### PR TITLE
Let basket exceptions be raised and subscribe synchronously

### DIFF
--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -1449,9 +1449,9 @@ class TestAccountNotificationViewSetUpdate(TestCase):
         request_call.assert_called_with(
             'post', 'subscribe',
             data={
-                'newsletters': 'about-addons',
+                'newsletters': 'about-addons', 'sync': 'Y',
                 'email': self.user.email},
-            headers={})
+            headers={'x-api-key': 'testkey'})
 
         with mock.patch('basket.base.request', autospec=True) as request_call:
             request_call.return_value = {

--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -351,11 +351,7 @@ def sync_user_with_basket(user):
 
 
 def fetch_subscribed_newsletters(user_profile):
-    try:
-        data = sync_user_with_basket(user_profile)
-    except (basket.BasketNetworkException, basket.BasketException):
-        log.exception('basket exception')
-        return []
+    data = sync_user_with_basket(user_profile)
 
     if not user_profile.basket_token and data is not None:
         user_profile.update(basket_token=data['token'])
@@ -365,11 +361,8 @@ def fetch_subscribed_newsletters(user_profile):
 
 
 def subscribe_newsletter(user_profile, basket_id):
-    try:
-        response = basket.subscribe(user_profile.email, basket_id)
-        return response['status'] == 'ok'
-    except (basket.BasketNetworkException, basket.BasketException):
-        log.exception('basket exception')
+    response = basket.subscribe(user_profile.email, basket_id, sync='Y')
+    return response['status'] == 'ok'
     return False
 
 
@@ -378,22 +371,16 @@ def unsubscribe_newsletter(user_profile, basket_id):
     # `fetch_subscribed_newsletters` but since we shouldn't simply error
     # we just fetch it in case something went wrong.
     if not user_profile.basket_token:
-        try:
-            sync_user_with_basket(user_profile)
-        except (basket.BasketNetworkException, basket.BasketException):
-            log.exception('basket exception')
+        sync_user_with_basket(user_profile)
 
     # If we still don't have a basket token we can't unsubscribe.
     # This usually means the user doesn't exist in basket yet, which
     # is more or less identical with not being subscribed to any
     # newsletters.
     if user_profile.basket_token:
-        try:
-            response = basket.unsubscribe(
-                user_profile.basket_token, user_profile.email, basket_id)
-            return response['status'] == 'ok'
-        except (basket.BasketNetworkException, basket.BasketException):
-            log.exception('basket exception')
+        response = basket.unsubscribe(
+            user_profile.basket_token, user_profile.email, basket_id)
+        return response['status'] == 'ok'
     return False
 
 

--- a/src/olympia/users/tests/test_forms.py
+++ b/src/olympia/users/tests/test_forms.py
@@ -327,9 +327,9 @@ class TestUserEditForm(UserFormBase):
 
         request_call.assert_called_with(
             'post', 'subscribe',
-            headers={},
+            headers={'x-api-key': 'testkey'},
             data={
-                'newsletters': 'about-addons',
+                'newsletters': 'about-addons', 'sync': 'Y',
                 'email': u'jbalogh@mozilla.com'})
 
     def test_basket_sync_behind_flag(self):


### PR DESCRIPTION
Swallowing basket errors or letting it do async calls is dangerous for us, because the user is not aware if something went wrong. Better for them to get a 500 page if things are not working properly.

Fix #8314