### PR TITLE
sent password reset email even for getpersonas migrated accounts (bug 998477)

### DIFF
--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -80,6 +80,11 @@ class PasswordResetForm(auth_forms.PasswordResetForm):
                   further information. If you do not receive an email then
                   please confirm you have entered the same email address used
                   during account registration."""))
+        user = self.users_cache[0]
+        if not user.has_usable_password():
+            raise forms.ValidationError(
+                _("We can't reset this account's password, please contact the "
+                  "support."))
         return email
 
     def save(self, **kw):

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -365,6 +365,14 @@ class UserProfile(amo.models.OnChangeMixin, amo.models.ModelBase, AbstractBaseUs
             self.resetcode_expires = datetime.now()
         super(UserProfile, self).save(force_insert, force_update, using, **kwargs)
 
+    def has_usable_password(self):
+        """Override AbstractBaseUser.has_usable_password."""
+        # We also override the check_password method, and don't rely on
+        # settings.PASSWORD_HASHERS, and don't use "set_unusable_password", so
+        # we want to bypass most of AbstractBaseUser.has_usable_password
+        # checks.
+        return bool(self.password)  # Not None and not empty.
+
     def check_password(self, raw_password):
         if '$' not in self.password:
             valid = (get_hexdigest('md5', '', raw_password) == self.password)


### PR DESCRIPTION
Fix [bug 998477](https://bugzilla.mozilla.org/show_bug.cgi?id=998477)

At the moment, even if we can't reset a user's password (because her password
is empty), we still display a message stating that an email was sent to
reset it. This is now fixed.

Also, we have our own way of checking passwords, so the `AbstractBaseUser.has_usable_password` checks aren't loose enough for us (for example it checks the `settings.PASSWORD_HASHERS` which we don't necessarily use). An exemple is for passwords for migrated getpersonas accounts which are b64encoded. We thus monkeypatch this `has_usable_password`, waiting for PR #63 to be merged.

@washort please check the `# TODO` I added in this PR if yours (#63) is merged after this one.
