### PR TITLE
 Add latest version hint for version exists error

### DIFF
--- a/src/olympia/signing/tests/test_views.py
+++ b/src/olympia/signing/tests/test_views.py
@@ -160,7 +160,8 @@ class TestUploadVersion(BaseUploadVersionTestMixin, TestCase):
         response = self.request(
             'PUT', self.url(self.guid, '2.1.072'), version='2.1.072')
         assert response.status_code == 409
-        assert response.data['error'] == 'Version already exists.'
+        assert response.data['error'] == ('Version already exists. '
+                                          'Latest version is: 2.1.072.')
 
     @mock.patch('olympia.devhub.views.Version.from_upload')
     def test_no_version_yet(self, from_upload):
@@ -201,7 +202,8 @@ class TestUploadVersion(BaseUploadVersionTestMixin, TestCase):
 
         response = self.request('PUT', self.url(self.guid, '3.0'))
         assert response.status_code == 409
-        assert response.data['error'] == 'Version already exists.'
+        assert response.data['error'] == ('Version already exists. '
+                                          'Latest version is: 3.0.')
 
     def test_version_failed_review(self):
         self.create_version('3.0')
@@ -212,7 +214,8 @@ class TestUploadVersion(BaseUploadVersionTestMixin, TestCase):
 
         response = self.request('PUT', self.url(self.guid, '3.0'))
         assert response.status_code == 409
-        assert response.data['error'] == 'Version already exists.'
+        assert response.data['error'] == ('Version already exists. '
+                                          'Latest version is: 3.0.')
 
         # Verify that you can check the status after upload (#953).
         response = self.get(self.url(self.guid, '3.0'))

--- a/src/olympia/signing/views.py
+++ b/src/olympia/signing/views.py
@@ -132,7 +132,7 @@ class VersionView(APIView):
                 addon.versions.filter(version=version_string).exists()):
             latest_version = addon.find_latest_version(None, exclude=())
             msg = ugettext('Version already exists. Latest version is: %s.'
-                 % latest_version)
+                 % latest_version.version)
             raise forms.ValidationError(msg, status.HTTP_409_CONFLICT)
 
         package_guid = parsed_data.get('guid', None)

--- a/src/olympia/signing/views.py
+++ b/src/olympia/signing/views.py
@@ -130,9 +130,10 @@ class VersionView(APIView):
 
         if (addon is not None and
                 addon.versions.filter(version=version_string).exists()):
-            raise forms.ValidationError(
-                ugettext('Version already exists.'),
-                status.HTTP_409_CONFLICT)
+            latest_version = addon.find_latest_version(None, exclude=())
+            msg = ugettext('Version already exists. Latest version is: %s.'
+                 % latest_version)
+            raise forms.ValidationError(msg, status.HTTP_409_CONFLICT)
 
         package_guid = parsed_data.get('guid', None)
 

--- a/src/olympia/signing/views.py
+++ b/src/olympia/signing/views.py
@@ -132,7 +132,7 @@ class VersionView(APIView):
                 addon.versions.filter(version=version_string).exists()):
             latest_version = addon.find_latest_version(None, exclude=())
             msg = ugettext('Version already exists. Latest version is: %s.'
-                 % latest_version.version)
+                           % latest_version.version)
             raise forms.ValidationError(msg, status.HTTP_409_CONFLICT)
 
         package_guid = parsed_data.get('guid', None)


### PR DESCRIPTION
Fixes: https://github.com/mozilla/addons-server/issues/9571

I have not done any `None` check because I think `find_latest_version` will return a valid version since a version already exists.