### PR TITLE
Fix rendering of add-on name and 'edit listing' link on RTL.

### DIFF
--- a/src/olympia/devhub/templates/devhub/new-landing/components/my-addons.html
+++ b/src/olympia/devhub/templates/devhub/new-landing/components/my-addons.html
@@ -53,8 +53,10 @@
           <div class="DevHub-MyAddons-item">
             <img class="DevHub-MyAddons-item-icon" src="{{ addon.get_icon_url(64) }}" alt="">
             <div class="DevHub-MyAddons-item-details">
-              <span class="DevHub-MyAddons-item-name">{{ addon.name }}</span>
-              <a href="{{ addon.get_dev_url('edit') }}">{{ _('Edit Listing') }}</a>
+              <div class="DevHub-MyAddons-item-name">
+                <span>{{ addon.name }}</span>
+                <a href="{{ addon.get_dev_url('edit') }}">{{ _('Edit Listing') }}</a>
+              </div>
 
               <div class="DevHub-MyAddons-item-versions">
                 {% if addon.has_listed_versions() %}

--- a/static/css/devhub/new-landing/sections/my-addons.less
+++ b/static/css/devhub/new-landing/sections/my-addons.less
@@ -55,8 +55,13 @@
 }
 
 .DevHub-MyAddons-item-name {
-  font-size: 24px;
-  font-weight: 400;
+  display: flex;
+  align-items: baseline;
+
+  span {
+    font-size: 24px;
+    font-weight: 400;
+  }
 }
 
 .DevHub-MyAddons-item-channel-listed,

--- a/static/css/devhub/new-landing/sections/my-addons.less
+++ b/static/css/devhub/new-landing/sections/my-addons.less
@@ -85,6 +85,10 @@
 .DevHub-MyAddons-item-icon {
   width: 48px;
   height: 48px;
+
+  html[dir=rtl] & {
+    margin-left: 15px;
+  }
 }
 
 .DevHub-MyAddons-item-versions {


### PR DESCRIPTION
Fixes #4320

After the fix:
![screenshot from 2017-01-18 12-47-35](https://cloud.githubusercontent.com/assets/139033/22062906/5b1babaa-dd7c-11e6-9846-ca52243f595d.png)

![screenshot from 2017-01-18 12-11-43](https://cloud.githubusercontent.com/assets/139033/22061958/a3207e30-dd77-11e6-8298-857b9eeed4d5.png)
