### PR TITLE
Enable GIT_OPT_ENABLE_FSYNC_GITDIR option

### DIFF
--- a/src/olympia/lib/git.py
+++ b/src/olympia/lib/git.py
@@ -115,7 +115,13 @@ class AddonGitRepository(object):
         # https://github.com/libgit2/pygit2/issues/339
         # https://github.com/libgit2/libgit2/issues/2122
         git_home = settings.ROOT
-        pygit2.settings.search_path[pygit2.GIT_CONFIG_LEVEL_GLOBAL] = git_home
+        pygit2.option(
+            pygit2.GIT_OPT_SET_SEARCH_PATH,
+            pygit2.GIT_CONFIG_LEVEL_GLOBAL,
+            git_home)
+
+        # Enable calling fsync() for various operations touching .git
+        pygit2.option(pygit2.GIT_OPT_ENABLE_FSYNC_GITDIR, True)
 
         addon_id = (
             addon_or_id.pk

--- a/src/olympia/lib/tests/test_git.py
+++ b/src/olympia/lib/tests/test_git.py
@@ -86,6 +86,8 @@ def test_temporary_worktree(settings):
 
 
 def test_enforce_pygit_global_search_path(settings):
+    # Not using pygit2.option() here to make sure the call in
+    # AddonGitRepository changes the correct things
     pygit2.settings.search_path[pygit2.GIT_CONFIG_LEVEL_GLOBAL] = '/root'
 
     assert (


### PR DESCRIPTION
Fixes #11449

Unfortunately… there's literally no API available to fetch the libgit
internal value of `git_repository__fsync_gitdir` so testing this is
kinda possible.

I'll see if on a Friday I can try to expose that value in the pygit2 api
somewhere.

Changes how the global search paths are being set by using `pygit2.option()` too which feels like a more official API and directly uses libgit2 mechanisms.