### PR TITLE
adjust slug generation JS to not overwrite a generated slug with ""

### DIFF
--- a/static/js/zamboni/global.js
+++ b/static/js/zamboni/global.js
@@ -444,16 +444,17 @@ function show_slug_edit(e) {
 }
 
 function slugify() {
-    var slug = $('#id_slug');
-    url_customized = slug.attr('data-customized') == 0;
-    if (url_customized || !slug.val()) {
-        var s = makeslug($('#id_name').val());
-        slug.val(s);
-        name_val = s;
-        $('#slug_value').text(s);
-    } else {
-        $('#slug_value').text($('#id_slug').val());
+    var $slug = $('#id_slug');
+    var url_customized = $slug.attr('data-customized') === 0 ||
+                                    !$slug.attr('data-customized');
+    if (url_customized || !$slug.val()) {
+        var new_slug = makeslug($('#id_name').val());
+        if (new_slug !== "") {
+            $slug.val(new_slug);
+        }
     }
+    name_val = $slug.val();
+    $('#slug_value').text($slug.val());
 }
 
 


### PR DESCRIPTION
fixes #8986 - reverts to the previous behaviour of normally overwriting a valid generated slug with a knowingly duplicate one; but still prevents a UUID slug being overwritten with "" (empty string).

#8913 changed the JS.