### PR TITLE
Remove package.json related extraction code, ignore it everywhere.

### DIFF
--- a/src/olympia/files/models.py
+++ b/src/olympia/files/models.py
@@ -213,7 +213,7 @@ class File(OnChangeMixin, ModelBase):
         except (zipfile.BadZipfile, IOError):
             # This path is not an XPI. It's probably an app manifest.
             return data
-        if "package.json" in zip_.namelist():
+        if 'package.json' in zip_.namelist():
             data['sdkVersion'] = "jpm"
         else:
             name = 'harness-options.json'

--- a/src/olympia/files/tests/test_utils_.py
+++ b/src/olympia/files/tests/test_utils_.py
@@ -338,6 +338,17 @@ def test_bump_version_in_alt_install_rdf(file_obj):
         assert parsed['version'] == '2.1.106.1-signed'
 
 
+def test_bump_version_in_package_json(file_obj):
+    with amo.tests.copy_file(
+            'src/olympia/files/fixtures/files/new-format-0.0.1.xpi',
+            file_obj.file_path):
+        utils.update_version_number(file_obj, '0.0.1.1-signed')
+
+        with zipfile.ZipFile(file_obj.file_path, 'r') as source:
+            parsed = json.loads(source.read('package.json'))
+            assert parsed['version'] == '0.0.1.1-signed'
+
+
 def test_bump_version_in_manifest_json(file_obj):
     with amo.tests.copy_file(
             'src/olympia/files/fixtures/files/webextension.xpi',

--- a/src/olympia/files/tests/test_utils_.py
+++ b/src/olympia/files/tests/test_utils_.py
@@ -150,11 +150,12 @@ class TestExtractor(TestCase):
     @mock.patch('olympia.files.utils.RDFExtractor')
     @mock.patch('olympia.files.utils.os.path.exists')
     def test_ignore_package_json(self, exists_mock, rdf_extractor,
-                                manifest_json_extractor):
+                                 manifest_json_extractor):
         # Previously we prefered `package.json` to `install.rdf` which
         # we don't anymore since
         # https://github.com/mozilla/addons-server/issues/2460
-        exists_mock.side_effect = self.os_path_exists_for(('install.rdf', 'package.json'))
+        exists_mock.side_effect = self.os_path_exists_for(
+            ('install.rdf', 'package.json'))
         utils.Extractor.parse('foobar')
         assert rdf_extractor.called
         assert not manifest_json_extractor.called

--- a/src/olympia/files/tests/test_utils_.py
+++ b/src/olympia/files/tests/test_utils_.py
@@ -134,168 +134,40 @@ class TestExtractor(TestCase):
         with self.assertRaises(forms.ValidationError) as exc:
             utils.Extractor.parse('foobar')
         assert exc.exception.message == (
-            "No install.rdf or package.json or manifest.json found")
+            'No install.rdf or manifest.json found')
 
     @mock.patch('olympia.files.utils.ManifestJSONExtractor')
-    @mock.patch('olympia.files.utils.PackageJSONExtractor')
     @mock.patch('olympia.files.utils.RDFExtractor')
     @mock.patch('olympia.files.utils.os.path.exists')
     def test_parse_install_rdf(self, exists_mock, rdf_extractor,
-                               package_json_extractor,
                                manifest_json_extractor):
         exists_mock.side_effect = self.os_path_exists_for('install.rdf')
         utils.Extractor.parse('foobar')
         assert rdf_extractor.called
-        assert not package_json_extractor.called
         assert not manifest_json_extractor.called
 
     @mock.patch('olympia.files.utils.ManifestJSONExtractor')
-    @mock.patch('olympia.files.utils.PackageJSONExtractor')
     @mock.patch('olympia.files.utils.RDFExtractor')
     @mock.patch('olympia.files.utils.os.path.exists')
-    def test_parse_package_json(self, exists_mock, rdf_extractor,
-                                package_json_extractor,
+    def test_ignore_package_json(self, exists_mock, rdf_extractor,
                                 manifest_json_extractor):
-        exists_mock.side_effect = self.os_path_exists_for('package.json')
+        # Previously we prefered `package.json` to `install.rdf` which
+        # we don't anymore since
+        # https://github.com/mozilla/addons-server/issues/2460
+        exists_mock.side_effect = self.os_path_exists_for(('install.rdf', 'package.json'))
         utils.Extractor.parse('foobar')
-        assert not rdf_extractor.called
-        assert package_json_extractor.called
+        assert rdf_extractor.called
         assert not manifest_json_extractor.called
 
     @mock.patch('olympia.files.utils.ManifestJSONExtractor')
-    @mock.patch('olympia.files.utils.PackageJSONExtractor')
     @mock.patch('olympia.files.utils.RDFExtractor')
     @mock.patch('olympia.files.utils.os.path.exists')
     def test_parse_manifest_json(self, exists_mock, rdf_extractor,
-                                 package_json_extractor,
                                  manifest_json_extractor):
         exists_mock.side_effect = self.os_path_exists_for('manifest.json')
         utils.Extractor.parse('foobar')
         assert not rdf_extractor.called
-        assert not package_json_extractor.called
         assert manifest_json_extractor.called
-
-
-class TestPackageJSONExtractor(TestCase):
-
-    def parse(self, base_data):
-        return utils.PackageJSONExtractor('/fake_path',
-                                          json.dumps(base_data)).parse()
-
-    def create_appversion(self, name, version):
-        return AppVersion.objects.create(application=amo.APPS[name].id,
-                                         version=version)
-
-    def test_instanciate_without_data(self):
-        """Without data, we load the data from the file path."""
-        data = {'id': 'some-id'}
-        with NamedTemporaryFile() as file_:
-            file_.write(json.dumps(data))
-            file_.flush()
-            pje = utils.PackageJSONExtractor(file_.name)
-            assert pje.data == data
-
-    def test_guid(self):
-        """Use id for the guid."""
-        assert self.parse({'id': 'some-id'})['guid'] == 'some-id'
-
-    def test_name_for_guid_if_no_id(self):
-        """Use the name for the guid if there is no id."""
-        assert self.parse({'name': 'addon-name'})['guid'] == 'addon-name'
-
-    def test_type(self):
-        """Package.json addons are always ADDON_EXTENSION."""
-        assert self.parse({})['type'] == amo.ADDON_EXTENSION
-
-    def test_no_restart(self):
-        """Package.json addons are always no-restart."""
-        assert self.parse({})['no_restart'] is True
-
-    def test_name_from_title_with_name(self):
-        """Use the title for the name."""
-        data = {'title': 'The Addon Title', 'name': 'the-addon-name'}
-        assert self.parse(data)['name'] == 'The Addon Title'
-
-    def test_name_from_name_without_title(self):
-        """Use the name for the name if there is no title."""
-        assert (
-            self.parse({'name': 'the-addon-name'})['name'] == 'the-addon-name')
-
-    def test_version(self):
-        """Use version for the version."""
-        assert self.parse({'version': '23.0.1'})['version'] == '23.0.1'
-
-    def test_homepage(self):
-        """Use homepage for the homepage."""
-        assert (
-            self.parse({'homepage': 'http://my-addon.org'})['homepage'] ==
-            'http://my-addon.org')
-
-    def test_summary(self):
-        """Use description for the summary."""
-        assert (
-            self.parse({'description': 'An addon.'})['summary'] == 'An addon.')
-
-    def test_apps(self):
-        """Use engines for apps."""
-        firefox_version = self.create_appversion('firefox', '33.0a1')
-        thunderbird_version = self.create_appversion('thunderbird', '33.0a1')
-        data = {'engines': {'firefox': '>=33.0a1', 'thunderbird': '>=33.0a1'}}
-        apps = self.parse(data)['apps']
-        apps_dict = dict((app.appdata.short, app) for app in apps)
-        assert sorted(apps_dict.keys()) == ['firefox', 'thunderbird']
-        assert apps_dict['firefox'].min == firefox_version
-        assert apps_dict['firefox'].max == firefox_version
-        assert apps_dict['thunderbird'].min == thunderbird_version
-        assert apps_dict['thunderbird'].max == thunderbird_version
-
-    def test_unknown_apps_are_ignored(self):
-        """Unknown engines get ignored."""
-        self.create_appversion('firefox', '33.0a1')
-        self.create_appversion('thunderbird', '33.0a1')
-        data = {
-            'engines': {
-                'firefox': '>=33.0a1',
-                'thunderbird': '>=33.0a1',
-                'node': '>=0.10',
-            },
-        }
-        apps = self.parse(data)['apps']
-        engines = [app.appdata.short for app in apps]
-        assert sorted(engines) == ['firefox', 'thunderbird']  # Not node.
-
-    def test_invalid_app_versions_are_ignored(self):
-        """Valid engines with invalid versions are ignored."""
-        firefox_version = self.create_appversion('firefox', '33.0a1')
-        data = {
-            'engines': {
-                'firefox': '>=33.0a1',
-                'fennec': '>=33.0a1',
-            },
-        }
-        apps = self.parse(data)['apps']
-        assert len(apps) == 1
-        assert apps[0].appdata.short == 'firefox'
-        assert apps[0].min == firefox_version
-        assert apps[0].max == firefox_version
-
-    def test_fennec_is_treated_as_android(self):
-        """Treat the fennec engine as android."""
-        android_version = self.create_appversion('android', '33.0a1')
-        data = {
-            'engines': {
-                'fennec': '>=33.0a1',
-                'node': '>=0.10',
-            },
-        }
-        apps = self.parse(data)['apps']
-        assert apps[0].appdata.short == 'android'
-        assert apps[0].min == android_version
-        assert apps[0].max == android_version
-
-    def test_is_webextension(self):
-        """An add-on with a package.json file can't be a webextension."""
-        assert 'is_webextension' not in self.parse({})
 
 
 class TestManifestJSONExtractor(TestCase):
@@ -464,15 +336,6 @@ def test_bump_version_in_alt_install_rdf(file_obj):
         utils.update_version_number(file_obj, '2.1.106.1-signed')
         parsed = utils.parse_xpi(file_obj.file_path)
         assert parsed['version'] == '2.1.106.1-signed'
-
-
-def test_bump_version_in_package_json(file_obj):
-    with amo.tests.copy_file(
-            'src/olympia/files/fixtures/files/new-format-0.0.1.xpi',
-            file_obj.file_path):
-        utils.update_version_number(file_obj, '0.0.1.1-signed')
-        parsed = utils.parse_xpi(file_obj.file_path)
-        assert parsed['version'] == '0.0.1.1-signed'
 
 
 def test_bump_version_in_manifest_json(file_obj):


### PR DESCRIPTION
This doesn't remove everything related to package.json though since it
appears that it's not used but is part of many add-ons and XPI files
so I left the version increment on resigning and the FileViewer code
untouched.

Also the amo-validator continues to validate package.json related
code as long as we accept "new style" jetpack add-ons.

Fixes #2460, refs #2564, refs #2438