### PR TITLE
Don't send an action to FxA to let them guess

### DIFF
--- a/static/js/common/fxa-login.js
+++ b/static/js/common/fxa-login.js
@@ -35,7 +35,6 @@ function enableFxALogin() {
     function fxaLogin(opts) {
         opts = opts || {};
         var authConfig = {
-            action:  'signin',
             client_id: config.clientId,
             email: opts.email || config.email,
             state: config.state + ':' + urlsafe(btoa(nextPath())),


### PR DESCRIPTION
FxA should redirect the user to sign in or sign up based on whether or not the account exists, but they only do that if we don't tell them what to do.