### PR TITLE
use attach_trans_dict to load all translations in TranslatedField

### DIFF
--- a/src/olympia/api/tests/test_fields.py
+++ b/src/olympia/api/tests/test_fields.py
@@ -58,7 +58,8 @@ class TestTranslationSerializerField(TestCase):
 
     def _test_expected_dict(self, field, serializer=None):
         field.bind('name', serializer)
-        result = field.to_representation(field.get_attribute(self.addon))
+        with self.assertNumQueries(1):
+            result = field.to_representation(field.get_attribute(self.addon))
         expected = {
             'en-US': unicode(Translation.objects.get(id=self.addon.name.id,
                                                      locale='en-US')),
@@ -69,7 +70,8 @@ class TestTranslationSerializerField(TestCase):
 
         field.source = None
         field.bind('description', serializer)
-        result = field.to_representation(field.get_attribute(self.addon))
+        with self.assertNumQueries(0):
+            result = field.to_representation(field.get_attribute(self.addon))
         expected = {
             'en-US': Translation.objects.get(
                 id=self.addon.description.id, locale='en-US'),


### PR DESCRIPTION
part of #8831 - this will mean we only have to fetch translations once per instance of a model.  

There's no easy fix I can see to fetch all translations for each Addon (for example) in a queryset at the same time, without modifying AddonManager, which will fetch all for all lookups (and we don't need _all_ when we're using a single locale, e.g. all devhub, api requests with `?lang=xx-XX`).  So sorting out that will be separate pull.