### PR TITLE
Fix id locale and unify 404 templates a bit

### DIFF
--- a/locale/id/LC_MESSAGES/django.po
+++ b/locale/id/LC_MESSAGES/django.po
@@ -762,7 +762,7 @@ msgstr "Beranda Pengaya"
 #, python-format
 msgid "If you followed a link from somewhere, please %(open_bug_link)sfile an issue%(close_bug_link)s. Tell us where you came from and what you were looking for, and we'll do our best to fix it."
 msgstr ""
-"Jika Anda mengikuti tautan dari suatu tempat, harap%(open_bug_link)kirimkan masalah%(close_bug_link)s. Beritahu kami dari mana Anda berasal dan apa yang Anda cari, kami akan melakukan yang terbaik "
+"Jika Anda mengikuti tautan dari suatu tempat, harap %(open_bug_link)s kirimkan masalah%(close_bug_link)s. Beritahu kami dari mana Anda berasal dan apa yang Anda cari, kami akan melakukan yang terbaik "
 "untuk memperbaikinya."
 
 msgid "Not Found"

--- a/src/olympia/amo/templates/amo/404-responsive.html
+++ b/src/olympia/amo/templates/amo/404-responsive.html
@@ -34,7 +34,7 @@
       <p>
         {% trans open_bug_link='<a href="https://github.com/mozilla/addons/issues/new">'|safe, close_bug_link='</a>'|safe %}
         If you followed a link from somewhere, please {{ open_bug_link }}file
-        an issue{{ close_bug_link }}. Tell us where you came from and what you
+        an issue {{ close_bug_link }}. Tell us where you came from and what you
         were looking for, and we'll do our best to fix it.
         {% endtrans %}
       </p>

--- a/src/olympia/amo/templates/amo/404.html
+++ b/src/olympia/amo/templates/amo/404.html
@@ -3,7 +3,8 @@
 {% block title %}{{ _('Not Found') }}{% endblock %}
 
 {% block content %}
-{% trans rec=url('browse.extensions')|urlparams(sort='featured'), search=url('search.search'), home=url('home') %}
+{% trans rec=url('browse.extensions')|urlparams(sort='featured'), search=url('search.search'), home=url('home'),
+         open_bug_link='<a href="https://github.com/mozilla/addons/issues/new">'|safe, close_bug_link='</a>'|safe %}%}
 <h1>We're sorry, but we can't find what you're looking for.</h1>
 
 <p>
@@ -14,8 +15,7 @@
 <ul>
   <li>If you typed in the address, please double check the spelling.</li>
   <li>
-    If you followed a link from somewhere, please 
-    <a href="https://github.com/mozilla/addons-server/issues/new/">file an issue</a>.
+    If you followed a link from somewhere, please {{ open_bug_link }}file an issue{{ close_bug_link }}.
     Tell us where you came from and what you were looking for, and we'll do
     our best to fix it.
   </li>


### PR DESCRIPTION
This fixes the `id` locale and fixes / unifies our 404 templates a bit along the way.