### PR TITLE
Redirect new users to edit profile on stage and prod

### DIFF
--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -115,7 +115,6 @@ FXA_CONFIG = {
         'redirect_url':
             'https://addons.mozilla.org/api/v3/accounts/authenticate/',
         'scope': 'profile',
-        'skip_register_redirect': True,
     },
 }
 DEFAULT_FXA_CONFIG_NAME = 'default'

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -133,7 +133,6 @@ FXA_CONFIG = {
         'redirect_url':
             'https://addons.allizom.org/api/v3/accounts/authenticate/',
         'scope': 'profile',
-        'skip_register_redirect': True,
     },
     'local': {
         'client_id': env('DEVELOPMENT_FXA_CLIENT_ID'),


### PR DESCRIPTION
Taking inspiration from #8297, this is my attempt to fix https://github.com/mozilla/addons-frontend/issues/6100. It may be that the `skip_register_redirect` can be entirely removed at this point, which would be more work than this simple patch.