### PR TITLE
Fix needlessly disabled save button for theme ownership transfer.

### DIFF
--- a/src/olympia/devhub/templates/devhub/personas/edit.html
+++ b/src/olympia/devhub/templates/devhub/personas/edit.html
@@ -28,11 +28,11 @@
         <a href="#ownership" class="button transfer-ownership">{{ _('Transfer ownership') }}</a>
       </h3>
       <div class="owner-email hidden">
-        <form action="{{ request.path }}" method="post">
+        <form action="{{ request.path }}#ownership" method="post">
           {{ csrf() }}
           {{ owner_form.owner.errors }}
           {{ owner_form.owner }}
-          <button name="owner_submit" disabled type="submit">{{ _('Save Changes') }}</button>
+          <button name="owner_submit" type="submit">{{ _('Save Changes') }}</button>
         </form>
       </div>
     </div>

--- a/static/js/impala/persona_creation.js
+++ b/static/js/impala/persona_creation.js
@@ -5,12 +5,6 @@
 
     initOwnership();
 
-    var $ownerForm = $('.owner-email form');
-    $ownerForm.delegate('input, select, textarea', 'change keyup paste', function(e) {
-        checkOwnerValid();
-    });
-    checkOwnerValid();
-
     // Validate the form.
     var $form = $('#submit-persona form');
     $form.delegate('input, select, textarea', 'change keyup paste', function(e) {
@@ -22,11 +16,6 @@
     initCharCount();
     initPreview();
     initReuploadTheme();
-
-
-    function checkOwnerValid() {
-        $ownerForm.find('button').prop('disabled', !$ownerForm.find('input').hasClass('valid'));
-    }
 
 
     function toggleOwnership() {


### PR DESCRIPTION
Also make sure the toggle stays toggled after clicking "Save"
so that the user can see the error message.

This got probably broken in 24d85149d3c6b201e67a75c411f4ba32b381f22c

Fixes #898