### PR TITLE
Bump jingo-minify (bug 1054306)

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -107,7 +107,7 @@ thrift==0.9.1
 -e git+https://github.com/mozilla/happyforms.git@729612c2a824a7e8283d416d2084bf506c671e24#egg=happyforms
 
 # Temporary fork.
--e git+https://github.com/yohanboniface/jingo-minify.git@amo.2014.08.15#egg=jingo_minify
+-e git+https://github.com/yohanboniface/jingo-minify.git@amo.2014.09.03#egg=jingo_minify
 -e git+https://github.com/mozilla/django-moz-header.git@djangoapp#egg=django-moz-header
 -e git+https://github.com/washort/nuggets.git@02798dfce84030fca64775eaf56e92400f394e4f#egg=nuggets
 -e git+https://github.com/washort/test-utils.git@4917197a64b6d0f2068c9ad1bfea0427c3e412e1#egg=test-utils


### PR DESCRIPTION
New commit on jingo-minify: https://github.com/yohanboniface/jingo-minify/commit/e9b8320a6ca3c6249229e7332a79123d278af981

This allows to specify static path from django app in our bundles (there was a bug in DEBUG=False).
