### PR TITLE
Get rid of request.groups, just cache groups on the user instead when accessed

### DIFF
--- a/docs/topics/development/acl.rst
+++ b/docs/topics/development/acl.rst
@@ -13,7 +13,7 @@ flag in the :class:`~django.contrib.auth.models.User` model to indicate that a
 user can access the admin site.
 
 Outside of that we use the ``access.models.GroupUser`` to define what
-access groups a user is a part of.  We store this in ``request.groups``.
+access groups a user is a part of.
 
 
 How permissions work

--- a/src/olympia/access/middleware.py
+++ b/src/olympia/access/middleware.py
@@ -18,10 +18,10 @@ class ACLMiddleware(object):
         """Attach authentication/permission helpers to request."""
         request.check_ownership = partial(acl.check_ownership, request)
 
-        # figure out our list of groups...
+        # Persist the user in the thread to make it accessible in log()
+        # statements etc.
         if request.user.is_authenticated():
             amo.set_user(request.user)
-            request.groups = request.user.groups.all()
 
     def process_response(self, request, response):
         amo.set_user(None)

--- a/src/olympia/access/models.py
+++ b/src/olympia/access/models.py
@@ -42,6 +42,7 @@ def groupuser_post_save(sender, instance, **kw):
 
     amo.log(amo.LOG.GROUP_USER_ADDED, instance.group, instance.user)
     log.info('Added %s to %s' % (instance.user, instance.group))
+    del instance.user.groups_list
 
 
 @dispatch.receiver(signals.post_delete, sender=GroupUser,
@@ -52,3 +53,4 @@ def groupuser_post_delete(sender, instance, **kw):
 
     amo.log(amo.LOG.GROUP_USER_REMOVED, instance.group, instance.user)
     log.info('Removed %s from %s' % (instance.user, instance.group))
+    del instance.user.groups_list

--- a/src/olympia/access/tests.py
+++ b/src/olympia/access/tests.py
@@ -1,5 +1,3 @@
-from django.http import HttpRequest
-
 import mock
 import pytest
 from nose.tools import assert_false
@@ -63,8 +61,7 @@ def test_match_rules():
 
 
 def test_anonymous_user():
-    # Fake request must not have .groups, just like an anonymous user.
-    fake_request = HttpRequest()
+    fake_request = req_factory_factory('/')
     assert_false(action_allowed(fake_request, amo.FIREFOX, 'Admin:%'))
 
 
@@ -93,7 +90,6 @@ class TestHasPerm(TestCase):
 
     def fake_request_with_user(self, user):
         request = mock.Mock()
-        request.groups = user.groups.all()
         request.user = user
         request.user.is_authenticated = mock.Mock(return_value=True)
         return request
@@ -119,7 +115,6 @@ class TestHasPerm(TestCase):
 
     def test_require_author_when_admin(self):
         self.request = self.fake_request_with_user(self.login_admin())
-        self.request.groups = self.request.user.groups.all()
         assert check_ownership(self.request, self.addon, require_author=False)
 
         assert not check_ownership(self.request, self.addon,
@@ -134,7 +129,6 @@ class TestHasPerm(TestCase):
         self.addon.update(status=amo.STATUS_DELETED)
         assert not check_addon_ownership(self.request, self.addon)
         self.request.user = self.login_admin()
-        self.request.groups = self.request.user.groups.all()
         assert not check_addon_ownership(self.request, self.addon)
 
     def test_ignore_disabled(self):

--- a/src/olympia/addons/tests/test_forms.py
+++ b/src/olympia/addons/tests/test_forms.py
@@ -9,7 +9,7 @@ from django.core.files.storage import default_storage as storage
 from django.test.client import RequestFactory
 
 from olympia import amo
-from olympia.amo.tests import TestCase, addon_factory
+from olympia.amo.tests import TestCase, addon_factory, req_factory_factory
 from olympia.amo.tests.test_helpers import get_image_path
 from olympia.amo.utils import rm_local_tmp_dir
 from olympia.addons import forms
@@ -48,12 +48,13 @@ class FormsTest(TestCase):
         self.existing_name = 'Delicious Bookmarks'
         self.non_existing_name = 'Does Not Exist'
         self.error_msg = 'This name is already in use. Please choose another.'
+        self.request = req_factory_factory('/')
 
     def test_update_addon_non_existing_name(self):
         """An add-on edit can change the name to any non-existing name."""
         addon = addon_factory(name='some name')
         form = forms.AddonFormBasic(dict(name=self.non_existing_name),
-                                    request=None, instance=addon)
+                                    request=self.request, instance=addon)
         form.is_valid()
         assert 'name' not in form.errors
 
@@ -61,7 +62,7 @@ class FormsTest(TestCase):
         """An add-on edit can't change the name to an existing add-on name."""
         addon = addon_factory(name='some name')
         form = forms.AddonFormBasic(dict(name=self.existing_name),
-                                    request=None, instance=addon)
+                                    request=self.request, instance=addon)
         assert not form.is_valid()
         assert form.errors['name'][0][1] == self.error_msg
 
@@ -71,7 +72,7 @@ class FormsTest(TestCase):
         Addon.objects.get(pk=3615).update(is_listed=False)
         addon = addon_factory(name='some name')
         form = forms.AddonFormBasic(dict(name=self.existing_name),
-                                    request=None, instance=addon)
+                                    request=self.request, instance=addon)
         form.is_valid()
         assert 'name' not in form.errors
 
@@ -80,7 +81,7 @@ class FormsTest(TestCase):
         by an listed add-on."""
         addon = addon_factory(name='some name', is_listed=False)
         form = forms.AddonFormBasic(dict(name=self.existing_name),
-                                    request=None, instance=addon)
+                                    request=self.request, instance=addon)
         form.is_valid()
         assert 'name' not in form.errors
 
@@ -89,7 +90,7 @@ class FormsTest(TestCase):
         another add-on type."""
         addon = addon_factory(name='some name', type=amo.ADDON_PERSONA)
         form = forms.AddonFormBasic(dict(name=self.existing_name),
-                                    request=None, instance=addon)
+                                    request=self.request, instance=addon)
         form.is_valid()
         assert 'name' not in form.errors
 
@@ -98,8 +99,8 @@ class FormsTest(TestCase):
         Exiting add-ons shouldn't be able to use someone else's name.
         """
         a = Addon.objects.create(type=1)
-        f = forms.AddonFormBasic(dict(name=self.existing_name), request=None,
-                                 instance=a)
+        f = forms.AddonFormBasic(dict(name=self.existing_name),
+                                 request=self.request, instance=a)
         assert not f.is_valid()
         assert f.errors.get('name')[0][1] == self.error_msg
 
@@ -108,18 +109,18 @@ class FormsTest(TestCase):
         Exiting add-ons should be able to re-use their name.
         """
         delicious = Addon.objects.get()
-        f = forms.AddonFormBasic(dict(name=self.existing_name), request=None,
-                                 instance=delicious)
+        f = forms.AddonFormBasic(dict(name=self.existing_name),
+                                 request=self.request, instance=delicious)
         f.is_valid()
         assert f.errors.get('name') is None
 
     def test_locales(self):
-        form = forms.AddonFormDetails(request={})
+        form = forms.AddonFormDetails(request=self.request)
         assert form.fields['default_locale'].choices[0][0] == 'af'
 
     def test_slug_blacklist(self):
         delicious = Addon.objects.get()
-        form = forms.AddonFormBasic({'slug': 'submit'}, request=None,
+        form = forms.AddonFormBasic({'slug': 'submit'}, request=self.request,
                                     instance=delicious)
         assert not form.is_valid()
         assert form.errors['slug'] == (
@@ -127,13 +128,13 @@ class FormsTest(TestCase):
 
     def test_bogus_homepage(self):
         form = forms.AddonFormDetails(
-            {'homepage': 'javascript://something.com'}, request=None)
+            {'homepage': 'javascript://something.com'}, request=self.request)
         assert not form.is_valid()
         assert form.errors['homepage'][0][1] == u'Enter a valid URL.'
 
     def test_ftp_homepage(self):
         form = forms.AddonFormDetails(
-            {'homepage': 'ftp://foo.com'}, request=None)
+            {'homepage': 'ftp://foo.com'}, request=self.request)
         assert not form.is_valid()
         assert form.errors['homepage'][0][1] == u'Enter a valid URL.'
 
@@ -141,12 +142,12 @@ class FormsTest(TestCase):
         delicious = Addon.objects.get()
         form = forms.AddonFormDetails(
             {'default_locale': 'en-US'},
-            request=None, instance=delicious)
+            request=self.request, instance=delicious)
         assert form.is_valid()
 
     def test_slug_isdigit(self):
         delicious = Addon.objects.get()
-        form = forms.AddonFormBasic({'slug': '123'}, request=None,
+        form = forms.AddonFormBasic({'slug': '123'}, request=self.request,
                                     instance=delicious)
         assert not form.is_valid()
         assert form.errors['slug'] == (
@@ -171,11 +172,12 @@ class TestTagsForm(TestCase):
 
         self.user = self.addon.authors.all()[0]
         amo.set_user(self.user)
+        self.request = req_factory_factory('/')
 
     def add_tags(self, tags):
         data = self.data.copy()
         data.update({'tags': tags})
-        form = forms.AddonFormBasic(data=data, request=None,
+        form = forms.AddonFormBasic(data=data, request=self.request,
                                     instance=self.addon)
         assert form.is_valid()
         form.save(self.addon)
@@ -215,7 +217,7 @@ class TestTagsForm(TestCase):
     def test_tags_restricted(self):
         self.add_restricted()
         self.add_tags('foo, bar')
-        form = forms.AddonFormBasic(data=self.data, request=None,
+        form = forms.AddonFormBasic(data=self.data, request=self.request,
                                     instance=self.addon)
 
         assert form.fields['tags'].initial, 'bar == foo'
@@ -227,12 +229,12 @@ class TestTagsForm(TestCase):
         self.add_restricted('restartless', 'sdk')
         data = self.data.copy()
         data.update({'tags': 'restartless'})
-        form = forms.AddonFormBasic(data=data, request=None,
+        form = forms.AddonFormBasic(data=data, request=self.request,
                                     instance=self.addon)
         assert form.errors['tags'][0] == (
             '"restartless" is a reserved tag and cannot be used.')
         data.update({'tags': 'restartless, sdk'})
-        form = forms.AddonFormBasic(data=data, request=None,
+        form = forms.AddonFormBasic(data=data, request=self.request,
                                     instance=self.addon)
         assert form.errors['tags'][0] == (
             '"restartless", "sdk" are reserved tags and cannot be used.')
@@ -245,7 +247,7 @@ class TestTagsForm(TestCase):
         assert self.get_tag_text(), ['bar' == 'foo']
         self.add_tags('foo, bar, restartless')
         assert self.get_tag_text(), ['bar', 'foo' == 'restartless']
-        form = forms.AddonFormBasic(data=self.data, request=None,
+        form = forms.AddonFormBasic(data=self.data, request=self.request,
                                     instance=self.addon)
         assert form.fields['tags'].initial, 'bar, foo == restartless'
 
@@ -271,7 +273,7 @@ class TestTagsForm(TestCase):
         tag = ' -%s' % ('t' * 128)
         data = self.data.copy()
         data.update({"tags": tag})
-        form = forms.AddonFormBasic(data=data, request=None,
+        form = forms.AddonFormBasic(data=data, request=self.request,
                                     instance=self.addon)
         assert not form.is_valid()
         assert form.errors['tags'] == [
@@ -348,7 +350,8 @@ class TestCategoryForm(TestCase):
         Category.objects.create(type=amo.ADDON_SEARCH,
                                 application=amo.FIREFOX.id)
         addon = Addon.objects.create(type=amo.ADDON_SEARCH)
-        form = forms.CategoryFormSet(addon=addon)
+        request = req_factory_factory('/')
+        form = forms.CategoryFormSet(addon=addon, request=request)
         apps = [f.app for f in form.forms]
         assert apps == [amo.FIREFOX]
 

--- a/src/olympia/amo/__init__.py
+++ b/src/olympia/amo/__init__.py
@@ -56,14 +56,16 @@ class CachedProperty(object):
                 # calculate something important here
                 return 42
 
-    Lifted from werkzeug.
+    Originally lifted from werkzeug. It's slighly more useful than the one in
+    django because you can write/delete to the property to overwrite it or
+    force it to be re-calculated.
     """
 
-    def __init__(self, func, name=None, doc=None, writable=False):
+    def __init__(self, func, writable=False):
         self.func = func
         self.writable = writable
-        self.__name__ = name or func.__name__
-        self.__doc__ = doc or func.__doc__
+        self.__name__ = func.__name__
+        self.__doc__ = func.__doc__
 
     def __delete__(self, obj):
         if not self.writable:

--- a/src/olympia/amo/__init__.py
+++ b/src/olympia/amo/__init__.py
@@ -65,6 +65,11 @@ class CachedProperty(object):
         self.__name__ = name or func.__name__
         self.__doc__ = doc or func.__doc__
 
+    def __delete__(self, obj):
+        if not self.writable:
+            raise TypeError('read only attribute')
+        obj.__dict__.pop(self.__name__, None)
+
     def __get__(self, obj, type=None):
         if obj is None:
             return self

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -13,6 +13,7 @@ from urlparse import parse_qs, urlparse, urlsplit, urlunsplit
 
 from django import forms, test
 from django.conf import settings
+from django.contrib.auth.models import AnonymousUser
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.core.management import call_command
 from django.db.models.signals import post_save
@@ -705,7 +706,8 @@ def req_factory_factory(url, user=None, post=False, data=None):
         req = req.get(url, data or {})
     if user:
         req.user = UserProfile.objects.get(id=user.id)
-        req.groups = user.groups.all()
+    else:
+        req.user = AnonymousUser()
     req.APP = None
     req.check_ownership = partial(check_ownership, req)
     return req

--- a/src/olympia/amo/tests/test_ext.py
+++ b/src/olympia/amo/tests/test_ext.py
@@ -14,7 +14,6 @@ def test_app_in_fragment_cache_key(cache_mock):
     request = mock.Mock()
     request.APP.id = '<app>'
     request.user.is_authenticated.return_value = False
-    request.groups = []
     template = jingo.get_env().from_string('{% cache 1 %}{% endcache %}')
     render(request, template)
     assert cache_mock.call_args[0][0].endswith('<app>')

--- a/src/olympia/devhub/tests/test_forms.py
+++ b/src/olympia/devhub/tests/test_forms.py
@@ -229,8 +229,8 @@ class TestThemeForm(TestCase):
         super(TestThemeForm, self).setUp()
         self.populate()
         self.request = mock.Mock()
-        self.request.groups = ()
         self.request.user = mock.Mock()
+        self.request.user.groups_list = []
         self.request.user.is_authenticated.return_value = True
 
     def populate(self):
@@ -474,8 +474,8 @@ class TestEditThemeForm(TestCase):
         super(TestEditThemeForm, self).setUp()
         self.populate()
         self.request = mock.Mock()
-        self.request.groups = ()
         self.request.user = mock.Mock()
+        self.request.user.groups_list = []
         self.request.user.username = 'swagyismymiddlename'
         self.request.user.name = 'Sir Swag A Lot'
         self.request.user.is_authenticated.return_value = True

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -148,7 +148,8 @@ class TestEditBasic(TestEdit):
             '<span lang="en-us">&lt;b&gt;oh my&lt;/b&gt;</span>')
 
         # Now make sure we don't have escaped content in the rendered form.
-        form = AddonFormBasic(instance=self.get_addon(), request=object())
+        form = AddonFormBasic(instance=self.get_addon(),
+                              request=req_factory_factory('/'))
         eq_(pq('<body>%s</body>' % form['summary'])(
             '[lang="en-us"]').html().strip(),
             '<b>oh my</b>')

--- a/src/olympia/tags/tests/test_helpers.py
+++ b/src/olympia/tags/tests/test_helpers.py
@@ -22,7 +22,6 @@ class TestHelpers(amo.tests.BaseTestCase):
 
         request = Mock()
         request.user = addon.authors.all()[0]
-        request.groups = ()
 
         tags = addon.tags.not_blacklisted()
 

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -261,6 +261,11 @@ class UserProfile(OnChangeMixin, ModelBase,
 
         return urls
 
+    @amo.cached_property(writable=True)
+    def groups_list(self):
+        """List of all groups the user is a member of, as a cached property."""
+        return list(self.groups.all())
+
     @amo.cached_property
     def addons_listed(self):
         """Public add-ons this user is listed as author of."""

--- a/src/olympia/zadmin/tests/test_commands.py
+++ b/src/olympia/zadmin/tests/test_commands.py
@@ -10,9 +10,13 @@ class TestCommand(TestCase):
     fixtures = ['zadmin/group_admin', 'zadmin/users']
 
     def test_group_management(self):
-        x = UserProfile.objects.get(pk=10968)
-        assert not action_allowed_user(x, 'Admin', '%')
+        user = UserProfile.objects.get(pk=10968)
+        assert not action_allowed_user(user, 'Admin', '%')
+
         do_adduser('10968', '1')
-        assert action_allowed_user(x, 'Admin', '%')
+        del user.groups_list
+        assert action_allowed_user(user, 'Admin', '%')
+
         do_removeuser('10968', '1')
-        assert not action_allowed_user(x, 'Admin', '%')
+        del user.groups_list
+        assert not action_allowed_user(user, 'Admin', '%')


### PR DESCRIPTION
This allows us to build auth that does not need to reset a property on request, which is useful since DRF does auth after middlewares are executed, so we can't rely on our `ACLMiddleware`.

Blocks #1859