### PR TITLE
Don't skip adding compatibility apps because of manifest incompatibility.

### DIFF
--- a/src/olympia/files/tests/test_utils_.py
+++ b/src/olympia/files/tests/test_utils_.py
@@ -501,6 +501,28 @@ class TestManifestJSONExtractor(TestCase):
 
         self.parse(data)['apps']
 
+    def test_dont_skip_apps_because_of_strict_version_incompatibility(self):
+        # We shouldn't skip adding specific apps to the WebExtension
+        # no matter any potential incompatibility, e.g
+        # browser_specific_settings is only supported from Firefox 48.0
+        # onwards, now if the user specifies strict_min_compat as 42.0
+        # we shouldn't skip the app because of that.
+        self.create_webext_default_versions()
+        data = {
+            'browser_specific_settings': {
+                'gecko': {
+                    'strict_min_version': '42.0',
+                    'id': '@random'
+                }
+            }
+        }
+
+        apps = self.parse(data)['apps']
+        assert len(apps) == 1
+
+        assert apps[0].appdata == amo.FIREFOX
+        assert apps[0].min.version == amo.DEFAULT_WEBEXT_MIN_VERSION
+
 
 class TestManifestJSONExtractorStaticTheme(TestManifestJSONExtractor):
     def parse(self, base_data):

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -501,17 +501,6 @@ class ManifestJSONExtractor(object):
             strict_max_version = (
                 self.strict_max_version or amo.DEFAULT_WEBEXT_MAX_VERSION)
 
-            # Don't attempt to add support for this app to the WebExtension
-            # if the `strict_min_version` is below the default minimum version
-            # that is required to run WebExtensions (48.* for Android and 42.*
-            # for Firefox).
-            skip_app = (
-                self.strict_min_version and vint(self.strict_min_version) <
-                vint(default_min_version)
-            )
-            if skip_app:
-                continue
-
             try:
                 min_appver, max_appver = get_appversions(
                     app, strict_min_version, strict_max_version)


### PR DESCRIPTION
For example, if the user uploads an add-on that sets the key
browser_specific_settings and sets strict_min_version to 42.0 the
add-on is potentially invalid/unable to be used but we shouldn't fail
to add compatibility just because of that.

Erroring because of schema errors is part of the addons-linter.

Fixes #10697
