### PR TITLE
Fix viewer role in devhub pages

### DIFF
--- a/src/olympia/devhub/templates/devhub/base.html
+++ b/src/olympia/devhub/templates/devhub/base.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
 
 {% if addon %}
-  {% set editable = "no-edit" if not check_addon_ownership(request, addon, dev=True) %}
+  {% set editable_body_class = "no-edit" if not check_addon_ownership(request, addon, dev=True) %}
 {% endif %}
-{% block bodyclass %}developer-hub {{ editable }}{% endblock %}
+{% block bodyclass %}developer-hub {{ editable_body_class }}{% endblock %}
 
 {# Don't show the amo header on devhub pages #}
 {% set hide_header = True %}

--- a/src/olympia/devhub/templates/devhub/base_impala.html
+++ b/src/olympia/devhub/templates/devhub/base_impala.html
@@ -1,9 +1,9 @@
 {% extends "impala/base.html" %}
 
 {% if addon %}
-  {% set editable = "no-edit" if not check_addon_ownership(request, addon, dev=True) %}
+  {% set editable_body_class = "no-edit" if not check_addon_ownership(request, addon, dev=True) %}
 {% endif %}
-{% block bodyclass %}developer-hub gutter {{ editable }}{% endblock %}
+{% block bodyclass %}developer-hub gutter {{ editable_body_class }}{% endblock %}
 
 {% block bodyattrs %}
 {% if addon %}data-default-locale="{{ addon.default_locale|lower }}"{% endif %}

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -364,6 +364,7 @@ class TestDevRequired(TestCase):
     def setUp(self):
         super(TestDevRequired, self).setUp()
         self.addon = Addon.objects.get(id=3615)
+        self.edit_page_url = self.addon.get_dev_url('edit')
         self.get_url = self.addon.get_dev_url('payments')
         self.post_url = self.addon.get_dev_url('payments.disable')
         assert self.client.login(email='del@icio.us')
@@ -373,9 +374,12 @@ class TestDevRequired(TestCase):
     def test_anon(self):
         self.client.logout()
         self.assertLoginRedirects(self.client.get(self.get_url), self.get_url)
+        self.assertLoginRedirects(self.client.get(
+            self.edit_page_url), self.edit_page_url)
 
     def test_dev_get(self):
         assert self.client.get(self.get_url).status_code == 200
+        assert self.client.get(self.edit_page_url).status_code == 200
 
     def test_dev_post(self):
         self.assert3xx(self.client.post(self.post_url), self.get_url)
@@ -384,6 +388,7 @@ class TestDevRequired(TestCase):
         self.au.role = amo.AUTHOR_ROLE_VIEWER
         self.au.save()
         assert self.client.get(self.get_url).status_code == 200
+        assert self.client.get(self.edit_page_url).status_code == 200
 
     def test_viewer_post(self):
         self.au.role = amo.AUTHOR_ROLE_VIEWER


### PR DESCRIPTION
The `{% set editable = ... %}` was propagated down to the includes, overshadowing the `editable` variable in context and causing us to try to access the `form` variable, which does not exist in viewer-only
mode...

Fix #6525