### PR TITLE
Update logger name to reflect changes in PR #7880

### DIFF
--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -111,7 +111,7 @@ CELERY_RESULT_BACKEND = env('CELERY_RESULT_BACKEND')
 LOG_LEVEL = logging.DEBUG
 
 LOGGING['loggers'].update({
-    'adi.updatecountsfromfile': {'level': logging.INFO},
+    'adi.updatecounts': {'level': logging.INFO},
     'amqp': {'level': logging.WARNING},
     'raven': {'level': logging.WARNING},
     'requests': {'level': logging.WARNING},


### PR DESCRIPTION
The logger was renamed in PR#7880. Since we default to `DEBUG` it is producing a lot of logs. 

r? @bqbn