### PR TITLE
Allow all reviewed add-ons in the add-ons API, not just public ones

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1235,6 +1235,9 @@ class Addon(OnChangeMixin, ModelBase):
     def is_rejected(self):
         return self.status == amo.STATUS_REJECTED
 
+    def is_reviewed(self):
+        return self.status in amo.REVIEWED_STATUSES
+
     def can_be_deleted(self):
         return not self.is_deleted
 

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -705,6 +705,28 @@ class TestAddonModels(TestCase):
         assert not a.is_public(), (
             'unreviewed, disabled add-on should not be is_public()')
 
+    def test_is_reviewed(self):
+        # Public add-on.
+        addon = Addon.objects.get(pk=3615)
+        assert addon.status == amo.STATUS_PUBLIC
+        assert addon.is_reviewed()
+
+        # Public, disabled add-on.
+        addon.disabled_by_user = True
+        assert addon.is_reviewed()  # It's still considered "reviewed".
+
+        # Preliminarily Reviewed.
+        addon.status = amo.STATUS_LITE
+        assert addon.is_reviewed()
+
+        # Preliminarily Reviewed and Awaiting Full Review.
+        addon.status = amo.STATUS_LITE_AND_NOMINATED
+        assert addon.is_reviewed()
+
+        # Unreviewed add-on.
+        addon.status = amo.STATUS_UNREVIEWED
+        assert not addon.is_reviewed()
+
     def test_is_no_restart(self):
         a = Addon.objects.get(pk=3615)
         f = a.current_version.all_files[0]

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -43,12 +43,12 @@ from olympia.bandwagon.models import (
 from olympia import paypal
 from olympia.api.paginator import ESPageNumberPagination
 from olympia.api.permissions import (
-    AllowAddonAuthor, AllowReadOnlyIfPublicAndListed, AllowReviewer,
+    AllowAddonAuthor, AllowReadOnlyIfReviewedAndListed, AllowReviewer,
     AllowReviewerUnlisted, AnyOf)
 from olympia.reviews.forms import ReviewForm
 from olympia.reviews.models import Review, GroupedRating
 from olympia.search.filters import (
-    PublicContentFilter, SearchParameterFilter, SearchQueryFilter,
+    ReviewedContentFilter, SearchParameterFilter, SearchQueryFilter,
     SortingFilter)
 from olympia.stats.models import Contribution
 from olympia.translations.query import order_by_translation
@@ -651,7 +651,7 @@ def persona_redirect(request, persona_id):
 
 class AddonViewSet(RetrieveModelMixin, GenericViewSet):
     permission_classes = [
-        AnyOf(AllowReadOnlyIfPublicAndListed, AllowAddonAuthor,
+        AnyOf(AllowReadOnlyIfReviewedAndListed, AllowAddonAuthor,
               AllowReviewer, AllowReviewerUnlisted),
     ]
     serializer_class = AddonSerializer
@@ -690,7 +690,7 @@ class AddonViewSet(RetrieveModelMixin, GenericViewSet):
 class AddonSearchView(ListAPIView):
     authentication_classes = []
     filter_backends = [
-        PublicContentFilter, SearchQueryFilter, SearchParameterFilter,
+        ReviewedContentFilter, SearchQueryFilter, SearchParameterFilter,
         SortingFilter,
     ]
     pagination_class = ESPageNumberPagination

--- a/src/olympia/api/permissions.py
+++ b/src/olympia/api/permissions.py
@@ -104,7 +104,7 @@ class AllowReviewerUnlisted(AllowReviewer):
         return not obj.is_listed and self.has_permission(request, view)
 
 
-class AllowReadOnlyIfPublicAndListed(BasePermission):
+class AllowReadOnlyIfReviewedAndListed(BasePermission):
     """
     Allow access when the object's is_public() method and is_listed property
     both return True and the request HTTP method is GET/OPTIONS/HEAD.
@@ -113,5 +113,5 @@ class AllowReadOnlyIfPublicAndListed(BasePermission):
         return request.method in SAFE_METHODS
 
     def has_object_permission(self, request, view, obj):
-        return (obj.is_public() and obj.is_listed and
-                self.has_permission(request, view))
+        return (obj.is_reviewed() and not obj.disabled_by_user and
+                obj.is_listed and self.has_permission(request, view))

--- a/src/olympia/search/filters.py
+++ b/src/olympia/search/filters.py
@@ -256,14 +256,15 @@ class InternalSearchParameterFilter(SearchParameterFilter):
     ]
 
 
-class PublicContentFilter(BaseFilterBackend):
+class ReviewedContentFilter(BaseFilterBackend):
     """
-    A django-rest-framework filter backend that filters only public items in an
-    ES query -- those listed, not deleted, with PUBLIC status and not disabled.
+    A django-rest-framework filter backend that filters only reviewed items in
+    an ES query -- those listed, not deleted, with a reviewed status and not
+    disabled.
     """
     def filter_queryset(self, request, qs, view):
         return qs.filter(
-            Bool(must=[F('term', status=amo.REVIEWED_STATUSES),
+            Bool(must=[F('terms', status=amo.REVIEWED_STATUSES),
                        F('term', has_version=True)],
                  must_not=[F('term', is_deleted=True),
                            F('term', is_listed=False),


### PR DESCRIPTION
This allows Preliminary Reviewed and Preliminary Reviewed but Awaiting Full Review add-ons to be shown.

Fix #2791