### PR TITLE
Apply a default style to promos (fix #2249)

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -564,6 +564,7 @@ body:not(.home) .amo-header {
     }
   }
 
+  .promo,
   .promo-collection.webdev,
   .promo-purple,
   #holiday,


### PR DESCRIPTION
### Before
﻿
My train wifi isn't liking uploading screenshots.

### After

It looks like the rest of the promos. My local dev just broke so sceenshot incoming once it's fixed.

r? -- if you want to wait for screenshots I'll be a bit.