### PR TITLE
Make the way CollectionAddonViewSet does permission checks more obvious

### DIFF
--- a/src/olympia/bandwagon/serializers.py
+++ b/src/olympia/bandwagon/serializers.py
@@ -76,7 +76,7 @@ class CollectionSerializer(serializers.ModelSerializer):
 class ThisCollectionDefault(object):
     def set_context(self, serializer_field):
         viewset = serializer_field.context['view']
-        self.collection = viewset.get_collection_viewset().get_object()
+        self.collection = viewset.get_collection()
 
     def __call__(self):
         return self.collection


### PR DESCRIPTION
Add comments but also directly instantiate the collection object from the viewset instead of doing through the serializer to do it.

Fix #8747 