### PR TITLE
Limit memory ElasticSearch consumes to ~1G, hard limit container to 1G.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,9 @@ mysqld:
 elasticsearch:
   image: docker.elastic.co/elasticsearch/elasticsearch:5.4.1
   environment:
-    -  xpack.security.enabled=false
+    - xpack.security.enabled=false
+    - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+  mem_limit: 2g
 
 redis:
   image: redis:2.8


### PR DESCRIPTION
docker stats:

![screenshot from 2017-07-26 16-18-18](https://user-images.githubusercontent.com/139033/28626006-2ea37e5e-721e-11e7-8eb5-c75c72f67d78.png)

From the log, the option get's appended to the ElasticSearch options.
![screenshot from 2017-07-26 16-14-31](https://user-images.githubusercontent.com/139033/28626007-2ecb7d50-721e-11e7-8944-e4a3229d093a.png)


For reference on my system without any limits:

![screenshot from 2017-07-26 16-20-39](https://user-images.githubusercontent.com/139033/28626086-6930dac6-721e-11e7-841d-61f440989ab8.png)
