### PR TITLE
Add CORS to validation results endpoint

### DIFF
--- a/src/olympia/devhub/tests/test_views_validation.py
+++ b/src/olympia/devhub/tests/test_views_validation.py
@@ -3,6 +3,7 @@ import json
 import shutil
 
 from django.core.files.storage import default_storage as storage
+from django.test.utils import override_settings
 
 import mock
 import waffle
@@ -211,6 +212,15 @@ class TestFileValidation(TestCase):
         assert not self.file.has_been_validated
 
         assert self.client.get(self.json_url).status_code == 405
+
+    def test_cors_headers_are_sent(self):
+        code_manager_url = 'https://my-code-manager-url.example.org'
+        with override_settings(CODE_MANAGER_URL=code_manager_url):
+            response = self.client.get(self.json_url)
+
+        assert response['Access-Control-Allow-Origin'] == code_manager_url
+        assert response['Access-Control-Allow-Methods'] == 'GET, OPTIONS'
+        assert response['Access-Control-Allow-Headers'] == 'Content-Type'
 
 
 class TestValidateAddon(TestCase):


### PR DESCRIPTION
Fixes #11048

---

This patch adds:

1. a `CODE_MANAGER_URL` variable in all envs (similar to `SERVICES_URL`)
2. CORS headers to the `validation.json` endpoint

It should be enough for code-manager although I did not try because it is complicated to make addons-server work with code-manager locally. I'll be able to test this patch in -dev though (using Chrome "Local Overrides" and code-manager in -dev).