### PR TITLE
Login with ~> Log in with

### DIFF
--- a/src/olympia/users/templates/users/login.html
+++ b/src/olympia/users/templates/users/login.html
@@ -9,7 +9,7 @@
 <div class="primary">
   {% if switch_is_active('fxa-migrated') %}
     <section class="island hero primary grid prettyform fxa-login-prompt">
-      <h1>{{ _('Login with Firefox Accounts') }}</h1>
+      <h1>{{ _('Log in with Firefox Accounts') }}</h1>
       {% include 'users/fxa_login_prompt_content.html' %}
     </section>
   {% else %}

--- a/src/olympia/users/templates/users/mobile/login.html
+++ b/src/olympia/users/templates/users/mobile/login.html
@@ -8,7 +8,7 @@
 
 {% if switch_is_active('fxa-migrated') %}
   <div class="primary fxa-login-prompt" role="main">
-    <h2>{{ _('Login with Firefox Accounts') }}</h2>
+    <h2>{{ _('Log in with Firefox Accounts') }}</h2>
     {% include 'users/fxa_login_prompt_content.html' %}
   </div>
 {% else %}


### PR DESCRIPTION
Apparently this is how words work [1].

Fixes #3193.

[1] http://grammarist.com/spelling/log-in-login/