### PR TITLE
Return 400 for guids in invalid format in return to AMO

### DIFF
--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -2885,7 +2885,21 @@ class TestAddonSearchView(ESTestCase):
 
         data = self.perform_search(
             self.url, {'guid': param}, expected_status=400)
-        assert data == [u'Invalid RTA guid (not base64url?)']
+        assert data == [u'Invalid RTA guid (not in base64url format?)']
+
+    def test_filter_by_guid_return_to_amo_garbage(self):
+        # 'garbage' does decode using base64, but would lead to an
+        # UnicodeDecodeError - invalid start byte.
+        param = 'rta:garbage'
+        data = self.perform_search(
+            self.url, {'guid': param}, expected_status=400)
+        assert data == [u'Invalid RTA guid (not in base64url format?)']
+
+        # Empty param is just as bad.
+        param = 'rta:'
+        data = self.perform_search(
+            self.url, {'guid': param}, expected_status=400)
+        assert data == [u'Invalid RTA guid (not in base64url format?)']
 
     @override_settings(RETURN_TO_AMO=False)
     def test_filter_by_guid_return_to_amo_feature_disabled(self):

--- a/src/olympia/search/filters.py
+++ b/src/olympia/search/filters.py
@@ -151,8 +151,10 @@ class AddonGuidQueryParam(AddonQueryParam):
             # Any ValueError will trigger a 400.
             try:
                 value = urlsafe_base64_decode(value[4:])
-            except TypeError:
-                raise ValueError('Invalid RTA guid (not base64url?)')
+                if not amo.ADDON_GUID_PATTERN.match(value):
+                    raise ValueError()
+            except (TypeError, ValueError):
+                raise ValueError('Invalid RTA guid (not in base64url format?)')
 
         return value.split(',') if value else []
 


### PR DESCRIPTION
Fix #10244 

This also fixes something @eviljeff noticed, this feature should only work with single guids. It was previously possible to base64encode multiple guids separated by commas, since we pass the decoded string down to the rest of the filter, but now with the validation in place this is also prevented.