### PR TITLE
Make sure 'class' is not set on the parent ul of our license widget.

### DIFF
--- a/src/olympia/devhub/forms.py
+++ b/src/olympia/devhub/forms.py
@@ -96,6 +96,18 @@ class DeleteForm(forms.Form):
 
 class LicenseRadioSelect(forms.RadioSelect):
 
+    def get_context(self, name, value, attrs):
+        context = super(LicenseRadioSelect, self).get_context(
+            name, value, attrs)
+
+        # Make sure the `class` is only set on the radio fields and
+        # not on the `ul`. This avoids style issues among other things.
+        # See https://github.com/mozilla/addons-server/issues/8902
+        # and https://github.com/mozilla/addons-server/issues/8920
+        del context['widget']['attrs']['class']
+
+        return context
+
     def create_option(self, name, value, label, selected, index,
                       subindex=None, attrs=None):
         context = super(LicenseRadioSelect, self).create_option(

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -785,6 +785,22 @@ class TestAddonSubmitDetails(DetailsPageMixin, TestSubmitBase):
         category_ids_new = [cat.id for cat in self.get_addon().all_categories]
         assert category_ids_new == [22]
 
+    def test_ul_class_rendering_regression(self):
+        """Test ul of license widget doesn't render `license` class.
+
+        Regression test for:
+         * https://github.com/mozilla/addons-server/issues/8902
+         * https://github.com/mozilla/addons-server/issues/8920
+        """
+
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+
+        ul = doc('#id_license-builtin')
+
+        assert ul.attr('class') is None
+
     def test_set_builtin_license_no_log(self):
         self.is_success(self.get_dict(**{'license-builtin': 3}))
         addon = self.get_addon()


### PR DESCRIPTION
This is a regression from our Django 1.11 upgrade, Django changed how
widgets and fields are rendered a lot and we're sometimes (especially in the JS) still relying on the old ways.

These may need follow-ups to be fixed properly.

Fixes #8902
Fixes #8920

![screenshot from 2018-07-19 11-43-25](https://user-images.githubusercontent.com/139033/42935060-0006c0ac-8b49-11e8-991c-4bcfa6a9b832.png)
