### PR TITLE
Fix various tasks broken by the switch to json for celery serialization

### DIFF
--- a/src/olympia/addons/cron.py
+++ b/src/olympia/addons/cron.py
@@ -67,7 +67,7 @@ def _update_addon_average_daily_users(data, **kw):
             task_log.debug(m % (count, pk))
             continue
 
-        addon.update(average_daily_users=count)
+        addon.update(average_daily_users=int(float(count)))
 
 
 def update_addon_download_totals():

--- a/src/olympia/stats/cron.py
+++ b/src/olympia/stats/cron.py
@@ -24,22 +24,22 @@ def update_addons_collections_downloads():
     """Update addons+collections download totals."""
     raise_if_reindex_in_progress('amo')
 
-    d = (AddonCollectionCount.objects.values('addon', 'collection')
-         .annotate(sum=Sum('count')))
+    data = (AddonCollectionCount.objects.values('addon', 'collection')
+                                        .annotate(sum=Sum('count')))
 
     ts = [tasks.update_addons_collections_downloads.subtask(args=[chunk])
-          for chunk in chunked(d, 100)]
+          for chunk in chunked(data, 100)]
     group(ts).apply_async()
 
 
 def update_collections_total():
     """Update collections downloads totals."""
 
-    d = (CollectionCount.objects.values('collection_id')
-                                .annotate(sum=Sum('count')))
+    data = (CollectionCount.objects.values('collection_id')
+                                   .annotate(sum=Sum('count')))
 
     ts = [tasks.update_collections_total.subtask(args=[chunk])
-          for chunk in chunked(d, 50)]
+          for chunk in chunked(data, 50)]
     group(ts).apply_async()
 
 
@@ -51,11 +51,11 @@ def update_global_totals(date=None):
         date = datetime.datetime.strptime(date, '%Y-%m-%d').date()
     # Assume that we want to populate yesterday's stats by default.
     today = date or datetime.date.today() - datetime.timedelta(days=1)
-    today_jobs = [dict(job=job, date=today) for job in
+    today_jobs = [{'job': job, 'date': today} for job in
                   tasks._get_daily_jobs(date)]
 
     max_update = date or UpdateCount.objects.aggregate(max=Max('date'))['max']
-    metrics_jobs = [dict(job=job, date=max_update) for job in
+    metrics_jobs = [{'job': job, 'date': max_update} for job in
                     tasks._get_metrics_jobs(date)]
 
     ts = [tasks.update_global_totals.subtask(kwargs=kw)

--- a/src/olympia/stats/tasks.py
+++ b/src/olympia/stats/tasks.py
@@ -4,6 +4,7 @@ import itertools
 from django.db import connection
 from django.db.models import Max, Sum
 
+from dateutil.parser import parse as dateutil_parser
 from elasticsearch.helpers import bulk as bulk_index
 
 import olympia.core.logger
@@ -58,7 +59,7 @@ def update_global_totals(job, date, **kw):
     if isinstance(date, basestring):
         # Because of celery serialization, date is not date object, it has been
         # transformed into a string, we need the date object back.
-        date = datetime.datetime.strptime(date, '%Y-%m-%dT%H:%M:%S').date()
+        date = dateutil_parser(date).date()
 
     jobs = _get_daily_jobs(date)
     jobs.update(_get_metrics_jobs(date))

--- a/src/olympia/stats/tasks.py
+++ b/src/olympia/stats/tasks.py
@@ -55,6 +55,11 @@ def update_collections_total(data, **kw):
 def update_global_totals(job, date, **kw):
     log.info('Updating global statistics totals (%s) for (%s)' % (job, date))
 
+    if isinstance(date, basestring):
+        # Because of celery serialization, date is not date object, it has been
+        # transformed into a string, we need the date object back.
+        date = datetime.datetime.strptime(date, '%Y-%m-%dT%H:%M:%S').date()
+
     jobs = _get_daily_jobs(date)
     jobs.update(_get_metrics_jobs(date))
 
@@ -88,14 +93,14 @@ def _get_daily_jobs(date=None):
     # Passing through a datetime would not generate an error,
     # but would pass and give incorrect values.
     if isinstance(date, datetime.datetime):
-        raise ValueError('This requires a valid date, not a datetime')
+        raise ValueError('This requires a valid date object, not a datetime')
 
     # Testing on lte created date doesn't get you todays date, you need to do
     # less than next date. That's because 2012-1-1 becomes 2012-1-1 00:00
     next_date = date + datetime.timedelta(days=1)
 
     date_str = date.strftime('%Y-%m-%d')
-    extra = dict(where=['DATE(created)=%s'], params=[date_str])
+    extra = {'where': ['DATE(created)=%s'], 'params': [date_str]}
 
     # If you're editing these, note that you are returning a function!  This
     # cheesy hackery was done so that we could pass the queries to celery

--- a/src/olympia/stats/tests/test_cron.py
+++ b/src/olympia/stats/tests/test_cron.py
@@ -48,9 +48,10 @@ class TestGlobalStats(TestCase):
         global_stat = GlobalStat.objects.no_cache().get(date=date, name=job)
         assert global_stat.count == 1
 
-        # Should still work if the date is passed as an ISO string.
+        # Should still work if the date is passed as a datetime string (what
+        # celery serialization does).
         job = 'version_count_new'
-        tasks.update_global_totals(job, date.isoformat())
+        tasks.update_global_totals(job, datetime.datetime.now().isoformat())
         global_stat = GlobalStat.objects.no_cache().get(date=date, name=job)
         assert global_stat.count == 1
 

--- a/src/olympia/stats/tests/test_cron.py
+++ b/src/olympia/stats/tests/test_cron.py
@@ -3,6 +3,7 @@ import datetime
 from django.core.management import call_command
 
 import mock
+from freezegun import freeze_time
 
 from olympia import amo
 from olympia.amo.tests import TestCase, addon_factory, version_factory
@@ -17,7 +18,6 @@ class TestGlobalStats(TestCase):
     fixtures = ['stats/test_models']
 
     def test_stats_for_date(self):
-
         date = datetime.date(2009, 6, 1)
         job = 'addon_total_downloads'
 
@@ -48,9 +48,42 @@ class TestGlobalStats(TestCase):
         global_stat = GlobalStat.objects.no_cache().get(date=date, name=job)
         assert global_stat.count == 1
 
+        # Should still work if the date is passed as an ISO string.
         job = 'version_count_new'
-        tasks.update_global_totals(job, date)
+        tasks.update_global_totals(job, date.isoformat())
         global_stat = GlobalStat.objects.no_cache().get(date=date, name=job)
+        assert global_stat.count == 1
+
+    def test_through_cron(self):
+        # Yesterday, create some stuff.
+        with freeze_time(datetime.datetime.now() - datetime.timedelta(days=1)):
+            yesterday = datetime.date.today()
+
+            # Add a listed add-on, it should show up in "addon_count_new".
+            listed_addon = addon_factory()
+
+            # Add an unlisted version to that add-on, it should *not* increase
+            # the "version_count_new" count.
+            version_factory(
+                addon=listed_addon, channel=amo.RELEASE_CHANNEL_UNLISTED)
+
+            # Add an unlisted add-on, it should not show up in either
+            # "addon_count_new" or "version_count_new".
+            addon_factory(version_kw={
+                'channel': amo.RELEASE_CHANNEL_UNLISTED
+            })
+
+        # Launch the cron.
+        cron.update_global_totals()
+
+        job = 'addon_count_new'
+        global_stat = GlobalStat.objects.no_cache().get(
+            date=yesterday, name=job)
+        assert global_stat.count == 1
+
+        job = 'version_count_new'
+        global_stat = GlobalStat.objects.no_cache().get(
+            date=yesterday, name=job)
         assert global_stat.count == 1
 
     def test_input(self):

--- a/src/olympia/users/tasks.py
+++ b/src/olympia/users/tasks.py
@@ -47,4 +47,4 @@ def update_user_ratings_task(data, **kw):
                   (len(data), update_user_ratings_task.rate_limit))
     for pk, rating in data:
         UserProfile.objects.filter(pk=pk).update(
-            averagerating=round(rating, 2))
+            averagerating=round(float(rating), 2))

--- a/src/olympia/users/tests/test_cron.py
+++ b/src/olympia/users/tests/test_cron.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from olympia.amo.tests import addon_factory, TestCase, user_factory
+from olympia.ratings.models import Rating
+from olympia.users.cron import update_user_ratings
+
+
+class TestUpdateUserRatings(TestCase):
+    def test_update_user_ratings(self):
+        developer_a = user_factory()
+        developer_b = user_factory()
+        developer_c = user_factory()
+        addon1 = addon_factory(users=[developer_a, developer_b])
+        addon2 = addon_factory(users=[developer_a])
+        addon3 = addon_factory(users=[developer_b])
+        addon_deleted = addon_factory(users=[developer_a, developer_c])
+        version_deleted = addon_deleted.current_version
+        addon_deleted.delete()
+
+        Rating.objects.create(
+            rating=4, addon=addon1, version=addon1.current_version,
+            user=user_factory())
+        Rating.objects.create(
+            rating=5, addon=addon1, version=addon1.current_version,
+            user=user_factory())
+        Rating.objects.create(
+            rating=3, addon=addon2, version=addon2.current_version,
+            user=user_factory())
+        Rating.objects.create(
+            rating=5, addon=addon_deleted,
+            version=version_deleted, user=user_factory())  # Should be ignored.
+        Rating.objects.create(
+            rating=0, addon=addon3, version=addon3.current_version,
+            user=user_factory())  # Should be ignored.
+
+        update_user_ratings()
+
+        developer_a.reload()
+        developer_b.reload()
+        developer_c.reload()
+
+        assert developer_a.averagerating == 4.0  # (4+5+3) / 3.
+        assert developer_b.averagerating == 4.5  # (4+5) / 2.
+        assert developer_c.averagerating is None


### PR DESCRIPTION
Fix #8364

None of these were properly unit tested... In addition, when using `celery.group` celery is bypassing the special eager mode serialization code we added to find those kind of bugs, that didn't help... Added a new hack for that.