### PR TITLE
Raise an exception when we can't sign a file instead of returning None

### DIFF
--- a/src/olympia/addons/tests/test_commands.py
+++ b/src/olympia/addons/tests/test_commands.py
@@ -165,6 +165,8 @@ def test_approve_addons_approve_files_no_review_type():
     assert file_.reload().status == amo.STATUS_PUBLIC
 
 
+@pytest.mark.django_db
+@mock.patch('olympia.reviewers.utils.sign_file', lambda f: None)
 def test_approve_addons_approve_files(use_case, mozilla_user):
     """Files are approved using the correct review type.
 

--- a/src/olympia/lib/crypto/signing.py
+++ b/src/olympia/lib/crypto/signing.py
@@ -180,14 +180,22 @@ def call_signing(file_obj):
 
 
 def sign_file(file_obj):
-    """Sign a File.
+    """Sign a File if necessary.
+
+    If it's not necessary (file exists but it's a mozilla signed one, or it's
+    a search plugin) then return the file directly.
 
     If there's no endpoint (signing is not enabled) or isn't reviewed yet,
     or there was an error while signing, raise an exception - it
     shouldn't happen.
 
-    Otherwise return the signed file.
+    Otherwise proceed with signing and return the signed file.
     """
+    if (file_obj.version.addon.type == amo.ADDON_SEARCH and
+            file_obj.version.is_webextension is False):
+        # Those aren't meant to be signed, we shouldn't be here.
+        return file_obj
+
     if not settings.ENABLE_ADDON_SIGNING:
         raise SigningError(u'Not signing file {0}: no active endpoint'.format(
             file_obj.pk))

--- a/src/olympia/lib/crypto/signing.py
+++ b/src/olympia/lib/crypto/signing.py
@@ -183,39 +183,39 @@ def sign_file(file_obj):
     """Sign a File.
 
     If there's no endpoint (signing is not enabled) or isn't reviewed yet,
-    or there was an error while signing, log and return nothing.
+    or there was an error while signing, raise an exception - it
+    shouldn't happen.
 
     Otherwise return the signed file.
     """
     if not settings.ENABLE_ADDON_SIGNING:
-        log.info(u'Not signing file {0}: no active endpoint'.format(
+        raise SigningError(u'Not signing file {0}: no active endpoint'.format(
             file_obj.pk))
-        return
 
     # No file? No signature.
     if not os.path.exists(file_obj.current_file_path):
-        log.info(u'File {0} doesn\'t exist on disk'.format(
+        raise SigningError(u'File {0} doesn\'t exist on disk'.format(
             file_obj.current_file_path))
-        return
 
     # Don't sign Mozilla signed extensions (they're already signed).
     if file_obj.is_mozilla_signed_extension:
+        # Don't raise an exception here, just log and return file_obj even
+        # though we didn't sign, it's not an error - we just don't need to do
+        # anything in this case.
         log.info(u'Not signing file {0}: mozilla signed extension is already '
                  u'signed'.format(file_obj.pk))
-        return
+        return file_obj
 
     # Don't sign multi-package XPIs. Their inner add-ons need to be signed.
     if file_obj.is_multi_package:
-        log.info(u'Not signing file {0}: multi-package XPI'.format(
+        raise SigningError(u'Not signing file {0}: multi-package XPI'.format(
             file_obj.pk))
-        return
 
     # We only sign files that are compatible with Firefox.
     if not supports_firefox(file_obj):
-        log.info(
+        raise SigningError(
             u'Not signing version {0}: not for a Firefox version we support'
             .format(file_obj.version.pk))
-        return
 
     # Sign the file. If there's any exception, we skip the rest.
     cert_serial_num = six.text_type(call_signing(file_obj))

--- a/src/olympia/lib/crypto/tests/test_signing.py
+++ b/src/olympia/lib/crypto/tests/test_signing.py
@@ -199,7 +199,13 @@ class TestSigning(TestCase):
         assert not self.file_.hash
         assert not signing.is_signed(self.file_.file_path)
 
-    def test_no_sign_again_mozilla_signed_extensions(self):
+    def test_dont_sign_search_plugins(self):
+        self.addon.update(type=amo.ADDON_SEARCH)
+        self.file_.update(is_webextension=False)
+        signing.sign_file(self.file_)
+        self.assert_not_signed()
+
+    def test_dont_sign_again_mozilla_signed_extensions(self):
         """Don't try to resign mozilla signed extensions."""
         self.file_.update(is_mozilla_signed_extension=True)
         signing.sign_file(self.file_)

--- a/src/olympia/lib/crypto/tests/test_signing.py
+++ b/src/olympia/lib/crypto/tests/test_signing.py
@@ -192,7 +192,8 @@ class TestSigning(TestCase):
         assert not self.file_.is_signed
         assert not self.file_.cert_serial_num
         assert not self.file_.hash
-        signing.sign_file(self.file_)
+        with self.assertRaises(signing.SigningError):
+            signing.sign_file(self.file_)
         assert not self.file_.is_signed
         assert not self.file_.cert_serial_num
         assert not self.file_.hash
@@ -222,7 +223,8 @@ class TestSigning(TestCase):
             self.file_.update(is_multi_package=True)
             self.assert_not_signed()
 
-            signing.sign_file(self.file_)
+            with self.assertRaises(signing.SigningError):
+                signing.sign_file(self.file_)
             self.assert_not_signed()
             # The multi-package itself isn't signed.
             assert not signing.is_signed(self.file_.file_path)

--- a/src/olympia/reviewers/tests/test_commands.py
+++ b/src/olympia/reviewers/tests/test_commands.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from django.conf import settings
 from django.core import mail
 from django.core.management import call_command
+from django.test.testcases import TransactionTestCase
 
 import mock
 import six
@@ -15,6 +16,7 @@ from olympia.addons.models import (
     AddonApprovalsCounter, AddonReviewerFlags, AddonUser)
 from olympia.amo.tests import (
     TestCase, addon_factory, file_factory, user_factory, version_factory)
+from olympia.amo.utils import days_ago
 from olympia.lib.crypto.signing import SigningError
 from olympia.files.models import FileValidation
 from olympia.files.utils import atomic_lock
@@ -24,7 +26,24 @@ from olympia.reviewers.models import (
     AutoApprovalSummary, ReviewerScore, get_reviewing_cache)
 
 
-class TestAutoApproveCommand(TestCase):
+class AutoApproveTestsMixin(object):
+    def setUp(self):
+        # Always mock log_final_summary() method so we can look at the stats
+        # easily.
+        patcher = mock.patch.object(auto_approve.Command, 'log_final_summary')
+        self.log_final_summary_mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _check_stats(self, expected_stats):
+        # We abuse the fact that log_final_summary receives stats as positional
+        # argument to check what happened. Depends on setUp() patching
+        # auto_approve.Command.log_final_summary
+        assert self.log_final_summary_mock.call_count == 1
+        stats = self.log_final_summary_mock.call_args[0][0]
+        assert stats == expected_stats
+
+
+class TestAutoApproveCommand(AutoApproveTestsMixin, TestCase):
     def setUp(self):
         self.user = user_factory(
             id=settings.TASK_USER_ID, username='taskuser',
@@ -38,19 +57,7 @@ class TestAutoApproveCommand(TestCase):
         self.file_validation = FileValidation.objects.create(
             file=self.version.all_files[0], validation=u'{}')
         AddonApprovalsCounter.objects.create(addon=self.addon, counter=1)
-
-        # Always mock log_final_summary() method so we can look at the stats
-        # easily.
-        patcher = mock.patch.object(auto_approve.Command, 'log_final_summary')
-        self.log_final_summary_mock = patcher.start()
-        self.addCleanup(patcher.stop)
-
-    def _check_stats(self, expected_stats):
-        # We abuse the fact that log_final_summary receives stats as positional
-        # argument to check what happened.
-        assert self.log_final_summary_mock.call_count == 1
-        stats = self.log_final_summary_mock.call_args[0][0]
-        assert stats == expected_stats
+        super(TestAutoApproveCommand, self).setUp()
 
     def test_fetch_candidates(self):
         # We already have an add-on with a version awaiting review that should
@@ -319,6 +326,72 @@ class TestAutoApproveCommand(TestCase):
 
         assert self.log_final_summary_mock.call_count == 0
         assert self.file.reload().status == amo.STATUS_AWAITING_REVIEW
+
+
+class TestAutoApproveCommandTransactions(
+        AutoApproveTestsMixin, TransactionTestCase):
+    def setUp(self):
+        user_factory(
+            id=settings.TASK_USER_ID, username='taskuser',
+            email='taskuser@mozilla.com')
+        self.addons = [
+            addon_factory(average_daily_users=666, users=[user_factory()]),
+            addon_factory(average_daily_users=999, users=[user_factory()]),
+        ]
+        self.versions = [
+            version_factory(
+                addon=self.addons[0], file_kw={
+                    'status': amo.STATUS_AWAITING_REVIEW,
+                    'is_webextension': True}),
+            version_factory(
+                addon=self.addons[1], file_kw={
+                    'status': amo.STATUS_AWAITING_REVIEW,
+                    'is_webextension': True}),
+        ]
+        self.files = [
+            self.versions[0].all_files[0],
+            self.versions[1].all_files[0],
+        ]
+        self.versions[0].update(nomination=days_ago(1))
+        FileValidation.objects.create(
+            file=self.versions[0].all_files[0], validation=u'{}')
+        FileValidation.objects.create(
+            file=self.versions[1].all_files[0], validation=u'{}')
+        super(TestAutoApproveCommandTransactions, self).setUp()
+
+    @mock.patch('olympia.reviewers.utils.sign_file')
+    def test_signing_error_roll_back(self, sign_file_mock):
+        sign_file_mock.side_effect = [SigningError, None]
+        call_command('auto_approve')
+        # Make sure that the AutoApprovalSummary created for the first add-on
+        # was rolled back because of the signing error, and that it didn't
+        # affect the approval of the second one.
+        assert sign_file_mock.call_count == 2
+
+        for file_ in self.files:
+            file_.reload()
+        for addon in self.addons:
+            addon.reload()
+
+        assert not AutoApprovalSummary.objects.filter(
+            version=self.versions[0]).exists()
+        assert self.addons[0].status == amo.STATUS_PUBLIC  # It already was.
+        assert self.files[0].status == amo.STATUS_AWAITING_REVIEW
+        assert not self.files[0].reviewed
+
+        assert AutoApprovalSummary.objects.get(version=self.versions[1])
+        assert self.addons[1].status == amo.STATUS_PUBLIC
+        assert self.files[1].status == amo.STATUS_PUBLIC
+        assert self.files[1].reviewed
+
+        assert len(mail.outbox) == 1
+
+        assert get_reviewing_cache(self.addons[0].pk) is None
+        assert get_reviewing_cache(self.addons[1].pk) is None
+
+        self._check_stats({'total': 2, 'error': 1, 'is_locked': 0,
+                           'has_auto_approval_disabled': 0,
+                           'auto_approved': 1})
 
 
 class TestAwardPostReviewPoints(TestCase):

--- a/src/olympia/reviewers/tests/test_review_scenarios.py
+++ b/src/olympia/reviewers/tests/test_review_scenarios.py
@@ -3,6 +3,7 @@
 For different add-on and file statuses, test reviewing them, and make sure then
 end up in the correct state.
 """
+import mock
 import pytest
 
 from olympia import amo
@@ -35,6 +36,7 @@ def addon_with_files(db):
     return addon
 
 
+@mock.patch('olympia.reviewers.utils.sign_file', lambda f: None)
 @pytest.mark.parametrize(
     'review_action,addon_status,file_status,review_class,review_type,'
     'final_addon_status,final_file_status',


### PR DESCRIPTION
This will prevent us from accidentally making public an add-on we can't sign for some reason. That will make such issues more explicit by either returning a 500 to the user (unlisted signing API), raising an exception that will show up in sentry (tasks) or leave the version awaiting review (every case above + auto_approve). The affected add-ons will still be somewhat broken but they'll be in a more consistent state.

Fixes #10693