### PR TITLE
Refactor submit_finish() to avoid using {Addon}.current_version

### DIFF
--- a/src/olympia/devhub/templates/devhub/addons/submit/done.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/done.html
@@ -5,8 +5,7 @@
 {% endblock %}
 
 {% block primary %}
-{% set upload_version = addon.current_version %}
-{% set version_edit_url = url('devhub.versions.edit', addon.slug, upload_version.id) %}
+{% set version_edit_url = url('devhub.versions.edit', addon.slug, uploaded_version.id) %}
 {% if addon.is_listed %}
   <h3>{{ _("Version Submitted for Review") }}</h3>
   <p>
@@ -29,7 +28,7 @@
   </p>
   <p>
     <a class="button" href="{{ version_edit_url }}">{{
-        _("Edit version {0}")|fe(upload_version.version) }}</a>
+        _("Edit version {0}")|fe(uploaded_version.version) }}</a>
   </p>
 {% else %}
   <h3>{{ _("Version Signed") }}</h3>
@@ -38,7 +37,7 @@
          "You can download it by clicking the button below.") }}
   </p>
   <p>
-    {% set file = upload_version.all_files[0] %}
+    {% set file = uploaded_version.all_files[0] %}
     <a class="button" id="download-addon-url" download href="{{ file.get_url_path('devhub') }}">{{
         _("Download {0}")|fe(file.pretty_filename()) }}</a>
   </p>

--- a/src/olympia/devhub/templates/devhub/email/submission.txt
+++ b/src/olympia/devhub/templates/devhub/email/submission.txt
@@ -1,8 +1,4 @@
-{% if full_review %}
 Thanks for submitting your {{ app }} Add-on to addons.mozilla.org (AMO)! Your add-on has been added to the New Add-on queue.
-{% else %}
-Thanks for submitting your {{ app }} Add-on to addons.mozilla.org (AMO)! Your add-on has been added to the Preliminary Review queue.
-{% endif %}
 
 We will contact you if we need more information. After it is reviewed, you will receive an email notification and your add-on will appear in categories and search results. While awaiting review, your add-on can still be accessed and installed directly from its detail page:
 

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -1588,7 +1588,6 @@ class TestSubmitStepFinish(TestSubmitBase):
             'detail_url': 'http://b.ro/en-US/firefox/addon/a3615/',
             'version_url': 'http://b.ro/en-US/developers/addon/a3615/versions',
             'edit_url': 'http://b.ro/en-US/developers/addon/a3615/edit',
-            'full_review': False,
         }
         send_welcome_email_mock.assert_called_with(
             self.addon.id, ['del@icio.us'], context)

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -1511,7 +1511,6 @@ def submit_finish(request, addon_id, addon):
             'detail_url': absolutify(addon.get_url_path()),
             'version_url': absolutify(addon.get_dev_url('versions')),
             'edit_url': absolutify(addon.get_dev_url('edit')),
-            'full_review': addon.status == amo.STATUS_NOMINATED
         }
         tasks.send_welcome_email.delay(addon.id, [author.email], context)
 

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -1490,8 +1490,9 @@ def submit_finish(request, addon_id, addon):
     # Bounce to the versions page if they don't have any versions.
     if not addon.versions.exists():
         return redirect(addon.get_dev_url('versions'))
-    sp = addon.current_version.supported_platforms
-    is_platform_specific = sp != [amo.PLATFORM_ALL]
+    uploaded_version = addon.versions.latest()
+    supported_platforms = uploaded_version.supported_platforms
+    is_platform_specific = supported_platforms != [amo.PLATFORM_ALL]
 
     try:
         author = addon.authors.all()[0]
@@ -1499,23 +1500,23 @@ def submit_finish(request, addon_id, addon):
         # This should never happen.
         author = None
 
-    if author:
-        submitted_addons = (author.addons
-                            .exclude(status=amo.STATUS_NULL).count())
-        if submitted_addons == 1:
-            # We can use locale-prefixed URLs because the submitter probably
-            # speaks the same language by the time he/she reads the email.
-            context = {
-                'app': unicode(request.APP.pretty),
-                'detail_url': absolutify(addon.get_url_path()),
-                'version_url': absolutify(addon.get_dev_url('versions')),
-                'edit_url': absolutify(addon.get_dev_url('edit')),
-                'full_review': addon.status == amo.STATUS_NOMINATED
-            }
-            tasks.send_welcome_email.delay(addon.id, [author.email], context)
+    if (author and not author.addons.exclude(status=amo.STATUS_NULL)
+                                    .exclude(pk=addon.pk).exists()):
+        # If that's the first time this developer has submitted an addon
+        # (no other addon by this author exists) send them a welcome email.
+        # We can use locale-prefixed URLs because the submitter probably
+        # speaks the same language by the time he/she reads the email.
+        context = {
+            'app': unicode(request.APP.pretty),
+            'detail_url': absolutify(addon.get_url_path()),
+            'version_url': absolutify(addon.get_dev_url('versions')),
+            'edit_url': absolutify(addon.get_dev_url('edit')),
+            'full_review': addon.status == amo.STATUS_NOMINATED
+        }
+        tasks.send_welcome_email.delay(addon.id, [author.email], context)
 
     return render(request, 'devhub/addons/submit/done.html',
-                  {'addon': addon,
+                  {'addon': addon, 'uploaded_version': uploaded_version,
                    'is_platform_specific': is_platform_specific})
 
 

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -1500,10 +1500,15 @@ def submit_finish(request, addon_id, addon):
         # This should never happen.
         author = None
 
-    if (author and not author.addons.exclude(status=amo.STATUS_NULL)
-                                    .exclude(pk=addon.pk).exists()):
-        # If that's the first time this developer has submitted an addon
-        # (no other addon by this author exists) send them a welcome email.
+    if (author and uploaded_version.channel == amo.RELEASE_CHANNEL_LISTED and
+            not Version.objects.exclude(pk=uploaded_version.pk)
+                               .filter(addon__authors=author,
+                                       channel=amo.RELEASE_CHANNEL_LISTED)
+                               .exclude(addon__status=amo.STATUS_NULL)
+                               .exists()):
+        # If that's the first time this developer has submitted an listed addon
+        # (no other listed Version by this author exists) send them a welcome
+        # email.
         # We can use locale-prefixed URLs because the submitter probably
         # speaks the same language by the time he/she reads the email.
         context = {


### PR DESCRIPTION
To prepare for #3847.

Bonus drive-by optimization, stop counting the add-ons for the user when we're only interested in knowing if they have submitted any other than the current one.