### PR TITLE
Custom createsuperuser command without password

### DIFF
--- a/src/olympia/users/management/commands/createsuperuser.py
+++ b/src/olympia/users/management/commands/createsuperuser.py
@@ -14,7 +14,11 @@ from django.utils.text import capfirst
 
 
 class Command(BaseCommand):
-    help = 'Used to create a superuser.'
+    help = '''
+Used to create a superuser. This is similar to django's createsuperuser
+command but it doesn't support any arguments. This will prompt for a username
+and email address and that's it.
+'''
     required_fields = ['username', 'email']
 
     def handle(self, *args, **options):

--- a/src/olympia/users/management/commands/createsuperuser.py
+++ b/src/olympia/users/management/commands/createsuperuser.py
@@ -1,0 +1,39 @@
+"""
+Management utility to create superusers.
+"""
+from __future__ import unicode_literals
+
+from django.contrib.auth import get_user_model
+from django.core import exceptions
+from django.core.management.base import BaseCommand
+from django.utils.six.moves import input
+from django.utils.text import capfirst
+
+
+class Command(BaseCommand):
+    help = 'Used to create a superuser.'
+    required_fields = ['username', 'email']
+
+    def __init__(self, *args, **kwargs):
+        super(Command, self).__init__(*args, **kwargs)
+        self.UserModel = get_user_model()
+
+    def handle(self, *args, **options):
+        user_data = {
+            field_name: self.get_value(field_name)
+            for field_name in self.required_fields
+        }
+        self.UserModel._default_manager.create_superuser(
+            password=None, **user_data)
+
+    def get_value(self, field_name):
+        field = self.UserModel._meta.get_field(field_name)
+        value = None
+        while value is None:
+            raw_value = input('{}: '.format(capfirst(field_name)))
+            try:
+                value = field.clean(raw_value, None)
+            except exceptions.ValidationError as e:
+                self.stderr.write('Error: {}'.format('; '.join(e.messages)))
+                value = None
+        return value

--- a/src/olympia/users/management/commands/createsuperuser.py
+++ b/src/olympia/users/management/commands/createsuperuser.py
@@ -22,12 +22,11 @@ and email address and that's it.
     required_fields = ['username', 'email']
 
     def handle(self, *args, **options):
-        UserModel = get_user_model()
         user_data = {
             field_name: self.get_value(field_name)
             for field_name in self.required_fields
         }
-        UserModel._default_manager.create_superuser(
+        get_user_model()._default_manager.create_superuser(
             password=None, **user_data)
 
     def get_value(self, field_name):

--- a/src/olympia/users/management/commands/createsuperuser.py
+++ b/src/olympia/users/management/commands/createsuperuser.py
@@ -17,20 +17,17 @@ class Command(BaseCommand):
     help = 'Used to create a superuser.'
     required_fields = ['username', 'email']
 
-    def __init__(self, *args, **kwargs):
-        super(Command, self).__init__(*args, **kwargs)
-        self.UserModel = get_user_model()
-
     def handle(self, *args, **options):
+        UserModel = get_user_model()
+        get_field = UserModel._meta.get_field
         user_data = {
-            field_name: self.get_value(field_name)
+            field_name: self.get_value(get_field(field_name), field_name)
             for field_name in self.required_fields
         }
-        self.UserModel._default_manager.create_superuser(
+        UserModel._default_manager.create_superuser(
             password=None, **user_data)
 
-    def get_value(self, field_name):
-        field = self.UserModel._meta.get_field(field_name)
+    def get_value(self, field, field_name):
         value = None
         while value is None:
             raw_value = input('{}: '.format(capfirst(field_name)))

--- a/src/olympia/users/management/commands/createsuperuser.py
+++ b/src/olympia/users/management/commands/createsuperuser.py
@@ -23,15 +23,15 @@ and email address and that's it.
 
     def handle(self, *args, **options):
         UserModel = get_user_model()
-        get_field = UserModel._meta.get_field
         user_data = {
-            field_name: self.get_value(get_field(field_name), field_name)
+            field_name: self.get_value(field_name)
             for field_name in self.required_fields
         }
         UserModel._default_manager.create_superuser(
             password=None, **user_data)
 
-    def get_value(self, field, field_name):
+    def get_value(self, field_name):
+        field = get_user_model()._meta.get_field(field_name)
         value = None
         while value is None:
             raw_value = input('{}: '.format(capfirst(field_name)))

--- a/src/olympia/users/management/commands/createsuperuser.py
+++ b/src/olympia/users/management/commands/createsuperuser.py
@@ -1,5 +1,8 @@
 """
 Management utility to create superusers.
+
+Inspired by django.contrib.auth.management.commands.createsuperuser.
+(http://bit.ly/2cTgsNV)
 """
 from __future__ import unicode_literals
 

--- a/src/olympia/users/tests/test_commands.py
+++ b/src/olympia/users/tests/test_commands.py
@@ -27,8 +27,11 @@ class TestCreateSuperUser(TestCase):
 
     @patch('olympia.users.management.commands.createsuperuser.input')
     def test_creates_user(self, input):
-        responses = ['myusername', 'me@mozilla.org']
-        input.side_effect = lambda *args: responses.pop(0)
+        responses = {
+            'Username: ': 'myusername',
+            'Email: ': 'me@mozilla.org',
+        }
+        input.side_effect = lambda label: responses[label]
         count = UserProfile.objects.count()
         CreateSuperUser().handle()
         assert UserProfile.objects.count() == count + 1

--- a/src/olympia/users/tests/test_commands.py
+++ b/src/olympia/users/tests/test_commands.py
@@ -1,0 +1,36 @@
+from mock import patch
+
+from olympia.amo.tests import TestCase
+from olympia.users.management.commands.createsuperuser import (
+    Command as CreateSuperUser)
+from olympia.users.models import UserProfile
+
+
+@patch('olympia.users.management.commands.createsuperuser.input')
+def test_createsuperuser_username_validation(input):
+    responses = ['', 'myusername']
+    input.side_effect = lambda *args: responses.pop(0)
+    command = CreateSuperUser()
+    assert command.get_value('username') == 'myusername'
+
+
+@patch('olympia.users.management.commands.createsuperuser.input')
+def test_createsuperuser_email_validation(input):
+    responses = ['', 'myemail', 'me@mozilla.org']
+    input.side_effect = lambda *args: responses.pop(0)
+    command = CreateSuperUser()
+    assert command.get_value('email') == 'me@mozilla.org'
+
+
+class TestCreateSuperUser(TestCase):
+    fixtures = ['users/test_backends']
+
+    @patch('olympia.users.management.commands.createsuperuser.input')
+    def test_creates_user(self, input):
+        responses = ['myusername', 'me@mozilla.org']
+        input.side_effect = lambda *args: responses.pop(0)
+        count = UserProfile.objects.count()
+        CreateSuperUser().handle()
+        assert UserProfile.objects.count() == count + 1
+        user = UserProfile.objects.get(username='myusername')
+        assert user.email == 'me@mozilla.org'


### PR DESCRIPTION
```
[root@fdb48ccd9a35 code]# ./manage.py createsuperuser
Raven is not configured (logging is disabled). Please see the documentation for more information.
18:26:38 z.startup:INFO Set RECURSION_LIMIT to 10000 :/code/src/olympia/core/apps.py:82
Username: super
Email: super@maininator.com
18:26:52 z.users:DEBUG Creating user with email super@maininator.com and username super :/code/src/olympia/users/models.py:156
18:26:52 z.amo:WARNING Activity log called with no user: 120 :/code/src/olympia/amo/log.py:710
18:26:52 z.users:INFO Added 11225: super to Admins :/code/src/olympia/access/models.py:44
```

A basic replacement for django's builtin `createsuperuser` command. It just prompts for username and email and delegates to `UserProfile.create_superuser()`. Just like [django's createsuperuser](http://bit.ly/2cTgsNV) but with less edge-case stuff that we hopefully don't need.

Supports #3049.