### PR TITLE
Don't call git extraction in case of unforseen errors.

### DIFF
--- a/src/olympia/devhub/tasks.py
+++ b/src/olympia/devhub/tasks.py
@@ -105,7 +105,6 @@ def submit_file(addon_pk, upload_pk, channel):
 
 @transaction.atomic
 def create_version_for_upload(addon, upload, channel):
-    """Note this function is only used for API uploads."""
     fileupload_exists = addon.fileupload_set.filter(
         created__gt=upload.created, version=upload.version).exists()
     version_exists = Version.unfiltered.filter(

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -8,7 +8,7 @@ import django.dispatch
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.storage import default_storage as storage
-from django.db import models
+from django.db import models, transaction
 from django.utils.encoding import force_text, python_2_unicode_compatible
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext
@@ -249,7 +249,8 @@ class Version(OnChangeMixin, ModelBase):
         version_uploaded.send(sender=version)
 
         # Extract this version into git repository
-        extract_version_to_git_repository(version, upload)
+        transaction.on_commit(
+            lambda: extract_version_to_git_repository(version, upload))
 
         # Generate a preview and icon for listed static themes
         if (addon.type == amo.ADDON_STATICTHEME and

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -878,7 +878,7 @@ class TestExtensionVersionFromUploadTransactional(
         # create_version_for_upload does
         with pytest.raises(ValueError):
             with transaction.atomic():
-                version = Version.from_upload(
+                Version.from_upload(
                     upload, addon, [self.selected_app],
                     amo.RELEASE_CHANNEL_LISTED,
                     parsed_data=parsed_data)

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -819,10 +819,8 @@ class TestExtensionVersionFromUploadTransactional(
 
     def setUp(self):
         super(TestExtensionVersionFromUploadTransactional, self).setUp()
-        # We're not inheriting from `TestVersionFromUpload` as it defines
-        # `setUpTestData` which doesn't play well with the behavior of
-        # `TransactionTestCase`
-        # That's also why AppVersion related instances are created here
+        # We can't use `setUpTestData` here because it doesn't play well with
+        # the behavior of `TransactionTestCase`
         amo.tests.create_default_webext_appversion()
 
         self.upload = self.get_upload(self.filename)
@@ -830,10 +828,6 @@ class TestExtensionVersionFromUploadTransactional(
 
     def get_upload(self, filename=None, abspath=None, validation=None,
                    addon=None, user=None, version=None, with_validation=True):
-        """We're implementing our own `get_upload` method because we can't
-        inherit from `UploadTest` as it inherits our `TestCase` class which
-        for some reason cancels out some of the transactional behavior we want
-        """
         fpath = self.file_fixture_path(filename)
         with open(abspath if abspath else fpath, 'rb') as fobj:
             xpi = fobj.read()


### PR DESCRIPTION
Don't run the git-extraction task if the database transaction is never
actually committed so that we don't end up trying to extract something
that doesn't exist.

Fixes #11183
