### PR TITLE
Prompt for username/display name and make anonymous usernames less anonymous

### DIFF
--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -368,6 +368,9 @@ class UserProfile(OnChangeMixin, ModelBase,
     def has_anonymous_username(self):
         return re.match('^anonymous-[0-9a-f]{32}$', self.username)
 
+    def has_anonymous_display_name(self):
+        return not self.display_name and self.has_anonymous_username()
+
     @amo.cached_property
     def reviews(self):
         """All reviews that are not dev replies."""

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -350,11 +350,18 @@ class UserProfile(OnChangeMixin, ModelBase,
         if self.display_name:
             return smart_unicode(self.display_name)
         elif self.has_anonymous_username():
-            return _('Anonymous')
+            # L10n: {id} will be something like "13ad6a", just a random number
+            # to differentiate this user from other anonymous users.
+            return _('Anonymous user {id}').format(
+                id=self._anonymous_username_id())
         else:
             return smart_unicode(self.username)
 
     welcome_name = name
+
+    def _anonymous_username_id(self):
+        if self.has_anonymous_username():
+            return self.username.split('-')[1][:6]
 
     def anonymize_username(self):
         """Set an anonymous username."""

--- a/src/olympia/users/templates/users/edit.html
+++ b/src/olympia/users/templates/users/edit.html
@@ -15,9 +15,15 @@ data-default-locale="{{ request.LANG|lower }}"
 {% block content %}
 {% include 'users/includes/navigation.html' %}
 <div id="user_edit" class="primary prettyform grid" role="main">
+  {% if switch_is_active('fxa-auth') and user.has_anonymous_display_name() %}
+    <div class="notification-box error anonymous">
+      <h2>{{ _('Please set your display name') }}</h2>
+      <p>{{ _('Please set your display name or username to complete the registration process.') }}</p>
+    </div>
+  {% endif %}
   <form method="post" class="user-input island"
         enctype="multipart/form-data">
-    {% set is_fxa_user = switch_is_active('fxa-auth') and user.source == 'fxa' %}
+    {% set is_fxa_user = switch_is_active('fxa-auth') and user.fxa_migrated() %}
     {{ csrf() }}
     <div id="user-edit" class="tab-wrapper">
       <div id="user-account" class="tab-panel">

--- a/src/olympia/users/tests/test_models.py
+++ b/src/olympia/users/tests/test_models.py
@@ -67,9 +67,9 @@ class TestUserProfile(TestCase):
         eq_(u3.welcome_name, '')
 
     def test_welcome_name_anonymous(self):
-        user = UserProfile()
-        user.anonymize_username()
-        assert user.welcome_name == 'Anonymous'
+        user = UserProfile(
+            username='anonymous-bb4f3cbd422e504080e32f2d9bbfcee0')
+        assert user.welcome_name == 'Anonymous user bb4f3c'
 
     def test_welcome_name_anonymous_with_display(self):
         user = UserProfile(display_name='John Connor')

--- a/src/olympia/users/tests/test_models.py
+++ b/src/olympia/users/tests/test_models.py
@@ -72,9 +72,45 @@ class TestUserProfile(TestCase):
         assert user.welcome_name == 'Anonymous'
 
     def test_welcome_name_anonymous_with_display(self):
-        user = UserProfile(
-            username='anonymous-foo', display_name='John Connor')
+        user = UserProfile(display_name='John Connor')
+        user.anonymize_username()
         assert user.welcome_name == 'John Connor'
+
+    def test_has_anonymous_username_no_names(self):
+        user = UserProfile(display_name=None)
+        user.anonymize_username()
+        assert user.has_anonymous_username()
+
+    def test_has_anonymous_username_username_set(self):
+        user = UserProfile(username='bob', display_name=None)
+        assert not user.has_anonymous_username()
+
+    def test_has_anonymous_username_display_name_set(self):
+        user = UserProfile(display_name='Bob Bobbertson')
+        user.anonymize_username()
+        assert user.has_anonymous_username()
+
+    def test_has_anonymous_username_both_names_set(self):
+        user = UserProfile(username='bob', display_name='Bob Bobbertson')
+        assert not user.has_anonymous_username()
+
+    def test_has_anonymous_display_name_no_names(self):
+        user = UserProfile(display_name=None)
+        user.anonymize_username()
+        assert user.has_anonymous_display_name()
+
+    def test_has_anonymous_display_name_username_set(self):
+        user = UserProfile(username='bob', display_name=None)
+        assert not user.has_anonymous_display_name()
+
+    def test_has_anonymous_display_name_display_name_set(self):
+        user = UserProfile(display_name='Bob Bobbertson')
+        user.anonymize_username()
+        assert not user.has_anonymous_display_name()
+
+    def test_has_anonymous_display_name_both_names_set(self):
+        user = UserProfile(username='bob', display_name='Bob Bobbertson')
+        assert not user.has_anonymous_display_name()
 
     def test_add_admin_powers(self):
         u = UserProfile.objects.get(username='jbalogh')

--- a/static/css/impala/users.less
+++ b/static/css/impala/users.less
@@ -360,3 +360,9 @@ img.icon {
         width: 100px;
     }
 }
+
+.notification-box.anonymous {
+    p {
+        margin-bottom: 0;
+    }
+}


### PR DESCRIPTION
This adds a prompt to the register page if the user doesn't have their username or display name set. It doesn't force them to do anything but it hopefully will get them to set it.

This also updates the anonymous usernames to be like `Anonymous user 17d1fc` rather than just `Anonymous`.

![anonyless mov](https://cloud.githubusercontent.com/assets/211578/12925285/38b7e9ec-cf23-11e5-93b5-7bcc604a561f.gif)

Fixes #1518.