### PR TITLE
Call generate_jsi18n_files on `make update_assets`.

### DIFF
--- a/Makefile-docker
+++ b/Makefile-docker
@@ -143,6 +143,7 @@ update_assets:
 	# If changing this here, make sure to adapt tests in amo/test_commands.py
 	$(PYTHON_COMMAND) manage.py compress_assets
 	$(PYTHON_COMMAND) manage.py collectstatic --noinput
+	$(PYTHON_COMMAND) manage.py generate_jsi18n_files
 
 update: update_deps update_db update_assets
 	$(PYTHON_COMMAND) manage.py update_permissions_from_mc

--- a/circle.yml
+++ b/circle.yml
@@ -100,9 +100,9 @@ jobs:
             docker-compose ps
             scripts/ui-test-hostname-setup.sh
             # Make sure dependencies get updated in worker and web container
-            docker-compose exec worker make -f Makefile-docker update_deps
+            docker-compose exec worker make -f Makefile-docker update_deps update_assets
             docker-compose restart worker
-            docker-compose exec web make -f Makefile-docker update_deps
+            docker-compose exec web make -f Makefile-docker update_deps update_assets
             docker-compose restart web
             # Delete any existing uitest users within restmail. TEMP FIX: https://github.com/mozilla/addons-server/issues/8980
             wget --method=DELETE http://restmail.net/mail/uitest


### PR DESCRIPTION
Fixes #10438 and thus local docker instances and circleci tests.
