### PR TITLE
Update done.html to correctly redirect "Go to submissions" when submitting static themes (Bug #8497)

### DIFF
--- a/src/olympia/devhub/templates/devhub/addons/submit/done.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/done.html
@@ -95,8 +95,12 @@
   </p>
 {% endif %}
 <p>
-  <a class="button" href="{{ url('devhub.addons') }}">
-      {{ _("Go to My Submissions") }}</a>
+  {% if addon.type == amo.ADDON_STATICTHEME %}
+    <a class="button" href="{{ url('devhub.themes') }}">
+  {% else %}
+    <a class="button" href="{{ url('devhub.addons') }}">
+  {% endif %}
+    {{ _("Go to My Submissions") }}</a>
 </p>
 
 {% endblock %}

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -1320,7 +1320,7 @@ class TestAddonSubmitFinish(TestSubmitBase):
         # First link is to edit listing.
         assert links[0].attrib['href'] == self.addon.get_dev_url()
         # Second link is back to my submissions.
-        assert links[1].attrib['href'] == reverse('devhub.addons')
+        assert links[1].attrib['href'] == reverse('devhub.themes')
 
         # Text is static theme specific.
         assert "This version will be available after it passes review." in (


### PR DESCRIPTION
Fixes #8497 

Now clicking on "Go to submissions" redirects to `devhub.themes` (the My Themes page) rather than the `devhub.addons` (the My Addons page) after submitting a static theme.

