### PR TITLE
Work around 'Multiple .dist-info directories' error when updating deps

### DIFF
--- a/Makefile-docker
+++ b/Makefile-docker
@@ -92,6 +92,10 @@ populate_data:
 	python manage.py cron category_totals
 	python manage.py update_permissions_from_mc
 
+cleanup_python_build_dir:
+	# Work arounds "Multiple .dist-info directories" issue.
+	rm -rf /deps/build/*
+
 install_python_common_dependencies:
 	# Can't use --progress-bar=off for system packages as long as our docker image
 	# doesn't have pip 10 by default.
@@ -116,7 +120,7 @@ copy_node_js:
 	for dest in $(NODE_LIBS_JS) ; do cp $(NODE_MODULES)$$dest $(STATIC_JS) ; done
 	for dest in $(NODE_LIBS_JQUERY_UI) ; do cp $(NODE_MODULES)$$dest $(STATIC_JQUERY_UI) ; done
 
-update_deps: install_python_dev_dependencies install_node_dependencies
+update_deps: cleanup_python_build_dir install_python_dev_dependencies install_node_dependencies
     # Make sure we pull our latest mozilla-product-data.
     # There were scenarios where this wouldn't happen automatically during our CircleCI ui-tests so we enforce it here as a workaround.
 	python manage.py update_product_details


### PR DESCRIPTION
Tired of fixing this manually...