### PR TITLE
Minimize chord_unlock retries in validator

### DIFF
--- a/src/olympia/devhub/tasks.py
+++ b/src/olympia/devhub/tasks.py
@@ -53,7 +53,10 @@ def validate(file_, listed=None, subtask=None):
         chain = annotator.task
         if subtask is not None:
             chain |= subtask
-        result = chain.delay()
+        # TODO: once we have a fix for chord_unlock errors (redis result
+        # backend?) then we can remove the retries maybe.
+        # See https://github.com/mozilla/addons-server/issues/1653
+        result = chain.apply_async(max_retries=1)
         cache.set(annotator.cache_key, result.task_id, 5 * 60)
         return result
 

--- a/src/olympia/devhub/tests/test_utils.py
+++ b/src/olympia/devhub/tests/test_utils.py
@@ -649,16 +649,16 @@ class TestValidationAnnotatorListed(TestValidationAnnotatorBase):
         """Tests that only a single validation task is run for a given file."""
         task = mock.Mock()
         chain.return_value = task
-        task.delay.return_value = mock.Mock(task_id='42')
+        task.apply_async.return_value = mock.Mock(task_id='42')
 
         assert isinstance(tasks.validate(self.file), mock.Mock)
-        assert task.delay.call_count == 1
+        assert task.apply_async.call_count == 1
 
         assert isinstance(tasks.validate(self.file), AsyncResult)
-        assert task.delay.call_count == 1
+        assert task.apply_async.call_count == 1
 
         assert isinstance(tasks.validate(self.file_1_1), mock.Mock)
-        assert task.delay.call_count == 2
+        assert task.apply_async.call_count == 2
 
     @mock.patch('olympia.devhub.utils.chain')
     def test_run_once_file_upload(self, chain):
@@ -666,13 +666,13 @@ class TestValidationAnnotatorListed(TestValidationAnnotatorBase):
         upload."""
         task = mock.Mock()
         chain.return_value = task
-        task.delay.return_value = mock.Mock(task_id='42')
+        task.apply_async.return_value = mock.Mock(task_id='42')
 
         assert isinstance(tasks.validate(self.file_upload), mock.Mock)
-        assert task.delay.call_count == 1
+        assert task.apply_async.call_count == 1
 
         assert isinstance(tasks.validate(self.file_upload), AsyncResult)
-        assert task.delay.call_count == 1
+        assert task.apply_async.call_count == 1
 
     def test_cache_key(self):
         """Tests that the correct cache key is generated for a given object."""


### PR DESCRIPTION
Attempts to mitigate https://github.com/mozilla/addons-server/issues/1653