### PR TITLE
Expose `current_version.is_strict_compatibility_enabled` in discovery API

### DIFF
--- a/docs/topics/api/discovery.rst
+++ b/docs/topics/api/discovery.rst
@@ -26,7 +26,7 @@ Firefox (about:addons).
     :>json string results[].heading: The heading for this item. May contain some HTML tags.
     :>json string|null results[].description: The description for this item, if any. May contain some HTML tags.
     :>json boolean results[].is_recommendation: If this item was from the recommendation service, rather than static curated content.
-    :>json object results[].addon: The :ref:`add-on <addon-detail-object>` for this item. Only a subset of fields are present: ``id``, ``current_version`` (with only the ``compatibility`` and ``files`` fields present), ``guid``, ``icon_url``, ``name``, ``previews``, ``slug``, ``theme_data``, ``type`` and ``url``.
+    :>json object results[].addon: The :ref:`add-on <addon-detail-object>` for this item. Only a subset of fields are present: ``id``, ``current_version`` (with only the ``compatibility``, ``is_strict_compatibility_enabled`` and ``files`` fields present), ``guid``, ``icon_url``, ``name``, ``previews``, ``slug``, ``theme_data``, ``type`` and ``url``.
 
 
 -------------------------

--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -278,3 +278,4 @@ v4 API changelog
 * 2018-09-27: backed out "localised field values are always returned as objects" change from 2018-07-19 from `v4` API.  This is intended to be temporary change while addons-frontend upgrades.
   On addons-dev and addons stage enviroments the previous behavior is available as `api/v4dev`. The `v4dev` api is not available on AMO production server.
   https://github.com/mozilla/addons-server/issues/9467
+* 2018-10-04: added ``is_strict_compatibility_enabled`` so discovery API ``addons.current_version`` object. This change was also backported to the `v3` API. https://github.com/mozilla/addons-server/issues/9520

--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -278,4 +278,4 @@ v4 API changelog
 * 2018-09-27: backed out "localised field values are always returned as objects" change from 2018-07-19 from `v4` API.  This is intended to be temporary change while addons-frontend upgrades.
   On addons-dev and addons stage enviroments the previous behavior is available as `api/v4dev`. The `v4dev` api is not available on AMO production server.
   https://github.com/mozilla/addons-server/issues/9467
-* 2018-10-04: added ``is_strict_compatibility_enabled`` so discovery API ``addons.current_version`` object. This change was also backported to the `v3` API. https://github.com/mozilla/addons-server/issues/9520
+* 2018-10-04: added ``is_strict_compatibility_enabled`` to discovery API ``addons.current_version`` object. This change was also backported to the `v3` API. https://github.com/mozilla/addons-server/issues/9520

--- a/src/olympia/discovery/serializers.py
+++ b/src/olympia/discovery/serializers.py
@@ -20,7 +20,7 @@ class DiscoveryEditorialContentSerializer(serializers.ModelSerializer):
 
 class DiscoveryVersionSerializer(VersionSerializer):
     class Meta:
-        fields = ('compatibility', 'files',)
+        fields = ('compatibility', 'is_strict_compatibility_enabled', 'files',)
         model = Version
 
 


### PR DESCRIPTION
Fix #9520