### PR TITLE
[UI-Tests] Add preference that prints console logs to geckodriver log.

### DIFF
--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -32,6 +32,7 @@ def firefox_options(firefox_options):
     firefox_options.set_preference('xpinstall.signatures.required', False)
     firefox_options.set_preference('extensions.webapi.testing', True)
     firefox_options.set_preference('ui.popup.disable_autohide', True)
+    firefox_options.set_preference('devtools.console.stdout.content', True)
     firefox_options.add_argument('-foreground')
     firefox_options.log.level = 'trace'
     return firefox_options


### PR DESCRIPTION
A preference to allow console errors to be added to the geckodriver log for the UI tests. This geckodriver log is available via the HTML report. Should help with #10954