### PR TITLE
Update redirect_url for the new frontend -dev server

### DIFF
--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -266,7 +266,7 @@ FXA_CONFIG = {
         'content_host': 'https://stable.dev.lcip.org',
         'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
         'profile_host': 'https://stable.dev.lcip.org/profile/v1',
-        'redirect_url': 'https://amo.dev.mozaws.net/fxa-authenticate',
+        'redirect_url': 'https://amo.addons-dev.allizom.org/fxa-authenticate',
         'scope': 'profile',
     },
     'local': {


### PR DESCRIPTION
Set the redirect URL for the FxA config. I pinged jason to set the client ID and secret in the environment variables.

Supports mozilla/addons-frontend#1251.