### PR TITLE
Don't override privacy policy when editing add-on details

### DIFF
--- a/src/olympia/devhub/templates/devhub/addons/submit/describe.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/describe.html
@@ -196,20 +196,20 @@
       </div>
     {% endif %}
     {% if addon.type != amo.ADDON_STATICTHEME %}
-      {% set values = form.data if form.is_bound else form.initial %}
+      {% set policy_form_data = policy_form.data if policy_form.is_bound else policy_form.initial %}
       <div class="optional-terms">
         <div class="addon-submission-field">
-          {{ form.has_priv }}
-          {{ form.has_priv.label_tag() }}
+          {{ policy_form.has_priv }}
+          {{ policy_form.has_priv.label_tag() }}
           <span class="tip tooltip"
             title="{{ _("If your add-on transmits any data from the user's computer, "
                         "a privacy policy is required that explains what data is sent "
                         "and how it is used.")
                   }}">?</span>
-          <div class="priv {{ 'hidden' if not values.has_priv }}">
-            {{ form.privacy_policy.errors }}
-            {{ form.privacy_policy.label_tag() }}
-            {{ form.privacy_policy }}
+          <div class="priv {{ 'hidden' if not policy_form_data.has_priv }}">
+            {{ policy_form.privacy_policy.errors }}
+            {{ policy_form.privacy_policy.label_tag() }}
+            {{ policy_form.privacy_policy }}
           </div>
         </div>
       </div>

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -771,6 +771,20 @@ class TestEditDescribeListed(BaseTestEditDescribe, L10nTestsMixin):
         doc = pq(response.content)
         assert doc('#trans-description textarea').attr('minlength') == '10'
 
+    def test_edit_description_does_not_affect_privacy_policy(self):
+        # Regression test for #10229
+        addon = self.get_addon()
+        addon.privacy_policy = u'My polïcy!'
+        addon.save()
+        data = self.get_dict(description=u'Sométhing descriptive.')
+        response = self.client.post(self.describe_edit_url, data)
+        assert response.status_code == 200
+        addon = Addon.objects.get(pk=addon.pk)
+        assert addon.privacy_policy_id
+        assert addon.privacy_policy == u'My polïcy!'
+        assert addon.description_id
+        assert addon.description == u'Sométhing descriptive.'
+
 
 class TestEditDescribeUnlisted(BaseTestEditDescribe, L10nTestsMixin):
     listed = False

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -1517,11 +1517,20 @@ def _submit_details(request, addon, version):
         cat_form_class = (addon_forms.CategoryFormSet if not static_theme
                           else forms.SingleCategoryForm)
         cat_form = cat_form_class(post_data, addon=addon, request=request)
+        policy_form = forms.PolicyForm(post_data, addon=addon)
         license_form = forms.LicenseForm(
             post_data, version=latest_version, prefix='license')
         context.update(license_form.get_context())
-        context.update(form=describe_form, cat_form=cat_form)
-        forms_list.extend([describe_form, cat_form, context['license_form']])
+        context.update(
+            form=describe_form,
+            cat_form=cat_form,
+            policy_form=policy_form)
+        forms_list.extend([
+            describe_form,
+            cat_form,
+            policy_form,
+            context['license_form']
+        ])
     if not static_theme:
         # Static themes don't need this form
         reviewer_form = forms.VersionForm(
@@ -1534,6 +1543,7 @@ def _submit_details(request, addon, version):
         if show_all_fields:
             addon = describe_form.save()
             cat_form.save()
+            policy_form.save()
             license_form.save(log=False)
             if not static_theme:
                 reviewer_form.save()


### PR DESCRIPTION
Instead of trying to replicate `PolicyForm` behavior in `DescribeForm` (which was broken when using it in the edit page, because it does not have the privacy policy field), have the submit step instantiate
the actual `PolicyForm` and remove all special handling of the privacy policy in `DescribeForm`

Fix #10229