### PR TITLE
Try to simplify hide_disabled_files/unhide_disabled_files crons

### DIFF
--- a/src/olympia/addons/cron.py
+++ b/src/olympia/addons/cron.py
@@ -131,17 +131,17 @@ def hide_disabled_files():
 
     See also unhide_disabled_files().
     """
-    q = (Q(version__addon__status=amo.STATUS_DISABLED) |
-         Q(version__addon__disabled_by_user=True))
-    ids = (File.objects.filter(q | Q(status=amo.STATUS_DISABLED))
-           .values_list('id', flat=True))
+    ids = (File.objects.filter(
+        Q(version__addon__status=amo.STATUS_DISABLED) |
+        Q(version__addon__disabled_by_user=True) |
+        Q(status=amo.STATUS_DISABLED)).values_list('id', flat=True))
     for chunk in chunked(ids, 300):
         qs = File.objects.select_related('version').filter(id__in=chunk)
-        for f in qs:
+        for file_ in qs:
             # This tries to move the file to the disabled location. If it
             # didn't exist at the source, it will catch the exception, log it
             # and continue.
-            f.hide_disabled_file()
+            file_.hide_disabled_file()
 
 
 def unhide_disabled_files():
@@ -151,17 +151,17 @@ def unhide_disabled_files():
 
     See also hide_disabled_files().
     """
-    q = (Q(version__addon__status=amo.STATUS_DISABLED) |
-         Q(version__addon__disabled_by_user=True))
-    ids = (File.objects.exclude(q | Q(status=amo.STATUS_DISABLED))
-           .values_list('id', flat=True))
+    ids = (File.objects.exclude(
+        Q(version__addon__status=amo.STATUS_DISABLED) |
+        Q(version__addon__disabled_by_user=True) |
+        Q(status=amo.STATUS_DISABLED)).values_list('id', flat=True))
     for chunk in chunked(ids, 300):
         qs = File.objects.select_related('version').filter(id__in=chunk)
-        for f in qs:
+        for file_ in qs:
             # This tries to move the file to the public location. If it
             # didn't exist at the source, it will catch the exception, log it
             # and continue.
-            f.unhide_disabled_file()
+            file_.unhide_disabled_file()
 
 
 def deliver_hotness():

--- a/src/olympia/files/models.py
+++ b/src/olympia/files/models.py
@@ -275,7 +275,9 @@ class File(OnChangeMixin, ModelBase):
         return os.path.splitext(self.filename)[-1]
 
     def move_file(self, source, destination, log_message):
-        """Move a file from `source` to `destination`."""
+        """Move a file from `source` to `destination`.
+
+        IOError and UnicodeEncodeError are caught and logged."""
         log_message = force_text(log_message)
         try:
             if storage.exists(source):
@@ -295,6 +297,7 @@ class File(OnChangeMixin, ModelBase):
             src, dst, 'Moving disabled file: {source} => {destination}')
 
     def unhide_disabled_file(self):
+        """Move a disabled file to the public file path."""
         if not self.filename:
             return
         src, dst = self.guarded_file_path, self.file_path


### PR DESCRIPTION
Naive attempt at fixing #11464 

We don't care about what files are currently in storage in guarded-addons, so we shouldn't need to walk through the directory.