### PR TITLE
fix script following new movers formula (bug 1059964)

### DIFF
--- a/apps/stats/management/commands/__init__.py
+++ b/apps/stats/management/commands/__init__.py
@@ -37,9 +37,9 @@ class HiveQueryToFileCommand(BaseCommand):
         limit_str = ('limit %s' % limit) if limit else ''
 
         if not os.path.isdir(folder):
-            os.makedirs(folder)
+            os.makedirs(folder, 0775)
         if not os.path.isdir(os.path.join(folder, day)):
-            os.makedirs(os.path.join(folder, day))
+            os.makedirs(os.path.join(folder, day), 0755)
         filepath = os.path.join(folder, day, self.filename)
         return query_to_file(self.query % (day, limit_str), filepath, sep)
 

--- a/apps/stats/management/commands/update_theme_popularity_movers.py
+++ b/apps/stats/management/commands/update_theme_popularity_movers.py
@@ -48,18 +48,19 @@ class Command(BaseCommand):
 
         temp_update_counts = []
 
-        # Loop over the three_weeks_avg_dict, which can't be shorter than the
-        # one_week_avg_dict.
-        for addon_id, prev_3_weeks in prev_3_weeks_avgs.iteritems():
+        for addon_id, popularity in last_week_avgs.iteritems():
+            if addon_id not in addon_to_persona:
+                continue
             # Create the temporary ThemeUpdateCountBulk for later bulk create.
-            pop = last_week_avgs.get(addon_id, 0)
+            prev_3_weeks_avg = prev_3_weeks_avgs.get(addon_id, 0)
             tucb = ThemeUpdateCountBulk(
                 persona_id=addon_to_persona[addon_id],
-                popularity=pop,
-                movers=(pop - prev_3_weeks) / prev_3_weeks)
+                popularity=popularity,
+                movers=0)
             # Set movers to 0 if values aren't high enough.
-            if pop <= 100 or prev_3_weeks_avgs <= 1:
-                tucb.movers = 0
+            if popularity > 100 and prev_3_weeks_avg > 1:
+                tucb.movers = (
+                    popularity - prev_3_weeks_avg) / prev_3_weeks_avg
             temp_update_counts.append(tucb)
 
         # Create in bulk: this is much faster.


### PR DESCRIPTION
fixes [bug 1059964](https://bugzilla.mozilla.org/show_bug.cgi?id=1059964)

This should fix the following cron error (previous fix was incomplete it seems):

```
Traceback (most recent call last):
  File "manage.py", line 93, in <module>
    execute_from_command_line(sys.argv)
  File "/data/mkt.prod/www/addons.mozilla.org/deploy-olympia-prod-20140912190542-8aa86cd45b/venv/lib/python2.6/site-packages/django/core/management/__init__.py", line 399, in execute_from_command_line
    utility.execute()
  File "/data/mkt.prod/www/addons.mozilla.org/deploy-olympia-prod-20140912190542-8aa86cd45b/venv/lib/python2.6/site-packages/django/core/management/__init__.py", line 392, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/data/mkt.prod/www/addons.mozilla.org/deploy-olympia-prod-20140912190542-8aa86cd45b/venv/lib/python2.6/site-packages/django/core/management/base.py", line 242, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/data/mkt.prod/www/addons.mozilla.org/deploy-olympia-prod-20140912190542-8aa86cd45b/venv/lib/python2.6/site-packages/django/core/management/base.py", line 285, in execute
    output = self.handle(*args, **options)
  File "/data/mkt.prod/www/addons.mozilla.org/deploy-olympia-prod-20140912190542-8aa86cd45b/olympia/apps/stats/management/commands/update_theme_popularity_movers.py", line 57, in handle
    persona_id=addon_to_persona[addon_id],
KeyError: 5L
```
