### PR TITLE
Remove safer_get_or_create in favour of builtin get_or_create.

### DIFF
--- a/src/olympia/amo/models.py
+++ b/src/olympia/amo/models.py
@@ -4,7 +4,7 @@ import time
 
 from django.conf import settings
 from django.core.files.storage import default_storage as storage
-from django.db import models, transaction
+from django.db import models
 from django.utils import translation
 from django.db.models.query import ModelIterable
 

--- a/src/olympia/amo/models.py
+++ b/src/olympia/amo/models.py
@@ -125,23 +125,6 @@ class ManagerBase(models.Manager):
         return RawQuerySet(raw_query, self.model, params=params,
                            using=self._db, *args, **kwargs)
 
-    def safer_get_or_create(self, defaults=None, **kw):
-        """
-        This is subjective, but I don't trust get_or_create until #13906
-        gets fixed. It's probably fine, but this makes me happy for the moment
-        and solved a get_or_create we've had in the past.
-
-        This should be replaced by "read committed" state:
-        https://github.com/mozilla/addons-server/issues/7158
-        """
-        with transaction.atomic():
-            try:
-                return self.get(**kw), False
-            except self.model.DoesNotExist:
-                if defaults is not None:
-                    kw.update(defaults)
-                return self.create(**kw), True
-
 
 class _NoChangeInstance(object):
     """A proxy for object instances to make safe operations within an

--- a/src/olympia/amo/tests/test_models.py
+++ b/src/olympia/amo/tests/test_models.py
@@ -117,11 +117,17 @@ class TestModelBase(TestCase):
         assert fn.called
         # No exception = pass
 
-    def test_safer_get_or_create(self):
+    def test_get_or_create_read_committed(self):
+        """Test get_or_create behavior.
+
+        This test originally tested our own `safer_get_or_create` method
+        but since we switched to using 'read committed' isolation level
+        Djangos builtin `get_or_create` works perfectly for us now.
+        """
         data = {'guid': '123', 'type': amo.ADDON_EXTENSION}
-        a, c = Addon.objects.safer_get_or_create(**data)
+        a, c = Addon.objects.get_or_create(**data)
         assert c
-        b, c = Addon.objects.safer_get_or_create(**data)
+        b, c = Addon.objects.get_or_create(**data)
         assert not c
         assert a == b
 

--- a/src/olympia/compat/cron.py
+++ b/src/olympia/compat/cron.py
@@ -90,7 +90,7 @@ def compatibility_report(index=None):
 
     total = sum(updates.values())
     # Remember the total so we can show % of usage later.
-    compat_total, created = CompatTotals.objects.safer_get_or_create(
+    compat_total, created = CompatTotals.objects.get_or_create(
         defaults={'total': total})
     if not created:
         compat_total.update(total=total)


### PR DESCRIPTION
Now that we are using the 'read committed' isolation level we can get
back to using Django's default get_or_create method.

Fixes #9222
