### PR TITLE
Avoid relying on git commit id to generate the assets build id

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -63,7 +63,7 @@ RUN DJANGO_SETTINGS_MODULE='settings_local' locale/compile-mo.sh locale
 
 # compile asssets
 RUN npm install \
-    && DJANGO_SETTINGS_MODULE='settings_local' python manage.py compress_assets -t \
+    && DJANGO_SETTINGS_MODULE='settings_local' python manage.py compress_assets --use-uuid -t \
     && DJANGO_SETTINGS_MODULE='settings_local' python manage.py collectstatic --noinput
 
 RUN rm -f settings_local.py settings_local.pyc

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ update_assets:
 ifeq ($(IN_DOCKER),)
 	$(warning Command is designed to be run in the container)
 endif
-	python manage.py compress_assets
+	python manage.py compress_assets --use-uuid
 	python manage.py collectstatic --noinput
 
 update_docker:


### PR DESCRIPTION
Relies on the new option added in https://github.com/mozilla/addons-server/pull/5058