### PR TITLE
Logout API for mobile pages

### DIFF
--- a/docs/topics/api/accounts.rst
+++ b/docs/topics/api/accounts.rst
@@ -121,3 +121,31 @@ This allows you to generate a new user account and sign in as that user.
         curl --cookie sessionid=... -s -D - \
             "https://addons.mozilla.org/en-US/developers/addon/submit/1" \
             -o /dev/null
+
+.. _`session`:
+
+-------
+Session
+-------
+
+Log out of the current session.
+
+.. http:delete:: /api/v3/accounts/session/
+
+    **Request:**
+
+    .. sourcecode:: bash
+
+        curl "https://addons.mozilla.org/api/v3/accounts/session/"
+            -H "Authorization: JWT <jwt-token>" -X DELETE
+
+    **Response:**
+
+    .. sourcecode:: json
+
+        {
+            "ok": true
+        }
+
+    :statuscode 200: session logged out.
+    :statuscode 401: authentication failed.

--- a/docs/topics/api/accounts.rst
+++ b/docs/topics/api/accounts.rst
@@ -128,7 +128,9 @@ This allows you to generate a new user account and sign in as that user.
 Session
 -------
 
-Log out of the current session.
+Log out of the current session. This is for use with the
+:ref:`internal authentication <api-auth-internal>` that authenticates browser
+sessions.
 
 .. http:delete:: /api/v3/accounts/session/
 
@@ -137,7 +139,7 @@ Log out of the current session.
     .. sourcecode:: bash
 
         curl "https://addons.mozilla.org/api/v3/accounts/session/"
-            -H "Authorization: JWT <jwt-token>" -X DELETE
+            -H "Authorization: Bearer <jwt-token>" -X DELETE
 
     **Response:**
 

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -755,6 +755,9 @@ class TestAuthenticateView(BaseAuthenticationView):
         assert not user_qs.exists()
         identity = {u'email': u'me@yeahoo.com', u'uid': u'e0b6f'}
         self.fxa_identify.return_value = identity
+        user = UserProfile(
+            username='foo', email='me@yeahoo.com', fxa_id='e0b6f')
+        self.register_user.return_value = user
         response = self.client.get(
             self.url, {'code': 'codes!!', 'state': self.fxa_state})
         # This 302s because the user isn't logged in due to mocking.
@@ -763,12 +766,18 @@ class TestAuthenticateView(BaseAuthenticationView):
         self.fxa_identify.assert_called_with('codes!!', config=FXA_CONFIG)
         assert not self.login_user.called
         self.register_user.assert_called_with(mock.ANY, identity)
+        user.save()  # Persist the user so it can be verified.
+        data = {'token': response.cookies['jwt_api_auth_token'].value}
+        verify = VerifyJSONWebTokenSerializer().validate(data)
+        assert verify['user'] == user
 
     def test_register_redirects_edit(self):
         user_qs = UserProfile.objects.filter(email='me@yeahoo.com')
         assert not user_qs.exists()
         identity = {u'email': u'me@yeahoo.com', u'uid': u'e0b6f'}
         self.fxa_identify.return_value = identity
+        user = UserProfile(username='foo', email='me@yeahoo.com')
+        self.register_user.return_value = user
         response = self.client.get(self.url, {
             'code': 'codes!!',
             'state': ':'.join(

--- a/src/olympia/accounts/urls.py
+++ b/src/olympia/accounts/urls.py
@@ -24,6 +24,8 @@ urlpatterns = [
     url(r'^login/start/$',
         views.LoginStartView.as_view(),
         name='accounts.login_start'),
+    url(r'^session/$', views.SessionView.as_view(),
+        name='accounts.session'),
     url(r'^profile/$', views.ProfileView.as_view(), name='accounts.profile'),
     url(r'^register/$', views.RegisterView.as_view(),
         name='accounts.register'),

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -306,13 +306,15 @@ class AuthenticateView(APIView):
     @with_user(format='html')
     def get(self, request, user, identity, next_path):
         if user is None:
-            register_user(request, identity)
-            return safe_redirect(reverse('users.edit'), 'register')
+            user = register_user(request, identity)
+            response = safe_redirect(reverse('users.edit'), 'register')
         else:
             login_user(request, user, identity)
             response = safe_redirect(next_path, 'login')
-            add_api_token_to_response(response, user)
-            return response
+        add_api_token_to_response(response, user)
+        return response
+
+
 
 
 class ProfileView(generics.RetrieveAPIView):

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -101,11 +101,6 @@ def cors_endpoint_overrides(internal, public):
             'CORS_ORIGIN_WHITELIST': public,
             'CORS_ALLOW_CREDENTIALS': True,
         }),
-        (r'^/api/v3/accounts/session/?$', {
-            'CORS_ORIGIN_ALLOW_ALL': False,
-            'CORS_ORIGIN_WHITELIST': internal,
-            'CORS_ALLOW_CREDENTIALS': True,
-        }),
         (r'^/api/v3/internal/.*$', {
             'CORS_ORIGIN_ALLOW_ALL': False,
             'CORS_ORIGIN_WHITELIST': internal,

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -101,6 +101,11 @@ def cors_endpoint_overrides(internal, public):
             'CORS_ORIGIN_WHITELIST': public,
             'CORS_ALLOW_CREDENTIALS': True,
         }),
+        (r'^/api/v3/accounts/session/?$', {
+            'CORS_ORIGIN_ALLOW_ALL': False,
+            'CORS_ORIGIN_WHITELIST': internal,
+            'CORS_ALLOW_CREDENTIALS': True,
+        }),
         (r'^/api/v3/internal/.*$', {
             'CORS_ORIGIN_ALLOW_ALL': False,
             'CORS_ORIGIN_WHITELIST': internal,

--- a/src/olympia/users/tests/test_views.py
+++ b/src/olympia/users/tests/test_views.py
@@ -17,6 +17,7 @@ from olympia import amo
 from olympia.amo.tests import TestCase
 from olympia.abuse.models import AbuseReport
 from olympia.access.models import Group, GroupUser
+from olympia.accounts.views import JWT_TOKEN_COOKIE
 from olympia.addons.models import Addon, AddonUser, Category
 from olympia.amo.helpers import urlparams
 from olympia.amo.urlresolvers import reverse
@@ -453,10 +454,14 @@ class TestLogout(UserViewBase):
 
     def test_session_cookie_deleted_on_logout(self):
         self.client.login(email='jbalogh@mozilla.com')
+        self.client.cookies[JWT_TOKEN_COOKIE] = 'a.jwt.value'
         r = self.client.get(reverse('users.logout'))
         cookie = r.cookies[settings.SESSION_COOKIE_NAME]
         assert cookie.value == ''
         assert cookie['expires'] == u'Thu, 01-Jan-1970 00:00:00 GMT'
+        jwt_cookie = r.cookies[JWT_TOKEN_COOKIE]
+        assert jwt_cookie.value == ''
+        assert jwt_cookie['expires'] == u'Thu, 01-Jan-1970 00:00:00 GMT'
 
 
 class TestRegistration(UserViewBase):


### PR DESCRIPTION
Supports mozilla/addons-frontend#1557.

This also sets the JWT as a cookie when the user registers via the authenticate view.