### PR TITLE
Use the primary database in FxA views

### DIFF
--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -641,7 +641,6 @@ class TestAuthenticateView(BaseAuthenticationView):
             self.client.get(self.url)
         assert use_master.called
 
-
     def test_no_code_provided(self):
         response = self.client.get(self.url)
         assert response.status_code == 302

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -636,6 +636,12 @@ class TestAuthenticateView(BaseAuthenticationView):
     def login_url(self, **params):
         return absolutify(urlparams(reverse('users.login'), **params))
 
+    def test_write_is_used(self, **params):
+        with mock.patch('olympia.amo.models.use_master') as use_master:
+            self.client.get(self.url)
+        assert use_master.called
+
+
     def test_no_code_provided(self):
         response = self.client.get(self.url)
         assert response.status_code == 302

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -22,6 +22,7 @@ from waffle.decorators import waffle_switch
 
 from olympia.access.models import GroupUser
 from olympia.amo import messages
+from olympia.amo.decorators import write
 from olympia.amo.utils import urlparams
 from olympia.api.authentication import JWTKeyAuthentication
 from olympia.api.permissions import GroupPermission
@@ -174,6 +175,7 @@ def with_user(format, config='default'):
 
     def outer(fn):
         @functools.wraps(fn)
+        @write
         def inner(self, request):
             if request.method == 'GET':
                 data = request.query_params


### PR DESCRIPTION
When there is replication lag the second login will generate a 500 since it tries to create the account again. Since this is a GET request I don't think it is using the primary database by default so I'm adding the `@write` decorator to force it. Along with atomic requests this should prevent the error.

I couldn't think of a way of testing replication lag locally so there are no tests.

Fixes #2498.