### PR TITLE
Fix ordering by collection name in AddonCollectionViewSet.

### DIFF
--- a/docs/topics/api/collections.rst
+++ b/docs/topics/api/collections.rst
@@ -179,6 +179,7 @@ This endpoint lists the add-ons in a collection, together with collector's notes
 
 All sort parameters can be reversed, e.g. '-added' for descending dates.
 The default sorting is by popularity, descending ('-popularity').
+There can only be one sort parameter, multiple orderings are not supported.
 
 
 .. _collection-addon-filtering-param:

--- a/src/olympia/bandwagon/views.py
+++ b/src/olympia/bandwagon/views.py
@@ -717,9 +717,8 @@ class TranslationAwareOrderingAliasFilter(OrderingAliasFilter):
 
         order_by = ordering[0]
 
-        if order_by.lstrip('-') == 'addon__name':
-            prefix = '-' if order_by.startswith('-') else ''
-            return order_by_translation(queryset, prefix + 'name', Addon)
+        if order_by in ('name', '-name'):
+            return order_by_translation(queryset, order_by, Addon)
 
         sup = super(TranslationAwareOrderingAliasFilter, self)
         return sup.filter_queryset(request, queryset, view)
@@ -732,7 +731,7 @@ class CollectionAddonViewSet(ModelViewSet):
     filter_backends = (TranslationAwareOrderingAliasFilter,)
     ordering_fields = ()
     ordering_field_aliases = {'popularity': 'addon__weekly_downloads',
-                              'name': 'addon__name',
+                              'name': 'name',
                               'added': 'created'}
     ordering = ('-addon__weekly_downloads',)
 

--- a/src/olympia/bandwagon/views.py
+++ b/src/olympia/bandwagon/views.py
@@ -14,6 +14,7 @@ from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.http import require_POST
 
 from django_statsd.clients import statsd
+from rest_framework import serializers
 from rest_framework.viewsets import ModelViewSet
 
 import olympia.core.logger
@@ -703,14 +704,35 @@ class CollectionViewSet(ModelViewSet):
         return qs.order_by(sort)[:limit]
 
 
+class TranslationAwareOrderingAliasFilter(OrderingAliasFilter):
+    def filter_queryset(self, request, queryset, view):
+        ordering = self.get_ordering(request, queryset, view)
+
+        if len(ordering) > 1:
+            # We can't support multiple orderings easily because of
+            # how order_by_translation works.
+            raise serializers.ValidationError(
+                'You can only specify one "sort" argument. Multiple '
+                'orderings are not supported')
+
+        order_by = ordering[0]
+
+        if order_by.lstrip('-') == 'addon__name':
+            prefix = '-' if order_by.startswith('-') else ''
+            return order_by_translation(queryset, prefix + 'name', Addon)
+
+        sup = super(TranslationAwareOrderingAliasFilter, self)
+        return sup.filter_queryset(request, queryset, view)
+
+
 class CollectionAddonViewSet(ModelViewSet):
     permission_classes = []  # We don't need extra permissions.
     serializer_class = CollectionAddonSerializer
     lookup_field = 'addon'
-    filter_backends = (OrderingAliasFilter,)
+    filter_backends = (TranslationAwareOrderingAliasFilter,)
     ordering_fields = ()
     ordering_field_aliases = {'popularity': 'addon__weekly_downloads',
-                              'name': 'addon__name__localized_string',
+                              'name': 'addon__name',
                               'added': 'created'}
     ordering = ('-addon__weekly_downloads',)
 
@@ -740,6 +762,7 @@ class CollectionAddonViewSet(ModelViewSet):
                                     self.action != 'list')
         # If deleted addons are requested, that implies all addons.
         include_all = filter_param == 'all' or include_all_with_deleted
+
         if not include_all:
             qs = qs.filter(
                 addon__status=amo.STATUS_PUBLIC, addon__disabled_by_user=False)

--- a/src/olympia/translations/query.py
+++ b/src/olympia/translations/query.py
@@ -8,7 +8,7 @@ from django.db.models.sql.datastructures import Join
 from django.utils import translation as translation_utils
 
 
-def order_by_translation(qs, fieldname):
+def order_by_translation(qs, fieldname, model=None):
     """
     Order the QuerySet by the translated field, honoring the current and
     fallback locales.  Returns a new QuerySet.
@@ -23,7 +23,7 @@ def order_by_translation(qs, fieldname):
         desc = False
 
     qs = qs.all()
-    model = qs.model
+    model = model or qs.model
     field = model._meta.get_field(fieldname)
 
     # Doing the manual joins is flying under Django's radar, so we need to make


### PR DESCRIPTION
* order_by_translation can now be applied a specific `model` to join on,
e.g in case of a m2n-table where the method couldn't determine the
correct joins correctly.

Fixes #8354 