### PR TITLE
Remove 'activate-basket-sync' waffle switch and implementation

### DIFF
--- a/src/olympia/accounts/serializers.py
+++ b/src/olympia/accounts/serializers.py
@@ -2,8 +2,6 @@ from django.conf import settings
 from django.core.files.storage import default_storage
 from django.utils.translation import ugettext
 
-import waffle
-
 from rest_framework import serializers
 
 import olympia.core.logger
@@ -246,9 +244,8 @@ class UserNotificationSerializer(serializers.Serializer):
 
         remote_by_id = {
             l.id: l for l in notifications.REMOTE_NOTIFICATIONS}
-        use_basket = waffle.switch_is_active('activate-basket-sync')
 
-        if use_basket and instance.notification_id in remote_by_id:
+        if instance.notification_id in remote_by_id:
             notification = remote_by_id[instance.notification_id]
             if not enabled:
                 unsubscribe_newsletter(

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -1435,8 +1435,6 @@ class TestAccountNotificationViewSetList(TestCase):
             response.data)
 
     def test_basket_integration(self):
-        create_switch('activate-basket-sync')
-
         self.client.login_api(self.user)
         response = self.client.get(self.url)
         assert response.status_code == 200
@@ -1455,8 +1453,6 @@ class TestAccountNotificationViewSetList(TestCase):
 
     def test_basket_integration_non_dev(self):
         self.user.addons.all().delete()
-        create_switch('activate-basket-sync')
-
         self.client.login_api(self.user)
         response = self.client.get(self.url)
         assert response.status_code == 200
@@ -1473,8 +1469,6 @@ class TestAccountNotificationViewSetList(TestCase):
             not in response.data)
 
     def test_basket_integration_ignore_db(self):
-        create_switch('activate-basket-sync')
-
         # Add some old obsolete data in the database for a notification that
         # is handled by basket: it should be ignored.
         notification_id = REMOTE_NOTIFICATIONS_BY_BASKET_ID['about-addons'].id
@@ -1627,19 +1621,6 @@ class TestAccountNotificationViewSetUpdate(TestCase):
         assert (
             {'name': u'announcements', 'enabled': False, 'mandatory': False} in
             self.client.get(self.list_url).data)
-
-        with mock.patch('basket.base.request', autospec=True) as request_call:
-            request_call.return_value = {
-                'status': 'ok', 'token': '123',
-                'newsletters': ['announcements']}
-            self.client.post(
-                self.url,
-                data={'announcements': True})
-
-        # We haven't set the switch yet, so there are no calls.
-        assert request_call.call_count == 0
-
-        create_switch('activate-basket-sync')
 
         with mock.patch('basket.base.request', autospec=True) as request_call:
             request_call.return_value = {

--- a/src/olympia/migrations/1055-remove-activate-basket-sync-waffle.sql
+++ b/src/olympia/migrations/1055-remove-activate-basket-sync-waffle.sql
@@ -1,0 +1,1 @@
+DELETE FROM waffle_switch WHERE name = 'activate-basket-sync';

--- a/src/olympia/users/tests/test_forms.py
+++ b/src/olympia/users/tests/test_forms.py
@@ -7,7 +7,7 @@ import basket
 from mock import Mock, patch, MagicMock
 from pyquery import PyQuery as pq
 
-from olympia.amo.tests import TestCase, addon_factory, create_switch
+from olympia.amo.tests import TestCase, addon_factory
 from olympia.amo.tests.test_helpers import get_uploaded_file
 from olympia.amo.urlresolvers import reverse
 from olympia.users.forms import AdminUserEditForm, UserEditForm
@@ -219,8 +219,6 @@ class TestUserEditForm(UserFormBase):
         assert self.user.reload().email == 'me@example.com'
 
     def test_only_show_notifications_user_has_permission_to(self):
-        create_switch('activate-basket-sync')
-
         with patch('basket.base.request', autospec=True) as request_call:
             request_call.return_value = {
                 'status': 'ok', 'token': '123', 'newsletters': []}
@@ -253,8 +251,6 @@ class TestUserEditForm(UserFormBase):
         ]
 
     def test_basket_unsubscribe_newsletter(self):
-        create_switch('activate-basket-sync')
-
         with patch('basket.base.request', autospec=True) as request_call:
             request_call.return_value = {
                 'status': 'ok', 'token': '123',
@@ -286,8 +282,6 @@ class TestUserEditForm(UserFormBase):
     def test_basket_data_is_used_for_initial_checkbox_state_subscribed(self):
         # When using basket, what's in the database is ignored for the
         # notification
-        create_switch('activate-basket-sync')
-
         notification_id = REMOTE_NOTIFICATIONS_BY_BASKET_ID['about-addons'].id
 
         # Add some old obsolete data in the database for a notification that
@@ -314,8 +308,6 @@ class TestUserEditForm(UserFormBase):
     def test_basket_data_is_used_for_initial_checkbox_state(self):
         # When using basket, what's in the database is ignored for the
         # notification
-        create_switch('activate-basket-sync')
-
         notification_id = REMOTE_NOTIFICATIONS_BY_BASKET_ID['about-addons'].id
 
         # Add some old obsolete data in the database for a notification that
@@ -343,8 +335,6 @@ class TestUserEditForm(UserFormBase):
         """
         Test that unsubscribing from a newsletter if user didn't exist yet
         """
-        create_switch('activate-basket-sync')
-
         with patch('basket.base.request', autospec=True) as request_call:
             request_call.side_effect = basket.base.BasketException(
                 'description', status_code=401,
@@ -360,8 +350,6 @@ class TestUserEditForm(UserFormBase):
             params={'email': u'jbalogh@mozilla.com'})
 
     def test_basket_subscribe_newsletter(self):
-        create_switch('activate-basket-sync')
-
         addon_factory(users=[self.user])
 
         with patch('basket.base.request', autospec=True) as request_call:
@@ -395,17 +383,6 @@ class TestUserEditForm(UserFormBase):
                 'newsletters': 'about-addons', 'sync': 'Y',
                 'optin': 'Y', 'source_url': 'http://testserver/users/edit/',
                 'email': u'jbalogh@mozilla.com'})
-
-    def test_basket_sync_behind_flag(self):
-
-        with patch('basket.base.request', autospec=True) as request_call:
-            request_call.return_value = {
-                'status': 'ok', 'token': '123',
-                'newsletters': ['announcements']}
-
-            UserEditForm({}, instance=self.user)
-
-        assert request_call.call_count == 0
 
 
 class TestAdminUserEditForm(UserFormBase):


### PR DESCRIPTION
Fixes #10025

This doesn't touch how notifications are synced to `UserNotification`
instances but only uses basket always.