### PR TITLE
Delete obsolete Thunderbird & Seamonkey categories

### DIFF
--- a/src/olympia/migrations/1043-remove-thunderbird-seamonkey-categories.sql
+++ b/src/olympia/migrations/1043-remove-thunderbird-seamonkey-categories.sql
@@ -1,0 +1,10 @@
+-- Remove categories for applications others than Firefox and Firefox for
+-- Android.
+-- Removing those categories and associated m2m will hide them from the site,
+-- and prevent developers from choosing them when submitting new add-ons or
+-- editing details for an existing one.
+DELETE addons_categories FROM addons_categories
+    INNER JOIN categories
+    ON addons_categories.category_id=categories.id
+    WHERE categories.application_id NOT IN (1, 61);
+DELETE FROM categories WHERE application_id NOT IN (1, 61);


### PR DESCRIPTION
Otherwise they can show up in devhub & API even though they are no longer useful
as we moved thunderbird & seamonkey add-ons to a different site.

Initially wrote some code to handle this, but then realized the right thing to do was just to delete the rows from the database entirely... We've already removed ApplicationsVersions anyway...  Fix #9096