### PR TITLE
Add an index to theme_update_counts.date to speed-up stats calculation.

### DIFF
--- a/src/olympia/migrations/951-add-theme-user-counts-date-index.sql
+++ b/src/olympia/migrations/951-add-theme-user-counts-date-index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX `theme_user_counts_5fc73231` ON `theme_user_counts` (`date`)

--- a/src/olympia/stats/models.py
+++ b/src/olympia/stats/models.py
@@ -280,7 +280,7 @@ class ThemeUserCount(StatsSearchMixin, models.Model):
     """
     addon = models.ForeignKey('addons.Addon')
     count = models.PositiveIntegerField()
-    date = models.DateField()
+    date = models.DateField(db_index=True)
 
     class Meta:
         db_table = 'theme_user_counts'


### PR DESCRIPTION
This will hopefully lower load on production while stats are calculating
and most definetely fix our -dev problems while reindexing stats (I hope).

That table is huge (51M on -dev alone, 64M on -stage) so any searches by
`date` without an index take ~30 seconds on -stage and ~2 minutes on
-dev and we're throwing a few hundred queries to the server for a
complete reindex.

There's an index on ('id', 'date') but mysql can't use that one for date-only queries since 'date' is not the leftmost column in the index.