### PR TITLE
Limit FxA migration email to "recently" logged in users

### DIFF
--- a/src/olympia/zadmin/tests/test_views.py
+++ b/src/olympia/zadmin/tests/test_views.py
@@ -1753,14 +1753,15 @@ class TestEmailDevs(TestCase):
 
     def test_exclude_fxa_migrated(self):
         user = self.addon.authors.get()
-        user.update(fxa_id='yup')
+        user.update(fxa_id='yup', last_login=datetime.now())
         res = self.post(recipients='fxa')
         self.assertNoFormErrors(res)
         assert len(mail.outbox) == 0
 
     def test_include_fxa_not_migrated(self):
-        res = self.post(recipients='fxa')
         user = self.addon.authors.get()
+        user.update(last_login=datetime.now())
+        res = self.post(recipients='fxa')
         self.assertNoFormErrors(res)
         assert len(mail.outbox) == 1
 
@@ -1769,6 +1770,19 @@ class TestEmailDevs(TestCase):
         res = self.post(recipients='fxa')
         self.assertNoFormErrors(res)
         assert len(mail.outbox) == 2
+
+    def test_exclude_old_fxa_not_migrated(self):
+        user = self.addon.authors.get()
+        user.update(fxa_id='', last_login=datetime(2013, 3, 14))
+        res = self.post(recipients='fxa')
+        self.assertNoFormErrors(res)
+        assert len(mail.outbox) == 0
+
+        user = self.addon.authors.get()
+        user.update(last_login=datetime(2014, 3, 14))
+        res = self.post(recipients='fxa')
+        self.assertNoFormErrors(res)
+        assert len(mail.outbox) == 1
 
 
 class TestFileDownload(TestCase):

--- a/src/olympia/zadmin/views.py
+++ b/src/olympia/zadmin/views.py
@@ -430,6 +430,10 @@ def email_devs(request):
         elif data['recipients'] == 'all_extensions':
             qs = qs.filter(addon__type=amo.ADDON_EXTENSION)
         elif data['recipients'] == 'fxa':
+            # We're limiting to logins since 2014 to limit the list
+            # dramatically. There was an import from getpersonas.com in 2013
+            # and if you haven't logged in within the last two years you
+            # likely won't migrate.
             qs = (qs
                 .filter(Q(user__fxa_id__isnull=True) | Q(user__fxa_id=''))
                 .filter(

--- a/src/olympia/zadmin/views.py
+++ b/src/olympia/zadmin/views.py
@@ -434,10 +434,9 @@ def email_devs(request):
             # dramatically. There was an import from getpersonas.com in 2013
             # and if you haven't logged in within the last two years you
             # likely won't migrate.
-            qs = (qs
-                .filter(Q(user__fxa_id__isnull=True) | Q(user__fxa_id=''))
-                .filter(
-                    user__last_login__gte=datetime(year=2014, month=1, day=1)))
+            qs = qs.filter(
+                Q(user__fxa_id__isnull=True) | Q(user__fxa_id=''),
+                user__last_login__gte=datetime(year=2014, month=1, day=1))
         else:
             raise NotImplementedError('If you want to support emailing other '
                                       'types of developers, do it here!')

--- a/src/olympia/zadmin/views.py
+++ b/src/olympia/zadmin/views.py
@@ -1,5 +1,6 @@
 import csv
 import json
+from datetime import datetime
 from decimal import Decimal
 
 from django.apps import apps
@@ -429,7 +430,10 @@ def email_devs(request):
         elif data['recipients'] == 'all_extensions':
             qs = qs.filter(addon__type=amo.ADDON_EXTENSION)
         elif data['recipients'] == 'fxa':
-            qs = qs.filter(Q(user__fxa_id__isnull=True) | Q(user__fxa_id=''))
+            qs = (qs
+                .filter(Q(user__fxa_id__isnull=True) | Q(user__fxa_id=''))
+                .filter(
+                    user__last_login__gte=datetime(year=2014, month=1, day=1)))
         else:
             raise NotImplementedError('If you want to support emailing other '
                                       'types of developers, do it here!')


### PR DESCRIPTION
We don't want to email all 200,000 developers that haven't migrated. If you haven't logged in since January 1st, 2014 then odds are you don't care.