### PR TITLE
Make current_version obey app & appversion param for langpacks, in add-on detail API

### DIFF
--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -144,6 +144,8 @@ This endpoint allows you to fetch a specific add-on by id, slug or guid.
 
     .. _addon-detail-object:
 
+    :query string app: Used in conjunction with ``appversion`` below to alter ``current_version`` behaviour. Need to be a valid :ref:`add-on application <addon-detail-application>`.
+    :query string appversion: Make ``current_version`` return the latest public version of the add-on compatible with the given application version, if possible, otherwise fall back on the generic implementation. Pass the full version as a string, e.g. ``46.0``. Only valid when the ``app`` parameter is also present. Currently only compatible with language packs through the add-on detail API, ignored for other types of add-ons and APIs.
     :query string lang: Activate translations in the specific language for that query. (See :ref:`Translated Fields <api-overview-translations>`)
     :query string wrap_outgoing_links: If this parameter is present, wrap outgoing links through ``outgoing.prod.mozaws.net`` (See :ref:`Outgoing Links <api-overview-outgoing>`)
     :>json int id: The add-on id on AMO.

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -855,7 +855,7 @@ class Addon(OnChangeMixin, ModelBase):
 
     @property
     def current_version(self):
-        """Return the latest public listed version of an addon
+        """Return the latest public listed version of an addon.
 
         If the add-on is not public, it can return a listed version awaiting
         review (since non-public add-ons should not have public versions).

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -2,7 +2,7 @@ import re
 
 from django.conf import settings
 
-from rest_framework import serializers
+from rest_framework import exceptions, serializers
 
 from olympia import amo
 from olympia.accounts.serializers import BaseUserSerializer
@@ -16,7 +16,8 @@ from olympia.constants.applications import APPS_ALL
 from olympia.constants.base import ADDON_TYPE_CHOICES_API
 from olympia.constants.categories import CATEGORIES_BY_ID
 from olympia.files.models import File
-from olympia.search.filters import AddonAppVersionQueryParam
+from olympia.search.filters import (
+    AddonAppQueryParam, AddonAppVersionQueryParam)
 from olympia.users.models import UserProfile
 from olympia.versions.models import (
     ApplicationsVersions, License, Version, VersionPreview)
@@ -211,6 +212,48 @@ class VersionSerializer(SimpleVersionSerializer):
                   'release_notes', 'reviewed', 'url', 'version')
 
 
+class CurrentVersionSerializer(SimpleVersionSerializer):
+    def to_representation(self, obj):
+        # If the add-on is a langpack, and `appversion` is passed, try to
+        # determine the latest public compatible version and replace the obj
+        # with the result. Because of the perf impact, only done for langpacks
+        # in the detail API.
+        request = self.context.get('request')
+        view = self.context.get('view')
+        addon = obj.addon
+        if (request and request.GET.get('appversion') and
+                getattr(view, 'action', None) == 'retrieve' and
+                addon.type == amo.ADDON_LPAPP):
+            obj = self.get_current_compatible_version(addon)
+        return super(CurrentVersionSerializer, self).to_representation(obj)
+
+    def get_current_compatible_version(self, addon):
+        """
+        Return latest public version compatible with the app & appversion
+        passed through the request, or fall back to addon.current_version if
+        none is found.
+
+        Only use on langpacks if the appversion parameter is present.
+        """
+        request = self.context.get('request')
+        try:
+            application = AddonAppQueryParam(request).get_value()
+        except ValueError:
+            raise exceptions.ParseError('Invalid or missing app parameter.')
+        try:
+            # AddonAppVersionQueryParam.get_values() returns (app_id, min, max)
+            # but we want {'min': min, 'max': max}.
+            appversions = dict(
+                zip(('min', 'max'),
+                    AddonAppVersionQueryParam(request).get_values()[1:]))
+        except ValueError:
+            raise exceptions.ParseError('Invalid appversion parameter.')
+
+        version_qs = Version.objects.latest_public_compatible_with(
+            application, appversions).filter(addon=addon)
+        return version_qs.first() or addon.current_version
+
+
 class AddonEulaPolicySerializer(serializers.ModelSerializer):
     eula = TranslationSerializerField()
     privacy_policy = TranslationSerializerField()
@@ -236,7 +279,7 @@ class AddonSerializer(serializers.ModelSerializer):
     authors = AddonDeveloperSerializer(many=True, source='listed_authors')
     categories = serializers.SerializerMethodField()
     contributions_url = serializers.URLField(source='contributions')
-    current_version = SimpleVersionSerializer()
+    current_version = CurrentVersionSerializer()
     description = TranslationSerializerField()
     developer_comments = TranslationSerializerField()
     edit_url = serializers.SerializerMethodField()

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -237,17 +237,13 @@ class CurrentVersionSerializer(SimpleVersionSerializer):
         """
         request = self.context.get('request')
         try:
-            application = AddonAppQueryParam(request).get_value()
-        except ValueError:
-            raise exceptions.ParseError('Invalid or missing app parameter.')
-        try:
             # AddonAppVersionQueryParam.get_values() returns (app_id, min, max)
             # but we want {'min': min, 'max': max}.
-            appversions = dict(
-                zip(('min', 'max'),
-                    AddonAppVersionQueryParam(request).get_values()[1:]))
-        except ValueError:
-            raise exceptions.ParseError('Invalid appversion parameter.')
+            value = AddonAppVersionQueryParam(request).get_values()
+            application = value[0]
+            appversions = dict(zip(('min', 'max'), value[1:]))
+        except ValueError as exc:
+            raise exceptions.ParseError(exc.message)
 
         version_qs = Version.objects.latest_public_compatible_with(
             application, appversions).filter(addon=addon)

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -16,8 +16,7 @@ from olympia.constants.applications import APPS_ALL
 from olympia.constants.base import ADDON_TYPE_CHOICES_API
 from olympia.constants.categories import CATEGORIES_BY_ID
 from olympia.files.models import File
-from olympia.search.filters import (
-    AddonAppQueryParam, AddonAppVersionQueryParam)
+from olympia.search.filters import AddonAppVersionQueryParam
 from olympia.users.models import UserProfile
 from olympia.versions.models import (
     ApplicationsVersions, License, Version, VersionPreview)

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -16,7 +16,8 @@ from olympia.addons.serializers import (
     LicenseSerializer, ReplacementAddonSerializer, SimpleVersionSerializer,
     VersionSerializer)
 from olympia.addons.utils import generate_addon_guid
-from olympia.addons.views import AddonAutoCompleteSearchView, AddonSearchView
+from olympia.addons.views import (
+    AddonAutoCompleteSearchView, AddonSearchView, AddonViewSet)
 from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.amo.tests import (
     ESTestCase, TestCase, addon_factory, collection_factory, file_factory,
@@ -667,12 +668,150 @@ class TestAddonSerializerOutput(AddonSerializerOutputTestMixin, TestCase):
     serializer_class = AddonSerializer
     serializer_class_with_unlisted_data = AddonSerializerWithUnlistedData
 
+    def setUp(self):
+        super(TestAddonSerializerOutput, self).setUp()
+        self.action = 'detail'
+
     def serialize(self):
-        self.serializer = self.serializer_class(
-            context={'request': self.request})
+        self.serializer = self.serializer_class(context={
+            'request': self.request,
+            'view': AddonViewSet(action=self.action)
+        })
         # Manually reload the add-on first to clear any cached properties.
         self.addon = Addon.unfiltered.get(pk=self.addon.pk)
         return self.serializer.to_representation(self.addon)
+
+    def test_langpack_current_version_with_appversion(self):
+        """Test for langpack current_version property when appversion param
+        is passed. Specific to the non-ES serializer, this option is only
+        available through the add-on detail API.
+        """
+        self.addon = addon_factory(
+            type=amo.ADDON_LPAPP, target_locale='es',
+            file_kw={'strict_compatibility': True},
+            version_kw={'min_app_version': '57.0', 'max_app_version': '57.*'})
+        self.addon.current_version.update(created=self.days_ago(2))
+        version_for_58 = version_factory(
+            addon=self.addon,
+            file_kw={'strict_compatibility': True},
+            min_app_version='58.0', max_app_version='58.*')
+        version_for_58.update(created=self.days_ago(1))
+        # Extra version for 59, should not be returned.
+        version_factory(
+            addon=self.addon,
+            file_kw={'strict_compatibility': True},
+            min_app_version='59.0', max_app_version='59.*')
+        self.request = APIRequestFactory().get('/?app=firefox&appversion=58.0')
+        self.action = 'retrieve'
+
+        result = self.serialize()
+        assert result['current_version']['id'] == version_for_58.pk
+        assert result['current_version']['compatibility'] == {
+            'firefox': {'max': u'58.*', 'min': u'58.0'}
+        }
+        assert result['current_version']['is_strict_compatibility_enabled']
+
+    def test_langpack_current_version_with_appversion_fallback(self):
+        """Like test_langpack_current_version_with_appversion() above, but
+        falling back to the current_version because no compatible version was
+        found."""
+        self.addon = addon_factory(
+            type=amo.ADDON_LPAPP, target_locale='es',
+            file_kw={'strict_compatibility': True},
+            version_kw={'min_app_version': '57.0', 'max_app_version': '57.*'})
+        self.addon.current_version.update(created=self.days_ago(2))
+        version_factory(
+            addon=self.addon,
+            file_kw={'strict_compatibility': True},
+            min_app_version='59.0', max_app_version='59.*')
+        self.request = APIRequestFactory().get('/?app=firefox&appversion=58.0')
+        self.action = 'retrieve'
+
+        result = self.serialize()
+        assert result['current_version']['id'] == self.addon.current_version.pk
+        assert result['current_version']['compatibility'] == {
+            'firefox': {'max': u'59.*', 'min': u'59.0'}
+        }
+        assert result['current_version']['is_strict_compatibility_enabled']
+
+    def test_langpack_current_version_without_parameters(self):
+        self.addon = addon_factory(
+            type=amo.ADDON_LPAPP, target_locale='es',
+            file_kw={'strict_compatibility': True},
+            version_kw={'min_app_version': '57.0', 'max_app_version': '57.*'})
+        self.addon.current_version.update(created=self.days_ago(2))
+        version_for_58 = version_factory(
+            addon=self.addon,
+            file_kw={'strict_compatibility': True},
+            min_app_version='58.0', max_app_version='58.*')
+        version_for_58.update(created=self.days_ago(1))
+        version_factory(
+            addon=self.addon,
+            file_kw={'strict_compatibility': True},
+            min_app_version='59.0', max_app_version='59.*')
+        # Regular detail action with no special parameters, we'll just return
+        # the current_version.
+        self.action = 'retrieve'
+
+        result = self.serialize()
+        assert result['current_version']['id'] == self.addon.current_version.pk
+        assert result['current_version']['compatibility'] == {
+            'firefox': {'max': u'59.*', 'min': u'59.0'}
+        }
+        assert result['current_version']['is_strict_compatibility_enabled']
+
+    def test_langpack_current_version_with_non_detail_action(self):
+        self.addon = addon_factory(
+            type=amo.ADDON_LPAPP, target_locale='es',
+            file_kw={'strict_compatibility': True},
+            version_kw={'min_app_version': '57.0', 'max_app_version': '57.*'})
+        self.addon.current_version.update(created=self.days_ago(2))
+        version_for_58 = version_factory(
+            addon=self.addon,
+            file_kw={'strict_compatibility': True},
+            min_app_version='58.0', max_app_version='58.*')
+        version_for_58.update(created=self.days_ago(1))
+        version_factory(
+            addon=self.addon,
+            file_kw={'strict_compatibility': True},
+            min_app_version='59.0', max_app_version='59.*')
+        # The parameters are going to be ignored, since we're not dealing with
+        # the detail API.
+        self.request = APIRequestFactory().get('/?app=firefox&appversion=58.0')
+        self.action = 'list'
+
+        result = self.serialize()
+        assert result['current_version']['id'] == self.addon.current_version.pk
+        assert result['current_version']['compatibility'] == {
+            'firefox': {'max': u'59.*', 'min': u'59.0'}
+        }
+        assert result['current_version']['is_strict_compatibility_enabled']
+
+    def test_app_and_appversion_parameters_on_non_langpack(self):
+        self.addon = addon_factory(
+            file_kw={'strict_compatibility': True},
+            version_kw={'min_app_version': '57.0', 'max_app_version': '57.*'})
+        self.addon.current_version.update(created=self.days_ago(2))
+        version_for_58 = version_factory(
+            addon=self.addon,
+            file_kw={'strict_compatibility': True},
+            min_app_version='58.0', max_app_version='58.*')
+        version_for_58.update(created=self.days_ago(1))
+        # Extra version for 59, should not be returned.
+        version_factory(
+            addon=self.addon,
+            file_kw={'strict_compatibility': True},
+            min_app_version='59.0', max_app_version='59.*')
+        # The parameters are going to be ignored since it's not a langpack.
+        self.request = APIRequestFactory().get('/?app=firefox&appversion=58.0')
+        self.action = 'retrieve'
+
+        result = self.serialize()
+        assert result['current_version']['id'] == self.addon.current_version.pk
+        assert result['current_version']['compatibility'] == {
+            'firefox': {'max': u'59.*', 'min': u'59.0'}
+        }
+        assert result['current_version']['is_strict_compatibility_enabled']
 
 
 class TestESAddonSerializerOutput(AddonSerializerOutputTestMixin, ESTestCase):
@@ -694,8 +833,10 @@ class TestESAddonSerializerOutput(AddonSerializerOutputTestMixin, ESTestCase):
         return qs.filter('term', id=self.addon.pk).execute()[0]
 
     def serialize(self):
-        self.serializer = self.serializer_class(
-            context={'request': self.request})
+        self.serializer = self.serializer_class(context={
+            'request': self.request,
+            'view': AddonSearchView(action='list')
+        })
 
         obj = self.search()
 

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -690,17 +690,32 @@ class TestAddonSerializerOutput(AddonSerializerOutputTestMixin, TestCase):
             type=amo.ADDON_LPAPP, target_locale='es',
             file_kw={'strict_compatibility': True},
             version_kw={'min_app_version': '57.0', 'max_app_version': '57.*'})
-        self.addon.current_version.update(created=self.days_ago(2))
+        self.addon.current_version.update(created=self.days_ago(3))
         version_for_58 = version_factory(
             addon=self.addon,
             file_kw={'strict_compatibility': True},
             min_app_version='58.0', max_app_version='58.*')
-        version_for_58.update(created=self.days_ago(1))
+        version_for_58.update(created=self.days_ago(2))
         # Extra version for 59, should not be returned.
         version_factory(
             addon=self.addon,
             file_kw={'strict_compatibility': True},
             min_app_version='59.0', max_app_version='59.*')
+        # Extra version that would be compatible and more recent, but belongs
+        # to a different add-on and should be ignored.
+        addon_factory(
+            type=amo.ADDON_LPAPP, target_locale='fr',
+            file_kw={'strict_compatibility': True},
+            version_kw={'min_app_version': '58.0', 'max_app_version': '58.*'})
+        # Extra version that would be compatible and more recent, but is not
+        # public.
+        not_public_version_for_58 = version_factory(
+            addon=self.addon,
+            file_kw={'strict_compatibility': True,
+                     'status': amo.STATUS_DISABLED},
+            min_app_version='58.0', max_app_version='58.*')
+        not_public_version_for_58.update(created=self.days_ago(1))
+
         self.request = APIRequestFactory().get('/?app=firefox&appversion=58.0')
         self.action = 'retrieve'
 

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -670,7 +670,7 @@ class TestAddonSerializerOutput(AddonSerializerOutputTestMixin, TestCase):
 
     def setUp(self):
         super(TestAddonSerializerOutput, self).setUp()
-        self.action = 'detail'
+        self.action = 'retrieve'
 
     def serialize(self):
         self.serializer = self.serializer_class(context={

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -1823,21 +1823,21 @@ class TestAddonViewSetDetail(AddonAndVersionViewSetDetailMixin, TestCase):
         response = self.client.get(self.url, {'appversion': '58.0'})
         assert response.status_code == 400
         data = json.loads(response.content)
-        assert data == {'detail': 'Invalid or missing app parameter.'}
+        assert data == {'detail': 'Invalid "app" parameter.'}
 
         # Invalid appversion
         response = self.client.get(
             self.url, {'appversion': 'fr', 'app': 'firefox'})
         assert response.status_code == 400
         data = json.loads(response.content)
-        assert data == {'detail': 'Invalid appversion parameter.'}
+        assert data == {'detail': 'Invalid "appversion" parameter.'}
 
         # Invalid app
         response = self.client.get(
             self.url, {'appversion': '58.0', 'app': 'fr'})
         assert response.status_code == 400
         data = json.loads(response.content)
-        assert data == {'detail': 'Invalid or missing app parameter.'}
+        assert data == {'detail': 'Invalid "app" parameter.'}
 
 
 class TestVersionViewSetDetail(AddonAndVersionViewSetDetailMixin, TestCase):

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -933,13 +933,10 @@ class LanguageToolsView(ListAPIView):
         # can avoid loading translations by removing transforms and then
         # re-applying the default one that takes care of the files and compat
         # info.
-        versions_qs = Version.objects.filter(
-            apps__application=application,
-            apps__min__version_int__lte=appversions['min'],
-            apps__max__version_int__gte=appversions['max'],
-            channel=amo.RELEASE_CHANNEL_LISTED,
-            files__status=amo.STATUS_PUBLIC,
-        ).order_by('-created').no_transforms().transform(Version.transformer)
+        versions_qs = (
+            Version.objects
+                   .latest_public_compatible_with(application, appversions)
+                   .no_transforms().transform(Version.transformer))
         return (
             qs.prefetch_related(Prefetch('versions',
                                          to_attr='compatible_versions',

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -60,6 +60,23 @@ class VersionManager(ManagerBase):
         return self.filter(
             files__status__in=amo.VALID_FILE_STATUSES).distinct()
 
+    def latest_public_compatible_with(self, application, appversions):
+        """Return a queryset filtering the versions so that they are public,
+        listed, and compatible with the application and appversions parameters
+        passed. The queryset is ordered by creation date descending, allowing
+        the caller to get the latest compatible version available.
+
+        application is an application id
+        appversions is a dict containing min and max values, as version ints.
+        """
+        return Version.objects.filter(
+            apps__application=application,
+            apps__min__version_int__lte=appversions['min'],
+            apps__max__version_int__gte=appversions['max'],
+            channel=amo.RELEASE_CHANNEL_LISTED,
+            files__status=amo.STATUS_PUBLIC,
+        ).order_by('-created')
+
 
 def source_upload_path(instance, filename):
     # At this point we already know that ext is one of VALID_SOURCE_EXTENSIONS

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -28,11 +28,115 @@ from olympia.files.utils import parse_addon
 from olympia.reviewers.models import (
     AutoApprovalSummary, ViewFullReviewQueue, ViewPendingQueue)
 from olympia.users.models import UserProfile
+from olympia.versions.compare import version_int
 from olympia.versions.models import (
     ApplicationsVersions, source_upload_path, Version, VersionPreview)
 
 
 pytestmark = pytest.mark.django_db
+
+
+class TestVersionManager(TestCase):
+    def test_latest_public_compatible_with(self):
+        # Add compatible add-ons. We're going to request versions compatible
+        # with 58.0.
+        compatible_pack1 = addon_factory(
+            name='Spanish Language Pack',
+            type=amo.ADDON_LPAPP, target_locale='es',
+            file_kw={'strict_compatibility': True},
+            version_kw={'min_app_version': '57.0', 'max_app_version': '57.*'})
+        compatible_pack1.current_version.update(created=self.days_ago(2))
+        compatible_version1 = version_factory(
+            addon=compatible_pack1, file_kw={'strict_compatibility': True},
+            min_app_version='58.0', max_app_version='58.*')
+        compatible_version1.update(created=self.days_ago(1))
+        compatible_pack2 = addon_factory(
+            name='French Language Pack',
+            type=amo.ADDON_LPAPP, target_locale='fr',
+            file_kw={'strict_compatibility': True},
+            version_kw={'min_app_version': '58.0', 'max_app_version': '58.*'})
+        compatible_version2 = compatible_pack2.current_version
+        compatible_version2.update(created=self.days_ago(2))
+        version_factory(
+            addon=compatible_pack2, file_kw={'strict_compatibility': True},
+            min_app_version='59.0', max_app_version='59.*')
+        # Add a more recent version for both add-ons, that would be compatible
+        # with 58.0, but is not public/listed so should not be returned.
+        version_factory(
+            addon=compatible_pack1, file_kw={'strict_compatibility': True},
+            min_app_version='58.0', max_app_version='58.*',
+            channel=amo.RELEASE_CHANNEL_UNLISTED)
+        version_factory(
+            addon=compatible_pack2,
+            file_kw={'strict_compatibility': True,
+                     'status': amo.STATUS_DISABLED},
+            min_app_version='58.0', max_app_version='58.*')
+        # And for the first pack, add a couple of versions that are also
+        # compatible. They are older so should appear after.
+        extra_compatible_version_1 = version_factory(
+            addon=compatible_pack1, file_kw={'strict_compatibility': True},
+            min_app_version='58.0', max_app_version='58.*')
+        extra_compatible_version_1.update(created=self.days_ago(3))
+        extra_compatible_version_2 = version_factory(
+            addon=compatible_pack1, file_kw={'strict_compatibility': True},
+            min_app_version='58.0', max_app_version='58.*')
+        extra_compatible_version_2.update(created=self.days_ago(4))
+
+        # Add a few of incompatible add-ons.
+        incompatible_pack1 = addon_factory(
+            name='German Language Pack (incompatible with 58.0)',
+            type=amo.ADDON_LPAPP, target_locale='fr',
+            file_kw={'strict_compatibility': True},
+            version_kw={'min_app_version': '56.0', 'max_app_version': '56.*'})
+        version_factory(
+            addon=incompatible_pack1, file_kw={'strict_compatibility': True},
+            min_app_version='59.0', max_app_version='59.*')
+        addon_factory(
+            name='Italian Language Pack (incompatible with 58.0)',
+            type=amo.ADDON_LPAPP, target_locale='it',
+            file_kw={'strict_compatibility': True},
+            version_kw={'min_app_version': '59.0', 'max_app_version': '59.*'})
+        addon_factory(
+            name='Thunderbird Polish Language Pack',
+            type=amo.ADDON_LPAPP, target_locale='pl',
+            file_kw={'strict_compatibility': True},
+            version_kw={
+                'application': amo.THUNDERBIRD.id,
+                'min_app_version': '58.0', 'max_app_version': '58.*'})
+        # Even add a pack with a compatible version... not public. And another
+        # one with a compatible version... not listed.
+        incompatible_pack2 = addon_factory(
+            name='Japanese Language Pack (public, but 58.0 version is not)',
+            type=amo.ADDON_LPAPP, target_locale='ja',
+            file_kw={'strict_compatibility': True},
+            version_kw={'min_app_version': '57.0', 'max_app_version': '57.*'})
+        version_factory(
+            addon=incompatible_pack2,
+            min_app_version='58.0', max_app_version='58.*',
+            file_kw={'status': amo.STATUS_AWAITING_REVIEW,
+                     'strict_compatibility': True})
+        incompatible_pack3 = addon_factory(
+            name='Nederlands Language Pack (58.0 version is unlisted)',
+            type=amo.ADDON_LPAPP, target_locale='ja',
+            file_kw={'strict_compatibility': True},
+            version_kw={'min_app_version': '57.0', 'max_app_version': '57.*'})
+        version_factory(
+            addon=incompatible_pack3,
+            min_app_version='58.0', max_app_version='58.*',
+            channel=amo.RELEASE_CHANNEL_UNLISTED,
+            file_kw={'strict_compatibility': True})
+
+        appversions = {
+            'min': version_int('58.0'),
+            'max': version_int('58.0a'),
+        }
+        qs = Version.objects.latest_public_compatible_with(
+            amo.FIREFOX.id, appversions)
+
+        expected_versions = [
+            compatible_version1, compatible_version2,
+            extra_compatible_version_1, extra_compatible_version_2]
+        assert list(qs) == expected_versions
 
 
 class TestVersion(TestCase):


### PR DESCRIPTION
Only for langpacks and only in the add-on detail API, overwrite the `current_version` property we return by the latest public version compatible with what is passed in the app and appversion parameters, if both are present.

Fix #8180 (at least the API side of things)