### PR TITLE
Deduplicate abuse report admin search results

### DIFF
--- a/src/olympia/abuse/tests/test_admin.py
+++ b/src/olympia/abuse/tests/test_admin.py
@@ -27,6 +27,8 @@ class TestAbuse(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.addon1 = addon_factory(guid='@guid1', name='Neo')
+        cls.addon1.name.__class__.objects.create(
+            id=cls.addon1.name_id, locale='fr', localized_string='Elu')
         cls.addon2 = addon_factory(guid='@guid2', name='Two')
         cls.addon3 = addon_factory(guid='@guid3', name='Three')
         cls.user = user_factory()


### PR DESCRIPTION
We're querying over `addon__name__localized_string` so we need a `DISTINCT()` because of the way the `JOIN`s are set up. Django has code for this, but doesn't follow through deep relations and only handles m2m.

Fixes #11558