### PR TITLE
Preload 'addon' and it's _current_version to avoid unneeded sql queries.

### DIFF
--- a/src/olympia/discovery/admin.py
+++ b/src/olympia/discovery/admin.py
@@ -4,8 +4,10 @@ from django.contrib.admin.widgets import ForeignKeyRawIdWidget
 from django.utils import translation
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
+from django.db.models import Prefetch
 
 from olympia.addons.models import Addon
+from olympia.versions.models import Version
 from olympia.discovery.models import DiscoveryItem
 from olympia.hero.admin import PrimaryHeroInline
 
@@ -81,7 +83,22 @@ class DiscoveryItemAdmin(admin.ModelAdmin):
     raw_id_fields = ('addon',)
     readonly_fields = ('recommended_status', 'previews',)
     view_on_site = False
-    list_select_related = ('primaryhero',)
+
+    def get_queryset(self, request):
+        # Select `primaryhero` and `addon` as well as it's `_current_version`.
+        # We are forced to use `prefetch_related` to ensure transforms
+        # are being run, though, we only care about translations
+        qset = (
+            DiscoveryItem.objects.all()
+            .select_related('primaryhero')
+            .prefetch_related(
+                Prefetch(
+                    'addon',
+                    queryset=(
+                        Addon.unfiltered.all()
+                        .select_related('_current_version')
+                        .only_translations()))))
+        return qset
 
     def formfield_for_foreignkey(self, db_field, request=None, **kwargs):
         if db_field.name == 'addon':

--- a/src/olympia/discovery/admin.py
+++ b/src/olympia/discovery/admin.py
@@ -7,7 +7,6 @@ from django.utils.safestring import mark_safe
 from django.db.models import Prefetch
 
 from olympia.addons.models import Addon
-from olympia.versions.models import Version
 from olympia.discovery.models import DiscoveryItem
 from olympia.hero.admin import PrimaryHeroInline
 


### PR DESCRIPTION
This brings the count down from ~500 queries to <10 queries.

Fixes #12035

![Screenshot from 2019-08-06 08-49-32](https://user-images.githubusercontent.com/139033/62517973-c41dca00-b828-11e9-9c40-4236c710575a.png)

![Screenshot from 2019-08-06 08-53-58](https://user-images.githubusercontent.com/139033/62517983-c718ba80-b828-11e9-96fb-f761c98c71b0.png)
