### PR TITLE
Fix appversion filtering in search

### DIFF
--- a/src/olympia/addons/indexers.py
+++ b/src/olympia/addons/indexers.py
@@ -212,6 +212,13 @@ class AddonIndexer(BaseSearchIndexer):
             if appver:
                 min_, max_ = appver.min.version_int, appver.max.version_int
                 min_human, max_human = appver.min.version, appver.max.version
+                if not version_obj.files.filter(
+                        strict_compatibility=True).exists():
+                    # The files attached to this version are not using strict
+                    # compatibility, so the max version essentially needs to be
+                    # ignored - let's fake a super high one. We leave max_human
+                    # alone to leave the API representation intact.
+                    max_ = version_int('9999')
             else:
                 # Fake wide compatibility for search tools and personas.
                 min_, max_ = 0, version_int('9999')

--- a/src/olympia/addons/tests/test_indexers.py
+++ b/src/olympia/addons/tests/test_indexers.py
@@ -203,10 +203,12 @@ class TestAddonIndexer(TestCase):
 
         assert extracted['current_version']
         assert extracted['current_version']['id'] == version.pk
+        # Because strict_compatibility is False, the max version we record in
+        # the index is an arbitrary super high version.
         assert extracted['current_version']['compatible_apps'] == {
             FIREFOX.id: {
                 'min': 2000000200100L,
-                'max': 4000000200100L,
+                'max': 9999000000200100,
                 'max_human': '4.0',
                 'min_human': '2.0',
             }
@@ -232,10 +234,12 @@ class TestAddonIndexer(TestCase):
         version = current_beta_version
         assert extracted['current_beta_version']
         assert extracted['current_beta_version']['id'] == version.pk
+        # Because strict_compatibility is False, the max version we record in
+        # the index is an arbitrary super high version.
         assert extracted['current_beta_version']['compatible_apps'] == {
             FIREFOX.id: {
                 'min': 4009900200100L,
-                'max': 5009900200100L,
+                'max': 9999000000200100,
                 'max_human': '5.0.99',
                 'min_human': '4.0.99',
             }
@@ -260,10 +264,12 @@ class TestAddonIndexer(TestCase):
         version = unlisted_version
         assert extracted['latest_unlisted_version']
         assert extracted['latest_unlisted_version']['id'] == version.pk
+        # Because strict_compatibility is False, the max version we record in
+        # the index is an arbitrary super high version.
         assert extracted['latest_unlisted_version']['compatible_apps'] == {
             FIREFOX.id: {
                 'min': 4009900200100L,
-                'max': 5009900200100L,
+                'max': 9999000000200100,
                 'max_human': '5.0.99',
                 'min_human': '4.0.99',
             }
@@ -283,6 +289,22 @@ class TestAddonIndexer(TestCase):
             assert extracted_file['size'] == file_.size
             assert extracted_file['status'] == file_.status
             assert extracted_file['webext_permissions_list'] == []
+
+    def test_version_compatibility_with_strict_compatibility_enabled(self):
+        version = self.addon.current_version
+        file_factory(
+            version=version, platform=PLATFORM_MAC.id,
+            strict_compatibility=True)
+        extracted = self._extract()
+
+        assert extracted['current_version']['compatible_apps'] == {
+            FIREFOX.id: {
+                'min': 2000000200100L,
+                'max': 4000000200100L,
+                'max_human': '4.0',
+                'min_human': '2.0',
+            }
+        }
 
     def test_extract_translations(self):
         translations_name = {

--- a/src/olympia/search/views.py
+++ b/src/olympia/search/views.py
@@ -388,14 +388,12 @@ def _filter_search(request, qs, query, filters, sorting,
         low = version_int(query['appver'])
         # Get a max version greater than X.0a.
         high = version_int(query['appver'] + 'a')
-        # If we're not using D2C then fall back to appversion checking.
-        extensions_shown = (not query.get('atype') or
-                            query['atype'] == amo.ADDON_EXTENSION)
-        if not extensions_shown or low < version_int('10.0'):
-            qs = qs.filter(**{
-                'current_version.compatible_apps.%s.max__gte' % APP.id: high,
-                'current_version.compatible_apps.%s.min__lte' % APP.id: low
-            })
+        # Note: when strict compatibility is not enabled on add-ons, we
+        # fake the max version we index in compatible_apps.
+        qs = qs.filter(**{
+            'current_version.compatible_apps.%s.max__gte' % APP.id: high,
+            'current_version.compatible_apps.%s.min__lte' % APP.id: low
+        })
     if 'atype' in show and query['atype'] in amo.ADDON_TYPES:
         qs = qs.filter(type=query['atype'])
     else:


### PR DESCRIPTION
Always apply appversion filtering when requested, but use the special '9999' max version hack we already use for themes when indexing the max version of add-ons that do not have strict compatibility enabled.

Fix #6009