### PR TITLE
Use redirect_url not redirect_uri in internal auth

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -106,7 +106,7 @@ FXA_CONFIG = {
         'content_host': 'https://stable.dev.lcip.org',
         'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
         'profile_host': 'https://stable.dev.lcip.org/profile/v1',
-        'redirect_uri': 'http://localhost:3000/fxa-authenticate',
+        'redirect_url': 'http://localhost:3000/fxa-authenticate',
         'scope': 'profile',
     },
 }

--- a/src/olympia/internal_tools/tests/test_views.py
+++ b/src/olympia/internal_tools/tests/test_views.py
@@ -17,7 +17,7 @@ from olympia.users.models import UserProfile
 FXA_CONFIG = {
     'oauth_host': 'https://accounts.firefox.com/v1',
     'client_id': '999abc111',
-    'redirect_uri': 'https://addons-frontend/fxa-authenticate',
+    'redirect_url': 'https://addons-frontend/fxa-authenticate',
     'scope': 'profile',
 }
 
@@ -185,7 +185,7 @@ class TestLoginStartView(TestCase):
         assert 'fxa_state' in self.client.session
         assert self.client.session['fxa_state'] == state
 
-    def test_redirect_uri_is_correct(self):
+    def test_redirect_url_is_correct(self):
         self.initialize_session({})
         with mock.patch('olympia.internal_tools.views.generate_fxa_state',
                         lambda: 'arandomstring'):
@@ -197,7 +197,7 @@ class TestLoginStartView(TestCase):
         assert redirect == 'https://accounts.firefox.com/v1/authorization'
         assert urlparse.parse_qs(url.query) == {
             'client_id': ['999abc111'],
-            'redirect_uri': ['https://addons-frontend/fxa-authenticate'],
+            'redirect_url': ['https://addons-frontend/fxa-authenticate'],
             'scope': ['profile'],
             'state': ['arandomstring'],
         }

--- a/src/olympia/internal_tools/views.py
+++ b/src/olympia/internal_tools/views.py
@@ -43,7 +43,7 @@ class LoginStart(APIView):
             state += ':' + urlsafe_b64encode(next_path).rstrip('=')
         query = {
             'client_id': config['client_id'],
-            'redirect_uri': config['redirect_uri'],
+            'redirect_url': config['redirect_url'],
             'scope': config['scope'],
             'state': state,
         }


### PR DESCRIPTION
The internal FxA views were using `redirect_uri` but the config should actually be called `redirect_url`.