### PR TITLE
Allow `message` to be omitted in addon abuse reports if `reason` is provided

### DIFF
--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -99,7 +99,7 @@ class AbuseReport(ModelBase):
     user = models.ForeignKey(
         UserProfile, null=True, related_name='abuse_reports',
         on_delete=models.SET_NULL)
-    message = models.TextField()
+    message = models.TextField(blank=True)
 
     state = models.PositiveSmallIntegerField(
         default=STATES.UNTRIAGED, choices=STATES.choices)


### PR DESCRIPTION
Fixes #11204