### PR TITLE
Pull in addons-linter 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "less": "1.3.x",
     "stylus": "0.32.x",
     "uglify-js": "2.4.x",
-    "addons-linter": "0.1.0"
+    "addons-linter": "0.3.1"
   }
 }


### PR DESCRIPTION
* Various hidden / binary files will now be flagged
* Upgrade WebExtension manfiest schema to 0.2.0 (optional id)
* Now flagging by file extension or magic number
* CSS related errors are now warnings