### PR TITLE
Make sure handle_file_validation_result() task result is serializable

### DIFF
--- a/src/olympia/devhub/tasks.py
+++ b/src/olympia/devhub/tasks.py
@@ -296,7 +296,7 @@ def handle_file_validation_result(results, file_id, *args):
         results=results, file_=file_, addon=file_.version.addon,
         version_string=file_.version.version, channel=file_.version.channel)
 
-    return FileValidation.from_json(file_, results)
+    return FileValidation.from_json(file_, results).pk
 
 
 def insert_validation_message(results, type_='error', message='', msg_id='',

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -693,7 +693,8 @@ def json_file_validation(request, addon_id, addon, file_id):
 
         # This API is, unfortunately, synchronous, so wait for the
         # task to complete and return the result directly.
-        result = tasks.validate(file, synchronous=True).get()
+        pk = tasks.validate(file, synchronous=True).get()
+        result = FileValidation.objects.get(pk=pk)
 
     return {'validation': result.processed_validation, 'error': None}
 


### PR DESCRIPTION
This is used *synchronously* in devhub when somehow a `File` has no `FileValidation` attached and the developer wants to see the validation results. It needs to return something that's json-serializable to work.

Fix #9033