### PR TITLE
Shield study privacy prefs

### DIFF
--- a/src/olympia/pages/templates/pages/shield_study_13.html
+++ b/src/olympia/pages/templates/pages/shield_study_13.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Containers</title>
+    <link rel="stylesheet" href="{{ STATIC_URL }}css/shield_study_12/main.css" type="text/css" />
+  </head>
+  <body>
+      <div class="container">
+        <div class="title-container">
+          <h1 class="title">Containers</h1>
+            <a href="#"><button class="button primary large">Try Containers</button></a>
+        </div>
+        <div class="content"><p>Mozilla wants to know if Containers help organize tasks and protect your online identity by keeping some aspects of your online use separate from others. Participating in this study will help us find out!</p>
+<h2 id="what-will-happen-next">What will happen next</h2>
+<p><strong>If you agree</strong> to participate:</p>
+<ol>
+<li>We will add additional functionality to Firefox that provides Containers for your tabs.</li>
+<li>You will see a new browser icon and panel to manage your Containers and Container tabs.</li>
+<li>You will see a new menu when you long-press on the "+" button in tab bar.</li>
+<li>Continue using Firefox - with or without Container tabs.</li>
+<li>After 28 days, the study will end on its own. Your Firefox will go back to normal. Any Containers you created and used during the study will be removed.</li>
+<li>We will ask you to fill out a quick <em>optional survey</em> to tell us about your experience. The survey should take less than 5 minutes to complete.</li>
+</ol>
+<h2 id="leaving-the-study">Leaving the study</h2>
+<p>The study will expire on its own in 28 days.  You may leave the study early.  To do so, follow these steps:</p>
+<ol>
+<li>Type <code>about:addons</code> into the location bar, and press enter.</li>
+<li>Find <code>Containers Experiment</code> in the <strong>extensions</strong> list pane.</li>
+<li>Click the <code>remove</code> button.</li>
+<li>If you opt out of the study early we will ask you to fill out a survey. We’re interested in hearing about your experience, even if you didn’t participate in the entire study.</li>
+</ol>
+<p>Opting out of a study does not prevent you from participating in future studies.</p>
+<h2 id="your-privacy">Your privacy</h2>
+<h3 id="all-shield-studies">All Shield Studies</h3>
+<p>Every Shield Study collects data about important study events, such as install, uninstall, daily usage, and end of study. Studies also include an optional survey.</p>
+<p>This data is associated with <a href="https://gecko.readthedocs.io/en/latest/toolkit/components/telemetry/telemetry/index.html">Firefox Telemetry collection</a>.</p>
+<h3 id="this-particular-study">This Particular Study</h3>
+<p>In addition to the data collected by all Shield Studies and your voluntary answers to the followup survey, here are the <strong>key things you should know</strong> about what is happening when you participate in this study:</p>
+<ul>
+<li>To learn which elements of Containers are most helpful to you, we measure the user interface element with which you interact.</li>
+<li>To learn which elements of Containers are used automatically, we measure some non-interactive events too.</li>
+</ul>
+<p>You can learn more about the data collection for this study <a href="https://github.com/mozilla/testpilot-containers/blob/master/docs/metrics.md">on our metrics document.</a></p>
+<h2 id="you-help-make-firefox-better">You help make Firefox better</h2>
+<p>At Mozilla, we pride ourselves on building products for you, the user! That’s why we need your help.  You help us by letting us observe how you use new features and by telling us your opinions about them.</p>
+<p>By participating in this study, you will help us make better decisions on your behalf and directly shape the future of Firefox.</p>
+<h2 id="brought-to-you-by">Brought to you by</h2>
+<ul>
+<li>Tanvi Vyas</li>
+<li>Jonathan Kingston</li>
+<li>Andrea Marchesini</li>
+<li>Kamil Jozwiak</li>
+<li>Luke Crouch</li>
+<li>Fang Shih</li>
+<li>Mark Liang</li>
+<li>Morpheus Chen</li>
+<li>John Gruen</li>
+</ul>
+</div>
+    </div>
+  </body>
+</html>

--- a/src/olympia/pages/templates/pages/shield_study_14.html
+++ b/src/olympia/pages/templates/pages/shield_study_14.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Containers</title>
+    <link rel="stylesheet" href="{{ STATIC_URL }}css/shield_study_12/main.css" type="text/css" />
+  </head>
+  <body>
+      <div class="container">
+        <div class="title-container">
+          <h1 class="title">Improved Privacy Settings</h1>
+          <a href="#"><button class="button primary large">Try Improved Privacy Settings</button></a>
+        </div>
+        <div class="content"><p>Mozilla wants to know if we can improve upon and expand our privacy features for Firefox Users. Participating in this study will help us find out!</p>
+<h2 id="what-will-happen-next">What will happen next</h2>
+<p><strong>If you agree</strong> to participate:</p>
+<ol>
+<li>We will add additional functionality to improve your privacy with Firefox.</li>
+<li>You will see a new browser icon that will allow you to report broken websites.</li>
+<li>Continue using Firefox as you normally would..</li>
+<li>When you see a broken site, use the browser icon to report it.</li>
+<li>After 28 days, the study will end on its own. Your Firefox will go back to normal.</li>
+<li>We will ask you to fill out a quick <em>optional survey</em> to tell us about your experience. The survey should take less than 5 minutes to complete.</li>
+</ol>
+<h2 id="leaving-the-study">Leaving the study</h2>
+<p>The study will expire on its own in 28 days.  You may leave the study early.  To do so, follow these steps:</p>
+<ol>
+  <li>Open the browser icon to report broken websites.</li>
+  <li>Click "Disable Privacy Study"</li>
+  <li>If you opt out of the study early we will ask you to fill out a survey. We’re interested in hearing about your experience, even if you didn’t participate in the entire study.</li>
+</ol>
+<p>Opting out of a study does not prevent you from participating in future studies.</p>
+<h2 id="your-privacy">Your privacy</h2>
+<h3 id="all-shield-studies">All Shield Studies</h3>
+<p>Every Shield Study collects data about important study events, such as install, uninstall, daily usage, and end of study. Studies also include an optional survey.</p>
+<p>This data is associated with <a href="https://gecko.readthedocs.io/en/latest/toolkit/components/telemetry/telemetry/index.html">Firefox Telemetry collection</a>.</p>
+<h3 id="this-particular-study">This Particular Study</h3>
+<p>In addition to the data collected by all Shield Studies and your voluntary answers to the followup survey, here are the <strong>key things you should know</strong> about what is happening when you participate in this study:</p>
+<ul>
+  <li>We collect given information regarding the breakage of reported webpages, including if there is a problem, what is the problem, and any additional comments.</li>
+  <li>Along with given information, we also collect the high-level domain name of each page reported.</li>
+  <li>No personal information or data will be collected or recorded during the study.</li>
+</ul>
+<p>You can learn more about the data collection for this study <a href="https://github.com/mozilla/shield-study-privacy/blob/master/docs/metrics.md">on our metrics document.</a></p>
+<h2 id="you-help-make-firefox-better">You help make Firefox better</h2>
+<p>At Mozilla, we pride ourselves on building products for you, the user! That’s why we need your help.  You help us by letting us observe how you use new features and by telling us your opinions about them.</p>
+<p>By participating in this study, you will help us make better decisions on your behalf and directly shape the future of Firefox.</p>
+<h2 id="brought-to-you-by">Brought to you by</h2>
+<ul>
+<li>Luke Crouch</li>
+<li>Peter Dolanjski</li>
+<li>Jacqueline Savory</li>
+<li>Firefox Privacy &amp; Security teams</li>
+<li>Firefox Strategy &amp; Insights team</li>
+</ul>
+</div>
+    </div>
+  </body>
+</html>

--- a/src/olympia/pages/tests.py
+++ b/src/olympia/pages/tests.py
@@ -18,7 +18,8 @@ class TestPages(TestCase):
                  'pages.shield_study_5', 'pages.shield_study_6',
                  'pages.shield_study_7', 'pages.shield_study_8',
                  'pages.shield_study_9', 'pages.shield_study_10',
-                 'pages.shield_study_11', 'pages.shield_study_12']
+                 'pages.shield_study_11', 'pages.shield_study_12',
+                 'pages.shield_study_13']
         for page in pages:
             self._check(page, 200)
 

--- a/src/olympia/pages/tests.py
+++ b/src/olympia/pages/tests.py
@@ -19,7 +19,7 @@ class TestPages(TestCase):
                  'pages.shield_study_7', 'pages.shield_study_8',
                  'pages.shield_study_9', 'pages.shield_study_10',
                  'pages.shield_study_11', 'pages.shield_study_12',
-                 'pages.shield_study_13']
+                 'pages.shield_study_13', 'pages.shield_study_14']
         for page in pages:
             self._check(page, 200)
 

--- a/src/olympia/pages/urls.py
+++ b/src/olympia/pages/urls.py
@@ -66,6 +66,9 @@ urlpatterns = [
     url('^shield_study_13$',
         TemplateView.as_view(template_name='pages/shield_study_13.html'),
         name='pages.shield_study_13'),
+    url('^shield_study_14$',
+        TemplateView.as_view(template_name='pages/shield_study_14.html'),
+        name='pages.shield_study_14'),
 
     url('^pages/compatibility_firstrun$',
         lambda r: perma_redirect(reverse('pages.acr_firstrun'))),

--- a/src/olympia/pages/urls.py
+++ b/src/olympia/pages/urls.py
@@ -63,6 +63,9 @@ urlpatterns = [
     url('^shield_study_12$',
         TemplateView.as_view(template_name='pages/shield_study_12.html'),
         name='pages.shield_study_12'),
+    url('^shield_study_13$',
+        TemplateView.as_view(template_name='pages/shield_study_13.html'),
+        name='pages.shield_study_13'),
 
     url('^pages/compatibility_firstrun$',
         lambda r: perma_redirect(reverse('pages.acr_firstrun'))),


### PR DESCRIPTION
This includes https://github.com/mozilla/addons-server/pull/5864, and that study is more important, so we need to work that PR first.

This adds a 14th shield study AMO consent page, for a study to learn about website breakage under various improved privacy settings.

Still need to:
* [x] Decide if/that https://github.com/mozilla/shield-study-privacy/pull/50 is required
* [ ] Get the study `.xpi` signed and deployed to fill in the link