### PR TITLE
Remove filesystem cache, use default (memcached) backend for everything

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -94,7 +94,6 @@ def default_prefixer(settings):
 @pytest.yield_fixture(autouse=True)
 def test_pre_setup(request, tmpdir, settings):
     caches['default'].clear()
-    caches['filesystem'].clear()
 
     translation.trans_real.deactivate()
     # Django fails to clear this cache.

--- a/settings.py
+++ b/settings.py
@@ -30,10 +30,6 @@ CACHES = {
         'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
         'LOCATION': os.environ.get('MEMCACHE_LOCATION', 'localhost:11211'),
     },
-    'filesystem': {
-        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
-        'LOCATION': FILESYSTEM_CACHE_ROOT,
-    }
 }
 
 # If you're not running on SSL you'll want this to be False.

--- a/settings_test.py
+++ b/settings_test.py
@@ -44,10 +44,6 @@ CACHES = {
             'ACTUAL_BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
         }
     },
-    'filesystem': {  # In real settings it's a filesystem cache, not here.
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-        'LOCATION': 'olympia-filesystem',
-    }
 }
 
 # Overrides whatever storage you might have put in local settings.

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -952,7 +952,7 @@ class LanguageToolsView(ListAPIView):
               .distinct()
         )
 
-    @method_decorator(cache_page(60 * 60 * 24, cache='filesystem'))
+    @method_decorator(cache_page(60 * 60 * 24))
     def dispatch(self, *args, **kwargs):
         return super(LanguageToolsView, self).dispatch(*args, **kwargs)
 

--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -56,8 +56,6 @@ ADDONS_PATH = NETAPP_STORAGE_ROOT + '/files'
 
 REVIEWER_ATTACHMENTS_PATH = MEDIA_ROOT + '/reviewer_attachment'
 
-FILESYSTEM_CACHE_ROOT = NETAPP_STORAGE_ROOT + '/cache'
-
 DATABASES = {}
 DATABASES['default'] = env.db('DATABASES_DEFAULT_URL')
 DATABASES['default']['ENGINE'] = 'django.db.backends.mysql'
@@ -79,12 +77,7 @@ SLAVE_DATABASES = ['slave']
 
 CACHE_MIDDLEWARE_KEY_PREFIX = CACHE_PREFIX
 
-CACHES = {
-    'filesystem': {
-        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
-        'LOCATION': FILESYSTEM_CACHE_ROOT,
-    }
-}
+CACHES = {}
 CACHES['default'] = env.cache('CACHES_DEFAULT')
 CACHES['default']['TIMEOUT'] = 500
 CACHES['default']['BACKEND'] = 'django.core.cache.backends.memcached.MemcachedCache'  # noqa

--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -46,8 +46,6 @@ ADDONS_PATH = NETAPP_STORAGE_ROOT + '/files'
 
 REVIEWER_ATTACHMENTS_PATH = MEDIA_ROOT + '/reviewer_attachment'
 
-FILESYSTEM_CACHE_ROOT = NETAPP_STORAGE_ROOT + '/cache'
-
 DATABASES = {}
 DATABASES['default'] = env.db('DATABASES_DEFAULT_URL')
 DATABASES['default']['ENGINE'] = 'django.db.backends.mysql'
@@ -69,12 +67,7 @@ SLAVE_DATABASES = ['slave']
 
 CACHE_MIDDLEWARE_KEY_PREFIX = CACHE_PREFIX
 
-CACHES = {
-    'filesystem': {
-        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
-        'LOCATION': FILESYSTEM_CACHE_ROOT,
-    }
-}
+CACHES = {}
 CACHES['default'] = env.cache('CACHES_DEFAULT')
 CACHES['default']['TIMEOUT'] = 500
 CACHES['default']['BACKEND'] = 'django.core.cache.backends.memcached.MemcachedCache'  # noqa

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -55,8 +55,6 @@ ADDONS_PATH = NETAPP_STORAGE_ROOT + '/files'
 
 REVIEWER_ATTACHMENTS_PATH = MEDIA_ROOT + '/reviewer_attachment'
 
-FILESYSTEM_CACHE_ROOT = NETAPP_STORAGE_ROOT + '/cache'
-
 DATABASES = {}
 DATABASES['default'] = env.db('DATABASES_DEFAULT_URL')
 DATABASES['default']['ENGINE'] = 'django.db.backends.mysql'
@@ -78,12 +76,7 @@ SLAVE_DATABASES = ['slave']
 
 CACHE_MIDDLEWARE_KEY_PREFIX = CACHE_PREFIX
 
-CACHES = {
-    'filesystem': {
-        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
-        'LOCATION': FILESYSTEM_CACHE_ROOT,
-    }
-}
+CACHES = {}
 CACHES['default'] = env.cache('CACHES_DEFAULT')
 CACHES['default']['TIMEOUT'] = 500
 CACHES['default']['BACKEND'] = 'django.core.cache.backends.memcached.MemcachedCache'  # noqa


### PR DESCRIPTION
Only the language tools API used the filesystem cache, and that was because it had a relatively low usage compared to cache-machine, which meant everything it cached was quickly evicted. Now that cache-machine is gone, let's use memcached again for this.

Fix #8924