### PR TITLE
Filter out addons without a current_version in public search API (fix #2306)

### DIFF
--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -90,18 +90,19 @@ class ESAddonSerializer(BaseESSerializer, AddonSerializer):
         """Create a fake instance of Addon and related models from ES data."""
         obj = Addon(id=data['id'], slug=data['slug'], is_listed=True)
 
-        if data['current_version'] and data['current_version']['files']:
-            data_version = data['current_version']
+        data_version = data.get('current_version')
+        if data_version:
             obj._current_version = Version(
                 id=data_version['id'],
                 reviewed=self.handle_date(data_version['reviewed']),
                 version=data_version['version'])
+            data_files = data_version.get('files', [])
             obj._current_version.all_files = [
                 File(
                     id=file_['id'], created=self.handle_date(file_['created']),
                     hash=file_['hash'], filename=file_['filename'],
                     size=file_['size'], status=file_['status'])
-                for file_ in data_version['files']
+                for file_ in data_files
             ]
 
         # Attach base attributes that have the same name/format in ES and in

--- a/src/olympia/search/filters.py
+++ b/src/olympia/search/filters.py
@@ -112,7 +112,8 @@ class PublicContentFilter(BaseFilterBackend):
     """
     def filter_queryset(self, request, qs, view):
         return qs.filter(
-            Bool(must=[F('term', status=amo.REVIEWED_STATUSES)],
+            Bool(must=[F('term', status=amo.REVIEWED_STATUSES),
+                       F('term', has_version=True)],
                  must_not=[F('term', is_deleted=True),
                            F('term', is_listed=False),
                            F('term', is_disabled=True)]))

--- a/src/olympia/search/tests/test_filters.py
+++ b/src/olympia/search/tests/test_filters.py
@@ -101,6 +101,7 @@ class TestPublicContentFilter(FilterTestsBase):
         must_not = qs['query']['filtered']['filter']['bool']['must_not']
 
         assert {'term': {'status': amo.REVIEWED_STATUSES}} in must
+        assert {'term': {'has_version': True}} in must
         assert {'term': {'is_disabled': True}} in must_not
         assert {'term': {'is_deleted': True}} in must_not
         assert {'term': {'is_listed': False}} in must_not


### PR DESCRIPTION
Also add a workaround in the serializer that will be useful for the internal search API, which *will* need to display those addons, even if they don't have a `current_version`.