### PR TITLE
Remove email message prompting to migrate to webext

### DIFF
--- a/src/olympia/reviewers/templates/reviewers/emails/author_super_review.ltxt
+++ b/src/olympia/reviewers/templates/reviewers/emails/author_super_review.ltxt
@@ -10,8 +10,6 @@ If you want to respond please reply to this email or visit {{ dev_versions_url }
 You can also join us in #addon-reviewers on irc.mozilla.org.
 
 To learn more about the review process, please visit https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Reviews
-{% if legacy_addon %}
-To ensure your add-ons are compatible past Firefox 57, please migrate them to WebExtensions as soon as possible: https://mzl.la/1RzETMA
-{% endif %}
+--
 Mozilla Add-ons Team
 {{ SITE_URL }}

--- a/src/olympia/reviewers/templates/reviewers/emails/base.ltxt
+++ b/src/olympia/reviewers/templates/reviewers/emails/base.ltxt
@@ -7,9 +7,6 @@ If you want to respond please reply to this email or visit {{ dev_versions_url }
 You can also join us in #addon-reviewers on irc.mozilla.org.
 
 To learn more about the review process, please visit https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Reviews
-{% if legacy_addon %}
-To ensure your add-ons are compatible past Firefox 57, please migrate them to WebExtensions as soon as possible: https://mzl.la/1RzETMA
-{% endif %}
 --
 Mozilla Add-ons Team
 {{ SITE_URL }}

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -380,7 +380,6 @@ class TestReviewHelper(TestCase):
     def test_notify_email(self):
         self.helper.set_data(self.get_data())
         base_fragment = 'If you want to respond please reply'
-        legacy_cta_fragment = 'add-ons are compatible past Firefox 57'
         user = self.addon.listed_authors[0]
         ActivityLogToken.objects.create(version=self.version, user=user)
         uuid = self.version.token.get(user=user).uuid.hex
@@ -394,20 +393,7 @@ class TestReviewHelper(TestCase):
             self.helper.handler.notify_email(template, 'Sample subject %s, %s')
             assert len(mail.outbox) == 1
             assert base_fragment in mail.outbox[0].body
-            assert legacy_cta_fragment in mail.outbox[0].body
             assert mail.outbox[0].reply_to == [reply_email]
-
-    def test_no_legacy_addon_cta_in_webext(self):
-        self.version.all_files[0].update(is_webextension=True)
-        self.helper.set_data(self.get_data())
-        legacy_cta_fragment = 'add-ons are compatible past Firefox 57'
-        for template in ('nominated_to_public', 'nominated_to_sandbox',
-                         'pending_to_public', 'pending_to_sandbox',
-                         'author_super_review', 'unlisted_to_reviewed_auto'):
-            mail.outbox = []
-            self.helper.handler.notify_email(template, 'Sample subject %s, %s')
-            assert len(mail.outbox) == 1
-            assert legacy_cta_fragment not in mail.outbox[0].body
 
     def test_email_links(self):
         expected = {

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -560,9 +560,7 @@ class ReviewBase(object):
                                                  kwargs=review_url_kw,
                                                  add_prefix=False)),
                 'comments': self.data.get('comments'),
-                'SITE_URL': settings.SITE_URL,
-                'legacy_addon':
-                    not self.files[0].is_webextension if self.files else False}
+                'SITE_URL': settings.SITE_URL}
 
     def reviewer_reply(self):
         # Default to reviewer reply action.


### PR DESCRIPTION
Fixes #7114.

This reverts https://github.com/mozilla/addons-server/commit/16448298581c81d6c3e0cafc7cbcc3f900d803f1.