### PR TITLE
Stop celery tsunami

### DIFF
--- a/src/olympia/files/management/commands/update_permissions_from_mc.py
+++ b/src/olympia/files/management/commands/update_permissions_from_mc.py
@@ -22,7 +22,8 @@ class Command(BaseCommand):
 
         central_url = settings.WEBEXT_PERM_DESCRIPTIONS_URL
         locales_url = settings.WEBEXT_PERM_DESCRIPTIONS_LOCALISED_URL
-        amo_locales = [l for l in settings.AMO_LANGUAGES if l != 'en-US']
+        amo_locales = [l for l in settings.AMO_LANGUAGES
+                       if l not in ['en-US', 'dbg']]
         # Fetch canonical en-US descriptions first; then l10n after.
         update_webext_descriptions_all.apply_async(
             args=[(central_url, 'en-US'),

--- a/src/olympia/files/management/commands/update_permissions_from_mc.py
+++ b/src/olympia/files/management/commands/update_permissions_from_mc.py
@@ -4,10 +4,8 @@ from optparse import make_option
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
-from celery import chain
-
 from olympia.files.models import WebextPermissionDescription
-from olympia.files.tasks import update_webext_descriptions
+from olympia.files.tasks import update_webext_descriptions_all
 
 
 class Command(BaseCommand):
@@ -24,10 +22,9 @@ class Command(BaseCommand):
 
         central_url = settings.WEBEXT_PERM_DESCRIPTIONS_URL
         locales_url = settings.WEBEXT_PERM_DESCRIPTIONS_LOCALISED_URL
+        amo_locales = [l for l in settings.AMO_LANGUAGES if l != 'en-US']
         # Fetch canonical en-US descriptions first; then l10n after.
-        tasks = [update_webext_descriptions.s(central_url)] + [
-            update_webext_descriptions.si(
-                locales_url.format(locale=locale),
-                locale=locale, create=False)
-            for locale in settings.AMO_LANGUAGES]
-        chain(tasks)()
+        update_webext_descriptions_all.apply_async(
+            args=[(central_url, 'en-US'),
+                  [(locales_url.format(locale=locale), locale)
+                   for locale in amo_locales]])

--- a/src/olympia/files/tasks.py
+++ b/src/olympia/files/tasks.py
@@ -44,6 +44,16 @@ WEBEXTPERMS_DESCRIPTION_REGEX = r'^webextPerms\.description\.(.+)=(.+)'
 
 @task
 @write
+def update_webext_descriptions_all(primary, additional, **kw):
+    """primary is a (url, locale) tuple; additional is a list of tuples."""
+    url, locale = primary
+    update_webext_descriptions(url, locale)
+    for url, locale in additional:
+        update_webext_descriptions(url, locale, create=False)
+
+
+@task
+@write
 def update_webext_descriptions(url, locale='en-US', create=True, **kw):
     class DummyContextManager(object):
         def __enter__(self):

--- a/src/olympia/files/tasks.py
+++ b/src/olympia/files/tasks.py
@@ -52,8 +52,6 @@ def update_webext_descriptions_all(primary, additional, **kw):
         update_webext_descriptions(url, locale, create=False)
 
 
-@task
-@write
 def update_webext_descriptions(url, locale='en-US', create=True, **kw):
     class DummyContextManager(object):
         def __enter__(self):

--- a/src/olympia/files/tasks.py
+++ b/src/olympia/files/tasks.py
@@ -59,7 +59,7 @@ def update_webext_descriptions(url, locale='en-US', create=True, **kw):
         response.raise_for_status()
     except RequestException as e:
         log.warning('Error retrieving %s: %s' % (url, e))
-        return False
+        return
 
     # We only need to activate the locale for creating new permission objects.
     context = translation.override(locale) if create else DummyContextManager()
@@ -86,4 +86,3 @@ def update_webext_descriptions(url, locale='en-US', create=True, **kw):
                     except WebextPermissionDescription.DoesNotExist:
                         log.warning('No "%s" permission found to update with '
                                     '[%s] locale' % (perm, locale))
-    return True


### PR DESCRIPTION
* flattens chain of tasks into a single task
* removes pointless return values
* doesn't try to get a l10n en-US because we already got it from m-c (and it doesn't exist anyway)