### PR TITLE
Hide the beta checkbox when a beta version isn't possible.

### DIFF
--- a/src/olympia/devhub/templates/devhub/addons/submit/upload.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/upload.html
@@ -66,7 +66,7 @@
       </div>
 
     </div>
-    {% if submit_page == 'version' %}
+    {% if submit_page == 'version' and addon.status == amo.STATUS_PUBLIC %}
       <div class="beta-status hide">
         <label>{{ new_addon_form.beta }} {{ _('Only publish this version to my beta channel.') }}</label>
         <span class="tip tooltip" title="{{ new_addon_form.beta.help_text }}">?</span>

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -965,6 +965,12 @@ class VersionSubmitUploadMixin(object):
         doc = pq(response.content)
         assert doc('.beta-status').length
 
+    def test_no_beta_field_when_addon_not_approved(self):
+        self.addon.update(status=amo.STATUS_NULL)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
+        assert not doc('.beta-status').length
+
     def test_url_is_404_for_disabled_addons(self):
         self.addon.update(status=amo.STATUS_DISABLED)
         r = self.client.get(self.url)


### PR DESCRIPTION
fixes #4302 
The status check is the same one in `File.from_upload` fwiw