### PR TITLE
Fix words breaking in-between in addon descriptions

### DIFF
--- a/static/css/devhub/forms.less
+++ b/static/css/devhub/forms.less
@@ -19,6 +19,9 @@
         tr.version-disabled {
             opacity: 0.5;
         }
+        td {
+            max-width: 547px;
+        }
         th {
             color: #888;
             font-size: 11px;

--- a/static/css/zamboni/developers.css
+++ b/static/css/zamboni/developers.css
@@ -17,7 +17,6 @@ form .char-count:after,
     width: 100%;
     overflow: hidden;
     word-wrap: break-word;
-    word-break: break-all;
 }
 
 #edit-addon h3 a {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/9429

As suggested by @muffinresearch [here](https://github.com/mozilla/addons-server/issues/9429#issuecomment-422851233), removed `word-break` and added a `max-width`.
Though I am not very sure of the place to add the `max-width`, `.devhub-form table td` is a selector I found to be common to all sections on the edit page. This change will also affect owner and version pages as shown by [this search result](https://github.com/mozilla/addons-server/search?q=class%3D%22.devhub-form%22&unscoped_q=class%3D%22.devhub-form%22). I have verified, in my limited testing, that they should be fine with this change.

## Before
![screenshot 8](https://user-images.githubusercontent.com/2388644/46465372-49ee6600-c77d-11e8-9208-9ff30a26a7ae.png)

## After
Chrome:
![screenshot 14](https://user-images.githubusercontent.com/2388644/46465392-55419180-c77d-11e8-85ae-30610fde1475.png)

Firefox:
![screenshot 15](https://user-images.githubusercontent.com/2388644/46465405-5a9edc00-c77d-11e8-9c8a-972b09aab398.png)
