### PR TITLE
Hide "New Version" for disabled add-ons in devhub action links

### DIFF
--- a/src/olympia/devhub/templates/devhub/addons/listing/item_actions.html
+++ b/src/olympia/devhub/templates/devhub/addons/listing/item_actions.html
@@ -30,12 +30,14 @@
          title="{{ _("Edit information about this add-on.") }}">
         {{ _('Edit Information') }}</a>
     </li>
-    <li>
-      {% set version_upload_url = url('devhub.submit.version', addon.slug) %}
-      <a href="{{ version_upload_url }}" class="tooltip"
-         title="{{ _('Upload a new version of this add-on.') }}">
-        {{ _('New Version') }}</a>
-    </li>
+    {% if not addon.is_disabled %}
+      <li>
+        {% set version_upload_url = url('devhub.submit.version', addon.slug) %}
+        <a href="{{ version_upload_url }}" class="tooltip"
+           title="{{ _('Upload a new version of this add-on.') }}">
+          {{ _('New Version') }}</a>
+      </li>
+    {% endif %}
     {% if addon.current_version and not addon.current_version.is_compatible_by_default %}
       <li class="compat"
           data-src="{{ url('devhub.ajax.compat.status', addon.slug) }}">

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -136,16 +136,24 @@ class TestDashboard(HubTest):
         doc = pq(response.content)
         assert len(doc('.item .item-info')) == 4
 
-    def test_show_hide_statistics(self):
-        # Not disabled by user: show statistics.
+    def test_show_hide_statistics_and_new_version_for_disabled(self):
+        # Not disabled: show statistics and new version links.
         self.addon.update(disabled_by_user=False)
         links = self.get_action_links(self.addon.pk)
         assert 'Statistics' in links, ('Unexpected: %r' % links)
+        assert 'New Version' in links, ('Unexpected: %r' % links)
 
-        # Disabled: hide statistics.
+        # Disabled (user): hide statistics and new version links.
         self.addon.update(disabled_by_user=True)
         links = self.get_action_links(self.addon.pk)
         assert 'Statistics' not in links, ('Unexpected: %r' % links)
+        assert 'New Version' not in links, ('Unexpected: %r' % links)
+
+        # Disabled (admin): hide statistics and new version links.
+        self.addon.update(disabled_by_user=False, status=amo.STATUS_DISABLED)
+        links = self.get_action_links(self.addon.pk)
+        assert 'Statistics' not in links, ('Unexpected: %r' % links)
+        assert 'New Version' not in links, ('Unexpected: %r' % links)
 
     def test_public_addon(self):
         assert self.addon.status == amo.STATUS_PUBLIC


### PR DESCRIPTION
Fix #7383