### PR TITLE
Avoid using the 'queryset' property in DRF viewsets

### DIFF
--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -397,7 +397,9 @@ class AccountViewSet(RetrieveModelMixin, UpdateModelMixin, DestroyModelMixin,
                 amo.permissions.USERS_EDIT)),
         }),
     ]
-    queryset = UserProfile.objects.all()
+
+    def get_queryset(self):
+        return UserProfile.objects.all()
 
     def get_object(self):
         if hasattr(self, 'instance'):

--- a/src/olympia/activity/views.py
+++ b/src/olympia/activity/views.py
@@ -31,7 +31,6 @@ class VersionReviewNotesViewSet(AddonChildMixin, ListModelMixin,
         AnyOf(AllowAddonAuthor, AllowReviewer, AllowReviewerUnlisted),
     ]
     serializer_class = ActivityLogSerializer
-    queryset = ActivityLog.objects.all()
 
     def get_queryset(self):
         alog = ActivityLog.objects.for_version(self.get_version_object)

--- a/src/olympia/addons/api_urls.py
+++ b/src/olympia/addons/api_urls.py
@@ -11,7 +11,7 @@ from .views import (
 
 
 addons = SimpleRouter()
-addons.register(r'addon', AddonViewSet)
+addons.register(r'addon', AddonViewSet, base_name='addon')
 
 # Router for children of /addons/addon/{addon_pk}/.
 sub_addons = NestedSimpleRouter(addons, r'addon', lookup='addon')

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -1790,6 +1790,30 @@ class TestAddonViewSetDetail(AddonAndVersionViewSetDetailMixin, TestCase):
         assert result['latest_unlisted_version']
         assert result['latest_unlisted_version']['id'] == unlisted_version.pk
 
+    def test_with_lang(self):
+        self.addon.name = {
+            'en-US': u'My Addôn, mine',
+            'fr': u'Mon Addôn, le mien',
+        }
+        self.addon.save()
+        response = self.client.get(self.url, {'lang': 'en-US'})
+        assert response.status_code == 200
+        result = json.loads(response.content)
+        assert result['id'] == self.addon.pk
+        assert result['name'] == u'My Addôn, mine'
+
+        response = self.client.get(self.url, {'lang': 'fr'})
+        assert response.status_code == 200
+        result = json.loads(response.content)
+        assert result['id'] == self.addon.pk
+        assert result['name'] == u'Mon Addôn, le mien'
+
+        response = self.client.get(self.url, {'lang': 'en-US'})
+        assert response.status_code == 200
+        result = json.loads(response.content)
+        assert result['id'] == self.addon.pk
+        assert result['name'] == u'My Addôn, mine'
+
 
 class TestVersionViewSetDetail(AddonAndVersionViewSetDetailMixin, TestCase):
     client_class = APITestClient

--- a/src/olympia/discovery/views.py
+++ b/src/olympia/discovery/views.py
@@ -10,7 +10,6 @@ from olympia.discovery.serializers import DiscoverySerializer
 class DiscoveryViewSet(ListModelMixin, GenericViewSet):
     permission_classes = []
     serializer_class = DiscoverySerializer
-    queryset = Addon.objects.public()
 
     def get_queryset(self):
         ids = [item.addon_id for item in discopane_items]
@@ -20,7 +19,7 @@ class DiscoveryViewSet(ListModelMixin, GenericViewSet):
         # es = amo.search.get_es()
         # es.mget({'ids': ids}, index=AddonIndexer.get_index_alias(),
         #         doc_type=AddonIndexer.get_doctype_name())
-        addons = self.queryset.in_bulk(ids)
+        addons = Addon.objects.public().in_bulk(ids)
 
         # Patch items to add addons.
         result = []

--- a/src/olympia/internal_tools/views.py
+++ b/src/olympia/internal_tools/views.py
@@ -41,11 +41,12 @@ class InternalAddonViewSet(AddonViewSet):
         AnyOf(GroupPermission(amo.permissions.ADMIN_TOOLS_VIEW),
               GroupPermission(amo.permissions.REVIEWER_ADMIN_TOOLS_VIEW))]
 
-    # Internal tools allow access to everything, including deleted add-ons.
-    queryset = Addon.unfiltered.all()
-
     # Can display unlisted data.
     serializer_class = AddonSerializerWithUnlistedData
+
+    def get_queryset(self):
+        # Internal tools allow access to everything, including deleted add-ons.
+        return Addon.unfiltered.all()
 
 
 class LoginStartView(LoginStartBaseView):

--- a/src/olympia/reviews/api_urls.py
+++ b/src/olympia/reviews/api_urls.py
@@ -6,7 +6,7 @@ from olympia.reviews.views import ReviewViewSet
 
 
 reviews = SimpleRouter()
-reviews.register(r'review', ReviewViewSet)
+reviews.register(r'review', ReviewViewSet, base_name='review')
 
 urlpatterns = [
     url(r'', include(reviews.urls))


### PR DESCRIPTION
DRF's `get_queryset()` calls `.all()` on `self.queryset` to force it to be re-executed, avoiding django internal results caching, but that's not enough in our case, we also have cache-machine caching the queryset when it should in fact be re-evaluated to potentially change the language.

Note: I removed all usage of the `queryset` property that I could find in this commit, despite the fact that some of the views were not affected by this bug - I think it's best to simply make a rule never to use the property than trying to use it in some views and not others.

Fix mozilla/addons-frontend/issues/2497