### PR TITLE
Note that the log in page is for log in and register in heading

### DIFF
--- a/src/olympia/users/templates/users/login.html
+++ b/src/olympia/users/templates/users/login.html
@@ -15,7 +15,7 @@
   {% else %}
     {% include "users/login_help.html" %}
     <section class="island hero primary grid prettyform">
-      <h1>{{ _('Enter your email') }}</h1>
+      <h1>{{ _('Log in or register with your email address') }}</h1>
       <p class="island-note">
         {% trans %}
           We are migrating existing Add-ons users to Firefox Accounts. We will


### PR DESCRIPTION
This will update the heading to note that the page is for both logging in and registering. We won't merge this until after the tag so localisers have time to update the translations.

Fixes mozilla/addons#180.