### PR TITLE
Extend blue background to entire height of header

### DIFF
--- a/static/css/restyle.less
+++ b/static/css/restyle.less
@@ -148,7 +148,7 @@ button.link:active span {
       to bottom,
       rgba(12, 153, 213, 0) 0,
       @primary-blue 500px,
-      #fff 0%
+      @primary-blue 0%
     ),
     repeating-linear-gradient(
       118deg,


### PR DESCRIPTION
Fix #1874
Fix #2004
Fix #2006

This fixes multiple issues with the text in the header being invisible
(white-on-white). The gradient was ending in #fff, but this wasn't needed
and in fact makes text invisible. This fixes that!

### Before

<img width="1086" alt="screenshot 2016-03-28 15 43 16" src="https://cloud.githubusercontent.com/assets/74699/14092479/fa4204e6-f4fb-11e5-8077-32d6259a01c9.png">
<img width="833" alt="screenshot 2016-03-28 15 44 47" src="https://cloud.githubusercontent.com/assets/74699/14092485/0460bfe4-f4fc-11e5-9a6e-4557b7d8c7e1.png">
![unspecified](https://cloud.githubusercontent.com/assets/90871/14115316/5495afb6-f5d2-11e5-852b-1ca903b14abd.png)

### After

<img width="1324" alt="screenshot 2016-03-29 17 12 25" src="https://cloud.githubusercontent.com/assets/90871/14115323/5c9f0d92-f5d2-11e5-9b21-1aaca2e4b48b.png">
<img width="1324" alt="screenshot 2016-03-29 17 12 06" src="https://cloud.githubusercontent.com/assets/90871/14115322/5c9ebebe-f5d2-11e5-8d3d-9259a0de7d1c.png">