### PR TITLE
Remove sudo:false from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false
 
 python:
   - 2.7


### PR DESCRIPTION
Fixes #10023

Travis is migrating away from their container-based infrastructure which
is something we should be ahead of and see what the impact is.