### PR TITLE
Remove clean_redis from cron.

### DIFF
--- a/scripts/crontab/crontab.tpl
+++ b/scripts/crontab/crontab.tpl
@@ -23,9 +23,6 @@ HOME=/tmp
 #every 3 hours
 20 */3 * * * %(z_cron)s compatibility_report
 
-#every 4 hours
-40 */4 * * * %(django)s clean_redis
-
 #twice per day
 # Use system python to use an older version of sqlalchemy than what is in our venv
 # Add slugs after we get all the new personas.


### PR DESCRIPTION
It seems like this is no longer needed. Logs for last 30 days show that 0 keys are dropped.

May 5 16:40:05 mktadm1: [][] z.redis:DEBUG [0 0.0%] Dropping 0 keys.

@oremj r?
