### PR TITLE
create a revoke method

### DIFF
--- a/src/olympia/devhub/templates/devhub/api/key.html
+++ b/src/olympia/devhub/templates/devhub/api/key.html
@@ -16,7 +16,7 @@
         <legend>
           {{ _('API Credentials') }}
         </legend>
-        <p class="island">
+        <p>
         {% trans
             docs_url='https://addons-server.readthedocs.io/en/latest/topics/api/index.html' %}
           For detailed instructions, consult the <a href="{{ docs_url }}">API documentation</a>.
@@ -45,24 +45,26 @@
         {% else %}
           <p>
           {% trans %}
-            You don't have any API credentials yet.
+            You don't have any API credentials.
           {% endtrans %}
           </p>
         {% endif %}
-        <p>
-          {% trans bug_link='https://github.com/mozilla/olympia/issues' %}
-            This feature is under active development. If you find a problem please <a target="_blank" href="{{ bug_link }}">report a bug</a>.
-          {% endtrans %}
-        </p>
       </fieldset>
       <div class="listing-footer">
-        <button id="generate-key" class="button prominent" type="submit">
+        <p class="footer-submit">
           {% if credentials %}
-            {{ _('Revoke and regenerate credentials') }}
+            <button id="revoke-key" class="button prominent" type="submit" name="action" value="revoke">
+              {{ _('Revoke') }}
+            </button>
+            <button id="generate-key" class="button prominent" type="submit" name="action" value="generate">
+              {{ _('Revoke and regenerate credentials') }}
+            </button>
           {% else %}
-            {{ _('Generate new credentials') }}
+            <button id="generate-key" class="button prominent" type="submit" name="action" value="generate">
+              {{ _('Generate new credentials') }}
+            </button>
           {% endif %}
-        </button>
+        </p>
       </div>
     </form>
   </div>

--- a/src/olympia/devhub/templates/devhub/email/new-key-email.ltxt
+++ b/src/olympia/devhub/templates/devhub/email/new-key-email.ltxt
@@ -1,11 +1,9 @@
-{% trans key=key, manage_url=url('devhub.api_key')|absolutify %}
+{% load i18n %}{# L10n: This is an email. Whitespace matters #}{% blocktrans %}The following API Key was added to your account:
 
-The following API Key was added to your account:
 {{ key }}
 
 If you believe this key was created in error, you can remove the key and
 disable access at the following location:
 
-{{ manage_url }}
-
-{% endtrans %}
+{{ url }}
+{% endblocktrans %}

--- a/src/olympia/devhub/templates/devhub/email/revoked-key-email.ltxt
+++ b/src/olympia/devhub/templates/devhub/email/revoked-key-email.ltxt
@@ -1,0 +1,9 @@
+{% load i18n %}{# L10n: This is an email. Whitespace matters #}{% blocktrans %}The API Key was revoked from your account:
+
+{{ key }}
+
+If you believe this key was revoked in error, you can create a new one
+at the following location:
+
+{{ url }}
+{% endblocktrans %}

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -260,6 +260,8 @@ JINGO_EXCLUDE_PATHS = (
     'reviews/emails',
     'editors/emails',
     'amo/emails',
+    'devhub/email/revoked-key-email.ltxt',
+    'devhub/email/new-key-email.ltxt'
 )
 
 TEMPLATE_CONTEXT_PROCESSORS = (


### PR DESCRIPTION
* allows a user to revoke a key, without generating a new one #2506

![screenshot 2016-04-27 16 49 36](https://cloud.githubusercontent.com/assets/74699/14871550/19bb225e-0c98-11e6-8ac3-8874dcda8abf.png)

* a minor style fix on the page too
* also put new line formatting in the emails, issue #916 which is pain because it breaks the translations and looks wonky but before:

![screenshot 2016-04-27 16 52 31](https://cloud.githubusercontent.com/assets/74699/14871592/77946dd6-0c98-11e6-8293-074ca722c7fc.png)

and after:

![screenshot 2016-04-27 16 51 35](https://cloud.githubusercontent.com/assets/74699/14871584/53771ac0-0c98-11e6-8889-23ab927f5464.png)


