### PR TITLE
Remove unused addon_total_contributions cron

### DIFF
--- a/src/olympia/stats/cron.py
+++ b/src/olympia/stats/cron.py
@@ -9,7 +9,6 @@ import waffle
 from celery.task.sets import TaskSet
 
 from olympia.amo.utils import chunked
-from olympia.addons.models import Addon
 from .models import (
     AddonCollectionCount, CollectionCount, UpdateCount)
 from . import tasks
@@ -76,14 +75,6 @@ def update_google_analytics(date=None):
         # Assume that we want to populate yesterday's stats by default.
         date = datetime.date.today() - datetime.timedelta(days=1)
     tasks.update_google_analytics.delay(date=date)
-
-
-@cronjobs.register
-def addon_total_contributions():
-    addons = Addon.objects.values_list('id', flat=True)
-    ts = [tasks.addon_total_contributions.subtask(args=chunk)
-          for chunk in chunked(addons, 100)]
-    TaskSet(ts).apply_async()
 
 
 @cronjobs.register

--- a/src/olympia/stats/tests/test_cron.py
+++ b/src/olympia/stats/tests/test_cron.py
@@ -7,12 +7,11 @@ import mock
 
 from olympia import amo
 from olympia.amo.tests import TestCase
-from olympia.addons.models import Addon
 from olympia.bandwagon.models import Collection, CollectionAddon
 from olympia.stats import cron, tasks
 from olympia.stats.models import (
-    AddonCollectionCount, Contribution, DownloadCount, GlobalStat,
-    ThemeUserCount, UpdateCount)
+    AddonCollectionCount, DownloadCount, GlobalStat, ThemeUserCount,
+    UpdateCount)
 
 
 class TestGlobalStats(TestCase):
@@ -56,30 +55,6 @@ class TestGoogleAnalytics(TestCase):
         cron.update_google_analytics(d)
         assert GlobalStat.objects.get(
             name='webtrends_DailyVisitors', date=d).count == 49
-
-
-class TestTotalContributions(TestCase):
-    fixtures = ['base/appversion', 'base/users', 'base/addon_3615']
-
-    def test_total_contributions(self):
-
-        c = Contribution()
-        c.addon_id = 3615
-        c.amount = '9.99'
-        c.save()
-
-        tasks.addon_total_contributions(3615)
-        a = Addon.objects.no_cache().get(pk=3615)
-        assert float(a.total_contributions) == 9.99
-
-        c = Contribution()
-        c.addon_id = 3615
-        c.amount = '10.00'
-        c.save()
-
-        tasks.addon_total_contributions(3615)
-        a = Addon.objects.no_cache().get(pk=3615)
-        assert float(a.total_contributions) == 19.99
 
 
 @mock.patch('olympia.stats.management.commands.index_stats.create_subtasks')


### PR DESCRIPTION
Part of #4028

The *task* is useful and still used, but the *cron* appears to be dead code (which is a good thing, since it loads all the add-ons from the database).