### PR TITLE
Remove all ApplicationsVersions/AppVersion/AppSupport for old MOBILE app

### DIFF
--- a/src/olympia/migrations/942-remove-app-mobile.sql
+++ b/src/olympia/migrations/942-remove-app-mobile.sql
@@ -1,0 +1,3 @@
+DELETE FROM `applications_versions` WHERE application_id = 60;
+DELETE FROM `appversions` WHERE application_id = 60;
+DELETE FROM `appsupport` WHERE app_id = 60;


### PR DESCRIPTION
Necessary to unbreak devhub compat form, which does not like dealing
with existing data not in `APPS_CHOICES`

Fix #5366