### PR TITLE
Fix tests using categories with add-ons created by addon_factory()

### DIFF
--- a/src/olympia/addons/tests/test_utils_.py
+++ b/src/olympia/addons/tests/test_utils_.py
@@ -45,7 +45,7 @@ class TestGetCreaturedIds(TestCase):
     fixtures = ['addons/featured', 'bandwagon/featured_collections',
                 'base/addon_3615', 'base/collections', 'base/featured',
                 'base/users']
-    category = 22
+    category_id = 22
 
     no_locale = (1001,)
     en_us_locale = (3481,)
@@ -54,50 +54,50 @@ class TestGetCreaturedIds(TestCase):
         super(TestGetCreaturedIds, self).setUp()
 
     def test_by_category_static(self):
-        category = CATEGORIES_BY_ID[self.category]
+        category = CATEGORIES_BY_ID[self.category_id]
         assert set(get_creatured_ids(category, None)) == (
             set(self.no_locale))
 
     def test_by_category_dynamic(self):
-        category = Category.objects.get(pk=self.category)
+        category = Category.objects.get(pk=self.category_id)
         assert set(get_creatured_ids(category, None)) == (
             set(self.no_locale))
 
     def test_by_category_id(self):
-        assert set(get_creatured_ids(self.category, None)) == (
+        assert set(get_creatured_ids(self.category_id, None)) == (
             set(self.no_locale))
 
     def test_by_category_app(self):
         # Add an addon to the same category, but in a featured collection
         # for a different app: it should not be returned.
-        extra_addon = addon_factory()
-        extra_addon.addoncategory_set.create(category_id=self.category)
+        extra_addon = addon_factory(
+            category=Category.objects.get(pk=self.category_id))
         collection = collection_factory()
         collection.add_addon(extra_addon)
         FeaturedCollection.objects.create(
             application=amo.THUNDERBIRD.id, collection=collection)
 
-        assert set(get_creatured_ids(self.category, None)) == (
+        assert set(get_creatured_ids(self.category_id, None)) == (
             set(self.no_locale))
 
     def test_by_locale(self):
-        assert set(get_creatured_ids(self.category, 'en-US')) == (
+        assert set(get_creatured_ids(self.category_id, 'en-US')) == (
             set(self.no_locale + self.en_us_locale))
 
     def test_by_category_app_and_locale(self):
         # Add an addon to the same category and locale, but in a featured
         # collection for a different app: it should not be returned.
-        extra_addon = addon_factory()
-        extra_addon.addoncategory_set.create(category_id=self.category)
+        extra_addon = addon_factory(
+            category=Category.objects.get(pk=self.category_id))
         collection = collection_factory()
         collection.add_addon(extra_addon)
         FeaturedCollection.objects.create(
             application=amo.THUNDERBIRD.id, collection=collection,
             locale='en-US')
 
-        assert set(get_creatured_ids(self.category, 'en-US')) == (
+        assert set(get_creatured_ids(self.category_id, 'en-US')) == (
             set(self.no_locale + self.en_us_locale))
 
     def test_shuffle(self):
-        ids = get_creatured_ids(self.category, 'en-US')
+        ids = get_creatured_ids(self.category_id, 'en-US')
         assert (ids[0],) == self.en_us_locale

--- a/src/olympia/users/tests/test_views.py
+++ b/src/olympia/users/tests/test_views.py
@@ -22,6 +22,7 @@ from olympia.addons.models import Addon, AddonUser, Category
 from olympia.amo.helpers import urlparams
 from olympia.amo.urlresolvers import reverse
 from olympia.bandwagon.models import Collection, CollectionWatcher
+from olympia.constants.categories import CATEGORIES
 from olympia.devhub.models import ActivityLog
 from olympia.reviews.models import Review
 from olympia.users import notifications as email
@@ -854,13 +855,16 @@ class TestThemesProfile(TestCase):
         assert res.status_code == 200
 
     def test_themes_category(self):
-        self.theme = amo.tests.addon_factory(type=amo.ADDON_PERSONA)
-        self.theme.addonuser_set.create(user=self.user, listed=True)
-        cat = Category.objects.create(type=amo.ADDON_PERSONA, slug='swag')
-        self.theme.addoncategory_set.create(category=cat)
+        static_category = (
+            CATEGORIES[amo.FIREFOX.id][amo.ADDON_PERSONA]['fashion'])
+        category, _ = Category.objects.get_or_create(
+            id=static_category.id, defaults=static_category.__dict__)
+
+        self.theme = amo.tests.addon_factory(
+            type=amo.ADDON_PERSONA, users=[self.user], category=category)
 
         res = self.client.get(
-            self.user.get_user_url('themes', args=[cat.slug]))
+            self.user.get_user_url('themes', args=[category.slug]))
         self._test_good(res)
 
 


### PR DESCRIPTION
`addon_factory()` randomly creates categories and assign addons it creates to them. Tests were failing because they were manually creating the `addoncategory` instance, which in some cases already
existed.