### PR TITLE
replace empty selection text with "no image selected" in hero admins

### DIFF
--- a/src/olympia/discovery/tests/test_admin.py
+++ b/src/olympia/discovery/tests/test_admin.py
@@ -237,6 +237,7 @@ class TestDiscoveryAdmin(TestCase):
         assert response.status_code == 200
         content = response.content.decode('utf-8')
         assert 'BarFöo' in content
+        assert 'No image selected' in content
         assert PrimaryHero.objects.count() == 0
 
         response = self.client.post(
@@ -527,6 +528,7 @@ class TestSecondaryHeroShelfAdmin(TestCase):
         assert response.status_code == 200
         content = response.content.decode('utf-8')
         assert 'BarFöo' in content
+        assert 'Not selected' in content
 
         shelves = [
             {

--- a/static/css/admin/discovery.css
+++ b/static/css/admin/discovery.css
@@ -82,6 +82,7 @@
 .dynamic-modules .field-icon li div label {
     color: transparent;
     display: block;
+    width: inherit;
 }
 
 .dynamic-modules .field-icon li:first-child div label {


### PR DESCRIPTION
fixes #12161

![screenshot 2019-08-22 13 47 33](https://user-images.githubusercontent.com/768592/63523903-e420df00-c4f2-11e9-897c-9400a382092c.png)

![screenshot 2019-08-22 13 47 30](https://user-images.githubusercontent.com/768592/63523902-e420df00-c4f2-11e9-9177-a2a635f2fded.png)

I changed the icon choice to be "not selected" instead as "no image selected" didn't fit 