### PR TITLE
Fix links used in abuse report admin tool to be absolute

### DIFF
--- a/src/olympia/abuse/tests/test_admin.py
+++ b/src/olympia/abuse/tests/test_admin.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 from datetime import date, datetime
 
+from django.conf import settings
 from django.contrib import admin
 from django.contrib.messages.storage import (
     default_storage as default_messages_storage)
-
 from django.test import RequestFactory
 from django.urls import reverse
 
@@ -518,6 +518,16 @@ class TestAbuse(TestCase):
             'Abuse Reports (2)')
         assert doc('.auto-approved-extra h3').eq(1).text() == (
             'Bad User Ratings (1)')
+        # 'addon-info-and-previews' and 'auto-approved-extra' are coming from a
+        # reviewer tools template and shouldn't contain any admin-specific
+        # links. It also means that all links in it should be external, in
+        # order to work when the admin is on a separate admin-only domain.
+        assert len(doc('.addon-info-and-previews a[href]'))
+        for link in doc('.addon-info-and-previews a[href]'):
+            assert link.attrib['href'].startswith(settings.EXTERNAL_SITE_URL)
+        assert len(doc('.auto-approved-extra a[href]'))
+        for link in doc('.auto-approved-extra a[href]'):
+            assert link.attrib['href'].startswith(settings.EXTERNAL_SITE_URL)
 
     def test_detail_guid_report(self):
         self.detail_url = reverse(

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -2106,7 +2106,7 @@ class TestPersonaModel(TestCase):
         with self.settings(LANGUAGE_CODE='fr',
                            LANGUAGE_URL_MAP={},
                            VAMO_URL='https://vamo',
-                           SITE_URL='https://omgsh.it'):
+                           EXTERNAL_SITE_URL='https://omgsh.it'):
             data = self.persona.theme_data
 
             id_ = str(self.persona.addon.id)
@@ -2145,7 +2145,7 @@ class TestPersonaModel(TestCase):
         with self.settings(LANGUAGE_CODE='fr',
                            LANGUAGE_URL_MAP={},
                            VAMO_URL='https://vamo',
-                           SITE_URL='https://omgsh.it'):
+                           EXTERNAL_SITE_URL='https://omgsh.it'):
             data = self.persona.theme_data
 
             id_ = str(self.persona.addon.id)

--- a/src/olympia/amo/templatetags/jinja_helpers.py
+++ b/src/olympia/amo/templatetags/jinja_helpers.py
@@ -191,11 +191,11 @@ def json(s):
 
 @library.filter
 def absolutify(url, site=None):
-    """Takes a URL and prepends the SITE_URL"""
-    if url.startswith('http'):
+    """Takes a URL and prepends the EXTERNAL_SITE_URL"""
+    if url.startswith(('http://', 'http://')):
         return url
     else:
-        return urljoin(site or settings.SITE_URL, url)
+        return urljoin(site or settings.EXTERNAL_SITE_URL, url)
 
 
 @library.filter

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -1644,7 +1644,7 @@ class TestAddonSubmitFinish(TestSubmitBase):
         super(TestAddonSubmitFinish, self).setUp()
         self.url = reverse('devhub.submit.finish', args=[self.addon.slug])
 
-    @mock.patch.object(settings, 'SITE_URL', 'http://b.ro')
+    @mock.patch.object(settings, 'EXTERNAL_SITE_URL', 'http://b.ro')
     @mock.patch('olympia.devhub.tasks.send_welcome_email.delay')
     def test_welcome_email_for_newbies(self, send_welcome_email_mock):
         self.client.get(self.url)
@@ -1658,7 +1658,7 @@ class TestAddonSubmitFinish(TestSubmitBase):
         send_welcome_email_mock.assert_called_with(
             self.addon.id, ['del@icio.us'], context)
 
-    @mock.patch.object(settings, 'SITE_URL', 'http://b.ro')
+    @mock.patch.object(settings, 'EXTERNAL_SITE_URL', 'http://b.ro')
     @mock.patch('olympia.devhub.tasks.send_welcome_email.delay')
     def test_welcome_email_first_listed_addon(self, send_welcome_email_mock):
         new_addon = addon_factory(
@@ -1675,7 +1675,7 @@ class TestAddonSubmitFinish(TestSubmitBase):
         send_welcome_email_mock.assert_called_with(
             self.addon.id, ['del@icio.us'], context)
 
-    @mock.patch.object(settings, 'SITE_URL', 'http://b.ro')
+    @mock.patch.object(settings, 'EXTERNAL_SITE_URL', 'http://b.ro')
     @mock.patch('olympia.devhub.tasks.send_welcome_email.delay')
     def test_welcome_email_if_previous_addon_is_incomplete(
             self, send_welcome_email_mock):

--- a/src/olympia/ratings/templates/ratings/impala/reviews_link.html
+++ b/src/olympia/ratings/templates/ratings/impala/reviews_link.html
@@ -7,7 +7,7 @@
   {% with num=addon.total_ratings %}
     {% if num %}
       {{ addon.average_rating|float|stars }}
-      <a href="{{ base }}">({{ num|numberfmt }})</a>
+      <a href="{{ base|absolutify }}">({{ num|numberfmt }})</a>
     {% else %}
       <b>{{ _('Not yet rated') }}</b>
     {% endif %}

--- a/src/olympia/ratings/templates/ratings/reviews_link.html
+++ b/src/olympia/ratings/templates/ratings/reviews_link.html
@@ -7,7 +7,7 @@
   {% with num=addon.total_ratings %}
     {% if num %}
     {{ addon.average_rating|float|stars }}
-    <a href="{{ base }}">
+    <a href="{{ base|absolutify }}">
       {% with count='<span itemprop="count">{0}</span>'|format_html(num|numberfmt) %}
         {# Using num=count so we don't change an L10n string. #}
         <strong>{{ ngettext('{num} review', '{num} reviews',

--- a/src/olympia/reviewers/templates/reviewers/addon_details_box.html
+++ b/src/olympia/reviewers/templates/reviewers/addon_details_box.html
@@ -115,7 +115,7 @@
           <tr class="meta-abuse">
             <th>{{ _('Abuse Reports') }}</th>
             <td>
-                <a href="{{ url('reviewers.abuse_reports', addon.slug) }}">
+                <a href="{{ url('reviewers.abuse_reports', addon.slug)|absolutify }}{{ '?channel=unlisted' if unlisted else '' }}">
                   <strong>{{ reports.paginator.count|numberfmt }}</strong>
                 </a>
             </td>
@@ -125,7 +125,7 @@
             <tr>
               <th>{{ _('Privacy Policy') }}</th>
               <td>
-                <a href="{{ privacy_url }}">
+                <a href="{{ url('reviewers.privacy', addon.slug)|absolutify }}{{ '?channel=unlisted' if unlisted else '' }}">
                   {{ _('View Privacy Policy') }}</a>
               </td>
             </tr>
@@ -140,7 +140,7 @@
             <tr>
               <th>{{ _('EULA') }}</th>
               <td>
-                <a href="{{ eula_url }}">
+                <a href="{{ url('reviewers.eula', addon.slug)|absolutify }}{{ '?channel=unlisted' if unlisted else '' }}">
                   {{ _('View End-User License Agreement') }}</a>
               </td>
             </tr>
@@ -160,12 +160,12 @@
   {% if was_auto_approved %}
   <div class="auto-approved-extra">
     {% if reports %}
-      <h3><a href="{{ url('reviewers.abuse_reports', addon.slug) }}">{{_('Abuse Reports ({num})')|format_html(num=reports.paginator.count|numberfmt) }}</a></h3>
+      <h3><a href="{{ url('reviewers.abuse_reports', addon.slug)|absolutify }}">{{_('Abuse Reports ({num})')|format_html(num=reports.paginator.count|numberfmt) }}</a></h3>
       {% include "reviewers/includes/abuse_reports_list.html" %}
     {% endif %}
 
     {% if user_ratings %}
-      <h3><a href="{{ url('addons.ratings.list', addon.slug) }}">{{_('Bad User Ratings ({num})')|format_html(num=user_ratings.paginator.count|numberfmt) }}</a></h3>
+      <h3><a href="{{ url('addons.ratings.list', addon.slug)|absolutify }}">{{_('Bad User Ratings ({num})')|format_html(num=user_ratings.paginator.count|numberfmt) }}</a></h3>
       {% include "reviewers/includes/user_ratings_list.html" %}
     {% endif %}
   </div>

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -3500,6 +3500,8 @@ class TestReview(ReviewBase):
         self.assertContains(response, privacy_url + '"')
 
         # The url should pass on the channel param so the backlink works
+        # FIXME: oh, that's why. I definitely need to fix that and document
+        # it.
         self.make_addon_unlisted(self.addon)
         self.login_as_admin()
         unlisted_url = reverse(

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -754,13 +754,6 @@ def determine_channel(channel_as_text):
 @login_required
 @addon_view_factory(qs=Addon.unfiltered.all)
 def review(request, addon, channel=None):
-    channel_param = ('?channel=%s' % channel) if channel else ''
-    eula_url = reverse(
-        'reviewers.eula',
-        args=(addon.slug if addon.slug else addon.pk,)) + (channel_param)
-    privacy_url = reverse(
-        'reviewers.privacy',
-        args=(addon.slug if addon.slug else addon.pk,)) + (channel_param)
     whiteboard_url = reverse(
         'reviewers.whiteboard',
         args=(channel or 'listed', addon.slug if addon.slug else addon.pk))
@@ -948,10 +941,9 @@ def review(request, addon, channel=None):
         actions_full=actions_full, addon=addon,
         api_token=request.COOKIES.get(API_TOKEN_COOKIE, None),
         approvals_info=approvals_info, auto_approval_info=auto_approval_info,
-        content_review_only=content_review_only,
-        count=count, eula_url=eula_url, flags=flags, form=form,
-        is_admin=is_admin, num_pages=num_pages, pager=pager, reports=reports,
-        privacy_url=privacy_url, show_diff=show_diff,
+        content_review_only=content_review_only, count=count, flags=flags,
+        form=form, is_admin=is_admin, num_pages=num_pages, pager=pager,
+        reports=reports, show_diff=show_diff,
         subscribed=ReviewerSubscription.objects.filter(
             user=request.user, addon=addon).exists(),
         unlisted=(channel == amo.RELEASE_CHANNEL_UNLISTED),

--- a/src/olympia/users/templatetags/jinja_helpers.py
+++ b/src/olympia/users/templatetags/jinja_helpers.py
@@ -42,5 +42,5 @@ def _user_link(user, max_text_length=None):
         name = user.name
 
     return u'<a href="%s" title="%s">%s</a>' % (
-        user.get_url_path(), jinja2.escape(user.name),
+        user.get_absolute_url(), jinja2.escape(user.name),
         jinja2.escape(force_text(name)))

--- a/src/olympia/users/tests/test_helpers.py
+++ b/src/olympia/users/tests/test_helpers.py
@@ -9,33 +9,35 @@ pytestmark = pytest.mark.django_db
 
 
 def test_user_link():
-    u = UserProfile(username='jconnor', display_name='John Connor', pk=1)
-    assert user_link(u) == (
-        '<a href="%s" title="%s">John Connor</a>' % (u.get_url_path(),
-                                                     u.name))
+    user = UserProfile(username='jconnor', display_name='John Connor', pk=1)
+    assert user_link(user) == (
+        '<a href="%s" title="%s">John Connor</a>' % (user.get_absolute_url(),
+                                                     user.name))
 
     # handle None gracefully
     assert user_link(None) == ''
 
 
 def test_user_link_xss():
-    u = UserProfile(username='jconnor',
-                    display_name='<script>alert(1)</script>', pk=1)
+    user = UserProfile(username='jconnor',
+                       display_name='<script>alert(1)</script>', pk=1)
     html = "&lt;script&gt;alert(1)&lt;/script&gt;"
-    assert user_link(u) == '<a href="%s" title="%s">%s</a>' % (
-        u.get_url_path(), html, html)
+    assert user_link(user) == '<a href="%s" title="%s">%s</a>' % (
+        user.get_absolute_url(), html, html)
 
-    u = UserProfile(username='jconnor',
-                    display_name="""xss"'><iframe onload=alert(3)>""", pk=1)
+    user = UserProfile(username='jconnor',
+                       display_name="""xss"'><iframe onload=alert(3)>""", pk=1)
     html = """xss&#34;&#39;&gt;&lt;iframe onload=alert(3)&gt;"""
-    assert user_link(u) == '<a href="%s" title="%s">%s</a>' % (
-        u.get_url_path(), html, html)
+    assert user_link(user) == '<a href="%s" title="%s">%s</a>' % (
+        user.get_absolute_url(), html, html)
 
 
 def test_users_list():
-    u1 = UserProfile(username='jconnor', display_name='John Connor', pk=1)
-    u2 = UserProfile(username='sconnor', display_name='Sarah Connor', pk=2)
-    assert users_list([u1, u2]) == ', '.join((user_link(u1), user_link(u2)))
+    user1 = UserProfile(username='jconnor', display_name='John Connor', pk=1)
+    user2 = UserProfile(username='sconnor', display_name='Sarah Connor', pk=2)
+    assert users_list([user1, user2]) == (
+        ', '.join((user_link(user1), user_link(user2)))
+    )
 
     # handle None gracefully
     assert user_link(None) == ''
@@ -44,31 +46,36 @@ def test_users_list():
 def test_short_users_list():
     """Test the option to shortened the users list to a certain size."""
     # short list with 'others'
-    u1 = UserProfile(username='oscar', display_name='Oscar the Grouch', pk=1)
-    u2 = UserProfile(username='grover', display_name='Grover', pk=2)
-    u3 = UserProfile(username='cookies!', display_name='Cookie Monster', pk=3)
-    shortlist = users_list([u1, u2, u3], size=2)
-    assert shortlist == ', '.join((user_link(u1), user_link(u2))) + ', others'
+    user1 = UserProfile(
+        username='oscar', display_name='Oscar the Grouch', pk=1)
+    user2 = UserProfile(
+        username='grover', display_name='Grover', pk=2)
+    user3 = UserProfile(
+        username='cookies!', display_name='Cookie Monster', pk=3)
+    shortlist = users_list([user1, user2, user3], size=2)
+    assert shortlist == (
+        ', '.join((user_link(user1), user_link(user2))) + ', others'
+    )
 
 
 def test_users_list_truncate_display_name():
-    u = UserProfile(username='oscar',
-                    display_name='Some Very Long Display Name', pk=1)
-    truncated_list = users_list([u], None, 10)
+    user = UserProfile(username='oscar',
+                       display_name='Some Very Long Display Name', pk=1)
+    truncated_list = users_list([user], None, 10)
     assert truncated_list == (
-        u'<a href="%s" title="%s">Some Very...</a>' % (u.get_url_path(),
-                                                       u.name))
+        '<a href="%s" title="%s">Some Very...</a>' % (user.get_absolute_url(),
+                                                      user.name))
 
 
 def test_user_link_unicode():
     """make sure helper won't choke on unicode input"""
-    u = UserProfile.objects.create(
-        username=u'jmüller', display_name=u'Jürgen Müller')
-    assert user_link(u) == (
-        u'<a href="%s" title="%s">Jürgen Müller</a>' % (
-            u.get_url_path(), u.name))
+    user = UserProfile.objects.create(
+        username='jmüller', display_name='Jürgen Müller')
+    assert user_link(user) == (
+        '<a href="%s" title="%s">Jürgen Müller</a>' % (
+            user.get_absolute_url(), user.name))
 
-    u = UserProfile.objects.create(display_name=u'\xe5\xaf\x92\xe6\x98\x9f')
-    assert user_link(u) == (
-        u'<a href="%s" title="%s">%s</a>' % (u.get_url_path(), u.name,
-                                             u.display_name))
+    user = UserProfile.objects.create(display_name='\xe5\xaf\x92\xe6\x98\x9f')
+    assert user_link(user) == (
+        '<a href="%s" title="%s">%s</a>' % (user.get_absolute_url(), user.name,
+                                            user.display_name))


### PR DESCRIPTION
The admin lives on an instance that doesn't support the rest of the app so any links pointing to outside the admin need to be absolute.

Fixes https://github.com/mozilla/addons-server/issues/11568
Fixes https://github.com/mozilla/addons-server/issues/11567
Fixes https://github.com/mozilla/addons-server/issues/11566