### PR TITLE
Only load 6 items when displaying grids of addons on homepage/category page

### DIFF
--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -345,16 +345,23 @@ def home(request):
     # This is lame for performance. Kill it with ES.
     frozen = list(FrozenAddon.objects.values_list('addon', flat=True))
 
-    # Collections.
+    # We want to display 6 Featured Extensions, Up & Coming Extensions and
+    # Featured Themes.
+    featured = Addon.objects.featured(request.APP, request.LANG,
+                                      amo.ADDON_EXTENSION)[:6]
+    hotness = base.exclude(id__in=frozen).order_by('-hotness')[:6]
+    personas = Addon.objects.featured(request.APP, request.LANG,
+                                      amo.ADDON_PERSONA)[:6]
+
+    # Most Popular extensions is a simple links list, we display slightly more.
+    popular = base.exclude(id__in=frozen).order_by('-average_daily_users')[:10]
+
+    # We want a maximum of 6 Featured Collections as well (though we may get
+    # fewer than that).
     collections = Collection.objects.filter(listed=True,
                                             application=request.APP.id,
-                                            type=amo.COLLECTION_FEATURED)
-    featured = Addon.objects.featured(request.APP, request.LANG,
-                                      amo.ADDON_EXTENSION)[:18]
-    popular = base.exclude(id__in=frozen).order_by('-average_daily_users')[:10]
-    hotness = base.exclude(id__in=frozen).order_by('-hotness')[:18]
-    personas = Addon.objects.featured(request.APP, request.LANG,
-                                      amo.ADDON_PERSONA)[:18]
+                                            type=amo.COLLECTION_FEATURED)[:6]
+
     return render(request, 'addons/home.html',
                   {'popular': popular, 'featured': featured,
                    'hotness': hotness, 'personas': personas,

--- a/src/olympia/browse/templates/browse/impala/category_landing.html
+++ b/src/olympia/browse/templates/browse/impala/category_landing.html
@@ -25,7 +25,7 @@
   {% endif %}
 
   {% for key, title in filter.opts if key != 'featured' %}
-  {% set addons = addon_sets[key][:18] %}
+  {% set addons = addon_sets[key][:6] %}
   {% set link = request.get_full_path()|urlparams(sort=key) %}
   {% set hc_src = 'cb-hc-' + src_dict[key] %}
   {% set dl_src = 'cb-dl-' + src_dict[key] %}


### PR DESCRIPTION
We used to load 18 and have js pagination, but the style refresh killed the pagination (yay) so we no longer need to load 18 add-ons in each block. The 12 extra hidden add-ons were just a waste of bandwidth, causing us to load extra HTML and images, so removing them should help performance quite a bit.

Fix #2743