### PR TITLE
Show approve content action even when add-on was not auto-approved

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -330,7 +330,6 @@ class AddonManager(ManagerBase):
                 '_current_version__files'
             )
             .order_by(
-                'addonapprovalscounter__last_content_review',
                 'created',
             )
         )

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -3990,7 +3990,7 @@ class TestReview(ReviewBase):
         self.grant_permission(self.reviewer, 'Addons:ContentReview')
         self.url = reverse(
             'reviewers.review', args=['content', self.addon.slug])
-        for action in ['confirm_auto_approved', 'reject_multiple_versions']:
+        for action in ['approve_content', 'reject_multiple_versions']:
             response = self.client.post(self.url, self.get_dict(action=action))
             assert response.status_code == 200  # Form error.
             # The add-on status must not change as non-admin reviewers are not
@@ -4034,7 +4034,7 @@ class TestReview(ReviewBase):
         assert ActivityLog.objects.filter(
             action=amo.LOG.CONFIRM_AUTO_APPROVED.id).count() == 0
 
-    def test_confirm_auto_approval_content_review(self):
+    def test_approve_content_content_review(self):
         GroupUser.objects.filter(user=self.reviewer).all().delete()
         self.url = reverse(
             'reviewers.review', args=['content', self.addon.slug])
@@ -4042,7 +4042,7 @@ class TestReview(ReviewBase):
             version=self.addon.current_version, verdict=amo.AUTO_APPROVED)
         self.grant_permission(self.reviewer, 'Addons:ContentReview')
         response = self.client.post(self.url, {
-            'action': 'confirm_auto_approved',
+            'action': 'approve_content',
             'comments': 'ignore me this action does not support comments'
         })
         assert response.status_code == 302
@@ -4068,7 +4068,7 @@ class TestReview(ReviewBase):
             addon=self.addon, needs_admin_content_review=True)
         self.grant_permission(self.reviewer, 'Addons:ContentReview')
         response = self.client.post(self.url, {
-            'action': 'confirm_auto_approved',
+            'action': 'approve_content',
             'comments': 'ignore me this action does not support comments'
         })
         assert response.status_code == 200  # Form error
@@ -4086,7 +4086,7 @@ class TestReview(ReviewBase):
             addon=self.addon, needs_admin_code_review=True)
         self.grant_permission(self.reviewer, 'Addons:ContentReview')
         response = self.client.post(self.url, {
-            'action': 'confirm_auto_approved',
+            'action': 'approve_content',
             'comments': 'ignore me this action does not support comments'
         })
         assert response.status_code == 302
@@ -4112,7 +4112,7 @@ class TestReview(ReviewBase):
             addon=self.addon, needs_admin_code_review=True)
         self.grant_permission(self.reviewer, 'Addons:ContentReview')
         response = self.client.post(self.url, {
-            'action': 'confirm_auto_approved',
+            'action': 'approve_content',
             'comments': 'ignore me this action does not support comments'
         })
         assert response.status_code == 200  # Form error
@@ -4125,7 +4125,7 @@ class TestReview(ReviewBase):
         AddonReviewerFlags.objects.create(
             addon=self.addon, needs_admin_content_review=True)
         self.grant_permission(self.reviewer, 'Addons:PostReview')
-        for action in ['confirm_auto_approved', 'public', 'reject',
+        for action in ['approve_content', 'public', 'reject',
                        'reject_multiple_versions']:
             response = self.client.post(self.url, self.get_dict(action=action))
             assert response.status_code == 200  # Form error.
@@ -4200,7 +4200,7 @@ class TestReview(ReviewBase):
         self.grant_permission(self.reviewer, 'Addons:ContentReview')
         self.grant_permission(self.reviewer, 'Reviews:Admin')
         response = self.client.post(self.url, {
-            'action': 'confirm_auto_approved',
+            'action': 'approve_content',
             'comments': 'ignore me this action does not support comments'
         })
         assert response.status_code == 302
@@ -4591,7 +4591,7 @@ class TestReview(ReviewBase):
         response = self.client.get(self.url)
         assert response.status_code == 200
         expected_actions = [
-            'confirm_auto_approved', 'reject_multiple_versions', 'reply',
+            'approve_content', 'reject_multiple_versions', 'reply',
             'super', 'comment']
         assert (
             [action[0] for action in response.context['actions']] ==

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -242,16 +242,17 @@ class AutoApprovedTable(ModernAddonQueueTable):
 
 
 class ContentReviewTable(AutoApprovedTable):
-    last_content_review = tables.DateTimeColumn(
-        verbose_name=_(u'Last Content Review'),
-        accessor='addonapprovalscounter.last_content_review')
+    last_updated = tables.DateTimeColumn(verbose_name=_(u'Last Updated'))
 
     class Meta(ReviewerQueueTable.Meta):
-        fields = ('addon_name', 'flags', 'last_content_review')
+        fields = ('addon_name', 'flags', 'last_updated')
         # Exclude base fields ReviewerQueueTable has that we don't want.
         exclude = ('addon_type_id', 'last_human_review', 'waiting_time_min',
                    'weight')
         orderable = False
+
+    def render_last_updated(self, value):
+        return naturaltime(value) if value else ''
 
     def _get_addon_name_url(self, record):
         return reverse('reviewers.review', args=['content', record.slug])

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -341,11 +341,8 @@ class ReviewHelper(object):
         was_auto_approved_and_user_can_post_review = (
             self.addon.current_version and
             self.addon.current_version.was_auto_approved and
-            is_post_reviewer)
-        was_auto_approved_and_user_can_content_review = (
-            self.addon.current_version and
-            self.addon.current_version.was_auto_approved and
-            is_content_reviewer and self.content_review_only)
+            is_post_reviewer and
+            not self.content_review_only)
         is_unlisted_and_user_can_review_unlisted = (
             self.version and
             self.version.channel == amo.RELEASE_CHANNEL_UNLISTED and
@@ -355,9 +352,9 @@ class ReviewHelper(object):
             self.addon.status == amo.STATUS_APPROVED and
             self.version.channel == amo.RELEASE_CHANNEL_LISTED and
             is_post_reviewer)
-        is_public_and_listed_and_user_can_content_review = (
+        is_valid_and_listed_and_user_can_content_review = (
             self.version and
-            self.addon.status == amo.STATUS_APPROVED and
+            (self.addon.is_public() or self.addon.is_unreviewed()) and
             self.version.channel == amo.RELEASE_CHANNEL_LISTED and
             is_content_reviewer and self.content_review_only)
 
@@ -384,6 +381,19 @@ class ReviewHelper(object):
             'minimal': False,
             'available': actions['public']['available'],
         }
+        actions['approve_content'] = {
+            'method': self.handler.approve_content,
+            'label': _('Approve Content'),
+            'details': _('This records your approbation of the '
+                         'content of the latest public version, '
+                         'without notifying the developer.'),
+            'minimal': False,
+            'comments': False,
+            'available': (
+                reviewable_because_not_reserved_for_admins_or_user_is_admin and
+                is_valid_and_listed_and_user_can_content_review
+            ),
+        }
         actions['confirm_auto_approved'] = {
             'method': self.handler.confirm_auto_approved,
             'label': _('Confirm Approval'),
@@ -396,7 +406,6 @@ class ReviewHelper(object):
             'available': (
                 reviewable_because_not_reserved_for_admins_or_user_is_admin and
                 (was_auto_approved_and_user_can_post_review or
-                 was_auto_approved_and_user_can_content_review or
                  is_unlisted_and_user_can_review_unlisted))
         }
         actions['reject_multiple_versions'] = {
@@ -411,7 +420,7 @@ class ReviewHelper(object):
                 self.addon.type != amo.ADDON_STATICTHEME and
                 reviewable_because_not_reserved_for_admins_or_user_is_admin and
                 (is_public_and_listed_and_user_can_post_review or
-                 is_public_and_listed_and_user_can_content_review)
+                 is_valid_and_listed_and_user_can_content_review)
             )
         }
         actions['reply'] = {
@@ -441,15 +450,6 @@ class ReviewHelper(object):
             'available': True,
         }
 
-        # Small tweaks to labels and descriptions when in content review mode.
-        if self.content_review_only:
-            if 'confirm_auto_approved' in actions:
-                actions['confirm_auto_approved'].update({
-                    'label': _('Approve Content'),
-                    'details': _('This records your approbation of the '
-                                 'content of the latest public version, '
-                                 'without notifying the developer.'),
-                })
         return OrderedDict(
             ((key, action) for key, action in actions.items()
              if action['available'])
@@ -738,6 +738,36 @@ class ReviewBase(object):
         self.log_action(log_action_type)
         log.info(u'%s for %s' % (log_action_type.short, self.addon))
 
+    def approve_content(self):
+        """Approve content of an add-on."""
+        channel = self.version.channel
+        version = self.addon.current_version
+
+        # Content review only action.
+        assert self.content_review_only
+
+        # Doesn't make sense for unlisted versions.
+        assert channel == amo.RELEASE_CHANNEL_LISTED
+
+        # Like confirm auto approval, the approve content action should not
+        # show the comment box, so override the text in case the reviewer
+        # switched between actions and accidently submitted some comments from
+        # another action.
+        self.data['comments'] = ''
+
+        # When doing a content review, don't increment the approvals counter,
+        # just record the date of the content approval and log it.
+        AddonApprovalsCounter.approve_content_for_addon(addon=self.addon)
+        self.log_action(amo.LOG.APPROVE_CONTENT, version=version)
+
+        # Assign reviewer incentive scores.
+        if self.request:
+            is_post_review = channel == amo.RELEASE_CHANNEL_LISTED
+            ReviewerScore.award_points(
+                self.request.user, self.addon, self.addon.status,
+                version=version, post_review=is_post_review,
+                content_review=self.content_review_only)
+
     def confirm_auto_approved(self):
         """Confirm an auto-approval decision."""
 
@@ -755,17 +785,10 @@ class ReviewBase(object):
         # so override the text in case the reviewer switched between actions
         # and accidently submitted some comments from another action.
         self.data['comments'] = ''
-        if self.content_review_only:
-            # If we're only doing a content review, then don't increment
-            # the counter, just record the date of the content approval
-            # and log it.
-            AddonApprovalsCounter.approve_content_for_addon(addon=self.addon)
-            self.log_action(amo.LOG.APPROVE_CONTENT, version=version)
-        else:
-            if channel == amo.RELEASE_CHANNEL_LISTED:
-                version.autoapprovalsummary.update(confirmed=True)
-                AddonApprovalsCounter.increment_for_addon(addon=self.addon)
-            self.log_action(amo.LOG.CONFIRM_AUTO_APPROVED, version=version)
+        if channel == amo.RELEASE_CHANNEL_LISTED:
+            version.autoapprovalsummary.update(confirmed=True)
+            AddonApprovalsCounter.increment_for_addon(addon=self.addon)
+        self.log_action(amo.LOG.CONFIRM_AUTO_APPROVED, version=version)
 
         # Assign reviewer incentive scores.
         if self.request:


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/11795