### PR TITLE
Allow get_redis_settings to be imported with star-import.

### DIFF
--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -123,10 +123,10 @@ LOGGING['loggers'].update({
 })
 
 REDIS_BACKENDS = {
-    'cache': _get_redis_settings(env('REDIS_BACKENDS_CACHE')),
-    'cache_slave': _get_redis_settings(env('REDIS_BACKENDS_CACHE_SLAVE')),
-    'master': _get_redis_settings(env('REDIS_BACKENDS_MASTER')),
-    'slave': _get_redis_settings(env('REDIS_BACKENDS_SLAVE'))
+    'cache': get_redis_settings(env('REDIS_BACKENDS_CACHE')),
+    'cache_slave': get_redis_settings(env('REDIS_BACKENDS_CACHE_SLAVE')),
+    'master': get_redis_settings(env('REDIS_BACKENDS_MASTER')),
+    'slave': get_redis_settings(env('REDIS_BACKENDS_SLAVE'))
 }
 
 CACHE_MACHINE_USE_REDIS = True

--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -115,10 +115,10 @@ LOGGING['loggers'].update({
 })
 
 REDIS_BACKENDS = {
-    'cache': _get_redis_settings(env('REDIS_BACKENDS_CACHE')),
-    'cache_slave': _get_redis_settings(env('REDIS_BACKENDS_CACHE_SLAVE')),
-    'master': _get_redis_settings(env('REDIS_BACKENDS_MASTER')),
-    'slave': _get_redis_settings(env('REDIS_BACKENDS_SLAVE'))
+    'cache': get_redis_settings(env('REDIS_BACKENDS_CACHE')),
+    'cache_slave': get_redis_settings(env('REDIS_BACKENDS_CACHE_SLAVE')),
+    'master': get_redis_settings(env('REDIS_BACKENDS_MASTER')),
+    'slave': get_redis_settings(env('REDIS_BACKENDS_SLAVE'))
 }
 
 CACHE_MACHINE_USE_REDIS = True

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -117,10 +117,10 @@ LOGGING['loggers'].update({
 })
 
 REDIS_BACKENDS = {
-    'cache': _get_redis_settings(env('REDIS_BACKENDS_CACHE')),
-    'cache_slave': _get_redis_settings(env('REDIS_BACKENDS_CACHE_SLAVE')),
-    'master': _get_redis_settings(env('REDIS_BACKENDS_MASTER')),
-    'slave': _get_redis_settings(env('REDIS_BACKENDS_SLAVE'))
+    'cache': get_redis_settings(env('REDIS_BACKENDS_CACHE')),
+    'cache_slave': get_redis_settings(env('REDIS_BACKENDS_CACHE_SLAVE')),
+    'master': get_redis_settings(env('REDIS_BACKENDS_MASTER')),
+    'slave': get_redis_settings(env('REDIS_BACKENDS_SLAVE'))
 }
 
 CACHE_MACHINE_USE_REDIS = True

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1392,7 +1392,7 @@ REDIS_LOCATION = os.environ.get(
     'REDIS_LOCATION', 'redis://localhost:6379/0?socket_timeout=0.5')
 
 
-def _get_redis_settings(uri):
+def get_redis_settings(uri):
     import urlparse
     urlparse.uses_netloc.append('redis')
 
@@ -1413,7 +1413,7 @@ def _get_redis_settings(uri):
 
 
 REDIS_BACKENDS = {
-    'master': _get_redis_settings(REDIS_LOCATION)
+    'master': get_redis_settings(REDIS_LOCATION)
 }
 
 # Full path or executable path (relative to $PATH) of the spidermonkey js


### PR DESCRIPTION
With a star-import all names will be imported except those that
start with an underscore.