### PR TITLE
Add queryset_transform into our repos as it's not released on pypi

### DIFF
--- a/requirements/prod_without_hash.txt
+++ b/requirements/prod_without_hash.txt
@@ -1,6 +1,5 @@
 
 ## Not on pypi.
--e git+https://github.com/jbalogh/django-queryset-transform@a1ba6ae41bd86f5bb9ff66fb56614e0fafe6e022#egg=django-queryset-transform
 -e git+https://github.com/miracle2k/django-tables.git@ce508b4b31f4c7a6ca3c24855d7be3aade6b6d3e#egg=django-tables
 -e git+https://github.com/mozilla/happyforms.git@729612c2a824a7e8283d416d2084bf506c671e24#egg=happyforms
 

--- a/src/olympia/amo/models.py
+++ b/src/olympia/amo/models.py
@@ -8,8 +8,9 @@ from django.utils import encoding, translation
 import caching.base
 import elasticsearch
 import multidb.pinning
-import queryset_transform
 from django_statsd.clients import statsd
+
+import olympia.lib.queryset_transform as queryset_transform
 
 from . import search
 

--- a/src/olympia/lib/queryset_transform.py
+++ b/src/olympia/lib/queryset_transform.py
@@ -54,8 +54,3 @@ class TransformQuerySet(models.query.QuerySet):
                 fn(results)
             return iter(results)
         return result_iter
-
-
-class TransformManager(models.Manager):
-    def get_queryset(self):
-        return TransformQuerySet(self.model)

--- a/src/olympia/lib/queryset_transform.py
+++ b/src/olympia/lib/queryset_transform.py
@@ -1,0 +1,61 @@
+from django.db import models
+
+"""
+Copyright (c) 2010, Simon Willison.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    3. Neither the name of Django nor the names of its contributors may be used
+       to endorse or promote products derived from this software without
+       specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+
+
+class TransformQuerySet(models.query.QuerySet):
+    def __init__(self, *args, **kwargs):
+        super(TransformQuerySet, self).__init__(*args, **kwargs)
+        self._transform_fns = []
+
+    def _clone(self, klass=None, setup=False, **kw):
+        c = super(TransformQuerySet, self)._clone(klass, setup, **kw)
+        c._transform_fns = self._transform_fns[:]
+        return c
+
+    def transform(self, fn):
+        c = self._clone()
+        c._transform_fns.append(fn)
+        return c
+
+    def iterator(self):
+        result_iter = super(TransformQuerySet, self).iterator()
+        if self._transform_fns:
+            results = list(result_iter)
+            for fn in self._transform_fns:
+                fn(results)
+            return iter(results)
+        return result_iter
+
+
+class TransformManager(models.Manager):
+    def get_queryset(self):
+        return TransformQuerySet(self.model)

--- a/src/olympia/lib/tests/test_queryset_transform.py
+++ b/src/olympia/lib/tests/test_queryset_transform.py
@@ -1,0 +1,31 @@
+from olympia.amo.tests import TestCase
+from olympia.lib.queryset_transform import TransformQuerySet
+from olympia.zadmin.models import DownloadSource
+
+
+class QuerysetTransformTestCase(TestCase):
+    def test_queryset_transform(self):
+        # We test with the DownloadSource model because it's a simple model
+        # with no translated fields, no caching or other fancy features.
+        DownloadSource.objects.create(name='Zero')
+        first = DownloadSource.objects.create(name='First')
+        second = DownloadSource.objects.create(name='Second')
+        DownloadSource.objects.create(name='Third')
+        DownloadSource.objects.create(name='')
+
+        seen_by_first_transform = []
+        seen_by_second_transform = []
+        with self.assertNumQueries(0):
+            # No database hit yet, everything is still lazy.
+            qs = TransformQuerySet(DownloadSource)
+            qs = qs.exclude(name='').order_by('id')[1:3]
+            qs = qs.transform(
+                lambda items: seen_by_first_transform.extend(list(items)))
+            qs = qs.transform(
+                lambda items: seen_by_second_transform.extend(
+                    list(reversed(items))))
+        with self.assertNumQueries(1):
+            assert list(qs) == [first, second]
+        # Check that each transform function was hit correctly, once.
+        assert seen_by_first_transform == [first, second]
+        assert seen_by_second_transform == [second, first]


### PR DESCRIPTION
I looked into getting rid of it completely but because of the way we deal with in-database translations this is really hard.

![pullmeback](https://cloud.githubusercontent.com/assets/187006/16273306/5d47f7ec-38a1-11e6-9cad-859a6ce04c07.jpg)
