### PR TITLE
Make 'make djshell' launch shell_plus by default

### DIFF
--- a/Makefile-os
+++ b/Makefile-os
@@ -53,7 +53,7 @@ shell:
 	docker-compose exec web bash
 
 djshell:
-	docker-compose exec web ./manage.py shell
+	docker-compose exec web ./manage.py shell_plus
 
 dbshell:
 	docker-compose exec web ./manage.py dbshell


### PR DESCRIPTION
It's just better (and available since we pull `django_extensions`) :)