### PR TITLE
Fix blank horizontal scroll on addons details page

### DIFF
--- a/static/css/impala/reviews.less
+++ b/static/css/impala/reviews.less
@@ -143,6 +143,7 @@
 
     .html-rtl & {
         transform: scale(-1, 1);
+        overflow: hidden;
     }
 }
 


### PR DESCRIPTION
Fixes #5965 

- This should stop the blank horizontal scroll in RTL view. 
- The star should work fine in RTL 

Please do a test before merging. I couldn't test it since AMO website in my local environment is not showing any add-ons.