### PR TITLE
Update clean_redis.py to clean old keys

### DIFF
--- a/src/olympia/amo/management/commands/clean_redis.py
+++ b/src/olympia/amo/management/commands/clean_redis.py
@@ -52,7 +52,8 @@ def cleanup(master, slave):
             pipe.scard(k)
         try:
             drop = [k for k, size in zip(ks, pipe.execute())
-                    if not k.startswith(settings.CACHE_PREFIX) or 0 < size < MIN or size > MAX]
+                        if not k.startswith(settings.CACHE_PREFIX)
+                            or 0 < size < MIN or size > MAX]
         except RedisError, err:
             log.warning('ignoring pipe.execute() error: {}'.format(err))
             continue

--- a/src/olympia/amo/management/commands/clean_redis.py
+++ b/src/olympia/amo/management/commands/clean_redis.py
@@ -52,7 +52,7 @@ def cleanup(master, slave):
             pipe.scard(k)
         try:
             drop = [k for k, size in zip(ks, pipe.execute())
-                    if 0 < size < MIN or size > MAX]
+                    if not k.startswith(settings.CACHE_PREFIX) or 0 < size < MIN or size > MAX]
         except RedisError, err:
             log.warning('ignoring pipe.execute() error: {}'.format(err))
             continue

--- a/src/olympia/amo/management/commands/clean_redis.py
+++ b/src/olympia/amo/management/commands/clean_redis.py
@@ -52,8 +52,8 @@ def cleanup(master, slave):
             pipe.scard(k)
         try:
             drop = [k for k, size in zip(ks, pipe.execute())
-                        if not k.startswith(settings.CACHE_PREFIX)
-                            or 0 < size < MIN or size > MAX]
+                    if not k.startswith(settings.CACHE_PREFIX) or
+                    0 < size < MIN or size > MAX]
         except RedisError, err:
             log.warning('ignoring pipe.execute() error: {}'.format(err))
             continue


### PR DESCRIPTION
https://github.com/mozilla/addons-server/pull/4228 has made it so that
we don't use fixed key prefix any more. Old key entries that have elements
whose sizes are between 10 and 50 are accumulated overtime. This change
removes all old keys that don't have the current key prefix, no matter the
size of the elements they have.

@jasonthomas r?