### PR TITLE
Make sure generate_jsi18n_files can run without a database configured

### DIFF
--- a/src/olympia/amo/management/commands/generate_jsi18n_files.py
+++ b/src/olympia/amo/management/commands/generate_jsi18n_files.py
@@ -10,6 +10,7 @@ from django.views.i18n import javascript_catalog
 
 class Command(BaseCommand):
     help = 'Generate static jsi18n files for each locale we support'
+    requires_system_checks = False  # Can be ran without the database up yet.
 
     def handle(self, *args, **options):
         fake_request = HttpRequest()


### PR DESCRIPTION
Follow-up fix for #9861 - we need to run this command at deploy time without a database configured.