### PR TITLE
wip, do not merge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ ifeq ($(IN_DOCKER),)
 endif
 	# reindex --wipe will force the ES mapping to be re-installed. Useful to
 	# make sure the mapping is correct before adding a bunch of add-ons.
-	python manage.py reindex --wipe --force --noinput
+	python manage.py reindex --wipe --force --noinput --with-stats
 	python manage.py generate_addons --app firefox $(NUM_ADDONS)
 	python manage.py generate_addons --app thunderbird $(NUM_ADDONS)
 	python manage.py generate_addons --app android $(NUM_ADDONS)

--- a/src/olympia/landfill/generators.py
+++ b/src/olympia/landfill/generators.py
@@ -18,6 +18,7 @@ from .images import generate_addon_preview, generate_theme_images
 from .names import generate_names
 from .translations import generate_translations
 from .ratings import generate_ratings
+from .stats import generate_stats
 from .user import generate_addon_user_and_category, generate_user
 from .version import generate_version
 
@@ -87,6 +88,7 @@ def generate_addons(num, owner, app_name):
             generate_collection(addon, app)
             featured_categories[category] += 1
         generate_ratings(addon, 5)
+        generate_addon_stats(addon, 10)
 
 
 def create_theme(name, **extra_kwargs):

--- a/src/olympia/landfill/stats.py
+++ b/src/olympia/landfill/stats.py
@@ -1,0 +1,37 @@
+import datetime
+import random
+
+from olympia.stats.models import DownloadCount, UpdateCount
+from olympia.stats.tasks import index_download_counts
+
+
+def generate_addon_stats(addon, days_back):
+    today = datetime.datetime.today()
+    versions = addon.versions.values_list('version', flat=True)
+
+    download_ids = []
+    update_ids = []
+    for day in range(0, days_back):
+        date = (today - datetime.timedelta(days=day)).date()
+        download = DownloadCount(
+            addon=addon,
+            count=random.randint(50, 100),
+            date=date,
+            sources='populate-stats-day-{}'.format(day)
+        )
+        # TODO: add in versions, statuses, applications and oses?
+        update = UpdateCount(
+            addon=addon,
+            count=random.randint(50, 100),
+            date=date,
+            locales=random.choice(['en-US', 'fr', 'de'])
+        )
+        download_ids.append(download.id)
+        update_ids.append(update.id)
+
+    index_download_counts(download_ids)
+
+def test():
+    from olympia.addons.models import Addon
+    addon = Addon.objects.get(slug='tibia-online-status')
+    generate_addon_stats(addon, 10)


### PR DESCRIPTION
* currently getting tripped up by:

```
23:35:05 z.es:ERROR Elasticsearch error: TransportError(404, u'IndexMissingException[[addons_stats] missing]') :/code/src/olympia/search/middleware.py:15
```


* although:

```
[root@7834839246cb code]# curl elasticsearch:9200/_cat/indices?v
health status index                       pri rep docs.count docs.deleted store.size pri.store.size 
green  open   addons-20160823233704         5   0        110            0    177.6kb        177.6kb 
green  open   addons-20160823233633         5   0        110            0    177.6kb        177.6kb 
green  open   addons_stats-20160823233633   5   0          0            0       720b           720b 
green  open   addons-20160823231400         5   0        110            0    190.4kb        190.4kb 
green  open   addons_stats-20160823231400   5   0          0            0       720b           720b 
````

* might just fix #3329