### PR TITLE
Add 'Sign In' link to new devhub navigation.

### DIFF
--- a/src/olympia/devhub/templates/devhub/new-landing/components/navigation.html
+++ b/src/olympia/devhub/templates/devhub/new-landing/components/navigation.html
@@ -20,7 +20,7 @@
       {% if user_authenticated %}
         <li class="avatar"><a href="#"><img src="{{ request.user.picture_url }}" /></a></li>
       {% else %}
-        <li class="show-on-desktop"><a href="#">{{ _('Sign In') }}</a></li>
+        <li class="show-on-desktop"><a href="{{ login_link() }}">{{ _('Sign In') }}</a></li>
       {% endif %}
     </ul>
   </div>


### PR DESCRIPTION
Refs #4051 

You can create a new account on the fxa page so there isn't a separate register link.