### PR TITLE
Require email to look like an email on login form (fixes #1637)

### DIFF
--- a/src/olympia/users/forms.py
+++ b/src/olympia/users/forms.py
@@ -27,7 +27,7 @@ from .models import (
     BlacklistedPassword)
 from .widgets import (
     NotificationsSelectMultiple, RequiredEmailInput, RequiredInputMixin,
-    RequiredTextarea, RequiredTextInput)
+    RequiredTextarea)
 
 
 log = commonware.log.getLogger('z.users')
@@ -65,7 +65,7 @@ class PasswordMixin:
 
 
 class AuthenticationForm(auth_forms.AuthenticationForm):
-    username = forms.CharField(max_length=75, widget=RequiredTextInput)
+    username = forms.CharField(max_length=75, widget=RequiredEmailInput)
     password = forms.CharField(max_length=255,
                                min_length=PasswordMixin.min_length,
                                error_messages=PasswordMixin.error_msg,


### PR DESCRIPTION
This just adds a frontend format check with HTML5 form validation.

![email-format mov](https://cloud.githubusercontent.com/assets/211578/12901783/1f5a67d6-ce83-11e5-9c20-80547d70ab7b.gif)

Fixes #1637.