### PR TITLE
Don't translate "add-on" string and use default translation for add-on name in editors emails

### DIFF
--- a/src/olympia/editors/templates/editors/emails/pending_to_public.ltxt
+++ b/src/olympia/editors/templates/editors/emails/pending_to_public.ltxt
@@ -1,5 +1,5 @@
 {% extends "editors/emails/base.ltxt" %}{% block content %}
-Your {{ addon_type }}, {{ name }} {{ number }}, has been fully reviewed and is now available for download in our gallery at {{ addon_url }}
+Your add-on, {{ name }} {{ number }}, has been fully reviewed and is now available for download in our gallery at {{ addon_url }}
 {% include "editors/emails/files.ltxt" %}
 Reviewer:
 {{ reviewer }}

--- a/src/olympia/editors/templates/editors/emails/pending_to_sandbox.ltxt
+++ b/src/olympia/editors/templates/editors/emails/pending_to_sandbox.ltxt
@@ -1,5 +1,5 @@
 {% extends "editors/emails/base.ltxt" %}{% block content %}
-Your {{ addon_type }}, {{ name }} {{ number }}, has been reviewed and did not meet the criteria for being hosted in our gallery.
+Your add-on, {{ name }} {{ number }}, has been reviewed and did not meet the criteria for being hosted in our gallery.
 {% include "editors/emails/files.ltxt" %}
 Reviewer:
 {{ reviewer }}
@@ -9,5 +9,5 @@ Comments:
 
 {{ tested }}
 
-This version of your {{ addon_type }} has been disabled. You may re-request review by addressing the reviewer's comments and uploading a new version at {{ dev_versions_url }}
+This version of your add-on has been disabled. You may re-request review by addressing the reviewer's comments and uploading a new version at {{ dev_versions_url }}
 {% endblock %}

--- a/src/olympia/editors/tests/test_review_scenarios.py
+++ b/src/olympia/editors/tests/test_review_scenarios.py
@@ -6,6 +6,7 @@ end up in the correct state.
 import pytest
 
 from olympia import amo
+from olympia.amo.tests import user_factory
 from olympia.addons.models import Addon
 from olympia.editors import helpers
 from olympia.files.models import File
@@ -15,7 +16,7 @@ from olympia.versions.models import Version
 @pytest.fixture
 def mock_request(rf, db):  # rf is a RequestFactory provided by pytest-django.
     request = rf.get('/')
-    request.user = amo.tests.user_factory()
+    request.user = user_factory()
     return request
 
 
@@ -26,7 +27,7 @@ def addon_with_files(db):
     By default the add-on is public, and the files are: beta, disabled,
     unreviewed, unreviewed.
     """
-    addon = Addon.objects.create()
+    addon = Addon.objects.create(name='My Addon', slug='my-addon')
     version = Version.objects.create(addon=addon)
     for status in [amo.STATUS_BETA, amo.STATUS_DISABLED, amo.STATUS_UNREVIEWED,
                    amo.STATUS_UNREVIEWED]:


### PR DESCRIPTION
Fix mozilla/addons#133