### PR TITLE
Fixes #3645

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -1774,6 +1774,7 @@ h3.author .transfer-ownership {
 
     .button.not-available {
       font-size: 12px;
+      float: none;
       margin-top: -10px;
       min-width: 0;
       padding: 5px 5px 5px 20px;


### PR DESCRIPTION
Fixes #3645.
Removed the `float: right` rule, so that the `.button.not-available` starts from left and layout doesnt breaks.
