### PR TITLE
Fixes #6899 - Remove name_sort field

### DIFF
--- a/src/olympia/addons/indexers.py
+++ b/src/olympia/addons/indexers.py
@@ -152,6 +152,17 @@ class AddonIndexer(BaseSearchIndexer):
                             'raw': {'type': 'keyword'}
                         },
                     },
+                    'persona': {
+                        'type': 'object',
+                        'properties': {
+                            'accentcolor': {'type': 'keyword', 'index': False},
+                            'author': {'type': 'keyword', 'index': False},
+                            'header': {'type': 'keyword', 'index': False},
+                            'footer': {'type': 'keyword', 'index': False},
+                            'is_new': {'type': 'boolean', 'index': False},
+                            'textcolor': {'type': 'keyword', 'index': False},
+                        }
+                    },
                     'platforms': {'type': 'byte'},
                     'previews': {
                         'type': 'object',

--- a/src/olympia/addons/indexers.py
+++ b/src/olympia/addons/indexers.py
@@ -379,8 +379,4 @@ class AddonIndexer(BaseSearchIndexer):
             data['previews'][i].update(
                 cls.extract_field_raw_translations(preview, 'caption'))
 
-        # Finally, add the special sort field, coercing the current translation
-        # into an unicode object first.
-        data['name_sort'] = unicode(obj.name).lower()
-
         return data

--- a/src/olympia/addons/indexers.py
+++ b/src/olympia/addons/indexers.py
@@ -24,7 +24,6 @@ class AddonIndexer(BaseSearchIndexer):
     or sorting."""
     hidden_fields = (
         '*.raw',
-        '*_sort',
         'boost',
         'hotness',
         # Translated content that is used for filtering purposes is stored

--- a/src/olympia/addons/indexers.py
+++ b/src/olympia/addons/indexers.py
@@ -152,19 +152,6 @@ class AddonIndexer(BaseSearchIndexer):
                             'raw': {'type': 'keyword'}
                         },
                     },
-                    # TODO: Can be removed once we have `name.raw` indexed
-                    'name_sort': {'type': 'keyword'},
-                    'persona': {
-                        'type': 'object',
-                        'properties': {
-                            'accentcolor': {'type': 'keyword', 'index': False},
-                            'author': {'type': 'keyword', 'index': False},
-                            'header': {'type': 'keyword', 'index': False},
-                            'footer': {'type': 'keyword', 'index': False},
-                            'is_new': {'type': 'boolean', 'index': False},
-                            'textcolor': {'type': 'keyword', 'index': False},
-                        }
-                    },
                     'platforms': {'type': 'byte'},
                     'previews': {
                         'type': 'object',

--- a/src/olympia/addons/tests/test_indexers.py
+++ b/src/olympia/addons/tests/test_indexers.py
@@ -55,7 +55,7 @@ class TestAddonIndexer(TestCase):
             'current_version', 'description', 'featured_for',
             'has_eula', 'has_privacy_policy',
             'has_theme_rereview', 'is_featured', 'latest_unlisted_version',
-            'listed_authors', 'name', 'name_sort', 'platforms', 'previews',
+            'listed_authors', 'name', 'name.raw', 'platforms', 'previews',
             'public_stats', 'ratings', 'summary', 'tags',
         ]
 

--- a/src/olympia/addons/tests/test_indexers.py
+++ b/src/olympia/addons/tests/test_indexers.py
@@ -55,7 +55,7 @@ class TestAddonIndexer(TestCase):
             'current_version', 'description', 'featured_for',
             'has_eula', 'has_privacy_policy',
             'has_theme_rereview', 'is_featured', 'latest_unlisted_version',
-            'listed_authors', 'name', 'name.raw', 'platforms', 'previews',
+            'listed_authors', 'name', 'platforms', 'previews',
             'public_stats', 'ratings', 'summary', 'tags',
         ]
 

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -2239,7 +2239,7 @@ class TestAddonSearchView(ESTestCase):
         qset = view.get_queryset()
 
         assert set(qset.to_dict()['_source']['excludes']) == set(
-            ('*.raw', '*_sort', 'boost', 'hotness', 'name', 'description',
+            ('*.raw', 'boost', 'hotness', 'name', 'description',
              'name_l10n_*', 'description_l10n_*', 'summary', 'summary_l10n_*')
         )
 
@@ -2251,7 +2251,7 @@ class TestAddonSearchView(ESTestCase):
         # for some reason I don't yet understand... (cgrebs 0717)
         # maybe because they're used for boosting or filtering or so?
         assert not any(key in source_keys for key in (
-            'name_sort', 'boost',
+            'boost',
         ))
 
         assert not any(

--- a/src/olympia/search/filters.py
+++ b/src/olympia/search/filters.py
@@ -481,7 +481,7 @@ class SortingFilter(BaseFilterBackend):
         'created': '-created',
         'downloads': '-weekly_downloads',
         'hotness': '-hotness',
-        'name': 'name_sort',
+        'name': 'name.raw',
         'random': '_score',
         'rating': '-bayesian_rating',
         'relevance': '_score',

--- a/src/olympia/search/views.py
+++ b/src/olympia/search/views.py
@@ -45,7 +45,7 @@ def _personas(request):
         'users': '-average_daily_users',
         'rating': '-bayesian_rating',
         'created': '-created',
-        'name': 'name_sort',
+        'name': 'name.raw',
         'updated': '-last_updated',
         'hotness': '-hotness'}
     results = _filter_search(request, qs, form.cleaned_data, filters,
@@ -416,7 +416,7 @@ def search(request, tag_name=None):
     mapping = {'users': '-average_daily_users',
                'rating': '-bayesian_rating',
                'created': '-created',
-               'name': 'name_sort',
+               'name': 'name.raw',
                'downloads': '-weekly_downloads',
                'updated': '-last_updated',
                'hotness': '-hotness'}


### PR DESCRIPTION
Fixes #6899:

- [x] Changed the default field that is being used in `SortingFilter` to `name.raw`
- [x] Removed `name_sort` from `addons.indexers`