### PR TITLE
Assign each user a random identifier to be used in API auth token generation

### DIFF
--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1187,6 +1187,7 @@ CELERY_ROUTES = {
     # Users
     'olympia.users.tasks.delete_photo': {'queue': 'users'},
     'olympia.users.tasks.update_user_ratings_task': {'queue': 'users'},
+    'olympia.users.tasks.generate_secret_for_users': {'queue': 'users'},
 
     # Zadmin
     'olympia.zadmin.tasks.add_validation_jobs': {'queue': 'zadmin'},

--- a/src/olympia/migrations/929-add-user-auth-id.sql
+++ b/src/olympia/migrations/929-add-user-auth-id.sql
@@ -1,0 +1,3 @@
+-- note: the column is added as nullable, a command will backfill values for
+-- existing users.
+ALTER TABLE `users` ADD COLUMN `auth_id` integer UNSIGNED;

--- a/src/olympia/users/management/commands/backfill_auth_id_for_existing_users.py
+++ b/src/olympia/users/management/commands/backfill_auth_id_for_existing_users.py
@@ -1,0 +1,13 @@
+from django.core.management.base import BaseCommand
+
+from olympia.amo.utils import chunked
+from olympia.users.models import UserProfile
+from olympia.users.tasks import generate_auth_id_for_users
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        pks = (UserProfile.objects.filter(auth_id=None)
+                          .values_list('pk', flat=True).order_by('pk'))
+        for chunk in chunked(pks, 1000):
+            generate_auth_id_for_users.delay(chunk)


### PR DESCRIPTION
This just adds the field and the command to backfill it, and does not use it yet.

Fix #4906 