### PR TITLE
Use docker-compose restart instead of supervisorctl.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:2.7.14-slim-stretch
 
+ENV PYTHONDONTWRITEBYTECODE=1
+
 # Allow scripts to detect we're running in our own container
 RUN touch /addons-server-docker-container
 
@@ -8,12 +10,8 @@ ADD docker/nodesource.gpg.key /etc/pki/gpg/GPG-KEY-nodesource
 RUN apt-get update && apt-get install -y \
         gnupg2 \
     && rm -rf /var/lib/apt/lists/*
-# ADD docker/nodesource.repo /etc/yum.repos.d/nodesource.repo
 RUN cat /etc/pki/gpg/GPG-KEY-nodesource | apt-key add -
 ADD docker/debian-stretch-nodesource-repo /etc/apt/sources.list.d/nodesource.list
-
-# For git dependencies
-# ADD docker/git.repo /etc/yum.repos.d/git.repo
 
 # Upgrade git
 RUN apt-get update && apt-get install -y \
@@ -64,8 +62,7 @@ ENV SWIG_FEATURES="-D__x86_64__"
 # Install all python requires
 RUN mkdir -p /deps/{build,cache,src}/ && \
     ln -s /code/package.json /deps/package.json && \
-    make update_deps && \
-    rm -r /deps/build/ /deps/cache/
+    make update_deps
 
 # Preserve bash history across image updates.
 # This works best when you link your local source code

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,8 @@ ENV SWIG_FEATURES="-D__x86_64__"
 # Install all python requires
 RUN mkdir -p /deps/{build,cache,src}/ && \
     ln -s /code/package.json /deps/package.json && \
-    make update_deps
+    make update_deps && \
+    rm -rf /deps/build/ /deps/cache/
 
 # Preserve bash history across image updates.
 # This works best when you link your local source code

--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -13,7 +13,6 @@ ADD docker/nodesource.gpg.key /etc/pki/gpg/GPG-KEY-nodesource
 RUN apt-get update && apt-get install -y \
         gnupg2 \
     && rm -rf /var/lib/apt/lists/*
-# ADD docker/nodesource.repo /etc/yum.repos.d/nodesource.repo
 RUN cat /etc/pki/gpg/GPG-KEY-nodesource | apt-key add -
 ADD docker/debian-stretch-nodesource-repo /etc/apt/sources.list.d/nodesource.list
 

--- a/Makefile-docker
+++ b/Makefile-docker
@@ -111,7 +111,6 @@ copy_node_js:
 	for dest in $(NODE_LIBS_JQUERY_UI) ; do cp $(NODE_MODULES)$$dest $(STATIC_JQUERY_UI) ; done
 
 update_deps: install_python_dependencies install_node_dependencies
-	rm -rf /deps/build/ /deps/cache/
 
 update_db:
 	schematic src/olympia/migrations

--- a/Makefile-docker
+++ b/Makefile-docker
@@ -111,6 +111,7 @@ copy_node_js:
 	for dest in $(NODE_LIBS_JQUERY_UI) ; do cp $(NODE_MODULES)$$dest $(STATIC_JQUERY_UI) ; done
 
 update_deps: install_python_dependencies install_node_dependencies
+	rm -rf /deps/build/ /deps/cache/
 
 update_db:
 	schematic src/olympia/migrations

--- a/Makefile-os
+++ b/Makefile-os
@@ -40,8 +40,8 @@ test_failed:
 update_docker:
 	docker-compose exec worker make update_deps
 	docker-compose exec web make update
-	docker-compose exec web supervisorctl restart all
-	docker-compose exec worker supervisorctl restart all
+	docker-compose restart web
+	docker-compose restart worker
 
 initialize_docker:
 	docker-compose exec web make initialize

--- a/circle.yml
+++ b/circle.yml
@@ -94,9 +94,9 @@ jobs:
             docker-compose ps
             # Make sure dependencies get updated in worker and web container
             docker-compose exec worker make -f Makefile-docker update_deps
-            docker-compose exec worker supervisorctl restart all
+            docker-compose restart worker
             docker-compose exec web make -f Makefile-docker update_deps
-            docker-compose exec web supervisorctl restart all
+            docker-compose restart web
             # Start Test in Firefox docker container
             docker-compose exec --user root selenium-firefox tox -e ui-tests
       - store_artifacts:

--- a/docker/supervisor-celery.conf
+++ b/docker/supervisor-celery.conf
@@ -1,7 +1,7 @@
 [supervisord]
 logfile=/code/logs/supervisord-celery.log
 
-[program:olympia]
+[program:olympia-worker]
 # This command mimics how we run it in prod from puppet:
 # https://github.com/mozilla-services/puppet-config/blob/master/amo/modules/olympia/manifests/celery.pp#L16-L24
 # https://github.com/mozilla-services/puppet-config/blob/master/amo/modules/celery/manifests/service.pp#L20


### PR DESCRIPTION
* Make also use of setting PYTHONDONTWRITEBYTECODE inside the docker
  image to reduce it's size considerably
* Remove some outdated code-parts
* Rename `olympia` inside our worker image to `olympia-worker`
* remove all build and cache folders after every `make update_deps`
  (which might help avoid any more package update/install ambiquities)

Fixes #7518 