### PR TITLE
Remove useless browse.views.es_extensions view (fix #2329)

### DIFF
--- a/src/olympia/browse/urls.py
+++ b/src/olympia/browse/urls.py
@@ -58,8 +58,6 @@ urlpatterns = patterns(
 
     url('^extensions/(?:(?P<category>[^/]+)/)?$', views.extensions,
         name='browse.extensions'),
-    url('^es/extensions/(?:(?P<category>[^/]+)/)?$', views.es_extensions,
-        name='browse.es.extensions'),
 
     # Creatured URLs now redirect to browse.extensions
     url('^extensions/(?P<category>[^/]+)/featured$',

--- a/src/olympia/browse/views.py
+++ b/src/olympia/browse/views.py
@@ -197,39 +197,6 @@ def extensions(request, category=None, template=None):
                    'dl_src': dl_src, 'search_cat': '%s,0' % TYPE})
 
 
-@mobile_template('browse/{mobile/}extensions.html')
-@non_atomic_requests
-def es_extensions(request, category=None, template=None):
-    TYPE = amo.ADDON_EXTENSION
-
-    if category is not None:
-        q = Category.objects.filter(application=request.APP.id, type=TYPE)
-        category = get_object_or_404(q, slug=category)
-
-    if ('sort' not in request.GET and not request.MOBILE
-            and category and category.count > 4):
-        return category_landing(request, category)
-
-    qs = (Addon.search().filter(type=TYPE, app=request.APP.id,
-                                is_disabled=False,
-                                status__in=amo.REVIEWED_STATUSES))
-    filter = ESAddonFilter(request, qs, key='sort', default='popular')
-    qs, sorting = filter.qs, filter.field
-    src = 'cb-btn-%s' % sorting
-    dl_src = 'cb-dl-%s' % sorting
-
-    if category:
-        qs = qs.filter(category=category.id)
-    addons = amo.utils.paginate(request, qs)
-
-    return render(request, template,
-                  {'section': 'extensions', 'addon_type': TYPE,
-                   'category': category, 'addons': addons,
-                   'filter': filter, 'sorting': sorting,
-                   'sort_opts': filter.opts, 'src': src,
-                   'dl_src': dl_src, 'search_cat': '%s,0' % TYPE})
-
-
 class CategoryLandingFilter(BaseFilter):
 
     opts = (('featured', _lazy(u'Featured')),


### PR DESCRIPTION
Was added 5 years ago in 79907baf21343a5ad613a7dfaccd72e8ff926872 but never used (though some of the code from that commit survives today in other parts of the site, powering search).