### PR TITLE
Make reviewer tools query simpler, don't do a subselect for the latest version

### DIFF
--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -127,7 +127,7 @@ def check_links(expected, elements, selected=None, verify=True):
 
         e = elements.eq(idx)
         if text is not None:
-            assert e.text() == text
+            assert e.text() == text, e.text()
         if link is not None:
             # If we passed an <li>, try to find an <a>.
             if not e.filter('a'):

--- a/src/olympia/editors/helpers.py
+++ b/src/olympia/editors/helpers.py
@@ -146,7 +146,6 @@ def queue_tabnav(context):
     Each tuple contains three elements: (tab_code, page_url, tab_text)
     """
     counts = context['queue_counts']
-    unlisted_counts = context['unlisted_queue_counts']
     listed = not context.get('unlisted')
 
     if listed:
@@ -166,11 +165,7 @@ def queue_tabnav(context):
                              counts['moderated'])
                     .format(counts['moderated'])))]
     else:
-        tabnav = [('all', 'unlisted_queue_all',
-                   (ngettext('All Unlisted Add-ons ({0})',
-                             'All Unlisted Add-ons ({0})',
-                             unlisted_counts['all'])
-                    .format(unlisted_counts['all'])))]
+        tabnav = [('all', 'unlisted_queue_all', _('All Unlisted Add-ons'))]
 
     return tabnav
 

--- a/src/olympia/editors/templates/editors/base.html
+++ b/src/olympia/editors/templates/editors/base.html
@@ -58,7 +58,7 @@
           {{ _('Unlisted Queues') }}</a>
         <ul>
           <li><a href="{{ url('editors.unlisted_queue_all') }}">
-                {{ _('All Unlisted Add-ons') }} ({{ unlisted_queue_counts['all'] }})</a></li>
+                {{ _('All Unlisted Add-ons') }}</a></li>
         </ul>
       </li>
     {% endif %}

--- a/src/olympia/editors/tests/test_models.py
+++ b/src/olympia/editors/tests/test_models.py
@@ -66,6 +66,9 @@ def create_addon_file(name, version_str, addon_status, file_status,
     if created:
         version.update(created=created)
         file_.update(created=created)
+    # Regular Version creation (via from_upload()) does this, it's necessary
+    # to make sure files as in a consistent state:
+    version.disable_old_files()
     # Update status *after* we are done creating/modifying version and files:
     addon = Addon.with_unlisted.get(pk=addon.id)
     addon.update(status=addon_status)

--- a/src/olympia/editors/tests/test_views.py
+++ b/src/olympia/editors/tests/test_views.py
@@ -955,14 +955,19 @@ class TestNominatedQueue(QueueTest):
         # Create another version, v0.2, by "cloning" v0.1.
         version2.pk = None
         version2.version = '0.2'
-        future = datetime.now() - timedelta(seconds=1)
-        version2.created = version2.nomination = future
         version2.save()
+
+        # Reset creation date once it has been saved.
+        future = datetime.now() - timedelta(seconds=1)
+        version2.update(created=future, nomination=future)
 
         # Associate v0.2 it with a file.
         file_.pk = None
         file_.version = version2
         file_.save()
+
+        # disable old files like Version.from_upload() would.
+        version2.disable_old_files()
 
         r = self.client.get(self.url)
         assert r.status_code == 200
@@ -1171,10 +1176,6 @@ class TestUnlistedAllList(QueueTest):
 
     def test_breadcrumbs(self):
         self._test_breadcrumbs([('All Unlisted Add-ons', None)])
-
-    def test_queue_count(self):
-        assert Addon.with_unlisted.all().count() == 5
-        self._test_queue_count(0, 'All Unlisted Add-ons', 5)
 
     def test_results(self):
         self._test_results()


### PR DESCRIPTION
Fix #3864 (hopefully)

Since we're filtering on file status, the version we get with a simple `JOIN` should always be the right one, except for the few add-ons which are in a weird state because they have been modified manually.