### PR TITLE
Revert "Add `has_addon` parameter to collection list API"

### DIFF
--- a/docs/topics/api/collections.rst
+++ b/docs/topics/api/collections.rst
@@ -18,9 +18,9 @@ List
 This endpoint allows you to list all collections authored by the specified user.
 The results are sorted by the most recently updated collection first.
 
+
 .. http:get:: /api/v3/accounts/account/(int:user_id|string:username)/collections/
 
-    :query int has_addon: Optional add-on id parameter allowing you to check if a given add-on is part of the collections being returned. When passed, each collection object in the results will have an extra `has_addon` boolean property indicating whether the add-on is present in this collection or not.
     :>json int count: The number of results for this query.
     :>json string next: The URL of the next page of results.
     :>json string previous: The URL of the previous page of results.

--- a/src/olympia/bandwagon/serializers.py
+++ b/src/olympia/bandwagon/serializers.py
@@ -68,13 +68,6 @@ class CollectionSerializer(serializers.ModelSerializer):
 
         return value
 
-    def to_representation(self, obj):
-        data = super(CollectionSerializer, self).to_representation(obj)
-        # If has_addon is present on the object, include it in the output.
-        if hasattr(obj, 'has_addon'):
-            data['has_addon'] = bool(obj.has_addon)
-        return data
-
 
 class ThisCollectionDefault(object):
     def set_context(self, serializer_field):

--- a/src/olympia/bandwagon/tests/test_serializers.py
+++ b/src/olympia/bandwagon/tests/test_serializers.py
@@ -31,18 +31,6 @@ class TestCollectionSerializer(BaseTestCase):
         assert data['slug'] == self.collection.slug
         assert data['public'] == self.collection.listed
         assert data['default_locale'] == self.collection.default_locale
-        assert 'has_addon' not in data
-
-    def test_has_addon(self):
-        self.collection.has_addon = False
-        data = self.serialize()
-        assert data['id'] == self.collection.id
-        assert data['has_addon'] is False
-
-        self.collection.has_addon = True
-        data = self.serialize()
-        assert data['id'] == self.collection.id
-        assert data['has_addon'] is True
 
 
 class TestCollectionAddonSerializer(BaseTestCase):

--- a/src/olympia/bandwagon/tests/test_views.py
+++ b/src/olympia/bandwagon/tests/test_views.py
@@ -1281,9 +1281,6 @@ class TestCollectionViewSetList(TestCase):
         response = self.client.get(self.url)
         assert response.status_code == 200
         assert len(response.data['results']) == 3
-        assert 'has_addon' not in response.data['results'][0]
-        assert 'has_addon' not in response.data['results'][1]
-        assert 'has_addon' not in response.data['results'][2]
 
     def test_no_auth(self):
         collection_factory(author=self.user)
@@ -1342,48 +1339,6 @@ class TestCollectionViewSetList(TestCase):
         assert response.data['results'][1]['uuid'] == col_a.uuid
         assert response.data['results'][2]['uuid'] == col_c.uuid
 
-    def test_has_addon(self):
-        col_a = collection_factory(author=self.user)
-        col_b = collection_factory(author=self.user)
-        col_c = collection_factory(author=self.user)
-        collection_factory(author=user_factory())  # Not our collection.
-        Collection.objects.all().count() == 4
-        addon = addon_factory()
-        addon2 = addon_factory()
-        CollectionAddon.objects.create(collection=col_a, addon=addon)
-        CollectionAddon.objects.create(collection=col_b, addon=addon2)
-        CollectionAddon.objects.create(collection=col_c, addon=addon)
-
-        # Reset modified date to ensure ordering.
-        col_a.update(modified=self.days_ago(1))
-        col_b.update(modified=self.days_ago(2))
-        col_c.update(modified=self.days_ago(3))
-
-        self.client.login_api(self.user)
-        response = self.client.get(self.url, {'has_addon': 42})
-        assert response.status_code == 200
-        assert len(response.data['results']) == 3
-        assert response.data['results'][0]['has_addon'] is False
-        assert response.data['results'][1]['has_addon'] is False
-        assert response.data['results'][2]['has_addon'] is False
-
-        response = self.client.get(self.url, {'has_addon': addon.pk})
-        assert response.status_code == 200
-        assert len(response.data['results']) == 3
-        assert response.data['results'][0]['uuid'] == col_a.uuid
-        assert response.data['results'][0]['has_addon'] is True
-        assert response.data['results'][1]['uuid'] == col_b.uuid
-        assert response.data['results'][1]['has_addon'] is False
-        assert response.data['results'][2]['uuid'] == col_c.uuid
-        assert response.data['results'][2]['has_addon'] is True
-
-    def test_has_addon_not_int(self):
-        self.client.login_api(self.user)
-        response = self.client.get(self.url, {'has_addon': u'holà'})
-        assert response.status_code == 400
-        assert response.data == {
-            'detail': 'has_addon parameter should be an integer.'}
-
 
 class TestCollectionViewSetDetail(TestCase):
     client_class = APITestClient
@@ -1400,7 +1355,6 @@ class TestCollectionViewSetDetail(TestCase):
         response = self.client.get(self.url)
         assert response.status_code == 200
         assert response.data['id'] == self.collection.id
-        assert 'has_addon' not in response.data
 
     def test_not_listed(self):
         self.collection.update(listed=False)

--- a/src/olympia/bandwagon/views.py
+++ b/src/olympia/bandwagon/views.py
@@ -13,7 +13,6 @@ from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.http import require_POST
 
 from django_statsd.clients import statsd
-from rest_framework.exceptions import ParseError
 from rest_framework.viewsets import ModelViewSet
 
 import olympia.core.logger
@@ -677,22 +676,9 @@ class CollectionViewSet(ModelViewSet):
         return self.account_viewset
 
     def get_queryset(self):
-        qs = Collection.objects.filter(
+        return Collection.objects.filter(
             author=self.get_account_viewset().get_object()).order_by(
             '-modified')
-        if 'has_addon' in self.request.GET and self.action == 'list':
-            # When listing collections belonging to someone, you can pass an
-            # addon id and we'll expose whether or not the add-on is part of
-            # each collection returned. No checks are made to see whether the
-            # add-on is public, but we're only revealing that it's part of a
-            # collection, and you need to be the collection author or an admin
-            # to access this anyway.
-            try:
-                addon_id = int(self.request.GET.get('has_addon'))
-            except ValueError:
-                raise ParseError('has_addon parameter should be an integer.')
-            qs = qs.with_has_addon(addon_id)
-        return qs
 
 
 class CollectionAddonViewSet(ModelViewSet):


### PR DESCRIPTION
This reverts commit 186110c1b85d199426553a9533f99449d87efa2c, it turns out we don't really need this API, the UX around this functionality for the frontend has changed.

Fix #7247