### PR TITLE
Fix author link on contrib

### DIFF
--- a/static/css/restyle.less
+++ b/static/css/restyle.less
@@ -869,9 +869,6 @@ button.good {
   margin-top: -5px;
 }
 
-// Re-colors links on top of details page to white
-#addon a,
-.author a,
 .addon-vitals .widgets .widget {
   color: #fff;
 }
@@ -973,6 +970,20 @@ button.good {
 // make hovercard hide discription and always show "add to firefox"
 .addon-details .primary .notice.dependencies {
   height: 130px;
+}
+
+// Standard pages have the default
+// text color. This is overridden for details
+// pages below.
+h3.author a,
+h4.author a {
+  color: @default-font-color;
+  text-decoration: underline;
+}
+
+h3.author .transfer-ownership {
+  color: @link-on-color-bg;
+  text-decoration: none;
 }
 
 // font issues on addon-details


### PR DESCRIPTION
Fixes #2061

Before:

<img alt="meet_the_personas_plus_developer____add-ons_for_firefox" src="https://cloud.githubusercontent.com/assets/1514/14146770/bb227480-f690-11e5-9d3e-6a3bc6efc5f3.png">

After:

<img alt="meet_the_personas_plus_developer____add-ons_for_firefox" src="https://cloud.githubusercontent.com/assets/1514/14146762/b56a7c2c-f690-11e5-9490-ec6c1faa3b38.png">

And for the theme edit page:



Before:

<img  alt="edit_listing____whatever____add-ons_for_firefox" src="https://cloud.githubusercontent.com/assets/1514/14147395/2e8e9ce4-f693-11e5-889a-b19b04e1b7e2.png">


After:

<img alt="edit_listing____whatever____add-ons_for_firefox" src="https://cloud.githubusercontent.com/assets/1514/14147383/1ff7c412-f693-11e5-8984-635890b1799c.png">
