### PR TITLE
Don't explicitly install npm, update Python to 2.7.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7.14-slim-stretch
+FROM python:2.7.15-slim-stretch
 
 ENV PYTHONDONTWRITEBYTECODE=1
 
@@ -31,7 +31,6 @@ RUN apt-get update && apt-get install -y \
         python-dev \
         python-pip \
         nodejs \
-        npm \
         # Git, because we're using git-checkout dependencies
         git \
         # Dependencies for mysql-python


### PR DESCRIPTION
Our docker builds were broken because of some inter-dependency weirdness
going on when you're installing npm and nodejs in one apt-get call. To
be honest I was too lazy to look up the actual root cause given the fix
is quite simple and npm is part of nodejs anyway.

This PR updates the Python version to 2.7.15 along the way.
