### PR TITLE
Set API token cookie on session domain, to have it in reviewer tools

### DIFF
--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -501,6 +501,7 @@ class TestWithUser(TestCase):
         response.set_cookie.assert_called_with(
             views.API_TOKEN_COOKIE,
             'fake-api-token',
+            domain=settings.SESSION_COOKIE_DOMAIN,
             max_age=settings.SESSION_COOKIE_AGE,
             secure=settings.SESSION_COOKIE_SECURE,
             httponly=settings.SESSION_COOKIE_HTTPONLY)

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -259,6 +259,7 @@ def add_api_token_to_response(response, user):
     response.set_cookie(
         API_TOKEN_COOKIE,
         token,
+        domain=settings.SESSION_COOKIE_DOMAIN,
         max_age=settings.SESSION_COOKIE_AGE,
         secure=settings.SESSION_COOKIE_SECURE,
         httponly=settings.SESSION_COOKIE_HTTPONLY)


### PR DESCRIPTION
Now that reviewer tools are on their own subdomain, if we don't specify the domain for this cookie it's only set on the domain we logged in from, which will be a.m.o and would be missing on reviewers.a.m.o.

Should fix #7311 in dev/stage/prod.