### PR TITLE
don't show min - max if its undefined

### DIFF
--- a/static/js/zamboni/buttons.js
+++ b/static/js/zamboni/buttons.js
@@ -348,7 +348,10 @@ var installButton = function() {
             $button.addClass('installer');
             $button.closest('div').attr('data-version-supported', true);
         } else if (!appSupported) {
-            var tpl = template(gettext('Works with {app} {min} - {max}') +
+            var msg = (min && max ?
+              gettext('Works with {app} {min} - {max}') :
+              gettext('Works with {app}'));
+            var tpl = template(msg +
                 '<span class="more-versions"><a href="{versions_url}">' +
                 gettext('View other versions') + '</a></span>');
             var context = {'app': z.appName, 'min': min, 'max': max,


### PR DESCRIPTION
* there's probably a more sophisticated fix about getting the data correctly, but given how long these buttons are going to be around this is a quick fix.
* fixes #1599 and mozilla/addons#103

before:

![screenshot 2016-06-24 13 18 38](https://cloud.githubusercontent.com/assets/74699/16349903/3cd406ac-3a10-11e6-96ec-c359029900d6.png)

after:

![screenshot 2016-06-24 13 18 19](https://cloud.githubusercontent.com/assets/74699/16349916/446a42d2-3a10-11e6-94d8-e84b2a6b8ecd.png)
