### PR TITLE
Add waffle switch to allow/disallow static themes.

### DIFF
--- a/src/olympia/files/tests/test_utils_.py
+++ b/src/olympia/files/tests/test_utils_.py
@@ -264,6 +264,10 @@ class TestManifestJSONExtractor(TestCase):
         with pytest.raises(forms.ValidationError) as exc:
             utils.check_xpi_info(manifest)
 
+        assert (
+            exc.value.message ==
+            'WebExtension theme uploads are currently not supported.')
+
     def test_allow_static_theme_waffle(self):
         create_switch('allow-static-theme-uploads')
 

--- a/src/olympia/files/tests/test_utils_.py
+++ b/src/olympia/files/tests/test_utils_.py
@@ -15,7 +15,7 @@ from django import forms
 from defusedxml.common import EntitiesForbidden, NotSupportedError
 
 from olympia import amo
-from olympia.amo.tests import TestCase
+from olympia.amo.tests import TestCase, create_switch
 from olympia.applications.models import AppVersion
 from olympia.files import utils
 from olympia.files.tests.test_helpers import get_file
@@ -256,6 +256,23 @@ class TestManifestJSONExtractor(TestCase):
 
     def test_is_webextension(self):
         assert self.parse({})['is_webextension']
+
+    def test_disallow_static_theme(self):
+        manifest = utils.ManifestJSONExtractor(
+            '/fake_path', '{"theme": {}}').parse()
+
+        with pytest.raises(forms.ValidationError) as exc:
+            utils.check_xpi_info(manifest)
+
+    def test_allow_static_theme_waffle(self):
+        create_switch('allow-static-theme-uploads')
+
+        manifest = utils.ManifestJSONExtractor(
+            '/fake_path', '{"theme": {}}').parse()
+
+        utils.check_xpi_info(manifest)
+
+        assert self.parse({'theme': {}})['is_static_theme']
 
     def test_is_e10s_compatible(self):
         data = self.parse({})

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -390,6 +390,7 @@ class ManifestJSONExtractor(object):
             'default_locale': self.get('default_locale'),
             'permissions': self.get('permissions', []),
             'content_scripts': self.get('content_scripts', []),
+            'is_static_theme': 'theme' in self.data
         }
 
 
@@ -713,6 +714,12 @@ def check_xpi_info(xpi_info, addon=None):
         raise forms.ValidationError(
             _('Version numbers should only contain letters, numbers, '
               'and these punctuation characters: +*.-_.'))
+
+    if is_webextension and xpi_info.get('is_static_theme', False):
+        if not waffle.switch_is_active('allow-static-theme-uploads'):
+            raise forms.ValidationError(
+                _('WebExtension theme uploads are currently not supported.'))
+
     return xpi_info
 
 

--- a/src/olympia/migrations/936-allow-static-theme-uploads-waffle-switch.sql
+++ b/src/olympia/migrations/936-allow-static-theme-uploads-waffle-switch.sql
@@ -1,0 +1,3 @@
+INSERT INTO waffle_switch (name, active, note, created, modified)
+VALUES ('allow-static-theme-uploads', 0, 'Allow submissions of static themes on AMO.', NOW(), NOW());
+


### PR DESCRIPTION
Fixes mozilla/addons-linter#1213

There's one open question in https://github.com/mozilla/addons-linter/issues/1213#issuecomment-295657175 that needs to be answered before this can be merged.

But I think implementing this directly in AMO is the best way to do this.