### PR TITLE
Remove explicit rss link to blog.mozilla.org feed.

### DIFF
--- a/src/olympia/devhub/templates/devhub/includes/blog_posts.html
+++ b/src/olympia/devhub/templates/devhub/includes/blog_posts.html
@@ -1,9 +1,6 @@
 <div class="blog-posts item">
   <h3>
     {{ _('Developer News') }}
-    <a title="{{ _('Subscribe to this feed') }}" class="subscribe-feed"
-       href="http://blog.mozilla.com/addons/feed/">
-      {{ _('Subscribe to this feed') }}</a>
   </h3>
   <ul class="blog-container">
     {% for post in blog_posts %}

--- a/src/olympia/devhub/templates/devhub/new-landing/components/blog_posts.html
+++ b/src/olympia/devhub/templates/devhub/new-landing/components/blog_posts.html
@@ -1,9 +1,5 @@
 <section class="DevHub-BlogPosts content scheme-dark">
-  <h2>
-    <a title="{{ _('Subscribe to this feed') }}" href="https://blog.mozilla.com/addons/feed/">
-      {{ _('Latest News') }}
-    </a>
-  </h2>
+  <h2>{{ _('Latest News') }}</h2>
   {% if blog_posts.exists() %}
     <ul>
       {% for post in blog_posts %}


### PR DESCRIPTION
There are other places on AMO where we explicitly use a separate link to
make the user subscribe to the RSS feed so those should be fine.

Fixes #10439

We could do a separate link like in other places like
<img src="https://user-images.githubusercontent.com/139033/51370506-a5a7e980-1af7-11e9-9c65-74a6c5428ba0.png" width=280>
but for that we'll need a new icon :see_no_evil: 

Opinions? cc @jvillalobos 