### PR TITLE
Only remove margin on addon-details (fix #2691)

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -293,6 +293,9 @@ body:not(.home) .amo-header,
 .addon-details .header-bg,
 .home .header-bg {
   min-height: 130px;
+}
+
+.addon-details .header-bg {
   margin-bottom: 0;
 }
 


### PR DESCRIPTION
### Before

<img width="1350" alt="screenshot 2016-05-17 15 12 43" src="https://cloud.githubusercontent.com/assets/90871/15325364/17d6495a-1c42-11e6-8ed9-bc58807a8c45.png">

### After

<img width="1350" alt="screenshot 2016-05-17 15 13 09" src="https://cloud.githubusercontent.com/assets/90871/15325418/3d7f152e-1c42-11e6-8383-15a6c950f29b.png">