### PR TITLE
Make sure we only support file-syntax aliases for SyntaxHighlighter that are installed.

### DIFF
--- a/src/olympia/files/helpers.py
+++ b/src/olympia/files/helpers.py
@@ -32,6 +32,21 @@ task_log = commonware.log.getLogger('z.task')
 
 LOCKED_LIFETIME = 60 * 5
 
+SYNTAX_HIGHLIGHTER_ALIAS_MAPPING = {
+    'xul': 'xml',
+    'rdf': 'xml',
+    'jsm': 'js',
+    'json': 'js',
+    'htm': 'html'
+}
+
+# See settings.MINIFY_BUNDLES['js']['zamboni/files'] for more details
+# as to which brushes we support.
+SYNTAX_HIGHLIGHTER_SUPPORTED_LANGUAGES = frozenset([
+    'css', 'html', 'java', 'javascript', 'js', 'jscript',
+    'plain', 'text', 'xml', 'xhtml', 'xlst',
+])
+
 
 @register.function
 def file_viewer_class(value, key):
@@ -303,15 +318,9 @@ class FileViewer(object):
         """
         if filename:
             short = os.path.splitext(filename)[1][1:]
-            syntax_map = {'xul': 'xml', 'rdf': 'xml', 'jsm': 'js',
-                          'json': 'js', 'htm': 'html'}
-            short = syntax_map.get(short, short)
-            if short in ['actionscript3', 'as3', 'bash', 'shell', 'cpp', 'c',
-                         'c#', 'c-sharp', 'csharp', 'css', 'diff', 'html',
-                         'java', 'javascript', 'js', 'jscript', 'patch',
-                         'pas', 'php', 'plain', 'py', 'python', 'sass',
-                         'scss', 'text', 'sql', 'vb', 'vbnet', 'xml', 'xhtml',
-                         'xslt']:
+            short = SYNTAX_HIGHLIGHTER_ALIAS_MAPPING.get(short, short)
+
+            if short in SYNTAX_HIGHLIGHTER_SUPPORTED_LANGUAGES:
                 return short
         return 'plain'
 

--- a/src/olympia/files/templates/files/viewer.html
+++ b/src/olympia/files/templates/files/viewer.html
@@ -18,6 +18,18 @@
      {% if automated_signing %}data-automated-signing="true"{% endif %}
      data-validation-failed="{{ _("Validation failed:") }}"></div>
 
+<div class="modal highlighter-output-broken js-hidden">
+  <h2>{{ _('File content not supported for syntax highlighting') }}</h2>
+  <p>
+   {% trans link_start='<a href="https://github.com/mozilla/addons-server/issues/">'|safe, link_end='</a>'|safe %}
+    The output can be broken, please be careful and {{ link_start }}report an issue{{ link_end }} immediately!
+    {% endtrans %}
+  </p>
+  <p>
+    <a class="close">{{ _('close') }}</a>
+  </p>
+</div>
+
 <h3>
   <a href="{{ file_link['url'] }}">{{ addon.name }} {{ version }}</a>
   {% if file.platform != amo.PLATFORM_ALL.id %}({{ file.get_platform_display() }}){% endif %}

--- a/src/olympia/files/tests/test_helpers.py
+++ b/src/olympia/files/tests/test_helpers.py
@@ -216,7 +216,8 @@ class TestFileViewer(TestCase):
                                  ('foo.json', 'js'),
                                  ('foo.jsm', 'js'),
                                  ('foo.htm', 'html'),
-                                 ('foo.bar', 'plain')]:
+                                 ('foo.bar', 'plain'),
+                                 ('foo.diff', 'plain')]:
             assert self.viewer.get_syntax(filename) == syntax
 
     def test_file_order(self):

--- a/static/js/zamboni/files.js
+++ b/static/js/zamboni/files.js
@@ -112,6 +112,32 @@ var Highlighter = {
         // highlighter will try to replace the original element in the
         // DOM when it's done.
 
+        // Verify that we actually support the used brush
+        // see https://github.com/mozilla/addons-server/issues/4552 for more
+        // details. This shows an alert if a brush is not supported.
+        var discoveredBrushes = SyntaxHighlighter.brushes;
+
+        if (discoveredBrushes) {
+            var brushes = [];
+
+            for (var discoveredBrush in discoveredBrushes) {
+                var aliases = discoveredBrushes[discoveredBrush].aliases;
+
+                if (aliases == null) {
+                    continue;
+                }
+
+                for (var i = 0, l = aliases.length; i < l; i++) {
+                    brushes.push(aliases[i]);
+                }
+            }
+
+            if (!brushes.includes(brush.toLowerCase())) {
+                $('.highlighter-output-broken').modal('', { width: 960 }).render();
+                $('.highlighter-output-broken').toggleClass('js-hidden');
+            }
+        }
+
         var $node = $('<pre>', {'class': format('brush: {0}; toolbar: false;',
                                                 [brush]),
                                 text: text});


### PR DESCRIPTION
Fixes #4552 

Apparently we removed some brushes in our last cleanup of our SyntaxHighlighter library so this kinda broke with that.

Before:

![screenshot from 2017-02-06 12-03-48](https://cloud.githubusercontent.com/assets/139033/22651919/c8c79f62-ec84-11e6-84e5-4a6af12a13d1.png)

After:

![screenshot from 2017-02-06 12-37-52](https://cloud.githubusercontent.com/assets/139033/22651930/cea4583a-ec84-11e6-874e-3812a8a3217c.png)

Not testable by QA but in case someone activates a brush (add it to the list of syntaxes supported) that is not installed:

![screenshot from 2017-02-06 18-40-17](https://cloud.githubusercontent.com/assets/139033/22658876/eec72446-ec9b-11e6-88eb-431d18f7e0d2.png)

