### PR TITLE
Fix 'required' rendering for forms that make use of translation fields.

### DIFF
--- a/src/olympia/translations/forms.py
+++ b/src/olympia/translations/forms.py
@@ -26,6 +26,11 @@ class TranslationFormMixin(object):
     A mixin for forms with translations that tells fields about the object's
     default locale.
     """
+    # Hack to restore behavior from pre Django 1.10 times.
+    # Django 1.10 enabled `required` rendering for required widgets. That
+    # wasn't the case before, this should be fixed properly but simplifies
+    # the actual Django 1.11 deployment for now.
+    use_required_attribute = False
 
     def __init__(self, *args, **kwargs):
         kwargs['error_class'] = LocaleErrorList


### PR DESCRIPTION
Translated form fields render hidden fields that don't have explicitly
set `required=False` and as of Django 1.10 django renders this attribute
in the HTML.

Especially in the error-case we are rendering some hidden fields in the form to keep translations in sync and working. These hidden fields now have a `required` attribute that requires the browser to block until they're filled out. This PR reverts that.

This is only a workaround to have simple, cherry-pickable commits but
certainly needs a proper fix which may involve touching many more of our
forms.

Fixes #8904 

Opened https://github.com/mozilla/addons-server/issues/8912 as a follow-up