### PR TITLE
Prevent developers from having several active api keys at the same time

### DIFF
--- a/src/olympia/api/management/commands/revoke_api_keys.py
+++ b/src/olympia/api/management/commands/revoke_api_keys.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
                     continue
                 else:
                     with transaction.atomic():
-                        apikey.update(is_active=False)
+                        apikey.update(is_active=None)
                         APIKey.new_jwt_credentials(user=apikey.user)
                     revoked_count += 1
                     self.stdout.write(

--- a/src/olympia/api/models.py
+++ b/src/olympia/api/models.py
@@ -23,6 +23,11 @@ class APIKey(ModelBase):
     A developer's key/secret pair to access the API.
     """
     user = models.ForeignKey(UserProfile, related_name='api_keys')
+
+    # A user can only have one active key at the same time, it's enforced by
+    # a unique db constraint. Since we keep old inactive keys though, nulls
+    # need to be allowed (and we need to always set is_active=None instead of
+    # is_active=False when revoking keys).
     is_active = models.NullBooleanField(default=True)
     type = models.PositiveIntegerField(
         choices=dict(zip(API_KEY_TYPES, API_KEY_TYPES)).items(), default=0)

--- a/src/olympia/api/tests/test_authentication.py
+++ b/src/olympia/api/tests/test_authentication.py
@@ -186,7 +186,7 @@ class TestJWTKeyAuthProtectedView(WithDynamicEndpoints, JWTAuthKeyTester):
         assert data['user_pk'] == self.user.pk
 
     def test_api_key_must_be_active(self):
-        api_key = self.create_api_key(self.user, is_active=False)
+        api_key = self.create_api_key(self.user, is_active=None)
         token = self.create_auth_token(api_key.user, api_key.key,
                                        api_key.secret)
         res = self.jwt_request(token, 'post', {})

--- a/src/olympia/api/tests/test_commands.py
+++ b/src/olympia/api/tests/test_commands.py
@@ -43,7 +43,7 @@ class TestRevokeAPIKeys(TestCase):
             'ab2228544a061cb2af21af97f637cc58e1f8340196f1ddc3de329b5974694b26')
         apikey = APIKey.objects.create(
             key='user:{}:{}'.format(user.pk, '333'), secret=right_secret,
-            user=user, is_active=False)  # inactive APIKey.
+            user=user, is_active=None)  # inactive APIKey.
         stdout = StringIO()
         call_command('revoke_api_keys', self.csv_path, stdout=stdout)
         stdout.seek(0)
@@ -57,7 +57,7 @@ class TestRevokeAPIKeys(TestCase):
         # additional APIKeys.
         apikey.reload()
         assert apikey.secret == right_secret
-        assert not apikey.is_active
+        assert apikey.is_active is None
         assert APIKey.objects.filter(user=user).count() == 1
 
     def test_api_key_has_wrong_secret(self):
@@ -77,7 +77,7 @@ class TestRevokeAPIKeys(TestCase):
         assert output[1] == (
             'Ignoring APIKey user:67890:333, it does not exist.\n')
 
-        # APIKey is still active, secret hasn't changed, there are no
+        # API key is still active, secret hasn't changed, there are no
         # additional APIKeys.
         apikey.reload()
         assert apikey.secret == right_secret
@@ -105,10 +105,10 @@ class TestRevokeAPIKeys(TestCase):
         assert output[3] == (
             'Done. Revoked 1 keys out of 3 entries.\n')
 
-        # APIKey is still active, secret hasn't changed, there are no
-        # additional APIKeys.
+        # API key is now inactive, secret hasn't changed, the other user api
+        # key is still there, there are no additional APIKeys.
         apikey.reload()
         assert apikey.secret == right_secret
-        assert not apikey.is_active
+        assert apikey.is_active is None
         assert APIKey.objects.filter(user=user).count() == 2
         assert APIKey.objects.filter(user=user, is_active=True).count() == 1

--- a/src/olympia/api/tests/test_jwt_auth.py
+++ b/src/olympia/api/tests/test_jwt_auth.py
@@ -83,8 +83,8 @@ class TestJWTKeyAuthDecodeHandler(JWTAuthKeyTester):
         token = self.create_auth_token(api_key.user, api_key.key,
                                        api_key.secret)
 
-        decoy_api_key = self.create_api_key(
-            self.user, key='another-issuer', secret='another-secret')
+        decoy_api_key = APIKey(  # Don't save in database, it would conflict.
+            user=self.user, key=api_key.key, secret='another-secret')
 
         with self.assertRaises(jwt.DecodeError) as ctx:
             jwt_auth.jwt_decode_handler(

--- a/src/olympia/api/tests/test_models.py
+++ b/src/olympia/api/tests/test_models.py
@@ -1,5 +1,7 @@
 import mock
 
+from django.db import IntegrityError
+
 from olympia.amo.tests import TestCase
 from olympia.users.models import UserProfile
 
@@ -28,12 +30,20 @@ class TestAPIKey(TestCase):
         assert credentials.secret not in str_creds
         assert str(credentials.user) in str_creds
 
+    def test_cant_have_two_active_keys_for_same_user(self):
+        APIKey.new_jwt_credentials(self.user)
+        with self.assertRaises(IntegrityError):
+            APIKey.new_jwt_credentials(self.user)
+
     def test_generate_new_unique_keys(self):
         last_key = None
         for counter in range(3):
             credentials = APIKey.new_jwt_credentials(self.user)
             assert credentials.key != last_key
             last_key = credentials.key
+            # Deactivate last key so that we can create a new one without
+            # triggering an IntegrityError.
+            credentials.update(is_active=None)
 
     def test_too_many_tries_at_finding_a_unique_key(self):
         max = 3
@@ -56,8 +66,12 @@ class TestAPIKey(TestCase):
             APIKey.generate_secret(31)
 
     def test_hide_inactive_jwt_keys(self):
-        active_key = APIKey.new_jwt_credentials(self.user)
         inactive_key = APIKey.new_jwt_credentials(self.user)
-        inactive_key.update(is_active=False)
+        inactive_key.update(is_active=None)
+        # Make a new active key, but that is somehow older than the inactive
+        # one: it should still be the one returned by get_jwt_key(), since it's
+        # the only active one.
+        active_key = APIKey.new_jwt_credentials(self.user)
+        active_key.update(created=self.days_ago(1))
         fetched_key = APIKey.get_jwt_key(user=self.user)
         assert fetched_key == active_key

--- a/src/olympia/devhub/tasks.py
+++ b/src/olympia/devhub/tasks.py
@@ -508,7 +508,7 @@ def revoke_api_key(key_id):
         else:
             with transaction.atomic():
                 log.info('Revoking key for user %s.' % current_key.user)
-                current_key.update(is_active=False)
+                current_key.update(is_active=None)
                 send_api_key_revocation_email(emails=[current_key.user.email])
     except APIKey.DoesNotExist:
         log.info('User %s has already revoked the key, nothing to be done.'

--- a/src/olympia/devhub/templates/devhub/api/key.html
+++ b/src/olympia/devhub/templates/devhub/api/key.html
@@ -9,7 +9,7 @@
 
 <section class="primary full">
   <div class="island prettyform row">
-    <form method="post" class="item">
+    <form method="post" class="item api-credentials">
       {% csrf_token %}
       <fieldset>
         <legend>

--- a/src/olympia/devhub/tests/test_tasks.py
+++ b/src/olympia/devhub/tests/test_tasks.py
@@ -1192,7 +1192,7 @@ class TestAPIKeyInSubmission(TestCase):
         assert mail.outbox[0].to[0] == self.user.email
 
     def test_api_key_already_revoked_by_developer(self):
-        self.key.update(is_active=False)
+        self.key.update(is_active=None)
         tasks.revoke_api_key(self.key.id)
         # If the key has already been revoked, there is no active key,
         # so `get_jwt_key` raises `DoesNotExist`.
@@ -1200,7 +1200,7 @@ class TestAPIKeyInSubmission(TestCase):
             APIKey.get_jwt_key(user_id=self.user.id)
 
     def test_api_key_already_regenerated_by_developer(self):
-        self.key.update(is_active=False)
+        self.key.update(is_active=None)
         current_key = APIKey.new_jwt_credentials(user=self.user)
         tasks.revoke_api_key(self.key.id)
         key_from_db = APIKey.get_jwt_key(user_id=self.user.id)

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -784,7 +784,7 @@ class TestAPIKeyPage(TestCase):
         self.assert3xx(response, self.url)
 
         old_key = APIKey.objects.get(pk=old_key.pk)
-        assert not old_key.is_active
+        assert old_key.is_active is None
 
         new_key = APIKey.get_jwt_key(user=self.user)
         assert new_key.key != old_key.key
@@ -799,7 +799,7 @@ class TestAPIKeyPage(TestCase):
         self.assert3xx(response, self.url)
 
         old_key = APIKey.objects.get(pk=old_key.pk)
-        assert not old_key.is_active
+        assert old_key.is_active is None
 
         assert len(mail.outbox) == 1
         assert 'revoked' in mail.outbox[0].body

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -1765,7 +1765,7 @@ def api_key(request):
     if request.method == 'POST' and request.POST.get('action') == 'generate':
         if credentials:
             log.info('JWT key was made inactive: {}'.format(credentials))
-            credentials.update(is_active=False)
+            credentials.update(is_active=None)
             msg = _(
                 'Your old credentials were revoked and are no longer valid. '
                 'Be sure to update all API clients with the new credentials.')
@@ -1779,7 +1779,7 @@ def api_key(request):
         return redirect(reverse('devhub.api_key'))
 
     if request.method == 'POST' and request.POST.get('action') == 'revoke':
-        credentials.update(is_active=False)
+        credentials.update(is_active=None)
         log.info('revoking JWT key for user: {}, {}'
                  .format(request.user.id, credentials))
         send_key_revoked_email(request.user.email, credentials.key)

--- a/src/olympia/migrations/1016-prevent-duplicate-api-keys.sql
+++ b/src/olympia/migrations/1016-prevent-duplicate-api-keys.sql
@@ -1,0 +1,22 @@
+-- First, disable all active API keys from users who have multiple active API
+-- keys. We can't know which one they expected to work, and they couldn't use
+-- them before anyway because of MultipleObjectsReturned exception.
+-- The double subquery is here to let MySQL update and select from the same
+-- table by creating a temporary one.
+UPDATE `api_key` SET `is_active` = 0 WHERE `user_id` IN (
+    SELECT `user_id` FROM (
+        SELECT `user_id` FROM `api_key`
+        GROUP BY `user_id` HAVING SUM(is_active) > 1
+        ORDER BY `user_id`)
+    AS `temp`);
+
+-- Allow NULLs for is_active.
+ALTER TABLE `api_key` MODIFY COLUMN `is_active` tinyint(1) NULL;
+
+-- Set all is_active=false to nulls to allow for the unique constraint to be
+-- added.
+UPDATE `api_key` SET `is_active` = NULL WHERE `is_active` = false;
+
+-- Add the unique constraint, preventing users from having more than one active
+-- key at the same time.
+ALTER TABLE `api_key` ADD UNIQUE INDEX(`user_id`, `is_active`);

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -215,6 +215,14 @@ $(document).ready(function() {
             }
         });
     });
+
+    // API credentials page
+    $('.api-credentials').on('submit', function() {
+        // Disallow double-submit. Don't actually disable the buttons, because
+        // then the correct one would not be submitted, but set the class to
+        // emulate that.
+        $(this).find('button').addClass('disabled');
+    });
 });
 
 function initPlatformChooser() {


### PR DESCRIPTION
Fix #8211