### PR TITLE
Fixed #2019: 404 url in FAQ page linked to open source

### DIFF
--- a/src/olympia/pages/templates/pages/faq.html
+++ b/src/olympia/pages/templates/pages/faq.html
@@ -251,7 +251,7 @@
         author. Most authors choose widely known open source licenses like the
         GPL or BSD licenses instead of making up their own.{% endtrans %}</p>
 
-        <p>{% trans url="http://www.mozilla.com/firefox/organic/" %}
+        <p>{% trans url="http://www.mozilla.com/MPL/" %}
         Firefox and other Mozilla software are <a href="{{ url }}">open source</a>.
         {% endtrans %}</p>
     </dd>


### PR DESCRIPTION
#2019 