### PR TITLE
Fixed directions to install virtualenv-burrito

### DIFF
--- a/docs/topics/install-olympia/installation.rst
+++ b/docs/topics/install-olympia/installation.rst
@@ -94,7 +94,7 @@ Are you ready to bootstrap virtualenv_ and virtualenvwrapper_?
 Since each shell setup is different, you can install everything you need
 and configure your shell using the `virtualenv-burrito`_. Type this::
 
-    curl -s https://raw.github.com/brainsik/virtualenv-burrito/master/virtualenv-burrito.sh | $SHELL
+    curl -sL https://raw.github.com/brainsik/virtualenv-burrito/master/virtualenv-burrito.sh | $SHELL
 
 Open a new shell to test it out. You should have the ``workon`` and
 ``mkvirtualenv`` commands.


### PR DESCRIPTION
Without the `-L` option added to curl the script wouldn't download.
According to its help page the flag allows following redirects.
