### PR TITLE
Add image to promo (close #2161)

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -522,6 +522,7 @@ body:not(.home) .amo-header {
     background-image: url(../../img/zamboni/discovery_pane/promos-refresh/carousel-1.png);
   }
 
+  .promo-collection.webdev,
   .promo-purple,
   #holiday,
   #travel {
@@ -535,6 +536,13 @@ body:not(.home) .amo-header {
       text-align: left;
       text-shadow: @dark-gray 1px 1px;
     }
+  }
+
+  .promo-collection.webdev h2,
+  #monthly h2,
+  #monthly h3 {
+    font-size: 36px;
+    font-weight: 100;
   }
 
   #travel {
@@ -647,18 +655,6 @@ body:not(.home) .amo-header {
 
   .promo {
     background-size: cover;
-  }
-
-  #monthly.promo {
-    h2, h3 {
-      color: #fff;
-      font-size: 36px;
-      font-weight: 100;
-    }
-
-    h2 {
-      text-shadow: none;
-    }
   }
 }
 


### PR DESCRIPTION
<img width="975" alt="screenshot 2016-04-05 17 28 45" src="https://cloud.githubusercontent.com/assets/90871/14289779/33b84862-fb54-11e5-9701-1015faf42482.png">


This promo is only on -dev, so that's where we'll see it :unamused: 