### PR TITLE
I5224: WebExtension compatibility label is not correctly RTL

### DIFF
--- a/static/css/impala/addon_details.less
+++ b/static/css/impala/addon_details.less
@@ -514,6 +514,10 @@ div a.is-webextension {
     margin: 11px 4px 0 0;
 }
 
+.html-rtl div a.is-webextension {
+    direction: ltr;
+}
+
 /* Inline Warning */
 .listing .warning {
     background-color: #FFEDF2;


### PR DESCRIPTION
Fixes #5224 

Need to explicitly put `direction:ltr` to get the `+` direction as required in the bug description.

**Before :** 
<img width="1241" alt="screen shot 2017-08-18 at 7 34 05 am" src="https://user-images.githubusercontent.com/5318732/29441382-93876f66-83e8-11e7-9e53-ab3e2245d742.png">

**After:** 
<img width="1063" alt="screen shot 2017-08-18 at 7 33 40 am" src="https://user-images.githubusercontent.com/5318732/29441399-a488de62-83e8-11e7-89d1-35701c32f696.png">
