### PR TITLE
Use distinct() on legacy files disabling script and don't do unnecessary work

### DIFF
--- a/src/olympia/addons/management/commands/process_addons.py
+++ b/src/olympia/addons/management/commands/process_addons.py
@@ -107,7 +107,8 @@ tasks = {
             Q(type__in=(amo.ADDON_EXTENSION, amo.ADDON_THEME, amo.ADDON_LPAPP),
               versions__files__is_webextension=False,
               versions__files__is_mozilla_signed_extension=False)
-        ]
+        ],
+        'pre': lambda values_qs: values_qs.distinct(),
     },
 }
 

--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -829,7 +829,7 @@ def disable_legacy_files(ids, **kw):
             # that we've identified as containing legacy File instances.
             files = File.objects.filter(
                 is_webextension=False, is_mozilla_signed_extension=False,
-                version__addon=addon)
+                version__addon=addon).exclude(status=amo.STATUS_DISABLED)
             for file_ in files:
+                log.info('Disabling file %d from addon %s', file_.pk, addon.pk)
                 file_.update(status=amo.STATUS_DISABLED)
-    index_addons.delay(ids)


### PR DESCRIPTION
Additional fix for https://github.com/mozilla/addons-server/issues/9472