### PR TITLE
Add separate 'Sign Out' link to navigation, link user profile.

### DIFF
--- a/src/olympia/devhub/templates/devhub/new-landing/components/navigation.html
+++ b/src/olympia/devhub/templates/devhub/new-landing/components/navigation.html
@@ -29,13 +29,15 @@
       </a></li>
 
       {% if user_authenticated %}
-        {# TODO: Not so sure this should be the logout link but where else to put it?
-                 Should probably be user.get_url_path() to point to the user profile #}
-        <li class="avatar"><a href="{{ url('users.logout') }}">
+        <li class="DevHub-Navigation-LogOut"><a href="{{ url('users.logout') }}">
+          {{ _('Sign Out') }}
+        </a></li>
+
+        <li class="avatar"><a href="{{ user.get_url_path() }}">
           <img src="{{ request.user.picture_url }}" alt="{% if not request.user.picture_type %}{{ _('No Photo') }}{% else %}{{ _('User Photo') }}{% endif %}" />
         </a></li>
       {% else %}
-        <li class="show-on-desktop"><a href="{{ login_link() }}">{{ _('Sign In') }}</a></li>
+        <li class="show-on-desktop DevHub-Navigation-LogIn"><a href="{{ login_link() }}">{{ _('Sign In') }}</a></li>
       {% endif %}
     </ul>
   </div>

--- a/static/css/devhub/new-landing/navigation.less
+++ b/static/css/devhub/new-landing/navigation.less
@@ -35,6 +35,16 @@
         }
       }
 
+      &.DevHub-Navigation-LogIn,
+      &.DevHub-Navigation-LogOut {
+        margin-left: 40px;
+
+        html[dir=rtl] & {
+          margin-right: 40px;
+          margin-left: 10px;
+        }
+      }
+
       a {
         color: @color-text;
         text-decoration: none;


### PR DESCRIPTION
Fixes #4288

This also adds the little more margin to the resources links in the navigation.

![screenshot from 2017-01-13 17-59-10](https://cloud.githubusercontent.com/assets/139033/21938222/b2d55dde-d9ba-11e6-8519-8f4dea4b06be.png)
![screenshot from 2017-01-13 17-58-53](https://cloud.githubusercontent.com/assets/139033/21938223/b301bdfc-d9ba-11e6-950a-b33b9fd1d79f.png)
