### PR TITLE
Fix height of sidebar links (fix #1936)

### DIFF
--- a/static/css/restyle.less
+++ b/static/css/restyle.less
@@ -580,6 +580,15 @@ button.search-button {
   margin-top: 0;
 }
 
+.toplist li a {
+  line-height: 1.5;
+  padding: .25em 0;
+
+  small {
+    margin-top: -3px;
+  }
+}
+
 // Side nav elsewhere (themes)
 .secondary .highlight {
   padding: 0;


### PR DESCRIPTION
Fix the line-height and spacing in the right-hand side links so letters with hangers don't get cut off.

### Before

<img width="185" alt="screenshot 2016-03-17 17 27 21" src="https://cloud.githubusercontent.com/assets/90871/13858545/6fd9d2b8-ec7f-11e5-9f4f-5bd191be5876.png">

### After

<img width="191" alt="screenshot 2016-03-17 20 40 31" src="https://cloud.githubusercontent.com/assets/90871/13864954/5c14595c-eca6-11e5-9885-ebeccbbdbb11.png">

r?