### PR TITLE
Adjust API permission classes to make them work without Addon.is_listed

### DIFF
--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -1901,6 +1901,47 @@ class TestVersionViewSetDetail(AddonAndVersionViewSetDetailMixin, TestCase):
         response = self.client.get(self.url)
         assert response.status_code == 404
 
+    def test_unlisted_version_reviewer(self):
+        user = UserProfile.objects.create(username='reviewer')
+        self.grant_permission(user, 'Addons:Review')
+        self.client.login_api(user)
+        self.version.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        response = self.client.get(self.url)
+        assert response.status_code == 403
+
+    def test_unlisted_version_unlisted_reviewer(self):
+        user = UserProfile.objects.create(username='reviewer')
+        self.grant_permission(user, 'Addons:ReviewUnlisted')
+        self.client.login_api(user)
+        self.version.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        self._test_url()
+
+    def test_unlisted_version_author(self):
+        user = UserProfile.objects.create(username='author')
+        AddonUser.objects.create(user=user, addon=self.addon)
+        self.client.login_api(user)
+        self.version.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        self._test_url()
+
+    def test_unlisted_version_admin(self):
+        user = UserProfile.objects.create(username='admin')
+        self.grant_permission(user, '*:*')
+        self.client.login_api(user)
+        self.version.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        self._test_url()
+
+    def test_unlisted_version_anonymous(self):
+        self.version.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        response = self.client.get(self.url)
+        assert response.status_code == 401
+
+    def test_unlisted_version_user_but_not_author(self):
+        user = UserProfile.objects.create(username='simpleuser')
+        self.client.login_api(user)
+        self.version.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        response = self.client.get(self.url)
+        assert response.status_code == 403
+
 
 class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
     client_class = APITestClient
@@ -1910,11 +1951,20 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
         self.addon = addon_factory(
             guid=generate_addon_guid(), name=u'My Addôn', slug='my-addon')
         self.old_version = self.addon.current_version
-        self.old_version.update(created=self.days_ago(1))
+        self.old_version.update(created=self.days_ago(2))
 
         # Don't use addon.current_version, changing its state as we do in
         # the tests might render the add-on itself inaccessible.
         self.version = version_factory(addon=self.addon, version='1.0.1')
+        self.version.update(created=self.days_ago(1))
+
+        # This version is unlisted and should be hidden by default, only
+        # shown when requesting to see unlisted stuff explicitly, with the
+        # right permissions.
+        self.unlisted_version = version_factory(
+            addon=self.addon, version='42.0',
+            channel=amo.RELEASE_CHANNEL_UNLISTED)
+
         self._set_tested_url(self.addon.pk)
 
     def _test_url(self, **kwargs):
@@ -1927,6 +1977,22 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
         assert result_version['id'] == self.version.pk
         assert result_version['version'] == self.version.version
         result_version = result['results'][1]
+        assert result_version['id'] == self.old_version.pk
+        assert result_version['version'] == self.old_version.version
+
+    def _test_url_contains_all(self, **kwargs):
+        response = self.client.get(self.url, data=kwargs)
+        assert response.status_code == 200
+        result = json.loads(response.content)
+        assert result['results']
+        assert len(result['results']) == 3
+        result_version = result['results'][0]
+        assert result_version['id'] == self.unlisted_version.pk
+        assert result_version['version'] == self.unlisted_version.version
+        result_version = result['results'][1]
+        assert result_version['id'] == self.version.pk
+        assert result_version['version'] == self.version.version
+        result_version = result['results'][2]
         assert result_version['id'] == self.old_version.pk
         assert result_version['version'] == self.old_version.version
 
@@ -2005,6 +2071,9 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
         response = self.client.get(
             self.url, data={'filter': 'all_with_deleted'})
         assert response.status_code == 403
+        response = self.client.get(
+            self.url, data={'filter': 'all_with_unlisted'})
+        assert response.status_code == 403
 
     def test_deleted_version_author(self):
         user = UserProfile.objects.create(username='author')
@@ -2025,18 +2094,44 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
         self._test_url_only_contains_old_version()
         self._test_url_only_contains_old_version(filter='all_without_unlisted')
 
-        # An admin can see deleted versions when explicitly asking for them.
-        self._test_url(filter='all_with_deleted')
+        # An admin can see deleted versions when explicitly asking
+        # for them.
+        self._test_url_contains_all(filter='all_with_deleted')
+
+    def test_all_with_unlisted_admin(self):
+        user = UserProfile.objects.create(username='admin')
+        self.grant_permission(user, '*:*')
+        self.client.login_api(user)
+        self._test_url_contains_all(filter='all_with_unlisted')
+
+    def test_with_unlisted_unlisted_reviewer(self):
+        user = UserProfile.objects.create(username='reviewer')
+        self.grant_permission(user, 'Addons:ReviewUnlisted')
+        self.client.login_api(user)
+
+        self._test_url_contains_all(filter='all_with_unlisted')
+
+    def test_with_unlisted_author(self):
+        user = UserProfile.objects.create(username='author')
+        AddonUser.objects.create(user=user, addon=self.addon)
+        self.client.login_api(user)
+
+        self._test_url_contains_all(filter='all_with_unlisted')
 
     def test_deleted_version_anonymous(self):
         self.version.delete()
         self._test_url_only_contains_old_version()
 
         response = self.client.get(
+            self.url, data={'filter': 'all_with_deleted'})
+        assert response.status_code == 401
+
+    def test_all_without_and_with_unlisted_anonymous(self):
+        response = self.client.get(
             self.url, data={'filter': 'all_without_unlisted'})
         assert response.status_code == 401
         response = self.client.get(
-            self.url, data={'filter': 'all_with_deleted'})
+            self.url, data={'filter': 'all_with_unlisted'})
         assert response.status_code == 401
 
     def test_deleted_version_user_but_not_author(self):
@@ -2044,11 +2139,20 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
         self.client.login_api(user)
         self.version.delete()
         self._test_url_only_contains_old_version()
+
+        response = self.client.get(
+            self.url, data={'filter': 'all_with_deleted'})
+        assert response.status_code == 403
+
+    def test_all_without_and_with_unlisted_user_but_not_author(self):
+        user = UserProfile.objects.create(username='simpleuser')
+        self.client.login_api(user)
+        self.version.delete()
         response = self.client.get(
             self.url, data={'filter': 'all_without_unlisted'})
         assert response.status_code == 403
         response = self.client.get(
-            self.url, data={'filter': 'all_with_deleted'})
+            self.url, data={'filter': 'all_with_unlisted'})
         assert response.status_code == 403
 
     def test_beta_version(self):

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -48,9 +48,8 @@ from olympia.constants.categories import CATEGORIES_BY_ID
 from olympia import paypal
 from olympia.api.paginator import ESPageNumberPagination
 from olympia.api.permissions import (
-    AllowAddonAuthor, AllowReadOnlyIfReviewedAndListed,
-    AllowRelatedObjectPermissions, AllowReviewer, AllowReviewerUnlisted, AnyOf,
-    GroupPermission)
+    AllowAddonAuthor, AllowReadOnlyIfReviewed, AllowRelatedObjectPermissions,
+    AllowReviewer, AllowReviewerUnlisted, AnyOf, GroupPermission)
 from olympia.reviews.forms import ReviewForm
 from olympia.reviews.models import Review, GroupedRating
 from olympia.search.filters import (
@@ -613,7 +612,7 @@ def icloud_bookmarks_redirect(request):
 
 class AddonViewSet(RetrieveModelMixin, GenericViewSet):
     permission_classes = [
-        AnyOf(AllowReadOnlyIfReviewedAndListed, AllowAddonAuthor,
+        AnyOf(AllowReadOnlyIfReviewed, AllowAddonAuthor,
               AllowReviewer, AllowReviewerUnlisted),
     ]
     serializer_class = AddonSerializer

--- a/src/olympia/migrations/912-set-unlisted-addons-status-to-null.sql
+++ b/src/olympia/migrations/912-set-unlisted-addons-status-to-null.sql
@@ -1,0 +1,1 @@
+UPDATE addons SET status=0 WHERE is_listed=false AND status=4

--- a/src/olympia/reviews/tests/test_views.py
+++ b/src/olympia/reviews/tests/test_views.py
@@ -1749,6 +1749,7 @@ class TestReviewViewSetFlag(TestCase):
         assert self.review.reload().editorreview is True
 
     def test_flag_logged_in_addon_denied(self):
+        self.addon.current_version.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
         self.addon.update(is_listed=False)
         self.user = user_factory()
         self.client.login_api(self.user)

--- a/src/olympia/reviews/views.py
+++ b/src/olympia/reviews/views.py
@@ -29,7 +29,7 @@ from olympia.addons.decorators import addon_view_factory
 from olympia.addons.models import Addon
 from olympia.addons.views import AddonChildMixin
 from olympia.api.permissions import (
-    AllowAddonAuthor, AllowIfReviewedAndListed, AllowOwner,
+    AllowAddonAuthor, AllowIfReviewed, AllowOwner,
     AllowRelatedObjectPermissions, AnyOf, ByHttpMethod, GroupPermission)
 
 from .helpers import user_can_delete_review
@@ -332,7 +332,7 @@ class ReviewViewSet(AddonChildMixin, ModelViewSet):
         # default from AddonViewSet is too restrictive, we are not modifying
         # the add-on itself so we don't need all the permission checks it does.
         return super(ReviewViewSet, self).get_addon_object(
-            permission_classes=[AllowIfReviewedAndListed])
+            permission_classes=[AllowIfReviewed])
 
     def check_permissions(self, request):
         if 'addon_pk' in self.kwargs:


### PR DESCRIPTION
Includes a migration to set the status of unlisted add-ons to `STATUS_NULL`, because `AllowReadOnlyIfReviewedAndListed` becomes `AllowReadOnlyIfReviewed` and no longer checks `Addon.is_listed`, so the migration is necessary to make sure those unlisted add-ons don't suddenly become publicly viewable.

Also includes a refactor of the permission tests to make them avoid fixtures, ensuring that the right permission rules are used.

Fix #4043