### PR TITLE
Fix download_url when requested file is known but does not exist in the tree anymore

### DIFF
--- a/docs/topics/api/reviewers.rst
+++ b/docs/topics/api/reviewers.rst
@@ -159,7 +159,7 @@ This endpoint allows you to compare two Add-on versions with each other.
 .. http:get:: /api/v4/reviewers/addon/(int:addon_id)/versions/(int:version_id)/compare_to/(int:version_id)/
 
     Inherits most properties from :ref:`browse detail <reviewers-versions-browse-detail>`, except that most of the `file.entries[]` properties
-    can be `null` in case of a deleted file.
+    and `file.download_url` can be `null` in case of a deleted file.
 
     Properties specific to this endpoint:
 

--- a/src/olympia/reviewers/serializers.py
+++ b/src/olympia/reviewers/serializers.py
@@ -203,7 +203,12 @@ class FileEntriesSerializer(FileSerializer):
         commit = self._get_commit(obj)
         tree = self.repo.get_root_tree(commit)
         selected_file = self.get_selected_file(obj)
-        blob_or_tree = tree[selected_file]
+
+        try:
+            blob_or_tree = tree[selected_file]
+        except KeyError:
+            # This can happen when the file has been deleted.
+            return None
 
         if blob_or_tree.type == 'tree':
             return None

--- a/src/olympia/reviewers/tests/test_serializers.py
+++ b/src/olympia/reviewers/tests/test_serializers.py
@@ -286,6 +286,23 @@ class TestFileEntriesDiffSerializer(TestCase):
         assert readme_data['size'] is None
         assert readme_data['modified'] is None
 
+    def test_serialize_deleted_file(self):
+        parent_version = self.addon.current_version
+        new_version = version_factory(
+            addon=self.addon, file_kw={
+                'filename': 'webextension_no_id.xpi',
+                'is_webextension': True,
+            }
+        )
+
+        repo = AddonGitRepository.extract_and_commit_from_version(new_version)
+        apply_changes(repo, new_version, '', 'manifest.json', delete=True)
+
+        file = self.addon.current_version.current_file
+        data = self.serialize(file, parent_version=parent_version)
+
+        assert data['download_url'] == None
+
 
 @pytest.mark.parametrize(
     'entry, filename, expected_category, expected_mimetype',


### PR DESCRIPTION
Fixes #11364

---

The file is known so the check in `get_selected_file` (cf. #11346) does
not catch the error. Because it is a deleted file, we cannot return a
download URL, so that's the idea of this patch.