### PR TITLE
Don't transform "" to "/" when wrapping outgoing links in the API

### DIFF
--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -325,12 +325,13 @@ class AddonSerializer(serializers.ModelSerializer):
         return data
 
     def outgoingify(self, data):
-        if isinstance(data, basestring):
-            return get_outgoing_url(data)
-        elif isinstance(data, dict):
-            return {key: get_outgoing_url(value) if value else None
-                    for key, value in data.items()}
-        # Probably None... don't bother.
+        if data:
+            if isinstance(data, basestring):
+                return get_outgoing_url(data)
+            elif isinstance(data, dict):
+                return {key: get_outgoing_url(value) if value else None
+                        for key, value in data.items()}
+        # None or empty string... don't bother.
         return data
 
     def get_categories(self, obj):

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -324,6 +324,14 @@ class AddonSerializerOutputTestMixin(object):
             get_outgoing_url(unicode(self.addon.support_url))
         )
 
+        # Try with empty strings/None. Annoyingly, contribution model field
+        # does not let us set it to None, so use a translated field for that
+        # part of the test.
+        self.addon.update(contributions='', homepage=None)
+        result = self.serialize()
+        assert result['contributions_url'] == ''
+        assert result['homepage'] is None
+
     def test_latest_unlisted_version(self):
         self.addon = addon_factory()
         version_factory(


### PR DESCRIPTION
Fix #7691