### PR TITLE
Move download url view from api to regular view.

### DIFF
--- a/src/olympia/reviewers/serializers.py
+++ b/src/olympia/reviewers/serializers.py
@@ -15,6 +15,7 @@ from django.utils.encoding import force_text
 from django.utils.timezone import FixedOffset
 
 from olympia.amo.urlresolvers import reverse
+from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.addons.serializers import (
     VersionSerializer, FileSerializer, SimpleAddonSerializer)
 from olympia.addons.models import AddonReviewerFlags
@@ -195,8 +196,6 @@ class FileEntriesSerializer(FileSerializer):
                 self.git_repo[blob_or_tree.oid].read_raw())
 
     def get_download_url(self, obj):
-        request = self.context.get('request')
-
         commit = self._get_commit(obj)
         tree = self.repo.get_root_tree(commit)
         selected_file = self.get_selected_file(obj)
@@ -205,14 +204,13 @@ class FileEntriesSerializer(FileSerializer):
         if blob_or_tree.type == 'tree':
             return None
 
-        return reverse(
+        return absolutify(reverse(
             'reviewers.download_git_file',
-            request=request,
             kwargs={
                 'version_id': self.get_instance().version.pk,
                 'filename': selected_file
             }
-        )
+        ))
 
 
 class AddonBrowseVersionSerializer(VersionSerializer):

--- a/src/olympia/reviewers/serializers.py
+++ b/src/olympia/reviewers/serializers.py
@@ -9,7 +9,6 @@ import magic
 
 from rest_framework import serializers
 from rest_framework.exceptions import NotFound
-from rest_framework.reverse import reverse as drf_reverse
 
 from django.utils.functional import cached_property
 from django.utils.encoding import force_text
@@ -206,12 +205,11 @@ class FileEntriesSerializer(FileSerializer):
         if blob_or_tree.type == 'tree':
             return None
 
-        return drf_reverse(
-            'reviewers-versions-download',
+        return reverse(
+            'reviewers.download_git_file',
             request=request,
             kwargs={
-                'addon_pk': self.get_instance().version.addon.pk,
-                'pk': self.get_instance().version.pk,
+                'version_id': self.get_instance().version.pk,
                 'filename': selected_file
             }
         )

--- a/src/olympia/reviewers/tests/test_serializers.py
+++ b/src/olympia/reviewers/tests/test_serializers.py
@@ -63,13 +63,13 @@ class TestFileEntriesSerializer(TestCase):
             '/notify-link-clicks-i18n.xpi?src=').format(file.pk)
 
         assert data['selected_file'] == 'manifest.json'
-        assert data['download_url'] == reverse(
+        assert data['download_url'] == absolutify(reverse(
             'reviewers.download_git_file',
             kwargs={
                 'version_id': self.addon.current_version.pk,
                 'filename': 'manifest.json'
             }
-        )
+        ))
 
         assert set(data['entries'].keys()) == {
             'README.md',
@@ -130,13 +130,13 @@ class TestFileEntriesSerializer(TestCase):
         assert data['selected_file'] == 'icons/LICENSE'
         assert data['content'].startswith(
             'The "link-48.png" icon is taken from the Geomicons')
-        assert data['download_url'] == reverse(
+        assert data['download_url'] == absolutify(reverse(
             'reviewers.download_git_file',
             kwargs={
                 'version_id': self.addon.current_version.pk,
                 'filename': 'icons/LICENSE'
             }
-        )
+        ))
 
     def test_get_entries_cached(self):
         file = self.addon.current_version.current_file

--- a/src/olympia/reviewers/tests/test_serializers.py
+++ b/src/olympia/reviewers/tests/test_serializers.py
@@ -17,7 +17,7 @@ from olympia import amo
 from olympia.reviewers.serializers import (
     AddonBrowseVersionSerializer, FileEntriesSerializer)
 from olympia.amo.urlresolvers import reverse
-from olympia.amo.tests import TestCase, addon_factory, reverse_ns
+from olympia.amo.tests import TestCase, addon_factory
 from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.versions.tasks import extract_version_to_git
 from olympia.versions.models import License
@@ -63,11 +63,10 @@ class TestFileEntriesSerializer(TestCase):
             '/notify-link-clicks-i18n.xpi?src=').format(file.pk)
 
         assert data['selected_file'] == 'manifest.json'
-        assert data['download_url'] == reverse_ns(
-            'reviewers-versions-download',
+        assert data['download_url'] == reverse(
+            'reviewers.download_git_file',
             kwargs={
-                'addon_pk': self.addon.pk,
-                'pk': self.addon.current_version.pk,
+                'version_id': self.addon.current_version.pk,
                 'filename': 'manifest.json'
             }
         )
@@ -131,11 +130,10 @@ class TestFileEntriesSerializer(TestCase):
         assert data['selected_file'] == 'icons/LICENSE'
         assert data['content'].startswith(
             'The "link-48.png" icon is taken from the Geomicons')
-        assert data['download_url'] == reverse_ns(
-            'reviewers-versions-download',
+        assert data['download_url'] == reverse(
+            'reviewers.download_git_file',
             kwargs={
-                'addon_pk': self.addon.pk,
-                'pk': self.addon.current_version.pk,
+                'version_id': self.addon.current_version.pk,
                 'filename': 'icons/LICENSE'
             }
         )

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -35,6 +35,7 @@ from olympia.amo.tests import (
     APITestClient, TestCase, addon_factory, check_links, file_factory, formset,
     initial, reverse_ns, user_factory, version_factory)
 from olympia.amo.urlresolvers import reverse
+from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.files.models import File, FileValidation, WebextPermission
 from olympia.ratings.models import Rating, RatingFlag
 from olympia.reviewers.models import (
@@ -5271,13 +5272,13 @@ class TestReviewAddonVersionViewSetDetail(
         assert result['file']['content'] == '# beastify\n'
 
         # make sure the correct download url is correctly generated
-        assert result['file']['download_url'] == reverse(
+        assert result['file']['download_url'] == absolutify(reverse(
             'reviewers.download_git_file',
             kwargs={
                 'version_id': self.version.pk,
                 'filename': 'README.md'
             }
-        )
+        ))
 
     def test_version_get_not_found(self):
         user = UserProfile.objects.create(username='reviewer')

--- a/src/olympia/reviewers/urls.py
+++ b/src/olympia/reviewers/urls.py
@@ -61,4 +61,7 @@ urlpatterns = (
     url(r'^theme_background_images/(?P<version_id>[^ /]+)?$',
         views.theme_background_images,
         name='reviewers.theme_background_images'),
+    url(r'^download-git-file/(?P<version_id>\d+)/(?P<filename>.*)/',
+        views.download_git_stored_file,
+        name='reviewers.download_git_file'),
 )


### PR DESCRIPTION
This is needed to allow us to authenticate a user based on already set
cookies instead of unnecessarily complicated through an API.

Fixes #10994