### PR TITLE
Use CIRCLE_TAG for version when available

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -70,7 +70,15 @@ RUN npm install \
 
 RUN rm -f settings_local.py settings_local.pyc
 
-RUN GITREF=$(git rev-parse HEAD)                        \
-    GITTAG=$(git name-rev --tags --name-only $GITREF)   \
-    SOURCE='https://github.com/mozilla/addons-server'   \
-    && echo "{\"source\": \"$SOURCE\", \"version\": \"$GITTAG\", \"commit\": \"$GITREF\"}" > version.json
+RUN [[ -z "$CIRCLE_TAG" ]]                                \
+    && {                                                  \
+      GITREF=$(git rev-parse HEAD)                        \
+      GITTAG=$(git name-rev --tags --name-only $GITREF)   \
+      SOURCE='https://github.com/mozilla/addons-server'   \
+      && echo "{\"source\": \"$SOURCE\", \"version\": \"$GITTAG\", \"commit\": \"$GITREF\"}" > version.json ;\
+    } || {                                                \
+      GITREF=$(git rev-parse HEAD)                        \
+      GITTAG=$CIRCLE_TAG                                  \
+      SOURCE='https://github.com/mozilla/addons-server'   \
+      && echo "{\"source\": \"$SOURCE\", \"version\": \"$GITTAG\", \"commit\": \"$GITREF\"}" > version.json ;\
+    }


### PR DESCRIPTION
CircleCI fails to pull the tag sometimes. But the tag is always passed
to CircleCI by GitHub and is recorded in the CIRCLE_TAG environment
variable.