### PR TITLE
Implement auto-approval command prototype

### DIFF
--- a/src/olympia/amo/__init__.py
+++ b/src/olympia/amo/__init__.py
@@ -8,6 +8,7 @@ from product_details import product_details
 
 from olympia.constants.applications import *  # noqa
 from olympia.constants.base import *  # noqa
+from olympia.constants.editors import *  # noqa
 from olympia.constants.licenses import *  # noqa
 from olympia.constants.payments import *  # noqa
 from olympia.constants.platforms import *  # noqa

--- a/src/olympia/constants/editors.py
+++ b/src/olympia/constants/editors.py
@@ -30,3 +30,18 @@ THEME_REJECT_REASONS = {
     8: _('Low-quality, stretched, or blank image'),
     9: _('Header image alignment problem'),
 }
+
+
+WOULD_NOT_HAVE_BEEN_AUTO_APPROVED = 0
+WOULD_HAVE_BEEN_AUTO_APPROVED = 1
+AUTO_APPROVED = 2
+NOT_AUTO_APPROVED = 3
+
+AUTO_APPROVAL_VERDICT_CHOICES = (
+    (WOULD_NOT_HAVE_BEEN_AUTO_APPROVED,
+        'Would have been auto-approved (dry-run mode was in effect)'),
+    (WOULD_HAVE_BEEN_AUTO_APPROVED,
+        'Would *not* have been auto-approved (dry-run mode was in effect)'),
+    (AUTO_APPROVED, 'Was auto-approved'),
+    (NOT_AUTO_APPROVED, 'Was *not* auto-approved'),
+)

--- a/src/olympia/constants/webext_permissions.py
+++ b/src/olympia/constants/webext_permissions.py
@@ -16,6 +16,7 @@ WEBEXT_PERMISSIONS = {
     u'http://*/*': ALL_URLS_PERMISSION,
     u'https://*/*': ALL_URLS_PERMISSION,
     u'*://*/*': ALL_URLS_PERMISSION,
+    # FIXME: how about https://*/path ?
 
     u'bookmarks': Permission(
         u'bookmarks',

--- a/src/olympia/editors/management/commands/auto_approve.py
+++ b/src/olympia/editors/management/commands/auto_approve.py
@@ -106,9 +106,8 @@ class Command(BaseCommand):
                     'Version %s was skipped either because it had no '
                     'file or because it had no validation attached.', version)
                 stats['error'] += 1
+            finally:
                 clear_reviewing_cache(version.addon.pk)
-                continue
-            clear_reviewing_cache(version.addon.pk)
 
         self.log_final_summary(stats, dry_run=dry_run)
 

--- a/src/olympia/editors/management/commands/auto_approve.py
+++ b/src/olympia/editors/management/commands/auto_approve.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+from collections import Counter
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+from django.core.urlresolvers import reverse
+
+import commonware.log
+
+from olympia import amo
+from olympia.editors.models import (
+    AutoApprovalNotEnoughFilesError, AutoApprovalNoValidationResultError,
+    AutoApprovalSummary)
+from olympia.editors.views import (
+    clear_reviewing_cache, get_reviewing_cache, set_reviewing_cache)
+from olympia.versions.models import Version
+from olympia.zadmin.models import get_config
+
+
+log = commonware.log.getLogger('z.editors.auto_approve')
+
+
+class Command(BaseCommand):
+    help = 'Auto-approve add-ons based on predefined criteria'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            dest='dry_run',
+            default=False,
+            help='Do everything except actually approving add-ons.')
+
+    def fetch_candidates(self):
+        return (Version.objects.filter(
+            addon__type=amo.ADDON_EXTENSION,
+            addon__disabled_by_user=False,
+            addon__status=amo.STATUS_PUBLIC,
+            files__status=amo.STATUS_AWAITING_REVIEW,
+            files__is_webextension=True)
+            .no_cache().order_by('nomination', 'created').distinct())
+
+    def handle(self, *args, **options):
+        dry_run = options.get('dry_run', False)
+        max_average_daily_users = int(
+            get_config('AUTO_APPROVAL_MAX_AVERAGE_DAILY_USERS') or 0)
+        min_approved_updates = int(
+            get_config('AUTO_APPROVAL_MIN_APPROVED_UPDATES') or 0)
+
+        if min_approved_updates <= 0 or max_average_daily_users <= 0:
+            # Auto approval are shut down if one of those values is not present
+            # or <= 0.
+            url = '%s%s' % (
+                settings.SITE_URL,
+                reverse('admin:zadmin_config_changelist'))
+            raise CommandError(
+                'Auto-approvals are deactivated because either '
+                'AUTO_APPROVAL_MAX_AVERAGE_DAILY_USERS or '
+                'AUTO_APPROVAL_MIN_APPROVED_UPDATES have not been '
+                'set or were set to 0. Use the admin tools Config model to '
+                'set them by going to %s.' % url)
+
+        stats = Counter()
+        qs = self.fetch_candidates()
+        stats['total'] = len(qs)
+
+        successful_verdict = (
+            amo.WOULD_HAVE_BEEN_AUTO_APPROVED if dry_run
+            else amo.AUTO_APPROVED)
+
+        for version in qs:
+            # Is the addon already locked by a reviewer ?
+            if get_reviewing_cache(version.addon.pk):
+                stats['locked'] += 1
+                continue
+
+            # Lock the addon for ourselves, no reviewer should touch it.
+            set_reviewing_cache(version.addon.pk, settings.TASK_USER_ID)
+
+            # If admin review or more information was requested, skip this
+            # version, let a human handle it.
+            if version.addon.admin_review or version.has_info_request:
+                stats['flagged'] += 1
+                clear_reviewing_cache(version.addon.pk)
+                continue
+
+            try:
+                log.info('Processing %s version %s...',
+                         unicode(version.addon.name), unicode(version.version))
+                summary, info = AutoApprovalSummary.create_summary_for_version(
+                    version, max_average_daily_users=max_average_daily_users,
+                    min_approved_updates=min_approved_updates,
+                    dry_run=dry_run)
+                log.info('Auto Approval for %s version %s: %s',
+                         unicode(version.addon.name),
+                         unicode(version.version),
+                         summary.get_verdict_display())
+                stats.update({k: int(v) for k, v in info.items()})
+                if summary.verdict == successful_verdict:
+                    stats['auto_approved'] += 1
+                # FIXME: implement auto-approve if verdict is amo.AUTO_APPROVED
+
+            except (AutoApprovalNotEnoughFilesError,
+                    AutoApprovalNoValidationResultError):
+                log.info(
+                    'Version %s was skipped either because it had no '
+                    'file or because it had no validation attached.', version)
+                stats['error'] += 1
+                clear_reviewing_cache(version.addon.pk)
+                continue
+            clear_reviewing_cache(version.addon.pk)
+
+        self.log_final_summary(stats, dry_run=dry_run)
+
+    def log_final_summary(self, stats, dry_run=False):
+        log.info('There were %d webextensions add-ons in the updates queue.',
+                 stats['total'])
+        log.info('%d versions were skipped because they were already locked.',
+                 stats['locked'])
+        log.info('%d versions were skipped because they were flagged for '
+                 'admin review or had info requested flag set.',
+                 stats['flagged'])
+        log.info('%d versions were skipped because they had no files or had '
+                 'no validation attached to their files.', stats['error'])
+        log.info('%d versions belonged to an add-on with too many daily '
+                 'active users.', stats['too_many_average_daily_users'])
+        log.info('%d versions did not have enough approved updates.',
+                 stats['too_few_approved_updates'])
+        log.info('%d versions used a custom CSP.',
+                 stats['uses_custom_csp'])
+        log.info('%d versions used nativeMessaging permission.',
+                 stats['uses_native_messaging'])
+        log.info('%d versions used a content script for all URLs.',
+                 stats['uses_content_script_for_all_urls'])
+        if dry_run:
+            log.info('%d versions were marked as would have been approved.',
+                     stats['auto_approved'])
+        else:
+            log.info('%d versions were approved.', stats['auto_approved'])

--- a/src/olympia/editors/management/commands/auto_approve.py
+++ b/src/olympia/editors/management/commands/auto_approve.py
@@ -74,15 +74,14 @@ class Command(BaseCommand):
                 stats['locked'] += 1
                 continue
 
-            # Lock the addon for ourselves, no reviewer should touch it.
-            set_reviewing_cache(version.addon.pk, settings.TASK_USER_ID)
-
             # If admin review or more information was requested, skip this
             # version, let a human handle it.
             if version.addon.admin_review or version.has_info_request:
                 stats['flagged'] += 1
-                clear_reviewing_cache(version.addon.pk)
                 continue
+
+            # Lock the addon for ourselves, no reviewer should touch it.
+            set_reviewing_cache(version.addon.pk, settings.TASK_USER_ID)
 
             try:
                 log.info('Processing %s version %s...',

--- a/src/olympia/editors/tests/test_commands.py
+++ b/src/olympia/editors/tests/test_commands.py
@@ -1,0 +1,257 @@
+# -*- coding: utf-8 -*-
+import mock
+
+from django.conf import settings
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from olympia import amo
+from olympia.addons.models import AddonApprovalsCounter
+from olympia.amo.tests import (
+    addon_factory, file_factory, TestCase, version_factory)
+from olympia.editors.management.commands import auto_approve
+from olympia.editors.models import (
+    AutoApprovalNotEnoughFilesError, AutoApprovalNoValidationResultError,
+    AutoApprovalSummary)
+from olympia.editors.views import get_reviewing_cache, set_reviewing_cache
+from olympia.files.models import FileValidation
+from olympia.zadmin.models import Config, get_config, set_config
+
+
+class TestAutoApproveCommand(TestCase):
+    def setUp(self):
+        self.addon = addon_factory(average_daily_users=666)
+        self.version = version_factory(
+            addon=self.addon, file_kw={
+                'status': amo.STATUS_AWAITING_REVIEW,
+                'is_webextension': True})
+        self.file = self.version.all_files[0]
+        self.file_validation = FileValidation.objects.create(
+            file=self.version.all_files[0], validation=u'{}')
+        AddonApprovalsCounter.objects.create(addon=self.addon, counter=1)
+        set_config('AUTO_APPROVAL_MAX_AVERAGE_DAILY_USERS', 10000)
+        set_config('AUTO_APPROVAL_MIN_APPROVED_UPDATES', 1)
+
+        # Always mock log_final_summary() method so we can look at the stats
+        # easily.
+        patcher = mock.patch.object(auto_approve.Command, 'log_final_summary')
+        self.log_final_summary_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _check_stats(self, expected_stats):
+        assert self.log_final_summary_mock.call_count == 1
+        stats = self.log_final_summary_mock.call_args[0][0]
+        assert stats == expected_stats
+
+    def test_handle_no_max_average_daily_users(self):
+        # With only one of the 2 keys set, raise CommandError.
+        Config.objects.get(
+            key='AUTO_APPROVAL_MAX_AVERAGE_DAILY_USERS').delete()
+        assert get_config('AUTO_APPROVAL_MAX_AVERAGE_DAILY_USERS') is None
+        with self.assertRaises(CommandError):
+            call_command('auto_approve')
+
+        # With both keys set but daily users is 0, raise CommandError.
+        set_config('AUTO_APPROVAL_MAX_AVERAGE_DAILY_USERS', 0)
+        with self.assertRaises(CommandError):
+            call_command('auto_approve')
+
+        # With both keys set to non-zero, everything should work.
+        set_config('AUTO_APPROVAL_MAX_AVERAGE_DAILY_USERS', 10000)
+        call_command('auto_approve')
+
+    def test_handle_no_min_approved_updates(self):
+        # With only one of the 2 keys set, raise CommandError.
+        Config.objects.get(
+            key='AUTO_APPROVAL_MIN_APPROVED_UPDATES').delete()
+        assert get_config('AUTO_APPROVAL_MIN_APPROVED_UPDATES') is None
+        with self.assertRaises(CommandError):
+            call_command('auto_approve')
+
+        # With both keys set but min approved updates is 0, raise CommandError.
+        set_config('AUTO_APPROVAL_MIN_APPROVED_UPDATES', 0)
+        with self.assertRaises(CommandError):
+            call_command('auto_approve')
+
+        # With both keys set to non-zero, everything should work.
+        set_config('AUTO_APPROVAL_MIN_APPROVED_UPDATES', 1)
+        call_command('auto_approve')
+
+    def test_fetch_candidates(self):
+        # Add a bunch of add-ons in various states that should not be returned.
+        # Public add-on with no updates.
+        addon_factory(file_kw={'is_webextension': True})
+
+        # Non-extension with updates.
+        search_addon = addon_factory(type=amo.ADDON_SEARCH)
+        version_factory(addon=search_addon, file_kw={
+            'status': amo.STATUS_AWAITING_REVIEW,
+            'is_webextension': True})
+
+        # Disabled add-on with updates.
+        disabled_addon = addon_factory(disabled_by_user=True)
+        version_factory(addon=disabled_addon, file_kw={
+            'status': amo.STATUS_AWAITING_REVIEW,
+            'is_webextension': True})
+
+        # Non-public add-on
+        addon_factory(status=amo.STATUS_NOMINATED, file_kw={
+            'status': amo.STATUS_AWAITING_REVIEW,
+            'is_webextension': True})
+
+        # Add-on with deleted version.
+        addon_with_deleted_version = addon_factory()
+        deleted_version = version_factory(
+            addon=addon_with_deleted_version, file_kw={
+                'status': amo.STATUS_AWAITING_REVIEW,
+                'is_webextension': True})
+        deleted_version.delete()
+
+        # Add-on with a non-webextension update.
+        non_webext_addon = addon_factory()
+        version_factory(addon=non_webext_addon, file_kw={
+            'status': amo.STATUS_AWAITING_REVIEW})
+
+        # Add-on with 3 versions:
+        # - one webext, listed, public.
+        # - one non-listed webext version
+        # - one listed non-webext awaiting review.
+        complex_addon = addon_factory(file_kw={'is_webextension': True})
+        version_factory(
+            addon=complex_addon, channel=amo.RELEASE_CHANNEL_UNLISTED,
+            file_kw={'is_webextension': True})
+        version_factory(addon=complex_addon, file_kw={
+            'status': amo.STATUS_AWAITING_REVIEW})
+
+        # Finally, add a second file to self.version to test the distinct().
+        file_factory(
+            version=self.version, status=amo.STATUS_AWAITING_REVIEW,
+            is_webextension=True)
+
+        # Gather the candidates.
+        command = auto_approve.Command()
+        qs = command.fetch_candidates()
+
+        # Only self.version should be found, once.
+        assert len(qs) == 1
+        assert qs[0] == self.version
+
+    @mock.patch.object(AutoApprovalSummary, 'create_summary_for_version')
+    def test_skip_if_admin_review(self, create_summary_for_version_mock):
+        self.addon.update(admin_review=True)
+        call_command('auto_approve')
+        assert create_summary_for_version_mock.call_count == 0
+        assert get_reviewing_cache(self.addon.pk) is None
+        self._check_stats({'total': 1, 'flagged': 1})
+
+    @mock.patch.object(AutoApprovalSummary, 'create_summary_for_version')
+    def test_skip_if_has_info_request(self, create_summary_for_version_mock):
+        self.version.update(has_info_request=True)
+        call_command('auto_approve')
+        assert create_summary_for_version_mock.call_count == 0
+        assert get_reviewing_cache(self.addon.pk) is None
+        self._check_stats({'total': 1, 'flagged': 1})
+
+    def test_full(self):
+        # Simple integration test.
+        assert not AutoApprovalSummary.objects.exists()
+        call_command('auto_approve', '--dry-run')
+        call_command('auto_approve')
+        assert AutoApprovalSummary.objects.count() == 1
+        assert AutoApprovalSummary.objects.get(version=self.version)
+        assert get_reviewing_cache(self.addon.pk) is None
+
+    @mock.patch.object(AutoApprovalSummary, 'create_summary_for_version')
+    def test_already_locked(self, create_summary_for_version_mock):
+        # Test that when an add-on is locked, we handle that gracefully, not
+        # touching it.
+        set_reviewing_cache(self.addon.pk, 666)
+        call_command('auto_approve')
+        assert get_reviewing_cache(self.addon.pk) == 666
+        assert create_summary_for_version_mock.call_count == 0
+        self._check_stats({'total': 1, 'locked': 1})
+
+    @mock.patch.object(auto_approve, 'set_reviewing_cache')
+    @mock.patch.object(auto_approve, 'clear_reviewing_cache')
+    @mock.patch.object(AutoApprovalSummary, 'create_summary_for_version')
+    def test_locking(
+            self, create_summary_for_version_mock, clear_reviewing_cache_mock,
+            set_reviewing_cache_mock):
+        create_summary_for_version_mock.return_value = (
+            AutoApprovalSummary(), {})
+        call_command('auto_approve')
+        assert create_summary_for_version_mock.call_count == 1
+        assert set_reviewing_cache_mock.call_count == 1
+        assert set_reviewing_cache_mock.call_args == (
+            (self.addon.pk, settings.TASK_USER_ID), {})
+        assert clear_reviewing_cache_mock.call_count == 1
+        assert clear_reviewing_cache_mock.call_args == ((self.addon.pk,), {})
+
+    @mock.patch.object(AutoApprovalSummary, 'create_summary_for_version')
+    def test_not_enough_files_error(self, create_summary_for_version_mock):
+        create_summary_for_version_mock.side_effect = (
+            AutoApprovalNotEnoughFilesError)
+        call_command('auto_approve')
+        assert get_reviewing_cache(self.addon.pk) is None
+        assert create_summary_for_version_mock.call_count == 1
+        self._check_stats({'total': 1, 'error': 1})
+
+    @mock.patch.object(AutoApprovalSummary, 'create_summary_for_version')
+    def test_no_validation_result(self, create_summary_for_version_mock):
+        create_summary_for_version_mock.side_effect = (
+            AutoApprovalNoValidationResultError)
+        call_command('auto_approve')
+        assert get_reviewing_cache(self.addon.pk) is None
+        assert create_summary_for_version_mock.call_count == 1
+        self._check_stats({'total': 1, 'error': 1})
+
+    @mock.patch.object(AutoApprovalSummary, 'create_summary_for_version')
+    def test_successful_verdict_dry_run(self, create_summary_for_version_mock):
+        create_summary_for_version_mock.return_value = (
+            AutoApprovalSummary(verdict=amo.WOULD_HAVE_BEEN_AUTO_APPROVED), {})
+        call_command('auto_approve', '--dry-run')
+        assert create_summary_for_version_mock.call_args == (
+            (self.version, ),
+            {'max_average_daily_users': 10000, 'min_approved_updates': 1,
+             'dry_run': True})
+        assert get_reviewing_cache(self.addon.pk) is None
+        self._check_stats({'total': 1, 'auto_approved': 1})
+
+    @mock.patch.object(AutoApprovalSummary, 'create_summary_for_version')
+    def test_successful_verdict(self, create_summary_for_version_mock):
+        create_summary_for_version_mock.return_value = (
+            AutoApprovalSummary(verdict=amo.AUTO_APPROVED), {})
+        call_command('auto_approve')
+        assert create_summary_for_version_mock.call_args == (
+            (self.version, ),
+            {'max_average_daily_users': 10000, 'min_approved_updates': 1,
+             'dry_run': False})
+        assert get_reviewing_cache(self.addon.pk) is None
+        self._check_stats({'total': 1, 'auto_approved': 1})
+
+    @mock.patch.object(AutoApprovalSummary, 'create_summary_for_version')
+    def test_failed_verdict(self, create_summary_for_version_mock):
+        fake_verdict_info = {
+            'uses_custom_csp': True,
+            'uses_native_messaging': True,
+            'uses_content_script_for_all_urls': True,
+            'too_many_average_daily_users': True,
+            'too_few_approved_updates': True,
+        }
+        create_summary_for_version_mock.return_value = (
+            AutoApprovalSummary(verdict=amo.NOT_AUTO_APPROVED),
+            fake_verdict_info)
+        call_command('auto_approve')
+        assert create_summary_for_version_mock.call_args == (
+            (self.version, ),
+            {'max_average_daily_users': 10000, 'min_approved_updates': 1,
+             'dry_run': False})
+        assert get_reviewing_cache(self.addon.pk) is None
+        self._check_stats({
+            'total': 1,
+            'uses_custom_csp': 1,
+            'uses_native_messaging': 1,
+            'uses_content_script_for_all_urls': 1,
+            'too_many_average_daily_users': 1,
+            'too_few_approved_updates': 1,
+        })

--- a/src/olympia/migrations/925-add-autoapprovalsummary.sql
+++ b/src/olympia/migrations/925-add-autoapprovalsummary.sql
@@ -1,7 +1,8 @@
+-- Note: if the migration fails for you locally, remove the 'UNSIGNED' next to version_id below.
 CREATE TABLE `editors_autoapprovalsummary` (
     `created` datetime(6) NOT NULL,
     `modified` datetime(6) NOT NULL,
-    `version_id` integer NOT NULL PRIMARY KEY,
+    `version_id` integer UNSIGNED NOT NULL PRIMARY KEY,
     `uses_custom_csp` bool NOT NULL,
     `uses_native_messaging` bool NOT NULL,
     `uses_content_script_for_all_urls` bool NOT NULL,

--- a/src/olympia/migrations/925-add-autoapprovalsummary.sql
+++ b/src/olympia/migrations/925-add-autoapprovalsummary.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `editors_autoapprovalsummary` (
+    `created` datetime(6) NOT NULL,
+    `modified` datetime(6) NOT NULL,
+    `version_id` integer NOT NULL PRIMARY KEY,
+    `uses_custom_csp` bool NOT NULL,
+    `uses_native_messaging` bool NOT NULL,
+    `uses_content_script_for_all_urls` bool NOT NULL,
+    `average_daily_users` integer UNSIGNED NOT NULL,
+    `approved_updates` integer UNSIGNED NOT NULL,
+    `verdict` smallint UNSIGNED NOT NULL
+);
+
+ALTER TABLE `editors_autoapprovalsummary` ADD CONSTRAINT `version_id_refs_id_6d27bb3c` FOREIGN KEY (`version_id`) REFERENCES `versions` (`id`);


### PR DESCRIPTION
Prototype phase of  #4533 

This adds an `auto_approve` management command, which fetches versions from the updates queue, and try to see if they pass the criteria for auto-approval. It stores the result of the tests for each version in
a model for future analysis.

At the moment actual approval action is not implemented yet.