### PR TITLE
disable paypal contributions roadblock and developer profile; manage payments and developer profile.

### DIFF
--- a/src/olympia/addons/buttons.py
+++ b/src/olympia/addons/buttons.py
@@ -3,6 +3,7 @@ from django.utils.translation import (
     ugettext, ugettext_lazy as _, pgettext_lazy)
 
 import jinja2
+import waffle
 
 from olympia import amo
 from olympia.amo.templatetags.jinja_helpers import urlparams
@@ -108,8 +109,10 @@ class InstallButton(object):
                          addon.is_featured(app, lang))
         self.is_persona = addon.type == amo.ADDON_PERSONA
 
-        self._show_contrib = show_contrib
-        self.show_contrib = (show_contrib and addon.takes_contributions and
+        simple_contributions = waffle.switch_is_active('simple-contributions')
+        self._show_contrib = show_contrib and not simple_contributions
+        self.show_contrib = (show_contrib and not simple_contributions and
+                             addon.takes_contributions and
                              addon.annoying == amo.CONTRIB_ROADBLOCK)
         self.show_warning = show_warning and self.unreviewed
 

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -153,6 +153,16 @@ class TestHomepageFeatures(TestCase):
             assert doc.find('%s .seeall' % id_).attr('href') == url
 
 
+@override_switch('simple-contributions', active=True)
+class TestContributeInstalled404(TestCase):
+    fixtures = ['base/appversion', 'base/addon_592']
+
+    def test_404(self):
+        url = reverse('addons.installed', args=['a592'])
+        assert self.client.get(url).status_code == 404
+
+
+@override_switch('simple-contributions', active=False)
 class TestContributeInstalled(TestCase):
     fixtures = ['base/appversion', 'base/addon_592']
 
@@ -184,6 +194,18 @@ class TestContributeInstalled(TestCase):
         assert title.startswith('Thank you for installing Gmail S/MIME')
 
 
+@override_switch('simple-contributions', active=True)
+class TestContributeEmbedded404(TestCase):
+    fixtures = ['base/appversion', 'base/addon_592']
+
+    @patch('olympia.paypal.get_paykey')
+    def test_404(self, get_paykey,):
+        get_paykey.return_value = ['abc', '']
+        url = reverse('addons.contribute', args=['a592'])
+        assert self.client.post(url).status_code == 404
+
+
+@override_switch('simple-contributions', active=False)
 class TestContributeEmbedded(TestCase):
     fixtures = ['base/addon_3615', 'base/addon_592', 'base/users']
 
@@ -337,6 +359,16 @@ class TestContributeEmbedded(TestCase):
         return self.client.post(urlparams(url, result_type='json'))
 
 
+@override_switch('simple-contributions', active=True)
+class TestDeveloperPages404(TestCase):
+    fixtures = ['base/addon_592', 'base/users']
+
+    def test_404(self):
+        url = reverse('addons.meet', args=['a592'])
+        assert self.client.get(url).status_code == 404
+
+
+@override_switch('simple-contributions', active=False)
 class TestDeveloperPages(TestCase):
     fixtures = ['base/addon_3615', 'base/addon_592',
                 'base/users', 'addons/eula+contrib-addon',

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -364,6 +364,7 @@ def privacy(request, addon):
 
 @addon_view
 @non_atomic_requests
+@waffle.decorators.waffle_switch('!simple-contributions')
 def developers(request, addon, page):
     if addon.is_persona():
         raise http.Http404()
@@ -386,6 +387,7 @@ def developers(request, addon, page):
 @anonymous_csrf_exempt
 @post_required
 @non_atomic_requests
+@waffle.decorators.waffle_switch('!simple-contributions')
 def contribute(request, addon):
 
     # Enforce paypal-imposed comment length limit
@@ -464,6 +466,7 @@ def contribute(request, addon):
 @csrf_exempt
 @addon_view
 @non_atomic_requests
+@waffle.decorators.waffle_switch('!simple-contributions')
 def paypal_result(request, addon, status):
     uuid = request.GET.get('uuid')
     if not uuid:

--- a/src/olympia/devhub/templates/devhub/addons/listing/item_actions.html
+++ b/src/olympia/devhub/templates/devhub/addons/listing/item_actions.html
@@ -55,7 +55,7 @@
   <li>
     <a href="#" class="more-actions">{{ _('More') }}</a>
     <div class="more-actions-popup popup hidden">
-      {% if show_listed %}
+      {% if show_listed and not waffle.switch('simple-contributions') %}
       {% set manage_urls = [
         (addon.get_dev_url('owner'), _('Manage Authors & License')),
         (addon.get_dev_url('profile'), _('Manage Developer Profile')),

--- a/src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html
+++ b/src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html
@@ -4,7 +4,7 @@
   (addon.get_dev_url('owner'), _('Manage Authors & License')),
   ] %}
 
-{% if show_listed %}
+{% if show_listed and not waffle.switch('simple-contributions') %}
 {% set urls = urls + [
   (addon.get_dev_url('profile'), _('Manage Developer Profile')),
   (addon.get_dev_url('payments'), _('Manage Payments')),

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -15,6 +15,7 @@ from django.utils.translation import trim_whitespace
 import mock
 import waffle
 from pyquery import PyQuery as pq
+from waffle.testutils import override_switch
 
 from olympia import amo, core, paypal
 from olympia.activity.models import ActivityLog
@@ -421,6 +422,19 @@ class TestVersionStats(TestCase):
         self.assertDictEqual(data, exp)
 
 
+@override_switch('simple-contributions', active=True)
+class TestPayments404(TestCase):
+    fixtures = ['base/users', 'base/addon_3615']
+
+    def test_404(self):
+        addon = Addon.objects.no_cache().get(id=3615)
+        url = addon.get_dev_url('payments')
+        assert self.client.login(email='del@icio.us')
+        assert self.client.get(url).status_code == 404
+        assert self.client.post(url).status_code == 404
+
+
+@override_switch('simple-contributions', active=False)
 class TestEditPayments(TestCase):
     fixtures = ['base/users', 'base/addon_3615']
 
@@ -702,6 +716,7 @@ class TestDisablePayments(TestCase):
         assert not Addon.objects.no_cache().get(id=3615).wants_contributions
 
 
+@override_switch('simple-contributions', active=False)
 class TestPaymentsProfile(TestCase):
     fixtures = ['base/users', 'base/addon_3615']
 
@@ -1063,6 +1078,19 @@ class TestActivityFeed(TestCase):
         assert len(doc('#recent-activity .item')) == 1
 
 
+@override_switch('simple-contributions', active=True)
+class TestProfile404(TestCase):
+    fixtures = ['base/users', 'base/addon_3615']
+
+    def test_404(self):
+        addon = Addon.objects.get(id=3615)
+        url = addon.get_dev_url('profile')
+        assert self.client.login(email='del@icio.us')
+        assert self.client.post(url).status_code == 404
+        assert self.client.get(url).status_code == 404
+
+
+@override_switch('simple-contributions', active=False)
 class TestProfileBase(TestCase):
     fixtures = ['base/users', 'base/addon_3615']
 
@@ -1095,6 +1123,7 @@ class TestProfileBase(TestCase):
                 assert getattr(addon, k) == v
 
 
+@override_switch('simple-contributions', active=False)
 class TestProfileStatusBar(TestProfileBase):
 
     def setUp(self):
@@ -1155,6 +1184,7 @@ class TestProfileStatusBar(TestProfileBase):
         assert not addon.wants_contributions
 
 
+@override_switch('simple-contributions', active=False)
 class TestProfile(TestProfileBase):
 
     def test_without_contributions_labels(self):

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -504,6 +504,7 @@ def ownership(request, addon_id, addon):
 
 
 @dev_required(owner_for_post=True)
+@waffle.decorators.waffle_switch('!simple-contributions')
 def payments(request, addon_id, addon):
     charity = None if addon.charity_id == amo.FOUNDATION_ORG else addon.charity
 
@@ -571,6 +572,7 @@ def remove_profile(request, addon_id, addon):
 
 
 @dev_required
+@waffle.decorators.waffle_switch('!simple-contributions')
 def profile(request, addon_id, addon):
     profile_form = forms.ProfileForm(request.POST or None, instance=addon)
 


### PR DESCRIPTION
fixes #6072 and fixes #6073 ... I think.  It's kinda hard to test a waffle being enabled but the obvious pages/buttons are gone - this needs some QA love on dev for a few days with some known old-skool-contribution enabled add-ons.

There are some references to the developer profile pages in the API still until #6308 changes that.  (The link will just be a 404)