### PR TITLE
Fix failing travis builds that are missing gettext

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ addons:
   apt:
     packages:
       - swig
+      - gettext
   firefox: latest
 
 before_install:


### PR DESCRIPTION
fixes this https://travis-ci.org/mozilla/addons-server/builds/255218522