### PR TITLE
Use "rating" as default addons listing on mobile (bug 1005304)

### DIFF
--- a/apps/browse/tests.py
+++ b/apps/browse/tests.py
@@ -1260,9 +1260,24 @@ class TestMobileExtensions(TestMobile):
         eq_(r.context['category'], None)
         eq_(pq(r.content)('.addon-listing .listview').length, 1)
 
-    def test_category(self):
+    def test_category_default_sort(self):
         cat = Category.objects.all()[0]
-        r = self.client.get(reverse('browse.extensions', args=[cat.slug]))
+        url = reverse('browse.extensions', args=[cat.slug])
+        r = self.client.get(url)
+        eq_(r.status_code, 200)
+        self.assertTemplateUsed(r, 'browse/mobile/extensions.html')
+        self.assertTemplateUsed(r, 'addons/listing/items_mobile.html')
+        eq_(r.context['sorting'], 'rating')
+        eq_(r.context['category'], cat)
+        doc = pq(r.content)
+        eq_(doc('.addon-listing .listview').length, 1)
+        eq_(doc('.addon-listing .listview li.item').length, 1)
+
+    def test_category_sort_by_featured(self):
+        cat = Category.objects.all()[0]
+        url = reverse('browse.extensions', args=[cat.slug])
+        url = "{0}?sort=featured".format(url)
+        r = self.client.get(url)
         eq_(r.status_code, 200)
         self.assertTemplateUsed(r, 'browse/mobile/extensions.html')
         self.assertTemplateNotUsed(r, 'addons/listing/items_mobile.html')

--- a/apps/browse/views.py
+++ b/apps/browse/views.py
@@ -76,8 +76,9 @@ class ESAddonFilter(ESBaseFilter):
     extras = AddonFilter.extras
 
 
-def addon_listing(request, addon_types, filter_=AddonFilter,
-                  default='featured'):
+def addon_listing(request, addon_types, filter_=AddonFilter, default=None):
+    if default is None:
+        default = 'rating' if request.MOBILE else 'featured'
     # Set up the queryset and filtering for themes & extension listing pages.
     if amo.ADDON_PERSONA in addon_types:
         qs = Addon.objects.public().filter(type=amo.ADDON_PERSONA)


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1005304
