### PR TITLE
Explicitly update our dependencies in our CircleCI tests.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,9 +20,9 @@ test:
     # Update deps to avoid missing dependencies
     # from the UI tests when a PR adds new dependency
     # that isn't yet built into the container.
-    - docker-compose run --entrypoint "/bin/sh/ -c" web "make update_deps"
-    - docker-compose run --entrypoint "/bin/sh/ -c" worker "make update_deps"
-    - docker-compose run --entrypoint "/bin/sh/ -c" web ./scripts/setup-docker.sh
+    - docker-compose run --entrypoint "/bin/sh -c" web "make update_deps"
+    - docker-compose run --entrypoint "/bin/sh -c" worker "make update_deps"
+    - docker-compose run --entrypoint "/bin/sh -c" web ./scripts/setup-docker.sh
   override:
     - tox -e ui-tests --
       --base-url=http://127.0.0.1

--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,13 @@ test:
     - docker-compose pull
     - docker-compose up -d
     - sleep 60
+    # Update deps to avoid missing dependencies
+    # from the UI tests when a PR adds new dependency
+    # that isn't yet built into the container.
+    - docker-compose run web --entrypoint "sh" "make update_deps"
+    - docker-compose run worker --entrypoint "sh" "make update_deps"
     - docker-compose run web ./scripts/setup-docker.sh
+    - docker-compose run worker ./scripts/setup-docker.sh
   override:
     - tox -e ui-tests --
       --base-url=http://127.0.0.1

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,8 @@
 machine:
   services:
     - docker
+  environment:
+    CIRCLECI_UITESTS: true
 
 dependencies:
   override:
@@ -20,9 +22,9 @@ test:
     # Update deps to avoid missing dependencies
     # from the UI tests when a PR adds new dependency
     # that isn't yet built into the container.
-    - docker-compose run --entrypoint "/bin/sh -c" web "make update_deps"
-    - docker-compose run --entrypoint "/bin/sh -c" worker "make update_deps"
-    - docker-compose run --entrypoint "/bin/sh -c" web ./scripts/setup-docker.sh
+    - docker-compose run web "make update_deps"
+    - docker-compose run worker "make update_deps"
+    - docker-compose run web ./scripts/setup-docker.sh
   override:
     - tox -e ui-tests --
       --base-url=http://127.0.0.1

--- a/circle.yml
+++ b/circle.yml
@@ -20,10 +20,9 @@ test:
     # Update deps to avoid missing dependencies
     # from the UI tests when a PR adds new dependency
     # that isn't yet built into the container.
-    - docker-compose run web --entrypoint "sh" "make update_deps"
-    - docker-compose run worker --entrypoint "sh" "make update_deps"
-    - docker-compose run web ./scripts/setup-docker.sh
-    - docker-compose run worker ./scripts/setup-docker.sh
+    - docker-compose run --entrypoint "/bin/sh/ -c" web "make update_deps"
+    - docker-compose run --entrypoint "/bin/sh/ -c" worker "make update_deps"
+    - docker-compose run --entrypoint "/bin/sh/ -c" web ./scripts/setup-docker.sh
   override:
     - tox -e ui-tests --
       --base-url=http://127.0.0.1

--- a/scripts/start-docker.sh
+++ b/scripts/start-docker.sh
@@ -9,7 +9,7 @@
 if [[ $CIRCLECI_UITESTS == true ]]; then
     echo "CIRCLECI TESTS"
     # Ignore all uid mangling for our circleci environment
-    exec sh -c "$@"
+    sh -c "$@"
     exit 0
 fi
 

--- a/scripts/start-docker.sh
+++ b/scripts/start-docker.sh
@@ -9,7 +9,7 @@
 if [[ $CIRCLECI_UITESTS == true ]]; then
     echo "CIRCLECI TESTS"
     # Ignore all uid mangling for our circleci environment
-    exec "$@" sh -- "$@"
+    exec sh -c "$@"
     exit 0
 fi
 

--- a/scripts/start-docker.sh
+++ b/scripts/start-docker.sh
@@ -9,7 +9,7 @@
 if [[ $CIRCLECI_UITESTS == true ]]; then
     echo "CIRCLECI TESTS"
     # Ignore all uid mangling for our circleci environment
-    sh -c "$@"
+    exec "$@" sh -- "$@"
     exit 0
 fi
 

--- a/scripts/start-docker.sh
+++ b/scripts/start-docker.sh
@@ -6,6 +6,13 @@
 # with files owned by root. So create a new user with the same UID,
 # and drop privileges before running any commands.
 
+if [[ $CIRCLECI_UITESTS == true ]]; then
+    echo "CIRCLECI TESTS"
+    # Ignore all uid mangling for our circleci environment
+    exec "$@"
+    exit 0
+fi
+
 # Get the numeric user ID of the current directory.
 uid=$(ls -nd . | awk '{ print $3 }')
 

--- a/scripts/start-docker.sh
+++ b/scripts/start-docker.sh
@@ -9,7 +9,7 @@
 if [[ $CIRCLECI_UITESTS == true ]]; then
     echo "CIRCLECI TESTS"
     # Ignore all uid mangling for our circleci environment
-    exec "$@"
+    exec sh -c "$@"
     exit 0
 fi
 


### PR DESCRIPTION
This fixes the fact that we cannot run circleci tests for pull requests
that change our dependencies because we are always using the
dockerhub image that builds from master and thus doesn't contain
the required dependencies.