### PR TITLE
Fix "get firefox" buttons in Chrome listing pages (fix #2348)

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -2201,7 +2201,7 @@ body.editor-tools {
         .warning {
           color: @link-on-color-bg;
         }
-      }      
+      }
     }
   }
 
@@ -2222,6 +2222,16 @@ body.editor-tools {
         opacity: 0.4;
       }
     }
+  }
+}
+
+.item-info .install-button .button {
+  max-width: 200px;
+  white-space: normal;
+
+  &.download {
+    color: @link-on-color-bg;
+    text-shadow: @dark-gray 1px 1px;
   }
 }
 


### PR DESCRIPTION
### Before

<img width="876" alt="screenshot 2016-05-11 12 41 35" src="https://cloud.githubusercontent.com/assets/90871/15179884/3861d156-1776-11e6-9536-fba4bc6baefa.png">

### After

<img width="763" alt="screenshot 2016-05-11 12 40 30" src="https://cloud.githubusercontent.com/assets/90871/15179887/3c4a8cea-1776-11e6-9cdf-e3a1b0fb0d77.png">
