### PR TITLE
Allow Advanced Admins to add/delete user restrictions

### DIFF
--- a/src/olympia/constants/permissions.py
+++ b/src/olympia/constants/permissions.py
@@ -117,8 +117,12 @@ DJANGO_PERMISSIONS_MAPPING.update({
 
     'users.change_userprofile': USERS_EDIT,
     'users.delete_userprofile': ADMIN_ADVANCED,
+    'users.add_emailuserrestriction': ADMIN_ADVANCED,
+    'users.add_ipnetworkuserrestriction': ADMIN_ADVANCED,
     'users.change_emailuserrestriction': ADMIN_ADVANCED,
     'users.change_ipnetworkuserrestriction': ADMIN_ADVANCED,
+    'users.delete_emailuserrestriction': ADMIN_ADVANCED,
+    'users.delete_ipnetworkuserrestriction': ADMIN_ADVANCED,
 
     'ratings.change_rating': RATINGS_MODERATE,
     'ratings.delete_rating': ADMIN_ADVANCED,


### PR DESCRIPTION
Follow-up for https://github.com/mozilla/addons-server/issues/11442