### PR TITLE
Fix basket integration for unknown users.

### DIFF
--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -355,12 +355,12 @@ def fetch_subscribed_newsletters(user_profile):
         data = sync_user_with_basket(user_profile)
     except (basket.BasketNetworkException, basket.BasketException):
         log.exception('basket exception')
-        return ()
+        return []
 
     if not user_profile.basket_token and data is not None:
         user_profile.update(basket_token=data['token'])
     elif data is None:
-        return ()
+        return []
     return data['newsletters']
 
 
@@ -382,7 +382,6 @@ def unsubscribe_newsletter(user_profile, basket_id):
             sync_user_with_basket(user_profile)
         except (basket.BasketNetworkException, basket.BasketException):
             log.exception('basket exception')
-            return ()
 
     # If we still don't have a basket token we can't unsubscribe.
     # This usually means the user doesn't exist in basket yet, which

--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -326,15 +326,41 @@ def send_html_mail_jinja(subject, html_template, text_template, context,
     return msg
 
 
+def sync_user_with_basket(user):
+    """Syncronize a user with basket.
+
+    Returns the user data in case of a successful sync.
+    Returns `None` in case of an unsuccessful sync. This can happen
+    if the user does not exist in basket yet.
+
+    This raises an exception all other errors.
+    """
+    try:
+        data = basket.lookup_user(user.email)
+        user.update(basket_token=data['token'])
+        return data
+    except Exception as exc:
+        acceptable_errors = (
+            basket.errors.BASKET_INVALID_EMAIL,
+            basket.errors.BASKET_UNKNOWN_EMAIL)
+
+        if getattr(exc, 'code', None) in acceptable_errors:
+            return None
+        else:
+            raise
+
+
 def fetch_subscribed_newsletters(user_profile):
     try:
-        data = basket.lookup_user(user_profile.email)
+        data = sync_user_with_basket(user_profile)
     except (basket.BasketNetworkException, basket.BasketException):
         log.exception('basket exception')
         return ()
 
-    if not user_profile.basket_token:
+    if not user_profile.basket_token and data is not None:
         user_profile.update(basket_token=data['token'])
+    elif data is None:
+        return ()
     return data['newsletters']
 
 
@@ -352,15 +378,23 @@ def unsubscribe_newsletter(user_profile, basket_id):
     # `fetch_subscribed_newsletters` but since we shouldn't simply error
     # we just fetch it in case something went wrong.
     if not user_profile.basket_token:
-        basket_data = basket.lookup_user(user_profile.email)
-        user_profile.update(basket_token=basket_data['token'])
+        try:
+            sync_user_with_basket(user_profile)
+        except (basket.BasketNetworkException, basket.BasketException):
+            log.exception('basket exception')
+            return ()
 
-    try:
-        response = basket.unsubscribe(
-            user_profile.basket_token, user_profile.email, basket_id)
-        return response['status'] == 'ok'
-    except (basket.BasketNetworkException, basket.BasketException):
-        log.exception('basket exception')
+    # If we still don't have a basket token we can't unsubscribe.
+    # This usually means the user doesn't exist in basket yet, which
+    # is more or less identical with not being subscribed to any
+    # newsletters.
+    if user_profile.basket_token:
+        try:
+            response = basket.unsubscribe(
+                user_profile.basket_token, user_profile.email, basket_id)
+            return response['status'] == 'ok'
+        except (basket.BasketNetworkException, basket.BasketException):
+            log.exception('basket exception')
     return False
 
 

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1264,7 +1264,6 @@ CELERY_TASK_ROUTES = {
     'olympia.users.tasks.delete_photo': {'queue': 'users'},
     'olympia.users.tasks.update_user_ratings_task': {'queue': 'users'},
     'olympia.users.tasks.generate_secret_for_users': {'queue': 'users'},
-    'olympia.users.tasks.sync_user_with_basket': {'queue': 'users'},
 
     # Zadmin
     'olympia.zadmin.tasks.admin_email': {'queue': 'zadmin'},

--- a/src/olympia/users/tasks.py
+++ b/src/olympia/users/tasks.py
@@ -1,7 +1,5 @@
 from django.core.files.storage import default_storage as storage
 
-import basket
-
 import olympia.core.logger
 
 from olympia.amo.celery import task
@@ -50,25 +48,3 @@ def update_user_ratings_task(data, **kw):
     for pk, rating in data:
         UserProfile.objects.filter(pk=pk).update(
             averagerating=round(rating, 2))
-
-
-@task(rate_limit='250/m')
-def sync_user_with_basket(user_profile_id):
-    user = UserProfile.objects.get(pk=user_profile_id)
-    if user.basket_token:
-        return
-
-    try:
-        data = basket.lookup_user(user.email)
-        user.update(basket_token=data['token'])
-        return True
-    except Exception as exc:
-        acceptable_errors = (
-            basket.errors.BASKET_INVALID_EMAIL,
-            basket.errors.BASKET_UNKNOWN_EMAIL)
-
-        if getattr(exc, 'code', None) not in acceptable_errors:
-            task_log.exception(
-                'sync_user_with_basket() failed with error: {}, retrying'
-                .format(exc))
-            return sync_user_with_basket.retry(exc=exc, max_retries=3)


### PR DESCRIPTION
Fixes #8281

This also removes the orphaned sync_user_with_basket task. We do that
synchronisation on-demand and during the request when a user calls
it's user profile page.
