### PR TITLE
Drop the foreign key first before dropping the index.

### DIFF
--- a/src/olympia/migrations/952-correct-index-theme-user-counts.sql
+++ b/src/olympia/migrations/952-correct-index-theme-user-counts.sql
@@ -1,4 +1,20 @@
--- Drop old index first, if it exists.
+-- Drop foreign key first so that we can drop the index next.
+SET @FOREIGN_KEY_ADDON_ID := (
+    SELECT CONSTRAINT_NAME FROM information_schema.KEY_COLUMN_USAGE WHERE
+        TABLE_SCHEMA = (SELECT DATABASE()) AND
+        TABLE_NAME = 'theme_user_counts' AND
+        COLUMN_NAME = 'addon_id');
+
+SET @QUERY_DROP_FOREIGN_KEY_ADDON_ID = IF(
+    @FOREIGN_KEY_ADDON_ID IS NOT NULL,
+    CONCAT('ALTER TABLE theme_user_counts DROP FOREIGN KEY ', @FOREIGN_KEY_ADDON_ID, ';'),
+    'SELECT 0;');
+
+PREPARE stmt FROM @QUERY_DROP_FOREIGN_KEY_ADDON_ID;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- Now drop old index, if it exists.
 
 -- Set to index_name (addon_date_idx) or NULL if it doesn't exist
 SET @KEY_ADDON_DATE_IDX := (
@@ -20,6 +36,9 @@ SET @QUERY_DROP_KEY_ADDON_DATE_IDX = IF(
 PREPARE stmt FROM @QUERY_DROP_KEY_ADDON_DATE_IDX;
 EXECUTE stmt;
 DEALLOCATE PREPARE stmt;
+
+-- First create the foreign key that we dropped earlier
+ALTER TABLE `theme_user_counts` ADD CONSTRAINT `addon_id_refs_id_ac19f783` FOREIGN KEY (`addon_id`) REFERENCES `addons` (`id`)
 
 -- Now create our new, proper index.
 ALTER TABLE `theme_user_counts` ADD CONSTRAINT `theme_user_counts_date_cc9034dde90789f_uniq` UNIQUE (`date`, `addon_id`);


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/5715

Log of me trying this locally:

```
MariaDB [olympoa_dev]> CREATE TABLE `theme_user_counts` (
    ->   `id` int(11) NOT NULL AUTO_INCREMENT,
    ->   `addon_id` int(11) signed NOT NULL,
    ->   `count` int(10) signed NOT NULL,
    ->   `date` date NOT NULL,
    ->   PRIMARY KEY (`id`),
    ->   KEY `addon_date_idx` (`addon_id`,`date`),
    ->   CONSTRAINT `addon_id_refs_id_ac19f783` FOREIGN KEY (`addon_id`) REFERENCES `addons` (`id`));
Query OK, 0 rows affected (0.04 sec)

MariaDB [olympoa_dev]> 
MariaDB [olympoa_dev]> 
MariaDB [olympoa_dev]> -- Drop foreign key first so that we can drop the index next.
MariaDB [olympoa_dev]> SET @FOREIGN_KEY_ADDON_ID := (
    ->     SELECT CONSTRAINT_NAME FROM information_schema.KEY_COLUMN_USAGE WHERE
    ->         TABLE_SCHEMA = (SELECT DATABASE()) AND
    ->         TABLE_NAME = 'theme_user_counts' AND
    ->         COLUMN_NAME = 'addon_id');
Query OK, 0 rows affected (0.00 sec)

MariaDB [olympoa_dev]> 
MariaDB [olympoa_dev]> SET @QUERY_DROP_FOREIGN_KEY_ADDON_ID = IF(
    ->     @FOREIGN_KEY_ADDON_ID IS NOT NULL,
    ->     CONCAT('ALTER TABLE theme_user_counts DROP FOREIGN KEY ', @FOREIGN_KEY_ADDON_ID, ';'),
    ->     'SELECT 0;');
Query OK, 0 rows affected (0.00 sec)

MariaDB [olympoa_dev]> 
MariaDB [olympoa_dev]> PREPARE stmt FROM @QUERY_DROP_FOREIGN_KEY_ADDON_ID;
Query OK, 0 rows affected (0.00 sec)
Statement prepared

MariaDB [olympoa_dev]> EXECUTE stmt;
Query OK, 0 rows affected (0.01 sec)
Records: 0  Duplicates: 0  Warnings: 0

MariaDB [olympoa_dev]> DEALLOCATE PREPARE stmt;
Query OK, 0 rows affected (0.00 sec)

MariaDB [olympoa_dev]> 
MariaDB [olympoa_dev]> 
MariaDB [olympoa_dev]> show create table theme_user_counts;
+-------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table             | Create Table                                                                                                                                                                                                                                                        |
+-------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| theme_user_counts | CREATE TABLE `theme_user_counts` (
  `id` int(11) NOT NULL AUTO_INCREMENT,
  `addon_id` int(11) NOT NULL,
  `count` int(10) NOT NULL,
  `date` date NOT NULL,
  PRIMARY KEY (`id`),
  KEY `addon_date_idx` (`addon_id`,`date`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8 |
+-------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)

MariaDB [olympoa_dev]> 
MariaDB [olympoa_dev]> 
MariaDB [olympoa_dev]> 
MariaDB [olympoa_dev]> -- Now drop old index, if it exists.
MariaDB [olympoa_dev]> 
MariaDB [olympoa_dev]> -- Set to index_name (addon_date_idx) or NULL if it doesn't exist
MariaDB [olympoa_dev]> SET @KEY_ADDON_DATE_IDX := (
    ->     SELECT INDEX_NAME FROM information_schema.STATISTICS WHERE
    ->         TABLE_SCHEMA = (SELECT DATABASE()) AND
    ->         TABLE_NAME = 'theme_user_counts' AND
    ->         INDEX_NAME = 'addon_date_idx'
    ->     -- Need the limit 1 here because the query will match two columns
    ->     -- because the index is a composite index on (addon_id, date)
    ->     -- and since we re-use it below in the prepared-statement we want
    ->     -- only the name.
    ->     LIMIT 1);
Query OK, 0 rows affected (0.00 sec)

MariaDB [olympoa_dev]> 
MariaDB [olympoa_dev]> SET @QUERY_DROP_KEY_ADDON_DATE_IDX = IF(
    ->     @KEY_ADDON_DATE_IDX IS NOT NULL,
    ->     CONCAT('ALTER TABLE theme_user_counts DROP KEY ', @KEY_ADDON_DATE_IDX, ';'),
    ->     'SELECT 0;');
Query OK, 0 rows affected (0.00 sec)

MariaDB [olympoa_dev]> 
MariaDB [olympoa_dev]> PREPARE stmt FROM @QUERY_DROP_KEY_ADDON_DATE_IDX;
Query OK, 0 rows affected (0.00 sec)
Statement prepared

MariaDB [olympoa_dev]> EXECUTE stmt;
Query OK, 0 rows affected (0.01 sec)
Records: 0  Duplicates: 0  Warnings: 0

MariaDB [olympoa_dev]> DEALLOCATE PREPARE stmt;
Query OK, 0 rows affected (0.00 sec)

MariaDB [olympoa_dev]> show create table theme_user_counts;
+-------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table             | Create Table                                                                                                                                                                                                            |
+-------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| theme_user_counts | CREATE TABLE `theme_user_counts` (
  `id` int(11) NOT NULL AUTO_INCREMENT,
  `addon_id` int(11) NOT NULL,
  `count` int(10) NOT NULL,
  `date` date NOT NULL,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8 |
+-------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)

MariaDB [olympoa_dev]> 
MariaDB [olympoa_dev]> -- First create the foreign key that we dropped earlier
MariaDB [olympoa_dev]> 
MariaDB [olympoa_dev]> SET @QUERY_CREATE_FOREIGN_KEY_ADDON_ID = CONCAT(
    ->     'ALTER TABLE `theme_user_counts` ADD CONSTRAINT ', @FOREIGN_KEY_ADDON_ID,
    ->     ' FOREIGN KEY (`addon_id`) REFERENCES `addons` (`id`);');
Query OK, 0 rows affected (0.00 sec)

MariaDB [olympoa_dev]> 
MariaDB [olympoa_dev]> PREPARE stmt FROM @QUERY_CREATE_FOREIGN_KEY_ADDON_ID;
Query OK, 0 rows affected (0.00 sec)
Statement prepared

MariaDB [olympoa_dev]> EXECUTE stmt;
Query OK, 0 rows affected (0.07 sec)               
Records: 0  Duplicates: 0  Warnings: 0

MariaDB [olympoa_dev]> DEALLOCATE PREPARE stmt;
Query OK, 0 rows affected (0.00 sec)

MariaDB [olympoa_dev]>
MariaDB [olympoa_dev]> show create table theme_user_counts;
+-------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table             | Create Table                                                                                                                                                                                                                                                                                                                                                          |
+-------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| theme_user_counts | CREATE TABLE `theme_user_counts` (
  `id` int(11) NOT NULL AUTO_INCREMENT,
  `addon_id` int(11) NOT NULL,
  `count` int(10) NOT NULL,
  `date` date NOT NULL,
  PRIMARY KEY (`id`),
  KEY `addon_id_refs_id_ac19f783` (`addon_id`),
  CONSTRAINT `addon_id_refs_id_ac19f783` FOREIGN KEY (`addon_id`) REFERENCES `addons` (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8 |
+-------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.01 sec)

MariaDB [olympoa_dev]>
MariaDB [olympoa_dev]> -- Now create our new, proper index.
MariaDB [olympoa_dev]> ALTER TABLE `theme_user_counts` ADD CONSTRAINT `theme_user_counts_date_cc9034dde90789f_uniq` UNIQUE (`date`, `addon_id`);
Query OK, 0 rows affected (0.03 sec)
Records: 0  Duplicates: 0  Warnings: 0

MariaDB [olympoa_dev]>
MariaDB [olympoa_dev]> show create table theme_user_counts;
+-------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table             | Create Table                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+-------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| theme_user_counts | CREATE TABLE `theme_user_counts` (
  `id` int(11) NOT NULL AUTO_INCREMENT,
  `addon_id` int(11) NOT NULL,
  `count` int(10) NOT NULL,
  `date` date NOT NULL,
  PRIMARY KEY (`id`),
  UNIQUE KEY `theme_user_counts_date_cc9034dde90789f_uniq` (`date`,`addon_id`),
  KEY `addon_id_refs_id_ac19f783` (`addon_id`),
  CONSTRAINT `addon_id_refs_id_ac19f783` FOREIGN KEY (`addon_id`) REFERENCES `addons` (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8 |
+-------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)
```

r?