### PR TITLE
Commit source uploads to git-storage.

### DIFF
--- a/src/olympia/addons/tests/test_commands.py
+++ b/src/olympia/addons/tests/test_commands.py
@@ -581,8 +581,8 @@ class TestMigrateLegacyDictionariesToWebextension(TestCase):
 class TestExtractWebextensionsToGitStorage(TestCase):
     @mock.patch('olympia.addons.tasks.index_addons.delay', autospec=True)
     @mock.patch(
-        'olympia.addons.tasks.extract_file_obj_to_git', autospec=True)
-    def test_basic(self, extract_file_obj_to_git_mock, index_addons_mock):
+        'olympia.versions.tasks.extract_version_to_git', autospec=True)
+    def test_basic(self, extract_version_to_git_mock, index_addons_mock):
         addon_factory(file_kw={'is_webextension': True})
         addon_factory(file_kw={'is_webextension': True})
         addon_factory(
@@ -601,7 +601,7 @@ class TestExtractWebextensionsToGitStorage(TestCase):
 
         call_command('process_addons',
                      task='extract_webextensions_to_git_storage')
-        assert extract_file_obj_to_git_mock.call_count == 6
+        assert extract_version_to_git_mock.call_count == 6
 
 
 class TestDisableLegacyAddons(TestCase):

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -36,6 +36,7 @@ from olympia.devhub import views
 from olympia.files.tests.test_models import UploadTest
 from olympia.files.utils import parse_addon
 from olympia.lib.akismet.models import AkismetReport
+from olympia.lib.git import AddonGitRepository
 from olympia.users.models import UserProfile
 from olympia.versions.models import License, VersionPreview
 from olympia.zadmin.models import Config, set_config
@@ -818,6 +819,29 @@ class TestAddonSubmitSource(TestSubmitBase):
         self.addon.update(type=amo.ADDON_DICT)
         response = self.client.get(self.url)
         self.assert3xx(response, self.next_url)
+
+    @override_settings(FILE_UPLOAD_MAX_MEMORY_SIZE=1)
+    @override_switch('enable-uploads-commit-to-git-storage', active=False)
+    def test_submit_source_doesnt_commit_to_git_by_default(self):
+        response = self.post(
+            has_source=True, source=self.generate_source_zip())
+        self.assert3xx(response, self.next_url)
+        self.addon = self.addon.reload()
+        assert self.get_version().source
+
+        repo = AddonGitRepository(self.addon.pk, package_type='source')
+        assert not os.path.exists(repo.git_repository_path)
+
+    @override_switch('enable-uploads-commit-to-git-storage', active=True)
+    def test_submit_source_commits_to_git(self):
+        response = self.post(
+            has_source=True, source=self.generate_source_zip())
+        self.assert3xx(response, self.next_url)
+        self.addon = self.addon.reload()
+        assert self.get_version().source
+
+        repo = AddonGitRepository(self.addon.pk, package_type='source')
+        assert os.path.exists(repo.git_repository_path)
 
 
 class DetailsPageMixin(object):

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -46,6 +46,7 @@ from olympia.devhub.utils import (
 from olympia.files.models import File, FileUpload, FileValidation
 from olympia.files.utils import parse_addon
 from olympia.lib.crypto.packaged import sign_file
+from olympia.lib.git import AddonGitRepository
 from olympia.reviewers.forms import PublicWhiteboardForm
 from olympia.reviewers.models import Whiteboard
 from olympia.reviewers.templatetags.jinja_helpers import get_position
@@ -1044,6 +1045,16 @@ def version_edit(request, addon_id, addon, version_id):
                     version_form.cleaned_data['source']):
                 AddonReviewerFlags.objects.update_or_create(
                     addon=addon, defaults={'needs_admin_code_review': True})
+
+                commit_to_git = waffle.switch_is_active(
+                    'enable-uploads-commit-to-git-storage')
+
+                if commit_to_git:
+                    # Extract into git repository
+                    AddonGitRepository.extract_and_commit_source_from_version(
+                        version=data['version_form'].instance,
+                        author=request.user)
+
                 if had_pending_info_request:
                     log_and_notify(amo.LOG.SOURCE_CODE_UPLOADED, None,
                                    request.user, version)
@@ -1427,6 +1438,7 @@ def _submit_source(request, addon, version, next_view):
         if form.cleaned_data.get('source'):
             AddonReviewerFlags.objects.update_or_create(
                 addon=addon, defaults={'needs_admin_code_review': True})
+
             activity_log = ActivityLog.objects.create(
                 action=amo.LOG.SOURCE_CODE_UPLOADED.id,
                 user=request.user,
@@ -1437,6 +1449,14 @@ def _submit_source(request, addon, version, next_view):
             VersionLog.objects.create(
                 version_id=latest_version.id, activity_log=activity_log)
             form.save()
+
+            # We can extract the actual source file only after the form
+            # has been saved because the file behind it may not have been
+            # written to disk yet (e.g for in-memory uploads)
+            if waffle.switch_is_active('enable-uploads-commit-to-git-storage'):
+                AddonGitRepository.extract_and_commit_source_from_version(
+                    version=form.instance, author=request.user)
+
         return redirect(next_view, *redirect_args)
     context = {
         'form': form,

--- a/src/olympia/files/tasks.py
+++ b/src/olympia/files/tasks.py
@@ -16,7 +16,6 @@ from olympia.files.models import (
 from olympia.files.utils import parse_xpi
 from olympia.translations.models import Translation
 from olympia.users.models import UserProfile
-from olympia.lib.git import AddonGitRepository
 
 
 log = olympia.core.logger.getLogger('z.files.task')
@@ -105,17 +104,3 @@ def update_webext_descriptions(url, locale='en-US', create=True, **kw):
                     except WebextPermissionDescription.DoesNotExist:
                         log.warning('No "%s" permission found to update with '
                                     '[%s] locale' % (perm, locale))
-
-
-@task
-def extract_file_obj_to_git(file_id, channel):
-    """Extract a `File` into our git storage backend."""
-    file_obj = File.objects.get(pk=file_id)
-
-    log.info('Extracting {file_id} into git backend'.format(file_id=file_id))
-
-    repo = AddonGitRepository.extract_and_commit_from_file_obj(
-        file_obj, channel)
-
-    log.info('Extracted {file_id} into {git_path}'.format(
-        file_id=file_id, git_path=repo.git_repository_path))

--- a/src/olympia/migrations/1063-add-source-git-hash-column.sql
+++ b/src/olympia/migrations/1063-add-source-git-hash-column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `versions` ADD COLUMN `source_git_hash` varchar(40) DEFAULT '' NOT NULL;

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -124,6 +124,7 @@ class Version(OnChangeMixin, ModelBase):
                                   default=amo.RELEASE_CHANNEL_LISTED)
 
     git_hash = models.CharField(max_length=40, blank=True)
+    source_git_hash = models.CharField(max_length=40, blank=True)
 
     # The order of those managers is very important: please read the lengthy
     # comment above the Addon managers declaration/instantiation.

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -255,10 +255,8 @@ class Version(OnChangeMixin, ModelBase):
 
         if waffle.switch_is_active('enable-uploads-commit-to-git-storage'):
             # Extract into git repository
-            AddonGitRepository.extract_and_commit_from_file_obj(
-                file_obj=version.all_files[0],
-                channel=channel,
-                author=upload.user)
+            AddonGitRepository.extract_and_commit_from_version(
+                version=version, author=upload.user)
 
         # Generate a preview and icon for listed static themes
         if (addon.type == amo.ADDON_STATICTHEME and


### PR DESCRIPTION
Fixes #9611

* Improves AddonGitRepository interface a bit to prepare for source
upload extraction
* Adds a new Version.source_git_hash field to store the current git hash
for source uploads
* Prepares in-request extraction behind a waffle-flag