### PR TITLE
Fixes #7275 - Drop "#addons.mozilla.org_service_history" target from "Site Status" link in footer

### DIFF
--- a/src/olympia/devhub/templates/devhub/new-landing/components/footer.html
+++ b/src/olympia/devhub/templates/devhub/new-landing/components/footer.html
@@ -29,7 +29,7 @@
           <li><a href="https://developer.mozilla.org/en-US/Add-ons/AMO/Policy">{{ _('Policies') }}</a></li>
           <li><a href="https://addons.mozilla.org/faq">{{ _('FAQ') }}</a></li>
           <li><a href="https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Contact">{{ _('Report Bug') }}</a></li>
-          <li><a href="https://status.mozilla.org/#addons.mozilla.org_service_history">{{ _('Site Status') }}</a></li>
+          <li><a href="https://status.mozilla.org">{{ _('Site Status') }}</a></li>
         </ul>
       </section>
 

--- a/src/olympia/templates/copyright.html
+++ b/src/olympia/templates/copyright.html
@@ -14,7 +14,7 @@
         {% if not hide_mobile_link %}
           &nbsp;|&nbsp;<a class="mobile-link" href="#" title="{{ _('The new website supports mobile and desktop clients') }}">{{ _('View the new site') }}</a>
         {% endif %}
-        &nbsp;|&nbsp;<a href="https://status.mozilla.org/#addons.mozilla.org_service_history">{{ _('Site Status')}}</a>
+        &nbsp;|&nbsp;<a href="https://status.mozilla.org">{{ _('Site Status')}}</a>
         &nbsp;|&nbsp;<a href="https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Contact">{{ _('Report a bug')}}</a>
       {% endblock %}
     {% endblock %}


### PR DESCRIPTION
Fixes #7275 - removed two instances where the redirection URL needed to be updated to properly redirect without an unnecessary extra click.