### PR TITLE
Fix persona long text causing button mis-alignment

### DIFF
--- a/static/css/zamboni/zamboni.css
+++ b/static/css/zamboni/zamboni.css
@@ -1082,18 +1082,19 @@ ul.license li.copyr { background-position: 0 -260px; }
 .persona-hover .persona-inner {
     background: #c8e8f2;
 }
+.persona-preview > a,
+.persona-preview > div {
+    position: relative;
+}
 .persona-install {
     border: 0.25em solid #C8E8F2;
     bottom: -3px;
     display: none;
-    left: 0;
+    left: -3px;
     position: absolute;
 }
 .addons-column .persona-install {
     left: -3px;
-}
-.with-details .persona-install {
-    bottom: 53px;
 }
 .persona-preview:hover .incompat-browser {
     display: block;


### PR DESCRIPTION
Fixes #1703

The fix positions the button absolutely within a relative container.

Before:

<img alt="up___coming_themes____add-ons_for_firefox" src="https://cloud.githubusercontent.com/assets/1514/13153684/3452a6a2-d66d-11e5-8582-c4c593254964.png">

After:

<img alt="up___coming_themes____add-ons_for_firefox" src="https://cloud.githubusercontent.com/assets/1514/13153716/5ab11284-d66d-11e5-8fd9-974dc82636bd.png">

