### PR TITLE
Use custom template for source file link in devhub version edit page

### DIFF
--- a/src/olympia/devhub/forms.py
+++ b/src/olympia/devhub/forms.py
@@ -290,23 +290,19 @@ class WithSourceMixin(object):
 
 class SourceFileInput(forms.widgets.ClearableFileInput):
     """
-    We need to customize the URL link.
-    1. Remove %(initial)% from template_with_initial
-    2. Prepend the new link (with customized text)
+    Like ClearableFileInput but with custom link URL and text for the initial
+    data. Uses a custom template because django's is not flexible enough for
+    our needs.
     """
+    initial_text = _('View current')
+    template_name = 'devhub/addons/includes/source_file_input.html'
 
-    template_with_initial = '%(clear_template)s<br />%(input_text)s: %(input)s'
-
-    def render(self, name, value, attrs=None):
-        output = super(SourceFileInput, self).render(name, value, attrs)
+    def get_context(self, name, value, attrs):
+        context = super(SourceFileInput, self).get_context(name, value, attrs)
         if value and hasattr(value, 'instance'):
-            url = reverse('downloads.source', args=(value.instance.pk, ))
-            params = {
-                'url': url,
-                'output': output,
-                'label': ugettext('View current')}
-            output = '<a href="%(url)s">%(label)s</a> %(output)s' % params
-        return output
+            context['download_url'] = reverse(
+                'downloads.source', args=(value.instance.pk, ))
+        return context
 
 
 class VersionForm(WithSourceMixin, forms.ModelForm):

--- a/src/olympia/devhub/templates/devhub/addons/includes/source_file_input.html
+++ b/src/olympia/devhub/templates/devhub/addons/includes/source_file_input.html
@@ -1,0 +1,5 @@
+{% if widget.is_initial and download_url %}<a class="current-source-link" href="{{ download_url }}">{{ widget.initial_text }}</a>{% if not widget.required %}
+<input type="checkbox" name="{{ widget.checkbox_name }}" id="{{ widget.checkbox_id }}" />
+<label for="{{ widget.checkbox_id }}">{{ widget.clear_checkbox_label }}</label>{% endif %}<br />
+{{ widget.input_text }}:{% endif %}
+<input type="{{ widget.type }}" name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %} />


### PR DESCRIPTION
The old custom widget didn't fully work as expected as django widget rendering is now template based and ignored our custom format string.

Fix #8906