### PR TITLE
Updated the link to the 'context graph experiment' addon

### DIFF
--- a/src/olympia/pages/templates/pages/shield_study_5.html
+++ b/src/olympia/pages/templates/pages/shield_study_5.html
@@ -13,7 +13,7 @@
       <div class="container">
         <div class="title-container">
           <h1 class="title">Context Graph Recommendation Engine</h1>
-            <a href="https://addons.mozilla.org/firefox/addon/context-graph-experiment/?src=shield-study-5"><button class="button primary large">Try Context Graph Recommendation Engine</button></a>
+            <a href="https://addons.mozilla.org/firefox/downloads/latest/context-graph-experiment/?src=shield-study-5"><button class="button primary large">Try Context Graph Recommendation Engine</button></a>
         </div>
         <div class="content"><h1 id="context-graph-experiment">Context Graph Experiment</h1>
 <p>Mozilla wants to test the viability of using information about the
@@ -30,8 +30,7 @@ go back to normal.</li>
 <li>We will ask you to fill out a quick optional survey to tell us about your experience. The survey should take less than 5 minutes to complete.</li>
 </ol>
 <h2 id="leaving-the-study">Leaving the study</h2>
-<p>The study will expire on its own within three months. You may leave
-the study early. To do so, follow these steps:</p>
+<p>The study will expire on its own within three months. You may leave the study early. To do so, follow these steps:</p>
 <ol>
 <li>Type about:addons into the location bar, and press enter.</li>
 <li>Find Context Graph Recommendation Engine Experiment in the addons list.</li>
@@ -44,14 +43,9 @@ the study early. To do so, follow these steps:</p>
 <p>Here are the key things you should know about what data is collected
 when you participate in this study:</p>
 <ul>
-<li>We collect URLs you visit, which tab you were in, when you visited and
-how long you spent on the page. We filter some potentially sensitive
-URLs and edit others to improve anonymity.</li>
-<li>This data will be linked to a random ID we only use for this
-experiment. It is used to keep a specific user&#39;s data together on the
-server and to allow a user to request that their data be deleted. </li>
-<li>Important study events, such as install, uninstall, and end of study
-will be collected.</li>
+<li>We collect URLs you visit, which tab you were in, when you visited and how long you spent on the page. We filter some potentially sensitive URLs and edit others to improve anonymity.</li>
+<li>This data will be linked to a random ID we only use for this experiment. It is used to keep a specific user&#39;s data together on the server and to allow a user to request that their data be deleted. </li>
+<li>Important study events, such as install, uninstall, and end of study will be collected.</li>
 </ul>
 <p>Our practices for collecting and handling the data can be found <a href="https://github.com/mozilla/heatmap/blob/master/docs/data_practices.md">here</a>.</p>
 <p>Technical specifications about the data collection for this study are


### PR DESCRIPTION
The shield study page has a button which needs the 'download' link which will let firefox install the
addon directly instead of being redirected to the AMO page.
