### PR TITLE
Fixes #3098. 

### DIFF
--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -335,11 +335,11 @@ function addonFormSubmit() {
             parent_div.find(".item").removeClass("loaded").addClass("loading");
             var $document = $(document),
                 scrollBottom = $document.height() - $document.scrollTop(),
-                $form = $(this),
-                hasErrors = $form.find('.errorlist').length;
+                $form = $(this);
 
             $.post($form.attr('action'), $form.serialize(), function(d) {
                 parent_div.html(d).each(addonFormSubmit);
+                hasErrors = parent_div.find('.errorlist').length;
                 $('.tooltip').tooltip('#tooltip');
                 if (!hasErrors && old_baseurl && old_baseurl !== baseurl()) {
                     document.location = baseurl();

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -338,8 +338,10 @@ function addonFormSubmit() {
                 $form = $(this);
 
             $.post($form.attr('action'), $form.serialize(), function(d) {
+                // The HTML has changed after we posted the form, thus the need to retrieve the new HTML
                 parent_div.html(d).each(addonFormSubmit);
-                hasErrors = parent_div.find('.errorlist').length;
+                $form = parent_div.find('form');
+                var hasErrors = $form.find('.errorlist').length;
                 $('.tooltip').tooltip('#tooltip');
                 if (!hasErrors && old_baseurl && old_baseurl !== baseurl()) {
                     document.location = baseurl();

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -338,8 +338,8 @@ function addonFormSubmit() {
                 $form = $(this);
 
             $.post($form.attr('action'), $form.serialize(), function(d) {
-                // The HTML has changed after we posted the form, thus the need to retrieve the new HTML
                 parent_div.html(d).each(addonFormSubmit);
+                // The HTML has changed after we posted the form, thus the need to retrieve the new HTML
                 $form = parent_div.find('form');
                 var hasErrors = $form.find('.errorlist').length;
                 $('.tooltip').tooltip('#tooltip');


### PR DESCRIPTION
Attempt to address the issue with saved message being displayed when edit errors occur. Fix #3098

The change regards the object on which we search for HTML elements with the class **errorList**, in order to be retrieve all possible errors that happened once the form has been submitted.

There were no tests about this that I could find.

Here is a screenrecording of how the UI changed
![addons-server-3098-fix](https://user-images.githubusercontent.com/1770381/36351104-be360874-14a4-11e8-8ea1-defffd06e082.gif)

Let me know if this is an acceptable solution.