### PR TITLE
Fix stats display RTL

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -2121,6 +2121,10 @@ h3.author .transfer-ownership {
     float: left;
     margin-left: 0;
     width: 74%;
+
+    .html-rtl& {
+      margin-right: 0;
+    }
   }
 
   .stat-criteria {


### PR DESCRIPTION
Fixes  #4260

Before:

<img width="485" alt="tab_mix_plus____statistics_dashboard____add-ons_for_" src="https://cloud.githubusercontent.com/assets/1514/21855901/f1183e58-d817-11e6-93bc-085e2ccdb448.png">

After:

<img width="530" alt="tab_mix_plus____statistics_dashboard____add-ons_for_" src="https://cloud.githubusercontent.com/assets/1514/21855938/0c6c0edc-d818-11e6-87e3-fb8a75aab170.png">
