### PR TITLE
Add DataDog monitoring to cron job runs

### DIFF
--- a/scripts/crontab/gen-cron.py
+++ b/scripts/crontab/gen-cron.py
@@ -26,7 +26,13 @@ def main():
     if not opts.deprecations:
         opts.python += ' -W ignore::DeprecationWarning'
 
-    ctx = {'django': 'cd %s; %s manage.py' % (opts.zamboni, opts.python)}
+    dogwrap_path = '/usr/local/bin/amo_cron_dogwrap'
+
+    ctx = {
+        "django": "cd %s; %s %s manage.py" % (opts.zamboni,
+                                              dogwrap_path,
+                                              opts.python)
+    }
     ctx['z_cron'] = '%s cron' % ctx['django']
 
     if opts.user:


### PR DESCRIPTION
Requires https://github.com/mozilla-services/cloudops-deployment/pull/2267 to be merged first.

This is already in stage. It creates datadog events such as https://app.datadoghq.com/event/event?id=4490255348531596847. The log output is unfortunately truncated, but at least we can set up DataDog monitors to warn us when the cron jobs fail. I've already done so, emails are sent to the amo-cron-datadog mailing list.

cc @wagnerand 