### PR TITLE
warn about strict min version, bug 1297752

### DIFF
--- a/src/olympia/applications/templates/applications/appversions.html
+++ b/src/olympia/applications/templates/applications/appversions.html
@@ -15,6 +15,10 @@ one of the below applications supported. Only the versions listed below are
 allowed for these applications.
 {% endtrans %}</p>
 
+<p>{% trans version_url=_('https://developer.mozilla.org/Add-ons/WebExtensions/manifest.json/applications') %}
+  Please be aware that WebExtensions will not accept a "*" in <a href="{{ version_url }}">strict_min_version</a>.
+{% endtrans %}</p>
+
 {% for app in apps %}
 <div class="appversion prose">
   <h3>


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1297752 and https://bugzilla.mozilla.org/show_bug.cgi?id=1298923, also updated the MDN page. Validator was updated in mozilla/addons-linter#914