### PR TITLE
Show fx57 label and boost for mozilla signed add-ons

### DIFF
--- a/src/olympia/addons/indexers.py
+++ b/src/olympia/addons/indexers.py
@@ -75,6 +75,7 @@ class AddonIndexer(BaseSearchIndexer):
                         'filename': {
                             'type': 'keyword', 'index': False},
                         'is_webextension': {'type': 'boolean'},
+                        'is_mozilla_signed_extension': {'type': 'boolean'},
                         'is_restart_required': {
                             'type': 'boolean', 'index': False},
                         'platform': {
@@ -209,6 +210,8 @@ class AddonIndexer(BaseSearchIndexer):
                 'filename': file_.filename,
                 'hash': file_.hash,
                 'is_webextension': file_.is_webextension,
+                'is_mozilla_signed_extension': (
+                    file_.is_mozilla_signed_extension),
                 'is_restart_required': file_.is_restart_required,
                 'platform': file_.platform,
                 'size': file_.size,

--- a/src/olympia/addons/management/commands/process_addons.py
+++ b/src/olympia/addons/management/commands/process_addons.py
@@ -31,8 +31,12 @@ tasks = {
     'sign_addons': {'method': sign_addons, 'qs': []},
     'add_firefox57_tag_to_webextensions': {
         'method': add_firefox57_tag,
-        'qs': [Q(status=amo.STATUS_PUBLIC,
-                 _current_version__files__is_webextension=True)]},
+        'qs': [
+            Q(status=amo.STATUS_PUBLIC) & (
+                Q(_current_version__files__is_webextension=True) |
+                Q(_current_version__files__is_mozilla_signed_extension=True)
+            )
+        ]},
     'bump_appver_for_legacy_addons': {
         'method': bump_appver_for_legacy_addons,
         'qs': [

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -38,8 +38,8 @@ class FileSerializer(serializers.ModelSerializer):
     class Meta:
         model = File
         fields = ('id', 'created', 'hash', 'is_restart_required',
-                  'is_webextension', 'platform', 'size', 'status', 'url',
-                  'permissions')
+                  'is_webextension', 'is_mozilla_signed_extension',
+                  'platform', 'size', 'status', 'url', 'permissions')
 
     def get_url(self, obj):
         # File.get_url_path() is a little different, it's already absolute, but
@@ -394,6 +394,8 @@ class ESAddonSerializer(BaseESSerializer, AddonSerializer):
             id=data['id'], created=self.handle_date(data['created']),
             hash=data['hash'], filename=data['filename'],
             is_webextension=data.get('is_webextension'),
+            is_mozilla_signed_extension=data.get(
+                'is_mozilla_signed_extension'),
             is_restart_required=data.get('is_restart_required', False),
             platform=data['platform'], size=data['size'],
             status=data['status'],

--- a/src/olympia/addons/templates/addons/macros.html
+++ b/src/olympia/addons/templates/addons/macros.html
@@ -40,8 +40,10 @@
     {% if version %}
       {% if version.is_restart_required %}
         <span class="is-restart-required">{{ _('Requires Restart') }}</span>
-      {% elif version.is_webextension %}
-        <a href="https://support.mozilla.org/kb/firefox-add-technology-modernizing" class="is-webextension" title="{{ _('This add-on is built with new technology that is compatible with Firefox 57 and beyond.') }}">{{ _('Compatible with Firefox 57+') }}</a>
+      {% elif version.is_webextension or version.is_mozilla_signed %}
+        <a href="https://support.mozilla.org/kb/firefox-add-technology-modernizing" class="is-webextension" title="{{ _('This add-on is built with new technology that is compatible with Firefox 57 and beyond.') }}">
+          {{ _('Compatible with Firefox 57+') }}
+        </a>
       {% endif %}
     {% endif %}
 {% endmacro %}

--- a/src/olympia/addons/tests/test_commands.py
+++ b/src/olympia/addons/tests/test_commands.py
@@ -222,16 +222,31 @@ class AddFirefox57TagTestCase(TestCase):
                                'status': amo.STATUS_AWAITING_REVIEW},
                       status=amo.STATUS_NOMINATED)
         public_webextension = addon_factory(file_kw={'is_webextension': True})
+        public_mozilla_signed = addon_factory(file_kw={
+            'is_mozilla_signed_extension': True})
 
         call_command(
             'process_addons', task='add_firefox57_tag_to_webextensions')
 
         assert add_firefox57_tag_mock.call_count == 1
         add_firefox57_tag_mock.assert_called_with(
-            args=[[public_webextension.pk]], kwargs={})
+            args=[[public_webextension.pk, public_mozilla_signed.pk]],
+            kwargs={})
 
-    def test_task_works(self):
+    def test_tag_added_for_is_webextension(self):
         self.addon = addon_factory(file_kw={'is_webextension': True})
+        assert self.addon.tags.all().count() == 0
+
+        call_command(
+            'process_addons', task='add_firefox57_tag_to_webextensions')
+
+        assert (
+            set(self.addon.tags.all().values_list('tag_text', flat=True)) ==
+            set(['firefox57']))
+
+    def test_tag_added_for_is_mozilla_signed_extension(self):
+        self.addon = addon_factory(
+            file_kw={'is_mozilla_signed_extension': True})
         assert self.addon.tags.all().count() == 0
 
         call_command(

--- a/src/olympia/addons/tests/test_indexers.py
+++ b/src/olympia/addons/tests/test_indexers.py
@@ -119,8 +119,9 @@ class TestAddonIndexer(TestCase):
         files_mapping = version_mapping['files']['properties']
         expected_file_keys = (
             'id', 'created', 'filename', 'hash', 'is_webextension',
-            'is_restart_required', 'platform', 'size', 'status',
-            'strict_compatibility', 'webext_permissions_list')
+            'is_restart_required', 'is_mozilla_signed_extension', 'platform',
+            'size', 'status', 'strict_compatibility',
+            'webext_permissions_list')
         assert set(files_mapping.keys()) == set(expected_file_keys)
 
     def test_index_setting_boolean(self):
@@ -252,7 +253,11 @@ class TestAddonIndexer(TestCase):
         file_factory(version=version, platform=PLATFORM_MAC.id)
         current_beta_version = version_factory(
             addon=self.addon,
-            file_kw={'status': amo.STATUS_BETA, 'is_webextension': True})
+            file_kw={
+                'status': amo.STATUS_BETA,
+                'is_webextension': True,
+                'is_mozilla_signed_extension': True,
+            })
         # Give one of the versions some webext permissions to test that.
         WebextPermission.objects.create(
             file=current_beta_version.all_files[0],
@@ -285,6 +290,8 @@ class TestAddonIndexer(TestCase):
             assert extracted_file['is_webextension'] == file_.is_webextension
             assert extracted_file['is_restart_required'] == (
                 file_.is_restart_required)
+            assert extracted_file['is_mozilla_signed_extension'] == (
+                file_.is_mozilla_signed_extension)
             assert extracted_file['platform'] == file_.platform
             assert extracted_file['size'] == file_.size
             assert extracted_file['status'] == file_.status
@@ -315,6 +322,8 @@ class TestAddonIndexer(TestCase):
             assert extracted_file['is_webextension'] == file_.is_webextension
             assert extracted_file['is_restart_required'] == (
                 file_.is_restart_required)
+            assert extracted_file['is_mozilla_signed_extension'] == (
+                file_.is_mozilla_signed_extension)
             assert extracted_file['platform'] == file_.platform
             assert extracted_file['size'] == file_.size
             assert extracted_file['status'] == file_.status
@@ -344,6 +353,8 @@ class TestAddonIndexer(TestCase):
             assert extracted_file['filename'] == file_.filename
             assert extracted_file['hash'] == file_.hash
             assert extracted_file['is_webextension'] == file_.is_webextension
+            assert extracted_file['is_mozilla_signed_extension'] == (
+                file_.is_mozilla_signed_extension)
             assert extracted_file['is_restart_required'] == (
                 file_.is_restart_required)
             assert extracted_file['platform'] == file_.platform

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -77,6 +77,9 @@ class AddonSerializerOutputTestMixin(object):
         assert result_file['hash'] == file_.hash
         assert result_file['is_restart_required'] == file_.is_restart_required
         assert result_file['is_webextension'] == file_.is_webextension
+        assert (
+            result_file['is_mozilla_signed_extension'] ==
+            file_.is_mozilla_signed_extension)
         assert result_file['platform'] == (
             amo.PLATFORM_CHOICES_API[file_.platform])
         assert result_file['size'] == file_.size
@@ -629,6 +632,7 @@ class TestVersionSerializerOutput(TestCase):
             file_kw={
                 'hash': 'fakehash',
                 'is_webextension': True,
+                'is_mozilla_signed_extension': True,
                 'platform': amo.PLATFORM_WIN.id,
                 'size': 42,
             },
@@ -668,6 +672,8 @@ class TestVersionSerializerOutput(TestCase):
         assert result['files'][0]['hash'] == first_file.hash
         assert result['files'][0]['is_webextension'] == (
             first_file.is_webextension)
+        assert result['files'][0]['is_mozilla_signed_extension'] == (
+            first_file.is_mozilla_signed_extension)
         assert result['files'][0]['platform'] == 'windows'
         assert result['files'][0]['size'] == first_file.size
         assert result['files'][0]['status'] == 'public'
@@ -679,6 +685,8 @@ class TestVersionSerializerOutput(TestCase):
         assert result['files'][1]['hash'] == second_file.hash
         assert result['files'][1]['is_webextension'] == (
             second_file.is_webextension)
+        assert result['files'][1]['is_mozilla_signed_extension'] == (
+            second_file.is_mozilla_signed_extension)
         assert result['files'][1]['platform'] == 'mac'
         assert result['files'][1]['size'] == second_file.size
         assert result['files'][1]['status'] == 'public'

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -993,16 +993,46 @@ class TestDetailPage(TestCase):
         response = self.client.get(self.url)
         assert span_is_restart_required in response.content
 
-    def test_is_webextension(self):
-        file_ = self.addon.current_version.all_files[0]
+    def test_fx57_label_is_webextension(self):
+        """Test that the Firefox 57 label is being shown.
 
+        That label depends on `is_webextension` being set or
+        if the add-on is a mozilla internally signed add-on.
+        """
+        file_ = self.addon.current_version.all_files[0]
         assert file_.is_webextension is False
+
         response = self.client.get(self.url)
         doc = pq(response.content)
         assert not doc('a.is-webextension')
 
         file_.update(is_webextension=True, is_restart_required=False)
         assert file_.is_webextension is True
+
+        response = self.client.get(self.url)
+        doc = pq(response.content)
+        link = doc('a.is-webextension')
+        assert (
+            link.attr['href'] ==
+            'https://support.mozilla.org/kb/firefox-add-technology-modernizing'
+        )
+
+    def test_fx57_label_is_mozilla_signed_extension(self):
+        """Test that the Firefox 57 label is being shown.
+
+        That label depends on `is_webextension` being set or
+        if the add-on is a mozilla internally signed add-on.
+        """
+        file_ = self.addon.current_version.all_files[0]
+        assert file_.is_mozilla_signed_extension is False
+
+        response = self.client.get(self.url)
+        doc = pq(response.content)
+        assert not doc('a.is-webextension')
+
+        file_.update(is_mozilla_signed_extension=True)
+        assert file_.is_mozilla_signed_extension is True
+
         response = self.client.get(self.url)
         doc = pq(response.content)
         link = doc('a.is-webextension')

--- a/src/olympia/editors/tests/test_utils.py
+++ b/src/olympia/editors/tests/test_utils.py
@@ -526,7 +526,8 @@ class TestReviewHelper(TestCase):
 
         self._check_score(amo.REVIEWED_ADDON_FULL)
 
-        # It wasn't a webextension, it should not receive the firefox57 tag.
+        # It wasn't a webextension and not signed by mozilla it should not
+        # receive the firefox57 tag.
         assert self.addon.tags.all().count() == 0
 
     @patch('olympia.editors.utils.sign_file')
@@ -670,7 +671,8 @@ class TestReviewHelper(TestCase):
 
         self._check_score(amo.REVIEWED_ADDON_UPDATE)
 
-        # It wasn't a webextension, it should not receive the firefox57 tag.
+        # It wasn't a webextension and not signed by mozilla it should not
+        # receive the firefox57 tag.
         assert self.addon.tags.all().count() == 0
 
     @patch('olympia.editors.utils.sign_file')
@@ -863,6 +865,17 @@ class TestReviewHelper(TestCase):
            lambda *a, **kw: None)
     def test_nomination_to_public_webextension(self):
         self.file.update(is_webextension=True)
+        self.setup_data(amo.STATUS_NOMINATED)
+        self.helper.handler.process_public()
+        assert (
+            set(self.addon.tags.all().values_list('tag_text', flat=True)) ==
+            set(['firefox57']))
+
+    @patch('olympia.editors.utils.sign_file',
+           lambda *a, **kw: None)
+    def test_nomination_to_public_mozilla_signed_extension(self):
+        """Test that the firefox57 tag is applied to mozilla signed add-ons"""
+        self.file.update(is_mozilla_signed_extension=True)
         self.setup_data(amo.STATUS_NOMINATED)
         self.helper.handler.process_public()
         assert (

--- a/src/olympia/editors/utils.py
+++ b/src/olympia/editors/utils.py
@@ -532,6 +532,10 @@ class ReviewBase(object):
         if any(file_.is_webextension for file_ in self.files):
             Tag(tag_text='firefox57').save_tag(self.addon)
 
+        # If we've approved a mozilla signed add-on, add the firefox57 tag
+        if all(file_.is_mozilla_signed_extension for file_ in self.files):
+            Tag(tag_text='firefox57').save_tag(self.addon)
+
         # Increment approvals counter if we have a request (it means it's a
         # human doing the review) otherwise reset it as it's an automatic
         # approval.

--- a/src/olympia/search/filters.py
+++ b/src/olympia/search/filters.py
@@ -345,12 +345,16 @@ class SearchQueryFilter(BaseFilterBackend):
             query.SF('field_value_factor', field='boost'),
         ]
         if waffle.switch_is_active('boost-webextensions-in-search'):
+            webext_boost_filter = (
+                Q('term', **{'current_version.files.is_webextension': True}) |
+                Q('term', **{
+                    'current_version.files.is_mozilla_signed_extension': True})
+            )
+
             functions.append(
                 query.SF({
                     'weight': WEBEXTENSIONS_WEIGHT,
-                    'filter': Q(
-                        'term',
-                        **{'current_version.files.is_webextension': True})
+                    'filter': webext_boost_filter
                 })
             )
 

--- a/src/olympia/search/tests/test_filters.py
+++ b/src/olympia/search/tests/test_filters.py
@@ -118,7 +118,12 @@ class TestQueryFilter(FilterTestsBase):
         assert len(functions) == 2
         assert functions[1] == {
             'weight': 2.0,  # WEBEXTENSIONS_WEIGHT,
-            'filter': {'term': {'current_version.files.is_webextension': True}}
+            'filter': {'bool': {'should': [
+                {'term': {'current_version.files.is_webextension': True}},
+                {'term': {
+                    'current_version.files.is_mozilla_signed_extension': True
+                }}
+            ]}}
         }
 
 

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -437,6 +437,20 @@ class Version(OnChangeMixin, ModelBase):
         return any(file_.is_webextension for file_ in self.all_files)
 
     @property
+    def is_mozilla_signed(self):
+        """Is the file a special "Mozilla Signed Extension"
+
+        See https://wiki.mozilla.org/Add-ons/InternalSigning for more details.
+        We use that information to workaround compatibility limits for legacy
+        add-ons and to avoid them receiving negative boosts compared to
+        WebExtensions.
+
+        See https://github.com/mozilla/addons-server/issues/6424
+        """
+        return all(
+            file_.is_mozilla_signed_extension for file_ in self.all_files)
+
+    @property
     def has_files(self):
         return bool(self.all_files)
 


### PR DESCRIPTION
Refs #6424 (and as the second part fixes it)

This felt a bit too straight forward so please let me know if I missed anything.