### PR TITLE
Upgrade gimme and point go to 'stable' (1.10.3 currently) release.

### DIFF
--- a/scripts/start-autograph.sh
+++ b/scripts/start-autograph.sh
@@ -2,9 +2,9 @@
 
 # Install autograph
 echo "installing autograph + dependencies"
-curl -sL -o ./gimme https://raw.githubusercontent.com/travis-ci/gimme/v1.2.0/gimme
+curl -sL -o ./gimme https://raw.githubusercontent.com/travis-ci/gimme/v1.5.0/gimme
 chmod +x ./gimme
-eval "$(./gimme 1.10)"
+eval "$(./gimme stable)"
 go get go.mozilla.org/autograph
 
 # Start autograph in background


### PR DESCRIPTION
Upgrade gimme and point go to 'stable' (1.10.3 currently) release.

This plus mozilla-services/autograph#103 should fix our recent build
problems.

autograph ci will use the 'stable' flag for their CI too so that we're
in-sync and should see failures fairly quickly.