### PR TITLE
Drop (now unused) column total_contributions from the addons table

### DIFF
--- a/960-drop-no-total-contributions-column.sql
+++ b/960-drop-no-total-contributions-column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `addons` DROP COLUMN `total_contributions`;


### PR DESCRIPTION
Fix #5906