### PR TITLE
Drop addons.adminreview column now that it's no longer used

### DIFF
--- a/src/olympia/migrations/992-drop-adminreview-column.sql
+++ b/src/olympia/migrations/992-drop-adminreview-column.sql
@@ -1,0 +1,3 @@
+-- `adminreview` has been replaced by a new table, made nullable and removed
+-- from the models in the previous tag, so it can be dropped.
+ALTER TABLE `addons` DROP COLUMN `adminreview`;


### PR DESCRIPTION
Wait until 2017.11.30 tag has landed in production before merging this (If somehow it does not land then we need to wait one more week). Fix #7000