### PR TITLE
Bring back border on table with add-on info in review page

### DIFF
--- a/src/olympia/reviewers/templates/reviewers/addon_details_box.html
+++ b/src/olympia/reviewers/templates/reviewers/addon_details_box.html
@@ -35,7 +35,7 @@
       {% endif %}
     </div>{# /secondary #}
 
-    <div class="addon-info">
+    <div class="addon-info object-lead">
       <p{{ addon.summary|locale_html }}>{{ addon.summary|nl2br }}</p>
       {% if version and version.is_restart_required %}
         <div>

--- a/static/css/zamboni/reviewers.less
+++ b/static/css/zamboni/reviewers.less
@@ -1147,6 +1147,7 @@ h2.addon {
 
 .addon-info {
     flex: 1;  /* try to take up "one" space regardless of content */
+    padding: 0 1em;
 }
 
 #addon-theme-previews-wrapper {


### PR DESCRIPTION
(it depends on the presence of the object-lead class on a parent,
 but we need to adjust the padding accordingly now that the styles
 have been simplified)

Fix #7913

**Before:**
![before](https://user-images.githubusercontent.com/187006/37965553-c317a332-31c5-11e8-942d-ffa307cf70c8.png)

**After:**
![after](https://user-images.githubusercontent.com/187006/37965551-c2dd97aa-31c5-11e8-876f-f3492fbda8a5.png)
