### PR TITLE
Refactor validation tasks chain to avoid passing results to each task

### DIFF
--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -886,7 +886,7 @@ class TestUpload(BaseUploadTest):
         msg = validation['messages'][0]
         assert msg['type'] == u'error'
         assert msg['message'] == (
-            u'Unsupported file type, please upload an a supported file '
+            u'Unsupported file type, please upload a supported file '
             '(.crx, .xpi, .jar, .xml, .json, .zip).')
         assert not msg['description']
 

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -535,18 +535,18 @@ def handle_upload(filedata, request, channel, addon=None, is_standalone=False,
             existing_data=existing_data)
     else:
         akismet_reports = []
-    # We HAVE to have a pretask here that returns a result, so we're always
-    # doing a comment_check task call even when it's pointless because
-    # there are no report ids in the list.  See tasks.validate for more.
-    akismet_checks = akismet_comment_check.si(
-        [report.id for _, report in akismet_reports])
+    if akismet_reports:
+        pretask = akismet_comment_check.si(
+            [report.id for _, report in akismet_reports])
+    else:
+        pretask = None
     if submit:
         tasks.validate_and_submit(
-            addon, upload, channel=channel, pretask=akismet_checks)
+            addon, upload, channel=channel, pretask=pretask)
     else:
         tasks.validate(
             upload, listed=(channel == amo.RELEASE_CHANNEL_LISTED),
-            pretask=akismet_checks)
+            pretask=pretask)
 
     return upload
 

--- a/src/olympia/files/tests/test_models.py
+++ b/src/olympia/files/tests/test_models.py
@@ -43,15 +43,21 @@ class UploadTest(TestCase, amo.tests.AMOPaths):
     def file_path(self, *args, **kw):
         return self.file_fixture_path(*args, **kw)
 
-    def get_upload(self, filename=None, abspath=None, validation=None):
+    def get_upload(self, filename=None, abspath=None, validation=None,
+                   addon=None, user=None, version=None, with_validation=True):
         with open(abspath if abspath else self.file_path(filename), 'rb') as f:
             xpi = f.read()
         upload = FileUpload.from_post([xpi], filename=abspath or filename,
                                       size=1234)
-        # Simulate what fetch_manifest() does after uploading an app.
-        upload.validation = (validation or
-                             json.dumps(dict(errors=0, warnings=1, notices=2,
-                                             metadata={}, messages=[])))
+        upload.addon = addon
+        upload.user = user
+        upload.version = version
+        if with_validation:
+            # Simulate what fetch_manifest() does after uploading an app.
+            upload.validation = validation or json.dumps({
+                'errors': 0, 'warnings': 1, 'notices': 2, 'metadata': {},
+                'messages': []
+            })
         upload.save()
         return upload
 

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -1083,7 +1083,7 @@ def parse_addon(pkg, addon=None, user=None, minimal=False):
             amo.VALID_ADDON_FILE_EXTENSIONS)
         raise UnsupportedFileType(
             ugettext(
-                'Unsupported file type, please upload an a supported '
+                'Unsupported file type, please upload a supported '
                 'file {extensions}.'.format(
                     extensions=valid_extensions_string)))
 

--- a/src/olympia/lib/akismet/tasks.py
+++ b/src/olympia/lib/akismet/tasks.py
@@ -13,11 +13,11 @@ def submit_to_akismet(report_ids, submit_spam):
         report.submit_spam() if submit_spam else report.submit_ham()
 
 
-@task(ignore_result=False)
+@task
 def akismet_comment_check(report_ids):
     reports = AkismetReport.objects.filter(id__in=report_ids)
-    return [
-        (report.comment_type, report.comment_check()) for report in reports]
+    for report in reports:
+        report.comment_check()
 
 
 @task


### PR DESCRIPTION
This makes the `pretask` argument more generic, allowing us to stop modifying the tasks in the rest of the validation chain when we add/remove one at the beginning.

Fix #10933