### PR TITLE
Fix unicode error on copying over extracted files from zip.

### DIFF
--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -26,7 +26,7 @@ from django.core.files.storage import (
     default_storage as storage, File as DjangoFile)
 from django.utils.jslex import JsLexer
 from django.utils.translation import ugettext as _
-from django.utils._os import npath
+from django.utils.encoding import force_bytes
 
 import rdflib
 import waffle
@@ -540,7 +540,7 @@ def copy_over(source, dest):
     """
     if os.path.exists(dest) and os.path.isdir(dest):
         shutil.rmtree(dest)
-    shutil.copytree(npath(source), npath(dest))
+    shutil.copytree(force_bytes(source), force_bytes(dest))
     # mkdtemp will set the directory permissions to 700
     # for the webserver to read them, we need 755
     os.chmod(dest, stat.S_IRWXU | stat.S_IRGRP |

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -26,6 +26,7 @@ from django.core.files.storage import (
     default_storage as storage, File as DjangoFile)
 from django.utils.jslex import JsLexer
 from django.utils.translation import ugettext as _
+from django.utils._os import npath
 
 import rdflib
 import waffle
@@ -539,7 +540,7 @@ def copy_over(source, dest):
     """
     if os.path.exists(dest) and os.path.isdir(dest):
         shutil.rmtree(dest)
-    shutil.copytree(source, dest)
+    shutil.copytree(npath(source), npath(dest))
     # mkdtemp will set the directory permissions to 700
     # for the webserver to read them, we need 755
     os.chmod(dest, stat.S_IRWXU | stat.S_IRGRP |


### PR DESCRIPTION
Refs #3579 (and hopefully fixes it)

The problem here is that under very hard unit-testable/reproducable
circumstances a zip-file with unicode filenames get's extracted to a
temporary directory and while calling `copy_over` which calls
`shutil.copytree` which fails on our production systems with a
UnicodeDecodeError.

Reproducing this is something along the lines of
```
>>> shutil.copytree(u'/tmp/tmp8WG6A8/', u'/tmp/tmp8WG6A8-2/')
# ... no error
>>> shutil.copytree('/tmp/tmp8WG6A8/', u'/tmp/tmp8WG6A8-2/')
UnicodeDecodeError: 'ascii' codec can't decode 	byte 0xd0 in ...
```
Checking all relevant environment configs in our production systems, all
LANG, LC_ALL and related configs are perfectly fine. It's not related to
uwsgi, it's not related to EFS so it's something else I have absolutely
no idea about :-/