### PR TITLE
Add `has_addon` parameter to collection list API

### DIFF
--- a/docs/topics/api/collections.rst
+++ b/docs/topics/api/collections.rst
@@ -18,9 +18,9 @@ List
 This endpoint allows you to list all collections authored by the specified user.
 The results are sorted by the most recently updated collection first.
 
-
 .. http:get:: /api/v3/accounts/account/(int:user_id|string:username)/collections/
 
+    :query int has_addon: Optional add-on id parameter allowing you to check if a given add-on is part of the collections being returned. When passed, each collection object in the results will have an extra `has_addon` boolean property indicating whether the add-on is present in this collection or not.
     :>json int count: The number of results for this query.
     :>json string next: The URL of the next page of results.
     :>json string previous: The URL of the previous page of results.

--- a/src/olympia/amo/models.py
+++ b/src/olympia/amo/models.py
@@ -380,10 +380,10 @@ class SaveUpdateMixin(object):
         return super(SaveUpdateMixin, self).save(**kwargs)
 
 
-class ModelBase(SearchMixin, caching.base.CachingMixin, SaveUpdateMixin,
-                models.Model):
+class UncachedModelBase(SearchMixin, SaveUpdateMixin, models.Model):
     """
-    Base class for AMO models to abstract some common features.
+    Base class for AMO models to abstract some common features
+    (without cache-machine).
 
     * Adds automatic created and modified fields to the model.
     * Fetches all translations in one subsequent query during initialization.
@@ -392,7 +392,7 @@ class ModelBase(SearchMixin, caching.base.CachingMixin, SaveUpdateMixin,
     created = models.DateTimeField(auto_now_add=True)
     modified = models.DateTimeField(auto_now=True)
 
-    objects = ManagerBase()
+    objects = UncachedManagerBase()
 
     class Meta:
         abstract = True
@@ -400,6 +400,19 @@ class ModelBase(SearchMixin, caching.base.CachingMixin, SaveUpdateMixin,
 
     def get_absolute_url(self, *args, **kwargs):
         return self.get_url_path(*args, **kwargs)
+
+
+class ModelBase(caching.base.CachingMixin, UncachedModelBase, models.Model):
+    """
+    Base class for AMO models to abstract some common features.
+
+    * Adds automatic created and modified fields to the model.
+    * Fetches all translations in one subsequent query during initialization.
+    """
+    objects = ManagerBase()
+
+    class Meta(UncachedModelBase.Meta):
+        abstract = True
 
     @classmethod
     def _cache_key(cls, pk, db):

--- a/src/olympia/bandwagon/models.py
+++ b/src/olympia/bandwagon/models.py
@@ -9,16 +9,15 @@ from django.conf import settings
 from django.core.cache import cache
 from django.db import connection, models
 
-import caching.base as caching
-
 from olympia import activity, amo
 from olympia.access import acl
 from olympia.addons.models import Addon
 from olympia.addons.utils import clear_get_featured_ids_cache
-from olympia.amo.models import ManagerBase, ModelBase
+from olympia.amo.models import UncachedManagerBase, UncachedModelBase
 from olympia.amo.templatetags.jinja_helpers import (
     absolutify, user_media_path, user_media_url)
 from olympia.amo.urlresolvers import reverse
+import olympia.lib.queryset_transform as queryset_transform
 from olympia.translations.fields import (
     LinkifiedField, NoLinksNoMarkupField, TranslatedField, save_signal)
 from olympia.users.models import UserProfile
@@ -43,7 +42,7 @@ class TopTags(object):
         cache.set(self.key(obj), value, two_days)
 
 
-class CollectionQuerySet(caching.CachingQuerySet):
+class CollectionQuerySet(queryset_transform.TransformQuerySet):
 
     def with_has_addon(self, addon_id):
         """Add a `has_addon` property to each collection.
@@ -61,7 +60,7 @@ class CollectionQuerySet(caching.CachingQuerySet):
             select_params=(addon_id,))
 
 
-class CollectionManager(ManagerBase):
+class CollectionManager(UncachedManagerBase):
 
     def get_queryset(self):
         qs = super(CollectionManager, self).get_queryset()
@@ -88,7 +87,7 @@ class CollectionManager(ManagerBase):
         return collections.distinct().order_by('name__localized_string')
 
 
-class Collection(ModelBase):
+class Collection(UncachedModelBase):
     TYPE_CHOICES = amo.COLLECTION_CHOICES.items()
 
     # TODO: Use models.UUIDField but it uses max_length=32 hex (no hyphen)
@@ -138,7 +137,7 @@ class Collection(ModelBase):
 
     top_tags = TopTags()
 
-    class Meta(ModelBase.Meta):
+    class Meta(UncachedModelBase.Meta):
         db_table = 'collections'
         unique_together = (('author', 'slug'),)
 
@@ -394,7 +393,7 @@ models.signals.post_delete.connect(Collection.post_delete, sender=Collection,
                                    dispatch_uid='coll.post_delete')
 
 
-class CollectionAddon(ModelBase):
+class CollectionAddon(UncachedModelBase):
     addon = models.ForeignKey(Addon)
     collection = models.ForeignKey(Collection)
     # category (deprecated: for "Fashion Your Firefox")
@@ -407,7 +406,7 @@ class CollectionAddon(ModelBase):
         help_text='Add-ons are displayed in ascending order '
                   'based on this field.')
 
-    class Meta(ModelBase.Meta):
+    class Meta(UncachedModelBase.Meta):
         db_table = 'addons_collections'
         unique_together = (('addon', 'collection'),)
 
@@ -429,11 +428,11 @@ models.signals.post_delete.connect(CollectionAddon.post_save_or_delete,
                                    dispatch_uid='coll.post_save')
 
 
-class CollectionWatcher(ModelBase):
+class CollectionWatcher(UncachedModelBase):
     collection = models.ForeignKey(Collection, related_name='following')
     user = models.ForeignKey(UserProfile)
 
-    class Meta(ModelBase.Meta):
+    class Meta(UncachedModelBase.Meta):
         db_table = 'collection_subscriptions'
 
     @staticmethod
@@ -483,7 +482,7 @@ models.signals.post_delete.connect(CollectionVote.post_save_or_delete,
                                    sender=CollectionVote)
 
 
-class FeaturedCollection(ModelBase):
+class FeaturedCollection(UncachedModelBase):
     application = models.PositiveIntegerField(choices=amo.APPS_CHOICES,
                                               db_column='application_id')
     collection = models.ForeignKey(Collection)
@@ -508,7 +507,7 @@ models.signals.post_delete.connect(FeaturedCollection.post_save_or_delete,
                                    sender=FeaturedCollection)
 
 
-class MonthlyPick(ModelBase):
+class MonthlyPick(UncachedModelBase):
     addon = models.ForeignKey(Addon)
     blurb = models.TextField()
     image = models.URLField()

--- a/src/olympia/bandwagon/serializers.py
+++ b/src/olympia/bandwagon/serializers.py
@@ -68,6 +68,13 @@ class CollectionSerializer(serializers.ModelSerializer):
 
         return value
 
+    def to_representation(self, obj):
+        data = super(CollectionSerializer, self).to_representation(obj)
+        # If has_addon is present on the object, include it in the output.
+        if hasattr(obj, 'has_addon'):
+            data['has_addon'] = bool(obj.has_addon)
+        return data
+
 
 class ThisCollectionDefault(object):
     def set_context(self, serializer_field):

--- a/src/olympia/bandwagon/tasks.py
+++ b/src/olympia/bandwagon/tasks.py
@@ -79,7 +79,7 @@ def collection_meta(*ids, **kw):
                           .annotate(Count('id')))
     tags = (Tag.objects.not_denied().values_list('id')
             .annotate(cnt=Count('id')).filter(cnt__gt=1).order_by('-cnt'))
-    for collection in Collection.objects.no_cache().filter(id__in=ids):
+    for collection in Collection.objects.filter(id__in=ids):
         addon_count = counts.get(collection.id, 0)
         all_personas = addon_count == persona_counts.get(collection.id, None)
         addons = list(collection.addons.values_list('id', flat=True))

--- a/src/olympia/bandwagon/templates/bandwagon/edit_contributors.html
+++ b/src/olympia/bandwagon/templates/bandwagon/edit_contributors.html
@@ -56,7 +56,7 @@
         </td>
       </tr>
       {{ user_row(collection.author, _('Owner')) }}
-      {% for user in collection.users.no_cache().all() %}
+      {% for user in collection.users.all() %}
         {{ user_row(user, _('Contributor')) }}
       {% endfor %}
     </tbody>

--- a/src/olympia/bandwagon/tests/test_models.py
+++ b/src/olympia/bandwagon/tests/test_models.py
@@ -141,7 +141,6 @@ class TestCollections(TestCase):
         c.add_addon(Addon.objects.all()[0])
         assert activitylog_count(amo.LOG.ADD_TO_COLLECTION) == 1
         c = Collection.objects.get(id=c.id)
-        assert not c.from_cache
         assert c.addon_count == 1
 
     def test_favorites_slug(self):

--- a/src/olympia/bandwagon/tests/test_serializers.py
+++ b/src/olympia/bandwagon/tests/test_serializers.py
@@ -31,6 +31,18 @@ class TestCollectionSerializer(BaseTestCase):
         assert data['slug'] == self.collection.slug
         assert data['public'] == self.collection.listed
         assert data['default_locale'] == self.collection.default_locale
+        assert 'has_addon' not in data
+
+    def test_has_addon(self):
+        self.collection.has_addon = False
+        data = self.serialize()
+        assert data['id'] == self.collection.id
+        assert data['has_addon'] is False
+
+        self.collection.has_addon = True
+        data = self.serialize()
+        assert data['id'] == self.collection.id
+        assert data['has_addon'] is True
 
 
 class TestCollectionAddonSerializer(BaseTestCase):

--- a/src/olympia/bandwagon/tests/test_views.py
+++ b/src/olympia/bandwagon/tests/test_views.py
@@ -1360,6 +1360,13 @@ class TestCollectionViewSetList(TestCase):
         assert response.data['results'][1]['has_addon'] is False
         assert response.data['results'][2]['has_addon'] is False
 
+    def test_has_addon_not_int(self):
+        self.client.login_api(self.user)
+        response = self.client.get(self.url, {'has_addon': u'holà'})
+        assert response.status_code == 400
+        assert response.data == {
+            'detail': 'has_addon parameter should be an integer.'}
+
 
 class TestCollectionViewSetDetail(TestCase):
     client_class = APITestClient

--- a/src/olympia/bandwagon/tests/test_views.py
+++ b/src/olympia/bandwagon/tests/test_views.py
@@ -286,7 +286,7 @@ class TestVotes(TestCase):
         self.assert3xx(r, self.c_url)
 
     def check(self, upvotes=0, downvotes=0):
-        c = Collection.objects.no_cache().get(slug='slug', author=9945)
+        c = Collection.objects.get(slug='slug', author=9945)
         assert c.upvotes == upvotes
         assert c.downvotes == downvotes
         assert CollectionVote.objects.filter(
@@ -1166,7 +1166,7 @@ class TestCollectionDetailFeed(TestCase):
 class TestCollectionForm(TestCase):
     fixtures = ['base/collection_57181', 'users/test_backends']
 
-    @patch('olympia.amo.models.ModelBase.update')
+    @patch('olympia.amo.models.UncachedModelBase.update')
     def test_icon(self, update_mock):
         collection = Collection.objects.get(pk=57181)
         # TODO(andym): altering this form is too complicated, can we simplify?

--- a/src/olympia/bandwagon/views.py
+++ b/src/olympia/bandwagon/views.py
@@ -15,6 +15,7 @@ from django.views.decorators.http import require_POST
 import caching.base as caching
 
 from django_statsd.clients import statsd
+from rest_framework.exceptions import ParseError
 from rest_framework.viewsets import ModelViewSet
 
 import olympia.core.logger
@@ -679,9 +680,22 @@ class CollectionViewSet(ModelViewSet):
         return self.account_viewset
 
     def get_queryset(self):
-        return Collection.objects.filter(
+        qs = Collection.objects.filter(
             author=self.get_account_viewset().get_object()).order_by(
             '-modified')
+        if 'has_addon' in self.request.GET and self.action == 'list':
+            # When listing collections belonging to someone, you can pass an
+            # addon id and we'll expose whether or not the add-on is part of
+            # each collection returned. No checks are made to see whether the
+            # add-on is public, but we're only revealing that it's part of a
+            # collection, and you need to be the collection author or an admin
+            # to access this anyway.
+            try:
+                addon_id = int(self.request.GET.get('has_addon'))
+            except ValueError:
+                raise ParseError('has_addon parameter should be an integer.')
+            qs = qs.with_has_addon(addon_id)
+        return qs
 
 
 class CollectionAddonViewSet(ModelViewSet):

--- a/src/olympia/lib/es/utils.py
+++ b/src/olympia/lib/es/utils.py
@@ -36,7 +36,11 @@ def index_objects(ids, model, extract_func, index=None, transforms=None,
     if transforms is None:
         transforms = []
 
-    qs = objects.no_cache().filter(id__in=ids)
+    if hasattr(objects, 'no_cache'):
+        qs = objects.no_cache()
+    else:
+        qs = objects
+    qs = qs.filter(id__in=ids)
     for t in transforms:
         qs = qs.transform(t)
 


### PR DESCRIPTION
This allows clients to do a single API call to return collections for a user and find out if a given add-on is in them. The frontend will use that to populate the collections dropdown on the add-on detail pages when the user is logged in.

Fix #7167