### PR TITLE
Add paypal.com to valid contributions domains

### DIFF
--- a/src/olympia/constants/base.py
+++ b/src/olympia/constants/base.py
@@ -214,7 +214,9 @@ ADDON_TYPE_CHOICES_API = {
 MAX_TAGS = 20
 MIN_TAG_LENGTH = 2
 MAX_CATEGORIES = 2
-VALID_CONTRIBUTION_DOMAINS = ('paypal.me', 'patreon.com', 'micropayment.de')
+VALID_CONTRIBUTION_DOMAINS = (
+    'paypal.me', 'paypal.com', 'patreon.com', 'micropayment.de'
+)
 
 # Icon upload sizes
 ADDON_ICON_SIZES = [32, 48, 64, 128, 256, 512]


### PR DESCRIPTION
It turns out you can set up a paypal.com link to donate without
using paypal.me.

Fix #6585