### PR TITLE
Move some requires_restart/compatible_apps calls to Version instead of Addon

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1305,9 +1305,9 @@ class Addon(OnChangeMixin, ModelBase):
 
     @property
     def requires_restart(self):
-        """Whether the add-on requires a browser restart to work."""
-        files = self.current_version and self.current_version.all_files
-        return bool(files and files[0].requires_restart)
+        """Whether the add-on current version requires a browser restart to
+        work."""
+        return self.current_version and self.current_version.requires_restart
 
     def is_featured(self, app, lang=None):
         """Is add-on globally featured for this app and language?"""

--- a/src/olympia/addons/templates/addons/details_box.html
+++ b/src/olympia/addons/templates/addons/details_box.html
@@ -4,13 +4,11 @@
       <div id="addon-summary-wrapper">
         <div id="addon-summary" class="primary">
           <p{{ addon.summary|locale_html }}>{{ addon.summary|nl2br }}</p>
-          {% with files = addon.current_version.all_files %}
-            {% if files and files[0].requires_restart %}
-              <div id="requires-restart" class="js-hidden">
-                <span id="requires-restart-msg">{{ _('Requires Restart') }}</span>
-              </div>
-            {% endif %}
-          {% endwith %}
+          {% if version and version.requires_restart %}
+            <div id="requires-restart" class="js-hidden">
+              <span id="requires-restart-msg">{{ _('Requires Restart') }}</span>
+            </div>
+          {% endif %}
 
           {% if show_actions %}
             {{ big_install_button(addon, show_warning=False) }}
@@ -50,10 +48,10 @@
                   </td>
                 </tr>
               {% endif %}
-              {% if addon.compatible_apps[APP] %}
+              {% if version and version.compatible_apps[APP] %}
                 <tr class="addon-compatible">
                   <th>{{ _('Works with') }}</th>
-                  <td>{{ addon.compatible_apps[APP] }}</td>
+                  <td>{{ version.compatible_apps[APP] }}</td>
                 </tr>
               {% endif %}
               <tr>

--- a/src/olympia/editors/views.py
+++ b/src/olympia/editors/views.py
@@ -642,8 +642,6 @@ def review(request, addon):
 
     if version:
         version.admin_review = addon.admin_review
-        version.requires_restart = any(
-            file_.requires_restart for file_ in version.all_files)
         version.sources_provided = bool(version.source)
         version.is_webextension = any(
             file_.is_webextension for file_ in version.all_files)

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -436,6 +436,10 @@ class Version(OnChangeMixin, ModelBase):
             return False
 
     @property
+    def requires_restart(self):
+        return any(file_.requires_restart for file_ in self.all_files)
+
+    @property
     def has_files(self):
         return bool(self.all_files)
 

--- a/src/olympia/versions/tests.py
+++ b/src/olympia/versions/tests.py
@@ -173,6 +173,17 @@ class TestVersion(TestCase):
         assert v.minor2 is None
         assert v.minor3 is None
 
+    def test_requires_restart(self):
+        version = Version.objects.get(pk=81551)
+        file_ = version.all_files[0]
+        assert not file_.no_restart
+        assert file_.requires_restart
+        assert version.requires_restart
+
+        file_.update(no_restart=True)
+        version = Version.objects.get(pk=81551)
+        assert not version.requires_restart
+
     def test_has_files(self):
         v = Version.objects.get(pk=81551)
         assert v.has_files, 'Version with files not recognized.'


### PR DESCRIPTION
Splitted from #3892, to prepare for version channel changes and current_version being limited to listed versions only.

Prerequisite for #3847.