### PR TITLE
Log an actual error in sentry for unavailable ES.

### DIFF
--- a/src/olympia/search/middleware.py
+++ b/src/olympia/search/middleware.py
@@ -11,5 +11,5 @@ class ElasticsearchExceptionMiddleware(object):
 
     def process_exception(self, request, exception):
         if issubclass(exception.__class__, TransportError):
-            log.error(u'Elasticsearch error: %s' % exception)
+            log.exception(u'Elasticsearch error')
             return render(request, 'search/down.html', status=503)


### PR DESCRIPTION
We have that for MySQL and it makes sense. Also, logging this as an
`exception` gives us a proper traceback in sentry.