### PR TITLE
Redirect beta versions detail url to the right version list page

### DIFF
--- a/src/olympia/versions/tests.py
+++ b/src/olympia/versions/tests.py
@@ -599,7 +599,7 @@ class TestViews(TestCase):
         self.addon = addon_factory(
             slug=u'my-addôn', file_kw={'size': 1024},
             version_kw={'version': '1.0'})
-        self.addon.current_version.update(created=self.days_ago(1))
+        self.addon.current_version.update(created=self.days_ago(3))
         self.url_list = reverse('addons.versions', args=[self.addon.slug])
         self.url_list_betas = reverse(
             'addons.beta-versions', args=[self.addon.slug])
@@ -609,16 +609,34 @@ class TestViews(TestCase):
 
     @mock.patch.object(views, 'PER_PAGE', 1)
     def test_version_detail(self):
-        version_factory(addon=self.addon, version='2.0')
+        version = version_factory(addon=self.addon, version='2.0')
+        version.update(created=self.days_ago(2))
+        version = version_factory(addon=self.addon, version='2.1b',
+                                  file_kw={'status': amo.STATUS_BETA})
+        version.update(created=self.days_ago(1))
+        version_factory(addon=self.addon, version='2.2b',
+                        file_kw={'status': amo.STATUS_BETA})
         urls = [(v.version, reverse('addons.versions',
                                     args=[self.addon.slug, v.version]))
                 for v in self.addon.versions.all()]
 
         version, url = urls[0]
+        assert version == '2.2b'
+        r = self.client.get(url, follow=True)
+        self.assert3xx(r, self.url_list_betas + '?page=1#version-%s' % version)
+
+        version, url = urls[1]
+        assert version == '2.1b'
+        r = self.client.get(url, follow=True)
+        self.assert3xx(r, self.url_list_betas + '?page=2#version-%s' % version)
+
+        version, url = urls[2]
+        assert version == '2.0'
         r = self.client.get(url, follow=True)
         self.assert3xx(r, self.url_list + '?page=1#version-%s' % version)
 
-        version, url = urls[1]
+        version, url = urls[3]
+        assert version == '1.0'
         r = self.client.get(url, follow=True)
         self.assert3xx(r, self.url_list + '?page=2#version-%s' % version)
 

--- a/src/olympia/versions/views.py
+++ b/src/olympia/versions/views.py
@@ -27,10 +27,7 @@ addon_view = addon_view_factory(Addon.objects.valid)
 log = commonware.log.getLogger('z.versions')
 
 
-@addon_view
-@mobile_template('versions/{mobile/}version_list.html')
-@non_atomic_requests
-def version_list(request, addon, template, beta=False):
+def _version_list_qs(addon, beta=False):
     # We only show versions that have files with the right status.
     if beta:
         status = amo.STATUS_BETA
@@ -38,9 +35,16 @@ def version_list(request, addon, template, beta=False):
         status = amo.STATUS_AWAITING_REVIEW
     else:
         status = amo.STATUS_PUBLIC
-    qs = (addon.versions.filter(channel=amo.RELEASE_CHANNEL_LISTED)
-          .filter(files__status=status)
-          .distinct().order_by('-created'))
+    return (addon.versions.filter(channel=amo.RELEASE_CHANNEL_LISTED)
+                          .filter(files__status=status)
+                          .distinct().order_by('-created'))
+
+
+@addon_view
+@mobile_template('versions/{mobile/}version_list.html')
+@non_atomic_requests
+def version_list(request, addon, template, beta=False):
+    qs = _version_list_qs(addon, beta=beta)
     versions = amo.utils.paginate(request, qs, PER_PAGE)
     versions.object_list = list(versions.object_list)
     Version.transformer(versions.object_list)
@@ -51,20 +55,22 @@ def version_list(request, addon, template, beta=False):
 @addon_view
 @non_atomic_requests
 def version_detail(request, addon, version_num):
-    qs = (addon.versions.filter(channel=amo.RELEASE_CHANNEL_LISTED)
-          .filter(files__status__in=amo.VALID_FILE_STATUSES)
-          .distinct().order_by('-created'))
+    beta = amo.VERSION_BETA.search(version_num)
+    qs = _version_list_qs(addon, beta=beta)
 
     # Use cached_with since values_list won't be cached.
     def f():
-        return _find_version_page(qs, addon, version_num)
+        return _find_version_page(qs, addon, version_num, beta=beta)
 
     return caching.cached_with(qs, f, 'vd:%s:%s' % (addon.id, version_num))
 
 
-def _find_version_page(qs, addon, version_num):
+def _find_version_page(qs, addon, version_num, beta=False):
+    if beta:
+        url = reverse('addons.beta-versions', args=[addon.slug])
+    else:
+        url = reverse('addons.versions', args=[addon.slug])
     ids = list(qs.values_list('version', flat=True))
-    url = reverse('addons.versions', args=[addon.slug])
     if version_num in ids:
         page = 1 + ids.index(version_num) / PER_PAGE
         to = urlparams(url, 'version-%s' % version_num, page=page)


### PR DESCRIPTION
Fix #4395 