### PR TITLE
attempt to fix UserProfile.is_public not being set with auto-approval

### DIFF
--- a/src/olympia/users/admin.py
+++ b/src/olympia/users/admin.py
@@ -23,7 +23,7 @@ class UserAdmin(admin.ModelAdmin):
         }),
         ('Flags', {
             'fields': ('deleted', 'display_collections',
-                       'display_collections_fav',
+                       'display_collections_fav', 'is_public',
                        'notifycompat', 'notifyevents'),
         }),
         ('Admin', {

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -293,10 +293,13 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
             self.addonuser_set.filter(
                 role__in=[amo.AUTHOR_ROLE_OWNER, amo.AUTHOR_ROLE_DEV],
                 listed=True,
-                addon__status=amo.STATUS_PUBLIC).exists())
-        log.info('Updating %s.is_public from %s to %s' % (
-            self.pk, pre, is_public))
-        self.update(is_public=is_public)
+                addon__status=amo.STATUS_PUBLIC).no_cache().exists())
+        if is_public != pre:
+            log.info('Updating %s.is_public from %s to %s' % (
+                self.pk, pre, is_public))
+            self.update(is_public=is_public)
+        else:
+            log.info('Not changing %s.is_public from %s' % (self.pk, pre))
 
     @property
     def name(self):


### PR DESCRIPTION
fixes #6726, probably (couldn't replicate locally)

Easiest fix for existing account profiles is probably just to have ops run https://github.com/mozilla/addons-server/pull/6219/files#diff-3247eb98d18088454da58e94c7100d68R9 again