### PR TITLE
Show confirmed state in review page listing headers

### DIFF
--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -68,6 +68,10 @@
             {% trans version = version.version, created = version.created|date, version_status = version_status(addon, version) %}
             Version {{ version }} &middot; {{ created }} <span class="light">&middot; {{ version_status }}</span>
             {% endtrans %}
+
+            {% if version.autoapprovalsummary and version.autoapprovalsummary.confirmed %}
+            <span class="light">{{ _("(Confirmed)") }}</span>
+            {% endif %}
           </th>
         </tr>
         <tr class="listing-body">


### PR DESCRIPTION
It would be nice to show the auto approval confirmed state in the review page listing headers, as otherwise with them collapsed it is impossible to differentiate if they are confirmed or not.

If you want to save strings, I could also re-use "Auto-Approval confirmed".

/cc @wagnerand 

<img width="817" alt="image" src="https://user-images.githubusercontent.com/607198/32452645-671dc6b6-c31a-11e7-9468-468ae3001996.png">
(ignore that error, seems unrelated)