### PR TITLE
Display file sizes using binary prefixes

### DIFF
--- a/src/olympia/browse/templates/browse/language_tools.html
+++ b/src/olympia/browse/templates/browse/language_tools.html
@@ -17,7 +17,7 @@
   {% for addon in addons %}
   <p>
     <a href="{{ url('addons.detail', addon.slug) }}">{{ text }}</a>
-    ({{ addon.file_size|filesizeformat }})
+    ({{ addon.file_size|filesizeformat(binary=True) }})
     {% if addon.locale_disambiguation %}
       <br>({{ addon.locale_disambiguation }})
     {% endif %}

--- a/src/olympia/browse/tests.py
+++ b/src/olympia/browse/tests.py
@@ -258,6 +258,10 @@ class TestLanguageTools(TestCase):
         self._get()
         assert self.all_locales_addons == []
 
+    def test_file_sizes_use_binary_prefixes(self):
+        response = self.client.get(self.url, follow=True)
+        assert '223.0 KiB' in response.content
+
 
 class TestThemes(TestCase):
     fixtures = ('base/category', 'base/addon_6704_grapple', 'base/addon_3615')

--- a/src/olympia/devhub/templates/devhub/includes/version_file.html
+++ b/src/olympia/devhub/templates/devhub/includes/version_file.html
@@ -4,7 +4,7 @@
       <a href="{{ file.get_url_path('devhub') }}">
         {{ file.pretty_filename() }}</a>
     </td>
-    <td>{{ file.size|filesizeformat }}</td>
+    <td>{{ file.size|filesizeformat(binary=True) }}</td>
     <td>{{ form.platform }}</td>
     <td>{{ choices[file.status] }}</td>
     <td>

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -1951,6 +1951,11 @@ class TestVersionAddFile(UploadTest):
         assert new_file != existing_file
         assert mock_sign_file.called
 
+    def test_file_Size_uses_binary_prefix(self):
+        response = self.client.get(self.edit_url)
+        table = pq(response.content)('#file-list')
+        assert '379.0 KiB' in table.find('td').eq(1).text()
+
 
 class TestUploadErrors(UploadTest):
     fixtures = ['base/users', 'base/addon_3615']

--- a/src/olympia/files/templates/files/file.html
+++ b/src/olympia/files/templates/files/file.html
@@ -1,7 +1,7 @@
 <p>
     <a href="{{ selected['url_serve'] }}">{{ _('Download {0}').format(selected['filename']) }}</a><br/>
     {% if selected['msg'] %}<b class="error">{{ selected['msg'] }}</b><br/>{% endif %}
-    {% trans version=selected['version'], size=selected['size']|filesizeformat,
+    {% trans version=selected['version'], size=selected['size']|filesizeformat(binary=True),
              md5=selected['md5'], mimetype=selected['mimetype'] %}
         Version: {{ version }} &bull;
         Size: {{ size }} &bull;

--- a/src/olympia/files/tests/test_views.py
+++ b/src/olympia/files/tests/test_views.py
@@ -473,6 +473,11 @@ class TestFileViewer(FilesBase, TestCase):
         self.file.version.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
         assert self.client.get(self.file_url()).status_code == 404
 
+    def test_content_file_size_uses_binary_prefix(self):
+        self.file_viewer.extract()
+        response = self.client.get(self.file_url('dictionaries/license.txt'))
+        assert '17.6 KiB' in response.content
+
 
 class TestDiffViewer(FilesBase, TestCase):
     fixtures = ['base/addon_3615', 'base/users']

--- a/src/olympia/versions/templates/versions/version.html
+++ b/src/olympia/versions/templates/versions/version.html
@@ -11,7 +11,7 @@
         </time>
         {% if version.has_files %}
           <span class="filesize">
-            {{ version.all_files[0].size|filesizeformat }}
+            {{ version.all_files[0].size|filesizeformat(binary=True) }}
           </span>
         {% endif %}
       </span>

--- a/src/olympia/versions/tests.py
+++ b/src/olympia/versions/tests.py
@@ -676,6 +676,11 @@ class TestViews(TestCase):
             reverse('addons.versions', args=[self.addon.slug, version_number]))
         assert response.status_code == 404
 
+    def test_version_list_file_size_uses_binary_prefix(self):
+        url = reverse('addons.versions', args=[self.addon.slug])
+        response = self.client.get(url)
+        assert '1.0 KiB' in response.content
+
 
 class TestFeeds(TestCase):
     fixtures = ['addons/eula+contrib-addon', 'addons/default-to-compat']

--- a/src/olympia/zadmin/templates/zadmin/hera.html
+++ b/src/olympia/zadmin/templates/zadmin/hera.html
@@ -47,7 +47,7 @@
           {% set hit_percentage = 0 %}
         {% endif %}
         <ul>
-          <li>Using {{ i.stats.bytes_used|filesizeformat }} ({{ i.stats.percent_used }}% of total space) for {{ i.stats.entries|numberfmt }} objects.</li>
+          <li>Using {{ i.stats.bytes_used|filesizeformat(binary=True) }} ({{ i.stats.percent_used }}% of total space) for {{ i.stats.entries|numberfmt }} objects.</li>
           <li>We've had {{ i.stats.num_hits|numberfmt }} hits out of {{ i.stats.num_lookups|numberfmt }} lookups ({{ hit_percentage|round(2) }}%).</li>
         </ul>
       {% else %}


### PR DESCRIPTION
Fixes [#1962](https://github.com/mozilla/addons-server/issues/1962)