### PR TITLE
Don't create files for Personas in addon_factory()

### DIFF
--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -828,6 +828,7 @@ def user_factory(**kw):
 def version_factory(file_kw=None, **kw):
     # We can't create duplicates of AppVersions, so make sure the versions are
     # not already created in fixtures (use fake versions).
+    addon_type = getattr(kw.get('addon'), 'type', None)
     min_app_version = kw.pop('min_app_version', '4.0.99')
     max_app_version = kw.pop('max_app_version', '5.0.99')
     version_str = kw.pop('version', '%.1f' % random.uniform(0, 2))
@@ -844,7 +845,7 @@ def version_factory(file_kw=None, **kw):
     ver = Version.objects.create(version=version_str, **kw)
     ver.created = ver.last_updated = _get_created(kw.pop('created', 'now'))
     ver.save()
-    if kw.get('addon').type not in amo.NO_COMPAT:
+    if addon_type not in amo.NO_COMPAT:
         av_min, _ = AppVersion.objects.get_or_create(application=application,
                                                      version=min_app_version)
         av_max, _ = AppVersion.objects.get_or_create(application=application,
@@ -853,7 +854,8 @@ def version_factory(file_kw=None, **kw):
                                                    version=ver, min=av_min,
                                                    max=av_max)
     file_kw = file_kw or {}
-    file_factory(version=ver, **file_kw)
+    if addon_type != amo.ADDON_PERSONA:
+        file_factory(version=ver, **file_kw)
     return ver
 
 

--- a/src/olympia/stats/tests/test_views.py
+++ b/src/olympia/stats/tests/test_views.py
@@ -37,9 +37,17 @@ class StatsTest(TestCase):
         self.url_args = {'start': '20090601', 'end': '20090930', 'addon_id': 4}
         self.url_args_theme = {'start': '20090601', 'end': '20090930',
                                'addon_id': 6}
+        # We use fixtures with fixed add-on pks. That causes the add-ons to be
+        # in a weird state that we have to fix.
+        # For the persona (pk=6) the current_version needs to be set manually
+        # because otherwise the version can't be found, as it has no files.
+        # For the rest we simply add a version and it will automatically be
+        # picked up as the current_version.
+        persona_addon = Addon.objects.get(pk=6)
         version_factory(addon=Addon.objects.get(pk=4))
         version_factory(addon=Addon.objects.get(pk=5))
-        version_factory(addon=Addon.objects.get(pk=6))
+        persona_version = version_factory(addon=persona_addon)
+        persona_addon.update(_current_version=persona_version)
         Addon.objects.filter(id__in=(4, 5, 6)).update(status=amo.STATUS_PUBLIC)
         # Most tests don't care about permissions.
         self.login_as_admin()


### PR DESCRIPTION
Personas don't have files attached to their version, that's just the way they are created (see `addons/forms.py:ThemeForm.save()`)

Fix #6263