### PR TITLE
Unpin celery, upgrading it to 4.2.x

### DIFF
--- a/requirements/prod_common.txt
+++ b/requirements/prod_common.txt
@@ -131,9 +131,9 @@ bleach==3.1.0 \
 boto3==1.9.114 \
     --hash=sha256:392a34d1c29b3d2b4b26aad79e2acbe960e70942a2e326aedc8c25d222927b8b \
     --hash=sha256:b2cbb8cda35e972c616af5967ac76ee61b18d0423d821eaf8e9c44dca595844d
-celery==4.1.1 \
-    --hash=sha256:6fc4678d1692af97e137b2a9f1c04efd8e7e2fb7134c5c5ad60738cdd927762f \
-    --hash=sha256:d1f2a3359bdbdfb344edce98b8e891f5fe64f8a11c5a45538ec20ac237c971f5 # pyup: <4.2
+celery==4.2.1 \
+    --hash=sha256:77dab4677e24dc654d42dfbdfed65fa760455b6bb563a0877ecc35f4cfcfc678 \
+    --hash=sha256:ad7a7411772b80a4d6c64f2f7f723200e39fb66cf614a7fdfab76d345acc7b13
 botocore==1.12.114 \
     --hash=sha256:87daf4a9545016d3307e5dbdfa471b084fb1b80fa39f9f47a67dd2b4d8b26b36 \
     --hash=sha256:f053c8c8938f698c25e26b42713e5f125ba562eb282fe454f0397536322f5dee

--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -208,7 +208,7 @@ def decode_json(json_string):
 def send_mail(subject, message, from_email=None, recipient_list=None,
               use_deny_list=True, perm_setting=None, manage_url=None,
               headers=None, cc=None, real_email=False, html_message=None,
-              attachments=None, max_retries=3, reply_to=None):
+              attachments=None, reply_to=None):
     """
     A wrapper around django.core.mail.EmailMessage.
 
@@ -270,7 +270,6 @@ def send_mail(subject, message, from_email=None, recipient_list=None,
             'from_email': from_email,
             'headers': headers,
             'html_message': html_message,
-            'max_retries': max_retries,
             'real_email': real_email,
             'reply_to': reply_to,
         }


### PR DESCRIPTION
This caused a few tests that do manual retrying of a task to fail in unit tests, celery now throwing an error if you try to fetch a result within a task, which `retry()` does. This appears to be only in eager mode though (works fine locally), so I removed the test and used celery's `autoretry_for` feature instead of our manual retry.

Hopefully fixes #9068