### PR TITLE
Fix URL anchor for web-ext sign in readthedocs

### DIFF
--- a/docs/topics/api/signing.rst
+++ b/docs/topics/api/signing.rst
@@ -17,7 +17,7 @@ The following libraries will make it easier to use the signing API:
 
 * `sign-addon <https://github.com/mozilla/sign-addon/>`_, for general programattic use in
   `NodeJS <https://nodejs.org/>`_
-* `web-ext sign <https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Getting_started_with_web-ext#Signing_your_WebExtension_for_distribution>`_,
+* `web-ext sign <https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Getting_started_with_web-ext#Signing_your_extension_for_distribution>`_,
   for developing `Web Extensions <https://developer.mozilla.org/en-US/Add-ons/WebExtensions>`_
 
 If you are using ``curl`` to interact with the API you should be sure to pass


### PR DESCRIPTION
Fixes an anchor issue because DevMo changed the article.
