### PR TITLE
Fix for broken Lightning URL on Sunbird page

### DIFF
--- a/src/olympia/pages/templates/pages/sunbird.html
+++ b/src/olympia/pages/templates/pages/sunbird.html
@@ -36,7 +36,7 @@
 
     <p>
     {% trans tb_url="https://www.mozilla.org/en-US/thunderbird/",
-             lightning_url="https://addons.mozilla.org/thunderbird/2313/" %}
+             lightning_url="https://addons.mozilla.org/thunderbird/addon/2313/" %}
        We recommend upgrading to <a href="{{ tb_url }}">Thunderbird</a> and <a href="{{ lightning_url }}">Lightning</a>.
     {% endtrans %}
     </p>


### PR DESCRIPTION
Simple typo fix, ID lookup doesn't work without /addon/ in the URL.