### PR TITLE
Adding a test to make sure we cannot change the display_name to a den…

### DIFF
--- a/src/olympia/users/tests/test_forms.py
+++ b/src/olympia/users/tests/test_forms.py
@@ -77,6 +77,16 @@ class TestUserEditForm(UserFormBase):
         self.assertNoFormErrors(response)
         assert self.user.reload().username == 'new-username'
 
+    def test_cannot_change_display_name_to_denied_ones(self):
+        assert self.user.display_name != 'Mozilla'
+        data = {'username': 'new-username',
+                'display_name': 'IE6Fan',
+                'email': 'jbalogh@mozilla.com'}
+        response = self.client.post(self.url, data)
+        msg = "This display name cannot be used."
+        self.assertFormError(response, 'form', 'display_name', msg)
+        assert self.user.reload().display_name != 'IE6Fan'
+
     def test_no_username_anonymous_does_not_change(self):
         """Test that username isn't required with auto-generated usernames and
         the auto-generated value does not change."""


### PR DESCRIPTION
…ied one. Ref #7449

This tests make sure we are not able to change the display_name property of a user into something present in the `DeniedName` list.