### PR TITLE
expose Addon.contributions as contributions_url in Addon API

### DIFF
--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -145,6 +145,7 @@ This endpoint allows you to fetch a specific add-on by id, slug or guid.
     :>json int average_daily_users: The average number of users for the add-on per day.
     :>json object categories: Object holding the categories the add-on belongs to.
     :>json array categories[app_name]: Array holding the :ref:`category slugs <category-list>` the add-on belongs to for a given :ref:`add-on application <addon-detail-application>`. (Combine with the add-on ``type`` to determine the name of the category).
+    :>json string|null contributions_url: URL to the (external) webpage where the addon's authors collect monetary contributions, if set.
     :>json object current_beta_version: Object holding the current beta :ref:`version <version-detail-object>` of the add-on, if it exists. For performance reasons the ``release_notes`` field is omitted and the ``license`` field omits the ``text`` property.
     :>json object current_version: Object holding the current :ref:`version <version-detail-object>` of the add-on.
     :>json string default_locale: The add-on default locale for translations.

--- a/src/olympia/addons/indexers.py
+++ b/src/olympia/addons/indexers.py
@@ -98,11 +98,12 @@ class AddonIndexer(BaseSearchIndexer):
                     'app': {'type': 'byte'},
                     'average_daily_users': {'type': 'long'},
                     'bayesian_rating': {'type': 'double'},
-                    'current_beta_version': version_mapping,
-                    'category': {'type': 'integer'},
-                    'created': {'type': 'date'},
-                    'current_version': version_mapping,
                     'boost': {'type': 'float', 'null_value': 1.0},
+                    'category': {'type': 'integer'},
+                    'contributions': {'type': 'text'},
+                    'created': {'type': 'date'},
+                    'current_beta_version': version_mapping,
+                    'current_version': version_mapping,
                     'default_locale': {'type': 'keyword', 'index': False},
                     'description': {'type': 'text', 'analyzer': 'snowball'},
                     'guid': {'type': 'keyword', 'index': False},
@@ -250,7 +251,8 @@ class AddonIndexer(BaseSearchIndexer):
         """Extract indexable attributes from an add-on."""
         from olympia.addons.models import Preview
 
-        attrs = ('id', 'average_daily_users', 'bayesian_rating', 'created',
+        attrs = ('id', 'average_daily_users', 'bayesian_rating',
+                 'contributions', 'created',
                  'default_locale', 'guid', 'hotness', 'icon_type',
                  'is_disabled', 'is_experimental', 'last_updated',
                  'modified', 'public_stats', 'requires_payment', 'slug',

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -192,6 +192,7 @@ class AddonEulaPolicySerializer(serializers.ModelSerializer):
 class AddonSerializer(serializers.ModelSerializer):
     authors = AddonDeveloperSerializer(many=True, source='listed_authors')
     categories = serializers.SerializerMethodField()
+    contributions_url = serializers.URLField(source='contributions')
     current_beta_version = SimpleVersionSerializer()
     current_version = SimpleVersionSerializer()
     description = TranslationSerializerField()
@@ -223,6 +224,7 @@ class AddonSerializer(serializers.ModelSerializer):
             'authors',
             'average_daily_users',
             'categories',
+            'contributions_url',
             'current_beta_version',
             'current_version',
             'default_locale',
@@ -426,6 +428,7 @@ class ESAddonSerializer(BaseESSerializer, AddonSerializer):
             obj, data, (
                 'average_daily_users',
                 'bayesian_rating',
+                'contributions',
                 'created',
                 'default_locale',
                 'guid',

--- a/src/olympia/addons/tests/test_indexers.py
+++ b/src/olympia/addons/tests/test_indexers.py
@@ -23,7 +23,8 @@ class TestAddonIndexer(TestCase):
     # This only contains the fields for which we use the value directly,
     # see expected_fields() for the rest.
     simple_fields = [
-        'average_daily_users', 'bayesian_rating', 'created', 'default_locale',
+        'average_daily_users', 'bayesian_rating', 'contributions', 'created',
+        'default_locale',
         'guid', 'hotness', 'icon_type', 'id', 'is_disabled', 'is_experimental',
         'last_updated', 'modified', 'public_stats', 'requires_payment', 'slug',
         'status', 'type', 'view_source', 'weekly_downloads',

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -110,6 +110,7 @@ class AddonSerializerOutputTestMixin(object):
             average_rating=4.21,
             bayesian_rating=4.22,
             category=cat1,
+            contributions=u'https://paypal.me/foobar/',
             description=u'My Addôn description',
             developer_comments=u'Dévelopers Addôn comments',
             file_kw={
@@ -203,6 +204,7 @@ class AddonSerializerOutputTestMixin(object):
         self._test_author(first_author, result['authors'][0])
         self._test_author(second_author, result['authors'][1])
 
+        assert result['contributions_url'] == self.addon.contributions
         assert result['edit_url'] == absolutify(self.addon.get_dev_url())
         assert result['default_locale'] == self.addon.default_locale
         assert result['description'] == {'en-US': self.addon.description}


### PR DESCRIPTION
fixes #6434 ; needed for mozilla/addons-frontend#3149