### PR TITLE
Add authors username to api responses

### DIFF
--- a/docs/topics/api/abuse.rst
+++ b/docs/topics/api/abuse.rst
@@ -24,6 +24,7 @@ to if nessecary.
     :>json object|null reporter: The user who submitted the report, if authenticated.
     :>json int reporter.id: The id of the user who submitted the report.
     :>json string reporter.name: The name of the user who submitted the report.
+    :>json string reporter.username: The username of the user who submitted the report.
     :>json string reporter.url: The link to the profile page for of the user who submitted the report.
     :>json object addon: The add-on reported for abuse.
     :>json string addon.guid: The add-on `extension identifier <https://developer.mozilla.org/en-US/Add-ons/Install_Manifests#id>`_.
@@ -52,8 +53,10 @@ so reports can be responded to if nessecary.
     :>json int reporter.id: The id of the user who submitted the report.
     :>json string reporter.name: The name of the user who submitted the report.
     :>json string reporter.url: The link to the profile page for of the user who submitted the report.
+    :>json string reporter.username: The username of the user who submitted the report.
     :>json object user: The user reported for abuse.
     :>json int user.id: The id of the user reported.
     :>json string user.name: The name of the user reported.
     :>json string user.url: The link to the profile page for of the user reported.
+    :>json string user.username: The username of the user reported.
     :>json string message: The body/content of the abuse report.

--- a/docs/topics/api/activity.rst
+++ b/docs/topics/api/activity.rst
@@ -48,6 +48,7 @@ This endpoint allows you to fetch a single review note for a specific version of
     :>json int user.id: The id of the reviewer or author who left the review note.
     :>json string user.name: The name of the reviewer or author.
     :>json string user.url: The link to the profile page for of the reviewer or author.
+    :>json string user.username: The username of the reviewer or author.
     :>json string comments: The text content of the review note.
     :>json string date: The date the review note was created.
 

--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -140,6 +140,7 @@ This endpoint allows you to fetch a specific add-on by id, slug or guid.
     :>json int authors[].id: The id for an author.
     :>json string authors[].name: The name for an author.
     :>json string authors[].url: The link to the profile page for an author.
+    :>json string authors[].username: The username for an author.
     :>json string authors[].picture_url: URL to a photo of the user, or `/static/img/anon_user.png` if not set. For performance reasons this field is omitted from the search endpoint.
     :>json int average_daily_users: The average number of users for the add-on per day.
     :>json object categories: Object holding the categories the add-on belongs to.

--- a/docs/topics/api/collections.rst
+++ b/docs/topics/api/collections.rst
@@ -47,6 +47,7 @@ If your account has the `Collections:Edit` permission then you can access any co
     :>json int author.id: The id of the author (creator) of the collection.
     :>json string author.name: The name of the author.
     :>json string author.url: The link to the profile page for of the author.
+    :>json string author.username: The username of the author.
     :>json string default_locale: The default locale of the description and name fields. (See :ref:`translated fields <api-overview-translations>`).
     :>json string|object|null description: The description the author added to the collection. (See :ref:`translated fields <api-overview-translations>`).
     :>json string modified: The date the collection was last updated.

--- a/docs/topics/api/reviews.rst
+++ b/docs/topics/api/reviews.rst
@@ -81,6 +81,7 @@ This endpoint allows you to fetch a review by its id.
     :>json string user.id: The user id.
     :>json string user.name: The user name.
     :>json string user.url: The user profile URL.
+    :>json string user.username: The user username.
 
 ----
 Post

--- a/src/olympia/accounts/serializers.py
+++ b/src/olympia/accounts/serializers.py
@@ -24,7 +24,7 @@ class PublicUserProfileSerializer(BaseUserSerializer):
         fields = BaseUserSerializer.Meta.fields + (
             'average_addon_rating', 'created', 'biography', 'homepage',
             'is_addon_developer', 'is_artist', 'location', 'occupation',
-            'num_addons_listed', 'picture_type', 'picture_url', 'username',
+            'num_addons_listed', 'picture_type', 'picture_url',
         )
         # This serializer should never be used for updates but just to be sure.
         read_only_fields = fields

--- a/src/olympia/activity/tests/test_serializers.py
+++ b/src/olympia/activity/tests/test_serializers.py
@@ -48,7 +48,9 @@ class TestReviewNotesSerializerOutput(TestCase, LogMixin):
         assert result['user'] == {
             'id': self.user.pk,
             'name': self.user.name,
-            'url': None}
+            'url': None,
+            'username': self.user.username,
+        }
 
     def test_url_for_yourself(self):
         # should include account profile url for your own requests

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -35,8 +35,10 @@ class AddonSerializerOutputTestMixin(object):
         assert data == {
             'id': author.pk,
             'name': author.name,
+            'picture_url': absolutify(author.picture_url),
             'url': absolutify(author.get_url_path()),
-            'picture_url': absolutify(author.picture_url)}
+            'username': author.username,
+        }
 
     def _test_version_license_and_release_notes(self, version, data):
         assert data['release_notes'] == {
@@ -585,7 +587,8 @@ class TestESAddonSerializerOutput(AddonSerializerOutputTestMixin, ESTestCase):
         assert data == {
             'id': author.pk,
             'name': author.name,
-            'url': absolutify(author.get_url_path())
+            'url': absolutify(author.get_url_path()),
+            'username': author.username,
         }
 
     def _test_version_license_and_release_notes(self, version, data):

--- a/src/olympia/devhub/forms.py
+++ b/src/olympia/devhub/forms.py
@@ -873,5 +873,5 @@ class DistributionChoiceForm(happyforms.Form):
 
 
 class AgreementForm(happyforms.Form):
-    developer_agreement = forms.BooleanField()
+    distribution_agreement = forms.BooleanField()
     review_policy = forms.BooleanField()

--- a/src/olympia/devhub/templates/devhub/agreement.html
+++ b/src/olympia/devhub/templates/devhub/agreement.html
@@ -9,7 +9,7 @@
     {% endtrans %}
     </p>
     <ul class="agreement-links">
-      <li>{{ agreement_form.developer_agreement }}<a href="{{ url('devhub.docs', 'policies/agreement') }}" target="_blank" rel="noopener noreferrer">{{ _('Developer Agreement') }}</a> {{ agreement_form.developer_agreement.errors }}</li>
+      <li>{{ agreement_form.distribution_agreement }}<a href="{{ url('devhub.docs', 'policies/agreement') }}" target="_blank" rel="noopener noreferrer">{{ _('Distribution Agreement') }}</a> {{ agreement_form.distribution_agreement.errors }}</li>
       <li>{{ agreement_form.review_policy }}<a href="{{ url('devhub.docs', 'policies/reviews') }}" target="_blank" rel="noopener noreferrer">{{ _('Review Policy') }}</a> {{ agreement_form.review_policy.errors }}</li>
     </ul>
   {% else %}

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -118,7 +118,7 @@ class TestAddonSubmitAgreement(TestSubmitBase):
 class TestAddonSubmitAgreementWithPostReviewEnabled(TestAddonSubmitAgreement):
     def test_set_read_dev_agreement(self):
         response = self.client.post(reverse('devhub.submit.agreement'), {
-            'developer_agreement': 'on',
+            'distribution_agreement': 'on',
             'review_policy': 'on',
         })
         assert response.status_code == 302
@@ -132,7 +132,7 @@ class TestAddonSubmitAgreementWithPostReviewEnabled(TestAddonSubmitAgreement):
         form = response.context['agreement_form']
         assert form.is_valid() is False
         assert form.errors == {
-            'developer_agreement': [u'This field is required.'],
+            'distribution_agreement': [u'This field is required.'],
             'review_policy': [u'This field is required.'],
         }
         doc = pq(response.content)

--- a/src/olympia/reviews/tests/test_serializers.py
+++ b/src/olympia/reviews/tests/test_serializers.py
@@ -50,6 +50,7 @@ class TestBaseReviewSerializer(TestCase):
             'id': self.user.pk,
             'name': unicode(self.user.name),
             'url': None,
+            'username': self.user.username,
         }
         assert result['version'] == {
             'id': self.review.version.id,
@@ -140,6 +141,7 @@ class TestBaseReviewSerializer(TestCase):
             'name': unicode(reply_user.name),
             # should be the profile for a developer
             'url': absolutify(reply_user.get_url_path()),
+            'username': reply_user.username,
         }
 
     def test_reply_profile_url_for_yourself(self):
@@ -198,6 +200,7 @@ class TestBaseReviewSerializer(TestCase):
             'id': reply_user.pk,
             'name': unicode(reply_user.name),
             'url': absolutify(reply_user.get_url_path()),
+            'username': reply_user.username,
         }
 
     def test_readonly_fields(self):

--- a/src/olympia/users/serializers.py
+++ b/src/olympia/users/serializers.py
@@ -11,7 +11,7 @@ class BaseUserSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = UserProfile
-        fields = ('id', 'name', 'url')
+        fields = ('id', 'name', 'url', 'username')
 
     def get_url(self, obj):
         def is_adminish(user):
@@ -29,7 +29,7 @@ class AddonDeveloperSerializer(BaseUserSerializer):
     picture_url = serializers.SerializerMethodField()
 
     class Meta(BaseUserSerializer.Meta):
-        fields = ('id', 'name', 'url', 'picture_url')
+        fields = ('id', 'name', 'url', 'username', 'picture_url')
         read_only_fields = fields
 
     def get_picture_url(self, obj):

--- a/src/olympia/users/tests/test_serializers.py
+++ b/src/olympia/users/tests/test_serializers.py
@@ -46,15 +46,19 @@ class TestBaseUserSerializer(TestCase):
         result = self.serialize()
         assert result['url'] == absolutify(self.user.get_url_path())
 
+    def test_username(self):
+        serialized = self.serialize()
+        assert serialized['username'] == self.user.username
+
 
 class TestAddonDeveloperSerializer(TestBaseUserSerializer):
     serializer_class = AddonDeveloperSerializer
 
     def test_picture(self):
-        serial = self.serialize()
-        assert ('anon_user.png' in serial['picture_url'])
+        serialized = self.serialize()
+        assert ('anon_user.png' in serialized['picture_url'])
 
         self.user.update(picture_type='image/jpeg')
-        serial = self.serialize()
-        assert serial['picture_url'] == absolutify(self.user.picture_url)
-        assert '%s.png' % self.user.id in serial['picture_url']
+        serialized = self.serialize()
+        assert serialized['picture_url'] == absolutify(self.user.picture_url)
+        assert '%s.png' % self.user.id in serialized['picture_url']


### PR DESCRIPTION
Fix #6346

I went for the easy fix and didn't add support for filtering by author id in ES, mainly because it would have made the ES queries a little messier that I was motivated to debug :)