### PR TITLE
fix profile photo size warning

### DIFF
--- a/src/olympia/accounts/serializers.py
+++ b/src/olympia/accounts/serializers.py
@@ -149,7 +149,7 @@ class UserProfileSerializer(PublicUserProfileSerializer):
         if value.size > settings.MAX_PHOTO_UPLOAD_SIZE:
             raise serializers.ValidationError(
                 ugettext(u'Please use images smaller than %dMB.' %
-                         (settings.MAX_PHOTO_UPLOAD_SIZE / 1024 / 1024 - 1)))
+                         (settings.MAX_PHOTO_UPLOAD_SIZE / 1024 / 1024)))
         return value
 
     def update(self, instance, validated_data):


### PR DESCRIPTION
Fixes #11186
Fix incorrect warning message when uploading large profile photo which stated that the file size limit is 3MB instead of 4MB.
## Before
![Screenshot from 2019-05-06 21-56-14](https://user-images.githubusercontent.com/19268668/57229954-d6ca0c80-7049-11e9-9756-4c412c27e897.png)

## After
![Screenshot from 2019-05-06 21-53-33](https://user-images.githubusercontent.com/19268668/57229781-80f56480-7049-11e9-9efb-98b47c5ceceb.png)
