### PR TITLE
Restore "featured" banner (fix #2193)

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -1265,6 +1265,10 @@ h3.author .transfer-ownership {
   border: 0;
 }
 
+.banner-box .featured {
+  background: #489615;
+}
+
 .featured-inner {
   border: 0;
   padding-top: 0;


### PR DESCRIPTION
I think this still looks wonky, but this restores the "featured" text off to the right I accidentally hid with an unrelated change.

### Before

![2016-04-05_1110](https://cloud.githubusercontent.com/assets/15685960/14275281/0f1dd3b2-fb1f-11e5-94be-572877df5dd2.png)

### After

<img width="756" alt="screenshot 2016-04-05 16 14 21" src="https://cloud.githubusercontent.com/assets/90871/14287166/aca725aa-fb49-11e5-9651-cdde94d6efb9.png">
