### PR TITLE
Move Return to AMO kill switch to a waffle switch

### DIFF
--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -18,6 +18,7 @@ from elasticsearch import Elasticsearch
 from mock import patch
 from pyquery import PyQuery as pq
 from rest_framework.test import APIRequestFactory
+from waffle import switch_is_active
 from waffle.testutils import override_switch
 
 from olympia import amo
@@ -2181,6 +2182,8 @@ class TestAddonSearchView(ESTestCase):
     def setUp(self):
         super(TestAddonSearchView, self).setUp()
         self.url = reverse_ns('addon-search')
+        self.create_switch('return-to-amo', active=True)
+        switch_is_active('return-to-amo')
 
     def tearDown(self):
         super(TestAddonSearchView, self).tearDown()
@@ -2901,8 +2904,9 @@ class TestAddonSearchView(ESTestCase):
             self.url, {'guid': param}, expected_status=400)
         assert data == [u'Invalid RTA guid (not in base64url format?)']
 
-    @override_settings(RETURN_TO_AMO=False)
     def test_filter_by_guid_return_to_amo_feature_disabled(self):
+        self.create_switch('return-to-amo', active=False)
+        assert not switch_is_active('return-to-amo')
         addon = addon_factory(slug='my-addon', name=u'My Addôn',
                               guid='random@guid', weekly_downloads=999)
         addon_factory()

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1705,12 +1705,6 @@ DRF_API_GATES = {
     ),
 }
 
-# Return to AMO (https://bugzilla.mozilla.org/show_bug.cgi?id=1468680)
-# kill switch. RETURN_TO_AMO=0 env variable deactivates it, causing the API to
-# return 400s when the feature is used.
-RETURN_TO_AMO = env('RETURN_TO_AMO', default=True)
-
-
 # Change this to deactivate API throttling for views using a throttling class
 # depending on the one defined in olympia.api.throttling.
 API_THROTTLING = True

--- a/src/olympia/migrations/1072-add-return-to-amo-waffle-switch.sql
+++ b/src/olympia/migrations/1072-add-return-to-amo-waffle-switch.sql
@@ -1,0 +1,2 @@
+INSERT INTO waffle_switch (name, active, note, created, modified)
+       VALUES ('return-to-amo', 0, 'Return to AMO kill switch.', NOW(), NOW());

--- a/src/olympia/search/filters.py
+++ b/src/olympia/search/filters.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.utils import translation
 from django.utils.encoding import force_text
 from django.utils.http import urlsafe_base64_decode
@@ -8,6 +7,7 @@ import colorgram
 from elasticsearch_dsl import Q, query
 from rest_framework import serializers
 from rest_framework.filters import BaseFilterBackend
+from waffle import switch_is_active
 
 from olympia import amo
 from olympia.constants.categories import CATEGORIES, CATEGORIES_BY_ID
@@ -152,7 +152,7 @@ class AddonGuidQueryParam(AddonQueryParam):
         # turned into 400 responses and this acts as a kill-switch for the
         # feature in Firefox.
         if value.startswith('rta:') and '@' not in value:
-            if settings.RETURN_TO_AMO is not True:
+            if not switch_is_active('return-to-amo'):
                 raise ValueError('RTA is currently disabled')
             try:
                 value = force_text(urlsafe_base64_decode(value[4:]))


### PR DESCRIPTION
Now that we are making a database request anyway to validate that the is part of the curated list, might as well bite the bullet and the kill switch for the feature a regular waffle switch. This make it easier to turn on and off, and will therefore simplify life of QA.

Fix #10557