### PR TITLE
DRF # 4458 has landed so remove APIClient get() patch

### DIFF
--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -330,17 +330,6 @@ class APITestClient(APIClient):
         """
         self.defaults.pop('HTTP_AUTHORIZATION', None)
 
-    def get(self, path, data=None, **extra):
-        # Work around DRF #4458 since we're running an old version that does
-        # not have this fix yet.
-        r = {
-            'QUERY_STRING': urlencode(data or {}, doseq=True),
-        }
-        if not data and '?' in path:
-            r['QUERY_STRING'] = force_bytes(path.split('?')[1])
-        r.update(extra)
-        return self.generic('GET', path, **r)
-
 
 def days_ago(days):
     return datetime.now().replace(microsecond=0) - timedelta(days=days)

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -23,9 +23,7 @@ from django.test.client import Client, RequestFactory
 from django.test.utils import override_settings
 from django.conf import urls as django_urls
 from django.utils import translation
-from django.utils.encoding import force_bytes
 from django.utils.importlib import import_module
-from django.utils.http import urlencode
 
 import mock
 import pytest


### PR DESCRIPTION
Not sure if there any tests we should remove.  Safer to keep them anyway I guess.