### PR TITLE
dicts should always be returned for TranslatedFields; add gate for old behavior

### DIFF
--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -118,8 +118,8 @@ Translated Fields
 ~~~~~~~~~~~~~~~~~
 
 Fields that can be translated by users (typically name, description) have a
-special behaviour. The default is to return them as an object, with languages
-as keys and translations as values:
+special behaviour. They are returned as an object, with languages as keys and
+translations as values, and by default all languages are returned:
 
 .. code-block:: json
 
@@ -134,18 +134,41 @@ as keys and translations as values:
 However, for performance, if you pass the ``lang`` parameter to a ``GET``
 request, then only the most relevant translation (the specified language or the
 fallback, depending on whether a translation is available in the requested
-language) will be returned as a string.
+language) will be returned.
 
 .. code-block:: json
 
     {
-        "name": "Games"
+        "name": {
+            "en-US": "Games"
+        }
     }
 
-This behaviour also applies to ``POST``, ``PATCH`` and ``PUT`` requests: you
-can either submit an object containing several translations, or just a string.
-If only a string is supplied, it will only be used to translate the field in
-the current language.
+For ``POST``, ``PATCH`` and ``PUT`` requests you submit an object containing
+translations for any languages needing to be updated/saved.  Any language not
+in the object is not updated, but is not removed.
+
+For example, if there were existing translations of::
+
+"name": {"en-US": "Games", "fr": "Jeux","kn": "ಆಟಗಳು"}
+
+and the following request was made:
+
+.. code-block:: json
+
+    {
+        "name": {
+            "en-US": "Fun"
+        }
+    }
+
+Then the resulting translations would be::
+
+"name": {"en-US": "Fun", "fr": "Jeux","kn": "ಆಟಗಳು"}
+
+To delete a translation, pass ``null`` as the value for that language.
+(Note: this behavior is currently buggy/broken)
+
 
 .. _api-overview-outgoing:
 
@@ -194,3 +217,6 @@ v4 API changelog
 * 2018-05-25: renamed ``rating.rating`` property to ``rating.score``  https://github.com/mozilla/addons-server/pull/8332
 * 2018-06-05: dropped ``rating.title`` property https://github.com/mozilla/addons-server/issues/8144
 * 2018-07-12: added ``type`` property to autocomplete API. This change was also backported to the `v3` API. https://github.com/mozilla/addons-server/issues/8803
+* 2018-07-19: localised field values are always returned as objects, even if only a single language is requested.
+  Setting a localised value with a string is removed too - it must always be an object of one or more translations.
+  https://github.com/mozilla/addons-server/issues/8794

--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -167,7 +167,8 @@ Then the resulting translations would be::
 "name": {"en-US": "Fun", "fr": "Jeux","kn": "ಆಟಗಳು"}
 
 To delete a translation, pass ``null`` as the value for that language.
-(Note: this behavior is currently buggy/broken)
+(Note: this behavior is currently buggy/broken - see
+https://github.com/mozilla/addons-server/issues/8816 for more details)
 
 
 .. _api-overview-outgoing:

--- a/docs/topics/development/logging.rst
+++ b/docs/topics/development/logging.rst
@@ -17,15 +17,17 @@ Configuration
 -------------
 
 The root logger is set up from ``settings_base`` in the ``src/olympia/lib``
-of addons-server. It sets up sensible defaults, but you can tweak them to your liking::
+of addons-server. It sets up sensible defaults, but you can tweak them to your liking:
 
-``Log level``
-    There is no unified log level, instead every logger has it's own log level
-    because it depends on the context they're used in.
+Log level
+~~~~~~~~~
+There is no unified log level, instead every logger has it's own log level
+because it depends on the context they're used in.
 
-``LOGGING``
-    See PEP 391 for formatting help. Messages will not propagate through a
-    logger unless ``propagate: True`` is set.
+LOGGING
+~~~~~~~
+See PEP 391 for formatting help. Messages will not propagate through a
+logger unless ``propagate: True`` is set.
 
     ::
 
@@ -35,7 +37,7 @@ of addons-server. It sets up sensible defaults, but you can tweak them to your l
             },
         }
 
-    If you want to add more to this do something like this::
+If you want to add more to this do something like this::
 
         LOGGING['loggers'].update({
             'z.paypal': {

--- a/src/olympia/api/fields.py
+++ b/src/olympia/api/fields.py
@@ -79,7 +79,7 @@ class TranslationSerializerField(fields.Field):
         'min_length': _(u'The field must have a length of at least {num} '
                         u'characters.'),
         'unknown_locale': _(u'The language code {lang_code} is invalid.'),
-        'no_dict': _(u'You must provide a dictionary of {lang-code:value}.')
+        'no_dict': _(u'You must provide an object of {lang-code:value}.')
     }
 
     def __init__(self, *args, **kwargs):

--- a/src/olympia/api/fields.py
+++ b/src/olympia/api/fields.py
@@ -6,6 +6,7 @@ from django.utils.translation import get_language, ugettext_lazy as _
 from rest_framework import fields, serializers
 
 from olympia.amo.utils import to_language
+from olympia.api.utils import is_gate_active
 from olympia.translations.models import Translation
 
 
@@ -48,6 +49,18 @@ class TranslationSerializerField(fields.Field):
     """
     Django-rest-framework custom serializer field for our TranslatedFields.
 
+    In normal operation:
+    - When deserializing, in `to_internal_value`, it accepts a dictionary only.
+
+    - When serializing, a dict with all translations for the given
+      `field_name` on `obj`, with languages as the keys.
+
+      However, if the parent's serializer context contains a request that has
+      a method 'GET', and a 'lang' parameter was passed, then only a returns
+      one translation in that dict.  If the request lang is available that is
+      returned, otherwise the  default locale is returned.
+
+    If the gate 'l10n_flat_input_output' is active then:
     - When deserializing, in `to_internal_value`, it accepts both a string
       or a dictionary. If a string is given, it'll be considered to be in the
       default language.
@@ -65,12 +78,18 @@ class TranslationSerializerField(fields.Field):
     default_error_messages = {
         'min_length': _(u'The field must have a length of at least {num} '
                         u'characters.'),
-        'unknown_locale': _(u'The language code {lang_code} is invalid.')
+        'unknown_locale': _(u'The language code {lang_code} is invalid.'),
+        'no_dict': _(u'You must provide a dictionary of {lang-code:value}.')
     }
 
     def __init__(self, *args, **kwargs):
         self.min_length = kwargs.pop('min_length', None)
         super(TranslationSerializerField, self).__init__(*args, **kwargs)
+
+    @property
+    def flat(self):
+        request = self.context.get('request', None)
+        return is_gate_active(request, 'l10n_flat_input_output')
 
     def fetch_all_translations(self, obj, source, field):
         translations = field.__class__.objects.filter(
@@ -79,7 +98,7 @@ class TranslationSerializerField(fields.Field):
                 for trans in translations} if translations else None
 
     def fetch_single_translation(self, obj, source, field, requested_language):
-        return unicode(field) if field else None
+        return {to_language(field.locale): unicode(field)} if field else None
 
     def get_attribute(self, obj):
         source = self.source or self.field_name
@@ -95,8 +114,9 @@ class TranslationSerializerField(fields.Field):
             requested_language = request.GET['lang']
 
         if requested_language:
-            return self.fetch_single_translation(obj, source, field,
-                                                 requested_language)
+            single = self.fetch_single_translation(obj, source, field,
+                                                   requested_language)
+            return single.values()[0] if single and self.flat else single
         else:
             return self.fetch_all_translations(obj, source, field)
 
@@ -115,6 +135,10 @@ class TranslationSerializerField(fields.Field):
         return unicode(data)
 
     def validate(self, value):
+        if not self.flat and not isinstance(value, dict):
+            raise ValidationError(
+                self.error_messages['no_dict']
+            )
         value_too_short = True
 
         if isinstance(value, basestring):
@@ -181,20 +205,28 @@ class ESTranslationSerializerField(TranslationSerializerField):
         # automatically made by the translations app.
         translation = self.fetch_single_translation(
             obj, target_name, target_translations, get_language())
-        value = (
-            Translation(localized_string=translation)
-            if translation is not None else translation)
-        setattr(obj, target_name, value)
+        if translation:
+            locale, value = translation.items()[0]
+            translation = Translation(localized_string=value, locale=locale)
+        setattr(obj, target_name, translation)
 
     def fetch_all_translations(self, obj, source, field):
         return field or None
 
     def fetch_single_translation(self, obj, source, field, requested_language):
         translations = self.fetch_all_translations(obj, source, field) or {}
-        return (translations.get(requested_language) or
-                translations.get(getattr(obj, 'default_locale', None)) or
-                translations.get(getattr(obj, 'default_language', None)) or
-                translations.get(settings.LANGUAGE_CODE) or None)
+        locale = None
+        value = None
+        if requested_language in translations:
+            locale = requested_language
+            value = translations.get(requested_language)
+        else:
+            default_locale = getattr(
+                obj, 'default_locale', settings.LANGUAGE_CODE)
+            if default_locale in translations:
+                locale = default_locale
+                value = translations.get(default_locale)
+        return {locale: value} if locale and value else None
 
 
 class SplitField(fields.Field):

--- a/src/olympia/api/tests/test_fields.py
+++ b/src/olympia/api/tests/test_fields.py
@@ -125,7 +125,7 @@ class TestTranslationSerializerField(TestCase):
         with self.assertRaises(ValidationError) as exc:
             field.to_internal_value(data['fr'])
         assert exc.exception.message == (
-            u'You must provide a dictionary of {lang-code:value}.')
+            u'You must provide an object of {lang-code:value}.')
 
     def test_to_internal_value_strip(self):
         data = {

--- a/src/olympia/bandwagon/tests/test_views.py
+++ b/src/olympia/bandwagon/tests/test_views.py
@@ -12,6 +12,8 @@ import pytest
 
 from mock import Mock, patch
 from pyquery import PyQuery as pq
+from rest_framework.fields import empty
+from rest_framework.settings import api_settings
 
 from olympia import amo, core
 from olympia.activity.models import ActivityLog
@@ -1312,14 +1314,32 @@ class TestCollectionViewSetDetail(TestCase):
         assert response.data['id'] == self.collection.id
         addon_data = response.data['addons'][0]['addon']
         assert addon_data['id'] == addon.id
-        assert isinstance(addon_data['name'], basestring)
-        assert addon_data['name'] == unicode(addon.name)
-        assert isinstance(addon_data['homepage'], basestring)
-        assert addon_data['homepage'] == get_outgoing_url(
-            unicode(addon.homepage))
-        assert isinstance(addon_data['support_url'], basestring)
-        assert addon_data['support_url'] == get_outgoing_url(
-            unicode(addon.support_url))
+        assert isinstance(addon_data['name']['en-US'], basestring)
+        assert addon_data['name'] == {'en-US': unicode(addon.name)}
+        assert isinstance(addon_data['homepage']['en-US'], basestring)
+        assert addon_data['homepage'] == {
+            'en-US': get_outgoing_url(unicode(addon.homepage))}
+        assert isinstance(addon_data['support_url']['en-US'], basestring)
+        assert addon_data['support_url'] == {
+            'en-US': get_outgoing_url(unicode(addon.support_url))}
+
+        overridden_api_gates = {
+            api_settings.DEFAULT_VERSION: ('l10n_flat_input_output',)}
+        with override_settings(DRF_API_GATES=overridden_api_gates):
+            response = self.client.get(
+                self.url + '?with_addons&lang=en-US&wrap_outgoing_links')
+            assert response.status_code == 200
+            assert response.data['id'] == self.collection.id
+            addon_data = response.data['addons'][0]['addon']
+            assert addon_data['id'] == addon.id
+            assert isinstance(addon_data['name'], basestring)
+            assert addon_data['name'] == unicode(addon.name)
+            assert isinstance(addon_data['homepage'], basestring)
+            assert addon_data['homepage'] == get_outgoing_url(
+                unicode(addon.homepage))
+            assert isinstance(addon_data['support_url'], basestring)
+            assert addon_data['support_url'] == get_outgoing_url(
+                unicode(addon.support_url))
 
 
 class CollectionViewSetDataMixin(object):
@@ -1367,6 +1387,25 @@ class CollectionViewSetDataMixin(object):
     def test_update_name_invalid(self):
         self.client.login_api(self.user)
         data = dict(self.data)
+        # Sending a single value for localized field is now forbidden.
+        data.update(name=u'   ')
+        response = self.send(data=data)
+        assert response.status_code == 400
+        assert json.loads(response.content) == {
+            'name': ['You must provide a dictionary of {lang-code:value}.']}
+
+        # Passing a dict of localised values
+        data.update(name={'en-US': u'   '})
+        response = self.send(data=data)
+        assert response.status_code == 400
+        assert json.loads(response.content) == {
+            'name': ['Name cannot be empty.']}
+
+    @override_settings(DRF_API_GATES={
+        api_settings.DEFAULT_VERSION: ('l10n_flat_input_output',)})
+    def test_update_name_invalid_flat_input(self):
+        self.client.login_api(self.user)
+        data = dict(self.data)
         data.update(name=u'   ')
         response = self.send(data=data)
         assert response.status_code == 400
@@ -1381,6 +1420,25 @@ class CollectionViewSetDataMixin(object):
             'name': ['Name cannot be empty.']}
 
     def test_biography_no_links(self):
+        self.client.login_api(self.user)
+        data = dict(self.data)
+        data.update(description='<a href="https://google.com">google</a>')
+        response = self.send(data=data)
+        assert response.status_code == 400
+        assert json.loads(response.content) == {
+            'description': [
+                'You must provide a dictionary of {lang-code:value}.']}
+
+        data.update(description={
+            'en-US': '<a href="https://google.com">google</a>'})
+        response = self.send(data=data)
+        assert response.status_code == 400
+        assert json.loads(response.content) == {
+            'description': ['No links are allowed.']}
+
+    @override_settings(DRF_API_GATES={
+        api_settings.DEFAULT_VERSION: ('l10n_flat_input_output',)})
+    def test_biography_no_links_flat_input(self):
         self.client.login_api(self.user)
         data = dict(self.data)
         data.update(description='<a href="https://google.com">google</a>')
@@ -1437,6 +1495,30 @@ class TestCollectionViewSetCreate(CollectionViewSetDataMixin, TestCase):
     def test_create_minimal(self):
         self.client.login_api(self.user)
         data = {
+            'name': {'en-US': u'this'},
+            'slug': u'minimal',
+        }
+        response = self.send(data=data)
+        assert response.status_code == 201, response.content
+        collection = Collection.objects.get()
+        assert collection.name == data['name']['en-US']
+        assert collection.slug == data['slug']
+
+        # Double-check trying to create with a non-dict name now fails
+        data = {
+            'name': u'this',
+            'slug': u'minimal',
+        }
+        response = self.send(data=data)
+        assert response.status_code == 400
+        assert json.loads(response.content) == {
+            'name': ['You must provide a dictionary of {lang-code:value}.']}
+
+    @override_settings(DRF_API_GATES={
+        api_settings.DEFAULT_VERSION: ('l10n_flat_input_output',)})
+    def test_create_minimal_flat_input(self):
+        self.client.login_api(self.user)
+        data = {
             'name': u'this',
             'slug': u'minimal',
         }
@@ -1449,7 +1531,7 @@ class TestCollectionViewSetCreate(CollectionViewSetDataMixin, TestCase):
     def test_create_cant_set_readonly(self):
         self.client.login_api(self.user)
         data = {
-            'name': u'this',
+            'name': {'en-US': u'this'},
             'slug': u'minimal',
             'addon_count': 99,  # In the serializer but read-only.
             'subscribers': 999,  # Not in the serializer.
@@ -1486,13 +1568,13 @@ class TestCollectionViewSetCreate(CollectionViewSetDataMixin, TestCase):
     def test_create_numeric_slug(self):
         self.client.login_api(self.user)
         data = {
-            'name': u'this',
+            'name': {'en-US': u'this'},
             'slug': u'1',
         }
         response = self.send(data=data)
         assert response.status_code == 201, response.content
         collection = Collection.objects.get()
-        assert collection.name == data['name']
+        assert collection.name == data['name']['en-US']
         assert collection.slug == data['slug']
 
 
@@ -1933,6 +2015,28 @@ class TestCollectionAddonViewSetCreate(CollectionAddonViewSetMixin, TestCase):
         self.client.login_api(self.user)
         response = self.send(self.url,
                              data={'addon': self.addon.pk,
+                                   'notes': {'en-US': 'its good!'}})
+        self.check_response(response)
+        collection_addon = CollectionAddon.objects.get(
+            collection=self.collection.id, addon=self.addon.id)
+        assert collection_addon.addon == self.addon
+        assert collection_addon.collection == self.collection
+        assert collection_addon.comments == 'its good!'
+
+        # Double-check trying to create with a non-dict name now fails
+        response = self.send(self.url,
+                             data={'addon': self.addon.pk,
+                                   'notes': 'its good!'})
+        assert response.status_code == 400
+        assert json.loads(response.content) == {
+            'notes': ['You must provide a dictionary of {lang-code:value}.']}
+
+    @override_settings(DRF_API_GATES={
+        api_settings.DEFAULT_VERSION: ('l10n_flat_input_output',)})
+    def test_add_with_comments_flat_input(self):
+        self.client.login_api(self.user)
+        response = self.send(self.url,
+                             data={'addon': self.addon.pk,
                                    'notes': 'its good!'})
         self.check_response(response)
         collection_addon = CollectionAddon.objects.get(
@@ -1943,7 +2047,7 @@ class TestCollectionAddonViewSetCreate(CollectionAddonViewSetMixin, TestCase):
 
     def test_fail_when_no_addon(self):
         self.client.login_api(self.user)
-        response = self.send(self.url, data={'notes': ''})
+        response = self.send(self.url, data={'notes': {'en-US': ''}})
         assert response.status_code == 400
         assert json.loads(response.content) == {
             'addon': [u'This field is required.']}
@@ -1997,17 +2101,17 @@ class TestCollectionAddonViewSetPatch(CollectionAddonViewSetMixin, TestCase):
                 'addon': self.addon.id})
         super(TestCollectionAddonViewSetPatch, self).setUp()
 
-    def check_response(self, response, data=None):
-        data = data or {'notes': 'it does things'}
+    def check_response(self, response, notes=empty):
+        notes = notes if notes != empty else u'it does things'
         assert response.status_code == 200, response.content
         collection_addon = CollectionAddon.objects.get(
             collection=self.collection.id)
         assert collection_addon.addon == self.addon
         assert collection_addon.collection == self.collection
-        assert collection_addon.comments == data['notes']
+        assert collection_addon.comments == notes
 
     def send(self, url, data=None):
-        data = data or {'notes': 'it does things'}
+        data = data or {'notes': {'en-US': 'it does things'}}
         return self.client.patch(url, data=data)
 
     def test_basic(self):
@@ -2015,12 +2119,27 @@ class TestCollectionAddonViewSetPatch(CollectionAddonViewSetMixin, TestCase):
         response = self.send(self.url)
         self.check_response(response)
 
+    def test_flat_input(self):
+        self.client.login_api(self.user)
+        data = {'notes': 'it does things'}
+        # By default this should be rejected
+        response = self.send(self.url, data)
+        assert response.status_code == 400
+        assert json.loads(response.content) == {
+            'notes': ['You must provide a dictionary of {lang-code:value}.']}
+        # But with the correct api gate, we can use the old behavior
+        overridden_api_gates = {
+            api_settings.DEFAULT_VERSION: ('l10n_flat_input_output',)}
+        with override_settings(DRF_API_GATES=overridden_api_gates):
+            response = self.send(self.url, data)
+            self.check_response(response)
+
     def test_cant_change_addon(self):
         self.client.login_api(self.user)
         new_addon = addon_factory()
         response = self.send(self.url,
                              data={'addon': new_addon.id})
-        self.check_response(response, data={'notes': None})
+        self.check_response(response, notes=None)
 
     def test_deleted(self):
         self.addon.delete()

--- a/src/olympia/bandwagon/tests/test_views.py
+++ b/src/olympia/bandwagon/tests/test_views.py
@@ -1392,7 +1392,7 @@ class CollectionViewSetDataMixin(object):
         response = self.send(data=data)
         assert response.status_code == 400
         assert json.loads(response.content) == {
-            'name': ['You must provide a dictionary of {lang-code:value}.']}
+            'name': ['You must provide an object of {lang-code:value}.']}
 
         # Passing a dict of localised values
         data.update(name={'en-US': u'   '})
@@ -1427,7 +1427,7 @@ class CollectionViewSetDataMixin(object):
         assert response.status_code == 400
         assert json.loads(response.content) == {
             'description': [
-                'You must provide a dictionary of {lang-code:value}.']}
+                'You must provide an object of {lang-code:value}.']}
 
         data.update(description={
             'en-US': '<a href="https://google.com">google</a>'})
@@ -1512,7 +1512,7 @@ class TestCollectionViewSetCreate(CollectionViewSetDataMixin, TestCase):
         response = self.send(data=data)
         assert response.status_code == 400
         assert json.loads(response.content) == {
-            'name': ['You must provide a dictionary of {lang-code:value}.']}
+            'name': ['You must provide an object of {lang-code:value}.']}
 
     @override_settings(DRF_API_GATES={
         api_settings.DEFAULT_VERSION: ('l10n_flat_input_output',)})
@@ -2029,7 +2029,7 @@ class TestCollectionAddonViewSetCreate(CollectionAddonViewSetMixin, TestCase):
                                    'notes': 'its good!'})
         assert response.status_code == 400
         assert json.loads(response.content) == {
-            'notes': ['You must provide a dictionary of {lang-code:value}.']}
+            'notes': ['You must provide an object of {lang-code:value}.']}
 
     @override_settings(DRF_API_GATES={
         api_settings.DEFAULT_VERSION: ('l10n_flat_input_output',)})
@@ -2126,7 +2126,7 @@ class TestCollectionAddonViewSetPatch(CollectionAddonViewSetMixin, TestCase):
         response = self.send(self.url, data)
         assert response.status_code == 400
         assert json.loads(response.content) == {
-            'notes': ['You must provide a dictionary of {lang-code:value}.']}
+            'notes': ['You must provide an object of {lang-code:value}.']}
         # But with the correct api gate, we can use the old behavior
         overridden_api_gates = {
             api_settings.DEFAULT_VERSION: ('l10n_flat_input_output',)}

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1769,9 +1769,10 @@ DRF_API_GATES = {
     'v3': (
         'ratings-rating-shim',
         'ratings-title-shim',
+        'l10n_flat_input_output',
     ),
     'v4': (
-    )
+    ),
 }
 
 REST_FRAMEWORK = {


### PR DESCRIPTION
fixes #8794 (but alas deletes are still as broken)

(Most of the change is tests and docs really)