### PR TITLE
Don't award overdue bonus points for content-review/post-review actions

### DIFF
--- a/src/olympia/editors/models.py
+++ b/src/olympia/editors/models.py
@@ -499,8 +499,10 @@ class ReviewerScore(ModelBase):
         # Add bonus to reviews greater than our limit to encourage fixing
         # old reviews. Does not apply to content-review/post-review at the
         # moment, because it would need to be calculated differently.
-        if (version and version.nomination and
-                not post_review and not content_review):
+        award_overdue_bonus = (
+            version and version.nomination and
+            not post_review and not content_review)
+        if award_overdue_bonus:
             waiting_time_days = (datetime.now() - version.nomination).days
             days_over = waiting_time_days - amo.REVIEWED_OVERDUE_LIMIT
             if days_over > 0:

--- a/src/olympia/editors/models.py
+++ b/src/olympia/editors/models.py
@@ -497,8 +497,10 @@ class ReviewerScore(ModelBase):
         score = amo.REVIEWED_SCORES.get(event)
 
         # Add bonus to reviews greater than our limit to encourage fixing
-        # old reviews.
-        if version and version.nomination:
+        # old reviews. Does not apply to content-review/post-review at the
+        # moment, because it would need to be calculated differently.
+        if (version and version.nomination and
+                not post_review and not content_review):
             waiting_time_days = (datetime.now() - version.nomination).days
             days_over = waiting_time_days - amo.REVIEWED_OVERDUE_LIMIT
             if days_over > 0:


### PR DESCRIPTION
Since those are done after approval, using the nomination date is wrong. If we truly want that functionality for post-review we'll  to think of a different mechanism.

Follow-up for #6473