### PR TITLE
Copy v3 docs into v3_legacy folder for better archiving.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,3 +19,12 @@ Contents
    topics/install/index
    topics/development/index
    topics/third-party
+
+Archived Contents
+-----------------
+
+.. toctree::
+   :titlesonly:
+   :maxdepth: 1
+
+   topics/api/v3_legacy/index

--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -257,7 +257,7 @@ guarantee 100% stability).  The `v3` API will be maintained for as long as Firef
 ESR60 is supported by Mozilla, i.e. at least June 30th 2019.
 The downside of using the `v3` API is, of course, no new cool features!
 
-The documentation for `v3` can be accessed at: http://addons-server.readthedocs.io/en/2018.05.17/topics/api/
+The documentation for `v3` can be accessed at: :ref:`v3-api-index`
 
 
 ----------------

--- a/docs/topics/api/v3_legacy/abuse.rst
+++ b/docs/topics/api/v3_legacy/abuse.rst
@@ -1,0 +1,62 @@
+=============
+Abuse Reports
+=============
+
+The following API endpoint covers abuse reporting
+
+---------------------------------
+Submitting an add-on abuse report
+---------------------------------
+
+.. _`v3-addonabusereport-create`:
+
+The following API endpoint allows an abuse report to be submitted for an Add-on,
+either listed on https://addons.mozilla.org or not.
+Authentication is not required, but is recommended so reports can be responded
+to if nessecary.
+
+.. http:post:: /api/v3/abuse/report/addon/
+
+    .. _v3-addonabusereport-create-request:
+
+    :<json string addon: The id, slug, or guid of the add-on to report for abuse (required).
+    :<json string message: The body/content of the abuse report (required).
+    :>json object|null reporter: The user who submitted the report, if authenticated.
+    :>json int reporter.id: The id of the user who submitted the report.
+    :>json string reporter.name: The name of the user who submitted the report.
+    :>json string reporter.username: The username of the user who submitted the report.
+    :>json string reporter.url: The link to the profile page for of the user who submitted the report.
+    :>json object addon: The add-on reported for abuse.
+    :>json string addon.guid: The add-on `extension identifier <https://developer.mozilla.org/en-US/Add-ons/Install_Manifests#id>`_.
+    :>json int|null addon.id: The add-on id on AMO. If the guid submitted didn't match a known add-on on AMO, then null.
+    :>json string|null addon.slug: The add-on slug. If the guid submitted didn't match a known add-on on AMO, then null.
+    :>json string message: The body/content of the abuse report.
+
+
+------------------------------
+Submitting a user abuse report
+------------------------------
+
+.. _`v3-userabusereport-create`:
+
+The following API endpoint allows an abuse report to be submitted for a user account
+on https://addons.mozilla.org.  Authentication is not required, but is recommended
+so reports can be responded to if nessecary.
+
+.. http:post:: /api/v3/abuse/report/user/
+
+    .. _v3-userabusereport-create-request:
+
+    :<json string user: The id or username of the user to report for abuse (required).
+    :<json string message: The body/content of the abuse report (required).
+    :>json object|null reporter: The user who submitted the report, if authenticated.
+    :>json int reporter.id: The id of the user who submitted the report.
+    :>json string reporter.name: The name of the user who submitted the report.
+    :>json string reporter.url: The link to the profile page for of the user who submitted the report.
+    :>json string reporter.username: The username of the user who submitted the report.
+    :>json object user: The user reported for abuse.
+    :>json int user.id: The id of the user reported.
+    :>json string user.name: The name of the user reported.
+    :>json string user.url: The link to the profile page for of the user reported.
+    :>json string user.username: The username of the user reported.
+    :>json string message: The body/content of the abuse report.

--- a/docs/topics/api/v3_legacy/accounts.rst
+++ b/docs/topics/api/v3_legacy/accounts.rst
@@ -1,0 +1,331 @@
+========
+Accounts
+========
+
+The following API endpoints cover a users account.
+
+
+-------
+Account
+-------
+
+.. _`v3-account`:
+
+This endpoint returns information about a user's account, by the account id.
+Only :ref:`developer <v3-developer_account>` accounts are publicly viewable - other user's accounts will return a 404 not found response code.
+Most of the information is optional and provided by the user so may be missing or inaccurate.
+
+.. _`v3-developer_account`:
+
+A developer is defined as a user who is listed as a developer or owner of one or more approved add-ons.
+
+
+.. http:get:: /api/v3/accounts/account/(int:user_id|string:username)/
+
+    .. _v3-account-object:
+
+    :>json float average_addon_rating: The average rating for addons the developer has listed on the website.
+    :>json string|null biography: More details about the user.
+    :>json string created: The date when this user first logged in and created this account.
+    :>json boolean has_anonymous_display_name: The user has chosen neither a name nor a username.
+    :>json boolean has_anonymous_username: The user hasn't chosen a username.
+    :>json string|null homepage: The user's website.
+    :>json int id: The numeric user id.
+    :>json boolean is_addon_developer: The user has developed and listed add-ons on this website.
+    :>json boolean is_artist: The user has developed and listed themes on this website.
+    :>json string|null location: The location of the user.
+    :>json string name: The name chosen by the user, or the username if not set.
+    :>json int num_addons_listed: The number of addons the developer has listed on the website.
+    :>json string|null occupation: The occupation of the user.
+    :>json string|null picture_type: the image type (only 'image/png' is supported) if a user photo has been uploaded, or null otherwise.
+    :>json string|null picture_url: URL to a photo of the user, or null if no photo has been uploaded.
+    :>json string username: username chosen by the user, used in the account url. If not set will be a randomly generated string.
+
+
+
+If you authenticate and access your own account by specifing your own ``user_id`` the following additional fields are returned.
+You can always access your account, regardless of whether you are a developer or not.
+If you have `Users:Edit` permission you will see these extra fields for all user accounts.
+
+.. http:get:: /api/v3/accounts/account/(int:user_id|string:username)/
+
+    .. _v3-account-object-self:
+
+    :>json boolean deleted: Is the account deleted.
+    :>json string|null display_name: The name chosen by the user.
+    :>json string email: Email address used by the user to login and create this account.
+    :>json string last_login: The date of the last successful log in to the website.
+    :>json string last_login_ip: The IP address of the last successfull log in to the website.
+    :>json boolean is_verified: The user has been verified via FirefoxAccounts.
+    :>json array permissions: A list of the additional :ref:`permissions <v3-account-permissions>` this user has.
+    :>json boolean read_dev_agreement: The user has read, and agreed to, the developer agreement that is required to submit addons.
+
+
+    :statuscode 200: account found.
+    :statuscode 400: an error occurred, check the ``error`` value in the JSON.
+    :statuscode 404: no account with that user id.
+
+
+.. important::
+
+    * ``Biography`` can contain HTML, or other unsanitized content, and it is the
+      responsibiliy of the client to clean and escape it appropriately before display.
+
+
+.. _v3-account-permissions:
+
+    Permissions can be any arbritary string in the format `app:action`. Either `app` or `action` can be
+    the wildcard `*`, so `*:*` means the user has permission to do all actions (i.e. full admin).
+
+    The following are some commonly tested permissions; see https://github.com/mozilla/addons-server/blob/master/src/olympia/constants/permissions.py
+    for the full list.
+
+    ==================  ==========================================================
+                 Value  Description
+    ==================  ==========================================================
+     `AdminTools:View`  Can access the website admin interface index page.  Inner
+                        pages may require other/additional permissions.
+         `Addons:Edit`  Allows viewing and editing of any add-ons details in
+                        developer tools.
+       `Addons:Review`  Can access the add-on reviewer tools to approve/reject
+                        add-on submissions.
+     `Personas:Review`  Can access the theme reviewer tools to approve/reject
+                        theme submissions.
+    ==================  ==========================================================
+
+
+-------
+Profile
+-------
+
+.. _`v3-profile`:
+
+.. note:: This API requires :doc:`authentication <auth>`.
+
+This endpoint is a shortcut to your own account. It returns an :ref:`account object <v3-account-object-self>`
+
+.. http:get:: /api/v3/accounts/profile/
+
+
+----
+Edit
+----
+
+.. _`v3-account-edit`:
+
+.. note::
+    This API requires :doc:`authentication <auth>` and `Users:Edit`
+    permission to edit accounts other than your own.
+
+This endpoint allows some of the details for an account to be updated.  Any fields
+in the :ref:`account <v3-account-object>` (or :ref:`self <v3-account-object-self>`)
+but not listed below are not editable and will be ignored in the patch request.
+
+.. http:patch:: /api/v3/accounts/account/(int:user_id|string:username)/
+
+    .. _v3-account-edit-request:
+
+    :<json string|null biography: More details about the user.  No links are allowed.
+    :<json string|null display_name: The name chosen by the user.
+    :<json string|null homepage: The user's website.
+    :<json string|null location: The location of the user.
+    :<json string|null occupation: The occupation of the user.
+    :<json string|null username: username to be used in the account url.  The username can only contain letters, numbers, underscores or hyphens. All-number usernames are prohibited as they conflict with user-ids.
+
+
+-------------------
+Uploading a picture
+-------------------
+
+To upload a picture for the profile the request must be sent as content-type `multipart/form-data` instead of JSON.
+Images must be either PNG or JPG; the maximum file size is 4MB.
+Other :ref:`editable values <v3-account-edit-request>` can be set at the same time.
+
+.. http:patch:: /api/v3/accounts/account/(int:user_id|string:username)/
+
+    **Request:**
+
+    .. sourcecode:: bash
+
+        curl "https://addons.mozilla.org/api/v3/accounts/account/12345/"
+            -g -XPATCH --form "picture_upload=@photo.png"
+            -H "Authorization: Bearer <token>"
+
+    :param user-id: The numeric user id.
+    :form picture_upload: The user's picture to upload.
+    :reqheader Content-Type: multipart/form-data
+
+
+--------------------
+Deleting the picture
+--------------------
+
+To delete the account profile picture call the special endpoint.
+
+.. http:delete:: /api/v3/accounts/account/(int:user_id|string:username)/picture
+
+
+------
+Delete
+------
+
+.. _`v3-account-delete`:
+
+.. note::
+    This API requires :doc:`authentication <auth>` and `Users:Edit`
+    permission to delete accounts other than your own.
+
+.. note::
+    Accounts of users who are authors of Add-ons can't be deleted.
+    All Add-ons (and Themes) must be deleted or transfered to other users first.
+
+This endpoint allows the account to be deleted. The reviews and ratings
+created by the user will not be deleted; but all the user's details are
+cleared.
+
+.. http:delete:: /api/v3/accounts/account/(int:user_id|string:username)/
+
+
+------------------
+Notifications List
+------------------
+
+.. _v3-notification-list:
+
+.. note::
+    This API requires :doc:`authentication <auth>` and `Users:Edit`
+    permission to list notifications on accounts other than your own.
+
+This endpoint allows you to list the account notifications set for the specified user.
+The result is an unpaginated list of the fields below. There are currently 11 notification types.
+
+.. http:get:: /api/v3/accounts/account/(int:user_id|string:username)/notifications/
+
+    :>json string name: The notification short name.
+    :>json boolean enabled: If the notification is enabled (defaults to True).
+    :>json boolean mandatory: If the notification can be set by the user.
+
+
+--------------------
+Notifications Update
+--------------------
+
+.. _`v3-notification-update`:
+
+.. note::
+    This API requires :doc:`authentication <auth>` and `Users:Edit`
+    permission to set notification preferences on accounts other than your own.
+
+This endpoint allows account notifications to be set or updated. The request should be a dict of `name`:True|False pairs.
+Any number of notifications can be changed; only non-mandatory notifications can be changed - attempting to set a mandatory notification will return an error.
+
+.. http:post:: /api/v3/accounts/account/(int:user_id|string:username)/notifications/
+
+    .. _v3-notification-update-request:
+
+    :<json boolean <name>: Is the notification enabled?
+
+
+--------------
+Super-creation
+--------------
+
+.. note:: This API requires :doc:`authentication <auth>`.
+
+
+This allows you to generate a new user account and sign in as that user.
+
+.. important::
+
+    * Your API user must be in the ``Accounts:SuperCreate`` group to access
+      this endpoint. Use ``manage.py createsuperuser --add-to-supercreate-group``
+      to create a superuser with proper access.
+    * This endpoint is not available in all
+      :ref:`API environments <v3-api-environments>`.
+
+.. http:post:: /api/v3/accounts/super-create/
+
+    **Request:**
+
+    :param email: assign the user a specific email address.
+        A fake email will be assigned by default.
+    :param username: assign the user a specific username.
+        A random username will be assigned by default.
+    :param fxa_id:
+        assign the user a Firefox Accounts ID, like one
+        returned in the ``uuid`` parameter of a
+        `profile request <https://github.com/mozilla/fxa-profile-server/blob/master/docs/API.md#get-v1profile>`_.
+        This is empty by default, meaning the user's account will
+        need to be migrated to a Firefox Account.
+    :param group:
+        assign the user to a permission group. Valid choices:
+
+        - **reviewer**: can access add-on reviewer pages, formerly known as Editor Tools
+        - **admin**: can access any protected page
+
+
+    .. sourcecode:: bash
+
+        curl "https://addons.mozilla.org/api/v3/accounts/super-create/" \
+            -X POST -H "Authorization: JWT <jwt-token>"
+
+    **Response:**
+
+    .. sourcecode:: json
+
+        {
+            "username": "super-created-7ee304ce",
+            "display_name": "Super Created 7ee304ce",
+            "user_id": 10985,
+            "email": "super-created-7ee304ce@addons.mozilla.org",
+            "fxa_id": null,
+            "groups": [],
+            "session_cookie": {
+                "encoded": "sessionid=.eJyrVopPLC3JiC8tTi2KT...",
+                "name": "sessionid",
+                "value": ".eJyrVopPLC3JiC8tTi2KT..."
+            }
+        }
+
+    :statuscode 201: Account created.
+    :statuscode 422: Incorrect request parameters.
+
+    The session cookie will enable you to sign in for a limited time
+    as this new user. You can pass it to any login-protected view like
+    this:
+
+    .. sourcecode:: bash
+
+        curl --cookie sessionid=... -s -D - \
+            "https://addons.mozilla.org/en-US/developers/addon/submit/1" \
+            -o /dev/null
+
+.. _`v3-session`:
+
+-------
+Session
+-------
+
+Log out of the current session. This is for use with the
+:ref:`internal authentication <v3-api-auth-internal>` that authenticates browser
+sessions.
+
+.. http:delete:: /api/v3/accounts/session/
+
+    **Request:**
+
+    .. sourcecode:: bash
+
+        curl "https://addons.mozilla.org/api/v3/accounts/session/"
+            -H "Authorization: Bearer <jwt-token>" -X DELETE
+
+    **Response:**
+
+    .. sourcecode:: json
+
+        {
+            "ok": true
+        }
+
+    :statuscode 200: session logged out.
+    :statuscode 401: authentication failed.

--- a/docs/topics/api/v3_legacy/activity.rst
+++ b/docs/topics/api/v3_legacy/activity.rst
@@ -1,0 +1,94 @@
+========
+Activity
+========
+
+.. note::
+
+    These APIs are experimental and are currently being worked on. Endpoints
+    may change without warning. The only authentication method available at
+    the moment is :ref:`the internal one<v3-api-auth-internal>`.
+
+
+-----------------
+Review Notes List
+-----------------
+
+.. _v3-review-notes-version-list:
+
+This endpoint allows you to list the approval/rejection review history for a version of an add-on.
+
+.. http:get:: /api/v3/addons/addon/(int:addon_id|string:addon_slug|string:addon_guid)/versions/(int:id)/reviewnotes/
+
+    .. note::
+        All add-ons require authentication and either
+        reviewer permissions or a user account listed as a developer of the
+        add-on.
+
+    :>json int count: The number of versions for this add-on.
+    :>json string next: The URL of the next page of results.
+    :>json string previous: The URL of the previous page of results.
+    :>json array results: An array of :ref:`per version review notes <v3-review-notes-version-detail-object>`.
+
+
+-------------------
+Review Notes Detail
+-------------------
+
+.. _v3-review-notes-version-detail:
+
+This endpoint allows you to fetch a single review note for a specific version of an add-on.
+
+.. http:get:: /api/v3/addons/addon/(int:addon_id|string:addon_slug|string:addon_guid)/versions/(int:id)/reviewnotes/(int:id)/
+
+    .. _v3-review-notes-version-detail-object:
+
+    :>json int id: The id for a review note.
+    :>json string action: The :ref:`type of review note <v3-review-note-action>`.
+    :>json string action_label: The text label of the action.
+    :>json int user.id: The id of the reviewer or author who left the review note.
+    :>json string user.name: The name of the reviewer or author.
+    :>json string user.url: The link to the profile page for of the reviewer or author.
+    :>json string user.username: The username of the reviewer or author.
+    :>json string comments: The text content of the review note.
+    :>json string date: The date the review note was created.
+
+
+.. _v3-review-note-action:
+
+    Possible values for the ``action`` field:
+
+    ==========================  ==========================================================
+                         Value  Description
+    ==========================  ==========================================================
+                      approved  Version, or file in the version, was approved
+                      rejected  Version, or file in the version, was rejected
+              review-requested  Developer requested review
+    more-information-requested  Reviewer requested more information from developer
+        super-review-requested  Add-on was referred to an admin for attention
+                       comment  Reviewer added comment for other reviewers
+                   review-note  Generic review comment
+    ==========================  ==========================================================
+
+
+-----------------------
+Incoming Mail End-point
+-----------------------
+
+.. _v3-activity_mail:
+
+This endpoint allows a mail server or similar to submit a json object containing single email into AMO which will be processed.
+The only type of email currently supported is a reply to an activity email (e.g an add-on review, or a reply to an add-on review).
+Any other content or invalid emails will be discarded.
+
+.. http:post:: /api/v3/activity/mail
+
+    .. note::
+        This API endpoint uses a custom authentication method.
+        The value `SecretKey` in the submitted json must match one defined in `settings.INBOUND_EMAIL_SECRET_KEY`.
+        The IP address of the request must match one defined in `settings.ALLOWED_CLIENTS_EMAIL_API`, if defined.
+
+    :<json string SecretKey: A value that matches `settings.INBOUND_EMAIL_SECRET_KEY`.
+    :<json string Message.TextBody: The plain text body of the email.
+    :<json array To: Array of To email addresses.  All will be parsed, and the first matching the correct format used.
+    :<json string To[].EmailAddress: An email address in the format `reviewreply+randomuuidstring@addons.mozilla.org`.
+

--- a/docs/topics/api/v3_legacy/addons.rst
+++ b/docs/topics/api/v3_legacy/addons.rst
@@ -1,0 +1,551 @@
+=======
+Add-ons
+=======
+
+.. note::
+
+    These APIs are experimental and are currently being worked on. Endpoints
+    may change without warning. The only authentication method available at
+    the moment is :ref:`the internal one <v3-api-auth-internal>`.
+
+--------
+Featured
+--------
+
+.. _v3-addon-featured:
+
+This endpoint allows you to list featured add-ons matching some parameters.
+Results are sorted randomly and therefore, the standard pagination parameters
+are not accepted. The query parameter ``page_size`` is allowed but only serves
+to customize the number of results returned, clients can not request a specific
+page.
+
+.. http:get:: /api/v3/addons/featured/
+
+    :query string app: **Required**. Filter by :ref:`add-on application <v3-addon-detail-application>` availability.
+    :query string category: Filter by :ref:`category slug <v3-category-list>`. ``app`` and ``type`` parameters need to be set, otherwise this parameter is ignored.
+    :query string lang: Request add-ons featured for this specific language to be returned alongside add-ons featured globally. Also activate translations for that query. (See :ref:`translated fields <v3-api-overview-translations>`)
+    :query string type: Filter by :ref:`add-on type <v3-addon-detail-type>`.
+    :query int page_size: Maximum number of results to return. Defaults to 25.
+    :>json array results: An array of :ref:`add-ons <v3-addon-detail-object>`.
+
+------
+Search
+------
+
+.. _v3-addon-search:
+
+This endpoint allows you to search through public add-ons.
+
+.. http:get:: /api/v3/addons/search/
+
+    :query string q: The search query. The maximum length allowed is 100 characters.
+    :query string app: Filter by :ref:`add-on application <v3-addon-detail-application>` availability.
+    :query string appversion: Filter by application version compatibility. Pass the full version as a string, e.g. ``46.0``. Only valid when the ``app`` parameter is also present.
+    :query string author: Filter by exact author username. Multiple author names can be specified, separated by comma(s), in which case add-ons with at least one matching author are returned.
+    :query string category: Filter by :ref:`category slug <v3-category-list>`. ``app`` and ``type`` parameters need to be set, otherwise this parameter is ignored.
+    :query string exclude_addons: Exclude add-ons by ``slug`` or ``id``. Multiple add-ons can be specified, separated by comma(s).
+    :query boolean featured: Filter to only featured add-ons.  Only ``featured=true`` is supported.
+        If ``app`` is provided as a parameter then only featured collections targeted to that application are taken into account.
+        If ``lang`` is provided then only featured collections targeted to that language, (and collections for all languages), are taken into account. Both ``app`` and ``lang`` can be provided to filter to addons that are featured in collections that application and for that language, (and for all languages).
+    :query string guid: Filter by exact add-on guid. Multiple guids can be specified, separated by comma(s), in which case any add-ons matching any of the guids will be returned.  As guids are unique there should be at most one add-on result per guid specified.
+    :query string lang: Activate translations in the specific language for that query. (See :ref:`translated fields <v3-api-overview-translations>`)
+    :query int page: 1-based page number. Defaults to 1.
+    :query int page_size: Maximum number of results to return for the requested page. Defaults to 25.
+    :query string platform: Filter by :ref:`add-on platform <v3-addon-detail-platform>` availability.
+    :query string tag: Filter by exact tag name. Multiple tag names can be specified, separated by comma(s), in which case add-ons containing *all* specified tags are returned.
+    :query string type: Filter by :ref:`add-on type <v3-addon-detail-type>`.
+    :query string sort: The sort parameter. The available parameters are documented in the :ref:`table below <v3-addon-search-sort>`.
+    :>json int count: The number of results for this query.
+    :>json string next: The URL of the next page of results.
+    :>json string previous: The URL of the previous page of results.
+    :>json array results: An array of :ref:`add-ons <v3-addon-detail-object>`. As described below, the following fields are omitted for performance reasons: ``release_notes`` and ``license`` fields on ``current_version`` as well as ``picture_url`` from ``authors``.
+
+.. _v3-addon-search-sort:
+
+    Available sorting parameters:
+
+    ==============  ==========================================================
+         Parameter  Description
+    ==============  ==========================================================
+           created  Creation date, descending.
+         downloads  Number of weekly downloads, descending.
+           hotness  Hotness (average number of users progression), descending.
+            random  Random ordering. Only available when no search query is
+                    passed and when filtering to only return featured add-ons.
+            rating  Bayesian rating, descending.
+         relevance  Search query relevance, descending.
+           updated  Last updated date, descending.
+             users  Average number of daily users, descending.
+    ==============  ==========================================================
+
+    The default is to sort by relevance if a search query (``q``) is present,
+    otherwise sort by number of weekly downloads, descending.
+
+    You can combine multiple parameters by separating them with a comma.
+    For instance, to sort search results by downloads and then by creation
+    date, use ``sort=downloads,created``. The only exception is the ``random``
+    sort parameter, which is only available alone.
+
+
+------------
+Autocomplete
+------------
+
+.. _v3-addon-autocomplete:
+
+Similar to :ref:`add-ons search endpoint <v3-addon-search>` above, this endpoint
+allows you to search through public add-ons. Because it's meant as a backend
+for autocomplete though, there are a couple key differences:
+
+  - No pagination is supported. There are no ``next``, ``prev`` or ``count``
+    fields, and passing ``page_size`` or ``page`` has no effect, a maximum of 10
+    results will be returned at all times.
+  - Only a subset of fields are returned.
+
+.. http:get:: /api/v3/addons/autocomplete/
+
+    :query string q: The search query.
+    :query string app: Filter by :ref:`add-on application <v3-addon-detail-application>` availability.
+    :query string appversion: Filter by application version compatibility. Pass the full version as a string, e.g. ``46.0``. Only valid when the ``app`` parameter is also present.
+    :query string author: Filter by exact author username.
+    :query string category: Filter by :ref:`category slug <v3-category-list>`. ``app`` and ``type`` parameters need to be set, otherwise this parameter is ignored.
+    :query string lang: Activate translations in the specific language for that query. (See :ref:`translated fields <v3-api-overview-translations>`)
+    :query string platform: Filter by :ref:`add-on platform <v3-addon-detail-platform>` availability.
+    :query string tag: Filter by exact tag name. Multiple tag names can be specified, separated by comma(s).
+    :query string type: Filter by :ref:`add-on type <v3-addon-detail-type>`.
+    :query string sort: The sort parameter. The available parameters are documented in the :ref:`table below <v3-addon-search-sort>`.
+    :>json array results: An array of :ref:`add-ons <v3-addon-detail-object>`. Only the ``id``, ``icon_url``, ``name`` and ``url`` fields are supported though.
+
+
+------
+Detail
+------
+
+.. _v3-addon-detail:
+
+This endpoint allows you to fetch a specific add-on by id, slug or guid.
+
+    .. note::
+        Non-public add-ons and add-ons with only unlisted versions require both
+        authentication and reviewer permissions or an account listed as a
+        developer of the add-on.
+
+        A 401 or 403 error response will be returned when clients don't meet
+        those requirements. Those responses will contain the following
+        properties:
+
+            * ``detail``: string containing a message about the error.
+            * ``is_disabled_by_developer``: boolean set to ``true`` when the add-on has been voluntarily disabled by its developer.
+            * ``is_disabled_by_mozilla``: boolean set to ``true`` when the add-on has been disabled by Mozilla.
+
+.. http:get:: /api/v3/addons/addon/(int:id|string:slug|string:guid)/
+
+    .. _v3-addon-detail-object:
+
+    :query string lang: Activate translations in the specific language for that query. (See :ref:`Translated Fields <v3-api-overview-translations>`)
+    :query string wrap_outgoing_links: If this parameter is present, wrap outgoing links through ``outgoing.prod.mozaws.net`` (See :ref:`Outgoing Links <v3-api-overview-outgoing>`)
+    :>json int id: The add-on id on AMO.
+    :>json array authors: Array holding information about the authors for the add-on.
+    :>json int authors[].id: The id for an author.
+    :>json string authors[].name: The name for an author.
+    :>json string authors[].url: The link to the profile page for an author.
+    :>json string authors[].username: The username for an author.
+    :>json string authors[].picture_url: URL to a photo of the user, or `/static/img/anon_user.png` if not set. For performance reasons this field is omitted from the search endpoint.
+    :>json int average_daily_users: The average number of users for the add-on (updated daily).
+    :>json object categories: Object holding the categories the add-on belongs to.
+    :>json array categories[app_name]: Array holding the :ref:`category slugs <v3-category-list>` the add-on belongs to for a given :ref:`add-on application <v3-addon-detail-application>`. (Combine with the add-on ``type`` to determine the name of the category).
+    :>json string|null contributions_url: URL to the (external) webpage where the addon's authors collect monetary contributions, if set.
+    :>json object current_version: Object holding the current :ref:`version <v3-version-detail-object>` of the add-on. For performance reasons the ``license`` field omits the ``text`` property from the detail endpoint. In addition, ``license`` and ``release_notes`` are omitted entirely from the search endpoint.
+    :>json string default_locale: The add-on default locale for translations.
+    :>json string|object|null description: The add-on description (See :ref:`translated fields <v3-api-overview-translations>`).
+    :>json string|object|null developer comments: Additional information about the add-on provided by the developer. (See :ref:`translated fields <v3-api-overview-translations>`).
+    :>json string edit_url: The URL to the developer edit page for the add-on.
+    :>json string guid: The add-on `extension identifier <https://developer.mozilla.org/en-US/Add-ons/Install_Manifests#id>`_.
+    :>json boolean has_eula: The add-on has an End-User License Agreement that the user needs to agree with before installing (See :ref:`add-on EULA and privacy policy <v3-addon-eula-policy>`).
+    :>json boolean has_privacy_policy: The add-on has a Privacy Policy (See :ref:`add-on EULA and privacy policy <v3-addon-eula-policy>`).
+    :>json string|object|null homepage: The add-on homepage (See :ref:`translated fields <v3-api-overview-translations>`).
+    :>json string icon_url: The URL to icon for the add-on (including a cachebusting query string).
+    :>json object icons: An object holding the URLs to an add-ons icon including a cachebusting query string as values and their size as properties. Currently exposes 32 and 64 pixels wide icons.
+    :>json boolean is_disabled: Whether the add-on is disabled or not.
+    :>json boolean is_experimental: Whether the add-on has been marked by the developer as experimental or not.
+    :>json boolean is_featured: The add-on appears in a featured collection.
+    :>json boolean is_source_public: Whether the add-on source is publicly viewable or not.
+    :>json string|object|null name: The add-on name (See :ref:`translated fields <v3-api-overview-translations>`).
+    :>json string last_updated: The date of the last time the add-on was updated by its developer(s).
+    :>json object|null latest_unlisted_version: Object holding the latest unlisted :ref:`version <v3-version-detail-object>` of the add-on. This field is only present if the user has unlisted reviewer permissions, or is listed as a developer of the add-on.
+    :>json array previews: Array holding information about the previews for the add-on.
+    :>json int previews[].id: The id for a preview.
+    :>json string|object|null previews[].caption: The caption describing a preview (See :ref:`translated fields <v3-api-overview-translations>`).
+    :>json int previews[].image_size[]: width, height dimensions of of the preview image.
+    :>json string previews[].image_url: The URL (including a cachebusting query string) to the preview image.
+    :>json int previews[].thumbnail_size[]: width, height dimensions of of the preview image thumbnail.
+    :>json string previews[].thumbnail_url: The URL (including a cachebusting query string) to the preview image thumbnail.
+    :>json boolean public_stats: Boolean indicating whether the add-on stats are public or not.
+    :>json object ratings: Object holding ratings summary information about the add-on.
+    :>json int ratings.count: The total number of user ratings for the add-on.
+    :>json int ratings.text_count: The number of user ratings with review text for the add-on.
+    :>json string ratings_url: The URL to the user ratings list page for the add-on.
+    :>json float ratings.average: The average user rating for the add-on.
+    :>json float ratings.bayesian_average: The bayesian average user rating for the add-on.
+    :>json boolean requires_payment: Does the add-on require payment, non-free services or software, or additional hardware.
+    :>json string review_url: The URL to the reviewer review page for the add-on.
+    :>json string slug: The add-on slug.
+    :>json string status: The :ref:`add-on status <v3-addon-detail-status>`.
+    :>json string|object|null summary: The add-on summary (See :ref:`translated fields <v3-api-overview-translations>`).
+    :>json string|object|null support_email: The add-on support email (See :ref:`translated fields <v3-api-overview-translations>`).
+    :>json string|object|null support_url: The add-on support URL (See :ref:`translated fields <v3-api-overview-translations>`).
+    :>json array tags: List containing the text of the tags set on the add-on.
+    :>json object theme_data: Object holding `lightweight theme (Persona) <https://developer.mozilla.org/en-US/Add-ons/Themes/Lightweight_themes>`_ data. Only present for themes (Persona).
+    :>json string type: The :ref:`add-on type <v3-addon-detail-type>`.
+    :>json string url: The (absolute) add-on detail URL.
+    :>json int weekly_downloads: The number of downloads for the add-on in the last week. Not present for lightweight themes.
+
+
+.. _v3-addon-detail-status:
+
+    Possible values for the ``status`` field / parameter:
+
+    ==============  ==========================================================
+             Value  Description
+    ==============  ==========================================================
+              lite  Preliminarily Reviewed
+            public  Fully Reviewed
+           deleted  Deleted
+           pending  Pending approval (Valid for themes only)
+          disabled  Disabled by Mozilla
+          rejected  Rejected (Valid for themes only)
+         nominated  Awaiting Full Review
+        incomplete  Incomplete
+        unreviewed  Awaiting Preliminary Review
+    lite-nominated  Preliminarily Reviewed and Awaiting Full Review
+    review-pending  Flagged for further review (Valid for themes only)
+    ==============  ==========================================================
+
+
+.. _v3-addon-detail-application:
+
+    Possible values for the keys in the ``compatibility`` field, as well as the
+    ``app`` parameter in the search API:
+
+    ==============  ==========================================================
+             Value  Description
+    ==============  ==========================================================
+           android  Firefox for Android
+           firefox  Firefox
+         seamonkey  SeaMonkey
+       thunderbird  Thunderbird
+    ==============  ==========================================================
+
+    .. note::
+        For possible version values per application, see
+        `valid application versions`_.
+
+.. _v3-addon-detail-platform:
+
+    Possible values for the ``current_version.files[].platform`` field:
+
+    ==============  ==========================================================
+             Value  Description
+    ==============  ==========================================================
+               all  All
+               mac  Mac
+             linux  Linux
+           android  Android
+           windows  Windows
+    ==============  ==========================================================
+
+.. _v3-addon-detail-type:
+
+    Possible values for the ``type`` field / parameter:
+
+    .. note::
+
+        For backwards-compatibility reasons, the value for Theme is ``persona``.
+        ``theme`` refers to a Complete Theme.
+
+    ==============  ==========================================================
+             Value  Description
+    ==============  ==========================================================
+             theme  Complete Theme
+            search  Search Engine
+           persona  Theme
+          language  Language Pack (Application)
+         extension  Extension
+        dictionary  Dictionary
+    ==============  ==========================================================
+
+
+-----------------------------
+Add-on and Version Submission
+-----------------------------
+
+See :ref:`Uploading a version <v3-upload-version>`.
+
+-------------
+Versions List
+-------------
+
+.. _v3-version-list:
+
+This endpoint allows you to list all versions belonging to a specific add-on.
+
+.. http:get:: /api/v3/addons/addon/(int:addon_id|string:addon_slug|string:addon_guid)/versions/
+
+    .. note::
+        Non-public add-ons and add-ons with only unlisted versions require both:
+
+            * authentication
+            * reviewer permissions or an account listed as a developer of the add-on
+
+    :query string filter: The :ref:`filter <v3-version-filtering-param>` to apply.
+    :query string lang: Activate translations in the specific language for that query. (See :ref:`translated fields <v3-api-overview-translations>`)
+    :query int page: 1-based page number. Defaults to 1.
+    :query int page_size: Maximum number of results to return for the requested page. Defaults to 25.
+    :>json int count: The number of versions for this add-on.
+    :>json string next: The URL of the next page of results.
+    :>json string previous: The URL of the previous page of results.
+    :>json array results: An array of :ref:`versions <v3-version-detail-object>`.
+
+.. _v3-version-filtering-param:
+
+   By default, the version list API will only return public versions
+   (excluding versions that have incomplete, disabled, deleted, rejected or
+   flagged for further review files) - you can change that with the ``filter``
+   query parameter, which may require authentication and specific permissions
+   depending on the value:
+
+    ====================  =====================================================
+                   Value  Description
+    ====================  =====================================================
+    all_without_unlisted  Show all listed versions attached to this add-on.
+                          Requires either reviewer permissions or a user
+                          account listed as a developer of the add-on.
+       all_with_unlisted  Show all versions (including unlisted) attached to
+                          this add-on. Requires either reviewer permissions or
+                          a user account listed as a developer of the add-on.
+        all_with_deleted  Show all versions attached to this add-on, including
+                          deleted ones. Requires admin permissions.
+    ====================  =====================================================
+
+--------------
+Version Detail
+--------------
+
+.. _v3-version-detail:
+
+This endpoint allows you to fetch a single version belonging to a specific add-on.
+
+.. http:get:: /api/v3/addons/addon/(int:addon_id|string:addon_slug|string:addon_guid)/versions/(int:id)/
+
+    .. _v3-version-detail-object:
+
+    :query string lang: Activate translations in the specific language for that query. (See :ref:`translated fields <v3-api-overview-translations>`)
+    :>json int id: The version id.
+    :>json string channel: The version channel, which determines its visibility on the site. Can be either ``unlisted`` or ``listed``.
+    :>json object compatibility:
+        Object detailing which :ref:`applications <v3-addon-detail-application>` the version is compatible with.
+        The exact min/max version numbers in the object correspond to
+        `valid application versions`_. Example:
+
+            .. code-block:: json
+
+                {
+                  "compatibility": {
+                    "android": {
+                      "min": "38.0a1",
+                      "max": "43.0"
+                    },
+                    "firefox": {
+                      "min": "38.0a1",
+                      "max": "43.0"
+                    }
+                  }
+                }
+
+    :>json object compatibility[app_name].max: Maximum version of the corresponding app the version is compatible with. Should only be enforced by clients if ``is_strict_compatibility_enabled`` is ``true``.
+    :>json object compatibility[app_name].min: Minimum version of the corresponding app the version is compatible with.
+    :>json string edit_url: The URL to the developer edit page for the version.
+    :>json array files: Array holding information about the files for the version.
+    :>json int files[].id: The id for a file.
+    :>json string files[].created: The creation date for a file.
+    :>json string files[].hash: The hash for a file.
+    :>json string files[].platform: The :ref:`platform <v3-addon-detail-platform>` for a file.
+    :>json int files[].id: The size for a file, in bytes.
+    :>json boolean files[].is_mozilla_signed_extension: Whether the file was signed with a Mozilla internal certificate or not.
+    :>json boolean files[].is_restart_required: Whether the file requires a browser restart to work once installed or not.
+    :>json boolean files[].is_webextension: Whether the file is a WebExtension or not.
+    :>json int files[].status: The :ref:`status <v3-addon-detail-status>` for a file.
+    :>json string files[].url: The (absolute) URL to download a file. Clients using this API can append an optional ``src`` query parameter to the url which would indicate the source of the request (See :ref:`download sources <v3-download-sources>`).
+    :>json array files[].permissions[]: Array of the webextension permissions for this File, as strings.  Empty for non-webextensions.
+    :>json object license: Object holding information about the license for the version. For performance reasons this field is omitted from add-on search endpoint.
+    :>json string|object|null license.name: The name of the license (See :ref:`translated fields <v3-api-overview-translations>`).
+    :>json string|object|null license.text: The text of the license (See :ref:`translated fields <v3-api-overview-translations>`). For performance reasons this field is omitted from add-on detail endpoint.
+    :>json string|null license.url: The URL of the full text of license.
+    :>json string|object|null release_notes: The release notes for this version (See :ref:`translated fields <v3-api-overview-translations>`). For performance reasons this field is omitted from add-on search endpoint.
+    :>json string reviewed: The date the version was reviewed at.
+    :>json boolean is_strict_compatibility_enabled: Whether or not this version has `strictCompatibility <https://developer.mozilla.org/en-US/Add-ons/Install_Manifests#strictCompatibility>`_. set.
+    :>json string version: The version number string for the version.
+
+
+----------------------------
+Add-on Feature Compatibility
+----------------------------
+
+.. _v3-addon-feature-compatibility:
+
+This endpoint allows you to fetch feature compatibility information for a
+a specific add-on by id, slug or guid.
+
+.. http:get:: /api/v3/addons/addon/(int:id|string:slug|string:guid)/feature_compatibility/
+
+    .. note::
+        Non-public add-ons and add-ons with only unlisted versions require both:
+
+            * authentication
+            * reviewer permissions or an account listed as a developer of the add-on
+
+    :>json int e10s: The add-on e10s compatibility. Can be one of the following:
+
+    =======================  ==========================================================
+                      Value  Description
+    =======================  ==========================================================
+                 compatible  multiprocessCompatible marked as true in the install.rdf.
+    compatible-webextension  A WebExtension, so compatible.
+               incompatible  multiprocessCompatible marked as false in the install.rdf.
+                    unknown  multiprocessCompatible has not been set.
+    =======================  ==========================================================
+
+------------------------------
+Add-on EULA and Privacy Policy
+------------------------------
+
+.. _v3-addon-eula-policy:
+
+This endpoint allows you to fetch an add-on EULA and privacy policy.
+
+.. http:get:: /api/v3/addons/addon/(int:id|string:slug|string:guid)/eula_policy/
+
+    .. note::
+        Non-public add-ons and add-ons with only unlisted versions require both:
+
+            * authentication
+            * reviewer permissions or an account listed as a developer of the add-on
+
+    :>json string|object|null eula: The text of the EULA, if present (See :ref:`translated fields <v3-api-overview-translations>`).
+    :>json string|object|null privacy_policy: The text of the Privacy Policy, if present (See :ref:`translated fields <v3-api-overview-translations>`).
+
+
+--------------
+Language Tools
+--------------
+
+.. _v3-addon-language-tools:
+
+This endpoint allows you to list all public language tools add-ons available
+on AMO.
+
+.. http:get:: /api/v3/addons/language-tools/
+
+    .. note::
+        Because this endpoint is intended to be used to feed a page that
+        displays all available language tools in a single page, it is not
+        paginated as normal, and instead will return all results without
+        obeying regular pagination parameters. The ordering is left undefined,
+        it's up to the clients to re-order results as needed before displaying
+        the add-ons to the end-users.
+
+        In addition, the results can be cached for up to 24 hours, based on the
+        full URL used in the request.
+
+    :query string app: Mandatory. Filter by :ref:`add-on application <v3-addon-detail-application>` availability.
+    :query string appversion: Filter by application version compatibility. Pass the full version as a string, e.g. ``46.0``. Only valid when both the ``app`` and ``type`` parameters are also present, and only makes sense for Language Packs, since Dictionaries are always compatible with every application version.
+    :query string lang: Activate translations in the specific language for that query. (See :ref:`translated fields <v3-api-overview-translations>`)
+    :query string type: Mandatory when ``appversion`` is present. Filter by :ref:`add-on type <v3-addon-detail-type>`. The default is to return both Language Packs or Dictionaries.
+    :>json array results: An array of language tools.
+    :>json int results[].id: The add-on id on AMO.
+    :>json object results[].current_compatible_version: Object holding the latest publicly available :ref:`version <v3-version-detail-object>` of the add-on compatible with the ``appversion`` parameter used. Only present when ``appversion`` is passed and valid. For performance reasons, only the following version properties are returned on the object: ``id``, ``files``, ``reviewed``, and ``version``.
+    :>json string results[].default_locale: The add-on default locale for translations.
+    :>json string|object|null results[].name: The add-on name (See :ref:`translated fields <v3-api-overview-translations>`).
+    :>json string results[].guid: The add-on `extension identifier <https://developer.mozilla.org/en-US/Add-ons/Install_Manifests#id>`_.
+    :>json string results[].locale_disambiguation: Free text field allowing clients to distinguish between multiple dictionaries in the same locale but different spellings. Only present when using the Language Tools endpoint.
+    :>json string results[].slug: The add-on slug.
+    :>json string results[].target_locale: For dictionaries and language packs, the locale the add-on is meant for. Only present when using the Language Tools endpoint.
+    :>json string results[].type: The :ref:`add-on type <v3-addon-detail-type>`.
+    :>json string results[].url: The (absolute) add-on detail URL.
+
+.. _`valid application versions`: https://addons.mozilla.org/en-US/firefox/pages/appversions/
+
+
+-------------------
+Replacement Add-ons
+-------------------
+
+.. _v3-addon-replacement-addons:
+
+This endpoint returns a list of suggested replacements for legacy add-ons that are unsupported in Firefox 57.  Added to support the TAAR recommendation service.
+
+.. http:get:: /api/v3/addons/replacement-addon/
+
+    :query int page: 1-based page number. Defaults to 1.
+    :query int page_size: Maximum number of results to return for the requested page. Defaults to 25.
+    :>json int count: The total number of replacements.
+    :>json string next: The URL of the next page of results.
+    :>json string previous: The URL of the previous page of results.
+    :>json array results: An array of replacements matches.
+    :>json string results[].guid: The extension identifier of the legacy add-on.
+    :>json string results[].replacement[]: An array of guids for the replacements add-ons.  If there is a direct replacement this will be a list of one add-on guid.  The list can be empty if all the replacement add-ons are invalid (e.g. not publicly available on AMO).  The list will also be empty if the replacement is to a url that is not an addon or collection.
+
+
+---------------
+Compat Override
+---------------
+
+.. _v3-addon-compat-override:
+
+This endpoint allows compatibility overrides specified by AMO admins to be searched.
+Compatibilty overrides are used within Firefox i(and other toolkit applications e.g. Thunderbird) to change compatibility of installed add-ons where they have stopped working correctly in new release of Firefox, etc.
+
+.. http:get:: /api/v3/addons/compat-override/
+
+    :query string guid: Filter by exact add-on guid. Multiple guids can be specified, separated by comma(s), in which case any add-ons matching any of the guids will be returned.  As guids are unique there should be at most one add-on result per guid specified.
+    :query int page: 1-based page number. Defaults to 1.
+    :query int page_size: Maximum number of results to return for the requested page. Defaults to 25.
+    :>json int count: The number of results for this query.
+    :>json string next: The URL of the next page of results.
+    :>json string previous: The URL of the previous page of results.
+    :>json array results: An array of compat overrides.
+    :>json int|null results[].addon_id: The add-on identifier on AMO, if specified.
+    :>json string results[].addon_guid: The add-on extension identifier.
+    :>json string results[].name: A description entered by AMO admins to describe the override.
+    :>json array results[].version_ranges: An array of affected versions of the add-on.
+    :>json string results[].version_ranges[].addon_min_version: minimum version of the add-on to be disabled.
+    :>json string results[].version_ranges[].addon_max_version: maximum version of the add-on to be disabled.
+    :>json array results[].version_ranges[].applications: An array of affected applications for this range of versions.
+    :>json string results[].version_ranges[].applications[].name: Application name (e.g. Firefox).
+    :>json int results[].version_ranges[].applications[].id: Application id on AMO.
+    :>json string results[].version_ranges[].applications[].min_version: minimum version of the application to be disabled in.
+    :>json string results[].version_ranges[].applications[].max_version: maximum version of the application to be disabled in.
+    :>json string results[].version_ranges[].applications[].guid: Application `guid <https://addons.mozilla.org/en-US/firefox/pages/appversions/>`_.
+
+
+---------------
+Recommendations
+---------------
+
+.. _v3-addon-recommendations:
+
+This endpoint provides recommendations of other addons to install, fetched from the `recommendation service <https://github.com/mozilla/taar>`_.
+Four recommendations are fetched, but only valid, publicly available addons are shown (so max 4 will be returned, and possibly less).
+
+.. http:get:: /api/v3/addons/recommendations/
+
+    :query string guid: Fetch recommendations for this add-on guid.
+    :query string lang: Activate translations in the specific language for that query. (See :ref:`translated fields <v3-api-overview-translations>`)
+    :query boolean recommended: Fetch recommendations from the recommendation service, or return a curated fallback list instead.
+    :>json string outcome: Outcome of the response returned.  Will be either: ``recommended`` - responses from recommendation service; ``recommended_fallback`` - service timed out or returned empty results so we returned fallback; ``curated`` - ``recommended=False`` was requested so fallback returned.
+    :>json string|null fallback_reason: if ``outcome`` was ``recommended_fallback`` then the reason why.  Will be either: ``timeout`` or ``no_results``.
+    :>json int count: The number of results for this query.
+    :>json string next: The URL of the next page of results.
+    :>json string previous: The URL of the previous page of results.
+    :>json array results: An array of :ref:`add-ons <v3-addon-detail-object>`. The following fields are omitted for performance reasons: ``release_notes`` and ``license`` fields on ``current_version`` and ``current_beta_version``, as well as ``picture_url`` from ``authors``.

--- a/docs/topics/api/v3_legacy/auth.rst
+++ b/docs/topics/api/v3_legacy/auth.rst
@@ -1,0 +1,143 @@
+.. _v3-api-auth:
+
+=========================
+Authentication (External)
+=========================
+
+To access the API as an external consumer, you need to include a
+`JSON Web Token (JWT)`_ in the ``Authorization`` header for every request.
+This header acts as a one-time token that authenticates your user account.
+No JWT claims are made about the actual API request you are making.
+
+If you are building an app that lives on the AMO domain, read the
+:ref:`documentation for internal authentication <v3-api-auth-internal>` instead.
+
+Access Credentials
+==================
+
+To create JWTs, first obtain a **key** and **secret** from the
+`API Credentials Management Page`_.
+
+
+.. note::
+
+    Keep your API keys secret and *never* commit them to a public code repository
+    or share them with anyone, including Mozilla contributors.
+
+    If someone obtains your secret they can make API requests on behalf of your user account.
+
+
+Create a JWT for each request
+=============================
+
+Prior to making every API request, you need to generate a fresh `JWT`_.
+The JWT will have a short expiration time and is only valid for a single
+request so you can't cache or reuse it.
+You only need to include a few standard fields; here's what the raw JSON object
+needs to look like before it's signed:
+
+.. code-block:: json
+
+    {
+        "iss": "your-api-key",
+        "jti": "0.47362944623455405",
+        "iat": 1447273096,
+        "exp": 1447273156
+    }
+
+iss
+    This is a `standard JWT claim`_ identifying
+    the *issuer*. Set this to the **API key** you generated on the
+    `credentials management page`_.
+    For example: ``user:543210:23``.
+jti
+    This is a `standard JWT claim`_ declaring a *JWT ID*.
+    This value needs to have a high probability of being unique across all
+    recent requests made by your issuer ID. This value is a type of
+    `cryptographic nonce <https://en.wikipedia.org/wiki/Cryptographic_nonce>`_
+    designed to prevent
+    `replay attacks <https://en.wikipedia.org/wiki/Replay_attack>`_.
+iat
+    This is a `standard JWT claim`_ indicating
+    the *issued at time*. It should be a Unix epoch timestamp and
+    **must be in UTC time**.
+exp
+    This is a `standard JWT claim`_ indicating
+    the *expiration time*. It should be a Unix epoch timestamp in UTC time
+    and must be **no longer than five minutes** past the issued at time.
+
+     .. versionchanged:: 2016-10-06
+
+        We increased the expiration time from 60 seconds to five minutes
+        to workaround support for large and slow uploads.
+
+
+.. note::
+    If you're having trouble authenticating, make sure your system
+    clock is correct and consider synchronizing it with something like
+    `tlsdate <https://github.com/ioerror/tlsdate>`_.
+
+Take this JSON object and sign it with the **API secret** you generated on the
+`credentials management page`_. You must sign the JWT using the ``HMAC-SHA256``
+algorithm (which is typically the default).
+The final JWT will be a blob of base64 encoded text, something like::
+
+    eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ5b3VyLWFwaS1rZXkiLCJqdGkiOiIwLjQ3MzYyOTQ0NjIzNDU1NDA1IiwiaWF0IjoxNDQ3MjczMDk2LCJleHAiOjE0NDcyNzMxNTZ9.fQGPSV85QPhbNmuu86CIgZiluKBvZKd-NmzM6vo11D
+
+.. note::
+    See `jwt.io debugger <https://jwt.io/?value=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ5b3VyLWFwaS1rZXkiLCJqdGkiOiIwLjQ3MzYyOTQ0NjIzNDU1NDA1IiwiaWF0IjoxNDQ3MjczMDk2LCJleHAiOjE0NDcyNzMxNTZ9.fQGPSV85QPhbNmuu86CIgZiluKBvZKd-NmzM6vo11DM#debugger>`_ for more information about the token.
+
+Here is an example of creating a JWT in `NodeJS <https://nodejs.org/en/>`_
+using the `node-jsonwebtoken <https://github.com/auth0/node-jsonwebtoken>`_
+library:
+
+.. code-block:: javascript
+
+    var jwt = require('jsonwebtoken');
+
+    var issuedAt = Math.floor(Date.now() / 1000);
+    var payload = {
+      iss: 'your-api-key',
+      jti: Math.random().toString(),
+      iat: issuedAt,
+      exp: issuedAt + 60,
+    };
+
+    var secret = 'your-api-secret';  // store this securely.
+    var token = jwt.sign(payload, secret, {
+      algorithm: 'HS256',  // HMAC-SHA256 signing algorithm
+    });
+
+Create an Authorization header
+==============================
+
+When making each request, put your generated `JSON Web Token (JWT)`_
+into an HTTP Authorization header prefixed with ``JWT``, like this::
+
+    Authorization: JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ5b3VyLWFwaS1rZXkiLCJqdGkiOiIwLjQ3MzYyOTQ0NjIzNDU1NDA1IiwiaWF0IjoxNDQ3MjczMDk2LCJleHAiOjE0NDcyNzMxNTZ9.fQGPSV85QPhbNmuu86CIgZiluKBvZKd-NmzM6vo11DM
+
+Example request
+===============
+
+Using the :ref:`profile <v3-profile>` as an example endpoint,
+here's what a JWT authenticated HTTP request would look like in
+`curl <http://curl.haxx.se/>`_::
+
+    curl "https://addons.mozilla.org/api/v3/accounts/profile/" \
+         -H "Authorization: JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ5b3VyLWFwaS1rZXkiLCJqdGkiOiIwLjQ3MzYyOTQ0NjIzNDU1NDA1IiwiaWF0IjoxNDQ3MjczMDk2LCJleHAiOjE0NDcyNzMxNTZ9.fQGPSV85QPhbNmuu86CIgZiluKBvZKd-NmzM6vo11DM"
+
+
+Find a JWT library
+==================
+
+There are robust open source libraries for creating JWTs in
+`all major programming languages <http://jwt.io/>`_.
+
+
+.. _`manage-credentials`: https://addons.mozilla.org/en-US/developers/addon/api/key/
+.. _`API Credentials Management Page`: manage-credentials_
+.. _`credentials management page`: manage-credentials_
+.. _`jwt-spec`: https://tools.ietf.org/html/rfc7519
+.. _JWT: jwt-spec_
+.. _`JSON Web Token (JWT)`: jwt-spec_
+.. _`standard JWT claim`: jwt-spec_

--- a/docs/topics/api/v3_legacy/auth_internal.rst
+++ b/docs/topics/api/v3_legacy/auth_internal.rst
@@ -1,0 +1,40 @@
+.. _v3-api-auth-internal:
+
+=========================
+Authentication (internal)
+=========================
+
+This documents how to use authentication in your API requests when you are
+working on a web application that lives on AMO domain or subdomain. If you
+are looking for how to authenticate with the API from an external client, using
+your API keys, read the :ref:`documentation for external authentication
+<v3-api-auth>` instead.
+
+When using this authentication mechanism, the server is responsible for
+creating an API Token when the user logs in, and sends it back in
+the response. The clients must then include that token as an ``Authorization``
+header on requests that need authentication. The clients never generate JWTs
+themselves.
+
+Fetching the token
+==================
+
+A fresh token, valid for 30 days, is automatically generated and added to the
+responses of the following endpoint:
+
+    * ``/api/v3/accounts/authenticate/``
+
+The token is available in two forms:
+
+    * For the endpoint mentioned above, as a property called ``token``.
+    * For all endpoints, as a cookie called ``frontend_auth_token``. This cookie
+      expires after 30 days and is set as ``HttpOnly``.
+
+
+Creating an Authorization header
+================================
+
+When making an authenticated API request, put your generated API Token into an
+HTTP Authorization header prefixed with ``Bearer``, like this::
+
+    Authorization: Bearer eyJhdXRoX2hhc2giOiJiY2E0MTZkN2RiMGU3NjFmYTA2NDE4MjAzZWU1NTMwOTM4OGZhNzcxIiwidXNlcl9pZCI6MTIzNDV9:1cqe2Q:cPMlmz8ejIkutD-gNo3EWU8IfL8

--- a/docs/topics/api/v3_legacy/categories.rst
+++ b/docs/topics/api/v3_legacy/categories.rst
@@ -1,0 +1,139 @@
+==========
+Categories
+==========
+
+.. note::
+
+    These APIs are experimental and are currently being worked on. Endpoints
+    may change without warning.
+
+-------------
+Category List
+-------------
+
+.. _v3-category-list:
+
+Categories are defined by a name, a slug, a type and an application. Slugs are
+only guaranteed to be unique for a given ``app`` and ``type`` combination, and
+can therefore be re-used for different categories.
+
+This endpoint is not paginated.
+
+.. http:get:: /api/v3/addons/categories/
+
+    :>json int id: The category id.
+    :>json string name: The category name. Returns the already translated string.
+    :>json string slug: The category slug. See :ref:`csv table <v3-category-csv-table>` for more possible values.
+    :>json string application: Application, see :ref:`add-on application <v3-addon-detail-application>` for more details.
+    :>json boolean misc: Whether or not the category is miscellaneous.
+    :>json string type: Category type, see :ref:`add-on type <v3-addon-detail-type>` for more details.
+    :>json int weight: Category weight used in sort ordering.
+    :>json string description: The category description. Returns the already translated string.
+
+
+.. _v3-category-csv-table:
+
+------------------
+Current categories
+------------------
+
+.. csv-table::
+   :header: "Name", "Slug", "Type", "Application"
+
+    "Alerts & Updates", alerts-updates, extension, firefox
+    "Appearance", appearance, extension, firefox
+    "Bookmarks", bookmarks, extension, firefox
+    "Download Management", download-management, extension, firefox
+    "Feeds, News & Blogging", feeds-news-blogging, extension, firefox
+    "Games & Entertainment", games-entertainment, extension, firefox
+    "Language Support", language-support, extension, firefox
+    "Photos, Music & Videos", photos-music-videos, extension, firefox
+    "Privacy & Security", privacy-security, extension, firefox
+    "Search Tools", search-tools, extension, firefox
+    "Shopping", shopping, extension, firefox
+    "Social & Communication", social-communication, extension, firefox
+    "Tabs", tabs, extension, firefox
+    "Web Development", web-development, extension, firefox
+    "Other", other, extension, firefox
+    "Animals", animals, theme, firefox
+    "Compact", compact, theme, firefox
+    "Large", large, theme, firefox
+    "Miscellaneous", miscellaneous, theme, firefox
+    "Modern", modern, theme, firefox
+    "Nature", nature, theme, firefox
+    "OS Integration", os-integration, theme, firefox
+    "Retro", retro, theme, firefox
+    "Sports", sports, theme, firefox
+    "General", general, dictionary, firefox
+    "Bookmarks", bookmarks, search, firefox
+    "Business", business, search, firefox
+    "Dictionaries & Encyclopedias", dictionaries-encyclopedias, search, firefox
+    "General", general, search, firefox
+    "Kids", kids, search, firefox
+    "Multiple Search", multiple-search, search, firefox
+    "Music", music, search, firefox
+    "News & Blogs", news-blogs, search, firefox
+    "Photos & Images", photos-images, search, firefox
+    "Shopping & E-Commerce", shopping-e-commerce, search, firefox
+    "Social & People", social-people, search, firefox
+    "Sports", sports, search, firefox
+    "Travel", travel, search, firefox
+    "Video", video, search, firefox
+    "General", general, language, firefox
+    "Abstract", abstract, persona, firefox
+    "Causes", causes, persona, firefox
+    "Fashion", fashion, persona, firefox
+    "Film and TV", film-and-tv, persona, firefox
+    "Firefox", firefox, persona, firefox
+    "Foxkeh", foxkeh, persona, firefox
+    "Holiday", holiday, persona, firefox
+    "Music", music, persona, firefox
+    "Nature", nature, persona, firefox
+    "Other", other, persona, firefox
+    "Scenery", scenery, persona, firefox
+    "Seasonal", seasonal, persona, firefox
+    "Solid", solid, persona, firefox
+    "Sports", sports, persona, firefox
+    "Websites", websites, persona, firefox
+    "Appearance and Customization", appearance, extension, thunderbird
+    "Calendar and Date/Time", calendar, extension, thunderbird
+    "Chat and IM", chat, extension, thunderbird
+    "Contacts", contacts, extension, thunderbird
+    "Folders and Filters", folders-and-filters, extension, thunderbird
+    "Import/Export", importexport, extension, thunderbird
+    "Language Support", language-support, extension, thunderbird
+    "Message Composition", composition, extension, thunderbird
+    "Message and News Reading", message-and-news-reading, extension, thunderbird
+    "Miscellaneous", miscellaneous, extension, thunderbird
+    "Privacy and Security", privacy-and-security, extension, thunderbird
+    "Tags", tags, extension, thunderbird
+    "Compact", compact, theme, thunderbird
+    "Miscellaneous", miscellaneous, theme, thunderbird
+    "Modern", modern, theme, thunderbird
+    "Nature", nature, theme, thunderbird
+    "General", general, dictionary, thunderbird
+    "General", general, language, thunderbird
+    "Bookmarks", bookmarks, extension, seamonkey
+    "Downloading and File Management", downloading-and-file-management, extension, seamonkey
+    "Interface Customizations", interface-customizations, extension, seamonkey
+    "Language Support and Translation", language-support-and-translation, extension, seamonkey
+    "Miscellaneous", miscellaneous, extension, seamonkey
+    "Photos and Media", photos-and-media, extension, seamonkey
+    "Privacy and Security", privacy-and-security, extension, seamonkey
+    "RSS, News and Blogging", rss-news-and-blogging, extension, seamonkey
+    "Search Tools", search-tools, extension, seamonkey
+    "Site-specific", site-specific, extension, seamonkey
+    "Web and Developer Tools", web-and-developer-tools, extension, seamonkey
+    "Miscellaneous", miscellaneous, theme, seamonkey
+    "General", general, dictionary, seamonkey
+    "General", general, language, seamonkey
+    "Device Features & Location", device-features-location, extension, android
+    "Experimental", experimental, extension, android
+    "Feeds, News, & Blogging", feeds-news-blogging, extension, android
+    "Performance", performance, extension, android
+    "Photos & Media", photos-media, extension, android
+    "Security & Privacy", security-privacy, extension, android
+    "Shopping", shopping, extension, android
+    "Social Networking", social-networking, extension, android
+    "Sports & Games", sports-games, extension, android
+    "User Interface", user-interface, extension, android

--- a/docs/topics/api/v3_legacy/collections.rst
+++ b/docs/topics/api/v3_legacy/collections.rst
@@ -1,0 +1,258 @@
+===========
+Collections
+===========
+
+The following API endpoints cover user created collections.
+
+
+----
+List
+----
+
+.. _v3-collection-list:
+
+.. note::
+    This API requires :doc:`authentication <auth>` and `Collections:Edit`
+    permission to list collections other than your own.
+
+This endpoint allows you to list all collections authored by the specified user.
+The results are sorted by the most recently updated collection first.
+
+
+.. http:get:: /api/v3/accounts/account/(int:user_id|string:username)/collections/
+
+    :>json int count: The number of results for this query.
+    :>json string next: The URL of the next page of results.
+    :>json string previous: The URL of the previous page of results.
+    :>json array results: An array of :ref:`collections <v3-collection-detail-object>`.
+
+
+------
+Detail
+------
+
+.. _v3-collection-detail:
+
+This endpoint allows you to fetch a single collection by its ``slug``.
+It returns any ``public`` collection by the specified user. You can access
+a non-``public`` collection only if it was authored by you, the authenticated user.
+If your account has the `Collections:Edit` permission then you can access any collection.
+
+
+.. http:get:: /api/v3/accounts/account/(int:user_id|string:username)/collections/(string:collection_slug)/
+
+    .. _v3-collection-detail-object:
+
+    :>json int id: The id for the collection.
+    :>json int addon_count: The number of add-ons in this collection.
+    :>json int author.id: The id of the author (creator) of the collection.
+    :>json string author.name: The name of the author.
+    :>json string author.url: The link to the profile page for of the author.
+    :>json string author.username: The username of the author.
+    :>json string default_locale: The default locale of the description and name fields. (See :ref:`translated fields <v3-api-overview-translations>`).
+    :>json string|object|null description: The description the author added to the collection. (See :ref:`translated fields <v3-api-overview-translations>`).
+    :>json string modified: The date the collection was last updated.
+    :>json string|object name: The name of the collection. (See :ref:`translated fields <v3-api-overview-translations>`).
+    :>json boolean public: Whether the collection is `listed` - publicly viewable.
+    :>json string slug: The name used in the URL.
+    :>json string url: The (absolute) collection detail URL.
+    :>json string uuid: A unique identifier for this collection; primarily used to count addon installations that come via this collection.
+
+
+If the ``with_addons`` parameter is passed then :ref:`addons in the collection<v3-collection-addon-detail>` are returned along with the detail.
+Add-ons returned are limited to the first 25 in the collection, in the default sort (popularity, descending).
+Filtering is as per :ref:`collection addon list endpoint<v3-collection-addon-filtering-param>` - i.e. defaults to only including public add-ons.
+Additional add-ons can be returned from the :ref:`Collection Add-on list endpoint<v3-collection-addon-list>`.
+
+
+.. http:get:: /api/v3/accounts/account/(int:user_id|string:username)/collections/(string:collection_slug)/?with_addons
+
+    .. _v3-collection-detail-object-with-addons:
+
+    :query string filter: The :ref:`filter <v3-collection-addon-filtering-param>` to apply.
+    :>json int id: The id for the collection.
+    :>json int addon_count: The number of add-ons in this collection.
+    :>json array addons: An array of :ref:`addons with notes<v3-collection-addon-detail>`.
+
+... rest as :ref:`collection detail response<v3-collection-detail-object>`
+
+
+------
+Create
+------
+
+.. _`v3-collection-create`:
+
+.. note::
+    This API requires :doc:`authentication <auth>`.
+
+This endpoint allows a collection to be created under your account.  Any fields
+in the :ref:`collection <v3-collection-detail-object>` but not listed below are not settable and will be ignored in the request.
+
+.. http:post:: /api/v3/accounts/account/(int:user_id|string:username)/collections/
+
+    .. _v3-collection-create-request:
+
+    :<json string|null default_locale: The default locale of the description and name fields. Defaults to `en-US`. (See :ref:`translated fields <v3-api-overview-translations>`).
+    :<json string|object|null description: The description the author added to the collection. (See :ref:`translated fields <v3-api-overview-translations>`).
+    :<json string|object name: The name of the collection. (required) (See :ref:`translated fields <v3-api-overview-translations>`).
+    :<json boolean public: Whether the collection is `listed` - publicly viewable.  Defaults to `True`.
+    :<json string slug: The name used in the URL (required).
+
+
+----
+Edit
+----
+
+.. _`v3-collection-edit`:
+
+.. note::
+    This API requires :doc:`authentication <auth>` and `Collections:Edit`
+    permission to edit collections other than your own.
+
+This endpoint allows some of the details for a collection to be updated.  Any fields
+in the :ref:`collection <collection-detail-object>` but not listed below are not editable and will be ignored in the patch request.
+
+.. http:patch:: /api/v3/accounts/account/(int:user_id|string:username)/collections/(string:collection_slug)/
+
+    .. _v3-collection-edit-request:
+
+    :<json string default_locale: The default locale of the description and name fields. (See :ref:`translated fields <api-overview-translations>`).
+    :<json string|object|null description: The description the author added to the collection. (See :ref:`translated fields <api-overview-translations>`).
+    :<json string|object name: The name of the collection. (See :ref:`translated fields <api-overview-translations>`).
+    :<json boolean public: Whether the collection is `listed` - publicly viewable.
+    :<json string slug: The name used in the URL.
+
+
+------
+Delete
+------
+
+.. _`v3-collection-delete`:
+
+.. note::
+    This API requires :doc:`authentication <auth>` and `Collections:Edit`
+    permission to delete collections other than your own.
+
+This endpoint allows the collection to be deleted.
+
+.. http:delete:: /api/v3/accounts/account/(int:user_id|string:username)/collections/(string:collection_slug)/
+
+
+
+-----------------------
+Collection Add-ons List
+-----------------------
+
+.. _v3-collection-addon-list:
+
+This endpoint lists the add-ons in a collection, together with collector's notes.
+
+.. http:get:: /api/v3/accounts/account/(int:user_id|string:username)/collections/(string:collection_slug)/addons/
+
+    :query string filter: The :ref:`filter <collection-addon-filtering-param>` to apply.
+    :query string sort: The sort parameter. The available parameters are documented in the :ref:`table below <collection-addon-list-sort>`.
+    :>json int count: The number of results for this query.
+    :>json string next: The URL of the next page of results.
+    :>json string previous: The URL of the previous page of results.
+    :>json array results: An array of :ref:`items <collection-addon-detail-object>` in this collection.
+
+
+.. _v3-collection-addon-list-sort:
+
+    Available sorting parameters:
+
+    ==============  ==========================================================
+         Parameter  Description
+    ==============  ==========================================================
+             added  Date the add-on was added to the collection, ascending.
+        popularity  Number of total weekly downloads of the add-on, ascending.
+              name  Add-on name, ascending.
+    ==============  ==========================================================
+
+All sort parameters can be reversed, e.g. '-added' for descending dates.
+The default sorting is by popularity, descending ('-popularity').
+
+
+.. _v3-collection-addon-filtering-param:
+
+   By default, the collection addon list API will only return public add-ons
+   (excluding add-ons that have no approved listed versions, are disabled or
+   deleted) - you can change that with the ``filter`` query parameter:
+
+    ================  ========================================================
+               Value  Description
+    ================  ========================================================
+                 all  Show all add-ons in the collection, including those that
+                      have non-public statuses.  This still excludes deleted
+                      add-ons.
+    all_with_deleted  Show all add-ons in the collection, including deleted
+                      add-ons too.
+    ================  ========================================================
+
+
+-------------------------
+Collection Add-ons Detail
+-------------------------
+
+.. _v3-collection-addon-detail:
+
+This endpoint gets details of a single add-on in a collection, together with collector's notes.
+
+.. http:get:: /api/v3/accounts/account/(int:user_id|string:username)/collections/(string:collection_slug)/addons/(int:addon_id|string:slug)/
+
+    .. _v3-collection-addon-detail-object:
+
+    :>json object addon: The :ref:`add-on <addon-detail-object>` for this item.
+    :>json string|object|null notes: The collectors notes for this item. (See :ref:`translated fields <api-overview-translations>`).
+    :>json int downloads: The downloads that occured via this collection.
+
+
+-------------------------
+Collection Add-ons Create
+-------------------------
+
+.. _v3-collection-addon-create:
+
+.. note::
+    This API requires :doc:`authentication <auth>` and `Collections:Edit`
+    permission to edit collections other than your own.
+
+This endpoint allows a single add-on to be added to a collection, optionally with collector's notes.
+
+.. http:post:: /api/v3/accounts/account/(int:user_id|string:username)/collections/(string:collection_slug)/addons/
+
+    :<json string addon: The add-on id or slug to be added (required).
+    :<json string|object|null notes: The collectors notes for this item. (See :ref:`translated fields <api-overview-translations>`).
+
+
+-----------------------
+Collection Add-ons Edit
+-----------------------
+
+.. _v3-collection-addon-edit:
+
+.. note::
+    This API requires :doc:`authentication <auth>` and `Collections:Edit`
+    permission to edit collections other than your own.
+
+This endpoint allows the collector's notes for single add-on to be updated.
+
+.. http:patch:: /api/v3/accounts/account/(int:user_id|string:username)/collections/(string:collection_slug)/addons/(int:addon_id|string:slug)/
+
+    :<json string|object|null notes: The collectors notes for this item. (See :ref:`translated fields <api-overview-translations>`).
+
+
+-------------------------
+Collection Add-ons Delete
+-------------------------
+
+.. _v3-collection-addon-delete:
+
+.. note::
+    This API requires :doc:`authentication <auth>` and `Collections:Edit`
+    permission to edit collections other than your own.
+
+This endpoint allows a single add-on to be removed from a collection.
+
+.. http:delete:: /api/v3/accounts/account/(int:user_id|string:username)/collections/(string:collection_slug)/addons/(int:addon_id|string:slug)/

--- a/docs/topics/api/v3_legacy/discovery.rst
+++ b/docs/topics/api/v3_legacy/discovery.rst
@@ -1,0 +1,57 @@
+=========
+Discovery
+=========
+
+.. note::
+    These APIs are experimental and are currently being worked on. Endpoints
+    may change without warning.
+
+-----------------
+Discovery Content
+-----------------
+
+.. _v3-disco-content:
+
+This endpoint allows you to fetch content for the new Discovery Pane in
+Firefox (about:addons).
+
+ .. http:get:: /api/v3/discovery/
+
+    :query string lang: Activate translations in the specific language for that query. (See :ref:`translated fields <v3-api-overview-translations>`)
+    :query string edition: Return content for a specific edition of Firefox.  Currently only ``china`` is supported.
+    :>json int count: The number of results for this query.
+    :>json array results: The array containing the results for this query.
+    :>json string results[].heading: The heading for this item. May contain some HTML tags.
+    :>json string|null results[].description: The description for this item, if any. May contain some HTML tags.
+    :>json boolean results[].is_recommendation: If this item was from the recommendation service, rather than static curated content.
+    :>json object results[].addon: The :ref:`add-on <v3-addon-detail-object>` for this item. Only a subset of fields are present: ``id``, ``current_version`` (with only the ``compatibility`` and ``files`` fields present), ``guid``, ``icon_url``, ``name``, ``slug``, ``theme_data``, ``type`` and ``url``.
+
+
+-------------------------
+Discovery Recommendations
+-------------------------
+
+.. _v3-disco-recommendations:
+
+If a telemetry client id is passed as a parameter to the discovery pane api
+endpoint then static curated content is amended with recommendations from the
+`recommendation service <https://github.com/mozilla/taar>`_.  The same number
+of results will be returned as a standard discovery response and only extensions
+(not themes) are recommeded.  Only valid, publicly available addons are shown.
+
+E.g. a standard discovery pane will display 7 items, 4 extensions and 3 themes.
+Up to 4 extensions will be replaced with recommendations; the 3 themes will not
+be replaced. The API will still return a total of 7 items.
+
+.. note::
+    Specifying an ``edition`` parameter disables recommendations - the ``telemetry-client-id``
+    is ignored and standard discovery response returned.
+
+
+ .. http:get:: /api/v3/discovery/?telemetry-client-id=12345678-90ab-cdef-1234-567890abcdef
+
+    :query string telemetry-client-id: The telemetry client ID to be passed to the TAAR service.
+    :query string lang: In addition to activating translations (see :ref:`Discovery Content <v3-disco-content>`), this will be passed as `locale` to TAAR.
+    :query string platform: The platform identifier to be passed to TAAR.
+    :query string branch: Additional parameter passed along to TAAR.
+    :query string study: Additional parameter passed along to TAAR.

--- a/docs/topics/api/v3_legacy/download_sources.rst
+++ b/docs/topics/api/v3_legacy/download_sources.rst
@@ -1,0 +1,75 @@
+================
+Download Sources
+================
+
+.. _v3-download-sources:
+
+When requesting an add-on file URL, clients have the option to indicate what is
+the source of the request. This will then be used to group by downloads by
+sources in the add-on statistics page.
+
+To indicate the source, add the ``src`` query parameter to the download URL.
+The following values are recognized:
+
+.. csv-table::
+   :header: "Name", "Description"
+
+    api,"Add-ons Manager"
+    discovery-promo,"Add-ons Manager Promo"
+    discovery-featured,"Add-ons Manager Featured"
+    discovery-learnmore,"Add-ons Manager Learn More"
+    ss,"Search Suggestions"
+    search,"Search Results"
+    homepagepromo,"Homepage Promo"
+    hp-btn-promo,"Homepage Promo"
+    hp-dl-promo,"Homepage Promo"
+    hp-hc-featured,"Homepage Featured"
+    hp-dl-featured,"Homepage Featured"
+    hp-hc-upandcoming,"Homepage Up and Coming"
+    hp-dl-upandcoming,"Homepage Up and Coming"
+    hp-dl-mostpopular,"Homepage Most Popular"
+    dp-btn-primary,"Detail Page"
+    dp-btn-version,"Detail Page (bottom)"
+    addondetail,"Detail Page"
+    addon-detail-version,"Detail Page (bottom)"
+    dp-btn-devchannel,"Detail Page (Development Channel)"
+    oftenusedwith,"Often Used With"
+    dp-hc-oftenusedwith,"Often Used With"
+    dp-dl-oftenusedwith,"Often Used With"
+    dp-hc-othersby,"Others By Author"
+    dp-dl-othersby,"Others By Author"
+    dp-hc-dependencies,"Dependencies"
+    dp-dl-dependencies,"Dependencies"
+    dp-hc-upsell,"Upsell"
+    dp-dl-upsell,"Upsell"
+    developers,"Meet the Developer"
+    userprofile,"User Profile"
+    version-history,"Version History"
+    sharingapi,"Sharing"
+    category,"Category Pages"
+    collection,"Collections"
+    cb-hc-featured,"Category Landing Featured Carousel"
+    cb-dl-featured,"Category Landing Featured Carousel"
+    cb-hc-toprated,"Category Landing Top Rated"
+    cb-dl-toprated,"Category Landing Top Rated"
+    cb-hc-mostpopular,"Category Landing Most Popular"
+    cb-dl-mostpopular,"Category Landing Most Popular"
+    cb-hc-recentlyadded,"Category Landing Recently Added"
+    cb-dl-recentlyadded,"Category Landing Recently Added"
+    cb-btn-featured,"Browse Listing Featured Sort"
+    cb-dl-featured,"Browse Listing Featured Sort"
+    cb-btn-users,"Browse Listing Users Sort"
+    cb-dl-users,"Browse Listing Users Sort"
+    cb-btn-rating,"Browse Listing Rating Sort"
+    cb-dl-rating,"Browse Listing Rating Sort"
+    cb-btn-created,"Browse Listing Created Sort"
+    cb-dl-created,"Browse Listing Created Sort"
+    cb-btn-name,"Browse Listing Name Sort"
+    cb-dl-name,"Browse Listing Name Sort"
+    cb-btn-popular,"Browse Listing Popular Sort"
+    cb-dl-popular,"Browse Listing Popular Sort"
+    cb-btn-updated,"Browse Listing Updated Sort"
+    cb-dl-updated,"Browse Listing Updated Sort"
+    cb-btn-hotness,"Browse Listing Up and Coming Sort"
+    cb-dl-hotness,"Browse Listing Up and Coming Sort"
+    find-replacement,"Find replacement service for obsolete add-ons"

--- a/docs/topics/api/v3_legacy/github.rst
+++ b/docs/topics/api/v3_legacy/github.rst
@@ -1,0 +1,39 @@
+===============
+GitHub Webhooks
+===============
+
+.. note::
+
+    This is an Experimental API and can change at any time.
+
+This API provides an endpoint that works with GitHub to provide add-on validation as a GitHub webhook. This end point is designed to be called specifically from GitHub and will only send API responses back to `api.github.com`.
+
+To set this up on a GitHub repository you will need to:
+
+* Go to `Settings > Webhooks & Services`
+* Add a new Webhook with Payload URL of `https://addons.mozilla.org/api/v3/github/validate/`
+* Click `Send me everything`
+* Click `Update webhook`
+
+At this point the validator will be able to get the data, but won't be able to write a response to GitHub. To enable responses to GitHub:
+
+* Go to `Settings > Collaborators`
+* Enter `addons-robot` and select the entry
+* Click `Add collaborator`
+* You will have to wait for a Mozilla person to respond to the invite
+
+If this service proves useful and this service transitions from its Experimental API state, we will remove as many of these steps as possible.
+
+The validator will run when you create or alter a pull request.
+
+.. http:post:: /api/v3/github/validate/
+
+    **Request:**
+
+    A `GitHub API webhook <https://developer.github.com/v3/repos/hooks/>`_ body. Currently only `pull_request` events are processed, all others are ignored.
+
+    **Response:**
+
+    :statuscode 201: request has been processed and a pending message sent back to GitHub.
+    :statuscode 200: request is not a `pull_request`, it's been accepted.
+    :statuscode 422: body is invalid.

--- a/docs/topics/api/v3_legacy/index.rst
+++ b/docs/topics/api/v3_legacy/index.rst
@@ -1,0 +1,48 @@
+.. _v3-api-index:
+
+=================
+External API (V3)
+=================
+
+This shows you how to use the `addons.mozilla.org <https://addons.mozilla.org/en-US/firefox/>`_
+API at ``/api/v3/`` which is hosted at the following URLs:
+
+.. _v3-api-environments:
+
+===========  =========================================
+Environment  URL
+===========  =========================================
+Production   ``https://addons.mozilla.org/api/v3/``
+Staging      ``https://addons.allizom.org/api/v3/``
+Development  ``https://addons-dev.allizom.org/api/v3/``
+===========  =========================================
+
+Production
+    Connect to this API for all normal operation.
+Staging or Development
+    Connect to these APIs if you need to work with a scratch database or
+    you're testing features that aren't available in production yet.
+    Your production account is not linked to any of these APIs.
+
+Dive into the :ref:`overview section <v3-api-overview>` and the
+:ref:`authentication section <v3-api-auth>` for an example of how to get started
+using the API.
+
+.. toctree::
+   :maxdepth: 2
+
+   overview
+   auth
+   auth_internal
+   abuse
+   accounts
+   activity
+   addons
+   categories
+   collections
+   discovery
+   download_sources
+   reviews
+   reviewers
+   signing
+   github

--- a/docs/topics/api/v3_legacy/overview.rst
+++ b/docs/topics/api/v3_legacy/overview.rst
@@ -1,0 +1,164 @@
+.. _v3-api-overview:
+
+========
+Overview
+========
+
+This describes the details of the requests and responses you can expect from
+the `addons.mozilla.org <https://addons.mozilla.org/en-US/firefox/>`_ API.
+
+--------
+Requests
+--------
+
+All requests should be made with the header::
+
+        Content-type: application/json
+
+---------
+Responses
+---------
+
+~~~~~~~~~~~~
+Status Codes
+~~~~~~~~~~~~
+
+There are some common API responses that you can expect to receive at times.
+
+.. http:get:: /api/v3/...
+
+    :statuscode 200: Success.
+    :statuscode 201: Creation successful.
+    :statuscode 202: The request has been accepted for processing.
+        This usually means one or more asyncronous tasks is being executed in
+        the background so results aren't immediately visible.
+    :statuscode 204: Success (no content is returned).
+    :statuscode 400: There was a problem with the parameters sent with this
+        request.
+    :statuscode 401: Authentication is required or failed.
+    :statuscode 403: You are not permitted to perform this action.
+    :statuscode 404: The requested resource could not be found.
+    :statuscode 500: An unknown error occurred.
+    :statuscode 503: The site is in maintenance mode at this current time and
+        the operation can not be performed.
+
+~~~~~~~~~~~~
+Bad Requests
+~~~~~~~~~~~~
+
+When returning a ``HTTP 400 Bad Request`` response, the API will try to return
+some information about the error(s) in the body of the response, as a JSON
+object. The keys of that object indicate the field(s) that caused an error, and
+for each, a list of messages will be provided (often only one message will be
+present, but sometimes more). If the error is not attached to a specific field
+the key ``non_field_errors`` will be used instead.
+
+Example:
+
+     .. code-block:: json
+
+         {
+             "username": ["This field is required."],
+             "non_field_errors": ["Error not linked to a specific field."]
+         }
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Unauthorized and Permission Denied
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When returning ``HTTP 401 Unauthorized`` and ``HTTP 403 Permission Denied``
+responses, the API will try to return some information about the error in the
+body of the response, as a JSON object. A ``detail`` property will contain a
+message explaining the error. In addition, in some cases, an optional ``code``
+property will be present and will contain a constant corresponding to
+specific problems to help clients address the situation programmatically. The
+constants are as follows:
+
+    ========================  =========================================================
+                       Value  Description
+    ========================  =========================================================
+        ERROR_INVALID_HEADER  The ``Authorization`` header is invalid.
+     ERROR_SIGNATURE_EXPIRED  The signature of the token indicates it has expired.
+    ERROR_DECODING_SIGNATURE  The token was impossible to decode and probably invalid.
+    ========================  =========================================================
+
+
+~~~~~~~~~~
+Pagination
+~~~~~~~~~~
+
+By default, all endpoints returning a list of results are paginated.
+The default number of items per page is 25 and clients can use the `page_size`
+query parameter to change it to any value between 1 and 50. Exceptions to those
+rules are possible but will be noted in the corresponding documentation for
+affected endpoints.
+
+The following properties will be available in paginated responses:
+
+* *next*: the URL for the next page in the pagination.
+* *previous*: the URL for the previous page in the pagination.
+* *page_size*: The number of items per page in the pagination.
+* *page_count*: The number of pages available in the pagination. It may be
+  lower than `count / page_size` for elasticsearch based paginations that
+  go beyond our `max_result_window` configuration.
+* *count*: the total number of records.
+* *results*: the array containing the results for this page.
+
+
+.. _v3-api-overview-translations:
+
+~~~~~~~~~~~~~~~~~
+Translated Fields
+~~~~~~~~~~~~~~~~~
+
+Fields that can be translated by users (typically name, description) have a
+special behaviour. The default is to return them as an object, with languages
+as keys and translations as values:
+
+.. code-block:: json
+
+    {
+        "name": {
+            "en-US": "Games",
+            "fr": "Jeux",
+            "kn": "ಆಟಗಳು"
+        }
+    }
+
+However, for performance, if you pass the ``lang`` parameter to a ``GET``
+request, then only the most relevant translation (the specified language or the
+fallback, depending on whether a translation is available in the requested
+language) will be returned as a string.
+
+.. code-block:: json
+
+    {
+        "name": "Games"
+    }
+
+This behaviour also applies to ``POST``, ``PATCH`` and ``PUT`` requests: you
+can either submit an object containing several translations, or just a string.
+If only a string is supplied, it will only be used to translate the field in
+the current language.
+
+.. _v3-api-overview-outgoing:
+
+~~~~~~~~~~~~~~
+Outgoing Links
+~~~~~~~~~~~~~~
+
+If the ``wrap_outgoing_links`` query parameter is present, any external links
+returned for properties such as ``support_url`` or ``homepage`` will be wrapped
+through ``outgoing.prod.mozaws.net``. Fields supporting some HTML, such as
+add-on ``description``, always do this regardless of whether or not the query
+parameter is present.
+
+~~~~~~~~~~~~
+Cross Origin
+~~~~~~~~~~~~
+
+All APIs are available with `Cross-Origin Resource Sharing`_ unless otherwise
+specified.
+
+
+.. _`Cross-Origin Resource Sharing`: https://developer.mozilla.org/en-US/docs/HTTP/Access_control_CORS

--- a/docs/topics/api/v3_legacy/reviewers.rst
+++ b/docs/topics/api/v3_legacy/reviewers.rst
@@ -1,0 +1,83 @@
+.. _v3-reviewers:
+
+=========
+Reviewers
+=========
+
+.. note::
+
+    These APIs are experimental and are currently being worked on. Endpoints
+    may change without warning. The only authentication method available at
+    the moment is :ref:`the internal one <v3-api-auth-internal>`.
+
+---------
+Subscribe
+---------
+
+This endpoint allows you to subscribe the current user to the notification
+sent when a new listed version is submitted on a particular add-on.
+
+    .. note::
+        Requires authentication and the current user to have any
+        reviewer-related permission.
+
+.. http:post::/api/v3/reviewers/addon/(int:addon_id)/subscribe/
+
+-----------
+Unsubscribe
+-----------
+
+This endpoint allows you to unsubscribe the current user to the notification
+sent when a new listed version is submitted on a particular add-on.
+
+    .. note::
+        Requires authentication and the current user to have any
+        reviewer-related permission.
+
+.. http:post::/api/v3/reviewers/addon/(int:addon_id)/unsubscribe/
+
+-------
+Disable
+-------
+
+This endpoint allows you to disable the public listing for an add-on.
+
+    .. note::
+       Requires authentication and the current user to have ``Reviews:Admin``
+        permission.
+
+.. http:post::/api/v3/reviewers/addon/(int:addon_id)/disable/
+
+------
+Enable
+------
+
+This endpoint allows you to re-enable the public listing for an add-on. If the
+add-on can't be public because it does not have public versions, it will
+instead be changed to awaiting review or incomplete depending on the status
+of its versions.
+
+    .. note::
+        Requires authentication and the current user to have ``Reviews:Admin``
+        permission.
+
+.. http:post::/api/v3/reviewers/addon/(int:addon_id)/enable/
+
+
+-----
+Flags
+-----
+
+This endpoint allows you to manipulate various reviewer-specific flags on an
+add-on.
+
+    .. note::
+       Requires authentication and the current user to have ``Reviews:Admin``
+       permission.
+
+.. http:patch::/api/v3/reviewers/addon/(int:addon_id)/flags/
+
+    :>json boolean auto_approval_disabled: Boolean indicating whether auto approval are disabled on an add-on or not. When it's ``true``, new versions for this add-on will make it appear in the regular reviewer queues instead of being auto-approved.
+    :>json string|null pending_info_request: Deadline date for the pending info request as a string, or ``null``.
+    :>json boolean needs_admin_code_review: Boolean indicating whether the add-on needs its code to be reviewed by an admin or not.
+    :>json boolean needs_admin_content_review: Boolean indicating whether the add-on needs its content to be reviewed by an admin or not.

--- a/docs/topics/api/v3_legacy/reviews.rst
+++ b/docs/topics/api/v3_legacy/reviews.rst
@@ -1,0 +1,197 @@
+=======
+Reviews
+=======
+
+.. note::
+
+    These APIs are experimental and are currently being worked on. Endpoints
+    may change without warning. The only authentication method available at
+    the moment is :ref:`the internal one<v3-api-auth-internal>`.
+
+------------
+List reviews
+------------
+
+.. review-list:
+
+This endpoint allows you to fetch reviews for a given add-on or user. Either
+``addon`` or ``user`` query parameters are required, and they can be
+combined together.
+
+When ``addon``, ``user`` and ``version`` are passed on the same request,
+``page_size`` will automatically be set to ``1``, since an user can only post
+one review per version of a given add-on. This can be useful to find out if a
+user has already posted a review for the current version of an add-on.
+
+.. http:get:: /api/v3/reviews/review/
+
+    :query string addon: The :ref:`add-on <v3-addon-detail>` id, slug, or guid to fetch reviews from. When passed, the reviews shown will always be the latest posted by each user on this particular add-on (which means there should only be one review per user in the results), unless the ``version`` parameter is also passed.
+    :query string filter: The :ref:`filter(s) <v3-review-filtering-param>` to apply.
+    :query string user: The user id to fetch reviews from.
+    :query boolean show_grouped_ratings: Whether or not to show ratings aggregates for this add-on in the response (Use "true"/"1" as truthy values, "0"/"false" as falsy ones).
+    :query string version: The version id to fetch reviews from.
+    :query int page: 1-based page number. Defaults to 1.
+    :query int page_size: Maximum number of results to return for the requested page. Defaults to 25.
+    :>json int count: The number of results for this query.
+    :>json string next: The URL of the next page of results.
+    :>json string previous: The URL of the previous page of results.
+    :>json array results: An array of :ref:`reviews <v3-review-detail-object>`.
+    :>json object grouped_ratings: Only present if ``show_grouped_ratings`` query parameter is present. An object with 5 key-value pairs, the keys representing each possible rating (Though a number, it has to be converted to a string because of the JSON formatting) and the values being the number of times the corresponding rating has been posted for this add-on, e.g. ``{"1": 4, "2": 8, "3": 15, "4": 16: "5": 23}``.
+
+.. _v3-review-filtering-param:
+
+   By default, the review list API will only return not-deleted reviews, and
+   include reviews without text. You can change that with the ``filter`` query
+   parameter.  You can filter by multiple values, e.g. ``filter=with_deleted,without_empty_body,with_yours``
+
+    ===================  ======================================================
+                  Value  Description
+    ===================  ======================================================
+           with_deleted  Returns deleted reviews too.  This requires the
+                         Addons:Edit permission.
+     without_empty_body  Excludes reviews that only contain a rating, and no
+                         textual content.
+             with_yours  Used in combination `without_empty_body` to include
+                         your own reviews, even if they have no text.
+    ===================  ======================================================
+
+------
+Detail
+------
+
+.. review-detail:
+
+This endpoint allows you to fetch a review by its id.
+
+.. http:get:: /api/v3/reviews/review/(int:id)/
+
+    .. _v3-review-detail-object:
+
+    :>json int id: The review id.
+    :>json object addon: An object included for convenience that contains only two properties: ``id`` and ``slug``, corresponding to the add-on id and slug.
+    :>json string|null body: The text of the review.
+    :>json boolean is_latest: Boolean indicating whether the review is the latest posted by the user on the same add-on.
+    :>json int previous_count: The number of reviews posted by the user on the same add-on before this one.
+    :>json int rating: The rating the user gave as part of the review.
+    :>json object|null reply: The review object containing the developer reply to this review, if any (The fields ``rating``, ``reply`` and ``version`` are omitted).
+    :>json string|null title: The title of the review.
+    :>json int version.id: The add-on version id the review applies to.
+    :>json string version.version: The add-on version string the review applies to.
+    :>json object user: Object holding information about the user who posted the review.
+    :>json string user.id: The user id.
+    :>json string user.name: The user name.
+    :>json string user.url: The user profile URL.
+    :>json string user.username: The user username.
+
+----
+Post
+----
+
+.. review-post:
+
+This endpoint allows you to post a new review for a given add-on and version.
+If successful a :ref:`review object <v3-review-detail-object>` is returned.
+
+ .. note::
+     Requires authentication.
+
+
+.. http:post:: /api/v3/reviews/review/
+
+    :<json string addon: The add-on id the review applies to (required).
+    :<json string|null body: The text of the review.
+    :<json string|null title: The title of the review.
+    :<json int rating: The rating the user wants to give as part of the review (required).
+    :<json int version: The add-on version id the review applies to (required).
+
+----
+Edit
+----
+
+.. review-edit:
+
+This endpoint allows you to edit an existing review by its id.
+If successful a :ref:`review object <v3-review-detail-object>` is returned.
+
+ .. note::
+     Requires authentication and Addons:Edit permissions or the user
+     account that posted the review.
+
+     Only body, title and rating are allowed for modification.
+
+.. http:patch:: /api/v3/reviews/review/(int:id)/
+
+    :<json string|null body: The text of the review.
+    :<json string|null title: The title of the review.
+    :<json int rating: The rating the user wants to give as part of the review.
+
+
+------
+Delete
+------
+
+.. review-delete:
+
+This endpoint allows you to delete an existing review by its id.
+
+ .. note::
+     Requires authentication and Addons:Edit permission or the user
+     account that posted the review. Even with the right permission, users can
+     not delete a review from somebody else if it was posted on an add-on they
+     are listed as a developer of.
+
+.. http:delete:: /api/v3/reviews/review/(int:id)/
+
+
+-----
+Reply
+-----
+
+.. review-reply:
+
+This endpoint allows you to reply to an existing user review.
+If successful a :ref:`review reply object <v3-review-detail-object>` is returned.
+
+ .. note::
+     Requires authentication and either Addons:Edit permission or a user account
+     listed as a developer of the add-on.
+
+.. http:post:: /api/v3/reviews/review/(int:id)/reply/
+
+    :<json string body: The text of the reply (required).
+    :<json string|null title: The title of the reply.
+
+
+----
+Flag
+----
+
+.. review-flag:
+
+This endpoint allows you to flag an existing user review, to let a moderator know
+that something may be wrong with it.
+
+
+ .. note::
+     Requires authentication and a user account different from the one that
+     posted the review.
+
+.. http:post:: /api/v3/reviews/review/(int:id)/flag/
+
+    :<json string flag: A :ref:`constant <v3-review-flag-constants>` describing the reason behind the flagging.
+    :<json string|null note: A note to explain further the reason behind the flagging.
+        This field is required if the flag is ``review_flag_reason_other``, and passing it will automatically change the flag to that value.
+    :>json object: If successful, an object with a ``msg`` property containing a success message. If not, an object indicating which fields contain errors.
+
+.. _v3-review-flag-constants:
+
+    Available constants for the ``flag`` property:
+
+    ===============================  ==========================================
+                          Constant    Description
+    ===============================  ==========================================
+            review_flag_reason_spam  Spam or otherwise non-review content
+        review_flag_reason_language  Inappropriate language/dialog
+     review_flag_reason_bug_support  Misplaced bug report or support request
+           review_flag_reason_other  Other (please specify)
+    ===============================  ==========================================

--- a/docs/topics/api/v3_legacy/signing.rst
+++ b/docs/topics/api/v3_legacy/signing.rst
@@ -1,0 +1,252 @@
+=======
+Signing
+=======
+
+.. note:: This API requires :doc:`authentication <auth>`.
+
+The following API endpoints help you get your add-on signed by Mozilla
+so it can be installed into Firefox without error. See
+`extension signing <https://wiki.mozilla.org/Addons/Extension_Signing>`_
+for more details about Firefox's signing policy.
+
+----------------
+Client Libraries
+----------------
+
+The following libraries will make it easier to use the signing API:
+
+* `sign-addon <https://github.com/mozilla/sign-addon/>`_, for general programattic use in
+  `NodeJS <https://nodejs.org/>`_
+* `web-ext sign <https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Getting_started_with_web-ext#Signing_your_extension_for_distribution>`_,
+  for developing `Web Extensions <https://developer.mozilla.org/en-US/Add-ons/WebExtensions>`_
+
+If you are using ``curl`` to interact with the API you should be sure to pass
+the ``-g`` flag to skip "URL globbing" which won't interact well with add-on
+Ids that have {} characters in them.
+
+
+.. _v3-upload-version:
+
+-------------------
+Uploading a version
+-------------------
+
+You can upload a new version for signing by issuing a ``PUT`` request
+and including the contents of your add-on in the ``upload`` parameter
+as multi-part formdata. This will create a pending version on the
+add-on and will prevent future submissions to this version unless
+validation or review fails.
+
+If the upload succeeded then it will be submitted for
+validation and you will be able to check its status.
+
+.. http:put:: /api/v3/addons/[string:addon-id]/versions/[string:version]/
+
+    **Request:**
+
+    .. sourcecode:: bash
+
+        curl "https://addons.mozilla.org/api/v3/addons/@my-addon/versions/1.0/"
+            -g -XPUT --form "upload=@build/my-addon.xpi"
+            -H "Authorization: JWT <jwt-token>"
+
+    :param addon-id: The id for the add-on.
+    :param version: The version of the add-on.
+    :form upload: The add-on file being uploaded.
+    :form channel: (optional) The channel this version should be uploaded to,
+        which determines its visibility on the site. It can be either
+        ``unlisted`` or ``listed``.  See the note below.
+    :reqheader Content-Type: multipart/form-data
+
+    .. note::
+        ``channel`` is only valid for new versions on existing add-ons.
+        If the add-on is new then the version will be created as ``unlisted``.
+        If the parameter isn't supplied then the channel of the most recent
+        version (submitted either via this API or the website) will be assumed.
+        For example, if you submit a version as ``listed`` then the next version
+        will be ``listed`` if you don't specify the channel.
+
+    **Response:**
+
+    The response body will be the same as the :ref:`v3-version-status` response.
+
+    :statuscode 201: new add-on and version created.
+    :statuscode 202: new version created.
+    :statuscode 400: an error occurred, check the `error` value in the JSON.
+    :statuscode 401: authentication failed.
+    :statuscode 403: you do not own this add-on.
+    :statuscode 409: version already exists.
+
+
+Uploading without an ID
+-----------------------
+
+.. note::
+    This is only valid for `WebExtensions <https://wiki.mozilla.org/WebExtensions>`_.
+    All other add-on types require an add-on ID and have to use the regular
+    endpoint to :ref:`upload a version <v3-upload-version>`.
+
+
+.. http:post:: /api/v3/addons/
+
+    **Request:**
+
+    .. sourcecode:: bash
+
+        curl "https://addons.mozilla.org/api/v3/addons/"
+            -g -XPOST -F "upload=@build/my-addon.xpi" -F "version=1.0"
+            -H "Authorization: JWT <jwt-token>"
+
+    :form upload: The add-on file being uploaded.
+    :form version: The version of the add-on.
+    :reqheader Content-Type: multipart/form-data
+
+    **Response:**
+
+    The response body will be the same as the :ref:`v3-version-status` response.
+
+    :statuscode 201: new add-on and version created.
+    :statuscode 202: new version created.
+    :statuscode 400: an error occurred, check the `error` value in the JSON.
+    :statuscode 401: authentication failed.
+    :statuscode 403: you do not own this add-on.
+    :statuscode 409: version already exists.
+
+------------------
+Creating an add-on
+------------------
+
+If this is the first time that your add-on's UUID has been seen then
+the add-on will be created as an unlisted add-on when the version is
+uploaded.
+
+.. _`v3-version-status`:
+
+-----------------------------------
+Checking the status of your upload
+-----------------------------------
+
+You can check the status of your upload by issuing a ``GET`` request.
+There are a few things that will happen once a version is uploaded
+and the status of those events is included in the response.
+
+Once validation is completed (whether it passes or fails) then the
+``processed`` property will be ``true``. You can check if validation
+passed using the ``valid`` property and check the results with
+``validation_results``.
+
+If validation passed then your add-on will be submitted for review.
+In the case of unlisted add-ons this will happen automatically.  If your add-on
+is listed then it will be reviewed by a human and that will take a bit longer.
+You can check the ``automated_signing`` property to see if signing will happen
+automatically or after a manual review. Once review is complete then the
+``reviewed`` property will be set and you can check the results with the
+``passed_review`` property.
+
+.. http:get:: /api/v3/addons/[string:addon-id]/versions/[string:version]/(uploads/[string:upload-pk]/)
+
+    **Request:**
+
+    .. sourcecode:: bash
+
+        curl "https://addons.mozilla.org/api/v3/addons/@my-addon/versions/1.0/"
+            -g -H "Authorization: JWT <jwt-token>"
+
+    :param addon-id: the id for the add-on.
+    :param version: the version of the add-on.
+    :param upload-pk: (optional) the pk for a specific upload.
+
+    **Response:**
+
+    .. code-block:: json
+
+            {
+                "guid": "420854ee-7a85-42b9-822f-8e03dc5f6de9",
+                "active": true,
+                "automated_signing": true,
+                "files": [
+                    {
+                        "download_url": "https://addons.mozilla.org/api/v3/downloads/file/100/example-id.0-fx+an.xpi?src=api",
+                        "hash": "sha256:1bb945266bf370170a656350d9b640cbcaf70e671cf753c410e604219cdd9267",
+                        "signed": true
+                    }
+                ],
+                "passed_review": true,
+                "pk": "f68abbb3b1624c098fe979a409fe3ce9",
+                "processed": true,
+                "reviewed": true,
+                "url": "https://addons.mozilla.org/api/v3/addons/@example-id.0/uploads/f68abbb3b1624c098fe979a409fe3ce9/",
+                "valid": true,
+                "validation_results": {},
+                "validation_url": "https://addons.mozilla.org/en-US/developers/upload/f68abbb3b1624c098fe979a409fe3ce9",
+                "version": "1.0"
+            }
+
+    :>json guid: The GUID of the addon.
+    :>json active: version is active.
+    :>json automated_signing:
+        If true, the version will be signed automatically. If false it will end
+        up in the manual review queue when valid.
+    :>json files[].download_url:
+        URL to :ref:`download the add-on file <v3-download-signed-file>`.
+    :>json files[].hash:
+        Hash of the file contents, prefixed by the hashing algorithm used.
+        Example: ``sha256:1bb945266bf3701...`` . In the case of signed files,
+        the hash will be that of the final signed file, not the original
+        unsigned file.
+    :>json files[].signed: if the file is signed.
+    :>json passed_review: if the version has passed review.
+    :>json pk: the pk for this upload.
+    :>json processed: if the version has been processed by the validator.
+    :>json reviewed: if the version has been reviewed.
+    :>json url: URL to check the status of this upload.
+    :>json valid: if the version passed validation.
+    :>json validation_results: the validation results (removed from the example for brevity).
+    :>json validation_url: a URL to the validation results in HTML format.
+    :>json version: the version.
+
+    :statuscode 200: request successful.
+    :statuscode 401: authentication failed.
+    :statuscode 403: you do not own this add-on.
+    :statuscode 404: add-on or version not found.
+
+.. _v3-download-signed-file:
+
+------------------------
+Downloading signed files
+------------------------
+
+When checking on your :ref:`request to sign a version <v3-version-status>`,
+a successful response will give you an API URL to download the signed files.
+This endpoint returns the actual file data for download.
+
+.. http:get:: /api/v3/file/[int:file_id]/[string:base_filename]
+
+    **Request:**
+
+    .. sourcecode:: bash
+
+        curl "https://addons.mozilla.org/api/v3/file/123/some-addon.xpi?src=api"
+            -g -H "Authorization: JWT <jwt-token>"
+
+    :param file_id: the primary key of the add-on file.
+    :param base_filename:
+        the base filename. This is just a convenience for
+        clients so that they write meaningful file names to disk.
+
+    **Response:**
+
+    There are two possible responses:
+
+    * Binary data containing the file
+    * A header that redirects you to a mirror URL for the file.
+      In this case, the initial response will include a
+      ``SHA-256`` hash of the file in the header ``X-Target-Digest``.
+      Clients should check that the final downloaded file matches
+      this hash.
+
+    :statuscode 200: request successful.
+    :statuscode 302: file resides at a mirror URL
+    :statuscode 401: authentication failed.
+    :statuscode 404: file does not exist or requester does not have
+                     access to it.


### PR DESCRIPTION
This allows us to make changes much easier.

* Change all :ref: links in v3-docs to include a "v3" prefix
* Add v3 docs to index under new "Archived Contents" label
* Fix all :ref: links I could find

Fixes #9560