### PR TITLE
Fix URLs with "reviewers" string in them

### DIFF
--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -1678,13 +1678,18 @@ class TestAddonViewSetDetail(AddonAndVersionViewSetDetailMixin, TestCase):
         result = json.loads(response.content)
         assert result['id'] == self.addon.pk
         assert result['name'] == {'en-US': u'My Addôn'}
-        assert result['slug'] == 'my-addon'
+        assert result['slug'] == self.addon.slug
         assert result['last_updated'] == (
             self.addon.last_updated.replace(microsecond=0).isoformat() + 'Z')
         return result
 
     def _set_tested_url(self, param):
         self.url = reverse('addon-detail', kwargs={'pk': param})
+
+    def test_detail_url_with_reviewers_in_the_url(self):
+        self.addon.update(slug='something-reviewers')
+        self.url = reverse('addon-detail', kwargs={'pk': self.addon.slug})
+        self._test_url()
 
     def test_hide_latest_unlisted_version_anonymous(self):
         unlisted_version = version_factory(

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -2054,8 +2054,8 @@ class BaseTestQueueSearch(SearchTest):
         addon = Addon.objects.get(pk=generated.id)
         addon.name = {'ja': uni}
         addon.save()
-        response = self.client.get('/ja/' + self.url, {'text_query': uni},
-                                   follow=True)
+        self.url = self.url.replace('/en-US/', '/ja/')
+        response = self.client.get(self.url, {'text_query': uni}, follow=True)
         assert response.status_code == 200
         assert self.named_addons(response) == [name]
 
@@ -2084,8 +2084,8 @@ class BaseTestQueueSearch(SearchTest):
         addon = Addon.objects.get(pk=generated.id)
         addon.support_email = {'ja': uni}
         addon.save()
-        response = self.client.get('/ja/' + self.url, {'text_query': uni},
-                                   follow=True)
+        self.url = self.url.replace('/en-US/', '/ja/')
+        response = self.client.get(self.url, {'text_query': uni}, follow=True)
         assert response.status_code == 200
         assert self.named_addons(response) == [name]
 

--- a/src/olympia/urls.py
+++ b/src/olympia/urls.py
@@ -52,10 +52,10 @@ urlpatterns = [
     url('^developers/', include('olympia.devhub.urls')),
 
     # Reviewers Hub.
-    url('reviewers/', include('olympia.reviewers.urls')),
+    url('^reviewers/', include('olympia.reviewers.urls')),
 
     # Redirect everything under editors/ (old reviewer urls) to reviewers/.
-    url('editors/(.*)',
+    url('^editors/(.*)',
         lambda r, path: redirect('/reviewers/%s' % path, permanent=True)),
 
     # AMO admin (not django admin).


### PR DESCRIPTION
Reviewer tools URLs need to *start* with "/reviewers"

Fix #7132