### PR TITLE
Allows the user to choose a nomination type (bug 1071228)

### DIFF
--- a/apps/devhub/templates/devhub/versions/add_file_modal.html
+++ b/apps/devhub/templates/devhub/versions/add_file_modal.html
@@ -31,14 +31,14 @@
           <label>{{ _('Which mobile platforms is this file compatible with?') }}</label>
           {{ new_file_form.mobile_platforms }}
         </div>
-       {% if addon.status == amo.STATUS_NULL %}
-        <div class="nomination-type">
-          <label>{{ _('Which review type would you like to nominate for?') }}</label>
-          {{ new_file_form.nomination_type }}
-        </div>
-       {% endif %}
       {% endif %}
       </div>
+      {% if addon.status == amo.STATUS_NULL %}
+      <div class="nomination-type">
+        <label>{{ _('Which review type would you like to nominate for?') }}</label>
+        {{ new_file_form.nomination_type }}
+      </div>
+      {% endif %}
       {% if is_admin %}
       <div class="admin-settings">
         <label>{{ _('Administrative overrides') }}</label>

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -697,14 +697,6 @@ function initVersions() {
             $('.current-version-warning', this).toggle(is_current);
             return true;
         }});
-
-    $('#upload-file-finish').click(function() {
-        var $button = $(this);
-        setTimeout(function() { // Chrome fix
-            $button.attr('disabled', true);
-        }, 50);
-    });
-
 }
 
 function initSubmit() {


### PR DESCRIPTION
Only when all versions are deleted (STATUS==NULL) and he wants to upload a new one. Otherwise the choice field should remain hidden.
