### PR TITLE
Index unlisted/deleted add-ons in ElasticSearch.

### DIFF
--- a/src/olympia/addons/cron.py
+++ b/src/olympia/addons/cron.py
@@ -278,9 +278,7 @@ def deliver_hotness():
 @cronjobs.register
 def reindex_addons(index=None, addon_type=None):
     from . import tasks
-    ids = (Addon.with_unlisted.values_list('id', flat=True)
-           .filter(_current_version__isnull=False,
-                   status__in=amo.VALID_STATUSES))
+    ids = Addon.unfiltered.values_list('id', flat=True)
     if addon_type:
         ids = ids.filter(type=addon_type)
     ts = [tasks.index_addons.subtask(args=[chunk], kwargs=dict(index=index))

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -479,9 +479,6 @@ class Addon(OnChangeMixin, ModelBase):
         for preview in previews:
             tasks.delete_preview_files.delay(preview)
 
-        # Remove from search index.
-        tasks.unindex_addons.delay([id])
-
         return True
 
     @classmethod

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -66,9 +66,9 @@ class AddonSerializer(serializers.ModelSerializer):
     class Meta:
         model = Addon
         fields = ('id', 'current_version', 'default_locale', 'description',
-                  'guid', 'homepage', 'name', 'last_updated', 'public_stats',
-                  'slug', 'status', 'summary', 'support_email', 'support_url',
-                  'tags', 'type', 'url')
+                  'guid', 'homepage', 'is_listed', 'name', 'last_updated',
+                  'public_stats', 'slug', 'status', 'summary', 'support_email',
+                  'support_url', 'tags', 'type', 'url')
 
     def get_tags(self, obj):
         if not hasattr(obj, 'tag_list'):

--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -106,7 +106,7 @@ def index_addons(ids, **kw):
     log.info('Indexing addons %s-%s. [%s]' % (ids[0], ids[-1], len(ids)))
     transforms = (attach_categories, attach_tags, attach_translations)
     index_objects(ids, Addon, AddonIndexer.extract_document,
-                  kw.pop('index', None), transforms, Addon.with_unlisted)
+                  kw.pop('index', None), transforms, Addon.unfiltered)
 
 
 @task

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -63,6 +63,7 @@ class AddonSerializerOutputTestMixin(object):
         assert result['description'] == {'en-US': self.addon.description}
         assert result['guid'] == self.addon.guid
         assert result['homepage'] == {'en-US': self.addon.homepage}
+        assert result['is_listed'] == self.addon.is_listed
         assert result['name'] == {'en-US': self.addon.name}
         assert result['last_updated'] == self.addon.last_updated.isoformat()
         assert result['public_stats'] == self.addon.public_stats
@@ -99,6 +100,21 @@ class AddonSerializerOutputTestMixin(object):
         assert result['current_version']['reviewed'] == version.reviewed
         assert result['current_version']['version'] == version.version
         assert result['current_version']['files'] == []
+
+    def test_deleted(self):
+        self.addon = addon_factory(name=u'My Deleted Addôn')
+        self.addon.delete()
+        result = self.serialize()
+
+        assert result['id'] == self.addon.pk
+        assert result['status'] == self.addon.get_status_display()
+
+    def test_unlisted(self):
+        self.addon = addon_factory(name=u'My Unlisted Addôn', is_listed=False)
+        result = self.serialize()
+
+        assert result['id'] == self.addon.pk
+        assert result['is_listed'] == self.addon.is_listed
 
     def test_translations(self):
         translated_descriptions = {

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -852,7 +852,7 @@ class ESTestCase(TestCase):
     @classmethod
     def reindex(cls, model, index='default'):
         # Emit post-save signal so all of the objects get reindexed.
-        manager = getattr(model, 'unfiltered', getattr(model, 'objects'))
+        manager = getattr(model, 'unfiltered', model.objects)
         [o.save() for o in manager.all()]
         cls.refresh(index)
 

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -852,7 +852,8 @@ class ESTestCase(TestCase):
     @classmethod
     def reindex(cls, model, index='default'):
         # Emit post-save signal so all of the objects get reindexed.
-        [o.save() for o in model.objects.all()]
+        manager = getattr(model, 'unfiltered', getattr(model, 'objects'))
+        [o.save() for o in manager.all()]
         cls.refresh(index)
 
     @classmethod

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -205,8 +205,7 @@ class TestVersion(TestCase):
         msg = entry.to_string()
         assert self.addon.name.__unicode__() in msg, ("Unexpected: %r" % msg)
 
-    @mock.patch('olympia.devhub.views.unindex_addons')
-    def test_user_can_unlist_addon(self, unindex):
+    def test_user_can_unlist_addon(self):
         self.addon.update(status=amo.STATUS_PUBLIC, disabled_by_user=False,
                           is_listed=True)
         res = self.client.post(self.unlist_url)
@@ -215,16 +214,12 @@ class TestVersion(TestCase):
         assert addon.status == amo.STATUS_PUBLIC
         assert not addon.is_listed
 
-        # Make sure we remove the addon from the search index.
-        assert unindex.delay.called
-
         entry = ActivityLog.objects.get()
         assert entry.action == amo.LOG.ADDON_UNLISTED.id
         msg = entry.to_string()
         assert self.addon.name.__unicode__() in msg
 
-    @mock.patch('olympia.devhub.views.unindex_addons')
-    def test_user_can_unlist_hidden_addon(self, unindex):
+    def test_user_can_unlist_hidden_addon(self):
         self.addon.update(status=amo.STATUS_PUBLIC, disabled_by_user=True,
                           is_listed=True)
         res = self.client.post(self.unlist_url)
@@ -233,9 +228,6 @@ class TestVersion(TestCase):
         assert addon.status == amo.STATUS_PUBLIC
         assert not addon.is_listed
         assert not addon.disabled_by_user
-
-        # Make sure we remove the addon from the search index.
-        assert unindex.delay.called
 
         entry = ActivityLog.objects.get()
         assert entry.action == amo.LOG.ADDON_UNLISTED.id

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -32,7 +32,6 @@ from olympia.access import acl
 from olympia.addons import forms as addon_forms
 from olympia.addons.decorators import addon_view
 from olympia.addons.models import Addon, AddonUser
-from olympia.addons.tasks import unindex_addons
 from olympia.addons.views import BaseFilter
 from olympia.amo import messages
 from olympia.amo.decorators import json_view, login_required, post_required
@@ -404,7 +403,6 @@ def disable(request, addon_id, addon):
 def unlist(request, addon_id, addon):
     addon.update(is_listed=False, disabled_by_user=False)
     amo.log(amo.LOG.ADDON_UNLISTED, addon)
-    unindex_addons.delay([addon.id])
     return redirect(addon.get_dev_url('versions'))
 
 

--- a/src/olympia/legacy_api/tests/test_views.py
+++ b/src/olympia/legacy_api/tests/test_views.py
@@ -996,6 +996,18 @@ class SearchTest(ESTestCase):
         self.assertContains(response, """<searchresults total_results="3">""")
         self.assertContains(response, "</addon>", 1)
 
+    def test_unlisted_are_ignored(self):
+        """
+        Test that unlisted add-ons are not shown.
+        """
+        addon = Addon.objects.get(pk=3615)
+        addon.update(is_listed=False)
+        self.refresh()
+        response = self.client.get(
+            "/en-US/firefox/api/1.2/search/delicious")
+        self.assertContains(response, """<searchresults total_results="0">""")
+        self.assertContains(response, "</addon>", 0)
+
     def test_compat_mode_url(self):
         """
         Test the compatMode paramenter in the URL is optional and only accepts

--- a/src/olympia/legacy_api/views.py
+++ b/src/olympia/legacy_api/views.py
@@ -343,6 +343,7 @@ class SearchView(APIView):
         filters = {
             'app': app_id,
             'status': amo.STATUS_PUBLIC,
+            'is_listed': True,
             'is_disabled': False,
             'has_version': True,
         }


### PR DESCRIPTION
This is in preparation of #1914, for which we'll need to be able to search for deleted/unlisted add-ons.

This was already half-implemented, with most of the code already filtering them out (as it should for public-facing pages), even testing listed add-ons would not appear, but not always.