### PR TITLE
Don't allow legacy extensions strictly targeting 53a1 to bypass the restriction

### DIFF
--- a/src/olympia/devhub/tasks.py
+++ b/src/olympia/devhub/tasks.py
@@ -289,7 +289,7 @@ def annotate_new_legacy_addon_restrictions(results):
         # the validator should have complained about the non-existant max
         # version, but it doesn't hurt to check that the value is sane anyway.
         max_target_firefox_version > 200100 and
-        max_target_firefox_version < 53000000200100
+        max_target_firefox_version < 53000000000000
     )
 
     if (is_extension_type and

--- a/src/olympia/devhub/tests/test_tasks.py
+++ b/src/olympia/devhub/tests/test_tasks.py
@@ -781,6 +781,27 @@ class TestNewLegacyAddonRestrictions(ValidatorTestCase):
         assert upload.processed_validation['messages'] == []
         assert upload.valid
 
+    def test_restrict_firefox_53_alpha(self):
+        data = {
+            'messages': [],
+            'errors': 0,
+            'metadata': {
+                'is_webextension': False,
+                'is_extension': True,
+                'strict_compatibility': True,
+                'applications': {
+                    'firefox': {
+                        'max': '53a1'
+                    }
+                }
+            }
+        }
+        results = tasks.annotate_new_legacy_addon_restrictions(data)
+        assert results['errors'] == 1
+        assert len(results['messages']) > 0
+        assert results['messages'][0]['id'] == [
+            'validation', 'messages', 'legacy_extensions_restricted']
+
 
 @mock.patch('olympia.devhub.tasks.send_html_mail_jinja')
 def test_send_welcome_email(send_html_mail_jinja_mock):


### PR DESCRIPTION
Fix #5118