### PR TITLE
Avoid double encoding urlparam by unquoting them first.

### DIFF
--- a/src/olympia/amo/tests/test_helpers.py
+++ b/src/olympia/amo/tests/test_helpers.py
@@ -278,6 +278,14 @@ def test_urlparams_unicode():
     utils.urlparams(url)
 
 
+def test_urlparams_returns_safe_string():
+    s = render('{{ "https://foo.com/"|urlparams(param="help+me") }}', {})
+    assert s == 'https://foo.com/?param=help%2Bme'
+
+    s = render('{{ "https://foo.com/"|urlparams(param="help%2Bme") }}', {})
+    assert s == 'https://foo.com/?param=help%2Bme'
+
+
 def test_isotime():
     time = datetime(2009, 12, 25, 10, 11, 12)
     s = render('{{ d|isotime }}', {'d': time})

--- a/src/olympia/amo/tests/test_views.py
+++ b/src/olympia/amo/tests/test_views.py
@@ -336,7 +336,7 @@ class TestOtherStuff(TestCase):
         r = test.Client().get(u'/ar/firefox/?q=འ')
         doc = pq(r.content)
         link = doc('.account.anonymous a')[1].attrib['href']
-        assert link.endswith('?to=%2Far%2Ffirefox%2F%3Fq%3D%25E0%25BD%25A0')
+        assert link.endswith('?to=%2Far%2Ffirefox%2F%3Fq%3D%E0%BD%A0')
 
 
 @mock.patch('olympia.amo.views.log_cef')

--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -34,7 +34,7 @@ from django.template import Context, loader
 from django.utils import translation
 from django.utils.encoding import smart_str, smart_unicode
 from django.utils.functional import Promise
-from django.utils.http import urlquote
+from django.utils.http import urlquote, urlunquote
 
 import bleach
 import html5lib
@@ -80,7 +80,7 @@ def urlparams(url_, hash=None, **query):
     query_dict = dict(urlparse.parse_qsl(smart_str(q))) if q else {}
     query_dict.update((k, v) for k, v in query.items())
 
-    query_string = urlencode([(k, v) for k, v in query_dict.items()
+    query_string = urlencode([(k, urlunquote(v)) for k, v in query_dict.items()
                              if v is not None])
     new = urlparse.ParseResult(url.scheme, url.netloc, url.path, url.params,
                                query_string, fragment)


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/73