### PR TITLE
Attempt to fix bug 7504. Update the name of addon after editing.

### DIFF
--- a/src/olympia/devhub/templates/devhub/addons/edit.html
+++ b/src/olympia/devhub/templates/devhub/addons/edit.html
@@ -20,7 +20,7 @@
   {% if show_listed_fields %}
     {{ l10n_menu(addon.default_locale) }}
   {% endif %}
-  <h2>{{ addon.name }}</h2>
+  <h2 class="addon-name">{{ addon.name }}</h2>
 </header>
 
 <section class="primary" role="main">

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -385,10 +385,9 @@ function refreshAddonBasicInformation($form) {
     update_name_div = $form.find('[data-name=name]')
     updated_name = update_name_div.text()
     // Get the element to update in the top-left quadrant and update it with the new name
-    // TODO if possible change the H2 tag to have an id attribute. Need to identify where the H2 tag is generated
-    // For the time being we rely on the structure of the page
-    name_h2_tag = $('[id=l10n-menu]').next()
-    name_h2_tag.text(updated_name)
+    // The element being defined in devhub/addons/edit.html file belongs to the class addon-name
+    addon_name_tag = $('.addon-name')
+    addon_name_tag.text(updated_name)
 }
 
 

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -364,6 +364,10 @@ function addonFormSubmit() {
                     var e = $(format('<b class="save-badge">{0}</b>',
                                      [gettext('Changes Saved')]))
                               .appendTo(parent_div.find('h3').first());
+                    // Fix bug 7504. If the basic information has been changed. Refresh the name of the addon
+                    if ($form.is('#addon-edit-basic')) {
+                        refreshAddonBasicInformation($form);
+                    }
                     setTimeout(function(){
                         e.css('opacity', 0);
                         setTimeout(function(){ e.remove(); }, 200);
@@ -374,6 +378,17 @@ function addonFormSubmit() {
         reorderPreviews();
         z.refreshL10n();
     })(parent_div);
+}
+
+function refreshAddonBasicInformation($form) {
+    // Retrieve the div containing the updated name and then its value
+    update_name_div = $form.find('[data-name=name]')
+    updated_name = update_name_div.text()
+    // Get the element to update in the top-left quadrant and update it with the new name
+    // TODO if possible change the H2 tag to have an id attribute. Need to identify where the H2 tag is generated
+    // For the time being we rely on the structure of the page
+    name_h2_tag = $('[id=l10n-menu]').next()
+    name_h2_tag.text(updated_name)
 }
 
 

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -366,7 +366,11 @@ function addonFormSubmit() {
                               .appendTo(parent_div.find('h3').first());
                     // Fix bug 7504. If the basic information has been changed. Refresh the name of the addon
                     if ($form.is('#addon-edit-basic')) {
-                        refreshAddonBasicInformation($form);
+                        // Retrieve the div containing the updated name and then its value
+                        updated_name = $form.find('[data-name=name]').text()
+                        // Get the element to update in the top-left quadrant and update it with the new name
+                        // The element being defined in devhub/addons/edit.html file belongs to the class addon-name
+                        $('.addon-name').text(updated_name)
                     }
                     setTimeout(function(){
                         e.css('opacity', 0);
@@ -378,16 +382,6 @@ function addonFormSubmit() {
         reorderPreviews();
         z.refreshL10n();
     })(parent_div);
-}
-
-function refreshAddonBasicInformation($form) {
-    // Retrieve the div containing the updated name and then its value
-    update_name_div = $form.find('[data-name=name]')
-    updated_name = update_name_div.text()
-    // Get the element to update in the top-left quadrant and update it with the new name
-    // The element being defined in devhub/addons/edit.html file belongs to the class addon-name
-    addon_name_tag = $('.addon-name')
-    addon_name_tag.text(updated_name)
 }
 
 


### PR DESCRIPTION
Fix #7504 

The change regards the update of the name after a successful editing of the basic information.
I added a function to retrieve the new name and update the relevant HTML tag.
One improvement would be to generate a HTML tag with an identifying attribute in order to make it easier to update it.
Please feel free to point me to where the HTML is being defined/generated if you wish to implement this improvement.

There were no tests about this that I could find.

Here is a screenrecording of how the UI changed
![ezgif com-crop](https://user-images.githubusercontent.com/1770381/36568539-acc18e36-182a-11e8-84f2-1105de5727f1.gif)
