### PR TITLE
Simplify temporary files setup during tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ install:
   - nvm deactivate
   - nvm install 6
   - nvm use 6
-  - pip install --upgrade pip wheel setuptools tox==1.8.1
+  - pip install --upgrade pip wheel setuptools tox==2.9.1
   - curl -sL -o ./gimme https://raw.githubusercontent.com/travis-ci/gimme/v1.2.0/gimme
   - chmod +x ./gimme
   - eval "$(./gimme 1.8.5)"

--- a/Makefile-os
+++ b/Makefile-os
@@ -20,22 +20,22 @@ help_submake:
 	@echo "  update_docker     to update a docker image"
 
 test:
-	docker-compose exec web py.test $(APP) $(ARGS)
+	docker-compose exec web pytest $(APP) $(ARGS)
 
 test_es:
-	docker-compose exec web py.test -m es_tests $(APP) $(ARGS)
+	docker-compose exec web pytest -m es_tests $(APP) $(ARGS)
 
 test_no_es:
-	docker-compose exec web py.test -m "not es_tests" $(APP) $(ARGS)
+	docker-compose exec web pytest -m "not es_tests" $(APP) $(ARGS)
 
 test_force_db:
-	docker-compose exec web py.test --create-db $(APP) $(ARGS)
+	docker-compose exec web pytest --create-db $(APP) $(ARGS)
 
 tdd:
-	docker-compose exec web py.test -x --pdb $(ARGS) $(APP)
+	docker-compose exec web pytest -x --pdb $(ARGS) $(APP)
 
 test_failed:
-	docker-compose exec web py.test --lf $(ARGS) $(APP)
+	docker-compose exec web pytest --lf $(ARGS) $(APP)
 
 update_docker:
 	docker-compose exec worker make update_deps

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,4 @@
 from django import http, test
-from django.conf import settings
 from django.core.cache import cache
 from django.utils import translation
 
@@ -74,7 +73,7 @@ def instrument_jinja():
     jinja2.Template.render = instrumented_render
 
 
-def default_prefixer():
+def default_prefixer(settings):
     """Make sure each test starts with a default URL prefixer."""
     request = http.HttpRequest()
     request.META['SCRIPT_NAME'] = ''
@@ -84,8 +83,8 @@ def default_prefixer():
     amo.urlresolvers.set_url_prefix(prefixer)
 
 
-@pytest.fixture(autouse=True)
-def test_pre_setup():
+@pytest.yield_fixture(autouse=True)
+def test_pre_setup(request, tmpdir, settings):
     cache.clear()
     # Override django-cache-machine caching.base.TIMEOUT because it's
     # computed too early, before settings_test.py is imported.
@@ -96,12 +95,25 @@ def test_pre_setup():
     translation.trans_real._translations = {}
     translation.trans_real.activate(settings.LANGUAGE_CODE)
 
-    # Reset the prefixer.
-    default_prefixer()
+    settings.MEDIA_ROOT = str(tmpdir.mkdir('media'))
+    settings.TMP_PATH = str(tmpdir.mkdir('tmp'))
+    settings.NETAPP_STORAGE = settings.TMP_PATH
 
+    # Reset the prefixer and urlconf after updating media root
+    default_prefixer(settings)
 
-@pytest.fixture(autouse=True)
-def test_post_teardown():
+    from django.core.urlresolvers import clear_url_caches, set_urlconf
+
+    def _clear_urlconf():
+        clear_url_caches()
+        set_urlconf(None)
+
+    _clear_urlconf()
+
+    request.addfinalizer(_clear_urlconf)
+
+    yield
+
     core.set_user(None)
     clean_translations(None)  # Make sure queued translations are removed.
 
@@ -116,7 +128,7 @@ def admin_group(db):
 
 
 @pytest.fixture
-def mozilla_user(admin_group):
+def mozilla_user(admin_group, settings):
     """Create a "Mozilla User"."""
     user = UserProfile.objects.create(pk=settings.TASK_USER_ID,
                                       email='admin@mozilla.com',

--- a/docs/topics/development/testing.rst
+++ b/docs/topics/development/testing.rst
@@ -38,7 +38,7 @@ Running Tests
 
 To run the whole test suite use::
 
-    py.test
+    pytest
 
 There are a lot of options you can pass to adjust the output.  Read `pytest`_
 and `pytest-django`_ docs for the full set, but some common ones are:
@@ -83,7 +83,7 @@ Our test runner is configured by default to reuse the database between each
 test run.  If you really want to make a new database (e.g. when models have
 changed), use the ``--create-db`` parameter::
 
-    py.test --create-db
+    pytest --create-db
 
 or
 

--- a/docs/topics/development/tests.rst
+++ b/docs/topics/development/tests.rst
@@ -13,27 +13,27 @@ Other, more niche, test commands::
     make tdd # run the entire test suite, but stop on the first error
 
 
-Using py.test directly
+Using pytest directly
 ----------------------
 
 **For advanced users.**
-To run the entire test suite you never need to use ``py.test`` directly.
+To run the entire test suite you never need to use ``pytest`` directly.
 
 You can connect to the docker container using ``make shell``; then use
-``py.test`` directly, which allows for finer-grained control of the test
+``pytest`` directly, which allows for finer-grained control of the test
 suite.
 
 Run your tests like this::
 
-    py.test
+    pytest
 
 For running subsets of the entire test suite, you can specify which tests
 run using different methods:
 
-* `py.test -m es_tests` to run the tests that are marked_ as `es_tests`
-* `py.test -k test_no_license` to run all the tests that have
+* `pytest -m es_tests` to run the tests that are marked_ as `es_tests`
+* `pytest -k test_no_license` to run all the tests that have
   `test_no_license` in their name
-* `py.test src/olympia/addons/tests/test_views.py::TestLicensePage::test_no_license`
+* `pytest src/olympia/addons/tests/test_views.py::TestLicensePage::test_no_license`
   to run this specific test
 
 For more, see the `Pytest usage documentation`_.

--- a/docs/topics/install/deprecated/elasticsearch.rst
+++ b/docs/topics/install/deprecated/elasticsearch.rst
@@ -96,7 +96,7 @@ All test cases using Elasticsearch should inherit from ``amo.tests.ESTestCase``.
 All such tests are marked with the ``es_tests`` pytest_ marker. To run only
 those tests::
 
-    py.test -m es_tests
+    pytest -m es_tests
 
 or
 

--- a/docs/topics/install/docker.rst
+++ b/docs/topics/install/docker.rst
@@ -95,7 +95,7 @@ Run the tests using ``make``, *outside* of the Docker container::
 
     make test
     # or
-    docker-compose exec web py.test src/olympia/
+    docker-compose exec web pytest src/olympia/
 
 You can run commands inside the Docker container by ``ssh``\ing into it using::
 
@@ -105,13 +105,13 @@ You can run commands inside the Docker container by ``ssh``\ing into it using::
 
 Then to run the tests inside the Docker container you can run::
 
-    py.test
+    pytest
 
 You can also run single commands from your host machine without opening a shell
-on each container. Here is an example of running the ``py.test`` command on the
+on each container. Here is an example of running the ``pytest`` command on the
 ``web`` container::
 
-    docker-compose run web py.test
+    docker-compose run web pytest
 
 If you'd like to use a python debugger to interactively
 debug Django view code, check out the :ref:`debugging` section.

--- a/services/settings.py
+++ b/services/settings.py
@@ -1,8 +1,5 @@
 import os
 
-from django.utils import importlib
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'settings_local')
 
-
-# get the right settings module
-settings = importlib.import_module(
-    os.environ.get('DJANGO_SETTINGS_MODULE', 'settings_local'))
+from django.conf import settings  # noqa isort:nofix

--- a/settings_test.py
+++ b/settings_test.py
@@ -1,43 +1,13 @@
 # -*- coding: utf-8 -*-
 from settings import *  # noqa
 
-import atexit
-import tempfile
-
 from django.utils.functional import lazy
-
-
-_tmpdirs = set()
-
-
-def _cleanup():
-    try:
-        import sys
-        import shutil
-    except ImportError:
-        return
-    tmp = None
-    try:
-        for tmp in _tmpdirs:
-            shutil.rmtree(tmp)
-    except Exception, exc:
-        sys.stderr.write("\n** shutil.rmtree(%r): %s\n" % (tmp, exc))
-
-atexit.register(_cleanup)
-
-
-def _polite_tmpdir():
-    tmp = tempfile.mkdtemp()
-    _tmpdirs.add(tmp)
-    return tmp
 
 # Make sure the app needed to test translations is present.
 INSTALLED_APPS += TEST_INSTALLED_APPS
 
 # See settings.py for documentation:
 IN_TEST_SUITE = True
-MEDIA_ROOT = _polite_tmpdir()
-TMP_PATH = _polite_tmpdir()
 
 # Don't call out to persona in tests.
 AUTHENTICATION_BACKENDS = (

--- a/src/olympia/addons/tests/test_forms.py
+++ b/src/olympia/addons/tests/test_forms.py
@@ -226,7 +226,7 @@ class TestIconForm(TestCase):
     # so this isn't necessary
     def setUp(self):
         super(TestIconForm, self).setUp()
-        self.temp_dir = tempfile.mkdtemp()
+        self.temp_dir = tempfile.mkdtemp(dir=settings.TMP_PATH)
         self.addon = Addon.objects.get(pk=3615)
 
         class DummyRequest:

--- a/src/olympia/amo/monitors.py
+++ b/src/olympia/amo/monitors.py
@@ -102,7 +102,7 @@ def path():
           user_media_path('previews'),
           user_media_path('userpics'),
           user_media_path('reviewer_attachments'),
-          dump_apps.Command.JSON_PATH,)
+          dump_apps.Command.get_json_path(),)
     r = [os.path.join(settings.ROOT, 'locale'),
          # The deploy process will want write access to this.
          # We do not want Django to have write access though.

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -1028,7 +1028,7 @@ class WithDynamicEndpoints(TestCase):
 
 def get_temp_filename():
     """Get a unique, non existing, temporary filename."""
-    with NamedTemporaryFile() as tempfile:
+    with NamedTemporaryFile(dir=settings.TMP_PATH) as tempfile:
         return tempfile.name
 
 

--- a/src/olympia/amo/tests/test_amo_utils.py
+++ b/src/olympia/amo/tests/test_amo_utils.py
@@ -158,7 +158,7 @@ class TestLocalFileStorage(BaseTestCase):
 
     def setUp(self):
         super(TestLocalFileStorage, self).setUp()
-        self.tmp = tempfile.mkdtemp()
+        self.tmp = tempfile.mkdtemp(dir=settings.TMP_PATH)
         self.stor = LocalFileStorage()
 
     def tearDown(self):

--- a/src/olympia/amo/tests/test_readonly.py
+++ b/src/olympia/amo/tests/test_readonly.py
@@ -1,64 +1,45 @@
-from django.conf import settings
 from django.db import models
-from django.utils import importlib
 
 import MySQLdb as mysql
+import pytest
 from pyquery import PyQuery as pq
 
-from olympia.amo.tests import TestCase
 from olympia.addons.models import Addon
 
 
-def pubdir(ob):
-    for name in dir(ob):
-        if not name.startswith('_'):
-            yield name
-
-
-def quickcopy(val):
-    if isinstance(val, dict):
-        val = val.copy()
-    elif isinstance(val, list):
-        val = list(val)
-    return val
-
-
-class ReadOnlyModeTest(TestCase):
-    extra = ('olympia.amo.middleware.ReadOnlyMiddleware',)
-
-    def setUp(self):
-        super(ReadOnlyModeTest, self).setUp()
-        models.signals.pre_save.connect(self.db_error)
-        models.signals.pre_delete.connect(self.db_error)
-        self.old_settings = dict((k, quickcopy(getattr(settings, k)))
-                                 for k in pubdir(settings))
-        settings.SLAVE_DATABASES = ['default']
-        settings_module = importlib.import_module(settings.SETTINGS_MODULE)
-        settings_module.read_only_mode(settings._wrapped.__dict__)
-        self.client.handler.load_middleware()
-
-    def tearDown(self):
-        for k in pubdir(settings):
-            if k not in self.old_settings:
-                delattr(self.old_settings, k)
-        for k, v in self.old_settings.items():
-            try:
-                setattr(settings, k, v)
-            except AttributeError:
-                # __weakref__
-                pass
-        models.signals.pre_save.disconnect(self.db_error)
-        models.signals.pre_delete.disconnect(self.db_error)
-        super(ReadOnlyModeTest, self).tearDown()
-
-    def db_error(self, *args, **kwargs):
+@pytest.yield_fixture
+def read_only_mode(client, settings, db):
+    def _db_error(*args, **kwargs):
         raise mysql.OperationalError("You can't do this in read-only mode.")
 
-    def test_db_error(self):
-        self.assertRaises(mysql.OperationalError, Addon.objects.create, id=12)
+    settings.SLAVE_DATABASES = ['default']
+    models.signals.pre_save.connect(_db_error)
+    models.signals.pre_delete.connect(_db_error)
 
-    def test_bail_on_post(self):
-        r = self.client.post('/en-US/firefox/')
-        assert r.status_code == 503
-        title = pq(r.content)('title').text()
-        assert title.startswith('Maintenance in progress'), title
+    from olympia.lib.settings_base import read_only_mode
+
+    env = {key: getattr(settings, key) for key in settings._explicit_settings}
+
+    read_only_mode(env)
+
+    for key, value in env.items():
+        setattr(settings, key, value)
+
+    client.handler.load_middleware()
+
+    yield
+
+    models.signals.pre_save.disconnect(_db_error)
+    models.signals.pre_delete.disconnect(_db_error)
+
+
+def test_db_error(read_only_mode):
+    with pytest.raises(mysql.OperationalError):
+        Addon.objects.create(id=12)
+
+
+def test_bail_on_post(read_only_mode, client):
+    r = client.post('/en-US/firefox/')
+    assert r.status_code == 503
+    title = pq(r.content)('title').text()
+    assert title.startswith('Maintenance in progress'), title

--- a/src/olympia/amo/tests/test_storage_utils.py
+++ b/src/olympia/amo/tests/test_storage_utils.py
@@ -2,6 +2,7 @@ from functools import partial
 import os
 import tempfile
 
+from django.conf import settings
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage as storage
 
@@ -17,7 +18,7 @@ pytestmark = pytest.mark.django_db
 
 
 def test_storage_walk():
-    tmp = tempfile.mkdtemp()
+    tmp = tempfile.mkdtemp(dir=settings.TMP_PATH)
     jn = partial(os.path.join, tmp)
     try:
         storage.save(jn('file1.txt'), ContentFile(''))
@@ -53,7 +54,7 @@ def test_storage_walk():
 
 
 def test_rm_stored_dir():
-    tmp = tempfile.mkdtemp()
+    tmp = tempfile.mkdtemp(dir=settings.TMP_PATH)
     jn = partial(os.path.join, tmp)
     try:
         storage.save(jn('file1.txt'), ContentFile('<stuff>'))
@@ -78,7 +79,7 @@ class TestFileOps(BaseTestCase):
 
     def setUp(self):
         super(TestFileOps, self).setUp()
-        self.tmp = tempfile.mkdtemp()
+        self.tmp = tempfile.mkdtemp(dir=settings.TMP_PATH)
 
     def tearDown(self):
         rm_local_tmp_dir(self.tmp)

--- a/src/olympia/amo/tests/test_utils_.py
+++ b/src/olympia/amo/tests/test_utils_.py
@@ -121,7 +121,7 @@ def test_has_links():
 
 
 def test_walkfiles():
-    basedir = tempfile.mkdtemp()
+    basedir = tempfile.mkdtemp(dir=settings.TMP_PATH)
     subdir = tempfile.mkdtemp(dir=basedir)
     file1, file1path = tempfile.mkstemp(dir=basedir, suffix='_foo')
     file2, file2path = tempfile.mkstemp(dir=subdir, suffix='_foo')

--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -782,6 +782,8 @@ def rm_local_tmp_dir(path):
     certain that your executing code is operating on a local temp dir, not a
     directory managed by the Django Storage API.
     """
+    assert path.startswith(settings.TMP_PATH)
+
     return shutil.rmtree(path)
 
 

--- a/src/olympia/applications/management/commands/dump_apps.py
+++ b/src/olympia/applications/management/commands/dump_apps.py
@@ -17,7 +17,9 @@ log = olympia.core.logger.getLogger('z.cron')
 class Command(BaseCommand):
     help = 'Dump a json file containing AMO apps and versions.'
 
-    JSON_PATH = os.path.join(settings.MEDIA_ROOT, 'apps.json')
+    @classmethod
+    def get_json_path(self):
+        return os.path.join(settings.MEDIA_ROOT, 'apps.json')
 
     def handle(self, *args, **kw):
         apps = {}
@@ -34,6 +36,6 @@ class Command(BaseCommand):
                 pass
 
         # Local file, to be read by validator.
-        with storage.open(self.JSON_PATH, 'w') as f:
+        with storage.open(self.get_json_path(), 'w') as f:
             json.dump(apps, f)
             log.debug("Wrote: %s" % f.name)

--- a/src/olympia/applications/tests.py
+++ b/src/olympia/applications/tests.py
@@ -1,6 +1,5 @@
 import json
 import mock
-import tempfile
 
 from django.core.management import call_command
 from django.db import IntegrityError
@@ -59,21 +58,19 @@ class TestCommands(TestCase):
     fixtures = ['base/appversion']
 
     def test_dump_apps(self):
-        tmpdir = tempfile.mkdtemp()
-        with self.settings(MEDIA_ROOT=tmpdir):  # Don't overwrite apps.json.
-            from olympia.applications.management.commands import dump_apps
-            call_command('dump_apps')
-            with open(dump_apps.Command.JSON_PATH, 'r') as f:
-                apps = json.load(f)
-            for idx, app in amo.APP_IDS.iteritems():
-                data = apps[str(app.id)]
-                versions = sorted([a.version for a in
-                                   AppVersion.objects.filter(
-                                       application=app.id)])
-                assert "%s: %r" % (app.short, sorted(data['versions'])) == (
-                    "%s: %r" % (app.short, versions))
-                assert data['name'] == app.short
-                assert data['guid'] == app.guid
+        from olympia.applications.management.commands import dump_apps
+        call_command('dump_apps')
+        with open(dump_apps.Command.get_json_path(), 'r') as f:
+            apps = json.load(f)
+        for idx, app in amo.APP_IDS.iteritems():
+            data = apps[str(app.id)]
+            versions = sorted([a.version for a in
+                               AppVersion.objects.filter(
+                                   application=app.id)])
+            assert "%s: %r" % (app.short, sorted(data['versions'])) == (
+                "%s: %r" % (app.short, versions))
+            assert data['name'] == app.short
+            assert data['guid'] == app.guid
 
     def test_addnewversion(self):
         new_version = '123.456'

--- a/src/olympia/devhub/tasks.py
+++ b/src/olympia/devhub/tasks.py
@@ -506,12 +506,14 @@ def run_validator(path, for_appversions=None, test_all_tiers=False,
     """
     from validator.validate import validate
 
-    apps = dump_apps.Command.JSON_PATH
+    apps = dump_apps.Command.get_json_path()
 
     if not os.path.exists(apps):
         call_command('dump_apps')
 
-    with NamedTemporaryFile(suffix='_' + os.path.basename(path)) as temp:
+    suffix = '_' + os.path.basename(path)
+
+    with NamedTemporaryFile(suffix=suffix, dir=settings.TMP_PATH) as temp:
         if path and not os.path.exists(path) and storage.exists(path):
             # This file doesn't exist locally. Write it to our
             # currently-open temp file and switch to that path.
@@ -555,7 +557,9 @@ def run_addons_linter(path, listed=True):
             'Path "{}" is not a file or directory or does not exist.'
             .format(path))
 
-    stdout, stderr = tempfile.TemporaryFile(), tempfile.TemporaryFile()
+    stdout, stderr = (
+        tempfile.TemporaryFile(dir=settings.TMP_PATH),
+        tempfile.TemporaryFile(dir=settings.TMP_PATH))
 
     with statsd.timer('devhub.linter'):
         process = subprocess.Popen(

--- a/src/olympia/devhub/tests/test_tasks.py
+++ b/src/olympia/devhub/tests/test_tasks.py
@@ -69,8 +69,8 @@ def _uploader(resize_size, final_size):
     img = get_image_path('mozilla.png')
     original_size = (339, 128)
 
-    src = tempfile.NamedTemporaryFile(mode='r+w+b', suffix=".png",
-                                      delete=False)
+    src = tempfile.NamedTemporaryFile(
+        mode='r+w+b', suffix='.png', delete=False, dir=settings.TMP_PATH)
 
     # resize_icon removes the original
     shutil.copyfile(img, src.name)
@@ -96,7 +96,7 @@ def _uploader(resize_size, final_size):
             assert not os.path.exists(dest_image.filename)
         shutil.rmtree(uploadto)
     else:
-        dest = tempfile.mktemp(suffix='.png')
+        dest = tempfile.mktemp(suffix='.png', dir=settings.TMP_PATH)
         tasks.resize_icon(src.name, dest, resize_size, locally=True)
         dest_image = Image.open(dest)
         assert dest_image.size == final_size

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -1,12 +1,9 @@
 import json
 import os
-import tempfile
 
-from django.conf import settings
 from django.core.cache import cache
 from django.core.files.storage import default_storage as storage
 from django.db.models import Q
-from django.test.utils import override_settings
 
 import mock
 from PIL import Image
@@ -31,7 +28,6 @@ from olympia.tags.models import Tag, AddonTag
 from olympia.users.models import UserProfile
 
 
-@override_settings(MEDIA_ROOT=None)  # Make it overridable.
 class BaseTestEdit(TestCase):
     fixtures = ['base/users', 'base/addon_3615',
                 'base/addon_5579', 'base/addon_3615_categories']
@@ -39,8 +35,6 @@ class BaseTestEdit(TestCase):
     __test__ = False  # this is an abstract test case
 
     def setUp(self):
-        # Make new for each test.
-        settings.MEDIA_ROOT = tempfile.mkdtemp()
         super(BaseTestEdit, self).setUp()
         assert self.client.login(email='del@icio.us')
 

--- a/src/olympia/files/templatetags/jinja_helpers.py
+++ b/src/olympia/files/templatetags/jinja_helpers.py
@@ -118,8 +118,9 @@ class FileViewer(object):
         self.file = file_obj
         self.addon = self.file.version.addon
         self.src = file_obj.current_file_path
+        self.base_tmp_path = os.path.join(settings.TMP_PATH, 'file_viewer')
         self.dest = os.path.join(
-            settings.TMP_PATH, 'file_viewer',
+            self.base_tmp_path,
             datetime.now().strftime('%m%d'),
             str(file_obj.pk))
         self._files, self.selected = None, None
@@ -395,7 +396,7 @@ class FileViewer(object):
         return result
 
     def _check_dest_for_complete_listing(self, expected_files):
-        """Check that all filex we expect are in `self.dest`."""
+        """Check that all files we expect are in `self.dest`."""
         dest_len = len(self.dest)
 
         files_to_verify = get_all_files(self.dest)
@@ -408,10 +409,14 @@ class FileViewer(object):
 
     def _normalize_file_list(self, expected_files):
         """Normalize file names, strip /tmp/xxxx/ prefix."""
-        normalized_files = [fname.strip('/') for fname in expected_files]
-        normalized_files = [
-            os.path.join(*fname.split(os.path.sep)[2:])
-            for fname in normalized_files]
+        prefix_len = settings.TMP_PATH.count('/')
+
+        normalized_files = filter(None, (
+            fname.strip('/').split('/')[prefix_len + 1:]
+            for fname in expected_files
+            if fname.startswith(settings.TMP_PATH)))
+
+        normalized_files = [os.path.join(*fname) for fname in normalized_files]
 
         return normalized_files
 
@@ -420,7 +425,7 @@ class FileViewer(object):
         # few milliseconds but it's still way faster than doing any
         # kind of sleeps to wait for writes to happen.
         for fname in files:
-            fpath = os.path.join(settings.TMP_PATH, fname)
+            fpath = os.path.join(self.base_tmp_path, fname)
             descriptor = os.open(fpath, os.O_RDONLY)
             os.fsync(descriptor)
 

--- a/src/olympia/files/tests/test_models.py
+++ b/src/olympia/files/tests/test_models.py
@@ -17,7 +17,7 @@ from mock import patch
 
 from olympia import amo
 from olympia.amo.tests import TestCase
-from olympia.amo.utils import rm_local_tmp_dir, chunked
+from olympia.amo.utils import chunked
 from olympia.addons.models import Addon
 from olympia.applications.models import AppVersion
 from olympia.files.models import (
@@ -1306,21 +1306,17 @@ class TestFileFromUpload(UploadTest):
 
 class TestZip(TestCase, amo.tests.AMOPaths):
 
-    def test_zip(self):
-        # This zip contains just one file chrome/ that we expect
-        # to be unzipped as a directory, not a file.
+    def test_zip_python_bug_4710(self):
+        """This zip contains just one file chrome/ that we expect
+        to be unzipped as a directory, not a file.
+        """
         xpi = self.xpi_path('directory-test')
 
-        # This is to work around: http://bugs.python.org/issue4710
-        # which was fixed in Python 2.6.2. If the required version
-        # of Python for zamboni goes to 2.6.2 or above, this can
-        # be removed.
-        try:
-            dest = tempfile.mkdtemp()
-            zipfile.ZipFile(xpi).extractall(dest)
-            assert os.path.isdir(os.path.join(dest, 'chrome'))
-        finally:
-            rm_local_tmp_dir(dest)
+        # This was to work around: http://bugs.python.org/issue4710
+        # which was fixed in Python 2.6.2.
+        dest = tempfile.mkdtemp(dir=settings.TMP_PATH)
+        zipfile.ZipFile(xpi).extractall(dest)
+        assert os.path.isdir(os.path.join(dest, 'chrome'))
 
 
 class TestParseSearch(TestCase, amo.tests.AMOPaths):

--- a/src/olympia/files/tests/test_utils_.py
+++ b/src/olympia/files/tests/test_utils_.py
@@ -11,6 +11,7 @@ import lxml
 import mock
 import pytest
 
+from django.conf import settings
 from django import forms
 from defusedxml.common import EntitiesForbidden, NotSupportedError
 
@@ -163,7 +164,7 @@ class TestManifestJSONExtractor(TestCase):
     def test_instanciate_without_data(self):
         """Without data, we load the data from the file path."""
         data = {'id': 'some-id'}
-        with tempfile.NamedTemporaryFile() as file_:
+        with tempfile.NamedTemporaryFile(dir=settings.TMP_PATH) as file_:
             file_.write(json.dumps(data))
             file_.flush()
             mje = utils.ManifestJSONExtractor(file_.name)
@@ -645,7 +646,7 @@ def test_extract_translations_fail_silent_invalid_file(read_mock, file_obj):
 
 
 def test_get_all_files():
-    tempdir = tempfile.mkdtemp()
+    tempdir = tempfile.mkdtemp(dir=settings.TMP_PATH)
 
     os.mkdir(os.path.join(tempdir, 'dir1'))
 
@@ -663,7 +664,7 @@ def test_get_all_files():
 
 
 def test_get_all_files_strip_prefix_no_prefix_silent():
-    tempdir = tempfile.mkdtemp()
+    tempdir = tempfile.mkdtemp(dir=settings.TMP_PATH)
 
     os.mkdir(os.path.join(tempdir, 'dir1'))
 
@@ -679,7 +680,7 @@ def test_get_all_files_strip_prefix_no_prefix_silent():
 
 
 def test_get_all_files_prefix():
-    tempdir = tempfile.mkdtemp()
+    tempdir = tempfile.mkdtemp(dir=settings.TMP_PATH)
 
     os.mkdir(os.path.join(tempdir, 'dir1'))
 
@@ -695,7 +696,7 @@ def test_get_all_files_prefix():
 
 
 def test_get_all_files_prefix_with_strip_prefix():
-    tempdir = tempfile.mkdtemp()
+    tempdir = tempfile.mkdtemp(dir=settings.TMP_PATH)
 
     os.mkdir(os.path.join(tempdir, 'dir1'))
 

--- a/src/olympia/files/tests/test_views.py
+++ b/src/olympia/files/tests/test_views.py
@@ -438,13 +438,13 @@ class TestFileViewer(FilesBase, TestCase):
         res = self.client.get(self.file_url(u'\u1109\u1161\u11a9'))
         assert res.status_code == 200
 
-    @override_settings(TMP_PATH=unicode(settings.TMP_PATH))
     def test_unicode_fails_with_wrong_configured_basepath(self):
-        file_viewer = FileViewer(self.file)
-        file_viewer.src = unicode_filenames
+        with override_settings(TMP_PATH=unicode(settings.TMP_PATH)):
+            file_viewer = FileViewer(self.file)
+            file_viewer.src = unicode_filenames
 
-        with pytest.raises(UnicodeDecodeError):
-            file_viewer.extract()
+            with pytest.raises(UnicodeDecodeError):
+                file_viewer.extract()
 
     def test_serve_no_token(self):
         self.file_viewer.extract()

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -647,6 +647,7 @@ class SafeUnzip(object):
         """Extracts the given info to a directory and checks the file size."""
         self.zip_file.extract(info, dest)
         dest = os.path.join(dest, info.filename)
+
         if not os.path.isdir(dest):
             # Directories consistently report their size incorrectly.
             size = os.stat(dest)[stat.ST_SIZE]
@@ -673,7 +674,7 @@ class SafeUnzip(object):
 
 def extract_zip(source, remove=False, fatal=True):
     """Extracts the zip file. If remove is given, removes the source file."""
-    tempdir = tempfile.mkdtemp()
+    tempdir = tempfile.mkdtemp(dir=settings.TMP_PATH)
 
     zip_file = SafeUnzip(source)
     try:
@@ -695,6 +696,7 @@ def copy_over(source, dest):
     """
     if os.path.exists(dest) and os.path.isdir(dest):
         shutil.rmtree(dest)
+
     shutil.copytree(source, dest)
     # mkdtemp will set the directory permissions to 700
     # for the webserver to read them, we need 755
@@ -784,8 +786,8 @@ def parse_xpi(xpi, addon=None, minimal=False):
     only the minimal set of properties needed to decide what to do with the
     add-on: guid, version and is_webextension.
     """
-    # Extract to /tmp
-    path = tempfile.mkdtemp()
+    # Extract to our configured temporary directory
+    path = tempfile.mkdtemp(dir=settings.TMP_PATH)
     try:
         xpi = get_file(xpi)
         extract_xpi(xpi, path)
@@ -967,17 +969,15 @@ def write_crx_as_xpi(chunks, storage, target):
     archive, then write it to `target`. Read more about the CRX file format:
     https://developer.chrome.com/extensions/crx
     """
-    temp_crx_file = tempfile.mkstemp()[1]  # a temp file to store the CRX
-
     # First we open the uploaded CRX so we can see how much we need
     # to trim from the header of the file to make it a valid ZIP.
-    with storage.open(temp_crx_file, 'rwb+') as temp_file:
+    with tempfile.NamedTemporaryFile('rwb+', dir=settings.TMP_PATH) as tmp:
         for chunk in chunks:
-            temp_file.write(chunk)
+            tmp.write(chunk)
 
-        temp_file.seek(0)
+        tmp.seek(0)
 
-        header = temp_file.read(16)
+        header = tmp.read(16)
         header_info = struct.unpack('4cHxII', header)
         public_key_length = header_info[5]
         signature_length = header_info[6]
@@ -987,16 +987,16 @@ def write_crx_as_xpi(chunks, storage, target):
         start_position = 16 + public_key_length + signature_length
 
         hash = hashlib.sha256()
-        temp_file.seek(start_position)
+        tmp.seek(start_position)
 
         # Now we open the Django storage and write our real XPI file.
         with storage.open(target, 'wb') as file_destination:
-            bytes = temp_file.read(65536)
+            bytes = tmp.read(65536)
             # Keep reading bytes and writing them to the XPI.
             while bytes:
                 hash.update(bytes)
                 file_destination.write(bytes)
-                bytes = temp_file.read(65536)
+                bytes = tmp.read(65536)
 
     return hash
 

--- a/src/olympia/landfill/images.py
+++ b/src/olympia/landfill/images.py
@@ -21,7 +21,7 @@ def generate_addon_preview(addon):
     color = random.choice(ImageColor.colormap.keys())
     im = Image.new('RGB', (320, 480), color)
     p = Preview.objects.create(addon=addon, caption='Screenshot 1', position=1)
-    f = tempfile.NamedTemporaryFile()
+    f = tempfile.NamedTemporaryFile(dir=settings.TMP_PATH)
     im.save(f, 'png')
     resize_preview(f.name, p)
 

--- a/src/olympia/lib/crypto/packaged.py
+++ b/src/olympia/lib/crypto/packaged.py
@@ -119,7 +119,7 @@ def call_signing(file_obj):
     cert_serial_num = get_signer_serial_number(pkcs7)
 
     # We only want the (unique) temporary file name.
-    with tempfile.NamedTemporaryFile() as temp_file:
+    with tempfile.NamedTemporaryFile(dir=settings.TMP_PATH) as temp_file:
         temp_filename = temp_file.name
 
     jar.make_signed(

--- a/src/olympia/lib/crypto/tests/test_packaged.py
+++ b/src/olympia/lib/crypto/tests/test_packaged.py
@@ -249,7 +249,7 @@ class TestPackagedTrunion(TestCase):
             # The multi-package itself isn't signed.
             assert not packaged.is_signed(self.file_.file_path)
             # The internal extensions aren't either.
-            folder = tempfile.mkdtemp()
+            folder = tempfile.mkdtemp(dir=settings.TMP_PATH)
             try:
                 extract_xpi(self.file_.file_path, folder)
                 # The extension isn't.

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -530,7 +530,7 @@ INSTALLED_APPS = (
 
 # These apps are only needed in a testing environment. They are added to
 # INSTALLED_APPS by settings_test.py (which is itself loaded by setup.cfg by
-# py.test)
+# pytest)
 TEST_INSTALLED_APPS = (
     'olympia.translations.tests.testapp',
 )
@@ -1389,7 +1389,7 @@ def read_only_mode(env):
 
     # Replace the default (master) db with a slave connection.
     if not env.get('SLAVE_DATABASES'):
-        raise Exception("We need at least one slave database.")
+        raise Exception('We need at least one slave database.')
     slave = env['SLAVE_DATABASES'][0]
     env['DATABASES']['default'] = env['DATABASES'][slave]
 

--- a/src/olympia/lib/tests/test_product_details_backend.py
+++ b/src/olympia/lib/tests/test_product_details_backend.py
@@ -1,15 +1,17 @@
 import json
 from tempfile import mkdtemp
 
+from django.conf import settings
+
 from mock import patch
 
 from olympia.lib.product_details_backend import NoCachePDFileStorage
 
 
 class TestNoCachePDFileStorage(object):
-    storage = NoCachePDFileStorage(json_dir=mkdtemp())
-
     def setup(self):
+        self.storage = NoCachePDFileStorage(
+            json_dir=mkdtemp(dir=settings.TMP_PATH))
         self.storage.clear_cache()
 
     def test_no_cache(self):

--- a/tox.ini
+++ b/tox.ini
@@ -13,48 +13,49 @@ whitelist_externals =
     make
     npm
     bash
+    pytest
 
 [testenv:es]
 commands =
     make -f Makefile-docker update_deps
     bash {toxinidir}/locale/compile-mo.sh {toxinidir}/locale/
-    py.test -m es_tests --ignore=tests/ui/ -v {posargs}
+    pytest -m es_tests --ignore=tests/ui/ -v {posargs}
 
 [testenv:addons]
 commands =
     make -f Makefile-docker update_deps
     bash {toxinidir}/locale/compile-mo.sh {toxinidir}/locale/
-    py.test -n 2 -m 'not es_tests' -v src/olympia/addons/ {posargs}
+    pytest -n 2 -m 'not es_tests' -v src/olympia/addons/ {posargs}
 
 [testenv:devhub]
 commands =
     make -f Makefile-docker update_deps
     bash {toxinidir}/locale/compile-mo.sh {toxinidir}/locale/
-    py.test -n 2 -m 'not es_tests' -v src/olympia/devhub/ {posargs}
+    pytest -n 2 -m 'not es_tests' -v src/olympia/devhub/ {posargs}
 
 [testenv:reviewers]
 commands =
     make -f Makefile-docker update_deps
     bash {toxinidir}/locale/compile-mo.sh {toxinidir}/locale/
-    py.test -n 2 -m 'not es_tests' -v src/olympia/reviewers/ {posargs}
+    pytest -n 2 -m 'not es_tests' -v src/olympia/reviewers/ {posargs}
 
 [testenv:amo]
 commands =
     make -f Makefile-docker update_deps
     bash {toxinidir}/locale/compile-mo.sh {toxinidir}/locale/
-    py.test -n 2 -m 'not es_tests' -v src/olympia/amo/ {posargs}
+    pytest -n 2 -m 'not es_tests' -v src/olympia/amo/ {posargs}
 
 [testenv:users]
 commands =
     make -f Makefile-docker update_deps
     bash {toxinidir}/locale/compile-mo.sh {toxinidir}/locale/
-    py.test -n 2 -m 'not es_tests' -v src/olympia/users/ {posargs}
+    pytest -n 2 -m 'not es_tests' -v src/olympia/users/ {posargs}
 
 [testenv:main]
 commands =
     make -f Makefile-docker update_deps
     bash {toxinidir}/locale/compile-mo.sh {toxinidir}/locale/
-    py.test -n 2 -m 'not es_tests' -v src/olympia/ --ignore src/olympia/addons/ --ignore src/olympia/devhub/ --ignore src/olympia/reviewers/ --ignore src/olympia/amo/ --ignore src/olympia/users/ {posargs}
+    pytest -n 2 -m 'not es_tests' -v src/olympia/ --ignore src/olympia/addons/ --ignore src/olympia/devhub/ --ignore src/olympia/reviewers/ --ignore src/olympia/amo/ --ignore src/olympia/users/ {posargs}
 
 [testenv:ui-tests]
 commands =


### PR DESCRIPTION
Refactor our tests and code to make better use of settings.TMP_PATH

 * Also let the dot in py.test die so that upstream is happy again :)
 * Update tox to 2.9.1
 * Make sure that our urlconf is reset *after* we set MEDIA_ROOT
 * Adapt file extraction handling to new TMP_PATH prefixes
 * Less dump_apps hacks since the apps.json file isn't present at the
   beginning of any test now thanks to temporary paths for every separate
   test
 * Rewrite read-only-mode tests to cope with pytest settings fixture
 * Remove atexit hack from settings_test

This will probably make things a lot easier for ui-tests as well.

Fixes #7205
Fixes #7206