### PR TITLE
Filter reviews API list to show only latest reviews by the same user/addon

### DIFF
--- a/docs/topics/api/reviews.rst
+++ b/docs/topics/api/reviews.rst
@@ -61,9 +61,11 @@ This endpoint allows you to fetch a review by its id.
 
     :>json int id: The review id.
     :>json string|null body: The text of the review.
-    :>json string|null title: The title of the review.
+    :>json boolean is_latest: Boolean indicating whether the review is the latest posted by the user on the same add-on.
+    :>json int previous_count: The number of reviews posted by the user on the same add-on before this one.
     :>json int rating: The rating the user gave as part of the review.
     :>json object|null reply: The review object containing the developer reply to this review, if any (The fields ``rating``, ``reply`` and ``version`` are omitted).
+    :>json string|null title: The title of the review.
     :>json string version: The add-on version string the review applies to.
     :>json object user: Object holding information about the user who posted the review.
     :>json string user.url: The user profile URL.

--- a/src/olympia/reviews/serializers.py
+++ b/src/olympia/reviews/serializers.py
@@ -18,10 +18,13 @@ class BaseReviewSerializer(serializers.ModelSerializer):
     body = serializers.CharField(allow_null=True, required=False)
     title = serializers.CharField(allow_null=True, required=False)
     user = BaseUserSerializer(read_only=True)
+    is_latest = serializers.BooleanField(read_only=True)
+    previous_count = serializers.IntegerField(read_only=True)
 
     class Meta:
         model = Review
-        fields = ('id', 'body', 'created', 'title', 'user')
+        fields = ('id', 'body', 'created', 'is_latest', 'previous_count',
+                  'title', 'user')
 
     def validate(self, data):
         data = super(BaseReviewSerializer, self).validate(data)

--- a/src/olympia/reviews/tests/test_serializers.py
+++ b/src/olympia/reviews/tests/test_serializers.py
@@ -31,6 +31,8 @@ class TestBaseReviewSerializer(TestCase):
         assert result['body'] == unicode(self.review.body)
         assert result['created'] == self.review.created.isoformat()
         assert result['title'] == unicode(self.review.title)
+        assert result['previous_count'] == int(self.review.previous_count)
+        assert result['is_latest'] == self.review.is_latest
         assert result['rating'] == int(self.review.rating)
         assert result['reply'] is None
         assert result['user'] == {
@@ -42,6 +44,19 @@ class TestBaseReviewSerializer(TestCase):
         self.review.update(version=None)
         result = self.serialize()
         assert result['version'] is None
+
+    def test_with_previous_count(self):
+        addon = addon_factory()
+        self.review = Review.objects.create(
+            addon=addon, user=self.user, rating=4,
+            version=addon.current_version, body=u'This is my rëview. Like ît?',
+            title=u'My Review Titlé')
+        self.review.update(is_latest=False, previous_count=42)
+        result = self.serialize()
+
+        assert result['id'] == self.review.pk
+        assert result['previous_count'] == 42
+        assert result['is_latest'] is False
 
     def test_with_reply(self):
         addon = addon_factory()

--- a/src/olympia/reviews/views.py
+++ b/src/olympia/reviews/views.py
@@ -383,7 +383,7 @@ class ReviewViewSet(AddonChildMixin, ModelViewSet):
     def filter_queryset(self, qs):
         if self.action == 'list':
             if 'addon_pk' in self.kwargs:
-                qs = qs.filter(addon=self.get_addon_object())
+                qs = qs.filter(is_latest=True, addon=self.get_addon_object())
             elif 'account_pk' in self.kwargs:
                 qs = qs.filter(user=self.kwargs.get('account_pk'))
             else:


### PR DESCRIPTION
Also add `is_latest` and `previous_count` information to the serialization.

Fix #3458