### PR TITLE
Pin GitPython to 0.1.7 to not break jingo-minify

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -7,7 +7,7 @@ Django==1.8.17 \
     --hash=sha256:87618c1011712faf7400e2a73315f4f4c3a6e68ab6309c3e642d5fef73d66d9e \
     --hash=sha256:021bd648fcf454027063187e63a1ab4136c6929430ef5dfbe36235f60015eb07 # pyup: >=1.8,<1.9, we're on Long Term Releases
 GitPython==0.1.7 \
-    --hash=sha256:03754bc7b256397c1b646e5048e2291590f5080171adb8b00f4e2d7384c76eee
+    --hash=sha256:03754bc7b256397c1b646e5048e2291590f5080171adb8b00f4e2d7384c76eee # pyup: ==0.1.7, breaks jingo minify and other things
 # Jinja2 is required by Sphinx
 Jinja2==2.8.1 \
     --hash=sha256:3997cf273f1424207c60d5895264f74483fce72702f15a7cd51a8551d43663ca \


### PR DESCRIPTION
Replaces https://github.com/mozilla/addons-server/pull/4333