### PR TITLE
split fully working python3 jobs from non-working jobs into different stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 jobs:
   fast_finish: true
   allow_failures:
-    - python: 3.6
+    - stage: python3
   include:
     - { stage: python2, env: TOXENV=codestyle }
     - { stage: python2, env: TOXENV=docs }
@@ -18,8 +18,8 @@ jobs:
     - { stage: python2, env: TOXENV=amo-locales-and-signing }
     - { stage: python2, env: TOXENV=users-accounts-and-ratings }
     - { stage: python2, env: TOXENV=main }
-    - { stage: python3, python: 3.6, env: TOXENV=codestyle}
-    - { stage: python3, python: 3.6, env: TOXENV=docs }
+    - { stage: python3working, python: 3.6, env: TOXENV=codestyle}
+    - { stage: python3working, python: 3.6, env: TOXENV=docs }
     - { stage: python3, python: 3.6, env: TOXENV=assets }
     - { stage: python3, python: 3.6, env: TOXENV=es }
     - { stage: python3, python: 3.6, env: TOXENV=addons }


### PR DESCRIPTION
to stop us from inadvertently regressing fully working python3 jobs