### PR TITLE
Fix a UnicodeDecodeError on translation redirect (bug 1007870)

### DIFF
--- a/apps/reviews/tests/test_views.py
+++ b/apps/reviews/tests/test_views.py
@@ -1,5 +1,4 @@
-from django.core import mail
-
+# -*- coding: utf-8 -*-
 from nose.tools import eq_
 from pyquery import PyQuery as pq
 
@@ -406,6 +405,15 @@ class TestTranslate(ReviewTest):
         r = self.client.get(url)
         eq_(r.status_code, 302)
         eq_(r.get('Location'), 'https://translate.google.com/#auto/fr/yes')
+
+    def test_unicode_call(self):
+        review = Review.objects.create(addon=self.addon, user=self.user,
+                                       title='or', body=u'héhé')
+        url = shared_url('reviews.translate', review.addon, review.id, 'fr')
+        r = self.client.get(url)
+        eq_(r.status_code, 302)
+        eq_(r.get('Location'),
+            'https://translate.google.com/#auto/fr/h%C3%A9h%C3%A9')
 
     @mock.patch('reviews.views.requests')
     def test_ajax_call(self, requests):

--- a/apps/reviews/views.py
+++ b/apps/reviews/views.py
@@ -103,11 +103,14 @@ def _retrieve_translation(text, language):
     return translated, r
 
 
-def translate_review(request, review, language):
+@addon_view
+@waffle_switch('reviews-translate')
+def translate(request, addon, review_id, language):
     """
-    Shared view splitted from the translate() views below for reusability
-    purposes (This is shared with mkt.reviewers).
+    Use the Google Translate API for ajax, redirect to Google Translate for
+    non ajax calls.
     """
+    review = get_object_or_404(Review, pk=review_id, addon=addon)
     if '-' in language:
         language = language.split('-')[0]
 
@@ -118,18 +121,7 @@ def translate_review(request, review, language):
                                  status=r.status_code)
     else:
         return redirect(settings.GOOGLE_TRANSLATE_REDIRECT_URL.format(
-            lang=language, text=review.body))
-
-
-@addon_view
-@waffle_switch('reviews-translate')
-def translate(request, addon, review_id, language):
-    """
-    Use the Google Translate API for ajax, redirect to Google Translate for
-    non ajax calls.
-    """
-    review = get_object_or_404(Review, pk=review_id, addon=addon)
-    return translate_review(request, review, language)
+            lang=language, text=review.body).decode('utf-8'))
 
 
 @addon_view


### PR DESCRIPTION
You have to turn the `reviews-translate` flag to 1 in order to reproduce.
