### PR TITLE
@cached_property should not return querysets; Remove UserProfile.addons_listed entirely

### DIFF
--- a/src/olympia/accounts/tests/test_serializers.py
+++ b/src/olympia/accounts/tests/test_serializers.py
@@ -41,13 +41,11 @@ class TestPublicUserProfileSerializer(BaseTestCase):
 
     def test_addons(self):
         self.user.update(averagerating=3.6)
-        del self.user.addons_listed
         assert self.serialize()['num_addons_listed'] == 0
 
         addon_factory(users=[self.user])
         addon_factory(users=[self.user])
         addon_factory(status=amo.STATUS_NULL, users=[self.user])
-        del self.user.addons_listed
         data = self.serialize()
         assert data['num_addons_listed'] == 2  # only public addons.
         assert data['average_addon_rating'] == '3.6'

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -218,16 +218,11 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
         """List of all groups the user is a member of, as a cached property."""
         return list(self.groups.all())
 
-    @amo.cached_property(writable=True)
-    def addons_listed(self):
-        """Public add-ons this user is listed as author of."""
-        return self.addons.public().filter(
-            addonuser__user=self, addonuser__listed=True)
-
     @property
     def num_addons_listed(self):
         """Number of public add-ons this user is listed as author of."""
-        return self.addons_listed.count()
+        return self.addons.public().filter(
+            addonuser__user=self, addonuser__listed=True).count()
 
     def my_addons(self, n=8):
         """Returns n addons"""

--- a/src/olympia/users/tests/test_models.py
+++ b/src/olympia/users/tests/test_models.py
@@ -10,7 +10,7 @@ import pytest
 
 import olympia  # noqa
 from olympia import amo
-from olympia.amo.tests import TestCase, safe_exec
+from olympia.amo.tests import addon_factory, TestCase, safe_exec
 from olympia.access.models import Group, GroupUser
 from olympia.addons.models import Addon, AddonUser
 from olympia.bandwagon.models import Collection, CollectionWatcher
@@ -182,20 +182,24 @@ class TestUserProfile(TestCase):
         assert new_reply.pk not in review_list, (
             'Developer reply must not show up in review list.')
 
-    def test_addons_listed(self):
-        """Make sure we're returning distinct add-ons."""
-        AddonUser.objects.create(addon_id=3615, user_id=2519, listed=True)
-        u = UserProfile.objects.get(id=2519)
-        addons = u.addons_listed.values_list('id', flat=True)
-        assert sorted(addons) == [3615]
+    def test_num_addons_listed(self):
+        """Test that num_addons_listed is only considering add-ons for which
+        the user is marked as listed, and that only public and listed add-ons
+        are counted."""
+        user = UserProfile.objects.get(id=2519)
+        addon = Addon.objects.get(pk=3615)
+        AddonUser.objects.create(addon=addon, user=user, listed=True)
+        assert user.num_addons_listed == 1
 
-    def test_addons_not_listed(self):
-        """Make sure user is not listed when another is."""
-        AddonUser.objects.create(addon_id=3615, user_id=2519, listed=False)
-        AddonUser.objects.create(addon_id=3615, user_id=4043307, listed=True)
-        u = UserProfile.objects.get(id=2519)
-        addons = u.addons_listed.values_list('id', flat=True)
-        assert 3615 not in addons
+        extra_addon = addon_factory(status=amo.STATUS_NOMINATED)
+        AddonUser.objects.create(addon=extra_addon, user=user, listed=True)
+        extra_addon2 = addon_factory()
+        AddonUser.objects.create(addon=extra_addon2, user=user, listed=True)
+        self.make_addon_unlisted(extra_addon2)
+        assert user.num_addons_listed == 1
+
+        AddonUser.objects.filter(addon=addon, user=user).update(listed=False)
+        assert user.num_addons_listed == 0
 
     def test_my_addons(self):
         """Test helper method to get N addons."""

--- a/src/olympia/users/tests/test_views.py
+++ b/src/olympia/users/tests/test_views.py
@@ -709,14 +709,14 @@ class TestProfileSections(TestCase):
 
     def test_my_reviews_no_pagination(self):
         r = self.client.get(self.url)
-        assert len(self.user.addons_listed) <= 10, (
+        assert self.user.num_addons_listed <= 10, (
             'This user should have fewer than 10 add-ons.')
         assert pq(r.content)('#my-addons .paginator').length == 0
 
     def test_my_reviews_pagination(self):
         for i in xrange(20):
             AddonUser.objects.create(user=self.user, addon_id=3615)
-        assert len(self.user.addons_listed) > 10, (
+        assert self.user.num_addons_listed > 10, (
             'This user should have way more than 10 add-ons.')
         r = self.client.get(self.url)
         assert pq(r.content)('#my-addons .paginator').length == 1


### PR DESCRIPTION
That property was not super useful nor used much anyway. It's important to not use `@cached_property` for querysets because it can break lazy evaluation and cause surprises...

Note: `@cached_property` from django does not have this problem, it's only our own. We should resume work on https://github.com/mozilla/addons-server/issues/3140 ...

Fix #5480