### PR TITLE
Fix tests for the rss pagination (bug 1070766)

### DIFF
--- a/apps/addons/fixtures/addons/default-to-compat.json
+++ b/apps/addons/fixtures/addons/default-to-compat.json
@@ -220,7 +220,7 @@
         "fields": {
             "has_info_request": false,
             "license": null,
-            "created": "2011-12-05 14:46:43",
+            "created": "2011-12-05 14:46:44",
             "has_editor_comment": false,
             "releasenotes": null,
             "approvalnotes": "",
@@ -248,7 +248,7 @@
         "fields": {
             "has_info_request": false,
             "license": null,
-            "created": "2011-12-05 14:46:43",
+            "created": "2011-12-05 14:46:45",
             "has_editor_comment": false,
             "releasenotes": null,
             "approvalnotes": "",
@@ -276,7 +276,7 @@
         "fields": {
             "has_info_request": false,
             "license": null,
-            "created": "2011-12-05 14:46:43",
+            "created": "2011-12-05 14:46:46",
             "has_editor_comment": false,
             "releasenotes": null,
             "approvalnotes": "",

--- a/apps/versions/tests.py
+++ b/apps/versions/tests.py
@@ -528,14 +528,14 @@ class TestFeeds(amo.tests.TestCase):
         """first page has the right elements and page relations"""
         doc = self.get_feed('addon-337203', page=1)
         eq_(doc('rss item title')[0].text,
-            'Addon for DTC 1.0 - December  5, 2011')
+            'Addon for DTC 1.3 - December  5, 2011')
         self.assert_page_relations(doc, {'self': 1, 'next': 2, 'last': 4})
 
     def test_feed_middle_page(self):
         """a middle page has the right elements and page relations"""
         doc = self.get_feed('addon-337203', page=2)
         eq_(doc('rss item title')[0].text,
-            'Addon for DTC 1.1 - December  5, 2011')
+            'Addon for DTC 1.2 - December  5, 2011')
         self.assert_page_relations(doc, {'previous': 1, 'self': 2, 'next': 3,
                                          'last': 4})
 
@@ -543,20 +543,20 @@ class TestFeeds(amo.tests.TestCase):
         """last page has the right elements and page relations"""
         doc = self.get_feed('addon-337203', page=4)
         eq_(doc('rss item title')[0].text,
-            'Addon for DTC 1.3 - December  5, 2011')
+            'Addon for DTC 1.0 - December  5, 2011')
         self.assert_page_relations(doc, {'previous': 3, 'self': 4, 'last': 4})
 
     def test_feed_invalid_page(self):
         """an invalid page falls back to page 1"""
         doc = self.get_feed('addon-337203', page=5)
         eq_(doc('rss item title')[0].text,
-            'Addon for DTC 1.0 - December  5, 2011')
+            'Addon for DTC 1.3 - December  5, 2011')
 
     def test_feed_no_page(self):
         """no page defaults to page 1"""
         doc = self.get_feed('addon-337203')
         eq_(doc('rss item title')[0].text,
-            'Addon for DTC 1.0 - December  5, 2011')
+            'Addon for DTC 1.3 - December  5, 2011')
 
 
 class TestDownloadsBase(amo.tests.TestCase):


### PR DESCRIPTION
This is following #301. The code was correct, but not the tests (the fixtures
had the same "created" date for all 4 versions, causing the builds to fail
randomly).

Fixes [bug 1070766](https://bugzilla.mozilla.org/show_bug.cgi?id=1070766)
