### PR TITLE
Separating the url from the text in email correspondence

### DIFF
--- a/src/olympia/activity/templates/activity/emails/developer.txt
+++ b/src/olympia/activity/templates/activity/emails/developer.txt
@@ -6,7 +6,8 @@ A reply has been added to the review of version {{ number }} of add-on {{ name }
 
 {{ comments }}
 
-If you want to respond please reply to this email or visit {{ url }}. If you need to send file attachments, please include the address amo-editors@mozilla.org and mention it in your reply.
+If you want to respond please reply to this email or visit {{ url }}
+If you need to send file attachments, please include the address amo-editors@mozilla.org and mention it in your reply.
 --
 Mozilla Add-ons
 {{ SITE_URL }}

--- a/src/olympia/activity/templates/activity/emails/from_reviewer.txt
+++ b/src/olympia/activity/templates/activity/emails/from_reviewer.txt
@@ -6,7 +6,8 @@ A reviewer sent a message regarding the review of version {{ number }} of add-on
 
 {{ comments }}
 
-If you want to respond please reply to this email or visit {{ url }}. If you need to send file attachments, please include the address amo-editors@mozilla.org and mention it in your reply.
+If you want to respond please reply to this email or visit {{ url }}
+If you need to send file attachments, please include the address amo-editors@mozilla.org and mention it in your reply.
 --
 Mozilla Add-ons
 {{ SITE_URL }}


### PR DESCRIPTION
ref: mozilla/addons#347

Removed the fullstop after {{ url }} and added a line break instead, to separate the {{ url }} from the text