### PR TITLE
[New Devhub Landing] Fix spacing in navigation.

### DIFF
--- a/static/css/devhub/new-landing/navigation.less
+++ b/static/css/devhub/new-landing/navigation.less
@@ -12,7 +12,7 @@
     width: 100%;
 
     li {
-      margin: 10px 20px;
+      margin: 10px;
 
       &:first-child {
         margin: 0 auto 0 0;


### PR DESCRIPTION
The spacing on desktop was broken.

Before:
![screenshot from 2017-01-09 10-31-32](https://cloud.githubusercontent.com/assets/139033/21762075/02adee5a-d657-11e6-9232-35dc50a81171.png)

After:
![screenshot from 2017-01-09 10-31-51](https://cloud.githubusercontent.com/assets/139033/21762082/08b4bd74-d657-11e6-9b52-df4ffab431d7.png)


This kinda broke when we introduced `box-sizing: border-box;` for all elements.
