### PR TITLE
Fix invisible eula link

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -1084,6 +1084,7 @@ h3.author .transfer-ownership {
   h4.author,
   h4.author a,
   #addon-summary,
+  a.eula,
   a.privacy-policy,
   .notice h3,
   .notice p,
@@ -1098,6 +1099,7 @@ h3.author .transfer-ownership {
 
   h4.author a,
   a.privacy-policy,
+  a.eula,
   #contribution.notice p a,
   .vital a,
   #reviews-link {


### PR DESCRIPTION
Fixes #2105

Before:

<img width="364" alt="personas_plus____add-ons_for_firefox" src="https://cloud.githubusercontent.com/assets/1514/14181297/4a69c544-f75e-11e5-91ae-aae3280851e2.png">


Postfix:

<img width="364" alt="personas_plus____add-ons_for_firefox" src="https://cloud.githubusercontent.com/assets/1514/14181274/32d828c6-f75e-11e5-96f6-c5909a202dcc.png">

