### PR TITLE
Update already existing no version test to test an update for an already existing add-on too.

### DIFF
--- a/src/olympia/devhub/tests/test_tasks.py
+++ b/src/olympia/devhub/tests/test_tasks.py
@@ -737,6 +737,8 @@ class TestWebextensionIncompatibilities(ValidatorTestCase):
 
     def test_no_upgrade_annotation_no_version(self):
         """Make sure there's no workaround the downgrade error."""
+        self.addon.update(guid='guid@xpi')
+
         file_ = amo.tests.AMOPaths().file_fixture_path(
             'delicious_bookmarks-no-version.xpi')
 

--- a/src/olympia/devhub/utils.py
+++ b/src/olympia/devhub/utils.py
@@ -190,7 +190,7 @@ def find_previous_version(addon, file, version_string):
     `version`, that can be used to compare validation results or
     issue upgrade warnings.
     """
-    if not addon:
+    if not addon or not version_string:
         return
 
     version = Version(version_string)


### PR DESCRIPTION
Before the test didn't catch all code-paths, now it does. See
https://sentry.prod.mozaws.net/operations/olympia-dev/issues/360475/ for
more details.

Fixes #3778, might ref mozilla/addons#252