### PR TITLE
Redirect to next_path on register from mobile pages

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -112,6 +112,7 @@ FXA_CONFIG = {
         'profile_host': 'https://stable.dev.lcip.org/profile/v1',
         'redirect_url': 'http://localhost:3000/fxa-authenticate',
         'scope': 'profile',
+        'skip_register_redirect': True,
     },
     'local': {
         'client_id': '1778aef72d1adfb3',

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -313,7 +313,11 @@ class AuthenticateView(FxAConfigMixin, APIView):
     def get(self, request, user, identity, next_path):
         if user is None:
             user = register_user(request, identity)
-            response = safe_redirect(reverse('users.edit'), 'register')
+            fxa_config = self.get_fxa_config(request)
+            if fxa_config.get('skip_register_redirect'):
+                response = safe_redirect(next_path, 'register')
+            else:
+                response = safe_redirect(reverse('users.edit'), 'register')
         else:
             login_user(request, user, identity)
             response = safe_redirect(next_path, 'login')

--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -266,6 +266,7 @@ FXA_CONFIG = {
         'profile_host': 'https://stable.dev.lcip.org/profile/v1',
         'redirect_url': 'https://amo.addons-dev.allizom.org/fxa-authenticate',
         'scope': 'profile',
+        'skip_register_redirect': True,
     },
     'local': {
         'client_id': env('DEVELOPMENT_FXA_CLIENT_ID'),


### PR DESCRIPTION
The mobile pages don't need to go to /user/edit after the user registers since there is no edit account page. This lets the FxA config decide if the user should be redirected to the edit account page after registering.

Fixes #4742.
Supports mozilla/addons-frontend#1660.