### PR TITLE
Add @mozilla.com to the list of add-on guids restricted to mozilla users

### DIFF
--- a/src/olympia/constants/base.py
+++ b/src/olympia/constants/base.py
@@ -450,7 +450,8 @@ ADDON_GUID_PATTERN = re.compile(
     r'|[a-z0-9-\._]*\@[a-z0-9-\._]+)$', re.IGNORECASE)
 
 SYSTEM_ADDON_GUIDS = (
-    u'@mozilla.org', u'@shield.mozilla.org', u'@pioneer.mozilla.org')
+    u'@mozilla.org', u'@shield.mozilla.org', u'@pioneer.mozilla.org',
+    u'@mozilla.com')
 
 MOZILLA_TRADEMARK_SYMBOLS = (
     'mozilla', 'firefox')

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -1208,7 +1208,7 @@ class TestUploadDetail(BaseUploadTest):
             {u'tier': 1,
              u'message': u'You cannot submit an add-on with a guid ending '
                          u'"@mozilla.org" or "@shield.mozilla.org" or '
-                         u'"@pioneer.mozilla.org"',
+                         u'"@pioneer.mozilla.org" or "@mozilla.com"',
              u'fatal': True, u'type': u'error'}]
 
     @mock.patch('olympia.devhub.tasks.run_validator')

--- a/src/olympia/signing/tests/test_views.py
+++ b/src/olympia/signing/tests/test_views.py
@@ -307,7 +307,7 @@ class TestUploadVersion(BaseUploadVersionCase):
         self.auto_sign_version.assert_called_with(latest_version)
 
     def test_system_addon_not_allowed_not_mozilla(self):
-        guid = 'systemaddon@mozilla.org'
+        guid = 'systemaddon@mozilla.com'
         self.user.update(email='yellowpanda@notzilla.com')
         qs = Addon.unfiltered.filter(guid=guid)
         assert not qs.exists()
@@ -319,7 +319,8 @@ class TestUploadVersion(BaseUploadVersionCase):
         assert response.status_code == 400
         assert response.data['error'] == (
             u'You cannot submit an add-on with a guid ending "@mozilla.org" '
-            u'or "@shield.mozilla.org" or "@pioneer.mozilla.org"')
+            u'or "@shield.mozilla.org" or "@pioneer.mozilla.org" '
+            u'or "@mozilla.com"')
 
     def test_system_addon_update_allowed(self):
         """Updates to system addons are allowed from anyone."""

--- a/src/olympia/users/tests/test_user_utils.py
+++ b/src/olympia/users/tests/test_user_utils.py
@@ -57,7 +57,8 @@ class TestAutoCreateUsername(TestCase):
 
 
 system_guids = pytest.mark.parametrize('guid', [
-    'foo@mozilla.org', 'baa@shield.mozilla.org', 'moo@pioneer.mozilla.org'])
+    u'foø@mozilla.org', u'baa@shield.mozilla.org', u'moo@pioneer.mozilla.org',
+    u'blâh@mozilla.com'])
 
 
 @system_guids


### PR DESCRIPTION
Fix #9278