### PR TITLE
Support optional ids for WebExtensions without addons-linter flag.

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -498,8 +498,7 @@ class Addon(OnChangeMixin, ModelBase):
 
         generate_guid = (
             not data.get('guid', None) and
-            data.get('is_webextension', False) and
-            waffle.switch_is_active('addons-linter')
+            data.get('is_webextension', False)
         )
 
         if generate_guid:

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -20,7 +20,6 @@ from django.utils.translation import trans_real, ugettext_lazy as _
 import caching.base as caching
 import commonware.log
 import json_field
-import waffle
 from django_statsd.clients import statsd
 from jinja2.filters import do_dictsort
 

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -13,12 +13,11 @@ from django.core.files.storage import default_storage as storage
 from django.db import IntegrityError
 from django.utils import translation
 
-import pytest
 import jingo
 from mock import Mock, patch
 
 from olympia import amo
-from olympia.amo.tests import TestCase, create_switch
+from olympia.amo.tests import TestCase
 from olympia.amo import set_user
 from olympia.amo.helpers import absolutify, user_media_url
 from olympia.amo.signals import _connect, _disconnect

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -2186,21 +2186,7 @@ class TestAddonFromUpload(UploadTest):
         addon = Addon.from_upload(upload, [self.platform])
         assert addon.admin_review
 
-    def test_webextension_guid_required(self):
-        """Test that the guid is required.
-
-        TODO: This test should be removed once the 'addons-linter' flag will
-        be deleted.
-        """
-        # still raises an error if the flag is inactive
-        with pytest.raises(ValidationError):
-            Addon.from_upload(
-                self.get_upload('webextension_no_id.xpi'),
-                [self.platform])
-
     def test_webextension_generate_guid(self):
-        create_switch('addons-linter')
-
         addon = Addon.from_upload(
             self.get_upload('webextension_no_id.xpi'),
             [self.platform])
@@ -2215,8 +2201,6 @@ class TestAddonFromUpload(UploadTest):
         assert new_addon.guid != addon.guid
 
     def test_webextension_reuse_guid(self):
-        create_switch('addons-linter')
-
         addon = Addon.from_upload(
             self.get_upload('webextension.xpi'),
             [self.platform])

--- a/src/olympia/files/tests/test_models.py
+++ b/src/olympia/files/tests/test_models.py
@@ -414,12 +414,10 @@ class TestParseXpi(TestCase):
         assert e.exception.messages == ['Duplicate add-on ID found.']
 
     def test_guid_no_dupe_webextension_no_id(self):
-        create_switch('addons-linter')
         Addon.objects.create(guid=None, type=1)
         self.parse(filename='webextension_no_id.xpi')
 
     def test_guid_dupe_webextension_guid_given(self):
-        create_switch('addons-linter')
         Addon.objects.create(guid='@webextension-guid', type=1)
         with self.assertRaises(forms.ValidationError) as e:
             self.parse(filename='webextension.xpi')

--- a/src/olympia/files/tests/test_models.py
+++ b/src/olympia/files/tests/test_models.py
@@ -17,7 +17,7 @@ import pytest
 from mock import patch
 
 from olympia import amo
-from olympia.amo.tests import TestCase, create_switch
+from olympia.amo.tests import TestCase
 from olympia.amo.utils import rm_local_tmp_dir, chunked
 from olympia.addons.models import Addon
 from olympia.applications.models import AppVersion

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -501,10 +501,7 @@ def check_xpi_info(xpi_info, addon=None):
     else:
         deleted_guid_clashes = Addon.unfiltered.filter(guid=guid)
 
-    guid_optional = (
-        waffle.switch_is_active('addons-linter') and
-        xpi_info.get('is_webextension', False)
-    )
+    guid_optional = xpi_info.get('is_webextension', False)
 
     guid_too_long = (
         not waffle.switch_is_active('allow-long-addon-guid') and

--- a/src/olympia/signing/tests/test_views.py
+++ b/src/olympia/signing/tests/test_views.py
@@ -1,4 +1,5 @@
 import os
+import json
 from datetime import datetime, timedelta
 
 from django.core.urlresolvers import reverse
@@ -268,6 +269,11 @@ class TestUploadVersionWebextensionOptionalID(BaseUploadVersionCase):
         super(TestUploadVersionWebextensionOptionalID, self).setUp()
         AppVersion.objects.create(application=amo.FIREFOX.id, version='42.0')
         AppVersion.objects.create(application=amo.FIREFOX.id, version='*')
+
+        validate_patcher = mock.patch('validator.validate.validate')
+        run_validator = validate_patcher.start()
+        run_validator.return_value = json.dumps(amo.VALIDATOR_SKELETON_RESULTS)
+        self.addCleanup(validate_patcher.stop)
 
     def test_addon_does_not_exist_webextension(self):
         response = self.request(

--- a/src/olympia/signing/tests/test_views.py
+++ b/src/olympia/signing/tests/test_views.py
@@ -8,10 +8,10 @@ import mock
 from rest_framework.response import Response
 
 from olympia import amo
-from olympia.amo.tests import create_switch
 from olympia.access.models import Group, GroupUser
 from olympia.addons.models import Addon, AddonUser
 from olympia.api.tests.utils import APIKeyAuthTestCase
+from olympia.applications.models import AppVersion
 from olympia.devhub import tasks
 from olympia.files.models import File, FileUpload
 from olympia.signing.views import VersionView
@@ -264,6 +264,11 @@ class TestUploadVersion(BaseUploadVersionCase):
 
 
 class TestUploadVersionWebextensionOptionalID(BaseUploadVersionCase):
+    def setUp(self):
+        super(TestUploadVersionWebextensionOptionalID, self).setUp()
+        AppVersion.objects.create(application=amo.FIREFOX.id, version='42.0')
+        AppVersion.objects.create(application=amo.FIREFOX.id, version='*')
+
     def test_addon_does_not_exist_webextension(self):
         response = self.request(
             'POST',

--- a/src/olympia/signing/tests/test_views.py
+++ b/src/olympia/signing/tests/test_views.py
@@ -264,10 +264,6 @@ class TestUploadVersion(BaseUploadVersionCase):
 
 
 class TestUploadVersionWebextensionOptionalID(BaseUploadVersionCase):
-    def setUp(self):
-        super(TestUploadVersionWebextensionOptionalID, self).setUp()
-        create_switch('addons-linter')
-
     def test_addon_does_not_exist_webextension(self):
         response = self.request(
             'POST',


### PR DESCRIPTION
This fixes #2597