### PR TITLE
Handle non-existent files in the Browse API

### DIFF
--- a/src/olympia/reviewers/serializers.py
+++ b/src/olympia/reviewers/serializers.py
@@ -188,7 +188,10 @@ class FileEntriesSerializer(FileSerializer):
     def get_content(self, obj):
         commit = self._get_commit(obj)
         tree = self.repo.get_root_tree(commit)
-        blob_or_tree = tree[self.get_selected_file(obj)]
+        try:
+            blob_or_tree = tree[self.get_selected_file(obj)]
+        except KeyError:
+            raise NotFound('File not found')
 
         if blob_or_tree.type == 'blob':
             # TODO: Test if this is actually needed, historically it was
@@ -201,7 +204,10 @@ class FileEntriesSerializer(FileSerializer):
         commit = self._get_commit(obj)
         tree = self.repo.get_root_tree(commit)
         selected_file = self.get_selected_file(obj)
-        blob_or_tree = tree[selected_file]
+        try:
+            blob_or_tree = tree[selected_file]
+        except KeyError:
+            raise NotFound('File not found')
 
         if blob_or_tree.type == 'tree':
             return None

--- a/src/olympia/reviewers/tests/test_serializers.py
+++ b/src/olympia/reviewers/tests/test_serializers.py
@@ -6,6 +6,7 @@ import pytest
 
 from unittest.mock import MagicMock
 
+from rest_framework.exceptions import NotFound
 from rest_framework.test import APIRequestFactory
 from rest_framework.settings import api_settings
 
@@ -140,6 +141,11 @@ class TestFileEntriesSerializer(TestCase):
                 'filename': 'icons/LICENSE'
             }
         ))
+
+    def test_requested_file_with_non_existent_file(self):
+        file = self.addon.current_version.current_file
+        with self.assertRaises(NotFound):
+            self.serialize(file, file='UNKNOWN_FILE')
 
     def test_supports_search_plugin(self):
         self.addon = addon_factory(file_kw={'filename': 'search_20190331.xml'})

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -5376,6 +5376,14 @@ class TestReviewAddonVersionViewSetDetail(
             }
         ))
 
+    def test_non_existent_requested_file_returns_404(self):
+        user = UserProfile.objects.create(username='reviewer')
+        self.grant_permission(user, 'Addons:Review')
+        self.client.login_api(user)
+
+        response = self.client.get(self.url + '?file=UNKNOWN_FILE')
+        assert response.status_code == 404
+
     def test_supports_search_plugins(self):
         self.addon = addon_factory(
             name=u'My Addôn', slug='my-addon',

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -18,6 +18,7 @@ from django.views.decorators.cache import never_cache
 import six
 
 from rest_framework import status
+from rest_framework.exceptions import NotFound
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
@@ -1202,7 +1203,7 @@ def download_git_stored_file(request, version_id, filename):
         if blob_or_tree.type == 'tree':
             return http.HttpResponseBadRequest('Can\'t serve directories')
         selected_file = serializer.get_entries(file)[filename]
-    except KeyError:
+    except (KeyError, NotFound):
         raise http.Http404()
 
     actual_blob = serializer.git_repo[blob_or_tree.oid]


### PR DESCRIPTION
Fixes #11297 
Fixes #11196

---

This patch prevents the API to crash when a non-existent file is requested.