### PR TITLE
Fixes #6489: Make Contribution URL clickable in new tab

### DIFF
--- a/src/olympia/devhub/templates/devhub/addons/edit/basic.html
+++ b/src/olympia/devhub/templates/devhub/addons/edit/basic.html
@@ -198,7 +198,7 @@
                 <p>{{ form.contributions }}</p>
                 {{ form.contributions.errors }}
               {% else %}
-                {{ addon.contributions }}
+                <a href="{{ addon.contributions }}" target="_blank" rel="noopener noreferrer">{{ addon.contributions }}</a>
               {% endif %}
             </td>
           </tr>


### PR DESCRIPTION
This makes contribution url clickable to encourage users to test out the URL.

`rel="noopener noreferrer"` is added along with `target="_blank"` to prevent tab nabbing.

Please delete anything that isn't relevant to your patch.

* [x] This PR relates to an existing open issue and there are no existing
      PRs open for the same issue.
* [x] Add `Fixes #ISSUENUM` at the top of your PR.
* [x] Add a description of the the changes introduced in this PR.
* [x] The change has been successfully run locally.
* [x] Add before and after screenshots (Only for changes that impact the UI).


Before:
<img width="769" alt="screen shot 2018-03-03 at 9 40 16 pm" src="https://user-images.githubusercontent.com/8039608/36936436-908368ae-1f2b-11e8-8e62-f3683adf0868.png">

After:
<img width="749" alt="screen shot 2018-03-03 at 9 38 35 pm" src="https://user-images.githubusercontent.com/8039608/36936439-9afbdf32-1f2b-11e8-9766-10c2e9c4a58b.png">
