### PR TITLE
Add an endpoint to clear the profile photo

### DIFF
--- a/docs/topics/api/accounts.rst
+++ b/docs/topics/api/accounts.rst
@@ -123,13 +123,13 @@ Other :ref:`editable values <account-edit-request>` can be set at the same time.
     :reqheader Content-Type: multipart/form-data
 
 
-------------------
-Clearing the photo
-------------------
+--------------------
+Deleting the picture
+--------------------
 
-To clear the photo call the special endpoint.
+To delete the account profile picture call the special endpoint.
 
-.. http:post:: /api/v3/accounts/account/(int:user_id|string:username)/clear_photo
+.. http:delete:: /api/v3/accounts/account/(int:user_id|string:username)/picture
 
 
 ------

--- a/docs/topics/api/accounts.rst
+++ b/docs/topics/api/accounts.rst
@@ -123,6 +123,15 @@ Other :ref:`editable values <account-edit-request>` can be set at the same time.
     :reqheader Content-Type: multipart/form-data
 
 
+------------------
+Clearing the photo
+------------------
+
+To clear the photo call the special endpoint.
+
+.. http:post:: /api/v3/accounts/account/(int:user_id|string:username)/clear_photo
+
+
 ------
 Delete
 ------

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -1129,6 +1129,20 @@ class TestAccountViewSetUpdate(TestCase):
 
         assert path.exists(self.user.picture_path)
 
+    def test_delete_photo(self):
+        # use test_picture_upload to set up a photo
+        self.test_picture_upload()
+        assert path.exists(self.user.picture_path)
+        # call the clear endpoint
+        clear_url = reverse('account-clear-picture',
+                            kwargs={'pk': self.user.pk})
+        response = self.client.post(clear_url)
+        assert response.status_code == 200
+        # Should clear the photo
+        assert not path.exists(self.user.picture_path)
+        json_content = json.loads(response.content)
+        assert 'anon_user.png' in json_content['picture_url']
+
     def test_picture_upload_valid(self):
         self.client.login_api(self.user)
         gif = get_uploaded_file('animated.gif')

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -1129,16 +1129,15 @@ class TestAccountViewSetUpdate(TestCase):
 
         assert path.exists(self.user.picture_path)
 
-    def test_delete_photo(self):
+    def test_delete_picture(self):
         # use test_picture_upload to set up a photo
         self.test_picture_upload()
         assert path.exists(self.user.picture_path)
-        # call the clear endpoint
-        clear_url = reverse('account-clear-picture',
-                            kwargs={'pk': self.user.pk})
-        response = self.client.post(clear_url)
+        # call the endpoint to delete
+        picture_url = reverse('account-picture', kwargs={'pk': self.user.pk})
+        response = self.client.delete(picture_url)
         assert response.status_code == 200
-        # Should clear the photo
+        # Should delete the photo
         assert not path.exists(self.user.picture_path)
         json_content = json.loads(response.content)
         assert 'anon_user.png' in json_content['picture_url']

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -1142,6 +1142,18 @@ class TestAccountViewSetUpdate(TestCase):
         json_content = json.loads(response.content)
         assert 'anon_user.png' in json_content['picture_url']
 
+    def test_account_picture_disallowed_verbs(self):
+        picture_url = reverse('account-picture', kwargs={'pk': self.user.pk})
+        self.client.login_api(self.user)
+        response = self.client.get(picture_url)
+        assert response.status_code == 405
+        response = self.client.post(picture_url)
+        assert response.status_code == 405
+        response = self.client.put(picture_url)
+        assert response.status_code == 405
+        response = self.client.patch(picture_url)
+        assert response.status_code == 405
+
     def test_picture_upload_valid(self):
         self.client.login_api(self.user)
         gif = get_uploaded_file('animated.gif')

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -441,9 +441,9 @@ class AccountViewSet(RetrieveModelMixin, UpdateModelMixin, DestroyModelMixin,
         return super(AccountViewSet, self).perform_destroy(instance)
 
     @detail_route(
-        methods=['post'], permission_classes=[
+        methods=['delete'], permission_classes=[
             AnyOf(AllowSelf, GroupPermission(amo.permissions.USERS_EDIT))])
-    def clear_picture(self, request, pk=None):
+    def picture(self, request, pk=None):
         user = self.get_object()
         user.update(picture_type='')
         log.debug(u'User (%s) deleted photo' % user)

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -15,6 +15,7 @@ from django.utils.translation import ugettext, ugettext_lazy as _
 
 from rest_framework import serializers
 from rest_framework.authentication import SessionAuthentication
+from rest_framework.decorators import detail_route
 from rest_framework.mixins import (
     DestroyModelMixin, ListModelMixin, RetrieveModelMixin, UpdateModelMixin)
 from rest_framework.permissions import (
@@ -33,6 +34,7 @@ from olympia.amo.decorators import write
 from olympia.api.authentication import (
     JWTKeyAuthentication, WebTokenAuthentication)
 from olympia.api.permissions import AnyOf, ByHttpMethod, GroupPermission
+from olympia.users import tasks
 from olympia.users.models import UserProfile, UserNotification
 from olympia.users.notifications import NOTIFICATIONS
 
@@ -437,6 +439,16 @@ class AccountViewSet(RetrieveModelMixin, UpdateModelMixin, DestroyModelMixin,
                 u'account. You must delete all add-ons and themes linked to '
                 u'this account, or transfer them to other users.'))
         return super(AccountViewSet, self).perform_destroy(instance)
+
+    @detail_route(
+        methods=['post'], permission_classes=[
+            AnyOf(AllowSelf, GroupPermission(amo.permissions.USERS_EDIT))])
+    def clear_picture(self, request, pk=None):
+        user = self.get_object()
+        user.update(picture_type='')
+        log.debug(u'User (%s) deleted photo' % user)
+        tasks.delete_photo.delay(user.picture_path)
+        return self.retrieve(request)
 
 
 class ProfileView(APIView):


### PR DESCRIPTION
Easiest way of fixing #5598 

Though... we do end up with 3 different ways to do things with profile photos:
- GETting `/account/user/` and `data.picture_url` to get the photo
- PATCHing `/account/user/` sending `data.picture_upload` to set the photo
- POSTing `/account/user/clear_picture` with no data to clear it