### PR TITLE
Use .update() instead of .save() in cron computing last updated date for add-ons

### DIFF
--- a/src/olympia/addons/cron.py
+++ b/src/olympia/addons/cron.py
@@ -130,8 +130,7 @@ def _change_last_updated(next):
     # Update + invalidate.
     qs = Addon.objects.no_cache().filter(id__in=changes).no_transforms()
     for addon in qs:
-        addon.last_updated = changes[addon.id]
-        addon.save()
+        addon.update(last_updated=changes[addon.id])
 
 
 @write


### PR DESCRIPTION
`.save()` re-submits all fields, our `.update()` doesn't. May explain some weird issues we've been seeing with _current_version being wrong, since this happens outside transactions.

Would hopefully fix #6962