### PR TITLE
Add a unique request id to every request in the system.

### DIFF
--- a/src/olympia/amo/middleware.py
+++ b/src/olympia/amo/middleware.py
@@ -7,6 +7,7 @@ import contextlib
 import re
 import socket
 import urllib
+import uuid
 
 from django.conf import settings
 from django.contrib.auth.middleware import AuthenticationMiddleware
@@ -249,3 +250,24 @@ class ScrubRequestOnException(object):
             # Clearing out all cookies in request.META. They will already
             # be sent with request.COOKIES.
             request.META['HTTP_COOKIE'] = '******'
+
+
+class RequestIdMiddleware(object):
+    """Middleware that adds a unique request-id to every incoming request.
+
+    This can be used to track a request across different system layers,
+    e.g to correlate logs with sentry exceptions.
+
+    We are exposing this request id in the `X-AMO-Request-ID` response header.
+    """
+
+    def process_request(self, request):
+        request.request_id = uuid.uuid4().hex
+
+    def process_response(self, request, response):
+        request_id = getattr(request, 'request_id', None)
+
+        if request_id:
+            response['X-AMO-Request-ID'] = request.request_id
+
+        return response

--- a/src/olympia/amo/tests/test_middleware.py
+++ b/src/olympia/amo/tests/test_middleware.py
@@ -8,7 +8,8 @@ from mock import patch
 from pyquery import PyQuery as pq
 
 from olympia.amo.middleware import (
-    AuthenticationMiddlewareWithoutAPI, ScrubRequestOnException)
+    AuthenticationMiddlewareWithoutAPI, ScrubRequestOnException,
+    RequestIdMiddleware)
 from olympia.amo.tests import TestCase
 from olympia.amo.urlresolvers import reverse
 from olympia.zadmin.models import Config
@@ -109,3 +110,16 @@ def test_hide_password_middleware():
     assert request.POST['x'] == '1'
     assert request.POST['password'] == '******'
     assert request.POST['password2'] == '******'
+
+
+def test_request_id_middleware(client):
+    """Test that we add a request id to every response"""
+    response = client.get(reverse('home'))
+    assert response.status_code == 200
+    assert isinstance(response['X-AMO-Request-ID'], basestring)
+
+    # Test that we set `request.request_id` too
+
+    request = RequestFactory().get('/')
+    RequestIdMiddleware().process_request(request)
+    assert request.request_id

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -481,6 +481,7 @@ MIDDLEWARE_CLASSES = (
     'olympia.access.middleware.UserAndAddrMiddleware',
 
     'olympia.amo.middleware.ScrubRequestOnException',
+    'olympia.amo.middleware.RequestIdMiddleware',
 )
 
 # Auth


### PR DESCRIPTION
This adds only very little overhead but allows us to track requests
through the system.

In future additions/enhancements, this can be used to:

 * correlate sentry errors with kibana logs
 * easier correlation between performance related logs (database, cache
 queries, etc) and load-test logs (locust requests)

Fixes #8033