### PR TITLE
add MozillaOnline as an alias for china in /discovery/ api endpoint

### DIFF
--- a/docs/topics/api/discovery.rst
+++ b/docs/topics/api/discovery.rst
@@ -34,7 +34,7 @@ Firefox (about:addons).
 .. http:get:: /api/v4/discovery/
 
     :query string lang: Activate translations in the specific language for that query. (See :ref:`translated fields <api-overview-translations>`)
-    :query string edition: Return content for a specific edition of Firefox.  Currently only ``china`` is supported.
+    :query string edition: Optionally return content for a specific edition of Firefox.  Currently only ``china`` (and the alias ``MozillaOnline``)  is supported.
     :query string telemetry-client-id: Optional sha256 hash of the telemetry client ID to be passed to the TAAR service to enable recommendations. Must be the hex value of a sha256 hash, otherwise it will be ignored.
     :>json int count: The number of results for this query.
     :>json array results: The array containing the results for this query.

--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -330,6 +330,7 @@ v4 API changelog
   Also made ``recommended`` sort available generally to the addons search API.  https://github.com/mozilla/addons-server/issues/11432
 * 2019-06-27: removed ``sort`` parameter from addon autocomplete API.  https://github.com/mozilla/addons-server/issues/11664
 * 2019-07-25: added /hero/ endpoint to expose recommended addons and other content to frontend to allow customizable promos https://github.com/mozilla/addons-server/issues/11842.
+* 2019-08-01: added alias ``edition=MozillaOnline`` for ``edition=china`` in /discovery/ endpoint.
 
 ----------------
 v5 API changelog

--- a/src/olympia/discovery/serializers.py
+++ b/src/olympia/discovery/serializers.py
@@ -64,8 +64,8 @@ class DiscoverySerializer(serializers.ModelSerializer):
         # If an object is ever returned without having a position set, that
         # means it's coming from the recommendation server, it wasn't an
         # editorial choice.
-        request = self.context.get('request')
-        if request and request.GET.get('edition') == 'china':
+        view = self.context.get('view')
+        if view and view.get_edition() == 'china':
             position_field = 'position_china'
         else:
             position_field = 'position'

--- a/src/olympia/discovery/tests/test_views.py
+++ b/src/olympia/discovery/tests/test_views.py
@@ -175,9 +175,9 @@ class TestDiscoveryViewList(DiscoveryTestMixin, TestCase):
         assert results[2]['addon']['id'] == discopane_items[5].addon_id
         assert results[3]['addon']['id'] == discopane_items[6].addon_id
 
-    def test_china_edition_list(self):
+    def test_china_edition_list(self, edition='china'):
         response = self.client.get(
-            self.url, {'lang': 'en-US', 'edition': 'china'})
+            self.url, {'lang': 'en-US', 'edition': edition})
         assert response.data
 
         discopane_items_china = DiscoveryItem.objects.all().filter(
@@ -188,6 +188,10 @@ class TestDiscoveryViewList(DiscoveryTestMixin, TestCase):
         for i, result in enumerate(response.data['results']):
             assert result['is_recommendation'] is False
             self._check_disco_addon(result, discopane_items_china[i])
+
+    def test_china_edition_alias_list(self, edition='china'):
+        self.test_china_edition_list(edition='MozillaOnline')
+        self.test_china_edition_list(edition='mozillaonline')
 
     def test_invalid_edition_returns_default(self):
         response = self.client.get(

--- a/src/olympia/discovery/views.py
+++ b/src/olympia/discovery/views.py
@@ -18,6 +18,9 @@ from olympia.discovery.utils import (
 # Permissive regexp for client IDs passed to the API, just to avoid sending
 # garbage to TAAR.
 VALID_CLIENT_ID = re.compile('^[a-zA-Z0-9-]+$')
+EDITION_ALIASES = {
+    'mozillaonline': 'china',
+}
 
 
 class DiscoveryViewSet(ListModelMixin, GenericViewSet):
@@ -25,8 +28,12 @@ class DiscoveryViewSet(ListModelMixin, GenericViewSet):
     permission_classes = []
     serializer_class = DiscoverySerializer
 
+    def get_edition(self):
+        edition = self.request.GET.get('edition', 'default').lower()
+        return EDITION_ALIASES.get(edition, edition)
+
     def get_queryset(self):
-        edition = self.request.GET.get('edition', 'default')
+        edition = self.get_edition()
         position_field = 'position_china' if edition == 'china' else 'position'
 
         # Base queryset for editorial content.


### PR DESCRIPTION
fixes #11937 