### PR TITLE
display paypal error in the contribution popup

### DIFF
--- a/media/js/zamboni/contributions.js
+++ b/media/js/zamboni/contributions.js
@@ -249,7 +249,7 @@ var contributions = {
                         dgFlow.startFlow(json.url);
                         $self.find('span.cancel a').click();
                     } else {
-                        $self.find('#paypal-error').show();
+                        $self.find('#paypal-error').text(json.error).show();
                     }
                 }
             });


### PR DESCRIPTION
This issue was spotted while investigating [bug 997695](https://bugzilla.mozilla.org/show_bug.cgi?id=997695).

When clicking on the "Make Contribution" button in the contribution popup,
nothing would happen if there was an issue while communicating with Paypal.

This is now fixed, but is in no way fixing the bug 997695.
