### PR TITLE
Add locked/has_info_request/has_admin_review criteria to AutoApprovalSummary

### DIFF
--- a/src/olympia/editors/views.py
+++ b/src/olympia/editors/views.py
@@ -29,9 +29,11 @@ from olympia.constants.base import REVIEW_LIMITED_DELAY_HOURS
 from olympia.constants.editors import REVIEWS_PER_PAGE, REVIEWS_PER_PAGE_MAX
 from olympia.editors import forms
 from olympia.editors.models import (
-    AddonCannedResponse, AutoApprovalSummary, EditorSubscription, EventLog,
-    get_flags, PerformanceGraph, ReviewerScore, ViewFullReviewQueue,
-    ViewPendingQueue, ViewUnlistedAllList)
+    AddonCannedResponse, AutoApprovalSummary, clear_reviewing_cache,
+    EditorSubscription, EventLog, get_flags, get_reviewing_cache,
+    get_reviewing_cache_key, PerformanceGraph, ReviewerScore,
+    set_reviewing_cache, ViewFullReviewQueue, ViewPendingQueue,
+    ViewUnlistedAllList)
 from olympia.editors.helpers import (
     AutoApprovedTable, is_limited_reviewer, ReviewHelper,
     ViewFullReviewQueueTable, ViewPendingQueueTable, ViewUnlistedAllListTable)
@@ -779,26 +781,6 @@ def review(request, addon, channel=None):
                   was_auto_approved=was_auto_approved)
 
     return render(request, 'editors/review.html', ctx)
-
-
-def get_reviewing_cache_key(addon_id):
-    return '%s:review_viewing:%s' % (settings.CACHE_PREFIX, addon_id)
-
-
-def clear_reviewing_cache(addon_id):
-    return cache.delete(get_reviewing_cache_key(addon_id))
-
-
-def get_reviewing_cache(addon_id):
-    return cache.get(get_reviewing_cache_key(addon_id))
-
-
-def set_reviewing_cache(addon_id, user_id):
-    # We want to save it for twice as long as the ping interval,
-    # just to account for latency and the like.
-    cache.set(get_reviewing_cache_key(addon_id),
-              user_id,
-              amo.EDITOR_VIEWING_INTERVAL * 2)
 
 
 @never_cache

--- a/src/olympia/migrations/941-add-criteria-to-auto-approval-summary.sql
+++ b/src/olympia/migrations/941-add-criteria-to-auto-approval-summary.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `editors_autoapprovalsummary`
+    ADD COLUMN `has_info_request` bool NOT NULL,
+    ADD COLUMN `is_locked` bool NOT NULL,
+    ADD COLUMN `is_under_admin_review` bool NOT NULL;


### PR DESCRIPTION
Previously, it was taken into account when the `auto_approve` command was run, before creating the `AutoApprovalSummary`, skipping the add-ons that matched. This commit changes it so that these criteria are recorded as normal, so that we can display them later to help debug how auto approvals behave.

Fix #5292