### PR TITLE
always render preview svg in ltr to have symbols and url render correctly

### DIFF
--- a/src/olympia/devhub/templates/devhub/addons/submit/wizard.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/wizard.html
@@ -59,7 +59,7 @@
     </div>
     <div>
         <h3>{{ _('Browser preview') }}</h3>
-        <div id="browser-preview">
+        <div id="browser-preview" dir="ltr">
             {% include 'devhub/addons/includes/static_theme_preview_svg.xml' %}
         </div>
     </div>


### PR DESCRIPTION
fixes mozilla/addons#649