### PR TITLE
Add micropayment.de to valid contribution domains

### DIFF
--- a/src/olympia/constants/base.py
+++ b/src/olympia/constants/base.py
@@ -214,7 +214,7 @@ ADDON_TYPE_CHOICES_API = {
 MAX_TAGS = 20
 MIN_TAG_LENGTH = 2
 MAX_CATEGORIES = 2
-VALID_CONTRIBUTION_DOMAINS = ('paypal.me', 'patreon.com')
+VALID_CONTRIBUTION_DOMAINS = ('paypal.me', 'patreon.com', 'micropayment.de')
 
 # Icon upload sizes
 ADDON_ICON_SIZES = [32, 48, 64, 128, 256, 512]


### PR DESCRIPTION
Fix #6309

(I've verified that the URLs you get for your payment page using that service do end up having the `micropayment.de` domain)