### PR TITLE
change some Addon.objects usage in /addons

### DIFF
--- a/src/olympia/addons/cron.py
+++ b/src/olympia/addons/cron.py
@@ -256,6 +256,7 @@ def deliver_hotness():
     """
     frozen = set(f.id for f in FrozenAddon.objects.all())
     all_ids = list((Addon.objects.exclude(type=amo.ADDON_PERSONA)
+                   .filter(status__in=amo.VALID_ADDON_STATUSES)
                    .values_list('id', flat=True)))
     now = datetime.now()
     one_week = now - timedelta(days=7)

--- a/src/olympia/addons/management/commands/process_addons.py
+++ b/src/olympia/addons/management/commands/process_addons.py
@@ -1,7 +1,6 @@
 from optparse import make_option
 
 from django.core.management.base import BaseCommand, CommandError
-from django.db.models import Q
 
 from celery import chord, group
 
@@ -19,7 +18,7 @@ tasks = {
     'addon_review_aggregates': {'method': addon_review_aggregates, 'qs': []},
     'sign_addons': {'method': sign_addons, 'qs': []},
     'update_current_version_for_unlisted': {
-        'method': update_current_version, 'qs': [Q(is_listed=False)]
+        'method': update_current_version, 'qs': []
     },
 }
 
@@ -38,11 +37,6 @@ class Command(BaseCommand):
     option_list = BaseCommand.option_list + (
         make_option('--task', action='store', type='string',
                     dest='task', help='Run task on the addons.'),
-
-        make_option('--with-unlisted', action='store_true',
-                    dest='with_unlisted',
-                    help='Include unlisted add-ons when determining which '
-                         'add-ons to process.'),
     )
 
     def handle(self, *args, **options):
@@ -50,10 +44,7 @@ class Command(BaseCommand):
         if not task:
             raise CommandError('Unknown task provided. Options are: %s'
                                % ', '.join(tasks.keys()))
-        if options.get('with_unlisted'):
-            base_manager = Addon.with_unlisted
-        else:
-            base_manager = Addon.objects
+        base_manager = Addon.with_unlisted
         pks = (base_manager.filter(*task['qs'])
                            .values_list('pk', flat=True)
                            .order_by('-last_updated'))

--- a/src/olympia/addons/management/commands/process_addons.py
+++ b/src/olympia/addons/management/commands/process_addons.py
@@ -5,7 +5,6 @@ from django.core.management.base import BaseCommand, CommandError
 from celery import chord, group
 
 from olympia.addons.models import Addon
-from olympia.addons.tasks import update_current_version
 from olympia.amo.utils import chunked
 from olympia.devhub.tasks import convert_purified, get_preview_sizes
 from olympia.lib.crypto.tasks import sign_addons
@@ -17,9 +16,6 @@ tasks = {
     'convert_purified': {'method': convert_purified, 'qs': []},
     'addon_review_aggregates': {'method': addon_review_aggregates, 'qs': []},
     'sign_addons': {'method': sign_addons, 'qs': []},
-    'update_current_version_for_unlisted': {
-        'method': update_current_version, 'qs': []
-    },
 }
 
 

--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -374,14 +374,3 @@ def calc_checksum(theme_id, **kw):
         theme.save()
     except IOError as e:
         log.error(str(e))
-
-
-@task
-@write
-def update_current_version(ids, **kw):
-    log.info('[%s@%s] Updating current_version on addons starting w/ id: %s...'
-             % (len(ids), update_current_version.rate_limit, ids[0]))
-    addons = Addon.unfiltered.filter(pk__in=ids)
-
-    for addon in addons:
-        addon.update_version()

--- a/src/olympia/addons/tests/test_commands.py
+++ b/src/olympia/addons/tests/test_commands.py
@@ -203,29 +203,3 @@ def test_approve_addons_get_review_type(use_case):
 def test_process_addons_invalid_task():
     with pytest.raises(CommandError):
         call_command('process_addons', task='foo')
-
-
-@pytest.mark.django_db
-def test_process_addons_update_current_version_for_unlisted():
-    addon1 = addon_factory(
-        version_kw={'channel': amo.RELEASE_CHANNEL_UNLISTED})
-    addon2 = addon_factory(
-        version_kw={'channel': amo.RELEASE_CHANNEL_UNLISTED})
-    listed_addon = addon_factory()
-
-    # Manually set a current version on the unlisted addons to mimic the state
-    # we want to fix.
-    addon1.update(_current_version=addon1.find_latest_version(
-        channel=amo.RELEASE_CHANNEL_UNLISTED))
-    addon2.update(_current_version=addon2.find_latest_version(
-        channel=amo.RELEASE_CHANNEL_UNLISTED))
-
-    assert addon1.reload().current_version
-    assert addon2.reload().current_version
-    assert listed_addon.reload().current_version
-
-    call_command('process_addons', task='update_current_version_for_unlisted')
-    assert not addon1.reload().current_version
-    assert not addon2.reload().current_version
-    # Does not touch the listed addon.
-    assert listed_addon.reload().current_version

--- a/src/olympia/addons/tests/test_commands.py
+++ b/src/olympia/addons/tests/test_commands.py
@@ -224,17 +224,8 @@ def test_process_addons_update_current_version_for_unlisted():
     assert addon2.reload().current_version
     assert listed_addon.reload().current_version
 
-    # Does nothing because --with-unlisted has not been specified.
     call_command('process_addons', task='update_current_version_for_unlisted')
-    assert addon1.reload().current_version
-    assert addon2.reload().current_version
-    assert listed_addon.reload().current_version
-
-    # Does not touch the listed addon.
-    call_command(
-        'process_addons',
-        task='update_current_version_for_unlisted',
-        with_unlisted=True)
     assert not addon1.reload().current_version
     assert not addon2.reload().current_version
+    # Does not touch the listed addon.
     assert listed_addon.reload().current_version

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -268,16 +268,6 @@ class TestAddonManager(TestCase):
         for a in Addon.objects.reviewed():
             assert a.status in amo.REVIEWED_STATUSES, (a.id, a.status)
 
-    def test_unreviewed(self):
-        """
-        Tests for unreviewed addons.
-        """
-        exp = Addon.objects.unreviewed()
-
-        for addon in exp:
-            assert addon.status in amo.UNREVIEWED_ADDON_STATUSES, (
-                'unreviewed() must return unreviewed addons.')
-
     def test_valid(self):
         addon = Addon.objects.get(pk=5299)
         addon.update(disabled_by_user=True)

--- a/src/olympia/addons/utils.py
+++ b/src/olympia/addons/utils.py
@@ -60,7 +60,7 @@ def get_featured_ids(app, lang=None, type=None):
     ids = []
     is_featured = (Q(collections__featuredcollection__isnull=False) &
                    Q(collections__featuredcollection__application=app.id))
-    qs = Addon.objects.all()
+    qs = Addon.objects.valid()
 
     if type:
         qs = qs.filter(type=type)
@@ -96,7 +96,7 @@ def get_creatured_ids(category, lang=None):
         category = CATEGORIES_BY_ID[category]
     app_id = category.application
 
-    others = (Addon.objects
+    others = (Addon.objects.public()
               .filter(
                   Q(collections__featuredcollection__locale__isnull=True) |
                   Q(collections__featuredcollection__locale=''),

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -74,7 +74,6 @@ from .utils import get_creatured_ids, get_featured_ids
 log = commonware.log.getLogger('z.addons')
 paypal_log = commonware.log.getLogger('z.paypal')
 addon_view = addon_view_factory(qs=Addon.objects.valid)
-addon_unreviewed_view = addon_view_factory(qs=Addon.objects.unreviewed)
 addon_valid_disabled_pending_view = addon_view_factory(
     qs=Addon.objects.valid_and_disabled_and_pending)
 


### PR DESCRIPTION
part of #4028 
from process_addons remove --with-unlisted
filter by status in cron
removes unused .unreviewed view
changes some managers in utils

doesn't touch `reverse_name_lookup`