### PR TITLE
Restored install button for unsupported add-on (fix #2288)

### DIFF
--- a/src/olympia/addons/templates/addons/popups.html
+++ b/src/olympia/addons/templates/addons/popups.html
@@ -20,7 +20,7 @@
     {% endtrans %}</p>
     <p><a href="{{ app_url }}" class="button">{{ _('Learn more about Firefox') }}</a></p>
     <p>{% trans %}
-      or <b><a class="installer" href="{url}">download anyway</a></b>
+      or <b><a class="button installer" href="{url}">download anyway</a></b>
     {% endtrans %}</p>
   {% elif APP == amo.THUNDERBIRD %}
     <p class="msg m-learn-more">{% trans %}
@@ -127,7 +127,7 @@
 
 {% macro platform_link() %}
 {# js vars: href, msg #}
-  <li><a class="installer" href="{href}">{msg}</a></li>
+  <li><a class="button installer" href="{href}">{msg}</a></li>
 {% endmacro %}
 
 {% macro not_compatible() %}

--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -882,8 +882,11 @@ input:not(.upvotes):not(.downvotes)[type="submit"],
   }
 
   &.disabled,
-  &:disabled {
+  &:disabled,
+  &.concealed {
     background: #ccc;
+    box-shadow: 0 2px 0 0 rgba(0, 0, 0, 0.10),
+          inset 0 -2px 0 0 rgba(136, 136, 136, 0.50);
     text-shadow: none;
 
     &:hover {
@@ -1670,14 +1673,8 @@ h3.author .transfer-ownership {
 }
 
 // Install buttons
-.install-button .concealed {
-  // This is display: none !important because JS modifies the element's
-  // CSS directly.
-  display: none !important;
-
-  &.CTA {
-    display: block !important;
-  }
+.install-button .concealed.CTA {
+  display: block !important;
 }
 
 .extra .button.not-available {


### PR DESCRIPTION
### Before

<img width="1350" alt="screenshot 2016-04-13 19 43 38" src="https://cloud.githubusercontent.com/assets/90871/14505205/0debb6b6-01b0-11e6-826d-e7d018256692.png">
<img width="759" alt="screenshot 2016-04-13 19 44 19" src="https://cloud.githubusercontent.com/assets/90871/14505220/25addae0-01b0-11e6-8e62-ea6cfb7f08f9.png">

### After

<img width="1350" alt="screenshot 2016-04-13 19 33 03" src="https://cloud.githubusercontent.com/assets/90871/14505167/e54c694e-01af-11e6-8343-19e2bd3e7d8e.png">
<img width="747" alt="screenshot 2016-04-13 19 45 40" src="https://cloud.githubusercontent.com/assets/90871/14505264/5328a194-01b0-11e6-8ca7-a3c313dd3308.png">
