### PR TITLE
Fix unicode error for downloads with unicode filenames.

### DIFF
--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -90,7 +90,8 @@ def urlparams(url_, hash=None, **query):
     New query params will be appended to existing parameters, except duplicate
     names, which will be replaced.
     """
-    url = django_urlparse(url_)
+    url = django_urlparse(force_text(url_))
+
     fragment = hash if hash is not None else url.fragment
 
     # Use dict(parse_qsl) so we don't get lists of values.

--- a/src/olympia/versions/tests/test_views.py
+++ b/src/olympia/versions/tests/test_views.py
@@ -4,6 +4,7 @@ import os
 from django.conf import settings
 from django.core.files import temp
 from django.core.files.base import File as DjangoFile
+from django.utils.http import urlquote
 from django.test.utils import override_settings
 
 import mock
@@ -183,8 +184,9 @@ class TestDownloadsBase(TestCase):
             file_ = self.file
         assert response.status_code == 302
         assert response.url == (
-            urlparams('%s%s/%s' % (host, self.addon.id, file_.filename),
-                      filehash=file_.hash))
+            urlparams('%s%s/%s' % (
+                host, self.addon.id, urlquote(file_.filename)
+            ), filehash=file_.hash))
         assert response['X-Target-Digest'] == file_.hash
 
     def assert_served_internally(self, response, guarded=True):
@@ -301,6 +303,11 @@ class TestDownloads(TestDownloadsBase):
         self.addon.update(status=amo.STATUS_BETA)
         self.file.update(status=amo.STATUS_BETA)
         self.assert_served_locally(self.client.get(self.file_url))
+
+    def test_unicode_url(self):
+        self.file.update(filename=u'图像浏览器-0.5-fx.xpi')
+
+        self.assert_served_by_cdn(self.client.get(self.file_url))
 
 
 class TestDisabledFileDownloads(TestDownloadsBase):


### PR DESCRIPTION
Fixes #5404

Not sure if the fix is sufficient but it seems to be working properly for me. I'm open for any potential improvements :)