### PR TITLE
Remove big red header from devhub pages (fix #2234)

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -107,6 +107,9 @@ h2 {
 h1,
 .primary h2,
 hgroup h2.addon,
+hgroup h2.collection,
+.developer-hub header h2,
+.developer-hub #homepage h2,
 .personas-featured h3 {
   color: @default-font-color;
   font-size: 1.692rem;


### PR DESCRIPTION
### Before

<img width="1350" alt="screenshot 2016-04-18 20 31 55" src="https://cloud.githubusercontent.com/assets/90871/14617064/ba045ac8-05a4-11e6-86fa-c7c9d66c4f3e.png">
<img width="1350" alt="screenshot 2016-04-18 20 31 47" src="https://cloud.githubusercontent.com/assets/90871/14617065/ba723278-05a4-11e6-8601-8df0fa000934.png">
<img width="1350" alt="screenshot 2016-04-18 20 31 42" src="https://cloud.githubusercontent.com/assets/90871/14617066/ba743cee-05a4-11e6-8d2f-88c3ddc64212.png">

### After

<img width="1350" alt="screenshot 2016-04-18 20 28 14" src="https://cloud.githubusercontent.com/assets/90871/14617068/be7345f6-05a4-11e6-9d3a-b8aec927ba9b.png">
<img width="1350" alt="screenshot 2016-04-18 20 27 57" src="https://cloud.githubusercontent.com/assets/90871/14617070/be74f4aa-05a4-11e6-81ea-d5a7fae0d8c9.png">
<img width="1350" alt="screenshot 2016-04-18 20 27 54" src="https://cloud.githubusercontent.com/assets/90871/14617071/bebeb4b4-05a4-11e6-8046-5010d817b5e4.png">