### PR TITLE
CC specified users (i.e. staff) on all Activity emails

### DIFF
--- a/src/olympia/migrations/899-add-activity-cc-group.sql
+++ b/src/olympia/migrations/899-add-activity-cc-group.sql
@@ -1,0 +1,4 @@
+INSERT INTO groups (name, rules, notes, created, modified) VALUES
+  ('Activity Mail CC', 'None:None',
+   'These users will get a copy of all Activity mail replies.  Membership of the group gives no permissions',
+   NOW(), NOW());


### PR DESCRIPTION
Fixes #3557 