### PR TITLE
Return browserVersion '' by default instead of 0

### DIFF
--- a/static/js/zamboni/browser.js
+++ b/static/js/zamboni/browser.js
@@ -20,7 +20,7 @@ function BrowserUtils() {
 
     // browser detection
     var browser = {},
-        browserVersion = 0,
+        browserVersion = '',
         pattern, match, i,
         badBrowser = true;
     for (i in userAgentStrings) {


### PR DESCRIPTION
Fixes #3785

[If detection succeeds, browserVersion is a string. If it fails (e.g. because the user agent does not match any of the supported user agents), then browserVersion is 0.](https://github.com/mozilla/addons-server/blob/0c2b633c592a882a51698949f2262773d1462b5b/static/js/zamboni/browser.js#L23-L32)

The problem with this is that code that assumes browserVersion to be a string throws. For example, the `VersionCompare.compareVersions` method assumes that the input is a string and calls `split` on its parameter. When used with `z.browserVersion`, it throws in unsupported browsers.
For example, when a Firefox add-on listing is viewed in Chrome, the user reviews do not appear because of this error:

> Uncaught TypeError: e.split is not a function(…) impala-min.js?build=6a92846-57ffb908:1

To verify this fix, open an add-on listing in Chrome/IE/Safari and confirm that no error appears in the console and that user reviews appear.