### PR TITLE
Fix Dockerfile (disable yum updates and compile locale)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,6 @@ FROM centos:centos7
 # Allow scripts to detect we're running in our own container
 RUN touch /addons-server-centos7-container
 
-# Set the locale. This is mainly so that tests can write non-ascii files to
-# disk.
-ENV LANG en_US.UTF-8
-ENV LC_ALL en_US.UTF-8
-
 ADD docker/mysql-community.gpg.key /etc/pki/rpm-gpg/RPM-GPG-KEY-mysql
 ADD docker/nodesource.gpg.key /etc/pki/rpm-gpg/RPM-GPG-KEY-nodesource
 
@@ -45,6 +40,15 @@ RUN yum update -y \
         epel-release \
         swig \
     && yum clean all
+
+# Compile required locale
+RUN localedef -i en_US -f UTF-8 en_US.UTF-8
+
+# Set the locale. This is mainly so that tests can write non-ascii files to
+# disk.
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
 
 RUN yum install -y python-pip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,7 @@ ADD docker/mysql.repo /etc/yum.repos.d/mysql.repo
 # This is temporary until https://bugzilla.mozilla.org/show_bug.cgi?id=1226533
 ADD docker/nodesource.repo /etc/yum.repos.d/nodesource.repo
 
-RUN yum update -y \
-    && yum install -y \
+RUN yum install -y \
         # Supervisor is being used to start and keep our services running
         supervisor \
         # General (dev-) dependencies

--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -12,8 +12,7 @@ ADD docker/nodesource.gpg.key /etc/pki/rpm-gpg/RPM-GPG-KEY-nodesource
 ADD docker/epel.gpg.key /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
 ADD docker/nodesource.repo docker/epel.repo /etc/yum.repos.d/
 
-RUN yum update -y                                           \
-    && yum install -y                                       \
+RUN yum install -y                                          \
         gcc-c++                                             \
         gettext                                             \
         # Git, because we're using git-checkout dependencies

--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -1,8 +1,5 @@
 FROM centos:centos7
 
-ENV LANG en_US.UTF-8
-ENV LC_ALL en_US.UTF-8
-
 # need to compile swig
 ENV SWIG_FEATURES="-D__x86_64__"
 
@@ -34,6 +31,11 @@ RUN yum update -y                                           \
         uwsgi-plugin-python                                 \
     && yum clean all                                        \
     && curl -sSL https://bootstrap.pypa.io/get-pip.py | python
+
+# Compile required locale
+RUN localedef -i en_US -f UTF-8 en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
 
 COPY . /data/olympia
 WORKDIR /data/olympia


### PR DESCRIPTION
I don't think we should be running 'yum update' as part of the Docker image build since we are relying on centos:centos7 image which should be the latest working version of centos7. Also I've added a command to compile utf-8 locale if glic-common does not ship with it in the future.