### PR TITLE
Change markup in restyle to fix header BG issues

### DIFF
--- a/src/olympia/addons/templates/addons/home.html
+++ b/src/olympia/addons/templates/addons/home.html
@@ -17,6 +17,17 @@
 }
 %}
 
+{% block header_content %}
+  {% if request.APP in (amo.FIREFOX, amo.ANDROID) %}
+    <section class="island" id="promos" data-promo-url="{{ url('addons.homepage_promos') }}">
+      <div>
+        <ul class="slider">
+        </ul>
+      </div>
+    </section>
+  {% endif %}
+{% endblock header_content %}
+
 
 {% block content %}
 {# IT looks for this comment with nagios, don't remove it. #}
@@ -27,13 +38,15 @@
 </section>
 
 <section class="primary" id="homepage">
-  {% if request.APP in (amo.FIREFOX, amo.ANDROID) %}
-    <section class="island" id="promos" data-promo-url="{{ url('addons.homepage_promos') }}">
-      <div>
-        <ul class="slider">
-        </ul>
-      </div>
-    </section>
+  {% if not waffle.flag('restyle') %}
+    {% if request.APP in (amo.FIREFOX, amo.ANDROID) %}
+      <section class="island" id="promos" data-promo-url="{{ url('addons.homepage_promos') }}">
+        <div>
+          <ul class="slider">
+          </ul>
+        </div>
+      </section>
+    {% endif %}
   {% endif %}
 
   {# Cache everything in one block since changes in each block are rare. #}

--- a/src/olympia/addons/templates/addons/impala/details.html
+++ b/src/olympia/addons/templates/addons/impala/details.html
@@ -18,130 +18,256 @@
   <meta property="og:description" content="{{ addon.summary|striptags }}">
 {% endblock %}
 
-{% block content %}
-{{ impala_breadcrumbs([(addon.type_url(), amo.ADDON_TYPES[addon.type]),
-                       (None, addon.name)]) }}
+{% block header_content %}
 <div itemscope itemtype="http://schema.org/WebApplication">
   <link itemprop="SoftwareApplicationCategory" href="http://schema.org/OtherApplication" />
   <aside class="secondary addon-vitals">
 
-  {# This assumes we'll never charge for add-ons. Ha. #}
-  <span itemprop="offers" itemscope itemtype="http://schema.org/Offer">
-    <meta itemprop="price" content="$0" />
-    <meta itemprop="priceCurrency" content="USD" />
-    <link itemprop="availability" href="http://schema.org/InStock" />
-  </span>
+    {# This assumes we'll never charge for add-ons. Ha. #}
+    <span itemprop="offers" itemscope itemtype="http://schema.org/Offer">
+      <meta itemprop="price" content="$0" />
+      <meta itemprop="priceCurrency" content="USD" />
+      <link itemprop="availability" href="http://schema.org/InStock" />
+    </span>
 
-  <div itemprop="aggregateRating" itemscope="" itemtype="http://schema.org/AggregateRating">
-    <meta content="{{ addon.average_rating }}" itemprop="ratingValue">
-    {{ addon.average_rating|stars(large=True) }}
+    <div itemprop="aggregateRating" itemscope="" itemtype="http://schema.org/AggregateRating">
+      <meta content="{{ addon.average_rating }}" itemprop="ratingValue">
+      {{ addon.average_rating|stars(large=True) }}
 
-    <div>
-      <a id="reviews-link" href="{{ addon.reviews_url }}">
-      {% trans cnt=addon.total_reviews, num=addon.total_reviews|numberfmt %}
-        <span itemprop="ratingCount">{{ num }}</span> user review
-      {% pluralize %}
-        <span itemprop="ratingCount">{{ num }}</span> user reviews
-      {% endtrans %}
-      </a>
+      <div>
+        <a id="reviews-link" href="{{ addon.reviews_url }}">
+          {% trans cnt=addon.total_reviews, num=addon.total_reviews|numberfmt %}
+            <span itemprop="ratingCount">{{ num }}</span> user review
+          {% pluralize %}
+            <span itemprop="ratingCount">{{ num }}</span> user reviews
+          {% endtrans %}
+        </a>
+      </div>
     </div>
-  </div>
 
-  {% if addon.show_adu() %}
-    {% set cnt = addon.average_daily_users %}
-    {% if cnt %}
-      {% set cnt_id = 'daily-users' %}
-      {% set cnt_pretty = ngettext('{0} user', '{0} users',
-                                   cnt)|f(cnt|numberfmt) %}
-    {% endif %}
-  {% else %}
-    {% set cnt = addon.weekly_downloads %}
-    {% if cnt %}
-      {% set cnt_id = 'weekly-downloads' %}
-      {% set cnt_pretty = ngettext('{0} weekly download',
-                                   '{0} weekly downloads',
-                                   cnt)|f(cnt|numberfmt) %}
-    {% endif %}
-  {% endif %}
-  {% if cnt %}
-    <div id="{{ cnt_id }}">
-      {% if addon.public_stats or is_author %}
-        <a class="stats" title="{{ _('View statistics') }}"
-           href="{{ url('stats.overview', addon.slug) }}">{{ cnt_pretty }}</a>
-      {% else %}
-        {{ cnt_pretty }}
+    {% if addon.show_adu() %}
+      {% set cnt = addon.average_daily_users %}
+      {% if cnt %}
+        {% set cnt_id = 'daily-users' %}
+        {% set cnt_pretty = ngettext(
+          '{0} user', '{0} users', cnt)|f(cnt|numberfmt) %}
       {% endif %}
-      <meta itemprop="interactionCount" content="UserDownloads:{{ addon.total_downloads }}" />
-    </div>
-  {% endif %}
-
-  <div class="widgets">
-    {{ favorites_widget(addon) }}
-    {% include 'addons/includes/collection_add_widget.html' %}
-    {{ sharing_widget(addon) }}
-  </div>
-  {% if is_author %}
-    <p class="manage-button"><a href="{{ addon.get_dev_url() }}" class="button developer prominent"><span>{{ _('Manage') }}</span></a></p>
-  {% endif %}
-  </aside>
-
-{% set version = addon.current_version %}
-
-{# All this depends on the addon or version, and nothing needs the user,
-   so we can cache it all against the addon. #}
-<section class="primary" id="addon-description-header">
-  <div id="addon" class="island c" role="main" data-id="{{ addon.id }}">
-    <hgroup>
-      {# L10n: {0} is an add-on name. #}
-      <img id="addon-icon" itemprop="image" src="{{ addon.get_icon_url(64) }}" class="icon" alt="{{ _('Icon of {0}')|fe(addon.name) }}">
-      <h1 class="addon"{{ addon.name|locale_html }}>
-        <span itemprop="name">{{ addon.name }}</span>
-        {% if version %}
-          <span class="version-number" itemprop="version">{{ version.version }}</span>
-        {% endif %}
-        {% if addon.is_no_restart() %}
-          &nbsp;<span class="no-restart">{{ _('No Restart') }}</span>
-        {% endif %}
-      </h1>
-      <h4 class="author">{{ _('by') }} {{ users_list(addon.listed_authors) }}</h4>
-    </hgroup>
-    <p id="addon-summary" itemprop="description" {{ addon.summary|locale_html }}>{{ addon.summary|nl2br }}</p>
-    {% if version %}
-      {{ big_install_button(addon, show_warning=False, impala=True) }}
+    {% else %}
+      {% set cnt = addon.weekly_downloads %}
+      {% if cnt %}
+        {% set cnt_id = 'weekly-downloads' %}
+        {% set cnt_pretty = ngettext('{0} weekly download',
+          '{0} weekly downloads', cnt)|f(cnt|numberfmt) %}
+      {% endif %}
     {% endif %}
-    {% if addon.is_featured(APP, LANG) %}
-      <div class="banner-box">
-        <div class="banner featured">{{ _('Featured') }}</div>
+    {% if cnt %}
+      <div id="{{ cnt_id }}">
+        {% if addon.public_stats or is_author %}
+          <a class="stats" title="{{ _('View statistics') }}"
+             href="{{ url('stats.overview', addon.slug) }}">{{ cnt_pretty }}</a>
+        {% else %}
+          {{ cnt_pretty }}
+        {% endif %}
+        <meta itemprop="interactionCount" content="UserDownloads:{{ addon.total_downloads }}" />
       </div>
     {% endif %}
-  </div>
 
-  {{ dependencies_note(addon) }}
-
-  {% if addon.takes_contributions %}
-    {{ impala_contribution(addon=addon, src='dp-btn-primary') }}
-  {% elif addon.has_profile() and addon.listed_authors %}
-    <div class="notice c author">
-      {% with single_dev = addon.listed_authors|random %}
-        <h3>
-          {% trans count=addon.listed_authors|length,
-                   name=single_dev.name,
-                   url=addon.meet_the_dev_url() %}
-            Meet the Developer: <a href="{{ url }}">{{ name }}</a>
-          {% pluralize %}
-            <a href="{{ url }}">Meet the Developers</a>
-          {% endtrans %}
-        </h3>
-        <img class="avatar" alt="{{ single_dev.name }}" height="64" alt=""
-             width="64" src="{{ single_dev.picture_url }}"/>
-        <p>{{ _("Learn why {0} was created and find out what's next for this "
-                'add-on.')|fe(addon.name) }}</p>
-      {% endwith %}
+    <div class="widgets">
+      {{ favorites_widget(addon) }}
+      {% include 'addons/includes/collection_add_widget.html' %}
+      {{ sharing_widget(addon) }}
     </div>
-  {% endif %}
-</section>
+    {% if is_author %}
+      <p class="manage-button"><a href="{{ addon.get_dev_url() }}" class="button developer prominent"><span>{{ _('Manage') }}</span></a></p>
+    {% endif %}
+  </aside>
+
+  {% set version = addon.current_version %}
+
+  {# All this depends on the addon or version, and nothing needs the user,
+     so we can cache it all against the addon. #}
+  <section class="primary addon-description-header">
+    <div id="addon" class="island c" role="main" data-id="{{ addon.id }}">
+      <hgroup>
+        {# L10n: {0} is an add-on name. #}
+        <img id="addon-icon" itemprop="image" src="{{ addon.get_icon_url(64) }}" class="icon" alt="{{ _('Icon of {0}')|fe(addon.name) }}">
+        <h1 class="addon"{{ addon.name|locale_html }}>
+          <span itemprop="name">{{ addon.name }}</span>
+          {% if version %}
+            <span class="version-number" itemprop="version">{{ version.version }}</span>
+          {% endif %}
+          {% if addon.is_no_restart() %}
+            &nbsp;<span class="no-restart">{{ _('No Restart') }}</span>
+          {% endif %}
+        </h1>
+        <h4 class="author">{{ _('by') }} {{ users_list(addon.listed_authors) }}</h4>
+      </hgroup>
+      <p id="addon-summary" itemprop="description" {{ addon.summary|locale_html }}>{{ addon.summary|nl2br }}</p>
+      {% if version %}
+        {{ big_install_button(addon, show_warning=False, impala=True) }}
+      {% endif %}
+      {% if addon.is_featured(APP, LANG) %}
+        <div class="banner-box">
+          <div class="banner featured">{{ _('Featured') }}</div>
+        </div>
+      {% endif %}
+    </div>
+
+    {{ dependencies_note(addon) }}
+
+    {% if addon.takes_contributions %}
+      {{ impala_contribution(addon=addon, src='dp-btn-primary') }}
+    {% elif addon.has_profile() and addon.listed_authors %}
+      <div class="notice c author">
+        {% with single_dev = addon.listed_authors|random %}
+          <h3>
+            {% trans count=addon.listed_authors|length,
+                     name=single_dev.name,
+                     url=addon.meet_the_dev_url() %}
+              Meet the Developer: <a href="{{ url }}">{{ name }}</a>
+            {% pluralize %}
+              <a href="{{ url }}">Meet the Developers</a>
+            {% endtrans %}
+          </h3>
+          <img class="avatar" alt="{{ single_dev.name }}" height="64" alt=""
+               width="64" src="{{ single_dev.picture_url }}"/>
+          <p>{{ _("Learn why {0} was created and find out what's next for this "
+                  "add-on.")|fe(addon.name) }}</p>
+        {% endwith %}
+      </div>
+    {% endif %}
+  </section>
+</div>
+{% endblock header_content %}
+
+{% block content %}
+{{ impala_breadcrumbs([(addon.type_url(), amo.ADDON_TYPES[addon.type]),
+                       (None, addon.name)]) }}
+{% if not waffle.flag('restyle') %}
+<div itemscope itemtype="http://schema.org/WebApplication">
+ <link itemprop="SoftwareApplicationCategory" href="http://schema.org/OtherApplication" />
+ <aside class="secondary addon-vitals">
+
+   {# This assumes we'll never charge for add-ons. Ha. #}
+   <span itemprop="offers" itemscope itemtype="http://schema.org/Offer">
+     <meta itemprop="price" content="$0" />
+     <meta itemprop="priceCurrency" content="USD" />
+     <link itemprop="availability" href="http://schema.org/InStock" />
+   </span>
+
+   <div itemprop="aggregateRating" itemscope="" itemtype="http://schema.org/AggregateRating">
+     <meta content="{{ addon.average_rating }}" itemprop="ratingValue">
+     {{ addon.average_rating|stars(large=True) }}
+
+     <div>
+       <a id="reviews-link" href="{{ addon.reviews_url }}">
+         {% trans cnt=addon.total_reviews, num=addon.total_reviews|numberfmt %}
+           <span itemprop="ratingCount">{{ num }}</span> user review
+         {% pluralize %}
+           <span itemprop="ratingCount">{{ num }}</span> user reviews
+         {% endtrans %}
+       </a>
+     </div>
+   </div>
+
+   {% if addon.show_adu() %}
+     {% set cnt = addon.average_daily_users %}
+     {% if cnt %}
+       {% set cnt_id = 'daily-users' %}
+       {% set cnt_pretty = ngettext(
+         '{0} user', '{0} users', cnt)|f(cnt|numberfmt) %}
+     {% endif %}
+   {% else %}
+     {% set cnt = addon.weekly_downloads %}
+     {% if cnt %}
+       {% set cnt_id = 'weekly-downloads' %}
+       {% set cnt_pretty = ngettext(
+         '{0} weekly download', '{0} weekly downloads', cnt)|f(cnt|numberfmt) %}
+     {% endif %}
+   {% endif %}
+   {% if cnt %}
+     <div id="{{ cnt_id }}">
+       {% if addon.public_stats or is_author %}
+         <a class="stats" title="{{ _('View statistics') }}"
+            href="{{ url('stats.overview', addon.slug) }}">{{ cnt_pretty }}</a>
+       {% else %}
+         {{ cnt_pretty }}
+       {% endif %}
+       <meta itemprop="interactionCount" content="UserDownloads:{{ addon.total_downloads }}" />
+     </div>
+   {% endif %}
+
+   <div class="widgets">
+     {{ favorites_widget(addon) }}
+     {% include 'addons/includes/collection_add_widget.html' %}
+     {{ sharing_widget(addon) }}
+   </div>
+   {% if is_author %}
+     <p class="manage-button"><a href="{{ addon.get_dev_url() }}" class="button developer prominent"><span>{{ _('Manage') }}</span></a></p>
+   {% endif %}
+ </aside>
+
+ {% set version = addon.current_version %}
+
+ {# All this depends on the addon or version, and nothing needs the user,
+    so we can cache it all against the addon. #}
+ <section class="primary" id="addon-description-header">
+   <div id="addon" class="island c" role="main" data-id="{{ addon.id }}">
+     <hgroup>
+       {# L10n: {0} is an add-on name. #}
+       <img id="addon-icon" itemprop="image" src="{{ addon.get_icon_url(64) }}" class="icon" alt="{{ _('Icon of {0}')|fe(addon.name) }}">
+       <h1 class="addon"{{ addon.name|locale_html }}>
+         <span itemprop="name">{{ addon.name }}</span>
+         {% if version %}
+           <span class="version-number" itemprop="version">{{ version.version }}</span>
+         {% endif %}
+         {% if addon.is_no_restart() %}
+           &nbsp;<span class="no-restart">{{ _('No Restart') }}</span>
+         {% endif %}
+       </h1>
+       <h4 class="author">{{ _('by') }} {{ users_list(addon.listed_authors) }}</h4>
+     </hgroup>
+     <p id="addon-summary" itemprop="description" {{ addon.summary|locale_html }}>{{ addon.summary|nl2br }}</p>
+     {% if version %}
+       {{ big_install_button(addon, show_warning=False, impala=True) }}
+     {% endif %}
+     {% if addon.is_featured(APP, LANG) %}
+       <div class="banner-box">
+         <div class="banner featured">{{ _('Featured') }}</div>
+       </div>
+     {% endif %}
+   </div>
+
+   {{ dependencies_note(addon) }}
+
+   {% if addon.takes_contributions %}
+     {{ impala_contribution(addon=addon, src='dp-btn-primary') }}
+   {% elif addon.has_profile() and addon.listed_authors %}
+     <div class="notice c author">
+       {% with single_dev = addon.listed_authors|random %}
+         <h3>
+           {% trans count=addon.listed_authors|length,
+                    name=single_dev.name,
+                    url=addon.meet_the_dev_url() %}
+             Meet the Developer: <a href="{{ url }}">{{ name }}</a>
+           {% pluralize %}
+             <a href="{{ url }}">Meet the Developers</a>
+           {% endtrans %}
+         </h3>
+         <img class="avatar" alt="{{ single_dev.name }}" height="64" alt=""
+              width="64" src="{{ single_dev.picture_url }}"/>
+         <p>{{ _("Learn why {0} was created and find out what's next for this "
+                 "add-on.")|fe(addon.name) }}</p>
+       {% endwith %}
+     </div>
+   {% endif %}
+ </section>
+</div>
+{% endif %}{# TODO: Remove this duplicated div once the refresh is live #}
 
 {% if addon.type != amo.ADDON_PERSONA %}
+  {% set version = addon.current_version %}
+
   {% if addon.all_previews|length > 0 %}
     <section class="previews">
       <div class="carousel">

--- a/src/olympia/templates/base.html
+++ b/src/olympia/templates/base.html
@@ -79,6 +79,10 @@
       {% endif %}
       <div class="section">
         {% block site_header %}
+          {% if waffle.flag('restyle') %}
+            <div class="header-bg">
+              <div class="amo-header-wrapper">
+          {% endif %}
           {% include "tabzilla.html" %}
           <div class="amo-header">
             <nav id="aux-nav" role="navigation" class="menu-nav c">
@@ -122,6 +126,10 @@
               {% block site_stats %}{% endblock %}
             </div>
           </div>
+          {% if waffle.flag('restyle') %}
+              </div> {# .header-bg #}
+            </div> {# .amo-header-wrapper #}
+          {% endif %}
         {% endblock site_header %}
 
         {# Overridden in base_side_categories, which expands categories

--- a/src/olympia/templates/impala/base.html
+++ b/src/olympia/templates/impala/base.html
@@ -64,11 +64,12 @@
         {% block bodyattrs %}{% endblock %}>
 
     <div id="main-wrapper">
-      {% if waffle.flag('restyle') %}
-        <div id="background-wrapper"></div>
-      {% endif %}
       <div id="page" class="c">
         {% block site_header %}
+          {% if waffle.flag('restyle') %}
+            <div class="header-bg">
+              <div class="amo-header-wrapper">
+          {% endif %}
           {% include "tabzilla.html" %}
           <div class="amo-header">
             <nav id="aux-nav" role="navigation" class="menu-nav c">
@@ -171,7 +172,14 @@
                 <a href="#" class="close">{{ _('Close') }}</a>
               </div>
             {% endblock %}
+            {% if waffle.flag('restyle') %}
+              {% block header_content %}{% endblock header_content %}
+            {% endif %}
           </div>
+          {% if waffle.flag('restyle') %}
+              </div> {# .header-bg #}
+            </div> {# .amo-header-wrapper #}
+          {% endif %}
         {% endblock site_header %}
 
         {# Overridden in base_side_categories, which expands categories

--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -79,7 +79,6 @@ body.restyle {
   font-family: @primary-font;
   font-style: normal;
   line-height: 1.5;
-  min-width: 1018px;
 }
 
 h1,
@@ -114,6 +113,11 @@ hgroup h2.addon,
 masthead.submit-theme,
 #collections-landing {
   margin-top: 20px;
+}
+
+.addon-description-header,
+.addon-details .secondary.addon-vitals {
+  background: none;
 }
 
 .addon-details h2 {
@@ -151,8 +155,24 @@ button.link:active span {
   color: @link-on-color-bg;
 }
 
-/* Main Content Wrapper */
-#background-wrapper {
+.amo-header,
+.primary,
+.secondary {
+  &::after {
+    clear: both;
+    content: "";
+    display: block;
+    height: 0;
+    width: 100%;
+  }
+}
+
+.primary,
+.secondary {
+  background: #fff;
+}
+
+.header-bg {
   background-color: #0c99d5;
   /*
     Main Content Wrapper Background - General
@@ -184,10 +204,13 @@ button.link:active span {
     0 416px,
     0 0,
     0 0;
-  border-top: 2px solid #fff;
-  position: absolute;
-  height: 130px;
-  width: 100%;
+  // This breaks the background panel wrapper out of the containing box,
+  // allowing it to be full-width. This means the background gradient can
+  // span the entire width of the viewport, even though the parent has a
+  // max-width.
+  margin: 0 0 12px ~"calc(-1 * ((100vw - 100%) / 2))";
+  min-width: 960px;
+  width: 100vw;
 }
 
 /*
@@ -195,8 +218,8 @@ button.link:active span {
   blue-pattern, blue-gradient, white overlay
   (sharp-cut at 416px)
 */
-.home #background-wrapper,
-.addon-details #background-wrapper {
+.home .header-bg,
+.addon-details .header-bg {
   background-image:
     linear-gradient(
       to bottom,
@@ -222,6 +245,15 @@ button.link:active span {
     0 416px,
     0 0,
     0 0;
+}
+
+.amo-header {
+  margin-bottom: 0;
+}
+
+.amo-header-wrapper {
+  margin: 0 auto;
+  max-width: 960px;
 }
 
 .category-landing [role="main"],
@@ -466,13 +498,10 @@ body:not(.home) .amo-header {
 
 #promos {
   display: block;
-  height: auto;
-  margin-left: -210px;
+  margin: 20px 0 0;
   min-height: 0;
   opacity: 1;
   visibility: visible;
-  width: 960px;
-  margin-bottom: 10px;
 }
 
 #promos,
@@ -909,14 +938,6 @@ a.button.release-theme-lock {
 
 #popular-extensions {
   margin-top: 0;
-}
-
-.restyle.home .shift-secondary {
-  margin-top: 282px;
-}
-
-.home .secondary {
-  margin: 12px 0;
 }
 
 .category-landing .secondary,
@@ -1367,7 +1388,8 @@ h3.author .transfer-ownership {
 // If the viewport is smaller than the min-width of the page weirdness
 // happens, so we go back to a non-full-width screenshot then.
 // See: https://github.com/mozilla/addons-server/issues/1983
-@media (max-width: 1018px) {
+@media (max-width: 960px) {
+  .header-bg,
   .restyle .previews {
     margin-left: 0;
     width: 100%;

--- a/static/js/impala/addon_details.js
+++ b/static/js/impala/addon_details.js
@@ -5,7 +5,7 @@ $(function () {
         $('#background-wrapper').height(
             $('.amo-header').height() +
             ($('.notification-box').length ? 80 : 0) +
-            $('#addon-description-header').height() + 20
+            $('.addon-description-header').height() + 20
         );
     }
 


### PR DESCRIPTION
Uses different markup in the restyle so the background of the header
is applied to an element that is the parent of the header rather than
the previous JS calculation method that caused lots of headaches.

* Fixes #2152
* Fixes #2141

Screenshots of the fix, so you know it a) looks the same as the old header and b) won't break with a bunch of stuff crammed in the header :smile: 

<img width="1360" alt="screenshot 2016-04-02 19 00 48" src="https://cloud.githubusercontent.com/assets/90871/14228173/9f0724f4-f905-11e5-868e-595634c784ff.png">
<img width="1360" alt="screenshot 2016-04-02 19 00 32" src="https://cloud.githubusercontent.com/assets/90871/14228174/9f1dcf9c-f905-11e5-9a4a-4c0f43da2bf0.png">
<img width="1360" alt="screenshot 2016-04-02 19 00 14" src="https://cloud.githubusercontent.com/assets/90871/14228175/9f25aab4-f905-11e5-887e-fb804f438584.png">

![apr 02 2016 19 03](https://cloud.githubusercontent.com/assets/90871/14228177/a3506c82-f905-11e5-886b-fc39c6d632c2.gif)

r?