### PR TITLE
Solving issue #8071

### DIFF
--- a/src/olympia/devhub/templates/devhub/addons/dashboard.html
+++ b/src/olympia/devhub/templates/devhub/addons/dashboard.html
@@ -1,6 +1,10 @@
 {% extends "devhub/base_impala.html" %}
 
 
+{% block user_logout_link %}
+  <a href="{{ url('users.logout') }}?to={{ url('devhub.index') }}">{{ _('Log out') }}</a>
+{% endblock %}
+
 {% set title = _('Manage My Submissions') %}
 
 {% block title %}{{ dev_page_title(title) }}{% endblock %}

--- a/src/olympia/templates/impala/user_login.html
+++ b/src/olympia/templates/impala/user_login.html
@@ -11,7 +11,9 @@
         {% endfor %}
       {% endif %}
       <li class="nomenu logout">
+        {% block user_logout_link %}
         <a href="{{ url('users.logout') }}">{{ _('Log out') }}</a>
+        {% endblock %}
       </li>
     </ul>
   </li>


### PR DESCRIPTION
Fixes #8071
When signing out of /developers/addons the user should land on DevHub homepage instead of AMO.