### PR TITLE
Introduce temporary workaround for circleci failures.

### DIFF
--- a/Makefile-docker
+++ b/Makefile-docker
@@ -68,7 +68,12 @@ help_submake:
 
 initialize_db:
 	rm -rf ./user-media/* ./tmp/*
-	python manage.py reset_db
+	# The --no-utf8 is a temporary workaround for https://github.com/mozilla/addons-server/issues/8593
+	# The actual fix is pushed upstream in https://github.com/django-extensions/django-extensions/issues/1213
+	# as https://github.com/django-extensions/django-extensions/pull/1214
+	# So this will have to be reverted once an upstream fix lands.  --no-utf8 here actually *enables*
+	# utf-8 support.
+	python manage.py reset_db --no-utf8
 	python manage.py migrate --noinput
 	python manage.py loaddata initial.json
 	python manage.py import_prod_versions
@@ -133,7 +138,12 @@ reindex:
 setup-ui-tests:
 	rm -rf ./user-media/* ./tmp/*
 	# Reset the database and fake database migrations
-	python manage.py reset_db --noinput
+	# The --no-utf8 is a temporary workaround for https://github.com/mozilla/addons-server/issues/8593
+	# The actual fix is pushed upstream in https://github.com/django-extensions/django-extensions/issues/1213
+	# as https://github.com/django-extensions/django-extensions/pull/1214
+	# So this will have to be reverted once an upstream fix lands. --no-utf8 here actually *enables*
+	# utf-8 support.
+	python manage.py reset_db --noinput --no-utf8
 	python manage.py migrate --noinput
 	schematic --fake src/olympia/migrations/
 


### PR DESCRIPTION
The --no-utf8 option accidentally got reversed in django-extensions
1.8.1. The issue got reported upstream in
https://github.com/django-extensions/django-extensions/issues/1213 and
there's a fix in
https://github.com/django-extensions/django-extensions/pull/1214 which,
once this lands means we can safely remove our "--no-utf8" in the
makefile.

Fixes #8593