### PR TITLE
Fix 'What's New' banner for Italiano

### DIFF
--- a/static/css/devhub/new-landing/sections/my-addons.less
+++ b/static/css/devhub/new-landing/sections/my-addons.less
@@ -161,7 +161,7 @@
     background-size: contain;
     position: absolute;
     width: 100%;
-    height: 170px;
+    height: 155px;
     left: -8px;
     bottom: -8px;
     pointer-events: none;


### PR DESCRIPTION
Fixes #6301 
- Decrease the height of the rocket picture so that it doesn't overlap with text.

### Before
![screenshot from 2017-09-05 19-50-59](https://user-images.githubusercontent.com/8364578/30064556-e6ebcf46-9273-11e7-8df9-702be78ee0df.png)

### After
![screenshot from 2017-09-05 19-50-38](https://user-images.githubusercontent.com/8364578/30064561-ecd41ba2-9273-11e7-8f9e-b760baad7389.png)
