### PR TITLE
pad out title

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -352,6 +352,7 @@ body:not(.home) .amo-header,
 
     small {
       margin-left: 5px;
+      margin-bottom: 10px;
     }
   }
 }


### PR DESCRIPTION
* dammit cannot unsee these things after looking at the style refresh fixes #2144 

before

![screenshot 2016-05-11 15 17 04](https://cloud.githubusercontent.com/assets/74699/15198307/72f1305e-178b-11e6-8e9c-53d0c1a46438.png)

after

![screenshot 2016-05-11 15 16 49](https://cloud.githubusercontent.com/assets/74699/15198310/7a1ccce4-178b-11e6-8cc2-571505388376.png)
