### PR TITLE
Remove nose dependency

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -210,10 +210,6 @@ newrelic==2.66.0.49 \
 nobot==0.4.1 \
     --hash=sha256:e835abfe9b813fe5697475e8fc0dfbaf9c7572f4574e3d2d7e5114bc84f4cf0b \
     --hash=sha256:bae7bc785e81d4edcc7e7e66457697995c47475e0a2aba405b3a5cb82697e880
-# nose is required by amo-validator
-nose==1.3.7 \
-    --hash=sha256:dadcddc0aefbf99eea214e0f1232b94f2fa9bd98fa8353711dacb112bfcbbb2a \
-    --hash=sha256:f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98
 oauthlib==0.4.0 \
     --hash=sha256:9fa2f6ecc03529b12e9c9445e9a29ca72fecdebfe1f7f5ccc9242ba7a9c4e996
 ordereddict==1.1 \


### PR DESCRIPTION
since it's no longer used by amo-validator