### PR TITLE
Support amo frontend auth more closely to production

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -113,9 +113,18 @@ FXA_CONFIG = {
         'redirect_url': 'http://localhost:3000/fxa-authenticate',
         'scope': 'profile',
     },
+    'local': {
+        'client_id': '1778aef72d1adfb3',
+        'client_secret':
+            '3feebe3c009c1a0acdedd009f3530eae2b88859f430fa8bb951ea41f2f859b18',
+        'content_host': 'https://stable.dev.lcip.org',
+        'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
+        'profile_host': 'https://stable.dev.lcip.org/profile/v1',
+        'redirect_url': 'http://localhost:3000/api/v3/accounts/authenticate/',
+        'scope': 'profile',
+    },
 }
 FXA_CONFIG['amo'] = FXA_CONFIG['internal']
-FXA_CONFIG['local'] = FXA_CONFIG['internal']
 ALLOWED_FXA_CONFIGS = ['default', 'amo', 'local']
 
 # CSP report endpoint which returns a 204 from addons-nginx in local dev.

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -508,7 +508,7 @@ class TestWithUser(TestCase):
             format='json')
 
     def test_dynamic_configuration(self):
-        fxa_config = { 'some': 'config' }
+        fxa_config = {'some': 'config'}
 
         class LoginView(object):
             def get_fxa_config(self, request):

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -507,6 +507,24 @@ class TestWithUser(TestCase):
             self.request, views.ERROR_STATE_MISMATCH, next_path='/next',
             format='json')
 
+    def test_dynamic_configuration(self):
+        fxa_config = { 'some': 'config' }
+
+        class LoginView(object):
+            def get_fxa_config(self, request):
+                return fxa_config
+
+            @views.with_user(format='json')
+            def post(*args, **kwargs):
+                return args, kwargs
+
+        identity = {'uid': '1234', 'email': 'hey@yo.it'}
+        self.fxa_identify.return_value = identity
+        self.find_user.return_value = self.user
+        self.request.data = {'code': 'foo', 'state': 'some-blob'}
+        LoginView().post(self.request)
+        self.fxa_identify.assert_called_with('foo', config=fxa_config)
+
 
 class TestRegisterUser(TestCase):
 

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -162,8 +162,11 @@ def with_user(format, config=None):
         @write
         def inner(self, request):
             if config is None:
-                fxa_config = (
-                    settings.FXA_CONFIG[settings.DEFAULT_FXA_CONFIG_NAME])
+                if hasattr(self, 'get_fxa_config'):
+                    fxa_config = self.get_fxa_config(request)
+                else:
+                    fxa_config = (
+                        settings.FXA_CONFIG[settings.DEFAULT_FXA_CONFIG_NAME])
             else:
                 fxa_config = config
 
@@ -267,20 +270,16 @@ class LoginStartView(LoginStartBaseView):
 
 class LoginBaseView(FxAConfigMixin, APIView):
 
-    def post(self, request):
-        config = self.get_fxa_config(request)
-
-        @with_user(format='json', config=config)
-        def _post(self, request, user, identity, next_path):
-            if user is None:
-                return Response({'error': ERROR_NO_USER}, status=422)
-            else:
-                update_user(user, identity)
-                response = Response({'email': identity['email']})
-                add_api_token_to_response(response, user, set_cookie=False)
-                log.info('Logging in user {} from FxA'.format(user))
-                return response
-        return _post(self, request)
+    @with_user(format='json')
+    def post(self, request, user, identity, next_path):
+        if user is None:
+            return Response({'error': ERROR_NO_USER}, status=422)
+        else:
+            update_user(user, identity)
+            response = Response({'email': identity['email']})
+            add_api_token_to_response(response, user, set_cookie=False)
+            log.info('Logging in user {} from FxA'.format(user))
+            return response
 
     def options(self, request):
         return Response()
@@ -306,7 +305,10 @@ class RegisterView(APIView):
             return response
 
 
-class AuthenticateView(APIView):
+class AuthenticateView(FxAConfigMixin, APIView):
+    DEFAULT_FXA_CONFIG_NAME = settings.DEFAULT_FXA_CONFIG_NAME
+    ALLOWED_FXA_CONFIGS = settings.ALLOWED_FXA_CONFIGS
+
     authentication_classes = (SessionAuthentication,)
 
     @with_user(format='html')


### PR DESCRIPTION
This adds a new FxA config for `local` in development and adds support for specifying an FxA config to the authenticate view. This allows addons-frontend to use the redirect login flow in development.

The addons-admin will now be the only app using the POST to `/api/v3/accounts/login/` flow so if that gets updated we can remove the login and register views.

Supports mozilla/addons-frontend#1766.