### PR TITLE
revert #7017 to fix addons#576 - latest version is always the one 'reviewed', even if disabled.

### DIFF
--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -3630,6 +3630,9 @@ class TestReview(ReviewBase):
             'public|reject|')
 
     def test_post_review_ignore_disabled_or_beta(self):
+        """After #7017 was reverted this test doesn't work as we want - by
+        allowing the auto approved version to be confirmed - but as we expect.
+        """
         AutoApprovalSummary.objects.create(
             verdict=amo.AUTO_APPROVED, version=self.version)
         version_factory(addon=self.addon, file_kw={'status': amo.STATUS_BETA})
@@ -3639,8 +3642,7 @@ class TestReview(ReviewBase):
         response = self.client.get(self.url)
         assert response.status_code == 200
         expected_actions = [
-            'confirm_auto_approved', 'reject_multiple_versions', 'reply',
-            'super', 'comment']
+            'reject_multiple_versions', 'reply', 'super', 'comment']
         assert (
             [action[0] for action in response.context['actions']] ==
             expected_actions)

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -754,11 +754,9 @@ def review(request, addon, channel=None):
         perform_review_permission_checks(
             request, addon, channel, content_review_only=content_review_only)
 
-    # Find the last version (ignoring beta and disabled: they don't need to be
-    # reviewed, betas are always public and disabled will revert to their
-    # original status if they are ever re-enabled), it will be the version we
-    # want to review.
-    version = addon.find_latest_version(channel=channel)
+    # Reverted #7017's changes here
+    version = addon.find_latest_version(
+        channel=channel, exclude=(amo.STATUS_BETA,))
 
     if not settings.ALLOW_SELF_REVIEWS and addon.has_author(request.user):
         amo.messages.warning(


### PR DESCRIPTION
fix mozilla/addons#576 by reverting #7017