### PR TITLE
Add migration to make all langpacks restartless.

### DIFF
--- a/src/olympia/migrations/894-make-langpacks-restartless.sql
+++ b/src/olympia/migrations/894-make-langpacks-restartless.sql
@@ -1,0 +1,1 @@
+UPDATE `files` INNER JOIN `versions` ON ( `files`.`version_id` = `versions`.`id` ) INNER JOIN `addons` ON ( `versions`.`addon_id` = `addons`.`id` ) SET `no_restart` = 1 WHERE `addons`.`addontype_id` = 5;


### PR DESCRIPTION
Forgot this in #3363