### PR TITLE
do not translate canned responses for editor reviews (bug 979484)

### DIFF
--- a/apps/editors/tasks.py
+++ b/apps/editors/tasks.py
@@ -96,9 +96,10 @@ def send_mail(cleaned_data, theme_lock):
             template = 'editors/themes/emails/moreinfo.html'
             context['reviewer_email'] = theme_lock.reviewer.email
 
-    send_mail_jinja(subject, template, context,
-                    recipient_list=emails, from_email=settings.ADDONS_EMAIL,
-                    headers={'Reply-To': settings.THEMES_EMAIL})
+        send_mail_jinja(subject, template, context,
+                        recipient_list=emails,
+                        from_email=settings.ADDONS_EMAIL,
+                        headers={'Reply-To': settings.THEMES_EMAIL})
 
 
 @task

--- a/apps/editors/tests/test_views_themes.py
+++ b/apps/editors/tests/test_views_themes.py
@@ -224,7 +224,7 @@ class ThemeReviewTestMixin(object):
             mock.call(
                 'A problem with your Theme submission',
                 'editors/themes/emails/reject.html',
-                {'reason': mock.ANY,
+                {'reason': u'Sexual or pornographic content',
                  'comment': u'reject',
                  'theme': themes[3],
                  'base_url': 'http://testserver'},


### PR DESCRIPTION
Fix [bug 979484](https://bugzilla.mozilla.org/show_bug.cgi?id=979484)

The previous PR #23 was incomplete: the canned responses were still translated.
This is now fixed: the canned response (the `reason` in the context) is used in `send_mail_jinja` which wasn't in the overriden language part. It's now indented properly (and the test has been modified to validate this).
