### PR TITLE
Prevent notification box from crowding text to bottom (fix #2050)

### DIFF
--- a/static/js/impala/addon_details.js
+++ b/static/js/impala/addon_details.js
@@ -1,9 +1,10 @@
 $(function () {
     if (!$("body").hasClass('addon-details')) return;
 
-    if($("body.restyle").length === 1) {
+    if ($("body.restyle").length === 1) {
         $('#background-wrapper').height(
             $('.amo-header').height() +
+            ($('.notification-box').length ? 80 : 0) +
             $('#addon-description-header').height() + 20
         );
     }


### PR DESCRIPTION
Because of how the background is rendered this was the best way to fix this issue.

<img width="1001" alt="screenshot 2016-03-30 17 17 08" src="https://cloud.githubusercontent.com/assets/90871/14149260/3fe8fde2-f69b-11e5-9c9c-853c391b9795.png">