### PR TITLE
Use latest Firefox release for UI tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,7 @@ dependencies:
 
 test:
   pre:
-    - mozdownload --version latest-esr --destination firefox.tar.bz2
+    - mozdownload --version latest --destination firefox.tar.bz2
     - mozinstall firefox.tar.bz2
     - wget "https://github.com/mozilla/geckodriver/releases/download/v0.9.0/geckodriver-v0.9.0-linux64.tar.gz"
     - gunzip -c geckodriver-v0.9.0-linux64.tar.gz | tar xopf -


### PR DESCRIPTION
This should fix the recent issue introduced with mozdownload failing to get the latest ESR release. It also probably makes more sense to be on the latest release now we're using Marionette.

@EnTeQuAk r?