### PR TITLE
Always display notification state from basket, don't trust our own data

### DIFF
--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -558,7 +558,7 @@ class AccountNotificationViewSet(ListModelMixin, GenericViewSet):
             by_basket_id = REMOTE_NOTIFICATIONS_BY_BASKET_ID
             for basket_id, notification in by_basket_id.items():
                 notification = self._get_default_object(notification)
-                notification.enabled = notification.id in newsletters
+                notification.enabled = basket_id in newsletters
                 out.append(notification)
 
         return out

--- a/src/olympia/users/forms.py
+++ b/src/olympia/users/forms.py
@@ -120,9 +120,7 @@ class UserEditForm(happyforms.ModelForm):
 
                 by_basket_id = notifications.REMOTE_NOTIFICATIONS_BY_BASKET_ID
                 for basket_id, notification in by_basket_id.items():
-                    subscribed = notification.id in newsletters
-                    if subscribed:
-                        default[notification.id] = True
+                    default[notification.id] = basket_id in newsletters
 
             # Add choices to Notification.
             choices = notifications.NOTIFICATIONS_CHOICES


### PR DESCRIPTION
2 things were wrong here:
- We didn't use basket data if the state was 'unsubscribed'
- We didn't check against the `basket_id` so the `if` was never `True`

The form had both mistakes, the API only the second one.

Fix #7808