### PR TITLE
Fix scrollbar issues for signed-in views.

### DIFF
--- a/static/css/devhub/new-landing/base.less
+++ b/static/css/devhub/new-landing/base.less
@@ -65,17 +65,21 @@ img {
   max-width: 100%;
 }
 
-html {
-  // prevent horizontal scrollbars.
-  overflow-x: hidden;
-}
-
 body {
   margin: 0;
   padding: 0;
   display: flex;
   flex-flow: column;
   line-height: 1.35;
+
+  // prevent horizontal scrollbars.
+  overflow-x: hidden;
+
+  &.user-signedin {
+    // But not for our signed-in 'My Addons' section
+    // since this is not supposed to be responsive (yet)
+    overflow-x: auto;
+  }
 }
 
 h1 {


### PR DESCRIPTION
This re-enables horizontal overflow for our 'My Addons' view again.

Fixes #4287 

I hope this doesn't introduce any bugs I didn't anticipate since it's moving the overflow hidden from `html` to `body` but I couldn't think of any problems here.

signed out still works as expected:

![screenshot from 2017-01-18 14-52-29](https://cloud.githubusercontent.com/assets/139033/22066620/12846d34-dd8e-11e6-8b00-adb54b5b2aca.png)

And scroll bars signed-out (as expected for now):
![screenshot from 2017-01-18 14-52-13](https://cloud.githubusercontent.com/assets/139033/22066630/1abf4c8a-dd8e-11e6-83d5-8ad09c24db1c.png)
