### PR TITLE
Don't overwrite user-media/apps.json with tests

### DIFF
--- a/apps/applications/tests.py
+++ b/apps/applications/tests.py
@@ -1,4 +1,5 @@
 import json
+import tempfile
 
 from django.core.management import call_command
 from django.db import IntegrityError
@@ -8,7 +9,6 @@ import amo
 import amo.tests
 from amo.helpers import url
 from applications.models import AppVersion
-from applications.management.commands import dump_apps
 
 
 class TestAppVersion(amo.tests.TestCase):
@@ -59,14 +59,18 @@ class TestCommands(amo.tests.TestCase):
     fixtures = ['base/appversion']
 
     def test_dump_apps(self):
-        call_command('dump_apps')
-        with open(dump_apps.Command.JSON_PATH, 'r') as f:
-            apps = json.load(f)
-        for idx, app in amo.APP_IDS.iteritems():
-            data = apps[str(app.id)]
-            versions = sorted([a.version for a in
-                               AppVersion.objects.filter(application=app.id)])
-            eq_("%s: %r" % (app.short, sorted(data['versions'])),
-                "%s: %r" % (app.short, versions))
-            eq_(data['name'], app.short)
-            eq_(data['guid'], app.guid)
+        tmpdir = tempfile.mkdtemp()
+        with self.settings(MEDIA_ROOT=tmpdir):  # Don't overwrite apps.json.
+            from applications.management.commands import dump_apps
+            call_command('dump_apps')
+            with open(dump_apps.Command.JSON_PATH, 'r') as f:
+                apps = json.load(f)
+            for idx, app in amo.APP_IDS.iteritems():
+                data = apps[str(app.id)]
+                versions = sorted([a.version for a in
+                                   AppVersion.objects.filter(
+                                       application=app.id)])
+                eq_("%s: %r" % (app.short, sorted(data['versions'])),
+                    "%s: %r" % (app.short, versions))
+                eq_(data['name'], app.short)
+                eq_(data['guid'], app.guid)

--- a/apps/files/tests/test_models.py
+++ b/apps/files/tests/test_models.py
@@ -34,12 +34,6 @@ class UploadTest(amo.tests.TestCase, amo.tests.AMOPaths):
     Base for tests that mess with file uploads, safely using temp directories.
     """
 
-    def setUp(self):
-        # The validator task (post Addon upload) loads apps.json
-        # so ensure it exists:
-        from django.core.management import call_command
-        call_command('dump_apps')
-
     def file_path(self, *args, **kw):
         return self.file_fixture_path(*args, **kw)
 


### PR DESCRIPTION
Running tests was overwriting the user-media/apps.json file, which contains the
result of running `./manage.py dump_apps`, which dumps all the apps and
appversions we have, and is used by the amo-validator.

Thus running the tests would overwrite all the apps and appversions previously
updated with `import_prod_versions`, and prevent uploading addons/versions with
"recent" versions.
