### PR TITLE
Add warning to not share api keys. 

### DIFF
--- a/src/olympia/devhub/templates/devhub/api/key.html
+++ b/src/olympia/devhub/templates/devhub/api/key.html
@@ -22,6 +22,10 @@
           For detailed instructions, consult the <a href="{{ docs_url }}">API documentation</a>.
         {% endtrans %}
         </p>
+
+        <p class="notification-box error">
+          Keep your API keys secret and <strong>never share them with anyone</strong>, including Mozilla contributors.
+        </p>
         {% if credentials %}
           <ul class="api-credentials">
             <li class="row api-input key-input">

--- a/src/olympia/devhub/templates/devhub/api/key.html
+++ b/src/olympia/devhub/templates/devhub/api/key.html
@@ -24,7 +24,7 @@
         </p>
 
         <p class="notification-box error">
-          Keep your API keys secret and <strong>never share them with anyone</strong>, including Mozilla contributors.
+          {{ _('Keep your API keys secret and <strong>never share them with anyone</strong>, including Mozilla contributors.') }}
         </p>
         {% if credentials %}
           <ul class="api-credentials">


### PR DESCRIPTION
Fixes #1268.

![a2036f87-b6de-45d1-a7e5-2320fd624a50](https://cloud.githubusercontent.com/assets/139033/19190231/a28f99c8-8c9c-11e6-91ea-20c175ed6b9d.png)