### PR TITLE
Update `scanners_results` constraints

### DIFF
--- a/src/olympia/constants/scanners.py
+++ b/src/olympia/constants/scanners.py
@@ -1,5 +1,7 @@
 CUSTOMS = 1
+WAT = 2
 
 SCANNERS = [
     (CUSTOMS, 'customs'),
+    (WAT, 'wat'),
 ]

--- a/src/olympia/migrations/1120-change-constraints-on-scanners-table.sql
+++ b/src/olympia/migrations/1120-change-constraints-on-scanners-table.sql
@@ -1,0 +1,8 @@
+ALTER TABLE `scanners_results` DROP FOREIGN KEY `scanners_results_upload_id_9259a7bf_fk_file_uploads_id`;
+ALTER TABLE `scanners_results` DROP FOREIGN KEY `scanners_results_version_id_dd07be31_fk_versions_id`;
+ALTER TABLE `scanners_results` DROP INDEX `upload_id`;
+ALTER TABLE `scanners_results` DROP INDEX `version_id`;
+ALTER TABLE `scanners_results` ADD CONSTRAINT `scanners_results_upload_id_scanner_version_id_ad9eb8a6_uniq` UNIQUE (`upload_id`,`scanner`,`version_id`);
+ALTER TABLE `scanners_results` ADD KEY `scanners_results_version_id_dd07be31_fk_versions_id` (`version_id`);
+ALTER TABLE `scanners_results` ADD CONSTRAINT `scanners_results_upload_id_9259a7bf_fk_file_uploads_id` FOREIGN KEY (`upload_id`) REFERENCES `file_uploads` (`id`);
+ALTER TABLE `scanners_results` ADD CONSTRAINT `scanners_results_version_id_dd07be31_fk_versions_id` FOREIGN KEY (`version_id`) REFERENCES `versions` (`id`);

--- a/src/olympia/scanners/models.py
+++ b/src/olympia/scanners/models.py
@@ -7,16 +7,17 @@ from olympia.files.models import FileUpload
 
 
 class ScannersResult(ModelBase):
-    upload = models.OneToOneField(FileUpload,
-                                  related_name='scanners_results',
-                                  on_delete=models.SET_NULL,
-                                  null=True)
+    upload = models.ForeignKey(FileUpload,
+                               related_name='scanners_results',
+                               on_delete=models.SET_NULL,
+                               null=True)
     results = JSONField(default={})
     scanner = models.PositiveSmallIntegerField(choices=SCANNERS)
-    version = models.OneToOneField('versions.Version',
-                                   related_name='scanners_results',
-                                   on_delete=models.CASCADE,
-                                   null=True)
+    version = models.ForeignKey('versions.Version',
+                                related_name='scanners_results',
+                                on_delete=models.CASCADE,
+                                null=True)
 
     class Meta:
         db_table = 'scanners_results'
+        unique_together = ('upload', 'scanner', 'version',)

--- a/src/olympia/scanners/tests/test_models.py
+++ b/src/olympia/scanners/tests/test_models.py
@@ -1,6 +1,6 @@
 from olympia.amo.tests import TestCase, addon_factory
 
-from olympia.constants.scanners import CUSTOMS
+from olympia.constants.scanners import CUSTOMS, WAT
 from olympia.files.models import FileUpload
 from olympia.scanners.models import ScannersResult
 
@@ -24,3 +24,13 @@ class TestScannersResult(TestCase):
         assert result.scanner == CUSTOMS
         assert result.results == {}
         assert result.version is None
+
+    def test_create_different_entries_for_a_single_upload(self):
+        upload = self.create_file_upload()
+
+        customs_result = ScannersResult.objects.create(upload=upload,
+                                                       scanner=CUSTOMS)
+        wat_result = ScannersResult.objects.create(upload=upload, scanner=WAT)
+
+        assert customs_result.scanner == CUSTOMS
+        assert wat_result.scanner == WAT


### PR DESCRIPTION
Fixes #12174

---

The test case fails without the update on the django model. The SQL allows to sync the existing database (based on the test db output, hat tip @eviljeff).