### PR TITLE
schematic should also use settings.py (bug 1050155)

### DIFF
--- a/migrations/schematic_settings.py
+++ b/migrations/schematic_settings.py
@@ -3,8 +3,7 @@ import os
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-# Set up zamboni.
-import manage
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
 from django.conf import settings
 
 config = settings.DATABASES['default']


### PR DESCRIPTION
fixes [bug 1050155](https://bugzilla.mozilla.org/show_bug.cgi?id=1050155)

Schematic wasn't using the proper settings file
