### PR TITLE
Implement a new draft-comment model.

### DIFF
--- a/src/olympia/activity/models.py
+++ b/src/olympia/activity/models.py
@@ -162,6 +162,20 @@ class GroupLog(ModelBase):
         ordering = ('-created',)
 
 
+class DraftComment(ModelBase):
+    """A model that allows us to draft comments for reviews before we have
+    an ActivityLog instance ready.
+
+    This is being used by the commenting API by the code-manager.
+    """
+    id = PositiveAutoField(primary_key=True)
+    comments = models.TextField()
+    version = models.OneToOneField(Version, on_delete=models.CASCADE)
+
+    class Meta:
+        db_table = 'log_activity_comment_draft'
+
+
 class ActivityLogManager(ManagerBase):
     def for_addons(self, addons):
         if isinstance(addons, Addon):

--- a/src/olympia/migrations/1090-create-log-activity-comment-draft-table.sql
+++ b/src/olympia/migrations/1090-create-log-activity-comment-draft-table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `log_activity_comment_draft` (
+  `id` integer UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY,
+  `created` datetime(6) NOT NULL,
+  `modified` datetime(6) NOT NULL,
+  `comments` longtext NOT NULL,
+  `version_id` integer UNSIGNED NOT NULL
+);
+
+ALTER TABLE `log_activity_comment_draft`
+  ADD CONSTRAINT `log_activity_comment_draft_version_id_b9633528_fk_versions_id`
+  FOREIGN KEY (`version_id`)
+  REFERENCES `versions` (`id`);

--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -376,6 +376,9 @@ class ReviewForm(forms.Form):
         self.fields['action'].choices = [
             (k, v['label']) for k, v in self.helper.actions.items()]
 
+        if self.initial.get('comments_draft'):
+            self.fields['comments'].initial = self.initial['comments_draft']
+
     @property
     def unreviewed_files(self):
         return (self.helper.version.unreviewed_files


### PR DESCRIPTION
This new model will be used to present draft-comments written in the
code-manager and displayed during review.

The related rest-api comes in a second step.

Fixes #11319
