### PR TITLE
Add BROKER_HEARTBEAT to settings

### DIFF
--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1004,6 +1004,7 @@ VALIDATION_FAQ_URL = ('https://wiki.mozilla.org/AMO:Editors/EditorGuide/'
 BROKER_URL = os.environ.get('BROKER_URL',
                             'amqp://olympia:olympia@localhost:5672/olympia')
 BROKER_CONNECTION_TIMEOUT = 0.1
+BROKER_HEARTBEAT = 60 * 15
 CELERY_DEFAULT_QUEUE = 'default'
 CELERY_RESULT_BACKEND = 'amqp'
 CELERY_IGNORE_RESULT = True


### PR DESCRIPTION
We see connection issues to rabbitmq especially when our services have been idle for a long time, specifically on -dev and stage. This cause cause strange issues with validation, which is known as hangs/pauses.

Setting BROKER_HEARTBEAT should help with that.

http://docs.celeryproject.org/en/latest/configuration.html#broker-heartbeat

r?