### PR TITLE
Disallow nominated addons from being given preliminary review

### DIFF
--- a/src/olympia/editors/helpers.py
+++ b/src/olympia/editors/helpers.py
@@ -11,6 +11,7 @@ from django.utils.translation import (
 import commonware.log
 import django_tables2 as tables
 import jinja2
+import waffle
 from jingo import register
 
 from olympia import amo
@@ -578,7 +579,9 @@ class ReviewHelper:
                                      'label': label}
             # An unlisted sideload add-on, which requests a full review, cannot
             # be granted a preliminary review.
-            if addon.is_listed or self.review_type == 'preliminary':
+            prelim_allowed = not waffle.flag_is_active(
+                request, 'no-prelim-review') and addon.is_listed
+            if prelim_allowed or self.review_type == 'preliminary':
                 actions['prelim'] = {
                     'method': self.handler.process_preliminary,
                     'label': labels['prelim'],

--- a/src/olympia/editors/tests/test_helpers.py
+++ b/src/olympia/editors/tests/test_helpers.py
@@ -8,6 +8,7 @@ from django.utils import translation
 import pytest
 from mock import Mock, patch
 from pyquery import PyQuery as pq
+from waffle.testutils import override_flag
 
 from olympia import amo
 from olympia.amo.tests import TestCase
@@ -371,8 +372,22 @@ class TestReviewHelper(TestCase):
             addon_status=amo.STATUS_NOMINATED,
             file_status=amo.STATUS_UNREVIEWED).keys() == expected
 
+    @override_flag('no-prelim-review', active=True)
+    def test_actions_full_nominated_no_prelim(self):
+        expected = ['public', 'reject', 'info', 'super', 'comment']
+        assert self.get_review_actions(
+            addon_status=amo.STATUS_NOMINATED,
+            file_status=amo.STATUS_UNREVIEWED).keys() == expected
+
     def test_actions_full_update(self):
         expected = ['public', 'prelim', 'reject', 'info', 'super', 'comment']
+        assert self.get_review_actions(
+            addon_status=amo.STATUS_PUBLIC,
+            file_status=amo.STATUS_UNREVIEWED).keys() == expected
+
+    @override_flag('no-prelim-review', active=True)
+    def test_actions_full_update_no_prelim(self):
+        expected = ['public', 'reject', 'info', 'super', 'comment']
         assert self.get_review_actions(
             addon_status=amo.STATUS_PUBLIC,
             file_status=amo.STATUS_UNREVIEWED).keys() == expected
@@ -407,6 +422,13 @@ class TestReviewHelper(TestCase):
 
     def test_actions_prelim_upgrade_to_full(self):
         expected = ['public', 'prelim', 'reject', 'info', 'super', 'comment']
+        assert self.get_review_actions(
+            addon_status=amo.STATUS_LITE_AND_NOMINATED,
+            file_status=amo.STATUS_LITE).keys() == expected
+
+    @override_flag('no-prelim-review', active=True)
+    def test_actions_prelim_upgrade_to_full_no_prelim(self):
+        expected = ['public', 'reject', 'info', 'super', 'comment']
         assert self.get_review_actions(
             addon_status=amo.STATUS_LITE_AND_NOMINATED,
             file_status=amo.STATUS_LITE).keys() == expected


### PR DESCRIPTION
fixes #3086 
Change here is quite minimal - it just removes the preliminary option for nominated (and lite nominated) addons so they can only either be rejected or approved. 