### PR TITLE
Add django-post-request-task

### DIFF
--- a/src/olympia/amo/celery.py
+++ b/src/olympia/amo/celery.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 
 import datetime
 
+import waffle
 from django.conf import settings
 from django.core.cache import cache
 
@@ -13,6 +14,7 @@ from celery.signals import task_failure, task_postrun, task_prerun
 from django_statsd.clients import statsd
 from raven import Client
 from raven.contrib.celery import register_signal, register_logger_signal
+from post_request_task.task import PostRequestTask
 
 import olympia.core.logger
 from olympia.amo.utils import chunked, utc_millesecs_from_epoch
@@ -21,7 +23,20 @@ from olympia.amo.utils import chunked, utc_millesecs_from_epoch
 log = olympia.core.logger.getLogger('z.task')
 
 
-app = Celery('olympia')
+
+class WaffleablePostRequestTask(PostRequestTask):
+    """Same as `PostRequestTask` only that this listens for a waffle-flag."""
+    abstract = True
+
+    def apply_async(self, args=None, kwargs=None, **extrakw):
+        if waffle.switch_is_active('activate-django-post-request'):
+            return super(WaffleablePostRequestTask, self).apply_async(
+                args, kwargs, **extrakw)
+
+        return self.original_apply_async(args=args, kwargs=kwargs, **extrakw)
+
+
+app = Celery('olympia', task_cls=WaffleablePostRequestTask)
 task = app.task
 
 app.config_from_object('django.conf:settings', namespace='CELERY')

--- a/src/olympia/amo/celery.py
+++ b/src/olympia/amo/celery.py
@@ -23,7 +23,6 @@ from olympia.amo.utils import chunked, utc_millesecs_from_epoch
 log = olympia.core.logger.getLogger('z.task')
 
 
-
 class WaffleablePostRequestTask(PostRequestTask):
     """Same as `PostRequestTask` only that this listens for a waffle-flag."""
     abstract = True

--- a/src/olympia/amo/tests/test_celery.py
+++ b/src/olympia/amo/tests/test_celery.py
@@ -6,6 +6,8 @@ import mock
 from django.core.signals import request_finished, request_started
 from django.test.testcases import TransactionTestCase
 from waffle.models import Switch
+from post_request_task.task import (
+    _discard_tasks, _stop_queuing_tasks)
 
 from olympia.amo.tests import TestCase, create_switch
 from olympia.amo.celery import task
@@ -70,6 +72,12 @@ class TestTaskQueued(TransactionTestCase):
         super(TestTaskQueued, self).setUp()
         create_switch('activate-django-post-request')
         fake_task_func.reset_mock()
+        _discard_tasks()
+
+    def tearDown(self):
+        fake_task_func.reset_mock()
+        _discard_tasks()
+        _stop_queuing_tasks()
 
     def test_not_queued_outside_request_response_cycle(self):
         fake_task.delay()

--- a/src/olympia/amo/tests/test_cron.py
+++ b/src/olympia/amo/tests/test_cron.py
@@ -1,14 +1,11 @@
 import datetime
 from datetime import timedelta
 
-from django.core.signals import request_finished, request_started
-
 import mock
-import pytest
 
 from olympia.amo.cron import gc
 from olympia.amo.tests import TestCase
-from olympia.amo.celery import app, task
+from olympia.amo.celery import task
 from olympia.amo.utils import utc_millesecs_from_epoch
 from olympia.files.models import FileUpload
 

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -679,16 +679,16 @@ def _compat_result(request, revalidate_url, target_app, target_version,
 def json_file_validation(request, addon_id, addon, file_id):
     file = get_object_or_404(File, id=file_id)
     try:
-        v_result = file.validation
+        result = file.validation
     except FileValidation.DoesNotExist:
         if request.method != 'POST':
             return http.HttpResponseNotAllowed(['POST'])
 
         # This API is, unfortunately, synchronous, so wait for the
         # task to complete and return the result directly.
-        v_result = tasks.validate(file).get()
+        result = tasks.validate(file, synchronous=True).get()
 
-    return {'validation': v_result.processed_validation, 'error': None}
+    return {'validation': result.processed_validation, 'error': None}
 
 
 @json_view

--- a/src/olympia/migrations/984-add-activate-django-post-request-waffle-switch.sql
+++ b/src/olympia/migrations/984-add-activate-django-post-request-waffle-switch.sql
@@ -1,0 +1,1 @@
+INSERT INTO waffle_switch (name, active, created, modified, note) VALUES ('activate-django-post-request', 0, NOW(), NOW(), 'Activate django-post-request-task') ON DUPLICATE KEY UPDATE active = 0;


### PR DESCRIPTION
Fixes #5999 

Adds django-post-request-task in a waffle-able fashion and fixes issues with synchronous task calls.

Todos:

* [x] Figure out if we have any other sync task calls hidden somewhere
* [x] Add tests for new waffle flag
* [x] Add migration for waffle flag