### PR TITLE
Added urdu language in AMO Desktop

### DIFF
--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -156,8 +156,8 @@ AMO_LANGUAGES = (
     'af', 'ar', 'bg', 'bn-BD', 'ca', 'cs', 'da', 'de', 'dsb',
     'el', 'en-GB', 'en-US', 'es', 'eu', 'fa', 'fi', 'fr', 'ga-IE', 'he', 'hu',
     'hsb', 'id', 'it', 'ja', 'ka', 'kab', 'ko', 'nn-NO', 'mk', 'mn', 'nl',
-    'pl', 'pt-BR', 'pt-PT', 'ro', 'ru', 'sk', 'sl', 'sq', 'sv-SE', 'uk', 'vi',
-    'zh-CN', 'zh-TW',
+    'pl', 'pt-BR', 'pt-PT', 'ro', 'ru', 'sk', 'sl', 'sq', 'sv-SE', 'uk', 'ur',
+    'vi', 'zh-CN', 'zh-TW',
 )
 
 # Explicit conversion of a shorter language code into a more specific one.

--- a/src/olympia/stats/tests/test_commands.py
+++ b/src/olympia/stats/tests/test_commands.py
@@ -135,8 +135,8 @@ class TestADICommand(FixturesFolderMixin, TestCase):
             'nb-NO', 'nl', 'nn-NO', 'nr', 'nso', 'or', 'pa-IN', 'pl', 'pt-BR',
             'pt-PT', 'rm', 'ro', 'ru', 'si', 'sk', 'sl', 'son', 'sq', 'sr',
             'ss', 'st', 'sv-SE', 'sw', 'sw-TZ', 'ta', 'ta-IN', 'ta-LK', 'te',
-            'th', 'tn', 'tr', 'ts', 'uk', 've', 'vi', 'wa', 'wo-SN', 'xh',
-            'zap-MX-diiste', 'zh-CN', 'zh-TW', 'zu']
+            'th', 'tn', 'tr', 'ts', 'uk', 'ur', 've', 'vi', 'wa', 'wo-SN',
+            'xh', 'zap-MX-diiste', 'zh-CN', 'zh-TW', 'zu']
         uc = UpdateCount(addon_id=3615)
         self.command.update_locale(uc, 'foobar', 123)  # Non-existent locale.
         assert not uc.locales


### PR DESCRIPTION
Fixes #5094

Urdu language has been added in AMO Desktop. 

![screenshot from 2017-08-28 00-02-01](https://user-images.githubusercontent.com/8364578/29752652-532d1db4-8b84-11e7-8e1f-3db8d19b29a9.png)
