### PR TITLE
Fix theme hover effect breaking with two rows (fix #2029)

### DIFF
--- a/static/css/restyle.less
+++ b/static/css/restyle.less
@@ -1174,6 +1174,7 @@ button.good {
 .personas-featured .persona-list-3col {
   border: 0;
   min-height: 125px;
+  padding-bottom: 10px;
 }
 
 .persona-list-3col {
@@ -1183,10 +1184,14 @@ button.good {
     overflow: hidden;
     padding: 0.6em 0 0;
     position: relative;
+
+    &:nth-of-type(3n) .persona.hovercard:hover {
+      margin-bottom: -3px;
+    }
   }
 
   .persona.hovercard {
-    margin-right: 14px;
+    margin-right: 29px;
     width: 32%;
 
     a {


### PR DESCRIPTION
Fixes the weird hover effect in #2029.

Fixed version here: http://gfycat.com/UglyMarriedGraywolf