### PR TITLE
Copy file to current_file_path when uploading instead file_path

### DIFF
--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -750,9 +750,7 @@ def file_factory(**kw):
         filename)
 
     if os.path.exists(fixture_path):
-        copy_stored_file(
-            fixture_path,
-            os.path.join(version.path_prefix, file_.filename))
+        copy_stored_file(fixture_path, file_.current_file_path)
 
     return file_
 

--- a/src/olympia/files/models.py
+++ b/src/olympia/files/models.py
@@ -197,9 +197,7 @@ class File(OnChangeMixin, ModelBase):
 
         log.debug('New file: %r from %r' % (file_, upload))
         # Move the uploaded file from the temp location.
-        copy_stored_file(
-            upload.path,
-            os.path.join(version.path_prefix, nfd_str(file_.filename)))
+        copy_stored_file(upload.path, file_.current_file_path)
 
         if upload.validation:
             FileValidation.from_json(file_, validation)

--- a/src/olympia/files/tests/test_models.py
+++ b/src/olympia/files/tests/test_models.py
@@ -1371,6 +1371,25 @@ class TestFileFromUpload(UploadTest):
         assert permissions_list[5:8] == [x for y in [
             cs['matches'] for cs in parsed_data['content_scripts']] for x in y]
 
+    def test_file_is_copied_to_current_path_at_upload(self):
+        upload = self.upload('webextension')
+        file_ = File.from_upload(
+            upload, self.version, self.platform,
+            parsed_data={'is_webextension': True})
+        assert os.path.exists(file_.file_path)
+        assert not os.path.exists(file_.guarded_file_path)
+        assert os.path.exists(file_.current_file_path)
+
+    def test_file_is_copied_to_current_path_at_upload_if_disabled(self):
+        self.addon.update(disabled_by_user=True)
+        upload = self.upload('webextension')
+        file_ = File.from_upload(
+            upload, self.version, self.platform,
+            parsed_data={'is_webextension': True})
+        assert not os.path.exists(file_.file_path)
+        assert os.path.exists(file_.guarded_file_path)
+        assert os.path.exists(file_.current_file_path)
+
 
 class TestZip(TestCase, amo.tests.AMOPaths):
 

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -273,10 +273,6 @@ class Version(OnChangeMixin, ModelBase):
 
         return version
 
-    @property
-    def path_prefix(self):
-        return os.path.join(user_media_path('addons'), str(self.addon_id))
-
     def license_url(self, impala=False):
         return reverse('addons.license', args=[self.addon.slug, self.version])
 


### PR DESCRIPTION
For "invisible" add-ons, the correct path to upload the file to is actually `guarded_file_path` and not `file_path`, that was causing uploads for disabled add-ons to result in a 404. This matters for uploads of unlisted versions, which can be uploaded while the add-on is in that state.

Hopefully fixes mozilla/addons/issues/324 (without having to implement full separate storage for unlisted add-ons, which is a more complex issue)