### PR TITLE
Allow log_and_notify to be called without a comment; return empty string in the API

### DIFF
--- a/src/olympia/activity/serializers.py
+++ b/src/olympia/activity/serializers.py
@@ -24,11 +24,7 @@ class ActivityLogSerializer(serializers.ModelSerializer):
         self.to_highlight = kwargs.get('context', []).get('to_highlight', [])
 
     def get_comments(self, obj):
-        # We have to do .unescape on the output of obj.to_string because the
-        # 'string' it returns is supposed to be used in markup and doesn't get
-        # serialized correctly unless we unescape it.
-        comments = (obj.details['comments'] if obj.details
-                    else obj.to_string().unescape())
+        comments = obj.details['comments'] if obj.details else ''
         return getattr(obj.log(), 'sanitize', comments)
 
     def get_action_label(self, obj):

--- a/src/olympia/activity/tests/test_serializers.py
+++ b/src/olympia/activity/tests/test_serializers.py
@@ -79,5 +79,5 @@ class TestReviewNotesSerializerOutput(TestCase, LogMixin):
             self.addon.find_latest_version(channel=amo.RELEASE_CHANNEL_LISTED),
             user=self.user)
         result = self.serialize()
-        # Should default to the string representation of the log event.
-        assert result['comments'] == self.entry.to_string()
+        # Should output an empty string.
+        assert result['comments'] == ''

--- a/src/olympia/activity/tests/test_utils.py
+++ b/src/olympia/activity/tests/test_utils.py
@@ -279,8 +279,9 @@ class TestLogAndNotify(TestCase):
         # One from the reviewer.
         self._create(amo.LOG.REJECT_VERSION, self.reviewer)
         action = amo.LOG.APPROVAL_NOTES_CHANGED
-        comments = None
-        log_and_notify(action, comments, self.developer, self.version)
+        log_and_notify(
+            action=action, comments=None, note_creator=self.developer,
+            version=self.version)
 
         logs = ActivityLog.objects.filter(action=action.id)
         assert len(logs) == 1

--- a/src/olympia/activity/utils.py
+++ b/src/olympia/activity/utils.py
@@ -13,7 +13,7 @@ from olympia.access import acl
 from olympia.activity.models import ActivityLogToken
 from olympia.amo.helpers import absolutify
 from olympia.amo.urlresolvers import reverse
-from olympia.amo.utils import send_mail
+from olympia.amo.utils import no_translation, send_mail
 from olympia.devhub.models import ActivityLog
 from olympia.users.models import UserProfile
 from olympia.users.utils import get_task_user
@@ -156,9 +156,17 @@ def log_and_notify(action, comments, note_creator, version):
     log_kwargs = {
         'user': note_creator,
         'created': datetime.datetime.now(),
-        'details': {
+    }
+    if comments:
+        log_kwargs['details'] = {
             'comments': comments,
-            'version': version.version}}
+            'version': version.version}
+    else:
+        # Just use the name of the action if no comments provided.  Alas we
+        # can't know the locale of recipient, and our templates are English
+        # only so prevent language jumble by forcing into en-US.
+        with no_translation():
+            comments = '%s' % action.short
     note = amo.log(action, version.addon, version, **log_kwargs)
 
     # Collect reviewers involved with this version.

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -1155,7 +1155,7 @@ def version_edit(request, addon_id, addon, version_id):
                 version.update(has_info_request=False)
                 if waffle.switch_is_active('activity-email'):
                     log_and_notify(amo.LOG.APPROVAL_NOTES_CHANGED,
-                                   u'Approval notes were updated.',
+                                   None,
                                    request.user,
                                    version)
                 else:
@@ -1172,27 +1172,15 @@ def version_edit(request, addon_id, addon, version_id):
                 version.update(has_info_request=False)
                 if waffle.switch_is_active('activity-email'):
                     log_and_notify(amo.LOG.SOURCE_CODE_UPLOADED,
-                                   u'Source code was uploaded.',
+                                   None,
                                    request.user,
                                    version)
                 else:
                     amo.log(amo.LOG.SOURCE_CODE_UPLOADED,
-                            version,
-                            request.user,
-                            details={
-                                'comments': (u'This version has been '
-                                             u'automatically flagged for '
-                                             u'admin review, as source files '
-                                             u'have been uploaded.')})
+                            addon, version, request.user)
             else:
                 amo.log(amo.LOG.SOURCE_CODE_UPLOADED,
-                        version,
-                        request.user,
-                        details={
-                            'comments': (u'This version has been '
-                                         u'automatically flagged for '
-                                         u'admin review, as source files '
-                                         u'have been uploaded.')})
+                        addon, version, request.user)
 
         messages.success(request, _('Changes successfully saved.'))
         return redirect('devhub.versions.edit', addon.slug, version_id)


### PR DESCRIPTION
better way of fixing #4521 with less drama than #4598