### PR TITLE
provide a reason option to sign file

### DIFF
--- a/src/olympia/addons/management/commands/sign_addons.py
+++ b/src/olympia/addons/management/commands/sign_addons.py
@@ -21,6 +21,9 @@ class Command(BaseCommand):
                     help='The signing server to use for preliminary reviews'),
         make_option('--force', action='store_true', dest='force',
                     help='Sign the addon if it is already signed'),
+        make_option('--reason', action='store', type='string', dest='reason',
+                    help='The reason for the resign that we will send '
+                         'the developer.')
     )
 
     def handle(self, *args, **options):
@@ -37,4 +40,5 @@ class Command(BaseCommand):
         with override_settings(
                 SIGNING_SERVER=full_server,
                 PRELIMINARY_SIGNING_SERVER=prelim_server):
-            sign_addons(addon_ids, force=options['force'])
+            sign_addons(
+                addon_ids, force=options['force'], reason=options['reason'])

--- a/src/olympia/addons/tests/test_commands.py
+++ b/src/olympia/addons/tests/test_commands.py
@@ -54,18 +54,26 @@ def test_override_PRELIMINARY_SIGNING_SERVER_setting(monkeypatch):
 
 def test_force_signing(monkeypatch):
     """You can force signing an addon even if it's already signed."""
-    def not_forced(ids, force):
+    def not_forced(ids, force, reason):
         assert not force
     monkeypatch.setattr(SIGN_ADDONS, not_forced)
     call_command('sign_addons', 123)
 
-    def is_forced(ids, force):
+    def is_forced(ids, force, reason):
         assert force
     monkeypatch.setattr(SIGN_ADDONS, is_forced)
     call_command('sign_addons', 123, force=True)
 
 
+def test_reason(monkeypatch):
+    """You can pass a reason."""
+    def has_reason(ids, force, reason):
+        assert reason == 'expiry'
+    monkeypatch.setattr(SIGN_ADDONS, has_reason)
+    call_command('sign_addons', 123, reason='expiry')
+
 # Test the "approve_addons" command.
+
 
 @pytest.mark.django_db
 def test_approve_addons_get_files_incomplete():

--- a/src/olympia/lib/crypto/tests.py
+++ b/src/olympia/lib/crypto/tests.py
@@ -6,6 +6,7 @@ import tempfile
 import zipfile
 
 from django.conf import settings
+from django.core import mail
 from django.core.files.storage import default_storage as storage
 from django.test.utils import override_settings
 
@@ -13,6 +14,7 @@ import mock
 import pytest
 
 from olympia import amo
+from olympia.addons.models import AddonUser
 from olympia.amo.tests import TestCase
 from olympia.files.utils import extract_xpi
 from olympia.lib.crypto import packaged, tasks
@@ -294,6 +296,7 @@ class TestPackaged(TestCase):
 
 
 class TestTasks(TestCase):
+    fixtures = ['base/users']
 
     def setUp(self):
         super(TestTasks, self).setUp()
@@ -614,3 +617,17 @@ class TestTasks(TestCase):
             assert self.version.version_int == version_int('1.3.1-signed')
             assert file_hash != self.file_.generate_hash()
             self.assert_backup()
+
+    @mock.patch('olympia.lib.crypto.tasks.sign_file')
+    def test_sign_mail(self, mock_sign_file):
+        """Check that an email reason can be provided."""
+        self.file_.update(status=amo.STATUS_PUBLIC)
+        AddonUser.objects.create(addon=self.addon, user_id=999)
+        with amo.tests.copy_file(
+                'src/olympia/files/fixtures/files/jetpack.xpi',
+                self.file_.file_path):
+            tasks.sign_addons([self.addon.pk], reason='expiry')
+            mock_sign_file.assert_called_with(
+                self.file_, settings.SIGNING_SERVER)
+
+        assert 'expire' in mail.outbox[0].message().as_string()


### PR DESCRIPTION
* fixes mozilla/addons#100
* provides a --reason argument to the sign_addons command to send a particular email

r? @EnTeQuAk for the python @jvillalobos for the message