### PR TITLE
Pin pycodestyle until flake8 supports it.

### DIFF
--- a/requirements/flake8.txt
+++ b/requirements/flake8.txt
@@ -22,7 +22,7 @@ mccabe==0.6.1 \
 # pycodestyle is required by flake8
 pycodestyle==2.3.1 \
     --hash=sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9 \
-    --hash=sha256:682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766
+    --hash=sha256:682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766 # pyup: <2.4.0
 # pyflakes is required by flake8
 pyflakes==2.0.0 \
     --hash=sha256:f661252913bc1dbe7fcfcbf0af0db3f42ab65aabd1a6ca68fe5d466bace94dae \


### PR DESCRIPTION
See https://gitlab.com/pycqa/flake8/issues/415
and https://github.com/mozilla/addons-server/pull/8365 for more details.

Closes #8365
