### PR TITLE
Return full compatibility info for NO_COMPAT add-ons in the API

### DIFF
--- a/services/update.py
+++ b/services/update.py
@@ -220,10 +220,10 @@ class Update(object):
             """)
             # Filter out versions that don't have the minimum maxVersion
             # requirement to qualify for default-to-compatible.
-            d2c_max = applications.D2C_MAX_VERSIONS.get(data['app_id'])
-            if d2c_max:
-                data['d2c_max_version'] = version_int(d2c_max)
-                sql.append("AND appmax.version_int >= %(d2c_max_version)s ")
+            d2c_min = applications.D2C_MIN_VERSIONS.get(data['app_id'])
+            if d2c_min:
+                data['d2c_min_version'] = version_int(d2c_min)
+                sql.append("AND appmax.version_int >= %(d2c_min_version)s ")
 
             # Filter out versions found in compat overrides
             sql.append("""AND

--- a/src/olympia/addons/forms.py
+++ b/src/olympia/addons/forms.py
@@ -250,13 +250,11 @@ class BaseCategoryFormSet(BaseFormSet):
         self.request = kw.pop('request', None)
         super(BaseCategoryFormSet, self).__init__(*args, **kw)
         self.initial = []
-        apps = sorted(self.addon.compatible_apps.keys(),
-                      key=lambda x: x.id)
+        apps = sorted(self.addon.compatible_apps.keys(), key=lambda x: x.id)
 
         # Drop any apps that don't have appropriate categories.
         qs = Category.objects.filter(type=self.addon.type)
-        app_cats = dict((k, list(v)) for k, v in
-                        sorted_groupby(qs, 'application'))
+        app_cats = {k: list(v) for k, v in sorted_groupby(qs, 'application')}
         for app in list(apps):
             if app and not app_cats.get(app.id):
                 apps.remove(app)

--- a/src/olympia/addons/indexers.py
+++ b/src/olympia/addons/indexers.py
@@ -252,7 +252,8 @@ class AddonIndexer(BaseSearchIndexer):
                 # want to reindex every time a new version of the app is
                 # released, so we directly index a super high version as the
                 # max.
-                min_human, max_human = '1.0', '9999'
+                min_human, max_human = amo.D2C_MIN_VERSIONS.get(
+                    app.id, '1.0'), amo.FAKE_MAX_VERSION,
                 min_, max_ = version_int(min_human), version_int(max_human)
             compatible_apps[app.id] = {
                 'min': min_, 'min_human': min_human,

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1230,10 +1230,6 @@ class Addon(OnChangeMixin, ModelBase):
     @cached_property
     def compatible_apps(self):
         """Shortcut to get compatible apps for the current version."""
-        # Search providers and personas don't list their supported apps.
-        if self.type in amo.NO_COMPAT:
-            return dict((app, None) for app in
-                        amo.APP_TYPE_SUPPORT[self.type])
         if self.current_version:
             return self.current_version.compatible_apps
         else:

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -152,8 +152,9 @@ class SimpleVersionSerializer(serializers.ModelSerializer):
     def get_compatibility(self, obj):
         return {
             app.short: {
-                'min': compat.min.version if compat else '1.0',
-                'max': compat.max.version if compat else '9999'
+                'min': compat.min.version if compat else (
+                    amo.D2C_MIN_VERSIONS.get(app.id, '1.0')),
+                'max': compat.max.version if compat else amo.FAKE_MAX_VERSION
             } for app, compat in obj.compatible_apps.items()
         }
 

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -150,11 +150,12 @@ class SimpleVersionSerializer(serializers.ModelSerializer):
             'versions.edit', args=[obj.pk], prefix_only=True))
 
     def get_compatibility(self, obj):
-        if obj.addon.type in amo.NO_COMPAT:
-            return {}
-        return {app.short: {'min': compat.min.version,
-                            'max': compat.max.version}
-                for app, compat in obj.compatible_apps.items()}
+        return {
+            app.short: {
+                'min': compat.min.version if compat else '1.0',
+                'max': compat.max.version if compat else '9999'
+            } for app, compat in obj.compatible_apps.items()
+        }
 
     def get_is_strict_compatibility_enabled(self, obj):
         return any(file_.strict_compatibility for file_ in obj.all_files)
@@ -439,7 +440,7 @@ class ESAddonSerializer(BaseESSerializer, AddonSerializer):
                 compatible_apps[app_name] = ApplicationsVersions(
                     min=AppVersion(version=compat_dict.get('min_human', '')),
                     max=AppVersion(version=compat_dict.get('max_human', '')))
-            version.compatible_apps = compatible_apps
+            version._compatible_apps = compatible_apps
         else:
             version = None
         return version

--- a/src/olympia/addons/tests/test_forms.py
+++ b/src/olympia/addons/tests/test_forms.py
@@ -9,7 +9,7 @@ from django.core.files.storage import default_storage as storage
 from django.test.client import RequestFactory
 
 from olympia import amo, core
-from olympia.amo.tests import TestCase, req_factory_factory
+from olympia.amo.tests import addon_factory, TestCase, req_factory_factory
 from olympia.amo.tests.test_helpers import get_image_path
 from olympia.amo.utils import rm_local_tmp_dir
 from olympia.addons import forms
@@ -287,7 +287,7 @@ class TestCategoryForm(TestCase):
     def test_no_possible_categories(self):
         Category.objects.create(type=amo.ADDON_SEARCH,
                                 application=amo.FIREFOX.id)
-        addon = Addon.objects.create(type=amo.ADDON_SEARCH)
+        addon = addon_factory(type=amo.ADDON_SEARCH)
         request = req_factory_factory('/')
         form = forms.CategoryFormSet(addon=addon, request=request)
         apps = [f.app for f in form.forms]

--- a/src/olympia/addons/tests/test_indexers.py
+++ b/src/olympia/addons/tests/test_indexers.py
@@ -486,9 +486,9 @@ class TestAddonIndexer(TestCase):
         assert extracted['platforms'] == [amo.PLATFORM_ALL.id]
         expected_version_compat = {
             'max': 9999000000200100,
-            'max_human': None,
-            'min': 0,
-            'min_human': None
+            'max_human': '9999',
+            'min': 1000000200100,
+            'min_human': '1.0',
         }
         assert extracted['current_version']['compatible_apps'] == {
             amo.ANDROID.id: expected_version_compat,

--- a/src/olympia/addons/tests/test_indexers.py
+++ b/src/olympia/addons/tests/test_indexers.py
@@ -482,19 +482,33 @@ class TestAddonIndexer(TestCase):
         assert extracted['persona']['textcolor'] == persona.textcolor
 
         # Personas are always considered compatible with every platform, and
-        # all versions of all apps.
+        # almost all versions of all apps.
         assert extracted['platforms'] == [amo.PLATFORM_ALL.id]
-        expected_version_compat = {
-            'max': 9999000000200100,
-            'max_human': '9999',
-            'min': 1000000200100,
-            'min_human': '1.0',
-        }
         assert extracted['current_version']['compatible_apps'] == {
-            amo.ANDROID.id: expected_version_compat,
-            amo.FIREFOX.id: expected_version_compat,
-            amo.THUNDERBIRD.id: expected_version_compat,
-            amo.SEAMONKEY.id: expected_version_compat,
+            amo.ANDROID.id: {
+                'max': 9999000000200100,
+                'max_human': '9999',
+                'min': 11000000200100,
+                'min_human': '11.0',
+            },
+            amo.FIREFOX.id: {
+                'max': 9999000000200100,
+                'max_human': '9999',
+                'min': 4000000200100,
+                'min_human': '4.0',
+            },
+            amo.THUNDERBIRD.id: {
+                'max': 9999000000200100,
+                'max_human': '9999',
+                'min': 5000000200100,
+                'min_human': '5.0',
+            },
+            amo.SEAMONKEY.id: {
+                'max': 9999000000200100,
+                'max_human': '9999',
+                'min': 2010000200100,
+                'min_human': '2.1',
+            },
         }
         self.addon = addon_factory(persona_id=0, type=amo.ADDON_PERSONA)
         extracted = self._extract()

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -565,9 +565,9 @@ class AddonSerializerOutputTestMixin(object):
             min=av_min, max=av_max)
         result_version = self.serialize()['current_version']
         assert result_version['compatibility'] == {
-            'android': {'max': '9999', 'min': '1.0'},
-            'firefox': {'max': '9999', 'min': '1.0'},
-            'seamonkey': {'max': '9999', 'min': '1.0'},
+            'android': {'max': '9999', 'min': '11.0'},
+            'firefox': {'max': '9999', 'min': '4.0'},
+            'seamonkey': {'max': '9999', 'min': '2.1'},
             # No thunderbird: it does not support that type, and when we return
             # fake compatibility data for NO_COMPAT add-ons we do obey that.
         }

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -171,7 +171,7 @@ class AddonSerializerOutputTestMixin(object):
             application=amo.THUNDERBIRD.id, version=self.addon.current_version,
             min=av_min, max=av_max)
         # Reset current_version.compatible_apps now that we've added an app.
-        del self.addon.current_version.compatible_apps
+        del self.addon.current_version._compatible_apps
 
         cat2 = Category.from_static_category(
             CATEGORIES[amo.FIREFOX.id][amo.ADDON_EXTENSION]['alerts-updates'])
@@ -553,8 +553,8 @@ class AddonSerializerOutputTestMixin(object):
         assert result_version['compatibility'] == {}
         assert result_version['is_strict_compatibility_enabled'] is False
 
-        # Test an add-on with some compatibility info but which should not have
-        # any because its type is in NO_COMPAT.
+        # Test an add-on with some compatibility info but that should be
+        # ignored because its type is in NO_COMPAT.
         self.addon = addon_factory(type=amo.ADDON_SEARCH)
         av_min = AppVersion.objects.get_or_create(
             application=amo.THUNDERBIRD.id, version='2.0.99')[0]
@@ -564,7 +564,13 @@ class AddonSerializerOutputTestMixin(object):
             application=amo.THUNDERBIRD.id, version=self.addon.current_version,
             min=av_min, max=av_max)
         result_version = self.serialize()['current_version']
-        assert result_version['compatibility'] == {}
+        assert result_version['compatibility'] == {
+            'android': {'max': '9999', 'min': '1.0'},
+            'firefox': {'max': '9999', 'min': '1.0'},
+            'seamonkey': {'max': '9999', 'min': '1.0'},
+            # No thunderbird: it does not support that type, and when we return
+            # fake compatibility data for NO_COMPAT add-ons we do obey that.
+        }
         assert result_version['is_strict_compatibility_enabled'] is False
 
 

--- a/src/olympia/constants/applications.py
+++ b/src/olympia/constants/applications.py
@@ -171,11 +171,15 @@ for _app in APP_USAGE:
     for _type in _app.types:
         APP_TYPE_SUPPORT.setdefault(_type, []).append(_app)
 
+# Fake max version for when we want max compatibility
+FAKE_MAX_VERSION = '9999'
+
 # The lowest maxVersion an app has to support to allow default-to-compatible.
 D2C_MIN_VERSIONS = {
     FIREFOX.id: '4.0',
     SEAMONKEY.id: '2.1',
     THUNDERBIRD.id: '5.0',
+    ANDROID.id: '11.0',
 }
 
 for _app in APPS_ALL.values():

--- a/src/olympia/constants/applications.py
+++ b/src/olympia/constants/applications.py
@@ -172,7 +172,7 @@ for _app in APP_USAGE:
         APP_TYPE_SUPPORT.setdefault(_type, []).append(_app)
 
 # The lowest maxVersion an app has to support to allow default-to-compatible.
-D2C_MAX_VERSIONS = {
+D2C_MIN_VERSIONS = {
     FIREFOX.id: '4.0',
     SEAMONKEY.id: '2.1',
     THUNDERBIRD.id: '5.0',

--- a/src/olympia/files/models.py
+++ b/src/olympia/files/models.py
@@ -252,7 +252,7 @@ class File(OnChangeMixin, ModelBase):
         parts.append(name)
         parts.append(self.version.version)
 
-        if self.version.compatible_apps:
+        if addon.type not in amo.NO_COMPAT and self.version.compatible_apps:
             apps = '+'.join(sorted([a.shortername for a in
                                     self.version.compatible_apps]))
             parts.append(apps)

--- a/src/olympia/files/tests/test_models.py
+++ b/src/olympia/files/tests/test_models.py
@@ -237,7 +237,7 @@ class TestFile(TestCase, amo.tests.AMOPaths):
 
     def test_generate_filename_many_apps(self):
         f = File.objects.get(id=67442)
-        f.version.compatible_apps = (amo.THUNDERBIRD, amo.FIREFOX)
+        f.version._compatible_apps = {amo.THUNDERBIRD: None, amo.FIREFOX: None}
         # After adding sorting for compatible_apps, above becomes
         # (amo.FIREFOX, amo.THUNDERBIRD) so 'fx+tb' is appended to filename
         # instead of 'tb+fx'
@@ -247,7 +247,7 @@ class TestFile(TestCase, amo.tests.AMOPaths):
     def test_generate_filename_ja(self):
         f = File()
         f.version = Version(version='0.1.7')
-        f.version.compatible_apps = (amo.FIREFOX,)
+        f.version._compatible_apps = {amo.FIREFOX: None}
         f.version.addon = Addon(name=u' フォクすけ  といっしょ')
         assert f.generate_filename() == 'addon-0.1.7-fx.xpi'
 

--- a/src/olympia/legacy_api/utils.py
+++ b/src/olympia/legacy_api/utils.py
@@ -241,7 +241,7 @@ def find_compatible_version(addon, app_id, app_version=None, platform=None,
         """)
         # Filter out versions that don't have the minimum maxVersion
         # requirement to qualify for default-to-compatible.
-        d2c_max = amo.D2C_MAX_VERSIONS.get(app_id)
+        d2c_max = amo.D2C_MIN_VERSIONS.get(app_id)
         if d2c_max:
             data['d2c_max_version'] = version_int(d2c_max)
             raw_sql.append(

--- a/src/olympia/legacy_api/utils.py
+++ b/src/olympia/legacy_api/utils.py
@@ -19,7 +19,7 @@ log = olympia.core.logger.getLogger('z.api')
 
 def addon_to_dict(addon, disco=False, src='api'):
     """
-    Renders an addon in JSON for the API.
+    Renders an addon into a dict for the legacy API.
     """
     def url(u, **kwargs):
         return settings.SITE_URL + urlparams(u, **kwargs)
@@ -62,10 +62,11 @@ def addon_to_dict(addon, disco=False, src='api'):
     if v:
         d['version'] = v.version
         d['platforms'] = [unicode(a.name) for a in v.supported_platforms]
-        d['compatible_apps'] = [
-            {unicode(amo.APP_IDS[obj.application].pretty): {
-                'min': unicode(obj.min), 'max': unicode(obj.max)}}
-            for obj in v.compatible_apps.values()]
+        d['compatible_apps'] = [{
+            unicode(amo.APP_IDS[obj.application].pretty): {
+                'min': unicode(obj.min) if obj else '1.0',
+                'max': unicode(obj.max) if obj else '9999',
+            }} for obj in v.compatible_apps.values() if obj]
     if addon.eula:
         d['eula'] = unicode(addon.eula)
 

--- a/src/olympia/legacy_api/utils.py
+++ b/src/olympia/legacy_api/utils.py
@@ -63,10 +63,11 @@ def addon_to_dict(addon, disco=False, src='api'):
         d['version'] = v.version
         d['platforms'] = [unicode(a.name) for a in v.supported_platforms]
         d['compatible_apps'] = [{
-            unicode(amo.APP_IDS[obj.application].pretty): {
-                'min': unicode(obj.min) if obj else '1.0',
-                'max': unicode(obj.max) if obj else '9999',
-            }} for obj in v.compatible_apps.values() if obj]
+            unicode(amo.APP_IDS[appver.application].pretty): {
+                'min': unicode(appver.min) if appver else (
+                    amo.D2C_MIN_VERSIONS.get(app.id, '1.0')),
+                'max': unicode(appver.max) if appver else amo.FAKE_MAX_VERSION,
+            }} for app, appver in v.compatible_apps.items() if appver]
     if addon.eula:
         d['eula'] = unicode(addon.eula)
 

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -179,7 +179,7 @@ class Version(OnChangeMixin, ModelBase):
         # fetching the ApplicationsVersions that were just created. To work
         # around this we pre-generate version.compatible_apps and avoid the
         # queries completely.
-        version.compatible_apps = compatible_apps
+        version._compatible_apps = compatible_apps
 
         if addon.type in [amo.ADDON_SEARCH, amo.ADDON_STATICTHEME]:
             # Search extensions and static themes are always for all platforms.
@@ -320,8 +320,19 @@ class Version(OnChangeMixin, ModelBase):
               .select_related('activity_log', 'version').no_cache())
         return al
 
-    @cached_property
+    @property
     def compatible_apps(self):
+        # Dicts, search providers and personas don't have compatibility info.
+        # Fake one for them.
+        if self.addon and self.addon.type in amo.NO_COMPAT:
+            return {app: None for app in amo.APP_TYPE_SUPPORT[self.addon.type]}
+        # Otherwise, return _compatible_apps which is a cached property that
+        # is filled by the transformer, or simply calculated from the related
+        # compat instances.
+        return self._compatible_apps
+
+    @cached_property
+    def _compatible_apps(self):
         """Get a mapping of {APP: ApplicationsVersions}."""
         avs = self.apps.select_related('version')
         return self._compat_map(avs)
@@ -355,6 +366,8 @@ class Version(OnChangeMixin, ModelBase):
 
     def is_compatible_app(self, app):
         """Returns True if the provided app passes compatibility conditions."""
+        if self.addon.type in amo.NO_COMPAT:
+            return True
         appversion = self.compatible_apps.get(app)
         if appversion and app.id in amo.D2C_MAX_VERSIONS:
             return (version_int(appversion.max.version) >=
@@ -513,7 +526,7 @@ class Version(OnChangeMixin, ModelBase):
 
         for version in versions:
             v_id = version.id
-            version.compatible_apps = cls._compat_map(av_dict.get(v_id, []))
+            version._compatible_apps = cls._compat_map(av_dict.get(v_id, []))
             version.all_files = file_dict.get(v_id, [])
             for f in version.all_files:
                 f.version = version

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -369,9 +369,9 @@ class Version(OnChangeMixin, ModelBase):
         if self.addon.type in amo.NO_COMPAT:
             return True
         appversion = self.compatible_apps.get(app)
-        if appversion and app.id in amo.D2C_MAX_VERSIONS:
+        if appversion and app.id in amo.D2C_MIN_VERSIONS:
             return (version_int(appversion.max.version) >=
-                    version_int(amo.D2C_MAX_VERSIONS.get(app.id, '*')))
+                    version_int(amo.D2C_MIN_VERSIONS.get(app.id, '*')))
         return False
 
     def compat_override_app_versions(self):


### PR DESCRIPTION
Before, we were returning `{}`, now we're returning `{'min': 1.0, 'max': 9999}` for each app relevant to the add-on type.

Fix #6781