### PR TITLE
fix issue #6698: unbroken strings wrapped using word-break CSS property

### DIFF
--- a/static/css/zamboni/developers.css
+++ b/static/css/zamboni/developers.css
@@ -16,6 +16,8 @@ form .char-count:after,
     margin-bottom:3em;
     width: 100%;
     overflow: hidden;
+    word-wrap: break-word;
+    word-break: break-all;
 }
 
 #edit-addon h3 a {


### PR DESCRIPTION
Fixes issue [#6698](https://github.com/mozilla/addons-server/issues/6698). I have fixed this by adding word-wrap and word-break CSS properties.

Before addon edit screen:
![firefox_1st_bug](https://user-images.githubusercontent.com/2492182/43986193-cf840468-9cc2-11e8-9a8d-7862bc466296.png)

After css patch addon screen 1:
![issue_ 6698_patchup](https://user-images.githubusercontent.com/2492182/43986201-e4398f5e-9cc2-11e8-906f-2192edeb0936.png)

screen 2:
![firefix_ 6698_patchup_scrn2](https://user-images.githubusercontent.com/2492182/43986203-ebd42bfc-9cc2-11e8-9197-0b50fa427240.png)
