### PR TITLE
linter stdout to system tmp instead of settings.TMP_PATH - fixes Wind…

### DIFF
--- a/src/olympia/devhub/tasks.py
+++ b/src/olympia/devhub/tasks.py
@@ -564,8 +564,8 @@ def run_addons_linter(path, listed=True):
             .format(path))
 
     stdout, stderr = (
-        tempfile.TemporaryFile(dir=settings.TMP_PATH),
-        tempfile.TemporaryFile(dir=settings.TMP_PATH))
+        tempfile.TemporaryFile(),
+        tempfile.TemporaryFile())
 
     with statsd.timer('devhub.linter'):
         process = subprocess.Popen(


### PR DESCRIPTION
For some undiagnosable reason, passing a path within code as stdout (i.e. `/code/tmp/`) to the linter fails on Windows.  This patch changes it back to using the default path, which resolves to `/tmp/`