### PR TITLE
Stops lite_and_nominated add-ons from becoming nominated and then incomplete

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1053,8 +1053,11 @@ class Addon(OnChangeMixin, ModelBase):
             if versions.filter(files__status=amo.STATUS_LITE).exists():
                 status = amo.STATUS_LITE
                 logit('only lite files')
+            elif versions.filter(files__status=amo.STATUS_UNREVIEWED).exists():
+                status = amo.STATUS_NOMINATED
+                logit('only an unreviewed file')
             else:
-                status = amo.STATUS_UNREVIEWED
+                status = amo.STATUS_NULL
                 logit('no reviewed files')
         elif (self.status in amo.REVIEWED_STATUSES and
               self.latest_version and
@@ -1230,6 +1233,7 @@ class Addon(OnChangeMixin, ModelBase):
         if disallow_preliminary_review:
             if (self.is_disabled or
                     self.status in (amo.STATUS_PUBLIC,
+                                    amo.STATUS_LITE_AND_NOMINATED,
                                     amo.STATUS_NOMINATED,
                                     amo.STATUS_DELETED) or
                     not self.latest_version or

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -1288,7 +1288,7 @@ class TestAddonModels(TestCase):
         addon, version = self.setup_files(amo.STATUS_UNREVIEWED)
         addon.update(status=amo.STATUS_PUBLIC)
         version.save()
-        assert addon.status == amo.STATUS_UNREVIEWED
+        assert addon.status == amo.STATUS_NOMINATED
 
     def test_removing_public_with_prelim(self):
         addon, version = self.setup_files(amo.STATUS_LITE)
@@ -1371,7 +1371,7 @@ class TestAddonModels(TestCase):
                    disallow_preliminary=True)
 
     def test_can_request_review_lite_and_nominated_no_prelim(self):
-        self.check(amo.STATUS_LITE_AND_NOMINATED, (amo.STATUS_PUBLIC,),
+        self.check(amo.STATUS_LITE_AND_NOMINATED, (),
                    disallow_preliminary=True)
 
     def test_none_homepage(self):

--- a/src/olympia/devhub/helpers.py
+++ b/src/olympia/devhub/helpers.py
@@ -134,7 +134,7 @@ def status_choices(addon):
                         amo.STATUS_PUBLIC):
         choices[amo.STATUS_UNREVIEWED] = (
             Addon.STATUS_CHOICES[amo.STATUS_NOMINATED])
-    else:
+    elif addon.status in (amo.STATUS_UNREVIEWED, amo.STATUS_LITE):
         choices[amo.STATUS_UNREVIEWED] = (
             Addon.STATUS_CHOICES[amo.STATUS_UNREVIEWED])
     return choices

--- a/src/olympia/devhub/tests/test_helpers.py
+++ b/src/olympia/devhub/tests/test_helpers.py
@@ -203,6 +203,11 @@ class TestDevFilesStatus(TestCase):
         self.file.status = amo.STATUS_PUBLIC
         self.expect(File.STATUS_CHOICES[amo.STATUS_PUBLIC])
 
+    def test_reviewed_null(self):
+        self.addon.status = amo.STATUS_NULL
+        self.file.status = amo.STATUS_UNREVIEWED
+        self.expect(File.STATUS_CHOICES[amo.STATUS_UNREVIEWED])
+
     def test_disabled(self):
         self.addon.status = amo.STATUS_PUBLIC
         self.file.status = amo.STATUS_DISABLED

--- a/src/olympia/devhub/tests/test_models.py
+++ b/src/olympia/devhub/tests/test_models.py
@@ -275,7 +275,7 @@ class TestVersion(TestCase):
 
         self.version.delete()
         assert self.addon.versions.count() == 1
-        assert Addon.objects.get(id=3615).status == amo.STATUS_UNREVIEWED
+        assert Addon.objects.get(id=3615).status == amo.STATUS_NULL
 
     def test_file_delete_status_null(self):
         assert self.addon.versions.count() == 1

--- a/src/olympia/devhub/tests/test_tasks.py
+++ b/src/olympia/devhub/tests/test_tasks.py
@@ -681,8 +681,10 @@ class TestSubmitFile(TestCase):
     @mock.patch('olympia.devhub.tasks.FileUpload.passed_all_validations', True)
     def test_file_passed_all_validations(self):
         upload = self.create_upload()
-        tasks.submit_file(self.addon.pk, upload.pk)
-        self.create_version_for_upload.assert_called_with(self.addon, upload)
+        tasks.submit_file(self.addon.pk, upload.pk,
+                          disallow_preliminary_review=False)
+        self.create_version_for_upload.assert_called_with(
+            self.addon, upload, disallow_preliminary_review=False)
 
     @mock.patch('olympia.devhub.tasks.FileUpload.passed_all_validations',
                 False)

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -177,7 +177,7 @@ class TestVersion(TestCase):
         res = self.client.post(self.delete_url, self.delete_data)
         assert res.status_code == 302
         assert self.addon.versions.count() == 1
-        assert Addon.objects.get(id=3615).status == amo.STATUS_UNREVIEWED
+        assert Addon.objects.get(id=3615).status == amo.STATUS_NULL
 
     @mock.patch('olympia.files.models.File.hide_disabled_file')
     def test_user_can_disable_addon(self, hide_mock):

--- a/src/olympia/editors/tests/test_review_scenarios.py
+++ b/src/olympia/editors/tests/test_review_scenarios.py
@@ -73,7 +73,7 @@ def addon_with_files(db):
         # scenario7: should succeed, files rejected.
         ('process_sandbox', amo.STATUS_LITE_AND_NOMINATED, amo.STATUS_LITE,
          helpers.ReviewAddon, 'nominated', amo.STATUS_NULL,
-         amo.STATUS_DISABLED),
+         amo.STATUS_LITE),
         # scenario8: Should succeed, files approved.
         ('process_preliminary', amo.STATUS_LITE_AND_NOMINATED, amo.STATUS_LITE,
          helpers.ReviewAddon, 'nominated', amo.STATUS_LITE, amo.STATUS_LITE),
@@ -84,7 +84,7 @@ def addon_with_files(db):
          helpers.ReviewFiles, 'pending', amo.STATUS_PUBLIC, amo.STATUS_PUBLIC),
         # scenario10: should succeed, files rejected.
         ('process_sandbox', amo.STATUS_PUBLIC, amo.STATUS_UNREVIEWED,
-         helpers.ReviewFiles, 'pending', amo.STATUS_UNREVIEWED,
+         helpers.ReviewFiles, 'pending', amo.STATUS_NOMINATED,
          amo.STATUS_DISABLED),
         # scenario11: should succeed, files approved.
         ('process_preliminary', amo.STATUS_PUBLIC, amo.STATUS_UNREVIEWED,
@@ -110,7 +110,8 @@ def test_review_scenario(mock_request, addon_with_files, review_action,
     addon = addon_with_files
     addon.update(status=addon_status)
     version = addon.versions.get()
-    version.files.filter(status=amo.STATUS_NULL).update(status=file_status)
+    version.files.filter(
+        status=amo.STATUS_UNREVIEWED).update(status=file_status)
     # Get the review helper.
     helper = helpers.ReviewHelper(mock_request, addon, version)
     assert isinstance(helper.handler, review_class)

--- a/src/olympia/signing/views.py
+++ b/src/olympia/signing/views.py
@@ -5,6 +5,7 @@ from django import forms
 from django.conf import settings
 from django.utils.translation import ugettext as _
 
+import waffle
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -155,8 +156,10 @@ class VersionView(APIView):
         else:
             created = False
 
+        no_prelim = waffle.flag_is_active(request, 'no-prelim-review')
         file_upload = handle_upload(
-            filedata=filedata, user=request.user, addon=addon, submit=True)
+            filedata=filedata, user=request.user, addon=addon, submit=True,
+            disallow_preliminary_review=no_prelim)
 
         return file_upload, created
 


### PR DESCRIPTION
fixes #3234 and should do the edge cases in #3085 too.
Changes unreviewed versions of incomplete add-ons from being labelled awaiting preliminary review;
Correctly makes unlisted add-ons be fully reviewed not preliminary