### PR TITLE
Give manage button breathing room (fix #1875)

### DIFF
--- a/src/olympia/addons/templates/addons/impala/details.html
+++ b/src/olympia/addons/templates/addons/impala/details.html
@@ -81,7 +81,7 @@
     {{ sharing_widget(addon) }}
   </div>
   {% if is_author %}
-    <p><a href="{{ addon.get_dev_url() }}" class="button developer prominent"><span>{{ _('Manage') }}</span></a></p>
+    <p class="manage-button"><a href="{{ addon.get_dev_url() }}" class="button developer prominent"><span>{{ _('Manage') }}</span></a></p>
   {% endif %}
   </aside>
 

--- a/static/css/restyle.less
+++ b/static/css/restyle.less
@@ -1131,3 +1131,7 @@ button.good {
   height: auto;
   width: auto;
 }
+
+.manage-button {
+  margin: 1em 0 0;
+}


### PR DESCRIPTION
I edited the template as otherwise the selector was _really_ generic (`.widgets + p`), which I didn't like.

### Before

![fireftp____add-ons_for_firefox](https://cloud.githubusercontent.com/assets/1514/13639432/9f5be62a-e608-11e5-86cb-3bd93648a34d.png)

### After

<img width="1324" alt="screenshot 2016-03-23 09 05 29" src="https://cloud.githubusercontent.com/assets/90871/13980596/6f70b1d2-f0d7-11e5-841b-024d797cc2e2.png">

r?