### PR TITLE
rename whitelist to allow list

### DIFF
--- a/src/olympia/amo/mail.py
+++ b/src/olympia/amo/mail.py
@@ -10,14 +10,14 @@ log = logging.getLogger('z.amo.mail')
 
 
 class DevEmailBackend(BaseEmailBackend):
-    """Log emails in the database, send whitelisted for real though.
+    """Log emails in the database, send allowed addresses for real though.
 
     Used for development environments when we don't want to send out
     real emails. This gets swapped in as the email backend when
     `settings.SEND_REAL_EMAIL` is disabled.
 
     BUT even if `settings.SEND_REAL_EMAIL` is disabled, if the targeted
-    email address is in the `settings.EMAIL_QA_WHITELIST` list,
+    email address is in the `settings.EMAIL_QA_ALLOW_LIST` list,
     the email will be sent.
     """
 
@@ -25,13 +25,13 @@ class DevEmailBackend(BaseEmailBackend):
         """Save a `FakeEmail` object viewable within the admin.
 
         If one of the target email addresses is in
-        `settings.EMAIL_QA_WHITELIST`, it send a real email message.
+        `settings.EMAIL_QA_ALLOW_LIST`, it send a real email message.
         """
         log.debug('Sending dev mail messages.')
         qa_messages = []
         for msg in messages:
             FakeEmail.objects.create(message=msg.message().as_string())
-            qa_emails = set(msg.to).intersection(settings.EMAIL_QA_WHITELIST)
+            qa_emails = set(msg.to).intersection(settings.EMAIL_QA_ALLOW_LIST)
             if qa_emails:
                 if len(msg.to) != len(qa_emails):
                     # We need to replace the recipients with the QA

--- a/src/olympia/amo/tests/test_send_mail.py
+++ b/src/olympia/amo/tests/test_send_mail.py
@@ -153,10 +153,10 @@ class TestSendMail(BaseTestCase):
 
     @mock.patch.object(settings, 'EMAIL_BLACKLIST', ())
     @mock.patch.object(settings, 'SEND_REAL_EMAIL', False)
-    @mock.patch.object(settings, 'EMAIL_QA_WHITELIST', ('nobody@mozilla.org',))
-    def test_qa_whitelist(self):
+    @mock.patch.object(settings, 'EMAIL_QA_ALLOW_LIST', ('nope@mozilla.org',))
+    def test_qa_allowed_list(self):
         assert send_mail('test subject', 'test body',
-                         recipient_list=['nobody@mozilla.org'],
+                         recipient_list=['nope@mozilla.org'],
                          fail_silently=False)
         assert len(mail.outbox) == 1
         assert mail.outbox[0].subject.find('test subject') == 0
@@ -166,13 +166,13 @@ class TestSendMail(BaseTestCase):
 
     @mock.patch.object(settings, 'EMAIL_BLACKLIST', ())
     @mock.patch.object(settings, 'SEND_REAL_EMAIL', False)
-    @mock.patch.object(settings, 'EMAIL_QA_WHITELIST', ('nobody@mozilla.org',))
-    def test_qa_whitelist_with_mixed_emails(self):
+    @mock.patch.object(settings, 'EMAIL_QA_ALLOW_LIST', ('nope@mozilla.org',))
+    def test_qa_allowed_list_with_mixed_emails(self):
         assert send_mail('test subject', 'test body',
-                         recipient_list=['nobody@mozilla.org', 'b@example.fr'],
+                         recipient_list=['nope@mozilla.org', 'b@example.fr'],
                          fail_silently=False)
         assert len(mail.outbox) == 1
-        assert mail.outbox[0].to == ['nobody@mozilla.org']
+        assert mail.outbox[0].to == ['nope@mozilla.org']
         assert FakeEmail.objects.count() == 1
 
     @mock.patch('olympia.amo.utils.Context')

--- a/src/olympia/amo/tests/test_url_prefix.py
+++ b/src/olympia/amo/tests/test_url_prefix.py
@@ -255,10 +255,10 @@ def test_redirect():
 def test_outgoing_url():
     redirect_url = settings.REDIRECT_URL
     secretkey = settings.REDIRECT_SECRET_KEY
-    exceptions = settings.REDIRECT_URL_WHITELIST
+    exceptions = settings.REDIRECT_URL_ALLOW_LIST
     settings.REDIRECT_URL = 'http://example.net'
     settings.REDIRECT_SECRET_KEY = 'sekrit'
-    settings.REDIRECT_URL_WHITELIST = ['nicedomain.com']
+    settings.REDIRECT_URL_ALLOW_LIST = ['nicedomain.com']
 
     try:
         myurl = 'http://example.com'
@@ -284,7 +284,7 @@ def test_outgoing_url():
     finally:
         settings.REDIRECT_URL = redirect_url
         settings.REDIRECT_SECRET_KEY = secretkey
-        settings.REDIRECT_URL_WHITELIST = exceptions
+        settings.REDIRECT_URL_ALLOW_LIST = exceptions
 
 
 def test_outgoing_url_dirty_unicode():

--- a/src/olympia/amo/urlresolvers.py
+++ b/src/olympia/amo/urlresolvers.py
@@ -182,7 +182,7 @@ def get_outgoing_url(url):
 
     # No double-escaping, and some domain names are excluded.
     if (url_netloc == urlparse(settings.REDIRECT_URL).netloc or
-            url_netloc in settings.REDIRECT_URL_WHITELIST):
+            url_netloc in settings.REDIRECT_URL_ALLOW_LIST):
         return url
 
     url = force_bytes(jinja2.utils.Markup(url).unescape())

--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -31,7 +31,7 @@ EMAIL_PORT = EMAIL_URL['EMAIL_PORT']
 EMAIL_BACKEND = EMAIL_URL['EMAIL_BACKEND']
 EMAIL_HOST_USER = EMAIL_URL['EMAIL_HOST_USER']
 EMAIL_HOST_PASSWORD = EMAIL_URL['EMAIL_HOST_PASSWORD']
-EMAIL_QA_WHITELIST = env.list('EMAIL_QA_WHITELIST')
+EMAIL_QA_ALLOW_LIST = env.list('EMAIL_QA_ALLOW_LIST')
 
 ENV = env('ENV')
 DEBUG = False
@@ -297,4 +297,4 @@ READ_ONLY = env.bool('READ_ONLY', default=False)
 
 RAVEN_DSN = (
     'https://5686e2a8f14446a3940c651c6a14dc73@sentry.prod.mozaws.net/75')
-RAVEN_WHITELIST = ['addons-dev.allizom.org', 'addons-dev-cdn.allizom.org']
+RAVEN_ALLOW_LIST = ['addons-dev.allizom.org', 'addons-dev-cdn.allizom.org']

--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -242,4 +242,4 @@ READ_ONLY = env.bool('READ_ONLY', default=False)
 
 RAVEN_DSN = (
     'https://8c1c5936578948a9a0614cbbafccf049@sentry.prod.mozaws.net/78')
-RAVEN_WHITELIST = ['addons.mozilla.org', 'addons.cdn.mozilla.net']
+RAVEN_ALLOW_LIST = ['addons.mozilla.org', 'addons.cdn.mozilla.net']

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -30,7 +30,7 @@ EMAIL_PORT = EMAIL_URL['EMAIL_PORT']
 EMAIL_BACKEND = EMAIL_URL['EMAIL_BACKEND']
 EMAIL_HOST_USER = EMAIL_URL['EMAIL_HOST_USER']
 EMAIL_HOST_PASSWORD = EMAIL_URL['EMAIL_HOST_PASSWORD']
-EMAIL_QA_WHITELIST = env.list('EMAIL_QA_WHITELIST')
+EMAIL_QA_ALLOW_LIST = env.list('EMAIL_QA_ALLOW_LIST')
 
 ENV = env('ENV')
 DEBUG = False
@@ -270,4 +270,4 @@ READ_ONLY = env.bool('READ_ONLY', default=False)
 
 RAVEN_DSN = (
     'https://e35602be5252460d97587478bcc642df@sentry.prod.mozaws.net/77')
-RAVEN_WHITELIST = ['addons.allizom.org', 'addons-cdn.allizom.org']
+RAVEN_ALLOW_LIST = ['addons.allizom.org', 'addons-cdn.allizom.org']

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -550,14 +550,14 @@ def copy_over(source, dest):
 def extract_xpi(xpi, path, expand=False):
     """
     If expand is given, will look inside the expanded file
-    and find anything in the whitelist and try and expand it as well.
+    and find anything in the allow list and try and expand it as well.
     It will do up to 10 iterations, after that you are on your own.
 
     It will replace the expanded file with a directory and the expanded
     contents. If you have 'foo.jar', that contains 'some-image.jpg', then
     it will create a folder, foo.jar, with an image inside.
     """
-    expand_whitelist = ['.crx', '.jar', '.xpi', '.zip']
+    expand_allow_list = ['.crx', '.jar', '.xpi', '.zip']
     tempdir = extract_zip(xpi)
 
     if expand:
@@ -565,7 +565,7 @@ def extract_xpi(xpi, path, expand=False):
             flag = False
             for root, dirs, files in os.walk(tempdir):
                 for name in files:
-                    if os.path.splitext(name)[1] in expand_whitelist:
+                    if os.path.splitext(name)[1] in expand_allow_list:
                         src = os.path.join(root, name)
                         if not os.path.isdir(src):
                             dest = extract_zip(src, remove=True, fatal=False)

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -86,6 +86,9 @@ CORS_ORIGIN_ALLOW_ALL = True
 CORS_URLS_REGEX = r'^/api/v3/.*$'
 
 
+# Sadly the term WHITELIST is used by the library
+# https://pypi.python.org/pypi/django-cors-headers-multi/1.2.0
+# TODO(andym): see if I can get them to accept a patch for that.
 def cors_endpoint_overrides(internal, public):
     return [
         (r'^/api/v3/internal/accounts/login/?$', {
@@ -967,7 +970,7 @@ REDIRECT_URL = 'https://outgoing.prod.mozaws.net/v1/'
 REDIRECT_SECRET_KEY = ''
 
 # Allow URLs from these servers. Use full domain names.
-REDIRECT_URL_WHITELIST = ['addons.mozilla.org']
+REDIRECT_URL_ALLOW_LIST = ['addons.mozilla.org']
 
 # Default to short expiration; check "remember me" to override
 SESSION_ENGINE = 'django.contrib.sessions.backends.signed_cookies'
@@ -1023,8 +1026,8 @@ EMAIL_BLACKLIST = (
     'nobody@mozilla.org',
 )
 
-# Please use all lowercase for the QA whitelist.
-EMAIL_QA_WHITELIST = ()
+# Please use all lowercase for the QA allow list.
+EMAIL_QA_ALLOW_LIST = ()
 
 # URL for Add-on Validation FAQ.
 VALIDATION_FAQ_URL = ('https://wiki.mozilla.org/Add-ons/Reviewers/Guide/'
@@ -1427,8 +1430,8 @@ FILE_UNZIP_SIZE_LIMIT = 104857600
 # How long to delay tasks relying on file system to cope with NFS lag.
 NFS_LAG_DELAY = 3
 
-# A whitelist of domains that the authentication script will redirect to upon
-# successfully logging in or out.
+# An approved list of domains that the authentication script will redirect to
+# upon successfully logging in or out.
 VALID_LOGIN_REDIRECTS = {
     'builder': 'https://builder.addons.mozilla.org',
     'builderstage': 'https://builder-addons.allizom.org',
@@ -1544,7 +1547,7 @@ JINGO_MINIFY_USE_STATIC = True
 
 # Whitelist IP addresses of the allowed clients that can post email
 # through the API.
-WHITELISTED_CLIENTS_EMAIL_API = []
+ALLOWED_CLIENTS_EMAIL_API = []
 
 # Allow URL style format override. eg. "?format=json"
 URL_FORMAT_OVERRIDE = 'format'

--- a/src/olympia/templates/base.html
+++ b/src/olympia/templates/base.html
@@ -57,7 +57,7 @@
         data-media-url="{{ MEDIA_URL }}"
         data-static-url="{{ STATIC_URL }}"
         data-raven-dsn="{{ settings.RAVEN_DSN }}"
-        data-raven-urls="{{ settings.RAVEN_WHITELIST }}"
+        data-raven-urls="{{ settings.RAVEN_ALLOW_LIST }}"
         {% block bodyattrs %}{% endblock %}>
 
     <div id="main-wrapper">

--- a/src/olympia/templates/impala/base.html
+++ b/src/olympia/templates/impala/base.html
@@ -52,7 +52,7 @@
         data-media-url="{{ MEDIA_URL }}"
         data-static-url="{{ STATIC_URL }}"
         data-raven-dsn="{{ settings.RAVEN_DSN }}"
-        data-raven-urls="{{ settings.RAVEN_WHITELIST }}"
+        data-raven-urls="{{ settings.RAVEN_ALLOW_LIST }}"
         data-fxa-config="{{ fxa_config()|json }}"
         {% block bodyattrs %}{% endblock %}>
 


### PR DESCRIPTION
- supports #935
- the first part, filed https://bugzilla.mozilla.org/show_bug.cgi?id=1313786 in case that env variable is used anywhere
