### PR TITLE
Remove filtering from Addon.objects, remove Addon.with_unlisted

### DIFF
--- a/src/olympia/addons/management/commands/approve_addons.py
+++ b/src/olympia/addons/management/commands/approve_addons.py
@@ -43,7 +43,7 @@ def get_files(addon_guids):
     """
     # Get all the add-ons that have a GUID from the list, and which are either
     # reviewed or awaiting a review.
-    addons = Addon.with_unlisted.filter(
+    addons = Addon.objects.filter(
         guid__in=addon_guids,
         status__in=amo.VALID_ADDON_STATUSES)
     # Of all those add-ons, we return the list of latest version files that are

--- a/src/olympia/addons/management/commands/process_addons.py
+++ b/src/olympia/addons/management/commands/process_addons.py
@@ -40,10 +40,9 @@ class Command(BaseCommand):
         if not task:
             raise CommandError('Unknown task provided. Options are: %s'
                                % ', '.join(tasks.keys()))
-        base_manager = Addon.with_unlisted
-        pks = (base_manager.filter(*task['qs'])
-                           .values_list('pk', flat=True)
-                           .order_by('-last_updated'))
+        pks = (Addon.objects.filter(*task['qs'])
+                            .values_list('pk', flat=True)
+                            .order_by('-last_updated'))
         if 'pre' in task:
             # This is run in process to ensure its run before the tasks.
             pks = task['pre'](pks)

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -205,22 +205,18 @@ class AddonQuerySet(caching.CachingQuerySet):
 
 class AddonManager(ManagerBase):
 
-    def __init__(self, include_deleted=False, include_unlisted=False):
-        # DO NOT change the default value of include_deleted and
-        # include_unlisted unless you've read through the comment just above
-        # the Addon managers declaration/instantiation and understand the
-        # consequences.
+    def __init__(self, include_deleted=False):
+        # DO NOT change the default value of include_deleted unless you've read
+        # through the comment just above the Addon managers
+        # declaration/instantiation and understand the consequences.
         ManagerBase.__init__(self)
         self.include_deleted = include_deleted
-        self.include_unlisted = include_unlisted
 
     def get_queryset(self):
         qs = super(AddonManager, self).get_queryset()
         qs = qs._clone(klass=AddonQuerySet)
         if not self.include_deleted:
             qs = qs.exclude(status=amo.STATUS_DELETED)
-        if not self.include_unlisted:
-            qs = qs.exclude(is_listed=False)
         return qs.transform(Addon.transformer)
 
     def id_or_slug(self, val):
@@ -391,10 +387,9 @@ class Addon(OnChangeMixin, ModelBase):
     # mistake. You thus want the CLASS of the first one to be filtered by
     # default.
     # We don't control the instantiation, but AddonManager sets include_deleted
-    # and include_unlisted to False by default, so filtering is enabled by
-    # default. This is also why it's not repeated for 'objects' below.
-    unfiltered = AddonManager(include_deleted=True, include_unlisted=True)
-    with_unlisted = AddonManager(include_unlisted=True)
+    # to False by default, so filtering is enabled by default. This is also why
+    # it's not repeated for 'objects' below.
+    unfiltered = AddonManager(include_deleted=True)
     objects = AddonManager()
 
     class Meta:

--- a/src/olympia/addons/tests/test_decorators.py
+++ b/src/olympia/addons/tests/test_decorators.py
@@ -106,7 +106,7 @@ class TestAddonViewWithUnlisted(TestAddonView):
     def setUp(self):
         super(TestAddonViewWithUnlisted, self).setUp()
         self.view = dec.addon_view_factory(
-            qs=Addon.with_unlisted.all)(self.func)
+            qs=Addon.objects.all)(self.func)
 
     @mock.patch('olympia.access.acl.check_unlisted_addons_reviewer',
                 lambda r: False)

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -204,25 +204,21 @@ class TestAddonManager(TestCase):
 
     def test_managers_public(self):
         assert self.addon in Addon.objects.all()
-        assert self.addon in Addon.with_unlisted.all()
         assert self.addon in Addon.unfiltered.all()
 
     def test_managers_unlisted(self):
         self.change_addon_visibility(listed=False)
-        assert self.addon not in Addon.objects.all()
-        assert self.addon in Addon.with_unlisted.all()
+        assert self.addon in Addon.objects.all()
         assert self.addon in Addon.unfiltered.all()
 
     def test_managers_unlisted_deleted(self):
         self.change_addon_visibility(deleted=True, listed=False)
         assert self.addon not in Addon.objects.all()
-        assert self.addon not in Addon.with_unlisted.all()
         assert self.addon in Addon.unfiltered.all()
 
     def test_managers_deleted(self):
         self.change_addon_visibility(deleted=True, listed=True)
         assert self.addon not in Addon.objects.all()
-        assert self.addon not in Addon.with_unlisted.all()
         assert self.addon in Addon.unfiltered.all()
 
     def test_featured(self):
@@ -329,13 +325,12 @@ class TestAddonManager(TestCase):
         collection = self.addon.collections.first()
         assert collection.addons.get() == self.addon
 
-        # Addon shouldn't be listed in collection.addons if it's deleted or
-        # unlisted.
+        # Addon shouldn't be listed in collection.addons if it's deleted.
 
         # Unlisted.
         self.addon.update(is_listed=False)
         collection = Collection.objects.get(pk=collection.pk)
-        assert collection.addons.count() == 0
+        assert collection.addons.get() == self.addon
 
         # Deleted and unlisted.
         self.addon.update(status=amo.STATUS_DELETED)
@@ -1456,7 +1451,7 @@ class TestAddonModels(TestCase):
         addon.versions.update(license=None)
         addon.categories.all().delete()
         delete_translation(addon, 'summary')
-        addon = Addon.with_unlisted.get(id=3615)
+        addon = Addon.objects.get(id=3615)
         assert addon.has_complete_metadata()  # Still complete
         assert not addon.has_complete_metadata(has_listed_versions=True)
 

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -622,9 +622,9 @@ class AddonViewSet(RetrieveModelMixin, GenericViewSet):
         r'^(\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\}'
         r'|[a-z0-9-\._]*\@[a-z0-9-\._]+)$', re.IGNORECASE)
     # Permission classes disallow access to non-public/unlisted add-ons unless
-    # logged in as a reviewer/addon owner/admin, so the with_unlisted queryset
-    # is fine here.
-    queryset = Addon.with_unlisted.all()
+    # logged in as a reviewer/addon owner/admin, so we don't have to filter the
+    # base queryset here.
+    queryset = Addon.objects.all()
     lookup_value_regex = '[^/]+'  # Allow '.' for email-like guids.
 
     def get_queryset(self):

--- a/src/olympia/compat/views.py
+++ b/src/olympia/compat/views.py
@@ -52,20 +52,20 @@ def reporter(request):
     if query:
         qs = None
         if query.isdigit():
-            qs = Addon.with_unlisted.filter(id=query)
+            qs = Addon.objects.filter(id=query)
         if not qs:
-            qs = Addon.with_unlisted.filter(slug=query)
+            qs = Addon.objects.filter(slug=query)
         if not qs:
-            qs = Addon.with_unlisted.filter(guid=query)
+            qs = Addon.objects.filter(guid=query)
         if not qs and len(query) > 4:
             qs = CompatReport.objects.filter(guid__startswith=query)
         if qs:
             guid = qs[0].guid
-            addon = Addon.with_unlisted.get(guid=guid)
+            addon = Addon.objects.get(guid=guid)
             if (addon.has_listed_versions() or
                     owner_or_unlisted_reviewer(request, addon)):
                 return redirect('compat.reporter_detail', guid)
-    addons = (Addon.with_unlisted.filter(authors=request.user)
+    addons = (Addon.objects.filter(authors=request.user)
               if request.user.is_authenticated() else [])
     return render(request, 'compat/reporter.html',
                   dict(query=query, addons=addons))
@@ -74,7 +74,7 @@ def reporter(request):
 @non_atomic_requests
 def reporter_detail(request, guid):
     try:
-        addon = Addon.with_unlisted.get(guid=guid)
+        addon = Addon.objects.get(guid=guid)
     except Addon.DoesNotExist:
         addon = None
     name = addon.name if addon else guid

--- a/src/olympia/devhub/decorators.py
+++ b/src/olympia/devhub/decorators.py
@@ -18,7 +18,7 @@ def dev_required(owner_for_post=False, allow_editors=False, theme=False,
     When allow_editors is True, an editor can view the page.
     """
     def decorator(f):
-        @addon_view_factory(qs=Addon.with_unlisted.all)
+        @addon_view_factory(qs=Addon.objects.all)
         @login_required
         @functools.wraps(f)
         def wrapper(request, addon, *args, **kw):

--- a/src/olympia/devhub/feeds.py
+++ b/src/olympia/devhub/feeds.py
@@ -29,7 +29,7 @@ class ActivityFeedRSS(Feed):
         if key.addon:
             addons = key.addon
         else:  # We are showing all the add-ons
-            addons = Addon.with_unlisted.filter(authors=key.user)
+            addons = Addon.objects.filter(authors=key.user)
 
         return (ActivityLog.objects.for_addons(addons)
                            .exclude(action__in=amo.LOG_HIDE_DEVELOPER))[:20]

--- a/src/olympia/devhub/templates/devhub/nav.html
+++ b/src/olympia/devhub/templates/devhub/nav.html
@@ -13,7 +13,7 @@
         <a href="{{ url('devhub.addons') }}" class="controller">
             {{ _('My Add-ons') }}</a>
         <ul>
-          {% set my_addons = request.user.my_addons(with_unlisted=True) %}
+          {% set my_addons = request.user.my_addons() %}
           {% for addon in my_addons %}
             {% if loop.index == 8 %}
               <li><a href="{{ url('devhub.addons') }}">

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -871,7 +871,7 @@ class TestHome(TestCase):
                 self.addon.STATUS_CHOICES[self.addon.status])
             assert status_str == addon_item.find('p').eq(1).text()
 
-        Addon.with_unlisted.all().delete()
+        Addon.objects.all().delete()
         assert self.get_pq()('#my-addons').length == 0
 
     @override_switch('step-version-upload', active=False)
@@ -903,7 +903,7 @@ class TestHome(TestCase):
                 self.addon.STATUS_CHOICES[self.addon.status])
             assert status_str == addon_item.find('p').eq(1).text()
 
-        Addon.with_unlisted.all().delete()
+        Addon.objects.all().delete()
         assert self.get_pq()('#my-addons').length == 0
 
     def test_my_unlisted_addons_inline_version_upload(self):
@@ -943,7 +943,7 @@ class TestHome(TestCase):
                 self.addon.STATUS_CHOICES[self.addon.status])
             assert status_str == addon_item.find('p').eq(1).text()
 
-        Addon.with_unlisted.all().delete()
+        Addon.objects.all().delete()
         assert self.get_pq()('#my-addons').length == 0
 
     @override_switch('step-version-upload', active=True)
@@ -967,7 +967,7 @@ class TestHome(TestCase):
             self.addon.STATUS_CHOICES[self.addon.status])
         assert status_str == addon_item.find('p').eq(1).text()
 
-        Addon.with_unlisted.all().delete()
+        Addon.objects.all().delete()
         assert self.get_pq()('#my-addons').length == 0
 
     @override_switch('step-version-upload', active=True)
@@ -993,7 +993,7 @@ class TestHome(TestCase):
             self.addon.STATUS_CHOICES[self.addon.status])
         assert status_str == addon_item.find('p').eq(1).text()
 
-        Addon.with_unlisted.all().delete()
+        Addon.objects.all().delete()
         assert self.get_pq()('#my-addons').length == 0
 
     def test_incomplete_no_new_version(self):

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -73,7 +73,7 @@ class BaseTestEdit(TestCase):
         self.addon = self.get_addon()
 
     def get_addon(self):
-        return Addon.with_unlisted.no_cache().get(id=3615)
+        return Addon.objects.no_cache().get(id=3615)
 
     def get_url(self, section, edit=False):
         return get_section_url(self.addon, section, edit)

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -77,7 +77,7 @@ class TestSubmitBase(TestCase):
         self.addon = self.get_addon()
 
     def get_addon(self):
-        return Addon.with_unlisted.no_cache().get(pk=3615)
+        return Addon.objects.no_cache().get(pk=3615)
 
     def get_version(self):
         return self.get_addon().versions.latest()
@@ -221,7 +221,7 @@ class TestAddonSubmitUpload(UploadTest, TestCase):
     @mock.patch('olympia.editors.helpers.sign_file')
     def test_success_unlisted(self, mock_sign_file):
         """Sign automatically."""
-        assert Addon.with_unlisted.count() == 0
+        assert Addon.objects.count() == 0
         # No validation errors or warning.
         self.upload = self.get_upload(
             'extension.xpi',
@@ -233,7 +233,7 @@ class TestAddonSubmitUpload(UploadTest, TestCase):
                                        passed_auto_validation=True
                                        )))
         self.post(listed=False)
-        addon = Addon.with_unlisted.get()
+        addon = Addon.objects.get()
         assert not addon.is_listed
         version = addon.find_latest_version(
             channel=amo.RELEASE_CHANNEL_UNLISTED)
@@ -244,7 +244,7 @@ class TestAddonSubmitUpload(UploadTest, TestCase):
 
     @mock.patch('olympia.editors.helpers.sign_file')
     def test_success_unlisted_fail_validation(self, mock_sign_file):
-        assert Addon.with_unlisted.count() == 0
+        assert Addon.objects.count() == 0
         self.upload = self.get_upload(
             'extension.xpi',
             validation=json.dumps(dict(errors=0, warnings=0, notices=2,
@@ -255,7 +255,7 @@ class TestAddonSubmitUpload(UploadTest, TestCase):
                                        passed_auto_validation=False
                                        )))
         self.post(listed=False)
-        addon = Addon.with_unlisted.get()
+        addon = Addon.objects.get()
         assert not addon.is_listed
         version = addon.find_latest_version(
             channel=amo.RELEASE_CHANNEL_UNLISTED)

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -272,7 +272,7 @@ class TestVersion(TestCase):
                           is_listed=True)
         res = self.client.post(self.unlist_url)
         assert res.status_code == 302
-        addon = Addon.with_unlisted.get(id=3615)
+        addon = Addon.objects.get(id=3615)
         assert addon.status == amo.STATUS_NULL
         assert not addon.is_listed
         latest_version = addon.find_latest_version(
@@ -291,7 +291,7 @@ class TestVersion(TestCase):
                           is_listed=True)
         res = self.client.post(self.unlist_url)
         assert res.status_code == 404
-        addon = Addon.with_unlisted.get(id=3615)
+        addon = Addon.objects.get(id=3615)
         assert addon.is_listed
         latest_version = addon.find_latest_version(
             channel=amo.RELEASE_CHANNEL_UNLISTED)
@@ -307,7 +307,7 @@ class TestVersion(TestCase):
 
         res = self.client.post(self.unlist_url)
         assert res.status_code == 302
-        addon = Addon.with_unlisted.get(id=3615)
+        addon = Addon.objects.get(id=3615)
         assert addon.status == amo.STATUS_NULL
         assert not addon.is_listed
 
@@ -325,7 +325,7 @@ class TestVersion(TestCase):
                           is_listed=True)
         res = self.client.post(self.unlist_url)
         assert res.status_code == 302
-        addon = Addon.with_unlisted.get(id=3615)
+        addon = Addon.objects.get(id=3615)
         assert addon.status == amo.STATUS_NULL
         assert not addon.is_listed
         assert not addon.disabled_by_user

--- a/src/olympia/devhub/utils.py
+++ b/src/olympia/devhub/utils.py
@@ -284,7 +284,7 @@ class ValidationAnnotator(object):
             # object, and a valid former submission to compare against.
             try:
                 self.addon = (self.addon or
-                              Addon.with_unlisted.get(guid=addon_data['guid']))
+                              Addon.objects.get(guid=addon_data['guid']))
             except Addon.DoesNotExist:
                 pass
 

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -88,7 +88,7 @@ def addon_listing(request, default='name', theme=False):
     if theme:
         qs = request.user.addons.filter(type=amo.ADDON_PERSONA)
     else:
-        qs = Addon.with_unlisted.filter(authors=request.user).exclude(
+        qs = Addon.objects.filter(authors=request.user).exclude(
             type=amo.ADDON_PERSONA)
     filter_cls = ThemeFilter if theme else AddonFilter
     filter_ = filter_cls(request, qs, 'sort', default)
@@ -99,7 +99,7 @@ def index(request):
 
     ctx = {'blog_posts': _get_posts()}
     if request.user.is_authenticated():
-        user_addons = Addon.with_unlisted.filter(authors=request.user)
+        user_addons = Addon.objects.filter(authors=request.user)
         recent_addons = user_addons.order_by('-modified')[:3]
         ctx['recent_addons'] = []
         for addon in recent_addons:
@@ -112,7 +112,7 @@ def index(request):
 @login_required
 def dashboard(request, theme=False):
     addon_items = _get_items(
-        None, Addon.with_unlisted.filter(authors=request.user))[:4]
+        None, Addon.objects.filter(authors=request.user))[:4]
 
     data = dict(rss=_get_rss_feed(request), blog_posts=_get_posts(),
                 timestamp=int(time.time()), addon_tab=not theme,
@@ -258,10 +258,10 @@ def feed(request, addon_id=None):
     if not request.user.is_authenticated():
         return redirect_for_login(request)
     else:
-        addons_all = Addon.with_unlisted.filter(authors=request.user)
+        addons_all = Addon.objects.filter(authors=request.user)
 
         if addon_id:
-            addon = get_object_or_404(Addon.with_unlisted.id_or_slug(addon_id))
+            addon = get_object_or_404(Addon.objects.id_or_slug(addon_id))
             addons = addon  # common query set
             try:
                 key = RssKey.objects.get(addon=addons)
@@ -810,7 +810,7 @@ def json_bulk_compat_result(request, addon_id, addon, result_id):
 def json_upload_detail(request, upload, addon_slug=None):
     addon = None
     if addon_slug:
-        addon = get_object_or_404(Addon.with_unlisted, slug=addon_slug)
+        addon = get_object_or_404(Addon.objects, slug=addon_slug)
     result = upload_validation_context(request, upload, addon=addon)
     plat_exclude = []
     if result['validation']:

--- a/src/olympia/editors/tests/test_models.py
+++ b/src/olympia/editors/tests/test_models.py
@@ -39,7 +39,7 @@ def create_addon_file(name, version_str, addon_status, file_status,
         version_kw['channel'] = channel
     app_vr, created_ = AppVersion.objects.get_or_create(
         application=application.id, version='1.0')
-    addon, created_ = Addon.with_unlisted.get_or_create(
+    addon, created_ = Addon.objects.get_or_create(
         name__localized_string=name,
         defaults={'type': addon_type, 'name': name, 'is_listed': listed})
     if admin_review:
@@ -70,7 +70,7 @@ def create_addon_file(name, version_str, addon_status, file_status,
     # to make sure files as in a consistent state:
     version.disable_old_files()
     # Update status *after* we are done creating/modifying version and files:
-    addon = Addon.with_unlisted.get(pk=addon.id)
+    addon = Addon.objects.get(pk=addon.id)
     addon.update(status=addon_status)
     return {'addon': addon, 'version': version, 'file': file_}
 
@@ -81,7 +81,7 @@ def create_search_ext(name, version_str, addon_status, file_status,
         channel = amo.RELEASE_CHANNEL_LISTED
     else:
         channel = amo.RELEASE_CHANNEL_UNLISTED
-    addon, created_ = Addon.with_unlisted.get_or_create(
+    addon, created_ = Addon.objects.get_or_create(
         name__localized_string=name,
         defaults={'type': amo.ADDON_SEARCH, 'name': name, 'is_listed': listed})
     version, created_ = Version.objects.get_or_create(
@@ -89,7 +89,7 @@ def create_search_ext(name, version_str, addon_status, file_status,
     File.objects.create(version=version, filename=u"%s.xpi" % name,
                         platform=amo.PLATFORM_ALL.id, status=file_status)
     # Update status *after* there are files:
-    addon = Addon.with_unlisted.get(pk=addon.id)
+    addon = Addon.objects.get(pk=addon.id)
     addon.update(status=addon_status)
     return addon
 

--- a/src/olympia/editors/tests/test_views.py
+++ b/src/olympia/editors/tests/test_views.py
@@ -1444,7 +1444,7 @@ class BaseTestQueueSearch(SearchTest):
         name = 'Not Admin Reviewed'
         d = self.generate_file(name)
         uni = 'フォクすけといっしょ'.decode('utf8')
-        a = Addon.with_unlisted.get(pk=d['addon'].id)
+        a = Addon.objects.get(pk=d['addon'].id)
         a.name = {'ja': uni}
         a.save()
         r = self.client.get('/ja/' + self.url, {'text_query': uni},
@@ -1472,7 +1472,7 @@ class BaseTestQueueSearch(SearchTest):
         name = 'Not Admin Reviewed'
         d = self.generate_file(name)
         uni = 'フォクすけといっしょ@site.co.jp'.decode('utf8')
-        a = Addon.with_unlisted.get(pk=d['addon'].id)
+        a = Addon.objects.get(pk=d['addon'].id)
         a.support_email = {'ja': uni}
         a.save()
         r = self.client.get('/ja/' + self.url, {'text_query': uni},

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -642,7 +642,7 @@ def check_xpi_info(xpi_info, addon=None):
             raise forms.ValidationError(msg % (guid, addon.guid))
         if (not addon and
             # Non-deleted add-ons.
-            (Addon.with_unlisted.filter(guid=guid).exists() or
+            (Addon.objects.filter(guid=guid).exists() or
              # DeniedGuid objects for legacy deletions.
              DeniedGuid.objects.filter(guid=guid).exists() or
              # Deleted add-ons that don't belong to the uploader.

--- a/src/olympia/reviews/tests/test_views.py
+++ b/src/olympia/reviews/tests/test_views.py
@@ -149,7 +149,7 @@ class TestViews(ReviewTest):
 
     def test_cant_view_unlisted_addon_reviews(self):
         """An unlisted addon doesn't have reviews."""
-        self.addon.update(is_listed=False)
+        self.make_addon_unlisted(self.addon)
         assert self.client.get(helpers.url('addons.reviews.list',
                                            self.addon.slug)).status_code == 404
 
@@ -432,7 +432,7 @@ class TestCreate(ReviewTest):
 
     def test_cant_review_unlisted_addon(self):
         """Can't review an unlisted addon."""
-        self.addon.update(is_listed=False)
+        self.make_addon_unlisted(self.addon)
         assert self.client.get(self.add_url).status_code == 404
 
 
@@ -1749,8 +1749,7 @@ class TestReviewViewSetFlag(TestCase):
         assert self.review.reload().editorreview is True
 
     def test_flag_logged_in_addon_denied(self):
-        self.addon.current_version.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
-        self.addon.update(is_listed=False)
+        self.make_addon_unlisted(self.addon)
         self.user = user_factory()
         self.client.login_api(self.user)
         response = self.client.post(

--- a/src/olympia/stats/views.py
+++ b/src/olympia/stats/views.py
@@ -58,7 +58,7 @@ GLOBAL_SERIES = ('addons_in_use', 'addons_updated', 'addons_downloaded',
                  'users_created', 'my_apps')
 
 
-addon_view_with_unlisted = addon_view_factory(qs=Addon.with_unlisted.all)
+addon_view = addon_view_factory(qs=Addon.objects.valid)
 storage = get_storage_class()()
 
 
@@ -154,7 +154,7 @@ def extract(dicts):
     return extracted
 
 
-@addon_view_with_unlisted
+@addon_view
 @non_atomic_requests
 def overview_series(request, addon, group, start, end, format):
     """Combines downloads_series and updates_series into one payload."""
@@ -200,7 +200,7 @@ def zip_overview(downloads, updates):
                'data': {'downloads': dl_count, 'updates': up_count}}
 
 
-@addon_view_with_unlisted
+@addon_view
 @non_atomic_requests
 def downloads_series(request, addon, group, start, end, format):
     """Generate download counts grouped by ``group`` in ``format``."""
@@ -215,7 +215,7 @@ def downloads_series(request, addon, group, start, end, format):
         return render_json(request, addon, series)
 
 
-@addon_view_with_unlisted
+@addon_view
 @non_atomic_requests
 def sources_series(request, addon, group, start, end, format):
     """Generate download source breakdown."""
@@ -233,7 +233,7 @@ def sources_series(request, addon, group, start, end, format):
         return render_json(request, addon, series)
 
 
-@addon_view_with_unlisted
+@addon_view
 @non_atomic_requests
 def usage_series(request, addon, group, start, end, format):
     """Generate ADU counts grouped by ``group`` in ``format``."""
@@ -250,7 +250,7 @@ def usage_series(request, addon, group, start, end, format):
         return render_json(request, addon, series)
 
 
-@addon_view_with_unlisted
+@addon_view
 @non_atomic_requests
 def usage_breakdown_series(request, addon, group,
                            start, end, format, field):
@@ -349,7 +349,7 @@ def check_stats_permission(request, addon, for_contributions=False):
     raise PermissionDenied
 
 
-@addon_view_factory(qs=Addon.with_unlisted.valid)
+@addon_view
 @non_atomic_requests
 def stats_report(request, addon, report):
     check_stats_permission(request, addon,
@@ -444,7 +444,7 @@ def site_event_format(request, events):
         }
 
 
-@addon_view_with_unlisted
+@addon_view
 @non_atomic_requests
 def contributions_series(request, addon, group, start, end, format):
     """Generate summarized contributions grouped by ``group`` in ``format``."""
@@ -709,7 +709,7 @@ class ArchiveMixin(object):
     """Provides common helper methods for all archive views."""
     def get_addon(self, request, slug):
         """Fetches an addon by `slug`"""
-        qset = Addon.with_unlisted.all()
+        qset = Addon.objects.all()
 
         addon = get_object_or_404(qset, slug=slug)
 

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -209,12 +209,9 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
         return self.addons.reviewed().filter(
             addonuser__user=self, addonuser__listed=True).count()
 
-    def my_addons(self, n=8, with_unlisted=False):
+    def my_addons(self, n=8):
         """Returns n addons"""
-        addons = self.addons
-        if with_unlisted:
-            addons = self.addons.model.with_unlisted.filter(authors=self)
-        qs = order_by_translation(addons, 'name')
+        qs = order_by_translation(self.addons, 'name')
         return qs[:n]
 
     @property

--- a/src/olympia/users/tests/test_models.py
+++ b/src/olympia/users/tests/test_models.py
@@ -194,16 +194,6 @@ class TestUserProfile(TestCase):
         addons = UserProfile.objects.get(id=2519).my_addons()
         assert sorted(a.name for a in addons) == [addon1.name, addon2.name]
 
-    def test_my_addons_with_unlisted_addons(self):
-        """Test helper method can return unlisted addons."""
-        addon1 = Addon.objects.create(name='test-1', type=amo.ADDON_EXTENSION)
-        AddonUser.objects.create(addon_id=addon1.id, user_id=2519, listed=True)
-        addon2 = Addon.objects.create(name='test-2', type=amo.ADDON_EXTENSION,
-                                      is_listed=False)
-        AddonUser.objects.create(addon_id=addon2.id, user_id=2519, listed=True)
-        addons = UserProfile.objects.get(id=2519).my_addons(with_unlisted=True)
-        assert sorted(a.name for a in addons) == [addon1.name, addon2.name]
-
     def test_mobile_collection(self):
         u = UserProfile.objects.get(id='4043307')
         assert not Collection.objects.filter(author=u)

--- a/src/olympia/versions/views.py
+++ b/src/olympia/versions/views.py
@@ -100,7 +100,7 @@ def download_file(request, file_id, type=None, file_=None, addon=None):
     if not file_:
         file_ = get_object_or_404(File.objects, pk=file_id)
     if not addon:
-        addon = get_object_or_404(Addon.with_unlisted,
+        addon = get_object_or_404(Addon.objects,
                                   pk=file_.version.addon_id)
     channel = file_.version.channel
 
@@ -140,7 +140,7 @@ def download_file(request, file_id, type=None, file_=None, addon=None):
 
 
 def guard():
-    return Addon.with_unlisted.filter(_current_version__isnull=False)
+    return Addon.objects.filter(_current_version__isnull=False)
 
 
 @addon_view_factory(guard)

--- a/src/olympia/zadmin/views.py
+++ b/src/olympia/zadmin/views.py
@@ -571,7 +571,7 @@ def general_search(request, app_id, model_id):
 
 
 @admin_required(reviewers=True)
-@addon_view_factory(qs=Addon.with_unlisted.all)
+@addon_view_factory(qs=Addon.objects.all)
 def addon_manage(request, addon):
     form = AddonStatusForm(request.POST or None, instance=addon)
     pager = amo.utils.paginate(


### PR DESCRIPTION
Filtering should be done either with the status from now (pure unlisted add-ons will have `STATUS_NULL`) or by checking if each add-on has listed versions or not (with `.has_listed_versions()`),
or by checking if `current_version` exists, depending on the use-case.

Fix #4028