### PR TITLE
Align items in version-details on baseline

### DIFF
--- a/static/css/devhub/new-landing/sections/my-addons.less
+++ b/static/css/devhub/new-landing/sections/my-addons.less
@@ -10,7 +10,7 @@
   display: flex;
   align-items: center;
   border-bottom: 1px solid #e4e4e4;
-  padding-bottom: 25px;
+  padding: 10px 0 25px 0;
 }
 
 .DevHub-MyAddons-item-modified {
@@ -105,6 +105,7 @@
 .DevHub-MyAddons-item-version-details {
   display: flex;
   width: 320px;
+  align-items: baseline;
 }
 
 .DevHub-MyAddons-item-version {


### PR DESCRIPTION
Before:

![screenshot from 2017-01-24 18-28-48](https://cloud.githubusercontent.com/assets/139033/22258795/42fc2090-e263-11e6-84bd-f52172ae3658.png)

After:

![screenshot from 2017-01-25 07-51-22](https://cloud.githubusercontent.com/assets/139033/22280779/4a7b3f16-e2d3-11e6-9598-51aeedd97750.png)


Note the "Awaiting Review" not lining up properly.