### PR TITLE
Set the default sorting for themes to "Created" instead of name. Fix …

### DIFF
--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -230,12 +230,12 @@ class TestDashboard(HubTest):
         addon = addon_factory(type=amo.ADDON_PERSONA)
         addon.addonuser_set.create(user=self.user_profile)
 
-        # There's no "updated" sort filter, so order by the default: "Name".
-        response = self.client.get(self.themes_url + '?sort=updated')
+        # There's no "updated" sort filter, so order by the default: "Created".
+        response = self.client.get(self.themes_url)
         doc = pq(response.content)
-        assert doc('#sorter li.selected').text() == 'Name'
+        assert doc('#sorter li.selected').text() == 'Created'
         sorts = doc('#sorter li a.opt')
-        assert not any('?sort=updated' in a.attrib['href'] for a in sorts)
+        assert not any('?sort=created' in a.attrib['href'] for a in sorts)
 
         # No "updated" in details.
         assert doc('.item-details .date-updated') == []

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -231,11 +231,11 @@ class TestDashboard(HubTest):
         addon.addonuser_set.create(user=self.user_profile)
 
         # There's no "updated" sort filter, so order by the default: "Created".
-        response = self.client.get(self.themes_url)
+        response = self.client.get(self.themes_url + '?sort=updated')
         doc = pq(response.content)
         assert doc('#sorter li.selected').text() == 'Created'
         sorts = doc('#sorter li a.opt')
-        assert not any('?sort=created' in a.attrib['href'] for a in sorts)
+        assert not any('?sort=updated' in a.attrib['href'] for a in sorts)
 
         # No "updated" in details.
         assert doc('.item-details .date-updated') == []

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -89,8 +89,8 @@ class AddonFilter(BaseFilter):
 
 
 class ThemeFilter(BaseFilter):
-    opts = (('name', _(u'Name')),
-            ('created', _(u'Created')),
+    opts = (('created', _(u'Created')),
+            ('name', _(u'Name')),
             ('popular', _(u'Downloads')),
             ('rating', _(u'Rating')))
 
@@ -101,7 +101,7 @@ def addon_listing(request, theme=False):
         qs = request.user.addons.filter(
             type__in=[amo.ADDON_PERSONA, amo.ADDON_STATICTHEME])
         filter_cls = ThemeFilter
-        default = 'name'
+        default = 'created'
     else:
         qs = Addon.objects.filter(authors=request.user).exclude(
             type__in=[amo.ADDON_PERSONA, amo.ADDON_STATICTHEME])
@@ -132,7 +132,6 @@ def dashboard(request, theme=False):
     data = dict(rss=_get_rss_feed(request), blog_posts=_get_posts(),
                 timestamp=int(time.time()), addon_tab=not theme,
                 theme=theme, addon_items=addon_items)
-
     if data['addon_tab']:
         addons, data['filter'] = addon_listing(request)
         # We know the dashboard is going to want to display feature


### PR DESCRIPTION
…#7502

This Fix #7502 
It changes the default sorting option of the theme listing page from name to created. It also changes the sort options list order.

![ezgif com-gif-maker](https://user-images.githubusercontent.com/1770381/37950528-202638d6-3199-11e8-8d44-9bc8e4d2a056.gif)
