### PR TITLE
Validate user with user_id not username in JWT

### DIFF
--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -271,6 +271,9 @@ class APITestClient(APIClient):
         from rest_framework_jwt.settings import api_settings
         payload = api_settings.JWT_PAYLOAD_HANDLER(user)
         payload.update(payload_overrides)
+        if ('user_id' in payload_overrides and
+                payload_overrides['user_id'] is None):
+            del payload['user_id']
         token = api_settings.JWT_ENCODE_HANDLER(payload)
         return token
 

--- a/src/olympia/api/authentication.py
+++ b/src/olympia/api/authentication.py
@@ -24,8 +24,9 @@ class JSONWebTokenAuthentication(UpstreamJSONWebTokenAuthentication):
 
     def authenticate_credentials(self, payload):
         """
-        Returns a verified AMO user who is active and allowed to make API
-        requests.
+        Mimic what our ACLMiddleware does after a successful authentication,
+        because otherwise that behaviour would be missing in the API since API
+        auth happens after the middleware process request phase.
         """
         try:
             user = UserProfile.objects.get(pk=payload['user_id'])

--- a/src/olympia/api/authentication.py
+++ b/src/olympia/api/authentication.py
@@ -34,8 +34,7 @@ class JSONWebTokenAuthentication(UpstreamJSONWebTokenAuthentication):
             raise exceptions.AuthenticationFailed('User not found.')
 
         if user.deleted:
-            msg = 'User account is disabled.'
-            raise exceptions.AuthenticationFailed(msg)
+            raise exceptions.AuthenticationFailed('User account is disabled.')
 
         amo.set_user(user)
         return user

--- a/src/olympia/api/authentication.py
+++ b/src/olympia/api/authentication.py
@@ -30,6 +30,7 @@ class JSONWebTokenAuthentication(UpstreamJSONWebTokenAuthentication):
         """
         if 'user_id' not in payload:
             log.info('No user_id in JWT payload {}'.format(payload))
+            raise exceptions.AuthenticationFailed('No user_id in JWT.')
         try:
             user = UserProfile.objects.get(pk=payload['user_id'])
         except UserProfile.DoesNotExist:

--- a/src/olympia/api/authentication.py
+++ b/src/olympia/api/authentication.py
@@ -38,7 +38,7 @@ class JSONWebTokenAuthentication(UpstreamJSONWebTokenAuthentication):
             raise exceptions.AuthenticationFailed('User not found.')
 
         if user.deleted:
-            log.info('Not allowing deled user to log in {}'.format(user.pk))
+            log.info('Not allowing deleted user to log in {}'.format(user.pk))
             raise exceptions.AuthenticationFailed('User account is disabled.')
 
         amo.set_user(user)

--- a/src/olympia/api/authentication.py
+++ b/src/olympia/api/authentication.py
@@ -28,12 +28,16 @@ class JSONWebTokenAuthentication(UpstreamJSONWebTokenAuthentication):
         because otherwise that behaviour would be missing in the API since API
         auth happens after the middleware process request phase.
         """
+        if 'user_id' not in payload:
+            log.info('No user_id in JWT payload {}'.format(payload))
         try:
             user = UserProfile.objects.get(pk=payload['user_id'])
         except UserProfile.DoesNotExist:
+            log.info('User not found from JWT payload {}'.format(payload))
             raise exceptions.AuthenticationFailed('User not found.')
 
         if user.deleted:
+            log.info('Not allowing deled user to log in {}'.format(user.pk))
             raise exceptions.AuthenticationFailed('User account is disabled.')
 
         amo.set_user(user)

--- a/src/olympia/api/tests/test_authentication.py
+++ b/src/olympia/api/tests/test_authentication.py
@@ -222,6 +222,11 @@ class TestJSONWebTokenAuthentication(TestCase):
         data = json.loads(response.content)
         assert data['token'] == token
 
+    def test_no_user_id(self):
+        token = self.client.generate_api_token(self.user, user_id=None)
+        with self.assertRaises(AuthenticationFailed):
+            self._authenticate(token)
+
     def test_user_deleted(self):
         self.user.anonymize()
         token = self.client.generate_api_token(self.user)

--- a/src/olympia/api/tests/test_authentication.py
+++ b/src/olympia/api/tests/test_authentication.py
@@ -221,3 +221,8 @@ class TestJSONWebTokenAuthentication(TestCase):
         assert response.status_code == 200
         data = json.loads(response.content)
         assert data['token'] == token
+
+    def test_invalid_user_id(self):
+        token = self.client.generate_api_token(self.user, user_id=-1)
+        with self.assertRaises(AuthenticationFailed):
+            self._authenticate(token)

--- a/src/olympia/api/tests/test_authentication.py
+++ b/src/olympia/api/tests/test_authentication.py
@@ -222,7 +222,19 @@ class TestJSONWebTokenAuthentication(TestCase):
         data = json.loads(response.content)
         assert data['token'] == token
 
-    def test_invalid_user_id(self):
+    def test_user_deleted(self):
+        self.user.anonymize()
+        token = self.client.generate_api_token(self.user)
+        with self.assertRaises(AuthenticationFailed):
+            self._authenticate(token)
+
+    def test_username_changes(self):
+        token = self.client.generate_api_token(self.user)
+        self.user.update(username='different')
+        user, _ = self._authenticate(token)
+        assert user == self.user
+
+    def test_invalid_user_not_found(self):
         token = self.client.generate_api_token(self.user, user_id=-1)
         with self.assertRaises(AuthenticationFailed):
             self._authenticate(token)


### PR DESCRIPTION
Find the user based on `user_id` instead of `username` since that field can change.

Fixes #3647.