### PR TITLE
CSP: Add static.addons.mozilla.net to img-src

### DIFF
--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1304,6 +1304,7 @@ CSP_IMG_SRC = (
     'https://www.paypal.com',
     ANALYTICS_HOST,
     PROD_CDN_HOST,
+    'https://static.addons.mozilla.net',  # CDN origin server.
     'https://ssl.gstatic.com/',
     'https://sentry.prod.mozaws.net',
 )


### PR DESCRIPTION
This is a workaround for the CDN origin being hit for certain image requests. Adding it to the img-src directive will prevent it being blocked / reported by CSP.

Kibana logs show this only happening for img-src using the query `blocked-uri:"static.addons.mozilla.net"`