### PR TITLE
Actually throw an error if we cannot find min/max version.

### DIFF
--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -2315,6 +2315,8 @@ class TestUploadDetail(BaseUploadTest):
         self.create_appversion('firefox', '42.*')
         self.create_appversion('firefox', '47.*')
         self.create_appversion('firefox', '48.*')
+        self.create_appversion('android', '42.*')
+        self.create_appversion('android', '47.*')
         self.create_appversion('android', '48.*')
         self.create_appversion('android', '*')
 

--- a/src/olympia/files/tests/test_utils_.py
+++ b/src/olympia/files/tests/test_utils_.py
@@ -246,24 +246,21 @@ class TestManifestJSONExtractor(TestCase):
 
     def test_apps_use_provided_versions(self):
         """Use the min and max versions if provided."""
-        firefox_min_version = self.create_appversion('firefox', '30.0')
-        firefox_max_version = self.create_appversion('firefox', '30.*')
-
-        self.create_appversion('android', '30.0')
-        self.create_appversion('android', '30.*')
+        firefox_min_version = self.create_appversion('firefox', '47.0')
+        firefox_max_version = self.create_appversion('firefox', '47.*')
 
         self.create_webext_default_versions()
         data = {
             'applications': {
                 'gecko': {
-                    'strict_min_version': '30.0',
-                    'strict_max_version': '30.*',
+                    'strict_min_version': '47.0',
+                    'strict_max_version': '47.*',
                     'id': '@random'
                 }
             }
         }
         apps = self.parse(data)['apps']
-        assert len(apps) == 2
+        assert len(apps) == 1
         app = apps[0]
         assert app.appdata == amo.FIREFOX
         assert app.min == firefox_min_version
@@ -373,8 +370,7 @@ class TestManifestJSONExtractor(TestCase):
         data = {
             'applications': {
                 'gecko': {
-                    'strict_min_version': '30.0.0',
-                    'strict_max_version': '=30.*',
+                    'strict_min_version': '47.0.0',
                     'id': '@random'
                 }
             }

--- a/src/olympia/files/tests/test_utils_.py
+++ b/src/olympia/files/tests/test_utils_.py
@@ -267,8 +267,8 @@ class TestManifestJSONExtractor(TestCase):
         data = {
             'applications': {
                 'gecko': {
-                    'strict_min_version': '47.0',
-                    'strict_max_version': '47.*',
+                    'strict_min_version': '>=47.0',
+                    'strict_max_version': '=47.*',
                     'id': '@random'
                 }
             }

--- a/src/olympia/files/tests/test_utils_.py
+++ b/src/olympia/files/tests/test_utils_.py
@@ -244,6 +244,20 @@ class TestManifestJSONExtractor(TestCase):
         assert (
             self.parse({'description': 'An addon.'})['summary'] == 'An addon.')
 
+    def test_invalid_app_versions_are_ignored(self):
+        """Invalid versions are ignored."""
+        data = {
+            'applications': {
+                'gecko': {
+                    # Not created, so are seen as invalid.
+                    'strict_min_version': '>=30.0',
+                    'strict_max_version': '=30.*',
+                    'id': '@random'
+                }
+            }
+        }
+        assert not self.parse(data)['apps']
+
     def test_apps_use_provided_versions(self):
         """Use the min and max versions if provided."""
         firefox_min_version = self.create_appversion('firefox', '47.0')
@@ -364,8 +378,6 @@ class TestManifestJSONExtractor(TestCase):
 
     def test_apps_contains_wrong_versions(self):
         """Use the min and max versions if provided."""
-        firefox_min_version = self.create_appversion('firefox', '30.0')
-        firefox_max_version = self.create_appversion('firefox', '30.*')
         self.create_webext_default_versions()
         data = {
             'applications': {

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -324,7 +324,7 @@ class ManifestJSONExtractor(JSONExtractor):
             msg = _(
                 'Cannot find min/max version. Maybe '
                 '"strict_min_version" or "strict_max_version" '
-                'contains a not supported version?')
+                'contains an unsupported version?')
             raise forms.ValidationError(msg)
 
     def parse(self):

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -315,6 +315,10 @@ class ManifestJSONExtractor(JSONExtractor):
                 vint(default_min_version)
             )
 
+            # Don't attempt to add support for this app to the WebExtension
+            # if the `strict_min_version` is below the default minimum version
+            # that is required to run WebExtensions (48.* for Android and 42.*
+            # for Firefox).
             if skip_app:
                 continue
 

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -310,6 +310,14 @@ class ManifestJSONExtractor(JSONExtractor):
             strict_max_version = (
                 self.strict_max_version or amo.DEFAULT_WEBEXT_MAX_VERSION)
 
+            skip_app = (
+                self.strict_min_version and vint(self.strict_min_version) <
+                vint(default_min_version)
+            )
+
+            if skip_app:
+                continue
+
             try:
                 min_appver, max_appver = get_appversions(
                     app, strict_min_version, strict_max_version)

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -298,6 +298,8 @@ class ManifestJSONExtractor(JSONExtractor):
                 _('GUID is required for Firefox 47 and below.')
             )
 
+        couldnt_find_version = False
+
         for app, default_min_version in apps:
             if self.guid is None and not self.strict_min_version:
                 strict_min_version = amo.DEFAULT_WEBEXT_MIN_VERSION_NO_ID
@@ -314,7 +316,16 @@ class ManifestJSONExtractor(JSONExtractor):
                 yield Extractor.App(
                     appdata=app, id=app.id, min=min_appver, max=max_appver)
             except AppVersion.DoesNotExist:
-                pass
+                couldnt_find_version = True
+
+        specified_versions = self.strict_min_version or self.strict_max_version
+
+        if couldnt_find_version and specified_versions:
+            msg = _(
+                'Cannot find min/max version. Maybe '
+                '"strict_min_version" or "strict_max_version" '
+                'contains a not supported version?')
+            raise forms.ValidationError(msg)
 
     def parse(self):
         return {


### PR DESCRIPTION
This refs #2970 as the manifest.json specified a wrong
strict_min_version, "45.0.0" which doesn't exist.

This will obviously fail loudly if, say we don't have the same version numbers for Android and Firefox anymore and someone wants to target his WebExtension specifically for that version for the specific app. But, maybe that's just better this way.

maybe cc'ing @wagnerand on this so that more people know this behavior.