### PR TITLE
Add position field to discovery items

### DIFF
--- a/src/olympia/discovery/admin.py
+++ b/src/olympia/discovery/admin.py
@@ -27,12 +27,54 @@ class SlugOrPkChoiceField(forms.ModelChoiceField):
         return super(SlugOrPkChoiceField, self).clean(value)
 
 
+class PositionFilter(admin.SimpleListFilter):
+    # Title for the filter section.
+    title = 'presence in Disco Pane editorial content'
+
+    # Parameter for the filter that will be used in the URL query. It's also
+    # the name of the database field.
+    parameter_name = 'position'
+
+    def lookups(self, request, model_admin):
+        """
+        Returns a list of tuples.
+        # - The first element in each tuple is the coded value for the option
+        #   that will appear in the URL query.
+        # - The second element is the human-readable name for the option that
+        #   will appear
+        in the right sidebar.
+        """
+        return (
+            ('yes', 'Yes'),
+            ('no', 'No'),
+        )
+
+    def queryset(self, request, queryset):
+        """
+        Returns the filtered queryset based on the value provided in the query
+        string and retrievable via `self.value()`.
+        """
+        # Compare the requested value (either 'on' or 'off')
+        # to decide how to filter the queryset.
+        if self.value() == 'yes':
+            return queryset.filter(**{self.parameter_name + '__gt': 0})
+        if self.value() == 'no':
+            return queryset.filter(**{self.parameter_name: 0})
+
+
+class PositionChinaFilter(PositionFilter):
+    title = 'presence in Disco Pane editorial content (China edition)'
+    parameter_name = 'position_china'
+
+
 class DiscoveryItemAdmin(admin.ModelAdmin):
     class Media:
         css = {
             'all': ('css/admin/discovery.css',)
         }
-    list_display = ('__unicode__', 'custom_addon_name', 'custom_heading',)
+    list_display = ('__unicode__', 'custom_addon_name', 'custom_heading',
+                    'position', 'position_china')
+    list_filter = (PositionFilter, PositionChinaFilter)
     raw_id_fields = ('addon',)
     readonly_fields = ('previews',)
     view_on_site = False

--- a/src/olympia/discovery/models.py
+++ b/src/olympia/discovery/models.py
@@ -30,6 +30,16 @@ class DiscoveryItem(ModelBase):
         blank=True, help_text='Longer text used to describe an add-on. Should '
                               'not contain any HTML or special tags. Will be '
                               'translated.')
+    position = models.PositiveSmallIntegerField(
+        default=0, blank=True, db_index=True,
+        help_text='Position in the discovery pane, the lower the number, the '
+                  'higher the item will appear in the page. If left blank or '
+                  'if the value is 0, the item will not appear unless part of '
+                  'telemetry-aware recommendations.')
+    position_china = models.PositiveSmallIntegerField(
+        default=0, blank=True, db_index=True,
+        help_text='Position in the discovery pane in China '
+                  '(See position field above).')
 
     def __unicode__(self):
         return unicode(self.addon)

--- a/src/olympia/discovery/tests/test_admin.py
+++ b/src/olympia/discovery/tests/test_admin.py
@@ -34,6 +34,63 @@ class TestDiscoveryAdmin(TestCase):
         assert response.status_code == 200
         assert u'FooBâr' in response.content.decode('utf-8')
 
+    def test_list_filtering_position_yes(self):
+        DiscoveryItem.objects.create(
+            addon=addon_factory(name=u'FooBâr'), position=1)
+        DiscoveryItem.objects.create(addon=addon_factory(name=u'Âbsent'))
+        user = user_factory()
+        self.grant_permission(user, 'Admin:Tools')
+        self.grant_permission(user, 'Discovery:Edit')
+        self.client.login(email=user.email)
+        response = self.client.get(
+            self.list_url + '?position=yes', follow=True)
+        assert response.status_code == 200
+        assert u'FooBâr' in response.content.decode('utf-8')
+        assert u'Âbsent' not in response.content.decode('utf-8')
+
+    def test_list_filtering_position_no(self):
+        DiscoveryItem.objects.create(
+            addon=addon_factory(name=u'FooBâr'), position_china=42)
+        DiscoveryItem.objects.create(
+            addon=addon_factory(name=u'Âbsent'), position=1)
+        user = user_factory()
+        self.grant_permission(user, 'Admin:Tools')
+        self.grant_permission(user, 'Discovery:Edit')
+        self.client.login(email=user.email)
+        response = self.client.get(self.list_url + '?position=no', follow=True)
+        assert response.status_code == 200
+        assert u'FooBâr' in response.content.decode('utf-8')
+        assert u'Âbsent' not in response.content.decode('utf-8')
+
+    def test_list_filtering_position_yes_china(self):
+        DiscoveryItem.objects.create(
+            addon=addon_factory(name=u'FooBâr'), position_china=1)
+        DiscoveryItem.objects.create(addon=addon_factory(name=u'Âbsent'))
+        user = user_factory()
+        self.grant_permission(user, 'Admin:Tools')
+        self.grant_permission(user, 'Discovery:Edit')
+        self.client.login(email=user.email)
+        response = self.client.get(
+            self.list_url + '?position_china=yes', follow=True)
+        assert response.status_code == 200
+        assert u'FooBâr' in response.content.decode('utf-8')
+        assert u'Âbsent' not in response.content.decode('utf-8')
+
+    def test_list_filtering_position_no_china(self):
+        DiscoveryItem.objects.create(
+            addon=addon_factory(name=u'FooBâr'), position=42)
+        DiscoveryItem.objects.create(
+            addon=addon_factory(name=u'Âbsent'), position_china=1)
+        user = user_factory()
+        self.grant_permission(user, 'Admin:Tools')
+        self.grant_permission(user, 'Discovery:Edit')
+        self.client.login(email=user.email)
+        response = self.client.get(
+            self.list_url + '?position_china=no', follow=True)
+        assert response.status_code == 200
+        assert u'FooBâr' in response.content.decode('utf-8')
+        assert u'Âbsent' not in response.content.decode('utf-8')
+
     def test_can_edit_with_discovery_edit_permission(self):
         addon = addon_factory(name=u'BarFöo')
         item = DiscoveryItem.objects.create(addon=addon)

--- a/src/olympia/migrations/1036-add-discovery-item-position.sql
+++ b/src/olympia/migrations/1036-add-discovery-item-position.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `discovery_discoveryitem`
+    ADD COLUMN `position` smallint UNSIGNED DEFAULT 0,
+    ADD COLUMN `position_china` smallint UNSIGNED DEFAULT 0;


### PR DESCRIPTION
This prepares the switch to the database being the source of the editorial recommendations. The code to actually use the field will be added in the push following the one containing this commit, ensuring a smooth transition.

Fix https://github.com/mozilla/addons-server/issues/9023