### PR TITLE
I6072: Removes meeth the develope

### DIFF
--- a/src/olympia/addons/templates/addons/impala/details.html
+++ b/src/olympia/addons/templates/addons/impala/details.html
@@ -126,24 +126,6 @@
 
     {% if addon.takes_contributions %}
       {{ impala_contribution(addon=addon, src='dp-btn-primary') }}
-    {% elif addon.has_profile() and addon.listed_authors %}
-      <div class="notice c author">
-        {% with single_dev = addon.listed_authors|random %}
-          <h3>
-            {% trans count=addon.listed_authors|length,
-                     name=single_dev.name,
-                     url=addon.meet_the_dev_url() %}
-              Meet the Developer: <a href="{{ url }}">{{ name }}</a>
-            {% pluralize %}
-              <a href="{{ url }}">Meet the Developers</a>
-            {% endtrans %}
-          </h3>
-          <img class="avatar" alt="{{ single_dev.name }}" height="64" alt=""
-               width="64" src="{{ single_dev.picture_url }}"/>
-          <p>{{ _("Learn why {0} was created and find out what's next for this "
-                  "add-on.")|format_html(addon.name) }}</p>
-        {% endwith %}
-      </div>
     {% endif %}
   </section>
 </div>


### PR DESCRIPTION
Fixes #6072 

I removed `meet the developer` part, I am not sure where to look for `contribution roadblock pages`

**Before** 
<img width="731" alt="screen shot 2017-08-23 at 6 26 35 pm" src="https://user-images.githubusercontent.com/5318732/29617088-36942400-8831-11e7-883c-5b4288d47f20.png">

**After**
<img width="798" alt="screen shot 2017-08-23 at 6 26 56 pm" src="https://user-images.githubusercontent.com/5318732/29617108-433e8c72-8831-11e7-8b97-55529cf3c130.png">
