### PR TITLE
Show error if add-on is using Mozilla trademarks incorrectly.

### DIFF
--- a/src/olympia/addons/forms.py
+++ b/src/olympia/addons/forms.py
@@ -119,12 +119,11 @@ class AddonFormBase(TranslationFormMixin, happyforms.ModelForm):
         return clean_addon_slug(self.cleaned_data['slug'], self.instance)
 
     def clean_name(self):
-        data = self.cleaned_data.copy()
         user = getattr(self.request, 'user', None)
 
-        verify_mozilla_trademark(data['name'], user)
+        name = verify_mozilla_trademark(self.cleaned_data['name'], user)
 
-        return data['name']
+        return name
 
     def clean_tags(self):
         return clean_tags(self.request, self.cleaned_data['tags'])

--- a/src/olympia/addons/forms.py
+++ b/src/olympia/addons/forms.py
@@ -119,8 +119,6 @@ class AddonFormBase(TranslationFormMixin, happyforms.ModelForm):
         return clean_addon_slug(self.cleaned_data['slug'], self.instance)
 
     def clean_name(self):
-        # TODO: This should be handled a bit cleaner in `TranslationFormMixin`
-        # but let's see if this actually works...
         data = self.cleaned_data.copy()
         user = getattr(self.request, 'user', None)
 

--- a/src/olympia/addons/forms.py
+++ b/src/olympia/addons/forms.py
@@ -124,7 +124,7 @@ class AddonFormBase(TranslationFormMixin, happyforms.ModelForm):
 
         verify_mozilla_trademark(data['name'], user)
 
-        return data
+        return data['name']
 
     def clean_tags(self):
         return clean_tags(self.request, self.cleaned_data['tags'])

--- a/src/olympia/addons/tests/test_forms.py
+++ b/src/olympia/addons/tests/test_forms.py
@@ -62,6 +62,45 @@ class FormsTest(TestCase):
         assert form.errors['slug'] == (
             [u'The slug cannot be "submit". Please choose another.'])
 
+    def test_name_trademark_mozilla(self):
+        delicious = Addon.objects.get()
+        form = forms.AddonFormBasic(
+            {'name': 'Delicious Mozilla', 'summary': 'foo', 'slug': 'bar'},
+            request=self.request,
+            instance=delicious)
+
+        assert not form.is_valid()
+        assert dict(form.errors['name'])['en-us'].startswith(
+            u'Add-on names cannot contain the Mozilla or Firefox trademarks.')
+
+    def test_name_trademark_firefox(self):
+        delicious = Addon.objects.get()
+        form = forms.AddonFormBasic(
+            {'name': 'Delicious Firefox', 'summary': 'foo', 'slug': 'bar'},
+            request=self.request,
+            instance=delicious)
+        assert not form.is_valid()
+        assert dict(form.errors['name'])['en-us'].startswith(
+            u'Add-on names cannot contain the Mozilla or Firefox trademarks.')
+
+    def test_name_trademark_allowed_for_prefix(self):
+        delicious = Addon.objects.get()
+        form = forms.AddonFormBasic(
+            {'name': 'Delicious for Mozilla', 'summary': 'foo', 'slug': 'bar'},
+            request=self.request,
+            instance=delicious)
+
+        assert form.is_valid()
+
+    def test_name_no_trademark(self):
+        delicious = Addon.objects.get()
+        form = forms.AddonFormBasic(
+            {'name': 'Delicious Dumdidum', 'summary': 'foo', 'slug': 'bar'},
+            request=self.request,
+            instance=delicious)
+
+        assert form.is_valid()
+
     def test_bogus_homepage(self):
         form = forms.AddonFormDetails(
             {'homepage': 'javascript://something.com'}, request=self.request)

--- a/src/olympia/addons/utils.py
+++ b/src/olympia/addons/utils.py
@@ -130,7 +130,7 @@ def verify_mozilla_trademark(name, user):
                 except forms.ValidationError as exc:
                     errors.extend(exc.messages, locale)
 
-    if errors:
-        raise LocaleValidationError(errors)
+        if errors:
+            raise LocaleValidationError(errors)
 
     return name

--- a/src/olympia/addons/utils.py
+++ b/src/olympia/addons/utils.py
@@ -117,8 +117,7 @@ def verify_mozilla_trademark(name, user):
         if violates_trademark:
             raise forms.ValidationError(ugettext(
                 u'Add-on names cannot contain the Mozilla or '
-                u'Firefox trademarks. These names should not be '
-                u'contained in add-on names if at all possible.'))
+                u'Firefox trademarks.'))
 
     if not skip_trademark_check:
         errors = LocaleList()

--- a/src/olympia/addons/utils.py
+++ b/src/olympia/addons/utils.py
@@ -105,18 +105,20 @@ def verify_mozilla_trademark(name, user):
 
     def _check(name):
         name = name.lower()
+        contains_trademark_symbol = any(
+            symbol in name for symbol in amo.MOZILLA_TRADEMARK_SYMBOLS)
+
         violates_trademark = (
-            any(symbol in name for symbol in amo.MOZILLA_TRADEMARK_SYMBOLS)
-            and not name.endswith(tuple(
+            contains_trademark_symbol and not
+            name.endswith(tuple(
                 'for {}'.format(symbol)
                 for symbol in amo.MOZILLA_TRADEMARK_SYMBOLS)))
 
         if violates_trademark:
             raise forms.ValidationError(ugettext(
-                        u'Add-on names cannot contain the Mozilla or '
-                        u'Firefox trademarks. These names should not be '
-                        u'contained in add-on names if at all possible.'))
-
+                u'Add-on names cannot contain the Mozilla or '
+                u'Firefox trademarks. These names should not be '
+                u'contained in add-on names if at all possible.'))
 
     if not skip_trademark_check:
         errors = LocaleList()

--- a/src/olympia/addons/utils.py
+++ b/src/olympia/addons/utils.py
@@ -100,7 +100,7 @@ def get_creatured_ids(category, lang=None):
 
 def verify_mozilla_trademark(name, user):
     skip_trademark_check = (
-        user and user.is_authenticated() and
+        user and user.is_authenticated() and user.email and
         user.email.endswith(amo.ALLOWED_TRADEMARK_SUBMITTING_EMAILS))
 
     def _check(name):

--- a/src/olympia/addons/utils.py
+++ b/src/olympia/addons/utils.py
@@ -1,12 +1,16 @@
 import random
 import uuid
 
+from django import forms
 from django.core.cache import cache
 from django.db.models import Q
+from django.utils.translation import ugettext
 
 import olympia.core.logger
 
+from olympia import amo
 from olympia.amo.cache_nuggets import memoize, memoize_key
+from olympia.translations.fields import LocaleList, LocaleValidationError
 from olympia.constants.categories import CATEGORIES_BY_ID
 
 
@@ -92,3 +96,41 @@ def get_creatured_ids(category, lang=None):
     random.shuffle(others)
     random.shuffle(per_locale)
     return map(int, filter(None, per_locale + others))
+
+
+def verify_mozilla_trademark(name, user):
+    skip_trademark_check = (
+        user and user.is_authenticated() and
+        user.email.endswith(amo.ALLOWED_TRADEMARK_SUBMITTING_EMAILS))
+
+    def _check(name):
+        name = name.lower()
+        violates_trademark = (
+            any(symbol in name for symbol in amo.MOZILLA_TRADEMARK_SYMBOLS)
+            and not name.endswith(tuple(
+                'for {}'.format(symbol)
+                for symbol in amo.MOZILLA_TRADEMARK_SYMBOLS)))
+
+        if violates_trademark:
+            raise forms.ValidationError(ugettext(
+                        u'Add-on names cannot contain the Mozilla or '
+                        u'Firefox trademarks. These names should not be '
+                        u'contained in add-on names if at all possible.'))
+
+
+    if not skip_trademark_check:
+        errors = LocaleList()
+
+        if not isinstance(name, dict):
+            _check(name)
+        else:
+            for locale, localized_name in name.items():
+                try:
+                    _check(localized_name)
+                except forms.ValidationError as exc:
+                    errors.extend(exc.messages, locale)
+
+    if errors:
+        raise LocaleValidationError(errors)
+
+    return name

--- a/src/olympia/constants/base.py
+++ b/src/olympia/constants/base.py
@@ -428,5 +428,11 @@ ADDON_GUID_PATTERN = re.compile(
 SYSTEM_ADDON_GUIDS = (
     u'@mozilla.org', u'@shield.mozilla.org', u'@pioneer.mozilla.org')
 
+MOZILLA_TRADEMARK_SYMBOLS = (
+    'mozilla', 'firefox')
+
+ALLOWED_TRADEMARK_SUBMITTING_EMAILS = (
+    '@mozilla.com', '@mozilla.org')
+
 TAAR_ALLOWED_PARAMETERS = (
     'telemetry-client-id', 'lang', 'platform', 'branch', 'study')

--- a/src/olympia/devhub/tests/test_tasks.py
+++ b/src/olympia/devhub/tests/test_tasks.py
@@ -822,7 +822,7 @@ class TestLegacyAddonRestrictions(ValidatorTestCase):
                 }
             }
         }
-        results = tasks.annotate_legacy_addon_restrictions(
+        results = tasks.annotate_addon_restrictions(
             data, is_new_upload=True)
         assert results['errors'] == 1
         assert len(results['messages']) > 0
@@ -844,7 +844,7 @@ class TestLegacyAddonRestrictions(ValidatorTestCase):
                 }
             }
         }
-        results = tasks.annotate_legacy_addon_restrictions(
+        results = tasks.annotate_addon_restrictions(
             data, is_new_upload=True)
         assert results['errors'] == 1
         assert len(results['messages']) > 0
@@ -965,14 +965,14 @@ class TestLegacyAddonRestrictions(ValidatorTestCase):
                 }
             }
         }
-        results = tasks.annotate_legacy_addon_restrictions(
+        results = tasks.annotate_addon_restrictions(
             data.copy(), is_new_upload=True)
         assert results['errors'] == 1
         assert len(results['messages']) > 0
         assert results['messages'][0]['id'] == [
             'validation', 'messages', 'legacy_addons_max_version']
 
-        results = tasks.annotate_legacy_addon_restrictions(
+        results = tasks.annotate_addon_restrictions(
             data.copy(), is_new_upload=False)
         assert results['errors'] == 1
         assert len(results['messages']) > 0

--- a/src/olympia/devhub/tests/test_tasks.py
+++ b/src/olympia/devhub/tests/test_tasks.py
@@ -822,7 +822,7 @@ class TestLegacyAddonRestrictions(ValidatorTestCase):
                 }
             }
         }
-        results = tasks.annotate_addon_restrictions(
+        results = tasks.annotate_legacy_addon_restrictions(
             data, is_new_upload=True)
         assert results['errors'] == 1
         assert len(results['messages']) > 0
@@ -844,7 +844,7 @@ class TestLegacyAddonRestrictions(ValidatorTestCase):
                 }
             }
         }
-        results = tasks.annotate_addon_restrictions(
+        results = tasks.annotate_legacy_addon_restrictions(
             data, is_new_upload=True)
         assert results['errors'] == 1
         assert len(results['messages']) > 0
@@ -965,14 +965,14 @@ class TestLegacyAddonRestrictions(ValidatorTestCase):
                 }
             }
         }
-        results = tasks.annotate_addon_restrictions(
+        results = tasks.annotate_legacy_addon_restrictions(
             data.copy(), is_new_upload=True)
         assert results['errors'] == 1
         assert len(results['messages']) > 0
         assert results['messages'][0]['id'] == [
             'validation', 'messages', 'legacy_addons_max_version']
 
-        results = tasks.annotate_addon_restrictions(
+        results = tasks.annotate_legacy_addon_restrictions(
             data.copy(), is_new_upload=False)
         assert results['errors'] == 1
         assert len(results['messages']) > 0

--- a/src/olympia/files/tests/test_utils_.py
+++ b/src/olympia/files/tests/test_utils_.py
@@ -339,6 +339,34 @@ class TestManifestJSONExtractor(TestCase):
             # We set `strictCompatibility` in install.rdf
             assert parsed['strict_compatibility']
 
+    @mock.patch('olympia.addons.models.resolve_i18n_message')
+    def test_mozilla_trademark_disallowed(self, resolve_message):
+        resolve_message.return_value = 'Notify Mozilla'
+
+        addon = amo.tests.addon_factory()
+        file_obj = addon.current_version.all_files[0]
+        fixture = (
+            'src/olympia/files/fixtures/files/notify-link-clicks-i18n.xpi')
+
+        with amo.tests.copy_file(fixture, file_obj.file_path):
+            with pytest.raises(forms.ValidationError) as exc:
+                utils.parse_xpi(file_obj.file_path)
+                assert dict(exc.value.messages)['en-us'].startswith(
+                    u'Add-on names cannot contain the Mozilla or'
+                )
+
+    @mock.patch('olympia.addons.models.resolve_i18n_message')
+    def test_mozilla_trademark_for_prefix_allowed(self, resolve_message):
+        resolve_message.return_value = 'Notify for Mozilla'
+
+        addon = amo.tests.addon_factory()
+        file_obj = addon.current_version.all_files[0]
+        fixture = (
+            'src/olympia/files/fixtures/files/notify-link-clicks-i18n.xpi')
+
+        with amo.tests.copy_file(fixture, file_obj.file_path):
+            utils.parse_xpi(file_obj.file_path)
+
     def test_apps_use_default_versions_if_applications_is_omitted(self):
         """
         WebExtensions are allowed to omit `applications[/gecko]` and we

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -867,8 +867,10 @@ def check_xpi_info(xpi_info, addon=None, xpi_file=None):
                 'WebExtension theme uploads are currently not supported.'))
 
     if xpi_file:
+        # Make sure we pass in a copy of `xpi_info` since
+        # `resolve_webext_translations` modifies data in-place
         translations = Addon.resolve_webext_translations(
-            xpi_info, xpi_file)
+            xpi_info.copy(), xpi_file)
         verify_mozilla_trademark(translations['name'], core.get_user())
 
     return xpi_info


### PR DESCRIPTION
Fixes #6693

Errors for misusing the trademark:

![screenshot from 2018-01-23 18-03-19](https://user-images.githubusercontent.com/139033/35289984-26f8e5ac-0069-11e8-83e1-aefa43a0e414.png)

![screenshot from 2018-01-23 18-20-32](https://user-images.githubusercontent.com/139033/35290367-56ece0dc-006a-11e8-8851-bfacd6e41331.png)

Perfectly fine using "for Mozilla" postfix:

![screenshot from 2018-01-23 18-20-54](https://user-images.githubusercontent.com/139033/35290378-60788368-006a-11e8-8271-f9ea1ec6776e.png)
