### PR TITLE
Flag incompatible add-ons more clearly in restyle list (fix #2024)

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -1545,9 +1545,22 @@ h3.author .transfer-ownership {
   cursor: default;
   font-size: 14px;
   padding-left: 20px;
+  padding-right: 5px;
   margin-bottom: 5px;
   white-space: normal;
   text-shadow: none;
+}
+
+.items .item.incompatible {
+  .extra .button.not-available {
+    display: none;
+    float: right;
+  }
+
+  &:focus .extra .button.not-available,
+  &:hover .extra .button.not-available {
+    display: block;
+  }
 }
 
 #addon .more-versions a {

--- a/static/js/impala/listing.js
+++ b/static/js/impala/listing.js
@@ -30,11 +30,15 @@ function initListingCompat(domContext) {
     // Mark incompatible add-ons on listing pages unless marked with ignore.
     $('.listing .item.addon', domContext).each(function() {
         var $this = $(this);
+        var isIncompatible = (!$this.hasClass('ignore-compatibility') &&
+          ($this.find('.concealed').length == $this.find('.button').length ||
+           $this.find('button.not-available').length)
+        );
+
         if ($this.find('.acr-override').length) {
             $this.addClass('acr');
-        } else if (!$this.hasClass('ignore-compatibility') &&
-                   $this.find('.concealed').length == $this.find('.button').length) {
-            $this.addClass('incompatible');
+        } else if (isIncompatible) {
+          $this.addClass('incompatible');
         }
     });
 }


### PR DESCRIPTION
Fixes #2024; add-ons are now clearly marked as incompatible.

![apr 04 2016 10 55](https://cloud.githubusercontent.com/assets/90871/14244592/c7ae2c00-fa53-11e5-85ea-faa69f49a680.gif)