### PR TITLE
Don't serve updates to disabled add-ons

### DIFF
--- a/services/update.py
+++ b/services/update.py
@@ -109,10 +109,13 @@ class Update(object):
         sql = """SELECT id, status, addontype_id, guid FROM addons
                  WHERE guid = %(guid)s AND
                        inactive = 0 AND
-                       status != %(STATUS_DELETED)s
+                       status NOT IN (%(STATUS_DELETED)s, %(STATUS_DISABLED)s)
                  LIMIT 1;"""
-        self.cursor.execute(sql, {'guid': self.data['id'],
-                                  'STATUS_DELETED': base.STATUS_DELETED})
+        self.cursor.execute(sql, {
+            'guid': self.data['id'],
+            'STATUS_DELETED': base.STATUS_DELETED,
+            'STATUS_DISABLED': base.STATUS_DISABLED,
+        })
         result = self.cursor.fetchone()
         if result is None:
             return False
@@ -135,7 +138,6 @@ class Update(object):
 
         data['STATUS_PUBLIC'] = base.STATUS_PUBLIC
         data['STATUS_BETA'] = base.STATUS_BETA
-        data['STATUS_DISABLED'] = base.STATUS_DISABLED
         data['RELEASE_CHANNEL_LISTED'] = base.RELEASE_CHANNEL_LISTED
 
         sql = ["""
@@ -355,7 +357,6 @@ def application(environ, start_response):
             output = force_bytes(update.get_rdf())
             start_response(status, update.get_headers(len(output)))
         except:
-            #mail_exception(data)
             log_exception(data)
             raise
     return [output]

--- a/services/utils.py
+++ b/services/utils.py
@@ -28,7 +28,6 @@ from olympia.lib.log_settings_base import formatters, handlers
 # remove all this.
 from olympia.constants.applications import APPS_ALL
 from olympia.constants.platforms import PLATFORMS
-from olympia.constants.base import STATUS_DISABLED
 
 
 # This is not DRY: it's a copy of amo.helpers.user_media_path, to avoid an

--- a/src/olympia/addons/tests/test_update.py
+++ b/src/olympia/addons/tests/test_update.py
@@ -84,6 +84,13 @@ class TestDataValidate(VersionCheckMixin, TestCase):
         up = self.get(self.good_data)
         assert not up.is_valid()
 
+    def test_disabled(self):
+        addon = Addon.objects.get(pk=3615)
+        addon.update(status=amo.STATUS_DISABLED)
+
+        up = self.get(self.good_data)
+        assert not up.is_valid()
+
     def test_no_version(self):
         data = self.good_data.copy()
         del data['version']


### PR DESCRIPTION
This matters only for edge cases where the files are somehow not disabled.

Fix #3228