### PR TITLE
Disable django-cache-machine on staging.

### DIFF
--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -80,6 +80,9 @@ SLAVE_DATABASES = ['slave']
 
 CACHE_MIDDLEWARE_KEY_PREFIX = CACHE_PREFIX
 
+# Disable cache-machine on dev to prepare for its removal.
+CACHE_MACHINE_ENABLED = False
+
 CACHES = {
     'filesystem': {
         'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',


### PR DESCRIPTION
Once this happened we can run our locust-tests, fix potential new
bottlenecks and then head towards production.

This should head to stage right after our tag. I'll run the locust-tests over night on stage.