### PR TITLE
Add locales that addons-frontend supports for parity

### DIFF
--- a/src/olympia/amo/tests/test_utils_.py
+++ b/src/olympia/amo/tests/test_utils_.py
@@ -183,7 +183,7 @@ def test_get_locale_from_lang(lang):
     locale = get_locale_from_lang(lang)
 
     debug_languages = ('dbg', 'dbr', 'dbl')
-    long_languages = ('hsb', 'dsb', 'kab')
+    long_languages = ('ast', 'cak', 'dsb', 'hsb', 'kab')
     expected_language = (
         lang[:3] if lang in long_languages else (
             lang[:2] if lang not in debug_languages else 'en'

--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -585,6 +585,14 @@ def get_locale_from_lang(lang):
     if not lang or lang in ('dbg', 'dbr', 'dbl'):
         lang = 'en'
 
+    if lang == 'cak':
+        # 'cak' is not in http://cldr.unicode.org/ and therefore not supported
+        # by Babel. That breaks get_locale_from_lang() entirely, so this hack
+        # creates a fake Locale class for this locale.
+        locale = Locale('en')
+        locale.language = 'cak'
+        return locale
+
     return Locale.parse(translation.to_locale(lang))
 
 

--- a/src/olympia/files/tests/test_utils_.py
+++ b/src/olympia/files/tests/test_utils_.py
@@ -641,10 +641,8 @@ def test_extract_translations_simple(file_obj):
     extension = 'src/olympia/files/fixtures/files/notify-link-clicks-i18n.xpi'
     with amo.tests.copy_file(extension, file_obj.file_path):
         messages = utils.extract_translations(file_obj)
-        # Make sure nb_NO is not in the list since we don't support
-        # it currently.
         assert list(sorted(messages.keys())) == [
-            'de', 'en-US', 'ja', 'nl', 'ru', 'sv-SE']
+            'de', 'en-US', 'ja', 'nb-NO', 'nl', 'ru', 'sv-SE']
 
 
 @mock.patch('olympia.files.utils.zipfile.ZipFile.read')

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -161,9 +161,12 @@ LANGUAGE_CODE = 'en-US'
 AMO_LANGUAGES = (
     'af',  # Afrikaans
     'ar',  # Arabic
+    'ast',  # Asturian
     'bg',  # Bulgarian
     'bn-BD',  # Bengali (Bangladesh)
+    'bs',  # Bosnian
     'ca',  # Catalan
+    'cak',  # Kaqchikel
     'cs',  # Czech
     'da',  # Danish
     'de',  # German
@@ -176,7 +179,9 @@ AMO_LANGUAGES = (
     'fa',  # Persian
     'fi',  # Finnish
     'fr',  # French
+    'fy-NL',  # Frisian
     'ga-IE',  # Irish
+    'gu',  # Gujarati
     'he',  # Hebrew
     'hsb',  # Upper Sorbian
     'hu',  # Hungarian
@@ -188,6 +193,8 @@ AMO_LANGUAGES = (
     'ko',  # Korean
     'mk',  # Macedonian
     'mn',  # Mongolian
+    'ms',  # Malay
+    'nb-NO',  # Norwegian (Bokmål)
     'nl',  # Dutch
     'nn-NO',  # Norwegian (Nynorsk)
     'pl',  # Polish
@@ -199,6 +206,8 @@ AMO_LANGUAGES = (
     'sl',  # Slovenian
     'sq',  # Albanian
     'sv-SE',  # Swedish
+    'te',  # Telugu
+    'th',  # Thai
     'tr',  # Turkish
     'uk',  # Ukrainian
     'ur',  # Urdu


### PR DESCRIPTION
This is a temporary measure while we wait for a better solution like a shared package between the two repos. This is needed because addons-server tries to redirect some URLs, adding missing locales,
and that code trips up on unknown locales.

Fix #7004 