### PR TITLE
Add 'Localize for' menu even for purely unlisted add-ons

### DIFF
--- a/src/olympia/devhub/templates/devhub/addons/edit.html
+++ b/src/olympia/devhub/templates/devhub/addons/edit.html
@@ -17,9 +17,7 @@
 
 {% block content %}
 <header>
-  {% if show_listed_fields %}
-    {{ l10n_menu(addon.default_locale) }}
-  {% endif %}
+  {{ l10n_menu(addon.default_locale) }}
   <h2>{{ addon.name }}</h2>
 </header>
 

--- a/src/olympia/devhub/templates/devhub/addons/edit/details.html
+++ b/src/olympia/devhub/templates/devhub/addons/edit/details.html
@@ -39,7 +39,6 @@
               {% endif %}
             </td>
           </tr>
-          {% if show_listed_fields %}
           <tr>
             <th>
               {{ tip(_("Default Locale"),
@@ -56,7 +55,6 @@
               {% endif %}
             </td>
           </tr>
-          {% endif %}
           <tr>
             <th>
               <label data-for="homepage">

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -1453,7 +1453,7 @@ class TestEditTechnical(BaseTestEdit):
         self.check_dep_ids([5299])
 
 
-class TestEditBasicUnlisted(BaseTestEditBasic):
+class TestEditBasicUnlisted(BaseTestEditBasic, L10nTestsMixin):
     listed = False
     __test__ = True
 


### PR DESCRIPTION
Even purely unlisted add-ons have fields that are translated behind the scenes (name, summary, description, homepage) and those don't behave correctly in devhub when the javascript doesn't find the
localize menu.

Fix #8932