### PR TITLE
Make our JWT internal tokens separate from the api-key ones

### DIFF
--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -5,10 +5,8 @@ Add-ons
 .. note::
 
     These APIs are experimental and are currently being worked on. Endpoints
-    may change without warning.
-
-    At the moment these APIs don't yet require authentication and therefore
-    are limited to listed public add-ons.
+    may change without warning. The only authentication method available at
+    the moment is :ref:`the internal one<api-auth-internal>`.
 
 ------
 Search
@@ -16,7 +14,7 @@ Search
 
 .. _addon-search:
 
-This endpoint allows you to search through public add-ons.
+This endpoint allows you to search through public, listed add-ons.
 
 .. http:get:: /api/v3/addons/search/
 
@@ -25,7 +23,7 @@ This endpoint allows you to search through public add-ons.
     :>json int count: The number of results for this query.
     :>json string next: The URL of the next page of results.
     :>json string previous: The URL of the previous page of results.
-    :>json array results: An array of :ref:`add-ons <addon-detail>`.
+    :>json array results: An array of :ref:`add-ons <addon-detail-object>`.
 
 .. _addon-search-sort:
 
@@ -57,6 +55,13 @@ Detail
 This endpoint allows you to fetch a specific add-on by id, slug or guid.
 
 .. http:get:: /api/v3/addons/addon/(int:id|string:slug|string:guid)/
+
+    .. note::
+        Unlisted or non-public addons require authentication and either
+        reviewer permissions or an user account listed as a developer of the
+        add-on.
+
+    .. _addon-detail-object:
 
     :>json int id: The add-on id on AMO.
     :>json object current_version: Object holding information about the add-on version served by AMO currently.

--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -14,7 +14,7 @@ Search
 
 .. _addon-search:
 
-This endpoint allows you to search through public, listed add-ons.
+This endpoint allows you to search through public add-ons.
 
 .. http:get:: /api/v3/addons/search/
 
@@ -57,8 +57,8 @@ This endpoint allows you to fetch a specific add-on by id, slug or guid.
 .. http:get:: /api/v3/addons/addon/(int:id|string:slug|string:guid)/
 
     .. note::
-        Unlisted or non-public addons require authentication and either
-        reviewer permissions or an user account listed as a developer of the
+        Unlisted or non-public add-ons require authentication and either
+        reviewer permissions or a user account listed as a developer of the
         add-on.
 
     .. _addon-detail-object:

--- a/docs/topics/api/auth.rst
+++ b/docs/topics/api/auth.rst
@@ -1,12 +1,16 @@
 .. _api-auth:
 
-================
-Authentication
-================
+=========================
+Authentication (External)
+=========================
 
-To access the API, you need to include a `JSON Web Token (JWT)`_
-in an authorization header for every request. This header authenticates
-your user account so you could think of it like a session cookie.
+To access the API as an external consumer, you need to include a
+`JSON Web Token (JWT)`_ in the ``Authorization`` header for every request.
+This header authenticates your user account so you could think of it like a
+session cookie.
+
+If you are building an app that lives on the AMO domain, read the
+:ref:`documentation for internal authentication <api-auth-internal>` instead.
 
 Access Credentials
 ==================
@@ -113,6 +117,7 @@ Find a JWT library
 
 There are robust open source libraries for creating JWTs in
 `all major programming languages <http://jwt.io/>`_.
+
 
 .. _`manage-credentials`: https://addons.mozilla.org/en-US/developers/addon/api/key/
 .. _`API Credentials Management Page`: manage-credentials_

--- a/docs/topics/api/auth_internal.rst
+++ b/docs/topics/api/auth_internal.rst
@@ -53,7 +53,7 @@ Creating an Authorization header
 
 When making an authenticated API request, put your generated
 `JSON Web Token (JWT)`_ into an HTTP Authorization header prefixed with
-``JWT-i``, like this::
+``Bearer``, like this::
 
     Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE0NDcyNzMwOTZ9.MG9LJiEK5_Db8WpF5cWWRebXCtUB48EJzxKIBqQhSOo
 

--- a/docs/topics/api/auth_internal.rst
+++ b/docs/topics/api/auth_internal.rst
@@ -1,0 +1,62 @@
+.. _api-auth-internal:
+
+=========================
+Authentication (internal)
+=========================
+
+This documents how to use authentication in your API requests when you are
+working on a web application that lives on AMO domain or subdomain. If you
+are looking for how to authenticate with the API from an external client, using
+your API keys, read the :ref:`documentation for external authentication
+<api-auth>` instead.
+
+When using this authentication mechanism, the server is responsible for
+creating a `JSON Web Token (JWT)`_ when the user logs in, and sends it back in
+the response. The clients must then include that token as an ``Authorization``
+header on requests that need authentication. The clients never generate JWTs
+themselves.
+
+Fetching the JWT
+================
+
+A fresh JWT, valid for 30 days, is automatically generated and added to the
+responses of the following endpoints:
+
+    * ``/api/v3/accounts/login/``
+    * ``/api/v3/accounts/register/``
+    * ``/api/v3/accounts/authenticate/``
+
+The token is available in two forms:
+
+    * For the endpoints returning JSON, as a property called ``token``.
+    * For all endpoints, as a cookie called ``jwt_api_auth_token``. This cookie
+      expires when the browser is closed and is set as ``HttpOnly``.
+
+
+Verifying a JWT
+===============
+
+You can verify that a token is valid by calling:
+
+.. http:post:: /api/v3/frontend-token/verify/
+
+    :<json string token: The JWT you want to verify.
+    :status 200: The token is valid.
+    :status 400: The token is invalid.
+
+If a 400 Bad Request error is returned, the body of the response may contain
+additional information explaining why the token is invalid.
+
+
+Creating an Authorization header
+================================
+
+When making an authenticated API request, put your generated
+`JSON Web Token (JWT)`_ into an HTTP Authorization header prefixed with
+``JWT-i``, like this::
+
+    Authorization: JWT-i eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE0NDcyNzMwOTZ9.MG9LJiEK5_Db8WpF5cWWRebXCtUB48EJzxKIBqQhSOo
+
+
+.. _`jwt-spec`: https://tools.ietf.org/html/rfc7519
+.. _`JSON Web Token (JWT)`: jwt-spec_

--- a/docs/topics/api/auth_internal.rst
+++ b/docs/topics/api/auth_internal.rst
@@ -30,7 +30,7 @@ The token is available in two forms:
 
     * For the endpoints returning JSON, as a property called ``token``.
     * For all endpoints, as a cookie called ``jwt_api_auth_token``. This cookie
-      expires when the browser is closed and is set as ``HttpOnly``.
+      expires after 30 days and is set as ``HttpOnly``.
 
 
 Verifying a JWT
@@ -55,7 +55,7 @@ When making an authenticated API request, put your generated
 `JSON Web Token (JWT)`_ into an HTTP Authorization header prefixed with
 ``JWT-i``, like this::
 
-    Authorization: JWT-i eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE0NDcyNzMwOTZ9.MG9LJiEK5_Db8WpF5cWWRebXCtUB48EJzxKIBqQhSOo
+    Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE0NDcyNzMwOTZ9.MG9LJiEK5_Db8WpF5cWWRebXCtUB48EJzxKIBqQhSOo
 
 
 .. _`jwt-spec`: https://tools.ietf.org/html/rfc7519

--- a/docs/topics/api/index.rst
+++ b/docs/topics/api/index.rst
@@ -31,6 +31,7 @@ using the API.
 
    overview
    auth
+   auth_internal
    accounts
    addons
    signing

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -231,8 +231,10 @@ def add_api_token_to_response(response, user):
     # Also include the API token in a session cookie, so that it is available
     # for universal frontend apps.
     response.set_cookie(
-        'jwt_api_auth_token', token,
-        max_age=None, secure=settings.SESSION_COOKIE_SECURE or None,
+        'jwt_api_auth_token',
+        token,
+        max_age=settings.SESSION_COOKIE_AGE or None,
+        secure=settings.SESSION_COOKIE_SECURE or None,
         httponly=settings.SESSION_COOKIE_HTTPONLY or None)
 
     return response

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -285,8 +285,10 @@ class TestClient(Client):
         will be sent in an Authorization header with all future requests for
         this client.
         """
+        from rest_framework_jwt.settings import api_settings
+        prefix = api_settings.JWT_AUTH_HEADER_PREFIX
         token = self.generate_api_token(user)
-        self.defaults['HTTP_AUTHORIZATION'] = 'JWT {0}'.format(token)
+        self.defaults['HTTP_AUTHORIZATION'] = '{0} {1}'.format(prefix, token)
 
     def logout_api(self):
         """

--- a/src/olympia/api/authentication.py
+++ b/src/olympia/api/authentication.py
@@ -116,7 +116,7 @@ class JWTKeyAuthentication(UpstreamJSONWebTokenAuthentication):
         """
         Get the JWT token from the authorization header.
 
-        Copied from upstream's implementation but uses an hardcoded 'JWT'
+        Copied from upstream's implementation but uses a hardcoded 'JWT'
         prefix in order to be isolated from JWT_AUTH_HEADER_PREFIX setting
         which is used for the non-api key auth above.
         """

--- a/src/olympia/api/authentication.py
+++ b/src/olympia/api/authentication.py
@@ -1,8 +1,10 @@
+from django.utils.encoding import smart_text
 from django.utils.translation import ugettext as _
 
 import commonware
 import jwt
 from rest_framework import exceptions
+from rest_framework.authentication import get_authorization_header
 from rest_framework_jwt.authentication import (
     JSONWebTokenAuthentication as UpstreamJSONWebTokenAuthentication)
 
@@ -17,12 +19,13 @@ log = commonware.log.getLogger('z.api.authentication')
 class JSONWebTokenAuthentication(UpstreamJSONWebTokenAuthentication):
     """
     DRF authentication class for JWT header auth.
-
-    This mimics what our ACLMiddleware does after a successful authentication,
-    because otherwise that behaviour would be missing in the API since API auth
-    happens after the middleware process request phase.
     """
     def authenticate_credentials(self, request):
+        """
+        Mimic what our ACLMiddleware does after a successful authentication,
+        because otherwise that behaviour would be missing in the API since API
+        auth happens after the middleware process request phase.
+        """
         result = super(
             JSONWebTokenAuthentication, self).authenticate_credentials(request)
         amo.set_user(result)
@@ -108,3 +111,27 @@ class JWTKeyAuthentication(UpstreamJSONWebTokenAuthentication):
 
         amo.set_user(api_key.user)
         return api_key.user
+
+    def get_jwt_value(self, request):
+        """
+        Get the JWT token from the authorization header.
+
+        Copied from upstream's implementation but uses an hardcoded 'JWT'
+        prefix in order to be isolated from JWT_AUTH_HEADER_PREFIX setting
+        which is used for the non-api key auth above.
+        """
+        auth = get_authorization_header(request).split()
+        auth_header_prefix = 'jwt'  # JWT_AUTH_HEADER_PREFIX.lower()
+
+        if not auth or smart_text(auth[0].lower()) != auth_header_prefix:
+            return None
+
+        if len(auth) == 1:
+            msg = _('Invalid Authorization header. No credentials provided.')
+            raise exceptions.AuthenticationFailed(msg)
+        elif len(auth) > 2:
+            msg = _('Invalid Authorization header. Credentials string '
+                    'should not contain spaces.')
+            raise exceptions.AuthenticationFailed(msg)
+
+        return auth[1]

--- a/src/olympia/api/tests/test_authentication.py
+++ b/src/olympia/api/tests/test_authentication.py
@@ -10,6 +10,7 @@ from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from rest_framework_jwt.settings import api_settings
 from rest_framework_jwt.views import refresh_jwt_token
 
 from olympia.amo.helpers import absolutify
@@ -198,9 +199,10 @@ class TestJSONWebTokenAuthentication(TestCase):
 
     def _authenticate(self, token):
         url = absolutify('/api/whatever')
+        prefix = api_settings.JWT_AUTH_HEADER_PREFIX
         request = self.factory.post(
             url, HTTP_HOST='testserver',
-            HTTP_AUTHORIZATION='JWT {0}'.format(token))
+            HTTP_AUTHORIZATION='{0} {1}'.format(prefix, token))
 
         return self.auth.authenticate(request)
 

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1668,7 +1668,7 @@ JWT_AUTH = {
 
     # Prefix for non-apikey jwt tokens. Should be different from 'JWT' which we
     # already used for api key tokens.
-    'JWT_AUTH_HEADER_PREFIX': 'JWT-i',
+    'JWT_AUTH_HEADER_PREFIX': 'Bearer',
 }
 
 REST_FRAMEWORK = {

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1665,6 +1665,10 @@ JWT_AUTH = {
 
     # We don't allow refreshes, instead we simply have a long duration.
     'JWT_ALLOW_REFRESH': False,
+
+    # Prefix for non-apikey jwt tokens. Should be different from 'JWT' which we
+    # already used for api key tokens.
+    'JWT_AUTH_HEADER_PREFIX': 'JWT-i',
 }
 
 REST_FRAMEWORK = {


### PR DESCRIPTION
Also document API authentication for "internal" consumers (fix #2198)

