### PR TITLE
Fixes #7652 - Correct spelling of submit for Theme generator back button

### DIFF
--- a/src/olympia/devhub/templates/devhub/addons/submit/describe.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/describe.html
@@ -146,7 +146,7 @@
       </div>
     {% endif %}
     <div class="submission-buttons addon-submission-field">
-      <button class="delete-button" type="sumbit"
+      <button class="delete-button" type="submit"
               formaction="{{ url('devhub.addons.cancel', addon.slug) }}">
           {{ _('Cancel and Disable Version') }}
       </button>

--- a/src/olympia/devhub/templates/devhub/addons/submit/describe_minimal.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/describe_minimal.html
@@ -25,7 +25,7 @@
     </div>
     {% include "devhub/includes/clear_pending_info_request.html" %}
     <div class="submission-buttons addon-submission-field">
-      <button class="delete-button" type="sumbit"
+      <button class="delete-button" type="submit"
               formaction="{{ url('devhub.addons.cancel', addon.slug) }}">
           {{ _('Cancel and Disable Version') }}
       </button>

--- a/src/olympia/devhub/templates/devhub/addons/submit/wizard.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/wizard.html
@@ -77,7 +77,7 @@
       <ul class="errorlist validator">
       </ul>
       <div class="submission-buttons addon-submission-field">
-        <button class="delete-button" type="sumbit"
+        <button class="delete-button" type="submit"
             {% if addon %}
                 formaction="{{ url('devhub.submit.version.upload', addon.slug, channel_param) }}"
             {% else %}


### PR DESCRIPTION
Fixes #7652 - Corrected a spelling mistake for the `type` of the **back** button in the Theme Generator page from `sumbit` to `submit`.