### PR TITLE
Remove extra "Hello," in developer notification after version update

### DIFF
--- a/src/olympia/reviewers/templates/reviewers/emails/base.ltxt
+++ b/src/olympia/reviewers/templates/reviewers/emails/base.ltxt
@@ -8,8 +8,7 @@ Developer Resources
 
 To respond, please reply to this email or visit: {{ dev_versions_url }}
 
-You can also get in touch with us using these channels:
-https://developer.mozilla.org/Add-ons#Contact_us
+You can also get in touch with us using these channels: https://developer.mozilla.org/Add-ons#Contact_us
 
 For tips on how to attract more users by updating your add-on’s listing, please visit: https://developer.mozilla.org/Add-ons/Listing
 

--- a/src/olympia/reviewers/templates/reviewers/emails/pending_to_public.ltxt
+++ b/src/olympia/reviewers/templates/reviewers/emails/pending_to_public.ltxt
@@ -1,6 +1,4 @@
 {% extends "reviewers/emails/base.ltxt" %}{% block content %}
-Hello,
-
 Your add-on {{ name }} has been updated on addons.mozilla.org (AMO). Version {{ number }} is now available for download in our gallery at {{ addon_url }} .
 
 This version has been screened and approved for the public. Keep in mind that other reviewers may look into this version in the future and determine that it requires changes or should be taken down. In that case, you will be notified again with details and next steps.


### PR DESCRIPTION
Also move the contact link to the same line as the text it relates to

Fix #7469