### PR TITLE
Don't use height on listing items (fix #2379)

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -2168,10 +2168,6 @@ body.editor-tools {
 }
 
 .listing .item {
-  // Because these are `display: table-row` this acts as a min-height.
-  // Prevents weird hover effects when an add-on has no description.
-  height: 95px;
-
   .desc {
     color: #777;
     font-size: 1rem;


### PR DESCRIPTION
Setting this height attribute fixed a largely development-case of an add-on with NO description growing in height by about 10px on hover, but that in practice never happens. It caused a regression though, so we'll have to live with this oddness on local dev for now.

### Before

<img width="745" alt="screenshot 2016-04-14 16 39 23" src="https://cloud.githubusercontent.com/assets/90871/14534085/98fa30d4-025f-11e6-9e6a-cf38d86cdcba.png">

### After

<img width="762" alt="screenshot 2016-04-14 16 38 42" src="https://cloud.githubusercontent.com/assets/90871/14534089/9ef05d74-025f-11e6-8528-aa44e188bb23.png">