### PR TITLE
Fix submit new theme button in other langs (fix #2059)

### DIFF
--- a/static/css/restyle.less
+++ b/static/css/restyle.less
@@ -1369,3 +1369,12 @@ button.good {
     }
   }
 }
+
+
+.secondary .submit-theme {
+  padding: 0;
+
+  a.button {
+    white-space: normal;
+  }
+}


### PR DESCRIPTION
Oops, I thought this was a blocker and didn't realise until too late it wasn't.

### Before

![2016-03-30_1638_001](https://cloud.githubusercontent.com/assets/15685960/14144264/a7167750-f697-11e5-8e11-d5579bc527d0.png)

### After

<img width="1360" alt="screenshot 2016-03-30 15 25 43" src="https://cloud.githubusercontent.com/assets/90871/14145594/5692e008-f68c-11e5-8352-996d06a2c5c4.png">
<img width="1360" alt="screenshot 2016-03-30 15 25 39" src="https://cloud.githubusercontent.com/assets/90871/14145595/56952ef8-f68c-11e5-8b5b-4074ee2088fb.png">

We can merge it for later; no rush.