### PR TITLE
Update addons-linter to 1.9.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": ">= 8.10"
   },
   "dependencies": {
-    "addons-linter": "1.9.6",
+    "addons-linter": "1.9.7",
     "clean-css": "4.1.9",
     "clean-css-cli": "4.3.0",
     "jqmodal": "1.4.2",


### PR DESCRIPTION
This fixes a regression in the recent reserved filename linting. Ideally
it should be cherry-picked.
