### PR TITLE
Removed "session cookie" reference from API docs since that's misleading

### DIFF
--- a/docs/topics/api/auth.rst
+++ b/docs/topics/api/auth.rst
@@ -6,8 +6,8 @@ Authentication (External)
 
 To access the API as an external consumer, you need to include a
 `JSON Web Token (JWT)`_ in the ``Authorization`` header for every request.
-This header authenticates your user account so you could think of it like a
-session cookie.
+This header acts as a one-time token that authenticates your user account.
+No JWT claims are made about the actual API request you are making.
 
 If you are building an app that lives on the AMO domain, read the
 :ref:`documentation for internal authentication <api-auth-internal>` instead.


### PR DESCRIPTION
Using a JWT as a "session cookie" is [frowned upon](http://cryto.net/~joepie91/blog/attachments/jwt-flowchart.png) (and rightly so!). That's not what we do for the external API at all so I wanted to clarify that it's a one-time token.