### PR TITLE
Help text change on edit addon page for Summary

### DIFF
--- a/src/olympia/devhub/templates/devhub/addons/edit/basic.html
+++ b/src/olympia/devhub/templates/devhub/addons/edit/basic.html
@@ -49,10 +49,9 @@
               <label data-for="summary">
                 {{ _("Summary") }}
                 {{ tip(None,
-                       _("A short explanation of your add-on's basic "
-                         "functionality that is displayed in search and browse "
-                         "listings, as well as at the top of your add-on's "
-                         "details page. It is only relevant for listed add-ons.")) }}
+                       _("This summary should clearly explain what your add-on "
+                         "does. It will be shown in listings and searches, and "
+                         "it will be used by reviewers to test your add-on.")) }}
               </label>
             </th>
             <td>


### PR DESCRIPTION
Fixes #3919 

The help text for summary on edit addons page was 

> A short explanation of your add-on's basic functionality that is displayed in search and browse listings, as well as at the top of your add-on's details page. It is only relevant for listed add-ons.

As per discussion on issue #3919 changed this to

> This summary should clearly explain what your add-on does. It will be shown in listings and searches, and it will be used by reviewers to test your add-on.