### PR TITLE
Fix reviewlog descriptions by directly using activity log short string

### DIFF
--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -212,7 +212,7 @@ class REQUEST_SUPER_REVIEW(_LOG):
 class COMMENT_VERSION(_LOG):
     id = 49
     format = _(u'Comment on {addon} {version}.')
-    short = _(u'Comment')
+    short = _(u'Commented')
     keep = True
     review_queue = True
     hide_developer = True

--- a/src/olympia/editors/templates/editors/reviewlog.html
+++ b/src/olympia/editors/templates/editors/reviewlog.html
@@ -46,13 +46,15 @@
                   {% else %}
                     {% set channel = 0 %}
                   {% endif %}
-                  {% if channel == amo.RELEASE_CHANNEL_LISTED %}
+                  {% if item.action == amo.LOG.REJECT_CONTENT.id or item.action == amo.LOG.APPROVE_CONTENT.id %}
+                    {% set review_url = url('editors.review', 'content', item.arguments[0].slug ) %}
+                  {% elif channel == amo.RELEASE_CHANNEL_LISTED %}
                     {% set review_url = url('editors.review', item.arguments[0].slug) %}
                   {% else %}
                     {% set review_url = url('editors.review', 'unlisted', item.arguments[0].slug) %}
                   {% endif %}
                   <a href="{{ review_url }}">
-                    {{ ACTION_DICT.get(item.action) }}
+                    {{ item.log.short }}
                   </a>
                 {% else %}
                     {{ _('Add-on has been deleted.') }}

--- a/src/olympia/editors/tests/test_views.py
+++ b/src/olympia/editors/tests/test_views.py
@@ -386,7 +386,7 @@ class TestReviewLog(EditorTest):
         self.make_an_approval(amo.LOG.COMMENT_VERSION)
         r = self.client.get(self.url)
         assert pq(r.content)('#log-listing tr td a').eq(1).text() == (
-            'Comment')
+            'Commented')
 
     def test_content_approval(self):
         self.make_an_approval(amo.LOG.APPROVE_CONTENT)
@@ -2364,7 +2364,7 @@ class TestReview(ReviewBase):
 
         r = self.client.get(self.url)
         doc = pq(r.content)('#review-files')
-        assert doc('th').eq(1).text() == 'Comment'
+        assert doc('th').eq(1).text() == 'Commented'
         assert doc('.history-comment').text() == 'hello sailor'
 
     def test_files_in_item_history(self):

--- a/src/olympia/editors/tests/test_views.py
+++ b/src/olympia/editors/tests/test_views.py
@@ -374,19 +374,35 @@ class TestReviewLog(EditorTest):
         self.make_an_approval(amo.LOG.REQUEST_INFORMATION)
         r = self.client.get(self.url)
         assert pq(r.content)('#log-listing tr td a').eq(1).text() == (
-            'needs more information')
+            'More information requested')
 
     def test_super_review_logs(self):
         self.make_an_approval(amo.LOG.REQUEST_SUPER_REVIEW)
         r = self.client.get(self.url)
         assert pq(r.content)('#log-listing tr td a').eq(1).text() == (
-            'needs super review')
+            'Super review requested')
 
     def test_comment_logs(self):
         self.make_an_approval(amo.LOG.COMMENT_VERSION)
         r = self.client.get(self.url)
         assert pq(r.content)('#log-listing tr td a').eq(1).text() == (
-            'commented')
+            'Comment')
+
+    def test_content_approval(self):
+        self.make_an_approval(amo.LOG.APPROVE_CONTENT)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        link = pq(response.content)('#log-listing tbody td a').eq(1)[0]
+        assert link.attrib['href'] == '/en-US/editors/review-content/a3615'
+        assert link.text_content().strip() == 'Content approved'
+
+    def test_content_rejection(self):
+        self.make_an_approval(amo.LOG.REJECT_CONTENT)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        link = pq(response.content)('#log-listing tbody td a').eq(1)[0]
+        assert link.attrib['href'] == '/en-US/editors/review-content/a3615'
+        assert link.text_content().strip() == 'Content rejected'
 
     @freeze_time('2017-08-03')
     def test_review_url(self):

--- a/src/olympia/editors/views.py
+++ b/src/olympia/editors/views.py
@@ -11,7 +11,7 @@ from django.core.paginator import Paginator
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect
 from django.views.decorators.cache import never_cache
-from django.utils.translation import ugettext, pgettext
+from django.utils.translation import ugettext
 
 import waffle
 

--- a/src/olympia/editors/views.py
+++ b/src/olympia/editors/views.py
@@ -957,22 +957,7 @@ def reviewlog(request):
                 Q(user__username__icontains=term)).distinct()
 
     pager = amo.utils.paginate(request, approvals, 50)
-    action_dict = {
-        amo.LOG.APPROVE_VERSION.id: ugettext('was approved'),
-        # The log will still show preliminary, even after the migration.
-        amo.LOG.PRELIMINARY_VERSION.id: ugettext('given preliminary review'),
-        amo.LOG.REJECT_VERSION.id: ugettext('rejected'),
-        amo.LOG.ESCALATE_VERSION.id: pgettext(
-            'editors_review_history_nominated_adminreview', 'escalated'),
-        amo.LOG.REQUEST_INFORMATION.id: ugettext('needs more information'),
-        amo.LOG.REQUEST_SUPER_REVIEW.id: ugettext('needs super review'),
-        amo.LOG.COMMENT_VERSION.id: ugettext('commented'),
-        amo.LOG.CONFIRM_AUTO_APPROVED.id: ugettext('confirmed as approved'),
-        amo.LOG.APPROVE_CONTENT .id: ugettext('was content approved'),
-        amo.LOG.REJECT_CONTENT.id: ugettext('was content rejected'),
-    }
-
-    data = context(request, form=form, pager=pager, ACTION_DICT=action_dict,
+    data = context(request, form=form, pager=pager,
                    motd_editable=motd_editable)
     return render(request, 'editors/reviewlog.html', data)
 

--- a/src/olympia/editors/views.py
+++ b/src/olympia/editors/views.py
@@ -968,6 +968,8 @@ def reviewlog(request):
         amo.LOG.REQUEST_SUPER_REVIEW.id: ugettext('needs super review'),
         amo.LOG.COMMENT_VERSION.id: ugettext('commented'),
         amo.LOG.CONFIRM_AUTO_APPROVED.id: ugettext('confirmed as approved'),
+        amo.LOG.APPROVE_CONTENT .id: ugettext('was content approved'),
+        amo.LOG.REJECT_CONTENT.id: ugettext('was content rejected'),
     }
 
     data = context(request, form=form, pager=pager, ACTION_DICT=action_dict,


### PR DESCRIPTION
This allows us to stop having to hardcode descriptions in the reviewlog view, which was annoying since it's easy to forget...

Fix #6602 
