### PR TITLE
Upload new file label (bug 1019153)

### DIFF
--- a/apps/devhub/templates/devhub/includes/addons_edit_nav.html
+++ b/apps/devhub/templates/devhub/includes/addons_edit_nav.html
@@ -15,7 +15,8 @@
     <p class="addon-upload">
       {% if not addon.is_incomplete() and not addon.is_disabled %}
         <strong>
-          <a href="{{ addon.get_dev_url('versions') }}#version-upload" class="version-upload">{{ _('Upload New Version') }}</a>
+          <a href="{{ addon.get_dev_url('versions') }}#version-upload" class="version-upload"
+          >{{ upload_file_label|default(_('Upload New Version')) }}</a>
         </strong>
         &middot;
       {% endif %}

--- a/apps/devhub/templates/devhub/versions/edit.html
+++ b/apps/devhub/templates/devhub/versions/edit.html
@@ -146,5 +146,6 @@
                     url('devhub.versions.add_file', addon.slug, version.id),
                     url('devhub.upload_for_addon', addon.slug), _('Add File') )}}
 </section>
+{% set upload_file_label = _('Upload a new file') %}
 {% include "devhub/includes/addons_edit_nav.html" %}
 {% endblock %}

--- a/apps/devhub/tests/test_views_versions.py
+++ b/apps/devhub/tests/test_views_versions.py
@@ -72,6 +72,12 @@ class TestVersion(amo.tests.TestCase):
             reverse('devhub.file_validation',
                     args=[self.addon.slug, self.version.all_files[0].id]))
 
+    def test_upload_link_label_in_edit_nav(self):
+        url = reverse('devhub.versions.edit', args=(self.addon.slug, self.version.pk))
+        r = self.client.get(url)
+        doc = pq(r.content)
+        eq_(doc('.addon-status>.addon-upload>strong>a').text(), 'Upload a new file')
+
     def test_delete_message(self):
         """Make sure we warn our users of the pain they will feel."""
         r = self.client.get(self.url)


### PR DESCRIPTION
Set the label of "Upload New Version" to "Upload a new file"
on an addon specific version devhub page.
