### PR TITLE
Fix theme masthead

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -107,6 +107,7 @@ hgroup h2.addon,
   line-height: 1.5;
 }
 
+masthead.submit-theme,
 #collections-landing {
   margin-top: 20px;
 }


### PR DESCRIPTION
Fixes #2138 
<img width="587" alt="create_a_new_theme____add-ons_for_firefox" src="https://cloud.githubusercontent.com/assets/1514/14209045/3dd8afcc-f81a-11e5-86d3-7152ea18e3fa.png">
