### PR TITLE
Add `type` to autocomplete API results

### DIFF
--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -116,7 +116,7 @@ for autocomplete though, there are a couple key differences:
     :query string tag: Filter by exact tag name. Multiple tag names can be specified, separated by comma(s).
     :query string type: Filter by :ref:`add-on type <addon-detail-type>`.
     :query string sort: The sort parameter. The available parameters are documented in the :ref:`table below <addon-search-sort>`.
-    :>json array results: An array of :ref:`add-ons <addon-detail-object>`. Only the ``id``, ``icon_url``, ``name`` and ``url`` fields are supported though.
+    :>json array results: An array of :ref:`add-ons <addon-detail-object>`. Only the ``id``, ``icon_url``, ``name``, ``type`` and ``url`` fields are supported though.
 
 
 ------

--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -191,5 +191,6 @@ v4 API changelog
 ----------------
 
 * 2018-05-18: renamed /reviews/ endpoint to /ratings/  https://github.com/mozilla/addons-server/issues/6849
-* 2018-05-25: renamed rating.rating property to rating.score  https://github.com/mozilla/addons-server/pull/8332
-* 2018-06-05: dropped rating.title property https://github.com/mozilla/addons-server/issues/8144
+* 2018-05-25: renamed ``rating.rating`` property to ``rating.score``  https://github.com/mozilla/addons-server/pull/8332
+* 2018-06-05: dropped ``rating.title`` property https://github.com/mozilla/addons-server/issues/8144
+* 2018-07-12: added ``type`` property to autocomplete API. This change was also backported to the `v3` API. https://github.com/mozilla/addons-server/issues/8803

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -625,7 +625,7 @@ class ESAddonSerializerWithUnlistedData(
 
 class ESAddonAutoCompleteSerializer(ESAddonSerializer):
     class Meta(ESAddonSerializer.Meta):
-        fields = ('id', 'icon_url', 'name', 'url')
+        fields = ('id', 'icon_url', 'name', 'type', 'url')
         model = Addon
 
     def get_url(self, obj):

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -285,7 +285,7 @@ class AddonSerializerOutputTestMixin(object):
             'en-US': unicode(self.addon.support_url),
         }
         assert 'theme_data' not in result
-        assert set(result['tags']) == set(['some_tag', 'some_other_tag'])
+        assert set(result['tags']) == {'some_tag', 'some_other_tag'}
         assert result['type'] == 'extension'
         assert result['url'] == absolutify(self.addon.get_url_path())
         assert result['weekly_downloads'] == self.addon.weekly_downloads
@@ -988,8 +988,10 @@ class TestLanguageToolsSerializerOutput(TestCase):
         result = self.serialize()
         assert 'current_compatible_version' in result
         assert result['current_compatible_version'] is not None
-        assert set(result['current_compatible_version'].keys()) == set(
-            ['id', 'files', 'reviewed', 'version'])
+        assert (
+            set(result['current_compatible_version'].keys()) ==
+            {'id', 'files', 'reviewed', 'version'}
+        )
 
         self.addon.compatible_versions = None
         result = self.serialize()
@@ -1034,8 +1036,10 @@ class TestESAddonAutoCompleteSerializer(ESTestCase):
         self.addon = addon_factory()
 
         result = self.serialize()
-        assert set(result.keys()) == set(
-            ['id', 'name', 'icon_url', 'type', 'url'])
+        assert (
+            set(result.keys()) ==
+            {'id', 'name', 'icon_url', 'type', 'url'}
+        )
         assert result['id'] == self.addon.pk
         assert result['name'] == {'en-US': unicode(self.addon.name)}
         assert result['icon_url'] == absolutify(self.addon.get_icon_url(64))
@@ -1076,8 +1080,10 @@ class TestESAddonAutoCompleteSerializer(ESTestCase):
         assert not persona.is_new()
 
         result = self.serialize()
-        assert set(result.keys()) == set(
-            ['id', 'name', 'icon_url', 'type', 'url'])
+        assert (
+            set(result.keys()) ==
+            {'id', 'name', 'icon_url', 'type', 'url'}
+        )
         assert result['type'] == 'persona'
         assert result['icon_url'] == absolutify(self.addon.get_icon_url(64))
 
@@ -1098,8 +1104,10 @@ class TestESAddonAutoCompleteSerializer(ESTestCase):
         assert persona.is_new()
 
         result = self.serialize()
-        assert set(result.keys()) == set(
-            ['id', 'name', 'icon_url', 'type', 'url'])
+        assert (
+            set(result.keys()) ==
+            {'id', 'name', 'icon_url', 'type', 'url'}
+        )
         assert result['type'] == 'persona'
         assert result['icon_url'] == absolutify(self.addon.get_icon_url(64))
 

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -1034,10 +1034,12 @@ class TestESAddonAutoCompleteSerializer(ESTestCase):
         self.addon = addon_factory()
 
         result = self.serialize()
-        assert set(result.keys()) == set(['id', 'name', 'icon_url', u'url'])
+        assert set(result.keys()) == set(
+            ['id', 'name', 'icon_url', 'type', 'url'])
         assert result['id'] == self.addon.pk
         assert result['name'] == {'en-US': unicode(self.addon.name)}
         assert result['icon_url'] == absolutify(self.addon.get_icon_url(64))
+        assert result['type'] == 'extension'
         assert result['url'] == absolutify(self.addon.get_url_path())
 
     def test_translations(self):
@@ -1074,7 +1076,9 @@ class TestESAddonAutoCompleteSerializer(ESTestCase):
         assert not persona.is_new()
 
         result = self.serialize()
-        assert set(result.keys()) == set(['id', 'name', 'icon_url', u'url'])
+        assert set(result.keys()) == set(
+            ['id', 'name', 'icon_url', 'type', 'url'])
+        assert result['type'] == 'persona'
         assert result['icon_url'] == absolutify(self.addon.get_icon_url(64))
 
     def test_icon_url_persona_with_no_persona_id(self):
@@ -1094,7 +1098,9 @@ class TestESAddonAutoCompleteSerializer(ESTestCase):
         assert persona.is_new()
 
         result = self.serialize()
-        assert set(result.keys()) == set(['id', 'name', 'icon_url', u'url'])
+        assert set(result.keys()) == set(
+            ['id', 'name', 'icon_url', 'type', 'url'])
+        assert result['type'] == 'persona'
         assert result['icon_url'] == absolutify(self.addon.get_icon_url(64))
 
 


### PR DESCRIPTION
This is also applied to the v3 API - we are considering such a trivial field addition backwards-compatible and as such safe enough to include in v3 API (which addons-frontend is still using).

Fix #8803