### PR TITLE
Handle invalid translation entry, fixes #3485

### DIFF
--- a/src/olympia/files/tests/test_utils_.py
+++ b/src/olympia/files/tests/test_utils_.py
@@ -523,7 +523,8 @@ class TestResolvei18nMessage(object):
             }
         }
 
-        assert utils.resolve_i18n_message('__MSG_foo__', messages, 'de') == 'bar'
+        result = utils.resolve_i18n_message('__MSG_foo__', messages, 'de')
+        assert result == 'bar'
 
     def test_uses_default_locale(self):
         messages = {
@@ -532,18 +533,21 @@ class TestResolvei18nMessage(object):
             }
         }
 
-        result = utils.resolve_i18n_message('__MSG_foo__', messages, 'de', 'en')
+        result = utils.resolve_i18n_message(
+            '__MSG_foo__', messages, 'de', 'en')
         assert result == 'bar'
 
     def test_no_locale_match(self):
-        # Neither `locale` or `locale` are found, "message" is returned unchanged
+        # Neither `locale` or `locale` are found, "message" is returned
+        # unchanged
         messages = {
             'fr': {
                 'foo': {'message': 'bar'}
             }
         }
 
-        result = utils.resolve_i18n_message('__MSG_foo__', messages, 'de', 'en')
+        result = utils.resolve_i18n_message(
+            '__MSG_foo__', messages, 'de', 'en')
         assert result == '__MSG_foo__'
 
     def test_field_not_set(self):

--- a/src/olympia/files/tests/test_utils_.py
+++ b/src/olympia/files/tests/test_utils_.py
@@ -512,64 +512,69 @@ def test_extract_translations_fail_silent_missing_file(read_mock, file_obj):
             utils.extract_translations(file_obj)
 
 
-def test_resolve_i18n_message_no_match():
-    assert utils.resolve_i18n_message('foo', {}, '') == 'foo'
+class TestResolvei18nMessage(object):
+    def test_no_match(self):
+        assert utils.resolve_i18n_message('foo', {}, '') == 'foo'
 
-
-def test_resolve_i18n_message_locale_found():
-    messages = {
-        'de': {
-            'foo': {'message': 'bar'}
+    def test_locale_found(self):
+        messages = {
+            'de': {
+                'foo': {'message': 'bar'}
+            }
         }
-    }
 
-    assert utils.resolve_i18n_message('__MSG_foo__', messages, 'de') == 'bar'
+        assert utils.resolve_i18n_message('__MSG_foo__', messages, 'de') == 'bar'
 
-
-def test_resolve_i18n_message_uses_default_locale():
-    messages = {
-        'en-US': {
-            'foo': {'message': 'bar'}
+    def test_uses_default_locale(self):
+        messages = {
+            'en-US': {
+                'foo': {'message': 'bar'}
+            }
         }
-    }
 
-    result = utils.resolve_i18n_message('__MSG_foo__', messages, 'de', 'en')
-    assert result == 'bar'
+        result = utils.resolve_i18n_message('__MSG_foo__', messages, 'de', 'en')
+        assert result == 'bar'
 
-
-def test_resolve_i18n_message_no_locale_match():
-    # Neither `locale` or `locale` are found, "message" is returned unchanged
-    messages = {
-        'fr': {
-            'foo': {'message': 'bar'}
+    def test_no_locale_match(self):
+        # Neither `locale` or `locale` are found, "message" is returned unchanged
+        messages = {
+            'fr': {
+                'foo': {'message': 'bar'}
+            }
         }
-    }
 
-    result = utils.resolve_i18n_message('__MSG_foo__', messages, 'de', 'en')
-    assert result == '__MSG_foo__'
+        result = utils.resolve_i18n_message('__MSG_foo__', messages, 'de', 'en')
+        assert result == '__MSG_foo__'
 
+    def test_field_not_set(self):
+        """Make sure we don't fail on messages that are `None`
 
-def test_resolve_i18n_message_field_not_set():
-    """Make sure we don't fail on messages that are `None`
+        Fixes https://github.com/mozilla/addons-server/issues/3067
+        """
+        result = utils.resolve_i18n_message(None, {}, 'de', 'en')
+        assert result is None
 
-    Fixes https://github.com/mozilla/addons-server/issues/3067
-    """
-    result = utils.resolve_i18n_message(None, {}, 'de', 'en')
-    assert result is None
+    def test_field_no_string(self):
+        """Make sure we don't fail on messages that are no strings"""
+        result = utils.resolve_i18n_message([], {}, 'de', 'en')
+        assert result == []
 
-
-def test_resolve_i18n_message_field_no_string():
-    """Make sure we don't fail on messages that are no strings"""
-    result = utils.resolve_i18n_message([], {}, 'de', 'en')
-    assert result == []
-
-
-def test_resolve_i18n_message_corrects_locales():
-    messages = {
-        'en-US': {
-            'foo': {'message': 'bar'}
+    def test_corrects_locales(self):
+        messages = {
+            'en-US': {
+                'foo': {'message': 'bar'}
+            }
         }
-    }
 
-    result = utils.resolve_i18n_message('__MSG_foo__', messages, 'en')
-    assert result == 'bar'
+        result = utils.resolve_i18n_message('__MSG_foo__', messages, 'en')
+        assert result == 'bar'
+
+    def test_wrong_format(self):
+        messages = {
+            'en-US': {
+                'foo': 'bar'
+            }
+        }
+
+        result = utils.resolve_i18n_message('__MSG_foo__', messages, 'en')
+        assert result == 'bar'

--- a/src/olympia/files/tests/test_utils_.py
+++ b/src/olympia/files/tests/test_utils_.py
@@ -569,7 +569,7 @@ class TestResolvei18nMessage(object):
         result = utils.resolve_i18n_message('__MSG_foo__', messages, 'en')
         assert result == 'bar'
 
-    def test_wrong_format(self):
+    def test_ignore_wrong_format(self):
         messages = {
             'en-US': {
                 'foo': 'bar'
@@ -577,4 +577,4 @@ class TestResolvei18nMessage(object):
         }
 
         result = utils.resolve_i18n_message('__MSG_foo__', messages, 'en')
-        assert result == 'bar'
+        assert result == '__MSG_foo__'

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -991,8 +991,7 @@ def resolve_i18n_message(message, messages, locale, default_locale=None):
 
     if locale in messages:
         message = messages[locale].get(msgid, default)
-
-    if default_locale in messages:
+    elif default_locale in messages:
         message = messages[default_locale].get(msgid, default)
 
     if not isinstance(message, dict):

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -995,10 +995,10 @@ def resolve_i18n_message(message, messages, locale, default_locale=None):
     if default_locale in messages:
         message = messages[default_locale].get(msgid, default)
 
-    if isinstance(message, basestring):
+    if not isinstance(message, dict):
         # Fallback for invalid message format, should be caught by
         # addons-linter in the future but we'll have to handle it.
         # See https://github.com/mozilla/addons-server/issues/3485
-        return message
+        return default['message']
 
     return message['message']

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -990,9 +990,15 @@ def resolve_i18n_message(message, messages, locale, default_locale=None):
     default = {'message': message}
 
     if locale in messages:
-        return messages[locale].get(msgid, default)['message']
+        message = messages[locale].get(msgid, default)
 
     if default_locale in messages:
-        return messages[default_locale].get(msgid, default)['message']
+        message = messages[default_locale].get(msgid, default)
 
-    return message
+    if isinstance(message, basestring):
+        # Fallback for invalid message format, should be caught by
+        # addons-linter in the future but we'll have to handle it.
+        # See https://github.com/mozilla/addons-server/issues/3485
+        return message
+
+    return message['message']


### PR DESCRIPTION
This also restructures the relevant tests so that they're better capsulated.

Only question remaining though, currently we are correctly resolving the message - should we maybe not resolve it at all instead? We don't have a proper feedback loop here for invalid entries, we could raise a `ValidationError` but imho it's the worst place to do that (since it's being called in the model).