### PR TITLE
Add new code-manager FxA configs

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -83,7 +83,7 @@ FXA_CONFIG = {
         'content_host': 'https://stable.dev.lcip.org',
         'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
         'profile_host': 'https://stable.dev.lcip.org/profile/v1',
-        'redirect_url': 'http://localhost:3000/fxa-authenticate',
+        'redirect_url': 'http://olympia.test/api/v3/accounts/authenticate/',
         'scope': 'profile',
     },
     'local': {
@@ -94,16 +94,18 @@ FXA_CONFIG = {
         'content_host': 'https://stable.dev.lcip.org',
         'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
         'profile_host': 'https://stable.dev.lcip.org/profile/v1',
-        'redirect_url': 'http://localhost:3000/api/v3/accounts/authenticate/',
+        'redirect_url': 'http://olympia.test/api/v3/accounts/authenticate/?config=local', # noqa
         'scope': 'profile',
     },
     'code-manager': {
-        'client_id': env('CODE_MANAGER_FXA_CLIENT_ID', default='CHANGE_ME'),
-        'client_secret': env('CODE_MANAGER_FXA_CLIENT_SECRET', default='CHANGE_ME'), # noqa
+        'client_id': env('CODE_MANAGER_FXA_CLIENT_ID', default='a98b671fdd3dfcea'), # noqa
+        'client_secret': env(
+            'CODE_MANAGER_FXA_CLIENT_SECRET',
+            default='d9934865e34bed4739a2dc60046a90d09a5d8336cf92809992dec74a4cff4665'),  # noqa
         'content_host': 'https://stable.dev.lcip.org',
         'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
         'profile_host': 'https://stable.dev.lcip.org/profile/v1',
-        'redirect_url': 'http://localhost:3000/fxa-authenticate',
+        'redirect_url': 'http://olympia.test/api/v4/accounts/authenticate/?config=code-manager', # noqa
         'scope': 'profile',
     },
 }

--- a/settings.py
+++ b/settings.py
@@ -83,7 +83,7 @@ FXA_CONFIG = {
         'content_host': 'https://stable.dev.lcip.org',
         'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
         'profile_host': 'https://stable.dev.lcip.org/profile/v1',
-        'redirect_url': 'http://olympia.test/api/v3/accounts/authenticate/',
+        'redirect_url': 'http://localhost:3000/fxa-authenticate',
         'scope': 'profile',
     },
     'local': {
@@ -94,7 +94,7 @@ FXA_CONFIG = {
         'content_host': 'https://stable.dev.lcip.org',
         'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
         'profile_host': 'https://stable.dev.lcip.org/profile/v1',
-        'redirect_url': 'http://olympia.test/api/v3/accounts/authenticate/?config=local', # noqa
+        'redirect_url': 'http://localhost:3000/api/v3/accounts/authenticate/?config=local', # noqa
         'scope': 'profile',
     },
     'code-manager': {

--- a/settings.py
+++ b/settings.py
@@ -97,8 +97,17 @@ FXA_CONFIG = {
         'redirect_url': 'http://localhost:3000/api/v3/accounts/authenticate/',
         'scope': 'profile',
     },
+    'code-manager': {
+        'client_id': env('CODE_MANAGER_FXA_CLIENT_ID', default='CHANGE_ME'),
+        'client_secret': env('CODE_MANAGER_FXA_CLIENT_SECRET', default='CHANGE_ME'), # noqa
+        'content_host': 'https://stable.dev.lcip.org',
+        'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
+        'profile_host': 'https://stable.dev.lcip.org/profile/v1',
+        'redirect_url': 'http://localhost:3000/fxa-authenticate',
+        'scope': 'profile',
+    },
 }
-ALLOWED_FXA_CONFIGS = ['default', 'amo', 'local']
+ALLOWED_FXA_CONFIGS = ['default', 'amo', 'local', 'code-manager']
 
 # CSP report endpoint which returns a 204 from addons-nginx in local dev.
 CSP_REPORT_URI = '/csp-report'

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -153,7 +153,7 @@ class TestLoginStartView(TestCase):
     def test_default_config_is_used(self):
         assert views.LoginStartView.DEFAULT_FXA_CONFIG_NAME == 'default'
         assert views.LoginStartView.ALLOWED_FXA_CONFIGS == (
-            ['default', 'amo', 'local'])
+            ['default', 'amo', 'local', 'code-manager'])
 
 
 class TestLoginUserAndRegisterUser(TestCase):

--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -130,9 +130,18 @@ FXA_CONFIG = {
         'redirect_url': 'http://localhost:3000/fxa-authenticate',
         'scope': 'profile',
     },
+    'code-manager': {
+        'client_id': env('CODE_MANAGER_FXA_CLIENT_ID'),
+        'client_secret': env('CODE_MANAGER_FXA_CLIENT_SECRET'),
+        'content_host': 'https://stable.dev.lcip.org',
+        'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
+        'profile_host': 'https://stable.dev.lcip.org/profile/v1',
+        'redirect_url': 'https://code.addons-dev.allizom.org/fxa-authenticate',
+        'scope': 'profile',
+    },
 }
 DEFAULT_FXA_CONFIG_NAME = 'default'
-ALLOWED_FXA_CONFIGS = ['default', 'amo', 'local']
+ALLOWED_FXA_CONFIGS = ['default', 'amo', 'local', 'code-manager']
 
 FXA_SQS_AWS_QUEUE_URL = (
     'https://sqs.us-east-1.amazonaws.com/927034868273/'

--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -127,7 +127,7 @@ FXA_CONFIG = {
         'content_host': 'https://stable.dev.lcip.org',
         'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
         'profile_host': 'https://stable.dev.lcip.org/profile/v1',
-        'redirect_url': 'https://addons-dev.allizom.org/api/v3/accounts/authenticate/?config=local', # noqa
+        'redirect_url': 'http://localhost:3000/api/v3/accounts/authenticate/?config=local', # noqa
         'scope': 'profile',
     },
     'code-manager': {

--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -118,7 +118,7 @@ FXA_CONFIG = {
         'content_host': 'https://stable.dev.lcip.org',
         'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
         'profile_host': 'https://stable.dev.lcip.org/profile/v1',
-        'redirect_url': 'https://amo.addons-dev.allizom.org/fxa-authenticate',
+        'redirect_url': 'https://addons-dev.allizom.org/api/v3/accounts/authenticate/?config=amo', # noqa
         'scope': 'profile',
     },
     'local': {
@@ -127,7 +127,7 @@ FXA_CONFIG = {
         'content_host': 'https://stable.dev.lcip.org',
         'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
         'profile_host': 'https://stable.dev.lcip.org/profile/v1',
-        'redirect_url': 'http://localhost:3000/fxa-authenticate',
+        'redirect_url': 'https://addons-dev.allizom.org/api/v3/accounts/authenticate/?config=local', # noqa
         'scope': 'profile',
     },
     'code-manager': {
@@ -136,7 +136,7 @@ FXA_CONFIG = {
         'content_host': 'https://stable.dev.lcip.org',
         'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
         'profile_host': 'https://stable.dev.lcip.org/profile/v1',
-        'redirect_url': 'https://code.addons-dev.allizom.org/fxa-authenticate',
+        'redirect_url': 'https://addons-dev.allizom.org/api/v4/accounts/authenticate/?config=code-manager', # noqa
         'scope': 'profile',
     },
 }

--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -101,9 +101,20 @@ FXA_CONFIG = {
         'scope': 'profile',
         'skip_register_redirect': True,
     },
+    'code-manager': {
+        'client_id': env('CODE_MANAGER_FXA_CLIENT_ID'),
+        'client_secret': env('CODE_MANAGER_FXA_CLIENT_SECRET'),
+        'content_host': 'https://accounts.firefox.com',
+        'oauth_host': 'https://oauth.accounts.firefox.com/v1',
+        'profile_host': 'https://profile.accounts.firefox.com/v1',
+        'redirect_url':
+            'https://addons.mozilla.org/api/v4/accounts/authenticate/',
+        'scope': 'profile',
+        'skip_register_redirect': True,
+    },
 }
 DEFAULT_FXA_CONFIG_NAME = 'default'
-ALLOWED_FXA_CONFIGS = ['default', 'amo']
+ALLOWED_FXA_CONFIGS = ['default', 'amo', 'code-manager']
 
 VALIDATOR_TIMEOUT = 360
 

--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -96,8 +96,7 @@ FXA_CONFIG = {
         'content_host': 'https://accounts.firefox.com',
         'oauth_host': 'https://oauth.accounts.firefox.com/v1',
         'profile_host': 'https://profile.accounts.firefox.com/v1',
-        'redirect_url':
-            'https://addons.mozilla.org/api/v3/accounts/authenticate/',
+        'redirect_url': 'https://addons.mozilla.org/api/v3/accounts/authenticate/?config=amo', # noqa
         'scope': 'profile',
         'skip_register_redirect': True,
     },
@@ -107,8 +106,7 @@ FXA_CONFIG = {
         'content_host': 'https://accounts.firefox.com',
         'oauth_host': 'https://oauth.accounts.firefox.com/v1',
         'profile_host': 'https://profile.accounts.firefox.com/v1',
-        'redirect_url':
-            'https://addons.mozilla.org/api/v4/accounts/authenticate/',
+        'redirect_url': 'https://addons.mozilla.org/api/v4/accounts/authenticate/?config=code-manager', # noqa
         'scope': 'profile',
         'skip_register_redirect': True,
     },

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -112,8 +112,7 @@ FXA_CONFIG = {
         'content_host': 'https://accounts.firefox.com',
         'oauth_host': 'https://oauth.accounts.firefox.com/v1',
         'profile_host': 'https://profile.accounts.firefox.com/v1',
-        'redirect_url':
-            'https://addons.allizom.org/api/v3/accounts/authenticate/',
+        'redirect_url': 'https://addons.allizom.org/api/v3/accounts/authenticate/?config=amo', # noqa
         'scope': 'profile',
         'skip_register_redirect': True,
     },
@@ -123,7 +122,7 @@ FXA_CONFIG = {
         'content_host': 'https://stable.dev.lcip.org',
         'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
         'profile_host': 'https://stable.dev.lcip.org/profile/v1',
-        'redirect_url': 'http://localhost:3000/fxa-authenticate',
+        'redirect_url': 'https://addons.allizom.org/api/v3/accounts/authenticate/?config=local', # noqa
         'scope': 'profile',
     },
     'code-manager': {
@@ -132,8 +131,7 @@ FXA_CONFIG = {
         'content_host': 'https://accounts.firefox.com',
         'oauth_host': 'https://oauth.accounts.firefox.com/v1',
         'profile_host': 'https://profile.accounts.firefox.com/v1',
-        'redirect_url':
-            'https://addons.allizom.org/api/v4/accounts/authenticate/',
+        'redirect_url': 'https://addons.allizom.org/api/v4/accounts/authenticate/?config=code-manager', # noqa
         'scope': 'profile',
         'skip_register_redirect': True,
     },

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -122,7 +122,7 @@ FXA_CONFIG = {
         'content_host': 'https://stable.dev.lcip.org',
         'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
         'profile_host': 'https://stable.dev.lcip.org/profile/v1',
-        'redirect_url': 'https://addons.allizom.org/api/v3/accounts/authenticate/?config=local', # noqa
+        'redirect_url': 'http://localhost:3000/api/v3/accounts/authenticate/?config=local', # noqa
         'scope': 'profile',
     },
     'code-manager': {

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -126,9 +126,20 @@ FXA_CONFIG = {
         'redirect_url': 'http://localhost:3000/fxa-authenticate',
         'scope': 'profile',
     },
+    'code-manager': {
+        'client_id': env('CODE_MANAGER_FXA_CLIENT_ID'),
+        'client_secret': env('CODE_MANAGER_FXA_CLIENT_SECRET'),
+        'content_host': 'https://accounts.firefox.com',
+        'oauth_host': 'https://oauth.accounts.firefox.com/v1',
+        'profile_host': 'https://profile.accounts.firefox.com/v1',
+        'redirect_url':
+            'https://addons.allizom.org/api/v4/accounts/authenticate/',
+        'scope': 'profile',
+        'skip_register_redirect': True,
+    },
 }
 DEFAULT_FXA_CONFIG_NAME = 'default'
-ALLOWED_FXA_CONFIGS = ['default', 'amo', 'local']
+ALLOWED_FXA_CONFIGS = ['default', 'amo', 'local', 'code-manager']
 
 TAAR_LITE_RECOMMENDATION_ENGINE_URL = env(
     'TAAR_LITE_RECOMMENDATION_ENGINE_URL',


### PR DESCRIPTION
Fixes #11015

---

I adapted the `amo` configs in each env. I don't really understand why we specify `/fxa-authenticate` in `redirect_url` though. I believe this is never used (FxA config has its own "redirect URI" that points to the correct API endpoint).