### PR TITLE
Don't show user-disabled add-ons in expired info-requests queue

### DIFF
--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -1993,6 +1993,14 @@ class TestExpiredInfoRequestsQueue(QueueTest):
             addon=addon5,
             pending_info_request=self.days_ago(42))
 
+        # Invisible (user-disabled) addon with expired info request.
+        addon6 = addon_factory(name=u'Incomplete Addön 5',
+                               status=amo.STATUS_PUBLIC,
+                               disabled_by_user=True)
+        AddonReviewerFlags.objects.create(
+            addon=addon6,
+            pending_info_request=self.days_ago(42))
+
         self.expected_addons = [addon2, addon1]
 
     def test_results_no_permission(self):

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -546,8 +546,10 @@ def queue_counts(admin_reviewer, limited_reviewer, extension_reviews,
 
     expired = (
         Addon.objects.filter(
-            addonreviewerflags__pending_info_request__lt=datetime.now()
-        ).order_by('addonreviewerflags__pending_info_request'))
+            addonreviewerflags__pending_info_request__lt=datetime.now(),
+            status__in=(amo.STATUS_NOMINATED, amo.STATUS_PUBLIC),
+            disabled_by_user=False)
+        .order_by('addonreviewerflags__pending_info_request'))
 
     counts = {
         'pending': construct_query_from_sql_model(ViewPendingQueue),
@@ -656,7 +658,8 @@ def queue_expired_info_requests(request):
     qs = (
         Addon.objects.filter(
             addonreviewerflags__pending_info_request__lt=datetime.now(),
-            status__in=(amo.STATUS_NOMINATED, amo.STATUS_PUBLIC))
+            status__in=(amo.STATUS_NOMINATED, amo.STATUS_PUBLIC),
+            disabled_by_user=False)
         .order_by('addonreviewerflags__pending_info_request'))
     return _queue(request, ExpiredInfoRequestsTable, 'expired_info_requests',
                   qs=qs, SearchForm=None)


### PR DESCRIPTION
Fix #8008.

This also fixes/synchronizes the queue count in the header.