### PR TITLE
Use utf8mb4 for stage MySQL connections

### DIFF
--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -44,8 +44,10 @@ INBOUND_EMAIL_DOMAIN = env('INBOUND_EMAIL_DOMAIN',
                            default='addons.allizom.org')
 
 DATABASES = {
-    'default': get_db_config('DATABASES_DEFAULT_URL'),
-    'slave': get_db_config('DATABASES_SLAVE_URL', atomic_requests=False),
+    'default': get_db_config('DATABASES_DEFAULT_URL', charset='utf8mb4'),
+    'slave': get_db_config(
+        'DATABASES_SLAVE_URL', atomic_requests=False, charset='utf8mb4',
+    ),
 }
 
 SERVICES_DATABASE = get_db_config('SERVICES_DATABASE_URL')


### PR DESCRIPTION
The -stage database was just migrated to utf8mb4, so this can be enabled.
