### PR TITLE
Remove nodesource.rep. We install node 6 from EPEL.

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -8,11 +8,10 @@ ENV SWIG_FEATURES="-D__x86_64__"
 ENV OLYMPIA_UID=9500
 RUN useradd -u ${OLYMPIA_UID} -s /sbin/nologin olympia
 
-ADD docker/nodesource.gpg.key /etc/pki/rpm-gpg/RPM-GPG-KEY-nodesource
 ADD docker/git.gpg.key /etc/pki/rpm-gpg/RPM-GPG-KEY-git
 ADD docker/epel.gpg.key /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
 
-ADD docker/nodesource.repo docker/epel.repo /etc/yum.repos.d/
+ADD docker/epel.repo /etc/yum.repos.d/
 ADD docker/git.repo /etc/yum.repos.d/git.repo
 
 RUN yum install -y                                          \


### PR DESCRIPTION
This is related to https://bugzilla.mozilla.org/show_bug.cgi?id=1323994

It sounds like nodesource.repo was set up for node 4. Now that we're using node 6, it can be installed from EPEL.
