### PR TITLE
Remove bogus primary property from paypal API call

### DIFF
--- a/src/olympia/paypal/__init__.py
+++ b/src/olympia/paypal/__init__.py
@@ -119,7 +119,6 @@ def get_paykey(data):
         'receiverList.receiver(0).email': data['email'],
         'receiverList.receiver(0).amount': data['amount'],
         'receiverList.receiver(0).invoiceID': 'mozilla-%s' % data['uuid'],
-        'receiverList.receiver(0).primary': 'true',
         'receiverList.receiver(0).paymentType': 'DIGITALGOODS',
         'requestEnvelope.errorLanguage': 'US'
     }

--- a/src/olympia/paypal/tests/test.py
+++ b/src/olympia/paypal/tests/test.py
@@ -81,7 +81,6 @@ class TestPayKey(TestCase):
             u'receiverList.receiver(0).invoiceID':
                 u'mozilla-%s' % self.data['uuid'],
             u'receiverList.receiver(0).paymentType': u'DIGITALGOODS',
-            u'receiverList.receiver(0).primary': u'true',
             u'requestEnvelope.errorLanguage': u'US',
             'returnUrl': (
                 u'%s/en-US/firefox/addon/xx/contribute/complete?uuid=%s' %


### PR DESCRIPTION
The docs indicate:
> Set to true to indicate a chained payment; only one
> receiver can be a primary receiver. Omit this field,
> or set it to false for simple and parallel payments.

I suspect it was just ignored when we were passing `"TRUE"`, and it should be false or just omitted. We don't provide a secondary recipient anyway.

I manually tested this change on a shell on dev and it appears to unbreak things, at least I can get a successful response from paypal sandbox. Don't know if that fixes the whole flow but it seems promising.

#5128