### PR TITLE
Disallow legacy firefox-only language packs.

### DIFF
--- a/src/olympia/devhub/tasks.py
+++ b/src/olympia/devhub/tasks.py
@@ -217,6 +217,8 @@ def handle_upload_validation_result(
         results = annotate_legacy_addon_restrictions(
             results=results, is_new_upload=is_new_upload)
 
+    annotate_legacy_langpack_restriction(results=results)
+
     # Check for API keys in submissions.
     # Make sure it is extension-like, e.g. no LWT or search plugin
     try:
@@ -389,6 +391,41 @@ def annotate_legacy_addon_restrictions(results, is_new_upload):
 
         insert_validation_message(
             results, message=msg, msg_id='legacy_addons_max_version')
+
+    return results
+
+
+def annotate_legacy_langpack_restriction(results):
+    """
+    Annotate validation results to restrict uploads of legacy langpacks.
+    See https://github.com/mozilla/addons-linter/issues/1985 for more details.
+    """
+    if not waffle.switch_is_active('disallow-legacy-langpacks'):
+        return
+
+    metadata = results.get('metadata', {})
+
+    is_webextension = metadata.get('is_webextension') is True
+    target_apps = metadata.get('applications', {})
+
+    is_langpack = results.get('detected_type') == 'langpack'
+    is_targeting_firefoxes_only = (
+        set(target_apps.keys()).intersection(('firefox', 'android')) ==
+        set(target_apps.keys())
+    )
+
+    if not is_webextension and is_langpack and is_targeting_firefoxes_only:
+        link = (
+            'https://developer.mozilla.org/Add-ons/WebExtensions/'
+            'manifest.json')
+        msg = ugettext(
+            u'Legacy language packs for Firefox are no longer supported. '
+            u'A WebExtensions install manifest is required. See {mdn_link} '
+            u'for more details.')
+
+        insert_validation_message(
+            results, message=msg.format(mdn_link=link),
+            msg_id='legacy_langpacks_disallowed')
 
     return results
 

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -1251,9 +1251,32 @@ class TestUploadDetail(BaseUploadTest):
         upload = FileUpload.objects.get()
         response = self.client.get(reverse('devhub.upload_detail_for_version',
                                            args=[addon.slug, upload.uuid.hex]))
-        print(response.content)
         data = json.loads(response.content)
         assert data['validation']['messages'] == []
+
+    def test_legacy_langpacks_allowed_by_default(self):
+        self.upload_file(
+            '../../../files/fixtures/files/langpack.xpi')
+        upload = FileUpload.objects.get()
+        response = self.client.get(reverse('devhub.upload_detail',
+                                           args=[upload.uuid.hex, 'json']))
+        data = json.loads(response.content)
+        msgid = [u'validation', u'messages', u'legacy_langpacks_disallowed']
+        assert not any(
+            message['id'] == msgid
+            for message in data['validation']['messages'])
+
+    @override_switch('disallow-legacy-langpacks', active=True)
+    def test_legacy_langpacks_disallowed(self):
+        self.upload_file(
+            '../../../files/fixtures/files/langpack.xpi')
+        upload = FileUpload.objects.get()
+        response = self.client.get(reverse('devhub.upload_detail',
+                                           args=[upload.uuid.hex, 'json']))
+        data = json.loads(response.content)
+        assert data['validation']['messages'][0]['id'] == [
+            u'validation', u'messages', u'legacy_langpacks_disallowed'
+        ]
 
     def test_no_redirect_for_metadata(self):
         user = UserProfile.objects.get(email='regular@mozilla.com')


### PR DESCRIPTION
This feature is behind the 'disallow-legacy-langpacks' waffle switch.

Fixes mozilla/addons-linter#1985