### PR TITLE
Refactor strict_min_version handling to avoid skipping apps silently

### DIFF
--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -2179,22 +2179,36 @@ class TestListedAddonTwoVersions(TestCase):
 class TestAddonFromUpload(UploadTest):
     fixtures = ['base/users']
 
+    @classmethod
+    def setUpTestData(self):
+        versions = {
+            '3.0',
+            '3.6.*',
+            amo.DEFAULT_WEBEXT_MIN_VERSION,
+            amo.DEFAULT_WEBEXT_MIN_VERSION_ANDROID,
+            amo.DEFAULT_WEBEXT_MIN_VERSION_NO_ID,
+            amo.DEFAULT_WEBEXT_MAX_VERSION,
+        }
+        for version in versions:
+            AppVersion.objects.create(
+                application=amo.FIREFOX.id, version=version)
+            AppVersion.objects.create(
+                application=amo.ANDROID.id, version=version)
+
     def setUp(self):
         super(TestAddonFromUpload, self).setUp()
         u = UserProfile.objects.get(pk=999)
         core.set_user(u)
         self.selected_app = amo.FIREFOX.id
-        for version in ('3.0', '3.6.*'):
-            AppVersion.objects.create(application=1, version=version)
         self.addCleanup(translation.deactivate)
 
         def _app(application):
             return Extractor.App(
                 appdata=application, id=application.id,
-                min=AppVersion.objects.get_or_create(
-                    application=application.id, version='3.0')[0],
-                max=AppVersion.objects.get_or_create(
-                    application=application.id, version='3.6.*')[0])
+                min=AppVersion.objects.get(
+                    application=application.id, version='3.0'),
+                max=AppVersion.objects.get(
+                    application=application.id, version='3.6.*'))
 
         self.dummy_parsed_data = {
             'guid': 'guid@xpi',

--- a/src/olympia/addons/tests/test_tasks.py
+++ b/src/olympia/addons/tests/test_tasks.py
@@ -150,6 +150,19 @@ class TestAddStaticThemeFromLwt(TestCase):
     modify_date = datetime(2008, 8, 8, 8, 8, 8)
     update_date = datetime(2009, 9, 9, 9, 9, 9)
 
+    @classmethod
+    def setUpTestData(cls):
+        versions = {
+            amo.DEFAULT_WEBEXT_MAX_VERSION,
+            amo.DEFAULT_STATIC_THEME_MIN_VERSION_FIREFOX,
+            amo.DEFAULT_STATIC_THEME_MIN_VERSION_ANDROID,
+        }
+        for version in versions:
+            AppVersion.objects.create(
+                application=amo.FIREFOX.id, version=version)
+            AppVersion.objects.create(
+                application=amo.ANDROID.id, version=version)
+
     def setUp(self):
         super(TestAddStaticThemeFromLwt, self).setUp()
         self.call_signing_mock = self.patch(
@@ -158,10 +171,6 @@ class TestAddStaticThemeFromLwt(TestCase):
             'olympia.addons.tasks.build_static_theme_xpi_from_lwt')
         self.build_mock.side_effect = self._mock_xpi_side_effect
         self.call_signing_mock.return_value = 'abcdefg1234'
-        AppVersion.objects.get_or_create(
-            application=amo.FIREFOX.id, version='53.0')
-        AppVersion.objects.get_or_create(
-            application=amo.FIREFOX.id, version='*')
         user_factory(id=settings.TASK_USER_ID, email='taskuser@mozilla.com')
 
     def _mock_xpi_side_effect(self, lwt, upload_path):

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -820,15 +820,22 @@ def developer_factory(**kw):
 
 
 def create_default_webext_appversion():
-    AppVersion.objects.get_or_create(
-        application=amo.ANDROID.id, version='48.0')
-    AppVersion.objects.get_or_create(
-        application=amo.ANDROID.id, version='*')
+    versions = {
+        amo.DEFAULT_WEBEXT_MIN_VERSION,
+        amo.DEFAULT_WEBEXT_MIN_VERSION_NO_ID,
+        amo.DEFAULT_STATIC_THEME_MIN_VERSION_FIREFOX,
+        amo.DEFAULT_WEBEXT_MAX_VERSION,
+    }
+    for version in versions:
+        AppVersion.objects.create(application=amo.FIREFOX.id, version=version)
 
-    AppVersion.objects.get_or_create(
-        application=amo.FIREFOX.id, version='48.0')
-    AppVersion.objects.get_or_create(
-        application=amo.FIREFOX.id, version='*')
+    versions = {
+        amo.DEFAULT_WEBEXT_MIN_VERSION_ANDROID,
+        amo.DEFAULT_STATIC_THEME_MIN_VERSION_ANDROID,
+        amo.DEFAULT_WEBEXT_MAX_VERSION,
+    }
+    for version in versions:
+        AppVersion.objects.create(application=amo.ANDROID.id, version=version)
 
 
 def version_factory(file_kw=None, **kw):

--- a/src/olympia/devhub/tests/test_utils.py
+++ b/src/olympia/devhub/tests/test_utils.py
@@ -16,6 +16,7 @@ from olympia import amo
 from olympia.amo.storage_utils import copy_stored_file
 from olympia.amo.tests import (
     addon_factory, TestCase, user_factory, version_factory)
+from olympia.applications.models import AppVersion
 from olympia.devhub import tasks, utils
 from olympia.files.models import FileUpload
 from olympia.lib.akismet.models import AkismetReport
@@ -421,6 +422,15 @@ class TestGetAddonAkismetReports(TestCase):
 
 @pytest.mark.django_db
 def test_extract_theme_properties():
+    versions = {
+        amo.DEFAULT_WEBEXT_MAX_VERSION,
+        amo.DEFAULT_STATIC_THEME_MIN_VERSION_FIREFOX,
+        amo.DEFAULT_STATIC_THEME_MIN_VERSION_ANDROID,
+    }
+    for version in versions:
+        AppVersion.objects.create(application=amo.FIREFOX.id, version=version)
+        AppVersion.objects.create(application=amo.ANDROID.id, version=version)
+
     addon = addon_factory(type=amo.ADDON_STATICTHEME)
     result = utils.extract_theme_properties(
         addon, addon.current_version.channel)

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -914,16 +914,26 @@ class TestUpload(BaseUploadTest):
 class TestUploadDetail(BaseUploadTest):
     fixtures = ['base/appversion', 'base/users']
 
+    @classmethod
+    def setUpTestData(cls):
+        versions = {
+            '51.0a1',
+            amo.DEFAULT_WEBEXT_MIN_VERSION,
+            amo.DEFAULT_WEBEXT_MIN_VERSION_ANDROID,
+            amo.DEFAULT_WEBEXT_MAX_VERSION
+        }
+        for version in versions:
+            cls.create_appversion('firefox', version)
+            cls.create_appversion('android', version)
+
     def setUp(self):
         super(TestUploadDetail, self).setUp()
-        self.create_appversion('firefox', '*')
-        self.create_appversion('firefox', '51.0a1')
-
         assert self.client.login(email='regular@mozilla.com')
 
-    def create_appversion(self, name, version):
+    @classmethod
+    def create_appversion(cls, application_name, version):
         return AppVersion.objects.create(
-            application=amo.APPS[name].id, version=version)
+            application=amo.APPS[application_name].id, version=version)
 
     def post(self):
         # Has to be a binary, non xpi file.

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -340,9 +340,12 @@ class TestAddonSubmitDistribution(TestCase):
 class TestAddonSubmitUpload(UploadTest, TestCase):
     fixtures = ['base/users']
 
+    @classmethod
+    def setUpTestData(cls):
+        create_default_webext_appversion()
+
     def setUp(self):
         super(TestAddonSubmitUpload, self).setUp()
-        create_default_webext_appversion()
         self.upload = self.get_upload('webextension_no_id.xpi')
         assert self.client.login(email='regular@mozilla.com')
         self.client.post(reverse('devhub.submit.agreement'))
@@ -517,7 +520,7 @@ class TestAddonSubmitUpload(UploadTest, TestCase):
         self.assert3xx(
             response, reverse('devhub.submit.details', args=[addon.slug]))
         all_ = sorted([f.filename for f in addon.current_version.all_files])
-        assert all_ == [u'weta_fade-1.0.xpi']  # One XPI for all platforms.
+        assert all_ == [u'weta_fade-1.0-an+fx.xpi']  # A single XPI for all.
         assert addon.type == amo.ADDON_STATICTHEME
         previews = list(addon.current_version.previews.all())
         assert len(previews) == 3
@@ -538,7 +541,7 @@ class TestAddonSubmitUpload(UploadTest, TestCase):
         self.assert3xx(
             response, reverse('devhub.submit.finish', args=[addon.slug]))
         all_ = sorted([f.filename for f in latest_version.all_files])
-        assert all_ == [u'weta_fade-1.0.xpi']  # One XPI for all platforms.
+        assert all_ == [u'weta_fade-1.0-an+fx.xpi']  # A single XPI for all.
         assert addon.type == amo.ADDON_STATICTHEME
         # Only listed submissions need a preview generated.
         assert latest_version.previews.all().count() == 0
@@ -565,7 +568,7 @@ class TestAddonSubmitUpload(UploadTest, TestCase):
         self.assert3xx(
             response, reverse('devhub.submit.details', args=[addon.slug]))
         all_ = sorted([f.filename for f in addon.current_version.all_files])
-        assert all_ == [u'weta_fade-1.0.xpi']  # One XPI for all platforms.
+        assert all_ == [u'weta_fade-1.0-an+fx.xpi']  # A single XPI for all.
         assert addon.type == amo.ADDON_STATICTHEME
         previews = list(addon.current_version.previews.all())
         assert len(previews) == 3
@@ -598,7 +601,7 @@ class TestAddonSubmitUpload(UploadTest, TestCase):
         self.assert3xx(
             response, reverse('devhub.submit.finish', args=[addon.slug]))
         all_ = sorted([f.filename for f in latest_version.all_files])
-        assert all_ == [u'weta_fade-1.0.xpi']  # One XPI for all platforms.
+        assert all_ == [u'weta_fade-1.0-an+fx.xpi']  # A single XPI for all.
         assert addon.type == amo.ADDON_STATICTHEME
         # Only listed submissions need a preview generated.
         assert latest_version.previews.all().count() == 0
@@ -1849,6 +1852,10 @@ class TestVersionSubmitAutoChannel(TestSubmitBase):
 class VersionSubmitUploadMixin(object):
     channel = None
     fixtures = ['base/users', 'base/addon_3615']
+
+    @classmethod
+    def setUpTestData(cls):
+        create_default_webext_appversion()
 
     def setUp(self):
         super(VersionSubmitUploadMixin, self).setUp()

--- a/src/olympia/files/tests/test_commands.py
+++ b/src/olympia/files/tests/test_commands.py
@@ -15,10 +15,21 @@ from olympia.users.models import UserProfile
 
 
 class TestWebextExtractPermissions(UploadTest):
+    @classmethod
+    def setUpTestData(cls):
+        versions = {
+            amo.DEFAULT_WEBEXT_MIN_VERSION_NO_ID,
+            amo.DEFAULT_WEBEXT_MIN_VERSION_ANDROID,
+            amo.DEFAULT_WEBEXT_MAX_VERSION
+        }
+        for version in versions:
+            AppVersion.objects.create(application=amo.FIREFOX.id,
+                                      version=version)
+            AppVersion.objects.create(application=amo.ANDROID.id,
+                                      version=version)
+
     def setUp(self):
         super(TestWebextExtractPermissions, self).setUp()
-        for version in ('3.0', '3.6', '3.6.*', '4.0b6'):
-            AppVersion(application=amo.FIREFOX.id, version=version).save()
         self.platform = amo.PLATFORM_ALL.id
         self.addon = Addon.objects.create(guid='guid@jetpack',
                                           type=amo.ADDON_EXTENSION,

--- a/src/olympia/files/tests/test_models.py
+++ b/src/olympia/files/tests/test_models.py
@@ -356,11 +356,26 @@ class TestTrackFileStatusChange(TestCase):
 
 class TestParseXpi(TestCase):
 
-    def setUp(self):
-        super(TestParseXpi, self).setUp()
-        for version in ('3.0', '3.6.*'):
+    @classmethod
+    def setUpTestData(cls):
+        versions = {
+            '3.0',
+            '3.6.*',
+            amo.DEFAULT_WEBEXT_MIN_VERSION,
+            amo.DEFAULT_WEBEXT_MIN_VERSION_NO_ID,
+            amo.DEFAULT_WEBEXT_MIN_VERSION_ANDROID,
+            amo.DEFAULT_STATIC_THEME_MIN_VERSION_FIREFOX,
+            amo.DEFAULT_STATIC_THEME_MIN_VERSION_ANDROID,
+            amo.DEFAULT_WEBEXT_DICT_MIN_VERSION_FIREFOX,
+            amo.DEFAULT_WEBEXT_MAX_VERSION
+        }
+        for version in versions:
             AppVersion.objects.create(application=amo.FIREFOX.id,
                                       version=version)
+            AppVersion.objects.create(application=amo.ANDROID.id,
+                                      version=version)
+
+    def setUp(self):
         self.user = user_factory()
 
     def parse(self, addon=None, filename='extension.xpi', **kwargs):
@@ -432,12 +447,15 @@ class TestParseXpi(TestCase):
     def test_parse_apps(self):
         expected = [Extractor.App(
             amo.FIREFOX, amo.FIREFOX.id,
-            AppVersion.objects.get(version='3.0'),
-            AppVersion.objects.get(version='3.6.*'))]
+            AppVersion.objects.get(
+                application=amo.FIREFOX.id, version='3.0'),
+            AppVersion.objects.get(
+                application=amo.FIREFOX.id, version='3.6.*'))]
         assert self.parse()['apps'] == expected
 
     def test_no_parse_apps_error_webextension(self):
-        AppVersion.objects.all().delete()
+        AppVersion.objects.create(application=amo.FIREFOX.id, version='57.0')
+        AppVersion.objects.create(application=amo.ANDROID.id, version='57.0')
         assert self.parse(filename='webextension_with_apps_targets.xpi')
 
         assert self.parse(
@@ -446,9 +464,7 @@ class TestParseXpi(TestCase):
 
     def test_parse_max_star(self):
         AppVersion.objects.create(application=amo.FIREFOX.id, version='56.*')
-        AppVersion.objects.create(application=amo.FIREFOX.id, version='*')
         AppVersion.objects.create(application=amo.FIREFOX.id, version='38.0a1')
-        AppVersion.objects.create(application=amo.ANDROID.id, version='*')
         AppVersion.objects.create(application=amo.ANDROID.id, version='56.*')
         AppVersion.objects.create(application=amo.ANDROID.id, version='38.0a1')
 
@@ -471,10 +487,6 @@ class TestParseXpi(TestCase):
         assert (
             set(self.parse(filename='jetpack_star.xpi')['apps']) ==
             set(expected))
-
-    def test_parse_apps_bad_appver(self):
-        AppVersion.objects.all().delete()
-        assert self.parse()['apps'] == []
 
     @mock.patch.object(amo.FIREFOX, 'guid', 'iamabadguid')
     def test_parse_apps_bad_guid(self):
@@ -1008,10 +1020,26 @@ def test_file_upload_passed_all_validations_invalid():
 
 class TestFileFromUpload(UploadTest):
 
+    @classmethod
+    def setUpTestData(cls):
+        versions = {
+            '3.0',
+            '3.6',
+            '3.6.*',
+            '4.0b6',
+            amo.DEFAULT_WEBEXT_MIN_VERSION,
+            amo.DEFAULT_WEBEXT_MAX_VERSION,
+            amo.DEFAULT_WEBEXT_MIN_VERSION_NO_ID,
+            amo.DEFAULT_WEBEXT_MIN_VERSION_ANDROID
+        }
+        for version in versions:
+            AppVersion.objects.create(
+                application=amo.FIREFOX.id, version=version)
+            AppVersion.objects.create(
+                application=amo.ANDROID.id, version=version)
+
     def setUp(self):
         super(TestFileFromUpload, self).setUp()
-        for version in ('3.0', '3.6', '3.6.*', '4.0b6'):
-            AppVersion(application=amo.FIREFOX.id, version=version).save()
         self.platform = amo.PLATFORM_ALL.id
         self.addon = Addon.objects.create(guid='guid@xpi',
                                           type=amo.ADDON_EXTENSION,

--- a/src/olympia/signing/tests/test_views.py
+++ b/src/olympia/signing/tests/test_views.py
@@ -19,9 +19,9 @@ from olympia.access.models import Group, GroupUser
 from olympia.addons.models import Addon, AddonUser
 from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.amo.tests import (
-    addon_factory, reverse_ns, TestCase, developer_factory)
+    addon_factory, create_default_webext_appversion, developer_factory,
+    reverse_ns, TestCase)
 from olympia.api.tests.utils import APIKeyAuthTestMixin
-from olympia.applications.models import AppVersion
 from olympia.files.models import File, FileUpload
 from olympia.lib.akismet.models import AkismetReport
 from olympia.signing.views import VersionView
@@ -36,6 +36,9 @@ class SigningAPITestMixin(APIKeyAuthTestMixin):
 
 
 class BaseUploadVersionTestMixin(SigningAPITestMixin):
+    @classmethod
+    def setUpTestData(cls):
+        create_default_webext_appversion()
 
     def setUp(self):
         super(BaseUploadVersionTestMixin, self).setUp()
@@ -531,11 +534,6 @@ class TestUploadVersion(BaseUploadVersionTestMixin, TestCase):
 
 
 class TestUploadVersionWebextension(BaseUploadVersionTestMixin, TestCase):
-    def setUp(self):
-        super(TestUploadVersionWebextension, self).setUp()
-        AppVersion.objects.create(application=amo.FIREFOX.id, version='42.0')
-        AppVersion.objects.create(application=amo.FIREFOX.id, version='*')
-
     def test_addon_does_not_exist_webextension(self):
         response = self.request(
             'POST',

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -595,15 +595,28 @@ def test_unreviewed_files(db, addon_status, file_status, is_unreviewed):
 class TestVersionFromUpload(UploadTest, TestCase):
     fixtures = ['base/addon_3615', 'base/users']
 
+    @classmethod
+    def setUpTestData(cls):
+        versions = {
+            '3.0',
+            '3.6.*',
+            amo.DEFAULT_WEBEXT_MIN_VERSION,
+            amo.DEFAULT_WEBEXT_MIN_VERSION_NO_ID,
+            amo.DEFAULT_WEBEXT_MIN_VERSION_ANDROID,
+            amo.DEFAULT_WEBEXT_MAX_VERSION
+        }
+        for version in versions:
+            AppVersion.objects.create(application=amo.FIREFOX.id,
+                                      version=version)
+            AppVersion.objects.create(application=amo.ANDROID.id,
+                                      version=version)
+
     def setUp(self):
         super(TestVersionFromUpload, self).setUp()
         self.upload = self.get_upload(self.filename)
         self.addon = Addon.objects.get(id=3615)
         self.addon.update(guid='guid@xpi')
         self.selected_app = amo.FIREFOX.id
-        for version in ('3.0', '3.6.*'):
-            AppVersion.objects.create(
-                application=amo.FIREFOX.id, version=version)
         self.dummy_parsed_data = {'version': '0.1'}
 
 
@@ -934,6 +947,19 @@ class TestStatusFromUpload(TestVersionFromUpload):
 
 
 class TestStaticThemeFromUpload(UploadTest):
+
+    @classmethod
+    def setUpTestData(cls):
+        versions = {
+            amo.DEFAULT_STATIC_THEME_MIN_VERSION_FIREFOX,
+            amo.DEFAULT_STATIC_THEME_MIN_VERSION_ANDROID,
+            amo.DEFAULT_WEBEXT_MAX_VERSION
+        }
+        for version in versions:
+            AppVersion.objects.create(application=amo.FIREFOX.id,
+                                      version=version)
+            AppVersion.objects.create(application=amo.ANDROID.id,
+                                      version=version)
 
     def setUp(self):
         path = 'src/olympia/devhub/tests/addons/static_theme.zip'


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/10864

This means:
- Throwing an error in case of a `min_version` that doesn't exist
- Ignoring (and overriding) `max_version` that doesn't exist yet
- Overriding `min_version` if it points to a version we know didn't support that add-on

A bunch of tests that created webextensions have been patched in this commit to have the appversions they depend on properly created beforehand as this change would make them fail because the appversion didn't exist.