### PR TITLE
Remove the (seemingly) unused packages: psutil, sqlparse

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,7 +5,6 @@
 
 # Testing related dependencies
 execnet==1.2 --hash=sha256:16293a69b17c846371f1ccb9cef10ad88838c9d5239ba26d88b39efb7b432f6f
-psutil==0.2.0 --hash=sha256:a103e3f9d07b7fabcf00d1f1c1c28607ba37e41a7e8e63a61bf62acfa02f506c
 py==1.4.30 --hash=sha256:b703e57685ed7c280b1a51c496a4984d83d89def2a930b5e9e5da5a6ca151514 \
            --hash=sha256:07e20ab90a550bd3c21891e0d887f0931b4098f148aec95e29b5188f161bb075
 pytest==2.7.0 --hash=sha256:91dc842785417208d57e5e8dc8bb40f57316c45da24a50c53b49cb8d045519d6
@@ -18,4 +17,3 @@ pytest-xdist==1.13.1 --hash=sha256:4382d7a944c1e2b1dc17fee3fd3575495fb10236a3b6e
 # General development helpers
 django-debug-toolbar==1.3.2 --hash=sha256:d05765591dce6a00aa5fc66179c5cfcfd9540f92046ce8a9e37cf3d4b8d5fe17
 django-fixture-magic==0.0.4 --hash=sha256:8ca514d1f52e57475ffc744e93161eb50848dcec245a16c06d8c5b7b5497c305
-sqlparse==0.1.14 --hash=sha256:36f0f40af9ef4d358b963ab275f62331083c68290a3d14a2199d5dd4d98cc45d


### PR DESCRIPTION
Nothing obviously fails... but I don't know what they were used for anyway :grimacing: 