### PR TITLE
supervisor: Fix restart all causes Docker exit 137

### DIFF
--- a/docker/supervisor.conf
+++ b/docker/supervisor.conf
@@ -4,7 +4,7 @@ logfile=/code/logs/supervisord.log
 [program:olympia]
 command=python /code/manage.py runserver 0.0.0.0:8000
 directory=/code
-stopasgroup=true
+stopasgroup=false
 autostart=true
 redirect_stderr=true
 stdout_logfile=logs/docker.log


### PR DESCRIPTION
When run within docker this now can lead to the process exiting from Docker,
even when only attempting to restart a process *within* supervisor

```
% docker-compose exec web supervisorctl restart all
olympia: stopped
olympia: started
```
```
web_1               | 2018-02-08 21:23:57,019 INFO waiting for olympia to stop
web_1               | 2018-02-08 21:23:57,029 INFO stopped: olympia (terminated by SIGKILL)
web_1               | 2018-02-08 21:23:58,045 INFO spawned: 'olympia' with pid 38
web_1               | 2018-02-08 21:23:59,048 INFO success: olympia entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
```

Needs more testing as olympia can still exit locally after a restart, but it does fix the issue with exit 137

Ref #7518 
