### PR TITLE
Fix bonus points for reviews > 7 days

### DIFF
--- a/src/olympia/editors/helpers.py
+++ b/src/olympia/editors/helpers.py
@@ -604,7 +604,8 @@ class ReviewBase(object):
 
         # Assign reviewer incentive scores.
         if self.request:
-            ReviewerScore.award_points(self.request.user, self.addon, status)
+            ReviewerScore.award_points(
+                self.request.user, self.addon, status, version=self.version)
 
     def process_sandbox(self):
         """Set an addon or a version back to sandbox."""
@@ -630,7 +631,8 @@ class ReviewBase(object):
 
         # Assign reviewer incentive scores.
         if self.request:
-            ReviewerScore.award_points(self.request.user, self.addon, status)
+            ReviewerScore.award_points(
+                self.request.user, self.addon, status, version=self.version)
 
     def process_super_review(self):
         """Give an addon super review."""

--- a/src/olympia/editors/tests/test_models.py
+++ b/src/olympia/editors/tests/test_models.py
@@ -418,7 +418,8 @@ class TestReviewerScore(TestCase):
     def _give_points(self, user=None, addon=None, status=None):
         user = user or self.user
         addon = addon or self.addon
-        ReviewerScore.award_points(user, addon, status or addon.status)
+        ReviewerScore.award_points(
+            user, addon, status or addon.status, version=addon.current_version)
 
     def check_event(self, type, status, event, **kwargs):
         self.addon.type = type


### PR DESCRIPTION
The `award_points()` method was looking for the add-on in the queue but it was already gone... instead, pass the version and calculate the waiting time from its nomination date.

Fix #4150