### PR TITLE
Restore author/ratings to themes (fix #2275)

### DIFF
--- a/src/olympia/addons/templates/addons/persona_preview.html
+++ b/src/olympia/addons/templates/addons/persona_preview.html
@@ -89,14 +89,23 @@
         <img src="{{ addon.persona.thumb_url }}"
              data-browsertheme="{{ addon.persona.json_data }}" alt="">
       </div>
-      <h3>{{ addon.name }}</h3>  
-      {% if linked %}
-        <div class="persona-install">
-          <button class="add">
-            <span>{{ _('Add') }}</span>
-          </button>
-        </div>
-      {% endif %}
+      <h3>{{ addon.name }}</h3>
     </a>
+    <h4>
+      {{ _('by') }}
+      {{ users_list(addon.listed_authors) or
+         addon.persona.display_username }}
+    </h4>
+    <h4>
+      {{ _('{0} Daily Users')|fe(addon.persona.popularity|numberfmt) }}
+    </h4>
+
+    {% if linked %}
+      <div class="persona-install">
+        <button class="add">
+          <span>{{ _('Add') }}</span>
+        </button>
+      </div>
+    {% endif %}
   </div>
 {% endif %}

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -1129,7 +1129,7 @@ class TestPersonaDetailPage(TestPersonas, TestCase):
 
         r = self.client.get(self.url)
         assert list(r.context['author_personas']) == [other]
-        a = pq(r.content)('#more-artist .persona.hovercard a')
+        a = pq(r.content)('#more-artist .persona.hovercard > a')
         assert a.length == 1
         assert a.attr('href') == other.get_url_path()
 

--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -1562,6 +1562,29 @@ h3.author .transfer-ownership {
   padding-bottom: 20px;
 }
 
+.restyle .persona.hovercard {
+  height: 100px;
+
+  &:focus,
+  &:hover {
+    height: 148px;
+    margin-bottom: -48px;
+  }
+
+  h3 {
+    padding-bottom: 0;
+  }
+
+  h4 {
+    clear: both;
+    font-size: 12px;
+  }
+
+  a {
+    display: inline;
+  }
+}
+
 .persona-list-3col {
   li {
     border: 0;


### PR DESCRIPTION
Restores daily users and authors back to theme previews, as per #2275.

### Before

![aug-04-2016 02-09-33](https://cloud.githubusercontent.com/assets/90871/17387116/a1d91dce-59e8-11e6-9c9e-9ebea8e07bee.gif)
![aug-04-2016 02-09-29](https://cloud.githubusercontent.com/assets/90871/17387117/a1d9f62c-59e8-11e6-8e6a-3dbeff44dc24.gif)

### After

![aug-04-2016 02-08-04](https://cloud.githubusercontent.com/assets/90871/17387122/abadda1a-59e8-11e6-80cc-997e408afbe3.gif)
![aug-04-2016 02-07-57](https://cloud.githubusercontent.com/assets/90871/17387123/abb43f04-59e8-11e6-906d-a055a10943af.gif)
