### PR TITLE
Record auto-approval confirmation on the current version

### DIFF
--- a/src/olympia/editors/helpers.py
+++ b/src/olympia/editors/helpers.py
@@ -718,9 +718,11 @@ class ReviewBase(object):
         is incrementing AddonApprovalsCounter, which also resets the last
         human review date to now, and log it so that it's displayed later
         in the review page."""
-        self.version = self.addon.current_version
         AddonApprovalsCounter.increment_for_addon(addon=self.addon)
-        self.log_action(amo.LOG.CONFIRM_AUTO_APPROVED)
+        # Log using the latest public version, not self.version, which could
+        # be awaiting review still.
+        self.log_action(
+            amo.LOG.CONFIRM_AUTO_APPROVED, version=self.addon.current_version)
 
     def reject_multiple_versions(self):
         """Reject a list of versions."""

--- a/src/olympia/editors/helpers.py
+++ b/src/olympia/editors/helpers.py
@@ -718,6 +718,7 @@ class ReviewBase(object):
         is incrementing AddonApprovalsCounter, which also resets the last
         human review date to now, and log it so that it's displayed later
         in the review page."""
+        self.version = self.addon.current_version
         AddonApprovalsCounter.increment_for_addon(addon=self.addon)
         self.log_action(amo.LOG.CONFIRM_AUTO_APPROVED)
 

--- a/src/olympia/editors/tests/test_helpers.py
+++ b/src/olympia/editors/tests/test_helpers.py
@@ -708,6 +708,43 @@ class TestReviewHelper(TestCase):
         approvals_counter = AddonApprovalsCounter.objects.get(addon=self.addon)
         self.assertCloseToNow(approvals_counter.last_human_review)
         assert self.check_log_count(amo.LOG.CONFIRM_AUTO_APPROVED.id) == 1
+        activity = (ActivityLog.objects.for_addons(self.addon)
+                               .filter(action=amo.LOG.CONFIRM_AUTO_APPROVED.id)
+                               .get())
+        assert activity.arguments == [self.addon, self.version]
+
+    def test_public_with_unreviewed_version_addon_confirm_auto_approval(self):
+        self.setup_data(amo.STATUS_PUBLIC, file_status=amo.STATUS_PUBLIC)
+        AutoApprovalSummary.objects.create(
+            version=self.version, verdict=amo.AUTO_APPROVED)
+        self.version = version_factory(
+            addon=self.addon, version='3.0',
+            file_kw={'status': amo.STATUS_AWAITING_REVIEW})
+        self.file = self.version.files.all()[0]
+        self.helper = self.get_helper()  # To make it pick up the new version.
+        self.helper.set_data(self.get_data())
+
+        # Safeguards.
+        self.addon.reload()
+        assert self.addon.status == amo.STATUS_PUBLIC
+        assert self.file.status == amo.STATUS_AWAITING_REVIEW
+        assert self.addon.current_version.files.all()[0].status == (
+            amo.STATUS_PUBLIC)
+        assert self.version == self.addon.find_latest_version(
+            channel=amo.RELEASE_CHANNEL_LISTED)
+        assert self.version != self.addon.current_version
+
+        self.helper.handler.confirm_auto_approved()
+
+        approvals_counter = AddonApprovalsCounter.objects.get(addon=self.addon)
+        self.assertCloseToNow(approvals_counter.last_human_review)
+        assert self.check_log_count(amo.LOG.CONFIRM_AUTO_APPROVED.id) == 1
+        activity = (ActivityLog.objects.for_addons(self.addon)
+                               .filter(action=amo.LOG.CONFIRM_AUTO_APPROVED.id)
+                               .get())
+        # The log should have been created with the current public version,
+        # not the latest (unreviewed) one.
+        assert activity.arguments == [self.addon, self.addon.current_version]
 
     @patch('olympia.editors.helpers.sign_file')
     def test_null_to_public_unlisted(self, sign_mock):


### PR DESCRIPTION
Through it's unlikely a post-reviewer would confirm approval when a new version is pending review, it should be recorded on the current version, not the latest one.

Fix #5456