### PR TITLE
Fix language packs with broken summary translation instance.

### DIFF
--- a/src/olympia/zadmin/management/commands/fix_langpack_summary.py
+++ b/src/olympia/zadmin/management/commands/fix_langpack_summary.py
@@ -1,0 +1,39 @@
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.db.models import Q, F
+
+from olympia.users.models import UserProfile
+from olympia.translations.models import Translation
+
+
+class Command(BaseCommand):
+    help = "Fix summary of broken language packs for #5432"
+
+    def handle(self, *args, **options):
+        log = self.stdout.write
+
+        owner = UserProfile.objects.get(email=settings.LANGPACK_OWNER_EMAIL)
+        broken_langpacks = owner.addons.filter(Q(summary_id=F('name_id')))
+
+        for langpack in broken_langpacks:
+            log(u'Attempt to fix %s' % langpack)
+
+            name_values_qset = (
+                Translation.objects
+                .filter(id=langpack.name.id)
+                .values_list('locale', 'localized_string'))
+
+            name_values = {locale: value for locale, value in name_values_qset}
+
+            # Force `summary` to be set to a new translation instance
+            delattr(langpack, 'summary_id')
+
+            # Now set summary to all the values of `name` but with a new
+            # translation object.
+            langpack.summary = name_values
+
+            langpack.save()
+
+            assert langpack.summary_id != langpack.name_id
+
+            log(u'fixed %s' % langpack)

--- a/src/olympia/zadmin/tasks.py
+++ b/src/olympia/zadmin/tasks.py
@@ -616,7 +616,7 @@ def fetch_langpack(url, xpi, **kw):
 
         # Finally, set the addon summary if one wasn't provided in the xpi.
         addon.status = amo.STATUS_PUBLIC
-        addon.summary = addon.summary if addon.summary else str(addon.name)
+        addon.summary = addon.summary if addon.summary else unicode(addon.name)
         addon.save(update_fields=('status', 'summary'))
         addon.update_status()
 

--- a/src/olympia/zadmin/tasks.py
+++ b/src/olympia/zadmin/tasks.py
@@ -615,8 +615,9 @@ def fetch_langpack(url, xpi, **kw):
         sign_file(file_, settings.SIGNING_SERVER)
 
         # Finally, set the addon summary if one wasn't provided in the xpi.
-        addon.update(status=amo.STATUS_PUBLIC,
-                     summary=(addon.summary if addon.summary else addon.name))
+        addon.status = amo.STATUS_PUBLIC
+        addon.summary = addon.summary if addon.summary else str(addon.name)
+        addon.save(update_fields=('status', 'summary'))
         addon.update_status()
 
 

--- a/src/olympia/zadmin/tests/test_commands.py
+++ b/src/olympia/zadmin/tests/test_commands.py
@@ -1,7 +1,8 @@
 from django.core import management
+from django.conf import settings
 
 from olympia import amo
-from olympia.amo.tests import TestCase
+from olympia.amo.tests import TestCase, addon_factory
 from olympia.access.acl import action_allowed_user
 from olympia.users.models import UserProfile
 
@@ -20,3 +21,37 @@ class TestCommand(TestCase):
         management.call_command('removeuserfromgroup', '10968', '1')
         del user.groups_list
         assert not action_allowed_user(user, amo.permissions.ADMIN)
+
+    def test_fix_langpack_summary(self):
+        """What happened on our production system:
+
+        The `zadmin.tasks.fetch_langpack` task set `summary` to the
+        same translation instance of `name` for add-ons without a
+        summary set.
+
+        This meant that changing `name` or `summary` automatically
+        changed the other one.
+        """
+        owner = UserProfile.objects.get(email=settings.LANGPACK_OWNER_EMAIL)
+        a1 = addon_factory(name='addon 1', users=[owner])
+        a1.summary = a1.name
+        a1.save()
+
+        # We won't touch this add-on, wrong owner
+        a2 = addon_factory(name='addon 2', users=[owner])
+        a2.summary = a2.name
+        a2.save()
+
+        assert a1.summary.id == a1.name.id
+        assert a2.summary.id == a2.summary.id
+
+        # Now, let's fix this mess.
+        management.call_command('fix_langpack_summary')
+
+        a1.refresh_from_db()
+        a2.refresh_from_db()
+
+        assert a1.summary_id != a1.name_id
+
+        # Didn't touch wrong owner add-on
+        assert a2.summary_id == a2.summary_id


### PR DESCRIPTION
Fixes #5432 

What happened on our production system:

The `zadmin.tasks.fetch_langpack` task set `summary` to the
same translation instance of `name` for add-ons without a
summary set.
This meant that changing `name` or `summary` automatically
changed the other one.
