### PR TITLE
Fix flake8 errors outside src/

### DIFF
--- a/locale/generate_category_po_files.py
+++ b/locale/generate_category_po_files.py
@@ -51,8 +51,8 @@ def extract_translations_for_given_locale(all_translations, locale):
 
 def main():
     if not os.path.isdir('locale'):
-        print ('Sorry, please run from the root of the project, '
-               'eg. ./locale/generate_category_po_files.py')
+        print('Sorry, please run from the root of the project, '
+              'eg. ./locale/generate_category_po_files.py')
         return
 
     print('Loading translations JSON dump...')

--- a/scripts/hash_requirements.py
+++ b/scripts/hash_requirements.py
@@ -6,16 +6,17 @@ import shlex
 from pkg_resources import safe_name
 
 import pip
-from pip.req.req_file import parse_requirements, build_parser, break_args_options
+from pip.req.req_file import (parse_requirements, build_parser,
+                              break_args_options)
 from hashin import run_single_package
 
 
 def rdeps(pkg_name):
     return sorted([safe_name(pkg.project_name)
-            for pkg in pip.get_installed_distributions()
-            if safe_name(pkg_name) in [
-                safe_name(requirement.project_name)
-                for requirement in pkg.requires()]])
+                   for pkg in pip.get_installed_distributions()
+                   if safe_name(pkg_name) in [
+                       safe_name(requirement.project_name)
+                       for requirement in pkg.requires()]])
 
 
 def main(requirements_path):
@@ -24,7 +25,7 @@ def main(requirements_path):
         requirements_path, session=pip.download.PipSession())
     requirements = [
         req for req in parsed
-            # Skip packages from other requirements files
+        # Skip packages from other requirements files
         if this_requirements_file in req.comes_from]
 
     reverse_requirements = {}

--- a/settings.py
+++ b/settings.py
@@ -116,7 +116,7 @@ INBOUND_EMAIL_VALIDATION_KEY = 'totally-unsecure-validation-string'
 # If you have settings you want to overload, put them in a local_settings.py.
 try:
     from local_settings import *  # noqa
-except ImportError as exc:
+except ImportError:
     import warnings
     import traceback
 


### PR DESCRIPTION
This just fixes some `flake8` errors outside the `src` directory.

```
./settings.py:119:1: F841 local variable 'exc' is assigned to but never used
./locale/generate_category_po_files.py:54:14: E211 whitespace before '('
./scripts/hash_requirements.py:9:80: E501 line too long (81 > 79 characters)
./scripts/hash_requirements.py:15:13: E128 continuation line under-indented for visual indent
./scripts/hash_requirements.py:16:13: E128 continuation line under-indented for visual indent
./scripts/hash_requirements.py:27:13: E131 continuation line unaligned for hanging indent
```