### PR TITLE
Update addons-linter to 0.40.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "potools": "potools"
   },
   "dependencies": {
-    "addons-linter": "0.39.1",
+    "addons-linter": "0.40.0",
     "clean-css": "4.1.9",
     "clean-css-cli": "4.1.11",
     "jqmodal": "1.4.2",


### PR DESCRIPTION
* Fix absent content script detection. mozilla/addons-linter#1902 (Fixes a regression)
* Remove explicit property linting from messages.json parsing. mozilla/addons-linter#1918 (fixes regression)
* Update dispensary to the latest version
* Import Firefox 60 schemas. mozilla/addons-linter#1898
