### PR TITLE
Ditch unused `.dictionaries tbody` color rule

### DIFF
--- a/static/css/impala/dictionaries.less
+++ b/static/css/impala/dictionaries.less
@@ -5,8 +5,6 @@
         color: @red;
     }
     tbody {
-        color: #555;
-
         td, th {
             width: 25%;
         }


### PR DESCRIPTION
`(body).dictionaries tbody { color: #555; }` is shadowed by the more specific `(section).full tbody { color: @dark-gray; }` in [tables.less](https://github.com/mozilla/olympia/blob/181dc72ca40352f63ba01fe76f29836e4ca0dba2/static/css/impala/tables.less#L20-22):

![Web inspector screenshot](https://cloud.githubusercontent.com/assets/24193/4410522/9efc634a-44e6-11e4-8f97-4b9e3bd1ca59.png)

Might as well nuke the unused rule in dictionaries.less.
