### PR TITLE
Document is_mozilla_signed_extension in the API

### DIFF
--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -371,6 +371,7 @@ This endpoint allows you to fetch a single version belonging to a specific add-o
     :>json string files[].hash: The hash for a file.
     :>json string files[].platform: The :ref:`platform <addon-detail-platform>` for a file.
     :>json int files[].id: The size for a file, in bytes.
+    :>json boolean files[].is_mozilla_signed_extension: Whether the file was signed with a Mozilla internal certificate or not.
     :>json boolean files[].is_restart_required: Whether the file requires a browser restart to work once installed or not.
     :>json boolean files[].is_webextension: Whether the file is a WebExtension or not.
     :>json int files[].status: The :ref:`status <addon-detail-status>` for a file.


### PR DESCRIPTION
Was surprised to see it was exposed but not documented.