### PR TITLE
Fix unbroken strings in add-on name

### DIFF
--- a/static/css/devhub/new-landing/sections/my-addons.less
+++ b/static/css/devhub/new-landing/sections/my-addons.less
@@ -34,6 +34,8 @@
   margin-left: 25px;
   display: flex;
   flex-flow: column;
+  overflow-wrap: break-word;
+  max-width: 74%;
 
   a {
     .link(@color-button-default);


### PR DESCRIPTION
Made css changes to `overflow-wrap` 

* [X] This PR relates to an existing open issue and there are no existing
      PRs open for the same issue.
* [X] Add `Fixes #ISSUENUM` at the top of your PR.
* [X] Add a description of the the changes introduced in this PR.
* [X] The change has been successfully run locally.
* [ ] Add tests to cover the changes added in this PR.
* [X] Add before and after screenshots (Only for changes that impact the UI).

Fix #8166 
Before -
![screenshot-2018-6-3 developer hub add-ons for firefox 1](https://user-images.githubusercontent.com/404460/40960808-7c0d818e-68be-11e8-9c41-6fb493019e8c.png)

After - 
![screenshot-2018-6-3 developer hub add-ons for firefox](https://user-images.githubusercontent.com/404460/40960818-8073ddea-68be-11e8-9b48-678def247c6a.png)

