### PR TITLE
Allow add-on search API to search by multiple authors (separated by commas)

### DIFF
--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -42,13 +42,13 @@ This endpoint allows you to search through public add-ons.
     :query string q: The search query.
     :query string app: Filter by :ref:`add-on application <addon-detail-application>` availability.
     :query string appversion: Filter by application version compatibility. Pass the full version as a string, e.g. ``46.0``. Only valid when the ``app`` parameter is also present.
-    :query string author: Filter by exact author username.
+    :query string author: Filter by exact author username. Multiple author names can be specified, separated by comma(s), in which case add-ons with at least one matching authors are returned.
     :query string category: Filter by :ref:`category slug <category-list>`. ``app`` and ``type`` parameters need to be set, otherwise this parameter is ignored.
     :query string lang: Activate translations in the specific language for that query. (See :ref:`translated fields <api-overview-translations>`)
     :query int page: 1-based page number. Defaults to 1.
     :query int page_size: Maximum number of results to return for the requested page. Defaults to 25.
     :query string platform: Filter by :ref:`add-on platform <addon-detail-platform>` availability.
-    :query string tag: Filter by exact tag name. Multiple tag names can be specified, separated by comma(s).
+    :query string tag: Filter by exact tag name. Multiple tag names can be specified, separated by comma(s), in which case add-ons containing *all* specified tags are returned.
     :query string type: Filter by :ref:`add-on type <addon-detail-type>`.
     :query string sort: The sort parameter. The available parameters are documented in the :ref:`table below <addon-search-sort>`.
     :>json int count: The number of results for this query.

--- a/src/olympia/search/filters.py
+++ b/src/olympia/search/filters.py
@@ -101,11 +101,16 @@ class AddonAppVersionFilterParam(AddonFilterParam):
 
 
 class AddonAuthorFilterParam(AddonFilterParam):
+    # Note: this filter returns add-ons that have at least one matching author
+    # when several are provided (separated by a comma).
+    # It works differently from the tag filter below that needs all tags
+    # provided to match.
+    operator = 'terms'
     query_param = 'author'
     es_field = 'listed_authors.username'
 
     def get_value(self):
-        return self.request.GET.get(self.query_param, '')
+        return self.request.GET.get(self.query_param, '').split(',')
 
 
 class AddonPlatformFilterParam(AddonFilterParam):

--- a/src/olympia/search/tests/test_filters.py
+++ b/src/olympia/search/tests/test_filters.py
@@ -367,7 +367,11 @@ class TestSearchParameterFilter(FilterTestsBase):
     def test_search_by_author(self):
         qs = self._filter(data={'author': 'fooBar'})
         must = qs['query']['bool']['must']
-        assert {'term': {'listed_authors.username': 'fooBar'}} in must
+        assert {'terms': {'listed_authors.username': ['fooBar']}} in must
+
+        qs = self._filter(data={'author': 'foo,bar'})
+        must = qs['query']['bool']['must']
+        assert {'terms': {'listed_authors.username': ['foo', 'bar']}} in must
 
 
 class TestInternalSearchParameterFilter(TestSearchParameterFilter):


### PR DESCRIPTION
Fix #6285