### PR TITLE
Disable weekly risk recalculation from crontab for now.

### DIFF
--- a/scripts/crontab/crontab.tpl
+++ b/scripts/crontab/crontab.tpl
@@ -40,7 +40,8 @@ HOME=/tmp
 
 # Once per week
 1 9 * * 1 %(django)s review_reports
-0 15 * * 6 %(django)s process_addons --task=constantly_recalculate_post_review_weight
+# Disabled for now, see https://github.com/mozilla/addons-server/issues/11790
+# 0 15 * * 6 %(django)s process_addons --task=constantly_recalculate_post_review_weight
 
 
 # Do not put crons below this line


### PR DESCRIPTION
Refs #11790 

This will need a cherry-pick.