### PR TITLE
Quote filename in Content-Disposition (bug 540028)

### DIFF
--- a/apps/versions/views.py
+++ b/apps/versions/views.py
@@ -129,7 +129,7 @@ def download_source(request, version_id):
                                    viewer=True, ignore_disabled=True)
          or acl.action_allowed(request, 'Editors', 'BinarySource'))):
         res = HttpResponseSendFile(request, version.source.path)
-        name = os.path.basename(version.source.path)
-        res['Content-Disposition'] = "attachment; filename={0}".format(name)
+        name = os.path.basename(version.source.path.replace('"', ''))
+        res['Content-Disposition'] = 'attachment; filename="{0}"'.format(name)
         return res
     raise http.Http404()


### PR DESCRIPTION
Ref: https://bugzilla.mozilla.org/show_bug.cgi?id=540028#c32

Without the quotes, it works in Chrome Windows, or even FF Linux, but it doesn't work on FF Windows. This is an attempt to fix that.
