### PR TITLE
Parse review API 'show_grouped_ratings' param with a DRF BooleanField

### DIFF
--- a/docs/topics/api/reviews.rst
+++ b/docs/topics/api/reviews.rst
@@ -23,7 +23,7 @@ combined together.
     :query string addon: The add-on id to fetch reviews from. When passed, the reviews shown will always be the latest posted by each user on this particular add-on (which means there should only be one review per user in the results).
     :query string filter: The :ref:`filter <review-filtering-param>` to apply.
     :query string user: The user id to fetch reviews from.
-    :query int show_grouped_ratings: Whether or not to show ratings aggregates for this add-on in the response.
+    :query boolean show_grouped_ratings: Whether or not to show ratings aggregates for this add-on in the response (Use "true"/"1" as truthy values, "0"/"false" as falsy ones).
     :>json int count: The number of results for this query.
     :>json string next: The URL of the next page of results.
     :>json string previous: The URL of the previous page of results.

--- a/src/olympia/reviews/views.py
+++ b/src/olympia/reviews/views.py
@@ -14,6 +14,7 @@ from django.utils.translation import ugettext as _
 
 import commonware.log
 from mobility.decorators import mobile_template
+from rest_framework import serializers
 from rest_framework.decorators import detail_route
 from rest_framework.exceptions import ParseError
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -405,10 +406,17 @@ class ReviewViewSet(AddonChildMixin, ModelViewSet):
 
     def get_paginated_response(self, data):
         response = super(ReviewViewSet, self).get_paginated_response(data)
-        show_grouped_ratings = self.request.GET.get('show_grouped_ratings')
-        if show_grouped_ratings and self.get_addon_object():
-            response.data['grouped_ratings'] = dict(GroupedRating.get(
-                self.addon_object.id))
+        if 'show_grouped_ratings' in self.request.GET:
+            try:
+                show_grouped_ratings = (
+                    serializers.BooleanField().to_internal_value(
+                        self.request.GET['show_grouped_ratings']))
+            except serializers.ValidationError:
+                raise ParseError(
+                    'show_grouped_ratings parameter should be a boolean')
+            if show_grouped_ratings and self.get_addon_object():
+                response.data['grouped_ratings'] = dict(GroupedRating.get(
+                    self.addon_object.id))
         return response
 
     def get_queryset(self):


### PR DESCRIPTION
Fixes issues we've been having with `show_grouped_ratings='0'` being accepted as a truthy value, and makes things more coherent.

Fix #4737