### PR TITLE
Add a DRF exception handler to catch all exceptions in API code

### DIFF
--- a/src/olympia/api/exceptions.py
+++ b/src/olympia/api/exceptions.py
@@ -1,0 +1,43 @@
+from django.conf import settings
+from django.core.signals import got_request_exception
+
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import exception_handler
+
+
+def custom_exception_handler(exc, context=None):
+    """
+    Custom exception handler for DRF, which ensures every exception we throw
+    is caught, returned as a nice DRF Response, while still going to sentry
+    etc.
+
+    The default DRF exception handler does some of this work already, but it
+    lets non-api exceptions through, and we don't want that.
+    """
+    # If propagate is true, bail early.
+    if settings.DEBUG_PROPAGATE_EXCEPTIONS:
+        raise
+
+    # Call REST framework's default exception handler first,
+    # to get the standard error response.
+    response = exception_handler(exc, context)
+
+    # If the response is None, then DRF didn't handle the exception and we
+    # should do it ourselves.
+    if response is None:
+        # Start with a generic default error message.
+        data = {"detail": "Internal Server Error"}
+
+        # Send the got_request_exception signal so other apps like sentry
+        # are aware of the exception. The sender does not match what a real
+        # exception would do (we don't have access to the handler here) but it
+        # should not be an issue, what matters is the request.
+        request = context.get('request')
+        sender = context.get('view').__class__
+        got_request_exception.send(sender, request=request)
+
+        # Send the 500 response back.
+        response = Response(data, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    return response

--- a/src/olympia/api/exceptions.py
+++ b/src/olympia/api/exceptions.py
@@ -27,7 +27,7 @@ def custom_exception_handler(exc, context=None):
     # should do it ourselves.
     if response is None:
         # Start with a generic default error message.
-        data = {"detail": "Internal Server Error"}
+        data = {'detail': 'Internal Server Error'}
 
         # Send the got_request_exception signal so other apps like sentry
         # are aware of the exception. The sender does not match what a real

--- a/src/olympia/api/tests/test_exceptions.py
+++ b/src/olympia/api/tests/test_exceptions.py
@@ -1,0 +1,128 @@
+from django.core.urlresolvers import reverse
+from django.http import Http404
+from django.test import TestCase
+
+import mock
+from rest_framework.exceptions import APIException, PermissionDenied
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.routers import SimpleRouter
+from rest_framework.settings import api_settings
+from rest_framework.viewsets import GenericViewSet
+
+
+class TestViewSet(GenericViewSet):
+    """Dummy test viewset that raises an exception when calling list()."""
+    def list(self, *args, **kwargs):
+        raise Exception('something went wrong')
+
+test_exception = SimpleRouter()
+test_exception.register('testexcept', TestViewSet, base_name='test-exception')
+
+
+class TestExceptionHandlerWithViewSet(TestCase):
+    urls = test_exception.urls
+
+    # The test client connects to got_request_exception, so we need to mock it
+    # otherwise it would immediately re-raise the exception.
+    @mock.patch('olympia.api.exceptions.got_request_exception')
+    def test_view_exception(self, got_request_exception_mock):
+        url = reverse('test-exception-list')
+        with self.settings(DEBUG_PROPAGATE_EXCEPTIONS=False):
+            response = self.client.get(url)
+            assert response.status_code == 500
+
+        assert got_request_exception_mock.send.call_count == 1
+        assert got_request_exception_mock.send.call_args[0][0] == TestViewSet
+        assert isinstance(
+            got_request_exception_mock.send.call_args[1]['request'], Request)
+
+
+class TestExceptionHandler(TestCase):
+    def test_api_exception_handler_returns_response(self):
+        exception_handler = api_settings.EXCEPTION_HANDLER
+
+        with self.settings(DEBUG_PROPAGATE_EXCEPTIONS=False):
+            try:
+                raise APIException()
+            except Exception as exc:
+                response = exception_handler(exc, {})
+                assert isinstance(response, Response)
+                assert response.status_code == 500
+
+    def test_exception_handler_returns_response_for_404(self):
+        exception_handler = api_settings.EXCEPTION_HANDLER
+
+        with self.settings(DEBUG_PROPAGATE_EXCEPTIONS=False):
+            try:
+                raise Http404()
+            except Exception as exc:
+                response = exception_handler(exc, {})
+                assert isinstance(response, Response)
+                assert response.status_code == 404
+
+    def test_exception_handler_returns_response_for_403(self):
+        exception_handler = api_settings.EXCEPTION_HANDLER
+
+        with self.settings(DEBUG_PROPAGATE_EXCEPTIONS=False):
+            try:
+                raise PermissionDenied()
+            except Exception as exc:
+                response = exception_handler(exc, {})
+                assert isinstance(response, Response)
+                assert response.status_code == 403
+
+    def test_non_api_exception_handler_returns_response(self):
+        # Regular DRF exception handler does not return a Response for non-api
+        # exceptions, but we do.
+        exception_handler = api_settings.EXCEPTION_HANDLER
+
+        with self.settings(DEBUG_PROPAGATE_EXCEPTIONS=False):
+            try:
+                raise Exception()
+            except Exception as exc:
+                response = exception_handler(exc, {})
+                assert isinstance(response, Response)
+                assert response.status_code == 500
+
+    def test_api_exception_handler_with_propagation(self):
+        exception_handler = api_settings.EXCEPTION_HANDLER
+
+        with self.assertRaises(APIException):
+            with self.settings(DEBUG_PROPAGATE_EXCEPTIONS=True):
+                try:
+                    raise APIException()
+                except Exception as exc:
+                    exception_handler(exc, {})
+
+    def test_exception_handler_404_with_propagation(self):
+        exception_handler = api_settings.EXCEPTION_HANDLER
+
+        with self.assertRaises(Http404):
+            with self.settings(DEBUG_PROPAGATE_EXCEPTIONS=True):
+                try:
+                    raise Http404()
+                except Exception as exc:
+                    exception_handler(exc, {})
+
+    def test_exception_handler_403_with_propagation(self):
+        exception_handler = api_settings.EXCEPTION_HANDLER
+
+        with self.assertRaises(PermissionDenied):
+            with self.settings(DEBUG_PROPAGATE_EXCEPTIONS=True):
+                try:
+                    raise PermissionDenied()
+                except Exception as exc:
+                    exception_handler(exc, {})
+
+    def test_non_api_exception_handler_with_propagation(self):
+        # Regular DRF exception handler does not return a Response for non-api
+        # exceptions, but we do.
+        exception_handler = api_settings.EXCEPTION_HANDLER
+
+        with self.assertRaises(KeyError):
+            with self.settings(DEBUG_PROPAGATE_EXCEPTIONS=True):
+                try:
+                    raise KeyError()
+                except Exception as exc:
+                    exception_handler(exc, {})

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1688,6 +1688,10 @@ REST_FRAMEWORK = {
         'rest_framework.parsers.FormParser',
         'olympia.api.parsers.MultiPartParser',
     ),
+    # Add our custom exception handler, that wraps all exceptions into
+    # Responses and not just the ones that are api-related.
+    'EXCEPTION_HANDLER': 'olympia.api.exceptions.custom_exception_handler',
+
     # Enable pagination
     'PAGE_SIZE': 25,
 }


### PR DESCRIPTION
This allows us to return a nice 500 error for unhandled exceptions in the API, while still sending the exception to sentry.

Fix #2735