### PR TITLE
Remove harsh borders from details (fix #1871)

### DIFF
--- a/static/css/restyle.less
+++ b/static/css/restyle.less
@@ -5,6 +5,9 @@
 @link-on-white-bg: #0996F8;
 @link-on-color-bg: #fff;
 
+// Common styles
+@detail-border: 1px solid #ebebeb;
+
 // Fonts
 @font-face {
   font-family: 'Open Sans';
@@ -395,8 +398,22 @@ button.search-button {
   box-shadow: none;
 }
 
-.restyle .primary .island {
-  padding-top: 0;
+.restyle .primary.island {
+  border-top: @detail-border;
+}
+
+.island > section {
+  border-bottom: @detail-border;
+}
+
+#reviews .review,
+#detail-relnotes .items {
+  border: 0;
+}
+
+#reviews a.more-info,
+#detail-relnotes a.more-info {
+  float: none;
 }
 
 #promos .promo-purple {


### PR DESCRIPTION
Remove the borders from the details page; there were tonnes of different kinds and I didn't think they were adding much. Feel free to tell me if I'm wrong ^_^

### Before

![copy_plain_text_2____add-ons_for_firefox](https://cloud.githubusercontent.com/assets/1514/13639051/d43db096-e606-11e5-9ba3-c9af72e2efb6.png)

### After

![screen shot 2016-03-21 at 15 22 34](https://cloud.githubusercontent.com/assets/90871/13923504/d097aea8-ef78-11e5-88e3-d6be085b9a01.png)

r? @muffinresearch @designakt 