### PR TITLE
Add a validator to reject AMO URLs

### DIFF
--- a/src/olympia/amo/fields.py
+++ b/src/olympia/amo/fields.py
@@ -39,17 +39,21 @@ class URLValidatorBackport(URLValidator):
 
 
 class HttpHttpsOnlyURLField(fields.URLField):
-    default_validators = [
-        URLValidatorBackport(schemes=('http', 'https')),
-        # Reject AMO URLs, see:
-        # https://github.com/mozilla/addons-server/issues/9012
-        RegexValidator(
-            regex=r'%s' % settings.SERVICES_DOMAIN,
-            message=_('Linking to AMO is forbidden.'),
-            code='no_amo_url',
-            inverse_match=True
-        )
-    ]
+
+    def __init__(self, *args, **kwargs):
+        super(HttpHttpsOnlyURLField, self).__init__(*args, **kwargs)
+
+        self.validators = [
+            URLValidatorBackport(schemes=('http', 'https')),
+            # Reject AMO URLs, see:
+            # https://github.com/mozilla/addons-server/issues/9012
+            RegexValidator(
+                regex=r'%s' % re.escape(settings.DOMAIN),
+                message=_('Linking to AMO is forbidden.'),
+                code='no_amo_url',
+                inverse_match=True
+            )
+        ]
 
 
 class ReCaptchaField(HumanCaptchaField):

--- a/src/olympia/amo/fields.py
+++ b/src/olympia/amo/fields.py
@@ -50,9 +50,9 @@ class HttpHttpsOnlyURLField(fields.URLField):
             RegexValidator(
                 regex=r'%s' % re.escape(settings.DOMAIN),
                 message=_(
-                    'This field can only be used to link to external websites. '
-                    'URLs on %(domain)s are not allowed.',
-                ) % { 'domain': settings.DOMAIN },
+                    'This field can only be used to link to external websites.'
+                    ' URLs on %(domain)s are not allowed.',
+                ) % {'domain': settings.DOMAIN},
                 code='no_amo_url',
                 inverse_match=True
             )

--- a/src/olympia/amo/fields.py
+++ b/src/olympia/amo/fields.py
@@ -1,7 +1,8 @@
 import re
 
+from django.conf import settings
 from django.core import exceptions
-from django.core.validators import URLValidator
+from django.core.validators import RegexValidator, URLValidator
 from django.db import models
 from django.forms import fields
 from django.utils.translation import ugettext, ugettext_lazy as _
@@ -38,7 +39,17 @@ class URLValidatorBackport(URLValidator):
 
 
 class HttpHttpsOnlyURLField(fields.URLField):
-    default_validators = [URLValidatorBackport(schemes=('http', 'https'))]
+    default_validators = [
+        URLValidatorBackport(schemes=('http', 'https')),
+        # Reject AMO URLs, see:
+        # https://github.com/mozilla/addons-server/issues/9012
+        RegexValidator(
+            regex=r'%s' % settings.SERVICES_DOMAIN,
+            message=_('Linking to AMO is forbidden.'),
+            code='no_amo_url',
+            inverse_match=True
+        )
+    ]
 
 
 class ReCaptchaField(HumanCaptchaField):

--- a/src/olympia/amo/fields.py
+++ b/src/olympia/amo/fields.py
@@ -49,7 +49,10 @@ class HttpHttpsOnlyURLField(fields.URLField):
             # https://github.com/mozilla/addons-server/issues/9012
             RegexValidator(
                 regex=r'%s' % re.escape(settings.DOMAIN),
-                message=_('Linking to AMO is forbidden.'),
+                message=_(
+                    'This field can only be used to link to external websites. '
+                    'URLs on %(domain)s are not allowed.',
+                ) % { 'domain': settings.DOMAIN },
                 code='no_amo_url',
                 inverse_match=True
             )

--- a/src/olympia/amo/tests/test_fields.py
+++ b/src/olympia/amo/tests/test_fields.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.core import exceptions
 from django.db import connection, DataError
 
@@ -37,6 +38,14 @@ class HttpHttpsOnlyURLFieldTestCase(TestCase):
         # https://github.com/mozilla/addons-server/issues/1452
         with self.assertRaises(exceptions.ValidationError):
             assert self.field.clean(u'https://test.[com')
+
+    def test_with_site_url(self):
+        with self.assertRaises(exceptions.ValidationError):
+            self.field.clean(u'%s' % settings.SITE_URL)
+
+    def test_with_services_domain(self):
+        with self.assertRaises(exceptions.ValidationError):
+            self.field.clean(u'%s' % settings.SERVICES_DOMAIN)
 
 
 class TestPositiveAutoField(TestCase):


### PR DESCRIPTION
Fixes #9012

---

I wish I could find a better name for such a field now that it also
rejects AMO URLs... I think adding a validator here makes sense though,
because  it avoids AMO links in the following form fields: `homepage`,
`support_url` and `contributions`.