### PR TITLE
Remove our own atomic decorator, run create_version_for_upload in 'read committed'

### DIFF
--- a/src/olympia/amo/decorators.py
+++ b/src/olympia/amo/decorators.py
@@ -5,7 +5,6 @@ import json
 from django import http
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
-from django.db import connection, transaction
 
 import olympia.core.logger
 

--- a/src/olympia/devhub/tasks.py
+++ b/src/olympia/devhub/tasks.py
@@ -29,7 +29,7 @@ import olympia.core.logger
 from olympia import amo
 from olympia.addons.models import Addon, Persona, Preview
 from olympia.amo.celery import task
-from olympia.amo.decorators import atomic, set_modified_on, use_primary_db
+from olympia.amo.decorators import set_modified_on, use_primary_db
 from olympia.amo.urlresolvers import reverse
 from olympia.amo.utils import (
     image_size, pngcrush_image, resize_image, send_html_mail_jinja, send_mail,
@@ -111,7 +111,7 @@ def submit_file(addon_pk, upload_pk, channel):
                  'validation'.format(upload_uuid=upload.uuid))
 
 
-@atomic
+@transaction.atomic
 def create_version_for_upload(addon, upload, channel):
     """Note this function is only used for API uploads."""
     fileupload_exists = addon.fileupload_set.filter(

--- a/src/olympia/devhub/tests/test_tasks.py
+++ b/src/olympia/devhub/tests/test_tasks.py
@@ -825,8 +825,6 @@ class TestCreateVersionForUpload(TestCase):
     def setUp(self):
         super(TestCreateVersionForUpload, self).setUp()
         self.addon = Addon.objects.get(pk=3615)
-        self.create_version_for_upload = (
-            tasks.create_version_for_upload.non_atomic)
         self.mocks = {}
         for key in ['Version.from_upload', 'parse_addon']:
             patcher = mock.patch('olympia.devhub.tasks.%s' % key)
@@ -845,13 +843,13 @@ class TestCreateVersionForUpload(TestCase):
         newer_upload.update(created=datetime.today() + timedelta(hours=1))
 
         # Check that the older file won't turn into a Version.
-        self.create_version_for_upload(self.addon, upload,
-                                       amo.RELEASE_CHANNEL_LISTED)
+        tasks.create_version_for_upload(self.addon, upload,
+                                        amo.RELEASE_CHANNEL_LISTED)
         assert not self.mocks['Version.from_upload'].called
 
         # But the newer one will.
-        self.create_version_for_upload(self.addon, newer_upload,
-                                       amo.RELEASE_CHANNEL_LISTED)
+        tasks.create_version_for_upload(self.addon, newer_upload,
+                                        amo.RELEASE_CHANNEL_LISTED)
         self.mocks['Version.from_upload'].assert_called_with(
             newer_upload, self.addon, [amo.FIREFOX.id, amo.ANDROID.id],
             amo.RELEASE_CHANNEL_LISTED,
@@ -862,8 +860,8 @@ class TestCreateVersionForUpload(TestCase):
         Version.objects.create(addon=upload.addon, version=upload.version)
 
         # Check that the older file won't turn into a Version.
-        self.create_version_for_upload(self.addon, upload,
-                                       amo.RELEASE_CHANNEL_LISTED)
+        tasks.create_version_for_upload(self.addon, upload,
+                                        amo.RELEASE_CHANNEL_LISTED)
         assert not self.mocks['Version.from_upload'].called
 
     def test_file_passed_all_validations_most_recent_failed(self):
@@ -873,8 +871,8 @@ class TestCreateVersionForUpload(TestCase):
                             valid=False,
                             validation=json.dumps({"errors": 5}))
 
-        self.create_version_for_upload(self.addon, upload,
-                                       amo.RELEASE_CHANNEL_LISTED)
+        tasks.create_version_for_upload(self.addon, upload,
+                                        amo.RELEASE_CHANNEL_LISTED)
         assert not self.mocks['Version.from_upload'].called
 
     def test_file_passed_all_validations_most_recent(self):
@@ -884,8 +882,8 @@ class TestCreateVersionForUpload(TestCase):
 
         # The Version is created because the newer upload is for a different
         # version_string.
-        self.create_version_for_upload(self.addon, upload,
-                                       amo.RELEASE_CHANNEL_LISTED)
+        tasks.create_version_for_upload(self.addon, upload,
+                                        amo.RELEASE_CHANNEL_LISTED)
         self.mocks['parse_addon'].assert_called_with(
             upload, self.addon, user=self.user)
         self.mocks['Version.from_upload'].assert_called_with(
@@ -895,8 +893,8 @@ class TestCreateVersionForUpload(TestCase):
 
     def test_file_passed_all_validations_beta_string(self):
         upload = self.create_upload(version='1.0-beta1')
-        self.create_version_for_upload(self.addon, upload,
-                                       amo.RELEASE_CHANNEL_LISTED)
+        tasks.create_version_for_upload(self.addon, upload,
+                                        amo.RELEASE_CHANNEL_LISTED)
         self.mocks['parse_addon'].assert_called_with(
             upload, self.addon, user=self.user)
         self.mocks['Version.from_upload'].assert_called_with(
@@ -906,8 +904,8 @@ class TestCreateVersionForUpload(TestCase):
 
     def test_file_passed_all_validations_no_version(self):
         upload = self.create_upload(version=None)
-        self.create_version_for_upload(self.addon, upload,
-                                       amo.RELEASE_CHANNEL_LISTED)
+        tasks.create_version_for_upload(self.addon, upload,
+                                        amo.RELEASE_CHANNEL_LISTED)
         self.mocks['parse_addon'].assert_called_with(
             upload, self.addon, user=self.user)
         self.mocks['Version.from_upload'].assert_called_with(

--- a/src/olympia/files/models.py
+++ b/src/olympia/files/models.py
@@ -654,11 +654,6 @@ class FileValidation(ModelBase):
     def from_json(cls, file, validation):
         if isinstance(validation, six.string_types):
             validation = json.loads(validation)
-        new = cls(file=file, validation=json.dumps(validation),
-                  errors=validation['errors'],
-                  warnings=validation['warnings'],
-                  notices=validation['notices'],
-                  valid=validation['errors'] == 0)
 
         if 'metadata' in validation:
             if (validation['metadata'].get('contains_binary_extension') or
@@ -674,8 +669,13 @@ class FileValidation(ModelBase):
         # currently do not have the ability to track.
         cls.objects.filter(file=file).delete()
 
-        new.save()
-        return new
+        return cls.objects.create(
+            file=file,
+            validation=json.dumps(validation),
+            errors=validation['errors'],
+            warnings=validation['warnings'],
+            notices=validation['notices'],
+            valid=validation['errors'] == 0)
 
     @property
     def processed_validation(self):

--- a/src/olympia/signing/tests/test_views.py
+++ b/src/olympia/signing/tests/test_views.py
@@ -22,7 +22,6 @@ from olympia.amo.tests import (
     addon_factory, reverse_ns, TestCase, developer_factory)
 from olympia.api.tests.utils import APIKeyAuthTestMixin
 from olympia.applications.models import AppVersion
-from olympia.devhub import tasks
 from olympia.files.models import File, FileUpload
 from olympia.lib.akismet.models import AkismetReport
 from olympia.signing.views import VersionView

--- a/src/olympia/signing/tests/test_views.py
+++ b/src/olympia/signing/tests/test_views.py
@@ -47,11 +47,6 @@ class BaseUploadVersionTestMixin(SigningAPITestMixin):
             users=[self.user])
 
         self.view = VersionView.as_view()
-        create_version_patcher = mock.patch(
-            'olympia.devhub.tasks.create_version_for_upload',
-            tasks.create_version_for_upload.non_atomic)
-        self.create_version_for_upload = create_version_patcher.start()
-        self.addCleanup(create_version_patcher.stop)
 
         auto_sign_version_patcher = mock.patch(
             'olympia.devhub.views.auto_sign_version')


### PR DESCRIPTION
This is an attempt to fix our enormous amounts of deadlocks. Now I
finally found a reasonable candidate.

`devhub.tasks:create_version_for_upload` is being wrapped in a custom
atomic decorator that sets the transaction level to 'SERIALIZABLE'. To
be fair, I don't think it needs that.

We switched to 'read committed' some time ago and I think it makes sense
to unify this here too.

Refs #10564 