### PR TITLE
Fix ActivityLogToken default for uuid column

### DIFF
--- a/src/olympia/activity/models.py
+++ b/src/olympia/activity/models.py
@@ -37,7 +37,7 @@ class ActivityLogToken(ModelBase):
     version = models.ForeignKey(Version, related_name='token')
     user = models.ForeignKey('users.UserProfile',
                              related_name='activity_log_tokens')
-    uuid = models.UUIDField(default=lambda: uuid.uuid4().hex, unique=True)
+    uuid = models.UUIDField(default=uuid.uuid4, unique=True)
     use_count = models.IntegerField(
         default=0,
         help_text='Stores the number of times the token has been used')

--- a/src/olympia/activity/tests/test_models.py
+++ b/src/olympia/activity/tests/test_models.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-# from os import path
+from uuid import UUID
 
 from django.core.urlresolvers import reverse
 
@@ -30,6 +30,10 @@ class TestActivityLogToken(TestCase):
         self.user = user_factory()
         self.token = ActivityLogToken.objects.create(
             version=self.version, user=self.user)
+
+    def test_uuid_is_automatically_created(self):
+        assert self.token.uuid
+        assert isinstance(self.token.uuid, UUID)
 
     def test_validity_use_expiry(self):
         assert self.token.use_count == 0

--- a/src/olympia/activity/utils.py
+++ b/src/olympia/activity/utils.py
@@ -223,8 +223,6 @@ def send_activity_mail(subject, message, version, recipients, from_email,
         if not created:
             token.update(use_count=0)
         else:
-            # We need .uuid to be a real UUID not just a str.
-            token.reload()
             log.info('Created token with UUID %s for user: %s.' % (
                 token.uuid, recipient.id))
         reply_to = "%s%s@%s" % (


### PR DESCRIPTION
Defaulting to the `hex()` format kinda works (the field does handle that case when writing to the db), but is unexpected, forces us to reload token from database to get the `UUID()` instance.

Using `default=uuid.uuid4` is [the recommended way of doing that in django docs](https://docs.djangoproject.com/en/1.11/ref/models/fields/#uuidfield).

Fix #5214