### PR TITLE
Restore "add" button to homepage themes (fix #2375)

### DIFF
--- a/src/olympia/addons/templates/addons/impala/persona_grid.html
+++ b/src/olympia/addons/templates/addons/impala/persona_grid.html
@@ -10,6 +10,11 @@
               <img {{ 'src' if first_page else 'data-defer-src' }}="{{ addon.persona.thumb_url }}"
                    data-browsertheme="{{ addon.persona.json_data }}" alt="">
             </div>
+            <div class="persona-install">
+              <button class="add">
+                <span>{{ _('Add') }}</span>
+              </button>
+            </div>
             <h3>{{ addon.name }}</h3>
           </a>
         </div>

--- a/src/olympia/addons/templates/addons/persona_preview.html
+++ b/src/olympia/addons/templates/addons/persona_preview.html
@@ -45,7 +45,6 @@
               <button class="add">
                 <div>
                   <img src="{{ static('img/impala/add-small.png') }}" alt="{{ _('Add') }}">
-                  <span class="disabled-icon">+</span>
                   <span>{{ _('Add') }}</span>
                 </div>
               </button>
@@ -93,7 +92,6 @@
       {% if linked %}
         <div class="persona-install">
           <button class="add">
-            <span class="disabled-icon">+</span>
             <span>{{ _('Add') }}</span>
           </button>
         </div>


### PR DESCRIPTION
### Before

<img width="1350" alt="screenshot 2016-04-22 12 28 44" src="https://cloud.githubusercontent.com/assets/90871/14740316/d724ce10-0885-11e6-9047-fd9db2b3787a.png">

### After

<img width="1350" alt="screenshot 2016-04-22 12 27 50" src="https://cloud.githubusercontent.com/assets/90871/14740317/d741f2ce-0885-11e6-9651-98af7e2323cb.png">