### PR TITLE
Fix wrong coding: file-header to make sure it doesn't break on tools using it.

### DIFF
--- a/src/olympia/addons/tests/test_cron.py
+++ b/src/olympia/addons/tests/test_cron.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 import os
 import datetime
 import time

--- a/src/olympia/constants/payments.py
+++ b/src/olympia/constants/payments.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 from olympia.lib.constants import ALL_CURRENCIES
 
 # Source, PayPal docs, PP_AdaptivePayments.PDF

--- a/src/olympia/files/tests/test_tasks.py
+++ b/src/olympia/files/tests/test_tasks.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 import mock
 from datetime import datetime, timedelta
 

--- a/src/olympia/lib/constants.py
+++ b/src/olympia/lib/constants.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 from django.utils.translation import ugettext_lazy as _lazy
 
 


### PR DESCRIPTION
I noticed this when I tried running `makemessages` (which is stupid because we're using puente...) and xgettext failed very hard reading the files.