### PR TITLE
Allow developers to upload sources of an Addon version (bug 540028)

### DIFF
--- a/apps/amo/utils.py
+++ b/apps/amo/utils.py
@@ -793,7 +793,7 @@ class LocalFileStorage(FileSystemStorage):
     """
 
     def __init__(self, base_url=None):
-        super(LocalFileStorage, self).__init__(location='/', base_url=base_url)
+        super(LocalFileStorage, self).__init__(base_url=base_url)
 
     def delete(self, name):
         """Delete a file or empty directory path.

--- a/apps/devhub/helpers.py
+++ b/apps/devhub/helpers.py
@@ -122,6 +122,11 @@ def add_version_modal(context, title, action, upload_url, action_label):
                        action_label=action_label)
 
 
+@register.inclusion_tag('devhub/includes/source_form_field.html')
+def source_form_field(field):
+    return {'field': field}
+
+
 @register.function
 def status_choices(addon):
     """Return a dict like STATUS_CHOICES customized for the addon status."""

--- a/apps/devhub/templates/devhub/addons/submit/upload.html
+++ b/apps/devhub/templates/devhub/addons/submit/upload.html
@@ -4,7 +4,7 @@
 
 {% block primary %}
 
-<form method="post" id="create-addon" class="item" action="">
+<form method="post" id="create-addon" class="item" action="" enctype="multipart/form-data">
   {{ csrf() }}
   <h3>{{ _('Step 2. Upload Your Add-on') }}</h3>
   <p>
@@ -22,6 +22,8 @@
   <input type="file" id="upload-addon" data-upload-url="{{ url('devhub.upload') }}">
 
   {{ new_addon_form.non_field_errors() }}
+
+  {{ source_form_field(new_addon_form.source) }}
 
       <div class="platform">
         <div class="desktop-platforms">

--- a/apps/devhub/templates/devhub/includes/source_form_field.html
+++ b/apps/devhub/templates/devhub/includes/source_form_field.html
@@ -1,0 +1,5 @@
+<div class="binary-source">
+<label>{{ _('If your add-on contains binary or obfuscated code other than known libraries, upload its sources for review.') }}<br />
+<a href="{{ url('devhub.docs') }}policies/reviews#section-binary" target="_blank">{{ _('Read more about the source code review policy.') }}</a></label>
+<div>{{ field }}</div>
+</div>

--- a/apps/devhub/templates/devhub/versions/add_file_modal.html
+++ b/apps/devhub/templates/devhub/versions/add_file_modal.html
@@ -16,6 +16,8 @@
       </div>
       <input type="file" id="upload-addon"  data-upload-url="{{ upload_url }}">
 
+      {{ source_form_field(new_file_form.source) }}
+
       <div class="platform{% if addon.type == amo.ADDON_SEARCH %} hide{% endif %}">
       {% if modal_type == 'file' %}
         <label>{{ _('Select the target platform for this file.') }}</label>
@@ -29,12 +31,12 @@
           <label>{{ _('Which mobile platforms is this file compatible with?') }}</label>
           {{ new_file_form.mobile_platforms }}
         </div>
-	{% if addon.status == amo.STATUS_NULL %}
-          <div class="nomination-type">
-            <label>{{ _('Which review type would you like to nominate for?') }}</label>
-            {{ new_file_form.nomination_type }}
-          </div>
-	{% endif %}
+       {% if addon.status == amo.STATUS_NULL %}
+        <div class="nomination-type">
+          <label>{{ _('Which review type would you like to nominate for?') }}</label>
+          {{ new_file_form.nomination_type }}
+        </div>
+       {% endif %}
       {% endif %}
       </div>
       {% if is_admin %}

--- a/apps/devhub/templates/devhub/versions/edit.html
+++ b/apps/devhub/templates/devhub/versions/edit.html
@@ -17,7 +17,7 @@
 </header>
 <section class="primary devhub-form edit-version" role="main">
   <h3>{{ title }}</h3>
-  <form method="post" action="">
+  <form method="post" action="" enctype="multipart/form-data">
     <div class="item">
       <div class="item_wrapper">
         {{ csrf() }}
@@ -114,6 +114,18 @@
               {{ tip(None, _("Optionally, enter any information that may be useful
                               to the Editor reviewing this add-on, such as test
                               account information.")) }}
+            </th>
+            <td>
+              {{ field.errors }}
+              {{ field }}
+            </td>
+          {% endwith %}
+          </tr>
+          <tr>
+          {% with field = version_form.source %}
+            <th>
+              <label for="{{ field.auto_id }}">{{ _("Source code") }}</label>
+              {{ tip(None, _("If your add-on contain binary or obfuscated code, make the source available here for reviewers.")) }}
             </th>
             <td>
               {{ field.errors }}

--- a/apps/editors/templates/editors/review.html
+++ b/apps/editors/templates/editors/review.html
@@ -91,6 +91,10 @@
               {% endfor %}
             </ul>
           {% endif %}
+          {% if version.source and is_admin %}
+            <div><strong>{{ _('Additional sources:') }}</strong></div>
+            <div><a href="{{ url('downloads.source', version.pk) }}">{{ _('Download files') }}</a></div>
+          {% endif %}
         </td>
         <td>
           <table class="activity">

--- a/apps/editors/views.py
+++ b/apps/editors/views.py
@@ -476,12 +476,6 @@ def review(request, addon):
     return _review(request, addon)
 
 
-@reviewer_required('app')
-@addon_view
-def app_review(request, addon):
-    return _review(request, addon)
-
-
 def _review(request, addon):
     version = addon.latest_version
 

--- a/apps/versions/models.py
+++ b/apps/versions/models.py
@@ -66,6 +66,8 @@ class Version(amo.models.ModelBase):
     _developer_name = models.CharField(max_length=255, default='',
                                        editable=False)
 
+    source = models.FileField(upload_to='addon_source', null=True, blank=True)
+
     objects = VersionManager()
     with_deleted = VersionManager(include_deleted=True)
 
@@ -96,7 +98,7 @@ class Version(amo.models.ModelBase):
         return self
 
     @classmethod
-    def from_upload(cls, upload, addon, platforms, send_signal=True):
+    def from_upload(cls, upload, addon, platforms, send_signal=True, source=None):
         data = utils.parse_addon(upload, addon)
         try:
             license = addon.versions.latest().license_id
@@ -104,8 +106,13 @@ class Version(amo.models.ModelBase):
             license = None
         max_len = cls._meta.get_field_by_name('_developer_name')[0].max_length
         developer = data.get('developer_name', '')[:max_len]
-        v = cls.objects.create(addon=addon, version=data['version'],
-                               license_id=license, _developer_name=developer)
+        v = cls.objects.create(
+            addon=addon,
+            version=data['version'],
+            license_id=license,
+            _developer_name=developer,
+            source=source
+        )
         log.info('New version: %r (%s) from %r' % (v, v.id, upload))
 
         AV = ApplicationsVersions

--- a/apps/versions/urls.py
+++ b/apps/versions/urls.py
@@ -19,6 +19,9 @@ download_patterns = patterns('',
     url('^file/(?P<file_id>\d+)(?:/type:(?P<type>\w+))?(?:/.*)?',
         views.download_file, name='downloads.file'),
 
+    url('^source/(?P<version_id>\d+)',
+        views.download_source, name='downloads.source'),
+
     # /latest/1865/type:xpi/platform:5
     url('^latest/%s/(?:type:(?P<type>\w+)/)?'
         '(?:platform:(?P<platform>\d+)/)?.*' % ADDON_ID,

--- a/apps/versions/views.py
+++ b/apps/versions/views.py
@@ -1,7 +1,6 @@
 import posixpath
 
 from django import http
-from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, redirect, render
 
 import caching.base as caching
@@ -119,3 +118,14 @@ def download_latest(request, addon, type='xpi', platform=None):
     if request.GET:
         url += '?' + request.GET.urlencode()
     return http.HttpResponseRedirect(url)
+
+
+def download_source(request, version_id):
+    version = get_object_or_404(Version, pk=version_id)
+
+    if (version.source and
+       (acl.check_addon_ownership(request, version.addon, viewer=True,
+                                  ignore_disabled=True) or
+       acl.action_allowed(request, 'Editors', 'BinarySource'))):
+        return HttpResponseSendFile(request, version.source)
+    raise http.Http404()

--- a/migrations/777-add-versions-source-field.sql
+++ b/migrations/777-add-versions-source-field.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `versions` ADD COLUMN `source` varchar(100);

--- a/static/css/zamboni/developers.css
+++ b/static/css/zamboni/developers.css
@@ -1011,6 +1011,12 @@ form.select-review .errorlist {
 #upload-file select {
     margin: 1em 0;
 }
+#upload-file .binary-source input[type="file"] {
+    margin-bottom: 1em;
+}
+#upload-file .binary-source {
+    display: none;
+}
 
 #file-list select {
     margin-right: 1em;

--- a/static/js/common/upload-addon.js
+++ b/static/js/common/upload-addon.js
@@ -218,6 +218,7 @@
                 }};
 
                 upload_progress_inside.animate({'width': '100%'}, animateArgs);
+                $('.binary-source').show();
             });
 
             $upload_field.bind("upload_onreadystatechange", function(e, file, xhr, aborted) {


### PR DESCRIPTION
Do not review yet (but comments always welcome ;) ).

Ref: https://bugzilla.mozilla.org/show_bug.cgi?id=540028
# TODO
- [x] restrict source file access
- [x] change file link in form widget (or do we want another widget than FileField?)
- [x] add field to "Upload New Version" form
- [x] add field to "Submit a new addon" form
- [x] add field to "Upload a new file" form
- [x] add download link in the "editor page"
- [x] automatically flag addon for 'admin review' when a source is added
- [x] style forms

From Jorgev:
- [x] In the review page, the Download Source option should only be available to Admin Reviewers (group 50005). I would also use "Additional sources" so it's clearly distinguishable from the sources in the XPI.
- [x] In the upload forms, the source code form should appear after the upload and validation for the XPI succeeds. Otherwise it might confuse developers.
- [x] I would change the label "If your add-on contains binary or obfuscated code other than known libraries, upload its sources for review. Read more about the source code review policy." The 'Read more' text should link to https://addons.mozilla.org/developers/docs/policies/reviews#section-binary and open in a new tab.
