### PR TITLE
Don't convert Persona.theme_data to string if it's None

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1633,7 +1633,9 @@ class Persona(caching.CachingMixin, models.Model):
                          addon.all_categories else ''),
             # TODO: Change this to be `addons_users.user.display_name`.
             'author': self.display_username,
-            'description': unicode(addon.description),
+            'description': (unicode(addon.description)
+                            if addon.description is not None
+                            else addon.description),
             'header': self.header_url,
             'footer': self.footer_url or '',
             'headerURL': self.header_url,

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -2060,6 +2060,10 @@ class TestPersonaModel(TestCase):
         assert data['footerURL'] == ''
         assert data['footer'] == ''
 
+    def test_theme_data_with_null_description(self):
+        addon = addon_factory(type=amo.ADDON_PERSONA, description=None)
+        assert addon.persona.theme_data['description'] is None
+
 
 class TestPreviewModel(TestCase):
     fixtures = ['base/previews']

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -673,6 +673,9 @@ def addon_factory(
 
     # Keep as much unique data as possible in the uuid: '-' aren't important.
     name = kw.pop('name', u'Addôn %s' % unicode(uuid.uuid4()).replace('-', ''))
+    slug = kw.pop('slug', None)
+    if slug is None:
+        slug = name.replace(' ', '-').lower()[:30]
 
     kwargs = {
         # Set artificially the status to STATUS_PUBLIC for now, the real
@@ -681,7 +684,7 @@ def addon_factory(
         # STATUS_DELETED.
         'status': amo.STATUS_PUBLIC,
         'name': name,
-        'slug': name.replace(' ', '-').lower()[:30],
+        'slug': slug,
         'average_daily_users': popularity or random.randint(200, 2000),
         'weekly_downloads': popularity or random.randint(200, 2000),
         'created': when,

--- a/src/olympia/api/fields.py
+++ b/src/olympia/api/fields.py
@@ -181,7 +181,10 @@ class ESTranslationSerializerField(TranslationSerializerField):
         # automatically made by the translations app.
         translation = self.fetch_single_translation(
             obj, target_name, target_translations, get_language())
-        setattr(obj, target_name, Translation(localized_string=translation))
+        value = (
+            Translation(localized_string=translation)
+            if translation is not None else translation)
+        setattr(obj, target_name, value)
 
     def fetch_all_translations(self, obj, source, field):
         return field or None

--- a/src/olympia/api/tests/test_fields.py
+++ b/src/olympia/api/tests/test_fields.py
@@ -200,9 +200,9 @@ class TestTranslationSerializerField(TestCase):
         mock_serializer = serializers.Serializer(context={'request': request})
         field = self.field_class()
 
-        # field.bind('name', mock_serializer)
-        # result = field.to_representation(field.get_attribute(self.addon))
-        # assert result is None
+        field.bind('name', mock_serializer)
+        result = field.to_representation(field.get_attribute(self.addon))
+        assert result is None
 
         field.source = None
         field.bind('description', mock_serializer)

--- a/src/olympia/api/tests/test_fields.py
+++ b/src/olympia/api/tests/test_fields.py
@@ -193,6 +193,22 @@ class TestTranslationSerializerField(TestCase):
         result = field.to_representation(field.get_attribute(self.addon))
         assert result is None
 
+    def test_field_value_null(self):
+        self.addon = addon_factory(slug='lol', name=None, description=None)
+
+        request = Request(self.factory.get('/', {'lang': 'en-US'}))
+        mock_serializer = serializers.Serializer(context={'request': request})
+        field = self.field_class()
+
+        # field.bind('name', mock_serializer)
+        # result = field.to_representation(field.get_attribute(self.addon))
+        # assert result is None
+
+        field.source = None
+        field.bind('description', mock_serializer)
+        result = field.to_representation(field.get_attribute(self.addon))
+        assert result is None
+
 
 class TestESTranslationSerializerField(TestTranslationSerializerField):
     field_class = ESTranslationSerializerField
@@ -293,6 +309,18 @@ class TestESTranslationSerializerField(TestTranslationSerializerField):
 
         self.addon.description_translations = None
         field.bind('description', None)
+        result = field.to_representation(field.get_attribute(self.addon))
+        assert result is None
+
+    def test_field_value_null(self):
+        request = Request(self.factory.get('/', {'lang': 'en-US'}))
+        mock_serializer = serializers.Serializer(context={'request': request})
+
+        field = self.field_class()
+        self.addon.description_translations = {
+            'en-US': None
+        }
+        field.bind('description', mock_serializer)
         result = field.to_representation(field.get_attribute(self.addon))
         assert result is None
 


### PR DESCRIPTION
Avoids returning `description: "None"` in json representation of `theme_data` later.

Fix #5650