### PR TITLE
Take the biggest blockID rather than the smallest one for multiple candidates.

### DIFF
--- a/src/olympia/blocklist/tests/test_views.py
+++ b/src/olympia/blocklist/tests/test_views.py
@@ -230,7 +230,7 @@ class BlocklistItemTest(XMLAssertsMixin, BlocklistViewTest):
 
         # Check that the blockID is the smallest
         assert item.getAttribute('blockID') == (
-            'i%s' % str(first_created_details.id))
+            'i%s' % str(secondly_created_details.id))
 
     def test_item_os(self):
         item = self.dom(self.fx4_url).getElementsByTagName('emItem')[0]

--- a/src/olympia/blocklist/views.py
+++ b/src/olympia/blocklist/views.py
@@ -117,7 +117,7 @@ def get_items(apiver=None, app=None, appver=None, groupby='guid'):
             rs[0].apps = [App(r.app_guid, r.app_min, r.app_max)
                           for r in rs if r.app_guid]
         os = [r.os for r in rr if r.os]
-        block_id = min([r.block_id for r in rows])
+        block_id = max([r.block_id for r in rows])
         items[guid] = BlItem(rr, os[0] if os else None, rows[0].modified,
                              block_id, prefs)
         details[guid] = sorted(rows, key=attrgetter('id'))[0]


### PR DESCRIPTION
Refs #3053 