### PR TITLE
Bugzilla 1305466

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -6,13 +6,10 @@ ENV LC_ALL en_US.UTF-8
 # need to compile swig
 ENV SWIG_FEATURES="-D__x86_64__"
 
-# Should change it to use ARG instead of ENV for UWSGI_GID and OLYMPIA_UID
+# Should change it to use ARG instead of ENV for OLYMPIA_UID
 # once the jenkins server is upgraded to support docker >= v1.9.0
-ENV UWSGI_GID=756
 ENV OLYMPIA_UID=9500
-RUN groupadd -g ${UWSGI_GID} uwsgi
 RUN useradd -u ${OLYMPIA_UID} -s /sbin/nologin olympia
-RUN usermod -a -G uwsgi olympia
 
 ADD docker/nodesource.gpg.key /etc/pki/rpm-gpg/RPM-GPG-KEY-nodesource
 ADD docker/epel.gpg.key /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7


### PR DESCRIPTION
@jasonthomas r?

Environment variable UWSGI_GID makes uwsgi override the command line
--gid option, causing files written by the containers having wrong group
ownership of "uwsgi".

We don't need the uwsgi group specifically defined inside containers
because the containers are going to be run as olympia user and olympia
group anyways.

This change also requires that puppet-config to change the group ownership
of some shared directories such as /var/run/uwsgi to be "olympia", which I'll
sent a PR shortly after.