### PR TITLE
Rename addons-validator to addons-linter and update to latest release.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,4 +85,4 @@ ENV CLEANCSS_BIN /srv/olympia-node/node_modules/clean-css/bin/cleancss
 ENV LESS_BIN /srv/olympia-node/node_modules/less/bin/lessc
 ENV STYLUS_BIN /srv/olympia-node/node_modules/stylus/bin/stylus
 ENV UGLIFY_BIN /srv/olympia-node/node_modules/uglify-js/bin/uglifyjs
-ENV VALIDATOR_BIN /srv/olympia-node/node_modules/addons-validator/bin/addons-validator
+ENV ADDONS_LINTER_BIN /srv/olympia-node/node_modules/addons-linter/bin/addons-linter

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "less": "1.3.x",
     "stylus": "0.32.x",
     "uglify-js": "2.4.x",
-    "addons-validator": "0.0.8"
+    "addons-linter": "0.0.13"
   }
 }

--- a/settings.py
+++ b/settings.py
@@ -60,9 +60,9 @@ CLEANCSS_BIN = os.getenv(
 UGLIFY_BIN = os.getenv(
     'UGLIFY_BIN',
     path('node_modules/uglify-js/bin/uglifyjs'))
-VALIDATOR_BIN = os.getenv(
-    'VALIDATOR_BIN',
-    path('node_modules/addons-validator/bin/addons-validator'))
+ADDONS_LINTER_BIN = os.getenv(
+    'ADDONS_LINTER_BIN',
+    path('node_modules/addons-linter/bin/addons-linter'))
 
 # Locally we typically don't run more than 1 elasticsearch node. So we set
 # replicas to zero.


### PR DESCRIPTION
In preparation for #882 

Fixes #1742