### PR TITLE
Always set algorithms when decoding JWT

### DIFF
--- a/src/olympia/api/jwt_auth.py
+++ b/src/olympia/api/jwt_auth.py
@@ -43,7 +43,7 @@ def jwt_decode_handler(token, get_api_key=APIKey.get_jwt_key):
         'verify_nbf': False,
         'verify_iat': False,
         'verify_aud': False,
-    })
+    }, algorithms=[api_settings.JWT_ALGORITHM])
 
     if 'iss' not in token_data:
         log.info('No issuer in JWT auth token: {}'.format(token_data))


### PR DESCRIPTION
It was already done later when we use the secret, but this should also
be done here.

Fixes #10694