### PR TITLE
Restrict current_version to listed versions only

### DIFF
--- a/src/olympia/addons/management/commands/process_addons.py
+++ b/src/olympia/addons/management/commands/process_addons.py
@@ -7,6 +7,7 @@ from celery import chord, group
 
 from olympia import amo
 from olympia.addons.models import Addon
+from olympia.addons.tasks import update_current_version
 from olympia.amo.utils import chunked
 from olympia.devhub.tasks import (
     convert_purified, flag_binary, get_preview_sizes)
@@ -29,6 +30,9 @@ tasks = {
     'convert_purified': {'method': convert_purified, 'qs': []},
     'addon_review_aggregates': {'method': addon_review_aggregates, 'qs': []},
     'sign_addons': {'method': sign_addons, 'qs': []},
+    'update_current_version_for_unlisted': {
+        'method': update_current_version, 'qs': [Q(is_listed=False)]
+    },
 }
 
 

--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -374,3 +374,14 @@ def calc_checksum(theme_id, **kw):
         theme.save()
     except IOError as e:
         log.error(str(e))
+
+
+@task
+@write
+def update_current_version(ids, **kw):
+    log.info('[%s@%s] Updating current_version on addons starting w/ id: %s...'
+             % (len(ids), update_current_version.rate_limit, ids[0]))
+    addons = Addon.unfiltered.filter(pk__in=ids)
+
+    for addon in addons:
+        addon.update_version()

--- a/src/olympia/addons/tests/test_management_command.py
+++ b/src/olympia/addons/tests/test_management_command.py
@@ -1,8 +1,0 @@
-import pytest
-from django.core.management import call_command
-from django.core.management.base import CommandError
-
-
-def test_process_addons_invalid_task():
-    with pytest.raises(CommandError):
-        call_command('process_addons', task='foo')

--- a/src/olympia/devhub/templates/devhub/includes/addon_details.html
+++ b/src/olympia/devhub/templates/devhub/includes/addon_details.html
@@ -75,7 +75,7 @@
   {% if latest_unlisted_version %}
     <li>
       <strong>{{ _('Latest Version:') }}</strong>
-      {{ link_if_listed_else_text(version, version.version) }}
+      {{ link_if_listed_else_text(latest_unlisted_version, latest_unlisted_version.version) }}
     </li>
   {% endif %}
 {% endif %}

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -677,6 +677,7 @@ class TestVersion(TestCase):
 
         # Make one of the versions listed.
         v2.update(channel=amo.RELEASE_CHANNEL_LISTED)
+        v2.all_files[0].update(status=amo.STATUS_AWAITING_REVIEW)
         r = self.client.get(self.url)
         assert r.status_code == 200
         doc = pq(r.content)

--- a/src/olympia/users/tests/test_models.py
+++ b/src/olympia/users/tests/test_models.py
@@ -154,7 +154,7 @@ class TestUserProfile(TestCase):
         """
         addon = Addon.objects.get(id=3615)
         u = UserProfile.objects.get(pk=2519)
-        version = addon.find_latest_public_version()
+        version = addon.find_latest_public_listed_version()
         new_review = Review(version=version, user=u, rating=2, body='hello',
                             addon=addon)
         new_review.save()

--- a/src/olympia/versions/tests.py
+++ b/src/olympia/versions/tests.py
@@ -824,7 +824,7 @@ class TestDownloadsUnlistedAddons(TestDownloadsBase):
     def test_download_for_unlisted_addon_owner(self):
         """File downloading is allowed for addon owners."""
         self.assert_served_internally(self.client.get(self.file_url), False)
-        self.assert_served_internally(self.client.get(self.latest_url), False)
+        assert self.client.get(self.latest_url).status_code == 404
 
     @mock.patch.object(acl, 'check_addons_reviewer', lambda x: True)
     @mock.patch.object(acl, 'check_unlisted_addons_reviewer', lambda x: False)
@@ -842,7 +842,7 @@ class TestDownloadsUnlistedAddons(TestDownloadsBase):
     def test_download_for_unlisted_addon_unlisted_reviewer(self):
         """File downloading is allowed for unlisted reviewers."""
         self.assert_served_internally(self.client.get(self.file_url), False)
-        self.assert_served_internally(self.client.get(self.latest_url), False)
+        assert self.client.get(self.latest_url).status_code == 404
 
 
 class TestDownloads(TestDownloadsBase):

--- a/src/olympia/zadmin/tests/test_views.py
+++ b/src/olympia/zadmin/tests/test_views.py
@@ -119,7 +119,7 @@ class BulkValidationTest(TestCase):
         assert self.client.login(email='admin@mozilla.com')
         self.addon = Addon.objects.get(pk=3615)
         self.creator = UserProfile.objects.get(username='editor')
-        self.version = self.addon.find_latest_public_version()
+        self.version = self.addon.find_latest_public_listed_version()
         ApplicationsVersions.objects.filter(
             application=amo.FIREFOX.id, version=self.version).update(
             max=AppVersion.objects.get(application=1, version='3.7a1pre'))


### PR DESCRIPTION
Depends on #3995 being merged first.

This has the side-effect of breaking download_latest view for unlisted addons, since it relied on current_version. From this point forward this view will always return the latest *listed*
version (it's necessary to make a decision about its behavior anyway since we're mixing unlisted/listed versions, and this preserves backwards-compatibility for listed behavior).

Also add `process_addons --task=update_current_version_for_unlisted` command to reset the field on unlisted addons we have right now. Note that it needs to be run with `--with-unlisted`.