### PR TITLE
Disable compat data editing for static themes.

### DIFF
--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -850,6 +850,22 @@ class TestVersionEditSearchEngine(TestVersionEditMixin, TestCase):
         assert not doc('a.add-file')
 
 
+class TestVersionEditStaticTheme(TestVersionEditBase):
+    def setUp(self):
+        super(TestVersionEditStaticTheme, self).setUp()
+        self.addon.update(type=amo.ADDON_STATICTHEME)
+
+    def test_no_compat(self):
+        response = self.client.get(self.url)
+        doc = pq(response.content)
+        assert not doc("#id_form-TOTAL_FORMS")
+
+    def test_no_upload(self):
+        response = self.client.get(self.url)
+        doc = pq(response.content)
+        assert not doc('a.add-file')
+
+
 class TestVersionEditCompat(TestVersionEditBase):
 
     def setUp(self):
@@ -989,3 +1005,8 @@ class TestVersionEditCompat(TestVersionEditBase):
         assert response.status_code == 302
         av = self.version.apps.all()[0]
         assert av.min == av.max
+
+    def test_statictheme_no_compat_edit(self):
+        """static themes don't allow users to overwrite compat data."""
+        addon = self.get_addon()
+        addon.update(type=amo.ADDON_STATICTHEME)

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -1004,7 +1004,7 @@ def version_edit(request, addon_id, addon, version_id):
     is_admin = acl.action_allowed(request,
                                   amo.permissions.REVIEWS_ADMIN)
 
-    if addon.accepts_compatible_apps():
+    if not static_theme and addon.accepts_compatible_apps():
         qs = version.apps.all()
         compat_form = forms.CompatFormSet(
             request.POST or None, queryset=qs,


### PR DESCRIPTION
Fixes #10189 

This simply disables editing the compat data but keeps all the compat data in the database that we extracted from the manifest during creation/upload.