### PR TITLE
Update CORS for login API on -dev

### DIFF
--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -283,12 +283,16 @@ DEFAULT_FXA_CONFIG_NAME = 'default'
 INTERNAL_FXA_CONFIG_NAME = 'internal'
 ALLOWED_FXA_CONFIGS = ['default', 'amo', 'local']
 
-INTERNAL_DOMAINS = [
-    'addons-admin.dev.mozaws.net',
-    'localhost:3000',
-]
-for regex, overrides in CORS_ENDPOINT_OVERRIDES:
-    overrides['CORS_ORIGIN_WHITELIST'] = INTERNAL_DOMAINS
+CORS_ENDPOINT_OVERRIDES = cors_endpoint_overrides(
+    public=[
+        'amo.addons-dev.allizom.org',
+        'localhost:3000',
+    ],
+    internal=[
+        'addons-admin.dev.mozaws.net',
+        'localhost:3000',
+    ],
+)
 
 READ_ONLY = env.bool('READ_ONLY', default=False)
 

--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -229,9 +229,10 @@ DEFAULT_FXA_CONFIG_NAME = 'default'
 INTERNAL_FXA_CONFIG_NAME = 'internal'
 ALLOWED_FXA_CONFIGS = ['default', 'amo']
 
-INTERNAL_DOMAINS = ['addons-admin.prod.mozaws.net']
-for regex, overrides in CORS_ENDPOINT_OVERRIDES:
-    overrides['CORS_ORIGIN_WHITELIST'] = INTERNAL_DOMAINS
+CORS_ENDPOINT_OVERRIDES = cors_endpoint_overrides(
+    public=['amo.addons.mozilla.org'],
+    internal=['addons-admin.prod.mozaws.net'],
+)
 
 VALIDATOR_TIMEOUT = 360
 

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -261,9 +261,10 @@ DEFAULT_FXA_CONFIG_NAME = 'default'
 INTERNAL_FXA_CONFIG_NAME = 'internal'
 ALLOWED_FXA_CONFIGS = ['default', 'amo']
 
-INTERNAL_DOMAINS = ['addons-admin.stage.mozaws.net']
-for regex, overrides in CORS_ENDPOINT_OVERRIDES:
-    overrides['CORS_ORIGIN_WHITELIST'] = INTERNAL_DOMAINS
+CORS_ENDPOINT_OVERRIDES = cors_endpoint_overrides(
+    public=['amo.addons.allizom.org'],
+    internal=['addons-admin.stage.mozaws.net'],
+)
 
 READ_ONLY = env.bool('READ_ONLY', default=False)
 

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -84,23 +84,29 @@ NOBODY_EMAIL = 'nobody@mozilla.org'
 # django-cors-headers.
 CORS_ORIGIN_ALLOW_ALL = True
 CORS_URLS_REGEX = r'^/api/v3/.*$'
-INTERNAL_DOMAINS = ['localhost:3000']
-CORS_ENDPOINT_OVERRIDES = [
-    (r'^/api/v3/internal/accounts/login/?$', {
-        'CORS_ORIGIN_ALLOW_ALL': False,
-        'CORS_ORIGIN_WHITELIST': INTERNAL_DOMAINS,
-        'CORS_ALLOW_CREDENTIALS': True,
-    }),
-    (r'^/api/v3/accounts/login/?$', {
-        'CORS_ORIGIN_ALLOW_ALL': False,
-        'CORS_ORIGIN_WHITELIST': INTERNAL_DOMAINS,
-        'CORS_ALLOW_CREDENTIALS': True,
-    }),
-    (r'^/api/v3/internal/.*$', {
-        'CORS_ORIGIN_ALLOW_ALL': False,
-        'CORS_ORIGIN_WHITELIST': INTERNAL_DOMAINS,
-    }),
-]
+
+def cors_endpoint_overrides(internal, public):
+    return [
+        (r'^/api/v3/internal/accounts/login/?$', {
+            'CORS_ORIGIN_ALLOW_ALL': False,
+            'CORS_ORIGIN_WHITELIST': internal,
+            'CORS_ALLOW_CREDENTIALS': True,
+        }),
+        (r'^/api/v3/accounts/login/?$', {
+            'CORS_ORIGIN_ALLOW_ALL': False,
+            'CORS_ORIGIN_WHITELIST': public,
+            'CORS_ALLOW_CREDENTIALS': True,
+        }),
+        (r'^/api/v3/internal/.*$', {
+            'CORS_ORIGIN_ALLOW_ALL': False,
+            'CORS_ORIGIN_WHITELIST': internal,
+        }),
+    ]
+
+CORS_ENDPOINT_OVERRIDES = cors_endpoint_overrides(
+    public=['localhost:3000', 'olympia.dev'],
+    internal=['localhost:3000'],
+)
 
 DATABASES = {
     'default': env.db(default='mysql://root:@localhost/olympia')

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -85,6 +85,7 @@ NOBODY_EMAIL = 'nobody@mozilla.org'
 CORS_ORIGIN_ALLOW_ALL = True
 CORS_URLS_REGEX = r'^/api/v3/.*$'
 
+
 def cors_endpoint_overrides(internal, public):
     return [
         (r'^/api/v3/internal/accounts/login/?$', {


### PR DESCRIPTION
Update the settings to use a helper to define the overrides based on our public and internal domains instead of overriding them all with `INTERNAL_DOMAINS`.

Fixes #3826.