### PR TITLE
Fix various escaping errors.

### DIFF
--- a/src/olympia/addons/templates/addons/persona_preview.html
+++ b/src/olympia/addons/templates/addons/persona_preview.html
@@ -25,7 +25,7 @@
             {# L10n: {0} is the number of users. #}
             {{ ngettext("<strong>{0}</strong> user",
                         "<strong>{0}</strong> users",
-                        addon.persona.popularity)|f(addon.persona.popularity|numberfmt)|safe }}
+                        addon.persona.popularity)|fe(addon.persona.popularity|numberfmt) }}
           </span>
         {% elif extra == 'rating' %}
           {# TODO(jbalogh): call this rating when remora is gone. #}
@@ -64,7 +64,7 @@
           <p>
             {# L10n: For datetime formatting, see the table on http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior #}
             {% set dt = _('%%Y-%%m-%%d') %}
-            {{ _('by {0} on {1}')|f(users_list(addon.listed_authors)|safe or persona.display_username|safe,
+            {{ _('by {0} on {1}')|fe(users_list(addon.listed_authors)|safe or persona.display_username|safe,
                                     addon.created|datetime(dt)) }}
           </p>
           {% if addon.total_reviews %}
@@ -75,7 +75,7 @@
             <span>{{ _('Not yet rated') }}</span>
           {% endif %}
           <span class="users">
-            {{ _('<b>{0}</b> users')|f(addon.persona.popularity|numberfmt) }}
+            {{ _('<b>{0}</b> users')|fe(addon.persona.popularity|numberfmt) }}
           </span>
         </div>
       {% endif %}

--- a/src/olympia/amo/tests/test_helpers.py
+++ b/src/olympia/amo/tests/test_helpers.py
@@ -93,6 +93,60 @@ def test_page_title_markup():
     assert res == 'It&#39;s all text :: Add-ons for Firefox'
 
 
+def test_template_escaping():
+    """Test that tests various formatting scenarios we're using in our
+    templates and makes sure they're working as expected.
+    """
+    # Simple HTML in a translatable string
+    expected = '<a href="...">This is a test</a>'
+    assert render('{{ _(\'<a href="...">This is a test</a>\') }}') == expected
+
+    # Simple HTML in a translatable string, with |fe works as expected
+    expected = '<a href="...">This is a test</a>'
+    original = '{{ _(\'<a href="...">{0}</a>\')|fe(\'This is a test\') }}'
+    assert render(original) == expected
+
+    # |f does not mark the resulting string as "safe" thus autoescaping
+    # set's in
+    expected = '&lt;a href=&#34;...&#34;&gt;This is a test&lt;/a&gt;'
+    original = '{{ _(\'<a href="...">{0}</a>\')|f(\'This is a test\') }}'
+    assert render(original) == expected
+
+    # if an explicit |safe before |f is applied the output is still unsafe
+    # and will be autoescaped. Use |fe for that.
+    expected = '&lt;a href=&#34;...&#34;&gt;This is a test&lt;/a&gt;'
+    original = '{{ _(\'<a href="...">{0}</a>\')|safe|f(\'This is a test\') }}'
+    assert render(original) == expected
+
+    # |safe after the |f marks the whole formatted string as safe though
+    # and autoescaping won't be applied anymore.
+    # Please note that this does not escape the arguments of |f!
+    expected = '<a href="...">This is a test</a>'
+    original = '{{ _(\'<a href="...">{0}</a>\')|f(\'This is a test\')|safe }}'
+    assert render(original) == expected
+
+    # Various tests for gettext related helpers and make sure they work
+    # properly just as `_()` does.
+    expected = '<b>5 users</b>'
+    assert render(
+        '{{ ngettext(\'<b>{0} user</b>\', \'<b>{0} users</b>\', 2)|fe(5) }}'
+    ) == expected
+
+    # You could also mark the whole output as |safe but note that this
+    # does not escape the arguments of |f!
+    expected = '<b>5 users</b>'
+    assert render(
+        '{{ ngettext(\'<b>{0} user</b>\', \'<b>{0} users</b>\', 2)'
+        '|f(5)|safe }}'
+    ) == expected
+
+    # and now only with |f it get's escaped again
+    expected = '&lt;b&gt;5 users&lt;/b&gt;'
+    assert render(
+        '{{ ngettext(\'<b>{0} user</b>\', \'<b>{0} users</b>\', 2)|f(5) }}'
+    ) == expected
+
+
 class TestBreadcrumbs(amo.tests.BaseTestCase):
 
     def setUp(self):

--- a/src/olympia/browse/templates/browse/search_tools.html
+++ b/src/olympia/browse/templates/browse/search_tools.html
@@ -37,7 +37,7 @@
     {% endif %}
       {% with cnt=addons.paginator.count %}
         <h3>{{ ngettext('<b>{0}</b> add-on', '<b>{0}</b> add-ons', cnt)
-                |f(cnt|numberfmt)|safe }}</h3>
+                |fe(cnt|numberfmt) }}</h3>
       {% endwith %}
       </hgroup>
   </header>
@@ -90,7 +90,7 @@
     <h3>{{ _('Additional Resources') }}</h3>
     <ul class="xoxo">
       {# L10n: {0} is an app name, like Firefox. #}
-      <li>{{ _('Learn more about the <a href="http://support.mozilla.com/kb/Search+bar">search bar</a> in {0}')|f(APP.pretty) }}</li>
+      <li>{{ _('Learn more about the <a href="http://support.mozilla.com/kb/Search+bar">search bar</a> in {0}')|fe(APP.pretty) }}</li>
       <li>{{ _('Browse through even more search providers at <a href="http://mycroft.mozdev.org/">mycroft.mozdev.org</a>') }}</li>
       <li>{{ _('<a href="https://developer.mozilla.org/en/Creating_OpenSearch_plugins_for_Firefox">Make your own</a> search tool') }}</li>
     </ul>

--- a/src/olympia/devhub/templates/devhub/addons/dashboard.html
+++ b/src/olympia/devhub/templates/devhub/addons/dashboard.html
@@ -14,7 +14,7 @@
       {% if addon_tab %}
         {% set cnt = addons.paginator.count %}
         {# L10n: {0} is an integer. #}
-        <h2 class="submission-count">{{ ngettext('<b>{0}</b> add-on', '<b>{0}</b> add-ons', cnt)|f(cnt|numberfmt)|safe }}</h2>
+        <h2 class="submission-count">{{ ngettext('<b>{0}</b> add-on', '<b>{0}</b> add-ons', cnt)|fe(cnt|numberfmt) }}</h2>
       {% endif %}
     </header>
   </section>
@@ -73,7 +73,7 @@
   <section class="dashboard primary theme-dashboard">
     {% set cnt = themes.paginator.count %}
     <h2 class="submission-count">
-      {{ ngettext('<b>{0}</b> theme', '<b>{0}</b> themes', cnt)|f(cnt|numberfmt)|safe }}
+      {{ ngettext('<b>{0}</b> theme', '<b>{0}</b> themes', cnt)|fe(cnt|numberfmt) }}
     </h2>
     {% include "addons/includes/dashboard_tabs.html" %}
     <div class="listing island hero c">

--- a/src/olympia/devhub/templates/devhub/agreement.html
+++ b/src/olympia/devhub/templates/devhub/agreement.html
@@ -18,7 +18,7 @@
     <button id="accept-agreement" type="submit">
       {{ _('I Accept this Agreement') }}
     </button>
-  {{ _('or <a href="{0}">Cancel</a>')|f(url('devhub.index')) }}
+  {{ _('or <a href="{0}">Cancel</a>')|fe(url('devhub.index')) }}
   </form>
 </div>
 

--- a/src/olympia/devhub/templates/devhub/includes/macros.html
+++ b/src/olympia/devhub/templates/devhub/includes/macros.html
@@ -69,7 +69,7 @@
                {1} is the application name. #}
       {{ ngettext('Select <b>up to {0}</b> {1} category for this add-on:',
                   'Select <b>up to {0}</b> {1} categories for this add-on:',
-                  max)|f(max, form.app.pretty if form.app else '')|safe }}
+                  max)|fe(max, form.app.pretty if form.app else '') }}
     </label>
     {{ form.application }}
     {{ form.categories }}

--- a/src/olympia/editors/templates/editors/includes/reviewers_score_bar.html
+++ b/src/olympia/editors/templates/editors/includes/reviewers_score_bar.html
@@ -52,7 +52,7 @@
 
     <h3>{{ _('All Time') }}</h3>
     {# L10n: {0} is a number, like "480". #}
-    <p class="total">{{ _('You have <span>{0}</span> points.')|f(total|numberfmt) }}</p>
+    <p class="total">{{ _('You have <span>{0}</span> points.')|fe(total|numberfmt) }}</p>
     <p><a href="{{ url('editors.leaderboard') }}">{{ _('Reviewer Leaderboard') }}</a></p>
 
   </li>

--- a/src/olympia/reviews/templates/reviews/review_list.html
+++ b/src/olympia/reviews/templates/reviews/review_list.html
@@ -26,7 +26,7 @@
           {# L10n: {0} is a number. #}
           <h3>{{ ngettext('<b>{0}</b> review for this add-on',
                           '<b>{0}</b> reviews for this add-on',
-                          num)|f(num|numberfmt)|safe }}</h3>
+                          num)|fe(num|numberfmt) }}</h3>
         {% endwith %}
       {% elif reply %}
         {# L10n: {0} is a developer's name. #}

--- a/src/olympia/reviews/templates/reviews/reviews_link.html
+++ b/src/olympia/reviews/templates/reviews/reviews_link.html
@@ -12,7 +12,7 @@
     {% if num %}
     {{ addon.average_rating|float|stars }}
     <a href="{{ base }}">
-      {% with count='<span itemprop="count">{0}</span>'|f(num|numberfmt) %}
+      {% with count='<span itemprop="count">{0}</span>'|fe(num|numberfmt) %}
         {# Using num=count so we don't change an L10n string. #}
         <strong>{{ ngettext('{num} review', '{num} reviews',
                             num)|f(num=count)|safe }}</strong></a>

--- a/src/olympia/search/templates/search/mobile/results.html
+++ b/src/olympia/search/templates/search/mobile/results.html
@@ -17,7 +17,7 @@
 {% block contentclass %}search{% endblock %}
 
 {% block page %}
-  <h2>{{ _('Search Results <i>({num})</i>')|f(num=pager.paginator.count) }}</h2>
+  <h2>{{ _('Search Results <i>({num})</i>')|fe(num=pager.paginator.count) }}</h2>
 
   <div class="menu">
     {% with query = query.q %}

--- a/src/olympia/search/templates/search/results.html
+++ b/src/olympia/search/templates/search/results.html
@@ -55,7 +55,7 @@
   <p class="cnt">
     {{ ngettext('<b>{0}</b> matching result',
                 '<b>{0}</b> matching results',
-                cnt)|f(cnt|numberfmt)|safe }}
+                cnt)|fe(cnt|numberfmt) }}
   </p>
 {% endmacro %}
 

--- a/src/olympia/stats/templates/stats/reports/overview.html
+++ b/src/olympia/stats/templates/stats/reports/overview.html
@@ -5,11 +5,11 @@
 {% block stats %}
     <section class="island two-up">
       <div>
-        <a href="downloads/">{{ _('<b>{0}</b> Downloads')|f(addon.total_downloads|numberfmt) }}</a>
+        <a href="downloads/">{{ _('<b>{0}</b> Downloads')|fe(addon.total_downloads|numberfmt) }}</a>
         <small id="downloads-in-range">{{ _('Loading...') }}</small>
       </div>
       <div>
-        <a href="usage/">{{ _('<b>{0}</b> Average Daily Users')|f(addon.average_daily_users|numberfmt) }}</a>
+        <a href="usage/">{{ _('<b>{0}</b> Average Daily Users')|fe(addon.average_daily_users|numberfmt) }}</a>
         <small id="users-in-range">{{ _('Loading...') }}</small>
       </div>
     </section>

--- a/src/olympia/versions/templates/versions/version_list.html
+++ b/src/olympia/versions/templates/versions/version_list.html
@@ -26,7 +26,7 @@
       <h1>{{ _('{0} Version History')|fe(addon.name) }}</h1>
       {% with cnt=versions.paginator.count %}
         {# L10n: {0} is a number. #}
-        <h3>{{ ngettext('<b>{0}</b> version', '<b>{0}</b> versions', cnt)|f(cnt)|safe }}</h3>
+        <h3>{{ ngettext('<b>{0}</b> version', '<b>{0}</b> versions', cnt)|fe(cnt) }}</h3>
       {% endwith %}
     </hgroup>
   </header>


### PR DESCRIPTION
We need to mark safe strings as safe now that we have autoescaping
activated for Jinja2 templates.

Fixes #1775, #1774, #1773, #1767, #1764, #1783