### PR TITLE
Show only personas with more than 100 users in up and coming page (bug 944096)

### DIFF
--- a/apps/addons/fixtures/addons/persona.json
+++ b/apps/addons/fixtures/addons/persona.json
@@ -138,7 +138,7 @@
         "model": "addons.persona",
         "fields": {
             "display_username": "persona_author",
-            "popularity": 10,
+            "popularity": 100,
             "license": null,
             "footer": "BCBG_Persona_footer2.png",
             "movers": null,

--- a/apps/browse/tests.py
+++ b/apps/browse/tests.py
@@ -1240,6 +1240,18 @@ class TestPersonas(amo.tests.TestCase):
         personas = pq(res.content).find('.persona-preview')
         eq_(personas.length, 1)
 
+    def test_only_popular_persona_are_shown_in_up_and_coming(self):
+        url = '{path}?sort=up-and-coming'.format(path=self.landing_url)
+        r = self.client.get(url)
+        personas = pq(r.content).find('.persona-preview')
+        eq_(personas.length, 2)
+        p = Persona.objects.get(pk=559)
+        p.popularity = 99
+        p.save()
+        r = self.client.get(url)
+        personas = pq(r.content).find('.persona-preview')
+        eq_(personas.length, 1)
+
 
 class TestMobileFeatured(TestMobile):
 

--- a/apps/browse/views.py
+++ b/apps/browse/views.py
@@ -297,6 +297,8 @@ class PersonasFilter(BaseFilter):
         elif field == 'rating':
             return qs.order_by('-bayesian_rating')
         else:
+            # See bug 944096
+            qs = qs.filter(persona__popularity__gte=100)
             return qs.order_by('-persona__movers')
 
 


### PR DESCRIPTION
Ref: https://bugzilla.mozilla.org/show_bug.cgi?id=944096

Note: we do have an index on `persona.popularity`.
