### PR TITLE
Fix busted migration

### DIFF
--- a/src/olympia/migrations/912-set-unlisted-addons-status-to-null.sql
+++ b/src/olympia/migrations/912-set-unlisted-addons-status-to-null.sql
@@ -1,1 +1,1 @@
-UPDATE addons SET status=0 WHERE is_listed=false AND status=4
+UPDATE addons SET status=0 WHERE is_listed=false AND status=4;


### PR DESCRIPTION
This fixes the following error during `make update_docker`:

```
Running SQL migration 912:
UPDATE addons SET status=0 WHERE is_listed=false AND status=4

Error: Had trouble running this: BEGIN;
UPDATE addons SET status=0 WHERE is_listed=false AND status=4

UPDATE schema_version SET version = 912;
COMMIT;
stdout:
stderr: ERROR 1064 (42000) at line 2: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'UPDATE schema_version SET version = 912' at line 3
```