### PR TITLE
Always import amo when using shell_plus

### DIFF
--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1638,3 +1638,8 @@ REST_FRAMEWORK = {
 # This is the DSN to the local Sentry service. It might be overridden in
 # site-specific settings files as well.
 SENTRY_DSN = os.environ.get('SENTRY_DSN')
+
+# Automatically do 'from olympia import amo' when running shell_plus.
+SHELL_PLUS_POST_IMPORTS = (
+    ('olympia', 'amo'),
+)


### PR DESCRIPTION
We use that module everywhere, it has all our constants etc. I keep doing the import manually when opening a shell and I'm tired of doing that :)