### PR TITLE
Document requirements for third-party usage

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,3 +18,4 @@ Contents
    topics/api/index
    topics/install/index
    topics/development/index
+   topics/third-party

--- a/docs/topics/third-party.rst
+++ b/docs/topics/third-party.rst
@@ -1,0 +1,17 @@
+.. _third-party:
+
+=================
+Third-Party Usage
+=================
+
+Running your own Add-ons server will likely require a few changes. There is currently no easy
+way to provide custom templates and since Firefox Accounts is used for authentication there is
+no way to authenticate a user outside of a Mozilla property.
+
+If you would like to run your own Add-ons server you may want to update addons-server to support
+custom templates and move the Firefox Accounts management to a `django authentication backend`_.
+
+Another option would be to add any APIs that you required and write a custom frontend. This work is
+already underway and should be completed at some point but help is always welcome.
+
+.. _django authentication backend: https://github.com/mozilla/addons-server/issues/3799

--- a/docs/topics/third-party.rst
+++ b/docs/topics/third-party.rst
@@ -12,6 +12,8 @@ If you would like to run your own Add-ons server you may want to update addons-s
 custom templates and move the Firefox Accounts management to a `django authentication backend`_.
 
 Another option would be to add any APIs that you required and write a custom frontend. This work is
-already underway and should be completed at some point but help is always welcome.
+already underway and should be completed at some point but help is always welcome. You can find
+the API work in this project and the fronend work in `addons-frontend`_.
 
 .. _django authentication backend: https://github.com/mozilla/addons-server/issues/3799
+.. _addons-frontend: https://github.com/mozilla/addons-frontend


### PR DESCRIPTION
Adds a page that documents what you might need to do to run your own third-party add-ons server. Once we have a solid API base it probably makes sense to update this to state that the preferred method is to use the API, this likely still requires moving the FxA code to an authentication backend.