### PR TITLE
Remove has_version in ES mapping, use current_version existence

### DIFF
--- a/src/olympia/addons/indexers.py
+++ b/src/olympia/addons/indexers.py
@@ -73,7 +73,6 @@ class AddonIndexer(BaseSearchIndexer):
                     'has_eula': {'type': 'boolean', 'index': 'no'},
                     'has_privacy_policy': {'type': 'boolean', 'index': 'no'},
                     'has_theme_rereview': {'type': 'boolean'},
-                    'has_version': {'type': 'boolean'},
                     'hotness': {'type': 'double'},
                     'icon_type': {'type': 'string', 'index': 'no'},
                     'is_disabled': {'type': 'boolean'},
@@ -229,14 +228,11 @@ class AddonIndexer(BaseSearchIndexer):
         # We can use all_categories because the indexing code goes through the
         # transformer that sets it.
         data['category'] = [cat.id for cat in obj.all_categories]
+        data['current_version'] = cls.extract_version(
+            obj, obj.current_version)
         if obj.current_version:
-            data['current_version'] = cls.extract_version(
-                obj, obj.current_version)
-            data['has_version'] = True
             data['platforms'] = [p.id for p in
                                  obj.current_version.supported_platforms]
-        else:
-            data['has_version'] = None
         data['current_beta_version'] = cls.extract_version(
             obj, obj.current_beta_version)
         data['listed_authors'] = [

--- a/src/olympia/addons/tests/test_indexers.py
+++ b/src/olympia/addons/tests/test_indexers.py
@@ -48,7 +48,9 @@ class TestAddonIndexer(TestCase):
         complex_fields = [
             'app', 'boost', 'category', 'current_beta_version',
             'current_version', 'description', 'has_eula', 'has_privacy_policy',
-            'has_theme_rereview', 'has_version', 'latest_unlisted_version',
+            'has_theme_rereview', 'latest_unlisted_version', 'listed_authors',
+            'name', 'name_sort', 'platforms', 'previews', 'public_stats',
+            'ratings', 'summary', 'tags', 'has_theme_rereview',
             'listed_authors', 'name', 'name_sort', 'platforms', 'previews',
             'public_stats', 'ratings', 'summary', 'tags',
         ]
@@ -166,6 +168,12 @@ class TestAddonIndexer(TestCase):
         assert extracted['has_eula'] is False
         assert extracted['has_privacy_policy'] is False
 
+    def test_extract_no_current_version(self):
+        self.addon.current_version.delete()
+        extracted = self._extract()
+
+        assert extracted['current_version'] is None
+
     def test_extract_version_and_files(self):
         version = self.addon.current_version
         file_factory(version=version, platform=PLATFORM_MAC.id)
@@ -201,7 +209,6 @@ class TestAddonIndexer(TestCase):
             assert extracted_file['size'] == file_.size
             assert extracted_file['status'] == file_.status
 
-        assert extracted['has_version']
         assert set(extracted['platforms']) == set([PLATFORM_MAC.id,
                                                    PLATFORM_ALL.id])
         version = current_beta_version

--- a/src/olympia/amo/search.py
+++ b/src/olympia/amo/search.py
@@ -191,7 +191,12 @@ class ES(object):
             key, field_action = self._split(key)
             if field_action is None:
                 rv.append({'term': {key: val}})
-            if field_action == 'in':
+            elif field_action == 'exists':
+                if val is not True:
+                    raise NotImplementedError(
+                        '<field>__exists only works with a "True" value.')
+                rv.append({'exists': {'field': key}})
+            elif field_action == 'in':
                 rv.append({'in': {key: val}})
             elif field_action in ('gt', 'gte', 'lt', 'lte'):
                 rv.append({'range': {key: {field_action: val}}})

--- a/src/olympia/legacy_api/views.py
+++ b/src/olympia/legacy_api/views.py
@@ -349,7 +349,7 @@ class SearchView(APIView):
             'is_listed': True,
             'is_experimental': False,
             'is_disabled': False,
-            'has_version': True,
+            'current_version__exists': True,
         }
 
         # Opts may get overridden by query string filters.

--- a/src/olympia/search/filters.py
+++ b/src/olympia/search/filters.py
@@ -295,7 +295,7 @@ class ReviewedContentFilter(BaseFilterBackend):
     def filter_queryset(self, request, qs, view):
         return qs.filter(
             Bool(must=[F('terms', status=amo.REVIEWED_STATUSES),
-                       F('term', has_version=True)],
+                       F('exists', field='current_version')],
                  must_not=[F('term', is_deleted=True),
                            F('term', is_listed=False),
                            F('term', is_disabled=True)]))

--- a/src/olympia/search/tests/test_filters.py
+++ b/src/olympia/search/tests/test_filters.py
@@ -103,7 +103,7 @@ class TestReviewedContentFilter(FilterTestsBase):
         must_not = qs['query']['filtered']['filter']['bool']['must_not']
 
         assert {'terms': {'status': amo.REVIEWED_STATUSES}} in must
-        assert {'term': {'has_version': True}} in must
+        assert {'exists': {'field': 'current_version'}} in must
         assert {'term': {'is_disabled': True}} in must_not
         assert {'term': {'is_deleted': True}} in must_not
         assert {'term': {'is_listed': False}} in must_not


### PR DESCRIPTION
`current_version` is an object, and in it, `id` is indexed, so we can use an exists filter.

Using that everywhere we want public add-ons should be enough to remove the `is_listed` property in search-related code.

Fix #3969