### PR TITLE
Fix reviewer tools "Approve content"

### DIFF
--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -281,6 +281,12 @@ class NumberInput(widgets.Input):
 
 
 class ReviewForm(forms.Form):
+    # Hack to restore behavior from pre Django 1.10 times.
+    # Django 1.10 enabled `required` rendering for required widgets. That
+    # wasn't the case before, this should be fixed properly but simplifies
+    # the actual Django 1.11 deployment for now.
+    use_required_attribute = False
+
     comments = forms.CharField(required=True, widget=forms.Textarea(),
                                label=_(u'Comments:'))
     canned_response = NonValidatingChoiceField(required=False)

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -33,9 +33,10 @@
   <h4 class="author">{{ _('by') }} {{ users_list(addon.listed_authors) }}</h4>
 </hgroup>
 
+<div id="addon" class="primary addon-type-{{ amo.ADDON_SLUGS.get(addon.type, addon.type) }}" role="main" data-id="{{ addon.id }}" data-url="{{ url('reviewers.review_viewing') }}">
+
 <form method="POST" action="#review-actions" class="review-form">
   {% csrf_token %}
-  <div id="addon" class="primary addon-type-{{ amo.ADDON_SLUGS.get(addon.type, addon.type) }}" role="main" data-id="{{ addon.id }}" data-url="{{ url('reviewers.review_viewing') }}">
 
   {% include 'reviewers/addon_details_box.html' %}
 
@@ -370,7 +371,7 @@
     </ul>
     {% endif %}
   </div>
-</div>
+</form>
 {% endif %}
 
 </div> {# /#primary #}

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -4472,6 +4472,14 @@ class TestReviewPending(ReviewBase):
         assert doc('.auto_approval li').eq(0).text() == (
             'Is locked by a reviewer.')
 
+    def test_comments_box_doesnt_have_required_html_attribute(self):
+        """Regression test
+
+        https://github.com/mozilla/addons-server/issues/8907"""
+        response = self.client.get(self.url)
+        doc = pq(response.content)
+        assert doc('#id_comments').attr('required') is None
+
 
 class TestReviewerMOTD(ReviewerTest):
 


### PR DESCRIPTION
Thanks to @wagnerand we noticed that the `comments` textarea now has a `required` attribute rendered. The `comments` textarea is hidden but the browser still requires `required` fields to be filled out. That's why the submit button can't be clicked.

This got introduced in Django 1.10 and there's an option to disable it. I did that for now only for this form but some of the other open issues may be related to that too.

This needs a proper fix throughout the system but that would be less cherry-pickable.

While looking at this, I noticed that the DOM for this reviewer page was broken. This was probably introduced in e02659290cd1217447c2ea4e6d411275a1f70bf9. One of the forms was not properly closed.

Fixes https://github.com/mozilla/addons-server/issues/8907

Opened https://github.com/mozilla/addons-server/issues/8912 as a follow-up