### PR TITLE
Make sure previous review count is updated when deleting/undeleting reviews

### DIFF
--- a/src/olympia/reviews/fixtures/reviews/test_models.json
+++ b/src/olympia/reviews/fixtures/reviews/test_models.json
@@ -102,7 +102,9 @@
             "version": 5,
             "addon": 4,
             "user": 1,
-            "reply_to": null
+            "reply_to": null,
+            "previous_count": 1,
+            "is_latest": true
         }
     },
     {


### PR DESCRIPTION
Also make sure those tasks are always using master - no need to pass `using='default'` everywhere, just mark the tasks as `@write` instead, less confusing.

Fix #3477