### PR TITLE
Replace Version.transformer_activity with a prefetch_related() call

### DIFF
--- a/src/olympia/devhub/tests/test_models.py
+++ b/src/olympia/devhub/tests/test_models.py
@@ -174,8 +174,8 @@ class TestActivityLog(TestCase):
         amo.log(amo.LOG.REJECT_VERSION, addon, version_two,
                 user=self.request.user)
 
-        versions = (Version.objects.filter(addon=addon).order_by('-created')
-                                   .transform(Version.transformer_activity))
+        versions = (Version.objects.with_all_activity()
+                                   .filter(addon=addon).order_by('-created'))
 
         assert len(versions[0].all_activity) == 1
         assert len(versions[1].all_activity) == 1

--- a/src/olympia/editors/views.py
+++ b/src/olympia/editors/views.py
@@ -640,10 +640,10 @@ def review(request, addon):
     # The actions we should show a minimal form from.
     actions_minimal = [k for (k, a) in actions if not a.get('minimal')]
 
-    versions = (Version.unfiltered.filter(addon=addon)
+    versions = (Version.unfiltered.with_all_activity()
+                                  .filter(addon=addon)
                                   .exclude(files__status=amo.STATUS_BETA)
                                   .order_by('-created')
-                                  .transform(Version.transformer_activity)
                                   .transform(Version.transformer))
 
     class PseudoVersion(object):

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -51,6 +51,14 @@ class VersionManager(ManagerBase):
             qs = qs.exclude(deleted=True)
         return qs.transform(Version.transformer)
 
+    def with_all_activity(self):
+        from olympia.devhub.models import VersionLog
+        versionlog_qs = (
+            VersionLog.objects.no_cache().order_by('created')
+            .select_related('activity_log', 'version'))
+        return self.get_queryset().prefetch_related(models.Prefetch(
+            'versionlog_set', to_attr='all_activity', queryset=versionlog_qs))
+
 
 def source_upload_path(instance, filename):
     # At this point we already know that ext is one of VALID_SOURCE_EXTENSIONS
@@ -287,13 +295,6 @@ class Version(OnChangeMixin, ModelBase):
         return None
 
     @amo.cached_property(writable=True)
-    def all_activity(self):
-        from olympia.devhub.models import VersionLog  # yucky
-        al = (VersionLog.objects.filter(version=self.id).order_by('created')
-              .select_related('activity_log', 'version').no_cache())
-        return al
-
-    @amo.cached_property(writable=True)
     def compatible_apps(self):
         """Get a mapping of {APP: ApplicationVersion}."""
         avs = self.apps.select_related('versions', 'license')
@@ -483,28 +484,6 @@ class Version(OnChangeMixin, ModelBase):
             version.all_files = file_dict.get(v_id, [])
             for f in version.all_files:
                 f.version = version
-
-    @classmethod
-    def transformer_activity(cls, versions):
-        """Attach all the activity to the versions."""
-        from olympia.devhub.models import VersionLog  # yucky
-
-        ids = set(v.id for v in versions)
-        if not versions:
-            return
-
-        al = (VersionLog.objects.filter(version__in=ids).order_by('created')
-              .select_related('activity_log', 'version').no_cache())
-
-        def rollup(xs):
-            groups = sorted_groupby(xs, 'version_id')
-            return dict((k, list(vs)) for k, vs in groups)
-
-        al_dict = rollup(al)
-
-        for version in versions:
-            v_id = version.id
-            version.all_activity = al_dict.get(v_id, [])
 
     def disable_old_files(self):
         if not self.files.filter(status=amo.STATUS_BETA).exists():


### PR DESCRIPTION
It might even work ! This is the most simple/isolated use of queryset transform in our code that I could find, if this replacement goes well we could do them all to get rid of django-queryset-transform (which isn't maintained, does not even have a release on pypi) entirely.