### PR TITLE
Lower git clone --depth to 1, speedup travis builds by almost 50s

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,4 +72,4 @@ notifications:
     on_failure: always
 
 git:
-  depth: 3
+  depth: 1


### PR DESCRIPTION
Might be weird for merge-buils but I kinda doubt that tbh