### PR TITLE
add v4 api.  Initially the same as v3.

### DIFF
--- a/src/olympia/abuse/tests/test_views.py
+++ b/src/olympia/abuse/tests/test_views.py
@@ -13,7 +13,7 @@ class AddonAbuseViewSetTestBase(object):
     client_class = APITestClient
 
     def setUp(self):
-        self.url = reverse('abusereportaddon-list')
+        self.url = reverse('v3:abusereportaddon-list')
 
     def check_reporter(self, report):
         raise NotImplementedError
@@ -157,7 +157,7 @@ class UserAbuseViewSetTestBase(object):
     client_class = APITestClient
 
     def setUp(self):
-        self.url = reverse('abusereportuser-list')
+        self.url = reverse('v3:abusereportuser-list')
 
     def check_reporter(self, report):
         raise NotImplementedError

--- a/src/olympia/activity/tests/test_views.py
+++ b/src/olympia/activity/tests/test_views.py
@@ -168,7 +168,7 @@ class TestReviewNotesViewSetDetail(ReviewNotesViewSetDetailMixin, TestCase):
         assert result['highlight']  # Its the first reply so highlight
 
     def _set_tested_url(self, pk=None, version_pk=None, addon_pk=None):
-        self.url = reverse('version-reviewnotes-detail', kwargs={
+        self.url = reverse('v3:version-reviewnotes-detail', kwargs={
             'addon_pk': addon_pk or self.addon.pk,
             'version_pk': version_pk or self.version.pk,
             'pk': pk or self.note.pk})
@@ -219,7 +219,7 @@ class TestReviewNotesViewSetList(ReviewNotesViewSetDetailMixin, TestCase):
         assert not result_version['highlight']  # The dev replied so read it.
 
     def _set_tested_url(self, pk=None, version_pk=None, addon_pk=None):
-        self.url = reverse('version-reviewnotes-list', kwargs={
+        self.url = reverse('v3:version-reviewnotes-list', kwargs={
             'addon_pk': addon_pk or self.addon.pk,
             'version_pk': version_pk or self.version.pk})
 
@@ -240,7 +240,7 @@ class TestReviewNotesViewSetCreate(TestCase):
             guid=generate_addon_guid(), name=u'My Addôn', slug='my-addon')
         self.version = self.addon.find_latest_version(
             channel=amo.RELEASE_CHANNEL_LISTED)
-        self.url = reverse('version-reviewnotes-list', kwargs={
+        self.url = reverse('v3:version-reviewnotes-list', kwargs={
             'addon_pk': self.addon.pk,
             'version_pk': self.version.pk})
 
@@ -354,7 +354,7 @@ class TestReviewNotesViewSetCreate(TestCase):
         self.client.login_api(self.user)
 
         # First check we can reply to new version
-        new_url = reverse('version-reviewnotes-list', kwargs={
+        new_url = reverse('v3:version-reviewnotes-list', kwargs={
             'addon_pk': self.addon.pk,
             'version_pk': new_version.pk})
         response = self.client.post(
@@ -388,7 +388,7 @@ class TestEmailApi(TestCase):
 
     def get_request(self, data):
         datastr = json.dumps(data)
-        req = req_factory_factory(reverse('inbound-email-api'), post=True)
+        req = req_factory_factory(reverse('v3:inbound-email-api'), post=True)
         req.META['REMOTE_ADDR'] = '10.10.10.10'
         req.META['CONTENT_LENGTH'] = len(datastr)
         req.META['CONTENT_TYPE'] = 'application/json'
@@ -397,7 +397,7 @@ class TestEmailApi(TestCase):
 
     def get_validation_request(self, data):
         req = req_factory_factory(
-            url=reverse('inbound-email-api'), post=True, data=data)
+            url=reverse('v3:inbound-email-api'), post=True, data=data)
         req.META['REMOTE_ADDR'] = '10.10.10.10'
         return req
 

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -1680,11 +1680,11 @@ class TestAddonViewSetDetail(AddonAndVersionViewSetDetailMixin, TestCase):
         return result
 
     def _set_tested_url(self, param):
-        self.url = reverse('addon-detail', kwargs={'pk': param})
+        self.url = reverse('v3:addon-detail', kwargs={'pk': param})
 
     def test_detail_url_with_reviewers_in_the_url(self):
         self.addon.update(slug='something-reviewers')
-        self.url = reverse('addon-detail', kwargs={'pk': self.addon.slug})
+        self.url = reverse('v3:addon-detail', kwargs={'pk': self.addon.slug})
         self._test_url()
 
     def test_hide_latest_unlisted_version_anonymous(self):
@@ -1775,11 +1775,11 @@ class TestVersionViewSetDetail(AddonAndVersionViewSetDetailMixin, TestCase):
         assert result['version'] == self.version.version
 
     def _set_tested_url(self, param):
-        self.url = reverse('addon-version-detail', kwargs={
+        self.url = reverse('v3:addon-version-detail', kwargs={
             'addon_pk': param, 'pk': self.version.pk})
 
     def test_version_get_not_found(self):
-        self.url = reverse('addon-version-detail', kwargs={
+        self.url = reverse('v3:addon-version-detail', kwargs={
             'addon_pk': self.addon.pk, 'pk': self.version.pk + 42})
         response = self.client.get(self.url)
         assert response.status_code == 404
@@ -1958,7 +1958,7 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
         assert result_version['version'] == self.old_version.version
 
     def _set_tested_url(self, param):
-        self.url = reverse('addon-version-list', kwargs={'addon_pk': param})
+        self.url = reverse('v3:addon-version-list', kwargs={'addon_pk': param})
 
     def test_bad_filter(self):
         response = self.client.get(self.url, data={'filter': 'ahahaha'})
@@ -2121,10 +2121,11 @@ class TestAddonViewSetFeatureCompatibility(TestCase):
         self.addon = addon_factory(
             guid=generate_addon_guid(), name=u'My Addôn', slug='my-addon')
         self.url = reverse(
-            'addon-feature-compatibility', kwargs={'pk': self.addon.pk})
+            'v3:addon-feature-compatibility', kwargs={'pk': self.addon.pk})
 
     def test_url(self):
-        self.detail_url = reverse('addon-detail', kwargs={'pk': self.addon.pk})
+        self.detail_url = reverse(
+            'v3:addon-detail', kwargs={'pk': self.addon.pk})
         assert self.url == '%s%s' % (self.detail_url, 'feature_compatibility/')
 
     def test_disabled_anonymous(self):
@@ -2155,10 +2156,11 @@ class TestAddonViewSetEulaPolicy(TestCase):
         self.addon = addon_factory(
             guid=generate_addon_guid(), name=u'My Addôn', slug='my-addon')
         self.url = reverse(
-            'addon-eula-policy', kwargs={'pk': self.addon.pk})
+            'v3:addon-eula-policy', kwargs={'pk': self.addon.pk})
 
     def test_url(self):
-        self.detail_url = reverse('addon-detail', kwargs={'pk': self.addon.pk})
+        self.detail_url = reverse(
+            'v3:addon-detail', kwargs={'pk': self.addon.pk})
         assert self.url == '%s%s' % (self.detail_url, 'eula_policy/')
 
     def test_disabled_anonymous(self):
@@ -2191,7 +2193,7 @@ class TestAddonSearchView(ESTestCase):
 
     def setUp(self):
         super(TestAddonSearchView, self).setUp()
-        self.url = reverse('addon-search')
+        self.url = reverse('v3:addon-search')
 
     def tearDown(self):
         super(TestAddonSearchView, self).tearDown()
@@ -2859,7 +2861,7 @@ class TestAddonSearchView(ESTestCase):
 
         for locale in ('en-US', 'en-GB', 'es'):
             with self.activate(locale):
-                url = reverse('addon-search')
+                url = reverse('v3:addon-search')
 
                 data = self.perform_search(url, {'lang': locale})
 
@@ -2952,7 +2954,7 @@ class TestAddonAutoCompleteSearchView(ESTestCase):
 
     def setUp(self):
         super(TestAddonAutoCompleteSearchView, self).setUp()
-        self.url = reverse('addon-autocomplete')
+        self.url = reverse('v3:addon-autocomplete')
 
     def tearDown(self):
         super(TestAddonAutoCompleteSearchView, self).tearDown()
@@ -3077,7 +3079,7 @@ class TestAddonFeaturedView(TestCase):
     client_class = APITestClient
 
     def setUp(self):
-        self.url = reverse('addon-featured')
+        self.url = reverse('v3:addon-featured')
 
     def test_no_parameters(self):
         response = self.client.get(self.url)
@@ -3262,7 +3264,7 @@ class TestStaticCategoryView(TestCase):
 
     def setUp(self):
         super(TestStaticCategoryView, self).setUp()
-        self.url = reverse('category-list')
+        self.url = reverse('v3:category-list')
 
     def test_basic(self):
         with self.assertNumQueries(0):
@@ -3332,7 +3334,7 @@ class TestLanguageToolsView(TestCase):
 
     def setUp(self):
         super(TestLanguageToolsView, self).setUp()
-        self.url = reverse('addon-language-tools')
+        self.url = reverse('v3:addon-language-tools')
 
     def test_wrong_app_or_no_app(self):
         response = self.client.get(self.url)
@@ -3575,7 +3577,7 @@ class TestReplacementAddonView(TestCase):
             guid='notgonnawork@moz',
             path='/addon/áddonmissing/')
 
-        response = self.client.get(reverse('addon-replacement-addon'))
+        response = self.client.get(reverse('v3:addon-replacement-addon'))
         assert response.status_code == 200
         data = json.loads(response.content)
         results = data['results']
@@ -3604,7 +3606,8 @@ class TestCompatOverrideView(TestCase):
 
     def test_single_guid(self):
         response = self.client.get(
-            reverse('addon-compat-override'), data={'guid': u'extrabad@thing'})
+            reverse('v3:addon-compat-override'),
+            data={'guid': u'extrabad@thing'})
         assert response.status_code == 200
         data = json.loads(response.content)
         assert len(data['results']) == 1
@@ -3615,7 +3618,7 @@ class TestCompatOverrideView(TestCase):
 
     def test_multiple_guid(self):
         response = self.client.get(
-            reverse('addon-compat-override'),
+            reverse('v3:addon-compat-override'),
             data={'guid': u'extrabad@thing,bad@thing'})
         assert response.status_code == 200
         data = json.loads(response.content)
@@ -3631,7 +3634,7 @@ class TestCompatOverrideView(TestCase):
 
         # Throw in some random invalid guids too that will be ignored.
         response = self.client.get(
-            reverse('addon-compat-override'),
+            reverse('v3:addon-compat-override'),
             data={'guid': (
                 u'extrabad@thing,invalid@guid,notevenaguid$,bad@thing')})
         assert response.status_code == 200
@@ -3643,19 +3646,20 @@ class TestCompatOverrideView(TestCase):
 
     def test_no_guid_param(self):
         response = self.client.get(
-            reverse('addon-compat-override'), data={'guid': u'invalid@thing'})
+            reverse('v3:addon-compat-override'),
+            data={'guid': u'invalid@thing'})
         # Searching for non-matching guids, it should be an empty 200 response.
         assert response.status_code == 200
         assert len(json.loads(response.content)['results']) == 0
 
         response = self.client.get(
-            reverse('addon-compat-override'), data={'guid': ''})
+            reverse('v3:addon-compat-override'), data={'guid': ''})
         # Empty query is a 400 because a guid is required for overrides.
         assert response.status_code == 400
         assert 'Empty, or no, guid parameter provided.' in response.content
 
         response = self.client.get(
-            reverse('addon-compat-override'))
+            reverse('v3:addon-compat-override'))
         # And no guid param should be a 400 too
         assert response.status_code == 400
         assert 'Empty, or no, guid parameter provided.' in response.content
@@ -3668,7 +3672,7 @@ class TestAddonRecommendationView(ESTestCase):
 
     def setUp(self):
         super(TestAddonRecommendationView, self).setUp()
-        self.url = reverse('addon-recommendations')
+        self.url = reverse('v3:addon-recommendations')
         patcher = mock.patch(
             'olympia.addons.views.get_addon_recommendations')
         self.get_recommendations_mock = patcher.start()

--- a/src/olympia/amo/templatetags/jinja_helpers.py
+++ b/src/olympia/amo/templatetags/jinja_helpers.py
@@ -20,9 +20,10 @@ from django.utils.translation import (
 
 import jinja2
 import waffle
-
 from babel.support import Format
 from django_jinja import library
+from rest_framework.reverse import reverse as drf_reverse
+from rest_framework.settings import api_settings
 
 from olympia import amo
 from olympia.amo import urlresolvers, utils
@@ -90,6 +91,18 @@ def url(viewname, *args, **kwargs):
     if src:
         url = urlparams(url, src=src)
     return url
+
+
+@library.global_function
+@jinja2.contextfunction
+def drf_url(context, viewname, *args, **kwargs):
+    """Helper for DjangoRestFramework's ``reverse`` in templates."""
+    request = context.get('request')
+    if request:
+        scheme = api_settings.DEFAULT_VERSIONING_CLASS()
+        request.versioning_scheme = scheme
+        request.version = scheme.determine_version(request, *args, **kwargs)
+    return drf_reverse(viewname, request=request, args=args, kwargs=kwargs)
 
 
 @library.global_function

--- a/src/olympia/amo/templatetags/jinja_helpers.py
+++ b/src/olympia/amo/templatetags/jinja_helpers.py
@@ -99,9 +99,10 @@ def drf_url(context, viewname, *args, **kwargs):
     """Helper for DjangoRestFramework's ``reverse`` in templates."""
     request = context.get('request')
     if request:
-        scheme = api_settings.DEFAULT_VERSIONING_CLASS()
-        request.versioning_scheme = scheme
-        request.version = scheme.determine_version(request, *args, **kwargs)
+        if not hasattr(request, 'versioning_scheme'):
+            request.versioning_scheme = api_settings.DEFAULT_VERSIONING_CLASS()
+        request.version = request.versioning_scheme.determine_version(
+            request, *args, **kwargs)
     return drf_reverse(viewname, request=request, args=args, kwargs=kwargs)
 
 

--- a/src/olympia/amo/tests/test_helpers.py
+++ b/src/olympia/amo/tests/test_helpers.py
@@ -7,6 +7,7 @@ from urlparse import urljoin
 
 from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from django.utils.encoding import force_bytes
@@ -156,8 +157,18 @@ def test_url(mock_reverse):
 
 
 def test_url_src():
-    s = render('{{ url("addons.detail", "a3615", src="xxx") }}')
-    assert s.endswith('?src=xxx')
+    fragment = render('{{ url("addons.detail", "a3615", src="xxx") }}')
+    assert fragment.endswith('?src=xxx')
+
+
+def test_drf_url():
+    rf = RequestFactory()
+    request = rf.get('/hello/')
+    fragment = render('{{ drf_url("addon-detail", pk="a3615") }}',
+                      context={'request': request})
+    # without a /vX/ in the request, RESTFRAMEWORK['DEFAULT_VERSION'] is used.
+    assert fragment == jinja_helpers.absolutify(
+        reverse('v4:addon-detail', args=['a3615'], add_prefix=False))
 
 
 def test_urlparams():

--- a/src/olympia/amo/tests/test_views.py
+++ b/src/olympia/amo/tests/test_views.py
@@ -392,7 +392,7 @@ class TestCORS(TestCase):
         assert not response.has_header('Access-Control-Allow-Credentials')
 
     def test_cors_api_v3(self):
-        url = reverse('addon-detail', args=(3615,))
+        url = reverse('v3:addon-detail', args=(3615,))
         assert '/api/v3/' in url
         response = self.get(url)
         assert response.status_code == 200

--- a/src/olympia/api/tests/test_middleware.py
+++ b/src/olympia/api/tests/test_middleware.py
@@ -45,7 +45,7 @@ class TestGzipMiddleware(TestCase):
     def test_api_endpoint_gzipped(self):
         """Test a simple API endpoint to make sure gzip is active there."""
         addon = addon_factory()
-        url = reverse('addon-detail', kwargs={'pk': addon.pk})
+        url = reverse('v3:addon-detail', kwargs={'pk': addon.pk})
         response = self.client.get(url)
         assert response.status_code == 200
         assert response.content

--- a/src/olympia/api/tests/test_namespace.py
+++ b/src/olympia/api/tests/test_namespace.py
@@ -1,0 +1,104 @@
+from django.conf.urls import include, url
+from django.core.urlresolvers import NoReverseMatch, reverse
+
+from rest_framework.response import Response
+from rest_framework.viewsets import GenericViewSet
+
+from olympia.amo.tests import addon_factory, TestCase, WithDynamicEndpoints
+
+
+class EmptyViewSet(GenericViewSet):
+    permission_classes = ()
+
+    def list(self, request, *args, **kwargs):
+        return Response({'version': request.version})
+
+
+class TestNamespacing(WithDynamicEndpoints, TestCase):
+
+    def setUp(self):
+        v3_only_url = url(
+            r'foo', EmptyViewSet.as_view(actions={'get': 'list'}), name='foo')
+        v4_only_url = url(
+            r'baa', EmptyViewSet.as_view(actions={'get': 'list'}), name='baa')
+        both_url = url(
+            r'yay', EmptyViewSet.as_view(actions={'get': 'list'}), name='yay')
+        v3_url = url(r'v3/', include([v3_only_url, both_url], namespace='v3'))
+        v4_url = url(r'v4/', include([v4_only_url, both_url], namespace='v4'))
+        self.endpoint(
+            include([v3_url, v4_url]),
+            url_regex=r'^api/')
+
+    def test_v3(self):
+        # The unique view
+        response = self.client.get(
+            'api/v3/foo', HTTP_ORIGIN='testserver', follow=True)
+        assert response.status_code == 200
+        assert response.content == '{"version":"v3"}'
+        url_ = reverse('v3:foo')
+        assert '/api/v3/' in url_
+        # And the common one
+        response = self.client.get(
+            'api/v3/yay', HTTP_ORIGIN='testserver', follow=True)
+        assert response.status_code == 200
+        assert response.content == '{"version":"v3"}'
+        url_ = reverse('v3:yay')
+        assert '/api/v3/' in url_
+        # But no baa in v3
+        response = self.client.get(
+            'api/v3/baa', HTTP_ORIGIN='testserver', follow=True)
+        assert response.status_code == 404
+        with self.assertRaises(NoReverseMatch):
+            reverse('v3:baa')
+
+    def test_v4(self):
+        # The unique view
+        response = self.client.get(
+            'api/v4/baa', HTTP_ORIGIN='testserver', follow=True)
+        assert response.status_code == 200
+        assert response.content == '{"version":"v4"}'
+        url_ = reverse('v4:baa')
+        assert '/api/v4/' in url_
+        # And the common one
+        response = self.client.get(
+            'api/v4/yay', HTTP_ORIGIN='testserver', follow=True)
+        assert response.status_code == 200
+        assert response.content == '{"version":"v4"}'
+        url_ = reverse('v4:yay')
+        assert '/api/v4/' in url_
+        # But no foo in v4
+        response = self.client.get(
+            'api/v4/foo', HTTP_ORIGIN='testserver', follow=True)
+        assert response.status_code == 404
+        with self.assertRaises(NoReverseMatch):
+            reverse('v4:foo')
+
+    def test_v5(self):
+        # There isn't a v5 API, so this should fail
+        with self.assertRaises(NoReverseMatch):
+            reverse('v5:yay')
+
+
+class TestRealAPIRouting(TestCase):
+
+    def setUp(self):
+        addon_factory(slug='foo')
+
+    def test_v3(self):
+        url = reverse('v3:addon-detail', args=('foo',))
+        assert '/api/v3/' in url
+        response = self.client.get(url, HTTP_ORIGIN='testserver')
+        assert response.status_code == 200
+        assert response
+
+    def test_v4(self):
+        url = reverse('v4:addon-detail', args=('foo',))
+        assert '/api/v4/' in url
+        response = self.client.get(url, HTTP_ORIGIN='testserver')
+        assert response.status_code == 200
+        assert response
+
+    def test_v5(self):
+        # There isn't a v5 API, so this should fail
+        with self.assertRaises(NoReverseMatch):
+            reverse('v5:addon-search')

--- a/src/olympia/api/urls.py
+++ b/src/olympia/api/urls.py
@@ -1,14 +1,19 @@
 from django.conf.urls import include, url
 
 
+v3_api_urls = [
+    url(r'^abuse/', include('olympia.abuse.urls')),
+    url(r'^accounts/', include('olympia.accounts.urls')),
+    url(r'^addons/', include('olympia.addons.api_urls')),
+    url(r'^', include('olympia.discovery.api_urls')),
+    url(r'^reviews/', include('olympia.ratings.api_urls')),
+    url(r'^reviewers/', include('olympia.reviewers.api_urls')),
+    url(r'^', include('olympia.signing.urls')),
+    url(r'^activity/', include('olympia.activity.urls')),
+    url(r'^github/', include('olympia.github.urls')),
+]
+
 urlpatterns = [
-    url(r'^v3/abuse/', include('olympia.abuse.urls')),
-    url(r'^v3/accounts/', include('olympia.accounts.urls')),
-    url(r'^v3/addons/', include('olympia.addons.api_urls')),
-    url(r'^v3/', include('olympia.discovery.api_urls')),
-    url(r'^v3/reviews/', include('olympia.ratings.api_urls')),
-    url(r'^v3/reviewers/', include('olympia.reviewers.api_urls')),
-    url(r'^v3/', include('olympia.signing.urls')),
-    url(r'^v3/activity/', include('olympia.activity.urls')),
-    url(r'^v3/github/', include('olympia.github.urls')),
+    url(r'^v3/', include(v3_api_urls, namespace='v3')),
+    url(r'^v4/', include(v3_api_urls, namespace='v4')),
 ]

--- a/src/olympia/bandwagon/tests/test_views.py
+++ b/src/olympia/bandwagon/tests/test_views.py
@@ -1311,7 +1311,8 @@ class TestCollectionViewSetList(TestCase):
 
     def setUp(self):
         self.user = user_factory()
-        self.url = reverse('collection-list', kwargs={'user_pk': self.user.pk})
+        self.url = reverse(
+            'v3:collection-list', kwargs={'user_pk': self.user.pk})
         super(TestCollectionViewSetList, self).setUp()
 
     def test_basic(self):
@@ -1333,7 +1334,7 @@ class TestCollectionViewSetList(TestCase):
 
     def test_different_user(self):
         random_user = user_factory()
-        other_url = reverse('collection-list',
+        other_url = reverse('v3:collection-list',
                             kwargs={'user_pk': random_user.pk})
         collection_factory(author=random_user)
 
@@ -1343,7 +1344,7 @@ class TestCollectionViewSetList(TestCase):
 
     def test_admin(self):
         random_user = user_factory()
-        other_url = reverse('collection-list',
+        other_url = reverse('v3:collection-list',
                             kwargs={'user_pk': random_user.pk})
         collection_factory(author=random_user)
 
@@ -1356,7 +1357,7 @@ class TestCollectionViewSetList(TestCase):
     def test_404(self):
         # Invalid user.
         url = reverse(
-            'collection-list', kwargs={'user_pk': self.user.pk + 66})
+            'v3:collection-list', kwargs={'user_pk': self.user.pk + 66})
 
         # Not logged in.
         response = self.client.get(url)
@@ -1402,7 +1403,7 @@ class TestCollectionViewSetDetail(TestCase):
 
     def _get_url(self, user, collection):
         return reverse(
-            'collection-detail', kwargs={
+            'v3:collection-detail', kwargs={
                 'user_pk': user.pk, 'slug': collection.slug})
 
     def test_basic(self):
@@ -1413,12 +1414,12 @@ class TestCollectionViewSetDetail(TestCase):
     def test_no_id_lookup(self):
         collection = collection_factory(author=self.user, slug='999')
         id_url = reverse(
-            'collection-detail', kwargs={
+            'v3:collection-detail', kwargs={
                 'user_pk': self.user.pk, 'slug': collection.id})
         response = self.client.get(id_url)
         assert response.status_code == 404
         slug_url = reverse(
-            'collection-detail', kwargs={
+            'v3:collection-detail', kwargs={
                 'user_pk': self.user.pk, 'slug': collection.slug})
         response = self.client.get(slug_url)
         assert response.status_code == 200
@@ -1474,12 +1475,12 @@ class TestCollectionViewSetDetail(TestCase):
     def test_404(self):
         # Invalid user.
         response = self.client.get(reverse(
-            'collection-detail', kwargs={
+            'v3:collection-detail', kwargs={
                 'user_pk': self.user.pk + 66, 'slug': self.collection.slug}))
         assert response.status_code == 404
         # Invalid collection.
         response = self.client.get(reverse(
-            'collection-detail', kwargs={
+            'v3:collection-detail', kwargs={
                 'user_pk': self.user.pk, 'slug': 'hello'}))
         assert response.status_code == 404
 
@@ -1628,7 +1629,7 @@ class TestCollectionViewSetCreate(CollectionViewSetDataMixin, TestCase):
         return self.client.post(url or self.url, data or self.data)
 
     def get_url(self, user):
-        return reverse('collection-list', kwargs={'user_pk': user.pk})
+        return reverse('v3:collection-list', kwargs={'user_pk': user.pk})
 
     def test_basic_create(self):
         self.client.login_api(self.user)
@@ -1704,7 +1705,7 @@ class TestCollectionViewSetPatch(CollectionViewSetDataMixin, TestCase):
 
     def get_url(self, user):
         return reverse(
-            'collection-detail', kwargs={
+            'v3:collection-detail', kwargs={
                 'user_pk': user.pk, 'slug': self.collection.slug})
 
     def test_basic_patch(self):
@@ -1767,7 +1768,7 @@ class TestCollectionViewSetDelete(TestCase):
 
     def get_url(self, user):
         return reverse(
-            'collection-detail', kwargs={
+            'v3:collection-detail', kwargs={
                 'user_pk': user.pk, 'slug': self.collection.slug})
 
     def test_delete(self):
@@ -1882,7 +1883,7 @@ class TestCollectionAddonViewSetList(CollectionAddonViewSetMixin, TestCase):
             status=amo.STATUS_AWAITING_REVIEW)
 
         self.url = reverse(
-            'collection-addon-list', kwargs={
+            'v3:collection-addon-list', kwargs={
                 'user_pk': self.user.pk,
                 'collection_slug': self.collection.slug})
         super(TestCollectionAddonViewSetList, self).setUp()
@@ -1894,13 +1895,13 @@ class TestCollectionAddonViewSetList(CollectionAddonViewSetMixin, TestCase):
     def test_404(self):
         # Invalid user.
         response = self.client.get(reverse(
-            'collection-addon-list', kwargs={
+            'v3:collection-addon-list', kwargs={
                 'user_pk': self.user.pk + 66,
                 'collection_slug': self.collection.slug}))
         assert response.status_code == 404
         # Invalid collection.
         response = self.client.get(reverse(
-            'collection-addon-list', kwargs={
+            'v3:collection-addon-list', kwargs={
                 'user_pk': self.user.pk,
                 'collection_slug': 'hello'}))
         assert response.status_code == 404
@@ -1992,7 +1993,7 @@ class TestCollectionAddonViewSetDetail(CollectionAddonViewSetMixin, TestCase):
         self.addon = addon_factory()
         self.collection.add_addon(self.addon)
         self.url = reverse(
-            'collection-addon-detail', kwargs={
+            'v3:collection-addon-detail', kwargs={
                 'user_pk': self.user.pk,
                 'collection_slug': self.collection.slug,
                 'addon': self.addon.id})
@@ -2004,7 +2005,7 @@ class TestCollectionAddonViewSetDetail(CollectionAddonViewSetMixin, TestCase):
 
     def test_with_slug(self):
         self.url = reverse(
-            'collection-addon-detail', kwargs={
+            'v3:collection-addon-detail', kwargs={
                 'user_pk': self.user.pk,
                 'collection_slug': self.collection.slug,
                 'addon': self.addon.slug})
@@ -2022,7 +2023,7 @@ class TestCollectionAddonViewSetCreate(CollectionAddonViewSetMixin, TestCase):
         self.user = user_factory()
         self.collection = collection_factory(author=self.user)
         self.url = reverse(
-            'collection-addon-list', kwargs={
+            'v3:collection-addon-list', kwargs={
                 'user_pk': self.user.pk,
                 'collection_slug': self.collection.slug})
         self.addon = addon_factory()
@@ -2106,7 +2107,7 @@ class TestCollectionAddonViewSetPatch(CollectionAddonViewSetMixin, TestCase):
         self.addon = addon_factory()
         self.collection.add_addon(self.addon)
         self.url = reverse(
-            'collection-addon-detail', kwargs={
+            'v3:collection-addon-detail', kwargs={
                 'user_pk': self.user.pk,
                 'collection_slug': self.collection.slug,
                 'addon': self.addon.id})
@@ -2151,7 +2152,7 @@ class TestCollectionAddonViewSetDelete(CollectionAddonViewSetMixin, TestCase):
         self.addon = addon_factory()
         self.collection.add_addon(self.addon)
         self.url = reverse(
-            'collection-addon-detail', kwargs={
+            'v3:collection-addon-detail', kwargs={
                 'user_pk': self.user.pk,
                 'collection_slug': self.collection.slug,
                 'addon': self.addon.id})

--- a/src/olympia/devhub/templates/devhub/versions/list.html
+++ b/src/olympia/devhub/templates/devhub/versions/list.html
@@ -112,7 +112,7 @@
   {% endif %}
   <tr>
       <td colspan="4" id="{{ version.id }}-review-history" class="review-history hidden"
-            data-api-url="{{ url('version-reviewnotes-list', addon.id, version.id) }}"
+            data-api-url="{{ drf_url('version-reviewnotes-list', addon.id, version.id) }}"
             data-token="{{ token }}">
           <div class="history-container">
               <div class="review-entry-loading">{{ _('Loading Review History...') }}</div>
@@ -128,7 +128,7 @@
           </div>
           {% if latest_version_in_channel == version %}
             <div class="dev-review-reply">
-              <form class="dev-review-reply-form" action="{{ url('version-reviewnotes-list', addon.id, version.id) }}"
+              <form class="dev-review-reply-form" action="{{ drf_url('version-reviewnotes-list', addon.id, version.id) }}"
                     data-token="{{ token }}" data-history="#{{ version.id }}-review-history" data-no-csrf>
                   <textarea name="comments" placeholder="{{ _('Leave a reply') }}"></textarea>
                   <button type="submit" class="submit" >{{ _('Reply') }}</button ty>

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -7,11 +7,13 @@ from django.core.files import temp
 import mock
 
 from pyquery import PyQuery as pq
+from rest_framework.reverse import reverse as drf_reverse
 
 from olympia import amo
 from olympia.accounts.views import API_TOKEN_COOKIE
 from olympia.activity.models import ActivityLog
 from olympia.addons.models import Addon, AddonReviewerFlags
+from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.amo.tests import TestCase, formset, initial, version_factory
 from olympia.amo.urlresolvers import reverse
 from olympia.applications.models import AppVersion
@@ -474,8 +476,9 @@ class TestVersion(TestCase):
         # Test review history
         review_history_td = doc('#%s-review-history' % v1.id)[0]
         assert review_history_td.attrib['data-token'] == 'magicbeans'
-        api_url = reverse(
-            'version-reviewnotes-list', args=[self.addon.id, self.version.id])
+        api_url = absolutify(drf_reverse(
+            'v4:version-reviewnotes-list',
+            args=[self.addon.id, self.version.id]))
         assert review_history_td.attrib['data-api-url'] == api_url
         assert doc('.review-history-hide').length == 2
 

--- a/src/olympia/discovery/tests/test_views.py
+++ b/src/olympia/discovery/tests/test_views.py
@@ -87,7 +87,7 @@ class DiscoveryTestMixin(object):
 class TestDiscoveryViewList(DiscoveryTestMixin, TestCase):
     def setUp(self):
         super(TestDiscoveryViewList, self).setUp()
-        self.url = reverse('discovery-list')
+        self.url = reverse('v3:discovery-list')
 
         self.addons = get_dummy_addons()
 
@@ -214,7 +214,7 @@ class TestDiscoveryRecommendations(DiscoveryTestMixin, TestCase):
         # If no recommendations then results should be as before - tests from
         # the parent class check this.
         self.get_recommendations.return_value = []
-        self.url = reverse('discovery-list')
+        self.url = reverse('v3:discovery-list')
 
     def test_recommendations(self):
         author = user_factory()

--- a/src/olympia/files/models.py
+++ b/src/olympia/files/models.py
@@ -136,9 +136,6 @@ class File(OnChangeMixin, ModelBase):
         return self._make_download_url(
             'downloads.file', src, attachment=attachment)
 
-    def get_signed_url(self, src):
-        return self._make_download_url('signing.file', src)
-
     def _make_download_url(self, view_name, src, attachment=False):
         kwargs = {
             'file_id': self.pk

--- a/src/olympia/files/tests/test_models.py
+++ b/src/olympia/files/tests/test_models.py
@@ -79,13 +79,6 @@ class TestFile(TestCase, amo.tests.AMOPaths):
                     '?src=src')
         assert file_.get_url_path('src', attachment=True) == expected
 
-    def test_get_signed_url(self):
-        file_ = File.objects.get(id=67442)
-        url = file_.get_signed_url('src')
-        expected = ('/api/v3/file/67442/'
-                    'delicious_bookmarks-2.1.072-fx.xpi?src=src')
-        assert url.endswith(expected), url
-
     def check_delete(self, file_, filename):
         """Test that when the File object is deleted, it is removed from the
         filesystem."""

--- a/src/olympia/github/tests/test_views.py
+++ b/src/olympia/github/tests/test_views.py
@@ -16,7 +16,7 @@ class TestGithubView(AMOPaths, GithubBaseTestCase, TestCase):
 
     def setUp(self):
         super(TestGithubView, self).setUp()
-        self.url = reverse('github.validate')
+        self.url = reverse('v3:github.validate')
 
     def post(self, data, header=None, data_type=None):
         data_type = data_type or 'application/json'

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1698,13 +1698,18 @@ REST_FRAMEWORK = {
         'rest_framework.parsers.FormParser',
         'olympia.api.parsers.MultiPartParser',
     ),
+
+    'ALLOWED_VERSIONS': ['v3', 'v4'],
+    'DEFAULT_VERSION': 'v4',
+    'DEFAULT_VERSIONING_CLASS': (
+        'rest_framework.versioning.NamespaceVersioning'),
+
     # Add our custom exception handler, that wraps all exceptions into
     # Responses and not just the ones that are api-related.
     'EXCEPTION_HANDLER': 'olympia.api.exceptions.custom_exception_handler',
 
     # Enable pagination
     'PAGE_SIZE': 25,
-
     # Use our pagination class by default, which allows clients to request a
     # different page size.
     'DEFAULT_PAGINATION_CLASS': (

--- a/src/olympia/ratings/tests/test_views.py
+++ b/src/olympia/ratings/tests/test_views.py
@@ -720,7 +720,7 @@ class TestRatingViewSetGet(TestCase):
     def setUp(self):
         self.addon = addon_factory(
             guid=generate_addon_guid(), name=u'My Addôn', slug='my-addon')
-        self.url = reverse('rating-list')
+        self.url = reverse('v3:rating-list')
 
     def test_list_addon(self, **kwargs):
         review1 = Rating.objects.create(
@@ -1153,7 +1153,7 @@ class TestRatingViewSetGet(TestCase):
     def test_detail(self):
         review = Rating.objects.create(
             addon=self.addon, body='review 1', user=user_factory())
-        self.url = reverse('rating-detail', kwargs={'pk': review.pk})
+        self.url = reverse('v3:rating-detail', kwargs={'pk': review.pk})
 
         response = self.client.get(self.url)
         assert response.status_code == 200
@@ -1166,7 +1166,7 @@ class TestRatingViewSetGet(TestCase):
         reply = Rating.objects.create(
             addon=self.addon, body='reply to review', user=user_factory(),
             reply_to=review)
-        self.url = reverse('rating-detail', kwargs={'pk': reply.pk})
+        self.url = reverse('v3:rating-detail', kwargs={'pk': reply.pk})
 
         response = self.client.get(self.url)
         assert response.status_code == 200
@@ -1176,7 +1176,7 @@ class TestRatingViewSetGet(TestCase):
     def test_detail_deleted(self):
         review = Rating.objects.create(
             addon=self.addon, body='review 1', user=user_factory())
-        self.url = reverse('rating-detail', kwargs={'pk': review.pk})
+        self.url = reverse('v3:rating-detail', kwargs={'pk': review.pk})
         review.delete()
 
         response = self.client.get(self.url)
@@ -1189,7 +1189,7 @@ class TestRatingViewSetGet(TestCase):
             addon=self.addon, body='reply to review', user=user_factory(),
             reply_to=review)
         reply.delete()
-        self.url = reverse('rating-detail', kwargs={'pk': review.pk})
+        self.url = reverse('v3:rating-detail', kwargs={'pk': review.pk})
 
         response = self.client.get(self.url)
         assert response.status_code == 200
@@ -1208,7 +1208,7 @@ class TestRatingViewSetGet(TestCase):
             reply_to=review)
         reply.delete()
         review.delete()
-        self.url = reverse('rating-detail', kwargs={'pk': review.pk})
+        self.url = reverse('v3:rating-detail', kwargs={'pk': review.pk})
 
         response = self.client.get(self.url)
         assert response.status_code == 200
@@ -1396,7 +1396,7 @@ class TestRatingViewSetDelete(TestCase):
         self.rating = Rating.objects.create(
             addon=self.addon, version=self.addon.current_version, rating=1,
             body='My review', user=self.user)
-        self.url = reverse('rating-detail', kwargs={'pk': self.rating.pk})
+        self.url = reverse('v3:rating-detail', kwargs={'pk': self.rating.pk})
 
     def test_delete_anonymous(self):
         response = self.client.delete(self.url)
@@ -1458,7 +1458,7 @@ class TestRatingViewSetDelete(TestCase):
         reply = Rating.objects.create(
             addon=self.addon, reply_to=self.rating,
             body=u'Reply that will be delêted...', user=addon_author)
-        self.url = reverse('rating-detail', kwargs={'pk': reply.pk})
+        self.url = reverse('v3:rating-detail', kwargs={'pk': reply.pk})
 
         response = self.client.delete(self.url)
         assert response.status_code == 204
@@ -1467,7 +1467,8 @@ class TestRatingViewSetDelete(TestCase):
 
     def test_delete_404(self):
         self.client.login_api(self.user)
-        self.url = reverse('rating-detail', kwargs={'pk': self.rating.pk + 42})
+        self.url = reverse(
+            'v3:rating-detail', kwargs={'pk': self.rating.pk + 42})
         response = self.client.delete(self.url)
         assert response.status_code == 404
         assert Rating.objects.count() == 1
@@ -1483,10 +1484,10 @@ class TestRatingViewSetDelete(TestCase):
         # And confirm we can rapidly delete them.
         self.client.login_api(self.user)
         response = self.client.delete(
-            reverse('rating-detail', kwargs={'pk': rating_a.pk}))
+            reverse('v3:rating-detail', kwargs={'pk': rating_a.pk}))
         assert response.status_code == 204
         response = self.client.delete(
-            reverse('rating-detail', kwargs={'pk': rating_b.pk}))
+            reverse('v3:rating-detail', kwargs={'pk': rating_b.pk}))
         assert response.status_code == 204
         assert Rating.objects.count() == 0
 
@@ -1501,7 +1502,7 @@ class TestRatingViewSetEdit(TestCase):
         self.rating = Rating.objects.create(
             addon=self.addon, version=self.addon.current_version, rating=1,
             body=u'My revïew', title=u'Titlé', user=self.user)
-        self.url = reverse('rating-detail', kwargs={'pk': self.rating.pk})
+        self.url = reverse('v3:rating-detail', kwargs={'pk': self.rating.pk})
 
     def test_edit_anonymous(self):
         response = self.client.patch(self.url, {'body': u'løl!'})
@@ -1609,7 +1610,7 @@ class TestRatingViewSetEdit(TestCase):
         reply = Rating.objects.create(
             reply_to=self.rating, body=u'This is â reply', user=addon_author,
             addon=self.addon)
-        self.url = reverse('rating-detail', kwargs={'pk': reply.pk})
+        self.url = reverse('v3:rating-detail', kwargs={'pk': reply.pk})
 
         response = self.client.patch(self.url, {'rating': 5})
         assert response.status_code == 200
@@ -1644,7 +1645,7 @@ class TestRatingViewSetPost(TestCase):
     def setUp(self):
         self.addon = addon_factory(
             guid=generate_addon_guid(), name=u'My Addôn', slug='my-addon')
-        self.url = reverse('rating-list')
+        self.url = reverse('v3:rating-list')
 
     def test_post_anonymous(self):
         response = self.client.post(self.url, {
@@ -2011,7 +2012,7 @@ class TestRatingViewSetPost(TestCase):
             self.client.login_api(self.user)
 
             # Submit an abuse report
-            report_abuse_url = reverse('abusereportaddon-list')
+            report_abuse_url = reverse('v3:abusereportaddon-list')
             response = self.client.post(
                 report_abuse_url,
                 data={'addon': unicode(self.addon.pk), 'message': 'lol!'},
@@ -2060,7 +2061,7 @@ class TestRatingViewSetFlag(TestCase):
         self.rating = Rating.objects.create(
             addon=self.addon, version=self.addon.current_version, rating=1,
             body='My review', user=self.rating_user)
-        self.url = reverse('rating-flag', kwargs={'pk': self.rating.pk})
+        self.url = reverse('v3:rating-flag', kwargs={'pk': self.rating.pk})
 
     def test_url(self):
         expected_url = '/api/v3/reviews/review/%d/flag/' % self.rating.pk
@@ -2198,7 +2199,7 @@ class TestRatingViewSetFlag(TestCase):
         rating_b = Rating.objects.create(
             addon=addon_b, version=addon_b.current_version, rating=2,
             body='My review', user=self.rating_user)
-        url_b = reverse('rating-flag', kwargs={'pk': rating_b.pk})
+        url_b = reverse('v3:rating-flag', kwargs={'pk': rating_b.pk})
 
         response = self.client.post(
             self.url, data={'flag': 'review_flag_reason_spam'})
@@ -2220,7 +2221,7 @@ class TestRatingViewSetReply(TestCase):
         self.rating = Rating.objects.create(
             addon=self.addon, version=self.addon.current_version, rating=1,
             body='My review', user=self.rating_user)
-        self.url = reverse('rating-reply', kwargs={'pk': self.rating.pk})
+        self.url = reverse('v3:rating-reply', kwargs={'pk': self.rating.pk})
 
     def test_url(self):
         expected_url = '/api/v3/reviews/review/%d/reply/' % self.rating.pk
@@ -2246,7 +2247,8 @@ class TestRatingViewSetReply(TestCase):
         self.addon_author = user_factory()
         self.addon.addonuser_set.create(user=self.addon_author)
         self.client.login_api(self.addon_author)
-        self.url = reverse('rating-reply', kwargs={'pk': self.rating.pk + 42})
+        self.url = reverse(
+            'v3:rating-reply', kwargs={'pk': self.rating.pk + 42})
         response = self.client.post(self.url, data={})
         assert response.status_code == 404
 

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -301,8 +301,8 @@
     <ul>
       <li>
         <input type="checkbox" id="notify_new_listed_versions"
-               data-api-url-subscribe="{{ url('reviewers-addon-subscribe', addon.pk) }}"
-               data-api-url-unsubscribe="{{ url('reviewers-addon-unsubscribe', addon.pk) }}"
+               data-api-url-subscribe="{{ drf_url('reviewers-addon-subscribe', addon.pk) }}"
+               data-api-url-unsubscribe="{{ drf_url('reviewers-addon-unsubscribe', addon.pk) }}"
                {% if subscribed %}checked="checked"{% endif %} autocomplete="off" />
           <label for="notify_new_listed_versions">{{ _('Notify me about new listed versions') }}</label>
       </li>
@@ -310,25 +310,25 @@
     {% if is_admin %}
     <ul class="admin_only">
         <li {% if addon.status == amo.STATUS_DISABLED %}class="hidden"{% endif %}>
-          <button data-api-url="{{ url('reviewers-addon-disable', addon.pk) }}"
+          <button data-api-url="{{ drf_url('reviewers-addon-disable', addon.pk) }}"
                   data-toggle-button-selector="#force_enable_addon"
                   id="force_disable_addon" type="button">{{ _('Force-disable add-on') }}</button>
         </li>
         <li {% if addon.status != amo.STATUS_DISABLED %}class="hidden"{% endif %}>
-          <button data-api-url="{{ url('reviewers-addon-enable', addon.pk) }}"
+          <button data-api-url="{{ drf_url('reviewers-addon-enable', addon.pk) }}"
                   data-toggle-button-selector="#force_disable_addon"
                   id="force_enable_addon" type="button">{{ _('Force-enable add-on') }}</button>
         </li>
         {% if addon.type in (amo.ADDON_EXTENSION, amo.ADDON_LPAPP) %}
           <li {% if addon.auto_approval_disabled %}class="hidden"{% endif %}>
-            <button data-api-url="{{ url('reviewers-addon-flags', addon.pk) }}"
+            <button data-api-url="{{ drf_url('reviewers-addon-flags', addon.pk) }}"
                     data-api-method="patch"
                     data-api-data="{&quot;auto_approval_disabled&quot;: true}"
                     data-toggle-button-selector="#enable_auto_approval"
                     id="disable_auto_approval" type="button">{{ _('Disable Auto-Approval') }}</button>
           </li>
           <li {% if not addon.auto_approval_disabled %}class="hidden"{% endif %}>
-            <button data-api-url="{{ url('reviewers-addon-flags', addon.pk) }}"
+            <button data-api-url="{{ drf_url('reviewers-addon-flags', addon.pk) }}"
                     data-api-method="patch"
                     data-api-data="{&quot;auto_approval_disabled&quot;: false}"
                     data-toggle-button-selector="#disable_auto_approval"
@@ -337,7 +337,7 @@
         {% endif %}
         {% if addon.pending_info_request %}
           <li>
-              <button data-api-url="{{ url('reviewers-addon-flags', addon.pk) }}"
+              <button data-api-url="{{ drf_url('reviewers-addon-flags', addon.pk) }}"
                       data-api-method="patch"
                       data-api-data="{&quot;pending_info_request&quot;: null}"
                       id="clear_pending_info_request" type="button">{{ _('Clear information request') }}</button>
@@ -345,7 +345,7 @@
         {% endif %}
         {% if addon.needs_admin_code_review %}
           <li>
-            <button data-api-url="{{ url('reviewers-addon-flags', addon.pk) }}"
+            <button data-api-url="{{ drf_url('reviewers-addon-flags', addon.pk) }}"
                     data-api-method="patch"
                     data-api-data="{&quot;needs_admin_code_review&quot;: false}"
                     id="clear_admin_code_review"  type="button">{{ _('Clear Admin Code Review Flag') }}</button>
@@ -353,7 +353,7 @@
         {% endif %}
         {% if addon.needs_admin_content_review %}
           <li>
-            <button data-api-url="{{ url('reviewers-addon-flags', addon.pk) }}"
+            <button data-api-url="{{ drf_url('reviewers-addon-flags', addon.pk) }}"
                     data-api-method="patch"
                     data-api-data="{&quot;needs_admin_content_review&quot;: false}"
                     id="clear_admin_content_review" type="button">{{ _('Clear Admin Content Review Flag') }}</button>
@@ -361,7 +361,7 @@
         {% endif %}
         {% if addon.needs_admin_theme_review %}
           <li>
-            <button data-api-url="{{ url('reviewers-addon-flags', addon.pk) }}"
+            <button data-api-url="{{ drf_url('reviewers-addon-flags', addon.pk) }}"
                     data-api-method="patch"
                     data-api-data="{&quot;needs_admin_theme_review&quot;: false}"
                     id="clear_admin_theme_review" type="button">{{ _('Clear Admin Static Theme Review Flag') }}</button>

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -4693,15 +4693,15 @@ class TestAddonReviewerViewSet(TestCase):
         self.user = user_factory()
         self.addon = addon_factory()
         self.subscribe_url = reverse(
-            'reviewers-addon-subscribe', kwargs={'pk': self.addon.pk})
+            'v3:reviewers-addon-subscribe', kwargs={'pk': self.addon.pk})
         self.unsubscribe_url = reverse(
-            'reviewers-addon-unsubscribe', kwargs={'pk': self.addon.pk})
+            'v3:reviewers-addon-unsubscribe', kwargs={'pk': self.addon.pk})
         self.enable_url = reverse(
-            'reviewers-addon-enable', kwargs={'pk': self.addon.pk})
+            'v3:reviewers-addon-enable', kwargs={'pk': self.addon.pk})
         self.disable_url = reverse(
-            'reviewers-addon-disable', kwargs={'pk': self.addon.pk})
+            'v3:reviewers-addon-disable', kwargs={'pk': self.addon.pk})
         self.flags_url = reverse(
-            'reviewers-addon-flags', kwargs={'pk': self.addon.pk})
+            'v3:reviewers-addon-flags', kwargs={'pk': self.addon.pk})
 
     def test_subscribe_not_logged_in(self):
         response = self.client.post(self.subscribe_url)
@@ -4716,7 +4716,7 @@ class TestAddonReviewerViewSet(TestCase):
         self.grant_permission(self.user, 'Addons:PostReview')
         self.client.login_api(self.user)
         self.subscribe_url = reverse(
-            'reviewers-addon-subscribe', kwargs={'pk': self.addon.pk + 42})
+            'v3:reviewers-addon-subscribe', kwargs={'pk': self.addon.pk + 42})
         response = self.client.post(self.subscribe_url)
         assert response.status_code == 404
 
@@ -4726,7 +4726,7 @@ class TestAddonReviewerViewSet(TestCase):
         self.grant_permission(self.user, 'Addons:PostReview')
         self.client.login_api(self.user)
         self.subscribe_url = reverse(
-            'reviewers-addon-subscribe', kwargs={'pk': self.addon.pk})
+            'v3:reviewers-addon-subscribe', kwargs={'pk': self.addon.pk})
         response = self.client.post(self.subscribe_url)
         assert response.status_code == 202
         assert ReviewerSubscription.objects.count() == 1
@@ -4735,7 +4735,7 @@ class TestAddonReviewerViewSet(TestCase):
         self.grant_permission(self.user, 'Addons:PostReview')
         self.client.login_api(self.user)
         self.subscribe_url = reverse(
-            'reviewers-addon-subscribe', kwargs={'pk': self.addon.pk})
+            'v3:reviewers-addon-subscribe', kwargs={'pk': self.addon.pk})
         response = self.client.post(self.subscribe_url)
         assert response.status_code == 202
         assert ReviewerSubscription.objects.count() == 1
@@ -4753,7 +4753,7 @@ class TestAddonReviewerViewSet(TestCase):
         self.grant_permission(self.user, 'Addons:PostReview')
         self.client.login_api(self.user)
         self.unsubscribe_url = reverse(
-            'reviewers-addon-subscribe', kwargs={'pk': self.addon.pk + 42})
+            'v3:reviewers-addon-subscribe', kwargs={'pk': self.addon.pk + 42})
         response = self.client.post(self.unsubscribe_url)
         assert response.status_code == 404
 
@@ -4761,7 +4761,7 @@ class TestAddonReviewerViewSet(TestCase):
         self.grant_permission(self.user, 'Addons:PostReview')
         self.client.login_api(self.user)
         self.subscribe_url = reverse(
-            'reviewers-addon-subscribe', kwargs={'pk': self.addon.pk})
+            'v3:reviewers-addon-subscribe', kwargs={'pk': self.addon.pk})
         response = self.client.post(self.unsubscribe_url)
         assert response.status_code == 202
         assert ReviewerSubscription.objects.count() == 0
@@ -4772,7 +4772,7 @@ class TestAddonReviewerViewSet(TestCase):
         self.grant_permission(self.user, 'Addons:PostReview')
         self.client.login_api(self.user)
         self.subscribe_url = reverse(
-            'reviewers-addon-subscribe', kwargs={'pk': self.addon.pk})
+            'v3:reviewers-addon-subscribe', kwargs={'pk': self.addon.pk})
         response = self.client.post(self.unsubscribe_url)
         assert response.status_code == 202
         assert ReviewerSubscription.objects.count() == 0
@@ -4789,7 +4789,7 @@ class TestAddonReviewerViewSet(TestCase):
         self.grant_permission(self.user, 'Addons:PostReview')
         self.client.login_api(self.user)
         self.subscribe_url = reverse(
-            'reviewers-addon-subscribe', kwargs={'pk': self.addon.pk})
+            'v3:reviewers-addon-subscribe', kwargs={'pk': self.addon.pk})
         response = self.client.post(self.unsubscribe_url)
         assert response.status_code == 202
         assert ReviewerSubscription.objects.count() == 2
@@ -4814,7 +4814,7 @@ class TestAddonReviewerViewSet(TestCase):
         self.grant_permission(self.user, 'Reviews:Admin')
         self.client.login_api(self.user)
         self.enable_url = reverse(
-            'reviewers-addon-enable', kwargs={'pk': self.addon.pk + 42})
+            'v3:reviewers-addon-enable', kwargs={'pk': self.addon.pk + 42})
         response = self.client.post(self.enable_url)
         assert response.status_code == 404
 
@@ -4882,7 +4882,7 @@ class TestAddonReviewerViewSet(TestCase):
         self.grant_permission(self.user, 'Reviews:Admin')
         self.client.login_api(self.user)
         self.disable_url = reverse(
-            'reviewers-addon-enable', kwargs={'pk': self.addon.pk + 42})
+            'v3:reviewers-addon-enable', kwargs={'pk': self.addon.pk + 42})
         response = self.client.post(self.disable_url)
         assert response.status_code == 404
 
@@ -4920,7 +4920,7 @@ class TestAddonReviewerViewSet(TestCase):
         self.grant_permission(self.user, 'Reviews:Admin')
         self.client.login_api(self.user)
         self.flags_url = reverse(
-            'reviewers-addon-flags', kwargs={'pk': self.addon.pk + 42})
+            'v3:reviewers-addon-flags', kwargs={'pk': self.addon.pk + 42})
         response = self.client.patch(
             self.flags_url, {'auto_approval_disabled': True})
         assert response.status_code == 404

--- a/src/olympia/search/tests/test_search_ranking.py
+++ b/src/olympia/search/tests/test_search_ranking.py
@@ -11,7 +11,7 @@ class TestRankingScenarios(ESTestCase):
 
     def _check_scenario(self, query, expected, no_match=None):
         # Make sure things are properly flushed and searchable
-        url = reverse('addon-search')
+        url = reverse('v3:addon-search')
 
         response = self.client.get(url, {'q': query})
         assert response.status_code == 200

--- a/src/olympia/signing/views.py
+++ b/src/olympia/signing/views.py
@@ -99,8 +99,9 @@ class VersionView(APIView):
                 {'error': exc.message},
                 status=exc.code or status.HTTP_400_BAD_REQUEST)
 
-        return Response(FileUploadSerializer(file_upload).data,
-                        status=status.HTTP_201_CREATED)
+        serializer = FileUploadSerializer(
+            file_upload, context={'request': request})
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     @handle_read_only_mode
     @with_addon(allow_missing=True)
@@ -116,8 +117,9 @@ class VersionView(APIView):
         status_code = (
             status.HTTP_201_CREATED if created else status.HTTP_202_ACCEPTED)
 
-        return Response(FileUploadSerializer(file_upload).data,
-                        status=status_code)
+        serializer = FileUploadSerializer(
+            file_upload, context={'request': request})
+        return Response(serializer.data, status=status_code)
 
     @write
     def handle_upload(self, request, addon, version_string, guid=None):
@@ -237,7 +239,8 @@ class VersionView(APIView):
         except Version.DoesNotExist:
             version = None
 
-        serializer = FileUploadSerializer(file_upload, version=version)
+        serializer = FileUploadSerializer(
+            file_upload, version=version, context={'request': request})
         return Response(serializer.data)
 
 


### PR DESCRIPTION
fixes #8139 (doesn't add API Gates, just namespace level switching for now)

Using namespacing requires some changes to our `reverse` usage.  Django `reverse`, and AMO's monkey-patch wrapper of it, don't understand DRF API namespacing, so have to explicitly reference an API view that was previously named `'addon-detail'` as `'v3:addon-detail'` or `'v4:addon-detail'`.  To do it properly we have to use DRF's `reverse` instead, and supply it with a `request=request` parameter (that has already gone through the middleware that sets up namespacing).  

So this PR changes the references to our v3 or v4 API code to use DRF's `reverse`, and namespacing magic means `reverse` expands to the matching version of the API the request came in on. (The `drf_url` jinja filter does this for non-API code referencing API urls).

Our tests, however, are a problem - we extensively use `reverse` to get the url to test with; where we have don't have a request, and we're using AMO's `reverse` anyway.  To avoid a lot of rewrite, or/and a hacky `require` wrapper, I just changed them to `v3:foo-baa` from `foo-baa`.  This has the advantage of testing the `v3` code path, and when we made a change in `v4` we can explicitly have new tests referencing `v4:...` instead.  This isn't a perfect solution though so I'm open to good alternatives.