### PR TITLE
Use a normal input for color on theme edit page (bug 1032084)

### DIFF
--- a/apps/addons/forms.py
+++ b/apps/addons/forms.py
@@ -479,11 +479,11 @@ class ThemeForm(ThemeFormBase):
     # See bugs 1005206 and 1003575.
     accentcolor = ColorField(
         required=False,
-        widget=forms.HiddenInput(attrs={'class': 'color-picker'}),
+        widget=forms.TextInput(attrs={'class': 'color-picker'}),
     )
     textcolor = ColorField(
         required=False,
-        widget=forms.HiddenInput(attrs={'class': 'color-picker'}),
+        widget=forms.TextInput(attrs={'class': 'color-picker'}),
     )
     agreed = forms.BooleanField()
     # This lets us POST the data URIs of the unsaved previews so we can still
@@ -549,11 +549,11 @@ class EditThemeForm(AddonFormBase):
     tags = forms.CharField(required=False)
     accentcolor = ColorField(
         required=False,
-        widget=forms.HiddenInput(attrs={'class': 'color-picker'}),
+        widget=forms.TextInput(attrs={'class': 'color-picker'}),
     )
     textcolor = ColorField(
         required=False,
-        widget=forms.HiddenInput(attrs={'class': 'color-picker'}),
+        widget=forms.TextInput(attrs={'class': 'color-picker'}),
     )
     license = forms.TypedChoiceField(
         choices=amo.PERSONA_LICENSES_CHOICES, coerce=int, empty_value=None,

--- a/apps/devhub/tests/test_views_edit.py
+++ b/apps/devhub/tests/test_views_edit.py
@@ -1288,15 +1288,15 @@ class TestThemeEdit(amo.tests.TestCase):
         doc = pq(r.content)
         assert doc('a.reupload')
 
-    def test_color_input_is_hidden_at_creation(self):
+    def test_color_input_is_empty_at_creation(self):
         self.client.login(username='regular@mozilla.com', password='password')
         r = self.client.get(reverse('devhub.themes.submit'))
         doc = pq(r.content)
         el = doc('input.color-picker')
-        assert el.attr('type') == 'hidden'
+        assert el.attr('type') == 'text'
         assert not el.attr('value')
 
-    def test_color_input_is_hidden_at_edit(self):
+    def test_color_input_is_not_empty_at_edit(self):
         color = "123456"
         self.addon.persona.accentcolor = color
         self.addon.persona.save()
@@ -1305,5 +1305,5 @@ class TestThemeEdit(amo.tests.TestCase):
         r = self.client.get(url)
         doc = pq(r.content)
         el = doc('input#id_accentcolor')
-        assert el.attr('type') == 'hidden'
+        assert el.attr('type') == 'text'
         assert el.attr('value') == "#" + color


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1032084
