### PR TITLE
remove super-review action when the addon has no versions or is deleted

### DIFF
--- a/src/olympia/activity/tests/test_views.py
+++ b/src/olympia/activity/tests/test_views.py
@@ -5,8 +5,6 @@ import StringIO
 
 from django.test.utils import override_settings
 
-from waffle.testutils import override_switch
-
 from olympia import amo
 from olympia.activity.models import ActivityLog, ActivityLogToken
 from olympia.activity.tests.test_serializers import LogMixin
@@ -232,7 +230,6 @@ class TestReviewNotesViewSetList(ReviewNotesViewSetDetailMixin, TestCase):
         self._test_url()
 
 
-@override_switch('activity-email', active=True)
 class TestReviewNotesViewSetCreate(TestCase):
     client_class = APITestClient
 
@@ -381,31 +378,6 @@ class TestReviewNotesViewSetCreate(TestCase):
         self.make_addon_unlisted(self.addon)
         self.version.files.update(status=amo.STATUS_DISABLED)
         self._test_reviewer_reply('Addons:ReviewUnlisted')
-
-
-class TestReviewNotesViewSetCreateActivityEmailWaffleOff(TestCase):
-    client_class = APITestClient
-
-    def setUp(self):
-        super(TestReviewNotesViewSetCreateActivityEmailWaffleOff, self).setUp()
-        self.addon = addon_factory(
-            guid=generate_addon_guid(), name=u'My Addôn', slug='my-addon')
-        self.version = self.addon.find_latest_version(
-            channel=amo.RELEASE_CHANNEL_LISTED)
-        self.url = reverse('version-reviewnotes-list', kwargs={
-            'addon_pk': self.addon.pk,
-            'version_pk': self.version.pk})
-
-    def _post_reply(self):
-        return self.client.post(self.url, {'comments': u'comménty McCómm€nt'})
-
-    def test_developer_reply(self):
-        self.user = user_factory()
-        self.user.addonuser_set.create(addon=self.addon)
-        self.client.login_api(self.user)
-
-        response = self._post_reply()
-        assert response.status_code == 404
 
 
 @override_settings(ALLOWED_CLIENTS_EMAIL_API=['10.10.10.10'])

--- a/src/olympia/activity/views.py
+++ b/src/olympia/activity/views.py
@@ -11,7 +11,6 @@ from rest_framework.exceptions import ParseError
 from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
-from waffle.decorators import waffle_switch
 
 import olympia.core.logger
 from olympia import amo
@@ -59,7 +58,6 @@ class VersionReviewNotesViewSet(AddonChildMixin, ListModelMixin,
             self.get_queryset())
         return ctx
 
-    @waffle_switch('activity-email')
     def create(self, request, *args, **kwargs):
         version = self.get_version_object()
         latest_version = version.addon.find_latest_version(

--- a/src/olympia/devhub/templates/devhub/versions/list.html
+++ b/src/olympia/devhub/templates/devhub/versions/list.html
@@ -129,8 +129,7 @@
                     <pre>$comments</pre>
                 </div>
             </div>
-            {% if waffle.switch('activity-email') %}
-              {% if latest_version_in_channel == version %}
+            {% if latest_version_in_channel == version %}
               <div class="dev-review-reply">
                 <form class="dev-review-reply-form" action="{{ url('version-reviewnotes-list', addon.id, version.id) }}"
                       data-token="{{ token }}" data-history="#{{ version.id }}-review-history" data-no-csrf>
@@ -138,11 +137,10 @@
                     <button type="submit" class="submit" >{{ _('Reply') }}</button ty>
                 </form>
               </div>
-              {% else %}
+            {% else %}
               <div>
                 <a href="#" class="review-history-show" data-version="{{ latest_version_in_channel.id }}">{{ _('Leave a reply') }}</a>
               </div>
-              {% endif %}
             {% endif %}
         </td>
     </tr>

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -17,7 +17,6 @@ from django.utils.translation import ugettext as _, ugettext_lazy as _lazy
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt
 
-import waffle
 from django_statsd.clients import statsd
 from PIL import Image
 
@@ -1115,14 +1114,8 @@ def version_edit(request, addon_id, addon, version_id):
         if 'approvalnotes' in version_form.changed_data:
             if version.has_info_request:
                 version.update(has_info_request=False)
-                if waffle.switch_is_active('activity-email'):
-                    log_and_notify(amo.LOG.APPROVAL_NOTES_CHANGED,
-                                   None,
-                                   request.user,
-                                   version)
-                else:
-                    ActivityLog.create(amo.LOG.APPROVAL_NOTES_CHANGED,
-                                       addon, version, request.user)
+                log_and_notify(amo.LOG.APPROVAL_NOTES_CHANGED, None,
+                               request.user, version)
             else:
                 ActivityLog.create(amo.LOG.APPROVAL_NOTES_CHANGED,
                                    addon, version, request.user)
@@ -1132,14 +1125,8 @@ def version_edit(request, addon_id, addon, version_id):
             addon.update(admin_review=True)
             if version.has_info_request:
                 version.update(has_info_request=False)
-                if waffle.switch_is_active('activity-email'):
-                    log_and_notify(amo.LOG.SOURCE_CODE_UPLOADED,
-                                   None,
-                                   request.user,
-                                   version)
-                else:
-                    ActivityLog.create(amo.LOG.SOURCE_CODE_UPLOADED,
-                                       addon, version, request.user)
+                log_and_notify(amo.LOG.SOURCE_CODE_UPLOADED, None,
+                               request.user, version)
             else:
                 ActivityLog.create(amo.LOG.SOURCE_CODE_UPLOADED,
                                    addon, version, request.user)

--- a/src/olympia/editors/helpers.py
+++ b/src/olympia/editors/helpers.py
@@ -11,7 +11,6 @@ from django.utils.translation import (
 
 import django_tables2 as tables
 import jinja2
-import waffle
 from jingo import register
 
 import olympia.core.logger
@@ -530,16 +529,9 @@ class ReviewBase(object):
         message = loader.get_template(
             'editors/emails/%s.ltxt' % template).render(
             Context(data, autoescape=False))
-        if not waffle.switch_is_active('activity-email'):
-            emails = [a.email for a in self.addon.authors.all()]
-            amo_send_mail(
-                subject, message, recipient_list=emails,
-                from_email=settings.EDITORS_EMAIL, use_deny_list=False,
-                perm_setting=perm_setting)
-        else:
-            send_activity_mail(
-                subject, message, self.version, self.addon.authors.all(),
-                settings.EDITORS_EMAIL, perm_setting)
+        send_activity_mail(
+            subject, message, self.version, self.addon.authors.all(),
+            settings.EDITORS_EMAIL, perm_setting)
 
     def get_context_data(self):
         addon_url = self.addon.get_url_path(add_prefix=False)

--- a/src/olympia/editors/helpers.py
+++ b/src/olympia/editors/helpers.py
@@ -373,7 +373,7 @@ class ReviewHelper(object):
         self.addon = addon
         self.version = version
         self.get_review_type(request)
-        self.actions = self.get_actions(request, addon)
+        self.actions = self.get_actions(request)
 
     def set_data(self, data):
         self.handler.set_data(data)
@@ -390,17 +390,17 @@ class ReviewHelper(object):
             self.handler = ReviewFiles(
                 request, self.addon, self.version, 'pending')
 
-    def get_actions(self, request, addon):
+    def get_actions(self, request):
         actions = SortedDict()
         if request is None:
             # If request is not set, it means we are just (ab)using the
             # ReviewHelper for its `handler` attribute and we don't care about
             # the actions.
             return actions
-        reviewable_because_complete = addon.status not in (
+        reviewable_because_complete = self.addon.status not in (
             amo.STATUS_NULL, amo.STATUS_DELETED)
         reviewable_because_admin = (
-            not addon.admin_review or
+            not self.addon.admin_review or
             acl.action_allowed(request,
                                amo.permissions.REVIEWER_ADMIN_TOOLS_VIEW))
         reviewable_because_submission_time = (
@@ -437,14 +437,14 @@ class ReviewHelper(object):
                 'details': _lazy('This will send a message to the developer. '
                                  'You will be notified when they reply.'),
                 'minimal': True}
-        actions['super'] = {
-            'method': self.handler.process_super_review,
-            'label': _lazy('Request super-review'),
-            'details': _lazy('If you have concerns about this add-on that an '
-                             'admin reviewer should look into, enter your '
-                             'comments in the area below. They will not be '
-                             'sent to the developer.'),
-            'minimal': True}
+            actions['super'] = {
+                'method': self.handler.process_super_review,
+                'label': _lazy('Request super-review'),
+                'details': _lazy('If you have concerns about this add-on that '
+                                 'an admin reviewer should look into, enter '
+                                 'your comments in the area below. They will '
+                                 'not be sent to the developer.'),
+                'minimal': True}
         actions['comment'] = {
             'method': self.handler.process_comment,
             'label': _lazy('Comment'),

--- a/src/olympia/editors/templates/editors/emails/author_super_review.ltxt
+++ b/src/olympia/editors/templates/editors/emails/author_super_review.ltxt
@@ -5,13 +5,10 @@ Your add-on, {{ name }} {{ number }}, has been flagged for Admin Review.
 
 Your add-on is still in our review queue, but it will need to be checked by one of our admin reviewers. This means that your review will probably take longer than usual.
 
-{% switch "activity-email" %}
 If you want to respond to this email please reply to this email or visit {{ dev_versions_url }} . If you need to send file attachments, please include the address amo-editors@mozilla.org and mention it in your reply.
 
 You can also join us in #addon-reviewers on irc.mozilla.org.
-{% else %}
-If you have any questions or comments, you can reply to this email or join #addon-reviewers on irc.mozilla.org.
-{% endswitch %}
+
 To learn more about the review process, please visit https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Reviews
 {% if legacy_addon %}
 To ensure your add-ons are compatible past Firefox 57, please migrate them to WebExtensions as soon as possible: https://mzl.la/1RzETMA

--- a/src/olympia/editors/templates/editors/emails/base.ltxt
+++ b/src/olympia/editors/templates/editors/emails/base.ltxt
@@ -2,13 +2,10 @@
 Hello,
 
 {% block content %}{% endblock %}
-{% switch "activity-email" %}
 If you want to respond please reply to this email or visit {{ dev_versions_url }} . If you need to send file attachments, please include the address amo-editors@mozilla.org and mention it in your reply.
 
 You can also join us in #addon-reviewers on irc.mozilla.org.
-{% else %}
-If you want to respond to this review, or have any questions about it, please reply to this email or join #addon-reviewers on irc.mozilla.org.
-{% endswitch %}
+
 To learn more about the review process, please visit https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Reviews
 {% if legacy_addon %}
 To ensure your add-ons are compatible past Firefox 57, please migrate them to WebExtensions as soon as possible: https://mzl.la/1RzETMA

--- a/src/olympia/editors/tests/test_forms.py
+++ b/src/olympia/editors/tests/test_forms.py
@@ -34,7 +34,7 @@ class TestReviewActions(TestCase):
             {'addon_files': [self.file.pk]},
             helper=ReviewHelper(request=self.request, addon=self.addon,
                                 version=self.version))
-        return form.helper.get_actions(self.request, self.addon)
+        return form.helper.get_actions(self.request)
 
     def test_reject(self):
         reject = self.set_statuses(

--- a/src/olympia/editors/tests/test_helpers.py
+++ b/src/olympia/editors/tests/test_helpers.py
@@ -277,7 +277,8 @@ class TestReviewHelper(TestCase):
         self.file.update(status=file_status)
         self.addon.update(status=addon_status)
         # Need to clear self.version.all_files cache since we updated the file.
-        del self.version.all_files
+        if self.version:
+            del self.version.all_files
         return self.get_helper().actions
 
     def test_actions_full_nominated(self):
@@ -299,6 +300,15 @@ class TestReviewHelper(TestCase):
             assert self.get_review_actions(
                 addon_status=amo.STATUS_PUBLIC,
                 file_status=file_status).keys() == expected
+
+    def test_actions_no_version(self):
+        """Deleted addons and addons with no versions in that channel have no
+        version set."""
+        expected = ['comment']
+        self.version = None
+        assert self.get_review_actions(
+            addon_status=amo.STATUS_PUBLIC,
+            file_status=amo.STATUS_PUBLIC).keys() == expected
 
     def test_set_files(self):
         self.file.update(datestatuschanged=yesterday)

--- a/src/olympia/editors/tests/test_helpers.py
+++ b/src/olympia/editors/tests/test_helpers.py
@@ -9,7 +9,6 @@ from django.utils import translation
 import pytest
 from mock import Mock, patch
 from pyquery import PyQuery as pq
-from waffle.testutils import override_switch
 
 from olympia import amo
 from olympia.activity.models import ActivityLog, ActivityLogToken
@@ -317,20 +316,6 @@ class TestReviewHelper(TestCase):
         assert self.check_log_count(amo.LOG.APPROVE_VERSION.id) == 1
 
     def test_notify_email(self):
-        self.helper.set_data(self.get_data())
-        base_fragment = 'reply to this email or join #addon-reviewers'
-        legacy_cta_fragment = 'add-ons are compatible past Firefox 57'
-        for template in ('nominated_to_public', 'nominated_to_sandbox',
-                         'pending_to_public', 'pending_to_sandbox',
-                         'author_super_review', 'unlisted_to_reviewed_auto'):
-            mail.outbox = []
-            self.helper.handler.notify_email(template, 'Sample subject %s, %s')
-            assert len(mail.outbox) == 1
-            assert base_fragment in mail.outbox[0].body
-            assert legacy_cta_fragment in mail.outbox[0].body
-
-    @override_switch('activity-email', active=True)
-    def test_notify_email_activity_email(self):
         self.helper.set_data(self.get_data())
         base_fragment = 'If you need to send file attachments'
         legacy_cta_fragment = 'add-ons are compatible past Firefox 57'

--- a/src/olympia/migrations/939-drop-activity-email-waffle.sql
+++ b/src/olympia/migrations/939-drop-activity-email-waffle.sql
@@ -1,0 +1,1 @@
+DELETE FROM waffle_switch WHERE name = 'activity-email';


### PR DESCRIPTION
drops `activity-email` waffle so we're not testing for unused codepaths and then fixes #4760 