### PR TITLE
fix an import loop in services (bug 1055654)

### DIFF
--- a/services/utils.py
+++ b/services/utils.py
@@ -36,7 +36,20 @@ from constants.base import (ADDON_PREMIUM, STATUS_PUBLIC, STATUS_DISABLED,
                             STATUS_BETA, STATUS_LITE,
                             STATUS_LITE_AND_NOMINATED)
 
-from amo.helpers import user_media_url
+
+# This is not DRY: it's a copy of amo.helpers.user_media_url, to avoid an
+# import (which should be avoided, according to the comments above, and which
+# triggers an import loop).
+# See bug 1055654.
+def user_media_url(what):
+    """
+    Generate default media url, and make possible to override it from
+    settings.
+    """
+    default = '%s%s/' % (settings.MEDIA_URL, what)
+    key = "{0}_URL".format(what.upper().replace('-', '_'))
+    return getattr(settings, key, default)
+
 
 APP_GUIDS = dict([(app.guid, app.id) for app in APPS_ALL.values()])
 PLATFORMS = dict([(plat.api_name, plat.id) for plat in PLATFORMS.values()])


### PR DESCRIPTION
Stack trace of the issue (introduced in 986d8670de51cfd009bafec2b4aaa65335397860)

```
[magopian@dev1.addons.phx1 olympia]$ ../venv/bin/python services/wsgi/versioncheck.py
Traceback (most recent call last):
  File "services/wsgi/versioncheck.py", line 14, in <module>
    from update import application
  File "/data/addons-dev/www/addons-dev.allizom.org/deploy-olympia-dev-20140819092755-8ce8dd365c/olympia/services/update.py", line 25, in <module>
    from utils import (APP_GUIDS, get_mirror, log_configure, PLATFORMS,
  File "/data/addons-dev/www/addons-dev.allizom.org/deploy-olympia-dev-20140819092755-8ce8dd365c/olympia/services/utils.py", line 38, in <module>
    from amo.helpers import user_media_url
  File "/data/addons-dev/www/addons-dev.allizom.org/deploy-olympia-dev-20140819092755-8ce8dd365c/olympia/apps/amo/__init__.py", line 7, in <module>
    from caching.base import CachingQuerySet
  File "/data/addons-dev/www/addons-dev.allizom.org/deploy-olympia-dev-20140819092755-8ce8dd365c/venv/src/django-cache-machine/caching/base.py", line 10, in <module>
    from .compat import DEFAULT_TIMEOUT, FOREVER
  File "/data/addons-dev/www/addons-dev.allizom.org/deploy-olympia-dev-20140819092755-8ce8dd365c/venv/src/django-cache-machine/caching/compat.py", line 7, in <module>
    from django.core.cache.backends.base import DEFAULT_TIMEOUT as DJANGO_DEFAULT_TIMEOUT
  File "/data/addons-dev/www/addons-dev.allizom.org/deploy-olympia-dev-20140819092755-8ce8dd365c/venv/lib/python2.6/site-packages/django/core/cache/__init__.py", line 138, in <module>
    cache = get_cache(DEFAULT_CACHE_ALIAS)
  File "/data/addons-dev/www/addons-dev.allizom.org/deploy-olympia-dev-20140819092755-8ce8dd365c/venv/lib/python2.6/site-packages/django/core/cache/__init__.py", line 130, in get_cache
    "Could not find backend '%s': %s" % (backend, e))
django.core.cache.backends.base.InvalidCacheBackendError: Could not find backend 'caching.backends.memcached.MemcachedCache': Error importing module caching.backends.memcached: "cannot import name DEFAULT_TIMEOUT"
```
