### PR TITLE
Add support for beta versions in the add-on APIs

### DIFF
--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -103,6 +103,7 @@ This endpoint allows you to fetch a specific add-on by id, slug or guid.
     :>json object compatibility: Object detailing the add-on :ref:`add-on application <addon-detail-application>` and version compatibility.
     :>json object compatibility[app_name].max: Maximum version of the corresponding app the add-on is compatible with.
     :>json object compatibility[app_name].min: Minimum version of the corresponding app the add-on is compatible with.
+    :>json object current_beta_version: Object holding the current beta :ref:`version <version-detail-object>` of the add-on, if it exists. For performance reasons the ``license`` and ``release_notes`` fields are omitted.
     :>json object current_version: Object holding the current :ref:`version <version-detail-object>` of the add-on. For performance reasons the ``license`` and ``release_notes`` fields are omitted.
     :>json string default_locale: The add-on default locale for translations.
     :>json string|object|null description: The add-on description (See :ref:`translated fields <api-overview-translations>`).
@@ -237,7 +238,7 @@ This endpoint allows you to list all versions belonging to a specific add-on.
    By default, the version list API will only return versions with valid statuses
    (excluding versions that have incomplete, disabled, deleted, rejected or
    flagged for further review files) - you can change that with the ``filter``
-   query parameter, which requires authentication and specific permissions
+   query parameter, which may require authentication and specific permissions
    depending on the value:
 
     ================  ========================================================
@@ -248,6 +249,7 @@ This endpoint allows you to list all versions belonging to a specific add-on.
                       a developer of the add-on.
     all_with_deleted  Show all versions attached to this add-on, including
                       deleted ones. Requires admin permissions.
+           beta_only  Show beta versions only.
     ================  ========================================================
 
 --------------

--- a/src/olympia/addons/indexers.py
+++ b/src/olympia/addons/indexers.py
@@ -20,12 +20,36 @@ class AddonIndexer(BaseSearchIndexer):
     @classmethod
     def get_mapping(cls):
         doc_name = cls.get_doctype_name()
-        appver = {
+        appver_mapping = {
             'properties': {
                 'max': {'type': 'long'},
                 'min': {'type': 'long'},
                 'max_human': {'type': 'string', 'index': 'no'},
                 'min_human': {'type': 'string', 'index': 'no'},
+            }
+        }
+        version_mapping = {
+            'type': 'object',
+            'properties': {
+                'compatible_apps': {'properties': {app.id: appver_mapping
+                                                   for app in amo.APP_USAGE}},
+                'id': {'type': 'long', 'index': 'no'},
+                'reviewed': {'type': 'date', 'index': 'no'},
+                'files': {
+                    'type': 'object',
+                    'properties': {
+                        'id': {'type': 'long', 'index': 'no'},
+                        'created': {'type': 'date', 'index': 'no'},
+                        'hash': {'type': 'string', 'index': 'no'},
+                        'filename': {
+                            'type': 'string', 'index': 'no'},
+                        'platform': {
+                            'type': 'byte', 'index': 'no'},
+                        'size': {'type': 'long', 'index': 'no'},
+                        'status': {'type': 'byte'},
+                    }
+                },
+                'version': {'type': 'string', 'index': 'no'},
             }
         }
         mapping = {
@@ -34,34 +58,17 @@ class AddonIndexer(BaseSearchIndexer):
                     'id': {'type': 'long'},
 
                     'app': {'type': 'byte'},
-                    'appversion': {'properties': {app.id: appver
+                    # FIXME: remove and update the code (search/views.py,
+                    # legacy_api/utils.py) to use the newest mapping that
+                    # replaces this field by current_version.compatible_apps.
+                    'appversion': {'properties': {app.id: appver_mapping
                                                   for app in amo.APP_USAGE}},
                     'average_daily_users': {'type': 'long'},
                     'bayesian_rating': {'type': 'double'},
+                    'current_beta_version': version_mapping,
                     'category': {'type': 'integer'},
                     'created': {'type': 'date'},
-                    'current_version': {
-                        'type': 'object',
-                        'properties': {
-                            'id': {'type': 'long', 'index': 'no'},
-                            'reviewed': {'type': 'date', 'index': 'no'},
-                            'files': {
-                                'type': 'object',
-                                'properties': {
-                                    'id': {'type': 'long', 'index': 'no'},
-                                    'created': {'type': 'date', 'index': 'no'},
-                                    'hash': {'type': 'string', 'index': 'no'},
-                                    'filename': {
-                                        'type': 'string', 'index': 'no'},
-                                    'platform': {
-                                        'type': 'byte', 'index': 'no'},
-                                    'size': {'type': 'long', 'index': 'no'},
-                                    'status': {'type': 'byte'},
-                                }
-                            },
-                            'version': {'type': 'string', 'index': 'no'},
-                        }
-                    },
+                    'current_version': version_mapping,
                     'boost': {'type': 'float', 'null_value': 1.0},
                     'default_locale': {'type': 'string', 'index': 'no'},
                     'description': {'type': 'string', 'analyzer': 'snowball'},
@@ -143,6 +150,41 @@ class AddonIndexer(BaseSearchIndexer):
         return mapping
 
     @classmethod
+    def extract_version(cls, obj, version_obj):
+        return {
+            'id': version_obj.pk,
+            'compatible_apps': cls.extract_compatibility_info(version_obj),
+            'files': [{
+                'id': file_.id,
+                'created': file_.created,
+                'filename': file_.filename,
+                'hash': file_.hash,
+                'platform': file_.platform,
+                'size': file_.size,
+                'status': file_.status,
+            } for file_ in version_obj.all_files],
+            'reviewed': version_obj.reviewed,
+            'version': version_obj.version,
+        }
+
+    @classmethod
+    def extract_compatibility_info(cls, version_obj):
+        compatible_apps = {}
+        for app, appver in version_obj.compatible_apps.items():
+            if appver:
+                min_, max_ = appver.min.version_int, appver.max.version_int
+                min_human, max_human = appver.min.version, appver.max.version
+            else:
+                # Fake wide compatibility for search tools and personas.
+                min_, max_ = 0, version_int('9999')
+                min_human, max_human = None, None
+            compatible_apps[app.id] = {
+                'min': min_, 'min_human': min_human,
+                'max': max_, 'max_human': max_human,
+            }
+        return compatible_apps
+
+    @classmethod
     def extract_document(cls, obj):
         """Extract indexable attributes from an add-on."""
         from olympia.addons.models import Preview
@@ -182,19 +224,6 @@ class AddonIndexer(BaseSearchIndexer):
             data['has_theme_rereview'] = None
 
         data['app'] = [app.id for app in obj.compatible_apps.keys()]
-        data['appversion'] = {}
-        for app, appver in obj.compatible_apps.items():
-            if appver:
-                min_, max_ = appver.min.version_int, appver.max.version_int
-                min_human, max_human = appver.min.version, appver.max.version
-            else:
-                # Fake wide compatibility for search tools and personas.
-                min_, max_ = 0, version_int('9999')
-                min_human, max_human = None, None
-            data['appversion'][app.id] = {
-                'min': min_, 'min_human': min_human,
-                'max': max_, 'max_human': max_human,
-            }
         # Quadruple the boost if the add-on is public.
         if (obj.status == amo.STATUS_PUBLIC and not obj.is_experimental and
                 'boost' in data):
@@ -203,25 +232,22 @@ class AddonIndexer(BaseSearchIndexer):
         # transformer that sets it.
         data['category'] = [cat.id for cat in obj.all_categories]
         if obj.current_version:
-            data['current_version'] = {
-                'id': obj.current_version.pk,
-                'files': [{
-                    'id': file_.id,
-                    'created': file_.created,
-                    'filename': file_.filename,
-                    'hash': file_.hash,
-                    'platform': file_.platform,
-                    'size': file_.size,
-                    'status': file_.status,
-                } for file_ in obj.current_version.all_files],
-                'reviewed': obj.current_version.reviewed,
-                'version': obj.current_version.version,
-            }
+            # FIXME: remove `appversion` once the newest mapping that has
+            # 'current_version.compatible_apps` is live.
+            data['appversion'] = cls.extract_compatibility_info(
+                obj.current_version)
+            data['current_version'] = cls.extract_version(
+                obj, obj.current_version)
             data['has_version'] = True
             data['platforms'] = [p.id for p in
                                  obj.current_version.supported_platforms]
         else:
             data['has_version'] = None
+        if obj.current_beta_version:
+            data['current_beta_version'] = cls.extract_version(
+                obj, obj.current_beta_version)
+        else:
+            data['current_beta_version'] = None
         data['listed_authors'] = [
             {'name': a.name, 'id': a.id, 'username': a.username}
             for a in obj.listed_authors

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1184,7 +1184,7 @@ class Addon(OnChangeMixin, ModelBase):
     def show_adu(self):
         return self.type != amo.ADDON_SEARCH
 
-    @amo.cached_property
+    @amo.cached_property(writable=True)
     def current_beta_version(self):
         """Retrieves the latest version of an addon, in the beta channel."""
         versions = self.versions.filter(files__status=amo.STATUS_BETA)[:1]

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -1944,6 +1944,10 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
         self._test_url_only_contains_old_version(filter='all')
         self._test_url_only_contains_old_version(filter='all_with_deleted')
 
+    def test_beta_version(self):
+        self.old_version.files.update(status=amo.STATUS_BETA)
+        self._test_url_only_contains_old_version(filter='beta_only')
+
 
 class TestAddonViewSetFeatureCompatibility(TestCase):
     def setUp(self):

--- a/src/olympia/search/filters.py
+++ b/src/olympia/search/filters.py
@@ -88,8 +88,10 @@ class AddonAppVersionFilterParam(AddonFilterParam):
     def get_es_filter(self):
         app_id, low, high = self.get_values()
         return [
-            F('range', **{'appversion.%d.min' % app_id: {'lte': low}}),
-            F('range', **{'appversion.%d.max' % app_id: {'gte': high}}),
+            F('range', **{'current_version.compatible_apps.%d.min' % app_id:
+              {'lte': low}}),
+            F('range', **{'current_version.compatible_apps.%d.max' % app_id:
+              {'gte': high}}),
         ]
 
 

--- a/src/olympia/search/tests/test_filters.py
+++ b/src/olympia/search/tests/test_filters.py
@@ -231,8 +231,10 @@ class TestSearchParameterFilter(FilterTestsBase):
                                 'app': 'firefox'})
         must = qs['query']['filtered']['filter']['bool']['must']
         assert {'term': {'app': amo.FIREFOX.id}} in must
-        assert {'range': {'appversion.1.min': {'lte': 46000000200100}}} in must
-        assert {'range': {'appversion.1.max': {'gte': 46000000000100}}} in must
+        assert {'range': {'current_version.compatible_apps.1.min':
+                {'lte': 46000000200100}}} in must
+        assert {'range': {'current_version.compatible_apps.1.max':
+                {'gte': 46000000000100}}} in must
 
     def test_search_by_platform_invalid(self):
         qs = self._filter(data={'platform': unicode(amo.PLATFORM_WIN.id + 42)})


### PR DESCRIPTION
- Expose `current_beta_version` in detail/search responses
- Allow filtering add-on versions list to show only betas

Had to refactor the way compatibility it stored in ES, it was stored at the top level but since it can be different for the `current_beta_version` so I had to change that. I kept the original property for backwards-compatibility and will open an issue to remove it next week.

Fix #3163