### PR TITLE
use changedTouches instead of touches

### DIFF
--- a/static/js/common/ratingwidget.js
+++ b/static/js/common/ratingwidget.js
@@ -50,7 +50,7 @@ $.fn.ratingwidget = function(classes) {
         }).bind('touchmove touchend', function(e) {
             var wid = $widget.width();
             var left = $widget.offset().left;
-            var r = (e.originalEvent.touches[0].clientX - left) / wid * 5 + 1;
+            var r = (e.originalEvent.changedTouches[0].clientX - left) / wid * 5 + 1;
             r = ~~Math.min(Math.max(r,1),5);
             setStars(r);
         });


### PR DESCRIPTION
Fixes #1935 

touches list was empty causing an error.

`orginalEvent.touches`: https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/changedTouches
`originalEvent.changedTouches`: https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/changedTouches