### PR TITLE
Fix rendering of input fields for custom icon upload.

### DIFF
--- a/src/olympia/addons/widgets.py
+++ b/src/olympia/addons/widgets.py
@@ -25,14 +25,14 @@ class IconTypeSelect(forms.RadioSelect):
         for option in self.subwidgets(name, value, attrs):
             option_value = option['value']
 
+            option['widget'] = self.create_option(
+                name=name, value=option['value'], label=option['label'],
+                selected=option_value == value,
+                index=option['index'],
+                attrs=option['attrs'])
+
             if option_value.split('/')[0] == 'icon' or option_value == '':
                 icon_name = option['label']
-
-                option['widget'] = self.create_option(
-                    name=name, value=option['value'], label=option['label'],
-                    selected=option_value == value,
-                    index=option['index'],
-                    attrs=option['attrs'])
 
                 output.append(format_html(
                     self.base_html,
@@ -43,6 +43,10 @@ class IconTypeSelect(forms.RadioSelect):
                     original_widget=self._render(
                         self.option_template_name, option)
                 ))
+            else:
+                output.append(format_html(
+                    '<li class="hide">{widget}</li>',
+                    widget=self._render(self.option_template_name, option)))
 
         return mark_safe(u'\n'.join(output))
 

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -728,6 +728,19 @@ class TestEditMedia(BaseTestEdit):
         assert labels[1].find('input').get('name') == 'icon_type'
         assert labels[1].find('input').get('value') == 'icon/alerts'
 
+        # Make sure we're rendering our <input> fields for custom icon
+        # upload correctly.
+        # They're split into two fields which happens in
+        # :func:`addons.forms:icons`
+        inputs = doc('#icons_default li.hide input')
+
+        assert inputs.length == 2
+        assert inputs[0].get('name') == 'icon_type'
+        assert inputs[0].get('value') == 'image/jpeg'
+
+        assert inputs[1].get('name') == 'icon_type'
+        assert inputs[1].get('value') == 'image/png'
+
     def test_edit_media_preuploadedicon(self):
         data = {'icon_type': 'icon/appearance'}
         data_formset = self.formset_media(**data)


### PR DESCRIPTION
This only adds a test that tests the correct form rendering, we already have a test that tests the actual upload.

This regression happened during the Django 1.11 upgrade, I forgot that specific `else` branch that adds the hidden `<li>` entries and renders the separate `input` elements.

This may be an ideal candidate for a future ui-test actually.

Fixes #8900