### PR TITLE
Change review templates to point to status & versions page for replies.

### DIFF
--- a/src/olympia/editors/templates/editors/emails/author_super_review.ltxt
+++ b/src/olympia/editors/templates/editors/emails/author_super_review.ltxt
@@ -1,10 +1,18 @@
+{% load waffle_tags %}
 Hello,
 
 Your add-on, {{ name }} {{ number }}, has been flagged for Admin Review.
 
 Your add-on is still in our review queue, but it will need to be checked by one of our admin reviewers. This means that your review will probably take longer than usual.
 
-If you have any questions or comments, you can reply to this email or join #amo-editors on irc.mozilla.org. To learn more about the review process, please visit https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Reviews
+{% switch "activity-email" %}
+If you want to respond to this email please reply to this email or visit {{ dev_versions_url }}. If you need to send file attachments, please include the address amo-editors@mozilla.org and mention it in your reply.
+
+You can also join us in #amo-editors on irc.mozilla.org.
+{% else %}
+If you have any questions or comments, you can reply to this email or join #amo-editors on irc.mozilla.org.
+{% endswitch %}
+To learn more about the review process, please visit https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Reviews
 
 Mozilla Add-ons Team
 {{ SITE_URL }}

--- a/src/olympia/editors/templates/editors/emails/base.ltxt
+++ b/src/olympia/editors/templates/editors/emails/base.ltxt
@@ -1,7 +1,15 @@
+{% load waffle_tags %}
 Hello,
 
 {% block content %}{% endblock %}
-If you want to respond to this review, or have any questions about it, please reply to this email or join #amo-editors on irc.mozilla.org. To learn more about the review process, please visit https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Reviews
+{% switch "activity-email" %}
+If you want to respond to this email please reply to this email or visit {{ dev_versions_url }}. If you need to send file attachments, please include the address amo-editors@mozilla.org and mention it in your reply.
+
+You can also join us in #amo-editors on irc.mozilla.org.
+{% else %}
+If you want to respond to this review, or have any questions about it, please reply to this email or join #amo-editors on irc.mozilla.org. 
+{% endswitch %}
+To learn more about the review process, please visit https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Reviews
 --
 Mozilla Add-ons Team
 {{ SITE_URL }}


### PR DESCRIPTION
Fixes #3148 
Note: this isn't of much use until #3147 is added as the link we include doesn't let you reply.
Waffle migration in #3397 