### PR TITLE
When unlisting an add-on, set channel to unlisted on its versions

### DIFF
--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -245,6 +245,7 @@ class TestVersion(TestCase):
         addon = Addon.with_unlisted.get(id=3615)
         assert addon.status == amo.STATUS_PUBLIC
         assert not addon.is_listed
+        assert addon.latest_version.channel == amo.RELEASE_CHANNEL_UNLISTED
 
         entry = ActivityLog.objects.get()
         assert entry.action == amo.LOG.ADDON_UNLISTED.id
@@ -260,6 +261,7 @@ class TestVersion(TestCase):
         assert addon.status == amo.STATUS_PUBLIC
         assert not addon.is_listed
         assert not addon.disabled_by_user
+        assert addon.latest_version.channel == amo.RELEASE_CHANNEL_UNLISTED
 
         entry = ActivityLog.objects.get()
         assert entry.action == amo.LOG.ADDON_UNLISTED.id

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -402,6 +402,10 @@ def disable(request, addon_id, addon):
 @post_required
 def unlist(request, addon_id, addon):
     addon.update(is_listed=False, disabled_by_user=False)
+    # In https://github.com/mozilla/addons-server/issues/3471 this view will
+    # no longer be global, but in the meantime we need to set the channel
+    # property on all versions to stay consistent.
+    addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
     amo.log(amo.LOG.ADDON_UNLISTED, addon)
 
     if addon.latest_version.is_unreviewed:

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -405,7 +405,8 @@ def unlist(request, addon_id, addon):
     # In https://github.com/mozilla/addons-server/issues/3471 this view will
     # no longer be global, but in the meantime we need to set the channel
     # property on all versions to stay consistent.
-    addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+    Version.unfiltered.filter(addon=addon).update(
+        channel=amo.RELEASE_CHANNEL_UNLISTED)
     amo.log(amo.LOG.ADDON_UNLISTED, addon)
 
     if addon.latest_version.is_unreviewed:


### PR DESCRIPTION
This view will be changed later in #3471 to not make it global any more, but we need to make sure the versions channel is set properly in the meantime.