### PR TITLE
Use django default filters instead of babel

### DIFF
--- a/src/olympia/addons/templates/addons/button.html
+++ b/src/olympia/addons/templates/addons/button.html
@@ -18,7 +18,7 @@
      data-version="{{ version.version }}"
      data-compatible-apps="{{ version.compatible_apps[request.APP] }}"
      data-lastupdated-isotime="{{ version.created|isotime }}"
-     data-lastupdated-datetime="{{ version.created|datetime }}"
+     data-lastupdated-datetime="{{ version.created|date }}"
   {% endif %}>
   <p class="install-button">
     {% set links = button.links() %}

--- a/src/olympia/addons/templates/addons/impala/details.html
+++ b/src/olympia/addons/templates/addons/impala/details.html
@@ -196,7 +196,7 @@
   {% if version %}
     <ul>
       <li>{{ _('Version {0}')|format_html(version.version) }} <a class="scrollto" href="#detail-relnotes">{{ _('Info') }}</a></li>
-      <li>{% trans %}Last Updated:{% endtrans %} {{ version.created|datetime }}</li>
+      <li>{% trans %}Last Updated:{% endtrans %} {{ version.created|date }}</li>
       <li class="source-license">
         {% set license = version.license %}
         {% if license %}

--- a/src/olympia/addons/templates/addons/impala/review_list_box.html
+++ b/src/olympia/addons/templates/addons/impala/review_list_box.html
@@ -11,7 +11,7 @@
           {{ review.rating|stars }}
         </h3>
         <p class="byline">
-          {% trans user=review.user|user_link, date=review.created|datetime %}
+          {% trans user=review.user|user_link, date=review.created|date %}
             by {{ user }} on {{ date }}
           {% endtrans %}
           &middot;

--- a/src/olympia/addons/templates/addons/listing/macros.html
+++ b/src/olympia/addons/templates/addons/listing/macros.html
@@ -36,10 +36,10 @@
   </p>
   <p class="updated">
     {% if show_date in ['created', 'new', 'newest'] %}
-    {{ _('Added {0}')|format_html(addon.created|datetime) }}
+    {{ _('Added {0}')|format_html(addon.created|date) }}
     {% elif show_date == 'updated' %}
     {# L10n: {0} is a date #}
-    {{ _('Updated {0}')|format_html(addon.last_updated|datetime) }}
+    {{ _('Updated {0}')|format_html(addon.last_updated|date) }}
     {% endif %}
   </p>
 {% endmacro %}

--- a/src/olympia/addons/templates/addons/macros.html
+++ b/src/olympia/addons/templates/addons/macros.html
@@ -4,10 +4,10 @@
       <span class="updated">
         {% if type == 'updated' %}
           {# L10n: {0} is a date. #}
-          {{ _('Updated {0}')|format_html(addon.last_updated|datetime) }}
+          {{ _('Updated {0}')|format_html(addon.last_updated|date) }}
         {% else %}
           {# L10n: {0} is a date. #}
-          {{ _('Added {0}')|format_html(addon.created|datetime) }}
+          {{ _('Added {0}')|format_html(addon.created|date) }}
         {% endif %}
       </span>
     {% elif type == 'rating' %}
@@ -78,10 +78,10 @@
     <div class="updated">
       {% if field == 'created' %}
         {# L10n: {0} is a date. #}
-        {{ _('Added {0}')|format_html(addon.created|datetime) }}
+        {{ _('Added {0}')|format_html(addon.created|date) }}
       {% else %}
         {# L10n: {0} is a date. #}
-        {{ _('Updated {0}')|format_html(addon.last_updated|datetime) }}
+        {{ _('Updated {0}')|format_html(addon.last_updated|date) }}
       {% endif %}
     </div>
   {% endif %}

--- a/src/olympia/addons/templates/addons/persona_detail_table.html
+++ b/src/olympia/addons/templates/addons/persona_detail_table.html
@@ -3,7 +3,7 @@
     <th>{{ _('Updated') }}</th>
     <td>
       <time datetime="{{ addon.modified|isotime }}">{{
-        addon.modified|datetime }}</time>
+        addon.modified|date }}</time>
     </td>
   </tr>
   <tr class="artist">

--- a/src/olympia/addons/templates/addons/persona_preview.html
+++ b/src/olympia/addons/templates/addons/persona_preview.html
@@ -19,7 +19,7 @@
 
           {% elif extra == 'created' %}
             <span class="created">
-              {{ _('Added {0}')|format_html(addon.created|datetime) }}
+              {{ _('Added {0}')|format_html(addon.created|date) }}
             </span>
           {% elif extra == 'popular' %}
             <span class="users">
@@ -63,9 +63,8 @@
           <div class="details">
             <p>
               {# L10n: For datetime formatting, see the table on http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior #}
-              {% set dt = _('%%Y-%%m-%%d') %}
               {{ _('by {0} on {1}')|format_html(users_list(addon.listed_authors)|safe or persona.display_username|safe,
-                                      addon.created|datetime(dt)) }}
+                                      addon.created|date('Y-m-d')) }}
             </p>
             {% if addon.total_reviews %}
               <a href="{{ url('addons.reviews.list', addon.slug) }}">

--- a/src/olympia/addons/templates/addons/review_list_box.html
+++ b/src/olympia/addons/templates/addons/review_list_box.html
@@ -11,7 +11,7 @@
         {% endif %}
         <p class="description">{{ review.body|nl2br }}</p>
         <p>{{ review.rating|stars }}
-          {% trans user=review.user|user_link, date=review.created|datetime %}
+          {% trans user=review.user|user_link, date=review.created|date %}
             by {{ user }} on {{ date }}
           {% endtrans %}
           {% if replies[review.id] %}

--- a/src/olympia/amo/templatetags/jinja_helpers.py
+++ b/src/olympia/amo/templatetags/jinja_helpers.py
@@ -66,16 +66,6 @@ def xssafe(value):
     return jinja2.Markup(value)
 
 
-@library.filter
-def babel_datetime(dt, format='medium'):
-    return _get_format().datetime(dt, format=format) if dt else ''
-
-
-@library.filter
-def babel_date(date, format='medium'):
-    return _get_format().date(date, format=format) if date else ''
-
-
 @library.global_function
 def locale_url(url):
     """Take a URL and give it the locale prefix."""
@@ -615,18 +605,14 @@ def nl2br(string):
     return jinja2.Markup('<br/>'.join(jinja2.escape(string).splitlines()))
 
 
+@library.filter(name='date')
+def format_date(value, format='DATE_FORMAT'):
+    return defaultfilters.date(value, format)
+
+
 @library.filter(name='datetime')
-def datetime_filter(t, fmt=None):
-    """Call ``datetime.strftime`` with the given format string.
-
-    This is a copy from jingo until we have time to port all our templates
-    to use django's datetime filter.
-    """
-    if fmt is None:
-        fmt = u'%B %e, %Y'
-
-    fmt = fmt.encode('utf-8')
-    return smart_text(t.strftime(fmt)) if t else ''
+def format_datetime(value, format='DATETIME_FORMAT'):
+    return defaultfilters.date(value, format)
 
 
 @library.filter

--- a/src/olympia/bandwagon/templates/bandwagon/collection_detail.html
+++ b/src/olympia/bandwagon/templates/bandwagon/collection_detail.html
@@ -41,7 +41,7 @@
             {% endtrans %}
           </li>
         {% endif %}
-        <li>{{ _('Updated {0}')|format_html(c.modified|datetime) }}</li>
+        <li>{{ _('Updated {0}')|format_html(c.modified|date) }}</li>
       </ul>
     </div>
     <div class='object-details'>

--- a/src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html
+++ b/src/olympia/bandwagon/templates/bandwagon/collection_listing_items.html
@@ -34,10 +34,10 @@
         <li class="modified">
           {% if field == 'created' %}
             {# L10n: {0} is a date. #}
-            {{ _('Added {0}')|format_html(c.created|datetime) }}
+            {{ _('Added {0}')|format_html(c.created|date) }}
           {% elif field == 'updated' %}
             {# L10n: {0} is a date. #}
-            {{ _('Updated {0}')|format_html(c.modified|datetime) }}
+            {{ _('Updated {0}')|format_html(c.modified|date) }}
           {% endif %}
         </li>
       {% endif %}

--- a/src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html
+++ b/src/olympia/bandwagon/templates/bandwagon/impala/collection_listing_items.html
@@ -34,10 +34,10 @@
           <div class="updated">
             {% if field == 'created' %}
               {# L10n: {0} is a date. #}
-              {{ _('Added {0}')|format_html(c.created|datetime) }}
+              {{ _('Added {0}')|format_html(c.created|date) }}
             {% elif field == 'updated' %}
               {# L10n: {0} is a date. #}
-              {{ _('Updated {0}')|format_html(c.modified|datetime) }}
+              {{ _('Updated {0}')|format_html(c.modified|date) }}
             {% endif %}
           </div>
         {% endif %}

--- a/src/olympia/browse/tests.py
+++ b/src/olympia/browse/tests.py
@@ -18,7 +18,7 @@ from olympia import amo
 from olympia.amo.tests import TestCase
 from olympia.amo.urlresolvers import reverse
 from olympia.amo.templatetags.jinja_helpers import (
-    absolutify, numberfmt, urlparams, datetime_filter)
+    absolutify, numberfmt, urlparams, format_date)
 from olympia.addons.models import (
     Addon, AddonCategory, Category, AppSupport, FrozenAddon, Persona)
 from olympia.bandwagon.models import (
@@ -164,7 +164,7 @@ class TestListing(TestCase):
             addon_id = item('.install').attr('data-addon')
             ts = Addon.objects.get(id=addon_id).created
             assert item('.updated').text() == (
-                u'Added %s' % trim_whitespace(datetime_filter(ts)))
+                u'Added %s' % trim_whitespace(format_date(ts)))
 
     def test_updated_date(self):
         doc = pq(self.client.get(urlparams(self.url, sort='updated')).content)
@@ -173,7 +173,7 @@ class TestListing(TestCase):
             addon_id = item('.install').attr('data-addon')
             ts = Addon.objects.get(id=addon_id).last_updated
             assert item('.updated').text() == (
-                u'Updated %s' % trim_whitespace(datetime_filter(ts)))
+                u'Updated %s' % trim_whitespace(format_date(ts)))
 
     def test_users_adu_unit(self):
         doc = pq(self.client.get(urlparams(self.url, sort='users')).content)

--- a/src/olympia/compat/templates/compat/reporter_detail.html
+++ b/src/olympia/compat/templates/compat/reporter_detail.html
@@ -74,7 +74,7 @@
                 </strong>
               {% endif %}
             </td>
-            <td>{{ report.created|datetime }}</td>
+            <td>{{ report.created|date }}</td>
           </tr>
           {% if report.comments %}
             <tr class="comments" class="{{ cls }}">

--- a/src/olympia/devhub/templates/devhub/addons/activity.html
+++ b/src/olympia/devhub/templates/devhub/addons/activity.html
@@ -32,7 +32,7 @@
           <p class="timestamp">
           {% trans user=item.user|user_link, ago=item.created|timesince,
                    iso=item.created|isotime,
-                   pretty=item.created|babel_datetime %}
+                   pretty=item.created|datetime %}
           <time datetime="{{ iso }}" title="{{ pretty }}">{{ ago }}</time>
           by {{ user }}
           {% endtrans %}

--- a/src/olympia/devhub/templates/devhub/addons/listing/items.html
+++ b/src/olympia/devhub/templates/devhub/addons/listing/items.html
@@ -26,7 +26,7 @@
         <ul class="item-details">
           {% if addon.is_persona() %}
             {# L10n: {0} is a date. #}
-            <li class="date-created">{{ _('<strong>Created:</strong> {0}'|format_html(addon.created|datetime)) }}</li>
+            <li class="date-created">{{ _('<strong>Created:</strong> {0}'|format_html(addon.created|date)) }}</li>
             <li id="version-status-item">
               <strong>{{ _('Status:') }}</strong>
               {% if addon.disabled_by_user %}

--- a/src/olympia/devhub/templates/devhub/includes/addon_details.html
+++ b/src/olympia/devhub/templates/devhub/includes/addon_details.html
@@ -35,13 +35,13 @@
   <li class="date-created">
     <strong>{{ _('Created:') }}</strong>
       {# L10n: {0} is a date. dennis-ignore: E201,E202,W202 #}
-      {{ addon.created|datetime(_('%%b %%e, %%Y')) }}
+      {{ addon.created|date }}
   </li>
 {% else %}
   <li class="date-updated">
     <strong>{{ _('Last Updated:') }}</strong>
       {# L10n: {0} is a date. dennis-ignore: E201,E202,W202 #}
-      {{ addon.last_updated|datetime(_('%%b %%e, %%Y')) }}
+      {{ addon.last_updated|date }}
   </li>
 {% endif %}
 {% if addon.type == amo.ADDON_EXTENSION and amo.FIREFOX in addon.compatible_apps %}

--- a/src/olympia/devhub/templates/devhub/new-landing/components/my-addons.html
+++ b/src/olympia/devhub/templates/devhub/new-landing/components/my-addons.html
@@ -105,11 +105,11 @@
               {% if addon.last_updated %}
                 <span>{{ _('Last Updated:') }}</span>
                 {# L10n: {0} is a date. dennis-ignore: E201,E202,W202 #}
-                <span>{{ addon.last_updated|datetime(_('%%b %%e, %%Y')) }}</span>
+                <span>{{ addon.last_updated|date }}</span>
               {% else %}
                 <span>{{ _('Created:') }}</span>
                 {# L10n: {0} is a date. dennis-ignore: E201,E202,W202 #}
-                <span>{{ addon.created|datetime(_('%%b %%e, %%Y')) }}</span>
+                <span>{{ addon.created|date }}</span>
               {% endif %}
             </span>
           </div>

--- a/src/olympia/devhub/templates/devhub/validation.html
+++ b/src/olympia/devhub/templates/devhub/validation.html
@@ -17,7 +17,7 @@
     {% if timestamp %}
     <tr>
         <th>{{ _('Validated at:') }}</th>
-        <td><time datetime="{{ timestamp|isotime}}">{{ timestamp|datetime}}</time></td>
+        <td><time datetime="{{ timestamp|isotime}}">{{ timestamp|date}}</time></td>
     </tr>
     {% endif %}
     {% if result_type == 'compat' %}

--- a/src/olympia/devhub/templates/devhub/versions/list.html
+++ b/src/olympia/devhub/templates/devhub/versions/list.html
@@ -36,7 +36,7 @@
           {{ _('Version {0}')|format_html(version.version) }}</a>
       </strong>
       <span title="{{ version.created|isotime }}" class="note">
-        {{ version.created|datetime }}
+        {{ version.created|date }}
       </span>
     </td>
     <td class="file-status">

--- a/src/olympia/devhub/templatetags/jinja_helpers.py
+++ b/src/olympia/devhub/templatetags/jinja_helpers.py
@@ -7,7 +7,7 @@ from django.utils.encoding import force_bytes
 from django_jinja import library
 
 from olympia import amo
-from olympia.amo.templatetags.jinja_helpers import page_title, datetime_filter
+from olympia.amo.templatetags.jinja_helpers import page_title, format_date
 from olympia.access import acl
 from olympia.activity.models import ActivityLog
 from olympia.activity.utils import filter_queryset_to_pending_replies
@@ -60,10 +60,10 @@ def source_form_field(field):
 def file_status_message(file):
     choices = File.STATUS_CHOICES
     return {'fileid': file.id, 'platform': file.get_platform_display(),
-            'created': datetime_filter(file.created),
+            'created': format_date(file.created),
             'status': choices[file.status],
             'actions': amo.LOG_REVIEW_EMAIL_USER,
-            'status_date': datetime_filter(file.datestatuschanged)}
+            'status_date': format_date(file.datestatuschanged)}
 
 
 @library.global_function

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -21,7 +21,7 @@ from olympia.amo.tests import TestCase
 from olympia.addons.models import (
     Addon, AddonFeatureCompatibility, AddonUser)
 from olympia.amo.templatetags.jinja_helpers import (
-    url as url_reverse, datetime_filter)
+    url as url_reverse, format_date)
 from olympia.amo.tests import addon_factory, user_factory, version_factory
 from olympia.amo.tests.test_helpers import get_image_path
 from olympia.amo.urlresolvers import reverse
@@ -193,7 +193,7 @@ class TestDashboard(HubTest):
         elm = doc('.item-details .date-created')
         assert elm.length == 1
         assert elm.remove('strong').text() == (
-            datetime_filter(self.addon.created, '%b %e, %Y'))
+            format_date(self.addon.created, '%b %e, %Y'))
 
     def test_sort_updated_filter(self):
         response = self.client.get(self.url)
@@ -203,7 +203,7 @@ class TestDashboard(HubTest):
         assert elm.length == 1
         assert elm.remove('strong').text() == (
             trim_whitespace(
-                datetime_filter(self.addon.last_updated, '%b %e, %Y')))
+                format_date(self.addon.last_updated, '%b %e, %Y')))
 
     def test_no_sort_updated_filter_for_themes(self):
         # Create a theme.
@@ -222,7 +222,7 @@ class TestDashboard(HubTest):
         # There's no "last updated" for themes, so always display "created".
         elm = doc('.item-details .date-created')
         assert elm.remove('strong').text() == (
-            trim_whitespace(datetime_filter(addon.created)))
+            trim_whitespace(format_date(addon.created)))
 
     def test_purely_unlisted_addon_are_not_shown_as_incomplete(self):
         self.make_addon_unlisted(self.addon)

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -193,7 +193,7 @@ class TestDashboard(HubTest):
         elm = doc('.item-details .date-created')
         assert elm.length == 1
         assert elm.remove('strong').text() == (
-            format_date(self.addon.created, '%b %e, %Y'))
+            format_date(self.addon.created))
 
     def test_sort_updated_filter(self):
         response = self.client.get(self.url)
@@ -203,7 +203,7 @@ class TestDashboard(HubTest):
         assert elm.length == 1
         assert elm.remove('strong').text() == (
             trim_whitespace(
-                format_date(self.addon.last_updated, '%b %e, %Y')))
+                format_date(self.addon.last_updated)))
 
     def test_no_sort_updated_filter_for_themes(self):
         # Create a theme.

--- a/src/olympia/devhub/tests/test_views_validation.py
+++ b/src/olympia/devhub/tests/test_views_validation.py
@@ -49,7 +49,7 @@ class TestUploadValidation(ValidatorTestCase, BaseUploadTest):
                                        args=[upload.uuid.hex]))
         assert resp.status_code == 200
         doc = pq(resp.content)
-        assert doc('td').text() == 'December  6, 2010'
+        assert doc('td').text() == 'Dec. 6, 2010'
 
     def test_upload_processed_validation_error(self):
         addon_file = open(

--- a/src/olympia/legacy_discovery/templates/legacy_discovery/addons/detail.html
+++ b/src/olympia/legacy_discovery/templates/legacy_discovery/addons/detail.html
@@ -59,11 +59,11 @@
   {% if addon.is_persona() %}
     <h3>{{ _('Created') }}</h3>
     <p><time datetime="{{ addon.created|isotime }}">{{
-      addon.created|datetime }}</time></p>
+      addon.created|date }}</time></p>
   {% else %}
     <h3>{{ _('Last Updated') }}</h3>
     <p><time datetime="{{ addon.last_updated|isotime }}">{{
-      addon.last_updated|datetime }}</time></p>
+      addon.last_updated|date }}</time></p>
   {% endif %}
   </li>
   {% if addon.homepage %}

--- a/src/olympia/legacy_discovery/tests/test_views.py
+++ b/src/olympia/legacy_discovery/tests/test_views.py
@@ -9,7 +9,7 @@ from pyquery import PyQuery as pq
 from olympia import amo
 from olympia.amo.tests import addon_factory, collection_factory, TestCase
 from olympia.amo.urlresolvers import reverse
-from olympia.amo.templatetags.jinja_helpers import datetime_filter
+from olympia.amo.templatetags.jinja_helpers import format_date
 from olympia.addons.models import (
     Addon, AddonDependency, CompatOverride, CompatOverrideRange, Preview)
 from olympia.bandwagon.models import MonthlyPick
@@ -434,7 +434,7 @@ class TestPersonaDetails(TestCase):
             if detail.find('h3').text_content() == 'Created':
                 created = detail.find('p').text_content()
                 assert created == (
-                    trim_whitespace(datetime_filter(self.addon.created)))
+                    trim_whitespace(format_date(self.addon.created)))
                 break  # Needed, or we go in the "else" clause.
         else:
             assert False, 'No "Created" entry found.'

--- a/src/olympia/reviewers/templates/reviewers/addon_details_box.html
+++ b/src/olympia/reviewers/templates/reviewers/addon_details_box.html
@@ -28,7 +28,7 @@
                 <th>{{ _('Updated') }}</th>
                 <td>
                   <time datetime="{{ addon.last_updated|isotime }}">{{
-                    addon.last_updated|datetime }}</time>
+                    addon.last_updated|date }}</time>
                 </td>
               </tr>
               {% if addon.homepage %}
@@ -140,7 +140,7 @@
               {% if is_post_reviewer and approvals_info %}
                 <tr class="last-approval-date">
                   <th> {{ _('Last Approval Date') }} </th>
-                  <td> {{ approvals_info.last_human_review|datetime }}
+                  <td> {{ approvals_info.last_human_review|date }}
                 </tr>
                 <tr class="approval-counter">
                   <th> {{ _('Approvals Since Last Automatic Review') }} </th>

--- a/src/olympia/reviewers/templates/reviewers/beta_signed_log.html
+++ b/src/olympia/reviewers/templates/reviewers/beta_signed_log.html
@@ -23,7 +23,7 @@
           {% for item in pager.object_list %}
           <tr>
             <td>
-              {{ item.created|babel_datetime }}
+              {{ item.created|datetime }}
             </td>
             <td>
               {{ item.to_string() }}

--- a/src/olympia/reviewers/templates/reviewers/eventlog.html
+++ b/src/olympia/reviewers/templates/reviewers/eventlog.html
@@ -30,7 +30,7 @@
           {% for item in pager.object_list %}
           <tr>
             <td>
-              {{ item.created|babel_datetime }}
+              {{ item.created|datetime }}
             </td>
             <td>
               {{ item.to_string('reviewer') }}

--- a/src/olympia/reviewers/templates/reviewers/home.html
+++ b/src/olympia/reviewers/templates/reviewers/home.html
@@ -93,7 +93,7 @@
                     {{ reviewers['user'].name }}
                   </a>
                 </td>
-                <td class="date" title="{{ reviewers['created']|babel_datetime }}">
+                <td class="date" title="{{ reviewers['created']|datetime }}">
                   {{ reviewers['created']|timesince }}
                 </td>
               </tr>
@@ -123,7 +123,7 @@
         </a>
         {% endif %}
         {% with ago=item.created|timesince, iso=item.created|isotime,
-                 pretty=item.created|babel_datetime %}
+                 pretty=item.created|datetime %}
           <time datetime="{{ iso }}" title="{{ pretty }}">{{ ago }}</time>
         {% endwith %}
       </div>

--- a/src/olympia/reviewers/templates/reviewers/includes/abuse_reports_list.html
+++ b/src/olympia/reviewers/templates/reviewers/includes/abuse_reports_list.html
@@ -11,7 +11,7 @@
     {% else %}
       {% set object_name = report.user|user_link %}
     {% endif %}
-    {% trans user=user_link, date=report.created|datetime, ip_address=report.ip_address, object=object_name %}
+    {% trans user=user_link, date=report.created|date, ip_address=report.ip_address, object=object_name %}
         {{ user }} [{{ ip_address }}] reported {{ object }} on {{ date }}
     {% endtrans %}
     <blockquote>{{ report.message }}</blockquote>

--- a/src/olympia/reviewers/templates/reviewers/includes/history.html
+++ b/src/olympia/reviewers/templates/reviewers/includes/history.html
@@ -3,7 +3,7 @@
     {{ record.log.short }}
   </th>
   <td>
-    {% trans user = record.user|user_link, date = record.created|babel_datetime %}
+    {% trans user = record.user|user_link, date = record.created|datetime %}
       <div>By {{ user }} on {{ date }}</div>
     {% endtrans %}
     {% if record.details %}

--- a/src/olympia/reviewers/templates/reviewers/includes/user_reviews_list.html
+++ b/src/olympia/reviewers/templates/reviewers/includes/user_reviews_list.html
@@ -1,7 +1,7 @@
 <ul class="user_reviews">
   {% for user_review in user_reviews %}
   <li>
-    {% with date=user_review.created|datetime, ip_address=user_review.ip_address %}
+    {% with date=user_review.created|date, ip_address=user_review.ip_address %}
       {% trans user=user_review.user|user_link %}
         {{ user }} on {{ date }} [{{ ip_address }}]
       {% endtrans %}

--- a/src/olympia/reviewers/templates/reviewers/queue.html
+++ b/src/olympia/reviewers/templates/reviewers/queue.html
@@ -78,7 +78,7 @@
               {%- if review.instance.title %}: <span>{{ review.instance.title }}</span>{% endif %}
             </h3>
             <p>
-            {% trans user=review.instance.user|user_link, date=review.instance.created|datetime,
+            {% trans user=review.instance.user|user_link, date=review.instance.created|date,
                      stars=review.instance.rating|stars, locale=review.instance.title.locale %}
               by {{ user }} on {{ date }}
               {{ stars }} ({{ locale }})
@@ -89,7 +89,7 @@
               {% for reason in review.instance.reviewflag_set.all() %}
               <li>
               <div>
-                {% trans user=reason.user|user_link, date=reason.modified|babel_datetime,
+                {% trans user=reason.user|user_link, date=reason.modified|datetime,
                          reason=flags[reason.flag] %}
                 <strong>{{ reason }}</strong>
                 <span class="light">Flagged by {{ user }} on {{ date }}</span>

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -65,7 +65,7 @@
         {% for version in pager.object_list|reverse %}
         <tr class="listing-header">
           <th colspan="2">
-            {% trans version = version.version, created = version.created|datetime, version_status = version_status(addon, version) %}
+            {% trans version = version.version, created = version.created|date, version_status = version_status(addon, version) %}
             Version {{ version }} &middot; {{ created }} <span class="light">&middot; {{ version_status }}</span>
             {% endtrans %}
           </th>

--- a/src/olympia/reviewers/templates/reviewers/reviewlog.html
+++ b/src/olympia/reviewers/templates/reviewers/reviewlog.html
@@ -36,7 +36,7 @@
         <tbody>
           {% for item in pager.object_list %}
             <tr{% if item.arguments[0] %} data-addonid="{{ item.arguments[0].id }}"{% endif %}>
-              <td>{{ item.created|babel_datetime }}</td>
+              <td>{{ item.created|datetime }}</td>
               <td>
                 {% if item.arguments.0 %}
                   {{ item.arguments.0|link }}

--- a/src/olympia/reviewers/templates/reviewers/themes/deleted.html
+++ b/src/olympia/reviewers/templates/reviewers/themes/deleted.html
@@ -18,7 +18,7 @@
         <tbody>
           {% for addon in pager.object_list %}
             <tr>
-              <td>{{ addon.modified|babel_datetime }}</td>
+              <td>{{ addon.modified|datetime }}</td>
               <td>
                 {{ addon.name }}
               </td>

--- a/src/olympia/reviewers/templates/reviewers/themes/history_table.html
+++ b/src/olympia/reviewers/templates/reviewers/themes/history_table.html
@@ -15,7 +15,7 @@
       {% for theme_review in theme_reviews.object_list %}
         {% set details = theme_review.details %}
         <tr>
-          <td>{{ theme_review.created|datetime('%Y-%m-%d') }}</td>
+          <td>{{ theme_review.created|date('Y-m-d') }}</td>
           {% if not user_history %}
             <td>{{ theme_review.user.display_name }}</td>
           {% else %}

--- a/src/olympia/reviewers/templates/reviewers/themes/logs.html
+++ b/src/olympia/reviewers/templates/reviewers/themes/logs.html
@@ -19,7 +19,7 @@
         <tbody>
           {% for item in pager.object_list %}
             <tr{% if item.arguments[0] %} data-addonid="{{ item.arguments[0].id }}"{% endif %}>
-              <td>{{ item.created|babel_datetime }}</td>
+              <td>{{ item.created|datetime }}</td>
               <td>
                 <a href="{{ url('reviewers.themes.single', item.arguments.0.slug) }}">{{ item.arguments.0.name }}</a>
               </td>

--- a/src/olympia/reviewers/templates/reviewers/themes/themes.html
+++ b/src/olympia/reviewers/templates/reviewers/themes/themes.html
@@ -37,7 +37,7 @@
           <a href="{{ category.get_url_path() }}">{{ category.name }}</a>{{ ', ' if not loop.last }}
         {% endfor %}
       </dd>
-      <dt>{{ _('Submitted') }}</dt><dd>{{ theme.addon.created|datetime('%Y-%m-%d') }}</dd>
+      <dt>{{ _('Submitted') }}</dt><dd>{{ theme.addon.created|date('Y-m-d') }}</dd>
       <dt class="license">{{ _('License') }}</dt><dd>{{ license_link(theme.license) }}</dd>
     </dl>
     <dl class="meta">

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -84,7 +84,7 @@ class TestEventLog(ReviewerTest):
         r = self.client.get(self.url, dict(end='2011-01-01'))
         assert r.status_code == 200
         assert pq(r.content)('tbody td').eq(0).text() == (
-            'Jan 1, 2011, 12:00:00 AM')
+            'Jan. 1, 2011, midnight')
 
     def test_action_filter(self):
         """
@@ -3179,7 +3179,7 @@ class TestReview(ReviewBase):
         report = AbuseReport.objects.create(
             addon=self.addon, message=u'Et mël mazim ludus.',
             ip_address='10.1.2.3')
-        created_at = report.created.strftime('%B %e, %Y')
+        created_at = report.created.strftime('%b. %e, %Y')
         response = self.client.get(self.url)
         doc = pq(response.content)
         assert not doc('.abuse_reports')
@@ -3203,7 +3203,7 @@ class TestReview(ReviewBase):
         report = AbuseReport.objects.create(
             user=self.addon.listed_authors[0], message=u'Foo, Bâr!',
             ip_address='10.4.5.6')
-        created_at = report.created.strftime('%B %e, %Y')
+        created_at = report.created.strftime('%b. %e, %Y')
         AutoApprovalSummary.objects.create(
             verdict=amo.AUTO_APPROVED, version=self.version)
         self.login_as_senior_reviewer()
@@ -3220,7 +3220,7 @@ class TestReview(ReviewBase):
         user_review = Review.objects.create(
             body=u'Lôrem ipsum dolor', rating=3, ip_address='10.5.6.7',
             addon=self.addon, user=user)
-        created_at = user_review.created.strftime('%B %e, %Y')
+        created_at = user_review.created.strftime('%b. %e, %Y')
         Review.objects.create(  # Review with no body, ignored.
             rating=1, addon=self.addon, user=user_factory())
         Review.objects.create(  # Reply to a review, ignored.

--- a/src/olympia/reviews/templates/reviews/review.html
+++ b/src/olympia/reviews/templates/reviews/review.html
@@ -23,11 +23,11 @@
   {% endwith %}
   <p class="byline">
     {% if is_reply %}
-      {% trans user=review.user|user_link, date=review.created|datetime %}
+      {% trans user=review.user|user_link, date=review.created|date %}
         by {{ user }} <b>(Developer)</b> on {{ date }}
       {% endtrans %}
     {% else %}
-      {% trans user=review.user|user_link, date=review.created|datetime %}
+      {% trans user=review.user|user_link, date=review.created|date %}
         by {{ user }} on {{ date }}
       {% endtrans %}
     {% endif %}

--- a/src/olympia/search/tests/test_views.py
+++ b/src/olympia/search/tests/test_views.py
@@ -14,7 +14,7 @@ from olympia import amo
 from olympia.amo.tests import (
     create_switch, ESTestCaseWithAddons, ESTestCase, addon_factory)
 from olympia.amo.templatetags.jinja_helpers import (
-    locale_url, numberfmt, urlparams, datetime_filter)
+    locale_url, numberfmt, urlparams, format_date)
 
 from olympia.amo.urlresolvers import reverse
 from olympia.addons.models import (
@@ -991,7 +991,7 @@ class TestCollectionSearch(SearchBase):
         items = pq(r.content)('.primary .item')
         for idx, c in enumerate(r.context['pager'].object_list):
             assert trim_whitespace(items.eq(idx).find('.modified').text()) == (
-                'Added %s' % trim_whitespace(datetime_filter(c.created)))
+                'Added %s' % trim_whitespace(format_date(c.created)))
 
     def test_updated_timestamp(self):
         self._generate()
@@ -999,7 +999,7 @@ class TestCollectionSearch(SearchBase):
         items = pq(r.content)('.primary .item')
         for idx, c in enumerate(r.context['pager'].object_list):
             assert trim_whitespace(items.eq(idx).find('.modified').text()) == (
-                'Updated %s' % trim_whitespace(datetime_filter(c.modified)))
+                'Updated %s' % trim_whitespace(format_date(c.modified)))
 
     def check_followers_count(self, sort, column):
         # Checks that we show the correct type/number of followers.

--- a/src/olympia/users/templates/users/support/emails/support-request.txt
+++ b/src/olympia/users/templates/users/support/emails/support-request.txt
@@ -1,7 +1,7 @@
 Add-on, {{ addon.name }}, has received a new support request:
 User: {{ user.display_name or user.username }}
 Email: {{ user.email }}
-Purchased on {{ contribution.date|datetime }}
+Purchased on {{ contribution.date|date }}
 
 Details:
 

--- a/src/olympia/users/templates/users/vcard.html
+++ b/src/olympia/users/templates/users/vcard.html
@@ -26,13 +26,13 @@
     {% endif %}
     <tr>
       <th>{{ _('User since') }}</th>
-      <td>{{ profile.created|datetime }}</td>
+      <td>{{ profile.created|date }}</td>
     </tr>
     {% if own_profile or edit_any_user %}
       {% if profile.last_login %}
         <tr class="last-login-time">
           <th>{{ _('Time of last login') }}</th>
-          <td>{{ profile.last_login|datetime('%B %e, %Y %H:%M:%S') }}</td>
+          <td>{{ profile.last_login|datetime }}</td>
         </tr>
       {% endif %}
       {% if profile.last_login_ip %}

--- a/src/olympia/versions/feeds.py
+++ b/src/olympia/versions/feeds.py
@@ -5,7 +5,7 @@ from django.utils.translation import ugettext
 from olympia import amo
 from olympia.amo.urlresolvers import reverse
 from olympia.amo.templatetags.jinja_helpers import (
-    absolutify, url, datetime_filter)
+    absolutify, url, format_date)
 from olympia.amo.feeds import NonAtomicFeed
 from olympia.amo.utils import urlparams
 from olympia.addons.models import Addon
@@ -81,7 +81,7 @@ class VersionsRss(NonAtomicFeed):
         # L10n: This is the Title for this Version of the Addon
         return u'{name} {version} - {created}'.format(
             name=self.addon.name, version=version.version,
-            created=datetime_filter(version.created))
+            created=format_date(version.created))
 
     def item_description(self, version):
         """Description for particular version (<item><description>)"""

--- a/src/olympia/versions/templates/versions/version.html
+++ b/src/olympia/versions/templates/versions/version.html
@@ -7,7 +7,7 @@
       <span class="meta">
         <time datetime="{{ version.created|isotime }}">
           {# L10n: {0} is a timestamp, such as September 28, 2011. #}
-          {{ _('Released {0}')|format_html(version.created|datetime) }}
+          {{ _('Released {0}')|format_html(version.created|date) }}
         </time>
         {% if version.has_files %}
           <span class="filesize">

--- a/src/olympia/versions/tests/test_feeds.py
+++ b/src/olympia/versions/tests/test_feeds.py
@@ -78,14 +78,14 @@ class TestFeeds(TestCase):
         """first page has the right elements and page relations"""
         doc = self.get_feed('addon-337203', page=1)
         assert doc('rss item title')[0].text == (
-            'Addon for DTC 1.3 - December  5, 2011')
+            'Addon for DTC 1.3 - Dec. 5, 2011')
         self.assert_page_relations(doc, {'self': 1, 'next': 2, 'last': 4})
 
     def test_feed_middle_page(self):
         """a middle page has the right elements and page relations"""
         doc = self.get_feed('addon-337203', page=2)
         assert doc('rss item title')[0].text == (
-            'Addon for DTC 1.2 - December  5, 2011')
+            'Addon for DTC 1.2 - Dec. 5, 2011')
         self.assert_page_relations(doc, {'previous': 1, 'self': 2, 'next': 3,
                                          'last': 4})
 
@@ -93,17 +93,17 @@ class TestFeeds(TestCase):
         """last page has the right elements and page relations"""
         doc = self.get_feed('addon-337203', page=4)
         assert doc('rss item title')[0].text == (
-            'Addon for DTC 1.0 - December  5, 2011')
+            'Addon for DTC 1.0 - Dec. 5, 2011')
         self.assert_page_relations(doc, {'previous': 3, 'self': 4, 'last': 4})
 
     def test_feed_invalid_page(self):
         """an invalid page falls back to page 1"""
         doc = self.get_feed('addon-337203', page=5)
         assert doc('rss item title')[0].text == (
-            'Addon for DTC 1.3 - December  5, 2011')
+            'Addon for DTC 1.3 - Dec. 5, 2011')
 
     def test_feed_no_page(self):
         """no page defaults to page 1"""
         doc = self.get_feed('addon-337203')
         assert doc('rss item title')[0].text == (
-            'Addon for DTC 1.3 - December  5, 2011')
+            'Addon for DTC 1.3 - Dec. 5, 2011')

--- a/src/olympia/zadmin/templates/zadmin/addon_manage.html
+++ b/src/olympia/zadmin/templates/zadmin/addon_manage.html
@@ -29,7 +29,7 @@
       <tbody>
       {% for v in versions %}
         <tr>
-          <td>{{ v.created|datetime }}</td>
+          <td>{{ v.created|date }}</td>
           <td>
             {% if v.channel == amo.RELEASE_CHANNEL_LISTED %}
               <a href="{{ url('reviewers.review', addon.slug) }}" title="{{ v.id }}">{{ v.version }}</a>

--- a/src/olympia/zadmin/templates/zadmin/celery.html
+++ b/src/olympia/zadmin/templates/zadmin/celery.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <h2>Celery Stats</h2>
-<p>The time is {{ now|babel_datetime }}.</p>
+<p>The time is {{ now|datetime }}.</p>
 <form method="post">
   {% csrf_token %}
   <input name="reset" type="submit" value="Reset">

--- a/src/olympia/zadmin/templates/zadmin/langpack_update.html
+++ b/src/olympia/zadmin/templates/zadmin/langpack_update.html
@@ -46,8 +46,8 @@
           <a href="{{ url('reviewers.review', addon.slug) }}">{{ latest_version }}</a>
         {% endif %}
       </td>
-      <td>{{ addon.created|datetime('%Y-%m-%d %H:%M:%S') }}</td>
-      <td>{{ addon.last_updated|datetime('%Y-%m-%d %H:%M:%S') }}</td>
+      <td>{{ addon.created|date('%Y-%m-%d %H:%M:%S') }}</td>
+      <td>{{ addon.last_updated|date('%Y-%m-%d %H:%M:%S') }}</td>
     </tr>
   {% endfor %}
   </tbody>


### PR DESCRIPTION
Please delete anything that isn't relevant to your patch.
Fixes #6485 
Remove babel_date and babel_datetime filters and use django template filters in place of it.
