### PR TITLE
Support development FxA config on dev

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -112,10 +112,10 @@ FXA_CONFIG = {
     },
 }
 FXA_CONFIG['amo'] = FXA_CONFIG['internal']
-FXA_CONFIG['development'] = FXA_CONFIG['internal']
+FXA_CONFIG['local'] = FXA_CONFIG['internal']
 DEFAULT_FXA_CONFIG_NAME = 'default'
 INTERNAL_FXA_CONFIG_NAME = 'internal'
-ALLOWED_FXA_CONFIGS = ['default', 'amo', 'development']
+ALLOWED_FXA_CONFIGS = ['default', 'amo', 'local']
 
 # CSP report endpoint which returns a 204 from addons-nginx in local dev.
 CSP_REPORT_URI = '/csp-report'

--- a/settings.py
+++ b/settings.py
@@ -112,6 +112,11 @@ FXA_CONFIG = {
     },
 }
 FXA_CONFIG['amo'] = FXA_CONFIG['internal']
+FXA_CONFIG['development'] = FXA_CONFIG['internal']
+DEFAULT_FXA_CONFIG_NAME = 'default'
+INTERNAL_FXA_CONFIG_NAME = 'internal'
+ALLOWED_FXA_CONFIGS = ['default', 'amo', 'development']
+
 
 # CSP report endpoint which returns a 204 from addons-nginx in local dev.
 CSP_REPORT_URI = '/csp-report'

--- a/settings.py
+++ b/settings.py
@@ -117,7 +117,6 @@ DEFAULT_FXA_CONFIG_NAME = 'default'
 INTERNAL_FXA_CONFIG_NAME = 'internal'
 ALLOWED_FXA_CONFIGS = ['default', 'amo', 'development']
 
-
 # CSP report endpoint which returns a 204 from addons-nginx in local dev.
 CSP_REPORT_URI = '/csp-report'
 

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -174,7 +174,7 @@ class TestLoginView(BaseAuthenticationView):
     def test_correct_config_is_used(self):
         assert views.LoginView.DEFAULT_FXA_CONFIG_NAME == 'default'
         assert views.LoginView.ALLOWED_FXA_CONFIGS == (
-            ['default', 'amo', 'development'])
+            ['default', 'amo', 'local'])
 
     def test_cors_addons_frontend(self):
         response = self.options(self.url, origin='https://addons-frontend')
@@ -200,7 +200,7 @@ class TestLoginStartView(TestCase):
     def test_default_config_is_used(self):
         assert views.LoginStartView.DEFAULT_FXA_CONFIG_NAME == 'default'
         assert views.LoginStartView.ALLOWED_FXA_CONFIGS == (
-            ['default', 'amo', 'development'])
+            ['default', 'amo', 'local'])
 
 
 class TestLoginUser(TestCase):

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -173,7 +173,8 @@ class TestLoginView(BaseAuthenticationView):
 
     def test_correct_config_is_used(self):
         assert views.LoginView.DEFAULT_FXA_CONFIG_NAME == 'default'
-        assert views.LoginView.ALLOWED_FXA_CONFIGS == ['default', 'amo']
+        assert views.LoginView.ALLOWED_FXA_CONFIGS == (
+            ['default', 'amo', 'development'])
 
     def test_cors_addons_frontend(self):
         response = self.options(self.url, origin='https://addons-frontend')
@@ -198,7 +199,8 @@ class TestLoginStartView(TestCase):
 
     def test_default_config_is_used(self):
         assert views.LoginStartView.DEFAULT_FXA_CONFIG_NAME == 'default'
-        assert views.LoginStartView.ALLOWED_FXA_CONFIGS == ['default', 'amo']
+        assert views.LoginStartView.ALLOWED_FXA_CONFIGS == (
+            ['default', 'amo', 'development'])
 
 
 class TestLoginUser(TestCase):

--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -261,7 +261,19 @@ FXA_CONFIG = {
         'redirect_url': 'https://amo.dev.mozaws.net/fxa-authenticate',
         'scope': 'profile',
     },
+    'development': {
+        'client_id': env('DEVELOPMENT_FXA_CLIENT_ID'),
+        'client_secret': env('DEVELOPMENT_FXA_CLIENT_SECRET'),
+        'content_host': 'https://stable.dev.lcip.org',
+        'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
+        'profile_host': 'https://stable.dev.lcip.org/profile/v1',
+        'redirect_url': 'http://localhost:3000/fxa-authenticate',
+        'scope': 'profile',
+    },
 }
+DEFAULT_FXA_CONFIG_NAME = 'default'
+INTERNAL_FXA_CONFIG_NAME = 'internal'
+ALLOWED_FXA_CONFIGS = ['default', 'amo', 'development']
 
 INTERNAL_DOMAINS = [
     'addons-admin.dev.mozaws.net',

--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -261,7 +261,7 @@ FXA_CONFIG = {
         'redirect_url': 'https://amo.dev.mozaws.net/fxa-authenticate',
         'scope': 'profile',
     },
-    'development': {
+    'local': {
         'client_id': env('DEVELOPMENT_FXA_CLIENT_ID'),
         'client_secret': env('DEVELOPMENT_FXA_CLIENT_SECRET'),
         'content_host': 'https://stable.dev.lcip.org',
@@ -273,7 +273,7 @@ FXA_CONFIG = {
 }
 DEFAULT_FXA_CONFIG_NAME = 'default'
 INTERNAL_FXA_CONFIG_NAME = 'internal'
-ALLOWED_FXA_CONFIGS = ['default', 'amo', 'development']
+ALLOWED_FXA_CONFIGS = ['default', 'amo', 'local']
 
 INTERNAL_DOMAINS = [
     'addons-admin.dev.mozaws.net',

--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -217,6 +217,9 @@ FXA_CONFIG = {
     },
 }
 FXA_CONFIG['amo'] = FXA_CONFIG['default']
+DEFAULT_FXA_CONFIG_NAME = 'default'
+INTERNAL_FXA_CONFIG_NAME = 'internal'
+ALLOWED_FXA_CONFIGS = ['default', 'amo']
 
 INTERNAL_DOMAINS = ['addons-admin.prod.mozaws.net']
 for regex, overrides in CORS_ENDPOINT_OVERRIDES:

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -249,6 +249,9 @@ FXA_CONFIG = {
     },
 }
 FXA_CONFIG['amo'] = FXA_CONFIG['default']
+DEFAULT_FXA_CONFIG_NAME = 'default'
+INTERNAL_FXA_CONFIG_NAME = 'internal'
+ALLOWED_FXA_CONFIGS = ['default', 'amo']
 
 INTERNAL_DOMAINS = ['addons-admin.stage.mozaws.net']
 for regex, overrides in CORS_ENDPOINT_OVERRIDES:

--- a/src/olympia/internal_tools/views.py
+++ b/src/olympia/internal_tools/views.py
@@ -1,5 +1,7 @@
 import logging
 
+from django.conf import settings
+
 from olympia.accounts.views import LoginBaseView, LoginStartBaseView
 from olympia.addons.views import AddonSearchView
 from olympia.api.authentication import JSONWebTokenAuthentication
@@ -27,8 +29,8 @@ class InternalAddonSearchView(AddonSearchView):
 
 
 class LoginStartView(LoginStartBaseView):
-    DEFAULT_FXA_CONFIG_NAME = 'internal'
+    DEFAULT_FXA_CONFIG_NAME = settings.INTERNAL_FXA_CONFIG_NAME
 
 
 class LoginView(LoginBaseView):
-    DEFAULT_FXA_CONFIG_NAME = 'internal'
+    DEFAULT_FXA_CONFIG_NAME = settings.INTERNAL_FXA_CONFIG_NAME


### PR DESCRIPTION
This allows a development FxA config to be used for the AMO frontend in development. This should allow logging in against -dev out of the box.

The environment variables will need to be set before this can be merged or builds will break.