### PR TITLE
apps/versions/feeds: add pagination support for RSS version history

### DIFF
--- a/apps/versions/tests.py
+++ b/apps/versions/tests.py
@@ -27,7 +27,7 @@ from devhub.models import ActivityLog
 from files.models import File
 from files.tests.test_models import UploadTest
 from users.models import UserProfile
-from versions import views
+from versions import feeds, views
 from versions.models import Version, ApplicationsVersions
 from versions.compare import (MAXVERSION, version_int, dict_from_int,
                               version_dict)
@@ -478,15 +478,24 @@ class TestViews(amo.tests.TestCase):
 
 
 class TestFeeds(amo.tests.TestCase):
-    fixtures = ['addons/eula+contrib-addon']
+    fixtures = ['addons/eula+contrib-addon', 'addons/default-to-compat']
+    rel_ns = {'atom': 'http://www.w3.org/2005/Atom'}
+
+    def setUp(self):
+        patcher = mock.patch.object(feeds, 'PER_PAGE', 1)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def get_feed(self, slug, **kwargs):
+        url = reverse('addons.versions.rss', args=[slug])
+        r = self.client.get(url, kwargs, follow=True)
+        return PyQuery(r.content)
 
     def test_feed_elements_present(self):
         """specific elements are present and reasonably well formed"""
-        url = reverse('addons.versions.rss', args=['a11730'])
-        r = self.client.get(url, follow=True)
-        doc = PyQuery(r.content)
+        doc = self.get_feed('a11730')
         eq_(doc('rss channel title')[0].text,
-                'IPv6 Google Search Version History')
+            'IPv6 Google Search Version History')
         assert doc('rss channel link')[0].text.endswith('/en-US/firefox/')
         # assert <description> is present
         assert len(doc('rss channel description')[0].text) > 0
@@ -503,6 +512,51 @@ class TestFeeds(amo.tests.TestCase):
         # proper date format for item
         item_pubdate = doc('rss channel item pubDate')[0]
         assert item_pubdate.text == 'Thu, 21 May 2009 05:37:15 -0700'
+
+    def assert_page_relations(self, doc, page_relations):
+        rel = doc[0].xpath('//channel/atom:link', namespaces=self.rel_ns)
+        relations = dict((link.get('rel'), link.get('href')) for link in rel)
+        assert relations.pop('first').endswith('format:rss')
+
+        eq_(len(relations), len(page_relations))
+        for rel, href in relations.iteritems():
+            page = page_relations[rel]
+            assert href.endswith('format:rss' if page == 1 else
+                                 'format:rss?page=%s' % page)
+
+    def test_feed_first_page(self):
+        """first page has the right elements and page relations"""
+        doc = self.get_feed('addon-337203', page=1)
+        eq_(doc('rss item title')[0].text,
+            'Addon for DTC 1.0 - December  5, 2011')
+        self.assert_page_relations(doc, {'self': 1, 'next': 2, 'last': 4})
+
+    def test_feed_middle_page(self):
+        """a middle page has the right elements and page relations"""
+        doc = self.get_feed('addon-337203', page=2)
+        eq_(doc('rss item title')[0].text,
+            'Addon for DTC 1.1 - December  5, 2011')
+        self.assert_page_relations(doc, {'previous': 1, 'self': 2, 'next': 3,
+                                         'last': 4})
+
+    def test_feed_last_page(self):
+        """last page has the right elements and page relations"""
+        doc = self.get_feed('addon-337203', page=4)
+        eq_(doc('rss item title')[0].text,
+            'Addon for DTC 1.3 - December  5, 2011')
+        self.assert_page_relations(doc, {'previous': 3, 'self': 4, 'last': 4})
+
+    def test_feed_invalid_page(self):
+        """an invalid page falls back to page 1"""
+        doc = self.get_feed('addon-337203', page=5)
+        eq_(doc('rss item title')[0].text,
+            'Addon for DTC 1.0 - December  5, 2011')
+
+    def test_feed_no_page(self):
+        """no page defaults to page 1"""
+        doc = self.get_feed('addon-337203')
+        eq_(doc('rss item title')[0].text,
+            'Addon for DTC 1.0 - December  5, 2011')
 
 
 class TestDownloadsBase(amo.tests.TestCase):


### PR DESCRIPTION
This fixes bug https://bugzilla.mozilla.org/show_bug.cgi?id=1070766 by adding a ?all option to the Version History RSS feed, that displays the entire history.

I had thought about enabling pagination but decided this was simpler, since even with pagination there is no easy way (for a crawler) to figure out "the last page", which is what I really need to fix https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=762310.
