### PR TITLE
Simplify read-only mode, don't set header.

### DIFF
--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -95,21 +95,22 @@ Maintainance Mode
 
 When returning ``HTTP 503 Service Unavailable`` responses the API may be in
 read-only mode. This means that for a short period of time we do not allow any
-write requests, this includes ``POST``, ``PATCH`` and ``DELETE`` requests.
+write requests, this includes ``POST``, ``PATCH``, ``PUT`` and ``DELETE`` requests.
 
 In case we are in read-only mode, the following behavior can be observed:
 
   * ``GET`` requests behave normally
-  * ``POST``, ``PUT`` and ``DELETE`` requests return 503 with a json response that contains a localized error message
-  * A custom ``X-AMO-Read-Only`` header is set to ``true``
-  * A ``Retry-After`` header may be set, it's not a requirement though and can be omitted
+  * ``POST``, ``PUT``, ``PATCH``, and ``DELETE`` requests return 503 with a json response that contains a localized error message
 
-In case we are not in read-only mode, the following (standard) behavior can be observed:
+The response when returning ``HTTP 503 Service Unavailable`` in case of read-only mode looks like this:
 
-  * ``GET``, ``POST``, ``PUT``, ``DELETE`` requests behave normally again
-  * ``X-AMO-Read-Only`` header is set to ``false``
+.. code-block:: json
 
-So, in case of a ``503`` HTTP response you can always check the ``X-AMO-Read-Only`` header to behave appropriately.
+    {
+        "error": "Some features are temporarily disabled while we perform websi…"
+    }
+
+In case we are not in read-only mode everything should be back working as normal.
 
 ~~~~~~~~~~
 Pagination

--- a/src/olympia/amo/middleware.py
+++ b/src/olympia/amo/middleware.py
@@ -19,6 +19,8 @@ from django.utils.deprecation import MiddlewareMixin
 from django.utils.encoding import force_bytes, iri_to_uri
 from django.utils.translation import activate, ugettext_lazy as _
 
+from rest_framework import permissions
+
 import MySQLdb as mysql
 from corsheaders.middleware import CorsMiddleware as _CorsMiddleware
 
@@ -231,8 +233,7 @@ class ReadOnlyMiddleware(MiddlewareMixin):
             return
 
         if request.is_api:
-            writable_method = request.method in (
-                'POST', 'PUT', 'DELETE', 'PATCH')
+            writable_method = request.method not in permissions.SAFE_METHODS
             if writable_method:
                 return JsonResponse({'error': self.ERROR_MSG}, status=503)
         elif request.method == 'POST':

--- a/src/olympia/amo/tests/test_middleware.py
+++ b/src/olympia/amo/tests/test_middleware.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
-from datetime import timedelta
-
 from django import test
 from django.test.client import RequestFactory
-from django.test.utils import override_settings
 
 import pytest
 
@@ -13,7 +10,7 @@ from pyquery import PyQuery as pq
 from olympia.amo.middleware import (
     AuthenticationMiddlewareWithoutAPI, ScrubRequestOnException,
     RequestIdMiddleware)
-from olympia.amo.tests import TestCase, reverse_ns
+from olympia.amo.tests import TestCase
 from olympia.amo.urlresolvers import reverse
 from olympia.zadmin.models import Config
 
@@ -142,29 +139,3 @@ def test_request_id_middleware(client):
     request = RequestFactory().get('/')
     RequestIdMiddleware().process_request(request)
     assert request.request_id
-
-
-def test_read_only_header_always_set(client):
-    response = client.get(reverse_ns('abusereportuser-list'))
-    assert response['X-AMO-Read-Only'] == 'false'
-
-
-def test_read_only_mode(client):
-    with override_settings(READ_ONLY=True):
-        response = client.post(reverse_ns('abusereportuser-list'))
-
-    assert response.status_code == 503
-    assert 'website maintenance' in response.json()['error']
-    assert response['X-AMO-Read-Only'] == 'true'
-    assert 'Retry-After' not in response
-
-
-def test_read_only_mode_with_retry_after(client):
-    delta = timedelta(minutes=8)
-    with override_settings(READ_ONLY=True, READ_ONLY_RETRY_AFTER=delta):
-        response = client.post(reverse_ns('abusereportuser-list'))
-
-    assert response.status_code == 503
-    assert 'website maintenance' in response.json()['error']
-    assert response['X-AMO-Read-Only'] == 'true'
-    assert response['Retry-After'] == '480'

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1543,8 +1543,6 @@ READ_ONLY = env.bool('READ_ONLY', default=False)
 
 # Turn on read-only mode in local_settings.py by putting this line
 # at the VERY BOTTOM: read_only_mode(globals())
-# Please also consider setting `retry_after` like this:
-# read_only_mode(globals())
 def read_only_mode(env):
     env['READ_ONLY'] = True
 

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1540,25 +1540,13 @@ ENGAGE_ROBOTS = True
 # Read-only mode setup.
 READ_ONLY = env.bool('READ_ONLY', default=False)
 
-# Expected retry-time that can be respected by clients. This will
-# be set as `Retry-After` header.
-# Please set this to a `datetime.timedelta()` instance that is
-# reasonable for clients to try again.
-# We don't support hard dates as these are usually quite hard to
-# adhere anyway.
-# Will be ignored if `None`
-READ_ONLY_RETRY_AFTER = None
-
 
 # Turn on read-only mode in local_settings.py by putting this line
 # at the VERY BOTTOM: read_only_mode(globals())
-# Please also consider setting `retry_after` like this
-# import datetime
-# read_only_mode(globals(), retry_after=datetime.timedelta(minutes=10))
-# See `READ_ONLY_RETRY_AFTER` comment for more details
-def read_only_mode(env, retry_after=None):
+# Please also consider setting `retry_after` like this:
+# read_only_mode(globals())
+def read_only_mode(env):
     env['READ_ONLY'] = True
-    env['READ_ONLY_RETRY_AFTER'] = retry_after
 
     # Replace the default (master) db with a slave connection.
     if not env.get('SLAVE_DATABASES'):


### PR DESCRIPTION
We discussed this in IRC and concluded that we don't need the explicit
header and an explicit "Retry-After" header as well.

* Adds support for `PATCH` methods along the way