### PR TITLE
Don't show <h3>preview</h3> when no version previews

### DIFF
--- a/src/olympia/devhub/templates/devhub/addons/edit.html
+++ b/src/olympia/devhub/templates/devhub/addons/edit.html
@@ -25,7 +25,7 @@
 
 <section class="primary" role="main">
 <div id="edit-addon" class="devhub-form">
-  {% if addon.current_version and addon.current_version.previews.all() %}
+  {% if addon.current_version and addon.current_version.previews.exists() %}
     <h3>
       {{ _('Preview') }}
     </h3>

--- a/src/olympia/devhub/templates/devhub/addons/edit.html
+++ b/src/olympia/devhub/templates/devhub/addons/edit.html
@@ -25,7 +25,7 @@
 
 <section class="primary" role="main">
 <div id="edit-addon" class="devhub-form">
-  {% if addon.current_version and addon.current_version.previews %}
+  {% if addon.current_version and addon.current_version.previews.all() %}
     <h3>
       {{ _('Preview') }}
     </h3>


### PR DESCRIPTION
`versions.previews` is truthy; `version.previews.all()` is falsey.  Fixes #7921 