### PR TITLE
Fixes #7561: Use Scandir to speed up our os.walk usage

### DIFF
--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -40,6 +40,7 @@ import jinja2
 import pytz
 
 from babel import Locale
+from scandir import walk as scandir_walk
 from django_statsd.clients import statsd
 from easy_thumbnails import processors
 from html5lib.serializer.htmlserializer import HTMLSerializer
@@ -920,7 +921,7 @@ def has_links(html):
 def walkfiles(folder, suffix=''):
     """Iterator over files in folder, recursively."""
     return (os.path.join(basename, filename)
-            for basename, dirnames, filenames in os.walk(folder)
+            for basename, dirnames, filenames in scandir_walk(folder)
             for filename in filenames
             if filename.endswith(suffix))
 

--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -17,6 +17,7 @@ import urllib
 import urlparse
 import string
 import subprocess
+import scandir
 
 import django.core.mail
 
@@ -40,7 +41,6 @@ import jinja2
 import pytz
 
 from babel import Locale
-from scandir import walk as scandir_walk
 from django_statsd.clients import statsd
 from easy_thumbnails import processors
 from html5lib.serializer.htmlserializer import HTMLSerializer
@@ -921,7 +921,7 @@ def has_links(html):
 def walkfiles(folder, suffix=''):
     """Iterator over files in folder, recursively."""
     return (os.path.join(basename, filename)
-            for basename, dirnames, filenames in scandir_walk(folder)
+            for basename, dirnames, filenames in scandir.walk(folder)
             for filename in filenames
             if filename.endswith(suffix))
 

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -10,12 +10,12 @@ import StringIO
 import struct
 import tempfile
 import zipfile
+import scandir
 
 from cStringIO import StringIO as cStringIO
 from datetime import datetime, timedelta
 from xml.dom import minidom
 from zipfile import BadZipfile, ZipFile
-from scandir import walk as scandir_walk
 
 from django import forms
 from django.conf import settings
@@ -777,7 +777,7 @@ def extract_xpi(xpi, path, expand=False, verify=True):
     if expand:
         for x in xrange(0, 10):
             flag = False
-            for root, dirs, files in scandir_walk(tempdir):
+            for root, dirs, files in scandir.walk(tempdir):
                 for name in files:
                     if os.path.splitext(name)[1] in expand_allow_list:
                         src = os.path.join(root, name)
@@ -936,7 +936,7 @@ def zip_folder_content(folder, filename):
     """Compress the _content_ of a folder."""
     with zipfile.ZipFile(filename, 'w', zipfile.ZIP_DEFLATED) as dest:
         # Add each file/folder from the folder to the zip file.
-        for root, dirs, files in scandir_walk(folder):
+        for root, dirs, files in scandir.walk(folder):
             relative_dir = os.path.relpath(root, folder)
             for file_ in files:
                 dest.write(os.path.join(root, file_),

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -15,6 +15,7 @@ from cStringIO import StringIO as cStringIO
 from datetime import datetime, timedelta
 from xml.dom import minidom
 from zipfile import BadZipfile, ZipFile
+from scandir import walk as scandir_walk
 
 from django import forms
 from django.conf import settings
@@ -776,7 +777,7 @@ def extract_xpi(xpi, path, expand=False, verify=True):
     if expand:
         for x in xrange(0, 10):
             flag = False
-            for root, dirs, files in os.walk(tempdir):
+            for root, dirs, files in scandir_walk(tempdir):
                 for name in files:
                     if os.path.splitext(name)[1] in expand_allow_list:
                         src = os.path.join(root, name)
@@ -935,7 +936,7 @@ def zip_folder_content(folder, filename):
     """Compress the _content_ of a folder."""
     with zipfile.ZipFile(filename, 'w', zipfile.ZIP_DEFLATED) as dest:
         # Add each file/folder from the folder to the zip file.
-        for root, dirs, files in os.walk(folder):
+        for root, dirs, files in scandir_walk(folder):
             relative_dir = os.path.relpath(root, folder)
             for file_ in files:
                 dest.write(os.path.join(root, file_),


### PR DESCRIPTION
Used scandir instead of `os.walk` to speed up usage of `walk` method.
I've imported it as `scandir_walk` to explicitly keep name-spacing consistent. This would help people in future to quickly know that it is not normal walk that is shipped with `os` module.

Please delete anything that isn't relevant to your patch.

* [x] This PR relates to an existing open issue and there are no existing
      PRs open for the same issue.
* [x] Add `Fixes #ISSUENUM` at the top of your PR.
* [x] Add a description of the the changes introduced in this PR.


Let me know if this needs any further changes ;)