### PR TITLE
Close all connections before we start creating `DownloadCount` values.

### DIFF
--- a/src/olympia/stats/management/commands/download_counts_from_file.py
+++ b/src/olympia/stats/management/commands/download_counts_from_file.py
@@ -165,6 +165,8 @@ class Command(BaseCommand):
         # If the calculation above takes too long it might happen that we run
         # into `wait_timeout` problems and django doesn't reconnect properly
         # (potentially because of misconfiguration).
+        # Django will re-connect properly after it notices that all
+        # connections are closed.
         connections.close_all()
 
         # Create in bulk: this is much faster.

--- a/src/olympia/stats/management/commands/download_counts_from_file.py
+++ b/src/olympia/stats/management/commands/download_counts_from_file.py
@@ -2,7 +2,7 @@ import codecs
 from datetime import datetime, timedelta
 from os import path, unlink
 
-from django.db import connection
+from django.db import close_old_connections
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
@@ -159,7 +159,7 @@ class Command(BaseCommand):
                 dc.count += counter
                 dc.sources = update_inc(dc.sources, src, counter)
 
-        # Close all connections in this thread before we start creating the
+        # Close all old connections in this thread before we start creating the
         # `DownloadCount` values.
         # https://github.com/mozilla/addons-server/issues/6886
         # If the calculation above takes too long it might happen that we run
@@ -167,7 +167,7 @@ class Command(BaseCommand):
         # (potentially because of misconfiguration).
         # Django will re-connect properly after it notices that all
         # connections are closed.
-        connection.close_if_unusable_or_obsolete()
+        close_old_connections()
 
         # Create in bulk: this is much faster.
         DownloadCount.objects.bulk_create(download_counts.values(), 100)

--- a/src/olympia/stats/management/commands/download_counts_from_file.py
+++ b/src/olympia/stats/management/commands/download_counts_from_file.py
@@ -2,6 +2,7 @@ import codecs
 from datetime import datetime, timedelta
 from os import path, unlink
 
+from django.db import connections
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
@@ -158,10 +159,20 @@ class Command(BaseCommand):
                 dc.count += counter
                 dc.sources = update_inc(dc.sources, src, counter)
 
+        # Close all connections in this thread before we start creating the
+        # `DownloadCount` values.
+        # https://github.com/mozilla/addons-server/issues/6886
+        # If the calculation above takes too long it might happen that we run
+        # into `wait_timeout` problems and django doesn't reconnect properly
+        # (potentially because of misconfiguration).
+        connections.close_all()
+
         # Create in bulk: this is much faster.
         DownloadCount.objects.bulk_create(download_counts.values(), 100)
+
         for download_count in download_counts.values():
             save_stats_to_file(download_count)
+
         log.info('Processed a total of %s lines' % (index + 1))
         log.debug('Total processing time: %s' % (datetime.now() - start))
 

--- a/src/olympia/stats/management/commands/download_counts_from_file.py
+++ b/src/olympia/stats/management/commands/download_counts_from_file.py
@@ -167,7 +167,7 @@ class Command(BaseCommand):
         # (potentially because of misconfiguration).
         # Django will re-connect properly after it notices that all
         # connections are closed.
-        connection.close()
+        connection.close_if_unusable_or_obsolete()
 
         # Create in bulk: this is much faster.
         DownloadCount.objects.bulk_create(download_counts.values(), 100)

--- a/src/olympia/stats/management/commands/download_counts_from_file.py
+++ b/src/olympia/stats/management/commands/download_counts_from_file.py
@@ -2,7 +2,7 @@ import codecs
 from datetime import datetime, timedelta
 from os import path, unlink
 
-from django.db import connections
+from django.db import connection
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
@@ -167,7 +167,7 @@ class Command(BaseCommand):
         # (potentially because of misconfiguration).
         # Django will re-connect properly after it notices that all
         # connections are closed.
-        connections.close_all()
+        connection.close()
 
         # Create in bulk: this is much faster.
         DownloadCount.objects.bulk_create(download_counts.values(), 100)

--- a/src/olympia/stats/tests/test_commands.py
+++ b/src/olympia/stats/tests/test_commands.py
@@ -211,7 +211,6 @@ class TestADICommand(FixturesFolderMixin, TransactionTestCase):
         assert DownloadCount.objects.all().count() == 2
         close_old_connections_mock.assert_called_once()
 
-
     @mock.patch('olympia.stats.management.commands.save_stats_to_file')
     def test_theme_update_counts_from_file(self, mock_save_stats_to_file):
         management.call_command('theme_update_counts_from_file', hive_folder,

--- a/src/olympia/stats/tests/test_commands.py
+++ b/src/olympia/stats/tests/test_commands.py
@@ -6,6 +6,7 @@ from datetime import date, timedelta
 import mock
 from django.conf import settings
 from django.core import management
+from django.test.testcases import TransactionTestCase
 
 from olympia import amo
 from olympia.amo.tests import addon_factory, TestCase
@@ -45,7 +46,7 @@ class FixturesFolderMixin(object):
         super(FixturesFolderMixin, self).tearDown()
 
 
-class TestADICommand(FixturesFolderMixin, TestCase):
+class TestADICommand(FixturesFolderMixin, TransactionTestCase):
     fixtures = ('base/addon_3615', 'base/featured', 'addons/persona',
                 'base/appversion.json')
     date = '2014-07-10'


### PR DESCRIPTION
Fixes #6886

If the calculation above takes too long it might happen that we run
into `wait_timeout` problems and django doesn't reconnect properly
(potentially because of misconfiguration).
