### PR TITLE
Simplify the hack needed to support `cak` locale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ static/css/node_lib/*
 static/js/node_lib/*
 *.signed.zip
 *.po~
+*.mo
 site-static/*
 user-media/*
 guarded-addons/*

--- a/src/olympia/amo/tests/test_utils_.py
+++ b/src/olympia/amo/tests/test_utils_.py
@@ -182,11 +182,11 @@ def test_get_locale_from_lang(lang):
     """Make sure all languages in settings.AMO_LANGUAGES can be resolved."""
     locale = get_locale_from_lang(lang)
 
-    debug_languages = ('dbg', 'dbr', 'dbl')
-    long_languages = ('ast', 'cak', 'dsb', 'hsb', 'kab')
+    debug_or_ignored_languages = ('cak', 'dbg', 'dbr', 'dbl')
+    long_languages = ('ast', 'dsb', 'hsb', 'kab')
     expected_language = (
         lang[:3] if lang in long_languages else (
-            lang[:2] if lang not in debug_languages else 'en'
+            lang[:2] if lang not in debug_or_ignored_languages else 'en'
         ))
 
     assert isinstance(locale, Locale)

--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -581,18 +581,13 @@ def to_language(locale):
 def get_locale_from_lang(lang):
     """Pass in a language (u'en-US') get back a Locale object courtesy of
     Babel.  Use this to figure out currencies, bidi, names, etc."""
-    # Special fake language can just act like English for formatting and such
-    if not lang or lang in ('dbg', 'dbr', 'dbl'):
+    # Special fake language can just act like English for formatting and such.
+    # Do the same for 'cak' because it's not in http://cldr.unicode.org/ and
+    # therefore not supported by Babel - trying to fake the class leads to a
+    # rabbit hole of more errors because we need valid locale data on disk, to
+    # get decimal formatting, plural rules etc.
+    if not lang or lang in ('cak', 'dbg', 'dbr', 'dbl'):
         lang = 'en'
-
-    if lang == 'cak':
-        # 'cak' is not in http://cldr.unicode.org/ and therefore not supported
-        # by Babel. That breaks get_locale_from_lang() entirely, so this hack
-        # creates a fake Locale class for this locale.
-        locale = Locale('en')
-        locale.language = 'cak'
-        return locale
-
     return Locale.parse(translation.to_locale(lang))
 
 


### PR DESCRIPTION
Trying to fake our way in doesn't work because when formatting later we'll need the locale data, which Babel will fail to load. We could load data preventively... but then we might as well just return the english Locale directly.

Fix #7004 again