### PR TITLE
Move match_phrase queries against description & summary to a rescore, add slop

### DIFF
--- a/src/olympia/addons/tests/test_indexers.py
+++ b/src/olympia/addons/tests/test_indexers.py
@@ -365,6 +365,7 @@ class TestAddonIndexer(TestCase):
             'fr': '',  # Empty description should be ignored in extract.
             'it': '<script>alert(42)</script>',
         }
+        self.addon.summary_id = None
         self.addon.name = translations_name
         self.addon.description = translations_description
         self.addon.save()
@@ -380,12 +381,19 @@ class TestAddonIndexer(TestCase):
         ])
         assert extracted['name_l10n_english'] == [translations_name['en-US']]
         assert extracted['name_l10n_spanish'] == [translations_name['es']]
+        assert extracted['name_l10n_italian'] == []
         assert (extracted['description_l10n_english'] ==
                 [translations_description['en-US']])
         assert (extracted['description_l10n_spanish'] ==
                 [translations_description['es']])
+        assert extracted['description_l10n_french'] == []
         assert (extracted['description_l10n_italian'] ==
                 ['&lt;script&gt;alert(42)&lt;/script&gt;'])
+        assert extracted['summary_l10n_english'] == []
+        # The non-l10n fields are fallbacks in the addon's default locale, they
+        # need to always contain a string.
+        assert extracted['name'] == u'Name in ënglish'
+        assert extracted['summary'] == ''
 
     def test_extract_translations_engb_default(self):
         """Make sure we do correctly extract things for en-GB default locale"""

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -637,8 +637,9 @@ def addon_factory(
         'created': when,
         'last_updated': when,
     }
-    if type_ != amo.ADDON_PERSONA:
-        # Personas don't have a summary.
+    if type_ != amo.ADDON_PERSONA and 'summary' not in kw:
+        # Assign a dummy summary if none was specified in keyword args, unless
+        # we're creating a Persona since they don't have summaries.
         kwargs['summary'] = u'Summary for %s' % name
     if type_ not in [amo.ADDON_PERSONA, amo.ADDON_SEARCH]:
         # Personas and search engines don't need guids

--- a/src/olympia/search/filters.py
+++ b/src/olympia/search/filters.py
@@ -477,11 +477,12 @@ class SearchQueryFilter(BaseFilterBackend):
                 'MultiMatch(%s(description),%s(description_l10n_%s))' % (
                     query_class_name, query_class_name, analyzer))
             should = [
-                # Note the presence of operator='and', which may seem weird
-                # for a multimatch query. It makes sense here because we really
-                # want all terms to be present in either of the fields
-                # individually. ES docs warn against this, but this is exactly
-                # what we want here.
+                # When *not* doing a rescore, we do regular non-phrase matches
+                # with 'operator': 'and' (see query_class/multi_match_kwargs
+                # above). This may seem wrong, the ES docs warn against this,
+                # but this is exactly what we want here: we want all terms
+                # to be present in either of the fields individually, not some
+                # in one and some in another.
                 query.MultiMatch(
                     _name=summary_query_name,
                     query=search_query,

--- a/src/olympia/search/tests/test_filters.py
+++ b/src/olympia/search/tests/test_filters.py
@@ -38,8 +38,7 @@ class TestQueryFilter(FilterTestsBase):
 
     filter_classes = [SearchQueryFilter]
 
-    def _test_q(self):
-        qs = self._filter(data={'q': 'tea pot'})
+    def _test_q(self, qs):
         # Spot check a few queries.
         should = qs['query']['function_score']['query']['bool']['should']
 
@@ -105,10 +104,12 @@ class TestQueryFilter(FilterTestsBase):
         return qs
 
     def test_no_rescore_if_not_sorting_by_relevance(self):
-        pass
+        qs = self._test_q(
+            self._filter(data={'q': 'tea pot', 'sort': 'rating'}))
+        assert 'rescore' not in qs
 
     def test_q(self):
-        qs = self._test_q()
+        qs = self._test_q(self._filter(data={'q': 'tea pot'}))
         functions = qs['query']['function_score']['functions']
         assert len(functions) == 1
 

--- a/src/olympia/search/tests/test_search_ranking.py
+++ b/src/olympia/search/tests/test_search_ranking.py
@@ -430,32 +430,32 @@ class TestRankingScenarios(ESTestCase):
             weekly_downloads=1123)
         amo.tests.addon_factory(
             name='GrApple Yummy', type=amo.ADDON_EXTENSION,
-            average_daily_users=1, weekly_downloads=1)
+            average_daily_users=1, weekly_downloads=1, summary=None)
         amo.tests.addon_factory(
             name='Delicious Bookmarks', type=amo.ADDON_EXTENSION,
-            average_daily_users=1, weekly_downloads=1)
+            average_daily_users=1, weekly_downloads=1, summary=None)
 
         # Some more or less Dummy data to test a few very specific scenarios
         # e.g for exact name matching
         amo.tests.addon_factory(
             name='Merge Windows', type=amo.ADDON_EXTENSION,
-            average_daily_users=1, weekly_downloads=1),
+            average_daily_users=1, weekly_downloads=1, summary=None)
         amo.tests.addon_factory(
             name='Merge All Windows', type=amo.ADDON_EXTENSION,
-            average_daily_users=1, weekly_downloads=1),
+            average_daily_users=1, weekly_downloads=1, summary=None)
         amo.tests.addon_factory(
             name='All Downloader Professional', type=amo.ADDON_EXTENSION,
-            average_daily_users=1, weekly_downloads=1),
+            average_daily_users=1, weekly_downloads=1, summary=None)
 
         amo.tests.addon_factory(
             name='test addon test11', type=amo.ADDON_EXTENSION,
-            average_daily_users=1, weekly_downloads=1),
+            average_daily_users=1, weekly_downloads=1, summary=None)
         amo.tests.addon_factory(
             name='test addon test21', type=amo.ADDON_EXTENSION,
-            average_daily_users=1, weekly_downloads=1),
+            average_daily_users=1, weekly_downloads=1, summary=None)
         amo.tests.addon_factory(
             name='test addon test31', type=amo.ADDON_EXTENSION,
-            average_daily_users=1, weekly_downloads=1),
+            average_daily_users=1, weekly_downloads=1, summary=None)
 
         names = {
             'fr': 'Foobar unique francais',
@@ -464,141 +464,143 @@ class TestRankingScenarios(ESTestCase):
         amo.tests.addon_factory(
             name=names, type=amo.ADDON_EXTENSION,
             default_locale='fr', slug='test-addon-test-special',
-            average_daily_users=1, weekly_downloads=1)
+            average_daily_users=1, weekly_downloads=1,
+            summary=None)
 
         amo.tests.addon_factory(
             name='1-Click YouTube Video Download',
             type=amo.ADDON_EXTENSION,
             average_daily_users=566337, weekly_downloads=150000,
+            summary=None,
             description=(
                 'button, click that button, 1-Click Youtube Video '
                 'Downloader is a click click great tool')),
         amo.tests.addon_factory(
             name='Amazon 1-Click Lock', type=amo.ADDON_EXTENSION,
-            average_daily_users=50, weekly_downloads=1),
+            average_daily_users=50, weekly_downloads=1, summary=None)
 
         cls.refresh()
 
     def test_scenario_tab_center_redux(self):
         self._check_scenario('tab center redux', (
-            ['Tab Center Redux', 69.52626],
-            ['Tab Mix Plus', 0.06525217],
-            ['Redux DevTools', 0.04450019],
+            ['Tab Center Redux', 69.5371],
+            ['Tab Mix Plus', 0.06526235],
+            ['Redux DevTools', 0.044507127],
         ))
 
     def test_scenario_open_image_new_tab(self):
         self._check_scenario('Open Image in New Tab', (
-            ['Open Image in New Tab', 34.78653],
-            ['Open image in a new tab', 10.8064375],
+            ['Open Image in New Tab', 34.543846],
+            ['Open image in a new tab', 10.555013],
         ))
 
     def test_scenario_coinhive(self):
         # TODO, should match "CoinBlock". Check word delimiting analysis maybe?
         self._check_scenario('CoinHive', (
-            ['Coinhive Blocker', 4.7844977],
-            ['NoMiners', 0.35266307],  # via description
+            ['Coinhive Blocker', 4.6710896],
+            ['NoMiners', 0.32348818],  # via description
             # ['CoinBlock', 0],  # via prefix search
         ))
 
     def test_scenario_privacy(self):
         self._check_scenario('Privacy', (
-            ['Privacy Badger', 9.189523],
-            ['Privacy Settings', 5.004992],
-            ['Google Privacy', 4.7066717],  # More users, summary
-            ['Privacy Pass', 3.2093506],
-            ['Blur', 0.70034933],
-            ['Ghostery', 0.539215],
+            ['Privacy Badger', 9.063842],
+            ['Privacy Settings', 4.917904],
+            ['Google Privacy', 4.638222],  # More users, summary
+            ['Privacy Pass', 3.2094479],
+            ['Blur', 0.62396055],
+            ['Ghostery', 0.47795504],
         ))
 
     def test_scenario_firebu(self):
         self._check_scenario('firebu', (
-            ['Firebug', 4.118528],
-            ['Firefinder for Firebug', 1.087826],
-            ['Firebug Autocompleter', 1.0656991],
-            ['Fire Drag', 0.6471504],
+            ['Firebug', 4.118729],
+            ['Firefinder for Firebug', 1.0878792],
+            ['Firebug Autocompleter', 1.0657512],
+            ['Fire Drag', 0.64718205],
         ))
 
     def test_scenario_fireb(self):
         self._check_scenario('fireb', (
-            ['Firebug', 4.118528],
-            ['Firefinder for Firebug', 1.087826],
-            ['Firebug Autocompleter', 1.0656991],
-            ['Fire Drag', 0.6471504],
+            ['Firebug', 4.118729],
+            ['Firefinder for Firebug', 1.0878792],
+            ['Firebug Autocompleter', 1.0657512],
+            ['Fire Drag', 0.64718205],
         ))
 
     def test_scenario_menu_wizzard(self):
         self._check_scenario('Menu Wizzard', (
-            ['Menu Wizard', 0.1069745],  # (fuzzy, typo)
+            ['Menu Wizard', 0.10698298],  # (fuzzy, typo)
             # partial match + users
-            ['Add-ons Manager Context Menu', 0.07929453],
+            ['Add-ons Manager Context Menu', 0.07930083],
         ))
 
     def test_scenario_frame_demolition(self):
         self._check_scenario('Frame Demolition', (
-            ['Frame Demolition', 20.532322],
+            ['Frame Demolition', 20.534973],
         ))
 
     def test_scenario_demolition(self):
         # Find "Frame Demolition" via a typo
         self._check_scenario('Demolation', (
-            ['Frame Demolition', 0.0578885],
+            ['Frame Demolition', 0.057891317],
         ))
 
     def test_scenario_restyle(self):
         self._check_scenario('reStyle', (
-            ['reStyle', 26.358738],
+            ['reStyle', 26.360489],
         ))
 
     def test_scenario_megaupload_downloadhelper(self):
         # Doesn't find "RapidShare DownloadHelper" anymore
         # since we now query by "MegaUpload AND DownloadHelper"
         self._check_scenario('MegaUpload DownloadHelper', (
-            ['MegaUpload DownloadHelper', 42.991062],
+            ['MegaUpload DownloadHelper', 42.995304],
         ))
 
     def test_scenario_downloadhelper(self):
         # No direct match, "Download Flash and Video" has
         # huge amount of users that puts it first here
         self._check_scenario('DownloadHelper', (
-            ['RapidShare DownloadHelper', 3.1014159],
-            ['MegaUpload DownloadHelper', 1.7235384],
-            ['Download Flash and Video', 1.5120169],
-            ['1-Click YouTube Video Download', 1.1415523],
+            ['RapidShare DownloadHelper', 3.1015685],
+            ['MegaUpload DownloadHelper', 1.7236232],
+            ['Download Flash and Video', 1.5120913],
+            ['1-Click YouTube Video Download', 1.1416086],
         ))
 
     def test_scenario_megaupload(self):
         self._check_scenario('MegaUpload', (
-            ['MegaUpload DownloadHelper', 3.9182916],
-            ['Popup Blocker', 1.4295081],
+            ['MegaUpload DownloadHelper', 3.8486633],
+            ['Popup Blocker', 1.4295679],
         ))
 
     def test_scenario_no_flash(self):
         self._check_scenario('No Flash', (
-            ['No Flash', 47.131393],
-            ['Download Flash and Video', 4.9062066],
-            ['YouTube Flash Player', 3.8485084],
-            ['YouTube Flash Video Player', 3.7404819],
+            ['No Flash', 47.049717],
+            ['Download Flash and Video', 4.7860165],
+            ['YouTube Flash Player', 3.7756333],
+            ['YouTube Flash Video Player', 3.627189],
         ))
 
         # Case should not matter.
         self._check_scenario('no flash', (
-            ['No Flash', 47.131393],
-            ['Download Flash and Video', 4.9062066],
-            ['YouTube Flash Player', 3.8485084],
-            ['YouTube Flash Video Player', 3.7404819],
+            ['No Flash', 47.049717],
+            ['Download Flash and Video', 4.7860165],
+            ['YouTube Flash Player', 3.7756333],
+            ['YouTube Flash Video Player', 3.627189],
         ))
 
     def test_scenario_youtube_html5_player(self):
         # Both are found thanks to their descriptions (matches each individual
         # term, then get rescored with a match_phrase w/ slop.
         self._check_scenario('Youtube html5 Player', (
-            ['YouTube Flash Player', 0.46292973],
-            ['No Flash', 0.07809982],
+            ['YouTube Flash Player', 0.41867542],
+            ['No Flash', 0.068471745],
         ))
 
     def test_scenario_disable_hello_pocket_reader_plus(self):
         self._check_scenario('Disable Hello, Pocket & Reader+', (
-            ['Disable Hello, Pocket & Reader+', 59.85741],  # yeay!
+            ['Disable Hello, Pocket & Reader+', 59.869083],  # yeay!
         ))
 
     def test_scenario_grapple(self):
@@ -607,7 +609,7 @@ class TestRankingScenarios(ESTestCase):
         see `legacy_api.SearchTest` for various examples.
         """
         self._check_scenario('grapple', (
-            ['GrApple Yummy', 1.9693669],
+            ['GrApple Yummy', 0.7218929],
         ))
 
     def test_scenario_delicious(self):
@@ -616,36 +618,36 @@ class TestRankingScenarios(ESTestCase):
         see `legacy_api.SearchTest` for various examples.
         """
         self._check_scenario('delicious', (
-            ['Delicious Bookmarks', 2.127837],
+            ['Delicious Bookmarks', 0.85394204],
         ))
 
     def test_score_boost_name_match(self):
         # Tests that we match directly "Merge Windows" and also find
         # "Merge All Windows" because of slop=1
         self._check_scenario('merge windows', (
-            ['Merge Windows', 14.019136],
-            ['Merge All Windows', 3.5159154],
+            ['Merge Windows', 10.207693],
+            ['Merge All Windows', 1.7960566],
         ), no_match=(
             'All Downloader Professional',
         ))
 
         self._check_scenario('merge all windows', (
-            ['Merge All Windows', 16.101984],
-            ['Merge Windows', 0.042862993],
-            ['All Downloader Professional', 0.0071017738],
+            ['Merge All Windows', 11.195793],
+            ['Merge Windows', 0.04285209],
+            ['All Downloader Professional', 0.0070999665],
         ))
 
     def test_score_boost_exact_match(self):
         """Test that we rank exact matches at the top."""
         self._check_scenario('test addon test21', (
-            ['test addon test21', 16.318735],
+            ['test addon test21', 11.341756],
         ))
 
     def test_score_boost_exact_match_description_hijack(self):
         """Test that we rank exact matches at the top."""
         self._check_scenario('Amazon 1-Click Lock', (
-            ['Amazon 1-Click Lock', 35.483917],
-            ['1-Click YouTube Video Download', 0.22377057],
+            ['Amazon 1-Click Lock', 26.223818],
+            ['1-Click YouTube Video Download', 0.22368877],
         ))
 
     def test_score_boost_exact_match_in_right_language(self):
@@ -653,13 +655,13 @@ class TestRankingScenarios(ESTestCase):
         # First in english. Straightforward: it should be an exact match, the
         # translation exists.
         self._check_scenario(u'foobar unique english', (
-            [u'Foobar unique english', 6.2519746],
+            [u'Foobar unique english', 2.9022827],
         ), lang='en-US')
 
         # Then check in french. Also straightforward: it should be an exact
         # match, the translation exists, it's even the default locale.
         self._check_scenario(u'foobar unique francais', (
-            [u'Foobar unique francais', 15.990762],
+            [u'Foobar unique francais', 10.837958],
         ), lang='fr')
 
         # Check with a language that we don't have a translation for (mn), and
@@ -670,7 +672,7 @@ class TestRankingScenarios(ESTestCase):
         assert 'mn' not in SEARCH_LANGUAGE_TO_ANALYZER
         assert 'mn' in settings.LANGUAGES
         self._check_scenario(u'foobar unique francais', (
-            [u'Foobar unique francais', 21.74215],
+            [u'Foobar unique francais', 9.005518],
         ), lang='mn', expected_lang='fr')
 
         # Check with a language that we don't have a translation for (ca), and
@@ -681,12 +683,12 @@ class TestRankingScenarios(ESTestCase):
         assert 'ca' in SEARCH_LANGUAGE_TO_ANALYZER
         assert 'ca' in settings.LANGUAGES
         self._check_scenario(u'foobar unique francais', (
-            [u'Foobar unique francais', 13.197082],
+            [u'Foobar unique francais', 8.107916],
         ), lang='ca', expected_lang='fr')
 
         # Check with a language that we do have a translation for (en-US), but
         # we're requesting the string that matches the default locale (fr).
         # Note that the name returned follows the language requested.
         self._check_scenario(u'foobar unique francais', (
-            [u'Foobar unique english', 11.437973],
+            [u'Foobar unique english', 7.0274434],
         ), lang='en-US')

--- a/src/olympia/search/tests/test_search_ranking.py
+++ b/src/olympia/search/tests/test_search_ranking.py
@@ -2,6 +2,7 @@
 import json
 
 from django.conf import settings
+from django.utils import translation
 
 from olympia import amo
 from olympia.amo.tests import (
@@ -481,124 +482,124 @@ class TestRankingScenarios(ESTestCase):
 
     def test_scenario_tab_center_redux(self):
         self._check_scenario('tab center redux', (
-            ['Tab Center Redux', 69.479675],
-            ['Tab Mix Plus', 0.06520844],
-            ['Redux DevTools', 0.044470366],
+            ['Tab Center Redux', 69.52626],
+            ['Tab Mix Plus', 0.06525217],
+            ['Redux DevTools', 0.04450019],
         ))
 
     def test_scenario_open_image_new_tab(self):
         self._check_scenario('Open Image in New Tab', (
-            ['Open Image in New Tab', 34.353912],
-            ['Open image in a new tab', 10.394562],
+            ['Open Image in New Tab', 34.78653],
+            ['Open image in a new tab', 10.8064375],
         ))
 
     def test_scenario_coinhive(self):
         # TODO, should match "CoinBlock". Check word delimiting analysis maybe?
         self._check_scenario('CoinHive', (
-            ['Coinhive Blocker', 4.5972457],
-            ['NoMiners', 0.28269354],  # via description
+            ['Coinhive Blocker', 4.7844977],
+            ['NoMiners', 0.35266307],  # via description
             # ['CoinBlock', 0],  # via prefix search
         ))
 
     def test_scenario_privacy(self):
         self._check_scenario('Privacy', (
-            ['Privacy Badger', 9.068837],
-            ['Privacy Settings', 4.8850355],
-            ['Google Privacy', 4.6105843],  # More users, summary
-            ['Privacy Pass', 3.2087922],
-            ['Blur', 0.5335082],
-            ['Ghostery', 0.42003605],
+            ['Privacy Badger', 9.189523],
+            ['Privacy Settings', 5.004992],
+            ['Google Privacy', 4.7066717],  # More users, summary
+            ['Privacy Pass', 3.2093506],
+            ['Blur', 0.70034933],
+            ['Ghostery', 0.539215],
         ))
 
     def test_scenario_firebu(self):
         self._check_scenario('firebu', (
-            ['Firebug', 4.117813],
-            ['Firefinder for Firebug', 1.0876373],
-            ['Firebug Autocompleter', 1.0655142],
-            ['Fire Drag', 0.6470381],
+            ['Firebug', 4.118528],
+            ['Firefinder for Firebug', 1.087826],
+            ['Firebug Autocompleter', 1.0656991],
+            ['Fire Drag', 0.6471504],
         ))
 
     def test_scenario_fireb(self):
         self._check_scenario('fireb', (
-            ['Firebug', 4.117813],
-            ['Firefinder for Firebug', 1.0876373],
-            ['Firebug Autocompleter', 1.0655142],
-            ['Fire Drag', 0.6470381],
+            ['Firebug', 4.118528],
+            ['Firefinder for Firebug', 1.087826],
+            ['Firebug Autocompleter', 1.0656991],
+            ['Fire Drag', 0.6471504],
         ))
 
     def test_scenario_menu_wizzard(self):
         self._check_scenario('Menu Wizzard', (
-            ['Menu Wizard', 0.106938206],  # (fuzzy, typo)
+            ['Menu Wizard', 0.1069745],  # (fuzzy, typo)
             # partial match + users
-            ['Add-ons Manager Context Menu', 0.07926763],
+            ['Add-ons Manager Context Menu', 0.07929453],
         ))
 
     def test_scenario_frame_demolition(self):
         self._check_scenario('Frame Demolition', (
-            ['Frame Demolition', 20.522936],
+            ['Frame Demolition', 20.532322],
         ))
 
     def test_scenario_demolition(self):
         # Find "Frame Demolition" via a typo
         self._check_scenario('Demolation', (
-            ['Frame Demolition', 0.057878494],
+            ['Frame Demolition', 0.0578885],
         ))
 
     def test_scenario_restyle(self):
         self._check_scenario('reStyle', (
-            ['reStyle', 26.352535],
+            ['reStyle', 26.358738],
         ))
 
     def test_scenario_megaupload_downloadhelper(self):
         # Doesn't find "RapidShare DownloadHelper" anymore
         # since we now query by "MegaUpload AND DownloadHelper"
         self._check_scenario('MegaUpload DownloadHelper', (
-            ['MegaUpload DownloadHelper', 42.974842],
+            ['MegaUpload DownloadHelper', 42.991062],
         ))
 
     def test_scenario_downloadhelper(self):
         # No direct match, "Download Flash and Video" has
         # huge amount of users that puts it first here
         self._check_scenario('DownloadHelper', (
-            ['RapidShare DownloadHelper', 3.1008768],
-            ['MegaUpload DownloadHelper', 1.7232388],
-            ['Download Flash and Video', 1.5117542],
-            ['1-Click YouTube Video Download', 1.141354],
+            ['RapidShare DownloadHelper', 3.1014159],
+            ['MegaUpload DownloadHelper', 1.7235384],
+            ['Download Flash and Video', 1.5120169],
+            ['1-Click YouTube Video Download', 1.1415523],
         ))
 
     def test_scenario_megaupload(self):
         self._check_scenario('MegaUpload', (
-            ['MegaUpload DownloadHelper', 3.7998059],
-            ['Popup Blocker', 1.4292603],
+            ['MegaUpload DownloadHelper', 3.9182916],
+            ['Popup Blocker', 1.4295081],
         ))
 
     def test_scenario_no_flash(self):
         self._check_scenario('No Flash', (
-            ['No Flash', 47.00143],
-            ['Download Flash and Video', 4.781514],
-            ['YouTube Flash Player', 3.763546],
-            ['YouTube Flash Video Player', 3.6051111],
+            ['No Flash', 47.131393],
+            ['Download Flash and Video', 4.9062066],
+            ['YouTube Flash Player', 3.8485084],
+            ['YouTube Flash Video Player', 3.7404819],
         ))
 
         # Case should not matter.
         self._check_scenario('no flash', (
-            ['No Flash', 47.00143],
-            ['Download Flash and Video', 4.781514],
-            ['YouTube Flash Player', 3.763546],
-            ['YouTube Flash Video Player', 3.6051111],
+            ['No Flash', 47.131393],
+            ['Download Flash and Video', 4.9062066],
+            ['YouTube Flash Player', 3.8485084],
+            ['YouTube Flash Video Player', 3.7404819],
         ))
 
     def test_scenario_youtube_html5_player(self):
         # Both are found thanks to their descriptions (matches each individual
         # term, then get rescored with a match_phrase w/ slop.
         self._check_scenario('Youtube html5 Player', (
-            ['YouTube Flash Player', 0.40480357],
-            ['No Flash', 0.07806653],
+            ['YouTube Flash Player', 0.46292973],
+            ['No Flash', 0.07809982],
         ))
 
     def test_scenario_disable_hello_pocket_reader_plus(self):
         self._check_scenario('Disable Hello, Pocket & Reader+', (
-            ['Disable Hello, Pocket & Reader+', 59.80632],  # yeay!
+            ['Disable Hello, Pocket & Reader+', 59.85741],  # yeay!
         ))
 
     def test_scenario_grapple(self):
@@ -607,7 +608,7 @@ class TestRankingScenarios(ESTestCase):
         see `legacy_api.SearchTest` for various examples.
         """
         self._check_scenario('grapple', (
-            ['GrApple Yummy', 1.7876518],
+            ['GrApple Yummy', 1.9693669],
         ))
 
     def test_scenario_delicious(self):
@@ -616,36 +617,36 @@ class TestRankingScenarios(ESTestCase):
         see `legacy_api.SearchTest` for various examples.
         """
         self._check_scenario('delicious', (
-            ['Delicious Bookmarks', 1.9460943],
+            ['Delicious Bookmarks', 2.127837],
         ))
 
     def test_score_boost_name_match(self):
         # Tests that we match directly "Merge Windows" and also find
         # "Merge All Windows" because of slop=1
         self._check_scenario('merge windows', (
-            ['Merge Windows', 13.634404],
-            ['Merge All Windows', 3.2467458],
+            ['Merge Windows', 14.019136],
+            ['Merge All Windows', 3.5159154],
         ), no_match=(
             'All Downloader Professional',
         ))
 
         self._check_scenario('merge all windows', (
-            ['Merge All Windows', 15.524793],
-            ['Merge Windows', 0.042835273],
-            ['All Downloader Professional', 0.00709718],
+            ['Merge All Windows', 16.101984],
+            ['Merge Windows', 0.042862993],
+            ['All Downloader Professional', 0.0071017738],
         ))
 
     def test_score_boost_exact_match(self):
         """Test that we rank exact matches at the top."""
         self._check_scenario('test addon test21', (
-            ['test addon test21', 15.742278],
+            ['test addon test21', 16.318735],
         ))
 
     def test_score_boost_exact_match_description_hijack(self):
         """Test that we rank exact matches at the top."""
         self._check_scenario('Amazon 1-Click Lock', (
-            ['Amazon 1-Click Lock', 34.837643],
-            ['1-Click YouTube Video Download', 0.22360161],
+            ['Amazon 1-Click Lock', 35.483917],
+            ['1-Click YouTube Video Download', 0.22377057],
         ))
 
     def test_score_boost_exact_match_in_right_language(self):
@@ -653,13 +654,13 @@ class TestRankingScenarios(ESTestCase):
         # First in english. Straightforward: it should be an exact match, the
         # translation exists.
         self._check_scenario(u'foobar unique english', (
-            [u'Foobar unique english', 5.9928703],
+            [u'Foobar unique english', 6.2519746],
         ), lang='en-US')
 
         # Then check in french. Also straightforward: it should be an exact
         # match, the translation exists, it's even the default locale.
         self._check_scenario(u'foobar unique francais', (
-            [u'Foobar unique francais', 15.588857],
+            [u'Foobar unique francais', 15.990762],
         ), lang='fr')
 
         # Check with a language that we don't have a translation for (mn), and
@@ -681,12 +682,12 @@ class TestRankingScenarios(ESTestCase):
         assert 'ca' in SEARCH_LANGUAGE_TO_ANALYZER
         assert 'ca' in settings.LANGUAGES
         self._check_scenario(u'foobar unique francais', (
-            [u'Foobar unique francais', 12.796962],
+            [u'Foobar unique francais', 13.197082],
         ), lang='ca', expected_lang='fr')
 
         # Check with a language that we do have a translation for (en-US), but
         # we're requesting the string that matches the default locale (fr).
         # Note that the name returned follows the language requested.
         self._check_scenario(u'foobar unique francais', (
-            [u'Foobar unique english', 11.158682],
+            [u'Foobar unique english', 11.437973],
         ), lang='en-US')

--- a/src/olympia/search/tests/test_search_ranking.py
+++ b/src/olympia/search/tests/test_search_ranking.py
@@ -2,7 +2,6 @@
 import json
 
 from django.conf import settings
-from django.utils import translation
 
 from olympia import amo
 from olympia.amo.tests import (

--- a/src/olympia/search/tests/test_search_ranking.py
+++ b/src/olympia/search/tests/test_search_ranking.py
@@ -70,7 +70,7 @@ class TestRankingScenarios(ESTestCase):
             # sense though!)
             # if found_score != expected_score:
             #     filename = 'src/olympia/search/tests/test_search_ranking.py'
-            #     with open('sed_me.sh', 'a+') as f:
+            #     with open('/code/tmp/sed_me.sh', 'a+') as f:
             #         f.write('sed -i s/%s/%s/ %s\n' % (
             #             expected_score, found_score, filename))
             #     continue
@@ -481,34 +481,33 @@ class TestRankingScenarios(ESTestCase):
 
     def test_scenario_tab_center_redux(self):
         self._check_scenario('tab center redux', (
-            ['Tab Center Redux', 69.21394],
-            ['Tab Mix Plus', 0.06495905],
-            ['Redux DevTools', 0.04430029],
+            ['Tab Center Redux', 69.479675],
+            ['Tab Mix Plus', 0.06520844],
+            ['Redux DevTools', 0.044470366],
         ))
 
     def test_scenario_open_image_new_tab(self):
         self._check_scenario('Open Image in New Tab', (
-            ['Open Image in New Tab', 24.277237],
-            ['Open image in a new tab', 5.6800475],
+            ['Open Image in New Tab', 34.353912],
+            ['Open image in a new tab', 10.394562],
         ))
 
     def test_scenario_coinhive(self):
         # TODO, should match "CoinBlock". Check word delimiting analysis maybe?
         self._check_scenario('CoinHive', (
-            ['Coinhive Blocker', 3.891288],
-            ['NoMiners', 0.017959397],  # via description
+            ['Coinhive Blocker', 4.5972457],
+            ['NoMiners', 0.28269354],  # via description
             # ['CoinBlock', 0],  # via prefix search
         ))
 
     def test_scenario_privacy(self):
         self._check_scenario('Privacy', (
-            ['Privacy Badger', 8.7432165],
-            ['Privacy Settings', 4.559415],
-            ['Google Privacy', 4.350088],  # More users, summary
+            ['Privacy Badger', 9.068837],
+            ['Privacy Settings', 4.8850355],
+            ['Google Privacy', 4.6105843],  # More users, summary
             ['Privacy Pass', 3.2087922],
-            ['Ghostery', 0.09441561],  # Crazy amount of users, summary
-            # summary + a lot of users, but not as many as ghostery
-            ['Blur', 0.0776396],
+            ['Blur', 0.5335082],
+            ['Ghostery', 0.42003605],
         ))
 
     def test_scenario_firebu(self):
@@ -529,14 +528,14 @@ class TestRankingScenarios(ESTestCase):
 
     def test_scenario_menu_wizzard(self):
         self._check_scenario('Menu Wizzard', (
-            ['Menu Wizard', 0.10683497],  # (fuzzy, typo)
+            ['Menu Wizard', 0.106938206],  # (fuzzy, typo)
             # partial match + users
-            ['Add-ons Manager Context Menu', 0.0791911],
+            ['Add-ons Manager Context Menu', 0.07926763],
         ))
 
     def test_scenario_frame_demolition(self):
         self._check_scenario('Frame Demolition', (
-            ['Frame Demolition', 20.48827],
+            ['Frame Demolition', 20.522936],
         ))
 
     def test_scenario_demolition(self):
@@ -554,7 +553,7 @@ class TestRankingScenarios(ESTestCase):
         # Doesn't find "RapidShare DownloadHelper" anymore
         # since we now query by "MegaUpload AND DownloadHelper"
         self._check_scenario('MegaUpload DownloadHelper', (
-            ['MegaUpload DownloadHelper', 42.920856],
+            ['MegaUpload DownloadHelper', 42.974842],
         ))
 
     def test_scenario_downloadhelper(self):
@@ -569,29 +568,37 @@ class TestRankingScenarios(ESTestCase):
 
     def test_scenario_megaupload(self):
         self._check_scenario('MegaUpload', (
-            ['MegaUpload DownloadHelper', 3.269901],
+            ['MegaUpload DownloadHelper', 3.7998059],
             ['Popup Blocker', 1.4292603],
         ))
 
     def test_scenario_no_flash(self):
         self._check_scenario('No Flash', (
-            ['No Flash', 46.64575],
-            ['Download Flash and Video', 4.4118795],
-            ['YouTube Flash Player', 3.5120416],
-            ['YouTube Flash Video Player', 3.202704],
+            ['No Flash', 47.00143],
+            ['Download Flash and Video', 4.781514],
+            ['YouTube Flash Player', 3.763546],
+            ['YouTube Flash Video Player', 3.6051111],
         ))
 
         # Case should not matter.
         self._check_scenario('no flash', (
-            ['No Flash', 46.64575],
-            ['Download Flash and Video', 4.4118795],
-            ['YouTube Flash Player', 3.5120416],
-            ['YouTube Flash Video Player', 3.202704],
+            ['No Flash', 47.00143],
+            ['Download Flash and Video', 4.781514],
+            ['YouTube Flash Player', 3.763546],
+            ['YouTube Flash Video Player', 3.6051111],
+        ))
+
+    def test_scenario_youtube_html5_player(self):
+        # Both are found thanks to their descriptions (matches each individual
+        # term, then get rescored with a match_phrase w/ slop.
+        self._check_scenario('Youtube html5 Player', (
+            ['YouTube Flash Player', 0.40480357],
+            ['No Flash', 0.07806653],
         ))
 
     def test_scenario_disable_hello_pocket_reader_plus(self):
         self._check_scenario('Disable Hello, Pocket & Reader+', (
-            ['Disable Hello, Pocket & Reader+', 59.37624],  # yeay!
+            ['Disable Hello, Pocket & Reader+', 59.80632],  # yeay!
         ))
 
     def test_scenario_grapple(self):
@@ -600,7 +607,7 @@ class TestRankingScenarios(ESTestCase):
         see `legacy_api.SearchTest` for various examples.
         """
         self._check_scenario('grapple', (
-            ['GrApple Yummy', 0.97180986],
+            ['GrApple Yummy', 1.7876518],
         ))
 
     def test_scenario_delicious(self):
@@ -609,36 +616,36 @@ class TestRankingScenarios(ESTestCase):
         see `legacy_api.SearchTest` for various examples.
         """
         self._check_scenario('delicious', (
-            ['Delicious Bookmarks', 1.1302524],
+            ['Delicious Bookmarks', 1.9460943],
         ))
 
     def test_score_boost_name_match(self):
         # Tests that we match directly "Merge Windows" and also find
         # "Merge All Windows" because of slop=1
         self._check_scenario('merge windows', (
-            ['Merge Windows', 12.554659],
-            ['Merge All Windows', 1.7936656],
+            ['Merge Windows', 13.634404],
+            ['Merge All Windows', 3.2467458],
         ), no_match=(
             'All Downloader Professional',
         ))
 
         self._check_scenario('merge all windows', (
-            ['Merge All Windows', 14.103567],
-            ['Merge Windows', 0.042702418],
-            ['All Downloader Professional', 0.0070751677],
+            ['Merge All Windows', 15.524793],
+            ['Merge Windows', 0.042835273],
+            ['All Downloader Professional', 0.00709718],
         ))
 
     def test_score_boost_exact_match(self):
         """Test that we rank exact matches at the top."""
         self._check_scenario('test addon test21', (
-            ['test addon test21', 14.293872],
+            ['test addon test21', 15.742278],
         ))
 
     def test_score_boost_exact_match_description_hijack(self):
         """Test that we rank exact matches at the top."""
         self._check_scenario('Amazon 1-Click Lock', (
-            ['Amazon 1-Click Lock', 34.255657],
-            ['1-Click YouTube Video Download', 0.22216046],
+            ['Amazon 1-Click Lock', 34.837643],
+            ['1-Click YouTube Video Download', 0.22360161],
         ))
 
     def test_score_boost_exact_match_in_right_language(self):
@@ -646,13 +653,13 @@ class TestRankingScenarios(ESTestCase):
         # First in english. Straightforward: it should be an exact match, the
         # translation exists.
         self._check_scenario(u'foobar unique english', (
-            [u'Foobar unique english', 4.675893],
+            [u'Foobar unique english', 5.9928703],
         ), lang='en-US')
 
         # Then check in french. Also straightforward: it should be an exact
         # match, the translation exists, it's even the default locale.
         self._check_scenario(u'foobar unique francais', (
-            [u'Foobar unique francais', 14.146512],
+            [u'Foobar unique francais', 15.588857],
         ), lang='fr')
 
         # Check with a language that we don't have a translation for (mn), and
@@ -663,7 +670,7 @@ class TestRankingScenarios(ESTestCase):
         assert 'mn' not in SEARCH_LANGUAGE_TO_ANALYZER
         assert 'mn' in settings.LANGUAGES
         self._check_scenario(u'foobar unique francais', (
-            [u'Foobar unique francais', 12.54679],
+            [u'Foobar unique francais', 21.74215],
         ), lang='mn', expected_lang='fr')
 
         # Check with a language that we don't have a translation for (ca), and
@@ -674,12 +681,12 @@ class TestRankingScenarios(ESTestCase):
         assert 'ca' in SEARCH_LANGUAGE_TO_ANALYZER
         assert 'ca' in settings.LANGUAGES
         self._check_scenario(u'foobar unique francais', (
-            [u'Foobar unique francais', 11.289922],
+            [u'Foobar unique francais', 12.796962],
         ), lang='ca', expected_lang='fr')
 
         # Check with a language that we do have a translation for (en-US), but
         # we're requesting the string that matches the default locale (fr).
         # Note that the name returned follows the language requested.
         self._check_scenario(u'foobar unique francais', (
-            [u'Foobar unique english', 9.786429],
+            [u'Foobar unique english', 11.158682],
         ), lang='en-US')


### PR DESCRIPTION
Adding a slop makes the matching against description & summary more useful, allowing us to skip words instead of doing a strict match in order. But since it's potentially costly, we move this to a rescore query and instead do a regular match for the main query phase.

Fixes #9933
Fixes #9803 
Fixes mozilla/addons#731