### PR TITLE
Allow clicking on "more versions" link (fix #2108)

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -1576,6 +1576,7 @@ h3.author .transfer-ownership {
   font-size: 14px;
   padding-left: 20px;
   padding-right: 5px;
+  pointer-events: all;
   margin-bottom: 5px;
   white-space: normal;
   text-shadow: none;

--- a/static/js/zamboni/buttons.js
+++ b/static/js/zamboni/buttons.js
@@ -19,9 +19,9 @@ var notavail = '<div class="extra"><span class="notavail">{0}</span></div>',
 
 // Restyle is enabled; we're going to modify the text.
 if ($('body').hasClass('restyle')) {
-    notavail = '<div class="extra"><button class="button not-available" disabled>{0}</button></div>';
-    incompat = '<div class="extra"><button class="button not-available" disabled>{0}</button></div>';
-    noappsupport = '<div class="extra"><button class="button not-available" disabled>{0}</button></div>';
+    notavail = '<div class="extra"><span class="button disabled not-available" disabled>{0}</span></div>';
+    incompat = '<div class="extra"><span class="button disabled not-available" disabled>{0}</span></div>';
+    noappsupport = '<div class="extra"><span class="button disabled not-available" disabled>{0}</span></div>';
 }
 
 // The lowest maxVersion an app has to support to allow default-to-compatible.


### PR DESCRIPTION
As reported in #2108, you couldn't click the link in previous versions and this acted like a button. Now it doesn't, yay!

Fixed screenshot:

![apr 04 2016 17 31](https://cloud.githubusercontent.com/assets/90871/14255252/0f88fb36-fa8b-11e5-8680-d2a11905d594.gif)