### PR TITLE
Use DOMAIN to derive FXA_CONFIG['default']['redirect_url']

### DIFF
--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -242,7 +242,7 @@ FXA_CONFIG = {
         'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
         'profile_host': 'https://stable.dev.lcip.org/profile/v1',
         'redirect_url':
-            'https://addons-dev.allizom.org/api/v3/accounts/authenticate/',
+            'https://%s/api/v3/accounts/authenticate/' % DOMAIN,
         'scope': 'profile',
     },
     'internal': {

--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -203,7 +203,7 @@ FXA_CONFIG = {
         'oauth_host': 'https://oauth.accounts.firefox.com/v1',
         'profile_host': 'https://profile.accounts.firefox.com/v1',
         'redirect_url':
-            'https://addons.mozilla.org/api/v3/accounts/authenticate/',
+            'https://%s/api/v3/accounts/authenticate/' % DOMAIN,
         'scope': 'profile',
     },
     'internal': {

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -236,7 +236,7 @@ FXA_CONFIG = {
         'oauth_host': 'https://oauth.accounts.firefox.com/v1',
         'profile_host': 'https://profile.accounts.firefox.com/v1',
         'redirect_url':
-            'https://addons.allizom.org/api/v3/accounts/authenticate/',
+            'https://%s/api/v3/accounts/authenticate/' % DOMAIN,
         'scope': 'profile',
     },
     'internal': {


### PR DESCRIPTION
As part of bug 1244224 we will need to override FXA_CONFIG['default'] for the internal endpoint so that users can login correctly. This change adjusts FXA_CONFIG['default']['redirect_url'] to be derived from DOMAIN since we need to point it to the internal endpoint and we override DOMAIN via config as part of the internal endpoint deployment. This should not affect the current configuration as we fall back to the default DOMAIN value if it is unset.

r?