### PR TITLE
Postpone statistics processing by a couple hours

### DIFF
--- a/scripts/crontab/crontab.tpl
+++ b/scripts/crontab/crontab.tpl
@@ -34,17 +34,17 @@ HOME=/tmp
 
 # Update ADI metrics from S3.
 # Once per day after 0800 UTC
-30 9 * * * %(django)s update_counts_from_file
-00 10 * * * %(django)s download_counts_from_file
-15 10 * * * %(django)s theme_update_counts_from_file
-30 10 * * * %(django)s update_theme_popularity_movers
+30 11 * * * %(django)s update_counts_from_file
+00 12 * * * %(django)s download_counts_from_file
+15 12 * * * %(django)s theme_update_counts_from_file
+30 12 * * * %(django)s update_theme_popularity_movers
 
 # Once per day after metrics import is done
-30 10 * * * %(z_cron)s update_addon_download_totals
-35 10 * * * %(z_cron)s weekly_downloads
-25 11 * * * %(z_cron)s update_global_totals
-30 11 * * * %(z_cron)s update_addon_average_daily_users
-00 12 * * * %(z_cron)s index_latest_stats
+30 12 * * * %(z_cron)s update_addon_download_totals
+35 12 * * * %(z_cron)s weekly_downloads
+25 13 * * * %(z_cron)s update_global_totals
+30 13 * * * %(z_cron)s update_addon_average_daily_users
+00 14 * * * %(z_cron)s index_latest_stats
 
 # Do not put crons below this line
 

--- a/scripts/crontab/crontab.tpl
+++ b/scripts/crontab/crontab.tpl
@@ -32,8 +32,7 @@ HOME=/tmp
 45 7 * * * %(django)s dump_apps
 0 8 * * * %(django)s update_product_details
 
-# Update ADI metrics from S3.
-# Once per day after 0800 UTC
+# Update ADI metrics from S3 once per day
 30 11 * * * %(django)s update_counts_from_file
 00 12 * * * %(django)s download_counts_from_file
 15 12 * * * %(django)s theme_update_counts_from_file


### PR DESCRIPTION
Data pipeline may fail and retry, when that happens the cron may exit early
due to non-existing S3 files.

* [X] Add a description of the the changes introduced in this PR.
