### PR TITLE
fix arrows

### DIFF
--- a/src/olympia/amo/templates/amo/impala/paginator.html
+++ b/src/olympia/amo/templates/amo/impala/paginator.html
@@ -15,20 +15,20 @@
                   if pager.has_previous() else '#' }}"
          title="{{ _('Jump to first page') }}"
          class="jump{{ ' disabled' if not pager.has_previous() }}">
-        &#x25C2;&#x25C2;</a>
+        &laquo;&laquo;</a>
       <a href="{{ pager.url|urlparams(page=pager.previous_page_number())
                   if pager.has_previous() else '#' }}"
          class="button prev{% if not pager.has_previous() %} disabled{% endif %}">
-        &#x25C2; {{ _('Previous') }}</a>
+        &laquo; {{ _('Previous') }}</a>
       <a href="{{ pager.url|urlparams(page=pager.next_page_number())
                   if pager.has_next() else '#' }}"
          class="button next{% if not pager.has_next() %} disabled{% endif %}">
-        {{ _('Next') }} &#x25B8;</a>
+        {{ _('Next') }} &raquo;</a>
       <a href="{{ pager.url|urlparams(page=pager.paginator.num_pages)
                   if pager.has_next() else '#' }}"
          title="{{ _('Jump to last page') }}"
          class="jump{{ ' disabled' if not pager.has_next() }}">
-        &#x25B8;&#x25B8;</a>
+        &raquo;&raquo;</a>
     </p>
     <p class="pos">
       {# L10n: First and second arguments are the result range (e.g., 1-20);


### PR DESCRIPTION
With &raquo; and &laquo; it looks like this:

<img width="337" alt="screenshot 2017-01-16 15 40 35" src="https://cloud.githubusercontent.com/assets/74699/22002586/19ef4d42-dc02-11e6-8b60-2c65450c510d.png">

Interestingly enough U+25BA and U+25C4 looks consistent on OS X. Probably doesn't work on other platforms though.

<img width="380" alt="screenshot 2017-01-16 15 36 02" src="https://cloud.githubusercontent.com/assets/74699/22002577/032278f0-dc02-11e6-82b1-c65d8c309d4e.png">

