### PR TITLE
Let the linter pick up uploads with no manifest

### DIFF
--- a/src/olympia/devhub/tests/test_tasks.py
+++ b/src/olympia/devhub/tests/test_tasks.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import json
 import os
 import shutil

--- a/src/olympia/devhub/tests/test_tasks.py
+++ b/src/olympia/devhub/tests/test_tasks.py
@@ -28,6 +28,7 @@ from olympia.applications.models import AppVersion
 from olympia.constants.base import VALIDATOR_SKELETON_RESULTS
 from olympia.devhub import tasks, file_validation_annotations as annotations
 from olympia.files.models import File, FileUpload
+from olympia.files.utils import NoManifestFound
 from olympia.versions.models import Version
 
 
@@ -520,6 +521,18 @@ class TestValidateFilePath(ValidatorTestCase):
 
         expected = amo.VALIDATOR_SKELETON_RESULTS
         assert result == expected
+
+    @mock.patch('olympia.devhub.tasks.parse_addon')
+    @mock.patch('olympia.devhub.tasks.run_addons_linter')
+    def test_manifest_not_found_error(
+            self, run_addons_linter_mock, parse_addon_mock):
+        parse_addon_mock.side_effect = NoManifestFound(message=u'Fôo')
+        # When parse_addon() raises a NoManifestFound error, we should
+        # still call the linter to let it raise the appropriate error message.
+        tasks.validate_file_path(
+            None, get_addon_file('valid_webextension.xpi'),
+            channel=amo.RELEASE_CHANNEL_LISTED)
+        assert run_addons_linter_mock.call_count == 1
 
 
 class TestWebextensionIncompatibilities(ValidatorTestCase):

--- a/src/olympia/files/tests/test_utils_.py
+++ b/src/olympia/files/tests/test_utils_.py
@@ -41,8 +41,9 @@ class TestExtractor(TestCase):
     def test_no_manifest(self):
         fake_zip = utils.make_xpi({'dummy': 'dummy'})
 
-        with self.assertRaises(forms.ValidationError) as exc:
+        with self.assertRaises(utils.NoManifestFound) as exc:
             utils.Extractor.parse(fake_zip)
+        assert isinstance(exc.exception, forms.ValidationError)
         assert exc.exception.message == (
             'No install.rdf or manifest.json found')
 

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -140,6 +140,10 @@ class UnsupportedFileType(forms.ValidationError):
     pass
 
 
+class NoManifestFound(forms.ValidationError):
+    pass
+
+
 class Extractor(object):
     """Extract add-on info from a manifest file."""
     App = collections.namedtuple('App', 'appdata id min max')
@@ -165,7 +169,7 @@ class Extractor(object):
             data = RDFExtractor(
                 zip_file, certinfo=certificate_info).parse(minimal=minimal)
         else:
-            raise forms.ValidationError(
+            raise NoManifestFound(
                 'No install.rdf or manifest.json found')
         return data
 


### PR DESCRIPTION
The linter knows how to return an appropriate error when there is no manifest, including a link to MDN explaining how to package add-ons properly.

Fix #10635