### PR TITLE
Fix pagination max window size validation.

### DIFF
--- a/src/olympia/amo/pagination.py
+++ b/src/olympia/amo/pagination.py
@@ -48,7 +48,7 @@ class ESPaginator(Paginator):
         bottom = (number - 1) * self.per_page
         top = bottom + self.per_page
 
-        if (number * self.per_page) > self.max_result_window:
+        if top > self.max_result_window:
             raise InvalidPage(
                 'That page number is too high for the current page size')
 

--- a/src/olympia/amo/pagination.py
+++ b/src/olympia/amo/pagination.py
@@ -48,7 +48,7 @@ class ESPaginator(Paginator):
         bottom = (number - 1) * self.per_page
         top = bottom + self.per_page
 
-        if bottom > self.max_result_window:
+        if (number * self.per_page) > self.max_result_window:
             raise InvalidPage(
                 'That page number is too high for the current page size')
 

--- a/src/olympia/amo/tests/test_pagination.py
+++ b/src/olympia/amo/tests/test_pagination.py
@@ -91,10 +91,19 @@ class TestSearchPaginator(TestCase):
         mocked_qs = MagicMock()
         paginator = ESPaginator(mocked_qs, 5)
         assert ESPaginator.max_result_window == 25000
-        with self.assertRaises(InvalidPage):
+
+        with pytest.raises(InvalidPage) as exc:
             # We're fetching 5 items per page, so requesting page 5001 should
             # fail, since the max result window should is set to 25000.
             paginator.page(5000 + 1)
+
+        # Make sure we raise exactly `InvalidPage`, this is needed
+        # unfortunately since `pytest.raises` won't check the exact
+        # instance but also accepts parent exceptions inherited.
+        assert (
+            exc.value.message ==
+            'That page number is too high for the current page size')
+        assert isinstance(exc.value, InvalidPage)
 
         with self.assertRaises(EmptyPage):
             paginator.page(0)


### PR DESCRIPTION
Fixes #6053

Unfortunately the `assertRaises` test didn't test the exact exception
and thus allowed child exception-instances (like `EmptyPage`) to be
truethy too.