### PR TITLE
remove trailing periods from tooltips

### DIFF
--- a/src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html
+++ b/src/olympia/devhub/templates/devhub/addons/ajax_compat_status.html
@@ -2,6 +2,6 @@
 {% set error_url = url('devhub.ajax.compat.error', addon.slug) %}
 <a class="tooltip {% if addon.incompatible_latest_apps() %}compat-error{% else %}compat-update{% endif %}"
    data-updateurl="{{ update_url }}" data-errorurl="{{ error_url }}" href="#"
-   title="{{ _('View and update application compatibility ranges.') }}">
+   title="{{ _('View and update application compatibility ranges') }}">
 {{ _('Compatibility') }}</a>
 

--- a/src/olympia/devhub/templates/devhub/addons/listing/item_actions.html
+++ b/src/olympia/devhub/templates/devhub/addons/listing/item_actions.html
@@ -8,7 +8,7 @@
         {% csrf_token %}
         <button
           class="link tooltip" type="submit"
-          title="{{ _("Resume the submission process for this add-on.")}}">
+          title="{{ _("Resume the submission process for this add-on")}}">
           {{ _('Resume') }}
         </button>
       </form>
@@ -27,14 +27,14 @@
   {% if check_addon_ownership(request, addon, dev=True) %}
     <li>
       <a href="{{ addon.get_dev_url() }}" class="tooltip"
-         title="{{ _("Edit details on this add-on's product page.") }}">
+         title="{{ _("Edit details on this add-on's product page") }}">
         {{ _('Edit Product Page') }}</a>
     </li>
     {% if not addon.is_disabled %}
       <li>
         {% set version_upload_url = url('devhub.submit.version', addon.slug) %}
         <a href="{{ version_upload_url }}" class="tooltip"
-           title="{{ _('Upload a new version of this add-on.') }}">
+           title="{{ _('Upload a new version of this add-on') }}">
           {{ _('New Version') }}</a>
       </li>
     {% endif %}
@@ -50,7 +50,7 @@
   {% if not addon.disabled_by_user and show_listed and addon.status == amo.STATUS_PUBLIC %}
     <li>
       <a href="{{ url('stats.overview', addon.slug) }}" class="tooltip"
-         title="{{ _('Daily statistics on downloads and users.') }}">
+         title="{{ _('Daily statistics on downloads and users') }}">
         {{ _('Statistics') }}</a>
     </li>
   {% endif %}

--- a/src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html
+++ b/src/olympia/devhub/templates/devhub/addons/listing/item_actions_theme.html
@@ -3,7 +3,7 @@
   {% if check_addon_ownership(request, addon, dev=True) %}
     <li>
       <a href="{{ addon.get_dev_url() }}" class="tooltip"
-         title="{{ _("Edit details on this theme's product page.") }}">
+         title="{{ _("Edit details on this theme's product page") }}">
         {{ _('Edit Product Page') }}</a>
     </li>
   {% endif %}
@@ -13,19 +13,19 @@
   </li>
   <li>
     <a href="{{ url('stats.usage', addon.slug) }}" class="tooltip"
-       title="{{ _("View the popularity of this theme over time.") }}">
+       title="{{ _("View the popularity of this theme over time") }}">
       {{ _('View Statistics') }}</a>
   </li>
   {% if check_addon_ownership(request, addon) %}
     <li>
       <a href="{{ addon.get_dev_url() }}#ownership" class="tooltip"
-         title="{{ _("Change the owner of this theme.") }}">
+         title="{{ _("Change the owner of this theme") }}">
         {{ _('Transfer Ownership') }}</a>
     </li>
     {% if addon.can_be_deleted() %}
       <li>
         <a href="#" class="delete-addon tooltip"
-           title="{{ _('Delete this theme.') }}">{{ _('Delete') }}</a>
+           title="{{ _('Delete this theme') }}">{{ _('Delete') }}</a>
         <div class="modal-delete modal hidden">
           {% include "devhub/addons/listing/delete_form.html" %}
         </div>

--- a/src/olympia/devhub/templates/devhub/includes/addon_details.html
+++ b/src/olympia/devhub/templates/devhub/includes/addon_details.html
@@ -48,7 +48,7 @@
 <li class="e10s-compatibility e10s-{{ addon.feature_compatibility.get_e10s_classname() }}">
   <strong>{{ _('Add-on Multi Process Status:') }}</strong>
   <b>{{ addon.feature_compatibility.get_e10s_display() }}</b>
-  <span class="tip tooltip" title="{{ _('Your add-on compatibility with Multi Process Firefox (e10s).') }}">?</span>
+  <span class="tip tooltip" title="{{ _('Your add-on compatibility with Multi Process Firefox (e10s)') }}">?</span>
 </li>
 {% endif %}
 
@@ -56,7 +56,7 @@
     {% if addon.has_unlisted_versions() %}
       <li class="distribution-tag-listed">
         <span class="distribution-tag-listed tooltip"
-              title="{{ _('Listed on this site after passing code review. Automatic updates are handled by this site.') }}"
+              title="{{ _('Listed on this site after passing code review. Automatic updates are handled by this site') }}"
               >AMO</span>
       </li>
     {% endif %}
@@ -72,7 +72,7 @@
         <a href="{{ addon.current_version.get_url_path() }}">{{ addon.current_version.version }}</a>
         <span class="tip tooltip" title="{{ _('This is the version of your add-on that will '
                                               'be installed if someone clicks the Install '
-                                              'button on addons.mozilla.org.') }}">?</span>
+                                              'button on addons.mozilla.org') }}">?</span>
       </li>
     {% endif %}
 
@@ -81,7 +81,7 @@
       <li>
         <strong>{{ _('Next Listed Version:') }}</strong>
         <a href="{{ addon.get_dev_url('versions') }}">{{ latest_listed_version.version }}</a>
-        <span class="tip tooltip" title="{{ _('This is the newest uploaded version, however it isn’t live on the site yet.') }}">?</span>
+        <span class="tip tooltip" title="{{ _('This is the newest uploaded version, however it isn’t live on the site yet') }}">?</span>
       </li>
     {% endif %}
 
@@ -119,6 +119,6 @@
     <li>
       <strong>{{ _('Latest Version:') }}</strong>
       {{ latest_unlisted_version.version }}
-      <span class="tip tooltip" title="{{ _('This is the newest uploaded unlisted version.') }}">?</span>
+      <span class="tip tooltip" title="{{ _('This is the newest uploaded unlisted version') }}">?</span>
     </li>
 {% endif %}

--- a/src/olympia/devhub/templates/devhub/personas/edit.html
+++ b/src/olympia/devhub/templates/devhub/personas/edit.html
@@ -265,10 +265,10 @@
         <h3 class="colors">{{ _('Select colors for your Theme.') }}</h3>
         <ul class="colors">
           {{ pretty_field(form.textcolor, label=_('Foreground Text'),
-                          tooltip=_('This is the color of the tab text.'),
+                          tooltip=_('This is the color of the tab text'),
                           validate=True) }}
           {{ pretty_field(form.accentcolor, label=_('Background'),
-                          tooltip=_('This is the color of the tabs.'),
+                          tooltip=_('This is the color of the tabs'),
                           validate=True) }}
         </ul>
       </fieldset>

--- a/src/olympia/devhub/templates/devhub/personas/submit.html
+++ b/src/olympia/devhub/templates/devhub/personas/submit.html
@@ -52,7 +52,7 @@
                             tooltip=_("A short explanation of your theme's "
                                       "basic functionality that is displayed in "
                                       "search and browse listings, as well as at "
-                                      "the top of your theme's details page."),
+                                      "the top of your theme's details page"),
                             tag=None, opt=True, validate=True) }}
             <div class="note">
               {{ some_html_tip() }}
@@ -85,10 +85,10 @@
         <h3>{{ _('Select colors for your Theme.') }}</h3>
         <ul class="colors">
           {{ pretty_field(form.textcolor, label=_('Foreground Text'),
-                          tooltip=_('This is the color of the tab text.'),
+                          tooltip=_('This is the color of the tab text'),
                           validate=True) }}
           {{ pretty_field(form.accentcolor, label=_('Background'),
-                          tooltip=_('This is the color of the tabs.'),
+                          tooltip=_('This is the color of the tabs'),
                           validate=True) }}
         </ul>
       </fieldset>


### PR DESCRIPTION
Fixes  #10056 
Remove trailing periods from tooltips following the localization guide
