### PR TITLE
Remove unused review-actions-visibility from editors tools (bug 1112615)

### DIFF
--- a/static/js/zamboni/editors.js
+++ b/static/js/zamboni/editors.js
@@ -79,7 +79,6 @@ function initReviewActions() {
         $data_toggle.filter('[data-value*="' + value + '"]').show();
 
         toggle_input();
-        togglePermissions(value);
 
         /* Fade out canned responses */
         var label = $element.text().trim();
@@ -108,22 +107,6 @@ function initReviewActions() {
         // Add a dummy, disabled input
         $files_input.prop('checked', true).hide();
         $files_input.after($('<input>', {'type': 'checkbox', 'checked': true, 'disabled': true}));
-    }
-
-    function togglePermissions(action) {
-        // Check/Uncheck/Disable default permissions associated with the action.
-        var $reviewerActions = $('.review-actions-visibility');
-        var $permissions = $('input[name="action_visibility"]');
-        $permissions.prop('checked', true).prop('disabled', false);
-
-        var disable_list = $reviewerActions.data('default-visibility')[action];
-        if (disable_list) {
-            _.each(disable_list.disabled, function(v) {
-                $permissions.filter('[value="' + v + '"]')
-                            .prop('disabled', true)
-                            .prop('checked', false);
-            });
-        }
     }
 
     function toggle_input(){


### PR DESCRIPTION
Fixes [bug 1112615](https://bugzilla.mozilla.org/show_bug.cgi?id=1112615)

This follows up from
https://github.com/mozilla/olympia/commit/f9464093504f2d820d84a58576da1c0216ec9f88
when this visibility feature was removed. This removed code was breaking the
javascript.
