### PR TITLE
fix XSS in users.helpers._user_link (bug 990078)

### DIFF
--- a/apps/bandwagon/templates/bandwagon/collection_listing_items.html
+++ b/apps/bandwagon/templates/bandwagon/collection_listing_items.html
@@ -53,7 +53,7 @@
       {% if c.type == amo.ADDON_PERSONA %}
         {{ users_list(c.persona.listed_authors) or c.persona.display_username }}
       {% else %}
-        {{ _('by {0}')|f(c.author|user_link|safe) }}
+        {{ _('by {0}')|f(c.author|user_link) }}
       {% endif %}
     </span>
   </h3>

--- a/apps/users/helpers.py
+++ b/apps/users/helpers.py
@@ -75,7 +75,7 @@ def _user_link(user, max_text_length=None):
         username = user.name[:max_text_length].strip() + '...'
 
     return u'<a href="%s" title="%s">%s</a>' % (
-        user.get_url_path(), user.name,
+        user.get_url_path(), jinja2.escape(user.name),
         jinja2.escape(smart_unicode(username)))
 
 

--- a/apps/users/tests/test_helpers.py
+++ b/apps/users/tests/test_helpers.py
@@ -53,7 +53,13 @@ def test_user_link_xss():
                     display_name='<script>alert(1)</script>', pk=1)
     html = "&lt;script&gt;alert(1)&lt;/script&gt;"
     eq_(user_link(u), '<a href="%s" title="%s">%s</a>' % (u.get_url_path(),
-                                                          u.name, html))
+                                                          html, html))
+
+    u = UserProfile(username='jconnor',
+                    display_name="""xss"'><iframe onload=alert(3)>""", pk=1)
+    html = """xss&#34;&#39;&gt;&lt;iframe onload=alert(3)&gt;"""
+    eq_(user_link(u), '<a href="%s" title="%s">%s</a>' % (u.get_url_path(),
+                                                          html, html))
 
 
 def test_users_list():


### PR DESCRIPTION
fix [bug 990078](https://bugzilla.mozilla.org/show_bug.cgi?id=990078)

There was a test in `users.tests.test_helpers.test_user_link_xss` that was
in fact broken and only partially tested the XSS (the username part, not the
name part, sadly).

I'm thus not sure it's a regression, just an XSS that slipped through until
now.
