### PR TITLE
Allow filtering by exact tag name in the search API

### DIFF
--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -47,6 +47,7 @@ This endpoint allows you to search through public add-ons.
     :query int page: 1-based page number. Defaults to 1.
     :query int page_size: Maximum number of results to return for the requested page. Defaults to 25.
     :query string platform: Filter by :ref:`add-on platform <addon-detail-platform>` availability.
+    :query string tag: Filter by exact tag name. Multiple tag names can be specified, separated by comma(s).
     :query string type: Filter by :ref:`add-on type <addon-detail-type>`.
     :query string sort: The sort parameter. The available parameters are documented in the :ref:`table below <addon-search-sort>`.
     :>json int count: The number of results for this query.

--- a/src/olympia/search/tests/test_filters.py
+++ b/src/olympia/search/tests/test_filters.py
@@ -326,6 +326,16 @@ class TestSearchParameterFilter(FilterTestsBase):
                 data={'category': 666, 'app': 'firefox', 'type': 'extension'})
         assert context.exception.detail == ['Invalid "category" parameter.']
 
+    def test_search_by_tag(self):
+        qs = self._filter(data={'tag': 'foo'})
+        must = qs['query']['filtered']['filter']['bool']['must']
+        assert {'term': {'tags': 'foo'}} in must
+
+        qs = self._filter(data={'tag': 'foo,bar'})
+        must = qs['query']['filtered']['filter']['bool']['must']
+        assert {'term': {'tags': 'foo'}} in must
+        assert {'term': {'tags': 'bar'}} in must
+
 
 class TestInternalSearchParameterFilter(TestSearchParameterFilter):
     filter_classes = [InternalSearchParameterFilter]


### PR DESCRIPTION
Bonus part of #4974 to allow the frontend/any api clients to search for the tag we're going to set on all webextensions.