### PR TITLE
Force pygit2 global search path to be set to HOME environment variable.

### DIFF
--- a/src/olympia/lib/git.py
+++ b/src/olympia/lib/git.py
@@ -66,6 +66,16 @@ class AddonGitRepository(object):
     def __init__(self, addon_id, package_type='package'):
         assert package_type in ('package', 'source')
 
+        # Always enforce the search path being set to the configured
+        # HOME environment variable. We are setting this here to avoid
+        # creating a unnecessary global state but since this is overwriting
+        # a global value in pygit2 it affects all pygit2 calls.
+
+        # https://github.com/libgit2/pygit2/issues/339
+        # https://github.com/libgit2/libgit2/issues/2122
+        home = os.path.expanduser('~')
+        pygit2.settings.search_path[pygit2.GIT_CONFIG_LEVEL_GLOBAL] = home
+
         self.git_repository_path = os.path.join(
             settings.GIT_FILE_STORAGE_PATH,
             id_to_path(addon_id),

--- a/src/olympia/lib/tests/test_git.py
+++ b/src/olympia/lib/tests/test_git.py
@@ -3,6 +3,7 @@ import subprocess
 import zipfile
 
 import pytest
+import pygit2
 import mock
 
 from django.conf import settings
@@ -36,6 +37,22 @@ def test_temporary_worktree():
     assert not os.path.exists(worktree.temp_directory)
     output = subprocess.check_output('git worktree list', shell=True, env=env)
     assert worktree.name not in output
+
+
+def test_enforce_pygit_global_search_path_to_home():
+    # https://github.com/mozilla/addons-server/issues/10320
+    pygit2.settings.search_path[pygit2.GIT_CONFIG_LEVEL_GLOBAL] = '/root'
+
+    assert (
+        pygit2.settings.search_path[pygit2.GIT_CONFIG_LEVEL_GLOBAL] ==
+        '/root')
+
+    os.environ['HOME'] = settings.GIT_FILE_STORAGE_PATH
+    repo = AddonGitRepository(1)
+
+    assert (
+        pygit2.settings.search_path[pygit2.GIT_CONFIG_LEVEL_GLOBAL] ==
+        settings.GIT_FILE_STORAGE_PATH)
 
 
 def test_git_repo_init():


### PR DESCRIPTION
It's a bit problematic since there isn't a real good default value since
it depends on how the app is hosted, if `HOME` is set correctly and many
other circumstances. Let's enforce it to be the users home to make sure
we are accessing a directory that we have the permissions to.

Fixes #10320
