### PR TITLE
Simplify Add-on type constants: remove ADDON_ANY except where it's actually used

### DIFF
--- a/src/olympia/addons/admin.py
+++ b/src/olympia/addons/admin.py
@@ -1,8 +1,6 @@
 from django import forms
 from django.contrib import admin
 
-from olympia import amo
-
 from . import models
 
 
@@ -42,8 +40,7 @@ class AddonAdmin(admin.ModelAdmin):
         }))
 
     def queryset(self, request):
-        types = amo.ADDON_ADMIN_SEARCH_TYPES
-        return models.Addon.unfiltered.filter(type__in=types)
+        return models.Addon.unfiltered
 
 
 class FeatureAdmin(admin.ModelAdmin):

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -260,9 +260,10 @@ class Addon(OnChangeMixin, ModelBase):
                                       db_column='defaultlocale')
 
     type = models.PositiveIntegerField(
-        choices=amo.ADDON_TYPE.items(), db_column='addontype_id', default=0)
+        choices=amo.ADDON_TYPE.items(), db_column='addontype_id',
+        default=amo.ADDON_EXTENSION)
     status = models.PositiveIntegerField(
-        choices=STATUS_CHOICES.items(), db_index=True, default=0)
+        choices=STATUS_CHOICES.items(), db_index=True, default=amo.STATUS_NULL)
     icon_type = models.CharField(max_length=25, blank=True,
                                  db_column='icontype')
     homepage = TranslatedField()

--- a/src/olympia/constants/base.py
+++ b/src/olympia/constants/base.py
@@ -128,7 +128,6 @@ GROUP_TYPE_THEME = [ADDON_THEME, ADDON_PERSONA]
 
 # Singular
 ADDON_TYPE = {
-    ADDON_ANY: _(u'Any'),
     ADDON_EXTENSION: _(u'Extension'),
     ADDON_THEME: _(u'Complete Theme'),
     ADDON_DICT: _(u'Dictionary'),
@@ -141,7 +140,6 @@ ADDON_TYPE = {
 
 # Plural
 ADDON_TYPES = {
-    ADDON_ANY: _(u'Any'),
     ADDON_EXTENSION: _(u'Extensions'),
     ADDON_THEME: _(u'Complete Themes'),
     ADDON_DICT: _(u'Dictionaries'),
@@ -162,12 +160,6 @@ ADDON_SEARCH_TYPES = [
     ADDON_LPAPP,
     ADDON_PERSONA,
 ]
-
-# Add-on types that need to be exposed in the admin. Those are directly used
-# with no special handling, so we need to remove the ADDON_ANY type, it's not
-# a valid type, just something we have for the frontend search UI.
-ADDON_ADMIN_SEARCH_TYPES = ADDON_SEARCH_TYPES + [ADDON_PLUGIN]
-ADDON_ADMIN_SEARCH_TYPES.remove(ADDON_ANY)
 
 # Icons
 ADDON_ICONS = {
@@ -243,7 +235,7 @@ VIDEO_TYPES = ('video/webm',)
 # These types don't maintain app compatibility in the db.  Instead, we look at
 # APP.types and APP_TYPE_SUPPORT to figure out where they are compatible.
 NO_COMPAT = (ADDON_SEARCH, ADDON_PERSONA)
-HAS_COMPAT = dict((t, t not in NO_COMPAT) for t in ADDON_TYPES)
+HAS_COMPAT = {t: t not in NO_COMPAT for t in ADDON_TYPES}
 
 # Contributions
 CONTRIB_NONE = 0

--- a/src/olympia/devhub/forms.py
+++ b/src/olympia/devhub/forms.py
@@ -727,9 +727,6 @@ PreviewFormSet = modelformset_factory(Preview, formset=BasePreviewFormSet,
 
 
 class AdminForm(happyforms.ModelForm):
-    _choices = [(k, v) for k, v in amo.ADDON_TYPE.items()
-                if k != amo.ADDON_ANY]
-    type = forms.ChoiceField(choices=_choices)
     reputation = forms.ChoiceField(
         label=_(u'Reputation'),
         choices=(

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -882,8 +882,8 @@ def upload_detail(request, uuid, format='html'):
 
 class AddonDependencySearch(BaseAjaxSearch):
     # No personas.
-    types = [amo.ADDON_ANY, amo.ADDON_EXTENSION, amo.ADDON_THEME,
-             amo.ADDON_DICT, amo.ADDON_SEARCH, amo.ADDON_LPAPP]
+    types = [amo.ADDON_EXTENSION, amo.ADDON_THEME, amo.ADDON_DICT,
+             amo.ADDON_SEARCH, amo.ADDON_LPAPP]
 
 
 @dev_required

--- a/src/olympia/editors/forms.py
+++ b/src/olympia/editors/forms.py
@@ -115,7 +115,7 @@ class QueueSearchForm(happyforms.Form):
     addon_type_ids = forms.MultipleChoiceField(
         required=False,
         label=_(u'Add-on Types'),
-        choices=((id, tp) for id, tp in amo.ADDON_TYPES.items()))
+        choices=[(amo.ADDON_ANY, _(u'Any'))] + amo.ADDON_TYPES.items())
 
     def __init__(self, *args, **kw):
         super(QueueSearchForm, self).__init__(*args, **kw)

--- a/src/olympia/search/views.py
+++ b/src/olympia/search/views.py
@@ -221,8 +221,8 @@ class SearchSuggestionsAjax(BaseAjaxSearch):
 
 class AddonSuggestionsAjax(SearchSuggestionsAjax):
     # No personas.
-    types = [amo.ADDON_ANY, amo.ADDON_EXTENSION, amo.ADDON_THEME,
-             amo.ADDON_DICT, amo.ADDON_SEARCH, amo.ADDON_LPAPP]
+    types = [amo.ADDON_EXTENSION, amo.ADDON_THEME, amo.ADDON_DICT,
+             amo.ADDON_SEARCH, amo.ADDON_LPAPP]
 
 
 class PersonaSuggestionsAjax(SearchSuggestionsAjax):

--- a/src/olympia/zadmin/views.py
+++ b/src/olympia/zadmin/views.py
@@ -558,9 +558,7 @@ def addon_search(request):
         if q.isdigit():
             qs = Addon.objects.filter(id=int(q))
         else:
-            qs = (Addon.search()
-                       .query(name__text=q.lower())
-                       .filter(type__in=amo.ADDON_ADMIN_SEARCH_TYPES)[:100])
+            qs = Addon.search().query(name__text=q.lower())[:100]
         if len(qs) == 1:
             return redirect('zadmin.addon_manage', qs[0].id)
         ctx['addons'] = qs


### PR DESCRIPTION
`ADDON_ANY` is not an actual type choice: there are no addons with that type, it's only a special value to be handled by search forms.

The only 2 places where we display a type widget selector are editors tools and admin search. The former does need `ADDON_ANY` (and has code and tests for it), the latter does not because the admin already has a "All" option when displaying list_filter choices.

Everywhere else on the site, we don't display a type widget when searching, so we don't need to support the `ADDON_ANY` choice.

Fix #5870 (for real this time)