### PR TITLE
Refactor the way Review logging/notifications are made

### DIFF
--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -748,7 +748,8 @@ user_factory_counter = 0
 def user_factory(**kw):
     global user_factory_counter
     username = kw.pop('username', u'factoryûser%d' % user_factory_counter)
-    email = kw.pop('email', 'factoryuser%d@mozilla.com' % user_factory_counter)
+    email = kw.pop(
+        'email', u'factoryuser%d@mozîlla.com' % user_factory_counter)
     user = UserProfile.objects.create(username=username, email=email, **kw)
 
     if 'username' not in kw:

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -748,9 +748,8 @@ user_factory_counter = 0
 def user_factory(**kw):
     global user_factory_counter
     username = kw.pop('username', u'factoryûser%d' % user_factory_counter)
-
-    user = UserProfile.objects.create(
-        username=username, email='%s@mozilla.com' % username, **kw)
+    email = kw.pop('email', 'factoryuser%d@mozilla.com' % user_factory_counter)
+    user = UserProfile.objects.create(username=username, email=email, **kw)
 
     if 'username' not in kw:
         user_factory_counter = user.id + 1

--- a/src/olympia/reviews/fixtures/reviews/test_models.json
+++ b/src/olympia/reviews/fixtures/reviews/test_models.json
@@ -33,13 +33,24 @@
         }
     },
     {
+        "pk": 5,
+        "model": "translations.translation",
+        "fields": {
+            "locale": "en-us",
+            "created": "2009-12-22 20:12:06",
+            "id": 4,
+            "modified": "2009-12-22 20:12:06",
+            "localized_string": "my addon name"
+        }
+    },
+    {
         "pk": 1,
         "model": "users.userprofile",
         "fields": {
             "created": "2009-10-19 06:21:02",
             "modified": "2009-10-19 06:21:02",
-            "username": "nobody",
-            "email": "nobody@mozilla.org"
+            "username": "no one",
+            "email": "arya@example.com"
         }
     },
     {
@@ -51,7 +62,7 @@
             "slug": "a4",
             "description": null,
             "modified": "2008-05-22 11:59:13",
-            "name": null,
+            "name": 4,
             "created": "2004-06-11 18:23:31",
             "_current_version": 592,
             "last_updated": "2010-01-14 14:15:28"

--- a/src/olympia/reviews/forms.py
+++ b/src/olympia/reviews/forms.py
@@ -8,9 +8,8 @@ from django.utils.translation import ugettext_lazy as _lazy
 from bleach import TLDS
 from quieter_formset.formset import BaseModelFormSet
 
-from olympia import amo, reviews
+from olympia import reviews
 from olympia.amo.utils import raise_required
-from olympia.editors.models import ReviewerScore
 from olympia.lib import happyforms
 
 from .models import Review, ReviewFlag
@@ -99,7 +98,6 @@ class ReviewFlagForm(forms.ModelForm):
 class BaseReviewFlagFormSet(BaseModelFormSet):
 
     def __init__(self, *args, **kwargs):
-        self.form = ModerateReviewFlagForm
         self.request = kwargs.pop('request', None)
         super(BaseReviewFlagFormSet, self).__init__(*args, **kwargs)
 
@@ -111,37 +109,10 @@ class BaseReviewFlagFormSet(BaseModelFormSet):
                                                             form.instance):
                 action = int(form.cleaned_data['action'])
 
-                is_flagged = (form.instance.reviewflag_set.count() > 0)
-
-                if action != reviews.REVIEW_MODERATE_SKIP:  # Delete flags.
-                    for flag in form.instance.reviewflag_set.all():
-                        flag.delete()
-
-                review = form.instance
-                addon = review.addon
                 if action == reviews.REVIEW_MODERATE_DELETE:
-                    review.delete()
-                    amo.log(amo.LOG.DELETE_REVIEW, addon, review,
-                            details=dict(title=unicode(review.title),
-                                         body=unicode(review.body),
-                                         addon_id=addon.id,
-                                         addon_title=unicode(addon.name),
-                                         is_flagged=is_flagged))
-                    if self.request:
-                        ReviewerScore.award_moderation_points(
-                            self.request.user, addon, review.id)
+                    form.instance.moderator_delete(user=self.request.user)
                 elif action == reviews.REVIEW_MODERATE_KEEP:
-                    review.editorreview = False
-                    review.save()
-                    amo.log(amo.LOG.APPROVE_REVIEW, addon, review,
-                            details=dict(title=unicode(review.title),
-                                         body=unicode(review.body),
-                                         addon_id=addon.id,
-                                         addon_title=unicode(addon.name),
-                                         is_flagged=is_flagged))
-                    if self.request:
-                        ReviewerScore.award_moderation_points(
-                            self.request.user, addon, review.id)
+                    form.instance.moderator_approve(user=self.request.user)
 
 
 class ModerateReviewFlagForm(happyforms.ModelForm):

--- a/src/olympia/reviews/tests/test_models.py
+++ b/src/olympia/reviews/tests/test_models.py
@@ -1,10 +1,14 @@
+# -*- coding: utf-8 -*-
 import mock
 
+from django.core import mail
 from django.utils import translation
 
 from olympia import amo
+from olympia.amo import helpers
 from olympia.amo.tests import addon_factory, TestCase, ESTestCase, user_factory
 from olympia.addons.models import Addon
+from olympia.devhub.models import ActivityLog
 from olympia.reviews import tasks
 from olympia.reviews.models import (
     check_spam, GroupedRating, Review, ReviewFlag, Spam)
@@ -48,6 +52,28 @@ class TestReviewModel(TestCase):
         review = Review.objects.get(id=2)
         assert review.previous_count == 0
         assert review.is_latest is True
+
+    @mock.patch('olympia.reviews.models.log')
+    def test_soft_delete_user_responsible(self, log_mock):
+        user_responsible = user_factory()
+        review = Review.objects.get(id=1)
+        review.delete(user_responsible=user_responsible)
+        assert log_mock.info.call_count == 1
+        assert (log_mock.info.call_args[0][0] ==
+                'Review deleted: %s deleted id:%s by %s ("%s": "%s")')
+        assert log_mock.info.call_args[0][1] == user_responsible.name
+        assert log_mock.info.call_args[0][2] == review.pk
+        assert log_mock.info.call_args[0][3] == review.user.name
+        assert log_mock.info.call_args[0][4] == unicode(review.title)
+        assert log_mock.info.call_args[0][5] == unicode(review.body)
+
+    def test_hard_delete(self):
+        # Hard deletion is only for tests, but it's still useful to make sure
+        # it's working properly.
+        assert Review.unfiltered.count() == 2
+        Review.objects.filter(id=1).delete(hard_delete=True)
+        assert Review.unfiltered.count() == 1
+        assert Review.objects.filter(id=2).exists()
 
     def test_undelete(self):
         self.test_soft_delete()
@@ -105,6 +131,93 @@ class TestReviewModel(TestCase):
         review.delete()
         flag = ReviewFlag.objects.get(pk=flag.pk)
         assert flag.review == review
+
+    def test_creation_triggers_email_and_logging(self):
+        addon = Addon.objects.get(pk=4)
+        addon_author = user_factory()
+        addon.addonuser_set.create(user=addon_author)
+        review_user = user_factory()
+        review = Review.objects.create(
+            user=review_user, addon=addon,
+            body=u'Rêviiiiiiew', user_responsible=review_user)
+
+        activity_log = ActivityLog.objects.latest('pk')
+        assert activity_log.user == review_user
+        assert activity_log.arguments == [addon, review]
+        assert activity_log.action == amo.LOG.ADD_REVIEW.id
+
+        assert len(mail.outbox) == 1
+        email = mail.outbox[0]
+        reply_url = helpers.absolutify(
+            helpers.url('addons.reviews.reply', addon.slug,
+                        review.pk, add_prefix=False))
+        assert email.subject == 'Mozilla Add-on User Review: my addon name'
+        assert 'A user has left a review for your add-on,' in email.body
+        assert 'my addon name' in email.body
+        assert reply_url in email.body
+        assert email.to == [addon_author.email]
+        assert email.from_email == 'Mozilla Add-ons <nobody@mozilla.org>'
+
+    def test_reply_triggers_email_but_no_logging(self):
+        review = Review.objects.get(id=1)
+        user = user_factory()
+        Review.objects.create(
+            reply_to=review, user=user, addon=review.addon,
+            body=u'Rêply', user_responsible=user)
+
+        assert not ActivityLog.objects.exists()
+        assert len(mail.outbox) == 1
+        email = mail.outbox[0]
+        reply_url = helpers.absolutify(
+            helpers.url('addons.reviews.detail', review.addon.slug,
+                        review.pk, add_prefix=False))
+        assert email.subject == 'Mozilla Add-on Developer Reply: my addon name'
+        assert 'A developer has replied to your review' in email.body
+        assert 'add-on my addon name' in email.body
+        assert reply_url in email.body
+        assert email.to == ['arya@example.com']
+        assert email.from_email == 'Mozilla Add-ons <nobody@mozilla.org>'
+
+    def test_edit_triggers_logging_but_no_email(self):
+        review = Review.objects.get(id=1)
+        assert not ActivityLog.objects.exists()
+        assert mail.outbox == []
+
+        review.user_responsible = review.user
+        review.body = u'Editëd...'
+        review.save()
+
+        activity_log = ActivityLog.objects.latest('pk')
+        assert activity_log.user == review.user
+        assert activity_log.arguments == [review.addon, review]
+        assert activity_log.action == amo.LOG.EDIT_REVIEW.id
+
+        assert mail.outbox == []
+
+    def test_edit_reply_triggers_logging_but_no_email(self):
+        review = Review.objects.get(id=1)
+        reply = Review.objects.create(
+            reply_to=review, user=user_factory(), addon=review.addon)
+        assert not ActivityLog.objects.exists()
+        assert mail.outbox == []
+
+        reply.user_responsible = reply.user
+        reply.body = u'Actuälly...'
+        reply.save()
+
+        activity_log = ActivityLog.objects.latest('pk')
+        assert activity_log.user == reply.user
+        assert activity_log.arguments == [reply.addon, reply]
+        assert activity_log.action == amo.LOG.EDIT_REVIEW.id
+
+        assert mail.outbox == []
+
+    def test_non_user_edit_triggers_nothing(self):
+        review = Review.objects.get(pk=1)
+        review.previous_count = 42
+        review.save()
+        assert not ActivityLog.objects.exists()
+        assert mail.outbox == []
 
 
 class TestGroupedRating(TestCase):

--- a/src/olympia/reviews/views.py
+++ b/src/olympia/reviews/views.py
@@ -7,7 +7,6 @@ from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.db.transaction import non_atomic_requests
 from django.shortcuts import get_object_or_404, redirect
-from django.template import Context, loader
 from django.utils.http import urlquote
 from django.utils.translation import ugettext as _
 
@@ -19,12 +18,11 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.viewsets import ModelViewSet
 from waffle.decorators import waffle_switch
 
-from olympia import amo
 from olympia.amo import messages
 from olympia.amo.decorators import (
     json_view, login_required, post_required, restricted_content)
 from olympia.amo import helpers
-from olympia.amo.utils import render, paginate, send_mail as amo_send_mail
+from olympia.amo.utils import render, paginate
 from olympia.access import acl
 from olympia.addons.decorators import addon_view_factory
 from olympia.addons.models import Addon
@@ -42,13 +40,6 @@ from . import forms
 
 log = commonware.log.getLogger('z.reviews')
 addon_view = addon_view_factory(qs=Addon.objects.valid)
-
-
-def send_mail(template, subject, emails, context, perm_setting):
-    template = loader.get_template(template)
-    amo_send_mail(
-        subject, template.render(Context(context, autoescape=False)),
-        recipient_list=emails, perm_setting=perm_setting)
 
 
 @addon_view
@@ -170,21 +161,29 @@ def delete(request, addon, review_id):
     review = get_object_or_404(Review.objects, pk=review_id, addon=addon)
     if not user_can_delete_review(request, review):
         raise PermissionDenied
-    review.delete()
-
-    log.info(u'Review deleted: %s deleted id:%s by %s ("%s": "%s")' %
-             (request.user.name, review_id, review.user.name, review.title,
-              review.body))
+    review.delete(user_responsible=request.user)
     return http.HttpResponse()
 
 
-def _review_details(request, addon, form):
-    version = addon.current_version and addon.current_version.id
-    d = dict(addon_id=addon.id, user_id=request.user.id,
-             version_id=version,
-             ip_address=request.META.get('REMOTE_ADDR', ''))
-    d.update(**form.cleaned_data)
-    return d
+def _review_details(request, addon, form, create=True):
+    data = {
+        # Always set deleted: False because when replying, you're actually
+        # editing the previous reply if it existed, even if it had been
+        # deleted.
+        'deleted': False,
+
+        # This field is not saved, but it helps the model know that the action
+        # should be logged.
+        'user_responsible': request.user,
+    }
+    if create:
+        # These fields should be set at creation time.
+        data['addon'] = addon
+        data['user'] = request.user
+        data['version'] = addon.current_version
+        data['ip_address'] = request.META.get('REMOTE_ADDR', '')
+    data.update(**form.cleaned_data)
+    return data
 
 
 @addon_view
@@ -198,27 +197,12 @@ def reply(request, addon, review_id):
     review = get_object_or_404(Review.objects, pk=review_id, addon=addon)
     form = forms.ReviewReplyForm(request.POST or None)
     if request.method == 'POST' and form.is_valid():
-        d = dict(reply_to=review, addon=addon,
-                 defaults=dict(user=request.user))
-        reply, new = Review.objects.get_or_create(**d)
-        for key, val in _review_details(request, addon, form).items():
-            setattr(reply, key, val)
-        reply.save()
-        action = 'New' if new else 'Edited'
-        log.debug('%s reply to %s: %s' % (action, review_id, reply.id))
-
-        if new:
-            reply_url = helpers.url('addons.reviews.detail', addon.slug,
-                                    review.id, add_prefix=False)
-            data = {'name': addon.name,
-                    'reply_title': reply.title,
-                    'reply': reply.body,
-                    'reply_url': helpers.absolutify(reply_url)}
-            emails = [review.user.email]
-            sub = u'Mozilla Add-on Developer Reply: %s' % addon.name
-            send_mail('reviews/emails/reply_review.ltxt',
-                      sub, emails, Context(data), 'reply')
-
+        kwargs = {
+            'reply_to': review,
+            'addon': addon,
+            'defaults': _review_details(request, addon, form)
+        }
+        reply, created = Review.unfiltered.update_or_create(**kwargs)
         return redirect(helpers.url('addons.reviews.detail', addon.slug,
                                     review_id))
     ctx = dict(review=review, form=form, addon=addon)
@@ -243,22 +227,6 @@ def add(request, addon, template=None):
                             flag=ReviewFlag.OTHER,
                             note='URLs')
             rf.save()
-
-        amo.log(amo.LOG.ADD_REVIEW, addon, review)
-        log.debug('New review: %s' % review.id)
-
-        reply_url = helpers.url('addons.reviews.reply', addon.slug, review.id,
-                                add_prefix=False)
-        data = {'name': addon.name,
-                'rating': '%s out of 5 stars' % details['rating'],
-                'review': details['body'],
-                'reply_url': helpers.absolutify(reply_url)}
-
-        emails = [a.email for a in addon.authors.all()]
-        send_mail('reviews/emails/add_review.ltxt',
-                  u'Mozilla Add-on User Review: %s' % addon.name,
-                  emails, Context(data), 'new_review')
-
         return redirect(helpers.url('addons.reviews.list', addon.slug))
     return render(request, template, dict(addon=addon, form=form))
 
@@ -275,10 +243,12 @@ def edit(request, addon, review_id):
     cls = forms.ReviewReplyForm if review.reply_to else forms.ReviewForm
     form = cls(request.POST)
     if form.is_valid():
-        for field in form.fields:
-            if field in form.cleaned_data:
-                setattr(review, field, form.cleaned_data[field])
-        amo.log(amo.LOG.EDIT_REVIEW, addon, review)
+        data = _review_details(request, addon, form, create=False)
+        for field, value in data.items():
+            setattr(review, field, value)
+        # Resist the temptation to use review.update(): it'd be more direct but
+        # doesn't work with extra fields that are not meant to be saved like
+        # 'user_responsible'.
         review.save()
         return {}
     else:
@@ -430,12 +400,16 @@ class ReviewViewSet(AddonChildMixin, ModelViewSet):
             self.queryset = Review.without_replies.all()
 
         qs = super(ReviewViewSet, self).get_queryset()
+        if self.action in ('list', 'retrieve'):
+            # Also avoid loading addon since we don't need it, we already
+            # loaded it for permission checks through the pk specified in the
+            # URL. Don't do it for write operations to avoid a bug in django
+            # 1.8 and signals (https://github.com/django/django/pull/7274)
+            qs = qs.defer('addon')
         # The serializer needs user, reply and version, so use
         # prefetch_related() to avoid extra queries (avoid select_related() as
-        # we need crazy joins already). Also avoid loading addon since we don't
-        # need it, we already loaded it for permission checks through the pk
-        # specified in the URL.
-        return qs.defer('addon').prefetch_related('reply', 'user', 'version')
+        # we need crazy joins already).
+        return qs.prefetch_related('reply', 'user', 'version')
 
     @detail_route(
         methods=['post'], permission_classes=reply_permission_classes,

--- a/src/olympia/users/tests/test_user_utils.py
+++ b/src/olympia/users/tests/test_user_utils.py
@@ -1,26 +1,39 @@
+# -*- coding: utf-8 -*-
 import mock
 
 from django.conf import settings
 
 from olympia.amo.tests import TestCase
 from olympia.users.models import BlacklistedName, UserProfile
-from olympia.users.utils import EmailResetCode, autocreate_username
+from olympia.users.utils import (
+    autocreate_username, EmailResetCode, UnsubscribeCode)
 
 
-class TestEmailResetCode(TestCase):
+class TestEmailResetAndUnsubscribeCode(TestCase):
 
-    def test_parse(self):
-        id = 1
-        mail = 'nobody@mozilla.org'
-        token, hash = EmailResetCode.create(id, mail)
+    def test_email_reset_code_parse(self):
+        user_id = 4815162342
+        email = 'nobody@mozîlla.org'
+        token, hash_ = EmailResetCode.create(user_id, email)
 
-        r_id, r_mail = EmailResetCode.parse(token, hash)
-        assert id == r_id
-        assert mail == r_mail
+        r_id, r_email = EmailResetCode.parse(token, hash_)
+        assert user_id == r_id
+        assert email == r_email
 
         # A bad token or hash raises ValueError
-        self.assertRaises(ValueError, EmailResetCode.parse, token, hash[:-5])
-        self.assertRaises(ValueError, EmailResetCode.parse, token[5:], hash)
+        self.assertRaises(ValueError, EmailResetCode.parse, token, hash_[:-5])
+        self.assertRaises(ValueError, EmailResetCode.parse, token[5:], hash_)
+
+    def test_email_unsubscribe_code_parse(self):
+        email = 'nobody@mozîlla.org'
+        token, hash_ = UnsubscribeCode.create(email)
+
+        r_email = UnsubscribeCode.parse(token, hash_)
+        assert email == r_email
+
+        # A bad token or hash raises ValueError
+        self.assertRaises(ValueError, UnsubscribeCode.parse, token, hash_[:-5])
+        self.assertRaises(ValueError, UnsubscribeCode.parse, token[5:], hash_)
 
 
 class TestAutoCreateUsername(TestCase):


### PR DESCRIPTION
The key difference is that logging and email notifications are now made at the models level and not in the view. This allows API to properly trigger logging and emails while staying DRY.

Fix #3444