### PR TITLE
Fix ui tests for new nginx config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,7 @@ jobs:
             # Make sure everything is started
             docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml up -d
             sleep 10
+            docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml sudo chown -R seluser:seluser .
             # Start Test in Firefox docker container
             docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml exec selenium-firefox tox -e ui-tests
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,22 +115,27 @@ jobs:
           command: |
             set -x
             sudo sysctl -w vm.max_map_count=262144
+            # Install UUID
+            sudo apt-get update -qqy && sudo apt-get -qqy install uuid
+            # Pull images
             docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml pull --quiet
+            #Set Fxa Username
+            export UITEST_FXA_EMAIL=uitest-$(uuid)@restmail.net
+            # Start Containers
             docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml up -d
             sleep 20
-            docker-compose ps
-            scripts/ui-test-hostname-setup.sh
+            docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml ps
             # Make sure dependencies get updated in worker and web container
-            docker-compose exec worker make -f Makefile-docker update_deps update_assets
-            docker-compose restart worker
-            docker-compose exec web make -f Makefile-docker update_deps update_assets
-            docker-compose restart web
-            # Delete any existing uitest users within restmail. TEMP FIX: https://github.com/mozilla/addons-server/issues/8980
-            wget --method=DELETE http://restmail.net/mail/uitest
+            docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml exec worker make -f Makefile-docker update_deps update_assets
+            docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml restart worker
+            docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml exec web make -f Makefile-docker update_deps update_assets
+            docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml restart web
             # mod user in firefox container
             docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml exec selenium-firefox sudo usermod -u 1001 seluser
             # proper chown
             sudo chown -R $USER .
+            # Run Ui-tests setup
+            docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml exec web make setup-ui-tests
             # Start Test in Firefox docker container
             docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml exec selenium-firefox tox -e ui-tests
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,11 @@ jobs:
             sudo mv ~/docker-compose /usr/local/bin/docker-compose
             docker-compose --version
       - run:
+          name: Set hosts
+          command: |
+            echo 127.0.0.1 olympia.test | sudo tee -a /etc/hosts
+            cat /etc/hosts
+      - run:
           name: Start container, verify it's running and start tests
           environment:
             UITEST_FXA_EMAIL: uitest-$(uuid)@restmail.net

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,7 @@ jobs:
             sudo sysctl -w vm.max_map_count=262144
             # Install UUID
             sudo apt-get update -qqy && sudo apt-get -qqy install uuid
+            export UITEST_FXA_EMAIL=uitest-$(uuid)@restmail.net
             # Pull images
             docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml pull --quiet
             # Start Containers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,6 @@ jobs:
       - run:
           name: Start container, verify it's running and start tests
           environment:
-            UITEST_FXA_EMAIL: uitest-$(uuid)@restmail.net
             MOZ_HEADLESS: 1
           command: |
             set -x
@@ -143,6 +142,9 @@ jobs:
             sudo chown -R $USER .
             # Run Ui-tests setup
             docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml exec web make setup-ui-tests
+            # Make sure everything is started
+            docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml up -d
+            sleep 10
             # Start Test in Firefox docker container
             docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml exec selenium-firefox tox -e ui-tests
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,7 @@ jobs:
           name: Start container, verify it's running and start tests
           environment:
             MOZ_HEADLESS: 1
+            PYTEST_ADDOPTS="--reruns 2"
           command: |
             set -x
             sudo sysctl -w vm.max_map_count=262144
@@ -147,7 +148,7 @@ jobs:
             sleep 10
             docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml exec selenium-firefox sudo chown -R seluser:seluser .
             # Start Test in Firefox docker container
-            docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml exec selenium-firefox tox -e ui-tests
+            docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml exec selenium-firefox tox -r -e ui-tests
       - store_artifacts:
           path: ui-test.html
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,9 @@ jobs:
             docker-compose --version
       - run:
           name: Start container, verify it's running and start tests
+          environment:
+            UITEST_FXA_EMAIL: uitest-$(uuid)@restmail.net
+            MOZ_HEADLESS: 1
           command: |
             set -x
             sudo sysctl -w vm.max_map_count=262144
@@ -119,8 +122,6 @@ jobs:
             sudo apt-get update -qqy && sudo apt-get -qqy install uuid
             # Pull images
             docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml pull --quiet
-            #Set Fxa Username
-            export UITEST_FXA_EMAIL=uitest-$(uuid)@restmail.net
             # Start Containers
             docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml up -d
             sleep 20

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,7 @@ jobs:
             # mod user in firefox container
             docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml exec selenium-firefox sudo usermod -u 1001 seluser
             # proper chown
-            sudo chown -R $USER .
+            sudo chown -R $USER:$USER .
             # Run Ui-tests setup
             docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml exec web make setup-ui-tests
             # Make sure everything is started

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,7 @@ jobs:
             # Make sure everything is started
             docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml up -d
             sleep 10
-            docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml sudo chown -R seluser:seluser .
+            docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml exec selenium-firefox sudo chown -R seluser:seluser .
             # Start Test in Firefox docker container
             docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml exec selenium-firefox tox -e ui-tests
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ jobs:
           name: Start container, verify it's running and start tests
           environment:
             MOZ_HEADLESS: 1
-            PYTEST_ADDOPTS="--reruns 2"
+            PYTEST_ADDOPTS: "--reruns 2"
           command: |
             set -x
             sudo sysctl -w vm.max_map_count=262144

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,5 +194,4 @@ workflows:
               only: /.*/
             branches:
               ignore: /.*/
-      # Integration tests are disabled while they're broken with py3.
-      # - integration_test
+      - integration_test

--- a/Makefile-docker
+++ b/Makefile-docker
@@ -172,6 +172,9 @@ setup-ui-tests:
 	$(PYTHON_COMMAND) manage.py migrate --noinput --run-syncdb
 	./schematic --fake src/olympia/migrations/
 
+	# Reindex
+	$(PYTHON_COMMAND) manage.py reindex --force --noinput --wipe
+
 	# Let's load some initial data and import mozilla-product versions
 	$(PYTHON_COMMAND) manage.py loaddata initial.json
 	$(PYTHON_COMMAND) manage.py loaddata zadmin/users

--- a/Makefile-docker
+++ b/Makefile-docker
@@ -189,8 +189,6 @@ setup-ui-tests:
 	$(PYTHON_COMMAND) manage.py generate_themes $(NUM_THEMES)
 	$(PYTHON_COMMAND) manage.py generate_default_addons_for_frontend
 
-	# Now that addons have been generated, reindex.
-	$(PYTHON_COMMAND) manage.py reindex --force --noinput --wipe
 	# Also update category counts (denormalized field)
 	$(PYTHON_COMMAND) manage.py cron category_totals
 

--- a/Makefile-docker
+++ b/Makefile-docker
@@ -7,8 +7,8 @@ export PIP_COMMAND=pip${PYTHON_VERSION_MAJOR}
 export PYTHON_COMMAND=python${PYTHON_VERSION_MAJOR}
 
 # FXA username and password for ui-tests
-export FXA_EMAIL=uitest-$(shell uuid)@restmail.net
-export FXA_PASSWORD=uitester
+export FXA_EMAIL=${UITEST_FXA_EMAIL}
+export FXA_PASSWORD=${UITEST_FXA_PASSWORD}
 
 NUM_ADDONS=10
 NUM_THEMES=$(NUM_ADDONS)
@@ -176,20 +176,26 @@ setup-ui-tests:
 	$(PYTHON_COMMAND) manage.py loaddata initial.json
 	$(PYTHON_COMMAND) manage.py loaddata zadmin/users
 	$(PYTHON_COMMAND) manage.py loaddata src/olympia/access/fixtures/initial.json
-
 	$(PYTHON_COMMAND) manage.py import_prod_versions
 
 	# Create a proper superuser that can be used to access the API
 	$(PYTHON_COMMAND) manage.py waffle_switch super-create-accounts on --create
 	$(PYTHON_COMMAND) manage.py waffle_switch activate-autograph-signing on --create
+	$(PYTHON_COMMAND) manage.py generate_addons --app firefox $(NUM_ADDONS)
+	$(PYTHON_COMMAND) manage.py generate_addons --app android $(NUM_ADDONS)
+	$(PYTHON_COMMAND) manage.py generate_themes $(NUM_THEMES)
+	$(PYTHON_COMMAND) manage.py generate_default_addons_for_frontend
+
+	# Now that addons have been generated, reindex.
+	$(PYTHON_COMMAND) manage.py reindex --force --noinput --wipe
+	# Also update category counts (denormalized field)
+	$(PYTHON_COMMAND) manage.py cron category_totals
 
 .PHONY: run-ui-tests
-run-ui-tests: setup-ui-tests
+run-ui-tests:
 	# Generate test add-ons and force a reindex to make sure things are updated
 	$(PIP_COMMAND) install --progress-bar=off --no-deps -r requirements/uitests.txt
 	$(PYTHON_COMMAND) manage.py generate_default_addons_for_frontend
-	$(PYTHON_COMMAND) manage.py reindex --force --noinput --wipe
-	pytest --driver Firefox tests/ui/
 
 .PHONY: perf-tests
 perf-tests: setup-ui-tests

--- a/Makefile-docker
+++ b/Makefile-docker
@@ -193,9 +193,7 @@ setup-ui-tests:
 
 .PHONY: run-ui-tests
 run-ui-tests:
-	# Generate test add-ons and force a reindex to make sure things are updated
-	$(PIP_COMMAND) install --progress-bar=off --no-deps -r requirements/uitests.txt
-	$(PYTHON_COMMAND) manage.py generate_default_addons_for_frontend
+	docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml exec selenium-firefox tox -e ui-tests
 
 .PHONY: perf-tests
 perf-tests: setup-ui-tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ x-env-mapping: &env
     - PYTHONDONTWRITEBYTECODE=1
     - PYTHONUNBUFFERED=1
     - TERM=xterm-256color
+    - UITEST_FXA_EMAIL
+    - UITEST_FXA_PASSWORD=uitester
 
 services:
   worker: &worker
@@ -39,6 +41,8 @@ services:
       - ./site-static:/srv/site-static
       - ./storage/shared_storage/uploads:/srv/user-media
       - ./storage/files:/srv/user-media/addons
+    ports:
+      - "80:80"
 
   memcached:
     image: memcached:1.4
@@ -83,11 +87,13 @@ services:
   addons-frontend:
     <<: *env
     environment:
+      - API_HOST=http://olympia.test
+      - PROXY_API_HOST=http://olympia.test
       - HOSTNAME=uitests
       - WEBPACK_SERVER_HOST=olympia.test
       - CSP=false
       - FXA_CONFIG=default
-    image: addons/addons-frontend
+    image: addons/addons-frontend:latest
     ports:
       - "3000:3000"
       - "3001:3001"

--- a/requirements/uitests.txt
+++ b/requirements/uitests.txt
@@ -26,6 +26,9 @@ pytest-instafail==0.4.1 \
 pytest-metadata==1.8.0 \
     --hash=sha256:c29a1fb470424926c63154c1b632c02585f2ba4282932058a71d35295ff8c96d \
     --hash=sha256:2071a59285de40d7541fde1eb9f1ddea1c9db165882df82781367471238b66ba
+pytest-rerunfailures==6.0 \
+    --hash=sha256:267e10c6aec4230bdee410fcb83901e4b41e4d7f53dff216c7f06c4c0dd6fd3f \
+    --hash=sha256:978349ae00687504fd0f9d0970c37199ccd89cbdb0cb8c4ed7ee417ede582b40
 pytest-selenium==1.16.0 \
     --hash=sha256:18c5db66512efcf6db9e32cfe8dcd0b69ef11ac1e8b9a4ce8a1b4813e6c73c9a \
     --hash=sha256:c4d5a73d501f9fb3afb70e781f6fc2106a7b5f64387ed449b15eb1df61fa7915

--- a/scripts/ui-test-hostname-setup.sh
+++ b/scripts/ui-test-hostname-setup.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-# This script sets the ip of the addons-frontend image as localhost within the selenium-firefox image.
-# This MUST be run before any user integration tests.
-
-UI_IP="`docker inspect addons-server_addons-frontend_1 | grep "IPAddress" | grep -oE "\b([0-9]{1,3}\.){3}[0-9]{1,3}\b"`"
-echo $UI_IP
-HOSTS_LINE="$UI_IP\tlocalhost"
-docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml exec --user root selenium-firefox sudo -- sh -c -e "echo '$HOSTS_LINE' >> /etc/hosts"
-docker-compose -f docker-compose.yml -f tests/ui/docker-compose.selenium.yml exec --user root selenium-firefox cat /etc/hosts

--- a/src/olympia/landfill/serializers.py
+++ b/src/olympia/landfill/serializers.py
@@ -42,8 +42,8 @@ class GenerateAddonsSerializer(serializers.Serializer):
     count = serializers.IntegerField(default=10)
 
     def __init__(self):
-        self.fxa_email = os.environ['FXA_EMAIL']
-        self.fxa_password = os.environ['FXA_PASSWORD']
+        self.fxa_email = os.environ['UITEST_FXA_EMAIL']
+        self.fxa_password = os.environ['UITEST_FXA_PASSWORD']
         self.fxa_id = self._create_fxa_user()
         self.user = self._create_addon_user()
 

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -33,7 +33,6 @@ def firefox_options(firefox_options):
     firefox_options.set_preference('extensions.webapi.testing', True)
     firefox_options.set_preference('ui.popup.disable_autohide', True)
     firefox_options.add_argument('-foreground')
-    # firefox_options.add_argument('-headless')
     firefox_options.log.level = 'trace'
     return firefox_options
 

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -33,7 +33,7 @@ def firefox_options(firefox_options):
     firefox_options.set_preference('extensions.webapi.testing', True)
     firefox_options.set_preference('ui.popup.disable_autohide', True)
     firefox_options.add_argument('-foreground')
-    firefox_options.add_argument('-headless')
+    # firefox_options.add_argument('-headless')
     firefox_options.log.level = 'trace'
     return firefox_options
 
@@ -74,8 +74,8 @@ def fxa_account(request):
 
     """
     try:
-        fxa_account.email = os.environ['FXA_EMAIL']
-        fxa_account.password = os.environ['FXA_PASSWORD']
+        fxa_account.email = os.environ['UITEST_FXA_EMAIL']
+        fxa_account.password = os.environ['UITEST_FXA_PASSWORD']
     except KeyError:
         if request.node.get_closest_marker('fxa_login'):
             pytest.skip(

--- a/tests/ui/docker-compose.selenium.yml
+++ b/tests/ui/docker-compose.selenium.yml
@@ -15,6 +15,7 @@ x-env-mapping: &env
     - TERM=xterm-256color
     - UITEST_FXA_EMAIL
     - UITEST_FXA_PASSWORD=uitester
+    - MOZ_HEADLESS=1
 
 services:
   selenium-firefox:

--- a/tests/ui/docker-compose.selenium.yml
+++ b/tests/ui/docker-compose.selenium.yml
@@ -13,11 +13,13 @@ x-env-mapping: &env
     - PYTHONDONTWRITEBYTECODE=1
     - PYTHONUNBUFFERED=1
     - TERM=xterm-256color
+    - UITEST_FXA_EMAIL
+    - UITEST_FXA_PASSWORD=uitester
 
 services:
   selenium-firefox:
     <<: *env
-    image: b4handjr/selenium-firefox
+    image: b4handjr/selenium-firefox:python3-latest
     volumes:
       - .:/code
     expose:
@@ -25,5 +27,4 @@ services:
     ports:
       - "5900"
     shm_size: 2g
-    links:
-      - "nginx:olympia.test"
+    network_mode: host

--- a/tests/ui/docker-compose.selenium.yml
+++ b/tests/ui/docker-compose.selenium.yml
@@ -16,6 +16,7 @@ x-env-mapping: &env
     - UITEST_FXA_EMAIL
     - UITEST_FXA_PASSWORD=uitester
     - MOZ_HEADLESS=1
+    - PYTEST_ADDOPTS=${PYTEST_ADDOPTS}
 
 services:
   selenium-firefox:

--- a/tests/ui/pages/desktop/base.py
+++ b/tests/ui/pages/desktop/base.py
@@ -114,11 +114,9 @@ class Header(Region):
         # menu. It pauses between each action to account for lag.
         action = ActionChains(self.selenium)
         action.move_to_element(menu)
-        action.pause(2)
         action.click()
         action.pause(2)
         action.move_to_element(links[item])
-        action.pause(2)
         action.click()
         action.pause(2)
         action.perform()

--- a/tests/ui/setup.cfg
+++ b/tests/ui/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-addopts = -vs --tb=long --showlocals --html=ui-test.html --self-contained-html --reruns 2
+addopts = -vs --tb=long --showlocals --html=ui-test.html --self-contained-html
 sensitive_url = mozilla\.(com|org)
 xfail_strict = true
 DJANGO_SETTINGS_MODULE = settings

--- a/tests/ui/setup.cfg
+++ b/tests/ui/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-addopts = -vs --tb=long --showlocals --html=ui-test.html --self-contained-html
+addopts = -vs --tb=long --showlocals --html=ui-test.html --self-contained-html --reruns 2
 sensitive_url = mozilla\.(com|org)
 xfail_strict = true
 DJANGO_SETTINGS_MODULE = settings

--- a/tests/ui/test_devhub.py
+++ b/tests/ui/test_devhub.py
@@ -52,7 +52,7 @@ def test_devhub_logout(base_url, selenium, devhub_login):
 @pytest.mark.nondestructive
 def test_devhub_register(base_url, selenium):
     """Test register link loads register page."""
-    selenium.get('{}/en-US/developers/'.format(base_url))
+    selenium.get('{}/developers'.format(base_url))
     devhub = DevHub(selenium, base_url)
     assert not devhub.logged_in
     devhub.header.register()

--- a/tox.ini
+++ b/tox.ini
@@ -79,6 +79,7 @@ commands =
         {posargs}
 
 [testenv:ui-tests]
+recreate = True
 commands =
     make -f Makefile-docker update_deps
     pip install --no-deps -r requirements/uitests.txt

--- a/tox.ini
+++ b/tox.ini
@@ -79,7 +79,6 @@ commands =
         {posargs}
 
 [testenv:ui-tests]
-recreate = True
 commands =
     make -f Makefile-docker update_deps
     pip install --no-deps -r requirements/uitests.txt

--- a/tox.ini
+++ b/tox.ini
@@ -80,7 +80,7 @@ commands =
 
 [testenv:ui-tests]
 commands =
-    make -f Makefile-docker install_python_dev_dependencies
+    make -f Makefile-docker update_deps
     pip install --no-deps -r requirements/uitests.txt
     pytest --driver Firefox tests/ui/ {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -79,10 +79,6 @@ commands =
         {posargs}
 
 [testenv:ui-tests]
-setenv =
-    FXA_EMAIL=uitest-$(shell uuid)@restmail.net
-    FXA_PASSWORD=uitester
-
 commands =
     make -f Makefile-docker install_python_dev_dependencies
     pip install --no-deps -r requirements/uitests.txt

--- a/tox.ini
+++ b/tox.ini
@@ -79,9 +79,14 @@ commands =
         {posargs}
 
 [testenv:ui-tests]
+setenv =
+    FXA_EMAIL=uitest-$(shell uuid)@restmail.net
+    FXA_PASSWORD=uitester
+
 commands =
-    make -f Makefile-docker update_deps
-    make -f Makefile-docker run-ui-tests
+    make -f Makefile-docker install_python_dev_dependencies
+    pip install --no-deps -r requirements/uitests.txt
+    pytest --driver Firefox tests/ui/ {posargs}
 
 [testenv:assets]
 commands =


### PR DESCRIPTION
I don't think we have an issue but the UI tests have been failing for a while now due to the nginx config and some other problems. This should fix them. 

Everything routes through nginx and ```http://olympia.test```. These can also been run locally outside of the docker container. I will add a PR with instructions later.