### PR TITLE
Fix overall width of the BlogPosts list in case a title is too long.

### DIFF
--- a/static/css/devhub/new-landing/sections/more-information.less
+++ b/static/css/devhub/new-landing/sections/more-information.less
@@ -29,6 +29,7 @@
   ul {
     list-style: none;
     padding: 0;
+    width: 90%;
 
     li {
       a {

--- a/static/css/devhub/new-landing/sections/more-information.less
+++ b/static/css/devhub/new-landing/sections/more-information.less
@@ -2,6 +2,7 @@
   > div {
     display: flex;
     flex-flow: column;
+    justify-content: space-between;
 
     @media @medium {
       flex-flow: row nowrap;
@@ -14,6 +15,7 @@
 .DevHub-Tools {
   line-height: 1.5;
   margin: 20px 0 auto;
+  max-width: 420px;
 
   h2,
   h2 a {
@@ -29,7 +31,6 @@
   ul {
     list-style: none;
     padding: 0;
-    width: 90%;
 
     li {
       a {

--- a/static/css/devhub/new-landing/sections/more-information.less
+++ b/static/css/devhub/new-landing/sections/more-information.less
@@ -50,6 +50,16 @@
 
     font-weight: 600;
   }
+
+  ul {
+    margin-right: 20px;
+
+    html[dir=rtl] & {
+      margin-right: auto;
+      margin-left: 20px;
+    }
+  }
+
 }
 
 .DevHub-Tools {


### PR DESCRIPTION
This bug only existed now that the last blog post with the super long title got released 18h ago :(

Before:

![screenshot from 2017-01-25 19-22-20](https://cloud.githubusercontent.com/assets/139033/22303570/23cc5f7e-e334-11e6-8ff3-0d5398bdcb65.png)

After:
![screenshot from 2017-01-27 13-19-54](https://cloud.githubusercontent.com/assets/139033/22370796/98233ef0-e493-11e6-8275-c20e4326219d.png)
![screenshot from 2017-01-27 13-21-27](https://cloud.githubusercontent.com/assets/139033/22370800/9cff5d6e-e493-11e6-8a72-0bcd8b48c058.png)


