### PR TITLE
Use ENV instead of ARG for now in Dockerfile.deploy

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -6,8 +6,10 @@ ENV LC_ALL en_US.UTF-8
 # need to compile swig
 ENV SWIG_FEATURES="-D__x86_64__"
 
-ARG UWSGI_GID=756
-ARG OLYMPIA_UID=9500
+# Should change it to use ARG instead of ENV for UWSGI_GID and OLYMPIA_UID
+# once the jenkins server is upgraded to support docker >= v1.9.0
+ENV UWSGI_GID=756
+ENV OLYMPIA_UID=9500
 RUN groupadd -g ${UWSGI_GID} uwsgi
 RUN useradd -u ${OLYMPIA_UID} -s /sbin/nologin olympia
 RUN usermod -a -G uwsgi olympia


### PR DESCRIPTION
fyi @jasonthomas 

Current docker version on jenkins server is v1.8.0. ARG is not supported
until v1.9.0. Use ENV for now until docker daemon is upgraded on jenkins
server.