### PR TITLE
Remove idna dependency, it's not used anymore.

### DIFF
--- a/requirements/system.txt
+++ b/requirements/system.txt
@@ -74,10 +74,6 @@ enum34==1.1.6 \
     --hash=sha256:8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1 \
     --hash=sha256:2d81cbbe0e73112bdfe6ef8576f2238f2ba27dd0d55752a776c41d38b7da2850 \
     --hash=sha256:644837f692e5f550741432dd3f223bbb9852018674981b1664e5dc339387588a
-# idna is required by cryptography
-idna==2.8 \
-    --hash=sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c \
-    --hash=sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407
 # ipaddress is required by cryptography, docker-py
 ipaddress==1.0.22 \
     --hash=sha256:64b28eec5e78e7510698f6d4da08800a5c575caa4a286c93d651c5d3ff7b6794 \


### PR DESCRIPTION
With https://github.com/mozilla/addons-server/pull/10488 we don't have
to depend on idna being installed anymore.
