### PR TITLE
Fix locale path in amo monitor

### DIFF
--- a/src/olympia/amo/monitors.py
+++ b/src/olympia/amo/monitors.py
@@ -116,7 +116,7 @@ def path():
           user_media_path('userpics'),
           user_media_path('reviewer_attachments'),
           dump_apps.Command.JSON_PATH,)
-    r = [os.path.join(settings.ROOT, 'src', 'olympia', 'locale'),
+    r = [os.path.join(settings.ROOT, 'locale'),
          # The deploy process will want write access to this.
          # We do not want Django to have write access though.
          settings.PROD_DETAILS_DIR]


### PR DESCRIPTION
Currently failing path check: https://addons.allizom.org/services/monitor

r?