### PR TITLE
Don't allow page numbers too large when paginating ES results for the API

### DIFF
--- a/src/olympia/api/paginator.py
+++ b/src/olympia/api/paginator.py
@@ -10,6 +10,13 @@ class ESPaginator(Paginator):
     results contain the total number of results, we can take an optimistic
     slice and then adjust the count.
     """
+
+    # Maximum result position. Should match 'index.max_result_window' ES
+    # setting if present. ES defaults to 10000 but we'd like more to make sure
+    # all our extensions can be found if searching without a query and
+    # paginating through all results.
+    max_result_window = 25000
+
     def validate_number(self, number):
         """
         Validates the given 1-based page number.
@@ -21,8 +28,6 @@ class ESPaginator(Paginator):
             raise PageNotAnInteger('That page number is not an integer')
         if number < 1:
             raise EmptyPage('That page number is less than 1')
-        elif number > 100000:
-            raise InvalidPage('That page number is too high')
         return number
 
     def page(self, number):
@@ -34,6 +39,10 @@ class ESPaginator(Paginator):
         number = self.validate_number(number)
         bottom = (number - 1) * self.per_page
         top = bottom + self.per_page
+
+        if bottom > self.max_result_window:
+            raise InvalidPage(
+                'That page number is too high for the current page size')
 
         # Force the search to evaluate and then attach the count. We want to
         # avoid an extra useless query even if there are no results, so we

--- a/src/olympia/api/paginator.py
+++ b/src/olympia/api/paginator.py
@@ -1,6 +1,6 @@
 from rest_framework.pagination import PageNumberPagination
 from django.core.paginator import (
-    EmptyPage, Page, PageNotAnInteger, Paginator)
+    EmptyPage, InvalidPage, Page, PageNotAnInteger, Paginator)
 
 
 class ESPaginator(Paginator):
@@ -21,6 +21,8 @@ class ESPaginator(Paginator):
             raise PageNotAnInteger('That page number is not an integer')
         if number < 1:
             raise EmptyPage('That page number is less than 1')
+        elif number > 100000:
+            raise InvalidPage('That page number is too high')
         return number
 
     def page(self, number):

--- a/src/olympia/api/tests/test_paginator.py
+++ b/src/olympia/api/tests/test_paginator.py
@@ -30,8 +30,11 @@ class TestSearchPaginator(TestCase):
     def test_invalid_page(self):
         mocked_qs = MagicMock()
         paginator = ESPaginator(mocked_qs, 5)
+        assert ESPaginator.max_result_window == 25000
         with self.assertRaises(InvalidPage):
-            paginator.page(100000 + 1)
+            # We're fetching 5 items per page, so requesting page 5001 should
+            # fail, since the max result window should is set to 25000.
+            paginator.page(5000 + 1)
 
         with self.assertRaises(EmptyPage):
             paginator.page(0)

--- a/src/olympia/api/tests/test_paginator.py
+++ b/src/olympia/api/tests/test_paginator.py
@@ -1,3 +1,5 @@
+from django.core.paginator import EmptyPage, InvalidPage, PageNotAnInteger
+
 from mock import MagicMock
 
 from olympia.amo.tests import TestCase
@@ -24,3 +26,15 @@ class TestSearchPaginator(TestCase):
         paginator.page(1)
         assert paginator.count == 666
         assert mocked_qs.count.call_count == 0
+
+    def test_invalid_page(self):
+        mocked_qs = MagicMock()
+        paginator = ESPaginator(mocked_qs, 5)
+        with self.assertRaises(InvalidPage):
+            paginator.page(100000 + 1)
+
+        with self.assertRaises(EmptyPage):
+            paginator.page(0)
+
+        with self.assertRaises(PageNotAnInteger):
+            paginator.page('lol')


### PR DESCRIPTION
Fix #4702