### PR TITLE
Send log in action to FxA

### DIFF
--- a/src/olympia/accounts/tests/test_utils.py
+++ b/src/olympia/accounts/tests/test_utils.py
@@ -65,6 +65,28 @@ def test_default_fxa_login_url_with_state():
     query = urlparse.parse_qs(url.query)
     next_path = urlsafe_b64encode(path).rstrip('=')
     assert query == {
+        'action': ['signin'],
+        'client_id': ['foo'],
+        'redirect_url': ['https://testserver/fxa'],
+        'scope': ['profile'],
+        'state': ['myfxastate:{next_path}'.format(next_path=next_path)],
+    }
+
+
+@override_settings(FXA_CONFIG=FXA_CONFIG)
+def test_default_fxa_register_url_with_state():
+    path = '/en-US/addons/abp/?source=ddg'
+    request = RequestFactory().get(path)
+    request.session = {'fxa_state': 'myfxastate'}
+    raw_url = utils.default_fxa_register_url(request)
+    url = urlparse.urlparse(raw_url)
+    base = '{scheme}://{netloc}{path}'.format(
+        scheme=url.scheme, netloc=url.netloc, path=url.path)
+    assert base == 'https://accounts.firefox.com/oauth/authorization'
+    query = urlparse.parse_qs(url.query)
+    next_path = urlsafe_b64encode(path).rstrip('=')
+    assert query == {
+        'action': ['signup'],
         'client_id': ['foo'],
         'redirect_url': ['https://testserver/fxa'],
         'scope': ['profile'],
@@ -94,7 +116,7 @@ def test_login_link_not_migrated(switch_is_active):
 
 
 @mock.patch(
-    'olympia.accounts.utils.default_fxa_login_url',
+    'olympia.accounts.utils.default_fxa_register_url',
     lambda c: 'http://auth.ca')
 @mock.patch('olympia.accounts.utils.waffle.switch_is_active')
 def test_register_link_migrated(switch_is_active):

--- a/src/olympia/accounts/utils.py
+++ b/src/olympia/accounts/utils.py
@@ -21,7 +21,7 @@ def login_link(request):
 
 def register_link(request):
     if waffle.switch_is_active('fxa-migrated'):
-        return default_fxa_login_url(request)
+        return default_fxa_register_url(request)
     else:
         return link_with_final_destination(request, reverse('users.register'))
 
@@ -52,12 +52,22 @@ def fxa_login_url(config, state, next_path=None, action=None):
         host=config['oauth_host'], query=urlencode(query))
 
 
+def default_fxa_register_url(request):
+    request.session.setdefault('fxa_state', generate_fxa_state())
+    return fxa_login_url(
+        config=settings.FXA_CONFIG['default'],
+        state=request.session['fxa_state'],
+        next_path=path_with_query(request),
+        action='signup')
+
+
 def default_fxa_login_url(request):
     request.session.setdefault('fxa_state', generate_fxa_state())
     return fxa_login_url(
         config=settings.FXA_CONFIG['default'],
         state=request.session['fxa_state'],
-        next_path=path_with_query(request))
+        next_path=path_with_query(request),
+        action='signin')
 
 
 def generate_fxa_state():


### PR DESCRIPTION
This sets the log in action explicitly instead of letting FxA decide based on if you have a cookie or not.

Fixes #3368.