### PR TITLE
Replace a bunch of one letter variables in devhub tests

### DIFF
--- a/src/olympia/devhub/tests/test_feeds.py
+++ b/src/olympia/devhub/tests/test_feeds.py
@@ -42,18 +42,18 @@ class TestActivity(HubTest):
 
     def log_collection(self, num, prefix='foo'):
         for i in xrange(num):
-            c = Collection.objects.create(name='%s %d' % (prefix, i))
-            amo.log(amo.LOG.ADD_TO_COLLECTION, self.addon, c)
+            collection = Collection.objects.create(name='%s %d' % (prefix, i))
+            amo.log(amo.LOG.ADD_TO_COLLECTION, self.addon, collection)
 
     def log_tag(self, num, prefix='foo'):
         for i in xrange(num):
-            t = Tag.objects.create(tag_text='%s %d' % (prefix, i))
-            amo.log(amo.LOG.ADD_TAG, self.addon, t)
+            tag = Tag.objects.create(tag_text='%s %d' % (prefix, i))
+            amo.log(amo.LOG.ADD_TAG, self.addon, tag)
 
     def log_review(self, num):
-        r = Review(addon=self.addon)
+        review = Review(addon=self.addon)
         for i in xrange(num):
-            amo.log(amo.LOG.ADD_REVIEW, self.addon, r)
+            amo.log(amo.LOG.ADD_REVIEW, self.addon, review)
 
     def get_response(self, **kwargs):
         url = reverse('devhub.feed_all')
@@ -71,8 +71,8 @@ class TestActivity(HubTest):
     def test_dashboard(self):
         """Make sure the dashboard is getting data."""
         self.log_creates(10)
-        r = self.client.get(reverse('devhub.addons'))
-        doc = pq(r.content)
+        response = self.client.get(reverse('devhub.addons'))
+        doc = pq(response.content)
         assert len(doc('li.item')) == 4
         assert doc('.subscribe-feed').attr('href')[:-32] == (
             reverse('devhub.feed_all') + '?privaterss=')

--- a/src/olympia/devhub/tests/test_forms.py
+++ b/src/olympia/devhub/tests/test_forms.py
@@ -132,7 +132,7 @@ class TestCharityForm(TestCase):
 
     def test_always_new(self):
         # Editing a charity should always produce a new row.
-        params = dict(name='name', url='http://url.com/', paypal='paypal')
+        params = {'name': 'name', 'url': 'http://url.com/', 'paypal': 'paypal'}
         charity = forms.CharityForm(params).save()
         for k, v in params.items():
             assert getattr(charity, k) == v
@@ -154,10 +154,10 @@ class TestCompatForm(TestCase):
     def test_mozilla_app(self):
         moz = amo.MOZILLA
         appver = AppVersion.objects.create(application=moz.id)
-        v = Addon.objects.get(id=3615).current_version
-        ApplicationsVersions(application=moz.id, version=v,
+        version = Addon.objects.get(id=3615).current_version
+        ApplicationsVersions(application=moz.id, version=version,
                              min=appver, max=appver).save()
-        fs = forms.CompatFormSet(None, queryset=v.apps.all())
+        fs = forms.CompatFormSet(None, queryset=version.apps.all())
         apps = [f.app for f in fs.forms]
         assert moz in apps
 

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -53,8 +53,11 @@ class HubTest(TestCase):
         ids = []
         for i in range(num):
             addon = Addon.objects.get(id=addon_id)
-            data = dict(type=addon.type, status=addon.status,
-                        name='cloned-addon-%s-%s' % (addon_id, i))
+            data = {
+                'type': addon.type,
+                'status': addon.status,
+                'name': 'cloned-addon-%s-%s' % (addon_id, i)
+            }
             new_addon = Addon.objects.create(**data)
             new_addon.addonuser_set.create(user=self.user_profile)
             ids.append(new_addon.id)
@@ -64,14 +67,14 @@ class HubTest(TestCase):
 class TestNav(HubTest):
 
     def test_navbar(self):
-        r = self.client.get(self.url)
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         assert doc('#site-nav').length == 1
 
     def test_no_addons(self):
         """Check that no add-ons are displayed for this user."""
-        r = self.client.get(self.url)
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         # My Add-ons menu should not be visible if user has no add-ons.
         assert doc('#navbar ul li.top a').eq(0).text() != 'My Add-ons'
 
@@ -83,8 +86,8 @@ class TestNav(HubTest):
         addon.save()
         addon.addonuser_set.create(user=self.user_profile)
 
-        r = self.client.get(self.url)
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
 
         # Check the anchor for the 'My Add-ons' menu item.
         assert doc('#site-nav ul li.top a').eq(0).text() == 'My Add-ons'
@@ -96,8 +99,8 @@ class TestNav(HubTest):
         # Create 6 add-ons.
         self.clone_addon(6)
 
-        r = self.client.get(self.url)
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
 
         # There should be 8 items in this menu.
         assert doc('#site-nav ul li.top').eq(0).find('ul li').length == 8
@@ -108,8 +111,8 @@ class TestNav(HubTest):
 
         self.clone_addon(1)
 
-        r = self.client.get(self.url)
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         assert doc('#site-nav ul li.top').eq(0).find('li a').eq(7).text() == (
             'more add-ons...')
 
@@ -122,8 +125,8 @@ class TestNav(HubTest):
         self.make_addon_unlisted(addon)
         addon.addonuser_set.create(user=self.user_profile)
 
-        r = self.client.get(self.url)
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
 
         # Check the anchor for the unlisted add-on.
         assert doc('#site-nav ul li.top li a').eq(0).attr('href') == (
@@ -151,16 +154,16 @@ class TestDashboard(HubTest):
         assert doc('#footer-links .mobile-link').length == 0
 
     def get_action_links(self, addon_id):
-        r = self.client.get(self.url)
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         selector = '.item[data-addonid="%s"] .item-actions li > a' % addon_id
         links = [a.text.strip() for a in doc(selector)]
         return links
 
     def test_no_addons(self):
         """Check that no add-ons are displayed for this user."""
-        r = self.client.get(self.url)
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         assert doc('.item item').length == 0
 
     def test_addon_pagination(self):
@@ -172,15 +175,15 @@ class TestDashboard(HubTest):
         """
         # Create 9 add-ons, there's already one existing from the setUp.
         self.clone_addon(9)
-        r = self.client.get(self.url)
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         assert len(doc('.item .item-info')) == 10
         assert doc('nav.paginator').length == 0
 
         # Create 5 add-ons.
         self.clone_addon(5)
-        r = self.client.get(self.url, dict(page=2))
-        doc = pq(r.content)
+        response = self.client.get(self.url, {'page': 2})
+        doc = pq(response.content)
         assert len(doc('.item .item-info')) == 5
         assert doc('nav.paginator').length == 1
 
@@ -190,8 +193,8 @@ class TestDashboard(HubTest):
         for x in range(2):
             addon = addon_factory(type=amo.ADDON_PERSONA)
             addon.addonuser_set.create(user=self.user_profile)
-        r = self.client.get(self.themes_url)
-        doc = pq(r.content)
+        response = self.client.get(self.themes_url)
+        doc = pq(response.content)
         assert len(doc('.item .item-info')) == 2
 
     def test_show_hide_statistics(self):
@@ -243,8 +246,8 @@ class TestDashboard(HubTest):
             bp = BlogPost(title='hi %s' % i,
                           date_posted=datetime.now() - timedelta(days=i))
             bp.save()
-        r = self.client.get(self.url)
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
 
         assert doc('.blog-posts').length == 1
         assert doc('.blog-posts li').length == 5
@@ -255,18 +258,18 @@ class TestDashboard(HubTest):
         response = self.client.get(self.url + '?sort=created')
         doc = pq(response.content)
         assert doc('.item-details').length == 1
-        d = doc('.item-details .date-created')
-        assert d.length == 1
-        assert d.remove('strong').text() == (
+        elm = doc('.item-details .date-created')
+        assert elm.length == 1
+        assert elm.remove('strong').text() == (
             datetime_filter(self.addon.created, '%b %e, %Y'))
 
     def test_sort_updated_filter(self):
         response = self.client.get(self.url)
         doc = pq(response.content)
         assert doc('.item-details').length == 1
-        d = doc('.item-details .date-updated')
-        assert d.length == 1
-        assert d.remove('strong').text() == (
+        elm = doc('.item-details .date-updated')
+        assert elm.length == 1
+        assert elm.remove('strong').text() == (
             trim_whitespace(
                 datetime_filter(self.addon.last_updated, '%b %e, %Y')))
 
@@ -285,8 +288,8 @@ class TestDashboard(HubTest):
         # No "updated" in details.
         assert doc('.item-details .date-updated') == []
         # There's no "last updated" for themes, so always display "created".
-        d = doc('.item-details .date-created')
-        assert d.remove('strong').text() == (
+        elm = doc('.item-details .date-created')
+        assert elm.remove('strong').text() == (
             trim_whitespace(datetime_filter(addon.created)))
 
 
@@ -308,30 +311,31 @@ class TestUpdateCompatibility(TestCase):
     def test_no_compat(self):
         self.client.logout()
         assert self.client.login(email='admin@mozilla.com')
-        r = self.client.get(self.url)
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         assert not doc('.item[data-addonid="4594"] li.compat')
-        a = Addon.objects.get(pk=4594)
-        r = self.client.get(reverse('devhub.ajax.compat.update',
-                                    args=[a.slug, a.current_version.id]))
-        assert r.status_code == 404
-        r = self.client.get(reverse('devhub.ajax.compat.status',
-                                    args=[a.slug]))
-        assert r.status_code == 404
+        addon = Addon.objects.get(pk=4594)
+        response = self.client.get(
+            reverse('devhub.ajax.compat.update',
+                    args=[addon.slug, addon.current_version.id]))
+        assert response.status_code == 404
+        response = self.client.get(
+            reverse('devhub.ajax.compat.status', args=[addon.slug]))
+        assert response.status_code == 404
 
     def test_compat(self):
-        a = Addon.objects.get(pk=3615)
+        addon = Addon.objects.get(pk=3615)
 
-        r = self.client.get(self.url)
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         cu = doc('.item[data-addonid="3615"] .tooltip.compat-update')
         assert cu
 
         update_url = reverse('devhub.ajax.compat.update',
-                             args=[a.slug, a.current_version.id])
+                             args=[addon.slug, addon.current_version.id])
         assert cu.attr('data-updateurl') == update_url
 
-        status_url = reverse('devhub.ajax.compat.status', args=[a.slug])
+        status_url = reverse('devhub.ajax.compat.status', args=[addon.slug])
         selector = '.item[data-addonid="3615"] li.compat'
         assert doc(selector).attr('data-src') == status_url
 
@@ -413,11 +417,11 @@ class TestVersionStats(TestCase):
                                   version=addon.current_version)
 
         url = reverse('devhub.versions.stats', args=[addon.slug])
-        r = json.loads(self.client.get(url).content)
+        data = json.loads(self.client.get(url).content)
         exp = {str(version.id):
                {'reviews': 10, 'files': 1, 'version': version.version,
                 'id': version.id}}
-        self.assertDictEqual(r, exp)
+        self.assertDictEqual(data, exp)
 
 
 class TestEditPayments(TestCase):
@@ -440,8 +444,8 @@ class TestEditPayments(TestCase):
         return Addon.objects.no_cache().get(id=3615)
 
     def post(self, *args, **kw):
-        d = dict(*args, **kw)
-        assert self.client.post(self.url, d).status_code == 302
+        data = dict(*args, **kw)
+        assert self.client.post(self.url, data).status_code == 302
 
     def check(self, **kw):
         addon = self.get_addon()
@@ -469,69 +473,89 @@ class TestEditPayments(TestCase):
                    charity=self.foundation, annoying=amo.CONTRIB_ROADBLOCK)
 
     def test_success_charity(self):
-        d = dict(recipient='org', suggested_amount=11.5,
-                 annoying=amo.CONTRIB_PASSIVE)
-        d.update({'charity-name': 'fligtar fund',
-                  'charity-url': 'http://feed.me',
-                  'charity-paypal': 'greed@org'})
-        self.post(d)
+        data = {
+            'recipient': 'org',
+            'suggested_amount': 11.5,
+            'annoying': amo.CONTRIB_PASSIVE,
+            'charity-name': 'fligtar fund',
+            'charity-url': 'http://feed.me',
+            'charity-paypal': 'greed@org'
+        }
+        self.post(data)
         self.check(paypal_id='', suggested_amount=Decimal('11.50'),
                    charity=Charity.objects.get(name='fligtar fund'))
 
     def test_dev_paypal_id_length(self):
-        r = self.client.get(self.url)
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         assert int(doc('#id_paypal_id').attr('size')) == 50
 
     def test_dev_paypal_reqd(self):
-        d = dict(recipient='dev', suggested_amount=2,
-                 annoying=amo.CONTRIB_PASSIVE)
-        r = self.client.post(self.url, d)
-        self.assertFormError(r, 'contrib_form', 'paypal_id',
+        data = {
+            'recipient': 'dev',
+            'suggested_amount': 2,
+            'annoying': amo.CONTRIB_PASSIVE
+        }
+        response = self.client.post(self.url, data)
+        self.assertFormError(response, 'contrib_form', 'paypal_id',
                              'PayPal ID required to accept contributions.')
 
     def test_bad_paypal_id_dev(self):
         self.paypal_mock.return_value = False, 'error'
-        d = dict(recipient='dev', suggested_amount=2, paypal_id='greed@dev',
-                 annoying=amo.CONTRIB_AFTER)
-        r = self.client.post(self.url, d)
-        self.assertFormError(r, 'contrib_form', 'paypal_id', 'error')
+        data = {
+            'recipient': 'dev',
+            'suggested_amount': 2,
+            'annoying': amo.CONTRIB_AFTER,
+            'paypal_id': 'greed@dev',
+        }
+        response = self.client.post(self.url, data)
+        self.assertFormError(response, 'contrib_form', 'paypal_id', 'error')
 
     def test_bad_paypal_id_charity(self):
         self.paypal_mock.return_value = False, 'error'
-        d = dict(recipient='org', suggested_amount=11.5,
-                 annoying=amo.CONTRIB_PASSIVE)
-        d.update({'charity-name': 'fligtar fund',
-                  'charity-url': 'http://feed.me',
-                  'charity-paypal': 'greed@org'})
-        r = self.client.post(self.url, d)
-        self.assertFormError(r, 'charity_form', 'paypal', 'error')
+        data = {
+            'recipient': 'org',
+            'suggested_amount': 11.5,
+            'annoying': amo.CONTRIB_PASSIVE,
+            'charity-name': 'fligtar fund',
+            'charity-url': 'http://feed.me',
+            'charity-paypal': 'greed@org'
+        }
+        response = self.client.post(self.url, data)
+        self.assertFormError(response, 'charity_form', 'paypal', 'error')
 
     def test_paypal_timeout(self):
         self.paypal_mock.side_effect = socket.timeout()
-        d = dict(recipient='dev', suggested_amount=2, paypal_id='greed@dev',
-                 annoying=amo.CONTRIB_AFTER)
-        r = self.client.post(self.url, d)
-        self.assertFormError(r, 'contrib_form', 'paypal_id',
+        data = {
+            'recipient': 'dev',
+            'suggested_amount': 2,
+            'paypal_id': 'greed@dev',
+            'annoying': amo.CONTRIB_AFTER
+        }
+        response = self.client.post(self.url, data)
+        self.assertFormError(response, 'contrib_form', 'paypal_id',
                              'Could not validate PayPal id.')
 
     def test_max_suggested_amount(self):
         too_much = settings.MAX_CONTRIBUTION + 1
         msg = ('Please enter a suggested amount less than $%d.' %
                settings.MAX_CONTRIBUTION)
-        r = self.client.post(self.url, {'suggested_amount': too_much})
-        self.assertFormError(r, 'contrib_form', 'suggested_amount', msg)
+        response = self.client.post(self.url, {'suggested_amount': too_much})
+        self.assertFormError(response, 'contrib_form', 'suggested_amount', msg)
 
     def test_neg_suggested_amount(self):
         msg = 'Please enter a suggested amount greater than 0.'
-        r = self.client.post(self.url, {'suggested_amount': -1})
-        self.assertFormError(r, 'contrib_form', 'suggested_amount', msg)
+        response = self.client.post(self.url, {'suggested_amount': -1})
+        self.assertFormError(response, 'contrib_form', 'suggested_amount', msg)
 
     def test_charity_details_reqd(self):
-        d = dict(recipient='org', suggested_amount=11.5,
-                 annoying=amo.CONTRIB_PASSIVE)
-        r = self.client.post(self.url, d)
-        self.assertFormError(r, 'charity_form', 'name',
+        data = {
+            'recipient': 'org',
+            'suggested_amount': 11.5,
+            'annoying': amo.CONTRIB_PASSIVE
+        }
+        response = self.client.post(self.url, data)
+        self.assertFormError(response, 'charity_form', 'name',
                              'This field is required.')
         assert self.get_addon().suggested_amount is None
 
@@ -570,70 +594,82 @@ class TestEditPayments(TestCase):
             amo.CONTRIB_AFTER)
 
     def test_enable_thankyou(self):
-        d = dict(enable_thankyou='on', thankyou_note='woo',
-                 annoying=1, recipient='moz')
-        r = self.client.post(self.url, d)
-        assert r.status_code == 302
+        data = {
+            'enable_thankyou': 'on',
+            'thankyou_note': 'woo',
+            'annoying': 1,
+            'recipient': 'moz'
+        }
+        response = self.client.post(self.url, data)
+        assert response.status_code == 302
         addon = self.get_addon()
         assert addon.enable_thankyou
         assert unicode(addon.thankyou_note) == 'woo'
 
     def test_enable_thankyou_unchecked_with_text(self):
-        d = dict(enable_thankyou='', thankyou_note='woo',
-                 annoying=1, recipient='moz')
-        r = self.client.post(self.url, d)
-        assert r.status_code == 302
+        data = {
+            'enable_thankyou': '',
+            'thankyou_note': 'woo',
+            'annoying': 1,
+            'recipient': 'moz'
+        }
+        response = self.client.post(self.url, data)
+        assert response.status_code == 302
         addon = self.get_addon()
         assert not addon.enable_thankyou
         assert addon.thankyou_note is None
 
     def test_contribution_link(self):
         self.test_success_foundation()
-        r = self.client.get(self.url)
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
 
         span = doc('#status-bar').find('span')
         assert span.length == 1
         assert span.text().startswith('Your contribution page: ')
 
-        a = span.find('a')
-        assert a.length == 1
-        assert a.attr('href') == reverse(
+        link = span.find('a')
+        assert link.length == 1
+        assert link.attr('href') == reverse(
             'addons.about', args=[self.get_addon().slug])
-        assert a.text() == url_reverse(
+        assert link.text() == url_reverse(
             'addons.about', self.get_addon().slug, host=settings.SITE_URL)
 
     def test_enable_thankyou_no_text(self):
-        d = dict(enable_thankyou='on', thankyou_note='',
-                 annoying=1, recipient='moz')
-        r = self.client.post(self.url, d)
-        assert r.status_code == 302
+        data = {
+            'enable_thankyou': 'on',
+            'thankyou_note': '',
+            'annoying': 1,
+            'recipient': 'moz'
+        }
+        response = self.client.post(self.url, data)
+        assert response.status_code == 302
         addon = self.get_addon()
         assert not addon.enable_thankyou
         assert addon.thankyou_note is None
 
     def test_no_future(self):
         self.get_addon().update(the_future=None)
-        res = self.client.get(self.url)
-        err = pq(res.content)('p.error').text()
-        assert 'completed developer profile' in err
+        response = self.client.get(self.url)
+        error_msg = pq(response.content)('p.error').text()
+        assert 'completed developer profile' in error_msg
 
     def test_addon_public(self):
         self.get_addon().update(status=amo.STATUS_PUBLIC)
-        res = self.client.get(self.url)
-        doc = pq(res.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         assert doc('#do-setup').text() == 'Set up Contributions'
 
     def test_voluntary_contributions_addons(self):
-        r = self.client.get(self.url)
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         assert doc('.intro').length == 1
         assert doc('.intro.full-intro').length == 0
 
     def test_no_voluntary_contributions_for_unlisted_addons(self):
         self.make_addon_unlisted(self.addon)
-        r = self.client.get(self.url)
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         assert doc('.intro').length == 1
         assert doc('.intro.full-intro').length == 0
         assert not doc('#do-setup')  # No way to setup the payment.
@@ -655,17 +691,17 @@ class TestDisablePayments(TestCase):
         assert self.client.login(email='del@icio.us')
 
     def test_statusbar_visible(self):
-        r = self.client.get(self.pay_url)
-        self.assertContains(r, '<div id="status-bar">')
+        response = self.client.get(self.pay_url)
+        self.assertContains(response, '<div id="status-bar">')
 
         self.addon.update(wants_contributions=False)
-        r = self.client.get(self.pay_url)
-        self.assertNotContains(r, '<div id="status-bar">')
+        response = self.client.get(self.pay_url)
+        self.assertNotContains(response, '<div id="status-bar">')
 
     def test_disable(self):
-        r = self.client.post(self.disable_url)
-        assert r.status_code == 302
-        assert(r['Location'].endswith(self.pay_url))
+        response = self.client.post(self.disable_url)
+        assert response.status_code == 302
+        assert(response['Location'].endswith(self.pay_url))
         assert not Addon.objects.no_cache().get(id=3615).wants_contributions
 
 
@@ -674,11 +710,15 @@ class TestPaymentsProfile(TestCase):
 
     def setUp(self):
         super(TestPaymentsProfile, self).setUp()
-        self.addon = a = self.get_addon()
+        self.addon = self.get_addon()
         self.url = self.addon.get_dev_url('payments')
         # Make sure all the payment/profile data is clear.
-        assert not (a.wants_contributions or a.paypal_id or a.the_reason or
-                    a.the_future or a.takes_contributions)
+        assert not (
+            self.addon.wants_contributions or
+            self.addon.paypal_id or
+            self.addon.the_reason or
+            self.addon.the_future or
+            self.addon.takes_contributions)
         assert self.client.login(email='del@icio.us')
         self.paypal_mock = mock.Mock()
         self.paypal_mock.return_value = (True, None)
@@ -704,11 +744,16 @@ class TestPaymentsProfile(TestCase):
         assert doc('#trans-the_future')
 
     def test_profile_form_success(self):
-        d = dict(recipient='dev', suggested_amount=2, paypal_id='xx@yy',
-                 annoying=amo.CONTRIB_ROADBLOCK, the_reason='xxx',
-                 the_future='yyy')
-        r = self.client.post(self.url, d)
-        assert r.status_code == 302
+        data = {
+            'recipient': 'dev',
+            'suggested_amount': 2,
+            'paypal_id': 'xx@yy',
+            'annoying': amo.CONTRIB_ROADBLOCK,
+            'the_reason': 'xxx',
+            'the_future': 'yyy'
+        }
+        response = self.client.post(self.url, data)
+        assert response.status_code == 302
 
         # The profile form is gone, we're accepting contributions.
         doc = pq(self.client.get(self.url).content)
@@ -732,24 +777,33 @@ class TestPaymentsProfile(TestCase):
             assert doc('#trans-the_reason')
             assert doc('#trans-the_future')
 
-        d = dict(recipient='dev', suggested_amount=2, paypal_id='xx@yy',
-                 annoying=amo.CONTRIB_ROADBLOCK)
-        r = self.client.post(self.url, d)
-        assert r.status_code == 200
-        self.assertFormError(r, 'profile_form', 'the_reason',
+        data = {
+            'recipient': 'dev',
+            'suggested_amount': 2,
+            'paypal_id': 'xx@yy',
+            'annoying': amo.CONTRIB_ROADBLOCK
+        }
+        response = self.client.post(self.url, data)
+        assert response.status_code == 200
+        self.assertFormError(response, 'profile_form', 'the_reason',
                              'This field is required.')
-        self.assertFormError(r, 'profile_form', 'the_future',
+        self.assertFormError(response, 'profile_form', 'the_future',
                              'This field is required.')
-        check_page(r)
+        check_page(response)
         assert not self.get_addon().wants_contributions
 
-        d = dict(recipient='dev', suggested_amount=2, paypal_id='xx@yy',
-                 annoying=amo.CONTRIB_ROADBLOCK, the_reason='xxx')
-        r = self.client.post(self.url, d)
-        assert r.status_code == 200
-        self.assertFormError(r, 'profile_form', 'the_future',
+        data = {
+            'recipient': 'dev',
+            'suggested_amount': 2,
+            'paypal_id': 'xx@yy',
+            'annoying': amo.CONTRIB_ROADBLOCK,
+            'the_reason': 'xxx'
+        }
+        response = self.client.post(self.url, data)
+        assert response.status_code == 200
+        self.assertFormError(response, 'profile_form', 'the_future',
                              'This field is required.')
-        check_page(r)
+        check_page(response)
         assert not self.get_addon().wants_contributions
 
 
@@ -770,38 +824,40 @@ class TestDelete(TestCase):
         return theme
 
     def test_post_not(self):
-        r = self.client.post(self.get_url(), follow=True)
-        assert pq(r.content)('.notification-box').text() == (
+        response = self.client.post(self.get_url(), follow=True)
+        assert pq(response.content)('.notification-box').text() == (
             'URL name was incorrect. Add-on was not deleted.')
         assert self.get_addon().exists()
 
     def test_post(self):
         self.get_addon().get().update(slug='addon-slug')
-        r = self.client.post(self.get_url(), {'slug': 'addon-slug'},
-                             follow=True)
-        assert pq(r.content)('.notification-box').text() == 'Add-on deleted.'
+        response = self.client.post(self.get_url(), {'slug': 'addon-slug'},
+                                    follow=True)
+        assert pq(response.content)('.notification-box').text() == (
+            'Add-on deleted.')
         assert not self.get_addon().exists()
 
     def test_post_wrong_slug(self):
         self.get_addon().get().update(slug='addon-slug')
-        r = self.client.post(self.get_url(), {'slug': 'theme-slug'},
-                             follow=True)
-        assert pq(r.content)('.notification-box').text() == (
+        response = self.client.post(self.get_url(), {'slug': 'theme-slug'},
+                                    follow=True)
+        assert pq(response.content)('.notification-box').text() == (
             'URL name was incorrect. Add-on was not deleted.')
         assert self.get_addon().exists()
 
     def test_post_theme(self):
         theme = self.make_theme()
-        r = self.client.post(
+        response = self.client.post(
             theme.get_dev_url('delete'), {'slug': 'theme-slug'}, follow=True)
-        assert pq(r.content)('.notification-box').text() == 'Theme deleted.'
+        assert pq(response.content)('.notification-box').text() == (
+            'Theme deleted.')
         assert not Addon.objects.filter(id=theme.id).exists()
 
     def test_post_theme_wrong_slug(self):
         theme = self.make_theme()
-        r = self.client.post(
+        response = self.client.post(
             theme.get_dev_url('delete'), {'slug': 'addon-slug'}, follow=True)
-        assert pq(r.content)('.notification-box').text() == (
+        assert pq(response.content)('.notification-box').text() == (
             'URL name was incorrect. Theme was not deleted.')
         assert Addon.objects.filter(id=theme.id).exists()
 
@@ -816,14 +872,14 @@ class TestHome(TestCase):
         self.addon = Addon.objects.get(pk=3615)
 
     def get_pq(self):
-        r = self.client.get(self.url)
-        assert r.status_code == 200
-        return pq(r.content)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        return pq(response.content)
 
     def test_addons(self):
-        r = self.client.get(self.url)
-        assert r.status_code == 200
-        self.assertTemplateUsed(r, 'devhub/index.html')
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        self.assertTemplateUsed(response, 'devhub/index.html')
 
     def test_editor_promo(self):
         assert self.get_pq()('#devhub-sidebar #editor-promo').length == 1
@@ -943,27 +999,30 @@ class TestActivityFeed(TestCase):
         self.version = self.addon.versions.first()
 
     def test_feed_for_all(self):
-        r = self.client.get(reverse('devhub.feed_all'))
-        assert r.status_code == 200
-        doc = pq(r.content)
+        response = self.client.get(reverse('devhub.feed_all'))
+        assert response.status_code == 200
+        doc = pq(response.content)
         assert doc('header h2').text() == 'Recent Activity for My Add-ons'
 
     def test_feed_for_addon(self):
-        r = self.client.get(reverse('devhub.feed', args=[self.addon.slug]))
-        assert r.status_code == 200
-        doc = pq(r.content)
+        response = self.client.get(
+            reverse('devhub.feed', args=[self.addon.slug]))
+        assert response.status_code == 200
+        doc = pq(response.content)
         assert doc('header h2').text() == (
             'Recent Activity for %s' % self.addon.name)
 
     def test_feed_disabled(self):
         self.addon.update(status=amo.STATUS_DISABLED)
-        r = self.client.get(reverse('devhub.feed', args=[self.addon.slug]))
-        assert r.status_code == 200
+        response = self.client.get(
+            reverse('devhub.feed', args=[self.addon.slug]))
+        assert response.status_code == 200
 
     def test_feed_disabled_anon(self):
         self.client.logout()
-        r = self.client.get(reverse('devhub.feed', args=[self.addon.slug]))
-        assert r.status_code == 302
+        response = self.client.get(
+            reverse('devhub.feed', args=[self.addon.slug]))
+        assert response.status_code == 302
 
     def add_log(self, action=amo.LOG.ADD_REVIEW):
         amo.set_user(UserProfile.objects.get(email='del@icio.us'))
@@ -1039,8 +1098,8 @@ class TestProfileBase(TestCase):
         self.addon.save()
 
     def post(self, *args, **kw):
-        d = dict(*args, **kw)
-        assert self.client.post(self.url, d).status_code == 302
+        data = dict(*args, **kw)
+        assert self.client.post(self.url, data).status_code == 302
 
     def check(self, **kw):
         addon = self.get_addon()
@@ -1115,9 +1174,9 @@ class TestProfileStatusBar(TestProfileBase):
 class TestProfile(TestProfileBase):
 
     def test_without_contributions_labels(self):
-        r = self.client.get(self.url)
-        assert r.status_code == 200
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
         assert doc('label[for=the_reason] .optional').length == 1
         assert doc('label[for=the_future] .optional').length == 1
 
@@ -1136,8 +1195,8 @@ class TestProfile(TestProfileBase):
 
     def test_with_contributions_labels(self):
         self.enable_addon_contributions()
-        r = self.client.get(self.url)
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         assert doc('label[for=the_reason] .req').length, (
             'the_reason field should be required.')
         assert doc('label[for=the_future] .req').length, (
@@ -1145,33 +1204,33 @@ class TestProfile(TestProfileBase):
 
     def test_log(self):
         self.enable_addon_contributions()
-        d = dict(the_reason='because', the_future='i can')
-        o = ActivityLog.objects
-        assert o.count() == 0
-        self.client.post(self.url, d)
-        assert o.filter(action=amo.LOG.EDIT_PROPERTIES.id).count() == 1
+        data = {'the_reason': 'because', 'the_future': 'i can'}
+        assert ActivityLog.objects.count() == 0
+        self.client.post(self.url, data)
+        assert ActivityLog.objects.filter(
+            action=amo.LOG.EDIT_PROPERTIES.id).count() == 1
 
     def test_with_contributions_fields_required(self):
         self.enable_addon_contributions()
 
-        d = dict(the_reason='', the_future='')
-        r = self.client.post(self.url, d)
-        assert r.status_code == 200
-        self.assertFormError(r, 'profile_form', 'the_reason',
+        data = {'the_reason': '', 'the_future': ''}
+        response = self.client.post(self.url, data)
+        assert response.status_code == 200
+        self.assertFormError(response, 'profile_form', 'the_reason',
                              'This field is required.')
-        self.assertFormError(r, 'profile_form', 'the_future',
-                             'This field is required.')
-
-        d = dict(the_reason='to be cool', the_future='')
-        r = self.client.post(self.url, d)
-        assert r.status_code == 200
-        self.assertFormError(r, 'profile_form', 'the_future',
+        self.assertFormError(response, 'profile_form', 'the_future',
                              'This field is required.')
 
-        d = dict(the_reason='', the_future='hot stuff')
-        r = self.client.post(self.url, d)
-        assert r.status_code == 200
-        self.assertFormError(r, 'profile_form', 'the_reason',
+        data = {'the_reason': 'to be cool', 'the_future': ''}
+        response = self.client.post(self.url, data)
+        assert response.status_code == 200
+        self.assertFormError(response, 'profile_form', 'the_future',
+                             'This field is required.')
+
+        data = {'the_reason': '', 'the_future': 'hot stuff'}
+        response = self.client.post(self.url, data)
+        assert response.status_code == 200
+        self.assertFormError(response, 'profile_form', 'the_reason',
                              'This field is required.')
 
         self.post(the_reason='to be hot', the_future='cold stuff')
@@ -1298,8 +1357,8 @@ class TestUpload(BaseUploadTest):
 
     def test_login_required(self):
         self.client.logout()
-        r = self.post()
-        assert r.status_code == 302
+        response = self.post()
+        assert response.status_code == 302
 
     def test_create_fileupload(self):
         self.post()
@@ -1333,12 +1392,10 @@ class TestUpload(BaseUploadTest):
         assert not msg['description'], 'Found unexpected description.'
 
     def test_redirect(self):
-        r = self.post()
+        response = self.post()
         upload = FileUpload.objects.get()
-        url = reverse(
-            'devhub.upload_detail',
-            args=[upload.uuid.hex, 'json'])
-        self.assert3xx(r, url)
+        url = reverse('devhub.upload_detail', args=[upload.uuid.hex, 'json'])
+        self.assert3xx(response, url)
 
     @mock.patch('validator.validate.validate')
     def test_upload_unlisted_addon(self, validate_mock):
@@ -1384,18 +1441,18 @@ class TestUploadDetail(BaseUploadTest):
         addon = os.path.join(
             settings.ROOT, 'src', 'olympia', 'devhub', 'tests', 'addons', file)
         with open(addon, 'rb') as f:
-            r = self.client.post(reverse('devhub.upload'),
-                                 {'upload': f})
-        assert r.status_code == 302
+            response = self.client.post(
+                reverse('devhub.upload'), {'upload': f})
+        assert response.status_code == 302
 
     def test_detail_json(self):
         self.post()
 
         upload = FileUpload.objects.get()
-        r = self.client.get(reverse('devhub.upload_detail',
-                                    args=[upload.uuid.hex, 'json']))
-        assert r.status_code == 200
-        data = json.loads(r.content)
+        response = self.client.get(reverse('devhub.upload_detail',
+                                   args=[upload.uuid.hex, 'json']))
+        assert response.status_code == 200
+        data = json.loads(response.content)
         assert data['validation']['errors'] == 2
         assert data['url'] == (
             reverse('devhub.upload_detail', args=[upload.uuid.hex, 'json']))
@@ -1446,19 +1503,19 @@ class TestUploadDetail(BaseUploadTest):
         self.upload_file('valid_webextension.xpi')
 
         upload = FileUpload.objects.get()
-        r = self.client.get(reverse('devhub.upload_detail',
-                                    args=[upload.uuid.hex, 'json']))
-        assert r.status_code == 200
-        data = json.loads(r.content)
+        response = self.client.get(
+            reverse('devhub.upload_detail', args=[upload.uuid.hex, 'json']))
+        assert response.status_code == 200
+        data = json.loads(response.content)
         assert data['processed_by_addons_linter'] is True
 
     def test_detail_view(self):
         self.post()
         upload = FileUpload.objects.filter().order_by('-created').first()
-        r = self.client.get(reverse('devhub.upload_detail',
-                                    args=[upload.uuid.hex]))
-        assert r.status_code == 200
-        doc = pq(r.content)
+        response = self.client.get(
+            reverse('devhub.upload_detail', args=[upload.uuid.hex]))
+        assert response.status_code == 200
+        doc = pq(response.content)
         expected = 'Validation Results for animated.png'
         assert doc('header h2').text() == expected
 
@@ -1473,10 +1530,10 @@ class TestUploadDetail(BaseUploadTest):
         v.return_value = json.dumps(self.validation_ok())
         self.upload_file(xpi)
         upload = FileUpload.objects.get()
-        r = self.client.get(reverse('devhub.upload_detail',
-                                    args=[upload.uuid.hex, 'json']))
-        assert r.status_code == 200
-        data = json.loads(r.content)
+        response = self.client.get(
+            reverse('devhub.upload_detail', args=[upload.uuid.hex, 'json']))
+        assert response.status_code == 200
+        data = json.loads(response.content)
         assert sorted(data['platforms_to_exclude']) == sorted(platforms)
 
     def test_multi_app_addon_can_have_all_platforms(self):
@@ -1532,9 +1589,9 @@ class TestUploadDetail(BaseUploadTest):
         """
         self.upload_file('valid_webextension_no_version.xpi')
         upload = FileUpload.objects.get()
-        r = self.client.get(reverse('devhub.upload_detail',
-                                    args=[upload.uuid.hex, 'json']))
-        data = json.loads(r.content)
+        response = self.client.get(
+            reverse('devhub.upload_detail', args=[upload.uuid.hex, 'json']))
+        data = json.loads(response.content)
         message = [(m['message'], m.get('type') == 'error')
                    for m in data['validation']['messages']]
         expected = [(u'&#34;/version&#34; is a required property', True)]
@@ -1547,9 +1604,9 @@ class TestUploadDetail(BaseUploadTest):
         v.return_value = json.dumps(self.validation_ok())
         self.upload_file('unopenable.xpi')
         upload = FileUpload.objects.get()
-        r = self.client.get(reverse('devhub.upload_detail',
-                                    args=[upload.uuid.hex, 'json']))
-        data = json.loads(r.content)
+        response = self.client.get(
+            reverse('devhub.upload_detail', args=[upload.uuid.hex, 'json']))
+        data = json.loads(response.content)
         message = [(m['message'], m.get('fatal', False))
                    for m in data['validation']['messages']]
         assert message == [(u'Could not parse the manifest file.', True)]
@@ -1627,10 +1684,11 @@ class TestQueuePosition(TestCase):
         version_files.save()
 
     def test_not_in_queue(self):
-        r = self.client.get(self.addon.get_dev_url('versions'))
+        response = self.client.get(self.addon.get_dev_url('versions'))
 
         assert self.addon.status == amo.STATUS_PUBLIC
-        assert pq(r.content)('.version-status-actions .dark').length == 0
+        assert (
+            pq(response.content)('.version-status-actions .dark').length == 0)
 
     def test_in_queue(self):
         statuses = [(amo.STATUS_NOMINATED, amo.STATUS_AWAITING_REVIEW),
@@ -1646,8 +1704,8 @@ class TestQueuePosition(TestCase):
             file.status = addon_status[1]
             file.save()
 
-            r = self.client.get(self.addon.get_dev_url('versions'))
-            doc = pq(r.content)
+            response = self.client.get(self.addon.get_dev_url('versions'))
+            doc = pq(response.content)
 
             span = doc('.queue-position')
 
@@ -1669,10 +1727,10 @@ class TestVersionXSS(TestCase):
         # encountered.
         self.version.update(
             version='<script>alert("Happy XSS-Xmas");<script>')
-        r = self.client.get(reverse('devhub.addons'))
-        assert r.status_code == 200
-        assert '<script>alert' not in r.content
-        assert '&lt;script&gt;alert' in r.content
+        response = self.client.get(reverse('devhub.addons'))
+        assert response.status_code == 200
+        assert '<script>alert' not in response.content
+        assert '&lt;script&gt;alert' in response.content
 
 
 class TestDeleteAddon(TestCase):
@@ -1685,16 +1743,16 @@ class TestDeleteAddon(TestCase):
         self.client.login(email='admin@mozilla.com')
 
     def test_bad_password(self):
-        r = self.client.post(self.url, dict(slug='nope'))
-        self.assert3xx(r, self.addon.get_dev_url('versions'))
-        assert r.context['title'] == (
+        response = self.client.post(self.url, {'slug': 'nope'})
+        self.assert3xx(response, self.addon.get_dev_url('versions'))
+        assert response.context['title'] == (
             'URL name was incorrect. Add-on was not deleted.')
         assert Addon.objects.count() == 1
 
     def test_success(self):
-        r = self.client.post(self.url, dict(slug='a3615'))
-        self.assert3xx(r, reverse('devhub.addons'))
-        assert r.context['title'] == 'Add-on deleted.'
+        response = self.client.post(self.url, {'slug': 'a3615'})
+        self.assert3xx(response, reverse('devhub.addons'))
+        assert response.context['title'] == 'Add-on deleted.'
         assert Addon.objects.count() == 0
 
 
@@ -1720,13 +1778,13 @@ class TestRequestReview(TestCase):
 
     def check(self, old_status, url, new_status):
         self.addon.update(status=old_status)
-        r = self.client.post(url)
-        self.assert3xx(r, self.redirect_url)
+        response = self.client.post(url)
+        self.assert3xx(response, self.redirect_url)
         assert self.get_addon().status == new_status
 
     def check_400(self, url):
-        r = self.client.post(url)
-        assert r.status_code == 400
+        response = self.client.post(url)
+        assert response.status_code == 400
 
     def test_public(self):
         self.addon.update(status=amo.STATUS_PUBLIC)
@@ -1768,24 +1826,26 @@ class TestRedirects(TestCase):
 
     def test_edit(self):
         url = self.base + 'addon/edit/3615'
-        r = self.client.get(url, follow=True)
-        self.assert3xx(r, reverse('devhub.addons.edit', args=['a3615']), 301)
+        response = self.client.get(url, follow=True)
+        self.assert3xx(
+            response, reverse('devhub.addons.edit', args=['a3615']), 301)
 
         url = self.base + 'addon/edit/3615/'
-        r = self.client.get(url, follow=True)
-        self.assert3xx(r, reverse('devhub.addons.edit', args=['a3615']), 301)
+        response = self.client.get(url, follow=True)
+        self.assert3xx(
+            response, reverse('devhub.addons.edit', args=['a3615']), 301)
 
     def test_status(self):
         url = self.base + 'addon/status/3615'
-        r = self.client.get(url, follow=True)
-        self.assert3xx(r, reverse('devhub.addons.versions',
-                                  args=['a3615']), 301)
+        response = self.client.get(url, follow=True)
+        self.assert3xx(
+            response, reverse('devhub.addons.versions', args=['a3615']), 301)
 
     def test_versions(self):
         url = self.base + 'versions/3615'
-        r = self.client.get(url, follow=True)
-        self.assert3xx(r, reverse('devhub.addons.versions',
-                                  args=['a3615']), 301)
+        response = self.client.get(url, follow=True)
+        self.assert3xx(
+            response, reverse('devhub.addons.versions', args=['a3615']), 301)
 
 
 class TestHasCompleteMetadataRedirects(TestCase):
@@ -1859,11 +1919,11 @@ class TestDocs(TestCase):
         index = reverse('devhub.index')
 
         for url in urls:
-            r = self.client.get(url[0])
-            assert r.status_code == url[1]
+            response = self.client.get(url[0])
+            assert response.status_code == url[1]
 
             if url[1] == 302:  # Redirect to the index page
-                self.assert3xx(r, index)
+                self.assert3xx(response, index)
 
 
 class TestRemoveLocale(TestCase):
@@ -1876,8 +1936,8 @@ class TestRemoveLocale(TestCase):
         assert self.client.login(email='del@icio.us')
 
     def test_bad_request(self):
-        r = self.client.post(self.url)
-        assert r.status_code == 400
+        response = self.client.post(self.url)
+        assert response.status_code == 400
 
     def test_success(self):
         self.addon.name = {'en-US': 'woo', 'el': 'yeah'}
@@ -1885,13 +1945,14 @@ class TestRemoveLocale(TestCase):
         self.addon.remove_locale('el')
         qs = (Translation.objects.filter(localized_string__isnull=False)
               .values_list('locale', flat=True))
-        r = self.client.post(self.url, {'locale': 'el'})
-        assert r.status_code == 200
+        response = self.client.post(self.url, {'locale': 'el'})
+        assert response.status_code == 200
         assert sorted(qs.filter(id=self.addon.name_id)) == ['en-US']
 
     def test_delete_default_locale(self):
-        r = self.client.post(self.url, {'locale': self.addon.default_locale})
-        assert r.status_code == 400
+        response = self.client.post(
+            self.url, {'locale': self.addon.default_locale})
+        assert response.status_code == 400
 
     def test_remove_version_locale(self):
         version = self.addon.versions.all()[0]
@@ -1936,16 +1997,16 @@ class TestNewDevHubLanding(TestCase):
         self.create_flag('new-devhub-landing')
 
     def get_pq(self):
-        r = self.client.get(self.url)
-        assert r.status_code == 200
-        return pq(r.content)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        return pq(response.content)
 
     def test_basic(self):
-        r = self.client.get(self.url)
-        assert r.status_code == 200
+        response = self.client.get(self.url)
+        assert response.status_code == 200
         # The actual switch happens in the template, so we're using the same
         # template.
-        self.assertTemplateUsed(r, 'devhub/index.html')
+        self.assertTemplateUsed(response, 'devhub/index.html')
 
     def test_waffle_flag_inactive(self):
         Flag.objects.filter(name='new-devhub-landing').delete()

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -52,9 +52,9 @@ class BaseTestEdit(TestCase):
         addon = self.get_addon()
         if self.listed:
             self.make_addon_listed(addon)
-            a = AddonCategory.objects.filter(addon=addon, category__id=22)[0]
-            a.feature = False
-            a.save()
+            ac = AddonCategory.objects.filter(addon=addon, category__id=22)[0]
+            ac.feature = False
+            ac.save()
             AddonCategory.objects.filter(addon=addon,
                                          category__id__in=[1, 71]).delete()
             cache.clear()
@@ -99,15 +99,15 @@ class BaseTestEditBasic(BaseTestEdit):
 
     def test_redirect(self):
         # /addon/:id => /addon/:id/edit
-        r = self.client.get('/en-US/developers/addon/3615/', follow=True)
-        self.assert3xx(r, self.url, 301)
+        response = self.client.get('/en-US/developers/addon/3615/', follow=True)
+        self.assert3xx(response, self.url, 301)
 
     def test_edit(self):
         old_name = self.addon.name
         data = self.get_dict()
 
-        r = self.client.post(self.basic_edit_url, data)
-        assert r.status_code == 200
+        response = self.client.post(self.basic_edit_url, data)
+        assert response.status_code == 200
         addon = self.get_addon()
 
         assert unicode(addon.name) == data['name']
@@ -124,8 +124,8 @@ class BaseTestEditBasic(BaseTestEdit):
         old_desc = self.addon.description
         data = self.get_dict()
 
-        r = self.client.post(self.basic_edit_url, data)
-        assert r.status_code == 200
+        response = self.client.post(self.basic_edit_url, data)
+        assert response.status_code == 200
         addon = self.get_addon()
 
         assert addon.description == old_desc
@@ -133,26 +133,27 @@ class BaseTestEditBasic(BaseTestEdit):
     def test_edit_slug_invalid(self):
         old_edit = self.basic_edit_url
         data = self.get_dict(name='', slug='invalid')
-        r = self.client.post(self.basic_edit_url, data)
-        doc = pq(r.content)
+        response = self.client.post(self.basic_edit_url, data)
+        doc = pq(response.content)
         assert doc('form').attr('action') == old_edit
 
     def test_edit_slug_valid(self):
         old_edit = self.basic_edit_url
         data = self.get_dict(slug='valid')
-        r = self.client.post(self.basic_edit_url, data)
-        doc = pq(r.content)
+        response = self.client.post(self.basic_edit_url, data)
+        doc = pq(response.content)
         assert doc('form').attr('action') != old_edit
 
     def test_edit_summary_escaping(self):
         data = self.get_dict()
         data['summary'] = '<b>oh my</b>'
-        r = self.client.post(self.basic_edit_url, data)
-        assert r.status_code == 200
+        response = self.client.post(self.basic_edit_url, data)
+        assert response.status_code == 200
 
         # Fetch the page so the LinkifiedTranslation gets in cache.
-        r = self.client.get(reverse('devhub.addons.edit', args=[data['slug']]))
-        assert pq(r.content)('[data-name=summary]').html().strip() == (
+        response = self.client.get(
+            reverse('devhub.addons.edit', args=[data['slug']]))
+        assert pq(response.content)('[data-name=summary]').html().strip() == (
             '<span lang="en-us">&lt;b&gt;oh my&lt;/b&gt;</span>')
 
         # Now make sure we don't have escaped content in the rendered form.
@@ -164,16 +165,16 @@ class BaseTestEditBasic(BaseTestEdit):
     def test_edit_as_developer(self):
         self.login('regular@mozilla.com')
         data = self.get_dict()
-        r = self.client.post(self.basic_edit_url, data)
+        response = self.client.post(self.basic_edit_url, data)
         # Make sure we get errors when they are just regular users.
-        assert r.status_code == 403 if self.listed else 404
+        assert response.status_code == 403 if self.listed else 404
 
         devuser = UserProfile.objects.get(pk=999)
         self.get_addon().addonuser_set.create(
             user=devuser, role=amo.AUTHOR_ROLE_DEV)
-        r = self.client.post(self.basic_edit_url, data)
+        response = self.client.post(self.basic_edit_url, data)
 
-        assert r.status_code == 200
+        assert response.status_code == 200
         addon = self.get_addon()
 
         assert unicode(addon.name) == data['name']
@@ -186,44 +187,47 @@ class BaseTestEditBasic(BaseTestEdit):
 
     def test_edit_name_required(self):
         data = self.get_dict(name='', slug='test_addon')
-        r = self.client.post(self.basic_edit_url, data)
-        assert r.status_code == 200
-        self.assertFormError(r, 'form', 'name', 'This field is required.')
+        response = self.client.post(self.basic_edit_url, data)
+        assert response.status_code == 200
+        self.assertFormError(
+            response, 'form', 'name', 'This field is required.')
 
     def test_edit_name_spaces(self):
         data = self.get_dict(name='    ', slug='test_addon')
-        r = self.client.post(self.basic_edit_url, data)
-        assert r.status_code == 200
-        self.assertFormError(r, 'form', 'name', 'This field is required.')
+        response = self.client.post(self.basic_edit_url, data)
+        assert response.status_code == 200
+        self.assertFormError(
+            response, 'form', 'name', 'This field is required.')
 
     def test_edit_slugs_unique(self):
         Addon.objects.get(id=5579).update(slug='test_slug')
         data = self.get_dict()
-        r = self.client.post(self.basic_edit_url, data)
-        assert r.status_code == 200
+        response = self.client.post(self.basic_edit_url, data)
+        assert response.status_code == 200
         self.assertFormError(
-            r, 'form', 'slug',
+            response, 'form', 'slug',
             'This slug is already in use. Please choose another.')
 
     def test_edit_name_not_empty(self):
         data = self.get_dict(name='', slug=self.addon.slug,
                              summary=self.addon.summary)
-        r = self.client.post(self.basic_edit_url, data)
-        self.assertFormError(r, 'form', 'name', 'This field is required.')
+        response = self.client.post(self.basic_edit_url, data)
+        self.assertFormError(
+            response, 'form', 'name', 'This field is required.')
 
     def test_edit_name_max_length(self):
         data = self.get_dict(name='xx' * 70, slug=self.addon.slug,
                              summary=self.addon.summary)
-        r = self.client.post(self.basic_edit_url, data)
-        self.assertFormError(r, 'form', 'name',
+        response = self.client.post(self.basic_edit_url, data)
+        self.assertFormError(response, 'form', 'name',
                              'Ensure this value has at most 50 '
                              'characters (it has 140).')
 
     def test_edit_summary_max_length(self):
         data = self.get_dict(name=self.addon.name, slug=self.addon.slug,
                              summary='x' * 251)
-        r = self.client.post(self.basic_edit_url, data)
-        self.assertFormError(r, 'form', 'summary',
+        response = self.client.post(self.basic_edit_url, data)
+        self.assertFormError(response, 'form', 'summary',
                              'Ensure this value has at most 250 '
                              'characters (it has 251).')
 
@@ -251,9 +255,10 @@ class BaseTestEditBasic(BaseTestEdit):
                 reverse('compat.reporter_detail', args=[self.addon.guid]),
             ]
 
-        r = self.client.get(self.url)
-        doc_links = [unicode(a.attrib['href'])
-                     for a in pq(r.content)('#edit-addon-nav').find('li a')]
+        response = self.client.get(self.url)
+        doc_links = [
+            unicode(a.attrib['href'])
+            for a in pq(response.content)('#edit-addon-nav').find('li a')]
         assert links == doc_links
 
 
@@ -263,10 +268,10 @@ class TestEditBasicListed(BaseTestEditBasic):
         count = ActivityLog.objects.all().count()
         self.tags.insert(0, 'tag4')
         data = self.get_dict()
-        r = self.client.post(self.basic_edit_url, data)
-        assert r.status_code == 200
+        response = self.client.post(self.basic_edit_url, data)
+        assert response.status_code == 200
 
-        result = pq(r.content)('#addon_tags_edit').eq(0).text()
+        result = pq(response.content)('#addon_tags_edit').eq(0).text()
 
         assert result == ', '.join(sorted(self.tags))
         html = ('<a href="/en-US/firefox/tag/tag4">tag4</a> added to '
@@ -279,42 +284,42 @@ class TestEditBasicListed(BaseTestEditBasic):
     def test_edit_denied_tag(self):
         Tag.objects.get_or_create(tag_text='blue', denied=True)
         data = self.get_dict(tags='blue')
-        r = self.client.post(self.basic_edit_url, data)
-        assert r.status_code == 200
+        response = self.client.post(self.basic_edit_url, data)
+        assert response.status_code == 200
 
         error = 'Invalid tag: blue'
-        self.assertFormError(r, 'form', 'tags', error)
+        self.assertFormError(response, 'form', 'tags', error)
 
     def test_edit_denied_tags_2(self):
         Tag.objects.get_or_create(tag_text='blue', denied=True)
         Tag.objects.get_or_create(tag_text='darn', denied=True)
         data = self.get_dict(tags='blue, darn, swearword')
-        r = self.client.post(self.basic_edit_url, data)
-        assert r.status_code == 200
+        response = self.client.post(self.basic_edit_url, data)
+        assert response.status_code == 200
 
         error = 'Invalid tags: blue, darn'
-        self.assertFormError(r, 'form', 'tags', error)
+        self.assertFormError(response, 'form', 'tags', error)
 
     def test_edit_denied_tags_3(self):
         Tag.objects.get_or_create(tag_text='blue', denied=True)
         Tag.objects.get_or_create(tag_text='darn', denied=True)
         Tag.objects.get_or_create(tag_text='swearword', denied=True)
         data = self.get_dict(tags='blue, darn, swearword')
-        r = self.client.post(self.basic_edit_url, data)
-        assert r.status_code == 200
+        response = self.client.post(self.basic_edit_url, data)
+        assert response.status_code == 200
 
         error = 'Invalid tags: blue, darn, swearword'
-        self.assertFormError(r, 'form', 'tags', error)
+        self.assertFormError(response, 'form', 'tags', error)
 
     def test_edit_remove_tag(self):
         self.tags.remove('tag2')
 
         count = ActivityLog.objects.all().count()
         data = self.get_dict()
-        r = self.client.post(self.basic_edit_url, data)
-        assert r.status_code == 200
+        response = self.client.post(self.basic_edit_url, data)
+        assert response.status_code == 200
 
-        result = pq(r.content)('#addon_tags_edit').eq(0).text()
+        result = pq(response.content)('#addon_tags_edit').eq(0).text()
 
         assert result == ', '.join(sorted(self.tags))
 
@@ -325,10 +330,10 @@ class TestEditBasicListed(BaseTestEditBasic):
         tags = self.tags
         tags.append('a' * (amo.MIN_TAG_LENGTH - 1))
         data = self.get_dict()
-        r = self.client.post(self.basic_edit_url, data)
-        assert r.status_code == 200
+        response = self.client.post(self.basic_edit_url, data)
+        assert response.status_code == 200
 
-        self.assertFormError(r, 'form', 'tags',
+        self.assertFormError(response, 'form', 'tags',
                              'All tags must be at least %d characters.' %
                              amo.MIN_TAG_LENGTH)
 
@@ -339,9 +344,9 @@ class TestEditBasicListed(BaseTestEditBasic):
             tags.append('test%d' % i)
 
         data = self.get_dict()
-        r = self.client.post(self.basic_edit_url, data)
+        response = self.client.post(self.basic_edit_url, data)
         self.assertFormError(
-            r, 'form', 'tags',
+            response, 'form', 'tags',
             'You have %d too many tags.' % (len(tags) - amo.MAX_TAGS))
 
     def test_edit_tag_empty_after_slug(self):
@@ -368,9 +373,9 @@ class TestEditBasicListed(BaseTestEditBasic):
         assert sorted(addon_cats) == [1, 22]
 
     def _feature_addon(self, addon_id=3615):
-        c = CollectionAddon.objects.create(
+        c_addon = CollectionAddon.objects.create(
             addon_id=addon_id, collection=Collection.objects.create())
-        FeaturedCollection.objects.create(collection=c.collection,
+        FeaturedCollection.objects.create(collection=c_addon.collection,
                                           application=amo.FIREFOX.id)
         cache.clear()
 
@@ -379,10 +384,10 @@ class TestEditBasicListed(BaseTestEditBasic):
         self._feature_addon()
 
         self.cat_initial['categories'] = [22, 1]
-        r = self.client.post(self.basic_edit_url, self.get_dict())
+        response = self.client.post(self.basic_edit_url, self.get_dict())
         addon_cats = self.get_addon().categories.values_list('id', flat=True)
 
-        assert r.context['cat_form'].errors[0]['categories'] == (
+        assert response.context['cat_form'].errors[0]['categories'] == (
             ['Categories cannot be changed while your add-on is featured for '
              'this application.'])
         # This add-on's categories should not change.
@@ -392,14 +397,14 @@ class TestEditBasicListed(BaseTestEditBasic):
         """Ensure that admins can change categories for creatured add-ons."""
         assert self.client.login(email='admin@mozilla.com')
         self._feature_addon()
-        r = self.client.get(self.basic_edit_url)
-        doc = pq(r.content)
+        response = self.client.get(self.basic_edit_url)
+        doc = pq(response.content)
         assert doc('#addon-categories-edit div.addon-app-cats').length == 1
         assert doc('#addon-categories-edit > p').length == 0
         self.cat_initial['categories'] = [22, 1]
-        r = self.client.post(self.basic_edit_url, self.get_dict())
+        response = self.client.post(self.basic_edit_url, self.get_dict())
         addon_cats = self.get_addon().categories.values_list('id', flat=True)
-        assert 'categories' not in r.context['cat_form'].errors[0]
+        assert 'categories' not in response.context['cat_form'].errors[0]
         # This add-on's categories should change.
         assert sorted(addon_cats) == [1, 22]
 
@@ -413,8 +418,8 @@ class TestEditBasicListed(BaseTestEditBasic):
 
     def test_edit_categories_no_disclaimer(self):
         """Ensure that there is a not disclaimer for non-creatured add-ons."""
-        r = self.client.get(self.basic_edit_url)
-        doc = pq(r.content)
+        response = self.client.get(self.basic_edit_url)
+        doc = pq(response.content)
         assert doc('#addon-categories-edit div.addon-app-cats').length == 1
         assert doc('#addon-categories-edit > p').length == 0
 
@@ -451,21 +456,21 @@ class TestEditBasicListed(BaseTestEditBasic):
             self.addon.all_categories)
 
     def test_edit_categories_xss(self):
-        c = Category.objects.get(id=22)
-        c.db_name = '<script>alert("test");</script>'
-        c.slug = 'xssattempt'
-        c.save()
+        category = Category.objects.get(id=22)
+        category.db_name = '<script>alert("test");</script>'
+        category.slug = 'xssattempt'
+        category.save()
 
         self.cat_initial['categories'] = [22, 71]
-        r = self.client.post(self.basic_edit_url, formset(self.cat_initial,
-                                                          initial_count=1))
+        response = self.client.post(
+            self.basic_edit_url, formset(self.cat_initial, initial_count=1))
 
-        assert '<script>alert' not in r.content
-        assert '&lt;script&gt;alert' in r.content
+        assert '<script>alert' not in response.content
+        assert '&lt;script&gt;alert' in response.content
 
     def test_edit_categories_remove(self):
-        c = Category.objects.get(id=1)
-        AddonCategory(addon=self.addon, category=c).save()
+        category = Category.objects.get(id=1)
+        AddonCategory(addon=self.addon, category=category).save()
         assert sorted(
             [cat.id for cat in self.get_addon().all_categories]) == [1, 22]
 
@@ -483,33 +488,33 @@ class TestEditBasicListed(BaseTestEditBasic):
 
     def test_edit_categories_required(self):
         del self.cat_initial['categories']
-        r = self.client.post(self.basic_edit_url, formset(self.cat_initial,
-                                                          initial_count=1))
-        assert r.context['cat_form'].errors[0]['categories'] == (
+        response = self.client.post(
+            self.basic_edit_url, formset(self.cat_initial, initial_count=1))
+        assert response.context['cat_form'].errors[0]['categories'] == (
             ['This field is required.'])
 
     def test_edit_categories_max(self):
         assert amo.MAX_CATEGORIES == 2
         self.cat_initial['categories'] = [22, 1, 71]
-        r = self.client.post(self.basic_edit_url, formset(self.cat_initial,
-                                                          initial_count=1))
-        assert r.context['cat_form'].errors[0]['categories'] == (
+        response = self.client.post(
+            self.basic_edit_url, formset(self.cat_initial, initial_count=1))
+        assert response.context['cat_form'].errors[0]['categories'] == (
             ['You can have only 2 categories.'])
 
     def test_edit_categories_other_failure(self):
         Category.objects.get(id=22).update(misc=True)
         self.cat_initial['categories'] = [22, 1]
-        r = self.client.post(self.basic_edit_url, formset(self.cat_initial,
-                                                          initial_count=1))
-        assert r.context['cat_form'].errors[0]['categories'] == (
+        response = self.client.post(
+            self.basic_edit_url, formset(self.cat_initial, initial_count=1))
+        assert response.context['cat_form'].errors[0]['categories'] == (
             ['The miscellaneous category cannot be combined with additional '
              'categories.'])
 
     def test_edit_categories_nonexistent(self):
         self.cat_initial['categories'] = [100]
-        r = self.client.post(self.basic_edit_url, formset(self.cat_initial,
-                                                          initial_count=1))
-        assert r.context['cat_form'].errors[0]['categories'] == (
+        response = self.client.post(
+            self.basic_edit_url, formset(self.cat_initial, initial_count=1))
+        assert response.context['cat_form'].errors[0]['categories'] == (
             ['Select a valid choice. 100 is not one of the available '
              'choices.'])
 
@@ -525,30 +530,30 @@ class TestEditBasicListed(BaseTestEditBasic):
         assert 'i_am_a_restricted_tag' in divs.eq(1).text()
 
     def test_text_not_none_when_has_flags(self):
-        r = self.client.get(self.url)
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         assert doc('#addon-flags').text() == (
             'This add-on requires external software.')
 
     def test_text_none_when_no_flags(self):
         addon = self.get_addon()
         addon.update(external_software=False)
-        r = self.client.get(self.url)
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         assert doc('#addon-flags').text() == 'None'
 
     def test_nav_links(self):
         activity_url = reverse('devhub.feed', args=['a3615'])
-        r = self.client.get(self.url)
-        doc = pq(r.content)('#edit-addon-nav')
+        response = self.client.get(self.url)
+        doc = pq(response.content)('#edit-addon-nav')
         assert doc('ul:last').find('li a').eq(1).attr('href') == (
             activity_url)
         assert doc('.view-stats').length == 1
 
     def test_nav_links_admin(self):
         assert self.client.login(email='admin@mozilla.com')
-        r = self.client.get(self.url)
-        doc = pq(r.content)('#edit-addon-nav')
+        response = self.client.get(self.url)
+        doc = pq(response.content)('#edit-addon-nav')
         links = doc('ul:last').find('li a')
         assert links.eq(1).attr('href') == reverse(
             'editors.review', args=[self.addon.slug])
@@ -556,15 +561,15 @@ class TestEditBasicListed(BaseTestEditBasic):
             'zadmin.addon_manage', args=[self.addon.slug])
 
     def test_not_experimental_flag(self):
-        r = self.client.get(self.url)
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         assert doc('#experimental-edit').text() == (
             'This add-on is ready for general use.')
 
     def test_experimental_flag(self):
         self.get_addon().update(is_experimental=True)
-        r = self.client.get(self.url)
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         assert doc('#experimental-edit').text() == (
             'This add-on is experimental.')
 
@@ -576,21 +581,24 @@ class TestEditBasicListed(BaseTestEditBasic):
     def test_l10n(self):
         Addon.objects.get(id=3615).update(default_locale='en-US')
         for url in self.get_l10n_urls():
-            r = self.client.get(url)
-            assert pq(r.content)('#l10n-menu').attr('data-default') == 'en-us'
+            response = self.client.get(url)
+            assert pq(
+                response.content)('#l10n-menu').attr('data-default') == 'en-us'
 
     def test_l10n_not_us(self):
         Addon.objects.get(id=3615).update(default_locale='fr')
         for url in self.get_l10n_urls():
-            r = self.client.get(url)
-            assert pq(r.content)('#l10n-menu').attr('data-default') == 'fr'
+            response = self.client.get(url)
+            assert pq(
+                response.content)('#l10n-menu').attr('data-default') == 'fr'
 
     def test_l10n_not_us_id_url(self):
         Addon.objects.get(id=3615).update(default_locale='fr')
         for url in self.get_l10n_urls():
             url = '/id' + url[6:]
-            r = self.client.get(url)
-            assert pq(r.content)('#l10n-menu').attr('data-default') == 'fr'
+            response = self.client.get(url)
+            assert pq(
+                response.content)('#l10n-menu').attr('data-default') == 'fr'
 
 
 class TestEditMedia(BaseTestEdit):
@@ -615,7 +623,7 @@ class TestEditMedia(BaseTestEdit):
         kw.setdefault('prefix', 'files')
 
         fs = formset(*[a for a in args] + [self.formset_new_form()], **kw)
-        return dict([(k, '' if v is None else v) for k, v in fs.items()])
+        return {k: '' if v is None else v for k, v in fs.items()}
 
     def test_icon_upload_attributes(self):
         doc = pq(self.client.get(self.media_edit_url).content)
@@ -626,11 +634,11 @@ class TestEditMedia(BaseTestEdit):
         assert field.attr('data-upload-url') == self.icon_upload
 
     def test_edit_media_defaulticon(self):
-        data = dict(icon_type='')
+        data = {'icon_type': ''}
         data_formset = self.formset_media(**data)
 
-        r = self.client.post(self.media_edit_url, data_formset)
-        assert r.context['form'].errors == {}
+        response = self.client.post(self.media_edit_url, data_formset)
+        assert response.context['form'].errors == {}
         addon = self.get_addon()
 
         assert addon.get_icon_url(64).endswith('icons/default-64.png')
@@ -639,11 +647,11 @@ class TestEditMedia(BaseTestEdit):
             assert unicode(getattr(addon, k)) == data[k]
 
     def test_edit_media_preuploadedicon(self):
-        data = dict(icon_type='icon/appearance')
+        data = {'icon_type': 'icon/appearance'}
         data_formset = self.formset_media(**data)
 
-        r = self.client.post(self.media_edit_url, data_formset)
-        assert r.context['form'].errors == {}
+        response = self.client.post(self.media_edit_url, data_formset)
+        assert response.context['form'].errors == {}
         addon = self.get_addon()
 
         assert addon.get_icon_url(64).endswith('icons/appearance-64.png')
@@ -655,19 +663,21 @@ class TestEditMedia(BaseTestEdit):
         img = get_image_path('mozilla.png')
         src_image = open(img, 'rb')
 
-        data = dict(upload_image=src_image)
+        data = {'upload_image': src_image}
 
         response = self.client.post(self.icon_upload, data)
         response_json = json.loads(response.content)
         addon = self.get_addon()
 
         # Now, save the form so it gets moved properly.
-        data = dict(icon_type='image/png',
-                    icon_upload_hash=response_json['upload_hash'])
+        data = {
+            'icon_type': 'image/png',
+            'icon_upload_hash': response_json['upload_hash']
+        }
         data_formset = self.formset_media(**data)
 
-        r = self.client.post(self.media_edit_url, data_formset)
-        assert r.context['form'].errors == {}
+        response = self.client.post(self.media_edit_url, data_formset)
+        assert response.context['form'].errors == {}
         addon = self.get_addon()
 
         # Unfortunate hardcoding of URL
@@ -696,19 +706,21 @@ class TestEditMedia(BaseTestEdit):
         img = "static/img/notifications/error.png"
         src_image = open(img, 'rb')
 
-        data = dict(upload_image=src_image)
+        data = {'upload_image': src_image}
 
         response = self.client.post(self.icon_upload, data)
         response_json = json.loads(response.content)
         addon = self.get_addon()
 
         # Now, save the form so it gets moved properly.
-        data = dict(icon_type='image/png',
-                    icon_upload_hash=response_json['upload_hash'])
+        data = {
+            'icon_type': 'image/png',
+            'icon_upload_hash': response_json['upload_hash']
+        }
         data_formset = self.formset_media(**data)
 
-        r = self.client.post(self.media_edit_url, data_formset)
-        assert r.context['form'].errors == {}
+        response = self.client.post(self.media_edit_url, data_formset)
+        assert response.context['form'].errors == {}
         addon = self.get_addon()
 
         # Unfortunate hardcoding of URL
@@ -825,12 +837,12 @@ class TestEditMedia(BaseTestEdit):
         img = get_image_path('mozilla.png')
         src_image = open(img, 'rb')
 
-        data = dict(upload_image=src_image)
+        data = {'upload_image': src_image}
         data_formset = self.formset_media(**data)
         url = self.preview_upload
-        r = self.client.post(url, data_formset)
+        response = self.client.post(url, data_formset)
 
-        details = json.loads(r.content)
+        details = json.loads(response.content)
         upload_hash = details['upload_hash']
 
         # Create and post with the formset.
@@ -840,10 +852,7 @@ class TestEditMedia(BaseTestEdit):
                                                 upload_hash=upload_hash,
                                                 position=i))
         data_formset = self.formset_media(*fields)
-
-        self.media_edit_url
-
-        r = self.client.post(self.media_edit_url, data_formset)
+        self.client.post(self.media_edit_url, data_formset)
 
     def test_edit_media_preview_add(self):
         self.preview_add()
@@ -871,18 +880,18 @@ class TestEditMedia(BaseTestEdit):
 
         previews = self.get_addon().previews.all()
 
-        base = dict(upload_hash='', file_upload=None)
+        base = {'upload_hash': '', 'file_upload': None}
 
         # Three preview forms were generated; mix them up here.
-        a = dict(caption="first", position=1, id=previews[2].id)
-        b = dict(caption="second", position=2, id=previews[0].id)
-        c = dict(caption="third", position=3, id=previews[1].id)
-        a.update(base)
-        b.update(base)
-        c.update(base)
+        one = {'caption': 'first', 'position': 1, 'id': previews[2].id}
+        two = {'caption': 'second', 'position': 2, 'id': previews[0].id}
+        three = {'caption': 'third', 'position': 3, 'id': previews[1].id}
+        one.update(base)
+        two.update(base)
+        three.update(base)
 
         # Add them in backwards ("third", "second", "first")
-        data_formset = self.formset_media(c, b, a, initial_count=3)
+        data_formset = self.formset_media(three, two, one, initial_count=3)
         assert data_formset['files-0-caption'] == 'third'
         assert data_formset['files-1-caption'] == 'second'
         assert data_formset['files-2-caption'] == 'first'
@@ -928,12 +937,14 @@ class BaseTestEditDetails(BaseTestEdit):
         self.details_edit_url = self.get_url('details', edit=True)
 
     def test_edit(self):
-        data = dict(description='New description with <em>html</em>!',
-                    default_locale='en-US',
-                    homepage='http://twitter.com/fligtarsmom')
+        data = {
+            'description': 'New description with <em>html</em>!',
+            'default_locale': 'en-US',
+            'homepage': 'http://twitter.com/fligtarsmom'
+        }
 
-        r = self.client.post(self.details_edit_url, data)
-        assert r.context['form'].errors == {}
+        response = self.client.post(self.details_edit_url, data)
+        assert response.context['form'].errors == {}
         addon = self.get_addon()
 
         for k in data:
@@ -947,17 +958,20 @@ class BaseTestEditDetails(BaseTestEdit):
         self.addon.description = ("This\n<b>IS</b>"
                                   "<script>alert('awesome')</script>")
         self.addon.save()
-        r = self.client.get(self.url)
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         assert doc('#edit-addon-details span[lang]').html() == (
             "This<br/><b>IS</b>&lt;script&gt;alert('awesome')&lt;/script&gt;")
 
     def test_edit_homepage_optional(self):
-        data = dict(description='New description with <em>html</em>!',
-                    default_locale='en-US', homepage='')
+        data = {
+            'description': 'New description with <em>html</em>!',
+            'default_locale': 'en-US',
+            'homepage': ''
+        }
 
-        r = self.client.post(self.details_edit_url, data)
-        assert r.context['form'].errors == {}
+        response = self.client.post(self.details_edit_url, data)
+        assert response.context['form'].errors == {}
         addon = self.get_addon()
 
         for k in data:
@@ -975,12 +989,15 @@ class TestEditDetailsListed(BaseTestEditDetails):
                  'summary, and description in that locale. '
                  'You are missing ')
 
-        d = dict(description=description, homepage=homepage,
-                 default_locale='fr')
-        r = self.client.post(self.details_edit_url, d)
+        data = {
+            'description': description,
+            'homepage': homepage,
+            'default_locale': 'fr'
+        }
+        response = self.client.post(self.details_edit_url, data)
         # We can't use assertFormError here, because the missing fields are
         # stored in a dict, which isn't ordered.
-        form_error = r.context['form'].non_field_errors()[0]
+        form_error = response.context['form'].non_field_errors()[0]
         assert form_error.startswith(error)
         assert "'description'" in form_error
         assert "'name'" in form_error
@@ -989,8 +1006,8 @@ class TestEditDetailsListed(BaseTestEditDetails):
         # Now we have a name.
         self.addon.name = {'fr': 'fr name'}
         self.addon.save()
-        r = self.client.post(self.details_edit_url, d)
-        form_error = r.context['form'].non_field_errors()[0]
+        response = self.client.post(self.details_edit_url, data)
+        form_error = response.context['form'].non_field_errors()[0]
         assert form_error.startswith(error)
         assert "'description'" in form_error
         assert "'summary'" in form_error
@@ -998,27 +1015,31 @@ class TestEditDetailsListed(BaseTestEditDetails):
         # Now we have a summary.
         self.addon.summary = {'fr': 'fr summary'}
         self.addon.save()
-        r = self.client.post(self.details_edit_url, d)
-        form_error = r.context['form'].non_field_errors()[0]
+        response = self.client.post(self.details_edit_url, data)
+        form_error = response.context['form'].non_field_errors()[0]
         assert form_error.startswith(error)
         assert "'description'" in form_error
 
         # Now we're sending an fr description with the form.
-        d['description_fr'] = 'fr description'
-        r = self.client.post(self.details_edit_url, d)
-        assert r.context['form'].errors == {}
+        data['description_fr'] = 'fr description'
+        response = self.client.post(self.details_edit_url, data)
+        assert response.context['form'].errors == {}
 
     def test_edit_default_locale_frontend_error(self):
-        d = dict(description='xx', homepage='https://staticfil.es/',
-                 default_locale='fr')
-        r = self.client.post(self.details_edit_url, d)
-        self.assertContains(r, 'Before changing your default locale you must')
+        data = {
+            'description': 'xx',
+            'homepage': 'https://staticfil.es/',
+            'default_locale': 'fr'
+        }
+        response = self.client.post(self.details_edit_url, data)
+        self.assertContains(
+            response, 'Before changing your default locale you must')
 
     def test_edit_locale(self):
         addon = self.get_addon()
         addon.update(default_locale='en-US')
-        r = self.client.get(self.details_url)
-        assert pq(r.content)('.addon_edit_locale').eq(0).text() == (
+        response = self.client.get(self.details_url)
+        assert pq(response.content)('.addon_edit_locale').eq(0).text() == (
             'English (US)')
 
 
@@ -1030,33 +1051,39 @@ class TestEditSupport(BaseTestEdit):
         self.support_edit_url = self.get_url('support', edit=True)
 
     def test_edit_support(self):
-        data = dict(support_email='sjobs@apple.com',
-                    support_url='http://apple.com/')
+        data = {
+            'support_email': 'sjobs@apple.com',
+            'support_url': 'http://apple.com/'
+        }
 
-        r = self.client.post(self.support_edit_url, data)
-        assert r.context['form'].errors == {}
+        response = self.client.post(self.support_edit_url, data)
+        assert response.context['form'].errors == {}
         addon = self.get_addon()
 
         for k in data:
             assert unicode(getattr(addon, k)) == data[k]
 
     def test_edit_support_optional_url(self):
-        data = dict(support_email='sjobs@apple.com',
-                    support_url='')
+        data = {
+            'support_email': 'sjobs@apple.com',
+            'support_url': ''
+        }
 
-        r = self.client.post(self.support_edit_url, data)
-        assert r.context['form'].errors == {}
+        response = self.client.post(self.support_edit_url, data)
+        assert response.context['form'].errors == {}
         addon = self.get_addon()
 
         for k in data:
             assert unicode(getattr(addon, k)) == data[k]
 
     def test_edit_support_optional_email(self):
-        data = dict(support_email='',
-                    support_url='http://apple.com/')
+        data = {
+            'support_email': '',
+            'support_url': 'http://apple.com/'
+        }
 
-        r = self.client.post(self.support_edit_url, data)
-        assert r.context['form'].errors == {}
+        response = self.client.post(self.support_edit_url, data)
+        assert response.context['form'].errors == {}
         addon = self.get_addon()
 
         for k in data:
@@ -1091,21 +1118,24 @@ class TestEditTechnical(BaseTestEdit):
 
     def test_log(self):
         data = self.formset({'developer_comments': 'This is a test'})
-        o = ActivityLog.objects
-        assert o.count() == 0
-        r = self.client.post(self.technical_edit_url, data)
-        assert r.context['form'].errors == {}
-        assert o.filter(action=amo.LOG.EDIT_PROPERTIES.id).count() == 1
+        assert ActivityLog.objects.count() == 0
+        response = self.client.post(self.technical_edit_url, data)
+        assert response.context['form'].errors == {}
+        assert ActivityLog.objects.filter(
+            action=amo.LOG.EDIT_PROPERTIES.id).count() == 1
 
     def test_technical_on(self):
         # Turn everything on
-        data = dict(developer_comments='Test comment!',
-                    external_software='on',
-                    view_source='on',
-                    whiteboard='Whiteboard info.')
+        data = {
+            'developer_comments': 'Test comment!',
+            'external_software': 'on',
+            'view_source': 'on',
+            'whiteboard': 'Whiteboard info.'
+        }
 
-        r = self.client.post(self.technical_edit_url, self.formset(data))
-        assert r.context['form'].errors == {}
+        response = self.client.post(
+            self.technical_edit_url, self.formset(data))
+        assert response.context['form'].errors == {}
 
         addon = self.get_addon()
         for k in data:
@@ -1117,19 +1147,23 @@ class TestEditTechnical(BaseTestEdit):
                 assert getattr(addon, k) == (data[k] == 'on')
 
         # Andddd offf
-        data = dict(developer_comments='Test comment!')
-        r = self.client.post(self.technical_edit_url, self.formset(data))
+        data = {'developer_comments': 'Test comment!'}
+        response = self.client.post(
+            self.technical_edit_url, self.formset(data))
         addon = self.get_addon()
 
         assert not addon.external_software
         assert not addon.view_source
 
     def test_technical_devcomment_notrequired(self):
-        data = dict(developer_comments='',
-                    external_software='on',
-                    view_source='on')
-        r = self.client.post(self.technical_edit_url, self.formset(data))
-        assert r.context['form'].errors == {}
+        data = {
+            'developer_comments': '',
+            'external_software': 'on',
+            'view_source': 'on'
+        }
+        response = self.client.post(
+            self.technical_edit_url, self.formset(data))
+        assert response.context['form'].errors == {}
 
         addon = self.get_addon()
         for k in data:
@@ -1139,68 +1173,69 @@ class TestEditTechnical(BaseTestEdit):
                 assert getattr(addon, k) == (data[k] == 'on')
 
     def test_auto_repackage_not_shown(self):
-        f = self.addon.current_version.all_files[0]
-        f.jetpack_version = None
-        f.save()
-        r = self.client.get(self.technical_edit_url)
-        self.assertNotContains(r, 'Upgrade SDK?')
+        file_ = self.addon.current_version.all_files[0]
+        file_.jetpack_version = None
+        file_.save()
+        response = self.client.get(self.technical_edit_url)
+        self.assertNotContains(response, 'Upgrade SDK?')
 
     def test_auto_repackage_shown(self):
-        f = self.addon.current_version.all_files[0]
-        f.jetpack_version = '1.0'
-        f.save()
-        r = self.client.get(self.technical_edit_url)
-        self.assertContains(r, 'Upgrade SDK?')
+        file_ = self.addon.current_version.all_files[0]
+        file_.jetpack_version = '1.0'
+        file_.save()
+        response = self.client.get(self.technical_edit_url)
+        self.assertContains(response, 'Upgrade SDK?')
 
     def test_dependencies_none(self):
         AddonDependency.objects.all().delete()
         assert list(self.addon.all_dependencies) == []
-        r = self.client.get(self.technical_url)
-        assert pq(r.content)('#required-addons .empty').length == 1
+        response = self.client.get(self.technical_url)
+        assert pq(response.content)('#required-addons .empty').length == 1
 
     def test_dependencies_overview(self):
         assert [d.id for d in self.addon.all_dependencies] == [5579]
-        r = self.client.get(self.technical_url)
-        req = pq(r.content)('#required-addons')
+        response = self.client.get(self.technical_url)
+        req = pq(response.content)('#required-addons')
         assert req.length == 1
         assert req.attr('data-src') == (
             reverse('devhub.ajax.dependencies', args=[self.addon.slug]))
         assert req.find('li').length == 1
-        a = req.find('a')
-        assert a.attr('href') == self.dependent_addon.get_url_path()
-        assert a.text() == unicode(self.dependent_addon.name)
+        link = req.find('a')
+        assert link.attr('href') == self.dependent_addon.get_url_path()
+        assert link.text() == unicode(self.dependent_addon.name)
 
     def test_dependencies_initial(self):
-        r = self.client.get(self.technical_edit_url)
-        form = pq(r.content)('#required-addons .dependencies li[data-addonid]')
+        response = self.client.get(self.technical_edit_url)
+        form = pq(response.content)(
+            '#required-addons .dependencies li[data-addonid]')
         assert form.length == 1
         assert form.find('input[id$=-dependent_addon]').val() == (
             str(self.dependent_addon.id))
         div = form.find('div')
         assert div.attr('style') == (
             'background-image:url(%s)' % self.dependent_addon.icon_url)
-        a = div.find('a')
-        assert a.attr('href') == self.dependent_addon.get_url_path()
-        assert a.text() == unicode(self.dependent_addon.name)
+        link = div.find('a')
+        assert link.attr('href') == self.dependent_addon.get_url_path()
+        assert link.text() == unicode(self.dependent_addon.name)
 
     def test_dependencies_add(self):
         addon = Addon.objects.get(id=5299)
         assert addon.type == amo.ADDON_EXTENSION
         assert addon in list(Addon.objects.public())
 
-        d = self.dep_formset({'dependent_addon': addon.id})
-        r = self.client.post(self.technical_edit_url, d)
-        assert not any(r.context['dependency_form'].errors)
+        data = self.dep_formset({'dependent_addon': addon.id})
+        response = self.client.post(self.technical_edit_url, data)
+        assert not any(response.context['dependency_form'].errors)
         self.check_dep_ids([self.dependent_addon.id, addon.id])
 
-        r = self.client.get(self.technical_edit_url)
-        reqs = pq(r.content)('#required-addons .dependencies')
+        response = self.client.get(self.technical_edit_url)
+        reqs = pq(response.content)('#required-addons .dependencies')
         assert reqs.find('li[data-addonid]').length == 2
         req = reqs.find('li[data-addonid="5299"]')
         assert req.length == 1
-        a = req.find('div a')
-        assert a.attr('href') == addon.get_url_path()
-        assert a.text() == unicode(addon.name)
+        link = req.find('div a')
+        assert link.attr('href') == addon.get_url_path()
+        assert link.text() == unicode(addon.name)
 
     def test_dependencies_limit(self):
         deps = Addon.objects.public().exclude(
@@ -1210,9 +1245,9 @@ class TestEditTechnical(BaseTestEdit):
         assert deps.count() > 3  # The limit is 3.
         for dep in deps:
             args.append({'dependent_addon': dep.id})
-        d = self.dep_formset(*args)
-        r = self.client.post(self.technical_edit_url, d)
-        assert r.context['dependency_form'].non_form_errors() == (
+        data = self.dep_formset(*args)
+        response = self.client.post(self.technical_edit_url, data)
+        assert response.context['dependency_form'].non_form_errors() == (
             ['There cannot be more than 3 required add-ons.'])
 
     def test_dependencies_limit_with_deleted_form(self):
@@ -1225,17 +1260,17 @@ class TestEditTechnical(BaseTestEdit):
 
         # If we delete one form and add three, everything should be A-OK.
         self.dep['DELETE'] = True
-        d = self.dep_formset(*args)
-        r = self.client.post(self.technical_edit_url, d)
-        assert not any(r.context['dependency_form'].errors)
+        data = self.dep_formset(*args)
+        response = self.client.post(self.technical_edit_url, data)
+        assert not any(response.context['dependency_form'].errors)
         self.check_dep_ids(deps.values_list('id', flat=True))
 
     def check_dep_ids(self, expected=None):
         if expected is None:
             expected = []
-        a = AddonDependency.objects.values_list('dependent_addon__id',
-                                                flat=True)
-        assert sorted(list(a)) == sorted(expected)
+        ids = AddonDependency.objects.values_list(
+            'dependent_addon__id', flat=True)
+        assert sorted(list(ids)) == sorted(expected)
 
     def check_bad_dep(self, r):
         """This helper checks that bad dependency data doesn't go through."""
@@ -1251,9 +1286,9 @@ class TestEditTechnical(BaseTestEdit):
             addon.update(status=status)
 
             assert addon in list(Addon.objects.public())
-            d = self.dep_formset({'dependent_addon': addon.id})
-            r = self.client.post(self.technical_edit_url, d)
-            assert not any(r.context['dependency_form'].errors)
+            data = self.dep_formset({'dependent_addon': addon.id})
+            response = self.client.post(self.technical_edit_url, data)
+            assert not any(response.context['dependency_form'].errors)
             self.check_dep_ids([self.dependent_addon.id, addon.id])
 
             AddonDependency.objects.get(dependent_addon=addon).delete()
@@ -1265,18 +1300,18 @@ class TestEditTechnical(BaseTestEdit):
             addon.update(status=status)
 
             assert addon not in list(Addon.objects.public())
-            d = self.dep_formset({'dependent_addon': addon.id})
-            r = self.client.post(self.technical_edit_url, d)
-            self.check_bad_dep(r)
+            data = self.dep_formset({'dependent_addon': addon.id})
+            response = self.client.post(self.technical_edit_url, data)
+            self.check_bad_dep(response)
 
     def test_dependencies_no_add_reviewed_persona(self):
         """Ensure that reviewed Personas cannot be made as dependencies."""
         addon = Addon.objects.get(id=15663)
         assert addon.type == amo.ADDON_PERSONA
         assert addon in list(Addon.objects.public())
-        d = self.dep_formset({'dependent_addon': addon.id})
-        r = self.client.post(self.technical_edit_url, d)
-        self.check_bad_dep(r)
+        data = self.dep_formset({'dependent_addon': addon.id})
+        response = self.client.post(self.technical_edit_url, data)
+        self.check_bad_dep(response)
 
     def test_dependencies_no_add_unreviewed_persona(self):
         """Ensure that unreviewed Personas cannot be made as dependencies."""
@@ -1284,44 +1319,45 @@ class TestEditTechnical(BaseTestEdit):
         addon.update(status=amo.STATUS_PENDING)
         assert addon.status == amo.STATUS_PENDING
         assert addon not in list(Addon.objects.public())
-        d = self.dep_formset({'dependent_addon': addon.id})
-        r = self.client.post(self.technical_edit_url, d)
-        self.check_bad_dep(r)
+        data = self.dep_formset({'dependent_addon': addon.id})
+        response = self.client.post(self.technical_edit_url, data)
+        self.check_bad_dep(response)
 
     def test_dependencies_add_self(self):
         """Ensure that an add-on cannot be made dependent on itself."""
-        d = self.dep_formset({'dependent_addon': self.addon.id})
-        r = self.client.post(self.technical_edit_url, d)
-        self.check_bad_dep(r)
+        data = self.dep_formset({'dependent_addon': self.addon.id})
+        response = self.client.post(self.technical_edit_url, data)
+        self.check_bad_dep(response)
 
     def test_dependencies_add_invalid(self):
         """Ensure that a non-existent add-on cannot be a dependency."""
-        d = self.dep_formset({'dependent_addon': 9999})
-        r = self.client.post(self.technical_edit_url, d)
-        self.check_bad_dep(r)
+        data = self.dep_formset({'dependent_addon': 9999})
+        response = self.client.post(self.technical_edit_url, data)
+        self.check_bad_dep(response)
 
     def test_dependencies_add_duplicate(self):
         """Ensure that an add-on cannot be made dependent more than once."""
-        d = self.dep_formset({'dependent_addon': self.dependent_addon.id})
-        r = self.client.post(self.technical_edit_url, d)
-        assert r.context['dependency_form'].forms[1].non_field_errors() == (
+        data = self.dep_formset({'dependent_addon': self.dependent_addon.id})
+        response = self.client.post(self.technical_edit_url, data)
+        assert (
+            response.context['dependency_form'].forms[1].non_field_errors() ==
             ['Addon dependency with this Addon and Dependent addon already '
              'exists.'])
         self.check_dep_ids([self.dependent_addon.id])
 
     def test_dependencies_delete(self):
         self.dep['DELETE'] = True
-        d = self.dep_formset(total_count=1, initial_count=1)
-        r = self.client.post(self.technical_edit_url, d)
-        assert not any(r.context['dependency_form'].errors)
+        data = self.dep_formset(total_count=1, initial_count=1)
+        response = self.client.post(self.technical_edit_url, data)
+        assert not any(response.context['dependency_form'].errors)
         self.check_dep_ids()
 
     def test_dependencies_add_delete(self):
         """Ensure that we can both delete a dependency and add another."""
         self.dep['DELETE'] = True
-        d = self.dep_formset({'dependent_addon': 5299})
-        r = self.client.post(self.technical_edit_url, d)
-        assert not any(r.context['dependency_form'].errors)
+        data = self.dep_formset({'dependent_addon': 5299})
+        response = self.client.post(self.technical_edit_url, data)
+        assert not any(response.context['dependency_form'].errors)
         self.check_dep_ids([5299])
 
 
@@ -1340,18 +1376,19 @@ class TestEditTechnicalUnlisted(BaseTestEdit):
         edit_url = self.get_url('technical', edit=True)
 
         # It's okay to post empty whiteboard instructions.
-        r = self.client.post(edit_url, {'whiteboard': ''})
-        assert r.context['form'].errors == {}
+        response = self.client.post(edit_url, {'whiteboard': ''})
+        assert response.context['form'].errors == {}
 
         # Let's update it.
-        r = self.client.post(edit_url, {'whiteboard': 'important stuff'})
-        assert r.context['form'].errors == {}
+        response = self.client.post(
+            edit_url, {'whiteboard': 'important stuff'})
+        assert response.context['form'].errors == {}
         addon = self.get_addon()
         assert addon.whiteboard == 'important stuff'
 
         # And clear it again.
-        r = self.client.post(edit_url, {'whiteboard': ''})
-        assert r.context['form'].errors == {}
+        response = self.client.post(edit_url, {'whiteboard': ''})
+        assert response.context['form'].errors == {}
         addon = self.get_addon()
         assert addon.whiteboard == ''
 
@@ -1368,31 +1405,31 @@ class TestAdmin(TestCase):
     def test_show_admin_settings_admin(self):
         self.login_admin()
         url = reverse('devhub.addons.edit', args=['a3615'])
-        r = self.client.get(url)
-        assert r.status_code == 200
-        self.assertContains(r, 'Admin Settings')
-        assert 'admin_form' in r.context, 'AdminForm expected in context.'
+        response = self.client.get(url)
+        assert response.status_code == 200
+        self.assertContains(response, 'Admin Settings')
+        assert 'admin_form' in response.context
 
     def test_show_admin_settings_nonadmin(self):
         self.login_user()
         url = reverse('devhub.addons.edit', args=['a3615'])
-        r = self.client.get(url)
-        assert r.status_code == 200
-        self.assertNotContains(r, 'Admin Settings')
-        assert 'admin_form' not in r.context, (
+        response = self.client.get(url)
+        assert response.status_code == 200
+        self.assertNotContains(response, 'Admin Settings')
+        assert 'admin_form' not in response.context, (
             'AdminForm not expected in context.')
 
     def test_post_as_admin(self):
         self.login_admin()
         url = reverse('devhub.addons.admin', args=['a3615'])
-        r = self.client.post(url)
-        assert r.status_code == 200
+        response = self.client.post(url)
+        assert response.status_code == 200
 
     def test_post_as_nonadmin(self):
         self.login_user()
         url = reverse('devhub.addons.admin', args=['a3615'])
-        r = self.client.post(url)
-        assert r.status_code == 403
+        response = self.client.post(url)
+        assert response.status_code == 403
 
 
 class TestThemeEdit(TestCase):
@@ -1410,29 +1447,29 @@ class TestThemeEdit(TestCase):
         req = req_factory_factory(
             self.addon.get_dev_url('edit'),
             user=self.user, post=True, data=data, session={})
-        r = edit_theme(req, self.addon.slug)
-        doc = pq(r.content)
+        response = edit_theme(req, self.addon.slug)
+        doc = pq(response.content)
         assert 'characters' in doc('#trans-description + ul li').text()
 
     def test_no_reupload_on_pending(self):
         self.addon.update(status=amo.STATUS_PENDING)
         req = req_factory_factory(
             self.addon.get_dev_url('edit'), user=self.user, session={})
-        r = edit_theme(req, self.addon.slug)
-        doc = pq(r.content)
+        response = edit_theme(req, self.addon.slug)
+        doc = pq(response.content)
         assert not doc('a.reupload')
 
         self.addon.update(status=amo.STATUS_PUBLIC)
         req = req_factory_factory(
             self.addon.get_dev_url('edit'), user=self.user, session={})
-        r = edit_theme(req, self.addon.slug)
-        doc = pq(r.content)
+        response = edit_theme(req, self.addon.slug)
+        doc = pq(response.content)
         assert doc('a.reupload')
 
     def test_color_input_is_empty_at_creation(self):
         self.client.login(email='regular@mozilla.com')
-        r = self.client.get(reverse('devhub.themes.submit'))
-        doc = pq(r.content)
+        response = self.client.get(reverse('devhub.themes.submit'))
+        doc = pq(response.content)
         el = doc('input.color-picker')
         assert el.attr('type') == 'text'
         assert not el.attr('value')
@@ -1443,8 +1480,8 @@ class TestThemeEdit(TestCase):
         self.addon.persona.save()
         self.client.login(email='regular@mozilla.com')
         url = reverse('devhub.themes.edit', args=(self.addon.slug, ))
-        r = self.client.get(url)
-        doc = pq(r.content)
+        response = self.client.get(url)
+        doc = pq(response.content)
         el = doc('input#id_accentcolor')
         assert el.attr('type') == 'text'
         assert el.attr('value') == "#" + color

--- a/src/olympia/devhub/tests/test_views_ownership.py
+++ b/src/olympia/devhub/tests/test_views_ownership.py
@@ -44,16 +44,16 @@ class TestEditPolicy(TestOwnership):
     def test_edit_eula(self):
         old_eula = self.addon.eula
         data = self.formset(eula='new eula', has_eula=True)
-        r = self.client.post(self.url, data)
-        assert r.status_code == 302
+        response = self.client.post(self.url, data)
+        assert response.status_code == 302
         addon = self.get_addon()
         assert unicode(addon.eula) == 'new eula'
         assert addon.eula.id == old_eula.id
 
     def test_delete_eula(self):
         assert self.addon.eula
-        r = self.client.post(self.url, self.formset(has_eula=False))
-        assert r.status_code == 302
+        response = self.client.post(self.url, self.formset(has_eula=False))
+        assert response.status_code == 302
         assert self.get_addon().eula is None
 
     def test_edit_eula_locale(self):
@@ -97,16 +97,16 @@ class TestEditLicense(TestOwnership):
 
     def test_success_add_builtin(self):
         data = self.formset(builtin=1)
-        r = self.client.post(self.url, data)
-        assert r.status_code == 302
+        response = self.client.post(self.url, data)
+        assert response.status_code == 302
         assert self.license == self.get_version().license
         assert ActivityLog.objects.filter(
             action=amo.LOG.CHANGE_LICENSE.id).count() == 1
 
     def test_success_add_custom(self):
         data = self.formset(builtin=License.OTHER, text='text', name='name')
-        r = self.client.post(self.url, data)
-        assert r.status_code == 302
+        response = self.client.post(self.url, data)
+        assert response.status_code == 302
         license = self.get_version().license
         assert unicode(license.text) == 'text'
         assert unicode(license.name) == 'name'
@@ -114,12 +114,12 @@ class TestEditLicense(TestOwnership):
 
     def test_success_edit_custom(self):
         data = self.formset(builtin=License.OTHER, text='text', name='name')
-        r = self.client.post(self.url, data)
+        response = self.client.post(self.url, data)
         license_one = self.get_version().license
 
         data = self.formset(builtin=License.OTHER, text='woo', name='name')
-        r = self.client.post(self.url, data)
-        assert r.status_code == 302
+        response = self.client.post(self.url, data)
+        assert response.status_code == 302
         license_two = self.get_version().license
         assert unicode(license_two.text) == 'woo'
         assert unicode(license_two.name) == 'name'
@@ -128,12 +128,12 @@ class TestEditLicense(TestOwnership):
 
     def test_success_switch_license(self):
         data = self.formset(builtin=1)
-        r = self.client.post(self.url, data)
+        response = self.client.post(self.url, data)
         license_one = self.get_version().license
 
         data = self.formset(builtin=License.OTHER, text='text', name='name')
-        r = self.client.post(self.url, data)
-        assert r.status_code == 302
+        response = self.client.post(self.url, data)
+        assert response.status_code == 302
         license_two = self.get_version().license
         assert unicode(license_two.text) == 'text'
         assert unicode(license_two.name) == 'name'
@@ -145,22 +145,22 @@ class TestEditLicense(TestOwnership):
         assert unicode(license.name) == 'bsd'
 
         data = self.formset(builtin=1)
-        r = self.client.post(self.url, data)
-        assert r.status_code == 302
+        response = self.client.post(self.url, data)
+        assert response.status_code == 302
         license_three = self.get_version().license
         assert license_three == license_one
 
     def test_custom_has_text(self):
         data = self.formset(builtin=License.OTHER, name='name')
-        r = self.client.post(self.url, data)
-        assert r.status_code == 200
-        self.assertFormError(r, 'license_form', None,
+        response = self.client.post(self.url, data)
+        assert response.status_code == 200
+        self.assertFormError(response, 'license_form', None,
                              'License text is required when choosing Other.')
 
     def test_custom_has_name(self):
         data = self.formset(builtin=License.OTHER, text='text')
-        r = self.client.post(self.url, data)
-        assert r.status_code == 302
+        response = self.client.post(self.url, data)
+        assert response.status_code == 302
         license = self.get_version().license
         assert unicode(license.text) == 'text'
         assert unicode(license.name) == 'Custom License'
@@ -171,8 +171,8 @@ class TestEditLicense(TestOwnership):
         self.addon.update(_current_version=None)
         Version.objects.all().delete()
         data = self.formset(builtin=License.OTHER, text='text')
-        r = self.client.post(self.url, data)
-        assert r.status_code == 302
+        response = self.client.post(self.url, data)
+        assert response.status_code == 302
 
     def test_license_details_links(self):
         # Check that builtin licenses get details links.
@@ -206,36 +206,44 @@ class TestEditAuthor(TestOwnership):
         ActivityLog.
         """
         # flip form-0-position
-        f = self.client.get(self.url).context['user_form'].initial_forms[0]
-        u = dict(user='regular@mozilla.com', listed=True,
-                 role=amo.AUTHOR_ROLE_DEV, position=0)
-        data = self.formset(f.initial, u, initial_count=1)
-        r = self.client.post(self.url, data)
-        assert r.status_code == 302
-        f = self.client.get(self.url).context['user_form'].initial_forms[0]
-        u1 = f.initial
+        form = self.client.get(self.url).context['user_form'].initial_forms[0]
+        user_data = {
+            'user': 'regular@mozilla.com',
+            'listed': True,
+            'role': amo.AUTHOR_ROLE_DEV,
+            'position': 0
+        }
+        data = self.formset(form.initial, user_data, initial_count=1)
+        response = self.client.post(self.url, data)
+        assert response.status_code == 302
+        form = self.client.get(self.url).context['user_form'].initial_forms[0]
+        u1 = form.initial
         u1['position'] = 1
-        f = self.client.get(self.url).context['user_form'].initial_forms[1]
-        u2 = f.initial
+        form = self.client.get(self.url).context['user_form'].initial_forms[1]
+        u2 = form.initial
         data = self.formset(u1, u2)
 
         orig = ActivityLog.objects.all().count()
-        r = self.client.post(self.url, data)
-        self.assert3xx(r, self.url, 302)
+        response = self.client.post(self.url, data)
+        self.assert3xx(response, self.url, 302)
         assert ActivityLog.objects.all().count() == orig
 
     def test_success_add_user(self):
-        q = (AddonUser.objects.no_cache().filter(addon=3615)
-             .values_list('user', flat=True))
-        assert list(q.all()) == [55021]
+        qs = (AddonUser.objects.no_cache().filter(addon=3615)
+              .values_list('user', flat=True))
+        assert list(qs.all()) == [55021]
 
-        f = self.client.get(self.url).context['user_form'].initial_forms[0]
-        u = dict(user='regular@mozilla.com', listed=True,
-                 role=amo.AUTHOR_ROLE_DEV, position=0)
-        data = self.formset(f.initial, u, initial_count=1)
-        r = self.client.post(self.url, data)
-        self.assert3xx(r, self.url, 302)
-        assert list(q.all()) == [55021, 999]
+        form = self.client.get(self.url).context['user_form'].initial_forms[0]
+        user_data = {
+            'user': 'regular@mozilla.com',
+            'listed': True,
+            'role': amo.AUTHOR_ROLE_DEV,
+            'position': 0
+        }
+        data = self.formset(form.initial, user_data, initial_count=1)
+        response = self.client.post(self.url, data)
+        self.assert3xx(response, self.url, 302)
+        assert list(qs.all()) == [55021, 999]
 
         # An email has been sent to the authors to warn them.
         author_added = mail.outbox[0]
@@ -247,10 +255,14 @@ class TestEditAuthor(TestOwnership):
 
     def test_success_edit_user(self):
         # Add an author b/c we can't edit anything about the current one.
-        f = self.client.get(self.url).context['user_form'].initial_forms[0]
-        u = dict(user='regular@mozilla.com', listed=True,
-                 role=amo.AUTHOR_ROLE_DEV, position=1)
-        data = self.formset(f.initial, u, initial_count=1)
+        form = self.client.get(self.url).context['user_form'].initial_forms[0]
+        user_data = {
+            'user': 'regular@mozilla.com',
+            'listed': True,
+            'role': amo.AUTHOR_ROLE_DEV,
+            'position': 1
+        }
+        data = self.formset(form.initial, user_data, initial_count=1)
         self.client.post(self.url, data)
         assert AddonUser.objects.get(addon=3615, user=999).listed
 
@@ -258,19 +270,28 @@ class TestEditAuthor(TestOwnership):
         user_form = self.client.get(self.url).context['user_form']
         one, two = user_form.initial_forms
         del two.initial['listed']
-        empty = dict(user='', listed=True, role=5, position=0)
+        empty = {
+            'user': '',
+            'listed': True,
+            'role': 5,
+            'position': 0
+        }
         data = self.formset(one.initial, two.initial, empty, initial_count=2)
-        r = self.client.post(self.url, data)
-        self.assert3xx(r, self.url, 302)
+        response = self.client.post(self.url, data)
+        self.assert3xx(response, self.url, 302)
         assert not AddonUser.objects.no_cache().get(
             addon=3615, user=999).listed
 
     def test_change_user_role(self):
         # Add an author b/c we can't edit anything about the current one.
-        f = self.client.get(self.url).context['user_form'].initial_forms[0]
-        u = dict(user='regular@mozilla.com', listed=True,
-                 role=amo.AUTHOR_ROLE_DEV, position=1)
-        data = self.formset(f.initial, u, initial_count=1)
+        form = self.client.get(self.url).context['user_form'].initial_forms[0]
+        user_data = {
+            'user': 'regular@mozilla.com',
+            'listed': True,
+            'role': amo.AUTHOR_ROLE_DEV,
+            'position': 1
+        }
+        data = self.formset(form.initial, user_data, initial_count=1)
         self.client.post(self.url, data)
         assert AddonUser.objects.get(addon=3615, user=999).listed
 
@@ -278,10 +299,15 @@ class TestEditAuthor(TestOwnership):
         user_form = self.client.get(self.url).context['user_form']
         one, two = user_form.initial_forms
         two.initial['role'] = amo.AUTHOR_ROLE_VIEWER
-        empty = dict(user='', listed=True, role=5, position=0)
+        empty = {
+            'user': '',
+            'listed': True,
+            'role': 5,
+            'position': 0
+        }
         data = self.formset(one.initial, two.initial, empty, initial_count=2)
-        r = self.client.post(self.url, data)
-        self.assert3xx(r, self.url, 302)
+        response = self.client.post(self.url, data)
+        self.assert3xx(response, self.url, 302)
 
         # An email has been sent to the authors to warn them.
         author_edit = mail.outbox[1]  # First mail was for the addition.
@@ -292,27 +318,36 @@ class TestEditAuthor(TestOwnership):
         assert 'regular@mozilla.com' in author_edit.to  # The edited one.
 
     def test_add_user_twice(self):
-        f = self.client.get(self.url).context['user_form'].initial_forms[0]
-        u = dict(user='regular@mozilla.com', listed=True,
-                 role=amo.AUTHOR_ROLE_DEV, position=1)
-        data = self.formset(f.initial, u, u, initial_count=1)
-        r = self.client.post(self.url, data)
-        assert r.status_code == 200
-        assert r.context['user_form'].non_form_errors() == (
+        form = self.client.get(self.url).context['user_form'].initial_forms[0]
+        user_data = {
+            'user': 'regular@mozilla.com',
+            'listed': True,
+            'role': amo.AUTHOR_ROLE_DEV,
+            'position': 1
+        }
+        data = self.formset(
+            form.initial, user_data, user_data, initial_count=1)
+        response = self.client.post(self.url, data)
+        assert response.status_code == 200
+        assert response.context['user_form'].non_form_errors() == (
             ['An author can only be listed once.'])
 
     def test_success_delete_user(self):
         # Add a new user so we have one to delete.
-        data = self.formset(dict(user='regular@mozilla.com', listed=True,
-                                 role=amo.AUTHOR_ROLE_OWNER, position=1),
-                            initial_count=0)
+        user_data = {
+            'user': 'regular@mozilla.com',
+            'listed': True,
+            'role': amo.AUTHOR_ROLE_OWNER,
+            'position': 1
+        }
+        data = self.formset(user_data, initial_count=0)
         self.client.post(self.url, data)
 
         one, two = self.client.get(self.url).context['user_form'].initial_forms
         one.initial['DELETE'] = True
         data = self.formset(one.initial, two.initial, initial_count=2)
-        r = self.client.post(self.url, data)
-        assert r.status_code == 302
+        response = self.client.post(self.url, data)
+        assert response.status_code == 302
         assert 999 == AddonUser.objects.get(addon=3615).user_id
 
         # An email has been sent to the authors to warn them.
@@ -325,11 +360,11 @@ class TestEditAuthor(TestOwnership):
 
     def test_switch_owner(self):
         # See if we can transfer ownership in one POST.
-        f = self.client.get(self.url).context['user_form'].initial_forms[0]
-        f.initial['user'] = 'regular@mozilla.com'
-        data = self.formset(f.initial, initial_count=1)
-        r = self.client.post(self.url, data)
-        assert r.status_code == 302
+        form = self.client.get(self.url).context['user_form'].initial_forms[0]
+        form.initial['user'] = 'regular@mozilla.com'
+        data = self.formset(form.initial, initial_count=1)
+        response = self.client.post(self.url, data)
+        assert response.status_code == 302
         assert 999 == AddonUser.objects.get(addon=3615).user_id
         assert ActivityLog.objects.filter(
             action=amo.LOG.ADD_USER_WITH_ROLE.id).count() == 1
@@ -337,10 +372,14 @@ class TestEditAuthor(TestOwnership):
             action=amo.LOG.REMOVE_USER_WITH_ROLE.id).count() == 1
 
     def test_only_owner_can_edit(self):
-        f = self.client.get(self.url).context['user_form'].initial_forms[0]
-        u = dict(user='regular@mozilla.com', listed=True,
-                 role=amo.AUTHOR_ROLE_DEV, position=0)
-        data = self.formset(f.initial, u, initial_count=1)
+        form = self.client.get(self.url).context['user_form'].initial_forms[0]
+        user_data = {
+            'user': 'regular@mozilla.com',
+            'listed': True,
+            'role': amo.AUTHOR_ROLE_DEV,
+            'position': 0
+        }
+        data = self.formset(form.initial, user_data, initial_count=1)
         self.client.post(self.url, data)
 
         self.client.login(email='regular@mozilla.com')
@@ -350,30 +389,30 @@ class TestEditAuthor(TestOwnership):
         one, two = self.client.get(self.url).context['user_form'].initial_forms
         one.initial['DELETE'] = True
         data = self.formset(one.initial, two.initial, initial_count=2)
-        r = self.client.post(self.url, data, follow=True)
-        assert r.status_code == 403
+        response = self.client.post(self.url, data, follow=True)
+        assert response.status_code == 403
         assert AddonUser.objects.filter(addon=3615).count() == 2
 
     def test_must_have_listed(self):
-        f = self.client.get(self.url).context['user_form'].initial_forms[0]
-        f.initial['listed'] = False
-        data = self.formset(f.initial, initial_count=1)
-        r = self.client.post(self.url, data)
-        assert r.context['user_form'].non_form_errors() == (
+        form = self.client.get(self.url).context['user_form'].initial_forms[0]
+        form.initial['listed'] = False
+        data = self.formset(form.initial, initial_count=1)
+        response = self.client.post(self.url, data)
+        assert response.context['user_form'].non_form_errors() == (
             ['At least one author must be listed.'])
 
     def test_must_have_owner(self):
-        f = self.client.get(self.url).context['user_form'].initial_forms[0]
-        f.initial['role'] = amo.AUTHOR_ROLE_DEV
-        data = self.formset(f.initial, initial_count=1)
-        r = self.client.post(self.url, data)
-        assert r.context['user_form'].non_form_errors() == (
+        form = self.client.get(self.url).context['user_form'].initial_forms[0]
+        form.initial['role'] = amo.AUTHOR_ROLE_DEV
+        data = self.formset(form.initial, initial_count=1)
+        response = self.client.post(self.url, data)
+        assert response.context['user_form'].non_form_errors() == (
             ['Must have at least one owner.'])
 
     def test_must_have_owner_delete(self):
-        f = self.client.get(self.url).context['user_form'].initial_forms[0]
-        f.initial['DELETE'] = True
-        data = self.formset(f.initial, initial_count=1)
-        r = self.client.post(self.url, data)
-        assert r.context['user_form'].non_form_errors() == (
+        form = self.client.get(self.url).context['user_form'].initial_forms[0]
+        form.initial['DELETE'] = True
+        data = self.formset(form.initial, initial_count=1)
+        response = self.client.post(self.url, data)
+        assert response.context['user_form'].non_form_errors() == (
             ['Must have at least one owner.'])

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -43,9 +43,9 @@ class TestSubmitPersona(TestCase):
         )
 
     def test_img_urls(self):
-        r = self.client.get(self.url)
-        assert r.status_code == 200
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
         header_url, footer_url = self.get_img_urls()
         assert doc('#id_header').attr('data-upload-url') == header_url
         assert doc('#id_footer').attr('data-upload-url') == footer_url
@@ -122,10 +122,10 @@ class TestAddonSubmitDistribution(TestCase):
         self.user = UserProfile.objects.get(email='regular@mozilla.com')
 
     def test_check_agreement_okay(self):
-        r = self.client.post(reverse('devhub.submit.agreement'))
-        self.assert3xx(r, reverse('devhub.submit.distribution'))
-        r = self.client.get(reverse('devhub.submit.distribution'))
-        assert r.status_code == 200
+        response = self.client.post(reverse('devhub.submit.agreement'))
+        self.assert3xx(response, reverse('devhub.submit.distribution'))
+        response = self.client.get(reverse('devhub.submit.distribution'))
+        assert response.status_code == 200
 
     def test_submit_notification_warning(self):
         config = Config.objects.create(
@@ -140,8 +140,9 @@ class TestAddonSubmitDistribution(TestCase):
         # We require a cookie that gets set in step 1.
         self.user.update(read_dev_agreement=None)
 
-        r = self.client.get(reverse('devhub.submit.distribution'), follow=True)
-        self.assert3xx(r, reverse('devhub.submit.agreement'))
+        response = self.client.get(
+            reverse('devhub.submit.distribution'), follow=True)
+        self.assert3xx(response, reverse('devhub.submit.agreement'))
 
     def test_listed_redirects_to_next_step(self):
         response = self.client.post(reverse('devhub.submit.distribution'),
@@ -169,17 +170,21 @@ class TestAddonSubmitUpload(UploadTest, TestCase):
              source=None, listed=True, status_code=200):
         if supported_platforms is None:
             supported_platforms = [amo.PLATFORM_ALL]
-        d = dict(upload=self.upload.uuid.hex, source=source,
-                 supported_platforms=[p.id for p in supported_platforms])
+        data = {
+            'upload': self.upload.uuid.hex,
+            'source': source,
+            'supported_platforms': [p.id for p in supported_platforms]
+        }
         url = reverse('devhub.submit.upload',
                       args=['listed' if listed else 'unlisted'])
-        r = self.client.post(url, d, follow=True)
-        assert r.status_code == status_code
+        response = self.client.post(url, data, follow=True)
+        assert response.status_code == status_code
         if not expect_errors:
             # Show any unexpected form errors.
-            if r.context and 'new_addon_form' in r.context:
-                assert r.context['new_addon_form'].errors.as_text() == ''
-        return r
+            if response.context and 'new_addon_form' in response.context:
+                assert (
+                    response.context['new_addon_form'].errors.as_text() == '')
+        return response
 
     def test_unique_name(self):
         addon_factory(name='xpi name')
@@ -216,13 +221,14 @@ class TestAddonSubmitUpload(UploadTest, TestCase):
 
     def test_success_listed(self):
         assert Addon.objects.count() == 0
-        r = self.post()
+        response = self.post()
         addon = Addon.objects.get()
         assert addon.is_listed
         version = addon.find_latest_version(channel=amo.RELEASE_CHANNEL_LISTED)
         assert version
         assert version.channel == amo.RELEASE_CHANNEL_LISTED
-        self.assert3xx(r, reverse('devhub.submit.details', args=[addon.slug]))
+        self.assert3xx(
+            response, reverse('devhub.submit.details', args=[addon.slug]))
         log_items = ActivityLog.objects.for_addons(addon)
         assert log_items.filter(action=amo.LOG.CREATE_ADDON.id), (
             'New add-on creation never logged.')
@@ -232,15 +238,19 @@ class TestAddonSubmitUpload(UploadTest, TestCase):
         """Sign automatically."""
         assert Addon.objects.count() == 0
         # No validation errors or warning.
+        result = {
+            'errors': 0,
+            'warnings': 0,
+            'notices': 2,
+            'metadata': {},
+            'messages': [],
+            'signing_summary': {
+                'trivial': 1, 'low': 0, 'medium': 0, 'high': 0
+            },
+            'passed_auto_validation': True
+        }
         self.upload = self.get_upload(
-            'extension.xpi',
-            validation=json.dumps(dict(errors=0, warnings=0, notices=2,
-                                       metadata={}, messages=[],
-                                       signing_summary={
-                                           'trivial': 1, 'low': 0, 'medium': 0,
-                                           'high': 0},
-                                       passed_auto_validation=True
-                                       )))
+            'extension.xpi', validation=json.dumps(result))
         self.post(listed=False)
         addon = Addon.objects.get()
         assert not addon.is_listed
@@ -254,15 +264,19 @@ class TestAddonSubmitUpload(UploadTest, TestCase):
     @mock.patch('olympia.editors.helpers.sign_file')
     def test_success_unlisted_fail_validation(self, mock_sign_file):
         assert Addon.objects.count() == 0
+        result = {
+            'errors': 0,
+            'warnings': 0,
+            'notices': 2,
+            'metadata': {},
+            'messages': [],
+            'signing_summary': {
+                'trivial': 0, 'low': 1, 'medium': 0, 'high': 0
+            },
+            'passed_auto_validation': False
+        }
         self.upload = self.get_upload(
-            'extension.xpi',
-            validation=json.dumps(dict(errors=0, warnings=0, notices=2,
-                                       metadata={}, messages=[],
-                                       signing_summary={
-                                           'trivial': 0, 'low': 1, 'medium': 0,
-                                           'high': 0},
-                                       passed_auto_validation=False
-                                       )))
+            'extension.xpi', validation=json.dumps(result))
         self.post(listed=False)
         addon = Addon.objects.get()
         assert not addon.is_listed
@@ -275,20 +289,21 @@ class TestAddonSubmitUpload(UploadTest, TestCase):
 
     def test_missing_platforms(self):
         url = reverse('devhub.submit.upload', args=['listed'])
-        r = self.client.post(url, dict(upload=self.upload.uuid.hex))
-        assert r.status_code == 200
-        assert r.context['new_addon_form'].errors.as_text() == (
+        response = self.client.post(url, {'upload': self.upload.uuid.hex})
+        assert response.status_code == 200
+        assert response.context['new_addon_form'].errors.as_text() == (
             '* supported_platforms\n  * Need at least one platform.')
-        doc = pq(r.content)
+        doc = pq(response.content)
         assert doc('ul.errorlist').text() == (
             'Need at least one platform.')
 
     def test_one_xpi_for_multiple_platforms(self):
         assert Addon.objects.count() == 0
-        r = self.post(supported_platforms=[amo.PLATFORM_MAC,
-                                           amo.PLATFORM_LINUX])
+        response = self.post(
+            supported_platforms=[amo.PLATFORM_MAC, amo.PLATFORM_LINUX])
         addon = Addon.objects.get()
-        self.assert3xx(r, reverse('devhub.submit.details', args=[addon.slug]))
+        self.assert3xx(
+            response, reverse('devhub.submit.details', args=[addon.slug]))
         all_ = sorted([f.filename for f in addon.current_version.all_files])
         assert all_ == [u'xpi_name-0.1-linux.xpi', u'xpi_name-0.1-mac.xpi']
 
@@ -296,13 +311,14 @@ class TestAddonSubmitUpload(UploadTest, TestCase):
     def test_one_xpi_for_multiple_platforms_unlisted_addon(
             self, mock_auto_sign_file):
         assert Addon.objects.count() == 0
-        r = self.post(supported_platforms=[amo.PLATFORM_MAC,
-                                           amo.PLATFORM_LINUX],
-                      listed=False)
+        response = self.post(
+            supported_platforms=[amo.PLATFORM_MAC, amo.PLATFORM_LINUX],
+            listed=False)
         addon = Addon.unfiltered.get()
         latest_version = addon.find_latest_version(
             channel=amo.RELEASE_CHANNEL_UNLISTED)
-        self.assert3xx(r, reverse('devhub.submit.finish', args=[addon.slug]))
+        self.assert3xx(
+            response, reverse('devhub.submit.finish', args=[addon.slug]))
         all_ = sorted([f.filename for f in latest_version.all_files])
         assert all_ == [u'xpi_name-0.1-linux.xpi', u'xpi_name-0.1-mac.xpi']
         mock_auto_sign_file.assert_has_calls(
@@ -314,9 +330,10 @@ class TestAddonSubmitUpload(UploadTest, TestCase):
         source.write('a' * (2 ** 21))
         source.seek(0)
         assert Addon.objects.count() == 0
-        r = self.post(source=source)
+        response = self.post(source=source)
         addon = Addon.objects.get()
-        self.assert3xx(r, reverse('devhub.submit.details', args=[addon.slug]))
+        self.assert3xx(
+            response, reverse('devhub.submit.details', args=[addon.slug]))
         assert addon.current_version.source
         assert Addon.objects.get(pk=addon.pk).admin_review
 
@@ -371,14 +388,14 @@ class TestAddonSubmitDetails(TestSubmitBase):
 
     def test_submit_success_required(self):
         # Set/change the required fields only
-        r = self.client.get(self.url)
-        assert r.status_code == 200
+        response = self.client.get(self.url)
+        assert response.status_code == 200
 
         # Post and be redirected - trying to sneak
         # in fields that shouldn't be modified via this form.
-        d = self.get_dict(homepage='foo.com',
-                          tags='whatevs, whatever')
-        self.is_success(d)
+        data = self.get_dict(homepage='foo.com',
+                             tags='whatevs, whatever')
+        self.is_success(data)
 
         addon = self.get_addon()
 
@@ -401,8 +418,8 @@ class TestAddonSubmitDetails(TestSubmitBase):
     def test_submit_success_optional_fields(self):
         # Set/change the optional fields too
         # Post and be redirected
-        d = self.get_dict(minimal=False)
-        self.is_success(d)
+        data = self.get_dict(minimal=False)
+        self.is_success(data)
 
         addon = self.get_addon()
 
@@ -421,57 +438,59 @@ class TestAddonSubmitDetails(TestSubmitBase):
 
     def test_submit_name_length(self):
         # Make sure the name isn't too long.
-        d = self.get_dict(name='a' * 51)
-        r = self.client.post(self.url, d)
-        assert r.status_code == 200
+        data = self.get_dict(name='a' * 51)
+        response = self.client.post(self.url, data)
+        assert response.status_code == 200
         error = 'Ensure this value has at most 50 characters (it has 51).'
-        self.assertFormError(r, 'form', 'name', error)
+        self.assertFormError(response, 'form', 'name', error)
 
     def test_submit_slug_invalid(self):
         # Submit an invalid slug.
-        d = self.get_dict(slug='slug!!! aksl23%%')
-        r = self.client.post(self.url, d)
-        assert r.status_code == 200
-        self.assertFormError(r, 'form', 'slug', "Enter a valid 'slug' " +
-                             "consisting of letters, numbers, underscores or "
-                             "hyphens.")
+        data = self.get_dict(slug='slug!!! aksl23%%')
+        response = self.client.post(self.url, data)
+        assert response.status_code == 200
+        self.assertFormError(response, 'form', 'slug', "Enter a valid 'slug'" +
+                             ' consisting of letters, numbers, underscores or '
+                             'hyphens.')
 
     def test_submit_slug_required(self):
         # Make sure the slug is required.
-        r = self.client.post(self.url, self.get_dict(slug=''))
-        assert r.status_code == 200
-        self.assertFormError(r, 'form', 'slug', 'This field is required.')
+        response = self.client.post(self.url, self.get_dict(slug=''))
+        assert response.status_code == 200
+        self.assertFormError(
+            response, 'form', 'slug', 'This field is required.')
 
     def test_submit_summary_required(self):
         # Make sure summary is required.
-        r = self.client.post(self.url, self.get_dict(summary=''))
-        assert r.status_code == 200
-        self.assertFormError(r, 'form', 'summary', 'This field is required.')
+        response = self.client.post(self.url, self.get_dict(summary=''))
+        assert response.status_code == 200
+        self.assertFormError(
+            response, 'form', 'summary', 'This field is required.')
 
     def test_submit_summary_length(self):
         # Summary is too long.
-        r = self.client.post(self.url, self.get_dict(summary='a' * 251))
-        assert r.status_code == 200
+        response = self.client.post(self.url, self.get_dict(summary='a' * 251))
+        assert response.status_code == 200
         error = 'Ensure this value has at most 250 characters (it has 251).'
-        self.assertFormError(r, 'form', 'summary', error)
+        self.assertFormError(response, 'form', 'summary', error)
 
     def test_submit_categories_required(self):
         del self.cat_initial['categories']
-        r = self.client.post(self.url,
-                             self.get_dict(cat_initial=self.cat_initial))
-        assert r.context['cat_form'].errors[0]['categories'] == (
+        response = self.client.post(
+            self.url, self.get_dict(cat_initial=self.cat_initial))
+        assert response.context['cat_form'].errors[0]['categories'] == (
             ['This field is required.'])
 
     def test_submit_categories_max(self):
         assert amo.MAX_CATEGORIES == 2
         self.cat_initial['categories'] = [22, 1, 71]
-        r = self.client.post(self.url,
-                             self.get_dict(cat_initial=self.cat_initial))
-        assert r.context['cat_form'].errors[0]['categories'] == (
+        response = self.client.post(
+            self.url, self.get_dict(cat_initial=self.cat_initial))
+        assert response.context['cat_form'].errors[0]['categories'] == (
             ['You can have only 2 categories.'])
 
     def test_submit_categories_add(self):
-        assert [c.id for c in self.get_addon().all_categories] == [22]
+        assert [cat.id for cat in self.get_addon().all_categories] == [22]
         self.cat_initial['categories'] = [22, 1]
 
         self.is_success(self.get_dict())
@@ -482,7 +501,7 @@ class TestAddonSubmitDetails(TestSubmitBase):
     def test_submit_categories_addandremove(self):
         AddonCategory(addon=self.addon, category_id=1).save()
         assert sorted(
-            [c.id for c in self.get_addon().all_categories]) == [1, 22]
+            [cat.id for cat in self.get_addon().all_categories]) == [1, 22]
 
         self.cat_initial['categories'] = [22, 71]
         self.client.post(self.url, self.get_dict(cat_initial=self.cat_initial))
@@ -490,10 +509,10 @@ class TestAddonSubmitDetails(TestSubmitBase):
         assert sorted(category_ids_new) == [22, 71]
 
     def test_submit_categories_remove(self):
-        c = Category.objects.get(id=1)
-        AddonCategory(addon=self.addon, category=c).save()
+        category = Category.objects.get(id=1)
+        AddonCategory(addon=self.addon, category=category).save()
         assert sorted(
-            [a.id for a in self.get_addon().all_categories]) == [1, 22]
+            [cat.id for cat in self.get_addon().all_categories]) == [1, 22]
 
         self.cat_initial['categories'] = [22]
         self.client.post(self.url, self.get_dict(cat_initial=self.cat_initial))
@@ -618,9 +637,9 @@ class TestAddonSubmitFinish(TestSubmitBase):
             channel=amo.RELEASE_CHANNEL_LISTED)
         assert version.supported_platforms == ([amo.PLATFORM_ALL])
 
-        r = self.client.get(self.url)
-        assert r.status_code == 200
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
 
         content = doc('.addon-submission-process')
         links = content('a')
@@ -664,9 +683,9 @@ class TestAddonSubmitFinish(TestSubmitBase):
             status=amo.STATUS_AWAITING_REVIEW, platform=amo.PLATFORM_MAC.id)
         latest_version.save()
         assert latest_version.is_allowed_upload()
-        r = self.client.get(self.url)
-        assert r.status_code == 200
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
 
         content = doc('.addon-submission-process')
         links = content('a')
@@ -694,9 +713,9 @@ class TestAddonSubmitFinish(TestSubmitBase):
             status=amo.STATUS_AWAITING_REVIEW, platform=amo.PLATFORM_MAC.id)
         latest_version.save()
         assert latest_version.is_allowed_upload()
-        r = self.client.get(self.url)
-        assert r.status_code == 200
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
 
         content = doc('.addon-submission-process')
         links = content('a')
@@ -715,16 +734,17 @@ class TestAddonSubmitFinish(TestSubmitBase):
     def test_addon_no_versions_redirects_to_versions(self):
         self.addon.update(status=amo.STATUS_NULL)
         self.addon.versions.all().delete()
-        r = self.client.get(self.url, follow=True)
-        self.assert3xx(r, self.addon.get_dev_url('versions'), 302)
+        response = self.client.get(self.url, follow=True)
+        self.assert3xx(response, self.addon.get_dev_url('versions'), 302)
 
     def test_incomplete_directs_to_details(self):
         # We get bounced back to details step.
         self.addon.update(status=amo.STATUS_NULL)
         self.addon.categories.all().delete()
-        r = self.client.get(reverse('devhub.submit.finish',
-                                    args=['a3615']), follow=True)
-        self.assert3xx(r, reverse('devhub.submit.details', args=['a3615']))
+        response = self.client.get(
+            reverse('devhub.submit.finish', args=['a3615']), follow=True)
+        self.assert3xx(
+            response, reverse('devhub.submit.details', args=['a3615']))
 
 
 class TestAddonSubmitResume(TestSubmitBase):
@@ -732,9 +752,10 @@ class TestAddonSubmitResume(TestSubmitBase):
     def test_redirect_from_other_pages(self):
         self.addon.update(status=amo.STATUS_NULL)
         self.addon.categories.all().delete()
-        r = self.client.get(reverse('devhub.addons.edit', args=['a3615']),
-                            follow=True)
-        self.assert3xx(r, reverse('devhub.submit.details', args=['a3615']))
+        response = self.client.get(
+            reverse('devhub.addons.edit', args=['a3615']), follow=True)
+        self.assert3xx(
+            response, reverse('devhub.submit.details', args=['a3615']))
 
 
 @override_switch('mixed-listed-unlisted', active=True)
@@ -857,12 +878,16 @@ class VersionSubmitUploadMixin(object):
              beta=False):
         if supported_platforms is None:
             supported_platforms = [amo.PLATFORM_MAC]
-        d = dict(upload=self.upload.uuid.hex, source=source,
-                 supported_platforms=[p.id for p in supported_platforms],
-                 admin_override_validation=override_validation, beta=beta)
-        r = self.client.post(self.url, d)
-        assert r.status_code == expected_status
-        return r
+        data = {
+            'upload': self.upload.uuid.hex,
+            'source': source,
+            'supported_platforms': [p.id for p in supported_platforms],
+            'admin_override_validation': override_validation,
+            'beta': beta
+        }
+        response = self.client.post(self.url, data)
+        assert response.status_code == expected_status
+        return response
 
     def get_next_url(self, version):
         raise NotImplementedError
@@ -888,9 +913,9 @@ class VersionSubmitUploadMixin(object):
             '* source\n  * Unsupported file type, please upload an archive ')
 
     def test_missing_platforms(self):
-        r = self.client.post(self.url, dict(upload=self.upload.uuid.hex))
-        assert r.status_code == 200
-        assert r.context['new_addon_form'].errors.as_text() == (
+        response = self.client.post(self.url, {'upload': self.upload.uuid.hex})
+        assert response.status_code == 200
+        assert response.context['new_addon_form'].errors.as_text() == (
             '* supported_platforms\n  * Need at least one platform.')
 
     def test_one_xpi_for_multiple_platforms(self):
@@ -904,8 +929,8 @@ class VersionSubmitUploadMixin(object):
 
     def test_unique_version_num(self):
         self.version.update(version='0.1')
-        r = self.post(expected_status=200)
-        assert pq(r.content)('ul.errorlist').text() == (
+        response = self.post(expected_status=200)
+        assert pq(response.content)('ul.errorlist').text() == (
             'Version 0.1 already exists, or was uploaded before.')
 
     def test_same_version_if_previous_is_rejected(self):
@@ -913,8 +938,8 @@ class VersionSubmitUploadMixin(object):
         # versions have been disabled/rejected.
         self.version.update(version='0.1')
         self.version.files.update(status=amo.STATUS_DISABLED)
-        r = self.post(expected_status=200)
-        assert pq(r.content)('ul.errorlist').text() == (
+        response = self.post(expected_status=200)
+        assert pq(response.content)('ul.errorlist').text() == (
             'Version 0.1 already exists, or was uploaded before.')
 
     def test_same_version_if_previous_is_deleted(self):
@@ -922,8 +947,8 @@ class VersionSubmitUploadMixin(object):
         # versions has been deleted either.
         self.version.update(version='0.1')
         self.version.delete()
-        r = self.post(expected_status=200)
-        assert pq(r.content)('ul.errorlist').text() == (
+        response = self.post(expected_status=200)
+        assert pq(response.content)('ul.errorlist').text() == (
             'Version 0.1 already exists, or was uploaded before.')
 
     @override_switch('mixed-listed-unlisted', active=True)
@@ -956,8 +981,8 @@ class VersionSubmitUploadMixin(object):
 
     def test_url_is_404_for_disabled_addons(self):
         self.addon.update(status=amo.STATUS_DISABLED)
-        r = self.client.get(self.url)
-        assert r.status_code == 404
+        response = self.client.get(self.url)
+        assert response.status_code == 404
 
     def test_no_redirect_for_metadata(self):
         self.addon.update(status=amo.STATUS_NULL)
@@ -1036,15 +1061,19 @@ class TestVersionSubmitUploadUnlisted(VersionSubmitUploadMixin, UploadTest):
     def test_success(self, mock_sign_file):
         """Sign automatically."""
         # No validation errors or warning.
+        result = {
+            'errors': 0,
+            'warnings': 0,
+            'notices': 2,
+            'metadata': {},
+            'messages': [],
+            'signing_summary': {
+                'trivial': 1, 'low': 0, 'medium': 0, 'high': 0
+            },
+            'passed_auto_validation': True
+        }
         self.upload = self.get_upload(
-            'extension.xpi',
-            validation=json.dumps(dict(errors=0, warnings=0, notices=2,
-                                       metadata={}, messages=[],
-                                       signing_summary={
-                                           'trivial': 1, 'low': 0, 'medium': 0,
-                                           'high': 0},
-                                       passed_auto_validation=True
-                                       )))
+            'extension.xpi', validation=json.dumps(result))
         response = self.post()
         version = self.addon.find_latest_version(
             channel=amo.RELEASE_CHANNEL_UNLISTED)
@@ -1055,15 +1084,19 @@ class TestVersionSubmitUploadUnlisted(VersionSubmitUploadMixin, UploadTest):
 
     @mock.patch('olympia.editors.helpers.sign_file')
     def test_success_fail_validation(self, mock_sign_file):
+        result = {
+            'errors': 0,
+            'warnings': 0,
+            'notices': 2,
+            'metadata': {},
+            'messages': [],
+            'signing_summary': {
+                'trivial': 0, 'low': 1, 'medium': 0, 'high': 0
+            },
+            'passed_auto_validation': False
+        }
         self.upload = self.get_upload(
-            'extension.xpi',
-            validation=json.dumps(dict(errors=0, warnings=0, notices=2,
-                                       metadata={}, messages=[],
-                                       signing_summary={
-                                           'trivial': 0, 'low': 1, 'medium': 0,
-                                           'high': 0},
-                                       passed_auto_validation=False
-                                       )))
+            'extension.xpi', validation=json.dumps(result))
         response = self.post()
         version = self.addon.find_latest_version(
             channel=amo.RELEASE_CHANNEL_UNLISTED)
@@ -1103,8 +1136,8 @@ class TestVersionSubmitDetails(TestSubmitBase):
 
     def test_submit_empty_is_okay(self):
         assert all(self.get_addon().get_required_metadata())
-        r = self.client.get(self.url)
-        assert r.status_code == 200
+        response = self.client.get(self.url)
+        assert response.status_code == 200
 
         response = self.client.post(self.url, {})
         self.assert3xx(
@@ -1116,8 +1149,8 @@ class TestVersionSubmitDetails(TestSubmitBase):
 
     def test_submit_success(self):
         assert all(self.get_addon().get_required_metadata())
-        r = self.client.get(self.url)
-        assert r.status_code == 200
+        response = self.client.get(self.url)
+        assert response.status_code == 200
 
         # Post and be redirected - trying to sneak in a field that shouldn't
         # be modified when this is not the first listed version.
@@ -1221,12 +1254,16 @@ class TestFileSubmitUpload(UploadTest):
              beta=False):
         if supported_platforms is None:
             supported_platforms = [amo.PLATFORM_MAC]
-        d = dict(upload=self.upload.uuid.hex, source=source,
-                 supported_platforms=[p.id for p in supported_platforms],
-                 admin_override_validation=override_validation, beta=beta)
-        r = self.client.post(self.url, d)
-        assert r.status_code == expected_status, r.content
-        return r
+        data = {
+            'upload': self.upload.uuid.hex,
+            'source': source,
+            'supported_platforms': [p.id for p in supported_platforms],
+            'admin_override_validation': override_validation,
+            'beta': beta
+        }
+        response = self.client.post(self.url, data)
+        assert response.status_code == expected_status, response.content
+        return response
 
     def test_success_listed(self):
         files_pre = self.version.all_files
@@ -1249,13 +1286,18 @@ class TestFileSubmitUpload(UploadTest):
     def test_success_unlisted(self):
         self.version.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
         files_pre = self.version.all_files
-        FileValidation.from_json(
-            files_pre[0],
-            json.dumps(dict(errors=0, warnings=0, notices=2, metadata={},
-                            messages=[],
-                            signing_summary={'trivial': 1, 'low': 0,
-                                             'medium': 0, 'high': 0},
-                            passed_auto_validation=True)))
+        result = {
+            'errors': 0,
+            'warnings': 0,
+            'notices': 2,
+            'metadata': {},
+            'messages': [],
+            'signing_summary': {
+                'trivial': 1, 'low': 0, 'medium': 0, 'high': 0
+            },
+            'passed_auto_validation': True
+        }
+        FileValidation.from_json(files_pre[0], json.dumps(result))
         response = self.post()
         assert self.version == self.addon.find_latest_version(
             channel=amo.RELEASE_CHANNEL_UNLISTED)
@@ -1278,14 +1320,14 @@ class TestFileSubmitUpload(UploadTest):
         self.version.all_files[0].update(status=amo.STATUS_PUBLIC)
         assert not self.version.is_allowed_upload()
 
-        r = self.post(expected_status=200)
-        assert pq(r.content)('ul.errorlist').text() == (
+        response = self.post(expected_status=200)
+        assert pq(response.content)('ul.errorlist').text() == (
             'You cannot upload any more files for this version.')
 
     def test_failure_when_version_number_doesnt_match(self):
         self.version.update(version='99')
-        r = self.post(expected_status=200)
-        assert pq(r.content)('ul.errorlist').text() == (
+        response = self.post(expected_status=200)
+        assert pq(response.content)('ul.errorlist').text() == (
             "Version doesn't match")
 
     def test_force_beta_is_ignored(self):
@@ -1299,13 +1341,18 @@ class TestFileSubmitUpload(UploadTest):
         """Files must have the same beta status as the existing version."""
         existing_file = self.version.all_files[0]
         existing_file.update(status=amo.STATUS_BETA)
-        FileValidation.from_json(
-            existing_file,
-            json.dumps(dict(errors=0, warnings=0, notices=2, metadata={},
-                            messages=[],
-                            signing_summary={'trivial': 1, 'low': 0,
-                                             'medium': 0, 'high': 0},
-                            passed_auto_validation=True)))
+        result = {
+            'errors': 0,
+            'warnings': 0,
+            'notices': 2,
+            'metadata': {},
+            'messages': [],
+            'signing_summary': {
+                'trivial': 1, 'low': 0, 'medium': 0, 'high': 0
+            },
+            'passed_auto_validation': True
+        }
+        FileValidation.from_json(existing_file, json.dumps(result))
         self.version.save()
 
         self.post(beta=False)

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -41,9 +41,9 @@ class TestVersion(TestCase):
         return Addon.objects.get(id=3615)
 
     def get_doc(self):
-        res = self.client.get(self.url)
-        assert res.status_code == 200
-        return pq(res.content)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        return pq(response.content)
 
     def test_version_status_public(self):
         doc = self.get_doc()
@@ -77,21 +77,21 @@ class TestVersion(TestCase):
     def test_upload_link_label_in_edit_nav(self):
         url = reverse('devhub.versions.edit',
                       args=(self.addon.slug, self.version.pk))
-        r = self.client.get(url)
-        link = pq(r.content)('.addon-status>.addon-upload>strong>a')
+        response = self.client.get(url)
+        link = pq(response.content)('.addon-status>.addon-upload>strong>a')
         assert link.text() == 'Upload New Version'
         assert link.attr('href') == (
             reverse('devhub.submit.version', args=[self.addon.slug]))
 
         # Don't show for STATUS_DISABLED addons.
         self.addon.update(status=amo.STATUS_DISABLED)
-        r = self.client.get(url)
-        assert not pq(r.content)('.addon-status>.addon-upload>strong>a')
+        response = self.client.get(url)
+        assert not pq(response.content)('.addon-status>.addon-upload>strong>a')
 
     def test_delete_message(self):
         """Make sure we warn our users of the pain they will feel."""
-        r = self.client.get(self.url)
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         assert doc('#modal-delete p').eq(0).text() == (
             'Deleting your add-on will permanently delete all versions and '
             'files you have submitted for this add-on, listed or not. '
@@ -103,8 +103,8 @@ class TestVersion(TestCase):
         self.addon.status = amo.STATUS_NOMINATED
         self.addon.save()
 
-        r = self.client.get(self.url)
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         assert doc('#modal-delete p').eq(0).text() == (
             'Deleting your add-on will permanently delete all versions and '
             'files you have submitted for this add-on, listed or not. '
@@ -120,8 +120,8 @@ class TestVersion(TestCase):
         self.addon.current_version.delete(hard=True)
         self.addon.reload()
         assert self.addon.status == amo.STATUS_NULL
-        r = self.client.get(self.url)
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         # Normally 2 paragraphs, one is the warning which we should take out.
         assert doc('#modal-delete p.warning').length == 0
 
@@ -134,8 +134,9 @@ class TestVersion(TestCase):
     def test_delete_version_then_detail(self):
         version, file = self._extra_version_and_file(amo.STATUS_PUBLIC)
         self.client.post(self.delete_url, self.delete_data)
-        res = self.client.get(reverse('addons.detail', args=[self.addon.slug]))
-        assert res.status_code == 200
+        response = self.client.get(
+            reverse('addons.detail', args=[self.addon.slug]))
+        assert response.status_code == 200
 
     def test_version_delete_version_deleted(self):
         self.version.delete()
@@ -144,13 +145,13 @@ class TestVersion(TestCase):
 
     def test_cant_delete_version(self):
         self.client.logout()
-        res = self.client.post(self.delete_url, self.delete_data)
-        assert res.status_code == 302
+        response = self.client.post(self.delete_url, self.delete_data)
+        assert response.status_code == 302
         assert Version.objects.filter(pk=81551).exists()
 
     def test_version_delete_status_null(self):
-        res = self.client.post(self.delete_url, self.delete_data)
-        assert res.status_code == 302
+        response = self.client.post(self.delete_url, self.delete_data)
+        assert response.status_code == 302
         assert self.addon.versions.count() == 0
         assert Addon.objects.get(id=3615).status == amo.STATUS_NULL
 
@@ -189,16 +190,16 @@ class TestVersion(TestCase):
     def test_version_delete_status(self):
         self._extra_version_and_file(amo.STATUS_PUBLIC)
 
-        res = self.client.post(self.delete_url, self.delete_data)
-        assert res.status_code == 302
+        response = self.client.post(self.delete_url, self.delete_data)
+        assert response.status_code == 302
         assert self.addon.versions.count() == 1
         assert Addon.objects.get(id=3615).status == amo.STATUS_PUBLIC
 
     def test_version_delete_status_unreviewd(self):
         self._extra_version_and_file(amo.STATUS_BETA)
 
-        res = self.client.post(self.delete_url, self.delete_data)
-        assert res.status_code == 302
+        response = self.client.post(self.delete_url, self.delete_data)
+        assert response.status_code == 302
         assert self.addon.versions.count() == 1
         assert Addon.objects.get(id=3615).status == amo.STATUS_NULL
 
@@ -207,8 +208,8 @@ class TestVersion(TestCase):
         version = self.addon.current_version
         self.addon.update(status=amo.STATUS_PUBLIC,
                           disabled_by_user=False)
-        res = self.client.post(self.disable_url)
-        assert res.status_code == 302
+        response = self.client.post(self.disable_url)
+        assert response.status_code == 302
         addon = Addon.objects.get(id=3615)
         version.reload()
         assert addon.disabled_by_user
@@ -232,8 +233,8 @@ class TestVersion(TestCase):
         assert self.addon.find_latest_version(
             channel=amo.RELEASE_CHANNEL_LISTED) == new_version
 
-        res = self.client.post(self.disable_url)
-        assert res.status_code == 302
+        response = self.client.post(self.disable_url)
+        assert response.status_code == 302
         addon = Addon.objects.get(id=3615)
         assert addon.disabled_by_user
         assert addon.status == amo.STATUS_PUBLIC
@@ -254,8 +255,8 @@ class TestVersion(TestCase):
     def test_user_can_unlist_addon(self):
         self.addon.update(status=amo.STATUS_PUBLIC, disabled_by_user=False,
                           is_listed=True)
-        res = self.client.post(self.unlist_url)
-        assert res.status_code == 302
+        response = self.client.post(self.unlist_url)
+        assert response.status_code == 302
         addon = Addon.objects.get(id=3615)
         assert addon.status == amo.STATUS_NULL
         assert not addon.is_listed
@@ -273,8 +274,8 @@ class TestVersion(TestCase):
     def test_user_cant_unlist_addon_with_mixed_versions(self):
         self.addon.update(status=amo.STATUS_PUBLIC, disabled_by_user=False,
                           is_listed=True)
-        res = self.client.post(self.unlist_url)
-        assert res.status_code == 404
+        response = self.client.post(self.unlist_url)
+        assert response.status_code == 404
         addon = Addon.objects.get(id=3615)
         assert addon.is_listed
         latest_version = addon.find_latest_version(
@@ -289,8 +290,8 @@ class TestVersion(TestCase):
         deleted_version = version_factory(addon=self.addon)
         deleted_version.delete()
 
-        res = self.client.post(self.unlist_url)
-        assert res.status_code == 302
+        response = self.client.post(self.unlist_url)
+        assert response.status_code == 302
         addon = Addon.objects.get(id=3615)
         assert addon.status == amo.STATUS_NULL
         assert not addon.is_listed
@@ -307,8 +308,8 @@ class TestVersion(TestCase):
     def test_user_can_unlist_hidden_addon(self):
         self.addon.update(status=amo.STATUS_PUBLIC, disabled_by_user=True,
                           is_listed=True)
-        res = self.client.post(self.unlist_url)
-        assert res.status_code == 302
+        response = self.client.post(self.unlist_url)
+        assert response.status_code == 302
         addon = Addon.objects.get(id=3615)
         assert addon.status == amo.STATUS_NULL
         assert not addon.is_listed
@@ -329,10 +330,15 @@ class TestVersion(TestCase):
             channel=amo.RELEASE_CHANNEL_LISTED)
 
         file = latest_version.files.all()[0]
-        validation = dict(notices=0, errors=0, messages=[], metadata={},
-                          warnings=1, passed_auto_validation=1,
-                          signing_summary=dict(trivial=0, low=0, medium=0,
-                                               high=0))
+        validation = {
+            'notices': 0,
+            'errors': 0,
+            'messages': [],
+            'metadata': {},
+            'warnings': 1,
+            'passed_auto_validation': 1,
+            'signing_summary': {'trivial': 0, 'low': 0, 'medium': 0, 'high': 0}
+        }
         FileValidation.from_json(file, validation)
         file.update(status=amo.STATUS_AWAITING_REVIEW)
 
@@ -348,8 +354,8 @@ class TestVersion(TestCase):
 
     def test_user_can_enable_addon(self):
         self.addon.update(status=amo.STATUS_PUBLIC, disabled_by_user=True)
-        res = self.client.post(self.enable_url)
-        self.assert3xx(res, self.url, 302)
+        response = self.client.post(self.enable_url)
+        self.assert3xx(response, self.url, 302)
         addon = self.get_addon()
         assert not addon.disabled_by_user
         assert addon.status == amo.STATUS_PUBLIC
@@ -362,24 +368,24 @@ class TestVersion(TestCase):
     def test_unprivileged_user_cant_disable_addon(self):
         self.addon.update(disabled_by_user=False)
         self.client.logout()
-        res = self.client.post(self.disable_url)
-        assert res.status_code == 302
+        response = self.client.post(self.disable_url)
+        assert response.status_code == 302
         assert not Addon.objects.get(id=3615).disabled_by_user
 
     def test_non_owner_cant_disable_addon(self):
         self.addon.update(disabled_by_user=False)
         self.client.logout()
         assert self.client.login(email='regular@mozilla.com')
-        res = self.client.post(self.disable_url)
-        assert res.status_code == 403
+        response = self.client.post(self.disable_url)
+        assert response.status_code == 403
         assert not Addon.objects.get(id=3615).disabled_by_user
 
     def test_non_owner_cant_enable_addon(self):
         self.addon.update(disabled_by_user=False)
         self.client.logout()
         assert self.client.login(email='regular@mozilla.com')
-        res = self.client.get(self.enable_url)
-        assert res.status_code == 403
+        response = self.client.get(self.enable_url)
+        assert response.status_code == 403
         assert not Addon.objects.get(id=3615).disabled_by_user
 
     def test_non_owner_cant_change_status(self):
@@ -388,8 +394,8 @@ class TestVersion(TestCase):
         addon_user = AddonUser.objects.get(addon=self.addon)
         addon_user.role = amo.AUTHOR_ROLE_VIEWER
         addon_user.save()
-        res = self.client.get(self.url)
-        doc = pq(res.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         assert doc('.enable-addon').attr('checked') == 'checked'
         assert doc('.enable-addon').attr('disabled') == 'disabled'
         assert not doc('.disable-addon').attr('checked')
@@ -401,8 +407,8 @@ class TestVersion(TestCase):
     def test_published_addon_radio(self):
         """Published (listed) addon is selected: can hide or publish."""
         self.addon.update(disabled_by_user=False)
-        res = self.client.get(self.url)
-        doc = pq(res.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         assert doc('.enable-addon').attr('checked') == 'checked'
         enable_url = self.addon.get_dev_url('enable')
         assert doc('.enable-addon').attr('data-url') == enable_url
@@ -418,8 +424,8 @@ class TestVersion(TestCase):
     def test_hidden_addon_radio(self):
         """Hidden (disabled) addon is selected: can hide or publish."""
         self.addon.update(disabled_by_user=True)
-        res = self.client.get(self.url)
-        doc = pq(res.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         assert not doc('.enable-addon').attr('checked')
         assert not doc('.enable-addon').attr('disabled')
         assert doc('.disable-addon').attr('checked') == 'checked'
@@ -433,8 +439,8 @@ class TestVersion(TestCase):
     def test_status_disabled_addon_radio(self):
         """Disabled by Mozilla addon: hidden selected, can't change status."""
         self.addon.update(status=amo.STATUS_DISABLED, disabled_by_user=False)
-        res = self.client.get(self.url)
-        doc = pq(res.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         assert not doc('.enable-addon').attr('checked')
         assert doc('.enable-addon').attr('disabled') == 'disabled'
         assert doc('.disable-addon').attr('checked') == 'checked'
@@ -446,8 +452,8 @@ class TestVersion(TestCase):
         """Unlisted addon: can't change its status so hide choices."""
         self.addon.update(disabled_by_user=False, is_listed=False)
         self.addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
-        res = self.client.get(self.url)
-        doc = pq(res.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         assert not doc('.enable-addon')
         assert not doc('.disable-addon')
         assert not doc('.unlist-addon')
@@ -458,8 +464,8 @@ class TestVersion(TestCase):
     def test_published_addon_radio_mixed_versions(self):
         """Published (listed) addon is selected: can hide or publish."""
         self.addon.update(disabled_by_user=False)
-        res = self.client.get(self.url)
-        doc = pq(res.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         assert doc('.enable-addon').attr('checked') == 'checked'
         enable_url = self.addon.get_dev_url('enable')
         assert doc('.enable-addon').attr('data-url') == enable_url
@@ -474,8 +480,8 @@ class TestVersion(TestCase):
     def test_hidden_addon_radio_mixed_versions(self):
         """Hidden (disabled) addon is selected: can hide or publish."""
         self.addon.update(disabled_by_user=True)
-        res = self.client.get(self.url)
-        doc = pq(res.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         assert not doc('.enable-addon').attr('checked')
         assert not doc('.enable-addon').attr('disabled')
         assert doc('.disable-addon').attr('checked') == 'checked'
@@ -488,8 +494,8 @@ class TestVersion(TestCase):
     def test_status_disabled_addon_radio_mixed_versions(self):
         """Disabled by Mozilla addon: hidden selected, can't change status."""
         self.addon.update(status=amo.STATUS_DISABLED, disabled_by_user=False)
-        res = self.client.get(self.url)
-        doc = pq(res.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         assert not doc('.enable-addon').attr('checked')
         assert doc('.enable-addon').attr('disabled') == 'disabled'
         assert doc('.disable-addon').attr('checked') == 'checked'
@@ -521,8 +527,8 @@ class TestVersion(TestCase):
         self.client.logout()
         cancel_url = reverse('devhub.addons.cancel', args=['a3615'])
         assert self.addon.status == amo.STATUS_PUBLIC
-        res = self.client.post(cancel_url)
-        assert res.status_code == 302
+        response = self.client.post(cancel_url)
+        assert response.status_code == 302
         assert Addon.objects.get(id=3615).status == amo.STATUS_PUBLIC
 
     def test_cancel_button(self):
@@ -531,8 +537,8 @@ class TestVersion(TestCase):
                 continue
 
             self.addon.update(status=status)
-            res = self.client.get(self.url)
-            doc = pq(res.content)
+            response = self.client.get(self.url)
+            doc = pq(response.content)
             assert doc('#cancel-review')
             assert doc('#modal-cancel')
 
@@ -542,8 +548,8 @@ class TestVersion(TestCase):
                 continue
 
             self.addon.update(status=status)
-            res = self.client.get(self.url)
-            doc = pq(res.content)
+            response = self.client.get(self.url)
+            doc = pq(response.content)
             assert not doc('#cancel-review'), status
             assert not doc('#modal-cancel'), status
 
@@ -569,9 +575,9 @@ class TestVersion(TestCase):
         v2, _ = self._extra_version_and_file(amo.STATUS_AWAITING_REVIEW)
         self._extra_version_and_file(amo.STATUS_BETA)
 
-        r = self.client.get(self.url)
-        assert r.status_code == 200
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
         show_links = doc('.review-history-show')
         assert show_links.length == 2  # beta version does not have the link.
         assert show_links[0].attrib['data-div'] == '#%s-review-history' % v1.id
@@ -600,9 +606,9 @@ class TestVersion(TestCase):
         v2, _ = self._extra_version_and_file(amo.STATUS_AWAITING_REVIEW)
         self._extra_version_and_file(amo.STATUS_BETA)
 
-        r = self.client.get(self.url)
-        assert r.status_code == 200
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
         show_links = doc('.review-history-show')
         assert show_links.length == 2  # beta version does not have the link.
         assert show_links[0].attrib['data-div'] == '#%s-review-history' % v1.id
@@ -627,9 +633,9 @@ class TestVersion(TestCase):
         amo.log(amo.LOG.REQUEST_INFORMATION, v2.addon, v2, user=self.user)
         amo.log(amo.LOG.REQUEST_INFORMATION, v2.addon, v2, user=self.user)
 
-        r = self.client.get(self.url)
-        assert r.status_code == 200
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
 
         # Two versions, but only one counter, for the latest/deleted version
         assert doc('.review-history-show').length == 2
@@ -643,9 +649,9 @@ class TestVersion(TestCase):
         v2, _ = self._extra_version_and_file(amo.STATUS_DISABLED)
         self.addon.versions.update(channel=amo.RELEASE_CHANNEL_LISTED)
         self.addon.update_version()
-        r = self.client.get(self.url)
-        assert r.status_code == 200
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
         assert doc('td.file-status').length == 2
         # No tag shown because all listed versions
         assert doc('span.distribution-tag-listed').length == 0
@@ -654,9 +660,9 @@ class TestVersion(TestCase):
         # Make all the versions unlisted.
         self.addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
         self.addon.update_version()
-        r = self.client.get(self.url)
-        assert r.status_code == 200
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
         assert doc('td.file-status').length == 2
         # No tag shown because all unlisted versions
         assert doc('span.distribution-tag-listed').length == 0
@@ -665,9 +671,9 @@ class TestVersion(TestCase):
         # Make one of the versions listed.
         v2.update(channel=amo.RELEASE_CHANNEL_LISTED)
         v2.all_files[0].update(status=amo.STATUS_AWAITING_REVIEW)
-        r = self.client.get(self.url)
-        assert r.status_code == 200
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
         file_status_tds = doc('td.file-status')
         assert file_status_tds.length == 2
         # Tag for channels are shown because both listed and unlisted versions.
@@ -739,21 +745,21 @@ class TestVersionEditDetails(TestVersionEditBase):
         return super(TestVersionEditDetails, self).formset(*args, **defaults)
 
     def test_edit_notes(self):
-        d = self.formset(releasenotes='xx', approvalnotes='yy')
-        r = self.client.post(self.url, d)
-        assert r.status_code == 302
+        data = self.formset(releasenotes='xx', approvalnotes='yy')
+        response = self.client.post(self.url, data)
+        assert response.status_code == 302
         version = self.get_version()
         assert unicode(version.releasenotes) == 'xx'
         assert unicode(version.approvalnotes) == 'yy'
 
     def test_version_number_redirect(self):
         url = self.url.replace(str(self.version.id), self.version.version)
-        r = self.client.get(url, follow=True)
-        self.assert3xx(r, self.url)
+        response = self.client.get(url, follow=True)
+        self.assert3xx(response, self.url)
 
     def test_supported_platforms(self):
-        res = self.client.get(self.url)
-        choices = res.context['new_file_form'].fields['platform'].choices
+        response = self.client.get(self.url)
+        choices = response.context['new_file_form'].fields['platform'].choices
         taken = [f.platform for f in self.version.files.all()]
         platforms = set(self.version.compatible_platforms()) - set(taken)
         assert len(choices) == len(platforms)
@@ -769,19 +775,19 @@ class TestVersionEditDetails(TestVersionEditBase):
 
     def test_can_upload(self):
         self.version.files.all().delete()
-        r = self.client.get(self.url)
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         assert doc('a.add-file')
 
     def test_not_upload(self):
-        res = self.client.get(self.url)
-        doc = pq(res.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         assert not doc('a.add-file')
 
     def test_add(self):
-        res = self.client.get(self.url)
-        doc = pq(res.content)
-        assert res.context['compat_form'].extra_forms
+        response = self.client.get(self.url)
+        doc = pq(response.content)
+        assert response.context['compat_form'].extra_forms
         assert doc('p.add-app')[0].attrib['class'] == 'add-app'
 
     def test_add_not(self):
@@ -791,9 +797,9 @@ class TestVersionEditDetails(TestVersionEditBase):
             ApplicationsVersions(application=id, min=av, max=av,
                                  version=self.version).save()
 
-        res = self.client.get(self.url)
-        doc = pq(res.content)
-        assert not res.context['compat_form'].extra_forms
+        response = self.client.get(self.url)
+        doc = pq(response.content)
+        assert not response.context['compat_form'].extra_forms
         assert doc('p.add-app')[0].attrib['class'] == 'add-app hide'
 
     def test_should_accept_zip_source_file(self):
@@ -892,27 +898,27 @@ class TestVersionEditSearchEngine(TestVersionEditMixin,
         dd = self.formset(prefix="files", releasenotes='xx',
                           approvalnotes='yy')
 
-        r = self.client.post(self.url, dd)
-        assert r.status_code == 302
+        response = self.client.post(self.url, dd)
+        assert response.status_code == 302
         version = Addon.objects.no_cache().get(id=4594).current_version
         assert unicode(version.releasenotes) == 'xx'
         assert unicode(version.approvalnotes) == 'yy'
 
     def test_no_compat(self):
-        r = self.client.get(self.url)
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         assert not doc("#id_form-TOTAL_FORMS")
 
     def test_no_upload(self):
-        r = self.client.get(self.url)
-        doc = pq(r.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         assert not doc('a.add-file')
 
     @mock.patch('olympia.versions.models.Version.is_allowed_upload')
     def test_can_upload(self, allowed):
         allowed.return_value = True
-        res = self.client.get(self.url)
-        doc = pq(res.content)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
         assert doc('a.add-file')
 
 
@@ -920,8 +926,9 @@ class TestVersionEditFiles(TestVersionEditBase):
 
     def setUp(self):
         super(TestVersionEditFiles, self).setUp()
-        f = self.client.get(self.url).context['compat_form'].initial_forms[0]
-        self.compat = initial(f)
+        form = self.client.get(
+            self.url).context['compat_form'].initial_forms[0]
+        self.compat = initial(form)
 
     def formset(self, *args, **kw):
         compat = formset(self.compat, initial_count=1)
@@ -937,7 +944,8 @@ class TestVersionEditFiles(TestVersionEditBase):
                     self.client.get(self.url).context['file_form'].forms)
         forms[0]['DELETE'] = True
         assert ActivityLog.objects.count() == 0
-        r = self.client.post(self.url, self.formset(*forms, prefix='files'))
+        response = self.client.post(
+            self.url, self.formset(*forms, prefix='files'))
 
         assert ActivityLog.objects.count() == 2
         log = ActivityLog.objects.order_by('created')[1]
@@ -948,15 +956,15 @@ class TestVersionEditFiles(TestVersionEditBase):
             # no url because no current version becomes none.
             u'<a href="">Delicious Bookmarks</a>.')
         assert log.to_string() == log_string
-        assert r.status_code == 302
+        assert response.status_code == 302
         assert self.version.files.count() == 0
-        r = self.client.get(self.url)
-        assert r.status_code == 200
+        response = self.client.get(self.url)
+        assert response.status_code == 200
 
     def test_unique_platforms(self):
         # Move the existing file to Linux.
-        f = self.version.files.get()
-        f.update(platform=amo.PLATFORM_LINUX.id)
+        file_ = self.version.files.get()
+        file_.update(platform=amo.PLATFORM_LINUX.id)
         # And make a new file for Mac.
         File.objects.create(version=self.version,
                             platform=amo.PLATFORM_MAC.id)
@@ -964,11 +972,12 @@ class TestVersionEditFiles(TestVersionEditBase):
         forms = map(initial,
                     self.client.get(self.url).context['file_form'].forms)
         forms[1]['platform'] = forms[0]['platform']
-        r = self.client.post(self.url, self.formset(*forms, prefix='files'))
-        doc = pq(r.content)
+        response = self.client.post(
+            self.url, self.formset(*forms, prefix='files'))
+        doc = pq(response.content)
         assert doc('#id_files-0-platform')
-        assert r.status_code == 200
-        assert r.context['file_form'].non_form_errors() == (
+        assert response.status_code == 200
+        assert response.context['file_form'].non_form_errors() == (
             ['A platform can only be chosen once.'])
 
     def test_all_platforms(self):
@@ -979,8 +988,9 @@ class TestVersionEditFiles(TestVersionEditBase):
                             platform=amo.PLATFORM_MAC.id)
         forms = self.client.get(self.url).context['file_form'].forms
         forms = map(initial, forms)
-        res = self.client.post(self.url, self.formset(*forms, prefix='files'))
-        assert res.context['file_form'].non_form_errors()[0] == (
+        response = self.client.post(
+            self.url, self.formset(*forms, prefix='files'))
+        assert response.context['file_form'].non_form_errors()[0] == (
             'The platform All cannot be combined with specific platforms.')
 
     def test_all_platforms_and_delete(self):
@@ -997,9 +1007,9 @@ class TestVersionEditFiles(TestVersionEditBase):
         assert self.version.files.count() == 1
 
     def add_in_bsd(self):
-        f = self.version.files.get()
+        file_ = self.version.files.get()
         # The default file is All, which prevents the addition of more files.
-        f.update(platform=amo.PLATFORM_MAC.id)
+        file_.update(platform=amo.PLATFORM_MAC.id)
         return File.objects.create(version=self.version,
                                    platform=amo.PLATFORM_BSD.id)
 
@@ -1088,8 +1098,8 @@ class TestVersionEditCompat(TestVersionEditBase):
         av = self.version.apps.get()
         assert av.min.version == '2.0'
         assert av.max.version == '4.0'
-        f = self.client.get(url).context['compat_form'].initial_forms[0]
-        return initial(f)
+        form = self.client.get(url).context['compat_form'].initial_forms[0]
+        return initial(form)
 
     def formset(self, *args, **kw):
         defaults = formset(prefix='files')
@@ -1097,22 +1107,24 @@ class TestVersionEditCompat(TestVersionEditBase):
         return super(TestVersionEditCompat, self).formset(*args, **defaults)
 
     def test_add_appversion(self):
-        f = self.client.get(self.url).context['compat_form'].initial_forms[0]
-        d = self.formset(initial(f), dict(application=18, min=288, max=298),
-                         initial_count=1)
-        r = self.client.post(self.url, d)
-        assert r.status_code == 302
+        form = self.client.get(
+            self.url).context['compat_form'].initial_forms[0]
+        data = self.formset(
+            initial(form), {'application': 18, 'min': 288, 'max': 298},
+            initial_count=1)
+        response = self.client.post(self.url, data)
+        assert response.status_code == 302
         apps = self.get_version().compatible_apps.keys()
         assert sorted(apps) == sorted([amo.FIREFOX, amo.THUNDERBIRD])
         assert list(ActivityLog.objects.all().values_list('action')) == (
             [(amo.LOG.MAX_APPVERSION_UPDATED.id,)])
 
     def test_update_appversion(self):
-        d = self.get_form()
-        d.update(min=self.v1.id, max=self.v5.id)
-        r = self.client.post(self.url,
-                             self.formset(d, initial_count=1))
-        assert r.status_code == 302
+        data = self.get_form()
+        data.update(min=self.v1.id, max=self.v5.id)
+        response = self.client.post(
+            self.url, self.formset(data, initial_count=1))
+        assert response.status_code == 302
         av = self.version.apps.get()
         assert av.min.version == '1.0'
         assert av.max.version == '5.0'
@@ -1122,10 +1134,10 @@ class TestVersionEditCompat(TestVersionEditBase):
     def test_ajax_update_appversion(self):
         url = reverse('devhub.ajax.compat.update',
                       args=['a3615', self.version.id])
-        d = self.get_form(url)
-        d.update(min=self.v1.id, max=self.v5.id)
-        r = self.client.post(url, self.formset(d, initial_count=1))
-        assert r.status_code == 200
+        data = self.get_form(url)
+        data.update(min=self.v1.id, max=self.v5.id)
+        response = self.client.post(url, self.formset(data, initial_count=1))
+        assert response.status_code == 200
         av = self.version.apps.get()
         assert av.min.version == '1.0'
         assert av.max.version == '5.0'
@@ -1135,60 +1147,68 @@ class TestVersionEditCompat(TestVersionEditBase):
     def test_ajax_update_on_deleted_version(self):
         url = reverse('devhub.ajax.compat.update',
                       args=['a3615', self.version.id])
-        d = self.get_form(url)
-        d.update(min=self.v1.id, max=self.v5.id)
+        data = self.get_form(url)
+        data.update(min=self.v1.id, max=self.v5.id)
         self.version.delete()
-        r = self.client.post(url, self.formset(d, initial_count=1))
-        assert r.status_code == 404
+        response = self.client.post(url, self.formset(data, initial_count=1))
+        assert response.status_code == 404
 
     def test_delete_appversion(self):
         # Add thunderbird compat so we can delete firefox.
         self.test_add_appversion()
-        f = self.client.get(self.url).context['compat_form']
-        d = map(initial, f.initial_forms)
-        d[0]['DELETE'] = True
-        r = self.client.post(self.url, self.formset(*d, initial_count=2))
-        assert r.status_code == 302
+        form = self.client.get(self.url).context['compat_form']
+        data = map(initial, form.initial_forms)
+        data[0]['DELETE'] = True
+        response = self.client.post(
+            self.url, self.formset(*data, initial_count=2))
+        assert response.status_code == 302
         apps = self.get_version().compatible_apps.keys()
         assert apps == [amo.THUNDERBIRD]
         assert list(ActivityLog.objects.all().values_list('action')) == (
             [(amo.LOG.MAX_APPVERSION_UPDATED.id,)])
 
     def test_unique_apps(self):
-        f = self.client.get(self.url).context['compat_form'].initial_forms[0]
-        dupe = initial(f)
+        form = self.client.get(
+            self.url).context['compat_form'].initial_forms[0]
+        dupe = initial(form)
         del dupe['id']
-        d = self.formset(initial(f), dupe, initial_count=1)
-        r = self.client.post(self.url, d)
-        assert r.status_code == 200
+        data = self.formset(initial(form), dupe, initial_count=1)
+        response = self.client.post(self.url, data)
+        assert response.status_code == 200
         # Because of how formsets work, the second form is expected to be a
         # tbird version range.  We got an error, so we're good.
 
     def test_require_appversion(self):
         old_av = self.version.apps.get()
-        f = self.client.get(self.url).context['compat_form'].initial_forms[0]
-        d = initial(f)
-        d['DELETE'] = True
-        r = self.client.post(self.url, self.formset(d, initial_count=1))
-        assert r.status_code == 200
-        assert r.context['compat_form'].non_form_errors() == (
+        form = self.client.get(
+            self.url).context['compat_form'].initial_forms[0]
+        data = initial(form)
+        data['DELETE'] = True
+        response = self.client.post(
+            self.url, self.formset(data, initial_count=1))
+        assert response.status_code == 200
+        assert response.context['compat_form'].non_form_errors() == (
             ['Need at least one compatible application.'])
         assert self.version.apps.get() == old_av
 
     def test_proper_min_max(self):
-        f = self.client.get(self.url).context['compat_form'].initial_forms[0]
-        d = initial(f)
-        d['min'], d['max'] = d['max'], d['min']
-        r = self.client.post(self.url, self.formset(d, initial_count=1))
-        assert r.status_code == 200
-        assert r.context['compat_form'].forms[0].non_field_errors() == (
+        form = self.client.get(
+            self.url).context['compat_form'].initial_forms[0]
+        data = initial(form)
+        data['min'], data['max'] = data['max'], data['min']
+        response = self.client.post(
+            self.url, self.formset(data, initial_count=1))
+        assert response.status_code == 200
+        assert response.context['compat_form'].forms[0].non_field_errors() == (
             ['Invalid version range.'])
 
     def test_same_min_max(self):
-        f = self.client.get(self.url).context['compat_form'].initial_forms[0]
-        d = initial(f)
-        d['min'] = d['max']
-        r = self.client.post(self.url, self.formset(d, initial_count=1))
-        assert r.status_code == 302
+        form = self.client.get(
+            self.url).context['compat_form'].initial_forms[0]
+        data = initial(form)
+        data['min'] = data['max']
+        response = self.client.post(
+            self.url, self.formset(data, initial_count=1))
+        assert response.status_code == 302
         av = self.version.apps.all()[0]
         assert av.min == av.max


### PR DESCRIPTION
Also replace `dict()` usage by `{}` in those tests

I was tired of debugging tests that use `c` or `r` variable shadowing useful `ipdb` shortcuts, so I decided to take a stand and fight back...