### PR TITLE
remove discovery_modules db table

### DIFF
--- a/src/olympia/migrations/1084-remove-discovery-modules-table.sql
+++ b/src/olympia/migrations/1084-remove-discovery-modules-table.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS `discovery_modules`;


### PR DESCRIPTION
I remove `discovery_modules` db table.
Please let me know if I need to correct any mistakes. 

Fixes #11110 
