### PR TITLE
Remove 'Cat Glasses' from the discovery themes for now

### DIFF
--- a/src/olympia/discovery/data.py
+++ b/src/olympia/discovery/data.py
@@ -56,7 +56,4 @@ discopane_items = [
             '</blockquote>')),
 
     DiscoItem(addon_id=686505),
-
-    DiscoItem(addon_id=345284),
-
 ]


### PR DESCRIPTION
Its background does not work well with our design.

Fix mozilla/addons#109

Note that the one immediately before in the list does not exist on dev, but does on stage/prod.