### PR TITLE
fix missing underscores from `{{ ('...`

### DIFF
--- a/src/olympia/addons/templates/addons/impala/details.html
+++ b/src/olympia/addons/templates/addons/impala/details.html
@@ -350,9 +350,9 @@
         <div class="prose">
           <img src="{{ static('img/developers/test-warning.png') }}" alt="{{ _('[Warning]') }}">
           <p>
-          {{ ('Some add-ons ask for permission to perform certain functions. Since you’re in control of your Firefox, the choice to grant or deny these requests is yours.') }}
+          {{ _('Some add-ons ask for permission to perform certain functions. Since you’re in control of your Firefox, the choice to grant or deny these requests is yours.') }}
           </p><p>
-          {{ ('Please note this add-on uses legacy technology, which gives it access to all browser functions and data without requesting your permission.') }}
+          {{ _('Please note this add-on uses legacy technology, which gives it access to all browser functions and data without requesting your permission.') }}
           </p>
         </div>
       {% endif %}

--- a/src/olympia/devhub/templates/devhub/new-landing/components/my-addons.html
+++ b/src/olympia/devhub/templates/devhub/new-landing/components/my-addons.html
@@ -46,7 +46,7 @@
       </div>
     </div>
 
-    <h2>{{ ('My Add-ons') }}</h2>
+    <h2>{{ _('My Add-ons') }}</h2>
 
     {% if recent_addons %}
       <div class="DevHub-MyAddons-list">


### PR DESCRIPTION
fixes mozilla/addons#448