### PR TITLE
Fix auto_approved queue ordering fallback on addon creation date

### DIFF
--- a/src/olympia/editors/tests/test_views.py
+++ b/src/olympia/editors/tests/test_views.py
@@ -1296,7 +1296,8 @@ class TestAutoApprovedQueue(QueueTest):
             addon=addon3, counter=1, last_human_review=None)
 
         # Has been auto-approved, should be first because of its weight.
-        addon4 = addon_factory(name=u'Addôn 4', created=self.days_ago(14))
+        addon4 = addon_factory(name=u'Addôn 4')
+        addon4.update(created=self.days_ago(14))
         AutoApprovalSummary.objects.create(
             version=addon4.current_version, verdict=amo.AUTO_APPROVED,
             weight=500)

--- a/src/olympia/editors/views.py
+++ b/src/olympia/editors/views.py
@@ -564,7 +564,8 @@ def queue_auto_approved(request):
             _current_version__autoapprovalsummary__verdict=amo.AUTO_APPROVED)
         .order_by(
             '-_current_version__autoapprovalsummary__weight',
-            'addonapprovalscounter__last_human_review'))
+            'addonapprovalscounter__last_human_review',
+            'created'))
     return _queue(request, AutoApprovedTable, 'auto_approved',
                   qs=qs, SearchForm=None)
 


### PR DESCRIPTION
Fix #5556