### PR TITLE
Remove jdk8 default setting.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,23 +26,22 @@ cache:
     - node_modules
     - $HOME/.gimme
 
-services:
-  - mysql
-  - memcached
-  - elasticsearch
-  - redis
-
 addons:
   apt:
     sources:
       - elasticsearch-5.x
     packages:
       - swig
-      - oracle-java8-set-default
       - elasticsearch
       - gettext
       - librsvg2-bin
       - pngcrush
+
+services:
+  - mysql
+  - memcached
+  - elasticsearch
+  - redis
 
 before_install:
   - mysql -e 'create database olympia;'


### PR DESCRIPTION
The `oracle-java8-set-default` package get's installed because of ElasticSearch 5. We configured this back when we were still using Travis tests running on Ubuntu Precise but now on Trusty this seems to be the default and we don't have to install the package anymore.

The mentioned package also seems to be a big factor in our recent Travis build failures - https://github.com/mozilla/addons-server/issues/8555 - and when there's a 404 error it's 90% of the time from this package.