### PR TITLE
Fix migration 923 again (integer unsigned vs unsigned integer)

### DIFF
--- a/src/olympia/migrations/923-add-approval-counter.sql
+++ b/src/olympia/migrations/923-add-approval-counter.sql
@@ -2,7 +2,7 @@
 CREATE TABLE `addons_addonapprovalscounter` (
     `created` datetime(6) NOT NULL,
     `modified` datetime(6) NOT NULL,
-    `addon_id` unsigned integer NOT NULL PRIMARY KEY,
+    `addon_id` integer UNSIGNED NOT NULL PRIMARY KEY,
     `counter` integer UNSIGNED NOT NULL
 );
 ALTER TABLE `addons_addonapprovalscounter` ADD CONSTRAINT `addon_id_refs_id_8fcb7166` FOREIGN KEY (`addon_id`) REFERENCES `addons` (`id`);


### PR DESCRIPTION
`INTEGER[(M)] [UNSIGNED] [ZEROFILL]`
https://dev.mysql.com/doc/refman/5.7/en/numeric-type-overview.html