### PR TITLE
Unify and set mysqld collation settings to utf-8.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,8 @@ mysqld:
   environment:
     - MYSQL_ALLOW_EMPTY_PASSWORD=yes
     - MYSQL_DATABASE=olympia
+  volumes:
+    - ./docker/etc/mysql/conf.d/:/etc/mysql/conf.d/
 
 elasticsearch:
   image: docker.elastic.co/elasticsearch/elasticsearch:5.4.1

--- a/docker/etc/mysql/conf.d/mysql.cnf
+++ b/docker/etc/mysql/conf.d/mysql.cnf
@@ -1,0 +1,6 @@
+[mysqld]
+init_connect='SET collation_connection = utf8_unicode_ci'
+init_connect='SET NAMES utf8'
+character-set-server=utf8
+collation-server=utf8_unicode_ci
+skip-character-set-client-handshake


### PR DESCRIPTION
Fixes #6183 

After:

```
mysql> show variables like "collation_%%";
+----------------------+-----------------+
| Variable_name        | Value           |
+----------------------+-----------------+
| collation_connection | utf8_unicode_ci |
| collation_database   | utf8_general_ci |
| collation_server     | utf8_unicode_ci |
+----------------------+-----------------+
3 rows in set (0.01 sec)
```