### PR TITLE
Disable more xpack features, add some documentation.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,14 @@ services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:5.4.1
     environment:
+      # Disable all xpack related features to avoid unrelated logging
+      # in docker logs. https://github.com/mozilla/addons-server/issues/8887
+      # This also avoids us to require authentication for local development
+      # which simplifies the setup.
       - xpack.security.enabled=false
+      - xpack.monitoring.enabled=false
+      - xpack.graph.enabled=false
+      - xpack.watcher.enabled=false
       - "discovery.type=single-node"
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     mem_limit: 2g


### PR DESCRIPTION
Fixes #8887

For some reason the documented `xpack.reporting.enabled` setting doesn't work for me locally…

```
elasticsearch_1     | [2018-07-26T14:29:27,470][WARN ][o.e.b.ElasticsearchUncaughtExceptionHandler] [] uncaught exception in thread [main]
elasticsearch_1     | org.elasticsearch.bootstrap.StartupException: java.lang.IllegalArgumentException: unknown setting [xpack.reporting.enabled] did you mean any of [xpack.monitoring.enabled, xpack.security.enabled]?
elasticsearch_1     |   at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:127) ~[elasticsearch-5.4.1.jar:5.4.1]
elasticsearch_1     |   at org.elasticsearch.bootstrap.Elasticsearch.execute(Elasticsearch.java:114) ~[elasticsearch-5.4.1.jar:5.4.1]
elasticsearch_1     |   at org.elasticsearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:67) ~[elasticsearch-5.4.1.jar:5.4.1]
elasticsearch_1     |   at org.elasticsearch.cli.Command.mainWithoutErrorHandling(Command.java:122) ~[elasticsearch-5.4.1.jar:5.4.1]
elasticsearch_1     |   at org.elasticsearch.cli.Command.main(Command.java:88) ~[elasticsearch-5.4.1.jar:5.4.1]
elasticsearch_1     |   at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:91) ~[elasticsearch-5.4.1.jar:5.4.1]
elasticsearch_1     |   at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:84) ~[elasticsearch-5.4.1.jar:5.4.1]
elasticsearch_1     | Caused by: java.lang.IllegalArgumentException: unknown setting [xpack.reporting.enabled] did you mean any of [xpack.monitoring.enabled, xpack.security.enabled]?
elasticsearch_1     |   at org.elasticsearch.common.settings.AbstractScopedSettings.validate(AbstractScopedSettings.java:293) ~[elasticsearch-5.4.1.jar:5.4.1]
elasticsearch_1     |   at org.elasticsearch.common.settings.AbstractScopedSettings.validate(AbstractScopedSettings.java:256) ~[elasticsearch-5.4.1.jar:5.4.1]
elasticsearch_1     |   at org.elasticsearch.common.settings.SettingsModule.<init>(SettingsModule.java:139) ~[elasticsearch-5.4.1.jar:5.4.1]
elasticsearch_1     |   at org.elasticsearch.node.Node.<init>(Node.java:343) ~[elasticsearch-5.4.1.jar:5.4.1]
elasticsearch_1     |   at org.elasticsearch.node.Node.<init>(Node.java:242) ~[elasticsearch-5.4.1.jar:5.4.1]
elasticsearch_1     |   at org.elasticsearch.bootstrap.Bootstrap$5.<init>(Bootstrap.java:232) ~[elasticsearch-5.4.1.jar:5.4.1]
elasticsearch_1     |   at org.elasticsearch.bootstrap.Bootstrap.setup(Bootstrap.java:232) ~[elasticsearch-5.4.1.jar:5.4.1]
elasticsearch_1     |   at org.elasticsearch.bootstrap.Bootstrap.init(Bootstrap.java:350) ~[elasticsearch-5.4.1.jar:5.4.1]
elasticsearch_1     |   at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:123) ~[elasticsearch-5.4.1.jar:5.4.1]
elasticsearch_1     |   ... 6 more
```

but it's not required to lower the logging volume apparently so I just left it out.