### PR TITLE
have addon_factory produce complete addons that have metadata to be public

### DIFF
--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -62,9 +62,13 @@ class AddonSerializerOutputTestMixin(object):
         assert data['url'] == absolutify(version.get_url_path())
 
     def test_basic(self):
+        cat1 = Category.from_static_category(
+            CATEGORIES[amo.FIREFOX.id][amo.ADDON_EXTENSION]['bookmarks'])
+        cat1.save()
         self.addon = addon_factory(
             average_daily_users=4242,
             average_rating=4.21,
+            category=cat1,
             description=u'My Addôn description',
             file_kw={
                 'hash': 'fakehash',
@@ -109,10 +113,6 @@ class AddonSerializerOutputTestMixin(object):
         # Reset current_version.compatible_apps now that we've added an app.
         del self.addon.current_version.compatible_apps
 
-        cat1 = Category.from_static_category(
-            CATEGORIES[amo.FIREFOX.id][amo.ADDON_EXTENSION]['bookmarks'])
-        cat1.save()
-        AddonCategory.objects.create(addon=self.addon, category=cat1)
         cat2 = Category.from_static_category(
             CATEGORIES[amo.FIREFOX.id][amo.ADDON_EXTENSION]['alerts-updates'])
         cat2.save()
@@ -553,6 +553,7 @@ class TestVersionSerializerOutput(TestCase):
     def test_no_license(self):
         addon = addon_factory()
         self.version = addon.current_version
+        self.version.update(license=None)
         result = self.serialize()
         assert result['id'] == self.version.pk
         assert result['license'] is None

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -797,7 +797,7 @@ def version_factory(file_kw=None, **kw):
     if not kw.get('license') and not kw.get('license_id'):
         # Is there a built-in one we can use?
         builtins = License.objects.builtins()
-        if builtins.count():
+        if builtins.exists():
             kw['license_id'] = builtins[0].id
         else:
             license_kw = {'builtin': 99}

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -307,7 +307,9 @@ class TestDashboard(HubTest):
 
     def test_mixed_versions_addon_with_incomplete_metadata(self):
         self.make_addon_unlisted(self.addon)
-        version_factory(addon=self.addon, channel=amo.RELEASE_CHANNEL_LISTED)
+        version = version_factory(
+            addon=self.addon, channel=amo.RELEASE_CHANNEL_LISTED)
+        version.update(license=None)
         self.addon.reload()
         assert not self.addon.has_complete_metadata()
 

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -1222,6 +1222,7 @@ class TestVersionSubmitDetailsFirstListed(TestAddonSubmitDetails):
         self.addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
         self.version = version_factory(addon=self.addon,
                                        channel=amo.RELEASE_CHANNEL_LISTED)
+        self.version.update(license=None)  # Addon needs to be missing data.
         self.url = reverse('devhub.submit.version.details',
                            args=['a3615', self.version.pk])
         self.next_step = reverse('devhub.submit.version.finish',

--- a/src/olympia/editors/tests/test_views_themes.py
+++ b/src/olympia/editors/tests/test_views_themes.py
@@ -775,7 +775,7 @@ class TestXssOnThemeName(amo.tests.TestXss):
         super(TestXssOnThemeName, self).setUp()
         self.theme = addon_factory(type=amo.ADDON_PERSONA,
                                    status=amo.STATUS_PENDING,
-                                   name=self.name)
+                                   name=unicode(self.name, 'utf-8'))
         persona = self.theme.persona
         persona.persona_id = 0
         persona.header = 'header'


### PR DESCRIPTION
This is part of the work to stop setting addon.status directly.