### PR TITLE
Added new ui tests

### DIFF
--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -91,8 +91,7 @@ def devhub_login(selenium, base_url, fxa_account):
     """Log into the devhub."""
     url = selenium.get('http://olympia.test/developers')
     devhub = DevHub(selenium, base_url)
-    devhub.login(fxa_account.email, fxa_account.password)
-    return devhub.wait_for_page_to_load()
+    return devhub.login(fxa_account.email, fxa_account.password)
 
 
 @pytest.fixture

--- a/tests/ui/pages/desktop/base.py
+++ b/tests/ui/pages/desktop/base.py
@@ -103,6 +103,8 @@ class Header(Region):
     def more_menu(self, item=None):
         menu = self.find_element(*self._more_dropdown_locator)
         links = menu.find_elements(*self._more_dropdown_link_locator)
+        # Create an action chain clicking on the elements of the dropdown more
+        # menu. It pauses between each action to account for lag.
         action = ActionChains(self.selenium)
         action.move_to_element(menu)
         action.pause(2)

--- a/tests/ui/pages/desktop/base.py
+++ b/tests/ui/pages/desktop/base.py
@@ -50,6 +50,10 @@ class Header(Region):
                            > li:nth-child(2) > a:nth-child(1)')
     _login_locator = (By.CLASS_NAME, 'Header-authenticate-button')
     _logout_locator = (By.CSS_SELECTOR, '.DropdownMenu-items .Header-logout-button')
+    _more_dropdown_locator = (
+        By.CSS_SELECTOR,
+        '.Header-SectionLinks .SectionLinks-dropdown')
+    _more_dropdown_link_locator = (By.CLASS_NAME, 'SectionLinks-dropdownlink')
     _themes_locator = (By.CSS_SELECTOR, '.SectionLinks > li:nth-child(3) > \
                        a:nth-child(1)')
     _user_locator = (By.CSS_SELECTOR,
@@ -71,6 +75,12 @@ class Header(Region):
         return Themes(
             self.selenium, self.page.base_url).wait_for_page_to_load()
 
+    def click_title(self):
+        self.find_element(*self._header_title_locator).click()
+
+        from pages.desktop.home import Home
+        return Home(self.selenium, self.page.base_url).wait_for_page_to_load()
+
     def click_login(self):
         self.find_element(*self._login_locator).click()
         from pages.desktop.login import Login
@@ -89,6 +99,20 @@ class Header(Region):
         action.perform()
         self.wait.until(lambda s: self.is_element_displayed(
             *self._login_locator))
+
+    def more_menu(self, item=None):
+        menu = self.find_element(*self._more_dropdown_locator)
+        links = menu.find_elements(*self._more_dropdown_link_locator)
+        action = ActionChains(self.selenium)
+        action.move_to_element(menu)
+        action.pause(2)
+        action.click()
+        action.pause(2)
+        action.move_to_element(links[item])
+        action.pause(2)
+        action.click()
+        action.pause(2)
+        action.perform()
 
     def search_for(self, term):
         textbox = self.find_element(*self._search_textbox_locator)

--- a/tests/ui/pages/desktop/base.py
+++ b/tests/ui/pages/desktop/base.py
@@ -53,7 +53,7 @@ class Header(Region):
     _more_dropdown_locator = (
         By.CSS_SELECTOR,
         '.Header-SectionLinks .SectionLinks-dropdown')
-    _more_dropdown_link_locator = (By.CLASS_NAME, 'SectionLinks-dropdownlink')
+    _more_dropdown_link_locator = (By.CSS_SELECTOR, '.DropdownMenuItem a')
     _themes_locator = (By.CSS_SELECTOR, '.SectionLinks > li:nth-child(3) > \
                        a:nth-child(1)')
     _user_locator = (By.CSS_SELECTOR,

--- a/tests/ui/pages/desktop/devhub.py
+++ b/tests/ui/pages/desktop/devhub.py
@@ -29,6 +29,7 @@ class DevHub(Base):
         By.CSS_SELECTOR,
         'input#id_admin_override_validation',
     )
+    _overview_locator = (By.CSS_SELECTOR, '.DevHub-Overview h1')
     _submit_addon_btn_locator = (
         By.CSS_SELECTOR,
         '.DevHub-MyAddons-item-buttons-submit > .Button:nth-child(1)',
@@ -39,7 +40,7 @@ class DevHub(Base):
 
     def wait_for_page_to_load(self):
         self.wait.until(
-            lambda _: self.is_element_displayed(*self._whats_new_locator)
+            lambda _: self.is_element_displayed(*self._overview_locator)
         )
         return self
 
@@ -53,10 +54,13 @@ class DevHub(Base):
         self.wait.until(
             lambda _: self.is_element_displayed(*self._avatar_locator)
         )
+        return self
 
     @property
     def logged_in(self):
-        return self.is_element_displayed(*self.header._sign_in_locator)
+        if self.is_element_displayed(*self.header._sign_in_locator):
+            return False
+        return True
 
     @property
     def addons_list(self):
@@ -111,13 +115,28 @@ class DevHub(Base):
 
     class Header(Region):
 
+        _register_link_locator = (
+            By.CSS_SELECTOR,
+            '.DevHub-Navigation-Register > a:nth-child(1)'
+        )
         _sign_in_locator = (
             By.CSS_SELECTOR,
             '.DevHub-Navigation-Register > a:nth-child(2)',
         )
+        _sign_out_locator = (By.CSS_SELECTOR, '.DevHub-Navigation-SignOut > a')
 
         def click_login(self):
             self.find_element(*self._sign_in_locator).click()
             from pages.desktop.login import Login
 
             return Login(self.selenium, self.page.base_url)
+
+        def register(self):
+            self.find_element(*self._register_link_locator).click()
+
+        def click_sign_out(self):
+            self.find_element(*self._sign_out_locator).click()
+            from pages.desktop.devhub import DevHub
+
+            devhub = DevHub(self.selenium, self.page.base_url)
+            return devhub.wait_for_page_to_load()

--- a/tests/ui/pages/desktop/devhub.py
+++ b/tests/ui/pages/desktop/devhub.py
@@ -58,9 +58,7 @@ class DevHub(Base):
 
     @property
     def logged_in(self):
-        if self.is_element_displayed(*self.header._sign_in_locator):
-            return False
-        return True
+        return not self.is_element_displayed(*self.header._sign_in_locator)
 
     @property
     def addons_list(self):

--- a/tests/ui/pages/desktop/home.py
+++ b/tests/ui/pages/desktop/home.py
@@ -10,10 +10,21 @@ class Home(Base):
     _extensions_category_locator = (By.CLASS_NAME, 'Home-CuratedCollections')
     _featured_extensions_locator = (By.CLASS_NAME, 'Home-FeaturedExtensions')
     _featured_themes_locator = (By.CLASS_NAME, 'Home-FeaturedThemes')
+    _hero_locator = (By.CLASS_NAME, 'HomeHeroBanner')
     _popular_extensions_locator = (By.CLASS_NAME, 'Home-PopularExtensions')
     _popular_themes_locator = (By.CLASS_NAME, 'Home-PopularThemes')
     _themes_category_locator = (By.CLASS_NAME, 'Home-CuratedThemes')
     _toprated_themes_locator = (By.CLASS_NAME, 'Home-TopRatedThemes')
+
+    def wait_for_page_to_load(self):
+        self.wait.until(
+            lambda _: self.is_element_displayed(*self._hero_locator)
+        )
+        return self
+
+    @property
+    def hero_banner(self):
+        return self.find_element(*self._hero_locator)
 
     @property
     def popular_extensions(self):

--- a/tests/ui/test_devhub.py
+++ b/tests/ui/test_devhub.py
@@ -42,7 +42,7 @@ def test_devhub_addon_upload(base_url, selenium, devhub_upload):
 @pytest.mark.nondestructive
 @pytest.mark.withoutresponses
 def test_devhub_logout(base_url, selenium, devhub_login):
-    """Test uploading an addon via devhub."""
+    """Logging out from devhub."""
     assert devhub_login.logged_in
     devhub = devhub_login.header.click_sign_out()
     assert not devhub.logged_in
@@ -52,7 +52,7 @@ def test_devhub_logout(base_url, selenium, devhub_login):
 @pytest.mark.nondestructive
 @pytest.mark.withoutresponses
 def test_devhub_register(base_url, selenium):
-    """Test uploading an addon via devhub."""
+    """Test register link loads register page."""
     selenium.get('http://olympia.test/en-US/developers/')
     devhub = DevHub(selenium, base_url)
     assert not devhub.logged_in

--- a/tests/ui/test_devhub.py
+++ b/tests/ui/test_devhub.py
@@ -1,6 +1,8 @@
 import pytest
 import requests
 
+from pages.desktop.devhub import DevHub
+
 
 @pytest.mark.fxa_login
 @pytest.mark.desktop_only
@@ -33,3 +35,26 @@ def test_devhub_addon_edit_link_works(base_url, selenium, devhub_login):
 def test_devhub_addon_upload(base_url, selenium, devhub_upload):
     """Test uploading an addon via devhub."""
     'ui-test-addon-2' in devhub_upload.addons[-1].name
+
+
+@pytest.mark.fxa_login
+@pytest.mark.desktop_only
+@pytest.mark.nondestructive
+@pytest.mark.withoutresponses
+def test_devhub_logout(base_url, selenium, devhub_login):
+    """Test uploading an addon via devhub."""
+    assert devhub_login.logged_in
+    devhub = devhub_login.header.click_sign_out()
+    assert not devhub.logged_in
+
+
+@pytest.mark.desktop_only
+@pytest.mark.nondestructive
+@pytest.mark.withoutresponses
+def test_devhub_register(base_url, selenium):
+    """Test uploading an addon via devhub."""
+    selenium.get('http://olympia.test/en-US/developers/')
+    devhub = DevHub(selenium, base_url)
+    assert not devhub.logged_in
+    devhub.header.register()
+    assert 'signup' in selenium.current_url

--- a/tests/ui/test_devhub.py
+++ b/tests/ui/test_devhub.py
@@ -50,7 +50,6 @@ def test_devhub_logout(base_url, selenium, devhub_login):
 
 @pytest.mark.desktop_only
 @pytest.mark.nondestructive
-@pytest.mark.withoutresponses
 def test_devhub_register(base_url, selenium):
     """Test register link loads register page."""
     selenium.get('http://olympia.test/en-US/developers/')

--- a/tests/ui/test_home.py
+++ b/tests/ui/test_home.py
@@ -72,3 +72,19 @@ def test_category_section_loads_correct_category(base_url, selenium):
     name = item.name
     category = item.click()
     assert name in category.header.name
+
+
+@pytest.mark.nondestructive
+def test_title_routes_to_home(base_url, selenium):
+    page = Extensions(selenium, base_url).open()
+    home = page.header.click_title()
+    assert home.hero_banner.is_displayed()
+
+
+@pytest.mark.parametrize('i, page_url',
+    enumerate(['language-tools', 'search-tools']))
+@pytest.mark.nondestructive
+def test_more_dropdown_navigates_correctly(base_url, selenium, i, page_url):
+    page = Home(selenium, base_url).open()
+    page.header.more_menu(item=i)
+    assert page_url in selenium.current_url

--- a/tests/ui/test_home.py
+++ b/tests/ui/test_home.py
@@ -82,7 +82,7 @@ def test_title_routes_to_home(base_url, selenium):
 
 
 @pytest.mark.parametrize('i, page_url',
-    enumerate(['language-tools', 'search-tools']))
+    enumerate(['language-tools', 'search-tools', 'android']))
 @pytest.mark.nondestructive
 def test_more_dropdown_navigates_correctly(base_url, selenium, i, page_url):
     page = Home(selenium, base_url).open()


### PR DESCRIPTION
Adds 4 new tests.
```test_devhub_logout```, Tests logging out from the developer hub.
```test_devhub_register```, Tests the register links navigates to the fxa signup page.
```test_title_routes_to_home```, tests Firefox Addons title routes to home page.
```test_more_dropdown_navigates_correctly```, tests the more drop down navigates to the correct links.