### PR TITLE
Only show promos when appropriate (fix #2191)

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -516,12 +516,15 @@ body:not(.home) .amo-header {
 }
 
 #promos {
-  display: block;
   margin: 20px 0 0;
   min-height: 0;
   opacity: 1;
   visibility: visible;
   width: @pageWidth;
+
+  &.show {
+    display: block;
+  }
 
   #monthly {
     background-image: url(../../img/zamboni/discovery_pane/promos-refresh/carousel-1.png);


### PR DESCRIPTION
### Before

![2016-04-05_1013](https://cloud.githubusercontent.com/assets/15685960/14273950/04ef3b90-fb17-11e5-8b60-27d36839e640.png)

### After

<img width="1360" alt="screenshot 2016-04-06 23 11 09" src="https://cloud.githubusercontent.com/assets/90871/14334538/f2128932-fc4c-11e5-927f-cd0902ce00ff.png">
<img width="1360" alt="screenshot 2016-04-06 23 10 58" src="https://cloud.githubusercontent.com/assets/90871/14334539/f212d068-fc4c-11e5-8dbe-42097592bd4f.png">

(Displays pages with promos as expected; hides promo area when none are to be shown)