### PR TITLE
Expose FxA URL (for editing a user email) in account response

### DIFF
--- a/docs/topics/api/accounts.rst
+++ b/docs/topics/api/accounts.rst
@@ -60,6 +60,7 @@ If you have `Users:Edit` permission you will see these extra fields for all user
     :>json boolean deleted: Is the account deleted.
     :>json string|null display_name: The name chosen by the user.
     :>json string email: Email address used by the user to login and create this account.
+    :>json string fxa_edit_email_url: The configured URL for editing the user's email on FxA.
     :>json string last_login: The date of the last successful log in to the website.
     :>json string last_login_ip: The IP address of the last successfull log in to the website.
     :>json boolean is_verified: The user has been verified via FirefoxAccounts.

--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -286,3 +286,4 @@ v4 API changelog
 * 2018-10-11: added ``created`` to the addons API.
 * 2018-10-18: added ``_score`` to the addons search API.
 * 2018-10-25: changed ``author`` parameter on addons search API to accept user ids as well as usernames. This change was also backported to the `v3` API. https://github.com/mozilla/addons-server/issues/8901
+* 2018-10-25: added ``fxa_edit_email_url`` parameter on accounts API to return the full URL for editing the user's email on FxA. https://github.com/mozilla/addons-server/issues/8674

--- a/src/olympia/accounts/serializers.py
+++ b/src/olympia/accounts/serializers.py
@@ -15,6 +15,7 @@ from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.amo.utils import (
     clean_nl, has_links, ImageCheck, slug_validator,
     subscribe_newsletter, unsubscribe_newsletter, urlparams)
+from olympia.api.utils import is_gate_active
 from olympia.users.models import DeniedName, UserProfile
 from olympia.users.tasks import resize_photo
 from olympia.users import notifications
@@ -163,6 +164,15 @@ class UserProfileSerializer(PublicUserProfileSerializer):
                 tmp_destination, instance.picture_path,
                 set_modified_on=instance.serializable_reference())
         return instance
+
+    def to_representation(self, obj):
+        data = super(UserProfileSerializer, self).to_representation(obj)
+        request = self.context.get('request', None)
+
+        if request and is_gate_active(request,
+                                      'del-accounts-fxa-edit-email-url'):
+            data.pop('fxa_edit_email_url', None)
+        return data
 
 
 group_rules = {

--- a/src/olympia/accounts/serializers.py
+++ b/src/olympia/accounts/serializers.py
@@ -14,7 +14,7 @@ from olympia.access.models import Group
 from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.amo.utils import (
     clean_nl, has_links, ImageCheck, slug_validator,
-    subscribe_newsletter, unsubscribe_newsletter)
+    subscribe_newsletter, unsubscribe_newsletter, urlparams)
 from olympia.users.models import DeniedName, UserProfile
 from olympia.users.tasks import resize_photo
 from olympia.users import notifications
@@ -71,17 +71,26 @@ class PublicUserProfileSerializer(BaseUserSerializer):
 class UserProfileSerializer(PublicUserProfileSerializer):
     picture_upload = serializers.ImageField(use_url=True, write_only=True)
     permissions = serializers.SerializerMethodField()
+    fxa_edit_email_url = serializers.SerializerMethodField()
 
     class Meta(PublicUserProfileSerializer.Meta):
         fields = PublicUserProfileSerializer.Meta.fields + (
             'display_name', 'email', 'deleted', 'last_login', 'picture_upload',
             'last_login_ip', 'read_dev_agreement', 'permissions',
+            'fxa_edit_email_url',
         )
         writeable_fields = (
             'biography', 'display_name', 'homepage', 'location', 'occupation',
             'picture_upload', 'username',
         )
         read_only_fields = tuple(set(fields) - set(writeable_fields))
+
+    def get_fxa_edit_email_url(self, user):
+        base_url = '{}/settings'.format(
+            settings.FXA_CONFIG['default']['content_host']
+        )
+        return urlparams(base_url, uid=user.fxa_id, email=user.email,
+                         entrypoint='addons')
 
     def validate_biography(self, value):
         if has_links(clean_nl(unicode(value))):

--- a/src/olympia/accounts/tests/test_serializers.py
+++ b/src/olympia/accounts/tests/test_serializers.py
@@ -208,6 +208,12 @@ class TestUserProfileSerializer(TestPublicUserProfileSerializer,
             data = super(TestUserProfileSerializer, self).test_basic()
             assert data['fxa_edit_email_url'] == expected_url
 
+        # And to make sure it's not present in v3
+        gates = {None: ('del-accounts-fxa-edit-email-url',)}
+        with override_settings(DRF_API_GATES=gates):
+            data = super(TestUserProfileSerializer, self).test_basic()
+            assert 'fxa_edit_email_url' not in data
+
 
 class TestUserNotificationSerializer(TestCase):
 

--- a/src/olympia/accounts/tests/test_serializers.py
+++ b/src/olympia/accounts/tests/test_serializers.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from django.test.utils import override_settings
 from rest_framework.test import APIRequestFactory
 
 from olympia import amo
@@ -8,6 +9,7 @@ from olympia.accounts.serializers import (
     UserNotificationSerializer, UserProfileSerializer)
 from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.amo.tests import TestCase, addon_factory, days_ago, user_factory
+from olympia.amo.utils import urlparams
 from olympia.users.models import UserNotification, UserProfile
 from olympia.users.notifications import NOTIFICATIONS_BY_SHORT
 
@@ -172,8 +174,9 @@ class TestUserProfileSerializer(TestPublicUserProfileSerializer,
 
     def setUp(self):
         self.now = days_ago(0)
+        self.user_email = u'a@m.o'
         self.user_kwargs.update({
-            'email': u'a@m.o',
+            'email': self.user_email,
             'display_name': u'This is my náme',
             'last_login_ip': '123.45.67.89',
         })
@@ -186,6 +189,24 @@ class TestUserProfileSerializer(TestPublicUserProfileSerializer,
         assert data['last_login'] == (
             self.now.replace(microsecond=0).isoformat() + 'Z')
         assert data['read_dev_agreement'] == data['last_login']
+
+    def test_expose_fxa_edit_email_url(self):
+        fxa_host = 'http://example.com'
+        fxa_config = {
+            'default': {
+                'content_host': fxa_host,
+            },
+        }
+        user_fxa_id = 'ufxa-id-123'
+        self.user.update(fxa_id=user_fxa_id)
+
+        with override_settings(FXA_CONFIG=fxa_config):
+            expected_url = urlparams('{}/settings'.format(fxa_host),
+                                     uid=user_fxa_id, email=self.user_email,
+                                     entrypoint='addons')
+
+            data = super(TestUserProfileSerializer, self).test_basic()
+            assert data['fxa_edit_email_url'] == expected_url
 
 
 class TestUserNotificationSerializer(TestCase):

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1785,6 +1785,7 @@ DRF_API_GATES = {
         'collections-downloads-shim',
         'addons-locale_disambiguation-shim',
         'del-addons-created-field',
+        'del-accounts-fxa-edit-email-url',
     ),
     'v4': (
         'l10n_flat_input_output',


### PR DESCRIPTION
Fixes #8674

---

This PR exposes a new (non-public) field named `fxa_edit_email_url` in the [Account API response](https://addons-server.readthedocs.io/en/latest/topics/api/accounts.html#account). I have a patch for the frontend, so I guess it suits my needs :D 

Note: I took inspiration from a django template tag. Would it be better to create a `utils` function that could be shared? The template tag lives in `src/olympia/users/`...