### PR TITLE
Don't nest matched validation messages

### DIFF
--- a/src/olympia/devhub/utils.py
+++ b/src/olympia/devhub/utils.py
@@ -408,7 +408,9 @@ class ValidationComparator(object):
             severity = msg.get('signing_severity')
             prev_msg = self.find_matching_message(msg)
             if prev_msg:
-                msg['matched'] = prev_msg
+                msg['matched'] = prev_msg.copy()
+                if 'matched' in msg['matched']:
+                    del msg['matched']['matched']
                 if severity:
                     msg['ignored'] = self.is_ignorable(prev_msg)
 


### PR DESCRIPTION
This deletes the first nested matched message when attaching it so that it only ever goes one level deep.

To reproduce the bug without this patch:

1. Upload an unlisted add-on with errors.
2. Bump the version of the add-on and upload it again.
3. Delete the version from step 1 (to ensure it matches with the newer version's validation with the nesting).
4. Repeat n times.

Each time you go through this process it adds another level of nesting.

Fixes #1851.