### PR TITLE
Revert "Temporarily re-enable static theme migration for LWT updates on dev"

### DIFF
--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -147,5 +147,3 @@ FXA_SQS_AWS_QUEUE_URL = (
     'amo-account-change-dev')
 
 VAMO_URL = 'https://versioncheck-dev.allizom.org'
-
-MIGRATED_LWT_UPDATES_ENABLED = True  # Temporarily enabled for #10246


### PR DESCRIPTION
Reverts mozilla/addons-server#10247, testing is complete.