### PR TITLE
Always include xmlns attribute when serving version update info

### DIFF
--- a/src/olympia/versions/templates/versions/update_info.html
+++ b/src/olympia/versions/templates/versions/update_info.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ LANG }}" dir="{{ DIR }}"{% if serve_xhtml %} xmlns="http://www.w3.org/1999/xhtml"{% endif %}>
+<html lang="{{ LANG }}" dir="{{ DIR }}" xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=utf-8"/>
   <title></title>

--- a/src/olympia/versions/views.py
+++ b/src/olympia/versions/views.py
@@ -87,10 +87,8 @@ def update_info(request, addon, version_num):
                                channel=amo.RELEASE_CHANNEL_LISTED)
     if not qs:
         raise http.Http404()
-    serve_xhtml = ('application/xhtml+xml' in
-                   request.META.get('HTTP_ACCEPT', '').lower())
     return render(request, 'versions/update_info.html',
-                  {'version': qs[0], 'serve_xhtml': serve_xhtml},
+                  {'version': qs[0]},
                   content_type='application/xhtml+xml')
 
 


### PR DESCRIPTION
Not doing it breaks Firefox 51, which no longer sends the `Accept` header we expected. I don't see a good reason not to always have the attribute.

Fix #4633