### PR TITLE
Improve the "add-on is not available" style

### DIFF
--- a/src/olympia/addons/templates/addons/impala/button.html
+++ b/src/olympia/addons/templates/addons/impala/button.html
@@ -11,24 +11,24 @@
       {{ _('No compatible versions') }}
     {% endif %}
     {% if settings.ADD_TO_MOBILE %}
-    {% if APP == amo.MOBILE %}
-      {% if request.user.is_authenticated() %}
-        {% set action = url('collections.alter', request.user.username, 'mobile', 'add') %}
+      {% if APP == amo.MOBILE %}
+        {% if request.user.is_authenticated() %}
+          {% set action = url('collections.alter', request.user.username, 'mobile', 'add') %}
+        {% endif %}
+        {% if installed %}
+          {% set extra, text = 'status ok', _('Added to Mobile') %}
+        {% else %}
+          {% set text = _('Add to Mobile') %}
+        {% endif %}
+        <form method="post" action="{{ action }}">
+          {{ csrf() }}
+          <input type="hidden" name="addon_id" value="{{ addon.id }}">
+          <button class="button mobile {{ extra }} {{ b.button_class|join(' ') }}">
+            <b></b>
+            <span>{{ text }}</span>
+          </button>
+        </form>
       {% endif %}
-      {% if installed %}
-        {% set extra, text = 'status ok', _('Added to Mobile') %}
-      {% else %}
-        {% set text = _('Add to Mobile') %}
-      {% endif %}
-      <form method="post" action="{{ action }}">
-        {{ csrf() }}
-        <input type="hidden" name="addon_id" value="{{ addon.id }}">
-        <button class="button mobile {{ extra }} {{ b.button_class|join(' ') }}">
-          <b></b>
-          <span>{{ text }}</span>
-        </button>
-    </form>
-    {% endif %}
     {% endif %}
     {% for link in links %}
       {% set extra = "platform " + link.os.shortname if link.os else "" %}

--- a/static/css/restyle.less
+++ b/static/css/restyle.less
@@ -1192,3 +1192,19 @@ button.good {
 .manage-button {
   margin: 1em 0 0;
 }
+
+// Install buttons
+.install-button .concealed {
+  display: none !important;
+}
+
+.extra .button.not-available {
+  background: #fbfbfb url(../img/impala/no.png) 6px 50% no-repeat;
+  border: 1px solid #b1b1b1;
+  border-radius: 3px;
+  box-shadow: 0 2px 0 0 rgba(0, 0, 0, 0.1),
+              inset 0 -2px 0 0 rgba(30, 30, 30, 0.25);
+  color: #b1b1b1;
+  font-size: 14px;
+  padding-left: 20px;
+}

--- a/static/js/zamboni/buttons.js
+++ b/static/js/zamboni/buttons.js
@@ -17,6 +17,13 @@ var notavail = '<div class="extra"><span class="notavail">{0}</span></div>',
     noappsupport = '<div class="extra"><span class="notsupported">{0}</span></div>',
     download_re = new RegExp('(/downloads/(?:latest|file)/\\d+)');
 
+// Restyle is enabled; we're going to modify the text.
+if ($('body').hasClass('restyle')) {
+    notavail = '<div class="extra"><button class="button not-available" disabled>{0}</button></div>';
+    incompat = '<div class="extra"><button class="button not-available" disabled>{0}</button></div>';
+    noappsupport = '<div class="extra"><button class="button not-available" disabled>{0}</button></div>';
+}
+
 // The lowest maxVersion an app has to support to allow default-to-compatible.
 var D2C_MAX_VERSIONS = {
     firefox: '4.0',


### PR DESCRIPTION
Close https://github.com/mozilla/addons.mozilla.org-mod/issues/24

r? @pwalm for the look, r? @muffinresearch for the code; I had to dig around in the `buttons.js` inline JS templating to get this working sanely :unamused: 

### Before

![screen shot 2015-12-18 at 17 28 21](https://cloud.githubusercontent.com/assets/8145891/11901610/c25dd936-a5ac-11e5-8531-405ea092f6b8.png)

### After

<img width="570" alt="screenshot 2016-03-23 08 49 55" src="https://cloud.githubusercontent.com/assets/90871/13980130/b48a5ab4-f0d4-11e5-90b5-1c1a5be08fc4.png">