### PR TITLE
don't add re.L (re.LOCALE) flag for regexs in python3

### DIFF
--- a/src/olympia/ratings/forms.py
+++ b/src/olympia/ratings/forms.py
@@ -1,4 +1,5 @@
 import re
+import six
 
 from six.moves.urllib.parse import unquote
 
@@ -42,7 +43,8 @@ class RatingForm(RatingReplyForm):
     rating = forms.ChoiceField(
         zip(range(1, 6), range(1, 6)), label=_(u'Rating')
     )
-    flags = re.I | re.L | re.U | re.M
+    # re.L flag has been removed in py3.6 for text_type strings.
+    flags = (re.I | re.L | re.U | re.M) if six.PY2 else (re.I | re.U | re.M)
     # This matches the following three types of patterns:
     # http://... or https://..., generic domain names, and IPv4
     # octets. It does not match IPv6 addresses or long strings such as


### PR DESCRIPTION
fixes #10349 
but it's kinda difficult to tell as it just exposes other test fails.
https://travis-ci.org/eviljeff/olympia/jobs/477334678 had the fails mentioning re.LOCALE and now https://travis-ci.org/eviljeff/olympia/jobs/477365985 doesn't.