### PR TITLE
Added right to left direction for collector-notes

### DIFF
--- a/static/css/legacy/main.css
+++ b/static/css/legacy/main.css
@@ -3212,7 +3212,9 @@ background-position:left -303px;
     margin-right:0;
     margin-left:220px;
 }
-
+.html-rtl .collector-note {
+    direction:rtl;
+}
 /* @end */
 
 


### PR DESCRIPTION
Fixes #5322 
(Tries to fix)
Added direction property for collector-notes inside html-rtl to have the value `rtl`