### PR TITLE
better Addon.update_status - will upgrade and downgrade as appropriate

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1798,6 +1798,9 @@ class Persona(caching.CachingMixin, models.Model):
     def listed_authors(self):
         return self.addon.listed_authors
 
+    def update_status(self, new_status):
+        self.addon.update(status=amo.new_status)
+
 
 class AddonCategory(caching.CachingMixin, models.Model):
     addon = models.ForeignKey(Addon, on_delete=models.CASCADE)

--- a/src/olympia/devhub/tasks.py
+++ b/src/olympia/devhub/tasks.py
@@ -105,12 +105,6 @@ def create_version_for_upload(addon, upload, channel):
         version = Version.from_upload(
             upload, addon, [amo.PLATFORM_ALL.id], channel,
             is_beta=beta)
-        # The add-on's status will be STATUS_NULL when its first version is
-        # created because the version has no files when it gets added and it
-        # gets flagged as invalid. We need to manually set the status.
-        if (addon.status == amo.STATUS_NULL and
-                channel == amo.RELEASE_CHANNEL_LISTED):
-            addon.update(status=amo.STATUS_NOMINATED)
         auto_sign_version(version, is_beta=version.is_beta)
 
 

--- a/src/olympia/devhub/tests/test_models.py
+++ b/src/olympia/devhub/tests/test_models.py
@@ -262,15 +262,6 @@ class TestVersion(TestCase):
         file_two.save()
         return version_two, file_two
 
-    def test_version_delete_status(self):
-        self._extra_version_and_file(amo.STATUS_PUBLIC)
-        self.addon.status = amo.STATUS_BETA
-        self.addon.save()
-
-        self.version.delete()
-        assert self.addon.versions.count() == 1
-        assert Addon.objects.get(id=3615).status == amo.STATUS_BETA
-
     def test_version_delete_status_unreviewed(self):
         self._extra_version_and_file(amo.STATUS_BETA)
 

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -75,6 +75,7 @@ class TestSubmitBase(TestCase):
         assert self.client.login(email='del@icio.us')
         self.user = UserProfile.objects.get(email='del@icio.us')
         self.addon = self.get_addon()
+        self.addon.update_status()
 
     def get_addon(self):
         return Addon.objects.no_cache().get(pk=3615)
@@ -542,6 +543,7 @@ class TestAddonSubmitDetails(TestSubmitBase):
 
     def test_nomination_date_set_only_once(self):
         self.get_version().update(nomination=None)
+        self.get_addon().update(status=amo.STATUS_NULL)
         self.is_success(self.get_dict())
         self.assertCloseToNow(self.get_version().nomination)
 

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -377,15 +377,12 @@ def enable(request, addon_id, addon):
 @dev_required(owner_for_post=True)
 @post_required
 def cancel(request, addon_id, addon):
-    if addon.status == amo.STATUS_NOMINATED:
-        addon.update(status=amo.STATUS_NULL)
-        amo.log(amo.LOG.CHANGE_STATUS, addon.get_status_display(), addon)
     latest_version = addon.find_latest_version(
         channel=amo.RELEASE_CHANNEL_LISTED)
     if latest_version:
-        latest_version.files.filter(
-            status=amo.STATUS_AWAITING_REVIEW).update(
-            status=amo.STATUS_DISABLED)
+        for file_ in latest_version.files.filter(
+                status=amo.STATUS_AWAITING_REVIEW):
+            file_.update(status=amo.STATUS_DISABLED)
     return redirect(addon.get_dev_url('versions'))
 
 
@@ -397,9 +394,9 @@ def disable(request, addon_id, addon):
     latest_version = addon.find_latest_version(
         channel=amo.RELEASE_CHANNEL_LISTED)
     if latest_version:
-        latest_version.files.filter(
-            status=amo.STATUS_AWAITING_REVIEW).update(
-            status=amo.STATUS_DISABLED)
+        for file_ in latest_version.files.filter(
+                status=amo.STATUS_AWAITING_REVIEW):
+            file_.update(status=amo.STATUS_DISABLED)
     addon.update_version()
     addon.update_status()
     addon.update(disabled_by_user=True)
@@ -1541,8 +1538,6 @@ def _submit_details(request, addon, version):
             cat_form.save()
             license_form.save(log=False)
             reviewer_form.save()
-            if addon.status == amo.STATUS_NULL:
-                addon.update(status=amo.STATUS_NOMINATED)
             signals.submission_done.send(sender=addon)
         else:
             reviewer_form.save()
@@ -1686,12 +1681,11 @@ def request_review(request, addon_id, addon):
     latest_version = addon.find_latest_version_including_rejected(
         amo.RELEASE_CHANNEL_LISTED)
     if latest_version:
-        for f in latest_version.files.filter(status=amo.STATUS_DISABLED):
-            f.update(status=amo.STATUS_AWAITING_REVIEW)
         # Clear the nomination date so it gets set again in Addon.watch_status.
         latest_version.update(nomination=None)
+        for file_ in latest_version.files.filter(status=amo.STATUS_DISABLED):
+            file_.update(status=amo.STATUS_AWAITING_REVIEW)
     if addon.has_complete_metadata():
-        addon.update(status=amo.STATUS_NOMINATED)
         messages.success(request, _('Review requested.'))
     else:
         messages.success(request, _(

--- a/src/olympia/editors/forms.py
+++ b/src/olympia/editors/forms.py
@@ -412,7 +412,7 @@ class ThemeReviewForm(happyforms.Form):
         if action == rvw.ACTION_APPROVE:
             if is_rereview:
                 approve_rereview(theme)
-            theme.addon.update(status=amo.STATUS_PUBLIC)
+            theme.update_status(amo.STATUS_PUBLIC)
             theme.approve = datetime.datetime.now()
             theme.save()
 
@@ -420,17 +420,17 @@ class ThemeReviewForm(happyforms.Form):
             if is_rereview:
                 reject_rereview(theme)
             else:
-                theme.addon.update(status=amo.STATUS_REJECTED)
+                theme.update_status(amo.STATUS_REJECTED)
 
         elif action == rvw.ACTION_FLAG:
             if is_rereview:
                 mail_and_log = False
             else:
-                theme.addon.update(status=amo.STATUS_REVIEW_PENDING)
+                theme.update_status(amo.STATUS_REVIEW_PENDING)
 
         elif action == rvw.ACTION_MOREINFO:
             if not is_rereview:
-                theme.addon.update(status=amo.STATUS_REVIEW_PENDING)
+                theme.update_status(amo.STATUS_REVIEW_PENDING)
 
         if mail_and_log:
             send_mail(self.cleaned_data, theme_lock)

--- a/src/olympia/editors/helpers.py
+++ b/src/olympia/editors/helpers.py
@@ -285,10 +285,6 @@ class ViewFullReviewQueueTable(EditorQueueTable):
 log = commonware.log.getLogger('z.mailer')
 
 
-PENDING_STATUSES = (amo.STATUS_BETA, amo.STATUS_DISABLED, amo.STATUS_NULL,
-                    amo.STATUS_PENDING, amo.STATUS_PUBLIC)
-
-
 @register.function
 def get_position(addon):
     if addon.is_persona() and addon.is_pending():

--- a/src/olympia/editors/helpers.py
+++ b/src/olympia/editors/helpers.py
@@ -568,10 +568,9 @@ class ReviewAddon(ReviewBase):
         # Hold onto the status before we change it.
         status = self.addon.status
 
-        # Save files first, because set_addon checks to make sure there
-        # is at least one public file or it won't make the addon public.
+        # Only files need to be changed - addon status will be updated
+        # automatically.
         self.set_files(amo.STATUS_PUBLIC, self.files)
-        self.set_addon(status=amo.STATUS_PUBLIC)
 
         self.log_action(amo.LOG.APPROVE_VERSION)
         template = u'%s_to_public' % self.review_type
@@ -592,7 +591,6 @@ class ReviewAddon(ReviewBase):
         # Hold onto the status before we change it.
         status = self.addon.status
 
-        self.set_addon(status=amo.STATUS_NULL)
         self.set_files(amo.STATUS_DISABLED, self.files,
                        hide_disabled_file=True)
 

--- a/src/olympia/editors/tests/test_review_scenarios.py
+++ b/src/olympia/editors/tests/test_review_scenarios.py
@@ -55,7 +55,7 @@ def addon_with_files(db):
          helpers.ReviewFiles, 'pending', amo.STATUS_PUBLIC, amo.STATUS_PUBLIC),
         # scenario3: should succeed, files rejected.
         ('process_sandbox', amo.STATUS_PUBLIC, amo.STATUS_AWAITING_REVIEW,
-         helpers.ReviewFiles, 'pending', amo.STATUS_NOMINATED,
+         helpers.ReviewFiles, 'pending', amo.STATUS_NULL,
          amo.STATUS_DISABLED),
     ])
 def test_review_scenario(mock_request, addon_with_files, review_action,

--- a/src/olympia/landfill/generators.py
+++ b/src/olympia/landfill/generators.py
@@ -10,7 +10,7 @@ from olympia.addons.forms import icons
 from olympia.addons.models import Addon, Persona, update_search_index
 from olympia.constants.applications import APPS, FIREFOX
 from olympia.constants.base import (
-    ADDON_EXTENSION, ADDON_PERSONA, STATUS_PUBLIC)
+    ADDON_EXTENSION, ADDON_PERSONA, STATUS_PUBLIC, RELEASE_CHANNEL_LISTED)
 
 from .categories import generate_categories
 from .collection import generate_collection
@@ -45,6 +45,7 @@ def create_addon(name, icon_type, application, **extra_kwargs):
     kwargs = {
         'status': STATUS_PUBLIC,
         'name': name,
+        'summary': 'A summary of %s' % name,
         'slug': slugify(name),
         'bayesian_rating': random.uniform(1, 5),
         'average_daily_users': random.randint(200, 2000),
@@ -57,8 +58,8 @@ def create_addon(name, icon_type, application, **extra_kwargs):
 
     addon = Addon.objects.create(type=ADDON_EXTENSION, **kwargs)
     generate_version(addon=addon, app=application)
-    addon.update_version()
     addon.save()
+    addon.update_status()
     return addon
 
 
@@ -86,6 +87,8 @@ def generate_addons(num, owner, app_name):
             generate_collection(addon, app)
             featured_categories[category] += 1
         generate_ratings(addon, 5)
+        addon.save()
+        addon.update_status()
 
 
 def create_theme(name, **extra_kwargs):

--- a/src/olympia/landfill/generators.py
+++ b/src/olympia/landfill/generators.py
@@ -58,7 +58,6 @@ def create_addon(name, icon_type, application, **extra_kwargs):
     addon = Addon.objects.create(type=ADDON_EXTENSION, **kwargs)
     generate_version(addon=addon, app=application)
     addon.update_version()
-    addon.status = STATUS_PUBLIC
     addon.save()
     return addon
 

--- a/src/olympia/landfill/tests/test_generators.py
+++ b/src/olympia/landfill/tests/test_generators.py
@@ -8,7 +8,7 @@ from olympia.constants.applications import APPS
 from olympia.constants.base import ADDON_EXTENSION, ADDON_PERSONA
 from olympia.constants.categories import CATEGORIES
 from olympia.landfill.generators import (
-    _yield_name_and_cat, create_addon, create_theme)
+    _yield_name_and_cat, create_theme, generate_addons)
 from olympia.versions.models import Version
 
 
@@ -79,8 +79,9 @@ class ThemeGeneratorTests(_BaseAddonGeneratorMixin, TestCase):
 class CreateGeneratorTests(TestCase):
 
     def test_create_addon(self):
-        addon = create_addon('foo', 'icon/default', APPS['android'])
-        assert Addon.objects.last().name == addon.name
+        generate_addons(1, u'foo@baa', 'android')
+        addon = Addon.objects.last()
+        assert addon.has_complete_metadata(), addon.get_required_metadata()
         assert amo.STATUS_PUBLIC == addon.status
         assert Version.objects.last() == addon._current_version
 

--- a/src/olympia/landfill/user.py
+++ b/src/olympia/landfill/user.py
@@ -12,6 +12,7 @@ def generate_addon_user_and_category(addon, user, category):
     AddonUser.objects.create(addon=addon, user=user)
     AddonCategory.objects.create(addon=addon, category=category,
                                  feature=True)
+    del addon.all_categories
 
 
 def generate_user(email):

--- a/src/olympia/landfill/version.py
+++ b/src/olympia/landfill/version.py
@@ -1,10 +1,11 @@
+# -*- coding: utf-8 -*-
 import random
 from datetime import datetime
 
 from olympia import amo
 from olympia.applications.models import AppVersion
 from olympia.files.models import File
-from olympia.versions.models import ApplicationsVersions, Version
+from olympia.versions.models import ApplicationsVersions, License, Version
 
 
 def generate_version(addon, app=None):
@@ -18,7 +19,17 @@ def generate_version(addon, app=None):
     min_app_version = '4.0'
     max_app_version = '50.0'
     version = '%.1f' % random.uniform(0, 2)
-    v = Version.objects.create(addon=addon, version=version)
+    license = License.objects.create(
+        name={
+            'en-US': u'My License',
+            'fr': u'Mä Licence',
+        },
+        text={
+            'en-US': u'Lorem ipsum dolor sit amet, has nemore patrioqué',
+        },
+        url='http://license.example.com/'
+    )
+    v = Version.objects.create(addon=addon, version=version, license=license)
     v.created = v.last_updated = datetime.now()
     v.save()
     if app is not None:  # Not for themes.
@@ -31,4 +42,5 @@ def generate_version(addon, app=None):
                                                    max=av_max)
     File.objects.create(filename='%s-%s' % (v.addon_id, v.id), version=v,
                         platform=amo.PLATFORM_ALL.id, status=amo.STATUS_PUBLIC)
+    v.save()
     return v

--- a/src/olympia/zadmin/tasks.py
+++ b/src/olympia/zadmin/tasks.py
@@ -578,7 +578,6 @@ def fetch_langpack(url, xpi, **kw):
             AddonUser(addon=addon, user=owner).save()
             version = addon.versions.get()
 
-            addon.status = amo.STATUS_PUBLIC
             if addon.default_locale.lower() == lang.lower():
                 addon.target_locale = addon.default_locale
 


### PR DESCRIPTION
Its a more complete `update_status` but could do with some specific tests beyond the few I had to change. Also, it's of questionable utility unless we remove all the instances where we set the status directly.