### PR TITLE
Update developer.css

### DIFF
--- a/static/css/zamboni/developers.css
+++ b/static/css/zamboni/developers.css
@@ -669,7 +669,8 @@ div.review-entry p {
 
 div.review-entry pre {
     white-space: pre-wrap;
-    word-break: break-all;
+    max-width: 650px;
+    word-wrap: break-word;
     margin-bottom: 0px;
 }
 


### PR DESCRIPTION
Fixes Issue #6971.

Updated `div.review-entry pre` selector in developer.css from 

```
word-break: break-all;
```

to 

```
max-width: 650px;
word-wrap: break-word; 
```

Here are the before and after screenshots again, please let me know if you need any additional information:

![beforescreenshot](https://user-images.githubusercontent.com/13584530/34305628-167f0c58-e70d-11e7-8675-81fb8b546701.png)

<img width="785" alt="screen shot 2017-12-22 at 11 39 15 am" src="https://user-images.githubusercontent.com/13584530/34305637-20f23494-e70d-11e7-8bab-4707813f117e.png">


Please let me know if there is anything else I need to do! Thanks!
