### PR TITLE
Auto sign pending files when switching to unlisted

### DIFF
--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -406,6 +406,10 @@ def disable(request, addon_id, addon):
 def unlist(request, addon_id, addon):
     addon.update(is_listed=False, disabled_by_user=False)
     amo.log(amo.LOG.ADDON_UNLISTED, addon)
+
+    if addon.latest_version.is_unreviewed:
+        auto_sign_version(addon.latest_version)
+
     return redirect(addon.get_dev_url('versions'))
 
 


### PR DESCRIPTION
I'm sure there is an issue filed for this, but I can't find it right now.

Basically, this fixes the issue where a version is added to the unlisted queue instead of being automatically signed when the developer switches their add-on to unlisted.