### PR TITLE
Fix populate_data target in Makefile-docker (therefore fixing initialize)

### DIFF
--- a/Makefile-docker
+++ b/Makefile-docker
@@ -85,10 +85,6 @@ initialize_db:
 
 .PHONY: populate_data
 populate_data:
-	# FXA username and password for ui-tests
-	export UITEST_FXA_EMAIL := uitest-$(shell uuid)@restmail.net
-	export UITEST_FXA_PASSWORD := uitester
-
 	# reindex --wipe will force the ES mapping to be re-installed. Useful to
 	# make sure the mapping is correct before adding a bunch of add-ons.
 	$(PYTHON_COMMAND) manage.py reindex --wipe --force --noinput

--- a/src/olympia/landfill/serializers.py
+++ b/src/olympia/landfill/serializers.py
@@ -4,6 +4,7 @@ import collections
 import mimetypes
 import os
 import random
+import uuid
 
 from django.conf import settings
 from django.utils.translation import activate
@@ -42,8 +43,10 @@ class GenerateAddonsSerializer(serializers.Serializer):
     count = serializers.IntegerField(default=10)
 
     def __init__(self):
-        self.fxa_email = os.environ['UITEST_FXA_EMAIL']
-        self.fxa_password = os.environ['UITEST_FXA_PASSWORD']
+        self.fxa_email = os.environ.get(
+            'UITEST_FXA_EMAIL', 'uitest-%s@restmail.net' % uuid.uuid4())
+        self.fxa_password = os.environ.get(
+            'UITEST_FXA_PASSWORD', 'uitester')
         self.fxa_id = self._create_fxa_user()
         self.user = self._create_addon_user()
 


### PR DESCRIPTION
Fixes the following:
```
% make populate_data
export UITEST_FXA_EMAIL := uitest-87b0c546-6b2e-11e9-8d08-0242ac120008@restmail.net
/bin/sh: 1: export: :: bad variable name
Makefile-docker:88: recipe for target 'populate_data' failed
make: *** [populate_data] Error 2
```

Fixes #11127