### PR TITLE
Fix #6235 - Change default sorting to be Updated on 'developers/addons'

### DIFF
--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -68,8 +68,8 @@ MDN_BASE = 'https://developer.mozilla.org/en-US/Add-ons'
 
 
 class AddonFilter(BaseFilter):
-    opts = (('name', _(u'Name')),
-            ('updated', _(u'Updated')),
+    opts = (('updated', _(u'Updated')),
+            ('name', _(u'Name')),
             ('created', _(u'Created')),
             ('popular', _(u'Downloads')),
             ('rating', _(u'Rating')))
@@ -82,7 +82,7 @@ class ThemeFilter(BaseFilter):
             ('rating', _(u'Rating')))
 
 
-def addon_listing(request, default='name', theme=False):
+def addon_listing(request, default='updated', theme=False):
     """Set up the queryset and filtering for addon listing for Dashboard."""
     if theme:
         qs = request.user.addons.filter(type=amo.ADDON_PERSONA)

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -82,14 +82,17 @@ class ThemeFilter(BaseFilter):
             ('rating', _(u'Rating')))
 
 
-def addon_listing(request, default='updated', theme=False):
+def addon_listing(request, default='name', theme=False):
     """Set up the queryset and filtering for addon listing for Dashboard."""
     if theme:
         qs = request.user.addons.filter(type=amo.ADDON_PERSONA)
     else:
         qs = Addon.objects.filter(authors=request.user).exclude(
             type=amo.ADDON_PERSONA)
-    filter_cls = ThemeFilter if theme else AddonFilter
+    filter_cls = ThemeFilter
+    if not theme:
+        filter_cls = AddonFilter
+        default = 'updated'
     filter_ = filter_cls(request, qs, 'sort', default)
     return filter_.qs, filter_
 


### PR DESCRIPTION
Hi, 
This fixes #6235.

I'm not sure changing the order of updated and name in opts was necassary, but I still did it.
Will change it if comes in review.

Thanks,