### PR TITLE
Fix floor_version() to not fail loudly when passed unicode data

### DIFF
--- a/src/olympia/search/tests/test_searchutils.py
+++ b/src/olympia/search/tests/test_searchutils.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 
 from olympia.search.utils import floor_version
@@ -26,3 +27,4 @@ def test_floor_version():
     c('8.x', '8.0')
     c('8.0x', '8.0')
     c('8.0.x', '8.0')
+    c(u'acux5442À¾z1À¼z2abcxuca5442', u'acux5442À¾z1À¼z2abcxuca5442')

--- a/src/olympia/search/utils.py
+++ b/src/olympia/search/utils.py
@@ -5,7 +5,7 @@ from olympia.versions.compare import version_re
 
 def floor_version(version):
     if version:
-        version = str(
+        version = unicode(
             version).replace('.x', '.0').replace('.*', '.0').replace('*', '.0')
         match = re.match(version_re, version)
         if match:


### PR DESCRIPTION
The result will then be fed to `version_int()` which does handle random meaningless data gracefully, including unicode (and has a test for this already).

Fix #6614