### PR TITLE
Implement new unified reviewer dashboard

### DIFF
--- a/src/olympia/reviewers/decorators.py
+++ b/src/olympia/reviewers/decorators.py
@@ -117,3 +117,22 @@ def any_reviewer_required(f):
             return f(request, *args, **kw)
         raise PermissionDenied
     return wrapper
+
+
+def any_reviewer_or_moderator_required(f):
+    """Like @any_reviewer_required, but allows users with Ratings:Moderate
+    as well."""
+    @functools.wraps(f)
+    def wrapper(request, *args, **kw):
+        allow_access = (
+            acl.action_allowed(request, permissions.REVIEWER_TOOLS_VIEW) or
+            acl.action_allowed(request, permissions.ADDONS_REVIEW) or
+            acl.action_allowed(request, permissions.ADDONS_REVIEW_UNLISTED) or
+            acl.action_allowed(request, permissions.ADDONS_CONTENT_REVIEW) or
+            acl.action_allowed(request, permissions.ADDONS_POST_REVIEW) or
+            acl.action_allowed(request, permissions.THEMES_REVIEW) or
+            acl.action_allowed(request, permissions.RATINGS_MODERATE))
+        if allow_access:
+            return f(request, *args, **kw)
+        raise PermissionDenied
+    return wrapper

--- a/src/olympia/reviewers/templates/reviewers/base.html
+++ b/src/olympia/reviewers/templates/reviewers/base.html
@@ -28,8 +28,8 @@
         {% endif %}
       </nav>
     {% endif %}
-</div>
   {% endblock %}
+</div>
 {% endblock %}
 
 {% block extrahead %}

--- a/src/olympia/reviewers/templates/reviewers/dashboard.html
+++ b/src/olympia/reviewers/templates/reviewers/dashboard.html
@@ -1,0 +1,21 @@
+{% extends "reviewers/base.html" %}
+
+{# Obsolete blocks that are not supposed to be displayed in the new reviewer UI #}
+{% block navbar %}{% endblock %}
+{% block pillnav %}{% endblock %}
+{% block header_search %}{% endblock %}
+
+{% block content %}
+  <div id="reviewers_main" class="dashboard">
+    <div class="listing">
+      {% for section_name in sections %}
+        <h3>{{ section_name }}</h3>
+        <ul>
+          {% for text, href in sections[section_name] %}
+            <li><a href="{{ href }}">{{ text }}</a></li>
+          {% endfor %}
+        </ul>
+      {% endfor %}
+    </div>
+  </div>
+{% endblock %}

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -31,7 +31,8 @@ from olympia.amo.urlresolvers import reverse
 from olympia.files.models import File, FileValidation, WebextPermission
 from olympia.ratings.models import Rating, RatingFlag
 from olympia.reviewers.models import (
-    AutoApprovalSummary, ReviewerScore, ReviewerSubscription)
+    AutoApprovalSummary, RereviewQueueTheme, ReviewerScore,
+    ReviewerSubscription)
 from olympia.users.models import UserProfile
 from olympia.versions.models import ApplicationsVersions, AppVersion, Version
 from olympia.zadmin.models import get_config, set_config
@@ -440,6 +441,264 @@ class TestReviewLog(ReviewerTest):
             args=['unlisted', addon.slug])
         assert pq(response.content)(
             '#log-listing tr td a').eq(1).attr('href') == url
+
+
+class TestDashboard(TestCase):
+    def setUp(self):
+        self.url = reverse('reviewers.dashboard')
+        self.user = user_factory()
+        self.client.login(email=self.user.email)
+
+    def test_not_a_reviewer(self):
+        response = self.client.get(self.url)
+        assert response.status_code == 403
+
+    def test_all_permissions(self):
+        admins_group = Group.objects.create(name='Admins', rules='*:*')
+        GroupUser.objects.create(user=self.user, group=admins_group)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        assert len(doc('.dashboard h3')) == 7  # All 7 sections are present.
+        expected_links = [
+            reverse('reviewers.queue_nominated'),
+            reverse('reviewers.queue_pending'),
+            reverse('reviewers.performance'),
+            reverse('reviewers.reviewlog'),
+            reverse('reviewers.beta_signed_log'),
+            reverse('reviewers.queue_auto_approved'),
+            reverse('reviewers.performance'),
+            reverse('reviewers.reviewlog'),
+            reverse('reviewers.queue_content_review'),
+            reverse('reviewers.performance'),
+            reverse('reviewers.themes.list'),
+            reverse('reviewers.themes.list_rereview'),
+            reverse('reviewers.themes.list_flagged'),
+            reverse('reviewers.themes.logs'),
+            reverse('reviewers.themes.deleted'),
+            reverse('reviewers.queue_moderated'),
+            reverse('reviewers.eventlog'),
+            reverse('reviewers.unlisted_queue_all'),
+            reverse('reviewers.motd'),
+        ]
+        links = [link.attrib['href'] for link in doc('.dashboard a')]
+        assert links == expected_links
+
+    def test_legacy_reviewer(self):
+        # Create some add-ons to test the queue counts.
+        addon_factory(
+            status=amo.STATUS_NOMINATED,
+            file_kw={'status': amo.STATUS_AWAITING_REVIEW})
+        version_factory(
+            addon=addon_factory(),
+            file_kw={'status': amo.STATUS_AWAITING_REVIEW})
+        version_factory(
+            addon=addon_factory(),
+            file_kw={'status': amo.STATUS_AWAITING_REVIEW})
+
+        # Grant user the permission to see only the legacy add-ons section.
+        self.grant_permission(self.user, 'Addons:Review')
+
+        # Test.
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        assert len(doc('.dashboard h3')) == 1
+        expected_links = [
+            reverse('reviewers.queue_nominated'),
+            reverse('reviewers.queue_pending'),
+            reverse('reviewers.performance'),
+            reverse('reviewers.reviewlog'),
+            reverse('reviewers.beta_signed_log'),
+        ]
+        links = [link.attrib['href'] for link in doc('.dashboard a')]
+        assert links == expected_links
+        assert doc('.dashboard a')[0].text == 'New Add-ons (1)'
+        assert doc('.dashboard a')[1].text == 'Add-on Updates (2)'
+
+    def test_post_reviewer(self):
+        # Create an add-on to test the queue count.
+        addon = addon_factory(
+            version_kw={'is_webextension': True})
+        AddonApprovalsCounter.reset_for_addon(addon=addon)
+        AutoApprovalSummary.objects.create(
+            version=addon.current_version, verdict=amo.AUTO_APPROVED)
+
+        # Grant user the permission to see only the Auto Approved section.
+        self.grant_permission(self.user, 'Addons:PostReview')
+
+        # Test.
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        assert len(doc('.dashboard h3')) == 1
+        expected_links = [
+            reverse('reviewers.queue_auto_approved'),
+            reverse('reviewers.performance'),
+            reverse('reviewers.reviewlog'),
+        ]
+        links = [link.attrib['href'] for link in doc('.dashboard a')]
+        assert links == expected_links
+        assert doc('.dashboard a')[0].text == 'Auto Approved Add-ons (1)'
+
+    def test_content_reviewer(self):
+        # Create an add-on to test the queue count.
+        addon = addon_factory(
+            version_kw={'is_webextension': True})
+        AddonApprovalsCounter.reset_for_addon(addon=addon)
+        AutoApprovalSummary.objects.create(
+            version=addon.current_version, verdict=amo.AUTO_APPROVED)
+
+        # Grant user the permission to see only the Content Review section.
+        self.grant_permission(self.user, 'Addons:ContentReview')
+
+        # Test.
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        assert len(doc('.dashboard h3')) == 1
+        expected_links = [
+            reverse('reviewers.queue_content_review'),
+            reverse('reviewers.performance'),
+        ]
+        links = [link.attrib['href'] for link in doc('.dashboard a')]
+        assert links == expected_links
+        assert doc('.dashboard a')[0].text == 'Content Review (1)'
+
+    def test_themes_reviewer(self):
+        # Create some themes to test the queue counts.
+        addon_factory(type=amo.ADDON_PERSONA, status=amo.STATUS_PENDING)
+        addon_factory(type=amo.ADDON_PERSONA, status=amo.STATUS_PENDING)
+        addon = addon_factory(type=amo.ADDON_PERSONA, status=amo.STATUS_PUBLIC)
+        RereviewQueueTheme.objects.create(theme=addon.persona)
+        addon_factory(type=amo.ADDON_PERSONA, status=amo.STATUS_REVIEW_PENDING)
+        addon_factory(type=amo.ADDON_PERSONA, status=amo.STATUS_REVIEW_PENDING)
+        addon_factory(type=amo.ADDON_PERSONA, status=amo.STATUS_REVIEW_PENDING)
+
+        # Grant user the permission to see only the themes section.
+        self.grant_permission(self.user, 'Personas:Review')
+
+        # Test.
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        assert len(doc('.dashboard h3')) == 1
+        expected_links = [
+            reverse('reviewers.themes.list'),
+            reverse('reviewers.themes.list_rereview'),
+            reverse('reviewers.themes.list_flagged'),
+            reverse('reviewers.themes.logs'),
+            reverse('reviewers.themes.deleted'),
+        ]
+        links = [link.attrib['href'] for link in doc('.dashboard a')]
+        assert links == expected_links
+        assert doc('.dashboard a')[0].text == 'New Themes (2)'
+        assert doc('.dashboard a')[1].text == 'Themes Updates (1)'
+        assert doc('.dashboard a')[2].text == 'Flagged Themes (3)'
+
+    def test_ratings_moderator(self):
+        # Create an rating to test the queue count.
+        addon = addon_factory()
+        user = user_factory()
+        rating = Rating.objects.create(
+            addon=addon, version=addon.current_version, user=user, flag=True,
+            body=u'This âdd-on sucks!!111', rating=1, editorreview=True)
+        rating.ratingflag_set.create()
+
+        # Grant user the permission to see only the ratings to review section.
+        self.grant_permission(self.user, 'Ratings:Moderate')
+
+        # Test.
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        assert len(doc('.dashboard h3')) == 1
+        expected_links = [
+            reverse('reviewers.queue_moderated'),
+            reverse('reviewers.eventlog'),
+        ]
+        links = [link.attrib['href'] for link in doc('.dashboard a')]
+        assert links == expected_links
+        assert doc('.dashboard a')[0].text == 'Ratings Awaiting Moderation (1)'
+
+    def test_unlisted_reviewer(self):
+        # Grant user the permission to see only the unlisted add-ons section.
+        self.grant_permission(self.user, 'Addons:ReviewUnlisted')
+
+        # Test.
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        assert len(doc('.dashboard h3')) == 1
+        expected_links = [
+            reverse('reviewers.unlisted_queue_all'),
+        ]
+        links = [link.attrib['href'] for link in doc('.dashboard a')]
+        assert links == expected_links
+
+    def test_post_reviewer_and_content_reviewer(self):
+        # Create add-ons to test the queue count. The first add-on has its
+        # content approved, so the post review queue should contain 2 add-ons,
+        # and the content review queue only 1.
+        addon = addon_factory(
+            version_kw={'is_webextension': True})
+        AutoApprovalSummary.objects.create(
+            version=addon.current_version, verdict=amo.AUTO_APPROVED)
+        AddonApprovalsCounter.approve_content_for_addon(addon=addon)
+
+        addon = addon_factory(
+            version_kw={'is_webextension': True})
+        AddonApprovalsCounter.reset_for_addon(addon=addon)
+        AutoApprovalSummary.objects.create(
+            version=addon.current_version, verdict=amo.AUTO_APPROVED)
+
+        # Grant user the permission to see both the Content Review and the
+        # Auto Approved Add-ons sections.
+        self.grant_permission(self.user, 'Addons:ContentReview')
+        self.grant_permission(self.user, 'Addons:PostReview')
+
+        # Test.
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        assert len(doc('.dashboard h3')) == 2  # 2 sections are shown.
+        expected_links = [
+            reverse('reviewers.queue_auto_approved'),
+            reverse('reviewers.performance'),
+            reverse('reviewers.reviewlog'),
+            reverse('reviewers.queue_content_review'),
+            reverse('reviewers.performance'),
+        ]
+        links = [link.attrib['href'] for link in doc('.dashboard a')]
+        assert links == expected_links
+        assert doc('.dashboard a')[0].text == 'Auto Approved Add-ons (2)'
+        assert doc('.dashboard a')[3].text == 'Content Review (1)'
+
+    def test_legacy_reviewer_and_ratings_moderator(self):
+        # Grant user the permission to see both the legacy add-ons and the
+        # ratings moderation sections.
+        self.grant_permission(self.user, 'Addons:Review')
+        self.grant_permission(self.user, 'Ratings:Moderate')
+
+        # Test.
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        assert len(doc('.dashboard h3')) == 2
+        expected_links = [
+            reverse('reviewers.queue_nominated'),
+            reverse('reviewers.queue_pending'),
+            reverse('reviewers.performance'),
+            reverse('reviewers.reviewlog'),
+            reverse('reviewers.beta_signed_log'),
+            reverse('reviewers.queue_moderated'),
+            reverse('reviewers.eventlog'),
+        ]
+        links = [link.attrib['href'] for link in doc('.dashboard a')]
+        assert links == expected_links
+        assert doc('.dashboard a')[0].text == 'New Add-ons (0)'
+        assert doc('.dashboard a')[1].text == 'Add-on Updates (0)'
+        assert doc('.dashboard a')[5].text == 'Ratings Awaiting Moderation (0)'
 
 
 class TestHome(ReviewerTest):

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -484,6 +484,36 @@ class TestDashboard(TestCase):
         links = [link.attrib['href'] for link in doc('.dashboard a')]
         assert links == expected_links
 
+    def test_can_see_all_through_reviewer_view_all_permission(self):
+        self.grant_permission(self.user, 'ReviewerTools:View')
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        assert len(doc('.dashboard h3')) == 7  # All 7 sections are present.
+        expected_links = [
+            reverse('reviewers.queue_nominated'),
+            reverse('reviewers.queue_pending'),
+            reverse('reviewers.performance'),
+            reverse('reviewers.reviewlog'),
+            reverse('reviewers.beta_signed_log'),
+            reverse('reviewers.queue_auto_approved'),
+            reverse('reviewers.performance'),
+            reverse('reviewers.reviewlog'),
+            reverse('reviewers.queue_content_review'),
+            reverse('reviewers.performance'),
+            reverse('reviewers.themes.list'),
+            reverse('reviewers.themes.list_rereview'),
+            reverse('reviewers.themes.list_flagged'),
+            reverse('reviewers.themes.logs'),
+            reverse('reviewers.themes.deleted'),
+            reverse('reviewers.queue_moderated'),
+            reverse('reviewers.eventlog'),
+            reverse('reviewers.unlisted_queue_all'),
+            reverse('reviewers.motd'),
+        ]
+        links = [link.attrib['href'] for link in doc('.dashboard a')]
+        assert links == expected_links
+
     def test_legacy_reviewer(self):
         # Create some add-ons to test the queue counts.
         addon_factory(

--- a/src/olympia/reviewers/urls.py
+++ b/src/olympia/reviewers/urls.py
@@ -7,6 +7,7 @@ from olympia.reviewers import views, views_themes
 # All URLs under /editors/
 urlpatterns = (
     url(r'^$', views.home, name='reviewers.home'),
+    url(r'dashboard$', views.dashboard, name='reviewers.dashboard'),
     url(r'^queue$', views.queue, name='reviewers.queue'),
     url(r'^queue/new$', views.queue_nominated,
         name='reviewers.queue_nominated'),

--- a/src/olympia/reviewers/urls.py
+++ b/src/olympia/reviewers/urls.py
@@ -7,7 +7,7 @@ from olympia.reviewers import views, views_themes
 # All URLs under /editors/
 urlpatterns = (
     url(r'^$', views.home, name='reviewers.home'),
-    url(r'dashboard$', views.dashboard, name='reviewers.dashboard'),
+    url(r'^dashboard$', views.dashboard, name='reviewers.dashboard'),
     url(r'^queue$', views.queue, name='reviewers.queue'),
     url(r'^queue/new$', views.queue_nominated,
         name='reviewers.queue_nominated'),

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -144,7 +144,8 @@ def dashboard(request):
     # defined by a text and an URL. The template will show every link of every
     # section we provide in the context.
     sections = OrderedDict()
-    if acl.action_allowed(request, amo.permissions.ADDONS_REVIEW):
+    view_all = acl.action_allowed(request, amo.permissions.REVIEWER_TOOLS_VIEW)
+    if view_all or acl.action_allowed(request, amo.permissions.ADDONS_REVIEW):
         sections[ugettext('Legacy Add-ons')] = [(
             ugettext('New Add-ons ({0})').format(
                 ViewFullReviewQueue.objects.count()),
@@ -163,7 +164,8 @@ def dashboard(request):
             ugettext('Signed Beta Files Log'),
             reverse('reviewers.beta_signed_log')
         )]
-    if acl.action_allowed(request, amo.permissions.ADDONS_POST_REVIEW):
+    if view_all or acl.action_allowed(
+            request, amo.permissions.ADDONS_POST_REVIEW):
         sections[ugettext('Auto-Approved Add-ons')] = [(
             ugettext('Auto Approved Add-ons ({0})').format(
                 AutoApprovalSummary.get_auto_approved_queue().count()),
@@ -175,7 +177,8 @@ def dashboard(request):
             ugettext('Add-on Review Log'),
             reverse('reviewers.reviewlog')
         )]
-    if acl.action_allowed(request, amo.permissions.ADDONS_CONTENT_REVIEW):
+    if view_all or acl.action_allowed(
+            request, amo.permissions.ADDONS_CONTENT_REVIEW):
         sections[ugettext('Content Review')] = [(
             ugettext('Content Review ({0})').format(
                 AutoApprovalSummary.get_content_review_queue().count()),
@@ -184,7 +187,8 @@ def dashboard(request):
             ugettext('Performance'),
             reverse('reviewers.performance')
         )]
-    if acl.action_allowed(request, amo.permissions.THEMES_REVIEW):
+    if view_all or acl.action_allowed(
+            request, amo.permissions.THEMES_REVIEW):
         sections[ugettext('Lightweight Themes')] = [(
             ugettext('New Themes ({0})').format(
                 Persona.objects.filter(
@@ -206,7 +210,8 @@ def dashboard(request):
             ugettext('Deleted themes Log'),
             reverse('reviewers.themes.deleted')
         )]
-    if acl.action_allowed(request, amo.permissions.RATINGS_MODERATE):
+    if view_all or acl.action_allowed(
+            request, amo.permissions.RATINGS_MODERATE):
         sections[ugettext('User Ratings Moderation')] = [(
             ugettext('Ratings Awaiting Moderation ({0})').format(
                 Rating.objects.all().to_moderate().count()),
@@ -215,13 +220,15 @@ def dashboard(request):
             ugettext('Moderated Review Log'),
             reverse('reviewers.eventlog')
         )]
-    if acl.action_allowed(request, amo.permissions.ADDONS_REVIEW_UNLISTED):
+    if view_all or acl.action_allowed(
+            request, amo.permissions.ADDONS_REVIEW_UNLISTED):
         sections[ugettext('Unlisted Add-ons')] = [(
             ugettext('All Unlisted Add-ons'),
             reverse('reviewers.unlisted_queue_all')
         )]
 
-    if acl.action_allowed(request, amo.permissions.ADDON_REVIEWER_MOTD_EDIT):
+    if view_all or acl.action_allowed(
+            request, amo.permissions.ADDON_REVIEWER_MOTD_EDIT):
         sections[ugettext('Announcement')] = [(
             ugettext('Update message of the day'),
             reverse('reviewers.motd')

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -63,7 +63,7 @@ def context(request, **kw):
     return ctx
 
 
-@any_reviewer_or_moderator_required
+@ratings_moderator_required
 def eventlog(request):
     form = forms.EventLogForm(request.GET)
     eventlog = ActivityLog.objects.reviewer_events()
@@ -86,7 +86,7 @@ def eventlog(request):
     return render(request, 'reviewers/eventlog.html', data)
 
 
-@any_reviewer_or_moderator_required
+@ratings_moderator_required
 def eventlog_detail(request, id):
     log = get_object_or_404(ActivityLog.objects.reviewer_events(), pk=id)
 

--- a/static/css/zamboni/reviewers.styl
+++ b/static/css/zamboni/reviewers.styl
@@ -436,6 +436,23 @@ div.reviewer-stats-table > div.reviewer-stats-dark {
     border-left: 1px solid #DDDDDD;
 }
 
+/* Dashboard */
+.dashboard .listing h3 {
+    margin: 0.5em 0 0 0;
+}
+.dashboard .listing ul {
+    columns: 3;
+}
+.dashboard .listing a {
+    display: block;
+    font-size: 110%;
+    margin: 0.1em;
+    padding: 0.5em;
+}
+.dashboard .listing a:hover {
+    background-color: #F9F9F9;
+}
+
 /* Moderated reviews css */
 
 #reviews-flagged .review-flagged {


### PR DESCRIPTION
Standalone version for now, living at /editors/dashboard. Once fully tested it will replace the old home.

Screenshot with a bunch of permissions:
![dashboard](https://user-images.githubusercontent.com/187006/33070238-aaf8183e-ceb7-11e7-851f-739284f67042.png)


Fix #6937