### PR TITLE
Make sure we use primary db for indexing tasks

### DIFF
--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -160,6 +160,7 @@ def delete_preview_files(id, **kw):
 
 
 @task(acks_late=True)
+@use_primary_db
 def index_addons(ids, **kw):
     log.info('Indexing addons %s-%s. [%s]' % (ids[0], ids[-1], len(ids)))
     transforms = (attach_tags, attach_translations)
@@ -168,6 +169,7 @@ def index_addons(ids, **kw):
 
 
 @task
+@use_primary_db
 def unindex_addons(ids, **kw):
     for addon in ids:
         log.info('Removing addon [%s] from search index.' % addon)


### PR DESCRIPTION
Without that change, we can theoretically get a race condition where the replica hasn't been updated yet when we index because the task is being processed too fast. It's unlikely but it does seem to happen sometimes on stage.