### PR TITLE
Handle non-existing or non-public add-ons in discovery API

### DIFF
--- a/src/olympia/discovery/views.py
+++ b/src/olympia/discovery/views.py
@@ -22,6 +22,11 @@ class DiscoveryViewSet(ListModelMixin, GenericViewSet):
         addons = self.queryset.in_bulk(ids)
 
         # Patch items to add addons.
+        result = []
         for item in discopane_items:
-            item.addon = addons[item.addon_id]
-        return discopane_items
+            try:
+                item.addon = addons[item.addon_id]
+                result.append(item)
+            except KeyError:
+                pass
+        return result

--- a/src/olympia/discovery/views.py
+++ b/src/olympia/discovery/views.py
@@ -1,3 +1,4 @@
+from django_statsd.clients import statsd
 from rest_framework.mixins import ListModelMixin
 from rest_framework.viewsets import GenericViewSet
 
@@ -28,5 +29,7 @@ class DiscoveryViewSet(ListModelMixin, GenericViewSet):
                 item.addon = addons[item.addon_id]
                 result.append(item)
             except KeyError:
-                pass
+                # Ignore this missing add-on, but increment a counter so we
+                # know something happened.
+                statsd.incr('discovery.api.missing_item')
         return result


### PR DESCRIPTION
I had planned to do this and somehow forgot...