### PR TITLE
Add message to indicate that the compatibility checker is not meant for webextensions

### DIFF
--- a/src/olympia/devhub/templates/devhub/validate_addon.html
+++ b/src/olympia/devhub/templates/devhub/validate_addon.html
@@ -12,6 +12,10 @@
   {% trans %}
     Use the field below to upload your add-on package.
   {% endtrans %}
+  {% trans webext_doc_url='https://developer.mozilla.org/en-US/Add-ons/WebExtensions' %}
+    Note that this tool only works with legacy add-ons.
+    WebExtension APIs are thoroughly <a href="{{ webext_doc_url }}">documented here</a>.
+  {% endtrans %}
   </p>
   {% if appversion_form %}
     <p>

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -621,6 +621,11 @@ def handle_upload(filedata, user, channel, app_id=None, version_id=None,
         upload.user = user
         upload.save()
     if app_id and version_id:
+        # If app_id and version_id are present, we are dealing with a
+        # compatibility check (i.e. this is not an upload meant for submission,
+        # we were called from check_addon_compatibility()), which essentially
+        # consists in running the addon uploaded against the legacy validator
+        # with a specific min/max appversion override.
         app = amo.APPS_ALL.get(int(app_id))
         if not app:
             raise http.Http404()


### PR DESCRIPTION
Just a message (and a comment to help future-us understand the code), most of the work was done in the validator itself in https://github.com/mozilla/amo-validator/issues/560

Fix #5950 