### PR TITLE
Support multiple FxA configurations

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -111,6 +111,7 @@ FXA_CONFIG = {
         'scope': 'profile',
     },
 }
+FXA_CONFIG['amo'] = FXA_CONFIG['internal']
 
 # CSP report endpoint which returns a 204 from addons-nginx in local dev.
 CSP_REPORT_URI = '/csp-report'

--- a/settings.py
+++ b/settings.py
@@ -97,7 +97,7 @@ FXA_CONFIG = {
         'content_host': 'https://stable.dev.lcip.org',
         'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
         'profile_host': 'https://stable.dev.lcip.org/profile/v1',
-        'redirect_url': 'http://olympia.dev/api/v3/accounts/authorize/',
+        'redirect_url': 'http://olympia.dev/api/v3/accounts/authenticate/',
         'scope': 'profile',
     },
     'internal': {

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -687,6 +687,11 @@ class TestFxAConfigMixin(TestCase):
         config = self.MultipleConfigs().get_fxa_config(request)
         assert config == {'BAZ': 789}
 
+    def test_config_is_not_allowed(self):
+        request = RequestFactory().get('/login?config=bar')
+        config = self.MultipleConfigs().get_fxa_config(request)
+        assert config == {'BAZ': 789}
+
 
 @override_settings(FXA_CONFIG={'current-config': FXA_CONFIG})
 class TestLoginBaseView(WithDynamicEndpoints, TestCase):

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -295,6 +295,7 @@ class LoginBaseView(FxAConfigMixin, APIView):
 
     def post(self, request):
         config = self.get_fxa_config(request)
+
         @with_user(format='json', config=config)
         def _post(self, request, user, identity, next_path):
             if user is None:

--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -240,7 +240,7 @@ FXA_CONFIG = {
         'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
         'profile_host': 'https://stable.dev.lcip.org/profile/v1',
         'redirect_url':
-            'https://addons-dev.allizom.org/api/v3/accounts/authorize/',
+            'https://addons-dev.allizom.org/api/v3/accounts/authenticate/',
         'scope': 'profile',
     },
     'internal': {
@@ -249,8 +249,7 @@ FXA_CONFIG = {
         'content_host': 'https://stable.dev.lcip.org',
         'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
         'profile_host': 'https://stable.dev.lcip.org/profile/v1',
-        'redirect_url':
-            'https://addons-dev.allizom.org/api/v3/accounts/authorize/',
+        'redirect_url': 'https://addons-admin.dev.mozaws.net/fxa-authenticate',
         'scope': 'profile',
     },
     'amo': {

--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -253,6 +253,15 @@ FXA_CONFIG = {
             'https://addons-dev.allizom.org/api/v3/accounts/authorize/',
         'scope': 'profile',
     },
+    'amo': {
+        'client_id': env('AMO_FXA_CLIENT_ID'),
+        'client_secret': env('AMO_FXA_CLIENT_SECRET'),
+        'content_host': 'https://stable.dev.lcip.org',
+        'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
+        'profile_host': 'https://stable.dev.lcip.org/profile/v1',
+        'redirect_url': 'https://amo.dev.mozaws.net/fxa-authenticate',
+        'scope': 'profile',
+    },
 }
 
 INTERNAL_DOMAINS = [

--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -215,6 +215,15 @@ FXA_CONFIG = {
             'https://addons.mozilla.org/api/v3/accounts/authorize/',
         'scope': 'profile',
     },
+    'amo': {
+        'client_id': env('AMO_FXA_CLIENT_ID'),
+        'client_secret': env('AMO_FXA_CLIENT_SECRET'),
+        'content_host': 'https://accounts.firefox.com',
+        'oauth_host': 'https://oauth.accounts.firefox.com/v1',
+        'profile_host': 'https://profile.accounts.firefox.com/v1',
+        'redirect_url': 'https://amo.prod.mozaws.net/fxa-authenticate',
+        'scope': 'profile',
+    },
 }
 
 INTERNAL_DOMAINS = ['addons-admin.prod.mozaws.net']

--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -202,7 +202,7 @@ FXA_CONFIG = {
         'oauth_host': 'https://oauth.accounts.firefox.com/v1',
         'profile_host': 'https://profile.accounts.firefox.com/v1',
         'redirect_url':
-            'https://addons.mozilla.org/api/v3/accounts/authorize/',
+            'https://addons.mozilla.org/api/v3/accounts/authenticate/',
         'scope': 'profile',
     },
     'internal': {
@@ -212,7 +212,7 @@ FXA_CONFIG = {
         'oauth_host': 'https://oauth.accounts.firefox.com/v1',
         'profile_host': 'https://profile.accounts.firefox.com/v1',
         'redirect_url':
-            'https://addons.mozilla.org/api/v3/accounts/authorize/',
+            'https://addons-admin.prod.mozaws.net/fxa-authenticate',
         'scope': 'profile',
     },
     'amo': {

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -247,6 +247,15 @@ FXA_CONFIG = {
             'https://addons.allizom.org/api/v3/accounts/authorize/',
         'scope': 'profile',
     },
+    'amo': {
+        'client_id': env('AMO_FXA_CLIENT_ID'),
+        'client_secret': env('AMO_FXA_CLIENT_SECRET'),
+        'content_host': 'https://accounts.firefox.com',
+        'oauth_host': 'https://oauth.accounts.firefox.com/v1',
+        'profile_host': 'https://profile.accounts.firefox.com/v1',
+        'redirect_url': 'https://amo.stage.mozaws.net/fxa-authenticate',
+        'scope': 'profile',
+    },
 }
 
 INTERNAL_DOMAINS = ['addons-admin.stage.mozaws.net']

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -234,7 +234,7 @@ FXA_CONFIG = {
         'oauth_host': 'https://oauth.accounts.firefox.com/v1',
         'profile_host': 'https://profile.accounts.firefox.com/v1',
         'redirect_url':
-            'https://addons.allizom.org/api/v3/accounts/authorize/',
+            'https://addons.allizom.org/api/v3/accounts/authenticate/',
         'scope': 'profile',
     },
     'internal': {
@@ -244,7 +244,7 @@ FXA_CONFIG = {
         'oauth_host': 'https://oauth.accounts.firefox.com/v1',
         'profile_host': 'https://profile.accounts.firefox.com/v1',
         'redirect_url':
-            'https://addons.allizom.org/api/v3/accounts/authorize/',
+            'https://addons-admin.stage.mozaws.net/fxa-authenticate',
         'scope': 'profile',
     },
     'amo': {

--- a/src/olympia/internal_tools/tests/test_views.py
+++ b/src/olympia/internal_tools/tests/test_views.py
@@ -169,7 +169,7 @@ class TestInternalAddonSearchView(ESTestCase):
 class TestLoginStartView(TestCase):
 
     def test_internal_config_is_used(self):
-        assert views.LoginStartView.FXA_CONFIG_NAME == 'internal'
+        assert views.LoginStartView.DEFAULT_FXA_CONFIG_NAME == 'internal'
 
 
 def has_cors_headers(response, origin='https://addons-frontend'):
@@ -208,7 +208,7 @@ class TestLoginView(BaseAuthenticationView):
         return self.client_class(HTTP_ORIGIN=origin).options(url)
 
     def test_internal_config_is_used(self):
-        assert views.LoginView.FXA_CONFIG_NAME == 'internal'
+        assert views.LoginView.DEFAULT_FXA_CONFIG_NAME == 'internal'
 
     def test_cors_addons_frontend(self):
         response = self.options(self.url, origin='https://addons-frontend')

--- a/src/olympia/internal_tools/views.py
+++ b/src/olympia/internal_tools/views.py
@@ -27,8 +27,8 @@ class InternalAddonSearchView(AddonSearchView):
 
 
 class LoginStartView(LoginStartBaseView):
-    FXA_CONFIG_NAME = 'internal'
+    DEFAULT_FXA_CONFIG_NAME = 'internal'
 
 
 class LoginView(LoginBaseView):
-    FXA_CONFIG_NAME = 'internal'
+    DEFAULT_FXA_CONFIG_NAME = 'internal'


### PR DESCRIPTION
This allows the FxA views to define with configurations are allowed to be used in the `config` GET parameter. With this you no longer need to force addons-server to use the internal config as the default config for addons-frontend:amo.

Based off of #3430.

Fixes #3496.