### PR TITLE
Allow users with post-review permission to record confirmation of auto-approval

### DIFF
--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -551,6 +551,7 @@ class CONFIRM_AUTO_APPROVED(_LOG):
     short = _(u'Auto-Approval confirmed')
     keep = True
     editor_review_action = True
+    review_queue = True
 
 
 LOGS = [x for x in vars().values()

--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -545,6 +545,14 @@ class SOURCE_CODE_UPLOADED(_LOG):
     review_queue = True
 
 
+class CONFIRM_AUTO_APPROVED(_LOG):
+    id = 144
+    format = _(u'Auto-Approval confirmed for {addon} {version}.')
+    short = _(u'Auto-Approval confirmed')
+    keep = True
+    editor_review_action = True
+
+
 LOGS = [x for x in vars().values()
         if isclass(x) and issubclass(x, _LOG) and x != _LOG]
 # Make sure there's no duplicate IDs.

--- a/src/olympia/editors/forms.py
+++ b/src/olympia/editors/forms.py
@@ -302,6 +302,10 @@ class ReviewForm(happyforms.Form):
         required=False, label=_lazy(u'Clear more info requested flag'))
 
     def is_valid(self):
+        # Some actions do not require comments.
+        action = self.helper.actions.get(self.data.get('action'))
+        if action and not action.get('comments', True):
+            self.fields['comments'].required = False
         result = super(ReviewForm, self).is_valid()
         if result:
             self.helper.set_data(self.cleaned_data)

--- a/src/olympia/editors/helpers.py
+++ b/src/olympia/editors/helpers.py
@@ -26,8 +26,8 @@ from olympia.amo.urlresolvers import reverse
 from olympia.amo.utils import send_mail as amo_send_mail, to_language
 from olympia.constants.base import REVIEW_LIMITED_DELAY_HOURS
 from olympia.editors.models import (
-    get_flags, ReviewerScore, ViewFullReviewQueue, ViewPendingQueue,
-    ViewUnlistedAllList)
+    AutoApprovalSummary, get_flags, ReviewerScore, ViewFullReviewQueue,
+    ViewPendingQueue, ViewUnlistedAllList)
 from olympia.lib.crypto.packaged import sign_file
 from olympia.tags.models import Tag
 from olympia.users.models import UserProfile
@@ -430,6 +430,32 @@ class ReviewHelper(object):
                                  'from the queue. The comments will be sent '
                                  'to the developer.'),
                 'minimal': False}
+        # If the addon current version was auto-approved, extra actions are
+        # available to users with post-review permission, allowing them to
+        # confirm the approval or reject versions.
+        if (self.addon.current_version and
+                self.addon.current_version.was_auto_approved and
+                acl.action_allowed(
+                    request, amo.permissions.ADDONS_POST_REVIEW)):
+            actions['confirm_auto_approved'] = {
+                'method': self.handler.confirm_auto_approved,
+                'label': _lazy('Confirm Approval'),
+                'details': _lazy('The latest public version of this add-on '
+                                 'was automatically approved. This records '
+                                 'your confirmation of the approval, '
+                                 'without notifying the developer.'),
+                'minimal': True,
+                'comments': False,
+            }
+            # Not implemented yet, will be in #5275.
+            # actions['reject_auto_approved'] = {
+            #     'method': self.handler.reject_auto_approved,
+            #     'label': _lazy('Reject'),
+            #     'details': _lazy('This will reject the specified '
+            #                      'auto-approved versions. The comments will '
+            #                      'be sent to the developer.'),
+            #     'minimal': True,
+            # }
         if self.version:
             actions['info'] = {
                 'method': self.handler.request_information,
@@ -683,6 +709,16 @@ class ReviewBase(object):
 
         # Always notify senior editors.
         self.send_super_mail()
+
+    def confirm_auto_approved(self):
+        """Confirm an auto-approval decision.
+
+        We don't need to really store that information, what we care about
+        is incrementing AddonApprovalsCounter, which also resets the last
+        human review date to now, and log it so that it's displayed later
+        in the review page."""
+        AddonApprovalsCounter.increment_for_addon(addon=self.addon)
+        self.log_action(amo.LOG.CONFIRM_AUTO_APPROVED)
 
 
 class ReviewAddon(ReviewBase):

--- a/src/olympia/editors/helpers.py
+++ b/src/olympia/editors/helpers.py
@@ -26,8 +26,8 @@ from olympia.amo.urlresolvers import reverse
 from olympia.amo.utils import send_mail as amo_send_mail, to_language
 from olympia.constants.base import REVIEW_LIMITED_DELAY_HOURS
 from olympia.editors.models import (
-    AutoApprovalSummary, get_flags, ReviewerScore, ViewFullReviewQueue,
-    ViewPendingQueue, ViewUnlistedAllList)
+    get_flags, ReviewerScore, ViewFullReviewQueue, ViewPendingQueue,
+    ViewUnlistedAllList)
 from olympia.lib.crypto.packaged import sign_file
 from olympia.tags.models import Tag
 from olympia.users.models import UserProfile

--- a/src/olympia/editors/templates/editors/review.html
+++ b/src/olympia/editors/templates/editors/review.html
@@ -168,12 +168,15 @@
         {{ _("You can still submit this form, however only do so if you know it won't conflict.") }}
       </div>
 
-      <label for="id_comments">{{ form.comments.label }}</label>
-      {{ form.comments }}
-      {{ form.comments.errors }}
-      <div class="review-actions-canned">
-        {{ _('Insert canned response...') }}
-        {{ form.canned_response }}
+      <div class="review-actions-section data-toggle"
+           data-value="{{ actions_comments|join("|") }}">
+        <label for="id_comments">{{ form.comments.label }}</label>
+        {{ form.comments }}
+        {{ form.comments.errors }}
+        <div class="review-actions-canned">
+          {{ _('Insert canned response...') }}
+          {{ form.canned_response }}
+        </div>
       </div>
 
       <div class="review-actions-section review-actions-files data-toggle"


### PR DESCRIPTION
Fix #5273

We shouldn't need to store anything new, just log and update the `last_human_review` date, which is done automatically when calling `AddonApprovalsCounter.increment_for_addon()`.

This will only be used to find out how much the add-on code has changed since the last time it was seen by a human (which will be used as one of the factors in the post review queue ordering). We'll do that by finding the most recent version reviewed before that date.