### PR TITLE
Add a weight to prioritize auto-approved add-ons

### DIFF
--- a/src/olympia/addons/management/commands/process_addons.py
+++ b/src/olympia/addons/management/commands/process_addons.py
@@ -11,6 +11,7 @@ from olympia.addons.tasks import (
     add_firefox57_tag, find_inconsistencies_between_es_and_db)
 from olympia.amo.utils import chunked
 from olympia.devhub.tasks import convert_purified, get_preview_sizes
+from olympia.editors.tasks import recalculate_post_review_weight
 from olympia.lib.crypto.tasks import sign_addons
 from olympia.reviews.tasks import addon_review_aggregates
 
@@ -21,6 +22,11 @@ tasks = {
     'get_preview_sizes': {'method': get_preview_sizes, 'qs': []},
     'convert_purified': {'method': convert_purified, 'qs': []},
     'addon_review_aggregates': {'method': addon_review_aggregates, 'qs': []},
+    'recalculate_post_review_weight': {
+        'method': recalculate_post_review_weight,
+        'qs': [
+            Q(_current_version__autoapprovalsummary__verdict=amo.AUTO_APPROVED)
+        ]},
     'sign_addons': {'method': sign_addons, 'qs': []},
     'add_firefox57_tag_to_webextensions': {
         'method': add_firefox57_tag,

--- a/src/olympia/addons/tests/test_commands.py
+++ b/src/olympia/addons/tests/test_commands.py
@@ -9,8 +9,8 @@ import pytest
 from olympia import amo
 from olympia.activity.models import AddonLog
 from olympia.addons.management.commands import approve_addons
-from olympia.amo.tests import addon_factory, TestCase
-from olympia.editors.models import ReviewerScore
+from olympia.amo.tests import addon_factory, TestCase, version_factory
+from olympia.editors.models import AutoApprovalSummary, ReviewerScore
 
 
 # Where to monkeypatch "lib.crypto.tasks.sign_addons" so it's correctly mocked.
@@ -235,3 +235,57 @@ class AddFirefox57TagTestCase(TestCase):
         assert (
             set(self.addon.tags.all().values_list('tag_text', flat=True)) ==
             set(['firefox57']))
+
+
+class RecalculateWeightTestCase(TestCase):
+    @mock.patch('olympia.editors.tasks.recalculate_post_review_weight.subtask')
+    def test_only_affects_auto_approved(
+            self, recalculate_post_review_weight_mock):
+        # Non auto-approved add-on, should not be considered.
+        addon_factory()
+
+        # Non auto-approved add-on that has an AutoApprovalSummary entry,
+        # should not be considered.
+        AutoApprovalSummary.objects.create(
+            version=addon_factory().current_version,
+            verdict=amo.NOT_AUTO_APPROVED)
+
+        # Add-on with the current version not auto-approved, should not be
+        # considered.
+        extra_addon = addon_factory()
+        AutoApprovalSummary.objects.create(
+            version=extra_addon.current_version, verdict=amo.AUTO_APPROVED)
+        extra_addon.current_version.update(created=self.days_ago(1))
+        version_factory(addon=extra_addon)
+
+        # Add-on that should be considered because it's current version is
+        # auto-approved.
+        auto_approved_addon = addon_factory()
+        AutoApprovalSummary.objects.create(
+            version=auto_approved_addon.current_version,
+            verdict=amo.AUTO_APPROVED)
+        # Add some extra versions that should not have an impact.
+        version_factory(
+            addon=auto_approved_addon,
+            file_kw={'status': amo.STATUS_AWAITING_REVIEW})
+        version_factory(
+            addon=auto_approved_addon, channel=amo.RELEASE_CHANNEL_UNLISTED)
+
+        call_command(
+            'process_addons', task='recalculate_post_review_weight')
+
+        assert recalculate_post_review_weight_mock.call_count == 1
+        recalculate_post_review_weight_mock.assert_called_with(
+            args=[[auto_approved_addon.pk]], kwargs={})
+
+    def test_task_works_correctly(self):
+        addon = addon_factory(average_daily_users=100000)
+        summary = AutoApprovalSummary.objects.create(
+            version=addon.current_version, verdict=amo.AUTO_APPROVED)
+        assert summary.weight == 0
+
+        call_command(
+            'process_addons', task='recalculate_post_review_weight')
+
+        summary.reload()
+        assert summary.weight == 10  # Because of average_daily_users / 10000.

--- a/src/olympia/editors/helpers.py
+++ b/src/olympia/editors/helpers.py
@@ -299,25 +299,33 @@ class ViewFullReviewQueueTable(EditorQueueTable):
 
 
 class AutoApprovedTable(EditorQueueTable):
-    addon = tables.Column(verbose_name=_(u'Add-on'))
+    addon_name = tables.Column(verbose_name=_(u'Add-on'), accessor='name')
     # Override empty_values for flags so that they can be displayed even if the
     # model does not have a flags attribute.
     flags = tables.Column(
         verbose_name=_(u'Flags'), empty_values=(), orderable=False)
     last_human_review = tables.DateTimeColumn(
-        verbose_name=_(u'Last Review'))
+        verbose_name=_(u'Last Review'),
+        accessor='addonapprovalscounter.last_human_review')
+    weight = tables.Column(
+        verbose_name=_(u'Weight'),
+        accessor='_current_version.autoapprovalsummary.weight')
 
     class Meta(EditorQueueTable.Meta):
-        fields = ('addon', 'flags', 'last_human_review')
+        fields = ('addon_name', 'flags', 'last_human_review', 'weight')
         # Exclude base fields EditorQueueTable has that we don't want.
-        exclude = ('addon_name', 'addon_type_id', 'waiting_time_min',)
+        exclude = ('addon_type_id', 'waiting_time_min',)
         orderable = False
 
-    def render_addon(self, record):
-        url = reverse('editors.review', args=[record.addon.slug])
+    def render_flags(self, record):
+        return super(AutoApprovedTable, self).render_flags(
+            record.current_version)
+
+    def render_addon_name(self, record):
+        url = reverse('editors.review', args=[record.slug])
         return u'<a href="%s">%s <em>%s</em></a>' % (
-            url, jinja2.escape(record.addon.name),
-            jinja2.escape(record.addon.current_version))
+            url, jinja2.escape(record.name),
+            jinja2.escape(record.current_version))
 
     def render_last_human_review(self, value):
         return naturaltime(value) if value else ''

--- a/src/olympia/editors/tasks.py
+++ b/src/olympia/editors/tasks.py
@@ -169,7 +169,9 @@ def recalculate_post_review_weight(ids):
     auto-approved add-on versions from a list of ids."""
     addons = Addon.objects.filter(id__in=ids)
     for addon in addons:
-        for summary in AutoApprovalSummary.objects.filter(
-                version__in=addon.versions.all()):
+        summaries = AutoApprovalSummary.objects.filter(
+            version__in=addons.versions.all())
+
+        for summary in summaries:
             summary.calculate_weight()
             summary.save()

--- a/src/olympia/editors/tasks.py
+++ b/src/olympia/editors/tasks.py
@@ -6,9 +6,11 @@ from django.utils.translation import override, ugettext
 import olympia.core.logger
 from olympia.constants import editors as rvw
 from olympia.activity.models import ActivityLog, CommentLog, VersionLog
+from olympia.addons.models import Addon
 from olympia.addons.tasks import create_persona_preview_images
 from olympia.amo.celery import task
 from olympia.amo.decorators import write
+from olympia.editors.models import AutoApprovalSummary
 from olympia.amo.helpers import user_media_path
 from olympia.amo.storage_utils import copy_stored_file, move_stored_file
 from olympia.amo.utils import LocalFileStorage, send_mail_jinja
@@ -158,3 +160,16 @@ def reject_rereview(theme):
     if reupload.footer:
         storage.delete(reupload.footer_path)
     rereview.delete()
+
+
+@task
+@write
+def recalculate_post_review_weight(ids):
+    """Recalculate the post-review weight that should be assigned to
+    auto-approved add-on versions from a list of ids."""
+    addons = Addon.objects.filter(id__in=ids)
+    for addon in addons:
+        for summary in AutoApprovalSummary.objects.filter(
+                version__in=addon.versions.all()):
+            summary.calculate_weight()
+            summary.save()

--- a/src/olympia/editors/tasks.py
+++ b/src/olympia/editors/tasks.py
@@ -170,7 +170,7 @@ def recalculate_post_review_weight(ids):
     addons = Addon.objects.filter(id__in=ids)
     for addon in addons:
         summaries = AutoApprovalSummary.objects.filter(
-            version__in=addons.versions.all())
+            version__in=addon.versions.all())
 
         for summary in summaries:
             summary.calculate_weight()

--- a/src/olympia/editors/tests/test_models.py
+++ b/src/olympia/editors/tests/test_models.py
@@ -771,6 +771,16 @@ class TestAutoApprovalSummary(TestCase):
         assert summary.weight == 4
         assert weight_info['negative_reviews'] == 4
 
+        # Create fifty more to make sure it's capped at 100.
+        reviews = [Review(
+            user=user_factory(), addon=self.addon,
+            version=self.version, rating=3) for i in range(0, 50)]
+        Review.objects.bulk_create(reviews)
+
+        weight_info = summary.calculate_weight()
+        assert summary.weight == 100
+        assert weight_info['negative_reviews'] == 100
+
     def test_calculate_weight_average_daily_users(self):
         self.addon.update(average_daily_users=142444)
         summary = AutoApprovalSummary(version=self.version)

--- a/src/olympia/editors/tests/test_models.py
+++ b/src/olympia/editors/tests/test_models.py
@@ -8,12 +8,14 @@ from django.conf import settings
 from django.core import mail
 
 from olympia import amo
+from olympia.abuse.models import AbuseReport
 from olympia.activity.models import ActivityLog
 from olympia.amo.tests import TestCase
 from olympia.amo.tests import (
     addon_factory, file_factory, user_factory, version_factory)
 from olympia.addons.models import Addon, AddonApprovalsCounter, AddonUser
 from olympia.files.models import FileValidation
+from olympia.reviews.models import Review
 from olympia.versions.models import (
     Version, version_uploaded)
 from olympia.files.models import File, WebextPermission
@@ -674,6 +676,161 @@ class TestAutoApprovalSummary(TestCase):
             file=self.version.all_files[0], validation=u'{}')
         AddonApprovalsCounter.objects.create(addon=self.addon, counter=1)
 
+    def test_calculate_weight(self):
+        summary = AutoApprovalSummary(version=self.version)
+        weight_info = summary.calculate_weight()
+        expected_result = {
+            'abuse_reports': 0,
+            'admin_review': 0,
+            'average_daily_users': 0,
+            'negative_reviews': 0,
+            'past_rejection_history': 0
+        }
+        assert weight_info == expected_result
+
+    def test_calculate_weight_admin_review(self):
+        self.addon.update(admin_review=True)
+        summary = AutoApprovalSummary(version=self.version)
+        weight_info = summary.calculate_weight()
+        assert summary.weight == 100
+        assert weight_info['admin_review'] == 100
+
+    def test_calculate_weight_abuse_reports(self):
+        # Extra abuse report for a different add-on, does not count.
+        AbuseReport.objects.create(addon=addon_factory())
+
+        # Extra abuse report for a different user, does not count.
+        AbuseReport.objects.create(user=user_factory())
+
+        # Extra old abuse report, does not count either.
+        old_report = AbuseReport.objects.create(addon=self.addon)
+        old_report.update(created=self.days_ago(370))
+
+        # Recent abuse reports.
+        AbuseReport.objects.create(addon=self.addon)
+        AbuseReport.objects.create(addon=self.addon)
+
+        # Recent abuse report for one of the developers of the add-on.
+        author = user_factory()
+        AddonUser.objects.create(addon=self.addon, user=author)
+        AbuseReport.objects.create(user=author)
+
+        summary = AutoApprovalSummary(version=self.version)
+        weight_info = summary.calculate_weight()
+        assert summary.weight == 30
+        assert weight_info['abuse_reports'] == 30
+
+        # Should be capped at 100.
+        for i in range(0, 10):
+            AbuseReport.objects.create(addon=self.addon)
+        weight_info = summary.calculate_weight()
+        assert summary.weight == 100
+        assert weight_info['abuse_reports'] == 100
+
+    def test_calculate_weight_negative_reviews(self):
+        # Positive review, does not count.
+        Review.objects.create(
+            user=user_factory(), addon=self.addon, version=self.version,
+            rating=5)
+
+        # Negative review, but too old, does not count.
+        old_review = Review.objects.create(
+            user=user_factory(), addon=self.addon, version=self.version,
+            rating=1)
+        old_review.update(created=self.days_ago(370))
+
+        # Negative review on a different add-on, does not count either.
+        extra_addon = addon_factory()
+        Review.objects.create(
+            user=user_factory(), addon=extra_addon,
+            version=extra_addon.current_version, rating=1)
+
+        # Recent negative reviews.
+        Review.objects.create(
+            user=user_factory(), addon=self.addon, version=self.version,
+            rating=1)
+        Review.objects.create(
+            user=user_factory(), addon=self.addon, version=self.version,
+            rating=2)
+        summary = AutoApprovalSummary(version=self.version)
+        weight_info = summary.calculate_weight()
+        assert summary.weight == 4
+        assert weight_info['negative_reviews'] == 4
+
+    def test_calculate_weight_average_daily_users(self):
+        self.addon.update(average_daily_users=142444)
+        summary = AutoApprovalSummary(version=self.version)
+        weight_info = summary.calculate_weight()
+        assert summary.weight == 14
+        assert weight_info['average_daily_users'] == 14
+
+        self.addon.update(average_daily_users=1756567658)
+        summary = AutoApprovalSummary(version=self.version)
+        weight_info = summary.calculate_weight()
+        assert summary.weight == 100
+        assert weight_info['average_daily_users'] == 100
+
+    def test_calculate_weight_past_rejection_history(self):
+        # Old rejected version, does not count.
+        version_factory(
+            addon=self.addon,
+            file_kw={'reviewed': self.days_ago(370),
+                     'status': amo.STATUS_DISABLED})
+
+        # Version disabled by the developer, not Mozilla (original_status
+        # is set to something different than STATUS_NULL), does not count.
+        version_factory(
+            addon=self.addon,
+            file_kw={'reviewed': self.days_ago(15),
+                     'status': amo.STATUS_DISABLED,
+                     'original_status': amo.STATUS_PUBLIC})
+
+        # Rejected version.
+        version_factory(
+            addon=self.addon,
+            file_kw={'reviewed': self.days_ago(14),
+                     'status': amo.STATUS_DISABLED})
+
+        # Another rejected version, with multiple files. Only counts once.
+        version_with_multiple_files = version_factory(
+            addon=self.addon,
+            file_kw={'reviewed': self.days_ago(13),
+                     'status': amo.STATUS_DISABLED,
+                     'platform': amo.PLATFORM_WIN.id})
+        file_factory(
+            reviewed=self.days_ago(13),
+            version=version_with_multiple_files,
+            status=amo.STATUS_DISABLED,
+            platform=amo.PLATFORM_MAC.id)
+
+        # Rejected version on a different add-on, does not count.
+        version_factory(
+            addon=addon_factory(),
+            file_kw={'reviewed': self.days_ago(12),
+                     'status': amo.STATUS_DISABLED})
+
+        # Approved version, does not count.
+        version_factory(
+            addon=self.addon,
+            file_kw={'reviewed': self.days_ago(11)})
+
+        summary = AutoApprovalSummary(version=self.version)
+        weight_info = summary.calculate_weight()
+        assert summary.weight == 20
+        assert weight_info['past_rejection_history'] == 20
+
+        # Should be capped at 100.
+        for i in range(0, 10):
+            version_factory(
+                addon=self.addon,
+                file_kw={'reviewed': self.days_ago(10),
+                         'status': amo.STATUS_DISABLED})
+
+        summary = AutoApprovalSummary(version=self.version)
+        weight_info = summary.calculate_weight()
+        assert summary.weight == 100
+        assert weight_info['past_rejection_history'] == 100
+
     def test_check_uses_custom_csp(self):
         assert AutoApprovalSummary.check_uses_custom_csp(self.version) is False
 
@@ -756,12 +913,15 @@ class TestAutoApprovalSummary(TestCase):
         self.version.update(has_info_request=True)
         assert AutoApprovalSummary.check_has_info_request(self.version) is True
 
+    @mock.patch.object(AutoApprovalSummary, 'calculate_weight', spec=True)
     @mock.patch.object(AutoApprovalSummary, 'calculate_verdict', spec=True)
-    def test_create_summary_for_version(self, calculate_verdict_mock):
+    def test_create_summary_for_version(
+            self, calculate_verdict_mock, calculate_weight_mock):
         calculate_verdict_mock.return_value = {'dummy_verdict': True}
         summary, info = AutoApprovalSummary.create_summary_for_version(
             self.version,
             max_average_daily_users=111, min_approved_updates=222)
+        assert calculate_weight_mock.call_count == 1
         assert calculate_verdict_mock.call_count == 1
         assert calculate_verdict_mock.call_args == ({
             'max_average_daily_users': 111,

--- a/src/olympia/editors/tests/test_models.py
+++ b/src/olympia/editors/tests/test_models.py
@@ -727,6 +727,20 @@ class TestAutoApprovalSummary(TestCase):
         assert summary.weight == 100
         assert weight_info['abuse_reports'] == 100
 
+    def test_calculate_weight_abuse_reports_use_created_from_instance(self):
+        # Create an abuse report 400 days in the past. It should be ignored it
+        # we were calculating from today, but use an AutoApprovalSummary
+        # instance that is 40 days old, making the abuse report count.
+        report = AbuseReport.objects.create(addon=self.addon)
+        report.update(created=self.days_ago(400))
+
+        summary = AutoApprovalSummary.objects.create(version=self.version)
+        summary.update(created=self.days_ago(40))
+
+        weight_info = summary.calculate_weight()
+        assert summary.weight == 10
+        assert weight_info['abuse_reports'] == 10
+
     def test_calculate_weight_negative_reviews(self):
         # Positive review, does not count.
         Review.objects.create(

--- a/src/olympia/editors/tests/test_views.py
+++ b/src/olympia/editors/tests/test_views.py
@@ -1285,7 +1285,12 @@ class TestAutoApprovedQueue(QueueTest):
         addon3 = addon_factory(name=u'Addôn 3', created=self.days_ago(10))
         AutoApprovalSummary.objects.create(
             version=addon3.current_version, verdict=amo.AUTO_APPROVED)
-        self.expected_addons = [addon2, addon3, addon1]
+        # Has been auto-approved, should be first because of its weight.
+        addon4 = addon_factory(name=u'Addôn 3', created=self.days_ago(14))
+        AutoApprovalSummary.objects.create(
+            version=addon4.current_version, verdict=amo.AUTO_APPROVED,
+            weight=500)
+        self.expected_addons = [addon4, addon2, addon3, addon1]
 
     def test_only_viewable_with_specific_permission(self):
         # Regular addon reviewer does not have access.
@@ -1311,10 +1316,10 @@ class TestAutoApprovedQueue(QueueTest):
         assert response.status_code == 200
         doc = pq(response.content)
         link = doc('.tabnav li a').eq(3)
-        assert link.text() == 'Auto Approved Add-ons (3)'
+        assert link.text() == 'Auto Approved Add-ons (4)'
         assert link.attr('href') == self.url
         assert doc('.data-grid-top .num-results').text() == (
-            u'Results 1 \u2013 1 of 3')
+            u'Results 1 \u2013 1 of 4')
 
     def test_navbar_queue_counts(self):
         self.login_with_permission()
@@ -1324,7 +1329,7 @@ class TestAutoApprovedQueue(QueueTest):
         assert response.status_code == 200
         doc = pq(response.content)
         assert doc('#navbar #listed-queues li').eq(3).text() == (
-            'Auto Approved Add-ons (3)'
+            'Auto Approved Add-ons (4)'
         )
 
 

--- a/src/olympia/migrations/947-add-autoapprovalsummary-weight.sql
+++ b/src/olympia/migrations/947-add-autoapprovalsummary-weight.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `editors_autoapprovalsummary` ADD COLUMN `weight` integer NOT NULL;


### PR DESCRIPTION
Fix #5473

More flags that affect this weight will be implemented later.