### PR TITLE
Fix some pytest warnings

### DIFF
--- a/src/olympia/api/tests/test_exceptions.py
+++ b/src/olympia/api/tests/test_exceptions.py
@@ -11,13 +11,13 @@ from rest_framework.settings import api_settings
 from rest_framework.viewsets import GenericViewSet
 
 
-class TestViewSet(GenericViewSet):
+class DummyViewSet(GenericViewSet):
     """Dummy test viewset that raises an exception when calling list()."""
     def list(self, *args, **kwargs):
         raise Exception('something went wrong')
 
 test_exception = SimpleRouter()
-test_exception.register('testexcept', TestViewSet, base_name='test-exception')
+test_exception.register('testexcept', DummyViewSet, base_name='test-exception')
 
 
 class TestExceptionHandlerWithViewSet(TestCase):
@@ -34,7 +34,7 @@ class TestExceptionHandlerWithViewSet(TestCase):
             assert response.data == {'detail': 'Internal Server Error'}
 
         assert got_request_exception_mock.send.call_count == 1
-        assert got_request_exception_mock.send.call_args[0][0] == TestViewSet
+        assert got_request_exception_mock.send.call_args[0][0] == DummyViewSet
         assert isinstance(
             got_request_exception_mock.send.call_args[1]['request'], Request)
 
@@ -52,7 +52,7 @@ class TestExceptionHandlerWithViewSet(TestCase):
             assert 'Traceback (most recent call last):' in data['traceback']
 
         assert got_request_exception_mock.send.call_count == 1
-        assert got_request_exception_mock.send.call_args[0][0] == TestViewSet
+        assert got_request_exception_mock.send.call_args[0][0] == DummyViewSet
         assert isinstance(
             got_request_exception_mock.send.call_args[1]['request'], Request)
 

--- a/src/olympia/stats/tests/test_views.py
+++ b/src/olympia/stats/tests/test_views.py
@@ -315,7 +315,7 @@ class TestCSVs(ESStatsTest):
                                           group='day', format='csv')
 
         assert (
-            set(response['cache-control'].split(', ')),
+            set(response['cache-control'].split(', ')) ==
             {'max-age=0', 'no-cache', 'no-store', 'must-revalidate'},
         )
 
@@ -323,7 +323,7 @@ class TestCSVs(ESStatsTest):
         response = self.get_view_response('stats.versions_series', head=True,
                                           group='day', format='json')
         assert (
-            set(response['cache-control'].split(', ')),
+            set(response['cache-control'].split(', ')) ==
             {'max-age=0', 'no-cache', 'no-store', 'must-revalidate'},
         )
 

--- a/src/olympia/translations/tests/test_forms.py
+++ b/src/olympia/translations/tests/test_forms.py
@@ -7,7 +7,7 @@ from olympia.translations import forms, fields
 from olympia.translations.tests.testapp.models import TranslatedModel
 
 
-class TestForm(forms.TranslationFormMixin, ModelForm):
+class DummyForm(forms.TranslationFormMixin, ModelForm):
     name = fields.TransField()
 
     class Meta:
@@ -21,7 +21,7 @@ class TestTranslationFormMixin(TestCase):
         obj = TranslatedModel()
         obj.get_fallback = lambda: 'pl'
 
-        f = TestForm(instance=obj)
+        f = DummyForm(instance=obj)
         assert f.fields['name'].default_locale == 'pl'
         assert f.fields['name'].widget.default_locale == 'pl'
         assert pq(f.as_p())('#id_name_0').attr('lang') == 'pl'


### PR DESCRIPTION
Found these while looking at some travis builds...
```
WC1 /home/travis/build/diox/olympia/src/olympia/api/tests/test_exceptions.py cannot collect test class 'TestViewSet' because it has a __init__ constructor
WR1 /home/travis/build/diox/olympia/src/olympia/stats/tests/test_views.py:317 assertion is always true, perhaps remove parentheses?
WR1 /home/travis/build/diox/olympia/src/olympia/stats/tests/test_views.py:325 assertion is always true, perhaps remove parentheses?
WC1 /home/travis/build/diox/olympia/src/olympia/translations/tests/test_forms.py cannot collect test class 'TestForm' because it has a __init__ constructor
```