### PR TITLE
Create an actual entry in the commitlog.

### DIFF
--- a/src/olympia/lib/tests/test_git.py
+++ b/src/olympia/lib/tests/test_git.py
@@ -6,7 +6,7 @@ import pytest
 from django.conf import settings
 
 from olympia import amo
-from olympia.amo.tests import addon_factory
+from olympia.amo.tests import addon_factory, version_factory
 from olympia.lib.git import AddonGitRepository, TemporaryWorktree
 
 
@@ -103,3 +103,60 @@ def test_extract_and_commit_from_file_obj_set_git_hash():
 
     addon.current_version.refresh_from_db()
     assert len(addon.current_version.git_hash) == 40
+
+
+@pytest.mark.django_db
+def test_extract_and_commit_from_file_obj_multiple_versions():
+    addon = addon_factory(
+        file_kw={'filename': 'webextension_no_id.xpi'},
+        version_kw={'version': '0.1'})
+
+    repo = AddonGitRepository.extract_and_commit_from_file_obj(
+        addon.current_version.all_files[0],
+        amo.RELEASE_CHANNEL_LISTED)
+
+    assert repo.git_repository_path == os.path.join(
+        settings.GIT_FILE_STORAGE_PATH, str(addon.id), 'package')
+    assert os.listdir(repo.git_repository_path) == ['.git']
+
+    # Verify via subprocess to make sure the repositories are properly
+    # read by the regular git client
+    env = {'GIT_DIR': os.path.join(repo.git_repository_path, '.git')}
+
+    output = subprocess.check_output('git branch', shell=True, env=env)
+    assert 'listed' in output
+
+    output = subprocess.check_output('git log listed', shell=True, env=env)
+    expected = 'Create new version {} ({}) for {} from {}'.format(
+        repr(addon.current_version), addon.current_version.id, repr(addon),
+        repr(addon.current_version.all_files[0]))
+    assert expected in output
+
+    # Create two more versions, check that they appear in the comitlog
+    version = version_factory(
+        addon=addon, file_kw={'filename': 'webextension_no_id.xpi'},
+        version='0.2')
+    AddonGitRepository.extract_and_commit_from_file_obj(
+        version.all_files[0],
+        amo.RELEASE_CHANNEL_LISTED)
+
+    version = version_factory(
+        addon=addon, file_kw={'filename': 'webextension_no_id.xpi'},
+        version='0.3')
+    repo = AddonGitRepository.extract_and_commit_from_file_obj(
+        version.all_files[0],
+        amo.RELEASE_CHANNEL_LISTED)
+
+    output = subprocess.check_output('git log listed', shell=True, env=env)
+    assert output.count('Create new version') == 3
+    assert '0.1' in output
+    assert '0.2' in output
+    assert '0.3' in output
+
+    # 4 actual commits, including the repo initialization
+    assert output.count('Mozilla Add-ons Robot') == 4
+
+    # Make sure the commits didn't spill over into the master branch
+    output = subprocess.check_output('git log', shell=True, env=env)
+    assert output.count('Mozilla Add-ons Robot') == 1
+    assert '0.1' not in output


### PR DESCRIPTION
We originally didn't set a proper parent for the commit that we created
in the worktree, now we set the parent commit to the current branches
(listed/unlisted) HEAD which shows the commit correctly in the
commitlog.

Fixes #9718