### PR TITLE
Attach search arrow (fix #2184)

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -1019,15 +1019,16 @@ a.button.release-theme-lock {
   border-radius: 0;
   box-shadow: none;
   height: 30px;
+  left: -6px;
 
   &:hover,
-  &:focus,
-  &:active {
+  &:focus {
     box-shadow: inset 0 0 100px rgba(255, 255, 255, 0.2);
   }
 
   &:active {
-    top: 1px;
+    box-shadow: none;
+    top: 0;
   }
 }
 


### PR DESCRIPTION
### Before
<img width="313" alt="screenshot 2016-08-09 19 15 58" src="https://cloud.githubusercontent.com/assets/90871/17528067/b7753df8-5e65-11e6-8a0f-f90ad6b0f6e8.png">

### After
<img width="309" alt="screenshot 2016-08-09 19 14 56" src="https://cloud.githubusercontent.com/assets/90871/17528070/bd412760-5e65-11e6-95c9-18219e891529.png">
