### PR TITLE
temporarily switch default to v3 for legacy pages

### DIFF
--- a/src/olympia/amo/tests/test_helpers.py
+++ b/src/olympia/amo/tests/test_helpers.py
@@ -169,7 +169,7 @@ def test_drf_url():
     rendered = render(fragment, context={'request': request})
     # As no /vX/ in the request, RESTFRAMEWORK['DEFAULT_VERSION'] is used.
     assert rendered == jinja_helpers.absolutify(
-        reverse('v4:addon-detail', args=['a3615'], add_prefix=False))
+        reverse('v3:addon-detail', args=['a3615'], add_prefix=False))
 
     with pytest.raises(NoReverseMatch):
         # Without a request it can't resolve the name correctly.

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -477,7 +477,7 @@ class TestVersion(TestCase):
         review_history_td = doc('#%s-review-history' % v1.id)[0]
         assert review_history_td.attrib['data-token'] == 'magicbeans'
         api_url = absolutify(drf_reverse(
-            'v4:version-reviewnotes-list',
+            'v3:version-reviewnotes-list',
             args=[self.addon.id, self.version.id]))
         assert review_history_td.attrib['data-api-url'] == api_url
         assert doc('.review-history-hide').length == 2

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1693,7 +1693,7 @@ REST_FRAMEWORK = {
     ),
 
     'ALLOWED_VERSIONS': ['v3', 'v4'],
-    'DEFAULT_VERSION': 'v4',
+    'DEFAULT_VERSION': 'v3',
     'DEFAULT_VERSIONING_CLASS': (
         'rest_framework.versioning.NamespaceVersioning'),
 


### PR DESCRIPTION
trivially fixes #8285 - proper fix will change a lot more and will be way too risky to cherry pick just before the prod push.