### PR TITLE
Fix email change task when using celery json serializer

### DIFF
--- a/src/olympia/accounts/tasks.py
+++ b/src/olympia/accounts/tasks.py
@@ -1,3 +1,5 @@
+from dateutil.parser import parse as dateutil_parser
+
 import olympia.core.logger
 
 from olympia.amo.celery import task
@@ -14,6 +16,7 @@ def primary_email_change_event(email, uid, timestamp):
     """Process the primaryEmailChangedEvent."""
     try:
         profile = UserProfile.objects.get(fxa_id=uid)
+        timestamp = dateutil_parser(timestamp)
         if (not profile.email_changed or
                 profile.email_changed < timestamp):
             profile.update(email=email, email_changed=timestamp)

--- a/src/olympia/accounts/tasks.py
+++ b/src/olympia/accounts/tasks.py
@@ -1,4 +1,4 @@
-from dateutil.parser import parse as dateutil_parser
+from datetime import datetime
 
 import olympia.core.logger
 
@@ -16,15 +16,15 @@ def primary_email_change_event(email, uid, timestamp):
     """Process the primaryEmailChangedEvent."""
     try:
         profile = UserProfile.objects.get(fxa_id=uid)
-        timestamp = dateutil_parser(timestamp)
+        changed_date = datetime.fromtimestamp(timestamp)
         if (not profile.email_changed or
-                profile.email_changed < timestamp):
-            profile.update(email=email, email_changed=timestamp)
+                profile.email_changed < changed_date):
+            profile.update(email=email, email_changed=changed_date)
             log.info('Account [%s] email [%s] changed from FxA on %s' %
-                     (profile.id, email, timestamp))
+                     (profile.id, email, changed_date))
         else:
             log.warning('Account [%s] email updated ignored, %s > %s' %
-                        (profile.id, profile.email_changed, timestamp))
+                        (profile.id, profile.email_changed, changed_date))
     except ValueError as e:
         log.error(e)
     except UserProfile.MultipleObjectsReturned:

--- a/src/olympia/accounts/tests/test_tasks.py
+++ b/src/olympia/accounts/tests/test_tasks.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from olympia.accounts.tasks import primary_email_change_event
+from olympia.accounts.tests.test_utils import totimestamp
 from olympia.amo.tests import TestCase, user_factory
 
 
@@ -11,7 +12,7 @@ class TestPrimaryEmailChangeEvent(TestCase):
                             fxa_id='ABCDEF012345689')
         primary_email_change_event(
             'new-email@example.com', 'ABCDEF012345689',
-            datetime(2017, 10, 11))
+            totimestamp(datetime(2017, 10, 11)))
         user.reload()
         assert user.email == 'new-email@example.com'
         assert user.email_changed == datetime(2017, 10, 11, 0, 0)
@@ -24,15 +25,15 @@ class TestPrimaryEmailChangeEvent(TestCase):
         tomorrow = datetime(2017, 10, 3)
 
         primary_email_change_event(
-            'today@example.com', 'ABCDEF012345689', today)
+            'today@example.com', 'ABCDEF012345689', totimestamp(today))
         assert user.reload().email == 'today@example.com'
 
         primary_email_change_event(
-            'tomorrow@example.com', 'ABCDEF012345689', tomorrow)
+            'tomorrow@example.com', 'ABCDEF012345689', totimestamp(tomorrow))
         assert user.reload().email == 'tomorrow@example.com'
 
         primary_email_change_event(
-            'yesterday@example.com', 'ABCDEF012345689', yesterday)
+            'yesterday@example.com', 'ABCDEF012345689', totimestamp(yesterday))
         assert user.reload().email != 'yesterday@example.com'
         assert user.reload().email == 'tomorrow@example.com'
 
@@ -40,4 +41,4 @@ class TestPrimaryEmailChangeEvent(TestCase):
         """Check that this doesn't throw"""
         primary_email_change_event(
             'email@example.com', 'ABCDEF012345689',
-            datetime(2017, 10, 11))
+            totimestamp(datetime(2017, 10, 11)))

--- a/src/olympia/accounts/tests/test_utils.py
+++ b/src/olympia/accounts/tests/test_utils.py
@@ -192,7 +192,7 @@ class TestProcessFxAEvent(TestCase):
         primary_email_change_event.assert_called()
         primary_email_change_event.assert_called_with(
             'new-email@example.com', 'ABCDEF012345689',
-            self.email_changed_date)
+            totimestamp(self.email_changed_date))
 
     @mock.patch('olympia.accounts.utils.primary_email_change_event.delay')
     def test_malformed_body_doesnt_throw(self, primary_email_change_event):

--- a/src/olympia/accounts/utils.py
+++ b/src/olympia/accounts/utils.py
@@ -2,7 +2,6 @@ import json
 import os
 
 from base64 import urlsafe_b64encode
-from datetime import datetime
 from urllib import urlencode
 
 from django.conf import settings
@@ -91,7 +90,7 @@ def process_fxa_event(raw_body, **kwargs):
         event = json.loads(body['Message'])
         event_type = event.get('event')
         uid = event.get('uid')
-        timestamp = datetime.fromtimestamp(event.get('ts', ''))
+        timestamp = event.get('ts', 0)
         if not (event_type and uid and timestamp):
             raise ValueError(
                 'Properties event, uuid, and ts must all be non-empty')


### PR DESCRIPTION
datetimes are passed a string to the task, so it needs to parse it.

Fix #8384