### PR TITLE
Restore thunderbird download buttons (fix #2406)

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -2327,3 +2327,7 @@ body.windows .install-shell .platform.mac {
 #search-facets .facets .facet > ul {
   overflow-y: visible;
 }
+
+.thunderbird .listing-grid .install-shell {
+  display: block;
+}


### PR DESCRIPTION
### Before

![pic001](https://cloud.githubusercontent.com/assets/18114210/14563939/fc4bfa46-032c-11e6-8804-c8288927e102.jpg)

### After

<img width="271" alt="screenshot 2016-05-11 14 59 04" src="https://cloud.githubusercontent.com/assets/90871/15183483/1ec56b8c-1789-11e6-9c5c-fe0d04268c28.png">

-----
Had to be that specific with the selector, as something else is that specific. 😑