### PR TITLE
Make sure not to return duplicates in language tools API

### DIFF
--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -3437,6 +3437,17 @@ class TestLanguageToolsView(TestCase):
             file_kw={'strict_compatibility': True,
                      'status': amo.STATUS_DISABLED},
             min_app_version='58.0', max_app_version='58.*')
+        # And for the first pack, add a couple of versions that are also
+        # compatible. We should not use them though, because we only need to
+        # return the latest public version that is compatible.
+        extra_compatible_version_1 = version_factory(
+            addon=compatible_pack1, file_kw={'strict_compatibility': True},
+            min_app_version='58.0', max_app_version='58.*')
+        extra_compatible_version_1.update(created=self.days_ago(3))
+        extra_compatible_version_2 = version_factory(
+            addon=compatible_pack1, file_kw={'strict_compatibility': True},
+            min_app_version='58.0', max_app_version='58.*')
+        extra_compatible_version_2.update(created=self.days_ago(4))
 
         # Add a few of incompatible add-ons.
         incompatible_pack1 = addon_factory(

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -910,7 +910,7 @@ class LanguageToolsView(ListAPIView):
             apps__max__version_int__gte=appversions['max'],
             channel=amo.RELEASE_CHANNEL_LISTED,
             files__status=amo.STATUS_PUBLIC,
-        ).no_transforms().transform(Version.transformer)
+        ).order_by('-created').no_transforms().transform(Version.transformer)
         qs = self.get_queryset_base(application, (amo.ADDON_LPAPP,))
         return (
             qs.prefetch_related(Prefetch('versions',
@@ -921,6 +921,7 @@ class LanguageToolsView(ListAPIView):
                       versions__apps__max__version_int__gte=appversions['max'],
                       versions__channel=amo.RELEASE_CHANNEL_LISTED,
                       versions__files__status=amo.STATUS_PUBLIC)
+              .distinct()
         )
 
     @method_decorator(cache_page(60 * 60 * 24, cache='filesystem'))


### PR DESCRIPTION
Fix #8198

Because of how the data is set up I don't think I can easily express the query in a way that avoids duplicates naturally, so... `DISTINCT()` to the rescue! Hopefully it's fine because it's heavily cached.