### PR TITLE
Reviewer emails: add login note for unlisted add-ons

### DIFF
--- a/src/olympia/editors/templates/editors/emails/unlisted_to_reviewed.ltxt
+++ b/src/olympia/editors/templates/editors/emails/unlisted_to_reviewed.ltxt
@@ -1,5 +1,5 @@
 {% extends "editors/emails/base.ltxt" %}{% block content %}
-Your add-on, {{ name }} {{ number }}, has been reviewed and is now signed and ready for you to download at {{ dev_versions_url }}
+Your add-on, {{ name }} {{ number }}, has been reviewed and is now signed and ready for you to download at {{ dev_versions_url }}. Note that you need to be logged in as a developer of the add-on before downloading.
 {% include "editors/emails/files.ltxt" %}
 Reviewer:
 {{ reviewer }}

--- a/src/olympia/editors/templates/editors/emails/unlisted_to_reviewed_auto.ltxt
+++ b/src/olympia/editors/templates/editors/emails/unlisted_to_reviewed_auto.ltxt
@@ -1,5 +1,5 @@
 {% extends "editors/emails/base.ltxt" %}{% block content %}
-Your add-on, {{ name }} {{ number }}, has passed our automatic tests and is now signed and ready for you to download at {{ dev_versions_url }}
+Your add-on, {{ name }} {{ number }}, has passed our automatic tests and is now signed and ready for you to download at {{ dev_versions_url }}. Note that you need to be logged in as a developer of the add-on before downloading.
 {% include "editors/emails/files.ltxt" %}
 Reviewer:
 {{ reviewer }}


### PR DESCRIPTION
We get regular inquiries from developers that the email download link for unlisted add-ons is not working, in almost all cases the cause is that they're not logged in.