### PR TITLE
Make sure Addon.compatible_version only returns listed versions

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -10,7 +10,6 @@ from operator import attrgetter
 from datetime import datetime
 
 from django.conf import settings
-from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.storage import default_storage as storage
 from django.db import models, transaction
@@ -806,127 +805,6 @@ class Addon(OnChangeMixin, ModelBase):
                           tuple(diff + [self, e]))
 
         return bool(updated)
-
-    def compatible_version(self, app_id, app_version=None, platform=None,
-                           compat_mode='strict'):
-        """Returns the newest compatible version given the input."""
-        if not app_id:
-            return None
-
-        if platform:
-            # We include platform_id=1 always in the SQL so we skip it here.
-            platform = platform.lower()
-            if platform != 'all' and platform in amo.PLATFORM_DICT:
-                platform = amo.PLATFORM_DICT[platform].id
-            else:
-                platform = None
-
-        log.debug(u'Checking compatibility for add-on ID:%s, APP:%s, V:%s, '
-                  u'OS:%s, Mode:%s' % (self.id, app_id, app_version, platform,
-                                       compat_mode))
-        valid_file_statuses = ','.join(map(str, self.valid_file_statuses))
-        data = {
-            'id': self.id,
-            'app_id': app_id,
-            'platform': platform,
-            'valid_file_statuses': valid_file_statuses,
-            'channel': amo.RELEASE_CHANNEL_LISTED,
-        }
-        if app_version:
-            data.update(version_int=version_int(app_version))
-        else:
-            # We can't perform the search queries for strict or normal without
-            # an app version.
-            compat_mode = 'ignore'
-
-        ns_key = cache_ns_key('d2c-versions:%s' % self.id)
-        cache_key = '%s:%s:%s:%s:%s' % (ns_key, app_id, app_version, platform,
-                                        compat_mode)
-        version_id = cache.get(cache_key)
-        if version_id is not None:
-            log.debug(u'Found compatible version in cache: %s => %s' % (
-                      cache_key, version_id))
-            if version_id == 0:
-                return None
-            else:
-                try:
-                    return Version.objects.get(pk=version_id)
-                except Version.DoesNotExist:
-                    pass
-
-        raw_sql = ["""
-            SELECT versions.*
-            FROM versions
-            INNER JOIN addons
-                ON addons.id = versions.addon_id AND addons.id = %(id)s
-            INNER JOIN applications_versions
-                ON applications_versions.version_id = versions.id
-            INNER JOIN appversions appmin
-                ON appmin.id = applications_versions.min
-                AND appmin.application_id = %(app_id)s
-            INNER JOIN appversions appmax
-                ON appmax.id = applications_versions.max
-                AND appmax.application_id = %(app_id)s
-            INNER JOIN files
-                ON files.version_id = versions.id AND
-                   (files.platform_id = 1"""]
-
-        if platform:
-            raw_sql.append(' OR files.platform_id = %(platform)s')
-
-        raw_sql.append(') WHERE files.status IN (%(valid_file_statuses)s) ')
-
-        raw_sql.append(' AND versions.channel = %(channel)s ')
-
-        if app_version:
-            raw_sql.append('AND appmin.version_int <= %(version_int)s ')
-
-        if compat_mode == 'ignore':
-            pass  # No further SQL modification required.
-
-        elif compat_mode == 'normal':
-            raw_sql.append("""AND
-                CASE WHEN files.strict_compatibility = 1 OR
-                          files.binary_components = 1
-                THEN appmax.version_int >= %(version_int)s ELSE 1 END
-            """)
-            # Filter out versions that don't have the minimum maxVersion
-            # requirement to qualify for default-to-compatible.
-            d2c_max = amo.D2C_MAX_VERSIONS.get(app_id)
-            if d2c_max:
-                data['d2c_max_version'] = version_int(d2c_max)
-                raw_sql.append(
-                    "AND appmax.version_int >= %(d2c_max_version)s ")
-
-            # Filter out versions found in compat overrides
-            raw_sql.append("""AND
-                NOT versions.id IN (
-                SELECT version_id FROM incompatible_versions
-                WHERE app_id=%(app_id)s AND
-                  (min_app_version='0' AND
-                       max_app_version_int >= %(version_int)s) OR
-                  (min_app_version_int <= %(version_int)s AND
-                       max_app_version='*') OR
-                  (min_app_version_int <= %(version_int)s AND
-                       max_app_version_int >= %(version_int)s)) """)
-
-        else:  # Not defined or 'strict'.
-            raw_sql.append('AND appmax.version_int >= %(version_int)s ')
-
-        raw_sql.append('ORDER BY versions.id DESC LIMIT 1;')
-
-        version = Version.objects.raw(''.join(raw_sql) % data)
-        if version:
-            version = version[0]
-            version_id = version.id
-        else:
-            version = None
-            version_id = 0
-
-        log.debug(u'Caching compat version %s => %s' % (cache_key, version_id))
-        cache.set(cache_key, version_id, None)
-
-        return version
 
     def increment_theme_version_number(self):
         """Increment theme version number by 1."""

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -825,8 +825,13 @@ class Addon(OnChangeMixin, ModelBase):
                   u'OS:%s, Mode:%s' % (self.id, app_id, app_version, platform,
                                        compat_mode))
         valid_file_statuses = ','.join(map(str, self.valid_file_statuses))
-        data = dict(id=self.id, app_id=app_id, platform=platform,
-                    valid_file_statuses=valid_file_statuses)
+        data = {
+            'id': self.id,
+            'app_id': app_id,
+            'platform': platform,
+            'valid_file_statuses': valid_file_statuses,
+            'channel': amo.RELEASE_CHANNEL_LISTED,
+        }
         if app_version:
             data.update(version_int=version_int(app_version))
         else:
@@ -870,6 +875,8 @@ class Addon(OnChangeMixin, ModelBase):
             raw_sql.append(' OR files.platform_id = %(platform)s')
 
         raw_sql.append(') WHERE files.status IN (%(valid_file_statuses)s) ')
+
+        raw_sql.append(' AND versions.channel = %(channel)s ')
 
         if app_version:
             raw_sql.append('AND appmin.version_int <= %(version_int)s ')

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -541,23 +541,16 @@ class TestAddonModels(TestCase):
         addon = Addon.objects.get(pk=5299)
         assert addon.current_beta_version.id == 50000
 
-    def _create_new_version(self, addon, status):
-        av = addon.current_version.apps.all()[0]
-
-        version = Version.objects.create(addon=addon, version='99')
-        File.objects.create(status=status, version=version)
-
-        ApplicationsVersions.objects.create(
-            application=amo.FIREFOX.id, version=version,
-            min=av.min, max=av.max)
-        return version
-
     def test_compatible_version(self):
         addon = Addon.objects.get(pk=3615)
         assert addon.status == amo.STATUS_PUBLIC
 
-        version = self._create_new_version(
-            addon=addon, status=amo.STATUS_PUBLIC)
+        version = version_factory(
+            addon=addon,
+            status=amo.STATUS_PUBLIC, version='99')
+        version_factory(
+            addon=addon, status=amo.STATUS_PUBLIC, version='100',
+            channel=amo.RELEASE_CHANNEL_UNLISTED)
         assert addon.compatible_version(amo.FIREFOX.id) == version
 
     def test_transformer(self):

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -541,18 +541,6 @@ class TestAddonModels(TestCase):
         addon = Addon.objects.get(pk=5299)
         assert addon.current_beta_version.id == 50000
 
-    def test_compatible_version(self):
-        addon = Addon.objects.get(pk=3615)
-        assert addon.status == amo.STATUS_PUBLIC
-
-        version = version_factory(
-            addon=addon,
-            status=amo.STATUS_PUBLIC, version='99')
-        version_factory(
-            addon=addon, status=amo.STATUS_PUBLIC, version='100',
-            channel=amo.RELEASE_CHANNEL_UNLISTED)
-        assert addon.compatible_version(amo.FIREFOX.id) == version
-
     def test_transformer(self):
         addon = Addon.objects.get(pk=3615)
         # If the transformer works then we won't have any more queries.

--- a/src/olympia/legacy_api/tests/test_utils.py
+++ b/src/olympia/legacy_api/tests/test_utils.py
@@ -1,0 +1,15 @@
+from olympia import amo
+from olympia.amo.tests import addon_factory, TestCase, version_factory
+from olympia.legacy_api.utils import find_compatible_version
+
+
+class TestCompatibleVersion(TestCase):
+    def test_compatible_version(self):
+        addon = addon_factory()
+        version = version_factory(
+            addon=addon,
+            status=amo.STATUS_PUBLIC, version='99')
+        version_factory(
+            addon=addon, status=amo.STATUS_PUBLIC, version='100',
+            channel=amo.RELEASE_CHANNEL_UNLISTED)
+        assert find_compatible_version(addon, amo.FIREFOX.id) == version

--- a/src/olympia/legacy_api/utils.py
+++ b/src/olympia/legacy_api/utils.py
@@ -1,13 +1,21 @@
 import re
 
 from django.conf import settings
+from django.core.cache import cache
 from django.utils.html import strip_tags
+
+import commonware.log
 
 from olympia import amo
 from olympia.amo.helpers import absolutify
 from olympia.amo.urlresolvers import reverse
-from olympia.amo.utils import urlparams, epoch
+from olympia.amo.utils import cache_ns_key, urlparams, epoch
 from olympia.tags.models import Tag
+from olympia.versions.compare import version_int
+from olympia.versions.models import Version
+
+
+log = commonware.log.getLogger('z.api')
 
 
 # For app version major.minor matching.
@@ -152,3 +160,126 @@ def extract_filters(term, opts=None):
             filters['tags__in'] = list(tag)
 
     return (term, filters, params)
+
+
+def find_compatible_version(addon, app_id, app_version=None, platform=None,
+                            compat_mode='strict'):
+    """Returns the newest compatible version (ordered by version id desc)
+    for the given addon."""
+    if not app_id:
+        return None
+
+    if platform:
+        # We include platform_id=1 always in the SQL so we skip it here.
+        platform = platform.lower()
+        if platform != 'all' and platform in amo.PLATFORM_DICT:
+            platform = amo.PLATFORM_DICT[platform].id
+        else:
+            platform = None
+
+    log.debug(u'Checking compatibility for add-on ID:%s, APP:%s, V:%s, '
+              u'OS:%s, Mode:%s' % (addon.id, app_id, app_version, platform,
+                                   compat_mode))
+    valid_file_statuses = ','.join(map(str, addon.valid_file_statuses))
+    data = {
+        'id': addon.id,
+        'app_id': app_id,
+        'platform': platform,
+        'valid_file_statuses': valid_file_statuses,
+        'channel': amo.RELEASE_CHANNEL_LISTED,
+    }
+    if app_version:
+        data.update(version_int=version_int(app_version))
+    else:
+        # We can't perform the search queries for strict or normal without
+        # an app version.
+        compat_mode = 'ignore'
+
+    ns_key = cache_ns_key('d2c-versions:%s' % addon.id)
+    cache_key = '%s:%s:%s:%s:%s' % (ns_key, app_id, app_version, platform,
+                                    compat_mode)
+    version_id = cache.get(cache_key)
+    if version_id is not None:
+        log.debug(u'Found compatible version in cache: %s => %s' % (
+                  cache_key, version_id))
+        if version_id == 0:
+            return None
+        else:
+            try:
+                return Version.objects.get(pk=version_id)
+            except Version.DoesNotExist:
+                pass
+
+    raw_sql = ["""
+        SELECT versions.*
+        FROM versions
+        INNER JOIN addons
+            ON addons.id = versions.addon_id AND addons.id = %(id)s
+        INNER JOIN applications_versions
+            ON applications_versions.version_id = versions.id
+        INNER JOIN appversions appmin
+            ON appmin.id = applications_versions.min
+            AND appmin.application_id = %(app_id)s
+        INNER JOIN appversions appmax
+            ON appmax.id = applications_versions.max
+            AND appmax.application_id = %(app_id)s
+        INNER JOIN files
+            ON files.version_id = versions.id AND
+               (files.platform_id = 1"""]
+
+    if platform:
+        raw_sql.append(' OR files.platform_id = %(platform)s')
+
+    raw_sql.append(') WHERE files.status IN (%(valid_file_statuses)s) ')
+
+    raw_sql.append(' AND versions.channel = %(channel)s ')
+
+    if app_version:
+        raw_sql.append('AND appmin.version_int <= %(version_int)s ')
+
+    if compat_mode == 'ignore':
+        pass  # No further SQL modification required.
+
+    elif compat_mode == 'normal':
+        raw_sql.append("""AND
+            CASE WHEN files.strict_compatibility = 1 OR
+                      files.binary_components = 1
+            THEN appmax.version_int >= %(version_int)s ELSE 1 END
+        """)
+        # Filter out versions that don't have the minimum maxVersion
+        # requirement to qualify for default-to-compatible.
+        d2c_max = amo.D2C_MAX_VERSIONS.get(app_id)
+        if d2c_max:
+            data['d2c_max_version'] = version_int(d2c_max)
+            raw_sql.append(
+                "AND appmax.version_int >= %(d2c_max_version)s ")
+
+        # Filter out versions found in compat overrides
+        raw_sql.append("""AND
+            NOT versions.id IN (
+            SELECT version_id FROM incompatible_versions
+            WHERE app_id=%(app_id)s AND
+              (min_app_version='0' AND
+                   max_app_version_int >= %(version_int)s) OR
+              (min_app_version_int <= %(version_int)s AND
+                   max_app_version='*') OR
+              (min_app_version_int <= %(version_int)s AND
+                   max_app_version_int >= %(version_int)s)) """)
+
+    else:  # Not defined or 'strict'.
+        raw_sql.append('AND appmax.version_int >= %(version_int)s ')
+
+    raw_sql.append('ORDER BY versions.id DESC LIMIT 1;')
+
+    version = Version.objects.raw(''.join(raw_sql) % data)
+    if version:
+        version = version[0]
+        version_id = version.id
+    else:
+        version = None
+        version_id = 0
+
+    log.debug(u'Caching compat version %s => %s' % (cache_key, version_id))
+    cache.set(cache_key, version_id, None)
+
+    return version

--- a/src/olympia/legacy_api/views.py
+++ b/src/olympia/legacy_api/views.py
@@ -28,7 +28,8 @@ from olympia.amo.decorators import (
 from olympia.amo.models import manual_order
 from olympia.amo.urlresolvers import get_url_prefix
 from olympia.amo.utils import AMOJSONEncoder
-from olympia.legacy_api.utils import addon_to_dict, extract_filters
+from olympia.legacy_api.utils import (
+    addon_to_dict, extract_filters, find_compatible_version)
 from olympia.search.views import (
     AddonSuggestionsAjax, PersonaSuggestionsAjax, name_query)
 from olympia.versions.compare import version_int
@@ -178,8 +179,8 @@ def addon_filter(addons, addon_type, limit, app, platform, version,
             elif compat_mode == 'normal':
                 # This does a db hit but it's cached. This handles the cases
                 # for strict opt-in, binary components, and compat overrides.
-                v = addon.compatible_version(APP.id, version, platform,
-                                             compat_mode)
+                v = find_compatible_version(addon, APP.id, version, platform,
+                                            compat_mode)
                 if v:  # There's a compatible version.
                     addons.append(addon)
 
@@ -383,10 +384,10 @@ class SearchView(APIView):
 
         results = []
         for addon in qs:
-            compat_version = addon.compatible_version(app_id,
-                                                      params['version'],
-                                                      params['platform'],
-                                                      compat_mode)
+            compat_version = find_compatible_version(addon, app_id,
+                                                     params['version'],
+                                                     params['platform'],
+                                                     compat_mode)
             # Specific case for Personas (bug 990768): if we search providing
             # the Persona addon type (9), then don't look for a compatible
             # version.


### PR DESCRIPTION
The legacy API (called by the add-on manager in Firefox) uses that method.