### PR TITLE
Properly reindex an add-on when it's removed from a collection

### DIFF
--- a/src/olympia/bandwagon/models.py
+++ b/src/olympia/bandwagon/models.py
@@ -391,7 +391,8 @@ class CollectionAddon(ModelBase):
             # present in the collection at the time, we also need to make sure
             # to invalidate add-ons that have been removed.
             Collection.update_featured_status(
-                sender, instance.collection, addons=[instance.addon], **kwargs)
+                sender, instance.collection,
+                addons=[instance.addon.pk], **kwargs)
 
 
 models.signals.pre_save.connect(save_signal, sender=CollectionAddon,

--- a/src/olympia/bandwagon/tests/test_models.py
+++ b/src/olympia/bandwagon/tests/test_models.py
@@ -183,7 +183,7 @@ class TestFeaturedCollectionSignals(TestCase):
             collection=self.collection,
             application=self.collection.application)
         assert index_addons.delay.call_count == 1
-        index_addons.delay.call_args[0] == ([self.addon.pk],)
+        assert index_addons.delay.call_args[0] == ([self.addon.pk],)
         index_addons.delay.reset_mock()
 
         # Adding an add-on re-indexes all add-ons in the collection
@@ -191,7 +191,8 @@ class TestFeaturedCollectionSignals(TestCase):
         # the one we just added and not the rest).
         self.collection.add_addon(extra_addon)
         assert index_addons.delay.call_count == 1
-        index_addons.delay.call_args[0] == ([self.addon.pk, extra_addon.pk],)
+        assert index_addons.delay.call_args[0] == (
+            [self.addon.pk, extra_addon.pk],)
         index_addons.delay.reset_mock()
 
         # Removing an add-on needs 2 calls: one to reindex the add-ons that
@@ -200,8 +201,8 @@ class TestFeaturedCollectionSignals(TestCase):
         # removed.
         self.collection.remove_addon(extra_addon)
         assert index_addons.delay.call_count == 2
-        index_addons.delay.call_args[0] == ([self.addon.pk],)
-        index_addons.delay.call_args[1] == ([extra_addon.pk],)
+        assert index_addons.delay.call_args_list[0][0] == ([extra_addon.pk],)
+        assert index_addons.delay.call_args_list[1][0] == ([self.addon.pk],)
 
     def test_addon_added_to_featured_collection(self):
         FeaturedCollection.objects.create(


### PR DESCRIPTION
Noticed that while cleaning up my local database. Hopefully fixes #9235