### PR TITLE
Make SERVICES_URL configurable via environment variable

### DIFF
--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -45,7 +45,8 @@ REDIRECT_SECRET_KEY = env('REDIRECT_SECRET_KEY')
 DOMAIN = env('DOMAIN', default='addons-dev.allizom.org')
 SERVER_EMAIL = 'zdev@addons.mozilla.org'
 SITE_URL = 'https://' + DOMAIN
-SERVICES_URL = 'https://services.addons-dev.allizom.org'
+SERVICES_URL = env('SERVICES_URL',
+                   default='https://services.addons-dev.allizom.org')
 STATIC_URL = 'https://addons-dev-cdn.allizom.org/static/'
 MEDIA_URL = 'https://addons-dev-cdn.allizom.org/user-media/'
 

--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -34,7 +34,8 @@ DOMAIN = env('DOMAIN', default='addons.mozilla.org')
 CRONJOB_LOCK_PREFIX = DOMAIN
 SERVER_EMAIL = 'zprod@addons.mozilla.org'
 SITE_URL = 'https://' + DOMAIN
-SERVICES_URL = 'https://services.addons.mozilla.org'
+SERVICES_URL = env('SERVICES_URL',
+                   default='https://services.addons.mozilla.org')
 STATIC_URL = 'https://addons.cdn.mozilla.net/static/'
 MEDIA_URL = 'https://addons.cdn.mozilla.net/user-media/'
 

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -43,7 +43,8 @@ REDIRECT_SECRET_KEY = env('REDIRECT_SECRET_KEY')
 DOMAIN = env('DOMAIN', default='addons.allizom.org')
 SERVER_EMAIL = 'zstage@addons.mozilla.org'
 SITE_URL = 'https://' + DOMAIN
-SERVICES_URL = 'https://services.addons.allizom.org'
+SERVICES_URL = env('SERVICES_URL',
+                   default='https://services.addons.allizom.org')
 STATIC_URL = 'https://addons-stage-cdn.allizom.org/static/'
 MEDIA_URL = 'https://addons-stage-cdn.allizom.org/user-media/'
 


### PR DESCRIPTION
For bug 1262209 we need to be able to configure SERVICES_URL to be a different endpoint. This will allow us to run services workers with different SERVICES_URL configured.

r?