### PR TITLE
Make sure we only use current_version in "listed" context

### DIFF
--- a/src/olympia/devhub/templates/devhub/includes/addon_details.html
+++ b/src/olympia/devhub/templates/devhub/includes/addon_details.html
@@ -65,12 +65,19 @@
 {% if addon.current_version %}
   <li>
     <strong>{{ _('Current Version:') }}</strong>
-    {{ link_if_listed_else_text(addon.current_version, addon.current_version) }}
+    {{ link_if_listed_else_text(addon.current_version, addon.current_version.version) }}
     <span class="tip tooltip" title="{{ _('This is the version of your add-on that will '
                                           'be installed if someone clicks the Install '
-                                          'button on addons.mozilla.org. It is only '
-                                          'relevant for listed add-ons.') }}">?</span>
+                                          'button on addons.mozilla.org.') }}">?</span>
   </li>
+{% else %}
+  {% set latest_unlisted_version = addon.find_latest_version(channel=amo.RELEASE_CHANNEL_UNLISTED) %}
+  {% if latest_unlisted_version %}
+    <li>
+      <strong>{{ _('Latest Version:') }}</strong>
+      {{ link_if_listed_else_text(version, version.version) }}
+    </li>
+  {% endif %}
 {% endif %}
 {% if addon.type == amo.ADDON_EXTENSION and amo.FIREFOX in addon.compatible_apps %}
 <li class="e10s-compatibility e10s-{{ addon.feature_compatibility.get_e10s_classname() }}">
@@ -92,22 +99,24 @@
       {{ addon.last_updated|datetime(_('%%b %%e, %%Y')) }}
   </li>
 {% endif %}
-{% set latest_listed_version=addon.find_latest_version(channel=amo.RELEASE_CHANNEL_LISTED) %}
-{% if latest_listed_version and latest_listed_version != addon.current_version %}
-  <li>
-    <strong>{{ _('Next Version:') }}</strong>
-    {{ link_if_listed_else_text(latest_listed_version, latest_listed_version.version) }}
-    <span class="tip tooltip" title="{{ _('This is the newest uploaded version, however it isn’t live on the site yet.') }}">?</span>
-  </li>
-{% endif %}
-{% with position = get_position(addon) %}
-  {% if position and position.pos and position.total %}
-    <li class="queue-position" title="{{ _('Queues are not reviewed strictly in order') }}">
-      <strong>{{ _('Queue Position:') }}</strong>
-      {% trans position=position.pos|numberfmt,
-               total=position.total|numberfmt %}
-        {{ position }} of {{ total }}
-      {% endtrans %}
+{% if addon.has_listed_versions() %}
+  {% set latest_listed_version=addon.find_latest_version(channel=amo.RELEASE_CHANNEL_LISTED) %}
+  {% if latest_listed_version and latest_listed_version != addon.current_version %}
+    <li>
+      <strong>{{ _('Next Version:') }}</strong>
+      {{ link_if_listed_else_text(latest_listed_version, latest_listed_version.version) }}
+      <span class="tip tooltip" title="{{ _('This is the newest uploaded version, however it isn’t live on the site yet.') }}">?</span>
     </li>
   {% endif %}
-{% endwith %}
+  {% with position = get_position(addon) %}
+    {% if position and position.pos and position.total %}
+      <li class="queue-position" title="{{ _('Queues are not reviewed strictly in order') }}">
+        <strong>{{ _('Queue Position:') }}</strong>
+        {% trans position=position.pos|numberfmt,
+                 total=position.total|numberfmt %}
+          {{ position }} of {{ total }}
+        {% endtrans %}
+      </li>
+    {% endif %}
+  {% endwith %}
+{% endif %}

--- a/src/olympia/devhub/templates/devhub/index-legacy.html
+++ b/src/olympia/devhub/templates/devhub/index-legacy.html
@@ -96,24 +96,28 @@
                         {{ _('Unlisted') }}
                       {% endif %}
                     </p>
-                    {% if item.addon.current_version %}
+                    {# Find the most appropriate version to show: either the current (listed) version, or the latest unlisted #}
+                    {% set version = item.addon.current_version or item.addon.find_latest_version(channel=amo.RELEASE_CHANNEL_UNLISTED) %}
+                    {% if version %}
                       <p>
                         <strong>{{ _('Latest Version:') }}</strong>
                         {{ link_if_listed_else_text(item.addon.current_version,
                                          item.addon.current_version.version) }}
                       </p>
-                    {% endif %}
-                    {% with position = item.position %}
-                      {% if position and position.pos and position.total %}
-                        <p>
-                          <strong>{{ _('Queue Position:') }}</strong>
-                          {% trans position=position.pos|numberfmt,
-                                   total=position.total|numberfmt %}
-                            {{ position }} of {{ total }}
-                          {% endtrans %}
-                        </p>
+                      {% if version.channel == amo.RELEASE_CHANNEL_LISTED %}
+                        {% with position = item.position %}
+                          {% if position and position.pos and position.total %}
+                            <p>
+                              <strong>{{ _('Queue Position:') }}</strong>
+                              {% trans position=position.pos|numberfmt,
+                                       total=position.total|numberfmt %}
+                                {{ position }} of {{ total }}
+                              {% endtrans %}
+                            </p>
+                          {% endif %}
+                        {% endwith %}
                       {% endif %}
-                    {% endwith %}
+                    {% endif %}
                     {% if not item.addon.is_persona() and item.addon.has_complete_metadata() and not item.addon.is_disabled %}
                       <p class="upload-new-version">
                         {% if waffle.switch('step-version-upload') %}

--- a/src/olympia/devhub/templates/devhub/versions/list.html
+++ b/src/olympia/devhub/templates/devhub/versions/list.html
@@ -53,27 +53,16 @@
         </form>
         </div>
       {% endif %}
-      {% if display_position %}
-        {% with position = get_position(addon) %}
-          {% if position.pos and position.total %}
-            <span class="note queue-position" title="{{ _('Queues are not reviewed strictly in order') }}">
-              {% trans pos=position.pos|numberfmt, total=position.total|numberfmt %}
-                Queue position: {{ pos }} of {{ total }}
-              {% endtrans %}
-            </li>
+      <div>
+          <a href="#" class="review-history-show" data-div="#{{ version.id }}-review-history">{{ _('Review History') }}</a>
+          <a href="#" class="review-history-hide hidden">{{ _('Close Review History') }}</a>
+          {% if is_latest_version_in_channel %}
+              {% set pending_count = pending_activity_log_count_for_developer(version) %}
+              {% if pending_count > 0 %}
+                  <b class="review-history-pending-count">{{ pending_count }}</b>
+              {% endif %}
           {% endif %}
-        {% endwith %}
-      {% endif %}
-        <div>
-            <a href="#" class="review-history-show" data-div="#{{ version.id }}-review-history">{{ _('Review History') }}</a>
-            <a href="#" class="review-history-hide hidden">{{ _('Close Review History') }}</a>
-            {% if is_latest_version_in_channel %}
-                {% set pending_count = pending_activity_log_count_for_developer(version) %}
-                {% if pending_count > 0 %}
-                    <b class="review-history-pending-count">{{ pending_count }}</b>
-                {% endif %}
-            {% endif %}
-        </div>
+      </div>
     </td>
     <td class="file-validation">
       <ul>

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -2397,7 +2397,7 @@ class TestVersionXSS(UploadTest):
         r = self.client.get(reverse('devhub.addons'))
         assert r.status_code == 200
         assert '<script>alert' not in r.content
-        assert '&amp;lt;script&amp;gt;alert' in r.content
+        assert '&lt;script&gt;alert' in r.content
 
 
 class TestDeleteAddon(TestCase):

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -652,8 +652,10 @@ class TestVersion(TestCase):
         assert pending_activity_count.text() == '2'
 
     def test_channel_tag(self):
+        self.addon.current_version.update(created=self.days_ago(1))
         v2, _ = self._extra_version_and_file(amo.STATUS_DISABLED)
         self.addon.versions.update(channel=amo.RELEASE_CHANNEL_LISTED)
+        self.addon.update_version()
         r = self.client.get(self.url)
         assert r.status_code == 200
         doc = pq(r.content)

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -1355,7 +1355,6 @@ def version_list(request, addon_id, addon):
     data = {'addon': addon,
             'versions': versions,
             'new_file_form': new_file_form,
-            'position': get_position(addon),
             'token': token,
             'is_admin': is_admin}
     return render(request, 'devhub/versions/list.html', data)


### PR DESCRIPTION
Part of #3847, current_version will soon only consider listed versions