### PR TITLE
Make user average_addon_rating in the API a float (as documented)

### DIFF
--- a/src/olympia/accounts/serializers.py
+++ b/src/olympia/accounts/serializers.py
@@ -52,7 +52,7 @@ class BaseUserSerializer(serializers.ModelSerializer):
 
 class PublicUserProfileSerializer(BaseUserSerializer):
     picture_url = serializers.SerializerMethodField()
-    average_addon_rating = serializers.CharField(source='averagerating')
+    average_addon_rating = serializers.FloatField(source='averagerating')
 
     class Meta(BaseUserSerializer.Meta):
         fields = BaseUserSerializer.Meta.fields + (

--- a/src/olympia/accounts/tests/test_serializers.py
+++ b/src/olympia/accounts/tests/test_serializers.py
@@ -97,7 +97,7 @@ class TestPublicUserProfileSerializer(TestCase):
         addon_factory(status=amo.STATUS_NULL, users=[self.user])
         data = self.serialize()
         assert data['num_addons_listed'] == 2  # only public addons.
-        assert data['average_addon_rating'] == '3.6'
+        assert data['average_addon_rating'] == 3.6
 
     def test_url_for_non_developers(self):
         result = self.serialize()


### PR DESCRIPTION
Fix #7822