### PR TITLE
Fix #5445 - Links from "Add-on Review Log" for unlisted/mixed add-ons load the listed review page of the add-on

### DIFF
--- a/src/olympia/editors/templates/editors/reviewlog.html
+++ b/src/olympia/editors/templates/editors/reviewlog.html
@@ -43,9 +43,15 @@
                   {% if item.arguments|count >= 2 %}
                     {{ item.arguments[1] }}
                   {% endif %}
+                  {% if item.arguments[1].channel == amo.RELEASE_CHANNEL_LISTED %}
                   <a href="{{ url('editors.review', item.arguments[0].slug) }}">
                     {{ ACTION_DICT.get(item.action) }}
                   </a>
+                  {% else %}
+                  <a href="{{ url('editors.review', 'unlisted', item.arguments[0].slug) }}">
+                    {{ ACTION_DICT.get(item.action) }}
+                  </a>
+                  {% endif %}
                 {% else %}
                     {{ _('Add-on has been deleted.') }}
                 {% endif %}

--- a/src/olympia/editors/templates/editors/reviewlog.html
+++ b/src/olympia/editors/templates/editors/reviewlog.html
@@ -42,16 +42,18 @@
                   {{ item.arguments.0|link }}
                   {% if item.arguments|count >= 2 %}
                     {{ item.arguments[1] }}
-                  {% endif %}
-                  {% if item.arguments[1].channel == amo.RELEASE_CHANNEL_LISTED %}
-                  <a href="{{ url('editors.review', item.arguments[0].slug) }}">
-                    {{ ACTION_DICT.get(item.action) }}
-                  </a>
+                    {% set channel = item.arguments[1].channel %}
                   {% else %}
-                  <a href="{{ url('editors.review', 'unlisted', item.arguments[0].slug) }}">
+                    {% set channel = 0 %}
+                  {% endif %}
+                  {% if channel == amo.RELEASE_CHANNEL_LISTED %}
+                    {% set review_url = url('editors.review', item.arguments[0].slug) %}
+                  {% else %}
+                    {% set review_url = url('editors.review', 'unlisted', item.arguments[0].slug) %}
+                  {% endif %}
+                  <a href="{{ review_url }}">
                     {{ ACTION_DICT.get(item.action) }}
                   </a>
-                  {% endif %}
                 {% else %}
                     {{ _('Add-on has been deleted.') }}
                 {% endif %}

--- a/src/olympia/editors/tests/test_views.py
+++ b/src/olympia/editors/tests/test_views.py
@@ -358,7 +358,8 @@ class TestReviewLog(EditorTest):
 
         ActivityLog.create(
             amo.LOG.APPROVE_VERSION, addon, addon.current_version,
-            user=self.get_user(), details={'comments': 'foo'})
+            user=self.get_user(), details={'comments': 'foo'},
+            created=self.days_ago(1))
 
         r = self.client.get(self.url)
         url = reverse('editors.review', args=[addon.slug])

--- a/src/olympia/editors/tests/test_views.py
+++ b/src/olympia/editors/tests/test_views.py
@@ -350,6 +350,30 @@ class TestReviewLog(EditorTest):
         assert pq(r.content)('#log-listing tr td a').eq(1).text() == (
             'commented')
 
+    def test_review_url(self):
+        self.login_as_admin()
+        addon = addon_factory()
+        unlisted_version = version_factory(
+            addon=addon, channel=amo.RELEASE_CHANNEL_UNLISTED)
+
+        ActivityLog.create(
+            amo.LOG.APPROVE_VERSION, addon, addon.current_version,
+            user=self.get_user(), details={'comments': 'foo'})
+
+        r = self.client.get(self.url)
+        url = reverse('editors.review', args=[addon.slug])
+        assert pq(r.content)('#log-listing tr td a').eq(1).attr('href') == url
+
+        ActivityLog.create(
+            amo.LOG.APPROVE_VERSION, addon,
+            unlisted_version,
+            user=self.get_user(), details={'comments': 'foo'})
+        r = self.client.get(self.url)
+        url = reverse(
+            'editors.review',
+            args=['unlisted'] + [addon.slug])
+        assert pq(r.content)('#log-listing tr td a').eq(1).attr('href') == url
+
 
 class TestHome(EditorTest):
     fixtures = EditorTest.fixtures + ['base/addon_3615']

--- a/src/olympia/editors/tests/test_views.py
+++ b/src/olympia/editors/tests/test_views.py
@@ -373,7 +373,7 @@ class TestReviewLog(EditorTest):
         r = self.client.get(self.url)
         url = reverse(
             'editors.review',
-            args=['unlisted'] + [addon.slug])
+            args=['unlisted', addon.slug])
         assert pq(r.content)('#log-listing tr td a').eq(1).attr('href') == url
 
 

--- a/src/olympia/editors/tests/test_views.py
+++ b/src/olympia/editors/tests/test_views.py
@@ -368,7 +368,8 @@ class TestReviewLog(EditorTest):
         ActivityLog.create(
             amo.LOG.APPROVE_VERSION, addon,
             unlisted_version,
-            user=self.get_user(), details={'comments': 'foo'})
+            user=self.get_user(), details={'comments': 'foo'},
+            created=self.days_ago(0))
         r = self.client.get(self.url)
         url = reverse(
             'editors.review',

--- a/src/olympia/editors/tests/test_views.py
+++ b/src/olympia/editors/tests/test_views.py
@@ -356,11 +356,11 @@ class TestReviewLog(EditorTest):
         unlisted_version = version_factory(
             addon=addon, channel=amo.RELEASE_CHANNEL_UNLISTED)
 
-        ActivityLog.create(
+        al = ActivityLog.create(
             amo.LOG.APPROVE_VERSION, addon, addon.current_version,
-            user=self.get_user(), details={'comments': 'foo'},
-            created=self.days_ago(1))
+            user=self.get_user(), details={'comments': 'foo'})
 
+        al.update(created=self.days_ago(1))
         r = self.client.get(self.url)
         url = reverse('editors.review', args=[addon.slug])
         assert pq(r.content)('#log-listing tr td a').eq(1).attr('href') == url
@@ -368,8 +368,7 @@ class TestReviewLog(EditorTest):
         ActivityLog.create(
             amo.LOG.APPROVE_VERSION, addon,
             unlisted_version,
-            user=self.get_user(), details={'comments': 'foo'},
-            created=self.days_ago(0))
+            user=self.get_user(), details={'comments': 'foo'})
         r = self.client.get(self.url)
         url = reverse(
             'editors.review',


### PR DESCRIPTION
Modified [reviewlog.html](https://github.com/harikishen/addons-server/blob/ticket_5445/src/olympia/editors/templates/editors/reviewlog.html) to consider `unlisted` add-ons and wrote [test_review_url](https://github.com/harikishen/addons-server/blob/ticket_5445/src/olympia/editors/tests/test_views.py#L353-L375) for it.

fixes #5445