### PR TITLE
Define FxA config names in settings_base.py

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -113,8 +113,6 @@ FXA_CONFIG = {
 }
 FXA_CONFIG['amo'] = FXA_CONFIG['internal']
 FXA_CONFIG['local'] = FXA_CONFIG['internal']
-DEFAULT_FXA_CONFIG_NAME = 'default'
-INTERNAL_FXA_CONFIG_NAME = 'internal'
 ALLOWED_FXA_CONFIGS = ['default', 'amo', 'local']
 
 # CSP report endpoint which returns a 204 from addons-nginx in local dev.

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1668,3 +1668,7 @@ SENTRY_DSN = os.environ.get('SENTRY_DSN')
 SHELL_PLUS_POST_IMPORTS = (
     ('olympia', 'amo'),
 )
+
+DEFAULT_FXA_CONFIG_NAME = 'default'
+INTERNAL_FXA_CONFIG_NAME = 'internal'
+ALLOWED_FXA_CONFIGS = ['default']


### PR DESCRIPTION
The docker build is breaking, this should fix it.