### PR TITLE
Git Backend: Use actual author, commit on upload

### DIFF
--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -11,6 +11,7 @@ from django.utils.functional import cached_property
 from django.utils.translation import ugettext
 
 import jinja2
+import waffle
 
 from django_extensions.db.fields.json import JSONField
 from django_statsd.clients import statsd
@@ -33,6 +34,7 @@ from olympia.files import utils
 from olympia.files.models import File, cleanup_file
 from olympia.translations.fields import (
     LinkifiedField, PurifiedField, TranslatedField, save_signal)
+from olympia.lib.git import AddonGitRepository
 
 from .compare import version_dict, version_int
 
@@ -246,6 +248,13 @@ class Version(OnChangeMixin, ModelBase):
         # After the upload has been copied to all platforms, remove the upload.
         storage.delete(upload.path)
         version_uploaded.send(sender=version)
+
+        if waffle.switch_is_active('enable-uploads-commit-to-git-storage'):
+            # Extract into git repository
+            AddonGitRepository.extract_and_commit_from_file_obj(
+                file_obj=version.all_files[0],
+                channel=channel,
+                author=upload.user)
 
         # Generate a preview and icon for listed static themes
         if (addon.type == amo.ADDON_STATICTHEME and

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -9,6 +9,7 @@ from django.core.files.storage import default_storage as storage
 
 import mock
 import pytest
+from waffle.testutils import override_switch
 
 from olympia import amo, core
 from olympia.activity.models import ActivityLog
@@ -16,7 +17,8 @@ from olympia.addons.models import (
     Addon, AddonFeatureCompatibility, AddonReviewerFlags, CompatOverride,
     CompatOverrideRange)
 from olympia.amo.templatetags.jinja_helpers import user_media_url
-from olympia.amo.tests import TestCase, addon_factory, version_factory
+from olympia.amo.tests import (
+    TestCase, addon_factory, version_factory, user_factory)
 from olympia.amo.tests.test_models import BasePreviewMixin
 from olympia.amo.utils import utc_millesecs_from_epoch
 from olympia.applications.models import AppVersion
@@ -29,6 +31,7 @@ from olympia.users.models import UserProfile
 from olympia.versions.compare import version_int
 from olympia.versions.models import (
     ApplicationsVersions, source_upload_path, Version, VersionPreview)
+from olympia.lib.git import AddonGitRepository
 
 
 pytestmark = pytest.mark.django_db
@@ -868,6 +871,36 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
             self.upload, self.addon, [self.selected_app],
             amo.RELEASE_CHANNEL_LISTED, parsed_data=self.dummy_parsed_data)
         assert upload_version.nomination == pending_version.nomination
+
+    @override_switch('enable-uploads-commit-to-git-storage', active=False)
+    def test_doesnt_commit_to_git_by_default(self):
+        addon = addon_factory()
+        upload = self.get_upload('webextension_no_id.xpi')
+        user = user_factory(username='fancyuser')
+        parsed_data = parse_addon(upload, addon, user=user)
+        version = Version.from_upload(
+            upload, addon, [self.selected_app],
+            amo.RELEASE_CHANNEL_LISTED,
+            parsed_data=parsed_data)
+        assert version.pk
+
+        repo = AddonGitRepository(addon.pk)
+        assert not os.path.exists(repo.git_repository_path)
+
+    @override_switch('enable-uploads-commit-to-git-storage', active=True)
+    def test_commits_to_git_waffle_enabled(self):
+        addon = addon_factory()
+        upload = self.get_upload('webextension_no_id.xpi')
+        user = user_factory(username='fancyuser')
+        parsed_data = parse_addon(upload, addon, user=user)
+        version = Version.from_upload(
+            upload, addon, [self.selected_app],
+            amo.RELEASE_CHANNEL_LISTED,
+            parsed_data=parsed_data)
+        assert version.pk
+
+        repo = AddonGitRepository(addon.pk)
+        assert os.path.exists(repo.git_repository_path)
 
 
 class TestSearchVersionFromUpload(TestVersionFromUpload):


### PR DESCRIPTION
* Restructure AddonGitRepository so that init doesn't have any side-effects.
* Add waffle + code and tests to create and commit new uploads to git.
* Apply the actual FileUpload user to the git commit

Fixes #8753
Fixes #9752 