### PR TITLE
Add a validator for the user's homepage

### DIFF
--- a/src/olympia/accounts/serializers.py
+++ b/src/olympia/accounts/serializers.py
@@ -106,6 +106,14 @@ class UserProfileSerializer(PublicUserProfileSerializer):
                 ugettext(u'This display name cannot be used.'))
         return value
 
+    def validate_homepage(self, value):
+        if settings.DOMAIN.lower() in value.lower():
+            raise serializers.ValidationError(
+                ugettext(u'The homepage field can only be used to link to '
+                         u'external websites.')
+            )
+        return value
+
     def validate_username(self, value):
         # All-digits usernames are disallowed since they can be confused for
         # user IDs in URLs.

--- a/src/olympia/accounts/tests/test_serializers.py
+++ b/src/olympia/accounts/tests/test_serializers.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from django.test.utils import override_settings
+from rest_framework import serializers
 from rest_framework.test import APIRequestFactory
 
 from olympia import amo
@@ -213,6 +214,17 @@ class TestUserProfileSerializer(TestPublicUserProfileSerializer,
         with override_settings(DRF_API_GATES=gates):
             data = super(TestUserProfileSerializer, self).test_basic()
             assert 'fxa_edit_email_url' not in data
+
+    def test_validate_homepage(self):
+        domain = u'example.org'
+        allowed_url = u'http://github.com'
+        serializer = self.serializer(context={'request': self.request})
+
+        with override_settings(DOMAIN=domain):
+            with self.assertRaises(serializers.ValidationError):
+                serializer.validate_homepage(u'http://{}'.format(domain))
+            # It should not raise when value is allowed.
+            assert serializer.validate_homepage(allowed_url) == allowed_url
 
 
 class TestUserNotificationSerializer(TestCase):


### PR DESCRIPTION
Fixes #9790

---

This PR adds a (DRF) `validate_*` method on the `UserProfile` serializer
to prevent users to set an AMO link in the `homepage` field of their profile.

In action in addons-frontend:

![screen shot 2018-10-26 at 15 45 44](https://user-images.githubusercontent.com/217628/47570350-3d9d9900-d936-11e8-8d77-3d318a1a8ed5.png)
