### PR TITLE
Change some tests to avoid using current_version for unlisted add-ons

### DIFF
--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -1430,11 +1430,11 @@ class TestAddonModels(TestCase):
     def test_unlisted_is_incomplete(self):
         addon = Addon.objects.get(id=3615)
         addon.update(is_listed=False)
-        addon.current_version.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
         assert not addon.is_incomplete()  # Confirm not incomplete already.
 
         # Clear everything
-        addon.current_version.update(license=None)
+        addon.versions.update(license=None)
         addon.categories.all().delete()
         delete_translation(addon, 'summary')
         addon = Addon.with_unlisted.get(id=3615)

--- a/src/olympia/devhub/tests/test_views_ownership.py
+++ b/src/olympia/devhub/tests/test_views_ownership.py
@@ -91,7 +91,7 @@ class TestEditLicense(TestOwnership):
 
     def test_no_license_required_for_unlisted(self):
         self.addon.update(is_listed=False)
-        self.addon.current_version.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        self.addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
         data = self.formset(builtin='')
         response = self.client.post(self.url, data)
         assert response.status_code == 302

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -420,6 +420,7 @@ class TestVersion(TestCase):
     def test_unlisted_addon_cant_change_status(self):
         """Unlisted addon: can't change its status."""
         self.addon.update(disabled_by_user=False, is_listed=False)
+        self.addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
         res = self.client.get(self.url)
         doc = pq(res.content)
         assert not doc('.enable-addon').attr('checked')

--- a/src/olympia/editors/tests/test_views.py
+++ b/src/olympia/editors/tests/test_views.py
@@ -1701,7 +1701,7 @@ class TestReview(ReviewBase):
     def test_breadcrumbs_unlisted_addons(self):
         self.addon.update(is_listed=False, status=amo.STATUS_PUBLIC)
         self.generate_files()
-        self.addon.current_version.files.update(status=amo.STATUS_PUBLIC)
+        self.addon.versions.latest().files.update(status=amo.STATUS_PUBLIC)
         self.login_as_admin()
         expected = [
             ('All Unlisted Add-ons',


### PR DESCRIPTION
Splitted from #3892.

Prerequisite to #3847. 