### PR TITLE
Prevent UnicodeDecodeError when passing garbage as next url during authentication

### DIFF
--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -1220,6 +1220,14 @@ class TestParseNextPath(TestCase):
         assert next_path == (
             u'/en-US/firefox/addon/dęlîcíøùs-päñčåkę/?src=hp-dl-featured')
 
+    def test_path_with_unicodedecodeerror(self):
+        parts = [
+            '09aedd38eebd72e896250ae5b7ea9c0172542b6cec7683e58227e5670df12fb2',
+            'l2vulvvtl2rldmvsb3blcnmv'
+        ]
+        next_path = views.parse_next_path(parts)
+        assert next_path is None
+
 
 class TestSessionView(TestCase):
     def login_user(self, user):

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -173,7 +173,7 @@ def parse_next_path(state_parts):
         try:
             next_path = base64.urlsafe_b64decode(
                 force_bytes(encoded_path)).decode('utf-8')
-        except TypeError:
+        except (TypeError, ValueError):
             log.info('Error decoding next_path {}'.format(
                 encoded_path))
             pass


### PR DESCRIPTION
Fix #8199