### PR TITLE
Make MDN links non localizable

### DIFF
--- a/src/olympia/addons/templates/addons/report_abuse.html
+++ b/src/olympia/addons/templates/addons/report_abuse.html
@@ -7,10 +7,13 @@
     {% endif %}
     <ol {% if hide %}style="display: none"{% endif %}>
       <li>
-        <p>{% trans url='https://developer.mozilla.org/en-US/Add-ons/AMO/Policy' %}
-          If you suspect this add-on violates <a href="{{ url }}">our policies</a> or
-          has security or privacy issues, please use the form below to describe your
-          concerns. Please do not use this form for any other reason.{% endtrans %}</p>
+        <p>{% trans amo_policy_link_open='<a href="https://developer.mozilla.org/en-US/Add-ons/AMO/Policy">'|safe,
+                    link_close='</a>'|safe %}
+              If you suspect this add-on violates {{ amo_policy_link_open }}our policies{{ link_close }} or
+              has security or privacy issues, please use the form below to describe your
+              concerns. Please do not use this form for any other reason.
+           {% endtrans %}
+        </p>
       </li>
       <li>
         {{ abuse_form.text }}

--- a/src/olympia/applications/templates/applications/appversions.html
+++ b/src/olympia/applications/templates/applications/appversions.html
@@ -15,9 +15,11 @@ one of the below applications supported. Only the versions listed below are
 allowed for these applications.
 {% endtrans %}</p>
 
-<p>{% trans version_url=_('https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/applications') %}
-  Please be aware that WebExtensions will not accept a "*" in <a href="{{ version_url }}">strict_min_version</a>.
-{% endtrans %}</p>
+<p>{% trans amo_version_link_open='<a href="https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/applications">'|safe,
+            amo_version_link_close='</a>'|safe %}
+      Please be aware that WebExtensions will not accept a "*" in {{ amo_version_link_open }}strict_min_version{{ amo_version_link_close }}.
+   {% endtrans %}
+</p>
 
 {% for app in apps %}
 <div class="appversion prose">
@@ -32,10 +34,13 @@ allowed for these applications.
 </div>
 {% endfor %}
 
-<p>{% trans url=_('http://developer.mozilla.org/en/docs/Install_Manifests') %}
-If your supported application does not require a manifest file, you still
-must include one with the required properties as specified
-<a href="{{ url }}">here</a>.
-{% endtrans %}</p>
+<p>
+  {% trans amo_manifests_mdn_link_open='<a href="http://developer.mozilla.org/en/docs/Install_Manifests">'|safe,
+            amo_manifests_mdn_link_close='</a>'|safe %}
+    If your supported application does not require a manifest file, you still
+    must include one with the required properties as specified
+    {{ amo_manifests_mdn_link_open }}here{{ amo_manifests_mdn_link_close }}.
+  {% endtrans %}
+</p>
 
 {% endblock %}

--- a/src/olympia/browse/templates/browse/search_tools.html
+++ b/src/olympia/browse/templates/browse/search_tools.html
@@ -90,7 +90,10 @@
       {# L10n: {0} is an app name, like Firefox. #}
       <li>{{ _('Learn more about the <a href="http://support.mozilla.com/kb/Search+bar">search bar</a> in {0}')|format_html(APP.pretty) }}</li>
       <li>{{ _('Browse through even more search providers at <a href="http://mycroftproject.com/">mycroftproject.com</a>') }}</li>
-      <li>{{ _('<a href="https://developer.mozilla.org/en-US/Creating_OpenSearch_plugins_for_Firefox">Make your own</a> search tool') }}</li>
+      <li>{% trans amo_mdn_link_open='<a href="https://developer.mozilla.org/en-US/Creating_OpenSearch_plugins_for_Firefox">'|safe, amo_mdn_link_close='</a>'|safe %}
+             {{ amo_mdn_link_open }}Make your own{{ amo_mdn_link_close }} search tool
+          {% endtrans %}
+      </li>
     </ul>
   </div>
 </div>

--- a/src/olympia/devhub/templates/devhub/new-landing/components/overview.html
+++ b/src/olympia/devhub/templates/devhub/new-landing/components/overview.html
@@ -2,10 +2,11 @@
   <div>
     <h1>{{ _('Customize Firefox') }}</h1>
     <p>
-      {% trans html_link="https://developer.mozilla.org/en-US/docs/Web/HTML", js_link="https://developer.mozilla.org/en-US/docs/Web/JavaScript", css_link="https://developer.mozilla.org/en-US/docs/Web/CSS" %}
-      Add-ons let millions of Firefox users enhance their browsing experience.
-      If you know <a href="{{ html_link }}">HTML</a>, <a href="{{ js_link }}">JavaScript</a>, and <a href="{{ css_link }}">CSS</a>,
-      you already have all the necessary skills to make a great add-on.
+      {% trans html_link_open='<a href="https://developer.mozilla.org/en-US/docs/Web/HTML">'|safe, js_link_open='<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript">'|safe,
+               css_link_open='<a href="https://developer.mozilla.org/en-US/docs/Web/CSS">'|safe, link_close='</a>'|safe %}
+        Add-ons let millions of Firefox users enhance their browsing experience.
+        If you know {{ html_link_open }}HTML{{ link_close }}, {{ js_link_open }}JavaScript{{ link_close }}, and{{ css_link_open }}CSS{{ link_close }},
+        you already have all the necessary skills to make a great add-on.
       {% endtrans %}
     </p>
     <a href="https://developer.mozilla.org/en-US/Add-ons" class="Button Button--primary">{{ _('Learn How to Make an Add-on') }}</a>

--- a/src/olympia/devhub/templates/devhub/personas/submit.html
+++ b/src/olympia/devhub/templates/devhub/personas/submit.html
@@ -192,9 +192,9 @@
       <p class="legal">
         <label>
           {{ form.agreed.as_widget(attrs={'required': ''}) }}
-          {% trans agreement_url='https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Agreement',
-                   privacy_notice_url='https://www.mozilla.org/en-US/privacy/websites/' %}
-            I agree to the <a href="{{ agreement_url }}">Firefox Add-on Distribution Agreement</a> and to my information being handled as described in the <a href="{{ privacy_notice_url }}">Websites, Communications and Cookies Privacy Notice</a>.
+          {% trans agreement_link_open='<a href="https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Agreement">'|safe,
+                   privacy_notice_link_open='<a href="https://www.mozilla.org/en-US/privacy/websites/">'|safe, link_close='</a>'|safe %}
+            I agree to the {{ agreement_link_open }}Firefox Add-on Distribution Agreement{{ link_close }} and to my information being handled as described in the {{ privacy_notice_link_open }}Websites, Communications and Cookies Privacy Notice{{ link_close }}.
           {% endtrans %}
         </label>
         {{ form.agreed.errors }}

--- a/src/olympia/pages/templates/pages/dev_faq.html
+++ b/src/olympia/pages/templates/pages/dev_faq.html
@@ -44,11 +44,12 @@
 
     <h2 id="developing">{{ _('Developing an Add-on') }}</h2>
 
-    {% trans url='https://developer.mozilla.org/en-US/Add-ons' %}
+    {% trans addons_link_open='<a href="https://developer.mozilla.org/en-US/Add-ons">'|safe,
+             link_close='</a>'|safe %}
       <h3>How do I build an Add-on?</h3>
       <p>
         Mozilla provides documentation on how to build an add-on via the
-        <a href="{{ url }}">Mozilla Developer Network</a>.
+        {{ addons_link_open }}Mozilla Developer Network{{ link_close }}.
       </p>
     {% endtrans %}
 
@@ -71,12 +72,13 @@
       {% endtrans %}
     </p>
     <p>
-      {% trans webext_url="https://developer.mozilla.org/en-US/Add-ons/WebExtensions",
-               portlegacy_url="https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Porting_a_legacy_Firefox_add-on"%}
+      {% trans webext_link_open='<a href="https://developer.mozilla.org/en-US/Add-ons/WebExtensions">'|safe,
+               portlegacy_link_open='<a href="https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Porting_a_legacy_Firefox_add-on">'|safe,
+               link_close='</a>'|safe %}
       <strong>Note:</strong> XUL is considered a legacy technology in Firefox, and add-ons using XUL will no longer load starting from 
-      Firefox 57. Please use <a href="{{ webext_url }}">WebExtensions</a> APIs to develop new add-ons. If you have a legacy add-on, 
+      Firefox 57. Please use {{ webext_link_open}}WebExtensions{{ link_close }} APIs to develop new add-ons. If you have a legacy add-on,
       consider migrating it to WebExtensions. For information on migrating a legacy add-on, please visit
-      <a href="{{ portlegacy_url }}">Porting a legacy Firefox add-on</a>. 
+      {{ portlegacy_link_open }}Porting a legacy Firefox add-on{{ link_close }}.
       {% endtrans %}
     </p>
 
@@ -180,23 +182,24 @@
 
     <h3>{{ _('Does Mozilla have a policy in place as to what is an acceptable submission?') }}</h3>
     <p>
-      {% trans p_url="https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Reviews",
-               g_url="https://wiki.mozilla.org/Add-ons/Reviewers/Guide" %}
-        Yes. Mozilla's <a href="{{ p_url }}">Add-on Review Policies</a> describe what is
+      {% trans policy_link_open='<a href="https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Reviews">'|safe,
+               guide_link_open='<a href="https://wiki.mozilla.org/Add-ons/Reviewers/Guide">'|safe, link_close='</a>'|safe %}
+        Yes. Mozilla's {{ policy_link_open }}Add-on Review Policies{{ link_close }} describe what is
         an acceptable submission. This policy is subject to change without
         notice. In addition, the Add-on Reviewer Team uses the
-        <a href="{{ g_url }}">Add-on Review Guide</a> to ensure that your add-on meets
+        {{ guide_link_open }}Add-on Review Guide{{ link_close}} to ensure that your add-on meets
         specific guidelines for functionality and security.
       {% endtrans %}
     </p>
 
     <h3>{{ _('How do I submit my add-on?') }}</h3>
     <p>
-      {% trans url='https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Reviews' %}
+      {% trans review_policy_link_open='<a href="https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Reviews">'|safe,
+               link_close='</a>'|safe %}
         The Developer Tools dashboard will allow you to upload and submit
         add-ons to AMO. You must be a registered AMO user before you can
         submit an add-on. Before submitting your add-on be sure to you have
-        read the <a href="{{ url }}">Add-on Review Policies</a> to
+        read the {{ review_policy_link_open }}Add-on Review Policies{{ link_close }} to
         ensure that your add-on has met our guidelines.
       {% endtrans %}
     </p>

--- a/src/olympia/pages/templates/pages/faq.html
+++ b/src/olympia/pages/templates/pages/faq.html
@@ -96,13 +96,16 @@
     </dd>
 
     <dt>{{ _('Are add-ons safe to install?') }}</dt>
-    <dd>{% trans learnmore_url="https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Reviews" %}
-        Use caution when installing add-ons, as they may harm your computer or
-        violate your privacy. Add-ons available from this site may be subject to
-        review by Mozilla's team of reviewers, and user feedback is closely
-        monitored, so they should generally be safe to install.
-        <a href="{{ learnmore_url }}">Learn more about our review
-        process</a>{% endtrans %}</dd>
+    <dd>{% trans learnmore_link_open='<a href ="https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Reviews">'|safe,
+                 link_close='</a>'|safe %}
+           Use caution when installing add-ons, as they may harm your computer or
+           violate your privacy. Add-ons available from this site may be subject to
+           review by Mozilla's team of reviewers, and user feedback is closely
+           monitored, so they should generally be safe to install.
+           {{ learnmore_link_open }}Learn more about our review
+           process{{ link_close }}
+        {% endtrans %}
+    </dd>
 
 
     <dt>{% trans app_name=request.APP.pretty %}Can add-ons make
@@ -160,21 +163,24 @@
          <a href="{{ forum_url }}">Add-ons forum</a>.{% endtrans %}</dd>
 
     <dt id="experimental">{{ _('What does it mean if an add-on is "experimental"?') }}</dt>
-    <dd>{% trans url="https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Reviews" %}
-         Experimental add-ons have been marked by their developers as not suitable
-         for a wide audience.  They may have bugs or not work properly. Use
-         caution when installing experimental add-ons and uninstall the add-on
-         immediately if you notice problems.
-         <a href="{{ url }}">Learn more about our review process</a></dd>
-         {% endtrans %}
+    <dd>{% trans learnmore_link_open='<a href ="https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Reviews">'|safe,
+                 link_close='</a>'|safe %}
+          Experimental add-ons have been marked by their developers as not suitable
+          for a wide audience.  They may have bugs or not work properly. Use
+          caution when installing experimental add-ons and uninstall the add-on
+          immediately if you notice problems.
+          {{ learnmore_link_open }}Learn more about our review process{{ link_close }}
+        {% endtrans %}
+    </dd>
 
     <dt id="unreviewed">{{ _('What does it mean if an add-on is "not reviewed"?') }}</dt>
-    <dd>{% trans url="https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Reviews" %}
+    <dd>{% trans learnmore_link_open='<a href ="https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Reviews">'|safe,
+                 link_close='</a>'|safe %}
          If you receive a direct link to an add-on that says it hasn't yet been
          reviewed, it means it's currently awaiting review by Mozilla. Use
          caution when installing these add-ons, as they could harm your computer
          or violate your privacy.
-         <a href="{{ url }}">Learn more about our review process</a></dd>
+         {{ learnmore_link_open }}Learn more about our review process{{ link_close }}</dd>
          {% endtrans %}
 
     <dt>{{ _('How much do add-ons cost to purchase?') }}</dt>


### PR DESCRIPTION
Tries to fix #5966 
@wagnerand  Make links non-localizable by removing them from the trans keyword and using variables to insert html tags.
@EnTeQuAk  Please take a look at the changes and let me know if I implemented what you suggested?

