### PR TITLE
Revert to use amqp 2.2.2 for now.

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -70,9 +70,9 @@ amo-validator==1.11.0 \
     --hash=sha256:e5ecfb7c4643f4020c9feb2236bf3c4c8ab50940e1f5bc2aebb074412ab2da8b \
     --hash=sha256:919b8d85dc01d408341fb5e26a145cfc9b3f2affee5545d904d88e76d19ec719
 # amqp is required by kombu
-amqp==2.3.0 \
-    --hash=sha256:e28da24204bb1cdae9446a66eecbaac69659fea6a44ce58a10a7a7dae5ecd679 \
-    --hash=sha256:b17591ceb27192195f00c04e848dd4fcda2dc72a8eb27ea3ffa899299679c185
+amqp==2.2.2 \
+    --hash=sha256:4e28d3ea61a64ae61830000c909662cb053642efddbe96503db0e7783a6ee85b \
+    --hash=sha256:cba1ace9d4ff6049b190d8b7991f9c1006b443a5238021aca96dd6ad2ac9da22
 # anyjson is required by kombu
 anyjson==0.3.3 \
     --hash=sha256:37812d863c9ad3e35c0734c42e0bf0320ce8c3bed82cd20ad54cb34d158157ba


### PR DESCRIPTION
Version 2.3 seems to issue weird unicode errors.

See
https://sentry.prod.mozaws.net/operations/olympia-dev/issues/4358941/
and others for examples. Going to investigate upstream.
