### PR TITLE
Fix purple promo style in carousel (fix #2002)

### DIFF
--- a/static/css/restyle.less
+++ b/static/css/restyle.less
@@ -482,7 +482,23 @@ button.search-button {
 }
 
 #promos .promo-purple {
-  background: none;
+  h2,
+  h3,
+  a,
+  p.desc {
+    color: @link-on-color-bg;
+    text-align: left;
+    text-shadow: none;
+  }
+
+  h2,
+  p.desc {
+    color: #000;
+  }
+}
+
+.promo h2 {
+  margin-top: 0;
 }
 
 .featured li {


### PR DESCRIPTION
Turns out the background was being disabled, possibly because the purple stands out a fair bit with the new design. But enabling it and tweaking the font colours does a decent job in terms of preserving the original vibe and keeping it readable. The promos have a lot of custom CSS and it can be hard to test them locally, so QA: feel free to test these rigorously on stage :smile: 

### Before

![screenshot 2016-03-28 14 45 55](https://cloud.githubusercontent.com/assets/90871/14091358/b6d84f80-f537-11e5-8878-424d826f7652.png)

### After

<img width="1360" alt="screenshot 2016-03-30 11 19 10" src="https://cloud.githubusercontent.com/assets/90871/14139236/b4b9c1b0-f669-11e5-943b-97b0cae7923e.png">