### PR TITLE
Run autograph with Go 1.10

### DIFF
--- a/scripts/start-autograph.sh
+++ b/scripts/start-autograph.sh
@@ -4,7 +4,7 @@
 echo "installing autograph + dependencies"
 curl -sL -o ./gimme https://raw.githubusercontent.com/travis-ci/gimme/v1.2.0/gimme
 chmod +x ./gimme
-eval "$(./gimme 1.8.5)"
+eval "$(./gimme 1.10)"
 go get go.mozilla.org/autograph
 
 # Start autograph in background


### PR DESCRIPTION
As part of https://github.com/mozilla-services/autograph/pull/101 autograph increased the minimal version of Go required to run it.

This adapts our setup script to use Go 1.10.