### PR TITLE
Modify the opacity of unsupported add-ons (fix #2289)

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -2148,9 +2148,15 @@ body.editor-tools {
 
 }
 
-.listing .item .desc {
-  color: #777;
-  font-size: 1rem;
+.listing .item {
+  // Because these are `display: table-row` this acts as a min-height.
+  // Prevents weird hover effects when an add-on has no description.
+  height: 95px;
+
+  .desc {
+    color: #777;
+    font-size: 1rem;
+  }
 }
 
 /* Source/Diff viewer */

--- a/static/js/zamboni/buttons.js
+++ b/static/js/zamboni/buttons.js
@@ -274,6 +274,7 @@ var installButton = function() {
             warn(gettext('Not available for your platform'));
             $button.addClass('concealed');
             $button.first().css('display', 'inherit');
+            $button.closest('.item.addon').addClass('incompatible');
         }
 
         if (appSupported && !compatible && (olderBrowser || newerBrowser)) {
@@ -290,6 +291,7 @@ var installButton = function() {
                 }
                 $button.closest('div').attr('data-version-supported', false);
                 $button.addClass('concealed');
+                $button.closest('.item.addon').addClass('incompatible');
 
                 var $ishell = $button.closest('.install-shell');
                 if (!compatible && $d2c_reasons.children().length) {
@@ -323,6 +325,7 @@ var installButton = function() {
                             [z.appName, z.browserVersion]));
                 $button.closest('div').attr('data-version-supported', false);
                 $button.addClass('concealed');
+                $button.closest('.item.addon').addClass('incompatible');
                 if (!opts.addPopup) return;
 
                 if (badPlatform && olderBrowser) {


### PR DESCRIPTION
### Before

<img width="759" alt="screenshot 2016-04-13 19 44 19" src="https://cloud.githubusercontent.com/assets/90871/14505220/25addae0-01b0-11e6-8e62-ea6cfb7f08f9.png">

### After

<img width="1350" alt="screenshot 2016-04-13 19 26 51" src="https://cloud.githubusercontent.com/assets/90871/14505110/aa3686dc-01af-11e6-966e-eb3e2ebd459d.png">
<img width="1350" alt="screenshot 2016-04-13 19 26 47" src="https://cloud.githubusercontent.com/assets/90871/14505111/aa59f5cc-01af-11e6-9952-0ff6ea09d8d5.png">
