### PR TITLE
Avoid returning disabled add-ons in legacy discovery modules

### DIFF
--- a/src/olympia/legacy_discovery/modules.py
+++ b/src/olympia/legacy_discovery/modules.py
@@ -5,7 +5,8 @@ from django.utils.translation import ugettext_lazy as _
 from django.template.loader import render_to_string
 
 from olympia.addons.models import Addon
-from olympia.bandwagon.models import Collection, MonthlyPick as MP
+from olympia.bandwagon.models import (
+    Collection, MonthlyPick as MonthlyPickModel)
 from olympia.legacy_api.views import addon_filter
 from olympia.versions.compare import version_int
 
@@ -66,7 +67,7 @@ class MonthlyPick(TemplatePromo):
     template = 'legacy_discovery/modules/monthly.html'
 
     def get_pick(self, locale):
-        monthly_pick = MP.objects.filter(locale=locale)[0]
+        monthly_pick = MonthlyPickModel.objects.filter(locale=locale)[0]
         if not monthly_pick.addon.is_public():
             raise IndexError
         return monthly_pick

--- a/src/olympia/legacy_discovery/tests/test_views.py
+++ b/src/olympia/legacy_discovery/tests/test_views.py
@@ -170,6 +170,17 @@ class TestPromos(TestCase):
         response = self.client.get(self.get_home_url(), {'platform': 'lol'})
         self._test_response_contains_addons(response)
 
+    def test_home_does_not_contain_disabled_addons(self):
+        self.addon1.update(disabled_by_user=True)
+        self.addon2.update(status=amo.STATUS_DISABLED)
+        response = self.client.get(self.get_home_url(), {'platform': 'mac'})
+        assert response.status_code == 200
+        assert response.content
+        content = smart_text(response.content)
+        assert unicode(self.addon1.name) not in content
+        assert unicode(self.addon2.name) not in content
+        assert 'This &amp; That' in content
+
     def test_pane_platform_filtering(self):
         """Ensure that the discovery pane is filtered by platform."""
         file_ = self.addon1.current_version.all_files[0]
@@ -511,14 +522,16 @@ class TestMonthlyPick(TestCase):
             module='Monthly Pick')
 
     def test_monthlypick(self):
+        # First test with locale=None, it should never appear.
         mp = MonthlyPick.objects.create(addon=self.addon, blurb='BOOP',
                                         image='http://mozilla.com')
-        r = self.client.get(self.url)
-        assert r.content == ''
-        mp.update(locale='')
+        response = self.client.get(self.url)
+        assert response.content == ''
 
-        r = self.client.get(self.url)
-        pick = pq(r.content)('#monthly')
+        # Now update with locale='', it should be used as the fallback.
+        mp.update(locale='')
+        response = self.client.get(self.url)
+        pick = pq(response.content)('#monthly')
         assert pick.length == 1
         assert pick.parents('.panel').attr('data-addonguid') == self.addon.guid
         a = pick.find('h3 a')
@@ -531,6 +544,18 @@ class TestMonthlyPick(TestCase):
         assert pick.find('.wrap > div > div > p').text() == 'BOOP'
         assert pick.find('p.install-button a').attr('href').endswith(
             '?src=discovery-promo')
+
+    def test_monthlypick_disabled_addon(self):
+        disabled_addon = addon_factory(disabled_by_user=True)
+        MonthlyPick.objects.create(
+            addon=disabled_addon, blurb='foo', locale='en-US')
+        MonthlyPick.objects.create(
+            addon=self.addon, blurb='bar', locale='')
+
+        response = self.client.get(self.url)
+        pick = pq(response.content)('#monthly')
+        assert pick.length == 1
+        assert pick.parents('.panel').attr('data-addonguid') == self.addon.guid
 
     def test_monthlypick_no_image(self):
         MonthlyPick.objects.create(addon=self.addon, blurb='BOOP', locale='',


### PR DESCRIPTION
Filtering with `status=STATUS_PUBLIC` is not enough to filter out add-ons disabled by their developers. The `public()` method takes care of that for us.

Fix #6251