### PR TITLE
Drop columns filetype and thumbtype from Preview model (fix #3110)

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1860,8 +1860,6 @@ dbsignals.pre_save.connect(save_signal, sender=Category,
 
 class Preview(ModelBase):
     addon = models.ForeignKey(Addon, related_name='previews')
-    filetype = models.CharField(max_length=25)
-    thumbtype = models.CharField(max_length=25)
     caption = TranslatedField()
 
     position = models.IntegerField(default=0)
@@ -1877,14 +1875,10 @@ class Preview(ModelBase):
         else:
             modified = 0
         args = [self.id / 1000, self.id, modified]
-        if '.png' not in url_template:
-            args.insert(2, self.file_extension)
         return url_template % tuple(args)
 
     def _image_path(self, url_template):
         args = [self.id / 1000, self.id]
-        if '.png' not in url_template:
-            args.append(self.file_extension)
         return url_template % tuple(args)
 
     def as_dict(self, src=None):
@@ -1901,13 +1895,6 @@ class Preview(ModelBase):
         return size[0] > size[1]
 
     @property
-    def file_extension(self):
-        # Assume that blank is an image.
-        if not self.filetype:
-            return 'png'
-        return self.filetype.split('/')[1]
-
-    @property
     def thumbnail_url(self):
         template = (
             helpers.user_media_url('previews') +
@@ -1918,7 +1905,7 @@ class Preview(ModelBase):
     def image_url(self):
         template = (
             helpers.user_media_url('previews') +
-            'full/%s/%d.%s?modified=%s')
+            'full/%s/%d.png?modified=%s')
         return self._image_url(template)
 
     @property
@@ -1937,7 +1924,7 @@ class Preview(ModelBase):
             helpers.user_media_path('previews'),
             'full',
             '%s',
-            '%d.%s'
+            '%d.png'
         )
         return self._image_path(template)
 

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -1953,17 +1953,13 @@ class TestPreviewModel(TestCase):
 
     def test_filename(self):
         preview = Preview.objects.get(pk=24)
-        assert preview.file_extension == 'png'
-        preview.update(filetype='')
-        assert preview.file_extension == 'png'
-        preview.update(filetype='video/webm')
-        assert preview.file_extension == 'webm'
+        assert 'png' in preview.thumbnail_path
+        assert 'png' in preview.image_path
 
     def test_filename_in_url(self):
         preview = Preview.objects.get(pk=24)
-        preview.update(filetype='video/webm')
-        assert 'png' in preview.thumbnail_path
-        assert 'webm' in preview.image_path
+        assert 'png' in preview.thumbnail_url
+        assert 'png' in preview.image_url
 
     def check_delete(self, preview, filename):
         """

--- a/src/olympia/amo/fixtures/base/addon_4664_twitterbar.json
+++ b/src/olympia/amo/fixtures/base/addon_4664_twitterbar.json
@@ -295,10 +295,8 @@
     {
         "fields": {
             "caption": 130761,
-            "filetype": "image/png",
             "created": "2008-05-03 10:03:27",
             "modified": "2008-05-03 10:03:28",
-            "thumbtype": "image/png",
             "addon": 4664
         },
         "model": "addons.preview",

--- a/src/olympia/amo/fixtures/base/previews.json
+++ b/src/olympia/amo/fixtures/base/previews.json
@@ -149,10 +149,8 @@
         "model": "addons.preview",
         "fields": {
             "caption": 32680,
-            "filetype": "image/png",
             "created": "2007-03-05 09:54:15",
             "modified": "2010-01-02 12:34:56",
-            "thumbtype": "image/png",
             "addon": 159
         }
     }

--- a/src/olympia/landfill/images.py
+++ b/src/olympia/landfill/images.py
@@ -20,10 +20,7 @@ def generate_addon_preview(addon):
     """
     color = random.choice(ImageColor.colormap.keys())
     im = Image.new('RGB', (320, 480), color)
-    p = Preview.objects.create(addon=addon, filetype='image/png',
-                               thumbtype='image/png',
-                               caption='Screenshot 1',
-                               position=1)
+    p = Preview.objects.create(addon=addon, caption='Screenshot 1', position=1)
     f = tempfile.NamedTemporaryFile()
     im.save(f, 'png')
     resize_preview(f.name, p)

--- a/src/olympia/legacy_api/templates/legacy_api/includes/addon.xml
+++ b/src/olympia/legacy_api/templates/legacy_api/includes/addon.xml
@@ -70,10 +70,10 @@
   <previews>
     {%- for preview in addon.all_previews -%}
     <preview position="{{ preview.position|int }}">
-      <full type="{{ preview.filetype }}"{% with sizes=preview.image_size -%}{% if sizes %} width="{{ sizes[0] }}" height="{{ sizes[1] }}"{% endif %}{% endwith -%}>
+      <full type="image/png"{% with sizes=preview.image_size -%}{% if sizes %} width="{{ sizes[0] }}" height="{{ sizes[1] }}"{% endif %}{% endwith -%}>
         {{ preview.image_url|urlparams(src='api') }}
       </full>
-      <thumbnail type="{{ preview.thumbtype }}"{% with sizes=preview.thumbnail_size -%}{% if sizes %} width="{{ sizes[0] }}" height="{{ sizes[1] }}"{% endif %}{% endwith -%}>
+      <thumbnail type="image/png"{% with sizes=preview.thumbnail_size -%}{% if sizes %} width="{{ sizes[0] }}" height="{{ sizes[1] }}"{% endif %}{% endwith -%}>
         {{ preview.thumbnail_url|urlparams(src='api') }}
       </thumbnail>
       {%- if preview.caption -%}

--- a/src/olympia/legacy_api/tests/test_views.py
+++ b/src/olympia/legacy_api/tests/test_views.py
@@ -528,9 +528,9 @@ class APITest(TestCase):
         preview.sizes = {'thumbnail': [200, 150]}
         preview.save()
         result = make_call('addon/5299', version=1.5)
-        self.assertContains(result, '<full type="">')
-        self.assertContains(result,
-                            '<thumbnail type="" width="200" height="150">')
+        self.assertContains(result, '<full type="image/png">')
+        self.assertContains(
+            result, '<thumbnail type="image/png" width="200" height="150">')
 
     @patch.object(Addon, 'is_disabled', lambda self: True)
     def test_disabled_addon(self):

--- a/src/olympia/migrations/885-remove-filetype-thumbtype.sql
+++ b/src/olympia/migrations/885-remove-filetype-thumbtype.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `previews` DROP COLUMN `filetype`, DROP COLUMN `thumbtype`;


### PR DESCRIPTION
We convert images to PNGs anyway.