### PR TITLE
Use manage.py migrate instead of deprecated syncdb.

### DIFF
--- a/Makefile-docker
+++ b/Makefile-docker
@@ -69,7 +69,7 @@ help_submake:
 initialize_db:
 	rm -rf ./user-media/* ./tmp/*
 	python manage.py reset_db
-	python manage.py syncdb --noinput
+	python manage.py migrate --noinput
 	python manage.py loaddata initial.json
 	python manage.py import_prod_versions
 	schematic --fake src/olympia/migrations/
@@ -134,7 +134,7 @@ setup-ui-tests:
 	rm -rf ./user-media/* ./tmp/*
 	# Reset the database and fake database migrations
 	python manage.py reset_db --noinput
-	python manage.py syncdb --noinput
+	python manage.py migrate --noinput
 	schematic --fake src/olympia/migrations/
 
 	# Let's load some initial data and import mozilla-product versions

--- a/scripts/setup-docker.sh
+++ b/scripts/setup-docker.sh
@@ -2,7 +2,7 @@
 
 # initialize_db:
 python manage.py reset_db --noinput
-python manage.py syncdb --noinput
+python manage.py migrate --noinput
 python manage.py loaddata initial.json
 python manage.py import_prod_versions
 schematic --fake src/olympia/migrations/

--- a/src/olympia/translations/models.py
+++ b/src/olympia/translations/models.py
@@ -252,7 +252,7 @@ class NoLinksNoMarkupTranslation(NoLinksMixin, LinkifiedTranslation):
 
 class TranslationSequence(models.Model):
     """
-    The translations_seq table, so syncdb will create it during testing.
+    The translations_seq table, so migrations will create it during testing.
     """
     id = models.IntegerField(primary_key=True)
 


### PR DESCRIPTION
This is just a small code-cleanup update towards Django 1.11 where
`syncdb` doesn't exist anymore.

Fixes #8530