### PR TITLE
Fix unicode errors with the redirect middleware again (bug 1097147))

### DIFF
--- a/apps/amo/middleware.py
+++ b/apps/amo/middleware.py
@@ -61,7 +61,8 @@ class LocaleAndAppURLMiddleware(object):
             full_path = urllib.quote(full_path.encode('utf-8'))
 
             if query_string:
-                full_path = "%s?%s" % (full_path, query_string)
+                query_string = query_string.decode('utf-8', 'ignore')
+                full_path = u'%s?%s' % (full_path, query_string)
 
             response = redirect_type(full_path)
             # Cache the redirect for a year.

--- a/apps/amo/tests/test_middleware.py
+++ b/apps/amo/tests/test_middleware.py
@@ -52,6 +52,15 @@ def test_redirect_with_unicode_get():
         '%83%90%E3%82%BA&utm_medium=twitter&utm_term=Google+%E3%83%90%'
         'E3%82%BA')
     eq_(response.status_code, 301)
+    assert response['Location'].endswith('&utm_term=Google+%E3%83%90%E3%82%BA')
+
+
+def test_source_with_wrong_unicode_get():
+    # The following url is a string (bytes), not unicode.
+    response = test.Client().get('/firefox/collections/mozmj/autumn/'
+                                 '?source=firefoxsocialmedia\x14\x85')
+    eq_(response.status_code, 301)
+    assert response['Location'].endswith('?source=firefoxsocialmedia%14')
 
 
 def test_trailing_slash_middleware():


### PR DESCRIPTION
Fixes [bug 1097147](https://bugzilla.mozilla.org/show_bug.cgi?id=1097147) again (cf #362 which was reverted)
