### PR TITLE
Actually choose version.json commit also if version is empty.

### DIFF
--- a/src/olympia/amo/tests/test_settings.py
+++ b/src/olympia/amo/tests/test_settings.py
@@ -71,3 +71,16 @@ def test_raven_release_config():
     if original:
         with open(version_json, 'wb') as fobj:
             fobj.write(original)
+
+    # Usual state of things, version is empty but commit is set
+    with open(version_json, 'wb') as fobj:
+        fobj.write(json.dumps({
+            'version': '',
+            'commit': '1111111'
+        }))
+
+    assert get_raven_release() == '1111111'
+
+    if original:
+        with open(version_json, 'wb') as fobj:
+            fobj.write(original)

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1838,7 +1838,7 @@ def get_raven_release():
         try:
             with open(version_json, 'rb') as fobj:
                 data = json.loads(fobj.read())
-                version = data.get('version', data.get('commit', None))
+                version = data.get('version') or data.get('commit')
         except (IOError, KeyError):
             version = None
 


### PR DESCRIPTION
No issue for it, I noticed that the release still isn't set on dev properly and this is why… 