### PR TITLE
Fix column width on reviews page

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -997,6 +997,7 @@ a.button.release-theme-lock {
 }
 
 .addon-details .secondary,
+.reviews .secondary,
 .category-landing .secondary,
 body:not(.developer-hub) section.secondary {
   .highlight {


### PR DESCRIPTION
Fixes #2353 

This is what it looks like with the fix:

![fastest_search____reviews____add-ons_for_firefox](https://cloud.githubusercontent.com/assets/1514/14504929/c9ed2b80-01ae-11e6-97a0-8bf76762e8e1.png)