### PR TITLE
Always display abuse reports / addon ratings in reviewer tools

### DIFF
--- a/src/olympia/abuse/admin.py
+++ b/src/olympia/abuse/admin.py
@@ -362,10 +362,6 @@ class AbuseReportAdmin(CommaSearchInAdminMixin, admin.ModelAdmin):
                 (Rating.without_replies
                     .filter(addon=addon, rating__lte=3, body__isnull=False)
                     .order_by('-created')), 5).page(1),
-            'was_auto_approved': (
-                addon.current_version and
-                addon.current_version.was_auto_approved
-            ),
         }
         return template.render(context)
     addon_card.short_description = ''

--- a/src/olympia/abuse/tests/test_admin.py
+++ b/src/olympia/abuse/tests/test_admin.py
@@ -513,20 +513,20 @@ class TestAbuse(TestCase):
         assert doc('.addon-info-and-previews .meta-rating td').text() == (
             'Rated 2 out of 5 stars 1 review')
         assert doc('.addon-info-and-previews .last-approval-date td').text()
-        assert doc('.auto-approved-extra')
-        assert doc('.auto-approved-extra h3').eq(0).text() == (
+        assert doc('.reports-and-ratings')
+        assert doc('.reports-and-ratings h3').eq(0).text() == (
             'Abuse Reports (2)')
-        assert doc('.auto-approved-extra h3').eq(1).text() == (
+        assert doc('.reports-and-ratings h3').eq(1).text() == (
             'Bad User Ratings (1)')
-        # 'addon-info-and-previews' and 'auto-approved-extra' are coming from a
+        # 'addon-info-and-previews' and 'reports-and-ratings' are coming from a
         # reviewer tools template and shouldn't contain any admin-specific
         # links. It also means that all links in it should be external, in
         # order to work when the admin is on a separate admin-only domain.
         assert len(doc('.addon-info-and-previews a[href]'))
         for link in doc('.addon-info-and-previews a[href]'):
             assert link.attrib['href'].startswith(settings.EXTERNAL_SITE_URL)
-        assert len(doc('.auto-approved-extra a[href]'))
-        for link in doc('.auto-approved-extra a[href]'):
+        assert len(doc('.reports-and-ratings a[href]'))
+        for link in doc('.reports-and-ratings a[href]'):
             assert link.attrib['href'].startswith(settings.EXTERNAL_SITE_URL)
 
     def test_detail_guid_report(self):

--- a/src/olympia/reviewers/templates/reviewers/addon_details_box.html
+++ b/src/olympia/reviewers/templates/reviewers/addon_details_box.html
@@ -157,8 +157,7 @@
     </div>{# /addon-info #}
   </div>{# /addon-info-and-previews #}
 
-  {% if was_auto_approved %}
-  <div class="auto-approved-extra">
+  <div class="reports-and-ratings">
     {% if reports %}
       <h3><a href="{{ url('reviewers.abuse_reports', addon.slug)|absolutify }}">{{_('Abuse Reports ({num})')|format_html(num=reports.paginator.count|numberfmt) }}</a></h3>
       {% include "reviewers/includes/abuse_reports_list.html" %}
@@ -169,7 +168,6 @@
       {% include "reviewers/includes/user_ratings_list.html" %}
     {% endif %}
   </div>
-  {% endif %}
 
   {% if addon.has_per_version_previews %}
     <div id="addon-theme-previews-wrapper">

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -4283,19 +4283,6 @@ class TestReview(ReviewBase):
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
-        assert not doc('.abuse_reports')
-
-        self.grant_permission(self.reviewer, 'Addons:PostReview')
-        response = self.client.get(self.url)
-        assert response.status_code == 200
-        doc = pq(response.content)
-        assert not doc('.abuse_reports')
-
-        AutoApprovalSummary.objects.create(
-            verdict=amo.AUTO_APPROVED, version=self.version)
-        response = self.client.get(self.url)
-        assert response.status_code == 200
-        doc = pq(response.content)
         assert doc('.abuse_reports')
         expected = [
             'Target',
@@ -4322,9 +4309,6 @@ class TestReview(ReviewBase):
             user=self.addon.listed_authors[0], message=u'Foo, Bâr!',
             country_code='DE')
         created_at = format_datetime(report.created)
-        AutoApprovalSummary.objects.create(
-            verdict=amo.AUTO_APPROVED, version=self.version)
-        self.grant_permission(self.reviewer, 'Addons:PostReview')
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
@@ -4362,19 +4346,6 @@ class TestReview(ReviewBase):
         Rating.objects.create(  # Review with high rating,, ignored.
             body=u'Qui platônem temporibus in', rating=5, addon=self.addon,
             user=user_factory())
-        response = self.client.get(self.url)
-        assert response.status_code == 200
-        doc = pq(response.content)
-        assert not doc('.user_ratings')
-
-        self.grant_permission(self.reviewer, 'Addons:PostReview')
-        response = self.client.get(self.url)
-        assert response.status_code == 200
-        doc = pq(response.content)
-        assert not doc('.user_ratings')
-
-        AutoApprovalSummary.objects.create(
-            verdict=amo.AUTO_APPROVED, version=self.version)
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)


### PR DESCRIPTION
Even for non-auto-approved add-ons, even for purely unlisted ones.

Fixes #11640