### PR TITLE
Avoid reloading a new Version instance in Version.compatible_apps

### DIFF
--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -361,8 +361,7 @@ class Version(OnChangeMixin, ModelBase):
     @cached_property
     def _compatible_apps(self):
         """Get a mapping of {APP: ApplicationsVersions}."""
-        avs = self.apps.select_related('version')
-        return self._compat_map(avs)
+        return self._compat_map(self.apps.all())
 
     @cached_property
     def compatible_apps_ordered(self):
@@ -501,10 +500,10 @@ class Version(OnChangeMixin, ModelBase):
     def sources_provided(self):
         return bool(self.source)
 
-    @classmethod
-    def _compat_map(cls, avs):
+    def _compat_map(self, avs):
         apps = {}
         for av in avs:
+            av.version = self
             app_id = av.application
             if app_id in amo.APP_IDS:
                 apps[amo.APP_IDS[app_id]] = av
@@ -529,7 +528,8 @@ class Version(OnChangeMixin, ModelBase):
 
         for version in versions:
             v_id = version.id
-            version._compatible_apps = cls._compat_map(av_dict.get(v_id, []))
+            version._compatible_apps = version._compat_map(
+                av_dict.get(v_id, []))
             version.all_files = file_dict.get(v_id, [])
             for f in version.all_files:
                 f.version = version

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -156,6 +156,10 @@ class TestVersion(TestCase):
 
         assert amo.FIREFOX in v.compatible_apps, "Missing Firefox >_<"
 
+        # We should be re-using the same Version instance in
+        # ApplicationsVersions loaded from <Version>._compat_map().
+        assert id(v) == id(v.compatible_apps[amo.FIREFOX].version)
+
     def test_supported_platforms(self):
         v = Version.objects.get(pk=81551)
         assert amo.PLATFORM_ALL in v.supported_platforms


### PR DESCRIPTION
This in turn will avoid reloading a new `Addon` instance when going through `ApplicationsVersions.__str__`, since it ends up calling `self.addon` on the `Version` instance. It's especially noticeable in reviewer tools review page.

Fixes #12041