### PR TITLE
Add a Django admin for `YaraResult`

### DIFF
--- a/src/olympia/constants/permissions.py
+++ b/src/olympia/constants/permissions.py
@@ -140,4 +140,6 @@ DJANGO_PERMISSIONS_MAPPING.update({
     'ratings.delete_rating': ADMIN_ADVANCED,
 
     'versions.change_version': ADMIN_ADVANCED,
+
+    'yara.view_yararesult': ADMIN_ADVANCED,
 })

--- a/src/olympia/yara/admin.py
+++ b/src/olympia/yara/admin.py
@@ -1,0 +1,54 @@
+import json
+
+from django.contrib import admin
+from django.utils.html import format_html
+
+from olympia import amo
+from olympia.amo.urlresolvers import reverse
+
+from .models import YaraResult
+
+
+@admin.register(YaraResult)
+class YaraResultAdmin(admin.ModelAdmin):
+    actions = None
+
+    list_display = ('id', 'formatted_addon', 'channel', 'matched_rules')
+    list_select_related = ('version',)
+
+    fields = ('id', 'upload', 'formatted_addon', 'channel',
+              'formatted_matches')
+
+    # Remove the "add" button
+    def has_add_permission(self, request):
+        return False
+
+    # Remove the "delete" button
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    # Read-only mode
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def formatted_addon(self, obj):
+        if obj.version:
+            return format_html(
+                '<a href="{}">{} (version: {})</a>',
+                reverse('reviewers.review', args=[obj.version.addon.slug]),
+                obj.version.addon.name,
+                obj.version.id
+            )
+        return "-"
+    formatted_addon.short_description = 'Add-on'
+
+    def channel(self, obj):
+        if obj.version:
+            return ('listed' if obj.version.channel ==
+                    amo.RELEASE_CHANNEL_LISTED else 'unlisted')
+        return "-"
+    channel.short_description = 'Channel'
+
+    def formatted_matches(self, obj):
+        return format_html('<pre>{}</pre>', json.dumps(obj.matches, indent=4))
+    formatted_matches.short_description = 'Matches'

--- a/src/olympia/yara/admin.py
+++ b/src/olympia/yara/admin.py
@@ -12,6 +12,7 @@ from .models import YaraResult
 @admin.register(YaraResult)
 class YaraResultAdmin(admin.ModelAdmin):
     actions = None
+    view_on_site = False
 
     list_display = ('id', 'formatted_addon', 'channel', 'matched_rules')
     list_select_related = ('version',)

--- a/src/olympia/yara/models.py
+++ b/src/olympia/yara/models.py
@@ -28,4 +28,4 @@ class YaraResult(ModelBase):
 
     @property
     def matched_rules(self):
-        return [m['rule'] for m in self.matches]
+        return [match['rule'] for match in self.matches]

--- a/src/olympia/yara/models.py
+++ b/src/olympia/yara/models.py
@@ -25,3 +25,7 @@ class YaraResult(ModelBase):
             'tags': tags or [],
             'meta': meta or {},
         })
+
+    @property
+    def matched_rules(self):
+        return [m['rule'] for m in self.matches]

--- a/src/olympia/yara/tests/test_admin.py
+++ b/src/olympia/yara/tests/test_admin.py
@@ -16,7 +16,7 @@ class TestYaraResultAdmin(TestCase):
         super().setUp()
 
         self.user = user_factory()
-        self.grant_permission(self.user, '*:*')
+        self.grant_permission(self.user, 'Admin:Advanced')
         self.client.login(email=self.user.email)
         self.list_url = reverse('admin:yara_yararesult_changelist')
 

--- a/src/olympia/yara/tests/test_admin.py
+++ b/src/olympia/yara/tests/test_admin.py
@@ -1,0 +1,94 @@
+import json
+
+from django.contrib.admin.sites import AdminSite
+from django.utils.html import format_html
+
+from olympia import amo
+from olympia.amo.tests import (TestCase, addon_factory, user_factory,
+                               version_factory)
+from olympia.amo.urlresolvers import reverse
+from olympia.yara.admin import YaraResultAdmin
+from olympia.yara.models import YaraResult
+
+
+class TestYaraResultAdmin(TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.user = user_factory()
+        self.grant_permission(self.user, '*:*')
+        self.client.login(email=self.user.email)
+        self.list_url = reverse('admin:yara_yararesult_changelist')
+
+        self.admin = YaraResultAdmin(model=YaraResult, admin_site=AdminSite())
+
+    def test_list_view(self):
+        response = self.client.get(self.list_url)
+        assert response.status_code == 200
+
+    def test_has_add_permission(self):
+        assert self.admin.has_add_permission(request=None) is False
+
+    def test_has_delete_permission(self):
+        assert self.admin.has_delete_permission(request=None) is False
+
+    def test_has_change_permission(self):
+        assert self.admin.has_change_permission(request=None) is False
+
+    def test_formatted_addon(self):
+        addon = addon_factory()
+        version = version_factory(
+            addon=addon,
+            channel=amo.RELEASE_CHANNEL_LISTED
+        )
+        r = YaraResult(version=version)
+
+        assert self.admin.formatted_addon(r) == (
+            '<a href="{}">{} (version: {})</a>'.format(
+                reverse('reviewers.review', args=[addon.slug]),
+                addon.name,
+                version.id
+            )
+        )
+
+    def test_formatted_addon_without_version(self):
+        r = YaraResult(version=None)
+
+        assert self.admin.formatted_addon(r) == '-'
+
+    def test_listed_channel(self):
+        version = version_factory(
+            addon=addon_factory(),
+            channel=amo.RELEASE_CHANNEL_LISTED
+        )
+        r = YaraResult(version=version)
+
+        assert self.admin.channel(r) == 'listed'
+
+    def test_unlisted_channel(self):
+        version = version_factory(
+            addon=addon_factory(),
+            channel=amo.RELEASE_CHANNEL_UNLISTED
+        )
+        r = YaraResult(version=version)
+
+        assert self.admin.channel(r) == 'unlisted'
+
+    def test_channel_without_version(self):
+        r = YaraResult(version=None)
+
+        assert self.admin.channel(r) == '-'
+
+    def test_formatted_matches(self):
+        r = YaraResult()
+        r.add_match(rule='some-rule')
+
+        assert self.admin.formatted_matches(r) == format_html(
+            '<pre>{}</pre>',
+            json.dumps(r.matches, indent=4)
+        )
+
+    def test_formatted_matches_without_matches(self):
+        r = YaraResult()
+
+        assert self.admin.formatted_matches(r) == '<pre>[]</pre>'

--- a/src/olympia/yara/tests/test_admin.py
+++ b/src/olympia/yara/tests/test_admin.py
@@ -26,6 +26,13 @@ class TestYaraResultAdmin(TestCase):
         response = self.client.get(self.list_url)
         assert response.status_code == 200
 
+    def test_list_view_is_restricted(self):
+        user = user_factory()
+        self.grant_permission(user, 'Admin:Curation')
+        self.client.login(email=user.email)
+        response = self.client.get(self.list_url)
+        assert response.status_code == 403
+
     def test_has_add_permission(self):
         assert self.admin.has_add_permission(request=None) is False
 

--- a/src/olympia/yara/tests/test_admin.py
+++ b/src/olympia/yara/tests/test_admin.py
@@ -41,9 +41,9 @@ class TestYaraResultAdmin(TestCase):
             addon=addon,
             channel=amo.RELEASE_CHANNEL_LISTED
         )
-        r = YaraResult(version=version)
+        result = YaraResult(version=version)
 
-        assert self.admin.formatted_addon(r) == (
+        assert self.admin.formatted_addon(result) == (
             '<a href="{}">{} (version: {})</a>'.format(
                 reverse('reviewers.review', args=[addon.slug]),
                 addon.name,
@@ -52,43 +52,43 @@ class TestYaraResultAdmin(TestCase):
         )
 
     def test_formatted_addon_without_version(self):
-        r = YaraResult(version=None)
+        result = YaraResult(version=None)
 
-        assert self.admin.formatted_addon(r) == '-'
+        assert self.admin.formatted_addon(result) == '-'
 
     def test_listed_channel(self):
         version = version_factory(
             addon=addon_factory(),
             channel=amo.RELEASE_CHANNEL_LISTED
         )
-        r = YaraResult(version=version)
+        result = YaraResult(version=version)
 
-        assert self.admin.channel(r) == 'listed'
+        assert self.admin.channel(result) == 'listed'
 
     def test_unlisted_channel(self):
         version = version_factory(
             addon=addon_factory(),
             channel=amo.RELEASE_CHANNEL_UNLISTED
         )
-        r = YaraResult(version=version)
+        result = YaraResult(version=version)
 
-        assert self.admin.channel(r) == 'unlisted'
+        assert self.admin.channel(result) == 'unlisted'
 
     def test_channel_without_version(self):
-        r = YaraResult(version=None)
+        result = YaraResult(version=None)
 
-        assert self.admin.channel(r) == '-'
+        assert self.admin.channel(result) == '-'
 
     def test_formatted_matches(self):
-        r = YaraResult()
-        r.add_match(rule='some-rule')
+        result = YaraResult()
+        result.add_match(rule='some-rule')
 
-        assert self.admin.formatted_matches(r) == format_html(
+        assert self.admin.formatted_matches(result) == format_html(
             '<pre>{}</pre>',
-            json.dumps(r.matches, indent=4)
+            json.dumps(result.matches, indent=4)
         )
 
     def test_formatted_matches_without_matches(self):
-        r = YaraResult()
+        result = YaraResult()
 
-        assert self.admin.formatted_matches(r) == '<pre>[]</pre>'
+        assert self.admin.formatted_matches(result) == '<pre>[]</pre>'

--- a/src/olympia/zadmin/tests/test_views.py
+++ b/src/olympia/zadmin/tests/test_views.py
@@ -68,7 +68,7 @@ class TestHomeAndIndex(TestCase):
         assert response.status_code == 200
         doc = pq(response.content)
         modules = [x.text for x in doc('a.section')]
-        assert len(modules) == 17  # Increment as we add new admin modules.
+        assert len(modules) == 18  # Increment as we add new admin modules.
 
         # Redirected because no permissions if not logged in.
         self.client.logout()


### PR DESCRIPTION
Fixes #11982 

---

I suppose this should be done at the end but I am waiting for #11984, so there we are. A few things:

- the add/edit/delete abilities have been removed
- not sure what else to test on this admin, I did not want to write assertions for HTML given that the admin is read-only for now
- I don't know how to restrict this admin to AMO Admins only (unless it is done already). I know about `has_module_permission` but I don't know what we should be doing here.
- I think we'd need a new permission, eventually. This dashboard should be visible to AMO admins for now but maybe it'd make sense that *I* (and other people in our team) have access to it

You can add some data into the `yara_results` database to try this new admin:

```sql
-- without any version attached and a single match
insert into yara_results (created, modified, upload_id, matches) values (now(), now(), 1, '[{"rule":"dummy-rule","tags":[],"meta":{"description": "desc for dummy-rule"}}]');
-- without any version attached and two matches
insert into yara_results (created, modified, upload_id, matches) values (now(), now(), 2, '[{"rule":"dummy-rule","tags":[],"meta":{"description": "desc for dummy-rule"}}, {"rule":"dummy-rule-2","tags":[],"meta":{"description": "desc for dummy-rule-2"}}]');
-- without any version attached and no matches
insert into yara_results (created, modified, upload_id, matches) values (now(), now(), 3, '[]');
-- with a version attached, no upload and a single match
insert into yara_results (created, modified, matches, version_id) values (now(), now(), '[{"rule":"dummy-rule","tags":[],"meta":{"description": "desc for dummy-rule"}}]', 30);
```

## Screenshots

List view:

<img width="1392" alt="Screen Shot 2019-08-01 at 19 48 45" src="https://user-images.githubusercontent.com/217628/62315496-b4ebf480-b495-11e9-959f-78c103278cad.png">

Detail view:

<img width="1392" alt="Screen Shot 2019-08-01 at 19 25 48" src="https://user-images.githubusercontent.com/217628/62313952-422d4a00-b492-11e9-940f-aa3b76f069b9.png">

<img width="1392" alt="Screen Shot 2019-08-01 at 19 25 51" src="https://user-images.githubusercontent.com/217628/62313953-422d4a00-b492-11e9-904e-8344705f7aab.png">

<img width="1392" alt="Screen Shot 2019-08-01 at 19 25 54" src="https://user-images.githubusercontent.com/217628/62313954-422d4a00-b492-11e9-95f5-43dd69bb6824.png">
