### PR TITLE
Deactivate dockerflow middleware, disabling request.summary logging

### DIFF
--- a/src/olympia/amo/middleware.py
+++ b/src/olympia/amo/middleware.py
@@ -20,7 +20,6 @@ from django.utils.encoding import iri_to_uri, force_bytes
 from django.utils.translation import activate
 
 import MySQLdb as mysql
-from dockerflow.django.middleware import DockerflowMiddleware
 
 from olympia import amo
 from olympia.amo.utils import render
@@ -250,9 +249,3 @@ class ScrubRequestOnException(object):
             # Clearing out all cookies in request.META. They will already
             # be sent with request.COOKIES.
             request.META['HTTP_COOKIE'] = '******'
-
-
-class DockerflowMiddlewareWithoutViews(DockerflowMiddleware):
-    """Like DockerflowMiddleware, but without hijacking any views, because at
-    the moment we have our own."""
-    viewpatterns = []

--- a/src/olympia/lib/log_settings_base.py
+++ b/src/olympia/lib/log_settings_base.py
@@ -125,8 +125,9 @@ def log_configure():
         cfg['loggers']['z.timer'] = {'handlers': ['syslog2']}
     if settings.USE_MOZLOG:
         # MozLog Application Request Summary. This is the logger
-        # DockerflowMiddleware uses on every request - we only enable it when
-        # USE_MOZLOG is True.
+        # DockerflowMiddleware uses on every request. We don't currently use
+        # that middleware because it's too much logging, but it does not hurt
+        # to have the logger configured correctly when USE_MOZLOG is True.
         cfg['loggers']['request.summary'] = {
             'handlers': ['mozlog'],
             'level': 'DEBUG',

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -378,7 +378,6 @@ MIDDLEWARE_CLASSES = (
     'django_statsd.middleware.GraphiteRequestTimingMiddleware',
     'django_statsd.middleware.GraphiteMiddleware',
     'olympia.amo.middleware.SetRemoteAddrFromForwardedFor',
-    'olympia.amo.middleware.DockerflowMiddlewareWithoutViews',
 
     # AMO URL middleware is as high as possible to get locale/app aware URLs.
     'olympia.amo.middleware.LocaleAndAppURLMiddleware',


### PR DESCRIPTION
The logging traffic it generates is too much for production and not very useful to us for the moment anyway.

Fix #5328