### PR TITLE
Cleanup 403 page. Remove temporary debug code, keep new detailed messages.

### DIFF
--- a/src/olympia/amo/templates/amo/403.html
+++ b/src/olympia/amo/templates/amo/403.html
@@ -11,10 +11,7 @@
   </section>
 
   <section class="primary">
-    {#
-      Temporary code for debugging. The text is based on Django's default CSRF
-      view content.
-    #}
+    {# Taken primarily from Django's CSRF page #}
     {% if no_referer %}
       <p>
         {% trans %}
@@ -47,24 +44,5 @@
         requests.
       </p>
     {% endif %}
-
-    {% if reason %}
-    <p>Reason given for failure:</p>
-    <pre>
-    {{ reason }}
-    </pre>
-    {% endif %}
-    <p>Other debug data</p>
-        <p>request_is_secure: <pre>{{ request_is_secure }}</pre></p>
-        <p>referer: <pre>{{ referer }}</pre></p>
-        <p>X-Forwarded-Proto: <pre>{{ x_forwarded_proto }}</pre></p>
-        <p>Port: <pre>{{ port }}</pre></p>
-        <p>Host: <pre>{{ host }}</pre></p>
-        <p>good referer: <pre>{{ good_referer }}</pre></p>
-        <p>X-Forwarded-Port: <pre>{{ x_forwarded_port }}</pre></p>
-        <p>Server port: <pre>{{ server_port }}</pre></p>
-
-      </li>
-    </ul>
   </section>
 {% endblock %}

--- a/src/olympia/amo/views.py
+++ b/src/olympia/amo/views.py
@@ -98,24 +98,10 @@ def handler500(request):
 @non_atomic_requests
 def csrf_failure(request, reason=''):
     from django.middleware.csrf import REASON_NO_REFERER, REASON_NO_CSRF_COOKIE
-    good_referer = (
-        settings.SESSION_COOKIE_DOMAIN
-        if settings.CSRF_USE_SESSIONS
-        else settings.CSRF_COOKIE_DOMAIN
-    )
     ctx = {
         'reason': reason,
         'no_referer': reason == REASON_NO_REFERER,
         'no_cookie': reason == REASON_NO_CSRF_COOKIE,
-        # Data that is used by CSRF middleware, for debugging
-        'request_is_secure': request.is_secure(),
-        'referer': request.META.get('HTTP_REFERER'),
-        'x_forwarded_proto': request.META.get('HTTP_X_FORWARDED_PROTO'),
-        'port': request.get_port(),
-        'x_forwarded_port': request.META.get('HTTP_X_FORWARDED_PORT'),
-        'server_port': request.META.get('SERVER_PORT'),
-        'host': request.get_host(),
-        'good_referer': good_referer,
     }
     return render(request, 'amo/403.html', ctx, status=403)
 


### PR DESCRIPTION
This keeps the new, detailed explanation of why you received that page in case of CSRF related problems.