### PR TITLE
API: Add new 'icons' property to add-on detail.

### DIFF
--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -166,6 +166,7 @@ This endpoint allows you to fetch a specific add-on by id, slug or guid.
     :>json boolean has_privacy_policy: The add-on has a Privacy Policy (See :ref:`add-on EULA and privacy policy <addon-eula-policy>`).
     :>json string|object|null homepage: The add-on homepage (See :ref:`translated fields <api-overview-translations>`).
     :>json string icon_url: The URL to icon for the add-on (including a cachebusting query string).
+    :>json object icons: An object holding the URLs to an add-ons icon including a cachebusting query string. Currently exposes 32 and 64 pixels wide icons.
     :>json boolean is_disabled: Whether the add-on is disabled or not.
     :>json boolean is_experimental: Whether the add-on has been marked by the developer as experimental or not.
     :>json boolean is_featured: The add-on appears in a featured collection.

--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -166,7 +166,7 @@ This endpoint allows you to fetch a specific add-on by id, slug or guid.
     :>json boolean has_privacy_policy: The add-on has a Privacy Policy (See :ref:`add-on EULA and privacy policy <addon-eula-policy>`).
     :>json string|object|null homepage: The add-on homepage (See :ref:`translated fields <api-overview-translations>`).
     :>json string icon_url: The URL to icon for the add-on (including a cachebusting query string).
-    :>json object icons: An object holding the URLs to an add-ons icon including a cachebusting query string. Currently exposes 32 and 64 pixels wide icons.
+    :>json object icons: An object holding the URLs to an add-ons icon including a cachebusting query string as values and their size as properties. Currently exposes 32 and 64 pixels wide icons.
     :>json boolean is_disabled: Whether the add-on is disabled or not.
     :>json boolean is_experimental: Whether the add-on has been marked by the developer as experimental or not.
     :>json boolean is_featured: The add-on appears in a featured collection.

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -242,6 +242,7 @@ class AddonSerializer(serializers.ModelSerializer):
     has_privacy_policy = serializers.SerializerMethodField()
     homepage = TranslationSerializerField()
     icon_url = serializers.SerializerMethodField()
+    icons = serializers.SerializerMethodField()
     is_source_public = serializers.BooleanField(source='view_source')
     is_featured = serializers.SerializerMethodField()
     name = TranslationSerializerField()
@@ -276,6 +277,7 @@ class AddonSerializer(serializers.ModelSerializer):
             'has_privacy_policy',
             'homepage',
             'icon_url',
+            'icons',
             'is_disabled',
             'is_experimental',
             'is_featured',
@@ -370,6 +372,16 @@ class AddonSerializer(serializers.ModelSerializer):
         if self.is_broken_persona(obj):
             return absolutify(obj.get_default_icon_url(64))
         return absolutify(obj.get_icon_url(64))
+
+    def get_icons(self, obj):
+        # We're using only 32 and 64 for compatibility reasons with the
+        # old search API. https://github.com/mozilla/addons-server/issues/7514
+        if self.is_broken_persona(obj):
+            get_icon = obj.get_default_icon_url
+        else:
+            get_icon = obj.get_icon_url
+
+        return {str(size): absolutify(get_icon(size)) for size in (32, 64)}
 
     def get_ratings(self, obj):
         return {

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -227,6 +227,10 @@ class AddonSerializerOutputTestMixin(object):
             'en-US': get_outgoing_url(unicode(self.addon.homepage))
         }
         assert result['icon_url'] == absolutify(self.addon.get_icon_url(64))
+        assert result['icons'] == {
+            '32': absolutify(self.addon.get_icon_url(32)),
+            '64': absolutify(self.addon.get_icon_url(64))
+        }
         assert result['is_disabled'] == self.addon.is_disabled
         assert result['is_experimental'] == self.addon.is_experimental is False
         assert result['is_featured'] == self.addon.is_featured() is False
@@ -368,6 +372,10 @@ class AddonSerializerOutputTestMixin(object):
 
         assert result['id'] == self.addon.pk
         assert result['icon_url'] == absolutify(self.addon.get_icon_url(64))
+        assert result['icons'] == {
+            '32': absolutify(self.addon.get_icon_url(32)),
+            '64': absolutify(self.addon.get_icon_url(64))
+        }
 
     def test_no_current_version(self):
         self.addon = addon_factory(name='lol')
@@ -516,6 +524,10 @@ class AddonSerializerOutputTestMixin(object):
         # icon url should just be a default icon instead of the Persona icon.
         assert result['icon_url'] == (
             'http://testserver/static/img/addon-icons/default-64.png')
+        assert result['icons'] == {
+            '32': 'http://testserver/static/img/addon-icons/default-32.png',
+            '64': 'http://testserver/static/img/addon-icons/default-64.png'
+        }
 
     def test_webextension(self):
         self.addon = addon_factory(file_kw={'is_webextension': True})


### PR DESCRIPTION
This exposes add-on icons in sizes 32 and 64 pixels, for compatibility
with the legacy search api.

Fixes #7514