### PR TITLE
Blind attempt to fix paypal API breakage - use "true" instead of "TRUE"

### DIFF
--- a/src/olympia/paypal/__init__.py
+++ b/src/olympia/paypal/__init__.py
@@ -93,6 +93,9 @@ def get_paykey(data):
     memo: any nice message (optional)
     qs: anything you want to append to the complete or cancel (optional)
     currency: valid paypal currency, defaults to USD (optional)
+
+    API Docs from Paypal are at :
+    https://developer.paypal.com/docs/classic/api/adaptive-payments/ ("Pay").
     """
     if data['pattern']:
         complete = reverse(data['pattern'], args=[data['slug'], 'complete'])

--- a/src/olympia/paypal/__init__.py
+++ b/src/olympia/paypal/__init__.py
@@ -116,7 +116,7 @@ def get_paykey(data):
         'receiverList.receiver(0).email': data['email'],
         'receiverList.receiver(0).amount': data['amount'],
         'receiverList.receiver(0).invoiceID': 'mozilla-%s' % data['uuid'],
-        'receiverList.receiver(0).primary': 'TRUE',
+        'receiverList.receiver(0).primary': 'true',
         'receiverList.receiver(0).paymentType': 'DIGITALGOODS',
         'requestEnvelope.errorLanguage': 'US'
     }


### PR DESCRIPTION
We're seeing:
`Paypal Error (580001): Invalid request: Data validation warning (line -1, col 0): String "TRUE" is not valid boolean value.`

The [paypal docs](https://developer.paypal.com/docs/classic/api/adaptive-payments/Pay_API_Operation/) seem to indicate boolean values should be lowercase, so trying to change this to see if it helps.



#5128