### PR TITLE
Search: Implement exact matching.

### DIFF
--- a/src/olympia/addons/indexers.py
+++ b/src/olympia/addons/indexers.py
@@ -22,7 +22,8 @@ class AddonIndexer(BaseSearchIndexer):
     """Fields we don't need to expose in the results, only used for filtering
     or sorting."""
     hidden_fields = (
-        'name_sort',
+        '*.raw',
+        '*_sort',
         'boost',
         'hotness',
         # Translated content that is used for filtering purposes is stored
@@ -140,11 +141,17 @@ class AddonIndexer(BaseSearchIndexer):
                         },
                     },
                     'modified': {'type': 'date', 'index': False},
-                    # Adding word-delimiter to split on camelcase and
-                    # punctuation.
-                    'name': {'type': 'text',
-                             'analyzer': 'standardPlusWordDelimiter'},
-                    # Turn off analysis on name so we can sort by it.
+                    'name': {
+                        'type': 'text',
+                        # Adding word-delimiter to split on camelcase and
+                        # punctuation.
+                        'analyzer': 'standardPlusWordDelimiter',
+                        'fields': {
+                            # Turn off analysis on name so we can sort by it.
+                            'raw': {'type': 'keyword'}
+                        },
+                    },
+                    # TODO: Can be removed once we have `name.raw` indexed
                     'name_sort': {'type': 'keyword'},
                     'persona': {
                         'type': 'object',

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -2218,7 +2218,7 @@ class TestAddonSearchView(ESTestCase):
         qset = AddonSearchView().get_queryset()
 
         assert set(qset.to_dict()['_source']['excludes']) == set(
-            ('name_sort', 'boost', 'hotness', 'name', 'description',
+            ('*.raw', '*_sort', 'boost', 'hotness', 'name', 'description',
              'name_l10n_*', 'description_l10n_*', 'summary', 'summary_l10n_*')
         )
 

--- a/src/olympia/search/filters.py
+++ b/src/olympia/search/filters.py
@@ -281,7 +281,7 @@ class SearchQueryFilter(BaseFilterBackend):
         # name and boost it since this is likely what the user wants.
         should.append(query.Term(**{
             'name_sort': {
-                'value': search_query, 'boost': 10
+                'value': search_query, 'boost': 100
             }
         }))
 

--- a/src/olympia/search/filters.py
+++ b/src/olympia/search/filters.py
@@ -282,7 +282,8 @@ class SearchQueryFilter(BaseFilterBackend):
         should.append(query.Term(**{
             'name_sort': {
                 'value': search_query, 'boost': 10
-        }}))
+            }
+        }))
 
         # For name, also search in translated field with the right language
         # and analyzer.

--- a/src/olympia/search/filters.py
+++ b/src/olympia/search/filters.py
@@ -272,9 +272,17 @@ class SearchQueryFilter(BaseFilterBackend):
 
         # Apply rules to search on few base fields. Some might not be present
         # in every document type / indexes.
-        for k, v in rules:
+        for query_cls, opts in rules:
             for field in ('name', 'slug', 'listed_authors.name'):
-                should.append(k(**{field: v}))
+                should.append(query_cls(**{field: opts}))
+
+        # Exact matches need to be queried against a non-analyzed field. Let's
+        # do a term query on `name_sort` for an exact match against the add-on
+        # name and boost it since this is likely what the user wants.
+        should.append(query.Term(**{
+            'name_sort': {
+                'value': search_query, 'boost': 10
+        }}))
 
         # For name, also search in translated field with the right language
         # and analyzer.

--- a/src/olympia/search/filters.py
+++ b/src/olympia/search/filters.py
@@ -277,7 +277,7 @@ class SearchQueryFilter(BaseFilterBackend):
                 should.append(query_cls(**{field: opts}))
 
         # Exact matches need to be queried against a non-analyzed field. Let's
-        # do a term query on `name_sort` for an exact match against the add-on
+        # do a term query on `name.raw` for an exact match against the add-on
         # name and boost it since this is likely what the user wants.
         should.append(query.Term(**{
             'name.raw': {

--- a/src/olympia/search/filters.py
+++ b/src/olympia/search/filters.py
@@ -279,6 +279,8 @@ class SearchQueryFilter(BaseFilterBackend):
         # Exact matches need to be queried against a non-analyzed field. Let's
         # do a term query on `name.raw` for an exact match against the add-on
         # name and boost it since this is likely what the user wants.
+        # Use a super-high boost to avoid `description` or `summary`
+        # getting in our way.
         should.append(query.Term(**{
             'name.raw': {
                 'value': search_query, 'boost': 100

--- a/src/olympia/search/filters.py
+++ b/src/olympia/search/filters.py
@@ -280,7 +280,7 @@ class SearchQueryFilter(BaseFilterBackend):
         # do a term query on `name_sort` for an exact match against the add-on
         # name and boost it since this is likely what the user wants.
         should.append(query.Term(**{
-            'name_sort': {
+            'name.raw': {
                 'value': search_query, 'boost': 100
             }
         }))

--- a/src/olympia/search/tests/test_filters.py
+++ b/src/olympia/search/tests/test_filters.py
@@ -134,6 +134,20 @@ class TestQueryFilter(FilterTestsBase):
             ]}}
         }
 
+    def test_q_exact(self):
+        qs = self._filter(data={'q': 'Adblock Plus'})
+        should = qs['query']['function_score']['query']['bool']['should']
+
+        expected = {
+            'term': {
+                'name_sort': {
+                    'boost': 10, 'value': u'adblock plus',
+                }
+            }
+        }
+
+        assert expected in should
+
 
 class TestReviewedContentFilter(FilterTestsBase):
 

--- a/src/olympia/search/tests/test_filters.py
+++ b/src/olympia/search/tests/test_filters.py
@@ -140,7 +140,7 @@ class TestQueryFilter(FilterTestsBase):
 
         expected = {
             'term': {
-                'name_sort': {
+                'name.raw': {
                     'boost': 10, 'value': u'adblock plus',
                 }
             }

--- a/src/olympia/search/tests/test_filters.py
+++ b/src/olympia/search/tests/test_filters.py
@@ -141,7 +141,7 @@ class TestQueryFilter(FilterTestsBase):
         expected = {
             'term': {
                 'name.raw': {
-                    'boost': 10, 'value': u'adblock plus',
+                    'boost': 100, 'value': u'adblock plus',
                 }
             }
         }

--- a/src/olympia/search/tests/test_views.py
+++ b/src/olympia/search/tests/test_views.py
@@ -785,13 +785,16 @@ class TestSearchResultScoring(ESTestCase):
 
         assert results[0] == addons[1].pk
 
-    def test_score_boost_exact_match_2(self):
+    def test_score_boost_exact_match_description_hijack(self):
         """Test that we rank exact matches at the top."""
         addons = [
             amo.tests.addon_factory(
                 name='1-Click YouTube Video Download',
                 type=amo.ADDON_EXTENSION,
-                average_daily_users=566337, weekly_downloads=150000),
+                average_daily_users=566337, weekly_downloads=150000,
+                description=(
+                    'button, click that button, 1-Click Youtube Video '
+                    'Downloader is a click click great tool')),
             amo.tests.addon_factory(
                 name='Amazon 1-Click Lock', type=amo.ADDON_EXTENSION,
                 average_daily_users=50, weekly_downloads=0),

--- a/src/olympia/search/tests/test_views.py
+++ b/src/olympia/search/tests/test_views.py
@@ -785,6 +785,27 @@ class TestSearchResultScoring(ESTestCase):
 
         assert results[0] == addons[1].pk
 
+    def test_score_boost_exact_match_2(self):
+        """Test that we rank exact matches at the top."""
+        addons = [
+            amo.tests.addon_factory(
+                name='1-Click YouTube Video Download',
+                type=amo.ADDON_EXTENSION,
+                average_daily_users=566337, weekly_downloads=150000),
+            amo.tests.addon_factory(
+                name='Amazon 1-Click Lock', type=amo.ADDON_EXTENSION,
+                average_daily_users=50, weekly_downloads=0),
+        ]
+
+        self.refresh()
+
+        response = self.client.get(self.url, {
+            'q': 'Amazon 1-Click Lock'
+        })
+        results = self.get_results(response)
+
+        assert results[0] == addons[1].pk
+
     def test_score_boost_exact_match_l10n(self):
         """Test that we rank exact matches for loalized content at the top."""
         addons = [

--- a/src/olympia/search/tests/test_views.py
+++ b/src/olympia/search/tests/test_views.py
@@ -809,38 +809,6 @@ class TestSearchResultScoring(ESTestCase):
 
         assert results[0] == addons[1].pk
 
-    def test_score_boost_exact_match_l10n(self):
-        """Test that we rank exact matches for loalized content at the top."""
-        addons = [
-            amo.tests.addon_factory(
-                name='test addon test11', type=amo.ADDON_EXTENSION,
-                average_daily_users=0, weekly_downloads=0),
-            amo.tests.addon_factory(
-                name='test addon test21', type=amo.ADDON_EXTENSION,
-                average_daily_users=0, weekly_downloads=0),
-            amo.tests.addon_factory(
-                name='test addon test31', type=amo.ADDON_EXTENSION,
-                average_daily_users=0, weekly_downloads=0),
-        ]
-
-        addons[0].name = {
-            'en-US': 'test addon test11', 'es': 'complemento de prueba test11'}
-        addons[1].name = {
-            'en-US': 'test addon test21', 'es': 'complemento de prueba test21'}
-        addons[2].name = {
-            'en-US': 'test addon test31', 'es': 'complemento de prueba test31'}
-
-        for addon in addons:
-            addon.save()
-
-        self.refresh()
-
-        url = self.url.replace('en-US', 'es')
-        response = self.client.get(url, {'q': 'complemento de prueba test21'})
-        results = self.get_results(response)
-
-        assert results[0] == addons[1].pk
-
 
 class TestPersonaSearch(SearchBase):
 


### PR DESCRIPTION
Fixes #6837

This re-uses the existing `name_sort` field that is a not analyzed
version of `name` which is needed for exact matches.

Doesn't take translations into account just now, I opened https://github.com/mozilla/addons-server/issues/6898 for that