### PR TITLE
Normalise xpi_info['guid'] before equality check

### DIFF
--- a/src/olympia/devhub/tests/test_views_validation.py
+++ b/src/olympia/devhub/tests/test_views_validation.py
@@ -117,14 +117,14 @@ class TestUploadErrors(BaseUploadTest):
         upper_guid = addon.guid.upper()
 
         with self.assertRaisesRegex(forms.ValidationError,
-                                    "does not match the ID of your add-on"
-                                    ) as e:
+                                    "does not match the ID of your add-on"):
             xpi_info = check_xpi_info({'guid': upper_guid,
                                        'version': '1.0'},
                                       addon=addon)
         xpi_info = check_xpi_info({'guid': upper_guid,
                                    'version': '1.0'})
         assert xpi_info['guid'] == upper_guid
+
 
 class TestFileValidation(TestCase):
     fixtures = ['base/users', 'devhub/addon-validation-1']

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -1023,9 +1023,9 @@ def check_xpi_info(xpi_info, addon=None, xpi_file=None, user=None):
         current_user = core.get_user()
         if current_user:
             deleted_guid_clashes = Addon.unfiltered.exclude(
-                authors__id=current_user.id).filter(guid=guid)
+                authors__id=current_user.id).filter(guid__iexact=guid)
         else:
-            deleted_guid_clashes = Addon.unfiltered.filter(guid=guid)
+            deleted_guid_clashes = Addon.unfiltered.filter(guid__iexact=guid)
 
         if addon and addon.guid.casefold() != guid.casefold():
             msg = ugettext(
@@ -1034,9 +1034,9 @@ def check_xpi_info(xpi_info, addon=None, xpi_file=None, user=None):
             raise forms.ValidationError(msg % (guid, addon.guid))
         if (not addon and
             # Non-deleted add-ons.
-            (Addon.objects.filter(guid=guid).exists() or
+            (Addon.objects.filter(guid__iexact=guid).exists() or
              # DeniedGuid objects for deletions for Mozilla disabled add-ons
-             DeniedGuid.objects.filter(guid=guid).exists() or
+             DeniedGuid.objects.filter(guid__iexact=guid).exists() or
              # Deleted add-ons that don't belong to the uploader.
              deleted_guid_clashes.exists())):
             raise forms.ValidationError(ugettext('Duplicate add-on ID found.'))

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -1023,11 +1023,11 @@ def check_xpi_info(xpi_info, addon=None, xpi_file=None, user=None):
         current_user = core.get_user()
         if current_user:
             deleted_guid_clashes = Addon.unfiltered.exclude(
-                authors__id=current_user.id).filter(guid__regex=r'{}'
-                                                    .format(re.escape(guid)))
+                authors__id=current_user.id).filter(
+                guid__regex=r'{}'.format(re.escape(guid)))
         else:
-            deleted_guid_clashes = Addon.unfiltered.filter(guid__regex=r'{}'
-                                                           .format(re.escape(guid)))
+            deleted_guid_clashes = Addon.unfiltered.filter(
+                guid__regex=r'{}'.format(re.escape(guid)))
 
         if addon and addon.guid != guid:
             msg = ugettext(
@@ -1036,11 +1036,11 @@ def check_xpi_info(xpi_info, addon=None, xpi_file=None, user=None):
             raise forms.ValidationError(msg % (guid, addon.guid))
         if (not addon and
             # Non-deleted add-ons.
-            (Addon.objects.filter(guid__regex=r'{}'
-                    .format(re.escape(guid))).exists() or
+            (Addon.objects.filter(
+                guid__regex=r'{}'.format(re.escape(guid))).exists() or
              # DeniedGuid objects for deletions for Mozilla disabled add-ons
-             DeniedGuid.objects.filter(guid__regex=r'{}'
-                     .format(re.escape(guid))).exists() or
+             DeniedGuid.objects.filter(
+                 guid__regex=r'{}'.format(re.escape(guid))).exists() or
              # Deleted add-ons that don't belong to the uploader.
              deleted_guid_clashes.exists())):
             raise forms.ValidationError(ugettext('Duplicate add-on ID found.'))

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -1027,7 +1027,7 @@ def check_xpi_info(xpi_info, addon=None, xpi_file=None, user=None):
         else:
             deleted_guid_clashes = Addon.unfiltered.filter(guid=guid)
 
-        if addon and addon.guid != guid:
+        if addon and addon.guid.casefold() != guid.casefold():
             msg = ugettext(
                 'The add-on ID in your manifest.json or install.rdf (%s) '
                 'does not match the ID of your add-on on AMO (%s)')

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -1023,20 +1023,24 @@ def check_xpi_info(xpi_info, addon=None, xpi_file=None, user=None):
         current_user = core.get_user()
         if current_user:
             deleted_guid_clashes = Addon.unfiltered.exclude(
-                authors__id=current_user.id).filter(guid__iexact=guid)
+                authors__id=current_user.id).filter(guid__regex=r'{}'
+                                                    .format(re.escape(guid)))
         else:
-            deleted_guid_clashes = Addon.unfiltered.filter(guid__iexact=guid)
+            deleted_guid_clashes = Addon.unfiltered.filter(guid__regex=r'{}'
+                                                           .format(re.escape(guid)))
 
-        if addon and addon.guid.casefold() != guid.casefold():
+        if addon and addon.guid != guid:
             msg = ugettext(
                 'The add-on ID in your manifest.json or install.rdf (%s) '
                 'does not match the ID of your add-on on AMO (%s)')
             raise forms.ValidationError(msg % (guid, addon.guid))
         if (not addon and
             # Non-deleted add-ons.
-            (Addon.objects.filter(guid__iexact=guid).exists() or
+            (Addon.objects.filter(guid__regex=r'{}'
+                    .format(re.escape(guid))).exists() or
              # DeniedGuid objects for deletions for Mozilla disabled add-ons
-             DeniedGuid.objects.filter(guid__iexact=guid).exists() or
+             DeniedGuid.objects.filter(guid__regex=r'{}'
+                     .format(re.escape(guid))).exists() or
              # Deleted add-ons that don't belong to the uploader.
              deleted_guid_clashes.exists())):
             raise forms.ValidationError(ugettext('Duplicate add-on ID found.'))


### PR DESCRIPTION
Fixes #11174 - normalises xpi_info['guid'] before equality check, performs iexact match on database query to ignore case.