### PR TITLE
Display recent user reviews and abuse reports in review page

### DIFF
--- a/src/olympia/editors/templates/editors/abuse_reports.html
+++ b/src/olympia/editors/templates/editors/abuse_reports.html
@@ -5,24 +5,7 @@
 {% endblock %}
 
 {% block content %}
-<h2>{{_('Abuse Reports for {addon} ({num})')|fe(addon=addon.name, num=total|numberfmt) }}</h2>
-<ul>
-  {% for report in reports %}
-  <li>
-    {% with date=report.created|datetime, ip_address=report.ip_address %}
-      {% if report.reporter %}
-        {% trans user=report.reporter|user_link %}
-          {{ user }} on {{ date }} [{{ ip_address }}]
-        {% endtrans %}
-      {% else %}
-        {% trans %}
-          <i>anonymous</i> on {{ date }} [{{ ip_address }}]
-        {% endtrans %}
-      {% endif %}
-    {% endwith %}
-    <blockquote>{{ report.message }}</blockquote>
-  </li>
-  {% endfor %}
-</ul>
-{{ reports|paginator }}
+  <h2>{{_('Abuse Reports for {addon} ({num})')|fe(addon=addon.name, num=reports.paginator.count|numberfmt) }}</h2>
+  {% include "editors/includes/abuse_reports_list.html" %}
+  {{ reports|paginator }}
 {% endblock %}

--- a/src/olympia/editors/templates/editors/addon_details_box.html
+++ b/src/olympia/editors/templates/editors/addon_details_box.html
@@ -183,14 +183,14 @@
     </div>{# /featured-inner #}
   </div>{# /featured #}
 
-  {% if is_post_reviewer and addon.status == amo.STATUS_PUBLIC %}
+  {% if is_post_reviewer and was_auto_approved %}
     {% if reports %}
       <h3><a href="{{ url('editors.abuse_reports', addon.slug) }}">{{_('Abuse Reports ({num})')|fe(num=reports.paginator.count|numberfmt) }}</a></h3>
       {% include "editors/includes/abuse_reports_list.html" %}
     {% endif %}
 
     {% if user_reviews %}
-      <h3><a href="{{ url('addons.reviews.list', addon.slug) }}">{{_('User Reviews ({num})')|fe(num=addon.total_reviews|numberfmt) }}</a></h3>
+      <h3><a href="{{ url('addons.reviews.list', addon.slug) }}">{{_('Bad User Reviews ({num})')|fe(num=user_reviews.paginator.count|numberfmt) }}</a></h3>
       {% include "editors/includes/user_reviews_list.html" %}
     {% endif %}
   {% endif %}

--- a/src/olympia/editors/templates/editors/addon_details_box.html
+++ b/src/olympia/editors/templates/editors/addon_details_box.html
@@ -111,15 +111,16 @@
                   </td>
                 </tr>
               {% endif %}
+              {% if reports %}
               <tr class="meta-abuse">
                 <th>{{ _('Abuse Reports') }}</th>
                 <td>
-                  {% if addon.has_listed_versions() %}
-                    <a href="{{ url('editors.abuse_reports', addon.slug) }}">{% endif %}
-                    <strong>{{ addon.abuse_reports.count()|numberfmt }}</strong>
-                  {% if addon.has_listed_versions() %}</a>{% endif %}
+                    <a href="{{ url('editors.abuse_reports', addon.slug) }}">
+                      <strong>{{ reports.paginator.count|numberfmt }}</strong>
+                    </a>
                 </td>
               </tr>
+              {% endif %}
               {% if not show_actions %}
                 {# Show privacy policy / eula if the button isn't shown #}
                 {# (Basically, on the add-on review page) #}
@@ -182,8 +183,20 @@
     </div>{# /featured-inner #}
   </div>{# /featured #}
 
-   {% if addon.description or addon.all_previews|length > 1 or addon.developer_comments or
-         addon.show_beta  %}
+  {% if is_post_reviewer and addon.status == amo.STATUS_PUBLIC %}
+    {% if reports %}
+      <h3><a href="{{ url('editors.abuse_reports', addon.slug) }}">{{_('Abuse Reports ({num})')|fe(num=reports.paginator.count|numberfmt) }}</a></h3>
+      {% include "editors/includes/abuse_reports_list.html" %}
+    {% endif %}
+
+    {% if user_reviews %}
+      <h3><a href="{{ url('addons.reviews.list', addon.slug) }}">{{_('User Reviews ({num})')|fe(num=addon.total_reviews|numberfmt) }}</a></h3>
+      {% include "editors/includes/user_reviews_list.html" %}
+    {% endif %}
+  {% endif %}
+
+  {% if addon.description or addon.all_previews|length > 1 or addon.developer_comments or
+        addon.show_beta  %}
     <h3 id="more-about">{{ _('More about this add-on') }}</h3>
     <div class="article userinput">
       {% if addon.id == 4664 or addon.id == 144983 %}
@@ -243,14 +256,14 @@
       {% endif %}
       {# /beta #}
     </div>{# /article #}
-    {% elif not show_actions %}
-      <h3 id="more-about">{{ _('More about this add-on') }}</h3>
-      <div class="article">
-        <em>
-          {{ _('Nothing to see here!  The developer did not include any details.') }}
-        </em>
-      </div>
-    {% endif %}
+  {% elif not show_actions %}
+    <h3 id="more-about">{{ _('More about this add-on') }}</h3>
+    <div class="article">
+      <em>
+        {{ _('Nothing to see here!  The developer did not include any details.') }}
+      </em>
+    </div>
+  {% endif %}
 
   {% if reviews is defined %}
     {{ review_list_box(addon=addon, reviews=reviews) }}

--- a/src/olympia/editors/templates/editors/includes/abuse_reports_list.html
+++ b/src/olympia/editors/templates/editors/includes/abuse_reports_list.html
@@ -1,0 +1,18 @@
+<ul class="abuse_reports">
+  {% for report in reports %}
+  <li>
+    {% with date=report.created|datetime, ip_address=report.ip_address %}
+      {% if report.reporter %}
+        {% trans user=report.reporter|user_link %}
+          {{ user }} on {{ date }} [{{ ip_address }}]
+        {% endtrans %}
+      {% else %}
+        {% trans %}
+          <i>anonymous</i> on {{ date }} [{{ ip_address }}]
+        {% endtrans %}
+      {% endif %}
+    {% endwith %}
+    <blockquote>{{ report.message }}</blockquote>
+  </li>
+  {% endfor %}
+</ul>

--- a/src/olympia/editors/templates/editors/includes/user_reviews_list.html
+++ b/src/olympia/editors/templates/editors/includes/user_reviews_list.html
@@ -1,0 +1,14 @@
+<ul class="user_reviews">
+  {% for user_review in user_reviews %}
+  <li>
+    {% with date=user_review.created|datetime, ip_address=user_review.ip_address %}
+      {% trans user=user_review.user|user_link %}
+        {{ user }} on {{ date }} [{{ ip_address }}]
+      {% endtrans %}
+    {% endwith %}
+    <blockquote>
+      <strong>{{ user_review.title }}</strong> {{ user_review.rating|stars }}<br/>
+      {{ user_review.body }}</blockquote>
+  </li>
+  {% endfor %}
+</ul>

--- a/src/olympia/editors/tests/test_views.py
+++ b/src/olympia/editors/tests/test_views.py
@@ -2711,6 +2711,49 @@ class TestReview(ReviewBase):
         info = pq(response.content)('#review-files .file-info div')
         assert info.eq(1).text() == 'Permissions: ' + ', '.join(permissions)
 
+    def test_abuse_reports(self):
+        report = AbuseReport.objects.create(
+            addon=self.addon, message=u'Et mël mazim ludus.',
+            ip_address='10.1.2.3')
+        created_at = report.created.strftime('%B %e, %Y')
+        response = self.client.get(self.url)
+        doc = pq(response.content)
+        assert not doc('.abuse_reports')
+
+        self.login_as_senior_editor()
+        response = self.client.get(self.url)
+        doc = pq(response.content)
+        assert doc('.abuse_reports')
+        assert (
+            doc('.abuse_reports').text() ==
+            u'anonymous on %s [10.1.2.3] Et mël mazim ludus.' % created_at)
+
+    def test_user_reviews(self):
+        user = user_factory()
+        user_review = Review.objects.create(
+            body=u'Lôrem ipsum dolor', rating=5, ip_address='10.5.6.7',
+            addon=self.addon, user=user)
+        created_at = user_review.created.strftime('%B %e, %Y')
+        Review.objects.create(  # Review with no body, ignored.
+            rating=1, addon=self.addon, user=user_factory())
+        Review.objects.create(  # Reply to a review, ignored.
+            body='Replyyyyy', reply_to=user_review,
+            addon=self.addon, user=user_factory())
+        response = self.client.get(self.url)
+        doc = pq(response.content)
+        assert not doc('.user_reviews')
+
+        self.login_as_senior_editor()
+        response = self.client.get(self.url)
+        doc = pq(response.content)
+        assert doc('.user_reviews')
+        assert (
+            doc('.user_reviews').text() ==
+            u'%s on %s [10.5.6.7] Rated 5 out of 5 stars Lôrem ipsum dolor' % (
+                user.username, created_at
+            )
+        )
+
 
 class TestReviewPending(ReviewBase):
 


### PR DESCRIPTION
Only for users with `Addons:PostReview`, if the add-on is public;  as the base for the new post review process, where the will use that information (among other things) to gauge an add-on is suspicious or not.

Fix #5272