### PR TITLE
Replace Review.objects.valid with Review.without_deleted, removing a useless JOIN

### DIFF
--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -146,7 +146,8 @@ def extension_detail(request, addon):
         'tags': addon.tags.not_blacklisted(),
         'grouped_ratings': GroupedRating.get(addon.id),
         'review_form': ReviewForm(),
-        'reviews': Review.objects.valid().filter(addon=addon, is_latest=True),
+        'reviews': Review.without_replies.all().filter(
+            addon=addon, is_latest=True),
         'get_replies': Review.get_replies,
         'collections': collections.order_by('-subscribers')[:3],
         'abuse_form': AbuseForm(request=request),
@@ -219,8 +220,8 @@ def persona_detail(request, addon, template=None):
             'dev_tags': dev_tags,
             'user_tags': user_tags,
             'review_form': ReviewForm(),
-            'reviews': Review.objects.valid().filter(addon=addon,
-                                                     is_latest=True),
+            'reviews': Review.without_replies.all().filter(
+                addon=addon, is_latest=True),
             'get_replies': Review.get_replies,
             'search_cat': 'themes',
             'abuse_form': AbuseForm(request=request),

--- a/src/olympia/legacy_discovery/views.py
+++ b/src/olympia/legacy_discovery/views.py
@@ -177,7 +177,7 @@ def _sync_db_and_registry(qs, app_id):
 @addon_view
 @non_atomic_requests
 def addon_detail(request, addon):
-    reviews = Review.objects.valid().filter(addon=addon, is_latest=True)
+    reviews = Review.without_replies.all().filter(addon=addon, is_latest=True)
     src = request.GET.get('src', 'discovery-details')
     return render(request, 'legacy_discovery/addons/detail.html',
                   {'addon': addon, 'reviews': reviews,

--- a/src/olympia/reviews/feeds.py
+++ b/src/olympia/reviews/feeds.py
@@ -32,7 +32,8 @@ class ReviewsRss(NonAtomicFeed):
 
     def items(self, addon):
         """Return the Reviews for this Addon to be output as RSS <item>'s"""
-        qs = (Review.objects.valid().filter(addon=addon).order_by('-created'))
+        qs = (Review.without_replies.all().filter(
+            addon=addon).order_by('-created'))
         return qs.all()[:30]
 
     def item_link(self, review):

--- a/src/olympia/reviews/tasks.py
+++ b/src/olympia/reviews/tasks.py
@@ -22,7 +22,7 @@ def update_denorm(*pairs, **kw):
              (len(pairs), update_denorm.rate_limit))
     using = kw.get('using')
     for addon, user in pairs:
-        reviews = list(Review.objects.valid().no_cache().using(using)
+        reviews = list(Review.without_replies.all().no_cache().using(using)
                        .filter(addon=addon, user=user).order_by('created'))
         if not reviews:
             continue
@@ -47,7 +47,7 @@ def addon_review_aggregates(addons, **kw):
     # The following returns something like
     # [{'rating': 2.0, 'addon': 7L, 'count': 5},
     #  {'rating': 3.75, 'addon': 6L, 'count': 8}, ...]
-    qs = (Review.objects.valid().no_cache().using(using)
+    qs = (Review.without_replies.all().no_cache().using(using)
           .values('addon')  # Group by addon id.
           .annotate(rating=Avg('rating'), count=Count('addon')))  # Aggregates.
     stats = dict((x['addon'], (x['rating'], x['count'])) for x in qs)


### PR DESCRIPTION
The default `objects` manager does an extra JOIN on `reply_to`, to hide replies to deleted reviews, but when we have already decided to not care about replies, this join is useless. The `.valid()` method, on top of having a weird name, could not easily change this behavior because it's too late (the manager has already applied the filtering, so the method can't remove the useless join), so this commit renames to `without_replies` and moves it to a manager instead.