### PR TITLE
solving issue #8071

### DIFF
--- a/src/olympia/templates/impala/user_login.html
+++ b/src/olympia/templates/impala/user_login.html
@@ -11,7 +11,7 @@
         {% endfor %}
       {% endif %}
       <li class="nomenu logout">
-        <a href="{{ url('users.logout') }}">{{ _('Log out') }}</a>
+        <a href="{{ url('users.logout') }}?to={{ url('devhub.index') }}">{{ _('Log out') }}</a>
       </li>
     </ul>
   </li>


### PR DESCRIPTION
Fixes #8071 
When signing out of /developers/addons the user should land on DevHub homepage instead of AMO
Please delete anything that isn't relevant to your patch.

