### PR TITLE
Reduce islisted usage in tests

### DIFF
--- a/src/olympia/activity/tests/test_views.py
+++ b/src/olympia/activity/tests/test_views.py
@@ -76,22 +76,19 @@ class ReviewNotesViewSetDetailMixin(LogMixin):
         assert response.status_code == 200
 
     def test_get_not_listed_simple_reviewer(self):
-        self.addon.update(is_listed=False)
-        self.addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        self.make_addon_unlisted(self.addon)
         self._login_reviewer()
         response = self.client.get(self.url)
         assert response.status_code == 403
 
     def test_get_not_listed_specific_reviewer(self):
-        self.addon.update(is_listed=False)
-        self.addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        self.make_addon_unlisted(self.addon)
         self._login_reviewer(permission='Addons:ReviewUnlisted')
         response = self.client.get(self.url)
         assert response.status_code == 200
 
     def test_get_not_listed_author(self):
-        self.addon.update(is_listed=False)
-        self.addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        self.make_addon_unlisted(self.addon)
         self._login_developer()
         response = self.client.get(self.url)
         assert response.status_code == 200
@@ -290,8 +287,7 @@ class TestReviewNotesViewSetCreate(TestCase):
         assert not rdata['highlight']  # developer replies aren't highlighted.
 
     def test_developer_reply_unlisted(self):
-        self.addon.update(is_listed=False)
-        self.addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        self.make_addon_unlisted(self.addon)
         self.test_developer_reply()
 
     def _test_reviewer_reply(self, perm):
@@ -319,8 +315,7 @@ class TestReviewNotesViewSetCreate(TestCase):
         self._test_reviewer_reply('Addons:Review')
 
     def test_reviewer_reply_unlisted(self):
-        self.addon.update(is_listed=False)
-        self.version.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        self.make_addon_unlisted(self.addon)
         self._test_reviewer_reply('Addons:ReviewUnlisted')
 
     def test_reply_to_deleted_addon_is_404(self):
@@ -384,8 +379,7 @@ class TestReviewNotesViewSetCreate(TestCase):
         self._test_reviewer_reply('Addons:Review')
 
     def test_reviewer_can_reply_to_disabled_version_unlisted(self):
-        self.addon.update(is_listed=False)
-        self.version.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        self.make_addon_unlisted(self.addon)
         self.version.files.update(status=amo.STATUS_DISABLED)
         self._test_reviewer_reply('Addons:ReviewUnlisted')
 

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -334,7 +334,7 @@ class TestAddonManager(TestCase):
         assert collection.addons.count() == 0
 
         # Only deleted.
-        self.make_addon_unlisted(self.addon, listed=True)
+        self.make_addon_listed(self.addon)
         collection = Collection.objects.get(pk=collection.pk)
         assert collection.addons.count() == 0
 
@@ -356,7 +356,7 @@ class TestAddonManager(TestCase):
         assert version.addon == self.addon
 
         # Only deleted.
-        self.make_addon_unlisted(self.addon, listed=True)
+        self.make_addon_listed(self.addon)
         version = Version.objects.get(pk=version.pk)  # Reload from db.
         assert version.addon == self.addon
 

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -197,27 +197,23 @@ class TestAddonManager(TestCase):
         set_user(None)
         self.addon = Addon.objects.get(pk=3615)
 
-    def change_addon_visibility(self, deleted=False, listed=True):
-        self.addon.update(
-            status=amo.STATUS_DELETED if deleted else amo.STATUS_PUBLIC,
-            is_listed=listed)
-
     def test_managers_public(self):
         assert self.addon in Addon.objects.all()
         assert self.addon in Addon.unfiltered.all()
 
     def test_managers_unlisted(self):
-        self.change_addon_visibility(listed=False)
+        self.make_addon_unlisted(self.addon)
         assert self.addon in Addon.objects.all()
         assert self.addon in Addon.unfiltered.all()
 
     def test_managers_unlisted_deleted(self):
-        self.change_addon_visibility(deleted=True, listed=False)
+        self.make_addon_unlisted(self.addon)
+        self.addon.update(status=amo.STATUS_DELETED)
         assert self.addon not in Addon.objects.all()
         assert self.addon in Addon.unfiltered.all()
 
     def test_managers_deleted(self):
-        self.change_addon_visibility(deleted=True, listed=True)
+        self.addon.update(status=amo.STATUS_DELETED)
         assert self.addon not in Addon.objects.all()
         assert self.addon in Addon.unfiltered.all()
 
@@ -328,7 +324,7 @@ class TestAddonManager(TestCase):
         # Addon shouldn't be listed in collection.addons if it's deleted.
 
         # Unlisted.
-        self.addon.update(is_listed=False)
+        self.make_addon_unlisted(self.addon)
         collection = Collection.objects.get(pk=collection.pk)
         assert collection.addons.get() == self.addon
 
@@ -338,7 +334,7 @@ class TestAddonManager(TestCase):
         assert collection.addons.count() == 0
 
         # Only deleted.
-        self.addon.update(is_listed=True)
+        self.make_addon_unlisted(self.addon, listed=True)
         collection = Collection.objects.get(pk=collection.pk)
         assert collection.addons.count() == 0
 
@@ -350,7 +346,7 @@ class TestAddonManager(TestCase):
         # Deleted or unlisted, version.addon should still work.
 
         # Unlisted.
-        self.addon.update(is_listed=False)
+        self.make_addon_unlisted(self.addon)
         version = Version.objects.get(pk=version.pk)  # Reload from db.
         assert version.addon == self.addon
 
@@ -360,7 +356,7 @@ class TestAddonManager(TestCase):
         assert version.addon == self.addon
 
         # Only deleted.
-        self.addon.update(is_listed=True)
+        self.make_addon_unlisted(self.addon, listed=True)
         version = Version.objects.get(pk=version.pk)  # Reload from db.
         assert version.addon == self.addon
 

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -1581,11 +1581,6 @@ class AddonAndVersionViewSetDetailMixin(object):
     def _set_tested_url(self, param):
         raise NotImplementedError
 
-    def _make_unlisted(self):
-        self.addon.update(is_listed=False)
-        for version in self.addon.versions.all():
-            version.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
-
     def test_get_by_id(self):
         self._test_url()
 
@@ -1650,13 +1645,13 @@ class AddonAndVersionViewSetDetailMixin(object):
         assert response.status_code == 401
 
     def test_get_not_listed(self):
-        self._make_unlisted()
+        self.make_addon_unlisted(self.addon)
         response = self.client.get(self.url)
         assert response.status_code == 401
 
     def test_get_not_listed_no_rights(self):
         user = UserProfile.objects.create(username='simpleuser')
-        self._make_unlisted()
+        self.make_addon_unlisted(self.addon)
         self.client.login_api(user)
         response = self.client.get(self.url)
         assert response.status_code == 403
@@ -1664,7 +1659,7 @@ class AddonAndVersionViewSetDetailMixin(object):
     def test_get_not_listed_simple_reviewer(self):
         user = UserProfile.objects.create(username='reviewer')
         self.grant_permission(user, 'Addons:Review')
-        self._make_unlisted()
+        self.make_addon_unlisted(self.addon)
         self.client.login_api(user)
         response = self.client.get(self.url)
         assert response.status_code == 403
@@ -1672,7 +1667,7 @@ class AddonAndVersionViewSetDetailMixin(object):
     def test_get_not_listed_specific_reviewer(self):
         user = UserProfile.objects.create(username='reviewer')
         self.grant_permission(user, 'Addons:ReviewUnlisted')
-        self._make_unlisted()
+        self.make_addon_unlisted(self.addon)
         self.client.login_api(user)
         response = self.client.get(self.url)
         assert response.status_code == 200
@@ -1680,7 +1675,7 @@ class AddonAndVersionViewSetDetailMixin(object):
     def test_get_not_listed_author(self):
         user = UserProfile.objects.create(username='author')
         AddonUser.objects.create(user=user, addon=self.addon)
-        self._make_unlisted()
+        self.make_addon_unlisted(self.addon)
         self.client.login_api(user)
         response = self.client.get(self.url)
         assert response.status_code == 200

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -591,7 +591,13 @@ class TestCase(PatchMixin, InitializeSessionMixin, MockEsMixin,
         setattr(request, '_messages', messages)
         return request
 
-    def make_addon_unlisted(self, addon, listed=False):
+    def make_addon_unlisted(self, addon):
+        self.change_channel_for_addon(addon, False)
+
+    def make_addon_listed(self, addon):
+        self.change_channel_for_addon(addon, True)
+
+    def change_channel_for_addon(self, addon, listed):
         addon.update(is_listed=listed)
         channel = (amo.RELEASE_CHANNEL_LISTED if listed else
                    amo.RELEASE_CHANNEL_UNLISTED)

--- a/src/olympia/devhub/tests/test_feeds.py
+++ b/src/olympia/devhub/tests/test_feeds.py
@@ -203,8 +203,7 @@ class TestActivity(HubTest):
 
     def test_rss_unlisted_addon(self):
         """Unlisted addon logs appear in the rss feed."""
-        self.addon.update(is_listed=False)
-        self.addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        self.make_addon_unlisted(self.addon)
         self.log_creates(5)
 
         # This will give us a new RssKey
@@ -231,9 +230,8 @@ class TestActivity(HubTest):
     def test_xss_unlisted_addon(self):
         self.addon.name = ("<script>alert('Buy more Diet Mountain Dew.')"
                            '</script>')
-        self.addon.is_listed = False
-        self.addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
         self.addon.save()
+        self.make_addon_unlisted(self.addon)
         self.log_creates(1)
         doc = self.get_pq()
         assert len(doc('.item')) == 1
@@ -248,8 +246,7 @@ class TestActivity(HubTest):
         assert '&lt;script&gt;' in unicode(doc), 'XSS FTL'
 
     def test_xss_collections_unlisted_addon(self):
-        self.addon.update(is_listed=False)
-        self.addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        self.make_addon_unlisted(self.addon)
         self.log_collection(1, "<script>alert('v1@gra for u')</script>")
         doc = self.get_pq()
         assert len(doc('.item')) == 1
@@ -264,8 +261,7 @@ class TestActivity(HubTest):
         assert '&lt;script' in unicode(doc('.item')), 'XSS FTL'
 
     def test_xss_tags_unlisted_addon(self):
-        self.addon.update(is_listed=False)
-        self.addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        self.make_addon_unlisted(self.addon)
         self.log_tag(1, "<script src='x.js'>")
         doc = self.get_pq()
         assert len(doc('.item')) == 1
@@ -280,8 +276,7 @@ class TestActivity(HubTest):
         assert '&lt;script' in unicode(doc('.item')), 'XSS FTL'
 
     def test_xss_versions_unlisted_addon(self):
-        self.addon.update(is_listed=False)
-        self.addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        self.make_addon_unlisted(self.addon)
         self.log_updates(1, "<script src='x.js'>")
         doc = self.get_pq()
         assert len(doc('.item')) == 2

--- a/src/olympia/devhub/tests/test_models.py
+++ b/src/olympia/devhub/tests/test_models.py
@@ -80,8 +80,9 @@ class TestActivityLog(TestCase):
         addon = Addon.objects.get()
         # Get the url before the addon is changed to unlisted.
         url_path = addon.get_url_path()
-        addon.update(is_listed=False)
-        addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        self.make_addon_unlisted(addon)
+        # Delete the status change log entry from making versions unlisted.
+        ActivityLog.objects.for_addons(addon).delete()
         amo.log(amo.LOG.CREATE_ADDON, (Addon, addon.id))
         entries = ActivityLog.objects.for_addons(addon)
         assert len(entries) == 1
@@ -152,11 +153,9 @@ class TestActivityLog(TestCase):
 
     def test_version_log_unlisted_addon(self):
         version = Version.objects.all()[0]
-        addon = version.addon
         # Get the url before the addon is changed to unlisted.
         url_path = version.get_url_path()
-        addon.update(is_listed=False)
-        version.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        self.make_addon_unlisted(version.addon)
         amo.log(amo.LOG.REJECT_VERSION, version.addon, version,
                 user=self.request.user)
         entries = ActivityLog.objects.for_version(version)

--- a/src/olympia/devhub/tests/test_tasks.py
+++ b/src/olympia/devhub/tests/test_tasks.py
@@ -719,9 +719,7 @@ class TestWebextensionIncompatibilities(ValidatorTestCase):
 
     def test_webextension_downgrade_only_warning_unlisted(self):
         self.update_files(is_webextension=True)
-        self.addon.is_listed = False
-        self.addon.save(update_fields=('is_listed',))
-        self.addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        self.make_addon_unlisted(self.addon)
 
         file_ = amo.tests.AMOPaths().file_fixture_path(
             'delicious_bookmarks-2.1.106-fx.xpi')

--- a/src/olympia/devhub/tests/test_utils.py
+++ b/src/olympia/devhub/tests/test_utils.py
@@ -569,11 +569,9 @@ class TestValidationAnnotatorUnlisted(TestValidationAnnotatorBase):
 
     def setUp(self):
         super(TestValidationAnnotatorUnlisted, self).setUp()
-
-        self.addon.update(is_listed=False)
-        self.version.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
-        self.file.version.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
-        self.file_1_1.version.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        self.make_addon_unlisted(self.addon)
+        self.file_1_1.reload()
+        self.file.reload()
 
     def test_find_fileupload_prev_version(self):
         """Test that the correct previous version is found for a new upload."""

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -50,8 +50,8 @@ class BaseTestEdit(TestCase):
         assert self.client.login(email='del@icio.us')
 
         addon = self.get_addon()
-        self.make_addon_unlisted(addon, listed=self.listed)
         if self.listed:
+            self.make_addon_listed(addon)
             a = AddonCategory.objects.filter(addon=addon, category__id=22)[0]
             a.feature = False
             a.save()
@@ -62,6 +62,8 @@ class BaseTestEdit(TestCase):
             self.tags = ['tag3', 'tag2', 'tag1']
             for t in self.tags:
                 Tag(tag_text=t).save_tag(addon)
+        else:
+            self.make_addon_unlisted(addon)
 
         self.url = addon.get_dev_url()
         self.user = UserProfile.objects.get(pk=55021)

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -50,13 +50,8 @@ class BaseTestEdit(TestCase):
         assert self.client.login(email='del@icio.us')
 
         addon = self.get_addon()
-        if not self.listed:
-            addon.update(is_listed=False)
-            addon.versions.update(
-                channel=amo.RELEASE_CHANNEL_UNLISTED)
-        else:
-            addon.versions.update(
-                channel=amo.RELEASE_CHANNEL_LISTED)
+        self.make_addon_unlisted(addon, listed=self.listed)
+        if self.listed:
             a = AddonCategory.objects.filter(addon=addon, category__id=22)[0]
             a.feature = False
             a.save()

--- a/src/olympia/devhub/tests/test_views_ownership.py
+++ b/src/olympia/devhub/tests/test_views_ownership.py
@@ -90,8 +90,7 @@ class TestEditLicense(TestOwnership):
         assert license_form.errors == {'builtin': [u'This field is required.']}
 
     def test_no_license_required_for_unlisted(self):
-        self.addon.update(is_listed=False)
-        self.addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        self.make_addon_unlisted(self.addon)
         data = self.formset(builtin='')
         response = self.client.post(self.url, data)
         assert response.status_code == 302

--- a/src/olympia/devhub/tests/test_views_validation.py
+++ b/src/olympia/devhub/tests/test_views_validation.py
@@ -405,7 +405,8 @@ class TestUploadURLs(TestCase):
     def upload_addon(self, status=amo.STATUS_PUBLIC, listed=True):
         """Update the test add-on with the given flags and send an upload
         request for it."""
-        self.addon.update(status=status, is_listed=listed)
+        self.make_addon_unlisted(self.addon, listed=listed)
+        self.addon.update(status=status)
         channel_text = 'listed' if listed else 'unlisted'
         return self.upload('devhub.upload_for_version',
                            channel=channel_text, addon_id=self.addon.slug)

--- a/src/olympia/devhub/tests/test_views_validation.py
+++ b/src/olympia/devhub/tests/test_views_validation.py
@@ -405,7 +405,7 @@ class TestUploadURLs(TestCase):
     def upload_addon(self, status=amo.STATUS_PUBLIC, listed=True):
         """Update the test add-on with the given flags and send an upload
         request for it."""
-        self.make_addon_unlisted(self.addon, listed=listed)
+        self.change_channel_for_addon(self.addon, listed=listed)
         self.addon.update(status=status)
         channel_text = 'listed' if listed else 'unlisted'
         return self.upload('devhub.upload_for_version',

--- a/src/olympia/files/tests/test_decorators.py
+++ b/src/olympia/files/tests/test_decorators.py
@@ -44,8 +44,8 @@ class AllowedTest(TestCase):
         self.assertRaises(http.Http404, allowed, self.request, self.file)
 
     def get_unlisted_addon_file(self):
-        addon = amo.tests.addon_factory(is_listed=False)
-        addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        addon = amo.tests.addon_factory(
+            version_kw={'channel': amo.RELEASE_CHANNEL_UNLISTED})
         return addon, addon.versions.get().files.get()
 
     @patch.object(acl, 'check_addons_reviewer', lambda x: False)

--- a/src/olympia/files/tests/test_views.py
+++ b/src/olympia/files/tests/test_views.py
@@ -469,8 +469,7 @@ class TestFileViewer(FilesBase, TestCase):
 
     def test_files_for_unlisted_addon_returns_404(self):
         """Files browsing isn't allowed for unlisted addons."""
-        self.addon.update(is_listed=False)
-        self.file.version.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        self.make_addon_unlisted(self.addon)
         assert self.client.get(self.file_url()).status_code == 404
 
     def test_content_file_size_uses_binary_prefix(self):

--- a/src/olympia/internal_tools/tests/test_views.py
+++ b/src/olympia/internal_tools/tests/test_views.py
@@ -260,7 +260,7 @@ class TestInternalAddonViewSetDetail(TestCase):
         assert response.status_code == 403
 
     def test_get_not_listed(self):
-        self.addon.update(is_listed=False)
+        self.make_addon_unlisted(self.addon)
         response = self.client.get(self.url)
         assert response.status_code == 200
 

--- a/src/olympia/legacy_api/tests/test_views.py
+++ b/src/olympia/legacy_api/tests/test_views.py
@@ -1006,9 +1006,8 @@ class SearchTest(ESTestCase):
         Test that unlisted add-ons are not shown.
         """
         addon = Addon.objects.get(pk=3615)
-        addon.current_version.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        self.make_addon_unlisted(addon)
         addon.reload()
-        addon.update(is_listed=False)
         self.refresh()
         response = self.client.get(
             "/en-US/firefox/api/1.2/search/delicious")

--- a/src/olympia/search/tests/test_views.py
+++ b/src/olympia/search/tests/test_views.py
@@ -638,9 +638,8 @@ class TestESSearch(SearchBase):
         response = self.client.get(self.url, {'q': 'Addon'})
         assert addon.pk in self.get_results(response)
 
-        addon.current_version.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        self.make_addon_unlisted(addon)
         addon.reload()
-        addon.update(is_listed=False)
         self.refresh()
         response = self.client.get(self.url, {'q': 'Addon'})
         assert addon.pk not in self.get_results(response)

--- a/src/olympia/zadmin/tests/test_views.py
+++ b/src/olympia/zadmin/tests/test_views.py
@@ -1491,7 +1491,7 @@ class TestAddonManagement(TestCase):
 
     def test_can_manage_unlisted_addons(self):
         """Unlisted addons can be managed too."""
-        self.addon.update(is_listed=False)
+        self.make_addon_unlisted(self.addon)
         assert self.client.get(self.url).status_code == 200
 
     def _form_data(self, data=None):


### PR DESCRIPTION
There are some tests that will be removed when #4165 is merged and some other random tests where it seemed advantageous to leave as is for now.

Surprisingly, only `test_can_download_once_authenticated` needed a material change.

Connected to #3977