### PR TITLE
Hide the install button entirely for incompatible versions in listing pages

### DIFF
--- a/src/olympia/addons/templates/addons/impala/button.html
+++ b/src/olympia/addons/templates/addons/impala/button.html
@@ -53,6 +53,6 @@
 {% endif %}
 
 <p>
-    <a id="downloadAnyway" hidden="true">{{ _('Download Anyway') }}</a>
+    <a id="downloadAnyway" hidden="true" download>{{ _('Download Anyway') }}</a>
 </p>
 </div> {# install-shell #}

--- a/static/css/impala/listing.less
+++ b/static/css/impala/listing.less
@@ -202,12 +202,8 @@
             border-color: darken(@border-blue, 10%);
             opacity: 0.4;
         }
-        .install-shell {
-            visibility: visible;
-
-            .install, br {
-                display: none;
-            }
+        .concealed {
+            display: none;
         }
     }
     h3 {

--- a/static/js/zamboni/buttons.js
+++ b/static/js/zamboni/buttons.js
@@ -186,6 +186,9 @@ var installButton = function() {
         var opts = $.extend({addWarning: true}, options);
             warn = opts.addWarning ? addWarning : _.identity;
 
+        $('#downloadAnyway').attr('href',escape_($button.filter(':visible').attr('href')));
+        $('#downloadAnyway').show();
+
         // Do badPlatform prep out here since we need it in all branches.
         if (badPlatform) {
             warn(gettext('Not available for your platform'));
@@ -249,8 +252,6 @@ var installButton = function() {
         var opts = no_compat_necessary ? {addWarning: false} : {};
         versionsAndPlatforms(opts);
     } else if (z.app == 'firefox') {
-        $('#downloadAnyway').attr('href',escape_($button.filter(':visible').attr('href')));
-        $('#downloadAnyway').show();
         versionsAndPlatforms();
         $button.addClass('CTA');
         $button.text(gettext('Only with Firefox \u2014 Get Firefox Now!'));

--- a/static/js/zamboni/buttons.js
+++ b/static/js/zamboni/buttons.js
@@ -186,7 +186,7 @@ var installButton = function() {
         var opts = $.extend({addWarning: true}, options);
             warn = opts.addWarning ? addWarning : _.identity;
 
-        $('#downloadAnyway').attr('href',escape_($button.filter(':visible').attr('href')));
+        $('#downloadAnyway').attr('href', escape_($button.filter(':visible').attr('href')));
         $('#downloadAnyway').show();
 
         // Do badPlatform prep out here since we need it in all branches.


### PR DESCRIPTION
Also show "download anyway" button when incompatible (it was already displayed when showing the "Only with Firefox" button, this makes it available to every incompatible situation)

Fix #6119 
Fix #6150