### PR TITLE
Restore "complete themes" to menu (fix #2052)

### DIFF
--- a/src/olympia/amo/templates/amo/site_nav.html
+++ b/src/olympia/amo/templates/amo/site_nav.html
@@ -39,7 +39,6 @@
             <li><a href="{{ cat.get_url_path() }}">{{ cat.name }}</a></li>
           {% endfor %}
         </ul>
-        {% if not waffle.flag('restyle') %}
         <div>
           <a class="complete-themes" href="{{ url('browse.themes') }}">
             {% trans %}
@@ -47,7 +46,6 @@
             {% endtrans %}
           </a>
         </div>
-        {% endif %}
       {% endif %}
     </li>
 

--- a/static/css/restyle.less
+++ b/static/css/restyle.less
@@ -392,13 +392,16 @@ body:not(.home) .amo-header {
 }
 
 #site-nav #themes ul.two-col {
-  height: 270px;
+  height: 293px;
   padding: 8px;
 
   div {
     display: none;
+  }
+
+  + div {
     left: -1px;
-    top: 314px;
+    top: 305px
   }
 }
 


### PR DESCRIPTION
Note the themes menu item now has a link to the "complete themes" section.

cc @jvillalobos 

<img width="1360" alt="screenshot 2016-03-30 16 11 50" src="https://cloud.githubusercontent.com/assets/90871/14147236/7bd1bfd2-f692-11e5-8d40-97983fec32d8.png">
