### PR TITLE
change acl permission strings to DRF permission constants

### DIFF
--- a/src/olympia/access/acl.py
+++ b/src/olympia/access/acl.py
@@ -1,4 +1,5 @@
 from olympia import amo
+from olympia.access import permissions
 
 
 def match_rules(rules, app, action):
@@ -71,9 +72,9 @@ def check_collection_ownership(request, collection, require_owner=False):
     if not request.user.is_authenticated():
         return False
 
-    if action_allowed(request, 'Admin', '%'):
+    if permissions.ADMIN.has_permission(request):
         return True
-    elif action_allowed(request, 'Collections', 'Edit'):
+    elif permissions.COLLECTIONS_EDIT.has_permission(request):
         return True
     elif request.user.id == collection.author_id:
         return True
@@ -101,7 +102,7 @@ def check_addon_ownership(request, addon, viewer=False, dev=False,
     if addon.is_deleted:
         return False
     # Users with 'Addons:Edit' can do anything.
-    if admin and action_allowed(request, 'Addons', 'Edit'):
+    if admin and permissions.ADDONS_EDIT.has_permission(request):
         return True
     # Only admins can edit admin-disabled addons.
     if addon.status == amo.STATUS_DISABLED and not ignore_disabled:
@@ -136,5 +137,6 @@ def check_personas_reviewer(request):
 def is_editor(request, addon):
     """Return True if the user is an addons reviewer, or a personas reviewer
     and the addon is a persona."""
-    return (check_addons_reviewer(request) or
-            (check_personas_reviewer(request) and addon.is_persona()))
+    return ((permissions.ADDONS_REVIEW.has_permission(request)) or
+            (permissions.THEMES_REVIEW.has_permission(request) and
+             addon.is_persona()))

--- a/src/olympia/access/permissions.py
+++ b/src/olympia/access/permissions.py
@@ -1,0 +1,102 @@
+import functools
+from rest_framework.permissions import BasePermission
+
+from django.core.exceptions import PermissionDenied
+
+from olympia.amo.decorators import login_required
+
+
+def match_rules(rules, app, action):
+    """
+    This will match rules found in Group.
+    """
+    for rule in rules.split(','):
+        rule_app, rule_action = rule.split(':')
+        if rule_app == '*' or rule_app == app:
+            if rule_action == '*' or rule_action == action or action == '%':
+                return True
+    return False
+
+
+class AclPermission(BasePermission):
+    """
+    Defines what permissions are needed to do a certain action.
+
+    'Admin:%' is true if the user has any of:
+    ('Admin:*', 'Admin:%s'%whatever, '*:*',) as rules.
+
+    Note: methods rely on user.groups_list, which is cached on the user
+    instance the first time it's accessed.
+    """
+
+    def __init__(self, app, action):
+        self.app = app
+        self.action = action
+
+    def user_has_permission(self, user):
+        if not user.is_authenticated():
+            return False
+
+        return any(
+            match_rules(group.rules, self.app, self.action)
+            for group in user.groups_list)
+
+    def has_permission(self, request, view=None):
+        # `view` param isn't used
+        return self.user_has_permission(request.user)
+
+    def has_object_permission(self, request, view, obj):
+        return self.has_permission(request, view)
+
+    def __unicode__(self):
+        return '%s:%s' % (self.app, self.action)
+
+    def __str__(self):
+        return unicode(self).encode('utf-8')
+
+    def __call__(self, *a):
+        """
+        ignore DRF's nonsensical need to call this object.
+        """
+        return self
+
+    def decorator(self, f):
+        """Makes this Permission into a decorator."""
+        @login_required
+        @functools.wraps(f)
+        def wrapper(request, *args, **kw):
+            if self.has_permission(request, None):
+                return f(request, *args, **kw)
+            raise PermissionDenied
+        return wrapper
+
+
+# Special null rule.
+NONE = AclPermission('None', 'None')
+
+# Admin super powers.  Very few users will have this permission (2-3)
+ADMIN = AclPermission('Admin', '%')
+
+# Can view admin tools.
+ADMINTOOLS = AclPermission('AdminTools', 'View')
+# Can view add-on reviewer admin tools.
+REVIEWERADMINTOOLS = AclPermission('ReviewerAdminTools', 'View')
+
+
+# These users gain access to the accounts API to super-create users.
+ACCOUNTS_SUPERCREATE = AclPermission('Accounts', 'SuperCreate')
+
+# Can submit an editor review for a listed add-on.
+ADDONS_REVIEW = AclPermission('Addons', 'Review')
+# Can submit an editor review for an unlisted add-on.
+ADDONS_REVIEW_UNLISTED = AclPermission('Addons', 'ReviewUnlisted')
+# Can edit the message of the day in the reviewer tools.
+ADDONREVIEWERMOTD_EDIT = AclPermission('AddonReviewerMOTD', 'Edit')
+# Can submit an editor review for a background theme (persona).
+THEMES_REVIEW = AclPermission('Personas', 'Review')
+
+# Can edit the properties of any add-on (pseduo-admin).
+ADDONS_EDIT = AclPermission('Addons', 'Edit')
+
+# Can edit all collections.
+COLLECTIONS_EDIT = AclPermission('Collections', 'Edit')

--- a/src/olympia/access/tests/test_acl.py
+++ b/src/olympia/access/tests/test_acl.py
@@ -2,13 +2,14 @@ import mock
 import pytest
 
 from olympia import amo
-from olympia.amo.tests import TestCase, req_factory_factory
+from olympia.access import permissions
+from olympia.access.acl import (
+    check_addon_ownership, check_ownership, check_addons_reviewer,
+    check_personas_reviewer, check_unlisted_addons_reviewer, is_editor,
+    match_rules)
 from olympia.addons.models import Addon, AddonUser
+from olympia.amo.tests import TestCase, req_factory_factory
 from olympia.users.models import UserProfile
-
-from .acl import (action_allowed, check_addon_ownership, check_ownership,
-                  check_addons_reviewer, check_personas_reviewer,
-                  check_unlisted_addons_reviewer, is_editor, match_rules)
 
 
 pytestmark = pytest.mark.django_db
@@ -60,7 +61,7 @@ def test_match_rules():
 
 def test_anonymous_user():
     fake_request = req_factory_factory('/')
-    assert not action_allowed(fake_request, amo.FIREFOX, 'Admin:%')
+    assert not permissions.ADMIN.has_permission(fake_request)
 
 
 class ACLTestCase(TestCase):

--- a/src/olympia/access/tests/test_permissions.py
+++ b/src/olympia/access/tests/test_permissions.py
@@ -1,0 +1,67 @@
+from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory
+
+from mock import Mock
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from olympia.access.models import Group, GroupUser
+from olympia.access.permissions import AclPermission
+from olympia.amo.tests import TestCase, WithDynamicEndpoints
+from olympia.users.models import UserProfile
+
+
+class ProtectedView(APIView):
+    # Use session auth for this test view because it's easy, and the goal is
+    # to test the permission, not the authentication.
+    authentication_classes = [SessionAuthentication]
+    permission_classes = [AclPermission('SomeRealm', 'SomePermission')]
+
+    def get(self, request):
+        return Response('ok')
+
+
+def myview(*args, **kwargs):
+    pass
+
+
+class TestAclPermissionOnView(WithDynamicEndpoints):
+    # Note: be careful when testing, under the hood we're using a method that
+    # relies on UserProfile.groups_list, which is cached on the UserProfile
+    # instance.
+    fixtures = ['base/users']
+
+    def setUp(self):
+        super(TestAclPermissionOnView, self).setUp()
+        self.endpoint(ProtectedView)
+        self.url = '/en-US/firefox/dynamic-endpoint'
+        email = 'regular@mozilla.com'
+
+        self.user = UserProfile.objects.get(email=email)
+        group = Group.objects.create(rules='SomeRealm:SomePermission')
+        GroupUser.objects.create(group=group, user=self.user)
+
+        assert self.client.login(email=email)
+
+    def test_user_must_be_in_required_group(self):
+        self.user.groups.all().delete()
+        res = self.client.get(self.url)
+        assert res.status_code == 403, res.content
+        assert res.data['detail'] == (
+            'You do not have permission to perform this action.')
+
+    def test_view_is_executed(self):
+        res = self.client.get(self.url)
+        assert res.status_code == 200, res.content
+        assert res.content == '"ok"'
+
+
+class TestAclPermission(TestCase):
+
+    def test_user_cannot_be_anonymous(self):
+        request = RequestFactory().get('/')
+        request.user = AnonymousUser()
+        view = Mock()
+        perm = AclPermission('SomeRealm', 'SomePermission')
+        assert not perm.has_permission(request, view)

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -23,12 +23,12 @@ from rest_framework.viewsets import GenericViewSet
 from rest_framework_jwt.settings import api_settings as jwt_api_settings
 from waffle.decorators import waffle_switch
 
+from olympia.access import permissions
 from olympia.access.models import GroupUser
 from olympia.amo import messages
 from olympia.amo.decorators import write
 from olympia.amo.utils import urlparams
 from olympia.api.authentication import JWTKeyAuthentication
-from olympia.api.permissions import GroupPermission
 from olympia.users.models import UserProfile
 
 from . import verify
@@ -337,7 +337,7 @@ class AccountViewSet(RetrieveModelMixin, GenericViewSet):
 class AccountSuperCreate(APIView):
     authentication_classes = [JWTKeyAuthentication]
     permission_classes = [
-        IsAuthenticated, GroupPermission('Accounts', 'SuperCreate')]
+        IsAuthenticated, permissions.ACCOUNTS_SUPERCREATE]
 
     @waffle_switch('super-create-accounts')
     def post(self, request):

--- a/src/olympia/activity/tests/test_utils.py
+++ b/src/olympia/activity/tests/test_utils.py
@@ -11,6 +11,7 @@ import pytest
 from waffle.testutils import override_switch
 
 from olympia import amo
+from olympia.access import permissions
 from olympia.access.models import Group, GroupUser
 from olympia.amo.helpers import absolutify
 from olympia.amo.tests import addon_factory, user_factory, TestCase
@@ -272,13 +273,15 @@ class TestLogAndNotify(TestCase):
                           self.addon.get_dev_url('versions'))
 
     def test_staff_cc_group_is_empty_no_failure(self):
-        Group.objects.create(name=ACTIVITY_MAIL_GROUP, rules='None:None')
+        Group.objects.create(name=ACTIVITY_MAIL_GROUP,
+                             rules=permissions.NONE)
         log_and_notify(amo.LOG.REJECT_VERSION, u'á', self.reviewer,
                        self.addon.latest_version)
 
     @mock.patch('olympia.activity.utils.send_mail')
     def test_staff_cc_group_get_mail(self, send_mail_mock):
-        self.grant_permission(self.reviewer, 'None:None', ACTIVITY_MAIL_GROUP)
+        self.grant_permission(self.reviewer, permissions.NONE,
+                              ACTIVITY_MAIL_GROUP)
         action = amo.LOG.DEVELOPER_REPLY_VERSION
         comments = u'Thïs is á reply'
         version = self.addon.latest_version

--- a/src/olympia/amo/context_processors.py
+++ b/src/olympia/amo/context_processors.py
@@ -6,7 +6,7 @@ from django.utils.http import urlquote
 
 from olympia import amo
 from olympia.amo.urlresolvers import reverse
-from olympia.access import acl
+from olympia.access import permissions
 from olympia.zadmin.models import get_config
 
 
@@ -42,8 +42,8 @@ def global_settings(request):
         user = request.user
 
         profile = request.user
-        is_reviewer = (acl.check_addons_reviewer(request) or
-                       acl.check_personas_reviewer(request))
+        is_reviewer = (permissions.ADDONS_REVIEW.has_permission(request) or
+                       permissions.THEMES_REVIEW.has_permission(request))
 
         account_links.append({'text': _('My Profile'),
                               'href': profile.get_url_path()})
@@ -86,8 +86,8 @@ def global_settings(request):
         if is_reviewer:
             tools_links.append({'text': _('Editor Tools'),
                                 'href': reverse('editors.home')})
-        if (acl.action_allowed(request, 'Admin', '%') or
-                acl.action_allowed(request, 'AdminTools', 'View')):
+        if (permissions.ADMIN.has_permission(request) or
+                permissions.ADMINTOOLS.has_permission(request)):
             tools_links.append({'text': _('Admin Tools'),
                                 'href': reverse('zadmin.home')})
 

--- a/src/olympia/api/permissions.py
+++ b/src/olympia/api/permissions.py
@@ -8,29 +8,6 @@ from olympia.access import acl
 # https://github.com/mozilla/zamboni/blob/master/mkt/api/permissions.py for
 # more.
 
-class GroupPermission(BasePermission):
-    """
-    Allow access depending on the result of action_allowed_user().
-    """
-    def __init__(self, app, action):
-        self.app = app
-        self.action = action
-
-    def has_permission(self, request, view):
-        if not request.user.is_authenticated():
-            return False
-        return acl.action_allowed_user(request.user, self.app, self.action)
-
-    def has_object_permission(self, request, view, obj):
-        return self.has_permission(request, view)
-
-    def __call__(self, *a):
-        """
-        ignore DRF's nonsensical need to call this object.
-        """
-        return self
-
-
 class AnyOf(BasePermission):
     """
     Takes multiple permission objects and succeeds if any single one does.

--- a/src/olympia/editors/tests/test_views.py
+++ b/src/olympia/editors/tests/test_views.py
@@ -17,11 +17,11 @@ from mock import Mock, patch
 from pyquery import PyQuery as pq
 
 from olympia import amo, reviews
-from olympia.amo.tests import TestCase
 from olympia.abuse.models import AbuseReport
+from olympia.access import permissions
 from olympia.access.models import Group, GroupUser
 from olympia.addons.models import Addon, AddonDependency, AddonUser
-from olympia.amo.tests import check_links, formset, initial
+from olympia.amo.tests import check_links, formset, initial, TestCase
 from olympia.amo.urlresolvers import reverse
 from olympia.constants.base import REVIEW_LIMITED_DELAY_HOURS
 from olympia.devhub.models import ActivityLog
@@ -2663,8 +2663,9 @@ class TestEditorMOTD(EditorTest):
 
     def test_motd_edit_group(self):
         user = UserProfile.objects.get(email='editor@mozilla.com')
-        group = Group.objects.create(name='Add-on Reviewer MOTD',
-                                     rules='AddonReviewerMOTD:Edit')
+        group = Group.objects.create(
+            name='Add-on Reviewer MOTD',
+            rules=permissions.ADDONREVIEWERMOTD_EDIT)
         GroupUser.objects.create(user=user, group=group)
         self.login_as_editor()
         r = self.client.post(reverse('editors.save_motd'),

--- a/src/olympia/editors/views.py
+++ b/src/olympia/editors/views.py
@@ -16,7 +16,7 @@ from django.utils.translation import ugettext as _, pgettext
 from olympia import amo
 from olympia.devhub import tasks as devhub_tasks
 from olympia.abuse.models import AbuseReport
-from olympia.access import acl
+from olympia.access import acl, permissions
 from olympia.addons.decorators import addon_view, addon_view_factory
 from olympia.addons.models import Addon, Version
 from olympia.amo.decorators import json_view, post_required
@@ -64,7 +64,7 @@ def context(request, **kw):
 def eventlog(request):
     form = forms.EventLogForm(request.GET)
     eventlog = ActivityLog.objects.editor_events()
-    motd_editable = acl.action_allowed(request, 'AddonReviewerMOTD', 'Edit')
+    motd_editable = permissions.ADDONREVIEWERMOTD_EDIT.has_permission(request)
 
     if form.is_valid():
         if form.cleaned_data['start']:
@@ -117,7 +117,7 @@ def beta_signed_log(request):
     """Log of all the beta files that got signed."""
     form = forms.BetaSignedLogForm(request.GET)
     beta_signed_log = ActivityLog.objects.beta_signed_events()
-    motd_editable = acl.action_allowed(request, 'AddonReviewerMOTD', 'Edit')
+    motd_editable = permissions.ADDONREVIEWERMOTD_EDIT.has_permission(request)
 
     if form.is_valid():
         if form.cleaned_data['filter']:
@@ -137,7 +137,7 @@ def home(request):
             acl.action_allowed(request, 'Personas', 'Review')):
         return http.HttpResponseRedirect(reverse('editors.themes.home'))
 
-    motd_editable = acl.action_allowed(request, 'AddonReviewerMOTD', 'Edit')
+    motd_editable = permissions.ADDONREVIEWERMOTD_EDIT.has_permission(request)
     durations = (('new', _('New Add-ons (Under 5 days)')),
                  ('med', _('Passable (5 to 10 days)')),
                  ('old', _('Overdue (Over 10 days)')))
@@ -234,7 +234,7 @@ def performance(request, user_id=False):
         except UserProfile.DoesNotExist:
             pass  # Use request.user from above.
 
-    motd_editable = acl.action_allowed(request, 'AddonReviewerMOTD', 'Edit')
+    motd_editable = permissions.ADDONREVIEWERMOTD_EDIT.has_permission(request)
 
     monthly_data = _performance_by_month(user.id)
     performance_total = _performance_total(monthly_data)
@@ -365,10 +365,10 @@ def _performance_by_month(user_id, months=12, end_month=None, end_year=None):
 @addons_reviewer_required
 def motd(request):
     form = None
-    if acl.action_allowed(request, 'AddonReviewerMOTD', 'Edit'):
+    motd_editable = permissions.ADDONREVIEWERMOTD_EDIT.has_permission(request)
+    if motd_editable:
         form = forms.MOTDForm(
             initial={'motd': get_config('editors_review_motd')})
-    motd_editable = acl.action_allowed(request, 'AddonReviewerMOTD', 'Edit')
     data = context(request, form=form, motd_editable=motd_editable)
     return render(request, 'editors/motd.html', data)
 
@@ -376,7 +376,7 @@ def motd(request):
 @addons_reviewer_required
 @post_required
 def save_motd(request):
-    if not acl.action_allowed(request, 'AddonReviewerMOTD', 'Edit'):
+    if not permissions.ADDONREVIEWERMOTD_EDIT.has_permission(request):
         raise PermissionDenied
     form = forms.MOTDForm(request.POST)
     if form.is_valid():
@@ -412,7 +412,7 @@ def _queue(request, TableObj, tab, qs=None, unlisted=False,
     if not admin_reviewer and not search_form.data.get('searching'):
         qs = exclude_admin_only_addons(qs)
 
-    motd_editable = acl.action_allowed(request, 'AddonReviewerMOTD', 'Edit')
+    motd_editable = permissions.ADDONREVIEWERMOTD_EDIT.has_permission(request)
     order_by = request.GET.get('sort', TableObj.default_order_by())
     if hasattr(TableObj, 'translate_sort_cols'):
         order_by = TableObj.translate_sort_cols(order_by)
@@ -499,7 +499,7 @@ def queue_moderated(request):
                         .order_by('reviewflag__created'))
 
     page = paginate(request, rf, per_page=20)
-    motd_editable = acl.action_allowed(request, 'AddonReviewerMOTD', 'Edit')
+    motd_editable = permissions.ADDONREVIEWERMOTD_EDIT.has_permission(request)
 
     flags = dict(ReviewFlag.FLAGS)
 
@@ -763,7 +763,7 @@ def queue_review_text(request, log_id):
 def reviewlog(request):
     data = request.GET.copy()
 
-    motd_editable = acl.action_allowed(request, 'AddonReviewerMOTD', 'Edit')
+    motd_editable = permissions.ADDONREVIEWERMOTD_EDIT.has_permission(request)
 
     if not data.get('start') and not data.get('end'):
         today = date.today()

--- a/src/olympia/internal_tools/views.py
+++ b/src/olympia/internal_tools/views.py
@@ -2,10 +2,11 @@ import logging
 
 from django.conf import settings
 
+from olympia.access import permissions
 from olympia.accounts.views import LoginBaseView, LoginStartBaseView
 from olympia.addons.views import AddonSearchView
 from olympia.api.authentication import JSONWebTokenAuthentication
-from olympia.api.permissions import AnyOf, GroupPermission
+from olympia.api.permissions import AnyOf
 from olympia.search.filters import (
     InternalSearchParameterFilter, SearchQueryFilter, SortingFilter)
 
@@ -24,8 +25,8 @@ class InternalAddonSearchView(AddonSearchView):
     ]
 
     # Restricted to specific permissions.
-    permission_classes = [AnyOf(GroupPermission('AdminTools', 'View'),
-                                GroupPermission('ReviewerAdminTools', 'View'))]
+    permission_classes = [AnyOf(permissions.ADMINTOOLS,
+                                permissions.REVIEWERADMINTOOLS)]
 
 
 class LoginStartView(LoginStartBaseView):

--- a/src/olympia/reviews/views.py
+++ b/src/olympia/reviews/views.py
@@ -24,13 +24,13 @@ from olympia.amo.decorators import (
     json_view, login_required, post_required, restricted_content)
 from olympia.amo import helpers
 from olympia.amo.utils import render, paginate
-from olympia.access import acl
+from olympia.access import acl, permissions
 from olympia.addons.decorators import addon_view_factory
 from olympia.addons.models import Addon
 from olympia.addons.views import AddonChildMixin
 from olympia.api.permissions import (
     AllowAddonAuthor, AllowIfReviewedAndListed, AllowOwner,
-    AllowRelatedObjectPermissions, AnyOf, ByHttpMethod, GroupPermission)
+    AllowRelatedObjectPermissions, AnyOf, ByHttpMethod)
 
 from .helpers import user_can_delete_review
 from .models import Review, ReviewFlag, GroupedRating, Spam
@@ -310,7 +310,7 @@ class ReviewViewSet(AddonChildMixin, ModelViewSet):
             'post': IsAuthenticated,
 
             # To edit a review you need to be the author or be an admin.
-            'patch': AnyOf(AllowOwner, GroupPermission('Addons', 'Edit')),
+            'patch': AnyOf(AllowOwner, permissions.ADDONS_EDIT),
 
             # Implementing PUT would be a little incoherent as we don't want to
             # allow users to change `version` but require it at creation time.
@@ -318,7 +318,7 @@ class ReviewViewSet(AddonChildMixin, ModelViewSet):
         }),
     ]
     reply_permission_classes = [AnyOf(
-        GroupPermission('Addons', 'Edit'),
+        permissions.ADDONS_EDIT,
         AllowRelatedObjectPermissions('addon', [AllowAddonAuthor]),
     )]
     reply_serializer_class = ReviewSerializerReply


### PR DESCRIPTION
start of #3572 
Only a sample of usage converted.

aims/ideas:
constants for permissions
make permission constants subclass `BasePermission` so can be used in DRF
easily allow them to be used as view decorators
