### PR TITLE
Correctly report identified files. Fixes #3015

### DIFF
--- a/src/olympia/devhub/tests/test_utils.py
+++ b/src/olympia/devhub/tests/test_utils.py
@@ -975,3 +975,6 @@ class TestFixAddonsLinterOutput(TestCase):
             'high': 0,
             'trivial': 0
         }
+        assert fixed['metadata']['identified_files'] == {
+            'lib/vendor/jquery.js': {'path': 'jquery.2.1.4.jquery.js'}
+        }

--- a/src/olympia/devhub/utils.py
+++ b/src/olympia/devhub/utils.py
@@ -149,6 +149,11 @@ def fix_addons_linter_output(validation, listed=True):
                 msg['tier'] = 1
                 yield msg
 
+    identified_files = {
+        name: {'path': path}
+        for name, path in validation['metadata'].get('jsLibs', {}).items()
+    }
+
     return {
         'success': not validation['errors'],
         'compatibility_summary': {
@@ -162,6 +167,7 @@ def fix_addons_linter_output(validation, listed=True):
         'messages': list(_merged_messages()),
         'metadata': {
             'listed': listed,
+            'identified_files': identified_files,
             'processed_by_addons_linter': True,
         },
         'signing_summary': {


### PR DESCRIPTION
This allows the information to be shown in the file-viewer.

See https://github.com/mozilla/addons-linter/issues/809 for the
addons-linter part for this feature.

![selection_024](https://cloud.githubusercontent.com/assets/139033/16582785/79566fee-42b1-11e6-82cb-f39971a7ef6d.png)
