### PR TITLE
Pin autograph to 2.2.0 temporarily.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ script:
   - |
     if [[ $TRAVIS_EVENT_TYPE != "cron" ]]; then
       if [[ $TOXENV == "amo-locales-and-signing" ]]; then
-         docker run --name autograph -d -p 5500:5500 -v $(pwd)/scripts/:/scripts/ mozilla/autograph:latest /go/bin/autograph -c /scripts/autograph_travis_test_config.yaml
+         docker run --name autograph -d -p 5500:5500 -v $(pwd)/scripts/:/scripts/ mozilla/autograph:2.2.0 /go/bin/autograph -c /scripts/autograph_travis_test_config.yaml
       fi
       RUNNING_IN_CI=True tox
     fi


### PR DESCRIPTION
This works around startup problems raised by https://github.com/mozilla-services/autograph/commit/a72245d8b8c5e7b0d6c4437d246bd153ca2a7c76