### PR TITLE
fixed white rectangle is displayed below menu that doesn't have sub menu

### DIFF
--- a/src/olympia/devhub/templates/devhub/nav.html
+++ b/src/olympia/devhub/templates/devhub/nav.html
@@ -28,7 +28,7 @@
         </ul>
       </li>
     {% endif %}
-    <li>
+    <li class="nomenu">
       <a href="https://extensionworkshop.com/?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=devhub-menu-link">
         {{ _('Extension Workshop') }}</a></li>
     <li>

--- a/static/css/restyle/restyle.less
+++ b/static/css/restyle/restyle.less
@@ -450,6 +450,10 @@ body:not(.home) .amo-header,
       width: 200px;
       z-index: 62;
     }
+
+    &.nomenu:hover:after {
+      display: none;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #11122 
This Issue is that white rectangle is displayed below Extension Workshop in some languages.

This problem is that Extension Workshop menu doesn't have sub menu.
But When I put mouse point on Extension Workshop menu, It happen hover effect that doesn't distinguish with the others menu.

**Before(I paint red color instead of white to check)**
![issues-11122-situation](https://user-images.githubusercontent.com/29684524/64059882-83368c80-cbff-11e9-8570-1e8667901c63.png)

**After(fixed)**
![issues-11122-situation_after](https://user-images.githubusercontent.com/29684524/64059926-5b93f400-cc00-11e9-806b-b28f5a770a33.png)
