### PR TITLE
Add UTM parameter to "heading" links returned by the discovery API endpoint

### DIFF
--- a/src/olympia/discovery/tests/test_models.py
+++ b/src/olympia/discovery/tests/test_models.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from django.http import QueryDict
+
 from olympia import amo
 from olympia.amo.tests import addon_factory, TestCase, user_factory
 from olympia.discovery.models import DiscoveryItem
@@ -181,3 +183,14 @@ class TestDiscoveryItem(TestCase):
         item = DiscoveryItem.objects.create(addon=addon_factory(
             type=amo.ADDON_DICT))
         assert item.description == u''
+
+    def test_build_querystring(self):
+        item = DiscoveryItem.objects.create(addon=addon_factory(
+            type=amo.ADDON_DICT))
+        # We do not use `urlencode()` and a string comparison because QueryDict
+        # does not preserve ordering.
+        q = QueryDict(item.build_querystring())
+        assert q.get('utm_source') == 'discovery.addons.mozilla.org'
+        assert q.get('utm_medium') == 'firefox-browser'
+        assert q.get('utm_content') == 'discopane-entry-link'
+        assert q.get('src') == 'api'

--- a/src/olympia/discovery/tests/test_models.py
+++ b/src/olympia/discovery/tests/test_models.py
@@ -20,8 +20,10 @@ class TestDiscoveryItem(TestCase):
                             u'{addon_name}{end_sub_heading}'))
         assert item.heading == (
             u'Fancy Héading <span>with '
-            u'<a href="http://testserver/en-US/firefox/addon/som%C3%A9-slug/">'
-            u'Sôme Name by Bàr, Fôo</a></span>')
+            u'<a href="http://testserver/en-US/firefox/addon/som%C3%A9-slug/'
+            u'?{}">'
+            u'Sôme Name by Bàr, Fôo</a></span>').format(
+                item.build_querystring())
 
     def test_heading_custom(self):
         addon = addon_factory(slug=u'somé-slug', name=u'Sôme Name')
@@ -33,8 +35,9 @@ class TestDiscoveryItem(TestCase):
                             u'{addon_name}{end_sub_heading}'))
         assert item.heading == (
             u'Fancy Héading <span>with '
-            u'<a href="http://testserver/en-US/firefox/addon/som%C3%A9-slug/">'
-            u'Sôme Name by Fløp</a></span>')
+            u'<a href="http://testserver/en-US/firefox/addon/som%C3%A9-slug/'
+            u'?{}">'
+            u'Sôme Name by Fløp</a></span>').format(item.build_querystring())
 
     def test_heading_custom_xss(self):
         # Custom heading itself should not contain HTML; only the special {xxx}
@@ -48,9 +51,11 @@ class TestDiscoveryItem(TestCase):
             custom_heading=u'<script>alert(0)</script>{addon_name}')
         assert item.heading == (
             u'&lt;script&gt;alert(0)&lt;/script&gt;'
-            u'<a href="http://testserver/en-US/firefox/addon/som%C3%A9-slug/">'
+            u'<a href="http://testserver/en-US/firefox/addon/som%C3%A9-slug/'
+            u'?{}">'
             u'&lt;script&gt;alert(42)&lt;/script&gt; '
-            'by &lt;script&gt;alert(666)&lt;/script&gt;</a>')
+            u'by &lt;script&gt;alert(666)&lt;/script&gt;</a>').format(
+                item.build_querystring())
 
     def test_heading_non_custom(self):
         addon = addon_factory(slug=u'somé-slug', name=u'Sôme Name')
@@ -58,8 +63,9 @@ class TestDiscoveryItem(TestCase):
         item = DiscoveryItem.objects.create(addon=addon)
         assert item.heading == (
             u'Sôme Name <span>by '
-            u'<a href="http://testserver/en-US/firefox/addon/som%C3%A9-slug/">'
-            u'Fløp</a></span>')
+            u'<a href="http://testserver/en-US/firefox/addon/som%C3%A9-slug/'
+            u'?{}">'
+            u'Fløp</a></span>').format(item.build_querystring())
 
     def test_heading_non_custom_xss(self):
         addon = addon_factory(
@@ -69,8 +75,10 @@ class TestDiscoveryItem(TestCase):
         item = DiscoveryItem.objects.create(addon=addon)
         assert item.heading == (
             u'&lt;script&gt;alert(43)&lt;/script&gt; <span>by '
-            u'<a href="http://testserver/en-US/firefox/addon/som%C3%A9-slug/">'
-            u'&lt;script&gt;alert(667)&lt;/script&gt;</a></span>')
+            u'<a href="http://testserver/en-US/firefox/addon/som%C3%A9-slug/'
+            u'?{}">'
+            u'&lt;script&gt;alert(667)&lt;/script&gt;</a></span>').format(
+                item.build_querystring())
 
     def test_heading_custom_with_custom_addon_name(self):
         addon = addon_factory(slug=u'somé-slug')
@@ -81,8 +89,9 @@ class TestDiscoveryItem(TestCase):
                             u'{addon_name}{end_sub_heading}'))
         assert item.heading == (
             u'Fancy Héading <span>with '
-            u'<a href="http://testserver/en-US/firefox/addon/som%C3%A9-slug/">'
-            u'Custôm Name by Fløp</a></span>')
+            u'<a href="http://testserver/en-US/firefox/addon/som%C3%A9-slug/'
+            u'?{}">'
+            u'Custôm Name by Fløp</a></span>').format(item.build_querystring())
 
     def test_heading_custom_with_custom_addon_name_xss(self):
         addon = addon_factory(slug=u'somé-slug')
@@ -96,9 +105,11 @@ class TestDiscoveryItem(TestCase):
         item.custom_heading = '<script>alert(2)</script>{addon_name}'
         assert item.heading == (
             u'&lt;script&gt;alert(2)&lt;/script&gt;'
-            u'<a href="http://testserver/en-US/firefox/addon/som%C3%A9-slug/">'
+            u'<a href="http://testserver/en-US/firefox/addon/som%C3%A9-slug/'
+            u'?{}">'
             u'&lt;script&gt;alert(2)&lt;/script&gt; '
-            u'by &lt;script&gt;alert(668)&lt;/script&gt;</a>')
+            u'by &lt;script&gt;alert(668)&lt;/script&gt;</a>').format(
+                item.build_querystring())
 
     def test_heading_non_custom_but_with_custom_addon_name(self):
         addon = addon_factory(slug=u'somé-slug')
@@ -107,8 +118,9 @@ class TestDiscoveryItem(TestCase):
             addon=addon, custom_addon_name=u'Custôm Name')
         assert item.heading == (
             u'Custôm Name <span>by '
-            u'<a href="http://testserver/en-US/firefox/addon/som%C3%A9-slug/">'
-            u'Fløp</a></span>')
+            u'<a href="http://testserver/en-US/firefox/addon/som%C3%A9-slug/'
+            u'?{}">'
+            u'Fløp</a></span>').format(item.build_querystring())
 
     def test_heading_non_custom_but_with_custom_addon_name_xss(self):
         addon = addon_factory(slug=u'somé-slug')
@@ -118,8 +130,10 @@ class TestDiscoveryItem(TestCase):
             addon=addon, custom_addon_name=u'<script>alert(3)</script>')
         assert item.heading == (
             u'&lt;script&gt;alert(3)&lt;/script&gt; <span>by '
-            u'<a href="http://testserver/en-US/firefox/addon/som%C3%A9-slug/">'
-            u'&lt;script&gt;alert(669)&lt;/script&gt;</a></span>')
+            u'<a href="http://testserver/en-US/firefox/addon/som%C3%A9-slug/'
+            u'?{}">'
+            u'&lt;script&gt;alert(669)&lt;/script&gt;</a></span>').format(
+                item.build_querystring())
 
     def test_description_custom(self):
         addon = addon_factory(summary='Foo', description='Bar')


### PR DESCRIPTION
Fixes #8884 

---

I created a method for the query string params to reuse it in the test file. Not sure if we really need to add a test case for this method though.