### PR TITLE
Reduce amount of queries on reviewe page

### DIFF
--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -75,7 +75,7 @@
   <div class="results">
     <div class="results-inner">
       <table id="review-files" class="item-history">
-        {% for version in pager.object_list|reverse %}
+        {% for version in pager.object_list %}
         <tr class="listing-header">
           <th colspan="2">
             {% trans version = version.version, created = version.created|date, version_status = version_status(addon, version) %}

--- a/src/olympia/reviewers/templatetags/jinja_helpers.py
+++ b/src/olympia/reviewers/templatetags/jinja_helpers.py
@@ -19,16 +19,15 @@ from olympia.versions.models import Version
 
 @library.global_function
 def file_compare(file_obj, version):
-    # Compare this file to the one in the version with same platform
-    file_obj = version.files.filter(platform=file_obj.platform)
-    # If not there, just compare to all.
-    if not file_obj:
-        file_obj = version.files.filter(platform=amo.PLATFORM_ALL.id)
-    # At this point we've got no idea what Platform file to
-    # compare with, so just chose the first.
-    if not file_obj:
-        file_obj = version.files.all()
-    return file_obj[0]
+    files = version.all_files
+
+    for file in files:
+        if file.platform == file_obj.platform:
+            return file
+        elif file.platform == amo.PLATFORM_ALL.id:
+            return file
+
+    return files[0]
 
 
 @library.global_function

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -4675,12 +4675,10 @@ class TestReview(ReviewBase):
         assert response.status_code == 200
         assert b'Previously deleted entries' not in response.content
 
-    @patch('olympia.versions.models.Version.transformer')
-    def test_transformer_only_called_once(self, transform_mock):
-        response = self.client.get(self.url)
+    def test_basic_query_count(self):
+        with self.assertNumQueries(11):
+            response = self.client.get(self.url)
         assert response.status_code == 200
-
-        assert transform_mock.call_count == 1
 
 
 @override_flag('code-manager', active=True)

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -4676,7 +4676,10 @@ class TestReview(ReviewBase):
         assert b'Previously deleted entries' not in response.content
 
     def test_basic_query_count(self):
-        with self.assertNumQueries(11):
+        # Partially optimized by
+        # https://github.com/mozilla/addons-server/issues/11797
+        # documented here for futher optimization
+        with self.assertNumQueries(89):
             response = self.client.get(self.url)
         assert response.status_code == 200
 

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -4675,6 +4675,13 @@ class TestReview(ReviewBase):
         assert response.status_code == 200
         assert b'Previously deleted entries' not in response.content
 
+    @patch('olympia.versions.models.Version.transformer')
+    def test_transformer_only_called_once(self, transform_mock):
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+
+        assert transform_mock.call_count == 1
+
 
 @override_flag('code-manager', active=True)
 class TestCodeManagerLinks(ReviewBase):

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -77,18 +77,9 @@ from .decorators import (
     permission_or_tools_view_required, unlisted_addons_reviewer_required)
 
 
-def base_context(**kw):
+def context(**kw):
     ctx = {'motd': get_config('reviewers_review_motd')}
     ctx.update(kw)
-    return ctx
-
-
-def context(request, **kw):
-    admin_reviewer = is_admin_reviewer(request)
-    ctx = {
-        'queue_counts': queue_counts(admin_reviewer=admin_reviewer),
-    }
-    ctx.update(base_context(**kw))
     return ctx
 
 
@@ -107,7 +98,7 @@ def ratings_moderation_log(request):
 
     pager = paginate(request, mod_log, 50)
 
-    data = context(request, form=form, pager=pager)
+    data = context(form=form, pager=pager)
 
     return render(request, 'reviewers/moderationlog.html', data)
 
@@ -139,7 +130,7 @@ def ratings_moderation_log_detail(request, id):
             review.undelete()
         return redirect('reviewers.ratings_moderation_log.detail', id)
 
-    data = context(request, log=log, can_undelete=can_undelete)
+    data = context(log=log, can_undelete=can_undelete)
     return render(request, 'reviewers/moderationlog_detail.html', data)
 
 
@@ -279,7 +270,7 @@ def dashboard(request):
                 expired.count())),
             reverse('reviewers.queue_expired_info_requests')
         )]
-    return render(request, 'reviewers/dashboard.html', base_context(**{
+    return render(request, 'reviewers/dashboard.html', context(**{
         # base_context includes motd.
         'sections': sections
     }))
@@ -339,8 +330,7 @@ def performance(request, user_id=False):
         }
     }
 
-    data = context(request,
-                   monthly_data=json.dumps(monthly_data),
+    data = context(monthly_data=json.dumps(monthly_data),
                    performance_month=performance_total['month'],
                    performance_year=performance_total['year'],
                    breakdown=breakdown, point_total=point_total,
@@ -429,7 +419,7 @@ def _performance_by_month(user_id, months=12, end_month=None, end_year=None):
 def motd(request):
     form = None
     form = MOTDForm(initial={'motd': get_config('reviewers_review_motd')})
-    data = context(request, form=form)
+    data = context(form=form)
     return render(request, 'reviewers/motd.html', data)
 
 
@@ -440,7 +430,7 @@ def save_motd(request):
     if form.is_valid():
         set_config('reviewers_review_motd', form.cleaned_data['motd'])
         return redirect(reverse('reviewers.motd'))
-    data = context(request, form=form)
+    data = context(form=form)
     return render(request, 'reviewers/motd.html', data)
 
 
@@ -472,10 +462,11 @@ def _queue(request, TableObj, tab, qs=None, unlisted=False,
         search_form = None
         is_searching = False
 
+    admin_reviewer = is_admin_reviewer(request)
+
     # Those restrictions will only work with our RawSQLModel, so we need to
     # make sure we're not dealing with a regular Django ORM queryset first.
     if hasattr(qs, 'sql_model'):
-        admin_reviewer = is_admin_reviewer(request)
         if not is_searching and not admin_reviewer:
             qs = filter_admin_review_for_legacy_queue(qs)
 
@@ -492,14 +483,18 @@ def _queue(request, TableObj, tab, qs=None, unlisted=False,
         per_page = REVIEWS_PER_PAGE
     page = paginate(request, table.rows, per_page=per_page, count=qs.count())
     table.set_page(page)
+
+    queue_counts = fetch_queue_counts(admin_reviewer=admin_reviewer)
+
     return render(request, 'reviewers/queue.html',
-                  context(request, table=table, page=page, tab=tab,
+                  context(table=table, page=page, tab=tab,
                           search_form=search_form,
                           point_types=amo.REVIEWED_AMO,
-                          unlisted=unlisted))
+                          unlisted=unlisted,
+                          queue_counts=queue_counts))
 
 
-def queue_counts(admin_reviewer):
+def fetch_queue_counts(admin_reviewer):
     def construct_query_from_sql_model(sqlmodel):
         qs = sqlmodel.objects
 
@@ -583,11 +578,15 @@ def queue_moderated(request):
                     for e in reviews_formset.errors))
         return redirect(reverse('reviewers.queue_moderated'))
 
+    admin_reviewer = is_admin_reviewer(request)
+    queue_counts = fetch_queue_counts(admin_reviewer=admin_reviewer)
+
     return render(request, 'reviewers/queue.html',
-                  context(request, reviews_formset=reviews_formset,
+                  context(reviews_formset=reviews_formset,
                           tab='moderated', page=page, flags=flags,
                           search_form=None,
-                          point_types=amo.REVIEWED_AMO))
+                          point_types=amo.REVIEWED_AMO,
+                          queue_counts=queue_counts))
 
 
 @any_reviewer_required
@@ -935,7 +934,7 @@ def review(request, addon, channel=None):
         user=request.user, addon=addon).exists()
 
     ctx = context(
-        request, actions=actions, actions_comments=actions_comments,
+        actions=actions, actions_comments=actions_comments,
         actions_full=actions_full, addon=addon,
         api_token=request.COOKIES.get(API_TOKEN_COOKIE, None),
         approvals_info=approvals_info, auto_approval_info=auto_approval_info,
@@ -1069,7 +1068,7 @@ def reviewlog(request):
                 Q(user__username__icontains=term)).distinct()
 
     pager = amo.utils.paginate(request, approvals, 50)
-    data = context(request, form=form, pager=pager)
+    data = context(form=form, pager=pager)
     return render(request, 'reviewers/reviewlog.html', data)
 
 
@@ -1080,14 +1079,15 @@ def abuse_reports(request, addon):
     reports = AbuseReport.objects.filter(
         Q(addon=addon) | Q(user__in=developers)).order_by('-created')
     reports = amo.utils.paginate(request, reports)
-    data = context(request, addon=addon, reports=reports)
+    data = context(addon=addon, reports=reports)
     return render(request, 'reviewers/abuse_reports.html', data)
 
 
 @any_reviewer_required
 def leaderboard(request):
-    return render(request, 'reviewers/leaderboard.html', context(
-        request, scores=ReviewerScore.all_users_by_score()))
+    return render(
+        request, 'reviewers/leaderboard.html',
+        context(scores=ReviewerScore.all_users_by_score()))
 
 
 # Permission checks for this view are done inside, depending on type of review

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -930,6 +930,10 @@ def review(request, addon, channel=None):
     user_changes_log = AddonLog.objects.filter(
         activity_log__action__in=user_changes_actions,
         addon=addon).order_by('id')
+
+    subscribed = ReviewerSubscription.objects.filter(
+        user=request.user, addon=addon).exists()
+
     ctx = context(
         request, actions=actions, actions_comments=actions_comments,
         actions_full=actions_full, addon=addon,
@@ -938,9 +942,7 @@ def review(request, addon, channel=None):
         content_review_only=content_review_only, count=count,
         deleted_addon_ids=deleted_addon_ids, flags=flags,
         form=form, is_admin=is_admin, num_pages=num_pages, pager=pager,
-        reports=reports, show_diff=show_diff,
-        subscribed=ReviewerSubscription.objects.filter(
-            user=request.user, addon=addon).exists(),
+        reports=reports, show_diff=show_diff, subscribed=subscribed,
         unlisted=(channel == amo.RELEASE_CHANNEL_UNLISTED),
         user_changes=user_changes_log, user_ratings=user_ratings,
         version=version, whiteboard_form=whiteboard_form,

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -488,32 +488,40 @@ class TestVersion(TestCase):
         addon = Addon.objects.get(id=3615)
         version = addon.current_version
         assert not version.is_ready_for_auto_approval
+        del version.is_ready_for_auto_approval
 
         version.files.all().update(
             status=amo.STATUS_AWAITING_REVIEW, is_webextension=True)
         version.update(channel=amo.RELEASE_CHANNEL_LISTED)
         assert version.is_ready_for_auto_approval
+        del version.is_ready_for_auto_approval
 
         version.files.all().update(is_webextension=False)
         assert not version.is_ready_for_auto_approval
+        del version.is_ready_for_auto_approval
 
         version.files.all().update(is_webextension=True)
         assert version.is_ready_for_auto_approval
+        del version.is_ready_for_auto_approval
 
         # With the auto-approval disabled flag set, it's still considered
         # "ready", even though the auto_approve code won't approve it.
         AddonReviewerFlags.objects.create(
             addon=addon, auto_approval_disabled=False)
         assert version.is_ready_for_auto_approval
+        del version.is_ready_for_auto_approval
 
         addon.update(type=amo.ADDON_THEME)
         assert not version.is_ready_for_auto_approval
+        del version.is_ready_for_auto_approval
 
         addon.update(type=amo.ADDON_LPAPP)
         assert version.is_ready_for_auto_approval
+        del version.is_ready_for_auto_approval
 
         addon.update(type=amo.ADDON_DICT)
         assert version.is_ready_for_auto_approval
+        del version.is_ready_for_auto_approval
 
         version.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
         assert not version.is_ready_for_auto_approval
@@ -525,6 +533,7 @@ class TestVersion(TestCase):
         version.files.all().update(
             status=amo.STATUS_AWAITING_REVIEW, is_webextension=True)
         assert version.is_ready_for_auto_approval
+        del version.is_ready_for_auto_approval
 
         addon.update(status=amo.STATUS_DISABLED)
         assert not version.is_ready_for_auto_approval


### PR DESCRIPTION
Refs #11797 but not necessarily fixes it.

On my tests we're down from ~130 queries to ~89 queries while reducing a few more in some edge-cases.

Unfortunately, to be honest, my debugging skills end here mostly and I can't figure out why version transforms still aren't properly run :disappointed:

Maybe someone else has an idea and is able to improve this number further.