### PR TITLE
Fix search by color for extreme luminosity values, and bump min ratio required

### DIFF
--- a/src/olympia/search/tests/test_filters.py
+++ b/src/olympia/search/tests/test_filters.py
@@ -789,45 +789,52 @@ class TestSearchParameterFilter(FilterTestsBase):
         filter_ = qs['query']['bool']['filter']
         assert len(filter_) == 1
         inner = filter_[0]['nested']['query']['bool']['filter']
-        assert len(inner) == 2
+        assert len(inner) == 4
         assert inner == [
+            {'range': {'colors.s': {'gt': 6.375}}},
+            {'range': {'colors.l': {'gt': 12.75, 'lt': 249.9}}},
             {'bool': {'should': [
                 {'range': {'colors.h': {'gte': 229}}},
                 {'range': {'colors.h': {'lte': 26}}}]}},
-            {'range': {'colors.ratio': {'gte': 0.2}}},
+            {'range': {'colors.ratio': {'gte': 0.25}}},
         ]
 
         qs = self._filter(data={'color': '703839'})
         filter_ = qs['query']['bool']['filter']
         assert len(filter_) == 1
         inner = filter_[0]['nested']['query']['bool']['filter']
-        assert len(inner) == 2
+        assert len(inner) == 4
         assert inner == [
+            {'range': {'colors.s': {'gt': 6.375}}},
+            {'range': {'colors.l': {'gt': 12.75, 'lt': 249.9}}},
             {'bool': {'should': [
                 {'range': {'colors.h': {'gte': 228}}},
                 {'range': {'colors.h': {'lte': 25}}}]}},
-            {'range': {'colors.ratio': {'gte': 0.2}}},
+            {'range': {'colors.ratio': {'gte': 0.25}}},
         ]
 
         qs = self._filter(data={'color': '#00ffff'})
         filter_ = qs['query']['bool']['filter']
         assert len(filter_) == 1
         inner = filter_[0]['nested']['query']['bool']['filter']
-        assert len(inner) == 2
+        assert len(inner) == 4
         assert inner == [
+            {'range': {'colors.s': {'gt': 6.375}}},
+            {'range': {'colors.l': {'gt': 12.75, 'lt': 249.9}}},
             {'range': {'colors.h': {'gte': 101, 'lte': 153}}},
-            {'range': {'colors.ratio': {'gte': 0.2}}},
+            {'range': {'colors.ratio': {'gte': 0.25}}},
         ]
 
+    def test_search_by_color_grey(self):
         qs = self._filter(data={'color': '#f6f6f6'})
         filter_ = qs['query']['bool']['filter']
         assert len(filter_) == 1
         inner = filter_[0]['nested']['query']['bool']['filter']
         assert len(inner) == 3
         assert inner == [
-            {'range': {'colors.s': {'lte': 5}}},
+            {'range': {'colors.s': {'lte': 6.375}}},
             {'range': {'colors.l': {'gte': 182, 'lte': 255}}},
-            {'range': {'colors.ratio': {'gte': 0.2}}},
+            {'range': {'colors.ratio': {'gte': 0.25}}},
         ]
 
         qs = self._filter(data={'color': '333'})
@@ -836,9 +843,30 @@ class TestSearchParameterFilter(FilterTestsBase):
         inner = filter_[0]['nested']['query']['bool']['filter']
         assert len(inner) == 3
         assert inner == [
-            {'range': {'colors.s': {'lte': 5}}},
+            {'range': {'colors.s': {'lte': 6.375}}},
             {'range': {'colors.l': {'gte': 0, 'lte': 115}}},
-            {'range': {'colors.ratio': {'gte': 0.2}}},
+            {'range': {'colors.ratio': {'gte': 0.25}}},
+        ]
+
+    def test_search_by_color_luminosity_extremes(self):
+        qs = self._filter(data={'color': '080603'})
+        filter_ = qs['query']['bool']['filter']
+        assert len(filter_) == 1
+        inner = filter_[0]['nested']['query']['bool']['filter']
+        assert len(inner) == 2
+        assert inner == [
+            {'range': {'colors.l': {'lte': 12.75}}},
+            {'range': {'colors.ratio': {'gte': 0.25}}},
+        ]
+
+        qs = self._filter(data={'color': 'FEFDFB'})
+        filter_ = qs['query']['bool']['filter']
+        assert len(filter_) == 1
+        inner = filter_[0]['nested']['query']['bool']['filter']
+        assert len(inner) == 2
+        assert inner == [
+            {'range': {'colors.l': {'gte': 249.9}}},
+            {'range': {'colors.ratio': {'gte': 0.25}}},
         ]
 
 


### PR DESCRIPTION
Regardless of saturation and hue, super low/high values of luminosity are basically black/white. In addition, some previews can get a ratio of 20% of one color a bit too easily because of the urlbar, so bump that to 25%.

Another follow-up to #10220