### PR TITLE
Dealing with percent character and Google translate (bug 1007870)

### DIFF
--- a/apps/reviews/tests/test_views.py
+++ b/apps/reviews/tests/test_views.py
@@ -408,12 +408,12 @@ class TestTranslate(ReviewTest):
 
     def test_unicode_call(self):
         review = Review.objects.create(addon=self.addon, user=self.user,
-                                       title='or', body=u'héhé')
+                                       title='or', body=u'héhé 3%')
         url = shared_url('reviews.translate', review.addon, review.id, 'fr')
         r = self.client.get(url)
         eq_(r.status_code, 302)
         eq_(r.get('Location'),
-            'https://translate.google.com/#auto/fr/h%C3%A9h%C3%A9')
+            'https://translate.google.com/#auto/fr/h%C3%A9h%C3%A9%203%25')
 
     @mock.patch('reviews.views.requests')
     def test_ajax_call(self, requests):

--- a/apps/reviews/views.py
+++ b/apps/reviews/views.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template import Context, loader
+from django.utils.http import urlquote
 
 import commonware.log
 from tower import ugettext as _
@@ -121,7 +122,7 @@ def translate(request, addon, review_id, language):
                                  status=r.status_code)
     else:
         return redirect(settings.GOOGLE_TRANSLATE_REDIRECT_URL.format(
-            lang=language, text=review.body).decode('utf-8'))
+            lang=language, text=urlquote(review.body)))
 
 
 @addon_view


### PR DESCRIPTION
A follow-up of the previous quick fix: https://github.com/mozilla/olympia/commit/49867fbd8813ee73bff83c7651513fa85b486f5a

Note that it doesn't work with Firefox but it's OK with Chrome, see details and STR on https://bugzilla.mozilla.org/show_bug.cgi?id=1007870
