### PR TITLE
parse region out of aws url and pass as a param to boto3.client

### DIFF
--- a/src/olympia/accounts/tests/test_utils.py
+++ b/src/olympia/accounts/tests/test_utils.py
@@ -136,9 +136,12 @@ class TestProcessSqsQueue(TestCase):
 
         with self.assertRaises(StopIteration):
             utils.process_sqs_queue(
-                queue_url='https://nowh.ere/')
+                queue_url='https://sqs.nowh-ere.aws.com/123456789/')
 
         client.assert_called()
+        client.assert_called_with(
+            'sqs', region_name='nowh-ere'
+        )
         process_fxa_event.assert_called()
         # The 'None' in messages would cause an exception, but it should be
         # handled, and the remaining message(s) still processed.
@@ -146,7 +149,8 @@ class TestProcessSqsQueue(TestCase):
             [mock.call('foo'), mock.call('bar'), mock.call('thisonetoo')])
         delete_mock.assert_called_once()  # Receipt handle is present in foo.
         delete_mock.assert_called_with(
-            QueueUrl='https://nowh.ere/', ReceiptHandle='$$$')
+            QueueUrl='https://sqs.nowh-ere.aws.com/123456789/',
+            ReceiptHandle='$$$')
 
 
 def totimestamp(datetime_obj):

--- a/src/olympia/accounts/tests/test_utils.py
+++ b/src/olympia/accounts/tests/test_utils.py
@@ -122,14 +122,18 @@ def test_redirect_for_login(default_fxa_login_url):
 
 class TestProcessSqsQueue(TestCase):
 
+    @mock.patch('boto3._get_default_session')
     @mock.patch('olympia.accounts.utils.process_fxa_event')
     @mock.patch('boto3.client')
-    def test_process_sqs_queue(self, client, process_fxa_event):
+    def test_process_sqs_queue(self, client, process_fxa_event, get_session):
         messages = [
             {'Body': 'foo', 'ReceiptHandle': '$$$'}, {'Body': 'bar'}, None,
             {'Body': 'thisonetoo'}]
         sqs = mock.MagicMock(
             **{'receive_message.side_effect': [{'Messages': messages}]})
+        session_mock = mock.MagicMock(
+            **{'get_available_regions.side_effect': ['nowh-ere']})
+        get_session.return_value = session_mock
         delete_mock = mock.MagicMock()
         sqs.delete_message = delete_mock
         client.return_value = sqs

--- a/src/olympia/accounts/utils.py
+++ b/src/olympia/accounts/utils.py
@@ -114,6 +114,11 @@ def process_sqs_queue(queue_url):
     log.info('Processing account events from %s', queue_url)
     try:
         region = queue_url.split('.')[1]
+        available_regions = (boto3._get_default_session()
+                             .get_available_regions('sqs'))
+        if region not in available_regions:
+            log.error('SQS misconfigured, expected region, got %s from %s' % (
+                region, queue_url))
         # Connect to the SQS queue.
         # Credentials are specified in EC2 as an IAM role on prod/stage/dev.
         # If you're testing locally see boto3 docs for how to specify:

--- a/src/olympia/accounts/utils.py
+++ b/src/olympia/accounts/utils.py
@@ -113,11 +113,12 @@ def process_sqs_queue(queue_url):
     log = getLogger('accounts.sqs')
     log.info('Processing account events from %s', queue_url)
     try:
+        region = queue_url.split('.')[1]
         # Connect to the SQS queue.
         # Credentials are specified in EC2 as an IAM role on prod/stage/dev.
         # If you're testing locally see boto3 docs for how to specify:
         # http://boto3.readthedocs.io/en/latest/guide/configuration.html
-        sqs = boto3.client('sqs')
+        sqs = boto3.client('sqs', region_name=region)
         # Poll for messages indefinitely.
         while True:
             response = sqs.receive_message(


### PR DESCRIPTION
fixes #7973