### PR TITLE
Remove sideloading distinction when uploading add-ons

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -608,11 +608,6 @@ class Addon(OnChangeMixin, ModelBase):
         # with on a file-by-file basis.
         return not self.is_listed
 
-    @property
-    def is_sideload(self):
-        # An add-on can side-load if it has been fully reviewed.
-        return self.status in (amo.STATUS_NOMINATED, amo.STATUS_PUBLIC)
-
     @amo.cached_property(writable=True)
     def listed_authors(self):
         return UserProfile.objects.filter(

--- a/src/olympia/devhub/forms.py
+++ b/src/olympia/devhub/forms.py
@@ -538,15 +538,6 @@ class NewAddonForm(AddonUploadForm):
         help_text=_lazy(
             u'Check this option if you intend to distribute your add-on on '
             u'your own and only need it to be signed by Mozilla.'))
-    is_sideload = forms.BooleanField(
-        initial=False,
-        required=False,
-        label=_lazy(u'This add-on will be bundled with an application '
-                    u'installer.'),
-        help_text=_lazy(u'Add-ons that are bundled with application '
-                        u'installers will be code reviewed '
-                        u'by Mozilla before they are signed and are held to a '
-                        u'higher quality standard.'))
 
     def clean(self):
         if not self.errors:

--- a/src/olympia/devhub/templates/devhub/addons/submit/upload.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/upload.html
@@ -28,19 +28,13 @@
         <span class="tip tooltip"
               title="{{ new_addon_form.is_unlisted.help_text }}">?</span>
       </label>
-      <label for="{{ new_addon_form.is_sideload.auto_id }}">
-        {{ new_addon_form.is_sideload }}
-        {{ new_addon_form.is_sideload.label }}
-        <span class="tip tooltip"
-              title="{{ new_addon_form.is_sideload.help_text }}">?</span>
-      </label>
     </div>
   </div>
   <input type="file" id="upload-addon"
     data-upload-url="{{ url('devhub.upload') }}"
     data-upload-url-listed="{{ url('devhub.upload') }}"
     data-upload-url-unlisted="{{ url('devhub.upload_unlisted') }}"
-    data-upload-url-sideload="{{ url('devhub.upload_sideload') }}">
+  >
 
   {{ new_addon_form.non_field_errors() }}
 

--- a/src/olympia/devhub/templates/devhub/validate_addon.html
+++ b/src/olympia/devhub/templates/devhub/validate_addon.html
@@ -47,12 +47,6 @@
           <span class="tip tooltip"
                 title="{{ new_addon_form.is_unlisted.help_text }}">?</span>
         </label>
-        <label for="{{ new_addon_form.is_sideload.auto_id }}">
-          {{ new_addon_form.is_sideload }}
-          {{ new_addon_form.is_sideload.label }}
-          <span class="tip tooltip"
-                title="{{ new_addon_form.is_sideload.help_text }}">?</span>
-        </label>
       </div>
     </div>
 
@@ -60,7 +54,7 @@
       data-upload-url="{{ url('devhub.standalone_upload') }}"
       data-upload-url-listed="{{ url('devhub.standalone_upload') }}"
       data-upload-url-unlisted="{{ url('devhub.standalone_upload_unlisted') }}"
-      data-upload-url-sideload="{{ url('devhub.standalone_upload_sideload') }}">
+    >
 
   </section>
 </form>

--- a/src/olympia/devhub/templates/devhub/versions/add_file_modal.html
+++ b/src/olympia/devhub/templates/devhub/versions/add_file_modal.html
@@ -1,7 +1,6 @@
 <div class="add-file-modal upload-file modal hidden">
   <form method="post" id="upload-file" class="new-addon-file" action="{{ action }}" enctype="multipart/form-data"
-    data-addon-is-listed="{% if addon.is_listed %}true{% else %}false{% endif %}"
-    data-addon-is-sideload="{% if not addon.is_listed and addon.status in [amo.STATUS_PUBLIC, amo.STATUS_NOMINATED] %}true{% else %}false{% endif %}">
+    data-addon-is-listed="{% if addon.is_listed %}true{% else %}false{% endif %}">
     <h3>{{ title }}</h3>
     <div class="upload-file-box">
       <p>

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -1292,8 +1292,6 @@ class TestSubmitStep2(TestCase):
         eq_(response.status_code, 200)
         doc = pq(response.content)
         assert doc('.list-addon input#id_is_unlisted[type=checkbox]')
-        # There also is a checkbox to select full review (side-load) or prelim.
-        assert doc('.list-addon input#id_is_sideload[type=checkbox]')
 
 
 class TestSubmitStep3(TestSubmitBase):
@@ -2596,60 +2594,15 @@ class TestVersionAddFile(UploadTest):
         eq_(response.status_code, 400)
         assert 'source' in json.loads(response.content)
 
-    @mock.patch('olympia.editors.helpers.sign_file')
-    def test_unlisted_addon_sideload_fail_validation(self, mock_sign_file):
-        """Sideloadable unlisted addons are also auto signed/reviewed."""
-        assert self.addon.status == amo.STATUS_PUBLIC  # Fully reviewed.
-        self.addon.update(is_listed=False, trusted=False)
-        # Make sure the file has validation warnings or errors.
-        self.upload.update(
-            validation='{"notices": 2, "errors": 0, "messages": [],'
-                       ' "metadata": {}, "warnings": 1,'
-                       ' "signing_summary": {"trivial": 1, "low": 1,'
-                       '                     "medium": 0, "high": 0},'
-                       ' "passed_auto_validation": 1}')
-        self.post()
-        file_ = File.objects.latest()
-        # Status is changed to fully reviewed and the file is signed.
-        assert self.addon.status == amo.STATUS_PUBLIC
-        assert file_.status == amo.STATUS_PUBLIC
-        assert mock_sign_file.called
-        # There is a log for that unlisted file signature (with failed
-        # validation).
-        log = ActivityLog.objects.order_by('pk').last()
-        expected = amo.LOG.UNLISTED_SIDELOAD_SIGNED_VALIDATION_FAILED.id
-        assert log.action == expected
-
-    @mock.patch('olympia.editors.helpers.sign_file')
-    def test_unlisted_addon_sideload_pass_validation(self, mock_sign_file):
-        """Sideloadable unlisted addons are also auto signed/reviewed."""
-        assert self.addon.status == amo.STATUS_PUBLIC  # Fully reviewed.
-        self.addon.update(is_listed=False, trusted=False)
-        # Make sure the file has no validation signing related messages.
-        self.upload.update(
-            validation='{"notices": 2, "errors": 0, "messages": [],'
-                       ' "metadata": {}, "warnings": 1,'
-                       ' "signing_summary": {"trivial": 1, "low": 0,'
-                       '                     "medium": 0, "high": 0},'
-                       ' "passed_auto_validation": 1}')
-        self.post()
-        file_ = File.objects.latest()
-        # Status is changed to fully reviewed and the file is signed.
-        assert self.addon.status == amo.STATUS_PUBLIC
-        assert file_.status == amo.STATUS_PUBLIC
-        assert mock_sign_file.called
-        # There is a log for that unlisted file signature (with failed
-        # validation).
-        log = ActivityLog.objects.order_by('pk').last()
-        expected = amo.LOG.UNLISTED_SIDELOAD_SIGNED_VALIDATION_PASSED.id
-        assert log.action == expected
+    # FIXME: test an unlisted addon that was preliminary reviewed, because we
+    # are not changing those, so they exist in the wild and need to continue
+    # working.
+    # And test it for both adding version and adding a file to a version.
 
     @mock.patch('olympia.editors.helpers.sign_file')
     def test_unlisted_addon_fail_validation(self, mock_sign_file):
         """Files that fail validation are also auto signed/reviewed."""
-        self.addon.update(
-            is_listed=False, status=amo.STATUS_LITE, trusted=False)
-        assert self.addon.status == amo.STATUS_LITE  # Preliminary reviewed.
+        self.addon.update(is_listed=False, trusted=False)
         # Make sure the file has validation warnings or errors.
         self.upload.update(
             validation='{"notices": 2, "errors": 0, "messages": [],'
@@ -2657,11 +2610,11 @@ class TestVersionAddFile(UploadTest):
                        ' "signing_summary": {"trivial": 1, "low": 1,'
                        '                     "medium": 0, "high": 0},'
                        ' "passed_auto_validation": 1}')
+        assert self.addon.status == amo.STATUS_PUBLIC
         self.post()
         file_ = File.objects.latest()
-        # Status is changed to preliminary reviewed and the file is signed.
-        assert self.addon.status == amo.STATUS_LITE
-        assert file_.status == amo.STATUS_LITE
+        assert self.addon.status == amo.STATUS_PUBLIC
+        assert file_.status == amo.STATUS_PUBLIC
         assert mock_sign_file.called
         # There is a log for that unlisted file signature (with failed
         # validation).
@@ -2671,8 +2624,7 @@ class TestVersionAddFile(UploadTest):
     @mock.patch('olympia.editors.helpers.sign_file')
     def test_unlisted_addon_pass_validation(self, mock_sign_file):
         """Files that pass validation are automatically signed/reviewed."""
-        self.addon.update(
-            is_listed=False, status=amo.STATUS_LITE, trusted=False)
+        self.addon.update(is_listed=False, trusted=False)
         # Make sure the file has no validation signing related messages.
         self.upload.update(
             validation='{"notices": 2, "errors": 0, "messages": [],'
@@ -2680,12 +2632,11 @@ class TestVersionAddFile(UploadTest):
                        ' "signing_summary": {"trivial": 1, "low": 0,'
                        '                     "medium": 0, "high": 0},'
                        ' "passed_auto_validation": 1}')
-        assert self.addon.status == amo.STATUS_LITE  # Preliminary reviewed.
+        assert self.addon.status == amo.STATUS_PUBLIC
         self.post()
         file_ = File.objects.latest()
-        # Status is changed to preliminary reviewed and the file is signed.
-        assert self.addon.status == amo.STATUS_LITE
-        assert file_.status == amo.STATUS_LITE
+        assert self.addon.status == amo.STATUS_PUBLIC
+        assert file_.status == amo.STATUS_PUBLIC
         assert mock_sign_file.called
         # There is a log for that unlisted file signature (with passed
         # validation).
@@ -2921,61 +2872,9 @@ class TestAddVersion(AddVersionTest):
         assert f.status != amo.STATUS_BETA
 
     @mock.patch('olympia.editors.helpers.sign_file')
-    def test_unlisted_addon_sideload_fail_validation(self, mock_sign_file):
-        """Sideloadable unlisted addons also get auto signed/reviewed."""
-        assert self.addon.status == amo.STATUS_PUBLIC  # Fully reviewed.
-        self.addon.update(is_listed=False, trusted=False)
-        # Make sure the file has validation warnings or errors.
-        self.upload.update(
-            validation=json.dumps({
-                "notices": 2, "errors": 0, "messages": [],
-                "metadata": {}, "warnings": 1,
-                "signing_summary": {"trivial": 1, "low": 1,
-                                    "medium": 0, "high": 0},
-                "passed_auto_validation": 0}))
-        self.post()
-        file_ = File.objects.latest()
-        # Status is changed to fully reviewed and the file is signed.
-        assert self.addon.status == amo.STATUS_PUBLIC
-        assert file_.status == amo.STATUS_PUBLIC
-        assert mock_sign_file.called
-        # There is a log for that unlisted file signature (with failed
-        # validation).
-        log = ActivityLog.objects.order_by('pk').last()
-        expected = amo.LOG.UNLISTED_SIDELOAD_SIGNED_VALIDATION_FAILED.id
-        assert log.action == expected
-
-    @mock.patch('olympia.editors.helpers.sign_file')
-    def test_unlisted_addon_sideload_pass_validation(self, mock_sign_file):
-        """Sideloadable unlisted addons also get auto signed/reviewed."""
-        assert self.addon.status == amo.STATUS_PUBLIC  # Fully reviewed.
-        self.addon.update(is_listed=False, trusted=False)
-        # Make sure the file has no validation warnings nor errors.
-        self.upload.update(
-            validation=json.dumps({
-                "notices": 2, "errors": 0, "messages": [],
-                "metadata": {}, "warnings": 1,
-                "signing_summary": {"trivial": 1, "low": 0,
-                                    "medium": 0, "high": 0},
-                "passed_auto_validation": 1}))
-        self.post()
-        file_ = File.objects.latest()
-        # Status is changed to fully reviewed and the file is signed.
-        assert self.addon.status == amo.STATUS_PUBLIC
-        assert file_.status == amo.STATUS_PUBLIC
-        assert mock_sign_file.called
-        # There is a log for that unlisted file signature (with failed
-        # validation).
-        log = ActivityLog.objects.order_by('pk').last()
-        expected = amo.LOG.UNLISTED_SIDELOAD_SIGNED_VALIDATION_PASSED.id
-        assert log.action == expected
-
-    @mock.patch('olympia.editors.helpers.sign_file')
     def test_unlisted_addon_fail_validation(self, mock_sign_file):
         """Files that fail validation are also auto signed/reviewed."""
-        self.addon.update(
-            is_listed=False, status=amo.STATUS_LITE, trusted=False)
-        assert self.addon.status == amo.STATUS_LITE  # Preliminary reviewed.
+        self.addon.update(is_listed=False, trusted=False)
         # Make sure the file has validation warnings or errors.
         self.upload.update(
             validation=json.dumps({
@@ -2987,8 +2886,8 @@ class TestAddVersion(AddVersionTest):
         self.post()
         file_ = File.objects.latest()
         # Status is changed to preliminary reviewed and the file is signed.
-        assert self.addon.status == amo.STATUS_LITE
-        assert file_.status == amo.STATUS_LITE
+        assert self.addon.status == amo.STATUS_PUBLIC
+        assert file_.status == amo.STATUS_PUBLIC
         assert mock_sign_file.called
         # There is a log for that unlisted file signature (with failed
         # validation).
@@ -2998,8 +2897,7 @@ class TestAddVersion(AddVersionTest):
     @mock.patch('olympia.editors.helpers.sign_file')
     def test_unlisted_addon_pass_validation(self, mock_sign_file):
         """Files that pass validation are automatically signed/reviewed."""
-        self.addon.update(
-            is_listed=False, status=amo.STATUS_LITE, trusted=False)
+        self.addon.update(is_listed=False, trusted=False)
         # Make sure the file has no validation warnings nor errors.
         self.upload.update(
             validation=json.dumps({
@@ -3008,12 +2906,11 @@ class TestAddVersion(AddVersionTest):
                 "signing_summary": {"trivial": 1, "low": 0,
                                     "medium": 0, "high": 0},
                 "passed_auto_validation": 1}))
-        assert self.addon.status == amo.STATUS_LITE  # Preliminary reviewed.
         self.post()
         file_ = File.objects.latest()
         # Status is changed to preliminary reviewed and the file is signed.
-        assert self.addon.status == amo.STATUS_LITE
-        assert file_.status == amo.STATUS_LITE
+        assert self.addon.status == amo.STATUS_PUBLIC
+        assert file_.status == amo.STATUS_PUBLIC
         assert mock_sign_file.called
         # There is a log for that unlisted file signature (with passed
         # validation).
@@ -3201,10 +3098,10 @@ class TestVersionXSS(UploadTest):
 class UploadAddon(object):
 
     def post(self, supported_platforms=[amo.PLATFORM_ALL], expect_errors=False,
-             source=None, is_listed=True, is_sideload=False, status_code=200):
+             source=None, is_listed=True, status_code=200):
         d = dict(upload=self.upload.uuid, source=source,
                  supported_platforms=[p.id for p in supported_platforms],
-                 is_unlisted=not is_listed, is_sideload=is_sideload)
+                 is_unlisted=not is_listed)
         r = self.client.post(self.url, d, follow=True)
         eq_(r.status_code, status_code)
         if not expect_errors:
@@ -3289,7 +3186,7 @@ class TestCreateAddon(BaseUploadTest, UploadAddon, TestCase):
         self.post(is_listed=False)
         addon = Addon.with_unlisted.get()
         assert not addon.is_listed
-        assert addon.status == amo.STATUS_LITE  # Automatic signing.
+        assert addon.status == amo.STATUS_PUBLIC
         assert mock_sign_file.called
 
     @mock.patch('olympia.editors.helpers.sign_file')
@@ -3307,16 +3204,6 @@ class TestCreateAddon(BaseUploadTest, UploadAddon, TestCase):
         self.post(is_listed=False)
         addon = Addon.with_unlisted.get()
         assert not addon.is_listed
-        assert addon.status == amo.STATUS_LITE  # Prelim review.
-        assert mock_sign_file.called
-
-    @mock.patch('olympia.editors.helpers.sign_file')
-    def test_success_unlisted_sideload(self, mock_sign_file):
-        assert Addon.with_unlisted.count() == 0
-        self.post(is_listed=False, is_sideload=True)
-        addon = Addon.with_unlisted.get()
-        assert not addon.is_listed
-        # Full review for sideload addons.
         assert addon.status == amo.STATUS_PUBLIC
         assert mock_sign_file.called
 

--- a/src/olympia/devhub/tests/test_views_validation.py
+++ b/src/olympia/devhub/tests/test_views_validation.py
@@ -351,20 +351,8 @@ class TestValidateAddon(TestCase):
         self.client.post(self.url, {'upload': data})
         # Make sure it was called with listed=False.
         assert not validate_mock.call_args[1]['listed']
-        # Automated signing enabled for unlisted, non-sideload add-ons.
+        # Automated signing enabled for unlisted add-ons.
         assert FileUpload.objects.get().automated_signing is True
-
-    @mock.patch('validator.validate.validate')
-    def test_upload_sideload_addon(self, validate_mock):
-        """Sideload addons are validated as "self-hosted" addons."""
-        validate_mock.return_value = json.dumps(amo.VALIDATOR_SKELETON_RESULTS)
-        self.url = reverse('devhub.upload_sideload')
-        data = open(get_image_path('animated.png'), 'rb')
-        self.client.post(self.url, {'upload': data})
-        # Make sure it was called with listed=False.
-        assert not validate_mock.call_args[1]['listed']
-        # No automated signing for sideload add-ons.
-        assert FileUpload.objects.get().automated_signing is False
 
 
 class TestUploadURLs(TestCase):
@@ -428,9 +416,6 @@ class TestUploadURLs(TestCase):
         self.upload('devhub.standalone_upload_unlisted'),
         self.expect_validation(listed=False, automated_signing=True)
 
-        self.upload('devhub.standalone_upload_sideload'),
-        self.expect_validation(listed=False, automated_signing=False)
-
     def test_upload_submit(self):
         """Test that the add-on creation upload URLs result in file uploads
         with the correct flags."""
@@ -439,9 +424,6 @@ class TestUploadURLs(TestCase):
 
         self.upload('devhub.upload_unlisted'),
         self.expect_validation(listed=False, automated_signing=True)
-
-        self.upload('devhub.upload_sideload'),
-        self.expect_validation(listed=False, automated_signing=False)
 
     def test_upload_addon_version(self):
         """Test that the add-on update upload URLs result in file uploads

--- a/src/olympia/devhub/urls.py
+++ b/src/olympia/devhub/urls.py
@@ -176,8 +176,6 @@ urlpatterns = decorate(write, patterns(
     url('^feed/%s$' % ADDON_ID, views.feed, name='devhub.feed'),
 
     url('^upload$', views.upload, name='devhub.upload'),
-    url('^upload/sideload$', partial(views.upload, is_listed=False),
-        name='devhub.upload_sideload'),
     url('^upload/unlisted$',
         partial(views.upload, is_listed=False, automated=True),
         name='devhub.upload_unlisted'),
@@ -192,9 +190,6 @@ urlpatterns = decorate(write, patterns(
         partial(views.upload, is_standalone=True, is_listed=False,
                 automated=True),
         name='devhub.standalone_upload_unlisted'),
-    url('^standalone-upload-sideload$',
-        partial(views.upload, is_standalone=True, is_listed=False),
-        name='devhub.standalone_upload_sideload'),
 
     url('^standalone-upload/([^/]+)$', views.standalone_upload_detail,
         name='devhub.standalone_upload_detail'),

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -621,6 +621,7 @@ def handle_upload(filedata, user, app_id=None, version_id=None, addon=None,
         ver = get_object_or_404(AppVersion, pk=version_id)
         tasks.compatibility_check.delay(upload.pk, app.guid, ver.version)
     elif submit:
+        # We're asked to directly submit a new Version with that upload.
         tasks.validate_and_submit(addon, upload, listed=is_listed)
     else:
         tasks.validate(upload, listed=is_listed)
@@ -1239,20 +1240,12 @@ def auto_sign_file(file_, is_beta=False):
         # Provide the file to review/sign to the helper.
         helper.set_data({'addon_files': [file_],
                          'comments': 'automatic validation'})
-        if addon.is_sideload:
-            helper.handler.process_public(auto_validation=True)
-            if validation.passed_auto_validation:
-                amo.log(amo.LOG.UNLISTED_SIDELOAD_SIGNED_VALIDATION_PASSED,
-                        file_)
-            else:
-                amo.log(amo.LOG.UNLISTED_SIDELOAD_SIGNED_VALIDATION_FAILED,
-                        file_)
+        # Automated signing directly sets add-ons as public no matter what.
+        helper.handler.process_public(auto_validation=True)
+        if validation.passed_auto_validation:
+            amo.log(amo.LOG.UNLISTED_SIGNED_VALIDATION_PASSED, file_)
         else:
-            helper.handler.process_preliminary(auto_validation=True)
-            if validation.passed_auto_validation:
-                amo.log(amo.LOG.UNLISTED_SIGNED_VALIDATION_PASSED, file_)
-            else:
-                amo.log(amo.LOG.UNLISTED_SIGNED_VALIDATION_FAILED, file_)
+            amo.log(amo.LOG.UNLISTED_SIGNED_VALIDATION_FAILED, file_)
 
 
 def auto_sign_version(version, **kwargs):
@@ -1442,12 +1435,13 @@ def submit_addon(request, step):
             AddonUser(addon=addon, user=request.user).save()
             check_validation_override(request, form, addon,
                                       addon.current_version)
-            if not addon.is_listed:  # Not listed? Automatically choose queue.
-                if data.get('is_sideload'):  # Full review needed.
-                    addon.update(status=amo.STATUS_NOMINATED)
-                else:  # Otherwise, simply do a prelim review.
-                    addon.update(status=amo.STATUS_UNREVIEWED)
-                # Sign all the files submitted, one for each platform.
+            if not addon.is_listed:
+                # Unlisted add-ons are a bit special: we want them to be
+                # immediately considered "fully reviewed" and have their
+                # files automatically signed. We set the addon as NOMINATED and
+                # call auto_sign_version(), which will set it to public and
+                # do the signing just like reviewer tools would normally do.
+                addon.update(status=amo.STATUS_NOMINATED)
                 auto_sign_version(addon.versions.get())
             SubmitStep.objects.create(addon=addon, step=3)
             return redirect(_step_url(3), addon.slug)

--- a/src/olympia/editors/helpers.py
+++ b/src/olympia/editors/helpers.py
@@ -562,8 +562,6 @@ class ReviewHelper:
                 actions['public'] = {'method': self.handler.process_public,
                                      'minimal': False,
                                      'label': label}
-            # An unlisted sideload add-on, which requests a full review, cannot
-            # be granted a preliminary review.
             if addon.is_listed or self.review_type == 'preliminary':
                 actions['prelim'] = {
                     'method': self.handler.process_preliminary,

--- a/static/css/zamboni/developers.css
+++ b/static/css/zamboni/developers.css
@@ -399,10 +399,7 @@ form.new-addon-file label,
     display: block;
     padding-bottom: 3px;
 }
-form.new-addon-file label[for=id_is_sideload] {
-    display: none;
-    margin-left: 20px;
-}
+
 .submit-license input[type=checkbox] + label {
     display: inline;
     padding-bottom: 0;

--- a/static/js/common/upload-addon.js
+++ b/static/js/common/upload-addon.js
@@ -297,7 +297,6 @@
 
             var $newForm = $('.new-addon-file');
             var $isUnlistedCheckbox = $('#id_is_unlisted');
-            var $isSideloadCheckbox = $('#id_is_sideload');
 
             function isUnlisted() {
               // True if there's a '#id_is_unlisted' checkbox that is checked, or a
@@ -306,19 +305,11 @@
                       (typeof($newForm.data('addon-is-listed')) != 'undefined' && !$newForm.data('addon-is-listed')));
             }
 
-            function isSideload() {
-              // True if there's a '#id_is_sideload' checkbox that is checked, or a
-              // 'addon-is-sideload' data on the new file form that is true.
-              return (($isSideloadCheckbox.length && $isSideloadCheckbox.is(':checked')) ||
-                      (typeof($newForm.data('addon-is-sideload')) != 'undefined' && $newForm.data('addon-is-sideload')));
-            }
-
             // is_unlisted checkbox: should the add-on be listed on AMO? If not,
             // change the addon upload button's data-upload-url.
             // If this add-on is unlisted, then tell the upload view so
             // it'll run the validator with the "listed=False"
             // parameter.
-            var $isSideloadLabel = $('label[for=id_is_sideload]');
             var $submitAddonProgress = $('.submit-addon-progress');
             function updateListedStatus() {
               if (!isUnlisted()) {  // It's a listed add-on.
@@ -328,18 +319,10 @@
                 // doesn't upload to the correct url. Using
                 // .attr('data-upload-url', val) instead fixes that.
                 $upload_field.attr('data-upload-url', $upload_field.data('upload-url-listed'));
-                $isSideloadLabel.hide();
-                $isSideloadCheckbox.prop('checked', false);
-                $submitAddonProgress.removeClass('unlisted');
               } else {  // It's an unlisted add-on.
-                if (isSideload()) {  // It's a sideload add-on.
-                  $upload_field.attr('data-upload-url', $upload_field.data('upload-url-sideload'));
-                } else {
-                  $upload_field.attr('data-upload-url', $upload_field.data('upload-url-unlisted'));
-                }
-                $isSideloadLabel.show();
-                $submitAddonProgress.addClass('unlisted');
+                $upload_field.attr('data-upload-url', $upload_field.data('upload-url-unlisted'));
               }
+              $submitAddonProgress.removeClass('unlisted');
               /* Don't allow submitting, need to reupload/revalidate the file. */
               $('.addon-upload-dependant').prop('disabled', true);
               $('.addon-upload-failure-dependant').prop({'disabled': true,
@@ -347,7 +330,6 @@
               $('.upload-status').remove();
             }
             $isUnlistedCheckbox.bind('change', updateListedStatus);
-            $isSideloadCheckbox.bind('change', updateListedStatus);
             updateListedStatus();
 
             $('#id_is_manual_review').bind('change', function() {
@@ -438,7 +420,6 @@
                     $("<strong>").text(message).appendTo(upload_results);
 
                     // Specific messages for unlisted addons.
-                    var isSideload = $('#id_is_sideload').is(':checked') || $newForm.data('addon-is-sideload');
                     if (isUnlisted()) {
                       $("<p>").text(gettext("Your submission will be automatically signed.")).appendTo(upload_results);
                     }


### PR DESCRIPTION
As a side-effect, all unlisted add-ons are now automatically set to "Fully Reviewed" when they are uploaded. Previously they were either set as "Preliminary Reviewed" *or* "Fully Reviewed" depending on whether they were using sideloading or not.

Fixes mozilla/addons#68