### PR TITLE
Add Buildtime Trend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,3 +31,6 @@ notifications:
       - "irc.mozilla.org#amo-bots"
     on_success: change
     on_failure: always
+  webhooks:
+        # trigger Buildtime Trend Service to parse Travis CI log
+        - https://buildtimetrend.herokuapp.com/travis

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,10 @@
 .. image:: https://travis-ci.org/mozilla/addons-server.svg?branch=master
     :target: https://travis-ci.org/mozilla/addons-server
 
+.. image:: https://buildtimetrend.herokuapp.com/badge/mozilla/addons-server/latest
+    :alt: Buildtime Trend badge
+    :target: https://buildtimetrend.herokuapp.com/dashboard/mozilla/addons-server
+
 .. image:: https://requires.io/github/mozilla/addons-server/requirements.svg?branch=master
     :target: https://requires.io/github/mozilla/addons-server/requirements/?branch=master
 


### PR DESCRIPTION
Nice visualizations about build times, even more useful after #1930 landed.

Example: http://buildtimetrend.herokuapp.com/dashboard/wagnerand/addons-server/index.html

What do you think?