### PR TITLE
Make API error message for adding duplicate add-on to collection more user-friendly

### DIFF
--- a/src/olympia/bandwagon/serializers.py
+++ b/src/olympia/bandwagon/serializers.py
@@ -91,6 +91,13 @@ class CollectionAddonSerializer(serializers.ModelSerializer):
     class Meta:
         model = CollectionAddon
         fields = ('addon', 'downloads', 'notes', 'collection')
+        validators = [
+            UniqueTogetherValidator(
+                queryset=CollectionAddon.objects.all(),
+                message=_(u'This add-on already belongs to the collection'),
+                fields=('addon', 'collection')
+            ),
+        ]
         writeable_fields = (
             'notes',
         )

--- a/src/olympia/bandwagon/tests/test_views.py
+++ b/src/olympia/bandwagon/tests/test_views.py
@@ -1951,6 +1951,17 @@ class TestCollectionAddonViewSetCreate(CollectionAddonViewSetMixin, TestCase):
         response = self.send(self.url, data={'addon': self.addon.slug})
         self.check_response(response)
 
+    def test_uniqueness_message(self):
+        CollectionAddon.objects.create(
+            collection=self.collection, addon=self.addon)
+        self.client.login_api(self.user)
+        response = self.send(self.url, data={'addon': self.addon.slug})
+        assert response.status_code == 400
+        assert response.data == {
+            u'non_field_errors':
+                [u'This add-on already belongs to the collection']
+        }
+
 
 class TestCollectionAddonViewSetPatch(CollectionAddonViewSetMixin, TestCase):
     client_class = APITestClient


### PR DESCRIPTION
Fix #7258