### PR TITLE
Add .cache and .vscode to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ logs/*
 supervisord.pid
 .ipython
 docker*.yml
+.cache
+.vscode


### PR DESCRIPTION
I seemed to have forgotten this branch.

`.cache` is being used by pytest as well.

r?