### PR TITLE
Unhide translations widgets in the django admin

### DIFF
--- a/src/olympia/addons/admin.py
+++ b/src/olympia/addons/admin.py
@@ -16,6 +16,12 @@ from . import models
 
 
 class AddonAdmin(admin.ModelAdmin):
+    class Media:
+        css = {
+            'all': ('css/admin/l10n.css',)
+        }
+        js = ('js/admin/l10n.js',)
+
     exclude = ('authors',)
     list_display = ('__unicode__', 'type', 'status', 'average_rating')
     list_filter = ('type', 'status')

--- a/src/olympia/translations/tests/test_models.py
+++ b/src/olympia/translations/tests/test_models.py
@@ -18,7 +18,6 @@ from mock import patch
 from pyquery import PyQuery as pq
 
 from olympia.amo.tests import BaseTestCase
-from olympia.translations import widgets
 from olympia.translations.models import (
     LinkifiedTranslation, NoLinksNoMarkupTranslation, NoLinksTranslation,
     PurifiedTranslation, Translation, TranslationSequence)
@@ -670,13 +669,6 @@ def test_translation_unicode():
 
     assert unicode(t('hello')) == 'hello'
     assert unicode(t(None)) == ''
-
-
-def test_widget_value_from_datadict():
-    data = {'f_en-US': 'woo', 'f_de': 'herr', 'f_fr_delete': ''}
-    actual = widgets.TransMulti().value_from_datadict(data, [], 'f')
-    expected = {'en-US': 'woo', 'de': 'herr', 'fr': None}
-    assert actual == expected
 
 
 def test_comparison_with_lazy():

--- a/src/olympia/translations/tests/test_widgets.py
+++ b/src/olympia/translations/tests/test_widgets.py
@@ -24,3 +24,43 @@ class TestWidget(TestCase):
         w.default_locale = 'pl'
         result = w.render('name', '')
         assert pq(result)('textarea:not([lang=init])').attr('lang') == 'pl'
+
+    def test_transinput(self):
+        models.Translation.objects.create(
+            id=666, locale='en-us', localized_string='test value en')
+        models.Translation.objects.create(
+            id=666, locale='fr', localized_string='test value fr')
+        models.Translation.objects.create(
+            id=666, locale='de', localized_string=None)
+
+        widget = widgets.TransInput()
+        assert not widget.is_hidden
+        expected_output = (
+            '<div id="trans-foo" class="trans" data-name="foo">'
+            '<input lang="en-us" name="foo_en-us" type="text"'
+            ' value="test value en" />'
+            '<input lang="fr" name="foo_fr" type="text"'
+            ' value="test value fr" />'
+            '<input class="trans-init hidden" lang="init" name="foo_init" '
+            'type="text" value="" /></div>')
+        assert widget.render('foo', 666) == expected_output
+
+    def test_transtextarea(self):
+        models.Translation.objects.create(
+            id=666, locale='en-us', localized_string='test value en')
+        models.Translation.objects.create(
+            id=666, locale='fr', localized_string='test value fr')
+        models.Translation.objects.create(
+            id=666, locale='de', localized_string=None)
+
+        widget = widgets.TransTextarea()
+        assert not widget.is_hidden
+        expected_output = (
+            '<div id="trans-foo" class="trans" data-name="foo">'
+            '<textarea cols="40" lang="en-us" name="foo_en-us" rows="10">\r\n'
+            'test value en</textarea>'
+            '<textarea cols="40" lang="fr" name="foo_fr" rows="10">\r\n'
+            'test value fr</textarea>'
+            '<textarea class="trans-init hidden" cols="40" lang="init" '
+            'name="foo_init" rows="10">\r\n</textarea></div>')
+        assert widget.render('foo', 666) == expected_output

--- a/src/olympia/translations/tests/test_widgets.py
+++ b/src/olympia/translations/tests/test_widgets.py
@@ -64,3 +64,9 @@ class TestWidget(TestCase):
             '<textarea class="trans-init hidden" cols="40" lang="init" '
             'name="foo_init" rows="10">\r\n</textarea></div>')
         assert widget.render('foo', 666) == expected_output
+
+    def test_value_from_datadict(self):
+        data = {'f_en-US': 'woo', 'f_de': 'herr', 'f_fr_delete': ''}
+        actual = widgets.TransInput().value_from_datadict(data, [], 'f')
+        expected = {'en-US': 'woo', 'de': 'herr', 'fr': None}
+        assert actual == expected

--- a/src/olympia/translations/widgets.py
+++ b/src/olympia/translations/widgets.py
@@ -47,9 +47,14 @@ class TransMulti(forms.widgets.MultiWidget):
     choices = None  # Django expects widgets to have a choices attribute.
 
     def __init__(self, attrs=None):
-        # We set up the widgets in render since every Translation needs a
-        # different number of widgets.
-        super(TransMulti, self).__init__(widgets=[], attrs=attrs)
+        # Parent implementation for MultiWidget would instantiate self.widgets,
+        # but in our case it hasn't been set yet, because we need the value
+        # which contains all the translations, which is only passed at render()
+        # time.
+        # We do need self.widgets to be non-empty in order for is_hidden to
+        # work, so we create a dummy one. It will also serve as fallback when
+        # there is no value set already.
+        super(TransMulti, self).__init__(widgets=[self.widget()], attrs=attrs)
 
     def render(self, name, value, attrs=None):
         self.name = name
@@ -57,10 +62,8 @@ class TransMulti(forms.widgets.MultiWidget):
         if value:
             self.widgets = [self.widget() for _ in value]
         else:
-            # Give an empty widget in the default locale.
             default_locale = getattr(self, 'default_locale',
                                      translation.get_language())
-            self.widgets = [self.widget()]
             value = [Translation(locale=default_locale)]
         return super(TransMulti, self).render(name, value, attrs)
 
@@ -101,12 +104,16 @@ class TransMulti(forms.widgets.MultiWidget):
         return rv
 
     def format_output(self, widgets):
-        s = super(TransMulti, self).format_output(widgets)
+        # Gather output for all widgets as normal...
+        rendered_widgets = super(TransMulti, self).format_output(widgets)
+        # ...But also add a widget that'll be cloned for when we want to add
+        # a new translation. Hide it by default.
         init = self.widget().render(self.name + '_',
                                     Translation(locale='init'),
-                                    {'class': 'trans-init'})
+                                    {'class': 'trans-init hidden'})
+        # Wrap it all inside a div that the javascript will look for.
         return '<div id="trans-%s" class="trans" data-name="%s">%s%s</div>' % (
-            self.name, self.name, s, init)
+            self.name, self.name, rendered_widgets, init)
 
 
 class _TransWidget(object):

--- a/src/olympia/translations/widgets.py
+++ b/src/olympia/translations/widgets.py
@@ -107,7 +107,8 @@ class TransMulti(forms.widgets.MultiWidget):
         # Gather output for all widgets as normal...
         rendered_widgets = super(TransMulti, self).format_output(widgets)
         # ...But also add a widget that'll be cloned for when we want to add
-        # a new translation. Hide it by default.
+        # a new translation. Hide it by default, it's only used in devhub, not
+        # the admin (which doesn't need to add new translations).
         init = self.widget().render(self.name + '_',
                                     Translation(locale='init'),
                                     {'class': 'trans-init hidden'})

--- a/static/css/admin/l10n.css
+++ b/static/css/admin/l10n.css
@@ -1,0 +1,14 @@
+/**
+ * Companion to js/admin/l10n.js
+ */
+
+.trans label {
+    display: inline;
+    float: none;
+    padding: 0 1px 0 0;
+    width: auto;
+}
+
+.trans input, .trans textarea {
+    margin-right: 1em;
+}

--- a/static/js/admin/l10n.js
+++ b/static/js/admin/l10n.js
@@ -1,0 +1,26 @@
+/**
+ * Small javascript helper to help admins edit translated content. Relies on
+ * the same widgets as zamboni/l10n.js which is used in devhub, but is a much
+ * simpler implementation as we only need to display all translations at all
+ * times.
+ *
+ * Uses django.jQuery as it's meant as a companion to the django admin.
+ */
+
+django.jQuery(document).ready(function ($) {
+    if (!$('body.change-form').length) {
+        // This is only for change forms.
+        return;
+    }
+
+    // Each localized field will be inside a <div class="trans">. We are
+    // displaying all of them, so we want to add individual labels to let the
+    // user know which one is for which locale.
+    $('div.trans :input:visible').before(function() {
+        let $elm = $(this);
+        let $label = $('<label>');
+        $label.prop('for', $elm.attr('id'))
+        $label.text('[' + $elm.attr('lang') + ']');
+        return $label;
+    })
+});


### PR DESCRIPTION
Also add a bit of custom css/js to make them easier to edit.

It turns out that just making sure it has a widget by default before rendering fixes the `is_hidden` property which then fixes displaying of the widget in the admin. The model field already had a custom `formfield()` returning corresponding widget in model forms, and therefore the admin.

Screenshots:
**Before:**
![Before](https://user-images.githubusercontent.com/187006/41098473-c36a1e9a-6a5b-11e8-9b96-6d6e6401fb35.png)
**After:**
![After](https://user-images.githubusercontent.com/187006/41098474-c3a8d158-6a5b-11e8-91bf-60a34e8dd5ee.png)


Fix #8450