### PR TITLE
Fix uwsgi autoreload.

### DIFF
--- a/Makefile-os
+++ b/Makefile-os
@@ -76,6 +76,10 @@ djshell:
 dbshell:
 	docker-compose exec web ./manage.py dbshell
 
+.PHONY: reload-uwsgi
+reload-uwsgi:
+	docker-compose exec web uwsgi --reload /code/docker/artifacts/addons-server-uwsgi-master.pid
+
 # Run a make command in the container
 .PHONY: make
 make:

--- a/docker/uwsgi.ini
+++ b/docker/uwsgi.ini
@@ -9,14 +9,14 @@ master          = true
 # maximum number of worker processes
 processes       = 4
 socket          = :8001
-vacuum          = true
 uid             = olympia
 gid             = olympia
+enable-threads  = true
+memory-report   = true
 
-# This only points to the src/ directory which should cover
-# 99% of autoreload scenarios. Coverting the whole %(base) will issue
-# autoreloads on new uploads etc as they're in %(base)/storage/
-fs-reload       = %(base)/src/
+# This will autoreload based on python module modifications.
+# The scanning will happen every 3 seconds.
+py-autoreload = 3
 
 safe-pidfile = %(base)/docker/artifacts/addons-server-uwsgi-master.pid
 max-requests = 5000

--- a/docker/uwsgi.ini
+++ b/docker/uwsgi.ini
@@ -8,6 +8,7 @@ module          = olympia.wsgi:application
 master          = true
 # maximum number of worker processes
 processes       = 4
+vaccum          = true
 socket          = :8001
 uid             = olympia
 gid             = olympia

--- a/docker/uwsgi.ini
+++ b/docker/uwsgi.ini
@@ -12,14 +12,14 @@ vaccum          = true
 socket          = :8001
 uid             = olympia
 gid             = olympia
-enable-threads  = true
 memory-report   = true
+enable-threads  = true
 
-# This will autoreload based on python module modifications.
-# The scanning will happen every 3 seconds.
-py-autoreload = 3
-
+# Run watchmedo (via watchdog) to implement unrestricted
+# autoreload capability.
+fs-reload = %(base)/docker/artifacts/
 safe-pidfile = %(base)/docker/artifacts/addons-server-uwsgi-master.pid
+attach-daemon = setsid watchmedo shell-command --patterns="*.py" --recursive --command='/usr/bin/touch %(safe-pidfile)' %(base)
 max-requests = 5000
 
 # Load apps in workers and not only in master


### PR DESCRIPTION
This will scan python modules for modifications every 3 seconds. It most
certainly will still be more efficient than Django's autoreload.

Fixes #11990

![Screenshot from 2019-07-31 19-39-36](https://user-images.githubusercontent.com/139033/62234456-febbd880-b3ca-11e9-8d8a-02e358bad97e.png)
