### PR TITLE
random requirement clearing - we don't use basket-client

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -11,8 +11,6 @@ argparse==1.2.1 --hash=sha256:bd3ecb056ac35bb01dd7de6b62b19d46897cba10ac85cf5592
                 --hash=sha256:ddaf4b0a618335a32b6664d4ae038a1de8fbada3b25033f9021510ed2b3941a4
 # babel is required by django-babel, puente
 babel==0.9.6 --hash=sha256:7681559bbd3f1694b05771942bd71b1ad9a1b2d39ee79e0c669ec88bb19a6bb3
-basket-client==0.3.7 --hash=sha256:dd8dffa3c5d2644f5ddcab3b7f535641186528ccf5c412526c81d69b3e31cffc \
-                     --hash=sha256:f60ef330944983b3c3a99532487e04dcc3126e61f4fda16530ac558d6b75d705
 # billiard is required by celery
 billiard==3.3.0.22 --hash=sha256:d216181387317f8696c6d1c80a2491258d037493c1f0c6eb58992a549481e77e
 bleach==1.4 --hash=sha256:5f48e7cd0fd91a35dd0433b22b4de1536cf5d826a6377dea7de7ee695c570da6 \

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1594,9 +1594,6 @@ LANGPACK_PATH_DEFAULT = '%s/releases/%s/win32/xpi/'
 LANGPACK_MANIFEST_PATH = '../../SHA512SUMS'
 LANGPACK_MAX_SIZE = 5 * 1024 * 1024  # 5MB should be more than enough
 
-# Basket subscription url for newsletter signups
-BASKET_URL = 'https://basket.mozilla.com'
-
 # This saves us when we upgrade jingo-minify (jsocol/jingo-minify@916b054c).
 JINGO_MINIFY_USE_STATIC = True
 


### PR DESCRIPTION
I'm pretty certain basket was only used for the Marketplace newsletter. 