### PR TITLE
Make version deletion modal dialog much more red.

### DIFF
--- a/src/olympia/devhub/templates/devhub/versions/list.html
+++ b/src/olympia/devhub/templates/devhub/versions/list.html
@@ -285,7 +285,7 @@
         <li id="del-files"></li>
         <li id="del-reviews"></li>
       </ul>
-      <p>
+      <p class="highlight warning">
       {% trans %}
         <strong>Important:</strong>
         Once a version has been deleted, you may not upload a new

--- a/static/css/legacy/main.css
+++ b/static/css/legacy/main.css
@@ -1445,6 +1445,12 @@ form.favorite {
     float: right;
 }
 
+.highlight.warning {
+    /* @button-red-dark in impala/lib */
+    background-color: #bc2b1a;;
+    color: #fff;
+}
+
 /* @end */
 
 /* @group Top search and cat bar */


### PR DESCRIPTION
The warnings are really not so easy to see and don't stand out enough
imho. Let's make 'em a bit more red.

Fixes #7984

![screenshot from 2018-04-06 15-13-47](https://user-images.githubusercontent.com/139033/38423103-3a8b37b4-39ad-11e8-9cd5-fe0fb621fe0b.png)

