### PR TITLE
fix docker building on circleci 2.0 infrastructure

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,11 +15,11 @@ jobs:
           "$CIRCLE_BUILD_URL"
           > version.json
       - run:
-        name: Build docker image and save to cache
-        command: |
-          docker build -t app:build -f Dockerfile.deploy .
-          mkdir -p docker-cache
-          docker save -o ./docker-cache/built-image.tar app:build
+          name: Build docker image and save to cache
+          command: |
+            docker build -t app:build -f Dockerfile.deploy .
+            mkdir -p docker-cache
+            docker save -o ./docker-cache/built-image.tar app:build
       - persist_to_workspace:
           root: .
           paths: .

--- a/circle.yml
+++ b/circle.yml
@@ -72,6 +72,7 @@ jobs:
             - .tox
   deploy:
     machine: true
+    working_directory: ~/addons-server
     steps:
       - attach_workspace:
           at: ~/addons-server
@@ -84,6 +85,7 @@ jobs:
             docker push ${DOCKERHUB_REPO}:latest
   release:
     machine: true
+    working_directory: ~/addons-server
     steps:
       - attach_workspace:
           at: ~/addons-server

--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ jobs:
         command: |
           docker build -t app:build -f Dockerfile.deploy .
           mkdir -p docker-cache
-          docker save -o ./docker-cache/built-image.tar my_app:$CIRCLE_BRANCH
+          docker save -o ./docker-cache/built-image.tar app:build
       - persist_to_workspace:
           root: .
           paths: .

--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,12 @@ jobs:
           "$CIRCLE_PROJECT_REPONAME"
           "$CIRCLE_BUILD_URL"
           > version.json
-      - run: docker build -t app:build -f Dockerfile.deploy .
+      - run:
+        name: Build docker image and save to cache
+        command: |
+          docker build -t app:build -f Dockerfile.deploy .
+          mkdir -p docker-cache
+          docker save -o ./docker-cache/built-image.tar my_app:$CIRCLE_BRANCH
       - persist_to_workspace:
           root: .
           paths: .
@@ -73,6 +78,7 @@ jobs:
       - run:
           name: Dockerfile deploy
           command: |
+            docker load -i ./docker-cache/built-image.tar
             docker tag app:build ${DOCKERHUB_REPO}:latest
             docker login -e $DOCKERHUB_EMAIL -u $DOCKERHUB_USER -p $DOCKERHUB_PASS
             docker push ${DOCKERHUB_REPO}:latest
@@ -84,6 +90,7 @@ jobs:
       - run:
           Name: Release
           command: |
+            docker load -i ./docker-cache/built-image.tar
             docker tag app:build ${DOCKERHUB_REPO}:${CIRCLE_TAG}
             docker login -e $DOCKERHUB_EMAIL -u $DOCKERHUB_USER -p $DOCKERHUB_PASS
             docker push ${DOCKERHUB_REPO}:${CIRCLE_TAG}

--- a/circle.yml
+++ b/circle.yml
@@ -105,6 +105,9 @@ workflows:
       - deploy:
           requires:
             - build
+          filters:
+            branches:
+              only: master
       - release:
           requires:
             - build

--- a/circle.yml
+++ b/circle.yml
@@ -103,9 +103,6 @@ workflows:
       - deploy:
           requires:
             - build
-          filters:
-            branches:
-              only: master
       - release:
           requires:
             - build


### PR DESCRIPTION
Essentially fixes current circleci `deploy` builds on master: https://circleci.com/gh/mozilla/addons-server/10184

The problem was  that all jobs are running independent from each other, on different executors (machines). So a `docker build` didn't share the image with the `deploy` build. This is now the case as we actually save the docker image and load it again before pushing it.

build that succeeded (on this branch): https://circleci.com/gh/mozilla/addons-server/10187