### PR TITLE
Add version endpoint

### DIFF
--- a/src/olympia/amo/tests/test_views.py
+++ b/src/olympia/amo/tests/test_views.py
@@ -424,3 +424,11 @@ class TestAtomicRequests(WithDynamicEndpoints, TransactionTestCase):
             assert qs.count() == 0
         finally:
             qs.all().delete()
+
+
+class TestVersion(TestCase):
+
+    def test_version_json(self):
+        res = self.client.get('/__version__')
+        eq_(res.status_code, 200)
+        eq_(res._headers['content-type'], ('Content-Type', 'application/json'))

--- a/src/olympia/amo/urls.py
+++ b/src/olympia/amo/urls.py
@@ -22,6 +22,7 @@ urlpatterns = patterns(
     url('^contribute.json$', views.contribute, name='contribute.json'),
     url(r'^wafflejs$', wafflejs, name='wafflejs'),
     ('^services/', include(services_patterns)),
+    url('^__version__$', views.version, name='version.json'),
 
     url('^opensearch.xml$', 'olympia.api.views.render_xml',
                             {'template': 'amo/opensearch.xml'},

--- a/src/olympia/amo/views.py
+++ b/src/olympia/amo/views.py
@@ -161,6 +161,12 @@ def cspreport(request):
 
 
 @non_atomic_requests
+def version(request):
+    path = os.path.join(settings.ROOT, 'version.json')
+    return HttpResponse(open(path, 'rb'), content_type='application/json')
+
+
+@non_atomic_requests
 def plugin_check_redirect(request):
     return http.HttpResponseRedirect('%s?%s' % (
         settings.PFS_URL, iri_to_uri(request.META.get('QUERY_STRING', ''))))

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -231,13 +231,14 @@ SUPPORTED_NONAPPS = (
     'developer_agreement', 'developer_faq', 'developers', 'editors', 'faq',
     'jsi18n', 'localizers', 'review_guide', 'google1f3e37b7351799a5.html',
     'robots.txt', 'statistics', 'services', 'sunbird', 'static', 'user-media',
+    '__version__',
 )
 DEFAULT_APP = 'firefox'
 
 # paths that don't require a locale prefix
 SUPPORTED_NONLOCALES = (
     'contribute.json', 'google1f3e37b7351799a5.html', 'robots.txt', 'services',
-    'downloads', 'blocklist', 'static', 'user-media',
+    'downloads', 'blocklist', 'static', 'user-media', '__version__',
 )
 
 # Make this unique, and don't share it with anybody.

--- a/version.json
+++ b/version.json
@@ -1,0 +1,5 @@
+{
+    "source": "https://github.com/mozilla/olympia",
+    "version": "origin/master",
+    "commit": "0000000"
+}

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-    "source": "https://github.com/mozilla/olympia",
+    "source": "https://github.com/mozilla/addons-server",
     "version": "origin/master",
     "commit": "0000000"
 }


### PR DESCRIPTION
As per "Standard for Version Route and Format" document, I've added a /__version__ endpoint [1]. We will write out a version.json to the olympia directory every time we build a package for deployment.

I've added a sample version.json as a placeholder but I feel like the content might not be useful.

r?

[1] https://docs.google.com/document/d/1rGVyiLYvZyKE2oHcSVx-vBmQRKhs1kLLgn7xeCs6qK