### PR TITLE
Unlock the magic of chord_unlock (fix: routing)

### DIFF
--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1048,7 +1048,10 @@ CELERY_ROUTES = {
     'olympia.devhub.tasks.validate_file_path': {'queue': 'devhub'},
 
     # This is currently used only by validation tasks.
-    'olympia.celery.chord_unlock': {'queue': 'devhub'},
+    # This puts the chord_unlock task on the devhub queue. Which means anything
+    # that uses chord() or group() must also be running in this queue or must
+    # be on a worker that listens to the same queue.
+    'celery.chord_unlock': {'queue': 'devhub'},
     'olympia.devhub.tasks.compatibility_check': {'queue': 'devhub'},
 
     # Videos.


### PR DESCRIPTION
This regressed in the module refactor. We need the chord_unlock task to be in the same queue as other tasks that use it.

Another attempt at fixing https://github.com/mozilla/addons-server/issues/1653