### PR TITLE
Fixes #8455 : Removed FAQ from footer

### DIFF
--- a/src/olympia/devhub/templates/devhub/new-landing/components/footer.html
+++ b/src/olympia/devhub/templates/devhub/new-landing/components/footer.html
@@ -27,7 +27,6 @@
         <h4>{{ _('Support') }}</h4>
         <ul>
           <li><a href="https://developer.mozilla.org/en-US/Add-ons/AMO/Policy">{{ _('Policies') }}</a></li>
-          <li><a href="https://addons.mozilla.org/faq">{{ _('FAQ') }}</a></li>
           <li><a href="https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Contact">{{ _('Report Bug') }}</a></li>
           <li><a href="https://status.mozilla.org">{{ _('Site Status') }}</a></li>
         </ul>


### PR DESCRIPTION
Fixes #8455 

* [X] This PR relates to an existing open issue and there are no existing
      PRs open for the same issue.
* [X] Add `Fixes #ISSUENUM` at the top of your PR.
* [X] Add a description of the the changes introduced in this PR.

This Pull Request removes the FAQ link from the Developer Hub Landing Page.

Cheers!