### PR TITLE
Accept package.json files without install.rdf (bug 1037201)

### DIFF
--- a/apps/amo/tests/__init__.py
+++ b/apps/amo/tests/__init__.py
@@ -533,7 +533,7 @@ class AMOPaths(object):
         shutil.copyfile(self.xpi_path(name), file.file_path)
 
 
-def assert_no_validation_errors(validation):
+def assert_no_validation_exceptions(validation):
     """Assert that the validation (JSON) does not contain a traceback.
 
     Note that this does not test whether the addon passed

--- a/apps/devhub/tests/test_views.py
+++ b/apps/devhub/tests/test_views.py
@@ -28,7 +28,7 @@ from addons.models import Addon, AddonCategory, Category, Charity
 
 from amo.helpers import absolutify, user_media_path, url as url_reverse
 
-from amo.tests import (addon_factory, assert_no_validation_errors, formset,
+from amo.tests import (addon_factory, assert_no_validation_exceptions, formset,
                        initial)
 from amo.tests.test_helpers import get_image_path
 from amo.urlresolvers import reverse
@@ -1787,7 +1787,7 @@ class TestUpload(BaseUploadTest):
     def test_fileupload_validation(self):
         self.post()
         fu = FileUpload.objects.get(name='animated.png')
-        assert_no_validation_errors(fu)
+        assert_no_validation_exceptions(fu)
         assert fu.validation
         validation = json.loads(fu.validation)
 
@@ -1850,7 +1850,7 @@ class TestUploadDetail(BaseUploadTest):
                                     args=[upload.uuid, 'json']))
         eq_(r.status_code, 200)
         data = json.loads(r.content)
-        assert_no_validation_errors(data)
+        assert_no_validation_exceptions(data)
         eq_(data['url'],
             reverse('devhub.upload_detail', args=[upload.uuid, 'json']))
         eq_(data['full_report_url'],

--- a/apps/devhub/tests/test_views_validation.py
+++ b/apps/devhub/tests/test_views_validation.py
@@ -8,14 +8,14 @@ from django.core.files.storage import default_storage as storage
 
 import mock
 from nose.plugins.attrib import attr
-from nose.tools import eq_
+from nose.tools import eq_, ok_
 from pyquery import PyQuery as pq
 import waffle
 
 import amo
 import amo.tests
 from addons.models import Addon
-from amo.tests import assert_no_validation_errors
+from amo.tests import assert_no_validation_exceptions
 from amo.tests.test_helpers import get_image_path
 from amo.urlresolvers import reverse
 from applications.models import AppVersion, Application
@@ -225,9 +225,9 @@ class TestValidateFile(BaseUploadTest):
                              follow=True)
         eq_(r.status_code, 200)
         data = json.loads(r.content)
-        assert_no_validation_errors(data)
+        assert_no_validation_exceptions(data)
         msg = data['validation']['messages'][0]
-        eq_(msg['message'], 'The value of &lt;em:id&gt; is invalid.')
+        ok_('is invalid' in msg['message'])
 
     def test_time(self):
         r = self.client.post(reverse('devhub.file_validation',
@@ -271,7 +271,7 @@ class TestValidateFile(BaseUploadTest):
                              follow=True)
         eq_(r.status_code, 200)
         data = json.loads(r.content)
-        assert_no_validation_errors(data)
+        assert_no_validation_exceptions(data)
         addon = Addon.objects.get(pk=self.addon.id)
         eq_(addon.binary, True)
 
@@ -328,7 +328,7 @@ class TestValidateFile(BaseUploadTest):
                              follow=True)
         eq_(r.status_code, 200)
         data = json.loads(r.content)
-        assert_no_validation_errors(data)
+        assert_no_validation_exceptions(data)
         addon = Addon.objects.get(pk=self.addon.id)
         eq_(addon.binary, True)
 
@@ -360,7 +360,7 @@ class TestValidateFile(BaseUploadTest):
                              follow=True)
         eq_(r.status_code, 200)
         data = json.loads(r.content)
-        assert_no_validation_errors(data)
+        assert_no_validation_exceptions(data)
         doc = pq(data['validation']['messages'][0]['description'][0])
         eq_(doc('a').text(), 'https://bugzilla.mozilla.org/')
 

--- a/apps/files/tests/test_models.py
+++ b/apps/files/tests/test_models.py
@@ -26,7 +26,7 @@ from addons.models import Addon
 from applications.models import Application, AppVersion
 from files.models import File, FileUpload, FileValidation, nfd_str, Platform
 from files.helpers import copyfileobj
-from files.utils import check_rdf, JetpackUpgrader, parse_addon, parse_xpi
+from files.utils import check_xpi_info, JetpackUpgrader, parse_addon, parse_xpi
 from versions.models import Version
 
 
@@ -415,18 +415,18 @@ class TestParseXpi(amo.tests.TestCase):
         eq_(result['type'], amo.ADDON_LPAPP)
 
     def test_good_version_number(self):
-        check_rdf({'guid': 'guid', 'version': '1.2a-b+32*__yeah'})
-        check_rdf({'guid': 'guid', 'version': '1' * 32})
+        check_xpi_info({'guid': 'guid', 'version': '1.2a-b+32*__yeah'})
+        check_xpi_info({'guid': 'guid', 'version': '1' * 32})
 
     def test_bad_version_number(self):
         with self.assertRaises(forms.ValidationError) as e:
-            check_rdf({'guid': 'guid', 'version': 'bad #version'})
+            check_xpi_info({'guid': 'guid', 'version': 'bad #version'})
         msg = e.exception.messages[0]
         assert msg.startswith('Version numbers should only contain'), msg
 
     def test_long_version_number(self):
         with self.assertRaises(forms.ValidationError) as e:
-            check_rdf({'guid': 'guid', 'version': '1' * 33})
+            check_xpi_info({'guid': 'guid', 'version': '1' * 33})
         msg = e.exception.messages[0]
         eq_(msg, 'Version numbers should have fewer than 32 characters.')
 

--- a/apps/files/tests/test_utils_.py
+++ b/apps/files/tests/test_utils_.py
@@ -1,10 +1,15 @@
+import json
+from contextlib import contextmanager
+from tempfile import NamedTemporaryFile
+
 from nose.tools import eq_
 
+import amo
 import amo.tests
-import files.utils
 from addons.models import Addon
+from applications.models import Application, AppVersion
 from files.models import File
-from files.utils import find_jetpacks
+from files.utils import find_jetpacks, PackageJSONExtractor
 from versions.models import Version
 
 
@@ -62,3 +67,119 @@ class TestFindJetpacks(amo.tests.TestCase):
         File.objects.update(builder_version='2.0.1')
         files = find_jetpacks('.1', '1.0', from_builder_only=True)
         eq_(files, [self.file])
+
+
+class TestPackageJSONExtractor(amo.tests.TestCase):
+    fixtures = ['applications/all_apps.json']
+
+    @contextmanager
+    def extractor(self, base_data):
+        with NamedTemporaryFile() as f:
+            f.write(json.dumps(base_data))
+            f.flush()
+            yield PackageJSONExtractor(f.name)
+
+    def create_appversion(self, name, version):
+        app_guid = amo.APPS[name].guid
+        app = Application.objects.supported().get(guid=app_guid)
+        return AppVersion.objects.create(application=app, version=version)
+
+    def test_guid(self):
+        """Use id for the guid."""
+        with self.extractor({'id': 'some-id'}) as extractor:
+            eq_(extractor.parse()['guid'], 'some-id')
+
+    def test_name_for_guid_if_no_id(self):
+        """Use the name for the guid if there is no id."""
+        with self.extractor({'name': 'addon-name'}) as extractor:
+            eq_(extractor.parse()['guid'], 'addon-name')
+
+    def test_type(self):
+        """Package.json addons are always ADDON_EXTENSION."""
+        with self.extractor({}) as extractor:
+            eq_(extractor.parse()['type'], amo.ADDON_EXTENSION)
+
+    def test_no_restart(self):
+        """Package.json addons are always no-restart."""
+        with self.extractor({}) as extractor:
+            eq_(extractor.parse()['no_restart'], True)
+
+    def test_name_from_title_with_name(self):
+        """Use the title for the name."""
+        data = {'title': 'The Addon Title', 'name': 'the-addon-name'}
+        with self.extractor(data) as extractor:
+            eq_(extractor.parse()['name'], 'The Addon Title')
+
+    def test_name_from_name_without_title(self):
+        """Use the name for the name if there is no title."""
+        with self.extractor({'name': 'the-addon-name'}) as extractor:
+            eq_(extractor.parse()['name'], 'the-addon-name')
+
+    def test_version(self):
+        """Use version for the version."""
+        with self.extractor({'version': '23.0.1'}) as extractor:
+            eq_(extractor.parse()['version'], '23.0.1')
+
+    def test_homepage(self):
+        """Use homepage for the homepage."""
+        with self.extractor({'homepage': 'http://my-addon.org'}) as extractor:
+            eq_(extractor.parse()['homepage'], 'http://my-addon.org')
+
+    def test_summary(self):
+        """Use description for the summary."""
+        with self.extractor({'description': 'An addon.'}) as extractor:
+            eq_(extractor.parse()['summary'], 'An addon.')
+
+    def test_apps(self):
+        """Use engines for apps."""
+        firefox_version = self.create_appversion('firefox', '33.0a1')
+        thunderbird_version = self.create_appversion('thunderbird', '33.0a1')
+        data = {
+            'engines': {
+                'firefox': '>=33.0a1',
+                'thunderbird': '>=33.0a1',
+            },
+        }
+        with self.extractor(data) as extractor:
+            apps = extractor.parse()['apps']
+            eq_(apps[0].appdata.short, 'firefox')
+            eq_(apps[0].min, firefox_version)
+            eq_(apps[0].max, firefox_version)
+            eq_(apps[1].appdata.short, 'thunderbird')
+            eq_(apps[1].min, thunderbird_version)
+            eq_(apps[1].max, thunderbird_version)
+
+    def test_unknown_apps_are_ignored(self):
+        """Unknown engines get ignored."""
+        firefox_version = self.create_appversion('firefox', '33.0a1')
+        thunderbird_version = self.create_appversion('thunderbird', '33.0a1')
+        data = {
+            'engines': {
+                'firefox': '>=33.0a1',
+                'thunderbird': '>=33.0a1',
+                'node': '>=0.10',
+            },
+        }
+        with self.extractor(data) as extractor:
+            apps = extractor.parse()['apps']
+            eq_(apps[0].appdata.short, 'firefox')
+            eq_(apps[0].min, firefox_version)
+            eq_(apps[0].max, firefox_version)
+            eq_(apps[1].appdata.short, 'thunderbird')
+            eq_(apps[1].min, thunderbird_version)
+            eq_(apps[1].max, thunderbird_version)
+
+    def test_fennec_is_treated_as_android(self):
+        """Treat the fennec engine as android."""
+        android_version = self.create_appversion('android', '33.0a1')
+        data = {
+            'engines': {
+                'fennec': '>=33.0a1',
+                'node': '>=0.10',
+            },
+        }
+        with self.extractor(data) as extractor:
+            apps = extractor.parse()['apps']
+            eq_(apps[0].appdata.short, 'android')
+            eq_(apps[0].min, android_version)
+            eq_(apps[0].max, android_version)

--- a/apps/zadmin/tests/test_views.py
+++ b/apps/zadmin/tests/test_views.py
@@ -5,7 +5,7 @@ from cStringIO import StringIO
 from datetime import datetime
 
 from django.conf import settings
-from django.core import mail, management
+from django.core import mail
 from django.core.cache import cache
 
 import mock
@@ -16,8 +16,8 @@ from pyquery import PyQuery as pq
 
 import amo
 import amo.tests
-from amo.tests import (assert_no_validation_errors, assert_required, formset,
-                       initial)
+from amo.tests import (assert_no_validation_exceptions, assert_required,
+                       formset, initial)
 from access.models import Group, GroupUser
 from addons.models import Addon, CompatOverride, CompatOverrideRange
 from amo.urlresolvers import reverse
@@ -715,7 +715,7 @@ class TestBulkValidationTask(BulkValidationTest):
         self.start_validation()
         res = ValidationResult.objects.get()
         self.assertCloseToNow(res.completed)
-        assert_no_validation_errors(res)
+        assert_no_validation_exceptions(res)
         eq_(res.errors, 1)  # package could not be found
         eq_(res.valid, False)
         eq_(res.warnings, 0)

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -101,7 +101,7 @@ suds==0.4
 thrift==0.9.1
 
 ## Not on pypi.
--e git+https://github.com/mozilla/amo-validator.git@18ca5fd18600ab54a3fa81257cfb6dc2e2571b81#egg=amo-validator
+-e git+https://github.com/mozilla/amo-validator.git@1.2#egg=amo-validator
 -e git+https://github.com/jbalogh/django-queryset-transform@a1ba6ae41bd86f5bb9ff66fb56614e0fafe6e022#egg=django-queryset-transform
 -e git+https://github.com/miracle2k/django-tables.git@546f339308103880c823b2056830fcdc9220edd0#egg=django-tables
 -e git+https://github.com/mozilla/happyforms.git@729612c2a824a7e8283d416d2084bf506c671e24#egg=happyforms


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1037201

Parse package.json files so that jpm does not need to provide install.rdf files.
