### PR TITLE
Drop obsolete columns from autoapprovalsummary table

### DIFF
--- a/src/olympia/migrations/983-drop-obsolete-autoapprovalsummary-columns.sql
+++ b/src/olympia/migrations/983-drop-obsolete-autoapprovalsummary-columns.sql
@@ -1,0 +1,8 @@
+ALTER TABLE `editors_autoapprovalsummary`
+    DROP COLUMN `uses_custom_csp`,
+    DROP COLUMN `uses_native_messaging`,
+    DROP COLUMN `uses_content_script_for_all_urls`,
+    DROP COLUMN `average_daily_users`,
+    DROP COLUMN `approved_updates`,
+    DROP COLUMN `has_info_request`,
+    DROP COLUMN `is_under_admin_review`;


### PR DESCRIPTION
The model fields were removed in a previous push and the db columns made nullable so they are now safe to drop.

Fix #6807