### PR TITLE
Part 1 of optimizing CollectionViewSet.

### DIFF
--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -418,7 +418,7 @@ class AccountViewSet(RetrieveModelMixin, UpdateModelMixin, DestroyModelMixin,
     def self_view(self):
         return (
             self.request.user.is_authenticated() and
-            self.kwargs.get('pk') == self.request.user.pk)
+            self.get_object() == self.request.user)
 
     @property
     def admin_viewing(self):

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -418,7 +418,7 @@ class AccountViewSet(RetrieveModelMixin, UpdateModelMixin, DestroyModelMixin,
     def self_view(self):
         return (
             self.request.user.is_authenticated() and
-            self.get_object() == self.request.user)
+            self.kwargs.get('pk') == self.request.user.pk)
 
     @property
     def admin_viewing(self):

--- a/src/olympia/bandwagon/views.py
+++ b/src/olympia/bandwagon/views.py
@@ -677,14 +677,9 @@ class CollectionAddonViewSet(ModelViewSet):
         return super(CollectionAddonViewSet, self).get_object()
 
     def get_queryset(self):
-        collection = (
-            self.get_collection_viewset().get_queryset()
-            .no_transforms()
-            .get(slug=self.kwargs['collection_slug']))
-
         qs = (
             CollectionAddon.objects
-            .filter(collection=collection)
+            .filter(collection=self.get_collection_viewset().get_object())
             .prefetch_related('addon'))
 
         filter_param = self.request.GET.get('filter')

--- a/src/olympia/bandwagon/views.py
+++ b/src/olympia/bandwagon/views.py
@@ -677,8 +677,16 @@ class CollectionAddonViewSet(ModelViewSet):
         return super(CollectionAddonViewSet, self).get_object()
 
     def get_queryset(self):
-        qs = CollectionAddon.objects.filter(
-            collection=self.get_collection_viewset().get_object())
+        collection = (
+            self.get_collection_viewset().get_queryset()
+            .no_transforms()
+            .get(slug=self.kwargs['collection_slug']))
+
+        qs = (
+            CollectionAddon.objects
+            .filter(collection=collection)
+            .prefetch_related('addon'))
+
         filter_param = self.request.GET.get('filter')
         # We only filter list action.
         include_all_with_deleted = (filter_param == 'all_with_deleted' or


### PR DESCRIPTION
Unfortunately, there isn't much we can do, except for this one smaller
change that is quite hard to test as well because of the query-count in
the view get's much bigger the more add-ons are in the view.

More important wins can be made by fixing mozilla/addons-server#8831

This change alone already brings down query-count for a collection with only
6 add-ons already from 98 to 53 database queries.

Fixes #8832 