### PR TITLE
use the 'amo_prod' user to run hive queries

### DIFF
--- a/lib/settings_base.py
+++ b/lib/settings_base.py
@@ -1467,7 +1467,7 @@ ADDON_COLLECTOR_ID = 11950
 HIVE_CONNECTION = {
     'host': 'peach-gw.peach.metrics.scl3.mozilla.com',
     'port': 10000,
-    'user': 'aphadke',
+    'user': 'amo_prod',
     'password': '',
     'auth_mechanism': 'PLAIN',
 }


### PR DESCRIPTION
Fixes [bug 1070901](https://bugzilla.mozilla.org/show_bug.cgi?id=1070901)
