### PR TITLE
I6086:  Incompatibility message is not entirely RTL in listing pages

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -1213,7 +1213,7 @@ body:not(.developer-hub) section.secondary {
   }
 }
 
-.html-rtl.addon-details {
+.html-rtl {
    .extra .button.disabled.not-available {
     background-position: right 6px center;
     padding: 5px 25px 5px 5px;


### PR DESCRIPTION
Fixes: #6086 
**BEFORE**
<img width="850" alt="screen shot 2017-08-21 at 2 26 28 pm" src="https://user-images.githubusercontent.com/5318732/29511437-d893924c-867c-11e7-8415-1af3cb9d09e3.png">
<img width="511" alt="screen shot 2017-08-21 at 2 26 56 pm" src="https://user-images.githubusercontent.com/5318732/29511453-e0c4b81a-867c-11e7-8bbb-ced18a632099.png">


**AFTER** 
<img width="839" alt="screen shot 2017-08-21 at 2 23 11 pm" src="https://user-images.githubusercontent.com/5318732/29511345-97e7882a-867c-11e7-9277-0d3e600a7d72.png">
<img width="594" alt="screen shot 2017-08-21 at 2 22 33 pm" src="https://user-images.githubusercontent.com/5318732/29511337-90208e2a-867c-11e7-9b73-9637e9f82b82.png">

