### PR TITLE
Correctly stream the raw file content.

### DIFF
--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -5636,6 +5636,10 @@ class TestDownloadGitFileView(TestCase):
             response['Content-Disposition'] ==
             'attachment; filename="manifest.json"')
 
+        content = b''.join(response.streaming_content).decode('utf-8')
+        assert content.startswith('{')
+        assert '"manifest_version": 2' in content
+
     def test_download_emoji_filename(self):
         new_version = version_factory(
             addon=self.addon, file_kw={'filename': 'webextension_no_id.xpi'})
@@ -5680,6 +5684,10 @@ class TestDownloadGitFileView(TestCase):
 
         response = self.client.get(url)
         assert response.status_code == 200
+
+        content = b''.join(response.streaming_content).decode('utf-8')
+        assert content.startswith('{')
+        assert '"manifest_version": 2' in content
 
     def test_disabled_version_reviewer(self):
         user = UserProfile.objects.create(username='reviewer')

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -1,5 +1,6 @@
 import json
 import time
+import io
 
 from collections import OrderedDict, defaultdict
 from datetime import date, datetime, timedelta
@@ -1201,8 +1202,9 @@ def download_git_stored_file(request, version_id, filename):
         raise http.Http404()
 
     actual_blob = serializer.git_repo[blob_or_tree.oid]
+
     response = http.FileResponse(
-        memoryview(actual_blob),
+        io.BytesIO(memoryview(actual_blob)),
         content_type=selected_file['mimetype'])
 
     # Backported from Django 2.1 to handle unicode filenames properly


### PR DESCRIPTION
If passed a bytestring as data the streamed content will be bonkers, if
passed a BytesIO file-like object the actual data will be correctly
streamed.

In theory, with a BytesIO wrapping the memoryview we should be keeping
the advantages of using `memoryview` for the blob, which is reduced
memory usage. In practice this probably won't matter much.

I have no idea how to actually test the memory-exhausting to be honest,
so this is primarily guesswork and docs-reading.

Fixes #1118