### PR TITLE
Pin signing-clients to version 1.4.1

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -329,7 +329,7 @@ schematic==0.4 \
     --hash=sha256:c0e10f877297f8414a1cafe759c67fb27902fe50838f725f4b5f15c598adeb9e
 signing-clients==1.4.1 \
     --hash=sha256:820618f67f697f79c601bec8dea46727080a745d38aa8f959b45f4261653d0a8 \
-    --hash=sha256:fbdf2c19db4817f4b4485b8812aaa63e453b97f5ff5630c21accc2dce959c5d0
+    --hash=sha256:fbdf2c19db4817f4b4485b8812aaa63e453b97f5ff5630c21accc2dce959c5d0 # pyup: ==1.4.1
 # simplejson is required by amo-validator
 simplejson==3.13.2 \
     --hash=sha256:194fa08e4047f16e7087f2a406abd15151a482a097e42d8babb1b8181b2232b1 \


### PR DESCRIPTION
This is required in preparation for
https://github.com/mozilla/signing-clients/pull/22 to not getting pulled
into AMO without proper testing after merging.

Fixes #7094