### PR TITLE
Fix padding for secondary on devhub

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -984,7 +984,7 @@ a.button.release-theme-lock {
 }
 
 .category-landing .secondary,
-section.secondary {
+body:not(.developer-hub) section.secondary {
   .highlight {
     padding: 7px 0 0;
   }


### PR DESCRIPTION
Fixes #2079 

Before:

<img width="575" alt="step_2____developer_hub____add-ons_for_firefox" src="https://cloud.githubusercontent.com/assets/1514/14458101/fd1e7102-00a6-11e6-806d-12058b34853c.png">


After:

<img width="505" alt="step_2____developer_hub____add-ons_for_firefox" src="https://cloud.githubusercontent.com/assets/1514/14458094/edd4cad4-00a6-11e6-8bfb-17400d079ae6.png">
