### PR TITLE
Don't raise a generic exception in activity process_email task when "To" is empty

### DIFF
--- a/src/olympia/activity/tests/test_utils.py
+++ b/src/olympia/activity/tests/test_utils.py
@@ -41,6 +41,16 @@ class TestEmailParser(TestCase):
         with self.assertRaises(ActivityEmailEncodingError):
             ActivityEmailParser('youtube?v=dQw4w9WgXcQ')
 
+    def test_with_empty_to(self):
+        message = copy.deepcopy(sample_message_content['Message'])
+        message['To'] = None
+        parser = ActivityEmailParser(message)
+        with self.assertRaises(ActivityEmailUUIDError):
+            # It should fail, but not because of a Not Iterable TypeError,
+            # instead we handle that gracefully and raise an exception that
+            # we control and catch later.
+            parser.get_uuid()
+
 
 @override_switch('activity-email-bouncing', active=True)
 class TestEmailBouncing(TestCase):

--- a/src/olympia/activity/utils.py
+++ b/src/olympia/activity/utils.py
@@ -78,8 +78,8 @@ class ActivityEmailParser(object):
             return split_email[0]
 
     def get_uuid(self):
-        addresses = [to.get('EmailAddress', '')
-                     for to in self.email.get('To', [])]
+        recipients = self.email.get('To', None) or []
+        addresses = [to.get('EmailAddress', '') for to in recipients]
         to_notifications_alias = False
         for address in addresses:
             if address.startswith(self.address_prefix):


### PR DESCRIPTION
Fix #6635