### PR TITLE
upgrade and lock django-tables2 to 1.16.0 because 1.8 support ends.

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -158,8 +158,8 @@ django-session-csrf==0.7.1 \
 django-statsd-mozilla==0.4.0 \
     --hash=sha256:81084f3d426f5184f0a0f1dbfe035cc26b66f041d2184559d916a228d856f0d3 \
     --hash=sha256:0d87cb63de8107279cbb748caad9aa74c6a44e7e96ccc5dbf07b89f77285a4b8
-django-tables2==1.14.2 \
-    --hash=sha256:40f18519f49cadec395dc2ce1590dcf8a27bca66f66f053342782f631f5ac0fc
+django-tables2==1.16.0 \
+    --hash=sha256:367d79bbe0a7968ce2a8b8e8e3586f51027abde2954521c978baa57642737375 # pyup: ==1.16.0
 django-waffle==0.12.0 \
     --hash=sha256:5825358d97cc327bc749cd3ce21ea70c958cd50ca91cb62e0c7b690eed83afc9 \
     --hash=sha256:b37da3c26b9d44920e9f5bb35a1339a9f8320437423e733aa8b1f8e03c39cb74

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -207,9 +207,11 @@ class AutoApprovedTable(ReviewerQueueTable):
         return super(AutoApprovedTable, self).render_flags(
             record.current_version)
 
-    def render_addon_name(self, record, url=None):
-        if url is None:
-            url = reverse('reviewers.review', args=[record.slug])
+    def _get_addon_name_url(self, record):
+        return reverse('reviewers.review', args=[record.slug])
+
+    def render_addon_name(self, record):
+        url = self._get_addon_name_url(record)
         return u'<a href="%s">%s <em>%s</em></a>' % (
             url, jinja2.escape(record.name),
             jinja2.escape(record.current_version))
@@ -244,10 +246,8 @@ class ContentReviewTable(AutoApprovedTable):
                    'weight')
         orderable = False
 
-    def render_addon_name(self, record):
-        url = reverse('reviewers.review', args=['content', record.slug])
-        return super(ContentReviewTable, self).render_addon_name(
-            record, url=url)
+    def _get_addon_name_url(self, record):
+        return reverse('reviewers.review', args=['content', record.slug])
 
 
 class ReviewHelper(object):


### PR DESCRIPTION
replaces #7141 - upgrades django-tables2 to 1.16.0.  We can't upgrade to the latest version of django-tables as support for 1.8 was removed in 1.17.0.

Refactoring was needed because https://github.com/jieter/django-tables2/compare/v1.14.2...v1.15.0#diff-0ba37b47c409c3a233d9a1508fb6e4f1R529 caused a conflict with the `url` kwarg in `render_addon_name`, meaning it wasn't called.