### PR TITLE
Move some config to env variable for integration tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,7 @@ jobs:
           name: Start container, verify it's running and start tests
           environment:
             MOZ_HEADLESS: 1
+            PYTEST_ADDOPTS: -k "test_devhub or test_install" -n 4 --reruns 1
           command: |
             set -x
             sudo sysctl -w vm.max_map_count=262144

--- a/tests/ui/setup.cfg
+++ b/tests/ui/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-addopts = -vs --tb=long --showlocals --html=ui-test.html --self-contained-html -k "test_devhub or test_install" -n 4 --reruns 1
+addopts = -vs --tb=long --showlocals --html=ui-test.html --self-contained-html
 sensitive_url = mozilla\.(com|org)
 xfail_strict = true
 DJANGO_SETTINGS_MODULE = settings


### PR DESCRIPTION
Since this repo is cloned and used for the addons-frontend integration tests (for now), this should allow those tests to still run the entire suite.
