### PR TITLE
Add margin before separator line on 2nd page of theme wizard

### DIFF
--- a/static/css/devhub/submission.less
+++ b/static/css/devhub/submission.less
@@ -72,10 +72,14 @@ ol.submit-addon-progress.unlisted {
 
 .submit-buttons,
 #agreement-buttons,
-.addon-submission-process .submission-buttons{
+.addon-submission-process .submission-buttons {
     border-top: 1px dotted #A4CFDE;
     margin-bottom: 0;
     padding-top: .8em;
+}
+
+.addon-submission-process #persona-license {
+    margin-bottom: 1em;
 }
 
 div.done-next-steps {


### PR DESCRIPTION
Fixes #7957.

*Before:*
![image](https://user-images.githubusercontent.com/3002987/44945545-07d3ac80-adec-11e8-94df-070c1d114fb7.png)

*After:*
![image](https://user-images.githubusercontent.com/3002987/44945543-fd191780-adeb-11e8-90b7-b2b07f05b154.png)
