### PR TITLE
add conf defaults for EXTERNAL_SITE_URL

### DIFF
--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -34,7 +34,8 @@ API_THROTTLING = False
 DOMAIN = env('DOMAIN', default='addons-dev.allizom.org')
 SERVER_EMAIL = 'zdev@addons.mozilla.org'
 SITE_URL = 'https://' + DOMAIN
-EXTERNAL_SITE_URL = env('EXTERNAL_SITE_URL', default=SITE_URL)
+EXTERNAL_SITE_URL = env('EXTERNAL_SITE_URL',
+                        default='https://addons-dev.allizom.org')
 SERVICES_URL = env('SERVICES_URL',
                    default='https://services.addons-dev.allizom.org')
 CODE_MANAGER_URL = env('CODE_MANAGER_URL',

--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -22,7 +22,8 @@ CDN_HOST = 'https://addons.cdn.mozilla.net'
 DOMAIN = env('DOMAIN', default='addons.mozilla.org')
 SERVER_EMAIL = 'zprod@addons.mozilla.org'
 SITE_URL = 'https://' + DOMAIN
-EXTERNAL_SITE_URL = env('EXTERNAL_SITE_URL', default=SITE_URL)
+EXTERNAL_SITE_URL = env('EXTERNAL_SITE_URL',
+                        default='https://addons.mozilla.org')
 SERVICES_URL = env('SERVICES_URL',
                    default='https://services.addons.mozilla.org')
 CODE_MANAGER_URL = env('CODE_MANAGER_URL',

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -32,7 +32,8 @@ API_THROTTLING = True
 DOMAIN = env('DOMAIN', default='addons.allizom.org')
 SERVER_EMAIL = 'zstage@addons.mozilla.org'
 SITE_URL = 'https://' + DOMAIN
-EXTERNAL_SITE_URL = env('EXTERNAL_SITE_URL', default=SITE_URL)
+EXTERNAL_SITE_URL = env('EXTERNAL_SITE_URL',
+                        default='https://addons.allizom.org')
 SERVICES_URL = env('SERVICES_URL',
                    default='https://services.addons.allizom.org')
 CODE_MANAGER_URL = env('CODE_MANAGER_URL',


### PR DESCRIPTION
followup for #10862 to avoid ops having to specify a bunch of extra urls for no benefit (I'm not sure how easy it is to add config for just the internal instances anyway)