### PR TITLE
change travis to test on django22; drop python2 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 dist: xenial
 
 python:
-  - 2.7
+  - 3.6
 
 jobs:
   fast_finish: true
@@ -17,17 +17,14 @@ jobs:
     - { env: TOXENV=accounts-users-and-ratings }
     - { env: TOXENV=amo-lib-locales-and-signing }
     - { env: TOXENV=main }
-    - { python: 3.6, env: TOXENV=codestyle}
-    - { python: 3.6, env: TOXENV=docs }
-    - { python: 3.6, env: TOXENV=assets }
-    - { python: 3.6, env: TOXENV=es }
-    - { python: 3.6, env: TOXENV=addons-versions-and-files }
-    - { python: 3.6, env: TOXENV=devhub }
-    - { python: 3.6, env: TOXENV=reviewers-and-zadmin }
-    - { python: 3.6, env: TOXENV=accounts-users-and-ratings }
-    - { python: 3.6, env: TOXENV=amo-lib-locales-and-signing }
-    - { python: 3.6, env: TOXENV=main }
-    - { python: 3.6, env: TOXENV=assets  DJANGO=django22 }
+    - { env: TOXENV=assets DJANGO=django22 }
+    - { env: TOXENV=es DJANGO=django22 }
+    - { env: TOXENV=addons-versions-and-files DJANGO=django22 }
+    - { env: TOXENV=devhub DJANGO=django22 }
+    - { env: TOXENV=reviewers-and-zadmin DJANGO=django22 }
+    - { env: TOXENV=accounts-users-and-ratings DJANGO=django22 }
+    - { env: TOXENV=amo-lib-locales-and-signing DJANGO=django22 }
+    - { env: TOXENV=main DJANGO=django22 }
 
 env:
   global:

--- a/requirements/prod_py3django22.txt
+++ b/requirements/prod_py3django22.txt
@@ -1,8 +1,8 @@
 -r prod_common.txt
 
-Django==2.2b1 \
-    --hash=sha256:58819ca72a13b963c16383687421261657abe5754aad9ad66166a921dd17559f \
-    --hash=sha256:62644444551e8e6fd36600e741a4d24dd2b4b58acf7bae8847a8da952468d771
+Django==2.2rc1 \
+    --hash=sha256:6cdb98d464e5ffc9cbe3d3ca5ca74d61e69ce1784d5e15b85ceb19dee939f650 \
+    --hash=sha256:b74420065c5a3f7bcb07c0811b1308239c05989e29963ff39f7b5e9c1cacc195
 # atpublic is required by flufl.lock
 atpublic==1.0 \
     --hash=sha256:7dca670499e9a9d3aae5a8914bc799475fe24be3bcd29c8129642dda665f7a44


### PR DESCRIPTION
fixes #10715 - doesn't remove any of the support for python2 or python2 testing if we need to quickly add it back (for now)