### PR TITLE
Exclude themes and language packs from content review queue.

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -317,6 +317,11 @@ class AddonManager(ManagerBase):
             .filter(
                 addonapprovalscounter__last_content_review=None
             )
+            # Exclude themes and language packs. See
+            # https://github.com/mozilla/addons-server/issues/11796
+            .exclude(
+                type__in=(amo.ADDON_STATICTHEME, amo.ADDON_LPAPP)
+            )
             # We need those joins for the queue to work without making extra
             # queries. See get_auto_approved_queue()
             .select_related(

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -528,7 +528,8 @@ class TestDashboard(TestCase):
                 addon=addon_factory(),
                 recommendation_approved=True,
                 file_kw={'status': amo.STATUS_AWAITING_REVIEW}).addon)
-        # Nominated and pending themes
+        # Nominated and pending themes, not being counted
+        # as per https://github.com/mozilla/addons-server/issues/11796
         addon_factory(
             status=amo.STATUS_NOMINATED,
             type=amo.ADDON_STATICTHEME,
@@ -671,7 +672,7 @@ class TestDashboard(TestCase):
         # auto-approved addons
         assert doc('.dashboard a')[5].text == 'Auto Approved Add-ons (4)'
         # content review
-        assert doc('.dashboard a')[9].text == 'Content Review (13)'
+        assert doc('.dashboard a')[9].text == 'Content Review (11)'
         # themes
         assert doc('.dashboard a')[11].text == 'New (1)'
         assert doc('.dashboard a')[12].text == 'Updates (1)'
@@ -2273,6 +2274,16 @@ class TestContentReviewQueue(QueueTest):
             version=addon4.current_version,
             verdict=amo.AUTO_APPROVED, confirmed=True)
         assert not AddonApprovalsCounter.objects.filter(addon=addon4).exists()
+
+        # Those should *not* appear in the queue
+        # Has not been auto-approved but themes are excluded.
+        addon_factory(
+            name=u'Theme 1', created=self.days_ago(4),
+            type=amo.ADDON_STATICTHEME)
+
+        addon_factory(
+            name=u'Langpack 1', created=self.days_ago(4),
+            type=amo.ADDON_LPAPP)
 
         # Addons with no last_content_review date, ordered by
         # their creation date, older first.

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -2276,7 +2276,7 @@ class TestContentReviewQueue(QueueTest):
         assert not AddonApprovalsCounter.objects.filter(addon=addon4).exists()
 
         # Those should *not* appear in the queue
-        # Has not been auto-approved but themes are excluded.
+        # Has not been auto-approved but themes and langpacks are excluded.
         addon_factory(
             name=u'Theme 1', created=self.days_ago(4),
             type=amo.ADDON_STATICTHEME)


### PR DESCRIPTION
Fixes #11796

Given that I haven't touched reviewer tools in a long time I may have solved this in the totally wrong place, any feedback in this regard appreciated.