### PR TITLE
 Provide error codes for failed some API auth responses

### DIFF
--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -62,6 +62,26 @@ Example:
              "non_field_errors": ["Error not linked to a specific field."]
          }
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Unauthorized and Permission Denied
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When returning ``HTTP 401 Unauthorized`` and ``HTTP 403 Permission Denied``
+responses, the API will try to return some information about the error in the
+body of the response, as a JSON object. A ``detail`` property will contain a
+message explaining the error. In addition, in some cases, an optional ``code``
+property will be present and will contain a constant corresponding to
+specific problems to help clients address the situation programmatically. The
+constants are as follows:
+
+    ========================  =========================================================
+                       Value  Description
+    ========================  =========================================================
+        ERROR_INVALID_HEADER  The ``Authorization`` header is invalid.
+     ERROR_SIGNATURE_EXPIRED  The signature of the token indicates it has expired.
+    ERROR_DECODING_SIGNATURE  The token was impossible to decode and probably invalid.
+    ========================  =========================================================
+
 
 ~~~~~~~~~~
 Pagination

--- a/src/olympia/api/authentication.py
+++ b/src/olympia/api/authentication.py
@@ -118,14 +118,13 @@ class WebTokenAuthentication(BaseAuthentication):
         """
         if 'user_id' not in payload:
             log.info('No user_id in token payload {}'.format(payload))
-            raise exceptions.AuthenticationFailed(
-                'No user_id in token payload.')
+            raise exceptions.AuthenticationFailed()
         try:
             user = UserProfile.objects.filter(deleted=False).get(
                 pk=payload['user_id'])
         except UserProfile.DoesNotExist:
             log.info('User not found from token payload {}'.format(payload))
-            raise exceptions.AuthenticationFailed('User not found.')
+            raise exceptions.AuthenticationFailed()
 
         # Check get_session_auth_hash like django's get_user() does.
         session_auth_hash = user.get_session_auth_hash()
@@ -133,8 +132,7 @@ class WebTokenAuthentication(BaseAuthentication):
         if not constant_time_compare(payload_auth_hash, session_auth_hash):
             log.info('User tried to authenticate with invalid auth hash in'
                      'payload {}'.format(payload))
-            raise exceptions.AuthenticationFailed(
-                'Invalid auth hash in token payload.')
+            raise exceptions.AuthenticationFailed()
 
         # Set user in thread like UserAndAddrMiddleware does.
         core.set_user(user)

--- a/src/olympia/api/authentication.py
+++ b/src/olympia/api/authentication.py
@@ -53,11 +53,18 @@ class WebTokenAuthentication(BaseAuthentication):
             return None
 
         if len(auth_header) == 1:
-            msg = _('Invalid Authorization header. No credentials provided.')
+            msg = {
+                'detail': _('Invalid Authorization header. '
+                            'No credentials provided.'),
+                'code': 'ERROR_INVALID_HEADER'
+            }
             raise exceptions.AuthenticationFailed(msg)
         elif len(auth_header) > 2:
-            msg = _('Invalid Authorization header. Credentials string '
-                    'should not contain spaces.')
+            msg = {
+                'detail': _('Invalid Authorization header. Credentials string '
+                            'should not contain spaces.'),
+                'code': 'ERROR_INVALID_HEADER',
+            }
             raise exceptions.AuthenticationFailed(msg)
 
         return auth_header[1]
@@ -83,10 +90,16 @@ class WebTokenAuthentication(BaseAuthentication):
                 token, salt=self.salt,
                 max_age=settings.SESSION_COOKIE_AGE or None)
         except signing.SignatureExpired:
-            msg = 'Signature has expired.'
+            msg = {
+                'detail': _('Signature has expired.'),
+                'code': 'ERROR_SIGNATURE_EXPIRED',
+            }
             raise exceptions.AuthenticationFailed(msg)
         except signing.BadSignature:
-            msg = _('Error decoding signature.')
+            msg = {
+                'detail': _('Error decoding signature.'),
+                'code': 'ERROR_DECODING_SIGNATURE'
+            }
             raise exceptions.AuthenticationFailed(msg)
 
         # We have a valid token, try to find the corresponding user.


### PR DESCRIPTION
Also *remove* some error messages that are really too specific for the users to see - they should just see that the authentication failed in those cases.

Fix #5122