### PR TITLE
Re-extract version after successful signing.

### DIFF
--- a/src/olympia/lib/git.py
+++ b/src/olympia/lib/git.py
@@ -156,7 +156,7 @@ class AddonGitRepository(object):
         return git_repository
 
     @classmethod
-    def extract_and_commit_from_version(cls, version, author=None):
+    def extract_and_commit_from_version(cls, version, author=None, note=None):
         """Extract the XPI from `version` and comit it.
 
         This is doing the following:
@@ -227,16 +227,18 @@ class AddonGitRepository(object):
             repo = cls(version.addon.id, package_type='addon')
             file_obj = version.all_files[0]
             branch = repo.find_or_create_branch(BRANCHES[version.channel])
+            note = ' ({})'.format(note) if note else ''
 
             commit = repo._commit_through_worktree(
                 path=file_obj.current_file_path,
                 message=(
                     'Create new version {version} ({version_id}) for '
-                    '{addon} from {file_obj}'.format(
+                    '{addon} from {file_obj}{note}'.format(
                         version=repr(version),
                         version_id=version.id,
                         addon=repr(version.addon),
-                        file_obj=repr(file_obj))),
+                        file_obj=repr(file_obj),
+                        note=note)),
                 author=author,
                 branch=branch)
 
@@ -345,11 +347,11 @@ class AddonGitRepository(object):
             # Now create an commit directly on top of the respective branch
             oid = worktree.repo.create_commit(
                 None,
-                # author, using the actual uploading user
+                # author, using the actual uploading user if possible.
                 self.get_author(author),
                 # committer, using addons-robot because that's the user
                 # actually doing the commit.
-                self.get_author(),  # commiter, using addons-robot
+                self.get_author(),
                 message,
                 tree,
                 # Set the current branch HEAD as the parent of this commit

--- a/src/olympia/lib/tests/test_git.py
+++ b/src/olympia/lib/tests/test_git.py
@@ -258,6 +258,25 @@ def test_extract_and_commit_from_version_use_addons_robot_default():
 
 
 @pytest.mark.django_db
+def test_extract_and_commit_from_version_support_custom_note():
+    addon = addon_factory(file_kw={'filename': 'webextension_no_id.xpi'})
+
+    repo = AddonGitRepository.extract_and_commit_from_version(
+        version=addon.current_version,
+        note='via signing')
+
+    output = _run_process('git log --format=full listed', repo)
+    print(output)
+
+    expected = (
+        'Create new version {} ({}) for {} from {} (via signing)'
+        .format(
+            repr(addon.current_version), addon.current_version.id, repr(addon),
+            repr(addon.current_version.all_files[0])))
+    assert expected in output
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize('filename', [
     'webextension_no_id.xpi',
     'webextension_no_id.zip',

--- a/src/olympia/versions/tasks.py
+++ b/src/olympia/versions/tasks.py
@@ -113,7 +113,7 @@ def delete_preview_files(pk, **kw):
 
 @task
 @use_primary_db
-def extract_version_to_git(version_id, author_id=None):
+def extract_version_to_git(version_id, author_id=None, note=None):
     """Extract a `File` into our git storage backend."""
     # We extract deleted or disabled versions as well so we need to make sure
     # we can access them.
@@ -128,7 +128,7 @@ def extract_version_to_git(version_id, author_id=None):
         version_id=version_id))
 
     repo = AddonGitRepository.extract_and_commit_from_version(
-        version=version, author=author)
+        version=version, author=author, note=note)
 
     log.info('Extracted {version} into {git_path}'.format(
         version=version_id, git_path=repo.git_repository_path))


### PR DESCRIPTION
Re-extract version after successful signing.

Fixes #11102

This is what it looks like now:

```
Author: Mozilla Add-ons Robot <addons-dev-automation+github@mozilla.com>
Date:   Thu Apr 4 08:58:01 2019 +0000

    Create new version <Version: 1.7> (127) for <Addon: 98: Addôn d3580094dec547c7958124ec447c087f> from <File: 127> (after successful signing)

commit 4cf4e71b72bd793a69eaa55959410576d9e43e17
Author: Mozilla Add-ons Robot <addons-dev-automation+github@mozilla.com>
Date:   Thu Apr 4 08:58:00 2019 +0000

    Create new version <Version: 1.7> (127) for <Addon: 98: Addôn d3580094dec547c7958124ec447c087f> from <File: 127>

commit 0029bd62c690373ed186c2b3f7b0c3f5dceac64a
Author: Mozilla Add-ons Robot <addons-dev-automation+github@mozilla.com>
Date:   Thu Apr 4 08:58:00 2019 +0000

    Initializing repository
```