### PR TITLE
This unfortunately broke with the recent babel upgrade.

### DIFF
--- a/src/olympia/amo/tests/test_utils_.py
+++ b/src/olympia/amo/tests/test_utils_.py
@@ -3,11 +3,13 @@ import tempfile
 
 import mock
 import pytest
+from django.conf import settings
 
 from olympia import amo
 from olympia.amo.tests import TestCase, addon_factory
 from olympia.amo.utils import (
-    attach_trans_dict, translations_for_field, walkfiles)
+    attach_trans_dict, translations_for_field, walkfiles,
+    get_locale_from_lang)
 from olympia.addons.models import Addon
 from olympia.versions.models import Version
 
@@ -172,3 +174,9 @@ def test_set_writable_cached_property():
     del foo.bar
     assert foo.bar == 'original value'
     assert callme.call_count == 1
+
+
+@pytest.mark.parametrize('lang', settings.AMO_LANGUAGES)
+def test_get_locale_from_lang(lang):
+    """Make sure all languages in settings.AMO_LANGUAGES can be resolved."""
+    get_locale_from_lang(lang)

--- a/src/olympia/amo/tests/test_utils_.py
+++ b/src/olympia/amo/tests/test_utils_.py
@@ -3,6 +3,7 @@ import tempfile
 
 import mock
 import pytest
+from babel import Locale
 from django.conf import settings
 
 from olympia import amo
@@ -179,4 +180,14 @@ def test_set_writable_cached_property():
 @pytest.mark.parametrize('lang', settings.AMO_LANGUAGES)
 def test_get_locale_from_lang(lang):
     """Make sure all languages in settings.AMO_LANGUAGES can be resolved."""
-    get_locale_from_lang(lang)
+    locale = get_locale_from_lang(lang)
+
+    assert isinstance(locale, Locale)
+    assert locale.language == lang[:2]
+
+    separator = filter(
+        None, [sep if sep in lang else None for sep in ('-', '_')])
+
+    if separator:
+        territory = lang.split(separator[0])[1]
+        assert locale.territory == territory

--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -597,7 +597,8 @@ def get_locale_from_lang(lang):
     # Special fake language can just act like English for formatting and such
     if not lang or lang == 'dbg':
         lang = 'en'
-    return Locale(translation.to_locale(lang))
+
+    return Locale.parse(translation.to_locale(lang))
 
 
 class HttpResponseSendFile(http.HttpResponse):


### PR DESCRIPTION
Make sure we use Locale.parse, this also adds a test that makes
sure we now can resolve all language codes that reside
in AMO_LANGUAGES.

Fixes #2753