### PR TITLE
Allow superusers to see django admin modules nobody else can access

### DIFF
--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -196,11 +196,15 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
     def has_module_perms(self, app_label):
         """Determine whether the user can see a particular app in the django
         admin tools. """
-        # If the user has permission for any action available for any of the
-        # models of the app, they can see the app in the django admin.
-        return any(self.has_perm(key)
-                   for key in amo.permissions.DJANGO_PERMISSIONS_MAPPING
-                   if key.startswith('%s.' % app_label))
+        # If the user is a superuser or has permission for any action available
+        # for any of the models of the app, they can see the app in the django
+        # admin. The is_superuser check is needed to allow superuser to access
+        # modules that are not in the mapping at all (i.e. things only they
+        # can access).
+        return (self.is_superuser or
+                any(self.has_perm(key)
+                    for key in amo.permissions.DJANGO_PERMISSIONS_MAPPING
+                    if key.startswith('%s.' % app_label)))
 
     def has_read_developer_agreement(self):
         from olympia.zadmin.models import get_config

--- a/src/olympia/zadmin/tests/test_views.py
+++ b/src/olympia/zadmin/tests/test_views.py
@@ -74,6 +74,9 @@ class TestHomeAndIndex(TestCase):
         url = reverse('admin:index')
         response = self.client.get(url)
         assert response.status_code == 200
+        doc = pq(response.content)
+        modules = [x.text for x in doc('a.section')]
+        assert len(modules) == 15  # Increment as we add new admin modules.
 
         # Redirected because no permissions if not logged in.
         self.client.logout()
@@ -92,6 +95,11 @@ class TestHomeAndIndex(TestCase):
         self.grant_permission(user, 'Admin:Something')
         response = self.client.get(url)
         assert response.status_code == 200
+        doc = pq(response.content)
+        modules = [x.text for x in doc('a.section')]
+        # Admin:Something doesn't give access to anything, so they can log in
+        # but they don't see any modules.
+        assert len(modules) == 0
 
     def test_django_admin_logout(self):
         url = reverse('admin:logout')


### PR DESCRIPTION
Follow-up fix for #7848