### PR TITLE
Only consider "valid" add-ons when calculating review bayesian averages

### DIFF
--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -664,7 +664,6 @@ def addon_factory(
         'status': amo.STATUS_PUBLIC,
         'name': name,
         'slug': name.replace(' ', '-').lower()[:30],
-        'bayesian_rating': random.uniform(1, 5),
         'average_daily_users': popularity or random.randint(200, 2000),
         'weekly_downloads': popularity or random.randint(200, 2000),
         'created': when,

--- a/src/olympia/reviews/tests/test_models.py
+++ b/src/olympia/reviews/tests/test_models.py
@@ -349,7 +349,7 @@ class TestRefreshTest(ESTestCase):
 
     def setUp(self):
         super(TestRefreshTest, self).setUp()
-        self.addon = Addon.objects.create(type=amo.ADDON_EXTENSION)
+        self.addon = addon_factory()
         self.user = UserProfile.objects.all()[0]
         self.refresh()
 


### PR DESCRIPTION
Part of #4028 