### PR TITLE
remove obsolete is_listed mentions from devhub

### DIFF
--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -11,7 +11,6 @@ from django.core.files.storage import default_storage as storage
 from django.db import IntegrityError
 from django.utils import translation
 
-import jingo
 from mock import Mock, patch
 
 from olympia import amo
@@ -1759,22 +1758,6 @@ class TestAddonGetURLPath(TestCase):
     def test_unlisted_addon_get_url_path(self):
         addon = Addon(slug='woo', is_listed=False)
         assert addon.get_url_path() == ''
-
-    @patch.object(Addon, 'get_url_path', lambda self: '<script>xss</script>')
-    def test_link_if_listed_else_text_xss(self):
-        """We're playing extra safe here by making sure the data is escaped at
-        the template level.
-
-        We shouldn't have to worry about it though, because the "reverse" will
-        prevent it.
-        """
-        addon = Addon(slug='woo')
-        tpl = jingo.get_env().from_string(
-            '{% from "devhub/includes/macros.html" '
-            'import link_if_listed_else_text %}'
-            '{{ link_if_listed_else_text(addon, "foo") }}')
-        result = tpl.render({'addon': addon}).strip()
-        assert result == '<a href="&lt;script&gt;xss&lt;/script&gt;">foo</a>'
 
 
 class TestAddonModelsFeatured(TestCase):

--- a/src/olympia/devhub/templates/devhub/addons/edit/basic.html
+++ b/src/olympia/devhub/templates/devhub/addons/edit/basic.html
@@ -40,7 +40,7 @@
                 {{ form.slug.errors }}
               {% else %}
                 {{ settings.SITE_URL }}/&hellip;/{{ addon.slug }}
-                {% if addon.is_listed %}<a href="{{ addon.get_url_path() }}">{{ _('View Listing') }}</a>{% endif %}
+                {% if addon.has_listed_versions() %}<a href="{{ addon.get_url_path() }}">{{ _('View Listing') }}</a>{% endif %}
               {% endif %}
             </td>
           </tr>

--- a/src/olympia/devhub/templates/devhub/includes/macros.html
+++ b/src/olympia/devhub/templates/devhub/includes/macros.html
@@ -76,11 +76,3 @@
     {{ form.categories.errors }}
   </div>
 {% endmacro %}
-
-{% macro link_if_listed_else_text(addon_or_version, text) %}
-  {% if addon_or_version.is_listed %}
-    <a href="{{ addon_or_version.get_url_path() }}">{{ text }}</a>
-  {% else %}
-    {{ text }}
-  {% endif %}
-{% endmacro %}

--- a/src/olympia/devhub/templates/devhub/index-legacy.html
+++ b/src/olympia/devhub/templates/devhub/index-legacy.html
@@ -1,5 +1,4 @@
 {% extends "devhub/base_impala.html" %}
-{% from "devhub/includes/macros.html" import link_if_listed_else_text %}
 
 {% macro docs_ul(docs) %}
   <ul class="listing-list">
@@ -86,23 +85,16 @@
                       <strong>{{ _('Status:') }}</strong>
                       <span class="{{ status_class(item.addon) }}"><b>{{ item.addon.STATUS_CHOICES[item.addon.status] }}</b></span>
                     </p>
-                    <p>
-                      <strong>{{ _('Visibility:') }}</strong>
-                      {% if not item.addon.is_disabled and item.addon.is_listed %}
-                        {{ _('Listed') }}
-                      {% elif item.addon.is_disabled and item.addon.is_listed %}
-                        {{ _('Hidden') }}
-                      {% elif not item.addon.is_listed %}
-                        {{ _('Unlisted') }}
-                      {% endif %}
-                    </p>
                     {# Find the most appropriate version to show: either the current (listed) version, or the latest unlisted #}
                     {% set version = item.addon.current_version or item.addon.find_latest_version(channel=amo.RELEASE_CHANNEL_UNLISTED) %}
                     {% if version %}
                       <p>
                         <strong>{{ _('Latest Version:') }}</strong>
-                        {{ link_if_listed_else_text(item.addon.current_version,
-                                         item.addon.current_version.version) }}
+                        {% if version.channel == amo.RELEASE_CHANNEL_LISTED %}
+                            <a href="{{ version.get_url_path() }}">{{ version.version }}</a>
+                        {% else %}
+                            {{ version.version }}
+                        {% endif %}
                       </p>
                       {% if version.channel == amo.RELEASE_CHANNEL_LISTED %}
                         {% with position = item.position %}

--- a/src/olympia/devhub/templates/devhub/payments/payments.html
+++ b/src/olympia/devhub/templates/devhub/payments/payments.html
@@ -41,10 +41,10 @@
         <li>{{ _('Choose when and how users are asked to contribute') }}</li>
         <li>{{ _('Receive contributions in your PayPal account or send them to an organization of your choice') }}</li>
       </ul>
-      {% if not addon.is_listed %}
+      {% if not addon.has_listed_versions() %}
         <p class="error">
         {% trans %}
-          Contributions are only available for listed add-ons.
+          Contributions are only available for add-ons with listed versions.
         {% endtrans %}
         </p>
       {% else %}

--- a/src/olympia/devhub/tests/test_feeds.py
+++ b/src/olympia/devhub/tests/test_feeds.py
@@ -204,6 +204,7 @@ class TestActivity(HubTest):
     def test_rss_unlisted_addon(self):
         """Unlisted addon logs appear in the rss feed."""
         self.addon.update(is_listed=False)
+        self.addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
         self.log_creates(5)
 
         # This will give us a new RssKey
@@ -231,6 +232,7 @@ class TestActivity(HubTest):
         self.addon.name = ("<script>alert('Buy more Diet Mountain Dew.')"
                            '</script>')
         self.addon.is_listed = False
+        self.addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
         self.addon.save()
         self.log_creates(1)
         doc = self.get_pq()
@@ -247,6 +249,7 @@ class TestActivity(HubTest):
 
     def test_xss_collections_unlisted_addon(self):
         self.addon.update(is_listed=False)
+        self.addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
         self.log_collection(1, "<script>alert('v1@gra for u')</script>")
         doc = self.get_pq()
         assert len(doc('.item')) == 1
@@ -262,6 +265,7 @@ class TestActivity(HubTest):
 
     def test_xss_tags_unlisted_addon(self):
         self.addon.update(is_listed=False)
+        self.addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
         self.log_tag(1, "<script src='x.js'>")
         doc = self.get_pq()
         assert len(doc('.item')) == 1
@@ -277,6 +281,7 @@ class TestActivity(HubTest):
 
     def test_xss_versions_unlisted_addon(self):
         self.addon.update(is_listed=False)
+        self.addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
         self.log_updates(1, "<script src='x.js'>")
         doc = self.get_pq()
         assert len(doc('.item')) == 2

--- a/src/olympia/devhub/tests/test_models.py
+++ b/src/olympia/devhub/tests/test_models.py
@@ -81,6 +81,7 @@ class TestActivityLog(TestCase):
         # Get the url before the addon is changed to unlisted.
         url_path = addon.get_url_path()
         addon.update(is_listed=False)
+        addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
         amo.log(amo.LOG.CREATE_ADDON, (Addon, addon.id))
         entries = ActivityLog.objects.for_addons(addon)
         assert len(entries) == 1


### PR DESCRIPTION
part of #3977 - removes references to `Addon.is_listed` from /devhub, apart from old version/file upload methods which will be removed once the new flows are live on prod.

Some further clean up of the `listed` parameters passed to many methods would be good to stop the messy conversions between listed and channel but it's not a blocker.