### PR TITLE
Restrict submissions per user email or IP

### DIFF
--- a/src/olympia/devhub/permissions.py
+++ b/src/olympia/devhub/permissions.py
@@ -1,0 +1,21 @@
+from rest_framework.permissions import BasePermission
+
+from olympia.devhub.utils import UploadRestrictionChecker
+
+
+class IsSubmissionAllowedFor(BasePermission):
+    """
+    Like is_submission_allowed_for_request, but in Permission form for use in
+    the API. If the client is disallowed, a message property specifiying the
+    reason is set on the permission instance to be returned to the client in
+    the 403 response.
+    """
+    def has_permission(self, request, view):
+        checker = UploadRestrictionChecker(request)
+        if not checker.is_submission_allowed():
+            self.message = checker.get_error_message()
+            return False
+        return True
+
+    def has_object_permission(self, request, view, obj):
+        return self.has_permission(request, view)

--- a/src/olympia/devhub/templates/devhub/agreement.html
+++ b/src/olympia/devhub/templates/devhub/agreement.html
@@ -1,11 +1,7 @@
 <form method="post">
+  {% if not agreement_form.has_error('__all__') %}
   <p>
-  {% trans %}
-    Before starting, please read and accept our Firefox Add-on Distribution
-    Agreement as well as our Review Policies and Rules. The Firefox
-    Add-on Distribution Agreement also links to our Privacy Notice which
-    explains how we handle your information.
-  {% endtrans %}
+    {{ agreement_message }}
   </p>
   <ul class="agreement-links">
     <li>{{ agreement_form.distribution_agreement }}<a href="{{ url('devhub.docs', 'policies/agreement') }}" target="_blank" rel="noopener noreferrer">{{ _('Firefox Add-on Distribution Agreement') }}</a> {{ agreement_form.distribution_agreement.errors }}</li>
@@ -29,4 +25,7 @@
       </button>
     {{ _('or <a href="{0}">Cancel</a>')|format_html(url('devhub.index')) }}
   </div>
+  {% else %}
+    {{ agreement_form.non_field_errors() }}
+  {% endif %}
 </form>

--- a/src/olympia/signing/views.py
+++ b/src/olympia/signing/views.py
@@ -21,6 +21,7 @@ from olympia.api.throttling import (
     ThrottleOnlyUnsafeMethodsMixin
 )
 from olympia.devhub.views import handle_upload as devhub_handle_upload
+from olympia.devhub.permissions import IsSubmissionAllowedFor
 from olympia.files.models import FileUpload
 from olympia.files.utils import parse_addon
 from olympia.signing.serializers import FileUploadSerializer
@@ -99,7 +100,7 @@ class SustainedIPAddonUploadThrottle(
 
 class VersionView(APIView):
     authentication_classes = [JWTKeyAuthentication]
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticated, IsSubmissionAllowedFor]
     throttle_classes = (
         BurstUserAddonUploadThrottle, SustainedUserAddonUploadThrottle,
         BurstIPAddonUploadThrottle, SustainedIPAddonUploadThrottle,

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -645,16 +645,26 @@ class IPNetworkUserRestriction(ModelBase):
         help_text=_(
             'Enter a valid IPv6 or IPv6 CIDR network range, eg. 127.0.0.1/28'))
 
+    error_message = _('Multiple add-ons violating our policies have been'
+                      ' submitted from your location. The IP address has been'
+                      ' blocked.')
+
     class Meta:
         db_table = 'users_user_network_restriction'
 
+    def __str__(self):
+        return str(self.network)
+
     @classmethod
     def allow_request(self, request):
+        """
+        Return whether the specified request should be allowed to submit
+        add-ons.
+        """
         try:
             remote_addr = ipaddress.ip_address(request.META.get('REMOTE_ADDR'))
         except ValueError:
             # If we don't have a valid ip address, let's deny
-            # TODO: Verify this is what we want…
             return False
 
         restrictions = IPNetworkUserRestriction.objects.all()
@@ -664,28 +674,48 @@ class IPNetworkUserRestriction(ModelBase):
                 return False
         return True
 
-    @classmethod
-    def get_error_message(self, request):
-        return _(
-            'Multiple add-ons violating our policies have been'
-            ' submitted from your location. The IP address has been'
-            ' blocked.')
-
 
 class EmailUserRestriction(ModelBase):
     id = PositiveAutoField(primary_key=True)
     email = models.EmailField(max_length=75, blank=True, null=True)
 
+    error_message = _('The email address you used for your developer account'
+                      ' is not allowed for add-on submission.')
+
     class Meta:
         db_table = 'users_user_email_restriction'
 
-    @classmethod
-    def allow_email(self, email):
-        return not EmailUserRestriction.objects.filter(email=email).exists()
+    def __str__(self):
+        return str(self.email)
 
-    def get_error_message(self, request):
-        return _('The email address you used for your developer account'
-                 ' is not allowed for add-on submission.')
+    @classmethod
+    def allow_request(self, request):
+        """
+        Return whether the specified request should be allowed to submit
+        add-ons.
+        """
+        if not request.user.is_authenticated:
+            return False
+        return not EmailUserRestriction.objects.filter(
+            email=request.user.email).exists()
+
+
+class DeveloperAgreementRestriction:
+    error_message = _('Before starting, please read and accept our Firefox'
+                      ' Add-on Distribution Agreement as well as our Review'
+                      ' Policies and Rules. The Firefox Add-on Distribution'
+                      ' Agreement also links to our Privacy Notice which'
+                      ' explains how we handle your information.')
+
+    @classmethod
+    def allow_request(cls, request):
+        """
+        Return whether the specified request should be allowed to submit
+        add-ons.
+        """
+        allowed = (request.user.is_authenticated and
+                   request.user.has_read_developer_agreement())
+        return allowed
 
 
 class UserHistory(ModelBase):


### PR DESCRIPTION
This forces restricted users (from their email or current IP) to go to the
developer agreement page when they want to use the submission flow. When
the agreement page is submitted, they'll be shown a message depending on
the reason behind the restriction.

A new API permission is also added that completely prevents the signing API
from allowing requests from such restricted users, with the corresponding
message returned as well.

Fixes #11441 
Fixes #11443