### PR TITLE
comment when auto-flagging as admin review (bug 1109701)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ initialize_db:
 	$(FIG_PREFIX) python manage.py import_prod_versions
 	$(FIG_PREFIX) schematic --fake migrations/
 	$(FIG_PREFIX) python manage.py createsuperuser
+	$(FIG_PREFIX) python manage.py loaddata zadmin/users
 
 populate_data:
 	$(FIG_PREFIX) python manage.py generate_addons --app firefox $(NUM_ADDONS)

--- a/apps/devhub/tests/test_views_versions.py
+++ b/apps/devhub/tests/test_views_versions.py
@@ -467,10 +467,16 @@ class TestVersionEditDetails(TestVersionEditBase):
             source_file.seek(0)
             data = self.formset(source=source_file)
             response = self.client.post(self.url, data)
-            eq_(response.status_code, 302)
-            version = Version.objects.get(pk=self.version.pk)
-            assert version.source
-            assert version.addon.admin_review
+        eq_(response.status_code, 302)
+        version = Version.objects.get(pk=self.version.pk)
+        assert version.source
+        assert version.addon.admin_review
+
+        # Check that the corresponding automatic activity log has been created.
+        log = ActivityLog.objects.get(action=amo.LOG.REQUEST_SUPER_REVIEW.id)
+        assert log.details['comments'] == (
+            u'This version has been automatically flagged as admin review, as '
+            u'it had some source files attached when submitted.')
 
     def test_should_not_accept_exe_source_file(self):
         tdir = temp.gettempdir()

--- a/apps/versions/tests.py
+++ b/apps/versions/tests.py
@@ -791,7 +791,7 @@ class TestDownloadsLatest(TestDownloadsBase):
 
 @override_settings(XSENDFILE=True)
 class TestDownloadSource(amo.tests.TestCase):
-    fixtures = ['base/addon_3615', 'base/admin', ]
+    fixtures = ['base/addon_3615', 'base/admin']
 
     def setUp(self):
         super(TestDownloadSource, self).setUp()


### PR DESCRIPTION
Fixes [bug 1109701](https://bugzilla.mozilla.org/show_bug.cgi?id=1109701)

This is following [bug 540028](https://bugzilla.mozilla.org/show_bug.cgi?id=540028) (PR #139) and [bug 1097634](https://bugzilla.mozilla.org/show_bug.cgi?id=1097634) (PR #363):
automatically add a review comment saying that the version has been flagged as "admin review" because some sources were provided.
