### PR TITLE
Fix up paths and font issues

### DIFF
--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -460,7 +460,7 @@ PUENTE = {
 MINIFY_BUNDLES = {
     'css': {
         'restyle/css': (
-            'css/restyle.less',
+            'css/restyle/restyle.less',
         ),
         # CSS files common to the entire site.
         'zamboni/css': (

--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -1,5 +1,5 @@
 // Needed for hovercards
-@import 'impala/hovercards';
+@import '../impala/hovercards';
 
 // Colors
 @primary-blue: rgba(12, 153, 213, 1);
@@ -20,7 +20,7 @@
   font-weight: 400;
   src: local('Open Sans'),
        local('OpenSans'),
-       url('../../css/impala/fonts/OpenSans-Regular.ttf') format('ttf');
+       url('../impala/fonts/OpenSans-Regular.ttf') format('truetype');
 }
 
 @font-face {
@@ -29,7 +29,7 @@
   font-weight: 700;
   src: local('Open Sans Bold'),
        local('OpenSans-Bold'),
-       url('../../css/impala/fonts/OpenSans-Bold.ttf') format('ttf');
+       url('../impala/fonts/OpenSans-Bold.ttf') format('truetype');
 }
 
 @font-face {
@@ -38,7 +38,7 @@
   font-weight: 700;
   src: local('Open Sans BoldItalic'),
        local('OpenSans-BoldItalic'),
-       url('../../css/impala/fonts/OpenSans-BoldItalic.ttf') format('ttf');
+       url('../impala/fonts/OpenSans-BoldItalic.ttf') format('truetype');
 }
 
 @font-face {
@@ -47,7 +47,7 @@
   font-weight: 400;
   src: local('Open Sans Italic'),
        local('OpenSans-Italic'),
-       url('../../css/impala/fonts/OpenSans-Italic.ttf') format('ttf');
+       url('../impala/fonts/OpenSans-Italic.ttf') format('truetype');
 }
 
 h1,
@@ -532,7 +532,7 @@ body:not(.home) .amo-header {
   background: none;
 
   &:before {
-    background-image: url('../img/zamboni/discovery_pane/promos/monthly-bg.png');
+    background-image: url('../../img/zamboni/discovery_pane/promos/monthly-bg.png');
     background-position: center;
     background-repeat: no-repeat;
     background-size: cover;
@@ -754,7 +754,7 @@ input:not(.upvotes):not(.downvotes)[type="submit"] {
     span {
       border: none;
       margin: 0;
-      background: url(../img/impala/button-icons.png) no-repeat 0 -191px;
+      background: url(../../img/impala/button-icons.png) no-repeat 0 -191px;
       padding: 0 0 0 24px;
     }
   }
@@ -805,14 +805,14 @@ input:not(.upvotes):not(.downvotes)[type="submit"] {
 
   &.installer.warning,
   &.installer.caution {
-    background-image: url(../img/impala/warning-bg.png);
+    background-image: url(../../img/impala/warning-bg.png);
     color: #333 !important;
   }
 }
 
 .header-search .search-button {
   background-color: #57bd35;
-  background-image: url('../img/icons/go-arrow.png');
+  background-image: url('../../img/icons/go-arrow.png');
   border-radius: 0;
   box-shadow: none;
   height: 30px;
@@ -1450,7 +1450,7 @@ h3.author .transfer-ownership {
 }
 
 .extra .button.not-available {
-  background: #fbfbfb url(../img/impala/no.png) 6px 50% no-repeat;
+  background: #fbfbfb url(../../img/impala/no.png) 6px 50% no-repeat;
   border: 1px solid #b1b1b1;
   border-radius: 3px;
   box-shadow: 0 2px 0 0 rgba(0, 0, 0, 0.1),


### PR DESCRIPTION
Fixes #2098

This should hopefully work for the local-dev and deployed case. 

I used a font manager to test what happens when deactivating open sans and I found that the web fonts weren't being loaded. the format looks like it should be `truetype` not `ttf`. This fixed it so it loads on chrome and ff.