### PR TITLE
Activate en-CA locale

### DIFF
--- a/src/olympia/constants/search.py
+++ b/src/olympia/constants/search.py
@@ -21,7 +21,7 @@ SEARCH_ANALYZER_MAP = {
     'danish': ['da'],
     'german': ['de'],
     'greek': ['el'],
-    'english': ['en-us', 'en-gb'],
+    'english': ['en-us', 'en-ca', 'en-gb'],
     'spanish': ['es'],
     'basque': ['eu'],
     'persian': ['fa'],

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -166,6 +166,7 @@ AMO_LANGUAGES = (
     'de',  # German
     'dsb',  # Lower Sorbian
     'el',  # Greek
+    'en-CA',  # English (Canada)
     'en-GB',  # English (British)
     'en-US',  # English (US)
     'es',  # Spanish


### PR DESCRIPTION
I have localized the site to [Canadian English (en-CA)](https://github.com/mozilla/addons-server/tree/master/locale/en_CA). Looks like the locale has already been enabled on the [frontend](https://addons.mozilla.org/en-CA/firefox/) but not in Django, so [/en-CA/](https://addons.mozilla.org/en-CA/), [/en-CA/developers/](https://addons.mozilla.org/en-CA/developers/) (Developer Hub link) and whatever lead to 404. Please activate the new locale. Thanks!