### PR TITLE
Only show confirm approval action if latest version is public

### DIFF
--- a/src/olympia/editors/helpers.py
+++ b/src/olympia/editors/helpers.py
@@ -443,10 +443,12 @@ class ReviewHelper(object):
         if acl.action_allowed(request, amo.permissions.ADDONS_POST_REVIEW):
             # Post-reviewers have 2 extra actions depending on the state of
             # the add-on:
-            # If the addon current version was auto-approved, they can confirm
-            # the approval.
-            if (self.addon.current_version and
-                    self.addon.current_version.was_auto_approved):
+            # If the addon current version was auto-approved, and it's the
+            # version we're looking at (i.e., we're using the listed review
+            # page, and it's the latest version) they can confirm the approval.
+            if (self.version and
+                    self.version == self.addon.current_version and
+                    self.version.was_auto_approved):
                 actions['confirm_auto_approved'] = {
                     'method': self.handler.confirm_auto_approved,
                     'label': _('Confirm Approval'),
@@ -733,8 +735,6 @@ class ReviewBase(object):
         human review date to now, and log it so that it's displayed later
         in the review page."""
         AddonApprovalsCounter.increment_for_addon(addon=self.addon)
-        # Log using the latest public version, not self.version, which could
-        # be awaiting review still.
         self.log_action(
             amo.LOG.CONFIRM_AUTO_APPROVED, version=self.addon.current_version)
 

--- a/src/olympia/editors/helpers.py
+++ b/src/olympia/editors/helpers.py
@@ -440,31 +440,41 @@ class ReviewHelper(object):
                              'from the queue. The comments will be sent '
                              'to the developer.'),
                 'minimal': False}
-        if acl.action_allowed(request, amo.permissions.ADDONS_POST_REVIEW):
-            # Post-reviewers have 2 extra actions depending on the state of
-            # the add-on:
-            # If the addon current version was auto-approved, and it's the
-            # version we're looking at (i.e., we're using the listed review
-            # page, and it's the latest version) they can confirm the approval.
-            if (self.version and
-                    self.version == self.addon.current_version and
-                    self.version.was_auto_approved):
+        if self.version:
+            version_is_auto_approved_and_current = (
+                self.version == self.addon.current_version and
+                self.version.was_auto_approved)
+            version_is_unlisted = (
+                self.version.channel == amo.RELEASE_CHANNEL_UNLISTED)
+            is_post_reviewer = acl.action_allowed(
+                request, amo.permissions.ADDONS_POST_REVIEW)
+            is_unlisted_reviewer = acl.action_allowed(
+                request, amo.permissions.ADDONS_REVIEW_UNLISTED)
+
+            # Post-reviewers and unlisted reviewers can confirm approval if
+            # the version is unlisted or it's the current public version
+            # and it was auto approved, respectively.
+            if (is_unlisted_reviewer and version_is_unlisted) or (
+                    is_post_reviewer and version_is_auto_approved_and_current):
                 actions['confirm_auto_approved'] = {
                     'method': self.handler.confirm_auto_approved,
                     'label': _('Confirm Approval'),
-                    'details': _('The latest public version of this add-on '
-                                 'was automatically approved. This records '
-                                 'your confirmation of the approval, '
-                                 'without notifying the developer.'),
+                    'details': _('The latest public version of this '
+                                 'add-on was automatically approved. This '
+                                 'records your confirmation of the '
+                                 'approval, without notifying the '
+                                 'developer.'),
                     'minimal': True,
                     'comments': False,
                 }
-            if (self.version and self.addon.status == amo.STATUS_PUBLIC and
-                    self.version.channel == amo.RELEASE_CHANNEL_LISTED):
-                # They can reject multiple versions in one action on the listed
-                # review page, if the add-on is public (it's useless if the
-                # add-on is not public: that means there should only be one
-                # version to reject at most).
+            # Post-reviewers can also reject multiple versions in one action on
+            # the listed review page, if the add-on is public (it's useless if
+            # the add-on is not public: that means there should only be one
+            # version to reject at most).
+            version_is_public_and_listed = (
+                self.addon.status == amo.STATUS_PUBLIC and
+                self.version.channel == amo.RELEASE_CHANNEL_LISTED)
+            if is_post_reviewer and version_is_public_and_listed:
                 actions['reject_multiple_versions'] = {
                     'method': self.handler.reject_multiple_versions,
                     'label': _('Reject Multiple Versions'),
@@ -474,7 +484,6 @@ class ReviewHelper(object):
                                  'versions. The comments will be sent to the '
                                  'developer.'),
                 }
-        if self.version:
             actions['info'] = {
                 'method': self.handler.request_information,
                 'label': _('Reviewer reply'),
@@ -731,12 +740,13 @@ class ReviewBase(object):
         """Confirm an auto-approval decision.
 
         We don't need to really store that information, what we care about
-        is incrementing AddonApprovalsCounter, which also resets the last
-        human review date to now, and log it so that it's displayed later
-        in the review page."""
-        AddonApprovalsCounter.increment_for_addon(addon=self.addon)
-        self.log_action(
-            amo.LOG.CONFIRM_AUTO_APPROVED, version=self.addon.current_version)
+        is logging something for future reviewers to be aware of, and, if the
+        version is listed, incrementing AddonApprovalsCounter, which also
+        resets the last human review date to now, and log it so that it's
+        displayed later in the review page."""
+        if self.version.channel == amo.RELEASE_CHANNEL_LISTED:
+            AddonApprovalsCounter.increment_for_addon(addon=self.addon)
+        self.log_action(amo.LOG.CONFIRM_AUTO_APPROVED)
 
     def reject_multiple_versions(self):
         """Reject a list of versions."""

--- a/src/olympia/editors/tests/test_helpers.py
+++ b/src/olympia/editors/tests/test_helpers.py
@@ -469,8 +469,8 @@ class TestReviewHelper(TestCase):
         self.setup_data(status)
 
         # Make sure we have no public files
-        for i in self.addon.versions.all():
-            i.files.update(status=amo.STATUS_AWAITING_REVIEW)
+        for version in self.addon.versions.all():
+            version.files.update(status=amo.STATUS_AWAITING_REVIEW)
 
         self.helper.handler.process_public()
 
@@ -692,6 +692,7 @@ class TestReviewHelper(TestCase):
         self._check_score(amo.REVIEWED_ADDON_UPDATE)
 
     def test_public_addon_confirm_auto_approval(self):
+        self.grant_permission(self.request.user, 'Addons:PostReview')
         self.setup_data(amo.STATUS_PUBLIC, file_status=amo.STATUS_PUBLIC)
         AutoApprovalSummary.objects.create(
             version=self.version, verdict=amo.AUTO_APPROVED)
@@ -714,6 +715,7 @@ class TestReviewHelper(TestCase):
         assert activity.arguments == [self.addon, self.version]
 
     def test_public_with_unreviewed_version_addon_confirm_auto_approval(self):
+        self.grant_permission(self.request.user, 'Addons:PostReview')
         self.setup_data(amo.STATUS_PUBLIC, file_status=amo.STATUS_PUBLIC)
         AutoApprovalSummary.objects.create(
             version=self.version, verdict=amo.AUTO_APPROVED)
@@ -729,6 +731,7 @@ class TestReviewHelper(TestCase):
         assert 'confirm_auto_approved' not in self.helper.actions
 
     def test_unlisted_version_addon_confirm_auto_approval(self):
+        self.grant_permission(self.request.user, 'Addons:ReviewUnlisted')
         self.setup_data(amo.STATUS_PUBLIC, file_status=amo.STATUS_PUBLIC)
         AutoApprovalSummary.objects.create(
             version=self.version, verdict=amo.AUTO_APPROVED)
@@ -739,9 +742,21 @@ class TestReviewHelper(TestCase):
         self.helper = self.get_helper()  # To make it pick up the new version.
         self.helper.set_data(self.get_data())
 
-        # Confirm approval action should not be available since the version
-        # we are looking at is unlisted (#5609).
-        assert 'confirm_auto_approved' not in self.helper.actions
+        # Confirm approval action should be available since the version
+        # we are looking at is unlisted and reviewer has permission.
+        assert 'confirm_auto_approved' in self.helper.actions
+
+        self.helper.handler.confirm_auto_approved()
+
+        assert (
+            AddonApprovalsCounter.objects.filter(addon=self.addon).count() ==
+            0)  # Not incremented since it was unlisted.
+
+        assert self.check_log_count(amo.LOG.CONFIRM_AUTO_APPROVED.id) == 1
+        activity = (ActivityLog.objects.for_addons(self.addon)
+                               .filter(action=amo.LOG.CONFIRM_AUTO_APPROVED.id)
+                               .get())
+        assert activity.arguments == [self.addon, self.version]
 
     @patch('olympia.editors.helpers.sign_file')
     def test_null_to_public_unlisted(self, sign_mock):

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -602,8 +602,8 @@ class Version(OnChangeMixin, ModelBase):
         """Return whether or not this version was auto-approved."""
         from olympia.editors.models import AutoApprovalSummary
         try:
-            return (self.is_public() and
-                    self.autoapprovalsummary.verdict == amo.AUTO_APPROVED)
+            return self.is_public() and AutoApprovalSummary.objects.filter(
+                version=self).get().verdict == amo.AUTO_APPROVED
         except AutoApprovalSummary.DoesNotExist:
             pass
         return False


### PR DESCRIPTION
Fix #5604 