### PR TITLE
Fix stats nav wrapping for non-en locales

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -1265,8 +1265,8 @@ body:not(.developer-hub) section.secondary {
   text-decoration: underline;
 }
 
-.notice.c.author a.download { 
-  text-decoration: none; 
+.notice.c.author a.download {
+  text-decoration: none;
 }
 
 .notice.c.author {
@@ -2123,8 +2123,12 @@ h3.author .transfer-ownership {
     width: 74%;
   }
 
-  .stat-criteria .island.criteria {
-    float: left;
+  .stat-criteria {
+    overflow: auto;
+
+    .island.criteria {
+      float: left;
+    }
   }
 
   .notification-box {


### PR DESCRIPTION
Fixes #2419

Before:

<img alt="tab_mix_plus____statistische_ubersicht____add-ons_fur_firefox" src="https://cloud.githubusercontent.com/assets/1514/21805639/187525f6-d72d-11e6-8046-a0cecc71e781.png">


After: 

<img alt="tab_mix_plus____statistische_ubersicht____add-ons_fur_firefox" src="https://cloud.githubusercontent.com/assets/1514/21805744/b28eb990-d72d-11e6-8677-c47222781ff7.png">
