### PR TITLE
Return 'normal' instead of ' ' for unmodified lines in fake hunks.

### DIFF
--- a/src/olympia/lib/git.py
+++ b/src/olympia/lib/git.py
@@ -631,7 +631,7 @@ class AddonGitRepository(object):
                 changes = [
                     {
                         'content': line,
-                        'type': GIT_DIFF_LINE_CONTEXT,
+                        'type': GIT_DIFF_LINE_MAPPING[GIT_DIFF_LINE_CONTEXT],
                         'old_line_number': lineno,
                         'new_line_number': lineno,
                     }

--- a/src/olympia/lib/tests/test_git.py
+++ b/src/olympia/lib/tests/test_git.py
@@ -952,7 +952,7 @@ def test_get_diff_unmodified_file():
     assert changes[0]['mode'] == ' '
     assert changes[0]['hunks'][0]['header'] == '@@ -0 +0 @@'
     assert all(
-        x['type'] == ' ' for x in changes[0]['hunks'][0]['changes'])
+        x['type'] == 'normal' for x in changes[0]['hunks'][0]['changes'])
 
     # Make sure line numbers start at 1
     # https://github.com/mozilla/addons-server/issues/11739
@@ -982,7 +982,7 @@ def test_get_diff_unmodified_file_binary_file():
     assert changes[0]['mode'] == ' '
     assert changes[0]['hunks'][0]['header'] == '@@ -0 +0 @@'
     assert all(
-        x['type'] == ' ' for x in changes[0]['hunks'][0]['changes'])
+        x['type'] == 'normal' for x in changes[0]['hunks'][0]['changes'])
 
     # Now Make sure we don't render a fake hunk for binary files such as images
     changes = repo.get_diff(


### PR DESCRIPTION
Fixes #11783
