### PR TITLE
Don't save the add-on instance unless the form is valid.

### DIFF
--- a/src/olympia/addons/forms.py
+++ b/src/olympia/addons/forms.py
@@ -14,9 +14,9 @@ import olympia.core.logger
 from olympia import amo
 from olympia.access import acl
 from olympia.activity.models import ActivityLog
+from olympia.addons import tasks as addons_tasks
 from olympia.addons.models import (
     Addon, AddonCategory, Category, DeniedSlug, Persona)
-from olympia.addons.tasks import save_theme, save_theme_reupload, index_addons
 from olympia.addons.widgets import CategoriesSelectMultiple, IconTypeSelect
 from olympia.addons.utils import verify_mozilla_trademark
 from olympia.amo.fields import (
@@ -227,7 +227,7 @@ class CategoryForm(forms.Form):
         del addon.all_categories
 
         # Make sure the add-on is properly re-indexed
-        index_addons.delay([addon.id])
+        addons_tasks.index_addons.delay([addon.id])
 
     def clean_categories(self):
         categories = self.cleaned_data['categories']
@@ -510,7 +510,7 @@ class ThemeForm(ThemeFormBase):
         p.save()
 
         # Save header and preview images.
-        save_theme.delay(data['header_hash'], addon.pk)
+        addons_tasks.save_theme.delay(data['header_hash'], addon.pk)
 
         # Save user info.
         addon.addonuser_set.create(user=user, role=amo.AUTHOR_ROLE_OWNER)
@@ -653,7 +653,8 @@ class EditThemeForm(AddonFormBase):
         # Theme reupload.
         if not addon.is_pending():
             if data['header_hash']:
-                save_theme_reupload.delay(data['header_hash'], addon.pk)
+                addons_tasks.save_theme_reupload.delay(
+                    data['header_hash'], addon.pk)
 
         return data
 

--- a/src/olympia/addons/forms.py
+++ b/src/olympia/addons/forms.py
@@ -16,7 +16,7 @@ from olympia.access import acl
 from olympia.activity.models import ActivityLog
 from olympia.addons.models import (
     Addon, AddonCategory, Category, DeniedSlug, Persona)
-from olympia.addons.tasks import save_theme, save_theme_reupload
+from olympia.addons.tasks import save_theme, save_theme_reupload, index_addons
 from olympia.addons.widgets import CategoriesSelectMultiple, IconTypeSelect
 from olympia.addons.utils import verify_mozilla_trademark
 from olympia.amo.fields import (
@@ -225,6 +225,9 @@ class CategoryForm(forms.Form):
 
         # Remove old, outdated categories cache on the model.
         del addon.all_categories
+
+        # Make sure the add-on is properly re-indexed
+        index_addons.delay([addon.id])
 
     def clean_categories(self):
         categories = self.cleaned_data['categories']

--- a/src/olympia/addons/tests/test_forms.py
+++ b/src/olympia/addons/tests/test_forms.py
@@ -336,7 +336,7 @@ class TestCategoryForm(TestCase):
 class TestThemeForm(TestCase):
 
     # Don't save image, we use a fake one.
-    @patch('olympia.addons.forms.save_theme')
+    @patch('olympia.addons.forms.addons_tasks.save_theme')
     def test_long_author_or_display_username(self, mock_save_theme):
         # Bug 1181751.
         user = UserProfile.objects.create(email='foo@bar.com',

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -196,6 +196,7 @@ class BaseTestEditBasic(BaseTestEdit):
         assert response.status_code == 200
         self.assertFormError(
             response, 'form', 'name', 'This field is required.')
+        assert self.get_addon().name != ''
 
     def test_edit_name_spaces(self):
         data = self.get_dict(name='    ', slug='test_addon')

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -912,7 +912,6 @@ def addons_section(request, addon_id, addon, section, editable=False):
             if cat_form:
                 if cat_form.is_valid():
                     cat_form.save()
-                    addon.save()
                 else:
                     editable = True
             if dependency_form:


### PR DESCRIPTION
The problem here is that form validation already sets the add-on data
(e.g name etc) during validation so that, in case you are saving that
instance we end up having an empty add-on name. The previous
`form.is_valid` (for the addon form) is correctly returning `False` so
we really just shouldn't issue a save if we know the instance is
invalid.

The `addon.save` call there was being used to make sure the categories for the add-on are correctly reindexed. Since they're managed via `AddonDependency` though imho we don't need that and simply need to call the reindex for that specific add-on.

I added a mental note and will open an issue to check what changed from
1.8 - 1.11 that `addon.name` receives the newly empty value while form
validation. But I couldn't find any re-use of that pattern so I'm
confident that this will fix issues like that.

Fixes #8919