### PR TITLE
Bump uwsgi version to 2.0.13

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -32,7 +32,7 @@ RUN yum update -y                                           \
         openssl-devel                                       \
         python-devel                                        \
         swig                                                \
-        uwsgi-2.0.12-2.el7                                  \
+        uwsgi-2.0.13.1-2.el7                                \
         uwsgi-plugin-python                                 \
     && yum clean all                                        \
     && curl -sSL https://bootstrap.pypa.io/get-pip.py | python


### PR DESCRIPTION
EPEL replaced version 2.0.12 with 2.0.13, which broke the yum install
command.

@jasonthomas r?