### PR TITLE
Stop monitoring /usr/bin/tracemonkey existence

### DIFF
--- a/src/olympia/amo/monitors.py
+++ b/src/olympia/amo/monitors.py
@@ -75,17 +75,6 @@ def libraries():
     except ImportError:
         libraries_results.append(('M2Crypto', False, 'Failed to import'))
 
-    if settings.SPIDERMONKEY:
-        if os.access(settings.SPIDERMONKEY, os.R_OK):
-            libraries_results.append(('Spidermonkey is ready!', True, None))
-            # TODO: see if it works?
-        else:
-            msg = "You said spidermonkey was at (%s)" % settings.SPIDERMONKEY
-            libraries_results.append(('Spidermonkey', False, msg))
-    else:
-        msg = "Please set SPIDERMONKEY in your settings file."
-        libraries_results.append(('Spidermonkey', False, msg))
-
     missing_libs = [l for l, s, m in libraries_results if not s]
     if missing_libs:
         status = 'missing libs: %s' % ",".join(missing_libs)

--- a/src/olympia/amo/tests/test_monitor.py
+++ b/src/olympia/amo/tests/test_monitor.py
@@ -35,13 +35,11 @@ class TestMonitor(TestCase):
             assert list(memcache_results[0][0:2]) == cache_info
             assert memcache_results[0][2]
 
-    @override_settings(SPIDERMONKEY='/bin/true')
     def test_libraries(self):
         status, libraries_result = monitors.libraries()
         assert status == ''
         assert libraries_result == [('PIL+JPEG', True, 'Got it!'),
-                                    ('M2Crypto', True, 'Got it!'),
-                                    ('Spidermonkey is ready!', True, None)]
+                                    ('M2Crypto', True, 'Got it!')]
 
     def test_elastic(self):
         status, elastic_result = monitors.elastic()

--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -142,8 +142,6 @@ PACKAGER_PATH = os.path.join(TMP_PATH, 'packager')
 
 ADDONS_PATH = NETAPP_STORAGE_ROOT + u'/files'
 
-SPIDERMONKEY = '/usr/bin/tracemonkey'
-
 # Remove DetectMobileMiddleware from middleware in production.
 detect = 'mobility.middleware.DetectMobileMiddleware'
 csp = 'csp.middleware.CSPMiddleware'

--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -134,8 +134,6 @@ PACKAGER_PATH = os.path.join(TMP_PATH, 'packager')
 
 ADDONS_PATH = NETAPP_STORAGE_ROOT + u'/files'
 
-SPIDERMONKEY = '/usr/bin/tracemonkey'
-
 # Remove DetectMobileMiddleware from middleware in production.
 detect = 'mobility.middleware.DetectMobileMiddleware'
 

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -136,8 +136,6 @@ PACKAGER_PATH = os.path.join(TMP_PATH, 'packager')
 
 ADDONS_PATH = NETAPP_STORAGE_ROOT + u'/files'
 
-SPIDERMONKEY = '/usr/bin/tracemonkey'
-
 # Remove DetectMobileMiddleware from middleware in production.
 detect = 'mobility.middleware.DetectMobileMiddleware'
 csp = 'csp.middleware.CSPMiddleware'

--- a/src/olympia/devhub/tasks.py
+++ b/src/olympia/devhub/tasks.py
@@ -397,7 +397,6 @@ def run_validator(path, for_appversions=None, test_all_tiers=False,
                 # tier fails.
                 determined=test_all_tiers,
                 approved_applications=apps,
-                spidermonkey=settings.SPIDERMONKEY,
                 overrides=overrides,
                 compat_test=compat,
                 listed=listed

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1389,10 +1389,6 @@ REDIS_BACKENDS = {
     'master': get_redis_settings(REDIS_LOCATION)
 }
 
-# Full path or executable path (relative to $PATH) of the spidermonkey js
-# binary.  It must be a version compatible with amo-validator.
-SPIDERMONKEY = None
-
 # Number of seconds before celery tasks will abort addon validation:
 VALIDATOR_TIMEOUT = 110
 


### PR DESCRIPTION
Now that AMO doesn't depend on tracemonkey any more, we no longer install it,
and as a result, we remove the monitoring as well.

@jasonthomas r?