### PR TITLE
Allow 'application' field in collections to be blank

### DIFF
--- a/src/olympia/bandwagon/models.py
+++ b/src/olympia/bandwagon/models.py
@@ -107,7 +107,8 @@ class Collection(ModelBase):
 
     application = models.PositiveIntegerField(choices=amo.APPS_CHOICES,
                                               db_column='application_id',
-                                              null=True, db_index=True)
+                                              blank=True, null=True,
+                                              db_index=True)
     addon_count = models.PositiveIntegerField(default=0,
                                               db_column='addonCount')
 


### PR DESCRIPTION
It's already nullable, setting `blank=True` allows us to not consider that field as mandatory when editing through the django admin.

Fix #9236