### PR TITLE
Remove 'beta-versions' waffle flag

### DIFF
--- a/src/olympia/migrations/1026-remove-beta-versions-waffle.sql
+++ b/src/olympia/migrations/1026-remove-beta-versions-waffle.sql
@@ -1,0 +1,1 @@
+DELETE FROM `waffle_switch` WHERE `name` = 'beta-versions';


### PR DESCRIPTION
Fix #7163.

See https://github.com/mozilla/addons-server/blob/b1ca6c6e564a80219f74a234d05351bfcc4e912c/src/olympia/migrations/997-add-beta-versions-flag.sql