### PR TITLE
Restore default retry settings for chord_unlock

### DIFF
--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1180,16 +1180,6 @@ CELERY_ROUTES = {
 }
 
 
-# TODO: once we have a fix for chord_unlock errors (redis result
-# backend?) then we can remove the retries maybe.
-# See https://github.com/mozilla/addons-server/issues/1653
-CELERY_ANNOTATIONS = {
-    'celery.chord_unlock': {
-        'max_retries': 3,
-    }
-}
-
-
 # This is just a place to store these values, you apply them in your
 # task decorator, for example:
 #   @task(time_limit=CELERY_TIME_LIMITS['lib...']['hard'])


### PR DESCRIPTION
Addresses https://github.com/mozilla/addons-server/issues/1653 yet again.

TLDR; @EnTeQuAk was right :) We changed too many things at once. This puts AMO back to the state it was in before the module refactor, when we knew validation was working.

I think I misunderstood how `chord_unlock` works. When a chorded/grouped task starts, I guess `chord_unlock` runs in the background repeatedly until the task finishes. What we were seeing was that a validation longer than three seconds would cause "too many retries" and the task would hang.

The real fix was https://github.com/mozilla/addons-server/pull/1677 !