### PR TITLE
Add note to developer to remember to enter reviewer notes.

### DIFF
--- a/src/olympia/devhub/templates/devhub/addons/submit/describe.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/describe.html
@@ -141,8 +141,19 @@
         <label for="{{ reviewer_form.approvalnotes.auto_id }}">
           {{ _('Notes to Reviewer:') }}
         </label>
-        <p>{{ _('Is there anything our reviewers should bear in mind when reviewing this add-on?') }}</p>
-          {{ reviewer_form.approvalnotes }}
+        <div class="source-submission-note">
+          <p>{{ _('Is there anything our reviewers should bear in mind when reviewing this add-on?') }}</p>
+          {% if version.sources_provided %}
+            <p>
+              <span class="req">{{ _('Remember') }}</span>:
+              {% trans %}
+              If you submitted source code, but did not include instructions, you must provide them here.
+              Enter step-by-step build instructions to create an exact copy of the add-on code, per policy requirements.
+              {%- endtrans -%}
+            </p>
+          {% endif %}
+        </div>
+        {{ reviewer_form.approvalnotes }}
         <p>{{ _('These notes will only be visible to you and our reviewers.') }}</p>
       </div>
     {% endif %}

--- a/src/olympia/devhub/templates/devhub/addons/submit/describe_minimal.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/describe_minimal.html
@@ -19,7 +19,18 @@
       <label for="{{ reviewer_form.approvalnotes.auto_id }}">
       {{ _('Notes to Reviewer:') }}
       </label>
-      <p>{{ _('Is there anything our reviewers should bear in mind when reviewing this add-on?') }}</p>
+      <div class="source-submission-note">
+        <p>{{ _('Is there anything our reviewers should bear in mind when reviewing this add-on?') }}</p>
+        {% if version.sources_provided %}
+          <p>
+            <span class="req">{{ _('Remember') }}</span>:
+            {% trans %}
+            If you submitted source code, but did not include instructions, you must provide them here.
+            Enter step-by-step build instructions to create an exact copy of the add-on code, per policy requirements.
+            {%- endtrans -%}
+          </p>
+        {% endif %}
+      </div>
       {{ reviewer_form.approvalnotes }}
       <p>{{ _('These notes will only be visible to you and our reviewers.') }}</p>
     </div>

--- a/static/css/zamboni/developers.css
+++ b/static/css/zamboni/developers.css
@@ -1547,3 +1547,12 @@ span.distribution-tag-listed {
 span.distribution-tag-unlisted {
     background-color: #7A2F7A;
 }
+
+.source-submission-note p {
+    font-size: 0.9em;
+    margin-bottom: 0.2em;
+}
+
+.source-submission-note p:last-child {
+    margin-bottom: 1.5em;
+}


### PR DESCRIPTION
Fixes #9149

I kinda disagreed with the recommendation rom the issue because then we have the word "submit" or "submission" in that sentence way too many times. I don't mind adding it though :man_shrugging: 

> when fixing this, it might be a good idea to also address the following section from the Source code upload form:
>     There is a text in the PRD which was partially omitted in the implementation:
>     PRD: "You may need to submit source code with your submission. "
>     AMO: "You may need to submit source code"