### PR TITLE
Serve background images to reviewers via a JSON endpoint 

### DIFF
--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -1,7 +1,6 @@
 import datetime
 import os
 import time
-from base64 import b64encode
 from uuid import UUID, uuid4
 
 from django import forms as django_forms, http
@@ -46,7 +45,7 @@ from olympia.devhub.utils import (
     get_addon_akismet_reports, wizard_unsupported_properties,
     extract_theme_properties)
 from olympia.files.models import File, FileUpload, FileValidation
-from olympia.files.utils import get_background_images, parse_addon
+from olympia.files.utils import parse_addon
 from olympia.lib.crypto.packaged import sign_file
 from olympia.reviewers.forms import PublicWhiteboardForm
 from olympia.reviewers.models import Whiteboard
@@ -1790,11 +1789,5 @@ def send_key_revoked_email(to_email, key):
 def theme_background_image(request, addon_id, addon, channel):
     channel_id = amo.CHANNEL_CHOICES_LOOKUP[channel]
     version = addon.find_latest_version(channel_id)
-    if not version or not version.all_files:
-        return {}
-    backgrounds = get_background_images(
-        version.all_files[0], theme_data=None, header_only=True)
-    backgrounds = {
-        name: b64encode(background)
-        for name, background in backgrounds.items()}
-    return backgrounds
+    return (version.get_background_images_encoded(header_only=True) if version
+            else {})

--- a/src/olympia/files/tests/test_utils_.py
+++ b/src/olympia/files/tests/test_utils_.py
@@ -10,7 +10,6 @@ from datetime import timedelta
 
 from django import forms
 from django.conf import settings
-from django.core.files.storage import default_storage
 
 import flufl.lock
 import lxml
@@ -958,68 +957,6 @@ class TestXMLVulnerabilities(TestCase):
 
         # Setting it explicitly to `False` is fine too.
         lxml.etree.XMLParser(resolve_entities=False)
-
-
-class TestExtractHeaderImg(TestCase):
-    file_obj = os.path.join(
-        settings.ROOT, 'src/olympia/devhub/tests/addons/static_theme.zip')
-
-    def test_extract_header_img(self):
-        data = {'images': {'headerURL': 'weta.png'}}
-        dest_path = tempfile.mkdtemp()
-        header_file = dest_path + '/weta.png'
-        assert not default_storage.exists(header_file)
-
-        utils.extract_header_img(self.file_obj, data, dest_path)
-        assert default_storage.exists(header_file)
-        assert default_storage.size(header_file) == 126447
-
-    def test_extract_header_img_missing(self):
-        data = {'images': {'headerURL': 'missing_file.png'}}
-        dest_path = tempfile.mkdtemp()
-        header_file = dest_path + '/missing_file.png'
-        assert not default_storage.exists(header_file)
-
-        utils.extract_header_img(self.file_obj, data, dest_path)
-        assert not default_storage.exists(header_file)
-
-    def test_extract_header_img_not_image(self):
-        self.file_obj = os.path.join(
-            settings.ROOT,
-            'src/olympia/devhub/tests/addons/static_theme_non_image.zip')
-        data = {'images': {'headerURL': 'not_an_image.js'}}
-        dest_path = tempfile.mkdtemp()
-        header_file = dest_path + '/not_an_image.js'
-        assert not default_storage.exists(header_file)
-
-        utils.extract_header_img(self.file_obj, data, dest_path)
-        assert not default_storage.exists(header_file)
-
-    def test_extract_header_with_additional_imgs(self):
-        self.file_obj = os.path.join(
-            settings.ROOT,
-            'src/olympia/devhub/tests/addons/static_theme_tiled.zip')
-        data = {'images': {
-            'headerURL': 'empty.png',
-            'additional_backgrounds': [
-                'transparent.gif', 'missing_&_ignored.png',
-                'weta_for_tiling.png']
-        }}
-        dest_path = tempfile.mkdtemp()
-        header_file = dest_path + '/empty.png'
-        additional_file_1 = dest_path + '/transparent.gif'
-        additional_file_2 = dest_path + '/weta_for_tiling.png'
-        assert not default_storage.exists(header_file)
-        assert not default_storage.exists(additional_file_1)
-        assert not default_storage.exists(additional_file_2)
-
-        utils.extract_header_img(self.file_obj, data, dest_path)
-        assert default_storage.exists(header_file)
-        assert default_storage.size(header_file) == 332
-        assert default_storage.exists(additional_file_1)
-        assert default_storage.size(additional_file_1) == 42
-        assert default_storage.exists(additional_file_2)
-        assert default_storage.size(additional_file_2) == 93371
 
 
 class TestGetBackgroundImages(TestCase):

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -1242,31 +1242,6 @@ def resolve_i18n_message(message, messages, locale, default_locale=None):
     return message['message']
 
 
-def extract_header_img(file_obj, theme_data, dest_path):
-    """Extract static theme header image from `file_obj`."""
-    xpi = get_filepath(file_obj)
-    images_dict = theme_data.get('images', {})
-    # Get the reference in the manifest.  theme_frame is the Chrome variant.
-    header_url = images_dict.get(
-        'headerURL', images_dict.get('theme_frame'))
-    # And any additional backgrounds too.
-    additional_urls = images_dict.get('additional_backgrounds', [])
-    image_urls = [header_url] + additional_urls
-    try:
-        with zipfile.ZipFile(xpi, 'r') as source:
-            for url in image_urls:
-                _, file_ext = os.path.splitext(text_type(url).lower())
-                if file_ext not in amo.THEME_BACKGROUND_EXTS:
-                    # wrong exts get served with wrong mimetype by the CDN.
-                    continue
-                try:
-                    source.extract(url, dest_path)
-                except KeyError:
-                    pass
-    except IOError as ioerror:
-        log.debug(ioerror)
-
-
 def get_background_images(file_obj, theme_data, header_only=False):
     """Extract static theme header image from `file_obj` and return in dict."""
     xpi = get_filepath(file_obj)

--- a/src/olympia/reviewers/templates/reviewers/addon_details_box.html
+++ b/src/olympia/reviewers/templates/reviewers/addon_details_box.html
@@ -184,15 +184,7 @@
         {% endfor %}
         {% endwith %}
       </div>
-      <div class="all-backgrounds">
-        {% for background in backgrounds %}
-          {% with filename=background.rsplit('/', 1)[1] %}
-          <div class="background zoombox">
-              <img src="{{ background }}" alt="" width="1000" height="200">
-              <span>{{ _('Background file {0} of {1} - {2}')|format_html(loop.index, loop.length, filename) }}</span>
-          </div>
-          {% endwith %}
-        {% endfor %}
+      <div class="all-backgrounds" data-backgrounds-url="{{ url('reviewers.theme_background_images', version.id if version else 0) }}">
       </div>
     </div>
   {% elif addon.description or addon.current_previews|length > 1 or addon.developer_comments %}

--- a/src/olympia/reviewers/urls.py
+++ b/src/olympia/reviewers/urls.py
@@ -58,6 +58,9 @@ urlpatterns = (
     url(r'^abuse-reports/%s$' % ADDON_ID, views.abuse_reports,
         name='reviewers.abuse_reports'),
     url(r'^leaderboard/$', views.leaderboard, name='reviewers.leaderboard'),
+    url(r'^theme_background_images/(?P<version_id>[^ /]+)?$',
+        views.theme_background_images,
+        name='reviewers.theme_background_images'),
 
     url(r'^themes$',
         lambda request: redirect('reviewers.dashboard', permanent=True)),

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -934,8 +934,6 @@ def review(request, addon, channel=None):
     wb_form_cls = PublicWhiteboardForm if is_static_theme else WhiteboardForm
     whiteboard_form = wb_form_cls(instance=whiteboard, prefix='whiteboard')
 
-    backgrounds = version.get_background_image_urls() if version else []
-
     user_changes_actions = [
         amo.LOG.ADD_USER_WITH_ROLE.id,
         amo.LOG.CHANGE_USER_WITH_ROLE.id,
@@ -948,7 +946,7 @@ def review(request, addon, channel=None):
         actions_full=actions_full, addon=addon,
         api_token=request.COOKIES.get(API_TOKEN_COOKIE, None),
         approvals_info=approvals_info, auto_approval_info=auto_approval_info,
-        backgrounds=backgrounds, content_review_only=content_review_only,
+        content_review_only=content_review_only,
         count=count, eula_url=eula_url, flags=flags, form=form,
         is_admin=is_admin, num_pages=num_pages, pager=pager, reports=reports,
         privacy_url=privacy_url, show_diff=show_diff,
@@ -1172,6 +1170,14 @@ def privacy(request, addon):
     return policy_viewer(request, addon, addon.privacy_policy,
                          page_title=ugettext('{addon} :: Privacy Policy'),
                          long_title=ugettext('Privacy Policy'))
+
+
+@any_reviewer_required
+@json_view
+def theme_background_images(request, version_id):
+    """similar to devhub.views.theme_background_image but returns all images"""
+    version = get_object_or_404(Version, id=int(version_id))
+    return version.get_background_images_encoded(header_only=False)
 
 
 class AddonReviewerViewSet(GenericViewSet):

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import datetime
 import os
+from base64 import b64encode
 
 import django.dispatch
 
@@ -23,11 +24,9 @@ from olympia.amo.fields import PositiveAutoField
 from olympia.amo.decorators import use_primary_db
 from olympia.amo.models import (
     BasePreview, ManagerBase, ModelBase, OnChangeMixin)
-from olympia.amo.templatetags.jinja_helpers import (
-    id_to_path, user_media_path, user_media_url)
+from olympia.amo.templatetags.jinja_helpers import id_to_path, user_media_path
 from olympia.amo.urlresolvers import reverse
-from olympia.amo.utils import (
-    sorted_groupby, utc_millesecs_from_epoch, walkfiles)
+from olympia.amo.utils import sorted_groupby, utc_millesecs_from_epoch
 from olympia.applications.models import AppVersion
 from olympia.constants.licenses import LICENSES_BY_BUILTIN
 from olympia.files import utils
@@ -634,17 +633,14 @@ class Version(OnChangeMixin, ModelBase):
             pass
         return False
 
-    def get_background_image_urls(self):
-        if self.addon.type != amo.ADDON_STATICTHEME:
-            return []
-        background_images_folder = os.path.join(
-            user_media_path('addons'), str(self.addon.id), unicode(self.id))
-        background_images_url = '/'.join(
-            (user_media_url('addons'), str(self.addon.id), unicode(self.id)))
-        out = [
-            background.replace(background_images_folder, background_images_url)
-            for background in walkfiles(background_images_folder)]
-        return out
+    def get_background_images_encoded(self, header_only=False):
+        if not self.has_files:
+            return {}
+        file_obj = self.all_files[0]
+        return {
+            name: b64encode(background)
+            for name, background in utils.get_background_images(
+                file_obj, theme_data=None, header_only=header_only).items()}
 
 
 def generate_static_theme_preview(theme_data, version_pk):

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -24,7 +24,7 @@ from olympia.amo.fields import PositiveAutoField
 from olympia.amo.decorators import use_primary_db
 from olympia.amo.models import (
     BasePreview, ManagerBase, ModelBase, OnChangeMixin)
-from olympia.amo.templatetags.jinja_helpers import id_to_path, user_media_path
+from olympia.amo.templatetags.jinja_helpers import id_to_path
 from olympia.amo.urlresolvers import reverse
 from olympia.amo.utils import sorted_groupby, utc_millesecs_from_epoch
 from olympia.applications.models import AppVersion
@@ -258,12 +258,7 @@ class Version(OnChangeMixin, ModelBase):
         # Generate a preview and icon for listed static themes
         if (addon.type == amo.ADDON_STATICTHEME and
                 channel == amo.RELEASE_CHANNEL_LISTED):
-            dst_root = os.path.join(user_media_path('addons'), str(addon.id))
             theme_data = parsed_data.get('theme', {})
-            version_root = os.path.join(dst_root, unicode(version.id))
-
-            utils.extract_header_img(
-                version.all_files[0].file_path, theme_data, version_root)
             generate_static_theme_preview(theme_data, version.pk)
 
         # Track the time it took from first upload through validation
@@ -648,8 +643,7 @@ def generate_static_theme_preview(theme_data, version_pk):
     needed, in tests."""
     # To avoid a circular import
     from . import tasks
-    tasks.generate_static_theme_preview.delay(
-        theme_data, version_pk)
+    tasks.generate_static_theme_preview.delay(theme_data, version_pk)
 
 
 class VersionPreview(BasePreview, ModelBase):

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -16,7 +16,6 @@ from olympia.activity.models import ActivityLog
 from olympia.addons.models import (
     Addon, AddonFeatureCompatibility, AddonReviewerFlags, CompatOverride,
     CompatOverrideRange)
-from olympia.amo.templatetags.jinja_helpers import user_media_url
 from olympia.amo.tests import (
     TestCase, addon_factory, version_factory, user_factory)
 from olympia.amo.tests.test_models import BasePreviewMixin
@@ -981,10 +980,6 @@ class TestStaticThemeFromUpload(UploadTest):
             parsed_data=parsed_data)
         assert len(version.all_files) == 1
         assert generate_static_theme_preview_mock.call_count == 1
-        assert version.get_background_image_urls() == [
-            '%s/%s/%s/%s' % (user_media_url('addons'), str(self.addon.id),
-                             unicode(version.id), 'weta.png')
-        ]
 
     @mock.patch('olympia.versions.models.generate_static_theme_preview')
     def test_new_version_while_public(
@@ -996,10 +991,6 @@ class TestStaticThemeFromUpload(UploadTest):
             parsed_data=parsed_data)
         assert len(version.all_files) == 1
         assert generate_static_theme_preview_mock.call_count == 1
-        assert version.get_background_image_urls() == [
-            '%s/%s/%s/%s' % (user_media_url('addons'), str(self.addon.id),
-                             unicode(version.id), 'weta.png')
-        ]
 
     @mock.patch('olympia.versions.models.generate_static_theme_preview')
     def test_new_version_with_additional_backgrounds(
@@ -1014,14 +1005,6 @@ class TestStaticThemeFromUpload(UploadTest):
             parsed_data=parsed_data)
         assert len(version.all_files) == 1
         assert generate_static_theme_preview_mock.call_count == 1
-        image_url_folder = u'%s/%s/%s/' % (
-            user_media_url('addons'), self.addon.id, version.id)
-
-        assert sorted(version.get_background_image_urls()) == [
-            image_url_folder + 'empty.png',
-            image_url_folder + 'transparent.gif',
-            image_url_folder + 'weta_for_tiling.png',
-        ]
 
 
 class TestApplicationsVersions(TestCase):

--- a/static/js/zamboni/helpers.js
+++ b/static/js/zamboni/helpers.js
@@ -19,3 +19,13 @@ $(document).ajaxSend(function(event, xhr, ajaxSettings) {
 }).ajaxSuccess(function(event, xhr, ajaxSettings) {
     $(window).trigger('resize'); // Redraw what needs to be redrawn.
 });
+
+function b64toBlob(data) {
+    var b64str = atob(data);
+    var counter = b64str.length;
+    var u8arr = new Uint8Array(counter);
+    while(counter--){
+        u8arr[counter] = b64str.charCodeAt(counter);
+    }
+    return new Blob([u8arr]);
+}

--- a/static/js/zamboni/static_theme.js
+++ b/static/js/zamboni/static_theme.js
@@ -55,16 +55,6 @@ $(document).ready(function() {
             $svg_img.attr('preserveAspectRatio', 'xMaxYMin '+ meetOrSlice);
         });
 
-        function b64toBlob(data) {
-            var b64str = atob(data);
-            var counter = b64str.length;
-            var u8arr = new Uint8Array(counter);
-            while(counter--){
-                u8arr[counter] = b64str.charCodeAt(counter);
-            }
-            return new Blob([u8arr]);
-        }
-
         $wizard.find('#theme-header').each(function(index, element) {
             var img_src = $(element).data('existing-header');
             // If we already have a preview from a selected file don't overwrite it.


### PR DESCRIPTION
fixes #9871 + finally stop saving the background files to the CDN, now nothing uses them.
