### PR TITLE
add a check again link when upload validation times out (bug 957158)

### DIFF
--- a/apps/devhub/tests/test_views.py
+++ b/apps/devhub/tests/test_views.py
@@ -1854,6 +1854,9 @@ class TestUploadDetail(BaseUploadTest):
             reverse('devhub.upload_detail', args=[upload.uuid, 'json']))
         eq_(data['full_report_url'],
             reverse('devhub.upload_detail', args=[upload.uuid]))
+        eq_(r['location'],
+            'http://testserver' +
+            reverse('devhub.upload_detail', args=[upload.uuid]))
         # We must have tiers
         assert len(data['validation']['messages'])
         msg = data['validation']['messages'][0]

--- a/apps/devhub/views.py
+++ b/apps/devhub/views.py
@@ -637,12 +637,14 @@ def upload(request, addon_slug=None, is_standalone=False):
     else:
         tasks.validator.delay(fu.pk)
     if addon_slug:
-        return redirect('devhub.upload_detail_for_addon',
-                        addon_slug, fu.pk)
+        response = redirect('devhub.upload_detail_for_addon',
+                            addon_slug, fu.pk)
     elif is_standalone:
-        return redirect('devhub.standalone_upload_detail', fu.pk)
+        response = redirect('devhub.standalone_upload_detail', fu.pk)
     else:
-        return redirect('devhub.upload_detail', fu.pk, 'json')
+        response = redirect('devhub.upload_detail', fu.pk, 'json')
+    response.set_cookie('last-upload-url', response['location'])
+    return response
 
 
 @login_required

--- a/media/js/common/upload-addon.js
+++ b/media/js/common/upload-addon.js
@@ -241,6 +241,26 @@
                     }
                     if(errors.length > 0) {
                         $upload_field.trigger("upload_errors", [file, errors, json]);
+                        var url = JSON.parse($.cookie('last-upload-url'));
+                        if (url) {
+                            $('#upload_errors').append(
+                                $('<a href="#" class="verify-upload">' +
+                                gettext('Try again') + '</a>')
+                            ).bind('click', '.verify-upload', function (e) {
+                                e.preventDefault();
+                                $('#upload-status-results').empty();
+                                $('#upload-file .upload-status').addClass('ajax-loading');
+                                $.get(url).done(function (data, textStatus, jqXHR) {
+                                    $upload_field.trigger(
+                                        "upload_onreadystatechange",
+                                        [file, jqXHR, false]);
+                                }).fail(function (jqXHR, textStatus, errorThrown) {
+                                    $upload_field.trigger(
+                                        "upload_onreadystatechange",
+                                        [file, jqXHR, false]);
+                                });
+                            });
+                        }
                     } else {
                         $upload_field.trigger("upload_success", [file, json]);
                         $upload_field.trigger("upload_progress", [file, 100]);


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=957158

When uploading an addon that takes a long time to validate the connection can get killed because the connection to check validation waits for validation to complete. This adds a "Check again" link that will check if the validation has completed so that the user can continue with their submission.

![retry-failed-upload m4v](https://cloud.githubusercontent.com/assets/211578/2962109/710e5b7e-dacd-11e3-9607-f514ced97798.gif)
I had to add `import time; time.sleep(2); response.content = 'lol'` to apps/devhub/views.py:900 to make the request fail as described in the bug and remove the line to make it pass. This bug cannot be reproduced on dev or stage.
