### PR TITLE
Upgrade django-csp and use base-uri, form-action and child-src

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -96,8 +96,9 @@ django-cors-headers-multi==1.2.0 \
     --hash=sha256:c40f17823aa59df3c064234cdc890c56667b5db1ea6aac0172c949dc5c42ed53
 django-cronjobs==0.2.3 \
     --hash=sha256:177295b1442400c92cdb67e8e18f9ff5946fb442f85813b9d0837823722ea08d
-django-csp==2.0.3 \
-    --hash=sha256:d32576baad77fdd9e6859be97c2b6a3c17a6f484364389db731f0697b7a19661
+django-csp==3.0 \
+    --hash=sha256:e6e627955651235852508f98238f3f04c7ab9a77b625a6bd101cd0cf1a1e3419 \
+    --hash=sha256:e44479be426ffd5371b7522f43f8c32f8597a5003c236f31bb98ff4497a20a21
 django-environ==0.4.0 \
     --hash=sha256:70cf521f87e64f4dd2aeb87ced006dc98f621e2cdb38134fbcbcf6309fde6244
 django-extensions==1.6.7 \

--- a/src/olympia/amo/tests/test_csp_headers.py
+++ b/src/olympia/amo/tests/test_csp_headers.py
@@ -28,7 +28,10 @@ class TestCSPHeaders(TestCase):
         assert "script-src" in response['content-security-policy']
         assert "style-src" in response['content-security-policy']
         assert "font-src" in response['content-security-policy']
+        assert "form-action" in response['content-security-policy']
         assert "frame-src" in response['content-security-policy']
+        assert "child-src" in response['content-security-policy']
+        assert "base-uri" in response['content-security-policy']
 
     def test_unsafe_inline_not_in_script_src(self):
         """Make sure a script-src does not have unsafe-inline."""
@@ -42,6 +45,11 @@ class TestCSPHeaders(TestCase):
         """Make sure a script-src does not have data:."""
         assert 'data:' not in base_settings.CSP_SCRIPT_SRC
 
+    def test_http_protocol_not_in_base_uri(self):
+        """Make sure a base-uri does not have hosts using http:."""
+        for val in base_settings.CSP_BASE_URI:
+            assert not val.startswith('http:')
+
     def test_http_protocol_not_in_script_src(self):
         """Make sure a script-src does not have hosts using http:."""
         for val in base_settings.CSP_SCRIPT_SRC:
@@ -50,6 +58,11 @@ class TestCSPHeaders(TestCase):
     def test_http_protocol_not_in_frame_src(self):
         """Make sure a frame-src does not have hosts using http:."""
         for val in base_settings.CSP_FRAME_SRC:
+            assert not val.startswith('http:')
+
+    def test_http_protocol_not_in_child_src(self):
+        """Make sure a child-src does not have hosts using http:."""
+        for val in base_settings.CSP_CHILD_SRC:
             assert not val.startswith('http:')
 
     def test_http_protocol_not_in_style_src(self):
@@ -62,6 +75,15 @@ class TestCSPHeaders(TestCase):
         for val in base_settings.CSP_IMG_SRC:
             assert not val.startswith('http:')
 
+    def test_http_protocol_not_in_form_action(self):
+        """Make sure a form-action does not have hosts using http:."""
+        for val in base_settings.CSP_FORM_ACTION:
+            assert not val.startswith('http:')
+
+    def test_child_src_matches_frame_src(self):
+        """Check frame-src directive has same settings as child-src"""
+        assert base_settings.CSP_FRAME_SRC == base_settings.CSP_CHILD_SRC
+
     def test_prod_cdn_in_common_settings(self):
         """Make sure prod cdn is specified by default for statics."""
         prod_cdn_host = base_settings.PROD_CDN_HOST
@@ -72,8 +94,11 @@ class TestCSPHeaders(TestCase):
 
     def test_self_in_common_settings(self):
         """Check 'self' is defined for common settings."""
+        assert "'self'" in base_settings.CSP_BASE_URI
         assert "'self'" in base_settings.CSP_CONNECT_SRC
+        assert "'self'" in base_settings.CSP_CHILD_SRC
         assert "'self'" in base_settings.CSP_FRAME_SRC
+        assert "'self'" in base_settings.CSP_FORM_ACTION
         assert "'self'" in base_settings.CSP_IMG_SRC
         assert "'self'" in base_settings.CSP_SCRIPT_SRC
         assert "'self'" in base_settings.CSP_STYLE_SRC

--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -9,9 +9,14 @@ environ.Env.read_env(env_file='/etc/olympia/settings.env')
 env = environ.Env()
 
 # Allow addons-dev CDN for CSP.
+CSP_BASE_URI += (
+    # Required for the legacy discovery pane.
+    'https://addons-dev.allizom.org',
+)
 CDN_HOST = 'https://addons-dev-cdn.allizom.org'
 CSP_FONT_SRC += (CDN_HOST,)
-CSP_FRAME_SRC += ('https://www.sandbox.paypal.com',)
+CSP_CHILD_SRC += ('https://www.sandbox.paypal.com',)
+CSP_FRAME_SRC = CSP_CHILD_SRC
 CSP_IMG_SRC += (CDN_HOST,)
 CSP_SCRIPT_SRC += (
     # Fix for discovery pane when using services subdomain.

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -8,9 +8,14 @@ from olympia.lib.settings_base import *  # noqa
 environ.Env.read_env(env_file='/etc/olympia/settings.env')
 env = environ.Env()
 
+CSP_BASE_URI += (
+    # Required for the legacy discovery pane.
+    'https://addons.allizom.org',
+)
 CDN_HOST = 'https://addons-stage-cdn.allizom.org'
 CSP_FONT_SRC += (CDN_HOST,)
-CSP_FRAME_SRC += ('https://www.sandbox.paypal.com',)
+CSP_CHILD_SRC += ('https://www.sandbox.paypal.com',)
+CSP_FRAME_SRC = CSP_CHILD_SRC
 CSP_IMG_SRC += (CDN_HOST,)
 CSP_SCRIPT_SRC += (
     # Fix for discovery pane when using services subdomain.

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1258,21 +1258,31 @@ CSP_EXCLUDE_URL_PREFIXES = ()
 CSP_DEFAULT_SRC = (
     "'self'",
 )
+CSP_BASE_URI = (
+    "'self'",
+    # Required for the legacy discovery pane.
+    'https://addons.mozilla.org',
+)
 CSP_CONNECT_SRC = (
     "'self'",
     'https://sentry.prod.mozaws.net',
+)
+CSP_FORM_ACTION = (
+    "'self'",
+    'https://developer.mozilla.org',
 )
 CSP_FONT_SRC = (
     "'self'",
     PROD_CDN_HOST,
 )
-CSP_FRAME_SRC = (
+CSP_CHILD_SRC = (
     "'self'",
     'https://ic.paypal.com',
     'https://paypal.com',
     'https://www.google.com/recaptcha/',
     'https://www.paypal.com',
 )
+CSP_FRAME_SRC = CSP_CHILD_SRC
 CSP_IMG_SRC = (
     "'self'",
     'data:',  # Used in inlined mobile css.


### PR DESCRIPTION
Fixes #3434 (added to make it easier to specify QA notes for testing)
Fixes #1535 (Although this adds child-src and keeps frame-src around for older browsers)
Fixes #1386