### PR TITLE
Fix variables in te locale translation

### DIFF
--- a/locale/te/LC_MESSAGES/django.po
+++ b/locale/te/LC_MESSAGES/django.po
@@ -2014,7 +2014,7 @@ msgid "{addon} icon changed."
 msgstr ""
 
 msgid "{review} for {addon} approved."
-msgstr "{జత చేయు} కోసం {సమీక్ష} ఆమోదించబడింది."
+msgstr "{review} కోసం {addon} ఆమోదించబడింది."
 
 msgid "{user} approved {review} for {addon}."
 msgstr "{addon} కోసం {user} {review}ను ఆమోదించారు."


### PR DESCRIPTION
Fix for:
```
 >>> Working on: /home/travis/build/mozilla/addons-server/locale/te/LC_MESSAGES/django.po
 E201: invalid variables: {జత చేయు}, {సమీక్ష}
 2016:msgid "{review} for {addon} approved."
 2017:msgstr "{జత చేయు} కోసం {సమీక్ష} ఆమోదించబడింది
```