### PR TITLE
Add API to post an add-on review

### DIFF
--- a/docs/topics/api/reviews.rst
+++ b/docs/topics/api/reviews.rst
@@ -60,3 +60,18 @@ This endpoint allows you to fetch a review by its id.
     :>json object user: Object holding information about the user who posted the review.
     :>json string user.url: The user profile URL.
     :>json string user.name: The user name.
+
+----
+Post
+----
+
+.. review-list-addon:
+
+This endpoint allows you to post a new review for a given add-on and version.
+
+.. http:post:: /api/v3/addons/addon/(int:id|string:slug|string:guid)/reviews/
+
+    :<json string|null body: The text of the review.
+    :<json string|null: The title of the review.
+    :<json int rating: The rating the user wants to give as part of the review (required).
+    :<json int version: The add-on version id the review applies to.

--- a/src/olympia/activity/tests/test_views.py
+++ b/src/olympia/activity/tests/test_views.py
@@ -4,7 +4,7 @@ import json
 from olympia import amo
 from olympia.activity.tests.test_serializers import LogMixin
 from olympia.amo.tests import (
-    addon_factory, user_factory, TestCase)
+    addon_factory, APITestClient, user_factory, TestCase)
 from olympia.amo.urlresolvers import reverse
 from olympia.addons.models import AddonUser
 from olympia.addons.utils import generate_addon_guid
@@ -123,6 +123,8 @@ class ReviewNotesViewSetDetailMixin(LogMixin):
 
 
 class TestReviewNotesViewSetDetail(ReviewNotesViewSetDetailMixin, TestCase):
+    client_class = APITestClient
+
     def setUp(self):
         super(TestReviewNotesViewSetDetail, self).setUp()
         self.addon = addon_factory(
@@ -155,6 +157,8 @@ class TestReviewNotesViewSetDetail(ReviewNotesViewSetDetailMixin, TestCase):
 
 
 class TestReviewNotesViewSetList(ReviewNotesViewSetDetailMixin, TestCase):
+    client_class = APITestClient
+
     def setUp(self):
         super(TestReviewNotesViewSetList, self).setUp()
         self.addon = addon_factory(

--- a/src/olympia/activity/views.py
+++ b/src/olympia/activity/views.py
@@ -34,5 +34,6 @@ class VersionReviewNotesViewSet(AddonChildMixin, RetrieveModelMixin,
 
     def check_object_permissions(self, request, obj):
         """Check object permissions against the Addon, not the ActivityLog."""
-        # Just loading the add-on object should trigger permission checks.
+        # Just loading the add-on object triggers permission checks, because
+        # the implementation in AddonChildMixin calls AddonViewSet.get_object()
         self.get_addon_object()

--- a/src/olympia/activity/views.py
+++ b/src/olympia/activity/views.py
@@ -19,7 +19,6 @@ class VersionReviewNotesViewSet(AddonChildMixin, RetrieveModelMixin,
     ]
     serializer_class = ActivityLogSerializer
     queryset = ActivityLog.objects.all()
-    filter = amo.LOG_REVIEW_QUEUE_DEVELOPER
 
     def get_queryset(self):
         addon = self.get_addon_object()
@@ -27,4 +26,13 @@ class VersionReviewNotesViewSet(AddonChildMixin, RetrieveModelMixin,
             Version.unfiltered.filter(addon=addon),
             pk=self.kwargs['version_pk'])
         alog = ActivityLog.objects.for_version(version_object)
-        return alog.filter(action__in=self.filter)
+        return alog.filter(action__in=amo.LOG_REVIEW_QUEUE_DEVELOPER)
+
+    def get_addon_object(self):
+        return super(VersionReviewNotesViewSet, self).get_addon_object(
+            permission_classes=self.permission_classes)
+
+    def check_object_permissions(self, request, obj):
+        """Check object permissions against the Addon, not the ActivityLog."""
+        # Just loading the add-on object should trigger permission checks.
+        self.get_addon_object()

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -15,7 +15,7 @@ from pyquery import PyQuery as pq
 from waffle.testutils import override_switch
 
 from olympia import amo
-from olympia.amo.tests import ESTestCase, TestCase
+from olympia.amo.tests import APITestClient, ESTestCase, TestCase
 from olympia.amo.helpers import numberfmt, urlparams
 from olympia.amo.tests import addon_factory, version_factory
 from olympia.amo.urlresolvers import reverse
@@ -1704,6 +1704,8 @@ class AddonAndVersionViewSetDetailMixin(object):
 
 
 class TestAddonViewSetDetail(AddonAndVersionViewSetDetailMixin, TestCase):
+    client_class = APITestClient
+
     def setUp(self):
         super(TestAddonViewSetDetail, self).setUp()
         self.addon = addon_factory(
@@ -1724,6 +1726,8 @@ class TestAddonViewSetDetail(AddonAndVersionViewSetDetailMixin, TestCase):
 
 
 class TestVersionViewSetDetail(AddonAndVersionViewSetDetailMixin, TestCase):
+    client_class = APITestClient
+
     def setUp(self):
         super(TestVersionViewSetDetail, self).setUp()
         self.addon = addon_factory(
@@ -1821,6 +1825,8 @@ class TestVersionViewSetDetail(AddonAndVersionViewSetDetailMixin, TestCase):
 
 
 class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
+    client_class = APITestClient
+
     def setUp(self):
         super(TestVersionViewSetList, self).setUp()
         self.addon = addon_factory(
@@ -1950,6 +1956,8 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
 
 
 class TestAddonViewSetFeatureCompatibility(TestCase):
+    client_class = APITestClient
+
     def setUp(self):
         super(TestAddonViewSetFeatureCompatibility, self).setUp()
         self.addon = addon_factory(
@@ -1982,6 +1990,8 @@ class TestAddonViewSetFeatureCompatibility(TestCase):
 
 
 class TestAddonViewSetEulaPolicy(TestCase):
+    client_class = APITestClient
+
     def setUp(self):
         super(TestAddonViewSetEulaPolicy, self).setUp()
         self.addon = addon_factory(
@@ -2017,6 +2027,8 @@ class TestAddonViewSetEulaPolicy(TestCase):
 
 
 class TestAddonSearchView(ESTestCase):
+    client_class = APITestClient
+
     fixtures = ['base/users']
 
     def setUp(self):
@@ -2337,6 +2349,8 @@ class TestAddonSearchView(ESTestCase):
 
 
 class TestAddonFeaturedView(TestCase):
+    client_class = APITestClient
+
     def setUp(self):
         self.url = reverse('addon-featured')
 

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -691,7 +691,7 @@ class AddonVersionViewSet(AddonChildMixin, RetrieveModelMixin,
         AllowRelatedObjectPermissions('addon', AddonViewSet.permission_classes)
     ]
     serializer_class = VersionSerializer
-    # Since permission checks are dont on the parent add-on, we rely on
+    # Since permission checks are done on the parent add-on, we rely on
     # queryset filtering to hide non-valid versions. get_queryset() might
     # override this if we are asked to see non-valid versions explicitly.
     queryset = Version.objects.filter(

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -44,8 +44,8 @@ from olympia.bandwagon.models import Collection
 from olympia import paypal
 from olympia.api.paginator import ESPageNumberPagination
 from olympia.api.permissions import (
-    AllowAddonAuthor, AllowReadOnlyIfReviewedAndListed, AllowReviewer,
-    AllowReviewerUnlisted, AnyOf)
+    AllowAddonAuthor, AllowReadOnlyIfReviewedAndListed,
+    AllowRelatedObjectPermissions, AllowReviewer, AllowReviewerUnlisted, AnyOf)
 from olympia.reviews.forms import ReviewForm
 from olympia.reviews.models import Review, GroupedRating
 from olympia.search.filters import (
@@ -663,34 +663,35 @@ class AddonViewSet(RetrieveModelMixin, GenericViewSet):
 
 
 class AddonChildMixin(object):
-    """Some methods to get the parent add-on object and ensure permissions are
-    checked against it"""
+    """Mixin containing method to retrive the parent add-on object."""
 
-    def get_addon_object(self):
+    def get_addon_object(self, permission_classes=None):
         """Return the parent Addon object using the URL parameter passed
-        to the view."""
+        to the view.
+
+        `permission_classes` can be use passed to change which permission
+        classes the parent viewset will be used when loading the Addon object,
+        otherwise AddonViewSet.permission_classes will be used."""
         if hasattr(self, 'addon_object'):
             return self.addon_object
 
+        if permission_classes is None:
+            permission_classes = AddonViewSet.permission_classes
+
         self.addon_object = AddonViewSet(
-            request=self.request, permission_classes=self.permission_classes,
+            request=self.request, permission_classes=permission_classes,
             kwargs={'pk': self.kwargs['addon_pk']}).get_object()
-
         return self.addon_object
-
-    def check_object_permissions(self, request, obj):
-        """Check object permissions against the add-on, not the version."""
-        super(AddonChildMixin, self).check_object_permissions(
-            request, self.get_addon_object())
 
 
 class AddonVersionViewSet(AddonChildMixin, RetrieveModelMixin,
                           ListModelMixin, GenericViewSet):
-    # Permissions are checked against the parent add-on - see
-    # check_object_permissions() implementation below.
-    permission_classes = AddonViewSet.permission_classes
+    # Permissions are checked against the parent add-on.
+    permission_classes = [
+        AllowRelatedObjectPermissions('addon', AddonViewSet.permission_classes)
+    ]
     serializer_class = VersionSerializer
-    # Permission classes are used to check the parent add-on, we rely on
+    # Since permission checks are dont on the parent add-on, we rely on
     # queryset filtering to hide non-valid versions. get_queryset() might
     # override this if we are asked to see non-valid versions explicitly.
     queryset = Version.objects.filter(

--- a/src/olympia/api/permissions.py
+++ b/src/olympia/api/permissions.py
@@ -76,6 +76,20 @@ class AllowAddonAuthor(BasePermission):
         return obj.authors.filter(pk=request.user.pk).exists()
 
 
+class AllowOwner(BasePermission):
+    """
+    Permission class to use when you are dealing with a model instance that has
+    a "user" FK pointing to an UserProfile, and you want only the corresponding
+    user to be able to access your instance.
+    """
+    def has_permission(self, request, view):
+        return request.user.is_authenticated()
+
+    def has_object_permission(self, request, view, obj):
+        return ((obj == request.user) or
+                (getattr(obj, 'user', None) == request.user))
+
+
 class AllowReviewer(BasePermission):
     """Allow addons reviewer access.
 
@@ -115,17 +129,26 @@ class AllowReviewerUnlisted(AllowReviewer):
         return not obj.is_listed and self.has_permission(request, view)
 
 
-class AllowReadOnlyIfReviewedAndListed(BasePermission):
+class AllowIfReviewedAndListed(BasePermission):
+    """
+    Allow access when the object's is_public() method and is_listed property
+    both return True.
+    """
+    def has_permission(self, request, view):
+        return True
+
+    def has_object_permission(self, request, view, obj):
+        return (obj.is_reviewed() and not obj.disabled_by_user and
+                obj.is_listed and self.has_permission(request, view))
+
+
+class AllowReadOnlyIfReviewedAndListed(AllowIfReviewedAndListed):
     """
     Allow access when the object's is_public() method and is_listed property
     both return True and the request HTTP method is GET/OPTIONS/HEAD.
     """
     def has_permission(self, request, view):
         return request.method in SAFE_METHODS
-
-    def has_object_permission(self, request, view, obj):
-        return (obj.is_reviewed() and not obj.disabled_by_user and
-                obj.is_listed and self.has_permission(request, view))
 
 
 class ByHttpMethod(BasePermission):

--- a/src/olympia/api/permissions.py
+++ b/src/olympia/api/permissions.py
@@ -157,3 +157,20 @@ class ByHttpMethod(BasePermission):
 
     def __call__(self):
         return self
+
+
+class AllowRelatedObjectPermissions(BasePermission):
+    def __init__(self, related_property, related_permissions):
+        self.perms = related_permissions
+        self.related_property = related_property
+
+    def has_permission(self, request, view):
+        return all(perm.has_permission(request, view) for perm in self.perms)
+
+    def has_object_permission(self, request, view, obj):
+        related_obj = getattr(obj, self.related_property)
+        return all(perm.has_object_permission(request, view, related_obj)
+                   for perm in self.perms)
+
+    def __call__(self):
+        return self

--- a/src/olympia/api/tests/test_authentication.py
+++ b/src/olympia/api/tests/test_authentication.py
@@ -14,7 +14,7 @@ from rest_framework_jwt.settings import api_settings
 from rest_framework_jwt.views import refresh_jwt_token
 
 from olympia.amo.helpers import absolutify
-from olympia.amo.tests import TestCase, WithDynamicEndpoints
+from olympia.amo.tests import APITestClient, TestCase, WithDynamicEndpoints
 from olympia.api.authentication import (
     JSONWebTokenAuthentication, JWTKeyAuthentication)
 from olympia.api.tests.test_jwt_auth import JWTAuthKeyTester
@@ -38,6 +38,7 @@ class JWTKeyAuthTestView(APIView):
 
 class TestJWTKeyAuthentication(JWTAuthKeyTester):
     fixtures = ['base/addon_3615']
+    client_class = APITestClient
 
     def setUp(self):
         super(TestJWTKeyAuthentication, self).setUp()
@@ -146,6 +147,7 @@ class TestJWTKeyAuthentication(JWTAuthKeyTester):
 
 class TestJWTKeyAuthProtectedView(WithDynamicEndpoints, JWTAuthKeyTester):
     fixtures = ['base/addon_3615']
+    client_class = APITestClient
 
     def setUp(self):
         super(TestJWTKeyAuthProtectedView, self).setUp()
@@ -190,6 +192,7 @@ class TestJWTKeyAuthProtectedView(WithDynamicEndpoints, JWTAuthKeyTester):
 
 class TestJSONWebTokenAuthentication(TestCase):
     fixtures = ['base/addon_3615']
+    client_class = APITestClient
 
     def setUp(self):
         super(TestJSONWebTokenAuthentication, self).setUp()

--- a/src/olympia/internal_tools/tests/test_views.py
+++ b/src/olympia/internal_tools/tests/test_views.py
@@ -8,12 +8,12 @@ from django.core.urlresolvers import reverse
 from django.test import override_settings
 
 import mock
-from rest_framework.test import APIClient
 from rest_framework_jwt.serializers import VerifyJSONWebTokenSerializer
 
 from olympia.accounts import verify, views
 from olympia.accounts.tests.test_views import BaseAuthenticationView
-from olympia.amo.tests import addon_factory, ESTestCase, TestCase
+from olympia.amo.tests import (
+    addon_factory, APITestClient, ESTestCase, TestCase)
 from olympia.users.models import UserProfile
 
 FXA_CONFIG = {
@@ -25,6 +25,7 @@ FXA_CONFIG = {
 
 
 class TestInternalAddonSearchView(ESTestCase):
+    client_class = APITestClient
     fixtures = ['base/users']
 
     def setUp(self):
@@ -172,6 +173,7 @@ class TestInternalAddonSearchView(ESTestCase):
 
 @override_settings(FXA_CONFIG={'internal': FXA_CONFIG})
 class TestLoginStartView(TestCase):
+    client_class = APITestClient
 
     def setUp(self):
         super(TestLoginStartView, self).setUp()
@@ -259,6 +261,7 @@ endpoint_overrides = [
     FXA_CONFIG={'internal': FXA_CONFIG},
     CORS_ENDPOINT_OVERRIDES=endpoint_overrides)
 class TestLoginView(BaseAuthenticationView):
+    client_class = APITestClient
     view_name = 'internal-login'
 
     def setUp(self):
@@ -276,7 +279,7 @@ class TestLoginView(BaseAuthenticationView):
         return self.client.post(self.url, kwargs)
 
     def options(self, url, origin):
-        return APIClient(HTTP_ORIGIN=origin).options(url)
+        return self.client_class(HTTP_ORIGIN=origin).options(url)
 
     def test_no_code_provided(self):
         response = self.post(code='')

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1641,7 +1641,10 @@ REST_FRAMEWORK = {
     # Use our pagination class by default, which allows clients to request a
     # different page size.
     'DEFAULT_PAGINATION_CLASS': (
-        'olympia.api.paginator.CustomPageNumberPagination')
+        'olympia.api.paginator.CustomPageNumberPagination'),
+
+    # Use json by default when using APIClient.
+    'TEST_REQUEST_DEFAULT_FORMAT': 'json',
 }
 
 # This is the DSN to the local Sentry service. It might be overridden in

--- a/src/olympia/reviews/permissions.py
+++ b/src/olympia/reviews/permissions.py
@@ -1,0 +1,12 @@
+from rest_framework.permissions import BasePermission
+
+from olympia.reviews.helpers import user_can_delete_review
+
+
+class CanDeleteReviewPermission(BasePermission):
+    """A DRF permission class wrapping user_can_delete_review()."""
+    def has_permission(self, request, view):
+        return request.user.is_authenticated()
+
+    def has_object_permission(self, request, view, obj):
+        return user_can_delete_review(request, obj)

--- a/src/olympia/reviews/serializers.py
+++ b/src/olympia/reviews/serializers.py
@@ -1,7 +1,9 @@
 from rest_framework import serializers
+from rest_framework.relations import PrimaryKeyRelatedField
 
 from olympia.reviews.models import Review
 from olympia.users.serializers import BaseUserSerializer
+from olympia.versions.models import Version
 
 
 class BaseReviewSerializer(serializers.ModelSerializer):
@@ -9,9 +11,13 @@ class BaseReviewSerializer(serializers.ModelSerializer):
     # translation for each review - it's essentially useless. Because of that
     # we use a simple CharField in the API, hiding the fact that it's a
     # TranslatedField underneath.
-    body = serializers.CharField()
-    title = serializers.CharField()
-    user = BaseUserSerializer()
+    body = serializers.CharField(allow_null=True, required=False)
+    title = serializers.CharField(allow_null=True, required=False)
+    user = BaseUserSerializer(read_only=True)
+
+    # Version queryset is unfiltered, the version is checked more thoroughly
+    # in the validate() method.
+    version = PrimaryKeyRelatedField(queryset=Version.unfiltered)
 
     class Meta:
         model = Review
@@ -24,9 +30,41 @@ class BaseReviewSerializer(serializers.ModelSerializer):
         data['version'] = unicode(obj.version.version) if obj.version else None
         return data
 
+    def validate_version(self, version):
+        addon = self.context['view'].get_addon_object()
+        if (version.addon_id != addon.pk or
+                not version.is_public()):
+            raise serializers.ValidationError(
+                'Version does not exist on this add-on or is not public.')
+        return version
+
+    def validate(self, data):
+        data = super(BaseReviewSerializer, self).validate(data)
+        # Get the add-on pk from the URL, no need to pass it as POST data since
+        # the URL is always going to have it.
+        data['addon'] = self.context['view'].get_addon_object()
+
+        # Get the user from the request, don't allow clients to pick one
+        # themselves.
+        data['user'] = self.context['request'].user
+
+        if data['addon'].authors.filter(pk=data['user'].pk).exists():
+            raise serializers.ValidationError(
+                'An add-on author can not leave a review on its own add-on.')
+
+        if Review.objects.filter(
+                addon=data['addon'], user=data['user'],
+                version=data['version']).exists():
+            raise serializers.ValidationError(
+                'The same user can not leave a review on the same version more'
+                ' than once.')
+
+        return data
+
 
 class ReviewSerializer(BaseReviewSerializer):
     reply = BaseReviewSerializer(read_only=True)
+    rating = serializers.IntegerField(min_value=1, max_value=5)
 
     class Meta:
         model = Review

--- a/src/olympia/reviews/tests/test_permissions.py
+++ b/src/olympia/reviews/tests/test_permissions.py
@@ -1,0 +1,33 @@
+from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory
+
+from mock import mock
+
+from olympia.amo.tests import TestCase
+from olympia.reviews.permissions import CanDeleteReviewPermission
+from olympia.users.models import UserProfile
+
+
+class TestCanDeleteReviewPermission(TestCase):
+    def setUp(self):
+        self.request = RequestFactory().get('/')
+        self.request.user = AnonymousUser()
+        self.perm = CanDeleteReviewPermission()
+
+    def test_has_permission_anonymous(self):
+        assert not self.perm.has_permission(self.request, None)
+
+    def test_has_permission_authenticated(self):
+        self.request.user = UserProfile()
+        assert self.perm.has_permission(self.request, None)
+
+    @mock.patch('olympia.reviews.permissions.user_can_delete_review')
+    def test_has_object_permission(self, user_can_delete_review_mock):
+        user_can_delete_review_mock.return_value = True
+        assert self.perm.has_object_permission(self.request, None, object())
+
+    @mock.patch('olympia.reviews.permissions.user_can_delete_review')
+    def test_has_object_permission_false(self, user_can_delete_review_mock):
+        user_can_delete_review_mock.return_value = False
+        assert not self.perm.has_object_permission(
+            self.request, None, object())

--- a/src/olympia/signing/tests/test_views.py
+++ b/src/olympia/signing/tests/test_views.py
@@ -81,7 +81,8 @@ class BaseUploadVersionCase(SigningAPITestCase):
 
             return getattr(self.client, method.lower())(
                 url, data,
-                HTTP_AUTHORIZATION=self.authorization())
+                HTTP_AUTHORIZATION=self.authorization(),
+                format='multipart')
 
     def make_admin(self, user):
         admin_group = Group.objects.create(name='Admin', rules='*:*')


### PR DESCRIPTION
Also some necessary refactors to enable this:
- Making `AddonChildMixin` more flexible
- Using `APIClient` in api tests to make sure we send json requests by default

Fix #3342