### PR TITLE
dirty hack to serve django-debug-toolbar's statics, monkeypatch django.core.urlresolvers.resolve

### DIFF
--- a/apps/amo/tests/test_url_prefix.py
+++ b/apps/amo/tests/test_url_prefix.py
@@ -176,6 +176,16 @@ class TestPrefixer:
         client.get('/')
         eq_(urlresolvers.reverse('home'), '/en-US/firefox/')
 
+    def test_resolve(self):
+        func, args, kwargs = urlresolvers.resolve('/')
+        eq_(func.__name__, 'home')
+
+        # With a request with locale and app prefixes, it still works.
+        client = test.Client()
+        client.get('/')
+        func, args, kwargs = urlresolvers.resolve('/en-US/firefox/')
+        eq_(func.__name__, 'home')
+
     def test_script_name(self):
         rf = test_utils.RequestFactory()
         request = rf.get('/foo', SCRIPT_NAME='/oremj')

--- a/lib/urls_base.py
+++ b/lib/urls_base.py
@@ -1,3 +1,5 @@
+import os
+
 from django.conf import settings
 from django.conf.urls import include, patterns, url
 from django.contrib import admin
@@ -221,10 +223,23 @@ if 'django_qunit' in settings.INSTALLED_APPS:
 if settings.TEMPLATE_DEBUG:
     # Remove leading and trailing slashes so the regex matches.
     media_url = settings.MEDIA_URL.lstrip('/').rstrip('/')
+
+    if 'debug_toolbar' in settings.INSTALLED_APPS:
+        # We're not using the staticfiles app, like every good Django citizen
+        # should, so we have to cope with this weirdness.
+        import debug_toolbar
+        ddt_folder = os.path.dirname(debug_toolbar.__file__)
+        ddt_static_path = os.path.join(ddt_folder, 'static')
+        urlpatterns += patterns('',
+            (r'^%s/(?P<path>debug_toolbar/.*)$' % media_url,
+             'django.views.static.serve',
+             {'document_root': ddt_static_path}))
+
     urlpatterns += patterns('',
         (r'^%s/(?P<path>.*)$' % media_url, 'django.views.static.serve',
          {'document_root': settings.MEDIA_ROOT}),
     )
+
 
 if settings.SERVE_TMP_PATH and settings.DEBUG:
     urlpatterns += patterns('',


### PR DESCRIPTION
We're not using the staticfiles app, so we have to deal with special cases like
the DjDT that needs statics files and we need to serve them even though they're
not in /media/.

Also, as we're using a prefixer to add the locale and app to the urls, `django.core.urlresolvers.resolve` (used by the DjDT to provide information about the current view and its parameters) can't match the url. The monkeypatch (which is the mirror of the one done on `django.core.urlresolvers.reverse`) fixes this by only passing the "path" part to the `resolve` function.
