### PR TITLE
Show specific message for incomplete add-ons with only a beta version in devhub

### DIFF
--- a/src/olympia/activity/views.py
+++ b/src/olympia/activity/views.py
@@ -62,8 +62,8 @@ class VersionReviewNotesViewSet(AddonChildMixin, ListModelMixin,
     @waffle_switch('activity-email')
     def create(self, request, *args, **kwargs):
         version = self.get_version_object()
-        latest_version = version.addon.find_latest_version_including_rejected(
-            channel=version.channel)
+        latest_version = version.addon.find_latest_version(
+            channel=version.channel, exclude=(amo.STATUS_BETA,))
         if version != latest_version:
             raise ParseError(
                 _('Only latest versions of addons can have notes added.'))

--- a/src/olympia/devhub/templates/devhub/addons/listing/items.html
+++ b/src/olympia/devhub/templates/devhub/addons/listing/items.html
@@ -13,6 +13,10 @@
         <p class="incomplete">
           {{ _("This add-on doesn't have any versions.")}}
         </p>
+      {% elif addon.status == amo.STATUS_NULL and addon.current_beta_version %}
+          <p class="incomplete">
+            {{ _("This add-on doesn't have any approved versions, so its public pages (including beta versions) are hidden.") }}
+          </p>
       {% else %}
         {% if addon.status != amo.STATUS_NULL or addon.has_listed_versions() %}
           <div class="item-info">

--- a/src/olympia/devhub/templates/devhub/versions/list.html
+++ b/src/olympia/devhub/templates/devhub/versions/list.html
@@ -27,7 +27,7 @@
 {% endif %}
 
 {% macro version_details(version, full_info=False) %}
-  {% set latest_version_in_channel = version.addon.find_latest_version_including_rejected(channel=version.channel) %}
+  {% set latest_version_in_channel = version.addon.find_latest_version(channel=version.channel, exclude=(amo.STATUS_BETA,)) %}
   <tr{% if version_disabled(version) %} class="version-disabled"{% endif %}>
     <td>
       <strong>
@@ -240,11 +240,10 @@
           <th class="version-delete">{{ _('Delete/Disable') }}</th>
         </tr>
 
-        {% set latest_version_including_disabled = addon.find_latest_version_including_rejected(channel=amo.RELEASE_CHANNEL_LISTED) %}
+        {% set latest_listed_version_including_disabled = addon.find_latest_version(channel=amo.RELEASE_CHANNEL_LISTED, exclude=(amo.STATUS_BETA,)) %}
         {% for version in versions.object_list %}
           {% if version != current_version and version != latest_listed_version %}
-            {{ version_details(version,
-                              full_info=version==latest_version_including_disabled) }}
+            {{ version_details(version, full_info=version==latest_listed_version_including_disabled) }}
           {% endif %}
         {% endfor %}
       </table>

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -1486,7 +1486,7 @@ def submit_version_upload(request, addon_id, addon, channel):
 @no_admin_disabled
 def submit_version_auto(request, addon_id, addon):
     # choose the channel we need from the last upload
-    last_version = addon.find_latest_version_including_rejected(None)
+    last_version = addon.find_latest_version(None, exclude=())
     if not last_version:
         return redirect('devhub.submit.version.distribution', addon.slug)
     channel = last_version.channel
@@ -1683,8 +1683,8 @@ def request_review(request, addon_id, addon):
     if not addon.can_request_review():
         return http.HttpResponseBadRequest()
 
-    latest_version = addon.find_latest_version_including_rejected(
-        amo.RELEASE_CHANNEL_LISTED)
+    latest_version = addon.find_latest_version(
+        amo.RELEASE_CHANNEL_LISTED, exclude=(amo.STATUS_BETA,))
     if latest_version:
         for f in latest_version.files.filter(status=amo.STATUS_DISABLED):
             f.update(status=amo.STATUS_AWAITING_REVIEW)

--- a/src/olympia/editors/views.py
+++ b/src/olympia/editors/views.py
@@ -577,7 +577,8 @@ def review(request, addon, channel=None):
     if unlisted_only and not acl.check_unlisted_addons_reviewer(request):
         raise PermissionDenied
 
-    version = addon.find_latest_version_including_rejected(channel=channel)
+    version = addon.find_latest_version(
+        channel=channel, exclude=(amo.STATUS_BETA,))
 
     if not settings.ALLOW_SELF_REVIEWS and addon.has_author(request.user):
         amo.messages.warning(request, _('Self-reviews are not allowed.'))

--- a/src/olympia/signing/views.py
+++ b/src/olympia/signing/views.py
@@ -181,7 +181,7 @@ class VersionView(APIView):
             channel = amo.CHANNEL_CHOICES_LOOKUP.get(channel_param)
             if not channel:
                 last_version = (
-                    addon.find_latest_version_including_rejected(None))
+                    addon.find_latest_version(None, exclude=()))
                 if last_version:
                     channel = last_version.channel
                 else:

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -142,8 +142,8 @@ class Version(OnChangeMixin, ModelBase):
             parsed_data = utils.parse_addon(upload, addon)
         license_id = None
         if channel == amo.RELEASE_CHANNEL_LISTED:
-            previous_version = addon.find_latest_version_including_rejected(
-                channel=channel)
+            previous_version = addon.find_latest_version(
+                channel=channel, exclude=())
             if previous_version and previous_version.license_id:
                 license_id = previous_version.license_id
         version = cls.objects.create(


### PR DESCRIPTION
To do that, refactor find_latest_version()`, making `get_required_metadata()` not care about the status of the latest version it finds anymore (it only cares about the license)

Fix #4427