### PR TITLE
Redirect directly to FxA when login is required

### DIFF
--- a/src/olympia/access/tests.py
+++ b/src/olympia/access/tests.py
@@ -4,6 +4,7 @@ import pytest
 from olympia import amo
 from olympia.amo.tests import TestCase, req_factory_factory
 from olympia.amo.urlresolvers import reverse
+from olympia.amo.utils import urlparams
 from olympia.addons.models import Addon, AddonUser
 from olympia.users.models import UserProfile
 
@@ -72,7 +73,7 @@ class ACLTestCase(TestCase):
         # Login form for anonymous user on the admin page.
         url = '/en-US/admin/'
         r = self.client.get(url, follow=True)
-        self.assert3xx(r, '%s?to=%s' % (reverse('users.login'), url))
+        self.assert3xx(r, urlparams(reverse('users.login'), to=url))
 
 
 class TestHasPerm(TestCase):

--- a/src/olympia/accounts/helpers.py
+++ b/src/olympia/accounts/helpers.py
@@ -4,6 +4,7 @@ from urllib import urlencode
 
 from django.conf import settings
 from django.core import urlresolvers
+from django.http import HttpResponseRedirect
 from django.utils.http import is_safe_url
 
 import jinja2
@@ -11,7 +12,6 @@ import waffle
 from jingo import register
 
 from olympia.amo.utils import urlparams
-
 
 @register.function
 @jinja2.contextfunction
@@ -90,3 +90,7 @@ def generate_fxa_state():
 def camel_case(snake):
     parts = snake.split('_')
     return parts[0] + ''.join(part.capitalize() for part in parts[1:])
+
+
+def redirect_for_login(request):
+    return HttpResponseRedirect(default_fxa_login_url(request))

--- a/src/olympia/accounts/helpers.py
+++ b/src/olympia/accounts/helpers.py
@@ -9,6 +9,7 @@ from olympia.accounts import utils
 def login_link(context):
     return utils.login_link(context['request'])
 
+
 @register.function
 @jinja2.contextfunction
 def register_link(context):

--- a/src/olympia/accounts/helpers.py
+++ b/src/olympia/accounts/helpers.py
@@ -1,96 +1,21 @@
-import os
-from base64 import urlsafe_b64encode
-from urllib import urlencode
-
-from django.conf import settings
-from django.core import urlresolvers
-from django.http import HttpResponseRedirect
-from django.utils.http import is_safe_url
-
 import jinja2
-import waffle
 from jingo import register
 
-from olympia.amo.utils import urlparams
+from olympia.accounts import utils
+
 
 @register.function
 @jinja2.contextfunction
 def login_link(context):
-    if waffle.switch_is_active('fxa-migrated'):
-        return default_fxa_login_url(context['request'])
-    else:
-        return link_with_final_destination(
-            context, urlresolvers.reverse('users.login'))
-
+    return utils.login_link(context['request'])
 
 @register.function
 @jinja2.contextfunction
 def register_link(context):
-    if waffle.switch_is_active('fxa-migrated'):
-        return default_fxa_login_url(context['request'])
-    else:
-        return link_with_final_destination(
-            context, urlresolvers.reverse('users.register'))
+    return utils.register_link(context['request'])
 
 
 @register.function
 @jinja2.contextfunction
 def fxa_config(context):
-    request = context['request']
-    config = {camel_case(key): value
-              for key, value in settings.FXA_CONFIG['default'].iteritems()
-              if key != 'client_secret'}
-    if request.user.is_authenticated():
-        config['email'] = request.user.email
-    request.session.setdefault('fxa_state', generate_fxa_state())
-    config['state'] = request.session['fxa_state']
-    return config
-
-
-def link_with_final_destination(context, base):
-    return urlparams(base, to=path_with_query(context['request']))
-
-
-def path_with_query(request):
-    next_path = request.path
-    qs = request.GET.urlencode()
-    if qs:
-        return u'{next_path}?{qs}'.format(next_path=next_path, qs=qs)
-    else:
-        return next_path
-
-
-def fxa_login_url(config, state, next_path=None, action=None):
-    if next_path and is_safe_url(next_path):
-        state += ':' + urlsafe_b64encode(next_path.encode('utf-8')).rstrip('=')
-    query = {
-        'client_id': config['client_id'],
-        'redirect_url': config['redirect_url'],
-        'scope': config['scope'],
-        'state': state,
-    }
-    if action is not None:
-        query['action'] = action
-    return '{host}/authorization?{query}'.format(
-        host=config['oauth_host'], query=urlencode(query))
-
-
-def default_fxa_login_url(request):
-    request.session.setdefault('fxa_state', generate_fxa_state())
-    return fxa_login_url(
-        config=settings.FXA_CONFIG['default'],
-        state=request.session['fxa_state'],
-        next_path=path_with_query(request))
-
-
-def generate_fxa_state():
-    return os.urandom(32).encode('hex')
-
-
-def camel_case(snake):
-    parts = snake.split('_')
-    return parts[0] + ''.join(part.capitalize() for part in parts[1:])
-
-
-def redirect_for_login(request):
-    return HttpResponseRedirect(default_fxa_login_url(request))
+    return utils.fxa_config(context['request'])

--- a/src/olympia/accounts/tests/test_helpers.py
+++ b/src/olympia/accounts/tests/test_helpers.py
@@ -120,3 +120,13 @@ def test_unicode_next_path():
     state = urlparse.parse_qs(urlparse.urlparse(url).query)['state'][0]
     next_path = urlsafe_b64decode(state.split(':')[1] + '===')
     assert next_path.decode('utf-8') == path
+
+
+@mock.patch('olympia.accounts.helpers.default_fxa_login_url')
+def test_redirect_for_login(default_fxa_login_url):
+    fxa_url = 'https://accounts.firefox.com/login'
+    default_fxa_login_url.return_value = fxa_url
+    request = mock.MagicMock()
+    response = helpers.redirect_for_login(request)
+    default_fxa_login_url.assert_called_with(request)
+    assert response['location'] == fxa_url

--- a/src/olympia/accounts/tests/test_utils.py
+++ b/src/olympia/accounts/tests/test_utils.py
@@ -2,13 +2,16 @@
 import urlparse
 from base64 import urlsafe_b64decode, urlsafe_b64encode
 
-from django.core.urlresolvers import reverse
+from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
 from django.test.utils import override_settings
 
 import mock
 
 from olympia.accounts import utils
+from olympia.amo.tests import create_switch
+from olympia.amo.urlresolvers import reverse
+from olympia.users.models import UserProfile
 
 FXA_CONFIG = {
     'default': {
@@ -23,10 +26,10 @@ FXA_CONFIG = {
 
 @override_settings(FXA_CONFIG=FXA_CONFIG)
 def test_fxa_config_anonymous():
-    context = mock.MagicMock()
-    context['request'].session = {'fxa_state': 'thestate!'}
-    context['request'].user.is_authenticated.return_value = False
-    assert utils.fxa_config(context) == {
+    request = RequestFactory().get('/en-US/firefox/addons')
+    request.session = {'fxa_state': 'thestate!'}
+    request.user = AnonymousUser()
+    assert utils.fxa_config(request) == {
         'clientId': 'foo',
         'state': 'thestate!',
         'oauthHost': 'https://accounts.firefox.com/oauth',
@@ -37,11 +40,10 @@ def test_fxa_config_anonymous():
 
 @override_settings(FXA_CONFIG=FXA_CONFIG)
 def test_fxa_config_logged_in():
-    context = mock.MagicMock()
-    context['request'].session = {'fxa_state': 'thestate!'}
-    context['request'].user.is_authenticated.return_value = True
-    context['request'].user.email = 'me@mozilla.org'
-    assert utils.fxa_config(context) == {
+    request = RequestFactory().get('/en-US/firefox/addons')
+    request.session = {'fxa_state': 'thestate!'}
+    request.user = UserProfile(email='me@mozilla.org')
+    assert utils.fxa_config(request) == {
         'clientId': 'foo',
         'state': 'thestate!',
         'email': 'me@mozilla.org',
@@ -77,7 +79,8 @@ def test_default_fxa_login_url_with_state():
 @mock.patch('olympia.accounts.utils.waffle.switch_is_active')
 def test_login_link_migrated(switch_is_active):
     switch_is_active.return_value = True
-    assert utils.login_link({'request': mock.MagicMock()}) == (
+    request = RequestFactory().get('/en-US/firefox/addons')
+    assert utils.login_link(request) == (
         'http://auth.ca')
     switch_is_active.assert_called_with('fxa-migrated')
 
@@ -86,7 +89,7 @@ def test_login_link_migrated(switch_is_active):
 def test_login_link_not_migrated(switch_is_active):
     request = RequestFactory().get('/en-US/foo')
     switch_is_active.return_value = False
-    assert utils.login_link({'request': request}) == (
+    assert utils.login_link(request) == (
         '{}?to=%2Fen-US%2Ffoo'.format(reverse('users.login')))
     switch_is_active.assert_called_with('fxa-migrated')
 
@@ -96,8 +99,9 @@ def test_login_link_not_migrated(switch_is_active):
     lambda c: 'http://auth.ca')
 @mock.patch('olympia.accounts.utils.waffle.switch_is_active')
 def test_register_link_migrated(switch_is_active):
+    request = RequestFactory().get('/en-US/firefox/addons')
     switch_is_active.return_value = True
-    assert utils.register_link({'request': mock.MagicMock()}) == (
+    assert utils.register_link(request) == (
         'http://auth.ca')
     switch_is_active.assert_called_with('fxa-migrated')
 
@@ -106,7 +110,7 @@ def test_register_link_migrated(switch_is_active):
 def test_register_link_not_migrated(switch_is_active):
     request = RequestFactory().get('/en-US/foo')
     switch_is_active.return_value = False
-    assert utils.register_link({'request': request}) == (
+    assert utils.register_link(request) == (
         '{}?to=%2Fen-US%2Ffoo'.format(reverse('users.register')))
     switch_is_active.assert_called_with('fxa-migrated')
 
@@ -116,17 +120,17 @@ def test_unicode_next_path():
     path = u'/en-US/føø/bãr'
     request = RequestFactory().get(path)
     request.session = {}
-    url = utils.login_link({'request': request})
+    url = utils.login_link(request)
     state = urlparse.parse_qs(urlparse.urlparse(url).query)['state'][0]
     next_path = urlsafe_b64decode(state.split(':')[1] + '===')
     assert next_path.decode('utf-8') == path
 
 
-@mock.patch('olympia.accounts.utils.default_fxa_login_url')
-def test_redirect_for_login(default_fxa_login_url):
-    fxa_url = 'https://accounts.firefox.com/login'
-    default_fxa_login_url.return_value = fxa_url
+@mock.patch('olympia.accounts.utils.login_link')
+def test_redirect_for_login_migration_over(login_link):
+    login_url = 'https://example.com/login'
+    login_link.return_value = login_url
     request = mock.MagicMock()
     response = utils.redirect_for_login(request)
-    default_fxa_login_url.assert_called_with(request)
-    assert response['location'] == fxa_url
+    login_link.assert_called_with(request)
+    assert response['location'] == login_url

--- a/src/olympia/accounts/tests/test_utils.py
+++ b/src/olympia/accounts/tests/test_utils.py
@@ -9,7 +9,6 @@ from django.test.utils import override_settings
 import mock
 
 from olympia.accounts import utils
-from olympia.amo.tests import create_switch
 from olympia.amo.urlresolvers import reverse
 from olympia.users.models import UserProfile
 

--- a/src/olympia/accounts/utils.py
+++ b/src/olympia/accounts/utils.py
@@ -1,0 +1,88 @@
+import os
+from base64 import urlsafe_b64encode
+from urllib import urlencode
+
+from django.conf import settings
+from django.core import urlresolvers
+from django.http import HttpResponseRedirect
+from django.utils.http import is_safe_url
+
+import waffle
+
+from olympia.amo.utils import urlparams
+
+
+def login_link(request):
+    if waffle.switch_is_active('fxa-migrated'):
+        return default_fxa_login_url(request)
+    else:
+        return link_with_final_destination(
+            request, urlresolvers.reverse('users.login'))
+
+
+def register_link(request):
+    if waffle.switch_is_active('fxa-migrated'):
+        return default_fxa_login_url(request)
+    else:
+        return link_with_final_destination(
+            request, urlresolvers.reverse('users.register'))
+
+
+def fxa_config(request):
+    config = {camel_case(key): value
+              for key, value in settings.FXA_CONFIG['default'].iteritems()
+              if key != 'client_secret'}
+    if request.user.is_authenticated():
+        config['email'] = request.user.email
+    request.session.setdefault('fxa_state', generate_fxa_state())
+    config['state'] = request.session['fxa_state']
+    return config
+
+
+def fxa_login_url(config, state, next_path=None, action=None):
+    if next_path and is_safe_url(next_path):
+        state += ':' + urlsafe_b64encode(next_path.encode('utf-8')).rstrip('=')
+    query = {
+        'client_id': config['client_id'],
+        'redirect_url': config['redirect_url'],
+        'scope': config['scope'],
+        'state': state,
+    }
+    if action is not None:
+        query['action'] = action
+    return '{host}/authorization?{query}'.format(
+        host=config['oauth_host'], query=urlencode(query))
+
+
+def default_fxa_login_url(request):
+    request.session.setdefault('fxa_state', generate_fxa_state())
+    return fxa_login_url(
+        config=settings.FXA_CONFIG['default'],
+        state=request.session['fxa_state'],
+        next_path=path_with_query(request))
+
+
+def generate_fxa_state():
+    return os.urandom(32).encode('hex')
+
+
+def redirect_for_login(request):
+    return HttpResponseRedirect(default_fxa_login_url(request))
+
+
+def path_with_query(request):
+    next_path = request.path
+    qs = request.GET.urlencode()
+    if qs:
+        return u'{next_path}?{qs}'.format(next_path=next_path, qs=qs)
+    else:
+        return next_path
+
+
+def link_with_final_destination(request, base):
+    return urlparams(base, to=path_with_query(request))
+
+
+def camel_case(snake):
+    parts = snake.split('_')
+    return parts[0] + ''.join(part.capitalize() for part in parts[1:])

--- a/src/olympia/accounts/utils.py
+++ b/src/olympia/accounts/utils.py
@@ -3,7 +3,7 @@ from base64 import urlsafe_b64encode
 from urllib import urlencode
 
 from django.conf import settings
-from django.core import urlresolvers
+from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.utils.http import is_safe_url
 
@@ -16,16 +16,14 @@ def login_link(request):
     if waffle.switch_is_active('fxa-migrated'):
         return default_fxa_login_url(request)
     else:
-        return link_with_final_destination(
-            request, urlresolvers.reverse('users.login'))
+        return link_with_final_destination(request, reverse('users.login'))
 
 
 def register_link(request):
     if waffle.switch_is_active('fxa-migrated'):
         return default_fxa_login_url(request)
     else:
-        return link_with_final_destination(
-            request, urlresolvers.reverse('users.register'))
+        return link_with_final_destination(request, reverse('users.register'))
 
 
 def fxa_config(request):
@@ -67,7 +65,7 @@ def generate_fxa_state():
 
 
 def redirect_for_login(request):
-    return HttpResponseRedirect(default_fxa_login_url(request))
+    return HttpResponseRedirect(login_link(request))
 
 
 def path_with_query(request):

--- a/src/olympia/amo/decorators.py
+++ b/src/olympia/amo/decorators.py
@@ -14,7 +14,7 @@ from olympia.users.utils import get_task_user
 
 from . import models as context
 from .utils import JSONEncoder
-from olympia.accounts.helpers import redirect_for_login
+from olympia.accounts.utils import redirect_for_login
 
 
 task_log = commonware.log.getLogger('z.task')

--- a/src/olympia/amo/decorators.py
+++ b/src/olympia/amo/decorators.py
@@ -13,7 +13,8 @@ from olympia.amo import get_user, set_user
 from olympia.users.utils import get_task_user
 
 from . import models as context
-from .utils import JSONEncoder, redirect_for_login
+from .utils import JSONEncoder
+from olympia.accounts.helpers import redirect_for_login
 
 
 task_log = commonware.log.getLogger('z.task')

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -35,6 +35,7 @@ from olympia.access.acl import check_ownership
 from olympia.search import indexers as search_indexers
 from olympia.stats import search as stats_search
 from olympia.amo import search as amo_search
+from olympia.amo.utils import urlparams
 from olympia.access.models import Group, GroupUser
 from olympia.addons.models import (
     Addon, Persona, update_search_index as addon_update_search_index)
@@ -397,7 +398,7 @@ class TestCase(InitializeSessionMixin, MockEsMixin, BaseTestCase):
         # Not using urlparams, because that escapes the variables, which
         # is good, but bad for assert3xx which will fail.
         self.assert3xx(
-            response, '%s?to=%s' % (reverse('users.login'), to), status_code)
+            response, urlparams(reverse('users.login'), to=to), status_code)
 
     def assert3xx(self, response, expected_url, status_code=302,
                   target_status_code=200):

--- a/src/olympia/amo/tests/test_decorators.py
+++ b/src/olympia/amo/tests/test_decorators.py
@@ -10,6 +10,7 @@ import pytest
 from olympia.amo.tests import BaseTestCase, TestCase
 from olympia.amo import decorators, get_user, set_user
 from olympia.amo.urlresolvers import reverse
+from olympia.amo.utils import urlparams
 from olympia.users.models import UserProfile
 
 
@@ -107,7 +108,7 @@ class TestLoginRequired(BaseTestCase):
         assert not self.f.called
         assert response.status_code == 302
         assert response['Location'] == (
-            '%s?to=%s' % (reverse('users.login'), 'path'))
+            urlparams(reverse('users.login'), to='path'))
 
     def test_no_redirect(self):
         func = decorators.login_required(self.f, redirect=False)

--- a/src/olympia/amo/tests/test_views.py
+++ b/src/olympia/amo/tests/test_views.py
@@ -238,7 +238,7 @@ class TestOtherStuff(TestCase):
         title_eq('/mobile/extensions/', 'Mobile', 'Mobile Add-ons')
         title_eq('/android/', 'Firefox for Android', 'Android Add-ons')
 
-    @patch('olympia.accounts.helpers.default_fxa_login_url',
+    @patch('olympia.accounts.utils.default_fxa_login_url',
            lambda request: 'https://login.com')
     def test_login_link_migration_over(self):
         self.create_switch('fxa-migrated', active=True)

--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -31,7 +31,7 @@ from django.template import Context, loader
 from django.utils import translation
 from django.utils.encoding import smart_str, smart_unicode
 from django.utils.functional import Promise
-from django.utils.http import urlquote, urlunquote
+from django.utils.http import urlunquote
 
 import bleach
 import html5lib

--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -627,14 +627,6 @@ class HttpResponseSendFile(http.HttpResponse):
             return wrapper()
 
 
-def redirect_for_login(request):
-    # We can't use urlparams here, because it escapes slashes,
-    # which a large number of tests don't expect
-    url = '%s?to=%s' % (reverse('users.login'),
-                        urlquote(request.get_full_path()))
-    return http.HttpResponseRedirect(url)
-
-
 def cache_ns_key(namespace, increment=False):
     """
     Returns a key with namespace value appended. If increment is True, the

--- a/src/olympia/bandwagon/views.py
+++ b/src/olympia/bandwagon/views.py
@@ -22,8 +22,9 @@ from olympia.amo.decorators import (
     allow_mine, json_view, login_required, post_required, restricted_content,
     write)
 from olympia.amo.urlresolvers import reverse
-from olympia.amo.utils import paginate, redirect_for_login, urlparams
+from olympia.amo.utils import paginate, urlparams
 from olympia.access import acl
+from olympia.accounts.helpers import redirect_for_login
 from olympia.addons.models import Addon
 from olympia.addons.views import BaseFilter
 from olympia.legacy_api.utils import addon_to_dict

--- a/src/olympia/bandwagon/views.py
+++ b/src/olympia/bandwagon/views.py
@@ -24,7 +24,7 @@ from olympia.amo.decorators import (
 from olympia.amo.urlresolvers import reverse
 from olympia.amo.utils import paginate, urlparams
 from olympia.access import acl
-from olympia.accounts.helpers import redirect_for_login
+from olympia.accounts.utils import redirect_for_login
 from olympia.addons.models import Addon
 from olympia.addons.views import BaseFilter
 from olympia.legacy_api.utils import addon_to_dict

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -29,6 +29,7 @@ from olympia.amo.helpers import absolutify, user_media_path, url as url_reverse
 from olympia.amo.tests import addon_factory, formset, initial
 from olympia.amo.tests.test_helpers import get_image_path
 from olympia.amo.urlresolvers import reverse
+from olympia.amo.utils import urlparams
 from olympia.api.models import APIKey, SYMMETRIC_JWT_TYPE
 from olympia.applications.models import AppVersion
 from olympia.devhub.forms import ContribForm
@@ -383,7 +384,7 @@ class TestDevRequired(TestCase):
         self.client.logout()
         r = self.client.get(self.get_url, follow=True)
         login = reverse('users.login')
-        self.assert3xx(r, '%s?to=%s' % (login, self.get_url))
+        self.assert3xx(r, urlparams(login, to=self.get_url))
 
     def test_dev_get(self):
         assert self.client.get(self.get_url).status_code == 200

--- a/src/olympia/editors/tests/test_views.py
+++ b/src/olympia/editors/tests/test_views.py
@@ -23,6 +23,7 @@ from olympia.access.models import Group, GroupUser
 from olympia.addons.models import Addon, AddonDependency, AddonUser
 from olympia.amo.tests import check_links, formset, initial
 from olympia.amo.urlresolvers import reverse
+from olympia.amo.utils import urlparams
 from olympia.constants.base import REVIEW_LIMITED_DELAY_HOURS
 from olympia.devhub.models import ActivityLog
 from olympia.editors.models import EditorSubscription, ReviewerScore
@@ -1948,7 +1949,7 @@ class TestReview(ReviewBase):
         self.client.logout()
         r = self.client.head(self.url)
         self.assert3xx(
-            r, '%s?to=%s' % (reverse('users.login'), self.url))
+            r, urlparams(reverse('users.login'), to=self.url))
 
     @patch.object(settings, 'ALLOW_SELF_REVIEWS', False)
     def test_not_author(self):
@@ -2892,7 +2893,7 @@ class TestEditorMOTD(EditorTest):
     def test_require_editor_to_view(self):
         url = self.get_url()
         r = self.client.head(url)
-        self.assert3xx(r, '%s?to=%s' % (reverse('users.login'), url))
+        self.assert3xx(r, urlparams(reverse('users.login'), to=url))
 
     def test_require_admin_to_change_motd(self):
         self.login_as_editor()

--- a/src/olympia/internal_tools/views.py
+++ b/src/olympia/internal_tools/views.py
@@ -6,7 +6,7 @@ from django.http import HttpResponseRedirect
 from rest_framework.views import APIView, Response
 
 
-from olympia.accounts.helpers import generate_fxa_state, fxa_login_url
+from olympia.accounts.utils import generate_fxa_state, fxa_login_url
 from olympia.accounts.views import (
     add_api_token_to_response, update_user, with_user, ERROR_NO_USER)
 from olympia.addons.views import AddonSearchView

--- a/src/olympia/zadmin/tests/test_views.py
+++ b/src/olympia/zadmin/tests/test_views.py
@@ -1622,7 +1622,7 @@ class TestElastic(amo.tests.ESTestCase):
         self.client.logout()
         self.assert3xx(
             self.client.get(self.url),
-            reverse('users.login') + '?to=/en-US/admin/elastic')
+            urlparams(reverse('users.login'), to='/en-US/admin/elastic'))
 
 
 class TestEmailDevs(TestCase):
@@ -1827,4 +1827,4 @@ class TestPerms(TestCase):
         # Anonymous users should also get a 403.
         self.client.logout()
         self.assert3xx(self.client.get(reverse('zadmin.index')),
-                       reverse('users.login') + '?to=/en-US/admin/')
+                       urlparams(reverse('users.login'), to='/en-US/admin/'))


### PR DESCRIPTION
The login required views will now redirect directly to FxA. Still not /users/login though. If you navigate there directly you'll see the "Use FxA to log in" page.

Fixes #3205.