### PR TITLE
Make exact matches in search dependent on language

### DIFF
--- a/docs/topics/development/search.rst
+++ b/docs/topics/development/search.rst
@@ -16,35 +16,19 @@ How does search on AMO work?
 General structure
 =================
 
-Our Elasticsearch cluster contains Add-ons (``addons`` index) and statistics data. The purpose of that document is to describe the add-ons part only though.
+Our Elasticsearch cluster contains Add-ons (``addons`` index) and statistics data. The purpose of that document is to describe the add-ons part only though. We store two kinds of data for add-ons: indexed fields that are used for search purposes, and non-indexed fields that are meant to be returned (often as-is with no transformations) by the search API (allowing us to return search results data without hitting the database). The latter is not relevant to this document.
 
-In addition to that we store the following data:
-
- * Add-on Versions (`Indexer / Serializer <https://github.com/mozilla/addons-server/blob/master/src/olympia/addons/indexers.py#L215-L237>`_)
- * Files for each Add-on Version
- * Compatibility information for each Add-on Version
-
-As well as
-
- * Authors
- * Previews (image links)
- * Translations (`Translations mapping generation <https://github.com/mozilla/addons-server/blob/master/src/olympia/amo/indexers.py#L40-L136>`_)
-
-And various other add-on related properties. See the `Add-on Indexer / Serializer <https://github.com/mozilla/addons-server/blob/master/src/olympia/addons/indexers.py#L215-L237>`_ for more details.
-
-Our search can be reached either via the API through :ref:`/api/v4/addons/search/ <addon-search>` or :ref:`/api/v4/addons/autocomplete/ <addon-autocomplete>` which are used by our addons-frontend as well as via our legacy pages (used much less).
-
-Both use similar filtering and scoring code. For legacy reasons they're not identical. We should focus on our API-based search though since the legacy search will be removed once support for Thunderbird and Seamonkey is moved to a new platform.
-
-The legacy search uses ElasticSearch to query the data and then requests the actual model objects from the database. The newer API-based search only hits ElasticSearch and uses data directly stored from ES which is much more efficient.
+Our search can be reached either via the API through :ref:`/api/v4/addons/search/ <addon-search>` or :ref:`/api/v4/addons/autocomplete/ <addon-autocomplete>` which are used by our addons-frontend as well as via our legacy pages (which are going away and off-topic here).
 
 
 Indexing
 ========
 
-We index all text fields that have translations twice: once with a generic analyzer (snowball for description & summary, a custom one for name) and once with the corresponding language-specific analyzer if it exists. We also index a special variant of the name called ``name.raw`` which is a non-analyzed keyword, normalized in lowercase though a custom normalizer.
+The key fields we search against are ``name``, ``summary`` and ``description``. Because all can be translated, we index twice:
+- Once with the translation in the language-specific analyzer if supported, under ``{field}_l10n_{analyzer}``
+- Once with the translation in the default locale of the add-on, under ``{field}``, analyzed with just the ``snowball`` analyzer for ``description`` and ``summary``, and a custom analyzer for ``name`` that applies the following filters: ``standard``, ``word_delimiter`` (a custom version with ``preserve_original`` set to ``true``), ``lowercase``, ``stop``, and ``dictionary_decompounder`` (with a specific word list) and ``unique``.
 
-Our custom name analyzer applies the following filters: ``standard``, ``word_delimiter`` (a custom version with ``preserve_original`` set to ``true``), ``lowercase``, ``stop``, and ``dictionary_decompounder`` (with a specific word list) and ``unique``.
+In addition, for the name, both fields also contains a subfield called ``raw`` that holds a non-analyzed variant for exact matches in the corresponding language (stored as a ``keyword``, with a ``lowercase`` normalizer).
 
 For each document, we store a ``boost`` field that depends on the average number of users for the add-on, as well as a multiplier for public, non-experimental add-ons.
 
@@ -68,14 +52,14 @@ to a specific set of fields: add-on name and author(s) name.
 
 **Applied rules** (merged via ``should``):
 
-1. Prefer ``term`` matches on ``name.raw`` (``boost=100.0``) - our attempt to implement exact matches
-2. Prefer phrase matches that allows swapped terms (``boost=8.0``, ``slop=1``)
-3. If a query is < 20 characters long, try to do a fuzzy match on the search query (``boost=4.0``, ``prefix_length=4``, ``fuzziness=AUTO``)
-4. Then text matches, using the standard text analyzer (``boost=6.0``, ``analyzer=standard``, ``operator=and``)
-5. Then look for the query as a prefix (``boost=3.0``)
-6. If we have a matching analyzer, add a query to ``name_l10n_{LANG}`` (``boost=5.0``, ``operator=and``)
+1. A ``term`` matches on either ``name_l10n_{analyzer}.raw`` if the language of the request matches a known language-specific analyzer, or just ``name.raw`` (``boost=100.0``) otherwise - our attempt to implement exact matches
+2. If we have a matching language-specific analyzer, we add a ``match`` query to ``name_l10n_{analyzer}`` (``boost=5.0``, ``operator=and``)
+3. A ``phrase`` match on ``name`` that allows swapped terms (``boost=8.0``, ``slop=1``)
+4. A ``match`` on ``name``, using the standard text analyzer (``boost=6.0``, ``analyzer=standard``, ``operator=and``)
+5. A ``prefix`` match on ``name`` (``boost=3.0``)
+6. If a query is < 20 characters long, a fuzzy match on ``name`` (``boost=4.0``, ``prefix_length=4``, ``fuzziness=AUTO``)
 
-All rules except 1 and 6 are applied to both ``name`` and ``listed_authors.name``.
+All rules except 1 and 2 are applied to both ``name`` and ``listed_authors.name``.
 
 
 Secondary rules

--- a/src/olympia/search/tests/test_search_ranking.py
+++ b/src/olympia/search/tests/test_search_ranking.py
@@ -437,117 +437,117 @@ class TestRankingScenarios(ESTestCase):
 
     def test_scenario_tab_center_redux(self):
         self._check_scenario('tab center redux', (
-            ['Tab Center Redux', 58.861458],
-            ['Tab Mix Plus', 0.059719414],
-            ['Redux DevTools', 0.042313993],
+            ['Tab Center Redux', 68.93481],
+            ['Tab Mix Plus', 0.06915905],
+            ['Redux DevTools', 0.048774697],
         ))
 
     def test_scenario_open_image_new_tab(self):
         self._check_scenario('Open Image in New Tab', (
-            ['Open Image in New Tab', 20.057362],
-            ['Open image in a new tab', 4.689237],
+            ['Open Image in New Tab', 24.203598],
+            ['Open image in a new tab', 5.657885],
         ))
 
     def test_scenario_coinhive(self):
         # TODO, should match "CoinBlock". Check word delimiting analysis maybe?
         self._check_scenario('CoinHive', (
-            ['Coinhive Blocker', 4.0704737],
-            ['NoMiners', 0.05506869],  # via description
+            ['Coinhive Blocker', 3.8724504],
+            ['NoMiners', 0.02196929],  # via description
             # ['CoinBlock', 0],  # via prefix search
         ))
 
     def test_scenario_privacy(self):
         self._check_scenario('Privacy', (
-            ['Privacy Badger', 8.979201],
-            ['Privacy Settings', 4.6844597],
-            ['Google Privacy', 4.440067],  # More users, summary
-            ['Privacy Pass', 2.7299168],
-            ['Ghostery', 0.2711954],  # Crazy amount of users, summary
+            ['Privacy Badger', 8.6709795],
+            ['Privacy Settings', 4.523729],
+            ['Google Privacy', 4.3162794],  # More users, summary
+            ['Privacy Pass', 3.1850927],
+            ['Ghostery', 0.09763952],  # Crazy amount of users, summary
             # summary + a lot of users, but not as many as ghostery
-            ['Blur', 0.2237452],
+            ['Blur', 0.081027344],
         ))
 
     def test_scenario_firebu(self):
         self._check_scenario('firebu', (
-            ['Firebug', 3.5018365],
-            ['Firefinder for Firebug', 0.9281566],
-            ['Firebug Autocompleter', 0.90936154],
-            ['Fire Drag', 0.55355644],
+            ['Firebug', 4.0864024],
+            ['Firefinder for Firebug', 1.0825881],
+            ['Firebug Autocompleter', 1.0606518],
+            ['Fire Drag', 0.64538175],
         ))
 
     def test_scenario_fireb(self):
         self._check_scenario('fireb', (
-            ['Firebug', 3.5018365],
-            ['Firefinder for Firebug', 0.9281566],
-            ['Firebug Autocompleter', 0.90936154],
-            ['Fire Drag', 0.55355644],
+            ['Firebug', 4.0864024],
+            ['Firefinder for Firebug', 1.0825881],
+            ['Firebug Autocompleter', 1.0606518],
+            ['Fire Drag', 0.64538175],
         ))
 
     def test_scenario_menu_wizzard(self):
         self._check_scenario('Menu Wizzard', (
-            ['Menu Wizard', 0.09492746],  # (fuzzy, typo)
+            ['Menu Wizard', 0.110211946],  # (fuzzy, typo)
             # partial match + users
-            ['Add-ons Manager Context Menu', 0.07142148],
+            ['Add-ons Manager Context Menu', 0.082752444],
         ))
 
     def test_scenario_frame_demolition(self):
         self._check_scenario('Frame Demolition', (
-            ['Frame Demolition', 17.449215],
+            ['Frame Demolition', 20.398996],
         ))
 
     def test_scenario_demolition(self):
         # Find "Frame Demolition" via a typo
         self._check_scenario('Demolation', (
-            ['Frame Demolition', 0.053424396],
+            ['Frame Demolition', 0.061664674],
         ))
 
     def test_scenario_restyle(self):
         self._check_scenario('reStyle', (
-            ['reStyle', 22.465034],
+            ['reStyle', 26.222485],
         ))
 
     def test_scenario_megaupload_downloadhelper(self):
         # Doesn't find "RapidShare DownloadHelper" anymore
         # since we now query by "MegaUpload AND DownloadHelper"
         self._check_scenario('MegaUpload DownloadHelper', (
-            ['MegaUpload DownloadHelper', 35.52409],
+            ['MegaUpload DownloadHelper', 42.696255],
         ))
 
     def test_scenario_downloadhelper(self):
         # No direct match, "Download Flash and Video" has
         # huge amount of users that puts it first here
         self._check_scenario('DownloadHelper', (
-            ['RapidShare DownloadHelper', 2.6389623],
-            ['MegaUpload DownloadHelper', 1.4683809],
-            ['Download Flash and Video', 1.2867662],
-            ['1-Click YouTube Video Download', 0.9725059],
+            ['RapidShare DownloadHelper', 3.07932],
+            ['MegaUpload DownloadHelper', 1.7131001],
+            ['Download Flash and Video', 1.5011319],
+            ['1-Click YouTube Video Download', 1.1343496],
         ))
 
     def test_scenario_megaupload(self):
         self._check_scenario('MegaUpload', (
-            ['MegaUpload DownloadHelper', 3.3756053],
-            ['Popup Blocker', 1.2201201],
+            ['MegaUpload DownloadHelper', 3.2528403],
+            ['Popup Blocker', 1.4232717],
         ))
 
     def test_scenario_no_flash(self):
         self._check_scenario('No Flash', (
-            ['No Flash', 47.867012],
-            ['Download Flash and Video', 5.01278],
-            ['YouTube Flash Player', 3.9155407],
-            ['YouTube Flash Video Player', 3.68004],
+            ['No Flash', 46.397503],
+            ['Download Flash and Video', 4.3807344],
+            ['YouTube Flash Player', 3.4882324],
+            ['YouTube Flash Video Player', 3.1814165],
         ))
 
         # Case should not matter.
         self._check_scenario('no flash', (
-            ['No Flash', 47.867012],
-            ['Download Flash and Video', 5.01278],
-            ['YouTube Flash Player', 3.9155407],
-            ['YouTube Flash Video Player', 3.68004],
+            ['No Flash', 46.397503],
+            ['Download Flash and Video', 4.3807344],
+            ['YouTube Flash Player', 3.4882324],
+            ['YouTube Flash Video Player', 3.1814165],
         ))
 
     def test_scenario_disable_hello_pocket_reader_plus(self):
         self._check_scenario('Disable Hello, Pocket & Reader+', (
-            ['Disable Hello, Pocket & Reader+', 49.027264],  # yeay!
+            ['Disable Hello, Pocket & Reader+', 59.208244],  # yeay!
         ))
 
     def test_scenario_grapple(self):
@@ -556,7 +556,7 @@ class TestRankingScenarios(ESTestCase):
         see `legacy_api.SearchTest` for various examples.
         """
         self._check_scenario('grapple', (
-            ['GrApple Yummy', 1.039957],
+            ['GrApple Yummy', 0.97031206],
         ))
 
     def test_scenario_delicious(self):
@@ -565,34 +565,34 @@ class TestRankingScenarios(ESTestCase):
         see `legacy_api.SearchTest` for various examples.
         """
         self._check_scenario('delicious', (
-            ['Delicious Bookmarks', 1.1974056],
+            ['Delicious Bookmarks', 1.1278144],
         ))
 
     def test_score_boost_name_match(self):
         # Tests that we match directly "Merge Windows" and also find
         # "Merge All Windows" because of slop=1
         self._check_scenario('merge windows', (
-            ['Merge Windows', 12.69009],
-            ['Merge All Windows', 1.5310124],
+            ['Merge Windows', 12.496464],
+            ['Merge All Windows', 1.7881233],
         ), no_match=(
             'All Downloader Professional',
         ))
 
         self._check_scenario('merge all windows', (
-            ['Merge All Windows', 14.4743595],
-            ['Merge Windows', 0.040898073],
-            ['All Downloader Professional', 0.010608638],
+            ['Merge All Windows', 14.047888],
+            ['Merge Windows', 0.04710354],
+            ['All Downloader Professional', 0.011649423],
         ))
 
     def test_score_boost_exact_match(self):
         """Test that we rank exact matches at the top."""
         self._check_scenario('test addon test21', (
-            ['test addon test21', 14.673265],
+            ['test addon test21', 14.237667],
         ))
 
     def test_score_boost_exact_match_description_hijack(self):
         """Test that we rank exact matches at the top."""
         self._check_scenario('Amazon 1-Click Lock', (
-            ['Amazon 1-Click Lock', 35.94747],
-            ['1-Click YouTube Video Download', 0.19314468],
+            ['Amazon 1-Click Lock', 34.156555],
+            ['1-Click YouTube Video Download', 0.22585051],
         ))


### PR DESCRIPTION
This also stops considering all languages into a single field for non-language aware matches - instead only considering the most appropriate translation for the request.

Fix #6898

Built on top of https://github.com/mozilla/addons-server/pull/9835 which landed in a previous tag, so the fields we're using will all be present when this lands.