### PR TITLE
don't show name in theme wizard for version uploads; add tooltip to name in details step

### DIFF
--- a/src/olympia/devhub/templates/devhub/addons/submit/describe.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/describe.html
@@ -10,7 +10,7 @@
     {% csrf_token %}
     <div class="addon-submission-field">
       <label for="id_name">{{ _("Name:") }}</label>
-      <span class="tip tooltip" title="{{ _('Name on listing on this site.  May be different to the name inside the add-on, which is shown inside Firefox') }}" data-oldtitle="">?</span>
+      <span class="tip tooltip" title="{{ _('Name on listing on this site. May be different to the name inside the add-on, which is shown inside Firefox') }}" data-oldtitle="">?</span>
       {{ form.name }}
       {{ form.name.errors }}
     </div>

--- a/src/olympia/devhub/templates/devhub/addons/submit/describe.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/describe.html
@@ -10,6 +10,7 @@
     {% csrf_token %}
     <div class="addon-submission-field">
       <label for="id_name">{{ _("Name:") }}</label>
+      <span class="tip tooltip" title="{{ _('Name on listing on this site.  May be different to the name inside the add-on, which is shown inside Firefox') }}" data-oldtitle="">?</span>
       {{ form.name }}
       {{ form.name.errors }}
     </div>

--- a/src/olympia/devhub/templates/devhub/addons/submit/wizard.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/wizard.html
@@ -15,7 +15,7 @@
           <input type="hidden" id="theme-name" value="{{ addon.name }}"/>
           {{ addon.name }}
           <ul class="note">
-            <li>{% trans edit_url_open=('<a href="' + url('devhub.addons.edit', addon.slug) + '">')|safe,
+            <li>{% trans edit_url_open='<a href="{}">'|format_html(url('devhub.addons.edit', addon.slug)),
                          edit_url_close='</a>'|safe %}
               To change the theme name, first go to {{ edit_url_open }}edit listing{{ edit_url_close }}.
             {% endtrans %}</li>

--- a/src/olympia/devhub/templates/devhub/addons/submit/wizard.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/wizard.html
@@ -14,12 +14,6 @@
         {% if addon %}
           <input type="hidden" id="theme-name" value="{{ addon.name }}"/>
           {{ addon.name }}
-          <ul class="note">
-            <li>{% trans edit_url_open='<a href="{}">'|format_html(url('devhub.addons.edit', addon.slug)),
-                         edit_url_close='</a>'|safe %}
-              To change the theme name, first go to {{ edit_url_open }}edit listing{{ edit_url_close }}.
-            {% endtrans %}</li>
-          </ul>
       </ul>
         {% else %}
           <input type="text" id="theme-name"/>

--- a/src/olympia/devhub/templates/devhub/addons/submit/wizard.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/wizard.html
@@ -11,7 +11,19 @@
   <div id="theme-wizard" data-version="{{ version_number }}">
     <div>
         <h3>{{ _('Theme name') }}<span class="req" title="{{ _('required') }}">*</span></h3>
-        <input type="text" id="theme-name"/>
+        {% if addon %}
+          <input type="hidden" id="theme-name" value="{{ addon.name }}"/>
+          {{ addon.name }}
+          <ul class="note">
+            <li>{% trans edit_url_open=('<a href="' + url('devhub.addons.edit', addon.slug) + '">')|safe,
+                         edit_url_close='</a>'|safe %}
+              To change the theme name, first go to {{ edit_url_open }}edit listing{{ edit_url_close }}.
+            {% endtrans %}</li>
+          </ul>
+      </ul>
+        {% else %}
+          <input type="text" id="theme-name"/>
+        {% endif %}
     </div>
     <div id="theme-header" class="row">
       <label class="row" for="header-img">

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -475,7 +475,7 @@ class TestAddonSubmitUpload(UploadTest, TestCase):
         doc = pq(response.content)
         assert doc('#theme-wizard')
         assert doc('#theme-wizard').attr('data-version') == '1.0'
-        assert doc('#theme-name').attr('type') == 'text'
+        assert doc('input#theme-name').attr('type') == 'text'
 
         # And then check the upload works.  In reality the zip is generated
         # client side in JS but the zip file is the same.
@@ -508,7 +508,7 @@ class TestAddonSubmitUpload(UploadTest, TestCase):
         doc = pq(response.content)
         assert doc('#theme-wizard')
         assert doc('#theme-wizard').attr('data-version') == '1.0'
-        assert doc('#theme-name').attr('type') == 'text'
+        assert doc('input#theme-name').attr('type') == 'text'
 
         # And then check the upload works.  In reality the zip is generated
         # client side in JS but the zip file is the same.
@@ -1428,8 +1428,9 @@ class VersionSubmitUploadMixin(object):
         doc = pq(response.content)
         assert doc('#theme-wizard')
         assert doc('#theme-wizard').attr('data-version') == '3.0'
-        assert doc('#theme-name').attr('type') == 'hidden'
-        assert doc('#theme-name').attr('value') == unicode(self.addon.name)
+        assert doc('input#theme-name').attr('type') == 'hidden'
+        assert doc('input#theme-name').attr('value') == (
+            unicode(self.addon.name))
 
         # And then check the upload works.
         path = os.path.join(

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -475,6 +475,7 @@ class TestAddonSubmitUpload(UploadTest, TestCase):
         doc = pq(response.content)
         assert doc('#theme-wizard')
         assert doc('#theme-wizard').attr('data-version') == '1.0'
+        assert doc('#theme-name').attr('type') == 'text'
 
         # And then check the upload works.  In reality the zip is generated
         # client side in JS but the zip file is the same.
@@ -507,6 +508,7 @@ class TestAddonSubmitUpload(UploadTest, TestCase):
         doc = pq(response.content)
         assert doc('#theme-wizard')
         assert doc('#theme-wizard').attr('data-version') == '1.0'
+        assert doc('#theme-name').attr('type') == 'text'
 
         # And then check the upload works.  In reality the zip is generated
         # client side in JS but the zip file is the same.
@@ -1426,6 +1428,8 @@ class VersionSubmitUploadMixin(object):
         doc = pq(response.content)
         assert doc('#theme-wizard')
         assert doc('#theme-wizard').attr('data-version') == '3.0'
+        assert doc('#theme-name').attr('type') == 'hidden'
+        assert doc('#theme-name').attr('value') == unicode(self.addon.name)
 
         # And then check the upload works.
         path = os.path.join(


### PR DESCRIPTION
fixes #8520 - in a way.  We need to show the name in the details step for new uploads because the one in the xpi may not be valid for AMO (too long, trademark issue, etc).  On the wizard for a new version the name is now hidden, and set to the Addon name.

wizard for new versions:
![screenshot 2018-07-09 14 03 13](https://user-images.githubusercontent.com/768592/42454020-5475252c-8386-11e8-9e48-f0725e853d92.png)

details step for new addons:
![screenshot 2018-07-09 14 09 44](https://user-images.githubusercontent.com/768592/42454034-614c2642-8386-11e8-8974-4730e265857e.png)
