### PR TITLE
Fixes #3258 long author names breaks themes layout

### DIFF
--- a/src/olympia/addons/templates/addons/persona_preview.html
+++ b/src/olympia/addons/templates/addons/persona_preview.html
@@ -92,9 +92,11 @@
       <h3>{{ addon.name }}</h3>
     </a>
     <h4>
-      {{ _('by') }}
-      {{ users_list(addon.listed_authors) or
+      <div class="author-names">
+        {{ _('by') }}
+        {{ users_list(addon.listed_authors) or
          addon.persona.display_username }}
+      </div>
     </h4>
     <h4>
       {{ _('{0} Daily Users')|fe(addon.persona.popularity|numberfmt) }}

--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -1602,6 +1602,13 @@ h3.author .transfer-ownership {
   h4 {
     clear: both;
     font-size: 12px;
+
+    .author-names{
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
+    }
+
   }
 
   a {


### PR DESCRIPTION
Before:
----------
![before1](https://cloud.githubusercontent.com/assets/5310329/18287058/37d25772-7493-11e6-8256-05a7a29d4157.png)
-----------------------------------------------------------------------------------------------------------------------------------------
![before2](https://cloud.githubusercontent.com/assets/5310329/18287065/3cfc07ca-7493-11e6-9b55-4c1b75ebf637.png)
------
After:
--------
![after1](https://cloud.githubusercontent.com/assets/5310329/18287082/49c7ac34-7493-11e6-9830-b00ff6d7e9f3.png)
-----------------------------------------------------------------------------------------------------------------------------------------
![after2](https://cloud.githubusercontent.com/assets/5310329/18287086/50815426-7493-11e6-865d-9ba0373a75a4.png)
