### PR TITLE
Fix #4751: No name in "Reviews This Month" from Reviewer Tools for an user without display name set

### DIFF
--- a/src/olympia/editors/templates/editors/home.html
+++ b/src/olympia/editors/templates/editors/home.html
@@ -58,7 +58,7 @@
             <table>
               {% for row in reviews_total: %}
               <tr>
-                <td>{{ row['user__display_name'] }}</td>
+                <td>{{ row['user__name'] }}</td>
                 <td class="int">{{ row['approval_count']|numberfmt }}</td>
               </tr>
               {% endfor %}
@@ -73,7 +73,7 @@
             <table>
               {% for row in reviews_monthly: %}
               <tr>
-                <td>{{ row['user__display_name'] }}</td>
+                <td>{{ row['user__name'] }}</td>
                 <td class="int">{{ row['approval_count']|numberfmt }}</td>
               </tr>
               {% endfor %}
@@ -90,7 +90,7 @@
               <tr>
                 <td>
                   <a href="{{ url('users.profile', editors['user'].username) }}">
-                    {{ editors['user'].display_name }}
+                    {{ editors['user'].name }}
                   </a>
                 </td>
                 <td class="date" title="{{ editors['created']|babel_datetime }}">

--- a/src/olympia/editors/templates/editors/home.html
+++ b/src/olympia/editors/templates/editors/home.html
@@ -58,11 +58,7 @@
             <table>
               {% for row in reviews_total: %}
               <tr>
-                {% if row['user__display_name'] != '' %}
-                <td>{{ row['user__display_name'] }}</td>
-                {% else %}
-                <td>{{ row['user__username'] }}</td>
-                {% endif %}
+                <td>{{ row['user__display_name'] or row['user__username'] }}</td>
                 <td class="int">{{ row['approval_count']|numberfmt }}</td>
               </tr>
               {% endfor %}
@@ -77,11 +73,7 @@
             <table>
               {% for row in reviews_monthly: %}
               <tr>
-                {% if row['user__display_name'] != '' %}
-                <td>{{ row['user__display_name'] }}</td>
-                {% else %}
-                <td>{{ row['user__username'] }}</td>
-                {% endif %}
+                <td>{{ row['user__display_name'] or row['user__username'] }}</td>
                 <td class="int">{{ row['approval_count']|numberfmt }}</td>
               </tr>
               {% endfor %}

--- a/src/olympia/editors/templates/editors/home.html
+++ b/src/olympia/editors/templates/editors/home.html
@@ -58,7 +58,11 @@
             <table>
               {% for row in reviews_total: %}
               <tr>
-                <td>{{ row['user__name'] }}</td>
+                {% if row['user__display_name'] != '' %}
+                <td>{{ row['user__display_name'] }}</td>
+                {% else %}
+                <td>{{ row['user__username'] }}</td>
+                {% endif %}
                 <td class="int">{{ row['approval_count']|numberfmt }}</td>
               </tr>
               {% endfor %}
@@ -73,7 +77,11 @@
             <table>
               {% for row in reviews_monthly: %}
               <tr>
-                <td>{{ row['user__name'] }}</td>
+                {% if row['user__display_name'] != '' %}
+                <td>{{ row['user__display_name'] }}</td>
+                {% else %}
+                <td>{{ row['user__username'] }}</td>
+                {% endif %}
                 <td class="int">{{ row['approval_count']|numberfmt }}</td>
               </tr>
               {% endfor %}

--- a/src/olympia/editors/tests/test_views.py
+++ b/src/olympia/editors/tests/test_views.py
@@ -572,7 +572,9 @@ class TestHome(EditorTest):
         doc = pq(self.client.get(self.url).content)
         cols = doc('#editors-stats .editor-stats-table').eq(1).find('td')
         assert cols.eq(0).text() != self.user.display_name
-        assert cols.eq(0).text() != self.user.name
+        assert cols.eq(0).text() == self.user.name
+
+
 
 class QueueTest(EditorTest):
     fixtures = ['base/users']

--- a/src/olympia/editors/tests/test_views.py
+++ b/src/olympia/editors/tests/test_views.py
@@ -564,6 +564,15 @@ class TestHome(EditorTest):
         listed_stats = doc('#editors-stats-charts {0}'.format(selector)).eq(0)
         assert 'New Add-on (1)' in listed_stats.text()
 
+    def test_stat_display_name(self):
+        self.user.display_name = ''
+        core.set_user(self.user)
+        self.approve_reviews()
+
+        doc = pq(self.client.get(self.url).content)
+        cols = doc('#editors-stats .editor-stats-table').eq(1).find('td')
+        assert cols.eq(0).text() != self.user.display_name
+        assert cols.eq(0).text() != self.user.name
 
 class QueueTest(EditorTest):
     fixtures = ['base/users']

--- a/src/olympia/editors/tests/test_views.py
+++ b/src/olympia/editors/tests/test_views.py
@@ -575,7 +575,6 @@ class TestHome(EditorTest):
         assert cols.eq(0).text() == self.user.name
 
 
-
 class QueueTest(EditorTest):
     fixtures = ['base/users']
     listed = True


### PR DESCRIPTION
Fix #4751

i have changed the display_name to name to fallback if display name is empty.
But when i run "tests editors/test_view.py::test_stats_total" fails, the cols.eq(0).text() is returning a blank string (”). 