### PR TITLE
Various performance improvements for travis tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,22 +5,26 @@ python:
   - "2.7"
 
 env:
-  - TOX_ENV=flake8
-  - TOX_ENV=docs
-  - TOX_ENV=assets
-  - TOX_ENV=main
-  - TOX_ENV=addons
-  - TOX_ENV=devhub
-  - TOX_ENV=editors
-  - TOX_ENV=es
+  - TOXENV=flake8
+  - TOXENV=docs
+  - TOXENV=assets
+  - TOXENV=es
+  - TOXENV=addons
+  - TOXENV=devhub
+  - TOXENV=editors
+  - TOXENV=amo
+  - TOXENV=users
+  - TOXENV=versions
+  - TOXENV=main
 
 matrix:
   fast_finish: true
 
 cache:
+  pip: true
   directories:
     - node_modules
-    - $HOME/.cache/pip/
+    - .tox
 
 services:
   - memcached
@@ -39,8 +43,7 @@ install:
   - nvm deactivate
   - nvm install 4
   - nvm use 4
-  - pip install --upgrade pip wheel coverage codecov
-  - pip install tox==1.8.1
+  - pip install --upgrade pip wheel setuptools coverage codecov tox==1.8.1
 
 before_script:
   - mysql -e 'create database olympia;'
@@ -48,7 +51,7 @@ before_script:
 
 script:
   - coverage erase
-  - RUNNING_IN_CI=True tox -v -e $TOX_ENV --recreate
+  - RUNNING_IN_CI=True tox -v
   - coverage combine
 
 notifications:
@@ -64,3 +67,6 @@ notifications:
 after_success:
   - coverage report
   - codecov
+
+git:
+  depth: 3

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 NUM_ADDONS=10
 NUM_THEMES=$(NUM_ADDONS)
 
+APP=src/olympia/
+
 # Get the name of the Makefile's directory for the docker container base name.
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 current_dir := $(notdir $(patsubst %/,%,$(dir $(mkfile_path))))
@@ -56,38 +58,37 @@ test:
 ifneq ($(IN_DOCKER),)
 	$(warning Command is designed to be run in the host)
 endif
-	docker exec -t -i ${DOCKER_NAME} py.test $(ARGS)
+	docker exec -t -i ${DOCKER_NAME} py.test $(APP) $(ARGS)
 
 test_es:
 ifneq ($(IN_DOCKER),)
 	$(warning Command is designed to be run in the host)
 endif
-	docker exec -t -i ${DOCKER_NAME} py.test -m es_tests $(ARGS)
-
+	docker exec -t -i ${DOCKER_NAME} py.test -m es_tests $(APP) $(ARGS)
 
 test_no_es:
 ifneq ($(IN_DOCKER),)
 	$(warning Command is designed to be run in the host)
 endif
-	docker exec -t -i ${DOCKER_NAME} py.test -m "not es_tests" $(ARGS)
+	docker exec -t -i ${DOCKER_NAME} py.test -m "not es_tests" $(APP) $(ARGS)
 
 test_force_db:
 ifneq ($(IN_DOCKER),)
 	$(warning Command is designed to be run in the host)
 endif
-	docker exec -t -i ${DOCKER_NAME} py.test --create-db $(ARGS)
+	docker exec -t -i ${DOCKER_NAME} py.test --create-db $(APP) $(ARGS)
 
 tdd:
 ifneq ($(IN_DOCKER),)
 	$(warning Command is designed to be run in the host)
 endif
-	docker exec -t -i ${DOCKER_NAME} py.test -x --pdb $(ARGS)
+	docker exec -t -i ${DOCKER_NAME} py.test -x --pdb $(ARGS) $(APP)
 
 test_failed:
 ifneq ($(IN_DOCKER),)
 	$(warning Command is designed to be run in the host)
 endif
-	docker exec -t -i ${DOCKER_NAME} py.test --lf $(ARGS)
+	docker exec -t -i ${DOCKER_NAME} py.test --lf $(ARGS) $(APP)
 
 initialize_db:
 ifeq ($(IN_DOCKER),)

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ commands =
 [testenv:main]
 commands =
     make update_deps
-    py.test --create-db -n 2 -m 'not es_tests' -v --ignore src/olympia/addons/ --ignore src/olympia/devhub/ --ignore src/olympia/editors/ --ignore src/olympia/amo/ --ignore src/olympia/users/ --ignore src/olympia/versions/ --cov-report= --cov=src/olympia/ {posargs}
+    py.test --create-db -n 2 -m 'not es_tests' -v src/olympia/ --ignore src/olympia/addons/ --ignore src/olympia/devhub/ --ignore src/olympia/editors/ --ignore src/olympia/amo/ --ignore src/olympia/users/ --ignore src/olympia/versions/ --cov-report= --cov=src/olympia/ {posargs}
 
 [testenv:ui-tests]
 passenv = DISPLAY

--- a/tox.ini
+++ b/tox.ini
@@ -15,32 +15,41 @@ whitelist_externals =
 [testenv:es]
 commands =
     make update_deps
-    npm install {toxinidir}
     py.test  -m es_tests --ignore=tests/ui/ --cov-report= --cov-report= --cov=src/olympia/ -v {posargs}
 
 [testenv:addons]
 commands =
     make update_deps
-    npm install {toxinidir}
-    py.test --create-db -n 3 -m 'not es_tests' -v src/olympia/addons/ --cov-report= --cov=src/olympia/ {posargs}
+    py.test --create-db -n 2 -m 'not es_tests' -v src/olympia/addons/ --cov-report= --cov=src/olympia/ {posargs}
 
 [testenv:devhub]
 commands =
     make update_deps
-    npm install {toxinidir}
-    py.test --create-db -n 3 -m 'not es_tests' -v src/olympia/devhub/ --cov-report= --cov=src/olympia/ {posargs}
+    py.test --create-db -n 2 -m 'not es_tests' -v src/olympia/devhub/ --cov-report= --cov=src/olympia/ {posargs}
 
 [testenv:editors]
 commands =
     make update_deps
-    npm install {toxinidir}
-    py.test --create-db -n 3 -m 'not es_tests' -v src/olympia/editors/ --cov-report= --cov=src/olympia/ {posargs}
+    py.test --create-db -n 2 -m 'not es_tests' -v src/olympia/editors/ --cov-report= --cov=src/olympia/ {posargs}
+
+[testenv:amo]
+commands =
+    make update_deps
+    py.test --create-db -n 2 -m 'not es_tests' -v src/olympia/amo/ --cov-report= --cov=src/olympia/ {posargs}
+
+[testenv:users]
+commands =
+    make update_deps
+    py.test --create-db -n 2 -m 'not es_tests' -v src/olympia/users/ --cov-report= --cov=src/olympia/ {posargs}
+
+[testenv:versions]
+commands =
+    make update_deps
 
 [testenv:main]
 commands =
     make update_deps
-    npm install {toxinidir}
-    py.test --create-db -n 3 -m 'not es_tests' -v --ignore=tests/ui/ --ignore src/olympia/addons/ --ignore src/olympia/devhub/ --ignore src/olympia/editors/ --cov-report= --cov=src/olympia/ {posargs}
+    py.test --create-db -n 2 -m 'not es_tests' -v --ignore src/olympia/addons/ --ignore src/olympia/devhub/ --ignore src/olympia/editors/ --ignore src/olympia/amo/ --ignore src/olympia/users/ --ignore src/olympia/versions/ --cov-report= --cov=src/olympia/ {posargs}
 
 [testenv:ui-tests]
 passenv = DISPLAY
@@ -51,7 +60,6 @@ commands = py.test --verify-base-url --driver=Firefox tests/ui {posargs}
 [testenv:assets]
 commands =
     make update_deps
-    npm install {toxinidir}
     make update_assets
 
 [testenv:flake8]


### PR DESCRIPTION
 * Avoid calling 'npm install' twice (make update_deps and separately)
 * Split users, amo, versions into separate tasks
 * cache .tox folder to speedup dependency installation
 * only clone 3 levels deep