### PR TITLE
Add flattr.com to VALID_CONTRIBUTION_DOMAINS

### DIFF
--- a/src/olympia/constants/base.py
+++ b/src/olympia/constants/base.py
@@ -216,8 +216,8 @@ MAX_TAGS = 20
 MIN_TAG_LENGTH = 2
 MAX_CATEGORIES = 2
 VALID_CONTRIBUTION_DOMAINS = (
-    'flattr.com',
     'donate.mozilla.org',
+    'flattr.com',
     'liberapay.com',
     'micropayment.de',
     'opencollective.com',

--- a/src/olympia/constants/base.py
+++ b/src/olympia/constants/base.py
@@ -216,6 +216,7 @@ MAX_TAGS = 20
 MIN_TAG_LENGTH = 2
 MAX_CATEGORIES = 2
 VALID_CONTRIBUTION_DOMAINS = (
+    'flattr.com',
     'donate.mozilla.org',
     'liberapay.com',
     'micropayment.de',


### PR DESCRIPTION
Please allow extension authors to solicit contributions through Flattr.

Here are some examples of Flattr contribution links:

* https://flattr.com/domain/fsfe.org
* https://flattr.com/github/da2x
* https://flattr.com/domain/noscript.net

I’ve not done any testing of this patch locally or otherwise as it’s only adding one domain to an array. There doesn’t seem to be any existing tests covering VALID_CONTRIBUTION_DOMAINS so I’m not updating any tests either.

Resolves issue #11680.