### PR TITLE
Fix jump in incompatible buttons (fix #3203)

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -1716,7 +1716,9 @@ h3.author .transfer-ownership {
   color: @default-font-color;
   font-size: 1rem;
   font-weight: normal;
-  padding: 5px 14px 5px 28px;
+  margin: 0;
+  min-width: 225px;
+  padding: 5px 0px 5px 16px;
 
   .addon-description-header &  {
     border: 0;
@@ -1824,6 +1826,10 @@ h3.author .transfer-ownership {
 
   .install-shell .install {
     display: inline-block;
+  }
+
+  .d2c-reasons-help {
+    margin: 0 0 0 -8px;
   }
 }
 


### PR DESCRIPTION
I didn't see the jump @ValentinaPC reported but I saw that text moved around _under_ the add-on being hovered, so I see why it happened (the margins on some of these elements were excessive). Should fix #3203 entirely.

### Before
![aug-09-2016 12-56-09](https://cloud.githubusercontent.com/assets/90871/17515525/e20ac19e-5e30-11e6-84af-13b869b22821.gif)

### After
![aug-09-2016 12-55-40](https://cloud.githubusercontent.com/assets/90871/17515526/e5eea1a4-5e30-11e6-8576-e348fa89240b.gif)
