### PR TITLE
combine accounts-users-and-ratings job into other jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,9 @@ jobs:
     - { env: TOXENV=docs }
     - { env: TOXENV=assets }
     - { env: TOXENV=es }
-    - { env: TOXENV=addons-versions-and-files }
+    - { env: TOXENV=addons-versions-files-ratings }
     - { env: TOXENV=devhub }
     - { env: TOXENV=reviewers-and-zadmin }
-    - { env: TOXENV=accounts-users-and-ratings }
     - { env: TOXENV=amo-lib-locales-and-signing }
     - { env: TOXENV=main }
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,10 +7,9 @@ envlist =
     docs,
     assets,
     codestyle
-    addons-versions-and-files,
+    addons-versions-files-ratings,
     amo-lib-locales-and-signin,
-    reviewers-and-zadmin,
-    accounts-users-and-ratings,
+    reviewers-and-zadmin
 
 [testenv]
 passenv = *
@@ -33,10 +32,10 @@ commands =
     make install_python_test_dependencies
     pytest -m "es_tests and not needs_locales_compilation and not static_assets" --ignore=tests/ui/ -v src/olympia/{posargs}
 
-[testenv:addons-versions-and-files]
+[testenv:addons-versions-files-ratings]
 commands =
     make install_python_test_dependencies
-    pytest -n 2 -m 'not es_tests and not needs_locales_compilation and not static_assets' -v src/olympia/addons/ src/olympia/versions/ src/olympia/files/ {posargs}
+    pytest -n 2 -m 'not es_tests and not needs_locales_compilation and not static_assets' -v src/olympia/addons/ src/olympia/versions/ src/olympia/files/  src/olympia/ratings/ {posargs}
 
 [testenv:devhub]
 commands =
@@ -55,11 +54,6 @@ commands =
     bash {toxinidir}/locale/compile-mo.sh {toxinidir}/locale/
     pytest -n 2 -m 'needs_locales_compilation' -v src/olympia/ {posargs}
 
-[testenv:accounts-users-and-ratings]
-commands =
-    make install_python_test_dependencies
-    pytest -n 2 -m 'not es_tests and not needs_locales_compilation and not static_assets' -v src/olympia/accounts/ src/olympia/users/ src/olympia/ratings/ {posargs}
-
 [testenv:main]
 commands =
     make install_python_test_dependencies install_node_dependencies
@@ -70,8 +64,7 @@ commands =
         --ignore src/olympia/reviewers/ \
         --ignore src/olympia/ratings/ \
         --ignore src/olympia/amo/ \
-        --ignore src/olympia/users/ \
-        --ignore src/olympia/accounts/ \
+
         --ignore src/olympia/lib/ \
         --ignore src/olympia/signing \
         --ignore src/olympia/versions/ \

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
     ui-tests,
     docs,
     assets,
-    codestyle
+    codestyle,
     addons-versions-files-ratings,
     amo-lib-locales-and-signin,
     reviewers-and-zadmin
@@ -64,7 +64,6 @@ commands =
         --ignore src/olympia/reviewers/ \
         --ignore src/olympia/ratings/ \
         --ignore src/olympia/amo/ \
-
         --ignore src/olympia/lib/ \
         --ignore src/olympia/signing \
         --ignore src/olympia/versions/ \


### PR DESCRIPTION
closes #12116 
I tried combing a few other jobs but there wasn't any particular benefit.  For the mozilla travis jobs they all run at once so the overall time is limited by the slowest job; for our own forks there appears to be a 5 job simultaneous limit, so it's about the combinations of jobs.

base line reference: https://travis-ci.org/eviljeff/olympia/builds/571801374
accounts-users-and-ratings into other jobs: https://travis-ci.org/eviljeff/olympia/builds/571811384

other combinations I tried without success:
https://travis-ci.org/eviljeff/olympia/builds/571914106 (roughly the same time or longer)
https://travis-ci.org/eviljeff/olympia/builds/571926016 (roughly the same time or longer)
https://travis-ci.org/eviljeff/olympia/builds/571820223 (test fails - probably because es_tests don't play well with pytest-xdist)