### PR TITLE
Fix ES index creation to always pass number of shards and number of replicas (fix #2304)

### DIFF
--- a/src/olympia/lib/es/management/commands/reindex.py
+++ b/src/olympia/lib/es/management/commands/reindex.py
@@ -68,23 +68,7 @@ def update_aliases(actions, stdout=sys.stdout):
 def create_new_index(alias, new_index, stdout=sys.stdout):
     log('Create the index {0}, for alias: {1}'.format(new_index, alias),
         stdout=stdout)
-
-    config = {}
-
-    # Retrieve settings from last index, if any
-    if ES.indices.exists(alias):
-        res = ES.indices.get_settings(alias)
-        idx_settings = res.get(alias, {}).get('settings', {})
-        config['number_of_replicas'] = idx_settings.get(
-            'number_of_replicas',
-            settings.ES_DEFAULT_NUM_REPLICAS
-        )
-        config['number_of_shards'] = idx_settings.get(
-            'number_of_shards',
-            settings.ES_DEFAULT_NUM_SHARDS
-        )
-
-    get_modules()[alias].create_new_index(new_index, config)
+    get_modules()[alias].create_new_index(new_index)
 
 
 @task_with_callbacks

--- a/src/olympia/lib/es/utils.py
+++ b/src/olympia/lib/es/utils.py
@@ -94,6 +94,7 @@ def create_index(index, config=None):
         # Make a deepcopy of the settings in the config that was passed, so
         # that we can modify it freely to add shards and replicas settings.
         config['settings'] = deepcopy(config['settings'])
+
     config['settings']['index'].update({
         'number_of_shards': settings.ES_DEFAULT_NUM_SHARDS,
         'number_of_replicas': settings.ES_DEFAULT_NUM_REPLICAS

--- a/src/olympia/search/indexers.py
+++ b/src/olympia/search/indexers.py
@@ -58,19 +58,24 @@ INDEX_SETTINGS = {
 }
 
 
-def create_new_index(index_name=None, config=None):
+def create_new_index(index_name=None):
     """
     Create a new index for search-related documents in ES.
 
     Intended to be used by reindexation (and tests), generally a bad idea to
     call manually.
     """
-    if config is None:
-        config = {}
     if index_name is None:
         index_name = BaseSearchIndexer.get_index_alias()
-    config['settings'] = {'index': INDEX_SETTINGS}
-    config['mappings'] = get_mappings()
+
+    config = {
+        'mappings': get_mappings(),
+        'settings': {
+            # create_index will add its own index settings like number of
+            # shards and replicas.
+            'index': INDEX_SETTINGS
+        },
+    }
     create_index(index_name, config)
 
 

--- a/src/olympia/stats/search.py
+++ b/src/olympia/stats/search.py
@@ -143,12 +143,12 @@ def get_alias():
     return settings.ES_INDEXES.get(StatsSearchMixin.ES_ALIAS_KEY)
 
 
-def create_new_index(index_name=None, config=None):
-    if config is None:
-        config = {}
+def create_new_index(index_name=None):
     if index_name is None:
         index_name = get_alias()
-    config['mappings'] = get_mappings()
+    config = {
+        'mappings': get_mappings(),
+    }
     create_index(index_name, config)
 
 


### PR DESCRIPTION
#2304 