### PR TITLE
Add no-cache backend for product-details.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,10 @@ docs/api/_build
 src/olympia/lib/product_json/.gitignore
 src/olympia/lib/product_json/*.json
 src/olympia/lib/product_json/.last_update
+src/olympia/lib/product_json/*.json.last_modified
 src/olympia/lib/product_json/regions/*.json
 src/olympia/lib/product_json/regions/.last_update
+src/olympia/lib/product_json/regions/*.json.last_modified
 build*.py
 web/media/build_id.txt
 web/media/manifest.appcache

--- a/src/olympia/lib/product_details_backend.py
+++ b/src/olympia/lib/product_details_backend.py
@@ -1,0 +1,22 @@
+import json
+
+from product_details.storage import PDFileStorage
+
+
+class NoCachePDFileStorage(PDFileStorage):
+
+    def data(self, name):
+        """Return the parsed JSON data of the requested file name.
+
+        Doesn't use the django-cache.
+        """
+        content = self.content(name)
+        data = None
+
+        if content:
+            try:
+                data = json.loads(content)
+            except ValueError:
+                return None
+
+        return data

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -142,6 +142,7 @@ def lazy_langs(languages):
 # Where product details are stored see django-mozilla-product-details
 PROD_DETAILS_DIR = path('src', 'olympia', 'lib', 'product_json')
 PROD_DETAILS_URL = 'https://svn.mozilla.org/libs/product-details/json/'
+PROD_DETAILS_STORAGE = 'olympia.lib.product_details_backend.NoCachePDFileStorage'  # noqa
 
 # Override Django's built-in with our native names
 LANGUAGES = lazy(lazy_langs, dict)(AMO_LANGUAGES)

--- a/src/olympia/lib/tests/test_product_details_backend.py
+++ b/src/olympia/lib/tests/test_product_details_backend.py
@@ -1,0 +1,27 @@
+import json
+from tempfile import mkdtemp
+
+from mock import patch
+
+from olympia.lib.product_details_backend import NoCachePDFileStorage
+
+
+class TestNoCachePDFileStorage(object):
+    storage = NoCachePDFileStorage(json_dir=mkdtemp())
+
+    def setup(self):
+        self.storage.clear_cache()
+
+    def test_no_cache(self):
+        good_data = {'dude': 'abiding'}
+        with patch.object(self.storage, 'content',
+                          return_value=json.dumps(good_data)) as content_mock:
+
+            assert self.storage.data('test.json') == good_data
+            content_mock.assert_called_once_with('test.json')
+
+        # make sure nothing was put in the django-cache
+        cache_key = self.storage._get_cache_key('test.json')
+        data = self.storage._cache.get(cache_key)
+
+        assert data is None


### PR DESCRIPTION
This avoids hitting the cache for product details and uses the old behaviour of 0.7.x times.

r? @diox @jasonthomas 