### PR TITLE
Use latest-py3 tag in docker-compose instead of a separate image name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
   web3:
     extends:
       service: web
-    image: addons/addons-server-py3
+    image: addons/addons-server:latest-py3
     # This container is only for running unit tests under python3 atm, so give
     # it a dummy command so that it doesn't exit, but don't let it run
     # supervisord as normal - we don't want the webserver.


### PR DESCRIPTION
Follow-up for #10472 - it turns out it's easier to just have docker hub build a separate tag of the same repo.