### PR TITLE
Use dfs_query_then_fetch to make scoring consistent across shards

### DIFF
--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -667,7 +667,8 @@ class AddonSearchView(ListAPIView):
             using=amo.search.get_es(),
             index=AddonIndexer.get_index_alias(),
             doc_type=AddonIndexer.get_doctype_name()).extra(
-                _source={'excludes': AddonIndexer.hidden_fields})
+                _source={'excludes': AddonIndexer.hidden_fields}).params(
+                    search_type='dfs_query_then_fetch')
 
         return qset
 


### PR DESCRIPTION
This has a slight performance impact, because ES needs to make another roundtrip to gather stats from all shards before fetching results, but this ensures the scoring is more consistent and therefore results are ranked more appropriately, especially for more obscure searches.

Fix #9771