### PR TITLE
Unify link colors for visited and hover effects.

### DIFF
--- a/static/css/devhub/new-landing/base.less
+++ b/static/css/devhub/new-landing/base.less
@@ -69,12 +69,21 @@ img {
   color: @color;
   text-decoration: @decoration;
 
+  &:link {
+    color: @color;
+  }
+
   &:visited {
     color: fadeOut(@color, 10%);
   }
 
   &:hover {
     color: fadeOut(@color, 20%);
+    text-decoration: underline;
+  }
+
+  &:active {
+    color: fadeOut(@color, 10%);
   }
 }
 

--- a/static/css/devhub/new-landing/base.less
+++ b/static/css/devhub/new-landing/base.less
@@ -74,16 +74,16 @@ img {
   }
 
   &:visited {
-    color: fadeOut(@color, 10%);
+    color: fadeout(@color, 10%);
   }
 
   &:hover {
-    color: fadeOut(@color, 20%);
+    color: fadeout(@color, 20%);
     text-decoration: underline;
   }
 
   &:active {
-    color: fadeOut(@color, 10%);
+    color: fadeout(@color, 10%);
   }
 }
 

--- a/static/css/devhub/new-landing/base.less
+++ b/static/css/devhub/new-landing/base.less
@@ -65,6 +65,23 @@ img {
   max-width: 100%;
 }
 
+.link(@color, @decoration: none) {
+  color: @color;
+  text-decoration: @decoration;
+
+  &:visited {
+    color: fadeOut(@color, 10%);
+  }
+
+  &:hover {
+    color: fadeOut(@color, 20%);
+  }
+}
+
+a {
+  .link(@color-text);
+}
+
 body {
   margin: 0;
   padding: 0;

--- a/static/css/devhub/new-landing/button.less
+++ b/static/css/devhub/new-landing/button.less
@@ -1,13 +1,41 @@
-.Button {
-  .link(@color-items);
+.button(@color, @background-color) {
+  background-color: @background-color;
+  color: @color;
 
-  background-color: @color-button-default;
+  // Reset global link styles
+  &:link,
+  &:visited,
+  &:hover,
+  &:active {
+    text-decoration: none;
+    color: @color;
+  }
+
+  &:active,
+  &:hover,
+  &:focus {
+    background-color: darken(@background-color, 5%);
+    text-decoration: none;
+  }
+
+  &:focus {
+    border-color: @color-callout-border;
+    box-shadow: 0 0 5px 0 @color-callout-border;
+    outline: none;
+  }
+}
+
+.Button {
+  .button(@color-items, @color-button-default);
+
   border-radius: 2px;
   box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.3);
+  color: @color-items;
   display: inline-block;
   padding: 10px 30px;
   margin: 10px 0;
   text-align: center;
+  text-decoration: none;
   width: 100%;
 
   @media @small {
@@ -20,5 +48,5 @@
 }
 
 .Button--primary {
-  background-color: @color-button-primary;
+  .button(@color-items, @color-button-primary);
 }

--- a/static/css/devhub/new-landing/button.less
+++ b/static/css/devhub/new-landing/button.less
@@ -1,13 +1,13 @@
 .Button {
+  .link(@color-items);
+
   background-color: @color-button-default;
   border-radius: 2px;
   box-shadow: 0 2px 3px 0 rgba(0, 0, 0, 0.3);
-  color: @color-items;
   display: inline-block;
   padding: 10px 30px;
   margin: 10px 0;
   text-align: center;
-  text-decoration: none;
   width: 100%;
 
   @media @small {

--- a/static/css/devhub/new-landing/footer.less
+++ b/static/css/devhub/new-landing/footer.less
@@ -3,8 +3,7 @@
   margin: 60px 0 0;
 
   a {
-    color: @color-button-default;
-    text-decoration: none;
+    .link(@color-button-default);
   }
 
   &.scheme-light {

--- a/static/css/devhub/new-landing/navigation.less
+++ b/static/css/devhub/new-landing/navigation.less
@@ -57,8 +57,7 @@
       }
 
       a {
-        color: @color-text;
-        text-decoration: none;
+        .link(@color-text);
       }
     }
   }
@@ -68,13 +67,13 @@
     min-width: @grid-max;
 
     ul li a {
-      color: @color-scheme-light-text;
+      .link(@color-scheme-light-text);
     }
   }
 
   &.scheme-medium {
     ul li a {
-      color: @color-scheme-medium-text;
+      .link(@color-scheme-medium-text);
     }
   }
 }

--- a/static/css/devhub/new-landing/navigation.less
+++ b/static/css/devhub/new-landing/navigation.less
@@ -67,13 +67,13 @@
     min-width: @grid-max;
 
     ul li a {
-      .link(@color-scheme-light-text);
+      color: @color-scheme-light-text;
     }
   }
 
   &.scheme-medium {
     ul li a {
-      .link(@color-scheme-medium-text);
+      color: @color-scheme-medium-text;
     }
   }
 }

--- a/static/css/devhub/new-landing/sections/more-information.less
+++ b/static/css/devhub/new-landing/sections/more-information.less
@@ -18,9 +18,12 @@
   h2,
   h2 a {
     color: @color-scheme-dark-text;
-    text-decoration: none;
     font-size: 32px;
     margin: 0;
+  }
+
+  h2 a {
+    .link(@color-scheme-dark-text);
   }
 
   ul {
@@ -29,8 +32,7 @@
 
     li {
       a {
-        color: @color-scheme-dark-items;
-        text-decoration: none;
+        .link(@color-scheme-dark-items);
       }
 
       p {
@@ -42,9 +44,9 @@
 
 .DevHub-BlogPosts {
   .read-more {
-    color: @color-scheme-dark-items;
+    .link(@color-scheme-dark-items);
+
     font-weight: 600;
-    text-decoration: none;
   }
 }
 

--- a/static/css/devhub/new-landing/sections/my-addons.less
+++ b/static/css/devhub/new-landing/sections/my-addons.less
@@ -31,10 +31,12 @@
 .DevHub-MyAddons-item-details {
   margin-left: 25px;
 
+  a {
+    .link(@color-button-default);
+  }
+
   a,
   .DevHub-MyAddons-VersionStatus {
-    .link(@color-button-default);
-
     font-size: 15px;
     margin: 0 5px;
 

--- a/static/css/devhub/new-landing/sections/my-addons.less
+++ b/static/css/devhub/new-landing/sections/my-addons.less
@@ -123,7 +123,6 @@
   .link(@color-button-default);
 
   font-size: 15px;
-  text-decoration: none;
 }
 
 .DevHub-MyAddons-item-buttons-submit {

--- a/static/css/devhub/new-landing/sections/my-addons.less
+++ b/static/css/devhub/new-landing/sections/my-addons.less
@@ -33,9 +33,9 @@
 
   a,
   .DevHub-MyAddons-VersionStatus {
+    .link(@color-button-default);
+
     font-size: 15px;
-    text-decoration: none;
-    color: @color-button-default;
     margin: 0 5px;
 
     &.DevHub-MyAddons-version-status-incomplete,
@@ -120,9 +120,10 @@
 }
 
 .DevHub-MyAddons-item-buttons-all-submissions {
+  .link(@color-button-default);
+
   font-size: 15px;
   text-decoration: none;
-  color: @color-button-default;
 }
 
 .DevHub-MyAddons-item-buttons-submit {

--- a/static/css/devhub/new-landing/sections/overview.less
+++ b/static/css/devhub/new-landing/sections/overview.less
@@ -1,5 +1,4 @@
 .DevHub-Overview {
-
   @media @medium {
     > div {
       background-image: url(../../../img/developers/new-landing/header-background.svg);
@@ -25,7 +24,7 @@
     max-width: 560px;
 
     > a {
-      color: @color-scheme-medium-text;
+      .link(@color-scheme-medium-text, @decoration: underline);
     }
 
     @media @small {


### PR DESCRIPTION
Fixes #4274 

We might want to cherry-pick this into this weeks release if we're enabling devhub pages.

Hard to screenshot hover / visited styles, especially since the fading is really subtle. I hope it works like this :) They really just fade a tiny but visible bit.