### PR TITLE
Fix #5241 - Distance between "Permissions" link and "Add to Firefox" button is too little in RTL

### DIFF
--- a/static/css/impala/addon_details.less
+++ b/static/css/impala/addon_details.less
@@ -23,6 +23,7 @@
     .badge {
         font-size: 14px;
         margin-left: 1em;
+        margin-right: 1em;
     }
     .install-shell {
         font-family: @sans-stack;


### PR DESCRIPTION
Fixes #5241

Hi,
Don't know if its the correct way. But I have added a margin-right of equal unit.
Please let me know if any changes is required.

Thanks,