### PR TITLE
Hide sideloading checkbox when prelim-review is disabled

### DIFF
--- a/src/olympia/devhub/templates/devhub/addons/submit/upload.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/upload.html
@@ -28,12 +28,14 @@
         <span class="tip tooltip"
               title="{{ new_addon_form.is_unlisted.help_text }}">?</span>
       </label>
+      {% if not waffle.flag('no-prelim-review') %}
       <label for="{{ new_addon_form.is_sideload.auto_id }}">
         {{ new_addon_form.is_sideload }}
         {{ new_addon_form.is_sideload.label }}
         <span class="tip tooltip"
               title="{{ new_addon_form.is_sideload.help_text }}">?</span>
       </label>
+      {% endif %}
     </div>
   </div>
   <input type="file" id="upload-addon"


### PR DESCRIPTION
it's ignored anyway, so it's confusing. Fixes #3305