### PR TITLE
serve /user-media/ via nginx.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
     volumes:
       - ./static:/srv/static
       - ./site-static:/srv/site-static
+      - ./user-media/:/srv/user-media
 
   memcached:
     image: memcached:1.4


### PR DESCRIPTION
This change landed in
https://github.com/mozilla/addons-nginx/commit/27fbed27e0ad969b9e1536412cea809d2b0dfb1f
and is primarily used by our future ui-tests to serve XPI files.

cc @jrbenny35 since this is a cherry-pick from the ui-test branch and might conflict.