### PR TITLE
Optimize /api/v4/compat-override, implement caching

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -13,6 +13,7 @@ from datetime import datetime
 from operator import attrgetter
 
 from django.conf import settings
+from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import IntegrityError, models, transaction
 from django.db.models import F, Max, Q, signals as dbsignals
@@ -2062,6 +2063,10 @@ class CompatOverride(ModelBase):
         for compat_id, ranges in sorted_groupby(qs, 'compat_id'):
             id_map[compat_id].compat_ranges = list(ranges)
 
+    @staticmethod
+    def get_api_cache_key(guid):
+        return 'api::addons::CompatOverride::{guid}'.format(guid=guid)
+
     # May be filled in by a transformer for performance.
     @cached_property
     def compat_ranges(self):
@@ -2087,6 +2092,11 @@ class CompatOverride(ModelBase):
                 item.apps.append(app)
             rv.append(item)
         return rv
+
+
+@receiver(dbsignals.post_save, sender=CompatOverride)
+def clear_compat_override_cache(sender, instance, **kw):
+    cache.delete(CompatOverride.get_api_cache_key(instance.guid))
 
 
 OVERRIDE_TYPES = (
@@ -2118,6 +2128,11 @@ class CompatOverrideRange(ModelBase):
     def override_type(self):
         """This is what Firefox wants to see in the XML output."""
         return {0: 'compatible', 1: 'incompatible'}[self.type]
+
+
+@receiver(dbsignals.post_save, sender=CompatOverrideRange)
+def clear_compat_override_cache_via_compat_range(sender, instance, **kw):
+    cache.delete(CompatOverride.get_api_cache_key(instance.compat.guid))
 
 
 class IncompatibleVersions(ModelBase):

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -3757,6 +3757,19 @@ class TestCompatOverrideView(TestCase):
         assert response.status_code == 400
         assert 'Empty, or no, guid parameter provided.' in response.content
 
+    def test_performance_no_matching_guid(self):
+        """This view is used by Firefox directly and queried a lot.
+
+        We need to ensure some performance characteristics.
+        """
+        with self.assertNumQueries(1):
+            response = self.client.get(
+                reverse_ns('addon-compat-override'),
+                data={'guid': u'unknownguid'})
+            assert response.status_code == 200
+            data = json.loads(response.content)
+            assert len(data['results']) == 0
+
 
 class TestAddonRecommendationView(ESTestCase):
     client_class = APITestClient

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -3846,6 +3846,50 @@ class TestCompatOverrideView(TestCase):
                 data = json.loads(response.content)
                 assert len(data['results']) == 2
 
+    def test_api_cache_invalidation(self):
+        # Fill the cache
+        with assert_cache_requests(2):
+            with self.assertNumQueries(2):
+                response = self.client.get(
+                    reverse_ns('addon-compat-override'),
+                    data={'guid': u'extrabad@thing'})
+                assert response.status_code == 200
+                data = json.loads(response.content)
+                assert len(data['results']) == 1
+
+        # Make sure the cache is filled
+        with assert_cache_requests(1):
+            with self.assertNumQueries(0):
+                response = self.client.get(
+                    reverse_ns('addon-compat-override'),
+                    data={'guid': u'extrabad@thing'})
+                assert response.status_code == 200
+                data = json.loads(response.content)
+                assert len(data['results']) == 1
+
+        # This invalidates the cache
+        self.override_addon.save()
+
+        # Now we're back to the original query characteristics
+        with assert_cache_requests(2):
+            with self.assertNumQueries(2):
+                response = self.client.get(
+                    reverse_ns('addon-compat-override'),
+                    data={'guid': u'extrabad@thing'})
+                assert response.status_code == 200
+                data = json.loads(response.content)
+                assert len(data['results']) == 1
+
+        # Make sure the cache is filled again
+        with assert_cache_requests(1):
+            with self.assertNumQueries(0):
+                response = self.client.get(
+                    reverse_ns('addon-compat-override'),
+                    data={'guid': u'extrabad@thing'})
+                assert response.status_code == 200
+                data = json.loads(response.content)
+                assert len(data['results']) == 1
+
 
 class TestAddonRecommendationView(ESTestCase):
     client_class = APITestClient

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -45,6 +45,7 @@ from olympia.users.models import UserProfile
 from olympia.users.templatetags.jinja_helpers import users_list
 from olympia.versions.models import (
     ApplicationsVersions, AppVersion, Version, VersionPreview)
+from olympia.lib.cache import assert_cache_requests
 
 
 def norm(s):
@@ -3765,38 +3766,40 @@ class TestCompatOverrideView(TestCase):
     def test_performance_no_matching_guid(self):
         # There is at least one query from the paginator, counting all objects
         # We do not query on `compat_override` though if the count is 0.
-        with self.assertNumQueries(1):
-            response = self.client.get(
-                reverse_ns('addon-compat-override'),
-                data={'guid': u'unknownguid'})
-            assert response.status_code == 200
-            data = json.loads(response.content)
-            assert len(data['results']) == 0
+        with assert_cache_requests(0):
+            with self.assertNumQueries(1):
+                response = self.client.get(
+                    reverse_ns('addon-compat-override'),
+                    data={'guid': u'unknownguid'})
+                assert response.status_code == 200
+                data = json.loads(response.content)
+                assert len(data['results']) == 0
 
     def test_performance_matches_one_guid(self):
-        # 1. Query is for the paginator, counting all objects
-        # 2. Query is querying compat_override
-        # 3. Query is adding CompatOverrideRange via the transformer
-        with self.assertNumQueries(3):
-            response = self.client.get(
-                reverse_ns('addon-compat-override'),
-                data={'guid': u'extrabad@thing'})
-            assert response.status_code == 200
-            data = json.loads(response.content)
-            assert len(data['results']) == 1
+        # 1. Query is querying compat_override
+        # 2. Query is adding CompatOverrideRange via the transformer
+        with assert_cache_requests(0):
+            with self.assertNumQueries(2):
+                response = self.client.get(
+                    reverse_ns('addon-compat-override'),
+                    data={'guid': u'extrabad@thing'})
+                assert response.status_code == 200
+                data = json.loads(response.content)
+                assert len(data['results']) == 1
 
     def test_performance_matches_multiple_guid(self):
-        # 1. Query is for the paginator, counting all objects
-        # 2. Query is querying compat_override
-        # 3. Query is adding CompatOverrideRange via the transformer
-        with self.assertNumQueries(3):
-            response = self.client.get(
-                reverse_ns('addon-compat-override'),
-                data={'guid': (
-                    u'extrabad@thing,invalid@guid,notevenaguid$,bad@thing')})
-            assert response.status_code == 200
-            data = json.loads(response.content)
-            assert len(data['results']) == 2
+        # 1. Query is querying compat_override
+        # 2. Query is adding CompatOverrideRange via the transformer
+        with assert_cache_requests(0):
+            with self.assertNumQueries(2):
+                response = self.client.get(
+                    reverse_ns('addon-compat-override'),
+                    data={'guid': (
+                        u'extrabad@thing,invalid@guid,notevenaguid$,'
+                        u'bad@thing')})
+                assert response.status_code == 200
+                data = json.loads(response.content)
+                assert len(data['results']) == 2
 
 
 class TestAddonRecommendationView(ESTestCase):

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -3766,7 +3766,8 @@ class TestCompatOverrideView(TestCase):
     def test_performance_no_matching_guid(self):
         # There is at least one query from the paginator, counting all objects
         # We do not query on `compat_override` though if the count is 0.
-        with assert_cache_requests(0):
+        # The cache query is to try and fetch already cached GUIds
+        with assert_cache_requests(1):
             with self.assertNumQueries(1):
                 response = self.client.get(
                     reverse_ns('addon-compat-override'),
@@ -3776,9 +3777,11 @@ class TestCompatOverrideView(TestCase):
                 assert len(data['results']) == 0
 
     def test_performance_matches_one_guid(self):
+        # 1. Cache-Query is the cache query to fetch already cached guids
+        # 2. Cache-Query is to set missing data
         # 1. Query is querying compat_override
         # 2. Query is adding CompatOverrideRange via the transformer
-        with assert_cache_requests(0):
+        with assert_cache_requests(2):
             with self.assertNumQueries(2):
                 response = self.client.get(
                     reverse_ns('addon-compat-override'),
@@ -3787,10 +3790,52 @@ class TestCompatOverrideView(TestCase):
                 data = json.loads(response.content)
                 assert len(data['results']) == 1
 
+        # Now the entries are already cached
+        with assert_cache_requests(1):
+            with self.assertNumQueries(0):
+                response = self.client.get(
+                    reverse_ns('addon-compat-override'),
+                    data={'guid': u'extrabad@thing'})
+                assert response.status_code == 200
+                data = json.loads(response.content)
+                assert len(data['results']) == 1
+
     def test_performance_matches_multiple_guid(self):
-        # 1. Query is querying compat_override
-        # 2. Query is adding CompatOverrideRange via the transformer
-        with assert_cache_requests(0):
+        # 1. Cache-Query is the cache query to fetch already cached guids
+        # 2. Cache-Query is to set missing data
+        # 1. DB-Query is querying compat_override
+        # 2. DB-Query is adding CompatOverrideRange via the transformer
+        with assert_cache_requests(2):
+            with self.assertNumQueries(2):
+                response = self.client.get(
+                    reverse_ns('addon-compat-override'),
+                    data={'guid': (
+                        u'extrabad@thing,invalid@guid,notevenaguid$,'
+                        u'bad@thing')})
+                assert response.status_code == 200
+                data = json.loads(response.content)
+                assert len(data['results']) == 2
+
+        # Only one cache request because all data is already cached
+        # But also one database request to fetch potential missing
+        # guids. Fetching invalid GUIDs should not happen too often
+        # in real-life later.
+        with assert_cache_requests(1):
+            with self.assertNumQueries(1):
+                response = self.client.get(
+                    reverse_ns('addon-compat-override'),
+                    data={'guid': (
+                        u'extrabad@thing,invalid@guid,notevenaguid$,'
+                        u'bad@thing')})
+                assert response.status_code == 200
+                data = json.loads(response.content)
+                assert len(data['results']) == 2
+
+        cache.delete('api::addons::CompatOverride::bad@thing')
+
+        # We're back at two database queries because we need to fetch
+        # and serialize one existing override instance
+        with assert_cache_requests(2):
             with self.assertNumQueries(2):
                 response = self.client.get(
                     reverse_ns('addon-compat-override'),

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -977,6 +977,12 @@ class CompatOverrideView(ListAPIView):
     queryset = CompatOverride.objects.all()
     serializer_class = CompatOverrideSerializer
 
+    @classmethod
+    def as_view(cls, **initkwargs):
+        """The API is read-only so we can turn off atomic requests."""
+        return non_atomic_requests(
+            super(CompatOverrideView, cls).as_view(**initkwargs))
+
     def filter_queryset(self, queryset):
         # Use the same Filter we use for AddonSearchView for consistency.
         guid_filter = AddonGuidQueryParam(self.request)

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -995,16 +995,12 @@ class CompatOverrideView(ListAPIView):
     def list(self, request, *args, **kwargs):
         """Override the `list` logic to integrate custom caching."""
         guids = self.get_guids()
-
-        def _key(guid):
-            return 'api::addons::CompatOverride::{guid}'.format(guid=guid)
-
         if not guids:
             raise exceptions.ParseError(
                 'Empty, or no, guid parameter provided.')
 
+        _key = CompatOverride.get_api_cache_key
         results = cache.get_many([_key(guid) for guid in guids]).values()
-
         missing = set(guids) - set(item['addon_guid'] for item in results)
 
         if missing:

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -975,6 +975,9 @@ class ReplacementAddonView(ListAPIView):
 
 
 class CompatOverrideView(ListAPIView):
+    """
+    This view is being used by Firefox and thus is performance-critical.
+    """
     queryset = CompatOverride.objects.all()
     serializer_class = CompatOverrideSerializer
 
@@ -989,17 +992,47 @@ class CompatOverrideView(ListAPIView):
         guid_filter = AddonGuidQueryParam(self.request)
         return guid_filter.get_value()
 
-    def filter_queryset(self, queryset):
+    def list(self, request, *args, **kwargs):
+        """Override the `list` logic to integrate custom caching."""
         guids = self.get_guids()
+
+        def _key(guid):
+            return 'api::addons::CompatOverride::{guid}'.format(guid=guid)
+
         if not guids:
             raise exceptions.ParseError(
                 'Empty, or no, guid parameter provided.')
-        # Evaluate the actual queryset. The amount of GUIDs we should get
-        # in real-life won't be paginated most of the time so it's safe to
-        # simply evaluate the query. The advantage here is that we are saving
-        # ourselves a `COUNT` query and these are expensive.
-        return list(queryset.filter(guid__in=guids).transform(
-            CompatOverride.transformer).order_by('-pk'))
+
+        results = cache.get_many([_key(guid) for guid in guids]).values()
+
+        missing = set(guids) - set(item['addon_guid'] for item in results)
+
+        if missing:
+            # Evaluate the actual queryset. The amount of GUIDs we should get
+            # in real-life won't be paginated most of the time so it's safe to
+            # simply evaluate the query. The advantage here is that we are
+            # saving ourselves a `COUNT` query and these are expensive.
+            qset = list(
+                self.get_queryset().filter(guid__in=missing)
+                .transform(CompatOverride.transformer)
+                # We are ordering manually because we have to merge cache +
+                # database fetched entries
+                .order_by())
+
+            if qset:
+                missing_data = self.get_serializer(qset, many=True).data
+                results.extend(missing_data)
+
+                cache.set_many({
+                    _key(item['addon_guid']): dict(item)
+                    for item in missing_data})
+
+        results = sorted(results, key=lambda x: x['addon_id'])
+        page = self.paginate_queryset(results)
+        if page is not None:
+            return self.get_paginated_response(page)
+
+        return Response(results)
 
 
 class AddonRecommendationView(AddonSearchView):


### PR DESCRIPTION
Fixes #8768 

This adds various smaller improvements ahead of implementing caching but also implements caching that should result in a performance-boost and reduce our database load significantly.

Personally, I'm not sure if the caching will give us too much benefit since we're actually increasing the number of network roundtrips compared to simply fetching the data and maybe hoping it's already in the database cache/buffer. Network roundtrip performance testing is hard to do locally, unfortunately.

That's why I split them off to simplify review.