### PR TITLE
Fix wrong GROUP_BY on performance stats (bug 1010728)

### DIFF
--- a/apps/editors/models.py
+++ b/apps/editors/models.py
@@ -1,4 +1,3 @@
-import copy
 import datetime
 
 from django.conf import settings
@@ -245,13 +244,14 @@ class PerformanceGraph(ViewQueue):
                 ('yearmonth',
                  "DATE_FORMAT(`log_activity`.`created`, '%%Y-%%m')"),
                 ('approval_created', '`log_activity`.`created`'),
-                ('user_id', '`users`.`id`'),
-                ('total', 'COUNT(*)')]),
+                ('user_id', '`log_activity`.`user_id`'),
+                ('total', 'COUNT(*)')
+            ]),
             'from': [
                 'log_activity',
-                'LEFT JOIN `users` ON (`users`.`id`=`log_activity`.`user_id`)'],
+            ],
             'where': ['log_activity.action in (%s)' % ','.join(review_ids)],
-            'group_by': 'yearmonth'
+            'group_by': 'yearmonth, user_id'
         }
 
 

--- a/apps/editors/tests/test_views.py
+++ b/apps/editors/tests/test_views.py
@@ -1050,6 +1050,18 @@ class TestPerformance(QueueTest):
         self.setUpAdmin()
         self._test_chart()
 
+    def test_usercount_with_more_than_one_editor(self):
+        self.client.login(username='clouserw@gmail.com', password='password')
+        amo.set_user(UserProfile.objects.get(username='clouserw'))
+        self.create_logs()
+        self.setUpEditor()
+        r = self.client.get(self.get_url())
+        eq_(r.status_code, 200)
+        doc = pq(r.content)
+        data = json.loads(doc('#monthly').attr('data-chart'))
+        label = datetime.now().strftime('%Y-%m')
+        eq_(data[label]['usercount'], 18)
+
     def _test_performance_other_user_as_admin(self):
         userid = amo.get_user().pk
 


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1010728

Note: the problem was only the missing `user_id` from the GROUP_BY clause (introduced in https://github.com/mozilla/olympia/commit/791b698efb38d450612e0953786b4713adad9f2c#diff-3aa796a7b0957c2c09bdd854786cf8b9L101), but I didn't see any good reason to do a JOIN on users, while only selecting user_id at the end, this is why I also removed the JOIN.
