### PR TITLE
Fix footer on stats page (close #2152)

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -84,6 +84,7 @@ body.restyle {
   font-family: @primary-font;
   font-style: normal;
   line-height: 1.5;
+  min-width: @containerWidth;
 }
 
 h1,
@@ -1054,6 +1055,7 @@ body:not(.developer-hub) section.secondary {
   color: #666;
   font-family: inherit;
   font-style: normal;
+  width: 100%;
 
   .links-footer a {
     color: @link-on-color-bg !important;


### PR DESCRIPTION
### Before

![footer](https://cloud.githubusercontent.com/assets/15685960/14489750/9a26e6ca-0177-11e6-80ad-f8ae60b78a31.png)

### After

<img width="853" alt="screenshot 2016-04-13 11 33 25" src="https://cloud.githubusercontent.com/assets/90871/14490635/c461cb50-016b-11e6-90e0-23a9ca7d80ac.png">
<img width="1014" alt="screenshot 2016-04-13 11 33 19" src="https://cloud.githubusercontent.com/assets/90871/14490636/c4657d9a-016b-11e6-9819-1cbfe3d2bc18.png">