### PR TITLE
Fix font-color + contrast for listing descriptions

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -2050,3 +2050,8 @@ body.editor-tools {
   }
 
 }
+
+.listing .item .desc {
+  color: #777;
+  font-size: 1rem;
+}


### PR DESCRIPTION
Fixes #2274

Before: 

<img width="324" alt="newest_extensions____add-ons_for_firefox" src="https://cloud.githubusercontent.com/assets/1514/14454069/621d482e-0090-11e6-9993-37031ac3ebfa.png">

After: 

<img width="326" alt="newest_extensions____add-ons_for_firefox" src="https://cloud.githubusercontent.com/assets/1514/14454036/3fe44c8a-0090-11e6-90e6-a9bfcc50f2cb.png">



