### PR TITLE
Use default FxA config on stage and prod for amo

### DIFF
--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -215,16 +215,8 @@ FXA_CONFIG = {
             'https://addons-admin.prod.mozaws.net/fxa-authenticate',
         'scope': 'profile',
     },
-    'amo': {
-        'client_id': env('AMO_FXA_CLIENT_ID'),
-        'client_secret': env('AMO_FXA_CLIENT_SECRET'),
-        'content_host': 'https://accounts.firefox.com',
-        'oauth_host': 'https://oauth.accounts.firefox.com/v1',
-        'profile_host': 'https://profile.accounts.firefox.com/v1',
-        'redirect_url': 'https://amo.prod.mozaws.net/fxa-authenticate',
-        'scope': 'profile',
-    },
 }
+FXA_CONFIG['amo'] = FXA_CONFIG['default']
 
 INTERNAL_DOMAINS = ['addons-admin.prod.mozaws.net']
 for regex, overrides in CORS_ENDPOINT_OVERRIDES:

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -247,16 +247,8 @@ FXA_CONFIG = {
             'https://addons-admin.stage.mozaws.net/fxa-authenticate',
         'scope': 'profile',
     },
-    'amo': {
-        'client_id': env('AMO_FXA_CLIENT_ID'),
-        'client_secret': env('AMO_FXA_CLIENT_SECRET'),
-        'content_host': 'https://accounts.firefox.com',
-        'oauth_host': 'https://oauth.accounts.firefox.com/v1',
-        'profile_host': 'https://profile.accounts.firefox.com/v1',
-        'redirect_url': 'https://amo.stage.mozaws.net/fxa-authenticate',
-        'scope': 'profile',
-    },
 }
+FXA_CONFIG['amo'] = FXA_CONFIG['default']
 
 INTERNAL_DOMAINS = ['addons-admin.stage.mozaws.net']
 for regex, overrides in CORS_ENDPOINT_OVERRIDES:


### PR DESCRIPTION
This should fix the issue where stage and prod are looking for AMO credentials that we don't have.