### PR TITLE
Handle invalid File statuses in editor tools (e.g. for Deleted addons)

### DIFF
--- a/src/olympia/editors/helpers.py
+++ b/src/olympia/editors/helpers.py
@@ -54,7 +54,7 @@ def file_review_status(addon, file):
         # unreviewed.  Especially for versions.
         else:
             return _(u'Rejected or Unreviewed')
-    return file.STATUS_CHOICES[file.status]
+    return file.STATUS_CHOICES.get(file.status, _('[status:%s]') % file.status)
 
 
 @register.function

--- a/src/olympia/editors/tests/test_helpers.py
+++ b/src/olympia/editors/tests/test_helpers.py
@@ -897,3 +897,12 @@ def test_version_status():
 
     version.all_files = [File(status=amo.STATUS_AWAITING_REVIEW)]
     assert u'Awaiting Review' == helpers.version_status(addon, version)
+
+
+def test_file_review_status_handles_invalid_status_id():
+    # When status is a valid one, one of STATUS_CHOICES_FILE return label.
+    assert amo.STATUS_CHOICES_FILE[amo.STATUS_PUBLIC] == (
+        helpers.file_review_status(None, File(status=amo.STATUS_PUBLIC)))
+
+    # 99 isn't a valid status, so return the status code for reference.
+    assert u'[status:99]' == helpers.file_review_status(None, File(status=99))

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -397,7 +397,8 @@ class Version(OnChangeMixin, ModelBase):
 
     @property
     def status(self):
-        return [f.STATUS_CHOICES[f.status] for f in self.all_files]
+        return [f.STATUS_CHOICES.get(f.status, _('[status:%s]') % f.status)
+                for f in self.all_files]
 
     @property
     def statuses(self):

--- a/src/olympia/versions/tests.py
+++ b/src/olympia/versions/tests.py
@@ -551,6 +551,16 @@ class TestVersion(TestCase):
         uploaded_name = source_upload_path(version, 'crosswarpex-확장.tar.gz')
         assert uploaded_name.endswith(u'crosswarpex-확장-0.1-src.tar.gz')
 
+    def test_status_handles_invalid_status_id(self):
+        version = Addon.objects.get(id=3615).current_version
+        # When status is a valid one, one of STATUS_CHOICES_FILE return label.
+        assert version.status == [
+            amo.STATUS_CHOICES_FILE[version.all_files[0].status]]
+
+        version.all_files[0].update(status=99)  # 99 isn't a valid status.
+        # otherwise return the status code for reference.
+        assert version.status == [u'[status:99]']
+
 
 @pytest.mark.parametrize("addon_status,file_status,is_unreviewed", [
     (amo.STATUS_NOMINATED, amo.STATUS_AWAITING_REVIEW, True),


### PR DESCRIPTION
Fixes #3721