### PR TITLE
Add language tools API

### DIFF
--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -131,6 +131,7 @@ This endpoint allows you to fetch a specific add-on by id, slug or guid.
     :>json string|object|null name: The add-on name (See :ref:`translated fields <api-overview-translations>`).
     :>json string last_updated: The date of the last time the add-on was updated by its developer(s).
     :>json object|null latest_unlisted_version: Object holding the latest unlisted :ref:`version <version-detail-object>` of the add-on. This field is only present if the user has unlisted reviewer permissions, or is listed as a developer of the add-on.
+    :>json string locale_disambiguation: Free text field allowing clients to distinguish between multiple dictionaries in the same locale but different spellings. Only present when using the Language Tools endpoint.
     :>json array previews: Array holding information about the previews for the add-on.
     :>json int previews[].id: The id for a preview.
     :>json string|object|null previews[].caption: The caption describing a preview (See :ref:`translated fields <api-overview-translations>`).
@@ -149,6 +150,7 @@ This endpoint allows you to fetch a specific add-on by id, slug or guid.
     :>json string|object|null support_email: The add-on support email (See :ref:`translated fields <api-overview-translations>`).
     :>json string|object|null support_url: The add-on support URL (See :ref:`translated fields <api-overview-translations>`).
     :>json array tags: List containing the text of the tags set on the add-on.
+    :>json string target_locale: For dictionaries and language packs, the locale the add-on is meant for. Only present when using the Language Tools endpoint.
     :>json object theme_data: Object holding `lightweight theme (Persona) <https://developer.mozilla.org/en-US/Add-ons/Themes/Lightweight_themes>`_ data. Only present for themes (Persona).
     :>json string type: The :ref:`add-on type <addon-detail-type>`.
     :>json string url: The (absolute) add-on detail URL.
@@ -358,3 +360,25 @@ This endpoint allows you to fetch an add-on EULA and privacy policy.
 
     :>json string|object|null eula: The text of the EULA, if present (See :ref:`translated fields <api-overview-translations>`).
     :>json string|object|null privacy_policy: The text of the Privacy Policy, if present (See :ref:`translated fields <api-overview-translations>`).
+
+
+--------------
+Language Tools
+--------------
+
+.. _addon-language-tools:
+
+This endpoint allows you to list all public language tools add-ons available
+on AMO.
+
+.. http:get:: /api/v3/addons/language-tools/
+
+    .. note::
+        Because this endpoint is intended to be used to feed a page that
+        displays all available language tools in a single page, it is not
+        paginated as normal, and instead will return all results without
+        obeying regular pagination parameters.
+
+    :query string app: Mandatory. Filter by :ref:`add-on application <addon-detail-application>` availability.
+    :query string lang: Activate translations in the specific language for that query. (See :ref:`translated fields <api-overview-translations>`)
+    :>json array results: An array of :ref:`add-ons <addon-detail-object>`, but with only the following fields present: ``id``, ``current_version``, ``default_locale``, ``locale_disambiguation``, ``name``, ``target_locale``, ``type`` and ``url``.

--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -377,8 +377,18 @@ on AMO.
         Because this endpoint is intended to be used to feed a page that
         displays all available language tools in a single page, it is not
         paginated as normal, and instead will return all results without
-        obeying regular pagination parameters.
+        obeying regular pagination parameters. The ordering is left undefined,
+        it's up to the clients to re-order results as needed before displaying
+        the add-ons to the end-users.
 
     :query string app: Mandatory. Filter by :ref:`add-on application <addon-detail-application>` availability.
     :query string lang: Activate translations in the specific language for that query. (See :ref:`translated fields <api-overview-translations>`)
-    :>json array results: An array of :ref:`add-ons <addon-detail-object>`, but with only the following fields present: ``id``, ``current_version``, ``default_locale``, ``locale_disambiguation``, ``name``, ``target_locale``, ``type`` and ``url``.
+    :>json array results: An array of language tools.
+    :>json int results[].id: The add-on id on AMO.
+    :>json object results[].current_version: Object holding the current :ref:`version <version-detail-object>` of the add-on. For performance reasons the ``release_notes`` field is omitted and the ``license`` field omits the ``text`` property.
+    :>json string results[].default_locale: The add-on default locale for translations.
+    :>json string|object|null results[].name: The add-on name (See :ref:`translated fields <api-overview-translations>`).
+    :>json string results[].locale_disambiguation: Free text field allowing clients to distinguish between multiple dictionaries in the same locale but different spellings. Only present when using the Language Tools endpoint.
+    :>json string results[].target_locale: For dictionaries and language packs, the locale the add-on is meant for. Only present when using the Language Tools endpoint.
+    :>json string results[].type: The :ref:`add-on type <addon-detail-type>`.
+    :>json string results[].url: The (absolute) add-on detail URL.

--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -131,7 +131,6 @@ This endpoint allows you to fetch a specific add-on by id, slug or guid.
     :>json string|object|null name: The add-on name (See :ref:`translated fields <api-overview-translations>`).
     :>json string last_updated: The date of the last time the add-on was updated by its developer(s).
     :>json object|null latest_unlisted_version: Object holding the latest unlisted :ref:`version <version-detail-object>` of the add-on. This field is only present if the user has unlisted reviewer permissions, or is listed as a developer of the add-on.
-    :>json string locale_disambiguation: Free text field allowing clients to distinguish between multiple dictionaries in the same locale but different spellings. Only present when using the Language Tools endpoint.
     :>json array previews: Array holding information about the previews for the add-on.
     :>json int previews[].id: The id for a preview.
     :>json string|object|null previews[].caption: The caption describing a preview (See :ref:`translated fields <api-overview-translations>`).
@@ -150,7 +149,6 @@ This endpoint allows you to fetch a specific add-on by id, slug or guid.
     :>json string|object|null support_email: The add-on support email (See :ref:`translated fields <api-overview-translations>`).
     :>json string|object|null support_url: The add-on support URL (See :ref:`translated fields <api-overview-translations>`).
     :>json array tags: List containing the text of the tags set on the add-on.
-    :>json string target_locale: For dictionaries and language packs, the locale the add-on is meant for. Only present when using the Language Tools endpoint.
     :>json object theme_data: Object holding `lightweight theme (Persona) <https://developer.mozilla.org/en-US/Add-ons/Themes/Lightweight_themes>`_ data. Only present for themes (Persona).
     :>json string type: The :ref:`add-on type <addon-detail-type>`.
     :>json string url: The (absolute) add-on detail URL.

--- a/src/olympia/addons/api_urls.py
+++ b/src/olympia/addons/api_urls.py
@@ -7,7 +7,7 @@ from olympia.activity.views import VersionReviewNotesViewSet
 
 from .views import (
     AddonFeaturedView, AddonSearchView, AddonVersionViewSet, AddonViewSet,
-    StaticCategoryView)
+    LanguageToolsView, StaticCategoryView)
 
 
 addons = SimpleRouter()
@@ -27,4 +27,6 @@ urlpatterns = [
     url(r'^search/$', AddonSearchView.as_view(), name='addon-search'),
     url(r'^featured/$', AddonFeaturedView.as_view(), name='addon-featured'),
     url(r'^categories/$', StaticCategoryView.as_view(), name='category-list'),
+    url(r'^language-tools/$', LanguageToolsView.as_view(),
+        name='addon-language-tools'),
 ]

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -474,3 +474,14 @@ class StaticCategorySerializer(serializers.Serializer):
 
     def get_type(self, obj):
         return ADDON_TYPE_CHOICES_API[obj.type]
+
+
+class LanguageToolsSerializer(AddonSerializer):
+    target_locale = serializers.CharField()
+    locale_disambiguation = serializers.CharField()
+
+    class Meta:
+        model = Addon
+        fields = ('id', 'current_version', 'default_locale',
+                  'locale_disambiguation', 'name', 'target_locale', 'type',
+                  'url', )

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -15,8 +15,8 @@ from olympia.addons.models import (
     Addon, AddonCategory, AddonUser, Category, Persona, Preview)
 from olympia.addons.serializers import (
     AddonSerializer, AddonSerializerWithUnlistedData, ESAddonSerializer,
-    ESAddonSerializerWithUnlistedData, SimpleVersionSerializer,
-    VersionSerializer)
+    ESAddonSerializerWithUnlistedData, LanguageToolsSerializer,
+    SimpleVersionSerializer, VersionSerializer)
 from olympia.addons.utils import generate_addon_guid
 from olympia.constants.categories import CATEGORIES
 from olympia.files.models import WebextPermission
@@ -675,3 +675,30 @@ class TestSimpleVersionSerializerOutput(TestCase):
         assert result['license']['name']['fr'] == u'Mä Licence'
         assert result['license']['url'] == 'http://license.example.com/'
         assert 'text' not in result['license']
+
+
+class TestLanguageToolsSerializerOutput(TestCase):
+    def setUp(self):
+        self.request = APIRequestFactory().get('/')
+
+    def serialize(self):
+        serializer = LanguageToolsSerializer(context={'request': self.request})
+        return serializer.to_representation(self.addon)
+
+    def test_basic(self):
+        self.addon = addon_factory(
+            type=amo.ADDON_DICT, target_locale='fr',
+            locale_disambiguation=u'lolé')
+        result = self.serialize()
+        assert result['id'] == self.addon.pk
+        assert result['default_locale'] == self.addon.default_locale
+        assert result['locale_disambiguation'] == (
+            self.addon.locale_disambiguation)
+        assert result['name'] == {'en-US': self.addon.name}
+        assert result['target_locale'] == self.addon.target_locale
+        assert result['url'] == absolutify(self.addon.get_url_path())
+
+        addon_testcase = AddonSerializerOutputTestMixin()
+        addon_testcase.addon = self.addon
+        addon_testcase._test_version(
+            self.addon.current_version, result['current_version'])

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -879,6 +879,9 @@ class LanguageToolsView(ListAPIView):
             target_locale__isnull=False).exclude(target_locale='')
 
     def list(self, request, *args, **kwargs):
+        # Ignore pagination (return everything) but do wrap the data in a
+        # 'results' property to mimic what the default implementation of list()
+        # does in DRF.
         queryset = self.filter_queryset(self.get_queryset())
         serializer = self.get_serializer(queryset, many=True)
         return Response({'results': serializer.data})


### PR DESCRIPTION
This returns all valid, public dictionaries and language packs on AMO in a single endpoint. Clients should then sort through the results to display them as they see fit.

Fix #5803
