### PR TITLE
issue 4210 - limited resizing of tr textareas to vertical movement

### DIFF
--- a/static/css/zamboni/zamboni.css
+++ b/static/css/zamboni/zamboni.css
@@ -3300,6 +3300,9 @@ table#addons-list, table#contributors-list {
 #addons-list .comments.hascomment {
     display: block;
 }
+#addons-list .comments.hascomment textarea {
+    resize:vertical;
+}
 td.remove {
     width: 20px;
     text-align:center;


### PR DESCRIPTION
Fixes #4210 

This is my first PR! Let me know if I'm missing something here. I'm still getting a feel for the process.

I added the `resize: vertical;` attribute to the the addon comment textarea to prevent the user from expanding the table outside of the primary layout div.