### PR TITLE
Drop need-info after sources upload

### DIFF
--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -580,6 +580,31 @@ class TestVersionEditDetails(TestVersionEditBase):
         assert version.source
         assert not version.addon.admin_review
 
+    def test_update_source_file_should_drop_info_request_flag(self):
+        version = Version.objects.get(pk=self.version.pk)
+        version.has_info_request = True
+        version.save()
+        tdir = temp.gettempdir()
+        tmp_file = temp.NamedTemporaryFile
+        with tmp_file(suffix=".zip", dir=tdir) as source_file:
+            source_file.write('a' * (2 ** 21))
+            source_file.seek(0)
+            data = self.formset(source=source_file)
+            response = self.client.post(self.url, data)
+        version = Version.objects.get(pk=self.version.pk)
+        assert response.status_code == 302
+        assert not version.has_info_request
+
+    def test_update_approvalnotes_should_drop_info_request_flag(self):
+        version = Version.objects.get(pk=self.version.pk)
+        version.has_info_request = True
+        version.save()
+        data = self.formset(approvalnotes="New notes.")
+        response = self.client.post(self.url, data)
+        version = Version.objects.get(pk=self.version.pk)
+        assert response.status_code == 302
+        assert not version.has_info_request
+
 
 class TestVersionEditSearchEngine(TestVersionEditMixin,
                                   amo.tests.BaseTestCase):

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -1147,6 +1147,12 @@ def version_edit(request, addon_id, addon, version_id):
                 if (isinstance(form, forms.CompatForm) and
                         'max' in form.changed_data):
                     _log_max_version_change(addon, version, form.instance)
+
+        fields = ('source', 'approvalnotes')
+        has_changed = [field in version_form.changed_data for field in fields]
+        if version.has_info_request and any(has_changed):
+            version.update(has_info_request=False)
+            version.save()
         messages.success(request, _('Changes successfully saved.'))
         return redirect('devhub.versions.edit', addon.slug, version_id)
 


### PR DESCRIPTION
We send a need-info request if code sources or instructions to reproduce the minification/obfuscation are missing. Once the developer provides the missing information (approval notes or sources) we should drop the need-info flag.

@EnTeQuAk r?