### PR TITLE
show theme preview in devhub

### DIFF
--- a/src/olympia/devhub/templates/devhub/addons/edit.html
+++ b/src/olympia/devhub/templates/devhub/addons/edit.html
@@ -25,6 +25,17 @@
 
 <section class="primary" role="main">
 <div id="edit-addon" class="devhub-form">
+  {% if addon.current_version and addon.current_version.previews %}
+    <h3>
+      {{ _('Preview') }}
+    </h3>
+    <div class="edit-addon-section">
+      {% for preview in addon.current_version.previews.all() %}
+        <img src="{{ preview.image_url }}" title="{{ _('Preview of listed version') }}"
+            alt="[{{ _('Preview still being generated - come back later or refresh the page.') }}]">
+      {% endfor %}
+    </div>
+  {% endif %}
 
   <div class="edit-addon-section" id="edit-addon-basic">
     {% include 'devhub/addons/edit/basic.html' %}

--- a/src/olympia/devhub/templates/devhub/addons/submit/done.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/done.html
@@ -15,6 +15,12 @@
     {% if addon.type == amo.ADDON_STATICTHEME %}
       <h3>{{ _("Version Submitted for Review") }}</h3>
       <p>
+        {% for preview in uploaded_version.previews.all() %}
+          <img src="{{ preview.image_url }}" title="{{ _('Preview of the version submitted') }}"
+            alt="[{{ _('Preview still being generated - come back later or refresh the page.') }}]">
+        {% endfor %}
+      </p>
+      <p>
         {{ _("You’re done! This version will be available after it passes review. "
              "You will be notified when it is reviewed.") }}
       </p>

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -26,7 +26,7 @@ from olympia.devhub import views
 from olympia.files.models import FileValidation
 from olympia.files.tests.test_models import UploadTest
 from olympia.users.models import UserProfile
-from olympia.versions.models import License
+from olympia.versions.models import License, VersionPreview
 from olympia.zadmin.models import Config
 
 
@@ -1050,6 +1050,7 @@ class TestAddonSubmitFinish(TestSubmitBase):
         self.addon.update(type=amo.ADDON_STATICTHEME)
         version = self.addon.find_latest_version(
             channel=amo.RELEASE_CHANNEL_LISTED)
+        VersionPreview.objects.create(version=version)
         assert version.supported_platforms == ([amo.PLATFORM_ALL])
 
         response = self.client.get(self.url)
@@ -1067,6 +1068,9 @@ class TestAddonSubmitFinish(TestSubmitBase):
         # Text is static theme specific.
         assert "This version will be available after it passes review." in (
             response.content)
+        # Show the preview we started generating just after the upload step.
+        assert content('img')[0].attrib['src'] == (
+            version.previews.first().image_url)
 
     def test_finish_submitting_unlisted_static_theme(self):
         self.addon.update(type=amo.ADDON_STATICTHEME)


### PR DESCRIPTION
Fixes #7873 to an extent - I'd like to show the previews in the addon version list and my submissions too but we could do with smaller previews (i.e. #7888) or creating an icon (something we do for LWT but don't display in new frontend)
