### PR TITLE
Force tox to always recreate flake8 env to make sure changes to flake8.txt are used

### DIFF
--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -3151,7 +3151,7 @@ class TestVersionXSS(UploadTest):
 
 class UploadAddon(object):
 
-    def post(self, supported_platforms=[amo.PLATFORM_ALL], expect_errors=False,
+    def post(self, supported_platforms=None, expect_errors=False,
              source=None, is_listed=True, status_code=200):
         if supported_platforms is None:
             supported_platforms = [amo.PLATFORM_ALL]

--- a/tox.ini
+++ b/tox.ini
@@ -63,6 +63,7 @@ commands =
     make update_assets
 
 [testenv:flake8]
+recreate = True
 deps =
     -rrequirements/flake8.txt
 commands = make flake8


### PR DESCRIPTION
Other envs do `make update_deps` before running their tests and therefore don't suffer from that issue.