### PR TITLE
Add actions to the user admin (delete picture, ban user, delete user)

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -424,6 +424,22 @@ class Addon(OnChangeMixin, ModelBase):
 
         clean_slug(self, slug_field)
 
+    def force_disable(self):
+        activity.log_create(amo.LOG.CHANGE_STATUS, self, amo.STATUS_DISABLED)
+        log.info('Addon "%s" status changed to: %s',
+                 self.slug, amo.STATUS_DISABLED)
+        self.update(status=amo.STATUS_DISABLED)
+        self.update_version()
+
+    def force_enable(self):
+        activity.log_create(amo.LOG.CHANGE_STATUS, self, amo.STATUS_PUBLIC)
+        log.info('Addon "%s" status changed to: %s',
+                 self.slug, amo.STATUS_PUBLIC)
+        self.update(status=amo.STATUS_PUBLIC)
+        # Call update_status() to fix the status if the add-on is not actually
+        # in a state that allows it to be public.
+        self.update_status()
+
     def is_soft_deleteable(self):
         return self.status or Version.unfiltered.filter(addon=self).exists()
 

--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -428,6 +428,18 @@ class THEME_REVIEW(_LOG):
     format = _(u'{addon} reviewed.')
 
 
+class ADMIN_USER_BANNED(_LOG):
+    id = 109
+    format = _(u'User {user} banned.')
+    admin_event = True
+
+
+class ADMIN_USER_PICTURE_DELETED(_LOG):
+    id = 110
+    format = _(u'User {user} picture deleted.')
+    admin_event = True
+
+
 class GROUP_USER_ADDED(_LOG):
     id = 120
     action_class = 'access'

--- a/src/olympia/constants/permissions.py
+++ b/src/olympia/constants/permissions.py
@@ -73,6 +73,9 @@ RATINGS_MODERATE = AclPermission('Ratings', 'Moderate')
 # add-on or clearing needs admin review flags.
 REVIEWS_ADMIN = AclPermission('Reviews', 'Admin')
 
+# Can access advanced admin features, like deletion.
+ADMIN_ADVANCED = AclPermission('Admin', 'Advanced')
+
 # All permissions, for easy introspection
 PERMISSIONS_LIST = [
     x for x in vars().values() if isinstance(x, AclPermission)]
@@ -85,6 +88,7 @@ DJANGO_PERMISSIONS_MAPPING = defaultdict(lambda: SUPERPOWERS)
 # will also check for addons:edit and give them read-only access to the
 # changelist (obj=None passed to the has_change_permission() method)
 DJANGO_PERMISSIONS_MAPPING.update({
+    'addons.change_addon': ADDONS_EDIT,
     'addons.change_replacementaddon': ADMIN_CURATION,
     'addons.add_replacementaddon': ADMIN_CURATION,
     'addons.delete_replacementaddon': ADMIN_CURATION,
@@ -93,6 +97,7 @@ DJANGO_PERMISSIONS_MAPPING.update({
     'bandwagon.delete_collection': COLLECTIONS_EDIT,
 
     'users.change_userprofile': USERS_EDIT,
+    'users.delete_userprofile': ADMIN_ADVANCED,
 
     'ratings.change_rating': RATINGS_MODERATE,
 })

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -455,6 +455,10 @@ MIDDLEWARE_CLASSES = (
     'csp.middleware.CSPMiddleware',
     'corsheaders.middleware.CorsMiddleware',
 
+    # This middleware does nothing, it's there for backwards-compatibility.
+    # Django < 1.10 checks for its presence to make session key rotation work.
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+
     'olympia.amo.middleware.CommonMiddleware',
     'olympia.amo.middleware.NoVarySessionMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -1153,11 +1153,7 @@ class AddonReviewerViewSet(GenericViewSet):
         permission_classes=[GroupPermission(amo.permissions.REVIEWS_ADMIN)])
     def disable(self, request, **kwargs):
         addon = get_object_or_404(Addon, pk=kwargs['pk'])
-        ActivityLog.create(amo.LOG.CHANGE_STATUS, addon, amo.STATUS_DISABLED)
-        self.log.info('Addon "%s" status changed to: %s',
-                      addon.slug, amo.STATUS_DISABLED)
-        addon.update(status=amo.STATUS_DISABLED)
-        addon.update_version()
+        addon.force_disable()
         return Response(status=status.HTTP_202_ACCEPTED)
 
     @detail_route(
@@ -1165,13 +1161,7 @@ class AddonReviewerViewSet(GenericViewSet):
         permission_classes=[GroupPermission(amo.permissions.REVIEWS_ADMIN)])
     def enable(self, request, **kwargs):
         addon = get_object_or_404(Addon, pk=kwargs['pk'])
-        ActivityLog.create(amo.LOG.CHANGE_STATUS, addon, amo.STATUS_PUBLIC)
-        self.log.info('Addon "%s" status changed to: %s',
-                      addon.slug, amo.STATUS_PUBLIC)
-        addon.update(status=amo.STATUS_PUBLIC)
-        # Call update_status() to fix the status if the add-on is not actually
-        # in a state that allows it to be public.
-        addon.update_status()
+        addon.force_enable()
         return Response(status=status.HTTP_202_ACCEPTED)
 
     @detail_route(

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -410,12 +410,9 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
         return not self.display_name and self.has_anonymous_username
 
     @cached_property
-    def reviews(self):
-        """All reviews that are not dev replies."""
-        qs = self._ratings_all.filter(reply_to=None)
-        # Force the query to occur immediately. Several
-        # reviews-related tests hang if this isn't done.
-        return qs
+    def ratings(self):
+        """All ratings that are not dev replies."""
+        return self._ratings_all.filter(reply_to=None)
 
     def delete(self, hard=False):
         # Recursive import

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -414,10 +414,51 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
         """All ratings that are not dev replies."""
         return self._ratings_all.filter(reply_to=None)
 
-    def delete(self, hard=False):
+    def delete_or_disable_related_content(self, delete=False):
+        """Delete or disable content produced by this user if they are the only
+        author."""
+        self.collections.all().delete()
+        for addon in self.addons.all().iterator():
+            if not addon.authors.exclude(pk=self.pk).exists():
+                if delete:
+                    addon.delete()
+                else:
+                    addon.force_disable()
+        user_responsible = core.get_user()
+        self._ratings_all.all().delete(user_responsible=user_responsible)
+        self.delete_picture()
+
+    def delete_picture(self, picture_path=None, original_picture_path=None):
+        """Delete picture of this user."""
         # Recursive import
         from olympia.users.tasks import delete_photo
 
+        if picture_path is None:
+            picture_path = self.picture_path
+        if original_picture_path is None:
+            original_picture_path = self.picture_path_original
+
+        if storage.exists(picture_path):
+            delete_photo.delay(picture_path)
+
+        if storage.exists(original_picture_path):
+            delete_photo.delay(original_picture_path)
+
+        if self.picture_type:
+            self.update(picture_type=None)
+
+    def ban_and_disable_related_content(self):
+        """Admin method to ban the user and disable the content they produced.
+
+        Similar to deletion, except that the content produced by the user is
+        forcibly disabled instead of being deleted where possible, and the user
+        is not fully anonymized: we keep their fxa_id and email so that they
+        are never able to log back in.
+        """
+        self.delete_or_disable_related_content(delete=False)
+        return self.delete(keep_fxa_id_and_email=True)
+
+    def delete(self, hard=False, keep_fxa_id_and_email=False):
         # Cache the values in case we do a hard delete and loose
         # reference to the user-id.
         picture_path = self.picture_path
@@ -426,10 +467,15 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
         if hard:
             super(UserProfile, self).delete()
         else:
-            log.info(
-                u'User (%s: <%s>) is being anonymized.' % (self, self.email))
-            self.email = None
-            self.fxa_id = None
+            if keep_fxa_id_and_email:
+                log.info(u'User (%s: <%s>) is being partially anonymized.' % (
+                    self, self.email))
+            else:
+                log.info(u'User (%s: <%s>) is being anonymized.' % (
+                    self, self.email))
+                self.email = None
+                self.fxa_id = None
+            self.biography = ''
             self.display_name = None
             self.homepage = ''
             self.location = ''
@@ -442,11 +488,8 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
             self.anonymize_username()
             self.save()
 
-        if storage.exists(picture_path):
-            delete_photo.delay(picture_path)
-
-        if storage.exists(original_picture_path):
-            delete_photo.delay(original_picture_path)
+        self.delete_picture(picture_path=picture_path,
+                            original_picture_path=original_picture_path)
 
     def set_unusable_password(self):
         raise NotImplementedError('cannot set unusable password')

--- a/src/olympia/users/templates/admin/users/userprofile/change_form.html
+++ b/src/olympia/users/templates/admin/users/userprofile/change_form.html
@@ -1,0 +1,21 @@
+{% extends "admin/change_form.html" %}
+{% load i18n admin_static admin_list admin_urls %}
+
+{% block submit_buttons_bottom %}
+    {{ block.super }}
+    <div class="submit-row">
+        <div class="align-left">
+            {% comment %}
+              Add custom <button>s for the actions we want on the change form.
+              They have to be *after* the other submit buttons, otherwise they
+              could become the default submit button of the page
+             {% endcomment %}
+             {% if can_ban %}
+                 <button formaction="{% url 'admin:users_userprofile_ban' original.pk|admin_urlquote %}"
+                         type="submit">{% trans "Ban" %}</button>
+             {% endif %}
+             <button formaction="{% url 'admin:users_userprofile_delete_picture' original.pk|admin_urlquote %}"
+                     type="submit">{% trans "Delete picture" %}</button>
+        </div>
+    </div>
+{% endblock %}

--- a/src/olympia/users/tests/test_models.py
+++ b/src/olympia/users/tests/test_models.py
@@ -217,25 +217,25 @@ class TestUserProfile(TestCase):
     def test_review_replies(self):
         """
         Make sure that developer replies are not returned as if they were
-        original reviews.
+        original ratings.
         """
         addon = Addon.objects.get(id=3615)
-        u = UserProfile.objects.get(pk=2519)
+        user = UserProfile.objects.get(pk=2519)
         version = addon.find_latest_public_listed_version()
-        new_rating = Rating(version=version, user=u, rating=2, body='hello',
+        new_rating = Rating(version=version, user=user, rating=2, body='hello',
                             addon=addon)
         new_rating.save()
-        new_reply = Rating(version=version, user=u, reply_to=new_rating,
+        new_reply = Rating(version=version, user=user, reply_to=new_rating,
                            addon=addon, body='my reply')
         new_reply.save()
 
-        review_list = [r.pk for r in u.reviews]
+        review_list = [rating.pk for rating in user.ratings]
 
         assert len(review_list) == 1
         assert new_rating.pk in review_list, (
-            'Original review must show up in review list.')
+            'Original review must show up in ratings list.')
         assert new_reply.pk not in review_list, (
-            'Developer reply must not show up in review list.')
+            'Developer reply must not show up in ratings list.')
 
     def test_num_addons_listed(self):
         """Test that num_addons_listed is only considering add-ons for which

--- a/src/olympia/users/tests/test_views.py
+++ b/src/olympia/users/tests/test_views.py
@@ -636,37 +636,37 @@ class TestProfileSections(TestCase):
         assert pq(self.client.get(self.url).content)(
             '.num-addons a').length == 0
 
-        a = amo.tests.addon_factory(type=amo.ADDON_PERSONA)
+        addon = amo.tests.addon_factory(type=amo.ADDON_PERSONA)
 
-        AddonUser.objects.create(user=self.user, addon=a)
+        AddonUser.objects.create(user=self.user, addon=addon)
 
-        r = self.client.get(self.url)
+        response = self.client.get(self.url)
 
-        doc = pq(r.content)
+        doc = pq(response.content)
         items = doc('#my-themes .persona')
         assert items.length == 1
-        assert items('a[href="%s"]' % a.get_url_path()).length == 1
+        assert items('a[href="%s"]' % addon.get_url_path()).length == 1
 
     def test_my_reviews(self):
-        r = Rating.objects.filter(reply_to=None)[0]
-        r.update(user=self.user)
+        rating = Rating.objects.filter(reply_to=None)[0]
+        rating.update(user=self.user)
         cache.clear()
-        self.assertSetEqual(set(self.user.reviews), {r})
+        self.assertSetEqual(set(self.user.ratings), {rating})
 
-        r = self.client.get(self.url)
-        doc = pq(r.content)('#reviews')
+        response = self.client.get(self.url)
+        doc = pq(response.content)('#reviews')
         assert not doc.hasClass('full'), (
             'reviews should not have "full" class when there are collections')
         assert doc('.item').length == 1
         assert doc('#review-218207').length == 1
 
         # Edit Review form should be present.
-        self.assertTemplateUsed(r, 'ratings/edit_review.html')
+        self.assertTemplateUsed(response, 'ratings/edit_review.html')
 
     def _get_reviews(self, username):
         self.client.login(email=username)
-        r = self.client.get(reverse('users.profile', args=[999]))
-        doc = pq(r.content)('#reviews')
+        response = self.client.get(reverse('users.profile', args=[999]))
+        doc = pq(response.content)('#reviews')
         return doc('#review-218207 .item-actions a.delete-review')
 
     def test_my_reviews_delete_link(self):

--- a/src/olympia/users/views.py
+++ b/src/olympia/users/views.py
@@ -255,7 +255,7 @@ def profile(request, user):
             '-weekly_downloads')
         addons = amo.utils.paginate(request, addons, 5)
 
-    reviews = amo.utils.paginate(request, user.reviews.all())
+    reviews = amo.utils.paginate(request, user.ratings.all())
 
     data = {'profile': user, 'own_coll': own_coll, 'reviews': reviews,
             'fav_coll': fav_coll, 'edit_any_user': edit_any_user,


### PR DESCRIPTION
This in turns means adding the notion of banned users and preventing them from logging on. They are just deleted users for which we keep the email and fxa_id.

And also enable session key rotation for django auth (it was already done for the API)

Fix #7268 
