### PR TITLE
Ignore comments completely when confirming auto-approval

### DIFF
--- a/src/olympia/editors/tests/test_utils.py
+++ b/src/olympia/editors/tests/test_utils.py
@@ -744,6 +744,7 @@ class TestReviewHelper(TestCase):
                                .filter(action=amo.LOG.CONFIRM_AUTO_APPROVED.id)
                                .get())
         assert activity.arguments == [self.addon, self.version]
+        assert activity.details['comments'] == ''
 
     def test_public_with_unreviewed_version_addon_confirm_auto_approval(self):
         self.grant_permission(self.request.user, 'Addons:PostReview')

--- a/src/olympia/editors/tests/test_views.py
+++ b/src/olympia/editors/tests/test_views.py
@@ -2663,11 +2663,17 @@ class TestReview(ReviewBase):
         AutoApprovalSummary.objects.create(
             version=self.addon.current_version, verdict=amo.AUTO_APPROVED)
         self.login_as_senior_editor()
-        response = self.client.post(
-            self.url, {'action': 'confirm_auto_approved'})
+        response = self.client.post(self.url, {
+            'action': 'confirm_auto_approved',
+            'comments': 'ignore me this action does not support comments'
+        })
         assert response.status_code == 302
         assert ActivityLog.objects.filter(
             action=amo.LOG.CONFIRM_AUTO_APPROVED.id).count() == 1
+        a_log = ActivityLog.objects.filter(
+            action=amo.LOG.CONFIRM_AUTO_APPROVED.id).get()
+        assert a_log.details['version'] == self.addon.current_version.version
+        assert a_log.details['comments'] == ''
 
     def test_user_changes_log(self):
         # Activity logs related to user changes should be displayed.

--- a/src/olympia/editors/utils.py
+++ b/src/olympia/editors/utils.py
@@ -598,6 +598,10 @@ class ReviewBase(object):
         version is listed, incrementing AddonApprovalsCounter, which also
         resets the last human review date to now, and log it so that it's
         displayed later in the review page."""
+        # The confirm auto-approval action should not show the comment box,
+        # so override the text in case the reviewer switched between actions
+        # and accidently submitted some comments from another action.
+        self.data['comments'] = ''
         if self.version.channel == amo.RELEASE_CHANNEL_LISTED:
             AddonApprovalsCounter.increment_for_addon(addon=self.addon)
         self.log_action(amo.LOG.CONFIRM_AUTO_APPROVED)


### PR DESCRIPTION
Fix #5929
