### PR TITLE
Readjust position of the "AMO is getting a new look" banner

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -85,6 +85,7 @@ body.restyle {
   font-style: normal;
   line-height: 1.5;
   min-width: @containerWidth;
+  overflow-x: hidden;
 }
 
 h1,
@@ -293,9 +294,6 @@ body:not(.home) .amo-header,
 .addon-details .header-bg,
 .home .header-bg {
   min-height: 130px;
-  // prevent margin collapsing, making sure notification area margins are
-  // respected:
-  border-bottom: 1px solid transparent;
 }
 
 .addon-details .header-bg {
@@ -611,9 +609,9 @@ body:not(.home) .amo-header,
   color: #fff;
   font-size: 17px;
   font-weight: bold;
-  line-height: 1.6;
+  line-height: 26px;
   margin: -12px 0 12px 0;  // header_bg has a 12px bottom margin.
-  padding: 24px 80px;
+  padding: 17px 80px;
 
   .close {
   }

--- a/static/js/zamboni/global.js
+++ b/static/js/zamboni/global.js
@@ -580,34 +580,6 @@ $(document).on('click', '.mobile-link', function(e) {
     window.location.reload();
 });
 
-// See: http://stackoverflow.com/questions/13382516/getting-scroll-bar-width-using-javascript
-// Used to remove the width of scrollbars from `.header-bg`
-
-function getScrollbarWidth() {
-    var outer = document.createElement('div');
-    outer.style.visibility = 'hidden';
-    outer.style.width = '100px';
-    outer.style.msOverflowStyle = 'scrollbar'; // needed for WinJS apps
-
-    document.body.appendChild(outer);
-
-    var widthNoScroll = outer.offsetWidth;
-    // force scrollbars
-    outer.style.overflow = 'scroll';
-
-    // add innerdiv
-    var inner = document.createElement('div');
-    inner.style.width = '100%';
-    outer.appendChild(inner);
-
-    var widthWithScroll = inner.offsetWidth;
-
-    // remove divs
-    outer.parentNode.removeChild(outer);
-
-    return widthNoScroll - widthWithScroll;
-}
-
 $(function() {
     "use strict";
 

--- a/static/js/zamboni/init.js
+++ b/static/js/zamboni/init.js
@@ -28,16 +28,6 @@ $(document).ready(function(){
             .before(gettext('This feature is temporarily disabled while we perform website maintenance. Please check back a little later.'))
             .find('input, button, select').prop('disabled', true).addClass('disabled');
     }
-
-    // Set the header background so width of scrollbars is removed from the
-    // 100vw width.
-    // See: https://github.com/mozilla/addons-server/issues/2161
-    if ($('body').hasClass('restyle')) {
-      var scrollbarWidthToRemove = getScrollbarWidth() / 2;
-      $('.header-bg,.restyle .previews').css({
-        width: 'calc(100vw - ' + scrollbarWidthToRemove + 'px)'
-      });
-    }
 });
 
 z.inlineSVG = (function() {


### PR DESCRIPTION
- `border-bottom` on `.amo_header` needs to go for the banner to be seamlessly displayed below
- scrollback hack is replaced with a `overflow-x: hidden` on the `body` because it causes a slight misalignment that is difficult to overcome without additional markup (which differs depending on which platform you're using, which does not help...)
- `padding`/`line-height` adjusted per mocks

Ref #6566 (addresses QA feedback)