### PR TITLE
Fix firefox logo alignment in RTL (fixes #3590)

### DIFF
--- a/static/css/impala/header.less
+++ b/static/css/impala/header.less
@@ -390,6 +390,9 @@
                 padding-right: 24px;
             }
         }
+        .firefox a {
+            background-position: right 5px;
+        }
         .thunderbird a {
             background-position: right -28px;
         }


### PR DESCRIPTION
Fixes #3590 
### Before
![Before](https://cloud.githubusercontent.com/assets/15685960/18861720/10ff79ce-8490-11e6-9eaa-7420263e10a2.png)
### After
![after](https://cloud.githubusercontent.com/assets/8364578/18877725/e5f6d636-84ef-11e6-8b81-3435e8836099.png)
