### PR TITLE
Restore other app icons (close #2043)

### DIFF
--- a/src/olympia/templates/impala/header_title.html
+++ b/src/olympia/templates/impala/header_title.html
@@ -1,7 +1,7 @@
 <h1 class="site-title">
 {% macro heading(app, text, icon) -%}
 <a href="{{ url('home') }}" title="{{ _('Return to the {0} Add-ons homepage')|f(request.APP.pretty) }}">
-  {% if waffle.flag ('restyle') %}
+  {% if waffle.flag ('restyle') and request.APP == amo.FIREFOX %}
   <img alt="" src="{{ static('img/icons/firefox.png')|safe }}">
   {% else %}
   <img alt="{{ APP.pretty }}" src="{{ static('img/app-icons/med/' + icon + '.png')|safe }}">


### PR DESCRIPTION
Fixes the waffle condition that made all icons Firefox.

<img width="597" alt="screenshot 2016-03-30 16 25 39" src="https://cloud.githubusercontent.com/assets/90871/14147602/1116a124-f694-11e5-9374-476fb6b32b1c.png">
<img width="542" alt="screenshot 2016-03-30 16 25 32" src="https://cloud.githubusercontent.com/assets/90871/14147608/12fd7db4-f694-11e5-9426-769c2d15367c.png">
<img width="556" alt="screenshot 2016-03-30 16 25 24" src="https://cloud.githubusercontent.com/assets/90871/14147606/12cdfb84-f694-11e5-8e65-0d6b0cebb698.png">

Waffle flag kept because it has a nicer (higher quality) version of the Firefox logo.