### PR TITLE
Sign every add-on that targets Firefox, even older versions

### DIFF
--- a/src/olympia/lib/crypto/packaged.py
+++ b/src/olympia/lib/crypto/packaged.py
@@ -15,12 +15,11 @@ from signing_clients.apps import get_signer_serial_number, JarExtractor
 
 import olympia.core.logger
 from olympia import amo
-from olympia.versions.compare import version_int
 
 log = olympia.core.logger.getLogger('z.crypto')
 
 
-SIGN_FOR_APPS = [amo.FIREFOX.id, amo.ANDROID.id]
+SIGN_FOR_APPS = (amo.FIREFOX.id, amo.ANDROID.id)
 
 
 class SigningError(Exception):
@@ -28,23 +27,13 @@ class SigningError(Exception):
 
 
 def supports_firefox(file_obj):
-    """Return True if the file support a high enough version of Firefox.
+    """Return True if the file supports Firefox or Firefox for Android.
 
-    We only sign files that are at least compatible with Firefox
-    MIN_D2C_VERSION, or Firefox MIN_NOT_D2C_VERSION if they are not default
-    to compatible.
+    We only sign files that are at least compatible with Firefox/Firefox for
+    Android.
     """
     apps = file_obj.version.apps.all()
-    if not file_obj.binary_components and not file_obj.strict_compatibility:
-        # Version is "default to compatible".
-        return apps.filter(
-            max__application__in=SIGN_FOR_APPS,
-            max__version_int__gte=version_int(settings.MIN_D2C_VERSION))
-    else:
-        # Version isn't "default to compatible".
-        return apps.filter(
-            max__application__in=[amo.FIREFOX.id, amo.ANDROID.id],
-            max__version_int__gte=version_int(settings.MIN_NOT_D2C_VERSION))
+    return apps.filter(max__application__in=SIGN_FOR_APPS)
 
 
 def get_endpoint(server):

--- a/src/olympia/lib/crypto/tasks.py
+++ b/src/olympia/lib/crypto/tasks.py
@@ -108,32 +108,15 @@ def sign_addons(addon_ids, force=False, **kw):
     }
     mail_subject, mail_message = reasons[kw.get('reason', 'default')]
 
-    def file_supports_firefox(version):
-        """Return a Q object: files supporting at least a firefox version."""
-        return Q(version__apps__max__application__in=SIGN_FOR_APPS,
-                 version__apps__max__version_int__gte=version_int(version))
-
-    is_default_compatible = Q(binary_components=False,
-                              strict_compatibility=False)
-    # We only want to sign files that are at least compatible with Firefox
-    # MIN_D2C_VERSION, or Firefox MIN_NOT_D2C_VERSION if they are not default
-    # to compatible.
-    # The signing feature should be supported from Firefox 40 and above, but
-    # we're still signing some files that are a bit older just in case.
-    ff_version_filter = (
-        (is_default_compatible &
-            file_supports_firefox(settings.MIN_D2C_VERSION)) |
-        (~is_default_compatible &
-            file_supports_firefox(settings.MIN_NOT_D2C_VERSION)))
-
     addons_emailed = set()
     # We only care about extensions.
     for version in Version.objects.filter(addon_id__in=addon_ids,
                                           addon__type=amo.ADDON_EXTENSION):
         # We only sign files that have been reviewed and are compatible with
         # versions of Firefox that are recent enough.
-        to_sign = version.files.filter(ff_version_filter,
-                                       status__in=amo.REVIEWED_STATUSES)
+        to_sign = version.files.filter(
+            version__apps__max__application__in=SIGN_FOR_APPS,
+            status__in=amo.REVIEWED_STATUSES)
 
         if force:
             to_sign = to_sign.all()

--- a/src/olympia/lib/crypto/tasks.py
+++ b/src/olympia/lib/crypto/tasks.py
@@ -3,7 +3,6 @@ import re
 import shutil
 
 from django.conf import settings
-from django.db.models import Q
 
 import olympia.core.logger
 from olympia import amo

--- a/src/olympia/lib/crypto/tests.py
+++ b/src/olympia/lib/crypto/tests.py
@@ -87,9 +87,7 @@ class TestPackaged(TestCase):
         max_appversion = self.version.apps.first().max
 
         # Old, and not default to compatible.
-        max_appversion.update(version=settings.MIN_D2C_VERSION,
-                              version_int=version_int(
-                                  settings.MIN_D2C_VERSION))
+        max_appversion.update(version='4', version_int=version_int('4'))
         self.file_.update(binary_components=True, strict_compatibility=True)
         self.assert_not_signed()
         packaged.sign_file(self.file_, settings.SIGNING_SERVER)
@@ -100,9 +98,7 @@ class TestPackaged(TestCase):
 
         # Old, and not default to compatible.
         max_appversion.update(application=amo.ANDROID.id,
-                              version=settings.MIN_D2C_VERSION,
-                              version_int=version_int(
-                                  settings.MIN_D2C_VERSION))
+                              version='4', version_int=version_int('4'))
         self.file_.update(binary_components=True, strict_compatibility=True)
         self.assert_not_signed()
         packaged.sign_file(self.file_, settings.SIGNING_SERVER)
@@ -112,9 +108,7 @@ class TestPackaged(TestCase):
         max_appversion = self.version.apps.first().max
 
         # Old, and default to compatible.
-        max_appversion.update(version=settings.MIN_D2C_VERSION,
-                              version_int=version_int(
-                                  settings.MIN_D2C_VERSION))
+        max_appversion.update(version='4', version_int=version_int('4'))
         self.file_.update(binary_components=False, strict_compatibility=False)
         self.assert_not_signed()
         packaged.sign_file(self.file_, settings.SIGNING_SERVER)
@@ -125,9 +119,7 @@ class TestPackaged(TestCase):
 
         # Old, and default to compatible.
         max_appversion.update(application=amo.ANDROID.id,
-                              version=settings.MIN_D2C_VERSION,
-                              version_int=version_int(
-                                  settings.MIN_D2C_VERSION))
+                              version='4', version_int=version_int('4'))
         self.file_.update(binary_components=False, strict_compatibility=False)
         self.assert_not_signed()
         packaged.sign_file(self.file_, settings.SIGNING_SERVER)
@@ -137,9 +129,7 @@ class TestPackaged(TestCase):
         max_appversion = self.version.apps.first().max
 
         # Recent, default to compatible.
-        max_appversion.update(version=settings.MIN_NOT_D2C_VERSION,
-                              version_int=version_int(
-                                  settings.MIN_NOT_D2C_VERSION))
+        max_appversion.update(version='37', version_int=version_int('37'))
         self.file_.update(binary_components=False, strict_compatibility=False)
         self.assert_not_signed()
         packaged.sign_file(self.file_, settings.SIGNING_SERVER)
@@ -150,9 +140,7 @@ class TestPackaged(TestCase):
 
         # Recent, not default to compatible.
         max_appversion.update(application=amo.ANDROID.id,
-                              version=settings.MIN_NOT_D2C_VERSION,
-                              version_int=version_int(
-                                  settings.MIN_NOT_D2C_VERSION))
+                              version='37', version_int=version_int('37'))
         self.file_.update(binary_components=True, strict_compatibility=True)
         self.assert_not_signed()
         packaged.sign_file(self.file_, settings.SIGNING_SERVER)
@@ -297,9 +285,9 @@ class TestTasks(TestCase):
         self.addon = amo.tests.addon_factory(version_kw={'version': '1.3'})
         self.version = self.addon.current_version
         # Make sure our file/version is at least compatible with FF
-        # MIN_NOT_D2C_VERSION.
+        # '37'.
         self.max_appversion = self.version.apps.first().max
-        self.set_max_appversion(settings.MIN_NOT_D2C_VERSION)
+        self.set_max_appversion('37')
         self.file_ = self.version.all_files[0]
         self.file_.update(filename='jetpack.xpi')
 
@@ -406,32 +394,6 @@ class TestTasks(TestCase):
         self.assert_no_backup()
 
     @mock.patch('olympia.lib.crypto.tasks.sign_file')
-    def test_dont_sign_dont_bump_old_versions(self, mock_sign_file):
-        """Don't sign files which are too old, or not default to compatible."""
-        fpath = fpath = 'src/olympia/files/fixtures/files/jetpack.xpi'
-        with amo.tests.copy_file(fpath, self.file_.file_path):
-            file_hash = self.file_.generate_hash()
-            assert self.version.version == '1.3'
-            assert self.version.version_int == version_int('1.3')
-
-            # Too old, don't sign.
-            self.set_max_appversion('1')  # Very very old.
-            tasks.sign_addons([self.addon.pk])
-            self.assert_not_signed(mock_sign_file, file_hash)
-
-            # MIN_D2C_VERSION, but strict compat: don't sign.
-            self.set_max_appversion(settings.MIN_D2C_VERSION)
-            self.file_.update(strict_compatibility=True)
-            tasks.sign_addons([self.addon.pk])
-            self.assert_not_signed(mock_sign_file, file_hash)
-
-            # MIN_D2C_VERSION, but binary component: don't sign.
-            self.file_.update(strict_compatibility=False,
-                              binary_components=True)
-            tasks.sign_addons([self.addon.pk])
-            self.assert_not_signed(mock_sign_file, file_hash)
-
-    @mock.patch('olympia.lib.crypto.tasks.sign_file')
     def test_dont_sign_dont_bump_other_applications(self, mock_sign_file):
         """Don't sign files which are for applications we don't sign for."""
         path = 'src/olympia/files/fixtures/files/jetpack.xpi'
@@ -493,7 +455,7 @@ class TestTasks(TestCase):
             file_hash = self.file_.generate_hash()
             assert self.version.version == '1.3'
             assert self.version.version_int == version_int('1.3')
-            self.set_max_appversion(settings.MIN_D2C_VERSION)
+            self.set_max_appversion('4')
             tasks.sign_addons([self.addon.pk])
             assert mock_sign_file.called
             self.version.reload()

--- a/src/olympia/lib/crypto/tests.py
+++ b/src/olympia/lib/crypto/tests.py
@@ -93,7 +93,7 @@ class TestPackaged(TestCase):
         self.file_.update(binary_components=True, strict_compatibility=True)
         self.assert_not_signed()
         packaged.sign_file(self.file_, settings.SIGNING_SERVER)
-        self.assert_not_signed()
+        self.assert_signed()
 
     def test_supports_firefox_android_old_not_default_to_compatible(self):
         max_appversion = self.version.apps.first().max
@@ -106,7 +106,7 @@ class TestPackaged(TestCase):
         self.file_.update(binary_components=True, strict_compatibility=True)
         self.assert_not_signed()
         packaged.sign_file(self.file_, settings.SIGNING_SERVER)
-        self.assert_not_signed()
+        self.assert_signed()
 
     def test_supports_firefox_old_default_to_compatible(self):
         max_appversion = self.version.apps.first().max
@@ -390,7 +390,7 @@ class TestTasks(TestCase):
         with amo.tests.copy_file(
                 'src/olympia/files/fixtures/files/jetpack.xpi',
                 self.file_.file_path):
-            for app in packaged.SIGN_FOR_APPS:
+            for app in (amo.ANDROID.id, amo.FIREFOX.id):
                 self.max_appversion.update(application=app)
                 tasks.sign_addons([self.addon.pk])
                 mock_sign_file.assert_called_with(

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1517,10 +1517,6 @@ SIGNING_SERVER_TIMEOUT = 10
 # Hotfix addons (don't sign those, they're already signed by Mozilla.
 HOTFIX_ADDON_GUIDS = ['firefox-hotfix@mozilla.org',
                       'thunderbird-hotfix@mozilla.org']
-# Minimum Firefox version for default to compatible addons to be signed.
-MIN_D2C_VERSION = '4'
-# Minimum Firefox version for not default to compatible addons to be signed.
-MIN_NOT_D2C_VERSION = '37'
 
 # True when the Django app is running from the test suite.
 IN_TEST_SUITE = False


### PR DESCRIPTION
Since we have set all add-ons to be strictly compatible it's a bad idea to keep silently not signing add-ons that don't target Firefox 37 or higher...

Fix #6188