### PR TITLE
Fix file upload permissions

### DIFF
--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -1,11 +1,13 @@
 import json
 import os
+import stat
 
 from datetime import datetime, timedelta
 
 from django.conf import settings
 from django.core.files import temp
 from django.core.files.storage import default_storage as storage
+from django.test.utils import override_settings
 
 import mock
 
@@ -377,6 +379,7 @@ class TestAddonSubmitUpload(UploadTest, TestCase):
             mock.call(f)
             for f in latest_version.all_files])
 
+    @override_settings(FILE_UPLOAD_MAX_MEMORY_SIZE=1)
     def test_with_source(self):
         response = self.client.get(
             reverse('devhub.submit.upload', args=['listed']))
@@ -392,6 +395,27 @@ class TestAddonSubmitUpload(UploadTest, TestCase):
             response, reverse('devhub.submit.details', args=[addon.slug]))
         assert addon.current_version.source
         assert Addon.objects.get(pk=addon.pk).needs_admin_code_review
+        mode = oct(os.stat(addon.current_version.source.path)[stat.ST_MODE])
+        assert mode == '0100644'
+
+    @override_settings(FILE_UPLOAD_MAX_MEMORY_SIZE=2 ** 22)
+    def test_with_source_in_memory_upload(self):
+        response = self.client.get(
+            reverse('devhub.submit.upload', args=['listed']))
+        assert pq(response.content)('#id_source')
+        tdir = temp.gettempdir()
+        source = temp.NamedTemporaryFile(suffix=".zip", dir=tdir)
+        source.write('a' * (2 ** 21))
+        source.seek(0)
+        assert Addon.objects.count() == 0
+        response = self.post(source=source)
+        addon = Addon.objects.get()
+        self.assert3xx(
+            response, reverse('devhub.submit.details', args=[addon.slug]))
+        assert addon.current_version.source
+        assert Addon.objects.get(pk=addon.pk).needs_admin_code_review
+        mode = oct(os.stat(addon.current_version.source.path)[stat.ST_MODE])
+        assert mode == '0100644'
 
     @override_switch('allow-static-theme-uploads', active=True)
     def test_static_theme_wizard_button_shown(self):

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1556,6 +1556,10 @@ MAX_PHOTO_UPLOAD_SIZE = MAX_ICON_UPLOAD_SIZE
 MAX_PERSONA_UPLOAD_SIZE = 300 * 1024
 MAX_REVIEW_ATTACHMENT_UPLOAD_SIZE = 5 * 1024 * 1024
 
+# File uploads should have -rw-r--r-- permissions in order to be served by
+# nginx later one. The 0o prefix is intentional, this is an octal value.
+FILE_UPLOAD_PERMISSIONS = 0o644
+
 # RECAPTCHA: overload the following key settings in local_settings.py
 # with your keys.
 # Old recaptcha V1


### PR DESCRIPTION
Since our django upgrade, permissions for files uploaded through a `FileField` (at least) were wrong if the file was exceeding `FILE_UPLOAD_MAX_MEMORY_SIZE` (2.5 MB by default). This affected source code uploads.

This setting is recommended in [django docs](https://docs.djangoproject.com/en/1.11/ref/settings/#file-upload-permissions) anyway, so let's use it.

Fix #9005