### PR TITLE
Fix global stats: compute for previous day (bug 1088639)

### DIFF
--- a/apps/stats/cron.py
+++ b/apps/stats/cron.py
@@ -50,7 +50,8 @@ def update_global_totals(date=None):
 
     if date:
         date = datetime.datetime.strptime(date, '%Y-%m-%d').date()
-    today = date or datetime.date.today()
+    # Assume that we want to populate yesterday's stats by default.
+    today = date or datetime.date.today() - datetime.timedelta(days=1)
     today_jobs = [dict(job=job, date=today) for job in
                   tasks._get_daily_jobs(date)]
 

--- a/apps/stats/tasks.py
+++ b/apps/stats/tasks.py
@@ -168,10 +168,10 @@ def _get_daily_jobs(date=None):
     """Return a dictionary of statistics queries.
 
     If a date is specified and applies to the job it will be used.  Otherwise
-    the date will default to today().
+    the date will default to the previous day.
     """
     if not date:
-        date = datetime.date.today()
+        date = datetime.date.today() - datetime.timedelta(days=1)
 
     # Passing through a datetime would not generate an error,
     # but would pass and give incorrect values.
@@ -227,7 +227,7 @@ def _get_daily_jobs(date=None):
     # If we're processing today's stats, we'll do some extras.  We don't do
     # these for re-processed stats because they change over time (eg. add-ons
     # move from sandbox -> public
-    if date == datetime.date.today():
+    if date == (datetime.date.today() - datetime.timedelta(days=1)):
         stats.update({
             'addon_count_experimental': Addon.objects.filter(
                 created__lte=date, status=amo.STATUS_UNREVIEWED,


### PR DESCRIPTION
Fixes [bug 1088639](https://bugzilla.mozilla.org/show_bug.cgi?id=1088639)

To backfill, you can run the following script:

```
import datetime

import manage
import cronjobs

from django.core.management import call_command


start = datetime.date(year=2014, month=7, day=10)
today = datetime.date.today()

current = start

while current < today:
    call_command('cron', 'update_global_totals', current.strftime('%Y-%m-%d'))
    # Manually override the django-cronjobs lock. Yikes.
    cronjobs.registered_lock.clear()
    current += datetime.timedelta(days=1)
```
