### PR TITLE
Let permissions list scroll when it is too long

### DIFF
--- a/src/olympia/editors/templates/editors/includes/files_view.html
+++ b/src/olympia/editors/templates/editors/includes/files_view.html
@@ -17,7 +17,7 @@
     <a class="compare" href="{{ url('files.compare', file[0].id, file_compare(file[0], show_diff)) }}">{{ _('Compare') }}</a>
     {% endif %}
     {% if file[0].is_webextension %}
-    <div><strong>{{ _('Permissions:') }}</strong> {{ ', '.join(file[0].webext_permissions_list) or _('None') }}</div>
+    <div class="file-permissions"><strong>{{ _('Permissions:') }}</strong> {{ ', '.join(file[0].webext_permissions_list) or _('None') }}</div>
     {% endif %}
   </span>
 </li>

--- a/static/css/zamboni/editors.styl
+++ b/static/css/zamboni/editors.styl
@@ -623,6 +623,10 @@ div.editor-stats-table > div.editor-stats-dark {
     width: 255px;
     padding: 15px;
 }
+#review-files .files .file-permissions {
+    max-height: 25.5em;
+    overflow: auto;
+}
 #review-files-header h3 {
     float: left;
 }


### PR DESCRIPTION
Solved by making the div auto-scrolling. I've added .5em so that it is more clear that there is a scroll area, especially on mac where the scrollbar is invisible.

[fixes #5339]