### PR TITLE
Revert "Disco Pane content update - Feb. 2017"

### DIFF
--- a/src/olympia/discovery/data.py
+++ b/src/olympia/discovery/data.py
@@ -11,24 +11,10 @@ class DiscoItem(object):
 
 
 # At the moment the disco pane items are hardcoded in this file in the repos,
-# which allows us to integrate in our translation workflow easily. Add-on ids
-# are used instead of slugs to prevent any accidental replacement of a deleted
-# add-on by another.
+# which allows us to integrate in our translation workflow easily.
 discopane_items = [
-
-    # 'Books' theme.
-    DiscoItem(addon_id=778525),
-
-    # Video DownloadHelper
-    DiscoItem(
-        addon_id=3006,
-        heading=_(u'Download videos {start_sub_heading}with {addon_name}'
-                  u'{end_sub_heading}'),
-        description=string_concat(
-            '<blockquote>',
-            _(u'Easily grab videos from YouTube, Dailymotion, Facebook, and '
-              u'most other video sites with this simple download tool.'),
-            '</blockquote>')),
+    # Theme: Symphony of colors
+    DiscoItem(addon_id=628864, addon_name=u'Symphony of Colors'),
 
     # uBlock Origin
     DiscoItem(
@@ -42,8 +28,30 @@ discopane_items = [
               u'bunch of memory.'),
             '</blockquote>')),
 
-    # 'yellowfield 1' theme.
-    DiscoItem(addon_id=599252, addon_name='Yellow Field 1'),
+    # Emoji Keyboard
+    DiscoItem(
+        addon_id=674732,
+        heading=_(u'Emoji expression {start_sub_heading}with {addon_name}'
+                  u'{end_sub_heading}'),
+        description=string_concat(
+            '<blockquote>',
+            _(u'Dozens of amazing emojis for every occasion—always just one '
+              u'click away.'),
+            '</blockquote>')),
+
+    # Theme: Stained Glass Fractal
+    DiscoItem(addon_id=465609),
+
+    # OmniSidebar
+    DiscoItem(
+        addon_id=296534,
+        heading=_(u'Easily access bookmarks {start_sub_heading}with '
+                  u'{addon_name}{end_sub_heading}'),
+        description=string_concat(
+            '<blockquote>',
+            _(u'Are you constantly scrolling through your bookmarks? '
+              u'Bring your lists into view with a single, simple gesture.'),
+            '</blockquote>')),
 
     # YouTube High Definition
     DiscoItem(
@@ -57,17 +65,6 @@ discopane_items = [
               u'personalize your video-watching experience.'),
             '</blockquote>')),
 
-    # Emoji Keyboard
-    DiscoItem(
-        addon_id=674732,
-        heading=_(u'Emoji expression {start_sub_heading}with {addon_name}'
-                  u'{end_sub_heading}'),
-        description=string_concat(
-            '<blockquote>',
-            _(u'Dozens of amazing emojis for every occasion—always just one '
-              u'click away.'),
-            '</blockquote>')),
-
-    # 'fon615 by levscaya' theme.
-    DiscoItem(addon_id=777344, addon_name='Fon615'),
+    # Theme: Blue Twirl
+    DiscoItem(addon_id=615472),
 ]

--- a/src/olympia/discovery/tests/test_views.py
+++ b/src/olympia/discovery/tests/test_views.py
@@ -13,18 +13,18 @@ class TestDiscoveryViewList(TestCase):
 
         # Represents a dummy version of `olympia.discovery.data`
         self.addons = {
-            778525: addon_factory(
-                id=778525, type=amo.ADDON_PERSONA,
+            628864: addon_factory(
+                id=628864, type=amo.ADDON_PERSONA,
                 users=[user_factory(), user_factory()]),
-            3006: addon_factory(id=3006, type=amo.ADDON_EXTENSION),
             607454: addon_factory(id=607454, type=amo.ADDON_EXTENSION),
-            599252: addon_factory(
-                id=599252, type=amo.ADDON_PERSONA,
-                users=[user_factory(), user_factory()]),
-            328839: addon_factory(id=328839, type=amo.ADDON_EXTENSION),
             674732: addon_factory(id=674732, type=amo.ADDON_EXTENSION),
-            777344: addon_factory(
-                id=777344, type=amo.ADDON_PERSONA,
+            465609: addon_factory(
+                id=465609, type=amo.ADDON_PERSONA,
+                users=[user_factory(), user_factory()]),
+            296534: addon_factory(id=296534, type=amo.ADDON_EXTENSION),
+            328839: addon_factory(id=328839, type=amo.ADDON_EXTENSION),
+            615472: addon_factory(
+                id=615472, type=amo.ADDON_PERSONA,
                 users=[user_factory(), user_factory()]),
         }
 
@@ -91,13 +91,13 @@ class TestDiscoveryViewList(TestCase):
         assert response.data['results']
 
     def test_missing_addon(self):
-        addon_deleted = self.addons[3006]
+        addon_deleted = self.addons[674732]
         addon_deleted.delete()
 
-        theme_disabled_by_user = self.addons[778525]
+        theme_disabled_by_user = self.addons[465609]
         theme_disabled_by_user.update(disabled_by_user=True)
 
-        self.addons[607454].update(status=amo.STATUS_NOMINATED)
+        self.addons[296534].update(status=amo.STATUS_NOMINATED)
 
         response = self.client.get(self.url)
         assert response.data
@@ -109,7 +109,5 @@ class TestDiscoveryViewList(TestCase):
         assert response.data['results']
 
         results = response.data['results']
-        assert results[0]['addon']['id'] == discopane_items[3].addon_id
-        assert results[1]['addon']['id'] == discopane_items[4].addon_id
-        assert results[2]['addon']['id'] == discopane_items[5].addon_id
-        assert results[3]['addon']['id'] == discopane_items[6].addon_id
+        assert results[0]['addon']['id'] == discopane_items[0].addon_id
+        assert results[1]['addon']['id'] == discopane_items[1].addon_id


### PR DESCRIPTION
Reverts mozilla/addons-server#4597

Too soon, should land after this week's tag.