### PR TITLE
Support a local proxy to hosted dev (for logins)

### DIFF
--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -264,13 +264,15 @@ FXA_CONFIG = {
         'scope': 'profile',
         'skip_register_redirect': True,
     },
+    # This configuration supports `yarn amo:dev` in addons-frontend which
+    # lets your local NodeJS server run as a proxy to the hosted dev API.
     'local': {
         'client_id': env('DEVELOPMENT_FXA_CLIENT_ID'),
         'client_secret': env('DEVELOPMENT_FXA_CLIENT_SECRET'),
         'content_host': 'https://stable.dev.lcip.org',
         'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
         'profile_host': 'https://stable.dev.lcip.org/profile/v1',
-        'redirect_url': 'http://localhost:3000/fxa-authenticate',
+        'redirect_url': 'http://localhost:3000/api/v3/accounts/authenticate/',
         'scope': 'profile',
     },
 }


### PR DESCRIPTION
On `addons-frontend` we support `yarn amo:dev` which starts a local server that proxies the hosted dev API. We never got logins to work so I'm hoping this will fix it.

See https://github.com/mozilla/addons-frontend/issues/2941

I want to try this on dev first before configuring stage. 

Question: will `redirect_url` will override the value defined in https://oauth-stable.dev.lcip.org/console/client/063dd7f1edaf1507 ?