### PR TITLE
Do not adjust adu when total downloads are lower.

### DIFF
--- a/src/olympia/addons/cron.py
+++ b/src/olympia/addons/cron.py
@@ -67,13 +67,7 @@ def _update_addon_average_daily_users(data, **kw):
             task_log.debug(m % (count, pk))
             continue
 
-        if (count - addon.total_downloads) > 10000:
-            # Adjust ADU to equal total downloads so bundled add-ons don't
-            # skew the results when sorting by users.
-            task_log.info('Readjusted ADU count for addon %s' % addon.slug)
-            addon.update(average_daily_users=addon.total_downloads)
-        else:
-            addon.update(average_daily_users=count)
+        addon.update(average_daily_users=count)
 
 
 def update_addon_download_totals():

--- a/src/olympia/addons/tests/test_cron.py
+++ b/src/olympia/addons/tests/test_cron.py
@@ -200,17 +200,6 @@ class AvgDailyUserCountTestCase(TestCase):
         super(AvgDailyUserCountTestCase, self).setUp()
         self.create_switch('local-statistics-processing')
 
-    def test_adu_is_adjusted_in_cron(self):
-        addon = Addon.objects.get(pk=3615)
-        assert addon.average_daily_users == 6000000
-        assert \
-            addon.average_daily_users > addon.total_downloads + 10000, \
-            ('Unexpected ADU count. ADU of %d not greater than %d' % (
-                addon.average_daily_users, addon.total_downloads + 10000))
-        cron._update_addon_average_daily_users([(3615, 6000000)])
-        addon = Addon.objects.get(pk=3615)
-        assert addon.average_daily_users == addon.total_downloads
-
     def test_13_day_window(self):
         addon = Addon.objects.get(pk=3615)
 


### PR DESCRIPTION
Fixes #6397

Waiting for confirmation when we can tackle this if this doesn't need any communications with developers and users we can just land this.

All values will be recalculated once the respective cron runs so there's no migration needed.