### PR TITLE
add `with_addons` param to Collection detail/view API

### DIFF
--- a/docs/topics/api/collections.rst
+++ b/docs/topics/api/collections.rst
@@ -27,11 +27,6 @@ The results are sorted by the most recently updated collection first.
     :>json array results: An array of :ref:`collections <collection-detail-object>`.
 
 
-If the ``with_addon`` parameter is passed then :ref:`addons in the collection<collection-addon-detail>` are returned along with the detail.
-Add-ons returned are limited to the first 25 in the collection, in the default sort (popularity, descending).
-Additional add-ons can be returned from the :ref:`Collection Add-on list endpoint<collection-addon-list>`.
-
-
 ------
 Detail
 ------
@@ -42,7 +37,6 @@ This endpoint allows you to fetch a single collection by its ``slug``.
 It returns any ``public`` collection by the specified user. You can access
 a non-``public`` collection only if it was authored by you, the authenticated user.
 If your account has the `Collections:Edit` permission then you can access any collection.
-
 
 
 .. http:get:: /api/v3/accounts/account/(int:user_id|string:username)/collections/(string:collection_slug)/
@@ -65,9 +59,22 @@ If your account has the `Collections:Edit` permission then you can access any co
     :>json string uuid: A unique identifier for this collection; primarily used to count addon installations that come via this collection.
 
 
-If the ``with_addon`` parameter is passed then :ref:`addons in the collection<collection-addon-detail>` are returned along with the detail.
+If the ``with_addons`` parameter is passed then :ref:`addons in the collection<collection-addon-detail>` are returned along with the detail.
 Add-ons returned are limited to the first 25 in the collection, in the default sort (popularity, descending).
+Filtering is as per :ref:`collection addon list endpoint<collection-addon-filtering-param>` - i.e. defaults to only including public add-ons.
 Additional add-ons can be returned from the :ref:`Collection Add-on list endpoint<collection-addon-list>`.
+
+
+.. http:get:: /api/v3/accounts/account/(int:user_id|string:username)/collections/(string:collection_slug)/?with_addons
+
+    .. _collection-detail-object-with-addons:
+
+    :query string filter: The :ref:`filter <collection-addon-filtering-param>` to apply.
+    :>json int id: The id for the collection.
+    :>json int addon_count: The number of add-ons in this collection.
+    :>json array addons: An array of :ref:`addons with notes<collection-addon-detail>`.
+
+... rest as :ref:`collection detail response<collection-detail-object>`
 
 
 ------

--- a/docs/topics/api/collections.rst
+++ b/docs/topics/api/collections.rst
@@ -27,6 +27,11 @@ The results are sorted by the most recently updated collection first.
     :>json array results: An array of :ref:`collections <collection-detail-object>`.
 
 
+If the ``with_addon`` parameter is passed then :ref:`addons in the collection<collection-addon-detail>` are returned along with the detail.
+Add-ons returned are limited to the first 25 in the collection, in the default sort (popularity, descending).
+Additional add-ons can be returned from the :ref:`Collection Add-on list endpoint<collection-addon-list>`.
+
+
 ------
 Detail
 ------
@@ -37,6 +42,8 @@ This endpoint allows you to fetch a single collection by its ``slug``.
 It returns any ``public`` collection by the specified user. You can access
 a non-``public`` collection only if it was authored by you, the authenticated user.
 If your account has the `Collections:Edit` permission then you can access any collection.
+
+
 
 .. http:get:: /api/v3/accounts/account/(int:user_id|string:username)/collections/(string:collection_slug)/
 
@@ -56,6 +63,11 @@ If your account has the `Collections:Edit` permission then you can access any co
     :>json string slug: The name used in the URL.
     :>json string url: The (absolute) collection detail URL.
     :>json string uuid: A unique identifier for this collection; primarily used to count addon installations that come via this collection.
+
+
+If the ``with_addon`` parameter is passed then :ref:`addons in the collection<collection-addon-detail>` are returned along with the detail.
+Add-ons returned are limited to the first 25 in the collection, in the default sort (popularity, descending).
+Additional add-ons can be returned from the :ref:`Collection Add-on list endpoint<collection-addon-list>`.
 
 
 ------

--- a/src/olympia/bandwagon/serializers.py
+++ b/src/olympia/bandwagon/serializers.py
@@ -121,6 +121,4 @@ class CollectionWithAddonsSerializer(CollectionSerializer):
 
     def get_addons(self, obj):
         addons_qs = self.context['view'].get_addons_queryset()
-        return [
-            CollectionAddonSerializer(addon).data for addon in addons_qs
-        ]
+        return CollectionAddonSerializer(addons_qs, many=True).data

--- a/src/olympia/bandwagon/serializers.py
+++ b/src/olympia/bandwagon/serializers.py
@@ -1,7 +1,5 @@
 from django.utils.translation import ugettext, ugettext_lazy as _
 
-from django.conf import settings
-
 from rest_framework import serializers
 from rest_framework.validators import UniqueTogetherValidator
 
@@ -122,12 +120,7 @@ class CollectionWithAddonsSerializer(CollectionSerializer):
             set(fields) - set(CollectionSerializer.Meta.writeable_fields))
 
     def get_addons(self, obj):
-        limit = settings.REST_FRAMEWORK['PAGE_SIZE']
-        sort = '-addon__weekly_downloads'
-        iterable = CollectionAddon.objects.filter(
-            collection=obj).all().order_by(sort)[:limit]
-
+        addons_qs = self.context['view'].get_addons_queryset()
         return [
-            CollectionAddonSerializer(item).data
-            for item in iterable
+            CollectionAddonSerializer(addon).data for addon in addons_qs
         ]

--- a/src/olympia/bandwagon/tests/test_views.py
+++ b/src/olympia/bandwagon/tests/test_views.py
@@ -1339,6 +1339,20 @@ class TestCollectionViewSetList(TestCase):
         assert response.data['results'][1]['uuid'] == col_a.uuid
         assert response.data['results'][2]['uuid'] == col_c.uuid
 
+    def test_with_addons(self):
+        collection_factory(author=self.user)
+        coll_with_addons = collection_factory(author=self.user)
+        addon = addon_factory()
+        coll_with_addons.add_addon(addon)
+        coll_with_addons.update(modified=self.days_ago(3))
+
+        self.client.login_api(self.user)
+        response = self.client.get(self.url + '?with_addons')
+        assert response.status_code == 200, response.data
+        assert response.data['results'][0]['addons'] == []
+        assert response.data['results'][1]['addons'][0]['addon']['id'] == (
+            addon.id)
+
 
 class TestCollectionViewSetDetail(TestCase):
     client_class = APITestClient
@@ -1416,6 +1430,14 @@ class TestCollectionViewSetDetail(TestCase):
             'collection-detail', kwargs={
                 'user_pk': self.user.pk, 'slug': 'hello'}))
         assert response.status_code == 404
+
+    def test_with_addons(self):
+        addon = addon_factory()
+        self.collection.add_addon(addon)
+        response = self.client.get(self.url + '?with_addons')
+        assert response.status_code == 200
+        assert response.data['id'] == self.collection.id
+        assert response.data['addons'][0]['addon']['id'] == addon.id
 
 
 class CollectionViewSetDataMixin(object):

--- a/src/olympia/bandwagon/views.py
+++ b/src/olympia/bandwagon/views.py
@@ -42,7 +42,9 @@ from .models import (
     SPECIAL_SLUGS, Collection, CollectionAddon, CollectionVote,
     CollectionWatcher)
 from .permissions import AllowCollectionAuthor, AllowCollectionContributor
-from .serializers import CollectionAddonSerializer, CollectionSerializer
+from .serializers import (
+    CollectionAddonSerializer, CollectionSerializer,
+    CollectionWithAddonsSerializer)
 
 
 log = olympia.core.logger.getLogger('z.collections')
@@ -664,7 +666,6 @@ class CollectionViewSet(ModelViewSet):
             AllOf(AllowReadOnlyIfPublic,
                   PreventActionPermission('list'))),
     ]
-    serializer_class = CollectionSerializer
     lookup_field = 'slug'
 
     def get_account_viewset(self):
@@ -674,6 +675,11 @@ class CollectionViewSet(ModelViewSet):
                 permission_classes=[],  # We handled permissions already.
                 kwargs={'pk': self.kwargs['user_pk']})
         return self.account_viewset
+
+    def get_serializer_class(self):
+        with_addons = 'with_addons' in self.request.GET
+        return (CollectionSerializer if not with_addons
+                else CollectionWithAddonsSerializer)
 
     def get_queryset(self):
         return Collection.objects.filter(


### PR DESCRIPTION
fixes #6548 - could be more complete and have full pagination and sorting options for the addons, but this seems sufficient... ?