### PR TITLE
Don't display the version nor the last_updated for personas (bug 1083236)

### DIFF
--- a/apps/devhub/templates/devhub/addons/listing/items.html
+++ b/apps/devhub/templates/devhub/addons/listing/items.html
@@ -18,21 +18,9 @@
         </div>
         <ul class="item-details">
           {% if addon.is_persona() %}
-            {% if addon.current_version %}
-              {% set link = url('devhub.versions.edit', addon.slug, addon.current_version.id) %}
-              {# L10n: {1} is a version number. #}
-              <li>{{ _('<strong>Latest version:</strong> <a href="{0}">{1}</a>')|
-                       f(link, addon.current_version) }}</li>
-            {% endif %}
-            {% if sorting == 'created' %}
-              {# L10n: {0} is a date. #}
-              <li class="date-created">{{ _('<strong>Created:</strong> {0}'|
-                     f(addon.created|datetime)) }}</li>
-            {% else %}
-              {# L10n: {0} is a date. #}
-              <li class="date-updated">{{ _('<strong>Last updated:</strong> {0}'|
-                     f(addon.last_updated|datetime)) }}</li>
-            {% endif %}
+            {# L10n: {0} is a date. #}
+            <li class="date-created">{{ _('<strong>Created:</strong> {0}'|
+                   f(addon.created|datetime)) }}</li>
             <li id="version-status-item">
               <strong>{{ _('Status:') }}</strong>
               {% if addon.disabled_by_user %}

--- a/apps/devhub/tests/test_views.py
+++ b/apps/devhub/tests/test_views.py
@@ -244,6 +244,24 @@ class TestDashboard(HubTest):
         eq_(d.remove('strong').text(),
             strip_whitespace(datetime_filter(addon.last_updated)))
 
+    def test_no_sort_updated_filter_for_themes(self):
+        # Create a theme.
+        addon = addon_factory(type=amo.ADDON_PERSONA)
+        addon.addonuser_set.create(user=self.user_profile)
+
+        # There's no "updated" sort filter, so order by the default: "Name".
+        response = self.client.get(self.themes_url + '?sort=updated')
+        doc = pq(response.content)
+        eq_(doc('#sorter li.selected').text(), 'Name')
+        sorts = doc('#sorter li a.opt')
+        assert not any('?sort=updated' in a.attrib['href'] for a in sorts)
+
+        # There's no "last updated" for themes, so always display "created".
+        eq_(doc('.item-details .date-updated'), [])  # No "updated" in details.
+        d = doc('.item-details .date-created')
+        eq_(d.remove('strong').text(),
+            strip_whitespace(datetime_filter(addon.created)))
+
 
 class TestUpdateCompatibility(amo.tests.TestCase):
     fixtures = ['base/users', 'base/addon_4594_a9', 'base/addon_3615']

--- a/apps/devhub/views.py
+++ b/apps/devhub/views.py
@@ -73,6 +73,13 @@ class AddonFilter(BaseFilter):
             ('rating', _lazy(u'Rating')))
 
 
+class ThemeFilter(BaseFilter):
+    opts = (('name', _lazy(u'Name')),
+            ('created', _lazy(u'Created')),
+            ('popular', _lazy(u'Downloads')),
+            ('rating', _lazy(u'Rating')))
+
+
 def addon_listing(request, default='name', theme=False):
     """Set up the queryset and filtering for addon listing for Dashboard."""
     if theme:
@@ -82,7 +89,8 @@ def addon_listing(request, default='name', theme=False):
         qs = request.amo_user.addons.exclude(type__in=[amo.ADDON_WEBAPP,
                                                        amo.ADDON_PERSONA])
         model = Addon
-    filter = AddonFilter(request, qs, 'sort', default, model=model)
+    filter_cls = ThemeFilter if theme else AddonFilter
+    filter = filter_cls(request, qs, 'sort', default, model=model)
     return filter.qs, filter
 
 

--- a/apps/discovery/templates/discovery/addons/base.html
+++ b/apps/discovery/templates/discovery/addons/base.html
@@ -19,7 +19,7 @@
         <img class="icon" src="{{ addon.icon_url }}" alt="">
         {{ addon.name }}
         {% set version = addon.current_version %}
-        {% if version %}
+        {% if not addon.is_persona() and version %}
           <span class="version">{{ version.version }}</span>
         {% endif %}
       </h1>

--- a/apps/discovery/templates/discovery/addons/detail.html
+++ b/apps/discovery/templates/discovery/addons/detail.html
@@ -72,9 +72,15 @@
     <p class="users">{{ addon.average_daily_users|numberfmt }}</p>
   </li>
   <li>
+  {% if addon.is_persona() %}
+    <h3>{{ _('Created') }}</h3>
+    <p><time datetime="{{ addon.created|isotime }}">{{
+      addon.created|datetime }}</time></p>
+  {% else %}
     <h3>{{ _('Last Updated') }}</h3>
     <p><time datetime="{{ addon.last_updated|isotime }}">{{
       addon.last_updated|datetime }}</time></p>
+  {% endif %}
   </li>
   {% if addon.homepage %}
     <li>

--- a/apps/discovery/tests/test_views.py
+++ b/apps/discovery/tests/test_views.py
@@ -4,8 +4,10 @@ from django import test
 from django.core.cache import cache
 from django.test.utils import override_settings
 
+from jingo.helpers import datetime as datetime_filter
 from nose.tools import eq_
 from pyquery import PyQuery as pq
+from tower import strip_whitespace
 import waffle
 
 import amo
@@ -452,9 +454,6 @@ class TestPersonaDetails(amo.tests.TestCase):
 
     def setUp(self):
         self.addon = Addon.objects.get(id=15663)
-        self.persona = self.addon.persona
-        self.persona.author = self.persona.author
-        self.persona.save()
         self.url = reverse('discovery.addons.detail', args=[self.addon.slug])
 
     def test_page(self):
@@ -465,6 +464,31 @@ class TestPersonaDetails(amo.tests.TestCase):
         """Test that the `by ... <authors>` section works."""
         r = self.client.get(self.url)
         assert pq(r.content)('h2.author').text().startswith('by persona_author')
+
+    def test_no_version(self):
+        """Don't display a version number for themes."""
+        r = self.client.get(self.url)
+        eq_(pq(r.content)('h1 .version'), [])
+
+    def test_created_not_updated(self):
+        """Don't display the updated date but the created date for themes."""
+        r = self.client.get(self.url)
+        doc = pq(r.content)
+        details = doc('.addon-info li')
+
+        # There's no "Last Updated" entry.
+        assert not any('Last Updated' in node.text_content()
+                       for node in details)
+
+        # But there's a "Created" entry.
+        for detail in details:
+            if detail.find('h3').text_content() == 'Created':
+                created = detail.find('p').text_content()
+                eq_(created,
+                    strip_whitespace(datetime_filter(self.addon.created)))
+                break  # Needed, or we go in the "else" clause.
+        else:
+            assert False, 'No "Created" entry found.'
 
 
 class TestDownloadSources(amo.tests.TestCase):


### PR DESCRIPTION
Fixes [bug 1083236](https://bugzilla.mozilla.org/show_bug.cgi?id=1083236)

I also took the opportunity to do a bit of cleanup.

The "my submissions" theme tab doesn't display the version nor the "last
updated" date for personas (the last_updated field is never set for personas). I also removed the "sort by updated" from the sort choices:
![theme_submission](https://cloud.githubusercontent.com/assets/167767/4682324/c4391e6e-561b-11e4-9ecb-631b00269991.png)

The discovery page for the themes doesn't display the version anymore, and it
displays the created date instead of the last updated date (which is always
empty):
![persona_discovery](https://cloud.githubusercontent.com/assets/167767/4681408/b91dd0dc-5612-11e4-87e5-dd0d7fd738f9.png)
