### PR TITLE
Decode guid using base64 if prefixed by rta: in search API

### DIFF
--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -50,7 +50,7 @@ This endpoint allows you to search through public add-ons.
     :query boolean featured: Filter to only featured add-ons.  Only ``featured=true`` is supported.
         If ``app`` is provided as a parameter then only featured collections targeted to that application are taken into account.
         If ``lang`` is provided then only featured collections targeted to that language, (and collections for all languages), are taken into account. Both ``app`` and ``lang`` can be provided to filter to addons that are featured in collections that application and for that language, (and for all languages).
-    :query string guid: Filter by exact add-on guid. Multiple guids can be specified, separated by comma(s), in which case any add-ons matching any of the guids will be returned.  As guids are unique there should be at most one add-on result per guid specified.
+    :query string guid: Filter by exact add-on guid. Multiple guids can be specified, separated by comma(s), in which case any add-ons matching any of the guids will be returned.  As guids are unique there should be at most one add-on result per guid specified. For usage with Firefox, instead of separating multiple guids by comma(s), a single guid can be passed in base64url format, prefixed by the ``rta:`` string.
     :query string lang: Activate translations in the specific language for that query. (See :ref:`translated fields <api-overview-translations>`)
     :query int page: 1-based page number. Defaults to 1.
     :query int page_size: Maximum number of results to return for the requested page. Defaults to 25.

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1788,6 +1788,12 @@ DRF_API_GATES = {
     ),
 }
 
+# Return to AMO (https://bugzilla.mozilla.org/show_bug.cgi?id=1468680)
+# kill switch. RETURN_TO_AMO=0 env variable deactivates it, causing the API to
+# return 400s when the feature is used.
+RETURN_TO_AMO = env('RETURN_TO_AMO', default=True)
+
+
 # Change this to deactivate API throttling for views using a throttling class
 # depending on the one defined in olympia.api.throttling.
 API_THROTTLING = True

--- a/src/olympia/search/filters.py
+++ b/src/olympia/search/filters.py
@@ -1,4 +1,6 @@
+from django.conf import settings
 from django.utils import translation
+from django.utils.http import urlsafe_base64_decode
 from django.utils.translation import ugettext
 
 import colorgram
@@ -135,7 +137,23 @@ class AddonGuidQueryParam(AddonQueryParam):
     es_field = 'guid'
 
     def get_value(self):
-        value = self.request.GET.get(self.query_param)
+        value = self.request.GET.get(self.query_param, '')
+
+        # Hack for Firefox 'return to AMO' feature (which, sadly, does not use
+        # a specific API but rather encodes the guid and adds a prefix to it,
+        # only in the search API): if the guid param matches this format, and
+        # the feature is enabled through a setting, then we decode it and
+        # proceed. A 400 is returned if the format is recognized but the
+        # feature is disabled through the setting, acting as a kill-switch.
+        if value.startswith('rta:') and '@' not in value:
+            if settings.RETURN_TO_AMO is not True:
+                raise ValueError('RTA is currently disabled')
+            # Any ValueError will trigger a 400.
+            try:
+                value = urlsafe_base64_decode(value[4:])
+            except TypeError:
+                raise ValueError('Invalid RTA guid (not base64url?)')
+
         return value.split(',') if value else []
 
 


### PR DESCRIPTION
This supports the "Return to AMO" feature from [bug 1468680](https://bugzilla.mozilla.org/show_bug.cgi?id=1468680).

Fix mozilla/addons#6258