### PR TITLE
Fix header regression (fix #2373)

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -159,7 +159,7 @@ button.link:active span {
 }
 
 .amo-header,
-.primary:not(.island.more-island),
+.primary:not(.more-island),
 .secondary {
   &::after {
     clear: both;


### PR DESCRIPTION
I went a bit too crazy with the `:not` selector. This preserves the version fix but doesn't blank out the header :smile: 

### Before

<img width="1350" alt="screenshot 2016-04-14 13 05 15" src="https://cloud.githubusercontent.com/assets/90871/14527400/9074945e-0241-11e6-8cb5-27f11eb4b713.png">

### After

<img width="1350" alt="screenshot 2016-04-14 13 05 01" src="https://cloud.githubusercontent.com/assets/90871/14527399/8de8d7cc-0241-11e6-80b9-5eadedcd501e.png">