### PR TITLE
Escape slashes in generated Google Translate URLs

### DIFF
--- a/src/olympia/reviews/tests/test_views.py
+++ b/src/olympia/reviews/tests/test_views.py
@@ -575,6 +575,18 @@ class TestTranslate(ReviewTest):
         assert r.get('Location') == (
             'https://translate.google.com/#auto/fr/h%C3%A9h%C3%A9%203%25')
 
+    def test_review_with_url_call(self):
+        review = Review.objects.create(addon=self.addon, user=self.user,
+                                       title='or', body='http://example.com')
+        url = helpers.url('addons.reviews.translate',
+                          review.addon.slug, review.id, 'fr')
+        r = self.client.get(url)
+        assert r.status_code == 302
+        # Slashes must be URL-encoded, because Google Translate truncates the
+        # text at the first unescaped slash.
+        assert r.get('Location') == (
+            'https://translate.google.com/#auto/fr/http%3A%2F%2Fexample.com')
+
     @mock.patch('olympia.reviews.views.requests')
     def test_ajax_call(self, requests):
         # Mock requests.

--- a/src/olympia/reviews/views.py
+++ b/src/olympia/reviews/views.py
@@ -127,8 +127,10 @@ def translate(request, addon, review_id, language):
         return http.HttpResponse(json.dumps({'title': title, 'body': body}),
                                  status=r.status_code)
     else:
+        # Override safe='/' to escape slashes too. Otherwise text containing
+        # a slash becomes truncated at that slash.
         return redirect(settings.GOOGLE_TRANSLATE_REDIRECT_URL.format(
-            lang=language, text=urlquote(review.body)))
+            lang=language, text=urlquote(review.body, safe='')))
 
 
 @addon_view


### PR DESCRIPTION
I clicked on the "Translate" link at a review, and noticed that the text and translation was truncated. Probably because of an embedded slash.

Compare:

- https://translate.google.com/#auto/en/http%3A%2F%2Fexample.com (good, text is `http://example.com`)
- https://translate.google.com/#auto/en/http://example.com (bad, text is `http:`)