### PR TITLE
Drop supporting invalid 'image/jpg' MIME type

### DIFF
--- a/src/olympia/constants/base.py
+++ b/src/olympia/constants/base.py
@@ -245,7 +245,7 @@ PERSONA_IMAGE_SIZES = {
 }
 
 # Accepted image MIME-types
-IMG_TYPES = ('image/png', 'image/jpeg', 'image/jpg')
+IMG_TYPES = ('image/png', 'image/jpeg')
 VIDEO_TYPES = ('video/webm',)
 
 # These types don't maintain app compatibility in the db.  Instead, we look at


### PR DESCRIPTION
Fixes #7943

I believe nothing should be broken in CI, let's see what happens.