### PR TITLE
Make category in "other add-ons" section visible (fix #2384)

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -1244,7 +1244,6 @@ h3.author .transfer-ownership {
   .notice p,
   .notice p a,
   .notice p b,
-  .category.more-info,
   .vital a,
   .warning a,
   #addon-summary,


### PR DESCRIPTION
### Before

<img width="1350" alt="screenshot 2016-04-15 14 06 07" src="https://cloud.githubusercontent.com/assets/90871/14562211/4f4811b8-0313-11e6-8e8f-0354745385aa.png">

### After

<img width="1350" alt="screenshot 2016-04-15 14 05 07" src="https://cloud.githubusercontent.com/assets/90871/14562206/48ad7532-0313-11e6-9dcd-4e78aef52ea7.png">