### PR TITLE
Pin amqp to 1.4.9 as required by kombu 3.0.5

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -46,7 +46,7 @@ amo-validator==1.10.49 \
 # amqp is required by kombu
 amqp==1.4.9 \
     --hash=sha256:e0ed0ce6b8ffe5690a2e856c7908dc557e0e605283d6885dd1361d79f2928908 \
-    --hash=sha256:2dea4d16d073c902c3b89d9b96620fb6729ac0f7a923bbc777cb4ad827c0c61a
+    --hash=sha256:2dea4d16d073c902c3b89d9b96620fb6729ac0f7a923bbc777cb4ad827c0c61a # pyup: >=1.4.9,<2.0, requirements by kombu 3.0
 # anyjson is required by kombu
 anyjson==0.3.3 \
     --hash=sha256:37812d863c9ad3e35c0734c42e0bf0320ce8c3bed82cd20ad54cb34d158157ba


### PR DESCRIPTION
Replaces https://github.com/mozilla/addons-server/pull/4332/