### PR TITLE
For license name use request.LANG instead of site default locale 

### DIFF
--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -133,8 +133,9 @@ class LicenseSerializer(serializers.ModelSerializer):
                 # A single lang requested so return a flat string
                 return unicode(license_constant.name)
             else:
-                # Otherwise mock the dict, and it's going to be lang default.
-                return {settings.LANGUAGE_CODE: unicode(license_constant.name)}
+                # Otherwise mock the dict with the default lang.
+                lang = getattr(request, 'LANG', None) or settings.LANGUAGE_CODE
+                return {lang: unicode(license_constant.name)}
 
 
 class CompactLicenseSerializer(LicenseSerializer):

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -795,6 +795,14 @@ class TestVersionSerializerOutput(TestCase):
         assert result['name'] == {
             'en-US': unicode(LICENSES_BY_BUILTIN[18].name)}
 
+        accept_request = APIRequestFactory().get('/')
+        accept_request.LANG = 'de'
+        result = LicenseSerializer(
+            context={'request': accept_request}).to_representation(license)
+        # An Accept-Language should result in a different default though.
+        assert result['name'] == {
+            'de': unicode(LICENSES_BY_BUILTIN[18].name)}
+
         # But a requested lang returns a flat string
         lang_request = APIRequestFactory().get('/?lang=fr')
         result = LicenseSerializer(


### PR DESCRIPTION
follow up from #6296, fixes #6941