### PR TITLE
Serve JSON update manifests instead of RDF

### DIFF
--- a/services/update.py
+++ b/services/update.py
@@ -1,3 +1,4 @@
+import json
 import sys
 
 from django.utils.encoding import force_bytes
@@ -24,51 +25,6 @@ from utils import (
 
 # Go configure the log.
 log_configure()
-
-good_rdf = """<?xml version="1.0"?>
-<RDF:RDF xmlns:RDF="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-         xmlns:em="http://www.mozilla.org/2004/em-rdf#">
-    <RDF:Description about="urn:mozilla:%(type)s:%(guid)s">
-        <em:updates>
-            <RDF:Seq>
-                <RDF:li resource="urn:mozilla:%(type)s:%(guid)s:%(version)s"/>
-            </RDF:Seq>
-        </em:updates>
-    </RDF:Description>
-
-    <RDF:Description about="urn:mozilla:%(type)s:%(guid)s:%(version)s">
-        <em:version>%(version)s</em:version>
-        <em:targetApplication>
-            <RDF:Description>
-                <em:id>%(appguid)s</em:id>
-                <em:minVersion>%(min)s</em:minVersion>
-                <em:maxVersion>%(max)s</em:maxVersion>
-                <em:updateLink>%(url)s</em:updateLink>
-                %(if_update)s
-                %(if_hash)s
-            </RDF:Description>
-        </em:targetApplication>
-    </RDF:Description>
-</RDF:RDF>"""
-
-
-bad_rdf = """<?xml version="1.0"?>
-<RDF:RDF xmlns:RDF="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-         xmlns:em="http://www.mozilla.org/2004/em-rdf#">
-</RDF:RDF>"""
-
-
-no_updates_rdf = """<?xml version="1.0"?>
-<RDF:RDF xmlns:RDF="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-         xmlns:em="http://www.mozilla.org/2004/em-rdf#">
-    <RDF:Description about="urn:mozilla:%(type)s:%(guid)s">
-        <em:updates>
-            <RDF:Seq>
-            </RDF:Seq>
-        </em:updates>
-    </RDF:Description>
-</RDF:RDF>"""
-
 
 error_log = olympia.core.logger.getLogger('z.services')
 
@@ -135,14 +91,19 @@ class Update(object):
 
         sql = ["""
             SELECT
-                addons.guid as guid, addons.addontype_id as type,
-                addons.inactive as disabled_by_user, appmin.version as min,
-                appmax.version as max, files.id as file_id,
-                files.status as file_status, files.hash,
-                files.filename, versions.id as version_id,
-                files.datestatuschanged as datestatuschanged,
+                addons.guid as guid,
+                addons.addontype_id as type,
+                addons.inactive as disabled_by_user,
+                appmin.version as min,
+                appmax.version as max,
+                files.id as file_id,
+                files.status as file_status,
+                files.hash,
+                files.filename,
+                versions.id as version_id,
                 files.strict_compatibility as strict_compat,
-                versions.releasenotes, versions.version as version
+                versions.releasenotes,
+                versions.version as version
             FROM versions
             INNER JOIN addons
                 ON addons.id = versions.addon_id AND addons.id = %(id)s
@@ -210,19 +171,6 @@ class Update(object):
         else:  # Not defined or 'strict'.
             sql.append('AND appmax.version_int >= %(version_int)s ')
 
-        # Special case for bug 1031516.
-        if data['guid'] == 'firefox-hotfix@mozilla.org':
-            app_version = data['version_int']
-            hotfix_version = data['version']
-            if version_int('10') <= app_version <= version_int('16.0.1'):
-                if hotfix_version < '20121019.01':
-                    sql.append("AND versions.version = '20121019.01' ")
-                elif hotfix_version < '20130826.01':
-                    sql.append("AND versions.version = '20130826.01' ")
-            elif version_int('16.0.2') <= app_version <= version_int('24.*'):
-                if hotfix_version < '20130826.01':
-                    sql.append("AND versions.version = '20130826.01' ")
-
         sql.append('ORDER BY versions.id DESC LIMIT 1;')
 
         self.cursor.execute(''.join(sql), data)
@@ -232,8 +180,7 @@ class Update(object):
             row = dict(zip([
                 'guid', 'type', 'disabled_by_user', 'min', 'max',
                 'file_id', 'file_status', 'hash', 'filename', 'version_id',
-                'datestatuschanged', 'strict_compat', 'releasenotes',
-                'version'],
+                'strict_compat', 'releasenotes', 'version'],
                 list(result)))
             row['type'] = base.ADDON_SLUGS_UPDATE[row['type']]
             row['url'] = get_cdn_url(data['id'], row)
@@ -243,47 +190,62 @@ class Update(object):
 
         return False
 
-    def get_bad_rdf(self):
-        return bad_rdf
-
-    def get_rdf(self):
+    def get_output(self):
         if self.is_valid():
             if self.get_update():
-                rdf = self.get_good_rdf()
+                output = self.get_success_output()
             else:
-                rdf = self.get_no_updates_rdf()
+                output = self.get_no_updates_output()
         else:
-            rdf = self.get_bad_rdf()
+            output = self.get_error_output()
         self.cursor.close()
         if self.conn:
             self.conn.close()
-        return rdf
+        return json.dumps(output)
 
-    def get_no_updates_rdf(self):
-        name = base.ADDON_SLUGS_UPDATE[self.data['type']]
-        return no_updates_rdf % ({'guid': self.data['guid'], 'type': name})
+    def get_error_output(self):
+        return {}
 
-    def get_good_rdf(self):
+    def get_no_updates_output(self):
+        return {
+            'addons': {
+                self.data['guid']: {
+                    'updates': []
+                }
+            }
+        }
+
+    def get_success_output(self):
         data = self.data['row']
-        data['if_hash'] = ''
+        update = {
+            'version': data['version'],
+            'update_link': data['url'],
+            'applications': {
+                'gecko': {
+                    'strict_min_version': data['min']
+                }
+            }
+        }
+        if data['strict_compat']:
+            update['applications']['gecko']['strict_max_version'] = data['max']
         if data['hash']:
-            data['if_hash'] = ('<em:updateHash>%s</em:updateHash>' %
-                               data['hash'])
-
-        data['if_update'] = ''
+            update['update_hash'] = data['hash']
         if data['releasenotes']:
-            data['if_update'] = ('<em:updateInfoURL>%s%s%s/%%APP_LOCALE%%/'
-                                 '</em:updateInfoURL>' %
-                                 (settings.SITE_URL, '/versions/updateInfo/',
-                                  data['version_id']))
-
-        return good_rdf % data
+            update['update_info_url'] = '%s%s%s/%%APP_LOCALE%%/' % (
+                settings.SITE_URL, '/versions/updateInfo/', data['version_id'])
+        return {
+            'addons': {
+                self.data['guid']: {
+                    'updates': [update]
+                }
+            }
+        }
 
     def format_date(self, secs):
         return '%s GMT' % formatdate(time() + secs)[:25]
 
     def get_headers(self, length):
-        return [('Content-Type', 'text/xml'),
+        return [('Content-Type', 'application/json'),
                 ('Cache-Control', 'public, max-age=3600'),
                 ('Last-Modified', self.format_date(0)),
                 ('Expires', self.format_date(3600)),

--- a/services/update.py
+++ b/services/update.py
@@ -264,7 +264,7 @@ def application(environ, start_response):
         compat_mode = data.pop('compatMode', 'strict')
         try:
             update = Update(data, compat_mode)
-            output = force_bytes(update.get_rdf())
+            output = force_bytes(update.get_output())
             start_response(status, update.get_headers(len(output)))
         except Exception:
             log_exception(data)

--- a/src/olympia/addons/tests/test_update.py
+++ b/src/olympia/addons/tests/test_update.py
@@ -7,8 +7,6 @@ from email import utils
 
 from django.db import connection
 
-from freezegun import freeze_time
-
 from services import update
 
 from olympia import amo
@@ -419,7 +417,6 @@ class TestDefaultToCompat(VersionCheckMixin, TestCase):
                     expected['-'.join([version, mode])]
                 )
 
-    @freeze_time('2018-05-04 11:27:00 UTC')
     def test_application(self):
         # Basic test making sure application() is returning the output of
         # Update.get_output(). Have to mock Update(): otherwise, the real

--- a/src/olympia/addons/tests/test_update.py
+++ b/src/olympia/addons/tests/test_update.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import json
+
 from datetime import datetime, timedelta
 from email import utils
 
@@ -17,10 +19,10 @@ from olympia.versions.models import ApplicationsVersions, Version
 
 class VersionCheckMixin(object):
 
-    def get(self, data):
-        up = update.Update(data)
-        up.cursor = connection.cursor()
-        return up
+    def get_update_instance(self, data):
+        instance = update.Update(data)
+        instance.cursor = connection.cursor()
+        return instance
 
 
 class TestDataValidate(VersionCheckMixin, TestCase):
@@ -39,72 +41,72 @@ class TestDataValidate(VersionCheckMixin, TestCase):
     def test_app_os(self):
         data = self.good_data.copy()
         data['appOS'] = 'something %s penguin' % amo.PLATFORM_LINUX.api_name
-        form = self.get(data)
-        assert form.is_valid()
-        assert form.data['appOS'] == amo.PLATFORM_LINUX.id
+        instance = self.get_update_instance(data)
+        assert instance.is_valid()
+        assert instance.data['appOS'] == amo.PLATFORM_LINUX.id
 
     def test_app_version_fails(self):
         data = self.good_data.copy()
         del data['appID']
-        form = self.get(data)
-        assert not form.is_valid()
+        instance = self.get_update_instance(data)
+        assert not instance.is_valid()
 
     def test_app_version_wrong(self):
         data = self.good_data.copy()
         data['appVersion'] = '67.7'
-        form = self.get(data)
+        instance = self.get_update_instance(data)
         # If you pass through the wrong version that's fine
         # you will just end up with no updates because your
         # version_int will be out.
-        assert form.is_valid()
+        assert instance.is_valid()
 
     def test_app_version(self):
         data = self.good_data.copy()
-        form = self.get(data)
-        assert form.is_valid()
-        assert form.data['version_int'] == 3070000001000
+        instance = self.get_update_instance(data)
+        assert instance.is_valid()
+        assert instance.data['version_int'] == 3070000001000
 
     def test_sql_injection(self):
         data = self.good_data.copy()
         data['id'] = "'"
-        up = self.get(data)
-        assert not up.is_valid()
+        instance = self.get_update_instance(data)
+        assert not instance.is_valid()
 
     def test_inactive(self):
         addon = Addon.objects.get(pk=3615)
         addon.update(disabled_by_user=True)
 
-        up = self.get(self.good_data)
-        assert not up.is_valid()
+        instance = self.get_update_instance(self.good_data)
+        assert not instance.is_valid()
 
     def test_soft_deleted(self):
         addon = Addon.objects.get(pk=3615)
         addon.update(status=amo.STATUS_DELETED)
 
-        up = self.get(self.good_data)
-        assert not up.is_valid()
+        instance = self.get_update_instance(self.good_data)
+        assert not instance.is_valid()
 
     def test_disabled(self):
         addon = Addon.objects.get(pk=3615)
         addon.update(status=amo.STATUS_DISABLED)
 
-        up = self.get(self.good_data)
-        assert not up.is_valid()
+        instance = self.get_update_instance(self.good_data)
+        assert not instance.is_valid()
 
     def test_no_version(self):
         data = self.good_data.copy()
         del data['version']
-        up = self.get(data)
-        assert up.is_valid()
+        instance = self.get_update_instance(data)
+        assert instance.is_valid()
 
     def test_unlisted_addon(self):
         """Add-ons with only unlisted versions are valid, they just don't
-        receive any updates (See TestLookup.test_no_unlisted below)."""
+        receive any updates (See TestLookinstance.test_no_unlisted below)."""
         addon = Addon.objects.get(pk=3615)
         self.make_addon_unlisted(addon)
 
-        up = self.get(self.good_data)
-        assert up.is_valid()
+        instance = self.get_update_instance(self.good_data)
+        assert instance.is_valid()
 
 
 class TestLookup(VersionCheckMixin, TestCase):
@@ -123,7 +125,7 @@ class TestLookup(VersionCheckMixin, TestCase):
         self.version_1_2_1 = 112396
         self.version_1_2_2 = 115509
 
-    def get(self, *args):
+    def get_update_instance(self, *args):
         data = {
             'id': self.addon.guid,
             'appID': args[2].guid,
@@ -134,12 +136,12 @@ class TestLookup(VersionCheckMixin, TestCase):
         # Allow version to be optional.
         if args[0]:
             data['version'] = args[0]
-        up = super(TestLookup, self).get(data)
-        assert up.is_valid()
-        up.data['version_int'] = args[1]
-        up.get_update()
-        return (up.data['row'].get('version_id'),
-                up.data['row'].get('file_id'))
+        instance = super(TestLookup, self).get_update_instance(data)
+        assert instance.is_valid()
+        instance.data['version_int'] = args[1]
+        instance.get_update()
+        return (instance.data['row'].get('version_id'),
+                instance.data['row'].get('file_id'))
 
     def change_status(self, version, status):
         version = Version.objects.get(pk=version)
@@ -156,8 +158,8 @@ class TestLookup(VersionCheckMixin, TestCase):
         Version 3.0a1 of Firefox is 3000000001100 and version 1.0.2 of the
         add-on is returned.
         """
-        version, file = self.get('', '3000000001100',
-                                 self.app, self.platform)
+        version, file = self.get_update_instance(
+            '', '3000000001100', self.app, self.platform)
         assert version == self.version_1_0_2
 
     def test_new_client(self):
@@ -165,8 +167,8 @@ class TestLookup(VersionCheckMixin, TestCase):
         Version 3.0.12 of Firefox is 3069900200100 and version 1.2.2 of the
         add-on is returned.
         """
-        version, file = self.get('', self.version_int,
-                                 self.app, self.platform)
+        version, file = self.get_update_instance(
+            '', self.version_int, self.app, self.platform)
         assert version == self.version_1_2_2
 
     def test_min_client(self):
@@ -180,8 +182,8 @@ class TestLookup(VersionCheckMixin, TestCase):
             appversion.min = AppVersion.objects.get(pk=325)  # 3.7a5
             appversion.save()
 
-        version, file = self.get('', '3070000005000',  # 3.7a5pre
-                                 self.app, self.platform)
+        version, file = self.get_update_instance(
+            '', '3070000005000', self.app, self.platform)  # 3.7a5pre
         assert version == self.version_1_1_3
 
     def test_new_client_ordering(self):
@@ -201,8 +203,8 @@ class TestLookup(VersionCheckMixin, TestCase):
         application_version.max_id = 329
         application_version.save()
 
-        version, file = self.get('', self.version_int,
-                                 self.app, self.platform)
+        version, file = self.get_update_instance(
+            '', self.version_int, self.app, self.platform)
         assert version == self.version_1_2_2
 
     def test_public(self):
@@ -212,8 +214,8 @@ class TestLookup(VersionCheckMixin, TestCase):
         self.change_status(self.version_1_2_2, amo.STATUS_PENDING)
         self.addon.reload()
         assert self.addon.status == amo.STATUS_PUBLIC
-        version, file = self.get('1.2', self.version_int,
-                                 self.app, self.platform)
+        version, file = self.get_update_instance(
+            '1.2', self.version_int, self.app, self.platform)
         assert version == self.version_1_2_1
 
     def test_no_unlisted(self):
@@ -224,8 +226,8 @@ class TestLookup(VersionCheckMixin, TestCase):
             channel=amo.RELEASE_CHANNEL_UNLISTED)
         self.addon.reload()
         assert self.addon.status == amo.STATUS_PUBLIC
-        version, file = self.get('1.2', self.version_int,
-                                 self.app, self.platform)
+        version, file = self.get_update_instance(
+            '1.2', self.version_int, self.app, self.platform)
         assert version == self.version_1_2_1
 
     def test_can_downgrade(self):
@@ -236,8 +238,8 @@ class TestLookup(VersionCheckMixin, TestCase):
         self.change_status(self.version_1_2_0, amo.STATUS_PENDING)
         for v in Version.objects.filter(pk__gte=self.version_1_2_1):
             v.delete()
-        version, file = self.get('1.2', self.version_int,
-                                 self.app, self.platform)
+        version, file = self.get_update_instance(
+            '1.2', self.version_int, self.app, self.platform)
 
         assert version == self.version_1_1_3
 
@@ -252,8 +254,8 @@ class TestLookup(VersionCheckMixin, TestCase):
         self.change_status(self.version_1_2_0, amo.STATUS_PENDING)
         self.change_version(self.version_1_2_0, '1.2beta')
 
-        version, file = self.get('1.2', self.version_int,
-                                 self.app, self.platform)
+        version, file = self.get_update_instance(
+            '1.2', self.version_int, self.app, self.platform)
 
         assert version == self.version_1_2_1
 
@@ -267,8 +269,8 @@ class TestLookup(VersionCheckMixin, TestCase):
         self.change_version(self.version_1_2_0, '1.2beta')
         Version.objects.get(pk=self.version_1_2_0).files.all().delete()
 
-        version, file = self.get('1.2beta', self.version_int,
-                                 self.app, self.platform)
+        version, file = self.get_update_instance(
+            '1.2beta', self.version_int, self.app, self.platform)
         dest = Version.objects.get(pk=self.version_1_2_2)
         assert dest.addon.status == amo.STATUS_PUBLIC
         assert dest.files.all()[0].status == amo.STATUS_PUBLIC
@@ -281,8 +283,8 @@ class TestLookup(VersionCheckMixin, TestCase):
         """
         self.change_status(self.version_1_2_2, amo.STATUS_NULL)
         self.addon.update(status=amo.STATUS_NULL)
-        version, file = self.get('1.2.1', self.version_int,
-                                 self.app, self.platform)
+        version, file = self.get_update_instance(
+            '1.2.1', self.version_int, self.app, self.platform)
         assert version == self.version_1_2_1
 
     def test_platform_does_not_exist(self):
@@ -292,8 +294,8 @@ class TestLookup(VersionCheckMixin, TestCase):
             file.platform = amo.PLATFORM_LINUX.id
             file.save()
 
-        version, file = self.get('1.2', self.version_int,
-                                 self.app, self.platform)
+        version, file = self.get_update_instance(
+            '1.2', self.version_int, self.app, self.platform)
         assert version == self.version_1_2_1
 
     def test_platform_exists(self):
@@ -303,8 +305,8 @@ class TestLookup(VersionCheckMixin, TestCase):
             file.platform = amo.PLATFORM_LINUX.id
             file.save()
 
-        version, file = self.get('1.2', self.version_int,
-                                 self.app, amo.PLATFORM_LINUX)
+        version, file = self.get_update_instance(
+            '1.2', self.version_int, self.app, amo.PLATFORM_LINUX)
         assert version == self.version_1_2_2
 
     def test_file_for_platform(self):
@@ -318,13 +320,13 @@ class TestLookup(VersionCheckMixin, TestCase):
                         platform=amo.PLATFORM_WIN.id,
                         status=amo.STATUS_PUBLIC)
         file_two.save()
-        version, file = self.get('1.2', self.version_int,
-                                 self.app, amo.PLATFORM_LINUX)
+        version, file = self.get_update_instance(
+            '1.2', self.version_int, self.app, amo.PLATFORM_LINUX)
         assert version == self.version_1_2_2
         assert file == file_one.pk
 
-        version, file = self.get('1.2', self.version_int,
-                                 self.app, amo.PLATFORM_WIN)
+        version, file = self.get_update_instance(
+            '1.2', self.version_int, self.app, amo.PLATFORM_WIN)
         assert version == self.version_1_2_2
         assert file == file_two.pk
 
@@ -385,18 +387,18 @@ class TestDefaultToCompat(VersionCheckMixin, TestCase):
             for file in version.files.all():
                 file.update(**kw)
 
-    def get(self, **kw):
-        up = super(TestDefaultToCompat, self).get({
+    def get_update_instance(self, **kw):
+        instance = super(TestDefaultToCompat, self).get_update_instance({
             'reqVersion': 1,
             'id': self.addon.guid,
             'version': kw.get('item_version', '1.0'),
             'appID': self.app.guid,
             'appVersion': kw.get('app_version', '3.0'),
         })
-        assert up.is_valid()
-        up.compat_mode = kw.get('compat_mode', 'strict')
-        up.get_update()
-        return up.data['row'].get('version_id')
+        assert instance.is_valid()
+        instance.compat_mode = kw.get('compat_mode', 'strict')
+        instance.get_update()
+        return instance.data['row'].get('version_id')
 
     def check(self, expected):
         """
@@ -408,8 +410,11 @@ class TestDefaultToCompat(VersionCheckMixin, TestCase):
 
         for version in versions:
             for mode in modes:
-                assert self.get(app_version=version, compat_mode=mode) == (
-                    expected['-'.join([version, mode])])
+                assert (
+                    self.get_update_instance(
+                        app_version=version, compat_mode=mode) ==
+                    expected['-'.join([version, mode])]
+                )
 
     def test_baseline(self):
         # Tests simple add-on (non-binary-components, non-strict).
@@ -536,9 +541,9 @@ class TestResponse(VersionCheckMixin, TestCase):
 
     def test_bad_guid(self):
         data = self.good_data.copy()
-        data["id"] = "garbage"
-        up = self.get(data)
-        assert up.get_rdf() == up.get_bad_rdf()
+        data['id'] = 'garbage'
+        instance = self.get_update_instance(data)
+        assert json.loads(instance.get_output()) == instance.get_error_output()
 
     def test_no_platform(self):
         file = File.objects.get(pk=67442)
@@ -546,14 +551,16 @@ class TestResponse(VersionCheckMixin, TestCase):
         file.save()
 
         data = self.good_data.copy()
-        data["appOS"] = self.win.api_name
-        up = self.get(data)
-        assert up.get_rdf()
-        assert up.data['row']['file_id'] == file.pk
+        data['appOS'] = self.win.api_name
+        instance = self.get_update_instance(data)
+        assert instance.get_output()
+        assert instance.data['row']['file_id'] == file.pk
 
-        data["appOS"] = self.mac.api_name
-        up = self.get(data)
-        assert up.get_rdf() == up.get_no_updates_rdf()
+        data['appOS'] = self.mac.api_name
+        instance = self.get_update_instance(data)
+        assert (
+            json.loads(instance.get_output()) ==
+            instance.get_no_updates_output())
 
     def test_different_platform(self):
         file = File.objects.get(pk=67442)
@@ -568,68 +575,64 @@ class TestResponse(VersionCheckMixin, TestCase):
 
         data = self.good_data.copy()
         data['appOS'] = self.win.api_name
-        up = self.get(data)
-        up.is_valid()
-        up.get_update()
-        assert up.data['row']['file_id'] == file_pk
+        instance = self.get_update_instance(data)
+        instance.is_valid()
+        instance.get_update()
+        assert instance.data['row']['file_id'] == file_pk
 
         data['appOS'] = self.mac.api_name
-        up = self.get(data)
-        up.is_valid()
-        up.get_update()
-        assert up.data['row']['file_id'] == mac_file_pk
+        instance = self.get_update_instance(data)
+        instance.is_valid()
+        instance.get_update()
+        assert instance.data['row']['file_id'] == mac_file_pk
 
     def test_good_version(self):
-        up = self.get(self.good_data)
-        up.is_valid()
-        up.get_update()
-        assert up.data['row']['hash'].startswith('sha256:3808b13e')
-        assert up.data['row']['min'] == '2.0'
-        assert up.data['row']['max'] == '4.0'
+        instance = self.get_update_instance(self.good_data)
+        instance.is_valid()
+        instance.get_update()
+        assert instance.data['row']['hash'].startswith('sha256:3808b13e')
+        assert instance.data['row']['min'] == '2.0'
+        assert instance.data['row']['max'] == '4.0'
 
     def test_no_app_version(self):
         data = self.good_data.copy()
         data['appVersion'] = '1.4'
-        up = self.get(data)
-        up.is_valid()
-        assert not up.get_update()
+        instance = self.get_update_instance(data)
+        instance.is_valid()
+        assert not instance.get_update()
 
     def test_low_app_version(self):
         data = self.good_data.copy()
         data['appVersion'] = '2.0'
-        up = self.get(data)
-        up.is_valid()
-        up.get_update()
-        assert up.data['row']['hash'].startswith('sha256:3808b13e')
-        assert up.data['row']['min'] == '2.0'
-        assert up.data['row']['max'] == '4.0'
+        instance = self.get_update_instance(data)
+        instance.is_valid()
+        instance.get_update()
+        assert instance.data['row']['hash'].startswith('sha256:3808b13e')
+        assert instance.data['row']['min'] == '2.0'
+        assert instance.data['row']['max'] == '4.0'
 
     def test_content_type(self):
-        up = self.get(self.good_data)
-        ('Content-Type', 'text/xml') in up.get_headers(1)
+        instance = self.get_update_instance(self.good_data)
+        ('Content-Type', 'text/xml') in instance.get_headers(1)
 
     def test_cache_control(self):
-        up = self.get(self.good_data)
-        ('Cache-Control', 'public, max-age=3600') in up.get_headers(1)
+        instance = self.get_update_instance(self.good_data)
+        ('Cache-Control', 'public, max-age=3600') in instance.get_headers(1)
 
     def test_length(self):
-        up = self.get(self.good_data)
-        ('Cache-Length', '1') in up.get_headers(1)
+        instance = self.get_update_instance(self.good_data)
+        ('Cache-Length', '1') in instance.get_headers(1)
 
     def test_expires(self):
         """Check there are these headers and that expires is 3600 later."""
         # We aren't bother going to test the actual time in expires, that
         # way lies pain with broken tests later.
-        up = self.get(self.good_data)
-        hdrs = dict(up.get_headers(1))
-        lm = datetime(*utils.parsedate_tz(hdrs['Last-Modified'])[:7])
-        exp = datetime(*utils.parsedate_tz(hdrs['Expires'])[:7])
-        assert (exp - lm).seconds == 3600
-
-    def test_appguid(self):
-        up = self.get(self.good_data)
-        rdf = up.get_rdf()
-        assert rdf.find(self.good_data['appID']) > -1
+        instance = self.get_update_instance(self.good_data)
+        headers = dict(instance.get_headers(1))
+        last_modified = datetime(
+            *utils.parsedate_tz(headers['Last-Modified'])[:7])
+        expires = datetime(*utils.parsedate_tz(headers['Expires'])[:7])
+        assert (expires - last_modified).seconds == 3600
 
     def get_file_url(self):
         """Return the file url with the hash as parameter."""
@@ -638,39 +641,47 @@ class TestResponse(VersionCheckMixin, TestCase):
                 'e09fef55f2673458bc31f')
 
     def test_url(self):
-        up = self.get(self.good_data)
-        up.get_rdf()
-        assert up.data['row']['url'] == self.get_file_url()
+        instance = self.get_update_instance(self.good_data)
+        instance.get_output()
+        assert instance.data['row']['url'] == self.get_file_url()
 
     def test_url_local_recent(self):
         a_bit_ago = datetime.now() - timedelta(seconds=60)
         File.objects.get(pk=67442).update(datestatuschanged=a_bit_ago)
-        up = self.get(self.good_data)
-        up.get_rdf()
-        assert up.data['row']['url'] == self.get_file_url()
+        instance = self.get_update_instance(self.good_data)
+        instance.get_output()
+        assert instance.data['row']['url'] == self.get_file_url()
 
     def test_hash(self):
-        rdf = self.get(self.good_data).get_rdf()
-        assert rdf.find('updateHash') > -1
+        content = self.get_update_instance(self.good_data).get_output()
+        data = json.loads(content)
+
+        file = File.objects.get(pk=67442)
+        guid = '{2fa4ed95-0317-4c6a-a74c-5f3e3912c1f9}'
+        assert data['addons'][guid]['updates'][0]['update_hash'] == file.hash
 
         file = File.objects.get(pk=67442)
         file.hash = ''
         file.save()
 
-        rdf = self.get(self.good_data).get_rdf()
-        assert rdf.find('updateHash') == -1
+        content = self.get_update_instance(self.good_data).get_output()
+        data = json.loads(content)
+        assert 'update_hash' not in data['addons'][guid]['updates'][0]
 
     def test_releasenotes(self):
-        rdf = self.get(self.good_data).get_rdf()
-        assert rdf.find('updateInfoURL') > -1
+        content = self.get_update_instance(self.good_data).get_output()
+        data = json.loads(content)
+        guid = '{2fa4ed95-0317-4c6a-a74c-5f3e3912c1f9}'
+        assert data['addons'][guid]['updates'][0]['update_info_url']
 
         version = Version.objects.get(pk=81551)
         version.update(releasenotes=None)
 
-        rdf = self.get(self.good_data).get_rdf()
-        assert rdf.find('updateInfoURL') == -1
+        content = self.get_update_instance(self.good_data).get_output()
+        data = json.loads(content)
+        assert 'update_info_url' not in data['addons'][guid]['updates'][0]
 
-    def test_sea_monkey(self):
+    def test_seamonkey(self):
         data = {
             'id': 'bettergmail2@ginatrapani.org',
             'version': '1',
@@ -678,107 +689,23 @@ class TestResponse(VersionCheckMixin, TestCase):
             'reqVersion': 1,
             'appVersion': '1.0',
         }
-        up = self.get(data)
-        rdf = up.get_rdf()
-        assert up.data['row']['hash'].startswith('sha256:9d9a389')
-        assert up.data['row']['min'] == '1.0'
-        assert up.data['row']['version'] == '0.5.2'
-        assert rdf.find(data['appID']) > -1
+        instance = self.get_update_instance(data)
+        instance.get_output()
+        assert instance.data['row']['hash'].startswith('sha256:9d9a389')
+        assert instance.data['row']['min'] == '1.0'
+        assert instance.data['row']['version'] == '0.5.2'
 
     def test_no_updates_at_all(self):
         self.addon_one.versions.all().delete()
-        upd = self.get(self.good_data)
-        assert upd.get_rdf() == upd.get_no_updates_rdf()
+        instance = self.get_update_instance(self.good_data)
+        assert (
+            json.loads(instance.get_output()) ==
+            instance.get_no_updates_output())
 
     def test_no_updates_my_fx(self):
         data = self.good_data.copy()
         data['appVersion'] = '5.0.1'
-        upd = self.get(data)
-        assert upd.get_rdf() == upd.get_no_updates_rdf()
-
-
-class TestFirefoxHotfix(VersionCheckMixin, TestCase):
-
-    def setUp(self):
-        """Create a "firefox hotfix" addon with a few versions.
-
-        Check bug 1031516 for more info.
-
-        """
-        super(TestFirefoxHotfix, self).setUp()
-        self.addon = amo.tests.addon_factory(guid='firefox-hotfix@mozilla.org')
-
-        # First signature changing hotfix.
-        amo.tests.version_factory(addon=self.addon, version='20121019.01',
-                                  min_app_version='10.0',
-                                  max_app_version='16.*')
-
-        # Second signature changing hotfix.
-        amo.tests.version_factory(addon=self.addon, version='20130826.01',
-                                  min_app_version='10.0',
-                                  max_app_version='24.*')
-
-        # Newest version compatible with any Firefox.
-        amo.tests.version_factory(addon=self.addon, version='20202020.01',
-                                  min_app_version='10.0',
-                                  max_app_version='30.*')
-
-        self.data = {
-            'id': 'firefox-hotfix@mozilla.org',
-            'appID': '{ec8030f7-c20a-464f-9b0e-13a3a9e97384}',
-            'reqVersion': '2',
-        }
-
-    def test_10_16_first_hotfix(self):
-        """The first hotfix changing the signature should be served."""
-        self.data['version'] = ''
-        self.data['appVersion'] = '16.0.1'
-
-        up = self.get(self.data)
-        rdf = up.get_rdf()
-        assert rdf.find('20121019.01') > -1
-
-    def test_10_16_second_hotfix(self):
-        """The second hotfix changing the signature should be served."""
-        self.data['version'] = '20121019.01'
-        self.data['appVersion'] = '16.0.1'
-
-        up = self.get(self.data)
-        rdf = up.get_rdf()
-        assert rdf.find('20130826.01') > -1
-
-    def test_10_16_newest_hotfix(self):
-        """The newest hotfix should be served."""
-        self.data['version'] = '20130826.01'
-        self.data['appVersion'] = '16.0.1'
-
-        up = self.get(self.data)
-        rdf = up.get_rdf()
-        assert rdf.find('20202020.01') > -1
-
-    def test_16_24_second_hotfix(self):
-        """The second hotfix changing the signature should be served."""
-        self.data['version'] = ''
-        self.data['appVersion'] = '16.0.2'
-
-        up = self.get(self.data)
-        rdf = up.get_rdf()
-        assert rdf.find('20130826.01') > -1
-
-    def test_16_24_newest_hotfix(self):
-        """The newest hotfix should be served."""
-        self.data['version'] = '20130826.01'
-        self.data['appVersion'] = '16.0.2'
-
-        up = self.get(self.data)
-        rdf = up.get_rdf()
-        assert rdf.find('20202020.01') > -1
-
-    def test_above_24_latest_version(self):
-        """The newest hotfix should be served."""
-        self.data['version'] = ''
-        self.data['appVersion'] = '28.0'
-
-        up = self.get(self.data)
-        rdf = up.get_rdf()
-        assert rdf.find('20202020.01') > -1
+        instance = self.get_update_instance(data)
+        assert (
+            json.loads(instance.get_output()) ==
+            instance.get_no_updates_output())


### PR DESCRIPTION
Also remove code to support hotfixes for super old versions of Firefox

Fix #7223