### PR TITLE
Avoid calling parse_addon() in Version.from_upload if applicable

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -585,7 +585,7 @@ class Addon(OnChangeMixin, ModelBase):
             AddonReviewerFlags.objects.update_or_create(
                 addon=addon, defaults={'needs_admin_code_review': True})
         Version.from_upload(upload, addon, platforms, source=source,
-                            channel=channel)
+                            channel=channel, parsed_data=parsed_data)
 
         activity.log_create(amo.LOG.CREATE_ADDON, addon)
         log.debug('New addon %r from %r' % (addon, upload))

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -36,6 +36,7 @@ from olympia.constants.categories import CATEGORIES
 from olympia.devhub.models import RssKey
 from olympia.files.models import File
 from olympia.files.tests.test_models import UploadTest
+from olympia.files.utils import parse_addon
 from olympia.ratings.models import Rating, RatingFlag
 from olympia.translations.models import (
     Translation, TranslationSequence, delete_translation)
@@ -2574,6 +2575,13 @@ class TestAddonFromUpload(UploadTest):
 
         # Normalized from `en` to `en-US`
         assert addon.default_locale == 'en-US'
+
+    @patch('olympia.files.utils.parse_addon', wraps=parse_addon)
+    def test_parse_addon_is_called_only_once(self, parse_addon):
+        Addon.from_upload(self.get_upload('webextension.xpi'), [self.platform])
+
+        # utils.parse_addon in Version.from_upload() should not be called.
+        parse_addon.assert_not_called()
 
 
 REDIRECT_URL = 'https://outgoing.prod.mozaws.net/v1/'

--- a/src/olympia/zadmin/tasks.py
+++ b/src/olympia/zadmin/tasks.py
@@ -199,7 +199,8 @@ def fetch_langpack(url, xpi, **kw):
 
             version = Version.from_upload(upload, addon, [amo.PLATFORM_ALL.id],
                                           amo.RELEASE_CHANNEL_LISTED,
-                                          is_beta=is_beta)
+                                          is_beta=is_beta,
+                                          parsed_data=data)
 
             log.info('[@None] Updated language pack "{0}" to version {1}'
                      .format(xpi, data['version']))


### PR DESCRIPTION
Fixes #7933

Version.from_upload() can take *parsed data*, but in two call sites, Addon.from_upload() and fetch_langpack() didn't pass the parsed data though they already have the parsed data.

In this PR, a test case was introduced for the case of Addon.from_upload() but wasn't introduced for fetch_langpack() case since there is no test cases to use the function directly.  (All test cases in src/olympia/zadmin/tests/test_tasks.py use fetch_langpacks instead)