### PR TITLE
Add a .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.cache
+logs/*


### PR DESCRIPTION
https://github.com/mozilla/addons-server/pull/5060 removed the git repo
dependency from jingo-minify, we shouldn't carry .git directory into our
container image any more.