### PR TITLE
Move messages above header contents (fix #2203)

### DIFF
--- a/src/olympia/templates/impala/base.html
+++ b/src/olympia/templates/impala/base.html
@@ -116,6 +116,8 @@
                     {% endif %}
                   </div>
                 {% endif %}
+                {# outer_content is for something you want above content on every page. #}
+                {% block outer_content %}{% include "messages.html" %}{% endblock %}
                 {% block amo_balloons %}
                   {% if APP == amo.FIREFOX %}
                     <div class="site-balloon" id="site-nonfx">
@@ -179,8 +181,6 @@
         {% block main_content %}
           {% block navbar %}
           {% endblock %}
-          {# outer_content is for something you want above content on every page. #}
-          {% block outer_content %}{% include "messages.html" %}{% endblock %}
           {% block content %}{% endblock %}
         {% endblock %}
       </div>

--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -531,11 +531,14 @@ body:not(.home) .amo-header,
   background: #fff;
 }
 
-.restyle .site-balloon {
+.restyle .site-balloon,
+.restyle .notification-box {
   background: #fbfbfb;
   border: 2px solid #1f386e;
   border-radius: 6px;
   color: @default-font-color;
+  margin-top: 22px;
+  padding: 15px 45px 15px 15px;
 
   &::before, &::after {
     display: none;
@@ -549,6 +552,22 @@ body:not(.home) .amo-header,
     &:hover {
       background-color: @dark-gray;
     }
+  }
+
+  h2 {
+    font-size: 1.1rem;
+  }
+
+  &.error {
+    background-color: #fee3e5;
+    border-color: ##e0c9d6;
+    // Previous selector is !important, so we have to do this :'(
+    color: @default-font-color !important;
+  }
+
+  &.warning {
+    background-color: #fd9;
+    border-color: #664400;
   }
 }
 


### PR DESCRIPTION
Messages still look a bit weird but they're in the right place and not below the header content now:

<img width="1350" alt="screenshot 2016-04-18 20 38 55" src="https://cloud.githubusercontent.com/assets/90871/14617352/cc4bd3fe-05a5-11e6-853e-e89da0abb155.png">
