### PR TITLE
Fix compress_assets to link to the correct /static/ folder

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -103,6 +103,7 @@ def test_pre_setup(request, tmpdir, settings):
 
     settings.MEDIA_ROOT = str(tmpdir.mkdir('media'))
     settings.TMP_PATH = str(tmpdir.mkdir('tmp'))
+    settings.STATIC_ROOT = str(tmpdir.mkdir('site-static'))
     settings.NETAPP_STORAGE = settings.TMP_PATH
 
     # Reset the prefixer and urlconf after updating media root

--- a/src/olympia/amo/management/commands/compress_assets.py
+++ b/src/olympia/amo/management/commands/compress_assets.py
@@ -8,6 +8,7 @@ import subprocess
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
+from django.core.management import call_command
 
 from olympia.lib.jingo_minify_helpers import get_path
 
@@ -65,6 +66,12 @@ class Command(BaseCommand):
             f.write('BUNDLE_HASHES = %s\n' % self.bundle_hashes)
 
     def handle(self, **options):
+        # HACK: Let's collect static files first so that we can
+        # actually use images in there and add relative links
+        # to the concatted files that will live in STATIC_ROOT
+        # too.
+        call_command('collectstatic', interactive=False)
+
         # This will loop through every bundle, and do the following:
         # - Concat all files into one
         # - Cache bust all images in CSS files

--- a/src/olympia/amo/management/commands/compress_assets.py
+++ b/src/olympia/amo/management/commands/compress_assets.py
@@ -168,7 +168,7 @@ class Command(BaseCommand):
             css_content = css_in.read()
 
         def _parse(url):
-            self._cachebust_regex(url, css_file)
+            return self._cachebust_regex(url, css_file)
 
         css_parsed = re.sub('url\(([^)]*?)\)', _parse, css_content)
 

--- a/src/olympia/amo/management/commands/compress_assets.py
+++ b/src/olympia/amo/management/commands/compress_assets.py
@@ -65,8 +65,6 @@ class Command(BaseCommand):
             f.write('BUNDLE_HASHES = %s\n' % self.bundle_hashes)
 
     def handle(self, **options):
-        self.verbose = '-v' if options.get('verbosity', False) == '2' else ''
-
         # This will loop through every bundle, and do the following:
         # - Concat all files into one
         # - Cache bust all images in CSS files
@@ -74,11 +72,13 @@ class Command(BaseCommand):
         for ftype, bundle in settings.MINIFY_BUNDLES.iteritems():
             for name, files in bundle.iteritems():
                 # Set the paths to the files.
-                concatted_file = path(ftype, '%s-all.%s' % (name, ftype,))
-                compressed_file = path(ftype, '%s-min.%s' % (name, ftype,))
+                concatted_file = get_path(os.path.join(
+                    ftype, '%s-all.%s' % (name, ftype,)))
+                compressed_file = get_path(os.path.join(
+                    ftype, '%s-min.%s' % (name, ftype,)))
 
-                ensure_path_exists(os.path.dirname(path(concatted_file)))
-                ensure_path_exists(os.path.dirname(path(compressed_file)))
+                ensure_path_exists(os.path.dirname(concatted_file))
+                ensure_path_exists(os.path.dirname(compressed_file))
 
                 files_all = []
                 for fn in files:
@@ -110,17 +110,16 @@ class Command(BaseCommand):
                 self._clean_tmp(concatted_file)
                 if is_changed or not os.path.isfile(compressed_file):
                     self._minify(ftype, concatted_file, compressed_file)
-                elif self.verbose:
+                else:
                     print(
                         'File unchanged, skipping minification of %s' % (
                             concatted_file))
-                else:
                     self.minify_skipped += 1
 
         # Write out the hashes
         self.update_hashes()
 
-        if not self.verbose and self.minify_skipped:
+        if self.minify_skipped:
             print(
                 'Unchanged files skipped for minification: %s' % (
                     self.minify_skipped))
@@ -180,9 +179,8 @@ class Command(BaseCommand):
         file_hash = hashlib.md5(css_parsed).hexdigest()[0:7]
         self.checked_hash[css_file] = file_hash
 
-        if not self.verbose and self.missing_files:
-            print(' - Error finding %s images (-v2 for info)' % (
-                self.missing_files,))
+        if self.missing_files:
+            print(' - Error finding %s images' % (self.missing_files,))
             self.missing_files = 0
 
         return file_hash
@@ -191,9 +189,8 @@ class Command(BaseCommand):
         """Run the proper minifier on the file."""
         if ftype == 'js' and hasattr(settings, 'UGLIFY_BIN'):
             opts = {'method': 'UglifyJS', 'bin': settings.UGLIFY_BIN}
-            run_command('{uglify} {verbose} -o {target} {source} -m'.format(
+            run_command('{uglify} -v -o {target} {source} -m'.format(
                 uglify=opts['bin'],
-                verbose=self.verbose,
                 target=file_out,
                 source=file_in))
         elif ftype == 'css' and hasattr(settings, 'CLEANCSS_BIN'):
@@ -216,8 +213,7 @@ class Command(BaseCommand):
                 file_hash = hashlib.md5(f.read()).hexdigest()[0:7]
         except IOError:
             self.missing_files += 1
-            if self.verbose:
-                print(' - Could not find file %s' % url)
+            print(' - Could not find file %s' % url)
 
         self.checked_hash[url] = file_hash
         return file_hash

--- a/src/olympia/amo/tests/test_commands.py
+++ b/src/olympia/amo/tests/test_commands.py
@@ -97,7 +97,7 @@ def test_compress_assets_correctly_fetches_static_images(settings, tmpdir):
         assert expected in fobj.read()
 
     # Compressed doesn't have any whitespace between `background-image:` and
-    # the url
+    # the url and the path is slightly different
     with open(css_min, 'rb') as fobj:
         data = fobj.read()
         assert 'background-image:url(' in data

--- a/src/olympia/amo/tests/test_commands.py
+++ b/src/olympia/amo/tests/test_commands.py
@@ -47,6 +47,7 @@ def test_cron_jobs_setting():
         getattr(module, name)
 
 
+@pytest.mark.static_assets
 @override_settings(
     MINIFY_BUNDLES={'css': {'common_multi': [
         'css/zamboni/admin-django.css',
@@ -70,7 +71,15 @@ def test_compress_assets_command_without_git(subprocess_mock):
     assert contents_before != contents_after
 
 
-def test_compiled_css_correct_background_url(settings, tmpdir):
+@pytest.mark.static_assets
+def test_compress_assets_correctly_fetches_static_images(settings, tmpdir):
+    """
+    Make sure that `compress_assets` correctly fetches static assets
+    such as icons and writes them correctly into our compressed
+    and concatted files.
+
+    Refs https://github.com/mozilla/addons-server/issues/8760
+    """
     settings.MINIFY_BUNDLES = {
         'css': {'zamboni/css': ['css/legacy/main.css']}}
 

--- a/src/olympia/amo/tests/test_commands.py
+++ b/src/olympia/amo/tests/test_commands.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import os
-import shutil
 from importlib import import_module
 
 from django.conf import settings

--- a/tox.ini
+++ b/tox.ini
@@ -18,39 +18,39 @@ whitelist_externals =
 [testenv:es]
 commands =
     make -f Makefile-docker install_python_test_dependencies
-    pytest -m "es_tests and not needs_locales_compilation" --ignore=tests/ui/ -v {posargs}
+    pytest -m "es_tests and not needs_locales_compilation and not static_assets" --ignore=tests/ui/ -v src/olympia/{posargs}
 
 [testenv:addons]
 commands =
     make -f Makefile-docker install_python_test_dependencies
-    pytest -n 2 -m 'not es_tests and not needs_locales_compilation' -v src/olympia/addons/ {posargs}
+    pytest -n 2 -m 'not es_tests and not needs_locales_compilation and not static_assets' -v src/olympia/addons/ {posargs}
 
 [testenv:devhub]
 commands =
     make -f Makefile-docker install_python_test_dependencies install_node_dependencies
-    pytest -n 2 -m 'not es_tests and not needs_locales_compilation' -v src/olympia/devhub/ {posargs}
+    pytest -n 2 -m 'not es_tests and not needs_locales_compilation and not static_assets' -v src/olympia/devhub/ {posargs}
 
 [testenv:reviewers]
 commands =
     make -f Makefile-docker install_python_test_dependencies
-    pytest -n 2 -m 'not es_tests and not needs_locales_compilation' -v src/olympia/reviewers/ {posargs}
+    pytest -n 2 -m 'not es_tests and not needs_locales_compilation and not static_assets' -v src/olympia/reviewers/ {posargs}
 
 [testenv:amo-locales-and-signing]
 commands =
     make -f Makefile-docker install_python_test_dependencies install_node_dependencies
-    pytest -n 2 -m 'not es_tests and not needs_locales_compilation' -v src/olympia/amo/ src/olympia/lib/crypto/ src/olympia/signing {posargs}
+    pytest -n 2 -m 'not es_tests and not needs_locales_compilation and not static_assets' -v src/olympia/amo/ src/olympia/lib/crypto/ src/olympia/signing {posargs}
     bash {toxinidir}/locale/compile-mo.sh {toxinidir}/locale/
     pytest -n 2 -m 'needs_locales_compilation' -v src/olympia/ {posargs}
 
 [testenv:users-and-accounts]
 commands =
     make -f Makefile-docker install_python_test_dependencies
-    pytest -n 2 -m 'not es_tests and not needs_locales_compilation' -v src/olympia/users/ src/olympia/accounts/ {posargs}
+    pytest -n 2 -m 'not es_tests and not needs_locales_compilation and not static_assets' -v src/olympia/users/ src/olympia/accounts/ {posargs}
 
 [testenv:main]
 commands =
     make -f Makefile-docker install_python_test_dependencies install_node_dependencies
-    pytest -n 2 -m 'not es_tests and not needs_locales_compilation' -v src/olympia/ --ignore src/olympia/addons/ --ignore src/olympia/devhub/ --ignore src/olympia/reviewers/ --ignore src/olympia/amo/ --ignore src/olympia/users/ --ignore src/olympia/accounts/ --ignore src/olympia/lib/crypto --ignore src/olympia/signing {posargs}
+    pytest -n 2 -m 'not es_tests and not needs_locales_compilation and not static_assets' -v src/olympia/ --ignore src/olympia/addons/ --ignore src/olympia/devhub/ --ignore src/olympia/reviewers/ --ignore src/olympia/amo/ --ignore src/olympia/users/ --ignore src/olympia/accounts/ --ignore src/olympia/lib/crypto --ignore src/olympia/signing {posargs}
 
 [testenv:ui-tests]
 commands =
@@ -61,6 +61,7 @@ commands =
 [testenv:assets]
 commands =
     make -f Makefile-docker update_deps
+    pytest -m "static_assets" --ignore=tests/ui/ -v src/olympia/ {posargs}
     make -f Makefile-docker update_assets
 
 [testenv:codestyle]


### PR DESCRIPTION
This broke in #8532 

Fixes #8760

Originally we hardcoded to look for settings.STATIC_ROOT but that
doesn't suffice since it's set to /site-static/ by default.

We are now using `get_path` instead which uses django's staticfiles
framework to find the correct files instead and only then falls back to
settings.STATIC_ROOT.

This commit also removes verbosity as an argument and simply logs all
errors immediately.

To verify this works locally:

* Change settings.STATIC_ROOT to `'/site-static/`'
* Add `/site-static/` to the folders served by nginx (I'll open an issue
on our nginx container to serve this by default too)
* You may have to restart the nginx container after that for nginx to
pick things up
* Remove everything inside site-static folder
* Run `make update_assets`

Please see the second commit - https://github.com/mozilla/addons-server/commit/6c9fc434ffe5ae5eb777372038bccc712d605eeb for the potentially even more important fix.

This should be cherry-picked since it's broken on -dev and -stage.