### PR TITLE
Avoid server error on duplicate public slugs.

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -58,7 +58,7 @@ from . import signals
 log = olympia.core.logger.getLogger('z.addons')
 
 
-MAX_SLUG_INCREMENT = 99
+MAX_SLUG_INCREMENT = 999
 SLUG_INCREMENT_SUFFIXES = set(range(1, MAX_SLUG_INCREMENT + 1))
 
 

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -17,6 +17,7 @@ import pytest
 from mock import Mock, patch
 
 from olympia import amo, core
+from olympia.addons import models as addons_models
 from olympia.activity.models import ActivityLog, AddonLog
 from olympia.addons.models import (
     Addon, AddonApprovalsCounter, AddonCategory, AddonDependency,
@@ -160,6 +161,9 @@ class TestCleanSlug(TestCase):
         b.clean_slug()
         assert b.slug.startswith('some-spaces-and'), b.slug
 
+    @patch.object(addons_models, 'MAX_SLUG_INCREMENT', 99)
+    @patch.object(
+        addons_models, 'SLUG_INCREMENT_SUFFIXES', set(range(1, 99 + 1)))
     def test_clean_slug_worst_case_scenario(self):
         long_slug = 'this_is_a_very_long_slug_that_is_longer_than_thirty_chars'
 


### PR DESCRIPTION
See https://sentry.prod.mozaws.net/operations/olympia-prod/issues/2870827/ - and that is a relict from the chrome add-ons -> firefox conversion stuff that was going on end of last year where tons and tons of duplicate add-ons were created.

We fixed that for unlisted add-ons but only fixed it for new, unlisted, uploads and never converted older unlisted add-ons to new slugs. So we have to increase the amount of public duplicate slugs we allow to avoid server errors. Unlisted slugs are always random so this should fix the issue, mostly.

Fixes #7990