### PR TITLE
Update link used in WebExtensions label on detail page/listings

### DIFF
--- a/src/olympia/addons/templates/addons/macros.html
+++ b/src/olympia/addons/templates/addons/macros.html
@@ -41,7 +41,7 @@
       {% if version.requires_restart %}
         <span class="requires-restart">{{ _('Requires Restart') }}</span>
       {% elif version.is_webextension %}
-        <a href="{{ url('pages.webextensions_info') }}" class="is-webextension" title="{{ _('This add-on is built with new technology that is compatible with Firefox 57 and beyond.') }}">{{ _('Compatible with Firefox 57+') }}</a>
+        <a href="https://support.mozilla.org/kb/firefox-add-technology-modernizing" class="is-webextension" title="{{ _('This add-on is built with new technology that is compatible with Firefox 57 and beyond.') }}">{{ _('Compatible with Firefox 57+') }}</a>
       {% endif %}
     {% endif %}
 {% endmacro %}

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -997,7 +997,10 @@ class TestDetailPage(TestCase):
         response = self.client.get(self.url)
         doc = pq(response.content)
         link = doc('a.is-webextension')
-        assert link.attr['href'] == reverse('pages.webextensions_info')
+        assert (
+            link.attr['href'] ==
+            'https://support.mozilla.org/kb/firefox-add-technology-modernizing'
+        )
 
     def test_version_displayed(self):
         response = self.client.get(self.url)

--- a/src/olympia/pages/tests.py
+++ b/src/olympia/pages/tests.py
@@ -50,18 +50,3 @@ class TestRedirects(TestCase):
                             follow=False)
         self.assert3xx(r, reverse(
             'devhub.docs', args=['policies/agreement']), 301)
-
-    def test_webextensions_info_redirect(self):
-        assert (reverse('pages.webextensions_info') ==
-                '/en-US/firefox/pages/webextensions_info')
-        self._check({
-            '/en-US/firefox/pages/webextensions_info':
-                'https://support.mozilla.org/kb/webextensions-en-us',
-            '/fr/firefox/pages/webextensions_info':
-                'https://support.mozilla.org/kb/webextensions-fr',
-            '/zh-CN/firefox/pages/webextensions_info':
-                'https://support.mozilla.org/kb/webextensions-zh-cn',
-            # Unsupported locale for this page, it should use en-US instead.
-            '/sv-SE/firefox/pages/webextensions_info':
-                'https://support.mozilla.org/kb/webextensions-en-us',
-        })

--- a/src/olympia/pages/urls.py
+++ b/src/olympia/pages/urls.py
@@ -74,9 +74,6 @@ urlpatterns = patterns(
     url('^pages/validation$',
         lambda r: perma_redirect(settings.VALIDATION_FAQ_URL)),
 
-    url('^pages/webextensions_info$', views.webextensions_info,
-        name='pages.webextensions_info'),
-
     url('^sunbird$',
         TemplateView.as_view(template_name='pages/sunbird.html'),
         name='pages.sunbird'),

--- a/src/olympia/pages/views.py
+++ b/src/olympia/pages/views.py
@@ -2,11 +2,10 @@ from collections import defaultdict
 
 from django.conf import settings
 from django.db.transaction import non_atomic_requests
-from django.http import HttpResponsePermanentRedirect
 
 from olympia.activity.models import ActivityLog
 from olympia.users.models import UserProfile
-from olympia.amo.utils import find_language, render
+from olympia.amo.utils import render
 
 
 @non_atomic_requests
@@ -73,17 +72,3 @@ def credits(request):
     }
 
     return render(request, 'pages/credits.html', context)
-
-
-@non_atomic_requests
-def webextensions_info(request):
-    """Redirect to the support page for webextensions in the right locale (
-    defaulting to english if there isn't one)."""
-    supported_languages = (
-        'de', 'en-US', 'es', 'fr', 'ja', 'pl', 'pt-PT', 'ru', 'zh-CN'
-    )
-    lang = find_language(request.LANG)
-    if lang not in supported_languages:
-        lang = 'en-US'
-    url = 'https://support.mozilla.org/kb/webextensions-%s' % (lang.lower())
-    return HttpResponsePermanentRedirect(url)


### PR DESCRIPTION
This new link will handle localization automatically, we no longer need to do it ourselves.

Fix #4974