### PR TITLE
Fix RemovedInDjango21Warning: Add the renderer argument to the render() method

### DIFF
--- a/src/olympia/addons/widgets.py
+++ b/src/olympia/addons/widgets.py
@@ -57,7 +57,7 @@ class CategoriesSelectMultiple(forms.CheckboxSelectMultiple):
     def __init__(self, **kwargs):
         super(self.__class__, self).__init__(**kwargs)
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         value = value or []
         has_id = attrs and 'id' in attrs
         final_attrs = self.build_attrs(attrs, {'name': name})

--- a/src/olympia/amo/widgets.py
+++ b/src/olympia/amo/widgets.py
@@ -9,7 +9,7 @@ class EmailWidget(Input):
         self.placeholder = kwargs.pop('placeholder', None)
         return super(EmailWidget, self).__init__(*args, **kwargs)
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         attrs = attrs or {}
         if self.placeholder:
             attrs['placeholder'] = self.placeholder
@@ -24,7 +24,7 @@ class ColorWidget(Input):
         self.placeholder = kwargs.pop('placeholder', None)
         return super(ColorWidget, self).__init__(*args, **kwargs)
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         attrs = attrs or {}
         if self.placeholder:
             attrs['placeholder'] = self.placeholder

--- a/src/olympia/translations/widgets.py
+++ b/src/olympia/translations/widgets.py
@@ -30,7 +30,7 @@ class TranslationTextInput(forms.widgets.TextInput):
 
 class TranslationTextarea(forms.widgets.Textarea):
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         if isinstance(value, six.integer_types):
             value = get_string(value)
         return super(TranslationTextarea, self).render(name, value, attrs)
@@ -60,7 +60,7 @@ class TransMulti(forms.widgets.MultiWidget):
         super(TransMulti, self).__init__(
             widgets=[self.widget(attrs=attrs)], attrs=attrs)
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         self.name = name
         value = self.decompress(value)
         if value:
@@ -156,7 +156,7 @@ class _TransWidget(object):
     input name.
     """
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         from .fields import switch
 
         if attrs is None:

--- a/src/olympia/users/widgets.py
+++ b/src/olympia/users/widgets.py
@@ -14,7 +14,7 @@ class NotificationsSelectMultiple(forms.CheckboxSelectMultiple):
     def __init__(self, **kwargs):
         super(self.__class__, self).__init__(**kwargs)
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         str_values = [int(v) for v in value] or []
         final_attrs = self.build_attrs(attrs, {'name': name})
         groups = {}
@@ -63,7 +63,7 @@ class RequiredInputMixin(object):
 
     required_attrs = {'required': 'required', 'aria-required': 'true'}
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         attrs = attrs or {}
         attrs.update(self.required_attrs)
         return super(RequiredInputMixin, self).render(name, value, attrs)


### PR DESCRIPTION
Fixes #10602