### PR TITLE
Always pass 'editable' in edit() when rendering edit.html just in case

### DIFF
--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -278,6 +278,7 @@ class TestEditBasicListed(BaseTestEditBasic):
         # The /edit page is the entry point for the individual edit sections,
         # and should never display the actual forms, so it should always pass
         # editable=False to the templates it renders.
+        # See https://github.com/mozilla/addons-server/issues/6208
         response = self.client.get(self.url)
         assert response.context['editable'] is False
 

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -274,6 +274,13 @@ class BaseTestEditBasic(BaseTestEdit):
 class TestEditBasicListed(BaseTestEditBasic):
     __test__ = True
 
+    def test_edit_page_not_editable(self):
+        # The /edit page is the entry point for the individual edit sections,
+        # and should never display the actual forms, so it should always pass
+        # editable=False to the templates it renders.
+        response = self.client.get(self.url)
+        assert response.context['editable'] is False
+
     def test_edit_add_tag(self):
         count = ActivityLog.objects.all().count()
         self.tags.insert(0, 'tag4')

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -302,6 +302,7 @@ def edit(request, addon_id, addon):
     data = {
         'page': 'edit',
         'addon': addon,
+        'editable': False,
         'show_listed_fields': addon.has_listed_versions(),
         'valid_slug': addon.slug,
         'tags': addon.tags.not_denied().values_list('tag_text', flat=True),


### PR DESCRIPTION
Should avoid a weird error we've seen where jinja is trying to render the inside of a `{% if editable %}` block when 'editable' is absent and should be considered falsy...

`edit()` should never display the forms as editable, that's handled by `addons_section()` which displays each form individually.

Fix #6208