### PR TITLE
Bypass contrib on mobile

### DIFF
--- a/src/olympia/addons/buttons.py
+++ b/src/olympia/addons/buttons.py
@@ -68,7 +68,7 @@ def big_install_button(context, addon, **kwargs):
 def mobile_install_button(context, addon, **kwargs):
     from olympia.addons.helpers import statusflags
     button = install_button(context, addon, detailed=True, size='prominent',
-                            mobile=True, **kwargs)
+                            mobile=True, show_contrib=False, **kwargs)
     flags = jinja2.escape(statusflags(context, addon))
     markup = u'<div class="install-wrapper %s">%s</div>' % (flags, button)
     return jinja2.Markup(markup)

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -307,7 +307,8 @@ class Addon(OnChangeMixin, ModelBase):
     annoying = models.PositiveIntegerField(
         choices=amo.CONTRIB_CHOICES, default=0,
         help_text=_(u'Users will always be asked in the Add-ons'
-                    u' Manager (Firefox 4 and above)'))
+                    u' Manager (Firefox 4 and above).'
+                    u' Only applies to desktop.'))
     enable_thankyou = models.BooleanField(
         default=False, help_text='Should the thank you note be sent to '
                                  'contributors?')


### PR DESCRIPTION
Fixes #1785 

Since we don't have any UI for contributions this patch ensures contrib features are not used by the buttons in the mobile view as used in FF Android.