### PR TITLE
Don't use required HTML attribute on submission form for now

### DIFF
--- a/src/olympia/devhub/forms.py
+++ b/src/olympia/devhub/forms.py
@@ -129,6 +129,12 @@ class LicenseRadioSelect(forms.RadioSelect):
 
 
 class LicenseForm(AMOModelForm):
+    # Hack to restore behavior from pre Django 1.10 times.
+    # Django 1.10 enabled `required` rendering for required widgets. That
+    # wasn't the case before, this should be fixed properly but simplifies
+    # the actual Django 1.11 deployment for now.
+    use_required_attribute = False
+
     builtin = forms.TypedChoiceField(
         choices=[], coerce=int,
         widget=LicenseRadioSelect(attrs={'class': 'license'}))


### PR DESCRIPTION
Otherwise it can be confusing as other parts of the details submission don't do client-side validation. This restores pre-django 1.11 behavior while we determine how to properly fix this.

Fix https://github.com/mozilla/addons-server/issues/8918