### PR TITLE
Avoid using version.all_files (which is cached) in ReviewBase

### DIFF
--- a/src/olympia/editors/helpers.py
+++ b/src/olympia/editors/helpers.py
@@ -522,9 +522,8 @@ class ReviewBase(object):
                                                  add_prefix=False)),
                 'comments': self.data.get('comments'),
                 'SITE_URL': settings.SITE_URL,
-                'legacy_addon': (
-                    not self.version.all_files[0].is_webextension
-                    if self.version else False)}
+                'legacy_addon':
+                    not self.files[0].is_webextension if self.files else False}
 
     def request_information(self):
         """Send a request for information to the authors."""


### PR DESCRIPTION
We're getting some weird `IndexError` exceptions because `all_files` is empty, and I can't reproduce (or write a test for) it locally. Using `self.files` should be more reliable, the class needs it to sign the files etc.

Fix #5124