### PR TITLE
Refactor reviews API to change the URL to /api/v3/reviews/review/...

### DIFF
--- a/docs/topics/api/reviews.rst
+++ b/docs/topics/api/reviews.rst
@@ -8,17 +8,21 @@ Reviews
     may change without warning. The only authentication method available at
     the moment is :ref:`the internal one<api-auth-internal>`.
 
--------------------
-List Add-on reviews
--------------------
+------------
+List reviews
+------------
 
-.. review-list-addon:
+.. review-list:
 
-This endpoint allows you to fetch reviews for a given add-on.
+This endpoint allows you to fetch reviews for a given add-on or user. Either
+``addon`` or ``user`` query parameters are required, and they can be
+combined together.
 
-.. http:get:: /api/v3/addons/addon/(int:id|string:slug|string:guid)/reviews/
+.. http:get:: /api/v3/reviews/review/(int:id|string:slug|string:guid)/reviews/
 
+    :query string addon: The add-on id to fetch reviews from. When passed, the reviews shown will always be the latest posted by each user on this particular add-on (which means there should only be one review per user in the results).
     :query string filter: The :ref:`filter <review-filtering-param>` to apply.
+    :query string user: The user id to fetch reviews from.
     :query int show_grouped_ratings: Whether or not to show ratings aggregates for this add-on in the response.
     :>json int count: The number of results for this query.
     :>json string next: The URL of the next page of results.
@@ -32,23 +36,6 @@ This endpoint allows you to fetch reviews for a given add-on.
    can change that with the ``filter=with_deleted`` query parameter, which
    requires the Addons:Edit permission.
 
-----------------------
-List reviews by a user
-----------------------
-
-.. review-list-user:
-
-This endpoint allows you to fetch reviews posted by a specific user.
-
-.. http:get:: /api/v3/accounts/account/(int:id)/reviews/
-
-    :query string filter: The :ref:`filter <review-filtering-param>` to apply.
-    :param int id: The user id.
-    :>json int count: The number of results for this query.
-    :>json string next: The URL of the next page of results.
-    :>json string previous: The URL of the previous page of results.
-    :>json array results: An array of :ref:`reviews <review-detail-object>`.
-
 ------
 Detail
 ------
@@ -57,7 +44,7 @@ Detail
 
 This endpoint allows you to fetch a review by its id.
 
-.. http:get:: /api/v3/addons/addon/(int:id|string:slug|string:guid)/reviews/(int:id)/
+.. http:get:: /api/v3/reviews/review/(int:id)/
 
     .. _review-detail-object:
 
@@ -89,12 +76,13 @@ If successful a :ref:`review object <review-detail-object>` is returned.
      Requires authentication.
 
 
-.. http:post:: /api/v3/addons/addon/(int:id|string:slug|string:guid)/reviews/
+.. http:post:: /api/v3/reviews/review/
 
+    :<json string addon: The add-on id the review applies to (required).
     :<json string|null body: The text of the review.
     :<json string|null title: The title of the review.
     :<json int rating: The rating the user wants to give as part of the review (required).
-    :<json int version: The add-on version id the review applies to.
+    :<json int version: The add-on version id the review applies to (required).
 
 ----
 Edit
@@ -111,7 +99,7 @@ If successful a :ref:`review object <review-detail-object>` is returned.
 
      Only body, title and rating are allowed for modification.
 
-.. http:patch:: /api/v3/addons/addon/(int:id|string:slug|string:guid)/reviews/(int:id)/
+.. http:patch:: /api/v3/reviews/review/(int:id)/
 
     :<json string|null body: The text of the review.
     :<json string|null title: The title of the review.
@@ -132,7 +120,7 @@ This endpoint allows you to delete an existing review by its id.
      not delete a review from somebody else if it was posted on an add-on they
      are listed as a developer of.
 
-.. http:delete:: /api/v3/addons/addon/(int:id|string:slug|string:guid)/reviews/(int:id)/
+.. http:delete:: /api/v3/reviews/review/(int:id)/
 
 
 -----
@@ -148,7 +136,7 @@ If successful a :ref:`review reply object <review-detail-object>` is returned.
      Requires authentication and either Addons:Edit permission or a user account
      listed as a developer of the add-on.
 
-.. http:post:: /api/v3/addons/addon/(int:id|string:slug|string:guid)/reviews/(int:id)/reply/
+.. http:post:: /api/v3/reviews/review/(int:id)/reply/
 
     :<json string body: The text of the reply (required).
     :<json string|null title: The title of the reply.
@@ -169,7 +157,7 @@ An empty response will be returned on success.
      Requires authentication and a user account different from the one that
      posted the review.
 
-.. http:post:: /api/v3/addons/addon/(int:id|string:slug|string:guid)/reviews/(int:id)/flag/
+.. http:post:: /api/v3/reviews/review/(int:id)/flag/
 
     :<json string flag: A :ref:`constant<review-flag-constants>` describing the reason behind the flagging.
     :<json string|null note: A note to explain further the reason behind the flagging.

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -995,16 +995,6 @@ class TestParseNextPath(TestCase):
             u'/en-US/firefox/addon/dęlîcíøùs-päñčåkę/?src=hp-dl-featured')
 
 
-class TestAccountViewSetGet(TestCase):
-    def test_basic(self):
-        self.user = user_factory()
-        self.url = reverse(
-            'account-detail', kwargs={'pk': self.user.pk})
-
-        with self.assertRaises(NotImplementedError):
-            self.client.get(self.url)
-
-
 class TestSessionView(TestCase):
     def login_user(self, user):
         identity = {

--- a/src/olympia/accounts/urls.py
+++ b/src/olympia/accounts/urls.py
@@ -1,23 +1,9 @@
-from django.conf.urls import include, url
+from django.conf.urls import url
 
-from rest_framework.routers import SimpleRouter
-from rest_framework_nested.routers import NestedSimpleRouter
-
-from olympia.reviews.views import ReviewViewSet
 from . import views
 
 
-accounts = SimpleRouter()
-accounts.register(r'account', views.AccountViewSet, base_name='account')
-
-# Router for children of /accounts/account/{account_pk}/.
-sub_accounts = NestedSimpleRouter(accounts, r'account', lookup='account')
-sub_accounts.register('reviews', ReviewViewSet, base_name='account-review')
-
-
 urlpatterns = [
-    url(r'', include(accounts.urls)),
-    url(r'', include(sub_accounts.urls)),
     url(r'^authenticate/$', views.AuthenticateView.as_view(),
         name='accounts.authenticate'),
     url(r'^login/$', views.LoginView.as_view(), name='accounts.login'),

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -15,11 +15,9 @@ from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import generics
 from rest_framework.authentication import SessionAuthentication
-from rest_framework.mixins import RetrieveModelMixin
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework.viewsets import GenericViewSet
 from rest_framework_jwt.settings import api_settings as jwt_api_settings
 from waffle.decorators import waffle_switch
 
@@ -342,16 +340,6 @@ class ProfileView(generics.RetrieveAPIView):
 
     def retrieve(self, request, *args, **kw):
         return Response(self.get_serializer(request.user).data)
-
-
-class AccountViewSet(RetrieveModelMixin, GenericViewSet):
-    queryset = UserProfile.objects.all()
-
-    def retrieve(self, request, *args, **kwargs):
-        # See https://github.com/mozilla/addons-server/issues/3138 ; be careful
-        # when implementing it, we don't want to list users, only retrieve them
-        # and eventually modify them through this ViewSet.
-        raise NotImplementedError
 
 
 class AccountSuperCreate(APIView):

--- a/src/olympia/addons/api_urls.py
+++ b/src/olympia/addons/api_urls.py
@@ -1,10 +1,9 @@
-from django.conf.urls import include, patterns, url
+from django.conf.urls import include, url
 
 from rest_framework.routers import SimpleRouter
 from rest_framework_nested.routers import NestedSimpleRouter
 
 from olympia.activity.views import VersionReviewNotesViewSet
-from olympia.reviews.views import ReviewViewSet
 
 from .views import (
     AddonFeaturedView, AddonSearchView, AddonVersionViewSet, AddonViewSet,
@@ -17,17 +16,15 @@ addons.register(r'addon', AddonViewSet)
 # Router for children of /addons/addon/{addon_pk}/.
 sub_addons = NestedSimpleRouter(addons, r'addon', lookup='addon')
 sub_addons.register('versions', AddonVersionViewSet, base_name='addon-version')
-sub_addons.register('reviews', ReviewViewSet, base_name='addon-review')
 sub_versions = NestedSimpleRouter(sub_addons, r'versions', lookup='version')
 sub_versions.register(r'reviewnotes', VersionReviewNotesViewSet,
                       base_name='version-reviewnotes')
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'', include(addons.urls)),
     url(r'', include(sub_addons.urls)),
     url(r'', include(sub_versions.urls)),
     url(r'^search/$', AddonSearchView.as_view(), name='addon-search'),
     url(r'^featured/$', AddonFeaturedView.as_view(), name='addon-featured'),
     url(r'^categories/$', StaticCategoryView.as_view(), name='category-list'),
-)
+]

--- a/src/olympia/addons/urls.py
+++ b/src/olympia/addons/urls.py
@@ -3,7 +3,6 @@ from django.views.decorators.csrf import csrf_exempt
 from django.shortcuts import redirect
 from django.views.decorators.cache import cache_page
 
-from olympia.reviews.urls import review_patterns
 from olympia.stats.urls import stats_patterns
 from . import buttons
 from . import views
@@ -12,8 +11,7 @@ ADDON_ID = r"""(?P<addon_id>[^/<>"']+)"""
 
 
 # These will all start with /addon/<addon_id>/
-detail_patterns = patterns(
-    '',
+detail_patterns = [
     url('^$', views.addon_detail, name='addons.detail'),
     url('^more$', views.addon_detail, name='addons.detail_more'),
     url('^eula/(?P<file_id>\d+)?$', views.eula, name='addons.eula'),
@@ -39,10 +37,10 @@ detail_patterns = patterns(
                                      addon_id, permanent=True),
         name='addons.about'),
 
-    ('^reviews/', include(review_patterns('addons'))),
-    ('^statistics/', include(stats_patterns)),
-    ('^versions/', include('olympia.versions.urls')),
-)
+    url('^reviews/', include('olympia.reviews.urls')),
+    url('^statistics/', include(stats_patterns)),
+    url('^versions/', include('olympia.versions.urls')),
+]
 
 
 urlpatterns = patterns(

--- a/src/olympia/api/urls.py
+++ b/src/olympia/api/urls.py
@@ -14,6 +14,7 @@ urlpatterns = patterns(
     url(r'^v3/addons/', include('olympia.addons.api_urls')),
     url(r'^v3/', include('olympia.discovery.api_urls')),
     url(r'^v3/internal/', include('olympia.internal_tools.urls')),
+    url(r'^v3/reviews/', include('olympia.reviews.api_urls')),
     url(r'^v3/', include('olympia.signing.urls')),
     url(r'^v3/statistics/', include('olympia.stats.api_urls')),
     url(r'^v3/activity/', include('olympia.activity.urls')),

--- a/src/olympia/reviews/api_urls.py
+++ b/src/olympia/reviews/api_urls.py
@@ -1,0 +1,13 @@
+from django.conf.urls import include, url
+
+from rest_framework.routers import SimpleRouter
+
+from olympia.reviews.views import ReviewViewSet
+
+
+reviews = SimpleRouter()
+reviews.register(r'review', ReviewViewSet)
+
+urlpatterns = [
+    url(r'', include(reviews.urls))
+]

--- a/src/olympia/reviews/serializers.py
+++ b/src/olympia/reviews/serializers.py
@@ -52,7 +52,7 @@ class BaseReviewSerializer(serializers.ModelSerializer):
         # modified afterwards:
         if not self.partial:
             # Because we want to avoid extra queries, addon is a
-            # serializerMethodField, which means it needs to be validated
+            # SerializerMethodField, which means it needs to be validated
             # manually. Fortunately the view does most of the work for us.
             data['addon'] = self.context['view'].get_addon_object()
             if data['addon'] is None:

--- a/src/olympia/reviews/serializers.py
+++ b/src/olympia/reviews/serializers.py
@@ -48,10 +48,16 @@ class BaseReviewSerializer(serializers.ModelSerializer):
 
         data['user_responsible'] = request.user
 
+        # There are a few fields that need to be set at creation time and never
+        # modified afterwards:
         if not self.partial:
-            # Get the add-on pk from the URL, no need to pass it as POST data
-            # since the URL is always going to have it.
+            # Because we want to avoid extra queries, addon is a
+            # serializerMethodField, which means it needs to be validated
+            # manually. Fortunately the view does most of the work for us.
             data['addon'] = self.context['view'].get_addon_object()
+            if data['addon'] is None:
+                raise serializers.ValidationError(
+                    {'addon': _('This field is required.')})
 
             # Get the user from the request, don't allow clients to pick one
             # themselves.
@@ -59,6 +65,12 @@ class BaseReviewSerializer(serializers.ModelSerializer):
 
             # Also include the user ip adress.
             data['ip_address'] = request.META.get('REMOTE_ADDR', '')
+        else:
+            # When editing, you can't change the add-on.
+            if self.context['request'].data.get('addon'):
+                raise serializers.ValidationError(
+                    {'addon': _(u"You can't change the add-on of a review once"
+                                u" it has been created.")})
 
         # Clean up body and automatically flag the review if an URL was in it.
         body = data.get('body', '')
@@ -121,7 +133,6 @@ class ReviewVersionSerializer(SimpleVersionSerializer):
 class ReviewSerializer(BaseReviewSerializer):
     reply = ReviewSerializerReply(read_only=True)
     rating = serializers.IntegerField(min_value=1, max_value=5)
-
     version = ReviewVersionSerializer()
 
     class Meta:
@@ -136,6 +147,10 @@ class ReviewSerializer(BaseReviewSerializer):
                   u"the review has been created."))
 
         addon = self.context['view'].get_addon_object()
+        if not addon:
+            # BaseReviewSerializer.validate() should complain about that, not
+            # this method.
+            return None
         if version.addon_id != addon.pk or not version.is_public():
             raise serializers.ValidationError(
                 _(u"This version of the add-on doesn't exist or isn't "

--- a/src/olympia/reviews/urls.py
+++ b/src/olympia/reviews/urls.py
@@ -1,32 +1,28 @@
-from django.conf.urls import include, patterns, url
+from django.conf.urls import include, url
 
 from olympia.reviews.feeds import ReviewsRss
 
 from . import views
 
 
-def review_detail_patterns(prefix):
-    # These all start with /addon/:id/reviews/:review_id/.
-    return patterns(
-        '',
-        url('^$', views.review_list, name='%s.reviews.detail' % prefix),
-        url('^reply$', views.reply, name='%s.reviews.reply' % prefix),
-        url('^flag$', views.flag, name='%s.reviews.flag' % prefix),
-        url('^delete$', views.delete, name='%s.reviews.delete' % prefix),
-        url('^edit$', views.edit, name='%s.reviews.edit' % prefix),
-        url('^translate/(?P<language>[a-z]{2,3}(-[A-Z]{2})?)$',
-            views.translate,
-            name='%s.reviews.translate' % prefix),
-    )
+# These all start with /addon/:id/reviews/:review_id/.
+review_detail_patterns = [
+    url('^$', views.review_list, name='addons.reviews.detail'),
+    url('^reply$', views.reply, name='addons.reviews.reply'),
+    url('^flag$', views.flag, name='addons.reviews.flag'),
+    url('^delete$', views.delete, name='addons.reviews.delete'),
+    url('^edit$', views.edit, name='addons.reviews.edit'),
+    url('^translate/(?P<language>[a-z]{2,3}(-[A-Z]{2})?)$',
+        views.translate,
+        name='addons.reviews.translate'),
+]
 
 
-def review_patterns(prefix):
-    return patterns(
-        '',
-        url('^$', views.review_list, name='%s.reviews.list' % prefix),
-        url('^add$', views.add, name='%s.reviews.add' % prefix),
-        url('^(?P<review_id>\d+)/', include(review_detail_patterns(prefix))),
-        url('^format:rss$', ReviewsRss(), name='%s.reviews.list.rss' % prefix),
-        url('^user:(?P<user_id>\d+)$', views.review_list,
-            name='%s.reviews.user' % prefix),
-    )
+urlpatterns = [
+    url('^$', views.review_list, name='addons.reviews.list'),
+    url('^add$', views.add, name='addons.reviews.add'),
+    url('^(?P<review_id>\d+)/', include(review_detail_patterns)),
+    url('^format:rss$', ReviewsRss(), name='addons.reviews.list.rss'),
+    url('^user:(?P<user_id>\d+)$', views.review_list,
+        name='addons.reviews.user'),
+]

--- a/src/olympia/reviews/views.py
+++ b/src/olympia/reviews/views.py
@@ -327,9 +327,33 @@ class ReviewViewSet(AddonChildMixin, ModelViewSet):
 
     queryset = Review.objects.all()
 
+    def set_addon_object_from_review(self, review):
+        """Set addon object on the instance from a review object."""
+        self.kwargs['addon_pk'] = str(review.addon.pk)
+        del self.addon_object  # Force get_addon_object() to try again.
+        return self.get_addon_object()
+
     def get_addon_object(self):
+        """Return addon object associated with the request, or None if not
+        relevant.
+
+        Will also fire permission checks on the addon object when it's loaded.
+        """
+        if hasattr(self, 'addon_object'):
+            return self.addon_object
+
         if 'addon_pk' not in self.kwargs:
-            return None
+            self.kwargs['addon_pk'] = (
+                self.request.data.get('addon') or
+                self.request.GET.get('addon'))
+        if self.kwargs['addon_pk'] is None:
+            # If we don't have an addon object, set it as None on the instance
+            # and return immediately, that's fine.
+            self.addon_object = None
+            return
+        else:
+            # AddonViewSet.get_lookup_field() expects a string.
+            self.kwargs['addon_pk'] = str(self.kwargs['addon_pk'])
         # When loading the add-on, pass a specific permission class - the
         # default from AddonViewSet is too restrictive, we are not modifying
         # the add-on itself so we don't need all the permission checks it does.
@@ -337,12 +361,12 @@ class ReviewViewSet(AddonChildMixin, ModelViewSet):
             permission_classes=[AllowIfPublic])
 
     def check_permissions(self, request):
-        if 'addon_pk' in self.kwargs:
-            # In addition to the regular permission checks that are made, we
-            # need to verify that the add-on exists, is public and listed. Just
-            # loading the addon should be enough to do that, since
-            # AddonChildMixin implementation calls AddonViewSet.get_object().
-            self.get_addon_object()
+        """Perform permission checks.
+
+        The regular DRF permissions checks are made, but also, before that, if
+        an addon was requested, verify that it exists, is public and listed,
+        through AllowIfPublic permission, that get_addon_object() uses."""
+        self.get_addon_object()
 
         # Proceed with the regular permission checks.
         return super(ReviewViewSet, self).check_permissions(request)
@@ -357,20 +381,21 @@ class ReviewViewSet(AddonChildMixin, ModelViewSet):
 
     def filter_queryset(self, qs):
         if self.action == 'list':
-            if 'addon_pk' in self.kwargs:
+            if 'addon' in self.request.GET:
                 qs = qs.filter(is_latest=True, addon=self.get_addon_object())
-            elif 'account_pk' in self.kwargs:
-                qs = qs.filter(user=self.kwargs.get('account_pk'))
-            else:
+            if 'user' in self.request.GET:
+                qs = qs.filter(user=self.request.GET.get('user'))
+            if ('addon' not in self.request.GET and
+                    'user' not in self.request.GET):
                 # Don't allow listing reviews without filtering by add-on or
                 # user.
-                raise ParseError('Need an addon or user identifier')
+                raise ParseError('Need an addon or user parameter')
         return qs
 
     def get_paginated_response(self, data):
         response = super(ReviewViewSet, self).get_paginated_response(data)
         show_grouped_ratings = self.request.GET.get('show_grouped_ratings')
-        if 'addon_pk' in self.kwargs and show_grouped_ratings:
+        if show_grouped_ratings and self.get_addon_object():
             response.data['grouped_ratings'] = dict(GroupedRating.get(
                 self.addon_object.id))
         return response
@@ -387,7 +412,7 @@ class ReviewViewSet(AddonChildMixin, ModelViewSet):
                 acl.action_allowed(self.request, 'Addons', 'Edit'))
 
         should_access_only_top_level_reviews = (
-            self.action == 'list' and self.kwargs.get('addon_pk'))
+            self.action == 'list' and self.get_addon_object())
 
         if self.should_access_deleted_reviews:
             # For admins or add-on authors replying. When listing, we include
@@ -423,6 +448,7 @@ class ReviewViewSet(AddonChildMixin, ModelViewSet):
         # FK to the current review object and only allow add-on authors/admins.
         # Call get_object() to trigger 404 if it does not exist.
         self.review_object = self.get_object()
+        self.set_addon_object_from_review(self.review_object)
         if Review.unfiltered.filter(reply_to=self.review_object).exists():
             # A reply already exists, just edit it.
             # We set should_access_deleted_reviews so that it works even if
@@ -434,14 +460,18 @@ class ReviewViewSet(AddonChildMixin, ModelViewSet):
 
     @detail_route(methods=['post'])
     def flag(self, request, *args, **kwargs):
+        # We load the add-on object from the review to trigger permission
+        # checks.
+        self.review_object = self.get_object()
+        self.set_addon_object_from_review(self.review_object)
+
         # Re-use flag view since it's already returning json. We just need to
         # pass it the addon slug (passing it the PK would result in a redirect)
         # and make sure request.POST is set with whatever data was sent to the
         # DRF view.
-        addon = self.get_addon_object()
         request._request.POST = request.data
         request = request._request
-        response = flag(request, addon.slug, kwargs.get('pk'))
+        response = flag(request, self.addon_object.slug, kwargs.get('pk'))
         if response.status_code == 200:
             response.content = ''
             response.status_code = 202

--- a/src/olympia/reviews/views.py
+++ b/src/olympia/reviews/views.py
@@ -329,8 +329,13 @@ class ReviewViewSet(AddonChildMixin, ModelViewSet):
 
     def set_addon_object_from_review(self, review):
         """Set addon object on the instance from a review object."""
+        # At this point it's likely we didn't have an addon in the request, so
+        # if we went through get_addon_object() before it's going to be set
+        # to None already. We delete the addon_object property cache and set
+        # addon_pk in kwargs to force get_addon_object() to reset
+        # self.addon_object.
+        del self.addon_object
         self.kwargs['addon_pk'] = str(review.addon.pk)
-        del self.addon_object  # Force get_addon_object() to try again.
         return self.get_addon_object()
 
     def get_addon_object(self):


### PR DESCRIPTION
 As a result of this, the addon (or user when listing) must now be passed in GET/POST data. This in turn allows the client to filter on both parameters at the same time.

Also refactor reviews urlpatterns to stop having useless functions, since it's only used once.

Fix #3986