### PR TITLE
Add an install button to theme hovercard (fix #2147)

### DIFF
--- a/src/olympia/addons/templates/addons/impala/persona_grid.html
+++ b/src/olympia/addons/templates/addons/impala/persona_grid.html
@@ -2,19 +2,19 @@
 {% for page in pages %}
   {% set first_page = loop.first %}
   <section>
-  {% for addon in page %}
-    <li>
-      <div class="persona hovercard">
-        <a href="{{ addon.get_url_path() }}">
-          <div class="persona-preview">
-            <img {{ 'src' if first_page else 'data-defer-src' }}="{{ addon.persona.thumb_url }}"
-                 data-browsertheme="{{ addon.persona.json_data }}" alt="">
-          </div>
-          <h3>{{ addon.name }}</h3>
-        </a>
-      </div>
-    </li>
-  {% endfor %}
+    {% for addon in page %}
+      <li>
+        <div class="persona hovercard">
+          <a href="{{ addon.get_url_path() }}">
+            <div class="persona-preview">
+              <img {{ 'src' if first_page else 'data-defer-src' }}="{{ addon.persona.thumb_url }}"
+                   data-browsertheme="{{ addon.persona.json_data }}" alt="">
+            </div>
+            <h3>{{ addon.name }}</h3>
+          </a>
+        </div>
+      </li>
+    {% endfor %}
   </section>
 {% endfor %}
 </ul>

--- a/src/olympia/addons/templates/addons/persona_preview.html
+++ b/src/olympia/addons/templates/addons/persona_preview.html
@@ -85,11 +85,19 @@
   </div>
 {% else %}
   <div class="persona hovercard">
-    <a href="{{ addon.get_url_path() }}">
+    <a href="{{ addon.get_url_path() }}" data-browsertheme="{{ addon.persona.json_data }}" class="persona-info">
       <div class="persona-preview">
         <img src="{{ addon.persona.thumb_url }}"
              data-browsertheme="{{ addon.persona.json_data }}" alt="">
       </div>
+      {% if linked %}
+        <div class="persona-install">
+          <button class="add">
+            <span class="disabled-icon">+</span>
+            <span>{{ _('Add') }}</span>
+          </button>
+        </div>
+      {% endif %}
       <h3>{{ addon.name }}</h3>
     </a>
   </div>

--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -823,7 +823,8 @@ button,
 button.button,
 .button,
 a.button:link,
-input:not(.upvotes):not(.downvotes)[type="submit"] {
+input:not(.upvotes):not(.downvotes)[type="submit"],
+.persona-install button {
   background: #5784bf;
   border: none;
   border-radius: 3px;
@@ -1492,7 +1493,7 @@ h3.author .transfer-ownership {
 .personas-featured .persona-list-3col {
   border: 0;
   min-height: 125px;
-  padding-bottom: 10px;
+  padding-bottom: 20px;
 }
 
 .persona-list-3col {
@@ -1592,12 +1593,31 @@ h3.author .transfer-ownership {
 .persona.hovercard {
   max-width: 200px;
 
+  .persona-install {
+    border: 0;
+    display: none;
+    float: right;
+    margin-top: 3px;
+    padding-bottom: 5px;
+    position: static;
+
+    button {
+      height: auto;
+      padding: 3px;
+    }
+  }
+
   &:hover {
-    margin-bottom: -12px;
-    height: 90px;
+    height: 100px;
+    margin-bottom: -22px;
+
+    .persona-install {
+      display: block;
+    }
   }
 
   h3 {
+    clear: none;
     font-size: 14px;
     margin: 0;
     padding: 6px 0 3px;

--- a/static/js/zamboni/personas.js
+++ b/static/js/zamboni/personas.js
@@ -21,10 +21,17 @@ function initPreviewTheme(mktTheme) {
 
     // Hover thumbnail install buttons.
     $('.persona-install .add').click(_pd(function(e) {
+        var $nearest = $(this).closest('.persona');
+        if ($(this).closest('.persona').find('.persona-preview a').length) {
+          $nearest = $nearest.find('.persona-preview a');
+        } else {
+          $nearest = $nearest.find('a[data-browsertheme]');
+        }
+
         dispatchPersonaEvent(
             'SelectPersona',
-            $(this).closest('.persona').find('.persona-preview a')[0]);
-        var name = $(this).closest('.persona-preview a').data('browsertheme').name;
+            $nearest[0]);
+        var name = $nearest.data('browsertheme').name;
         _gaq.push(['_trackEvent', 'AMO Addon / Theme Installs', 'theme', name]);
     }));
 


### PR DESCRIPTION
Restores the "Add" button to themes.

### Before

<img width="741" alt="screenshot 2016-04-12 18 20 46" src="https://cloud.githubusercontent.com/assets/90871/14469185/5e45087c-00db-11e6-8d7b-52983e6e7667.png">

### After

<img width="743" alt="screenshot 2016-04-12 18 18 31" src="https://cloud.githubusercontent.com/assets/90871/14469189/625867e2-00db-11e6-88fe-44b03481445c.png">