### PR TITLE
Fix #5491 - Empty string in 'Add-on Reviewer Performance' for users without display name

### DIFF
--- a/src/olympia/editors/templates/editors/performance.html
+++ b/src/olympia/editors/templates/editors/performance.html
@@ -9,10 +9,10 @@
   <p>
     {{ _('View statistics for user') }}
     <select id="select_user" data-url="{{ url('editors.performance') }}">
-      <option value="" selected="selected">{{ current_user.display_name }}</option>
+      <option value="" selected="selected">{{ current_user.name }}</option>
       <option value="">-----------------------</option>
       {% for editor in editors %}
-        <option value="{{ editor.id }}">{{ editor.display_name }}</option>
+        <option value="{{ editor.id }}">{{ editor.name }}</option>
       {% endfor %}
     </select>
   </p>


### PR DESCRIPTION
Hi,
Patched a similar bug previously.
Let me know if any changes are requested.

Thanks.