### PR TITLE
Discovery Pane Content Update November 2016.

### DIFF
--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -643,6 +643,7 @@ def addon_factory(
     popularity = kw.pop('popularity', None)
     persona_id = kw.pop('persona_id', None)
     tags = kw.pop('tags', [])
+    users = kw.pop('users', [])
     when = _get_created(kw.pop('created', None))
 
     # Keep as much unique data as possible in the uuid: '-' aren't important.
@@ -689,6 +690,9 @@ def addon_factory(
 
     for tag in tags:
         Tag(tag_text=tag).save_tag(addon)
+
+    for user in users:
+        addon.addonuser_set.create(user=user)
 
     # Put signals back.
     post_save.connect(addon_update_search_index, sender=Addon,

--- a/src/olympia/discovery/data.py
+++ b/src/olympia/discovery/data.py
@@ -5,20 +5,21 @@ from django.utils.translation import string_concat, ugettext_lazy as _
 class DiscoItem(object):
     def __init__(self, *args, **kwargs):
         self.addon_id = kwargs.get('addon_id')
+        self.addon_name = kwargs.get('addon_name')
         self.heading = kwargs.get('heading')
         self.description = kwargs.get('description')
 
 # At the moment the disco pane items are hardcoded in this file in the repos,
 # which allows us to integrate in our translation workflow easily.
 discopane_items = [
-    # Glitter Closeup
-    DiscoItem(addon_id=466579),
+    # Theme: Aurora Australis
+    DiscoItem(addon_id=49331),
 
     # uBlock Origin
     DiscoItem(
         addon_id=607454,
         heading=_(u'Block ads {start_sub_heading}with {addon_name}'
-                  '{end_sub_heading}'),
+                  u'{end_sub_heading}'),
         description=string_concat(
             '<blockquote>',
             _(u'A lightweight and effective ad blocker. uBlock Origin '
@@ -30,33 +31,32 @@ discopane_items = [
     DiscoItem(
         addon_id=287841,
         heading=_(u'Take screenshots {start_sub_heading}with {addon_name}'
-                  '{end_sub_heading}'),
+                  u'{end_sub_heading}'),
         description=string_concat(
             '<blockquote>',
             _(u'So much more than just a screenshot tool, this add-on also '
               u'lets you edit, annotate, and share images.'),
             '</blockquote>')),
 
-    # Metal Flowers - animated
-    DiscoItem(addon_id=188332),
+    # Theme: Snow Style
+    DiscoItem(addon_id=68349, addon_name=u'Snow Style'),
 
-    # Emoji Cheatsheet
+    # OmniSidebar
     DiscoItem(
-        addon_id=511962,
-        heading=_(u'Up your emoji game {start_sub_heading}with {addon_name}'
-                  '{end_sub_heading}'),
+        addon_id=296534,
+        heading=_(u'Easily access bookmarks {start_sub_heading}with '
+                  u'{addon_name}{end_sub_heading}'),
         description=string_concat(
             '<blockquote>',
-            _(u'Get instant access to a bunch of great emojis and easily use '
-              u'them on popular sites like Facebook, Twitter, Google+, and '
-              u'others.'),
+            _(u'Are you constantly scrolling through your bookmarks? '
+              u'Bring your lists into view with a single, simple gesture.'),
             '</blockquote>')),
 
     # Video DownloadHelper
     DiscoItem(
         addon_id=3006,
         heading=_(u'Download videos {start_sub_heading}with {addon_name}'
-                  '{end_sub_heading}'),
+                  u'{end_sub_heading}'),
         description=string_concat(
             '<blockquote>',
             _(u'Want an easy way to download videos to watch offline or save '
@@ -65,6 +65,6 @@ discopane_items = [
               u'and others.'),
             '</blockquote>')),
 
-    # Live with Music
-    DiscoItem(addon_id=23428),
+    # Theme: My Vinyl
+    DiscoItem(addon_id=125478),
 ]

--- a/src/olympia/discovery/serializers.py
+++ b/src/olympia/discovery/serializers.py
@@ -32,7 +32,7 @@ class DiscoverySerializer(serializers.Serializer):
         data = super(DiscoverySerializer, self).to_representation(instance)
         authors = u', '.join(
             author.name for author in instance.addon.listed_authors)
-        addon_name = unicode(instance.addon.name)
+        addon_name = unicode(instance.addon_name or instance.addon.name)
         url = absolutify(instance.addon.get_url_path())
 
         if data['heading'] is None:
@@ -43,6 +43,7 @@ class DiscoverySerializer(serializers.Serializer):
             # Note: target and rel attrs are added in addons-frontend.
             addon_link = u'<a href="{0}">{1} {2} {3}</a>'.format(
                 url, addon_name, _(u'by'), authors)
+
             data['heading'] = data['heading'].replace(
                 '{start_sub_heading}', '<span>').replace(
                 '{end_sub_heading}', '</span>').replace(


### PR DESCRIPTION
Fixes #3931

For QA (and review): I am working on a script that populates the appropriate data on dev and stage for testing but that needs a few more minutes / hours of fiddling around so in the mean-time the best thing to do is to verify the add-on ids in this pull request point to the correct add-ons and themes when called with `https://addons.mozilla.org/en-US/firefox/addon/<addon-id>/`