### PR TITLE
Unify disabled buttons behavior across the site

### DIFF
--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -548,6 +548,7 @@ MINIFY_BUNDLES = {
             'css/zamboni/zamboni.css',
             'css/zamboni/tags.css',
             'css/zamboni/tabs.css',
+            'css/impala/buttons.less',
             'css/impala/formset.less',
             'css/impala/suggestions.less',
             'css/impala/header.less',

--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -895,6 +895,7 @@ a.delete-button.delete-addon,
 #upload-file-widget .button.prominent,
 #promos .view-button a,
 .cta a.button:link,
+.cta a.button:visited,
 .theme-queue a.button,
 .theme-queue button,
 .theme .choices button,
@@ -902,6 +903,7 @@ button,
 button.button,
 .button,
 a.button:link,
+a.button:visited,
 input:not(.upvotes):not(.downvotes)[type="submit"],
 .persona-install button {
   background: #5784bf;
@@ -973,6 +975,7 @@ input:not(.upvotes):not(.downvotes)[type="submit"],
     background: #ccc;
     box-shadow: 0 2px 0 0 rgba(0, 0, 0, 0.10),
           inset 0 -2px 0 0 rgba(136, 136, 136, 0.50);
+    color: #919497;
     text-shadow: none;
 
     &:hover {
@@ -982,6 +985,14 @@ input:not(.upvotes):not(.downvotes)[type="submit"],
 
     &:active {
       top: 0;
+    }
+
+    span:not(.os) {
+      background-position: 0 -253px;
+
+      .html-rtl & {
+        .sprite-pos-right(4, 64, 3px);
+      }
     }
   }
 
@@ -1017,11 +1028,6 @@ input:not(.upvotes):not(.downvotes)[type="submit"],
            .sprite-pos-right(5, 64, 3px);
        }
     }
-  }
-
-  &.caution.concealed,
-  &.warning.concealed {
-    pointer-events: all;
   }
 }
 

--- a/static/js/zamboni/buttons.js
+++ b/static/js/zamboni/buttons.js
@@ -217,7 +217,7 @@ var installButton = function() {
               gettext('Works with {app} {min} - {max}') :
               gettext('Works with {app}'));
             var tpl = template(msg +
-                '<span class="more-versions"><a href="{versions_url}">' +
+                '<br/><span class="more-versions"><a href="{versions_url}">' +
                 gettext('View other versions') + '</a></span>');
             var context = {'app': z.appName, 'min': min, 'max': max,
                 'versions_url': versions_url};


### PR DESCRIPTION
Fix #6134 
Fix #6135

This commit contains multiple small changes that go together:

Some pages are not "impala"-ed and therefore don't get the impala and restyle styles, so they weren't getting the pointer-events: none rule that disable the buttons. Fixing those pages would require a
lot more work, so the impala button styles have been added to the base css bundle instead.

In addition, ~~the `clickHijack` class responsible for setting pointer events set it on the contents of the button but not on the button itself, so it was still possible to click through it, so this commit
changes that.~~ the restyle was setting pointer-events: all on disabled buttons, but since we are no longer showing the popup on those buttons we can remove that.

It was also possible in some pages to get the wrong style for a `a.button` element with an `href` that you had already visited, because the restyle wasn't targeting visited links, so this is changed as
well. Since doing this added more rules that previously weren't always applied, the background position and color of the concealed button also had to be specified.

Finally, there was an extra case where the more-versions link was missing the newline that separates it from the compatibility info, this was fixed.