### PR TITLE
Use a test backend for client login

### DIFF
--- a/settings_test.py
+++ b/settings_test.py
@@ -40,7 +40,7 @@ TMP_PATH = _polite_tmpdir()
 
 # Don't call out to persona in tests.
 AUTHENTICATION_BACKENDS = (
-    'olympia.users.backends.AmoUserBackend',
+    'olympia.users.backends.TestUserBackend',
 )
 
 CELERY_ALWAYS_EAGER = True

--- a/src/olympia/access/tests.py
+++ b/src/olympia/access/tests.py
@@ -78,7 +78,7 @@ class TestHasPerm(TestCase):
 
     def setUp(self):
         super(TestHasPerm, self).setUp()
-        assert self.client.login(username='del@icio.us', password='password')
+        assert self.client.login(email='del@icio.us')
         self.user = UserProfile.objects.get(email='del@icio.us')
         self.addon = Addon.objects.get(id=3615)
         self.au = AddonUser.objects.get(addon=self.addon, user=self.user)
@@ -92,8 +92,7 @@ class TestHasPerm(TestCase):
         return request
 
     def login_admin(self):
-        assert self.client.login(username='admin@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='admin@mozilla.com')
         return UserProfile.objects.get(email='admin@mozilla.com')
 
     def test_anonymous(self):

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -975,7 +975,7 @@ class TestImpalaDetailPage(TestCase):
 
     def test_downloads_stats_regular(self):
         self.addon.update(type=amo.ADDON_SEARCH)
-        self.client.login(email='regular@mozilla.com', password='password')
+        self.client.login(email='regular@mozilla.com')
         # Should not be a link to statistics dashboard for regular users.
         dls = self.get_pq()('#weekly-downloads')
         assert dls.length == 1

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -938,14 +938,14 @@ class TestImpalaDetailPage(TestCase):
         assert self.get_pq()('#daily-users').length == 0
 
     def test_adu_stats_regular(self):
-        self.client.login(username='regular@mozilla.com', password='password')
+        self.client.login(email='regular@mozilla.com')
         # Should not be a link to statistics dashboard for regular users.
         adu = self.get_pq()('#daily-users')
         assert adu.length == 1
         assert adu.find('a').length == 0
 
     def test_adu_stats_admin(self):
-        self.client.login(username='del@icio.us', password='password')
+        self.client.login(email='del@icio.us')
         # Check link to statistics dashboard for add-on authors.
         assert self.get_pq()('#daily-users a.stats').attr('href') == (
             reverse('stats.overview', args=[self.addon.slug]))
@@ -975,7 +975,7 @@ class TestImpalaDetailPage(TestCase):
 
     def test_downloads_stats_regular(self):
         self.addon.update(type=amo.ADDON_SEARCH)
-        self.client.login(username='regular@mozilla.com', password='password')
+        self.client.login(email='regular@mozilla.com', password='password')
         # Should not be a link to statistics dashboard for regular users.
         dls = self.get_pq()('#weekly-downloads')
         assert dls.length == 1
@@ -983,7 +983,7 @@ class TestImpalaDetailPage(TestCase):
 
     def test_downloads_stats_admin(self):
         self.addon.update(public_stats=True, type=amo.ADDON_SEARCH)
-        self.client.login(username='del@icio.us', password='password')
+        self.client.login(email='del@icio.us')
         # Check link to statistics dashboard for add-on authors.
         assert self.get_pq()('#weekly-downloads a.stats').attr('href') == (
             reverse('stats.overview', args=[self.addon.slug]))
@@ -1353,7 +1353,7 @@ class TestXssOnName(amo.tests.TestXss):
 
     def test_reviews_add(self):
         url = reverse('addons.reviews.add', args=[self.addon.slug])
-        self.client.login(username='fligtar@gmail.com', password='foo')
+        self.client.login(email='fligtar@gmail.com')
         self.assertNameAndNoXSS(url)
 
 
@@ -1399,7 +1399,7 @@ class TestReportAbuse(TestCase):
         assert 'recaptcha' in r.context['abuse_form'].errors
 
     def test_abuse_logged_in(self):
-        self.client.login(username='regular@mozilla.com', password='password')
+        self.client.login(email='regular@mozilla.com')
         self.client.post(self.full_page, {'text': 'spammy'})
         assert len(mail.outbox) == 1
         assert 'spammy' in mail.outbox[0].body
@@ -1412,7 +1412,7 @@ class TestReportAbuse(TestCase):
         addon.name = 'Bmrk.ru Социальные закладки'
         addon.save()
 
-        self.client.login(username='regular@mozilla.com', password='password')
+        self.client.login(email='regular@mozilla.com')
         self.client.post(self.full_page, {'text': 'spammy'})
         assert 'spammy' in mail.outbox[0].body
         assert AbuseReport.objects.get(addon=addon)
@@ -1424,7 +1424,7 @@ class TestReportAbuse(TestCase):
         assert doc("fieldset.abuse")
 
         # and now just test it works
-        self.client.login(username='regular@mozilla.com', password='password')
+        self.client.login(email='regular@mozilla.com')
         r = self.client.post(reverse('addons.abuse', args=['a15663']),
                              {'text': 'spammy'})
         self.assert3xx(r, shared_url)
@@ -2165,7 +2165,7 @@ class TestAddonSearchView(ESTestCase):
     def test_with_session_cookie(self):
         # Session cookie should be ignored, therefore a request with it should
         # not cause more database queries.
-        self.client.login(username='regular@mozilla.com', password='password')
+        self.client.login(email='regular@mozilla.com')
         data = self.perform_search(self.url)
         assert data['count'] == 0
         assert len(data['results']) == 0

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -572,7 +572,7 @@ class TestCase(PatchMixin, InitializeSessionMixin, MockEsMixin,
         email = getattr(profile, 'email', profile)
         if '@' not in email:
             email += '@mozilla.com'
-        assert self.client.login(username=email, password='password')
+        assert self.client.login(email=email)
 
     def assertUrlEqual(self, url, other, compare_host=False):
         """Compare url paths and query strings."""
@@ -913,7 +913,7 @@ class TestXss(TestCase):
         u = UserProfile.objects.get(email='del@icio.us')
         GroupUser.objects.create(group=Group.objects.get(name='Admins'),
                                  user=u)
-        self.client.login(username='del@icio.us', password='password')
+        self.client.login(email='del@icio.us')
 
     def assertNameAndNoXSS(self, url):
         response = self.client.get(url)

--- a/src/olympia/amo/tests/test_views.py
+++ b/src/olympia/amo/tests/test_views.py
@@ -27,8 +27,7 @@ class Test403(TestCase):
 
     def setUp(self):
         super(Test403, self).setUp()
-        assert self.client.login(username='regular@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='regular@mozilla.com')
 
     def test_403_no_app(self):
         response = self.client.get('/en-US/admin/')

--- a/src/olympia/api/tests/test_permissions.py
+++ b/src/olympia/api/tests/test_permissions.py
@@ -48,8 +48,7 @@ class TestGroupPermissionOnView(WithDynamicEndpoints):
         group = Group.objects.create(rules='SomeRealm:SomePermission')
         GroupUser.objects.create(group=group, user=self.user)
 
-        assert self.client.login(username=email,
-                                 password='password')
+        assert self.client.login(email=email)
 
     def test_user_must_be_in_required_group(self):
         self.user.groups.all().delete()

--- a/src/olympia/bandwagon/tests/test_views.py
+++ b/src/olympia/bandwagon/tests/test_views.py
@@ -118,7 +118,7 @@ class TestViews(TestCase):
             self.check_response(*test)
 
     def test_legacy_redirects_edit(self):
-        self.client.login(username='jbalogh@mozilla.com', password='password')
+        self.client.login(email='jbalogh@mozilla.com')
         u = UserProfile.objects.get(email='jbalogh@mozilla.com')
         uuid = u.favorites_collection().uuid
         self.check_response('/collections/edit/%s' % uuid, 301,
@@ -138,7 +138,7 @@ class TestViews(TestCase):
             self.check_response(*test)
 
     def test_collection_directory_redirects_with_login(self):
-        self.client.login(username='jbalogh@mozilla.com', password='password')
+        self.client.login(email='jbalogh@mozilla.com')
 
         self.check_response('/collections/favorites/', 301,
                             reverse('collections.following'))
@@ -162,7 +162,7 @@ class TestViews(TestCase):
         amo.set_user(u)
         c.add_addon(addon)
 
-        self.client.login(username='jbalogh@mozilla.com', password='password')
+        self.client.login(email='jbalogh@mozilla.com')
         response = self.client.get(c.get_url_path())
         assert list(response.context['addons'].object_list) == [addon]
 
@@ -173,8 +173,7 @@ class TestViews(TestCase):
         amo.set_user(u)
         c.add_addon(addon)
 
-        assert self.client.login(username='jbalogh@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='jbalogh@mozilla.com')
 
         # My Collections.
         response = self.client.get('/en-US/firefox/collections/mine/')
@@ -200,8 +199,7 @@ class TestViews(TestCase):
                          'http://example.com <b>foo</b> some text')
         c.save()
 
-        assert self.client.login(username='jbalogh@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='jbalogh@mozilla.com')
         response = self.client.get('/en-US/firefox/collections/mine/')
         # All markup is escaped, all links are stripped.
         self.assertContains(response, '&lt;b&gt;foo&lt;/b&gt; some text')
@@ -216,7 +214,7 @@ class TestViews(TestCase):
         assert res.status_code == 302
         assert res.url != edit_url
 
-        self.client.login(username='jbalogh@mozilla.com', password='password')
+        self.client.login(email='jbalogh@mozilla.com')
 
         res = self.client.post(collection.delete_icon_url())
         assert res.status_code == 302
@@ -228,7 +226,7 @@ class TestViews(TestCase):
         collection = user.favorites_collection()
         client = django.test.Client(enforce_csrf_checks=True)
 
-        client.login(username='jbalogh@mozilla.com', password='password')
+        client.login(email='jbalogh@mozilla.com')
 
         res = client.get(collection.delete_icon_url())
         assert res.status_code == 405  # Only POSTs are allowed.
@@ -254,14 +252,14 @@ class TestPrivacy(TestCase):
         super(TestPrivacy, self).setUp()
         # The favorites collection is created automatically.
         self.url = reverse('collections.detail', args=['jbalogh', 'favorites'])
-        self.client.login(username='jbalogh@mozilla.com', password='password')
+        self.client.login(email='jbalogh@mozilla.com')
         assert self.client.get(self.url).status_code == 200
         self.client.logout()
         self.c = Collection.objects.get(slug='favorites',
                                         author__username='jbalogh')
 
     def test_owner(self):
-        self.client.login(username='jbalogh@mozilla.com', password='password')
+        self.client.login(email='jbalogh@mozilla.com')
         r = self.client.get(self.url)
         assert r.status_code == 200
         # TODO(cvan): Uncomment when bug 719512 gets fixed.
@@ -270,7 +268,7 @@ class TestPrivacy(TestCase):
 
     def test_private(self):
         self.client.logout()
-        self.client.login(username='fligtar@gmail.com', password='foo')
+        self.client.login(email='fligtar@gmail.com')
         assert self.client.get(self.url).status_code == 403
 
     def test_public(self):
@@ -289,7 +287,7 @@ class TestPrivacy(TestCase):
         self.assertLoginRedirects(self.client.get(self.url), self.url)
         u = UserProfile.objects.get(email='fligtar@gmail.com')
         CollectionUser.objects.create(collection=self.c, user=u)
-        self.client.login(username='fligtar@gmail.com', password='foo')
+        self.client.login(email='fligtar@gmail.com')
         r = self.client.get(self.url)
         assert r.status_code == 200
         # TODO(cvan): Uncomment when bug 719512 gets fixed.
@@ -302,7 +300,7 @@ class TestVotes(TestCase):
 
     def setUp(self):
         super(TestVotes, self).setUp()
-        self.client.login(username='jbalogh@mozilla.com', password='password')
+        self.client.login(email='jbalogh@mozilla.com')
         args = ['fligtar', 'slug']
         Collection.objects.create(slug='slug', author_id=9945)
         self.c_url = reverse('collections.detail', args=args)
@@ -379,12 +377,10 @@ class TestCRUD(TestCase):
         }
 
     def login_admin(self):
-        assert self.client.login(username='admin@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='admin@mozilla.com')
 
     def login_regular(self):
-        assert self.client.login(username='regular@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='regular@mozilla.com')
 
     def create_collection(self, **kw):
         self.data.update(kw)
@@ -399,8 +395,7 @@ class TestCRUD(TestCase):
 
     def test_restricted(self, **kw):
         g, created = Group.objects.get_or_create(rules='Restricted:UGC')
-        self.client.login(username='clouserw@gmail.com',
-                          password='password')
+        self.client.login(email='clouserw@gmail.com')
         user = UserProfile.objects.get(id='10482')
         GroupUser.objects.create(group=g, user=user)
         self.data.update(kw)
@@ -422,8 +417,7 @@ class TestCRUD(TestCase):
 
     def test_listing_xss(self):
         c = Collection.objects.get(id=80)
-        assert self.client.login(username='clouserw@gmail.com',
-                                 password='password')
+        assert self.client.login(email='clouserw@gmail.com')
 
         url = reverse('collections.watch', args=[c.author.username, c.slug])
 
@@ -892,7 +886,7 @@ class TestChangeAddon(TestCase):
 
     def setUp(self):
         super(TestChangeAddon, self).setUp()
-        self.client.login(username='jbalogh@mozilla.com', password='password')
+        self.client.login(email='jbalogh@mozilla.com')
         self.add = reverse('collections.alter',
                            args=['jbalogh', 'mobile', 'add'])
         self.remove = reverse('collections.alter',
@@ -991,8 +985,7 @@ class AjaxTest(TestCase):
 
     def setUp(self):
         super(AjaxTest, self).setUp()
-        assert self.client.login(username='clouserw@gmail.com',
-                                 password='password')
+        assert self.client.login(email='clouserw@gmail.com')
         self.user = UserProfile.objects.get(email='clouserw@gmail.com')
         self.other = UserProfile.objects.exclude(id=self.user.id)[0]
 
@@ -1065,8 +1058,7 @@ class TestWatching(TestCase):
         self.collection = c = Collection.objects.get(id=57181)
         self.url = reverse('collections.watch',
                            args=[c.author.username, c.slug])
-        assert self.client.login(username='clouserw@gmail.com',
-                                 password='password')
+        assert self.client.login(email='clouserw@gmail.com')
 
         self.qs = CollectionWatcher.objects.filter(user__username='clouserw',
                                                    collection=57181)

--- a/src/olympia/browse/tests.py
+++ b/src/olympia/browse/tests.py
@@ -1217,7 +1217,7 @@ class TestMobileHeader(amo.tests.MobileTest, TestCase):
         assert nav.find('li.login').length == 1
 
     def _test_auth_nav(self, expected):
-        self.client.login(username='regular@mozilla.com', password='password')
+        self.client.login(email='regular@mozilla.com')
         self.url = reverse('browse.extensions')
         r = self.client.get(self.url)
         assert r.status_code == 200

--- a/src/olympia/compat/tests.py
+++ b/src/olympia/compat/tests.py
@@ -174,7 +174,7 @@ class TestReporter(TestCase):
     def test_unlisted_addons_listed_in_left_sidebar(self):
         """Display unlisted addons in the 'reports for your add-ons' list."""
         self.addon.update(is_listed=False)
-        self.client.login(username='del@icio.us', password='password')
+        self.client.login(email='del@icio.us')
         response = self.client.get(reverse('compat.reporter'))
         assert self.addon in response.context['addons']
 

--- a/src/olympia/devhub/tests/test_feeds.py
+++ b/src/olympia/devhub/tests/test_feeds.py
@@ -157,16 +157,14 @@ class TestActivity(HubTest):
     def test_filter_addon_admin(self):
         """Admins should be able to see specific pages."""
         self.log_creates(10)
-        assert self.client.login(username='admin@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='admin@mozilla.com')
         r = self.get_response(addon=self.addon.id)
         assert r.status_code == 200
 
     def test_filter_addon_otherguy(self):
         """Make sure nobody else can see my precious add-on feed."""
         self.log_creates(10)
-        assert self.client.login(username='clouserw@gmail.com',
-                                 password='password')
+        assert self.client.login(email='clouserw@gmail.com')
         r = self.get_response(addon=self.addon.id)
         assert r.status_code == 403
 

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -52,8 +52,7 @@ class HubTest(TestCase):
     def setUp(self):
         super(HubTest, self).setUp()
         self.url = reverse('devhub.index')
-        assert self.client.login(username='regular@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='regular@mozilla.com')
         assert self.client.get(self.url).status_code == 200
         self.user_profile = UserProfile.objects.get(id=999)
 
@@ -304,7 +303,7 @@ class TestUpdateCompatibility(TestCase):
 
     def setUp(self):
         super(TestUpdateCompatibility, self).setUp()
-        assert self.client.login(username='del@icio.us', password='password')
+        assert self.client.login(email='del@icio.us')
         self.url = reverse('devhub.addons')
 
         # TODO(andym): use Mock appropriately here.
@@ -317,8 +316,7 @@ class TestUpdateCompatibility(TestCase):
 
     def test_no_compat(self):
         self.client.logout()
-        assert self.client.login(username='admin@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='admin@mozilla.com')
         r = self.client.get(self.url)
         doc = pq(r.content)
         assert not doc('.item[data-addonid="4594"] li.compat')
@@ -374,7 +372,7 @@ class TestDevRequired(TestCase):
         self.addon = Addon.objects.get(id=3615)
         self.get_url = self.addon.get_dev_url('payments')
         self.post_url = self.addon.get_dev_url('payments.disable')
-        assert self.client.login(username='del@icio.us', password='password')
+        assert self.client.login(email='del@icio.us')
         self.au = self.addon.addonuser_set.get(user__email='del@icio.us')
         assert self.au.role == amo.AUTHOR_ROLE_OWNER
 
@@ -404,8 +402,7 @@ class TestDevRequired(TestCase):
 
     def test_disabled_post_admin(self):
         self.addon.update(status=amo.STATUS_DISABLED)
-        assert self.client.login(username='admin@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='admin@mozilla.com')
         self.assert3xx(self.client.post(self.post_url), self.get_url)
 
 
@@ -414,8 +411,7 @@ class TestVersionStats(TestCase):
 
     def setUp(self):
         super(TestVersionStats, self).setUp()
-        assert self.client.login(username='admin@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='admin@mozilla.com')
 
     def test_counts(self):
         addon = Addon.objects.get(id=3615)
@@ -444,7 +440,7 @@ class TestEditPayments(TestCase):
         self.foundation = Charity.objects.create(
             id=amo.FOUNDATION_ORG, name='moz', url='$$.moz', paypal='moz.pal')
         self.url = self.addon.get_dev_url('payments')
-        assert self.client.login(username='del@icio.us', password='password')
+        assert self.client.login(email='del@icio.us')
         self.paypal_mock = mock.Mock()
         self.paypal_mock.return_value = (True, None)
         paypal.check_paypal_id = self.paypal_mock
@@ -665,7 +661,7 @@ class TestDisablePayments(TestCase):
         self.addon.update(wants_contributions=True, paypal_id='woohoo')
         self.pay_url = self.addon.get_dev_url('payments')
         self.disable_url = self.addon.get_dev_url('payments.disable')
-        assert self.client.login(username='del@icio.us', password='password')
+        assert self.client.login(email='del@icio.us')
 
     def test_statusbar_visible(self):
         r = self.client.get(self.pay_url)
@@ -692,7 +688,7 @@ class TestPaymentsProfile(TestCase):
         # Make sure all the payment/profile data is clear.
         assert not (a.wants_contributions or a.paypal_id or a.the_reason or
                     a.the_future or a.takes_contributions)
-        assert self.client.login(username='del@icio.us', password='password')
+        assert self.client.login(email='del@icio.us')
         self.paypal_mock = mock.Mock()
         self.paypal_mock.return_value = (True, None)
         paypal.check_paypal_id = self.paypal_mock
@@ -772,7 +768,7 @@ class TestDelete(TestCase):
     def setUp(self):
         super(TestDelete, self).setUp()
         self.get_addon = lambda: Addon.objects.filter(id=3615)
-        assert self.client.login(username='del@icio.us', password='password')
+        assert self.client.login(email='del@icio.us')
         self.user = UserProfile.objects.get(email='del@icio.us')
         self.get_url = lambda: self.get_addon()[0].get_dev_url('delete')
 
@@ -824,7 +820,7 @@ class TestHome(TestCase):
 
     def setUp(self):
         super(TestHome, self).setUp()
-        assert self.client.login(username='del@icio.us', password='password')
+        assert self.client.login(email='del@icio.us')
         self.url = reverse('devhub.index')
         self.addon = Addon.objects.get(pk=3615)
 
@@ -910,7 +906,7 @@ class TestActivityFeed(TestCase):
 
     def setUp(self):
         super(TestActivityFeed, self).setUp()
-        assert self.client.login(username='del@icio.us', password='password')
+        assert self.client.login(email='del@icio.us')
         self.addon = Addon.objects.get(id=3615)
         self.version = self.addon.versions.first()
 
@@ -1002,7 +998,7 @@ class TestProfileBase(TestCase):
         self.addon = Addon.objects.get(id=3615)
         self.version = self.addon.current_version
         self.url = self.addon.get_dev_url('profile')
-        assert self.client.login(username='del@icio.us', password='password')
+        assert self.client.login(email='del@icio.us')
 
     def get_addon(self):
         return Addon.objects.no_cache().get(id=self.addon.id)
@@ -1157,7 +1153,7 @@ class TestSubmitBase(TestCase):
 
     def setUp(self):
         super(TestSubmitBase, self).setUp()
-        assert self.client.login(username='del@icio.us', password='password')
+        assert self.client.login(email='del@icio.us')
         self.user = UserProfile.objects.get(email='del@icio.us')
         self.addon = self.get_addon()
 
@@ -1198,7 +1194,7 @@ class TestAPIKeyPage(TestCase):
     def setUp(self):
         super(TestAPIKeyPage, self).setUp()
         self.url = reverse('devhub.api_key')
-        assert self.client.login(username='del@icio.us', password='password')
+        assert self.client.login(email='del@icio.us')
         self.user = UserProfile.objects.get(email='del@icio.us')
 
     def test_key_redirect(self):
@@ -1308,7 +1304,7 @@ class TestSubmitStep2(TestCase):
 
     def setUp(self):
         super(TestSubmitStep2, self).setUp()
-        self.client.login(username='regular@mozilla.com', password='password')
+        self.client.login(email='regular@mozilla.com')
         self.user = UserProfile.objects.get(email='regular@mozilla.com')
 
     def test_step_2_seen(self):
@@ -1957,8 +1953,7 @@ class TestSubmitBump(TestSubmitBase):
         assert r.status_code == 403
 
     def test_bump_submit_and_redirect(self):
-        assert self.client.login(username='admin@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='admin@mozilla.com')
         r = self.client.post(self.url, {'step': 4}, follow=True)
         self.assert3xx(r, reverse('devhub.submit.4', args=['a3615']))
         assert self.get_step().step == 4
@@ -1969,7 +1964,7 @@ class TestSubmitSteps(TestCase):
 
     def setUp(self):
         super(TestSubmitSteps, self).setUp()
-        assert self.client.login(username='del@icio.us', password='password')
+        assert self.client.login(email='del@icio.us')
         self.user = UserProfile.objects.get(email='del@icio.us')
 
     def assert_linked(self, doc, numbers):
@@ -2066,8 +2061,7 @@ class TestUpload(BaseUploadTest):
 
     def setUp(self):
         super(TestUpload, self).setUp()
-        assert self.client.login(username='regular@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='regular@mozilla.com')
         self.url = reverse('devhub.upload')
         self.image_path = get_image_path('animated.png')
 
@@ -2090,7 +2084,7 @@ class TestUpload(BaseUploadTest):
         assert storage.open(upload.path).read() == data
 
     def test_fileupload_user(self):
-        self.client.login(username='regular@mozilla.com', password='password')
+        self.client.login(email='regular@mozilla.com')
         self.post()
         user = UserProfile.objects.get(email='regular@mozilla.com')
         assert FileUpload.objects.get().user == user
@@ -2135,8 +2129,7 @@ class TestUploadDetail(BaseUploadTest):
 
     def setUp(self):
         super(TestUploadDetail, self).setUp()
-        assert self.client.login(username='regular@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='regular@mozilla.com')
 
     def create_appversion(self, name, version):
         return AppVersion.objects.create(
@@ -2370,7 +2363,7 @@ class UploadTest(BaseUploadTest, TestCase):
         self.addon = Addon.objects.get(id=3615)
         self.version = self.addon.current_version
         self.addon.update(guid='guid@xpi')
-        assert self.client.login(username='del@icio.us', password='password')
+        assert self.client.login(email='del@icio.us')
 
 
 class TestQueuePosition(UploadTest):
@@ -3082,8 +3075,7 @@ class TestAddBetaVersion(AddVersionTest):
 class TestAddVersionValidation(AddVersionTest):
 
     def login_as_admin(self):
-        assert self.client.login(username='admin@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='admin@mozilla.com')
 
     def do_upload_non_fatal(self):
         validation = {
@@ -3174,8 +3166,7 @@ class TestCreateAddon(BaseUploadTest, UploadAddon, TestCase):
         super(TestCreateAddon, self).setUp()
         self.upload = self.get_upload('extension.xpi')
         self.url = reverse('devhub.submit.2')
-        assert self.client.login(username='regular@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='regular@mozilla.com')
         self.client.post(reverse('devhub.submit.1'))
 
     def assert_json_error(self, *args):
@@ -3316,7 +3307,7 @@ class TestDeleteAddon(TestCase):
         super(TestDeleteAddon, self).setUp()
         self.addon = Addon.objects.get(id=3615)
         self.url = self.addon.get_dev_url('delete')
-        self.client.login(username='admin@mozilla.com', password='password')
+        self.client.login(email='admin@mozilla.com')
 
     def test_bad_password(self):
         r = self.client.post(self.url, dict(slug='nope'))
@@ -3344,8 +3335,7 @@ class TestRequestReview(TestCase):
         self.redirect_url = self.addon.get_dev_url('versions')
         self.public_url = reverse('devhub.request-review',
                                   args=[self.addon.slug])
-        assert self.client.login(username='admin@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='admin@mozilla.com')
 
     def get_addon(self):
         return Addon.objects.get(id=self.addon.id)
@@ -3399,8 +3389,7 @@ class TestRedirects(TestCase):
     def setUp(self):
         super(TestRedirects, self).setUp()
         self.base = reverse('devhub.index')
-        assert self.client.login(username='admin@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='admin@mozilla.com')
 
     def test_edit(self):
         url = self.base + 'addon/edit/3615'
@@ -3457,7 +3446,7 @@ class TestRemoveLocale(TestCase):
         super(TestRemoveLocale, self).setUp()
         self.addon = Addon.objects.get(id=3615)
         self.url = reverse('devhub.addons.remove-locale', args=['a3615'])
-        assert self.client.login(username='del@icio.us', password='password')
+        assert self.client.login(email='del@icio.us')
 
     def test_bad_request(self):
         r = self.client.post(self.url)

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -47,7 +47,7 @@ class TestEdit(TestCase):
         settings.MEDIA_ROOT = tempfile.mkdtemp()
         super(TestEdit, self).setUp()
         addon = self.get_addon()
-        assert self.client.login(username='del@icio.us', password='password')
+        assert self.client.login(email='del@icio.us')
 
         a = AddonCategory.objects.filter(addon=addon, category__id=22)[0]
         a.feature = False
@@ -326,8 +326,7 @@ class TestEditBasic(TestEdit):
 
     def test_edit_categories_add_new_creatured_admin(self):
         """Ensure that admins can change categories for creatured add-ons."""
-        assert self.client.login(username='admin@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='admin@mozilla.com')
         self._feature_addon()
         r = self.client.get(self.basic_edit_url)
         doc = pq(r.content)
@@ -1277,11 +1276,10 @@ class TestAdmin(TestCase):
     fixtures = ['base/users', 'base/addon_3615']
 
     def login_admin(self):
-        assert self.client.login(username='admin@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='admin@mozilla.com')
 
     def login_user(self):
-        assert self.client.login(username='del@icio.us', password='password')
+        assert self.client.login(email='del@icio.us')
 
     def test_show_admin_settings_admin(self):
         self.login_admin()
@@ -1348,7 +1346,7 @@ class TestThemeEdit(TestCase):
         assert doc('a.reupload')
 
     def test_color_input_is_empty_at_creation(self):
-        self.client.login(username='regular@mozilla.com', password='password')
+        self.client.login(email='regular@mozilla.com')
         r = self.client.get(reverse('devhub.themes.submit'))
         doc = pq(r.content)
         el = doc('input.color-picker')
@@ -1359,7 +1357,7 @@ class TestThemeEdit(TestCase):
         color = "123456"
         self.addon.persona.accentcolor = color
         self.addon.persona.save()
-        self.client.login(username='regular@mozilla.com', password='password')
+        self.client.login(email='regular@mozilla.com')
         url = reverse('devhub.themes.edit', args=(self.addon.slug, ))
         r = self.client.get(url)
         doc = pq(r.content)

--- a/src/olympia/devhub/tests/test_views_ownership.py
+++ b/src/olympia/devhub/tests/test_views_ownership.py
@@ -20,7 +20,7 @@ class TestOwnership(TestCase):
         self.addon = Addon.objects.get(id=3615)
         self.version = self.addon.current_version
         self.url = self.addon.get_dev_url('owner')
-        assert self.client.login(username='del@icio.us', password='password')
+        assert self.client.login(email='del@icio.us')
 
     def formset(self, *args, **kw):
         defaults = {'builtin': License.OTHER, 'text': 'filler'}
@@ -343,7 +343,7 @@ class TestEditAuthor(TestOwnership):
         data = self.formset(f.initial, u, initial_count=1)
         self.client.post(self.url, data)
 
-        self.client.login(username='regular@mozilla.com', password='password')
+        self.client.login(email='regular@mozilla.com')
         self.client.post(self.url, data, follow=True)
 
         # Try deleting the other AddonUser

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -13,8 +13,7 @@ class TestSubmitPersona(TestCase):
 
     def setUp(self):
         super(TestSubmitPersona, self).setUp()
-        assert self.client.login(username='regular@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='regular@mozilla.com')
         self.url = reverse('devhub.themes.submit')
 
     def get_img_urls(self):

--- a/src/olympia/devhub/tests/test_views_validation.py
+++ b/src/olympia/devhub/tests/test_views_validation.py
@@ -30,8 +30,7 @@ class TestUploadValidation(BaseUploadTest):
 
     def setUp(self):
         super(TestUploadValidation, self).setUp()
-        assert self.client.login(username='regular@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='regular@mozilla.com')
 
     def test_no_html_in_messages(self):
         upload = FileUpload.objects.get(name='invalid-id-20101206.xpi')
@@ -70,8 +69,7 @@ class TestUploadErrors(BaseUploadTest):
 
     def setUp(self):
         super(TestUploadErrors, self).setUp()
-        self.client.login(username='regular@mozilla.com',
-                          password='password')
+        self.client.login(email='regular@mozilla.com')
 
     @mock.patch.object(waffle, 'flag_is_active')
     def test_dupe_uuid(self, flag_is_active):
@@ -113,7 +111,7 @@ class TestFileValidation(TestCase):
 
     def setUp(self):
         super(TestFileValidation, self).setUp()
-        assert self.client.login(username='del@icio.us', password='password')
+        assert self.client.login(email='del@icio.us')
         self.user = UserProfile.objects.get(email='del@icio.us')
         self.file_validation = FileValidation.objects.get(pk=1)
         self.file = self.file_validation.file
@@ -145,26 +143,22 @@ class TestFileValidation(TestCase):
 
     def test_only_dev_can_see_results(self):
         self.client.logout()
-        assert self.client.login(username='regular@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='regular@mozilla.com')
         assert self.client.head(self.url, follow=True).status_code == 403
 
     def test_only_dev_can_see_json_results(self):
         self.client.logout()
-        assert self.client.login(username='regular@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='regular@mozilla.com')
         assert self.client.head(self.json_url, follow=True).status_code == 403
 
     def test_editor_can_see_results(self):
         self.client.logout()
-        assert self.client.login(username='editor@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='editor@mozilla.com')
         assert self.client.head(self.url, follow=True).status_code == 200
 
     def test_editor_can_see_json_results(self):
         self.client.logout()
-        assert self.client.login(username='editor@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='editor@mozilla.com')
         assert self.client.head(self.json_url, follow=True).status_code == 200
 
     def test_no_html_in_messages(self):
@@ -221,8 +215,7 @@ class TestFileAnnotation(TestCase):
 
     def setUp(self):
         super(TestFileAnnotation, self).setUp()
-        assert self.client.login(username='editor@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='editor@mozilla.com')
 
         self.RESULTS = deepcopy(amo.VALIDATOR_SKELETON_RESULTS)
         self.RESULTS['messages'] = [
@@ -310,8 +303,7 @@ class TestValidateAddon(TestCase):
 
     def setUp(self):
         super(TestValidateAddon, self).setUp()
-        assert self.client.login(username='regular@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='regular@mozilla.com')
 
     def test_login_required(self):
         self.client.logout()
@@ -371,8 +363,7 @@ class TestUploadURLs(TestCase):
     def setUp(self):
         super(TestUploadURLs, self).setUp()
         user = UserProfile.objects.get(email='regular@mozilla.com')
-        self.client.login(username='regular@mozilla.com',
-                          password='password')
+        self.client.login(email='regular@mozilla.com')
 
         self.addon = Addon.objects.create(guid='thing@stuff',
                                           slug='thing-stuff',
@@ -451,7 +442,7 @@ class TestValidateFile(BaseUploadTest):
 
     def setUp(self):
         super(TestValidateFile, self).setUp()
-        assert self.client.login(username='del@icio.us', password='password')
+        assert self.client.login(email='del@icio.us')
         self.user = UserProfile.objects.get(email='del@icio.us')
         self.file = File.objects.get(pk=100456)
         # Move the file into place as if it were a real file
@@ -653,8 +644,7 @@ class TestCompatibilityResults(TestCase):
 
     def setUp(self):
         super(TestCompatibilityResults, self).setUp()
-        assert self.client.login(username='editor@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='editor@mozilla.com')
         self.addon = Addon.objects.get(slug='addon-compat-results')
         self.result = ValidationResult.objects.get(
             file__version__addon=self.addon)
@@ -735,7 +725,7 @@ class TestUploadCompatCheck(BaseUploadTest):
 
     def setUp(self):
         super(TestUploadCompatCheck, self).setUp()
-        assert self.client.login(username='del@icio.us', password='password')
+        assert self.client.login(email='del@icio.us')
         self.app = amo.FIREFOX
         self.appver = AppVersion.objects.get(application=self.app.id,
                                              version='3.7a1pre')

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -24,7 +24,7 @@ class TestVersion(TestCase):
 
     def setUp(self):
         super(TestVersion, self).setUp()
-        self.client.login(username='del@icio.us', password='password')
+        self.client.login(email='del@icio.us')
         self.user = UserProfile.objects.get(email='del@icio.us')
         self.addon = self.get_addon()
         self.version = Version.objects.get(id=81551)
@@ -310,8 +310,7 @@ class TestVersion(TestCase):
     def test_non_owner_cant_disable_addon(self):
         self.addon.update(disabled_by_user=False)
         self.client.logout()
-        assert self.client.login(username='regular@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='regular@mozilla.com')
         res = self.client.post(self.disable_url)
         assert res.status_code == 403
         assert not Addon.objects.get(id=3615).disabled_by_user
@@ -319,8 +318,7 @@ class TestVersion(TestCase):
     def test_non_owner_cant_enable_addon(self):
         self.addon.update(disabled_by_user=False)
         self.client.logout()
-        assert self.client.login(username='regular@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='regular@mozilla.com')
         res = self.client.get(self.enable_url)
         assert res.status_code == 403
         assert not Addon.objects.get(id=3615).disabled_by_user
@@ -562,7 +560,7 @@ class TestVersionEditBase(TestVersionEditMixin, TestCase):
 
     def setUp(self):
         super(TestVersionEditBase, self).setUp()
-        self.client.login(username='del@icio.us', password='password')
+        self.client.login(email='del@icio.us')
         self.addon = self.get_addon()
         self.version = self.get_version()
         self.url = reverse('devhub.versions.edit',
@@ -750,7 +748,7 @@ class TestVersionEditSearchEngine(TestVersionEditMixin,
 
     def setUp(self):
         super(TestVersionEditSearchEngine, self).setUp()
-        self.client.login(username='admin@mozilla.com', password='password')
+        self.client.login(email='admin@mozilla.com')
         self.url = reverse('devhub.versions.edit',
                            args=['a4594', 42352])
 
@@ -932,7 +930,7 @@ class TestPlatformSearch(TestVersionEditMixin, amo.tests.BaseTestCase):
 
     def setUp(self):
         super(TestPlatformSearch, self).setUp()
-        self.client.login(username='admin@mozilla.com', password='password')
+        self.client.login(email='admin@mozilla.com')
         self.url = reverse('devhub.versions.edit',
                            args=['a4594', 42352])
         self.version = Version.objects.get(id=42352)

--- a/src/olympia/editors/tests/test_views.py
+++ b/src/olympia/editors/tests/test_views.py
@@ -39,16 +39,13 @@ class EditorTest(TestCase):
     fixtures = ['base/users', 'base/approvals', 'editors/pending-queue']
 
     def login_as_admin(self):
-        assert self.client.login(username='admin@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='admin@mozilla.com')
 
     def login_as_editor(self):
-        assert self.client.login(username='editor@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='editor@mozilla.com')
 
     def login_as_senior_editor(self):
-        assert self.client.login(username='senioreditor@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='senioreditor@mozilla.com')
 
     def make_review(self, username='a'):
         u = UserProfile.objects.create(username=username)
@@ -716,15 +713,13 @@ class TestQueueBasics(QueueTest):
 
         # Regular user doesn't have access.
         self.client.logout()
-        assert self.client.login(username='regular@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='regular@mozilla.com')
         r = self.client.get(self.url)
         assert r.status_code == 403
 
         # Persona reviewer doesn't have access either.
         self.client.logout()
-        assert self.client.login(username='persona_reviewer@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='persona_reviewer@mozilla.com')
         r = self.client.get(self.url)
         assert r.status_code == 403
 
@@ -940,22 +935,19 @@ class TestUnlistedQueueBasics(TestQueueBasics):
 
         # Regular user doesn't have access.
         self.client.logout()
-        assert self.client.login(username='regular@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='regular@mozilla.com')
         r = self.client.get(self.url)
         assert r.status_code == 403
 
         # Persona reviewer doesn't have access either.
         self.client.logout()
-        assert self.client.login(username='persona_reviewer@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='persona_reviewer@mozilla.com')
         r = self.client.get(self.url)
         assert r.status_code == 403
 
         # Standard reviewer doesn't have access either.
         self.client.logout()
-        assert self.client.login(username='editor@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='editor@mozilla.com')
         r = self.client.get(self.url)
         assert r.status_code == 403
 
@@ -1366,7 +1358,7 @@ class TestPerformance(QueueTest):
         self._test_chart()
 
     def test_usercount_with_more_than_one_editor(self):
-        self.client.login(username='clouserw@gmail.com', password='password')
+        self.client.login(email='clouserw@gmail.com')
         amo.set_user(UserProfile.objects.get(username='clouserw'))
         self.create_logs()
         self.setUpEditor()
@@ -2565,13 +2557,13 @@ class TestReview(ReviewBase):
 
         # Admin reviewer: able to download sources.
         user = UserProfile.objects.get(email='admin@mozilla.com')
-        self.client.login(username=user.email, password='password')
+        self.client.login(email=user.email)
         response = self.client.get(url, follow=True)
         assert 'Download files' in response.content
 
         # Standard reviewer: should know that sources were provided.
         user = UserProfile.objects.get(email='editor@mozilla.com')
-        self.client.login(username=user.email, password='password')
+        self.client.login(email=user.email)
         response = self.client.get(url, follow=True)
         assert 'The developer has provided source code.' in response.content
 
@@ -2883,8 +2875,7 @@ class TestAbuseReports(TestCase):
         AbuseReport.objects.create(user=user, message='hey now')
 
     def test_abuse_reports_list(self):
-        assert self.client.login(username='admin@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='admin@mozilla.com')
         r = self.client.get(reverse('editors.abuse_reports', args=['a3615']))
         assert r.status_code == 200
         # We see the two abuse reports created in setUp.
@@ -2894,7 +2885,7 @@ class TestAbuseReports(TestCase):
         """Unlisted addons aren't public, and thus have no abuse reports."""
         addon = Addon.objects.get(pk=3615)
         addon.update(is_listed=False)
-        self.client.login(username='admin@mozilla.com', password='password')
+        self.client.login(email='admin@mozilla.com')
         response = reverse('editors.review', args=[addon.slug])
         abuse_report_url = reverse('editors.abuse_reports', args=['a3615'])
         assert abuse_report_url not in response
@@ -2993,8 +2984,7 @@ class LimitedReviewerBase:
 
     def login_as_limited_reviewer(self):
         self.client.logout()
-        assert self.client.login(username='limited@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='limited@mozilla.com')
 
 
 class TestLimitedReviewerQueue(QueueTest, LimitedReviewerBase):

--- a/src/olympia/editors/tests/test_views_themes.py
+++ b/src/olympia/editors/tests/test_views_themes.py
@@ -42,7 +42,7 @@ class ThemeReviewTestMixin(object):
         user.save()
         GroupUser.objects.create(group_id=50060, user=user)
 
-        self.client.login(username=email, password='password')
+        self.client.login(email=email)
         self.reviewer_count += 1
         return user
 

--- a/src/olympia/files/tests/test_views.py
+++ b/src/olympia/files/tests/test_views.py
@@ -30,8 +30,7 @@ binary = 'dictionaries/ar.dic'
 class FilesBase(object):
 
     def login_as_editor(self):
-        assert self.client.login(username='editor@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='editor@mozilla.com')
 
     def setUp(self):
         super(FilesBase, self).setUp()
@@ -102,7 +101,7 @@ class FilesBase(object):
 
     def test_view_access_developer(self):
         self.client.logout()
-        assert self.client.login(username=self.dev.email, password='password')
+        assert self.client.login(email=self.dev.email)
         self.file_viewer.extract()
         self.check_urls(200)
 
@@ -121,22 +120,20 @@ class FilesBase(object):
 
     def test_view_access_developer_view_source(self):
         self.client.logout()
-        assert self.client.login(username=self.dev.email, password='password')
+        assert self.client.login(email=self.dev.email)
         self.addon.update(view_source=True)
         self.file_viewer.extract()
         self.check_urls(200)
 
     def test_view_access_another_developer(self):
         self.client.logout()
-        assert self.client.login(username=self.regular.email,
-                                 password='password')
+        assert self.client.login(email=self.regular.email)
         self.file_viewer.extract()
         self.check_urls(403)
 
     def test_view_access_another_developer_view_source(self):
         self.client.logout()
-        assert self.client.login(username=self.regular.email,
-                                 password='password')
+        assert self.client.login(email=self.regular.email)
         self.addon.update(view_source=True)
         self.file_viewer.extract()
         self.check_urls(200)

--- a/src/olympia/internal_tools/tests/test_views.py
+++ b/src/olympia/internal_tools/tests/test_views.py
@@ -67,7 +67,7 @@ class TestInternalAddonSearchView(ESTestCase):
     def test_permissions_but_only_session_cookie(self):
         # A session cookie is not enough, we need a JWT in the headers.
         user = UserProfile.objects.get(email='editor@mozilla.com')
-        self.client.login(username=user.username, password='password')
+        self.client.login(email=user.username)
         with self.assertNumQueries(0):
             response = self.client.get(self.url)
         assert response.status_code == 401

--- a/src/olympia/legacy_discovery/tests/test_views.py
+++ b/src/olympia/legacy_discovery/tests/test_views.py
@@ -248,7 +248,7 @@ class TestPane(TestCase):
         self.url = reverse('discovery.pane', args=['3.7a1pre', 'Darwin'])
 
     def test_my_account(self):
-        self.client.login(username='regular@mozilla.com', password='password')
+        self.client.login(email='regular@mozilla.com')
         r = self.client.get(reverse('discovery.pane.account'))
         assert r.status_code == 200
         doc = pq(r.content)

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -401,9 +401,6 @@ MIDDLEWARE_CLASSES = (
 )
 
 # Auth
-AUTHENTICATION_BACKENDS = (
-    'olympia.users.backends.AmoUserBackend',
-)
 AUTH_USER_MODEL = 'users.UserProfile'
 
 # Override this in the site settings.

--- a/src/olympia/reviews/tests/test_views.py
+++ b/src/olympia/reviews/tests/test_views.py
@@ -32,10 +32,10 @@ class ReviewTest(TestCase):
         self.addon = Addon.objects.get(id=1865)
 
     def login_dev(self):
-        self.client.login(username='trev@adblockplus.org', password='password')
+        self.client.login(email='trev@adblockplus.org')
 
     def login_admin(self):
-        self.client.login(username='jbalogh@mozilla.com', password='password')
+        self.client.login(email='jbalogh@mozilla.com')
 
     def make_it_my_review(self, review_id=218468):
         r = Review.objects.get(id=review_id)
@@ -301,7 +301,7 @@ class TestCreate(ReviewTest):
     def setUp(self):
         super(TestCreate, self).setUp()
         self.add_url = helpers.url('addons.reviews.add', self.addon.slug)
-        self.client.login(username='root_x@ukr.net', password='password')
+        self.client.login(email='root_x@ukr.net')
         self.user = UserProfile.objects.get(email='root_x@ukr.net')
         self.qs = Review.objects.filter(addon=1865)
         self.more_url = self.addon.get_url_path(more=True)
@@ -440,7 +440,7 @@ class TestEdit(ReviewTest):
 
     def setUp(self):
         super(TestEdit, self).setUp()
-        self.client.login(username='root_x@ukr.net', password='password')
+        self.client.login(email='root_x@ukr.net')
 
     def test_edit(self):
         url = helpers.url('addons.reviews.edit', self.addon.slug, 218207)
@@ -625,13 +625,13 @@ class TestMobileReviews(MobileTest, TestCase):
         self.list_url = helpers.url('addons.reviews.list', self.addon.slug)
 
     def login_regular(self):
-        self.client.login(username='regular@mozilla.com', password='password')
+        self.client.login(email='regular@mozilla.com')
 
     def login_dev(self):
-        self.client.login(username='trev@adblockplus.org', password='password')
+        self.client.login(email='trev@adblockplus.org')
 
     def login_admin(self):
-        self.client.login(username='jbalogh@mozilla.com', password='password')
+        self.client.login(email='jbalogh@mozilla.com')
 
     def test_mobile(self):
         self.client.logout()

--- a/src/olympia/stats/tests/test_views.py
+++ b/src/olympia/stats/tests/test_views.py
@@ -42,12 +42,11 @@ class StatsTest(TestCase):
 
     def login_as_admin(self):
         self.client.logout()
-        self.client.login(username='jbalogh@mozilla.com', password='password')
+        self.client.login(email='jbalogh@mozilla.com')
 
     def login_as_visitor(self):
         self.client.logout()
-        self.client.login(username='nobodyspecial@mozilla.com',
-                          password='password')
+        self.client.login(email='nobodyspecial@mozilla.com')
 
     def get_view_response(self, view, **kwargs):
         view_args = self.url_args.copy()
@@ -818,18 +817,18 @@ class TestCollections(amo.tests.ESTestCase):
         assert res.status_code == 403
 
     def tests_collection_user(self):
-        self.client.login(username='admin@mozilla.com', password='password')
+        self.client.login(email='admin@mozilla.com')
         res = self.client.get(self.url)
         assert res.status_code == 200
 
     def tests_collection_admin(self):
-        self.client.login(username='admin@mozilla.com', password='password')
+        self.client.login(email='admin@mozilla.com')
         self.collection.update(author=None)
         res = self.client.get(self.url)
         assert res.status_code == 200
 
     def test_collection_json(self):
-        self.client.login(username='admin@mozilla.com', password='password')
+        self.client.login(email='admin@mozilla.com')
         res = self.client.get(self.url)
         content = json.loads(res.content)
         assert len(content) == 3
@@ -838,7 +837,7 @@ class TestCollections(amo.tests.ESTestCase):
         assert content[0]['data']['downloads'] == 1
 
     def test_collection_csv(self):
-        self.client.login(username='admin@mozilla.com', password='password')
+        self.client.login(email='admin@mozilla.com')
         self.url = reverse('stats.collection',
                            args=[self.collection.uuid, 'csv'])
         res = self.client.get(self.url)
@@ -853,7 +852,7 @@ class TestCollections(amo.tests.ESTestCase):
                              end.strftime('%Y%m%d'), 'json'])
 
     def test_collection_one_day(self):
-        self.client.login(username='admin@mozilla.com', password='password')
+        self.client.login(email='admin@mozilla.com')
         url = self.get_url(self.today, self.today)
         res = self.client.get(url)
         content = json.loads(res.content)
@@ -861,7 +860,7 @@ class TestCollections(amo.tests.ESTestCase):
         assert content[0]['date'] == self.today.strftime('%Y-%m-%d')
 
     def test_collection_range(self):
-        self.client.login(username='admin@mozilla.com', password='password')
+        self.client.login(email='admin@mozilla.com')
         yesterday = self.today - datetime.timedelta(days=1)
         day_before = self.today - datetime.timedelta(days=2)
         url = self.get_url(day_before, yesterday)

--- a/src/olympia/users/backends.py
+++ b/src/olympia/users/backends.py
@@ -1,3 +1,5 @@
+from django.db.models import Q
+
 from .models import UserProfile
 
 
@@ -11,6 +13,26 @@ class AmoUserBackend(object):
             profile = UserProfile.objects.get(email=username)
             if profile.check_password(password):
                 return profile
+        except UserProfile.DoesNotExist:
+            return None
+
+    def get_user(self, user_id):
+        try:
+            return UserProfile.objects.get(pk=user_id)
+        except UserProfile.DoesNotExist:
+            return None
+
+
+class TestUserBackend(object):
+    """Authentication backend to easily log in a user while testing."""
+    supports_anonymous_user = False
+    supports_inactive_user = False
+    supports_object_permissions = False
+
+    def authenticate(self, username=None, email=None):
+        try:
+            return UserProfile.objects.get(
+                Q(email=email) | Q(username=username))
         except UserProfile.DoesNotExist:
             return None
 

--- a/src/olympia/users/backends.py
+++ b/src/olympia/users/backends.py
@@ -3,31 +3,8 @@ from django.db.models import Q
 from .models import UserProfile
 
 
-class AmoUserBackend(object):
-    supports_anonymous_user = False
-    supports_inactive_user = False
-    supports_object_permissions = False
-
-    def authenticate(self, username=None, password=None):
-        try:
-            profile = UserProfile.objects.get(email=username)
-            if profile.check_password(password):
-                return profile
-        except UserProfile.DoesNotExist:
-            return None
-
-    def get_user(self, user_id):
-        try:
-            return UserProfile.objects.get(pk=user_id)
-        except UserProfile.DoesNotExist:
-            return None
-
-
 class TestUserBackend(object):
     """Authentication backend to easily log in a user while testing."""
-    supports_anonymous_user = False
-    supports_inactive_user = False
-    supports_object_permissions = False
 
     def authenticate(self, username=None, email=None):
         try:

--- a/src/olympia/users/backends.py
+++ b/src/olympia/users/backends.py
@@ -6,7 +6,9 @@ from .models import UserProfile
 class TestUserBackend(object):
     """Authentication backend to easily log in a user while testing."""
 
-    def authenticate(self, username=None, email=None):
+    def authenticate(self, username=None, email=None, password=None):
+        if password is not None:
+            raise TypeError('password is not allowed')
         try:
             return UserProfile.objects.get(
                 Q(email=email) | Q(username=username))

--- a/src/olympia/users/backends.py
+++ b/src/olympia/users/backends.py
@@ -7,6 +7,9 @@ class TestUserBackend(object):
     """Authentication backend to easily log in a user while testing."""
 
     def authenticate(self, username=None, email=None, password=None):
+        # This needs to explicitly throw when there is a password since django
+        # will skip this backend if a user passes a password.
+        # http://bit.ly/2duYr93
         if password is not None:
             raise TypeError('password is not allowed')
         try:

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -238,7 +238,7 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
     def has_module_perms(self, app_label):
         return self.is_superuser
 
-    backend = 'olympia.users.backends.AmoUserBackend'
+    backend = 'django.contrib.auth.backends.ModelBackend'
 
     def is_anonymous(self):
         return False

--- a/src/olympia/users/tests/test_backends.py
+++ b/src/olympia/users/tests/test_backends.py
@@ -1,18 +1,6 @@
 from olympia.amo.tests import TestCase
-from olympia.users.backends import AmoUserBackend, TestUserBackend
+from olympia.users.backends import TestUserBackend
 from olympia.users.models import UserProfile
-
-
-class TestAmoUserBackend(TestCase):
-    fixtures = ['users/test_backends']
-
-    def test_success(self):
-        assert AmoUserBackend().authenticate(
-            username='jbalogh@mozilla.com', password='password')
-
-    def test_failure(self):
-        assert not AmoUserBackend().authenticate(
-            username='jbalogh@mozilla.com', password='x')
 
 
 class TestTestUserBackend(TestCase):

--- a/src/olympia/users/tests/test_backends.py
+++ b/src/olympia/users/tests/test_backends.py
@@ -17,3 +17,16 @@ class TestTestUserBackend(TestCase):
 
     def test_no_user(self):
         assert TestUserBackend().authenticate(username='hmm') is None
+
+    def test_login_with_password(self):
+        UserProfile.objects.create(
+            email='me@mozilla.com', username='whatever', password='pass')
+        with self.assertRaises(TypeError):
+            TestUserBackend().authenticate(
+                email='me@mozilla.com', password='pass')
+
+    def test_client_login_does_not_work_with_password(self):
+        UserProfile.objects.create(
+            email='me@mozilla.com', username='whatever', password='pass')
+        with self.assertRaises(TypeError):
+            self.client.login(email='me@mozilla.com', password='pass')

--- a/src/olympia/users/tests/test_backends.py
+++ b/src/olympia/users/tests/test_backends.py
@@ -1,14 +1,31 @@
-from django.contrib.auth import authenticate
-
 from olympia.amo.tests import TestCase
+from olympia.users.backends import AmoUserBackend, TestUserBackend
+from olympia.users.models import UserProfile
 
 
 class TestAmoUserBackend(TestCase):
     fixtures = ['users/test_backends']
 
     def test_success(self):
-        assert authenticate(username='jbalogh@mozilla.com',
-                            password='password')
+        assert AmoUserBackend().authenticate(
+            username='jbalogh@mozilla.com', password='password')
 
     def test_failure(self):
-        assert not authenticate(username='jbalogh@mozilla.com', password='x')
+        assert not AmoUserBackend().authenticate(
+            username='jbalogh@mozilla.com', password='x')
+
+
+class TestTestUserBackend(TestCase):
+
+    def test_login_with_email(self):
+        user = UserProfile.objects.create(
+            email='me@mozilla.com', username='whatever', password='pass')
+        assert TestUserBackend().authenticate(email='me@mozilla.com') == user
+
+    def test_login_with_username(self):
+        user = UserProfile.objects.create(
+            email='me@mozilla.com', username='whatever', password='pass')
+        assert TestUserBackend().authenticate(username='whatever') == user
+
+    def test_no_user(self):
+        assert TestUserBackend().authenticate(username='hmm') is None

--- a/src/olympia/users/tests/test_forms.py
+++ b/src/olympia/users/tests/test_forms.py
@@ -24,20 +24,20 @@ class UserFormBase(TestCase):
 class TestUserDeleteForm(UserFormBase):
 
     def test_bad_email(self):
-        self.client.login(username='jbalogh@mozilla.com', password='password')
+        self.client.login(email='jbalogh@mozilla.com')
         data = {'email': 'wrong@example.com', 'confirm': True}
         r = self.client.post('/en-US/firefox/users/delete', data)
         msg = "Email must be jbalogh@mozilla.com."
         self.assertFormError(r, 'form', 'email', msg)
 
     def test_not_confirmed(self):
-        self.client.login(username='jbalogh@mozilla.com', password='password')
+        self.client.login(email='jbalogh@mozilla.com')
         data = {'email': 'jbalogh@mozilla.com'}
         r = self.client.post('/en-US/firefox/users/delete', data)
         self.assertFormError(r, 'form', 'confirm', 'This field is required.')
 
     def test_success(self):
-        self.client.login(username='jbalogh@mozilla.com', password='password')
+        self.client.login(email='jbalogh@mozilla.com')
         data = {'email': 'jbalogh@mozilla.com', 'confirm': True}
         self.client.post('/en-US/firefox/users/delete', data, follow=True)
         # TODO XXX: Bug 593055
@@ -50,7 +50,7 @@ class TestUserDeleteForm(UserFormBase):
     def test_developer_attempt(self, f):
         """A developer's attempt to delete one's self must be thwarted."""
         f.return_value = True
-        self.client.login(username='jbalogh@mozilla.com', password='password')
+        self.client.login(email='jbalogh@mozilla.com')
         data = {'email': 'jbalogh@mozilla.com', 'confirm': True}
         r = self.client.post('/en-US/firefox/users/delete', data, follow=True)
         self.assertContains(r, 'You cannot delete your account')
@@ -60,7 +60,7 @@ class TestUserEditForm(UserFormBase):
 
     def setUp(self):
         super(TestUserEditForm, self).setUp()
-        self.client.login(username='jbalogh@mozilla.com', password='password')
+        self.client.login(email='jbalogh@mozilla.com')
         self.url = reverse('users.edit')
 
     def test_no_username_or_display_name(self):
@@ -193,7 +193,7 @@ class TestAdminUserEditForm(UserFormBase):
 
     def setUp(self):
         super(TestAdminUserEditForm, self).setUp()
-        self.client.login(username='admin@mozilla.com', password='password')
+        self.client.login(email='admin@mozilla.com')
         self.url = reverse('users.admin_edit', args=[self.user.id])
 
     def test_delete_link(self):
@@ -218,7 +218,7 @@ class TestAdminUserEditForm(UserFormBase):
 class TestBlacklistedNameAdminAddForm(UserFormBase):
 
     def test_no_usernames(self):
-        self.client.login(username='testo@example.com', password='password')
+        self.client.login(email='testo@example.com')
         url = reverse('admin:users_blacklistedname_add')
         data = {'names': "\n\n", }
         r = self.client.post(url, data)
@@ -226,7 +226,7 @@ class TestBlacklistedNameAdminAddForm(UserFormBase):
         self.assertFormError(r, 'form', 'names', msg)
 
     def test_add(self):
-        self.client.login(username='testo@example.com', password='password')
+        self.client.login(email='testo@example.com')
         url = reverse('admin:users_blacklistedname_add')
         data = {'names': "IE6Fan\nfubar\n\n", }
         r = self.client.post(url, data)

--- a/src/olympia/versions/tests.py
+++ b/src/olympia/versions/tests.py
@@ -916,46 +916,45 @@ class TestDisabledFileDownloads(TestDownloadsBase):
         assert self.client.get(self.file_url).status_code == 404
 
     def test_file_disabled_unprivileged_404(self):
-        assert self.client.login(username='regular@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='regular@mozilla.com')
         self.file.update(status=amo.STATUS_DISABLED)
         assert self.client.get(self.file_url).status_code == 404
 
     def test_file_disabled_ok_for_author(self):
         self.file.update(status=amo.STATUS_DISABLED)
-        assert self.client.login(username='g@gmail.com', password='password')
+        assert self.client.login(email='g@gmail.com')
         self.assert_served_internally(self.client.get(self.file_url))
 
     def test_file_disabled_ok_for_editor(self):
         self.file.update(status=amo.STATUS_DISABLED)
-        self.client.login(username='editor@mozilla.com', password='password')
+        self.client.login(email='editor@mozilla.com')
         self.assert_served_internally(self.client.get(self.file_url))
 
     def test_file_disabled_ok_for_admin(self):
         self.file.update(status=amo.STATUS_DISABLED)
-        self.client.login(username='admin@mozilla.com', password='password')
+        self.client.login(email='admin@mozilla.com')
         self.assert_served_internally(self.client.get(self.file_url))
 
     def test_admin_disabled_ok_for_author(self):
         # downloads_controller.php claims that add-on authors should be able to
         # download their disabled files.
         self.addon.update(status=amo.STATUS_DISABLED)
-        assert self.client.login(username='g@gmail.com', password='password')
+        assert self.client.login(email='g@gmail.com')
         self.assert_served_internally(self.client.get(self.file_url))
 
     def test_admin_disabled_ok_for_admin(self):
         self.addon.update(status=amo.STATUS_DISABLED)
-        self.client.login(username='admin@mozilla.com', password='password')
+        self.client.login(email='admin@mozilla.com')
         self.assert_served_internally(self.client.get(self.file_url))
 
     def test_user_disabled_ok_for_author(self):
         self.addon.update(disabled_by_user=True)
-        assert self.client.login(username='g@gmail.com', password='password')
+        assert self.client.login(email='g@gmail.com')
         self.assert_served_internally(self.client.get(self.file_url))
 
     def test_user_disabled_ok_for_admin(self):
         self.addon.update(disabled_by_user=True)
-        self.client.login(username='admin@mozilla.com', password='password')
+        self.client.login(email='admin@mozilla.com')
         self.assert_served_internally(self.client.get(self.file_url))
 
 
@@ -1067,7 +1066,7 @@ class TestDownloadSource(TestCase):
         self.url = reverse('downloads.source', args=(self.version.pk, ))
 
     def test_owner_should_be_allowed(self):
-        self.client.login(username=self.user.email, password="password")
+        self.client.login(email=self.user.email)
         response = self.client.get(self.url)
         assert response.status_code == 200
         assert response[settings.XSENDFILE_HEADER]
@@ -1088,13 +1087,13 @@ class TestDownloadSource(TestCase):
     def test_deleted_version(self):
         self.version.delete()
         GroupUser.objects.create(user=self.user, group=self.group)
-        self.client.login(username=self.user.email, password="password")
+        self.client.login(email=self.user.email)
         response = self.client.get(self.url)
         assert response.status_code == 404
 
     def test_group_binarysource_should_be_allowed(self):
         GroupUser.objects.create(user=self.user, group=self.group)
-        self.client.login(username=self.user.email, password="password")
+        self.client.login(email=self.user.email)
         response = self.client.get(self.url)
         assert response.status_code == 200
         assert response[settings.XSENDFILE_HEADER]

--- a/src/olympia/zadmin/tests/test_views.py
+++ b/src/olympia/zadmin/tests/test_views.py
@@ -54,7 +54,7 @@ class TestHome(TestCase):
 
     def setUp(self):
         super(TestHome, self).setUp()
-        self.client.login(username='admin@mozilla.com', password='password')
+        self.client.login(email='admin@mozilla.com')
 
     def test_get(self):
         url = reverse('zadmin.home')
@@ -69,7 +69,7 @@ class TestSiteEvents(TestCase):
 
     def setUp(self):
         super(TestSiteEvents, self).setUp()
-        self.client.login(username='admin@mozilla.com', password='password')
+        self.client.login(email='admin@mozilla.com')
 
     def test_get(self):
         url = reverse('zadmin.site_events')
@@ -115,8 +115,7 @@ class BulkValidationTest(TestCase):
 
     def setUp(self):
         super(BulkValidationTest, self).setUp()
-        assert self.client.login(username='admin@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='admin@mozilla.com')
         self.addon = Addon.objects.get(pk=3615)
         self.creator = UserProfile.objects.get(username='editor')
         self.version = self.addon.get_version()
@@ -1112,8 +1111,7 @@ class TestEmailPreview(TestCase):
 
     def setUp(self):
         super(TestEmailPreview, self).setUp()
-        assert self.client.login(username='admin@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='admin@mozilla.com')
         addon = Addon.objects.get(pk=3615)
         self.topic = EmailPreviewTopic(addon)
 
@@ -1136,8 +1134,7 @@ class TestMonthlyPick(TestCase):
 
     def setUp(self):
         super(TestMonthlyPick, self).setUp()
-        assert self.client.login(username='admin@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='admin@mozilla.com')
         self.url = reverse('zadmin.monthly_pick')
         addon = Addon.objects.get(pk=3615)
         MonthlyPick.objects.create(addon=addon,
@@ -1211,8 +1208,7 @@ class TestFeatures(TestCase):
 
     def setUp(self):
         super(TestFeatures, self).setUp()
-        assert self.client.login(username='admin@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='admin@mozilla.com')
         self.url = reverse('zadmin.features')
         FeaturedCollection.objects.create(application=amo.FIREFOX.id,
                                           locale='zh-CN', collection_id=80)
@@ -1323,8 +1319,7 @@ class TestLookup(TestCase):
 
     def setUp(self):
         super(TestLookup, self).setUp()
-        assert self.client.login(username='admin@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='admin@mozilla.com')
         self.user = UserProfile.objects.get(pk=999)
         self.url = reverse('zadmin.search', args=['users', 'userprofile'])
 
@@ -1376,8 +1371,7 @@ class TestAddonSearch(amo.tests.ESTestCase):
     def setUp(self):
         super(TestAddonSearch, self).setUp()
         self.reindex(Addon)
-        assert self.client.login(username='admin@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='admin@mozilla.com')
         self.url = reverse('zadmin.addon-search')
 
     def test_lookup_addon(self):
@@ -1391,8 +1385,7 @@ class TestAddonAdmin(TestCase):
 
     def setUp(self):
         super(TestAddonAdmin, self).setUp()
-        assert self.client.login(username='admin@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='admin@mozilla.com')
         self.url = reverse('admin:addons_addon_changelist')
 
     def test_basic(self):
@@ -1411,7 +1404,7 @@ class TestAddonManagement(TestCase):
         super(TestAddonManagement, self).setUp()
         self.addon = Addon.objects.get(pk=3615)
         self.url = reverse('zadmin.addon_manage', args=[self.addon.slug])
-        self.client.login(username='admin@mozilla.com', password='password')
+        self.client.login(email='admin@mozilla.com')
 
     def test_can_manage_unlisted_addons(self):
         """Unlisted addons can be managed too."""
@@ -1489,7 +1482,7 @@ class TestCompat(TestCompatibilityReportCronMixin, amo.tests.ESTestCase):
     def setUp(self):
         super(TestCompat, self).setUp()
         self.url = reverse('zadmin.compat')
-        self.client.login(username='admin@mozilla.com', password='password')
+        self.client.login(email='admin@mozilla.com')
         self.app_version = FIREFOX_COMPAT[0]['main']
 
     def get_pq(self, **kw):
@@ -1649,7 +1642,7 @@ class TestMemcache(TestCase):
         super(TestMemcache, self).setUp()
         self.url = reverse('zadmin.memcache')
         cache.set('foo', 'bar')
-        self.client.login(username='admin@mozilla.com', password='password')
+        self.client.login(email='admin@mozilla.com')
 
     def test_login(self):
         self.client.logout()
@@ -1670,7 +1663,7 @@ class TestElastic(amo.tests.ESTestCase):
     def setUp(self):
         super(TestElastic, self).setUp()
         self.url = reverse('zadmin.elastic')
-        self.client.login(username='admin@mozilla.com', password='password')
+        self.client.login(email='admin@mozilla.com')
 
     def test_login(self):
         self.client.logout()
@@ -1819,8 +1812,7 @@ class TestFileDownload(TestCase):
     def setUp(self):
         super(TestFileDownload, self).setUp()
 
-        assert self.client.login(username='admin@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='admin@mozilla.com')
 
         self.file = open(get_image_path('animated.png'), 'rb')
         resp = self.client.post(reverse('devhub.upload'),
@@ -1849,8 +1841,7 @@ class TestPerms(TestCase):
 
     def test_admin_user(self):
         # Admin should see views with Django's perm decorator and our own.
-        assert self.client.login(username='admin@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='admin@mozilla.com')
         self.assert_status('zadmin.index', 200)
         self.assert_status('zadmin.settings', 200)
         self.assert_status('zadmin.langpacks', 200)
@@ -1865,8 +1856,7 @@ class TestPerms(TestCase):
         user = UserProfile.objects.get(email='regular@mozilla.com')
         group = Group.objects.create(name='Staff', rules='AdminTools:View')
         GroupUser.objects.create(group=group, user=user)
-        assert self.client.login(username='regular@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='regular@mozilla.com')
         self.assert_status('zadmin.index', 200)
         self.assert_status('zadmin.settings', 200)
         self.assert_status('zadmin.langpacks', 200)
@@ -1882,8 +1872,7 @@ class TestPerms(TestCase):
         group = Group.objects.create(name='Sr Reviewer',
                                      rules='ReviewerAdminTools:View')
         GroupUser.objects.create(group=group, user=user)
-        assert self.client.login(username='regular@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='regular@mozilla.com')
         self.assert_status('zadmin.index', 200)
         self.assert_status('zadmin.langpacks', 200)
         self.assert_status('zadmin.download_file', 404, uuid=self.FILE_ID)
@@ -1892,8 +1881,7 @@ class TestPerms(TestCase):
 
     def test_unprivileged_user(self):
         # Unprivileged user.
-        assert self.client.login(username='regular@mozilla.com',
-                                 password='password')
+        assert self.client.login(email='regular@mozilla.com')
         self.assert_status('zadmin.index', 403)
         self.assert_status('zadmin.settings', 403)
         self.assert_status('zadmin.langpacks', 403)


### PR DESCRIPTION
This makes it so you just need an email address or username to log in using the test client. One less thing that needs a password.

Supports #3049.