### PR TITLE
Revert "Remove sideloading distinction when uploading add-ons" (fix #2388)

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -605,6 +605,11 @@ class Addon(OnChangeMixin, ModelBase):
         # with on a file-by-file basis.
         return not self.is_listed
 
+    @property
+    def is_sideload(self):
+        # An add-on can side-load if it has been fully reviewed.
+        return self.status in (amo.STATUS_NOMINATED, amo.STATUS_PUBLIC)
+
     @amo.cached_property(writable=True)
     def listed_authors(self):
         return UserProfile.objects.filter(

--- a/src/olympia/devhub/forms.py
+++ b/src/olympia/devhub/forms.py
@@ -538,6 +538,15 @@ class NewAddonForm(AddonUploadForm):
         help_text=_lazy(
             u'Check this option if you intend to distribute your add-on on '
             u'your own and only need it to be signed by Mozilla.'))
+    is_sideload = forms.BooleanField(
+        initial=False,
+        required=False,
+        label=_lazy(u'This add-on will be bundled with an application '
+                    u'installer.'),
+        help_text=_lazy(u'Add-ons that are bundled with application '
+                        u'installers will be code reviewed '
+                        u'by Mozilla before they are signed and are held to a '
+                        u'higher quality standard.'))
 
     def clean(self):
         if not self.errors:

--- a/src/olympia/devhub/tasks.py
+++ b/src/olympia/devhub/tasks.py
@@ -63,8 +63,6 @@ def validate(file_, listed=None, subtask=None):
 
 
 def validate_and_submit(addon, file_, listed=None):
-    """Validate a file upload, then directly submit a new version from that
-    upload."""
     return validate(file_, listed=listed,
                     subtask=submit_file.si(addon.pk, file_.pk))
 
@@ -96,21 +94,16 @@ def create_version_for_upload(addon, upload):
 
         log.info('Creating version for {upload_uuid} that passed '
                  'validation'.format(upload_uuid=upload.uuid))
-        beta = (addon.is_listed and
-                bool(upload.version) and is_beta(upload.version))
+        beta = bool(upload.version) and is_beta(upload.version)
         version = Version.from_upload(
             upload, addon, [amo.PLATFORM_ALL.id], is_beta=beta)
         # The add-on's status will be STATUS_NULL when its first version is
         # created because the version has no files when it gets added and it
         # gets flagged as invalid. We need to manually set the status.
-        #
-        # Note: this assumes the developer wants a full review. This makes
-        # sense for now because this function is only called from
-        # submit_file(), which is itself only called from the signing API,
-        # which only supports unlisted add-ons, and unlisted add-ons are
-        # supposed to automatically be set as fully reviewed once signed.
+        # TODO: Handle sideload add-ons. This assumes the user wants a prelim
+        # review since listed and sideload aren't supported for creation yet.
         if addon.status == amo.STATUS_NULL:
-            addon.update(status=amo.STATUS_NOMINATED)
+            addon.update(status=amo.STATUS_LITE)
         auto_sign_version(version, is_beta=version.is_beta)
 
 

--- a/src/olympia/devhub/templates/devhub/addons/submit/upload.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/upload.html
@@ -28,13 +28,19 @@
         <span class="tip tooltip"
               title="{{ new_addon_form.is_unlisted.help_text }}">?</span>
       </label>
+      <label for="{{ new_addon_form.is_sideload.auto_id }}">
+        {{ new_addon_form.is_sideload }}
+        {{ new_addon_form.is_sideload.label }}
+        <span class="tip tooltip"
+              title="{{ new_addon_form.is_sideload.help_text }}">?</span>
+      </label>
     </div>
   </div>
   <input type="file" id="upload-addon"
     data-upload-url="{{ url('devhub.upload') }}"
     data-upload-url-listed="{{ url('devhub.upload') }}"
     data-upload-url-unlisted="{{ url('devhub.upload_unlisted') }}"
-  >
+    data-upload-url-sideload="{{ url('devhub.upload_sideload') }}">
 
   {{ new_addon_form.non_field_errors() }}
 

--- a/src/olympia/devhub/templates/devhub/validate_addon.html
+++ b/src/olympia/devhub/templates/devhub/validate_addon.html
@@ -47,6 +47,12 @@
           <span class="tip tooltip"
                 title="{{ new_addon_form.is_unlisted.help_text }}">?</span>
         </label>
+        <label for="{{ new_addon_form.is_sideload.auto_id }}">
+          {{ new_addon_form.is_sideload }}
+          {{ new_addon_form.is_sideload.label }}
+          <span class="tip tooltip"
+                title="{{ new_addon_form.is_sideload.help_text }}">?</span>
+        </label>
       </div>
     </div>
 
@@ -54,7 +60,7 @@
       data-upload-url="{{ url('devhub.standalone_upload') }}"
       data-upload-url-listed="{{ url('devhub.standalone_upload') }}"
       data-upload-url-unlisted="{{ url('devhub.standalone_upload_unlisted') }}"
-    >
+      data-upload-url-sideload="{{ url('devhub.standalone_upload_sideload') }}">
 
   </section>
 </form>

--- a/src/olympia/devhub/templates/devhub/versions/add_file_modal.html
+++ b/src/olympia/devhub/templates/devhub/versions/add_file_modal.html
@@ -1,6 +1,7 @@
 <div class="add-file-modal upload-file modal hidden">
   <form method="post" id="upload-file" class="new-addon-file" action="{{ action }}" enctype="multipart/form-data"
-    data-addon-is-listed="{% if addon.is_listed %}true{% else %}false{% endif %}">
+    data-addon-is-listed="{% if addon.is_listed %}true{% else %}false{% endif %}"
+    data-addon-is-sideload="{% if not addon.is_listed and addon.status in [amo.STATUS_PUBLIC, amo.STATUS_NOMINATED] %}true{% else %}false{% endif %}">
     <h3>{{ title }}</h3>
     <div class="upload-file-box">
       <p>

--- a/src/olympia/devhub/urls.py
+++ b/src/olympia/devhub/urls.py
@@ -176,6 +176,8 @@ urlpatterns = decorate(write, patterns(
     url('^feed/%s$' % ADDON_ID, views.feed, name='devhub.feed'),
 
     url('^upload$', views.upload, name='devhub.upload'),
+    url('^upload/sideload$', partial(views.upload, is_listed=False),
+        name='devhub.upload_sideload'),
     url('^upload/unlisted$',
         partial(views.upload, is_listed=False, automated=True),
         name='devhub.upload_unlisted'),
@@ -190,6 +192,9 @@ urlpatterns = decorate(write, patterns(
         partial(views.upload, is_standalone=True, is_listed=False,
                 automated=True),
         name='devhub.standalone_upload_unlisted'),
+    url('^standalone-upload-sideload$',
+        partial(views.upload, is_standalone=True, is_listed=False),
+        name='devhub.standalone_upload_sideload'),
 
     url('^standalone-upload/([^/]+)$', views.standalone_upload_detail,
         name='devhub.standalone_upload_detail'),

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -619,7 +619,6 @@ def handle_upload(filedata, user, app_id=None, version_id=None, addon=None,
         ver = get_object_or_404(AppVersion, pk=version_id)
         tasks.compatibility_check.delay(upload.pk, app.guid, ver.version)
     elif submit:
-        # We're asked to directly submit a new Version with that upload.
         tasks.validate_and_submit(addon, upload, listed=is_listed)
     else:
         tasks.validate(upload, listed=is_listed)
@@ -1238,12 +1237,20 @@ def auto_sign_file(file_, is_beta=False):
         # Provide the file to review/sign to the helper.
         helper.set_data({'addon_files': [file_],
                          'comments': 'automatic validation'})
-        # Automated signing directly sets add-ons as public no matter what.
-        helper.handler.process_public(auto_validation=True)
-        if validation.passed_auto_validation:
-            amo.log(amo.LOG.UNLISTED_SIGNED_VALIDATION_PASSED, file_)
+        if addon.is_sideload:
+            helper.handler.process_public(auto_validation=True)
+            if validation.passed_auto_validation:
+                amo.log(amo.LOG.UNLISTED_SIDELOAD_SIGNED_VALIDATION_PASSED,
+                        file_)
+            else:
+                amo.log(amo.LOG.UNLISTED_SIDELOAD_SIGNED_VALIDATION_FAILED,
+                        file_)
         else:
-            amo.log(amo.LOG.UNLISTED_SIGNED_VALIDATION_FAILED, file_)
+            helper.handler.process_preliminary(auto_validation=True)
+            if validation.passed_auto_validation:
+                amo.log(amo.LOG.UNLISTED_SIGNED_VALIDATION_PASSED, file_)
+            else:
+                amo.log(amo.LOG.UNLISTED_SIGNED_VALIDATION_FAILED, file_)
 
 
 def auto_sign_version(version, **kwargs):
@@ -1433,13 +1440,12 @@ def submit_addon(request, step):
             AddonUser(addon=addon, user=request.user).save()
             check_validation_override(request, form, addon,
                                       addon.current_version)
-            if not addon.is_listed:
-                # Unlisted add-ons are a bit special: we want them to be
-                # immediately considered "fully reviewed" and have their
-                # files automatically signed. We set the addon as NOMINATED and
-                # call auto_sign_version(), which will set it to public and
-                # do the signing just like reviewer tools would normally do.
-                addon.update(status=amo.STATUS_NOMINATED)
+            if not addon.is_listed:  # Not listed? Automatically choose queue.
+                if data.get('is_sideload'):  # Full review needed.
+                    addon.update(status=amo.STATUS_NOMINATED)
+                else:  # Otherwise, simply do a prelim review.
+                    addon.update(status=amo.STATUS_UNREVIEWED)
+                # Sign all the files submitted, one for each platform.
                 auto_sign_version(addon.versions.get())
             SubmitStep.objects.create(addon=addon, step=3)
             return redirect(_step_url(3), addon.slug)

--- a/src/olympia/editors/helpers.py
+++ b/src/olympia/editors/helpers.py
@@ -564,6 +564,8 @@ class ReviewHelper:
                 actions['public'] = {'method': self.handler.process_public,
                                      'minimal': False,
                                      'label': label}
+            # An unlisted sideload add-on, which requests a full review, cannot
+            # be granted a preliminary review.
             if addon.is_listed or self.review_type == 'preliminary':
                 actions['prelim'] = {
                     'method': self.handler.process_preliminary,

--- a/src/olympia/signing/tests/test_views.py
+++ b/src/olympia/signing/tests/test_views.py
@@ -81,7 +81,7 @@ class TestUploadVersion(BaseUploadVersionCase):
         assert 'website maintenance' in response.data['error']
 
     @mock.patch('olympia.devhub.views.auto_sign_version')
-    def test_addon_is_created_if_it_does_not_already_exist(self, sign_version):
+    def test_addon_does_not_exist(self, sign_version):
         guid = '@create-version'
         qs = Addon.unfiltered.filter(guid=guid)
         assert not qs.exists()
@@ -91,10 +91,7 @@ class TestUploadVersion(BaseUploadVersionCase):
         addon = qs.get()
         assert addon.has_author(self.user)
         assert not addon.is_listed
-        # This is the addon status we expect to have *before* entering
-        # auto_sign_version() - because it's mocked here, we don't get the
-        # actual status we would get without the mocks, which is STATUS_PUBLIC.
-        assert addon.status == amo.STATUS_NOMINATED
+        assert addon.status == amo.STATUS_LITE
         sign_version.assert_called_with(addon.latest_version, is_beta=False)
 
     def test_user_does_not_own_addon(self):
@@ -191,10 +188,7 @@ class TestUploadVersion(BaseUploadVersionCase):
         addon = qs.get()
         assert addon.has_author(self.user)
         assert not addon.is_listed
-        # This is the addon status we expect to have *before* entering
-        # auto_sign_version() - because it's mocked here, we don't get the
-        # actual status we would get without the mocks, which is STATUS_PUBLIC.
-        assert addon.status == amo.STATUS_NOMINATED
+        assert addon.status == amo.STATUS_LITE
         sign_version.assert_called_with(addon.latest_version, is_beta=False)
 
     @mock.patch('olympia.devhub.views.auto_sign_version')
@@ -212,7 +206,7 @@ class TestUploadVersion(BaseUploadVersionCase):
     @mock.patch('olympia.devhub.views.auto_sign_version')
     def test_version_is_beta_unlisted(self, sign_version):
         Addon.objects.get(guid=self.guid).update(
-            is_listed=False, trusted=False)
+            status=amo.STATUS_LITE, is_listed=False)
         version_string = '4.0-beta1'
         qs = Version.objects.filter(
             addon__guid=self.guid, version=version_string)
@@ -225,13 +219,10 @@ class TestUploadVersion(BaseUploadVersionCase):
 
         version = qs.get()
         assert version.addon.guid == self.guid
-        assert not version.is_beta
         assert version.version == version_string
-        # This is the version status we expect to have *before* entering
-        # auto_sign_version() - because it's mocked here, we don't get the
-        # actual status we would get without the mocks, which is STATUS_PUBLIC.
-        assert version.statuses[0][1] == amo.STATUS_UNREVIEWED
-        assert version.addon.status == amo.STATUS_PUBLIC
+        assert version.statuses[0][1] == amo.STATUS_LITE
+        assert version.addon.status == amo.STATUS_LITE
+        assert not version.is_beta
         sign_version.assert_called_with(version, is_beta=False)
 
     @mock.patch('olympia.devhub.views.auto_sign_version')

--- a/static/css/zamboni/developers.css
+++ b/static/css/zamboni/developers.css
@@ -399,7 +399,10 @@ form.new-addon-file label,
     display: block;
     padding-bottom: 3px;
 }
-
+form.new-addon-file label[for=id_is_sideload] {
+    display: none;
+    margin-left: 20px;
+}
 .submit-license input[type=checkbox] + label {
     display: inline;
     padding-bottom: 0;

--- a/static/js/common/upload-addon.js
+++ b/static/js/common/upload-addon.js
@@ -297,6 +297,7 @@
 
             var $newForm = $('.new-addon-file');
             var $isUnlistedCheckbox = $('#id_is_unlisted');
+            var $isSideloadCheckbox = $('#id_is_sideload');
 
             function isUnlisted() {
               // True if there's a '#id_is_unlisted' checkbox that is checked, or a
@@ -305,11 +306,19 @@
                       (typeof($newForm.data('addon-is-listed')) != 'undefined' && !$newForm.data('addon-is-listed')));
             }
 
+            function isSideload() {
+              // True if there's a '#id_is_sideload' checkbox that is checked, or a
+              // 'addon-is-sideload' data on the new file form that is true.
+              return (($isSideloadCheckbox.length && $isSideloadCheckbox.is(':checked')) ||
+                      (typeof($newForm.data('addon-is-sideload')) != 'undefined' && $newForm.data('addon-is-sideload')));
+            }
+
             // is_unlisted checkbox: should the add-on be listed on AMO? If not,
             // change the addon upload button's data-upload-url.
             // If this add-on is unlisted, then tell the upload view so
             // it'll run the validator with the "listed=False"
             // parameter.
+            var $isSideloadLabel = $('label[for=id_is_sideload]');
             var $submitAddonProgress = $('.submit-addon-progress');
             function updateListedStatus() {
               if (!isUnlisted()) {  // It's a listed add-on.
@@ -319,10 +328,18 @@
                 // doesn't upload to the correct url. Using
                 // .attr('data-upload-url', val) instead fixes that.
                 $upload_field.attr('data-upload-url', $upload_field.data('upload-url-listed'));
+                $isSideloadLabel.hide();
+                $isSideloadCheckbox.prop('checked', false);
+                $submitAddonProgress.removeClass('unlisted');
               } else {  // It's an unlisted add-on.
-                $upload_field.attr('data-upload-url', $upload_field.data('upload-url-unlisted'));
+                if (isSideload()) {  // It's a sideload add-on.
+                  $upload_field.attr('data-upload-url', $upload_field.data('upload-url-sideload'));
+                } else {
+                  $upload_field.attr('data-upload-url', $upload_field.data('upload-url-unlisted'));
+                }
+                $isSideloadLabel.show();
+                $submitAddonProgress.addClass('unlisted');
               }
-              $submitAddonProgress.removeClass('unlisted');
               /* Don't allow submitting, need to reupload/revalidate the file. */
               $('.addon-upload-dependant').prop('disabled', true);
               $('.addon-upload-failure-dependant').prop({'disabled': true,
@@ -330,6 +347,7 @@
               $('.upload-status').remove();
             }
             $isUnlistedCheckbox.bind('change', updateListedStatus);
+            $isSideloadCheckbox.bind('change', updateListedStatus);
             updateListedStatus();
 
             $('#id_is_manual_review').bind('change', function() {
@@ -420,6 +438,7 @@
                     $("<strong>").text(message).appendTo(upload_results);
 
                     // Specific messages for unlisted addons.
+                    var isSideload = $('#id_is_sideload').is(':checked') || $newForm.data('addon-is-sideload');
                     if (isUnlisted()) {
                       $("<p>").text(gettext("Your submission will be automatically signed.")).appendTo(upload_results);
                     }


### PR DESCRIPTION
Reverts mozilla/addons-server#2276

See https://github.com/mozilla/addons-server/issues/2388#issuecomment-210403211