### PR TITLE
Integrate git-release into raven messages.

### DIFF
--- a/settings_test.py
+++ b/settings_test.py
@@ -22,8 +22,6 @@ DEBUG = False
 # We won't actually send an email.
 SEND_REAL_EMAIL = True
 
-PAYPAL_PERMISSIONS_URL = ''
-
 SITE_URL = CDN_HOST = 'http://testserver'
 
 STATIC_URL = '%s/static/' % CDN_HOST

--- a/src/olympia/amo/celery.py
+++ b/src/olympia/amo/celery.py
@@ -82,7 +82,7 @@ app.config_from_object('django.conf:settings', namespace='CELERY')
 app.autodiscover_tasks()
 
 # Hook up Sentry in celery.
-raven_client = Client(settings.SENTRY_DSN)
+raven_client = Client(settings.RAVEN_CONFIG['dsn'])
 
 # register a custom filter to filter out duplicate logs
 register_logger_signal(raven_client)

--- a/src/olympia/amo/tests/test_settings.py
+++ b/src/olympia/amo/tests/test_settings.py
@@ -47,9 +47,10 @@ def test_raven_release_config():
 
         os.remove(version_json)
 
-    # by default it simply fetches a git-sha
+    # by default, if no version.json exists it simply fetches a git-sha
     assert len(get_raven_release()) == 40
 
+    # It fetches `version` from the version.json
     with open(version_json, 'wb') as fobj:
         fobj.write(json.dumps({
             'version': '2018.07.19'
@@ -58,6 +59,14 @@ def test_raven_release_config():
     assert get_raven_release() == '2018.07.19'
 
     os.remove(version_json)
+
+    # Or tries to get the commit from version.json alternatively
+    with open(version_json, 'wb') as fobj:
+        fobj.write(json.dumps({
+            'commit': '1111111'
+        }))
+
+    assert get_raven_release() == '1111111'
 
     if original:
         with open(version_json, 'wb') as fobj:

--- a/src/olympia/amo/tests/test_settings.py
+++ b/src/olympia/amo/tests/test_settings.py
@@ -1,12 +1,16 @@
 # -*- coding: utf-8 -*-
-from django.conf import settings
+import os
+import json
 
 import pytest
 
+from django.conf import settings
+
+from olympia.lib.settings_base import get_raven_release
+
 
 @pytest.mark.parametrize('key', (
-    'NETAPP_STORAGE', 'GUARDED_ADDONS_PATH', 'MEDIA_ROOT', 'TMP_PATH',
-    'MEDIA_ROOT'))
+    'NETAPP_STORAGE', 'GUARDED_ADDONS_PATH', 'TMP_PATH', 'MEDIA_ROOT'))
 def test_base_paths_bytestring(key):
     """Make sure all relevant base paths are bytestrings.
 
@@ -25,3 +29,36 @@ def test_base_paths_bytestring(key):
     See https://github.com/mozilla/addons-server/issues/3579 for context.
     """
     assert isinstance(getattr(settings, key), str)
+
+
+def test_raven_release_config():
+    version_json = os.path.join(settings.ROOT, 'version.json')
+    original = None
+
+    # There is a version.json that contains `version: origin/master`
+    # by default in the repository. We should ignore that and fetch
+    # the git commit.
+    assert len(get_raven_release()) == 40
+
+    # Cleanup for tests
+    if os.path.exists(version_json):
+        with open(version_json, 'rb') as fobj:
+            original = fobj.read()
+
+        os.remove(version_json)
+
+    # by default it simply fetches a git-sha
+    assert len(get_raven_release()) == 40
+
+    with open(version_json, 'wb') as fobj:
+        fobj.write(json.dumps({
+            'version': '2018.07.19'
+        }))
+
+    assert get_raven_release() == '2018.07.19'
+
+    os.remove(version_json)
+
+    if original:
+        with open(version_json, 'wb') as fobj:
+            fobj.write(original)

--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -185,9 +185,9 @@ CORS_ENDPOINT_OVERRIDES = cors_endpoint_overrides(
     ['amo.addons-dev.allizom.org', 'localhost:3000']
 )
 
-RAVEN_DSN = (
+RAVEN_JS_DSN = (
     'https://5686e2a8f14446a3940c651c6a14dc73@sentry.prod.mozaws.net/75')
-RAVEN_ALLOW_LIST = ['addons-dev.allizom.org', 'addons-dev-cdn.allizom.org']
+RAVEN_JS_ALLOW_LIST = ['addons-dev.allizom.org', 'addons-dev-cdn.allizom.org']
 
 FXA_SQS_AWS_QUEUE_URL = (
     'https://sqs.us-east-1.amazonaws.com/927034868273/'

--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -155,9 +155,9 @@ VALIDATOR_TIMEOUT = 360
 
 ES_DEFAULT_NUM_SHARDS = 10
 
-RAVEN_DSN = (
+RAVEN_JS_DSN = (
     'https://8c1c5936578948a9a0614cbbafccf049@sentry.prod.mozaws.net/78')
-RAVEN_ALLOW_LIST = ['addons.mozilla.org', 'addons.cdn.mozilla.net']
+RAVEN_JS_ALLOW_LIST = ['addons.mozilla.org', 'addons.cdn.mozilla.net']
 
 
 RECOMMENDATION_ENGINE_URL = env(

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -179,9 +179,9 @@ FXA_CONFIG = {
 DEFAULT_FXA_CONFIG_NAME = 'default'
 ALLOWED_FXA_CONFIGS = ['default', 'amo', 'local']
 
-RAVEN_DSN = (
+RAVEN_JS_DSN = (
     'https://e35602be5252460d97587478bcc642df@sentry.prod.mozaws.net/77')
-RAVEN_ALLOW_LIST = ['addons.allizom.org', 'addons-cdn.allizom.org']
+RAVEN_JS_ALLOW_LIST = ['addons.allizom.org', 'addons-cdn.allizom.org']
 
 TAAR_LITE_RECOMMENDATION_ENGINE_URL = env(
     'TAAR_LITE_RECOMMENDATION_ENGINE_URL',

--- a/src/olympia/devhub/templates/devhub/index.html
+++ b/src/olympia/devhub/templates/devhub/index.html
@@ -44,8 +44,8 @@
   {% set user_authenticated = request.user.is_authenticated() %}
 
   <body class="html-{{ DIR }} {{ request.APP.short }} {% if user_authenticated %}user-signedin{% endif %} {% block bodyclass %}{% endblock %}"
-        data-raven-dsn="{{ settings.RAVEN_DSN }}"
-        data-raven-urls="{{ settings.RAVEN_ALLOW_LIST }}"
+        data-raven-dsn="{{ settings.RAVEN_JS_DSN }}"
+        data-raven-urls="{{ settings.RAVEN_JS_ALLOW_LIST }}"
         {% block bodyattrs %}{% endblock %}>
 
 

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1838,11 +1838,12 @@ def get_raven_release():
     if os.path.exists(version_json):
         try:
             with open(version_json, 'rb') as fobj:
-                version = json.loads(fobj.read())['version']
+                data = json.loads(fobj.read())
+                version = data.get('version', data.get('commit', None))
         except (IOError, KeyError):
             version = None
 
-    if version is None or version == 'origin/master':
+    if not version or version == 'origin/master':
         version = raven.fetch_git_sha(ROOT)
     return version
 

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -5,10 +5,12 @@ import environ
 import logging
 import os
 import socket
+import json
 
 from django.urls import reverse_lazy
 from django.utils.functional import lazy
 
+import raven
 from kombu import Queue
 
 import olympia.core.logger
@@ -53,11 +55,8 @@ def path(*folders):
     return os.path.join(ROOT, *folders)
 
 
-# We need to track this because hudson can't just call its checkout "olympia".
-# It puts it in a dir called "workspace".  Way to be, hudson.
-ROOT_PACKAGE = os.path.basename(ROOT)
-
 DEBUG = False
+
 # Ensure that exceptions aren't re-raised.
 DEBUG_PROPAGATE_EXCEPTIONS = False
 SILENCED_SYSTEM_CHECKS = (
@@ -1586,8 +1585,6 @@ REDIS_BACKENDS = {
     'master': get_redis_settings(REDIS_LOCATION)
 }
 
-RESPONSYS_ID = env('RESPONSYS_ID', default=None)
-
 # Number of seconds before celery tasks will abort addon validation:
 VALIDATOR_TIMEOUT = 110
 
@@ -1833,8 +1830,31 @@ REST_FRAMEWORK = {
     'ORDERING_PARAM': 'sort',
 }
 
+
+def get_raven_release():
+    version_json = os.path.join(ROOT, 'version.json')
+    version = None
+
+    if os.path.exists(version_json):
+        try:
+            with open(version_json, 'rb') as fobj:
+                version = json.loads(fobj.read())['version']
+        except (IOError, KeyError):
+            version = None
+
+    if version is None or version == 'origin/master':
+        version = raven.fetch_git_sha(ROOT)
+    return version
+
+
 # This is the DSN to the Sentry service.
-SENTRY_DSN = env('SENTRY_DSN', default=os.environ.get('SENTRY_DSN'))
+RAVEN_CONFIG = {
+    'dsn': env('SENTRY_DSN', default=os.environ.get('SENTRY_DSN')),
+    # Automatically configure the release based on git information.
+    # This uses our `version.json` file if possible or tries to fetch
+    # the current git-sha.
+    'release': get_raven_release(),
+}
 
 # Automatically do 'from olympia import amo' when running shell_plus.
 SHELL_PLUS_POST_IMPORTS = (

--- a/src/olympia/templates/base.html
+++ b/src/olympia/templates/base.html
@@ -51,8 +51,8 @@
         data-readonly="{{ settings.READ_ONLY|json }}"
         data-media-url="{{ MEDIA_URL }}"
         data-static-url="{{ STATIC_URL }}"
-        data-raven-dsn="{{ settings.RAVEN_DSN }}"
-        data-raven-urls="{{ settings.RAVEN_ALLOW_LIST }}"
+        data-raven-dsn="{{ settings.RAVEN_JS_DSN }}"
+        data-raven-urls="{{ settings.RAVEN_JS_ALLOW_LIST }}"
         {% block bodyattrs %}{% endblock %}>
 
     <div id="main-wrapper">

--- a/src/olympia/templates/impala/base.html
+++ b/src/olympia/templates/impala/base.html
@@ -40,8 +40,8 @@
         data-readonly="{{ settings.READ_ONLY|json }}"
         data-media-url="{{ MEDIA_URL }}"
         data-static-url="{{ STATIC_URL }}"
-        data-raven-dsn="{{ settings.RAVEN_DSN }}"
-        data-raven-urls="{{ settings.RAVEN_ALLOW_LIST }}"
+        data-raven-dsn="{{ settings.RAVEN_JS_DSN }}"
+        data-raven-urls="{{ settings.RAVEN_JS_ALLOW_LIST }}"
         data-fxa-config="{{ fxa_config()|json }}"
         {% block bodyattrs %}{% endblock %}>
 


### PR DESCRIPTION
This renames a few raven related settings that aren't used by the
official raven package but only set in our base templates for Raven.js
to pick them up.

This also removes a few unused settings variables.

Fixes #8851

From my test-message on olympia-dev sentry:

![screenshot from 2018-07-12 11-28-29](https://user-images.githubusercontent.com/139033/42624983-f9d48c50-85c6-11e8-9c9e-ccb6fc6d9dc4.png)
