### PR TITLE
fix the movers computation formula (bug 1059964)

### DIFF
--- a/apps/stats/models.py
+++ b/apps/stats/models.py
@@ -109,12 +109,11 @@ class UpdateCountTmp(SearchMixin, models.Model):
 
 class ThemeUpdateCountManager(models.Manager):
 
-    def get_last_x_days_avg(self, days):
-        """Return a dict of the average number of users (count) over the last x
-        days per addon."""
-        today = datetime.date.today()
+    def get_range_days_avg(self, start, end):
+        """Return a a dict of the average number of users (count) over the
+        given range of days, per addons."""
         averages = (self.values('addon_id')
-                        .filter(date__gt=today - datetime.timedelta(days=days))
+                        .filter(date__range=[start, end])
                         .annotate(avg=models.Avg('count')))
         # Transform the queryset from a list of dicts
         #   [{'addon_id': id1, 'count__avg': avg1], {'addon_id': id2, ...

--- a/apps/stats/tests/test_commands.py
+++ b/apps/stats/tests/test_commands.py
@@ -77,25 +77,36 @@ class TestADICommand(amo.tests.TestCase):
 
     def test_update_theme_popularity_movers(self):
         # Create ThemeUpdateCount entries for the persona 559 with addon_id
-        # 15663 and the persona 575 with addon_id 15679 for the last 21 days.
-        for i in range(21):
-            d = date.today() - timedelta(days=i)
+        # 15663 and the persona 575 with addon_id 15679 for the last 28 days.
+        # We start from the previous day, as the theme_update_counts_from_*
+        # scripts are gathering data for the day before.
+        yesterday = date.today() - timedelta(days=1)
+        for i in range(28):
+            d = yesterday - timedelta(days=i)
             ThemeUpdateCount.objects.create(addon_id=15663, count=i, date=d)
             ThemeUpdateCount.objects.create(addon_id=15679,
-                                            count=i * 10, date=d)
+                                            count=i * 100, date=d)
         # Compute the popularity and movers.
         management.call_command('update_theme_popularity_movers')
         p1 = Persona.objects.get(pk=559)
         p2 = Persona.objects.get(pk=575)
 
         # TODO: remove _tmp from the fields when we use the ADI stuff for real
+        # The popularity is the average over the last 7 days, and as we created
+        # entries with one more user per day in the past (or 100 more), the
+        # calculation is "sum(range(7)) / 7" (or "sum(range(7)) * 100 / 7").
         eq_(p1.popularity_tmp, 3)  # sum(range(7)) / 7
-        # Three weeks avg (sum(range(21)) / 21) = 10 so (3 - 10) / 10.
-        eq_(p1.movers_tmp, -0.7)
+        eq_(p2.popularity_tmp, 300)  # sum(range(7)) * 100 / 7
 
-        eq_(p2.popularity_tmp, 30)  # sum(range(7)) * 10 / 7
-        # Three weeks avg (sum(range(21)) * 10 / 21) = 100 so (30 - 100) / 100.
-        eq_(p2.movers_tmp, -0.7)
+        # Three weeks avg (sum(range(21)) / 21) = 10 so (3 - 10) / 10.
+        # The movers is computed with the following formula:
+        # previous_3_weeks: the average over the 21 days before the last 7 days
+        # movers: (popularity - previous_3_weeks) / previous_3_weeks
+        # The calculation for the previous_3_weeks is:
+        # previous_3_weeks: (sum(range(28) - sum(range(7))) * 100 / 21 == 1700.
+        eq_(p1.movers_tmp, 0.0)  # Because the popularity is <= 100.
+        # We round the results to cope with floating point imprecision.
+        eq_(round(p2.movers_tmp, 5), round((300.0 - 1700) / 1700, 5))
 
     def test_is_valid_source(self):
         assert is_valid_source('foo',


### PR DESCRIPTION
Fixes [bug 1059964](https://bugzilla.mozilla.org/show_bug.cgi?id=1059964)

The formula to compute the movers was incorrect, cf [comment 22](https://bugzilla.mozilla.org/show_bug.cgi?id=1059964#c22)
