### PR TITLE
Completely remove traces of caching.backends settings.

### DIFF
--- a/docs/topics/install/deprecated/advanced-installation.rst
+++ b/docs/topics/install/deprecated/advanced-installation.rst
@@ -49,7 +49,7 @@ settings already use the following, so you shouldn't need to change anything::
 
     CACHES = {
         'default': {
-            'BACKEND': 'caching.backends.memcached.MemcachedCache',
+            'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
             'LOCATION': ['localhost:11211'],
             'TIMEOUT': 500,
         }

--- a/settings.py
+++ b/settings.py
@@ -23,21 +23,11 @@ FILESYSTEM_CACHE_ROOT = os.path.join(TMP_PATH, 'cache')
 # Disable cache-machine locally and in tests to prepare for its removal.
 CACHE_MACHINE_ENABLED = False
 
-# Using locmem deadlocks in certain scenarios. This should all be fixed,
-# hopefully, in Django1.7. At that point, we may try again, and remove this to
-# not require memcache installation for newcomers.
-# A failing scenario is:
-# 1/ log in
-# 2/ click on "Submit a new addon"
-# 3/ click on "I accept this Agreement" => request never ends
-#
-# If this is changed back to locmem, make sure to use it from "caching" (by
-# default in Django for locmem, a timeout of "0" means "don't cache it", while
-# on other backends it means "cache forever"):
-#      'BACKEND': 'caching.backends.locmem.LocMemCache'
+# We are setting memcached here to make sure our local setup is as close
+# to our production system as possible.
 CACHES = {
     'default': {
-        'BACKEND': 'caching.backends.memcached.MemcachedCache',
+        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
         'LOCATION': os.environ.get('MEMCACHE_LOCATION', 'localhost:11211'),
     },
     'filesystem': {


### PR DESCRIPTION
Most of this work landed already in
6a8fc341daaa2754d7ccf74ef44ea49e94f9f5f9 and
91605a4c1fa679f8563e1434a0145ffc1b607beb so this is just a follow-up to
remove all other traces. This has been running on dev, stage and prod for quite some time now.

The removed comment is no longer true, Django received all the necessary
fixes for LocMemCache. On the other hand, LoMemCache is no longer used
for a regular local setup because we are using memcached and try to be
as close to production as possible so this won't change anytime
soon.