### PR TITLE
Replace -moz-calc for mobile and fallback for legacy disco pane

### DIFF
--- a/static/css/zamboni/discovery-pane.css
+++ b/static/css/zamboni/discovery-pane.css
@@ -175,6 +175,7 @@ header:after,
     float: right;
     width: 22%;
     width: -moz-calc(24% - 22px);
+    width: calc(24% - 22px);
     border-radius: 8px;
 }
 
@@ -187,6 +188,7 @@ header:after,
 .no-recs header.auth {
     background:
         url(../../img/zamboni/discovery_pane/bg-home.png) no-repeat 100% -moz-calc(100% - 3px),
+        url(../../img/zamboni/discovery_pane/bg-home.png) no-repeat 100% calc(100% - 3px),
         linear-gradient(#fff 0, #ecf1f7 100%);
 }
 .no-recs #my-account {
@@ -461,6 +463,7 @@ section#featured-addons {
     line-height: 32px;
     display: inline-block;
     width: -moz-calc(100% - 48px);
+    width: calc(100% - 48px);
 }
 
 .featured .featured-addons a.addon-title,
@@ -564,6 +567,7 @@ section#featured-addons {
     top: 80px;
     margin: 10px;
     width: -moz-calc(100% - 20px);
+    width: calc(100% - 20px);
 }
 
 .pane #main .persona-large .persona-preview [data-browsertheme] {
@@ -690,10 +694,12 @@ section#featured-addons {
         margin-right: 1%;
         width: 30%;
         width: -moz-calc(100% / 3 - 22px - 0.5%);
+        width: calc(100% / 3 - 22px - 0.5%);
     }
     #sub #more-ways {
         margin-right: 0;
         width: -moz-calc(100% / 3 - 22px - 1%);
+        width: calc(100% / 3 - 22px - 1%);
     }
 
     #promo-video-addons {
@@ -1028,9 +1034,11 @@ body.eula header + h3:after {
     bottom: 4px;
     right: 0;
     width: -moz-calc(100% - 70px);
+    width: calc(100% - 70px);
 }
 body.eula header + h3:after {
     width: -moz-calc(100% - 235px);
+    width: calc(100% - 235px);
 }
 
 .html-rtl #addon-reviews h3,
@@ -1295,6 +1303,7 @@ a#lightbox-secNav-btnClose {
 
 #images.js .panel {
     width: -moz-calc(100% / 3);
+    width: calc(100% / 3);
     margin: 0 -3px;
     padding: 15px 0;
     text-align: center;

--- a/static/css/zamboni/mobile.css
+++ b/static/css/zamboni/mobile.css
@@ -623,12 +623,12 @@ ul.license li.copyr { background-position: 0 -260px; }
 
 .persona-previewer .confirm-buttons .add {
     float: left;
-    width: -moz-calc(50% - 63px); /* 63px = 39px + 24px (for plus-sign icon) */
+    width: calc(50% - 63px); /* 63px = 39px + 24px (for plus-sign icon) */
 }
 
 .persona-previewer .confirm-buttons .cancel {
     float: right;
-    width: -moz-calc(50% - 39px); /* 39px = 32px + 14px / 2 (margin) */
+    width: calc(50% - 39px); /* 39px = 32px + 14px / 2 (margin) */
 }
 
 .persona-previewer .persona-installed p:before {
@@ -995,7 +995,7 @@ button:active,
     position: fixed;
     bottom: -1px;
     left: 14px;
-    width: -moz-calc(100% - 28px);
+    width: calc(100% - 28px);
     background: #fff;
 }
 #eula:after {
@@ -1003,7 +1003,7 @@ button:active,
     content: "";
     bottom: 0;
     height: 20px;
-    width: -moz-calc(100% - 28px);
+    width: calc(100% - 28px);
     z-index: 1000;
     border-width: 14px;
     border-style: solid;
@@ -1026,7 +1026,7 @@ button:active,
     margin: 8px;
     display: block;
     float: left;
-    width: -moz-calc(50% - 48px);
+    width: calc(50% - 48px);
 }
 
 


### PR DESCRIPTION
Fixes mozilla/addons#332

Removes calc from mobile css and adds fallbacks for the discovery pane since the legacy disco pane is likely to only be visited by legacy UAs.