### PR TITLE
make background filename always visible in reviewer tools

### DIFF
--- a/src/olympia/reviewers/templates/reviewers/addon_details_box.html
+++ b/src/olympia/reviewers/templates/reviewers/addon_details_box.html
@@ -189,7 +189,7 @@
           {% with filename=background.rsplit('/', 1)[1] %}
           <div class="background zoombox">
               <img src="{{ background }}" alt="" width="1000" height="200">
-              {{ _('Background file {0} of {1} - {2}')|format_html(loop.index, loop.length, filename) }}
+              <span>{{ _('Background file {0} of {1} - {2}')|format_html(loop.index, loop.length, filename) }}</span>
           </div>
           {% endwith %}
         {% endfor %}

--- a/static/css/zamboni/reviewers.less
+++ b/static/css/zamboni/reviewers.less
@@ -1168,6 +1168,10 @@ h2.addon {
             position: absolute;
             right: 0;
         }
+        span {
+            position: absolute;
+            background-color: rgba(255,255,255,.75);
+        }
     }
   }
 }


### PR DESCRIPTION
fixes #8556 
Before:
![image](https://user-images.githubusercontent.com/31961530/41531587-7570a606-72fc-11e8-8d0d-352046e149b8.png)
After:
![screenshot 2018-06-26 10 05 29](https://user-images.githubusercontent.com/768592/41901483-ebeacde8-7928-11e8-877b-2b35a15df5a8.png)

