### PR TITLE
Compare API: Render unmodified files.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,6 @@
 Addons-Server
 =============
 
-foo
 Welcome to the Addons Server repository!  Please feel free to visit the web page of the current project hosted on `addons.mozilla.org`_. If you want to install it follow our guide located in `install docs`_.  We'd love your help!  You can come talk to us on `irc.mozilla.org #amo`_ if you have any questions.
 
 Please report bugs here: https://github.com/mozilla/addons/issues or https://github.com/mozilla/addons-server/issues

--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,7 @@
 Addons-Server
 =============
 
+foo
 Welcome to the Addons Server repository!  Please feel free to visit the web page of the current project hosted on `addons.mozilla.org`_. If you want to install it follow our guide located in `install docs`_.  We'd love your help!  You can come talk to us on `irc.mozilla.org #amo`_ if you have any questions.
 
 Please report bugs here: https://github.com/mozilla/addons/issues or https://github.com/mozilla/addons-server/issues

--- a/docs/topics/api/reviewers.rst
+++ b/docs/topics/api/reviewers.rst
@@ -159,6 +159,10 @@ This endpoint allows you to compare two Add-on versions with each other.
 
 .. http:get:: /api/v4/reviewers/addon/(int:addon_id)/versions/(int:version_id)/compare_to/(int:version_id)/
 
+    .. note::
+
+        Contrary to what ``git diff`` does, this API renders a hunk full of unmodified lines for unmodified files.
+
     Inherits most properties from :ref:`browse detail <reviewers-versions-browse-detail>`, except that most of the `file.entries[]` properties
     and `file.download_url` can be `null` in case of a deleted file.
 

--- a/src/olympia/lib/git.py
+++ b/src/olympia/lib/git.py
@@ -417,7 +417,7 @@ class AddonGitRepository(object):
                     tree_entry=tree_entry,
                     path=tree_entry.name)
 
-    def get_raw_diff(self, commit, parent=None):
+    def get_raw_diff(self, commit, parent=None, include_unmodifed=False):
         """Return the raw diff object.
 
         This is cached as we'll be calling it multiple times, e.g
@@ -425,6 +425,11 @@ class AddonGitRepository(object):
         status information (added, removed etc) in a later step.
         """
         diff_cache = getattr(self, '_diff_cache', {})
+
+        flags = pygit2.GIT_DIFF_NORMAL
+
+        if include_unmodifed:
+            flags |= pygit2.GIT_DIFF_INCLUDE_UNMODIFIED
 
         try:
             return diff_cache[(commit, parent)]
@@ -434,6 +439,7 @@ class AddonGitRepository(object):
                     # We always show the whole file by default
                     context_lines=sys.maxsize,
                     interhunk_lines=0,
+                    flags=flags,
                     swap=True)
             else:
                 retval = self.git_repository.diff(
@@ -441,6 +447,7 @@ class AddonGitRepository(object):
                     self.get_root_tree(commit),
                     # We always show the whole file by default
                     context_lines=sys.maxsize,
+                    flags=flags,
                     interhunk_lines=0)
 
             diff_cache[(commit, parent)] = retval
@@ -454,13 +461,11 @@ class AddonGitRepository(object):
         If `parent` is not given we assume it's the first commit and handle
         it accordingly.
 
-        We are resolving renames and copies according to a 50% similarity
-        threshold.
-
         :param pathspec: If a list of files is given we only retrieve a list
                          for them.
         """
-        diff = self.get_raw_diff(commit, parent=parent)
+        diff = self.get_raw_diff(
+            commit, parent=parent, include_unmodifed=pathspec is not None)
 
         changes = []
 
@@ -472,12 +477,14 @@ class AddonGitRepository(object):
                 continue
 
             if parent is None:
-                changes.append(self._render_patch(patch, commit, commit))
+                changes.append(self._render_patch(
+                    patch, commit, commit, pathspec))
             else:
-                changes.append(self._render_patch(patch, commit, parent))
+                changes.append(self._render_patch(
+                    patch, commit, parent, pathspec))
         return changes
 
-    def _render_patch(self, patch, commit, parent):
+    def _render_patch(self, patch, commit, parent, pathspec=None):
         """
         This will be moved to a proper drf serializer in the future
         but until the format isn't set we'll keep it like that to simplify
@@ -524,6 +531,47 @@ class AddonGitRepository(object):
                 'new_lines': hunk.new_lines,
                 'changes': changes
             })
+
+        # We are exposing unchanged files fully to the frontend client
+        # so that it can show them for an better review experience.
+        # We are using the "include unmodified"-flag for git but that
+        # doesn't render any hunks and there's no way to enforce it.
+        # Unfortunately that means we have to simulate line changes and
+        # hunk data for unmodified files.
+        # Unchanged files are *only* exposed in case of explicitly requesting
+        # a diff view for an file. That way we increase performance for
+        # reguar unittests and full-tree diffs.
+        generate_unmodified_fake_diff = (
+            not patch.delta.is_binary
+            and pathspec is not None
+            and patch.delta.status == pygit2.GIT_DELTA_UNMODIFIED
+        )
+        if generate_unmodified_fake_diff:
+            tree = self.get_root_tree(commit)
+
+            blob_or_tree = tree[patch.delta.new_file.path]
+
+            actual_blob = self.git_repository[blob_or_tree.oid]
+
+            changes = [
+                {
+                    'content': line,
+                    'type': GIT_DIFF_LINE_CONTEXT,
+                    'old_line_number': lineno,
+                    'new_line_number': lineno,
+                }
+                for lineno, line in enumerate(actual_blob.data.split(b'\n'))
+            ]
+
+            hunks.append({
+                'header': '@@ -0 +0 @@',
+                'old_start': 0,
+                'new_start': 0,
+                'old_lines': changes[-1]['old_line_number'],
+                'new_lines': changes[-1]['new_line_number'],
+                'changes': changes
+            })
+
 
         entry = {
             'path': patch.delta.new_file.path,

--- a/src/olympia/lib/git.py
+++ b/src/olympia/lib/git.py
@@ -543,7 +543,7 @@ class AddonGitRepository(object):
         # reguar unittests and full-tree diffs.
         generate_unmodified_fake_diff = (
             not patch.delta.is_binary and
-            pathspec is not None
+            pathspec is not None and
             patch.delta.status == pygit2.GIT_DELTA_UNMODIFIED
         )
         if generate_unmodified_fake_diff:

--- a/src/olympia/lib/git.py
+++ b/src/olympia/lib/git.py
@@ -542,9 +542,9 @@ class AddonGitRepository(object):
         # a diff view for an file. That way we increase performance for
         # reguar unittests and full-tree diffs.
         generate_unmodified_fake_diff = (
-            not patch.delta.is_binary
-            and pathspec is not None
-            and patch.delta.status == pygit2.GIT_DELTA_UNMODIFIED
+            not patch.delta.is_binary and
+            pathspec is not None
+            patch.delta.status == pygit2.GIT_DELTA_UNMODIFIED
         )
         if generate_unmodified_fake_diff:
             tree = self.get_root_tree(commit)
@@ -571,7 +571,6 @@ class AddonGitRepository(object):
                 'new_lines': changes[-1]['new_line_number'],
                 'changes': changes
             })
-
 
         entry = {
             'path': patch.delta.new_file.path,

--- a/src/olympia/lib/tests/test_git.py
+++ b/src/olympia/lib/tests/test_git.py
@@ -906,7 +906,6 @@ def test_get_diff_delete_file():
         x['type'] == 'delete' for x in changes[0]['hunks'][0]['changes'])
 
 
-
 @pytest.mark.django_db
 def test_get_diff_unmodified_file_by_default_not_rendered():
     addon = addon_factory(file_kw={'filename': 'webextension_no_id.xpi'})


### PR DESCRIPTION
Currently we followed how ``git diff`` works and didn't render any
changes for unmodified files.

To help with some frontend issues (e.g showing linter messages in compare view for unmodified files, and others) we now need to include unmodified files.
That alone would not render their contents, so we're including a faked
hunk that shows all lines as unmodified.

Fixes #11639