### PR TITLE
Disable frontend related tests.

### DIFF
--- a/tests/ui/setup.cfg
+++ b/tests/ui/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-addopts = -vs --tb=long --showlocals --html=ui-test.html --self-contained-html
+addopts = -vs --tb=long --showlocals --html=ui-test.html --self-contained-html -k "test_devhub or test_install" -n 4 --reruns 1
 sensitive_url = mozilla\.(com|org)
 xfail_strict = true
 DJANGO_SETTINGS_MODULE = settings


### PR DESCRIPTION
Should work on #11691 

This disables the frontend related tests and only runs devhub and install tests.
