### PR TITLE
Export blocklists json without groupby blockid

### DIFF
--- a/src/olympia/blocklist/tests/test_views.py
+++ b/src/olympia/blocklist/tests/test_views.py
@@ -408,7 +408,8 @@ class BlocklistItemTest(XMLAssertsMixin, BlocklistViewTest):
         self.item.update(os="WINNT 5.0", name="addons name",
                          severity=0, min='0', max='*')
 
-        self.app.update(min='2.0', max='3.0')
+        BlocklistApp.objects.create(blitem=self.item, guid=amo.FIREFOX.guid,
+                                    min="1.0", max="2.0")
 
         details = BlocklistDetail.objects.create(
             name="blocked item",
@@ -417,7 +418,7 @@ class BlocklistItemTest(XMLAssertsMixin, BlocklistViewTest):
             bug="http://bug.url.com/",
         )
 
-        item2 = BlocklistItem.objects.create(guid='guid@addon.com',
+        item2 = BlocklistItem.objects.create(guid=self.item.guid,
                                              os="WINNT 5.0",
                                              name="addons name",
                                              severity=0, min='0', max='*',
@@ -427,14 +428,12 @@ class BlocklistItemTest(XMLAssertsMixin, BlocklistViewTest):
                                     guid=amo.THUNDERBIRD.guid,
                                     min='17.0', max='*')
 
-        BlocklistApp.objects.create(
-            blitem=self.item, guid=amo.FIREFOX.guid,
-            min="1.0", max="2.0")
-
         r = self.client.get(self.json_url)
         blocklist = json.loads(r.content)
 
+        assert 'Firefox' in r.content
         assert 'Thunderbird' in r.content
+        # Items are not grouped by guid
         assert len(blocklist['addons']) == 2
         assert len(blocklist['addons'][0]['versionRange']) == 1
         assert len(blocklist['addons'][1]['versionRange']) == 1

--- a/src/olympia/blocklist/views.py
+++ b/src/olympia/blocklist/views.py
@@ -87,7 +87,7 @@ for m in (BlocklistItem, BlocklistPlugin, BlocklistGfx, BlocklistApp,
                                    dispatch_uid='delete_%s' % m)
 
 
-def get_items(apiver=None, app=None, appver=None):
+def get_items(apiver=None, app=None, appver=None, groupby='guid'):
     # Collapse multiple blocklist items (different version ranges) into one
     # item and collapse each item's apps.
 
@@ -108,7 +108,7 @@ def get_items(apiver=None, app=None, appver=None):
                              'app_max': 'blapps.max'}))
 
     items, details = {}, {}
-    for guid, rows in sorted_groupby(addons, 'guid'):
+    for guid, rows in sorted_groupby(addons, groupby):
         rows = list(rows)
         rr = []
         prefs = []
@@ -171,7 +171,7 @@ def _blocklist_json(request):
 
     It will select blocklists for all apps.
     """
-    items, _ = get_items()
+    items, _ = get_items(groupby='id')
     plugins = get_plugins()
     issuerCertBlocks = BlocklistIssuerCert.objects.all()
     gfxs = BlocklistGfx.objects.all()
@@ -189,7 +189,7 @@ def _blocklist_json(request):
     results = {
         'last_update': last_update,
         'certificates': certificates_to_json(issuerCertBlocks),
-        'add-ons': addons_to_json(items),
+        'addons': addons_to_json(items),
         'plugins': plugins_to_json(plugins),
         'gfx': gfxs_to_json(gfxs),
         'ca': ca,


### PR DESCRIPTION
In the JSON export grouping by guid prevents us to obtain the exaustive list of block ID's and details.

Two block items can have the same guid if they apply to different version range or app (Firefox, Thunderbird, Fennec) and they can have different bug numbers or details description: [i111](https://addons.mozilla.org/fr/firefox/blocked/i111) [i916](https://addons.mozilla.org/fr/firefox/blocked/i918)