### PR TITLE
I6342: Fixes broken layout in theme details page

### DIFF
--- a/static/css/impala/hovercards.less
+++ b/static/css/impala/hovercards.less
@@ -259,10 +259,6 @@
         font-size: 16px;
         line-height: 18px;
     }
-    li {
-        height: 212px;
-        width: 240px;
-    }
     .hovercard {
         padding: 9px 9px 11px;
         margin: 0;


### PR DESCRIPTION
Fixes : #6342 

Removed the CSS rule for `featured li`, it was also used in following places but rule removal doesnt impact there.
https://addons.allizom.org/en-US/firefox/themes/?sort=popular

**Before:** 
<img width="1034" alt="screen shot 2017-09-06 at 6 10 07 pm" src="https://user-images.githubusercontent.com/5318732/30112582-7afcd782-932f-11e7-8caa-6cbddaf8e314.png">

**After:**
<img width="1208" alt="screen shot 2017-09-06 at 6 12 26 pm" src="https://user-images.githubusercontent.com/5318732/30112588-88db7ba6-932f-11e7-84e9-1195286f95dc.png">

