### PR TITLE
Remove 'firefox57' tag, ignore it in search filtering

### DIFF
--- a/src/olympia/addons/management/commands/process_addons.py
+++ b/src/olympia/addons/management/commands/process_addons.py
@@ -8,7 +8,6 @@ from olympia import amo
 from olympia.addons.models import Addon
 from olympia.addons.tasks import (
     add_dynamic_theme_tag,
-    add_firefox57_tag,
     bump_appver_for_legacy_addons,
     delete_addons,
     disable_legacy_files,
@@ -43,14 +42,6 @@ tasks = {
     'sign_addons': {
         'method': sign_addons,
         'qs': []},
-    'add_firefox57_tag_to_webextensions': {
-        'method': add_firefox57_tag,
-        'qs': [
-            Q(status=amo.STATUS_PUBLIC) & (
-                Q(_current_version__files__is_webextension=True) |
-                Q(_current_version__files__is_mozilla_signed_extension=True)
-            )
-        ]},
     'bump_appver_for_legacy_addons': {
         'method': bump_appver_for_legacy_addons,
         'qs': [

--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -455,24 +455,6 @@ def find_inconsistencies_between_es_and_db(ids, **kw):
 
 @task
 @use_primary_db
-def add_firefox57_tag(ids, **kw):
-    """Add firefox57 tag to addons with the specified ids."""
-    log.info(
-        'Adding firefox57 tag to addons %d-%d [%d].',
-        ids[0], ids[-1], len(ids))
-
-    addons = Addon.objects.filter(id__in=ids)
-    for addon in addons:
-        # This will create a couple extra queries to check for tag/addontag
-        # existence, and then trigger update_tag_stat tasks. But the
-        # alternative is adding activity log manually, making sure we don't
-        # add duplicate tags, manually updating the tag stats, so it's ok for
-        # a one-off task.
-        Tag(tag_text='firefox57').save_tag(addon)
-
-
-@task
-@use_primary_db
 def add_dynamic_theme_tag(ids, **kw):
     """Add dynamic theme tag to addons with the specified ids."""
     log.info(

--- a/src/olympia/addons/tests/test_commands.py
+++ b/src/olympia/addons/tests/test_commands.py
@@ -253,49 +253,6 @@ def test_process_addons_limit_addons():
         assert calls[0]['kwargs']['args'] == [addon_ids[:2]]
 
 
-class AddFirefox57TagTestCase(TestCase):
-    def test_affects_only_public_webextensions(self):
-        addon_factory()
-        addon_factory(file_kw={'is_webextension': True,
-                               'status': amo.STATUS_AWAITING_REVIEW},
-                      status=amo.STATUS_NOMINATED)
-        public_webextension = addon_factory(file_kw={'is_webextension': True})
-        public_mozilla_signed = addon_factory(file_kw={
-            'is_mozilla_signed_extension': True})
-
-        with count_subtask_calls(pa.add_firefox57_tag) as calls:
-            call_command(
-                'process_addons', task='add_firefox57_tag_to_webextensions')
-
-        assert len(calls) == 1
-        assert calls[0]['kwargs']['args'] == [
-            [public_webextension.pk, public_mozilla_signed.pk]
-        ]
-
-    def test_tag_added_for_is_webextension(self):
-        self.addon = addon_factory(file_kw={'is_webextension': True})
-        assert self.addon.tags.all().count() == 0
-
-        call_command(
-            'process_addons', task='add_firefox57_tag_to_webextensions')
-
-        assert (
-            set(self.addon.tags.all().values_list('tag_text', flat=True)) ==
-            set(['firefox57']))
-
-    def test_tag_added_for_is_mozilla_signed_extension(self):
-        self.addon = addon_factory(
-            file_kw={'is_mozilla_signed_extension': True})
-        assert self.addon.tags.all().count() == 0
-
-        call_command(
-            'process_addons', task='add_firefox57_tag_to_webextensions')
-
-        assert (
-            set(self.addon.tags.all().values_list('tag_text', flat=True)) ==
-            set(['firefox57']))
-
-
 class TestAddDynamicThemeTagForThemeApiCommand(TestCase):
     def test_affects_only_public_webextensions(self):
         addon_factory()

--- a/src/olympia/migrations/1081-remove-firefox57-tag.sql
+++ b/src/olympia/migrations/1081-remove-firefox57-tag.sql
@@ -1,0 +1,5 @@
+DELETE `users_tags_addons` FROM `users_tags_addons` INNER JOIN `tags`
+    ON ( `users_tags_addons`.`tag_id` = `tags`.`id` )
+    WHERE `tags`.`tag_text` = 'firefox57';
+
+DELETE FROM `tags` WHERE `tag_text` = 'firefox57';

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -27,7 +27,6 @@ from olympia.reviewers.models import AutoApprovalSummary, ReviewerScore
 from olympia.reviewers.utils import (
     PENDING_STATUSES, ReviewAddon, ReviewFiles, ReviewHelper,
     ViewPendingQueueTable, ViewUnlistedAllListTable)
-from olympia.tags.models import Tag
 from olympia.users.models import UserProfile
 
 

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -584,10 +584,6 @@ class TestReviewHelper(TestCase):
 
         self._check_score(amo.REVIEWED_ADDON_FULL)
 
-        # It wasn't a webextension and not signed by mozilla it should not
-        # receive the firefox57 tag.
-        assert self.addon.tags.all().count() == 0
-
     @patch('olympia.reviewers.utils.sign_file')
     def test_nomination_to_public(self, sign_mock):
         sign_mock.reset()
@@ -727,10 +723,6 @@ class TestReviewHelper(TestCase):
         assert self.check_log_count(amo.LOG.APPROVE_VERSION.id) == 1
 
         self._check_score(amo.REVIEWED_ADDON_UPDATE)
-
-        # It wasn't a webextension and not signed by mozilla it should not
-        # receive the firefox57 tag.
-        assert self.addon.tags.all().count() == 0
 
     @patch('olympia.reviewers.utils.sign_file')
     def test_public_addon_with_version_awaiting_review_to_sandbox(
@@ -977,55 +969,6 @@ class TestReviewHelper(TestCase):
         assert storage.exists(self.file.guarded_file_path)
         assert not storage.exists(self.file.file_path)
         assert self.check_log_count(amo.LOG.REJECT_VERSION.id) == 1
-
-    @patch('olympia.reviewers.utils.sign_file',
-           lambda *a, **kw: None)
-    def test_nomination_to_public_webextension(self):
-        self.file.update(is_webextension=True)
-        self.setup_data(amo.STATUS_NOMINATED)
-        self.helper.handler.process_public()
-        assert (
-            set(self.addon.tags.all().values_list('tag_text', flat=True)) ==
-            set(['firefox57']))
-
-    @patch('olympia.reviewers.utils.sign_file',
-           lambda *a, **kw: None)
-    def test_nomination_to_public_mozilla_signed_extension(self):
-        """Test that the firefox57 tag is applied to mozilla signed add-ons"""
-        self.file.update(is_mozilla_signed_extension=True)
-        self.setup_data(amo.STATUS_NOMINATED)
-        self.helper.handler.process_public()
-        assert (
-            set(self.addon.tags.all().values_list('tag_text', flat=True)) ==
-            set(['firefox57']))
-
-    @patch('olympia.reviewers.utils.sign_file',
-           lambda *a, **kw: None)
-    def test_public_to_public_already_had_webextension_tag(self):
-        self.file.update(is_webextension=True)
-        Tag(tag_text='firefox57').save_tag(self.addon)
-        assert (
-            set(self.addon.tags.all().values_list('tag_text', flat=True)) ==
-            set(['firefox57']))
-        self.addon.current_version.update(created=self.days_ago(1))
-        self.version = version_factory(
-            addon=self.addon, channel=amo.RELEASE_CHANNEL_LISTED,
-            version='3.0.42',
-            file_kw={'status': amo.STATUS_AWAITING_REVIEW})
-        self.file = self.version.files.all()[0]
-        self.setup_data(amo.STATUS_PUBLIC)
-
-        # Safeguards.
-        assert isinstance(self.helper.handler, ReviewFiles)
-        assert self.addon.status == amo.STATUS_PUBLIC
-        assert self.file.status == amo.STATUS_AWAITING_REVIEW
-        assert self.addon.current_version.files.all()[0].status == (
-            amo.STATUS_PUBLIC)
-
-        self.helper.handler.process_public()
-        assert (
-            set(self.addon.tags.all().values_list('tag_text', flat=True)) ==
-            set(['firefox57']))
 
     def test_email_unicode_monster(self):
         self.addon.name = u'TaobaoShopping淘宝网导航按钮'

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -651,14 +651,6 @@ class ReviewBase(object):
         if self.set_addon_status:
             self.set_addon(status=amo.STATUS_PUBLIC)
 
-        # If we've approved a webextension, add a tag identifying them as such.
-        if any(file_.is_webextension for file_ in self.files):
-            Tag(tag_text='firefox57').save_tag(self.addon)
-
-        # If we've approved a mozilla signed add-on, add the firefox57 tag
-        if all(file_.is_mozilla_signed_extension for file_ in self.files):
-            Tag(tag_text='firefox57').save_tag(self.addon)
-
         # Increment approvals counter if we have a request (it means it's a
         # human doing the review) otherwise reset it as it's an automatic
         # approval.

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -28,7 +28,6 @@ from olympia.lib.crypto.signing import sign_file
 from olympia.reviewers.models import (
     ReviewerScore, ViewFullReviewQueue, ViewPendingQueue, ViewUnlistedAllList,
     get_flags, get_flags_for_row)
-from olympia.tags.models import Tag
 from olympia.users.models import UserProfile
 
 

--- a/src/olympia/search/filters.py
+++ b/src/olympia/search/filters.py
@@ -299,13 +299,18 @@ class AddonTagQueryParam(AddonQueryParam):
     # even with the custom get_value() implementation.
     query_param = 'tag'
 
+    # These tags are tags that used to exist but don't any more, filtering
+    # on them would find nothing, so they are ignored.
+    ignored = ('jetpack', 'firefox57')
+
     def get_value(self):
         return self.request.GET.get(self.query_param, '').split(',')
 
     def get_es_query(self):
         # Just using 'terms' would not work, as it would return any tag match
         # in the list, but we want to exactly match all of them.
-        return [Q('term', tags=tag) for tag in self.get_value()]
+        return [Q('term', tags=tag) for tag in self.get_value()
+                if tag not in self.ignored]
 
 
 class AddonExcludeAddonsQueryParam(AddonQueryParam):

--- a/src/olympia/search/tests/test_filters.py
+++ b/src/olympia/search/tests/test_filters.py
@@ -664,6 +664,19 @@ class TestSearchParameterFilter(FilterTestsBase):
         assert {'term': {'tags': 'foo'}} in filter_
         assert {'term': {'tags': 'bar'}} in filter_
 
+    def test_search_by_tag_ignored(self):
+        # firefox57 is in the ignore list, we shouldn't filter the query with
+        # it.
+        qs = self._filter(data={'tag': 'firefox57'})
+        assert 'bool' not in qs['query']
+
+        qs = self._filter(data={'tag': 'foo,firefox57'})
+        assert 'must' not in qs['query']['bool']
+        assert 'must_not' not in qs['query']['bool']
+        filter_ = qs['query']['bool']['filter']
+        assert {'term': {'tags': 'foo'}} in filter_
+        assert {'term': {'tags': 'firefox57'}} not in filter_
+
     def test_search_by_author(self):
         qs = self._filter(data={'author': 'fooBar'})
         assert 'must' not in qs['query']['bool']


### PR DESCRIPTION
This tag is useless now that we only support WebExtensions.

There might be links for AMO search with that tag used in the wild, so we need to accept this tag during search and do no filtering with it.

Fixes #10968