### PR TITLE
Finally fix third/sixth featured hovercard theme (fix #2227)

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -1515,8 +1515,13 @@ h3.author .transfer-ownership {
     padding: 0.6em 0 0;
     position: relative;
 
-    &:nth-of-type(3n) .persona.hovercard:hover {
-      margin-bottom: -14px;
+    &:nth-of-type(3n) .persona.hovercard:hover,
+    &:nth-of-type(3n) .persona.hovercard:focus {
+      margin-bottom: -14.5px;
+    }
+
+    &:nth-of-type(4n) .persona.hovercard {
+      clear: both;
     }
   }
 


### PR DESCRIPTION
So you were right, but looks like `14.5px` is actually perfect. I tried that before but it moved the content. Then I remembered `clear`, because I'm dumb.

So yeah, this should finally fix it.

### Before

![apr-14-2016 10-44-39](https://cloud.githubusercontent.com/assets/90871/14523973/15451b36-022e-11e6-9287-39ab4458e590.gif)

(Notice the slight shifting of the content)

### After

![apr-14-2016 10-44-02](https://cloud.githubusercontent.com/assets/90871/14523978/19114190-022e-11e6-972f-22389b9bfd8b.gif)