### PR TITLE
Always send theme reviewers auto-replies in english (bug 979484)

### DIFF
--- a/apps/editors/tasks.py
+++ b/apps/editors/tasks.py
@@ -1,19 +1,17 @@
-import json
 
 from django.conf import settings
+from django.utils.translation import override
 
 import commonware.log
 from celeryutils import task
 from tower import ugettext as _
 
-import amo
 import constants.editors as rvw
 from addons.tasks import create_persona_preview_images
 from amo.decorators import write
 from amo.storage_utils import copy_stored_file, move_stored_file
 from amo.utils import LocalFileStorage, send_mail_jinja
 from devhub.models import ActivityLog, CommentLog, VersionLog
-from editors.models import ReviewerScore
 from versions.models import Version
 
 
@@ -24,7 +22,6 @@ log = commonware.log.getLogger('z.task')
 def add_commentlog(items, **kw):
     log.info('[%s@%s] Adding CommentLog starting with ActivityLog: %s' %
              (len(items), add_commentlog.rate_limit, items[0]))
-
 
     for al in ActivityLog.objects.filter(pk__in=items):
         # Delete existing entries:
@@ -78,25 +75,26 @@ def send_mail(cleaned_data, theme_lock):
     }
 
     subject = None
-    if action == rvw.ACTION_APPROVE:
-        subject = _('Thanks for submitting your Theme')
-        template = 'editors/themes/emails/approve.html'
+    with override('en-US'):
+        if action == rvw.ACTION_APPROVE:
+            subject = _('Thanks for submitting your Theme')
+            template = 'editors/themes/emails/approve.html'
 
-    elif action in (rvw.ACTION_REJECT, rvw.ACTION_DUPLICATE):
-        subject = _('A problem with your Theme submission')
-        template = 'editors/themes/emails/reject.html'
+        elif action in (rvw.ACTION_REJECT, rvw.ACTION_DUPLICATE):
+            subject = _('A problem with your Theme submission')
+            template = 'editors/themes/emails/reject.html'
 
-    elif action == rvw.ACTION_FLAG:
-        subject = _('Theme submission flagged for review')
-        template = 'editors/themes/emails/flag_reviewer.html'
+        elif action == rvw.ACTION_FLAG:
+            subject = _('Theme submission flagged for review')
+            template = 'editors/themes/emails/flag_reviewer.html'
 
-        # Send the flagged email to themes email.
-        emails = [settings.THEMES_EMAIL]
+            # Send the flagged email to themes email.
+            emails = [settings.THEMES_EMAIL]
 
-    elif action == rvw.ACTION_MOREINFO:
-        subject = _('A question about your Theme submission')
-        template = 'editors/themes/emails/moreinfo.html'
-        context['reviewer_email'] = theme_lock.reviewer.email
+        elif action == rvw.ACTION_MOREINFO:
+            subject = _('A question about your Theme submission')
+            template = 'editors/themes/emails/moreinfo.html'
+            context['reviewer_email'] = theme_lock.reviewer.email
 
     send_mail_jinja(subject, template, context,
                     recipient_list=emails, from_email=settings.ADDONS_EMAIL,


### PR DESCRIPTION
fix [bug 979484](https://bugzilla.mozilla.org/show_bug.cgi?id=979484)

Makes sure the subject and content of the email is sent in english, regardless
of the reviewer's default locale.
