### PR TITLE
Bump amo-validator and addons-linter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "addons-server",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "private": true,
   "engines": {
     "node": ">= 0.10.x",
@@ -12,6 +12,6 @@
     "less": "1.3.x",
     "stylus": "0.32.x",
     "uglify-js": "2.4.x",
-    "addons-linter": "0.9.0"
+    "addons-linter": "0.10.0"
   }
 }

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,6 +1,6 @@
 -r compiled.txt
 
-amo-validator==1.10.31 --hash=sha256:21ae7515e7b9b5d5f1c97dbdbbc9838b9de0603903712d122b17a1cac4835384
+amo-validator==1.10.32 --hash=sha256:5e06da44eb6dcc288a5fec9641d72d0819d14d9ae1f576e6ea3541f7c29c4ffa
 # amqp is required by kombu
 amqp==1.4.9 --hash=sha256:e0ed0ce6b8ffe5690a2e856c7908dc557e0e605283d6885dd1361d79f2928908
 # anyjson is required by kombu

--- a/src/olympia/devhub/tests/test_tasks.py
+++ b/src/olympia/devhub/tests/test_tasks.py
@@ -570,9 +570,9 @@ class TestRunAddonsLinter(ValidatorTestCase):
             ))
 
             assert tmpf.call_count == 2
-            assert not result['success']
+            assert result['success']
             assert result['warnings'] > 700
-            assert result['errors']
+            assert not result['errors']
 
 
 class TestValidateFilePath(ValidatorTestCase):


### PR DESCRIPTION
* Firefox 48 compatibility tests in validator
* Various updates for crx support, schema update and better warnings in linter