### PR TITLE
Lay the groundwork for configuring addons-linter on dev, stage and prod.

### DIFF
--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -170,6 +170,7 @@ REDIRECT_URL = 'https://outgoing.allizom.org/v1/'
 
 CLEANCSS_BIN = 'cleancss'
 UGLIFY_BIN = 'uglifyjs'
+ADDONS_LINTER_BIN = 'addons-linter'
 
 LESS_PREPROCESS = True
 

--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -159,6 +159,7 @@ NEW_FEATURES = True
 
 CLEANCSS_BIN = 'cleancss'
 UGLIFY_BIN = 'uglifyjs'
+ADDONS_LINTER_BIN = 'addons-linter'
 
 LESS_PREPROCESS = True
 

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -164,6 +164,7 @@ REDIRECT_URL = 'https://outgoing.allizom.org/v1/'
 
 CLEANCSS_BIN = 'cleancss'
 UGLIFY_BIN = 'uglifyjs'
+ADDONS_LINTER_BIN = 'addons-linter'
 
 LESS_PREPROCESS = True
 


### PR DESCRIPTION
@jasonthomas can you make sure that these are correct and work?

`addons-linter` will be installed as a npm package, I blondly assumed that the installed node_modules binaries will be added to `PATH` but if that's not the case just let me know.