### PR TITLE
Invert meaning of AddonApprovalsCounter, store last human review date

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1718,7 +1718,8 @@ class AddonApprovalsCounter(ModelBase):
     belonging to an add-on has been auto-approved. Reset everytime a
     listed version is approved by a human for this add-on."""
     addon = models.OneToOneField(
-        Addon, primary_key=True, on_delete=models.CASCADE)
+        Addon, primary_key=True, on_delete=models.CASCADE,
+        related_name='approvalscounter')
     counter = models.PositiveIntegerField(default=0)
     last_human_review = models.DateTimeField(null=True)
 

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1715,11 +1715,12 @@ class AddonFeatureCompatibility(ModelBase):
 
 class AddonApprovalsCounter(ModelBase):
     """Model holding a counter of the number of times a listed version
-    belonging to an add-on has been approved by a human. Reset everytime a
-    listed version is auto-approved for this add-on."""
+    belonging to an add-on has been auto-approved. Reset everytime a
+    listed version is approved by a human for this add-on."""
     addon = models.OneToOneField(
         Addon, primary_key=True, on_delete=models.CASCADE)
     counter = models.PositiveIntegerField(default=0)
+    last_human_review = models.DateTimeField(null=True)
 
     def __unicode__(self):
         return u'%s: %d' % (unicode(self.pk), self.counter) if self.pk else u''
@@ -1740,10 +1741,12 @@ class AddonApprovalsCounter(ModelBase):
     @classmethod
     def reset_for_addon(cls, addon):
         """
-        Reset the approval counter for the specified addon.
+        Reset the approval counter for the specified addon, setting the last
+        human review date to now.
         """
+        now = datetime.now()
         obj, created = cls.objects.update_or_create(
-            addon=addon, defaults={'counter': 0})
+            addon=addon, defaults={'counter': 0, 'last_human_review': now})
         return obj
 
 

--- a/src/olympia/editors/helpers.py
+++ b/src/olympia/editors/helpers.py
@@ -591,8 +591,13 @@ class ReviewBase(object):
         if any(file_.is_webextension for file_ in self.files):
             Tag(tag_text='firefox57').save_tag(self.addon)
 
-        # Increment approvals counter.
-        AddonApprovalsCounter.increment_for_addon(addon=self.addon)
+        # Reset approvals counter if we have a request (it means it's an
+        # human doing the review) otherwise increment it as it's an automatic
+        # approval.
+        if self.request:
+            AddonApprovalsCounter.reset_for_addon(addon=self.addon)
+        else:
+            AddonApprovalsCounter.increment_for_addon(addon=self.addon)
 
         self.log_action(amo.LOG.APPROVE_VERSION)
         template = u'%s_to_public' % self.review_type

--- a/src/olympia/migrations/935-add-last-human-review-date.sql
+++ b/src/olympia/migrations/935-add-last-human-review-date.sql
@@ -1,0 +1,2 @@
+TRUNCATE TABLE `addons_addonapprovalscounter`;
+ALTER TABLE `addons_addonapprovalscounter` ADD COLUMN `last_human_review` datetime(6);

--- a/src/olympia/migrations/936-change-auto-approval-summary-updates-column.sql
+++ b/src/olympia/migrations/936-change-auto-approval-summary-updates-column.sql
@@ -1,0 +1,4 @@
+UPDATE `config` SET `key`="AUTO_APPROVAL_MAX_AUTO_APPROVED_UPDATES" WHERE `key`="AUTO_APPROVAL_MIN_APPROVED_UPDATES";
+TRUNCATE TABLE `editors_autoapprovalsummary`;
+ALTER TABLE `editors_autoapprovalsummary` DROP COLUMN `approved_updates`;
+ALTER TABLE `editors_autoapprovalsummary` ADD COLUMN `auto_approved_updates` integer UNSIGNED NOT NULL;


### PR DESCRIPTION
Fix #5164

The behaviour is now:
- Increment when auto-approved
- Reset when human-approved (setting last_human_review date to now)

This matches the expectations from the PRD (read the issue for the discussion about it). Because the counters are currently wrong for every add-on, reset them all.