### PR TITLE
Expose more specific mimetype.

### DIFF
--- a/src/olympia/reviewers/serializers.py
+++ b/src/olympia/reviewers/serializers.py
@@ -99,7 +99,6 @@ class FileEntriesSerializer(FileSerializer):
                 path = force_text(entry_wrapper.path)
                 blob = entry_wrapper.blob
 
-                mime, encoding = mimetypes.guess_type(entry.name)
                 sha_hash = (
                     get_sha256(io.BytesIO(memoryview(blob)))
                     if not entry.type == 'tree' else '')
@@ -156,6 +155,13 @@ class FileEntriesSerializer(FileSerializer):
 
         mime_type = mime.split('/')[0]
         known_types = ('image', 'text')
+
+        if mime_type == 'text':
+            # Allow text mimetypes to be more specific for readable
+            # files. `python-magic`/`libmagic` usually just returns
+            # plain/text but we should use actual types like text/css or
+            # text/javascript.
+            mime, _ = mimetypes.guess_type(entry.name)
 
         return mime, 'binary' if mime_type not in known_types else mime_type
 

--- a/src/olympia/reviewers/tests/test_serializers.py
+++ b/src/olympia/reviewers/tests/test_serializers.py
@@ -68,7 +68,7 @@ class TestFileEntriesSerializer(TestCase):
         assert manifest_data['filename'] == u'manifest.json'
         assert manifest_data['sha256'] == (
             '71d4122c0f2f78e089136602f88dbf590f2fa04bb5bc417454bf21446d6cb4f0')
-        assert manifest_data['mimetype'] == 'text/plain'
+        assert manifest_data['mimetype'] == 'application/json'
         assert manifest_data['mime_category'] == 'text'
         assert manifest_data['path'] == u'manifest.json'
         assert manifest_data['size'] == 622
@@ -133,16 +133,16 @@ class TestFileEntriesSerializer(TestCase):
         (MagicMock(type='blob'), 'empty_bat.exe', 'binary',
                                  'application/x-dosexec'),
         (MagicMock(type='blob'), 'fff.gif', 'image', 'image/gif'),
-        (MagicMock(type='blob'), 'foo.css', 'text', 'text/plain'),
+        (MagicMock(type='blob'), 'foo.css', 'text', 'text/css'),
         (MagicMock(type='blob'), 'foo.html', 'text', 'text/html'),
-        (MagicMock(type='blob'), 'foo.js', 'text', 'text/plain'),
-        (MagicMock(type='blob'), 'foo.py', 'text', 'text/plain'),
+        (MagicMock(type='blob'), 'foo.js', 'text', 'application/javascript'),
+        (MagicMock(type='blob'), 'foo.py', 'text', 'text/x-python'),
         (MagicMock(type='blob'), 'image.jpg', 'image', 'image/jpeg'),
         (MagicMock(type='blob'), 'image.png', 'image', 'image/png'),
-        (MagicMock(type='blob'), 'search.xml', 'text', 'text/xml'),
+        (MagicMock(type='blob'), 'search.xml', 'text', 'application/xml'),
         (MagicMock(type='blob'), 'js_containing_png_data.js', 'text',
-                                 'text/plain'),
-        (MagicMock(type='blob'), 'foo.json', 'text', 'text/plain'),
+                                 'application/javascript'),
+        (MagicMock(type='blob'), 'foo.json', 'text', 'application/json'),
         (MagicMock(type='tree'), 'foo', 'directory',
                                  'application/octet-stream'),
     ]
@@ -150,6 +150,8 @@ class TestFileEntriesSerializer(TestCase):
 def test_file_entries_serializer_category_type(
         entry, filename, expected_category, expected_mimetype):
     serializer = FileEntriesSerializer()
+
+    entry.name = filename
 
     root = os.path.join(
         settings.ROOT,


### PR DESCRIPTION
The browse api returns currently `text/plain` for all text files but we should make the mimetype more specific for readable text files and allow them to be classified as `text/css`, `text/javascript` etc

Fixes #10796
