### PR TITLE
Fallback to en translations if no translation supplied for plural

### DIFF
--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -737,6 +737,7 @@ MINIFY_BUNDLES = {
         ),
         # Impala: Things to be loaded at the bottom
         'impala': (
+            'js/lib/ngettext-overload.js',
             'js/lib/raven.min.js',
             'js/common/raven-config.js',
             'js/lib/underscore.js',

--- a/static/js/lib/ngettext-overload.js
+++ b/static/js/lib/ngettext-overload.js
@@ -1,0 +1,18 @@
+// Overload the ngettext function provided by django to fall-back
+// to the provided string if a translation is missing.
+// TODO: Remove this once we upgrade to a version of Django that contains
+// the fix for https://code.djangoproject.com/ticket/27418
+if (window.ngettext && django && django.ngettext && django.catalog && django.pluralidx) {
+  django.ngettext = function (singular, plural, count) {
+    var value = django.catalog[singular];
+    var translation;
+    if (typeof(value) !== 'undefined') {
+      translation = value[django.pluralidx(count)];
+      if (translation && translation.length > 0) {
+        return translation;
+      }
+    }
+    return (count == 1) ? singular : plural;
+  };
+  window.ngettext = django.ngettext;
+}


### PR DESCRIPTION
Fixes #4564

This is a hack to overload the ngettext on the site so that missing plural forms fallback to english.

This is the old code for reference:

```js
django.ngettext = function (singular, plural, count) {
  var value = django.catalog[singular];
  if (typeof(value) == 'undefined') {
    return (count == 1) ? singular : plural;
  } else {
    return value[django.pluralidx(count)];
  }
};
```

Another suggested solution would be to have our own version of the i18n file but I suspect that will need a bit more time to work out. 