### PR TITLE
Remove references to amo-editors mailing list

### DIFF
--- a/src/olympia/activity/templates/activity/emails/bounce.txt
+++ b/src/olympia/activity/templates/activity/emails/bounce.txt
@@ -3,7 +3,7 @@ Hello,
 An email was received, apparently from you. Unfortunately we couldn't process it because of:
 {{ reason }}
 
-Please visit {{ SITE_URL }} to leave a reply instead; alternatively if you need to send file attachments, please reply by email to amo-editors@mozilla.org.
+Please visit {{ SITE_URL }} to leave a reply instead.
 --
 Mozilla Add-ons
 {{ SITE_URL }}

--- a/src/olympia/activity/templates/activity/emails/developer.txt
+++ b/src/olympia/activity/templates/activity/emails/developer.txt
@@ -7,7 +7,6 @@ A reply has been added to the review of version {{ number }} of add-on {{ name }
 {{ comments }}
 
 If you want to respond please reply to this email or visit {{ url }}
-If you need to send file attachments, please include the address amo-editors@mozilla.org and mention it in your reply.
 --
 Mozilla Add-ons
 {{ SITE_URL }}

--- a/src/olympia/activity/templates/activity/emails/from_reviewer.txt
+++ b/src/olympia/activity/templates/activity/emails/from_reviewer.txt
@@ -7,7 +7,6 @@ A reviewer sent a message regarding the review of version {{ number }} of add-on
 {{ comments }}
 
 If you want to respond please reply to this email or visit {{ url }}
-If you need to send file attachments, please include the address amo-editors@mozilla.org and mention it in your reply.
 --
 Mozilla Add-ons
 {{ SITE_URL }}

--- a/src/olympia/activity/tests/test_utils.py
+++ b/src/olympia/activity/tests/test_utils.py
@@ -47,9 +47,7 @@ class TestEmailBouncing(TestCase):
     BOUNCE_REPLY = (
         'Hello,\n\nAn email was received, apparently from you. Unfortunately '
         'we couldn\'t process it because of:\n%s\n\nPlease visit %s to leave '
-        'a reply instead; alternatively if you need to send file attachments, '
-        'please reply by email to amo-editors@mozilla.org.\n'
-        '--\nMozilla Add-ons\n%s')
+        'a reply instead.\n--\nMozilla Add-ons\n%s')
 
     def setUp(self):
         self.bounce_reply = (

--- a/src/olympia/devhub/templates/devhub/addons/edit/basic.html
+++ b/src/olympia/devhub/templates/devhub/addons/edit/basic.html
@@ -101,7 +101,7 @@
                       {{ cats|join(' &middot; ')|safe }}
                     </p>
                     <p>
-                      {% trans email='amo-editors@mozilla.org' %}
+                      {% trans email='amo-admins@mozilla.org' %}
                         Categories cannot be changed while your add-on is
                         featured for this application. Please email
                         <a href="mailto:{{ email }}">{{ email }}</a> if there is

--- a/src/olympia/editors/templates/editors/emails/author_super_review.ltxt
+++ b/src/olympia/editors/templates/editors/emails/author_super_review.ltxt
@@ -5,7 +5,7 @@ Your add-on, {{ name }} {{ number }}, has been flagged for Admin Review.
 
 Your add-on is still in our review queue, but it will need to be checked by one of our admin reviewers. This means that your review will probably take longer than usual.
 
-If you want to respond to this email please reply to this email or visit {{ dev_versions_url }} . If you need to send file attachments, please include the address amo-editors@mozilla.org and mention it in your reply.
+If you want to respond please reply to this email or visit {{ dev_versions_url }} .
 
 You can also join us in #addon-reviewers on irc.mozilla.org.
 

--- a/src/olympia/editors/templates/editors/emails/base.ltxt
+++ b/src/olympia/editors/templates/editors/emails/base.ltxt
@@ -2,7 +2,7 @@
 Hello,
 
 {% block content %}{% endblock %}
-If you want to respond please reply to this email or visit {{ dev_versions_url }} . If you need to send file attachments, please include the address amo-editors@mozilla.org and mention it in your reply.
+If you want to respond please reply to this email or visit {{ dev_versions_url }} .
 
 You can also join us in #addon-reviewers on irc.mozilla.org.
 

--- a/src/olympia/editors/tests/test_helpers.py
+++ b/src/olympia/editors/tests/test_helpers.py
@@ -342,7 +342,7 @@ class TestReviewHelper(TestCase):
 
     def test_notify_email(self):
         self.helper.set_data(self.get_data())
-        base_fragment = 'If you need to send file attachments'
+        base_fragment = 'If you want to respond please reply'
         legacy_cta_fragment = 'add-ons are compatible past Firefox 57'
         user = self.addon.listed_authors[0]
         ActivityLogToken.objects.create(version=self.version, user=user)

--- a/src/olympia/lib/crypto/tasks.py
+++ b/src/olympia/lib/crypto/tasks.py
@@ -188,5 +188,5 @@ def sign_addons(addon_ids, force=False, **kw):
                 amo.utils.send_mail(
                     subject, message, recipient_list=emails,
                     fail_silently=True,
-                    headers={'Reply-To': 'amo-editors@mozilla.org'})
+                    headers={'Reply-To': 'amo-admins@mozilla.org'})
                 addons_emailed.add(addon.pk)

--- a/src/olympia/pages/templates/pages/review_guide.html
+++ b/src/olympia/pages/templates/pages/review_guide.html
@@ -149,8 +149,7 @@
     <h3>{{ _('I’m an add-on author, can I delete unfavorable reviews or ratings?') }}</h3>
     <p>
       {% trans %}
-        In general, no. But if the review did not meet the review guidelines outlined above, you can click "Report this review" and have it moderated. If a review included a complaint that is no longer valid due to a new release of your add-on, we may consider deleting the review. Submit your detailed request to
-        amo-editors@mozilla.org.
+        In general, no. But if the review did not meet the review guidelines outlined above, you can click "Report this review" and have it moderated. If a review included a complaint that is no longer valid due to a new release of your add-on, we may consider deleting the review.
       {% endtrans %}
     </p>
   </section>


### PR DESCRIPTION
The amo-editors mailing list is going to be deprecated, now that we have activity email.