### PR TITLE
Fix unicode issue preventing forms with translated fields from displaying error messages

### DIFF
--- a/src/olympia/translations/forms.py
+++ b/src/olympia/translations/forms.py
@@ -74,17 +74,17 @@ class LocaleErrorList(ErrorList):
             if isinstance(item, LocaleErrorMessage):
                 locale, message = item.locale, item.message
                 extra = mark_safe(
-                    ' data-lang="%s"' % conditional_escape(locale))
+                    u' data-lang="%s"' % conditional_escape(locale))
             else:
-                message, extra = ''.join(list(item)), ''
+                message, extra = u''.join(list(item)), u''
             li.append((extra, conditional_escape(force_text(message))))
 
         return mark_safe(format_html(
-            '<ul class="{}">{}</ul>',
+            u'<ul class="{}">{}</ul>',
             self.error_class,
             format_html_join(
-                '',
-                '<li{}>{}</li>',
+                u'',
+                u'<li{}>{}</li>',
                 ((extra, elem) for extra, elem in li)
             )
         ))


### PR DESCRIPTION
Fix #9203