### PR TITLE
Sign add-ons with recommendation signer based on DiscoveryItem.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,17 +69,17 @@ before_script:
 
 script:
   - |
-    if [[ $TRAVIS_EVENT_TYPE != "cron" ]]; then
-      if [[ $TOXENV == "amo-lib-locales-and-signing" ]]; then
+    if [ $TRAVIS_EVENT_TYPE != "cron" ]; then
+      if [ $TOXENV == "amo-lib-locales-and-signing" ] || [ $TOXENV == "reviewers-and-zadmin" ] ; then
          docker run --name autograph -d -p 5500:5500 -v $(pwd)/scripts/:/scripts/ mozilla/autograph:3.3.2 /go/bin/autograph -c /scripts/autograph_travis_test_config.yaml
       fi
       RUNNING_IN_CI=True tox
     fi
   - |
-    if [[ $TRAVIS_EVENT_TYPE == "cron" ]]; then
+    if [ $TRAVIS_EVENT_TYPE == "cron" ]; then
       # Only run the extraction on "main" environment to avoid creating
       # 8 pull requests for each tox environment.
-      if [[ $TOXENV == "main" ]]; then
+      if [ $TOXENV == "main" ]; then
           bash scripts/travis-extract-l10n.sh
       fi
     fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,9 @@ services:
 
   autograph:
     image: mozilla/autograph:3.3.2
+    command: /go/bin/autograph -c /code/scripts/autograph_travis_test_config.yaml
+    volumes:
+      - .:/code
 
   addons-frontend:
     <<: *env

--- a/scripts/autograph_travis_test_config.yaml
+++ b/scripts/autograph_travis_test_config.yaml
@@ -245,4 +245,7 @@ authorizations:
       key: fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu
       signers:
           - webextensions-rsa
+    - id: bob
+      key: 9vh6bhlc10y63ow2k4zke7k0c3l9hpr8mo96p92jmbfqngs9e7d
+      signers:
           - webextensions-rsa-with-recommendation

--- a/src/olympia/lib/crypto/tests/test_signing.py
+++ b/src/olympia/lib/crypto/tests/test_signing.py
@@ -368,15 +368,14 @@ class TestSigning(TestCase):
         # 2 actual commits, including the repo initialization
         assert output.count('Mozilla Add-ons Robot') == 3
 
-    def test_call_signing_recommended_addon(self):
-        # Mark the add-on as recommended
+    def test_call_signing_recommendable(self):
+        # This is the usual process for recommended add-ons, they're
+        # in "pending recommendation" and only *after* we approve and sign
+        # them they will become "recommended". Once the `recommendable`
+        # flag is turned off we won't sign further versions as recommended.
         DiscoveryItem.objects.create(
             addon=self.file_.version.addon,
             recommendable=True)
-
-        # And also set the required flags on the version as done during
-        # approval.
-        self.file_.version.update(recommendation_approved=True)
 
         assert signing.sign_file(self.file_)
 
@@ -395,14 +394,10 @@ class TestSigning(TestCase):
         assert recommendation_data['addon_id'] == 'xxxxx'
         assert recommendation_data['states'] == ['recommended']
 
-    def test_call_signing_pending_recommendation(self):
-        # Mark the add-on as recommended
+    def test_call_signing_not_recommendable(self):
         DiscoveryItem.objects.create(
             addon=self.file_.version.addon,
-            recommendable=True)
-
-        # But don't set the necessary flag on the version yet
-        self.file_.version.update(recommendation_approved=False)
+            recommendable=False)
 
         assert signing.sign_file(self.file_)
 

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1567,10 +1567,19 @@ AUTOGRAPH_CONFIG = {
     'signer': env(
         'AUTOGRAPH_SIGNER_ID',
         default='webextensions-rsa'),
+
     # This signer is only used for add-ons that are recommended.
-    'recommendation-signer': env(
+    # The signer uses it's own HAWK auth credentials
+    'recommendation_signer': env(
         'AUTOGRAPH_RECOMMENDATION_SIGNER_ID',
-        default='webextensions-rsa-with-recommendation')
+        default='webextensions-rsa-with-recommendation'),
+    'recommendation_signer_user_id': env(
+        'AUTOGRAPH_RECOMMENDATION_SIGNER_HAWK_USER_ID',
+        default='alice'),
+    'recommendation_signer_key': env(
+        'AUTOGRAPH_RECOMMENDATION_SIGNER_HAWK_KEY',
+        default='fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu'),
+
 }
 
 # Enable addon signing. Autograph is configured to something reasonable

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1553,7 +1553,7 @@ SIGNING_SERVER_MONITORING_TIMEOUT = 10
 AUTOGRAPH_CONFIG = {
     'server_url': env(
         'AUTOGRAPH_SERVER_URL',
-        default='http://autograph:8000'),
+        default='http://autograph:5500'),
     'user_id': env(
         'AUTOGRAPH_HAWK_USER_ID',
         default='alice'),
@@ -1575,10 +1575,10 @@ AUTOGRAPH_CONFIG = {
         default='webextensions-rsa-with-recommendation'),
     'recommendation_signer_user_id': env(
         'AUTOGRAPH_RECOMMENDATION_SIGNER_HAWK_USER_ID',
-        default='alice'),
+        default='bob'),
     'recommendation_signer_key': env(
         'AUTOGRAPH_RECOMMENDATION_SIGNER_HAWK_KEY',
-        default='fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu'),
+        default='9vh6bhlc10y63ow2k4zke7k0c3l9hpr8mo96p92jmbfqngs9e7d'),
 
 }
 


### PR DESCRIPTION
This also prepares for the possibility that we may have to use different
credentials for the recommendations signer. In case we don't, ops only
has to set the creds twice which seems fair.

Fixes #11062
