### PR TITLE
Allow urls to new frontend views to link to the public facing site on internal instances

### DIFF
--- a/src/olympia/amo/tests/test_models.py
+++ b/src/olympia/amo/tests/test_models.py
@@ -1,11 +1,15 @@
+import os
 import pytest
 from mock import Mock
 
+from django.conf import settings
 from django.core.files.storage import default_storage as storage
+from django.test.utils import override_settings
 
 from olympia import amo
 from olympia.addons.models import Addon
 from olympia.amo import models as amo_models
+from olympia.amo.urlresolvers import reverse
 from olympia.amo.tests import TestCase
 from olympia.users.models import UserProfile
 from olympia.zadmin.models import Config
@@ -147,6 +151,35 @@ class TestModelBase(TestCase):
     def test_get_unfiltered_manager(self):
         Addon.get_unfiltered_manager() == Addon.unfiltered
         UserProfile.get_unfiltered_manager() == UserProfile.objects
+
+    def test_get_url_path(self):
+        addon = Addon.objects.get(pk=3615)
+        assert addon.get_url_path() == reverse(
+            'addons.detail', args=[addon.slug], add_prefix=True)
+
+    def test_get_absolute_url_with_frontend_view(self):
+        addon = Addon.objects.get(pk=3615)
+        relative = reverse('addons.detail', args=[addon.slug], add_prefix=True)
+        with override_settings(EXTERNAL_SITE_URL=settings.SITE_URL):
+            # The normal case
+            assert addon.get_absolute_url() == settings.SITE_URL + relative
+        with override_settings(EXTERNAL_SITE_URL='https://example.com'):
+            # When an external site url has been set
+            assert addon.get_absolute_url() == (
+                'https://example.com' + relative)
+
+    def test_get_absolute_url_with_django_view(self):
+        file = Addon.objects.get(pk=3615).current_version.all_files[0]
+        relative = os.path.join(
+            reverse('downloads.file', args=[file.id]), file.filename)
+        with override_settings(EXTERNAL_SITE_URL=settings.SITE_URL):
+            # The normal case
+            assert file.get_absolute_url(src='foo') == (
+                settings.SITE_URL + relative + '?src=foo')
+        with override_settings(EXTERNAL_SITE_URL='https://example.com'):
+            # downloads.file is a django served view so the same.
+            assert file.get_absolute_url(src='foo') == (
+                settings.SITE_URL + relative + '?src=foo')
 
 
 class BasePreviewMixin(object):

--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -34,6 +34,7 @@ API_THROTTLING = False
 DOMAIN = env('DOMAIN', default='addons-dev.allizom.org')
 SERVER_EMAIL = 'zdev@addons.mozilla.org'
 SITE_URL = 'https://' + DOMAIN
+EXTERNAL_SITE_URL = env('EXTERNAL_SITE_URL', default=SITE_URL)
 SERVICES_URL = env('SERVICES_URL',
                    default='https://services.addons-dev.allizom.org')
 CODE_MANAGER_URL = env('CODE_MANAGER_URL',

--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -22,6 +22,7 @@ CDN_HOST = 'https://addons.cdn.mozilla.net'
 DOMAIN = env('DOMAIN', default='addons.mozilla.org')
 SERVER_EMAIL = 'zprod@addons.mozilla.org'
 SITE_URL = 'https://' + DOMAIN
+EXTERNAL_SITE_URL = env('EXTERNAL_SITE_URL', default=SITE_URL)
 SERVICES_URL = env('SERVICES_URL',
                    default='https://services.addons.mozilla.org')
 CODE_MANAGER_URL = env('CODE_MANAGER_URL',

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -32,6 +32,7 @@ API_THROTTLING = True
 DOMAIN = env('DOMAIN', default='addons.allizom.org')
 SERVER_EMAIL = 'zstage@addons.mozilla.org'
 SITE_URL = 'https://' + DOMAIN
+EXTERNAL_SITE_URL = env('EXTERNAL_SITE_URL', default=SITE_URL)
 SERVICES_URL = env('SERVICES_URL',
                    default='https://services.addons.allizom.org')
 CODE_MANAGER_URL = env('CODE_MANAGER_URL',

--- a/src/olympia/files/tests/test_models.py
+++ b/src/olympia/files/tests/test_models.py
@@ -21,6 +21,7 @@ from mock import patch
 
 from olympia import amo
 from olympia.addons.models import Addon
+from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.amo.tests import TestCase, user_factory
 from olympia.amo.utils import chunked
 from olympia.applications.models import AppVersion
@@ -77,8 +78,8 @@ class TestFile(TestCase, amo.tests.AMOPaths):
 
     def test_get_url_path(self):
         file_ = File.objects.get(id=67442)
-        assert file_.get_url_path('src') == \
-            file_.get_absolute_url(src='src')
+        assert absolutify(file_.get_url_path('src')) == (
+            file_.get_absolute_url(src='src'))
 
     def test_get_url_path_attachment(self):
         file_ = File.objects.get(id=67442)

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -200,6 +200,10 @@ DOMAIN = HOSTNAME
 #   Example: https://addons.mozilla.org
 SITE_URL = 'http://%s' % DOMAIN
 
+# The base URL for the external user-facing frontend.  Only really useful for
+# the internal admin instances of addons-server that don't run addons-frontend.
+EXTERNAL_SITE_URL = env('EXTERNAL_SITE_URL', default=SITE_URL)
+
 # Domain of the services site.  This is where your API, and in-product pages
 # live.
 SERVICES_DOMAIN = 'services.%s' % DOMAIN

--- a/src/olympia/users/templates/users/email/author_added.ltxt
+++ b/src/olympia/users/templates/users/email/author_added.ltxt
@@ -1,5 +1,5 @@
 {% load i18n %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans with addon_url=addon.get_absolute_url addon_name=addon.name author_url=author.user.get_absolute_url author_name=author.user.name author_role=author.get_role_display %}
-The following author has been added to your addon {{ addon_name }} ( {{ site_url }}{{ addon_url }} ):
+The following author has been added to your addon {{ addon_name }} ( {{ addon_url }} ):
 
-{{ author_name }} ( {{ site_url }}{{ author_url }} ): {{ author_role }}
+{{ author_name }} ( {{ author_url }} ): {{ author_role }}
 {% endblocktrans %}

--- a/src/olympia/users/templates/users/email/author_changed.ltxt
+++ b/src/olympia/users/templates/users/email/author_changed.ltxt
@@ -1,5 +1,5 @@
 {% load i18n %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans with addon_url=addon.get_absolute_url addon_name=addon.name author_url=author.user.get_absolute_url author_name=author.user.name author_role=author.get_role_display %}
-The following author has been changed on your addon {{ addon_name }} ( {{ site_url }}{{ addon_url }} ):
+The following author has been changed on your addon {{ addon_name }} ( {{ addon_url }} ):
 
-{{ author_name }} ( {{ site_url }}{{ author_url }} ): {{ author_role }}
+{{ author_name }} ( {{ author_url }} ): {{ author_role }}
 {% endblocktrans %}

--- a/src/olympia/users/templates/users/email/author_removed.ltxt
+++ b/src/olympia/users/templates/users/email/author_removed.ltxt
@@ -1,5 +1,5 @@
 {% load i18n %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans with addon_url=addon.get_absolute_url addon_name=addon.name author_url=author.user.get_absolute_url author_name=author.user.name %}
-The following author has been removed from addon {{ addon_name }} ( {{ site_url }}{{ addon_url }} ):
+The following author has been removed from addon {{ addon_name }} ( {{ addon_url }} ):
 
-{{ author_name }} ( {{ site_url }}{{ author_url }} )
+{{ author_name }} ( {{ author_url }} )
 {% endblocktrans %}


### PR DESCRIPTION
fixes #10862 and #11014 and any other place /admin links to a frontend view.