### PR TITLE
Cute Editor Tools menu for every language (fixes #3171)

### DIFF
--- a/src/olympia/editors/templates/editors/base.html
+++ b/src/olympia/editors/templates/editors/base.html
@@ -5,6 +5,7 @@
 {% block bodyclass %}editor-tools {% endblock %}
 
 {% block site_header_title %}
+<div class="editor-menu">
   <h1 class="site-title amo">
     <a href="{{ url('editors.home') }}" title="{{ _('Return to the Editor Tools homepage') }}">
       <strong>{{ _('Editor Tools') }}</strong>
@@ -27,6 +28,7 @@
         {% endif %}
       </nav>
     {% endif %}
+</div>
   {% endblock %}
 {% endblock %}
 

--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -1232,6 +1232,14 @@ body:not(.developer-hub) section.secondary {
 
 #masthead h1 {
   margin-top: -5px;
+
+  &.site-title.amo {
+    margin: -29px 20px 0 0;
+
+    .html-rtl & {
+      margin: -29px 0 0 20px;
+    }
+  }
 }
 
 .addon-vitals .widgets .widget {
@@ -2097,6 +2105,11 @@ body.editor-tools {
     color: @link-on-color-bg;
   }
 
+  .editor-menu {
+    margin-top: 30px;
+    width: 660px;
+  }
+
   .pill-nav-amo {
     border-radius: 0;
     background-color: transparent;
@@ -2120,8 +2133,8 @@ body.editor-tools {
   }
 
   #navbar ul li.top {
-    width: 20%;
     border-right: 0;
+    padding: 0 30px 0;
     text-align: center;
   }
 

--- a/static/css/zamboni/editors.styl
+++ b/static/css/zamboni/editors.styl
@@ -1001,8 +1001,8 @@ h2.addon {
     text-align: right;
 }
 
-.html-trl #reviewers-score-bar .number,
-.html-trl #leaderboard .number {
+.html-rtl #reviewers-score-bar .number,
+.html-rtl #leaderboard .number {
     text-align: left;
 }
 #leaderboard .name {
@@ -1023,6 +1023,10 @@ h2.addon {
 
 .site-title.amo {
     float: left;
+
+    .html-rtl & {
+        float: right;
+    }
 }
 #navbar {
     clear: left;
@@ -1037,8 +1041,6 @@ gradient-two-color($color1, $color2) {
     gradient-two-color(darken(#563C4B, 50%), darken(#563C4B, 30%));
     border-radius: 16px;
     display: inline-block;
-    left: 20px;
-    margin-top: 22px;
     padding: 8px 1px;
     position: relative;
     top: 9px;


### PR DESCRIPTION
Fixes #3171 
# ltr
## Before
![Before](https://cloud.githubusercontent.com/assets/15685960/17142890/58b665fa-535a-11e6-9480-2dcb40693226.png)
## After
![screenshot from 2016-09-16 06-04-49](https://cloud.githubusercontent.com/assets/8364578/18571358/9b9d7a1a-7bd3-11e6-88dc-8a2570a88cf9.png)
![screenshot from 2016-09-16 06-02-58](https://cloud.githubusercontent.com/assets/8364578/18571361/a28deb7a-7bd3-11e6-9bc0-074097bc8e69.png)
# rtl
## Before
![screenshot from 2016-09-16 06-17-31](https://cloud.githubusercontent.com/assets/8364578/18571612/86d38668-7bd5-11e6-98f6-8569d9cbe8d5.png)
## After
![screenshot from 2016-09-16 06-04-02](https://cloud.githubusercontent.com/assets/8364578/18571368/b59ebf00-7bd3-11e6-80d6-89ef33d1d98d.png)

@tofumatt please check if it's enough cute. Although not sure if it's the best solution. 