### PR TITLE
If ReviewHelper is called without a request, don't try fetching actions (fix #2261)

### DIFF
--- a/src/olympia/editors/helpers.py
+++ b/src/olympia/editors/helpers.py
@@ -537,9 +537,13 @@ class ReviewHelper:
             self.handler = ReviewFiles(request, addon, version, 'pending')
 
     def get_actions(self, request, addon):
-        labels, details = self._review_actions()
-
         actions = SortedDict()
+        if request is None:
+            # If request is not set, it means we are just (ab)using the
+            # ReviewHelper for its `handler` attribute and we don't care about
+            # the actions.
+            return actions
+        labels, details = self._review_actions()
         reviewable_because_complete = addon.status != amo.STATUS_NULL
         reviewable_because_admin = (
             not addon.admin_review or

--- a/src/olympia/editors/tests/test_helpers.py
+++ b/src/olympia/editors/tests/test_helpers.py
@@ -262,6 +262,11 @@ class TestReviewHelper(TestCase):
         return (ActivityLog.objects.for_addons(self.helper.addon)
                                    .filter(action=id).count())
 
+    def test_no_request(self):
+        self.request = None
+        helper = self.get_helper()
+        assert helper.actions == {}
+
     def test_type_nominated(self):
         eq_(self.setup_type(amo.STATUS_NOMINATED), 'nominated')
         eq_(self.setup_type(amo.STATUS_LITE_AND_NOMINATED), 'nominated')


### PR DESCRIPTION
`ReviewHelper` is called from auto_sign_* functions without a request, because in that case we only care about the handler property, that does the signing. Unfortunately `ReviewHelper` fetches actions available for the current user at init time, so bail early when doing that if no request was passed.

Workaround (or fix, depending on how much you care about this mess) for https://sentry.prod.mozaws.net/operations/olympia-prod/group/323242/