### PR TITLE
Adjust boundaries for points rewards for post-review actions

### DIFF
--- a/src/olympia/editors/models.py
+++ b/src/olympia/editors/models.py
@@ -442,11 +442,11 @@ class ReviewerScore(ModelBase):
                     'No such version/auto approval summary when determining '
                     'event type to award points: %r', exception)
                 weight = 0
-            if weight >= amo.POST_REVIEW_WEIGHT_HIGHEST_RISK:
+            if weight > amo.POST_REVIEW_WEIGHT_HIGHEST_RISK:
                 reviewed_score_name = 'REVIEWED_EXTENSION_HIGHEST_RISK'
-            elif weight >= amo.POST_REVIEW_WEIGHT_HIGH_RISK:
+            elif weight > amo.POST_REVIEW_WEIGHT_HIGH_RISK:
                 reviewed_score_name = 'REVIEWED_EXTENSION_HIGH_RISK'
-            elif weight >= amo.POST_REVIEW_WEIGHT_MEDIUM_RISK:
+            elif weight > amo.POST_REVIEW_WEIGHT_MEDIUM_RISK:
                 reviewed_score_name = 'REVIEWED_EXTENSION_MEDIUM_RISK'
             else:
                 reviewed_score_name = 'REVIEWED_EXTENSION_LOW_RISK'

--- a/src/olympia/editors/tests/test_models.py
+++ b/src/olympia/editors/tests/test_models.py
@@ -573,7 +573,7 @@ class TestReviewerScore(TestCase):
         self.addon.current_version.update(nomination=self.days_ago(29))
         AutoApprovalSummary.objects.create(
             version=self.addon.current_version, verdict=amo.AUTO_APPROVED,
-            weight=100)
+            weight=101)
         ReviewerScore.award_points(
             self.user, self.addon, self.addon.status,
             version=self.addon.current_version,

--- a/src/olympia/editors/tests/test_utils.py
+++ b/src/olympia/editors/tests/test_utils.py
@@ -745,7 +745,7 @@ class TestReviewHelper(TestCase):
         self.grant_permission(self.request.user, 'Addons:PostReview')
         self.setup_data(amo.STATUS_PUBLIC, file_status=amo.STATUS_PUBLIC)
         summary = AutoApprovalSummary.objects.create(
-            version=self.version, verdict=amo.AUTO_APPROVED, weight=150)
+            version=self.version, verdict=amo.AUTO_APPROVED, weight=151)
         assert summary.confirmed is None
         self.create_paths()
 
@@ -1051,7 +1051,7 @@ class TestReviewHelper(TestCase):
         old_version = self.version
         self.version = version_factory(addon=self.addon, version='3.0')
         AutoApprovalSummary.objects.create(
-            version=self.version, verdict=amo.AUTO_APPROVED, weight=100)
+            version=self.version, verdict=amo.AUTO_APPROVED, weight=101)
         # An extra file should not change anything.
         file_factory(version=self.version, platform=amo.PLATFORM_LINUX.id)
         self.setup_data(amo.STATUS_PUBLIC, file_status=amo.STATUS_PUBLIC)
@@ -1096,7 +1096,7 @@ class TestReviewHelper(TestCase):
         # Add yet another version we don't want to reject.
         self.version = version_factory(addon=self.addon, version='42.0')
         AutoApprovalSummary.objects.create(
-            version=self.version, verdict=amo.AUTO_APPROVED, weight=20)
+            version=self.version, verdict=amo.AUTO_APPROVED, weight=21)
         self.setup_data(amo.STATUS_PUBLIC, file_status=amo.STATUS_PUBLIC)
 
         # Safeguards.


### PR DESCRIPTION
I had already made most of the tests use 151, 101, 21 etc, but
forgot to update the conditions.

Follow up fix #6473