### PR TITLE
Revert "Fixes issue #3514: "Continue to download" button for experimental add…"

### DIFF
--- a/src/olympia/addons/buttons.py
+++ b/src/olympia/addons/buttons.py
@@ -206,6 +206,7 @@ class UnreviewedInstallButton(InstallButton):
 
 class ExperimentalInstallButton(InstallButton):
     install_class = ['lite']
+    button_class = ['caution']
     install_text = pgettext_lazy('install_button', u'Experimental')
 
 

--- a/src/olympia/addons/tests/test_buttons.py
+++ b/src/olympia/addons/tests/test_buttons.py
@@ -257,7 +257,7 @@ class TestButton(ButtonTest):
         b = self.get_button()
         assert not b.featured
         assert b.experimental
-        assert b.button_class == ['download']
+        assert b.button_class == ['caution']
         assert b.install_class == ['lite']
         assert b.install_text == 'Experimental'
 


### PR DESCRIPTION
Reverts mozilla/addons-server#5080
[
According to QA](https://github.com/mozilla/addons-server/issues/3514#issuecomment-296567386), this is not behaving as intended, affecting regular download button for experimental add-ons instead of just the continue to download roadblock button ; reverting so that it does not land in the next push.