### PR TITLE
Fix flake8 errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
     - secure: "bYe6WOTAnlS8Ru4ODWSSOnHffxcN23NkKZh4M0eO510HvZGCMB4zZn8afiVKGXd1YqsoRfMXTBZJ0yBcFEvWnyH7S4kd+7d1PpNS4kgLVKtLCW5d7Wc5GA6uh1jWLS+zKFBNN5sZ8OVc7rCsLCBRDEoI94wBKYwDX2Kk1WKylz8="
     - AUTOGRAPH_SERVER_URL: http://localhost:5500
   matrix:
-  - TOXENV=flake8
+  - TOXENV=codestyle
   - TOXENV=docs
   - TOXENV=assets
   - TOXENV=es

--- a/src/olympia/api/permissions.py
+++ b/src/olympia/api/permissions.py
@@ -1,7 +1,6 @@
 from rest_framework.exceptions import MethodNotAllowed
 from rest_framework.permissions import SAFE_METHODS, BasePermission
 
-from olympia import amo
 from olympia.amo import permissions
 from olympia.access import acl
 

--- a/src/olympia/reviewers/models.py
+++ b/src/olympia/reviewers/models.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.core.cache import cache
 from django.db import models
 from django.db.models import Q, Sum
-from django.db.models.functions import Coalesce, Func
+from django.db.models.functions import Func
 from django.template import loader
 from django.utils.translation import ugettext, ugettext_lazy as _
 

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -39,7 +39,7 @@ from olympia.reviewers.models import (
     AutoApprovalSummary, RereviewQueueTheme, ReviewerScore,
     ReviewerSubscription, Whiteboard)
 from olympia.users.models import UserProfile
-from olympia.versions.models import ApplicationsVersions, AppVersion, Version
+from olympia.versions.models import ApplicationsVersions, AppVersion
 from olympia.zadmin.models import get_config, set_config
 
 


### PR DESCRIPTION
Weirdly, flake8 builds seem to pass on master... but there are clearly some "imported but unused errors" in the repos...

**Edit:** this is because `.travis.yml` calls `TOXENV=flake8` but in `tox.ini` the env was changed to `codestyle`. Fixing this as well.