### PR TITLE
Make the review API handle replying when a reply was already posted but was deleted

### DIFF
--- a/src/olympia/reviews/serializers.py
+++ b/src/olympia/reviews/serializers.py
@@ -74,6 +74,10 @@ class ReviewSerializerReply(BaseReviewSerializer):
         # review_object is set on the view by the reply() method.
         data['reply_to'] = self.context['view'].review_object
 
+        # When a reply is made on top of an existing deleted reply, we make
+        # an edit instead, so we need to make sure `deleted` is reset.
+        data['deleted'] = False
+
         if data['reply_to'].reply_to:
             # Only one level of replying is allowed, so if it's already a
             # reply, we shouldn't allow that.

--- a/src/olympia/reviews/tests/test_views.py
+++ b/src/olympia/reviews/tests/test_views.py
@@ -1746,6 +1746,43 @@ class TestReviewViewSetReply(TestCase):
 
         assert len(mail.outbox) == 1
 
+    def test_reply_if_a_reply_already_exists_updates_existing(self):
+        self.addon_author = user_factory()
+        self.addon.addonuser_set.create(user=self.addon_author)
+        existing_reply = Review.objects.create(
+            reply_to=self.review, user=self.addon_author,
+            addon=self.addon, body=u'My existing rêply')
+        self.client.login_api(self.addon_author)
+        response = self.client.post(self.url, data={
+            'body': u'My réply...',
+        })
+        assert response.status_code == 200
+        data = json.loads(response.content)
+        assert Review.objects.count() == 2
+        existing_reply.reload()
+        assert unicode(existing_reply.body) == data['body'] == u'My réply...'
+
+    def test_reply_if_an_existing_reply_was_deleted_updates_existing(self):
+        self.addon_author = user_factory()
+        self.addon.addonuser_set.create(user=self.addon_author)
+        existing_reply = Review.objects.create(
+            reply_to=self.review, user=self.addon_author,
+            addon=self.addon, body=u'My existing rêply')
+        existing_reply.delete()  # Soft delete the existing reply.
+        assert Review.objects.count() == 1
+        assert Review.unfiltered.count() == 2
+        self.client.login_api(self.addon_author)
+        response = self.client.post(self.url, data={
+            'body': u'My réply...',
+        })
+        assert response.status_code == 200
+        data = json.loads(response.content)
+        assert Review.objects.count() == 2  # No longer deleted.
+        assert Review.unfiltered.count() == 2
+        existing_reply.reload()
+        assert unicode(existing_reply.body) == data['body'] == u'My réply...'
+        assert existing_reply.deleted is False
+
     def test_reply_disabled_addon(self):
         self.addon_author = user_factory()
         self.addon.addonuser_set.create(user=self.addon_author)

--- a/src/olympia/reviews/views.py
+++ b/src/olympia/reviews/views.py
@@ -375,25 +375,26 @@ class ReviewViewSet(AddonChildMixin, ModelViewSet):
 
         # Add this as a property of the view, because we need to pass down the
         # information to the serializer to show/hide delete replies.
-        self.should_access_deleted_reviews = (
-            (requested == 'with_deleted' or self.action != 'list') and
-            self.request.user.is_authenticated() and
-            acl.action_allowed(self.request, 'Addons', 'Edit'))
+        if not hasattr(self, 'should_access_deleted_reviews'):
+            self.should_access_deleted_reviews = (
+                (requested == 'with_deleted' or self.action != 'list') and
+                self.request.user.is_authenticated() and
+                acl.action_allowed(self.request, 'Addons', 'Edit'))
 
-        should_access_only_replies = (
+        should_access_only_top_level_reviews = (
             self.action == 'list' and self.kwargs.get('addon_pk'))
 
         if self.should_access_deleted_reviews:
-            # For admins. When listing, we include deleted reviews but still
-            # filter out out replies, because they'll be in the serializer
-            # anyway. For other actions, we simply remove any filtering,
-            # allowing them to access any review out of the box with no
-            # extra parameter needed.
+            # For admins or add-on authors replying. When listing, we include
+            # deleted reviews but still filter out out replies, because they'll
+            # be in the serializer anyway. For other actions, we simply remove
+            # any filtering, allowing them to access any review out of the box
+            # with no extra parameter needed.
             if self.action == 'list':
                 self.queryset = Review.unfiltered.filter(reply_to__isnull=True)
             else:
                 self.queryset = Review.unfiltered.all()
-        elif should_access_only_replies:
+        elif should_access_only_top_level_reviews:
             # When listing add-on reviews, exclude replies, they'll be
             # included during serialization as children of the relevant
             # reviews instead.
@@ -419,6 +420,13 @@ class ReviewViewSet(AddonChildMixin, ModelViewSet):
         # FK to the current review object and only allow add-on authors/admins.
         # Call get_object() to trigger 404 if it does not exist.
         self.review_object = self.get_object()
+        if Review.unfiltered.filter(reply_to=self.review_object).exists():
+            # A reply already exists, just edit it.
+            # We set should_access_deleted_reviews so that it works even if
+            # the reply has been deleted.
+            self.kwargs['pk'] = kwargs['pk'] = self.review_object.reply.pk
+            self.should_access_deleted_reviews = True
+            return self.partial_update(*args, **kwargs)
         return self.create(*args, **kwargs)
 
     @detail_route(methods=['post'])


### PR DESCRIPTION
See mozilla/addons#158.

I already implemented it for the legacy view in https://github.com/mozilla/addons-server/commit/188b5099789d6bbc1463a8eccedfe67dd1ffb061 but the API didn't have it.