### PR TITLE
Travis: Switch back to trusty default image.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 sudo: false
-dist: precise
 
 python:
   - 2.7


### PR DESCRIPTION
We disabled the new trusty default images because they were unstable and raised MySQL connection errors.

https://github.com/travis-ci/travis-ci/issues/8137#issuecomment-317853152 mentions that this should now be fixed and more stable.

Let's try that again.