### PR TITLE
Handle and warn properly for invalid opensearch xml.

### DIFF
--- a/src/olympia/files/fixtures/files/search_empty_shortname.xml
+++ b/src/olympia/files/fixtures/files/search_empty_shortname.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+<ShortName></ShortName>
+<Tags>SearchGeek Search Engine</Tags>
+<Description>Search Engine for Firefox</Description>
+<Contact>xxx@yyy.com</Contact>
+<InputEncoding>UTF-8</InputEncoding>
+<SyndicationRight>limited</SyndicationRight>
+<Image width="16" height="16" type="image/x-icon">http://www.yyy.com/favicon.ico</Image>
+<Url type="text/html" template="http://www.yyy.com?q={searchTerms}"/>
+<Url type="application/x-suggestions+json" template="http://www.yyy.net/?query={searchTerms}"/>
+</OpenSearchDescription>

--- a/src/olympia/files/tests/test_utils_.py
+++ b/src/olympia/files/tests/test_utils_.py
@@ -21,6 +21,7 @@ from olympia.applications.models import AppVersion
 from olympia.files import utils
 from olympia.files.models import File
 from olympia.versions.models import Version
+from olympia.files.tests.test_helpers import get_file
 
 
 pytestmark = pytest.mark.django_db
@@ -638,6 +639,17 @@ def test_atomic_lock_lifetime():
 
         with _get_lock() as lock_attained2:
             assert lock_attained2
+
+
+def test_parse_search_empty_shortname():
+    fname = get_file('search_empty_shortname.xml')
+
+    with pytest.raises(forms.ValidationError) as excinfo:
+        utils.parse_search(fname)
+
+    assert (
+        excinfo.value[0] ==
+        'Could not parse uploaded file, missing <ShortName> element')
 
 
 class TestResolvei18nMessage(object):

--- a/src/olympia/files/tests/test_utils_.py
+++ b/src/olympia/files/tests/test_utils_.py
@@ -649,7 +649,7 @@ def test_parse_search_empty_shortname():
 
     assert (
         excinfo.value[0] ==
-        'Could not parse uploaded file, missing <ShortName> element')
+        'Could not parse uploaded file, missing or empty <ShortName> element')
 
 
 class TestResolvei18nMessage(object):

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -398,8 +398,12 @@ def extract_search(content):
     rv = {}
     dom = minidom.parse(content)
 
-    def text(x):
-        return dom.getElementsByTagName(x)[0].childNodes[0].wholeText
+    def text(tag):
+        try:
+            return dom.getElementsByTagName(tag)[0].childNodes[0].wholeText
+        except (IndexError, AttributeError):
+            raise forms.ValidationError(
+                _('Could not parse uploaded file, missing <%s> element') % tag)
 
     rv['name'] = text('ShortName')
     rv['description'] = text('Description')

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -403,7 +403,8 @@ def extract_search(content):
             return dom.getElementsByTagName(tag)[0].childNodes[0].wholeText
         except (IndexError, AttributeError):
             raise forms.ValidationError(
-                _('Could not parse uploaded file, missing <%s> element') % tag)
+                _('Could not parse uploaded file, missing or empty '
+                  '<%s> element') % tag)
 
     rv['name'] = text('ShortName')
     rv['description'] = text('Description')


### PR DESCRIPTION
Fixes #4162

amo-validator validates this but there are cases where we parse the XML
before amo-validator (e.g to get some meta-data) so let's handle that.