### PR TITLE
Unify developer policies link name.

### DIFF
--- a/src/olympia/devhub/templates/devhub/nav.html
+++ b/src/olympia/devhub/templates/devhub/nav.html
@@ -36,7 +36,7 @@
         <li><a href="https://developer.mozilla.org/en-US/Add-ons/Themes/Background">
           {{ _('Lightweight Themes') }}</a></li>
         <li><a href="{{ url('devhub.docs', 'policies') }}">
-          {{ _('Add-on Policies') }}</a></li>
+          {{ _('Developer Policies') }}</a></li>
       </ul>
     </li>
     <li>

--- a/src/olympia/devhub/templates/devhub/new-landing/components/footer.html
+++ b/src/olympia/devhub/templates/devhub/new-landing/components/footer.html
@@ -26,7 +26,7 @@
       <section class="DevHub-Footer-section">
         <h4>{{ _('Support') }}</h4>
         <ul>
-          <li><a href="https://developer.mozilla.org/en-US/Add-ons/AMO/Policy">{{ _('Policies') }}</a></li>
+          <li><a href="https://developer.mozilla.org/en-US/Add-ons/AMO/Policy">{{ _('Developer Policies') }}</a></li>
           <li><a href="https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Contact">{{ _('Report Bug') }}</a></li>
           <li><a href="https://status.mozilla.org">{{ _('Site Status') }}</a></li>
         </ul>


### PR DESCRIPTION
Fixes #9621

@MeridelW there was one other link on the older devhub navigation where I changed the name from "Add-on Policies" to "Developer Policies" as well.

cc @wagnerand on this change.

![screenshot from 2018-10-09 08-42-58](https://user-images.githubusercontent.com/139033/46651148-6d5f4980-cb9f-11e8-8da6-b8b84f7ab7c2.png)
![screenshot from 2018-10-09 08-42-27](https://user-images.githubusercontent.com/139033/46651149-6df7e000-cb9f-11e8-942c-459313c05fd7.png)
