### PR TITLE
Wrap task deleting add-ons not compatible with Firefoxes in a transaction

### DIFF
--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -653,9 +653,10 @@ def delete_addon_not_compatible_with_firefoxes(ids, **kw):
         ids[0], ids[-1], len(ids))
     qs = Addon.objects.filter(id__in=ids)
     for addon in qs:
-        addon.appsupport_set.filter(
-            app__in=(amo.THUNDERBIRD.id, amo.SEAMONKEY.id)).delete()
-        addon.delete()
+        with transaction.atomic():
+            addon.appsupport_set.filter(
+                app__in=(amo.THUNDERBIRD.id, amo.SEAMONKEY.id)).delete()
+            addon.delete()
 
 
 @task


### PR DESCRIPTION
Otherwise if an error happens during the add-on delete() call the appsupport ends up being deleted prematurely.

Additional fix for #8645