### PR TITLE
Change order and link in Tools section of Dev Hub footer

### DIFF
--- a/src/olympia/devhub/templates/devhub/new-landing/components/footer.html
+++ b/src/olympia/devhub/templates/devhub/new-landing/components/footer.html
@@ -36,9 +36,9 @@
       <section class="DevHub-Footer-section">
         <h4>{{ _('Tools') }}</h4>
         <ul>
+          <li><a href="https://github.com/mozilla/web-ext">{{ _('Web-Ext: build & test extensions') }}</a></li>
           <li><a href="{{ url('devhub.validate_addon') }}">{{ _('Add-on Validator') }}</a></li>
           <li><a href="{{ url('devhub.check_addon_compatibility') }}">{{ _('Compatibility Checker') }}</a></li>
-          <li><a href="https://addons.mozilla.org/firefox/addon/add-on-compatibility-reporter/">{{ _('Compatibility Reporter') }}</a></li>
           <li><a href="{{ url('devhub.api_key') }}">{{ _('Manage API Keys') }}</a></li>
         </ul>
       </section>


### PR DESCRIPTION
Fixes #6721 
Before----
![developer hub add ons for firefox](https://user-images.githubusercontent.com/21103831/31897442-08514374-b834-11e7-90e6-e90f4210529d.png)
After----
![developer hub add ons for firefox 1](https://user-images.githubusercontent.com/21103831/31897456-10d10624-b834-11e7-93ce-ce024443165f.png)

@atsay How does it look?
