### PR TITLE
prevent appversions duplicates (bug 1007544)

### DIFF
--- a/apps/amo/fixtures/base/thunderbird.json
+++ b/apps/amo/fixtures/base/thunderbird.json
@@ -9,7 +9,7 @@
         }
     },
     {
-        "pk": 29,
+        "pk": 298,
         "model": "applications.appversion",
         "fields": {
             "version_int": 3020000001000,
@@ -20,7 +20,7 @@
         }
     },
     {
-        "pk": 28,
+        "pk": 288,
         "model": "applications.appversion",
         "fields": {
             "version_int": 3000000200100,

--- a/apps/amo/tests/__init__.py
+++ b/apps/amo/tests/__init__.py
@@ -692,8 +692,10 @@ def user_factory(**kw):
 
 
 def version_factory(file_kw={}, **kw):
-    min_app_version = kw.pop('min_app_version', '4.0')
-    max_app_version = kw.pop('max_app_version', '5.0')
+    # We can't create duplicates of AppVersions, so make sure the versions are
+    # not already created in fixtures (use fake versions).
+    min_app_version = kw.pop('min_app_version', '4.0.99')
+    max_app_version = kw.pop('max_app_version', '5.0.99')
     version = kw.pop('version', '%.1f' % random.uniform(0, 2))
     v = Version.objects.create(version=version, **kw)
     v.created = v.last_updated = _get_created(kw.pop('created', 'now'))

--- a/apps/applications/models.py
+++ b/apps/applications/models.py
@@ -37,6 +37,7 @@ class AppVersion(amo.models.ModelBase):
     class Meta:
         db_table = 'appversions'
         ordering = ['-version_int']
+        unique_together = ('application', 'version')
 
     def save(self, *args, **kw):
         if not self.version_int:

--- a/apps/applications/tests.py
+++ b/apps/applications/tests.py
@@ -1,6 +1,7 @@
 import json
 
 from django.core.management import call_command
+from django.db import IntegrityError
 from nose.tools import eq_
 
 import amo
@@ -35,6 +36,14 @@ class TestAppVersion(amo.tests.TestCase):
         eq_(v.minor1, None)
         eq_(v.minor2, None)
         eq_(v.minor3, None)
+
+    def test_unique_together_application_version(self):
+        """Check that one can't add duplicate application-version pairs."""
+        app = Application.objects.create(guid='foobar')
+        AppVersion.objects.create(application=app, version='123')
+
+        with self.assertRaises(IntegrityError):
+            AppVersion.objects.create(application=app, version='123')
 
 
 class TestApplication(amo.tests.TestCase):

--- a/migrations/778-appversions-application-version-unique.sql
+++ b/migrations/778-appversions-application-version-unique.sql
@@ -1,0 +1,1 @@
+ALTER TABLE appversions ADD UNIQUE INDEX(application_id, version);


### PR DESCRIPTION
Fixes [bug 1007544](https://bugzilla.mozilla.org/show_bug.cgi?id=1007544)

This is the "reloaded" version, with the tests passing (fixtures modifications, prevent AppVersion duplicates in the tests...)
