### PR TITLE
Bug 1073977 - To remove redundant filters from Hive query for theme_update_counts

### DIFF
--- a/apps/stats/management/commands/theme_update_counts_from_hive.py
+++ b/apps/stats/management/commands/theme_update_counts_from_hive.py
@@ -32,9 +32,6 @@ class Command(HiveQueryToFileCommand):
         where true
           and domain = "versioncheck.addons.mozilla.org"
           and ds = '{day}'
-          -- fast filters:
-          and request_url like '%%update-check%%'
-          -- takes more time but it's the correct filter:
           and regexp_extract(request_url, '^/([-\\w]+)(/themes/update-check/)(\\d+).*', 2) = '/themes/update-check/'
           group by
              ds


### PR DESCRIPTION
Reduces running time of job by 2 orders of magnitude
