### PR TITLE
don't use persona's popularity and movers field just yet (bug 1059964)

### DIFF
--- a/apps/addons/models.py
+++ b/apps/addons/models.py
@@ -1650,6 +1650,9 @@ class Persona(caching.CachingMixin, models.Model):
     approve = models.DateTimeField(null=True)
     movers = models.FloatField(null=True, db_index=True)
     popularity = models.IntegerField(null=False, default=0, db_index=True)
+    # TODO: remove the following two fields when the ADI stuff is used for real
+    movers_tmp = models.FloatField(null=True)
+    popularity_tmp = models.IntegerField(null=False, default=0)
     license = models.PositiveIntegerField(
         choices=amo.PERSONA_LICENSES_CHOICES, null=True, blank=True)
 

--- a/apps/stats/management/commands/update_theme_popularity_movers.py
+++ b/apps/stats/management/commands/update_theme_popularity_movers.py
@@ -51,7 +51,8 @@ class Command(BaseCommand):
         for addon_id, three_weeks_avg in three_weeks_avg_dict.iteritems():
             popularity = int(one_week_avg_dict.get(addon_id, 0))
             Persona.objects.filter(addon_id=addon_id).update(
-                popularity=popularity,
-                movers=(popularity - three_weeks_avg) / three_weeks_avg)
+                # TODO: remove _tmp from the fields when the ADI stuff is used
+                popularity_tmp=popularity,
+                movers_tmp=(popularity - three_weeks_avg) / three_weeks_avg)
 
         log.debug('Total processing time: %s' % (datetime.now() - start))

--- a/apps/stats/tests/test_commands.py
+++ b/apps/stats/tests/test_commands.py
@@ -80,10 +80,11 @@ class TestADICommand(amo.tests.TestCase):
         p1 = Persona.objects.get(pk=559)
         p2 = Persona.objects.get(pk=575)
 
-        eq_(p1.popularity, 3)  # sum(range(7)) / 7
+        # TODO: remove _tmp from the fields when we use the ADI stuff for real
+        eq_(p1.popularity_tmp, 3)  # sum(range(7)) / 7
         # Three weeks avg (sum(range(21)) / 21) = 10 so (3 - 10) / 10.
-        eq_(p1.movers, -0.7)
+        eq_(p1.movers_tmp, -0.7)
 
-        eq_(p2.popularity, 30)  # sum(range(7)) * 10 / 7
+        eq_(p2.popularity_tmp, 30)  # sum(range(7)) * 10 / 7
         # Three weeks avg (sum(range(21)) * 10 / 21) = 100 so (30 - 100) / 100.
-        eq_(p2.movers, -0.7)
+        eq_(p2.movers_tmp, -0.7)

--- a/migrations/783-add-personas-tmp-fields.sql
+++ b/migrations/783-add-personas-tmp-fields.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `personas` ADD COLUMN `movers_tmp` double DEFAULT NULL;
+ALTER TABLE `personas` ADD COLUMN `popularity_tmp` int(11) NOT NULL DEFAULT '0';


### PR DESCRIPTION
Fix for the previous commit which was mistakenly using the real persona fields
for popularity and movers. We're not ready for the real deal just yet.
