### PR TITLE
Make sure bulk validation results don't expire after default timeout.

### DIFF
--- a/src/olympia/zadmin/models.py
+++ b/src/olympia/zadmin/models.py
@@ -255,9 +255,8 @@ class ValidationJobTally(object):
             cache.set(cache_key, {
                 'long_message': des,
                 'message': msg['message'],
-                'type': msg.get('compatibility_type',
-                    msg.get('type'))
-                }, timeout=None)
+                'type': msg.get('compatibility_type', msg.get('type'))
+            }, timeout=None)
             aa = ('validation.job_id:%s.msg_key:%s:addons_affected'
                   % (self.job_id, key))
             try:

--- a/src/olympia/zadmin/models.py
+++ b/src/olympia/zadmin/models.py
@@ -237,7 +237,7 @@ class ValidationJobTally(object):
 
     def save_messages(self, msgs):
         msg_ids = ['.'.join(msg['id']) for msg in msgs]
-        cache.set('validation.job_id:%s' % self.job_id, msg_ids)
+        cache.set('validation.job_id:%s' % self.job_id, msg_ids, timeout=None)
         for msg, key in zip(msgs, msg_ids):
             if isinstance(msg['description'], list):
                 des = []
@@ -250,12 +250,14 @@ class ValidationJobTally(object):
                 des = '; '.join(des)
             else:
                 des = msg['description']
-            cache.set('validation.msg_key:' + key,
-                      {'long_message': des,
-                       'message': msg['message'],
-                       'type': msg.get('compatibility_type',
-                                       msg.get('type'))
-                       })
+
+            cache_key = 'validation.msg_key:' + key
+            cache.set(cache_key, {
+                'long_message': des,
+                'message': msg['message'],
+                'type': msg.get('compatibility_type',
+                    msg.get('type'))
+                }, timeout=None)
             aa = ('validation.job_id:%s.msg_key:%s:addons_affected'
                   % (self.job_id, key))
             try:


### PR DESCRIPTION
Fixes #1862

This is the simplest fix I came up with. It's not nice that the results are actually saved in memcached but we're doing that for a very long time now (they were in redis directly before) and it seems to work.

Thus we're now just making sure that they really don't expire. It appears in our django 1.7 upgrade or so the default value for `timeout` changed or I accidentally touched the code. Anyway, this fixes it.