### PR TITLE
Increase theme update caching duration to 24 hours

### DIFF
--- a/services/theme_update.py
+++ b/services/theme_update.py
@@ -1,6 +1,4 @@
-import base64
 import json
-import os
 import posixpath
 import re
 from time import time
@@ -9,7 +7,7 @@ from wsgiref.handlers import format_date_time
 from olympia.constants import base
 
 from services.utils import log_configure, log_exception, mypool
-from services.utils import settings, user_media_path, user_media_url
+from services.utils import settings, user_media_url
 
 # This has to be imported after the settings (utils).
 from django_statsd.clients import statsd
@@ -36,21 +34,6 @@ class ThemeUpdate(object):
         if not self.cursor:
             self.conn = mypool.connect()
             self.cursor = self.conn.cursor()
-
-    def base64_icon(self, addon_id):
-        path = self.image_path('icon.jpg')
-        if not os.path.isfile(path):
-            return ''
-
-        try:
-            with open(path, 'r') as f:
-                return base64.b64encode(f.read())
-        except IOError as e:
-            if len(e.args) == 1:
-                log_exception('I/O error: {0}'.format(e[0]))
-            else:
-                log_exception('I/O error({0}): {1}'.format(e[0], e[1]))
-            return ''
 
     def get_headers(self, length):
         return [('Cache-Control', 'public, max-age=86400'),
@@ -148,7 +131,6 @@ class ThemeUpdate(object):
                                          '/addon/%s/' % row['slug']),
             'previewURL': self.image_url('preview.png'),
             'iconURL': self.image_url('icon.png'),
-            'dataurl': self.base64_icon(row['addon_id']),
             'accentcolor': '#%s' % accent if accent else None,
             'textcolor': '#%s' % text if text else None,
             'updateURL': self.locale_url(settings.VAMO_URL,
@@ -163,19 +145,6 @@ class ThemeUpdate(object):
             data['updateURL'] += '?src=gp'
 
         return json.dumps(data)
-
-    def image_path(self, filename):
-        row = self.data['row']
-
-        # Special cased for non-AMO-uploaded themes imported from getpersonas.
-        if row['persona_id'] != 0:
-            if filename == 'preview.png':
-                filename = 'preview.jpg'
-            elif filename == 'icon.png':
-                filename = 'preview_small.jpg'
-
-        return os.path.join(user_media_path('addons'), str(row['addon_id']),
-                            filename)
 
     def image_url(self, filename):
         row = self.data['row']

--- a/services/theme_update.py
+++ b/services/theme_update.py
@@ -53,10 +53,10 @@ class ThemeUpdate(object):
             return ''
 
     def get_headers(self, length):
-        return [('Cache-Control', 'public, max-age=3600'),
+        return [('Cache-Control', 'public, max-age=86400'),
                 ('Content-Length', str(length)),
                 ('Content-Type', 'application/json'),
-                ('Expires', format_date_time(time() + 3600)),
+                ('Expires', format_date_time(time() + 86400)),
                 ('Last-Modified', format_date_time(time()))]
 
     def get_update(self):

--- a/src/olympia/addons/tests/test_theme_update.py
+++ b/src/olympia/addons/tests/test_theme_update.py
@@ -11,8 +11,7 @@ import mock
 from services import theme_update
 
 from olympia.addons.models import Addon
-from olympia.amo.templatetags.jinja_helpers import (
-    user_media_path, user_media_url)
+from olympia.amo.templatetags.jinja_helpers import user_media_url
 from olympia.amo.tests import TestCase
 from olympia.versions.models import Version
 
@@ -79,7 +78,6 @@ class TestThemeUpdate(TestCase):
             'textcolor': '#ffffff',
             'id': '15663',
             'headerURL': '/15663/BCBG_Persona_header2.png?modified=fakehash',
-            'dataurl': '',
             'name': 'My Persona',
             'author': 'persona_author',
             'updateURL': (settings.VAMO_URL +
@@ -139,12 +137,6 @@ class TestThemeUpdate(TestCase):
         persona.save()
         data = json.loads(self.get_update('en-US', addon.pk).get_json())
         assert data['footerURL'] == ''
-
-    def test_image_path(self):
-        up = self.get_update('en-US', 15663)
-        up.get_update()
-        image_path = up.image_path('foo.png')
-        assert user_media_path('addons') in image_path
 
     def test_image_url(self):
         up = self.get_update('en-US', 15663)


### PR DESCRIPTION
Also remove `dataurl` from theme update data - it's not used by Firefox 

Fix #8510