### PR TITLE
Validation of collection name. Whitespace only strings are invalid.  

### DIFF
--- a/src/olympia/bandwagon/serializers.py
+++ b/src/olympia/bandwagon/serializers.py
@@ -45,6 +45,9 @@ class CollectionSerializer(serializers.ModelSerializer):
         if isinstance(value, dict):
             return {locale: self.validate_name(sub_value)
                     for locale, sub_value in value.iteritems()}
+        if value.strip() == u'':
+            raise serializers.ValidationError(
+                ugettext(u'Name cannot be empty.'))
         if DeniedName.blocked(value):
             raise serializers.ValidationError(
                 ugettext(u'This name cannot be used.'))

--- a/src/olympia/bandwagon/tests/test_views.py
+++ b/src/olympia/bandwagon/tests/test_views.py
@@ -1574,6 +1574,22 @@ class CollectionViewSetDataMixin(object):
         response = self.send()
         assert response.status_code == 401
 
+    def test_update_name_invalid(self):
+        self.client.login_api(self.user)
+        data = dict(self.data)
+        data.update(name=u'   ')
+        response = self.send(data=data)
+        assert response.status_code == 400
+        assert json.loads(response.content) == {
+            'name': ['Name cannot be empty.']}
+
+        # Passing a dict of localised values
+        data.update(name={'en-US': u'   '})
+        response = self.send(data=data)
+        assert response.status_code == 400
+        assert json.loads(response.content) == {
+            'name': ['Name cannot be empty.']}
+
     def test_biography_no_links(self):
         self.client.login_api(self.user)
         data = dict(self.data)


### PR DESCRIPTION
Fixes #7936

I added a test to make sure that names composed of white space only are not accepted as a valid collection name.
Then I added the proper, simple, logic to handle this.

Tests are passing locally.