### PR TITLE
Add responsive 404 page for mobile fallback

### DIFF
--- a/src/olympia/amo/templates/amo/404-responsive.html
+++ b/src/olympia/amo/templates/amo/404-responsive.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="{{ LANG }}" dir="{{ DIR }}">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    {% if not settings.ENGAGE_ROBOTS %}
+      <meta name="robots" content="noindex">
+    {% endif %}
+    <title>{% block title %}{{ _('Page Not Found') }}{% endblock %}</title>
+    <link rel="shortcut icon" type="image/x-icon"
+          href="{{ STATIC_URL }}img/favicon.ico">
+    {% block site_css %}
+      {{ css('errors/css') }}
+    {% endblock %}
+  </head>
+  <body>
+    <div class="ErrorPage NotFound">
+      <h1 class="logo">{{ _('Firefox Add-ons') }}</h1>
+      <h2>{{ _('Page Not Found') }}</h3>
+      <p>
+        {% trans %}
+        Sorry, but we can't find anything at the address you entered. If you
+        followed a link to an add-on, it's possible that add-on has been removed
+        by its author.
+        {% endtrans %}
+      </p>
+
+      <h3>{{ _('Suggested Pages') }}</h3>
+      <ul>
+         <li><a href="{{ url('browse.extensions') }}">{{ _('Browse all extensions') }}</a></li>
+         <li><a href="{{ url('browse.personas') }}">{{ _('Browse all themes') }}</a></li>
+         <li><a href="{{ url('home') }}">{{ _('Add-ons Home Page') }}</a></li>
+      </ul>
+      <p>
+        {% trans open_bug_link='<a href="https://github.com/mozilla/addons/issues/new">'|safe, close_bug_link='</a>'|safe %}
+        If you followed a link from somewhere, please {{ open_bug_link }}file
+        an issue{{ close_bug_link }}. Tell us where you came from and what you
+        were looking for, and we'll do our best to fix it.
+        {% endtrans %}
+      </p>
+    </div>
+  </body>
+</html>

--- a/src/olympia/amo/tests/test_views.py
+++ b/src/olympia/amo/tests/test_views.py
@@ -9,6 +9,7 @@ from django.test.testcases import TransactionTestCase
 from django.test.utils import override_settings
 
 import commonware.log
+from Cookie import SimpleCookie
 from lxml import etree
 import mock
 from mock import patch
@@ -63,6 +64,19 @@ class Test404(TestCase):
         assert response.status_code == 404
         data = json.loads(response.content)
         assert data['detail'] == u'Not found.'
+
+    def test_404_with_mamo_cookie(self):
+        self.client.cookies = SimpleCookie({'mamo': 'on'})
+        res = self.client.get('/en-US/firefox/xxxxxxx')
+        assert res.status_code == 404
+        self.assertTemplateUsed(res, 'amo/404-responsive.html')
+
+    def test_404_with_mobile_ua_string(self):
+        res = self.client.get('/en-US/firefox/xxxxxxx', **{
+            'HTTP_USER_AGENT': ('Mozilla/5.0 (Android 4.4; Mobile; '
+                                'rv:41.0) Gecko/41.0 Firefox/41.0')})
+        assert res.status_code == 404
+        self.assertTemplateUsed(res, 'amo/404-responsive.html')
 
 
 class TestCommon(TestCase):

--- a/src/olympia/amo/views.py
+++ b/src/olympia/amo/views.py
@@ -85,6 +85,8 @@ def handler404(request):
     elif request.path_info.startswith('/api/'):
         # Pass over to handler404 view in api if api was targeted.
         return legacy_api.views.handler404(request)
+    if request.MOBILE:
+        return render(request, 'amo/404-responsive.html', status=404)
     else:
         return render(request, 'amo/404.html', status=404)
 

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -530,6 +530,11 @@ MINIFY_BUNDLES = {
             'css/devhub/new-landing/base.less',
         ),
 
+        # Responsive error page styling.
+        'errors/css': (
+            'css/errors/base.less',
+        ),
+
         # CSS files common to the entire site.
         'zamboni/css': (
             'css/legacy/main.css',

--- a/static/css/errors/base.less
+++ b/static/css/errors/base.less
@@ -1,0 +1,56 @@
+@import (less) '../common/normalize.css';
+
+* {
+  box-sizing: border-box;
+}
+
+@font-face {
+  font-family: 'Fira Sans';
+  src:
+    local("Fira Sans"),
+    local("Fira Sans Regular"),
+    url("../../fonts/fira/woff2/FiraSans-Regular.woff2") format("woff2"),
+    url("../../fonts/fira/woff/FiraSans-Regular.woff") format("woff"),
+    url("../../fonts/fira/otf/FiraSans-Regular.otf") format("opentype");
+  font-weight: 400;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'Fira Sans';
+  src:
+    local("Fira Sans Bold"),
+    url("../../fonts/fira/woff2/FiraSans-Bold.woff2") format("woff2"),
+    url("../../fonts/fira/woff/FiraSans-Bold.woff") format("woff"),
+    url("../../fonts/fira/otf/FiraSans-Bold.otf") format("opentype");
+  font-weight: 600;
+  font-style: normal;
+}
+
+body, html {
+  background: #fbfbfb;
+  font-family: 'Fira Sans', sans-serif;
+  font-size: 14px;
+}
+
+.logo {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 35px;
+
+  &::before {
+    content: '';
+    min-width: 50px;
+    min-height: 50px;
+    background: url('../../img/developers/addons-logo-black.svg') no-repeat left center;
+    margin-right: 10px;
+  }
+}
+
+.ErrorPage {
+  margin: 0 auto;
+  max-width: 680px;
+  min-width: 260px;
+  padding: 30px 20px 20px;
+}


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/4706

See the bug for more information on the problem this is solving. 

One possible thing that could need adding to this is a language switcher.


Before: 

![screen shot 2017-02-17 at 19 58 34](https://cloud.githubusercontent.com/assets/1514/23081180/8fe6fe34-f54b-11e6-8e15-47276e7bcd22.png)

After:

![screen shot 2017-02-17 at 19 56 24](https://cloud.githubusercontent.com/assets/1514/23081183/92fadb04-f54b-11e6-8982-a3809c70b50f.png)