### PR TITLE
Fix android not able to install addons anymore (bug 1083704)

### DIFF
--- a/static/js/zamboni/mobile/buttons.js
+++ b/static/js/zamboni/mobile/buttons.js
@@ -245,16 +245,10 @@
                     }
                     if (self.tooOld) errors.push("tooOld");
                     if (self.tooNew) errors.push("tooNew");
-                } else {
-                    if (!z.appMatchesUserAgent && !z.badBrowser) {
-                        errors.push("badApp");
-                        canInstall = false;
-                    }
-                    if (!platformSupported) {
-                        errors.push("badPlatform");
-                        dom.buttons.hide().eq(0).show();
-                        canInstall = false;
-                    }
+                } else if (!platformSupported) {
+                    errors.push("badPlatform");
+                    dom.buttons.hide().eq(0).show();
+                    canInstall = false;
                 }
 
                 if (platformer) {


### PR DESCRIPTION
Fixes [bug 1083704](https://bugzilla.mozilla.org/show_bug.cgi?id=1083704)

The previous modification on those lines for #317 was incomplete, and caused
the addons to always be detected as "can't install".
