### PR TITLE
Restore download CTA for Chrome (#2056)

### DIFF
--- a/static/css/restyle.less
+++ b/static/css/restyle.less
@@ -1354,6 +1354,10 @@ h3.author .transfer-ownership {
   // This is display: none !important because JS modifies the element's
   // CSS directly.
   display: none !important;
+
+  &.CTA {
+    display: block !important;
+  }
 }
 
 .extra .button.not-available {


### PR DESCRIPTION
Fixes #2056 

Fixed screenshot:

![screenshot 2016-03-30 16 56 25](https://cloud.githubusercontent.com/assets/90871/14148690/6a94ce20-f698-11e5-8066-ed8670e90718.png)

This button has JS modifications so I'm using `!important`, but it's the only way to get this working. I'm ashamed.