### PR TITLE
Redirect new users to edit profile in -dev

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -112,7 +112,6 @@ FXA_CONFIG = {
         'profile_host': 'https://stable.dev.lcip.org/profile/v1',
         'redirect_url': 'http://localhost:3000/fxa-authenticate',
         'scope': 'profile',
-        'skip_register_redirect': True,
     },
     'local': {
         'client_id': '1778aef72d1adfb3',

--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -171,7 +171,6 @@ FXA_CONFIG = {
         'profile_host': 'https://stable.dev.lcip.org/profile/v1',
         'redirect_url': 'https://amo.addons-dev.allizom.org/fxa-authenticate',
         'scope': 'profile',
-        'skip_register_redirect': True,
     },
     'local': {
         'client_id': env('DEVELOPMENT_FXA_CLIENT_ID'),


### PR DESCRIPTION
Fix https://github.com/mozilla/addons-frontend/issues/4376

---

Now that we have a user profile edit page in the new frontend, we should redirect new registered users to this page instead of the homepage. That's the intent of this PR.