### PR TITLE
Fix #2668 - fix handling of large output from addons-linter.

### DIFF
--- a/src/olympia/devhub/tasks.py
+++ b/src/olympia/devhub/tasks.py
@@ -422,7 +422,11 @@ def run_addons_linter(path, listed=True):
 
     file_size = os.path.getsize(path)
 
-    if file_size > settings.FILE_UPLOAD_MAX_MEMORY_SIZE:
+    # If the add-on file is large we assume that the generated output
+    # can be large and pipe it into a temporary file.
+    # This isn't a guarantee so let's see how it goes and maybe fall back
+    # to using a temporary file for everything if something breaks
+    if file_size > settings.ADDONS_LINTER_MAX_MEMORY_SIZE:
         stdout, stderr = tempfile.TemporaryFile(), tempfile.TemporaryFile()
     else:
         stdout, stderr = subprocess.PIPE, subprocess.PIPE

--- a/src/olympia/devhub/tests/test_tasks.py
+++ b/src/olympia/devhub/tests/test_tasks.py
@@ -536,7 +536,7 @@ class TestRunAddonsLinter(ValidatorTestCase):
 
         assert exc.value.message == (
             'Path "doesntexist" is not a file or directory or '
-            'does not exist.\n')
+            'does not exist.')
 
     def test_run_linter_large_output(self):
         result = json.loads(

--- a/src/olympia/devhub/tests/test_tasks.py
+++ b/src/olympia/devhub/tests/test_tasks.py
@@ -538,6 +538,14 @@ class TestRunAddonsLinter(ValidatorTestCase):
             'Path "doesntexist" is not a file or directory or '
             'does not exist.\n')
 
+    def test_run_linter_large_output(self):
+        result = json.loads(
+            tasks.run_addons_linter(get_addon_file('bookmark.xpi')))
+
+        assert result['success']
+        assert result['warnings']
+        assert not result['errors']
+
 
 class TestValidateFilePath(ValidatorTestCase):
 

--- a/src/olympia/devhub/tests/test_tasks.py
+++ b/src/olympia/devhub/tests/test_tasks.py
@@ -538,13 +538,39 @@ class TestRunAddonsLinter(ValidatorTestCase):
             'Path "doesntexist" is not a file or directory or '
             'does not exist.')
 
-    def test_run_linter_large_output(self):
-        result = json.loads(
-            tasks.run_addons_linter(get_addon_file('bookmark.xpi')))
+    def test_run_linter_use_memory_for_output(self):
+        # valid_webextension.xpi is approx 1.2K, the default setting of
+        # ADDONS_LINTER_MAX_MEMORY_SIZE is 2M so `run_addons_linter`
+        # uses in-memory storage for the output.
+        TemporaryFile = tempfile.TemporaryFile
 
-        assert result['success']
-        assert result['warnings']
-        assert not result['errors']
+        with mock.patch('olympia.devhub.tasks.tempfile.TemporaryFile') as tmpf:
+            tmpf.side_effect = lambda *a, **kw: TemporaryFile(*a, **kw)
+
+            result = json.loads(tasks.run_addons_linter(
+                get_addon_file('valid_webextension.xpi')
+            ))
+
+            assert tmpf.call_count == 0
+            assert result['success']
+            assert not result['warnings']
+            assert not result['errors']
+
+    @override_settings(ADDONS_LINTER_MAX_MEMORY_SIZE=800)
+    def test_run_linter_use_temporary_file_large_output(self):
+        TemporaryFile = tempfile.TemporaryFile
+
+        with mock.patch('olympia.devhub.tasks.tempfile.TemporaryFile') as tmpf:
+            tmpf.side_effect = lambda *a, **kw: TemporaryFile(*a, **kw)
+
+            result = json.loads(tasks.run_addons_linter(
+                get_addon_file('valid_webextension.xpi')
+            ))
+
+            assert tmpf.call_count == 2
+            assert result['success']
+            assert not result['warnings']
+            assert not result['errors']
 
 
 class TestValidateFilePath(ValidatorTestCase):

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1683,3 +1683,5 @@ REST_FRAMEWORK = {
 # This is the DSN to the local Sentry service. It might be overidden in
 # site-specific settings files as well.
 SENTRY_DSN = os.environ.get('SENTRY_DSN')
+
+ADDONS_LINTER_MAX_MEMORY_SIZE = 2 * 1024 * 1024


### PR DESCRIPTION
stderr and stdout are now written to a temporary file instead of PIPE
to allow for larger outputs and less memory pressure.

Unforunately this adds a quite slow test but I figured that's the best
way to test it :(