### PR TITLE
move name/creator/homepageURL/updateURL to attributes (bug 1006794)

### DIFF
--- a/apps/blocklist/templates/blocklist/blocklist.xml
+++ b/apps/blocklist/templates/blocklist/blocklist.xml
@@ -3,7 +3,7 @@
 {% if items %}
   <emItems>
   {% for guid, details in items.items() %}
-    <emItem {{ attrs(id=guid, os=details.os, blockID=details.block_id) }}>
+    <emItem {{ attrs(id=guid, os=details.os, blockID=details.block_id, name=details.rows.0.name, creator=details.rows.0.creator, homepageURL=details.rows.0.homepage_url, updateURL=details.rows.0.update_url) }}>
       {% for row in details.rows %}
         {% if row.min or row.max or row.severity or row.apps %}
           <versionRange {{ attrs(minVersion=row.min, maxVersion=row.max,
@@ -16,18 +16,6 @@
             </targetApplication>
           {% endfor %}
           </versionRange>
-        {% endif %}
-        {% if row.name %}
-          <name>{{ row.name }}</name>
-        {% endif %}
-        {% if row.creator %}
-          <creator>{{ row.creator }}</creator>
-        {% endif %}
-        {% if row.homepage_url %}
-          <homepageURL>{{ row.homepage_url }}</homepageURL>
-        {% endif %}
-        {% if row.update_url %}
-          <updateURL>{{ row.update_url }}</updateURL>
         {% endif %}
       {% endfor %}
       <prefs>

--- a/apps/blocklist/tests/test_views.py
+++ b/apps/blocklist/tests/test_views.py
@@ -39,6 +39,17 @@ class XMLAssertsMixin(object):
         finally:
             obj.update(**{field: initial})
 
+    def assertAttribute(self, obj, field, tag, attr_name):
+        # Save the initial value.
+        initial = getattr(obj, field)
+        try:
+            # If set, it's in the XML.
+            obj.update(**{field: 'foobar'})
+            element = self.dom(self.fx4_url).getElementsByTagName(tag)[0]
+            eq_(element.getAttribute(attr_name), 'foobar')
+        finally:
+            obj.update(**{field: initial})
+
     def assertEscaped(self, obj, field):
         """Make sure that the field content is XML escaped."""
         obj.update(**{field: 'http://example.com/?foo=<bar>&baz=crux'})
@@ -290,11 +301,21 @@ class BlocklistItemTest(XMLAssertsMixin, BlocklistViewTest):
         app = self.dom(self.fx4_url).getElementsByTagName('targetApplication')
         eq_(app[0].getElementsByTagName('versionRange'), [])
 
-    def test_optional_fields(self):
-        self.assertOptional(self.item, 'name', 'name')
-        self.assertOptional(self.item, 'creator', 'creator')
-        self.assertOptional(self.item, 'homepage_url', 'homepageURL')
-        self.assertOptional(self.item, 'update_url', 'updateURL')
+    def test_name(self):
+        self.assertAttribute(self.item, field='name', tag='emItem',
+                             attr_name='name')
+
+    def test_creator(self):
+        self.assertAttribute(self.item, field='creator', tag='emItem',
+                             attr_name='creator')
+
+    def test_homepage_url(self):
+        self.assertAttribute(self.item, field='homepage_url', tag='emItem',
+                             attr_name='homepageURL')
+
+    def test_update_url(self):
+        self.assertAttribute(self.item, field='update_url', tag='emItem',
+                             attr_name='updateURL')
 
     def test_urls_escaped(self):
         self.assertEscaped(self.item, 'homepage_url')


### PR DESCRIPTION
(re)fixes [bug 1006794](https://bugzilla.mozilla.org/show_bug.cgi?id=1006794)

Move the tags added in the previous PR, to be attributes on the `emItem` tag.
