### PR TITLE
Also assign weight in post-review if the addon uses document.write

### DIFF
--- a/src/olympia/editors/models.py
+++ b/src/olympia/editors/models.py
@@ -773,9 +773,10 @@ class AutoApprovalSummary(ModelBase):
         try:
             factors = {
                 # Static analysis flags from linter:
-                # eval, evalInSandbox, document.write: 20.
-                'uses_dangerous_eval': (
-                    20 if self.check_uses_eval(self.version) else 0),
+                # eval() or document.write(): 20.
+                'uses_eval_or_document_write': (
+                    20 if self.check_uses_eval_or_document_write(self.version)
+                    else 0),
                 # Implied eval in setTimeout/setInterval/ on* attributes: 5.
                 'uses_implied_eval': (
                     5 if self.check_uses_implied_eval(self.version) else 0),
@@ -878,8 +879,10 @@ class AutoApprovalSummary(ModelBase):
                    for file_ in version.all_files)
 
     @classmethod
-    def check_uses_eval(cls, version):
-        return cls.check_for_linter_flag(version, 'DANGEROUS_EVAL')
+    def check_uses_eval_or_document_write(cls, version):
+        return (
+            cls.check_for_linter_flag(version, 'NO_DOCUMENT_WRITE') or
+            cls.check_for_linter_flag(version, 'DANGEROUS_EVAL'))
 
     @classmethod
     def check_uses_implied_eval(cls, version):

--- a/src/olympia/editors/tests/test_models.py
+++ b/src/olympia/editors/tests/test_models.py
@@ -710,7 +710,7 @@ class TestAutoApprovalSummary(TestCase):
             'reputation': 0,
             'past_rejection_history': 0,
             'uses_custom_csp': 0,
-            'uses_dangerous_eval': 0,
+            'uses_eval_or_document_write': 0,
             'uses_implied_eval': 0,
             'uses_innerhtml': 0,
             'uses_native_messaging': 0
@@ -912,7 +912,7 @@ class TestAutoApprovalSummary(TestCase):
         assert summary.weight == 100
         assert weight_info['past_rejection_history'] == 100
 
-    def test_calculate_weight_uses_dangerous_eval(self):
+    def test_calculate_weight_uses_eval_or_document_write(self):
         validation_data = {
             'messages': [{
                 'id': ['DANGEROUS_EVAL'],
@@ -922,7 +922,32 @@ class TestAutoApprovalSummary(TestCase):
         summary = AutoApprovalSummary(version=self.version)
         weight_info = summary.calculate_weight()
         assert summary.weight == 20
-        assert weight_info['uses_dangerous_eval'] == 20
+        assert weight_info['uses_eval_or_document_write'] == 20
+
+        validation_data = {
+            'messages': [{
+                'id': ['NO_DOCUMENT_WRITE'],
+            }]
+        }
+        self.file_validation.update(validation=json.dumps(validation_data))
+        summary = AutoApprovalSummary(version=self.version)
+        weight_info = summary.calculate_weight()
+        assert summary.weight == 20
+        assert weight_info['uses_eval_or_document_write'] == 20
+
+        # Still only 20 if both appear.
+        validation_data = {
+            'messages': [{
+                'id': ['DANGEROUS_EVAL'],
+            }, {
+                'id': ['NO_DOCUMENT_WRITE'],
+            }]
+        }
+        self.file_validation.update(validation=json.dumps(validation_data))
+        summary = AutoApprovalSummary(version=self.version)
+        weight_info = summary.calculate_weight()
+        assert summary.weight == 20
+        assert weight_info['uses_eval_or_document_write'] == 20
 
     def test_calculate_weight_uses_implied_eval(self):
         validation_data = {
@@ -990,7 +1015,7 @@ class TestAutoApprovalSummary(TestCase):
             'reputation': 0,
             'past_rejection_history': 0,
             'uses_custom_csp': 30,
-            'uses_dangerous_eval': 20,
+            'uses_eval_or_document_write': 20,
             'uses_implied_eval': 5,
             'uses_innerhtml': 20,
             'uses_native_messaging': 0


### PR DESCRIPTION
Per weights spreadsheet it should be counted together with `eval()`.

Fix #5475 (hopefully for the last time, at least until new linter flags are supported)