### PR TITLE
Remove obsolete mobile documentation links

### DIFF
--- a/apps/devhub/templates/devhub/docs/how-to-thunderbird-mobile.html
+++ b/apps/devhub/templates/devhub/docs/how-to-thunderbird-mobile.html
@@ -76,22 +76,8 @@
   <div class="table-listing">
     <div class="item">
       <div class="main-info">
-
         <h4>
-          <a href="https://wiki.mozilla.org/Mobile/Fennec/Architecture"
-             target="_blank">{{ _('Mobile Architecture') }}</a>
-        </h4>
-        <p>
-        {% trans %}
-        This document describes the architecture of Firefox on mobile and includes performance tips for mobile code.
-        {% endtrans %}
-        </p>
-      </div>
-    </div>
-    <div class="item">
-      <div class="main-info">
-        <h4>
-          <a href="https://wiki.mozilla.org/Mobile/Fennec/Extensions"
+          <a href="https://developer.mozilla.org//Add-ons/Firefox_for_Android"
              target="_blank">{{ _('Mobile Extensions') }}</a>
         </h4>
         <p>
@@ -102,42 +88,15 @@
       </div>
     </div>
     <div class="item">
-      <div class="main-info">
-        <h4>
-          <a href="https://wiki.mozilla.org/Mobile/Fennec/Extensions/BestPractices"
-             target="_blank">{{ _('Best Practices for Mobile Extensions') }}</a>
-        </h4>
-        <p>
-        {% trans %}
-        Mobile extensions have small screen space and limited resources to work with. This document explains best practices for designing and developing for a mobile environment.
-        {% endtrans %}
-        </p>
-
-      </div>
-    </div>
-    <div class="item">
 
       <div class="main-info">
         <h4>
-          <a href="https://wiki.mozilla.org/Mobile/Fennec/CodeSnippets"
+          <a href="https://developer.mozilla.org/Add-ons/Firefox_for_Android/Code_snippets"
              target="_blank">{{ _('Mobile Code Snippets') }}</a>
         </h4>
         <p>
         {% trans %}
         Code snippets specific to mobile.
-        {% endtrans %}
-        </p>
-      </div>
-    </div>
-    <div class="item">
-      <div class="main-info">
-        <h4>
-          <a href="https://wiki.mozilla.org/Mobile/Fennec/Extensions/UserInterface"
-             target="_blank">{{ _('Designing User Interfaces for Mobile') }}</a>
-        </h4>
-        <p>
-        {% trans %}
-        How to design an interface for your mobile extension.
         {% endtrans %}
         </p>
       </div>


### PR DESCRIPTION
I updated some of the mobile links to point to up-to-date resources on MDN, but I removed the links that don't have a modern equivalent. I'm taking note of those links to create new MDN articles, but in the meantime, I think it's better to point to fewer, yet accurate, documents.
