### PR TITLE
fix the theme_update_counts_from_hive query (bug 1061734)

### DIFF
--- a/apps/stats/management/commands/theme_update_counts_from_hive.py
+++ b/apps/stats/management/commands/theme_update_counts_from_hive.py
@@ -31,7 +31,7 @@ class Command(HiveQueryToFileCommand):
         from v2_raw_logs
         where true
           and domain = "versioncheck.addons.mozilla.org"
-          and ds = '%s'
+          and ds = '{day}'
           -- fast filters:
           and request_url like '%%update-check%%'
           -- takes more time but it's the correct filter:
@@ -41,5 +41,5 @@ class Command(HiveQueryToFileCommand):
            , regexp_extract(request_url, '^/([-\\w]+)(/themes/update-check/)(\\d+).*', 3)
            , parse_url(concat('http://www.a.com',request_url), 'QUERY', 'src')
         -- limit
-        %s
+        {limit}
     """  # noqa


### PR DESCRIPTION
Fixes [bug 1061734](https://bugzilla.mozilla.org/show_bug.cgi?id=1061734)

In the previous PR #295, the hive query for the theme update counts wasn't properly updated. This fixes this mistake.
