### PR TITLE
Close all potentially open database cursors.

### DIFF
--- a/src/olympia/amo/cron.py
+++ b/src/olympia/amo/cron.py
@@ -106,11 +106,14 @@ def category_totals():
         UPDATE categories AS t INNER JOIN (
          SELECT at.category_id, COUNT(DISTINCT Addon.id) AS ct
           FROM addons AS Addon
-          INNER JOIN versions AS Version ON (Addon.id = Version.addon_id)
-          INNER JOIN applications_versions AS av ON (av.version_id = Version.id)
-          INNER JOIN addons_categories AS at ON (at.addon_id = Addon.id)
-          INNER JOIN files AS File ON (Version.id = File.version_id
-                                       AND File.status IN (%s))
+          INNER JOIN versions AS Version
+            ON (Addon.id = Version.addon_id)
+          INNER JOIN applications_versions AS av
+            ON (av.version_id = Version.id)
+          INNER JOIN addons_categories AS at
+            ON (at.addon_id = Addon.id)
+          INNER JOIN files AS File
+            ON (Version.id = File.version_id AND File.status IN (%s))
           WHERE Addon.status IN (%s) AND Addon.inactive = 0
           GROUP BY at.category_id)
         AS j ON (t.id = j.category_id)
@@ -130,7 +133,8 @@ def collection_subscribers():
 
     with connection.cursor() as cursor:
         cursor.execute("""
-            UPDATE collections SET weekly_subscribers = 0, monthly_subscribers = 0
+            UPDATE collections
+            SET weekly_subscribers = 0, monthly_subscribers = 0
         """)
         cursor.execute("""
             UPDATE collections AS c

--- a/src/olympia/amo/cron.py
+++ b/src/olympia/amo/cron.py
@@ -100,22 +100,23 @@ def category_totals():
     log.debug('Starting category counts update...')
     addon_statuses = ",".join(['%s'] * len(VALID_ADDON_STATUSES))
     file_statuses = ",".join(['%s'] * len(VALID_FILE_STATUSES))
-    cursor = connection.cursor()
-    cursor.execute("""
-    UPDATE categories AS t INNER JOIN (
-     SELECT at.category_id, COUNT(DISTINCT Addon.id) AS ct
-      FROM addons AS Addon
-      INNER JOIN versions AS Version ON (Addon.id = Version.addon_id)
-      INNER JOIN applications_versions AS av ON (av.version_id = Version.id)
-      INNER JOIN addons_categories AS at ON (at.addon_id = Addon.id)
-      INNER JOIN files AS File ON (Version.id = File.version_id
-                                   AND File.status IN (%s))
-      WHERE Addon.status IN (%s) AND Addon.inactive = 0
-      GROUP BY at.category_id)
-    AS j ON (t.id = j.category_id)
-    SET t.count = j.ct
-    """ % (file_statuses, addon_statuses),
-        VALID_FILE_STATUSES + VALID_ADDON_STATUSES)
+
+    with connection.cursor() as cursor:
+        cursor.execute("""
+        UPDATE categories AS t INNER JOIN (
+         SELECT at.category_id, COUNT(DISTINCT Addon.id) AS ct
+          FROM addons AS Addon
+          INNER JOIN versions AS Version ON (Addon.id = Version.addon_id)
+          INNER JOIN applications_versions AS av ON (av.version_id = Version.id)
+          INNER JOIN addons_categories AS at ON (at.addon_id = Addon.id)
+          INNER JOIN files AS File ON (Version.id = File.version_id
+                                       AND File.status IN (%s))
+          WHERE Addon.status IN (%s) AND Addon.inactive = 0
+          GROUP BY at.category_id)
+        AS j ON (t.id = j.category_id)
+        SET t.count = j.ct
+        """ % (file_statuses, addon_statuses),
+            VALID_FILE_STATUSES + VALID_ADDON_STATUSES)
 
 
 def collection_subscribers():
@@ -127,31 +128,31 @@ def collection_subscribers():
     if not waffle.switch_is_active('local-statistics-processing'):
         return False
 
-    cursor = connection.cursor()
-    cursor.execute("""
-        UPDATE collections SET weekly_subscribers = 0, monthly_subscribers = 0
-    """)
-    cursor.execute("""
-        UPDATE collections AS c
-        INNER JOIN (
-            SELECT
-                COUNT(collection_id) AS count,
-                collection_id
-            FROM collection_subscriptions
-            WHERE created >= DATE_SUB(CURDATE(), INTERVAL 7 DAY)
-            GROUP BY collection_id
-        ) AS weekly ON (c.id = weekly.collection_id)
-        INNER JOIN (
-            SELECT
-                COUNT(collection_id) AS count,
-                collection_id
-            FROM collection_subscriptions
-            WHERE created >= DATE_SUB(CURDATE(), INTERVAL 31 DAY)
-            GROUP BY collection_id
-        ) AS monthly ON (c.id = monthly.collection_id)
-        SET c.weekly_subscribers = weekly.count,
-            c.monthly_subscribers = monthly.count
-    """)
+    with connection.cursor() as cursor:
+        cursor.execute("""
+            UPDATE collections SET weekly_subscribers = 0, monthly_subscribers = 0
+        """)
+        cursor.execute("""
+            UPDATE collections AS c
+            INNER JOIN (
+                SELECT
+                    COUNT(collection_id) AS count,
+                    collection_id
+                FROM collection_subscriptions
+                WHERE created >= DATE_SUB(CURDATE(), INTERVAL 7 DAY)
+                GROUP BY collection_id
+            ) AS weekly ON (c.id = weekly.collection_id)
+            INNER JOIN (
+                SELECT
+                    COUNT(collection_id) AS count,
+                    collection_id
+                FROM collection_subscriptions
+                WHERE created >= DATE_SUB(CURDATE(), INTERVAL 31 DAY)
+                GROUP BY collection_id
+            ) AS monthly ON (c.id = monthly.collection_id)
+            SET c.weekly_subscribers = weekly.count,
+                c.monthly_subscribers = monthly.count
+        """)
 
 
 def weekly_downloads():
@@ -163,32 +164,37 @@ def weekly_downloads():
         return False
 
     raise_if_reindex_in_progress('amo')
-    cursor = connection.cursor()
-    cursor.execute("""
-        SELECT addon_id, SUM(count) AS weekly_count
-        FROM download_counts
-        WHERE `date` >= DATE_SUB(CURDATE(), INTERVAL 7 DAY)
-        GROUP BY addon_id
-        ORDER BY addon_id""")
-    counts = cursor.fetchall()
+
+    with connection.cursor() as cursor:
+        cursor.execute("""
+            SELECT addon_id, SUM(count) AS weekly_count
+            FROM download_counts
+            WHERE `date` >= DATE_SUB(CURDATE(), INTERVAL 7 DAY)
+            GROUP BY addon_id
+            ORDER BY addon_id""")
+        counts = cursor.fetchall()
+
     addon_ids = [r[0] for r in counts]
+
     if not addon_ids:
         return
-    cursor.execute("""
-        SELECT id, 0
-        FROM addons
-        WHERE id NOT IN %s""", (addon_ids,))
-    counts += cursor.fetchall()
 
-    cursor.execute("""
-        CREATE TEMPORARY TABLE tmp_wd
-        (addon_id INT PRIMARY KEY, count INT)""")
-    cursor.execute('INSERT INTO tmp_wd VALUES %s' %
-                   ','.join(['(%s,%s)'] * len(counts)),
-                   list(itertools.chain(*counts)))
+    with connection.cursor() as cursor:
+        cursor.execute("""
+            SELECT id, 0
+            FROM addons
+            WHERE id NOT IN %s""", (addon_ids,))
+        counts += cursor.fetchall()
 
-    cursor.execute("""
-        UPDATE addons INNER JOIN tmp_wd
-            ON addons.id = tmp_wd.addon_id
-        SET weeklydownloads = tmp_wd.count""")
-    cursor.execute("DROP TABLE IF EXISTS tmp_wd")
+        cursor.execute("""
+            CREATE TEMPORARY TABLE tmp_wd
+            (addon_id INT PRIMARY KEY, count INT)""")
+        cursor.execute('INSERT INTO tmp_wd VALUES %s' %
+                       ','.join(['(%s,%s)'] * len(counts)),
+                       list(itertools.chain(*counts)))
+
+        cursor.execute("""
+            UPDATE addons INNER JOIN tmp_wd
+                ON addons.id = tmp_wd.addon_id
+            SET weeklydownloads = tmp_wd.count""")
+        cursor.execute("DROP TABLE IF EXISTS tmp_wd")

--- a/src/olympia/amo/tests/test_redirects.py
+++ b/src/olympia/amo/tests/test_redirects.py
@@ -170,16 +170,18 @@ class TestPersonaRedirect(TestCase):
         """When the persona exists but not its addon, throw a 404."""
         # Got get shady to separate Persona/Addons.
         try:
-            connection.cursor().execute("""
-                SET FOREIGN_KEY_CHECKS = 0;
-                UPDATE personas SET addon_id=123 WHERE persona_id=813;
-                SET FOREIGN_KEY_CHECKS = 1;
-            """)
+            with connection.cursor() as cursor:
+                cursor.execute("""
+                    SET FOREIGN_KEY_CHECKS = 0;
+                    UPDATE personas SET addon_id=123 WHERE persona_id=813;
+                    SET FOREIGN_KEY_CHECKS = 1;
+                """)
             r = self.client.get('/persona/813', follow=True)
             assert r.status_code == 404
         finally:
-            connection.cursor().execute("""
-                SET FOREIGN_KEY_CHECKS = 0;
-                UPDATE personas SET addon_id=15663 WHERE persona_id=813;
-                SET FOREIGN_KEY_CHECKS = 1;
-            """)
+            with connection.cursor() as cursor:
+                cursor.execute("""
+                    SET FOREIGN_KEY_CHECKS = 0;
+                    UPDATE personas SET addon_id=15663 WHERE persona_id=813;
+                    SET FOREIGN_KEY_CHECKS = 1;
+                """)

--- a/src/olympia/editors/tests/test_sql_model.py
+++ b/src/olympia/editors/tests/test_sql_model.py
@@ -15,11 +15,11 @@ from olympia.editors.sql_model import RawSQLModel
 
 
 def execute_all(statements):
-    cursor = connection.cursor()
-    for sql in statements:
-        if not sql.strip():
-            continue
-        cursor.execute(sql, [])
+    with connection.cursor() as cursor:
+        for sql in statements:
+            if not sql.strip():
+                continue
+            cursor.execute(sql, [])
 
 
 class Summary(RawSQLModel):

--- a/src/olympia/stats/management/commands/update_theme_popularity_movers.py
+++ b/src/olympia/stats/management/commands/update_theme_popularity_movers.py
@@ -85,8 +85,9 @@ class Command(BaseCommand):
                 p.movers=t.movers
             WHERE t.persona_id=p.id
         """
-        cursor = connection.cursor()
-        cursor.execute(raw_query)
+
+        with connection.cursor() as cursor:
+            cursor.execute(raw_query)
 
         log.debug('Total processing time: %s' % (
             datetime.datetime.now() - start))

--- a/src/olympia/translations/transformer.py
+++ b/src/olympia/translations/transformer.py
@@ -74,14 +74,14 @@ def get_trans(items):
     item_dict = dict((item.pk, item) for item in items)
     ids = ','.join(map(str, item_dict.keys()))
 
-    cursor = connection.cursor()
-    cursor.execute(sql.format(ids='(%s)' % ids), tuple(params))
-    step = len(trans_fields)
-    for row in cursor.fetchall():
-        # We put the item's pk as the first selected field.
-        item = item_dict[row[0]]
-        for index, field in enumerate(model._meta.translated_fields):
-            start = 1 + step * index
-            t = Translation(*row[start:start + step])
-            if t.id is not None and t.localized_string is not None:
-                setattr(item, field.name, t)
+    with connection.cursor() as cursor:
+        cursor.execute(sql.format(ids='(%s)' % ids), tuple(params))
+        step = len(trans_fields)
+        for row in cursor.fetchall():
+            # We put the item's pk as the first selected field.
+            item = item_dict[row[0]]
+            for index, field in enumerate(model._meta.translated_fields):
+                start = 1 + step * index
+                t = Translation(*row[start:start + step])
+                if t.id is not None and t.localized_string is not None:
+                    setattr(item, field.name, t)

--- a/src/olympia/zadmin/tasks.py
+++ b/src/olympia/zadmin/tasks.py
@@ -59,9 +59,11 @@ def tally_job_results(job_id, **kw):
                     sum(case when completed IS NOT NULL then 1 else 0 end)
              from validation_result
              where validation_job_id=%s"""
-    cursor = connection.cursor()
-    cursor.execute(sql, [job_id])
-    total, completed = cursor.fetchone()
+
+    with connection.cursor() as cursor:
+        cursor.execute(sql, [job_id])
+        total, completed = cursor.fetchone()
+
     if completed == total:
         # The job has finished.
         job = ValidationJob.objects.get(pk=job_id)


### PR DESCRIPTION
So apparently we do raw-queries all over the place which isn't
necessarily bad but we don't make use of cursor.close() in many places
which could lead to open connections, not properly reading data
and potentially lead to deadlocks and out-of-sync errors.

This urgently needs tests to verify my findings.

Might reference https://sentry.prod.mozaws.net/operations/olympia-prod/issues/389934/
and https://sentry.prod.mozaws.net/operations/olympia-dev/issues/610935/

This should not be a huge problem for the web-app given that django I think closes open cursors at the end of a middleware but it's more of a bummer for celery tasks.