### PR TITLE
fix primary hero background color gradient in django admin

### DIFF
--- a/src/olympia/hero/models.py
+++ b/src/olympia/hero/models.py
@@ -9,7 +9,7 @@ from olympia.amo.models import ModelBase
 from olympia.discovery.models import DiscoveryItem
 
 
-GRADIENT_START_COLOR = ('#2123A', 'ink-80')
+GRADIENT_START_COLOR = ('#20123A', 'ink-80')
 # Before changing these colors think about existing shelves.  We either need a
 # db migration to update them or define a default end color if they're invalid.
 GRADIENT_COLORS = {


### PR DESCRIPTION
fixes #12165 

Going to file a follow-up after discovering that the colour codes aren't actually photon colours anyway!