### PR TITLE
move report numbers down to a new line

### DIFF
--- a/src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html
+++ b/src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html
@@ -41,6 +41,7 @@
         <li class="compat-reports">
           <a href="{{ url('compat.reporter_detail', addon.guid) }}">
             <span>{{ _('Compatibility Reports') }}</span>
+            <br />
             {% set compat_counts = get_compat_counts(addon) %}
             <b class="failure" title="{{ _('{0} failure reports')|f(compat_counts.failure) }}">
               {{ compat_counts.failure|numberfmt }}</b>


### PR DESCRIPTION
* fixes #2175, the compat part, the rest of it looks good to me

before:

<img width="260" alt="screenshot 2016-05-10 13 33 48" src="https://cloud.githubusercontent.com/assets/74699/15161733/2318f7ce-16b4-11e6-833b-93055c3b645f.png">

after:

<img width="262" alt="screenshot 2016-05-10 13 33 36" src="https://cloud.githubusercontent.com/assets/74699/15161725/1b89f120-16b4-11e6-85f3-ed63ac539bd9.png">