### PR TITLE
Fix release theme locks button

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -947,9 +947,19 @@ input:not(.upvotes):not(.downvotes)[type="submit"],
 }
 
 a.button.release-theme-lock {
+  bottom: 4px;
   position: absolute;
+  right: 0;
+  top: -14px;
+  z-index: 10;
+
   span {
     top: 0;
+  }
+
+  &:active {
+    bottom: 2px;
+    top: -12px;
   }
 }
 


### PR DESCRIPTION
Fixes: #2168

The old styles used absolute positioning including bottom being set differently when active. This updates the absolute positioning so the button moves more as expected when click e.g. just down byt 2px not being truncated.

![editor_tools____add-ons_for_firefox](https://cloud.githubusercontent.com/assets/1514/14526702/0ffe49fe-023d-11e6-873d-a4a7b509ad1a.png)
