### PR TITLE
display Personas in api search when specifically asked for it (bug 990768)

### DIFF
--- a/apps/api/tests/test_views.py
+++ b/apps/api/tests/test_views.py
@@ -930,7 +930,7 @@ class SearchTest(ESTestCase):
     fixtures = ('base/apps', 'base/platforms', 'base/appversion',
                 'base/addon_6113', 'base/addon_40', 'base/addon_3615',
                 'base/addon_6704_grapple', 'base/addon_4664_twitterbar',
-                'base/addon_10423_youtubesearch')
+                'base/addon_10423_youtubesearch', 'base/featured')
 
     no_results = """<searchresults total_results="0">"""
 
@@ -1028,12 +1028,12 @@ class SearchTest(ESTestCase):
 
     def test_total_results(self):
         """
-        The search for firefox should result in 2 total addons, even though we
+        The search for firefox should result in 3 total addons, even though we
         limit (and therefore show) only 1.
         """
         response = self.client.get(
                 "/en-US/firefox/api/1.2/search/firefox/all/1")
-        self.assertContains(response, """<searchresults total_results="2">""")
+        self.assertContains(response, """<searchresults total_results="3">""")
         self.assertContains(response, "</addon>", 1)
 
     def test_compat_mode_url(self):
@@ -1229,6 +1229,17 @@ class SearchTest(ESTestCase):
 
         assert not response.has_header('Access-Control-Allow-Origin')
         assert not response.has_header('Access-Control-Allow-Methods')
+
+    def test_persona_search(self):
+        self.defaults.update(query='lady')
+        # Personas aren't returned in a standard API search.
+        response = self.client.get(self.url % self.defaults)
+        self.assertNotContains(response, 'Lady Gaga')
+
+        # But they are if you specifically ask for Personas (type=9).
+        self.defaults.update(type='9')
+        response = self.client.get(self.url % self.defaults)
+        self.assertContains(response, 'Lady Gaga')
 
     def test_suggestions(self):
         response = self.client.get(

--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -337,9 +337,13 @@ class SearchView(APIView):
         # Opts may get overridden by query string filters.
         opts = {
             'addon_type': addon_type,
-            'platform': platform,
             'version': version,
         }
+        # Specific case for Personas (bug 990768): if we search providing the
+        # Persona addon type (9), don't filter on the platform as Personas
+        # don't have compatible platforms to filter on.
+        if addon_type != '9':
+            opts['platform'] = platform
 
         if self.version < 1.5:
             # Fix doubly encoded query strings.
@@ -368,7 +372,10 @@ class SearchView(APIView):
                                                       params['version'],
                                                       params['platform'],
                                                       compat_mode)
-            if compat_version:
+            # Specific case for Personas (bug 990768): if we search providing
+            # the Persona addon type (9), then don't look for a compatible
+            # version.
+            if compat_version or addon_type == '9':
                 addon.compat_version = compat_version
                 results.append(addon)
                 if len(results) == limit:

--- a/apps/api/views_drf.py
+++ b/apps/api/views_drf.py
@@ -150,9 +150,13 @@ class SearchView(DRFView):
         # Opts may get overridden by query string filters.
         opts = {
             'addon_type': addon_type,
-            'platform': platform,
             'version': version,
         }
+        # Specific case for Personas (bug 990768): if we search providing the
+        # Persona addon type (9), don't filter on the platform as Personas
+        # don't have compatible platforms to filter on.
+        if addon_type != '9':
+            opts['platform'] = platform
 
         if self.api_version < 1.5:
             # Fix doubly encoded query strings.
@@ -181,7 +185,10 @@ class SearchView(DRFView):
                                                       params['version'],
                                                       params['platform'],
                                                       compat_mode)
-            if compat_version:
+            # Specific case for Personas (bug 990768): if we search providing
+            # the Persona addon type (9), then don't look for a compatible
+            # version.
+            if compat_version or addon_type == '9':
                 addon.compat_version = compat_version
                 results.append(addon)
                 if len(results) == limit:


### PR DESCRIPTION
fix [bug 990768](https://bugzilla.mozilla.org/show_bug.cgi?id=990768)

When searching specifically for Personas (by providing a `type` of `9` like so: `http://localhost:8000/en-US/firefox/api/1.5/search/foo/9`, return the Personas found, instead of nothing.
