### PR TITLE
Fix third and sixth item hover in featured section (fix #2227)

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -1516,7 +1516,7 @@ h3.author .transfer-ownership {
     position: relative;
 
     &:nth-of-type(3n) .persona.hovercard:hover {
-      margin-bottom: -3px;
+      margin-bottom: -14px;
     }
   }
 


### PR DESCRIPTION
Prevents the content being pushed down when the final item in the row of featured themes is hovered over.

### Before

![apr-13-2016 20-52-08](https://cloud.githubusercontent.com/assets/90871/14507260/b4439b06-01b9-11e6-8a0b-a9c7fe070b85.gif)

### After

![apr-13-2016 20-47-38](https://cloud.githubusercontent.com/assets/90871/14507266/ba3f6742-01b9-11e6-9e1c-7836c20a313b.gif)