### PR TITLE
Paypal form comment length and amount check (bug 1061203)

### DIFF
--- a/apps/addons/forms.py
+++ b/apps/addons/forms.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from decimal import Decimal
 import os
 
 from django import forms
@@ -719,4 +720,4 @@ class EditThemeOwnerForm(happyforms.Form):
 
 
 class ContributionForm(happyforms.Form):
-    amount = forms.DecimalField(required=True)
+    amount = forms.DecimalField(required=True, min_value=Decimal('0.01'))

--- a/apps/addons/tests/test_views.py
+++ b/apps/addons/tests/test_views.py
@@ -251,6 +251,13 @@ class TestContributeEmbedded(amo.tests.TestCase):
         eq_(data['paykey'], '')
         eq_(data['error'], 'Invalid data.')
 
+    def test_amount_length(self):
+        response = self.client_post(rev=['a592'], data={'onetime-amount': '0',
+                                                        'type': 'onetime'})
+        data = json.loads(response.content)
+        eq_(data['paykey'], '')
+        eq_(data['error'], 'Invalid data.')
+
     def test_ppal_json_switch(self):
         response = self.client_post(rev=['a592'], qs='?result_type=json')
         eq_(response.status_code, 200)
@@ -267,6 +274,14 @@ class TestContributeEmbedded(amo.tests.TestCase):
         eq_(res.status_code, 302)
         assert settings.PAYPAL_FLOW_URL in res._headers['location'][1]
         eq_(Contribution.objects.all()[0].comment, u'版本历史记录')
+
+    def test_comment_too_long(self):
+        response = self.client_post(rev=['a592'],
+                            data={'comment': u'a' * 256})
+
+        data = json.loads(response.content)
+        eq_(data['paykey'], '')
+        eq_(data['error'], 'Invalid data.')
 
     def test_organization(self):
         c = Charity.objects.create(name='moz', url='moz.com',

--- a/apps/addons/views.py
+++ b/apps/addons/views.py
@@ -470,6 +470,8 @@ def developers(request, addon, page):
 @anonymous_csrf_exempt
 @post_required
 def contribute(request, addon):
+    commentlimit = 255  # Enforce paypal-imposed comment length limit
+
     contrib_type = request.POST.get('type', 'suggested')
     is_suggested = contrib_type == 'suggested'
     source = request.POST.get('source', '')
@@ -483,7 +485,7 @@ def contribute(request, addon):
         amount = settings.DEFAULT_SUGGESTED_CONTRIBUTION
 
     form = ContributionForm({'amount': amount})
-    if not form.is_valid():
+    if len(comment) > commentlimit or not form.is_valid():
         return http.HttpResponse(json.dumps({'error': 'Invalid data.',
                                              'status': '', 'url': '',
                                              'paykey': ''}),


### PR DESCRIPTION
Enforce comment length to 255 characters max and the amount to be 0.01 min in addons.contribute view and form. (bug 1061203)
