### PR TITLE
Add id's to contribute and abuse forms

### DIFF
--- a/src/olympia/addons/templates/addons/contributions_lightbox.html
+++ b/src/olympia/addons/templates/addons/contributions_lightbox.html
@@ -1,5 +1,5 @@
 <div id="contribute-box" class="jqmWindow modal">
-  <form action="{{ url('addons.contribute', addon.slug) }}" method="post">
+  <form action="{{ url('addons.contribute', addon.slug) }}" method="post" data-no-csrf="anon-only">
     {{ csrf() }}
     <input type="hidden" name="source" value="{{ contribution_src }}"/>
     <h2>{{ _('Make a Contribution') }}</h2>

--- a/src/olympia/addons/templates/addons/report_abuse.html
+++ b/src/olympia/addons/templates/addons/report_abuse.html
@@ -1,4 +1,4 @@
-<form method="post" action="{{ url('addons.abuse', addon.slug) }}">
+<form method="post" action="{{ url('addons.abuse', addon.slug) }}" data-no-csrf="anon-only">
   {{ csrf() }}
   <fieldset class="abuse">
     {% if hide %}


### PR DESCRIPTION
The ids are there to allow us to ignore these forms when checking for missing anti-CSRF tokens using the baseline scan.
We cant use the data-no-csrf annotation as the forms do have the tokens when authenticated.
However when accessed anonymously the tokens are not present:
https://github.com/mozilla/addons-server/blob/master/src/olympia/addons/views.py#L449-L525
https://github.com/mozilla/addons-server/blob/master/src/olympia/addons/views.py#L566-L577
The forms are not actually vulnerable to CSRF attacks even when the tokens are not present as they use a Paypal form (for donations) and reCAPTCH (for abuse).
The ids then allow us to whitelist these forms in the baseline scan.
Alternative suggestions for solutions to this problem gratefully received :)