### PR TITLE
Improve header link contrast (fix #1870)

### DIFF
--- a/static/css/restyle.less
+++ b/static/css/restyle.less
@@ -903,14 +903,12 @@ button.good {
     color: @link-on-color-bg;
   }
 
-  .version-number,
-  h4.author,
+  h4.author a,
   a.privacy-policy,
   #contribution.notice p a,
-  .category.more-info,
   .vital a,
   #reviews-link {
-    opacity: 0.4;
+    text-decoration: underline;
   }
 
   .version-number {


### PR DESCRIPTION
Turns out these all had their opacity cranked way down; I upped it from `0.4` to 0.8` then added underlines to links on the left, but not to the version or # of reviews links.

### Before

![copy_plain_text_2____add-ons_for_firefox](https://cloud.githubusercontent.com/assets/1514/13638995/a08a5074-e606-11e5-8812-68dff44491de.png)

### After

<img width="964" alt="screenshot 2016-03-26 17 32 30" src="https://cloud.githubusercontent.com/assets/90871/14061480/dd4fdcfc-f378-11e5-8535-22feb631ee10.png">