### PR TITLE
Properly default to our default AppVersions even if applications[/gecko] is omitted.

### DIFF
--- a/src/olympia/constants/base.py
+++ b/src/olympia/constants/base.py
@@ -524,3 +524,7 @@ SIGNED_CHOICES = {
     SIGNED_FULL: _(u'Signed for a full review'),
     SIGNED_PRELIM: _(u'Signed of a preliminary review'),
 }
+
+# Default strict_min_version and strict_max_version for WebExtensions
+DEFAULT_WEBEXT_MIN_VERSION = '42.0'
+DEFAULT_WEBEXT_MAX_VERSION = '*'

--- a/src/olympia/files/tests/test_utils_.py
+++ b/src/olympia/files/tests/test_utils_.py
@@ -272,6 +272,26 @@ class TestManifestJSONExtractor(TestCase):
     def test_is_webextension(self):
         assert self.parse({})['is_webextension']
 
+    def test_apps_use_default_versions_if_applications_is_omitted(self):
+        """
+        WebExtensions are allowed to omit `applications[/gecko]` and we
+        previously skipped defaulting to any `AppVersion` once this is not
+        defined. That resulted in none of our plattforms being selectable.
+
+        See https://github.com/mozilla/addons-server/issues/2586 and
+        probably many others.
+        """
+        # Default AppVersions, see `ManifestJSONExtractor.app`
+        firefox_min_version = self.create_appversion('firefox', '42.0')
+        firefox_max_version = self.create_appversion('firefox', '*')
+        data = {}
+        apps = self.parse(data)['apps']
+        assert len(apps) == 1  # Only Firefox for now.
+        app = apps[0]
+        assert app.appdata == amo.FIREFOX
+        assert app.min == firefox_min_version
+        assert app.max == firefox_max_version
+
 
 def test_zip_folder_content():
     extension_file = 'src/olympia/files/fixtures/files/extension.xpi'

--- a/src/olympia/files/tests/test_utils_.py
+++ b/src/olympia/files/tests/test_utils_.py
@@ -181,6 +181,10 @@ class TestManifestJSONExtractor(TestCase):
         return AppVersion.objects.create(application=amo.APPS[name].id,
                                          version=version)
 
+    def create_webext_default_versions(self):
+        self.create_appversion('firefox', amo.DEFAULT_WEBEXT_MIN_VERSION)
+        self.create_appversion('firefox', amo.DEFAULT_WEBEXT_MAX_VERSION)
+
     def test_instanciate_without_data(self):
         """Without data, we load the data from the file path."""
         data = {'id': 'some-id'}
@@ -232,8 +236,7 @@ class TestManifestJSONExtractor(TestCase):
         """Use the min and max versions if provided."""
         firefox_min_version = self.create_appversion('firefox', '30.0')
         firefox_max_version = self.create_appversion('firefox', '30.*')
-        self.create_appversion('firefox', '42.0')  # Default AppVersions.
-        self.create_appversion('firefox', '*')
+        self.create_webext_default_versions()
         data = {
             'applications': {
                 'gecko': {
@@ -248,16 +251,15 @@ class TestManifestJSONExtractor(TestCase):
 
     def test_apps_use_default_versions_if_none_provided(self):
         """Use the default min and max versions if none provided."""
-        # Default AppVersions.
-        firefox_min_version = self.create_appversion('firefox', '42.0')
-        firefox_max_version = self.create_appversion('firefox', '*')
+        min_version, max_version = self.create_webext_default_versions()
+
         data = {'applications': {'gecko': {'id': 'some-id'}}}
         apps = self.parse(data)['apps']
         assert len(apps) == 1  # Only Firefox for now.
         app = apps[0]
         assert app.appdata == amo.FIREFOX
-        assert app.min == firefox_min_version
-        assert app.max == firefox_max_version
+        assert app.min == min_version
+        assert app.max == max_version
 
     def test_invalid_app_versions_are_ignored(self):
         """Invalid versions are ignored."""
@@ -281,16 +283,15 @@ class TestManifestJSONExtractor(TestCase):
         See https://github.com/mozilla/addons-server/issues/2586 and
         probably many others.
         """
-        # Default AppVersions, see `ManifestJSONExtractor.app`
-        firefox_min_version = self.create_appversion('firefox', '42.0')
-        firefox_max_version = self.create_appversion('firefox', '*')
+        min_version, max_version = self.create_webext_default_versions()
+
         data = {}
         apps = self.parse(data)['apps']
         assert len(apps) == 1  # Only Firefox for now.
         app = apps[0]
         assert app.appdata == amo.FIREFOX
-        assert app.min == firefox_min_version
-        assert app.max == firefox_max_version
+        assert app.min == min_version
+        assert app.max == max_version
 
 
 def test_zip_folder_content():

--- a/src/olympia/files/tests/test_utils_.py
+++ b/src/olympia/files/tests/test_utils_.py
@@ -182,8 +182,9 @@ class TestManifestJSONExtractor(TestCase):
                                          version=version)
 
     def create_webext_default_versions(self):
-        self.create_appversion('firefox', amo.DEFAULT_WEBEXT_MIN_VERSION)
-        self.create_appversion('firefox', amo.DEFAULT_WEBEXT_MAX_VERSION)
+        min = self.create_appversion('firefox', amo.DEFAULT_WEBEXT_MIN_VERSION)
+        max = self.create_appversion('firefox', amo.DEFAULT_WEBEXT_MAX_VERSION)
+        return min, max
 
     def test_instanciate_without_data(self):
         """Without data, we load the data from the file path."""

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -242,8 +242,6 @@ class ManifestJSONExtractor(JSONExtractor):
     @property
     def app(self):
         """Get `AppVersion`s for the application."""
-        if not self.gecko:
-            return
         app = amo.FIREFOX
         strict_min_version = (
             # At least this version supports installing.

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -245,10 +245,12 @@ class ManifestJSONExtractor(JSONExtractor):
         app = amo.FIREFOX
         strict_min_version = (
             # At least this version supports installing.
-            get_simple_version(self.gecko.get('strict_min_version')) or '42.0')
+            get_simple_version(self.gecko.get('strict_min_version')) or
+            amo.DEFAULT_WEBEXT_MIN_VERSION)
         strict_max_version = (
             # Not sure what we should default to here.
-            get_simple_version(self.gecko.get('strict_max_version')) or '*')
+            get_simple_version(self.gecko.get('strict_max_version')) or
+            amo.DEFAULT_WEBEXT_MAX_VERSION)
         try:
             min_appver, max_appver = get_appversions(
                 app, strict_min_version, strict_max_version)


### PR DESCRIPTION
Fixes #2586 and probably a few others.

WebExtensions are allowed to omit `applications[/gecko]` and we
previously skipped defaulting to any `AppVersion` once this is
not defined. That resulted in none of our plattforms being selectable.

Since WebExtensions can skip defining `applications[/gecko]` (e.g from
the Chrome Store) we should ignore this too.