### PR TITLE
Add task to run `customs` (over HTTP)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ tmp/*
 # private projects
 addons-yara
 private/
+
+# do not ignore the following files
+!docker-compose.private.yml
+!private/README.md

--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,4 @@ supervisord.pid
 tmp/*
 
 # private projects
-addons-yara
+private/

--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,5 @@ supervisord.pid
 tmp/*
 
 # private projects
+addons-yara
 private/

--- a/docker-compose.private.yml
+++ b/docker-compose.private.yml
@@ -1,0 +1,6 @@
+version: "2.3"
+
+services:
+  customs:
+    build:
+      context: ./private/addons-customs-scanner

--- a/private/README.md
+++ b/private/README.md
@@ -1,0 +1,26 @@
+# Private tools
+
+This folder should contain some of our private tools. In the following, we describe how to use them locally.
+
+## customs
+
+If you have access to `customs`, you should first clone it in `private/addons-customs-scanner`.
+
+Specify the [`docker-compose.private.yml`](../docker-compose.private.yml) file to `docker-compose` (together with the default [`docker-compose.yml`](../docker-compose.yml) file) to build the Docker images:
+
+```
+$ docker-compose -f docker-compose.yml -f docker-compose.private.yml build
+```
+
+Run the local environment with the private services:
+
+```
+$ docker-compose -f docker-compose.yml -f docker-compose.private.yml  up -d
+```
+
+A waffle switch is used to enable/disable the `customs` Celery task:
+
+```
+$ make shell
+$ [root@<docker>:/code#] ./manage.py waffle_switch enable-customs on
+```

--- a/settings.py
+++ b/settings.py
@@ -137,7 +137,7 @@ INBOUND_EMAIL_SECRET_KEY = 'totally-unsecure-secret-string'
 INBOUND_EMAIL_VALIDATION_KEY = 'totally-unsecure-validation-string'
 
 # Sectools
-CUSTOMS_API_URL = 'http://host.docker.internal:10101/'
+CUSTOMS_API_URL = 'http://customs:10101/'
 CUSTOMS_API_KEY = 'customssecret'
 
 # If you have settings you want to overload, put them in a local_settings.py.

--- a/settings.py
+++ b/settings.py
@@ -136,6 +136,10 @@ INBOUND_EMAIL_SECRET_KEY = 'totally-unsecure-secret-string'
 # Validation key we need to send in POST response.
 INBOUND_EMAIL_VALIDATION_KEY = 'totally-unsecure-validation-string'
 
+# Sectools
+CUSTOMS_API_URL = 'http://host.docker.internal:10101/'
+CUSTOMS_API_KEY = 'customssecret'
+
 # If you have settings you want to overload, put them in a local_settings.py.
 try:
     from local_settings import *  # noqa

--- a/src/olympia/devhub/tasks.py
+++ b/src/olympia/devhub/tasks.py
@@ -10,6 +10,7 @@ from copy import deepcopy
 from decimal import Decimal
 from functools import wraps
 from zipfile import BadZipfile
+import waffle
 
 from django.conf import settings
 from django.core.cache import cache
@@ -42,6 +43,7 @@ from olympia.files.utils import (
 from olympia.files.tasks import repack_fileupload
 from olympia.versions.models import Version
 from olympia.devhub import file_validation_annotations as annotations
+from olympia.scanners.tasks import run_customs
 
 
 log = olympia.core.logger.getLogger('z.devhub.task')
@@ -265,6 +267,17 @@ def handle_upload_validation_result(
     """Annotate a set of validation results and save them to the given
     FileUpload instance."""
     upload = FileUpload.objects.get(pk=upload_pk)
+
+    if waffle.switch_is_active('enable-customs') and results['errors'] == 0:
+        # Run customs. This cannot be asynchronous because we have no way to
+        # know whether the task will complete before we attach a `Version` to
+        # it later in the submission process... Because we cannot use `chord`
+        # reliably right now (requires Celery 4.2+), this task is actually not
+        # run as a task, it's a simple function call.
+        #
+        # TODO: use `run_customs` as a task in the submission chord once it is
+        # possible.
+        run_customs(upload.pk)
 
     # Check for API keys in submissions.
     # Make sure it is extension-like, e.g. no search plugin

--- a/src/olympia/devhub/tests/test_tasks.py
+++ b/src/olympia/devhub/tests/test_tasks.py
@@ -1277,3 +1277,59 @@ def test_opensearch_validation_rel_self_url():
         results, fixture_path, channel=amo.RELEASE_CHANNEL_LISTED)
 
     assert results['errors']
+
+
+class TestHandleUploadValidationResult(UploadTest, TestCase):
+    @mock.patch('olympia.devhub.tasks.run_customs')
+    def test_calls_run_customs_with_mock(self, run_customs_mock):
+        self.create_switch('enable-customs', active=True)
+        upload = self.get_upload(
+            abspath=get_addon_file('valid_webextension.xpi'),
+            with_validation=False
+        )
+
+        tasks.handle_upload_validation_result(
+            results=amo.VALIDATOR_SKELETON_RESULTS.copy(),
+            upload_pk=upload.pk,
+            channel=amo.RELEASE_CHANNEL_LISTED,
+            is_mozilla_signed=False
+        )
+
+        assert run_customs_mock.called
+        run_customs_mock.assert_called_with(upload.pk)
+
+    @mock.patch('olympia.devhub.tasks.run_customs')
+    def test_does_not_run_customs_when_validation_has_errors_with_mock(
+            self, run_customs_mock):
+        self.create_switch('enable-customs', active=True)
+        upload = self.get_upload(
+            abspath=get_addon_file('invalid_webextension.xpi'),
+            with_validation=False
+        )
+
+        tasks.handle_upload_validation_result(
+            results=amo.VALIDATOR_SKELETON_EXCEPTION_WEBEXT.copy(),
+            upload_pk=upload.pk,
+            channel=amo.RELEASE_CHANNEL_LISTED,
+            is_mozilla_signed=False
+        )
+
+        assert not run_customs_mock.called
+
+    @mock.patch('olympia.devhub.tasks.run_customs')
+    def test_does_not_run_customs_when_switch_is_off_with_mock(
+            self, run_customs_mock):
+        self.create_switch('enable-customs', active=False)
+        upload = self.get_upload(
+            abspath=get_addon_file('valid_webextension.xpi'),
+            with_validation=False
+        )
+
+        tasks.handle_upload_validation_result(
+            results=amo.VALIDATOR_SKELETON_RESULTS.copy(),
+            upload_pk=upload.pk,
+            channel=amo.RELEASE_CHANNEL_LISTED,
+            is_mozilla_signed=False
+        )
+
+        assert not run_customs_mock.called

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1845,5 +1845,6 @@ AKISMET_REAL_SUBMIT = False
 GEOIP_PATH = '/usr/local/share/GeoIP/GeoLite2-Country.mmdb'
 
 # Sectools
+SCANNER_TIMEOUT = 60  # seconds
 CUSTOMS_API_URL = env('CUSTOMS_API_URL', default=None)
 CUSTOMS_API_KEY = env('CUSTOMS_API_KEY', default=None)

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1094,6 +1094,7 @@ CELERY_TASK_ROUTES = {
     'olympia.devhub.tasks.validate_upload': {'queue': 'devhub'},
     'olympia.files.tasks.repack_fileupload': {'queue': 'devhub'},
     'olympia.lib.akismet.tasks.akismet_comment_check': {'queue': 'devhub'},
+    'olympia.scanners.tasks.run_customs': {'queue': 'devhub'},
 
     # Activity (goes to devhub queue).
     'olympia.activity.tasks.process_email': {'queue': 'devhub'},
@@ -1842,3 +1843,7 @@ AKISMET_API_TIMEOUT = 5
 AKISMET_REAL_SUBMIT = False
 
 GEOIP_PATH = '/usr/local/share/GeoIP/GeoLite2-Country.mmdb'
+
+# Sectools
+CUSTOMS_API_URL = env('CUSTOMS_API_URL', default=None)
+CUSTOMS_API_KEY = env('CUSTOMS_API_KEY', default=None)

--- a/src/olympia/migrations/1124-run-customs-waffle-switch.sql
+++ b/src/olympia/migrations/1124-run-customs-waffle-switch.sql
@@ -1,0 +1,1 @@
+INSERT INTO waffle_switch (name, active, note, created, modified) VALUES ('enable-customs', 0, 'Enable the customs task during submission.', NOW(), NOW());

--- a/src/olympia/scanners/tasks.py
+++ b/src/olympia/scanners/tasks.py
@@ -1,0 +1,80 @@
+import os
+
+import requests
+
+from django.conf import settings
+from django_statsd.clients import statsd
+
+import olympia.core.logger
+
+from olympia.amo.celery import task
+from olympia.constants.scanners import SCANNERS, CUSTOMS
+from olympia.files.models import FileUpload
+
+from .models import ScannersResult
+
+log = olympia.core.logger.getLogger('z.scanners.task')
+
+
+def run_scanner(upload_pk, scanner, api_url, api_key):
+    """
+    Run a scanner on a FileUpload via RPC and store the results.
+    """
+    scanner_name = dict(SCANNERS).get(scanner)
+    log.info('Starting scanner "%s" task for FileUpload %s.', scanner_name,
+             upload_pk)
+
+    upload = FileUpload.objects.get(pk=upload_pk)
+
+    if not upload.path.endswith('.xpi'):
+        log.info('Not running scanner "%s" for FileUpload %s, it is not a xpi '
+                 'file.', scanner_name, upload_pk)
+        return
+
+    try:
+        if not os.path.exists(upload.path):
+            raise ValueError('Path "{}" is not a file or directory or does '
+                             'not exist.' .format(upload.path))
+
+        result = ScannersResult()
+        result.upload = upload
+        result.scanner = scanner
+
+        with statsd.timer('devhub.{}'.format(scanner_name)):
+            headers = {'Authorization': 'Bearer {}'.format(api_key)}
+            with open(upload.path, 'rb') as xpi:
+                response = requests.post(url=api_url,
+                                         files={'xpi': xpi},
+                                         headers=headers)
+
+        results = response.json()
+        if 'error' in results:
+            raise ValueError(results)
+
+        result.results = results
+        result.save()
+
+        log.info('Ending scanner "%s" task for FileUpload %s.', scanner_name,
+                 upload_pk)
+    except Exception:
+        # We log the exception but we do not raise to avoid perturbing the
+        # submission flow.
+        log.exception('Error in scanner "%s" task for FileUpload %s.',
+                      scanner_name, upload_pk)
+
+
+@task
+def run_customs(upload_pk):
+    """
+    Run the customs scanner on a FileUpload and store the results.
+
+    This task is intended to be run as part of the submission process only.
+    When a version is created from a FileUpload, the files are removed. In
+    addition, we usually delete old FileUpload entries after 180 days.
+    """
+    return run_scanner(
+        upload_pk,
+        scanner=CUSTOMS,
+        api_url=settings.CUSTOMS_API_URL,
+        api_key=settings.CUSTOMS_API_KEY
+    )

--- a/src/olympia/scanners/tasks.py
+++ b/src/olympia/scanners/tasks.py
@@ -45,7 +45,8 @@ def run_scanner(upload_pk, scanner, api_url, api_key):
             with open(upload.path, 'rb') as xpi:
                 response = requests.post(url=api_url,
                                          files={'xpi': xpi},
-                                         headers=headers)
+                                         headers=headers,
+                                         timeout=settings.SCANNER_TIMEOUT)
 
         results = response.json()
         if 'error' in results:

--- a/src/olympia/scanners/tests/test_tasks.py
+++ b/src/olympia/scanners/tests/test_tasks.py
@@ -1,0 +1,126 @@
+from unittest import mock
+
+from django.test.utils import override_settings
+
+from olympia.amo.tests import TestCase
+from olympia.constants.scanners import CUSTOMS
+from olympia.files.tests.test_models import UploadTest
+from olympia.scanners.models import ScannersResult
+from olympia.scanners.tasks import run_scanner, run_customs
+
+
+class TestRunScanner(UploadTest, TestCase):
+    FAKE_SCANNER = 1
+    MOCK_SCANNERS = [(FAKE_SCANNER, 'fake-scanner'), ]
+    API_URL = 'http://scanner.example.org'
+    API_KEY = 'api-key'
+
+    def create_response(self, ok=True, data=None):
+        response = mock.Mock(ok=ok)
+        response.json.return_value = data if data else {}
+        return response
+
+    @mock.patch('olympia.scanners.tasks.SCANNERS', MOCK_SCANNERS)
+    def test_skip_non_xpi_files(self):
+        upload = self.get_upload('search.xml')
+
+        run_scanner(
+            upload.pk,
+            scanner=self.FAKE_SCANNER,
+            api_url=self.API_URL,
+            api_key=self.API_KEY
+        )
+
+        assert len(ScannersResult.objects.all()) == 0
+
+    @mock.patch('olympia.scanners.tasks.SCANNERS', MOCK_SCANNERS)
+    @mock.patch('olympia.scanners.tasks.requests.post')
+    def test_run_with_mocks(self, requests_mock):
+        upload = self.get_upload('webextension.xpi')
+        scanner_data = {'some': 'results'}
+        requests_mock.return_value = self.create_response(data=scanner_data)
+        assert len(ScannersResult.objects.all()) == 0
+
+        run_scanner(
+            upload.pk,
+            scanner=self.FAKE_SCANNER,
+            api_url=self.API_URL,
+            api_key=self.API_KEY
+        )
+
+        assert requests_mock.called
+        requests_mock.assert_called_with(
+            url=self.API_URL,
+            files={'xpi': mock.ANY},
+            headers={'Authorization': 'Bearer {}'.format(self.API_KEY)}
+        )
+        result = ScannersResult.objects.all()[0]
+        assert result.upload == upload
+        assert result.scanner == self.FAKE_SCANNER
+        assert result.results == scanner_data
+
+    @mock.patch('olympia.scanners.tasks.SCANNERS', MOCK_SCANNERS)
+    @mock.patch('olympia.scanners.tasks.requests.post')
+    def test_handles_scanner_errors_with_mocks(self, requests_mock):
+        upload = self.get_upload('webextension.xpi')
+        scanner_data = {'error': 'some error'}
+        requests_mock.return_value = self.create_response(data=scanner_data)
+        assert len(ScannersResult.objects.all()) == 0
+
+        run_scanner(
+            upload.pk,
+            scanner=self.FAKE_SCANNER,
+            api_url=self.API_URL,
+            api_key=self.API_KEY
+        )
+
+        assert requests_mock.called
+        assert len(ScannersResult.objects.all()) == 0
+
+    def test_run_does_not_raise(self):
+        upload = self.get_upload('webextension.xpi')
+
+        # This call should not raise even though there will be an error because
+        # `api_url` is `None`.
+        run_scanner(
+            upload.pk,
+            scanner=self.FAKE_SCANNER,
+            api_url=None,
+            api_key='does-not-matter'
+        )
+
+    @mock.patch('olympia.scanners.tasks.SCANNERS', MOCK_SCANNERS)
+    @mock.patch('olympia.scanners.tasks.statsd.timer')
+    @mock.patch('olympia.scanners.tasks.requests.post')
+    def test_calls_statsd_timer(self, requests_mock, timer_mock):
+        upload = self.get_upload('webextension.xpi')
+        requests_mock.return_value = self.create_response()
+
+        run_scanner(
+            upload.pk,
+            scanner=self.FAKE_SCANNER,
+            api_url=self.API_URL,
+            api_key=self.API_KEY
+        )
+
+        assert timer_mock.called
+        scanner_name = dict(self.MOCK_SCANNERS).get(self.FAKE_SCANNER)
+        timer_mock.assert_called_with('devhub.{}'.format(scanner_name))
+
+
+class TestRunCustoms(TestCase):
+    API_URL = 'http://customs.example.org'
+    API_KEY = 'some-api-key'
+
+    @override_settings(CUSTOMS_API_URL=API_URL, CUSTOMS_API_KEY=API_KEY)
+    @mock.patch('olympia.scanners.tasks.run_scanner')
+    def test_calls_run_scanner_with_mock(self, run_scanner_mock):
+        upload_pk = 1234
+
+        run_customs(upload_pk)
+
+        assert run_scanner_mock.called
+        run_scanner_mock.assert_called_once_with(upload_pk,
+                                                 scanner=CUSTOMS,
+                                                 api_url=self.API_URL,
+                                                 api_key=self.API_KEY)

--- a/src/olympia/scanners/tests/test_tasks.py
+++ b/src/olympia/scanners/tests/test_tasks.py
@@ -33,6 +33,7 @@ class TestRunScanner(UploadTest, TestCase):
 
         assert len(ScannersResult.objects.all()) == 0
 
+    @override_settings(SCANNER_TIMEOUT=123)
     @mock.patch('olympia.scanners.tasks.SCANNERS', MOCK_SCANNERS)
     @mock.patch('olympia.scanners.tasks.requests.post')
     def test_run_with_mocks(self, requests_mock):
@@ -52,7 +53,8 @@ class TestRunScanner(UploadTest, TestCase):
         requests_mock.assert_called_with(
             url=self.API_URL,
             files={'xpi': mock.ANY},
-            headers={'Authorization': 'Bearer {}'.format(self.API_KEY)}
+            headers={'Authorization': 'Bearer {}'.format(self.API_KEY)},
+            timeout=123
         )
         result = ScannersResult.objects.all()[0]
         assert result.upload == upload


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/12208

---

~~This is basically #12166 but using HTTP/RPC to run the `customs` scanner.~~

This patch adds a task to run scanners _via_ RPC. It adds the actual code to run `customs` behind a waffle switch. It is synchronous for the moment, because we need to update Celery first. I believe we can safely try this patch in -dev for a while though.

## Try it!

1. clone `customs` locally in `addons-server/private/addons-customs-scanner` and checkout the `functions` branch
2. checkout this patch locally
3. build new docker services:

    ```
    docker-compose -f docker-compose.yml -f docker-compose.private.yml build
    docker-compose -f docker-compose.yml -f docker-compose.private.yml  up -d
    ```

4. run `make update_docker`
5. enable the waffle switch named `enable-customs`:

    ```
    ./manage.py waffle_switch enable-customs on
    ```

6. upload a new xpi and you should have a new entry in the `scanners_results` table shortly after