### PR TITLE
Fix types in the ratings API documentation

### DIFF
--- a/docs/topics/api/ratings.rst
+++ b/docs/topics/api/ratings.rst
@@ -28,9 +28,9 @@ user has already posted a rating for the current version of an add-on.
 
     :query string addon: The :ref:`add-on <addon-detail>` id, slug, or guid to fetch ratings from. When passed, the ratings shown will always be the latest posted by each user on this particular add-on (which means there should only be one rating per user in the results), unless the ``version`` parameter is also passed.
     :query string filter: The :ref:`filter(s) <rating-filtering-param>` to apply.
-    :query string user: The user id to fetch ratings from.
+    :query int user: The user id to fetch ratings from.
     :query boolean show_grouped_ratings: Whether or not to show ratings aggregates for this add-on in the response (Use "true"/"1" as truthy values, "0"/"false" as falsy ones).
-    :query string version: The version id to fetch ratings from.
+    :query int version: The version id to fetch ratings from.
     :query int page: 1-based page number. Defaults to 1.
     :query int page_size: Maximum number of results to return for the requested page. Defaults to 25.
     :>json int count: The number of results for this query.


### PR DESCRIPTION
The version and user fields on the /ratings/rating/ endpoint are version/user IDs, i.e. ints not strings. (Cf. filter_queryset in src/olympia/ratings/views.py)