### PR TITLE
Make version upload process cancellable at the details step.

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1244,17 +1244,10 @@ class Addon(OnChangeMixin, ModelBase):
                                 amo.STATUS_DELETED)):
             return False
 
-        if not File.objects.filter(version__addon=self).exists():
-            return False
-
-        latest_version = self.find_latest_version(
+        latest_version = self.find_latest_version_including_rejected(
             channel=amo.RELEASE_CHANNEL_LISTED)
 
-        if not latest_version or not latest_version.files.exclude(
-                status=amo.STATUS_DISABLED).exists():
-            return False
-
-        return True
+        return latest_version is not None and latest_version.files.exists()
 
     def is_persona(self):
         return self.type == amo.ADDON_PERSONA

--- a/src/olympia/devhub/templates/devhub/addons/submit/describe.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/describe.html
@@ -121,6 +121,11 @@
       <p>{{ _('These notes will only be visible to you and our reviewers.') }}</p>
     </div>
     <div class="submission-buttons addon-submission-field">
+      <button class="delete-button" type="sumbit"
+              formaction="{{ url('devhub.addons.cancel', addon.slug) }}">
+          {{ _('Cancel Review and Disable Version') }}
+      </button>
+      &nbsp;
       <button type="submit">
         {{ _('Submit Version for Review') }}
       </button>

--- a/src/olympia/devhub/templates/devhub/addons/submit/describe_minimal.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/describe_minimal.html
@@ -24,6 +24,11 @@
       <p>{{ _('These notes will only be visible to you and our reviewers.') }}</p>
     </div>
     <div class="submission-buttons addon-submission-field">
+      <button class="delete-button" type="sumbit"
+              formaction="{{ url('devhub.addons.cancel', addon.slug) }}">
+          {{ _('Cancel Review and Disable Version') }}
+      </button>
+      &nbsp;
       <button type="submit">
         {{ _('Submit Version for Review') }}
       </button>

--- a/src/olympia/devhub/templates/devhub/versions/list.html
+++ b/src/olympia/devhub/templates/devhub/versions/list.html
@@ -399,9 +399,8 @@
       <h3>{{ _('Cancel Review Request') }}</h3>
       <p>
         {% trans %}
-            Canceling your review request will mark your add-on incomplete.
-            If you do not complete your add-on after several days
-            by re-requesting review, it will be deleted.
+            Canceling your review request will mark your add-on incomplete,
+            and any versions awaiting review for listing on AMO will be disabled.
         {% endtrans %}
       </p>
       <p>

--- a/src/olympia/devhub/templates/devhub/versions/list.html
+++ b/src/olympia/devhub/templates/devhub/versions/list.html
@@ -400,7 +400,7 @@
       <p>
         {% trans %}
             Canceling your review request will mark your add-on incomplete,
-            and any versions awaiting review for listing on AMO will be disabled.
+            and any versions awaiting review will be disabled.
         {% endtrans %}
       </p>
       <p>

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -1821,8 +1821,7 @@ class TestRequestReview(TestCase):
     def test_renominate_for_full_review(self, mock_has_complete_metadata):
         # When a version is rejected, the addon is disabled.
         # The author must upload a new version and re-nominate.
-        # However, renominating the *same* version does not adjust the
-        # nomination date.
+        # Renominating the same version resets the nomination date.
         mock_has_complete_metadata.return_value = True
 
         orig_date = datetime.now() - timedelta(days=30)
@@ -1832,20 +1831,7 @@ class TestRequestReview(TestCase):
         response = self.client.post(self.public_url)
         self.assert3xx(response, self.redirect_url)
         assert self.get_addon().status == amo.STATUS_NOMINATED
-        assert self.get_version().nomination.timetuple()[0:5] == (
-            orig_date.timetuple()[0:5])
-
-    def test_renomination_doesnt_reset_nomination_date(self):
-        # Nominate:
-        self.addon.update(status=amo.STATUS_NOMINATED)
-        # Pretend it was nominated in the past:
-        orig_date = datetime.now() - timedelta(days=30)
-        self.version.update(nomination=orig_date, _signal=False)
-        # Reject it:
-        self.addon.update(status=amo.STATUS_NULL)
-        # Re-nominate:
-        self.addon.update(status=amo.STATUS_NOMINATED)
-        assert self.get_version().nomination.timetuple()[0:5] == (
+        assert self.get_version().nomination.timetuple()[0:5] != (
             orig_date.timetuple()[0:5])
 
 

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -576,14 +576,14 @@ class TestVersion(TestCase):
         buttons = doc('.version-status-actions form button').text()
         assert buttons == 'Request Review'
 
-    def test_rejected_request_review(self):
+    def test_rejected_can_request_review(self):
         self.addon.update(status=amo.STATUS_NULL)
         latest_version = self.addon.find_latest_version(
             channel=amo.RELEASE_CHANNEL_LISTED)
         latest_version.files.update(status=amo.STATUS_DISABLED)
         doc = pq(self.client.get(self.url).content)
         buttons = doc('.version-status-actions form button').text()
-        assert not buttons
+        assert buttons
 
     @override_switch('activity-email', active=True)
     def test_version_history(self):

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -1712,15 +1712,16 @@ def request_review(request, addon_id, addon):
     latest_version = addon.find_latest_version_including_rejected(
         amo.RELEASE_CHANNEL_LISTED)
     if latest_version:
-        latest_version.files.filter(
-            status=amo.STATUS_DISABLED).update(
-            status=amo.STATUS_AWAITING_REVIEW)
+        for f in latest_version.files.filter(status=amo.STATUS_DISABLED):
+            f.update(status=amo.STATUS_AWAITING_REVIEW)
+        # Clear the nomination date so it gets set again in Addon.watch_status.
+        latest_version.update(nomination=None)
     if addon.has_complete_metadata():
         addon.update(status=amo.STATUS_NOMINATED)
-        messages.success(request, _('Review Requested.'))
+        messages.success(request, _('Review requested.'))
     else:
         messages.success(request, _(
-            'Review Requested.  You must provide further details to proceed.'))
+            'Review requested.  You must provide further details to proceed.'))
     amo.log(amo.LOG.CHANGE_STATUS, addon.get_status_display(), addon)
     return redirect(addon.get_dev_url('versions'))
 

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -380,6 +380,12 @@ def cancel(request, addon_id, addon):
     if addon.status == amo.STATUS_NOMINATED:
         addon.update(status=amo.STATUS_NULL)
         amo.log(amo.LOG.CHANGE_STATUS, addon.get_status_display(), addon)
+    latest_version = addon.find_latest_version(
+        channel=amo.RELEASE_CHANNEL_LISTED)
+    if latest_version:
+        latest_version.files.filter(
+            status=amo.STATUS_AWAITING_REVIEW).update(
+            status=amo.STATUS_DISABLED)
     return redirect(addon.get_dev_url('versions'))
 
 
@@ -1703,8 +1709,18 @@ def request_review(request, addon_id, addon):
     if not addon.can_request_review():
         return http.HttpResponseBadRequest()
 
-    addon.update(status=amo.STATUS_NOMINATED)
-    messages.success(request, _('Review Requested.'))
+    latest_version = addon.find_latest_version_including_rejected(
+        amo.RELEASE_CHANNEL_LISTED)
+    if latest_version:
+        latest_version.files.filter(
+            status=amo.STATUS_DISABLED).update(
+            status=amo.STATUS_AWAITING_REVIEW)
+    if addon.has_complete_metadata():
+        addon.update(status=amo.STATUS_NOMINATED)
+        messages.success(request, _('Review Requested.'))
+    else:
+        messages.success(request, _(
+            'Review Requested.  You must provide further details to proceed.'))
     amo.log(amo.LOG.CHANGE_STATUS, addon.get_status_display(), addon)
     return redirect(addon.get_dev_url('versions'))
 

--- a/static/css/zamboni/developers.css
+++ b/static/css/zamboni/developers.css
@@ -676,13 +676,13 @@ div.dev-review-reply {
     margin: 0em 1em;
 }
 
-#dev-review-reply-comments {
+div.dev-review-reply textarea {
     border-color: #999;
     border-radius: 3px;
     margin: 0.5em 0em;
 }
 
-#dev-review-reply-submit {
+div.dev-review-reply button {
     float: right;
 }
 


### PR DESCRIPTION
fixes #4440 
Plus allow request review to restart the process with a disabled version.