### PR TITLE
FIxes #7646 - Theme name field is not updated when changing the image

### DIFF
--- a/static/js/zamboni/static_theme.js
+++ b/static/js/zamboni/static_theme.js
@@ -27,13 +27,6 @@ $(document).ready(function() {
                 updateManifest();
             };
             reader.readAsDataURL(file);
-
-            var filename = file.name.replace(/\.[^/.]+$/, "");
-            $wizard.find('a.download').attr('download', filename + ".zip");
-            var name_input = $wizard.find('#theme-name');
-            if (!name_input.val()) {
-                name_input.val(filename);
-            }
         });
         $wizard.find('input[type="file"]').trigger('change');
 


### PR DESCRIPTION
Fixes #7646 - Removed functionality to automatically populate the Theme Name upon uploading a header image.

**Reason behind change**:

The current functionality automatically populates the theme name (if empty) with the **file name** of the uploaded header image. In most cases, this file name does not translate into a professional and unique theme name that accurately represents the created theme. After speaking with some individuals (_a very small sample size of 5_), all entered the Theme name first and didn't expect the uploaded header image file name to be used at all.

**Before GIF**:

![themename_before](https://user-images.githubusercontent.com/13009507/37184787-2c81f7d8-230b-11e8-9ddd-9a0a794c56c5.gif)

**After GIF**:

![themename_after](https://user-images.githubusercontent.com/13009507/37184891-973557f0-230b-11e8-91fd-76e73241779d.gif)



