### PR TITLE
Don't load the version in addons.developers view

### DIFF
--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -433,22 +433,6 @@ class TestDeveloperPages(TestCase):
         r = self.client.get(reverse('addons.meet', args=['a592']))
         assert pq(r.content)('#contribute-button').length == 1
 
-    def test_get_old_version(self):
-        url = reverse('addons.meet', args=['a11730'])
-        r = self.client.get(url)
-        assert r.context['version'].version == '20090521'
-
-        r = self.client.get('%s?version=%s' % (url, '20080521'))
-        assert r.context['version'].version == '20080521'
-
-    def test_duplicate_version_number(self):
-        qs = Version.objects.filter(addon=11730)
-        qs.update(version='1.x')
-        assert qs.count() == 2
-        url = reverse('addons.meet', args=['a11730']) + '?version=1.x'
-        r = self.client.get(url)
-        assert r.context['version'].version == '1.x'
-
     def test_purified(self):
         addon = Addon.objects.get(pk=592)
         addon.the_reason = addon.the_future = '<b>foo</b>'

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -431,12 +431,6 @@ def privacy(request, addon):
 def developers(request, addon, page):
     if addon.is_persona():
         raise http.Http404()
-    if 'version' in request.GET:
-        qs = addon.versions.filter(files__status__in=amo.VALID_ADDON_STATUSES)
-        version = get_list_or_404(qs, version=request.GET['version'])[0]
-    else:
-        version = addon.current_version
-
     if 'src' in request.GET:
         contribution_src = src = request.GET['src']
     else:
@@ -449,8 +443,7 @@ def developers(request, addon, page):
         src, contribution_src = page_srcs.get(page)
     return render(request, 'addons/impala/developers.html',
                   {'addon': addon, 'page': page, 'src': src,
-                   'contribution_src': contribution_src,
-                   'version': version})
+                   'contribution_src': contribution_src})
 
 
 @addon_view


### PR DESCRIPTION
It wasn't used by the template or the view, and we don't request that URL with the version anywhere.

Part of #4117