### PR TITLE
[WIP] Only use Addon.current_version for listed add-ons

### DIFF
--- a/src/olympia/addons/indexers.py
+++ b/src/olympia/addons/indexers.py
@@ -231,7 +231,7 @@ class AddonIndexer(BaseSearchIndexer):
         # We can use all_categories because the indexing code goes through the
         # transformer that sets it.
         data['category'] = [cat.id for cat in obj.all_categories]
-        if obj.current_version:
+        if obj.is_listed and obj.current_version:
             # FIXME: remove `appversion` once the newest mapping that has
             # 'current_version.compatible_apps` is live.
             data['appversion'] = cls.extract_compatibility_info(

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -946,9 +946,16 @@ class Addon(OnChangeMixin, ModelBase):
 
     @property
     def current_version(self):
-        """Returns the current_version or None if the app is deleted or not
-        created yet"""
+        """Return the latest public listed version of an addon
+
+        If the add-on is not public, it can return a listed version awaiting
+        review (since non-public add-ons should not have public versions).
+
+        If the add-on has not been created yet or is deleted, it returns None.
+        """
         if not self.is_listed:
+            # FIXME: this is temporary to find broken stuff. We'll need to
+            # remove that if/raise when pushing.
             raise ValueError('unlisted addons should not need current_version')
         if not self.id or self.status == amo.STATUS_DELETED:
             return None

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1362,7 +1362,7 @@ class Addon(OnChangeMixin, ModelBase):
 
     def incompatible_latest_apps(self):
         """Returns a list of applications with which this add-on is
-        incompatible (based on the latest version).
+        incompatible (based on the latest version of each app).
 
         """
         return [app for app, ver in self.compatible_apps.items() if ver and

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -1685,19 +1685,19 @@ class TestGetVersion(TestCase):
 
     def test_public_new_nominated_version(self):
         self.new_version(amo.STATUS_NOMINATED)
-        assert self.addon.find_latest_public_version() == self.version
+        assert self.addon.find_latest_public_listed_version() == self.version
 
     def test_public_new_public_version(self):
         v = self.new_version(amo.STATUS_PUBLIC)
-        assert self.addon.find_latest_public_version() == v
+        assert self.addon.find_latest_public_listed_version() == v
 
     def test_public_new_unreviewed_version(self):
         self.new_version(amo.STATUS_AWAITING_REVIEW)
-        assert self.addon.find_latest_public_version() == self.version
+        assert self.addon.find_latest_public_listed_version() == self.version
 
     def test_should_promote_previous_valid_version_if_latest_is_disabled(self):
         self.new_version(amo.STATUS_DISABLED)
-        assert self.addon.find_latest_public_version() == self.version
+        assert self.addon.find_latest_public_listed_version() == self.version
 
 
 class TestAddonGetURLPath(TestCase):

--- a/src/olympia/devhub/templates/devhub/addons/listing/item_actions.html
+++ b/src/olympia/devhub/templates/devhub/addons/listing/item_actions.html
@@ -30,7 +30,7 @@
          title="{{ _('Upload a new version of this add-on.') }}">
         {{ _('New Version') }}</a>
     </li>
-    {% if addon.accepts_compatible_apps() and addon.current_version %}
+    {% if addon.is_listed and addon.accepts_compatible_apps() and addon.current_version %}
       <li class="compat"
           data-src="{{ url('devhub.ajax.compat.status', addon.slug) }}">
         {% include "devhub/addons/ajax_compat_status.html" %}

--- a/src/olympia/devhub/templates/devhub/addons/submit/done.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/done.html
@@ -5,8 +5,7 @@
 {% endblock %}
 
 {% block primary %}
-{% set upload_version = addon.current_version %}
-{% set version_edit_url = url('devhub.versions.edit', addon.slug, upload_version.id) %}
+{% set version_edit_url = url('devhub.versions.edit', addon.slug, uploaded_version.id) %}
 {% if addon.is_listed %}
   <h3>{{ _("Version Submitted for Review") }}</h3>
   <p>
@@ -29,7 +28,7 @@
   </p>
   <p>
     <a class="button" href="{{ version_edit_url }}">{{
-        _("Edit version {0}")|fe(upload_version.version) }}</a>
+        _("Edit version {0}")|fe(uploaded_version.version) }}</a>
   </p>
 {% else %}
   <h3>{{ _("Version Signed") }}</h3>
@@ -38,7 +37,7 @@
          "You can download it by clicking the button below.") }}
   </p>
   <p>
-    {% set file = upload_version.all_files[0] %}
+    {% set file = uploaded_version.all_files[0] %}
     <a class="button" id="download-addon-url" download href="{{ file.get_url_path('devhub') }}">{{
         _("Download {0}")|fe(file.pretty_filename()) }}</a>
   </p>

--- a/src/olympia/devhub/templates/devhub/includes/addon_details.html
+++ b/src/olympia/devhub/templates/devhub/includes/addon_details.html
@@ -63,7 +63,7 @@
 </li>
 
 </li>
-{% if addon.current_version %}
+{% if addon.is_listed and addon.current_version %}
   <li>
     <strong>{{ _('Current Version:') }}</strong>
     {{ link_if_listed_else_text(addon.current_version, addon.current_version) }}

--- a/src/olympia/devhub/templates/devhub/includes/addon_details.html
+++ b/src/olympia/devhub/templates/devhub/includes/addon_details.html
@@ -73,7 +73,7 @@
                                           'relevant for listed add-ons.') }}">?</span>
   </li>
 {% endif %}
-{% if addon.type == amo.ADDON_EXTENSION and amo.FIREFOX in addon.compatible_apps %}
+{% if addon.is_listed and addon.type == amo.ADDON_EXTENSION and amo.FIREFOX in addon.compatible_apps %}
 <li class="e10s-compatibility e10s-{{ addon.feature_compatibility.get_e10s_classname() }}">
   <strong>{{ _('Multi Process Status:') }}</strong>
   <b>{{ addon.feature_compatibility.get_e10s_display() }}</b>
@@ -94,21 +94,23 @@
   </li>
 {% endif %}
 {% set latest_listed_version=addon.find_latest_version(channel=amo.RELEASE_CHANNEL_LISTED) %}
-{% if latest_listed_version and latest_listed_version != addon.current_version %}
-  <li>
-    <strong>{{ _('Next Version:') }}</strong>
-    {{ link_if_listed_else_text(latest_listed_version, latest_listed_version.version) }}
-    <span class="tip tooltip" title="{{ _('This is the newest uploaded version, however it isn’t live on the site yet.') }}">?</span>
-  </li>
-{% endif %}
-{% with position = get_position(addon) %}
-  {% if position and position.pos and position.total %}
-    <li class="queue-position" title="{{ _('Queues are not reviewed strictly in order') }}">
-      <strong>{{ _('Queue Position:') }}</strong>
-      {% trans position=position.pos|numberfmt,
-               total=position.total|numberfmt %}
-        {{ position }} of {{ total }}
-      {% endtrans %}
+{% if addon.is_listed %}
+  {% if latest_listed_version and latest_listed_version != addon.current_version %}
+    <li>
+      <strong>{{ _('Next Version:') }}</strong>
+      {{ link_if_listed_else_text(latest_listed_version, latest_listed_version.version) }}
+      <span class="tip tooltip" title="{{ _('This is the newest uploaded version, however it isn’t live on the site yet.') }}">?</span>
     </li>
   {% endif %}
-{% endwith %}
+  {% with position = get_position(addon) %}
+    {% if position and position.pos and position.total %}
+      <li class="queue-position" title="{{ _('Queues are not reviewed strictly in order') }}">
+        <strong>{{ _('Queue Position:') }}</strong>
+        {% trans position=position.pos|numberfmt,
+                 total=position.total|numberfmt %}
+          {{ position }} of {{ total }}
+        {% endtrans %}
+      </li>
+    {% endif %}
+  {% endwith %}
+{% endif %}

--- a/src/olympia/devhub/templates/devhub/index.html
+++ b/src/olympia/devhub/templates/devhub/index.html
@@ -96,24 +96,26 @@
                         {{ _('Unlisted') }}
                       {% endif %}
                     </p>
-                    {% if item.addon.current_version %}
-                      <p>
-                        <strong>{{ _('Latest Version:') }}</strong>
-                        {{ link_if_listed_else_text(item.addon.current_version,
-                                         item.addon.current_version.version) }}
-                      </p>
-                    {% endif %}
-                    {% with position = item.position %}
-                      {% if position and position.pos and position.total %}
+                    {% if item.addon.is_listed %}
+                      {% if item.addon.current_version %}
                         <p>
-                          <strong>{{ _('Queue Position:') }}</strong>
-                          {% trans position=position.pos|numberfmt,
-                                   total=position.total|numberfmt %}
-                            {{ position }} of {{ total }}
-                          {% endtrans %}
+                          <strong>{{ _('Latest Version:') }}</strong>
+                          {{ link_if_listed_else_text(item.addon.current_version,
+                                           item.addon.current_version.version) }}
                         </p>
                       {% endif %}
-                    {% endwith %}
+                      {% with position = item.position %}
+                        {% if position and position.pos and position.total %}
+                          <p>
+                            <strong>{{ _('Queue Position:') }}</strong>
+                            {% trans position=position.pos|numberfmt,
+                                     total=position.total|numberfmt %}
+                              {{ position }} of {{ total }}
+                            {% endtrans %}
+                          </p>
+                        {% endif %}
+                      {% endwith %}
+                    {% endif %}
                     {% if not item.addon.is_persona() and not item.addon.is_incomplete() and not item.addon.is_disabled %}
                       <p class="upload-new-version">
                         <a href="{{ item.addon.get_dev_url('versions') }}#version-upload">

--- a/src/olympia/devhub/templates/devhub/versions/list.html
+++ b/src/olympia/devhub/templates/devhub/versions/list.html
@@ -77,7 +77,7 @@
       </ul>
     </td>
     <td class="version-delete">
-      <a href="#" class="remove" data-version="{{ version.id }}" data-is-current="{{ (version == addon.current_version)|int }}">x</a>
+      <a href="#" class="remove" data-version="{{ version.id }}" data-is-current="{{ (version.channel == amo.RELEASE_CHANNEL_LISTED and version == addon.current_version)|int }}">x</a>
     </td>
   </tr>
   {% set can_request_review=addon.can_request_review() %}
@@ -171,42 +171,45 @@
   </div>
 
   {% set latest_listed_version=addon.find_latest_version(channel=amo.RELEASE_CHANNEL_LISTED) %}
-  <h3>{{ _('Current versions') }}</h3>
-  {% if addon.current_version %}
-    <div class="item" id="current-version-status">
-      <div class="item_wrapper">
-        <table>
-          <tr>
-            <th>{{ _('Currently on AMO') }}</th>
-            <th>{{ _('Status') }}</th>
-            <th>{{ _('Validation') }}</th>
-            <th class="version-delete">{{ _('Delete/Disable') }}</th>
-          </tr>
-          {{ version_details(addon.current_version,
-                             full_info=(not latest_listed_version
-                                        or latest_listed_version == addon.current_version)) }}
-        </table>
+  {% if latest_listed_version %}
+    <h3>{{ _('Current versions') }}</h3>
+    {% if addon.current_version %}
+      <div class="item" id="current-version-status">
+        <div class="item_wrapper">
+          <table>
+            <tr>
+              <th>{{ _('Currently on AMO') }}</th>
+              <th>{{ _('Status') }}</th>
+              <th>{{ _('Validation') }}</th>
+              <th class="version-delete">{{ _('Delete/Disable') }}</th>
+            </tr>
+            {{ version_details(addon.current_version,
+                               full_info=(not latest_listed_version
+                                          or latest_listed_version == addon.current_version)) }}
+          </table>
+        </div>
       </div>
-    </div>
-  {% endif %}
+    {% endif %}
 
-  {% if latest_listed_version and latest_listed_version != addon.current_version %}
-    <div class="item" id="next-version-status">
-      <div class="item_wrapper">
-        <table>
-          <tr>
-            <th>{{ _('Next version of this add-on') }}</th>
-            <th>{{ _('Status') }}</th>
-            <th>{{ _('Validation') }}</th>
-            <th class="version-delete">{{ _('Delete/Disable') }}</th>
-          </tr>
-          {{ version_details(latest_listed_version, full_info=True) }}
-        </table>
+    {% if latest_listed_version and latest_listed_version != addon.current_version %}
+      <div class="item" id="next-version-status">
+        <div class="item_wrapper">
+          <table>
+            <tr>
+              <th>{{ _('Next version of this add-on') }}</th>
+              <th>{{ _('Status') }}</th>
+              <th>{{ _('Validation') }}</th>
+              <th class="version-delete">{{ _('Delete/Disable') }}</th>
+            </tr>
+            {{ version_details(latest_listed_version, full_info=True) }}
+          </table>
+        </div>
       </div>
-    </div>
+    {% endif %}
+    <h3>{{ _('Older versions') }}</h3>
+  {% else %}
+    <h3>{{ _('All versions') }}</h3>
   {% endif %}
-
-  <h3>{{ _('Older versions') }}</h3>
   <div class="item" id="version-list"
        data-stats="{{ url('devhub.versions.stats', addon.slug) }}">
     <div class="item_wrapper">
@@ -223,7 +226,7 @@
           </td>
         </tr>
         {% for version in versions.object_list %}
-          {% if version != addon.current_version and version != latest_listed_version %}
+          {% if version.channel == amo.RELEASE_CHANNEL_UNLISTED or (version != addon.current_version and version != latest_listed_version) %}
             {{ version_details(version) }}
           {% endif %}
         {% endfor %}

--- a/src/olympia/devhub/tests/test_views_ownership.py
+++ b/src/olympia/devhub/tests/test_views_ownership.py
@@ -91,7 +91,7 @@ class TestEditLicense(TestOwnership):
 
     def test_no_license_required_for_unlisted(self):
         self.addon.update(is_listed=False)
-        self.addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        self.addon.versions.get().update(channel=amo.RELEASE_CHANNEL_UNLISTED)
         data = self.formset(builtin='')
         response = self.client.post(self.url, data)
         assert response.status_code == 302

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -419,21 +419,23 @@ def unlist(request, addon_id, addon):
 
 @dev_required(owner_for_post=True)
 def ownership(request, addon_id, addon):
-    fs, ctx = [], {}
+    forms_list, ctx = [], {}
     post_data = request.POST if request.method == 'POST' else None
     # Authors.
     qs = AddonUser.objects.filter(addon=addon).order_by('position')
     user_form = forms.AuthorFormSet(post_data, queryset=qs)
-    fs.append(user_form)
+    forms_list.append(user_form)
     # Versions.
-    license_form = forms.LicenseForm(post_data, version=addon.current_version)
-    ctx.update(license_form.get_context())
-    if ctx['license_form']:  # if addon has a version
-        fs.append(ctx['license_form'])
+    if addon.has_listed_versions():
+        license_form = forms.LicenseForm(
+            post_data, version=addon.current_version)
+        ctx.update(license_form.get_context())
+        if ctx['license_form']:  # if addon has a version
+            forms_list.append(ctx['license_form'])
     # Policy.
     policy_form = forms.PolicyForm(post_data, addon=addon)
     ctx.update(policy_form=policy_form)
-    fs.append(policy_form)
+    forms_list.append(policy_form)
 
     def mail_user_changes(author, title, template_part, recipients):
         from olympia.amo.utils import send_mail
@@ -445,7 +447,7 @@ def ownership(request, addon_id, addon):
                                     'site_url': settings.SITE_URL})),
                   None, recipients, use_blacklist=False)
 
-    if request.method == 'POST' and all([form.is_valid() for form in fs]):
+    if request.method == 'POST' and all([f.is_valid() for f in forms_list]):
         # Authors.
         authors = user_form.save(commit=False)
         addon_authors_emails = list(
@@ -490,10 +492,10 @@ def ownership(request, addon_id, addon):
                 template_part='author_removed',
                 recipients=authors_emails)
 
-        if license_form in fs:
-            license_form.save()
-        if policy_form in fs:
-            policy_form.save()
+        # Save other forms.
+        for form in forms_list:
+            if form != user_form:
+                form.save()
         messages.success(request, _('Changes successfully saved.'))
 
         return redirect(addon.get_dev_url('owner'))
@@ -1419,18 +1421,16 @@ def submit_addon_upload(request, channel):
     if request.method == 'POST':
         if form.is_valid():
             data = form.cleaned_data
-
-            p = data.get('supported_platforms', [])
-
-            addon = Addon.from_upload(data['upload'], p, source=data['source'],
-                                      is_listed=is_listed)
+            addon = Addon.from_upload(
+                data['upload'], data.get('supported_platforms', []),
+                source=data['source'], is_listed=is_listed)
+            version = addon.versions.get()
             AddonUser(addon=addon, user=request.user).save()
-            check_validation_override(request, form, addon,
-                                      addon.current_version)
+            check_validation_override(request, form, addon, version)
             if not addon.is_listed:  # Not listed? Automatically choose queue.
                 addon.update(status=amo.STATUS_NOMINATED)
                 # Sign all the files submitted, one for each platform.
-                auto_sign_version(addon.versions.get())
+                auto_sign_version(version)
                 return redirect('devhub.submit.finish', addon.slug)
             return redirect('devhub.submit.details', addon.slug)
     is_admin = acl.action_allowed(request, 'ReviewerAdminTools', 'View')
@@ -1490,8 +1490,9 @@ def submit_finish(request, addon_id, addon):
     # Bounce to the versions page if they don't have any versions.
     if not addon.versions.exists():
         return redirect(addon.get_dev_url('versions'))
-    sp = addon.current_version.supported_platforms
-    is_platform_specific = sp != [amo.PLATFORM_ALL]
+    uploaded_version = addon.versions.latest()
+    supported_platforms = uploaded_version.supported_platforms
+    is_platform_specific = supported_platforms != [amo.PLATFORM_ALL]
 
     try:
         author = addon.authors.all()[0]
@@ -1515,7 +1516,7 @@ def submit_finish(request, addon_id, addon):
             tasks.send_welcome_email.delay(addon.id, [author.email], context)
 
     return render(request, 'devhub/addons/submit/done.html',
-                  {'addon': addon,
+                  {'addon': addon, 'uploaded_version': uploaded_version,
                    'is_platform_specific': is_platform_specific})
 
 

--- a/src/olympia/users/tests/test_models.py
+++ b/src/olympia/users/tests/test_models.py
@@ -154,7 +154,7 @@ class TestUserProfile(TestCase):
         """
         addon = Addon.objects.get(id=3615)
         u = UserProfile.objects.get(pk=2519)
-        version = addon.find_latest_public_version()
+        version = addon.find_latest_public_listed_version()
         new_review = Review(version=version, user=u, rating=2, body='hello',
                             addon=addon)
         new_review.save()

--- a/src/olympia/versions/tests.py
+++ b/src/olympia/versions/tests.py
@@ -835,9 +835,10 @@ class TestDownloadsUnlistedAddons(TestDownloadsBase):
     @mock.patch.object(acl, 'check_addon_ownership',
                        lambda *args, **kwargs: True)
     def test_download_for_unlisted_addon_owner(self):
-        """File downloading is allowed for addon owners."""
+        """File downloading is allowed for addon owners, except 'latest' which
+        only works for listed add-ons."""
         self.assert_served_internally(self.client.get(self.file_url), False)
-        self.assert_served_internally(self.client.get(self.latest_url), False)
+        assert self.client.get(self.latest_url).status_code == 404
 
     @mock.patch.object(acl, 'check_addons_reviewer', lambda x: True)
     @mock.patch.object(acl, 'check_unlisted_addons_reviewer', lambda x: False)
@@ -853,9 +854,10 @@ class TestDownloadsUnlistedAddons(TestDownloadsBase):
     @mock.patch.object(acl, 'check_addon_ownership',
                        lambda *args, **kwargs: False)
     def test_download_for_unlisted_addon_unlisted_reviewer(self):
-        """File downloading is allowed for unlisted reviewers."""
+        """File downloading is allowed for unlisted reviewers, except 'latest'
+        which only works for listed add-ons."""
         self.assert_served_internally(self.client.get(self.file_url), False)
-        self.assert_served_internally(self.client.get(self.latest_url), False)
+        assert self.client.get(self.latest_url).status_code == 404
 
 
 class TestDownloads(TestDownloadsBase):

--- a/src/olympia/versions/views.py
+++ b/src/olympia/versions/views.py
@@ -138,7 +138,7 @@ def download_file(request, file_id, type=None, file_=None, addon=None):
 
 
 def guard():
-    return Addon.with_unlisted.filter(_current_version__isnull=False)
+    return Addon.objects.filter(_current_version__isnull=False)
 
 
 @addon_view_factory(guard)
@@ -153,8 +153,7 @@ def download_latest(request, addon, beta=False, type='xpi', platform=None):
         version = addon.current_beta_version.id
     else:
         version = addon._current_version_id
-    files = File.objects.filter(platform__in=platforms,
-                                version=version)
+    files = File.objects.filter(platform__in=platforms, version=version)
     try:
         # If there's a file matching our platform, it'll float to the end.
         file_ = sorted(files, key=lambda f: f.platform == platforms[-1])[-1]

--- a/src/olympia/zadmin/tests/test_views.py
+++ b/src/olympia/zadmin/tests/test_views.py
@@ -118,7 +118,7 @@ class BulkValidationTest(TestCase):
         assert self.client.login(email='admin@mozilla.com')
         self.addon = Addon.objects.get(pk=3615)
         self.creator = UserProfile.objects.get(username='editor')
-        self.version = self.addon.find_latest_public_version()
+        self.version = self.addon.find_latest_public_listed_version()
         ApplicationsVersions.objects.filter(
             application=amo.FIREFOX.id, version=self.version).update(
             max=AppVersion.objects.get(application=1, version='3.7a1pre'))


### PR DESCRIPTION
This is a prerequisite to #3847. Since the idea of #3847 is the make `current_version` only return listed versions, this PR aims to change all code that expect `current_version` to work in unlisted situations.

It's a WIP, don't merge yet, but I'd like comments on it. The following will be changed before merging:
- The exception thrown in `current_version` if `addon.is_listed` is `False`. I'll remove that completely when merging, and in the next PR I'll make `update_versions()` only consider listed versions.
- Some of the checks on `addon.is_listed` where `current_version` is used will be simply changed to checking if `current_version` exists. I just wanted to make sure the maximum number of tests were passing.
- The API exposes `current_version` so a decision will need to be made here. See https://github.com/mozilla/addons-server/issues/3847#issuecomment-255747523
