### PR TITLE
Remove code related to Firefox hotfixes, they are no longer used

### DIFF
--- a/services/update.py
+++ b/services/update.py
@@ -221,19 +221,6 @@ class Update(object):
         else:  # Not defined or 'strict'.
             sql.append('AND appmax.version_int >= %(version_int)s ')
 
-        # Special case for bug 1031516.
-        if data['guid'] == 'firefox-hotfix@mozilla.org':
-            app_version = data['version_int']
-            hotfix_version = data['version']
-            if version_int('10') <= app_version <= version_int('16.0.1'):
-                if hotfix_version < '20121019.01':
-                    sql.append("AND versions.version = '20121019.01' ")
-                elif hotfix_version < '20130826.01':
-                    sql.append("AND versions.version = '20130826.01' ")
-            elif version_int('16.0.2') <= app_version <= version_int('24.*'):
-                if hotfix_version < '20130826.01':
-                    sql.append("AND versions.version = '20130826.01' ")
-
         sql.append('ORDER BY versions.id DESC LIMIT 1;')
 
         self.cursor.execute(''.join(sql), data)

--- a/src/olympia/lib/crypto/packaged.py
+++ b/src/olympia/lib/crypto/packaged.py
@@ -107,9 +107,8 @@ def call_signing(file_obj):
 def sign_file(file_obj):
     """Sign a File.
 
-    If there's no endpoint (signing is not enabled), or the file is a hotfix,
-    or isn't reviewed yet, or there was an error while signing, log and return
-    nothing.
+    If there's no endpoint (signing is not enabled) or isn't reviewed yet,
+    or there was an error while signing, log and return nothing.
 
     Otherwise return the signed file.
     """
@@ -121,12 +120,6 @@ def sign_file(file_obj):
     # No file? No signature.
     if not os.path.exists(file_obj.file_path):
         log.info(u'File {0} doesn\'t exist on disk'.format(file_obj.file_path))
-        return
-
-    # Don't sign hotfixes.
-    if file_obj.version.addon.guid in settings.HOTFIX_ADDON_GUIDS:
-        log.info(u'Not signing file {0}: addon is a hotfix'.format(
-            file_obj.pk))
         return
 
     # Don't sign Mozilla signed extensions (they're already signed).

--- a/src/olympia/lib/crypto/tests/test_packaged.py
+++ b/src/olympia/lib/crypto/tests/test_packaged.py
@@ -181,13 +181,6 @@ class TestPackaged(TestCase):
         assert not self.file_.hash
         assert not packaged.is_signed(self.file_.file_path)
 
-    def test_no_sign_hotfix_addons(self):
-        """Don't sign hotfix addons."""
-        for hotfix_guid in settings.HOTFIX_ADDON_GUIDS:
-            self.addon.update(guid=hotfix_guid)
-            packaged.sign_file(self.file_)
-            self.assert_not_signed()
-
     def test_no_sign_again_mozilla_signed_extensions(self):
         """Don't try to resign mozilla signed extensions."""
         self.file_.update(is_mozilla_signed_extension=True)

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1570,10 +1570,6 @@ DEFAULT_FILE_STORAGE = 'olympia.amo.utils.LocalFileStorage'
 # We currently do not have any actual timeouts during the signing-process.
 SIGNING_SERVER_MONITORING_TIMEOUT = 10
 
-# Hotfix addons (don't sign those, they're already signed by Mozilla.
-HOTFIX_ADDON_GUIDS = ['firefox-hotfix@mozilla.org',
-                      'thunderbird-hotfix@mozilla.org']
-
 AUTOGRAPH_CONFIG = {
     'server_url': env(
         'AUTOGRAPH_SERVER_URL',


### PR DESCRIPTION
They were replaced by system add-ons, which operate outside AMO.

Fix #5174