### PR TITLE
Include version ID in review API response. Fixes #3680

### DIFF
--- a/docs/topics/api/reviews.rst
+++ b/docs/topics/api/reviews.rst
@@ -69,7 +69,8 @@ This endpoint allows you to fetch a review by its id.
     :>json int rating: The rating the user gave as part of the review.
     :>json object|null reply: The review object containing the developer reply to this review, if any (The fields ``rating``, ``reply`` and ``version`` are omitted).
     :>json string|null title: The title of the review.
-    :>json string version: The add-on version string the review applies to.
+    :>json int version.id: The add-on version id the review applies to.
+    :>json string version.version: The add-on version string the review applies to.
     :>json object user: Object holding information about the user who posted the review.
     :>json string user.url: The user profile URL.
     :>json string user.name: The user name.
@@ -114,6 +115,7 @@ If successful a :ref:`review object <review-detail-object>` is returned.
     :<json string|null body: The text of the review.
     :<json string|null title: The title of the review.
     :<json int rating: The rating the user wants to give as part of the review.
+    :<json int version: The add-on version id the review applies to.
 
 
 ------

--- a/docs/topics/api/reviews.rst
+++ b/docs/topics/api/reviews.rst
@@ -115,7 +115,6 @@ If successful a :ref:`review object <review-detail-object>` is returned.
     :<json string|null body: The text of the review.
     :<json string|null title: The title of the review.
     :<json int rating: The rating the user wants to give as part of the review.
-    :<json int version: The add-on version id the review applies to.
 
 
 ------

--- a/src/olympia/reviews/tests/test_serializers.py
+++ b/src/olympia/reviews/tests/test_serializers.py
@@ -40,7 +40,10 @@ class TestBaseReviewSerializer(TestCase):
             'name': unicode(self.user.name),
             'url': absolutify(self.user.get_url_path()),
         }
-        assert result['version'] == self.review.version.version
+        assert result['version'] == {
+            'id': self.review.version.id,
+            'version': self.review.version.version
+        }
 
         self.review.update(version=None)
         result = self.serialize()

--- a/src/olympia/reviews/tests/test_views.py
+++ b/src/olympia/reviews/tests/test_views.py
@@ -1229,7 +1229,10 @@ class TestReviewViewSetEdit(TestCase):
         assert response.data['body'] == unicode(self.review.body) == u'løl!'
         assert response.data['title'] == unicode(self.review.title) == u'Titlé'
         assert response.data['rating'] == self.review.rating == 2
-        assert response.data['version'] == self.review.version.version
+        assert response.data['version'] == {
+            'id': self.review.version.id,
+            'version': self.review.version.version
+        }
         assert self.review.created == original_created_date
 
         activity_log = ActivityLog.objects.latest('pk')
@@ -1263,7 +1266,11 @@ class TestReviewViewSetEdit(TestCase):
         assert response.data['id'] == self.review.pk
         assert response.data['body'] == unicode(self.review.body) == u'løl!'
         assert response.data['title'] == unicode(self.review.title) == u'Titlé'
-        assert response.data['version'] == self.review.version.version
+        assert response.data['version'] == {
+            'id': self.review.version.id,
+            'version': self.review.version.version,
+        }
+
         assert self.review.user == original_review_user
 
         activity_log = ActivityLog.objects.latest('pk')
@@ -1354,7 +1361,10 @@ class TestReviewViewSetPost(TestCase):
         assert review.reply_to is None
         assert review.addon == self.addon
         assert review.version == self.addon.current_version
-        assert response.data['version'] == review.version.version
+        assert response.data['version'] == {
+            'id': review.version.id,
+            'version': review.version.version
+        }
         assert 'ip_address' not in response.data
         assert review.ip_address == '213.225.312.5'
         assert not review.flag
@@ -1387,7 +1397,10 @@ class TestReviewViewSetPost(TestCase):
         assert review.reply_to is None
         assert review.addon == self.addon
         assert review.version == self.addon.current_version
-        assert response.data['version'] == review.version.version
+        assert response.data['version'] == {
+            'id': review.version.id,
+            'version': review.version.version
+        }
         assert review.flag
         assert review.editorreview
 
@@ -1441,7 +1454,10 @@ class TestReviewViewSetPost(TestCase):
         assert review.reply_to is None
         assert review.addon == self.addon
         assert review.version == self.addon.current_version
-        assert response.data['version'] == review.version.version
+        assert response.data['version'] == {
+            'id': review.version.id,
+            'version': review.version.version
+        }
 
     def test_no_body_or_title_just_rating(self):
         self.user = user_factory()
@@ -1462,7 +1478,10 @@ class TestReviewViewSetPost(TestCase):
         assert review.reply_to is None
         assert review.addon == self.addon
         assert review.version == self.addon.current_version
-        assert response.data['version'] == review.version.version
+        assert response.data['version'] == {
+            'id': review.version.id,
+            'version': review.version.version
+        }
 
     def test_omit_body_and_title_completely_just_rating(self):
         self.user = user_factory()
@@ -1482,7 +1501,10 @@ class TestReviewViewSetPost(TestCase):
         assert review.reply_to is None
         assert review.addon == self.addon
         assert review.version == self.addon.current_version
-        assert response.data['version'] == review.version.version
+        assert response.data['version'] == {
+            'id': review.version.id,
+            'version': review.version.version
+        }
 
     def test_post_rating_rating_required(self):
         self.user = user_factory()


### PR DESCRIPTION
Fixes #3680 

This returns an object for `review.version` rather than just
the actual id but still allows for only receiving the id
for `POST` and `PATCH` requests.