### PR TITLE
fix(package): update clean-css to version 4.0.2

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -56,7 +56,7 @@ RUN pip install --no-cache-dir --exists-action=w --no-deps -r requirements/prod.
 RUN echo -e "from olympia.lib.settings_base import *\n\
 STYLUS_BIN = 'node_modules/stylus/bin/stylus'\n\
 LESS_BIN = 'node_modules/less/bin/lessc'\n\
-CLEANCSS_BIN = 'node_modules/clean-css/bin/cleancss'\n\
+CLEANCSS_BIN = 'node_modules/clean-css-cli/bin/cleancss'\n\
 UGLIFY_BIN = 'node_modules/uglify-js/bin/uglifyjs'\n\
 FXA_CONFIG = {'default': {}, 'internal': {}}\n"\
 > settings_local.py

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "addons-linter": "0.15.15",
-    "clean-css": "3.4.24",
+    "clean-css": "4.0.2",
+    "clean-css-cli": "4.0.0",
     "less": "2.7.2",
     "stylus": "0.54.5",
     "uglify-js": "2.7.5"

--- a/settings.py
+++ b/settings.py
@@ -59,7 +59,7 @@ STYLUS_BIN = os.getenv('STYLUS_BIN', path('node_modules/stylus/bin/stylus'))
 LESS_BIN = os.getenv('LESS_BIN', path('node_modules/less/bin/lessc'))
 CLEANCSS_BIN = os.getenv(
     'CLEANCSS_BIN',
-    path('node_modules/clean-css/bin/cleancss'))
+    path('node_modules/clean-css-cli/bin/cleancss'))
 UGLIFY_BIN = os.getenv(
     'UGLIFY_BIN',
     path('node_modules/uglify-js/bin/uglifyjs'))


### PR DESCRIPTION
With v4.0 clean-css has split it's command line tools into a separate
package.

Closes #4475