### PR TITLE
Force strict_compatibility to be enabled for existing langpacks

### DIFF
--- a/src/olympia/migrations/967-force-strict-compatibility-for-langpacks.sql
+++ b/src/olympia/migrations/967-force-strict-compatibility-for-langpacks.sql
@@ -1,0 +1,5 @@
+UPDATE `files`
+INNER JOIN `versions` ON ( `files`.`version_id` = `versions`.`id` )
+INNER JOIN `addons` ON ( `versions`.`addon_id` = `addons`.`id` )
+SET `strict_compatibility` = 1 
+WHERE `addons`.`addontype_id` = 5;


### PR DESCRIPTION
3a23e4021d8845c609a82735716e81f55c8f959c already forced it at upload time for all legacy extensions, and that includes langpacks.

Fix #6196