### PR TITLE
Warn developers on upgrading to a WebExtension.

### DIFF
--- a/src/olympia/amo/tests/test_helpers.py
+++ b/src/olympia/amo/tests/test_helpers.py
@@ -15,11 +15,17 @@ import pytest
 from mock import Mock, patch
 from pyquery import PyQuery
 
+import olympia
 from olympia import amo
 from olympia.amo.tests import TestCase
 from olympia.amo import urlresolvers, utils, helpers
 from olympia.amo.utils import ImageCheck
 from olympia.versions.models import License
+
+
+ADDONS_TEST_FILES = os.path.join(
+    os.path.dirname(olympia.__file__),
+    'devhub', 'tests', 'addons')
 
 
 pytestmark = pytest.mark.django_db
@@ -477,6 +483,10 @@ def get_uploaded_file(name):
     data = open(get_image_path(name)).read()
     return SimpleUploadedFile(name, data,
                               content_type=mimetypes.guess_type(name)[0])
+
+
+def get_addon_file(name):
+    return os.path.join(ADDONS_TEST_FILES, name)
 
 
 class TestAnimatedImages(TestCase):

--- a/src/olympia/devhub/tests/test_tasks.py
+++ b/src/olympia/devhub/tests/test_tasks.py
@@ -19,19 +19,14 @@ from olympia.amo.tests import TestCase
 from olympia.constants.base import VALIDATOR_SKELETON_RESULTS
 from olympia.addons.models import Addon
 from olympia.amo.helpers import user_media_path
-from olympia.amo.tests.test_helpers import get_image_path
+from olympia.amo.tests.test_helpers import get_image_path, get_addon_file
 from olympia.amo.utils import utc_millesecs_from_epoch
 from olympia.devhub import tasks
 from olympia.files.models import FileUpload
 from olympia.versions.models import Version
 
 
-ADDON_TEST_FILES = os.path.join(os.path.dirname(__file__), 'addons')
 pytestmark = pytest.mark.django_db
-
-
-def get_addon_file(name):
-    return os.path.join(ADDON_TEST_FILES, name)
 
 
 def test_resize_icon_shrink():
@@ -614,6 +609,63 @@ class TestValidateFilePath(ValidatorTestCase):
         assert not result['success']
         assert result['errors']
         assert not result['warnings']
+
+
+class TestWebextensionUpgrade(TestCase):
+    fixtures = ['base/addon_3615']
+
+    def setUp(self):
+        self.addon = Addon.objects.get(pk=3615)
+
+        # valid_webextension.xpi has version 1.0 so mock the original version
+        self.addon.update(guid='beastify@mozilla.org')
+        self.addon.current_version.update(version='0.9')
+        self.update_files(
+            version=self.addon.current_version,
+            filename='delicious_bookmarks-2.1.106-fx.xpi')
+
+    def update_files(self, **kw):
+        for version in self.addon.versions.all():
+            for file in version.files.all():
+                file.update(**kw)
+
+    def test_webextension_upgrade_is_annotated(self):
+        assert all(f.is_webextension is False
+                   for f in self.addon.current_version.all_files)
+
+        file_ = get_addon_file('valid_webextension.xpi')
+        upload = FileUpload.objects.create(path=file_, addon=self.addon)
+
+        tasks.validate(upload)
+
+        upload.refresh_from_db()
+        assert upload.processed_validation['is_upgrade_to_webextension']
+
+        expected = ['validation', 'messages', 'webext_upgrade']
+        assert upload.processed_validation['messages'][0]['id'] == expected
+
+    def test_webextension_webext_to_webext(self):
+        previous_file = self.addon.current_version.all_files[-1]
+        previous_file.is_webextension = True
+        previous_file.save()
+
+        file_ = get_addon_file('valid_webextension.xpi')
+        upload = FileUpload.objects.create(path=file_, addon=self.addon)
+
+        tasks.validate(upload)
+        upload.refresh_from_db()
+
+        assert 'is_upgrade_to_webextension' not in upload.processed_validation
+
+    def test_webextension_no_webext_no_warning(self):
+        file_ = amo.tests.AMOPaths().file_fixture_path(
+            'delicious_bookmarks-2.1.106-fx.xpi')
+        upload = FileUpload.objects.create(path=file_, addon=self.addon)
+
+        tasks.validate(upload)
+        upload.refresh_from_db()
+
+        assert 'is_upgrade_to_webextension' not in upload.processed_validation
 
 
 class TestFlagBinary(TestCase):

--- a/src/olympia/files/models.py
+++ b/src/olympia/files/models.py
@@ -592,6 +592,7 @@ class FileUpload(ModelBase):
     def add_file(self, chunks, filename, size):
         if not self.uuid:
             self.uuid = self._meta.get_field('uuid')._create_uuid()
+
         filename = force_bytes(u'{0}_{1}'.format(self.uuid.hex, filename))
         loc = os.path.join(user_media_path('addons'), 'temp', uuid.uuid4().hex)
         base, ext = os.path.splitext(smart_path(filename))

--- a/static/css/zamboni/developers.css
+++ b/static/css/zamboni/developers.css
@@ -939,6 +939,32 @@ pre.email_comment {
     margin-top: 10px;
 }
 
+#upload-file .important-warning {
+    margin: 10px;
+    padding: 10px;
+    border-radius: 10px;
+    border: 1px solid #F0B500;
+}
+
+#upload-file .important-warning h5 {
+    line-height: 32px;
+}
+
+#upload-file .important-warning h5:before {
+    background-image: url('../../img/developers/test-warning-important.png');
+    width: 32px;
+    height: 32px;
+    margin-right: 10px;
+    content: " ";
+    display: inline-block;
+    vertical-align: middle;
+}
+#upload-file .important-warning a.review-process-overview {
+    display: block;
+    margin-top: 10px;
+}
+
+
 /* @end */
 
 /* @group Recent Activity */

--- a/static/js/common/upload-addon.js
+++ b/static/js/common/upload-addon.js
@@ -431,6 +431,20 @@
                       $("<p>").text(gettext("Your submission will be automatically signed.")).appendTo(upload_results);
                     }
 
+                    if (results.validation.is_upgrade_to_webextension) {
+                        var warning_box = $('<div>').attr('class', 'important-warning').appendTo(upload_results);
+
+                        $('<h5>').text(gettext("WebExtension upgrade")).appendTo(warning_box);
+                        $('<p>').text(gettext(
+                            "We allow and encourage an upgrade but you cannot reverse this process. Once your users have the WebExtension installed, they will not be able to install a legacy add-on."
+                        )).appendTo(warning_box);
+
+                        $('<a>').text(gettext('Porting a legacy Firefox add-on on MDN'))
+                                .attr('href', 'https://developer.mozilla.org/Add-ons/WebExtensions/Porting_a_legacy_Firefox_add-on')
+                                .attr('target', '_blank')
+                                .appendTo(warning_box);
+                    }
+
                     if (messageCount > 0) {
                         // Validation checklist
                         var checklist_box = $('<div>').attr('class', 'submission-checklist').appendTo(upload_results),
@@ -448,6 +462,7 @@
                             matchId = function (id) {
                               return this.hasOwnProperty('id') && _.contains(this.id, id);
                             };
+
 
                         $('<h5>').text(gettext("Add-on submission checklist")).appendTo(checklist_box);
                         $('<p>').text(gettext("Please verify the following points before finalizing your submission. This will minimize delays or misunderstanding during the review process:")).appendTo(checklist_box);


### PR DESCRIPTION
Fixes #3082

* Move ValidationAnnotator.find_previous_version to separate function to allow reusage.
* Annotate validation results in case of an webextension upgrade.
* Insert explicit validation message, e.g to for the API, add tests.

This introduces a present warning in case someone upgrades a old-style add-on to a WebExtension

![screenshot from 2016-09-15 08-32-33](https://cloud.githubusercontent.com/assets/139033/18547395/820455d2-7b43-11e6-8c30-a0ccd4d4cbe1.png)

And also inserts a validation message, e.g for API based validations / uploads / reviewer accessibility.

![screenshot from 2016-09-15 12-40-49](https://cloud.githubusercontent.com/assets/139033/18547401/873f3fe4-7b43-11e6-8434-62b5f6166445.png)