### PR TITLE
Fix colspan in addon admin page for versions with multiple files

### DIFF
--- a/src/olympia/zadmin/templates/zadmin/addon_manage.html
+++ b/src/olympia/zadmin/templates/zadmin/addon_manage.html
@@ -41,7 +41,7 @@
           {% with files = file_map.get(v.id, []) %}
             {% if files %}
               {% for file in files %}
-                {% if not loop.first %}</tr><tr><td colspan="2">{% endif %}
+                {% if not loop.first %}</tr><tr><td colspan="3">{% endif %}
                 <td><a href="{{ url('files.list', file.id) }}" title="{{ file.filename }}">{{ file.id }}</a></td>
                 <td>{{ file.get_platform_display() }}</td>
                 <td>


### PR DESCRIPTION
Before:
![screen shot 2017-01-25 at 13 10 32](https://cloud.githubusercontent.com/assets/187006/22290288/3ced61e4-e300-11e6-9c85-65ca08a0cae6.png)

After:
![screen shot 2017-01-25 at 13 10 16](https://cloud.githubusercontent.com/assets/187006/22290289/3cef70a6-e300-11e6-8069-1fc8bcb1ad16.png)
