### PR TITLE
Align add button with theme name (fix #2337)

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -1620,7 +1620,7 @@ h3.author .transfer-ownership {
     border: 0;
     display: none;
     float: right;
-    margin-top: 3px;
+    margin-top: 8px;
     padding-bottom: 5px;
     position: static;
 


### PR DESCRIPTION
### Before

<img width="224" alt="screenshot 2016-04-13 11 07 46" src="https://cloud.githubusercontent.com/assets/90871/14489977/ff1d4e44-0167-11e6-87cf-bdefd0174c11.png">

### After

<img width="221" alt="screenshot 2016-04-13 11 07 33" src="https://cloud.githubusercontent.com/assets/90871/14489980/02964602-0168-11e6-938a-7ea9238b68b0.png">