### PR TITLE
Show reviewer events only in review log

### DIFF
--- a/src/olympia/amo/log.py
+++ b/src/olympia/amo/log.py
@@ -238,6 +238,7 @@ class REQUEST_SUPER_REVIEW(_LOG):
                  u'in our review queue, but it will need to be checked by one '
                  u'of our admin reviewers. The review might take longer than '
                  u'usual.')
+    editor_review_action = True
 
 
 class COMMENT_VERSION(_LOG):

--- a/src/olympia/devhub/models.py
+++ b/src/olympia/devhub/models.py
@@ -154,6 +154,11 @@ class ActivityLogManager(ManagerBase):
         return (qs.filter(action__in=amo.LOG_REVIEW_QUEUE)
                   .exclude(user__id=settings.TASK_USER_ID))
 
+    def review_log(self):
+        qs = self._by_type()
+        return (qs.filter(action__in=amo.LOG_EDITOR_REVIEW_ACTION)
+                  .exclude(user__id=settings.TASK_USER_ID))
+
     def beta_signed_events(self):
         """List of all the auto signatures of beta files."""
         return self.filter(action__in=[

--- a/src/olympia/editors/views.py
+++ b/src/olympia/editors/views.py
@@ -777,7 +777,7 @@ def reviewlog(request):
 
     form = forms.ReviewLogForm(data)
 
-    approvals = ActivityLog.objects.review_queue()
+    approvals = ActivityLog.objects.review_log()
     if not acl.check_unlisted_addons_reviewer(request):
         # Display logs related to unlisted versions only to senior reviewers.
         list_channel = amo.RELEASE_CHANNEL_LISTED


### PR DESCRIPTION
Fix https://github.com/mozilla/addons/issues/287