### PR TITLE
give people more information before filing a bug

### DIFF
--- a/src/olympia/templates/copyright.html
+++ b/src/olympia/templates/copyright.html
@@ -15,7 +15,7 @@
           &nbsp;|&nbsp;<a class="mobile-link" href="#">{{ _('View Mobile Site') }}</a>
         {% endif %}
         &nbsp;|&nbsp;<a href="https://status.mozilla.org/#addons.mozilla.org_service_history">{{ _('Site Status')}}</a>
-        &nbsp;|&nbsp;<a href="https://github.com/mozilla/addons/issues/new">{{ _('Report a bug')}}</a>
+        &nbsp;|&nbsp;<a href="https://developer.mozilla.org/Add-ons/AMO/Policy/Contact">{{ _('Report a bug')}}</a>
       {% endblock %}
     {% endblock %}
   </p>


### PR DESCRIPTION
* supports #3951
* there is a page that lists the options and its easy to alter since its a wiki page on MDN
* this is the page that the FAQs on AMO also link to
* hopefully this will reduce the amount of bug spam in mozilla/addons