### PR TITLE
Add UserProfile edit API

### DIFF
--- a/docs/topics/api/accounts.rst
+++ b/docs/topics/api/accounts.rst
@@ -73,6 +73,55 @@ This endpoint is a shortcut to your own account. It returns an :ref:`account obj
 .. http:get:: /api/v3/accounts/profile/
 
 
+----
+Edit
+----
+
+.. _`account-edit`:
+
+.. note::
+    This API requires :doc:`authentication <auth>` and `Users:Edit`
+    permission to edit accounts other than your own.
+
+This endpoint allows some of the details for an account to be updated.  Any fields
+in the :ref:`account <account-object>` (or :ref:`self <account-object-self>`)
+but not listed below are not editable and will be ignored in the patch request.
+
+.. http:patch:: /api/v3/accounts/account/(int:user_id)/
+
+    .. _account-edit-request:
+
+    :<json string|null biography: More details about the user.  No links are allowed.
+    :<json string|null display_name: The name chosen by the user.
+    :<json string|null homepage: The user's website.
+    :<json string|null location: The location of the user.
+    :<json string|null occupation: The occupation of the user.
+    :<json string|null username: username to be used in the account url.  The username can only contain letters, numbers, underscores or hyphens. All-number usernames are prohibited as they conflict with user-ids.
+
+
+-------------------
+Uploading a picture
+-------------------
+
+To upload a picture for the profile the request must be sent as content-type `multipart/form-data` instead of JSON.
+Images must be either PNG or JPG and the maximum file size is 4MB.
+Other :ref:`editable values <account-edit-request>` can be set at the same time.
+
+.. http:patch:: /api/v3/accounts/account/(int:user_id)/
+
+    **Request:**
+
+    .. sourcecode:: bash
+
+        curl "https://addons.mozilla.org/api/v3/accounts/account/12345/"
+            -g -XPUT --form "picture_upload=@photo.png"
+            -H "Authorization: Bearer <token>"
+
+    :param user-id: The numeric user id.
+    :form picture_upload: The user's picture to upload.
+    :reqheader Content-Type: multipart/form-data
+
+
 ----------------
 Collections List
 ----------------
@@ -136,7 +185,6 @@ This endpoint lists the add-ons in a collection, together with collector's notes
     :>json object results[].addon: The :ref:`add-on <addon-detail-object>` for this item.
     :>json string|object|null results[].notes: The collectors notes for this item. (See :ref:`translated fields <api-overview-translations>`).
     :>json int results[].downloads: The downloads that occured via this collection.
-
 
 
 --------------

--- a/docs/topics/api/accounts.rst
+++ b/docs/topics/api/accounts.rst
@@ -104,7 +104,7 @@ Uploading a picture
 -------------------
 
 To upload a picture for the profile the request must be sent as content-type `multipart/form-data` instead of JSON.
-Images must be either PNG or JPG and the maximum file size is 4MB.
+Images must be either PNG or JPG; the maximum file size is 4MB.
 Other :ref:`editable values <account-edit-request>` can be set at the same time.
 
 .. http:patch:: /api/v3/accounts/account/(int:user_id)/
@@ -114,7 +114,7 @@ Other :ref:`editable values <account-edit-request>` can be set at the same time.
     .. sourcecode:: bash
 
         curl "https://addons.mozilla.org/api/v3/accounts/account/12345/"
-            -g -XPUT --form "picture_upload=@photo.png"
+            -g -XPATCH --form "picture_upload=@photo.png"
             -H "Authorization: Bearer <token>"
 
     :param user-id: The numeric user id.

--- a/src/olympia/accounts/serializers.py
+++ b/src/olympia/accounts/serializers.py
@@ -19,6 +19,8 @@ class PublicUserProfileSerializer(BaseUserSerializer):
             'is_addon_developer', 'is_artist', 'location', 'occupation',
             'num_addons_listed', 'picture_type', 'picture_url', 'username',
         )
+        # This serializer should never be used for updates but just to be sure.
+        read_only_fields = fields
 
 
 class UserProfileSerializer(PublicUserProfileSerializer):
@@ -28,6 +30,11 @@ class UserProfileSerializer(PublicUserProfileSerializer):
             'display_name', 'email', 'deleted', 'last_login',
             'last_login_ip', 'read_dev_agreement', 'is_verified',
         )
+        writeable_fields = (
+            'biography', 'display_name', 'homepage', 'location', 'occupation',
+            'username',
+        )
+        read_only_fields = tuple(set(fields) - set(writeable_fields))
 
 
 group_rules = {

--- a/src/olympia/accounts/tests/test_serializers.py
+++ b/src/olympia/accounts/tests/test_serializers.py
@@ -19,10 +19,16 @@ class TestPublicUserProfileSerializer(BaseTestCase):
     def serialize(self):
         return self.serializer(self.user).data
 
-    def test_picture_url(self):
+    def test_picture(self):
         serial = self.serialize()
         assert ('anon_user.png' in serial['picture_url'])
         assert serial['picture_type'] == ''
+        assert 'picture_upload' not in serial  # its a write only field.
+
+        self.user.update(picture_type='image/jpeg')
+        serial = self.serialize()
+        assert serial['picture_url'] == self.user.picture_url
+        assert '%s.png' % self.user.id in serial['picture_url']
 
     def test_basic(self):
         data = self.serialize()

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import base64
+import json
 import urlparse
 from datetime import datetime
 
@@ -945,10 +946,8 @@ class TestAccountViewSet(TestCase):
         # instead...
         response = self.client.post(reverse('account-profile'))
         assert response.status_code == 405
-        # We can try put/patch on the detail URL though.
+        # We can try put on the detail URL though.
         response = self.client.put(self.url)
-        assert response.status_code == 405
-        response = self.client.patch(self.url)
         assert response.status_code == 405
 
     def test_self_view(self):
@@ -999,6 +998,76 @@ class TestAccountViewSet(TestCase):
         assert response.status_code == 200
         assert response.data['name'] == self.random_user.name
         assert response.data['email'] == self.random_user.email
+
+
+class TestAccountViewSetUpdate(TestCase):
+    client_class = APITestClient
+    update_data = {
+        'display_name': 'Bob Loblaw',
+        'biography': 'You don`t need double talk; you need Bob Loblaw',
+        'homepage': 'http://bob-loblaw-law.blog',
+        'location': 'law office',
+        'occupation': 'lawyer',
+        'username': 'bob',
+    }
+
+    def setUp(self):
+        self.user = user_factory()
+        self.url = reverse('account-detail',
+                           kwargs={'pk': self.user.pk})
+        super(TestAccountViewSetUpdate, self).setUp()
+
+    def patch(self, url=None, data=None):
+        return self.client.patch(url or self.url, data or self.update_data)
+
+    def test_basic_patch(self):
+        self.client.login_api(self.user)
+        original = self.client.get(self.url).content
+        response = self.patch()
+        assert response.status_code == 200
+        assert response.content != original
+        modified_json = json.loads(response.content)
+        self.user = self.user.reload()
+        for prop, value in self.update_data.iteritems():
+            assert modified_json[prop] == value
+            assert getattr(self.user, prop) == value
+
+    def test_no_auth(self):
+        response = self.patch()
+        assert response.status_code == 401
+
+    def test_different_account(self):
+        self.client.login_api(self.user)
+        url = reverse('account-detail', kwargs={'pk': user_factory().pk})
+        response = self.patch(url=url)
+        assert response.status_code == 403
+
+    def test_admin_patch(self):
+        self.grant_permission(self.user, 'Users:Edit')
+        self.client.login_api(self.user)
+        random_user = user_factory()
+        url = reverse('account-detail', kwargs={'pk': random_user.pk})
+        original = self.client.get(url).content
+        response = self.patch(url=url)
+        assert response.status_code == 200
+        assert response.content != original
+        modified_json = json.loads(response.content)
+        random_user = random_user.reload()
+        for prop, value in self.update_data.iteritems():
+            assert modified_json[prop] == value
+            assert getattr(random_user, prop) == value
+
+    def test_read_only_fields(self):
+        self.client.login_api(self.user)
+        original = self.client.get(self.url).content
+        # Try to patch a field that can't be patched.
+        response = self.patch(data={'last_login_ip': '666.666.666.666'})
+        assert response.status_code == 200
+        assert response.content == original
+        self.user = self.user.reload()
+        # Confirm field hasn't been updated.
+        assert json.loads(response.content)['last_login_ip'] == ''
+        assert self.user.last_login_ip == ''
 
 
 class TestAccountSuperCreate(APIKeyAuthTestCase):


### PR DESCRIPTION
fixes #5263 
Doesn't implement any admin-specific editing, like email address, or account notes.