### PR TITLE
Configure settings_test to make sure we're always using the mocked product-details.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ install_command =
 setenv =
     PYTHONPATH=src
     ADDONS_LINTER_BIN={toxinidir}/node_modules/.bin/addons-linter
+    DJANGO_SETTINGS_MODULE=settings_test
 whitelist_externals =
     make
     npm


### PR DESCRIPTION
Refs #2228