### PR TITLE
Disable platform support submission (behind waffle flag).

### DIFF
--- a/src/olympia/devhub/forms.py
+++ b/src/olympia/devhub/forms.py
@@ -491,8 +491,14 @@ class NewUploadForm(forms.Form):
         self.version = kw.pop('version', None)
         super(NewUploadForm, self).__init__(*args, **kw)
 
+        show_supported_platforms = not waffle.switch_is_active(
+            'disallow-supported-platform-submission')
+
+        if not show_supported_platforms:
+            del self.fields['supported_platforms']
+
         # If we have a version reset platform choices to just those compatible.
-        if self.version:
+        if self.version and show_supported_platforms:
             platforms = self.fields['supported_platforms']
             compat_platforms = self.version.compatible_platforms().values()
             platforms.choices = sorted(

--- a/src/olympia/devhub/templates/devhub/addons/submit/upload.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/upload.html
@@ -52,13 +52,15 @@
 
   {{ new_addon_form.non_field_errors() }}
 
-    <div class="platform">
-      <div class="supported-platforms{% if not new_addon_form.supported_platforms.errors %} edit_initially_hidden{% endif %}">
-        <label>{{ _('Which platforms is this file compatible with?') }}</label>
-        {{ new_addon_form.supported_platforms.errors }}
-        {{ new_addon_form.supported_platforms }}
+    {% if 'supported_platforms' in new_addon_form.fields %}
+      <div class="platform">
+        <div class="supported-platforms{% if not new_addon_form.supported_platforms.errors %} edit_initially_hidden{% endif %}">
+          <label>{{ _('Which platforms is this file compatible with?') }}</label>
+          {{ new_addon_form.supported_platforms.errors }}
+          {{ new_addon_form.supported_platforms }}
+        </div>
       </div>
-    </div>
+    {% endif %}
 
     {% if is_admin %}
     <div class="admin-settings">

--- a/src/olympia/devhub/templates/devhub/addons/submit/wizard.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/wizard.html
@@ -83,9 +83,13 @@
       {% csrf_token %}
       <div class="hidden">
         {{ new_addon_form.upload }}
-        {{ new_addon_form.supported_platforms }}
+        {% if 'supported_platforms' in new_addon_form.fields %}
+          {{ new_addon_form.supported_platforms }}
+        {% endif %}
       </div>
-      {{ new_addon_form.supported_platforms.errors }}
+      {% if 'supported_platforms' in new_addon_form.fields %}
+        {{ new_addon_form.supported_platforms.errors }}
+      {% endif %}
       {{ new_addon_form.upload.errors }}
       {{ new_addon_form.non_field_errors() }}
       <ul class="errorlist validator">


### PR DESCRIPTION
This is a very naive implementation to simply disable submission of
separate platform files during add-on submission.

It doesn't do anything yet towards removing support for it, these would
be follow-up patches.

Fixes #8752