### PR TITLE
Only wrap outgoing links in the API if `wrap_outgoing_links` param is present

### DIFF
--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -143,7 +143,8 @@ This endpoint allows you to fetch a specific add-on by id, slug or guid.
 
     .. _addon-detail-object:
 
-    :query string lang: Activate translations in the specific language for that query. (See :ref:`translated fields <api-overview-translations>`)
+    :query string lang: Activate translations in the specific language for that query. (See :ref:`Translated Fields <api-overview-translations>`)
+    :query string wrap_outgoing_links: If this parameter is present, wrap outgoing links through ``outgoing.prod.mozaws.net`` (See :ref:`Outgoing Links <api-overview-outgoing>`)
     :>json int id: The add-on id on AMO.
     :>json array authors: Array holding information about the authors for the add-on.
     :>json int authors[].id: The id for an author.

--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -108,7 +108,7 @@ The following properties will be available in paginated responses:
 .. _api-overview-translations:
 
 ~~~~~~~~~~~~~~~~~
-Translated fields
+Translated Fields
 ~~~~~~~~~~~~~~~~~
 
 Fields that can be translated by users (typically name, description) have a
@@ -125,8 +125,8 @@ as keys and translations as values:
         }
     }
 
-However, for performance, if you pass the `lang` parameter to a `GET` request,
-then only the most relevant translation (the specified language or the
+However, for performance, if you pass the ``lang`` parameter to a ``GET``
+request, then only the most relevant translation (the specified language or the
 fallback, depending on whether a translation is available in the requested
 language) will be returned as a string.
 
@@ -136,10 +136,22 @@ language) will be returned as a string.
         "name": "Games"
     }
 
-This behaviour also applies to `POST`, `PATCH` and `PUT` requests: you can
-either submit an object containing several translations, or just a string. If
-only a string is supplied, it will only be used to translate the field in the
-current language.
+This behaviour also applies to ``POST``, ``PATCH`` and ``PUT`` requests: you
+can either submit an object containing several translations, or just a string.
+If only a string is supplied, it will only be used to translate the field in
+the current language.
+
+.. _api-overview-outgoing:
+
+~~~~~~~~~~~~~~
+Outgoing Links
+~~~~~~~~~~~~~~
+
+If the ``wrap_outgoing_links`` query parameter is present, any external links
+returned for properties such as ``support_url`` or ``homepage`` will be wrapped
+through ``outgoing.prod.mozaws.net``. Fields supporting some HTML, such as
+add-on ``description``, always do this regardless of whether or not the query
+parameter is present.
 
 ~~~~~~~~~~~~
 Cross Origin

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -306,10 +306,14 @@ class AddonSerializer(serializers.ModelSerializer):
         data = super(AddonSerializer, self).to_representation(obj)
         if 'theme_data' in data and data['theme_data'] is None:
             data.pop('theme_data')
-        if 'homepage' in data:
-            data['homepage'] = self.outgoingify(data['homepage'])
-        if 'support_url' in data:
-            data['support_url'] = self.outgoingify(data['support_url'])
+        if 'wrap_outgoing_links' in self.context['request'].GET:
+            if 'homepage' in data:
+                data['homepage'] = self.outgoingify(data['homepage'])
+            if 'support_url' in data:
+                data['support_url'] = self.outgoingify(data['support_url'])
+            if 'contributions_url' in data:
+                data['contributions_url'] = self.outgoingify(
+                    data['contributions_url'])
         if obj.type == amo.ADDON_PERSONA:
             if 'weekly_downloads' in data:
                 # weekly_downloads don't make sense for lightweight themes.

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -306,14 +306,10 @@ class AddonSerializer(serializers.ModelSerializer):
         data = super(AddonSerializer, self).to_representation(obj)
         if 'theme_data' in data and data['theme_data'] is None:
             data.pop('theme_data')
-        if 'wrap_outgoing_links' in self.context['request'].GET:
-            if 'homepage' in data:
-                data['homepage'] = self.outgoingify(data['homepage'])
-            if 'support_url' in data:
-                data['support_url'] = self.outgoingify(data['support_url'])
-            if 'contributions_url' in data:
-                data['contributions_url'] = self.outgoingify(
-                    data['contributions_url'])
+        if ('request' in self.context and
+                'wrap_outgoing_links' in self.context['request'].GET):
+            for key in ('homepage', 'support_url', 'contributions_url'):
+                data[key] = self.outgoingify(data[key])
         if obj.type == amo.ADDON_PERSONA:
             if 'weekly_downloads' in data:
                 # weekly_downloads don't make sense for lightweight themes.

--- a/src/olympia/bandwagon/serializers.py
+++ b/src/olympia/bandwagon/serializers.py
@@ -121,4 +121,5 @@ class CollectionWithAddonsSerializer(CollectionSerializer):
 
     def get_addons(self, obj):
         addons_qs = self.context['view'].get_addons_queryset()
-        return CollectionAddonSerializer(addons_qs, many=True).data
+        return CollectionAddonSerializer(
+            addons_qs, context=self.context, many=True).data


### PR DESCRIPTION
Ready for review, but do not merge: this should not land until the frontend sends the parameter.

Fix #7513