### PR TITLE
Add more languages to the list of our supported languages.

### DIFF
--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -133,10 +133,11 @@ LANGUAGE_CODE = 'en-US'
 # Note: If you update this list, don't forget to also update the locale
 # permissions in the database.
 AMO_LANGUAGES = (
-    'af', 'ar', 'bg', 'bn-BD', 'ca', 'cs', 'da', 'de', 'el', 'en-GB', 'en-US',
-    'es', 'eu', 'fa', 'fi', 'fr', 'ga-IE', 'he', 'hu', 'id', 'it', 'ja', 'ko',
-    'mk', 'mn', 'nl', 'pl', 'pt-BR', 'pt-PT', 'ro', 'ru', 'sk', 'sl', 'sq',
-    'sv-SE', 'uk', 'vi', 'zh-CN', 'zh-TW',
+    'af', 'ar', 'bg', 'bn-BD', 'ca', 'cs', 'da', 'de', 'dsb',
+    'el', 'en-GB', 'en-US', 'es', 'eu', 'fa', 'fi', 'fr', 'ga-IE', 'he', 'hu',
+    'hsb', 'id', 'it', 'ja', 'ka', 'ko', 'nn-NO', 'mk', 'mn', 'nl', 'pl',
+    'pt-BR', 'pt-PT', 'ro', 'ru', 'sk', 'sl', 'sq', 'sv-SE', 'uk', 'vi',
+    'zh-CN', 'zh-TW',
 )
 
 # Explicit conversion of a shorter language code into a more specific one.


### PR DESCRIPTION
Add more languages to the list of our supported languages.

* Add 'ka' (Georgia) locale to our translations.
* Add 'dsb' (Lower Sorbian) and hsb (Upper Sorbian) to supported list of languages.
* Add 'nn-NO' (Norwegian Nynorsk) to the list of supported languages

fixes #2479 (opened a followup ticket for ka-GE in #2739), fixes #2416 