### PR TITLE
Update test addon creation to work better with new amo frontend.

### DIFF
--- a/src/olympia/landfill/management/commands/generate_ui_test_addons.py
+++ b/src/olympia/landfill/management/commands/generate_ui_test_addons.py
@@ -30,7 +30,7 @@ class Command(BaseCommand):
             serializer.create_featured_theme()
             serializer.create_featured_collections()
             serializer.create_featured_themes()
+            serializer.create_mozilla_addons_and_collections()
             serializer.create_installable_addon()
-
         cache.clear()
         call_command('clear_cache')

--- a/src/olympia/landfill/management/commands/generate_ui_test_addons.py
+++ b/src/olympia/landfill/management/commands/generate_ui_test_addons.py
@@ -6,6 +6,36 @@ from django.test.utils import override_settings
 
 from olympia.landfill.serializers import GenerateAddonsSerializer
 
+#  Featured collections on the homepage.
+#  Needs to be updated as the homepage is updated
+featured_collections = [
+    'dynamic-media-downloaders',
+]
+
+#  Featured collections on the homepage.
+base_collections = [
+    'bookmark-managers',
+    'password-managers',
+    'ad-blockers',
+    'smarter-shopping',
+    'be-more-productive',
+    'watching-videos',
+]
+
+#  Addons that exist in the carousel.
+#  Needs to be updated as the homepage is updated
+carousel_addons = [
+    'wikipedia-context-menu-search',
+    'momentumdash',
+    'undo-close-tab-button',
+    'grammarly-1',
+    'facebook-filter',
+    'gesturefy',
+    'multi-account-containers',
+    'tree-style-tab',
+    'lastpass-password-manager',
+]
+
 
 class Command(BaseCommand):
     """
@@ -30,7 +60,14 @@ class Command(BaseCommand):
             serializer.create_featured_theme()
             serializer.create_featured_collections()
             serializer.create_featured_themes()
-            serializer.create_mozilla_addons_and_collections()
+            for addon in featured_collections:
+                serializer.create_a_named_collection_and_addon(
+                    addon, author='mozilla')
+            for addon in base_collections:
+                serializer.create_a_named_collection_and_addon(
+                    addon, author='mozilla')
+            for addon in carousel_addons:
+                serializer.create_named_addon_with_author(addon)
             serializer.create_installable_addon()
         cache.clear()
         call_command('clear_cache')

--- a/src/olympia/landfill/serializers.py
+++ b/src/olympia/landfill/serializers.py
@@ -44,6 +44,17 @@ class GenerateAddonsSerializer(serializers.Serializer):
             AddonUser.objects.create(
                 user=user_factory(), addon=addon_factory())
 
+    def create_generic_mozilla_addon(self):
+        """Create a generic addon and a user 'mozilla'."""
+
+        generate_user('mozilla@mozilla.com')
+        addon = addon_factory(
+            status=STATUS_PUBLIC,
+            users=[UserProfile.objects.get(username='mozilla')],
+        )
+        addon.save()
+        return addon
+
     def create_featured_addon_with_version(self):
         """Creates a custom addon named 'Ui-Addon'.
 
@@ -204,27 +215,16 @@ class GenerateAddonsSerializer(serializers.Serializer):
             generate_collection(addon, app=FIREFOX)
 
     def create_mozilla_addons_and_collections(self):
-        """Creates 2 collections for the account 'mozilla'."""
+        """Create 2 collections for the account 'mozilla'."""
 
-        generate_user('mozilla@mozilla.com')
-        addon = addon_factory(
-            status=STATUS_PUBLIC,
-            users=[UserProfile.objects.get(username='mozilla')],
-        )
-        addon.save()
         generate_collection(
-            addon,
+            self.create_generic_mozilla_addon(),
             app=FIREFOX,
             author=UserProfile.objects.get(username='mozilla'),
             type=amo.COLLECTION_FEATURED,
             name=FIRST_COLLECTION_SLUG)
-        addon = addon_factory(
-            status=STATUS_PUBLIC,
-            users=[UserProfile.objects.get(username='mozilla')],
-        )
-        addon.save()
         generate_collection(
-            addon,
+            self.create_generic_mozilla_addon(),
             app=FIREFOX,
             author=UserProfile.objects.get(username='mozilla'),
             type=amo.COLLECTION_FEATURED,

--- a/tests/ui/pages/desktop/search.py
+++ b/tests/ui/pages/desktop/search.py
@@ -1,4 +1,5 @@
 from pypom import Region
+from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 
 from base import Base
@@ -46,5 +47,8 @@ class SearchResultList(Base):
         @property
         def rating(self):
             """Returns the rating"""
-            rating = self.find_element(*self._rating_locator).text
-            return int(rating.split()[1])
+            try:
+                rating = self.find_element(*self._rating_locator).text
+                return int(rating.split()[1])
+            except NoSuchElementException:
+                return 0

--- a/tests/ui/test_home.py
+++ b/tests/ui/test_home.py
@@ -67,4 +67,4 @@ def test_that_clicking_see_all_collections_link_works(
     page = Home(selenium, base_url).open()
     collections = page.featured_collections.collections
     collections_page = page.featured_collections.see_all()
-    assert len(collections) == len(collections_page.collections)
+    assert len(collections_page.collections) >= len(collections)


### PR DESCRIPTION
* Create 2 new collections under the username 'Mozilla'. These have 1 addon each.
* Change the status of the installable addon to Public.

These changes help compatibility with the new amo front-end for integration testing.

Also I have created some variables that will help keep the tests updated as the new frontend changes.