### PR TITLE
Migrate LWT update counts to static themes.  popularity -> ADU

### DIFF
--- a/src/olympia/stats/management/commands/theme_update_counts_from_file.py
+++ b/src/olympia/stats/management/commands/theme_update_counts_from_file.py
@@ -91,7 +91,7 @@ class Command(BaseCommand):
         ThemeUpdateCount.objects.filter(date=day).delete()
 
         theme_update_counts = {}
-        new_st_update_counts = {}
+        new_stheme_update_counts = {}
 
         # Preload a set containing the ids of all the persona Add-on objects
         # that we care about. When looping, if we find an id that is not in
@@ -105,7 +105,7 @@ class Command(BaseCommand):
             MigratedLWT.objects.values_list(
                 'lightweight_theme_id', 'static_theme_id')
         )
-        existing_st_update_counts = {
+        existing_stheme_update_counts = {
             uc.addon_id: uc for uc in UpdateCount.objects.filter(
                 addon_id__in=migrated_personas.values())}
         # Preload all the Personas once and for all. This builds a dict where
@@ -142,13 +142,13 @@ class Command(BaseCommand):
             # Is the persona already migrated to static theme?
             if addon_id in migrated_personas:
                 mig_addon_id = migrated_personas[addon_id]
-                if mig_addon_id in existing_st_update_counts:
-                    existing_st_update_counts[mig_addon_id].count += count
-                    existing_st_update_counts[mig_addon_id].save()
-                elif mig_addon_id in new_st_update_counts:
-                    new_st_update_counts[mig_addon_id].count += count
+                if mig_addon_id in existing_stheme_update_counts:
+                    existing_stheme_update_counts[mig_addon_id].count += count
+                    existing_stheme_update_counts[mig_addon_id].save()
+                elif mig_addon_id in new_stheme_update_counts:
+                    new_stheme_update_counts[mig_addon_id].count += count
                 else:
-                    new_st_update_counts[mig_addon_id] = UpdateCount(
+                    new_stheme_update_counts[mig_addon_id] = UpdateCount(
                         addon_id=mig_addon_id, date=day, count=count)
 
             # Does this addon exist?
@@ -168,7 +168,7 @@ class Command(BaseCommand):
 
         # Create in bulk: this is much faster.
         ThemeUpdateCount.objects.bulk_create(theme_update_counts.values(), 100)
-        UpdateCount.objects.bulk_create(new_st_update_counts.values(), 100)
+        UpdateCount.objects.bulk_create(new_stheme_update_counts.values(), 100)
 
         log.info('Processed a total of %s lines' % (index + 1))
         log.debug('Total processing time: %s' % (datetime.now() - start))

--- a/src/olympia/stats/utils.py
+++ b/src/olympia/stats/utils.py
@@ -1,0 +1,15 @@
+from olympia.stats.models import ThemeUpdateCount, UpdateCount
+
+
+def migrate_theme_update_count(lwt, static_theme, **kw):
+    """Create UpdateCount instances from ThemeUpdateCount instances.
+    By default all instances for the specified lwt (lightweight theme) are
+    copied.  Any additional **kw are passed to the filter to - for example to
+    limit to a certain day or day range."""
+    theme_update_counts = ThemeUpdateCount.objects.filter(
+        addon_id=lwt.id, **kw).iterator()
+    update_counts = [
+        UpdateCount(addon_id=static_theme.id, date=tuc.date, count=tuc.count)
+        for tuc in theme_update_counts
+    ]
+    UpdateCount.objects.bulk_create(update_counts, 100)


### PR DESCRIPTION
Fixes #8662 as much as we can.  Download counts I can't see a way to replicate.

Looking at the way and the order in which the crons operate, the ADU and hotness calculations happen after both the theme and extension update counts are processed, so counts from the existing LWTs installed will be added and included in the migrated theme ADU.