### PR TITLE
Just fixes the history link in django admin model forms

### DIFF
--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -366,6 +366,9 @@ class UserProfile(OnChangeMixin, ModelBase,
 
     welcome_name = name
 
+    def get_full_name(self):
+        return self.name
+
     def _anonymous_username_id(self):
         if self.has_anonymous_username():
             return self.username.split('-')[1][:6]


### PR DESCRIPTION
https://sentry.prod.mozaws.net/operations/olympia-dev/issues/328508/
"subclasses of AbstractBaseUser must provide a get_full_name() method"