### PR TITLE
Making e-mail restrictions case insensitive

### DIFF
--- a/src/olympia/users/tests/test_user_utils.py
+++ b/src/olympia/users/tests/test_user_utils.py
@@ -58,7 +58,8 @@ class TestAutoCreateUsername(TestCase):
 
 system_guids = pytest.mark.parametrize('guid', [
     u'foø@mozilla.org', u'baa@shield.mozilla.org', u'moo@pioneer.mozilla.org',
-    u'blâh@mozilla.com'])
+    u'blâh@mozilla.com', u'foø@Mozilla.Org', u'baa@ShielD.MozillA.OrG',
+    u'moo@PIONEER.mozilla.org', u'blâh@MOZILLA.COM'])
 
 
 @system_guids

--- a/src/olympia/users/utils.py
+++ b/src/olympia/users/utils.py
@@ -87,9 +87,9 @@ def autocreate_username(candidate, tries=1):
 
 
 def system_addon_submission_allowed(user, parsed_addon_data):
-    guid = parsed_addon_data.get('guid').lower() or ''
+    guid = parsed_addon_data.get('guid') or ''
     return (
-        not guid.endswith(amo.SYSTEM_ADDON_GUIDS) or
+        not guid.lower().endswith(amo.SYSTEM_ADDON_GUIDS) or
         user.email.endswith(u'@mozilla.com'))
 
 

--- a/src/olympia/users/utils.py
+++ b/src/olympia/users/utils.py
@@ -87,7 +87,7 @@ def autocreate_username(candidate, tries=1):
 
 
 def system_addon_submission_allowed(user, parsed_addon_data):
-    guid = parsed_addon_data.get('guid') or ''
+    guid = parsed_addon_data.get('guid').lower() or ''
     return (
         not guid.endswith(amo.SYSTEM_ADDON_GUIDS) or
         user.email.endswith(u'@mozilla.com'))


### PR DESCRIPTION
Fixes #9425 

I made the assumption that GUID will have ASCII values since the `lower()` function seems to break for some Greek characters.