### PR TITLE
Add annotations to donate form doesnt need CSRF token

### DIFF
--- a/src/olympia/addons/templates/addons/contributions_lightbox.html
+++ b/src/olympia/addons/templates/addons/contributions_lightbox.html
@@ -1,5 +1,5 @@
 <div id="contribute-box" class="jqmWindow modal">
-  <form action="{{ url('addons.contribute', addon.slug) }}" method="post">
+  <form action="{{ url('addons.contribute', addon.slug) }}" method="post" data-no-csrf>
     {{ csrf() }}
     <input type="hidden" name="source" value="{{ contribution_src }}"/>
     <h2>{{ _('Make a Contribution') }}</h2>


### PR DESCRIPTION
As per #4235 
In this case the baseline scan is complaining about pages like https://addons.mozilla.org/en-GB/firefox/addon/adblock-plus/?src=hp-dl-mostpopular
Interestingly theres another form on the page that doesnt appear to have an anti CSRF token: 
`<form method="post" action="/en-GB/firefox/addon/adblock-plus/abuse/">`
I _think_ thats generated by [report_abuse.html](https://github.com/mozilla/addons-server/blob/master/src/olympia/addons/templates/addons/report_abuse.html) but that does appear to have the `{{ csrf() }}` token. What am I missing?