### PR TITLE
Prevent cut off of last row (fix #2622)

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -1939,7 +1939,7 @@ h3.author .transfer-ownership {
 
 // Theme detail page
 #persona #more-personas .article {
-  padding: 0 10px 10px;
+  padding: 0 10px 20px;
 
   .persona.hovercard:nth-child(odd) {
     clear: left;


### PR DESCRIPTION
### Before
<img width="478" alt="screenshot 2016-05-18 12 31 03" src="https://cloud.githubusercontent.com/assets/90871/15357084/9b936ec8-1cf4-11e6-8b5c-37fd9c2b95d4.png">
### After
<img width="480" alt="screenshot 2016-05-18 12 30 50" src="https://cloud.githubusercontent.com/assets/90871/15357085/9bb5aaec-1cf4-11e6-9136-a34fc73720ec.png">
