### PR TITLE
Attempt at fixing 'assets' job.

### DIFF
--- a/Makefile-docker
+++ b/Makefile-docker
@@ -138,6 +138,7 @@ update_db:
 	schematic src/olympia/migrations
 
 update_assets:
+	# If changing this here, make sure to adapt tests in amo/test_commands.py
 	python manage.py compress_assets
 	python manage.py collectstatic --noinput
 

--- a/tox.ini
+++ b/tox.ini
@@ -76,7 +76,6 @@ commands =
 commands =
     make -f Makefile-docker update_deps
     pytest -m "static_assets" --ignore=tests/ui/ -v src/olympia/ {posargs}
-    make -f Makefile-docker update_assets
 
 [testenv:codestyle]
 recreate = True


### PR DESCRIPTION
Let's just remove the manual `update_assets` call and document that
whenever it get's changed / updated the appropriate pytest tests should
be adapted too.

That way we only run it once and potentially fix our unstable 'assets'
job.

Fixes #9656