### PR TITLE
Fixed layout issue of "Learn How" button in Dev Hub page

### DIFF
--- a/static/css/devhub/new-landing/common.less
+++ b/static/css/devhub/new-landing/common.less
@@ -263,7 +263,7 @@
   }
 
   .DevHub-content-copy .Button {
-    margin-top: 25px;
+    margin: 25px 0 40px 0;
   }
 
   .DevHub-content-copy--manage .Button {


### PR DESCRIPTION
Fixes #4308 

### Before
<img width="944" alt="before" src="https://cloud.githubusercontent.com/assets/8364578/22010772/79103ef4-dcb5-11e6-9850-006ad917e48b.png">

### After
<img width="941" alt="after" src="https://cloud.githubusercontent.com/assets/8364578/22010780/876c75d0-dcb5-11e6-8c1c-e7ccc2df3d23.png">