### PR TITLE
Fix current disco links: reinstate target=_blank rel=noreferrer

### DIFF
--- a/src/olympia/legacy_discovery/templates/legacy_discovery/base.html
+++ b/src/olympia/legacy_discovery/templates/legacy_discovery/base.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=700">
     <title>{% block title %}{{ _('Discover Add-ons') }}{% endblock %}</title>
     {{ css('zamboni/discovery-pane') }}
-    <base href="{{ settings.SITE_URL }}">
+    <base target="_blank" rel="noreferrer" href="{{ settings.SITE_URL }}">
     {% block extrahead %}{% endblock %}
   </head>
   <body class="html-{{ DIR }} {{ request.APP.short }} {% block bodyclass %}{% endblock %}"


### PR DESCRIPTION
Fixes #2871

`rel="noreferrer"` removes the opener so achieves the same thing as `_blank` removal except the new tab is re-instated which is needed for links from `about:`.

We're doing the same thing on the new disco pane.

