### PR TITLE
Don't apply 'concealed' class to 'Get Firefox Now!' button

### DIFF
--- a/static/js/zamboni/buttons.js
+++ b/static/js/zamboni/buttons.js
@@ -251,7 +251,6 @@ var installButton = function() {
     } else if (z.app == 'firefox') {
         $('#downloadAnyway').attr('href',escape_($button.filter(':visible').attr('href')));
         $('#downloadAnyway').show();
-        $button.addClass('concealed');
         versionsAndPlatforms();
         $button.addClass('CTA');
         $button.text(gettext('Only with Firefox \u2014 Get Firefox Now!'));


### PR DESCRIPTION
It's not supposed to be disabled, it should not need that class. It used to not be a problem, but now that I've made `concealed` buttons *really* disabled...

Fix #6177