### PR TITLE
Fixes #7298: Fix DevHub title overlap in some languages. (#7298)

### DIFF
--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -321,7 +321,8 @@ body:not(.home) .amo-header,
 
     small {
       margin-left: 5px;
-      margin-bottom: 10px;
+      margin-bottom: -7px;
+      line-height: normal;
     }
   }
 }


### PR DESCRIPTION
Fixes #7298 by resetting the `line-height` of a `<small>` element in the title back to its original height. [Depending on user agent, but roughly 1.2](https://developer.mozilla.org/en-US/docs/Web/CSS/line-height#Values).

Question for reviewer: I've had a bit of trouble figuring out where to put the changes, due to the fact that there are several files where dev hub title is selected and modified. I don't know the historical reason behind having a `restyle.less`, `developers.less`, `headers.less`, but each of them has selectors like `.developer-hub .site-title` in them and it's sort of confusing (at least to me). I'd rather have something dealing with the developer hub header in a single place than spread throughout. I wanted to move some code to be together and easier to follow from [restyle.less](https://github.com/mozilla/addons-server/blob/9189e9be0c0d9f3df9c9dfbc26e9b16ae934d19e/static/css/restyle/restyle.less#L307-L327) to [developers.less](https://github.com/mozilla/addons-server/blob/9189e9be0c0d9f3df9c9dfbc26e9b16ae934d19e/static/css/impala/developers.less#L3-L27), but was instructed on IRC to keep the changes to their initial focus and potentially open up a new issue. Should I keep this separate in a new issue, or add them here, or leave the code how it is?

Before
<img width="400" alt="screen shot 2018-08-16 at 12 34 14 pm" src="https://user-images.githubusercontent.com/721171/44230704-c3d87a80-a150-11e8-80a9-a24ec4387eaa.png">


After
- Notice that only the last one (in Greek) has a bit of overlap still, but increasing the line height even more makes it look weird for other languages, so I thought this is a compromise. I browsed through all languages and that was the only one that caught my attention.

<img width="400" alt="screen shot 2018-08-16 at 12 32 09 pm" src="https://user-images.githubusercontent.com/721171/44230602-6e9c6900-a150-11e8-8cc1-9cd6e96d55a3.png">
<img width="400" alt="screen shot 2018-08-16 at 12 13 19 pm" src="https://user-images.githubusercontent.com/721171/44230553-4ca2e680-a150-11e8-9c8f-2c7f7a4cfe88.png">
<img width="400" alt="screen shot 2018-08-16 at 12 13 11 pm" src="https://user-images.githubusercontent.com/721171/44230571-5a586c00-a150-11e8-93be-281a9efaabd2.png">
<img width="400" alt="screen shot 2018-08-16 at 12 13 48 pm" src="https://user-images.githubusercontent.com/721171/44230536-3f85f780-a150-11e8-8110-bd8ff7eac97b.png">