### PR TITLE
Remove Addon.__new__, an ancient relict from marketplace <> amo times.

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -387,16 +387,6 @@ class Addon(OnChangeMixin, ModelBase):
             ['type', 'status', 'disabled_by_user'],
         ]
 
-    @staticmethod
-    def __new__(cls, *args, **kw):
-        try:
-            type_idx = Addon._meta._type_idx
-        except AttributeError:
-            type_idx = (idx for idx, f in enumerate(Addon._meta.fields)
-                        if f.attname == 'type').next()
-            Addon._meta._type_idx = type_idx
-        return object.__new__(cls)
-
     def __unicode__(self):
         return u'%s: %s' % (self.id, self.name)
 


### PR DESCRIPTION
I found this by looking through our code for usage of `__new__`,
relatively randomly and was almost shocked after I found this heh :)

Well, it introduced back in 2011 and partially removed already so it's
time to remove it completely.
