### PR TITLE
Extend createsuperuser command to allow SuperCreate assignment.

### DIFF
--- a/docs/topics/api/accounts.rst
+++ b/docs/topics/api/accounts.rst
@@ -60,7 +60,8 @@ This allows you to generate a new user account and sign in as that user.
 .. important::
 
     * Your API user must be in the ``Accounts:SuperCreate`` group to access
-      this endpoint.
+      this endpoint. Use ``manage.py createsuperuser --add-to-supercreate-group``
+      to create a superuser with proper access.
     * This endpoint is not available in all
       :ref:`API environments <api-environments>`.
 

--- a/src/olympia/users/management/commands/createsuperuser.py
+++ b/src/olympia/users/management/commands/createsuperuser.py
@@ -4,29 +4,81 @@ Management utility to create superusers.
 Inspired by django.contrib.auth.management.commands.createsuperuser.
 (http://bit.ly/2cTgsNV)
 """
-from __future__ import unicode_literals
+import json
+from datetime import datetime
+
+from olympia.api.models import APIKey
+from olympia.users.models import Group, GroupUser
 
 from django.contrib.auth import get_user_model
+from django.contrib.auth.management.commands.createsuperuser import (
+    Command as CreateSuperUserCommand)
 from django.core import exceptions
-from django.core.management.base import BaseCommand
+from django.core.management.base import CommandError
 from django.utils.six.moves import input
 from django.utils.text import capfirst
 
 
-class Command(BaseCommand):
+class Command(CreateSuperUserCommand):
     help = '''
 Used to create a superuser. This is similar to django's createsuperuser
 command but it doesn't support any arguments. This will prompt for a username
 and email address and that's it.
 '''
-    required_fields = ['username', 'email']
+    # TODO: Use `UserProfile.REQUIRED_FIELDS`? Not sure why `username`
+    # isn't in there...
+    required_fields = ('username', 'email')
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--add-to-supercreate-group',
+            action='store_true',
+            dest='add_to_supercreate_group',
+            default=False,
+            help='Assign the user to the Accounts:SuperCreate group',
+        )
 
     def handle(self, *args, **options):
-        user_data = {
-            field_name: self.get_value(field_name)
-            for field_name in self.required_fields
-        }
-        get_user_model()._default_manager.create_superuser(**user_data)
+        user_data = {}
+
+        # Do quick and dirty validation if --noinput
+        if not options.get('interactive', True):
+            # Stolen from django's `createsuperuser` implementation.
+            try:
+                for field_name in self.required_fields:
+                    if options.get(field_name, None):
+                        field = self.UserModel._meta.get_field(field_name)
+                        user_data[field_name] = field.clean(
+                            options[field_name], None)
+                    else:
+                        raise CommandError(
+                            'You must use --%s with --noinput.' % field_name)
+            except exceptions.ValidationError as exc:
+                raise CommandError('; '.join(exc.messages))
+        else:
+            user_data = {
+                field_name: self.get_value(field_name)
+                for field_name in self.required_fields
+            }
+
+        user = get_user_model()._default_manager.create_superuser(**user_data)
+
+        if options.get('add_to_supercreate_group', False):
+            user.read_dev_agreement = datetime.utcnow()
+            user.save(update_fields=('read_dev_agreement',))
+
+            group, _ = Group.objects.get_or_create(
+                rules='Accounts:SuperCreate',
+                defaults={'name': 'Account Super Creators'})
+            GroupUser.objects.create(user=user, group=group)
+            apikey = APIKey.new_jwt_credentials(user=user)
+
+            self.stdout.write(json.dumps({
+                'username': user.username,
+                'email': user.email,
+                'api-key': apikey.key,
+                'api-secret': apikey.secret
+            }))
 
     def get_value(self, field_name):
         field = get_user_model()._meta.get_field(field_name)
@@ -35,7 +87,7 @@ and email address and that's it.
             raw_value = input('{}: '.format(capfirst(field_name)))
             try:
                 value = field.clean(raw_value, None)
-            except exceptions.ValidationError as e:
-                self.stderr.write('Error: {}'.format('; '.join(e.messages)))
+            except exceptions.ValidationError as exc:
+                self.stderr.write('Error: {}'.format('; '.join(exc.messages)))
                 value = None
         return value


### PR DESCRIPTION
This re-adds --no-input arguments and handles it properly.

Fixes #2593 