### PR TITLE
Align theme update JSON with theme pages on AMO

### DIFF
--- a/services/theme_update.py
+++ b/services/theme_update.py
@@ -149,8 +149,8 @@ class ThemeUpdate(object):
             'previewURL': self.image_url('preview.png'),
             'iconURL': self.image_url('icon.png'),
             'dataurl': self.base64_icon(row['addon_id']),
-            'accentcolor': '#%s' % accent if accent else None,
-            'textcolor': '#%s' % text if text else None,
+            'accentcolor': '#%s' % accent if accent else "#",
+            'textcolor': '#%s' % text if text else "#",
             'updateURL': self.locale_url(settings.VAMO_URL,
                                          '/themes/update-check/' + id_),
             # 04-25-2013: Bumped for GP migration so we get new `updateURL`s.

--- a/src/olympia/addons/tests/test_theme_update.py
+++ b/src/olympia/addons/tests/test_theme_update.py
@@ -132,6 +132,15 @@ class TestThemeUpdate(TestCase):
         self.check_good(
             json.loads(self.get_update('en-US', 813, 'src=gp').get_json()))
 
+    def test_get_json_missing_colors(self):
+        addon = Addon.objects.get()
+        addon.persona.textcolor = None
+        addon.persona.accentcolor = None
+        addon.persona.save()
+        data = json.loads(self.get_update('en-US', addon.pk).get_json())
+        assert data['textcolor'] == '#'
+        assert data['accentcolor'] == '#'
+
     def test_blank_footer_url(self):
         addon = Addon.objects.get()
         persona = addon.persona


### PR DESCRIPTION
For the same theme data, the theme install page on AMO provides `"#"` as accent/textcolor strings, if those properties are not present. The fact that the update service then provides `null` is breaking themes in Firefox 60 and later. It seems sensible to align the two views of what is essentially the same data.

@eviljeff , can you confirm if there are current tests covering this part of the server? I didn't see any, but maybe I didn't look in the right place...