### PR TITLE
Add explicit sort by relevance option in search API

### DIFF
--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -60,15 +60,17 @@ This endpoint allows you to search through public add-ons.
     ==============  ==========================================================
          Parameter  Description
     ==============  ==========================================================
-           created  Creation date, descending
-         downloads  Number of weekly downloads, descending
+           created  Creation date, descending.
+         downloads  Number of weekly downloads, descending.
            hotness  Hotness (average number of users progression), descending.
             rating  Bayesian rating, descending.
-           updated  Last updated date, descending
+         relevance  Search query relevance, descending.
+           updated  Last updated date, descending.
              users  Average number of daily users, descending.
     ==============  ==========================================================
 
-    The default is to sort by number of weekly downloads, descending.
+    The default is to sort by relevance if a search query (``q``) is present,
+    otherwise sort by number of weekly downloads, descending.
 
     You can combine multiple parameters by separating them with a comma.
     For instance, to sort search results by downloads and then by creation

--- a/src/olympia/search/tests/test_filters.py
+++ b/src/olympia/search/tests/test_filters.py
@@ -120,7 +120,7 @@ class TestSortingFilter(FilterTestsBase):
 
     def test_sort_default(self):
         qs = self._filter(data={'q': 'something'})
-        assert 'sort' not in qs
+        assert qs['sort'] == [self._reformat_order('-_score')]
 
         qs = self._filter()
         assert qs['sort'] == [self._reformat_order('-weekly_downloads')]
@@ -144,7 +144,7 @@ class TestSortingFilter(FilterTestsBase):
 
         # Same as above but with a search query.
         qs = self._filter(data={'q': 'something', 'sort': 'WRONGLOL'})
-        assert 'sort' not in qs
+        assert qs['sort'] == [self._reformat_order('-_score')]
 
     def test_sort_query_multiple(self):
         qs = self._filter(data={'sort': ['rating,created']})
@@ -372,7 +372,7 @@ class TestCombinedFilter(FilterTestsBase):
         must_not = filtered['filter']['bool']['must_not']
         assert {'term': {'is_disabled': True}} in must_not
 
-        assert 'sort' not in qs
+        assert qs['sort'] == [{'_score': {'order': 'desc'}}]
 
         should = filtered['query']['function_score']['query']['bool']['should']
         expected = {


### PR DESCRIPTION
Also fix docs to explain that sorting by relevance will be the default if a search query is specified.

Fix #4187