### PR TITLE
Make the editor tools work on the last version, even if it's been rejected

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -937,6 +937,17 @@ class Addon(OnChangeMixin, ModelBase):
             pass
         return None
 
+    @property
+    def latest_or_rejected_version(self):
+        """Similar to latest_version but includes rejected versions.  Used so
+        we correctly attach review content to the last version reviewed."""
+        try:
+            latest = self.versions.exclude(
+                files__status=amo.STATUS_BETA).latest('id')
+        except Version.DoesNotExist:
+            latest = self.latest_version
+        return latest
+
     @amo.cached_property
     def binary(self):
         """Returns if the current version has binary files."""

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -463,6 +463,20 @@ class TestAddonModels(TestCase):
         v2.save()
         assert a.latest_version.id == v1.id  # Still should be v1
 
+    def test_latest_or_rejected_version(self):
+        a = Addon.objects.get(pk=3615)
+
+        v1 = Version.objects.create(addon=a, version='1.0')
+        File.objects.create(version=v1)
+        assert a.latest_or_rejected_version.id == v1.id
+        v2 = Version.objects.create(addon=a, version='2.0')
+        f2 = File.objects.create(version=v2)
+        v2.save()
+        assert a.latest_or_rejected_version.id == v2.id
+
+        f2.update(status=amo.STATUS_DISABLED)
+        assert a.latest_or_rejected_version.id == v2.id  # Should still be 2.0.
+
     def test_current_version_unsaved(self):
         a = Addon()
         a._current_version = Version()

--- a/src/olympia/editors/views.py
+++ b/src/olympia/editors/views.py
@@ -586,7 +586,7 @@ def review(request, addon):
     if not addon.is_listed and not acl.check_unlisted_addons_reviewer(request):
         raise http.Http404
 
-    version = addon.latest_version
+    version = addon.latest_or_rejected_version
 
     if not settings.ALLOW_SELF_REVIEWS and addon.has_author(request.user):
         amo.messages.warning(request, _('Self-reviews are not allowed.'))


### PR DESCRIPTION
fixes #3011 