### PR TITLE
Fixes #7679: Change anonymous user image url/picture_type to a null value

### DIFF
--- a/src/olympia/accounts/serializers.py
+++ b/src/olympia/accounts/serializers.py
@@ -45,8 +45,7 @@ class BaseUserSerializer(serializers.ModelSerializer):
 
     # Used in subclasses.
     def get_picture_url(self, obj):
-        if obj.picture_url and \
-                not obj.picture_url.endswith('/img/zamboni/anon_user.png'):
+        if obj.picture_type:
             return absolutify(obj.picture_url)
         return None
 

--- a/src/olympia/accounts/serializers.py
+++ b/src/olympia/accounts/serializers.py
@@ -45,7 +45,10 @@ class BaseUserSerializer(serializers.ModelSerializer):
 
     # Used in subclasses.
     def get_picture_url(self, obj):
-        return absolutify(obj.picture_url)
+        if obj.picture_url and \
+                not obj.picture_url.endswith('/img/zamboni/anon_user.png'):
+            return absolutify(obj.picture_url)
+        return None
 
 
 class PublicUserProfileSerializer(BaseUserSerializer):

--- a/src/olympia/accounts/tests/test_serializers.py
+++ b/src/olympia/accounts/tests/test_serializers.py
@@ -73,8 +73,8 @@ class TestPublicUserProfileSerializer(TestCase):
 
     def test_picture(self):
         serial = self.serialize()
-        assert ('anon_user.png' in serial['picture_url'])
-        assert serial['picture_type'] == ''
+        assert serial['picture_url'] is None
+        assert serial['picture_type'] is None
         assert 'picture_upload' not in serial  # its a write only field.
 
         self.user.update(picture_type='image/jpeg')

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -968,7 +968,7 @@ class TestAccountViewSetUpdate(TestCase):
         # Should delete the photo
         assert not path.exists(self.user.picture_path)
         json_content = json.loads(response.content)
-        assert 'anon_user.png' in json_content['picture_url']
+        assert json_content['picture_url'] is None
 
     def test_account_picture_disallowed_verbs(self):
         picture_url = reverse('account-picture', kwargs={'pk': self.user.pk})

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -425,7 +425,7 @@ class AccountViewSet(RetrieveModelMixin, UpdateModelMixin, DestroyModelMixin,
             AnyOf(AllowSelf, GroupPermission(amo.permissions.USERS_EDIT))])
     def picture(self, request, pk=None):
         user = self.get_object()
-        user.update(picture_type='')
+        user.update(picture_type=None)
         log.debug(u'User (%s) deleted photo' % user)
         tasks.delete_photo.delay(user.picture_path)
         return self.retrieve(request)

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -41,7 +41,7 @@ class AddonSerializerOutputTestMixin(object):
         assert data == {
             'id': author.pk,
             'name': author.name,
-            'picture_url': absolutify(author.picture_url),
+            'picture_url': None,
             'url': absolutify(author.get_url_path()),
             'username': author.username,
         }
@@ -1049,7 +1049,7 @@ class TestAddonDeveloperSerializer(TestBaseUserSerializer):
 
     def test_picture(self):
         serialized = self.serialize()
-        assert ('anon_user.png' in serialized['picture_url'])
+        assert serialized['picture_url'] is None
 
         self.user.update(picture_type='image/jpeg')
         serialized = self.serialize()

--- a/src/olympia/migrations/1001-drop-users-picture-type-not-null.sql
+++ b/src/olympia/migrations/1001-drop-users-picture-type-not-null.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `users`
+MODIFY `picture_type` varchar(75) NULL DEFAULT NULL;

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -134,7 +134,8 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
     notifyevents = models.BooleanField(default=True)
     occupation = models.CharField(max_length=255, default='', blank=True)
     # This is essentially a "has_picture" flag right now
-    picture_type = models.CharField(max_length=75, default='', blank=True)
+    picture_type = models.CharField(max_length=75, default=None, null=True,
+                                    blank=True)
     read_dev_agreement = models.DateTimeField(null=True, blank=True)
 
     last_login_ip = models.CharField(default='', max_length=45, editable=False)
@@ -377,7 +378,7 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
             self.display_name = None
             self.homepage = ""
             self.deleted = True
-            self.picture_type = ""
+            self.picture_type = None
             self.auth_id = generate_auth_id()
             self.save()
 

--- a/src/olympia/users/views.py
+++ b/src/olympia/users/views.py
@@ -118,7 +118,7 @@ def delete_photo(request, user_id):
     user = UserProfile.objects.get(id=user_id)
 
     if request.method == 'POST':
-        user.picture_type = ''
+        user.picture_type = None
         user.save()
         log.debug(u'User (%s) deleted photo' % user)
         tasks.delete_photo.delay(user.picture_path)


### PR DESCRIPTION
Requesting user from API: (https://addons-server.readthedocs.io/en/latest/topics/api/accounts.html#get--api-v3-accounts-account-(int-user_id|string-username)-) will now return `null` in `picture_type` and `picture_url` if the profile picture is not set.

The only last bit that should be included in this patch is the migration (since models are changed). I'm having this build running with docker-compose and when I try to do `make shell` and then run db migrations via `python manage.py makemigrations`, it tells me that no changes detected.

Further to this, I explored the codebase and found that there is just one migration folder referring to all the SQL files. I'm curious to know how do we generate these files/migrations for that say.


* [x] This PR relates to an existing open issue and there are no existing
      PRs open for the same issue.
* [x] Add `Fixes #ISSUENUM` at the top of your PR.
* [x] Add a description of the the changes introduced in this PR.
* [x] The change has been successfully run locally.
* [x] Add tests to cover the changes added in this PR.

