### PR TITLE
Fix flaky SearchTest.test_compat_override test

### DIFF
--- a/src/olympia/amo/tests/test_amo_utils.py
+++ b/src/olympia/amo/tests/test_amo_utils.py
@@ -201,23 +201,24 @@ class TestCacheNamespaces(BaseTestCase):
         super(TestCacheNamespaces, self).setUp()
         self.namespace = 'redis-is-dead'
 
-    @mock.patch('olympia.amo.utils.epoch')
+    @mock.patch('olympia.amo.utils.utc_millesecs_from_epoch')
     def test_no_preexisting_key(self, epoch_mock):
-        epoch_mock.return_value = 123456
-        assert cache_ns_key(self.namespace) == '123456:ns:%s' % self.namespace
+        epoch_mock.return_value = 1549383758398
+        assert cache_ns_key(self.namespace) == (
+            '1549383758398:ns:%s' % self.namespace)
 
-    @mock.patch('olympia.amo.utils.epoch')
+    @mock.patch('olympia.amo.utils.utc_millesecs_from_epoch')
     def test_no_preexisting_key_incr(self, epoch_mock):
-        epoch_mock.return_value = 123456
+        epoch_mock.return_value = 1549383758398
         assert cache_ns_key(self.namespace, increment=True) == (
-            '123456:ns:%s' % self.namespace)
+            '1549383758398:ns:%s' % self.namespace)
 
-    @mock.patch('olympia.amo.utils.epoch')
+    @mock.patch('olympia.amo.utils.utc_millesecs_from_epoch')
     def test_key_incr(self, epoch_mock):
-        epoch_mock.return_value = 123456
-        cache_ns_key(self.namespace)  # Sets ns to 123456
-        ns_key = cache_ns_key(self.namespace, increment=True)
-        expected = '123457:ns:%s' % self.namespace
+        epoch_mock.return_value = 1549383758398
+        cache_ns_key(self.namespace)  # Sets ns to 1549383758398
+        ns_key = cache_ns_key(self.namespace, increment=True)  # Increments it.
+        expected = '1549383758399:ns:%s' % self.namespace
         assert ns_key == expected
         assert cache_ns_key(self.namespace) == expected
 

--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -761,12 +761,12 @@ def cache_ns_key(namespace, increment=False):
             ns_val = cache.incr(ns_key)
         except ValueError:
             log.info('Cache increment failed for key: %s. Resetting.' % ns_key)
-            ns_val = epoch(datetime.datetime.now())
+            ns_val = utc_millesecs_from_epoch(datetime.datetime.now())
             cache.set(ns_key, ns_val, None)
     else:
         ns_val = cache.get(ns_key)
         if ns_val is None:
-            ns_val = epoch(datetime.datetime.now())
+            ns_val = utc_millesecs_from_epoch(datetime.datetime.now())
             cache.set(ns_key, ns_val, None)
     return '%s:%s' % (ns_val, ns_key)
 


### PR DESCRIPTION
It depends on the cache key being different for the cached compat info, and using seconds precision to generate it wasn't enough. We could probably use a completely random value instead, but switching
to milliseconds keeps it an ever-incrementing value as before and should be safer.

Fix #10599