### PR TITLE
Use same timestamp for all rejects in 'reject multiple versions'

### DIFF
--- a/src/olympia/activity/models.py
+++ b/src/olympia/activity/models.py
@@ -466,40 +466,41 @@ class ActivityLog(ModelBase):
         from olympia import core
 
         user = kw.get('user', core.get_user())
+        created = kw.get('created', datetime.now())
 
         if not user:
             log.warning('Activity log called with no user: %s' % action.id)
             return
 
-        al = ActivityLog(user=user, action=action.id)
+        al = ActivityLog(user=user, action=action.id, created=created)
         al.arguments = args
         if 'details' in kw:
             al.details = kw['details']
         al.save()
 
         if 'details' in kw and 'comments' in al.details:
-            CommentLog(comments=al.details['comments'], activity_log=al).save()
+            CommentLog(comments=al.details['comments'], activity_log=al, created=created).save()
 
         for arg in args:
             if isinstance(arg, tuple):
                 if arg[0] == Addon:
-                    AddonLog(addon_id=arg[1], activity_log=al).save()
+                    AddonLog(addon_id=arg[1], activity_log=al, created=created).save()
                 elif arg[0] == Version:
-                    VersionLog(version_id=arg[1], activity_log=al).save()
+                    VersionLog(version_id=arg[1], activity_log=al, created=created).save()
                 elif arg[0] == UserProfile:
-                    UserLog(user_id=arg[1], activity_log=al).save()
+                    UserLog(user_id=arg[1], activity_log=al, created=created).save()
                 elif arg[0] == Group:
-                    GroupLog(group_id=arg[1], activity_log=al).save()
+                    GroupLog(group_id=arg[1], activity_log=al, created=created).save()
             elif isinstance(arg, Addon):
-                AddonLog(addon=arg, activity_log=al).save()
+                AddonLog(addon=arg, activity_log=al, created=created).save()
             elif isinstance(arg, Version):
-                VersionLog(version=arg, activity_log=al).save()
+                VersionLog(version=arg, activity_log=al, created=created).save()
             elif isinstance(arg, UserProfile):
                 # Index by any user who is mentioned as an argument.
-                UserLog(activity_log=al, user=arg).save()
+                UserLog(activity_log=al, user=arg, created=created).save()
             elif isinstance(arg, Group):
-                GroupLog(group=arg, activity_log=al).save()
+                GroupLog(group=arg, activity_log=al, created=created).save()
 
         # Index by every user
-        UserLog(activity_log=al, user=user).save()
+        UserLog(activity_log=al, user=user, created=created).save()
         return al

--- a/src/olympia/activity/models.py
+++ b/src/olympia/activity/models.py
@@ -466,41 +466,73 @@ class ActivityLog(ModelBase):
         from olympia import core
 
         user = kw.get('user', core.get_user())
-        created = kw.get('created', datetime.now())
 
         if not user:
             log.warning('Activity log called with no user: %s' % action.id)
             return
 
-        al = ActivityLog(user=user, action=action.id, created=created)
+        al = ActivityLog(user=user, action=action.id)
         al.arguments = args
         if 'details' in kw:
             al.details = kw['details']
         al.save()
 
+        if 'created' in kw:
+            al.update(created=kw.get('created'))
+
         if 'details' in kw and 'comments' in al.details:
-            CommentLog(comments=al.details['comments'], activity_log=al, created=created).save()
+            l = CommentLog(comments=al.details['comments'], activity_log=al)
+            l.save()
+            if 'created' in kw:
+                l.update(created=kw.get('created'))
 
         for arg in args:
             if isinstance(arg, tuple):
                 if arg[0] == Addon:
-                    AddonLog(addon_id=arg[1], activity_log=al, created=created).save()
+                    l = AddonLog(addon_id=arg[1], activity_log=al)
+                    l.save()
+                    if 'created' in kw:
+                        l.update(created=kw.get('created'))
                 elif arg[0] == Version:
-                    VersionLog(version_id=arg[1], activity_log=al, created=created).save()
+                    l = VersionLog(version_id=arg[1], activity_log=al)
+                    l.save()
+                    if 'created' in kw:
+                        l.update(created=kw.get('created'))
                 elif arg[0] == UserProfile:
-                    UserLog(user_id=arg[1], activity_log=al, created=created).save()
+                    l = UserLog(user_id=arg[1], activity_log=al)
+                    l.save()
+                    if 'created' in kw:
+                        l.update(created=kw.get('created'))
                 elif arg[0] == Group:
-                    GroupLog(group_id=arg[1], activity_log=al, created=created).save()
+                    l = GroupLog(group_id=arg[1], activity_log=al)
+                    l.save()
+                    if 'created' in kw:
+                        l.update(created=kw.get('created'))
             elif isinstance(arg, Addon):
-                AddonLog(addon=arg, activity_log=al, created=created).save()
+                l = AddonLog(addon=arg, activity_log=al)
+                l.save()
+                if 'created' in kw:
+                    l.update(created=kw.get('created'))
             elif isinstance(arg, Version):
-                VersionLog(version=arg, activity_log=al, created=created).save()
+                l = VersionLog(version=arg, activity_log=al)
+                l.save()
+                if 'created' in kw:
+                    l.update(created=kw.get('created'))
             elif isinstance(arg, UserProfile):
                 # Index by any user who is mentioned as an argument.
-                UserLog(activity_log=al, user=arg, created=created).save()
+                l = UserLog(activity_log=al, user=arg)
+                l.save()
+                if 'created' in kw:
+                    l.update(created=kw.get('created'))
             elif isinstance(arg, Group):
-                GroupLog(group=arg, activity_log=al, created=created).save()
+                l = GroupLog(group=arg, activity_log=al)
+                l.save()
+                if 'created' in kw:
+                    l.update(created=kw.get('created'))
 
         # Index by every user
-        UserLog(activity_log=al, user=user, created=created).save()
+        l = UserLog(activity_log=al, user=user)
+        l.save()
+        if 'created' in kw:
+            l.update(created=kw.get('created'))
         return al

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -1146,6 +1146,10 @@ class TestReviewHelper(TestCase):
         assert self.check_log_count(amo.LOG.REJECT_VERSION.id) == 2
         assert self.check_log_count(amo.LOG.REJECT_CONTENT.id) == 0
 
+        logs = (ActivityLog.objects.for_addons(self.addon)
+                                   .filter(action=amo.LOG.REJECT_VERSION.id))
+        assert logs[0].created == logs[1].created
+
         # Check points awarded.
         self._check_score(amo.REVIEWED_EXTENSION_HIGH_RISK)
 

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -505,7 +505,8 @@ class ReviewBase(object):
             file.status = status
             file.save()
 
-    def log_action(self, action, version=None, files=None):
+    def log_action(self, action, version=None, files=None,
+                   timestamp=datetime.now()):
         details = {'comments': self.data['comments'],
                    'reviewtype': self.review_type}
         if files is None and self.files:
@@ -520,7 +521,7 @@ class ReviewBase(object):
         else:
             args = (self.addon,)
 
-        kwargs = {'user': self.user, 'created': datetime.now(),
+        kwargs = {'user': self.user, 'created': timestamp,
                   'details': details}
         self.log_entry = ActivityLog.create(action, *args, **kwargs)
 
@@ -776,10 +777,12 @@ class ReviewBase(object):
         self.files = None
         action_id = (amo.LOG.REJECT_CONTENT if self.content_review_only
                      else amo.LOG.REJECT_VERSION)
+        timestamp = datetime.now()
         for version in self.data['versions']:
             files = version.files.all()
             self.set_files(amo.STATUS_DISABLED, files, hide_disabled_file=True)
-            self.log_action(action_id, version=version, files=files)
+            self.log_action(action_id, version=version, files=files,
+                            timestamp=timestamp)
         self.addon.update_status()
         self.data['version_numbers'] = u', '.join(
             unicode(v.version) for v in self.data['versions'])

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -506,7 +506,7 @@ class ReviewBase(object):
             file.save()
 
     def log_action(self, action, version=None, files=None,
-                   timestamp=datetime.now()):
+                   timestamp=None):
         details = {'comments': self.data['comments'],
                    'reviewtype': self.review_type}
         if files is None and self.files:
@@ -520,6 +520,8 @@ class ReviewBase(object):
             args = (self.addon, version)
         else:
             args = (self.addon,)
+        if timestamp is None:
+            timestamp = datetime.now()
 
         kwargs = {'user': self.user, 'created': timestamp,
                   'details': details}


### PR DESCRIPTION
I wanted to pass `created` in the constructor, but that's not possible, because https://docs.djangoproject.com/en/1.8/ref/models/fields/#django.db.models.DateField.auto_now_add
Then I wanted to override the `created` field in the `ActivityLog` class but that's not possible in Django 1.8, see https://docs.djangoproject.com/en/1.8/topics/db/models/#field-name-hiding-is-not-permitted