### PR TITLE
Allow reviewers approval confirmation when latest version is disabled

### DIFF
--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -705,7 +705,7 @@ class ReviewBase(object):
     def confirm_auto_approved(self):
         """Confirm an auto-approval decision."""
 
-        channel = self.version.channel if self.version else None
+        channel = self.version.channel
         if channel == amo.RELEASE_CHANNEL_LISTED:
             # When doing an approval in listed channel, the version we care
             # about is always current_version and *not* self.version.

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -756,7 +756,6 @@ def review(request, addon, channel=None):
         perform_review_permission_checks(
             request, addon, channel, content_review_only=content_review_only)
 
-    # Reverted #7017's changes here
     version = addon.find_latest_version(
         channel=channel, exclude=(amo.STATUS_BETA,))
 


### PR DESCRIPTION
This is the second attempt at doing this, this time instead of excluding disabled versions for all actions, we only modify the confirm approval action, and make it always use `addon.current_version` if we're looking at the listed channel.

Fix #6894