### PR TITLE
Make request.APP part of the cache key used in legacy api guid search

### DIFF
--- a/src/olympia/legacy_api/tests/test_views.py
+++ b/src/olympia/legacy_api/tests/test_views.py
@@ -824,6 +824,15 @@ class TestGuidSearch(TestCase):
         response = make_call(self.good, lang='fr')
         self.assertContains(response, '<summary>Francais')
 
+    def test_api_caching_app(self):
+        response = make_call(self.good)
+        assert 'en-US/firefox/addon/None/reviews/?src=api' in response.content
+        assert 'en-US/android/addon/None/reviews/' not in response.content
+
+        response = make_call(self.good, app='android')
+        assert 'en-US/android/addon/None/reviews/?src=api' in response.content
+        assert 'en-US/firefox/addon/None/reviews/' not in response.content
+
     def test_xss(self):
         addon_factory(guid='test@xss', name='<script>alert("test");</script>')
         r = make_call('search/guid:test@xss')

--- a/src/olympia/legacy_api/views.py
+++ b/src/olympia/legacy_api/views.py
@@ -282,9 +282,10 @@ class AddonDetailView(APIView):
 @non_atomic_requests
 def guid_search(request, api_version, guids):
     lang = request.LANG
+    app_id = request.APP.id
 
     def guid_search_cache_key(guid):
-        key = 'guid_search:%s:%s:%s' % (api_version, lang, guid)
+        key = 'guid_search:%s:%s:%s:%s' % (api_version, lang, app_id, guid)
         return hashlib.sha256(force_bytes(key)).hexdigest()
 
     guids = [guid.strip() for guid in guids.split(',')] if guids else []


### PR DESCRIPTION
Fix #6393