### PR TITLE
Disable cache when building python modules

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -42,10 +42,10 @@ COPY . /data/olympia
 WORKDIR /data/olympia
 
 # Install all python requires
-RUN pip install --exists-action=w --no-deps -r requirements/prod.txt                \
-    && [ -f requirements/prod_without_hash.txt ]                                    \
-    && pip install --exists-action=w --no-deps -r requirements/prod_without_hash.txt\
-    && pip install --exists-action=w --no-deps -e .
+RUN pip install --no-cache-dir --exists-action=w --no-deps -r requirements/prod.txt                \
+    && [ -f requirements/prod_without_hash.txt ]                                                   \
+    && pip install --no-cache-dir --exists-action=w --no-deps -r requirements/prod_without_hash.txt\
+    && pip install --no-cache-dir --exists-action=w --no-deps -e .
 
 RUN echo -e "from olympia.lib.settings_base import *\n\
 STYLUS_BIN = 'node_modules/stylus/bin/stylus'\n\


### PR DESCRIPTION
This helps reduce the size of the image by a couple hundred MB.

@jasonthomas r?