### PR TITLE
Add an optional reviewer name alias for reviewers to hide their actual display name

### DIFF
--- a/docs/topics/api/activity.rst
+++ b/docs/topics/api/activity.rst
@@ -39,6 +39,11 @@ Review Notes Detail
 
 This endpoint allows you to fetch a single review note for a specific version of an add-on.
 
+    .. note::
+        To allow reviewers to stay anonymous if they wish, the ``user`` object ``name`` can point to
+        their "reviewer" name depending on the action. In addition all other fields in that object,
+        despite being present for backwards-compatibility, are set to ``null``.
+
 .. http:get:: /api/v4/addons/addon/(int:addon_id|string:addon_slug|string:addon_guid)/versions/(int:id)/reviewnotes/(int:id)/
 
     .. _review-notes-version-detail-object:
@@ -46,10 +51,10 @@ This endpoint allows you to fetch a single review note for a specific version of
     :>json int id: The id for a review note.
     :>json string action: The :ref:`type of review note<review-note-action>`.
     :>json string action_label: The text label of the action.
-    :>json int user.id: The id of the reviewer or author who left the review note.
+    :>json int|null user.id: The id of the reviewer or author who left the review note.
     :>json string user.name: The name of the reviewer or author.
-    :>json string user.url: The link to the profile page for of the reviewer or author.
-    :>json string user.username: The username of the reviewer or author.
+    :>json string|null user.url: The link to the profile page for of the reviewer or author.
+    :>json string|null user.username: The username of the reviewer or author.
     :>json string comments: The text content of the review note.
     :>json string date: The date the review note was created.
 

--- a/src/olympia/activity/models.py
+++ b/src/olympia/activity/models.py
@@ -479,6 +479,17 @@ class ActivityLog(ModelBase):
     def __html__(self):
         return self
 
+    @property
+    def author_name(self):
+        """Name of the user that triggered the activity.
+
+        If it's a reviewer action that will be shown to developers, the
+        `reviewer_name` property is used if present, otherwise `name` is
+        used."""
+        if self.action in constants.activity.LOG_REVIEW_QUEUE_DEVELOPER:
+            return self.user.reviewer_name or self.user.name
+        return self.user.name
+
     @classmethod
     def create(cls, action, *args, **kw):
         """

--- a/src/olympia/activity/serializers.py
+++ b/src/olympia/activity/serializers.py
@@ -2,7 +2,6 @@ from django.utils.translation import ugettext
 
 from rest_framework import serializers
 
-from olympia.accounts.serializers import BaseUserSerializer
 from olympia.activity.models import ActivityLog
 
 
@@ -11,7 +10,7 @@ class ActivityLogSerializer(serializers.ModelSerializer):
     action_label = serializers.SerializerMethodField()
     comments = serializers.SerializerMethodField()
     date = serializers.DateTimeField(source='created')
-    user = BaseUserSerializer()
+    user = serializers.SerializerMethodField()
     highlight = serializers.SerializerMethodField()
 
     class Meta:
@@ -37,3 +36,16 @@ class ActivityLogSerializer(serializers.ModelSerializer):
 
     def get_highlight(self, obj):
         return obj in self.to_highlight
+
+    def get_user(self, obj):
+        """Return minimal user information using ActivityLog.author_name to
+        avoid revealing actual name of reviewers for their review actions if
+        they have set an alias.
+
+        id, username and url are present for backwards-compatibility only."""
+        return {
+            'id': None,
+            'username': None,
+            'url': None,
+            'name': obj.author_name,
+        }

--- a/src/olympia/activity/utils.py
+++ b/src/olympia/activity/utils.py
@@ -242,7 +242,7 @@ def notify_about_activity_log(addon, version, note, perm_setting=None,
     author_context_dict = {
         'name': addon.name,
         'number': version.version,
-        'author': note.user.name,
+        'author': note.author_name,
         'comments': comments,
         'url': absolutify(addon.get_dev_url('versions')),
         'SITE_URL': settings.SITE_URL,
@@ -279,7 +279,7 @@ def notify_about_activity_log(addon, version, note, perm_setting=None,
                 addon.name, version.version)
     # Build and send the mail for authors.
     template = template_from_user(note.user, version)
-    from_email = formataddr((note.user.name, NOTIFICATIONS_FROM_EMAIL))
+    from_email = formataddr((note.author_name, NOTIFICATIONS_FROM_EMAIL))
     send_activity_mail(
         subject, template.render(author_context_dict),
         version, addon_authors, from_email, note.id, perm_setting)

--- a/src/olympia/devhub/templates/devhub/addons/activity.html
+++ b/src/olympia/devhub/templates/devhub/addons/activity.html
@@ -30,7 +30,8 @@
             {{ item }}
           </p>
           <p class="timestamp">
-          {% trans user=item.user|user_link, ago=item.created|timesince,
+          {% trans user=item.author_name,
+                   ago=item.created|timesince,
                    iso=item.created|isotime,
                    pretty=item.created|datetime %}
           <time datetime="{{ iso }}" title="{{ pretty }}">{{ ago }}</time>

--- a/src/olympia/devhub/templates/devhub/versions/list.html
+++ b/src/olympia/devhub/templates/devhub/versions/list.html
@@ -121,8 +121,8 @@
                   <p><a href="#" class="review-history-loadmore" data-div="#{{ version.id }}-review-history">{{ _('Load older...') }}</a></p>
               </div>
               <div class="review-entry-empty hidden">
-                  <p><span class="action">$action_label</span> {{ _('by') }}
-                  <a href="$user_profile">$user_name</a> <time class="timeago" datetime=$date>$date</time></p>
+                  <p><strong class="action">$action_label</strong> {{ _('by') }}
+                  <em class="user_name">$user_name</em> <time class="timeago" datetime=$date>$date</time></p>
                   <pre>$comments</pre>
               </div>
           </div>

--- a/src/olympia/migrations/1082-add-reviewer-name.sql
+++ b/src/olympia/migrations/1082-add-reviewer-name.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `users` ADD COLUMN `reviewer_name` varchar(50);

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -570,7 +570,7 @@ class ReviewBase(object):
             dev_ver_url = self.addon.get_dev_url('versions')
         return {'name': addon.name,
                 'number': self.version.version if self.version else '',
-                'reviewer': self.user.name,
+                'reviewer': self.user.reviewer_name or self.user.name,
                 'addon_url': absolutify(addon_url),
                 'dev_versions_url': absolutify(dev_ver_url),
                 'review_url': absolutify(reverse('reviewers.review',

--- a/src/olympia/users/admin.py
+++ b/src/olympia/users/admin.py
@@ -48,8 +48,8 @@ class UserAdmin(admin.ModelAdmin):
     fieldsets = (
         (None, {
             'fields': ('id', 'email', 'fxa_id', 'username', 'display_name',
-                       'biography', 'homepage', 'location', 'occupation',
-                       'picture_img'),
+                       'reviewer_name', 'biography', 'homepage', 'location',
+                       'occupation', 'picture_img'),
         }),
         ('Flags', {
             'fields': ('display_collections', 'deleted', 'is_public'),

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -166,6 +166,10 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
     # newsletter
     basket_token = models.CharField(blank=True, default='', max_length=128)
 
+    reviewer_name = models.CharField(
+        max_length=50, default='', null=True, blank=True,
+        validators=[validators.MinLengthValidator(2)])
+
     class Meta:
         db_table = 'users'
 

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -563,11 +563,10 @@ function initVersions() {
             if (note["highlight"] == true) {
                 clone.addClass("new");
             }
-            clone.find('span.action')[0].textContent = note["action_label"];
-            var user = clone.find('a:contains("$user_name")');
+            clone.find('.action')[0].textContent = note["action_label"];
+            var user = clone.find('.user_name');
             user[0].textContent = note["user"]["name"];
-            user.attr('href', note["user"]["url"]);
-            var date = clone.find('time.timeago');
+            var date = clone.find('.timeago');
             date[0].textContent = note["date"];
             date.attr('datetime', note["date"]);
             date.attr('title', note["date"]);


### PR DESCRIPTION
Used in logs, emails, any communication with developers.

Fixes #11002