### PR TITLE
fix the reindex test fail on jenkins

### DIFF
--- a/lib/es/tests/test_commands.py
+++ b/lib/es/tests/test_commands.py
@@ -27,6 +27,7 @@ class TestIndexCommand(amo.tests.ESTestCase):
         self.indices = call_es('_status').json()['indices'].keys()
 
     def tearDown(self):
+        super(TestIndexCommand, self).tearDown()
         current_indices = call_es('_status').json()['indices'].keys()
         for index in current_indices:
             if index not in self.indices:
@@ -101,9 +102,9 @@ class TestIndexCommand(amo.tests.ESTestCase):
             amo.search.get_es().refresh()
             self.check_results(wanted)
 
-        if len(wanted) == old_addons_count:
-            raise AssertionError('Could not index objects in foreground while '
-                                 'reindexing in the background.')
+        if len(wanted) < old_addons_count + 3:
+            raise AssertionError('Could not index enough objects in foreground'
+                                 ' while reindexing in the background.')
 
         t.join()  # Wait for the thread to finish.
         t.stdout.seek(0)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -104,7 +104,7 @@ if [[ $3 = 'with-coverage' ]]; then
     coverage run manage.py test -v 2 --noinput --logging-clear-handlers --with-xunit
     coverage xml $(find apps lib -name '*.py')
 else
-    python manage.py test -v 2 --noinput --logging-clear-handlers --with-xunit --with-blockage --http-whitelist=127.0.0.1,localhost,${ES_HOST}
+    python manage.py test -v 2 --noinput --logging-clear-handlers --with-xunit --with-blockage --http-whitelist=127.0.0.1,localhost,${ES_HOST} lib.es.tests.test_commands:TestIndexCommand.test_reindexation
 fi
 
 


### PR DESCRIPTION
DO NOT REVIEW, this isn't going to be merged, only experiments to try and tackle down the https://ci-addons.allizom.org/job/olympia/105/testReport/workspace.lib.es.tests.test_commands/TestIndexCommand/test_reindexation/ failure
