### PR TITLE
use a custom reverse in tests so no need to specify explicit namespaces

### DIFF
--- a/src/olympia/abuse/tests/test_views.py
+++ b/src/olympia/abuse/tests/test_views.py
@@ -1,19 +1,18 @@
 import json
 
 from django.core import mail
-from django.core.urlresolvers import reverse
 
 from olympia import amo
 from olympia.abuse.models import AbuseReport
 from olympia.amo.tests import (
-    APITestClient, TestCase, addon_factory, user_factory)
+    APITestClient, TestCase, addon_factory, reverse_ns, user_factory)
 
 
 class AddonAbuseViewSetTestBase(object):
     client_class = APITestClient
 
     def setUp(self):
-        self.url = reverse('v3:abusereportaddon-list')
+        self.url = reverse_ns('abusereportaddon-list')
 
     def check_reporter(self, report):
         raise NotImplementedError
@@ -157,7 +156,7 @@ class UserAbuseViewSetTestBase(object):
     client_class = APITestClient
 
     def setUp(self):
-        self.url = reverse('v3:abusereportuser-list')
+        self.url = reverse_ns('abusereportuser-list')
 
     def check_reporter(self, report):
         raise NotImplementedError

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -15,6 +15,7 @@ from django.test.utils import override_settings
 
 import mock
 
+from rest_framework.settings import api_settings
 from rest_framework.test import APIRequestFactory, APITestCase
 from waffle.models import Switch
 
@@ -1571,7 +1572,7 @@ class TestAccountNotificationViewSetUpdate(TestCase):
                     'http://testserver/api/{api_version}/accounts/account/'
                     '{id}/notifications/').format(
                     id=self.user.id,
-                    api_version=settings.REST_FRAMEWORK['DEFAULT_VERSION']),
+                    api_version=api_settings.DEFAULT_VERSION),
                 'email': self.user.email},
             headers={'x-api-key': 'testkey'})
 

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -26,7 +26,7 @@ from olympia.amo.templatetags.jinja_helpers import absolutify, urlparams
 from olympia.amo.tests import (
     APITestClient, InitializeSessionMixin, PatchMixin, TestCase,
     WithDynamicEndpoints, addon_factory, assert_url_equal, create_switch,
-    user_factory)
+    reverse_ns, user_factory)
 from olympia.amo.tests.test_helpers import get_uploaded_file
 from olympia.api.authentication import WebTokenAuthentication
 from olympia.api.tests.utils import APIKeyAuthTestCase
@@ -58,7 +58,7 @@ class BaseAuthenticationView(APITestCase, PatchMixin,
                              InitializeSessionMixin):
 
     def setUp(self):
-        self.url = reverse(self.view_name)
+        self.url = reverse_ns(self.view_name)
         self.fxa_identify = self.patch(
             'olympia.accounts.views.verify.fxa_identify')
 
@@ -239,7 +239,7 @@ class TestFindUser(TestCase):
 class TestRenderErrorHTML(TestCase):
 
     def make_request(self):
-        request = APIRequestFactory().get(reverse('v3:accounts.authenticate'))
+        request = APIRequestFactory().get(reverse_ns('accounts.authenticate'))
         request.user = AnonymousUser()
         return self.enable_messages(request)
 
@@ -300,7 +300,7 @@ class TestRenderErrorJSON(TestCase):
         self.addCleanup(patcher.stop)
 
     def make_request(self):
-        return APIRequestFactory().post(reverse('v3:accounts.authenticate'))
+        return APIRequestFactory().post(reverse_ns('accounts.authenticate'))
 
     def render_error(self, error):
         views.render_error(self.make_request(), error, format='json')
@@ -584,7 +584,7 @@ class TestFxAConfigMixin(TestCase):
 
 
 class TestAuthenticateView(BaseAuthenticationView):
-    view_name = 'v3:accounts.authenticate'
+    view_name = 'accounts.authenticate'
 
     def setUp(self):
         super(TestAuthenticateView, self).setUp()
@@ -739,27 +739,26 @@ class TestAccountViewSet(TestCase):
 
     def setUp(self):
         self.user = user_factory()
-        self.url = reverse('v3:account-detail',
-                           kwargs={'pk': self.user.pk})
+        self.url = reverse_ns('account-detail', kwargs={'pk': self.user.pk})
         super(TestAccountViewSet, self).setUp()
 
     def test_profile_url(self):
         self.client.login_api(self.user)
-        response = self.client.get(reverse('v3:account-profile'))
+        response = self.client.get(reverse_ns('account-profile'))
         assert response.status_code == 200
         assert response.data['name'] == self.user.name
         assert response.data['email'] == self.user.email
         assert response.data['url'] == absolutify(self.user.get_url_path())
 
     def test_profile_url_404(self):
-        response = self.client.get(reverse('v3:account-profile'))  # No auth.
+        response = self.client.get(reverse_ns('account-profile'))  # No auth.
         assert response.status_code == 401
 
     def test_disallowed_verbs(self):
         self.client.login_api(self.user)
         # We have no list URL to post to, try posting to accounts-profile
         # instead...
-        response = self.client.post(reverse('v3:account-profile'))
+        response = self.client.post(reverse_ns('account-profile'))
         assert response.status_code == 405
         # We can try put on the detail URL though.
         response = self.client.put(self.url)
@@ -797,8 +796,8 @@ class TestAccountViewSet(TestCase):
         self.grant_permission(self.user, 'Users:Edit')
         self.client.login_api(self.user)
         self.random_user = user_factory()
-        random_user_profile_url = reverse(
-            'v3:account-detail', kwargs={'pk': self.random_user.pk})
+        random_user_profile_url = reverse_ns(
+            'account-detail', kwargs={'pk': self.random_user.pk})
         response = self.client.get(random_user_profile_url)
         assert response.status_code == 200
         assert response.data['name'] == self.random_user.name
@@ -808,14 +807,14 @@ class TestAccountViewSet(TestCase):
 
     def test_self_view_slug(self):
         # Check it works the same with an account slug rather than pk.
-        self.url = reverse('v3:account-detail',
-                           kwargs={'pk': self.user.username})
+        self.url = reverse_ns('account-detail',
+                              kwargs={'pk': self.user.username})
         self.test_self_view()
 
     def test_is_public_because_developer_slug(self):
         # Check it works the same with an account slug rather than pk.
-        self.url = reverse('v3:account-detail',
-                           kwargs={'pk': self.user.username})
+        self.url = reverse_ns('account-detail',
+                              kwargs={'pk': self.user.username})
         self.test_is_public_because_developer()
 
     def test_admin_view_slug(self):
@@ -823,8 +822,8 @@ class TestAccountViewSet(TestCase):
         self.grant_permission(self.user, 'Users:Edit')
         self.client.login_api(self.user)
         self.random_user = user_factory()
-        random_user_profile_url = reverse(
-            'v3:account-detail', kwargs={'pk': self.random_user.username})
+        random_user_profile_url = reverse_ns(
+            'account-detail', kwargs={'pk': self.random_user.username})
         response = self.client.get(random_user_profile_url)
         assert response.status_code == 200
         assert response.data['name'] == self.random_user.name
@@ -841,7 +840,7 @@ class TestProfileViewWithJWT(APIKeyAuthTestCase):
 
     def test_profile_url(self):
         self.create_api_user()
-        response = self.get(reverse('v3:account-profile'))
+        response = self.get(reverse_ns('account-profile'))
         assert response.status_code == 200
         assert response.data['name'] == self.user.name
         assert response.data['email'] == self.user.email
@@ -860,8 +859,7 @@ class TestAccountViewSetUpdate(TestCase):
 
     def setUp(self):
         self.user = user_factory()
-        self.url = reverse('v3:account-detail',
-                           kwargs={'pk': self.user.pk})
+        self.url = reverse_ns('account-detail', kwargs={'pk': self.user.pk})
         super(TestAccountViewSetUpdate, self).setUp()
 
     def patch(self, url=None, data=None):
@@ -885,7 +883,7 @@ class TestAccountViewSetUpdate(TestCase):
 
     def test_different_account(self):
         self.client.login_api(self.user)
-        url = reverse('v3:account-detail', kwargs={'pk': user_factory().pk})
+        url = reverse_ns('account-detail', kwargs={'pk': user_factory().pk})
         response = self.patch(url=url)
         assert response.status_code == 403
 
@@ -893,7 +891,7 @@ class TestAccountViewSetUpdate(TestCase):
         self.grant_permission(self.user, 'Users:Edit')
         self.client.login_api(self.user)
         random_user = user_factory()
-        url = reverse('v3:account-detail', kwargs={'pk': random_user.pk})
+        url = reverse_ns('account-detail', kwargs={'pk': random_user.pk})
         original = self.client.get(url).content
         response = self.patch(url=url)
         assert response.status_code == 200
@@ -962,8 +960,8 @@ class TestAccountViewSetUpdate(TestCase):
         self.test_picture_upload()
         assert path.exists(self.user.picture_path)
         # call the endpoint to delete
-        picture_url = reverse(
-            'v3:account-picture', kwargs={'pk': self.user.pk})
+        picture_url = reverse_ns(
+            'account-picture', kwargs={'pk': self.user.pk})
         response = self.client.delete(picture_url)
         assert response.status_code == 200
         # Should delete the photo
@@ -972,8 +970,8 @@ class TestAccountViewSetUpdate(TestCase):
         assert json_content['picture_url'] is None
 
     def test_account_picture_disallowed_verbs(self):
-        picture_url = reverse(
-            'v3:account-picture', kwargs={'pk': self.user.pk})
+        picture_url = reverse_ns(
+            'account-picture', kwargs={'pk': self.user.pk})
         self.client.login_api(self.user)
         response = self.client.get(picture_url)
         assert response.status_code == 405
@@ -1024,8 +1022,7 @@ class TestAccountViewSetDelete(TestCase):
 
     def setUp(self):
         self.user = user_factory()
-        self.url = reverse('v3:account-detail',
-                           kwargs={'pk': self.user.pk})
+        self.url = reverse_ns('account-detail', kwargs={'pk': self.user.pk})
         super(TestAccountViewSetDelete, self).setUp()
 
     def test_delete(self):
@@ -1052,7 +1049,7 @@ class TestAccountViewSetDelete(TestCase):
 
     def test_different_account(self):
         self.client.login_api(self.user)
-        url = reverse('v3:account-detail', kwargs={'pk': user_factory().pk})
+        url = reverse_ns('account-detail', kwargs={'pk': user_factory().pk})
         response = self.client.delete(url)
         assert response.status_code == 403
 
@@ -1063,7 +1060,7 @@ class TestAccountViewSetDelete(TestCase):
         # when the admin deletes someone else's account.
         self.client.cookies[views.API_TOKEN_COOKIE] = 'something'
         random_user = user_factory()
-        url = reverse('v3:account-detail', kwargs={'pk': random_user.pk})
+        url = reverse_ns('account-detail', kwargs={'pk': random_user.pk})
         response = self.client.delete(url)
         assert response.status_code == 204
         assert random_user.reload().deleted
@@ -1116,7 +1113,7 @@ class TestAccountSuperCreate(APIKeyAuthTestCase):
         super(TestAccountSuperCreate, self).setUp()
         create_switch('super-create-accounts', active=True)
         self.create_api_user()
-        self.url = reverse('v3:accounts.super-create')
+        self.url = reverse_ns('accounts.super-create')
         group = Group.objects.create(
             name='Account Super Creators',
             rules='Accounts:SuperCreate')
@@ -1271,7 +1268,7 @@ class TestSessionView(TestCase):
                 lambda code, config: identity):
             response = self.client.get(
                 '{url}?code={code}&state={state}'.format(
-                    url=reverse('v3:accounts.authenticate'),
+                    url=reverse_ns('accounts.authenticate'),
                     state='myfxastate',
                     code='thecode'))
             token = response.cookies[views.API_TOKEN_COOKIE].value
@@ -1286,12 +1283,12 @@ class TestSessionView(TestCase):
         token = self.login_user(user)
         authorization = 'Bearer {token}'.format(token=token)
         response = self.client.delete(
-            reverse('v3:accounts.session'), HTTP_AUTHORIZATION=authorization)
+            reverse_ns('accounts.session'), HTTP_AUTHORIZATION=authorization)
         assert not response.cookies[views.API_TOKEN_COOKIE].value
         assert not self.client.session.get('_auth_user_id')
 
     def test_delete_when_unauthenticated(self):
-        response = self.client.delete(reverse('v3:accounts.session'))
+        response = self.client.delete(reverse_ns('accounts.session'))
         assert response.status_code == 401
 
 
@@ -1301,8 +1298,8 @@ class TestAccountNotificationViewSetList(TestCase):
     def setUp(self):
         self.user = user_factory()
         addon_factory(users=[self.user])  # Developers get all notifications.
-        self.url = reverse('v3:notification-list',
-                           kwargs={'user_pk': self.user.pk})
+        self.url = reverse_ns('notification-list',
+                              kwargs={'user_pk': self.user.pk})
         super(TestAccountNotificationViewSetList, self).setUp()
 
     def test_defaults_only(self):
@@ -1452,10 +1449,10 @@ class TestAccountNotificationViewSetUpdate(TestCase):
     def setUp(self):
         self.user = user_factory()
         addon_factory(users=[self.user])  # Developers get all notifications.
-        self.url = reverse('v3:notification-list',
-                           kwargs={'user_pk': self.user.pk})
-        self.list_url = reverse('v3:notification-list',
-                                kwargs={'user_pk': self.user.pk})
+        self.url = reverse_ns('notification-list',
+                              kwargs={'user_pk': self.user.pk})
+        self.list_url = reverse_ns('notification-list',
+                                   kwargs={'user_pk': self.user.pk})
         super(TestAccountNotificationViewSetUpdate, self).setUp()
 
     def test_new_notification(self):
@@ -1571,8 +1568,10 @@ class TestAccountNotificationViewSetUpdate(TestCase):
             data={
                 'newsletters': 'about-addons', 'sync': 'Y', 'optin': 'Y',
                 'source_url': (
-                    'http://testserver/api/v3/accounts/account/'
-                    '{id}/notifications/').format(id=self.user.id),
+                    'http://testserver/api/{api_version}/accounts/account/'
+                    '{id}/notifications/').format(
+                    id=self.user.id,
+                    api_version=settings.REST_FRAMEWORK['DEFAULT_VERSION']),
                 'email': self.user.email},
             headers={'x-api-key': 'testkey'})
 

--- a/src/olympia/activity/tests/test_views.py
+++ b/src/olympia/activity/tests/test_views.py
@@ -14,9 +14,8 @@ from olympia.activity.views import EmailCreationPermission, inbound_email
 from olympia.addons.models import AddonUser
 from olympia.addons.utils import generate_addon_guid
 from olympia.amo.tests import (
-    APITestClient, TestCase, addon_factory, req_factory_factory, user_factory,
-    version_factory)
-from olympia.amo.urlresolvers import reverse
+    APITestClient, TestCase, addon_factory, req_factory_factory, reverse_ns,
+    user_factory, version_factory)
 from olympia.users.models import UserProfile
 
 
@@ -168,7 +167,7 @@ class TestReviewNotesViewSetDetail(ReviewNotesViewSetDetailMixin, TestCase):
         assert result['highlight']  # Its the first reply so highlight
 
     def _set_tested_url(self, pk=None, version_pk=None, addon_pk=None):
-        self.url = reverse('v3:version-reviewnotes-detail', kwargs={
+        self.url = reverse_ns('version-reviewnotes-detail', kwargs={
             'addon_pk': addon_pk or self.addon.pk,
             'version_pk': version_pk or self.version.pk,
             'pk': pk or self.note.pk})
@@ -219,7 +218,7 @@ class TestReviewNotesViewSetList(ReviewNotesViewSetDetailMixin, TestCase):
         assert not result_version['highlight']  # The dev replied so read it.
 
     def _set_tested_url(self, pk=None, version_pk=None, addon_pk=None):
-        self.url = reverse('v3:version-reviewnotes-list', kwargs={
+        self.url = reverse_ns('version-reviewnotes-list', kwargs={
             'addon_pk': addon_pk or self.addon.pk,
             'version_pk': version_pk or self.version.pk})
 
@@ -240,7 +239,7 @@ class TestReviewNotesViewSetCreate(TestCase):
             guid=generate_addon_guid(), name=u'My Addôn', slug='my-addon')
         self.version = self.addon.find_latest_version(
             channel=amo.RELEASE_CHANNEL_LISTED)
-        self.url = reverse('v3:version-reviewnotes-list', kwargs={
+        self.url = reverse_ns('version-reviewnotes-list', kwargs={
             'addon_pk': self.addon.pk,
             'version_pk': self.version.pk})
 
@@ -354,7 +353,7 @@ class TestReviewNotesViewSetCreate(TestCase):
         self.client.login_api(self.user)
 
         # First check we can reply to new version
-        new_url = reverse('v3:version-reviewnotes-list', kwargs={
+        new_url = reverse_ns('version-reviewnotes-list', kwargs={
             'addon_pk': self.addon.pk,
             'version_pk': new_version.pk})
         response = self.client.post(
@@ -388,7 +387,7 @@ class TestEmailApi(TestCase):
 
     def get_request(self, data):
         datastr = json.dumps(data)
-        req = req_factory_factory(reverse('v3:inbound-email-api'), post=True)
+        req = req_factory_factory(reverse_ns('inbound-email-api'), post=True)
         req.META['REMOTE_ADDR'] = '10.10.10.10'
         req.META['CONTENT_LENGTH'] = len(datastr)
         req.META['CONTENT_TYPE'] = 'application/json'
@@ -397,7 +396,7 @@ class TestEmailApi(TestCase):
 
     def get_validation_request(self, data):
         req = req_factory_factory(
-            url=reverse('v3:inbound-email-api'), post=True, data=data)
+            url=reverse_ns('inbound-email-api'), post=True, data=data)
         req.META['REMOTE_ADDR'] = '10.10.10.10'
         return req
 

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -31,7 +31,7 @@ from olympia.addons.views import (
 from olympia.amo.templatetags.jinja_helpers import numberfmt, urlparams
 from olympia.amo.tests import (
     APITestClient, ESTestCase, TestCase, addon_factory, collection_factory,
-    user_factory, version_factory)
+    reverse_ns, user_factory, version_factory)
 from olympia.amo.urlresolvers import get_outgoing_url, reverse
 from olympia.bandwagon.models import Collection, FeaturedCollection
 from olympia.constants.categories import CATEGORIES, CATEGORIES_BY_ID
@@ -1689,11 +1689,11 @@ class TestAddonViewSetDetail(AddonAndVersionViewSetDetailMixin, TestCase):
         return result
 
     def _set_tested_url(self, param):
-        self.url = reverse('v3:addon-detail', kwargs={'pk': param})
+        self.url = reverse_ns('addon-detail', kwargs={'pk': param})
 
     def test_detail_url_with_reviewers_in_the_url(self):
         self.addon.update(slug='something-reviewers')
-        self.url = reverse('v3:addon-detail', kwargs={'pk': self.addon.slug})
+        self.url = reverse_ns('addon-detail', kwargs={'pk': self.addon.slug})
         self._test_url()
 
     def test_hide_latest_unlisted_version_anonymous(self):
@@ -1784,11 +1784,11 @@ class TestVersionViewSetDetail(AddonAndVersionViewSetDetailMixin, TestCase):
         assert result['version'] == self.version.version
 
     def _set_tested_url(self, param):
-        self.url = reverse('v3:addon-version-detail', kwargs={
+        self.url = reverse_ns('addon-version-detail', kwargs={
             'addon_pk': param, 'pk': self.version.pk})
 
     def test_version_get_not_found(self):
-        self.url = reverse('v3:addon-version-detail', kwargs={
+        self.url = reverse_ns('addon-version-detail', kwargs={
             'addon_pk': self.addon.pk, 'pk': self.version.pk + 42})
         response = self.client.get(self.url)
         assert response.status_code == 404
@@ -1967,7 +1967,7 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
         assert result_version['version'] == self.old_version.version
 
     def _set_tested_url(self, param):
-        self.url = reverse('v3:addon-version-list', kwargs={'addon_pk': param})
+        self.url = reverse_ns('addon-version-list', kwargs={'addon_pk': param})
 
     def test_bad_filter(self):
         response = self.client.get(self.url, data={'filter': 'ahahaha'})
@@ -2129,12 +2129,12 @@ class TestAddonViewSetFeatureCompatibility(TestCase):
         super(TestAddonViewSetFeatureCompatibility, self).setUp()
         self.addon = addon_factory(
             guid=generate_addon_guid(), name=u'My Addôn', slug='my-addon')
-        self.url = reverse(
-            'v3:addon-feature-compatibility', kwargs={'pk': self.addon.pk})
+        self.url = reverse_ns(
+            'addon-feature-compatibility', kwargs={'pk': self.addon.pk})
 
     def test_url(self):
-        self.detail_url = reverse(
-            'v3:addon-detail', kwargs={'pk': self.addon.pk})
+        self.detail_url = reverse_ns(
+            'addon-detail', kwargs={'pk': self.addon.pk})
         assert self.url == '%s%s' % (self.detail_url, 'feature_compatibility/')
 
     def test_disabled_anonymous(self):
@@ -2164,12 +2164,12 @@ class TestAddonViewSetEulaPolicy(TestCase):
         super(TestAddonViewSetEulaPolicy, self).setUp()
         self.addon = addon_factory(
             guid=generate_addon_guid(), name=u'My Addôn', slug='my-addon')
-        self.url = reverse(
-            'v3:addon-eula-policy', kwargs={'pk': self.addon.pk})
+        self.url = reverse_ns(
+            'addon-eula-policy', kwargs={'pk': self.addon.pk})
 
     def test_url(self):
-        self.detail_url = reverse(
-            'v3:addon-detail', kwargs={'pk': self.addon.pk})
+        self.detail_url = reverse_ns(
+            'addon-detail', kwargs={'pk': self.addon.pk})
         assert self.url == '%s%s' % (self.detail_url, 'eula_policy/')
 
     def test_disabled_anonymous(self):
@@ -2202,7 +2202,7 @@ class TestAddonSearchView(ESTestCase):
 
     def setUp(self):
         super(TestAddonSearchView, self).setUp()
-        self.url = reverse('v3:addon-search')
+        self.url = reverse_ns('addon-search')
 
     def tearDown(self):
         super(TestAddonSearchView, self).tearDown()
@@ -2870,7 +2870,7 @@ class TestAddonSearchView(ESTestCase):
 
         for locale in ('en-US', 'en-GB', 'es'):
             with self.activate(locale):
-                url = reverse('v3:addon-search')
+                url = reverse_ns('addon-search')
 
                 data = self.perform_search(url, {'lang': locale})
 
@@ -2963,7 +2963,7 @@ class TestAddonAutoCompleteSearchView(ESTestCase):
 
     def setUp(self):
         super(TestAddonAutoCompleteSearchView, self).setUp()
-        self.url = reverse('v3:addon-autocomplete')
+        self.url = reverse_ns('addon-autocomplete')
 
     def tearDown(self):
         super(TestAddonAutoCompleteSearchView, self).tearDown()
@@ -3088,7 +3088,7 @@ class TestAddonFeaturedView(TestCase):
     client_class = APITestClient
 
     def setUp(self):
-        self.url = reverse('v3:addon-featured')
+        self.url = reverse_ns('addon-featured')
 
     def test_no_parameters(self):
         response = self.client.get(self.url)
@@ -3273,7 +3273,7 @@ class TestStaticCategoryView(TestCase):
 
     def setUp(self):
         super(TestStaticCategoryView, self).setUp()
-        self.url = reverse('v3:category-list')
+        self.url = reverse_ns('category-list')
 
     def test_basic(self):
         with self.assertNumQueries(0):
@@ -3343,7 +3343,7 @@ class TestLanguageToolsView(TestCase):
 
     def setUp(self):
         super(TestLanguageToolsView, self).setUp()
-        self.url = reverse('v3:addon-language-tools')
+        self.url = reverse_ns('addon-language-tools')
 
     def test_wrong_app_or_no_app(self):
         response = self.client.get(self.url)
@@ -3597,7 +3597,7 @@ class TestReplacementAddonView(TestCase):
             guid='notgonnawork@moz',
             path='/addon/áddonmissing/')
 
-        response = self.client.get(reverse('v3:addon-replacement-addon'))
+        response = self.client.get(reverse_ns('addon-replacement-addon'))
         assert response.status_code == 200
         data = json.loads(response.content)
         results = data['results']
@@ -3626,7 +3626,7 @@ class TestCompatOverrideView(TestCase):
 
     def test_single_guid(self):
         response = self.client.get(
-            reverse('v3:addon-compat-override'),
+            reverse_ns('addon-compat-override'),
             data={'guid': u'extrabad@thing'})
         assert response.status_code == 200
         data = json.loads(response.content)
@@ -3638,7 +3638,7 @@ class TestCompatOverrideView(TestCase):
 
     def test_multiple_guid(self):
         response = self.client.get(
-            reverse('v3:addon-compat-override'),
+            reverse_ns('addon-compat-override'),
             data={'guid': u'extrabad@thing,bad@thing'})
         assert response.status_code == 200
         data = json.loads(response.content)
@@ -3654,7 +3654,7 @@ class TestCompatOverrideView(TestCase):
 
         # Throw in some random invalid guids too that will be ignored.
         response = self.client.get(
-            reverse('v3:addon-compat-override'),
+            reverse_ns('addon-compat-override'),
             data={'guid': (
                 u'extrabad@thing,invalid@guid,notevenaguid$,bad@thing')})
         assert response.status_code == 200
@@ -3666,20 +3666,20 @@ class TestCompatOverrideView(TestCase):
 
     def test_no_guid_param(self):
         response = self.client.get(
-            reverse('v3:addon-compat-override'),
+            reverse_ns('addon-compat-override'),
             data={'guid': u'invalid@thing'})
         # Searching for non-matching guids, it should be an empty 200 response.
         assert response.status_code == 200
         assert len(json.loads(response.content)['results']) == 0
 
         response = self.client.get(
-            reverse('v3:addon-compat-override'), data={'guid': ''})
+            reverse_ns('addon-compat-override'), data={'guid': ''})
         # Empty query is a 400 because a guid is required for overrides.
         assert response.status_code == 400
         assert 'Empty, or no, guid parameter provided.' in response.content
 
         response = self.client.get(
-            reverse('v3:addon-compat-override'))
+            reverse_ns('addon-compat-override'))
         # And no guid param should be a 400 too
         assert response.status_code == 400
         assert 'Empty, or no, guid parameter provided.' in response.content
@@ -3692,7 +3692,7 @@ class TestAddonRecommendationView(ESTestCase):
 
     def setUp(self):
         super(TestAddonRecommendationView, self).setUp()
-        self.url = reverse('v3:addon-recommendations')
+        self.url = reverse_ns('addon-recommendations')
         patcher = mock.patch(
             'olympia.addons.views.get_addon_recommendations')
         self.get_recommendations_mock = patcher.start()

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -28,6 +28,8 @@ from django.utils.importlib import import_module
 import mock
 import pytest
 from dateutil.parser import parse as dateutil_parser
+from rest_framework.reverse import reverse as drf_reverse
+from rest_framework.settings import api_settings
 from rest_framework.views import APIView
 from rest_framework.test import APIClient
 from waffle.models import Flag, Sample, Switch
@@ -1075,3 +1077,13 @@ def prefix_indexes(config):
 
     settings.CACHE_PREFIX = 'amo:{0}:'.format(prefix)
     settings.KEY_PREFIX = settings.CACHE_PREFIX
+
+
+def reverse_ns(viewname, api_version=None, args=None, kwargs=None, **extra):
+    api_version = api_version or settings.REST_FRAMEWORK['DEFAULT_VERSION']
+    request = req_factory_factory('/api/%s/' % api_version)
+    request.versioning_scheme = api_settings.DEFAULT_VERSIONING_CLASS()
+    request.version = api_version
+    return drf_reverse(
+        viewname, args=args or [], kwargs=kwargs or {}, request=request,
+        **extra)

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -1092,7 +1092,7 @@ def reverse_ns(viewname, api_version=None, args=None, kwargs=None, **extra):
     e.g. reverse_ns('addon-detail') is resolved to reverse('v4:addon-detail')
     if the api version is 'v4'.
     """
-    api_version = api_version or settings.REST_FRAMEWORK['DEFAULT_VERSION']
+    api_version = api_version or api_settings.DEFAULT_VERSION
     request = req_factory_factory('/api/%s/' % api_version)
     request.versioning_scheme = api_settings.DEFAULT_VERSIONING_CLASS()
     request.version = api_version

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -1080,6 +1080,18 @@ def prefix_indexes(config):
 
 
 def reverse_ns(viewname, api_version=None, args=None, kwargs=None, **extra):
+    """An API namespace aware reverse to be used in DRF API based tests.
+
+    It works by creating a fake request from the API version you need, and
+    then setting the version so the un-namespaced viewname from DRF is resolved
+    into the namespaced viewname used interally by django.
+
+    Unless overriden with the api_version parameter, the API version used is
+    the DEFAULT_VERSION in settings.
+
+    e.g. reverse_ns('addon-detail') is resolved to reverse('v4:addon-detail')
+    if the api version is 'v4'.
+    """
     api_version = api_version or settings.REST_FRAMEWORK['DEFAULT_VERSION']
     request = req_factory_factory('/api/%s/' % api_version)
     request.versioning_scheme = api_settings.DEFAULT_VERSIONING_CLASS()

--- a/src/olympia/amo/tests/test_helpers.py
+++ b/src/olympia/amo/tests/test_helpers.py
@@ -7,7 +7,7 @@ from urlparse import urljoin
 
 from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.core.urlresolvers import NoReverseMatch, reverse
+from django.core.urlresolvers import NoReverseMatch
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from django.utils.encoding import force_bytes
@@ -22,7 +22,7 @@ import olympia
 from olympia import amo
 from olympia.amo import urlresolvers, utils
 from olympia.amo.templatetags import jinja_helpers
-from olympia.amo.tests import TestCase
+from olympia.amo.tests import TestCase, reverse_ns
 from olympia.amo.utils import ImageCheck
 from olympia.versions.models import License
 
@@ -169,7 +169,7 @@ def test_drf_url():
     rendered = render(fragment, context={'request': request})
     # As no /vX/ in the request, RESTFRAMEWORK['DEFAULT_VERSION'] is used.
     assert rendered == jinja_helpers.absolutify(
-        reverse('v4:addon-detail', args=['a3615'], add_prefix=False))
+        reverse_ns('addon-detail', args=['a3615']))
 
     with pytest.raises(NoReverseMatch):
         # Without a request it can't resolve the name correctly.

--- a/src/olympia/amo/tests/test_views.py
+++ b/src/olympia/amo/tests/test_views.py
@@ -21,7 +21,8 @@ from olympia import amo, core
 from olympia.access import acl
 from olympia.access.models import Group, GroupUser
 from olympia.addons.models import Addon, AddonUser
-from olympia.amo.tests import TestCase, WithDynamicEndpoints, check_links
+from olympia.amo.tests import (
+    TestCase, WithDynamicEndpoints, check_links, reverse_ns)
 from olympia.amo.urlresolvers import reverse
 from olympia.users.models import UserProfile
 
@@ -398,7 +399,7 @@ class TestCORS(TestCase):
         assert not response.has_header('Access-Control-Allow-Credentials')
 
     def test_cors_api_v3(self):
-        url = reverse('v3:addon-detail', args=(3615,))
+        url = reverse_ns('addon-detail', api_version='v3', args=(3615,))
         assert '/api/v3/' in url
         response = self.get(url)
         assert response.status_code == 200
@@ -406,7 +407,7 @@ class TestCORS(TestCase):
         assert response['Access-Control-Allow-Origin'] == '*'
 
     def test_cors_api_v4(self):
-        url = reverse('v4:addon-detail', args=(3615,))
+        url = reverse_ns('addon-detail', api_version='v4', args=(3615,))
         assert '/api/v4/' in url
         response = self.get(url)
         assert response.status_code == 200

--- a/src/olympia/api/tests/test_middleware.py
+++ b/src/olympia/api/tests/test_middleware.py
@@ -5,8 +5,7 @@ from django.conf import settings
 
 import mock
 
-from olympia.amo.tests import TestCase, addon_factory
-from olympia.amo.urlresolvers import reverse
+from olympia.amo.tests import TestCase, addon_factory, reverse_ns
 from olympia.api.middleware import GZipMiddlewareForAPIOnly
 
 
@@ -45,7 +44,7 @@ class TestGzipMiddleware(TestCase):
     def test_api_endpoint_gzipped(self):
         """Test a simple API endpoint to make sure gzip is active there."""
         addon = addon_factory()
-        url = reverse('v3:addon-detail', kwargs={'pk': addon.pk})
+        url = reverse_ns('addon-detail', kwargs={'pk': addon.pk})
         response = self.client.get(url)
         assert response.status_code == 200
         assert response.content

--- a/src/olympia/api/tests/test_namespace.py
+++ b/src/olympia/api/tests/test_namespace.py
@@ -1,8 +1,8 @@
-from django.conf import settings
 from django.conf.urls import include, url
 from django.core.urlresolvers import NoReverseMatch
 
 from rest_framework.response import Response
+from rest_framework.settings import api_settings
 from rest_framework.viewsets import GenericViewSet
 
 from olympia.amo.tests import (
@@ -102,7 +102,7 @@ class TestRealAPIRouting(TestCase):
 
     def test_default(self):
         url = reverse_ns('addon-detail', args=('foo',))
-        assert '/api/%s/' % settings.REST_FRAMEWORK['DEFAULT_VERSION'] in url
+        assert '/api/%s/' % api_settings.DEFAULT_VERSION in url
         response = self.client.get(url, HTTP_ORIGIN='testserver')
         assert response.status_code == 200
         assert response

--- a/src/olympia/bandwagon/tests/test_views.py
+++ b/src/olympia/bandwagon/tests/test_views.py
@@ -18,7 +18,8 @@ from olympia.access.models import Group, GroupUser
 from olympia.activity.models import ActivityLog
 from olympia.addons.models import Addon
 from olympia.amo.tests import (
-    APITestClient, TestCase, addon_factory, collection_factory, user_factory)
+    APITestClient, TestCase, addon_factory, collection_factory, reverse_ns,
+    user_factory)
 from olympia.amo.tests.test_helpers import get_uploaded_file
 from olympia.amo.urlresolvers import get_outgoing_url, reverse
 from olympia.amo.utils import urlparams
@@ -1311,8 +1312,8 @@ class TestCollectionViewSetList(TestCase):
 
     def setUp(self):
         self.user = user_factory()
-        self.url = reverse(
-            'v3:collection-list', kwargs={'user_pk': self.user.pk})
+        self.url = reverse_ns(
+            'collection-list', kwargs={'user_pk': self.user.pk})
         super(TestCollectionViewSetList, self).setUp()
 
     def test_basic(self):
@@ -1334,8 +1335,8 @@ class TestCollectionViewSetList(TestCase):
 
     def test_different_user(self):
         random_user = user_factory()
-        other_url = reverse('v3:collection-list',
-                            kwargs={'user_pk': random_user.pk})
+        other_url = reverse_ns('collection-list',
+                               kwargs={'user_pk': random_user.pk})
         collection_factory(author=random_user)
 
         self.client.login_api(self.user)
@@ -1344,8 +1345,8 @@ class TestCollectionViewSetList(TestCase):
 
     def test_admin(self):
         random_user = user_factory()
-        other_url = reverse('v3:collection-list',
-                            kwargs={'user_pk': random_user.pk})
+        other_url = reverse_ns('collection-list',
+                               kwargs={'user_pk': random_user.pk})
         collection_factory(author=random_user)
 
         self.grant_permission(self.user, 'Collections:Edit')
@@ -1356,8 +1357,8 @@ class TestCollectionViewSetList(TestCase):
 
     def test_404(self):
         # Invalid user.
-        url = reverse(
-            'v3:collection-list', kwargs={'user_pk': self.user.pk + 66})
+        url = reverse_ns(
+            'collection-list', kwargs={'user_pk': self.user.pk + 66})
 
         # Not logged in.
         response = self.client.get(url)
@@ -1402,8 +1403,8 @@ class TestCollectionViewSetDetail(TestCase):
         super(TestCollectionViewSetDetail, self).setUp()
 
     def _get_url(self, user, collection):
-        return reverse(
-            'v3:collection-detail', kwargs={
+        return reverse_ns(
+            'collection-detail', kwargs={
                 'user_pk': user.pk, 'slug': collection.slug})
 
     def test_basic(self):
@@ -1413,13 +1414,13 @@ class TestCollectionViewSetDetail(TestCase):
 
     def test_no_id_lookup(self):
         collection = collection_factory(author=self.user, slug='999')
-        id_url = reverse(
-            'v3:collection-detail', kwargs={
+        id_url = reverse_ns(
+            'collection-detail', kwargs={
                 'user_pk': self.user.pk, 'slug': collection.id})
         response = self.client.get(id_url)
         assert response.status_code == 404
-        slug_url = reverse(
-            'v3:collection-detail', kwargs={
+        slug_url = reverse_ns(
+            'collection-detail', kwargs={
                 'user_pk': self.user.pk, 'slug': collection.slug})
         response = self.client.get(slug_url)
         assert response.status_code == 200
@@ -1474,13 +1475,13 @@ class TestCollectionViewSetDetail(TestCase):
 
     def test_404(self):
         # Invalid user.
-        response = self.client.get(reverse(
-            'v3:collection-detail', kwargs={
+        response = self.client.get(reverse_ns(
+            'collection-detail', kwargs={
                 'user_pk': self.user.pk + 66, 'slug': self.collection.slug}))
         assert response.status_code == 404
         # Invalid collection.
-        response = self.client.get(reverse(
-            'v3:collection-detail', kwargs={
+        response = self.client.get(reverse_ns(
+            'collection-detail', kwargs={
                 'user_pk': self.user.pk, 'slug': 'hello'}))
         assert response.status_code == 404
 
@@ -1629,7 +1630,7 @@ class TestCollectionViewSetCreate(CollectionViewSetDataMixin, TestCase):
         return self.client.post(url or self.url, data or self.data)
 
     def get_url(self, user):
-        return reverse('v3:collection-list', kwargs={'user_pk': user.pk})
+        return reverse_ns('collection-list', kwargs={'user_pk': user.pk})
 
     def test_basic_create(self):
         self.client.login_api(self.user)
@@ -1704,8 +1705,8 @@ class TestCollectionViewSetPatch(CollectionViewSetDataMixin, TestCase):
         return self.client.patch(url or self.url, data or self.data)
 
     def get_url(self, user):
-        return reverse(
-            'v3:collection-detail', kwargs={
+        return reverse_ns(
+            'collection-detail', kwargs={
                 'user_pk': user.pk, 'slug': self.collection.slug})
 
     def test_basic_patch(self):
@@ -1767,8 +1768,8 @@ class TestCollectionViewSetDelete(TestCase):
         super(TestCollectionViewSetDelete, self).setUp()
 
     def get_url(self, user):
-        return reverse(
-            'v3:collection-detail', kwargs={
+        return reverse_ns(
+            'collection-detail', kwargs={
                 'user_pk': user.pk, 'slug': self.collection.slug})
 
     def test_delete(self):
@@ -1893,8 +1894,8 @@ class TestCollectionAddonViewSetList(CollectionAddonViewSetMixin, TestCase):
         self.addon_pending.current_version.all_files[0].update(
             status=amo.STATUS_AWAITING_REVIEW)
 
-        self.url = reverse(
-            'v3:collection-addon-list', kwargs={
+        self.url = reverse_ns(
+            'collection-addon-list', kwargs={
                 'user_pk': self.user.pk,
                 'collection_slug': self.collection.slug})
         super(TestCollectionAddonViewSetList, self).setUp()
@@ -1905,14 +1906,14 @@ class TestCollectionAddonViewSetList(CollectionAddonViewSetMixin, TestCase):
 
     def test_404(self):
         # Invalid user.
-        response = self.client.get(reverse(
-            'v3:collection-addon-list', kwargs={
+        response = self.client.get(reverse_ns(
+            'collection-addon-list', kwargs={
                 'user_pk': self.user.pk + 66,
                 'collection_slug': self.collection.slug}))
         assert response.status_code == 404
         # Invalid collection.
-        response = self.client.get(reverse(
-            'v3:collection-addon-list', kwargs={
+        response = self.client.get(reverse_ns(
+            'collection-addon-list', kwargs={
                 'user_pk': self.user.pk,
                 'collection_slug': 'hello'}))
         assert response.status_code == 404
@@ -2026,8 +2027,8 @@ class TestCollectionAddonViewSetDetail(CollectionAddonViewSetMixin, TestCase):
         self.collection = collection_factory(author=self.user)
         self.addon = addon_factory()
         self.collection.add_addon(self.addon)
-        self.url = reverse(
-            'v3:collection-addon-detail', kwargs={
+        self.url = reverse_ns(
+            'collection-addon-detail', kwargs={
                 'user_pk': self.user.pk,
                 'collection_slug': self.collection.slug,
                 'addon': self.addon.id})
@@ -2038,8 +2039,8 @@ class TestCollectionAddonViewSetDetail(CollectionAddonViewSetMixin, TestCase):
         assert response.data['addon']['id'] == self.addon.id
 
     def test_with_slug(self):
-        self.url = reverse(
-            'v3:collection-addon-detail', kwargs={
+        self.url = reverse_ns(
+            'collection-addon-detail', kwargs={
                 'user_pk': self.user.pk,
                 'collection_slug': self.collection.slug,
                 'addon': self.addon.slug})
@@ -2056,8 +2057,8 @@ class TestCollectionAddonViewSetCreate(CollectionAddonViewSetMixin, TestCase):
     def setUp(self):
         self.user = user_factory()
         self.collection = collection_factory(author=self.user)
-        self.url = reverse(
-            'v3:collection-addon-list', kwargs={
+        self.url = reverse_ns(
+            'collection-addon-list', kwargs={
                 'user_pk': self.user.pk,
                 'collection_slug': self.collection.slug})
         self.addon = addon_factory()
@@ -2140,8 +2141,8 @@ class TestCollectionAddonViewSetPatch(CollectionAddonViewSetMixin, TestCase):
         self.collection = collection_factory(author=self.user)
         self.addon = addon_factory()
         self.collection.add_addon(self.addon)
-        self.url = reverse(
-            'v3:collection-addon-detail', kwargs={
+        self.url = reverse_ns(
+            'collection-addon-detail', kwargs={
                 'user_pk': self.user.pk,
                 'collection_slug': self.collection.slug,
                 'addon': self.addon.id})
@@ -2185,8 +2186,8 @@ class TestCollectionAddonViewSetDelete(CollectionAddonViewSetMixin, TestCase):
         self.collection = collection_factory(author=self.user)
         self.addon = addon_factory()
         self.collection.add_addon(self.addon)
-        self.url = reverse(
-            'v3:collection-addon-detail', kwargs={
+        self.url = reverse_ns(
+            'collection-addon-detail', kwargs={
                 'user_pk': self.user.pk,
                 'collection_slug': self.collection.slug,
                 'addon': self.addon.id})

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -7,14 +7,14 @@ from django.core.files import temp
 import mock
 
 from pyquery import PyQuery as pq
-from rest_framework.reverse import reverse as drf_reverse
 
 from olympia import amo
 from olympia.accounts.views import API_TOKEN_COOKIE
 from olympia.activity.models import ActivityLog
 from olympia.addons.models import Addon, AddonReviewerFlags
 from olympia.amo.templatetags.jinja_helpers import absolutify
-from olympia.amo.tests import TestCase, formset, initial, version_factory
+from olympia.amo.tests import (
+    TestCase, formset, initial, reverse_ns, version_factory)
 from olympia.amo.urlresolvers import reverse
 from olympia.applications.models import AppVersion
 from olympia.files.models import File
@@ -476,8 +476,8 @@ class TestVersion(TestCase):
         # Test review history
         review_history_td = doc('#%s-review-history' % v1.id)[0]
         assert review_history_td.attrib['data-token'] == 'magicbeans'
-        api_url = absolutify(drf_reverse(
-            'v4:version-reviewnotes-list',
+        api_url = absolutify(reverse_ns(
+            'version-reviewnotes-list',
             args=[self.addon.id, self.version.id]))
         assert review_history_td.attrib['data-api-url'] == api_url
         assert doc('.review-history-hide').length == 2

--- a/src/olympia/discovery/tests/test_views.py
+++ b/src/olympia/discovery/tests/test_views.py
@@ -3,12 +3,13 @@ from collections import OrderedDict
 
 import mock
 
+from django.conf import settings
+
 from waffle.testutils import override_switch
 
 from olympia import amo
 from olympia.amo.templatetags.jinja_helpers import absolutify
-from olympia.amo.tests import TestCase, addon_factory, user_factory
-from olympia.amo.urlresolvers import reverse
+from olympia.amo.tests import TestCase, addon_factory, reverse_ns, user_factory
 from olympia.discovery.data import DiscoItem, discopane_items as disco_data
 from olympia.discovery.utils import replace_extensions
 
@@ -87,12 +88,13 @@ class DiscoveryTestMixin(object):
 class TestDiscoveryViewList(DiscoveryTestMixin, TestCase):
     def setUp(self):
         super(TestDiscoveryViewList, self).setUp()
-        self.url = reverse('v3:discovery-list')
+        self.url = reverse_ns('discovery-list')
 
         self.addons = get_dummy_addons()
 
     def test_reverse(self):
-        assert self.url == '/api/v3/discovery/'
+        assert self.url.endswith(
+            '/api/%s/discovery/' % settings.REST_FRAMEWORK['DEFAULT_VERSION'])
 
     def test_list(self):
         response = self.client.get(self.url, {'lang': 'en-US'})
@@ -214,7 +216,7 @@ class TestDiscoveryRecommendations(DiscoveryTestMixin, TestCase):
         # If no recommendations then results should be as before - tests from
         # the parent class check this.
         self.get_recommendations.return_value = []
-        self.url = reverse('v3:discovery-list')
+        self.url = reverse_ns('discovery-list')
 
     def test_recommendations(self):
         author = user_factory()

--- a/src/olympia/discovery/tests/test_views.py
+++ b/src/olympia/discovery/tests/test_views.py
@@ -3,8 +3,7 @@ from collections import OrderedDict
 
 import mock
 
-from django.conf import settings
-
+from rest_framework.settings import api_settings
 from waffle.testutils import override_switch
 
 from olympia import amo
@@ -94,7 +93,7 @@ class TestDiscoveryViewList(DiscoveryTestMixin, TestCase):
 
     def test_reverse(self):
         assert self.url.endswith(
-            '/api/%s/discovery/' % settings.REST_FRAMEWORK['DEFAULT_VERSION'])
+            '/api/%s/discovery/' % api_settings.DEFAULT_VERSION)
 
     def test_list(self):
         response = self.client.get(self.url, {'lang': 'en-US'})

--- a/src/olympia/github/tests/test_views.py
+++ b/src/olympia/github/tests/test_views.py
@@ -5,8 +5,7 @@ from django.utils.http import urlencode
 import mock
 import requests
 
-from olympia.amo.tests import AMOPaths, TestCase
-from olympia.amo.urlresolvers import reverse
+from olympia.amo.tests import AMOPaths, TestCase, reverse_ns
 from olympia.files.models import FileUpload
 from olympia.github.tests.test_github import (
     GithubBaseTestCase, example_pull_request)
@@ -16,7 +15,7 @@ class TestGithubView(AMOPaths, GithubBaseTestCase, TestCase):
 
     def setUp(self):
         super(TestGithubView, self).setUp()
-        self.url = reverse('v3:github.validate')
+        self.url = reverse_ns('github.validate')
 
     def post(self, data, header=None, data_type=None):
         data_type = data_type or 'application/json'

--- a/src/olympia/ratings/tests/test_views.py
+++ b/src/olympia/ratings/tests/test_views.py
@@ -5,7 +5,6 @@ from datetime import timedelta
 
 from django.core import mail
 from django.core.cache import cache
-from django.core.urlresolvers import reverse
 
 import mock
 
@@ -19,7 +18,8 @@ from olympia.addons.models import Addon, AddonUser
 from olympia.addons.utils import generate_addon_guid
 from olympia.amo.templatetags import jinja_helpers
 from olympia.amo.tests import (
-    APITestClient, TestCase, addon_factory, user_factory, version_factory)
+    APITestClient, TestCase, addon_factory, reverse_ns, user_factory,
+    version_factory)
 from olympia.ratings.models import Rating, RatingFlag
 from olympia.users.models import UserProfile
 
@@ -715,26 +715,28 @@ class TestEdit(ReviewTest):
 
 class TestRatingViewSetGet(TestCase):
     client_class = APITestClient
-    list_url_name = 'v4:rating-list'
-    detail_url_name = 'v4:rating-detail'
+    list_url_name = 'rating-list'
+    detail_url_name = 'rating-detail'
 
     def setUp(self):
         self.addon = addon_factory(
             guid=generate_addon_guid(), name=u'My Addôn', slug='my-addon')
-        self.url = reverse(self.list_url_name)
+        self.url = reverse_ns(self.list_url_name)
 
     def test_url_v3(self):
-        assert reverse('v3:rating-list').endswith('/v3/reviews/review/')
+        assert reverse_ns('rating-list', api_version='v3').endswith(
+            '/v3/reviews/review/')
         rating = Rating.objects.create(
             addon=self.addon, body='review 1', user=user_factory())
-        detail_url = reverse('v3:rating-detail', kwargs={'pk': rating.pk})
+        detail_url = reverse_ns(
+            'rating-detail', api_version='v3', kwargs={'pk': rating.pk})
         assert detail_url.endswith('/v3/reviews/review/%d/' % rating.pk)
 
     def test_url_default(self):
         assert self.url.endswith('/v4/ratings/rating/')
         rating = Rating.objects.create(
             addon=self.addon, body='review 1', user=user_factory())
-        detail_url = reverse(self.detail_url_name, kwargs={'pk': rating.pk})
+        detail_url = reverse_ns(self.detail_url_name, kwargs={'pk': rating.pk})
         assert detail_url.endswith('/v4/ratings/rating/%d/' % rating.pk)
 
     def test_list_addon(self, **kwargs):
@@ -1165,7 +1167,7 @@ class TestRatingViewSetGet(TestCase):
     def test_detail(self):
         review = Rating.objects.create(
             addon=self.addon, body='review 1', user=user_factory())
-        self.url = reverse(self.detail_url_name, kwargs={'pk': review.pk})
+        self.url = reverse_ns(self.detail_url_name, kwargs={'pk': review.pk})
 
         response = self.client.get(self.url)
         assert response.status_code == 200
@@ -1178,7 +1180,7 @@ class TestRatingViewSetGet(TestCase):
         reply = Rating.objects.create(
             addon=self.addon, body='reply to review', user=user_factory(),
             reply_to=review)
-        self.url = reverse(self.detail_url_name, kwargs={'pk': reply.pk})
+        self.url = reverse_ns(self.detail_url_name, kwargs={'pk': reply.pk})
 
         response = self.client.get(self.url)
         assert response.status_code == 200
@@ -1188,7 +1190,7 @@ class TestRatingViewSetGet(TestCase):
     def test_detail_deleted(self):
         review = Rating.objects.create(
             addon=self.addon, body='review 1', user=user_factory())
-        self.url = reverse(self.detail_url_name, kwargs={'pk': review.pk})
+        self.url = reverse_ns(self.detail_url_name, kwargs={'pk': review.pk})
         review.delete()
 
         response = self.client.get(self.url)
@@ -1201,7 +1203,7 @@ class TestRatingViewSetGet(TestCase):
             addon=self.addon, body='reply to review', user=user_factory(),
             reply_to=review)
         reply.delete()
-        self.url = reverse(self.detail_url_name, kwargs={'pk': review.pk})
+        self.url = reverse_ns(self.detail_url_name, kwargs={'pk': review.pk})
 
         response = self.client.get(self.url)
         assert response.status_code == 200
@@ -1220,7 +1222,7 @@ class TestRatingViewSetGet(TestCase):
             reply_to=review)
         reply.delete()
         review.delete()
-        self.url = reverse(self.detail_url_name, kwargs={'pk': review.pk})
+        self.url = reverse_ns(self.detail_url_name, kwargs={'pk': review.pk})
 
         response = self.client.get(self.url)
         assert response.status_code == 200
@@ -1401,7 +1403,7 @@ class TestRatingViewSetGet(TestCase):
 
 class TestRatingViewSetDelete(TestCase):
     client_class = APITestClient
-    detail_url_name = 'v4:rating-detail'
+    detail_url_name = 'rating-detail'
 
     def setUp(self):
         self.addon = addon_factory(
@@ -1410,7 +1412,8 @@ class TestRatingViewSetDelete(TestCase):
         self.rating = Rating.objects.create(
             addon=self.addon, version=self.addon.current_version, rating=1,
             body='My review', user=self.user)
-        self.url = reverse(self.detail_url_name, kwargs={'pk': self.rating.pk})
+        self.url = reverse_ns(
+            self.detail_url_name, kwargs={'pk': self.rating.pk})
 
     def test_delete_anonymous(self):
         response = self.client.delete(self.url)
@@ -1472,7 +1475,7 @@ class TestRatingViewSetDelete(TestCase):
         reply = Rating.objects.create(
             addon=self.addon, reply_to=self.rating,
             body=u'Reply that will be delêted...', user=addon_author)
-        self.url = reverse(self.detail_url_name, kwargs={'pk': reply.pk})
+        self.url = reverse_ns(self.detail_url_name, kwargs={'pk': reply.pk})
 
         response = self.client.delete(self.url)
         assert response.status_code == 204
@@ -1481,7 +1484,7 @@ class TestRatingViewSetDelete(TestCase):
 
     def test_delete_404(self):
         self.client.login_api(self.user)
-        self.url = reverse(
+        self.url = reverse_ns(
             self.detail_url_name, kwargs={'pk': self.rating.pk + 42})
         response = self.client.delete(self.url)
         assert response.status_code == 404
@@ -1498,17 +1501,17 @@ class TestRatingViewSetDelete(TestCase):
         # And confirm we can rapidly delete them.
         self.client.login_api(self.user)
         response = self.client.delete(
-            reverse(self.detail_url_name, kwargs={'pk': rating_a.pk}))
+            reverse_ns(self.detail_url_name, kwargs={'pk': rating_a.pk}))
         assert response.status_code == 204
         response = self.client.delete(
-            reverse(self.detail_url_name, kwargs={'pk': rating_b.pk}))
+            reverse_ns(self.detail_url_name, kwargs={'pk': rating_b.pk}))
         assert response.status_code == 204
         assert Rating.objects.count() == 0
 
 
 class TestRatingViewSetEdit(TestCase):
     client_class = APITestClient
-    detail_url_name = 'v4:rating-detail'
+    detail_url_name = 'rating-detail'
 
     def setUp(self):
         self.addon = addon_factory(
@@ -1517,7 +1520,8 @@ class TestRatingViewSetEdit(TestCase):
         self.rating = Rating.objects.create(
             addon=self.addon, version=self.addon.current_version, rating=1,
             body=u'My revïew', user=self.user)
-        self.url = reverse(self.detail_url_name, kwargs={'pk': self.rating.pk})
+        self.url = reverse_ns(
+            self.detail_url_name, kwargs={'pk': self.rating.pk})
 
     def test_edit_anonymous(self):
         response = self.client.patch(self.url, {'body': u'løl!'})
@@ -1623,7 +1627,7 @@ class TestRatingViewSetEdit(TestCase):
         reply = Rating.objects.create(
             reply_to=self.rating, body=u'This is â reply', user=addon_author,
             addon=self.addon)
-        self.url = reverse(self.detail_url_name, kwargs={'pk': reply.pk})
+        self.url = reverse_ns(self.detail_url_name, kwargs={'pk': reply.pk})
 
         response = self.client.patch(self.url, {'score': 5})
         assert response.status_code == 200
@@ -1654,13 +1658,13 @@ class TestRatingViewSetEdit(TestCase):
 
 class TestRatingViewSetPost(TestCase):
     client_class = APITestClient
-    list_url_name = 'v4:rating-list'
-    abuse_report_url_name = 'v4:abusereportaddon-list'
+    list_url_name = 'rating-list'
+    abuse_report_url_name = 'abusereportaddon-list'
 
     def setUp(self):
         self.addon = addon_factory(
             guid=generate_addon_guid(), name=u'My Addôn', slug='my-addon')
-        self.url = reverse(self.list_url_name)
+        self.url = reverse_ns(self.list_url_name)
 
     def test_post_anonymous(self):
         response = self.client.post(self.url, {
@@ -2031,7 +2035,7 @@ class TestRatingViewSetPost(TestCase):
             self.client.login_api(self.user)
 
             # Submit an abuse report
-            report_abuse_url = reverse(self.abuse_report_url_name)
+            report_abuse_url = reverse_ns(self.abuse_report_url_name)
             response = self.client.post(
                 report_abuse_url,
                 data={'addon': unicode(self.addon.pk), 'message': 'lol!'},
@@ -2070,7 +2074,7 @@ class TestRatingViewSetPost(TestCase):
 
 class TestRatingViewSetFlag(TestCase):
     client_class = APITestClient
-    flag_url_name = 'v4:rating-flag'
+    flag_url_name = 'rating-flag'
 
     def setUp(self):
         self.addon = addon_factory(
@@ -2079,11 +2083,13 @@ class TestRatingViewSetFlag(TestCase):
         self.rating = Rating.objects.create(
             addon=self.addon, version=self.addon.current_version, rating=1,
             body='My review', user=self.rating_user)
-        self.url = reverse(self.flag_url_name, kwargs={'pk': self.rating.pk})
+        self.url = reverse_ns(
+            self.flag_url_name, kwargs={'pk': self.rating.pk})
 
     def test_url_v3(self):
         expected_url = '/v3/reviews/review/%d/flag/' % self.rating.pk
-        v3_url = reverse('v3:rating-flag', kwargs={'pk': self.rating.pk})
+        v3_url = reverse_ns(
+            'rating-flag', api_version='v3', kwargs={'pk': self.rating.pk})
         assert v3_url.endswith(expected_url)
 
     def test_url_default(self):
@@ -2222,7 +2228,7 @@ class TestRatingViewSetFlag(TestCase):
         rating_b = Rating.objects.create(
             addon=addon_b, version=addon_b.current_version, rating=2,
             body='My review', user=self.rating_user)
-        url_b = reverse(self.flag_url_name, kwargs={'pk': rating_b.pk})
+        url_b = reverse_ns(self.flag_url_name, kwargs={'pk': rating_b.pk})
 
         response = self.client.post(
             self.url, data={'flag': 'review_flag_reason_spam'})
@@ -2236,7 +2242,7 @@ class TestRatingViewSetFlag(TestCase):
 
 class TestRatingViewSetReply(TestCase):
     client_class = APITestClient
-    reply_url_name = 'v4:rating-reply'
+    reply_url_name = 'rating-reply'
 
     def setUp(self):
         self.addon = addon_factory(
@@ -2245,10 +2251,12 @@ class TestRatingViewSetReply(TestCase):
         self.rating = Rating.objects.create(
             addon=self.addon, version=self.addon.current_version, rating=1,
             body='My review', user=self.rating_user)
-        self.url = reverse(self.reply_url_name, kwargs={'pk': self.rating.pk})
+        self.url = reverse_ns(
+            self.reply_url_name, kwargs={'pk': self.rating.pk})
 
     def test_url_v3(self):
-        v3_url = reverse('v3:rating-reply', kwargs={'pk': self.rating.pk})
+        v3_url = reverse_ns(
+            'rating-reply', api_version='v3', kwargs={'pk': self.rating.pk})
         expected_url = '/api/v3/reviews/review/%d/reply/' % self.rating.pk
         assert v3_url.endswith(expected_url)
 
@@ -2276,7 +2284,7 @@ class TestRatingViewSetReply(TestCase):
         self.addon_author = user_factory()
         self.addon.addonuser_set.create(user=self.addon_author)
         self.client.login_api(self.addon_author)
-        self.url = reverse(
+        self.url = reverse_ns(
             self.reply_url_name, kwargs={'pk': self.rating.pk + 42})
         response = self.client.post(self.url, data={})
         assert response.status_code == 404
@@ -2396,8 +2404,8 @@ class TestRatingViewSetReply(TestCase):
         other_rating = Rating.objects.create(
             addon=self.addon, version=self.addon.current_version, rating=1,
             body='My review', user=user_factory())
-        other_url = reverse(self.reply_url_name,
-                            kwargs={'pk': other_rating.pk})
+        other_url = reverse_ns(
+            self.reply_url_name, kwargs={'pk': other_rating.pk})
 
         with freeze_time('2017-11-01') as frozen_time:
             self.client.login_api(self.addon_author)

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -34,7 +34,7 @@ from olympia.amo.templatetags.jinja_helpers import (
     user_media_path, user_media_url)
 from olympia.amo.tests import (
     APITestClient, TestCase, addon_factory, check_links, file_factory, formset,
-    initial, user_factory, version_factory)
+    initial, reverse_ns, user_factory, version_factory)
 from olympia.amo.urlresolvers import reverse
 from olympia.files.models import File, FileValidation, WebextPermission
 from olympia.ratings.models import Rating, RatingFlag
@@ -4702,16 +4702,16 @@ class TestAddonReviewerViewSet(TestCase):
         super(TestAddonReviewerViewSet, self).setUp()
         self.user = user_factory()
         self.addon = addon_factory()
-        self.subscribe_url = reverse(
-            'v3:reviewers-addon-subscribe', kwargs={'pk': self.addon.pk})
-        self.unsubscribe_url = reverse(
-            'v3:reviewers-addon-unsubscribe', kwargs={'pk': self.addon.pk})
-        self.enable_url = reverse(
-            'v3:reviewers-addon-enable', kwargs={'pk': self.addon.pk})
-        self.disable_url = reverse(
-            'v3:reviewers-addon-disable', kwargs={'pk': self.addon.pk})
-        self.flags_url = reverse(
-            'v3:reviewers-addon-flags', kwargs={'pk': self.addon.pk})
+        self.subscribe_url = reverse_ns(
+            'reviewers-addon-subscribe', kwargs={'pk': self.addon.pk})
+        self.unsubscribe_url = reverse_ns(
+            'reviewers-addon-unsubscribe', kwargs={'pk': self.addon.pk})
+        self.enable_url = reverse_ns(
+            'reviewers-addon-enable', kwargs={'pk': self.addon.pk})
+        self.disable_url = reverse_ns(
+            'reviewers-addon-disable', kwargs={'pk': self.addon.pk})
+        self.flags_url = reverse_ns(
+            'reviewers-addon-flags', kwargs={'pk': self.addon.pk})
 
     def test_subscribe_not_logged_in(self):
         response = self.client.post(self.subscribe_url)
@@ -4725,8 +4725,8 @@ class TestAddonReviewerViewSet(TestCase):
     def test_subscribe_addon_does_not_exist(self):
         self.grant_permission(self.user, 'Addons:PostReview')
         self.client.login_api(self.user)
-        self.subscribe_url = reverse(
-            'v3:reviewers-addon-subscribe', kwargs={'pk': self.addon.pk + 42})
+        self.subscribe_url = reverse_ns(
+            'reviewers-addon-subscribe', kwargs={'pk': self.addon.pk + 42})
         response = self.client.post(self.subscribe_url)
         assert response.status_code == 404
 
@@ -4735,8 +4735,8 @@ class TestAddonReviewerViewSet(TestCase):
             user=self.user, addon=self.addon)
         self.grant_permission(self.user, 'Addons:PostReview')
         self.client.login_api(self.user)
-        self.subscribe_url = reverse(
-            'v3:reviewers-addon-subscribe', kwargs={'pk': self.addon.pk})
+        self.subscribe_url = reverse_ns(
+            'reviewers-addon-subscribe', kwargs={'pk': self.addon.pk})
         response = self.client.post(self.subscribe_url)
         assert response.status_code == 202
         assert ReviewerSubscription.objects.count() == 1
@@ -4744,8 +4744,8 @@ class TestAddonReviewerViewSet(TestCase):
     def test_subscribe(self):
         self.grant_permission(self.user, 'Addons:PostReview')
         self.client.login_api(self.user)
-        self.subscribe_url = reverse(
-            'v3:reviewers-addon-subscribe', kwargs={'pk': self.addon.pk})
+        self.subscribe_url = reverse_ns(
+            'reviewers-addon-subscribe', kwargs={'pk': self.addon.pk})
         response = self.client.post(self.subscribe_url)
         assert response.status_code == 202
         assert ReviewerSubscription.objects.count() == 1
@@ -4762,16 +4762,16 @@ class TestAddonReviewerViewSet(TestCase):
     def test_unsubscribe_addon_does_not_exist(self):
         self.grant_permission(self.user, 'Addons:PostReview')
         self.client.login_api(self.user)
-        self.unsubscribe_url = reverse(
-            'v3:reviewers-addon-subscribe', kwargs={'pk': self.addon.pk + 42})
+        self.unsubscribe_url = reverse_ns(
+            'reviewers-addon-subscribe', kwargs={'pk': self.addon.pk + 42})
         response = self.client.post(self.unsubscribe_url)
         assert response.status_code == 404
 
     def test_unsubscribe_not_subscribed(self):
         self.grant_permission(self.user, 'Addons:PostReview')
         self.client.login_api(self.user)
-        self.subscribe_url = reverse(
-            'v3:reviewers-addon-subscribe', kwargs={'pk': self.addon.pk})
+        self.subscribe_url = reverse_ns(
+            'reviewers-addon-subscribe', kwargs={'pk': self.addon.pk})
         response = self.client.post(self.unsubscribe_url)
         assert response.status_code == 202
         assert ReviewerSubscription.objects.count() == 0
@@ -4781,8 +4781,8 @@ class TestAddonReviewerViewSet(TestCase):
             user=self.user, addon=self.addon)
         self.grant_permission(self.user, 'Addons:PostReview')
         self.client.login_api(self.user)
-        self.subscribe_url = reverse(
-            'v3:reviewers-addon-subscribe', kwargs={'pk': self.addon.pk})
+        self.subscribe_url = reverse_ns(
+            'reviewers-addon-subscribe', kwargs={'pk': self.addon.pk})
         response = self.client.post(self.unsubscribe_url)
         assert response.status_code == 202
         assert ReviewerSubscription.objects.count() == 0
@@ -4798,8 +4798,8 @@ class TestAddonReviewerViewSet(TestCase):
             user=another_user, addon=self.addon)
         self.grant_permission(self.user, 'Addons:PostReview')
         self.client.login_api(self.user)
-        self.subscribe_url = reverse(
-            'v3:reviewers-addon-subscribe', kwargs={'pk': self.addon.pk})
+        self.subscribe_url = reverse_ns(
+            'reviewers-addon-subscribe', kwargs={'pk': self.addon.pk})
         response = self.client.post(self.unsubscribe_url)
         assert response.status_code == 202
         assert ReviewerSubscription.objects.count() == 2
@@ -4823,8 +4823,8 @@ class TestAddonReviewerViewSet(TestCase):
     def test_enable_addon_does_not_exist(self):
         self.grant_permission(self.user, 'Reviews:Admin')
         self.client.login_api(self.user)
-        self.enable_url = reverse(
-            'v3:reviewers-addon-enable', kwargs={'pk': self.addon.pk + 42})
+        self.enable_url = reverse_ns(
+            'reviewers-addon-enable', kwargs={'pk': self.addon.pk + 42})
         response = self.client.post(self.enable_url)
         assert response.status_code == 404
 
@@ -4891,8 +4891,8 @@ class TestAddonReviewerViewSet(TestCase):
     def test_disable_addon_does_not_exist(self):
         self.grant_permission(self.user, 'Reviews:Admin')
         self.client.login_api(self.user)
-        self.disable_url = reverse(
-            'v3:reviewers-addon-enable', kwargs={'pk': self.addon.pk + 42})
+        self.disable_url = reverse_ns(
+            'reviewers-addon-enable', kwargs={'pk': self.addon.pk + 42})
         response = self.client.post(self.disable_url)
         assert response.status_code == 404
 
@@ -4929,8 +4929,8 @@ class TestAddonReviewerViewSet(TestCase):
     def test_patch_flags_addon_does_not_exist(self):
         self.grant_permission(self.user, 'Reviews:Admin')
         self.client.login_api(self.user)
-        self.flags_url = reverse(
-            'v3:reviewers-addon-flags', kwargs={'pk': self.addon.pk + 42})
+        self.flags_url = reverse_ns(
+            'reviewers-addon-flags', kwargs={'pk': self.addon.pk + 42})
         response = self.client.patch(
             self.flags_url, {'auto_approval_disabled': True})
         assert response.status_code == 404

--- a/src/olympia/search/tests/test_search_ranking.py
+++ b/src/olympia/search/tests/test_search_ranking.py
@@ -2,8 +2,7 @@
 import json
 
 from olympia import amo
-from olympia.amo.tests import APITestClient, ESTestCase
-from olympia.amo.urlresolvers import reverse
+from olympia.amo.tests import APITestClient, ESTestCase, reverse_ns
 
 
 class TestRankingScenarios(ESTestCase):
@@ -11,7 +10,7 @@ class TestRankingScenarios(ESTestCase):
 
     def _check_scenario(self, query, expected, no_match=None):
         # Make sure things are properly flushed and searchable
-        url = reverse('v3:addon-search')
+        url = reverse_ns('addon-search')
 
         response = self.client.get(url, {'q': query})
         assert response.status_code == 200

--- a/src/olympia/signing/tests/test_views.py
+++ b/src/olympia/signing/tests/test_views.py
@@ -5,7 +5,6 @@ import os
 from datetime import datetime, timedelta
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
 from django.forms import ValidationError
 from django.test.utils import override_settings
 from django.utils import translation
@@ -18,7 +17,7 @@ from olympia import amo
 from olympia.access.models import Group, GroupUser
 from olympia.addons.models import Addon, AddonUser
 from olympia.amo.templatetags.jinja_helpers import absolutify
-from olympia.amo.tests import addon_factory
+from olympia.amo.tests import addon_factory, reverse_ns
 from olympia.api.tests.utils import APIKeyAuthTestCase
 from olympia.applications.models import AppVersion
 from olympia.devhub import tasks
@@ -60,7 +59,7 @@ class BaseUploadVersionCase(SigningAPITestCase):
             args = [guid, version]
         if pk is not None:
             args.append(pk)
-        return reverse('v3:signing.version', args=args)
+        return reverse_ns('signing.version', args=args)
 
     def create_version(self, version):
         response = self.request('PUT', self.url(self.guid, version), version)
@@ -463,7 +462,7 @@ class TestUploadVersionWebextension(BaseUploadVersionCase):
     def test_addon_does_not_exist_webextension(self):
         response = self.request(
             'POST',
-            url=reverse('v3:signing.version'),
+            url=reverse_ns('signing.version'),
             addon='@create-webextension',
             version='1.0')
         assert response.status_code == 201
@@ -529,7 +528,7 @@ class TestUploadVersionWebextension(BaseUploadVersionCase):
     def test_optional_id_not_allowed_for_regular_addon(self):
         response = self.request(
             'POST',
-            url=reverse('v3:signing.version'),
+            url=reverse_ns('signing.version'),
             addon='@create-version-no-id',
             version='1.0')
         assert response.status_code == 400
@@ -537,7 +536,7 @@ class TestUploadVersionWebextension(BaseUploadVersionCase):
     def test_webextension_reuse_guid(self):
         response = self.request(
             'POST',
-            url=reverse('v3:signing.version'),
+            url=reverse_ns('signing.version'),
             addon='@create-webextension-with-guid',
             version='1.0')
 
@@ -552,14 +551,14 @@ class TestUploadVersionWebextension(BaseUploadVersionCase):
         # have to use the regular `PUT` endpoint for that.
         response = self.request(
             'POST',
-            url=reverse('v3:signing.version'),
+            url=reverse_ns('signing.version'),
             addon='@create-webextension-with-guid',
             version='1.0')
         assert response.status_code == 201
 
         response = self.request(
             'POST',
-            url=reverse('v3:signing.version'),
+            url=reverse_ns('signing.version'),
             addon='@create-webextension-with-guid',
             version='1.0')
         assert response.status_code == 400
@@ -570,7 +569,7 @@ class TestUploadVersionWebextension(BaseUploadVersionCase):
         # have to use the regular `PUT` endpoint for that.
         response = self.request(
             'POST',
-            url=reverse('v3:signing.version'),
+            url=reverse_ns('signing.version'),
             addon='@create-webextension-with-guid-and-version',
             version='99.0')
         assert response.status_code == 201
@@ -585,7 +584,7 @@ class TestUploadVersionWebextension(BaseUploadVersionCase):
 
         response = self.request(
             'POST',
-            url=reverse('v3:signing.version'),
+            url=reverse_ns('signing.version'),
             addon='@notify-link-clicks-i18n',
             version='1.0',
             filename=fname)
@@ -742,7 +741,7 @@ class TestCheckVersion(BaseUploadVersionCase):
         assert response.status_code == 200
         file_ = qs.get()
         assert response.data['files'][0]['download_url'] == absolutify(
-            reverse('v3:signing.file', kwargs={'file_id': file_.id}) +
+            reverse_ns('signing.file', kwargs={'file_id': file_.id}) +
             '/delicious_bookmarks-3.0-fx.xpi?src=api')
 
     def test_file_hash(self):
@@ -775,7 +774,7 @@ class TestSignedFile(SigningAPITestCase):
         self.file_ = self.create_file()
 
     def url(self):
-        return reverse('v3:signing.file', args=[self.file_.pk])
+        return reverse_ns('signing.file', args=[self.file_.pk])
 
     def create_file(self):
         addon = addon_factory(


### PR DESCRIPTION
fixes #8517 

As `reverse_ns` defaults to `settings.REST_FRAMEWORK['DEFAULT_VERSION']` we can run an entire job with a different settings file that overrides it to `v3` or `v4` to run the API tests twice.

If we go down the route of doing it all the in same job then we need to split a number of classes into base and subclasses.  In that case `reverse_ns` could maybe be moved inside `TestClass`