### PR TITLE
Make sure you can delete add-ons with unknown types

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -479,7 +479,7 @@ class Addon(OnChangeMixin, ModelBase):
             # Don't localize email to admins, use 'en-US' always.
             with translation.override(settings.LANGUAGE_CODE):
                 # The types are lazy translated in apps/constants/base.py.
-                atype = amo.ADDON_TYPE.get(self.type).upper()
+                atype = amo.ADDON_TYPE.get(self.type, 'unknown').upper()
             context = {
                 'atype': atype,
                 'authors': [u.email for u in self.authors.all()],

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -655,6 +655,14 @@ class TestAddonModels(TestCase):
         self._delete(3615)
         assert DeniedGuid.objects.filter(guid=addon.guid).exists()
 
+    def test_delete_unknown_type(self):
+        """
+        Test making sure deleting add-ons with an unknown type, like old
+        webapps from Marketplace that are somehow still around, is possible."""
+        addon = Addon.objects.get(pk=3615)
+        addon.update(type=11)
+        self._delete(3615)
+
     def test_incompatible_latest_apps(self):
         a = Addon.objects.get(pk=3615)
         assert a.incompatible_latest_apps() == []


### PR DESCRIPTION
Unblocks deleting add-ons not compatible with Firefoxes, since
we have some webapps that are still in the database...

Hopefully fix https://github.com/mozilla/addons-server/issues/8645