### PR TITLE
Add initial data for access.Group (bug 1062303)

### DIFF
--- a/apps/access/fixtures/initial.json
+++ b/apps/access/fixtures/initial.json
@@ -1,0 +1,32 @@
+[
+  {
+    "pk": 1,
+    "model": "access.group",
+    "fields": {
+        "name": "Admins",
+        "rules": "*:*",
+        "created": "2010-09-08 07:06:05",
+        "modified": "2010-09-08 07:06:05"
+    }
+  },
+  {
+    "pk": 2,
+    "model": "access.group",
+    "fields": {
+        "name": "Staff",
+        "rules": "Addons:Review,Apps:Review,Personas:Review,Reviews:Edit,Addons:Edit,Addons:Configure,Users:Edit,Stats:View,CollectionStats:View,Collections:Edit,AdminTools:View,SeniorPersonasTools:View,Apps:Configure,AccountLookup:View,AppLookup:View,Lookup:View,FeaturedApps:View,FeaturedApps:Edit,Stats:View,Apps:ReviewPrivileged,Apps:Publisher,Apps:ReviewRegionCN",
+        "created": "2010-09-08 07:06:05",
+        "modified": "2010-09-08 07:06:05"
+    }
+  },
+  {
+    "pk": 3,
+    "model": "access.group",
+    "fields": {
+        "name": "Add-on Reviewers",
+        "rules": "Addons:Review,Reviews:Edit",
+        "created": "2010-09-08 07:06:05",
+        "modified": "2010-09-08 07:06:05"
+    }
+  }
+]

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -139,14 +139,9 @@ class UserManager(BaseUserManager, amo.models.ManagerBase):
     def create_superuser(self, username, email, password):
         """
         Creates and saves a superuser.
-
-        If no Admins Group yet exists, it's created.
         """
         user = self.create_user(username, email, password)
-        admins, created = Group.objects.get_or_create(
-            name='Admins',
-            rules='*:*'
-        )
+        admins = Group.objects.get(name='Admins')
         GroupUser.objects.create(user=user, group=admins)
         return user
 

--- a/apps/users/tests/test_models.py
+++ b/apps/users/tests/test_models.py
@@ -419,6 +419,7 @@ class TestUserHistory(amo.tests.TestCase):
 
 
 class TestUserManager(amo.tests.TestCase):
+    fixtures = ('users/test_backends', )
 
     def test_create_user(self):
         user = UserProfile.objects.create_user("test", "test@test.com", 'xxx')


### PR DESCRIPTION
Ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1062303

We need https://github.com/mozilla/schematic/pull/1 to land (or another solution) to clean up the "init db" steps that will run the needed loaddata.
