### PR TITLE
Refactor the way categories are attached to Addons using StaticCategory

### DIFF
--- a/src/olympia/addons/forms.py
+++ b/src/olympia/addons/forms.py
@@ -223,6 +223,9 @@ class CategoryForm(forms.Form):
             AddonCategory.objects.filter(
                 addon=addon, category_id=c_id).delete()
 
+        # Remove old, outdated categories cache on the model.
+        del addon.all_categories
+
     def clean_categories(self):
         categories = self.cleaned_data['categories']
         total = categories.count()

--- a/src/olympia/addons/forms.py
+++ b/src/olympia/addons/forms.py
@@ -211,7 +211,8 @@ class CategoryForm(forms.Form):
         application = self.cleaned_data.get('application')
         categories_new = [c.id for c in self.cleaned_data['categories']]
         categories_old = [
-            c.id for c in addon.app_categories[amo.APP_IDS[application]]]
+            c.id for c in
+            addon.app_categories.get(amo.APP_IDS[application], [])]
 
         # Add new categories.
         for c_id in set(categories_new) - set(categories_old):

--- a/src/olympia/addons/forms.py
+++ b/src/olympia/addons/forms.py
@@ -203,12 +203,12 @@ class AddonFormBasic(AddonFormBase):
 class CategoryForm(forms.Form):
     application = forms.TypedChoiceField(amo.APPS_CHOICES, coerce=int,
                                          widget=forms.HiddenInput,
-                                         required=False)
+                                         required=True)
     categories = forms.ModelMultipleChoiceField(
         queryset=Category.objects.all(), widget=CategoriesSelectMultiple)
 
     def save(self, addon):
-        application = self.cleaned_data.get('application', amo.FIREFOX.id)
+        application = self.cleaned_data.get('application')
         categories_new = [c.id for c in self.cleaned_data['categories']]
         categories_old = [
             c.id for c in addon.app_categories[amo.APP_IDS[application]]]

--- a/src/olympia/addons/forms.py
+++ b/src/olympia/addons/forms.py
@@ -208,21 +208,19 @@ class CategoryForm(forms.Form):
         queryset=Category.objects.all(), widget=CategoriesSelectMultiple)
 
     def save(self, addon):
-        application = self.cleaned_data.get('application')
-        categories_new = self.cleaned_data['categories']
-        categories_old = [cats for app, cats in addon.app_categories if
-                          (app and application and app.id == application) or
-                          (not app and not application)]
-        if categories_old:
-            categories_old = categories_old[0]
+        application = self.cleaned_data.get('application', amo.FIREFOX.id)
+        categories_new = [c.id for c in self.cleaned_data['categories']]
+        categories_old = [
+            c.id for c in addon.app_categories[amo.APP_IDS[application]]]
 
         # Add new categories.
-        for c in set(categories_new) - set(categories_old):
-            AddonCategory(addon=addon, category=c).save()
+        for c_id in set(categories_new) - set(categories_old):
+            AddonCategory(addon=addon, category_id=c_id).save()
 
         # Remove old categories.
-        for c in set(categories_old) - set(categories_new):
-            AddonCategory.objects.filter(addon=addon, category=c).delete()
+        for c_id in set(categories_old) - set(categories_new):
+            AddonCategory.objects.filter(
+                addon=addon, category_id=c_id).delete()
 
     def clean_categories(self):
         categories = self.cleaned_data['categories']
@@ -270,7 +268,7 @@ class BaseCategoryFormSet(BaseFormSet):
             apps = []
 
         for app in apps:
-            cats = dict(self.addon.app_categories).get(app, [])
+            cats = self.addon.app_categories.get(app, [])
             self.initial.append({'categories': [c.id for c in cats]})
 
         for app, form in zip(apps, self.forms):

--- a/src/olympia/addons/indexers.py
+++ b/src/olympia/addons/indexers.py
@@ -197,9 +197,9 @@ class AddonIndexer(BaseSearchIndexer):
         if (obj.status == amo.STATUS_PUBLIC and not obj.is_experimental and
                 'boost' in data):
             data['boost'] = float(max(data['boost'], 1) * 4)
-        # We go through attach_categories and attach_tags transformer before
-        # calling this function, it sets category_ids and tag_list.
-        data['category'] = getattr(obj, 'category_ids', [])
+        # We can use all_categories because the indexing code goes through the
+        # transformer that sets it.
+        data['category'] = [cat.id for cat in obj.all_categories]
         if obj.current_version:
             data['current_version'] = {
                 'id': obj.current_version.pk,
@@ -233,6 +233,8 @@ class AddonIndexer(BaseSearchIndexer):
             'average': obj.average_rating,
             'count': obj.total_reviews,
         }
+        # We can use tag_list because the indexing code goes through the
+        # transformer that sets it (attach_tags).
         data['tags'] = getattr(obj, 'tag_list', [])
 
         # Handle localized fields.

--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -11,9 +11,8 @@ from PIL import Image
 
 from olympia import amo
 from olympia.addons.models import (
-    Addon, AddonFeatureCompatibility, attach_categories, attach_tags,
-    attach_translations, AppSupport, CompatOverride, IncompatibleVersions,
-    Persona, Preview)
+    Addon, AddonFeatureCompatibility, attach_tags, attach_translations,
+    AppSupport, CompatOverride, IncompatibleVersions, Persona, Preview)
 from olympia.addons.indexers import AddonIndexer
 from olympia.amo.celery import task
 from olympia.amo.decorators import set_modified_on, write
@@ -106,7 +105,7 @@ def delete_preview_files(id, **kw):
 @task(acks_late=True)
 def index_addons(ids, **kw):
     log.info('Indexing addons %s-%s. [%s]' % (ids[0], ids[-1], len(ids)))
-    transforms = (attach_categories, attach_tags, attach_translations)
+    transforms = (attach_tags, attach_translations)
     index_objects(ids, Addon, AddonIndexer.extract_document,
                   kw.pop('index', None), transforms, Addon.unfiltered)
 

--- a/src/olympia/addons/tests/test_indexers.py
+++ b/src/olympia/addons/tests/test_indexers.py
@@ -5,7 +5,7 @@ from olympia import amo
 from olympia.amo.models import SearchMixin
 from olympia.amo.tests import addon_factory, ESTestCase, file_factory, TestCase
 from olympia.addons.models import (
-    Addon, attach_categories, attach_tags, attach_translations, Preview)
+    Addon, attach_tags, attach_translations, Preview)
 from olympia.addons.indexers import AddonIndexer
 from olympia.constants.applications import FIREFOX
 from olympia.constants.platforms import PLATFORM_ALL, PLATFORM_MAC
@@ -28,7 +28,7 @@ class TestAddonIndexer(TestCase):
 
     def setUp(self):
         super(TestAddonIndexer, self).setUp()
-        self.transforms = (attach_categories, attach_tags, attach_translations)
+        self.transforms = (attach_tags, attach_translations)
         self.indexer = AddonIndexer()
         self.addon = Addon.objects.get(pk=3615)
 
@@ -144,7 +144,7 @@ class TestAddonIndexer(TestCase):
             }
         }
         assert extracted['boost'] == self.addon.average_daily_users ** .2 * 4
-        assert extracted['category'] == [22, 23, 24]  # From fixture.
+        assert extracted['category'] == [1, 22, 71]  # From fixture.
         assert extracted['has_theme_rereview'] is None
         assert extracted['listed_authors'] == [
             {'name': u'55021 التطب', 'id': 55021, 'username': '55021'}]

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -1057,7 +1057,6 @@ class TestImpalaDetailPage(TestCase):
     def test_categories(self):
         cat = self.addon.all_categories[0]
         cat.application = amo.THUNDERBIRD.id
-        cat.save()
         links = self.get_more_pq()('#related ul:first').find('a')
         expected = [(unicode(c.name), c.get_url_path())
                     for c in self.addon.categories.filter(

--- a/src/olympia/amo/fixtures/base/addon_3615.json
+++ b/src/olympia/amo/fixtures/base/addon_3615.json
@@ -346,6 +346,20 @@
         }
     },
     {
+        "pk": 1,
+        "model": "addons.category",
+        "fields": {
+            "count": 901,
+            "weight": 0,
+            "created": "2007-03-05 13:09:27",
+            "modified": "2010-02-23 19:17:32",
+            "application": 1,
+            "type": 1,
+            "slug": "feeds-news-blogging",
+            "db_name": 2323
+        }
+    },    
+    {
         "pk": 22,
         "model": "addons.category",
         "fields": {
@@ -360,7 +374,7 @@
         }
     },
     {
-        "pk": 24,
+        "pk": 71,
         "model": "addons.category",
         "fields": {
             "count": 901,
@@ -369,22 +383,8 @@
             "modified": "2010-02-23 19:17:32",
             "application": 1,
             "type": 1,
-            "slug": "social",
+            "slug": "social-communication",
             "db_name": 2424
-        }
-    },
-    {
-        "pk": 23,
-        "model": "addons.category",
-        "fields": {
-            "count": 901,
-            "weight": 0,
-            "created": "2007-03-05 13:09:27",
-            "modified": "2010-02-23 19:17:32",
-            "application": 1,
-            "type": 1,
-            "slug": "feeds",
-            "db_name": 2323
         }
     },
     {
@@ -400,7 +400,7 @@
         "pk": 6344,
         "model": "addons.addoncategory",
         "fields": {
-            "category": 23,
+            "category": 1,
             "feature": 1,
             "addon": 3615
         }
@@ -409,7 +409,7 @@
         "pk": 6345,
         "model": "addons.addoncategory",
         "fields": {
-            "category": 24,
+            "category": 71,
             "feature": 1,
             "addon": 3615
         }

--- a/src/olympia/amo/fixtures/base/addon_3615_categories.json
+++ b/src/olympia/amo/fixtures/base/addon_3615_categories.json
@@ -1,5 +1,19 @@
 [
     {
+        "pk": 1,
+        "model": "addons.category",
+        "fields": {
+            "count": 901,
+            "weight": 0,
+            "created": "2007-03-05 13:09:27",
+            "modified": "2010-02-23 19:17:32",
+            "application": 1,
+            "type": 1,
+            "slug": "feeds-news-blogging",
+            "db_name": 3
+        }
+    },
+    {
         "pk": 22,
         "model": "addons.category",
         "fields": {
@@ -14,7 +28,7 @@
         }
     },
     {
-        "pk": 24,
+        "pk": 71,
         "model": "addons.category",
         "fields": {
             "count": 901,
@@ -23,22 +37,8 @@
             "modified": "2010-02-23 19:17:32",
             "application": 1,
             "type": 1,
-            "slug": "social",
+            "slug": "social-communication",
             "db_name": 2
-        }
-    },
-    {
-        "pk": 23,
-        "model": "addons.category",
-        "fields": {
-            "count": 901,
-            "weight": 0,
-            "created": "2007-03-05 13:09:27",
-            "modified": "2010-02-23 19:17:32",
-            "application": 1,
-            "type": 1,
-            "slug": "feeds",
-            "db_name": 3
         }
     },
     {

--- a/src/olympia/constants/applications.py
+++ b/src/olympia/constants/applications.py
@@ -5,7 +5,7 @@ from olympia.versions.compare import version_int as vint
 from base import *  # noqa
 
 
-class App:
+class App(object):
     @classmethod
     def matches_user_agent(cls, user_agent):
         return cls.user_agent_string in user_agent

--- a/src/olympia/constants/categories.py
+++ b/src/olympia/constants/categories.py
@@ -10,10 +10,11 @@ from olympia.constants.base import (
 
 
 class StaticCategory(object):
-    def __init__(self, id=None, app=None, type=None, name=None, slug=None,
-                 weight=0):
+    def __init__(self, id=None, app=None, type=None, misc=False,
+                 name=None, slug=None, weight=0):
         self.id = id
         self.application = app
+        self.misc = misc
         self.name = name
         self.slug = slug
         self.type = type
@@ -226,6 +227,8 @@ for app in CATEGORIES:
     for type_ in CATEGORIES[app]:
         for slug in CATEGORIES[app][type_]:
             cat = CATEGORIES[app][type_][slug]
+            if slug in ('miscellaneous', 'other'):
+                cat.misc = True
             cat.slug = slug
             cat.application = app
             cat.type = type_

--- a/src/olympia/devhub/templates/devhub/addons/edit/basic.html
+++ b/src/olympia/devhub/templates/devhub/addons/edit/basic.html
@@ -98,7 +98,7 @@
                   {% if form.disabled %}
                     <p class="addon-app-cats addon-app-cats-inline">
                       <b>{{ form.app.pretty }}:</b>
-                      {% set cats = dict(addon.app_categories).get(form.app, []) %}
+                      {% set cats = addon.app_categories.get(form.app, []) %}
                       {{ cats|join(' &middot; ')|safe }}
                     </p>
                     <p>
@@ -117,7 +117,7 @@
                 {% set categories = addon.app_categories %}
                 {% call empty_unless(categories) %}
                   <ul class="addon-app-cats-inline">
-                    {% for app, cats in categories %}
+                    {% for app, cats in categories.items() %}
                       <li>
                         <b>{{ app.pretty }}:</b>
                         {{ cats|join(' &middot; ')|safe }}

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -1348,10 +1348,10 @@ class TestSubmitStep3(TestSubmitBase):
 
         AddonCategory.objects.filter(
             addon=self.get_addon(),
-            category=Category.objects.get(id=23)).delete()
+            category=Category.objects.get(id=1)).delete()
         AddonCategory.objects.filter(
             addon=self.get_addon(),
-            category=Category.objects.get(id=24)).delete()
+            category=Category.objects.get(id=71)).delete()
 
         ctx = self.client.get(self.url).context['cat_form']
         self.cat_initial = initial(ctx.initial_forms[0])
@@ -1516,7 +1516,7 @@ class TestSubmitStep3(TestSubmitBase):
 
     def test_submit_categories_max(self):
         assert amo.MAX_CATEGORIES == 2
-        self.cat_initial['categories'] = [22, 23, 24]
+        self.cat_initial['categories'] = [22, 1, 71]
         r = self.client.post(self.url,
                              self.get_dict(cat_initial=self.cat_initial))
         assert r.context['cat_form'].errors[0]['categories'] == (
@@ -1524,26 +1524,28 @@ class TestSubmitStep3(TestSubmitBase):
 
     def test_submit_categories_add(self):
         assert [c.id for c in self.get_addon().all_categories] == [22]
-        self.cat_initial['categories'] = [22, 23]
+        self.cat_initial['categories'] = [22, 1]
 
         self.client.post(self.url, self.get_dict())
 
         addon_cats = self.get_addon().categories.values_list('id', flat=True)
-        assert sorted(addon_cats) == [22, 23]
+        assert sorted(addon_cats) == [1, 22]
 
     def test_submit_categories_addandremove(self):
-        AddonCategory(addon=self.addon, category_id=23).save()
-        assert [c.id for c in self.get_addon().all_categories] == [22, 23]
+        AddonCategory(addon=self.addon, category_id=1).save()
+        assert sorted(
+            [c.id for c in self.get_addon().all_categories]) == [1, 22]
 
-        self.cat_initial['categories'] = [22, 24]
+        self.cat_initial['categories'] = [22, 71]
         self.client.post(self.url, self.get_dict(cat_initial=self.cat_initial))
         category_ids_new = [c.id for c in self.get_addon().all_categories]
-        assert category_ids_new == [22, 24]
+        assert sorted(category_ids_new) == [22, 71]
 
     def test_submit_categories_remove(self):
-        c = Category.objects.get(id=23)
+        c = Category.objects.get(id=1)
         AddonCategory(addon=self.addon, category=c).save()
-        assert [a.id for a in self.get_addon().all_categories] == [22, 23]
+        assert sorted(
+            [a.id for a in self.get_addon().all_categories]) == [1, 22]
 
         self.cat_initial['categories'] = [22]
         self.client.post(self.url, self.get_dict(cat_initial=self.cat_initial))

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -356,6 +356,22 @@ class TestEditBasic(TestEdit):
         assert doc('#addon-categories-edit div.addon-app-cats').length == 1
         assert doc('#addon-categories-edit > p').length == 0
 
+    def test_edit_no_previous_categories(self):
+        AddonCategory.objects.filter(addon=self.addon).delete()
+        response = self.client.get(self.basic_edit_url)
+        assert response.status_code == 200
+
+        self.cat_initial['categories'] = [22, 71]
+        response = self.client.post(self.basic_edit_url, self.get_dict())
+        self.addon = self.get_addon()
+        addon_cats = self.addon.categories.values_list('id', flat=True)
+        assert sorted(addon_cats) == [22, 71]
+
+        # Make sure the categories list we display to the user in the response
+        # has been updated.
+        assert set(response.context['addon'].all_categories) == set(
+            self.addon.all_categories)
+
     def test_edit_categories_addandremove(self):
         AddonCategory(addon=self.addon, category_id=1).save()
         assert sorted(

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -378,9 +378,15 @@ class TestEditBasic(TestEdit):
             [c.id for c in self.get_addon().all_categories]) == [1, 22]
 
         self.cat_initial['categories'] = [22, 71]
-        self.client.post(self.basic_edit_url, self.get_dict())
-        addon_cats = self.get_addon().categories.values_list('id', flat=True)
+        response = self.client.post(self.basic_edit_url, self.get_dict())
+        self.addon = self.get_addon()
+        addon_cats = self.addon.categories.values_list('id', flat=True)
         assert sorted(addon_cats) == [22, 71]
+
+        # Make sure the categories list we display to the user in the response
+        # has been updated.
+        assert set(response.context['addon'].all_categories) == set(
+            self.addon.all_categories)
 
     def test_edit_categories_xss(self):
         c = Category.objects.get(id=22)
@@ -402,10 +408,16 @@ class TestEditBasic(TestEdit):
             [cat.id for cat in self.get_addon().all_categories]) == [1, 22]
 
         self.cat_initial['categories'] = [22]
-        self.client.post(self.basic_edit_url, self.get_dict())
+        response = self.client.post(self.basic_edit_url, self.get_dict())
 
-        addon_cats = self.get_addon().categories.values_list('id', flat=True)
+        self.addon = self.get_addon()
+        addon_cats = self.addon.categories.values_list('id', flat=True)
         assert sorted(addon_cats) == [22]
+
+        # Make sure the categories list we display to the user in the response
+        # has been updated.
+        assert set(response.context['addon'].all_categories) == set(
+            self.addon.all_categories)
 
     def test_edit_categories_required(self):
         del self.cat_initial['categories']

--- a/src/olympia/landfill/categories.py
+++ b/src/olympia/landfill/categories.py
@@ -1,118 +1,26 @@
 from olympia.addons.models import Category
-from olympia.constants.base import ADDON_EXTENSION, ADDON_PERSONA
+from olympia.constants.categories import CATEGORIES
 
 
-# Based on production categories.
-addons_categories = {
-    'firefox': (
-        # (Label in production, Default icon name),
-        (u'Alerts & Updates', u'alerts'),
-        (u'Appearance', u'appearance'),
-        (u'Bookmarks', u'bookmarks'),
-        (u'Download Management', u'downloads'),
-        (u'Feeds, News & Blogging', u'feeds'),
-        (u'Games & Entertainment', u'games'),
-        (u'Language Support', u'dictionary'),
-        (u'Photos, Music & Videos', u'photos'),
-        (u'Privacy & Security', u'security'),
-        (u'Search Tools', u'search'),
-        (u'Shopping', u'shopping'),
-        (u'Social & Communication', u'social'),
-        (u'Tabs', u'tabs'),
-        (u'Web Development', u'webdev'),
-        (u'Other', u'default'),
-    ),
-    'thunderbird': (
-        # (Label in production, Default icon name),
-        (u'Appearance and Customization', u'appearance'),
-        (u'Calendar and Date/Time', u'video'),
-        (u'Chat and IM', u'social'),
-        (u'Contacts', u'music'),
-        (u'Folders and Filters', u'shopping'),
-        (u'Import/Export', u'downloads'),
-        (u'Language Support', u'dictionary'),
-        (u'Message Composition', u'posts'),
-        (u'Message and News Reading', u'feeds'),
-        (u'Miscellaneous', u'default'),
-        (u'Privacy and Security', u'alerts'),
-        (u'Tags', u'bookmarks'),
-    ),
-    'android': (
-        # (Label in production, Default icon name),
-        (u'Device Features & Location', u'search'),
-        (u'Experimental', u'alerts'),
-        (u'Feeds, News, & Blogging', u'feeds'),
-        (u'Performance', u'webdev'),
-        (u'Photos & Media', u'photos'),
-        (u'Security & Privacy', u'security'),
-        (u'Shopping', u'shopping'),
-        (u'Social Networking', u'social'),
-        (u'Sports & Games', u'games'),
-        (u'User Interface', u'tabs'),
-    ),
-    'seamonkey': (
-        # (Label in production, Default icon name),
-        (u'Bookmarks', u'bookmarks'),
-        (u'Downloading and File Management', u'downloads'),
-        (u'Interface Customizations', u'appearance'),
-        (u'Language Support & Translation', u'dictionary'),
-        (u'Miscellaneous', u'default'),
-        (u'Photos & Media', u'photos'),
-        (u'Privacy and Security', u'alerts'),
-        (u'RSS, News and Blogging', u'feeds'),
-        (u'Search Tools', u'search'),
-        (u'Site-specific', u'posts'),
-        (u'User Interface', u'tabs'),
-        (u'Web and Developer Tools', u'webdev'),
-    ),
-}
-
-
-themes_categories = (
-    # (Label in production, slug),
-    (u'Abstract', u'abstract'),
-    (u'Causes', u'causes'),
-    (u'Fashion', u'fashion'),
-    (u'Film and TV', u'film-and-tv'),
-    (u'Firefox', u'firefox'),
-    (u'Foxkeh', u'foxkeh'),
-    (u'Holiday', u'holiday'),
-    (u'Music', u'music'),
-    (u'Nature', u'nature'),
-    (u'Other', u'other'),
-    (u'Scenery', u'scenery'),
-    (u'Seasonal', u'seasonal'),
-    (u'Solid', u'solid'),
-    (u'Sports', u'sports'),
-    (u'Websites', u'websites'),
-)
-
-
-def generate_categories(app=None):
+def generate_categories(app=None, type=None):
     """
-    Generate a list of categories for the optional `app` based on
-    production categories names. If the `app` is not provided,
-    the category will be created for a theme (old persona).
-
+    Generate a list of categories for the given `app` and `type` based on
+    categories constants.
     """
     categories = []
-    if app is None:  # This is a theme.
-        type_ = ADDON_PERSONA
-        application = None
-        categories_choices = themes_categories
-    else:
-        type_ = ADDON_EXTENSION
-        application = app.id
-        categories_choices = addons_categories[app.short]
-
-    for i, category_choice in enumerate(categories_choices):
+    categories_choices = CATEGORIES[app.id][type]
+    for category_choice in categories_choices.values():
+        defaults = {
+            'slug': category_choice.slug,
+            'db_name': unicode(category_choice.name),
+            'application': app.id,
+            'misc': category_choice.misc,
+            'type': type,
+            'weight': category_choice.weight,
+        }
         category, created = Category.objects.get_or_create(
-            slug=category_choice[1],
-            type=type_,
-            application=application,
-            defaults={
-                'db_name': category_choice[0],
-                'weight': i,
-            })
+            id=category_choice.id, defaults=defaults)
+        if not created:
+            category.update(**defaults)
         categories.append(category)
     return categories

--- a/src/olympia/landfill/tests/test_categories.py
+++ b/src/olympia/landfill/tests/test_categories.py
@@ -2,17 +2,18 @@
 from olympia.amo.tests import TestCase
 from olympia.addons.models import Category
 from olympia.constants.applications import APPS
+from olympia.constants.base import ADDON_EXTENSION, ADDON_PERSONA
 from olympia.landfill.categories import generate_categories
 
 
 class CategoriesTests(TestCase):
 
     def test_categories_themes_generation(self):
-        data = generate_categories()
+        data = generate_categories(APPS['firefox'], ADDON_PERSONA)
         assert len(data) == Category.objects.all().count()
         assert len(data) == 15
 
     def test_categories_addons_generation(self):
-        data = generate_categories(APPS['android'])
+        data = generate_categories(APPS['android'], ADDON_EXTENSION)
         assert len(data) == Category.objects.all().count()
         assert len(data) == 10


### PR DESCRIPTION
This makes `all_categories`, `app_categories`, `get_category` coherent, using the same source, so that it's easier to then override when needed. `app_categories` is changed to return a dict, because it's
more useful that way.

This removes the need for the special `attach_categories()` function that the add-on indexer was using, as we now load all categories for each add-on instead of just the first one.

The final (big!) change is to use `StaticCategory` instances instead of `Category` for these properties, because we have all the relevant information in the constants.