### PR TITLE
Small tweaks to version incompatibility message display

### DIFF
--- a/src/olympia/versions/templates/versions/version_list.html
+++ b/src/olympia/versions/templates/versions/version_list.html
@@ -35,7 +35,7 @@
         You should always use the <a href="{{ url }}">latest version</a> of an add-on.
       {% endtrans %}</p>
     </div>
-    <div class="items">
+    <div class="items versions-list">
       {% for version in versions.object_list %}
         {#
            We pass skip_contrib=False on purpose, to display the direct link.

--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -1203,7 +1203,7 @@ body:not(.developer-hub) section.secondary {
   }
 
   .extra .button.disabled.not-available {
-    padding: 5px 5px 5px 20px;
+    padding: 5px 5px 5px 25px;
   }
 }
 
@@ -1811,7 +1811,8 @@ h3.author .transfer-ownership {
   font-size: 1rem;
   font-weight: normal;
   margin: 0;
-  padding: 5px 0px 5px 25px;
+  padding: 5px 5px 5px 25px;
+  text-align: left;
 
   .addon-description-header &  {
     border: 0;
@@ -1821,12 +1822,8 @@ h3.author .transfer-ownership {
     border: 1px solid #ebebeb;
   }
 
-  .more-versions {
-    margin: 0 0 0 5px;
-
-    a {
-      color: #0996f8 !important; //need to override .disabled a[href] color: #888!important; rule
-    }
+  .more-versions a {
+    color: #0996f8 !important; //need to override .disabled a[href] color: #888!important; rule
   }
 }
 
@@ -1919,10 +1916,6 @@ h3.author .transfer-ownership {
   &:focus .extra .button.not-available,
   &:hover .extra .button.not-available {
     display: block !important;
-
-    span {
-      padding-left: 1rem;
-    }
   }
 
   .install-shell .install {
@@ -1934,16 +1927,12 @@ h3.author .transfer-ownership {
   }
 }
 
-.addon.hovercard,
-.items .item {
-  .more-versions {
-    padding-left: 1rem;
-  }
-}
-
 #addon .more-versions a {
   color: @link-on-white-bg;
-  margin-left: 10px;
+}
+
+.versions-list .more-versions {
+  display: none;  // Hide the more versions link on the versions list page.
 }
 
 // Contribute button fixes


### PR DESCRIPTION
- Hide the message in versions page
- Make padding/margin of that message more uniform accross pages
- Align text on the left cause there might be a lot of it

Fix #6062 

**Post-tweaks screenshots:**

*Detail page*
![tweak_detail_page](https://user-images.githubusercontent.com/187006/28785248-192114f0-7616-11e7-8085-46b89be23377.png)

*Versions page*
![tweak_versions_page](https://user-images.githubusercontent.com/187006/28785249-19211982-7616-11e7-8657-8be732d8d132.png)

*Homepage*
![tweak_homepage](https://user-images.githubusercontent.com/187006/28785247-191e89d8-7616-11e7-8f3b-376f36657b62.png)
