### PR TITLE
Don't try to wrap outgoing links for fields not present in serializer ouput

### DIFF
--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -309,7 +309,8 @@ class AddonSerializer(serializers.ModelSerializer):
         if ('request' in self.context and
                 'wrap_outgoing_links' in self.context['request'].GET):
             for key in ('homepage', 'support_url', 'contributions_url'):
-                data[key] = self.outgoingify(data[key])
+                if key in data:
+                    data[key] = self.outgoingify(data[key])
         if obj.type == amo.ADDON_PERSONA:
             if 'weekly_downloads' in data:
                 # weekly_downloads don't make sense for lightweight themes.

--- a/src/olympia/discovery/tests/test_views.py
+++ b/src/olympia/discovery/tests/test_views.py
@@ -175,6 +175,24 @@ class TestDiscoveryViewList(DiscoveryTestMixin, TestCase):
             else:
                 self._check_disco_addon(result, discopane_items[i])
 
+    def test_with_wrap_outgoing_links(self):
+        response = self.client.get(
+            self.url, {'lang': 'en-US', 'wrap_outgoing_links': 'true'})
+        assert response.data
+
+        discopane_items = disco_data['default']
+        assert response.data['count'] == len(discopane_items)
+        assert response.data['next'] is None
+        assert response.data['previous'] is None
+        assert response.data['results']
+
+        for i, result in enumerate(response.data['results']):
+            assert result['is_recommendation'] is False
+            if 'theme_data' in result['addon']:
+                self._check_disco_theme(result, discopane_items[i])
+            else:
+                self._check_disco_addon(result, discopane_items[i])
+
 
 @override_switch('disco-recommendations', active=True)
 class TestDiscoveryRecommendations(DiscoveryTestMixin, TestCase):


### PR DESCRIPTION
This fixes the disco pane API with wrap_outgoing_links=true, since it does not have any of the fields that we apply the wrapping on...

Fix #7626