### PR TITLE
filter out deleted and non-public add-ons by default from collection addon list api

### DIFF
--- a/docs/topics/api/collections.rst
+++ b/docs/topics/api/collections.rst
@@ -161,14 +161,14 @@ The default sorting is by popularity, descending ('-popularity').
    (excluding add-ons that have no approved listed versions, are disabled or
    deleted) - you can change that with the ``filter`` query parameter:
 
-    ====================  =====================================================
-                   Value  Description
-    ====================  =====================================================
-            with_deleted  Show all add-ons in the collection, regardless of
-                          state.
-             with_hidden  Show addons that have non-public statuses, but still
-                          exclude deleted add-ons.
-    ====================  =====================================================
+    =======================  ==================================================
+                      Value  Description
+    =======================  ==================================================
+                with_hidden  Show addons that have non-public statuses, but
+                             still exclude deleted add-ons.
+    with_hidden_and_deleted  Show all add-ons in the collection, regardless of
+                             state.
+    =======================  ==================================================
 
 
 -------------------------

--- a/docs/topics/api/collections.rst
+++ b/docs/topics/api/collections.rst
@@ -131,6 +131,7 @@ This endpoint lists the add-ons in a collection, together with collector's notes
 
 .. http:get:: /api/v3/accounts/account/(int:user_id|string:username)/collections/(string:collection_slug)/addons/
 
+    :query string filter: The :ref:`filter <collection-addon-filtering-param>` to apply.
     :query string sort: The sort parameter. The available parameters are documented in the :ref:`table below <collection-addon-list-sort>`.
     :>json int count: The number of results for this query.
     :>json string next: The URL of the next page of results.
@@ -152,6 +153,22 @@ This endpoint lists the add-ons in a collection, together with collector's notes
 
 All sort parameters can be reversed, e.g. '-added' for descending dates.
 The default sorting is by popularity, descending ('-popularity').
+
+
+.. _collection-addon-filtering-param:
+
+   By default, the collection addon list API will only return public add-ons
+   (excluding add-ons that have no approved listed versions, are disabled or
+   deleted) - you can change that with the ``filter`` query parameter:
+
+    ====================  =====================================================
+                   Value  Description
+    ====================  =====================================================
+            with_deleted  Show all add-ons in the collection, regardless of
+                          state.
+             with_hidden  Show addons that have non-public statuses, but still
+                          exclude deleted add-ons.
+    ====================  =====================================================
 
 
 -------------------------

--- a/docs/topics/api/collections.rst
+++ b/docs/topics/api/collections.rst
@@ -161,14 +161,15 @@ The default sorting is by popularity, descending ('-popularity').
    (excluding add-ons that have no approved listed versions, are disabled or
    deleted) - you can change that with the ``filter`` query parameter:
 
-    =======================  ==================================================
-                      Value  Description
-    =======================  ==================================================
-                with_hidden  Show addons that have non-public statuses, but
-                             still exclude deleted add-ons.
-    with_hidden_and_deleted  Show all add-ons in the collection, regardless of
-                             state.
-    =======================  ==================================================
+    ================  ========================================================
+               Value  Description
+    ================  ========================================================
+                 all  Show all add-ons in the collection, including those that
+                      have non-public statuses.  This still excludes deleted
+                      add-ons.
+    all_with_deleted  Show all add-ons in the collection, including deleted
+                      add-ons too.
+    ================  ========================================================
 
 
 -------------------------

--- a/src/olympia/bandwagon/tests/test_views.py
+++ b/src/olympia/bandwagon/tests/test_views.py
@@ -1834,7 +1834,7 @@ class TestCollectionAddonViewSetList(CollectionAddonViewSetMixin, TestCase):
         # Now there should be 2 extra
         assert len(response.data['results']) == 5
 
-        response = self.send(self.url + '?filter=with_deleted')
+        response = self.send(self.url + '?filter=with_hidden_and_deleted')
         assert response.status_code == 200
         # And one more still - with_deleted gets you with_hidden too.
         assert len(response.data['results']) == 6

--- a/src/olympia/bandwagon/tests/test_views.py
+++ b/src/olympia/bandwagon/tests/test_views.py
@@ -1829,15 +1829,22 @@ class TestCollectionAddonViewSetList(CollectionAddonViewSetMixin, TestCase):
         # Normal
         assert len(response.data['results']) == 3
 
-        response = self.send(self.url + '?filter=with_hidden')
+        response = self.send(self.url + '?filter=all')
         assert response.status_code == 200
         # Now there should be 2 extra
         assert len(response.data['results']) == 5
 
-        response = self.send(self.url + '?filter=with_hidden_and_deleted')
+        response = self.send(self.url + '?filter=all_with_deleted')
         assert response.status_code == 200
         # And one more still - with_deleted gets you with_hidden too.
         assert len(response.data['results']) == 6
+        all_addons_ids = {
+            self.addon_a.id, self.addon_b.id, self.addon_c.id,
+            self.addon_disabled.id, self.addon_deleted.id,
+            self.addon_pending.id}
+        result_ids = {
+            result['addon']['id'] for result in response.data['results']}
+        assert all_addons_ids == result_ids
 
 
 class TestCollectionAddonViewSetDetail(CollectionAddonViewSetMixin, TestCase):

--- a/src/olympia/bandwagon/views.py
+++ b/src/olympia/bandwagon/views.py
@@ -710,5 +710,17 @@ class CollectionAddonViewSet(ModelViewSet):
         return super(CollectionAddonViewSet, self).get_object()
 
     def get_queryset(self):
-        return CollectionAddon.objects.filter(
+        qs = CollectionAddon.objects.filter(
             collection=self.get_collection_viewset().get_object())
+        filter_param = self.request.GET.get('filter')
+        # We only filter list action.
+        include_deleted = (filter_param == 'with_deleted' or
+                           self.action != 'list')
+        # If deleted addons are requested, that implies hidden addons.
+        include_hidden = filter_param == 'with_hidden' or include_deleted
+        if not include_hidden:
+            qs = qs.filter(
+                addon__status=amo.STATUS_PUBLIC, addon__disabled_by_user=False)
+        elif not include_deleted:
+            qs = qs.exclude(addon__status=amo.STATUS_DELETED)
+        return qs

--- a/src/olympia/bandwagon/views.py
+++ b/src/olympia/bandwagon/views.py
@@ -714,7 +714,7 @@ class CollectionAddonViewSet(ModelViewSet):
             collection=self.get_collection_viewset().get_object())
         filter_param = self.request.GET.get('filter')
         # We only filter list action.
-        include_deleted = (filter_param == 'with_deleted' or
+        include_deleted = (filter_param == 'with_hidden_and_deleted' or
                            self.action != 'list')
         # If deleted addons are requested, that implies hidden addons.
         include_hidden = filter_param == 'with_hidden' or include_deleted

--- a/src/olympia/bandwagon/views.py
+++ b/src/olympia/bandwagon/views.py
@@ -714,13 +714,13 @@ class CollectionAddonViewSet(ModelViewSet):
             collection=self.get_collection_viewset().get_object())
         filter_param = self.request.GET.get('filter')
         # We only filter list action.
-        include_deleted = (filter_param == 'with_hidden_and_deleted' or
-                           self.action != 'list')
-        # If deleted addons are requested, that implies hidden addons.
-        include_hidden = filter_param == 'with_hidden' or include_deleted
-        if not include_hidden:
+        include_all_with_deleted = (filter_param == 'all_with_deleted' or
+                                    self.action != 'list')
+        # If deleted addons are requested, that implies all addons.
+        include_all = filter_param == 'all' or include_all_with_deleted
+        if not include_all:
             qs = qs.filter(
                 addon__status=amo.STATUS_PUBLIC, addon__disabled_by_user=False)
-        elif not include_deleted:
+        elif not include_all_with_deleted:
             qs = qs.exclude(addon__status=amo.STATUS_DELETED)
         return qs


### PR DESCRIPTION
+ add filters to include them.

Fixes #6845 

Tbh, not 100% on the filter names.