### PR TITLE
Show HTML error when using the redirect FxA flow (fixes #1226)

### DIFF
--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -149,8 +149,8 @@ def check_selected(expected, links, selected):
 
 def assert_url_equal(url, other, compare_host=False):
     """Compare url paths and query strings."""
-    parsed = urlparse(url)
-    parsed_other = urlparse(other)
+    parsed = urlparse(unicode(url))
+    parsed_other = urlparse(unicode(other))
     eq_(parsed.path, parsed_other.path)  # Paths are equal.
     eq_(parse_qs(parsed.query),
         parse_qs(parsed_other.query))  # Params are equal.

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -152,8 +152,8 @@ def assert_url_equal(url, other, compare_host=False):
     parsed = urlparse(url)
     parsed_other = urlparse(other)
     eq_(parsed.path, parsed_other.path)  # Paths are equal.
-    eq_(parse_qs(parsed.path),
-        parse_qs(parsed_other.path))  # Params are equal.
+    eq_(parse_qs(parsed.query),
+        parse_qs(parsed_other.query))  # Params are equal.
     if compare_host:
         eq_(parsed.netloc, parsed_other.netloc)
 
@@ -555,16 +555,9 @@ class TestCase(InitializeSessionMixin, MockEsMixin, RedisTest, BaseTestCase):
         """
         return pq(pq(html)(template_selector).html())
 
-    def assertUrlEqual(self, url, other, compare_host=False,
-                       compare_scheme=False):
+    def assertUrlEqual(self, url, other, compare_host=False):
         """Compare url paths and query strings."""
-        parsed = urlparse(url)
-        parsed_other = urlparse(other)
-        eq_(parsed.path, parsed_other.path)  # Paths are equal.
-        eq_(parse_qs(parsed.path),
-            parse_qs(parsed_other.path))  # Params are equal.
-        if compare_host:
-            eq_(parsed.netloc, parsed_other.netloc)
+        assert_url_equal(url, other, compare_host)
 
 
 class AMOPaths(object):

--- a/src/olympia/api/tests/test_views.py
+++ b/src/olympia/api/tests/test_views.py
@@ -451,15 +451,17 @@ class APITest(TestCase):
 
         # For urls with several parameters, we need to use self.assertUrlEqual,
         # as the parameters could be in random order. Dicts aren't ordered!
+        # We need to subtract 7 hours from the modified time since May 3, 2008
+        # is during daylight savings time.
         url_needles = {
             "full": urlparams(
                 '{previews}full/20/20397.png'.format(
                     previews=helpers.user_media_url('previews')),
-                src='api', modified=1209834208),
+                src='api', modified=1209834208 - 7 * 3600),
             "thumbnail": urlparams(
                 '{previews}thumbs/20/20397.png'.format(
                     previews=helpers.user_media_url('previews')),
-                src='api', modified=1209834208),
+                src='api', modified=1209834208 - 7 * 3600),
         }
 
         response = make_call('addon/4664', version=1.5)

--- a/src/olympia/users/templates/users/login_form.html
+++ b/src/olympia/users/templates/users/login_form.html
@@ -1,12 +1,15 @@
 <form method="post" action="{{ action }}"
       class="{% if is_ajax %}ajax-submit {% endif %}listing-footer{% if login_source_form %} login-source-form{% else %} login-form{% endif %}">
   {{ csrf() }}
-  {% if form.non_field_errors() %}
+  {% if form.non_field_errors() or login_error %}
       <div class="notification-box error">
         <ul>
         {% for error in form.non_field_errors() %}
         <li>{{ error }}</li>
         {% endfor %}
+        {% if login_error %}
+        <li>{{ login_error }} <a href="{{ fxa_login_help_url }}" target="_blank">{{ _('Need help?') }}</a></li>
+        {% endif %}
         </ul>
       </div>
   {% endif %}

--- a/src/olympia/users/views.py
+++ b/src/olympia/users/views.py
@@ -28,6 +28,7 @@ from olympia.users import notifications as notifications
 from olympia.abuse.models import send_abuse_report
 from olympia.access import acl
 from olympia.access.middleware import ACLMiddleware
+from olympia.accounts.views import LOGIN_ERROR_MESSAGES
 from olympia.addons.decorators import addon_view_factory
 from olympia.addons.models import Addon, AddonUser, Category
 from olympia.amo import messages
@@ -375,6 +376,12 @@ def _login(request, template=None, data=None, dont_redirect=False):
 
     data['login_source_form'] = (waffle.switch_is_active('fxa-auth') and
                                  not request.POST)
+    login_error = request.GET.get('error')
+    if login_error in LOGIN_ERROR_MESSAGES:
+        data['login_error'] = LOGIN_ERROR_MESSAGES[login_error]
+        data['fxa_login_help_url'] = ('https://support.mozilla.org/kb/'
+                                      'access-your-add-ons-firefox-accounts')
+
     limited = getattr(request, 'limited', 'recaptcha_shown' in request.POST)
     user = None
     login_status = None

--- a/static/css/impala/forms.less
+++ b/static/css/impala/forms.less
@@ -149,6 +149,10 @@ textarea {
 
     li {
         margin-bottom: 15px;
+
+        &:last-of-type {
+            margin-bottom: 0;
+        }
     }
 
     ul {


### PR DESCRIPTION
![fxa-login-error-html mov](https://cloud.githubusercontent.com/assets/211578/12766408/4f7b9ffc-c9c9-11e5-9a2f-71c3da955f05.gif)

Fixes #1226 and #1517.
