### PR TITLE
changes upload new file to always be upload new version in devhub nav

### DIFF
--- a/src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html
+++ b/src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html
@@ -5,6 +5,9 @@
   (addon.get_dev_url('payments'), _('Manage Payments')),
   (addon.get_dev_url('versions'), _('Manage Status & Versions')),
 ] %}
+{% if not no_inline_version_upload %}
+    {% set version_upload_class = 'version-upload' %}
+{% endif %}
 
 <section class="secondary" role="complementary">
   <div class="addon-status">
@@ -15,8 +18,9 @@
     <p class="addon-upload">
       {% if not addon.is_incomplete() and not addon.is_disabled %}
         <strong>
-          <a href="{{ addon.get_dev_url('versions') }}#version-upload" class="version-upload"
-          >{{ upload_file_label|default(_('Upload New Version')) }}</a>
+          <a href="{{ addon.get_dev_url('versions') }}#version-upload"
+             class="{{ version_upload_class }}">
+            {{ _('Upload New Version') }}</a>
         </strong>
         &middot;
       {% endif %}

--- a/src/olympia/devhub/templates/devhub/versions/edit.html
+++ b/src/olympia/devhub/templates/devhub/versions/edit.html
@@ -146,6 +146,6 @@
                     url('devhub.versions.add_file', addon.slug, version.id),
                     _('Add File') )}}
 </section>
-{% set upload_file_label = _('Upload a new file') %}
+{% set no_inline_version_upload = True %}
 {% include "devhub/includes/addons_edit_nav.html" %}
 {% endblock %}

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -76,9 +76,10 @@ class TestVersion(TestCase):
         url = reverse('devhub.versions.edit',
                       args=(self.addon.slug, self.version.pk))
         r = self.client.get(url)
-        doc = pq(r.content)
-        assert doc('.addon-status>.addon-upload>strong>a').text() == (
-            'Upload a new file')
+        link = pq(r.content)('.addon-status>.addon-upload>strong>a')
+        assert link.text() == 'Upload New Version'
+        assert link.attr('href') == '%s#version-upload' % (
+            reverse('devhub.addons.versions', args=[self.addon.slug]))
 
     def test_delete_message(self):
         """Make sure we warn our users of the pain they will feel."""


### PR DESCRIPTION
On all the devhub pages for an addon the left navbar has a link to upload a new version, except the edit version page, where it adds a new file.  This is inconsistent UX; rarely what the developer wants to do; and only shows up on the one page where there is a button to do the same thing (i.e. the edit version page). This pull fixes that.

(It also does no checks about if you should be _able to_ add a new file, unlike the button on the page itself that calls `is_allowed_upload` to only appear when needed.)

@jvillalobos in case the existing functionality was actually desired.