### PR TITLE
Fix test dependency on what date it's being run.

### DIFF
--- a/src/olympia/files/tests/test_helpers.py
+++ b/src/olympia/files/tests/test_helpers.py
@@ -132,7 +132,6 @@ class TestFileViewer(TestCase):
     @freeze_time('2017-01-08 02:01:00')
     def test_dest(self):
         viewer = FileViewer(make_file(1, get_file('webextension.xpi')))
-        
         assert viewer.dest == os.path.join(
             settings.TMP_PATH, 'file_viewer',
             '0108', str(self.viewer.file.pk))

--- a/src/olympia/files/tests/test_helpers.py
+++ b/src/olympia/files/tests/test_helpers.py
@@ -129,11 +129,13 @@ class TestFileViewer(TestCase):
         self.viewer.cleanup()
         assert not self.viewer.is_extracted()
 
-    @freeze_time('2017-02-08 02:01:00')
+    @freeze_time('2017-01-08 02:01:00')
     def test_dest(self):
-        assert self.viewer.dest == os.path.join(
+        viewer = FileViewer(make_file(1, get_file('webextension.xpi')))
+        
+        assert viewer.dest == os.path.join(
             settings.TMP_PATH, 'file_viewer',
-            '0208', str(self.viewer.file.pk))
+            '0108', str(self.viewer.file.pk))
 
     def test_isbinary(self):
         binary = self.viewer._is_binary


### PR DESCRIPTION
test_dest was unfortunately dependend on when `FileViewer` got initialized. This fixes it and makes the test run on any date.