### PR TITLE
make editor page accessible and nominally functional for deleted addons.

### DIFF
--- a/src/olympia/addons/decorators.py
+++ b/src/olympia/addons/decorators.py
@@ -28,7 +28,7 @@ def addon_view(f, qs=Addon.objects.all):
         if addon_id and addon_id.isdigit():
             addon = get_object_or_404(qs(), id=addon_id)
             # Don't get in an infinite loop if addon.slug.isdigit().
-            if addon.slug != addon_id:
+            if addon.slug and addon.slug != addon_id:
                 url = request.path.replace(addon_id, addon.slug, 1)
 
                 if request.GET:

--- a/src/olympia/addons/templates/addons/details_box.html
+++ b/src/olympia/addons/templates/addons/details_box.html
@@ -26,6 +26,14 @@
               <caption>{{ _('Add-on Information for {0}')|f(addon_name|xssafe) }}</caption>
             {% endwith %}
             <tbody>
+              {% if addon.is_deleted %}
+              <tr class="addon-status">
+                <th>{{ _('Status') }}</th>
+                <td>
+                    <strong>{{ addon.STATUS_CHOICES[addon.status] }}</strong>
+                </td>
+              </tr>
+              {% endif %}
               <tr class="addon-updated">
                 <th>{{ _('Updated') }}</th>
                 <td>

--- a/src/olympia/editors/helpers.py
+++ b/src/olympia/editors/helpers.py
@@ -546,7 +546,8 @@ class ReviewHelper:
             # the actions.
             return actions
         labels, details = self._review_actions()
-        reviewable_because_complete = addon.status != amo.STATUS_NULL
+        reviewable_because_complete = addon.status not in (
+            amo.STATUS_NULL, amo.STATUS_DELETED)
         reviewable_because_admin = (
             not addon.admin_review or
             acl.action_allowed(request, 'ReviewerAdminTools', 'View'))

--- a/src/olympia/editors/templates/editors/review.html
+++ b/src/olympia/editors/templates/editors/review.html
@@ -227,7 +227,7 @@
   </div>
 </form>
 
-<form method="POST" action="{{ url('editors.whiteboard', addon.slug) }}">
+<form method="POST" action="{{ url('editors.whiteboard', addon.slug if addon.slug else addon.pk) }}">
   {{ csrf() }}
   <div class="whiteboard">
     <div class="whiteboard-inner">
@@ -250,6 +250,7 @@
   <div id="scroll_sidebar">
   <div class="currently_viewing_warning"></div>
 
+  {% if not addon.is_deleted %}
   <strong>{{ _('Actions') }}</strong>
   <ul id="actions-addon">
     {% if addon.is_listed %}<li><a href="{{ addon.get_url_path() }}">{{ _('View Listing') }}</a></li>{% endif %}
@@ -258,6 +259,7 @@
     <li><a href="{{ url('zadmin.addon_manage', addon.id) }}">{{ _('Admin Page') }}</a> <em>{{ _('(admin)') }}</em></li>
     {% endif %}
   </ul>
+  {% endif %}
 
 
   <strong>{{ _('Review This Add-on') }}</strong>

--- a/src/olympia/editors/tests/test_forms.py
+++ b/src/olympia/editors/tests/test_forms.py
@@ -40,7 +40,9 @@ class TestReviewActions(TestCase):
 
     def test_other_statuses(self):
         for status in Addon.STATUS_CHOICES:
-            if status in NOMINATED_STATUSES + (amo.STATUS_NULL, ):
+            statuses = NOMINATED_STATUSES + (
+                amo.STATUS_NULL, amo.STATUS_DELETED)
+            if status in statuses:
                 return
             else:
                 label = self.set_status(status)['prelim']['label']
@@ -68,6 +70,10 @@ class TestReviewActions(TestCase):
     def test_addon_status_null(self):
         # If the add-on is null we only show info, comment and super review.
         assert len(self.set_status(amo.STATUS_NULL)) == 3
+
+    def test_addon_status_deleted(self):
+        # If the add-on is deleted we only show info, comment and super review.
+        assert len(self.set_status(amo.STATUS_DELETED)) == 3
 
     @mock.patch('olympia.access.acl.action_allowed')
     def test_admin_flagged_addon_actions(self, action_allowed_mock):

--- a/src/olympia/editors/tests/test_helpers.py
+++ b/src/olympia/editors/tests/test_helpers.py
@@ -475,6 +475,10 @@ class TestReviewHelper(TestCase):
         assert mail.outbox[0].subject == subject
         assert self.check_log_count(amo.LOG.REQUEST_INFORMATION.id) == 1
 
+    def test_request_more_information_deleted_addon(self):
+        self.addon.delete()
+        self.test_request_more_information()
+
     def test_email_no_locale(self):
         self.setup_data(amo.STATUS_NOMINATED, ['addon_files'])
         self.helper.handler.process_public()

--- a/src/olympia/editors/views.py
+++ b/src/olympia/editors/views.py
@@ -581,7 +581,7 @@ def application_versions_json(request):
 
 
 @addons_reviewer_required
-@addon_view_factory(qs=Addon.with_unlisted.all)
+@addon_view_factory(qs=Addon.unfiltered.all)
 def review(request, addon):
     if not addon.is_listed and not acl.check_unlisted_addons_reviewer(request):
         raise http.Http404
@@ -841,7 +841,7 @@ def leaderboard(request):
 
 
 @addons_reviewer_required
-@addon_view_factory(qs=Addon.with_unlisted.all)
+@addon_view_factory(qs=Addon.unfiltered.all)
 def whiteboard(request, addon):
     form = forms.WhiteboardForm(request.POST or None, instance=addon)
 


### PR DESCRIPTION
fixes #2242 
Makes the page with history accessible, with info/comment/super actions available.  I think I caught all the non-working links but some things still might not work (the add-on **is** deleted, after all)