### PR TITLE
Fixed broken comments in reviewer/theme/logs and reviewer/theme/history

### DIFF
--- a/src/olympia/reviewers/templates/reviewers/themes/history_table.html
+++ b/src/olympia/reviewers/templates/reviewers/themes/history_table.html
@@ -41,7 +41,7 @@
               {{ reject_reasons[details.reject_reason] }}
             {% endif %}
           </td>
-          <td>{{ details.comment }}</td>
+          <td class="comment">{{ details.comment }}</td>
         </tr>
       {% endfor %}
     </tbody>

--- a/src/olympia/reviewers/templates/reviewers/themes/logs.html
+++ b/src/olympia/reviewers/templates/reviewers/themes/logs.html
@@ -36,13 +36,12 @@
             </tr>
             <tr class="comments hide">
               <td>&nbsp;</td>
-              <td colspan="3">
+              <td colspan="4">
                 {{ item.details.comment }}
                 {% if item.details.reject_reason %}
                   {{ REJECT_REASONS[item.details.reject_reason] }}
                 {% endif %}
               </td>
-              <td>&nbsp;</td>
             </tr>
           {% endfor %}
         </tbody>

--- a/src/olympia/reviewers/templates/reviewers/themes/logs.html
+++ b/src/olympia/reviewers/templates/reviewers/themes/logs.html
@@ -36,12 +36,13 @@
             </tr>
             <tr class="comments hide">
               <td>&nbsp;</td>
-              <td colspan="4">
+              <td colspan="3">
                 {{ item.details.comment }}
                 {% if item.details.reject_reason %}
                   {{ REJECT_REASONS[item.details.reject_reason] }}
                 {% endif %}
               </td>
+              <td>&nbsp;</td>
             </tr>
           {% endfor %}
         </tbody>

--- a/static/css/zamboni/reviewers.styl
+++ b/static/css/zamboni/reviewers.styl
@@ -401,6 +401,8 @@ ul.tabnav a:hover {
 table.data-grid tr.comments td {
     border-top: none;
     background: #def;
+    overflow-wrap: break-word;
+    hyphens: auto;
 }
 
 .waiting_old, .waiting_med, .waiting_new {

--- a/static/css/zamboni/themes_review.styl
+++ b/static/css/zamboni/themes_review.styl
@@ -526,6 +526,10 @@ h2 a:last-child {
             padding-left: 13px;
         }
     }
+
+    .comment {
+        hyphens: auto;
+    }
 }
 
 .queue-search {


### PR DESCRIPTION
Fixes #6769 

Here is how it looks now
**reviewers/themes/history**
![image](https://user-images.githubusercontent.com/24241258/35302715-814592ac-00b5-11e8-8985-44ed7bfbb34e.png)

**reviewers/themes/logs**
![image](https://user-images.githubusercontent.com/24241258/35302787-c6e7ed82-00b5-11e8-802a-037aacbce199.png)

**Before**

![image](https://user-images.githubusercontent.com/24241258/35302816-da5e32d6-00b5-11e8-9dc4-8af81d6089b7.png)

