### PR TITLE
remove add-on icon

### DIFF
--- a/src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html
+++ b/src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html
@@ -11,7 +11,6 @@
 
 <section class="secondary" role="complementary">
   <div class="addon-status">
-    <img class="addon-icon" src="{{ addon.icon_url }}" alt="">
     <ul class="addon-details">
       {% include "devhub/includes/addon_details.html" %}
     </ul>

--- a/static/css/impala/developers.less
+++ b/static/css/impala/developers.less
@@ -411,7 +411,7 @@
         }
         .addon-details {
             font-size: 12px;
-            margin: 0 0 5px 45px;
+            margin: 0 0 5px 0px;
             li:first-child {
                 color: #444;
             }


### PR DESCRIPTION
* it doesn't feel like its necessary and just pushes everything over
* is this a bit too utilitarian? does it matter? personally I prefer the easily readable text... bet there's a style refresh bug on this somewhere...

before:

<img width="263" alt="screenshot 2016-05-30 16 50 20" src="https://cloud.githubusercontent.com/assets/74699/15659829/a0558446-2686-11e6-9e19-4d7dd7e74bf4.png">

after:

<img width="280" alt="screenshot 2016-05-30 16 45 47" src="https://cloud.githubusercontent.com/assets/74699/15659821/6e54a760-2686-11e6-850f-309d14c93bd1.png">
