### PR TITLE
Update add-on detail API regexp for guid detection

### DIFF
--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -1554,6 +1554,11 @@ class TestAddonViewSetDetail(TestCase):
         self.url = reverse('addon-detail', kwargs={'pk': self.addon.guid})
         self._test_detail_url()
 
+    def test_get_by_guid_uppercase(self):
+        self.url = reverse('addon-detail',
+                           kwargs={'pk': self.addon.guid.upper()})
+        self._test_detail_url()
+
     def test_get_by_guid_email_format(self):
         self.addon.update(guid='my-addon@example.tld')
         self.url = reverse('addon-detail', kwargs={'pk': self.addon.guid})
@@ -1561,6 +1566,11 @@ class TestAddonViewSetDetail(TestCase):
 
     def test_get_by_guid_email_short_format(self):
         self.addon.update(guid='@example.tld')
+        self.url = reverse('addon-detail', kwargs={'pk': self.addon.guid})
+        self._test_detail_url()
+
+    def test_get_by_guid_email_really_short_format(self):
+        self.addon.update(guid='@example')
         self.url = reverse('addon-detail', kwargs={'pk': self.addon.guid})
         self._test_detail_url()
 

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -1559,6 +1559,11 @@ class TestAddonViewSetDetail(TestCase):
         self.url = reverse('addon-detail', kwargs={'pk': self.addon.guid})
         self._test_detail_url()
 
+    def test_get_by_guid_email_short_format(self):
+        self.addon.update(guid='@example.tld')
+        self.url = reverse('addon-detail', kwargs={'pk': self.addon.guid})
+        self._test_detail_url()
+
     def test_get_lite_status(self):
         self.addon.update(status=amo.STATUS_LITE)
         self._test_detail_url()

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -662,7 +662,7 @@ class AddonViewSet(RetrieveModelMixin, GenericViewSet):
         # Match {uuid} or something@host.tld ("something" being optional)
         # guids. Copied from mozilla-central XPIProvider.jsm.
         r'^(\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\}'
-        r'|[a-z0-9-\._]*\@[a-z0-9-\._]+)$')
+        r'|[a-z0-9-\._]*\@[a-z0-9-\._]+)$', re.IGNORECASE)
     # Permission classes disallow access to non-public/unlisted add-ons unless
     # logged in as a reviewer/addon owner/admin, so the unfiltered queryset
     # is fine here.

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -658,7 +658,11 @@ class AddonViewSet(RetrieveModelMixin, GenericViewSet):
               AllowReviewer, AllowReviewerUnlisted),
     ]
     serializer_class = AddonSerializer
-    addon_id_pattern = re.compile(r'^(\{.*\}|.*@.*)$')
+    addon_id_pattern = re.compile(
+        # Match {uuid} or something@host.tld ("something" being optional)
+        # guids. Copied from mozilla-central XPIProvider.jsm.
+        r'^(\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\}'
+        r'|[a-z0-9-\._]*\@[a-z0-9-\._]+)$')
     # Permission classes disallow access to non-public/unlisted add-ons unless
     # logged in as a reviewer/addon owner/admin, so the unfiltered queryset
     # is fine here.


### PR DESCRIPTION
This matches what Firefox uses.

Fix #2786