### PR TITLE
Fix review page URLs for /developers/addons

### DIFF
--- a/src/olympia/addons/templates/addons/macros.html
+++ b/src/olympia/addons/templates/addons/macros.html
@@ -11,7 +11,7 @@
         {% endif %}
       </span>
     {% elif type == 'rating' %}
-      {{ impala_reviews_link(addon, link_to_list=True) }}
+      {{ impala_reviews_link(addon) }}
     {% elif type in ('downloads', 'adu') %}
       {% if type == 'downloads' %}
         <span class="downloads adu">

--- a/src/olympia/legacy_discovery/templates/legacy_discovery/addons/detail.html
+++ b/src/olympia/legacy_discovery/templates/legacy_discovery/addons/detail.html
@@ -49,7 +49,7 @@
 <ul class="addon-info">
   <li>
     <h3>{{ _('Rating') }}</h3>
-    {{ reviews_link(addon, link_to_list=True) }}
+    {{ reviews_link(addon) }}
   </li>
   <li>
     <h3>{{ _('Active Users') }}</h3>

--- a/src/olympia/ratings/templates/ratings/impala/reviews_link.html
+++ b/src/olympia/ratings/templates/ratings/impala/reviews_link.html
@@ -1,10 +1,6 @@
-{% if link_to_list %}
-  {% set base = url('addons.ratings.list', addon.slug) %}
-{% else %}
-  {% set base = addon.get_url_path()|urlparams('reviews') %}
-  {% if collection_uuid %}
+{% set base = url('addons.ratings.list', addon.slug) %}
+{% if collection_uuid %}
     {% set base = base|urlparams(collection_uuid=collection_uuid) %}
-  {% endif %}
 {% endif %}
 
 <span class="rating">

--- a/src/olympia/ratings/templates/ratings/reviews_link.html
+++ b/src/olympia/ratings/templates/ratings/reviews_link.html
@@ -1,10 +1,6 @@
-{% if link_to_list %}
-  {% set base = url('addons.ratings.list', addon.slug) %}
-{% else %}
-  {% set base = addon.get_url_path()|urlparams('reviews') %}
-  {% if collection_uuid %}
+{% set base = url('addons.ratings.list', addon.slug) %}
+{% if collection_uuid %}
     {% set base = base|urlparams(collection_uuid=collection_uuid) %}
-  {% endif %}
 {% endif %}
 
 <p class="addon-rating">

--- a/src/olympia/ratings/templatetags/jinja_helpers.py
+++ b/src/olympia/ratings/templatetags/jinja_helpers.py
@@ -26,18 +26,16 @@ def stars(num, large=False):
 
 
 @library.global_function
-def reviews_link(addon, collection_uuid=None, link_to_list=False):
+def reviews_link(addon, collection_uuid=None):
     t = get_template('ratings/reviews_link.html')
     return jinja2.Markup(t.render({'addon': addon,
-                                   'link_to_list': link_to_list,
                                    'collection_uuid': collection_uuid}))
 
 
 @library.global_function
-def impala_reviews_link(addon, collection_uuid=None, link_to_list=False):
+def impala_reviews_link(addon, collection_uuid=None):
     t = get_template('ratings/impala/reviews_link.html')
     return jinja2.Markup(t.render({'addon': addon,
-                                   'link_to_list': link_to_list,
                                    'collection_uuid': collection_uuid}))
 
 

--- a/src/olympia/ratings/tests/test_helpers.py
+++ b/src/olympia/ratings/tests/test_helpers.py
@@ -40,14 +40,14 @@ class HelpersTest(TestCase):
         assert pq(s)('strong').text() == '37 reviews'
 
         # without collection uuid
-        assert pq(s)('a').attr('href') == '/en-US/firefox/addon/xx/#reviews'
+        assert pq(s)('a').attr('href') == '/en-US/firefox/addon/xx/reviews/'
 
         # with collection uuid
         myuuid = 'f19a8822-1ee3-4145-9440-0a3640201fe6'
         s = self.render('{{ reviews_link(myaddon, myuuid) }}',
                         {'myaddon': a, 'myuuid': myuuid})
         assert pq(s)('a').attr('href') == (
-            '/en-US/firefox/addon/xx/?collection_uuid=%s#reviews' % myuuid)
+            '/en-US/firefox/addon/xx/reviews/?collection_uuid=%s' % myuuid)
 
         z = Addon(average_rating=0, total_ratings=0, id=1, type=1, slug='xx')
         s = self.render('{{ reviews_link(myaddon) }}', {'myaddon': z})
@@ -55,7 +55,7 @@ class HelpersTest(TestCase):
 
         # with link
         u = reverse('addons.ratings.list', args=['xx'])
-        s = self.render('{{ reviews_link(myaddon, link_to_list=True) }}',
+        s = self.render('{{ reviews_link(myaddon) }}',
                         {'myaddon': a})
         assert pq(s)('a').attr('href') == u
 
@@ -65,14 +65,14 @@ class HelpersTest(TestCase):
         assert pq(s)('a').text() == '(37)'
 
         # without collection uuid
-        assert pq(s)('a').attr('href') == '/en-US/firefox/addon/xx/#reviews'
+        assert pq(s)('a').attr('href') == '/en-US/firefox/addon/xx/reviews/'
 
         # with collection uuid
         myuuid = 'f19a8822-1ee3-4145-9440-0a3640201fe6'
         s = self.render('{{ impala_reviews_link(myaddon, myuuid) }}',
                         {'myaddon': a, 'myuuid': myuuid})
         assert pq(s)('a').attr('href') == (
-            '/en-US/firefox/addon/xx/?collection_uuid=%s#reviews' % myuuid)
+            '/en-US/firefox/addon/xx/reviews/?collection_uuid=%s' % myuuid)
 
         z = Addon(average_rating=0, total_ratings=0, id=1, type=1, slug='xx')
         s = self.render('{{ impala_reviews_link(myaddon) }}', {'myaddon': z})
@@ -81,7 +81,7 @@ class HelpersTest(TestCase):
         # with link
         u = reverse('addons.ratings.list', args=['xx'])
         s = self.render(
-            '{{ impala_reviews_link(myaddon, link_to_list=True) }}',
+            '{{ impala_reviews_link(myaddon) }}',
             {'myaddon': a})
         assert pq(s)('a').attr('href') == u
 


### PR DESCRIPTION
Fixes #7111 - updated add-ons to use `/reviews` instead of the old anchor tag `#reviews`.

**WIP** as of Feb 4, 2018