### PR TITLE
Remove ssl.gstatic.com from img-src

### DIFF
--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1308,7 +1308,6 @@ CSP_IMG_SRC = (
     ANALYTICS_HOST,
     PROD_CDN_HOST,
     'https://static.addons.mozilla.net',  # CDN origin server.
-    'https://ssl.gstatic.com/',
     'https://sentry.prod.mozaws.net',
 )
 CSP_MEDIA_SRC = (


### PR DESCRIPTION
Another google host that's not needed for recaptcha2 any more.

https://developers.google.com/recaptcha/docs/faq#im-using-content-security-policy-csp-on-my-website-how-can-i-configure-it-to-work-with-recaptcha