### PR TITLE
Update addons-linter to 0.39.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "potools": "potools"
   },
   "dependencies": {
-    "addons-linter": "0.38.0",
+    "addons-linter": "0.39.1",
     "clean-css": "4.1.9",
     "clean-css-cli": "4.1.11",
     "jqmodal": "1.4.2",


### PR DESCRIPTION
* restores node6 compatibility
* fixes language pack .ftl file parsing

And a few more fixes along the way.