### PR TITLE
Updates the error message for short passwords (bug 1067673)

### DIFF
--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -85,8 +85,7 @@ class AuthenticationForm(auth_forms.AuthenticationForm):
         if ('password' in self.errors and 'password' in self.data and
                 1 < len(self.data['password']) < PasswordMixin.min_length):
             msg = _('As part of our new password policy, your password must '
-                    'be %s characters or more. '
-                    'Please update your password if that is not the case by '
+                    'be %s characters or more. Please update your password by '
                     '<a href="%s">issuing a password reset</a>.'
                     ) % (PasswordMixin.min_length,
                          reverse('password_reset_form'))

--- a/apps/users/tests/test_forms.py
+++ b/apps/users/tests/test_forms.py
@@ -316,8 +316,7 @@ class TestUserLoginForm(UserFormBase):
                               'password': 'shortpw'})
         error_msg = (u'As part of our new password policy, your password must '
                       'be 8 characters or more. Please update your password '
-                      'if that is not the case by '
-                      '<a href="/en-US/firefox/users/pwreset">issuing a '
+                      'by <a href="/en-US/firefox/users/pwreset">issuing a '
                       'password reset</a>.')
         self.assertFormError(r, 'form', 'password', error_msg)
 


### PR DESCRIPTION
A follow up of https://github.com/mozilla/olympia/commit/ae824ab8bb17ade02611d1dc15cba731b1db4193
