### PR TITLE
Make signing API always ignore cache-machine

### DIFF
--- a/src/olympia/signing/views.py
+++ b/src/olympia/signing/views.py
@@ -14,7 +14,7 @@ import olympia.core.logger
 from olympia import amo
 from olympia.access import acl
 from olympia.addons.models import Addon
-from olympia.amo.decorators import use_master
+from olympia.amo.decorators import write
 from olympia.api.authentication import JWTKeyAuthentication
 from olympia.devhub.views import handle_upload
 from olympia.files.models import FileUpload
@@ -119,6 +119,7 @@ class VersionView(APIView):
         return Response(FileUploadSerializer(file_upload).data,
                         status=status_code)
 
+    @write
     def handle_upload(self, request, addon, version_string, guid=None):
         if 'upload' in request.FILES:
             filedata = request.FILES['upload']
@@ -209,7 +210,7 @@ class VersionView(APIView):
 
         return file_upload, created
 
-    @use_master
+    @write
     @with_addon()
     def get(self, request, addon, version_string, uuid=None, guid=None):
         file_upload_qs = FileUpload.objects.filter(
@@ -244,6 +245,6 @@ class SignedFile(APIView):
     authentication_classes = [JWTKeyAuthentication]
     permission_classes = [IsAuthenticated]
 
-    @use_master
+    @write
     def get(self, request, file_id):
         return version_views.download_file(request, file_id)


### PR DESCRIPTION
Fix #8136 (hopefully)