### PR TITLE
Add a new process_addons task to remove AMO links in some fields

### DIFF
--- a/src/olympia/addons/management/commands/process_addons.py
+++ b/src/olympia/addons/management/commands/process_addons.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.db.models import Q
 
@@ -11,7 +12,8 @@ from olympia.addons.tasks import (
     find_inconsistencies_between_es_and_db,
     migrate_legacy_dictionaries_to_webextension,
     migrate_lwts_to_static_themes,
-    migrate_webextensions_to_git_storage)
+    migrate_webextensions_to_git_storage,
+    remove_amo_links_in_url_fields)
 from olympia.amo.utils import chunked
 from olympia.devhub.tasks import get_preview_sizes, recreate_previews
 from olympia.lib.crypto.tasks import sign_addons
@@ -97,6 +99,15 @@ tasks = {
             Q(type__in=(amo.ADDON_EXTENSION, amo.ADDON_THEME, amo.ADDON_LPAPP),
               versions__files__is_webextension=False,
               versions__files__is_mozilla_signed_extension=False)
+        ],
+        'pre': lambda values_qs: values_qs.distinct(),
+    },
+    'remove_amo_links_in_url_fields': {
+        'method': remove_amo_links_in_url_fields,
+        'qs': [
+            Q(homepage__localized_string__icontains=settings.DOMAIN) |
+            Q(support_url__localized_string__icontains=settings.DOMAIN) |
+            Q(contributions__icontains=settings.DOMAIN)
         ],
         'pre': lambda values_qs: values_qs.distinct(),
     },

--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -822,14 +822,14 @@ def remove_amo_links_in_url_fields(ids, **kw):
     for addon in addons:
         with transaction.atomic():
             translation_ids = []
-            if addon.homepage:
-                translation_ids.append(addon.homepage.id)
-            if addon.support_url:
-                translation_ids.append(addon.support_url.id)
+            if addon.homepage_id:
+                translation_ids.append(addon.homepage_id)
+            if addon.support_url_id:
+                translation_ids.append(addon.support_url_id)
             if translation_ids:
                 Translation.objects.filter(
                     id__in=translation_ids,
                     localized_string__icontains=settings.DOMAIN
-                ).update(localized_string=u'')
+                ).update(localized_string=u'', localized_string_clean=u'')
             if settings.DOMAIN.lower() in addon.contributions.lower():
                 addon.update(contributions=u'')

--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -41,6 +41,7 @@ from olympia.ratings.models import Rating
 from olympia.reviewers.models import RereviewQueueTheme
 from olympia.stats.utils import migrate_theme_update_count
 from olympia.tags.models import AddonTag, Tag
+from olympia.translations.models import Translation
 from olympia.users.models import UserProfile
 from olympia.versions.models import License, Version
 
@@ -808,3 +809,27 @@ def disable_legacy_files(ids, **kw):
             for file_ in files:
                 log.info('Disabling file %d from addon %s', file_.pk, addon.pk)
                 file_.update(status=amo.STATUS_DISABLED)
+
+
+@task
+@use_primary_db
+def remove_amo_links_in_url_fields(ids, **kw):
+    """With the specified ids, remove the AMO links in the following URL fields
+    of each add-on: homepage, support_url, contribution."""
+    log.info('Deleting AMO links in URL fields %d-%d [%d].', ids[0], ids[-1],
+             len(ids))
+    addons = Addon.objects.filter(id__in=ids)
+    for addon in addons:
+        with transaction.atomic():
+            translation_ids = []
+            if addon.homepage:
+                translation_ids.append(addon.homepage.id)
+            if addon.support_url:
+                translation_ids.append(addon.support_url.id)
+            if translation_ids:
+                Translation.objects.filter(
+                    id__in=translation_ids,
+                    localized_string__icontains=settings.DOMAIN
+                ).update(localized_string=u'')
+            if settings.DOMAIN.lower() in addon.contributions.lower():
+                addon.update(contributions=u'')

--- a/src/olympia/addons/tests/test_commands.py
+++ b/src/olympia/addons/tests/test_commands.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.forms import ValidationError
+from django.utils import translation
 
 import mock
 import pytest
@@ -659,3 +660,81 @@ class TestDisableLegacyAddons(TestCase):
             assert addon.current_version
             file_ = addon.versions.all()[0].all_files[0]
             assert file_.status == amo.STATUS_PUBLIC
+
+
+class TestRemoveAMOLinksInURLFields(TestCase):
+    domain = settings.DOMAIN
+    allowed_url = u'https://example.org'
+
+    def test_remove_links_in_homepages(self):
+        addons = [
+            addon_factory(homepage=u'%s' % self.domain),
+            addon_factory(homepage=u'https://%s/page.html' % self.domain),
+        ]
+
+        call_command('process_addons', task='remove_amo_links_in_url_fields')
+
+        for addon in addons:
+            addon.reload()
+            assert addon.homepage == u''
+
+    def test_remove_links_in_support_urls(self):
+        addons = [
+            addon_factory(support_url=u'%s' % self.domain),
+            addon_factory(support_url=u'https://%s/page.html' % self.domain),
+        ]
+
+        call_command('process_addons', task='remove_amo_links_in_url_fields')
+
+        for addon in addons:
+            addon.reload()
+            assert addon.support_url == u''
+
+    def test_remove_links_in_contributions(self):
+        addons = [
+            addon_factory(contributions=u'%s' % self.domain),
+            addon_factory(contributions=u'https://%s/page.html' % self.domain),
+        ]
+
+        call_command('process_addons', task='remove_amo_links_in_url_fields')
+
+        for addon in addons:
+            addon.reload()
+            assert addon.contributions == u''
+
+    def test_remove_links_in_support_url_and_homepage(self):
+        addons = [
+            addon_factory(
+                homepage=u'http://%s' % self.domain,
+                support_url=u'%s' % self.domain,
+            ),
+        ]
+        should_be_kept_intact = [
+            addon_factory(support_url=self.allowed_url),
+        ]
+
+        call_command('process_addons', task='remove_amo_links_in_url_fields')
+
+        for addon in addons:
+            addon.reload()
+            assert addon.homepage == u''
+            assert addon.support_url == u''
+        for addon in should_be_kept_intact:
+            addon.reload()
+            assert addon.support_url == self.allowed_url
+
+    def test_with_multiple_translations(self):
+        addon = addon_factory(support_url={
+            'en-US': self.allowed_url,
+            'fr': u'http://%s' % self.domain,
+        })
+
+        call_command('process_addons', task='remove_amo_links_in_url_fields')
+
+        translation.activate('en-US')
+        addon.reload()
+        assert addon.support_url.localized_string == self.allowed_url
+
+        translation.activate('fr')
+        addon.reload()
+        assert addon.support_url.localized_string == u''

--- a/src/olympia/addons/tests/test_commands.py
+++ b/src/olympia/addons/tests/test_commands.py
@@ -676,7 +676,8 @@ class TestRemoveAMOLinksInURLFields(TestCase):
 
         for addon in addons:
             addon.reload()
-            assert addon.homepage == u''
+            assert addon.homepage.localized_string == u''
+            assert addon.homepage.localized_string_clean == u''
 
     def test_remove_links_in_support_urls(self):
         addons = [
@@ -688,7 +689,8 @@ class TestRemoveAMOLinksInURLFields(TestCase):
 
         for addon in addons:
             addon.reload()
-            assert addon.support_url == u''
+            assert addon.support_url.localized_string == u''
+            assert addon.support_url.localized_string_clean == u''
 
     def test_remove_links_in_contributions(self):
         addons = [
@@ -733,8 +735,8 @@ class TestRemoveAMOLinksInURLFields(TestCase):
 
         translation.activate('en-US')
         addon.reload()
-        assert addon.support_url.localized_string == self.allowed_url
+        assert addon.support_url == self.allowed_url
 
         translation.activate('fr')
         addon.reload()
-        assert addon.support_url.localized_string == u''
+        assert addon.support_url == u''


### PR DESCRIPTION
Fixes #9735

---

As per our IRC discussion, I set the values of the translated fields to
an empty string instead of deleting the `Translation` objects.

In the test suite, I rely on the default `settings` because I cannot use
`override_settings` here (the `settings.DOMAIN` value is used in a
static `tasks` dict, which cannot be easily overridden because it is
already set when the file is imported).