### PR TITLE
Add API token cookie if it's missing and user is already authenticated when logging in

### DIFF
--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -9,10 +9,10 @@ from django.contrib.messages import get_messages
 from django.core.urlresolvers import resolve, reverse
 from django.test import RequestFactory
 from django.test.utils import override_settings
-import mock
-from waffle.models import Switch
 
+import mock
 from rest_framework.test import APIRequestFactory, APITestCase
+from waffle.models import Switch
 
 from olympia.access.acl import action_allowed_user
 from olympia.access.models import Group, GroupUser
@@ -510,6 +510,32 @@ class TestWithUser(TestCase):
             self.request, views.ERROR_AUTHENTICATED, next_path='/next',
             format='json')
         assert not self.find_user.called
+
+    @mock.patch.object(views, 'generate_api_token', lambda u: 'fake-api-token')
+    def test_already_logged_in_add_api_token_cookie_if_missing(self):
+        self.request.data = {
+            'code': 'foo',
+            'state': 'some-blob:{}'.format(base64.urlsafe_b64encode('/next')),
+        }
+        self.user = UserProfile()
+        self.request.user = self.user
+        assert self.user.is_authenticated()
+        self.request.COOKIES = {}
+        self.fn(self.request)
+        self.render_error.assert_called_with(
+            self.request, views.ERROR_AUTHENTICATED, next_path='/next',
+            format='json')
+        assert not self.find_user.called
+        response = self.render_error.return_value
+        assert response.set_cookie.call_count == 1
+        response.set_cookie.assert_called_with(
+            # Fatal flow: though we are able to set the max age of the cookie,
+            # we aren't setting a different timestamp for the token itself...
+            views.API_TOKEN_COOKIE,
+            'fake-api-token',
+            max_age=settings.SESSION_COOKIE_AGE,
+            secure=settings.SESSION_COOKIE_SECURE,
+            httponly=settings.SESSION_COOKIE_HTTPONLY)
 
     def test_state_does_not_match(self):
         identity = {'uid': '1234', 'email': 'hey@yo.it'}

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -533,8 +533,6 @@ class TestWithUser(TestCase):
         response = self.render_error.return_value
         assert response.set_cookie.call_count == 1
         response.set_cookie.assert_called_with(
-            # Fatal flow: though we are able to set the max age of the cookie,
-            # we aren't setting a different timestamp for the token itself...
             views.API_TOKEN_COOKIE,
             'fake-api-token',
             max_age=settings.SESSION_COOKIE_AGE,

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -204,6 +204,9 @@ def with_user(format, config=None):
                 # If the api token cookie is missing but we're still
                 # authenticated using the session, add it back.
                 if API_TOKEN_COOKIE not in request.COOKIES:
+                    log.info('User %s was already authenticated but did not '
+                             'have an API token cookie, adding one.',
+                             request.user.pk)
                     response = add_api_token_to_response(
                         response, request.user)
                 return response

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -128,7 +128,7 @@ def fxa_error_message(message):
 def render_error(request, error, next_path=None, format=None):
     if format == 'json':
         status = ERROR_STATUSES.get(error, 422)
-        return Response({'error': error}, status=status)
+        response = Response({'error': error}, status=status)
     else:
         if not is_safe_url(next_path):
             next_path = None
@@ -136,9 +136,10 @@ def render_error(request, error, next_path=None, format=None):
             request, fxa_error_message(LOGIN_ERROR_MESSAGES[error]),
             extra_tags='fxa')
         if next_path is None:
-            return HttpResponseRedirect(reverse('users.login'))
+            response = HttpResponseRedirect(reverse('users.login'))
         else:
-            return HttpResponseRedirect(next_path)
+            response = HttpResponseRedirect(next_path)
+    return response
 
 
 def parse_next_path(state_parts):
@@ -197,9 +198,15 @@ def with_user(format, config=None):
                     request, ERROR_STATE_MISMATCH, next_path=next_path,
                     format=format)
             elif request.user.is_authenticated():
-                return render_error(
+                response = render_error(
                     request, ERROR_AUTHENTICATED, next_path=next_path,
                     format=format)
+                # If the api token cookie is missing but we're still
+                # authenticated using the session, add it back.
+                if API_TOKEN_COOKIE not in request.COOKIES:
+                    response = add_api_token_to_response(
+                        response, request.user)
+                return response
             try:
                 identity = verify.fxa_identify(data['code'], config=fxa_config)
             except verify.IdentificationError:
@@ -215,29 +222,36 @@ def with_user(format, config=None):
     return outer
 
 
-def add_api_token_to_response(response, user, set_cookie=True):
-    # Generate API token and add it to the json response.
+def generate_api_token(user):
+    """Generate a new API token for a given user."""
     data = {
         'auth_hash': user.get_session_auth_hash(),
         'user_id': user.pk,
     }
-    token = signing.dumps(data, salt=WebTokenAuthentication.salt)
+    return signing.dumps(data, salt=WebTokenAuthentication.salt)
+
+
+def add_api_token_to_response(response, user):
+    """Generate API token and add it to the response (both as a `token` key in
+    the response if it was json and by setting a cookie named API_TOKEN_COOKIE.
+    """
+    token = generate_api_token(user)
     if hasattr(response, 'data'):
         response.data['token'] = token
-    if set_cookie:
-        # Also include the API token in a session cookie, so that it is
-        # available for universal frontend apps.
-        response.set_cookie(
-            API_TOKEN_COOKIE,
-            token,
-            max_age=settings.SESSION_COOKIE_AGE or None,
-            secure=settings.SESSION_COOKIE_SECURE or None,
-            httponly=settings.SESSION_COOKIE_HTTPONLY or None)
+    # Also include the API token in a session cookie, so that it is
+    # available for universal frontend apps.
+    response.set_cookie(
+        API_TOKEN_COOKIE,
+        token,
+        max_age=settings.SESSION_COOKIE_AGE,
+        secure=settings.SESSION_COOKIE_SECURE,
+        httponly=settings.SESSION_COOKIE_HTTPONLY)
 
     return response
 
 
 def remove_api_token_cookie(response):
+    """Delete the api token cookie."""
     response.delete_cookie(API_TOKEN_COOKIE)
 
 
@@ -284,7 +298,7 @@ class LoginBaseView(FxAConfigMixin, APIView):
         else:
             update_user(user, identity)
             response = Response({'email': identity['email']})
-            add_api_token_to_response(response, user, set_cookie=False)
+            add_api_token_to_response(response, user)
             log.info('Logging in user {} from FxA'.format(user))
             return response
 

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -245,7 +245,7 @@ class InitializeSessionMixin(object):
             'max-age': None,
             'path': '/',
             'domain': settings.SESSION_COOKIE_DOMAIN,
-            'secure': settings.SESSION_COOKIE_SECURE or None,
+            'secure': settings.SESSION_COOKIE_SECURE,
             'expires': None,
         }
         self.client.cookies[session_cookie].update(cookie_data)

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -94,7 +94,6 @@ def addon_listing(request, default='name', theme=False):
 
 
 def index(request):
-
     ctx = {'blog_posts': _get_posts()}
     if request.user.is_authenticated():
         user_addons = Addon.objects.filter(authors=request.user)


### PR DESCRIPTION
Note that the new api token may end up expiring after the session cookie (django's `TimestampSigner` does not allow you to customize the timestamp out of the box. We could implement it but there is very little reason for it, the user did just go through FxA so potentially extending his api token life should not be a problem)

Fix #5017