### PR TITLE
Fixes #7301: Add outline: none; to .site-title.prominent <a> tag

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -317,6 +317,7 @@ body:not(.home) .amo-header,
 
   a {
     color: @link-on-color-bg;
+    outline: none;
 
     &:before {
       background-image: none;


### PR DESCRIPTION
Fixes #7301: Added `outline: none;` to `.site-title.prominent a` class in `restyle.less`.

Confirmation of the problem:

![layoutissues](https://user-images.githubusercontent.com/13009507/36010324-d3805c4e-0d1e-11e8-9d90-b8a780182690.gif)

After applying my fix:

![layoutissuesfixcompressed](https://user-images.githubusercontent.com/13009507/36010577-2bc08ffe-0d20-11e8-9b5d-ab5fdde31d8d.gif)
