### PR TITLE
Remove now useless logging about category name fallback

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1865,9 +1865,6 @@ class Category(OnChangeMixin, ModelBase):
         except KeyError:
             # If we can't find the category in the constants dict, fall back
             # to the db field.
-            log.info(
-                u'Could not find category %s (%s) in constants, using name'
-                ' stored in db: "%s"', str(self.pk), self.slug, self.db_name)
             value = self.db_name
         return unicode(value)
 


### PR DESCRIPTION
The only categories for which we still see this logging are categories corresponding to deprecated applications that we should consider removing from the db, see https://github.com/mozilla/addons-server/issues/3360