### PR TITLE
bump autograph version to 2.3.0 for travis CI and docker compose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ script:
   - |
     if [[ $TRAVIS_EVENT_TYPE != "cron" ]]; then
       if [[ $TOXENV == "amo-locales-and-signing" ]]; then
-         docker run --name autograph -d -p 5500:5500 -v $(pwd)/scripts/:/scripts/ mozilla/autograph:2.2.3 /go/bin/autograph -c /scripts/autograph_travis_test_config.yaml
+         docker run --name autograph -d -p 5500:5500 -v $(pwd)/scripts/:/scripts/ mozilla/autograph:2.3.0 /go/bin/autograph -c /scripts/autograph_travis_test_config.yaml
       fi
       RUNNING_IN_CI=True tox
     fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       - RABBITMQ_DEFAULT_VHOST=olympia
 
   autograph:
-    image: mozilla/autograph:2.0.5
+    image: mozilla/autograph:2.3.0
 
   selenium-firefox:
     <<: *env


### PR DESCRIPTION
refs: https://bugzilla.mozilla.org/show_bug.cgi?id=1471186 

We plan to switch to autograph's XPI `/sign/file` endpoint eventually. This PR updates to an autograph image with the latest XPI sign file code and kicks off CI to make sure that version isn't breaking AMO.
