### PR TITLE
syntax highlight htm

### DIFF
--- a/src/olympia/files/helpers.py
+++ b/src/olympia/files/helpers.py
@@ -250,7 +250,7 @@ class FileViewer(object):
         if filename:
             short = os.path.splitext(filename)[1][1:]
             syntax_map = {'xul': 'xml', 'rdf': 'xml', 'jsm': 'js',
-                          'json': 'js'}
+                          'json': 'js', 'htm': 'html'}
             short = syntax_map.get(short, short)
             if short in ['actionscript3', 'as3', 'bash', 'shell', 'cpp', 'c',
                          'c#', 'c-sharp', 'csharp', 'css', 'diff', 'html',

--- a/src/olympia/files/tests/test_helpers.py
+++ b/src/olympia/files/tests/test_helpers.py
@@ -176,6 +176,7 @@ class TestFileHelper(TestCase):
                                  ('foo.xul', 'xml'),
                                  ('foo.json', 'js'),
                                  ('foo.jsm', 'js'),
+                                 ('foo.htm', 'html'),
                                  ('foo.bar', 'plain')]:
             assert self.viewer.get_syntax(filename) == syntax
 


### PR DESCRIPTION
* fixes mozilla/addons#247 by highlighting htm as html