### PR TITLE
deploy prod_py2.txt instead of prod.txt

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -71,7 +71,7 @@ WORKDIR /data/olympia
 
 # Install all python requires
 RUN pip install --no-cache-dir --exists-action=w --no-deps -r requirements/system.txt              \
-    && pip install --no-cache-dir --exists-action=w --no-deps -r requirements/prod.txt             \
+    && pip install --no-cache-dir --exists-action=w --no-deps -r requirements/prod_py2.txt         \
     && pip install --no-cache-dir --exists-action=w --no-deps -e .
 
 # Link /usr/sbin/uwsgi and /usr/bin/uwsgi to deal with migration from Centos -> Debian

--- a/circle.yml
+++ b/circle.yml
@@ -74,7 +74,8 @@ jobs:
       - restore_cache:
           keys:
             - uitest-cache-{{ checksum "requirements/docs.txt" }}
-            - uitest-cache-{{ checksum "requirements/prod.txt" }}
+            - uitest-cache-{{ checksum "requirements/prod_py2.txt" }}
+            - uitest-cache-{{ checksum "requirements/tests.txt" }}
             - uitest-cache-{{ checksum "requirements/dev.txt" }}
             - uitest-cache-{{ checksum "requirements/uitests.txt" }}
             - uitest-cache-
@@ -116,7 +117,11 @@ jobs:
           paths:
             - .tox
       - save_cache:
-          key: uitest-cache-{{ checksum "requirements/prod.txt" }}
+          key: uitest-cache-{{ checksum "requirements/prod_py2.txt" }}
+          paths:
+            - .tox
+      - save_cache:
+          key: uitest-cache-{{ checksum "requirements/tests.txt" }}
           paths:
             - .tox
       - save_cache:


### PR DESCRIPTION
fixes a regression from #9345 - `prod.txt` got renamed and in the aim of simplification some of the requirement files includes were removed.