### PR TITLE
increase line height to reduce clipping

### DIFF
--- a/static/css/impala/addon_details.less
+++ b/static/css/impala/addon_details.less
@@ -13,7 +13,7 @@
     }
     #addon-summary {
         font-size: 16px;
-        line-height: 20px;
+        line-height: 21px;
     }
     h1 {
         color: @dark-gray;


### PR DESCRIPTION
* after seeing it in bug #2166 I could not unsee it

before (look at the descender on the "y"):
![screenshot 2016-05-11 15 06 16](https://cloud.githubusercontent.com/assets/74699/15198164/8f2093f6-178a-11e6-9814-060369e16863.png)

after: 

![screenshot 2016-05-11 15 06 05](https://cloud.githubusercontent.com/assets/74699/15198170/93de09e6-178a-11e6-841d-305e87c0daae.png)
