### PR TITLE
Add simple test to fail in case of duplicate migration ids.

### DIFF
--- a/src/olympia/core/tests/test_db.py
+++ b/src/olympia/core/tests/test_db.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import os
 import pytest
 
 from olympia.core.tests.db_tests_testapp.models import TestRegularCharField
@@ -14,3 +15,15 @@ def test_max_length_utf8mb4(value):
     TestRegularCharField.objects.create(name=value * 255)
 
     assert TestRegularCharField.objects.get().name == value * 255
+
+
+def test_no_duplicate_migration_ids():
+    seen = set()
+
+    migration_ids = [
+        fname.split('-')[0] for fname in os.listdir('src/olympia/migrations/')
+        if fname.endswith('.sql')]
+
+    duplicates = {x for x in migration_ids if x in seen or seen.add(x)}
+
+    assert not duplicates


### PR DESCRIPTION
The test fails by showing which migrations are duplicated.

```python
src/olympia/core/tests/test_db.py:29: in test_no_duplicate_migration_ids
    assert not duplicates
E   AssertionError: assert not {'99'}
```

Fixes #11852