### PR TITLE
Create a separate web3 container, a Python 3 variant of the web container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,17 @@ services:
     <<: *worker
     command: supervisord -n -c /code/docker/supervisor.conf
 
+  web3:
+    extends:
+      service: web
+    # This container is only for running unit tests under python3 atm, so give
+    # it a dummy command so that it doesn't exit, but don't let it run
+    # supervisord as normal - we don't want the webserver.
+    command: /usr/bin/tail -f /dev/null
+    environment:
+      - PYTHON_VERSION_MAJOR=3
+
+
   nginx:
     image: addons/addons-nginx
     volumes:


### PR DESCRIPTION
This doesn't run services yet, and is just useful to run tests. Because it shares the same image as the regular web container, an initial `make update_deps` is necessary to get it working. After that, running `pytest` as normal should function normally and be using Python 3.

Note: to use, make sure your `addons-server` image is up to date, then simply run `docker-compose up -d` as normal. Then you'll have a new `web3` container and you can follow the instructions above to run Python 3 in it.

Fixes #10385