### PR TITLE
Always return large preview in Persona.theme_data (fix #2756)

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1759,7 +1759,7 @@ class Persona(caching.CachingMixin, models.Model):
             'footer': self.footer_url or '',
             'headerURL': self.header_url,
             'footerURL': self.footer_url or '',
-            'previewURL': self.thumb_url,
+            'previewURL': self.preview_url,
             'iconURL': self.icon_url,
             'updateURL': self.update_url,
             'detailURL': helpers.absolutify(self.addon.get_url_path()),

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -1846,9 +1846,48 @@ class TestPersonaModel(TestCase):
             assert data['footerURL'].startswith(
                 '%s%s/footer.png?' % (user_media_url('addons'), id_))
             assert data['previewURL'].startswith(
-                '%s%s/preview.jpg?' % (user_media_url('addons'), id_))
+                '%s%s/preview_large.jpg?' % (user_media_url('addons'), id_))
             assert data['iconURL'].startswith(
                 '%s%s/preview_small.jpg?' % (user_media_url('addons'), id_))
+
+            assert data['detailURL'] == (
+                'https://omgsh.it%s' % self.persona.addon.get_url_path())
+            assert data['updateURL'] == (
+                'https://vamo/fr/themes/update-check/' + id_)
+            assert data['version'] == '1.0'
+
+    def test_json_data_new_persona(self):
+        self.persona.persona_id = 0  # Make this a "new" theme.
+        self.persona.save()
+
+        self.persona.addon.all_categories = [Category(name='Yolo Art')]
+
+        VAMO = 'https://vamo/%(locale)s/themes/update-check/%(id)d'
+
+        with self.settings(LANGUAGE_CODE='fr',
+                           LANGUAGE_URL_MAP={},
+                           NEW_PERSONAS_UPDATE_URL=VAMO,
+                           SITE_URL='https://omgsh.it'):
+            data = self.persona.theme_data
+
+            id_ = str(self.persona.addon.id)
+
+            assert data['id'] == id_
+            assert data['name'] == unicode(self.persona.addon.name)
+            assert data['accentcolor'] == '#8d8d97'
+            assert data['textcolor'] == '#ffffff'
+            assert data['category'] == 'Yolo Art'
+            assert data['author'] == 'persona_author'
+            assert data['description'] == unicode(self.addon.description)
+
+            assert data['headerURL'].startswith(
+                '%s%s/header.png?' % (user_media_url('addons'), id_))
+            assert data['footerURL'].startswith(
+                '%s%s/footer.png?' % (user_media_url('addons'), id_))
+            assert data['previewURL'].startswith(
+                '%s%s/preview.png?' % (user_media_url('addons'), id_))
+            assert data['iconURL'].startswith(
+                '%s%s/icon.png?' % (user_media_url('addons'), id_))
 
             assert data['detailURL'] == (
                 'https://omgsh.it%s' % self.persona.addon.get_url_path())


### PR DESCRIPTION
It only matters for old themes, which have a different image for the medium and large previews, new themes all use preview.png anyway.

(services/theme_update.py was already using preview.png)

#2756