### PR TITLE
Add a proper warning if the add-on exceeds configured maxSize.

### DIFF
--- a/static/js/common/upload-addon.js
+++ b/static/js/common/upload-addon.js
@@ -285,7 +285,7 @@
                     if (xhr.status == 413) {
                         errors.push(
                             format(
-                                gettext("Your add-on exceeds the maximum size of 200 MB."),
+                                gettext("Your add-on exceeds the maximum size of " + textSize(settings.maxSize) + "."),
                                 [xhr.status]));
                     } else {
                         // L10n: first argument is an HTTP status code

--- a/static/js/common/upload-addon.js
+++ b/static/js/common/upload-addon.js
@@ -92,7 +92,6 @@
             $upload_field.fileUploader(settings);
 
             function textSize(bytes) {
-                // Based on code by Cary Dunn (http://bit.ly/d8qbWc).
                 var s = ['bytes', 'KB', 'MB', 'GB', 'TB', 'PB'];
                 if(bytes === 0) return bytes + " " + s[1];
                 var e = Math.floor( Math.log(bytes) / Math.log(1024) );

--- a/static/js/common/upload-addon.js
+++ b/static/js/common/upload-addon.js
@@ -27,7 +27,12 @@
     }
 
     $.fn.addonUploader = function( options ) {
-        var settings = {'filetypes': ['zip', 'xpi', 'crx', 'jar', 'xml'], 'getErrors': getErrors, 'cancel': $()};
+        var settings = {
+            'filetypes': ['zip', 'xpi', 'crx', 'jar', 'xml'],
+            'getErrors': getErrors,
+            'cancel': $(),
+            'maxSize': 200 * 1024 * 1024 // 200M
+        };
 
         if (options) {
             $.extend( settings, options );
@@ -277,9 +282,18 @@
                     $upload_field.trigger("upload_finished", [file]);
 
                 } else if(xhr.readyState == 4 && !aborted) {
-                    // L10n: first argument is an HTTP status code
-                    errors = [format(gettext("Received an empty response from the server; status: {0}"),
-                                     [xhr.status])];
+                    if (xhr.status == 413) {
+                        errors.push(
+                            format(
+                                gettext("Your add-on exceeds the maximum size of 200 MB."),
+                                [xhr.status]));
+                    } else {
+                        // L10n: first argument is an HTTP status code
+                        errors.push(
+                            format(
+                                gettext("Received an empty response from the server; status: {0}"),
+                                [xhr.status]));
+                    }
 
                     $upload_field.trigger("upload_errors", [file, errors]);
                 }

--- a/static/js/common/upload-base.js
+++ b/static/js/common/upload-base.js
@@ -7,7 +7,6 @@
     }
 
     function textSize(bytes) {
-        // Based on code by Cary Dunn (http://bit.ly/d8qbWc).
         var s = ['bytes', 'KB', 'MB', 'GB', 'TB', 'PB'];
         if(bytes === 0) return bytes + " " + s[1];
         var e = Math.floor( Math.log(bytes) / Math.log(1024) );

--- a/static/js/common/upload-base.js
+++ b/static/js/common/upload-base.js
@@ -6,7 +6,15 @@
         return results.errors;
     }
 
-    var settings = {'filetypes': [], 'getErrors': getErrors, 'cancel': $()};
+    function textSize(bytes) {
+        // Based on code by Cary Dunn (http://bit.ly/d8qbWc).
+        var s = ['bytes', 'KB', 'MB', 'GB', 'TB', 'PB'];
+        if(bytes === 0) return bytes + " " + s[1];
+        var e = Math.floor( Math.log(bytes) / Math.log(1024) );
+        return (bytes / Math.pow(1024, Math.floor(e))).toFixed(2)+" "+s[e];
+    }
+
+    var settings = {'filetypes': [], 'getErrors': getErrors, 'cancel': $(), 'maxSize': null};
 
     $.fn.fileUploader = function( options ) {
 
@@ -59,6 +67,14 @@
                     $upload_field.trigger("upload_errors", [file, errors]);
                     $upload_field.trigger("upload_finished", [file]);
 
+                    return;
+                }
+
+                if (settings.maxSize && domfile.size > settings.maxSize) {
+                    errors = [gettext("Your file exceeds the maximum size of " + textSize(settings.maxSize) + ".")];
+
+                    $upload_field.trigger("upload_errors", [file, errors]);
+                    $upload_field.trigger("upload_finished", [file]);
                     return;
                 }
 


### PR DESCRIPTION
* adds a generic maxSize setting to our file uploader
* catches xhr 413 responses in case our javascript didn't catch
file-size and nginx aborts

Fixes #5752

Our JavaScript generically catching the file size:
![screenshot from 2017-07-06 12-26-35](https://user-images.githubusercontent.com/139033/27907250-3c95b9a0-6247-11e7-8dbe-c001cd89496a.png)

Nginx catching it, responds with HTTP 413 and we're catching it:
![screenshot from 2017-07-06 10-43-33](https://user-images.githubusercontent.com/139033/27907251-3c96991a-6247-11e7-9a7e-9a4a3ed5c0a0.png)
