### PR TITLE
Log in start view for default FxA config

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -111,7 +111,6 @@ FXA_CONFIG = {
         'scope': 'profile',
     },
 }
-FXA_CONFIG['default'] = FXA_CONFIG['internal']
 
 # CSP report endpoint which returns a 204 from addons-nginx in local dev.
 CSP_REPORT_URI = '/csp-report'

--- a/settings.py
+++ b/settings.py
@@ -111,6 +111,7 @@ FXA_CONFIG = {
         'scope': 'profile',
     },
 }
+FXA_CONFIG['default'] = FXA_CONFIG['internal']
 
 # CSP report endpoint which returns a 204 from addons-nginx in local dev.
 CSP_REPORT_URI = '/csp-report'

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -171,6 +171,9 @@ class TestLoginView(BaseAuthenticationView):
     def options(self, url, origin):
         return self.client_class(HTTP_ORIGIN=origin).options(url)
 
+    def test_correct_config_is_used(self):
+        assert views.LoginView.FXA_CONFIG_NAME == 'default'
+
     def test_cors_addons_frontend(self):
         response = self.options(self.url, origin='https://addons-frontend')
         assert has_cors_headers(response, origin='https://addons-frontend')
@@ -719,12 +722,6 @@ class TestLoginBaseView(WithDynamicEndpoints, TestCase):
             self.client.post(
                 self.url, {'code': 'code', 'state': 'some-blob'})
         assert not self.update_user.called
-
-
-class TestLoginView(TestCase):
-
-  def test_correct_config_is_used(self):
-    assert views.LoginView.FXA_CONFIG_NAME == 'default'
 
 
 class TestRegisterView(BaseAuthenticationView):

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -115,8 +115,7 @@ class TestLoginStartBaseView(WithDynamicEndpoints, TestCase):
         self.initialize_session({})
         with mock.patch('olympia.accounts.views.generate_fxa_state',
                         lambda: state):
-            response = self.client.get(
-                '{url}?to={path}'.format(path=path, url=self.url))
+            response = self.client.get(self.url, data={'to': path})
         assert self.client.session['fxa_state'] == state
         url = urlparse.urlparse(response['location'])
         query = urlparse.parse_qs(url.query)

--- a/src/olympia/accounts/urls.py
+++ b/src/olympia/accounts/urls.py
@@ -24,6 +24,9 @@ urlpatterns = [
     # authenticate for a while.
     url(r'^authorize/$', views.AuthenticateView.as_view()),
     url(r'^login/$', views.LoginView.as_view(), name='accounts.login'),
+    url(r'^login/start/$',
+        views.LoginStartView.as_view(),
+        name='accounts.login_start'),
     url(r'^profile/$', views.ProfileView.as_view(), name='accounts.profile'),
     url(r'^register/$', views.RegisterView.as_view(),
         name='accounts.register'),

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -279,21 +279,27 @@ class LoginStartView(LoginStartBaseView):
     FXA_CONFIG_NAME = 'default'
 
 
-class LoginView(APIView):
+class LoginBaseView(APIView):
 
-    @with_user(format='json')
-    def post(self, request, user, identity, next_path):
-        if user is None:
-            return Response({'error': ERROR_NO_USER}, status=422)
-        else:
-            update_user(user, identity)
-            response = Response({'email': identity['email']})
-            add_api_token_to_response(response, user, set_cookie=False)
-            log.info('Logging in user {} from FxA'.format(user))
-            return response
+    def post(self, request):
+        @with_user(format='json', config=self.FXA_CONFIG_NAME)
+        def _post(self, request, user, identity, next_path):
+            if user is None:
+                return Response({'error': ERROR_NO_USER}, status=422)
+            else:
+                update_user(user, identity)
+                response = Response({'email': identity['email']})
+                add_api_token_to_response(response, user, set_cookie=False)
+                log.info('Logging in user {} from FxA'.format(user))
+                return response
+        return _post(self, request)
 
     def options(self, request):
         return Response()
+
+
+class LoginView(LoginBaseView):
+    FXA_CONFIG_NAME = 'default'
 
 
 class RegisterView(APIView):

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -280,17 +280,20 @@ class LoginStartView(LoginStartBaseView):
 
 
 class LoginView(APIView):
-    authentication_classes = (SessionAuthentication,)
 
     @with_user(format='json')
     def post(self, request, user, identity, next_path):
         if user is None:
             return Response({'error': ERROR_NO_USER}, status=422)
         else:
-            login_user(request, user, identity)
+            update_user(user, identity)
             response = Response({'email': identity['email']})
-            add_api_token_to_response(response, user)
+            add_api_token_to_response(response, user, set_cookie=False)
+            log.info('Logging in user {} from FxA'.format(user))
             return response
+
+    def options(self, request):
+        return Response()
 
 
 class RegisterView(APIView):

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -213,6 +213,14 @@ def mobile_test(f):
     return wrapper
 
 
+class PatchMixin(object):
+
+    def patch(self, thing):
+        patcher = mock.patch(thing)
+        self.addCleanup(patcher.stop)
+        return patcher.start()
+
+
 class InitializeSessionMixin(object):
 
     def initialize_session(self, session_data):
@@ -356,7 +364,8 @@ class BaseTestCase(test.TestCase):
         assert_url_equal(url, other, compare_host=compare_host)
 
 
-class TestCase(InitializeSessionMixin, MockEsMixin, BaseTestCase):
+class TestCase(PatchMixin, InitializeSessionMixin, MockEsMixin,
+               BaseTestCase):
     """Base class for all amo tests."""
     client_class = TestClient
 

--- a/src/olympia/internal_tools/tests/test_views.py
+++ b/src/olympia/internal_tools/tests/test_views.py
@@ -1,13 +1,10 @@
 # -*- coding: utf-8 -*-
-import base64
 import json
-import urlparse
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.test import override_settings
 
-import mock
 from rest_framework_jwt.serializers import VerifyJSONWebTokenSerializer
 
 from olympia.accounts import verify, views as accounts_views

--- a/src/olympia/internal_tools/tests/test_views.py
+++ b/src/olympia/internal_tools/tests/test_views.py
@@ -5,9 +5,6 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.test import override_settings
 
-from rest_framework_jwt.serializers import VerifyJSONWebTokenSerializer
-
-from olympia.accounts import verify, views as accounts_views
 from olympia.accounts.tests.test_views import BaseAuthenticationView
 from olympia.amo.tests import (
     addon_factory, APITestClient, ESTestCase, TestCase)
@@ -175,12 +172,6 @@ class TestLoginStartView(TestCase):
         assert views.LoginStartView.FXA_CONFIG_NAME == 'internal'
 
 
-class TestLoginView(TestCase):
-
-    def test_internal_config_is_used(self):
-      assert views.LoginView.FXA_CONFIG_NAME == 'internal'
-
-
 def has_cors_headers(response, origin='https://addons-frontend'):
     return (
         response['Access-Control-Allow-Origin'] == origin and
@@ -216,6 +207,9 @@ class TestLoginView(BaseAuthenticationView):
     def options(self, url, origin):
         return self.client_class(HTTP_ORIGIN=origin).options(url)
 
+    def test_internal_config_is_used(self):
+        assert views.LoginView.FXA_CONFIG_NAME == 'internal'
+
     def test_cors_addons_frontend(self):
         response = self.options(self.url, origin='https://addons-frontend')
         assert has_cors_headers(response, origin='https://addons-frontend')
@@ -233,4 +227,3 @@ class TestLoginView(BaseAuthenticationView):
         assert 'Access-Control-Allow-Headers' not in response
         assert 'Access-Control-Allow-Credentials' not in response
         assert response.status_code == 200
-

--- a/src/olympia/internal_tools/urls.py
+++ b/src/olympia/internal_tools/urls.py
@@ -10,7 +10,7 @@ urlpatterns = patterns(
         views.InternalAddonSearchView.as_view(),
         name='internal-addon-search'),
     url(r'^accounts/login/start/$',
-        views.LoginStart.as_view(),
+        views.LoginStartView.as_view(),
         name='internal-login-start'),
     url(r'^accounts/login/$',
         views.LoginView.as_view(),

--- a/src/olympia/internal_tools/views.py
+++ b/src/olympia/internal_tools/views.py
@@ -1,8 +1,5 @@
 import logging
 
-from django.conf import settings
-from django.http import HttpResponseRedirect
-
 from rest_framework.views import APIView, Response
 
 

--- a/src/olympia/internal_tools/views.py
+++ b/src/olympia/internal_tools/views.py
@@ -6,9 +6,9 @@ from django.http import HttpResponseRedirect
 from rest_framework.views import APIView, Response
 
 
-from olympia.accounts.utils import generate_fxa_state, fxa_login_url
 from olympia.accounts.views import (
-    add_api_token_to_response, update_user, with_user, ERROR_NO_USER)
+    add_api_token_to_response, update_user, with_user, ERROR_NO_USER,
+    LoginStartBaseView)
 from olympia.addons.views import AddonSearchView
 from olympia.api.authentication import JSONWebTokenAuthentication
 from olympia.api.permissions import AnyOf, GroupPermission
@@ -34,16 +34,8 @@ class InternalAddonSearchView(AddonSearchView):
                                 GroupPermission('ReviewerAdminTools', 'View'))]
 
 
-class LoginStart(APIView):
-
-    def get(self, request):
-        request.session.setdefault('fxa_state', generate_fxa_state())
-        return HttpResponseRedirect(
-            fxa_login_url(
-                config=settings.FXA_CONFIG['internal'],
-                state=request.session['fxa_state'],
-                next_path=request.GET.get('to'),
-                action='signin'))
+class LoginStartView(LoginStartBaseView):
+    FXA_CONFIG_NAME = 'internal'
 
 
 class LoginView(APIView):

--- a/src/olympia/internal_tools/views.py
+++ b/src/olympia/internal_tools/views.py
@@ -3,9 +3,7 @@ import logging
 from rest_framework.views import APIView, Response
 
 
-from olympia.accounts.views import (
-    add_api_token_to_response, update_user, with_user, ERROR_NO_USER,
-    LoginStartBaseView)
+from olympia.accounts.views import LoginBaseView, LoginStartBaseView
 from olympia.addons.views import AddonSearchView
 from olympia.api.authentication import JSONWebTokenAuthentication
 from olympia.api.permissions import AnyOf, GroupPermission
@@ -35,18 +33,5 @@ class LoginStartView(LoginStartBaseView):
     FXA_CONFIG_NAME = 'internal'
 
 
-class LoginView(APIView):
-
-    @with_user(format='json', config='internal')
-    def post(self, request, user, identity, next_path):
-        if user is None:
-            return Response({'error': ERROR_NO_USER}, status=422)
-        else:
-            update_user(user, identity)
-            response = Response({'email': identity['email']})
-            add_api_token_to_response(response, user, set_cookie=False)
-            log.info('Logging in user {} from FxA'.format(user))
-            return response
-
-    def options(self, request):
-        return Response()
+class LoginView(LoginBaseView):
+    FXA_CONFIG_NAME = 'internal'

--- a/src/olympia/internal_tools/views.py
+++ b/src/olympia/internal_tools/views.py
@@ -1,8 +1,5 @@
 import logging
 
-from rest_framework.views import APIView, Response
-
-
 from olympia.accounts.views import LoginBaseView, LoginStartBaseView
 from olympia.addons.views import AddonSearchView
 from olympia.api.authentication import JSONWebTokenAuthentication

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -102,10 +102,6 @@ CORS_ENDPOINT_OVERRIDES = [
     }),
 ]
 
-
-
-
-
 DATABASES = {
     'default': env.db(default='mysql://root:@localhost/olympia')
 }

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -91,11 +91,20 @@ CORS_ENDPOINT_OVERRIDES = [
         'CORS_ORIGIN_WHITELIST': INTERNAL_DOMAINS,
         'CORS_ALLOW_CREDENTIALS': True,
     }),
+    (r'^/api/v3/accounts/login/?$', {
+        'CORS_ORIGIN_ALLOW_ALL': False,
+        'CORS_ORIGIN_WHITELIST': INTERNAL_DOMAINS,
+        'CORS_ALLOW_CREDENTIALS': True,
+    }),
     (r'^/api/v3/internal/.*$', {
         'CORS_ORIGIN_ALLOW_ALL': False,
         'CORS_ORIGIN_WHITELIST': INTERNAL_DOMAINS,
     }),
 ]
+
+
+
+
 
 DATABASES = {
     'default': env.db(default='mysql://root:@localhost/olympia')


### PR DESCRIPTION
Support the `/login/start/` endpoint for logging in on AMO through the API. This will be needed for the mobile pages login to work but should also be used on the frontend at some point. More config will be needed for both of them to work side-by-side but this is a start.

Supports #3389.