### PR TITLE
Upgrade use of MIDDLEWARE_CLASSES to newer MIDDLEWARE setting in django1.10+

### DIFF
--- a/src/olympia/access/middleware.py
+++ b/src/olympia/access/middleware.py
@@ -4,8 +4,9 @@ their ACLs into the request.
 """
 from functools import partial
 
-import olympia.core.logger
+from django.utils.deprecation import MiddlewareMixin
 
+import olympia.core.logger
 from olympia import core
 from olympia.access import acl
 
@@ -13,7 +14,7 @@ from olympia.access import acl
 log = olympia.core.logger.getLogger('z.access')
 
 
-class UserAndAddrMiddleware(object):
+class UserAndAddrMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
         """Attach authentication/permission helpers to request, and persist

--- a/src/olympia/amo/middleware.py
+++ b/src/olympia/amo/middleware.py
@@ -1,8 +1,3 @@
-"""
-Borrowed from: http://code.google.com/p/django-localeurl
-
-Note: didn't make sense to use localeurl since we need to capture app as well
-"""
 import contextlib
 import re
 import socket
@@ -19,10 +14,14 @@ from django.http import (
     JsonResponse)
 from django.middleware import common
 from django.utils.cache import patch_cache_control, patch_vary_headers
+from django.utils.deprecation import MiddlewareMixin
 from django.utils.encoding import force_bytes, iri_to_uri
 from django.utils.translation import activate, ugettext_lazy as _
 
 import MySQLdb as mysql
+from corsheaders.middleware import CorsMiddleware as _CorsMiddleware
+from multidb.middleware import (
+    PinningRouterMiddleware as _PinningRouterMiddleware)
 
 from olympia import amo
 from olympia.amo.utils import render
@@ -34,7 +33,7 @@ from .templatetags.jinja_helpers import urlparams
 auth_path = re.compile('%saccounts/authenticate/?$' % settings.DRF_API_REGEX)
 
 
-class LocaleAndAppURLMiddleware(object):
+class LocaleAndAppURLMiddleware(MiddlewareMixin):
     """
     1. search for locale first
     2. see if there are acceptable apps
@@ -149,7 +148,7 @@ class NoVarySessionMiddleware(SessionMiddleware):
         return new_response
 
 
-class RemoveSlashMiddleware(object):
+class RemoveSlashMiddleware(MiddlewareMixin):
     """
     Middleware that tries to remove a trailing slash if there was a 404.
 
@@ -195,7 +194,7 @@ class CommonMiddleware(common.CommonMiddleware):
             return super(CommonMiddleware, self).process_request(request)
 
 
-class ReadOnlyMiddleware(object):
+class ReadOnlyMiddleware(MiddlewareMixin):
     """Middleware that announces a downtime which for us usually means
     putting the site into read only mode.
 
@@ -246,7 +245,7 @@ class ReadOnlyMiddleware(object):
             return render(request, 'amo/read-only.html', status=503)
 
 
-class SetRemoteAddrFromForwardedFor(object):
+class SetRemoteAddrFromForwardedFor(MiddlewareMixin):
     """
     Set request.META['REMOTE_ADDR'] from request.META['HTTP_X_FORWARDED_FOR'].
 
@@ -283,7 +282,7 @@ class SetRemoteAddrFromForwardedFor(object):
                 break
 
 
-class ScrubRequestOnException(object):
+class ScrubRequestOnException(MiddlewareMixin):
     """
     Hide sensitive information so they're not recorded in error logging.
     * passwords in request.POST
@@ -305,7 +304,7 @@ class ScrubRequestOnException(object):
             request.META['HTTP_COOKIE'] = '******'
 
 
-class RequestIdMiddleware(object):
+class RequestIdMiddleware(MiddlewareMixin):
     """Middleware that adds a unique request-id to every incoming request.
 
     This can be used to track a request across different system layers,
@@ -324,3 +323,19 @@ class RequestIdMiddleware(object):
             response['X-AMO-Request-ID'] = request.request_id
 
         return response
+
+
+class PinningRouterMiddleware(_PinningRouterMiddleware, MiddlewareMixin):
+    """Wrapper to allow old style Middleware to work with django 1.10+.
+    Will be unneeded once
+    https://github.com/jbalogh/django-multidb-router/pull/41 is merged and a
+    new release of django-multidb-router is available."""
+    pass
+
+
+class CorsMiddleware(_CorsMiddleware, MiddlewareMixin):
+    """Wrapper to allow old style Middleware to work with django 1.10+.
+    Will be unneeded once
+    https://github.com/mstriemer/django-cors-headers/pull/3 is merged and a
+    new release of django-cors-headers-multi is available."""
+    pass

--- a/src/olympia/api/tests/test_middleware.py
+++ b/src/olympia/api/tests/test_middleware.py
@@ -54,7 +54,7 @@ class TestGzipMiddleware(TestCase):
         # Sadly, raven inserts 2 middlewares before, but luckily the ones it
         # automatically inserts not modify the response.
         assert (
-            settings.MIDDLEWARE_CLASSES[3] ==
+            settings.MIDDLEWARE[3] ==
             'olympia.api.middleware.GZipMiddlewareForAPIOnly')
 
     def test_api_endpoint_gzipped(self):

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -456,7 +456,7 @@ SECURE_HSTS_SECONDS = 31536000
 # to using `Port` if `X-Forwarded-Port` isn't set.
 USE_X_FORWARDED_PORT = True
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     # Test if it's an API request first so later middlewares don't need to.
     'olympia.api.middleware.IdentifyAPIRequestMiddleware',
     # Gzip (for API only) middleware needs to be executed after every
@@ -478,17 +478,13 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.security.SecurityMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 
-    'multidb.middleware.PinningRouterMiddleware',
+    'olympia.amo.middleware.PinningRouterMiddleware',
     'waffle.middleware.WaffleMiddleware',
 
     # CSP and CORS need to come before CommonMiddleware because they might
     # need to add headers to 304 responses returned by CommonMiddleware.
     'csp.middleware.CSPMiddleware',
-    'corsheaders.middleware.CorsMiddleware',
-
-    # This middleware does nothing, it's there for backwards-compatibility.
-    # Django < 1.10 checks for its presence to make session key rotation work.
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+    'olympia.amo.middleware.CorsMiddleware',
 
     # Enable conditional processing, e.g ETags.
     'django.middleware.http.ConditionalGetMiddleware',

--- a/src/olympia/search/middleware.py
+++ b/src/olympia/search/middleware.py
@@ -1,14 +1,15 @@
+from django.utils.deprecation import MiddlewareMixin
+
 from elasticsearch import TransportError
 
 import olympia.core.logger
-
 from olympia.amo.utils import render
 
 
 log = olympia.core.logger.getLogger('z.es')
 
 
-class ElasticsearchExceptionMiddleware(object):
+class ElasticsearchExceptionMiddleware(MiddlewareMixin):
 
     def process_exception(self, request, exception):
         if issubclass(exception.__class__, TransportError):


### PR DESCRIPTION
fixes #9275 

We should actually rewrite the classes at some point, but using `MiddlewareMixin` is what django seems to have done for it's own built-in midldeware classes so if it's good enough for them 😉 