### PR TITLE
I4757 : corrects search bar url

### DIFF
--- a/src/olympia/browse/templates/browse/search_tools.html
+++ b/src/olympia/browse/templates/browse/search_tools.html
@@ -88,7 +88,7 @@
     <h3>{{ _('Additional Resources') }}</h3>
     <ul class="xoxo">
       {# L10n: {0} is an app name, like Firefox. #}
-      <li>{{ _('Learn more about the <a href="http://support.mozilla.com/kb/Search+bar">search bar</a> in {0}')|format_html(APP.pretty) }}</li>
+      <li>{{ _('Learn more about the <a href="https://support.mozilla.org/kb/use-search-bar-firefox">search bar</a> in {0}')|format_html(APP.pretty) }}</li>
       <li>{{ _('Browse through even more search providers at <a href="http://mycroftproject.com/">mycroftproject.com</a>') }}</li>
       <li>{% trans amo_mdn_link_open='<a href="https://developer.mozilla.org/en-US/Creating_OpenSearch_plugins_for_Firefox">'|safe, amo_mdn_link_close='</a>'|safe %}
              {{ amo_mdn_link_open }}Make your own{{ amo_mdn_link_close }} search tool


### PR DESCRIPTION
Fixes #4757

Note : this is also handled at `support.mozilla.org` as it redirects the wrong link to correct link.