### PR TITLE
Fix 'dynamic theme' tag migration. The column blacklisted got renamed to denied.

### DIFF
--- a/src/olympia/migrations/1032-make-dynamic-theme-a-restricted-tag.sql
+++ b/src/olympia/migrations/1032-make-dynamic-theme-a-restricted-tag.sql
@@ -1,2 +1,2 @@
-INSERT INTO tags (tag_text, blacklisted, restricted)
+INSERT INTO tags (tag_text, denied, restricted)
 VALUES ('dynamic theme', 0, 1) ON DUPLICATE KEY UPDATE restricted = 1;


### PR DESCRIPTION
The column got renamed as part of b5992d5c20e5d56bc53ad68e90a65fdeafe231b1

Fixes #8757