### PR TITLE
Revert "Refactor our search filters to use Elasticsearch filter context"

### DIFF
--- a/src/olympia/search/tests/test_filters.py
+++ b/src/olympia/search/tests/test_filters.py
@@ -195,12 +195,13 @@ class TestReviewedContentFilter(FilterTestsBase):
 
     def test_status(self):
         qs = self._filter(self.req)
-        assert 'must' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
+        must = qs['query']['bool']['must']
+        must_not = qs['query']['bool']['must_not']
 
-        assert {'terms': {'status': amo.REVIEWED_STATUSES}} in filter_
-        assert {'exists': {'field': 'current_version'}} in filter_
-        assert {'term': {'is_disabled': False}} in filter_
+        assert {'terms': {'status': amo.REVIEWED_STATUSES}} in must
+        assert {'exists': {'field': 'current_version'}} in must
+        assert {'term': {'is_disabled': True}} in must_not
+        assert {'term': {'is_deleted': True}} in must_not
 
 
 class TestSortingFilter(FilterTestsBase):
@@ -306,37 +307,27 @@ class TestSearchParameterFilter(FilterTestsBase):
 
     def test_search_by_type_id(self):
         qs = self._filter(data={'type': unicode(amo.ADDON_EXTENSION)})
-        assert 'must' not in qs['query']['bool']
-        assert 'must_not' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
-        assert {'terms': {'type': [amo.ADDON_EXTENSION]}} in filter_
+        must = qs['query']['bool']['must']
+        assert {'terms': {'type': [amo.ADDON_EXTENSION]}} in must
 
         qs = self._filter(data={'type': unicode(amo.ADDON_PERSONA)})
-        assert 'must' not in qs['query']['bool']
-        assert 'must_not' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
-        assert {'terms': {'type': [amo.ADDON_PERSONA]}} in filter_
+        must = qs['query']['bool']['must']
+        assert {'terms': {'type': [amo.ADDON_PERSONA]}} in must
 
     def test_search_by_type_string(self):
         qs = self._filter(data={'type': 'extension'})
-        assert 'must' not in qs['query']['bool']
-        assert 'must_not' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
-        assert {'terms': {'type': [amo.ADDON_EXTENSION]}} in filter_
+        must = qs['query']['bool']['must']
+        assert {'terms': {'type': [amo.ADDON_EXTENSION]}} in must
 
         qs = self._filter(data={'type': 'persona'})
-        assert 'must' not in qs['query']['bool']
-        assert 'must_not' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
-        assert {'terms': {'type': [amo.ADDON_PERSONA]}} in filter_
+        must = qs['query']['bool']['must']
+        assert {'terms': {'type': [amo.ADDON_PERSONA]}} in must
 
         qs = self._filter(data={'type': 'persona,extension'})
-        assert 'must' not in qs['query']['bool']
-        assert 'must_not' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
+        must = qs['query']['bool']['must']
         assert (
             {'terms': {'type': [amo.ADDON_PERSONA, amo.ADDON_EXTENSION]}}
-            in filter_)
+            in must)
 
     def test_search_by_app_invalid(self):
         with self.assertRaises(serializers.ValidationError) as context:
@@ -348,29 +339,21 @@ class TestSearchParameterFilter(FilterTestsBase):
 
     def test_search_by_app_id(self):
         qs = self._filter(data={'app': unicode(amo.FIREFOX.id)})
-        assert 'must' not in qs['query']['bool']
-        assert 'must_not' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
-        assert {'term': {'app': amo.FIREFOX.id}} in filter_
+        must = qs['query']['bool']['must']
+        assert {'term': {'app': amo.FIREFOX.id}} in must
 
         qs = self._filter(data={'app': unicode(amo.ANDROID.id)})
-        assert 'must' not in qs['query']['bool']
-        assert 'must_not' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
-        assert {'term': {'app': amo.ANDROID.id}} in filter_
+        must = qs['query']['bool']['must']
+        assert {'term': {'app': amo.ANDROID.id}} in must
 
     def test_search_by_app_string(self):
         qs = self._filter(data={'app': 'firefox'})
-        assert 'must' not in qs['query']['bool']
-        assert 'must_not' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
-        assert {'term': {'app': amo.FIREFOX.id}} in filter_
+        must = qs['query']['bool']['must']
+        assert {'term': {'app': amo.FIREFOX.id}} in must
 
         qs = self._filter(data={'app': 'android'})
-        assert 'must' not in qs['query']['bool']
-        assert 'must_not' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
-        assert {'term': {'app': amo.ANDROID.id}} in filter_
+        must = qs['query']['bool']['must']
+        assert {'term': {'app': amo.ANDROID.id}} in must
 
     def test_search_by_appversion_app_missing(self):
         with self.assertRaises(serializers.ValidationError) as context:
@@ -392,14 +375,12 @@ class TestSearchParameterFilter(FilterTestsBase):
     def test_search_by_appversion(self):
         qs = self._filter(data={'appversion': '46.0',
                                 'app': 'firefox'})
-        assert 'must' not in qs['query']['bool']
-        assert 'must_not' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
-        assert {'term': {'app': amo.FIREFOX.id}} in filter_
+        must = qs['query']['bool']['must']
+        assert {'term': {'app': amo.FIREFOX.id}} in must
         assert {'range': {'current_version.compatible_apps.1.min':
-                {'lte': 46000000200100}}} in filter_
+                {'lte': 46000000200100}}} in must
         assert {'range': {'current_version.compatible_apps.1.max':
-                {'gte': 46000000000100}}} in filter_
+                {'gte': 46000000000100}}} in must
 
     def test_search_by_platform_invalid(self):
         with self.assertRaises(serializers.ValidationError) as context:
@@ -411,61 +392,45 @@ class TestSearchParameterFilter(FilterTestsBase):
 
     def test_search_by_platform_id(self):
         qs = self._filter(data={'platform': unicode(amo.PLATFORM_WIN.id)})
-        assert 'must' not in qs['query']['bool']
-        assert 'must_not' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
+        must = qs['query']['bool']['must']
         assert {'terms': {'platforms': [
-            amo.PLATFORM_WIN.id, amo.PLATFORM_ALL.id]}} in filter_
+            amo.PLATFORM_WIN.id, amo.PLATFORM_ALL.id]}} in must
 
         qs = self._filter(data={'platform': unicode(amo.PLATFORM_LINUX.id)})
-        assert 'must' not in qs['query']['bool']
-        assert 'must_not' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
+        must = qs['query']['bool']['must']
         assert {'terms': {'platforms': [
-            amo.PLATFORM_LINUX.id, amo.PLATFORM_ALL.id]}} in filter_
+            amo.PLATFORM_LINUX.id, amo.PLATFORM_ALL.id]}} in must
 
     def test_search_by_platform_string(self):
         qs = self._filter(data={'platform': 'windows'})
-        assert 'must' not in qs['query']['bool']
-        assert 'must_not' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
+        must = qs['query']['bool']['must']
         assert {'terms': {'platforms': [
-            amo.PLATFORM_WIN.id, amo.PLATFORM_ALL.id]}} in filter_
+            amo.PLATFORM_WIN.id, amo.PLATFORM_ALL.id]}} in must
 
         qs = self._filter(data={'platform': 'win'})
-        assert 'must' not in qs['query']['bool']
-        assert 'must_not' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
+        must = qs['query']['bool']['must']
         assert {'terms': {'platforms': [
-            amo.PLATFORM_WIN.id, amo.PLATFORM_ALL.id]}} in filter_
+            amo.PLATFORM_WIN.id, amo.PLATFORM_ALL.id]}} in must
 
         qs = self._filter(data={'platform': 'darwin'})
-        assert 'must' not in qs['query']['bool']
-        assert 'must_not' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
+        must = qs['query']['bool']['must']
         assert {'terms': {'platforms': [
-            amo.PLATFORM_MAC.id, amo.PLATFORM_ALL.id]}} in filter_
+            amo.PLATFORM_MAC.id, amo.PLATFORM_ALL.id]}} in must
 
         qs = self._filter(data={'platform': 'mac'})
-        assert 'must' not in qs['query']['bool']
-        assert 'must_not' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
+        must = qs['query']['bool']['must']
         assert {'terms': {'platforms': [
-            amo.PLATFORM_MAC.id, amo.PLATFORM_ALL.id]}} in filter_
+            amo.PLATFORM_MAC.id, amo.PLATFORM_ALL.id]}} in must
 
         qs = self._filter(data={'platform': 'macosx'})
-        assert 'must' not in qs['query']['bool']
-        assert 'must_not' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
+        must = qs['query']['bool']['must']
         assert {'terms': {'platforms': [
-            amo.PLATFORM_MAC.id, amo.PLATFORM_ALL.id]}} in filter_
+            amo.PLATFORM_MAC.id, amo.PLATFORM_ALL.id]}} in must
 
         qs = self._filter(data={'platform': 'linux'})
-        assert 'must' not in qs['query']['bool']
-        assert 'must_not' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
+        must = qs['query']['bool']['must']
         assert {'terms': {'platforms': [
-            amo.PLATFORM_LINUX.id, amo.PLATFORM_ALL.id]}} in filter_
+            amo.PLATFORM_LINUX.id, amo.PLATFORM_ALL.id]}} in must
 
     def test_search_by_category_slug_no_app_or_type(self):
         with self.assertRaises(serializers.ValidationError) as context:
@@ -484,10 +449,8 @@ class TestSearchParameterFilter(FilterTestsBase):
             'app': 'firefox',
             'type': 'extension'
         })
-        assert 'must' not in qs['query']['bool']
-        assert 'must_not' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
-        assert {'terms': {'category': [category.id]}} in filter_
+        must = qs['query']['bool']['must']
+        assert {'terms': {'category': [category.id]}} in must
 
     def test_search_by_category_slug_multiple_types(self):
         category_a = CATEGORIES[amo.FIREFOX.id][amo.ADDON_EXTENSION]['other']
@@ -497,11 +460,9 @@ class TestSearchParameterFilter(FilterTestsBase):
             'app': 'firefox',
             'type': 'extension,persona'
         })
-        assert 'must' not in qs['query']['bool']
-        assert 'must_not' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
+        must = qs['query']['bool']['must']
         assert (
-            {'terms': {'category': [category_a.id, category_b.id]}} in filter_)
+            {'terms': {'category': [category_a.id, category_b.id]}} in must)
 
     def test_search_by_category_id(self):
         qs = self._filter(data={
@@ -509,10 +470,8 @@ class TestSearchParameterFilter(FilterTestsBase):
             'app': 'firefox',
             'type': 'extension'
         })
-        assert 'must' not in qs['query']['bool']
-        assert 'must_not' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
-        assert {'terms': {'category': [1]}} in filter_
+        must = qs['query']['bool']['must']
+        assert {'terms': {'category': [1]}} in must
 
     def test_search_by_category_invalid(self):
         with self.assertRaises(serializers.ValidationError) as context:
@@ -522,99 +481,64 @@ class TestSearchParameterFilter(FilterTestsBase):
 
     def test_search_by_tag(self):
         qs = self._filter(data={'tag': 'foo'})
-        assert 'must' not in qs['query']['bool']
-        assert 'must_not' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
-        assert {'term': {'tags': 'foo'}} in filter_
+        must = qs['query']['bool']['must']
+        assert {'term': {'tags': 'foo'}} in must
 
         qs = self._filter(data={'tag': 'foo,bar'})
-        assert 'must' not in qs['query']['bool']
-        assert 'must_not' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
-        assert {'term': {'tags': 'foo'}} in filter_
-        assert {'term': {'tags': 'bar'}} in filter_
+        must = qs['query']['bool']['must']
+        assert {'term': {'tags': 'foo'}} in must
+        assert {'term': {'tags': 'bar'}} in must
 
     def test_search_by_author(self):
         qs = self._filter(data={'author': 'fooBar'})
-        assert 'must' not in qs['query']['bool']
-        assert 'must_not' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
-        assert len(filter_) == 1
-        should = filter_[0]['bool']['should']
+        must = qs['query']['bool']['must']
+        assert len(must) == 1
+        should = must[0]['bool']['should']
         assert {'terms': {'listed_authors.id': []}} in should
         assert {'terms': {'listed_authors.username': ['fooBar']}} in should
 
         qs = self._filter(data={'author': 'foo,bar'})
-        assert 'must' not in qs['query']['bool']
-        assert 'must_not' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
-        assert len(filter_) == 1
-        should = filter_[0]['bool']['should']
+        must = qs['query']['bool']['must']
+        assert len(must) == 1
+        should = must[0]['bool']['should']
         assert {'terms': {'listed_authors.id': []}} in should
         assert {'terms': {'listed_authors.username': ['foo', 'bar']}} in should
 
         qs = self._filter(data={'author': '123,456'})
-        assert 'must' not in qs['query']['bool']
-        assert 'must_not' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
-        assert len(filter_) == 1
-        should = filter_[0]['bool']['should']
+        must = qs['query']['bool']['must']
+        assert len(must) == 1
+        should = must[0]['bool']['should']
         assert {'terms': {'listed_authors.id': ['123', '456']}} in should
         assert {'terms': {'listed_authors.username': []}} in should
 
         qs = self._filter(data={'author': '123,bar'})
-        assert 'must' not in qs['query']['bool']
-        assert 'must_not' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
-        assert len(filter_) == 1
-        should = filter_[0]['bool']['should']
+        must = qs['query']['bool']['must']
+        assert len(must) == 1
+        should = must[0]['bool']['should']
         assert {'terms': {'listed_authors.id': ['123']}} in should
         assert {'terms': {'listed_authors.username': ['bar']}} in should
 
     def test_exclude_addons(self):
         qs = self._filter(data={'exclude_addons': 'fooBar'})
         assert 'must' not in qs['query']['bool']
-        assert 'must_not' not in qs['query']['bool']
-
-        # We've got another bool query inside our filter to handle the
-        # must_not here.
-        filter_ = qs['query']['bool']['filter']
-        assert len(filter_) == 1
-        assert 'must' not in filter_[0]['bool']
-        must_not = filter_[0]['bool']['must_not']
+        must_not = qs['query']['bool']['must_not']
         assert must_not == [{'terms': {'slug': [u'fooBar']}}]
 
         qs = self._filter(data={'exclude_addons': 1})
         assert 'must' not in qs['query']['bool']
-        assert 'must_not' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
-        assert len(filter_) == 1
-        assert 'must' not in filter_[0]['bool']
-        must_not = filter_[0]['bool']['must_not']
+        must_not = qs['query']['bool']['must_not']
         assert must_not == [{'ids': {'values': [u'1']}}]
 
         qs = self._filter(data={'exclude_addons': 'fooBar,1'})
         assert 'must' not in qs['query']['bool']
-        assert 'must_not' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
-        # elasticsearch-dsl seems to separate our 2 bool clauses instead of
-        # keeping them together. It might be a byproduct of using
-        # nested+filter. The resulting query is ugly but it should still work,
-        # and it's an edge-case anyway, usually clients won't pass 2 different
-        # types of identifiers.
-        assert len(filter_) == 2
-        assert 'must' not in filter_[0]['bool']
-        assert 'must' not in filter_[1]['bool']
-        must_not = filter_[0]['bool']['must_not']
+        must_not = qs['query']['bool']['must_not']
         assert {'ids': {'values': [u'1']}} in must_not
-        must_not = filter_[1]['bool']['must_not']
         assert {'terms': {'slug': [u'fooBar']}} in must_not
 
     def test_search_by_featured_no_app_no_locale(self):
         qs = self._filter(data={'featured': 'true'})
-        assert 'must' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
-        assert {'term': {'is_featured': True}} in filter_
+        must = qs['query']['bool']['must']
+        assert {'term': {'is_featured': True}} in must
 
         with self.assertRaises(serializers.ValidationError) as context:
             self._filter(data={'featured': 'false'})
@@ -622,12 +546,11 @@ class TestSearchParameterFilter(FilterTestsBase):
 
     def test_search_by_featured_yes_app_no_locale(self):
         qs = self._filter(data={'featured': 'true', 'app': 'firefox'})
-        assert 'must' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
-        assert len(filter_) == 2
-        assert filter_[0] == {'term': {'app': amo.FIREFOX.id}}
-        inner = filter_[1]['nested']['query']['bool']['filter']
-        assert len(inner) == 1
+        must = qs['query']['bool']['must']
+        assert {'term': {'is_featured': True}} not in must
+        assert must[0] == {'term': {'app': amo.FIREFOX.id}}
+        inner = must[1]['nested']['query']['bool']['must']
+        assert len(must) == 2
         assert {'term': {'featured_for.application': amo.FIREFOX.id}} in inner
 
         with self.assertRaises(serializers.ValidationError) as context:
@@ -637,12 +560,11 @@ class TestSearchParameterFilter(FilterTestsBase):
     def test_search_by_featured_yes_app_yes_locale(self):
         qs = self._filter(data={'featured': 'true', 'app': 'firefox',
                                 'lang': 'fr'})
-        assert 'must' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
-        assert len(filter_) == 2
-        assert filter_[0] == {'term': {'app': amo.FIREFOX.id}}
-        inner = filter_[1]['nested']['query']['bool']['filter']
-        assert len(inner) == 2
+        must = qs['query']['bool']['must']
+        assert {'term': {'is_featured': True}} not in must
+        assert must[0] == {'term': {'app': amo.FIREFOX.id}}
+        inner = must[1]['nested']['query']['bool']['must']
+        assert len(must) == 2
         assert {'term': {'featured_for.application': amo.FIREFOX.id}} in inner
         assert {'terms': {'featured_for.locales': ['fr', 'ALL']}} in inner
 
@@ -652,12 +574,10 @@ class TestSearchParameterFilter(FilterTestsBase):
 
     def test_search_by_featured_no_app_yes_locale(self):
         qs = self._filter(data={'featured': 'true', 'lang': 'fr'})
-        assert 'must' not in qs['query']['bool']
-        assert 'must_not' not in qs['query']['bool']
-        filter_ = qs['query']['bool']['filter']
-        assert len(filter_) == 1
-        inner = filter_[0]['nested']['query']['bool']['filter']
-        assert len(inner) == 1
+        must = qs['query']['bool']['must']
+        assert {'term': {'is_featured': True}} not in must
+        inner = must[0]['nested']['query']['bool']['must']
+        assert len(must) == 1
         assert {'terms': {'featured_for.locales': ['fr', 'ALL']}} in inner
 
 
@@ -671,18 +591,18 @@ class TestCombinedFilter(FilterTestsBase):
 
     def test_combined(self):
         qs = self._filter(data={'q': 'test'})
-        bool_ = qs['query']['bool']
+        filtered = qs['query']['bool']
+        assert filtered['must'][2]['function_score']
 
-        assert 'must_not' not in bool_
+        must = filtered['must']
+        assert {'terms': {'status': amo.REVIEWED_STATUSES}} in must
 
-        filter_ = bool_['filter']
-        assert {'terms': {'status': amo.REVIEWED_STATUSES}} in filter_
-        assert {'exists': {'field': 'current_version'}} in filter_
-        assert {'term': {'is_disabled': False}} in filter_
+        must_not = filtered['must_not']
+        assert {'term': {'is_disabled': True}} in must_not
 
         assert qs['sort'] == ['_score']
 
-        should = bool_['must'][0]['function_score']['query']['bool']['should']
+        should = must[2]['function_score']['query']['bool']['should']
         expected = {
             'match': {
                 'name_l10n_english': {
@@ -695,17 +615,15 @@ class TestCombinedFilter(FilterTestsBase):
 
     def test_filter_featured_sort_random(self):
         qs = self._filter(data={'featured': 'true', 'sort': 'random'})
-        bool_ = qs['query']['bool']
+        filtered = qs['query']['bool']
+        must = filtered['must']
+        assert {'terms': {'status': amo.REVIEWED_STATUSES}} in must
 
-        assert 'must_not' not in bool_
-
-        filter_ = bool_['filter']
-        assert {'terms': {'status': amo.REVIEWED_STATUSES}} in filter_
-        assert {'exists': {'field': 'current_version'}} in filter_
-        assert {'term': {'is_disabled': False}} in filter_
+        must_not = filtered['must_not']
+        assert {'term': {'is_disabled': True}} in must_not
 
         assert qs['sort'] == ['_score']
 
-        assert bool_['must'][0]['function_score']['functions'] == [
+        assert filtered['must'][2]['function_score']['functions'] == [
             {'random_score': {}}
         ]

--- a/src/olympia/search/tests/test_search_ranking.py
+++ b/src/olympia/search/tests/test_search_ranking.py
@@ -63,9 +63,8 @@ class TestRankingScenarios(ESTestCase):
             )
 
             # Quick and dirty way to generate a script to change the expected
-            # scores in this file, uncomment this block then launch the script
-            # it generates (note that it will skip the assert below because of
-            # 'continue').
+            # scores in this file, uncomment this block and comment the next
+            # to use, then launch the script it generates.
             # Don't forget to verify the diff afterwards to see if they make
             # sense though!)
             # if found_score != expected_score:
@@ -73,7 +72,7 @@ class TestRankingScenarios(ESTestCase):
             #     with open('sed_me.sh', 'a+') as f:
             #         f.write('sed -i s/%s/%s/ %s\n' % (
             #             expected_score, found_score, filename))
-            #     continue
+            # else:
             assert found_score == expected_score, (
                 'Expected "{}" to be on position {} with score {} but '
                 '"{}" was found instead with score {} for query {}'
@@ -481,117 +480,117 @@ class TestRankingScenarios(ESTestCase):
 
     def test_scenario_tab_center_redux(self):
         self._check_scenario('tab center redux', (
-            ['Tab Center Redux', 69.21394],
-            ['Tab Mix Plus', 0.06495905],
-            ['Redux DevTools', 0.04430029],
+            ['Tab Center Redux', 69.21823],
+            ['Tab Mix Plus', 0.069614045],
+            ['Redux DevTools', 0.04895539],
         ))
 
     def test_scenario_open_image_new_tab(self):
         self._check_scenario('Open Image in New Tab', (
-            ['Open Image in New Tab', 24.277237],
-            ['Open image in a new tab', 5.6800475],
+            ['Open Image in New Tab', 24.281683],
+            ['Open image in a new tab', 5.68459],
         ))
 
     def test_scenario_coinhive(self):
         # TODO, should match "CoinBlock". Check word delimiting analysis maybe?
         self._check_scenario('CoinHive', (
-            ['Coinhive Blocker', 3.891288],
-            ['NoMiners', 0.017959397],  # via description
+            ['Coinhive Blocker', 3.8953888],
+            ['NoMiners', 0.022077063],  # via description
             # ['CoinBlock', 0],  # via prefix search
         ))
 
     def test_scenario_privacy(self):
         self._check_scenario('Privacy', (
-            ['Privacy Badger', 8.7432165],
-            ['Privacy Settings', 4.559415],
-            ['Google Privacy', 4.350088],  # More users, summary
-            ['Privacy Pass', 3.2087922],
-            ['Ghostery', 0.09441561],  # Crazy amount of users, summary
+            ['Privacy Badger', 8.747306],
+            ['Privacy Settings', 4.563522],
+            ['Google Privacy', 4.354196],  # More users, summary
+            ['Privacy Pass', 3.2129042],
+            ['Ghostery', 0.098541625],  # Crazy amount of users, summary
             # summary + a lot of users, but not as many as ghostery
-            ['Blur', 0.0776396],
+            ['Blur', 0.08176569],
         ))
 
     def test_scenario_firebu(self):
         self._check_scenario('firebu', (
-            ['Firebug', 4.117813],
-            ['Firefinder for Firebug', 1.0876373],
-            ['Firebug Autocompleter', 1.0655142],
-            ['Fire Drag', 0.6470381],
+            ['Firebug', 4.121915],
+            ['Firefinder for Firebug', 1.0917512],
+            ['Firebug Autocompleter', 1.0696282],
+            ['Fire Drag', 0.65115386],
         ))
 
     def test_scenario_fireb(self):
         self._check_scenario('fireb', (
-            ['Firebug', 4.117813],
-            ['Firefinder for Firebug', 1.0876373],
-            ['Firebug Autocompleter', 1.0655142],
-            ['Fire Drag', 0.6470381],
+            ['Firebug', 4.121915],
+            ['Firefinder for Firebug', 1.0917512],
+            ['Firebug Autocompleter', 1.0696282],
+            ['Fire Drag', 0.65115386],
         ))
 
     def test_scenario_menu_wizzard(self):
         self._check_scenario('Menu Wizzard', (
-            ['Menu Wizard', 0.10683497],  # (fuzzy, typo)
+            ['Menu Wizard', 0.11090311],  # (fuzzy, typo)
             # partial match + users
-            ['Add-ons Manager Context Menu', 0.0791911],
+            ['Add-ons Manager Context Menu', 0.08325935],
         ))
 
     def test_scenario_frame_demolition(self):
         self._check_scenario('Frame Demolition', (
-            ['Frame Demolition', 20.48827],
+            ['Frame Demolition', 20.492874],
         ))
 
     def test_scenario_demolition(self):
         # Find "Frame Demolition" via a typo
         self._check_scenario('Demolation', (
-            ['Frame Demolition', 0.057878494],
+            ['Frame Demolition', 0.06198895],
         ))
 
     def test_scenario_restyle(self):
         self._check_scenario('reStyle', (
-            ['reStyle', 26.352535],
+            ['reStyle', 26.357182],
         ))
 
     def test_scenario_megaupload_downloadhelper(self):
         # Doesn't find "RapidShare DownloadHelper" anymore
         # since we now query by "MegaUpload AND DownloadHelper"
         self._check_scenario('MegaUpload DownloadHelper', (
-            ['MegaUpload DownloadHelper', 42.920856],
+            ['MegaUpload DownloadHelper', 42.92495],
         ))
 
     def test_scenario_downloadhelper(self):
         # No direct match, "Download Flash and Video" has
         # huge amount of users that puts it first here
         self._check_scenario('DownloadHelper', (
-            ['RapidShare DownloadHelper', 3.1008768],
-            ['MegaUpload DownloadHelper', 1.7232388],
-            ['Download Flash and Video', 1.5117542],
-            ['1-Click YouTube Video Download', 1.141354],
+            ['RapidShare DownloadHelper', 3.1049876],
+            ['MegaUpload DownloadHelper', 1.7273555],
+            ['Download Flash and Video', 1.5158719],
+            ['1-Click YouTube Video Download', 1.1454732],
         ))
 
     def test_scenario_megaupload(self):
         self._check_scenario('MegaUpload', (
-            ['MegaUpload DownloadHelper', 3.269901],
-            ['Popup Blocker', 1.4292603],
+            ['MegaUpload DownloadHelper', 3.2740066],
+            ['Popup Blocker', 1.4333737],
         ))
 
     def test_scenario_no_flash(self):
         self._check_scenario('No Flash', (
-            ['No Flash', 46.64575],
-            ['Download Flash and Video', 4.4118795],
-            ['YouTube Flash Player', 3.5120416],
-            ['YouTube Flash Video Player', 3.202704],
+            ['No Flash', 46.650276],
+            ['Download Flash and Video', 4.416651],
+            ['YouTube Flash Player', 3.5168178],
+            ['YouTube Flash Video Player', 3.2074819],
         ))
 
         # Case should not matter.
         self._check_scenario('no flash', (
-            ['No Flash', 46.64575],
-            ['Download Flash and Video', 4.4118795],
-            ['YouTube Flash Player', 3.5120416],
-            ['YouTube Flash Video Player', 3.202704],
+            ['No Flash', 46.650276],
+            ['Download Flash and Video', 4.416651],
+            ['YouTube Flash Player', 3.5168178],
+            ['YouTube Flash Video Player', 3.2074819],
         ))
 
     def test_scenario_disable_hello_pocket_reader_plus(self):
         self._check_scenario('Disable Hello, Pocket & Reader+', (
-            ['Disable Hello, Pocket & Reader+', 59.37624],  # yeay!
+            ['Disable Hello, Pocket & Reader+', 59.380463],  # yeay!
         ))
 
     def test_scenario_grapple(self):
@@ -600,7 +599,7 @@ class TestRankingScenarios(ESTestCase):
         see `legacy_api.SearchTest` for various examples.
         """
         self._check_scenario('grapple', (
-            ['GrApple Yummy', 0.97180986],
+            ['GrApple Yummy', 0.97592336],
         ))
 
     def test_scenario_delicious(self):
@@ -609,36 +608,36 @@ class TestRankingScenarios(ESTestCase):
         see `legacy_api.SearchTest` for various examples.
         """
         self._check_scenario('delicious', (
-            ['Delicious Bookmarks', 1.1302524],
+            ['Delicious Bookmarks', 1.1343652],
         ))
 
     def test_score_boost_name_match(self):
         # Tests that we match directly "Merge Windows" and also find
         # "Merge All Windows" because of slop=1
         self._check_scenario('merge windows', (
-            ['Merge Windows', 12.554659],
-            ['Merge All Windows', 1.7936656],
+            ['Merge Windows', 12.559275],
+            ['Merge All Windows', 1.79834],
         ), no_match=(
             'All Downloader Professional',
         ))
 
         self._check_scenario('merge all windows', (
-            ['Merge All Windows', 14.103567],
-            ['Merge Windows', 0.042702418],
-            ['All Downloader Professional', 0.0070751677],
+            ['Merge All Windows', 14.108069],
+            ['Merge Windows', 0.047278892],
+            ['All Downloader Professional', 0.011651831],
         ))
 
     def test_score_boost_exact_match(self):
         """Test that we rank exact matches at the top."""
         self._check_scenario('test addon test21', (
-            ['test addon test21', 14.293872],
+            ['test addon test21', 14.298365],
         ))
 
     def test_score_boost_exact_match_description_hijack(self):
         """Test that we rank exact matches at the top."""
         self._check_scenario('Amazon 1-Click Lock', (
-            ['Amazon 1-Click Lock', 34.255657],
-            ['1-Click YouTube Video Download', 0.22216046],
+            ['Amazon 1-Click Lock', 34.26],
+            ['1-Click YouTube Video Download', 0.22667459],
         ))
 
     def test_score_boost_exact_match_in_right_language(self):
@@ -646,13 +645,13 @@ class TestRankingScenarios(ESTestCase):
         # First in english. Straightforward: it should be an exact match, the
         # translation exists.
         self._check_scenario(u'foobar unique english', (
-            [u'Foobar unique english', 4.675893],
+            [u'Foobar unique english', 4.679805],
         ), lang='en-US')
 
         # Then check in french. Also straightforward: it should be an exact
         # match, the translation exists, it's even the default locale.
         self._check_scenario(u'foobar unique francais', (
-            [u'Foobar unique francais', 14.146512],
+            [u'Foobar unique francais', 14.150987],
         ), lang='fr')
 
         # Check with a language that we don't have a translation for (mn), and
@@ -663,7 +662,7 @@ class TestRankingScenarios(ESTestCase):
         assert 'mn' not in SEARCH_LANGUAGE_TO_ANALYZER
         assert 'mn' in settings.LANGUAGES
         self._check_scenario(u'foobar unique francais', (
-            [u'Foobar unique francais', 12.54679],
+            [u'Foobar unique francais', 12.551275],
         ), lang='mn', expected_lang='fr')
 
         # Check with a language that we don't have a translation for (ca), and
@@ -674,12 +673,12 @@ class TestRankingScenarios(ESTestCase):
         assert 'ca' in SEARCH_LANGUAGE_TO_ANALYZER
         assert 'ca' in settings.LANGUAGES
         self._check_scenario(u'foobar unique francais', (
-            [u'Foobar unique francais', 11.289922],
+            [u'Foobar unique francais', 11.294411],
         ), lang='ca', expected_lang='fr')
 
         # Check with a language that we do have a translation for (en-US), but
         # we're requesting the string that matches the default locale (fr).
         # Note that the name returned follows the language requested.
         self._check_scenario(u'foobar unique francais', (
-            [u'Foobar unique english', 9.786429],
+            [u'Foobar unique english', 9.790334],
         ), lang='en-US')


### PR DESCRIPTION
Reverts mozilla/addons-server#9966 because we're seeing issues on dev that might be related - featured add-ons and themes are no longer shown.