### PR TITLE
Generate version.json in circle.yml for pipeline v2

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -36,6 +36,14 @@ RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
+# The pipeline v2 standard requires the existence of /app/version.json
+# inside the docker image, although the content of the file comes from
+# circle.yml.
+# We realize that the content of version.json is written twice (once in
+# circle.yml, and the other in the end of this file), we should remove
+# the bits at the end of this file after we fully migrate to use pipeline
+# v2.
+COPY version.json /app/version.json
 COPY . /data/olympia
 WORKDIR /data/olympia
 

--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,14 @@ machine:
 dependencies:
   override:
     - docker version
+    - >
+        printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n'
+        "$CIRCLE_SHA1"
+        "$CIRCLE_TAG"
+        "$CIRCLE_PROJECT_USERNAME"
+        "$CIRCLE_PROJECT_REPONAME"
+        "$CIRCLE_BUILD_URL"
+        > version.json
     - docker build -t app:build -f Dockerfile.deploy .
     - pip install tox mozdownload mozinstall
 


### PR DESCRIPTION
Also copy the generated file to /app/version.json in Docker.deploy so it
complies with pipeline v2 standard.