### PR TITLE
Fix review unlisted page for add-ons with mixed unlisted/listed versions

### DIFF
--- a/src/olympia/editors/helpers.py
+++ b/src/olympia/editors/helpers.py
@@ -358,8 +358,6 @@ class ReviewHelper(object):
             # ReviewHelper for its `handler` attribute and we don't care about
             # the actions.
             return actions
-        latest_version = addon.find_latest_version(
-            channel=amo.RELEASE_CHANNEL_LISTED)
         reviewable_because_complete = addon.status not in (
             amo.STATUS_NULL, amo.STATUS_DELETED)
         reviewable_because_admin = (
@@ -367,13 +365,13 @@ class ReviewHelper(object):
             acl.action_allowed(request, 'ReviewerAdminTools', 'View'))
         reviewable_because_submission_time = (
             not is_limited_reviewer(request) or
-            (latest_version is not None and
-                latest_version.nomination is not None and
-                (datetime.datetime.now() - latest_version.nomination >=
+            (self.version is not None and
+                self.version.nomination is not None and
+                (datetime.datetime.now() - self.version.nomination >=
                     datetime.timedelta(hours=REVIEW_LIMITED_DELAY_HOURS))))
         reviewable_because_pending = (
-            latest_version is not None and
-            len(latest_version.is_unreviewed) > 0)
+            self.version is not None and
+            len(self.version.is_unreviewed) > 0)
         if (reviewable_because_complete and
                 reviewable_because_admin and
                 reviewable_because_submission_time and

--- a/src/olympia/editors/templates/editors/review.html
+++ b/src/olympia/editors/templates/editors/review.html
@@ -23,7 +23,7 @@
       {{ _('Review {0}')|fe(addon.name) }}
     </span>
     {% if version %}
-      <span class="version">{{ version.version }}</span>
+      <span class="version">{{ version.version }} ({{ version.get_channel_display() }})</span>
     {% endif %}
   </h2>
   <h4 class="author">{{ _('by') }} {{ users_list(addon.listed_authors) }}</h4>
@@ -251,7 +251,18 @@
   {% if not addon.is_deleted %}
   <strong>{{ _('Actions') }}</strong>
   <ul id="actions-addon">
-    {% if addon.has_listed_versions() %}<li><a href="{{ addon.get_url_path() }}">{{ _('View Listing') }}</a></li>{% endif %}
+    {% if version and addon.has_listed_versions() %}
+      <li><a href="{{ addon.get_url_path() }}">{{ _('View Listing') }}</a></li>
+      {% if version.channel == amo.RELEASE_CHANNEL_LISTED %}
+        {# On the listed review page, show link to unlisted version review if necessary and allowed #}
+        {% if action_allowed('Addons', 'ReviewUnlisted') and addon.has_unlisted_versions() %}
+          <li><a href="{{ url('editors.review', 'unlisted', addon.slug) }}">{{ _('Unlisted Review Page') }}</a></li>
+        {% endif %}
+      {% else %}
+        {# If we are on the unlisted review page, show the link to the listed review page #}
+        <li><a href="{{ url('editors.review', addon.slug) }}">{{ _('Listed Review Page') }}</a></li>
+      {% endif %}
+    {% endif %}
     {% if is_admin %}
     <li><a href="{{ addon.get_dev_url() }}">{{ _('Edit') }}</a> <em>{{ _('(admin)') }}</em></li>
     <li><a href="{{ url('zadmin.addon_manage', addon.id) }}">{{ _('Admin Page') }}</a> <em>{{ _('(admin)') }}</em></li>

--- a/src/olympia/editors/tests/test_forms.py
+++ b/src/olympia/editors/tests/test_forms.py
@@ -28,6 +28,8 @@ class TestReviewActions(TestCase):
     def set_statuses(self, addon_status, file_status):
         self.file.update(status=file_status)
         self.addon.update(status=addon_status)
+        # Need to clear self.version.all_files cache since we updated the file.
+        del self.version.all_files
         form = ReviewForm(
             {'addon_files': [self.file.pk]},
             helper=ReviewHelper(request=self.request, addon=self.addon,

--- a/src/olympia/editors/tests/test_helpers.py
+++ b/src/olympia/editors/tests/test_helpers.py
@@ -276,6 +276,8 @@ class TestReviewHelper(TestCase):
     def get_review_actions(self, addon_status, file_status):
         self.file.update(status=file_status)
         self.addon.update(status=addon_status)
+        # Need to clear self.version.all_files cache since we updated the file.
+        del self.version.all_files
         return self.get_helper().actions
 
     def test_actions_full_nominated(self):
@@ -697,6 +699,15 @@ class TestReviewHelper(TestCase):
             self.setup_data(amo.STATUS_NOMINATED)
             getattr(self.helper.handler, process)()
             assert File.objects.get(pk=self.file.pk).reviewed
+
+    def test_review_unlisted_while_a_listed_version_is_awaiting_review(self):
+        self.make_addon_unlisted(self.addon)
+        self.version.reload()
+        version_factory(
+            addon=self.addon, channel=amo.RELEASE_CHANNEL_LISTED,
+            file_kw={'status': amo.STATUS_AWAITING_REVIEW})
+        self.addon.update(status=amo.STATUS_NOMINATED)
+        assert self.get_helper()
 
 
 def test_page_title_unicode():

--- a/src/olympia/editors/tests/test_views.py
+++ b/src/olympia/editors/tests/test_views.py
@@ -1643,6 +1643,17 @@ class TestReview(ReviewBase):
         AddonUser.objects.create(addon=self.addon, user=self.editor)
         assert self.client.head(self.url).status_code == 302
 
+    def test_review_unlisted_while_a_listed_version_is_awaiting_review(self):
+        self.make_addon_unlisted(self.addon)
+        version_factory(
+            addon=self.addon, channel=amo.RELEASE_CHANNEL_LISTED,
+            file_kw={'status': amo.STATUS_AWAITING_REVIEW})
+        self.addon.update(status=amo.STATUS_NOMINATED, slug='awaiting')
+        self.url = reverse(
+            'editors.review', args=('unlisted', self.addon.slug))
+        self.login_as_senior_editor()
+        assert self.client.get(self.url).status_code == 200
+
     def test_needs_unlisted_reviewer_for_only_unlisted(self):
         self.addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
         assert self.client.head(self.url).status_code == 404

--- a/src/olympia/editors/tests/test_views.py
+++ b/src/olympia/editors/tests/test_views.py
@@ -1974,7 +1974,7 @@ class TestReview(ReviewBase):
             ('View Listing', self.addon.get_url_path()),
             ('Edit', self.addon.get_dev_url()),
             ('Admin Page',
-             reverse('zadmin.addon_manage', args=[self.addon.id])),
+                reverse('zadmin.addon_manage', args=[self.addon.id])),
         ]
         check_links(expected, pq(r.content)('#actions-addon a'), verify=False)
 
@@ -1987,9 +1987,63 @@ class TestReview(ReviewBase):
         expected = [
             ('Edit', self.addon.get_dev_url()),
             ('Admin Page',
-             reverse('zadmin.addon_manage', args=[self.addon.id])),
+                reverse('zadmin.addon_manage', args=[self.addon.id])),
         ]
         check_links(expected, pq(r.content)('#actions-addon a'), verify=False)
+
+    def test_mixed_channels_action_links_as_admin(self):
+        self.make_addon_unlisted(self.addon)
+        version_factory(
+            addon=self.addon, channel=amo.RELEASE_CHANNEL_LISTED,
+            file_kw={'status': amo.STATUS_AWAITING_REVIEW})
+        self.addon.update(status=amo.STATUS_NOMINATED)
+        self.login_as_admin()
+        response = self.client.get(self.url)
+        expected = [
+            ('View Listing', self.addon.get_url_path()),
+            ('Unlisted Review Page',
+                reverse('editors.review', args=('unlisted', self.addon.slug))),
+            ('Edit', self.addon.get_dev_url()),
+            ('Admin Page',
+                reverse('zadmin.addon_manage', args=[self.addon.id])),
+        ]
+        check_links(
+            expected, pq(response.content)('#actions-addon a'), verify=False)
+
+    def test_mixed_channels_action_links_as_admin_on_unlisted_review(self):
+        self.make_addon_unlisted(self.addon)
+        version_factory(
+            addon=self.addon, channel=amo.RELEASE_CHANNEL_LISTED,
+            file_kw={'status': amo.STATUS_AWAITING_REVIEW})
+        self.addon.update(status=amo.STATUS_NOMINATED)
+        self.login_as_admin()
+        self.url = reverse(
+            'editors.review', args=('unlisted', self.addon.slug))
+        response = self.client.get(self.url)
+        expected = [
+            ('View Listing', self.addon.get_url_path()),
+            ('Listed Review Page',
+                reverse('editors.review', args=(self.addon.slug,))),
+            ('Edit', self.addon.get_dev_url()),
+            ('Admin Page',
+                reverse('zadmin.addon_manage', args=[self.addon.id])),
+        ]
+        check_links(
+            expected, pq(response.content)('#actions-addon a'), verify=False)
+
+    def test_mixed_channels_action_links_as_regular_reviewer(self):
+        self.make_addon_unlisted(self.addon)
+        version_factory(
+            addon=self.addon, channel=amo.RELEASE_CHANNEL_LISTED,
+            file_kw={'status': amo.STATUS_AWAITING_REVIEW})
+        self.addon.update(status=amo.STATUS_NOMINATED)
+        self.login_as_editor()
+        response = self.client.get(self.url)
+        expected = [
+            ('View Listing', self.addon.get_url_path()),
+        ]
+        check_links(
+            expected, pq(response.content)('#actions-addon a'), verify=False)
 
     def test_admin_links_as_non_admin(self):
         self.login_as_editor()


### PR DESCRIPTION
Bonus: add a link to switch between unlisted and non-unlisted review pages.

Fix #4479