### PR TITLE
update last login time directly (bug 1010320)

### DIFF
--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -11,7 +11,8 @@ from datetime import datetime
 from django import dispatch, forms
 from django.conf import settings
 from django.contrib.auth.hashers import BasePasswordHasher, mask_hash
-from django.contrib.auth.models import AbstractBaseUser, BaseUserManager
+from django.contrib.auth.models import (AbstractBaseUser, BaseUserManager,
+                                        update_last_login)
 from django.core import validators
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models, transaction
@@ -426,6 +427,8 @@ class UserProfile(amo.models.OnChangeMixin, amo.models.ModelBase, AbstractBaseUs
             log.debug(u"User (%s) logged in successfully" % self)
             self.failed_login_attempts = 0
             self.last_login_ip = commonware.log.get_remote_addr()
+            update_last_login(None, self)
+
         else:
             log.debug(u"User (%s) failed to log in" % self)
             if self.failed_login_attempts < 16777216:

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -4,6 +4,8 @@ from functools import partial
 from django import http
 from django.conf import settings
 from django.contrib import auth
+from django.contrib.auth.models import update_last_login, user_logged_in
+
 from django.contrib.auth.forms import PasswordResetForm
 from django.contrib.auth.tokens import default_token_generator
 from django.db import IntegrityError, transaction
@@ -48,6 +50,7 @@ from .models import UserProfile
 from .signals import logged_out
 from .utils import autocreate_username, EmailResetCode, UnsubscribeCode
 
+user_logged_in.disconnect(update_last_login)
 
 log = commonware.log.getLogger('z.users')
 


### PR DESCRIPTION
Depending on signals is suspicious and seems to not work in our deployments. This updates the field more straightforwardly.
