### PR TITLE
Fix featured hovercard (fix #2042)

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -1464,9 +1464,26 @@ h3.author .transfer-ownership {
   }
 }
 
-.category-landing .featured.three-col .addon.hovercard:hover {
-  height: 320px;
-  margin-bottom: -320px;
+.category-landing .featured.three-col .addon.hovercard {
+
+  &:hover {
+    height: 320px;
+    margin-bottom: -320px;
+  }
+
+  .addon-writeup {
+    display: none;
+  }
+
+  .extra {
+    max-width: 200px;
+
+    .button.not-available {
+      margin-top: -12px;
+      font-size: 12px;
+    }
+  }
+
 }
 
 .persona.hovercard {
@@ -1475,10 +1492,6 @@ h3.author .transfer-ownership {
   &:hover {
     margin-bottom: -12px;
     height: 90px;
-
-    .addon-writeup {
-      display: none;
-    }
   }
 
   h3 {


### PR DESCRIPTION
Fixed style:
<img width="850" alt="screenshot 2016-04-01 16 25 04" src="https://cloud.githubusercontent.com/assets/90871/14211498/5aa5702a-f826-11e5-8181-b25ad7475f47.png">


I had the `.addon-writeup` nested in the wrong bit, whoops.