### PR TITLE
Force unicode when dealing with hive files (bug 1014752)

### DIFF
--- a/apps/stats/management/commands/download_counts_from_file.py
+++ b/apps/stats/management/commands/download_counts_from_file.py
@@ -1,3 +1,4 @@
+import codecs
 from datetime import datetime, timedelta
 from optparse import make_option
 from os import path, unlink
@@ -95,7 +96,7 @@ class Command(BaseCommand):
         prefixes = DownloadSource.objects.filter(type='prefix').values_list(
             'name', flat=True)
 
-        with open(filepath) as count_file:
+        with codecs.open(filepath, encoding='utf8') as count_file:
             for index, line in enumerate(count_file):
                 if index and (index % 1000000) == 0:
                     log.info('Processed %s lines' % index)

--- a/apps/stats/management/commands/hive_connection.py
+++ b/apps/stats/management/commands/hive_connection.py
@@ -1,3 +1,4 @@
+import codecs
 from datetime import datetime
 
 import commonware.log
@@ -53,7 +54,7 @@ def query_to_file(query, filepath, sep):
             authMechanism=settings.HIVE_CONNECTION['auth_mechanism']) as conn:
         log.info('Storing hive results in %s' % filepath)
         num_reqs = 0
-        with open(filepath, 'w') as f:
+        with codecs.open(filepath, 'w', encoding='utf8') as f:
             with conn.cursor() as cur:
                 cur.execute(query)
                 for row in cur.fetch():

--- a/apps/stats/management/commands/theme_update_counts_from_file.py
+++ b/apps/stats/management/commands/theme_update_counts_from_file.py
@@ -1,3 +1,4 @@
+import codecs
 from datetime import datetime, timedelta
 from optparse import make_option
 from os import path, unlink
@@ -72,7 +73,7 @@ class Command(BaseCommand):
         persona_to_addon = dict(Persona.objects.values_list('persona_id',
                                                             'addon_id'))
 
-        with open(filepath) as count_file:
+        with codecs.open(filepath, encoding='utf8') as count_file:
             for index, line in enumerate(count_file):
                 if index and (index % 1000000) == 0:
                     log.info('Processed %s lines' % index)

--- a/apps/stats/management/commands/update_counts_from_file.py
+++ b/apps/stats/management/commands/update_counts_from_file.py
@@ -1,3 +1,4 @@
+import codecs
 from datetime import datetime, timedelta
 from optparse import make_option
 from os import path, unlink
@@ -87,7 +88,7 @@ class Command(BaseCommand):
 
         index = -1
         for group, filepath in group_filepaths:
-            with open(filepath) as results_file:
+            with codecs.open(filepath, encoding='utf8') as results_file:
                 for line in results_file:
                     index += 1
                     if index and (index % 1000000) == 0:


### PR DESCRIPTION
Fixes [bug 1014752](https://bugzilla.mozilla.org/show_bug.cgi?id=1014752)

This should fix the issue we got from the crons yesterday:

```
Traceback (most recent call last):
  File "manage.py", line 93, in <module>
    execute_from_command_line(sys.argv)
  File "/data/mkt.prod/www/addons.mozilla.org/deploy-olympia-prod-20140929141229-29f3b6aa38/venv/lib/python2.6/site-packages/django/core/management/__init__.py", line 399, in execute_from_command_line
    utility.execute()
  File "/data/mkt.prod/www/addons.mozilla.org/deploy-olympia-prod-20140929141229-29f3b6aa38/venv/lib/python2.6/site-packages/django/core/management/__init__.py", line 392, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/data/mkt.prod/www/addons.mozilla.org/deploy-olympia-prod-20140929141229-29f3b6aa38/venv/lib/python2.6/site-packages/django/core/management/base.py", line 242, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/data/mkt.prod/www/addons.mozilla.org/deploy-olympia-prod-20140929141229-29f3b6aa38/venv/lib/python2.6/site-packages/django/core/management/base.py", line 285, in execute
    output = self.handle(*args, **options)
  File "/data/mkt.prod/www/addons.mozilla.org/deploy-olympia-prod-20140929141229-29f3b6aa38/olympia/apps/stats/management/commands/download_counts_from_file.py", line 115, in handle
    if not is_valid_source(src, fulls=fulls, prefixes=prefixes):
  File "/data/mkt.prod/www/addons.mozilla.org/deploy-olympia-prod-20140929141229-29f3b6aa38/olympia/apps/stats/management/commands/download_counts_from_file.py", line 28, in is_valid_source
    return src in fulls or any(p in src for p in prefixes)
  File "/data/mkt.prod/www/addons.mozilla.org/deploy-olympia-prod-20140929141229-29f3b6aa38/olympia/apps/stats/management/commands/download_counts_from_file.py", line 28, in <genexpr>
    return src in fulls or any(p in src for p in prefixes)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xef in position 6: ordinal not in range(128)
```
