### PR TITLE
Only show `userEnabled` installations for daily active users

### DIFF
--- a/src/olympia/addons/cron.py
+++ b/src/olympia/addons/cron.py
@@ -35,7 +35,7 @@ def update_addon_average_daily_users():
     cursor = connections[multidb.get_slave()].cursor()
     q = """SELECT addon_id, AVG(`count`)
            FROM update_counts
-           WHERE `date` > DATE_SUB(CURDATE(), INTERVAL 7 DAY)
+           WHERE `date` > DATE_SUB(CURDATE(), INTERVAL 13 DAY)
            GROUP BY addon_id
            ORDER BY addon_id"""
     cursor.execute(q)

--- a/src/olympia/stats/fixtures/files/src/update_counts_by_status.hive
+++ b/src/olympia/stats/fixtures/files/src/update_counts_by_status.hive
@@ -1,2 +1,3 @@
 2014-07-10	{2fa4ed95-0317-4c6a-a74c-5f3e3912c1f9}	userEnabled	2	112
-2014-07-10	{2fa4ed95-0317-4c6a-a74c-5f3e3912c1f9}	userEnabled	3	112
+2014-07-10	{2fa4ed95-0317-4c6a-a74c-5f3e3912c1f9}	userEnabled	2	112
+2014-07-10	{2fa4ed95-0317-4c6a-a74c-5f3e3912c1f9}	userDisabled	1	112

--- a/src/olympia/stats/management/commands/update_counts_from_file.py
+++ b/src/olympia/stats/management/commands/update_counts_from_file.py
@@ -25,6 +25,7 @@ LOCALE_REGEX = re.compile(r"""^[a-z]{2,3}      # General: fr, en, dsb,...
                           """, re.VERBOSE)
 VALID_STATUSES = ["userDisabled,incompatible", "userEnabled", "Unknown",
                   "userDisabled", "userEnabled,incompatible"]
+UPDATE_COUNT_TRIGGER = "userEnabled"
 VALID_APP_GUIDS = amo.APP_GUIDS.keys()
 APPVERSION_REGEX = re.compile(
     r"""^[0-9]{1,3}                # Major version: 2, 35
@@ -168,11 +169,12 @@ class Command(BaseCommand):
                     # We can now fill the UpdateCount object.
                     if group == 'version':
                         self.update_version(uc, data, count)
-                        # Use this count to compute the global number of daily
-                        # users for this addon.
-                        uc.count += count
                     elif group == 'status':
                         self.update_status(uc, data, count)
+                        if data == UPDATE_COUNT_TRIGGER:
+                            # Use this count to compute the global number
+                            # of daily users for this addon.
+                            uc.count += count
                     elif group == 'app':
                         self.update_app(uc, app_id, app_ver, count)
                     elif group == 'os':

--- a/src/olympia/stats/tests/test_commands.py
+++ b/src/olympia/stats/tests/test_commands.py
@@ -63,10 +63,11 @@ class TestADICommand(FixturesFolderMixin, TestCase):
                                 date=self.date)
         assert UpdateCount.objects.all().count() == 1
         update_count = UpdateCount.objects.last()
-        assert update_count.count == 5
+        # should be identical to `statuses.userEnabled`
+        assert update_count.count == 4
         assert update_count.date == date(2014, 7, 10)
         assert update_count.versions == {u'3.8': 2, u'3.7': 3}
-        assert update_count.statuses == {u'userEnabled': 5}
+        assert update_count.statuses == {u'userDisabled': 1, u'userEnabled': 4}
         application = u'{ec8030f7-c20a-464f-9b0e-13a3a9e97384}'
         assert update_count.applications[application] == {u'3.6': 18}
         assert update_count.oses == {u'WINNT': 5}
@@ -283,8 +284,9 @@ class TestThemeADICommand(FixturesFolderMixin, TestCase):
                                 date=self.date)
         assert UpdateCount.objects.all().count() == 1
         uc = UpdateCount.objects.last()
-        assert uc.count == 1320
-        assert uc.date == date(2014, 11, 06)
+        # should be identical to `statuses.userEnabled`
+        assert uc.count == 1259
+        assert uc.date == date(2014, 11, 6)
         assert (uc.versions ==
                 {u'1.7.16': 1, u'userEnabled': 3, u'1.7.13': 2, u'1.7.11': 3,
                  u'1.6.0': 1, u'1.7.14': 1304, u'1.7.6': 6})


### PR DESCRIPTION
Fixes #3632 

This changes our daily active users calculation to only show `userEnabled` installations.

Migration Plan:

 * Run `update_addon_average_daily_users` after deployment

This will be potentially hard to test on -dev, once it lands on -dev I'll create a few dummy `UpdateCount` instances and run the cron so that QA can verify numbers are shown correctly.