### PR TITLE
Downgrade celery and dependend libraries (billiard, kombu).

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -33,15 +33,17 @@ argparse==1.4.0 \
     --hash=sha256:c31647edb69fd3d465a847ea3157d37bed1f95f19760b11a47aa91c04b666314 \
     --hash=sha256:62b089a55be1d8949cd2bc7e0df0bddb9e028faefc8c32038cc84862aefdd6e4
 # billiard is required by celery
-billiard==3.5.0.1 \
-    --hash=sha256:de80ea1d53b9babf6bdbafc78dc0e547e3d56767bc8c54f7a902e7aec8b14651 \
-    --hash=sha256:989e5c208350ada5f37f0f187758a801457fe53e9a1d06c139796afcfafabd5b
+billiard==3.3.0.23 \
+    --hash=sha256:c0cbe8d45ba8d8213ad68ef9a1881002a151569c9424d551634195a18c3a4160 \
+    --hash=sha256:82041dbaa62f7fde1464d7ab449978618a38b241b40c0d31dafabb36446635dc \
+    --hash=sha256:958fc9f8fd5cc9b936b2cb9d96f02aa5ec3613ba13ee7f089c77ff0bcc368fac \
+    --hash=sha256:692a2a5a55ee39a42bcb7557930e2541da85df9ea81c6e24827f63b80cd39d0b
 bleach==1.4.3 \
     --hash=sha256:75bb62077ad33f8d57fb783267b062a8a0662d2ded8398b8c0098a06b6f466cc \
     --hash=sha256:1293061adb5a9eebb7b260516e691785ac08cc1646c8976aeda7db9dbb1c6f4b
-celery==3.1.24 \
-    --hash=sha256:25396191954521184cc15018f776a2a2278b04dd4213d94f795daef4b7961b4b \
-    --hash=sha256:99b8085ff3013c8cebb9211857fadf5f402882ccada863d67c4d74db60be027a
+celery==3.1.23 \
+    --hash=sha256:eaf5dee3becbc35c7754a2d4482d53bdf72ea3f85dd258525259983262081474 \
+    --hash=sha256:1a359c815837f9dbf193a7dbc6addafa34612c077ff70c66e3b16e14eebd2418
 certifi==0.0.8 \
     --hash=sha256:46ecf5f7526a08cc1f8bc8232adf0cffce046f46ceff95539daec42ebc4849ef
 # cffi is required by cryptography
@@ -193,9 +195,9 @@ jingo==0.9.0 \
     --hash=sha256:12a983286519303c6afd3da6f0a7e1859e69effb5fe46109424cdfca382bea56 \
     --hash=sha256:37de5435622d05763bc55d1a3d0a7edcf998ece9e6048bb470db431d1aa83c3a
 # kombu is required by celery
-kombu==3.0.37 \
-    --hash=sha256:7ceab743e3e974f3e5736082e8cc514c009e254e646d6167342e0e192aee81a6 \
-    --hash=sha256:e064a00c66b4d1058cd2b0523fb8d98c82c18450244177b6c0f7913016642650
+kombu==3.0.35 \
+    --hash=sha256:2c59a5e087d5895675cdb4d6a38a0aa147f0411366e68330a76e480ba3b25727 \
+    --hash=sha256:22ab336a17962717a5d9470547e5508d4bcf1b6ec10cd9486868daf4e5edb727
 # m2secret is required by django-aesfield
 m2secret==0.1.1 \
     --hash=sha256:4174f4967b378d751e758894d6c394db506c4f8753d1db66494320c31667d8a0


### PR DESCRIPTION
This might be related to an exception we started to see on production:

File "/usr/lib64/python2.7/site-packages/billiard/pool.py", line 1626, in _terminate_pool :/usr/lib/python2.7/site-packages/celery/utils/log.py:282
...

(no full traceback available unfortunately)

Also, I noticed that I didn't see the requirement of celery for billiard> 3.3, <3.4 so let's downgrade for now and be more careful next time.