### PR TITLE
Update 'My Addons' layout to be responsive with long names and other locales.

### DIFF
--- a/src/olympia/devhub/templates/devhub/new-landing/components/my-addons.html
+++ b/src/olympia/devhub/templates/devhub/new-landing/components/my-addons.html
@@ -56,10 +56,13 @@
           <div class="DevHub-MyAddons-item">
             <img class="DevHub-MyAddons-item-icon" src="{{ addon.get_icon_url(64) }}" alt="">
             <div class="DevHub-MyAddons-item-details">
-              <div class="DevHub-MyAddons-item-name">
-                <span>{{ addon.name }}</span>
-                <a href="{{ addon.get_dev_url('edit') }}">{{ _('Edit Listing') }}</a>
-              </div>
+              <span class="DevHub-MyAddons-item-name">
+                {{ addon.name }}
+              </span>
+
+              <a class="DevHub-MyAddons-item-edit" href="{{ addon.get_dev_url('edit') }}">
+                {{ _('Edit Listing') }}
+              </a>
 
               <div class="DevHub-MyAddons-item-versions">
                 {% if addon.has_listed_versions() %}

--- a/static/css/devhub/new-landing/sections/my-addons.less
+++ b/static/css/devhub/new-landing/sections/my-addons.less
@@ -30,6 +30,8 @@
 
 .DevHub-MyAddons-item-details {
   margin-left: 25px;
+  display: flex;
+  flex-flow: column;
 
   a {
     .link(@color-button-default);
@@ -38,7 +40,6 @@
   a,
   .DevHub-MyAddons-VersionStatus {
     font-size: 15px;
-    margin: 0 5px;
 
     &.DevHub-MyAddons-version-status-incomplete,
     &.DevHub-MyAddons-version-status-deleted,
@@ -60,16 +61,15 @@
       color: @color-version-state-admin-disabled;
     }
   }
+
+  .DevHub-MyAddons-VersionStatus {
+    margin: 0 5px;
+  }
 }
 
 .DevHub-MyAddons-item-name {
-  display: flex;
-  align-items: baseline;
-
-  span {
-    font-size: 24px;
-    font-weight: 400;
-  }
+  font-size: 24px;
+  font-weight: 400;
 }
 
 .DevHub-MyAddons-item-channel-listed,
@@ -111,7 +111,7 @@
 }
 
 .DevHub-MyAddons-item-version {
-  margin: 0 5px;
+  margin: 0 0 5px;
 }
 
 .DevHub-MyAddons-item-buttons {


### PR DESCRIPTION
* The add-on name should be given its own line, so when it becomes too long, it just continues down the next line uninterrupted
* The “Edit Listing” link should also have its own line, directly below the add-on name (no longer appearing inline and to the side of the add-on name)
* The “Last Updated” field is always aligned right and to the bottom, so it lines up with add-on version and status.

Fixes mozilla/addons-frontend#1800

![screenshot from 2017-02-14 11-28-38](https://cloud.githubusercontent.com/assets/139033/22925431/0cf2d182-f2a9-11e6-963b-b9f76df089f7.png)
![screenshot from 2017-02-14 11-28-07](https://cloud.githubusercontent.com/assets/139033/22925432/0cf5a826-f2a9-11e6-9195-01b36a07e080.png)
![screenshot from 2017-02-14 11-27-46](https://cloud.githubusercontent.com/assets/139033/22925433/0d00cecc-f2a9-11e6-94d8-b8e2024df05c.png)
