### PR TITLE
Expose 'created' field for add-ons.

### DIFF
--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -159,7 +159,7 @@ This endpoint allows you to fetch a specific add-on by id, slug or guid.
     :>json object categories: Object holding the categories the add-on belongs to.
     :>json array categories[app_name]: Array holding the :ref:`category slugs <category-list>` the add-on belongs to for a given :ref:`add-on application <addon-detail-application>`. (Combine with the add-on ``type`` to determine the name of the category).
     :>json string|null contributions_url: URL to the (external) webpage where the addon's authors collect monetary contributions, if set.
-    :>json string created: The date the add-on got created.
+    :>json string created: The date the add-on was created.
     :>json object current_version: Object holding the current :ref:`version <version-detail-object>` of the add-on. For performance reasons the ``license`` field omits the ``text`` property from the detail endpoint. In addition, ``license`` and ``release_notes`` are omitted entirely from the search endpoint.
     :>json string default_locale: The add-on default locale for translations.
     :>json string|object|null description: The add-on description (See :ref:`translated fields <api-overview-translations>`).

--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -159,6 +159,7 @@ This endpoint allows you to fetch a specific add-on by id, slug or guid.
     :>json object categories: Object holding the categories the add-on belongs to.
     :>json array categories[app_name]: Array holding the :ref:`category slugs <category-list>` the add-on belongs to for a given :ref:`add-on application <addon-detail-application>`. (Combine with the add-on ``type`` to determine the name of the category).
     :>json string|null contributions_url: URL to the (external) webpage where the addon's authors collect monetary contributions, if set.
+    :>json string created: The date the add-on got created.
     :>json object current_version: Object holding the current :ref:`version <version-detail-object>` of the add-on. For performance reasons the ``license`` field omits the ``text`` property from the detail endpoint. In addition, ``license`` and ``release_notes`` are omitted entirely from the search endpoint.
     :>json string default_locale: The add-on default locale for translations.
     :>json string|object|null description: The add-on description (See :ref:`translated fields <api-overview-translations>`).

--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -282,3 +282,4 @@ v4 API changelog
 * 2018-10-04: added ``is_deleted`` to the ratings API. This change was also backported to the `v3` API. https://github.com/mozilla/addons-server/issues/9371
 * 2018-10-04: added ``exclude_ratings`` parameter to ratings API. This change was also backported to the `v3` API. https://github.com/mozilla/addons-server/issues/9424
 * 2018-10-11: removed ``locale_disambiguation`` from the Language Tools API.
+* 2018-10-11: added ``created`` to the addons API.

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -308,6 +308,7 @@ class AddonSerializer(serializers.ModelSerializer):
             'average_daily_users',
             'categories',
             'contributions_url',
+            'created',
             'current_version',
             'default_locale',
             'description',
@@ -345,6 +346,8 @@ class AddonSerializer(serializers.ModelSerializer):
 
     def to_representation(self, obj):
         data = super(AddonSerializer, self).to_representation(obj)
+        request = self.context.get('request', None)
+
         if 'theme_data' in data and data['theme_data'] is None:
             data.pop('theme_data')
         if ('request' in self.context and
@@ -362,6 +365,8 @@ class AddonSerializer(serializers.ModelSerializer):
                 # In addition, their average_daily_users number must come from
                 # the popularity field of the attached Persona.
                 data['average_daily_users'] = obj.persona.popularity
+        if request and is_gate_active(request, 'del-addons-created-field'):
+            data.pop('created', None)
         return data
 
     def outgoingify(self, data):

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -663,6 +663,19 @@ class AddonSerializerOutputTestMixin(object):
         assert result['current_version'] is None
         assert result['previews'] == []
 
+    def test_created(self):
+        self.addon = addon_factory()
+        result = self.serialize()
+
+        assert result['created'] == (
+            self.addon.created.replace(microsecond=0).isoformat() + 'Z')
+
+        # And to make sure it's not present in v3
+        gates = {None: ('del-addons-created-field',)}
+        with override_settings(DRF_API_GATES=gates):
+            result = self.serialize()
+            assert 'created' not in result
+
 
 class TestAddonSerializerOutput(AddonSerializerOutputTestMixin, TestCase):
     serializer_class = AddonSerializer

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1795,7 +1795,8 @@ DRF_API_GATES = {
         'ratings-title-shim',
         'l10n_flat_input_output',
         'collections-downloads-shim',
-        'addons-locale_disambiguation-shim'
+        'addons-locale_disambiguation-shim',
+        'del-addons-created-field',
     ),
     'v4': (
         'l10n_flat_input_output',


### PR DESCRIPTION
Fixes #9564

Output from `/api/v3/addons/search/`:
![screenshot from 2018-10-09 08-52-53](https://user-images.githubusercontent.com/139033/46651591-d1ced880-cba0-11e8-9dad-31117f188535.png)
