### PR TITLE
Don't ignore 400 errors when creating ES indices

### DIFF
--- a/src/olympia/lib/es/utils.py
+++ b/src/olympia/lib/es/utils.py
@@ -102,6 +102,6 @@ def create_index(index, config=None):
     })
 
     if not es.indices.exists(index):
-        es.indices.create(index, body=config, ignore=400)
+        es.indices.create(index, body=config)
 
     return index


### PR DESCRIPTION
It can reveal tricky issues, and ignoring the error is not going to help anyway if the index has not been created when we blindly expect it to present later.

Fix #5859