### PR TITLE
Restore warning button for unreviewed add-on (fix #2230)

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -871,7 +871,9 @@ input:not(.upvotes):not(.downvotes)[type="submit"] {
   }
 
   &.installer.warning,
-  &.installer.caution {
+  &.installer.caution,
+  &.caution,
+  &.warning {
     background-image: url(../../img/impala/warning-bg.png);
     color: #333 !important;
 


### PR DESCRIPTION
### Before

![stage](https://cloud.githubusercontent.com/assets/15685960/14317582/9d0f956e-fc11-11e5-970d-9de109f56f76.png)

### After

<img width="594" alt="screenshot 2016-04-06 14 16 38" src="https://cloud.githubusercontent.com/assets/90871/14317908/5db126a8-fc02-11e5-8b31-8c192c61cd3b.png">