### PR TITLE
Add add-on url to rejection emails

### DIFF
--- a/src/olympia/editors/helpers.py
+++ b/src/olympia/editors/helpers.py
@@ -639,14 +639,13 @@ class ReviewBase(object):
                   emails, Context(data), perm_setting='editor_reviewed')
 
     def get_context_data(self):
-        if self.addon.is_listed:
-            url = self.addon.get_url_path(add_prefix=False)
-        else:
-            url = self.addon.get_dev_url('versions')
+        addon_url = self.addon.get_url_path(add_prefix=False)
+        dev_ver_url = self.addon.get_dev_url('versions')
         return {'name': self.addon.name,
                 'number': self.version.version,
                 'reviewer': self.user.display_name,
-                'addon_url': absolutify(url),
+                'addon_url': absolutify(addon_url),
+                'dev_versions_url': absolutify(dev_ver_url),
                 'review_url': absolutify(reverse('editors.review',
                                                  args=[self.addon.pk],
                                                  add_prefix=False)),

--- a/src/olympia/editors/templates/editors/emails/nominated_to_public.ltxt
+++ b/src/olympia/editors/templates/editors/emails/nominated_to_public.ltxt
@@ -1,5 +1,5 @@
 {% extends "editors/emails/base.ltxt" %}{% block content %}
-Your add-on, {{ name }} {{ number }}, has been fully reviewed and is now available for download in our gallery at {{ addon_url}}
+Your add-on, {{ name }} {{ number }}, has been fully reviewed and is now available for download in our gallery at {{ addon_url }}
 {% include "editors/emails/files.ltxt" %}
 Reviewer:
 {{ reviewer }}

--- a/src/olympia/editors/templates/editors/emails/nominated_to_sandbox.ltxt
+++ b/src/olympia/editors/templates/editors/emails/nominated_to_sandbox.ltxt
@@ -9,5 +9,5 @@ Comments:
 
 {{ tested }}
 
-This version of your add-on has been disabled. You may re-request review by addressing the reviewer's comments and uploading a new version.
+This version of your add-on has been disabled. You may re-request review by addressing the reviewer's comments and uploading a new version at {{ dev_versions_url }}
 {% endblock %}

--- a/src/olympia/editors/templates/editors/emails/pending_to_sandbox.ltxt
+++ b/src/olympia/editors/templates/editors/emails/pending_to_sandbox.ltxt
@@ -9,5 +9,5 @@ Comments:
 
 {{ tested }}
 
-This version of your {{ addon_type }} has been disabled. You may re-request review by addressing the reviewer's comments and uploading a new version.
+This version of your {{ addon_type }} has been disabled. You may re-request review by addressing the reviewer's comments and uploading a new version at {{ dev_versions_url }}
 {% endblock %}

--- a/src/olympia/editors/templates/editors/emails/preliminary_to_sandbox.ltxt
+++ b/src/olympia/editors/templates/editors/emails/preliminary_to_sandbox.ltxt
@@ -9,5 +9,5 @@ Comments:
 
 {{ tested }}
 
-This version of your add-on has been disabled. You may re-request review by addressing the reviewer's comments and uploading a new version.
+This version of your add-on has been disabled. You may re-request review by addressing the reviewer's comments and uploading a new version at {{ dev_versions_url }}
 {% endblock %}

--- a/src/olympia/editors/templates/editors/emails/unlisted_to_reviewed.ltxt
+++ b/src/olympia/editors/templates/editors/emails/unlisted_to_reviewed.ltxt
@@ -1,5 +1,5 @@
 {% extends "editors/emails/base.ltxt" %}{% block content %}
-Your add-on, {{ name }} {{ number }}, has been reviewed and is now signed and ready for you to download at {{ addon_url }}.
+Your add-on, {{ name }} {{ number }}, has been reviewed and is now signed and ready for you to download at {{ dev_versions_url }}
 {% include "editors/emails/files.ltxt" %}
 Reviewer:
 {{ reviewer }}

--- a/src/olympia/editors/templates/editors/emails/unlisted_to_reviewed_auto.ltxt
+++ b/src/olympia/editors/templates/editors/emails/unlisted_to_reviewed_auto.ltxt
@@ -1,5 +1,5 @@
 {% extends "editors/emails/base.ltxt" %}{% block content %}
-Your add-on, {{ name }} {{ number }}, has passed our automatic tests and is now signed and ready for you to download at {{ addon_url }}.
+Your add-on, {{ name }} {{ number }}, has passed our automatic tests and is now signed and ready for you to download at {{ dev_versions_url }}
 {% include "editors/emails/files.ltxt" %}
 Reviewer:
 {{ reviewer }}

--- a/src/olympia/editors/templates/editors/emails/unlisted_to_sandbox.ltxt
+++ b/src/olympia/editors/templates/editors/emails/unlisted_to_sandbox.ltxt
@@ -1,5 +1,6 @@
 {% extends "editors/emails/base.ltxt" %}{% block content %}
 Your add-on, {{ name }} {{ number }}, didn't pass review and therefore won't be signed.
+To view the status of your add-on, visit {{ dev_versions_url }}
 {% include "editors/emails/files.ltxt" %}
 Reviewer:
 {{ reviewer }}

--- a/src/olympia/editors/tests/test_helpers.py
+++ b/src/olympia/editors/tests/test_helpers.py
@@ -341,6 +341,33 @@ class TestReviewHelper(TestCase):
             eq_(len(mail.outbox), 1)
             assert mail.outbox[0].body, 'Expected a message'
 
+    def test_email_links(self):
+        expected = {
+            'nominated_to_nominated': 'addon_url',
+            'nominated_to_preliminary': 'addon_url',
+            'nominated_to_public': 'addon_url',
+            'nominated_to_sandbox': 'dev_versions_url',
+
+            'pending_to_preliminary': 'addon_url',
+            'pending_to_public': 'addon_url',
+            'pending_to_sandbox': 'dev_versions_url',
+
+            'preliminary_to_preliminary': 'addon_url',
+
+            'unlisted_to_reviewed': 'dev_versions_url',
+            'unlisted_to_reviewed_auto': 'dev_versions_url',
+            'unlisted_to_sandbox': 'dev_versions_url'
+        }
+
+        self.helper.set_data(self.get_data())
+        context_data = self.helper.handler.get_context_data()
+        for template, context_key in expected.iteritems():
+            mail.outbox = []
+            self.helper.handler.notify_email(template, 'Sample subject %s, %s')
+            eq_(len(mail.outbox), 1)
+            assert context_key in context_data
+            assert context_data.get(context_key) in mail.outbox[0].body
+
     def setup_data(self, status, delete=[], is_listed=True):
         mail.outbox = []
         ActivityLog.objects.for_addons(self.helper.addon).delete()


### PR DESCRIPTION
When reading emails on amo-editors that relate to a rejected add-on I didn't personally review, I either have to guess the review link, google the add-on name, or for unlisted add-ons use mxr to find the add-on.

It would be much easier for me rejection/needinfo/approval emails sent to the developer would include the link to the add-on. From there I can easily get to the review page using the AMO Admin Assistant.

I'm open to other places for the url, I could put it into a new sentence under where it is now, e.g.
 `To view the status of your add-on, visit https://addons.mozilla.org/en-US/developers/addon/xxxx/`

r? @jvillalobos 