### PR TITLE
Stop setting _latest_version field, remove it from Addon model

### DIFF
--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -1820,7 +1820,7 @@ class TestBackupVersion(TestCase):
 
     def test_firefox_versions(self):
         self.setup_new_version()
-        assert self.addon.update_version()
+        self.addon.update_version()
         current = self.addon.current_version.compatible_apps[amo.FIREFOX]
         assert current.max.version == '4.0b8pre'
         assert current.min.version == '3.0.12'


### PR DESCRIPTION
Part of #3751

The column is kept for now because the migration is costly, but since it's NULLable it should not be a problem. Deleting the column is a follow-up task in the same issue.