### PR TITLE
Prettify validation results page by not prepending UUID to filename.

### DIFF
--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -2239,8 +2239,7 @@ class TestUploadDetail(BaseUploadTest):
                                     args=[upload.uuid.hex]))
         assert r.status_code == 200
         doc = pq(r.content)
-        expected = 'Validation Results for {0}_animated.png'.format(
-            upload.uuid.hex)
+        expected = 'Validation Results for animated.png'
         assert doc('header h2').text() == expected
 
         suite = doc('#addon-validator-suite')

--- a/src/olympia/devhub/tests/test_views_validation.py
+++ b/src/olympia/devhub/tests/test_views_validation.py
@@ -330,6 +330,17 @@ class TestValidateAddon(TestCase):
             reverse('devhub.standalone_upload_unlisted'))
 
     @mock.patch('validator.validate.validate')
+    def test_filename_not_uuidfied(self, validate_mock):
+        validate_mock.return_value = json.dumps(amo.VALIDATOR_SKELETON_RESULTS)
+        url = reverse('devhub.upload')
+        data = open(get_image_path('animated.png'), 'rb')
+        self.client.post(url, {'upload': data})
+        upload = FileUpload.objects.get()
+        response = self.client.get(
+            reverse('devhub.upload_detail', args=(upload.uuid.hex,)))
+        assert 'Validation Results for animated.png' in response.content
+
+    @mock.patch('validator.validate.validate')
     def test_upload_listed_addon(self, validate_mock):
         """Listed addons are not validated as "self-hosted" addons."""
         validate_mock.return_value = json.dumps(amo.VALIDATOR_SKELETON_RESULTS)

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -760,6 +760,7 @@ def _compat_result(request, revalidate_url, target_app, target_version,
     for app, ver in ff_versions:
         major = ver.split('.')[0]  # 4.0b3 -> 4
         change_links['%s %s' % (amo.APP_IDS[app].guid, ver)] = tpl % major
+
     return render(request, 'devhub/validation.html',
                   dict(validate_url=revalidate_url,
                        filename=validated_filename, timestamp=validated_ts,
@@ -901,7 +902,7 @@ def upload_detail(request, uuid, format='html'):
                               upload.compat_with_app,
                               upload.compat_with_appver)
 
-    context = {'validate_url': validate_url, 'filename': upload.name,
+    context = {'validate_url': validate_url, 'filename': upload.pretty_name,
                'automated_signing': upload.automated_signing,
                'timestamp': upload.created}
 

--- a/src/olympia/files/models.py
+++ b/src/olympia/files/models.py
@@ -680,6 +680,13 @@ class FileUpload(ModelBase):
     def load_validation(self):
         return json.loads(self.validation)
 
+    @property
+    def pretty_name(self):
+        parts = self.name.split('_', 1)
+        if len(parts) > 1:
+            return parts[1]
+        return self.name
+
 
 class FileValidation(ModelBase):
     file = models.OneToOneField(File, related_name='validation')


### PR DESCRIPTION
Fixes #1104

![page-shot-2016-10-7 validation results for gamingwonderland_v12 41 9 65484 zip __ developer hub __ add-ons for firefox](https://cloud.githubusercontent.com/assets/139033/19192839/eae3899a-8ca7-11e6-9c32-f3b1a745e430.png)
