### PR TITLE
Fix date format string in de/ja/pt_PT locales

### DIFF
--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -1123,7 +1123,7 @@ msgstr "vor {0}"
 
 #, python-format
 msgid "%B %e, %Y"
-msgstr "%B %e, %Y"
+msgstr "%%B %%e, %%Y"
 
 msgid "Title"
 msgstr "Titel"

--- a/locale/ja/LC_MESSAGES/django.po
+++ b/locale/ja/LC_MESSAGES/django.po
@@ -1087,7 +1087,7 @@ msgstr "{0}前"
 
 #, python-format
 msgid "%B %e, %Y"
-msgstr "%Y 年 %m 月 %e 日"
+msgstr "%%Y 年 %%B 月 %e 日"
 
 msgid "Title"
 msgstr "タイトル"

--- a/locale/pt_PT/LC_MESSAGES/django.po
+++ b/locale/pt_PT/LC_MESSAGES/django.po
@@ -1114,7 +1114,7 @@ msgstr "{0} atrás"
 
 #, python-format
 msgid "%B %e, %Y"
-msgstr "%B %e, %Y"
+msgstr "%%B %%e, %%Y"
 
 msgid "Title"
 msgstr "Título"


### PR DESCRIPTION
Similar to #5928 

This feels wrong on several levels: 
1. I should not have to escape the `%` in the `msgstr`
2. I shouldn't need to use a specific (and potentially wrong with that translation) format string
3. It *will* happen with other locales...

But it should unbreak the build while we figure out a better solution.