### PR TITLE
Handle JWTs created with broken iat/exp type (string containing an int)

### DIFF
--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -30,7 +30,7 @@ from olympia.amo.tests import (
     reverse_ns, user_factory)
 from olympia.amo.tests.test_helpers import get_uploaded_file
 from olympia.api.authentication import WebTokenAuthentication
-from olympia.api.tests.utils import APIKeyAuthTestCase
+from olympia.api.tests.utils import APIKeyAuthTestMixin
 from olympia.users.models import UserNotification, UserProfile
 from olympia.users.notifications import (
     NOTIFICATIONS_BY_ID, REMOTE_NOTIFICATIONS_BY_BASKET_ID)
@@ -897,7 +897,7 @@ class TestAccountViewSet(TestCase):
             self.random_user.get_url_path())
 
 
-class TestProfileViewWithJWT(APIKeyAuthTestCase):
+class TestProfileViewWithJWT(APIKeyAuthTestMixin, TestCase):
     """This just tests JWT Auth (external) on the profile endpoint.
 
     See TestAccountViewSet for internal auth test.
@@ -1172,7 +1172,7 @@ class TestAccountViewSetDelete(TestCase):
         assert self.user.reload().deleted
 
 
-class TestAccountSuperCreate(APIKeyAuthTestCase):
+class TestAccountSuperCreate(APIKeyAuthTestMixin, TestCase):
 
     def setUp(self):
         super(TestAccountSuperCreate, self).setUp()

--- a/src/olympia/api/authentication.py
+++ b/src/olympia/api/authentication.py
@@ -181,6 +181,9 @@ class JWTKeyAuthentication(JSONWebTokenAuthentication):
                          'it raised %s (%s)', exc.__class__.__name__, exc)
                 # Re-raise to deal with them properly.
                 raise exc
+            except TypeError:
+                msg = ugettext('Wrong type for one or more keys in payload')
+                raise exceptions.AuthenticationFailed(msg)
             except jwt.ExpiredSignature:
                 msg = ugettext('Signature has expired.')
                 raise exceptions.AuthenticationFailed(msg)

--- a/src/olympia/api/tests/test_jwt_auth.py
+++ b/src/olympia/api/tests/test_jwt_auth.py
@@ -13,7 +13,7 @@ from olympia.api.models import SYMMETRIC_JWT_TYPE, APIKey
 from olympia.users.models import UserProfile
 
 
-class JWTAuthKeyTester(TestCase):
+class JWTAuthKeyTester(object):
 
     def create_api_key(self, user, key='some-user-key', is_active=True,
                        secret='some-shared-secret', **kw):
@@ -21,7 +21,7 @@ class JWTAuthKeyTester(TestCase):
                                      user=user, key=key, secret=secret,
                                      is_active=is_active, **kw)
 
-    def auth_token_payload(self, user, issuer):
+    def auth_token_payload(self, user, issuer, issued_at=None):
         """Creates a JWT payload as a client would."""
         issued_at = datetime.utcnow()
         return {
@@ -42,7 +42,7 @@ class JWTAuthKeyTester(TestCase):
         return self.encode_token_payload(payload, secret)
 
 
-class TestJWTKeyAuthDecodeHandler(JWTAuthKeyTester):
+class TestJWTKeyAuthDecodeHandler(JWTAuthKeyTester, TestCase):
     fixtures = ['base/addon_3615']
 
     def setUp(self):

--- a/src/olympia/api/tests/utils.py
+++ b/src/olympia/api/tests/utils.py
@@ -7,7 +7,7 @@ from olympia.api.tests.test_jwt_auth import JWTAuthKeyTester
 from olympia.users.models import UserProfile
 
 
-class APIKeyAuthTestCase(APITestCase, JWTAuthKeyTester):
+class APIKeyAuthTestMixin(APITestCase, JWTAuthKeyTester):
 
     def create_api_user(self):
         self.user = UserProfile.objects.create(


### PR DESCRIPTION
Fix #6862