### PR TITLE
point make to the correct file in Dockerfile.deploy

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -66,7 +66,7 @@ RUN DJANGO_SETTINGS_MODULE='settings_local' locale/compile-mo.sh locale
 
 # compile asssets
 RUN npm install \
-    && make copy_node_js \
+    && make -f Makefile-docker copy_node_js \
     && DJANGO_SETTINGS_MODULE='settings_local' python manage.py compress_assets --use-uuid -t \
     && DJANGO_SETTINGS_MODULE='settings_local' python manage.py collectstatic --noinput
 


### PR DESCRIPTION
We don't do `touch /addons-server-centos7-container` in .deploy so the Makefile can't detect we're in the container.