### PR TITLE
Add a few more useful badges.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,7 @@
+.. image:: https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg
+    :target: https://github.com/mozilla/addons-server/blob/master/CODE_OF_CONDUCT.md
+    :alt: Code of conduct
+
 .. image:: https://travis-ci.org/mozilla/addons-server.svg?branch=master
     :target: https://travis-ci.org/mozilla/addons-server
 
@@ -5,11 +9,17 @@
     :alt: Buildtime Trend badge
     :target: https://buildtimetrend.herokuapp.com/dashboard/mozilla/addons-server
 
-.. image:: https://requires.io/github/mozilla/addons-server/requirements.svg?branch=master
-    :target: https://requires.io/github/mozilla/addons-server/requirements/?branch=master
+.. image:: https://pyup.io/repos/github/mozilla/addons-server/shield.svg
+    :target: https://pyup.io/repos/github/mozilla/addons-server/
+    :alt: Updates
 
 .. image:: https://codecov.io/gh/mozilla/addons-server/branch/master/graph/badge.svg
-  :target: https://codecov.io/gh/mozilla/addons-server
+    :target: https://codecov.io/gh/mozilla/addons-server
+
+.. image:: https://pyup.io/repos/github/mozilla/addons-server/python-3-shield.svg
+    :target: https://pyup.io/repos/github/mozilla/addons-server/
+    :alt: Python 3
+
 
 Addons-Server
 =============


### PR DESCRIPTION
 * pyup badge ![](https://pyup.io/repos/github/mozilla/addons-server/shield.svg) replaces requires.io plus a steady reminder of Python 3 ![](https://pyup.io/repos/github/mozilla/addons-server/python-3-shield.svg)
 * A more present link to our code of conduct ![code of conduct](https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg)

I wonder if we want something like ![this showing our current tag](https://img.shields.io/github/tag/mozilla/addons-server.svg) that links to http://addons.readthedocs.org/en/latest/server/push-duty.html?

One problem I see with the pyup badge: It's not lying with "insecure" but we cannot upgrade these libs because they either break things horribly (html5lib with two more nines) or don't have a proper release (httplib2)