### PR TITLE
Remove the 'addon_review_aggregates' task from process-addons.

### DIFF
--- a/src/olympia/addons/management/commands/process_addons.py
+++ b/src/olympia/addons/management/commands/process_addons.py
@@ -11,7 +11,6 @@ from olympia.amo.utils import chunked
 from olympia.devhub.tasks import convert_purified, get_preview_sizes
 from olympia.editors.tasks import recalculate_post_review_weight
 from olympia.lib.crypto.tasks import sign_addons
-from olympia.reviews.tasks import addon_review_aggregates
 
 
 tasks = {
@@ -19,7 +18,6 @@ tasks = {
         'method': find_inconsistencies_between_es_and_db, 'qs': []},
     'get_preview_sizes': {'method': get_preview_sizes, 'qs': []},
     'convert_purified': {'method': convert_purified, 'qs': []},
-    'addon_review_aggregates': {'method': addon_review_aggregates, 'qs': []},
     'recalculate_post_review_weight': {
         'method': recalculate_post_review_weight,
         'qs': [


### PR DESCRIPTION
This is for our own safety and sanity to not reproduce todays downtime
again. See #6421 for a few more details.
