### PR TITLE
Fix wording in devhub review history

### DIFF
--- a/src/olympia/devhub/templates/devhub/versions/list.html
+++ b/src/olympia/devhub/templates/devhub/versions/list.html
@@ -125,7 +125,7 @@
                 </div>
                 <div class="review-entry-empty hidden">
                     <p><span class="action">$action_label</span> {{ _('by') }}
-                    <a href="$user_profile">$user_name</a> {{ _('on') }} <time class="timeago" datetime=$date>$date</time></p>
+                    <a href="$user_profile">$user_name</a> <time class="timeago" datetime=$date>$date</time></p>
                     <pre>$comments</pre>
                 </div>
             </div>


### PR DESCRIPTION
The time is always relative as we use _jQuery.timeago_ for that field by `class=timeago`.