### PR TITLE
Make sure API 404 errors handled by django are returned in json

### DIFF
--- a/src/olympia/amo/tests/test_views.py
+++ b/src/olympia/amo/tests/test_views.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime, timedelta
+import json
 import random
 
 from django import test
@@ -56,6 +57,12 @@ class Test404(TestCase):
         self.assertTemplateUsed(res, 'amo/404.html')
         links = pq(res.content)('[role=main] ul a[href^="/en-US/thunderbird"]')
         assert links.length == 4
+
+    def test_404_api(self):
+        response = self.client.get('/api/v3/lol')
+        assert response.status_code == 404
+        data = json.loads(response.content)
+        assert data['detail'] == u'Not found.'
 
 
 class TestCommon(TestCase):

--- a/src/olympia/amo/views.py
+++ b/src/olympia/amo/views.py
@@ -4,10 +4,11 @@ import os
 from django import http
 from django.conf import settings
 from django.db.transaction import non_atomic_requests
-from django.http import HttpResponse
+from django.http import HttpResponse, JsonResponse
 from django.views.decorators.cache import never_cache
 
 from django_statsd.clients import statsd
+from rest_framework.exceptions import NotFound
 
 from olympia import amo, legacy_api
 from olympia.amo.utils import render
@@ -78,7 +79,10 @@ def handler403(request):
 
 @non_atomic_requests
 def handler404(request):
-    if request.path_info.startswith('/api/'):
+    if request.path_info.startswith('/api/v3/'):
+        return JsonResponse(
+            {'detail': unicode(NotFound.default_detail)}, status=404)
+    elif request.path_info.startswith('/api/'):
         # Pass over to handler404 view in api if api was targeted.
         return legacy_api.views.handler404(request)
     else:


### PR DESCRIPTION
This only affects 404 not handled by DRF - the 404 comes from django because the URL does not point to any known urlpattern, but since the prefix is `/api/v3/`, let's not return XML...

403s and 500s should be unaffected as they should only happen inside DRF-handled code, so they already go through our custom DRF exception handler instead of hitting the default django handlers.

Fix #4576