### PR TITLE
Bump signing-clients to version 1.5.0

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -321,9 +321,9 @@ requests==2.18.4 \
     --hash=sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e
 schematic==0.4 \
     --hash=sha256:c0e10f877297f8414a1cafe759c67fb27902fe50838f725f4b5f15c598adeb9e
-signing-clients==1.4.1 \
-    --hash=sha256:820618f67f697f79c601bec8dea46727080a745d38aa8f959b45f4261653d0a8 \
-    --hash=sha256:fbdf2c19db4817f4b4485b8812aaa63e453b97f5ff5630c21accc2dce959c5d0 # pyup: ==1.4.1
+signing-clients==1.5.0 \
+    --hash=sha256:3411cab13d8a82ea294ed4523649d037ef8a97f5042f2e97b0a8898d617fd2f6 \
+    --hash=sha256:dd6a5810b97ec4a1aa8b35bed413750e89b5df0714bce2782bdf734231ca348b
 # simplejson is required by amo-validator
 simplejson==3.13.2 \
     --hash=sha256:194fa08e4047f16e7087f2a406abd15151a482a097e42d8babb1b8181b2232b1 \

--- a/src/olympia/lib/crypto/tests/test_packaged.py
+++ b/src/olympia/lib/crypto/tests/test_packaged.py
@@ -276,8 +276,10 @@ class TestPackagedTrunion(TestCase):
             'Signature-Version: 1.0\n'
             'MD5-Digest-Manifest: 38vYqmQVrnRoU0Ac00upqw==\n'
             'SHA1-Digest-Manifest: 5zn5SCe3RDBgGhSCK8rFJi98JCw=\n'
-            'SHA256-Digest-Manifest: 4ZpVcLE00kZymr5C4M/'
-                'KYTat9tj5kncqtv84gvlbT5g=') in call.body
+            'SHA256-Digest-Manifest: ' (
+                '4ZpVcLE00kZymr5C4M/KYTat9tj5kncqtv84gvlbT5g='
+            )
+        ) in call.body
 
     @responses.activate
     def test_call_signing_too_long_guid_bug_1203365(self):
@@ -294,8 +296,10 @@ class TestPackagedTrunion(TestCase):
             'Signature-Version: 1.0\n'
             'MD5-Digest-Manifest: 38vYqmQVrnRoU0Ac00upqw==\n'
             'SHA1-Digest-Manifest: 5zn5SCe3RDBgGhSCK8rFJi98JCw=\n'
-            'SHA256-Digest-Manifest: 4ZpVcLE00kZymr5C4M/'
-                'KYTat9tj5kncqtv84gvlbT5g=') in call.body
+            'SHA256-Digest-Manifest: ' (
+                '4ZpVcLE00kZymr5C4M/KYTat9tj5kncqtv84gvlbT5g='
+            )
+        ) in call.body
 
     def test_get_id_short_guid(self):
         assert len(self.addon.guid) <= 64

--- a/src/olympia/lib/crypto/tests/test_packaged.py
+++ b/src/olympia/lib/crypto/tests/test_packaged.py
@@ -276,9 +276,8 @@ class TestPackagedTrunion(TestCase):
             'Signature-Version: 1.0\n'
             'MD5-Digest-Manifest: 38vYqmQVrnRoU0Ac00upqw==\n'
             'SHA1-Digest-Manifest: 5zn5SCe3RDBgGhSCK8rFJi98JCw=\n'
-            'SHA256-Digest-Manifest: ' (
-                '4ZpVcLE00kZymr5C4M/KYTat9tj5kncqtv84gvlbT5g='
-            )
+            'SHA256-Digest-Manifest: '
+                '4ZpVcLE00kZymr5C4M/KYTat9tj5kncqtv84gvlbT5g='  # noqa
         ) in call.body
 
     @responses.activate
@@ -296,9 +295,8 @@ class TestPackagedTrunion(TestCase):
             'Signature-Version: 1.0\n'
             'MD5-Digest-Manifest: 38vYqmQVrnRoU0Ac00upqw==\n'
             'SHA1-Digest-Manifest: 5zn5SCe3RDBgGhSCK8rFJi98JCw=\n'
-            'SHA256-Digest-Manifest: ' (
-                '4ZpVcLE00kZymr5C4M/KYTat9tj5kncqtv84gvlbT5g='
-            )
+            'SHA256-Digest-Manifest: '
+                '4ZpVcLE00kZymr5C4M/KYTat9tj5kncqtv84gvlbT5g='  # noqa
         ) in call.body
 
     def test_get_id_short_guid(self):


### PR DESCRIPTION
This adds SHA256 hashes to our signing manifests.

Fixes #7668 

Test plan / QA:

Make sure 
   * new add-on uploads with current Firefox and Firefox ESR
   * and updates with current Firefox and Firefox ESR

… work correctly and are installable. 