### PR TITLE
Preserve original uwsgi path in Python 3 container image

### DIFF
--- a/Dockerfile.python3.deploy
+++ b/Dockerfile.python3.deploy
@@ -72,6 +72,10 @@ RUN pip3 install --no-cache-dir --exists-action=w --no-deps -r requirements/syst
     && pip3 install --no-cache-dir --exists-action=w --no-deps -r requirements/prod_py3.txt         \
     && pip3 install --no-cache-dir --exists-action=w --no-deps -e .
 
+# Link /usr/bin/uwsgi to /usr/local/bin/uwsgi, as that was the
+# previous location of the binary when installed by apt-get.
+RUN ln -s /usr/local/bin/uwsgi /usr/bin/uwsgi
+
 # Install uwsgi statsd exporter to collect metrics from uwsgi when deployed
 WORKDIR /usr/lib/uwsgi/plugins
 RUN uwsgi --build-plugin https://github.com/Datadog/uwsgi-dogstatsd && \


### PR DESCRIPTION
This now works:

```
docker run mozilla/addons-server:latest-py3 /usr/sbin/uwsgi
```

```
*** Starting uWSGI 2.0.18 (64bit) on [Tue Feb 12 18:12:55 2019] ***
compiled with version: 6.3.0 20170516 on 12 February 2019 18:08:52
os: Linux-4.9.125-linuxkit #1 SMP Fri Sep 7 08:20:28 UTC 2018
nodename: 96d71176b127
machine: x86_64
clock source: unix
pcre jit disabled
detected number of CPU cores: 4
current working directory: /data/olympia
detected binary path: /usr/local/bin/uwsgi
uWSGI running as root, you can use --uid/--gid/--chroot options
*** WARNING: you are running uWSGI as root !!! (use the --uid flag) ***
*** WARNING: you are running uWSGI without its master process manager ***
your memory page size is 4096 bytes
detected max file descriptor number: 1048576
lock engine: pthread robust mutexes
thunder lock: disabled (you can enable it with --thunder-lock)
uWSGI running as root, you can use --uid/--gid/--chroot options
*** WARNING: you are running uWSGI as root !!! (use the --uid flag) ***
uWSGI running as root, you can use --uid/--gid/--chroot options
*** WARNING: you are running uWSGI as root !!! (use the --uid flag) ***
The -s/--socket option is missing and stdin is not a socket.
```