### PR TITLE
Don't show "only works with legacy add-ons" warning on standalone validator

### DIFF
--- a/src/olympia/devhub/templates/devhub/validate_addon.html
+++ b/src/olympia/devhub/templates/devhub/validate_addon.html
@@ -12,12 +12,12 @@
   {% trans %}
     Use the field below to upload your add-on package.
   {% endtrans %}
-  {% trans webext_doc_url='https://developer.mozilla.org/en-US/Add-ons/WebExtensions' %}
-    Note that this tool only works with legacy add-ons.
-    WebExtension APIs are thoroughly <a href="{{ webext_doc_url }}">documented here</a>.
-  {% endtrans %}
-  </p>
   {% if appversion_form %}
+    {% trans webext_doc_url='https://developer.mozilla.org/en-US/Add-ons/WebExtensions' %}
+      Note that this tool only works with legacy add-ons.
+      WebExtension APIs are thoroughly <a href="{{ webext_doc_url }}">documented here</a>.
+    {% endtrans %}
+    </p>
     <p>
     {% trans %}
       After upload, a series of automated validation tests will
@@ -33,7 +33,6 @@
       {% endfor %}
     </section>
   {% else %}
-    <p>
     {% trans %}
       After upload, a series of automated validation tests will be
       run on your file.

--- a/src/olympia/devhub/tests/test_views_validation.py
+++ b/src/olympia/devhub/tests/test_views_validation.py
@@ -241,9 +241,12 @@ class TestValidateAddon(TestCase):
         response = self.client.get(reverse('devhub.validate_addon'))
         assert response.status_code == 302
 
-    def test_context(self):
+    def test_context_and_content(self):
         response = self.client.get(reverse('devhub.validate_addon'))
         assert response.status_code == 200
+
+        assert 'this tool only works with legacy' not in response.content
+
         doc = pq(response.content)
         assert doc('#upload-addon').attr('data-upload-url') == (
             reverse('devhub.standalone_upload'))
@@ -697,6 +700,8 @@ class TestUploadCompatCheck(BaseUploadTest):
         assert res.status_code == 200
         doc = pq(res.content)
 
+        assert 'this tool only works with legacy add-ons' in res.content
+
         options = doc('#id_application option')
         expected = [(str(a.id), unicode(a.pretty)) for a in amo.APP_USAGE]
         for idx, element in enumerate(options):
@@ -706,7 +711,6 @@ class TestUploadCompatCheck(BaseUploadTest):
             assert e.text() == text
 
         assert doc('#upload-addon').attr('data-upload-url') == self.upload_url
-        # TODO(Kumar) actually check the form here after bug 671587
 
     @mock.patch('olympia.devhub.tasks.run_validator')
     def test_js_upload_validates_compatibility(self, run_validator):


### PR DESCRIPTION
Fix #6580