### PR TITLE
Read environment settings file at the beginning of settings module.

### DIFF
--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -1,12 +1,8 @@
 import logging
 import os
-import environ
 import datetime
 
 from olympia.lib.settings_base import *  # noqa
-
-environ.Env.read_env(env_file='/etc/olympia/settings.env')
-env = environ.Env()
 
 # Allow addons-dev CDN for CSP.
 CSP_BASE_URI += (

--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -1,12 +1,8 @@
 import logging
 import os
-import environ
 import datetime
 
 from olympia.lib.settings_base import *  # noqa
-
-environ.Env.read_env(env_file='/etc/olympia/settings.env')
-env = environ.Env()
 
 ENGAGE_ROBOTS = True
 

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -1,12 +1,8 @@
 import logging
 import os
-import environ
 import datetime
 
 from olympia.lib.settings_base import *  # noqa
-
-environ.Env.read_env(env_file='/etc/olympia/settings.env')
-env = environ.Env()
 
 CSP_BASE_URI += (
     # Required for the legacy discovery pane.

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -14,6 +14,12 @@ from kombu import Queue
 
 env = environ.Env()
 
+ENVIRON_SETTINGS_FILE_PATH = '/etc/olympia/settings.env'
+
+if os.path.exists(ENVIRON_SETTINGS_FILE_PATH):
+    env.read_env(env_file=ENVIRON_SETTINGS_FILE_PATH)
+
+
 ALLOWED_HOSTS = [
     '.allizom.org',
     '.mozilla.org',


### PR DESCRIPTION
Fixes #7096

This currently makes all env() calls in our settings_base useless and
prevents us from unifying our settings in the long term.