### PR TITLE
Fix spacing between modal window buttons (Fixes #4571)

### DIFF
--- a/src/olympia/translations/templates/translations/trans-menu.html
+++ b/src/olympia/translations/templates/translations/trans-menu.html
@@ -44,7 +44,7 @@
       Would you like to save your changes before switching locales?
     {% endtrans %}
     </p>
-    <p class="listing-footer modal-actions">
+    <p class="modal-actions">
       <button id="l10n-save-changes" class="button">{{ _('Save Changes') }}</button>
       <button id="l10n-discard-changes" class="button">{{ _('Discard Changes') }}</button>
       {{ _('or') }} <a id="l10n-cancel-changes" href="#">{{ _('Cancel') }}</a>


### PR DESCRIPTION
- Removes the listing-footer class which essentially removes the "float:left;" style
  from the <p> tag which was causing the display to be ugly.
- Fixes https://github.com/mozilla/addons-server/issues/4571