### PR TITLE
Update html5lib now that bleach does not depend directly on it

### DIFF
--- a/requirements/prod_common.txt
+++ b/requirements/prod_common.txt
@@ -210,10 +210,10 @@ feedparser==5.2.1 \
 funcsigs==1.0.2 \
     --hash=sha256:330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca \
     --hash=sha256:a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50
-# html5lib is required by bleach, rdflib
-# see setup.py of bleach for supported and required versions
-html5lib==0.9999999 \
-    --hash=sha256:2612a191a8d5842bfa057e41ba50bbb9dcb722419d2408c78cff4758d0754868 # pyup: <=0.9999999
+# html5lib is required by rdflib
+html5lib==1.0.1 \
+    --hash=sha256:20b159aa3badc9d5ee8f5c647e5efd02ed2a66ab8d354930bd9ff139fc1dc0a3 \
+    --hash=sha256:66cb0dcfdbbc4f9c3ba1a63fdb511ffdbd4f513b2b6d81b80cd26ce6b3fb3736
 # isodate is required by rdflib
 isodate==0.6.0 \
     --hash=sha256:aa4d33c06640f5352aca96e4b81afd8ab3b47337cc12089822d6f322ac772c81 \

--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -537,7 +537,7 @@ def clean_nl(string):
     # Serialize the parsed tree back to html.
     walker = html5lib.treewalkers.getTreeWalker('etree')
     stream = walker(parse)
-    serializer = HTMLSerializer(quote_attr_values=True,
+    serializer = HTMLSerializer(quote_attr_values='always',
                                 omit_optional_tags=False)
     return serializer.render(stream)
 

--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -44,7 +44,7 @@ import basket
 from babel import Locale
 from django_statsd.clients import statsd
 from easy_thumbnails import processors
-from html5lib.serializer.htmlserializer import HTMLSerializer
+from html5lib.serializer import HTMLSerializer
 from PIL import Image
 from rest_framework.utils.encoders import JSONEncoder
 from validator import unicodehelper

--- a/src/olympia/translations/utils.py
+++ b/src/olympia/translations/utils.py
@@ -77,7 +77,7 @@ def truncate(html, length, killwords=False, end='...'):
         walker = html5lib.treewalkers.getTreeWalker('etree')
         stream = walker(short)
         serializer = html5lib.serializer.HTMLSerializer(
-            quote_attr_values=True, omit_optional_tags=False)
+            quote_attr_values='always', omit_optional_tags=False)
         return jinja2.Markup(force_text(serializer.render(stream)))
 
 

--- a/src/olympia/translations/utils.py
+++ b/src/olympia/translations/utils.py
@@ -76,7 +76,7 @@ def truncate(html, length, killwords=False, end='...'):
         # Serialize the parsed tree back to html.
         walker = html5lib.treewalkers.getTreeWalker('etree')
         stream = walker(short)
-        serializer = html5lib.serializer.htmlserializer.HTMLSerializer(
+        serializer = html5lib.serializer.HTMLSerializer(
             quote_attr_values=True, omit_optional_tags=False)
         return jinja2.Markup(force_text(serializer.render(stream)))
 


### PR DESCRIPTION
Bleach 3.x has its own vendored version of html5lib. To quote [bleach changelog](https://bleach.readthedocs.io/en/latest/changes.html):

> This means Bleach will now work fine with other libraries that depend on html5lib regardless of what version of html5lib they require.

Fix #9690