### PR TITLE
File status (beta or not) is explicit on upload (bug 669674)

### DIFF
--- a/apps/devhub/forms.py
+++ b/apps/devhub/forms.py
@@ -535,6 +535,10 @@ class NewVersionForm(NewAddonForm):
         error_messages={
             'required': _lazy(u'Please choose a review nomination type')
         })
+    beta = forms.BooleanField(
+        required=False,
+        help_text=_lazy(u'A file with a version ending with a|alpha|b|beta and'
+                        u' an optional number is detected as beta.'))
 
     def __init__(self, *args, **kw):
         self.addon = kw.pop('addon')
@@ -565,6 +569,10 @@ class NewFileForm(AddonUploadForm):
                                     u'not one of the available choices.')
         }
     )
+    beta = forms.BooleanField(
+        required=False,
+        help_text=_lazy(u'A file with a version ending with a|alpha|b|beta and'
+                        u' an optional number is detected as beta.'))
 
     def __init__(self, *args, **kw):
         self.addon = kw.pop('addon')

--- a/apps/devhub/templates/devhub/versions/add_file_modal.html
+++ b/apps/devhub/templates/devhub/versions/add_file_modal.html
@@ -39,6 +39,10 @@
         {{ new_file_form.nomination_type }}
       </div>
       {% endif %}
+      <div class="beta-status hide">
+        <label>{{ new_file_form.beta }} {{ _('Only publish this version to my beta channel.') }}</label>
+        <span class="tip tooltip" title="{{ new_file_form.beta.help_text }}">?</span>
+      </div>
       {% if is_admin %}
       <div class="admin-settings">
         <label>{{ _('Administrative overrides') }}</label>

--- a/apps/files/models.py
+++ b/apps/files/models.py
@@ -150,11 +150,8 @@ class File(amo.models.OnChangeMixin, amo.models.ModelBase):
         f.builder_version = data['builderVersion']
         f.no_restart = parse_data.get('no_restart', False)
         f.strict_compatibility = parse_data.get('strict_compatibility', False)
-        if version.addon.status == amo.STATUS_PUBLIC:
-            if amo.VERSION_BETA.search(parse_data.get('version', '')):
-                f.status = amo.STATUS_BETA
-            elif version.addon.trusted:
-                f.status = amo.STATUS_PUBLIC
+        if version.addon.status == amo.STATUS_PUBLIC and version.addon.trusted:
+            f.status = amo.STATUS_PUBLIC
         elif (version.addon.status in amo.LITE_STATUSES
               and version.addon.trusted):
             f.status = version.addon.status

--- a/apps/files/tests/test_models.py
+++ b/apps/files/tests/test_models.py
@@ -878,22 +878,6 @@ class TestFileFromUpload(UploadTest):
         f = File.from_upload(upload, self.version, self.platform, data)
         eq_(f.status, amo.STATUS_UNREVIEWED)
 
-    def test_public_to_beta(self):
-        upload = self.upload('beta-extension')
-        data = parse_addon(upload.path)
-        self.addon.update(status=amo.STATUS_PUBLIC)
-        eq_(self.addon.status, amo.STATUS_PUBLIC)
-        f = File.from_upload(upload, self.version, self.platform, data)
-        eq_(f.status, amo.STATUS_BETA)
-
-    def test_trusted_public_to_beta(self):
-        upload = self.upload('beta-extension')
-        data = parse_addon(upload.path)
-        self.addon.update(status=amo.STATUS_PUBLIC, trusted=True)
-        eq_(self.addon.status, amo.STATUS_PUBLIC)
-        f = File.from_upload(upload, self.version, self.platform, data)
-        eq_(f.status, amo.STATUS_BETA)
-
     def test_public_to_unreviewed(self):
         upload = self.upload('extension')
         data = parse_addon(upload.path)

--- a/apps/files/tests/test_utils_.py
+++ b/apps/files/tests/test_utils_.py
@@ -9,8 +9,24 @@ import amo.tests
 from addons.models import Addon
 from applications.models import AppVersion
 from files.models import File
-from files.utils import find_jetpacks, PackageJSONExtractor
+from files.utils import find_jetpacks, is_beta, PackageJSONExtractor
 from versions.models import Version
+
+
+def test_is_beta():
+    assert not is_beta('1.2')
+    assert is_beta('1.2a')
+    assert is_beta('1.2alpha')
+    assert is_beta('1.2a1')
+    assert is_beta('1.2alpha1')
+    assert is_beta('1.2a123')
+    assert is_beta('1.2alpha123')
+    assert is_beta('1.2b')
+    assert is_beta('1.2beta')
+    assert is_beta('1.2b1')
+    assert is_beta('1.2beta1')
+    assert is_beta('1.2b123')
+    assert is_beta('1.2blpha123')
 
 
 class TestFindJetpacks(amo.tests.TestCase):

--- a/apps/files/utils.py
+++ b/apps/files/utils.py
@@ -77,6 +77,11 @@ def make_xpi(files):
     return f
 
 
+def is_beta(version):
+    """Return True if the version is believed to be a beta version."""
+    return bool(amo.VERSION_BETA.search(version))
+
+
 class Extractor(object):
     """Extract adon info from an install.rdf or package.json"""
     App = collections.namedtuple('App', 'appdata id min max')

--- a/apps/versions/tests.py
+++ b/apps/versions/tests.py
@@ -933,27 +933,12 @@ class TestStatusFromUpload(TestVersionFromUpload):
     def setUp(self):
         super(TestStatusFromUpload, self).setUp()
         self.current = self.addon.current_version
-        # We need one public file to stop the addon update signal
-        # moving the addon away from public. Only public addons check
-        # for beta status on from_upload.
         self.current.files.all().update(status=amo.STATUS_UNREVIEWED)
-        File.objects.create(version=self.current, status=amo.STATUS_PUBLIC)
-        self.addon.update(status=amo.STATUS_PUBLIC)
 
     def test_status(self):
-        qs = File.objects.filter(version=self.current)
         Version.from_upload(self.upload, self.addon, [self.platform])
-        eq_(sorted([q.status for q in qs.all()]),
-            [amo.STATUS_PUBLIC, amo.STATUS_DISABLED])
-
-    @mock.patch('files.utils.parse_addon')
-    def test_status_beta(self, parse_addon):
-        parse_addon.return_value = {'version': u'0.1beta'}
-
-        qs = File.objects.filter(version=self.current)
-        Version.from_upload(self.upload, self.addon, [self.platform])
-        eq_(sorted([q.status for q in qs.all()]),
-            [amo.STATUS_UNREVIEWED, amo.STATUS_PUBLIC])
+        eq_(File.objects.filter(version=self.current)[0].status,
+            amo.STATUS_DISABLED)
 
 
 class TestMobileVersions(TestMobile):

--- a/static/js/common/upload-addon.js
+++ b/static/js/common/upload-addon.js
@@ -259,6 +259,11 @@
 
 
             $upload_field.bind("upload_success_results", function(e, file, results) {
+                    // If the addon is detected as beta, automatically check the "beta" input.
+                    if (results.beta) {
+                      $('#id_beta').prop('checked', true);
+                      $('.beta-status').show();
+                    }
                 if(results.error) {
                     // This shouldn't happen.  But it might.
                     var error = gettext('Unexpected server error while validating.');


### PR DESCRIPTION
Fixes [bug 669674](https://bugzilla.mozilla.org/show_bug.cgi?id=669674)

The rationale here is to allow a developer to explicitely specify the beta
status of a file uploaded.

If a file has a version that looks like beta, the "beta" checkbox is
pre-selected.

![beta_version](https://cloud.githubusercontent.com/assets/167767/4573374/b06ff6f4-4f91-11e4-9e83-a7f2b03dc6ba.png)
