### PR TITLE
Allow users with Admin:Advanced to delete users with relations to other models

### DIFF
--- a/src/olympia/addons/admin.py
+++ b/src/olympia/addons/admin.py
@@ -73,6 +73,10 @@ class AddonAdmin(admin.ModelAdmin):
     status_with_admin_manage_link.short_description = _(u'Status')
 
 
+class AddonUserAdmin(admin.ModelAdmin):
+    raw_id_fields = ('addon', 'user')
+
+
 class FeatureAdmin(admin.ModelAdmin):
     raw_id_fields = ('addon',)
     list_filter = ('application', 'locale')

--- a/src/olympia/constants/permissions.py
+++ b/src/olympia/constants/permissions.py
@@ -84,7 +84,14 @@ PERMISSIONS_LIST = [
 DJANGO_PERMISSIONS_MAPPING = defaultdict(lambda: SUPERPOWERS)
 
 DJANGO_PERMISSIONS_MAPPING.update({
+    'abuse.delete_abusereport': ADMIN_ADVANCED,
+    # Note that ActivityLog's ModelAdmin actually forbids deletion entirely.
+    # This is just here to allow deletion of users, because django checks
+    # foreign keys even though users are only soft-deleted and related objects
+    # will be kept.
+    'activity.delete_activitylog': ADMIN_ADVANCED,
     'addons.change_addon': ADDONS_EDIT,
+    'addons.delete_addonuser': ADMIN_ADVANCED,
     # Users with Admin:Curation can do anything to ReplacementAddon.
     # In addition, the modeladmin will also check for Addons:Edit and give them
     # read-only access to the changelist (obj=None passed to the
@@ -100,8 +107,11 @@ DJANGO_PERMISSIONS_MAPPING.update({
     'discovery.change_discoveryitem': DISCOVERY_EDIT,
     'discovery.delete_discoveryitem': DISCOVERY_EDIT,
 
+    'reviewers.delete_reviewerscore': ADMIN_ADVANCED,
+
     'users.change_userprofile': USERS_EDIT,
     'users.delete_userprofile': ADMIN_ADVANCED,
 
     'ratings.change_rating': RATINGS_MODERATE,
+    'ratings.delete_rating': ADMIN_ADVANCED,
 })

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -419,6 +419,8 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
                     addon.delete()
                 else:
                     addon.force_disable()
+            else:
+                addon.addonuser_set.filter(user=self).delete()
         user_responsible = core.get_user()
         self._ratings_all.all().delete(user_responsible=user_responsible)
         self.delete_picture()


### PR DESCRIPTION
Note that the behaviour depends on which model is affected - some are kept, others are deleted because of `UserProfile.delete_or_disable_related_content()`.

Fix #9046