### PR TITLE
show channel tags on version list page

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1308,6 +1308,10 @@ class Addon(OnChangeMixin, ModelBase):
         return self.versions.filter(
             channel=amo.RELEASE_CHANNEL_LISTED).exists()
 
+    def has_unlisted_versions(self):
+        return self.versions.filter(
+            channel=amo.RELEASE_CHANNEL_UNLISTED).exists()
+
     @classmethod
     def featured_random(cls, app, lang):
         return get_featured_ids(app, lang)

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -1467,7 +1467,7 @@ class TestAddonModels(TestCase):
         assert addon.has_complete_metadata()  # Still complete
 
 
-class TestHasListedVersions(TestCase):
+class TestHasListedAndUnlistedVersions(TestCase):
     def setUp(self):
         self.addon = addon_factory()
         latest_version = self.addon.find_latest_version(
@@ -1475,21 +1475,25 @@ class TestHasListedVersions(TestCase):
         latest_version.delete(hard=True)
         assert self.addon.versions.count() == 0
 
-    def test_no_versions_is_unlisted(self):
+    def test_no_versions(self):
         assert not self.addon.has_listed_versions()
+        assert not self.addon.has_unlisted_versions()
 
     def test_listed_version(self):
         version_factory(channel=amo.RELEASE_CHANNEL_LISTED, addon=self.addon)
         assert self.addon.has_listed_versions()
+        assert not self.addon.has_unlisted_versions()
 
     def test_unlisted_version(self):
         version_factory(channel=amo.RELEASE_CHANNEL_UNLISTED, addon=self.addon)
         assert not self.addon.has_listed_versions()
+        assert self.addon.has_unlisted_versions()
 
-    def test_unlisted_and_listed_versions_is_listed(self):
+    def test_unlisted_and_listed_versions(self):
         version_factory(channel=amo.RELEASE_CHANNEL_LISTED, addon=self.addon)
         version_factory(channel=amo.RELEASE_CHANNEL_UNLISTED, addon=self.addon)
         assert self.addon.has_listed_versions()
+        assert self.addon.has_unlisted_versions()
 
 
 class TestAddonNomination(TestCase):

--- a/src/olympia/devhub/templates/devhub/addons/listing/delete_form.html
+++ b/src/olympia/devhub/templates/devhub/addons/listing/delete_form.html
@@ -12,8 +12,10 @@
       {% else %}
         <b>
           {% trans %}
-            Deleting your add-on will permanently remove it from the site and
-            prevent its GUID from being submitted again by others.
+          Deleting your add-on will permanently delete all versions and files you
+          have submitted for this add-on, listed or not. The add-on ID will
+          continue to be linked to your account, so others won't be able to submit
+          versions using the same ID.
           {% endtrans %}
         </b>
       {% endif %}

--- a/src/olympia/devhub/templates/devhub/versions/list.html
+++ b/src/olympia/devhub/templates/devhub/versions/list.html
@@ -161,7 +161,7 @@
                     {% if not addon.is_disabled %}checked="checked"{% endif %}
                     data-url="{{ addon.get_dev_url('enable') }}"
                     class="enable-addon">
-        <strong>{{ _('Visible:') }}</strong> {{ _('Visible to everyone on {0} and included in search results and listing pages')|f(settings.SITE_URL) }}</label>
+        <strong>{{ _('Visible:') }}</strong> {{ _('Visible to everyone on {0} and included in search results and listing pages.')|f(settings.SITE_URL) }}</label>
         <br>
         <label><input name="addon-state" value="hidden" type="radio"
                     {% if not owner %}disabled="disabled"{% endif %}
@@ -260,9 +260,19 @@
       </div>
     {% endif %}
   </div>
-  <br><br>
   {% if check_addon_ownership(request, addon) and addon.can_be_deleted() %}
-    <a class="delete-button delete-addon" href="{{ addon.get_dev_url('versions') }}#delete-addon">{{ _('Delete Add-on') }}</a>
+  <h3>{{ _('Delete Add-on') }}</h3>
+  <div class="item" id="addon-delete-listing">
+    <div class="item_wrapper">
+      <p>{% trans %}
+      Deleting your add-on will permanently delete all versions and files you
+      have submitted for this add-on, listed or not. The add-on ID will
+      continue to be linked to your account, so others won't be able to submit
+      versions using the same ID.
+      {% endtrans %}</p>
+      <a class="delete-button delete-addon" href="{{ addon.get_dev_url('versions') }}#delete-addon">{{ _('Delete Add-on') }}</a>
+    </div>
+  </div>
   {% endif %}
 </section>
 

--- a/src/olympia/devhub/templates/devhub/versions/list.html
+++ b/src/olympia/devhub/templates/devhub/versions/list.html
@@ -3,6 +3,25 @@
 {% set title = _('Status & Versions') %}
 {% block title %}{{ dev_page_title(title, addon) }}{% endblock %}
 
+{% if addon.has_listed_versions() %}
+  {% set has_listed_versions = True %}
+{% endif %}
+{% if addon.has_unlisted_versions() %}
+  {% set has_unlisted_versions = True %}
+{% endif %}
+
+{% if has_listed_versions and has_unlisted_versions %}
+  {% macro distro_tag(channel) %}
+    {% if channel == amo.RELEASE_CHANNEL_LISTED %}
+      <span class="distribution-tag-listed">AMO</span>
+    {% elif channel == amo.RELEASE_CHANNEL_UNLISTED %}
+      <span class="distribution-tag-unlisted">Self</span>
+    {% endif %}
+  {% endmacro %}
+{% else %}
+  {% macro distro_tag(channel) %}{% endmacro %}
+{% endif %}
+
 {% macro version_details(version, full_info=False) %}
   {% set is_latest_version_in_channel = (version == version.addon.find_latest_version_including_rejected(channel=version.channel)) %}
   <tr{% if version_disabled(version) %} class="version-disabled"{% endif %}>
@@ -19,8 +38,7 @@
     <td class="file-status">
       {% for count, status in dev_files_status(version.all_files) %}
           <div>
-            {# L10n: {0} is the number of files #}
-            {{ status }} ({{ ngettext('{0} file', '{0} files', count)|f(count) }})
+            {{ distro_tag(version.channel)}} {{ status }}
           </div>
       {% else %}
           {{ _('0 files') }}
@@ -133,83 +151,94 @@
   <h2>{{ addon.name }}</h2>
 </header>
 <section id="edit-addon" class="primary devhub-form" role="main">
-  <h3>{{ _('Add-on visibility') }}</h3>
-  <div class="item" id="addon-current-state">
-    <div class="item_wrapper">
-      {% if not addon.is_listed %}
-        <div class="highlight">
-          <h3>{{ _('Why can\'t I switch to <i>Listed</i> or <i>Hidden</i>?') }}</h3>
-          <p>{{ _('Due to technical limitations, you need to delete your entire add-on and resubmit it using this AMO account in order to switch your add-on to listed.
-            The process is described in detail in <a href="{link}">this documentation</a>.').format(
-                link='https://developer.mozilla.org/en-US/Add-ons/Distribution') }}</p>
-        </div>
-      {% endif %}
-      {% set owner = check_addon_ownership(request, addon, dev=True) %}
-      <label><input name="addon-state" value="listed" type="radio"
-                    {% if not owner or addon.status == amo.STATUS_DISABLED or not addon.is_listed %}disabled="disabled"{% endif %}
-                    {% if not addon.is_disabled and addon.is_listed %}checked="checked"{% endif %}
+  {% if has_listed_versions %}
+    <h3>{{ distro_tag(amo.RELEASE_CHANNEL_LISTED)}} {{ _('Listing visibility') }}</h3>
+    <div class="item" id="addon-current-state">
+      <div class="item_wrapper">
+        {% set owner = check_addon_ownership(request, addon, dev=True) %}
+        <label><input name="addon-state" value="listed" type="radio"
+                    {% if not owner or addon.status == amo.STATUS_DISABLED %}disabled="disabled"{% endif %}
+                    {% if not addon.is_disabled %}checked="checked"{% endif %}
                     data-url="{{ addon.get_dev_url('enable') }}"
                     class="enable-addon">
-             <strong>{{ _('Listed:') }}</strong> {{ _('Visible to everyone on {0} and included in search results and listing pages')|f(settings.SITE_URL) }}</label>
-      <br><br>
-      <label><input name="addon-state" value="hidden" type="radio"
-                    {% if not owner or not addon.is_listed %}disabled="disabled"{% endif %}
-                    {% if addon.is_disabled and addon.is_listed %}checked="checked"{% endif %}
+        <strong>{{ _('Visible:') }}</strong> {{ _('Visible to everyone on {0} and included in search results and listing pages')|f(settings.SITE_URL) }}</label>
+        <br>
+        <label><input name="addon-state" value="hidden" type="radio"
+                    {% if not owner %}disabled="disabled"{% endif %}
+                    {% if addon.is_disabled %}checked="checked"{% endif %}
                     class="disable-addon">
-             <strong>{{ _('Hidden:') }}</strong> {{ _('Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide listings or discontinue them.')|f(settings.SITE_URL) }}</label>
-      <br><br>
-      <label><input name="addon-state" value="unlisted" type="radio"
+        <strong>{{ _('Invisible:') }}</strong> {{ _('Hosted on {0}, but hidden to anyone but authors. Used to temporarily hide listings or discontinue them.')|f(settings.SITE_URL) }}</label>
+        <br>
+        {% if not waffle.switch('mixed-listed-unlisted') %}
+            <label><input name="addon-state" value="unlisted" type="radio"
                     {% if not owner or addon.status == amo.STATUS_DISABLED %}disabled="disabled"{% endif %}
-                    {% if not addon.is_listed %}checked="checked"{% endif %}
                     class="unlist-addon">
-             <strong>{{ _('Unlisted:') }}</strong> {{ _('Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own.')|f(settings.SITE_URL) }}</label>
-      <br><br>
-      {% if check_addon_ownership(request, addon) and addon.can_be_deleted() %}
-        <a class="delete-button delete-addon" href="{{ addon.get_dev_url('versions') }}#delete-addon">{{ _('Delete Add-on') }}</a>
-      {% endif %}
-    </div>
-  </div>
-
-  {% set latest_listed_version=addon.find_latest_version(channel=amo.RELEASE_CHANNEL_LISTED) %}
-  <h3>{{ _('Current versions') }}</h3>
-  {% if addon.current_version %}
-    <div class="item" id="current-version-status">
-      <div class="item_wrapper">
-        <table>
-          <tr>
-            <th>{{ _('Currently on AMO') }}</th>
-            <th>{{ _('Status') }}</th>
-            <th>{{ _('Validation') }}</th>
-            <th class="version-delete">{{ _('Delete/Disable') }}</th>
-          </tr>
-          {{ version_details(addon.current_version,
-                             full_info=(not latest_listed_version
-                                        or latest_listed_version == addon.current_version)) }}
-        </table>
+            <strong>{{ _('Unlisted:') }}</strong> {{ _('Not distributed on {0}. Developers will upload new versions for signing and distribute the add-ons on their own.')|f(settings.SITE_URL) }}</label>
+        {% endif %}
       </div>
     </div>
-  {% endif %}
 
-  {% if latest_listed_version and latest_listed_version != addon.current_version %}
-    <div class="item" id="next-version-status">
-      <div class="item_wrapper">
-        <table>
-          <tr>
-            <th>{{ _('Next version of this add-on') }}</th>
-            <th>{{ _('Status') }}</th>
-            <th>{{ _('Validation') }}</th>
-            <th class="version-delete">{{ _('Delete/Disable') }}</th>
-          </tr>
-          {{ version_details(latest_listed_version, full_info=True) }}
-        </table>
+    {% set latest_listed_version=addon.find_latest_version(channel=amo.RELEASE_CHANNEL_LISTED) %}
+    {% set current_version=addon.current_version %}
+
+    {% if latest_listed_version or current_version %}
+        <h3>{{ distro_tag(amo.RELEASE_CHANNEL_LISTED)}} {{ _('Listed versions') }}</h3>
+    {% endif %}
+    {% if current_version %}
+      <div class="item" id="current-version-status">
+        <div class="item_wrapper">
+          <table>
+            <tr>
+              <th>{{ _('Currently on AMO') }}</th>
+              <th>{{ _('Status') }}</th>
+              <th>{{ _('Validation') }}</th>
+              <th class="version-delete">{{ _('Delete/Disable') }}</th>
+            </tr>
+            {{ version_details(current_version,
+                               full_info=(not latest_listed_version
+                                          or latest_listed_version == current_version)) }}
+          </table>
+        </div>
       </div>
-    </div>
-  {% endif %}
+    {% endif %}
 
-  <h3>{{ _('Older versions') }}</h3>
+    {% if latest_listed_version and latest_listed_version != current_version %}
+      <div class="item" id="next-version-status">
+        <div class="item_wrapper">
+          <table>
+            <tr>
+              <th>{{ _('Next version of this add-on') }}</th>
+              <th>{{ _('Status') }}</th>
+              <th>{{ _('Validation') }}</th>
+              <th class="version-delete">{{ _('Delete/Disable') }}</th>
+            </tr>
+            {{ version_details(latest_listed_version, full_info=True) }}
+          </table>
+        </div>
+      </div>
+    {% endif %}
+
+    <h3>{{ _('Older versions') }}</h3>
+  {% else %}
+    <div class="highlight">
+      <h3>{{ _('Why can\'t I switch to <i>Listed</i>?') }}</h3>
+      <p>{{ _('Due to technical limitations, you need to delete your entire add-on and resubmit it using this AMO account in order to switch your add-on to listed.
+        The process is described in detail in <a href="{link}">this documentation</a>.').format(
+            link='https://developer.mozilla.org/en-US/Add-ons/Distribution') }}</p>
+    </div>
+    <h3>{{ _('All versions') }}</h3>
+  {% endif %}
   <div class="item" id="version-list"
        data-stats="{{ url('devhub.versions.stats', addon.slug) }}">
     <div class="item_wrapper">
+      <div>
+        {% if waffle.switch('step-version-upload') %}
+          {% set version_upload_url = url('devhub.submit.version', addon.slug) %}
+        {% else %}
+          {% set version_upload_url = '#' %}
+        {% endif %}
+        <a href="{{ version_upload_url }}" class="button version-upload">{{ _('Upload a New Version') }}</a>
+      </div>
       <table>
         <tr>
           <th>{{ _('Version') }}</th>
@@ -217,18 +246,9 @@
           <th>{{ _('Validation') }}</th>
           <th class="version-delete">{{ _('Delete/Disable') }}</th>
         </tr>
-        <tr>
-          <td colspan="0">
-            {% if waffle.switch('step-version-upload') %}
-              {% set version_upload_url = url('devhub.submit.version', addon.slug) %}
-            {% else %}
-              {% set version_upload_url = '#' %}
-            {% endif %}
-            <a href="{{ version_upload_url }}" class="button version-upload">{{ _('Upload a New Version') }}</a>
-          </td>
-        </tr>
+
         {% for version in versions.object_list %}
-          {% if version != addon.current_version and version != latest_listed_version %}
+          {% if version != current_version and version != latest_listed_version %}
             {{ version_details(version) }}
           {% endif %}
         {% endfor %}
@@ -240,7 +260,10 @@
       </div>
     {% endif %}
   </div>
-
+  <br><br>
+  {% if check_addon_ownership(request, addon) and addon.can_be_deleted() %}
+    <a class="delete-button delete-addon" href="{{ addon.get_dev_url('versions') }}#delete-addon">{{ _('Delete Add-on') }}</a>
+  {% endif %}
 </section>
 
 <div id="modals">
@@ -287,6 +310,7 @@
                        'version')}}
   {% endif %}
 
+  {% if has_listed_versions %}
   {% if not addon.disabled_by_user and not addon.is_disabled %}
   <div id="modal-disable" class="modal">
     <form method="post" action="{{ addon.get_dev_url('disable') }}">
@@ -325,7 +349,7 @@
   </div>
   {% endif %}
 
-  {% if addon.is_listed %}
+  {% if not waffle.switch('mixed-listed-unlisted') %}
   <div id="modal-unlist" class="modal">
     <form method="post" action="{{ addon.get_dev_url('unlist') }}">
       <h3>
@@ -385,6 +409,7 @@
       <a href="#" class="close">{{ _('Close') }}</a>
     </form>
   </div>
+  {% endif %}
   {% endif %}
 </div>
 

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -99,8 +99,10 @@ class TestVersion(TestCase):
         r = self.client.get(self.url)
         doc = pq(r.content)
         assert doc('#modal-delete p').eq(0).text() == (
-            'Deleting your add-on will permanently remove it from the site '
-            'and prevent its GUID from being submitted again by others.')
+            'Deleting your add-on will permanently delete all versions and '
+            'files you have submitted for this add-on, listed or not. '
+            'The add-on ID will continue to be linked to your account, so '
+            'others won\'t be able to submit versions using the same ID.')
 
     def test_delete_message_if_bits_are_messy(self):
         """Make sure we warn krupas of the pain they will feel."""
@@ -110,8 +112,10 @@ class TestVersion(TestCase):
         r = self.client.get(self.url)
         doc = pq(r.content)
         assert doc('#modal-delete p').eq(0).text() == (
-            'Deleting your add-on will permanently remove it from the site '
-            'and prevent its GUID from being submitted again by others.')
+            'Deleting your add-on will permanently delete all versions and '
+            'files you have submitted for this add-on, listed or not. '
+            'The add-on ID will continue to be linked to your account, so '
+            'others won\'t be able to submit versions using the same ID.')
 
     def test_delete_message_incomplete(self):
         """

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -401,6 +401,7 @@ def disable(request, addon_id, addon):
 
 @dev_required
 @post_required
+@waffle_switch('!mixed-listed-unlisted')
 def unlist(request, addon_id, addon):
     addon.update(is_listed=False, disabled_by_user=False)
     # In https://github.com/mozilla/addons-server/issues/3471 this view will

--- a/static/css/devhub/listing.less
+++ b/static/css/devhub/listing.less
@@ -132,6 +132,6 @@
 .item:hover a.delete-addon {
     color: #d33;
 }
-#addon-current-state.item:hover a.delete-addon {
+#addon-delete-listing.item:hover a.delete-addon {
     color: #fff;
 }

--- a/static/css/zamboni/developers.css
+++ b/static/css/zamboni/developers.css
@@ -1499,3 +1499,18 @@ button.search-button {
 .html-rtl #addon-compat-upload span {
     margin: 0 0 0 3em;
 }
+
+.distribution-tag-listed, .distribution-tag-unlisted {
+    color: white;
+    border-radius: 4px;
+    padding: 1px 5px;
+    font-size: smaller
+}
+
+.distribution-tag-listed {
+    background-color: #01BDAD;
+}
+
+.distribution-tag-unlisted {
+    background-color: #7A2F7A;
+}


### PR DESCRIPTION
Fixes #3470 
Depends on #3940 for the waffle migration (and because it's only testable when you are able to mix listed and unlisted versions... or you hack the database)