### PR TITLE
Collector notes rtl fix

### DIFF
--- a/static/css/legacy/main.css
+++ b/static/css/legacy/main.css
@@ -2299,6 +2299,11 @@ ol.pagination + .num-results {
     float: left;
 }
 
+.html-rtl .separated-listing .collector-note strong {
+  float: right;
+  margin-left: 1px;
+}
+
 .separated-listing .item img.icon {
     overflow: hidden;
 }


### PR DESCRIPTION
Fixes #5322 

I have added a css for collector notes when in RTL mode.
Added float right so that text aligns to the right.

Before Screenshot:
![vishal s collection](https://user-images.githubusercontent.com/8337936/28861527-eb97fc3c-777e-11e7-9411-10c28882ec9d.png)

After Screenshot:
![vishal s collection 1](https://user-images.githubusercontent.com/8337936/28861549-08241d5e-777f-11e7-8bc6-0fa72a4c8435.png)

