### PR TITLE
Strip hunk header and line content trailing newlines.

### DIFF
--- a/src/olympia/lib/git.py
+++ b/src/olympia/lib/git.py
@@ -488,7 +488,7 @@ class AddonGitRepository(object):
                     origin = '-'
 
                 changes.append({
-                    'content': line.content,
+                    'content': line.content.rstrip('\r\n'),
                     'type': GIT_DIFF_LINE_MAPPING[origin],
                     # Can be `-1` for additions
                     'old_line_number': line.old_lineno,
@@ -496,7 +496,7 @@ class AddonGitRepository(object):
                 })
 
             hunks.append({
-                'header': hunk.header,
+                'header': hunk.header.rstrip('\r\n'),
                 'old_start': hunk.old_start,
                 'new_start': hunk.new_start,
                 'old_lines': hunk.old_lines,

--- a/src/olympia/lib/tests/test_git.py
+++ b/src/olympia/lib/tests/test_git.py
@@ -467,7 +467,7 @@ def test_get_diff_add_new_file():
 
     assert changes[0]['hunks'] == [{
         'changes': [{
-            'content': '{"id": "random"}\n',
+            'content': '{"id": "random"}',
             'new_line_number': 1,
             'old_line_number': -1,
             'type': 'insert'
@@ -476,7 +476,7 @@ def test_get_diff_add_new_file():
         'new_start': 1,
         'old_lines': 0,
         'old_start': 0,
-        'header': '@@ -0,0 +1 @@\n',
+        'header': '@@ -0,0 +1 @@',
     }]
 
     assert changes[0]['is_binary'] is False
@@ -527,7 +527,7 @@ def test_get_diff_change_files():
     # removing everything and adding new content
     assert len(changes[0]['hunks']) == 1
 
-    assert changes[0]['hunks'][0]['header'] == '@@ -1,25 +1 @@\n'
+    assert changes[0]['hunks'][0]['header'] == '@@ -1,25 +1 @@'
     assert changes[0]['hunks'][0]['old_start'] == 1
     assert changes[0]['hunks'][0]['new_start'] == 1
     assert changes[0]['hunks'][0]['old_lines'] == 25
@@ -536,7 +536,7 @@ def test_get_diff_change_files():
     hunk_changes = changes[0]['hunks'][0]['changes']
 
     assert hunk_changes[0] == {
-        'content': '# notify-link-clicks-i18n\n',
+        'content': '# notify-link-clicks-i18n',
         'new_line_number': -1,
         'old_line_number': 1,
         'type': 'delete'
@@ -545,7 +545,7 @@ def test_get_diff_change_files():
     assert all(x['type'] == 'delete' for x in hunk_changes[:-1])
 
     assert hunk_changes[-1] == {
-        'content': 'Updated readme\n',
+        'content': 'Updated readme',
         'new_line_number': 1,
         'old_line_number': -1,
         'type': 'insert',
@@ -566,7 +566,7 @@ def test_get_diff_change_files():
     # removing everything and adding new content
     assert len(changes[1]['hunks']) == 1
 
-    assert changes[1]['hunks'][0]['header'] == '@@ -1,32 +1 @@\n'
+    assert changes[1]['hunks'][0]['header'] == '@@ -1,32 +1 @@'
     assert changes[1]['hunks'][0]['old_start'] == 1
     assert changes[1]['hunks'][0]['new_start'] == 1
     assert changes[1]['hunks'][0]['old_lines'] == 32
@@ -577,7 +577,7 @@ def test_get_diff_change_files():
     assert all(x['type'] == 'delete' for x in hunk_changes[:-1])
 
     assert hunk_changes[-1] == {
-        'content': '{"id": "random"}\n',
+        'content': '{"id": "random"}',
         'new_line_number': 1,
         'old_line_number': -1,
         'type': 'insert'
@@ -700,7 +700,7 @@ def test_get_diff_change_files_pathspec():
     # removing everything and adding new content
     assert len(changes[0]['hunks']) == 1
 
-    assert changes[0]['hunks'][0]['header'] == '@@ -1,25 +1 @@\n'
+    assert changes[0]['hunks'][0]['header'] == '@@ -1,25 +1 @@'
     assert changes[0]['hunks'][0]['old_start'] == 1
     assert changes[0]['hunks'][0]['new_start'] == 1
     assert changes[0]['hunks'][0]['old_lines'] == 25
@@ -709,7 +709,7 @@ def test_get_diff_change_files_pathspec():
     hunk_changes = changes[0]['hunks'][0]['changes']
 
     assert hunk_changes[0] == {
-        'content': '# notify-link-clicks-i18n\n',
+        'content': '# notify-link-clicks-i18n',
         'new_line_number': -1,
         'old_line_number': 1,
         'type': 'delete'
@@ -718,7 +718,7 @@ def test_get_diff_change_files_pathspec():
     assert all(x['type'] == 'delete' for x in hunk_changes[:-1])
 
     assert hunk_changes[-1] == {
-        'content': 'Updated readme\n',
+        'content': 'Updated readme',
         'new_line_number': 1,
         'old_line_number': -1,
         'type': 'insert',

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -5285,7 +5285,7 @@ class TestReviewAddonVersionViewSetDetail(
         assert response.status_code == 200
         result = json.loads(response.content)
 
-        assert result['file']['content'] == '# beastify\n'
+        assert result['file']['content'] == '# beastify'
 
     def test_version_get_not_found(self):
         user = UserProfile.objects.create(username='reviewer')
@@ -5503,7 +5503,7 @@ class TestReviewAddonVersionCompareViewSet(
 
         change = result['file']['diff'][0]['hunks'][0]['changes'][0]
 
-        assert change['content'] == '# beastify\n'
+        assert change['content'] == '# beastify'
         assert change['type'] == 'insert'
 
     def test_version_get_not_found(self):
@@ -5543,13 +5543,13 @@ class TestReviewAddonVersionCompareViewSet(
         assert result['file']['diff'][0]['path'] == 'README.md'
         assert result['file']['diff'][0]['hunks'][0]['changes'] == [
             {
-                'content': '# beastify\n',
+                'content': '# beastify',
                 'new_line_number': -1,
                 'old_line_number': 1,
                 'type': 'delete'
             },
             {
-                'content': 'Updated readme\n',
+                'content': 'Updated readme',
                 'new_line_number': 1,
                 'old_line_number': -1,
                 'type': 'insert'

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -5285,7 +5285,7 @@ class TestReviewAddonVersionViewSetDetail(
         assert response.status_code == 200
         result = json.loads(response.content)
 
-        assert result['file']['content'] == '# beastify'
+        assert result['file']['content'] == '# beastify\n'
 
     def test_version_get_not_found(self):
         user = UserProfile.objects.create(username='reviewer')


### PR DESCRIPTION
Fixes #10932

~~cc @willdurand 	about the header part, otherwise I'll only normalize the content trailing newlines.~~

> 10:20 <@willdurand> cgrebs: I am not sure we're using `header` but I would also remove trailing newlines because that's likely what gitdiff-parser does