### PR TITLE
permissions dialog revision.

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1372,6 +1372,12 @@ class Addon(OnChangeMixin, ModelBase):
             feature_compatibility = AddonFeatureCompatibility()
         return feature_compatibility
 
+    def should_show_permissions(self, version=None):
+        version = version or self.current_version
+        return (version and version.all_files[0] and
+                (not version.all_files[0].is_webextension or
+                 version.all_files[0].webext_permissions))
+
 
 dbsignals.pre_save.connect(save_signal, sender=Addon,
                            dispatch_uid='addon_translations')

--- a/src/olympia/addons/templates/addons/impala/button.html
+++ b/src/olympia/addons/templates/addons/impala/button.html
@@ -50,13 +50,12 @@
       {{ _('End-User License Agreement') }}
     </a>
   {% endif %}
-  {% if waffle.switch('webext-permissions') and version and version.all_files[0] %}
-    <br>
+  {% if waffle.switch('webext-permissions') and version and version.all_files[0] and
+        (not version.all_files[0].is_webextension or version.all_files[0].webext_permissions) %}
     <a class="webext-permissions badge" href="#">
       {% if not version.all_files[0].is_webextension %}
-        <img src="{{ static('img/developers/test-warning.png') }}" alt="{{ _('[Warning]') }}">
-      {% endif %}
-      {{ _('Permissions') }}
+        <img src="{{ static('img/developers/test-warning.png') }}" alt="{{ _('[Warning]') }}"
+		>{% endif %}{{ _('Permissions') }}
     </a>
   {% endif %}
   </div>

--- a/src/olympia/addons/templates/addons/impala/button.html
+++ b/src/olympia/addons/templates/addons/impala/button.html
@@ -50,8 +50,7 @@
       {{ _('End-User License Agreement') }}
     </a>
   {% endif %}
-  {% if waffle.switch('webext-permissions') and version and version.all_files[0] and
-        (not version.all_files[0].is_webextension or version.all_files[0].webext_permissions) %}
+  {% if waffle.switch('webext-permissions') and addon.should_show_permissions(version) %}
     <a class="webext-permissions badge" href="#">
       {% if not version.all_files[0].is_webextension %}
         <img src="{{ static('img/developers/test-warning.png') }}" alt="{{ _('[Warning]') }}"

--- a/src/olympia/addons/templates/addons/impala/details.html
+++ b/src/olympia/addons/templates/addons/impala/details.html
@@ -322,11 +322,7 @@
       </div>
     </div>
   {% endif %}
-  {% if waffle.switch('webext-permissions') and
-        addon.current_version and addon.current_version.all_files[0] and
-        (not addon.current_version.all_files[0].is_webextension or
-         addon.current_version.all_files[0].webext_permissions)
-  %}
+  {% if waffle.switch('webext-permissions') and addon.should_show_permissions() %}
     <div class="modal" id="webext-permissions">
       <a href="#" class="close">{{ _('close') }}</a>
       <h2>{{ _('Permissions') }}</h2>

--- a/src/olympia/addons/templates/addons/impala/details.html
+++ b/src/olympia/addons/templates/addons/impala/details.html
@@ -322,7 +322,11 @@
       </div>
     </div>
   {% endif %}
-  {% if waffle.switch('webext-permissions') and addon.current_version and addon.current_version.all_files[0] %}
+  {% if waffle.switch('webext-permissions') and
+        addon.current_version and addon.current_version.all_files[0] and
+        (not addon.current_version.all_files[0].is_webextension or
+         addon.current_version.all_files[0].webext_permissions)
+  %}
     <div class="modal" id="webext-permissions">
       <a href="#" class="close">{{ _('close') }}</a>
       <h2>{{ _('Permissions') }}</h2>
@@ -330,7 +334,7 @@
         {% set permissions = addon.current_version.all_files[0].webext_permissions %}
         <div class="prose">
           <p>
-          {{ _('Some add-ons ask for permissions to perform certain functions (example: a tab management add-on will ask permission to access your browser’s tab system).') }}
+          {{ _('Some add-ons ask for permission to perform certain functions (example: a tab management add-on will ask permission to access your browser’s tab system).') }}
           </p><p>
           {{ _('Since you’re in control of your Firefox, the choice to grant or deny these requests is yours. Accepting permissions does not inherently compromise your browser’s performance or security, but in some rare cases risk may be involved.') }}
           </p>
@@ -338,12 +342,10 @@
         <div>
           <p>
             {# l10n: This is a header of a list of things the add-on can do. #}
-            <h3>{{ _('It can:') }}</h3>
+            <h3>{{ _('This add-on can:') }}</h3>
             <ul class="webext-permissions-list">
               {% for perm in permissions %}
                 <li class="webext-permissions-list">{{ perm.description|e }}</li>
-              {% else %}
-                {{ ("The add-on doesn't have any special permissions.") }}
               {% endfor %}
             </ul>
           </p>
@@ -352,7 +354,7 @@
         <div class="prose">
           <img src="{{ static('img/developers/test-warning.png') }}" alt="{{ _('[Warning]') }}">
           <p>
-          {{ ('Some add-ons ask for permissions to perform certain functions. Since you’re in control of your Firefox, the choice to grant or deny these requests is yours.') }}
+          {{ ('Some add-ons ask for permission to perform certain functions. Since you’re in control of your Firefox, the choice to grant or deny these requests is yours.') }}
           </p><p>
           {{ ('Please note this add-on uses legacy technology, which gives it access to all browser functions and data without requesting your permission.') }}
           </p>

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -761,8 +761,8 @@ class TestDetailPage(TestCase):
         # See File.webext_permissions for the order logic
         assert doc('li.webext-permissions-list').text() == (
             u'Access your data for all websites '
-            u'Access bookmarks '
-            u'Read and change your data for https://google.com/ website')
+            u'Read and modify bookmarks '
+            u'Access your data for https://google.com/')
 
     @override_switch('webext-permissions', active=True)
     def test_permissions_webext_no_permissions(self):
@@ -801,8 +801,8 @@ class TestDetailPage(TestCase):
         response = self.client.get(self.url)
         doc = pq(response.content)
         assert doc('li.webext-permissions-list').text() == (
-            u'Read and change your data for '
-            u'<script>alert("//")</script> website')
+            u'Access your data for '
+            u'<script>alert("//")</script>')
         assert '<script>alert(' not in response.content
         assert '&lt;script&gt;alert(' in response.content
 
@@ -816,7 +816,7 @@ class TestDetailPage(TestCase):
         response = self.client.get(self.url)
         doc = pq(response.content)
         assert doc('li.webext-permissions-list').text() == (
-            u'Read and change your data on various websites '
+            u'Access your data on various websites '
             u'<script>alert("//")</script> '
             u'<script>foo("https://")</script>')
         assert '<script>alert(' not in response.content

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -757,13 +757,12 @@ class TestDetailPage(TestCase):
         assert u'perform certain functions (example: a tab management' in (
             doc('#webext-permissions div.prose').text())
         assert doc('ul.webext-permissions-list').length == 1
-        assert doc('li.webext-permissions-list').length == 4
+        assert doc('li.webext-permissions-list').length == 3
         # See File.webext_permissions for the order logic
         assert doc('li.webext-permissions-list').text() == (
             u'Access your data for all websites '
             u'Access bookmarks '
-            u'Access your data for https://google.com/ website '
-            u'made up permission')
+            u'Read and change your data for https://google.com/ website')
 
     @override_switch('webext-permissions', active=True)
     def test_permissions_webext_no_permissions(self):
@@ -772,16 +771,10 @@ class TestDetailPage(TestCase):
         assert file_.webext_permissions_list == []
         response = self.client.get(self.url)
         doc = pq(response.content)
-        # The link next to the button - still shown even when no permissions.
-        assert doc('a.webext-permissions').length == 1
-        # And the model dialog
-        assert doc('#webext-permissions').length == 1
-        assert u'perform certain functions (example: a tab management' in (
-            doc('#webext-permissions div.prose').text())
-        assert doc('ul.webext-permissions-list').length == 1
-        assert doc('li.webext-permissions-list').length == 0
-        assert u"doesn't have any special" in (
-            doc('ul.webext-permissions-list').text())
+        # Don't show the link when no permissions.
+        assert doc('a.webext-permissions').length == 0
+        # And no model dialog
+        assert doc('#webext-permissions').length == 0
 
     @override_switch('webext-permissions', active=True)
     def test_permissions_non_webext(self):

--- a/src/olympia/constants/webext_permissions.py
+++ b/src/olympia/constants/webext_permissions.py
@@ -19,20 +19,28 @@ WEBEXT_PERMISSIONS = {
 
     u'bookmarks': Permission(
         u'bookmarks',
-        _lazy(u'Access bookmarks'),
+        _lazy(u'Read and modify bookmarks'),
         ''),
-    u'clipboard': Permission(
+    u'clipboardRead': Permission(
         u'clipboard',
-        _lazy(u'Access text clipboard'),
+        _lazy(u'Get data from the clipboard'),
+        ''),
+    u'clipboardWrite': Permission(
+        u'clipboard',
+        _lazy(u'Input data to the clipboard'),
         ''),
     u'downloads': Permission(
         u'downloads',
-        _lazy(u"Download files and read and modify the browser's download"
+        _lazy(u"Download files and read and modify the browser's download "
               u"history"),
+        ''),
+    u'geolocation': Permission(
+        u'history',
+        _lazy(u'Access your location'),
         ''),
     u'history': Permission(
         u'history',
-        _lazy(u'Access browser history'),
+        _lazy(u'Access browsing history'),
         ''),
     u'nativeMessaging': Permission(
         u'nativeMessaging',
@@ -44,7 +52,7 @@ WEBEXT_PERMISSIONS = {
         ''),
     u'sessions': Permission(
         u'sessions',
-        _lazy(u'Access browser history to restore tabs'),
+        _lazy(u'Access recently closed tabs'),
         ''),
     u'tabs': Permission(
         u'tabs',
@@ -58,15 +66,4 @@ WEBEXT_PERMISSIONS = {
         u'webNavigation',
         _lazy(u'Access browser activity during navigation'),
         ''),
-    u'unlimitedStorage': Permission(
-        u'unlimitedStorage',
-        _lazy(u'Provide unlimited storage of client-side data'),
-        ''),
-    u'webRequest': Permission(
-        u'webRequest',
-        _lazy(u'Access browser during Web activity'),
-        ''),
 }
-
-# webRequestBlocking has the same description as webRequest.
-WEBEXT_PERMISSIONS[u'webRequestBlocking'] = WEBEXT_PERMISSIONS[u'webRequest']

--- a/src/olympia/files/models.py
+++ b/src/olympia/files/models.py
@@ -18,6 +18,9 @@ import commonware
 from cache_nuggets.lib import memoize
 from django_extensions.db.fields.json import JSONField
 from django_statsd.clients import statsd
+from django.utils.safestring import mark_safe
+
+from jinja2 import escape as jinja2_escape
 
 from olympia import amo
 from olympia.amo.models import OnChangeMixin, ModelBase, UncachedManagerBase
@@ -379,13 +382,13 @@ class File(OnChangeMixin, ModelBase):
 
     @property
     def webext_permissions(self):
-        """Return permissions with descriptions in defined order:
+        """Return permissions that should be displayed, with descriptions, in
+        defined order:
         1) match all urls (e.g. <all-urls>)
         2) known permissions, in constants order (alphabetically),
         3) match urls for sites
-        4) unknown permissions
         """
-        out, urls, unknowns = [], [], []
+        out, urls = [], []
         for name in self.webext_permissions_list:
             perm = WEBEXT_PERMISSIONS.get(name, None)
             if perm:
@@ -396,17 +399,23 @@ class File(OnChangeMixin, ModelBase):
             elif '//' in name:
                 # Filter out match urls so we can group them.
                 urls.append(name)
-            else:
-                # Other strings are unknown permissions.
-                unknowns.append(name)
+            # Other strings are unknown permissions we don't care about
         out.sort()
-        # TODO: group match urls.
-        out += [
-            Permission(name, _(u'Access your data for {name} website').format(
-                name=name), '')
-            for name in urls]
-        # return + other (unknown) permissions at the end.
-        return out + [Permission(name, name, '') for name in unknowns]
+        if len(urls) == 1:
+            out.append(Permission(
+                u'single-match',
+                _(u'Read and change your data for {name} website')
+                .format(name=urls[0]), ''))
+        elif len(urls) > 1:
+            details = (u'<details><summary>{copy}</summary><ul>{sites}</ul>'
+                       u'</details>')
+            copy = _(u'Read and change your data on various websites')
+            sites = ''.join(
+                [u'<li>%s</li>' % jinja2_escape(name) for name in urls])
+            out.append(Permission(
+                u'multiple-match',
+                mark_safe(details.format(copy=copy, sites=sites)), ''))
+        return out
 
     @amo.cached_property(writable=True)
     def webext_permissions_list(self):

--- a/src/olympia/files/models.py
+++ b/src/olympia/files/models.py
@@ -404,12 +404,12 @@ class File(OnChangeMixin, ModelBase):
         if len(urls) == 1:
             out.append(Permission(
                 u'single-match',
-                _(u'Read and change your data for {name} website')
+                _(u'Access your data for {name}')
                 .format(name=urls[0]), ''))
         elif len(urls) > 1:
             details = (u'<details><summary>{copy}</summary><ul>{sites}</ul>'
                        u'</details>')
-            copy = _(u'Read and change your data on various websites')
+            copy = _(u'Access your data on various websites')
             sites = ''.join(
                 [u'<li>%s</li>' % jinja2_escape(name) for name in urls])
             out.append(Permission(

--- a/src/olympia/files/tests/test_models.py
+++ b/src/olympia/files/tests/test_models.py
@@ -250,11 +250,12 @@ class TestFile(TestCase, amo.tests.AMOPaths):
         # First should be catch-all match urls, if present.
         assert permissions[0] == ALL_URLS_PERMISSION
         # Second should be known permission(s).
-        assert permissions[1] == (u'bookmarks', 'Access bookmarks', '')
+        assert permissions[1] == (
+            u'bookmarks', 'Read and modify bookmarks', '')
         # Third is match urls for specified site(s).
         assert permissions[2] == (
             u'single-match',
-            u'Read and change your data for https://google.com/ website', '')
+            u'Access your data for https://google.com/', '')
 
     def test_webext_permissions(self):
         perm_list = [u'http://*/*', u'<all_urls>', u'bookmarks',
@@ -278,7 +279,7 @@ class TestFile(TestCase, amo.tests.AMOPaths):
         perm_name, perm_desc, _ = file_.webext_permissions[0]
         assert perm_name == u'multiple-match'
         assert perm_desc == (
-            u'<details><summary>Read and change your data on various websites'
+            u'<details><summary>Access your data on various websites'
             u'</summary><ul><li>https://mozilla.org/</li>'
             u'<li>https://mozillians.org/</li></ul></details>')
 

--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -2575,20 +2575,39 @@ body.windows .install-shell .platform.mac {
 }
 
 .webext-permissions.badge {
+  display: block;
   img {
     height: 1.1em;
+    margin-right: 0.25em;
   }
 }
 
 #webext-permissions {
-  li {
-    list-style: circle;
-    list-style-position: inside;
+  ul {
+    margin-left: 1.5em;
+    li {
+      list-style: circle;
+      details {
+        summary {
+          list-style: none;
+        }
+        li {
+          list-style-type: disc;
+        }
+      }
+      details[open] summary:after {
+        content: " \25b2"
+      }
+      details summary:after {
+        content: " \25bc"
+      }
+    }
+  }
+  h3 {
+      font-size: larger;
+      margin-top: 1em;
   }
   .prose {
-    h3 {
-      font-size: larger
-    }
     img {
       float: left;
       margin: 10px;
@@ -2598,5 +2617,5 @@ body.windows .install-shell .platform.mac {
 
 div.detailed {
   display: inline-block;
-  vertical-align: bottom;
+  vertical-align: middle;
 }


### PR DESCRIPTION
Fixes #4726 
also fixes #4733 and fixes #4731 
changes:
- hide unknown permissions
- change 'it can' to 'this add-on can'
- permissions to permission in blurb
- no permissions, don't show link and dialog
- underline between icon and permissions
- group sites
- middle align permissions, privacy policy links