### PR TITLE
Unify database configuration, enable 'read committed' transaction level

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ x-env-mapping: &env
   environment:
     - CELERY_BROKER_URL=amqp://olympia:olympia@rabbitmq/olympia
     - CELERY_RESULT_BACKEND=redis://redis:6379/1
-    - DATABASE_URL=mysql://root:@mysqld/olympia
+    - DATABASES_DEFAULT_URL=mysql://root:@mysqld/olympia
     - ELASTICSEARCH_LOCATION=elasticsearch:9200
     - MEMCACHE_LOCATION=memcached:11211
     - MYSQL_DATABASE=olympia

--- a/docs/topics/install/deprecated/installation.rst
+++ b/docs/topics/install/deprecated/installation.rst
@@ -198,7 +198,7 @@ If you want to change settings, you can either add the database settings in
 your :ref:`local_settings.py<example-settings>` or set the environment variable
 ``DATABASE_URL``::
 
-    export DATABASE_URL=mysql://<user>:<password>@<hostname>/<database>
+    export DATABASES_DEFAULT_URL=mysql://<user>:<password>@<hostname>/<database>
 
 If you've changed the user and password information, you need to grant
 permissions to the new user::

--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -56,22 +56,12 @@ ADDONS_PATH = NETAPP_STORAGE_ROOT + '/files'
 
 REVIEWER_ATTACHMENTS_PATH = MEDIA_ROOT + '/reviewer_attachment'
 
-DATABASES = {}
-DATABASES['default'] = env.db('DATABASES_DEFAULT_URL')
-DATABASES['default']['ENGINE'] = 'django.db.backends.mysql'
-# Run all views in a transaction (on master) unless they are decorated not to.
-DATABASES['default']['ATOMIC_REQUESTS'] = True
-# Pool our database connections up for 300 seconds
-DATABASES['default']['CONN_MAX_AGE'] = 300
+DATABASES = {
+    'default': get_db_config('DATABASES_DEFAULT_URL'),
+    'slave': get_db_config('DATABASES_SLAVE_URL'),
+}
 
-DATABASES['slave'] = env.db('DATABASES_SLAVE_URL')
-# Do not open a transaction for every view on the slave DB.
-DATABASES['slave']['ATOMIC_REQUESTS'] = False
-DATABASES['slave']['ENGINE'] = 'django.db.backends.mysql'
-# Pool our database connections up for 300 seconds
-DATABASES['slave']['CONN_MAX_AGE'] = 300
-
-SERVICES_DATABASE = env.db('SERVICES_DATABASE_URL')
+SERVICES_DATABASE = get_db_config('SERVICES_DATABASE_URL')
 
 SLAVE_DATABASES = ['slave']
 

--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -46,22 +46,12 @@ ADDONS_PATH = NETAPP_STORAGE_ROOT + '/files'
 
 REVIEWER_ATTACHMENTS_PATH = MEDIA_ROOT + '/reviewer_attachment'
 
-DATABASES = {}
-DATABASES['default'] = env.db('DATABASES_DEFAULT_URL')
-DATABASES['default']['ENGINE'] = 'django.db.backends.mysql'
-# Run all views in a transaction (on master) unless they are decorated not to.
-DATABASES['default']['ATOMIC_REQUESTS'] = True
-# Pool our database connections up for 300 seconds
-DATABASES['default']['CONN_MAX_AGE'] = 300
+DATABASES = {
+    'default': get_db_config('DATABASES_DEFAULT_URL'),
+    'slave': get_db_config('DATABASES_SLAVE_URL'),
+}
 
-DATABASES['slave'] = env.db('DATABASES_SLAVE_URL')
-# Do not open a transaction for every view on the slave DB.
-DATABASES['slave']['ATOMIC_REQUESTS'] = False
-DATABASES['slave']['ENGINE'] = 'django.db.backends.mysql'
-# Pool our database connections up for 300 seconds
-DATABASES['slave']['CONN_MAX_AGE'] = 300
-
-SERVICES_DATABASE = env.db('SERVICES_DATABASE_URL')
+SERVICES_DATABASE = get_db_config('SERVICES_DATABASE_URL')
 
 SLAVE_DATABASES = ['slave']
 

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -55,22 +55,12 @@ ADDONS_PATH = NETAPP_STORAGE_ROOT + '/files'
 
 REVIEWER_ATTACHMENTS_PATH = MEDIA_ROOT + '/reviewer_attachment'
 
-DATABASES = {}
-DATABASES['default'] = env.db('DATABASES_DEFAULT_URL')
-DATABASES['default']['ENGINE'] = 'django.db.backends.mysql'
-# Run all views in a transaction (on master) unless they are decorated not to.
-DATABASES['default']['ATOMIC_REQUESTS'] = True
-# Pool our database connections up for 300 seconds
-DATABASES['default']['CONN_MAX_AGE'] = 300
+DATABASES = {
+    'default': get_db_config('DATABASES_DEFAULT_URL'),
+    'slave': get_db_config('DATABASES_SLAVE_URL'),
+}
 
-DATABASES['slave'] = env.db('DATABASES_SLAVE_URL')
-# Do not open a transaction for every view on the slave DB.
-DATABASES['slave']['ATOMIC_REQUESTS'] = False
-DATABASES['slave']['ENGINE'] = 'django.db.backends.mysql'
-# Pool our database connections up for 300 seconds
-DATABASES['slave']['CONN_MAX_AGE'] = 300
-
-SERVICES_DATABASE = env.db('SERVICES_DATABASE_URL')
+SERVICES_DATABASE = get_db_config('SERVICES_DATABASE_URL')
 
 SLAVE_DATABASES = ['slave']
 


### PR DESCRIPTION
Fixes #7158

This unifies our database configuration so that we don't have that much custom config for dev, stage and prod. This now also set's the `read comitted` transaction level.

We probably don't want this in the next tag but merge it right after we tagged so that we get as much testing time on -dev and -stage as possible.

I actually wonder if we want to add a test, similarly to https://github.com/django/django/blob/master/tests/transactions/tests.py#L367-L400 to make sure this is working as we expect?