### PR TITLE
Don't accept API uploads for deleted add-ons

### DIFF
--- a/src/olympia/signing/tests/test_views.py
+++ b/src/olympia/signing/tests/test_views.py
@@ -132,6 +132,15 @@ class TestUploadVersion(BaseUploadVersionCase):
         assert response.status_code == 200
         assert 'processed' in response.data
 
+    @mock.patch('olympia.devhub.views.Version.from_upload')
+    def test_addon_was_deleted(self, from_upload):
+        addon = Addon.unfiltered.get(guid=self.guid)
+        addon.delete()
+        response = self.put(self.url(self.guid, '3.0'))
+        assert response.status_code == 400
+        assert 'error' in response.data
+        assert response.data['error'] == 'That add-on has been deleted.'
+
     @mock.patch('olympia.devhub.views.auto_sign_version')
     def test_version_added(self, sign_version):
         assert Addon.objects.get(guid=self.guid).status == amo.STATUS_PUBLIC

--- a/src/olympia/signing/views.py
+++ b/src/olympia/signing/views.py
@@ -46,6 +46,10 @@ def with_addon(allow_missing=False):
         def inner(view, request, guid=None, **kwargs):
             try:
                 addon = Addon.unfiltered.get(guid=guid)
+                if addon.is_deleted:
+                    return Response(
+                        {'error': _('That add-on has been deleted.')},
+                        status=status.HTTP_400_BAD_REQUEST)
             except Addon.DoesNotExist:
                 if allow_missing:
                     addon = None


### PR DESCRIPTION
Check that an add-on is deleted and return an error if it has been.

Fixes mozilla/addons#62