### PR TITLE
Remove pytest reruns for integration-tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
           name: Start container, verify it's running and start tests
           environment:
             MOZ_HEADLESS: 1
-            PYTEST_ADDOPTS: -k "test_devhub or test_install" -n 4 --reruns 1
+            PYTEST_ADDOPTS: -k "test_devhub or test_install" -n 4
           command: |
             set -x
             sudo sysctl -w vm.max_map_count=262144


### PR DESCRIPTION
Sometimes a test gets rerun but the way the tests are configured, they don't rerun well. Lets just remove this for now.
