### PR TITLE
tighten Trademark restricts.  No more "for Mozilla|Firefox"

### DIFF
--- a/src/olympia/addons/tests/test_utils_.py
+++ b/src/olympia/addons/tests/test_utils_.py
@@ -30,10 +30,10 @@ from olympia.constants.categories import CATEGORIES_BY_ID
 @pytest.mark.parametrize('name, allowed, email', (
     # Regular name, obviously always allowed
     ('Fancy new Add-on', True, 'foo@bar.com'),
-    # We allow the 'for ...' postfix to be used
-    ('Fancy new Add-on for Firefox', True, 'foo@bar.com'),
-    ('Fancy new Add-on for Mozilla', True, 'foo@bar.com'),
-    # But only the postfix
+    # We don't allow the 'for ...' postfix to be used anymore
+    ('Fancy new Add-on for Firefox', False, 'foo@bar.com'),
+    ('Fancy new Add-on for Mozilla', False, 'foo@bar.com'),
+    # Or the postfix
     ('Fancy new Add-on for Firefox Browser', False, 'foo@bar.com'),
     ('For Firefox fancy new add-on', False, 'foo@bar.com'),
     # But users with @mozilla.com or @mozilla.org email addresses
@@ -43,11 +43,13 @@ from olympia.constants.categories import CATEGORIES_BY_ID
     ('Firefox makes everything better', True, 'foo@mozilla.org'),
     ('Mozilla makes everything better', True, 'foo@mozilla.com'),
     ('Mozilla makes everything better', True, 'foo@mozilla.org'),
+    ('Fancy new Add-on for Firefox', True, 'foo@mozilla.org'),
+    ('Fancy new Add-on for Mozilla', True, 'foo@mozilla.org'),
     # A few more test-cases...
     ('Firefox add-on for Firefox', False, 'foo@bar.com'),
     ('Firefox add-on for Firefox', True, 'foo@mozilla.com'),
     ('Foobarfor Firefox', False, 'foo@bar.com'),
-    ('Better Privacy for Firefox!', True, 'foo@bar.com'),
+    ('Better Privacy for Firefox!', False, 'foo@bar.com'),
     ('Firefox awesome for Mozilla', False, 'foo@bar.com'),
     ('Firefox awesome for Mozilla', True, 'foo@mozilla.org'),
 ))

--- a/src/olympia/addons/tests/test_utils_.py
+++ b/src/olympia/addons/tests/test_utils_.py
@@ -9,6 +9,8 @@ import zipfile
 from django.conf import settings
 from django.forms import ValidationError
 
+from waffle.testutils import override_switch
+
 from olympia import amo
 from olympia.addons.models import Category
 from olympia.addons.utils import (
@@ -27,43 +29,70 @@ from olympia.constants.categories import CATEGORIES_BY_ID
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('name, allowed, email', (
+@pytest.mark.parametrize('name, allowed, email, content_optmzn_waffle', (
+    # First with the content optimization waffle off:
     # Regular name, obviously always allowed
-    ('Fancy new Add-on', True, 'foo@bar.com'),
-    # We don't allow the 'for ...' postfix to be used anymore
-    ('Fancy new Add-on for Firefox', False, 'foo@bar.com'),
-    ('Fancy new Add-on for Mozilla', False, 'foo@bar.com'),
-    # Or the postfix
-    ('Fancy new Add-on for Firefox Browser', False, 'foo@bar.com'),
-    ('For Firefox fancy new add-on', False, 'foo@bar.com'),
+    ('Fancy new Add-on', True, 'foo@bar.com', False),
+    # We allow the 'for ...' postfix to be used
+    ('Fancy new Add-on for Firefox', True, 'foo@bar.com', False),
+    ('Fancy new Add-on for Mozilla', True, 'foo@bar.com', False),
+    # But only the postfix
+    ('Fancy new Add-on for Firefox Browser', False, 'foo@bar.com', False),
+    ('For Firefox fancy new add-on', False, 'foo@bar.com', False),
     # But users with @mozilla.com or @mozilla.org email addresses
     # are allowed
-    ('Firefox makes everything better', False, 'bar@baz.com'),
-    ('Firefox makes everything better', True, 'foo@mozilla.com'),
-    ('Firefox makes everything better', True, 'foo@mozilla.org'),
-    ('Mozilla makes everything better', True, 'foo@mozilla.com'),
-    ('Mozilla makes everything better', True, 'foo@mozilla.org'),
-    ('Fancy new Add-on for Firefox', True, 'foo@mozilla.org'),
-    ('Fancy new Add-on for Mozilla', True, 'foo@mozilla.org'),
+    ('Firefox makes everything better', False, 'bar@baz.com', False),
+    ('Firefox makes everything better', True, 'foo@mozilla.com', False),
+    ('Firefox makes everything better', True, 'foo@mozilla.org', False),
+    ('Mozilla makes everything better', True, 'foo@mozilla.com', False),
+    ('Mozilla makes everything better', True, 'foo@mozilla.org', False),
     # A few more test-cases...
-    ('Firefox add-on for Firefox', False, 'foo@bar.com'),
-    ('Firefox add-on for Firefox', True, 'foo@mozilla.com'),
-    ('Foobarfor Firefox', False, 'foo@bar.com'),
-    ('Better Privacy for Firefox!', False, 'foo@bar.com'),
-    ('Firefox awesome for Mozilla', False, 'foo@bar.com'),
-    ('Firefox awesome for Mozilla', True, 'foo@mozilla.org'),
+    ('Firefox add-on for Firefox', False, 'foo@bar.com', False),
+    ('Firefox add-on for Firefox', True, 'foo@mozilla.com', False),
+    ('Foobarfor Firefox', False, 'foo@bar.com', False),
+    ('Better Privacy for Firefox!', True, 'foo@bar.com', False),
+    ('Firefox awesome for Mozilla', False, 'foo@bar.com', False),
+    ('Firefox awesome for Mozilla', True, 'foo@mozilla.org', False),
+
+    # And with the content optimization waffle onL
+    # Regular name, obviously always allowed
+    ('Fancy new Add-on', True, 'foo@bar.com', True),
+    # We don't allow the 'for ...' postfix to be used anymore
+    ('Fancy new Add-on for Firefox', False, 'foo@bar.com', True),
+    ('Fancy new Add-on for Mozilla', False, 'foo@bar.com', True),
+    # Or the postfix
+    ('Fancy new Add-on for Firefox Browser', False, 'foo@bar.com', True),
+    ('For Firefox fancy new add-on', False, 'foo@bar.com', True),
+    # But users with @mozilla.com or @mozilla.org email addresses
+    # are allowed
+    ('Firefox makes everything better', False, 'bar@baz.com', True),
+    ('Firefox makes everything better', True, 'foo@mozilla.com', True),
+    ('Firefox makes everything better', True, 'foo@mozilla.org', True),
+    ('Mozilla makes everything better', True, 'foo@mozilla.com', True),
+    ('Mozilla makes everything better', True, 'foo@mozilla.org', True),
+    ('Fancy new Add-on for Firefox', True, 'foo@mozilla.org', True),
+    ('Fancy new Add-on for Mozilla', True, 'foo@mozilla.org', True),
+    # A few more test-cases...
+    ('Firefox add-on for Firefox', False, 'foo@bar.com', True),
+    ('Firefox add-on for Firefox', True, 'foo@mozilla.com', True),
+    ('Foobarfor Firefox', False, 'foo@bar.com', True),
+    ('Better Privacy for Firefox!', False, 'foo@bar.com', True),
+    ('Firefox awesome for Mozilla', False, 'foo@bar.com', True),
+    ('Firefox awesome for Mozilla', True, 'foo@mozilla.org', True),
 ))
-def test_verify_mozilla_trademark(name, allowed, email):
+def test_verify_mozilla_trademark(name, allowed, email, content_optmzn_waffle):
     user = user_factory(email=email)
 
-    if not allowed:
-        with pytest.raises(ValidationError) as exc:
+    with override_switch('content-optimization', active=content_optmzn_waffle):
+        if not allowed:
+            with pytest.raises(ValidationError) as exc:
+                verify_mozilla_trademark(name, user)
+            assert exc.value.message == (
+                'Add-on names cannot contain the Mozilla or Firefox '
+                'trademarks.'
+            )
+        else:
             verify_mozilla_trademark(name, user)
-        assert exc.value.message == (
-            'Add-on names cannot contain the Mozilla or Firefox trademarks.'
-        )
-    else:
-        verify_mozilla_trademark(name, user)
 
 
 class TestGetFeaturedIds(TestCase):

--- a/src/olympia/addons/utils.py
+++ b/src/olympia/addons/utils.py
@@ -111,10 +111,7 @@ def verify_mozilla_trademark(name, user, form=None):
         name = normalize_string(name, strip_puncutation=True).lower()
 
         for symbol in amo.MOZILLA_TRADEMARK_SYMBOLS:
-            violates_trademark = (
-                name.count(symbol) > 1 or (
-                    name.count(symbol) >= 1 and not
-                    name.endswith(' for {}'.format(symbol))))
+            violates_trademark = symbol in name
 
             if violates_trademark:
                 raise forms.ValidationError(ugettext(

--- a/src/olympia/devhub/tests/test_forms.py
+++ b/src/olympia/devhub/tests/test_forms.py
@@ -804,15 +804,6 @@ class TestDescribeForm(TestCase):
         assert form.errors['name'].data[0].message.startswith(
             u'Add-on names cannot contain the Mozilla or Firefox trademarks.')
 
-    def test_name_trademark_allowed_for_prefix(self):
-        delicious = Addon.objects.get()
-        form = forms.DescribeForm(
-            {'name': 'Delicious for Mozilla', 'summary': 'foo', 'slug': 'bar'},
-            request=self.request,
-            instance=delicious)
-
-        assert form.is_valid()
-
     def test_name_no_trademark(self):
         delicious = Addon.objects.get()
         form = forms.DescribeForm(
@@ -857,14 +848,14 @@ class TestDescribeForm(TestCase):
 
         with override_switch('content-optimization', active=False):
             form = forms.DescribeForm(
-                {'name': 'Delicious for Mozilla', 'summary': 'foo',
+                {'name': 'Delicious for everyone', 'summary': 'foo',
                  'slug': 'bar'},
                 request=self.request, instance=delicious)
             assert form.is_valid(), form.errors
 
         with override_switch('content-optimization', active=True):
             form = forms.DescribeForm(
-                {'name': 'Delicious for Mozilla', 'summary': 'foo',
+                {'name': 'Delicious for everyone', 'summary': 'foo',
                  'slug': 'bar'},
                 request=self.request, instance=delicious)
             assert not form.is_valid()
@@ -872,7 +863,7 @@ class TestDescribeForm(TestCase):
             # But only extensions are required to have a description
             delicious.update(type=amo.ADDON_STATICTHEME)
             form = forms.DescribeForm(
-                {'name': 'Delicious for Mozilla', 'summary': 'foo',
+                {'name': 'Delicious for everyone', 'summary': 'foo',
                  'slug': 'bar'},
                 request=self.request, instance=delicious)
             assert form.is_valid(), form.errors
@@ -880,7 +871,7 @@ class TestDescribeForm(TestCase):
             #  Do it again, but this time with a description
             delicious.update(type=amo.ADDON_EXTENSION)
             form = forms.DescribeForm(
-                {'name': 'Delicious for Mozilla', 'summary': 'foo',
+                {'name': 'Delicious for everyone', 'summary': 'foo',
                  'slug': 'bar', 'description': 'its a description'},
                 request=self.request,
                 instance=delicious)
@@ -892,14 +883,14 @@ class TestDescribeForm(TestCase):
 
         with override_switch('content-optimization', active=False):
             form = forms.DescribeForm(
-                {'name': 'Delicious for Mozilla', 'summary': 'foo',
+                {'name': 'Delicious for everyone', 'summary': 'foo',
                  'slug': 'bar', 'description': '123456789'},
                 request=self.request, instance=delicious)
             assert form.is_valid(), form.errors
 
         with override_switch('content-optimization', active=True):
             form = forms.DescribeForm(
-                {'name': 'Delicious for Mozilla', 'summary': 'foo',
+                {'name': 'Delicious for everyone', 'summary': 'foo',
                  'slug': 'bar', 'description': '123456789'},
                 request=self.request, instance=delicious)
             assert not form.is_valid()
@@ -907,7 +898,7 @@ class TestDescribeForm(TestCase):
             # But only extensions have a minimum length
             delicious.update(type=amo.ADDON_STATICTHEME)
             form = forms.DescribeForm(
-                {'name': 'Delicious for Mozilla', 'summary': 'foo',
+                {'name': 'Delicious for everyone', 'summary': 'foo',
                  'slug': 'bar', 'description': '123456789'},
                 request=self.request, instance=delicious)
             assert form.is_valid()
@@ -915,7 +906,7 @@ class TestDescribeForm(TestCase):
             #  Do it again, but this time with a description
             delicious.update(type=amo.ADDON_EXTENSION)
             form = forms.DescribeForm(
-                {'name': 'Delicious for Mozilla', 'summary': 'foo',
+                {'name': 'Delicious for everyone', 'summary': 'foo',
                  'slug': 'bar', 'description': '1234567890'},
                 request=self.request,
                 instance=delicious)

--- a/src/olympia/devhub/tests/test_forms.py
+++ b/src/olympia/devhub/tests/test_forms.py
@@ -804,6 +804,16 @@ class TestDescribeForm(TestCase):
         assert form.errors['name'].data[0].message.startswith(
             u'Add-on names cannot contain the Mozilla or Firefox trademarks.')
 
+    @override_switch('content-optimization', active=False)
+    def test_name_trademark_allowed_for_prefix(self):
+        delicious = Addon.objects.get()
+        form = forms.DescribeForm(
+            {'name': 'Delicious for Mozilla', 'summary': 'foo', 'slug': 'bar'},
+            request=self.request,
+            instance=delicious)
+
+        assert form.is_valid()
+
     def test_name_no_trademark(self):
         delicious = Addon.objects.get()
         form = forms.DescribeForm(

--- a/src/olympia/files/tests/test_utils_.py
+++ b/src/olympia/files/tests/test_utils_.py
@@ -382,18 +382,6 @@ class TestManifestJSONExtractor(TestCase):
                     u'Add-on names cannot contain the Mozilla or'
                 )
 
-    @mock.patch('olympia.addons.models.resolve_i18n_message')
-    def test_mozilla_trademark_for_prefix_allowed(self, resolve_message):
-        resolve_message.return_value = 'Notify for Mozilla'
-
-        addon = amo.tests.addon_factory()
-        file_obj = addon.current_version.all_files[0]
-        fixture = (
-            'src/olympia/files/fixtures/files/notify-link-clicks-i18n.xpi')
-
-        with amo.tests.copy_file(fixture, file_obj.file_path):
-            utils.parse_xpi(file_obj.file_path)
-
     def test_apps_use_default_versions_if_applications_is_omitted(self):
         """
         WebExtensions are allowed to omit `applications[/gecko]` and we

--- a/src/olympia/files/tests/test_utils_.py
+++ b/src/olympia/files/tests/test_utils_.py
@@ -18,6 +18,7 @@ import mock
 import pytest
 
 from defusedxml.common import EntitiesForbidden, NotSupportedError
+from waffle.testutils import override_switch
 
 from olympia import amo
 from olympia.amo.tests import TestCase
@@ -381,6 +382,19 @@ class TestManifestJSONExtractor(TestCase):
                 assert dict(exc.value.messages)['en-us'].startswith(
                     u'Add-on names cannot contain the Mozilla or'
                 )
+
+    @mock.patch('olympia.addons.models.resolve_i18n_message')
+    @override_switch('content-optimization', active=False)
+    def test_mozilla_trademark_for_prefix_allowed(self, resolve_message):
+        resolve_message.return_value = 'Notify for Mozilla'
+
+        addon = amo.tests.addon_factory()
+        file_obj = addon.current_version.all_files[0]
+        fixture = (
+            'src/olympia/files/fixtures/files/notify-link-clicks-i18n.xpi')
+
+        with amo.tests.copy_file(fixture, file_obj.file_path):
+            utils.parse_xpi(file_obj.file_path)
 
     def test_apps_use_default_versions_if_applications_is_omitted(self):
         """


### PR DESCRIPTION
fixes #9267 