### PR TITLE
Make exact matches against add-on names in search language-aware

### DIFF
--- a/docs/topics/development/search.rst
+++ b/docs/topics/development/search.rst
@@ -16,35 +16,19 @@ How does search on AMO work?
 General structure
 =================
 
-Our Elasticsearch cluster contains Add-ons (``addons`` index) and statistics data. The purpose of that document is to describe the add-ons part only though.
+Our Elasticsearch cluster contains Add-ons (``addons`` index) and statistics data. The purpose of that document is to describe the add-ons part only though. We store two kinds of data for add-ons: indexed fields that are used for search purposes, and non-indexed fields that are meant to be returned (often as-is with no transformations) by the search API (allowing us to return search results data without hitting the database). The latter is not relevant to this document.
 
-In addition to that we store the following data:
-
- * Add-on Versions (`Indexer / Serializer <https://github.com/mozilla/addons-server/blob/master/src/olympia/addons/indexers.py#L215-L237>`_)
- * Files for each Add-on Version
- * Compatibility information for each Add-on Version
-
-As well as
-
- * Authors
- * Previews (image links)
- * Translations (`Translations mapping generation <https://github.com/mozilla/addons-server/blob/master/src/olympia/amo/indexers.py#L40-L136>`_)
-
-And various other add-on related properties. See the `Add-on Indexer / Serializer <https://github.com/mozilla/addons-server/blob/master/src/olympia/addons/indexers.py#L215-L237>`_ for more details.
-
-Our search can be reached either via the API through :ref:`/api/v4/addons/search/ <addon-search>` or :ref:`/api/v4/addons/autocomplete/ <addon-autocomplete>` which are used by our addons-frontend as well as via our legacy pages (used much less).
-
-Both use similar filtering and scoring code. For legacy reasons they're not identical. We should focus on our API-based search though since the legacy search will be removed once support for Thunderbird and Seamonkey is moved to a new platform.
-
-The legacy search uses ElasticSearch to query the data and then requests the actual model objects from the database. The newer API-based search only hits ElasticSearch and uses data directly stored from ES which is much more efficient.
+Our search can be reached either via the API through :ref:`/api/v4/addons/search/ <addon-search>` or :ref:`/api/v4/addons/autocomplete/ <addon-autocomplete>` which are used by our addons-frontend as well as via our legacy pages (which are going away and off-topic here).
 
 
 Indexing
 ========
 
-We index all text fields that have translations twice: once with a generic analyzer (snowball for description & summary, a custom one for name) and once with the corresponding language-specific analyzer if it exists. We also index a special variant of the name called ``name.raw`` which is a non-analyzed keyword, normalized in lowercase though a custom normalizer.
+The key fields we search against are ``name``, ``summary`` and ``description``. Because all can be translated, we index twice:
+- Once with the translation in the language-specific analyzer if supported, under ``{field}_l10n_{analyzer}``
+- Once with the translation in the default locale of the add-on, under ``{field}``, analyzed with just the ``snowball`` analyzer for ``description`` and ``summary``, and a custom analyzer for ``name`` that applies the following filters: ``standard``, ``word_delimiter`` (a custom version with ``preserve_original`` set to ``true``), ``lowercase``, ``stop``, and ``dictionary_decompounder`` (with a specific word list) and ``unique``.
 
-Our custom name analyzer applies the following filters: ``standard``, ``word_delimiter`` (a custom version with ``preserve_original`` set to ``true``), ``lowercase``, ``stop``, and ``dictionary_decompounder`` (with a specific word list) and ``unique``.
+In addition, for the name, both fields also contains a subfield called ``raw`` that holds a non-analyzed variant for exact matches in the corresponding language (stored as a ``keyword``, with a ``lowercase`` normalizer).
 
 For each document, we store a ``boost`` field that depends on the average number of users for the add-on, as well as a multiplier for public, non-experimental add-ons.
 
@@ -68,14 +52,14 @@ to a specific set of fields: add-on name and author(s) name.
 
 **Applied rules** (merged via ``should``):
 
-1. Prefer ``term`` matches on ``name.raw`` (``boost=100.0``) - our attempt to implement exact matches
-2. Prefer phrase matches that allows swapped terms (``boost=8.0``, ``slop=1``)
-3. If a query is < 20 characters long, try to do a fuzzy match on the search query (``boost=4.0``, ``prefix_length=4``, ``fuzziness=AUTO``)
-4. Then text matches, using the standard text analyzer (``boost=6.0``, ``analyzer=standard``, ``operator=and``)
-5. Then look for the query as a prefix (``boost=3.0``)
-6. If we have a matching analyzer, add a query to ``name_l10n_{LANG}`` (``boost=5.0``, ``operator=and``)
+1. A ``dis_max`` query with ``term`` matches on ``name_l10n_{analyzer}.raw`` and ``name.raw`` if the language of the request matches a known language-specific analyzer, or just a ``term`` query on ``name.raw`` (``boost=100.0``) otherwise - our attempt to implement exact matches
+2. If we have a matching language-specific analyzer, we add a ``match`` query to ``name_l10n_{analyzer}`` (``boost=5.0``, ``operator=and``)
+3. A ``phrase`` match on ``name`` that allows swapped terms (``boost=8.0``, ``slop=1``)
+4. A ``match`` on ``name``, using the standard text analyzer (``boost=6.0``, ``analyzer=standard``, ``operator=and``)
+5. A ``prefix`` match on ``name`` (``boost=3.0``)
+6. If a query is < 20 characters long, a fuzzy match on ``name`` (``boost=4.0``, ``prefix_length=4``, ``fuzziness=AUTO``)
 
-All rules except 1 and 6 are applied to both ``name`` and ``listed_authors.name``.
+All rules except 1 and 2 are applied to both ``name`` and ``listed_authors.name``.
 
 
 Secondary rules
@@ -86,12 +70,10 @@ containing more text like description, summary and tags.
 
 **Applied rules** (merged via ``should``):
 
-1. Look for phrase matches inside the summary (``boost=2.0``)
-2. Look for phrase matches inside the summary using language specific
-   analyzer (``boost=3.0``)
-3. Look for phrase matches inside the description (``boost=2.0``)
-4. Look for phrase matches inside the description using language
-   specific analyzer (``boost=3.0``)
+1. Look for phrase matches inside the summary (``boost=3.0``)
+2. Look for phrase matches inside the description (``boost=2.0``)
+
+If the language of the request matches a known language-specific analyzer, those are made using a ``multi_match`` query using ``summary`` or ``description`` and the corresponding ``{field}_l10n_{analyzer}``, similar to how exact name matches are performed above, in order to support potential translations.
 
 
 General query flow:


### PR DESCRIPTION
This makes us try to do an exact match against both the raw name in the current language, and the raw name in the default locale for each add-on (only boosting once, thanks to a `dis_max` query).

The same kind of logic is also added to description and summary matches.

Extra debugging features (search query naming, API returning matched_queries information, commented out script to update expected scores in test_search_ranking.py) are included but shouldn't affect production (or dev/stage) environments.

Fix #6898