### PR TITLE
Set ADDONS_LINTER_BIN to a path that works on web envs too in dev/stage/prod

### DIFF
--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -111,9 +111,7 @@ NEW_FEATURES = True
 
 REDIRECT_URL = 'https://outgoing.stage.mozaws.net/v1/'
 
-CLEANCSS_BIN = 'cleancss'
-UGLIFY_BIN = 'uglifyjs'
-ADDONS_LINTER_BIN = 'addons-linter'
+ADDONS_LINTER_BIN = 'node_modules/.bin/addons-linter'
 
 XSENDFILE_HEADER = 'X-Accel-Redirect'
 

--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -96,9 +96,7 @@ CEF_PRODUCT = STATSD_PREFIX
 
 NEW_FEATURES = True
 
-CLEANCSS_BIN = 'cleancss'
-UGLIFY_BIN = 'uglifyjs'
-ADDONS_LINTER_BIN = 'addons-linter'
+ADDONS_LINTER_BIN = 'node_modules/.bin/addons-linter'
 
 XSENDFILE_HEADER = 'X-Accel-Redirect'
 

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -106,9 +106,7 @@ NEW_FEATURES = True
 
 REDIRECT_URL = 'https://outgoing.stage.mozaws.net/v1/'
 
-CLEANCSS_BIN = 'cleancss'
-UGLIFY_BIN = 'uglifyjs'
-ADDONS_LINTER_BIN = 'addons-linter'
+ADDONS_LINTER_BIN = 'node_modules/.bin/addons-linter'
 
 XSENDFILE_HEADER = 'X-Accel-Redirect'
 


### PR DESCRIPTION
The current one depends on node_modules/.bin/ being in the PATH, which is only true in celery workers, which is not enough.

Fix #9033