### PR TITLE
Make warning about sharing API creds clearer

### DIFF
--- a/docs/topics/api/auth.rst
+++ b/docs/topics/api/auth.rst
@@ -17,9 +17,15 @@ Access Credentials
 
 To create JWTs, first obtain a **key** and **secret** from the
 `API Credentials Management Page`_.
-Keep the secret string well protected and never check it into version control.
-If someone obtains your secret they can make API requests on behalf of your
-user account.
+
+
+.. note::
+
+    Keep your API keys secret and *never* commit them to a public code repository
+    or share them with anyone, including Mozilla contributors.
+
+    If someone obtains your secret they can make API requests on behalf of your user account.
+
 
 Create a JWT for each request
 =============================


### PR DESCRIPTION
Fixes #3813

Before: 
<img alt="authentication__external__ _addons-server_3_0_documentation" src="https://cloud.githubusercontent.com/assets/1514/19552545/1fe46f2e-96a8-11e6-8b48-a122b3f84a7f.png">

After (note the lack of the icon next to the word "note" is a local issue only):

<img alt="authentication__external__ _addons-server_3_0_documentation" src="https://cloud.githubusercontent.com/assets/1514/19552536/15ac77d6-96a8-11e6-8c99-17547f5125ea.png">
