### PR TITLE
Implement extra inline actions on the review page for reviewers and admins

### DIFF
--- a/docs/topics/api/index.rst
+++ b/docs/topics/api/index.rst
@@ -41,6 +41,7 @@ using the API.
    discovery
    download_sources
    reviews
+   reviewers
    signing
    stats
    github

--- a/docs/topics/api/reviewers.rst
+++ b/docs/topics/api/reviewers.rst
@@ -1,0 +1,80 @@
+.. _reviewers:
+
+=========
+Reviewers
+=========
+
+.. note::
+
+    These APIs are experimental and are currently being worked on. Endpoints
+    may change without warning. The only authentication method available at
+    the moment is :ref:`the internal one<api-auth-internal>`.
+
+---------
+Subscribe
+---------
+
+This endpoint allows you to subscribe the current user to the notification
+sent when a new listed version is submitted on a particular add-on.
+
+    .. note::
+        Requires authentication and the current user to have any
+        reviewer-related permission.
+
+.. http:post::/api/v3/reviewers/addon/(int:addon_id)/subscribe/
+
+-----------
+Unsubscribe
+-----------
+
+This endpoint allows you to unsubscribe the current user to the notification
+sent when a new listed version is submitted on a particular add-on.
+
+    .. note::
+        Requires authentication and the current user to have any
+        reviewer-related permission.
+
+.. http:post::/api/v3/reviewers/addon/(int:addon_id)/unsubscribe/
+
+-------
+Disable
+-------
+
+This endpoint allows you to disable the public listing for an add-on.
+
+    .. note::
+       Requires authentication and the current user to have ``Reviews:Edit``
+        permission.
+
+.. http:post::/api/v3/reviewers/addon/(int:addon_id)/disable/
+
+------
+Enable
+------
+
+This endpoint allows you to re-enable the public listing for an add-on. If the
+add-on can't be public because it does not have public versions, it will
+instead be changed to awaiting review or incomplete depending on the status
+of its versions.
+
+    .. note::
+        Requires authentication and the current user to have ``Reviews:Edit``
+        permission.
+
+.. http:post::/api/v3/reviewers/addon/(int:addon_id)/enable/
+
+-----------------------
+Clear Admin Review Flag
+-----------------------
+
+This endpoint allows you to clear either the code or the content admin review
+flag that reviewers can set on an add-on.
+
+    .. note::
+        Requires authentication and the current user to have ``Reviews:Edit``
+        permission.
+
+.. http:post::/api/v3/reviewers/addon/1/clear_admin_review_flag/
+
+    :query string flag_type: The flag to clear. Can be either ``code`` or
+        ``content``.

--- a/docs/topics/api/reviewers.rst
+++ b/docs/topics/api/reviewers.rst
@@ -43,7 +43,7 @@ Disable
 This endpoint allows you to disable the public listing for an add-on.
 
     .. note::
-       Requires authentication and the current user to have ``Reviews:Edit``
+       Requires authentication and the current user to have ``Reviews:Admin``
         permission.
 
 .. http:post::/api/v3/reviewers/addon/(int:addon_id)/disable/
@@ -58,7 +58,7 @@ instead be changed to awaiting review or incomplete depending on the status
 of its versions.
 
     .. note::
-        Requires authentication and the current user to have ``Reviews:Edit``
+        Requires authentication and the current user to have ``Reviews:Admin``
         permission.
 
 .. http:post::/api/v3/reviewers/addon/(int:addon_id)/enable/
@@ -71,7 +71,7 @@ This endpoint allows you to clear either the code or the content admin review
 flag that reviewers can set on an add-on.
 
     .. note::
-        Requires authentication and the current user to have ``Reviews:Edit``
+        Requires authentication and the current user to have ``Reviews:Admin``
         permission.
 
 .. http:post::/api/v3/reviewers/addon/1/clear_admin_review_flag/

--- a/src/olympia/access/acl.py
+++ b/src/olympia/access/acl.py
@@ -138,3 +138,24 @@ def is_reviewer(request, addon):
     and the addon is a persona."""
     return (check_addons_reviewer(request) or
             (check_personas_reviewer(request) and addon.is_persona()))
+
+
+def is_any_kind_of_reviewer(request):
+    """More lax version of is_reviewer: does not check what kind of reviewer
+    the user is, and accepts unlisted reviewers, post reviewers, content
+    reviewers, or people with just revierwer tools view access.
+
+    Don't use on anything that would alter add-on data.
+
+    any_reviewer_required() decorator and AllowAnyKindOfReviewer DRF permission
+    use this function behind the scenes to guard views that don't change the
+    add-on but still need to be restricted to reviewers only.
+    """
+    allow_access = (
+        action_allowed(request, amo.permissions.REVIEWER_TOOLS_VIEW) or
+        action_allowed(request, amo.permissions.ADDONS_REVIEW) or
+        action_allowed(request, amo.permissions.ADDONS_REVIEW_UNLISTED) or
+        action_allowed(request, amo.permissions.ADDONS_CONTENT_REVIEW) or
+        action_allowed(request, amo.permissions.ADDONS_POST_REVIEW) or
+        action_allowed(request, amo.permissions.THEMES_REVIEW))
+    return allow_access

--- a/src/olympia/api/permissions.py
+++ b/src/olympia/api/permissions.py
@@ -2,6 +2,7 @@ from rest_framework.exceptions import MethodNotAllowed
 from rest_framework.permissions import SAFE_METHODS, BasePermission
 
 from olympia import amo
+from olympia.amo import permissions
 from olympia.access import acl
 
 
@@ -125,12 +126,13 @@ class AllowReviewer(BasePermission):
     'ReviewerTools:View' permission, or simply be a reviewer or admin.
 
     An add-on reviewer is someone who is in the group with the following
-    permission: 'Addons:Review'.
+    permission: 'Addons:Review'. Notably, that does not include people with
+    only Addons:PostReview.
     """
     def has_permission(self, request, view):
         return ((request.method in SAFE_METHODS and
                  acl.action_allowed(request,
-                                    amo.permissions.REVIEWER_TOOLS_VIEW)) or
+                                    permissions.REVIEWER_TOOLS_VIEW)) or
                 acl.check_addons_reviewer(request))
 
     def has_object_permission(self, request, view, obj):
@@ -147,7 +149,7 @@ class AllowReviewerUnlisted(AllowReviewer):
     The user logged in must an unlisted add-on reviewer or admin.
 
     An unlisted add-on reviewer is someone who is in the group with the
-    following permission: 'Addons:Review'.
+    following permission: 'Addons:ReviewUnlisted'.
     """
     def has_permission(self, request, view):
         return acl.check_unlisted_addons_reviewer(request)
@@ -156,6 +158,28 @@ class AllowReviewerUnlisted(AllowReviewer):
         return (
             (obj.has_unlisted_versions() or not obj.has_listed_versions()) and
             self.has_permission(request, view))
+
+
+class AllowAnyKindOfReviewer(BasePermission):
+    """Allow access to any kind of reviewer. Use only for views that don't
+    alter add-on data.
+
+    Allows access to users with any of those permissions:
+    - ReviewerTools:View
+    - Addons:Review
+    - Addons:ReviewUnlisted
+    - Addons:ContentReview
+    - Addons:PostReview
+    - Personas:Review
+
+    Uses acl.is_any_kind_of_reviewer() behind the scenes.
+    See also any_reviewer_required() decorator.
+    """
+    def has_permission(self, request, view):
+        return acl.is_any_kind_of_reviewer(request)
+
+    def has_object_permission(self, request, view, obj):
+        return self.has_permission(request, view)
 
 
 class AllowIfPublic(BasePermission):

--- a/src/olympia/api/urls.py
+++ b/src/olympia/api/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     url(r'^v3/addons/', include('olympia.addons.api_urls')),
     url(r'^v3/', include('olympia.discovery.api_urls')),
     url(r'^v3/reviews/', include('olympia.ratings.api_urls')),
+    url(r'^v3/reviewers/', include('olympia.reviewers.api_urls')),
     url(r'^v3/', include('olympia.signing.urls')),
     url(r'^v3/statistics/', include('olympia.stats.api_urls')),
     url(r'^v3/activity/', include('olympia.activity.urls')),

--- a/src/olympia/constants/permissions.py
+++ b/src/olympia/constants/permissions.py
@@ -61,8 +61,9 @@ MAILING_LISTS_VIEW = AclPermission('MailingLists', 'View')
 # Can moderate add-on ratings submitted by users.
 RATINGS_MODERATE = AclPermission('Ratings', 'Moderate')
 
-# Can access advanced reviewer features.
-REVIEWS_EDIT = AclPermission('Reviews', 'Edit')
+# Can access advanced reviewer features meant for admins, such as disabling an
+# add-on or clearing needs admin review flags.
+REVIEWS_ADMIN = AclPermission('Reviews', 'Admin')
 
 # All permissions, for easy introspection
 PERMISSIONS_LIST = [

--- a/src/olympia/constants/permissions.py
+++ b/src/olympia/constants/permissions.py
@@ -61,6 +61,9 @@ MAILING_LISTS_VIEW = AclPermission('MailingLists', 'View')
 # Can moderate add-on ratings submitted by users.
 RATINGS_MODERATE = AclPermission('Ratings', 'Moderate')
 
+# Can access advanced reviewer features.
+REVIEWS_EDIT = AclPermission('Reviews', 'Edit')
+
 # All permissions, for easy introspection
 PERMISSIONS_LIST = [
     x for x in vars().values() if isinstance(x, AclPermission)]

--- a/src/olympia/reviewers/api_urls.py
+++ b/src/olympia/reviewers/api_urls.py
@@ -1,0 +1,13 @@
+from django.conf.urls import include, url
+
+from rest_framework.routers import SimpleRouter
+
+from olympia.reviewers.views import AddonReviewerViewSet
+
+
+addons = SimpleRouter()
+addons.register(r'addon', AddonReviewerViewSet, base_name='reviewers-addon')
+
+urlpatterns = [
+    url(r'', include(addons.urls)),
+]

--- a/src/olympia/reviewers/decorators.py
+++ b/src/olympia/reviewers/decorators.py
@@ -106,14 +106,7 @@ def any_reviewer_required(f):
     """
     @functools.wraps(f)
     def wrapper(request, *args, **kw):
-        allow_access = (
-            acl.action_allowed(request, permissions.REVIEWER_TOOLS_VIEW) or
-            acl.action_allowed(request, permissions.ADDONS_REVIEW) or
-            acl.action_allowed(request, permissions.ADDONS_REVIEW_UNLISTED) or
-            acl.action_allowed(request, permissions.ADDONS_CONTENT_REVIEW) or
-            acl.action_allowed(request, permissions.ADDONS_POST_REVIEW) or
-            acl.action_allowed(request, permissions.THEMES_REVIEW))
-        if allow_access:
+        if acl.is_any_kind_of_reviewer(request):
             return f(request, *args, **kw)
         raise PermissionDenied
     return wrapper
@@ -125,12 +118,7 @@ def any_reviewer_or_moderator_required(f):
     @functools.wraps(f)
     def wrapper(request, *args, **kw):
         allow_access = (
-            acl.action_allowed(request, permissions.REVIEWER_TOOLS_VIEW) or
-            acl.action_allowed(request, permissions.ADDONS_REVIEW) or
-            acl.action_allowed(request, permissions.ADDONS_REVIEW_UNLISTED) or
-            acl.action_allowed(request, permissions.ADDONS_CONTENT_REVIEW) or
-            acl.action_allowed(request, permissions.ADDONS_POST_REVIEW) or
-            acl.action_allowed(request, permissions.THEMES_REVIEW) or
+            acl.is_any_kind_of_reviewer(request) or
             acl.action_allowed(request, permissions.RATINGS_MODERATE))
         if allow_access:
             return f(request, *args, **kw)

--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -304,15 +304,6 @@ class ReviewForm(happyforms.Form):
                                         label=_(u'Operating systems:'))
     applications = forms.CharField(required=False,
                                    label=_(u'Applications:'))
-    notify = forms.BooleanField(required=False,
-                                label=_(u'Notify me the next time this '
-                                        u'add-on is updated. (Subsequent '
-                                        u'updates will not generate an '
-                                        u'email)'))
-    clear_admin_code_review = forms.BooleanField(
-        required=False, label=_(u'Clear Admin Code Review Flag'))
-    clear_admin_content_review = forms.BooleanField(
-        required=False, label=_(u'Clear Admin Content Review Flag'))
     info_request = forms.BooleanField(
         required=False, label=_(u'Is more info requested?'))
 

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -226,31 +226,6 @@
         {{ form.operating_systems.errors }}
         {{ form.applications.errors }}
       </div>
-      <div class="review-actions-section">
-        {{ form.notify }}
-        <label for="id_notify">
-          {{ form.notify.label }}
-        </label>
-        {{ form.notify.errors }}
-      </div>
-      {% if is_admin %}
-        <div class="review-actions-section">
-          {% if addon.needs_admin_code_review %}
-            {{ form.clear_admin_code_review }}
-            <label for="{{ form.clear_admin_code_review.auto_id }}">
-              {{ form.clear_admin_code_review.label }}
-            </label>
-            {{ form.clear_admin_code_review.errors }}
-          {% endif %}
-          {% if addon.needs_admin_content_review %}
-            {{ form.clear_admin_content_review }}
-            <label for="{{ form.clear_admin_content_review.auto_id }}">
-              {{ form.clear_admin_content_review.label }}
-            </label>
-            {{ form.clear_admin_content_review.errors }}
-          {% endif %}
-        </div>
-      {% endif %}
       <div class="review-actions-section data-toggle review-info-request"
            data-value="{{ actions_info_request|join("|") }}|">
         {{ form.info_request }}
@@ -292,10 +267,33 @@
     </div>
   </div>
   <div class="whiteboard-actions">
-    {{ form.notify.errors }}
+    {{ whiteboard_form.errors }}
     <input type="submit" value="{{ _('Update whiteboards') }}" />
   </div>
 </form>
+
+{% if not addon.is_deleted %}
+<form class="more-actions" id="extra-review-actions" data-api-token="{{ api_token }}">
+  <p><strong>{{ _('More Actions') }}</strong></p>
+  <div class="more-actions-inner">
+    <ul>
+      <li><input type="checkbox" id="notify_new_listed_versions" data-api-url-subscribe="{{ url('reviewers-addon-subscribe', addon.pk) }}" data-api-url-unsubscribe="{{ url('reviewers-addon-unsubscribe', addon.pk) }}" {% if subscribed %}checked="checked"{% endif %} autocomplete="off" /><label for="notify_new_listed_versions">{{ _('Notify me about new listed versions') }}</label></li>
+    </ul>
+    {% if is_admin %}
+    <ul class="admin_only">
+        <li {% if addon.status == amo.STATUS_DISABLED %}class="hidden"{% endif %}><button id="force_disable_addon" data-api-url="{{ url('reviewers-addon-disable', addon.pk) }}">{{ _('Force-disable add-on') }}</button></li>
+        <li {% if addon.status != amo.STATUS_DISABLED %}class="hidden"{% endif %}><button id="force_enable_addon" data-api-url="{{ url('reviewers-addon-enable', addon.pk) }}">{{ _('Force-enable add-on') }}</button></li>
+        {% if addon.needs_admin_code_review %}
+          <li><button id="clear_admin_code_review" data-api-url="{{ url('reviewers-addon-clear-admin-review-flag', addon.pk) }}" data-api-flag="code"> {{ _('Clear Admin Code Review Flag') }}</button></li>
+        {% endif %}
+        {% if addon.needs_admin_content_review %}
+          <li><button id="clear_admin_content_review" data-api-url="{{ url('reviewers-addon-clear-admin-review-flag', addon.pk) }}" data-api-flag="content">{{ _('Clear Admin Content Review Flag') }}</button></li>
+        {% endif %}
+    </ul>
+    {% endif %}
+  </div>
+</div>
+{% endif %}
 
 </div> {# /#primary #}
 

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -4161,7 +4161,7 @@ class TestAddonReviewerViewSet(TestCase):
         assert response.status_code == 403
 
     def test_enable_addon_does_not_exist(self):
-        self.grant_permission(self.user, 'Reviews:Edit')
+        self.grant_permission(self.user, 'Reviews:Admin')
         self.client.login_api(self.user)
         self.enable_url = reverse(
             'reviewers-addon-enable', kwargs={'pk': self.addon.pk + 42})
@@ -4169,7 +4169,7 @@ class TestAddonReviewerViewSet(TestCase):
         assert response.status_code == 404
 
     def test_enable(self):
-        self.grant_permission(self.user, 'Reviews:Edit')
+        self.grant_permission(self.user, 'Reviews:Admin')
         self.client.login_api(self.user)
         self.addon.update(status=amo.STATUS_DISABLED)
         response = self.client.post(self.enable_url)
@@ -4182,7 +4182,7 @@ class TestAddonReviewerViewSet(TestCase):
         assert activity_log.arguments[0] == self.addon
 
     def test_enable_already_public(self):
-        self.grant_permission(self.user, 'Reviews:Edit')
+        self.grant_permission(self.user, 'Reviews:Admin')
         self.client.login_api(self.user)
         response = self.client.post(self.enable_url)
         assert response.status_code == 202
@@ -4194,7 +4194,7 @@ class TestAddonReviewerViewSet(TestCase):
         assert activity_log.arguments[0] == self.addon
 
     def test_enable_no_public_versions_should_fall_back_to_incomplete(self):
-        self.grant_permission(self.user, 'Reviews:Edit')
+        self.grant_permission(self.user, 'Reviews:Admin')
         self.client.login_api(self.user)
         self.addon.update(status=amo.STATUS_DISABLED)
         self.addon.versions.all().delete()
@@ -4204,7 +4204,7 @@ class TestAddonReviewerViewSet(TestCase):
         assert self.addon.status == amo.STATUS_NULL
 
     def test_enable_version_is_awaiting_review_fall_back_to_nominated(self):
-        self.grant_permission(self.user, 'Reviews:Edit')
+        self.grant_permission(self.user, 'Reviews:Admin')
         self.client.login_api(self.user)
         self.addon.current_version.files.all().update(
             status=amo.STATUS_AWAITING_REVIEW)
@@ -4229,7 +4229,7 @@ class TestAddonReviewerViewSet(TestCase):
         assert response.status_code == 403
 
     def test_disable_addon_does_not_exist(self):
-        self.grant_permission(self.user, 'Reviews:Edit')
+        self.grant_permission(self.user, 'Reviews:Admin')
         self.client.login_api(self.user)
         self.disable_url = reverse(
             'reviewers-addon-enable', kwargs={'pk': self.addon.pk + 42})
@@ -4237,7 +4237,7 @@ class TestAddonReviewerViewSet(TestCase):
         assert response.status_code == 404
 
     def test_disable(self):
-        self.grant_permission(self.user, 'Reviews:Edit')
+        self.grant_permission(self.user, 'Reviews:Admin')
         self.client.login_api(self.user)
         self.addon.versions.all().delete()
         response = self.client.post(self.disable_url)
@@ -4267,7 +4267,7 @@ class TestAddonReviewerViewSet(TestCase):
         assert response.status_code == 403
 
     def test_clear_admin_review_flag_addon_does_not_exist(self):
-        self.grant_permission(self.user, 'Reviews:Edit')
+        self.grant_permission(self.user, 'Reviews:Admin')
         self.client.login_api(self.user)
         self.clear_admin_review_flag_url = reverse(
             'reviewers-addon-clear-admin-review-flag',
@@ -4277,7 +4277,7 @@ class TestAddonReviewerViewSet(TestCase):
         assert response.status_code == 404
 
     def test_clear_admin_review_flag_wrong_flag_type(self):
-        self.grant_permission(self.user, 'Reviews:Edit')
+        self.grant_permission(self.user, 'Reviews:Admin')
         self.client.login_api(self.user)
         response = self.client.post(
             self.clear_admin_review_flag_url, {'flag_type': 'lol'})
@@ -4286,7 +4286,7 @@ class TestAddonReviewerViewSet(TestCase):
             'detail': 'Invalid or missing flag_type parameter.'}
 
     def test_clear_admin_review_flag_no_flag_type(self):
-        self.grant_permission(self.user, 'Reviews:Edit')
+        self.grant_permission(self.user, 'Reviews:Admin')
         self.client.login_api(self.user)
         response = self.client.post(self.clear_admin_review_flag_url)
         assert response.status_code == 400
@@ -4295,7 +4295,7 @@ class TestAddonReviewerViewSet(TestCase):
 
     def test_clear_admin_review_flag_no_flags_yet(self):
         assert not AddonReviewerFlags.objects.filter(addon=self.addon).exists()
-        self.grant_permission(self.user, 'Reviews:Edit')
+        self.grant_permission(self.user, 'Reviews:Admin')
         self.client.login_api(self.user)
         response = self.client.post(
             self.clear_admin_review_flag_url, {'flag_type': 'code'})
@@ -4307,7 +4307,7 @@ class TestAddonReviewerViewSet(TestCase):
             addon=self.addon,
             needs_admin_code_review=True,
             needs_admin_content_review=True)
-        self.grant_permission(self.user, 'Reviews:Edit')
+        self.grant_permission(self.user, 'Reviews:Admin')
         self.client.login_api(self.user)
         response = self.client.post(
             self.clear_admin_review_flag_url, {'flag_type': 'code'})

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -24,13 +24,14 @@ from pyquery import PyQuery as pq
 from olympia import amo, core, ratings
 from olympia.abuse.models import AbuseReport
 from olympia.access.models import Group, GroupUser
+from olympia.accounts.views import API_TOKEN_COOKIE
 from olympia.activity.models import ActivityLog
 from olympia.addons.models import (
     Addon, AddonApprovalsCounter, AddonDependency, AddonReviewerFlags,
     AddonUser)
 from olympia.amo.tests import (
-    TestCase, addon_factory, check_links, file_factory, formset, initial,
-    user_factory, version_factory)
+    APITestClient, TestCase, addon_factory, check_links, file_factory, formset,
+    initial, user_factory, version_factory)
 from olympia.amo.urlresolvers import reverse
 from olympia.files.models import File, FileValidation, WebextPermission
 from olympia.ratings.models import Rating, RatingFlag
@@ -2365,19 +2366,6 @@ class TestReview(ReviewBase):
         assert len(mail.outbox) == 1
         self.assertTemplateUsed(response, 'activity/emails/from_reviewer.txt')
 
-    def test_notify(self):
-        response = self.client.post(self.url, {'action': 'reply',
-                                               'comments': 'hello sailor',
-                                               'notify': True})
-        assert response.status_code == 302
-        assert ReviewerSubscription.objects.count() == 1
-
-    def test_no_notify(self):
-        response = self.client.post(self.url, {'action': 'reply',
-                                               'comments': 'hello sailor'})
-        assert response.status_code == 302
-        assert ReviewerSubscription.objects.count() == 0
-
     def test_page_title(self):
         response = self.client.get(self.url)
         assert response.status_code == 200
@@ -2736,6 +2724,52 @@ class TestReview(ReviewBase):
         admin = doc('#actions-addon li')
         assert admin.length == 1
 
+    def test_extra_actions_subscribe_checked_state(self):
+        self.login_as_reviewer()
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        subscribe_input = doc('#notify_new_listed_versions')[0]
+        assert 'checked' not in subscribe_input.attrib
+
+        ReviewerSubscription.objects.create(
+            addon=self.addon, user=self.reviewer)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        subscribe_input = doc('#notify_new_listed_versions')[0]
+        assert subscribe_input.attrib['checked'] == 'checked'
+
+    def test_extra_actions_token(self):
+        self.login_as_reviewer()
+        self.client.cookies[API_TOKEN_COOKIE] = 'youdidntsaythemagicword'
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        token = doc('#extra-review-actions').attr('data-api-token')
+        assert token == 'youdidntsaythemagicword'
+
+    def test_extra_actions_admin_disable_enable_not_for_reviewers(self):
+        self.login_as_reviewer()
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        assert not doc('#force_disable_addon')
+        assert not doc('#force_enable_addon')
+
+    def test_extra_actions_admin_disable_enable(self):
+        self.login_as_admin()
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        assert doc('#force_disable_addon')
+        elem = doc('#force_disable_addon')[0]
+        assert 'hidden' not in elem.getparent().attrib.get('class', '')
+
+        assert doc('#force_enable_addon')
+        elem = doc('#force_enable_addon')[0]
+        assert 'hidden' in elem.getparent().attrib.get('class', '')
+
     def test_unflag_option_forflagged_as_admin(self):
         self.login_as_admin()
         AddonReviewerFlags.objects.create(
@@ -2743,8 +2777,8 @@ class TestReview(ReviewBase):
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
-        assert doc('#id_clear_admin_code_review').length == 1
-        assert doc('#id_clear_admin_content_review').length == 0
+        assert doc('#clear_admin_code_review').length == 1
+        assert doc('#clear_admin_content_review').length == 0
 
     def test_unflag_option_forflagged_as_reviewer(self):
         self.login_as_reviewer()
@@ -2753,8 +2787,8 @@ class TestReview(ReviewBase):
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
-        assert doc('#id_clear_admin_code_review').length == 0
-        assert doc('#id_clear_admin_content_review').length == 0
+        assert doc('#clear_admin_code_review').length == 0
+        assert doc('#clear_admin_content_review').length == 0
 
     def test_unflag_content_option_forflagged_as_admin(self):
         self.login_as_admin()
@@ -2765,40 +2799,8 @@ class TestReview(ReviewBase):
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
-        assert doc('#id_clear_admin_code_review').length == 0
-        assert doc('#id_clear_admin_content_review').length == 1
-
-    def test_unadmin_flag_as_admin(self):
-        AddonReviewerFlags.objects.create(
-            addon=self.addon,
-            needs_admin_code_review=True,
-            needs_admin_content_review=True)
-        self.login_as_admin()
-        response = self.client.post(
-            self.url, {'action': 'reply',
-                       'comments': 'hello sailor',
-                       'clear_admin_code_review': True,
-                       'clear_admin_content_review': True})
-        self.assert3xx(response, reverse('reviewers.queue_pending'),
-                       status_code=302)
-        self.addon.addonreviewerflags.reload()
-        assert not self.addon.needs_admin_code_review
-        assert not self.addon.needs_admin_content_review
-
-    def test_unadmin_flag_as_reviewer(self):
-        AddonReviewerFlags.objects.create(
-            addon=self.addon, needs_admin_code_review=True)
-        self.login_as_reviewer()
-        response = self.client.post(
-            self.url, {'action': 'reply',
-                       'comments': 'hello sailor',
-                       'clear_admin_code_review': True})
-        # Should silently fail to clear admin code review flag but work
-        # otherwise.
-        self.assert3xx(response, reverse('reviewers.queue_pending'),
-                       status_code=302)
-        assert self.addon.needs_admin_code_review
-        assert not self.addon.needs_admin_content_review
+        assert doc('#clear_admin_code_review').length == 0
+        assert doc('#clear_admin_content_review').length == 1
 
     def test_info_request_checkbox(self):
         self.login_as_reviewer()
@@ -4030,3 +4032,293 @@ class TestXssOnAddonName(amo.tests.TestXss):
     def test_reviewers_review_page(self):
         url = reverse('reviewers.review', args=[self.addon.slug])
         self.assertNameAndNoXSS(url)
+
+
+class TestAddonReviewerViewSet(TestCase):
+    client_class = APITestClient
+
+    def setUp(self):
+        super(TestAddonReviewerViewSet, self).setUp()
+        self.user = user_factory()
+        self.addon = addon_factory()
+        self.subscribe_url = reverse(
+            'reviewers-addon-subscribe', kwargs={'pk': self.addon.pk})
+        self.unsubscribe_url = reverse(
+            'reviewers-addon-unsubscribe', kwargs={'pk': self.addon.pk})
+        self.enable_url = reverse(
+            'reviewers-addon-enable', kwargs={'pk': self.addon.pk})
+        self.disable_url = reverse(
+            'reviewers-addon-disable', kwargs={'pk': self.addon.pk})
+        self.clear_admin_review_flag_url = reverse(
+            'reviewers-addon-clear-admin-review-flag',
+            kwargs={'pk': self.addon.pk})
+
+    def test_subscribe_not_logged_in(self):
+        response = self.client.post(self.subscribe_url)
+        assert response.status_code == 401
+
+    def test_subscribe_no_rights(self):
+        self.client.login_api(self.user)
+        response = self.client.post(self.subscribe_url)
+        assert response.status_code == 403
+
+    def test_subscribe_addon_does_not_exist(self):
+        self.grant_permission(self.user, 'Addons:PostReview')
+        self.client.login_api(self.user)
+        self.subscribe_url = reverse(
+            'reviewers-addon-subscribe', kwargs={'pk': self.addon.pk + 42})
+        response = self.client.post(self.subscribe_url)
+        assert response.status_code == 404
+
+    def test_subscribe_already_subscribed(self):
+        ReviewerSubscription.objects.create(
+            user=self.user, addon=self.addon)
+        self.grant_permission(self.user, 'Addons:PostReview')
+        self.client.login_api(self.user)
+        self.subscribe_url = reverse(
+            'reviewers-addon-subscribe', kwargs={'pk': self.addon.pk})
+        response = self.client.post(self.subscribe_url)
+        assert response.status_code == 202
+        assert ReviewerSubscription.objects.count() == 1
+
+    def test_subscribe(self):
+        self.grant_permission(self.user, 'Addons:PostReview')
+        self.client.login_api(self.user)
+        self.subscribe_url = reverse(
+            'reviewers-addon-subscribe', kwargs={'pk': self.addon.pk})
+        response = self.client.post(self.subscribe_url)
+        assert response.status_code == 202
+        assert ReviewerSubscription.objects.count() == 1
+
+    def test_unsubscribe_not_logged_in(self):
+        response = self.client.post(self.unsubscribe_url)
+        assert response.status_code == 401
+
+    def test_unsubscribe_no_rights(self):
+        self.client.login_api(self.user)
+        response = self.client.post(self.unsubscribe_url)
+        assert response.status_code == 403
+
+    def test_unsubscribe_addon_does_not_exist(self):
+        self.grant_permission(self.user, 'Addons:PostReview')
+        self.client.login_api(self.user)
+        self.unsubscribe_url = reverse(
+            'reviewers-addon-subscribe', kwargs={'pk': self.addon.pk + 42})
+        response = self.client.post(self.unsubscribe_url)
+        assert response.status_code == 404
+
+    def test_unsubscribe_not_subscribed(self):
+        self.grant_permission(self.user, 'Addons:PostReview')
+        self.client.login_api(self.user)
+        self.subscribe_url = reverse(
+            'reviewers-addon-subscribe', kwargs={'pk': self.addon.pk})
+        response = self.client.post(self.unsubscribe_url)
+        assert response.status_code == 202
+        assert ReviewerSubscription.objects.count() == 0
+
+    def test_unsubscribe(self):
+        ReviewerSubscription.objects.create(
+            user=self.user, addon=self.addon)
+        self.grant_permission(self.user, 'Addons:PostReview')
+        self.client.login_api(self.user)
+        self.subscribe_url = reverse(
+            'reviewers-addon-subscribe', kwargs={'pk': self.addon.pk})
+        response = self.client.post(self.unsubscribe_url)
+        assert response.status_code == 202
+        assert ReviewerSubscription.objects.count() == 0
+
+    def test_unsubscribe_dont_touch_another(self):
+        another_user = user_factory()
+        another_addon = addon_factory()
+        ReviewerSubscription.objects.create(
+            user=self.user, addon=self.addon)
+        ReviewerSubscription.objects.create(
+            user=self.user, addon=another_addon)
+        ReviewerSubscription.objects.create(
+            user=another_user, addon=self.addon)
+        self.grant_permission(self.user, 'Addons:PostReview')
+        self.client.login_api(self.user)
+        self.subscribe_url = reverse(
+            'reviewers-addon-subscribe', kwargs={'pk': self.addon.pk})
+        response = self.client.post(self.unsubscribe_url)
+        assert response.status_code == 202
+        assert ReviewerSubscription.objects.count() == 2
+        assert not ReviewerSubscription.objects.filter(
+            addon=self.addon, user=self.user).exists()
+
+    def test_enable_not_logged_in(self):
+        response = self.client.post(self.enable_url)
+        assert response.status_code == 401
+
+    def test_enable_no_rights(self):
+        self.client.login_api(self.user)
+        response = self.client.post(self.enable_url)
+        assert response.status_code == 403
+
+        # Being a reviewer is not enough.
+        self.grant_permission(self.user, 'Addons:Review')
+        response = self.client.post(self.enable_url)
+        assert response.status_code == 403
+
+    def test_enable_addon_does_not_exist(self):
+        self.grant_permission(self.user, 'Reviews:Edit')
+        self.client.login_api(self.user)
+        self.enable_url = reverse(
+            'reviewers-addon-enable', kwargs={'pk': self.addon.pk + 42})
+        response = self.client.post(self.enable_url)
+        assert response.status_code == 404
+
+    def test_enable(self):
+        self.grant_permission(self.user, 'Reviews:Edit')
+        self.client.login_api(self.user)
+        self.addon.update(status=amo.STATUS_DISABLED)
+        response = self.client.post(self.enable_url)
+        assert response.status_code == 202
+        self.addon.reload()
+        assert self.addon.status == amo.STATUS_PUBLIC
+        assert ActivityLog.objects.count() == 1
+        activity_log = ActivityLog.objects.latest('pk')
+        assert activity_log.action == amo.LOG.CHANGE_STATUS.id
+        assert activity_log.arguments[0] == self.addon
+
+    def test_enable_already_public(self):
+        self.grant_permission(self.user, 'Reviews:Edit')
+        self.client.login_api(self.user)
+        response = self.client.post(self.enable_url)
+        assert response.status_code == 202
+        self.addon.reload()
+        assert self.addon.status == amo.STATUS_PUBLIC
+        assert ActivityLog.objects.count() == 1
+        activity_log = ActivityLog.objects.latest('pk')
+        assert activity_log.action == amo.LOG.CHANGE_STATUS.id
+        assert activity_log.arguments[0] == self.addon
+
+    def test_enable_no_public_versions_should_fall_back_to_incomplete(self):
+        self.grant_permission(self.user, 'Reviews:Edit')
+        self.client.login_api(self.user)
+        self.addon.update(status=amo.STATUS_DISABLED)
+        self.addon.versions.all().delete()
+        response = self.client.post(self.enable_url)
+        assert response.status_code == 202
+        self.addon.reload()
+        assert self.addon.status == amo.STATUS_NULL
+
+    def test_enable_version_is_awaiting_review_fall_back_to_nominated(self):
+        self.grant_permission(self.user, 'Reviews:Edit')
+        self.client.login_api(self.user)
+        self.addon.current_version.files.all().update(
+            status=amo.STATUS_AWAITING_REVIEW)
+        self.addon.update(status=amo.STATUS_DISABLED)
+        response = self.client.post(self.enable_url)
+        assert response.status_code == 202
+        self.addon.reload()
+        assert self.addon.status == amo.STATUS_NOMINATED
+
+    def test_disable_not_logged_in(self):
+        response = self.client.post(self.disable_url)
+        assert response.status_code == 401
+
+    def test_disable_no_rights(self):
+        self.client.login_api(self.user)
+        response = self.client.post(self.disable_url)
+        assert response.status_code == 403
+
+        # Being a reviewer is not enough.
+        self.grant_permission(self.user, 'Addons:Review')
+        response = self.client.post(self.disable_url)
+        assert response.status_code == 403
+
+    def test_disable_addon_does_not_exist(self):
+        self.grant_permission(self.user, 'Reviews:Edit')
+        self.client.login_api(self.user)
+        self.disable_url = reverse(
+            'reviewers-addon-enable', kwargs={'pk': self.addon.pk + 42})
+        response = self.client.post(self.disable_url)
+        assert response.status_code == 404
+
+    def test_disable(self):
+        self.grant_permission(self.user, 'Reviews:Edit')
+        self.client.login_api(self.user)
+        self.addon.versions.all().delete()
+        response = self.client.post(self.disable_url)
+        assert response.status_code == 202
+        self.addon.reload()
+        assert self.addon.status == amo.STATUS_DISABLED
+        assert ActivityLog.objects.count() == 1
+        activity_log = ActivityLog.objects.latest('pk')
+        assert activity_log.action == amo.LOG.CHANGE_STATUS.id
+        assert activity_log.arguments[0] == self.addon
+
+    def test_clear_admin_review_flag_not_logged_in(self):
+        response = self.client.post(
+            self.clear_admin_review_flag_url, {'flag_type': 'code'})
+        assert response.status_code == 401
+
+    def test_clear_admin_review_flag_no_rights(self):
+        self.client.login_api(self.user)
+        response = self.client.post(
+            self.clear_admin_review_flag_url, {'flag_type': 'code'})
+        assert response.status_code == 403
+
+        # Being a reviewer is not enough.
+        self.grant_permission(self.user, 'Addons:Review')
+        response = self.client.post(
+            self.clear_admin_review_flag_url, {'flag_type': 'code'})
+        assert response.status_code == 403
+
+    def test_clear_admin_review_flag_addon_does_not_exist(self):
+        self.grant_permission(self.user, 'Reviews:Edit')
+        self.client.login_api(self.user)
+        self.clear_admin_review_flag_url = reverse(
+            'reviewers-addon-clear-admin-review-flag',
+            kwargs={'pk': self.addon.pk + 42})
+        response = self.client.post(
+            self.clear_admin_review_flag_url, {'flag_type': 'code'})
+        assert response.status_code == 404
+
+    def test_clear_admin_review_flag_wrong_flag_type(self):
+        self.grant_permission(self.user, 'Reviews:Edit')
+        self.client.login_api(self.user)
+        response = self.client.post(
+            self.clear_admin_review_flag_url, {'flag_type': 'lol'})
+        assert response.status_code == 400
+        assert response.data == {
+            'detail': 'Invalid or missing flag_type parameter.'}
+
+    def test_clear_admin_review_flag_no_flag_type(self):
+        self.grant_permission(self.user, 'Reviews:Edit')
+        self.client.login_api(self.user)
+        response = self.client.post(self.clear_admin_review_flag_url)
+        assert response.status_code == 400
+        assert response.data == {
+            'detail': 'Invalid or missing flag_type parameter.'}
+
+    def test_clear_admin_review_flag_no_flags_yet(self):
+        assert not AddonReviewerFlags.objects.filter(addon=self.addon).exists()
+        self.grant_permission(self.user, 'Reviews:Edit')
+        self.client.login_api(self.user)
+        response = self.client.post(
+            self.clear_admin_review_flag_url, {'flag_type': 'code'})
+        assert response.status_code == 202
+        assert not AddonReviewerFlags.objects.filter(addon=self.addon).exists()
+
+    def test_clear_admin_review_flag(self):
+        reviewer_flags = AddonReviewerFlags.objects.create(
+            addon=self.addon,
+            needs_admin_code_review=True,
+            needs_admin_content_review=True)
+        self.grant_permission(self.user, 'Reviews:Edit')
+        self.client.login_api(self.user)
+        response = self.client.post(
+            self.clear_admin_review_flag_url, {'flag_type': 'code'})
+        assert response.status_code == 202
+        reviewer_flags.reload()
+        assert not reviewer_flags.needs_admin_code_review
+        assert reviewer_flags.needs_admin_content_review  # Not touched.
+
+        response = self.client.post(
+            self.clear_admin_review_flag_url, {'flag_type': 'content'})
+        assert response.status_code == 202
+        reviewer_flags.reload()
+        assert not reviewer_flags.needs_admin_code_review
+        assert not reviewer_flags.needs_admin_content_review

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -782,7 +782,7 @@ def review(request, addon, channel=None):
         content_review_only=content_review_only)
     form = forms.ReviewForm(request.POST if request.method == 'POST' else None,
                             helper=form_helper, initial=form_initial)
-    is_admin = acl.action_allowed(request, amo.permissions.REVIEWS_EDIT)
+    is_admin = acl.action_allowed(request, amo.permissions.REVIEWS_ADMIN)
 
     approvals_info = None
     reports = None
@@ -1128,7 +1128,7 @@ class AddonReviewerViewSet(GenericViewSet):
 
     @detail_route(
         methods=['post'],
-        permission_classes=[GroupPermission(amo.permissions.REVIEWS_EDIT)])
+        permission_classes=[GroupPermission(amo.permissions.REVIEWS_ADMIN)])
     def disable(self, request, **kwargs):
         addon = get_object_or_404(Addon, pk=kwargs['pk'])
         ActivityLog.create(amo.LOG.CHANGE_STATUS, addon, amo.STATUS_DISABLED)
@@ -1140,7 +1140,7 @@ class AddonReviewerViewSet(GenericViewSet):
 
     @detail_route(
         methods=['post'],
-        permission_classes=[GroupPermission(amo.permissions.REVIEWS_EDIT)])
+        permission_classes=[GroupPermission(amo.permissions.REVIEWS_ADMIN)])
     def enable(self, request, **kwargs):
         addon = get_object_or_404(Addon, pk=kwargs['pk'])
         ActivityLog.create(amo.LOG.CHANGE_STATUS, addon, amo.STATUS_PUBLIC)
@@ -1154,7 +1154,7 @@ class AddonReviewerViewSet(GenericViewSet):
 
     @detail_route(
         methods=['post'],
-        permission_classes=[GroupPermission(amo.permissions.REVIEWS_EDIT)])
+        permission_classes=[GroupPermission(amo.permissions.REVIEWS_ADMIN)])
     def clear_admin_review_flag(self, request, **kwargs):
         addon = get_object_or_404(Addon, pk=kwargs['pk'])
         flag_type = request.data.get('flag_type', None)

--- a/static/css/zamboni/reviewers.styl
+++ b/static/css/zamboni/reviewers.styl
@@ -904,7 +904,8 @@ form.review-form .data-toggle {
     text-align: right;
 }
 
-.review-actions-section label {
+.review-actions-section label,
+.more-actions label {
     font-weight: normal;
 }
 
@@ -1107,5 +1108,28 @@ gradient-two-color($color1, $color2) {
         .whiteboard-actions {
             text-align: right;
         }
+    }
+}
+
+.more-actions {
+    border: 1px solid #ebebeb;
+    padding: 10px;
+
+    .more-actions-inner {
+        display: flex;
+        justify-content: space-between;
+    }
+
+    .admin_only {
+        background-color: oldlace;
+        padding: 1em;
+    }
+
+    li {
+      margin: 0 0 1em 0;
+    }
+
+    #force_disable_addon, #force_enable_addon {
+        background-color: orange;
     }
 }

--- a/static/js/zamboni/reviewers.js
+++ b/static/js/zamboni/reviewers.js
@@ -31,6 +31,10 @@
         initReviewActions();
     }
 
+    if ($('#extra-review-actions').length) {
+        initExtraReviewActions();
+    }
+
     if($('#monthly.highcharts-container').length) {
         initPerformanceStats();
     }
@@ -187,6 +191,78 @@ function initReviewActions() {
         }
     }
     check_receipt();
+}
+
+function initExtraReviewActions() {
+    $('#notify_new_listed_versions').click(_pd(function() {
+        var $input = $(this);
+        $input.prop('disabled', true);  // Prevent double-send.
+        var checked = !$input.prop('checked');  // It's already changed.
+        var apiUrl;
+        if (checked) {
+            apiUrl = $input.data('api-url-unsubscribe');
+        } else {
+            apiUrl = $input.data('api-url-subscribe');
+        }
+        var token = $input.parents('form.more-actions').data('api-token');
+        $.ajax({
+            url: apiUrl,
+            type: 'post',
+            beforeSend: function (xhr) {
+                xhr.setRequestHeader ("Authorization", 'Bearer ' + token);
+            },
+            processData: false,
+            contentType: 'application/json',
+            success: function() {
+                $input.prop('disabled', false);
+                $input.prop('checked', !checked)
+            },
+         });
+    }));
+
+    $('#clear_admin_code_review, #clear_admin_content_review').click(_pd(function() {
+        var $button = $(this);
+        $button.prop('disabled', true);  // Prevent double-send.
+        var apiUrl = $button.data('api-url');
+        var token = $button.parents('form.more-actions').data('api-token');
+        var flagType = $button.data('api-flag');
+        $.ajax({
+            url: apiUrl,
+            data: JSON.stringify({
+                flag_type: flagType,
+            }),
+            type: 'post',
+            beforeSend: function (xhr) {
+                xhr.setRequestHeader ("Authorization", 'Bearer ' + token);
+            },
+            processData: false,
+            contentType: 'application/json',
+            success: function() {
+                $button.remove();
+            },
+         });
+    }));
+
+    $('#force_disable_addon, #force_enable_addon').click(_pd(function() {
+        var $button = $(this);
+        var $other_button = $('.hidden #force_disable_addon, .hidden #force_enable_addon');
+        $button.prop('disabled', true);  // Prevent double-send.
+        var apiUrl = $button.data('api-url');
+        var token = $button.parents('form.more-actions').data('api-token');
+        $.ajax({
+            url: apiUrl,
+            type: 'post',
+            beforeSend: function (xhr) {
+                xhr.setRequestHeader ("Authorization", 'Bearer ' + token);
+            },
+            processData: false,
+            contentType: 'application/json',
+            success: function() {
+                $button.prop('disabled', false).parents('li').addClass('hidden').hide();
+                $other_button.parents('li').removeClass('hidden').show();
+            },
+         });
+    }));
 }
 
 function insertAtCursor(textarea, text) {


### PR DESCRIPTION
- Subscribing to notifications
- Force disabling/enabling of an add-on (admins)
- Clear needs admin code/content review flag (admins)

Fix #7282