### PR TITLE
Treat an empty locale string in FeaturedCollection as None

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1275,7 +1275,10 @@ class Addon(OnChangeMixin, ModelBase):
                                         'featuredcollection__locale'))
         out = collections.defaultdict(set)
         for app, locale in qset:
-            out[app].add(locale)
+            # Even if the locale for the FeaturedCollection is an empty string
+            # instead of None, we return it as None so that it keeps its
+            # special meaning.
+            out[app].add(locale or None)
         return out
 
     def has_full_profile(self):

--- a/src/olympia/addons/tests/test_indexers.py
+++ b/src/olympia/addons/tests/test_indexers.py
@@ -205,9 +205,17 @@ class TestAddonIndexer(TestCase):
 
     def test_extract_featured_for(self):
         collection = collection_factory()
-        FeaturedCollection.objects.create(collection=collection,
-                                          application=amo.FIREFOX.id)
+        featured_collection = FeaturedCollection.objects.create(
+            collection=collection, application=amo.FIREFOX.id)
         collection.add_addon(self.addon)
+        extracted = self._extract()
+        assert extracted['featured_for'] == [
+            {'application': [amo.FIREFOX.id], 'locales': [None]}]
+
+        # Even if the locale for the FeaturedCollection is an empty string
+        # instead of None, we extract it as None so that it keeps its special
+        # meaning.
+        featured_collection.update(locale='')
         extracted = self._extract()
         assert extracted['featured_for'] == [
             {'application': [amo.FIREFOX.id], 'locales': [None]}]

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -794,6 +794,10 @@ class TestAddonModels(TestCase):
         # Get the applications this addon is featured for.
         assert addon.get_featured_by_app() == {amo.FIREFOX.id: {None}}
 
+        featured_coll.update(locale='')
+        # Check that an empty string is considered None.
+        assert addon.get_featured_by_app() == {amo.FIREFOX.id: {None}}
+
         featured_coll.update(locale='fr')
         # Check the locale works.
         assert addon.get_featured_by_app() == {amo.FIREFOX.id: {'fr'}}


### PR DESCRIPTION
This ensures that whatever happens, a `FeaturedCollection` with an empty locale is considered as such.

Fix #9980