### PR TITLE
Fix attempt for activity mail gmail threading fail

### DIFF
--- a/src/olympia/activity/tests/test_utils.py
+++ b/src/olympia/activity/tests/test_utils.py
@@ -516,7 +516,7 @@ def test_send_activity_mail():
     assert len(mail.outbox) == 1
     assert mail.outbox[0].body == message
     assert mail.outbox[0].subject == subject
-    reference_header = '{addon}/{version}@{site}'.format(
+    reference_header = '<{addon}/{version}@{site}>'.format(
         addon=latest_version.addon.id, version=latest_version.id,
         site=settings.INBOUND_EMAIL_DOMAIN)
     assert mail.outbox[0].extra_headers['In-Reply-To'] == reference_header

--- a/src/olympia/activity/utils.py
+++ b/src/olympia/activity/utils.py
@@ -283,7 +283,7 @@ def send_activity_mail(subject, message, version, recipients, from_email,
                 token.uuid, recipient.id))
         reply_to = "%s%s@%s" % (
             REPLY_TO_PREFIX, token.uuid.hex, settings.INBOUND_EMAIL_DOMAIN)
-        reference_header = '{addon}/{version}@{site}'.format(
+        reference_header = '<{addon}/{version}@{site}>'.format(
             addon=version.addon.id, version=version.id,
             site=settings.INBOUND_EMAIL_DOMAIN)
         headers = {


### PR DESCRIPTION
Another attempt to fix #5015 by enclosing references and in-reply-to headers in `< >`