### PR TITLE
Add `unique_together` constraint to `AppVersion` for `application` and `...

### DIFF
--- a/apps/applications/models.py
+++ b/apps/applications/models.py
@@ -37,6 +37,7 @@ class AppVersion(amo.models.ModelBase):
     class Meta:
         db_table = 'appversions'
         ordering = ['-version_int']
+        unique_together = ('application', 'version'),
 
     def save(self, *args, **kw):
         if not self.version_int:

--- a/migrations/778-unique-app-versions.sql
+++ b/migrations/778-unique-app-versions.sql
@@ -1,0 +1,4 @@
+ALTER TABLE
+    `appversions`
+ADD CONSTRAINT
+    UNIQUE (`application_id`, `version`);


### PR DESCRIPTION
...version` columns.

See https://bugzilla.la/1051547 – "duplicate supported application versions listed on AMO" — for rationale.
