### PR TITLE
 Add-ons icons are not RTL in search suggestions #5800

### DIFF
--- a/static/css/impala/suggestions.less
+++ b/static/css/impala/suggestions.less
@@ -114,4 +114,9 @@
         left: auto;
         right: 14px;
     }
+    a span {
+        background-position: right;
+        float: none;
+        padding: 2px 32px 2px 2px;
+    }
 }


### PR DESCRIPTION
Fixes: #5800 

Please delete anything that isn't relevant to your patch.

Added rtl CSS rules for suggestion dropdown.

**Before**:
<img width="492" alt="screen shot 2017-07-18 at 9 28 58 pm" src="https://user-images.githubusercontent.com/5318732/28327204-630fa204-6c00-11e7-988c-95f514553104.png">

**After**:
<img width="511" alt="screen shot 2017-07-18 at 9 28 20 pm" src="https://user-images.githubusercontent.com/5318732/28327235-727c1a7e-6c00-11e7-900b-ea1927237b07.png">

