### PR TITLE
Fix order_by_translation() when translation is on a related model

### DIFF
--- a/src/olympia/translations/tests/testapp/models.py
+++ b/src/olympia/translations/tests/testapp/models.py
@@ -55,3 +55,14 @@ models.signals.pre_save.connect(
     save_signal,
     sender=TranslatedModelWithDefaultNull,
     dispatch_uid='testapp_translatedmodelwithdefaultnull')
+
+
+class ContainsManyToManyToTranslatedModel(ModelBase):
+    things = models.ManyToManyField(
+        TranslatedModel, through='ContainsTranslatedThrough')
+
+
+class ContainsTranslatedThrough(ModelBase):
+    container = models.ForeignKey(
+        ContainsManyToManyToTranslatedModel, on_delete=models.CASCADE)
+    target = models.ForeignKey(TranslatedModel, on_delete=models.CASCADE)


### PR DESCRIPTION
Fixes #12070

We need to pull `get_fallback()` from the model the translated field is, not the model from the queryset. Otherwise if the model with the translated field has no translation in the current language and no translation in english either, it would get filtered out.

This fixes a problem that was happening when sorting add-ons from a collection in the collection addon API: because it does an `order_by_translation()` on `CollectionAddon`, and not `Addon` directly, addons could disappear from the result if they didn't have translations in either the current language or english.