### PR TITLE
Change internal auth API token name to be able to clear it completely

### DIFF
--- a/docs/topics/api/auth_internal.rst
+++ b/docs/topics/api/auth_internal.rst
@@ -27,7 +27,7 @@ responses of the following endpoint:
 The token is available in two forms:
 
     * For the endpoint mentioned above, as a property called ``token``.
-    * For all endpoints, as a cookie called ``api_auth_token``. This cookie
+    * For all endpoints, as a cookie called ``frontend_auth_token``. This cookie
       expires after 30 days and is set as ``HttpOnly``.
 
 

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -644,7 +644,7 @@ class TestAuthenticateView(BaseAuthenticationView):
         self.fxa_identify.assert_called_with('codes!!', config=FXA_CONFIG)
         assert not self.login_user.called
         self.register_user.assert_called_with(mock.ANY, identity)
-        token = response.cookies['api_auth_token'].value
+        token = response.cookies['frontend_auth_token'].value
         verify = WebTokenAuthentication().authenticate_token(token)
         assert verify[0] == UserProfile.objects.get(username='foo')
 
@@ -697,7 +697,7 @@ class TestAuthenticateView(BaseAuthenticationView):
         response = self.client.get(
             self.url, {'code': 'code', 'state': self.fxa_state})
         self.assertRedirects(response, reverse('home'))
-        token = response.cookies['api_auth_token'].value
+        token = response.cookies['frontend_auth_token'].value
         verify = WebTokenAuthentication().authenticate_token(token)
         assert verify[0] == user
         self.login_user.assert_called_with(mock.ANY, user, identity)

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -68,7 +68,12 @@ LOGIN_ERROR_MESSAGES = {
     ERROR_STATE_MISMATCH: _(u'You could not be logged in. Please try again.'),
 }
 
-API_TOKEN_COOKIE = 'api_auth_token'
+# Name of the cookie that contains the auth token for the API. It used to be
+# "api_auth_token" but we had to change it because it wasn't set on the right
+# domain, and we couldn't clear both the old and new versions at the same time,
+# since sending multiple Set-Cookie headers with the same name is not allowed
+# by the spec, even if they have a distinct domain attribute.
+API_TOKEN_COOKIE = 'frontend_auth_token'
 
 
 def safe_redirect(url, action):
@@ -325,11 +330,6 @@ class AuthenticateView(FxAConfigMixin, APIView):
 
 def logout_user(request, response):
     logout(request)
-    # The API_TOKEN_COOKIE needs to be deleted twice, one with specifying
-    # the domain, and one without. This is because it used to be set without
-    # the domain, so we still have users around with that version of the
-    # cookie.
-    response.delete_cookie(API_TOKEN_COOKIE)
     response.delete_cookie(
         API_TOKEN_COOKIE, domain=settings.SESSION_COOKIE_DOMAIN)
 


### PR DESCRIPTION
Sending multiple `Set-Cookie` headers with the same name is not allowed by the spec, even if they have a distinct domain attribute, so we could not clear the cookie on logout reliably, depending on how the user logged in. Only solution is to change the name, so that it will be correct from now on.