### PR TITLE
Fix up holiday headings

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -102,13 +102,10 @@ h2 {
 h1,
 .primary h2,
 hgroup h2.addon,
-.personas-featured h3,
-#featured-addons .featured-inner h3 {
+.personas-featured h3 {
   color: @default-font-color;
-  font-family: @primary-font !important;
   font-size: 1.692rem;
   font-style: normal;
-  line-height: 1.5;
 }
 
 masthead.submit-theme,


### PR DESCRIPTION
Also removes some duplicated rules.

Before

<img width="535" alt="holiday_themes____add-ons_for_firefox" src="https://cloud.githubusercontent.com/assets/1514/14214222/bc323db6-f833-11e5-9c34-e7ff27ba695b.png">

After:

<img width="550" alt="holiday_themes____add-ons_for_firefox" src="https://cloud.githubusercontent.com/assets/1514/14214207/a15e2284-f833-11e5-822c-7b894f989f1e.png">