### PR TITLE
 Do not expose heading_text in the discovery pane serializer. 

### DIFF
--- a/docs/topics/api/discovery.rst
+++ b/docs/topics/api/discovery.rst
@@ -39,7 +39,6 @@ Firefox (about:addons).
     :>json int count: The number of results for this query.
     :>json array results: The array containing the results for this query.
     :>json string results[].heading: The heading for this item. May contain some HTML tags.
-    :>json string|null results[].heading_text: The heading for this item. Text-only, content might slightly differ from ``heading`` because of that.
     :>json string|null results[].description: The description for this item, if any. May contain some HTML tags.
     :>json string|null results[].description_text: The description for this item, if any. Text-only, content might slightly differ from ``description`` because of that.
     :>json boolean results[].is_recommendation: If this item was from the recommendation service, rather than static curated content.

--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -332,6 +332,7 @@ v4 API changelog
 * 2019-07-25: added /hero/ endpoint to expose recommended addons and other content to frontend to allow customizable promos https://github.com/mozilla/addons-server/issues/11842.
 * 2019-08-01: added alias ``edition=MozillaOnline`` for ``edition=china`` in /discovery/ endpoint.
 * 2019-08-08: add support for externally hosted addons to /hero/ endpoints.  https://github.com/mozilla/addons-server/issues/11882
+* 2019-08-08: removed ``heading_text`` property from discovery api. https://github.com/mozilla/addons-server/issues/11817
 
 ----------------
 v5 API changelog

--- a/src/olympia/discovery/models.py
+++ b/src/olympia/discovery/models.py
@@ -31,7 +31,8 @@ class DiscoveryItem(OnChangeMixin, ModelBase):
         max_length=255, blank=True,
         help_text='Short text used in the header. Can contain the following '
                   'special tags: {start_sub_heading}, {addon_name}, '
-                  '{end_sub_heading}. Will be translated.')
+                  '{end_sub_heading}. Will be translated. '
+                  'Currently *not* visible to the user - #11817')
     custom_description = models.TextField(
         blank=True, help_text='Longer text used to describe an add-on. Should '
                               'not contain any HTML or special tags. Will be '

--- a/src/olympia/discovery/serializers.py
+++ b/src/olympia/discovery/serializers.py
@@ -50,13 +50,12 @@ class DiscoveryAddonSerializer(AddonSerializer):
 class DiscoverySerializer(serializers.ModelSerializer):
     heading = serializers.CharField()
     description = serializers.CharField()
-    heading_text = serializers.CharField()
     description_text = serializers.CharField()
     addon = DiscoveryAddonSerializer()
     is_recommendation = serializers.SerializerMethodField()
 
     class Meta:
-        fields = ('heading', 'description', 'heading_text', 'description_text',
+        fields = ('heading', 'description', 'description_text',
                   'addon', 'is_recommendation')
         model = DiscoveryItem
 

--- a/src/olympia/discovery/tests/test_views.py
+++ b/src/olympia/discovery/tests/test_views.py
@@ -59,8 +59,10 @@ class DiscoveryTestMixin(object):
 
         assert result['heading'] == item.heading
         assert result['description'] == item.description
-        assert result['heading_text'] == item.heading_text
         assert result['description_text'] == item.description_text
+
+        # https://github.com/mozilla/addons-server/issues/11817
+        assert 'heading_text' not in result
 
         self._check_disco_addon_version(
             result['addon']['current_version'], addon.current_version)


### PR DESCRIPTION
Fixes #11817