### PR TITLE
Include a bunch of static analysis flags in AutoApprovalSummary.weight

### DIFF
--- a/src/olympia/addons/tests/test_commands.py
+++ b/src/olympia/addons/tests/test_commands.py
@@ -288,4 +288,6 @@ class RecalculateWeightTestCase(TestCase):
             'process_addons', task='recalculate_post_review_weight')
 
         summary.reload()
-        assert summary.weight == 10  # Because of average_daily_users / 10000.
+        # Weight should be 110 because of average_daily_users / 10000 and the
+        # fact there is no file validation result.
+        assert summary.weight == 110

--- a/src/olympia/editors/models.py
+++ b/src/olympia/editors/models.py
@@ -758,7 +758,39 @@ class AutoApprovalSummary(ModelBase):
                         files__status=amo.STATUS_DISABLED)
                 .distinct().count() * 10, 100),
         }
+        factors.update(self.calculate_static_analysis_weight_factors())
         self.weight = sum(factors.values())
+        return factors
+
+    def calculate_static_analysis_weight_factors(self):
+        """Calculate the static analysis risk factors.
+        Used by calculate_weight()."""
+        try:
+            factors = {
+                # Static analysis flags from linter:
+                # eval, evalInSandbox, document.write: 20.
+                'uses_dangerous_eval': (
+                    20 if self.check_uses_eval(self.version) else 0),
+                # Implied eval in setTimeout/setInterval/ on* attributes: 5.
+                'uses_implied_eval': (
+                    5 if self.check_uses_implied_eval(self.version) else 0),
+                # innerHTML / unsafe DOM: 20.
+                'uses_innerhtml': (
+                    20 if self.check_uses_innerhtml(self.version) else 0),
+                # custom CSP: 30.
+                'uses_custom_csp': (
+                    30 if self.check_uses_custom_csp(self.version) else 0),
+                # nativeMessaging permission: 20.
+                'uses_native_messaging': (
+                    20 if self.check_uses_native_messaging(self.version) else
+                    0),
+            }
+        except AutoApprovalNoValidationResultError:
+            # We should have a FileValidationResult... since we don't and
+            # something is wrong, increase the weight by 100.
+            factors = {
+                'no_validation_result': 100,
+            }
         return factors
 
     def calculate_verdict(
@@ -823,17 +855,33 @@ class AutoApprovalSummary(ModelBase):
                 if value)
 
     @classmethod
-    def check_uses_custom_csp(cls, version):
-        def _check_uses_custom_csp_in_file(file_):
+    def check_for_linter_flag(cls, version, flag):
+        def _check_for_linter_flag_in_file(file_):
             try:
                 validation = file_.validation
             except FileValidation.DoesNotExist:
                 raise AutoApprovalNoValidationResultError()
             validation_data = json.loads(validation.validation)
-            return any('MANIFEST_CSP' in message['id']
+            return any(flag in message['id']
                        for message in validation_data.get('messages', []))
-        return any(_check_uses_custom_csp_in_file(file_)
+        return any(_check_for_linter_flag_in_file(file_)
                    for file_ in version.all_files)
+
+    @classmethod
+    def check_uses_eval(cls, version):
+        return cls.check_for_linter_flag(version, 'DANGEROUS_EVAL')
+
+    @classmethod
+    def check_uses_implied_eval(cls, version):
+        return cls.check_for_linter_flag(version, 'IMPLIED_EVAL')
+
+    @classmethod
+    def check_uses_innerhtml(cls, version):
+        return cls.check_for_linter_flag(version, 'UNSAFE_VAR_ASSIGNMENT')
+
+    @classmethod
+    def check_uses_custom_csp(cls, version):
+        return cls.check_for_linter_flag(version, 'MANIFEST_CSP')
 
     @classmethod
     def check_uses_native_messaging(cls, version):


### PR DESCRIPTION
Fix #5475

This implements all the flags that were requested and already available in the linter at this time.