### PR TITLE
Add dismissable banner to legacy frontend with link to try the new site

### DIFF
--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -114,6 +114,15 @@ class TestHomepage(TestCase):
             'Welcome to Thunderbird Add-ons. Add extra features and styles to '
             'make Thunderbird your own.')
 
+    def test_try_new_frontend_banner_presence(self):
+        self.url = '/en-US/firefox/'
+        response = self.client.get(self.url)
+        assert 'AMO is getting a new look.' not in response.content
+
+        with override_switch('try-new-frontend', active=True):
+            response = self.client.get(self.url)
+            assert 'AMO is getting a new look.' in response.content
+
 
 class TestHomepageFeatures(TestCase):
     fixtures = ['base/appversion',
@@ -587,6 +596,14 @@ class TestDetailPage(TestCase):
         self.addon = Addon.objects.get(id=3615)
         self.url = self.addon.get_url_path()
         self.more_url = self.addon.get_url_path(more=True)
+
+    def test_try_new_frontend_banner_presence(self):
+        response = self.client.get(self.url)
+        assert 'AMO is getting a new look.' not in response.content
+
+        with override_switch('try-new-frontend', active=True):
+            response = self.client.get(self.url)
+            assert 'AMO is getting a new look.' in response.content
 
     def test_304(self):
         response = self.client.get(self.url)

--- a/src/olympia/browse/tests.py
+++ b/src/olympia/browse/tests.py
@@ -12,6 +12,7 @@ from django.utils.translation import trim_whitespace
 import pytest
 import mock
 from pyquery import PyQuery as pq
+from waffle.testutils import override_switch
 
 from olympia import amo
 from olympia.amo.tests import TestCase
@@ -78,6 +79,14 @@ class TestListing(TestCase):
         super(TestListing, self).setUp()
         cache.clear()
         self.url = reverse('browse.extensions')
+
+    def test_try_new_frontend_banner_presence(self):
+        response = self.client.get(self.url)
+        assert 'AMO is getting a new look.' not in response.content
+
+        with override_switch('try-new-frontend', active=True):
+            response = self.client.get(self.url)
+            assert 'AMO is getting a new look.' in response.content
 
     def test_default_sort(self):
         r = self.client.get(self.url)
@@ -1052,6 +1061,14 @@ class TestPersonas(TestCase):
             a._current_version = v
             a.status = amo.STATUS_PUBLIC
             a.save()
+
+    def test_try_new_frontend_banner_presence(self):
+        response = self.client.get(self.landing_url)
+        assert 'AMO is getting a new look.' not in response.content
+
+        with override_switch('try-new-frontend', active=True):
+            response = self.client.get(self.landing_url)
+            assert 'AMO is getting a new look.' in response.content
 
     def test_does_not_500_in_development(self):
         with self.settings(DEBUG=True):

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -739,6 +739,7 @@ MINIFY_BUNDLES = {
             'js/node_lib/ui/sortable.js',
 
             'js/zamboni/helpers.js',
+            'js/common/banners.js',
             'js/zamboni/global.js',
             'js/amo2009/global.js',
             'js/common/ratingwidget.js',
@@ -836,6 +837,7 @@ MINIFY_BUNDLES = {
             'js/zamboni/truncation.js',
             'js/impala/ajaxcache.js',
             'js/zamboni/helpers.js',
+            'js/common/banners.js',
             'js/zamboni/global.js',
             'js/impala/global.js',
             'js/common/ratingwidget.js',

--- a/src/olympia/migrations/978-add-try-new-frontend-waffle.sql
+++ b/src/olympia/migrations/978-add-try-new-frontend-waffle.sql
@@ -1,0 +1,1 @@
+INSERT INTO waffle_switch (name, active, created, modified, note) VALUES ('try-new-frontend', 0, NOW(), NOW(), 'Display notification to try the new frontend') ON DUPLICATE KEY UPDATE active = 0;

--- a/src/olympia/templates/base.html
+++ b/src/olympia/templates/base.html
@@ -115,6 +115,17 @@
                   {% block navbar %}{% endblock %}
                   {% block site_stats %}{% endblock %}
                 </div>
+                {% if APP == amo.FIREFOX and waffle.switch('try-new-frontend') %}
+                  <div class="site-balloon" id="try-new-frontend">
+                    <p>
+                      {{ _('AMO is getting a new look. Would you like to see it?') }}
+                    </p>
+                    <p>
+                      <a href="#" class="mobile-link">{{ _('Visit the new site') }}</a>
+                    </p>
+                    <a href="#" class="close">{{ _('Close') }}</a>
+                  </div>
+                {% endif %}
               </div>
             </div> {# .header-bg #}
           </div> {# .amo-header-wrapper #}

--- a/src/olympia/templates/impala/base.html
+++ b/src/olympia/templates/impala/base.html
@@ -117,6 +117,17 @@
                       </p>
                       <a href="#" class="close">{{ _('Close') }}</a>
                     </div>
+                    {% if waffle.switch('try-new-frontend') %}
+                      <div class="site-balloon" id="try-new-frontend">
+                        <p>
+                          {{ _('AMO is getting a new look. Would you like to see it?') }}
+                        </p>
+                        <p>
+                          <a href="#" class="mobile-link">{{ _('Visit the new site') }}</a>
+                        </p>
+                        <a href="#" class="close">{{ _('Close') }}</a>
+                      </div>
+                    {% endif %}
                   {% endif %}
                   <div class="site-balloon" id="site-welcome">
                     {# L10n: {0} is an application, such as Firefox. #}

--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -293,6 +293,9 @@ body:not(.home) .amo-header,
 .addon-details .header-bg,
 .home .header-bg {
   min-height: 130px;
+  // prevent margin collapsing, making sure notification area margins are
+  // respected:
+  border-bottom: 1px solid transparent;
 }
 
 .addon-details .header-bg {
@@ -563,7 +566,7 @@ body:not(.home) .amo-header,
   border: 2px solid #1f386e;
   border-radius: 6px;
   color: @default-font-color;
-  margin-top: 22px;
+  margin: 22px 0;
   padding: 15px 45px 15px 15px;
 
   .html-rtl& {
@@ -602,11 +605,16 @@ body:not(.home) .amo-header,
 }
 
 #promos {
+  float: none;
   margin: 20px 0 0;
   min-height: 0;
   opacity: 1;
   visibility: visible;
   width: @pageWidth;
+
+  hgroup {
+    margin: 0 auto 20px;
+  }
 
   &.show {
     display: block;
@@ -1122,7 +1130,7 @@ body:not(.developer-hub) section.secondary {
 }
 
 .secondary {
-  margin: 0 0 12px;
+  margin: 0;
   width: 21.49%;
 
   h2, h3 {
@@ -1234,7 +1242,6 @@ body:not(.developer-hub) section.secondary {
 .addon-details {
   .primary:first-of-type {
     min-height: 257px;
-    padding-bottom: 1em;
   }
 
   .secondary.addon-vitals {

--- a/static/js/amo2009/global.js
+++ b/static/js/amo2009/global.js
@@ -246,7 +246,6 @@ jQuery(function($) {
 	  },2000);
     });
 
-
 	// account dropdown in auxillary menu
 	var accountDropdown = new DropdownArea();
 	// set up variables for object

--- a/static/js/common/banners.js
+++ b/static/js/common/banners.js
@@ -1,0 +1,49 @@
+z.visitor = z.Storage('visitor');
+z.currentVisit = z.SessionStorage('current-visit');
+
+function initBanners(delegate) {
+    var $delegate = $(delegate || document.body);
+
+    if ($delegate.hasClass('editor-tools')) {
+        // Don't bother showing those on editor tools, it has a bunch of weird
+        // styles for the menu that don't play nice with those banners.
+        return;
+    }
+
+    // Show the various banners, but only one at a time, and only if they
+    // haven't been dimissed before.
+    // To reset dismissal state: z.visitor.remove('xx')
+
+    // Show the bad-browser message
+    if (!z.visitor.get('seen_badbrowser_warning') && $('body').hasClass('badbrowser')) {
+        $('#site-nonfx').show();
+    }
+    // Show the first visit banner.
+    else if (!z.visitor.get('seen_impala_first_visit')) {
+        $('body').addClass('firstvisit');
+        z.visitor.set('seen_impala_first_visit', 1);
+    }
+    // Show the link to try the new frontend.
+    else if (!z.visitor.get('seen_try_new_frontend')) {
+        $('#try-new-frontend').show();
+    }
+    // Show the ACR pitch if it has not been dismissed.
+    else if (!z.visitor.get('seen_acr_pitch') && $('body').hasClass('acr-pitch')) {
+        $delegate.find('#acr-pitch').show();
+    }
+
+    // Allow dismissal of site-balloons.
+    $delegate.on('click', '.site-balloon .close, .site-tip .close', _pd(function() {
+        var $parent = $(this).closest('.site-balloon, .site-tip');
+        $parent.fadeOut();
+        if ($parent.is('#site-nonfx')) {
+            z.visitor.set('seen_badbrowser_warning', 1);
+        } else if ($parent.is('#acr-pitch')) {
+            z.visitor.set('seen_acr_pitch', 1);
+        } else if ($parent.is('#appruntime-pitch')) {
+            z.visitor.set('seen_appruntime_pitch', 1);
+        } else if ($parent.is('#try-new-frontend')) {
+            z.visitor.set('seen_try_new_frontend', 1);
+        }
+    }));
+}

--- a/static/js/impala/global.js
+++ b/static/js/impala/global.js
@@ -29,15 +29,6 @@ $('.island .listing-grid').on('grid.init', function(e, data) {
     }
 });
 
-z.visitor = z.Storage('visitor');
-z.currentVisit = z.SessionStorage('current-visit');
-(function() {
-    // Show the bad-browser message if it has not been dismissed
-    if (!z.visitor.get('seen_badbrowser_warning') && $('body').hasClass('badbrowser')) {
-        $('#site-nonfx').show();
-    }
-})();
-
 function hoverTruncate(grid) {
     var $grid = $(grid);
     if ($grid.hasClass('hovercard')) {
@@ -88,8 +79,6 @@ function listing_grid() {
 
 $(function() {
     "use strict";
-
-    initBanners();
 
     // Paginate listing grids.
     $('.listing-grid').each(listing_grid);
@@ -143,35 +132,6 @@ $(function() {
 
     $("select[name='rating']").ratingwidget();
 });
-
-
-function initBanners(delegate) {
-    var $delegate = $(delegate || document.body);
-
-    // Show the first visit banner.
-    if (!z.visitor.get('seen_impala_first_visit')) {
-        $('body').addClass('firstvisit');
-        z.visitor.set('seen_impala_first_visit', 1);
-    }
-
-    // Show the ACR pitch if it has not been dismissed.
-    if (!z.visitor.get('seen_acr_pitch') && $('body').hasClass('acr-pitch')) {
-        $delegate.find('#acr-pitch').show();
-    }
-
-    // Allow dismissal of site-balloons.
-    $delegate.on('click', '.site-balloon .close, .site-tip .close', _pd(function() {
-        var $parent = $(this).closest('.site-balloon, .site-tip');
-        $parent.fadeOut();
-        if ($parent.is('#site-nonfx')) {
-            z.visitor.set('seen_badbrowser_warning', 1);
-        } else if ($parent.is('#acr-pitch')) {
-            z.visitor.set('seen_acr_pitch', 1);
-        } else if ($parent.is('#appruntime-pitch')) {
-            z.visitor.set('seen_appruntime_pitch', 1);
-        }
-    }));
-}
 
 // AJAX form submit
 

--- a/static/js/zamboni/global.js
+++ b/static/js/zamboni/global.js
@@ -611,6 +611,6 @@ function getScrollbarWidth() {
 $(function() {
     "use strict";
 
-// Notification banners that go on every page.
+    // Notification banners that go on every page.
     initBanners();
 });

--- a/static/js/zamboni/global.js
+++ b/static/js/zamboni/global.js
@@ -574,7 +574,8 @@ $.fn.exists = function(callback, args){
 };
 
 // Bind to the mobile site if a mobile link is clicked.
-$(document).on('click', '.mobile-link', function() {
+$(document).on('click', '.mobile-link', function(e) {
+    e.preventDefault();
     $.cookie('mamo', 'on', {expires:30, path: '/'});
     window.location.reload();
 });
@@ -606,3 +607,10 @@ function getScrollbarWidth() {
 
     return widthNoScroll - widthWithScroll;
 }
+
+$(function() {
+    "use strict";
+
+// Notification banners that go on every page.
+    initBanners();
+});


### PR DESCRIPTION
The banner is behind a `try-new-frontend` waffle, which defaults to off for the moment.

A few yaks had to be shaved to achieve all this:
- The banner code was separated and called from `zamboni/global.js`, in order to be shown on non-impala pages (i.e. themes).
- The banner code was modified to try to only display one banner at a time.
- Because the banners were not shown in non-impala pages before, some tweaks to the layout css properties were made, to make sure the banner have the correct margin everywhere.
- The mobile site link handling code prevents default to avoid following a link to `#`.

Ref #6566