### PR TITLE
Fix error message display in translated forms

### DIFF
--- a/src/olympia/translations/forms.py
+++ b/src/olympia/translations/forms.py
@@ -64,7 +64,6 @@ class TranslationFormMixin(object):
 
 
 class LocaleErrorList(ErrorList):
-
     def as_ul(self):
         if not self.data:
             return u''
@@ -73,9 +72,10 @@ class LocaleErrorList(ErrorList):
         for item in self.data:
             if isinstance(item, LocaleErrorMessage):
                 locale, message = item.locale, item.message
-                extra = ' data-lang="%s"' % locale
+                extra = mark_safe(
+                    ' data-lang="%s"' % conditional_escape(locale))
             else:
-                message, extra = item, ''
+                message, extra = ''.join(list(item)), ''
             li.append((extra, conditional_escape(force_text(message))))
 
         return mark_safe(format_html(

--- a/src/olympia/translations/tests/test_forms.py
+++ b/src/olympia/translations/tests/test_forms.py
@@ -25,3 +25,37 @@ class TestTranslationFormMixin(TestCase):
         assert f.fields['name'].default_locale == 'pl'
         assert f.fields['name'].widget.default_locale == 'pl'
         assert pq(f.as_p())('#id_name_0').attr('lang') == 'pl'
+
+    def test_error_display(self):
+        form = DummyForm(data={})
+        # Both name and default_locale should display errors as lists with no
+        # issues. Nothing about the underlying implementation should be shown
+        # (i.e., don't display an ugly [u'This field is required'] message).
+        # name is a translated field so data-lang is present.
+        expected = (
+            '<ul class="errorlist">'
+            '<li data-lang="en-us">This field is required.</li>'
+            '</ul>')
+        assert form.errors['name'].as_ul() == expected
+        # default_locale is a normal field so data-lang is absent.
+        expected = (
+            '<ul class="errorlist">'
+            '<li>This field is required.</li>'
+            '</ul>')
+        assert form.errors['default_locale'].as_ul() == expected
+
+        # When there are multiple errors, they should all be shown.
+        form.add_error('name', 'Error message about name')
+        form.add_error('default_locale', 'Error message about default_locale')
+        expected = (
+            '<ul class="errorlist">'
+            '<li data-lang="en-us">This field is required.</li>'
+            '<li>Error message about name</li>'
+            '</ul>')
+        assert form.errors['name'].as_ul() == expected
+        expected = (
+            '<ul class="errorlist">'
+            '<li>This field is required.</li>'
+            '<li>Error message about default_locale</li>'
+            '</ul>')
+        assert form.errors['default_locale'].as_ul() == expected


### PR DESCRIPTION
- Translated field errors data-lang attribute must not be escaped (only the value should be)
- Non-translated fields errors should not be shown as a python list

Fix #8914