### PR TITLE
Use "Firefox user" instead of "Anonymous user" when user doesn't have a display name (issue #9242)

### DIFF
--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -370,7 +370,7 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
         elif self.has_anonymous_username:
             # L10n: {id} will be something like "13ad6a", just a random number
             # to differentiate this user from other anonymous users.
-            return ugettext('Anonymous user {id}').format(
+            return ugettext('Firefox user {id}').format(
                 id=self._anonymous_username_id())
         else:
             return force_text(self.username)

--- a/src/olympia/users/tests/test_models.py
+++ b/src/olympia/users/tests/test_models.py
@@ -284,7 +284,7 @@ class TestUserProfile(TestCase):
     def test_welcome_name_anonymous(self):
         user = UserProfile(
             username='anonymous-bb4f3cbd422e504080e32f2d9bbfcee0')
-        assert user.welcome_name == 'Anonymous user bb4f3c'
+        assert user.welcome_name == 'Firefox user bb4f3c'
 
     def test_welcome_name_anonymous_with_display(self):
         user = UserProfile(display_name='John Connor')


### PR DESCRIPTION
Fixes #9242 

