### PR TITLE
Handle serializing a log event without a .details (so no comments)

### DIFF
--- a/src/olympia/activity/serializers.py
+++ b/src/olympia/activity/serializers.py
@@ -24,7 +24,8 @@ class ActivityLogSerializer(serializers.ModelSerializer):
         self.to_highlight = kwargs.get('context', []).get('to_highlight', [])
 
     def get_comments(self, obj):
-        return getattr(obj.log(), 'sanitize', obj.details['comments'])
+        return getattr(obj.log(), 'sanitize',
+                       obj.details['comments'] if obj.details else obj.log())
 
     def get_action_label(self, obj):
         log = obj.log()

--- a/src/olympia/activity/serializers.py
+++ b/src/olympia/activity/serializers.py
@@ -24,8 +24,8 @@ class ActivityLogSerializer(serializers.ModelSerializer):
         self.to_highlight = kwargs.get('context', []).get('to_highlight', [])
 
     def get_comments(self, obj):
-        return getattr(obj.log(), 'sanitize',
-                       obj.details['comments'] if obj.details else obj.log())
+        comments = obj.details['comments'] if obj.details else obj.to_string()
+        return getattr(obj.log(), 'sanitize', comments)
 
     def get_action_label(self, obj):
         log = obj.log()

--- a/src/olympia/activity/tests/test_serializers.py
+++ b/src/olympia/activity/tests/test_serializers.py
@@ -74,10 +74,10 @@ class TestReviewNotesSerializerOutput(TestCase, LogMixin):
 
     def test_log_entry_without_details(self):
         # Create a log but without a details property.
-        entry = amo.log(
-            amo.APPROVAL_NOTES_CHANGED, self.addon,
+        self.entry = amo.log(
+            amo.LOG.APPROVAL_NOTES_CHANGED, self.addon,
             self.addon.find_latest_version(channel=amo.RELEASE_CHANNEL_LISTED),
             user=self.user)
         result = self.serialize()
         # Should default to the string representation of the log event.
-        assert result['comments'] == entry.to_string()
+        assert result['comments'] == self.entry.to_string()

--- a/src/olympia/activity/tests/test_serializers.py
+++ b/src/olympia/activity/tests/test_serializers.py
@@ -71,3 +71,13 @@ class TestReviewNotesSerializerOutput(TestCase, LogMixin):
         assert result['comments'] == amo.LOG.REQUEST_SUPER_REVIEW.sanitize
         assert result['comments'].startswith(
             'The addon has been flagged for Admin Review.')
+
+    def test_log_entry_without_details(self):
+        # Create a log but without a details property.
+        entry = amo.log(
+            amo.APPROVAL_NOTES_CHANGED, self.addon,
+            self.addon.find_latest_version(channel=amo.RELEASE_CHANNEL_LISTED),
+            user=self.user)
+        result = self.serialize()
+        # Should default to the string representation of the log event.
+        assert result['comments'] == entry.to_string()


### PR DESCRIPTION
fixes #4126 