### PR TITLE
Always use current public version when displaying addons in auto approved list

### DIFF
--- a/src/olympia/editors/helpers.py
+++ b/src/olympia/editors/helpers.py
@@ -315,7 +315,7 @@ class AutoApprovedTable(EditorQueueTable):
         url = reverse('editors.review', args=[record.addon.slug])
         return u'<a href="%s">%s <em>%s</em></a>' % (
             url, jinja2.escape(record.addon.name),
-            jinja2.escape(record.version))
+            jinja2.escape(record.addon.current_version))
 
     def render_last_human_review(self, value):
         return naturaltime(value) if value else ''

--- a/src/olympia/editors/tests/test_views.py
+++ b/src/olympia/editors/tests/test_views.py
@@ -1251,10 +1251,10 @@ class TestAutoApprovedQueue(QueueTest):
     def get_addon_latest_version(self, addon):
         """Method used by _test_results() to fetch the version that the queue
         is supposed to display. Overridden here because in our case, it's not
-        necessarily the latest available version - we want the latest one to
-        have been auto approved."""
-        return AutoApprovalSummary.objects.filter(
-            version__in=list(addon.versions.all())).latest('pk').version
+        necessarily the latest available version - we display the current
+        public version instead (which is not guaranteed to be the latest
+        auto-approved one, but good enough) for this page."""
+        return addon.current_version
 
     def generate_files(self):
         """Generate add-ons needed for these tests."""


### PR DESCRIPTION
Previously the `GROUP BY versions.addon_id` we're doing could sometimes give us a super-old version and it was tricky to fix it in the query itself. The current version should be the right one in most cases - it's better than what we had.

Fix #5293