### PR TITLE
Fix featured extensions "jumping around" as you hover them.

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -702,11 +702,6 @@ body:not(.home) .amo-header,
   margin-top: 0;
 }
 
-.featured li {
-  height: auto;
-  width: auto;
-}
-
 // Featured/Monthly Add-on background modification
 #featured-addon,
 #monthly {

--- a/static/js/zamboni/buttons.js
+++ b/static/js/zamboni/buttons.js
@@ -261,7 +261,6 @@ var installButton = function() {
         var opts = no_compat_necessary ? {addWarning: false} : {};
         versionsAndPlatforms(opts);
     } else if (z.app == 'firefox') {
-        versionsAndPlatforms();
         $button.addClass('CTA');
         $button.text(gettext('Only with Firefox \u2014 Get Firefox Now!'));
         $button.attr('href', 'https://www.mozilla.org/firefox/new/?scene=2&utm_source=addons.mozilla.org&utm_medium=referral&utm_campaign=non-fx-button#download-fx');


### PR DESCRIPTION
Though the main fix is to remove the width/height: auto, removing the compatibility messages also help prevent potential display issues because it makes the box smaller. A user on Chrome probably does not care much about which version of Firefox or which platforms the add-ons are compatible with anyway.

Fix #6302
