### PR TITLE
Add alt to img of addon detail view

### DIFF
--- a/apps/addons/templates/addons/impala/details.html
+++ b/apps/addons/templates/addons/impala/details.html
@@ -97,7 +97,8 @@
 <section class="primary">
   <div id="addon" class="island c" role="main" data-id="{{ addon.id }}">
     <hgroup>
-      <img id="addon-icon" itemprop="image" src="{{ addon.get_icon_url(64) }}" class="icon" alt="">
+      {# L10n: {0} is an add-on name. #}
+      <img id="addon-icon" itemprop="image" src="{{ addon.get_icon_url(64) }}" class="icon" alt="{{ _('Icon of {0}')|f(addon.name) }}">
       <h1 class="addon"{{ addon.name|locale_html }}>
         <span itemprop="name">{{ addon.name }}</span>
         {% if version %}
@@ -160,7 +161,8 @@
             <li class="panel">
               <a class="screenshot thumbnail" rel="jquery-lightbox"
                  href="{{ preview.image_url }}" title="{{ preview.caption }}">
-                <img src="{{ preview.thumbnail_url }}" alt="">
+                {# L10n: {0} is an index. #}
+                <img src="{{ preview.thumbnail_url }}" alt="{{ _('Add-on screenshot #{0}')|f(loop.index) }}">
               </a>
             </li>
           {%- endfor -%}


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=752481

No sure if I also need to makemessages (it fails atm).
