### PR TITLE
Align featured themes (fix #2076)

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -1512,9 +1512,13 @@ h3.author .transfer-ownership {
     padding: 0.6em 0 0;
     position: relative;
 
-    &:nth-of-type(3n) .persona.hovercard:hover,
-    &:nth-of-type(3n) .persona.hovercard:focus {
-      margin-bottom: -14.5px;
+    &:nth-of-type(3n) .persona.hovercard {
+      margin-right: 0;
+
+      &:hover,
+      &:focus {
+        margin-bottom: -14.5px;
+      }
     }
 
     &:nth-of-type(4n) .persona.hovercard {
@@ -1523,8 +1527,8 @@ h3.author .transfer-ownership {
   }
 
   .persona.hovercard {
-    margin-right: 29px;
-    width: 32%;
+    margin-right: 34px;
+    width: 33.3%;
 
     a {
       padding: 0;


### PR DESCRIPTION
This is one of those things where I just could not figure out, for ages, why I couldn't get things to line up. The huge margin on the last hovercard would push it over. Removing that fixes, how didn't I think of this before?!

Anyway, here it is all lined up:

<img width="738" alt="screenshot 2016-04-18 20 46 40" src="https://cloud.githubusercontent.com/assets/90871/14617663/ecdec21a-05a6-11e6-8f2b-1dc02a830aac.png">
<img width="1350" alt="screenshot 2016-04-18 20 46 26" src="https://cloud.githubusercontent.com/assets/90871/14617662/ecdd4692-05a6-11e6-9c63-80b4d5aa498b.png">