### PR TITLE
Remove confusing `app_slug` parameter from addon_view inner function

### DIFF
--- a/src/olympia/addons/decorators.py
+++ b/src/olympia/addons/decorators.py
@@ -21,7 +21,7 @@ def owner_or_unlisted_reviewer(request, addon):
 
 def addon_view(f, qs=Addon.objects.all):
     @functools.wraps(f)
-    def wrapper(request, addon_id=None, app_slug=None, *args, **kw):
+    def wrapper(request, addon_id=None, *args, **kw):
         """Provides an addon given either an addon id or an addon slug."""
         assert addon_id, 'Must provide addon id or slug'
 

--- a/src/olympia/addons/decorators.py
+++ b/src/olympia/addons/decorators.py
@@ -22,7 +22,8 @@ def owner_or_unlisted_reviewer(request, addon):
 def addon_view(f, qs=Addon.objects.all):
     @functools.wraps(f)
     def wrapper(request, addon_id=None, *args, **kw):
-        """Provides an addon given either an addon id or an addon slug."""
+        """Provides an addon instance to the view given addon_id, which can be
+        an Addon pk or a slug."""
         assert addon_id, 'Must provide addon id or slug'
 
         if addon_id and addon_id.isdigit():

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -1281,7 +1281,7 @@ class TestThemeEdit(TestCase):
         req = req_factory_factory(
             self.addon.get_dev_url('edit'),
             user=self.user, post=True, data=data, session={})
-        r = edit_theme(req, self.addon.slug, self.addon)
+        r = edit_theme(req, self.addon.slug)
         doc = pq(r.content)
         assert 'characters' in doc('#trans-description + ul li').text()
 
@@ -1289,14 +1289,14 @@ class TestThemeEdit(TestCase):
         self.addon.update(status=amo.STATUS_PENDING)
         req = req_factory_factory(
             self.addon.get_dev_url('edit'), user=self.user, session={})
-        r = edit_theme(req, self.addon.slug, self.addon)
+        r = edit_theme(req, self.addon.slug)
         doc = pq(r.content)
         assert not doc('a.reupload')
 
         self.addon.update(status=amo.STATUS_PUBLIC)
         req = req_factory_factory(
             self.addon.get_dev_url('edit'), user=self.user, session={})
-        r = edit_theme(req, self.addon.slug, self.addon)
+        r = edit_theme(req, self.addon.slug)
         doc = pq(r.content)
         assert doc('a.reupload')
 


### PR DESCRIPTION
It's a relic from Marketplace that is not used in AMO, and it's just confusing since the docstring mentions a slug.