### PR TITLE
Fix screenshot and addon info placement on review page

### DIFF
--- a/static/css/zamboni/reviewers.less
+++ b/static/css/zamboni/reviewers.less
@@ -1145,11 +1145,8 @@ h2.addon {
     flex-flow: row wrap;
 }
 
-.screenshot.thumbnail {
-    /* we don't want the float from the legacy css, so we need to apply display
-       block ourselves. */
-    display: block;
-    float: none;
+.addon-info {
+    flex: 1;  /* try to take up "one" space regardless of content */
 }
 
 #addon-theme-previews-wrapper {


### PR DESCRIPTION
Fix #7913
Fix #7914

We don't need/want to remove the float on the previews, and we want to make sure the add-on info grows in size on the same row as the thumbnail.