### PR TITLE
Start mocking elasticsearch earlier, before loading django fixtures

### DIFF
--- a/src/olympia/abuse/tests/test_serializers.py
+++ b/src/olympia/abuse/tests/test_serializers.py
@@ -2,10 +2,10 @@ from olympia.abuse.models import AbuseReport
 from olympia.abuse.serializers import (
     AddonAbuseReportSerializer, UserAbuseReportSerializer)
 from olympia.accounts.serializers import BaseUserSerializer
-from olympia.amo.tests import BaseTestCase, addon_factory, user_factory
+from olympia.amo.tests import TestCase, addon_factory, user_factory
 
 
-class TestAddonAbuseReportSerializer(BaseTestCase):
+class TestAddonAbuseReportSerializer(TestCase):
 
     def serialize(self, report, **extra_context):
         return AddonAbuseReportSerializer(report, context=extra_context).data
@@ -30,7 +30,7 @@ class TestAddonAbuseReportSerializer(BaseTestCase):
                           'message': 'bad stuff'}
 
 
-class TestUserAbuseReportSerializer(BaseTestCase):
+class TestUserAbuseReportSerializer(TestCase):
 
     def serialize(self, report, **extra_context):
         return UserAbuseReportSerializer(report, context=extra_context).data

--- a/src/olympia/amo/tests/test_amo_utils.py
+++ b/src/olympia/amo/tests/test_amo_utils.py
@@ -8,7 +8,7 @@ from django.core.validators import ValidationError
 import mock
 import pytest
 
-from olympia.amo.tests import BaseTestCase
+from olympia.amo.tests import TestCase
 from olympia.amo.utils import (
     LocalFileStorage, cache_ns_key, escape_all, find_language, from_string,
     no_jinja_autoescape, resize_image, rm_local_tmp_dir,
@@ -118,7 +118,7 @@ def test_find_language(test_input, expected):
     assert find_language(test_input) == expected
 
 
-class TestLocalFileStorage(BaseTestCase):
+class TestLocalFileStorage(TestCase):
 
     def setUp(self):
         super(TestLocalFileStorage, self).setUp()
@@ -195,7 +195,7 @@ class TestLocalFileStorage(BaseTestCase):
         assert os.path.exists(dp)
 
 
-class TestCacheNamespaces(BaseTestCase):
+class TestCacheNamespaces(TestCase):
 
     def setUp(self):
         super(TestCacheNamespaces, self).setUp()

--- a/src/olympia/amo/tests/test_decorators.py
+++ b/src/olympia/amo/tests/test_decorators.py
@@ -11,7 +11,7 @@ import pytest
 
 from olympia import amo
 from olympia.amo import decorators
-from olympia.amo.tests import BaseTestCase, TestCase, fxa_login_link
+from olympia.amo.tests import TestCase, TestCase, fxa_login_link
 from olympia.users.models import UserProfile
 
 
@@ -79,7 +79,7 @@ def test_json_view_response_status():
     assert response.status_code == 202
 
 
-class TestLoginRequired(BaseTestCase):
+class TestLoginRequired(TestCase):
 
     def setUp(self):
         super(TestLoginRequired, self).setUp()

--- a/src/olympia/amo/tests/test_send_mail.py
+++ b/src/olympia/amo/tests/test_send_mail.py
@@ -13,7 +13,7 @@ import six
 from celery.exceptions import Retry
 
 from olympia.amo.models import FakeEmail
-from olympia.amo.tests import BaseTestCase
+from olympia.amo.tests import TestCase
 from olympia.amo.utils import send_html_mail_jinja, send_mail
 from olympia.users import notifications
 from olympia.users.models import UserNotification, UserProfile
@@ -23,7 +23,7 @@ TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
 ATTACHMENTS_DIR = os.path.join(TESTS_DIR, 'attachments')
 
 
-class TestSendMail(BaseTestCase):
+class TestSendMail(TestCase):
     fixtures = ['base/users']
 
     def setUp(self):

--- a/src/olympia/amo/tests/test_storage_utils.py
+++ b/src/olympia/amo/tests/test_storage_utils.py
@@ -12,7 +12,7 @@ import pytest
 
 from olympia.amo.storage_utils import (
     copy_stored_file, move_stored_file, rm_stored_dir, walk_storage)
-from olympia.amo.tests import BaseTestCase
+from olympia.amo.tests import TestCase
 from olympia.amo.utils import rm_local_tmp_dir
 
 
@@ -78,7 +78,7 @@ def test_rm_stored_dir():
         rm_local_tmp_dir(tmp)
 
 
-class TestFileOps(BaseTestCase):
+class TestFileOps(TestCase):
 
     def setUp(self):
         super(TestFileOps, self).setUp()

--- a/src/olympia/amo/tests/test_url_prefix.py
+++ b/src/olympia/amo/tests/test_url_prefix.py
@@ -7,13 +7,13 @@ import pytest
 
 from olympia.amo import urlresolvers
 from olympia.amo.middleware import LocaleAndAppURLMiddleware
-from olympia.amo.tests import BaseTestCase, TestCase
+from olympia.amo.tests import TestCase, TestCase
 
 
 pytestmark = pytest.mark.django_db
 
 
-class MiddlewareTest(BaseTestCase):
+class MiddlewareTest(TestCase):
     """Tests that the locale and app redirection work properly."""
 
     def setUp(self):
@@ -147,7 +147,7 @@ class MiddlewareTest(BaseTestCase):
         check('/en-US/firefox?lang=es-PE', '/es/firefox/')
 
 
-class TestPrefixer(BaseTestCase):
+class TestPrefixer(TestCase):
 
     def tearDown(self):
         urlresolvers.clean_url_prefixes()
@@ -198,7 +198,7 @@ class TestPrefixer(BaseTestCase):
 
     def test_reverse(self):
         # Make sure it works outside the request.
-        urlresolvers.clean_url_prefixes()  # Modified in BaseTestCase.
+        urlresolvers.clean_url_prefixes()  # Modified in TestCase.
         assert urlresolvers.reverse('home') == '/'
 
         # With a request, locale and app prefixes work.

--- a/src/olympia/bandwagon/tests/test_helpers.py
+++ b/src/olympia/bandwagon/tests/test_helpers.py
@@ -2,12 +2,12 @@ import six
 
 from pyquery import PyQuery as pq
 
-from olympia.amo.tests import BaseTestCase
+from olympia.amo.tests import TestCase
 from olympia.bandwagon.models import Collection
 from olympia.bandwagon.templatetags.jinja_helpers import user_collection_list
 
 
-class TestHelpers(BaseTestCase):
+class TestHelpers(TestCase):
     def test_user_collection_list(self):
         c1 = Collection(uuid='eb4e3cd8-5cf1-4832-86fb-a90fc6d3765c')
         c2 = Collection(uuid='61780943-e159-4206-8acd-0ae9f63f294c',

--- a/src/olympia/bandwagon/tests/test_serializers.py
+++ b/src/olympia/bandwagon/tests/test_serializers.py
@@ -4,7 +4,7 @@ from rest_framework import serializers
 from waffle.testutils import override_switch
 
 from olympia.amo.tests import (
-    BaseTestCase, addon_factory, collection_factory, TestCase, user_factory)
+    TestCase, addon_factory, collection_factory, TestCase, user_factory)
 from olympia.bandwagon.models import CollectionAddon
 from olympia.bandwagon.serializers import (
     CollectionAddonSerializer, CollectionAkismetSpamValidator,
@@ -105,7 +105,7 @@ class TestCollectionAkismetSpamValidator(TestCase):
         assert comment_check_mock.call_count == 1
 
 
-class TestCollectionSerializer(BaseTestCase):
+class TestCollectionSerializer(TestCase):
     serializer = CollectionSerializer
 
     def setUp(self):
@@ -133,7 +133,7 @@ class TestCollectionSerializer(BaseTestCase):
         assert data['default_locale'] == self.collection.default_locale
 
 
-class TestCollectionAddonSerializer(BaseTestCase):
+class TestCollectionAddonSerializer(TestCase):
 
     def setUp(self):
         self.collection = collection_factory()

--- a/src/olympia/devhub/tests/test_helpers.py
+++ b/src/olympia/devhub/tests/test_helpers.py
@@ -68,7 +68,7 @@ def test_log_action_class():
         assert render('{{ log_action_class(id) }}', {'id': v.id}) == cls
 
 
-class TestDisplayUrl(amo.tests.BaseTestCase):
+class TestDisplayUrl(amo.tests.TestCase):
 
     def setUp(self):
         super(TestDisplayUrl, self).setUp()

--- a/src/olympia/reviewers/tests/test_sql_model.py
+++ b/src/olympia/reviewers/tests/test_sql_model.py
@@ -11,7 +11,7 @@ from django.db.models import Q
 
 import pytest
 
-from olympia.amo.tests import BaseTestCase
+from olympia.amo.tests import TestCase
 from olympia.reviewers.sql_model import RawSQLModel
 
 
@@ -62,7 +62,7 @@ class ProductDetail(RawSQLModel):
         }
 
 
-class TestSQLModel(BaseTestCase):
+class TestSQLModel(TestCase):
 
     @pytest.fixture(autouse=True)
     def setup(self, request):

--- a/src/olympia/tags/tests/test_helpers.py
+++ b/src/olympia/tags/tests/test_helpers.py
@@ -13,7 +13,7 @@ def render(s, context=None):
     return t.render(context)
 
 
-class TestHelpers(amo.tests.BaseTestCase):
+class TestHelpers(amo.tests.TestCase):
     fixtures = ('base/addon_3615', 'base/user_2519', 'base/user_4043307',
                 'tags/tags')
 

--- a/src/olympia/translations/tests/test_models.py
+++ b/src/olympia/translations/tests/test_models.py
@@ -18,7 +18,7 @@ from mock import patch
 from pyquery import PyQuery as pq
 
 from olympia.amo.models import use_primary_db
-from olympia.amo.tests import BaseTestCase
+from olympia.amo.tests import TestCase
 from olympia.translations.models import (
     LinkifiedTranslation, NoLinksNoMarkupTranslation,
     PurifiedTranslation, Translation, TranslationSequence)
@@ -35,7 +35,7 @@ def ids(qs):
     return [o.id for o in qs]
 
 
-class TranslationFixturelessTestCase(BaseTestCase):
+class TranslationFixturelessTestCase(TestCase):
     "We want to be able to rollback stuff."
 
     def test_whitespace(self):
@@ -44,7 +44,7 @@ class TranslationFixturelessTestCase(BaseTestCase):
         assert 'khaaaaaan!' == t.localized_string
 
 
-class TranslationSequenceTestCase(BaseTestCase):
+class TranslationSequenceTestCase(TestCase):
     """
     Make sure automatic translation sequence generation works
     as expected.
@@ -77,7 +77,7 @@ class TranslationSequenceTestCase(BaseTestCase):
             'Translation sequence needs to keep increasing.')
 
 
-class TranslationTestCase(BaseTestCase):
+class TranslationTestCase(TestCase):
     fixtures = ['testapp/test_models.json']
 
     def setUp(self):
@@ -530,7 +530,7 @@ class TranslationMultiDbTests(TransactionTestCase):
                 assert len(connections['slave-2'].queries) == 0
 
 
-class PurifiedTranslationTest(BaseTestCase):
+class PurifiedTranslationTest(TestCase):
 
     def test_output(self):
         assert isinstance(PurifiedTranslation().__html__(), six.text_type)
@@ -579,7 +579,7 @@ class PurifiedTranslationTest(BaseTestCase):
         assert doc('b')[0].text == 'markup'
 
 
-class LinkifiedTranslationTest(BaseTestCase):
+class LinkifiedTranslationTest(TestCase):
 
     @patch('olympia.amo.urlresolvers.get_outgoing_url')
     def test_allowed_tags(self, get_outgoing_url_mock):
@@ -598,7 +598,7 @@ class LinkifiedTranslationTest(BaseTestCase):
             '&lt;b&gt;bold&lt;/b&gt;')
 
 
-class NoLinksNoMarkupTranslationTest(BaseTestCase):
+class NoLinksNoMarkupTranslationTest(TestCase):
 
     def test_forbidden_tags(self):
         s = u'<script>some naughty xss</script> <b>bold</b>'


### PR DESCRIPTION
We were mocking es using a pytest autouse fixture, which are apparently called too late, after the loading of django fixtures. This was causing useless index calls, possibly slowing down the tests
slightly.

Fix #10655