### PR TITLE
Redirect new-style type params to old-style type params in search

### DIFF
--- a/src/olympia/search/tests/test_views.py
+++ b/src/olympia/search/tests/test_views.py
@@ -179,9 +179,14 @@ class TestESSearch(SearchBase):
     def test_results_sort_name(self):
         self.check_sort_links('name', 'Name', 'name', reverse=False)
 
+    def test_new_frontend_type_redirect(self):
+        response = self.client.get(self.url + u'?q=fôo&type=extension')
+        self.assert3xx(
+            response, self.url + '?q=f%C3%B4o&atype=1', status_code=302)
+
     def test_legacy_redirects(self):
-        r = self.client.get(self.url + '?sort=averagerating')
-        self.assert3xx(r, self.url + '?sort=rating', status_code=301)
+        response = self.client.get(self.url + '?sort=averagerating')
+        self.assert3xx(response, self.url + '?sort=rating', status_code=301)
 
     def test_legacy_redirects_to_non_ascii(self):
         # see http://sentry.dmz.phx1.mozilla.com/addons/group/2186/
@@ -1180,6 +1185,10 @@ class TestCollectionSearch(SearchBase):
     ('pid=2', 'platform=linux'),
     ('q=woo&lver=6.0&sort=users&pid=5',
      'q=woo&appver=6.0&sort=users&platform=windows'),
+    ('type=extension', 'atype=1'),
+    ('type=dictionary', 'atype=3'),
+    ('type=search', 'atype=4'),
+    ('type=language', 'atype=5'),
 ])
 def test_search_redirects(test_input, expected):
     assert views.fix_search_query(QueryDict(test_input)) == (


### PR DESCRIPTION
This allows users searching on new frontend to be able to switch to the old frontend and then back seamlessly without losing their search.

Fix #6846