### PR TITLE
Make sure git-extraction can happen for disabled/deleted versions.

### DIFF
--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -789,7 +789,8 @@ def migrate_legacy_dictionary_to_webextension(addon):
 @task(rate_limit='1/m')
 def migrate_webextensions_to_git_storage(ids, **kw):
     # recursive imports...
-    from olympia.versions.tasks import extract_version_to_git
+    from olympia.versions.tasks import (
+        extract_version_to_git, extract_version_source_to_git)
 
     log.info(
         'Migrating add-ons to git storage %d-%d [%d].',
@@ -835,6 +836,9 @@ def migrate_webextensions_to_git_storage(ids, **kw):
                     file_id=file_id))
 
                 extract_version_to_git(version.pk)
+
+                if version.source:
+                    extract_version_source_to_git(version.pk)
 
                 log.info(
                     'Extraction of file {file_id} into git storage succeeded'

--- a/src/olympia/addons/tests/test_tasks.py
+++ b/src/olympia/addons/tests/test_tasks.py
@@ -33,7 +33,7 @@ from olympia.ratings.models import Rating
 from olympia.stats.models import ThemeUpdateCount, UpdateCount
 from olympia.tags.models import Tag
 from olympia.users.models import UserProfile
-from olympia.versions.models import License, VersionPreview
+from olympia.versions.models import License, VersionPreview, source_upload_path
 from olympia.lib.git import AddonGitRepository
 
 
@@ -424,6 +424,26 @@ class TestMigrateWebextensionsToGitStorage(TestCase):
         assert extract_mock.call_args_list[0][0][0] == oldest_version.pk
         assert extract_mock.call_args_list[1][0][0] == older_version.pk
         assert extract_mock.call_args_list[2][0][0] == most_recent.pk
+
+    @mock.patch('olympia.versions.tasks.extract_version_to_git')
+    @mock.patch('olympia.versions.tasks.extract_version_source_to_git')
+    def test_migrate_versions_extracts_source(
+            self, extract_source_mock, extract_mock):
+        addon = addon_factory(file_kw={'filename': 'webextension_no_id.xpi'})
+        version_to_migrate = addon.current_version
+        version_to_migrate.update(
+            source=source_upload_path(version_to_migrate, 'foo.tar.gz'))
+
+        version_without_source = version_factory(
+            addon=addon, file_kw={'filename': 'webextension_no_id.xpi'})
+
+        migrate_webextensions_to_git_storage([addon.pk])
+
+        extract_source_mock.assert_called_once_with(version_to_migrate.pk)
+        extract_mock.assert_has_calls([
+            mock.call(version_to_migrate.pk),
+            mock.call(version_without_source.pk)
+        ])
 
 
 @pytest.mark.django_db

--- a/src/olympia/versions/tasks.py
+++ b/src/olympia/versions/tasks.py
@@ -115,7 +115,9 @@ def delete_preview_files(pk, **kw):
 @use_primary_db
 def extract_version_to_git(version_id, author_id=None):
     """Extract a `File` into our git storage backend."""
-    version = Version.objects.get(pk=version_id)
+    # We extract deleted or disabled versions as well so we need to make sure
+    # we can access them.
+    version = Version.unfiltered.get(pk=version_id)
 
     if author_id is not None:
         author = UserProfile.objects.get(pk=author_id)
@@ -131,19 +133,14 @@ def extract_version_to_git(version_id, author_id=None):
     log.info('Extracted {version} into {git_path}'.format(
         version=version_id, git_path=repo.git_repository_path))
 
-    if version.source:
-        repo = AddonGitRepository.extract_and_commit_source_from_version(
-            version=version, author=author)
-
-        log.info(
-            'Extracted source files from {version} into {git_path}'.format(
-                version=version_id, git_path=repo.git_repository_path))
-
 
 @task
 @use_primary_db
 def extract_version_source_to_git(version_id, author_id=None):
-    version = Version.objects.get(pk=version_id)
+    # We extract deleted or disabled versions as well so we need to make sure
+    # we can access them.
+    version = Version.unfiltered.get(pk=version_id)
+
     if not version.source:
         log.info('Tried to extract sources of {version_id} but there none.')
         return


### PR DESCRIPTION
This implements a few cleanups along the way.

* version source extraction only happens explicitly from now on (e.g
during migration or upload)
* added a few tests for git extraction related tasks in versions.tasks

Fixes #10900