### PR TITLE
Redirecting the href of the About page to the url for pages.about. 

### DIFF
--- a/src/olympia/devhub/templates/devhub/new-landing/components/footer.html
+++ b/src/olympia/devhub/templates/devhub/new-landing/components/footer.html
@@ -16,7 +16,7 @@
       <section class="DevHub-Footer-section">
         <h4>{{ _('Community') }}</h4>
         <ul>
-          <li><a href="https://addons.mozilla.org/about">{{ _('About') }}</a></li>
+          <li><a href="{{ url('pages.about') }}">{{ _('About') }}</a></li>
           <li><a href="https://discourse.mozilla-community.org/c/add-ons">{{ _('Forum') }}</a></li>
           <li><a href="https://blog.mozilla.org/addons/">{{ _('Blog') }}</a></li>
           <li><a href="https://developer.mozilla.org/en-US/Add-ons#Contact_us">{{ _('Contact Us') }}</a></li>


### PR DESCRIPTION
Changing the href for the **About** link to point to the url of such a page and not a fixed link. Fix #6789