### PR TITLE
detect `browser_specific_settings` as pseudonym of `applications` in manifest

### DIFF
--- a/src/olympia/addons/tests/test_utils_.py
+++ b/src/olympia/addons/tests/test_utils_.py
@@ -327,7 +327,7 @@ class TestBuildWebextDictionaryFromLegacy(AMOPaths, TestCase):
             manifest = xpi.read('manifest.json')
             manifest_json = json.loads(manifest)
             assert (
-                manifest_json['applications']['gecko']['id'] ==
+                manifest_json['browser_specific_settings']['gecko']['id'] ==
                 self.addon.guid)
             assert manifest_json['version'] == expected_version
             expected_dict_obj = {'ar': 'dictionaries/ar.dic'}

--- a/src/olympia/addons/utils.py
+++ b/src/olympia/addons/utils.py
@@ -292,7 +292,7 @@ def build_webext_dictionary_from_legacy(addon, destination):
         manifest = {
             'manifest_version': 2,
             'name': unicode(addon.name),
-            'applications': {
+            'browser_specific_settings': {
                 'gecko': {
                     'id': addon.guid,
                 },

--- a/src/olympia/constants/base.py
+++ b/src/olympia/constants/base.py
@@ -416,6 +416,9 @@ DEFAULT_WEBEXT_MIN_VERSION_ANDROID = '48.0'
 # The default version of Firefox that supports WebExtensions without an id
 DEFAULT_WEBEXT_MIN_VERSION_NO_ID = '48.0'
 
+# The default version of Firefox that supported `browser_specific_settings`
+DEFAULT_WEBEXT_MIN_VERSION_BROWSER_SPECIFIC = '48.0'
+
 # The version of Firefox that first supported static themes.  Not Android yet.
 DEFAULT_STATIC_THEME_MIN_VERSION_FIREFOX = '53.0'
 

--- a/src/olympia/files/tests/test_utils_.py
+++ b/src/olympia/files/tests/test_utils_.py
@@ -155,10 +155,17 @@ class TestManifestJSONExtractor(TestCase):
         extractor = utils.ManifestJSONExtractor(zipfile.ZipFile(fake_zip))
         assert extractor.data == data
 
-    def test_guid(self):
+    def test_guid_from_applications(self):
         """Use applications>gecko>id for the guid."""
         assert self.parse(
             {'applications': {
+                'gecko': {
+                    'id': 'some-id'}}})['guid'] == 'some-id'
+
+    def test_guid_from_browser_specific_settings(self):
+        """Use applications>gecko>id for the guid."""
+        assert self.parse(
+            {'browser_specific_settings': {
                 'gecko': {
                     'id': 'some-id'}}})['guid'] == 'some-id'
 
@@ -256,6 +263,16 @@ class TestManifestJSONExtractor(TestCase):
         app = apps[0]
         assert app.appdata == amo.FIREFOX
         assert app.min.version == amo.DEFAULT_WEBEXT_MIN_VERSION
+        assert app.max.version == amo.DEFAULT_WEBEXT_MAX_VERSION
+
+        # But if 'browser_specific_settings' is used, it's higher min version.
+        data = {'browser_specific_settings': {'gecko': {'id': 'some-id'}}}
+        apps = self.parse(data)['apps']
+        assert len(apps) == 1  # Only Firefox for now.
+        app = apps[0]
+        assert app.appdata == amo.FIREFOX
+        assert app.min.version == (
+            amo.DEFAULT_WEBEXT_MIN_VERSION_BROWSER_SPECIFIC)
         assert app.max.version == amo.DEFAULT_WEBEXT_MAX_VERSION
 
     def test_is_webextension(self):

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -387,8 +387,11 @@ class ManifestJSONExtractor(object):
 
     @property
     def gecko(self):
-        """Return the "applications["gecko"]" part of the manifest."""
-        return self.get('applications', {}).get('gecko', {})
+        """Return the "applications|browser_specific_settings["gecko"]" part
+        of the manifest."""
+        parent_block = self.get(
+            'browser_specific_settings', self.get('applications', {}))
+        return parent_block.get('gecko', {})
 
     @property
     def guid(self):
@@ -433,8 +436,12 @@ class ManifestJSONExtractor(object):
                 (amo.FIREFOX, amo.DEFAULT_WEBEXT_DICT_MIN_VERSION_FIREFOX),
             )
         else:
+            webext_min = (
+                amo.DEFAULT_WEBEXT_MIN_VERSION
+                if self.get('browser_specific_settings', None) is None
+                else amo.DEFAULT_WEBEXT_MIN_VERSION_BROWSER_SPECIFIC)
             apps = (
-                (amo.FIREFOX, amo.DEFAULT_WEBEXT_MIN_VERSION),
+                (amo.FIREFOX, webext_min),
                 (amo.ANDROID, amo.DEFAULT_WEBEXT_MIN_VERSION_ANDROID),
             )
 


### PR DESCRIPTION
fixes #9989 
It takes into account minimum Firefox version if you use `browser_specific_settings` rather than `applications` but if you specify a lower version in the manifest you're on your own.  (It seemed a edge case someone would manually specify a minimum version of Firefox lower than 48.0 yet decide to use a property only publicised on MDN yesterday)