### PR TITLE
speed up the popularity/movers update by running bulk queries (bug 1059964)

### DIFF
--- a/apps/stats/management/commands/update_theme_popularity_movers.py
+++ b/apps/stats/management/commands/update_theme_popularity_movers.py
@@ -1,11 +1,12 @@
 from datetime import datetime
 
 from django.core.management.base import BaseCommand
+from django.db import connection
 
 import commonware.log
 
 from addons.models import Persona
-from stats.models import ThemeUpdateCount
+from stats.models import ThemeUpdateCount, ThemeUpdateCountBulk
 
 
 log = commonware.log.getLogger('adi.themepopularitymovers')
@@ -30,29 +31,40 @@ class Command(BaseCommand):
         start = datetime.now()  # Measure the time it takes to run the script.
 
         # Average number of users over the last 7 days.
-        one_week_avg = ThemeUpdateCount.objects.get_last_x_days_avg(7)
+        one_week_averages = ThemeUpdateCount.objects.get_last_x_days_avg(7)
 
         # Average number of users over the last three weeks (21 days).
-        three_weeks_avg = ThemeUpdateCount.objects.get_last_x_days_avg(21)
+        three_weeks_averages = ThemeUpdateCount.objects.get_last_x_days_avg(21)
 
-        # Transform the querysets from a list of dicts
-        #   [{'addon_id': id1, 'count__avg': avg1], {'addon_id': id2, ...
-        # to a dict
-        #   {id1: avg1, id2: avg2, ...}
-        one_week_avg_dict = {}
-        for d in one_week_avg:
-            one_week_avg_dict[d['addon_id']] = d['count__avg']
-        three_weeks_avg_dict = {}
-        for d in three_weeks_avg:
-            three_weeks_avg_dict[d['addon_id']] = d['count__avg']
+        # Perf: memoize the addon to persona relation.
+        addon_to_persona = dict(Persona.objects.values_list('addon_id', 'id'))
+
+        temp_update_counts = []
 
         # Loop over the three_weeks_avg_dict, which can't be shorter than the
         # one_week_avg_dict.
-        for addon_id, three_weeks_avg in three_weeks_avg_dict.iteritems():
-            popularity = int(one_week_avg_dict.get(addon_id, 0))
-            Persona.objects.filter(addon_id=addon_id).update(
-                # TODO: remove _tmp from the fields when the ADI stuff is used
-                popularity_tmp=popularity,
-                movers_tmp=(popularity - three_weeks_avg) / three_weeks_avg)
+        for addon_id, three_weeks_avg in three_weeks_averages.iteritems():
+            # Create the temporary ThemeUpdateCountBulk for later bulk create.
+            pop = one_week_averages.get(addon_id, 0)
+            tucb = ThemeUpdateCountBulk(
+                persona_id=addon_to_persona[addon_id],
+                popularity=pop,
+                movers=(pop - three_weeks_avg) / three_weeks_avg)
+            temp_update_counts.append(tucb)
+
+        # Create in bulk: this is much faster.
+        ThemeUpdateCountBulk.objects.all().delete()  # Clean slate first.
+        ThemeUpdateCountBulk.objects.bulk_create(temp_update_counts, 100)
+
+        # Update in bulk from the above temp table: again, much faster.
+        # TODO: remove _tmp from the fields when the ADI stuff is used
+        raw_query = """
+            UPDATE personas p, theme_update_counts_bulk t
+            SET p.popularity_tmp=t.popularity,
+                p.movers_tmp=t.movers
+            WHERE t.persona_id=p.id
+        """
+        cursor = connection.cursor()
+        cursor.execute(raw_query)
 
         log.debug('Total processing time: %s' % (datetime.now() - start))

--- a/migrations/784-add-theme-update-counts-tmp.sql
+++ b/migrations/784-add-theme-update-counts-tmp.sql
@@ -1,0 +1,6 @@
+CREATE TABLE `theme_update_counts_bulk` (
+    `id` int(11) UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY,
+    `persona_id` int(11) UNSIGNED NOT NULL,
+    `popularity` int(11) UNSIGNED,
+    `movers` DOUBLE
+) ENGINE=InnoDB CHARACTER SET utf8 COLLATE utf8_general_ci;


### PR DESCRIPTION
Fixes [bug 1059964](https://bugzilla.mozilla.org/show_bug.cgi?id=1059964)

The idea is to do a "bulk update" using a temporary table:
1/ compute (two queries) the average number of users over a week and over three weeks
2/ bulk insert the popularity and movers computed from those numbers in the temporary table
3/ We can then

`````` sql
UPDATE personas, tmp_table
SET personas.popularity = tmp_table.popularity,
    personas.movers = tmp_table.movers
WHERE personas.id = tmp.personas_id```
``````
