### PR TITLE
Remove buildtimetrend webhook, we aren't using it any more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,9 +70,6 @@ notifications:
       - "irc.mozilla.org#amo-bots"
     on_success: change
     on_failure: always
-  webhooks:
-    # trigger Buildtime Trend Service to parse Travis CI log
-    - https://buildtimetrend.herokuapp.com/travis
 
 git:
   depth: 3


### PR DESCRIPTION
We removed the badge in f86377ca934194aa9f62770a08aab6e3789bfbdc