### PR TITLE
Store last human review date in ApprovalsCounter when a human approves an add-on

### DIFF
--- a/src/olympia/editors/helpers.py
+++ b/src/olympia/editors/helpers.py
@@ -591,8 +591,13 @@ class ReviewBase(object):
         if any(file_.is_webextension for file_ in self.files):
             Tag(tag_text='firefox57').save_tag(self.addon)
 
-        # Increment approvals counter.
-        AddonApprovalsCounter.increment_for_addon(addon=self.addon)
+        # Increment approvals counter if we have a request (it means it's an
+        # human doing the review) otherwise reset it as it's an automatic
+        # approval.
+        if self.request:
+            AddonApprovalsCounter.increment_for_addon(addon=self.addon)
+        else:
+            AddonApprovalsCounter.reset_for_addon(addon=self.addon)
 
         self.log_action(amo.LOG.APPROVE_VERSION)
         template = u'%s_to_public' % self.review_type

--- a/src/olympia/editors/helpers.py
+++ b/src/olympia/editors/helpers.py
@@ -591,7 +591,7 @@ class ReviewBase(object):
         if any(file_.is_webextension for file_ in self.files):
             Tag(tag_text='firefox57').save_tag(self.addon)
 
-        # Increment approvals counter if we have a request (it means it's an
+        # Increment approvals counter if we have a request (it means it's a
         # human doing the review) otherwise reset it as it's an automatic
         # approval.
         if self.request:

--- a/src/olympia/editors/tests/test_helpers.py
+++ b/src/olympia/editors/tests/test_helpers.py
@@ -513,9 +513,11 @@ class TestReviewHelper(TestCase):
         assert len(mail.outbox) == 1
         assert mail.outbox[0].subject == '%s Approved' % self.preamble
 
-        # AddonApprovalsCounter counter is now at 1 for this addon.
+        # AddonApprovalsCounter counter is now at 1 for this addon since there
+        # was a human review.
         approval_counter = AddonApprovalsCounter.objects.get(addon=self.addon)
         assert approval_counter.counter == 1
+        self.assertCloseToNow(approval_counter.last_human_review)
 
         assert storage.exists(self.file.file_path)
 
@@ -584,6 +586,39 @@ class TestReviewHelper(TestCase):
         self._check_score(amo.REVIEWED_ADDON_FULL, bonus=4)
 
     @patch('olympia.editors.helpers.sign_file')
+    def test_nomination_to_public_no_request(self, sign_mock):
+        self.request = None
+        sign_mock.reset()
+        self.setup_data(amo.STATUS_NOMINATED)
+        with self.settings(SIGNING_SERVER='full'):
+            self.helper.handler.process_public()
+
+        assert self.addon.status == amo.STATUS_PUBLIC
+        assert self.addon.versions.all()[0].files.all()[0].status == (
+            amo.STATUS_PUBLIC)
+
+        assert len(mail.outbox) == 1
+        assert mail.outbox[0].subject == (
+            '%s Approved' % self.preamble)
+        assert 'has been approved' in mail.outbox[0].body
+
+        # AddonApprovalsCounter counter is now at 0 for this addon since there
+        # was an automatic approval.
+        approval_counter = AddonApprovalsCounter.objects.get(addon=self.addon)
+        assert approval_counter.counter == 0
+        # Since approval counter did not exist for this add-on before, the last
+        # human review field should be empty.
+        assert approval_counter.last_human_review is None
+
+        sign_mock.assert_called_with(self.file, 'full')
+        assert storage.exists(self.file.file_path)
+
+        assert self.check_log_count(amo.LOG.APPROVE_VERSION.id) == 1
+
+        # No request, no user, therefore no score.
+        assert ReviewerScore.objects.count() == 0
+
+    @patch('olympia.editors.helpers.sign_file')
     def test_public_addon_with_version_awaiting_review_to_public(
             self, sign_mock):
         sign_mock.reset()
@@ -596,7 +631,8 @@ class TestReviewHelper(TestCase):
         self.file = self.version.files.all()[0]
         self.setup_data(amo.STATUS_PUBLIC)
         self.create_paths()
-        AddonApprovalsCounter.objects.create(addon=self.addon, counter=1)
+        AddonApprovalsCounter.objects.create(
+            addon=self.addon, counter=1, last_human_review=self.days_ago(42))
 
         # Safeguards.
         assert isinstance(self.helper.handler, helpers.ReviewFiles)
@@ -619,9 +655,12 @@ class TestReviewHelper(TestCase):
             '%s Approved' % self.preamble)
         assert 'has been approved' in mail.outbox[0].body
 
-        # AddonApprovalsCounter counter is now at 2 for this addon.
+        # AddonApprovalsCounter counter is now at 2 for this addon since there
+        # was another human review. The last human review date should have been
+        # updated.
         approval_counter = AddonApprovalsCounter.objects.get(addon=self.addon)
         assert approval_counter.counter == 2
+        self.assertCloseToNow(approval_counter.last_human_review)
 
         sign_mock.assert_called_with(self.file, 'full')
         assert storage.exists(self.file.file_path)

--- a/src/olympia/migrations/935-add-last-human-review-date.sql
+++ b/src/olympia/migrations/935-add-last-human-review-date.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `addons_addonapprovalscounter` ADD COLUMN `last_human_review` datetime(6);


### PR DESCRIPTION
Fix #5164 

Don't invert the behavior this time, just implement reset when it's auto-approved as it was originally intended, and add the last human review date.