### PR TITLE
Implement language switcher.

### DIFF
--- a/src/olympia/devhub/templates/devhub/new-landing/components/footer.html
+++ b/src/olympia/devhub/templates/devhub/new-landing/components/footer.html
@@ -94,5 +94,11 @@
         <a href="https://wiki.mozilla.org/Add-ons/Contribute">{{ _('See how') }}</a>
       </section>
     </div>
+
+    <div class="DevHub-Footer-sections DevHub-Footer-LanguageSwitcher">
+      <section class="DevHub-Footer-section">
+        {% include 'includes/lang_switcher.html' %}
+      </section>
+    </div>
   </div>
 </footer>

--- a/src/olympia/devhub/templates/devhub/new-landing/index.html
+++ b/src/olympia/devhub/templates/devhub/new-landing/index.html
@@ -38,6 +38,7 @@
     {% endif %}
 
     {{ js('preload') }}
+    {{ js('common') }}
   </head>
   {% set user_authenticated = request.user.is_authenticated() %}
 

--- a/static/css/devhub/new-landing/footer.less
+++ b/static/css/devhub/new-landing/footer.less
@@ -44,3 +44,15 @@
     }
   }
 }
+
+.DevHub-Footer-LanguageSwitcher {
+  justify-content: flex-end;
+
+  label {
+    display: block;
+    font-size: 16px;
+    font-weight: 400;
+    margin: 10px 0 4px;
+    text-transform: none;
+  }
+}


### PR DESCRIPTION
Unfortunately this now means including 'common' javascript stuff. I
chose to do that instead of just loading the footer-relevant stuff since
I think that all common stuff is usually already in the users cache
anyway.

Fixes #4291

@pwalm this is how it'll look like. Let me know if that's alright or if I should change something (e.g make the label font-size 14px (sub-level footer )heading instead of the current 16px (main footer heading)) - it's adapted from how it currently looks but coloring the label with the link colors in the footer looked weird to me but that could just be me :)

Anyhow, let me know what you think!

![screenshot from 2017-01-16 16-43-09](https://cloud.githubusercontent.com/assets/139033/21989491/590af5f4-dc0b-11e6-8949-da2515f12871.png)
