### PR TITLE
Don't display approvals counter for non-webextensions in reviewer tools

### DIFF
--- a/src/olympia/editors/tests/test_views.py
+++ b/src/olympia/editors/tests/test_views.py
@@ -2674,6 +2674,7 @@ class TestReview(ReviewBase):
     def test_approvals_info(self):
         approval_info = AddonApprovalsCounter.objects.create(
             addon=self.addon, last_human_review=datetime.now(), counter=42)
+        self.file.update(is_webextension=True)
         response = self.client.get(self.url)
         doc = pq(response.content)
         # No permission: nothing displayed.

--- a/src/olympia/editors/views.py
+++ b/src/olympia/editors/views.py
@@ -658,7 +658,7 @@ def review(request, addon, channel=None):
                 )
             except AutoApprovalSummary.DoesNotExist:
                 pass
-        if is_post_reviewer:
+        if is_post_reviewer and version and version.is_webextension:
             try:
                 approvals_info = addon.addonapprovalscounter
             except AddonApprovalsCounter.DoesNotExist:


### PR DESCRIPTION
Fix #5341