### PR TITLE
feat: Disable GA when DNT is enabled

### DIFF
--- a/static/js/zamboni/analytics.js
+++ b/static/js/zamboni/analytics.js
@@ -1,14 +1,31 @@
 // GA Analytics code. The '_setAccount' below is specific to AMO tracking.
 
+function isDoNotTrackEnabled() {
+    // We ignore things like `msDoNotTrack` because they are for older,
+    // unsupported browsers and don't really respect the DNT spec. This
+    // covers new versions of IE/Edge, Firefox from 32+, Chrome, Safari, and
+    // any browsers built on these stacks (Chromium, Tor Browser, etc.).
+    var dnt = navigator.doNotTrack || window.doNotTrack;
+    if (dnt === '1') {
+        window.console && console.info('[TRACKING]: Do Not Track Enabled; Google Analytics will not be loaded.');
+        return true;
+    }
+
+    // Known DNT values not set, so we will assume it's off.
+    return false;
+}
+
 var _gaq = _gaq || [];
 _gaq.push(['_setAccount', 'UA-36116321-7']);
 _gaq.push(['_trackPageview']);
 
 (function() {
-    var ga = document.createElement('script');
-    ga.type = 'text/javascript';
-    ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0];
-    s.parentNode.insertBefore(ga, s);
+    if (isDoNotTrackEnabled() === false) {
+      var ga = document.createElement('script');
+      ga.type = 'text/javascript';
+      ga.async = true;
+      ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+      var s = document.getElementsByTagName('script')[0];
+      s.parentNode.insertBefore(ga, s);
+    }
 })();


### PR DESCRIPTION
Fixes #5901.

r? from whomever

This disables the tracking when DNT is on for the old Disco Pane and AMO. It logs a message as well informing the user tracking is disabled.

### Without DNT/Tracking Protection
<img width="1250" alt="screenshot 2017-07-13 14 01 16" src="https://user-images.githubusercontent.com/90871/28167549-dd449038-67d3-11e7-85ba-90b62bad6a6c.png">
<img width="1250" alt="screenshot 2017-07-13 14 02 57" src="https://user-images.githubusercontent.com/90871/28168026-98ee0dcc-67d5-11e7-8f6b-faa4b71ddaaa.png">
<img width="1250" alt="screen shot 2017-07-13 at 13 57 40" src="https://user-images.githubusercontent.com/90871/28167599-0652e772-67d4-11e7-8718-cabde0e4a0e5.png">
<img width="1250" alt="screen shot 2017-07-13 at 13 57 43" src="https://user-images.githubusercontent.com/90871/28167600-0655b2ae-67d4-11e7-85a4-000be006900f.png">

### With DNT/Tracking Protection
<img width="1250" alt="screenshot 2017-07-13 14 01 10" src="https://user-images.githubusercontent.com/90871/28167551-e3b7aeb4-67d3-11e7-8891-b4bc2ad18910.png">
<img width="1250" alt="screenshot 2017-07-13 14 02 57 2" src="https://user-images.githubusercontent.com/90871/28168033-a0b991f2-67d5-11e7-9d7e-bf3329057e55.png">
<img width="1250" alt="screenshot 2017-07-13 14 03 29 4" src="https://user-images.githubusercontent.com/90871/28167999-8a7b1ad2-67d5-11e7-853b-d8298e3a1175.png">
<img width="1250" alt="screenshot 2017-07-13 14 03 29 3" src="https://user-images.githubusercontent.com/90871/28168000-8a7cd96c-67d5-11e7-9ca1-4652f79925f4.png">
