### PR TITLE
Avoid extra ES queries in legacy search code

### DIFF
--- a/src/olympia/amo/search.py
+++ b/src/olympia/amo/search.py
@@ -85,7 +85,7 @@ class ES(object):
         return new
 
     def count(self):
-        if self._results_cache:
+        if self._results_cache is not None:
             return self._results_cache.count
         else:
             return self[:0].raw()['hits']['total']
@@ -223,7 +223,7 @@ class ES(object):
         return query
 
     def _do_search(self):
-        if not self._results_cache:
+        if self._results_cache is None:
             hits = self.raw()
             if self.as_dict:
                 ResultClass = DictSearchResults


### PR DESCRIPTION
Between 1 and 4 (!) extra ES queries were made for every legacy search. Fortunately the worst case scenario appears to be when there wasn't any results.
     
This did not affect the API, but this commit adds tests there just to be sure.


Fix #7364