### PR TITLE
Let IOError and OSError be raised in file viewer, don't hide them

### DIFF
--- a/src/olympia/files/templatetags/jinja_helpers.py
+++ b/src/olympia/files/templatetags/jinja_helpers.py
@@ -294,13 +294,8 @@ class FileViewer(object):
         if not self.is_extracted():
             return {}
 
-        # In case a cron job comes along and deletes the files
-        # mid tree building.
-        try:
-            self._files = self._get_files(locale=get_language())
-            return self._files
-        except (OSError, IOError):
-            return {}
+        self._files = self._get_files(locale=get_language())
+        return self._files
 
     def truncate(self, filename, pre_length=15,
                  post_length=10, ellipsis=u'..'):

--- a/src/olympia/files/tests/test_helpers.py
+++ b/src/olympia/files/tests/test_helpers.py
@@ -304,7 +304,8 @@ class TestFileViewer(TestCase):
     def test_delete_mid_tree(self, get_sha256):
         get_sha256.side_effect = IOError('ow')
         self.viewer.extract()
-        assert {} == self.viewer.get_files()
+        with self.assertRaises(IOError):
+            self.viewer.get_files()
 
     @patch('olympia.files.templatetags.jinja_helpers.os.fsync')
     def test_verify_files_doesnt_call_fsync_regularly(self, fsync):


### PR DESCRIPTION
These exceptions are valuable, if something is triggering them hiding them and returning {} is just going to cause us to cache and display an empty list of files, that's the wrong thing to do.

Will hopefully help us figure out the root cause of #8220