### PR TITLE
Add license info to current_version (fix #3964)

### DIFF
--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -109,8 +109,8 @@ This endpoint allows you to fetch a specific add-on by id, slug or guid.
     :>json object compatibility: Object detailing the add-on :ref:`add-on application <addon-detail-application>` and version compatibility.
     :>json object compatibility[app_name].max: Maximum version of the corresponding app the add-on is compatible with.
     :>json object compatibility[app_name].min: Minimum version of the corresponding app the add-on is compatible with.
-    :>json object current_beta_version: Object holding the current beta :ref:`version <version-detail-object>` of the add-on, if it exists. For performance reasons the ``license`` and ``release_notes`` fields are omitted.
-    :>json object current_version: Object holding the current :ref:`version <version-detail-object>` of the add-on. For performance reasons the ``license`` and ``release_notes`` fields are omitted.
+    :>json object current_beta_version: Object holding the current beta :ref:`version <version-detail-object>` of the add-on, if it exists. For performance reasons the ``release_notes`` field is omitted and the ``license`` field omits the ``text`` property.
+    :>json object current_version: Object holding the current :ref:`version <version-detail-object>` of the add-on. For performance reasons the ``release_notes`` field is omitted and the ``license`` field omits the ``text`` property.
     :>json string default_locale: The add-on default locale for translations.
     :>json string|object|null description: The add-on description (See :ref:`translated fields <api-overview-translations>`).
     :>json string edit_url: The URL to the developer edit page for the add-on.

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -84,19 +84,26 @@ class LicenseSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = License
-        fields = ('name', 'text', 'url')
+        fields = ('id', 'name', 'text', 'url')
+
+
+class CompactLicenseSerializer(LicenseSerializer):
+    class Meta:
+        model = License
+        fields = ('id', 'name', 'url')
 
 
 class SimpleVersionSerializer(serializers.ModelSerializer):
     compatibility = serializers.SerializerMethodField()
     edit_url = serializers.SerializerMethodField()
     files = FileSerializer(source='all_files', many=True)
+    license = CompactLicenseSerializer()
     url = serializers.SerializerMethodField()
 
     class Meta:
         model = Version
-        fields = ('id', 'compatibility', 'edit_url', 'files', 'reviewed',
-                  'url', 'version')
+        fields = ('id', 'license', 'compatibility', 'edit_url', 'files',
+                  'reviewed', 'url', 'version')
 
     def get_url(self, obj):
         return absolutify(obj.get_url_path())


### PR DESCRIPTION
I couldn't find what tests, if any, need adding but this added the license info I need to fix #3964.

I don't want to be a pain but a quick glance seemed this would be easier than merging my huge addons-frontend patch, so if this looks okay or you can quickly tell me what I need to do to get this r+ let me know 😄 

If it's getting it your way and no one has time right now that's totally cool–just let me know and I'll leave this alone and land my add-ons frontend patch without this. cheers!