### PR TITLE
Update email template for reviewer information requests

### DIFF
--- a/src/olympia/activity/templates/activity/emails/from_reviewer.txt
+++ b/src/olympia/activity/templates/activity/emails/from_reviewer.txt
@@ -1,14 +1,19 @@
 Hello,
 
-A reviewer sent a message regarding the review of version {{ number }} of add-on {{ name }}.
+{{ author }}, a reviewer at addons.mozilla.org, found an issue when reviewing version {{ version }} of the add-on {{ name }} and requests additional information. You are receiving this email because {{ email_reason }}.
 
+*********
 {{ author }} wrote:
 
 {{ comments }}
 
-If you want to respond please reply to this email or visit {{ url }}
+*******
 
-You are receiving this email because {{ email_reason }}.
---
+To respond, please reply to this email or visit {{ url }}. {% if is_info_request %}If we do not hear from you within seven (7) days of this notification, this listing may be removed from addons.mozilla.org.{% endif %}
+
+
+Thank you for your attention.
+
+-- 
 Mozilla Add-ons
 {{ SITE_URL }}

--- a/src/olympia/activity/templates/activity/emails/from_reviewer.txt
+++ b/src/olympia/activity/templates/activity/emails/from_reviewer.txt
@@ -7,7 +7,7 @@ Hello,
 
 {{ comments }}
 
-*******
+*********
 
 To respond, please reply to this email or visit {{ url }}. {% if is_info_request %}If we do not hear from you within seven (7) days of this notification, this listing may be removed from addons.mozilla.org.{% endif %}
 

--- a/src/olympia/activity/utils.py
+++ b/src/olympia/activity/utils.py
@@ -238,7 +238,8 @@ def log_and_notify(action, comments, note_creator, version, perm_setting=None,
         'comments': comments,
         'url': absolutify(version.addon.get_dev_url('versions')),
         'SITE_URL': settings.SITE_URL,
-        'email_reason': 'you are an author of this add-on'
+        'email_reason': 'you are listed as an author of this add-on',
+        'is_info_request': action == amo.LOG.REQUEST_INFORMATION,
     }
 
     reviewer_context_dict = author_context_dict.copy()
@@ -255,8 +256,12 @@ def log_and_notify(action, comments, note_creator, version, perm_setting=None,
 
     # Not being localised because we don't know the recipients locale.
     with translation.override('en-US'):
-        subject = u'Mozilla Add-ons: %s %s' % (
-            version.addon.name, version.version)
+        if action == amo.LOG.REQUEST_INFORMATION:
+            subject = u'Mozilla Add-ons: Action Required for %s %s' % (
+                version.addon.name, version.version)
+        else:
+            subject = u'Mozilla Add-ons: %s %s' % (
+                version.addon.name, version.version)
     template = template_from_user(note_creator, version)
     from_email = formataddr((note_creator.name, NOTIFICATIONS_FROM_EMAIL))
     send_activity_mail(

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -456,7 +456,9 @@ class TestReviewHelper(TestCase):
         assert self.version.has_info_request
 
         assert len(mail.outbox) == 1
-        assert mail.outbox[0].subject == self.preamble
+        assert (
+            mail.outbox[0].subject ==
+            'Mozilla Add-ons: Action Required for Delicious Bookmarks 2.1.072')
 
         assert self.check_log_count(amo.LOG.REQUEST_INFORMATION.id) == 1
 


### PR DESCRIPTION
Fix #7366

Per discussion in the issue, I didn't bother to make too many modifications in the template, so it will be slightly more alarming than before even for follow-up replies by reviewers and not just the initial info request.