### PR TITLE
Randomize unlisted add-on slugs created via the API.

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -435,10 +435,11 @@ class Addon(OnChangeMixin, ModelBase):
         if self.status == amo.STATUS_DELETED:
             return
 
-        randomize_slug = False
-
-        if self.id and not self.has_listed_versions():
-            randomize_slug = True
+        randomize_slug = (
+            self.id and
+            self.versions.all().exists() and not
+            self.has_listed_versions()
+        )
 
         clean_slug(self, slug_field, randomize=randomize_slug)
 

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -59,7 +59,7 @@ log = olympia.core.logger.getLogger('z.addons')
 
 
 MAX_SLUG_INCREMENT = 99
-_SLUG_INCREMENT_SUFFIXES = set(range(1, MAX_SLUG_INCREMENT + 1))
+SLUG_INCREMENT_SUFFIXES = set(range(1, MAX_SLUG_INCREMENT + 1))
 
 
 def get_random_slug():
@@ -128,7 +128,7 @@ def clean_slug(instance, slug_field='slug', unlisted=False):
 
         # find the next free slug number
         slug_numbers = {int(i) for i in used_slug_numbers if i.isdigit()}
-        unused_numbers = _SLUG_INCREMENT_SUFFIXES - slug_numbers
+        unused_numbers = SLUG_INCREMENT_SUFFIXES - slug_numbers
 
         if unused_numbers:
             num = min(unused_numbers)
@@ -136,9 +136,9 @@ def clean_slug(instance, slug_field='slug', unlisted=False):
             num = max(slug_numbers) + 1
         else:
             # This could happen. The current implementation (using
-            # ``[:max_length -3]``) only works for the first 100 clashes in the
+            # ``[:max_length -2]``) only works for the first 100 clashes in the
             # worst case (if the slug is equal to or longuer than
-            # ``max_length - 3`` chars).
+            # ``max_length - 2`` chars).
             # After that, {verylongslug}-100 will be trimmed down to
             # {verylongslug}-10, which is already assigned, but it's the last
             # solution tested.

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -78,11 +78,13 @@ def clean_slug(instance, slug_field='slug', unlisted=False):
     :param unlisted: Whether the instance is listed or unlisted. We generate
                      random slugs For unlisted instances.
     """
-    slug = getattr(instance, slug_field, None) or instance.name
+    slug = getattr(instance, slug_field, None)
 
     if not slug and unlisted:
         slug = get_random_slug()
     elif not slug and not unlisted:
+        slug = instance.name
+
         # Initialize the slug with what we have available: a name translation,
         # or the id of the instance, or in last resort the model name.
         translations = Translation.objects.filter(id=instance.name_id)

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -80,7 +80,7 @@ def clean_slug(instance, slug_field='slug', randomize=False):
     """
     slug = getattr(instance, slug_field, None)
 
-    if randomize:
+    if not slug and randomize:
         slug = get_random_slug()
     else:
         slug = slug or instance.name

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -80,11 +80,12 @@ def clean_slug(instance, slug_field='slug', unlisted=False):
     """
     slug = getattr(instance, slug_field, None)
 
-    if not slug and unlisted:
+    if unlisted and not slug:
         slug = get_random_slug()
-    elif not slug and not unlisted:
-        slug = instance.name
+    else:
+        slug = slug or instance.name
 
+    if not slug:
         # Initialize the slug with what we have available: a name translation,
         # or the id of the instance, or in last resort the model name.
         translations = Translation.objects.filter(id=instance.name_id)

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -145,7 +145,7 @@ def clean_slug(instance, slug_field='slug', unlisted=False):
             raise RuntimeError(
                 'No suitable slug increment for {} found'.format(slug))
 
-        slug = '{slug}{postfix}'.format(slug=slug, postfix=num)
+        slug = u'{slug}{postfix}'.format(slug=slug, postfix=num)
 
     setattr(instance, slug_field, slug)
 

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -70,7 +70,7 @@ def get_random_slug():
 def clean_slug(instance, slug_field='slug'):
     """Cleans a model instance slug.
 
-    This strives to be as generic as possible but is generally only used
+    This strives to be as generic as possible but is only used
     by Add-ons at the moment.
 
     :param instance: The instance to clean the slug for.

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -79,8 +79,8 @@ def clean_slug(instance, slug_field='slug'):
     slug = getattr(instance, slug_field, None) or instance.name
 
     if not slug:
-        # Initialize the slug with what we have available: a name translation,
-        # or the id of the instance, or in last resort the model name.
+        # Initialize the slug with what we have available: a name translation
+        # or in last resort a random slug.
         translations = Translation.objects.filter(id=instance.name_id)
         if translations.exists():
             slug = translations[0]

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -181,40 +181,6 @@ class TestCleanSlug(TestCase):
         addon = Addon.objects.create(name=u'Addön 1')
         assert addon.slug == u'addön-1'
 
-    def test_clean_slug_unlisted_version(self):
-        """Randomize the slug if an add-on only has unlisted versions."""
-        addon = addon_factory(
-            name=u'Addön',
-            version_kw={'channel': amo.RELEASE_CHANNEL_UNLISTED})
-
-        assert addon.has_unlisted_versions()
-        assert not addon.has_listed_versions()
-
-        assert u'addön' not in addon.slug
-        assert len(addon.slug) == 20
-
-    def test_clean_slug_listed_version(self):
-        """Don't randomize slug if an add-on has listed versions."""
-        addon = addon_factory(
-            name=u'Addön',
-            version_kw={'channel': amo.RELEASE_CHANNEL_LISTED})
-
-        assert not addon.has_unlisted_versions()
-        assert addon.has_listed_versions()
-        assert addon.slug == u'addön'
-
-    def test_clean_slug_listed_and_unlisted_version(self):
-        addon = addon_factory(
-            name=u'Addön',
-            version_kw={'channel': amo.RELEASE_CHANNEL_LISTED})
-        version_factory(
-            addon=addon, version='3.0', channel=amo.RELEASE_CHANNEL_UNLISTED)
-        addon.clean_slug()
-
-        assert addon.has_unlisted_versions()
-        assert addon.has_listed_versions()
-        assert addon.slug == u'addön'
-
 
 class TestAddonManager(TestCase):
     fixtures = ['base/appversion', 'base/users',

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -181,6 +181,40 @@ class TestCleanSlug(TestCase):
         addon = Addon.objects.create(name=u'Addön 1')
         assert addon.slug == u'addön-1'
 
+    def test_clean_slug_unlisted_version(self):
+        """Randomize the slug if an add-on only has unlisted versions."""
+        addon = addon_factory(
+            name=u'Addön',
+            version_kw={'channel': amo.RELEASE_CHANNEL_UNLISTED})
+
+        assert addon.has_unlisted_versions()
+        assert not addon.has_listed_versions()
+
+        assert u'addön' not in addon.slug
+        assert len(addon.slug) == 20
+
+    def test_clean_slug_listed_version(self):
+        """Don't randomize slug if an add-on has listed versions."""
+        addon = addon_factory(
+            name=u'Addön',
+            version_kw={'channel': amo.RELEASE_CHANNEL_LISTED})
+
+        assert not addon.has_unlisted_versions()
+        assert addon.has_listed_versions()
+        assert addon.slug == u'addön'
+
+    def test_clean_slug_listed_and_unlisted_version(self):
+        addon = addon_factory(
+            name=u'Addön',
+            version_kw={'channel': amo.RELEASE_CHANNEL_LISTED})
+        version_factory(
+            addon=addon, version='3.0', channel=amo.RELEASE_CHANNEL_UNLISTED)
+        addon.clean_slug()
+
+        assert addon.has_unlisted_versions()
+        assert addon.has_listed_versions()
+        assert addon.slug == u'addön'
+
 
 class TestAddonManager(TestCase):
     fixtures = ['base/appversion', 'base/users',

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -44,9 +44,9 @@ class TestCleanSlug(TestCase):
         # Make sure there's at least an addon with the "addon" slug, subsequent
         # ones should be "addon-1", "addon-2" ...
         a = Addon.objects.create(name='Addon')
-        assert a.slug == "addon"
+        assert a.slug == 'addon'
 
-        # Start with a first clash. This should give us "addon-1".
+        # Start with a first clash. This should give us 'addon-1".
         # We're not saving yet, we're testing the slug creation without an id.
         b = Addon(name='Addon')
         b.clean_slug()
@@ -74,7 +74,7 @@ class TestCleanSlug(TestCase):
         # Create an addon and save it to have an id.
         a = Addon.objects.create()
         # Start over: don't use the name nor the id to generate the slug.
-        a.slug = a.name = ""
+        a.slug = a.name = ''
         a.clean_slug()
 
         # Slugs that are generated from add-ons without an name use
@@ -82,24 +82,24 @@ class TestCleanSlug(TestCase):
         assert len(a.slug) == 20
 
     def test_clean_slug_with_name(self):
-        # Make sure there's at least an addon with the "fooname" slug,
-        # subsequent ones should be "fooname-1", "fooname-2" ...
-        a = Addon.objects.create(name="fooname")
-        assert a.slug == "fooname"
+        # Make sure there's at least an addon with the 'fooname' slug,
+        # subsequent ones should be 'fooname-1', 'fooname-2' ...
+        a = Addon.objects.create(name='fooname')
+        assert a.slug == 'fooname'
 
-        b = Addon(name="fooname")
+        b = Addon(name='fooname')
         b.clean_slug()
-        assert b.slug == "fooname1"
+        assert b.slug == 'fooname1'
 
     def test_clean_slug_with_slug(self):
-        # Make sure there's at least an addon with the "fooslug" slug,
-        # subsequent ones should be "fooslug-1", "fooslug-2" ...
-        a = Addon.objects.create(name="fooslug")
-        assert a.slug == "fooslug"
+        # Make sure there's at least an addon with the 'fooslug' slug,
+        # subsequent ones should be 'fooslug-1', 'fooslug-2' ...
+        a = Addon.objects.create(name='fooslug')
+        assert a.slug == 'fooslug'
 
-        b = Addon(name="fooslug")
+        b = Addon(name='fooslug')
         b.clean_slug()
-        assert b.slug == "fooslug1"
+        assert b.slug == 'fooslug1'
 
     def test_clean_slug_denied_slug(self):
         denied_slug = 'foodenied'
@@ -107,30 +107,30 @@ class TestCleanSlug(TestCase):
 
         a = Addon(slug=denied_slug)
         a.clean_slug()
-        # Blacklisted slugs (like "activate" or IDs) have a "~" appended to
+        # Blacklisted slugs (like 'activate" or IDs) have a "~" appended to
         # avoid clashing with URLs.
-        assert a.slug == "%s~" % denied_slug
+        assert a.slug == '%s~' % denied_slug
         # Now save the instance to the database for future clashes.
         a.save()
 
         b = Addon(slug=denied_slug)
         b.clean_slug()
-        assert b.slug == "%s~1" % denied_slug
+        assert b.slug == '%s~1' % denied_slug
 
     def test_clean_slug_denied_slug_long_slug(self):
-        long_slug = "this_is_a_very_long_slug_that_is_longer_than_thirty_chars"
+        long_slug = 'this_is_a_very_long_slug_that_is_longer_than_thirty_chars'
         DeniedSlug.objects.create(name=long_slug[:30])
 
-        # If there's no clashing slug, just append a "~".
+        # If there's no clashing slug, just append a '~'.
         a = Addon.objects.create(slug=long_slug[:30])
-        assert a.slug == "%s~" % long_slug[:29]
+        assert a.slug == '%s~' % long_slug[:29]
 
         # If there's a clash, use the standard clash resolution.
         a = Addon.objects.create(slug=long_slug[:30])
-        assert a.slug == "%s1" % long_slug[:28]
+        assert a.slug == '%s1' % long_slug[:28]
 
     def test_clean_slug_long_slug(self):
-        long_slug = "this_is_a_very_long_slug_that_is_longer_than_thirty_chars"
+        long_slug = 'this_is_a_very_long_slug_that_is_longer_than_thirty_chars'
 
         # If there's no clashing slug, don't over-shorten it.
         a = Addon.objects.create(slug=long_slug)
@@ -139,28 +139,28 @@ class TestCleanSlug(TestCase):
         # Now that there is a clash, test the clash resolution.
         b = Addon(slug=long_slug)
         b.clean_slug()
-        assert b.slug == "%s1" % long_slug[:28]
+        assert b.slug == '%s1' % long_slug[:28]
 
     def test_clean_slug_always_slugify(self):
-        illegal_chars = "some spaces and !?@"
+        illegal_chars = 'some spaces and !?@'
 
         # Slugify if there's a slug provided.
         a = Addon(slug=illegal_chars)
         a.clean_slug()
-        assert a.slug.startswith("some-spaces-and"), a.slug
+        assert a.slug.startswith('some-spaces-and'), a.slug
 
         # Also slugify if there's no slug provided.
         b = Addon(name=illegal_chars)
         b.clean_slug()
-        assert b.slug.startswith("some-spaces-and"), b.slug
+        assert b.slug.startswith('some-spaces-and'), b.slug
 
     def test_clean_slug_worst_case_scenario(self):
-        long_slug = "this_is_a_very_long_slug_that_is_longer_than_thirty_chars"
+        long_slug = 'this_is_a_very_long_slug_that_is_longer_than_thirty_chars'
 
         # Generate 100 addons with this very long slug. We should encounter the
         # worst case scenario where all the available clashes have been
-        # avoided. Check the comment in addons.models.clean_slug, in the "else"
-        # part of the "for" loop checking for available slugs not yet assigned.
+        # avoided. Check the comment in addons.models.clean_slug, in the 'else'
+        # part of the 'for" loop checking for available slugs not yet assigned.
         for i in range(100):
             Addon.objects.create(slug=long_slug)
 
@@ -176,6 +176,10 @@ class TestCleanSlug(TestCase):
         b = Addon.objects.create(name='ends with dash -')
         assert b.slug == 'ends-with-dash-1'
         assert b.slug == amo.utils.slugify(b.slug)
+
+    def test_clean_slug_unicode(self):
+        addon = Addon.objects.create(name=u'Addön 1')
+        assert addon.slug == u'addön-1'
 
 
 class TestAddonManager(TestCase):
@@ -576,8 +580,8 @@ class TestAddonModels(TestCase):
         log = AddonLog.objects.order_by('-id').first().activity_log
         assert log.action == amo.LOG.DELETE_ADDON.id
         assert log.to_string() == (
-            "Addon id {0} with GUID {1} has been deleted".format(addon_id,
-                                                                 guid))
+            'Addon id {0} with GUID {1} has been deleted'.format(
+                addon_id, guid))
 
     def test_delete(self):
         addon = Addon.unfiltered.get(pk=3615)

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -124,13 +124,10 @@ class BaseTestEditBasic(BaseTestEdit):
         assert addon.name.id == old_name.id
 
         assert unicode(addon.summary) == data['summary']
+        assert unicode(addon.slug) == data['slug']
 
         if self.listed:
             assert [unicode(t) for t in addon.tags.all()] == sorted(self.tags)
-            assert unicode(addon.slug) == data['slug']
-        else:
-            # We randomize slugs for unlisted add-ons
-            assert len(data['slug']) == 20
 
     def test_edit_check_description(self):
         # Make sure bug 629779 doesn't return.

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -127,8 +127,10 @@ class BaseTestEditBasic(BaseTestEdit):
 
         if self.listed:
             assert [unicode(t) for t in addon.tags.all()] == sorted(self.tags)
-            # We randomize slugs for unlisted add-ons
             assert unicode(addon.slug) == data['slug']
+        else:
+            # We randomize slugs for unlisted add-ons
+            assert len(data['slug']) == 20
 
     def test_edit_check_description(self):
         # Make sure bug 629779 doesn't return.
@@ -195,9 +197,11 @@ class BaseTestEditBasic(BaseTestEdit):
 
         if self.listed:
             assert [unicode(t) for t in addon.tags.all()] == sorted(self.tags)
-            # We randomize slugs for unlisted add-ons so we can't rely
-            # on the output
             assert unicode(addon.slug) == data['slug']
+        else:
+            # We randomize slugs for unlisted add-ons so we can't rely
+            # on the output and can only check the length of the hash
+            assert len(data['slug']) == 20
 
     def test_edit_name_required(self):
         data = self.get_dict(name='', slug='test_addon')

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -59,10 +59,11 @@ class BaseTestEdit(TestCase):
                 Tag(tag_text=t).save_tag(addon)
         else:
             self.make_addon_unlisted(addon)
+            addon.save()
 
-        self.url = addon.get_dev_url()
         self.user = UserProfile.objects.get(pk=55021)
         self.addon = self.get_addon()
+        self.url = self.addon.get_dev_url()
 
     def get_addon(self):
         return Addon.objects.no_cache().get(id=3615)
@@ -122,11 +123,12 @@ class BaseTestEditBasic(BaseTestEdit):
         assert unicode(addon.name) == data['name']
         assert addon.name.id == old_name.id
 
-        assert unicode(addon.slug) == data['slug']
         assert unicode(addon.summary) == data['summary']
 
         if self.listed:
             assert [unicode(t) for t in addon.tags.all()] == sorted(self.tags)
+            # We randomize slugs for unlisted add-ons
+            assert unicode(addon.slug) == data['slug']
 
     def test_edit_check_description(self):
         # Make sure bug 629779 doesn't return.
@@ -159,15 +161,16 @@ class BaseTestEditBasic(BaseTestEdit):
         response = self.client.post(self.basic_edit_url, data)
         assert response.status_code == 200
 
+        addon = self.get_addon()
+
         # Fetch the page so the LinkifiedTranslation gets in cache.
         response = self.client.get(
-            reverse('devhub.addons.edit', args=[data['slug']]))
+            reverse('devhub.addons.edit', args=[addon.slug]))
         assert pq(response.content)('[data-name=summary]').html().strip() == (
             '<span lang="en-us">&lt;b&gt;oh my&lt;/b&gt;</span>')
 
         # Now make sure we don't have escaped content in the rendered form.
-        form = AddonFormBasic(instance=self.get_addon(),
-                              request=req_factory_factory('/'))
+        form = AddonFormBasic(instance=addon, request=req_factory_factory('/'))
         html = pq('<body>%s</body>' % form['summary'])('[lang="en-us"]').html()
         assert html.strip() == '<b>oh my</b>'
 
@@ -188,11 +191,13 @@ class BaseTestEditBasic(BaseTestEdit):
 
         assert unicode(addon.name) == data['name']
 
-        assert unicode(addon.slug) == data['slug']
         assert unicode(addon.summary) == data['summary']
 
         if self.listed:
             assert [unicode(t) for t in addon.tags.all()] == sorted(self.tags)
+            # We randomize slugs for unlisted add-ons so we can't rely
+            # on the output
+            assert unicode(addon.slug) == data['slug']
 
     def test_edit_name_required(self):
         data = self.get_dict(name='', slug='test_addon')
@@ -1026,6 +1031,7 @@ class BaseTestEditDetails(BaseTestEdit):
         self.addon.save()
         response = self.client.get(self.url)
         doc = pq(response.content)
+
         assert doc('#edit-addon-details span[lang]').html() == (
             "This<br/><b>IS</b>&lt;script&gt;alert('awesome')&lt;/script&gt;")
 

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -189,16 +189,11 @@ class BaseTestEditBasic(BaseTestEdit):
         addon = self.get_addon()
 
         assert unicode(addon.name) == data['name']
-
         assert unicode(addon.summary) == data['summary']
+        assert unicode(addon.slug) == data['slug']
 
         if self.listed:
             assert [unicode(t) for t in addon.tags.all()] == sorted(self.tags)
-            assert unicode(addon.slug) == data['slug']
-        else:
-            # We randomize slugs for unlisted add-ons so we can't rely
-            # on the output and can only check the length of the hash
-            assert len(data['slug']) == 20
 
     def test_edit_name_required(self):
         data = self.get_dict(name='', slug='test_addon')

--- a/src/olympia/signing/tests/test_views.py
+++ b/src/olympia/signing/tests/test_views.py
@@ -123,8 +123,29 @@ class TestUploadVersion(BaseUploadVersionCase):
         self.auto_sign_version.assert_called_with(
             latest_version, is_beta=False)
 
-        # Also make sure that we are assigning a random 20 character long
-        # slug that has nothing to do with the addon name.
+    def test_new_addon_random_slug_unlisted_channel(self):
+        guid = '@create-version'
+        qs = Addon.unfiltered.filter(guid=guid)
+        assert not qs.exists()
+        response = self.request('PUT', addon=guid, version='1.0')
+        assert response.status_code == 201
+        assert qs.exists()
+        addon = qs.get()
+
+        assert len(addon.slug) == 20
+        assert 'create' not in addon.slug
+
+    def test_new_addon_no_random_slug_listed_channel(self):
+        guid = '@create-version'
+        qs = Addon.unfiltered.filter(guid=guid)
+        assert not qs.exists()
+        response = self.request(
+            'PUT', addon=guid, version='1.0',
+            channel=amo.RELEASE_CHANNEL_LISTED)
+        assert response.status_code == 201
+        assert qs.exists()
+        addon = qs.get()
+
         assert len(addon.slug) == 20
         assert 'create' not in addon.slug
 

--- a/src/olympia/signing/tests/test_views.py
+++ b/src/olympia/signing/tests/test_views.py
@@ -124,24 +124,10 @@ class TestUploadVersion(BaseUploadVersionCase):
             latest_version, is_beta=False)
 
     def test_new_addon_random_slug_unlisted_channel(self):
-        guid = '@create-version'
+        guid = '@create-webextension'
         qs = Addon.unfiltered.filter(guid=guid)
         assert not qs.exists()
         response = self.request('PUT', addon=guid, version='1.0')
-        assert response.status_code == 201
-        assert qs.exists()
-        addon = qs.get()
-
-        assert len(addon.slug) == 20
-        assert 'create' not in addon.slug
-
-    def test_new_addon_no_random_slug_listed_channel(self):
-        guid = '@create-version'
-        qs = Addon.unfiltered.filter(guid=guid)
-        assert not qs.exists()
-        response = self.request(
-            'PUT', addon=guid, version='1.0',
-            channel=amo.RELEASE_CHANNEL_LISTED)
         assert response.status_code == 201
         assert qs.exists()
         addon = qs.get()

--- a/src/olympia/signing/tests/test_views.py
+++ b/src/olympia/signing/tests/test_views.py
@@ -123,6 +123,11 @@ class TestUploadVersion(BaseUploadVersionCase):
         self.auto_sign_version.assert_called_with(
             latest_version, is_beta=False)
 
+        # Also make sure that we are assigning a random 20 character long
+        # slug that has nothing to do with the addon name.
+        assert len(addon.slug) == 20
+        assert not 'create' in addon.slug
+
     def test_user_does_not_own_addon(self):
         self.user = UserProfile.objects.create(
             read_dev_agreement=datetime.now())

--- a/src/olympia/signing/tests/test_views.py
+++ b/src/olympia/signing/tests/test_views.py
@@ -126,7 +126,7 @@ class TestUploadVersion(BaseUploadVersionCase):
         # Also make sure that we are assigning a random 20 character long
         # slug that has nothing to do with the addon name.
         assert len(addon.slug) == 20
-        assert not 'create' in addon.slug
+        assert 'create' not in addon.slug
 
     def test_user_does_not_own_addon(self):
         self.user = UserProfile.objects.create(


### PR DESCRIPTION
Fixes #5955

This also simplifies `clean_slug` a bit by using a set operation to
find free numbers instead of a for loop that doesn't cover the whole
range.

We only set a random slug if an add-on has no listed versions whatsoever, otherwise, we rely on postfix
increments.

This patch also removes possibility of exposing add-on ids or even the
model name as default slugs.