### PR TITLE
Fix Review aggregation queries with django 1.8 by resetting order_by()

### DIFF
--- a/src/olympia/reviews/models.py
+++ b/src/olympia/reviews/models.py
@@ -209,7 +209,7 @@ class GroupedRating(object):
         q = (Review.without_replies.all().using(using)
              .filter(addon=addon, is_latest=True)
              .values_list('rating')
-             .annotate(models.Count('rating')))
+             .annotate(models.Count('rating')).order_by())
         counts = dict(q)
         ratings = [(rating, counts.get(rating, 0)) for rating in range(1, 6)]
         cache.set(cls.key(addon), ratings)

--- a/src/olympia/reviews/tasks.py
+++ b/src/olympia/reviews/tasks.py
@@ -49,7 +49,8 @@ def addon_review_aggregates(addons, **kw):
     #  {'rating': 3.75, 'addon': 6L, 'count': 8}, ...]
     qs = (Review.without_replies.all().no_cache().using(using)
           .values('addon')  # Group by addon id.
-          .annotate(rating=Avg('rating'), count=Count('addon')))  # Aggregates.
+          .annotate(rating=Avg('rating'), count=Count('addon'))  # Aggregates.
+          .order_by())  # Reset order by so that `created` is not included.
     stats = dict((x['addon'], (x['rating'], x['count'])) for x in qs)
     for addon in addon_objs:
         rating, reviews = stats.get(addon.id, [0, 0])

--- a/src/olympia/reviews/tests/test_tasks.py
+++ b/src/olympia/reviews/tests/test_tasks.py
@@ -1,0 +1,52 @@
+import mock
+
+from olympia.amo.tests import addon_factory, TestCase, user_factory
+from olympia.reviews.models import Review
+from olympia.reviews.tasks import addon_review_aggregates
+
+
+class TestAddonReviewAggregates(TestCase):
+    @classmethod
+    # Prevent <Review>.refresh() from being fired when setting up test data,
+    # since it'd call addon_review_aggregates too early.
+    @mock.patch.object(Review, 'refresh', lambda x, update_denorm=False: None)
+    def test_total_reviews(self):
+        addon = addon_factory()
+        addon2 = addon_factory()
+
+        # Create a few reviews with various ratings.
+        review = Review.objects.create(
+            addon=addon, rating=3, user=user_factory())
+        Review.objects.create(addon=addon, rating=3, user=user_factory())
+        Review.objects.create(addon=addon, rating=2, user=user_factory())
+        Review.objects.create(addon=addon, rating=1, user=user_factory())
+
+        # On another addon as well.
+        Review.objects.create(addon=addon2, rating=1, user=user_factory())
+        Review.objects.create(addon=addon2, rating=1, user=user_factory())
+
+        # addon_review_aggregates should ignore replies, so let's add one.
+        Review.objects.create(
+            addon=addon, rating=5, user=user_factory(), reply_to=review)
+
+        # Make sure total_reviews hasn't been updated yet.
+        addon.reload()
+        addon2.reload()
+        assert addon.total_reviews == 0
+        assert addon2.total_reviews == 0
+
+        # Trigger the task and test results.
+        addon_review_aggregates([addon.pk, addon2.pk])
+        addon.reload()
+        addon2.reload()
+        assert addon.total_reviews == 4
+        assert addon2.total_reviews == 2
+
+        # Trigger the task with a single add-on.
+        Review.objects.create(addon=addon2, rating=5, user=user_factory())
+        addon2.reload()
+        assert addon2.total_reviews == 2
+
+        addon_review_aggregates(addon2.pk)
+        addon2.reload()
+        assert addon2.total_reviews == 3


### PR DESCRIPTION
Fix #3452