### PR TITLE
Add white space around private whiteboard area

### DIFF
--- a/static/css/zamboni/reviewers.styl
+++ b/static/css/zamboni/reviewers.styl
@@ -1100,6 +1100,7 @@ gradient-two-color($color1, $color2) {
     border-radius: 7px;
     &.private {
       background-color: #FFE4E4;
+      margin: 1em 0 1em 0;
     }
     .whiteboard-inner {
         padding: 10px;


### PR DESCRIPTION
Fixes #7377 - added `1em` of padding to the top and bottom `margins` for `.whiteboard .private` CSS classes.

**Before:**

![buttonbefore](https://user-images.githubusercontent.com/13009507/35488422-adb3cec2-0456-11e8-81b5-82dacbc9bee2.png)

**After:**

![buttonafter](https://user-images.githubusercontent.com/13009507/35488421-a8dccff2-0456-11e8-918c-8fdc46fcf5d6.png)
