### PR TITLE
Fix review page when a version has been hard-deleted

### DIFF
--- a/src/olympia/editors/tests/test_views.py
+++ b/src/olympia/editors/tests/test_views.py
@@ -2771,6 +2771,18 @@ class TestReviewPending(ReviewBase):
         assert mock_sign.called
 
     def test_auto_approval_summary(self):
+        # Hard-delete a version, faking the right ActivityLog so that the view
+        # creates a PseudoVersion instance...
+        deleted_version = version_factory(addon=self.addon)
+        ActivityLog.create(
+            amo.LOG.REJECT_VERSION, self.addon,
+            version=deleted_version, details={
+                'comments': u'Eh, thîs is a deleted version'
+            }, user=user_factory(),
+        )
+        deleted_version.delete(hard=True)
+
+        # Now auto-approve the regular version left.
         AutoApprovalSummary.objects.create(
             version=self.version,
             verdict=amo.NOT_AUTO_APPROVED,

--- a/src/olympia/editors/views.py
+++ b/src/olympia/editors/views.py
@@ -589,6 +589,7 @@ def _get_comments_for_hard_deleted_versions(addon):
         status = 'Deleted'
         deleted = True
         channel = amo.RELEASE_CHANNEL_LISTED
+        is_ready_for_auto_approval = False
 
         @property
         def created(self):


### PR DESCRIPTION
`PseudoVersion` was missing `is_ready_for_auto_approval` property, so the review page was 500ing for senior editors viewing a review page with hard-deleted versions.

Fix #5312