### PR TITLE
Fix compress_assets to not require any system checks.

### DIFF
--- a/src/olympia/amo/management/commands/compress_assets.py
+++ b/src/olympia/amo/management/commands/compress_assets.py
@@ -27,7 +27,12 @@ def run_command(command):
 
 class Command(BaseCommand):
     help = ('Compresses css and js assets defined in settings.MINIFY_BUNDLES')
-    requires_model_validation = False
+
+    # This command must not do any system checks because Django runs db-field
+    # related checks since 1.10 which require a working MySQL connection.
+    # We don't have that during our docker builds and since `compress_assets`
+    # is being used while building our docker images we have to disable them.
+    requires_system_checks = False
 
     checked_hash = {}
     bundle_hashes = {}


### PR DESCRIPTION
This command is being used during docker builds and thus needs to work
without any database.

We don't run a MySQL database while building the docker image and when Django runs db-field checks
(which it does by default since Django 1.10) it requires a working MySQL
connection.