### PR TITLE
Split selenium based docker-config into tests/ui/docker-compose.selenium.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -106,11 +106,11 @@ jobs:
             # Delete any existing uitest users within restmail. TEMP FIX: https://github.com/mozilla/addons-server/issues/8980
             wget --method=DELETE http://restmail.net/mail/uitest
             # mod user in firefox container
-            docker-compose exec selenium-firefox sudo usermod -u 1001 seluser
+            docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml exec selenium-firefox sudo usermod -u 1001 seluser
             # proper chown
             sudo chown -R $USER .
             # Start Test in Firefox docker container
-            docker-compose exec selenium-firefox tox -e ui-tests
+            docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml exec selenium-firefox tox -e ui-tests
       - store_artifacts:
           path: ui-test.html
       - save_cache:

--- a/circle.yml
+++ b/circle.yml
@@ -93,8 +93,8 @@ jobs:
           command: |
             set -x
             sudo sysctl -w vm.max_map_count=262144
-            docker-compose pull --quiet
-            docker-compose up -d
+            docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml pull --quiet
+            docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml up -d
             sleep 20
             docker-compose ps
             scripts/ui-test-hostname-setup.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,8 @@
 version: "2.3"
 
+# If you're changing the &env mapping
+# please make sure to update tests/ui/docker-compose.selenium.yml
+# accordingly.
 x-env-mapping: &env
   environment:
     - CELERY_BROKER_URL=amqp://olympia:olympia@rabbitmq/olympia
@@ -77,20 +80,6 @@ services:
 
   autograph:
     image: mozilla/autograph:2.3.0
-
-  selenium-firefox:
-    <<: *env
-    image: b4handjr/selenium-firefox
-    volumes:
-      - .:/code
-    expose:
-      - "4444"
-    ports:
-      - "5900"
-    shm_size: 2g
-    links:
-      - "addons-frontend:olympia-frontend.test"
-      - "nginx:olympia.test"
 
   addons-frontend:
     <<: *env

--- a/docs/topics/development/testing.rst
+++ b/docs/topics/development/testing.rst
@@ -82,7 +82,7 @@ the respective docker image, use the following command::
 
 Now, to run the selenium based tests outside of the docker container use the following command::
 
-    docker-compose exec --user root selenium-firefox tox -e ui-tests
+    docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml exec --user root selenium-firefox tox -e ui-tests
 
 WARNING: This will WIPE the database as the test will create specific data for itself to look for.
 If you have anything you don't want to be deleted, please do not run these tests.

--- a/docs/topics/development/testing.rst
+++ b/docs/topics/development/testing.rst
@@ -75,7 +75,12 @@ If you wish to re-run only the tests failed from the previous run::
 
 Selenium Integration Tests
 --------------------------
-To run the selenium based tests outside of the docker container use the following command::
+The selenium based tests require a separate docker-compose configuration, so to start
+the respective docker image, use the following command::
+
+    docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml up -d
+
+Now, to run the selenium based tests outside of the docker container use the following command::
 
     docker-compose exec --user root selenium-firefox tox -e ui-tests
 

--- a/tests/ui/README.md
+++ b/tests/ui/README.md
@@ -26,7 +26,7 @@ To run the tests, execute the commands below:
 ```sh
 # Make sure all required containers are running.
 docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml up -d
-docker-compose exec --user root selenium-firefox tox -e ui-tests
+docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml exec --user root selenium-firefox tox -e ui-tests
 ```
 WARNING: This will WIPE the database as the test will create specific data for itself to look for.
 If you have anything you don't want to be deleted, please do not run these tests.

--- a/tests/ui/README.md
+++ b/tests/ui/README.md
@@ -19,11 +19,13 @@ Follow the instructions found [here][addons-server-docs].
 
 *IMPORTANT* : Run the script in ```scripts/ui-test-hostname-setup.sh``` before running the test to setup the hostnames within the docker container.
 
-Included in the docker-compose file is an image containing Firefox Nightly. [tox][Tox]
+The selenium tests are included in a separate ``tests/ui/docker-compose.selenium.yml`` file. This image contains Firefox Nightly. [tox][Tox]
 is our test environment manager and [pytest][pytest] is the test runner.
 
-To run the tests, execute the command below:
+To run the tests, execute the commands below:
 ```sh
+# Make sure all required containers are running.
+docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml up -d
 docker-compose exec --user root selenium-firefox tox -e ui-tests
 ```
 WARNING: This will WIPE the database as the test will create specific data for itself to look for.
@@ -56,7 +58,7 @@ docker-compose ps
 ```
 If not start them detached:
 ```sh
-docker-compose up -d
+docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml up -d
 ```
 
 2. Copy the port that is forwarded for the ```selenium-firefox``` image:

--- a/tests/ui/docker-compose.selenium.yml
+++ b/tests/ui/docker-compose.selenium.yml
@@ -1,0 +1,31 @@
+version: "2.3"
+
+x-env-mapping: &env
+  environment:
+    - CELERY_BROKER_URL=amqp://olympia:olympia@rabbitmq/olympia
+    - CELERY_RESULT_BACKEND=redis://redis:6379/1
+    - DATABASES_DEFAULT_URL=mysql://root:@mysqld/olympia
+    - ELASTICSEARCH_LOCATION=elasticsearch:9200
+    - MEMCACHE_LOCATION=memcached:11211
+    - MYSQL_DATABASE=olympia
+    - MYSQL_ROOT_PASSWORD=docker
+    - OLYMPIA_SITE_URL=http://olympia.test
+    - PYTHONDONTWRITEBYTECODE=1
+    - PYTHONUNBUFFERED=1
+    - RECURSION_LIMIT=10000
+    - TERM=xterm-256color
+
+services:
+  selenium-firefox:
+    <<: *env
+    image: b4handjr/selenium-firefox
+    volumes:
+      - .:/code
+    expose:
+      - "4444"
+    ports:
+      - "5900"
+    shm_size: 2g
+    links:
+      - "addons-frontend:olympia-frontend.test"
+      - "nginx:olympia.test"


### PR DESCRIPTION
Unfortunately, we'll have to duplicate the environment config but I added
a comment so that should be fine. It's very rarely being used anyway.

Fixes #9288