### PR TITLE
Allow credentials (CORS) for accounts/session API endpoint

### DIFF
--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -1599,6 +1599,17 @@ class TestSessionView(TestCase):
         assert response['Access-Control-Allow-Origin'] == origin
         assert response['Access-Control-Allow-Credentials'] == 'true'
 
+    def test_delete_omits_cors_headers_when_there_is_no_origin(self):
+        user = user_factory(fxa_id='123123412')
+        token = self.login_user(user)
+        authorization = 'Bearer {token}'.format(token=token)
+        response = self.client.delete(
+            reverse_ns('accounts.session'),
+            HTTP_AUTHORIZATION=authorization,
+        )
+        assert not response.has_header('Access-Control-Allow-Origin')
+        assert not response.has_header('Access-Control-Allow-Credentials')
+
     def test_responds_to_cors_preflight_requests(self):
         user = user_factory(fxa_id='123123412')
         token = self.login_user(user)
@@ -1616,6 +1627,20 @@ class TestSessionView(TestCase):
         assert 'DELETE' in response['Access-Control-Allow-Methods']
         assert response.has_header('Access-Control-Max-Age')
         assert response['Access-Control-Allow-Origin'] == origin
+
+    def test_options_omits_cors_headers_when_there_is_no_origin(self):
+        user = user_factory(fxa_id='123123412')
+        token = self.login_user(user)
+        authorization = 'Bearer {token}'.format(token=token)
+        response = self.client.options(
+            reverse_ns('accounts.session'),
+            HTTP_AUTHORIZATION=authorization,
+        )
+        assert not response.has_header('Access-Control-Allow-Credentials')
+        assert not response.has_header('Access-Control-Allow-Headers')
+        assert not response.has_header('Access-Control-Allow-Methods')
+        assert not response.has_header('Access-Control-Allow-Origin')
+        assert not response.has_header('Access-Control-Max-Age')
 
 
 class TestAccountNotificationViewSetList(TestCase):

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -1586,6 +1586,37 @@ class TestSessionView(TestCase):
         response = self.client.delete(reverse_ns('accounts.session'))
         assert response.status_code == 401
 
+    def test_cors_headers_are_exposed(self):
+        user = user_factory(fxa_id='123123412')
+        token = self.login_user(user)
+        authorization = 'Bearer {token}'.format(token=token)
+        origin = 'http://example.org'
+        response = self.client.delete(
+            reverse_ns('accounts.session'),
+            HTTP_AUTHORIZATION=authorization,
+            HTTP_ORIGIN=origin,
+        )
+        assert response['Access-Control-Allow-Origin'] == origin
+        assert response['Access-Control-Allow-Credentials'] == 'true'
+
+    def test_responds_to_cors_preflight_requests(self):
+        user = user_factory(fxa_id='123123412')
+        token = self.login_user(user)
+        authorization = 'Bearer {token}'.format(token=token)
+        origin = 'http://example.org'
+        response = self.client.options(
+            reverse_ns('accounts.session'),
+            HTTP_AUTHORIZATION=authorization,
+            HTTP_ORIGIN=origin,
+        )
+        assert response['Content-Length'] == '0'
+        assert response['Access-Control-Allow-Credentials'] == 'true'
+        assert response.has_header('Access-Control-Allow-Headers')
+        assert response.has_header('Access-Control-Allow-Methods')
+        assert 'DELETE' in response['Access-Control-Allow-Methods']
+        assert response.has_header('Access-Control-Max-Age')
+        assert response['Access-Control-Allow-Origin'] == origin
+
 
 class TestAccountNotificationViewSetList(TestCase):
     client_class = APITestClient

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -395,15 +395,14 @@ def logout_user(request, response):
 class SessionView(APIView):
     permission_classes = [IsAuthenticated]
 
-    def add_common_cors_headers(self, request, response):
-        origin = request.META.get('HTTP_ORIGIN')
-        response[ACCESS_CONTROL_ALLOW_ORIGIN] = origin
-        response[ACCESS_CONTROL_ALLOW_CREDENTIALS] = 'true'
-
     def options(self, request, *args, **kwargs):
         response = Response()
         response['Content-Length'] = '0'
-        self.add_common_cors_headers(request, response)
+        origin = request.META.get('HTTP_ORIGIN')
+        if not origin:
+            return response
+        response[ACCESS_CONTROL_ALLOW_ORIGIN] = origin
+        response[ACCESS_CONTROL_ALLOW_CREDENTIALS] = 'true'
         # Mimics the django-cors-headers middleware.
         response[ACCESS_CONTROL_ALLOW_HEADERS] = ', '.join(
             corsheaders_conf.CORS_ALLOW_HEADERS
@@ -419,7 +418,11 @@ class SessionView(APIView):
     def delete(self, request, *args, **kwargs):
         response = Response({'ok': True})
         logout_user(request, response)
-        self.add_common_cors_headers(request, response)
+        origin = request.META.get('HTTP_ORIGIN')
+        if not origin:
+            return response
+        response[ACCESS_CONTROL_ALLOW_ORIGIN] = origin
+        response[ACCESS_CONTROL_ALLOW_CREDENTIALS] = 'true'
         return response
 
 

--- a/src/olympia/amo/tests/test_views.py
+++ b/src/olympia/amo/tests/test_views.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
+import re
 import sys
 
 from datetime import datetime, timedelta
@@ -376,6 +377,12 @@ class TestCORS(TestCase):
         assert response.status_code == 200
         assert not response.has_header('Access-Control-Allow-Credentials')
         assert response['Access-Control-Allow-Origin'] == '*'
+
+    def test_cors_excludes_accounts_session_endpoint(self):
+        assert re.match(
+            settings.CORS_URLS_REGEX,
+            reverse('v4:accounts.session'),
+        ) is None
 
 
 class TestContribute(TestCase):

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -2,10 +2,10 @@
 # Django settings for addons-server project.
 
 import environ
+import json
 import logging
 import os
 import socket
-import json
 
 import raven
 from kombu import Queue
@@ -99,7 +99,9 @@ DRF_API_REGEX = r'^/?api/(?:v3|v4|v4dev)/'
 # Add Access-Control-Allow-Origin: * header for the new API with
 # django-cors-headers.
 CORS_ORIGIN_ALLOW_ALL = True
-CORS_URLS_REGEX = DRF_API_REGEX
+# Exclude the `accounts/session` endpoint, see:
+# https://github.com/mozilla/addons-server/issues/11100
+CORS_URLS_REGEX = r'{}(?!accounts/session/)'.format(DRF_API_REGEX)
 
 
 def get_db_config(environ_var, atomic_requests=True):


### PR DESCRIPTION
Fixes #11100

---

API call (with the authenticated by-passed):

```
$ http OPTIONS http://olympia.test/api/v4/accounts/session/ Origin:http://foobar.exampl.com
HTTP/1.1 200 OK
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers: accept, accept-encoding, authorization, content-type, dnt, origin, user-agent, x-csrftoken, x-requested-with
Access-Control-Allow-Methods: DELETE, GET, OPTIONS, PATCH, POST, PUT
Access-Control-Allow-Origin: http://foobar.exampl.com
Access-Control-Max-Age: 86400
Allow: DELETE, OPTIONS
Connection: keep-alive
Content-Length: 0
Content-Security-Policy: default-src 'self'; object-src 'none'; script-src https://ssl.google-analytics.com/ga.js https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ https://addons.cdn.mozilla.net http://www.google-analytics.com 'self'; child-src 'self' https://www.google.com/recaptcha/; form-action 'self' https://developer.mozilla.org; base-uri 'self' https://addons.mozilla.org; frame-src 'self' https://www.google.com/recaptcha/; media-src https://videos.cdn.mozilla.net; connect-src 'self' https://sentry.prod.mozaws.net https://addons.cdn.mozilla.net; style-src 'self' 'unsafe-inline' https://addons.cdn.mozilla.net; font-src 'self' https://addons.cdn.mozilla.net; img-src 'self' data: blob: https://ssl.google-analytics.com https://addons.cdn.mozilla.net https://static.addons.mozilla.net https://sentry.prod.mozaws.net http://www.google-analytics.com; report-uri /csp-report
Date: Tue, 02 Apr 2019 12:46:59 GMT
Server: nginx/1.15.8
Vary: User-Agent
X-AMO-Request-ID: 9ca36fa5c009493cbc23422ee80f9170
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
```

```
$ http DELETE http://olympia.test/api/v4/accounts/session/ Origin:http://foobar.exampl.com
HTTP/1.1 200 OK
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: http://foobar.exampl.com
Allow: DELETE, OPTIONS
Connection: keep-alive
Content-Length: 11
Content-Security-Policy: default-src 'self'; object-src 'none'; script-src https://ssl.google-analytics.com/ga.js https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ https://addons.cdn.mozilla.net http://www.google-analytics.com 'self'; child-src 'self' https://www.google.com/recaptcha/; form-action 'self' https://developer.mozilla.org; base-uri 'self' https://addons.mozilla.org; frame-src 'self' https://www.google.com/recaptcha/; media-src https://videos.cdn.mozilla.net; connect-src 'self' https://sentry.prod.mozaws.net https://addons.cdn.mozilla.net; style-src 'self' 'unsafe-inline' https://addons.cdn.mozilla.net; font-src 'self' https://addons.cdn.mozilla.net; img-src 'self' data: blob: https://ssl.google-analytics.com https://addons.cdn.mozilla.net https://static.addons.mozilla.net https://sentry.prod.mozaws.net http://www.google-analytics.com; report-uri /csp-report
Content-Type: application/json
Date: Tue, 02 Apr 2019 12:47:33 GMT
Server: nginx/1.15.8
Set-Cookie: frontend_auth_token=""; expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/
Set-Cookie: multidb_pin_writes=y; expires=Tue, 02 Apr 2019 12:47:48 GMT; Max-Age=15; Path=/
Vary: User-Agent
X-AMO-Request-ID: 1c5bd4e152904ca3b5b8c71bb9b2ed94
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
X-XSS-Protection: 1; mode=block

{
    "ok": true
}
```