### PR TITLE
Don't display button to disable auto-approvals on static themes

### DIFF
--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -319,20 +319,22 @@
                   data-toggle-button-selector="#force_disable_addon"
                   id="force_enable_addon" type="button">{{ _('Force-enable add-on') }}</button>
         </li>
-        <li {% if addon.auto_approval_disabled %}class="hidden"{% endif %}>
-          <button data-api-url="{{ url('reviewers-addon-flags', addon.pk) }}"
-                  data-api-method="patch"
-                  data-api-data="{&quot;auto_approval_disabled&quot;: true}"
-                  data-toggle-button-selector="#enable_auto_approval"
-                  id="disable_auto_approval" type="button">{{ _('Disable Auto-Approval') }}</button>
-        </li>
-        <li {% if not addon.auto_approval_disabled %}class="hidden"{% endif %}>
-          <button data-api-url="{{ url('reviewers-addon-flags', addon.pk) }}"
-                  data-api-method="patch"
-                  data-api-data="{&quot;auto_approval_disabled&quot;: false}"
-                  data-toggle-button-selector="#disable_auto_approval"
-                  id="enable_auto_approval" type="button">{{ _('Enable Auto-Approval') }}</button>
-        </li>
+        {% if addon.type in (amo.ADDON_EXTENSION, amo.ADDON_LPAPP) %}
+          <li {% if addon.auto_approval_disabled %}class="hidden"{% endif %}>
+            <button data-api-url="{{ url('reviewers-addon-flags', addon.pk) }}"
+                    data-api-method="patch"
+                    data-api-data="{&quot;auto_approval_disabled&quot;: true}"
+                    data-toggle-button-selector="#enable_auto_approval"
+                    id="disable_auto_approval" type="button">{{ _('Disable Auto-Approval') }}</button>
+          </li>
+          <li {% if not addon.auto_approval_disabled %}class="hidden"{% endif %}>
+            <button data-api-url="{{ url('reviewers-addon-flags', addon.pk) }}"
+                    data-api-method="patch"
+                    data-api-data="{&quot;auto_approval_disabled&quot;: false}"
+                    data-toggle-button-selector="#disable_auto_approval"
+                    id="enable_auto_approval" type="button">{{ _('Enable Auto-Approval') }}</button>
+          </li>
+        {% endif %}
         {% if addon.pending_info_request %}
           <li>
               <button data-api-url="{{ url('reviewers-addon-flags', addon.pk) }}"

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -3176,6 +3176,15 @@ class TestReview(ReviewBase):
         elem = doc('#enable_auto_approval')[0]
         assert 'hidden' in elem.getparent().attrib.get('class', '')
 
+        # Both of them should be absent on static themes, which are not
+        # auto-approved.
+        self.addon.update(type=amo.ADDON_STATICTHEME)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        assert not doc('#disable_auto_approval')
+        assert not doc('#enable_auto_approval')
+
     def test_enable_auto_approvals_as_admin_auto_approvals_disabled(self):
         self.login_as_admin()
         AddonReviewerFlags.objects.create(
@@ -3190,6 +3199,15 @@ class TestReview(ReviewBase):
         assert doc('#enable_auto_approval')
         elem = doc('#enable_auto_approval')[0]
         assert 'hidden' not in elem.getparent().attrib.get('class', '')
+
+        # Both of them should be absent on static themes, which are not
+        # auto-approved.
+        self.addon.update(type=amo.ADDON_STATICTHEME)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        assert not doc('#disable_auto_approval')
+        assert not doc('#enable_auto_approval')
 
     def test_clear_pending_info_request_as_admin(self):
         self.login_as_admin()


### PR DESCRIPTION
Fix #7854