### PR TITLE
Fix Issue #7783

### DIFF
--- a/src/olympia/devhub/templates/devhub/addons/submit/wizard.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/wizard.html
@@ -30,7 +30,7 @@
         {{ _('Select a different header image') }}</a>
     </div>
     <div class="colors">
-      <h3>{{ _('Select colors for your theme') }}</h4>
+      <h3>{{ _('Select colors for your theme') }}</h3>
       {% set colors = [
         ('accentcolor', _('Header area background'), _('The color of the header area background, displayed in the part of the header not covered or visible through the header image. Manifest field:  accentcolor.'), 'rgba(229,230,232,1)'),
         ('textcolor', _('Header area text and icons'), _('The color of the text and icons in the header area, except the active tab. Manifest field:  textcolor.'), 'rgba(0,0,0,1'),
@@ -40,8 +40,13 @@
         ('toolbar_field_text', _('Toolbar field area text'), _('The color of text in fields in the toolbar, such as the URL bar. Manifest field:  toolbar_field_text.'), false)] %}
 
       <ul class="colors">
+        {% set property_list = ['textcolor','toolbar_text', 'toolbar_field_text'] %}
         {% for (property, label, tip, val_default) in colors %}
-        <li class="row">
+          {% if property in property_list  %}
+            <li class="row left">
+          {% else %}
+            <li class="row">
+          {% endif %}
           <label class="row" for="{{ property }}">
             {{ label }}
             <span>

--- a/static/css/devhub/static-theme.less
+++ b/static/css/devhub/static-theme.less
@@ -23,9 +23,12 @@
         margin-top: 26px;
     }
     .colors {
+        li.row.left {
+            margin-right: 20px;
+            margin-left: 20px;
+        }
         li.row {
             display: inline-block;
-            margin-right: 20px;
             width: 325px;
 
             label {


### PR DESCRIPTION
This PR set the same margins for RTL and LTR for color selector area when we submit a new static theme using the wizard. For this there are some changes that i do in **src/olympia/devhub/templates/devhub/addons/submit/wizard.html** and **static/css/devhub/static-theme.less** file. Screenshot after changes and before are posted below.