### PR TITLE
Detect WebExtension Language Packs and assign correct type

### DIFF
--- a/src/olympia/files/tests/test_utils_.py
+++ b/src/olympia/files/tests/test_utils_.py
@@ -300,6 +300,14 @@ class TestManifestJSONExtractor(TestCase):
         data = self.parse({})
         assert data['e10s_compatibility'] == amo.E10S_COMPATIBLE_WEBEXTENSION
 
+    def test_langpack(self):
+        data = self.parse({'langpack_id': 'foo'})
+        assert data['type'] == amo.ADDON_LPAPP
+        assert data['strict_compatibility'] is True
+
+    def test_extensions_dont_have_strict_compatibility(self):
+        assert self.parse({})['strict_compatibility'] is False
+
     def test_apps_use_default_versions_if_applications_is_omitted(self):
         """
         WebExtensions are allowed to omit `applications[/gecko]` and we

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -338,6 +338,13 @@ class ManifestJSONExtractor(object):
         return self.gecko.get('id', None)
 
     @property
+    def type(self):
+        return (
+            amo.ADDON_LPAPP if self.get('langpack_id')
+            else amo.ADDON_EXTENSION
+        )
+
+    @property
     def strict_max_version(self):
         return get_simple_version(self.gecko.get('strict_max_version'))
 
@@ -416,7 +423,7 @@ class ManifestJSONExtractor(object):
     def parse(self, minimal=False):
         data = {
             'guid': self.guid,
-            'type': amo.ADDON_EXTENSION,
+            'type': self.type,
             'version': self.get('version', ''),
             'is_webextension': True,
         }
@@ -428,6 +435,9 @@ class ManifestJSONExtractor(object):
                 'is_restart_required': False,
                 'apps': list(self.apps()),
                 'e10s_compatibility': amo.E10S_COMPATIBLE_WEBEXTENSION,
+                # Langpacks have strict compatibility enabled, rest of
+                # webextensions don't.
+                'strict_compatibility': data['type'] == amo.ADDON_LPAPP,
                 'default_locale': self.get('default_locale'),
                 'permissions': self.get('permissions', []),
                 'content_scripts': self.get('content_scripts', []),


### PR DESCRIPTION
Fix #6350

We already validate that the `strict_min_version` and `strict_max_version` are valid now, so the linter will just need to make them mandatory for langpacks.