### PR TITLE
Add unlisted review page link to devhub and change review page links.

### DIFF
--- a/src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html
+++ b/src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html
@@ -46,7 +46,9 @@
       {% endif %}
       {% if action_allowed("Addons", "Edit") %}
         <li><a href="{{ url('editors.review', addon.slug) }}">
-          {{ _('Add-on Review') }}</a></li>
+          {{ _('Listed Review Page') }}</a></li>
+        <li><a href="{{ url('editors.review', 'unlisted', addon.slug) }}">
+          {{ _('Unlisted Review Page') }}</a></li>
       {% endif %}
       {% if action_allowed("ReviewerAdminTools", "View") %}
         <li><a href="{{ url('zadmin.addon_manage', addon.slug) }}">

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -559,6 +559,8 @@ class TestEditBasicListed(BaseTestEditBasic):
         assert links.eq(1).attr('href') == reverse(
             'editors.review', args=[self.addon.slug])
         assert links.eq(2).attr('href') == reverse(
+            'editors.review', args=['unlisted', self.addon.slug])
+        assert links.eq(3).attr('href') == reverse(
             'zadmin.addon_manage', args=[self.addon.slug])
 
     def test_not_experimental_flag(self):

--- a/src/olympia/editors/templates/editors/review.html
+++ b/src/olympia/editors/templates/editors/review.html
@@ -251,17 +251,15 @@
   {% if not addon.is_deleted %}
   <strong>{{ _('Actions') }}</strong>
   <ul id="actions-addon">
-    {% if version and addon.has_listed_versions() %}
+    {% if addon.has_listed_versions() %}
       <li><a href="{{ addon.get_url_path() }}">{{ _('View Listing') }}</a></li>
-      {% if version.channel == amo.RELEASE_CHANNEL_LISTED %}
-        {# On the listed review page, show link to unlisted version review if necessary and allowed #}
-        {% if action_allowed('Addons', 'ReviewUnlisted') and addon.has_unlisted_versions() %}
-          <li><a href="{{ url('editors.review', 'unlisted', addon.slug) }}">{{ _('Unlisted Review Page') }}</a></li>
-        {% endif %}
-      {% else %}
-        {# If we are on the unlisted review page, show the link to the listed review page #}
-        <li><a href="{{ url('editors.review', addon.slug) }}">{{ _('Listed Review Page') }}</a></li>
-      {% endif %}
+    {% endif %}
+    {# If we are on the unlisted review page, show the link to the listed review page #}
+    {% if unlisted and addon.has_listed_versions() %}
+      <li><a href="{{ url('editors.review', addon.slug) }}">{{ _('Listed Review Page') }}</a></li>
+    {# On the listed review page, show link to unlisted version review if necessary and allowed #}
+    {% elif action_allowed('Addons', 'ReviewUnlisted') and addon.has_unlisted_versions() %}
+      <li><a href="{{ url('editors.review', 'unlisted', addon.slug) }}">{{ _('Unlisted Review Page') }}</a></li>
     {% endif %}
     {% if is_admin %}
     <li><a href="{{ addon.get_dev_url() }}">{{ _('Edit') }}</a> <em>{{ _('(admin)') }}</em></li>

--- a/src/olympia/editors/templates/editors/review.html
+++ b/src/olympia/editors/templates/editors/review.html
@@ -258,7 +258,7 @@
     {% if unlisted and addon.has_listed_versions() %}
       <li><a href="{{ url('editors.review', addon.slug) }}">{{ _('Listed Review Page') }}</a></li>
     {# On the listed review page, show link to unlisted version review if necessary and allowed #}
-    {% elif action_allowed('Addons', 'ReviewUnlisted') and addon.has_unlisted_versions() %}
+    {% elif not unlisted and action_allowed('Addons', 'ReviewUnlisted') and addon.has_unlisted_versions() %}
       <li><a href="{{ url('editors.review', 'unlisted', addon.slug) }}">{{ _('Unlisted Review Page') }}</a></li>
     {% endif %}
     {% if is_admin %}

--- a/src/olympia/editors/tests/test_views.py
+++ b/src/olympia/editors/tests/test_views.py
@@ -2004,6 +2004,8 @@ class TestReview(ReviewBase):
         self.login_as_admin()
         r = self.client.get(self.url)
         expected = [
+            ('Unlisted Review Page',
+                reverse('editors.review', args=('unlisted', self.addon.slug))),
             ('Edit', self.addon.get_dev_url()),
             ('Admin Page',
                 reverse('zadmin.addon_manage', args=[self.addon.id])),


### PR DESCRIPTION
fixes #4536 and simplifies the logic on the review page so it works in more edge cases (e.g. accessing the listed review page when there aren't any listed versions)