### PR TITLE
Add Addon submission reporting to Akismet

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -625,6 +625,12 @@ class Addon(OnChangeMixin, ModelBase):
         This returns a modified `data` dictionary accordingly with proper
         translations filled in.
         """
+        # If we've already done this then data[xxx] will be dict already.
+        fields = ('name', 'homepage', 'summary')
+        if any((isinstance(data.get(field, None), dict) for field in fields)):
+            # If so not only redundant but also will break resolve_i18n_message
+            return data
+
         default_locale = find_language(data.get('default_locale'))
 
         if not data.get('is_webextension') or not default_locale:
@@ -634,7 +640,6 @@ class Addon(OnChangeMixin, ModelBase):
         # find_language might have expanded short to full locale, so update it.
         data['default_locale'] = default_locale
 
-        fields = ('name', 'homepage', 'summary')
         messages = extract_translations(upload)
 
         for field in fields:

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -2577,6 +2577,31 @@ class TestAddonFromUpload(UploadTest):
         # Normalized from `en` to `en-US`
         assert addon.default_locale == 'en-US'
 
+    @patch('olympia.addons.models.extract_translations')
+    def test_webext_resolve_translations_doesnt_run_twice(self, extract_mock):
+        """If we've already resolved translations to dicts, don't do it again.
+        """
+        parsed_data = {
+            'default_locale': u'sv',
+            'e10s_compatibility': 2,
+            'guid': u'notify-link-clicks-i18n@notzilla.org',
+            'name': {'en-US': u'foo-de-baa', 'sv-SE': u'fóó'},
+            'is_webextension': True,
+            'type': 1,
+            'apps': [],
+            'summary': {'en-US': u'summary', 'sv-SE': u'súmmáry'},
+            'version': u'1.0',
+            'homepage': '...'
+        }
+
+        addon = Addon.from_upload(
+            self.get_upload('notify-link-clicks-i18n.xpi'),
+            [self.platform], parsed_data=parsed_data)
+        extract_mock.assert_not_called()
+
+        assert addon.name == u'foo-de-baa'
+        assert addon.summary == u'summary'
+
 
 REDIRECT_URL = 'https://outgoing.prod.mozaws.net/v1/'
 

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -1329,7 +1329,8 @@ def _submit_upload(request, addon, channel, next_view, version=None,
         request.FILES or None,
         addon=addon,
         version=version,
-        request=request
+        request=request,
+        channel=channel,
     )
     if request.method == 'POST' and form.is_valid():
         data = form.cleaned_data

--- a/src/olympia/lib/akismet/tests.py
+++ b/src/olympia/lib/akismet/tests.py
@@ -21,55 +21,13 @@ from .models import AkismetReport
 from .tasks import submit_to_akismet
 
 
-class TestAkismetReportsModel(TestCase):
+class BaseAkismetReportsModelTest(object):
 
-    def test_create_for_rating(self):
-        user = user_factory(homepage='https://spam.spam/')
-        addon = addon_factory()
-        rating = Rating.objects.create(
-            addon=addon, user=user, rating=4, body='spám?',
-            ip_address='1.23.45.67')
-        ua = 'foo/baa'
-        referrer = 'https://mozilla.org/'
-        report = AkismetReport.create_for_rating(rating, ua, referrer)
-
-        assert report.rating_instance == rating
-        data = report._get_data()
-        assert data == {
-            'blog': settings.SITE_URL,
-            'user_ip': rating.ip_address,
-            'user_agent': ua,
-            'referrer': referrer,
-            'permalink': addon.get_url_path(),
-            'comment_type': 'user-review',
-            'comment_author': user.username,
-            'comment_author_email': user.email,
-            'comment_author_url': user.homepage,
-            'comment_content': rating.body,
-            'comment_date_gmt': rating.modified,
-            'comment_post_modified_gmt': addon.last_updated,
-            'blog_charset': 'utf-8',
-            'is_test': not settings.AKISMET_REAL_SUBMIT,
-        }
+    def test_create(self):
+        raise NotImplementedError()
 
     def _create_report(self, kws=None):
-        defaults = dict(
-            comment_type='user-review',
-            user_ip='9.8.7.6.5',
-            user_agent='Agent Bond',
-            referrer='á4565',
-            user_name='steve',
-            user_email='steve@steve.com',
-            user_homepage='http://spam.spam',
-            content_link='https://addons.mozilla.org',
-            content_modified=datetime.now(),
-            comment='spammy McSpam?',
-            comment_modified=datetime.now(),
-        )
-        if kws:
-            defaults.update(**kws)
-        instance = AkismetReport.objects.create(**defaults)
-        return instance
+        raise NotImplementedError()
 
     @responses.activate
     @override_settings(AKISMET_API_KEY=None)
@@ -90,29 +48,27 @@ class TestAkismetReportsModel(TestCase):
         responses.add(
             responses.POST, url, body='foo')
 
+        statsd_str = 'services.akismet.comment_check.%s' % report.comment_type
+
         with mock.patch('olympia.lib.akismet.models.statsd.incr') as incr_mock:
             result = report.comment_check()
             assert result == report.result == AkismetReport.MAYBE_SPAM
-            incr_mock.assert_called_with(
-                'services.akismet.comment_check.user-review.maybespam')
+            incr_mock.assert_called_with(statsd_str + '.maybespam')
 
         with mock.patch('olympia.lib.akismet.models.statsd.incr') as incr_mock:
             result = report.comment_check()
             assert result == report.result == AkismetReport.DEFINITE_SPAM
-            incr_mock.assert_called_with(
-                'services.akismet.comment_check.user-review.definitespam')
+            incr_mock.assert_called_with(statsd_str + '.definitespam')
 
         with mock.patch('olympia.lib.akismet.models.statsd.incr') as incr_mock:
             result = report.comment_check()
             assert result == report.result == AkismetReport.HAM
-            incr_mock.assert_called_with(
-                'services.akismet.comment_check.user-review.ham')
+            incr_mock.assert_called_with(statsd_str + '.ham')
 
         with mock.patch('olympia.lib.akismet.models.statsd.incr') as incr_mock:
             result = report.comment_check()
             assert result == report.result == AkismetReport.UNKNOWN
-            incr_mock.assert_called_with(
-                'services.akismet.comment_check.user-review.fail')
+            incr_mock.assert_called_with(statsd_str + '.fail')
 
     @responses.activate
     @override_settings(AKISMET_API_KEY=None)
@@ -173,6 +129,104 @@ class TestAkismetReportsModel(TestCase):
 
         report.update(reported=False)
         assert not report.submit_ham()
+
+
+class TestAkismetReportsRating(BaseAkismetReportsModelTest, TestCase):
+
+    def test_create(self):
+        user = user_factory(homepage='https://spam.spam/')
+        addon = addon_factory()
+        rating = Rating.objects.create(
+            addon=addon, user=user, rating=4, body='spám?',
+            ip_address='1.23.45.67')
+        ua = 'foo/baa'
+        referrer = 'https://mozilla.org/'
+        report = AkismetReport.create_for_rating(rating, ua, referrer)
+
+        assert report.rating_instance == rating
+        assert report.user == user
+        data = report._get_data()
+        assert data == {
+            'blog': settings.SITE_URL,
+            'user_ip': rating.ip_address,
+            'user_agent': ua,
+            'referrer': referrer,
+            'permalink': addon.get_url_path(),
+            'comment_type': 'user-review',
+            'comment_author': user.username,
+            'comment_author_email': user.email,
+            'comment_author_url': user.homepage,
+            'comment_content': rating.body,
+            'comment_date_gmt': rating.modified,
+            'comment_post_modified_gmt': addon.last_updated,
+            'blog_charset': 'utf-8',
+            'is_test': not settings.AKISMET_REAL_SUBMIT,
+        }
+
+    def _create_report(self, kws=None):
+        defaults = dict(
+            comment_type='user-review',
+            user_ip='9.8.7.6.5',
+            user_agent='Agent Bond',
+            referrer='á4565',
+            user_name='steve',
+            user_email='steve@steve.com',
+            user_homepage='http://spam.spam',
+            content_link='https://addons.mozilla.org',
+            content_modified=datetime.now(),
+            comment='spammy McSpam?',
+            comment_modified=datetime.now(),
+        )
+        if kws:
+            defaults.update(**kws)
+        instance = AkismetReport.objects.create(**defaults)
+        return instance
+
+
+class TestAkismetReportsAddon(BaseAkismetReportsModelTest, TestCase):
+
+    def test_create(self):
+        user = user_factory(homepage='https://spam.spam/')
+        addon = addon_factory(name=u'100% génuine spamm')
+        ua = 'foo/baa'
+        referrer = 'https://mozilla.org/'
+        report = AkismetReport.create_for_addon(
+            addon, user, 'name', addon.name, ua, referrer)
+
+        assert report.addon_instance == addon
+        assert report.user == user
+        data = report._get_data()
+        assert data == {
+            'blog': settings.SITE_URL,
+            'user_ip': user.last_login_ip,
+            'user_agent': ua,
+            'referrer': referrer,
+            'comment_type': 'product-name',
+            'comment_author': user.username,
+            'comment_author_email': user.email,
+            'comment_author_url': user.homepage,
+            'comment_content': unicode(addon.name),
+            'comment_date_gmt': addon.modified,
+            'blog_charset': 'utf-8',
+            'is_test': not settings.AKISMET_REAL_SUBMIT,
+        }
+
+    def _create_report(self, kws=None):
+        defaults = dict(
+            comment_type='product-summary',
+            user_ip='9.8.7.6.5',
+            user_agent='Agent Bond',
+            referrer='á4565',
+            user_name='steve',
+            user_email='steve@steve.com',
+            user_homepage='http://spam.spam',
+            comment='spammy McSpam?',
+            comment_modified=datetime.now(),
+        )
+        if kws:
+            defaults.update(**kws)
+        instance = AkismetReport.objects.create(**defaults)
+        return instance
 
 
 class TestAkismetAdmin(TestCase):

--- a/src/olympia/migrations/1046-akismet-reports-addon-and-collection-fks.sql
+++ b/src/olympia/migrations/1046-akismet-reports-addon-and-collection-fks.sql
@@ -1,0 +1,13 @@
+ALTER TABLE `akismet_reports`
+  MODIFY `content_link` varchar(255) DEFAULT NULL,
+  MODIFY `content_modified` datetime(6) DEFAULT NULL,
+  ADD COLUMN `user_id` int(11) unsigned DEFAULT NULL,
+  ADD COLUMN `addon_instance_id` int(11) unsigned DEFAULT NULL,
+  ADD COLUMN`collection_instance_id` int(11) unsigned DEFAULT NULL,
+  ADD KEY `akismet_reports_user_id_fk_users_id` (`user_id`),
+  ADD CONSTRAINT `akismet_reports_user_id_fk_users_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+  ADD KEY `akismet_reports_addon_instance_id_fk_addons_id` (`addon_instance_id`),
+  ADD CONSTRAINT `akismet_reports_addon_instance_id_fk_addons_id` FOREIGN KEY (`addon_instance_id`) REFERENCES `addons` (`id`),
+  ADD KEY `akismet_reports_collection_instance_id_fk_collections_id` (`collection_instance_id`),
+  ADD CONSTRAINT `akismet_reports_collection_instance_id_fk_collections_id` FOREIGN KEY (`collection_instance_id`) REFERENCES `collections` (`id`)
+;


### PR DESCRIPTION
First part of #8704 - any new addon or version will be spam checked with Akismet. Second part will be handling post submission edits (both in the update flow, i.e. details step, and in edit listing afterwards).  This patch was already getting to an unmanageable size so thought I'd submit this part first.