### PR TITLE
Correctly use quote_etags to quote/escape our etag values.

### DIFF
--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -33,7 +33,7 @@ from django.http import HttpResponse
 from django.template import engines, loader
 from django.utils import translation
 from django.utils.encoding import force_bytes, force_text
-from django.utils.http import _urlparse as django_urlparse
+from django.utils.http import _urlparse as django_urlparse, quote_etag
 
 import bleach
 import html5lib
@@ -711,7 +711,7 @@ class HttpResponseSendFile(HttpResponse):
         if settings.XSENDFILE:
             self[settings.XSENDFILE_HEADER] = header_path
         if etag:
-            self['ETag'] = '"%s"' % etag
+            self['ETag'] = quote_etag(etag)
 
     def __iter__(self):
         if settings.XSENDFILE:

--- a/src/olympia/files/decorators.py
+++ b/src/olympia/files/decorators.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from django import http
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.shortcuts import get_object_or_404
-from django.utils.http import http_date
+from django.utils.http import http_date, quote_etag
 
 import olympia.core.logger
 
@@ -58,7 +58,10 @@ def last_modified(request, obj, key=None, **kw):
 
 
 def etag(request, obj, key=None, **kw):
-    return _get_value(obj, key, 'sha256')
+    value = _get_value(obj, key, 'sha256')
+    if value:
+        return quote_etag(value)
+    return value
 
 
 def file_view(func, **kwargs):
@@ -77,7 +80,7 @@ def file_view(func, **kwargs):
 
         response = func(request, obj, *args, **kw)
         if obj.selected:
-            response['ETag'] = '"%s"' % obj.selected.get('sha256')
+            response['ETag'] = quote_etag(obj.selected.get('sha256'))
             response['Last-Modified'] = http_date(obj.selected.get('modified'))
         return response
     return wrapper
@@ -99,7 +102,7 @@ def compare_file_view(func, **kwargs):
 
         response = func(request, obj, *args, **kw)
         if obj.left.selected:
-            response['ETag'] = '"%s"' % obj.left.selected.get('sha256')
+            response['ETag'] = quote_etag(obj.left.selected.get('sha256'))
             response['Last-Modified'] = http_date(obj.left.selected
                                                           .get('modified'))
         return response

--- a/src/olympia/files/tests/test_views.py
+++ b/src/olympia/files/tests/test_views.py
@@ -7,7 +7,7 @@ import urlparse
 from django.conf import settings
 from django.core.cache import cache
 from django.test.utils import override_settings
-from django.utils.http import http_date
+from django.utils.http import http_date, quote_etag
 
 import pytest
 
@@ -186,7 +186,7 @@ class FilesBase(object):
         self.file_viewer.extract()
         self.file_viewer.select('install.js')
         obj = getattr(self.file_viewer, 'left', self.file_viewer)
-        etag = obj.selected.get('sha256')
+        etag = quote_etag(obj.selected.get('sha256'))
         res = self.client.get(self.file_url('install.js'),
                               HTTP_IF_NONE_MATCH=etag)
         assert res.status_code == 304


### PR DESCRIPTION
We do have tests for most of these already so there's not much adaption
needed.

Fixes #8534