### PR TITLE
Revert "Fix search-on-click"

### DIFF
--- a/static/js/impala/site_suggestions.js
+++ b/static/js/impala/site_suggestions.js
@@ -12,11 +12,6 @@
         // Update the 'Search add-ons for <b>"{addon}"</b>' text.
         settings['$results'].find('p b').html(format('"{0}"',
                                                      settings.searchTerm));
-        
-        // Update the .sel link.
-        var searchUrl = settings['$form'].attr('action') + '?q={0}';
-        settings['$results'].find('.sel').attr('href', format(searchUrl,
-                                                              settings.urlSearchTerm));
 
         var li_item = template(
             '<li><a href="{url}"><span {cls} {icon}>{name}</span>{subtitle}</a></li>'

--- a/static/js/impala/suggestions.js
+++ b/static/js/impala/suggestions.js
@@ -130,14 +130,12 @@ $.fn.searchSuggestions = function($results, processCallback, searchType) {
             $results.filter('.visible').removeClass('visible');
             return;
         }
-        var urlVal = encodeURIComponent($self.val());
 
         // Required data to send to the callback.
         var settings = {
             '$results': $results,
             '$form': $form,
-            'searchTerm': val,
-            'urlSearchTerm': urlVal
+            'searchTerm': val
         };
 
         // Optional data for callback.


### PR DESCRIPTION
Fixes #4755

Reverts mozilla/addons-server#4691

Unfortunately building the link this way doesn't take into account other form fields and so additional search criteria are missing. Probably could be solved easiest by simply making the link submit instead of link building.