### PR TITLE
Fix reputation weight factor: it should go from -300 to 0, not 0 to 300

### DIFF
--- a/src/olympia/editors/models.py
+++ b/src/olympia/editors/models.py
@@ -748,7 +748,7 @@ class AutoApprovalSummary(ModelBase):
             # Reputation is set by admin - the value is inverted to add from
             # -300 (decreasing priority for "trusted" add-ons) to 0.
             'reputation': (
-                max(min(int(addon.reputation or 0) * -100, 300), 0)),
+                max(min(int(addon.reputation or 0) * -100, 0), -300)),
             # Average daily users: value divided by 10000 is added to the
             # weight, up to a maximum of 100.
             'average_daily_users': min(addon.average_daily_users / 10000, 100),

--- a/src/olympia/editors/tests/test_models.py
+++ b/src/olympia/editors/tests/test_models.py
@@ -817,23 +817,23 @@ class TestAutoApprovalSummary(TestCase):
         assert weight_info['negative_reviews'] == 100
 
     def test_calculate_weight_reputation(self):
-        self.addon.update(reputation=3)
         summary = AutoApprovalSummary(version=self.version)
+        self.addon.update(reputation=0)
         weight_info = summary.calculate_weight()
         assert summary.weight == 0
         assert weight_info['reputation'] == 0
 
-        self.addon.update(reputation=-3)
+        self.addon.update(reputation=3)
         weight_info = summary.calculate_weight()
-        assert summary.weight == 300
-        assert weight_info['reputation'] == 300
-
-        self.addon.update(reputation=-1000)
-        weight_info = summary.calculate_weight()
-        assert summary.weight == 300
-        assert weight_info['reputation'] == 300
+        assert summary.weight == -300
+        assert weight_info['reputation'] == -300
 
         self.addon.update(reputation=1000)
+        weight_info = summary.calculate_weight()
+        assert summary.weight == -300
+        assert weight_info['reputation'] == -300
+
+        self.addon.update(reputation=-1000)
         weight_info = summary.calculate_weight()
         assert summary.weight == 0
         assert weight_info['reputation'] == 0


### PR DESCRIPTION
(Positive reputation equals negative weight - the comment was already
 accurate, the code below wasn't right.)

Fix #5520