### PR TITLE
Fix migration 956

### DIFF
--- a/src/olympia/migrations/956-add-find-replacement-download-source.sql
+++ b/src/olympia/migrations/956-add-find-replacement-download-source.sql
@@ -1,2 +1,1 @@
-insert into download_sources (name, type, created)
-    values ('find-replacement', 'full', NOW());
+INSERT INTO download_sources (name, description, type, created) VALUES ('find-replacement', '', 'full', NOW());


### PR DESCRIPTION
Fix #5976 in the simplest way possible while the `description` column still exists.