### PR TITLE
Make collections API error messages for slugs more human-friendly

### DIFF
--- a/src/olympia/bandwagon/serializers.py
+++ b/src/olympia/bandwagon/serializers.py
@@ -31,7 +31,7 @@ class CollectionSerializer(serializers.ModelSerializer):
         validators = [
             UniqueTogetherValidator(
                 queryset=Collection.objects.all(),
-                message=_(u'This slug is already in use by another one '
+                message=_(u'This custom URL is already in use by another one '
                           u'of your collections.'),
                 fields=('slug', 'author')
             )
@@ -60,11 +60,11 @@ class CollectionSerializer(serializers.ModelSerializer):
     def validate_slug(self, value):
         slug_validator(
             value, lower=False,
-            message=ugettext(u'Enter a valid slug consisting of letters, '
+            message=ugettext(u'The custom URL must consist of letters, '
                              u'numbers, underscores or hyphens.'))
         if DeniedName.blocked(value):
             raise serializers.ValidationError(
-                ugettext(u'This slug cannot be used.'))
+                ugettext(u'This custom URL cannot be used.'))
 
         return value
 

--- a/src/olympia/bandwagon/tests/test_views.py
+++ b/src/olympia/bandwagon/tests/test_views.py
@@ -1534,8 +1534,8 @@ class CollectionViewSetDataMixin(object):
         response = self.send(data=data)
         assert response.status_code == 400
         assert json.loads(response.content) == {
-            'slug': [u'Enter a valid slug consisting of letters, '
-                     u'numbers, underscores or hyphens.']}
+            'slug': [u'The custom URL must consist of letters, numbers, '
+                     u'underscores or hyphens.']}
 
     def test_slug_unique(self):
         collection_factory(author=self.user, slug='edam')
@@ -1544,7 +1544,7 @@ class CollectionViewSetDataMixin(object):
         data.update(slug=u'edam')
         response = self.send(data=data)
         assert response.status_code == 400
-        assert u'This slug is already in use' in (
+        assert u'This custom URL is already in use' in (
             ','.join(json.loads(response.content)['non_field_errors']))
 
 


### PR DESCRIPTION
Fix #7547