### PR TITLE
Remove addon_total_contributions task: nobody is using the field it updates

### DIFF
--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1195,7 +1195,6 @@ CELERY_ROUTES = {
 
 
     # Stats
-    'olympia.stats.tasks.addon_total_contributions': {'queue': 'stats'},
     'olympia.stats.tasks.index_collection_counts': {'queue': 'stats'},
     'olympia.stats.tasks.index_download_counts': {'queue': 'stats'},
     'olympia.stats.tasks.index_theme_user_counts': {'queue': 'stats'},

--- a/src/olympia/stats/models.py
+++ b/src/olympia/stats/models.py
@@ -250,11 +250,6 @@ class Contribution(amo.models.ModelBase):
             from_email, [to_email], fail_silently=True,
             perm_setting='dev_thanks')
 
-    @staticmethod
-    def post_save(sender, instance, **kwargs):
-        from . import tasks
-        tasks.addon_total_contributions.delay(instance.addon_id)
-
     def get_amount_locale(self, locale=None):
         """Localise the amount paid into the current locale."""
         if not locale:
@@ -263,9 +258,6 @@ class Contribution(amo.models.ModelBase):
         return numbers.format_currency(self.amount or 0,
                                        self.currency or 'USD',
                                        locale=locale)
-
-
-models.signals.post_save.connect(Contribution.post_save, sender=Contribution)
 
 
 class GlobalStat(caching.base.CachingMixin, models.Model):

--- a/src/olympia/stats/tasks.py
+++ b/src/olympia/stats/tasks.py
@@ -17,7 +17,6 @@ from olympia.addons.models import Addon
 from olympia.amo.celery import task
 from olympia.bandwagon.models import Collection
 from olympia.reviews.models import Review
-from olympia.stats.models import Contribution
 from olympia.users.models import UserProfile
 from olympia.versions.models import Version
 
@@ -28,20 +27,6 @@ from .models import (
 
 
 log = olympia.core.logger.getLogger('z.task')
-
-
-@task
-def addon_total_contributions(*addons, **kw):
-    "Updates the total contributions for a given addon."
-
-    log.info('[%s@%s] Updating total contributions.' %
-             (len(addons), addon_total_contributions.rate_limit))
-    # Only count uuid=None; those are verified transactions.
-    stats = (Contribution.objects.filter(addon__in=addons, uuid=None)
-             .values_list('addon').annotate(Sum('amount')))
-
-    for addon, total in stats:
-        Addon.objects.filter(id=addon).update(total_contributions=total)
 
 
 @task


### PR DESCRIPTION
(Not removing the field yet because I don't want to deal with a costly
 migration right now)

Addresses the urgent part of #5069