### PR TITLE
Add cron to send last warning notification email for info requests

### DIFF
--- a/scripts/crontab/crontab.tpl
+++ b/scripts/crontab/crontab.tpl
@@ -11,6 +11,7 @@ HOME=/tmp
 #once per hour
 5 * * * * %(z_cron)s update_collections_subscribers
 10 * * * * %(z_cron)s update_blog_posts
+15 * * * * %(django)s send_info_request_last_warning_notifications
 20 * * * * %(z_cron)s addon_last_updated
 25 * * * * %(z_cron)s update_collections_votes
 45 * * * * %(z_cron)s update_addon_appsupport


### PR DESCRIPTION
Last bit to fix #7283 now that I've tested the command on dev and verified that it only notifies once.