### PR TITLE
Fix #5809 - Empty "Name" field inside "Reviewer Leaderboard"

### DIFF
--- a/src/olympia/editors/models.py
+++ b/src/olympia/editors/models.py
@@ -716,6 +716,9 @@ class ReviewerScore(ModelBase):
 
         for row in query:
             user_id, name, total = row
+            if not name:
+                name = cls.objects.values_list('user__username', flat=True).get(user__id=user_id)
+
             user_level = len(amo.REVIEWED_LEVELS) - 1
             for i, level in enumerate(amo.REVIEWED_LEVELS):
                 if total < level['points']:


### PR DESCRIPTION
Hi, 
This fixes #5809.

I have already fixed this type of issue twice before.

Solution: If the display name is empty then default it to the username.

Work Around:
Although, those two time, updating the Jinja template worked, because the query object returning from `models.py` and returned to the template.html does contained username and display both. 
But here, Only display name is being returned, so I have to make changes into `models.py`.

Please see if its the correct way or not.
Also, I wasn't able to run tests locally because of some fixtures error. So waiting for TravisCli tests results.

Thanks