### PR TITLE
Remove our own assert3xx implementation in favor of Django's assertRedirects.

### DIFF
--- a/src/olympia/addons/tests/test_decorators.py
+++ b/src/olympia/addons/tests/test_decorators.py
@@ -21,7 +21,8 @@ class TestAddonView(TestCase):
         self.request = mock.Mock()
         self.slug_path = urllib.quote(
             ('/addon/%s/reviews' % self.addon.slug).encode('utf8'))
-        self.request.path = self.id_path = u'/addon/%s/reviews' % self.addon.id
+        self.request.path = self.id_path = (
+            u'http://testserver/addon/%s/reviews' % self.addon.id)
         self.request.GET = {}
 
     def test_301_by_id(self):
@@ -29,8 +30,9 @@ class TestAddonView(TestCase):
         self.assert3xx(res, self.slug_path, 301)
 
     def test_slug_replace_no_conflict(self):
-        self.request.path = u'/addon/{id}/reviews/{id}345/path'.format(
-            id=self.addon.id)
+        path = u'http://testserver/addon/{id}/reviews/{id}345/path'
+        self.request.path = path.format(id=self.addon.id)
+
         res = self.view(self.request, str(self.addon.id))
         redirection = urllib.quote(
             u'/addon/{slug}/reviews/{id}345/path'.format(

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta
 from functools import partial
 from tempfile import NamedTemporaryFile
-from urlparse import parse_qs, urlparse, urlsplit, urlunsplit
+from urlparse import parse_qs, urlparse
 
 from django import forms, test
 from django.conf import settings

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -394,54 +394,6 @@ def fxa_login_link(response=None, to=None, request=None):
         action='signin')
 
 
-def assertLoginRedirects(response, to, status_code=302):
-    fxa_url = fxa_login_link(response, to)
-    assert3xx(response, fxa_url, status_code)
-
-
-def assert3xx(response, expected_url, status_code=302, target_status_code=200):
-    """Asserts redirect and final redirect matches expected URL.
-
-    Similar to Django's `assertRedirects` but skips the final GET
-    verification for speed.
-
-    """
-    if hasattr(response, 'redirect_chain'):
-        # The request was a followed redirect
-        assert \
-            len(response.redirect_chain) > 0, \
-            ("Response didn't redirect as expected: Response"
-                " code was %d (expected %d)" % (response.status_code,
-                                                status_code))
-
-        url, status_code = response.redirect_chain[-1]
-
-        assert response.status_code == target_status_code, \
-            ("Response didn't redirect as expected: Final"
-                " Response code was %d (expected %d)" % (response.status_code,
-                                                         target_status_code))
-
-    else:
-        # Not a followed redirect
-        assert response.status_code == status_code, \
-            ("Response didn't redirect as expected: Response"
-                " code was %d (expected %d)" % (response.status_code,
-                                                status_code))
-        url = response['Location']
-
-    scheme, netloc, path, query, fragment = urlsplit(url)
-    e_scheme, e_netloc, e_path, e_query, e_fragment = urlsplit(
-        expected_url)
-    if (scheme and not e_scheme) and (netloc and not e_netloc):
-        expected_url = urlunsplit(('http', 'testserver', e_path, e_query,
-                                   e_fragment))
-
-    msg = (
-        "Response redirected to '%s', expected '%s'" %
-        (url, expected_url))
-    assert url == expected_url, msg
-
-
 class TestCase(PatchMixin, InitializeSessionMixin, BaseTestCase):
     """Base class for all amo tests."""
     client_class = TestClient
@@ -497,11 +449,13 @@ class TestCase(PatchMixin, InitializeSessionMixin, BaseTestCase):
                     if hasattr(v, 'non_form_errors'):
                         assert v.non_form_errors() == []
 
-    def assertLoginRedirects(self, *args, **kwargs):
-        return assertLoginRedirects(*args, **kwargs)
+    def assertLoginRedirects(self, response, to, status_code=302):
+        fxa_url = fxa_login_link(response, to)
+        return self.assert3xx(response, fxa_url, status_code)
 
     def assert3xx(self, *args, **kwargs):
-        return assert3xx(*args, **kwargs)
+        kwargs.setdefault('fetch_redirect_response', False)
+        return self.assertRedirects(*args, **kwargs)
 
     def assertCloseToNow(self, dt, now=None):
         """

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -1492,7 +1492,7 @@ class TestRedirects(TestCase):
         url = reverse('devhub.themes.submit')
         response = self.client.get(url, follow=True)
         self.assert3xx(
-            response, reverse('devhub.submit.distribution'), 301)
+            response, reverse('devhub.submit.distribution'), 302)
 
     @override_switch('disable-lwt-uploads', active=False)
     def test_lwt_submit_no_redirect_when_waffle_offf(self):


### PR DESCRIPTION
This keeps our own `self.assert3xx` for backwards compatibility but
re-uses Django's self.assertRedirects and sets `fetch_direct_response`
to `False`.

Fixes #8533