### PR TITLE
Update addons-linter to 1.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": ">= 8.10"
   },
   "dependencies": {
-    "addons-linter": "1.9.7",
+    "addons-linter": "1.10.0",
     "clean-css": "4.1.9",
     "clean-css-cli": "4.3.0",
     "jqmodal": "1.4.2",


### PR DESCRIPTION
* Firefox 68 schema import
* Various smaller dependency updates
* Regression fix regarding reserved filename linting

~~…npm seems to be slow on recognizing the new version today, still waiting…~~