### PR TITLE
Force langpacks to only be compatible with Desktop (they don't work with Android)

### DIFF
--- a/src/olympia/files/tests/test_utils_.py
+++ b/src/olympia/files/tests/test_utils_.py
@@ -236,9 +236,32 @@ class TestManifestJSONExtractor(TestCase):
         assert data['e10s_compatibility'] == amo.E10S_COMPATIBLE_WEBEXTENSION
 
     def test_langpack(self):
-        data = self.parse({'langpack_id': 'foo'})
-        assert data['type'] == amo.ADDON_LPAPP
-        assert data['strict_compatibility'] is True
+        self.create_webext_default_versions()
+        self.create_appversion('firefox', '60.0')
+        self.create_appversion('firefox', '60.*')
+        self.create_appversion('android', '60.0')
+        self.create_appversion('android', '60.*')
+
+        data = {
+            'applications': {
+                'gecko': {
+                    'strict_min_version': '>=60.0',
+                    'strict_max_version': '=60.*',
+                    'id': '@langp'
+                }
+            },
+            'langpack_id': 'foo'
+        }
+
+        parsed_data = self.parse(data)
+        assert parsed_data['type'] == amo.ADDON_LPAPP
+        assert parsed_data['strict_compatibility'] is True
+
+        apps = parsed_data['apps']
+        assert len(apps) == 1  # Langpacks are not compatible with android.
+        assert apps[0].appdata == amo.FIREFOX
+        assert apps[0].min.version == '60.0'
+        assert apps[0].max.version == '60.*'
 
     def test_extensions_dont_have_strict_compatibility(self):
         assert self.parse({})['strict_compatibility'] is False
@@ -325,6 +348,7 @@ class TestManifestJSONExtractor(TestCase):
         self.create_appversion('android', amo.DEFAULT_WEBEXT_MAX_VERSION)
 
         apps = self.parse(data)['apps']
+        assert len(apps) == 2
 
         assert apps[0].appdata == amo.FIREFOX
         assert apps[1].appdata == amo.ANDROID
@@ -490,6 +514,9 @@ class TestManifestJSONExtractorStaticTheme(TestManifestJSONExtractor):
         # Check theme data is extracted from the manifest and returned.
         data = {'theme': {'colors': {'textcolor': "#3deb60"}}}
         assert self.parse(data)['theme'] == data['theme']
+
+    def test_langpack(self):
+        pass  # Irrelevant for static themes.
 
 
 def test_zip_folder_content():

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -406,12 +406,25 @@ class ManifestJSONExtractor(object):
 
     def apps(self):
         """Get `AppVersion`s for the application."""
-        apps = (
-            (amo.FIREFOX, amo.DEFAULT_WEBEXT_MIN_VERSION),
-            (amo.ANDROID, amo.DEFAULT_WEBEXT_MIN_VERSION_ANDROID)
-        ) if self.type != amo.ADDON_STATICTHEME else (
-            (amo.FIREFOX, amo.DEFAULT_STATIC_THEME_MIN_VERSION_FIREFOX),
-        )
+        type_ = self.type
+        if type_ == amo.ADDON_LPAPP:
+            # Langpack are only compatible with Firefox desktop at the moment.
+            # https://github.com/mozilla/addons-server/issues/8381
+            # They are all strictly compatible with a specific version, so
+            # the default min version here doesn't matter much.
+            apps = (
+                (amo.FIREFOX, amo.DEFAULT_WEBEXT_MIN_VERSION),
+            )
+        elif type_ == amo.ADDON_STATICTHEME:
+            # Static themes are only compatible with Firefox desktop >= 53.
+            apps = (
+                (amo.FIREFOX, amo.DEFAULT_STATIC_THEME_MIN_VERSION_FIREFOX),
+            )
+        else:
+            apps = (
+                (amo.FIREFOX, amo.DEFAULT_WEBEXT_MIN_VERSION),
+                (amo.ANDROID, amo.DEFAULT_WEBEXT_MIN_VERSION_ANDROID),
+            )
 
         doesnt_support_no_id = (
             self.strict_min_version and


### PR DESCRIPTION
Fix #8381