### PR TITLE
Using redirect path when already logged in and logging in

### DIFF
--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -275,7 +275,14 @@ class TestRenderErrorHTML(TestCase):
         messages = get_messages(request)
         assert len(messages) == 1
         assert 'could not be parsed' in next(iter(messages)).message
-        assert_url_equal(response['location'], self.login_url(to='/over/here'))
+        assert_url_equal(response['location'], absolutify('/over/here'))
+        response = self.render_error(
+            request, views.ERROR_NO_CODE, next_path=None)
+        assert response.status_code == 302
+        messages = get_messages(request)
+        assert len(messages) == 1
+        assert 'could not be parsed' in next(iter(messages)).message
+        assert_url_equal(response['location'], self.login_url())
 
     def test_error_no_profile_with_no_path(self):
         request = self.make_request()

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -26,7 +26,6 @@ from waffle.decorators import waffle_switch
 from olympia.access.models import GroupUser
 from olympia.amo import messages
 from olympia.amo.decorators import write
-from olympia.amo.utils import urlparams
 from olympia.api.authentication import JWTKeyAuthentication
 from olympia.api.permissions import GroupPermission
 from olympia.users.models import UserProfile
@@ -130,9 +129,10 @@ def render_error(request, error, next_path=None, format=None):
         messages.error(
             request, fxa_error_message(LOGIN_ERROR_MESSAGES[error]),
             extra_tags='fxa')
-        redirect_view = 'users.login'
-        return HttpResponseRedirect(
-            urlparams(reverse(redirect_view), to=next_path))
+        if next_path is None:
+            return HttpResponseRedirect(reverse('users.login'))
+        else:
+            return HttpResponseRedirect(next_path)
 
 
 def parse_next_path(state_parts):


### PR DESCRIPTION
Use `users.login` page if available when logging in and already logged in.
Error is shown after redirecting the user to the `to` path if it is valid,
otherwise `/users/login/`.

Fixes #4112 