### PR TITLE
Point My Collections to the collection homepage for frontend compat

### DIFF
--- a/src/olympia/amo/context_processors.py
+++ b/src/olympia/amo/context_processors.py
@@ -50,7 +50,7 @@ def global_settings(request):
                               'href': reverse('users.edit')})
         account_links.append({
             'text': ugettext('My Collections'),
-            'href': reverse('collections.user', args=[request.user.id])})
+            'href': reverse('collections.list')})
 
         if request.user.favorite_addons:
             account_links.append(

--- a/src/olympia/amo/templates/amo/site_nav.html
+++ b/src/olympia/amo/templates/amo/site_nav.html
@@ -60,11 +60,8 @@
           <li><em><a href="{{ base_url|urlparams(sort=sort) }}">{{ title }}</a></em></li>
         {% endfor %}
         <hr>
-        <li><a href="{{ url('collections.mine') }}">
+        <li><a href="{{ url('collections.list') }}">
           {{ _("Collections I've Made") }}</a></li>
-        {# We never let you change the favorites slug. #}
-        <li><a href="{{ url('collections.mine', 'favorites') }}">
-          {{ _('My Favorite Add-ons') }}</a></li>
       </ul>
       {% endwith %}
     </li>

--- a/src/olympia/users/templates/users/includes/navigation.html
+++ b/src/olympia/users/templates/users/includes/navigation.html
@@ -1,12 +1,8 @@
 {% set links = [
     (_('My Profile'), user.get_url_path()),
     (_('Account Settings'), url('users.edit')),
-    (_('My Collections'), url('collections.mine'))
+    (_('My Collections'), url('collections.list'))
 ] %}
-{% if user.favorite_addons %}
-  {% do links.append((_('My Favorites'),
-                      url('collections.mine', 'favorites'))) %}
-{% endif %}
 
 <div id="secondary-nav" class="secondary">
   <h2>{{ _('My Account') }}</h2>


### PR DESCRIPTION
The individual collection pages no longer exist in the new frontend, so we need this link to point to something that does and this is the one that makes the most sense.

Fixes #10638