### PR TITLE
Bring back linkify_title option in legacy discovery modules

### DIFF
--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -707,7 +707,8 @@ def collection_factory(**kw):
     }
     data.update(kw)
     c = Collection(**data)
-    c.slug = data['name'].replace(' ', '-').lower()
+    if c.slug is None:
+        c.slug = data['name'].replace(' ', '-').lower()
     c.rating = (c.upvotes - c.downvotes) * math.log(c.upvotes + c.downvotes)
     c.created = c.modified = datetime(2011, 11, 11, random.randint(0, 23),
                                       random.randint(0, 59))

--- a/src/olympia/legacy_discovery/modules.py
+++ b/src/olympia/legacy_discovery/modules.py
@@ -84,6 +84,7 @@ class CollectionPromo(PromoModule):
     subtitle = None
     cls = 'promo'
     limit = 3
+    linkify_title = False
 
     def __init__(self, *args, **kw):
         super(CollectionPromo, self).__init__(*args, **kw)
@@ -297,3 +298,4 @@ class Games(CollectionPromo):
     subtitle = _(u'Add more fun to your Firefox. Play dozens of games right '
                  u'from your browser—puzzles, classic arcade, action games, '
                  u'and more!')
+    linkify_title = True

--- a/src/olympia/legacy_discovery/templates/legacy_discovery/modules/collection.html
+++ b/src/olympia/legacy_discovery/templates/legacy_discovery/modules/collection.html
@@ -3,7 +3,17 @@
 <li class="panel">
   <div id="{{ promo.id }}" class="feature promo-collection {{ promo.cls }}">
     <hgroup>
-      <h2>{{ promo.title|safe }}</h2>
+      {% if promo.linkify_title %}
+        <h2>
+          {% if module_context == 'discovery' %}
+            <a href="{{ collection.get_url_path()|urlparams(src='discovery-promo') }}">{{ promo.title|safe }}</a>
+          {% else %}
+            <a href="{{ collection.get_url_path()|urlparams(src='hp-dl-promo') }}">{{ promo.title|safe }}</a>
+          {% endif %}
+        </h2>
+      {% else %}
+        <h2>{{ promo.title|safe }}</h2>
+      {% endif %}
       {% if promo.subtitle %}
         <h3>{{ promo.subtitle|safe }}</h3>
       {% endif %}


### PR DESCRIPTION
Fix https://github.com/mozilla/addons/issues/118 : we want that option back for the new new Games! promo module.

Also fix the broken tests while we're at it...