### PR TITLE
theme rejection email when duplicate is sent in english (bug 979484)

### DIFF
--- a/apps/editors/tasks.py
+++ b/apps/editors/tasks.py
@@ -55,27 +55,27 @@ def send_mail(cleaned_data, theme_lock):
     """
     Send emails out for respective review actions taken on themes.
     """
-    theme = cleaned_data['theme']
-    action = cleaned_data['action']
-    comment = cleaned_data['comment']
-    reject_reason = cleaned_data['reject_reason']
+    with override('en-US'):  # Make sure the email is always sent in english.
+        theme = cleaned_data['theme']
+        action = cleaned_data['action']
+        comment = cleaned_data['comment']
+        reject_reason = cleaned_data['reject_reason']
 
-    reason = None
-    if reject_reason:
-        reason = rvw.THEME_REJECT_REASONS[reject_reason]
-    elif action == rvw.ACTION_DUPLICATE:
-        reason = _('Duplicate Submission')
+        reason = None
+        if reject_reason:
+            reason = rvw.THEME_REJECT_REASONS[reject_reason]
+        elif action == rvw.ACTION_DUPLICATE:
+            reason = _('Duplicate Submission')
 
-    emails = set(theme.addon.authors.values_list('email', flat=True))
-    context = {
-        'theme': theme,
-        'base_url': settings.SITE_URL,
-        'reason': reason,
-        'comment': comment
-    }
+        emails = set(theme.addon.authors.values_list('email', flat=True))
+        context = {
+            'theme': theme,
+            'base_url': settings.SITE_URL,
+            'reason': reason,
+            'comment': comment
+        }
 
-    subject = None
-    with override('en-US'):
+        subject = None
         if action == rvw.ACTION_APPROVE:
             subject = _('Thanks for submitting your Theme')
             template = 'editors/themes/emails/approve.html'

--- a/apps/editors/tests/test_views_themes.py
+++ b/apps/editors/tests/test_views_themes.py
@@ -214,7 +214,7 @@ class ThemeReviewTestMixin(object):
             mock.call(
                 'A problem with your Theme submission',
                 'editors/themes/emails/reject.html',
-                {'reason': mock.ANY,
+                {'reason': u'Duplicate Submission',
                  'comment': u'duplicate',
                  'theme': themes[2],
                  'base_url': 'http://testserver'},


### PR DESCRIPTION
fixes [bug 979484](https://bugzilla.mozilla.org/show_bug.cgi?id=979484)

Fixing variations of this bug for the 3rd time (sic), each time broadening the
scope of the "forced english language activation" context manager.
