### PR TITLE
Reject submissions for legacy add-ons that are not compatible with Firefox

### DIFF
--- a/src/olympia/applications/views.py
+++ b/src/olympia/applications/views.py
@@ -1,6 +1,8 @@
 from django.db.transaction import non_atomic_requests
 from django.utils.translation import ugettext
 
+import waffle
+
 from olympia import amo
 from olympia.amo.feeds import NonAtomicFeed
 from olympia.amo.templatetags.jinja_helpers import absolutify, url
@@ -12,8 +14,11 @@ from .models import AppVersion
 
 def get_versions(order=('application', 'version_int')):
     def fetch_versions():
-        apps = amo.APP_USAGE
-        versions = dict((app.id, []) for app in apps)
+        if waffle.switch_is_active('disallow-thunderbird-and-seamonkey'):
+            apps = amo.APP_USAGE_FIREFOXES_ONLY
+        else:
+            apps = amo.APP_USAGE
+        versions = {app.id: [] for app in apps}
         qs = list(AppVersion.objects.order_by(*order)
                   .filter(application__in=versions)
                   .values_list('application', 'version'))
@@ -27,7 +32,7 @@ def get_versions(order=('application', 'version_int')):
 def appversions(request):
     apps, versions = get_versions()
     return render(request, 'applications/appversions.html',
-                  dict(apps=apps, versions=versions))
+                  {'apps': apps, 'versions': versions})
 
 
 class AppversionsFeed(NonAtomicFeed):

--- a/src/olympia/constants/applications.py
+++ b/src/olympia/constants/applications.py
@@ -159,6 +159,15 @@ class UNKNOWN_APP(App):
 # UAs will attempt to match in this order.
 APP_DETECT = (ANDROID, THUNDERBIRD, SEAMONKEY, FIREFOX)
 APP_USAGE = (FIREFOX, THUNDERBIRD, ANDROID, SEAMONKEY)
+# APP_USAGE_FIREFOXES_ONLY is a temporary constant while we have a waffle to
+# disable thunderbird and seamonkey support.
+# Since it's evaluated at import time, we can't change APP_USAGE through a
+# waffle, so to support the waffle disabling Thunderbird and Seamonkey support
+# we add a temporary constant that will be used by relevant code in place of
+# APP_USAGE while the waffle is still used. When the waffle is turned on
+# permanently and removed this constant can go away and APP_USAGE can be
+# changed to only (ANDROID, FIREFOX).
+APP_USAGE_FIREFOXES_ONLY = (ANDROID, FIREFOX)
 APP_USAGE_STATICTHEME = (FIREFOX,)
 APPS = {app.short: app for app in APP_USAGE}
 APPS_ALL = {app.id: app for app in APP_USAGE + (MOZILLA, SUNBIRD, MOBILE)}

--- a/src/olympia/devhub/tests/test_forms.py
+++ b/src/olympia/devhub/tests/test_forms.py
@@ -105,8 +105,16 @@ class TestCompatForm(TestCase):
         version = Addon.objects.get(id=3615).current_version
         formset = forms.CompatFormSet(None, queryset=version.apps.all(),
                                       form_kwargs={'version': version})
-        apps = [f.app for f in formset.forms]
-        assert set(apps) == set(amo.APPS.values())
+        apps = [form.app for form in formset.forms]
+        assert set(apps) == set(amo.APP_USAGE)
+
+    def test_forms_disallow_thunderbird_and_seamonkey(self):
+        self.create_switch('disallow-thunderbird-and-seamonkey')
+        version = Addon.objects.get(id=3615).current_version
+        formset = forms.CompatFormSet(None, queryset=version.apps.all(),
+                                      form_kwargs={'version': version})
+        apps = [form.app for form in formset.forms]
+        assert set(apps) == set(amo.APP_USAGE_FIREFOXES_ONLY)
 
     def test_form_initial(self):
         version = Addon.objects.get(id=3615).current_version

--- a/src/olympia/migrations/1019-disallow-thunderbird-seamonkey-waffle.sql
+++ b/src/olympia/migrations/1019-disallow-thunderbird-seamonkey-waffle.sql
@@ -1,0 +1,2 @@
+INSERT INTO waffle_switch (name, active, note, created, modified)
+VALUES ('disallow-thunderbird-and-seamonkey', 0, 'Reject submissions for add-ons that are not compatible with Firefox.', NOW(), NOW());


### PR DESCRIPTION
... Behind a `disallow-thunderbird-and-seamonkey` waffle

Fix https://github.com/mozilla/addons-server/issues/8344