### PR TITLE
Add id to fileviewer metadata

### DIFF
--- a/src/olympia/files/templates/files/viewer.html
+++ b/src/olympia/files/templates/files/viewer.html
@@ -9,6 +9,7 @@
 
 {% block content %}
 <div id="metadata" class="js-hidden"
+     data-id="{{ addon.id }}"
      data-name="{{ addon.name }}"
      data-slug="{{ addon.slug }}"
      data-version="{{ version }}"


### PR DESCRIPTION
In an add-on I am working on it would be great to have the ID of the add-on available in the filebrowser. I can certainly find a workaround in the add-on, but given this is just a one line addition I thought I'd just patch it.