### PR TITLE
Fixed CSS for language pie chart legend in add-on stats.

### DIFF
--- a/static/css/impala/stats.less
+++ b/static/css/impala/stats.less
@@ -214,7 +214,8 @@ table tbody tr {
 
         &:first-child {
             text-align: left;
-            display: inline-block;
+            display: inline-flex;
+            flex-direction: row-reverse;
         }
         &:last-child {
             text-align: left;


### PR DESCRIPTION
Fixes #3326 .

I don't get to test it locally but proposed changes tested through developer tools on chrome/firefox on actual AMO website fixes it as shown. It also fixes the dot which appears in 2nd line in English (en-us) row which preferably should appear before english. Here are the screenshots:

Before:
![image](https://user-images.githubusercontent.com/24241258/34920328-37bf8432-f997-11e7-9e63-9edb67d938c9.png)

After:
![image](https://user-images.githubusercontent.com/24241258/34920354-668cd300-f997-11e7-9514-59404d0a2e62.png)
