### PR TITLE
Restore header alignment with carousel enabled (fix #1866)

### DIFF
--- a/static/css/restyle.less
+++ b/static/css/restyle.less
@@ -374,7 +374,6 @@ button.search-button {
   display: block !important;
   height: auto !important;
   margin-left: -210px;
-  margin-bottom: 15px;
   min-height: 0 !important;
   opacity: 1 !important;
   visibility: visible !important;
@@ -396,8 +395,8 @@ button.search-button {
   box-shadow: none;
 }
 
-.primary.island {
-  border-top: solid 1px @primary-blue;
+.restyle .primary .island {
+  padding-top: 0;
 }
 
 #promos .promo-purple {
@@ -622,8 +621,8 @@ button.good {
   margin-top: 0;
 }
 
-.shift-secondary {
-  margin-top: 290px !important;
+.restyle.home .shift-secondary {
+  margin-top: 300px;
 }
 
 .home .secondary {


### PR DESCRIPTION
Tweak the headers so they're all aligned and farther from the header.

### Before

![add-ons_for_firefox](https://cloud.githubusercontent.com/assets/1514/13638098/a25b3958-e602-11e5-91c7-cd08f90bfdff.png)

### After

<img width="1324" alt="screenshot 2016-03-21 12 30 17" src="https://cloud.githubusercontent.com/assets/90871/13918666/b301e006-ef60-11e5-9f19-3eb2cb4d4cda.png">