### PR TITLE
Fix underline and layout for contrib install button

### DIFF
--- a/static/css/restyle.less
+++ b/static/css/restyle.less
@@ -1370,6 +1370,19 @@ h3.author .transfer-ownership {
 // Contribute button fixes
 .notice.author .aux {
   text-align: right;
+
+  #contribute-button {
+    text-decoration: none;
+  }
+
+  .install-button {
+    margin-right: 0;
+
+    .add {
+      margin-top: 5px;
+      text-decoration: none;
+    }
+  }
 }
 
 .notice.c.author {


### PR DESCRIPTION
Fixes #2060
Fixes #2065


Before:

<img alt="meet_the_personas_plus_developer____add-ons_for_firefox" src="https://cloud.githubusercontent.com/assets/1514/14148494/94a3968e-f697-11e5-9c61-454a9b41c08e.png">

After:

<img alt="meet_the_personas_plus_developer____add-ons_for_firefox" src="https://cloud.githubusercontent.com/assets/1514/14148504/a297eeac-f697-11e5-93bf-af258703aa38.png">



