### PR TITLE
Format heading field server-side in discovery API, returning HTML directly

### DIFF
--- a/docs/topics/api/discovery.rst
+++ b/docs/topics/api/discovery.rst
@@ -19,6 +19,6 @@ Firefox (about:addons).
 
     :>json int count: The number of results for this query.
     :>json array results: The array containing the results for this query.
-    :>json string results[].heading: The heading for this item. May contain the following sub-strings, that clients need to use to format the string as they desire: ``{start_sub_heading}``, ``{end_sub_heading}`` and ``{addon_name}``.
+    :>json string results[].heading: The heading for this item. May contain some HTML tags.
     :>json string|null results[].description: The description for this item, if any. May contain some HTML tags.
     :>json object results[].addon: The :ref:`add-on <addon-detail-object>` for this item. Only a subset of fields are present: ``id``, ``current_version`` (with only the ``compatibility`` and ``files`` fields present), ``guid``, ``icon_url``, ``name``, ``slug``, ``theme_data``, ``type`` and ``url``.

--- a/src/olympia/discovery/serializers.py
+++ b/src/olympia/discovery/serializers.py
@@ -29,4 +29,9 @@ class DiscoverySerializer(serializers.Serializer):
         data = super(DiscoverySerializer, self).to_representation(instance)
         if data['heading'] is None:
             data['heading'] = unicode(instance.addon.name)
+        else:
+            data['heading'] = data['heading'].replace(
+                '{start_sub_heading}', '<span>').replace(
+                '{end_sub_heading}', '</span>').replace(
+                '{addon_name}', unicode(instance.addon.name))
         return data


### PR DESCRIPTION
Fix #2752