### PR TITLE
Index addons {version}.id in ES to prepare for has_version removal

### DIFF
--- a/src/olympia/addons/indexers.py
+++ b/src/olympia/addons/indexers.py
@@ -33,7 +33,9 @@ class AddonIndexer(BaseSearchIndexer):
             'properties': {
                 'compatible_apps': {'properties': {app.id: appver_mapping
                                                    for app in amo.APP_USAGE}},
-                'id': {'type': 'long', 'index': 'no'},
+                # Keep '<version>.id' indexed to be able to run exists queries
+                # on it.
+                'id': {'type': 'long'},
                 'reviewed': {'type': 'date', 'index': 'no'},
                 'files': {
                     'type': 'object',


### PR DESCRIPTION
This will allow filtering against `current_version.id` or `latest_unlisted_version.id` existence.

Part of #3969

Has to be committed separately to maintain backwards-compatibility before the reindex.