### PR TITLE
Move tasks from olympia.addons.cron to olympia.addons.tasks

### DIFF
--- a/src/olympia/addons/cron.py
+++ b/src/olympia/addons/cron.py
@@ -16,8 +16,11 @@ from celery import group
 import olympia.core.logger
 
 from olympia import amo
-from olympia.addons.models import Addon, AppSupport, FrozenAddon
-from olympia.amo.celery import task
+from olympia.addons.models import Addon, FrozenAddon
+from olympia.addons.tasks import (
+    update_addon_average_daily_users as _update_addon_average_daily_users,
+    update_addon_download_totals as _update_addon_download_totals,
+    update_appsupport)
 from olympia.amo.decorators import use_primary_db
 from olympia.amo.utils import chunked, walkfiles
 from olympia.files.models import File
@@ -50,26 +53,6 @@ def update_addon_average_daily_users():
     group(ts).apply_async()
 
 
-@task
-def _update_addon_average_daily_users(data, **kw):
-    task_log.info("[%s] Updating add-ons ADU totals." % (len(data)))
-
-    if not waffle.switch_is_active('local-statistics-processing'):
-        return False
-
-    for pk, count in data:
-        try:
-            addon = Addon.objects.get(pk=pk)
-        except Addon.DoesNotExist:
-            # The processing input comes from metrics which might be out of
-            # date in regards to currently existing add-ons
-            m = "Got an ADU update (%s) but the add-on doesn't exist (%s)"
-            task_log.debug(m % (count, pk))
-            continue
-
-        addon.update(average_daily_users=int(float(count)))
-
-
 def update_addon_download_totals():
     """Update add-on total and average downloads."""
     if not waffle.switch_is_active('local-statistics-processing'):
@@ -84,30 +67,6 @@ def update_addon_download_totals():
     ts = [_update_addon_download_totals.subtask(args=[chunk])
           for chunk in chunked(qs, 250)]
     group(ts).apply_async()
-
-
-@task
-def _update_addon_download_totals(data, **kw):
-    task_log.info('[%s] Updating add-ons download+average totals.' %
-                  (len(data)))
-
-    if not waffle.switch_is_active('local-statistics-processing'):
-        return False
-
-    for pk, sum_download_counts in data:
-        try:
-            addon = Addon.objects.get(pk=pk)
-            # Don't trigger a save unless we have to (the counts may not have
-            # changed)
-            if (sum_download_counts and
-                    addon.total_downloads != sum_download_counts):
-                addon.update(total_downloads=sum_download_counts)
-        except Addon.DoesNotExist:
-            # We exclude deleted add-ons in the cron, but an add-on could have
-            # been deleted by the time the task is processed.
-            m = ("Got new download totals (total=%s) but the add-on"
-                 "doesn't exist (%s)" % (sum_download_counts, pk))
-            task_log.debug(m)
 
 
 def _change_last_updated(next):
@@ -160,27 +119,9 @@ def update_addon_appsupport():
            .filter(newish, good).values_list('id', flat=True))
 
     task_log.info('Updating appsupport for %d new-ish addons.' % len(ids))
-    ts = [_update_appsupport.subtask(args=[chunk])
+    ts = [update_appsupport.subtask(args=[chunk])
           for chunk in chunked(ids, 20)]
     group(ts).apply_async()
-
-
-def update_all_appsupport():
-    from .tasks import update_appsupport
-    ids = sorted(set(AppSupport.objects.values_list('addon', flat=True)))
-    task_log.info('Updating appsupport for %s addons.' % len(ids))
-    for idx, chunk in enumerate(chunked(ids, 100)):
-        if idx % 10 == 0:
-            task_log.info('[%s/%s] Updating appsupport.'
-                          % (idx * 100, len(ids)))
-        update_appsupport(chunk)
-
-
-@task
-def _update_appsupport(ids, **kw):
-    from .tasks import update_appsupport
-    task_log.info('Updating appsupport for %d of new-ish addons.' % len(ids))
-    update_appsupport(ids)
 
 
 def hide_disabled_files():

--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -9,6 +9,7 @@ from django.db import transaction
 from django.forms import ValidationError
 from django.utils import translation
 
+import waffle
 from django_statsd.clients import statsd
 from elasticsearch_dsl import Search
 from PIL import Image
@@ -82,8 +83,9 @@ def update_last_updated(addon_id):
         Addon.objects.filter(pk=pk).update(last_updated=t)
 
 
+@task
 @use_primary_db
-def update_appsupport(ids):
+def update_appsupport(ids, **kw):
     log.info("[%s@None] Updating appsupport for %s." % (len(ids), ids))
 
     addons = Addon.objects.filter(id__in=ids).no_transforms()
@@ -105,6 +107,49 @@ def update_appsupport(ids):
     with transaction.atomic():
         AppSupport.objects.filter(addon__id__in=ids).delete()
         AppSupport.objects.bulk_create(support)
+
+
+@task
+def update_addon_average_daily_users(data, **kw):
+    log.info("[%s] Updating add-ons ADU totals." % (len(data)))
+
+    if not waffle.switch_is_active('local-statistics-processing'):
+        return False
+
+    for pk, count in data:
+        try:
+            addon = Addon.objects.get(pk=pk)
+        except Addon.DoesNotExist:
+            # The processing input comes from metrics which might be out of
+            # date in regards to currently existing add-ons
+            m = "Got an ADU update (%s) but the add-on doesn't exist (%s)"
+            log.debug(m % (count, pk))
+            continue
+
+        addon.update(average_daily_users=int(float(count)))
+
+
+@task
+def update_addon_download_totals(data, **kw):
+    log.info('[%s] Updating add-ons download+average totals.' % (len(data)))
+
+    if not waffle.switch_is_active('local-statistics-processing'):
+        return False
+
+    for pk, sum_download_counts in data:
+        try:
+            addon = Addon.objects.get(pk=pk)
+            # Don't trigger a save unless we have to (the counts may not have
+            # changed)
+            if (sum_download_counts and
+                    addon.total_downloads != sum_download_counts):
+                addon.update(total_downloads=sum_download_counts)
+        except Addon.DoesNotExist:
+            # We exclude deleted add-ons in the cron, but an add-on could have
+            # been deleted by the time the task is processed.
+            msg = ("Got new download totals (total=%s) but the add-on"
+                   "doesn't exist (%s)" % (sum_download_counts, pk))
+            log.debug(msg)
 
 
 @task

--- a/src/olympia/addons/tests/test_cron.py
+++ b/src/olympia/addons/tests/test_cron.py
@@ -53,11 +53,11 @@ class TestLastUpdated(TestCase):
 
     def test_appsupport(self):
         ids = Addon.objects.values_list('id', flat=True)
-        cron._update_appsupport(ids)
+        cron.update_appsupport(ids)
         assert AppSupport.objects.filter(app=amo.FIREFOX.id).count() == 3  # ??
 
         # Run it again to test deletes.
-        cron._update_appsupport(ids)
+        cron.update_appsupport(ids)
         assert AppSupport.objects.filter(app=amo.FIREFOX.id).count() == 3  # ??
 
     def test_appsupport_listed(self):

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1252,11 +1252,9 @@ CELERY_TASK_ROUTES = {
     'olympia.api.tasks.process_webhook': {'queue': 'api'},
 
     # Crons
-    'olympia.addons.cron._update_addon_average_daily_users': {'queue': 'cron'},
-    'olympia.addons.cron._update_addon_download_totals': {'queue': 'cron'},
-    'olympia.addons.cron._update_addons_current_version': {'queue': 'cron'},
-    'olympia.addons.cron._update_appsupport': {'queue': 'cron'},
-    'olympia.addons.cron._update_daily_theme_user_counts': {'queue': 'cron'},
+    'olympia.addons.tasks.update_addon_average_daily_users': {'queue': 'cron'},
+    'olympia.addons.tasks.update_addon_download_totals': {'queue': 'cron'},
+    'olympia.addons.tasks.update_appsupport': {'queue': 'cron'},
 
     # Bandwagon
     'olympia.bandwagon.tasks.collection_meta': {'queue': 'bandwagon'},
@@ -1889,7 +1887,6 @@ CRON_JOBS = {
     'update_addon_download_totals': 'olympia.addons.cron',
     'addon_last_updated': 'olympia.addons.cron',
     'update_addon_appsupport': 'olympia.addons.cron',
-    'update_all_appsupport': 'olympia.addons.cron',
     'hide_disabled_files': 'olympia.addons.cron',
     'unhide_disabled_files': 'olympia.addons.cron',
     'deliver_hotness': 'olympia.addons.cron',


### PR DESCRIPTION
Having those tasks in cron.py, which is no longer imported, prevents
celery from finding them.

In addition, remove unused `update_all_appsupport cron`.

Fix #9947