### PR TITLE
Remove ability to edit any collection through the frontend with Collections:Edit permission

### DIFF
--- a/docs/topics/api/collections.rst
+++ b/docs/topics/api/collections.rst
@@ -19,8 +19,7 @@ List
 .. _collection-list:
 
 .. note::
-    This API requires :doc:`authentication <auth>` and `Collections:Edit`
-    permission to list collections other than your own.
+    This API requires :doc:`authentication <auth>`.
 
 This endpoint allows you to list all collections authored by the specified user.
 The results are sorted by the most recently updated collection first.
@@ -43,7 +42,8 @@ Detail
 This endpoint allows you to fetch a single collection by its ``slug``.
 It returns any ``public`` collection by the specified user. You can access
 a non-``public`` collection only if it was authored by you, the authenticated user.
-If your account has the `Collections:Edit` permission then you can access any collection.
+ If you have ``Admin:Curation`` permission you can see any collection belonging
+ to the ``mozilla`` user.
 
 
 .. http:get:: /api/v4/accounts/account/(int:user_id|string:username)/collections/(string:collection_slug)/
@@ -114,8 +114,10 @@ Edit
 .. _`collection-edit`:
 
 .. note::
-    This API requires :doc:`authentication <auth>` and `Collections:Edit`
-    permission to edit collections other than your own.
+    This API requires :doc:`authentication <auth>`. If you have
+    ``Admin:Curation`` permission you can edit any collection belonging to the
+    ``mozilla`` user.
+
 
 This endpoint allows some of the details for a collection to be updated.  Any fields
 in the :ref:`collection <collection-detail-object>` but not listed below are not editable and will be ignored in the patch request.
@@ -138,8 +140,9 @@ Delete
 .. _`collection-delete`:
 
 .. note::
-    This API requires :doc:`authentication <auth>` and `Collections:Edit`
-    permission to delete collections other than your own.
+    This API requires :doc:`authentication <auth>`. If you have
+    ``Admin:Curation`` permission you can delete any collection belonging to the
+    ``mozilla`` user.
 
 This endpoint allows the collection to be deleted.
 
@@ -223,8 +226,7 @@ Collection Add-ons Create
 .. _collection-addon-create:
 
 .. note::
-    This API requires :doc:`authentication <auth>` and `Collections:Edit`
-    permission to edit collections other than your own.
+    This API requires :doc:`authentication <auth>`.
 
 This endpoint allows a single add-on to be added to a collection, optionally with collector's notes.
 
@@ -241,8 +243,11 @@ Collection Add-ons Edit
 .. _collection-addon-edit:
 
 .. note::
-    This API requires :doc:`authentication <auth>` and `Collections:Edit`
-    permission to edit collections other than your own.
+    This API requires :doc:`authentication <auth>`. If you have
+    ``Admin:Curation`` permission you can edit the add-ons of any collection
+    belonging to the ``mozilla`` user. If you have ``Collections:Contribute``
+    permission you can edit the add-ons of mozilla's ``Featured Themes``
+    collection.
 
 This endpoint allows the collector's notes for single add-on to be updated.
 
@@ -258,8 +263,11 @@ Collection Add-ons Delete
 .. _collection-addon-delete:
 
 .. note::
-    This API requires :doc:`authentication <auth>` and `Collections:Edit`
-    permission to edit collections other than your own.
+    This API requires :doc:`authentication <auth>`. If you have
+    ``Admin:Curation`` permission you can remove add-ons from any collection
+    belonging to the ``mozilla`` user. If you have ``Collections:Contribute``
+    permission you can remove add-ons from mozilla's ``Featured Themes``
+    collection.
 
 This endpoint allows a single add-on to be removed from a collection.
 

--- a/src/olympia/access/acl.py
+++ b/src/olympia/access/acl.py
@@ -73,9 +73,10 @@ def check_collection_ownership(request, collection, require_owner=False):
     if not request.user.is_authenticated():
         return False
 
-    if action_allowed(request, amo.permissions.COLLECTIONS_EDIT):
+    if request.user.id == collection.author_id:
         return True
-    elif request.user.id == collection.author_id:
+    elif collection.author.username == 'mozilla' and action_allowed_user(
+            request.user, amo.permissions.ADMIN_CURATION):
         return True
     elif not require_owner:
         return (

--- a/src/olympia/api/permissions.py
+++ b/src/olympia/api/permissions.py
@@ -272,7 +272,7 @@ class PreventActionPermission(BasePermission):
     Allow access except for a given action(s).
     """
     def __init__(self, actions):
-        if not isinstance(actions, list):
+        if not isinstance(actions, (list, tuple)):
             actions = [actions]
         self.actions = actions
 

--- a/src/olympia/bandwagon/permissions.py
+++ b/src/olympia/bandwagon/permissions.py
@@ -30,3 +30,20 @@ class AllowCollectionContributor(BasePermission):
             obj.pk == settings.COLLECTION_FEATURED_THEMES_ID and
             acl.action_allowed(request, amo.permissions.COLLECTIONS_CONTRIBUTE)
         )
+
+
+class AllowContentCurators(BasePermission):
+    """Allow people with Admin:Curation permission to modify mozilla
+    collections.  Be careful where this used as it can allow
+    creating / listing objects if used alone in a ViewSet that has those
+    actions."""
+
+    def has_permission(self, request, view):
+        return request.user.is_authenticated()
+
+    def has_object_permission(self, request, view, obj):
+        return (
+            obj and
+            obj.author.username == 'mozilla' and
+            acl.action_allowed(request, amo.permissions.ADMIN_CURATION)
+        )

--- a/src/olympia/bandwagon/tests/test_views.py
+++ b/src/olympia/bandwagon/tests/test_views.py
@@ -14,7 +14,6 @@ from mock import Mock, patch
 from pyquery import PyQuery as pq
 
 from olympia import amo, core
-from olympia.access.models import Group, GroupUser
 from olympia.activity.models import ActivityLog
 from olympia.addons.models import Addon
 from olympia.amo.tests import (
@@ -344,6 +343,9 @@ class TestCRUD(TestCase):
             'description': '',
             'listed': 'True'
         }
+        self.grant_permission(
+            UserProfile.objects.get(email='admin@mozilla.com'),
+            'Admin:Curation')
 
     def login_admin(self):
         assert self.client.login(email='admin@mozilla.com')
@@ -353,9 +355,9 @@ class TestCRUD(TestCase):
 
     def create_collection(self, **kw):
         self.data.update(kw)
-        r = self.client.post(self.add_url, self.data, follow=True)
-        assert r.status_code == 200
-        return r
+        response = self.client.post(self.add_url, self.data, follow=True)
+        assert response.status_code == 200
+        return response
 
     @patch('olympia.bandwagon.views.statsd.incr')
     def test_create_collection_statsd(self, mock_incr):
@@ -563,32 +565,61 @@ class TestCRUD(TestCase):
             r = self.client.post(url)
             assert r.status_code == 403
 
-    def test_acl_collections_edit(self):
-        # Test users in group with 'Collections:Edit' are allowed.
+    def test_acl_admin_curation(self):
+        # Test that even with 'Admin:Curation' you can't edit anyone's
+        # collection through the legacy frontend.
+        self.create_collection()
+
         user = UserProfile.objects.get(email='regular@mozilla.com')
-        group = Group.objects.create(name='Staff', rules='Collections:Edit')
-        GroupUser.objects.create(user=user, group=group)
-        r = self.client.post(self.add_url, self.data, follow=True)
+        self.grant_permission(user, 'Admin:Curation')
         self.login_regular()
         url_args = ['admin', self.slug]
 
         url = reverse('collections.edit', args=url_args)
-        r = self.client.get(url)
-        assert r.status_code == 200
+        response = self.client.get(url)
+        assert response.status_code == 403
 
         url = reverse('collections.edit_addons', args=url_args)
-        r = self.client.get(url)
-        assert r.status_code == 405
-        # Passed acl check, but this view needs a POST.
+        response = self.client.get(url)
+        assert response.status_code == 403
 
         url = reverse('collections.edit_privacy', args=url_args)
-        r = self.client.get(url)
-        assert r.status_code == 405
-        # Passed acl check, but this view needs a POST.
+        response = self.client.get(url)
+        assert response.status_code == 403
 
         url = reverse('collections.delete', args=url_args)
-        r = self.client.get(url)
-        assert r.status_code == 200
+        response = self.client.get(url)
+        assert response.status_code == 403
+
+    def test_acl_admin_curation_mozilla(self):
+        # Test that with 'Admin:Curation' you can edit collections by the
+        # user named "mozilla".
+        self.create_collection()
+        mozilla = UserProfile.objects.get(username='mozilla')
+        Collection.objects.get(slug=self.slug).update(author=mozilla)
+
+        user = UserProfile.objects.get(email='regular@mozilla.com')
+        self.grant_permission(user, 'Admin:Curation')
+        self.login_regular()
+        url_args = ['mozilla', self.slug]
+
+        url = reverse('collections.edit', args=url_args)
+        response = self.client.get(url)
+        assert response.status_code == 200
+
+        url = reverse('collections.edit_addons', args=url_args)
+        response = self.client.get(url)
+        # Passed acl check, but this view needs a POST.
+        assert response.status_code == 405
+
+        url = reverse('collections.edit_privacy', args=url_args)
+        response = self.client.get(url)
+        # Passed acl check, but this view needs a POST.
+        assert response.status_code == 405
+
+        url = reverse('collections.delete', args=url_args)
+        response = self.client.get(url)
+        assert response.status_code == 200
 
     def test_edit_favorites(self):
         r = self.client.get(reverse('collections.list'))
@@ -666,20 +697,24 @@ class TestCRUD(TestCase):
         assert Collection.objects.filter(slug='mobile', author=u)
 
     def test_no_changing_owners(self):
-        self.login_regular()
-        self.create_collection()
-        c = Collection.objects.get(slug=self.slug)
-
         self.login_admin()
-        r = self.client.post(c.edit_url(),
-                             dict(name='new name', slug=self.slug,
-                                  listed=True),
-                             follow=True)
-        assert r.status_code == 200
+        self.create_collection()
+        mozilla = UserProfile.objects.get(username='mozilla')
+        collection = Collection.objects.get(slug=self.slug)
+        collection.update(author=mozilla)
 
-        newc = Collection.objects.get(slug=self.slug,
-                                      author__username=c.author_username)
-        assert unicode(newc.name) == 'new name'
+        self.login_regular()
+        self.grant_permission(
+            UserProfile.objects.get(email='regular@mozilla.com'),
+            'Admin:Curation')
+        response = self.client.post(
+            collection.edit_url(),
+            {'name': 'new name', 'slug': self.slug, 'listed': True},
+            follow=True)
+        assert response.status_code == 200
+
+        collection.reload()
+        assert unicode(collection.name) == 'new name'
 
 
 class TestChangeAddon(TestCase):
@@ -1079,8 +1114,11 @@ class TestCollectionViewSetList(TestCase):
         self.grant_permission(self.user, 'Collections:Edit')
         self.client.login_api(self.user)
         response = self.client.get(other_url)
-        assert response.status_code == 200
-        assert len(response.data['results']) == 1
+        assert response.status_code == 403
+
+        self.grant_permission(self.user, 'Admin:Curation')
+        response = self.client.get(other_url)
+        assert response.status_code == 403
 
     def test_404(self):
         # Invalid user.
@@ -1181,8 +1219,16 @@ class TestCollectionViewSetDetail(TestCase):
         self.grant_permission(self.user, 'Collections:Edit')
         self.client.login_api(self.user)
         response = self.client.get(self._get_url(random_user, collection))
+        assert response.status_code == 403
+
+        self.grant_permission(self.user, 'Admin:Curation')
+        response = self.client.get(self._get_url(random_user, collection))
+        assert response.status_code == 403
+
+        random_user.update(username='mozilla')
+        response = self.client.get(self._get_url(random_user, collection))
         assert response.status_code == 200
-        assert response.data['id'] == collection.id
+        assert response.data['id'] == collection.pk
 
     def test_not_listed_contributor(self):
         self.collection.update(listed=False)
@@ -1414,6 +1460,10 @@ class TestCollectionViewSetCreate(CollectionViewSetDataMixin, TestCase):
         response = self.send(url=url)
         assert response.status_code == 403
 
+        self.grant_permission(self.user, 'Admin:Curation')
+        response = self.send(url=url)
+        assert response.status_code == 403
+
     def test_create_numeric_slug(self):
         self.client.login_api(self.user)
         data = {
@@ -1467,7 +1517,16 @@ class TestCollectionViewSetPatch(CollectionViewSetDataMixin, TestCase):
         url = self.get_url(random_user)
         original = self.client.get(url).content
         response = self.send(url=url)
+        assert response.status_code == 403
+
+        self.grant_permission(self.user, 'Admin:Curation')
+        response = self.send(url=url)
+        assert response.status_code == 403
+
+        random_user.update(username='mozilla')
+        response = self.send(url=url)
         assert response.status_code == 200
+
         assert response.content != original
         self.collection = self.collection.reload()
         self.check_data(self.collection, self.data,
@@ -1530,6 +1589,15 @@ class TestCollectionViewSetDelete(TestCase):
         self.collection.update(author=random_user)
         url = self.get_url(random_user)
         response = self.client.delete(url)
+        assert response.status_code == 403
+
+        self.grant_permission(self.user, 'Admin:Curation')
+        response = self.client.delete(url)
+        assert response.status_code == 403
+        assert Collection.objects.filter(id=self.collection.id).exists()
+
+        random_user.update(username='mozilla')
+        response = self.client.delete(url)
         assert response.status_code == 204
         assert not Collection.objects.filter(id=self.collection.id).exists()
 
@@ -1582,6 +1650,13 @@ class CollectionAddonViewSetMixin(object):
         admin_user = user_factory()
         self.grant_permission(admin_user, 'Collections:Edit')
         self.client.login_api(admin_user)
+        response = self.send(self.url)
+        assert response.status_code == 403
+        self.grant_permission(admin_user, 'Admin:Curation')
+        response = self.send(self.url)
+        assert response.status_code == 403
+
+        self.collection.author.update(username='mozilla')
         self.check_response(self.send(self.url))
 
     def test_contributor(self):


### PR DESCRIPTION
`Admin:Curation` gives you the ability to edit collections owned by mozilla through the frontend. Anything else (i.e., modifying other collections) must be done through the admin tools.

Fix #8509