### PR TITLE
remove two errant 'step-version-upload' waffle checks

### DIFF
--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -747,7 +747,11 @@ class TestAddonSubmitFinish(TestSubmitBase):
         self.addon.update(status=amo.STATUS_NULL)
         self.addon.versions.all().delete()
         response = self.client.get(self.url, follow=True)
-        self.assert3xx(response, self.addon.get_dev_url('versions'), 302)
+        # Would go to 'devhub.submit.version' but no previous version means
+        # channel needs to be selected first.
+        self.assert3xx(
+            response,
+            reverse('devhub.submit.version.distribution', args=['a3615']), 302)
 
     def test_incomplete_directs_to_details(self):
         # We get bounced back to details step.

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -21,7 +21,6 @@ import commonware.log
 import waffle
 from django_statsd.clients import statsd
 from PIL import Image
-from waffle.decorators import waffle_switch
 
 from olympia import amo
 from olympia.amo import utils as amo_utils
@@ -1613,10 +1612,7 @@ def submit_addon_finish(request, addon_id, addon):
         return redirect('devhub.submit.details', addon.slug)
     # Bounce to the versions page if they don't have any versions.
     if not addon.versions.exists():
-        if waffle.switch_is_active('step-version-upload'):
-            return redirect('devhub.submit.version', addon.slug)
-        else:
-            return redirect(addon.get_dev_url('versions'))
+        return redirect('devhub.submit.version', addon.slug)
     return _submit_finish(request, addon, None)
 
 
@@ -1627,7 +1623,6 @@ def submit_version_finish(request, addon_id, addon, version_id):
 
 
 @dev_required
-@waffle_switch('step-version-upload')
 def submit_file_finish(request, addon_id, addon, version_id):
     version = get_object_or_404(Version, id=version_id)
     return _submit_finish(request, addon, version, is_file=True)


### PR DESCRIPTION
Fixes #4525 
these should have all been removed in #4165 but looks like they slipped between the merges.