### PR TITLE
correct video source type to be video/ogg instead of video/ogv (bug 1003188)

### DIFF
--- a/media/js/zamboni/discovery_video.js
+++ b/media/js/zamboni/discovery_video.js
@@ -55,9 +55,9 @@ function PopcornObj() {
             $promos.addClass('show-video');
             video = $('<div>', {'class': 'promo-video'});
             video_el = $('<video>', {'controls': 'controls', 'tabindex': 0, 'id': 'promo-video', 'text': 'Your browser does not support the video tag'});
-            video_el_mp4  = $('<source>', {'type': 'video/mp4; codecs="avc1.42E01E, mp4a.40.2"', 'src': 'https://videos-cdn.mozilla.net/addons/fds0fo.mov'});
-            video_el_webm = $('<source>', {'type': 'video/webm; codecs="vp8, vorbis"', 'src': 'https://videos-cdn.mozilla.net/addons/vuue2y.webm'});
-            video_el_ogv = $('<source>', {'type': 'video/ogv; codecs="theora, vorbis"', 'src': 'https://videos-cdn.mozilla.net/addons/b85p03.ogv'});
+            video_el_mp4  = $('<source>', {'type': 'video/mp4; codecs="avc1.42E01E, mp4a.40.2"', 'src': 'https://videos.cdn.mozilla.net/addons/fds0fo.mov'});
+            video_el_webm = $('<source>', {'type': 'video/webm; codecs="vp8, vorbis"', 'src': 'https://videos.cdn.mozilla.net/addons/vuue2y.webm'});
+            video_el_ogv = $('<source>', {'type': 'video/ogg; codecs="theora, vorbis"', 'src': 'https://videos.cdn.mozilla.net/addons/b85p03.ogv'});
             $video_details = $('#video-details');
 
             video_el.append(video_el_mp4, video_el_webm, video_el_ogv);


### PR DESCRIPTION
Fix [bug 1003188](https://bugzilla.mozilla.org/show_bug.cgi?id=1003188)

This is only part of the fix, it also needs modifications on the server to
offer the proper mimetypes for the videos, see the bug for more information.
