### PR TITLE
provide addon's summary as description meta for Facebook share

### DIFF
--- a/apps/addons/templates/addons/impala/details.html
+++ b/apps/addons/templates/addons/impala/details.html
@@ -18,6 +18,7 @@
   <meta property="og:type" content="website">
   <meta property="og:image" content="{{ addon.get_icon_url(64)|absolutify }}">
   <meta property="og:url" content="{{ addon.get_url_path()|absolutify }}">
+  <meta property="og:description" content="{{ addon.summary }}">
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
This is kinda hard to test, so it might be a miss. Providing this added `meta` should prevent Facebook from scraping the shared page for the first `p` tag with a long enough text.
