### PR TITLE
Temporarily hide public version source code links.

### DIFF
--- a/src/olympia/versions/templates/versions/version.html
+++ b/src/olympia/versions/templates/versions/version.html
@@ -52,14 +52,6 @@
             {{ _("What's this?") }}</a>
         </li>
     {% endif %}
-    {% if addon.view_source and version.has_files and
-          addon.status in amo.REVIEWED_STATUSES %}
-      <li>
-        <a class="source-code"
-           href="{{ url('files.list', version.all_files[0].pk) }}">
-          {{ _('View the source') }}</a>
-      </li>
-    {% endif %}
     </ul>
 
   </div>

--- a/src/olympia/versions/tests/test_views.py
+++ b/src/olympia/versions/tests/test_views.py
@@ -8,6 +8,7 @@ from django.utils.http import urlquote
 from django.test.utils import override_settings
 
 import mock
+import pytest
 from pyquery import PyQuery
 
 from olympia import amo
@@ -83,6 +84,7 @@ class TestViews(TestCase):
         assert response.status_code == 200
         return PyQuery(response.content)
 
+    @pytest.mark.xfail(reason='Temporarily hidden, #5431')
     def test_version_source(self):
         self.addon.update(view_source=True)
         assert len(self.get_content()('a.source-code')) == 1


### PR DESCRIPTION
Fixes #5431

I couldn't find any other references, this seems to be the main template that's included in all version information templates.