### PR TITLE
Fix addons admin page: replace "prerelease" field by "is_experimental"

### DIFF
--- a/src/olympia/addons/admin.py
+++ b/src/olympia/addons/admin.py
@@ -30,7 +30,7 @@ class AddonAdmin(admin.ModelAdmin):
         }),
         ('Truthiness', {
             'fields': ('disabled_by_user', 'view_source',
-                       'public_stats', 'prerelease', 'admin_review',
+                       'public_stats', 'is_experimental', 'admin_review',
                        'external_software', 'dev_agreement'),
         }),
         ('Money', {


### PR DESCRIPTION
Fix #5862