### PR TITLE
Don't include paypal js on pages that don't need it

### DIFF
--- a/src/olympia/addons/templates/addons/impala/details.html
+++ b/src/olympia/addons/templates/addons/impala/details.html
@@ -5,7 +5,9 @@
 
 {% block title %}{{ page_title(addon.name) }}{% endblock %}
 {% block js %}
-  <script async defer src="{{ settings.PAYPAL_JS_URL }}"></script>
+  {% if addon.takes_contributions %}
+    <script async defer src="{{ settings.PAYPAL_JS_URL }}"></script>
+  {% endif %}
 {% endblock %}
 {% block bodyclass %}gutter addon-details {{ super() }}{% endblock %}
 

--- a/src/olympia/addons/templates/addons/impala/developers.html
+++ b/src/olympia/addons/templates/addons/impala/developers.html
@@ -1,9 +1,5 @@
 {% extends "impala/base_shared.html" %}
 
-{% block js %}
-    <script async defer src="{{ settings.PAYPAL_JS_URL }}"></script>
-{% endblock %}
-
 {% if page == 'installed' %}
   {# L10n: {0} is an add-on name. #}
   {% set title = _('Thank you for installing {0}')|fe(addon.name) %}

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -1095,6 +1095,16 @@ class TestImpalaDetailPage(TestCase):
                         application=amo.FIREFOX.id)]
         amo.tests.check_links(expected, links)
 
+    def test_paypal_js_is_present_if_contributions_are_enabled(self):
+        self.addon = Addon.objects.get(id=592)
+        assert self.addon.takes_contributions
+        self.url = self.addon.get_url_path()
+        assert self.get_pq()('script[src="%s"]' % settings.PAYPAL_JS_URL)
+
+    def test_paypal_js_is_absent_if_contributions_are_disabled(self):
+        assert not self.addon.takes_contributions
+        assert not self.get_pq()('script[src="%s"]' % settings.PAYPAL_JS_URL)
+
 
 class TestPersonas(object):
     fixtures = ['addons/persona', 'base/users']

--- a/src/olympia/editors/templates/editors/review.html
+++ b/src/olympia/editors/templates/editors/review.html
@@ -2,7 +2,9 @@
 
 {% block js %}
   {{ super() }}
-  <script async defer src="{{ settings.PAYPAL_JS_URL }}"></script>
+  {% if addon.takes_contributions %}
+    <script async defer src="{{ settings.PAYPAL_JS_URL }}"></script>
+  {% endif %}
 {% endblock %}
 
 {% block title %}

--- a/src/olympia/editors/tests/test_views.py
+++ b/src/olympia/editors/tests/test_views.py
@@ -2401,6 +2401,22 @@ class TestReview(ReviewBase):
         assert (pq(review_page.content)('#review-files').text() ==
                 pq(listed_review_page.content)('#review-files').text())
 
+    def test_paypal_js_is_present_if_contributions_are_enabled(self):
+        # Note: takes_contributions is used to display the button and include
+        # the js, but it only returns True for public add-ons.
+        self.addon.update(
+            paypal_id='xx', wants_contributions=True, status=amo.STATUS_PUBLIC)
+        assert self.addon.takes_contributions
+        response = self.client.get(self.url)
+        doc = pq(response.content)
+        assert doc('script[src="%s"]' % settings.PAYPAL_JS_URL)
+
+    def test_paypal_js_is_absent_if_contributions_are_disabled(self):
+        assert not self.addon.takes_contributions
+        response = self.client.get(self.url)
+        doc = pq(response.content)
+        assert not doc('script[src="%s"]' % settings.PAYPAL_JS_URL)
+
 
 class TestReviewPending(ReviewBase):
 


### PR DESCRIPTION
Fix #4421