### PR TITLE
Make sure soft-deleted instances are inaccessible everywhere

### DIFF
--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -559,7 +559,7 @@ def license(request, addon, version=None):
 
 @non_atomic_requests
 def license_redirect(request, version):
-    version = get_object_or_404(Version, pk=version)
+    version = get_object_or_404(Version.objects, pk=version)
     return redirect(version.license_url(), permanent=True)
 
 
@@ -584,7 +584,7 @@ def persona_redirect(request, persona_id):
         # Newer themes have persona_id == 0, doesn't mean anything.
         return http.HttpResponseNotFound()
 
-    persona = get_object_or_404(Persona, persona_id=persona_id)
+    persona = get_object_or_404(Persona.objects, persona_id=persona_id)
     try:
         to = reverse('addons.detail', args=[persona.addon.slug])
     except Addon.DoesNotExist:

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -158,7 +158,7 @@ def ajax_compat_error(request, addon_id, addon):
 def ajax_compat_update(request, addon_id, addon, version_id):
     if not addon.accepts_compatible_apps():
         raise http.Http404()
-    version = get_object_or_404(Version, pk=version_id, addon=addon)
+    version = get_object_or_404(Version.objects, pk=version_id, addon=addon)
     compat_form = forms.CompatFormSet(request.POST or None,
                                       queryset=version.apps.all())
     if request.method == 'POST' and compat_form.is_valid():
@@ -809,7 +809,7 @@ def json_bulk_compat_result(request, addon_id, addon, result_id):
 def json_upload_detail(request, upload, addon_slug=None):
     addon = None
     if addon_slug:
-        addon = get_object_or_404(Addon, slug=addon_slug)
+        addon = get_object_or_404(Addon.objects, slug=addon_slug)
     result = upload_validation_context(request, upload, addon=addon)
     plat_exclude = []
     if result['validation']:
@@ -856,11 +856,7 @@ def json_upload_detail(request, upload, addon_slug=None):
     return result
 
 
-def upload_validation_context(request, upload, addon_slug=None, addon=None,
-                              url=None):
-    if addon_slug and not addon:
-        addon = get_object_or_404(Addon, slug=addon_slug)
-
+def upload_validation_context(request, upload, addon=None, url=None):
     if not url:
         if addon:
             url = reverse('devhub.upload_detail_for_addon',
@@ -1121,7 +1117,7 @@ def upload_image(request, addon_id, addon, upload_type):
 
 @dev_required
 def version_edit(request, addon_id, addon, version_id):
-    version = get_object_or_404(Version, pk=version_id, addon=addon)
+    version = get_object_or_404(Version.objects, pk=version_id, addon=addon)
     version_form = forms.VersionForm(
         request.POST or None,
         request.FILES or None,
@@ -1195,7 +1191,7 @@ def _log_max_version_change(addon, version, appversion):
 @transaction.atomic
 def version_delete(request, addon_id, addon):
     version_id = request.POST.get('version_id')
-    version = get_object_or_404(Version, pk=version_id, addon=addon)
+    version = get_object_or_404(Version.objects, pk=version_id, addon=addon)
     if 'disable_version' in request.POST:
         messages.success(request, _('Version %s disabled.') % version.version)
         version.is_user_disabled = True
@@ -1211,7 +1207,7 @@ def version_delete(request, addon_id, addon):
 @transaction.atomic
 def version_reenable(request, addon_id, addon):
     version_id = request.POST.get('version_id')
-    version = get_object_or_404(Version, pk=version_id, addon=addon)
+    version = get_object_or_404(Version.objects, pk=version_id, addon=addon)
     messages.success(request, _('Version %s re-enabled.') % version.version)
     version.is_user_disabled = False
     version.addon.update_status()
@@ -1329,7 +1325,7 @@ def version_add(request, addon_id, addon):
 @dev_required
 @post_required
 def version_add_file(request, addon_id, addon, version_id):
-    version = get_object_or_404(Version, pk=version_id, addon=addon)
+    version = get_object_or_404(Version.objects, pk=version_id, addon=addon)
     new_file_form = forms.NewFileForm(request.POST, request.FILES, addon=addon,
                                       version=version, request=request)
     if not new_file_form.is_valid():

--- a/src/olympia/editors/views.py
+++ b/src/olympia/editors/views.py
@@ -785,7 +785,7 @@ def queue_viewing(request):
 @json_view
 @addons_reviewer_required
 def queue_version_notes(request, addon_id):
-    addon = get_object_or_404(Addon, pk=addon_id)
+    addon = get_object_or_404(Addon.objects, pk=addon_id)
     version = addon.latest_version
     return {'releasenotes': unicode(version.releasenotes),
             'approvalnotes': version.approvalnotes}

--- a/src/olympia/versions/tests.py
+++ b/src/olympia/versions/tests.py
@@ -397,6 +397,12 @@ class TestVersion(TestCase):
                       args=(self.version.addon.slug, self.version.version))
         self.assert3xx(r, url, 301)
 
+    def test_version_update_info_legacy_redirect_deleted(self):
+        self.version.delete()
+        response = self.client.get(
+            '/en-US/firefox/versions/updateInfo/%s' % self.version.id)
+        assert response.status_code == 404
+
     def _reset_version(self, version):
         version.all_files[0].status = amo.STATUS_PUBLIC
         version.deleted = False
@@ -1107,6 +1113,13 @@ class TestDownloadSource(TestCase):
         assert response[settings.XSENDFILE_HEADER].decode('utf8') == path
 
     def test_anonymous_should_not_be_allowed(self):
+        response = self.client.get(self.url)
+        assert response.status_code == 404
+
+    def test_deleted_version(self):
+        self.version.delete()
+        GroupUser.objects.create(user=self.user, group=self.group)
+        self.client.login(username=self.user.email, password="password")
         response = self.client.get(self.url)
         assert response.status_code == 404
 

--- a/src/olympia/versions/views.py
+++ b/src/olympia/versions/views.py
@@ -81,7 +81,7 @@ def update_info(request, addon, version_num):
 
 @non_atomic_requests
 def update_info_redirect(request, version_id):
-    version = get_object_or_404(Version, pk=version_id)
+    version = get_object_or_404(Version.objects, pk=version_id)
     return redirect(reverse('addons.versions.update_info',
                             args=(version.addon.id, version.version)),
                     permanent=True)
@@ -151,7 +151,7 @@ def download_latest(request, addon, beta=False, type='xpi', platform=None):
 
 @non_atomic_requests
 def download_source(request, version_id):
-    version = get_object_or_404(Version, pk=version_id)
+    version = get_object_or_404(Version.objects, pk=version_id)
 
     # General case: addon is listed.
     if version.addon.is_listed:


### PR DESCRIPTION
`get_object_or_404(model, ...)` will use the default manager, which does not filter out deleted instances. Using `model.objects` prevents this issue.

Fix #3478