### PR TITLE
Add an explicit id when migrating dictionaries to webextension format

### DIFF
--- a/src/olympia/addons/tests/test_utils_.py
+++ b/src/olympia/addons/tests/test_utils_.py
@@ -295,6 +295,9 @@ class TestBuildWebextDictionaryFromLegacy(AMOPaths, TestCase):
             # dictionaries properties.
             manifest = xpi.read('manifest.json')
             manifest_json = json.loads(manifest)
+            assert (
+                manifest_json['applications']['gecko']['id'] ==
+                self.addon.guid)
             assert manifest_json['version'] == expected_version
             expected_dict_obj = {'ar': 'dictionaries/ar.dic'}
             assert manifest_json['dictionaries'] == expected_dict_obj

--- a/src/olympia/addons/utils.py
+++ b/src/olympia/addons/utils.py
@@ -277,6 +277,11 @@ def build_webext_dictionary_from_legacy(addon, destination):
         manifest = {
             'manifest_version': 2,
             'name': unicode(addon.name),
+            'applications': {
+                'gecko': {
+                    'id': addon.guid,
+                },
+            },
             'version': version_number,
             'dictionaries': {target_language: dictionary_path},
         }


### PR DESCRIPTION
Fix #9460