### PR TITLE
Improve bulk validation results and handling.

### DIFF
--- a/src/olympia/zadmin/models.py
+++ b/src/olympia/zadmin/models.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 import json
+import hashlib
 
 import caching
 
@@ -149,8 +150,13 @@ class ValidationResult(ModelBase):
         self.notices = results['notices'] + compat['notices']
         self.valid = self.errors == 0
 
+        generated = 'testcases_regex.generic._generated'
+
         messages = results['messages']
-        message_ids = ['.'.join(msg['id']) for msg in messages]
+        message_ids = [(msg, '.'.join(msg['id'])) for msg in messages]
+        message_ids = [
+                hashlib.md5(msg['message']).hexdigest() if msg_id == generated
+                else msg_id for msg, msg_id in message_ids]
 
         message_summary = {}
 

--- a/src/olympia/zadmin/models.py
+++ b/src/olympia/zadmin/models.py
@@ -155,8 +155,8 @@ class ValidationResult(ModelBase):
         messages = results['messages']
         message_ids = [(msg, '.'.join(msg['id'])) for msg in messages]
         message_ids = [
-                hashlib.md5(msg['message']).hexdigest() if msg_id == generated
-                else msg_id for msg, msg_id in message_ids]
+            hashlib.md5(msg['message']).hexdigest() if msg_id == generated
+            else msg_id for msg, msg_id in message_ids]
 
         message_summary = {}
 

--- a/src/olympia/zadmin/tests/resources/compatibility_validation.json
+++ b/src/olympia/zadmin/tests/resources/compatibility_validation.json
@@ -35,6 +35,34 @@
             "tier": 5,
             "type": "warning",
             "uid": "413d2e888f9a492390d4a3b46317e560"
+        },
+        {
+            "column": null,
+            "compatibility_type": "error",
+            "context": [],
+            "description": "...",
+            "file": "chrome/content/foxclocks.xul",
+            "for_appversions": {},
+            "id": ["testcases_regex", "generic", "_generated"],
+            "line": 214,
+            "message": "regex compat error",
+            "tier": 5,
+            "type": "warning",
+            "uid": "413d2e888f9a492390d4a3b46317e560"
+        },
+        {
+            "column": null,
+            "compatibility_type": "error",
+            "context": [],
+            "description": "...",
+            "file": "chrome/content/foxclocks.xul",
+            "for_appversions": {},
+            "id": ["testcases_regex", "generic", "_generated"],
+            "line": 214,
+            "message": "regex compat error 2",
+            "tier": 5,
+            "type": "warning",
+            "uid": "413d2e888f9a492390d4a3b46317e560"
         }
     ],
     "metadata": {

--- a/src/olympia/zadmin/tests/test_views.py
+++ b/src/olympia/zadmin/tests/test_views.py
@@ -363,8 +363,15 @@ class TestBulkValidation(BulkValidationTest):
         doc = pq(fromstring(response.content, parser=UTF8_PARSER))
 
         msgid = u'testcases_regex.generic.餐飲'
-        assert doc('table tr td').eq(0).text() == msgid
-        assert doc('table tr td').eq(1).text() == 'compat error'
+        assert doc('table tr').eq(3).find('td').eq(0).text() == msgid
+        assert doc('table tr').eq(3).find('td').eq(1).text() == 'compat error'
+
+        assert (
+            doc('table tr').eq(1).find('td').eq(0).text() ==
+            'ab24f1e609f5c5860e37e32b2359572a')
+        assert (
+            doc('table tr').eq(2).find('td').eq(0).text() ==
+            'ee59c03fd64d266e838b771dc91c62b0')
 
     def test_bulk_validation_summary_detail(self):
         self.addon.name = '美味的食物'
@@ -406,6 +413,7 @@ class TestBulkValidation(BulkValidationTest):
         UTF8_PARSER = HTMLParser(encoding='utf-8')
         doc = pq(fromstring(response.content, parser=UTF8_PARSER))
         assert doc('table tr td').eq(0).text() == u'美味的食物'
+        assert '3615/validation-resul' in doc('table tr td').eq(1).html()
 
 
 class TestBulkUpdate(BulkValidationTest):

--- a/src/olympia/zadmin/views.py
+++ b/src/olympia/zadmin/views.py
@@ -303,7 +303,8 @@ def validation_summary_affected_addons(request, job_id, message_id):
         validation_result_message=message_id)
     order_by = request.GET.get('sort', 'addon')
 
-    results = (ValidationResult.objects
+    results = (
+        ValidationResult.objects
         .select_related('file__version')
         .filter(validation_job=job_id,
                 file__version__addon__in=[x.addon_id for x in addons]))

--- a/src/olympia/zadmin/views.py
+++ b/src/olympia/zadmin/views.py
@@ -42,7 +42,7 @@ from olympia.users.models import UserProfile
 from olympia.versions.compare import version_int as vint
 from olympia.versions.models import Version
 from olympia.zadmin.forms import SiteEventForm
-from olympia.zadmin.models import SiteEvent
+from olympia.zadmin.models import SiteEvent, ValidationResult
 
 from . import tasks
 from .decorators import admin_required
@@ -254,10 +254,30 @@ class BulkValidationResultTable(ItemStateTable, tables.Table):
 
 class BulkValidationAffectedAddonsTable(ItemStateTable, tables.Table):
     addon = tables.Column(verbose_name=_lazy('Addon'))
+    validation_link = tables.Column(
+        verbose_name=_lazy('Validation Result'),
+        empty_values=())
 
-    def render_addon(self, value):
-        detail_url = reverse('addons.detail', args=(value.pk,))
-        return format_html(u'<a href="{0}">{1}</a>', detail_url, value.name)
+    def __init__(self, *args, **kwargs):
+        self.results = kwargs.pop('results')
+        super(BulkValidationAffectedAddonsTable, self).__init__(
+            *args, **kwargs)
+
+    def render_addon(self, record):
+        addon = record.addon
+        detail_url = reverse('addons.detail', args=(addon.pk,))
+        return format_html(u'<a href="{0}">{1}</a>', detail_url, addon.name)
+
+    def render_validation_link(self, record):
+        results = [
+            (result.pk, reverse(
+                'devhub.bulk_compat_result',
+                args=(result.file.version.addon_id, result.pk)))
+            for result in self.results]
+
+        return ', '.join(
+            format_html(u'<a href="{0}">{1}</a>', result[1], result[0])
+            for result in results)
 
 
 @any_permission_required([('Admin', '%'),
@@ -283,7 +303,14 @@ def validation_summary_affected_addons(request, job_id, message_id):
         validation_result_message=message_id)
     order_by = request.GET.get('sort', 'addon')
 
-    table = BulkValidationAffectedAddonsTable(data=addons, order_by=order_by)
+    results = (ValidationResult.objects
+        .select_related('file__version')
+        .filter(validation_job=job_id,
+                file__version__addon__in=[x.addon_id for x in addons]))
+
+    table = BulkValidationAffectedAddonsTable(
+        results=results,
+        data=addons, order_by=order_by)
 
     page = amo.utils.paginate(request, table.rows, per_page=25)
     table.set_page(page)


### PR DESCRIPTION
Show explicitly all regex matches (shows a hash of the message instead of  testcases_regex.generic._generated)

![screenshot from 2016-11-29 15-56-16](https://cloud.githubusercontent.com/assets/139033/20714757/48d4b000-b64d-11e6-883a-6a5486a3efcd.png)


Shows a link to the validation results

![screenshot from 2016-11-29 15-56-36](https://cloud.githubusercontent.com/assets/139033/20714756/48d3d482-b64d-11e6-8858-bf036f584a6b.png)


Fixes #4089 