### PR TITLE
Prevent dynamic fields in reviewer tools from being shown for the wrong action

### DIFF
--- a/src/olympia/editors/forms.py
+++ b/src/olympia/editors/forms.py
@@ -290,8 +290,11 @@ class ReviewForm(happyforms.Form):
     canned_response = NonValidatingChoiceField(required=False)
     action = forms.ChoiceField(required=True, widget=forms.RadioSelect())
     versions = ModelMultipleChoiceField(
-        widget=forms.SelectMultiple(attrs={
-            'class': 'data-toggle', 'data-value': 'reject_multiple_versions'}),
+        widget=forms.SelectMultiple(
+            attrs={
+                'class': 'data-toggle',
+                'data-value': 'reject_multiple_versions|'
+            }),
         required=False,
         queryset=Version.objects.none())  # queryset is set later in __init__.
 
@@ -333,7 +336,7 @@ class ReviewForm(happyforms.Form):
         # don't really care about this field.
         if 'reject_multiple_versions' in self.helper.actions:
             self.fields['versions'].queryset = (
-                self.helper.addon.versions.filter(
+                self.helper.addon.versions.distinct().filter(
                     channel=amo.RELEASE_CHANNEL_LISTED,
                     files__status=amo.STATUS_PUBLIC).order_by('created'))
 

--- a/src/olympia/editors/helpers.py
+++ b/src/olympia/editors/helpers.py
@@ -449,15 +449,21 @@ class ReviewHelper(object):
                     'minimal': True,
                     'comments': False,
                 }
-            # In any case, they can reject multiple versions in one action.
-            actions['reject_multiple_versions'] = {
-                'method': self.handler.reject_multiple_versions,
-                'label': _('Reject Multiple Versions'),
-                'minimal': True,
-                'versions': True,
-                'details': _('This will reject the selected versions. '
-                             'The comments will be sent to the developer.'),
-            }
+            if (self.version and self.addon.status == amo.STATUS_PUBLIC and
+                    self.version.channel == amo.RELEASE_CHANNEL_LISTED):
+                # They can reject multiple versions in one action on the listed
+                # review page, if the add-on is public (it's useless if the
+                # add-on is not public: that means there should only be one
+                # version to reject at most).
+                actions['reject_multiple_versions'] = {
+                    'method': self.handler.reject_multiple_versions,
+                    'label': _('Reject Multiple Versions'),
+                    'minimal': True,
+                    'versions': True,
+                    'details': _('This will reject the selected public '
+                                 'versions. The comments will be sent to the '
+                                 'developer.'),
+                }
         if self.version:
             actions['info'] = {
                 'method': self.handler.request_information,

--- a/src/olympia/editors/templates/editors/review.html
+++ b/src/olympia/editors/templates/editors/review.html
@@ -157,7 +157,7 @@
     <div id="review-actions-form">
 
       {% for (setting, action) in actions %}
-      <div class="data-toggle review-actions-desc" data-value="{{ setting }}">
+      <div class="data-toggle review-actions-desc" data-value="{{ setting }}|">
         {{ action['details'] }}
 
         {# We don't have a better place to display versions error messages, so let's do it here.
@@ -176,8 +176,8 @@
       {{ form.versions }}
       {{ form.versions.errors }}
 
-      <div class="review-actions-section data-toggle"
-           data-value="{{ actions_comments|join("|") }}">
+      <div class="review-actions-section data-toggle review-comments"
+           data-value="{{ actions_comments|join("|") }}|">
         <label for="id_comments">{{ form.comments.label }}</label>
         {{ form.comments }}
         {{ form.comments.errors }}
@@ -187,8 +187,8 @@
         </div>
       </div>
 
-      <div class="review-actions-section review-actions-files data-toggle"
-           data-value="{{ actions_minimal|join("|") }}">
+      <div class="review-actions-section review-actions-files data-toggle review-files"
+           data-value="{{ actions_minimal|join("|") }}|">
         <label><strong>{{ _('Files:') }}</strong></label>
         <ul>
           {% for file in form.unreviewed_files %}
@@ -201,8 +201,8 @@
         </ul>
       </div>
 
-      <div class="review-actions-section review-actions-tested data-toggle"
-           data-value="{{ actions_minimal|join("|") }}">
+      <div class="review-actions-section review-actions-tested data-toggle review-tested"
+           data-value="{{ actions_minimal|join("|") }}|">
         <strong>{{ _('Tested on:') }}</strong>
         <label>
           {{ form.operating_systems.label }}

--- a/src/olympia/editors/tests/test_forms.py
+++ b/src/olympia/editors/tests/test_forms.py
@@ -3,7 +3,8 @@ import mock
 from django.utils.encoding import force_text
 
 from olympia import amo
-from olympia.amo.tests import addon_factory, TestCase, version_factory
+from olympia.amo.tests import (
+    addon_factory, file_factory, TestCase, version_factory)
 from olympia.addons.models import Addon
 from olympia.editors.forms import ReviewForm
 from olympia.editors.helpers import ReviewHelper
@@ -117,6 +118,7 @@ class TestReviewForm(TestCase):
 
     def test_versions_queryset(self):
         addon_factory()
+        file_factory(version=self.addon.current_version)
         version_factory(addon=self.addon, channel=amo.RELEASE_CHANNEL_UNLISTED)
         form = self.get_form()
         assert not form.is_bound

--- a/static/js/zamboni/editors.js
+++ b/static/js/zamboni/editors.js
@@ -75,8 +75,13 @@ function initReviewActions() {
           $('#review-actions').find('.errorlist').remove();
         }
 
+        // Hide everything, then show the ones containing the value we're
+        // interested in. An extra | (the separator used) is added at the end
+        // to make sure we don't match things with a common prefix (i.e. don't
+        // show elements with data-value="reject_multiple_versions" when the
+        // value is "reject".)
         $data_toggle.hide();
-        $data_toggle.filter('[data-value*="' + value + '"]').show();
+        $data_toggle.filter('[data-value*="' + value + '|"]').show();
 
         /* Fade out canned responses */
         var label = $element.text().trim();


### PR DESCRIPTION
fields with `data-value="reject_multiple_versions"` were shown for the `reject` action because the value started with `"reject"`... Added a separator at the end of every value list, and made sure to always include the separator when searching, guaranteeing an exact match.

Also limit `reject_multiple_versions` to listed, public add-ons and make sure the same version is not shown multiple times if it has multiple files while we're at it.

Fix #5508 