### PR TITLE
Maintain a counter of the number of times an add-on has been approved

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1731,11 +1731,10 @@ class AddonApprovalsCounter(ModelBase):
         AddonApprovalsCounter already exists, it updates it, otherwise it
         creates and saves a new instance.
         """
-        try:
-            obj = cls.objects.get(addon=addon)
+        obj, created = cls.objects.get_or_create(
+            addon=addon, defaults={'counter': 1})
+        if not created:
             obj.update(counter=F('counter') + 1)
-        except cls.DoesNotExist:
-            obj = cls.objects.create(addon=addon, counter=1)
         return obj
 
     @classmethod

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -13,8 +13,8 @@ from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.storage import default_storage as storage
 from django.db import models, transaction
+from django.db.models import F, Max, Q, signals as dbsignals
 from django.dispatch import receiver
-from django.db.models import Max, Q, signals as dbsignals
 from django.utils.translation import trans_real, ugettext_lazy as _
 
 import caching.base as caching
@@ -1711,6 +1711,39 @@ class AddonFeatureCompatibility(ModelBase):
 
     def get_e10s_classname(self):
         return amo.E10S_COMPATIBILITY_CHOICES_API[self.e10s]
+
+
+class AddonApprovalsCounter(ModelBase):
+    """Model holding a counter of the number of times a listed version
+    belonging to an add-on has been approved by a human. Reset everytime a
+    listed version is auto-approved for this add-on."""
+    addon = models.OneToOneField(
+        Addon, primary_key=True, on_delete=models.CASCADE)
+    counter = models.PositiveIntegerField(default=0)
+
+    def __unicode__(self):
+        return u'%s: %d' % (unicode(self.pk), self.counter) if self.pk else u''
+
+    @classmethod
+    def increment_for_addon(cls, addon):
+        """
+        Increment approval counter for the specified addon. If an
+        AddonApprovalsCounter already exists, it updates it, otherwise it
+        creates and saves a new instance.
+        """
+        try:
+            obj = cls.objects.get(addon=addon)
+            obj.update(counter=F('counter') + 1)
+        except cls.DoesNotExist:
+            obj = cls.objects.create(addon=addon, counter=1)
+        return obj
+
+    @classmethod
+    def reset_for_addon(cls, addon):
+        """
+        Reset the approval counter for the specified addon.
+        """
+        return cls.objects.filter(addon=addon).delete()
 
 
 class DeniedGuid(ModelBase):

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1742,7 +1742,11 @@ class AddonApprovalsCounter(ModelBase):
         """
         Reset the approval counter for the specified addon.
         """
-        return cls.objects.filter(addon=addon).delete()
+        obj, created = cls.objects.get_or_create(
+            addon=addon, defaults={'counter': 0})
+        if not created:
+            obj.update(counter=0)
+        return obj
 
 
 class DeniedGuid(ModelBase):

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1742,10 +1742,8 @@ class AddonApprovalsCounter(ModelBase):
         """
         Reset the approval counter for the specified addon.
         """
-        obj, created = cls.objects.get_or_create(
+        obj, created = cls.objects.update_or_create(
             addon=addon, defaults={'counter': 0})
-        if not created:
-            obj.update(counter=0)
         return obj
 
 

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -3018,15 +3018,15 @@ class TestAddonApprovalsCounter(TestCase):
         assert approval_counter.counter == 1
 
     def test_reset_existing(self):
-        AddonApprovalsCounter.objects.create(
+        approval_counter = AddonApprovalsCounter.objects.create(
             addon=self.addon, counter=42)
         AddonApprovalsCounter.reset_for_addon(self.addon)
-        assert not AddonApprovalsCounter.objects.filter(
-            addon=self.addon).exists()
+        approval_counter.reload()
+        assert approval_counter.counter == 0
 
     def test_reset_non_existing(self):
         assert not AddonApprovalsCounter.objects.filter(
             addon=self.addon).exists()
         AddonApprovalsCounter.reset_for_addon(self.addon)
-        assert not AddonApprovalsCounter.objects.filter(
-            addon=self.addon).exists()
+        approval_counter = AddonApprovalsCounter.objects.get(addon=self.addon)
+        assert approval_counter.counter == 0

--- a/src/olympia/editors/helpers.py
+++ b/src/olympia/editors/helpers.py
@@ -19,7 +19,7 @@ from olympia.access import acl
 from olympia.access.models import GroupUser
 from olympia.activity.utils import send_activity_mail
 from olympia.addons.helpers import new_context
-from olympia.addons.models import Addon
+from olympia.addons.models import Addon, AddonApprovalsCounter
 from olympia.amo.helpers import absolutify, page_title
 from olympia.amo.urlresolvers import reverse
 from olympia.amo.utils import send_mail as amo_send_mail, to_language
@@ -563,8 +563,8 @@ class ReviewAddon(ReviewBase):
 
     def process_public(self):
         """Set an addon to public."""
-        assert not self.version or (
-            self.version.channel == amo.RELEASE_CHANNEL_LISTED)
+        assert self.version.channel == amo.RELEASE_CHANNEL_LISTED
+
         # Sign addon.
         for file_ in self.files:
             sign_file(file_, settings.SIGNING_SERVER)
@@ -576,6 +576,9 @@ class ReviewAddon(ReviewBase):
         # is at least one public file or it won't make the addon public.
         self.set_files(amo.STATUS_PUBLIC, self.files)
         self.set_addon(status=amo.STATUS_PUBLIC)
+
+        # Increment approvals counter.
+        AddonApprovalsCounter.increment_for_addon(addon=self.addon)
 
         self.log_action(amo.LOG.APPROVE_VERSION)
         template = u'%s_to_public' % self.review_type
@@ -591,8 +594,8 @@ class ReviewAddon(ReviewBase):
 
     def process_sandbox(self):
         """Set an addon back to sandbox."""
-        assert not self.version or (
-            self.version.channel == amo.RELEASE_CHANNEL_LISTED)
+        assert self.version.channel == amo.RELEASE_CHANNEL_LISTED
+
         # Hold onto the status before we change it.
         status = self.addon.status
 
@@ -614,8 +617,8 @@ class ReviewAddon(ReviewBase):
 
     def process_super_review(self):
         """Give an addon super review."""
-        assert not self.version or (
-            self.version.channel == amo.RELEASE_CHANNEL_LISTED)
+        assert self.version.channel == amo.RELEASE_CHANNEL_LISTED
+
         self.addon.update(admin_review=True)
         self.notify_email('author_super_review',
                           u'Mozilla Add-ons: %s %s flagged for Admin Review')
@@ -631,8 +634,8 @@ class ReviewFiles(ReviewBase):
 
     def process_public(self):
         """Set an addons files to public."""
-        assert not self.version or (
-            self.version.channel == amo.RELEASE_CHANNEL_LISTED)
+        assert self.version.channel == amo.RELEASE_CHANNEL_LISTED
+
         # Sign addon.
         for file_ in self.files:
             sign_file(file_, settings.SIGNING_SERVER)
@@ -641,6 +644,9 @@ class ReviewFiles(ReviewBase):
         status = self.addon.status
 
         self.set_files(amo.STATUS_PUBLIC, self.files)
+
+        # Increment approvals counter.
+        AddonApprovalsCounter.increment_for_addon(addon=self.addon)
 
         self.log_action(amo.LOG.APPROVE_VERSION)
         template = u'%s_to_public' % self.review_type
@@ -657,8 +663,8 @@ class ReviewFiles(ReviewBase):
 
     def process_sandbox(self):
         """Set an addons files to sandbox."""
-        assert not self.version or (
-            self.version.channel == amo.RELEASE_CHANNEL_LISTED)
+        assert self.version.channel == amo.RELEASE_CHANNEL_LISTED
+
         # Hold onto the status before we change it.
         status = self.addon.status
 
@@ -681,8 +687,8 @@ class ReviewFiles(ReviewBase):
 
     def process_super_review(self):
         """Give an addon super review."""
-        assert not self.version or (
-            self.version.channel == amo.RELEASE_CHANNEL_LISTED)
+        assert self.version.channel == amo.RELEASE_CHANNEL_LISTED
+
         self.addon.update(admin_review=True)
 
         self.notify_email('author_super_review',
@@ -700,8 +706,8 @@ class ReviewUnlisted(ReviewBase):
 
     def process_public(self):
         """Set an addons files to public."""
-        assert not self.version or (
-            self.version.channel == amo.RELEASE_CHANNEL_UNLISTED)
+        assert self.version.channel == amo.RELEASE_CHANNEL_UNLISTED
+
         # Sign addon.
         for file_ in self.files:
             sign_file(file_, settings.SIGNING_SERVER)
@@ -719,8 +725,8 @@ class ReviewUnlisted(ReviewBase):
 
     def process_super_review(self):
         """Give an addon super review."""
-        assert not self.version or (
-            self.version.channel == amo.RELEASE_CHANNEL_UNLISTED)
+        assert self.version.channel == amo.RELEASE_CHANNEL_UNLISTED
+
         self.addon.update(admin_review=True)
 
         self.notify_email('author_super_review',

--- a/src/olympia/migrations/923-add-approval-counter.sql
+++ b/src/olympia/migrations/923-add-approval-counter.sql
@@ -1,7 +1,8 @@
+-- Note: if the migration fails for you locally, remove the 'unsigned' next to addon_id below.
 CREATE TABLE `addons_addonapprovalscounter` (
     `created` datetime(6) NOT NULL,
     `modified` datetime(6) NOT NULL,
-    `addon_id` integer NOT NULL PRIMARY KEY,
+    `addon_id` unsigned integer NOT NULL PRIMARY KEY,
     `counter` integer UNSIGNED NOT NULL
 );
 ALTER TABLE `addons_addonapprovalscounter` ADD CONSTRAINT `addon_id_refs_id_8fcb7166` FOREIGN KEY (`addon_id`) REFERENCES `addons` (`id`);

--- a/src/olympia/migrations/923-add-approval-counter.sql
+++ b/src/olympia/migrations/923-add-approval-counter.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `addons_addonapprovalscounter` (
+    `created` datetime(6) NOT NULL,
+    `modified` datetime(6) NOT NULL,
+    `addon_id` integer NOT NULL PRIMARY KEY,
+    `counter` integer UNSIGNED NOT NULL
+);
+ALTER TABLE `addons_addonapprovalscounter` ADD CONSTRAINT `addon_id_refs_id_8fcb7166` FOREIGN KEY (`addon_id`) REFERENCES `addons` (`id`);
+
+-- Start all existing public addons at 1: they had to have at least one human review to be public.
+INSERT INTO addons_addonapprovalscounter (addon_id, counter, created, modified) SELECT id, 1, NOW(), NOW() FROM addons WHERE status = 4 AND inactive = false;


### PR DESCRIPTION
Fix #4752