### PR TITLE
Remove addons-linter waffle switch usage.

### DIFF
--- a/src/olympia/devhub/tasks.py
+++ b/src/olympia/devhub/tasks.py
@@ -23,7 +23,6 @@ from django_statsd.clients import statsd
 from PIL import Image
 
 import validator
-import waffle
 
 from olympia import amo
 from olympia.amo.celery import task
@@ -155,9 +154,7 @@ def validate_file_path(path, hash_, listed=True, is_webextension=False, **kw):
     results.
 
     Should only be called directly by ValidationAnnotator."""
-    run_linter = is_webextension and waffle.switch_is_active('addons-linter')
-
-    if run_linter:
+    if is_webextension:
         return run_addons_linter(path, listed=listed)
     return run_validator(path, listed=listed)
 
@@ -173,10 +170,7 @@ def validate_file(file_id, hash_, is_webextension=False, **kw):
     try:
         return file_.validation.validation
     except FileValidation.DoesNotExist:
-        run_linter = (
-            is_webextension and waffle.switch_is_active('addons-linter'))
-
-        if run_linter:
+        if is_webextension:
             return run_addons_linter(
                 file_.current_file_path, listed=file_.version.addon.is_listed)
 

--- a/src/olympia/devhub/tests/test_tasks.py
+++ b/src/olympia/devhub/tests/test_tasks.py
@@ -192,8 +192,6 @@ class TestValidator(ValidatorTestCase):
     @mock.patch('olympia.devhub.tasks.run_addons_linter')
     def test_validation_error_webextension(self, _mock):
         _mock.side_effect = Exception
-        self.create_switch('addons-linter')
-
         self.upload.update(path=get_addon_file('valid_webextension.xpi'))
 
         assert self.upload.validation is None
@@ -523,8 +521,6 @@ class TestRunAddonsLinter(ValidatorTestCase):
     def setUp(self):
         super(TestRunAddonsLinter, self).setUp()
 
-        self.create_switch('addons-linter')
-
         valid_path = get_addon_file('valid_webextension.xpi')
         invalid_path = get_addon_file('invalid_webextension_invalid_id.xpi')
 
@@ -602,8 +598,6 @@ class TestValidateFilePath(ValidatorTestCase):
         assert not result['warnings']
 
     def test_amo_validator_addons_linter_success(self):
-        self.create_switch('addons-linter')
-
         result = tasks.validate_file_path(
             get_addon_file('valid_webextension.xpi'),
             hash_=None, listed=True, is_webextension=True)
@@ -612,8 +606,6 @@ class TestValidateFilePath(ValidatorTestCase):
         assert not result['warnings']
 
     def test_amo_validator_addons_linter_error(self):
-        self.create_switch('addons-linter')
-
         # This test assumes that `amo-validator` doesn't correctly
         # validate a invalid id in manifest.json
         result = tasks.validate_file_path(

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -21,7 +21,7 @@ from PIL import Image
 from pyquery import PyQuery as pq
 
 from olympia import amo, paypal, files
-from olympia.amo.tests import TestCase, version_factory, create_switch
+from olympia.amo.tests import TestCase, version_factory
 from olympia.addons.models import (
     Addon, AddonCategory, AddonFeatureCompatibility, Category, Charity)
 from olympia.amo.helpers import absolutify, user_media_path, url as url_reverse
@@ -2246,7 +2246,6 @@ class TestUploadDetail(BaseUploadTest):
         assert msg['tier'] == 1
 
     def test_detail_json_addons_linter(self):
-        create_switch('addons-linter')
         self.upload_file('valid_webextension.xpi')
 
         upload = FileUpload.objects.get()

--- a/src/olympia/migrations/882-remove-addons-linter-switch.sql
+++ b/src/olympia/migrations/882-remove-addons-linter-switch.sql
@@ -1,0 +1,1 @@
+DELETE FROM waffle_switch WHERE name = 'addons-linter';


### PR DESCRIPTION
This is now live for quite some time and we have way better support
and way less bugs with addons-linter for WebExtensions than we have
with the validator.

Fixes #2937