### PR TITLE
Fix various layout issues caused by 748878cf

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -702,6 +702,11 @@ body:not(.home) .amo-header,
   margin-top: 0;
 }
 
+.featured:not(.listing-grid) li {
+  height: auto;
+  width: auto;
+}
+
 // Featured/Monthly Add-on background modification
 #featured-addon,
 #monthly {


### PR DESCRIPTION
Unfortunately the `featured` class is used everywhere, for all kinds of things. So we only want to drop the `width:`/`height:` `auto` on the featured section of the browse pages where it also has the `listing-grid` class.

Fix #6342
Fix #6356
Fix #6323