### PR TITLE
pause celery tasks before starting migrations; resume after.

### DIFF
--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -31,6 +31,7 @@ from olympia.constants.licenses import (
     LICENSE_COPYRIGHT_AR, PERSONA_LICENSES_IDS)
 from olympia.files.models import FileUpload
 from olympia.files.utils import RDFExtractor, get_file, parse_addon, SafeZip
+from olympia.amo.celery import pause_all_tasks, resume_all_tasks
 from olympia.lib.crypto.packaged import sign_file
 from olympia.lib.es.utils import index_objects
 from olympia.ratings.models import Rating
@@ -611,6 +612,7 @@ def migrate_lwts_to_static_themes(ids, **kw):
 
     # Incoming ids should already by type=persona only
     lwts = Addon.objects.filter(id__in=ids)
+    pause_all_tasks()
     for lwt in lwts:
         static = None
         try:
@@ -628,6 +630,7 @@ def migrate_lwts_to_static_themes(ids, **kw):
         slug = lwt.slug
         lwt.delete()
         static.update(slug=slug)
+    resume_all_tasks()
 
 
 @task

--- a/src/olympia/amo/celery.py
+++ b/src/olympia/amo/celery.py
@@ -12,7 +12,8 @@ from celery import Celery, group
 from celery.signals import task_failure, task_postrun, task_prerun
 from django_statsd.clients import statsd
 from kombu import serialization
-from post_request_task.task import PostRequestTask
+from post_request_task.task import (
+    PostRequestTask, _start_queuing_tasks, _send_tasks_and_stop_queuing)
 from raven import Client
 from raven.contrib.celery import register_logger_signal, register_signal
 
@@ -174,3 +175,11 @@ def create_subtasks(task, qs, chunk_size, countdown=None, task_args=None):
         job.apply_async(countdown=countdown)
     else:
         job.apply_async()
+
+
+def pause_all_tasks():
+    _start_queuing_tasks()
+
+
+def resume_all_tasks():
+    _send_tasks_and_stop_queuing()


### PR DESCRIPTION
It's hacky but it should fix #8405 
Couldn't work out a sensible way of testing it.