### PR TITLE
Fix blank space in navigation for logged in view.

### DIFF
--- a/static/css/devhub/new-landing/navigation.less
+++ b/static/css/devhub/new-landing/navigation.less
@@ -65,6 +65,8 @@
 
   // Schemas:
   &.scheme-light {
+    min-width: @grid-max;
+
     ul li a {
       color: @color-scheme-light-text;
     }


### PR DESCRIPTION
The problem here is that the content below the navigation is not
responsive and has a min-width of @grid-max (960px) but the navigation
shrinks according to the view-port.

This adds a min-width to the navigation for the logged in view.

Fixes #4425