### PR TITLE
Require confirmation of email to delete user (fixes #1523)

### DIFF
--- a/src/olympia/users/templates/users/delete.html
+++ b/src/olympia/users/templates/users/delete.html
@@ -45,10 +45,10 @@
           <fieldset>
             <legend>{{ _('Confirm account deletion') }}</legend>
             <ul>
-              <li{% if form.password.errors %} class="error"{% endif %}>
-                <label for="id_password">{{ _('Password') }} {{ required() }}</label>
-                {{ form.password }}
-                {{ form.password.errors }}
+              <li{% if form.email.errors %} class="error"{% endif %}>
+                <label for="id_email">{{ _('Email') }} {{ required() }}</label>
+                {{ form.email }}
+                {{ form.email.errors }}
               </li>
               <li{% if form.confirm.errors %} class="error"{% endif %}>
                 <label for="id_confirm" class="check">

--- a/src/olympia/users/tests/test_forms.py
+++ b/src/olympia/users/tests/test_forms.py
@@ -144,22 +144,22 @@ class TestPasswordResetForm(UserFormBase):
 
 class TestUserDeleteForm(UserFormBase):
 
-    def test_bad_password(self):
+    def test_bad_email(self):
         self.client.login(username='jbalogh@mozilla.com', password='password')
-        data = {'password': 'wrongpassword', 'confirm': True, }
+        data = {'email': 'wrong@example.com', 'confirm': True}
         r = self.client.post('/en-US/firefox/users/delete', data)
-        msg = "Wrong password entered!"
-        self.assertFormError(r, 'form', 'password', msg)
+        msg = "Email must be jbalogh@mozilla.com."
+        self.assertFormError(r, 'form', 'email', msg)
 
     def test_not_confirmed(self):
         self.client.login(username='jbalogh@mozilla.com', password='password')
-        data = {'password': 'password'}
+        data = {'email': 'jbalogh@mozilla.com'}
         r = self.client.post('/en-US/firefox/users/delete', data)
         self.assertFormError(r, 'form', 'confirm', 'This field is required.')
 
     def test_success(self):
         self.client.login(username='jbalogh@mozilla.com', password='password')
-        data = {'password': 'password', 'confirm': True, }
+        data = {'email': 'jbalogh@mozilla.com', 'confirm': True}
         self.client.post('/en-US/firefox/users/delete', data, follow=True)
         # TODO XXX: Bug 593055
         #self.assertContains(r, "Profile Deleted")
@@ -172,7 +172,7 @@ class TestUserDeleteForm(UserFormBase):
         """A developer's attempt to delete one's self must be thwarted."""
         f.return_value = True
         self.client.login(username='jbalogh@mozilla.com', password='password')
-        data = {'password': 'password', 'confirm': True, }
+        data = {'email': 'jbalogh@mozilla.com', 'confirm': True}
         r = self.client.post('/en-US/firefox/users/delete', data, follow=True)
         self.assertContains(r, 'You cannot delete your account')
 

--- a/src/olympia/users/views.py
+++ b/src/olympia/users/views.py
@@ -151,7 +151,7 @@ def delete(request):
             form = None
             return http.HttpResponseRedirect(reverse('users.login'))
     else:
-        form = forms.UserDeleteForm()
+        form = forms.UserDeleteForm(request=request)
 
     return render(request, 'users/delete.html',
                   {'form': form, 'amouser': amouser})

--- a/src/olympia/users/widgets.py
+++ b/src/olympia/users/widgets.py
@@ -78,3 +78,7 @@ class RequiredEmailInput(RequiredInputMixin, forms.EmailInput):
 
 class RequiredTextarea(RequiredInputMixin, forms.Textarea):
     """A Django Textarea with required attributes."""
+
+
+class RequiredCheckboxInput(RequiredInputMixin, forms.CheckboxInput):
+    """A Django Checkbox with required attributes."""


### PR DESCRIPTION
Update the delete user form to confirm email address instead of password.

![delete-account mov](https://cloud.githubusercontent.com/assets/211578/12896378/3bbb136a-ce67-11e5-9b65-5c65a29604b7.gif)

Fixes #1523.