### PR TITLE
Prevent Firefox Accounts users from changing their email (fixes #1612)

### DIFF
--- a/src/olympia/users/templates/users/edit.html
+++ b/src/olympia/users/templates/users/edit.html
@@ -17,7 +17,7 @@ data-default-locale="{{ request.LANG|lower }}"
 <div id="user_edit" class="primary prettyform grid" role="main">
   <form method="post" class="user-input island"
         enctype="multipart/form-data">
-    {% set is_fxa_user = switch_is_active('fxa-auth') and user.source == 'fxa' %}
+    {% set is_fxa_user = switch_is_active('fxa-auth') and user.fxa_migrated() %}
     {{ csrf() }}
     <div id="user-edit" class="tab-wrapper">
       <div id="user-account" class="tab-panel">
@@ -35,8 +35,14 @@ data-default-locale="{{ request.LANG|lower }}"
               {{ form.username.errors }}
             </li>
             <li{% if form.email.errors %} class="error"{% endif %}>
-              <label for="id_email">{{ _('Email Address') }} {{ required() }}</label>
+              <label for="id_email">
+                {{ _('Email Address') }}
+                {% if not is_fxa_user %}{{ required() }}{% endif %}
+              </label>
               {{ form.email }}
+              {% if form.email.help_text %}
+                <small class="note">{{ form.email.help_text }}</small>
+              {% endif %}
               {{ form.email.errors }}
             </li>
             <li>

--- a/static/css/impala/forms.less
+++ b/static/css/impala/forms.less
@@ -439,3 +439,11 @@ button.loading-submit:after {
         padding: 0;
     }
 }
+
+.prettyform {
+    input[readonly],
+    input[disabled] {
+        box-shadow: none;
+        background: #eee;
+    }
+}


### PR DESCRIPTION
This is based off of #1656. It disabled the email field when the user has migrated to FxA.

<img width="763" alt="screenshot 2016-02-10 11 45 38" src="https://cloud.githubusercontent.com/assets/211578/12956098/d7214948-cfeb-11e5-8531-a19845b1f5b3.png">

Fixes #1612.