### PR TITLE
Fixed issue #2818 long author name breaking section

### DIFF
--- a/src/olympia/addons/templates/addons/impala/featured_grid.html
+++ b/src/olympia/addons/templates/addons/impala/featured_grid.html
@@ -5,7 +5,7 @@
   <section>
   {% for addon in page %}
     <li>
-      <div class="hovercard addon">
+      <div class="hovercard addon feature">
         <a href="{{ addon.get_url_path()|urlparams(src=dl_src) }}">
           <div class="summary">
             <h3>{{ addon.name }}</h3>

--- a/static/css/impala/hovercards.less
+++ b/static/css/impala/hovercards.less
@@ -83,6 +83,7 @@
         margin-top: 8px;
         font-size: 11px;
         font-style: italic;
+        max-width: 220px;
 
         a {
             display: inline;

--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -1666,6 +1666,14 @@ h3.author .transfer-ownership {
   }
 }
 
+.category-landing .featured.three-col .addon.hovercard.feature {
+
+  &:focus,
+  &:hover {
+    height: auto;
+  }
+}
+
 .extra .button.disabled.not-available {
   background-color: #fff;
   border: 1px solid #ebebeb;


### PR DESCRIPTION
Fixes #2818

Before:
![before](https://cloud.githubusercontent.com/assets/5310329/16765410/8135c2b4-4851-11e6-9148-8b8a7d621ff4.png)
After:
![after](https://cloud.githubusercontent.com/assets/5310329/16765419/8921abdc-4851-11e6-83d8-2c0a9ee4ca3c.png)
