### PR TITLE
Make file comparison compare against the last version approved by a human

### DIFF
--- a/src/olympia/editors/models.py
+++ b/src/olympia/editors/models.py
@@ -714,6 +714,7 @@ class AutoApprovalSummary(ModelBase):
         choices=amo.AUTO_APPROVAL_VERDICT_CHOICES,
         default=amo.NOT_AUTO_APPROVED)
     weight = models.IntegerField(default=0)
+    confirmed = models.NullBooleanField(default=None)
 
     def __unicode__(self):
         return u'%s %s' % (self.version.addon.name, self.version)

--- a/src/olympia/editors/tests/test_utils.py
+++ b/src/olympia/editors/tests/test_utils.py
@@ -723,8 +723,9 @@ class TestReviewHelper(TestCase):
     def test_public_addon_confirm_auto_approval(self):
         self.grant_permission(self.request.user, 'Addons:PostReview')
         self.setup_data(amo.STATUS_PUBLIC, file_status=amo.STATUS_PUBLIC)
-        AutoApprovalSummary.objects.create(
+        summary = AutoApprovalSummary.objects.create(
             version=self.version, verdict=amo.AUTO_APPROVED)
+        assert summary.confirmed is None
         self.create_paths()
 
         # Safeguards.
@@ -735,6 +736,8 @@ class TestReviewHelper(TestCase):
 
         self.helper.handler.confirm_auto_approved()
 
+        summary.reload()
+        assert summary.confirmed is True
         approvals_counter = AddonApprovalsCounter.objects.get(addon=self.addon)
         self.assertCloseToNow(approvals_counter.last_human_review)
         assert self.check_log_count(amo.LOG.CONFIRM_AUTO_APPROVED.id) == 1

--- a/src/olympia/editors/utils.py
+++ b/src/olympia/editors/utils.py
@@ -606,6 +606,7 @@ class ReviewBase(object):
         # and accidently submitted some comments from another action.
         self.data['comments'] = ''
         if self.version.channel == amo.RELEASE_CHANNEL_LISTED:
+            self.version.autoapprovalsummary.update(confirmed=True)
             AddonApprovalsCounter.increment_for_addon(addon=self.addon)
         self.log_action(amo.LOG.CONFIRM_AUTO_APPROVED)
 

--- a/src/olympia/editors/views.py
+++ b/src/olympia/editors/views.py
@@ -710,8 +710,15 @@ def review(request, addon, channel=None):
     actions = form.helper.actions.items()
 
     try:
+        # Find the previously approved version to compare to.
         show_diff = version and (
             addon.versions.exclude(id=version.id).filter(
+                # We're looking for a version that was either manually approved
+                # or auto-approved but then confirmed.
+                Q(autoapprovalsummary__isnull=True) |
+                Q(autoapprovalsummary__verdict=amo.AUTO_APPROVED,
+                  autoapprovalsummary__confirmed=True)
+            ).filter(
                 channel=channel,
                 files__isnull=False,
                 created__lt=version.created,

--- a/src/olympia/migrations/975-add-autoapprovalsummary-confirmed.sql
+++ b/src/olympia/migrations/975-add-autoapprovalsummary-confirmed.sql
@@ -1,0 +1,3 @@
+-- Note: backfilling for previously confirmed auto-approvals is not trivial,
+-- we'd need to go through the activity log, so we just don't do it...
+ALTER TABLE `editors_autoapprovalsummary` ADD COLUMN `confirmed` bool DEFAULT NULL;


### PR DESCRIPTION
To do that, record on `AutoApprovalSummary` when an auto-approved has been confirmed. We can then filter on that (or the absence of an `AutoApprovalSummary`) to find the file to compare to.

Fix #6483