### PR TITLE
Don't cache .tox folder, we recreate the environment every time.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ matrix:
 cache:
   directories:
     - node_modules
-    - .tox
     - $HOME/.cache/pip/
 
 services:


### PR DESCRIPTION
This is a bit experimental, let's see if this will speed things up.