### PR TITLE
Return diff as an object or null, not an array

### DIFF
--- a/docs/topics/api/reviewers.rst
+++ b/docs/topics/api/reviewers.rst
@@ -174,7 +174,7 @@ This endpoint allows you to compare two Add-on versions with each other.
     :>json string|null files.entries[].mime_category: The mime type category of this file. Can be ``image``, ``directory``, ``text`` or ``binary``.
     :>json int|null file.entries[].size: The size in bytes.
     :>json string|null file.entries[].modified: The exact time of the commit, should be equivalent with ``created``.
-    :>json object diff: See the following output with inline comments for a complete description.
+    :>json object|null diff: See the following output with inline comments for a complete description.
 
     Git patch we're talking about:
 
@@ -235,42 +235,40 @@ This endpoint allows you to compare two Add-on versions with each other.
 
     .. code:: javascript
 
-        "diff": [
-            {
-                "path": "README.md",
-                "old_path": "README.md",
-                "size": 15,  // Size in bytes
-                "lines_added": 1,  // How many lines got added
-                "lines_deleted": 1,  // How many lines got deleted
-                "is_binary": false,  // Is this a binary file (as determined by git)
-                "mode": "M",  // Status of this file, see https://git-scm.com/docs/git-status#_short_format
-                "hunks": [
-                    {
-                        "header": "@@ -1 +1 @@\\n",
-                        "old_start": 1,
-                        "new_start": 1,
-                        "old_lines": 1,
-                        "new_lines": 1,
-                        "changes": [
-                            {
-                                "content": "# beastify\\n",
-                                "type": "delete",
-                                "old_line_number": 1,
-                                "new_line_number": -1
-                            },
-                            {
-                                "content": "Updated readme\\n",
-                                "type": "insert",
-                                "old_line_number": -1,
-                                "new_line_number": 1
-                            }
-                        ]
-                    }
-                ],
-                "parent": "075c5755198be472522477a1b396951b3b68ac18",
-                "hash": "00161dcf22afb7bab23cf205f0c903eb5aad5431"
-            }
-        ]
+        "diff": {
+            "path": "README.md",
+            "old_path": "README.md",
+            "size": 15,  // Size in bytes
+            "lines_added": 1,  // How many lines got added
+            "lines_deleted": 1,  // How many lines got deleted
+            "is_binary": false,  // Is this a binary file (as determined by git)
+            "mode": "M",  // Status of this file, see https://git-scm.com/docs/git-status#_short_format
+            "hunks": [
+                {
+                    "header": "@@ -1 +1 @@\\n",
+                    "old_start": 1,
+                    "new_start": 1,
+                    "old_lines": 1,
+                    "new_lines": 1,
+                    "changes": [
+                        {
+                            "content": "# beastify\\n",
+                            "type": "delete",
+                            "old_line_number": 1,
+                            "new_line_number": -1
+                        },
+                        {
+                            "content": "Updated readme\\n",
+                            "type": "insert",
+                            "old_line_number": -1,
+                            "new_line_number": 1
+                        }
+                    ]
+                }
+            ],
+            "parent": "075c5755198be472522477a1b396951b3b68ac18",
+            "hash": "00161dcf22afb7bab23cf205f0c903eb5aad5431"
+        }
 
 
 -----------------

--- a/src/olympia/reviewers/serializers.py
+++ b/src/olympia/reviewers/serializers.py
@@ -307,6 +307,10 @@ class FileEntriesDiffSerializer(FileEntriesSerializer):
             parent=parent,
             pathspec=[self.get_selected_file(obj)])
 
+        # Because we're always specifying `pathspec` with the currently
+        # selected file we can inline the diff because there will always be
+        # one.
+        # See: https://github.com/mozilla/addons-server/issues/11392
         return next(iter(diff), None)
 
     def get_entries(self, obj):

--- a/src/olympia/reviewers/serializers.py
+++ b/src/olympia/reviewers/serializers.py
@@ -307,7 +307,7 @@ class FileEntriesDiffSerializer(FileEntriesSerializer):
             parent=parent,
             pathspec=[self.get_selected_file(obj)])
 
-        return diff
+        return next(iter(diff), None)
 
     def get_entries(self, obj):
         """Overwrite `FileEntriesSerializer.get_entries to inject

--- a/src/olympia/reviewers/tests/test_serializers.py
+++ b/src/olympia/reviewers/tests/test_serializers.py
@@ -286,6 +286,10 @@ class TestFileEntriesDiffSerializer(TestCase):
         assert readme_data['size'] is None
         assert readme_data['modified'] is None
 
+        # There is no difference for the selected file because we did not
+        # change it.
+        assert data['diff'] is None
+
     def test_serialize_deleted_file(self):
         parent_version = self.addon.current_version
         new_version = version_factory(
@@ -302,6 +306,9 @@ class TestFileEntriesDiffSerializer(TestCase):
         data = self.serialize(file, parent_version=parent_version)
 
         assert data['download_url'] is None
+        # We deleted the selected file, so there should be a diff.
+        assert data['diff'] is not None
+        assert data['diff']['mode'] == 'D'
 
 
 @pytest.mark.parametrize(

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -5790,9 +5790,9 @@ class TestReviewAddonVersionCompareViewSet(
 
         assert result['id'] == self.version.pk
         assert result['file']['id'] == self.version.current_file.pk
-        assert result['file']['diff'][0]['path'] == 'manifest.json'
+        assert result['file']['diff']['path'] == 'manifest.json'
 
-        change = result['file']['diff'][0]['hunks'][0]['changes'][3]
+        change = result['file']['diff']['hunks'][0]['changes'][3]
 
         assert '"name": "Beastify"' in change['content']
         assert change['type'] == 'insert'
@@ -5815,9 +5815,9 @@ class TestReviewAddonVersionCompareViewSet(
         response = self.client.get(self.url + '?file=README.md')
         assert response.status_code == 200
         result = json.loads(response.content)
-        assert result['file']['diff'][0]['path'] == 'README.md'
+        assert result['file']['diff']['path'] == 'README.md'
 
-        change = result['file']['diff'][0]['hunks'][0]['changes'][0]
+        change = result['file']['diff']['hunks'][0]['changes'][0]
 
         assert change['content'] == '# beastify'
         assert change['type'] == 'insert'
@@ -5851,9 +5851,9 @@ class TestReviewAddonVersionCompareViewSet(
         response = self.client.get(self.url)
         assert response.status_code == 200
         result = json.loads(response.content)
-        changes = result['file']['diff'][0]['hunks'][0]['changes']
+        changes = result['file']['diff']['hunks'][0]['changes']
 
-        assert result['file']['diff'][0]['path'] == 'search.xml'
+        assert result['file']['diff']['path'] == 'search.xml'
         assert changes[-1] == {
             'content': '<xml></xml>',
             'new_line_number': 1,
@@ -5897,8 +5897,8 @@ class TestReviewAddonVersionCompareViewSet(
 
         result = json.loads(response.content)
 
-        assert result['file']['diff'][0]['path'] == 'README.md'
-        assert result['file']['diff'][0]['hunks'][0]['changes'] == [
+        assert result['file']['diff']['path'] == 'README.md'
+        assert result['file']['diff']['hunks'][0]['changes'] == [
             {
                 'content': '# beastify',
                 'new_line_number': -1,


### PR DESCRIPTION
Fixes #11392

---

I am not sure what the best Python idiom is for returning the first item of a list or `None`.