### PR TITLE
Revamp draft comments API.

### DIFF
--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -112,6 +112,8 @@ The response when returning ``HTTP 503 Service Unavailable`` in case of read-onl
 
 In case we are not in read-only mode everything should be back working as normal.
 
+.. _api-overview-pagination:
+
 ~~~~~~~~~~
 Pagination
 ~~~~~~~~~~

--- a/docs/topics/api/reviewers.rst
+++ b/docs/topics/api/reviewers.rst
@@ -323,7 +323,7 @@ These endpoints allow you to draft comments that can be submitted through the re
     :>json int id: The id of the draft comment object.
     :>json string comment: The comment that is being drafted as part of a review. Specific to a line in a file.
     :>json string filename: The filename a specific comment is related to.
-    :>json int lineno: The line number a specific comment is related to.
+    :>json int lineno: The line number a specific comment is related to. Please make sure that in case of comments for git diffs, that the `lineno` used here belongs to the file in the version that belongs to `version_id` and not it's parent.
     :>json object version: Object holding the :ref:`version <version-detail-object>`.
     :>json int user.id: The id for an author.
     :>json string user.name: The name for an author.
@@ -335,8 +335,8 @@ These endpoints allow you to draft comments that can be submitted through the re
     Create a draft comment for a specific version.
 
     :<json string comment: The comment that is being drafted as part of a review.
-    :<json string filename: The filename this comment is related to.
-    :<json int lineno: The line number this comment is related to.
+    :<json string filename: The filename this comment is related to (optional).
+    :<json int lineno: The line number this comment is related to (optional). Please make sure that in case of comments for git diffs, that the `lineno` used here belongs to the file in the version that belongs to `version_id` and not it's parent.
     :statuscode 201: New comment has been created.
     :statuscode 400: An error occurred, check the `error` value in the JSON.
     :statuscode 403: The user doesn't have the permission to create a comment. This might happen (among other cases) when someone without permissions for unlisted versions tries to add a comment for an unlisted version (which shouldn't happen as the user doesn't see unlisted versions, but it's blocked here too).
@@ -354,6 +354,6 @@ These endpoints allow you to draft comments that can be submitted through the re
 
     :<json string comment: The comment that is being drafted as part of a review.
     :<json string filename: The filename this comment is related to.
-    :<json int lineno: The line number this comment is related to.
+    :<json int lineno: The line number this comment is related to. Please make sure that in case of comments for git diffs, that the `lineno` used here belongs to the file in the version that belongs to `version_id` and not it's parent.
     :statuscode 200: The comment has been updated.
     :statuscode 400: An error occurred, check the `error` value in the JSON.

--- a/docs/topics/api/reviewers.rst
+++ b/docs/topics/api/reviewers.rst
@@ -343,6 +343,7 @@ These endpoints allow you to draft comments that can be submitted through the re
 .. http:delete:: /api/v4/reviewers/addon/(int:addon_id)/versions/(int:version_id)/draft_comments/(int:comment_id)/
 
     Delete a draft comment.
+
     :statuscode 204: The comment has been deleted successfully.
     :statuscode 404: The user doesn't have the permission to delete. This might happen when someone tries to delete a comment created by another reviewer or author.
 
@@ -353,5 +354,5 @@ These endpoints allow you to draft comments that can be submitted through the re
     :<json string comments: The comment that is being drafted as part of a review.
     :<json string filename: The filename this comment is related to.
     :<json int lineno: The line number this comment is related to.
-    :statuscode 201: New comment has been created.
+    :statuscode 200: The comment has been updated.
     :statuscode 400: An error occurred, check the `error` value in the JSON.

--- a/docs/topics/api/reviewers.rst
+++ b/docs/topics/api/reviewers.rst
@@ -316,9 +316,20 @@ These endpoints allow you to draft comments that can be submitted through the re
         unlisted add-ons. Additionally the current user can also be the owner
         of the add-on.
 
+
 .. http:get:: /api/v4/reviewers/addon/(int:addon_id)/versions/(int:version_id)/draft_comments/
 
-    Retrieve existing draft comments for a specific version.
+    Retrieve existing draft comments for a specific version. See :ref:`pagination <api-overview-pagination>` for more details.
+
+    :>json int count: The number of comments for this version.
+    :>json string next: The URL of the next page of results.
+    :>json string previous: The URL of the previous page of results.
+    :>json array results: An array of :ref:`comments <reviewers-draft-comment-detail-object>`.
+
+
+.. http:get:: /api/v4/reviewers/addon/(int:addon_id)/versions/(int:version_id)/draft_comments/(int:comment_id)/
+
+    .. _reviewers-draft-comment-detail-object:
 
     :>json int id: The id of the draft comment object.
     :>json string comment: The comment that is being drafted as part of a review. Specific to a line in a file.
@@ -329,6 +340,7 @@ These endpoints allow you to draft comments that can be submitted through the re
     :>json string user.name: The name for an author.
     :>json string user.url: The link to the profile page for an author.
     :>json string user.username: The username for an author.
+
 
 .. http:post:: /api/v4/reviewers/addon/(int:addon_id)/versions/(int:version_id)/draft_comments/
 
@@ -341,12 +353,14 @@ These endpoints allow you to draft comments that can be submitted through the re
     :statuscode 400: An error occurred, check the `error` value in the JSON.
     :statuscode 403: The user doesn't have the permission to create a comment. This might happen (among other cases) when someone without permissions for unlisted versions tries to add a comment for an unlisted version (which shouldn't happen as the user doesn't see unlisted versions, but it's blocked here too).
 
+
 .. http:delete:: /api/v4/reviewers/addon/(int:addon_id)/versions/(int:version_id)/draft_comments/(int:comment_id)/
 
     Delete a draft comment.
 
     :statuscode 204: The comment has been deleted successfully.
     :statuscode 404: The user doesn't have the permission to delete. This might happen when someone tries to delete a comment created by another reviewer or author.
+
 
 .. http:patch:: /api/v4/reviewers/addon/(int:addon_id)/versions/(int:version_id)/draft_comments/(int:comment_id)
 

--- a/docs/topics/api/reviewers.rst
+++ b/docs/topics/api/reviewers.rst
@@ -97,6 +97,10 @@ This endpoint allows you to list versions that can be used either for :ref:`brow
         unlisted add-ons. Additionally the current user can also be the owner
         of the add-on.
 
+        This endpoint is not paginated as normal, and instead will return all
+        results without obeying regular pagination parameters.
+
+
 If the user doesn't have ``AddonsReviewUnlisted`` permissions only listed versions are shown. Otherwise it can contain mixed listed and unlisted versions.
 
 .. http:get:: /api/v4/reviewers/addon/(int:addon_id)/versions/
@@ -289,6 +293,11 @@ This endpoint allows you to retrieve a list of canned responses.
 
     Retrieve canned responses
 
+    .. note::
+        Because this endpoint is not returning too much data it is not
+        paginated as normal, and instead will return all results without
+        obeying regular pagination parameters.
+
     :>json int id: The canned response id.
     :>json string title: The title of the canned response.
     :>json string response: The text that will be filled in as the response.
@@ -301,8 +310,6 @@ Drafting Comments
 
 These endpoints allow you to draft comments that can be submitted through the regular reviewer pages.
 
-Please note, that once a review is submitted the drafted comments are being cleared as well.
-
     .. note::
         Requires authentication and the current user to have ``ReviewerTools:View``
         permission for listed add-ons as well as ``Addons:ReviewUnlisted`` for
@@ -311,16 +318,40 @@ Please note, that once a review is submitted the drafted comments are being clea
 
 .. http:get:: /api/v4/reviewers/addon/(int:addon_id)/versions/(int:version_id)/draft_comments/
 
-    Retrieve an exising draft.
+    Retrieve existing draft comments for a specific version.
 
-    :>json string comments: The comment that is being drafted as part of a review.
+    :>json string comment: The comment that is being drafted as part of a review. Specific to a line in a file.
+    :>json string filename: The filename a specific comment is related to.
+    :>json int lineno: The line number a specific comment is related to.
+    :>json object version: Object holding the :ref:`version <version-detail-object>`.
+    :>json int user.id: The id for an author.
+    :>json string user.name: The name for an author.
+    :>json string user.url: The link to the profile page for an author.
+    :>json string user.username: The username for an author.
 
-.. http:patch:: /api/v4/reviewers/addon/(int:addon_id)/versions/(int:version_id)/draft_comments/
+.. http:post:: /api/v4/reviewers/addon/(int:addon_id)/versions/(int:version_id)/draft_comments/
 
-    Create or update a draft.
+    Create a draft comment for a specific version.
 
     :<json string comments: The comment that is being drafted as part of a review.
+    :<json string filename: The filename this comment is related to.
+    :<json int lineno: The line number this comment is related to.
+    :statuscode 201: New comment has been created.
+    :statuscode 400: An error occurred, check the `error` value in the JSON.
+    :statuscode 403: The user doesn't have the permission to create a comment. This might happen (among other cases) when someone without permissions for unlisted versions tries to add a comment for an unlisted version (which shouldn't happen as the user doesn't see unlisted versions, but it's blocked here too).
 
-.. http:delete:: /api/v4/reviewers/addon/(int:addon_id)/versions/(int:version_id)/draft_comments/
+.. http:delete:: /api/v4/reviewers/addon/(int:addon_id)/versions/(int:version_id)/draft_comments/(int:comment_id)/
 
-    Delete a drafted comment.
+    Delete a draft comment.
+    :statuscode 204: The comment has been deleted successfully.
+    :statuscode 404: The user doesn't have the permission to delete. This might happen when someone tries to delete a comment created by another reviewer or author.
+
+.. http:patch:: /api/v4/reviewers/addon/(int:addon_id)/versions/(int:version_id)/draft_comments/(int:comment_id)
+
+    Update a comment, it's filename or line number.
+
+    :<json string comments: The comment that is being drafted as part of a review.
+    :<json string filename: The filename this comment is related to.
+    :<json int lineno: The line number this comment is related to.
+    :statuscode 201: New comment has been created.
+    :statuscode 400: An error occurred, check the `error` value in the JSON.

--- a/docs/topics/api/reviewers.rst
+++ b/docs/topics/api/reviewers.rst
@@ -320,6 +320,7 @@ These endpoints allow you to draft comments that can be submitted through the re
 
     Retrieve existing draft comments for a specific version.
 
+    :>json int id: The id of the draft comment object.
     :>json string comment: The comment that is being drafted as part of a review. Specific to a line in a file.
     :>json string filename: The filename a specific comment is related to.
     :>json int lineno: The line number a specific comment is related to.
@@ -333,7 +334,7 @@ These endpoints allow you to draft comments that can be submitted through the re
 
     Create a draft comment for a specific version.
 
-    :<json string comments: The comment that is being drafted as part of a review.
+    :<json string comment: The comment that is being drafted as part of a review.
     :<json string filename: The filename this comment is related to.
     :<json int lineno: The line number this comment is related to.
     :statuscode 201: New comment has been created.
@@ -351,7 +352,7 @@ These endpoints allow you to draft comments that can be submitted through the re
 
     Update a comment, it's filename or line number.
 
-    :<json string comments: The comment that is being drafted as part of a review.
+    :<json string comment: The comment that is being drafted as part of a review.
     :<json string filename: The filename this comment is related to.
     :<json int lineno: The line number this comment is related to.
     :statuscode 200: The comment has been updated.

--- a/src/olympia/activity/models.py
+++ b/src/olympia/activity/models.py
@@ -171,8 +171,8 @@ class DraftComment(ModelBase):
     id = PositiveAutoField(primary_key=True)
     version = models.ForeignKey(Version, on_delete=models.CASCADE)
     user = models.ForeignKey(UserProfile, on_delete=models.CASCADE)
-    filename = models.CharField(max_length=255)
-    lineno = models.PositiveIntegerField()
+    filename = models.CharField(max_length=255, null=True, blank=True)
+    lineno = models.PositiveIntegerField(null=True)
     comment = models.TextField()
 
     class Meta:

--- a/src/olympia/activity/models.py
+++ b/src/olympia/activity/models.py
@@ -169,9 +169,11 @@ class DraftComment(ModelBase):
     This is being used by the commenting API by the code-manager.
     """
     id = PositiveAutoField(primary_key=True)
-    comments = models.TextField()
     version = models.ForeignKey(Version, on_delete=models.CASCADE)
     user = models.ForeignKey(UserProfile, on_delete=models.CASCADE)
+    filename = models.CharField(max_length=255)
+    lineno = models.PositiveIntegerField()
+    comment = models.TextField()
 
     class Meta:
         db_table = 'log_activity_comment_draft'

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1483,6 +1483,7 @@ PS_BIN = '/bin/ps'
 
 # The maximum file size that is shown inside the file viewer.
 FILE_VIEWER_SIZE_LIMIT = 1048576
+
 # The maximum file size that you can have inside a zip file.
 FILE_UNZIP_SIZE_LIMIT = 104857600
 

--- a/src/olympia/migrations/1102-add-file-lineno-draft-comment.sql
+++ b/src/olympia/migrations/1102-add-file-lineno-draft-comment.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `log_activity_comment_draft`
+  ADD COLUMN `filename` varchar(255) NOT NULL,
+  ADD COLUMN `lineno` integer UNSIGNED NOT NULL,
+  CHANGE `comments` `comment` longtext NOT NULL;

--- a/src/olympia/migrations/1102-add-file-lineno-draft-comment.sql
+++ b/src/olympia/migrations/1102-add-file-lineno-draft-comment.sql
@@ -1,4 +1,4 @@
 ALTER TABLE `log_activity_comment_draft`
-  ADD COLUMN `filename` varchar(255) NOT NULL,
-  ADD COLUMN `lineno` integer UNSIGNED NOT NULL,
+  ADD COLUMN `filename` varchar(255) NULL,
+  ADD COLUMN `lineno` integer UNSIGNED NULL,
   CHANGE `comments` `comment` longtext NOT NULL;

--- a/src/olympia/reviewers/api_urls.py
+++ b/src/olympia/reviewers/api_urls.py
@@ -5,7 +5,8 @@ from rest_framework_nested.routers import NestedSimpleRouter
 
 from .views import (
     AddonReviewerViewSet, ReviewAddonVersionViewSet,
-    ReviewAddonVersionCompareViewSet, CannedResponseViewSet)
+    ReviewAddonVersionCompareViewSet, CannedResponseViewSet,
+    ReviewAddonVersionDraftCommentViewSet)
 
 
 addons = SimpleRouter()
@@ -20,10 +21,16 @@ compare.register(
     r'compare_to', ReviewAddonVersionCompareViewSet,
     basename='reviewers-versions-compare')
 
+draft_comments = NestedSimpleRouter(versions, r'versions', lookup='version')
+draft_comments.register(
+    r'draft_comments', ReviewAddonVersionDraftCommentViewSet,
+    basename='reviewers-versions-draft-comment')
+
 urlpatterns = [
     url(r'', include(addons.urls)),
     url(r'', include(versions.urls)),
     url(r'', include(compare.urls)),
+    url(r'', include(draft_comments.urls)),
     url(r'^canned-responses/$', CannedResponseViewSet.as_view(),
         name='reviewers-canned-response-list'),
 ]

--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -376,9 +376,6 @@ class ReviewForm(forms.Form):
         self.fields['action'].choices = [
             (k, v['label']) for k, v in self.helper.actions.items()]
 
-        if self.initial.get('comments_draft'):
-            self.fields['comments'].initial = self.initial['comments_draft']
-
     @property
     def unreviewed_files(self):
         return (self.helper.version.unreviewed_files

--- a/src/olympia/reviewers/serializers.py
+++ b/src/olympia/reviewers/serializers.py
@@ -19,8 +19,7 @@ from olympia.accounts.serializers import BaseUserSerializer
 from olympia.amo.urlresolvers import reverse
 from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.addons.serializers import (
-    VersionSerializer, FileSerializer, SimpleAddonSerializer,
-    SimpleVersionSerializer)
+    VersionSerializer, FileSerializer, SimpleAddonSerializer)
 from olympia.addons.models import AddonReviewerFlags
 from olympia.api.fields import SplitField
 from olympia.users.models import UserProfile
@@ -342,12 +341,12 @@ class DraftCommentSerializer(serializers.ModelSerializer):
     version = SplitField(
         serializers.PrimaryKeyRelatedField(
             queryset=Version.unfiltered.all()),
-        SimpleVersionSerializer())
+        VersionSerializer())
 
     class Meta:
         model = DraftComment
         fields = (
-            'filename', 'lineno', 'comment',
+            'id', 'filename', 'lineno', 'comment',
             'version', 'user'
         )
 

--- a/src/olympia/reviewers/serializers.py
+++ b/src/olympia/reviewers/serializers.py
@@ -15,11 +15,15 @@ from django.utils.timezone import FixedOffset
 
 from olympia import amo
 from olympia.activity.models import DraftComment
+from olympia.accounts.serializers import BaseUserSerializer
 from olympia.amo.urlresolvers import reverse
 from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.addons.serializers import (
-    VersionSerializer, FileSerializer, SimpleAddonSerializer)
+    VersionSerializer, FileSerializer, SimpleAddonSerializer,
+    SimpleVersionSerializer)
 from olympia.addons.models import AddonReviewerFlags
+from olympia.api.fields import SplitField
+from olympia.users.models import UserProfile
 from olympia.files.utils import get_sha256
 from olympia.files.models import File
 from olympia.reviewers.models import CannedResponse
@@ -332,10 +336,20 @@ class AddonCompareVersionSerializer(AddonBrowseVersionSerializer):
 
 
 class DraftCommentSerializer(serializers.ModelSerializer):
+    user = SplitField(
+        serializers.PrimaryKeyRelatedField(queryset=UserProfile.objects.all()),
+        BaseUserSerializer())
+    version = SplitField(
+        serializers.PrimaryKeyRelatedField(
+            queryset=Version.unfiltered.all()),
+        SimpleVersionSerializer())
 
     class Meta:
         model = DraftComment
-        fields = ('comments',)
+        fields = (
+            'filename', 'lineno', 'comment',
+            'version', 'user'
+        )
 
 
 class CannedResponseSerializer(serializers.ModelSerializer):

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -5836,6 +5836,37 @@ class TestReviewAddonVersionViewSetList(TestCase):
         assert response.json()['lineno'] == 16
         assert response.json()['filename'] == 'new_manifest.json'
 
+    def test_draft_comment_lineno_filename_optional(self):
+        user = UserProfile.objects.create(username='reviewer')
+        self.grant_permission(user, 'Addons:Review')
+        self.client.login_api(user)
+
+        data = {
+            'comment': 'Some really fancy comment',
+        }
+
+        url = reverse_ns('reviewers-versions-draft-comment-list', kwargs={
+            'addon_pk': self.addon.pk,
+            'version_pk': self.version.pk
+        })
+
+        response = self.client.post(url, data)
+        comment_id = response.json()['id']
+
+        assert response.status_code == 201
+
+        url = reverse_ns('reviewers-versions-draft-comment-detail', kwargs={
+            'addon_pk': self.addon.pk,
+            'version_pk': self.version.pk,
+            'pk': comment_id
+        })
+
+        response = self.client.get(url)
+
+        assert response.json()['comment'] == 'Some really fancy comment'
+        assert response.json()['lineno'] is None
+        assert response.json()['filename'] is None
+
     def test_draft_comment_delete(self):
         user = UserProfile.objects.create(username='reviewer')
         self.grant_permission(user, 'Addons:Review')

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -5727,7 +5727,7 @@ class TestReviewAddonVersionViewSetList(TestCase):
         ]
 
     def test_draft_comment_create_and_retrieve(self):
-        user = UserProfile.objects.create(username='reviewer')
+        user = user_factory(username='reviewer')
         self.grant_permission(user, 'Addons:Review')
         self.client.login_api(user)
 
@@ -5772,7 +5772,7 @@ class TestReviewAddonVersionViewSetList(TestCase):
         }
 
     def test_draft_comment_create_retrieve_and_update(self):
-        user = UserProfile.objects.create(username='reviewer')
+        user = user_factory(username='reviewer')
         self.grant_permission(user, 'Addons:Review')
         self.client.login_api(user)
 
@@ -5839,7 +5839,7 @@ class TestReviewAddonVersionViewSetList(TestCase):
         assert response.json()['filename'] == 'new_manifest.json'
 
     def test_draft_comment_lineno_filename_optional(self):
-        user = UserProfile.objects.create(username='reviewer')
+        user = user_factory(username='reviewer')
         self.grant_permission(user, 'Addons:Review')
         self.client.login_api(user)
 
@@ -5870,7 +5870,7 @@ class TestReviewAddonVersionViewSetList(TestCase):
         assert response.json()['filename'] is None
 
     def test_draft_comment_delete(self):
-        user = UserProfile.objects.create(username='reviewer')
+        user = user_factory(username='reviewer')
         self.grant_permission(user, 'Addons:Review')
         self.client.login_api(user)
 
@@ -5890,7 +5890,7 @@ class TestReviewAddonVersionViewSetList(TestCase):
         assert DraftComment.objects.first() is None
 
     def test_draft_comment_delete_not_comment_owner(self):
-        user = UserProfile.objects.create(username='reviewer')
+        user = user_factory(username='reviewer')
         self.grant_permission(user, 'Addons:Review')
 
         comment = DraftComment.objects.create(
@@ -5898,7 +5898,7 @@ class TestReviewAddonVersionViewSetList(TestCase):
             lineno=0, filename='manifest.json')
 
         # Let's login as someone else who is also a reviewer
-        other_reviewer = UserProfile.objects.create(username='reviewer2')
+        other_reviewer = user_factory(username='reviewer2')
 
         # Let's give the user admin permissions which doesn't help
         self.grant_permission(other_reviewer, '*:*')
@@ -5915,7 +5915,7 @@ class TestReviewAddonVersionViewSetList(TestCase):
         assert response.status_code == 404
 
     def test_draft_comment_disabled_version_user_but_not_author(self):
-        user = UserProfile.objects.create(username='simpleuser')
+        user = user_factory(username='simpleuser')
         self.client.login_api(user)
         self.version.files.update(status=amo.STATUS_DISABLED)
 
@@ -5934,7 +5934,7 @@ class TestReviewAddonVersionViewSetList(TestCase):
         assert response.status_code == 403
 
     def test_draft_comment_deleted_version_reviewer(self):
-        user = UserProfile.objects.create(username='reviewer')
+        user = user_factory(username='reviewer')
         self.grant_permission(user, 'Addons:Review')
         self.client.login_api(user)
         self.version.delete()
@@ -5954,7 +5954,7 @@ class TestReviewAddonVersionViewSetList(TestCase):
         assert response.status_code == 404
 
     def test_draft_comment_deleted_version_author(self):
-        user = UserProfile.objects.create(username='author')
+        user = user_factory(username='author')
         AddonUser.objects.create(user=user, addon=self.addon)
         self.client.login_api(user)
         self.version.delete()
@@ -5974,7 +5974,7 @@ class TestReviewAddonVersionViewSetList(TestCase):
         assert response.status_code == 404
 
     def test_draft_comment_deleted_version_user_but_not_author(self):
-        user = UserProfile.objects.create(username='simpleuser')
+        user = user_factory(username='simpleuser')
         self.client.login_api(user)
         self.version.delete()
 
@@ -5993,7 +5993,7 @@ class TestReviewAddonVersionViewSetList(TestCase):
         assert response.status_code == 404
 
     def test_draft_comment_unlisted_version_reviewer(self):
-        user = UserProfile.objects.create(username='reviewer')
+        user = user_factory(username='reviewer')
         self.grant_permission(user, 'Addons:Review')
         self.client.login_api(user)
         self.version.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
@@ -6013,7 +6013,7 @@ class TestReviewAddonVersionViewSetList(TestCase):
         assert response.status_code == 403
 
     def test_draft_comment_unlisted_version_user_but_not_author(self):
-        user = UserProfile.objects.create(username='simpleuser')
+        user = user_factory(username='simpleuser')
         self.client.login_api(user)
         self.version.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
 

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -36,7 +36,7 @@ from olympia.accounts.serializers import BaseUserSerializer
 from olympia.activity.models import ActivityLog, DraftComment
 from olympia.addons.models import (
     Addon, AddonApprovalsCounter, AddonReviewerFlags, AddonUser)
-from olympia.addons.serializers import SimpleVersionSerializer
+from olympia.addons.serializers import VersionSerializer
 from olympia.amo.storage_utils import copy_stored_file
 from olympia.amo.templatetags.jinja_helpers import (
     absolutify, format_date, format_datetime)
@@ -5761,7 +5761,7 @@ class TestReviewAddonVersionViewSetList(TestCase):
             'lineno': 20,
             'comment': 'Some really fancy comment',
             'version': json.loads(json.dumps(
-                SimpleVersionSerializer(self.version).data,
+                VersionSerializer(self.version).data,
                 cls=amo.utils.AMOJSONEncoder)),
             'user': json.loads(json.dumps(
                 BaseUserSerializer(

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -5743,6 +5743,7 @@ class TestReviewAddonVersionViewSetList(TestCase):
         })
 
         response = self.client.post(url, data)
+        comment_id = response.json()['id']
         assert response.status_code == 201
 
         response = self.client.post(url, data)
@@ -5757,6 +5758,7 @@ class TestReviewAddonVersionViewSetList(TestCase):
 
         assert response.json()['count'] == 2
         assert response.json()['results'][0] == {
+            'id': comment_id,
             'filename': 'manifest.json',
             'lineno': 20,
             'comment': 'Some really fancy comment',

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -24,7 +24,9 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 from rest_framework.generics import ListAPIView
-from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
+from rest_framework.mixins import (
+    ListModelMixin, RetrieveModelMixin, CreateModelMixin, DestroyModelMixin,
+    UpdateModelMixin)
 
 import olympia.core.logger
 
@@ -44,8 +46,7 @@ from olympia.amo.urlresolvers import reverse
 from olympia.amo.utils import paginate, render
 from olympia.api.permissions import (
     AllowAnyKindOfReviewer, GroupPermission,
-    AllowAddonAuthor, AllowReviewer, AllowReviewerUnlisted, AnyOf,
-    ByHttpMethod)
+    AllowAddonAuthor, AllowReviewer, AllowReviewerUnlisted, AnyOf)
 from olympia.constants.reviewers import REVIEWS_PER_PAGE, REVIEWS_PER_PAGE_MAX
 from olympia.devhub import tasks as devhub_tasks
 from olympia.discovery.models import DiscoveryItem
@@ -789,14 +790,6 @@ def review(request, addon, channel=None):
         'info_request': addon.pending_info_request,
     }
 
-    try:
-        comments_draft = version.draftcomment_set.get(user=request.user)
-    except (DraftComment.DoesNotExist, AttributeError):
-        comments_draft = None
-
-    form_initial['comments_draft'] = (
-        comments_draft.comments if comments_draft else '')
-
     form_helper = ReviewHelper(
         request=request, addon=addon, version=version,
         content_review_only=content_review_only)
@@ -836,9 +829,6 @@ def review(request, addon, channel=None):
 
     if request.method == 'POST' and form.is_valid():
         form.helper.process()
-
-        if comments_draft:
-            comments_draft.delete()
 
         amo.messages.success(
             request, ugettext('Review successfully processed.'))
@@ -1329,7 +1319,7 @@ class ReviewAddonVersionMixin(object):
 
         kwargs.setdefault(
             self.lookup_field,
-            self.kwargs[self.lookup_url_kwarg or self.lookup_field])
+            self.kwargs.get(self.lookup_url_kwarg or self.lookup_field))
 
         obj = get_object_or_404(qset, **kwargs)
 
@@ -1392,40 +1382,72 @@ class ReviewAddonVersionViewSet(ReviewAddonVersionMixin, ListModelMixin,
         )
         return Response(serializer.data)
 
-    draft_comment_permissions = AnyOf(
+
+class ReviewAddonVersionDraftCommentViewSet(
+        RetrieveModelMixin, ListModelMixin, CreateModelMixin,
+        DestroyModelMixin, UpdateModelMixin, GenericViewSet):
+
+    permission_classes = [AnyOf(
         AllowReviewer, AllowReviewerUnlisted, AllowAddonAuthor,
-    )
+    )]
 
-    @action(
-        detail=True,
-        methods=['get', 'put', 'delete'],
-        permission_classes=[ByHttpMethod({
-            'get': draft_comment_permissions,
-            'put': draft_comment_permissions,
-            'delete': draft_comment_permissions})
-        ])
-    def draft_comment(self, request, **kwargs):
-        version = self.get_object()
+    queryset = DraftComment.objects.all()
+    serializer_class = DraftCommentSerializer
 
-        if request.method == 'GET':
-            instance = get_object_or_404(
-                DraftComment, version=version, user=request.user)
-            serializer = DraftCommentSerializer(instance, data=request.data)
-            return Response(serializer.data)
-        elif request.method == 'DELETE':
-            instance = get_object_or_404(
-                DraftComment, version=version, user=request.user)
+    def check_object_permissions(self, request, obj):
+        """Check permissions against the parent add-on object."""
+        return super().check_object_permissions(request, obj.version.addon)
 
-            instance.delete()
-            return Response(status=status.HTTP_204_NO_CONTENT)
-        elif request.method == 'PUT':
-            instance, _ = DraftComment.objects.get_or_create(
-                version=version, user=request.user)
-            serializer = DraftCommentSerializer(instance, data=request.data)
-            serializer.is_valid(raise_exception=True)
-            serializer.save()
-            return Response(serializer.data)
-        return Response(status=http.HTTP_405_METHOD_NOT_ALLOWED)
+    def _verify_object_permissions(self, object_to_verify, version):
+        """Verify permissions.
+
+        This method works for `Version` and `DraftComment` objects.
+        """
+        # If the instance is marked as deleted and the client is not allowed to
+        # see deleted instances, we want to return a 404, behaving as if it
+        # does not exist.
+        if version.deleted and not (
+                GroupPermission(amo.permissions.ADDONS_VIEW_DELETED).
+                has_object_permission(self.request, self, version.addon)):
+            raise http.Http404
+
+        # Now we can checking permissions
+        super().check_object_permissions(self.request, version.addon)
+
+    def get_object(self, **kwargs):
+        qset = self.filter_queryset(self.get_queryset())
+
+        kwargs.setdefault(
+            self.lookup_field,
+            self.kwargs.get(self.lookup_url_kwarg or self.lookup_field))
+
+        obj = get_object_or_404(qset, **kwargs)
+        self._verify_object_permissions(obj, obj.version)
+        return obj
+
+    def get_version_object(self):
+        version = get_object_or_404(
+            Version.objects.get_queryset().only_translations(),
+            pk=self.kwargs['version_pk'])
+        self._verify_object_permissions(version, version)
+        return version
+
+    def get_extra_comment_data(self):
+        return {
+            'version': self.get_version_object().pk,
+            'user': self.request.user.pk
+        }
+
+    def filter_queryset(self, qset):
+        qset = super().filter_queryset(qset)
+        return qset.filter(**self.get_extra_comment_data())
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        # Patch in `version` and `user` as those are required by the serializer
+        # and not provided by the API client as part of the POST data.
+        self.request.data.update(self.get_extra_comment_data())
+        return context
 
 
 class ReviewAddonVersionCompareViewSet(ReviewAddonVersionMixin,


### PR DESCRIPTION
Revamp how draft comments work, store multiple comments per version and
paginate them.

This also implement PATCH to update a comment, updates DELETE, GET
and POST endpoints properly and updates the documentation accordingly.

This patch is removing the integration with the current reviewer tools. We will re-implement this in a much better way in a follow-up patch. I'll file an issue about that.

Fixes #11380
Fixes #11379
Fixes #11378
Fixes #11374