### PR TITLE
Force update_webext_descriptions to run in the 'addons' queue

### DIFF
--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1114,6 +1114,7 @@ CELERY_ROUTES = {
     'olympia.addons.tasks.update_incompatible_appversions': {
         'queue': 'addons'},
     'olympia.addons.tasks.version_changed': {'queue': 'addons'},
+    'olympia.files.tasks.update_webext_descriptions': {'queue': 'addons'},
 
     # API
     'olympia.api.tasks.process_results': {'queue': 'api'},


### PR DESCRIPTION
(Trying to understand the issue with that task being spawn to many  times - the command that spawns it use chaining, so we want to see how forcing it to use a specific queue changes the behaviour)