### PR TITLE
Isolate JWT Auth mechanism with API Keys

### DIFF
--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -15,7 +15,7 @@ from olympia.accounts import verify, views
 from olympia.amo.helpers import absolutify, urlparams
 from olympia.amo.tests import (
     assert_url_equal, create_switch, InitializeSessionMixin, TestCase)
-from olympia.api.tests.utils import APIAuthTestCase
+from olympia.api.tests.utils import APIKeyAuthTestCase
 from olympia.users.models import UserProfile
 
 FXA_CONFIG = {'some': 'stuff', 'that is': 'needed'}
@@ -724,7 +724,7 @@ class TestAuthenticateView(BaseAuthenticationView):
         assert not self.register_user.called
 
 
-class TestProfileView(APIAuthTestCase):
+class TestProfileView(APIKeyAuthTestCase):
 
     def setUp(self):
         self.create_api_user()
@@ -779,7 +779,7 @@ class TestAccountSourceView(APITestCase):
         assert response.data == {'error': 'Email is required.'}
 
 
-class TestAccountSuperCreate(APIAuthTestCase):
+class TestAccountSuperCreate(APIKeyAuthTestCase):
 
     def setUp(self):
         super(TestAccountSuperCreate, self).setUp()

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -22,7 +22,7 @@ from waffle.decorators import waffle_switch
 from olympia.access.models import GroupUser
 from olympia.amo import messages
 from olympia.amo.utils import urlparams
-from olympia.api.jwt_auth.views import JWTProtectedView
+from olympia.api.jwt_auth.views import JWTKeyAuthentication
 from olympia.api.permissions import GroupPermission
 from olympia.users.models import UserProfile
 from olympia.accounts.serializers import (
@@ -255,7 +255,9 @@ class AuthenticateView(APIView):
             return safe_redirect(next_path, 'login')
 
 
-class ProfileView(JWTProtectedView, generics.RetrieveAPIView):
+class ProfileView(generics.RetrieveAPIView):
+    authentication_classes = [JWTKeyAuthentication]
+    permission_classes = [IsAuthenticated]
     serializer_class = UserProfileSerializer
 
     def retrieve(self, request, *args, **kw):
@@ -280,7 +282,8 @@ class AccountSourceView(generics.RetrieveAPIView):
         return Response(self.get_serializer(user).data)
 
 
-class AccountSuperCreate(JWTProtectedView):
+class AccountSuperCreate(APIView):
+    authentication_classes = [JWTKeyAuthentication]
     permission_classes = [
         IsAuthenticated, GroupPermission('Accounts', 'SuperCreate')]
 

--- a/src/olympia/api/jwt_auth/handlers.py
+++ b/src/olympia/api/jwt_auth/handlers.py
@@ -82,8 +82,8 @@ def jwt_decode_handler(token, get_api_key=APIKey.get_jwt_key):
                     u'{e.__class__.__name__}: {e}'.format(e=exc))
         raise
 
-    if (payload['exp'] - payload['iat'] >
-            settings.MAX_APIKEY_JWT_AUTH_TOKEN_LIFETIME):
+    max_jwt_auth_token_lifetime = settings.MAX_APIKEY_JWT_AUTH_TOKEN_LIFETIME
+    if payload['exp'] - payload['iat'] > max_jwt_auth_token_lifetime:
         log.info('JWT auth: expiration is too long; '
                  'iss={iss}, iat={iat}, exp={exp}'.format(**payload))
         raise exceptions.AuthenticationFailed(

--- a/src/olympia/api/jwt_auth/handlers.py
+++ b/src/olympia/api/jwt_auth/handlers.py
@@ -12,7 +12,6 @@ AMO uses JWT tokens in a different way. Notes:
 
 See https://github.com/GetBlimp/django-rest-framework-jwt/ for more info.
 """
-from datetime import datetime
 import logging
 
 from django.conf import settings
@@ -27,24 +26,8 @@ from olympia.api.models import APIKey
 log = logging.getLogger('z.jwt')
 
 
-def jwt_payload_handler(user, issuer):
-    # This creates a payload but at the time of this comment it is only used
-    # for testing.
-    issued_at = datetime.utcnow()
-    return {
-        # The JWT issuer must match the 'key' field of APIKey
-        'iss': issuer,
-        'iat': issued_at,
-        'exp': issued_at + api_settings.JWT_EXPIRATION_DELTA,
-    }
-
-
-def jwt_encode_handler(payload, secret):
-    token = jwt.encode(payload, secret, api_settings.JWT_ALGORITHM)
-    return token.decode('utf-8')
-
-
 def jwt_decode_handler(token, get_api_key=APIKey.get_jwt_key):
+    """Decodes a JWT token."""
     # If you raise AuthenticationFailed from this method, its value will
     # be displayed to the client. Be careful not to reveal anything
     # sensitive. When you raise other exceptions, the user will see
@@ -99,7 +82,8 @@ def jwt_decode_handler(token, get_api_key=APIKey.get_jwt_key):
                     u'{e.__class__.__name__}: {e}'.format(e=exc))
         raise
 
-    if payload['exp'] - payload['iat'] > settings.MAX_JWT_AUTH_TOKEN_LIFETIME:
+    if (payload['exp'] - payload['iat'] >
+            settings.MAX_APIKEY_JWT_AUTH_TOKEN_LIFETIME):
         log.info('JWT auth: expiration is too long; '
                  'iss={iss}, iat={iat}, exp={exp}'.format(**payload))
         raise exceptions.AuthenticationFailed(

--- a/src/olympia/api/jwt_auth/views.py
+++ b/src/olympia/api/jwt_auth/views.py
@@ -45,20 +45,24 @@ class JWTKeyAuthentication(JSONWebTokenAuthentication):
 
         try:
             payload = handlers.jwt_decode_handler(jwt_value)
-        except jwt.ExpiredSignature:
-            log.exception('JWTKeyAuthentication signature has expired.')
-            msg = _('Signature has expired.')
-            raise exceptions.AuthenticationFailed(msg)
-        except jwt.DecodeError:
-            log.exception('JWTKeyAuthentication error decoding signature.')
-            msg = _('Error decoding signature.')
-            raise exceptions.AuthenticationFailed(msg)
-        except jwt.InvalidTokenError:
-            log.exception('JWTKeyAuthentication invalid token.')
-            msg = _('Invalid JWT Token.')
-            raise exceptions.AuthenticationFailed(msg)
-        # AuthenticationFailed can also be raised directly from our
-        # jwt_decode_handler.
+        except Exception, exc:
+            try:
+                # Log all exceptions
+                log.info('JWTKeyAuthentication failed; '
+                         'it raised %s (%s)', exc.__class__.__name__, exc)
+                # Re-raise to deal with them properly.
+                raise exc
+            except jwt.ExpiredSignature:
+                msg = _('Signature has expired.')
+                raise exceptions.AuthenticationFailed(msg)
+            except jwt.DecodeError:
+                msg = _('Error decoding signature.')
+                raise exceptions.AuthenticationFailed(msg)
+            except jwt.InvalidTokenError:
+                msg = _('Invalid JWT Token.')
+                raise exceptions.AuthenticationFailed(msg)
+            # Note: AuthenticationFailed can also be raised directly from our
+            # jwt_decode_handler.
 
         user = self.authenticate_credentials(payload)
 

--- a/src/olympia/api/tests/test_permissions.py
+++ b/src/olympia/api/tests/test_permissions.py
@@ -1,7 +1,9 @@
 from django.test import RequestFactory
 from mock import Mock
-from rest_framework.views import APIView
+from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
+from rest_framework.views import APIView
+
 
 from olympia.access.models import Group, GroupUser
 from olympia.api.permissions import GroupPermission
@@ -10,6 +12,9 @@ from olympia.users.models import UserProfile
 
 
 class ProtectedView(APIView):
+    # Use session auth for this test view because it's easy, and the goal is
+    # to test the permission, not the authentication.
+    authentication_classes = [SessionAuthentication]
     permission_classes = [GroupPermission('SomeRealm', 'SomePermission')]
 
     def get(self, request):
@@ -52,4 +57,4 @@ class TestGroupPermission(TestCase):
         request.user = Mock(is_authenticated=Mock(return_value=False))
         view = Mock()
         perm = GroupPermission('SomeRealm', 'SomePermission')
-        assert perm.has_permission(request, view) == False
+        assert perm.has_permission(request, view) is False

--- a/src/olympia/api/tests/utils.py
+++ b/src/olympia/api/tests/utils.py
@@ -3,11 +3,11 @@ from datetime import datetime
 from rest_framework.test import APITestCase
 
 from olympia.api.jwt_auth.views import JWTKeyAuthentication
-from olympia.api.tests.test_jwt_auth import JWTAuthTester
+from olympia.api.tests.test_jwt_auth import JWTAuthKeyTester
 from olympia.users.models import UserProfile
 
 
-class APIAuthTestCase(APITestCase, JWTAuthTester):
+class APIKeyAuthTestCase(APITestCase, JWTAuthKeyTester):
 
     def create_api_user(self):
         self.user = UserProfile.objects.create(

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1647,6 +1647,11 @@ MAX_APIKEY_JWT_AUTH_TOKEN_LIFETIME = 60
 
 # django-rest-framework-jwt settings:
 JWT_AUTH = {
+    # Use HMAC using SHA-256 hash algorithm. It should be the default, but we
+    # want to make sure it does not change behind our backs.
+    # See https://github.com/jpadilla/pyjwt/blob/master/docs/algorithms.rst
+    'JWT_ALGORITHM': 'HS256',
+
     # This adds some padding to timestamp validation in case client/server
     # clocks are off.
     'JWT_LEEWAY': 5,

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -250,6 +250,7 @@ JINGO_EXCLUDE_APPS = (
     'admin',
     'toolbar_statsd',
     'registration',
+    'rest_framework',
     'debug_toolbar',
     'waffle',
 )
@@ -398,6 +399,7 @@ INSTALLED_APPS = (
     'aesfield',
     'django_extensions',
     'raven.contrib.django',
+    'rest_framework',
     'waffle',
     'jingo_minify',
     'puente',
@@ -1638,30 +1640,20 @@ AES_KEYS = {
     #'api_key:secret': os.path.join(ROOT, 'path', 'to', 'file.key'),
 }
 
-# Time in seconds for how long a JWT auth token can live.
-# When developers are creating auth tokens they cannot set the expiration any
-# longer than this.
-MAX_JWT_AUTH_TOKEN_LIFETIME = 60
-
+# Time in seconds for how long a JWT auth token created by developers with
+# their API key can live. When developers are creating auth tokens they cannot
+# set the expiration any longer than this.
+MAX_APIKEY_JWT_AUTH_TOKEN_LIFETIME = 60
 
 # django-rest-framework-jwt settings:
 JWT_AUTH = {
-    # We don't want to refresh tokens right now. Refreshing a token is when
-    # you accept a request with a valid token and return a new one with a
-    # longer expiration.
-    'JWT_ALLOW_REFRESH': False,
-
-    # JWTs are only valid for one minute.
-    'JWT_EXPIRATION_DELTA': datetime.timedelta(
-        seconds=MAX_JWT_AUTH_TOKEN_LIFETIME),
-
-    'JWT_ENCODE_HANDLER': 'olympia.api.jwt_auth.handlers.jwt_encode_handler',
-    'JWT_DECODE_HANDLER': 'olympia.api.jwt_auth.handlers.jwt_decode_handler',
-    'JWT_PAYLOAD_HANDLER': 'olympia.api.jwt_auth.handlers.jwt_payload_handler',
-    'JWT_ALGORITHM': 'HS256',
     # This adds some padding to timestamp validation in case client/server
     # clocks are off.
     'JWT_LEEWAY': 5,
+
+    # Expiration for non-apikey jwt tokens. Since this will be used by our
+    # frontend clients we want a slightly longer expiration than normal.
+    'JWT_EXPIRATION_DELTA': datetime.timedelta(hours=1),
 }
 
 REST_FRAMEWORK = {
@@ -1670,6 +1662,9 @@ REST_FRAMEWORK = {
     # Which it will try to use if the client accepts text/html.
     'DEFAULT_RENDERER_CLASSES': (
         'rest_framework.renderers.JSONRenderer',
+    ),
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework_jwt.authentication.JSONWebTokenAuthentication',
     ),
 }
 

--- a/src/olympia/signing/tests/test_views.py
+++ b/src/olympia/signing/tests/test_views.py
@@ -10,7 +10,7 @@ from rest_framework.response import Response
 from olympia import amo
 from olympia.access.models import Group, GroupUser
 from olympia.addons.models import Addon, AddonUser
-from olympia.api.tests.utils import APIAuthTestCase
+from olympia.api.tests.utils import APIKeyAuthTestCase
 from olympia.devhub import tasks
 from olympia.files.models import File, FileUpload
 from olympia.signing.views import VersionView
@@ -18,7 +18,7 @@ from olympia.users.models import UserProfile
 from olympia.versions.models import Version
 
 
-class SigningAPITestCase(APIAuthTestCase):
+class SigningAPITestCase(APIKeyAuthTestCase):
     fixtures = ['base/addon_3615', 'base/user_4043307']
 
     def setUp(self):

--- a/src/olympia/signing/views.py
+++ b/src/olympia/signing/views.py
@@ -6,18 +6,21 @@ from django.conf import settings
 from django.utils.translation import ugettext as _
 
 from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from olympia.access import acl
 from olympia.addons.models import Addon
 from olympia.amo.decorators import use_master
-from olympia.api.jwt_auth.views import JWTProtectedView
+from olympia.api.jwt_auth.views import JWTKeyAuthentication
 from olympia.devhub.views import handle_upload
 from olympia.files.models import FileUpload
 from olympia.files.utils import parse_addon
 from olympia.versions import views as version_views
 from olympia.versions.models import Version
 from olympia.signing.serializers import FileUploadSerializer
+
 
 log = logging.getLogger('signing')
 
@@ -70,7 +73,9 @@ def with_addon(allow_missing=False):
     return wrapper
 
 
-class VersionView(JWTProtectedView):
+class VersionView(APIView):
+    authentication_classes = [JWTKeyAuthentication]
+    permission_classes = [IsAuthenticated]
 
     @handle_read_only_mode
     @with_addon(allow_missing=True)
@@ -145,7 +150,9 @@ class VersionView(JWTProtectedView):
         return Response(serializer.data)
 
 
-class SignedFile(JWTProtectedView):
+class SignedFile(APIView):
+    authentication_classes = [JWTKeyAuthentication]
+    permission_classes = [IsAuthenticated]
 
     @use_master
     def get(self, request, file_id):

--- a/src/olympia/stats/tests/test_views.py
+++ b/src/olympia/stats/tests/test_views.py
@@ -17,7 +17,7 @@ from olympia.amo.tests import TestCase
 from olympia.amo.urlresolvers import reverse
 from olympia.access.models import Group, GroupUser
 from olympia.addons.models import Addon, AddonUser
-from olympia.api.tests.utils import APIAuthTestCase
+from olympia.api.tests.utils import APIKeyAuthTestCase
 from olympia.bandwagon.models import Collection
 from olympia.stats import views, tasks
 from olympia.stats import search
@@ -886,7 +886,7 @@ class TestXss(amo.tests.TestXss):
         assert views.get_report_view(req) == {}
 
 
-class ArchiveTestCase(APIAuthTestCase):
+class ArchiveTestCase(APIKeyAuthTestCase):
     fixtures = ['base/addon_3615']
 
     def setUp(self):

--- a/src/olympia/stats/views.py
+++ b/src/olympia/stats/views.py
@@ -18,12 +18,14 @@ from django.db.transaction import non_atomic_requests
 from django.shortcuts import get_object_or_404, render
 from django.utils.cache import add_never_cache_headers, patch_cache_control
 from django.utils.datastructures import SortedDict
-from rest_framework import status
-from rest_framework.response import Response
 
 from cache_nuggets.lib import memoize
 from dateutil.parser import parse
 from product_details import product_details
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from olympia import amo
 from olympia.amo.utils import DecimalJSONEncoder
@@ -33,7 +35,7 @@ from olympia.addons.models import Addon
 from olympia.amo.decorators import (
     allow_cross_site_request, json_view, login_required)
 from olympia.amo.urlresolvers import reverse
-from olympia.api.jwt_auth.views import JWTProtectedView
+from olympia.api.jwt_auth.views import JWTKeyAuthentication
 from olympia.bandwagon.models import Collection
 from olympia.bandwagon.views import get_collection
 from olympia.stats.forms import DateForm
@@ -721,7 +723,9 @@ class ArchiveMixin(object):
         return addon
 
 
-class ArchiveListView(ArchiveMixin, JWTProtectedView):
+class ArchiveListView(ArchiveMixin, APIView):
+    authentication_classes = [JWTKeyAuthentication]
+    permission_classes = [IsAuthenticated]
 
     def get(self, request, slug, year, month):
         addon = self.get_addon(request, slug)
@@ -752,7 +756,9 @@ class ArchiveListView(ArchiveMixin, JWTProtectedView):
         return Response(data)
 
 
-class ArchiveView(ArchiveMixin, JWTProtectedView):
+class ArchiveView(ArchiveMixin, APIView):
+    authentication_classes = [JWTKeyAuthentication]
+    permission_classes = [IsAuthenticated]
 
     def get(self, request, slug, year, month, day, model_name):
         addon = self.get_addon(request, slug)


### PR DESCRIPTION
This is done in preparation for the introduction of a JWT Auth mechanism that does not depend on API Keys, for use in our frontend projects, with tokens generated by us with our secret key at login time instead of generated by clients.

This blocks #1859