### PR TITLE
Default Akismet into logging only mode, waffle actions taken on spam

### DIFF
--- a/src/olympia/bandwagon/tests/test_serializers.py
+++ b/src/olympia/bandwagon/tests/test_serializers.py
@@ -78,7 +78,7 @@ class TestCollectionAkismetSpamValidator(TestCase):
         assert summary_report.comment_type == 'collection-description'
         assert summary_report.comment == self.data['description']['fr']
 
-        # After the first comment_check was spam, additinal ones are skipped.
+        # After the first comment_check was spam, additional ones are skipped.
         assert comment_check_mock.call_count == 1
 
     @override_switch('akismet-spam-check', active=True)
@@ -101,7 +101,7 @@ class TestCollectionAkismetSpamValidator(TestCase):
         assert summary_report.comment_type == 'collection-description'
         assert summary_report.comment == self.data['description']['fr']
 
-        # After the first comment_check was spam, additinal ones are skipped.
+        # After the first comment_check was spam, additional ones are skipped.
         assert comment_check_mock.call_count == 1
 
 

--- a/src/olympia/bandwagon/tests/test_serializers.py
+++ b/src/olympia/bandwagon/tests/test_serializers.py
@@ -60,8 +60,31 @@ class TestCollectionAkismetSpamValidator(TestCase):
         assert comment_check_mock.call_count == 2
 
     @override_switch('akismet-spam-check', active=True)
+    @override_switch('akismet-collection-action', active=False)
     @mock.patch('olympia.lib.akismet.models.AkismetReport.comment_check')
-    def test_spam(self, comment_check_mock):
+    def test_spam_logging_only(self, comment_check_mock):
+        comment_check_mock.return_value = AkismetReport.MAYBE_SPAM
+
+        self.validator(self.data)
+
+        # Akismet check is there
+        assert AkismetReport.objects.count() == 2
+        name_report = AkismetReport.objects.first()
+        # name will only be there once because it's duplicated.
+        assert name_report.comment_type == 'collection-name'
+        assert name_report.comment == self.data['name']['en-US']
+        summary_report = AkismetReport.objects.last()
+        # en-US description won't be there because it's an existing description
+        assert summary_report.comment_type == 'collection-description'
+        assert summary_report.comment == self.data['description']['fr']
+
+        # After the first comment_check was spam, additinal ones are skipped.
+        assert comment_check_mock.call_count == 1
+
+    @override_switch('akismet-spam-check', active=True)
+    @override_switch('akismet-collection-action', active=True)
+    @mock.patch('olympia.lib.akismet.models.AkismetReport.comment_check')
+    def test_spam_action_taken(self, comment_check_mock):
         comment_check_mock.return_value = AkismetReport.MAYBE_SPAM
 
         with self.assertRaises(serializers.ValidationError):

--- a/src/olympia/bandwagon/tests/test_views.py
+++ b/src/olympia/bandwagon/tests/test_views.py
@@ -1370,8 +1370,23 @@ class CollectionViewSetDataMixin(object):
         assert comment_check_mock.call_count == 4
 
     @override_switch('akismet-spam-check', active=True)
+    @override_switch('akismet-collection-action', active=False)
     @patch('olympia.lib.akismet.models.AkismetReport.comment_check')
-    def test_akismet_is_spam(self, comment_check_mock):
+    def test_akismet_is_spam_logging_only(self, comment_check_mock):
+        comment_check_mock.return_value = AkismetReport.MAYBE_SPAM
+        self.client.login_api(self.user)
+        response = self.send(data=self.data)
+        assert response.status_code in [200, 201]
+
+        # AkismetReports are there
+        assert AkismetReport.objects.count() == 4
+        # After the first comment_check was spam, additional ones are skipped.
+        assert comment_check_mock.call_count == 1
+
+    @override_switch('akismet-spam-check', active=True)
+    @override_switch('akismet-collection-action', active=True)
+    @patch('olympia.lib.akismet.models.AkismetReport.comment_check')
+    def test_akismet_is_spam_take_action(self, comment_check_mock):
         comment_check_mock.return_value = AkismetReport.MAYBE_SPAM
         self.client.login_api(self.user)
         response = self.send(data=self.data)

--- a/src/olympia/devhub/tasks.py
+++ b/src/olympia/devhub/tasks.py
@@ -525,8 +525,9 @@ def annotate_webext_incompatibilities(results, file_, addon, version_string,
 
 def annotate_akismet_spam_check(results, akismet_results):
     msg = ugettext('The text entered has been flagged as spam.')
+    error_if_spam = waffle.switch_is_active('akismet-addon-action')
     for report_result in akismet_results:
-        if report_result in (
+        if error_if_spam and report_result in (
                 AkismetReport.MAYBE_SPAM, AkismetReport.DEFINITE_SPAM):
             insert_validation_message(
                 results, message=msg, msg_id='akismet_is_spam')

--- a/src/olympia/migrations/1051-add-more-akismet-waffles.sql
+++ b/src/olympia/migrations/1051-add-more-akismet-waffles.sql
@@ -1,5 +1,5 @@
 INSERT INTO waffle_switch (name, active, note, created, modified)
 VALUES ('akismet-rating-action', 0, 'Take action if Akismet flags a rating as spam', NOW(), NOW()),
-VALUES ('akismet-addon-action', 0, 'Take action if Akismet flags addon metadata as spam', NOW(), NOW()),
-VALUES ('akismet-collection-action', 0, 'Take action if Akismet flags collection metadata as spam', NOW(), NOW())
+       ('akismet-addon-action', 0, 'Take action if Akismet flags addon metadata as spam', NOW(), NOW()),
+       ('akismet-collection-action', 0, 'Take action if Akismet flags collection metadata as spam', NOW(), NOW())
 ;

--- a/src/olympia/migrations/1051-add-more-akismet-waffles.sql
+++ b/src/olympia/migrations/1051-add-more-akismet-waffles.sql
@@ -1,0 +1,5 @@
+INSERT INTO waffle_switch (name, active, note, created, modified)
+VALUES ('akismet-rating-action', 0, 'Take action if Akismet flags a rating as spam', NOW(), NOW()),
+VALUES ('akismet-addon-action', 0, 'Take action if Akismet flags addon metadata as spam', NOW(), NOW()),
+VALUES ('akismet-collection-action', 0, 'Take action if Akismet flags collection metadata as spam', NOW(), NOW())
+;

--- a/src/olympia/ratings/utils.py
+++ b/src/olympia/ratings/utils.py
@@ -1,17 +1,26 @@
 import waffle
 
-from .tasks import check_with_akismet
+from olympia.lib.akismet.models import AkismetReport
+
+from .tasks import check_akismet_reports
 
 
 def maybe_check_with_akismet(request, instance, pre_save_body):
+    akismet_reports = get_rating_akismet_reports(
+        request, instance, pre_save_body)
+    if akismet_reports:
+        check_akismet_reports.delay([rep.id for rep in akismet_reports])
+    return akismet_reports != []
+
+
+def get_rating_akismet_reports(request, instance, pre_save_body):
     should_check = (
         instance.body and instance.body != pre_save_body and
         getattr(instance, 'user_responsible', None) == instance.user and
         waffle.switch_is_active('akismet-spam-check'))
     if should_check:
-        check_with_akismet.delay(
-            instance.id,
+        return [AkismetReport.create_for_rating(
+            instance,
             request.META.get('HTTP_USER_AGENT'),
-            request.META.get('HTTP_REFERER'))
-        return True
-    return False
+            request.META.get('HTTP_REFERER'))]
+    return []


### PR DESCRIPTION
fixes #9732 + a bit of refactoring of `maybe_check_with_akismet` so Rating reports work in a similar way to Addons and Collections (i.e. the AkismetReport is generated first, and _then_ it's sent to a task to be checked with Akismet)