### PR TITLE
Add back missing files form input id in devhub version edit

### DIFF
--- a/src/olympia/devhub/templates/devhub/includes/version_file.html
+++ b/src/olympia/devhub/templates/devhub/includes/version_file.html
@@ -1,6 +1,7 @@
 {% with file = form.instance %}
   <tr>
     <td>
+      {{ form.id }}
       <a href="{{ file.get_url_path('devhub') }}">
         {{ file.pretty_filename() }}</a>
     </td>

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -668,6 +668,9 @@ class TestVersionEditDetails(TestVersionEditBase):
         response = self.client.get(self.url)
         doc = pq(response.content)
         assert not doc('a.add-file')
+        # Make sure the files form is present.
+        assert doc('#id_files-0-id').val() == str(
+            self.version.files.all()[0].pk)
 
     def test_add(self):
         response = self.client.get(self.url)


### PR DESCRIPTION
Fixes regression from 0defb8cc ; that missing input was breaking the view entirely, the file(s) form(s) were considered invalid as a result.

Fix #4889