### PR TITLE
Summary field help text changed as per issue #3919

### DIFF
--- a/src/olympia/devhub/templates/devhub/addons/submit/describe.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/describe.html
@@ -31,7 +31,7 @@
       {{ form.summary }}
       {{ form.summary.errors }}
       <div class="edit-addon-details">
-        {{ _('This summary will be shown in listings and searches.') }}
+        {{ _('This summary should clearly explain what your add-on does. It will be shown in listings and searches, and it will be used by reviewers to test your add-on.') }}
         <div class="char-count"
              data-for-startswith="{{ form.summary.auto_id }}_"
              data-maxlength="{{ form.summary.field.max_length }}"></div>


### PR DESCRIPTION
Fixes #3919.

Before the change summary field help was text was 

> This summary will be shown in listings and searches.

I have changed this to 
 
> This summary should clearly explain what your add-on does. It will be shown in listings and searches, and it will be used by reviewers to test your add-on.

as mentioned in issue description.
