### PR TITLE
Speed up LanguageTools API by cutting out current_version from response

### DIFF
--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -459,7 +459,6 @@ on AMO.
     :query string lang: Activate translations in the specific language for that query. (See :ref:`translated fields <api-overview-translations>`)
     :>json array results: An array of language tools.
     :>json int results[].id: The add-on id on AMO.
-    :>json object results[].current_version: Object holding the current :ref:`version <version-detail-object>` of the add-on. For performance reasons the ``release_notes`` field is omitted and the ``license`` field omits the ``text`` property.
     :>json string results[].default_locale: The add-on default locale for translations.
     :>json string|object|null results[].name: The add-on name (See :ref:`translated fields <api-overview-translations>`).
     :>json string results[].guid: The add-on `extension identifier <https://developer.mozilla.org/en-US/Add-ons/Install_Manifests#id>`_.

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -620,7 +620,7 @@ class LanguageToolsSerializer(AddonSerializer):
 
     class Meta:
         model = Addon
-        fields = ('id', 'current_version', 'default_locale', 'guid',
+        fields = ('id', 'default_locale', 'guid',
                   'locale_disambiguation', 'name', 'slug', 'target_locale',
                   'type', 'url', )
 

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -888,11 +888,6 @@ class TestLanguageToolsSerializerOutput(TestCase):
         assert result['type'] == 'language'
         assert result['url'] == absolutify(self.addon.get_url_path())
 
-        addon_testcase = AddonSerializerOutputTestMixin()
-        addon_testcase.addon = self.addon
-        addon_testcase._test_version(
-            self.addon.current_version, result['current_version'])
-
     def test_basic_dict(self):
         self.addon = addon_factory(type=amo.ADDON_DICT)
         result = self.serialize()


### PR DESCRIPTION
part of #6850 - though possibly not the whole "fix"