### PR TITLE
Log successful FxA login attempts

### DIFF
--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -123,6 +123,7 @@ def login_user(request, user, identity):
             _(u'You can now log in to Add-ons with your Firefox Account.'),
             extra_tags='fxa')
     log.info('Logging in user {} from FxA'.format(user))
+    user.log_login_attempt(True)
     login(request, user)
 
 


### PR DESCRIPTION
This sets the `last_login_*` fields when the user successfully logs in with FxA.

There doesn't seem to be a good way to log unsuccessful attempts anymore. Those should be handled by FxA. We could do something for state mismatches or bad oauth tokens but I'm not sure we'd be able to reliably detect what user it was.

Fixes #1777.