### PR TITLE
Swap jobs order in travis to make builds faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ env:
   - TOX_ENV=flake8
   - TOX_ENV=docs
   - TOX_ENV=assets
-  - TOX_ENV=es
+  - TOX_ENV=main
   - TOX_ENV=addons
   - TOX_ENV=devhub
   - TOX_ENV=editors
-  - TOX_ENV=main
+  - TOX_ENV=es
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
`es` is usually 2 minutes faster than `main`, and the _last_ job to run usually starts later than the rest because it needs to wait for one of the first jobs to be finished to start. So that last job needs to be the fastest job that we have to speed the whole build up.