### PR TITLE
Use `confirmed` field to calculate size of code changes and auto-approved queue

### DIFF
--- a/src/olympia/reviewers/management/commands/recalculate_post_review_weights.py
+++ b/src/olympia/reviewers/management/commands/recalculate_post_review_weights.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from django.core.management.base import BaseCommand
+
+import olympia.core.logger
+
+from olympia import amo
+from olympia.reviewers.models import AutoApprovalSummary
+
+
+log = olympia.core.logger.getLogger('z.reviewers.recalculate_weights')
+
+
+class Command(BaseCommand):
+    help = 'Recalculate post-review weights for unconfirmed auto-approvals.'
+
+    def handle(self, *args, **options):
+        qs = AutoApprovalSummary.objects.filter(
+            confirmed=False, verdict=amo.AUTO_APPROVED)
+        for summary in qs:
+            log.info('Recalculating weight for %s', summary)
+            old_weight = summary.weight
+            summary.calculate_weight()
+            if summary.weight != old_weight:
+                log.info('Saving weight change (from %d to %d) for %s',
+                         old_weight, summary.weight, summary)
+                summary.save()

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -1534,7 +1534,7 @@ class TestAutoApprovedQueue(QueueTest):
         extra_addon3 = addon_factory(name=u'Extra Addôn 3')
         extra_summary3 = AutoApprovalSummary.objects.create(
             version=extra_addon3.current_version,
-            verdict=amo.AUTO_APPROVED)
+            verdict=amo.AUTO_APPROVED, confirmed=True)
         AddonApprovalsCounter.objects.create(
             addon=extra_addon3, counter=1,
             last_human_review=extra_summary3.created)


### PR DESCRIPTION
Now that this field exist and is properly populated it allows us to simplify the queryset to generate the queue and also calculate size of code changes more accurately.

Also include a command to recalculate post-review weights, we'll need to run it to benefit from the new size of code changes formula.

Fix mozilla/addons#616