### PR TITLE
Avoid auto-respones by adding rfc 3834 headers

### DIFF
--- a/src/olympia/amo/tests/test_send_mail.py
+++ b/src/olympia/amo/tests/test_send_mail.py
@@ -242,6 +242,14 @@ class TestSendMail(BaseTestCase):
                   recipient_list=['b@example.com'])
         assert 'test subject' == mail.outbox[0].subject, 'Subject not stripped'
 
+    def test_autoresponse_headers(self):
+        send_mail('subject', 'test body', from_email='a@example.com',
+                  recipient_list=['b@example.com'])
+
+        headers = mail.outbox[0].extra_headers
+        assert headers['X-Auto-Response-Suppress'] == 'RN, NRN, OOF, AutoReply'
+        assert headers['Auto-Submitted'] == 'auto-generated'
+
     def make_backend_class(self, error_order):
         throw_error = iter(error_order)
 

--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -208,6 +208,10 @@ def send_mail(subject, message, from_email=None, recipient_list=None,
     if not headers:
         headers = {}
 
+    # Avoid auto-replies per rfc 3834 and the Microsoft variant
+    headers['X-Auto-Response-Suppress'] = 'RN, NRN, OOF, AutoReply'
+    headers['Auto-Submitted'] = 'auto-generated'
+
     def send(recipient, message, **options):
         kwargs = {
             'async': async,


### PR DESCRIPTION
As suggested by a developer, some support systems actually listen to these headers and don't generate auto-responses. One of them is standardized, the other is Microsoft-specific:

https://tools.ietf.org/rfcmarkup?doc=3834
https://msdn.microsoft.com/en-us/library/ee219609(v=exchg.80).aspx