### PR TITLE
Update settings to point recommendation engine url to the new TAAR

### DIFF
--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -121,7 +121,7 @@ ES_DEFAULT_NUM_SHARDS = 10
 
 RECOMMENDATION_ENGINE_URL = env(
     'RECOMMENDATION_ENGINE_URL',
-    default='https://taar.prod.mozaws.net/api/recommendations/')
+    default='https://taar.prod.mozaws.net/v1/api/recommendations/')
 
 TAAR_LITE_RECOMMENDATION_ENGINE_URL = env(
     'TAAR_LITE_RECOMMENDATION_ENGINE_URL',

--- a/src/olympia/discovery/tests/test_utils.py
+++ b/src/olympia/discovery/tests/test_utils.py
@@ -111,7 +111,7 @@ def test_get_disco_recommendations(call_recommendation_server):
     ]
     recommendations = get_disco_recommendations('0', [])
     call_recommendation_server.assert_called_with(
-        'https://taar.dev.mozaws.net/api/recommendations/', '0', None,
+        'https://taar.dev.mozaws.net/v1/api/recommendations/', '0', None,
         verb='post')
     assert [result.addon for result in recommendations] == expected_addons
 
@@ -133,7 +133,7 @@ def test_get_disco_recommendations_empty(call_recommendation_server):
     recommendations = get_disco_recommendations('0', [])
     assert recommendations == []
     call_recommendation_server.assert_called_with(
-        'https://taar.dev.mozaws.net/api/recommendations/', '0', None,
+        'https://taar.dev.mozaws.net/v1/api/recommendations/', '0', None,
         verb='post')
 
 
@@ -154,7 +154,7 @@ def test_get_disco_recommendations_overrides(call_recommendation_server):
         }
     }
     call_recommendation_server.assert_called_with(
-        'https://taar.dev.mozaws.net/api/recommendations/', 'xxx', data,
+        'https://taar.dev.mozaws.net/v1/api/recommendations/', 'xxx', data,
         verb='post')
 
 

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1834,7 +1834,7 @@ CRON_JOBS = {
 
 RECOMMENDATION_ENGINE_URL = env(
     'RECOMMENDATION_ENGINE_URL',
-    default='https://taar.dev.mozaws.net/api/recommendations/')
+    default='https://taar.dev.mozaws.net/v1/api/recommendations/')
 TAAR_LITE_RECOMMENDATION_ENGINE_URL = env(
     'TAAR_LITE_RECOMMENDATION_ENGINE_URL',
     default=('https://taar.dev.mozaws.net/taarlite/api/v1/'


### PR DESCRIPTION
The old URL didn't have the v1/ part in it, but the new one does.

Fix #10174