### PR TITLE
anonymize to delete();

### DIFF
--- a/src/olympia/api/tests/test_authentication.py
+++ b/src/olympia/api/tests/test_authentication.py
@@ -291,7 +291,7 @@ class TestWebTokenAuthentication(TestCase):
             self._authenticate(token)
 
     def test_user_deleted(self):
-        self.user.anonymize()
+        self.user.delete()
         token = self.client.generate_api_token(self.user)
         with self.assertRaises(AuthenticationFailed):
             self._authenticate(token)

--- a/src/olympia/users/admin.py
+++ b/src/olympia/users/admin.py
@@ -31,6 +31,9 @@ class UserAdmin(admin.ModelAdmin):
         }),
     )
 
+    def delete_model(self, request, obj):
+        obj.delete(hard=True)
+
 
 class DeniedModelAdmin(admin.ModelAdmin):
     def add_view(self, request, form_url='', extra_context=None):

--- a/src/olympia/users/forms.py
+++ b/src/olympia/users/forms.py
@@ -257,7 +257,7 @@ class AdminUserEditForm(UserEditForm):
         if self.cleaned_data['anonymize']:
             ActivityLog.create(amo.LOG.ADMIN_USER_ANONYMIZED, self.instance,
                                self.cleaned_data['admin_log'])
-            profile.anonymize()  # This also logs
+            profile.delete()  # This also logs
         else:
             ActivityLog.create(amo.LOG.ADMIN_USER_EDITED, self.instance,
                                self.cleaned_data['admin_log'],

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -320,16 +320,20 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
         # reviews-related tests hang if this isn't done.
         return qs
 
-    def delete(self):
-        log.info(u"User (%s: <%s>) is being anonymized." % (self, self.email))
-        self.email = None
-        self.fxa_id = None
-        self.username = "Anonymous-%s" % self.id  # Can't be null
-        self.display_name = None
-        self.homepage = ""
-        self.deleted = True
-        self.picture_type = ""
-        self.save()
+    def delete(self, hard=False):
+        if hard:
+            super(UserProfile, self).delete()
+        else:
+            log.info(
+                u'User (%s: <%s>) is being anonymized.' % (self, self.email))
+            self.email = None
+            self.fxa_id = None
+            self.username = "Anonymous-%s" % self.id  # Can't be null
+            self.display_name = None
+            self.homepage = ""
+            self.deleted = True
+            self.picture_type = ""
+            self.save()
 
     def set_unusable_password(self):
         raise NotImplementedError('cannot set unusable password')

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -177,9 +177,6 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
 
     backend = 'django.contrib.auth.backends.ModelBackend'
 
-    def is_anonymous(self):
-        return False
-
     def get_session_auth_hash(self):
         """Return a hash used to invalidate sessions of users when necessary.
 
@@ -323,7 +320,7 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
         # reviews-related tests hang if this isn't done.
         return qs
 
-    def anonymize(self):
+    def delete(self):
         log.info(u"User (%s: <%s>) is being anonymized." % (self, self.email))
         self.email = None
         self.fxa_id = None

--- a/src/olympia/users/tests/test_models.py
+++ b/src/olympia/users/tests/test_models.py
@@ -41,10 +41,10 @@ class TestUserProfile(TestCase):
         del user.is_developer
         assert not user.is_developer
 
-    def test_anonymize(self):
+    def test_delete(self):
         u = UserProfile.objects.get(id='4043307')
         assert u.email == 'jbalogh@mozilla.com'
-        u.anonymize()
+        u.delete()
         x = UserProfile.objects.get(id='4043307')
         assert x.email is None
 

--- a/src/olympia/users/views.py
+++ b/src/olympia/users/views.py
@@ -95,7 +95,7 @@ def delete(request):
         form = forms.UserDeleteForm(request.POST, request=request)
         if form.is_valid():
             messages.success(request, ugettext('Profile Deleted'))
-            amouser.anonymize()
+            amouser.delete()
             response = http.HttpResponseRedirect(reverse('home'))
             logout_user(request, response)
             return response


### PR DESCRIPTION
Sort of fixes #5440.  

Doesn't rename anonymous_username and similar -  partly because I couldn't think of a good alternative name; partly because we use 'anonymous' in the username so it might be (more) confusing if the methods setting that are called something different.