### PR TITLE
Make clear what the add-on id is in signing api docs.

### DIFF
--- a/docs/topics/api/signing.rst
+++ b/docs/topics/api/signing.rst
@@ -44,7 +44,7 @@ validation or review fails.
 If the upload succeeded then it will be submitted for
 validation and you will be able to check its status.
 
-.. http:put:: /api/v4/addons/[string:addon-id]/versions/[string:version]/
+.. http:put:: /api/v4/addons/(string:guid)/versions/(string:version)/
 
     **Request:**
 
@@ -54,7 +54,7 @@ validation and you will be able to check its status.
             -g -XPUT --form "upload=@build/my-addon.xpi"
             -H "Authorization: JWT <jwt-token>"
 
-    :param addon-id: The id for the add-on.
+    :param guid: The add-on `extension identifier <https://developer.mozilla.org/en-US/Add-ons/Install_Manifests#id>`_.
     :param version: The version of the add-on.
     :form upload: The add-on file being uploaded.
     :form channel: (optional) The channel this version should be uploaded to,
@@ -147,7 +147,7 @@ automatically or after a manual review. Once review is complete then the
 ``reviewed`` property will be set and you can check the results with the
 ``passed_review`` property.
 
-.. http:get:: /api/v4/addons/[string:addon-id]/versions/[string:version]/(uploads/[string:upload-pk]/)
+.. http:get:: /api/v4/addons/(string:guid)/versions/(string:version)/[uploads/(string:upload-pk)/]
 
     **Request:**
 
@@ -156,7 +156,7 @@ automatically or after a manual review. Once review is complete then the
         curl "https://addons.mozilla.org/api/v4/addons/@my-addon/versions/1.0/"
             -g -H "Authorization: JWT <jwt-token>"
 
-    :param addon-id: the id for the add-on.
+    :param guid: The add-on `extension identifier <https://developer.mozilla.org/en-US/Add-ons/Install_Manifests#id>`_.
     :param version: the version of the add-on.
     :param upload-pk: (optional) the pk for a specific upload.
 

--- a/docs/topics/api/v3_legacy/signing.rst
+++ b/docs/topics/api/v3_legacy/signing.rst
@@ -40,7 +40,7 @@ validation or review fails.
 If the upload succeeded then it will be submitted for
 validation and you will be able to check its status.
 
-.. http:put:: /api/v3/addons/[string:addon-id]/versions/[string:version]/
+.. http:put:: /api/v3/addons/(string:guid)/versions/(string:version)/
 
     **Request:**
 
@@ -50,7 +50,7 @@ validation and you will be able to check its status.
             -g -XPUT --form "upload=@build/my-addon.xpi"
             -H "Authorization: JWT <jwt-token>"
 
-    :param addon-id: The id for the add-on.
+    :param guid: The add-on `extension identifier <https://developer.mozilla.org/en-US/Add-ons/Install_Manifests#id>`_.
     :param version: The version of the add-on.
     :form upload: The add-on file being uploaded.
     :form channel: (optional) The channel this version should be uploaded to,
@@ -143,7 +143,7 @@ automatically or after a manual review. Once review is complete then the
 ``reviewed`` property will be set and you can check the results with the
 ``passed_review`` property.
 
-.. http:get:: /api/v3/addons/[string:addon-id]/versions/[string:version]/(uploads/[string:upload-pk]/)
+.. http:get:: /api/v3/addons/(string:guid)/versions/(string:version)/[uploads/(string:upload-pk)/]
 
     **Request:**
 
@@ -152,7 +152,7 @@ automatically or after a manual review. Once review is complete then the
         curl "https://addons.mozilla.org/api/v3/addons/@my-addon/versions/1.0/"
             -g -H "Authorization: JWT <jwt-token>"
 
-    :param addon-id: the id for the add-on.
+    :param guid: The add-on `extension identifier <https://developer.mozilla.org/en-US/Add-ons/Install_Manifests#id>`_.
     :param version: the version of the add-on.
     :param upload-pk: (optional) the pk for a specific upload.
 

--- a/src/olympia/signing/tests/test_views.py
+++ b/src/olympia/signing/tests/test_views.py
@@ -734,7 +734,8 @@ class TestCheckVersion(BaseUploadVersionTestMixin, TestCase):
     def test_addon_does_not_exist(self):
         response = self.get(self.url('foo', '12.5'))
         assert response.status_code == 404
-        assert response.data['error'] == 'Could not find add-on with id "foo".'
+        assert response.data['error'] == (
+            'Could not find add-on with guid "foo".')
 
     def test_user_does_not_own_addon(self):
         self.create_version('3.0')

--- a/src/olympia/signing/views.py
+++ b/src/olympia/signing/views.py
@@ -44,7 +44,7 @@ def with_addon(allow_missing=False):
                     addon = None
                 else:
                     msg = ugettext(
-                        'Could not find add-on with id "{}".').format(guid)
+                        'Could not find add-on with guid "{}".').format(guid)
                     return Response(
                         {'error': msg},
                         status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
This also brings the signing api docs closer to how all other docs
specify their parameters.

Fixes #7519