### PR TITLE
Declare some indexes that already exist on dev/stage/prod in our models

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1588,9 +1588,6 @@ class MigratedLWT(OnChangeMixin, ModelBase):
         db_table = 'migrated_personas'
         indexes = [
             LongNameIndex(
-                fields=('lightweight_theme_id',),
-                name='migrated_personas_lightweight_theme_id_fk_addons_id'),
-            LongNameIndex(
                 fields=('static_theme',),
                 name='migrated_personas_static_theme_id_fk_addons_id'),
             LongNameIndex(

--- a/src/olympia/amo/models.py
+++ b/src/olympia/amo/models.py
@@ -497,3 +497,9 @@ class BasePreview(object):
             except Exception as e:
                 log.error(
                     'Error deleting preview file (%s): %s' % (filename, e))
+
+
+class LongNameIndex(models.Index):
+    """Django's Index, but with a longer allowed name since we don't care about
+    compatibility with Oracle."""
+    max_name_length = 64  # Django default is 30, but MySQL can go up to 64.

--- a/src/olympia/ratings/models.py
+++ b/src/olympia/ratings/models.py
@@ -125,7 +125,7 @@ class Rating(ModelBase):
             models.Index(fields=('user',), name='reviews_ibfk_2'),
             models.Index(fields=('addon',), name='addon_id'),
             models.Index(
-                fields=('reply_to', 'is_latest', 'addon_id', 'created'),
+                fields=('reply_to', 'is_latest', 'addon', 'created'),
                 name='latest_reviews'),
         ]
         constraints = [

--- a/src/olympia/ratings/models.py
+++ b/src/olympia/ratings/models.py
@@ -120,6 +120,18 @@ class Rating(ModelBase):
         # description
         base_manager_name = 'unfiltered'
         ordering = ('-created',)
+        indexes = [
+            models.Index(fields=('version',), name='version_id'),
+            models.Index(fields=('user',), name='reviews_ibfk_2'),
+            models.Index(fields=('addon',), name='addon_id'),
+            models.Index(
+                fields=('reply_to', 'is_latest', 'addon_id', 'created'),
+                name='latest_reviews'),
+        ]
+        constraints = [
+            models.UniqueConstraint(fields=('version', 'user', 'reply_to'),
+                                    name='one_review_per_user'),
+        ]
 
     def __str__(self):
         return truncate(str(self.body), 10)
@@ -326,7 +338,15 @@ class RatingFlag(ModelBase):
 
     class Meta:
         db_table = 'reviews_moderation_flags'
-        unique_together = (('rating', 'user'),)
+        indexes = [
+            models.Index(fields=('user',), name='index_user'),
+            models.Index(fields=('rating',), name='index_review'),
+            models.Index(fields=('modified',), name='index_modified'),
+        ]
+        constraints = [
+            models.UniqueConstraint(fields=('rating', 'user'),
+                                    name='index_review_user')
+        ]
 
 
 class GroupedRating(object):

--- a/src/olympia/reviewers/models.py
+++ b/src/olympia/reviewers/models.py
@@ -453,6 +453,17 @@ class ReviewerScore(ModelBase):
     class Meta:
         db_table = 'reviewer_scores'
         ordering = ('-created',)
+        indexes = [
+            models.Index(fields=('addon_id',),
+                         name='reviewer_scores_addon_id_fk'),
+            models.Index(fields=('created',),
+                         name='reviewer_scores_created_idx'),
+            models.Index(fields=('user_id',),
+                         name='reviewer_scores_user_id_idx'),
+            models.Index(fields=('version_id',),
+                         name='reviewer_scores_version_id'),
+        ]
+ 
 
     @classmethod
     def get_key(cls, key=None, invalidate=False):

--- a/src/olympia/reviewers/models.py
+++ b/src/olympia/reviewers/models.py
@@ -463,7 +463,6 @@ class ReviewerScore(ModelBase):
             models.Index(fields=('version_id',),
                          name='reviewer_scores_version_id'),
         ]
- 
 
     @classmethod
     def get_key(cls, key=None, invalidate=False):

--- a/src/olympia/reviewers/models.py
+++ b/src/olympia/reviewers/models.py
@@ -454,13 +454,13 @@ class ReviewerScore(ModelBase):
         db_table = 'reviewer_scores'
         ordering = ('-created',)
         indexes = [
-            models.Index(fields=('addon_id',),
+            models.Index(fields=('addon',),
                          name='reviewer_scores_addon_id_fk'),
             models.Index(fields=('created',),
                          name='reviewer_scores_created_idx'),
-            models.Index(fields=('user_id',),
+            models.Index(fields=('user',),
                          name='reviewer_scores_user_id_idx'),
-            models.Index(fields=('version_id',),
+            models.Index(fields=('version',),
                          name='reviewer_scores_version_id'),
         ]
 

--- a/src/olympia/stats/models.py
+++ b/src/olympia/stats/models.py
@@ -28,7 +28,7 @@ class DownloadCount(StatsSearchMixin, models.Model):
     class Meta:
         db_table = 'download_counts'
         indexes = [
-            # FIXME: some of these might redundant.
+            # FIXME: some of these might redundant. See #5712
             models.Index(fields=('count',), name='count'),
             models.Index(fields=('addon',), name='addon_id'),
             models.Index(fields=('addon', 'count'), name='addon_and_count'),
@@ -53,7 +53,7 @@ class UpdateCount(StatsSearchMixin, models.Model):
     class Meta:
         db_table = 'update_counts'
         indexes = [
-            # FIXME: some of these might redundant.
+            # FIXME: some of these might redundant. See #5712
             models.Index(fields=('count',), name='count'),
             models.Index(fields=('addon',), name='addon_id'),
             models.Index(fields=('date',), name='date'),

--- a/src/olympia/stats/models.py
+++ b/src/olympia/stats/models.py
@@ -19,34 +19,31 @@ class StatsSearchMixin(SearchMixin):
 
 class DownloadCount(StatsSearchMixin, models.Model):
     id = PositiveAutoField(primary_key=True)
-    # has an index `addon_id` on this column...
     addon = models.ForeignKey('addons.Addon', on_delete=models.CASCADE)
 
-    # has an index named `count` in dev, stage and prod
-    count = models.PositiveIntegerField(db_index=True)
+    count = models.PositiveIntegerField()
     date = models.DateField()
     sources = JSONField(db_column='src', null=True)
 
     class Meta:
         db_table = 'download_counts'
-
-        # additional indices on this table (in dev, stage and prod):
-        # * KEY `addon_and_count` (`addon_id`,`count`)
-        # * KEY `addon_date_idx` (`addon_id`,`date`)
-
-        # in our (dev, stage and prod) database:
-        # UNIQUE KEY `date_2` (`date`,`addon_id`)
-        unique_together = ('date', 'addon')
+        indexes = [
+            # FIXME: some of these might redundant.
+            models.Index(fields=('count',), name='count'),
+            models.Index(fields=('addon',), name='addon_id'),
+            models.Index(fields=('addon', 'count'), name='addon_and_count'),
+            models.Index(fields=('addon', 'date'), name='addon_date_idx')
+        ]
+        constraints = [
+            models.UniqueConstraint(fields=['date', 'addon'], name='date_2'),
+        ]
 
 
 class UpdateCount(StatsSearchMixin, models.Model):
     id = PositiveAutoField(primary_key=True)
-    # Has an index `addon_id` in our dev, stage and prod database
     addon = models.ForeignKey('addons.Addon', on_delete=models.CASCADE)
-    # Has an index named `count` in our dev, stage and prod database
-    count = models.PositiveIntegerField(db_index=True)
-    # Has an index named `date` in our dev, stage and prod database
-    date = models.DateField(db_index=True)
+    count = models.PositiveIntegerField()
+    date = models.DateField()
     versions = JSONField(db_column='version', null=True)
     statuses = JSONField(db_column='status', null=True)
     applications = JSONField(db_column='application', null=True)
@@ -55,7 +52,11 @@ class UpdateCount(StatsSearchMixin, models.Model):
 
     class Meta:
         db_table = 'update_counts'
-
-        # Additional indices on this table (on dev, stage and prod):
-        # * KEY `addon_and_count` (`addon_id`,`count`)
-        # * KEY `addon_date_idx` (`addon_id`,`date`)
+        indexes = [
+            # FIXME: some of these might redundant.
+            models.Index(fields=('count',), name='count'),
+            models.Index(fields=('addon',), name='addon_id'),
+            models.Index(fields=('date',), name='date'),
+            models.Index(fields=('addon', 'count'), name='addon_and_count'),
+            models.Index(fields=('addon', 'date'), name='addon_date_idx')
+        ]

--- a/src/olympia/tags/models.py
+++ b/src/olympia/tags/models.py
@@ -28,6 +28,13 @@ class Tag(ModelBase):
     class Meta:
         db_table = 'tags'
         ordering = ('tag_text',)
+        indexes = [
+            models.Index(fields=('denied', 'num_addons'),
+                         name='tag_blacklisted_num_addons_idx')
+        ]
+        constraints = [
+            models.UniqueConstraint(fields=('tag_text',), name='tag_text')
+        ]
 
     def __str__(self):
         return self.tag_text
@@ -74,6 +81,13 @@ class AddonTag(ModelBase):
 
     class Meta:
         db_table = 'users_tags_addons'
+        indexes = [
+            models.Index(fields=('tag',), name='tag_id'),
+            models.Index(fields=('addon',), name='addon_id'),
+        ]
+        constraints = [
+            models.UniqueConstraint(fields=('tag', 'addon'), name='tag_id_2'),
+        ]
 
 
 def update_tag_stat_signal(sender, instance, **kw):

--- a/src/olympia/translations/models.py
+++ b/src/olympia/translations/models.py
@@ -46,7 +46,9 @@ class Translation(ModelBase):
 
     class Meta:
         db_table = 'translations'
-        unique_together = ('id', 'locale')
+        constraints = [
+            models.UniqueConstraint(fields=('id', 'locale'), name='id'),
+        ]
 
     def __str__(self):
         return (

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -195,6 +195,10 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
 
     class Meta:
         db_table = 'users'
+        indexes = [
+            models.Index(fields=('created',), name='created'),
+            models.Index(fields=('fxa_id',), name='users_fxa_id_index'),
+        ]
 
     def __init__(self, *args, **kw):
         super(UserProfile, self).__init__(*args, **kw)
@@ -622,6 +626,9 @@ class UserNotification(ModelBase):
 
     class Meta:
         db_table = 'users_notifications'
+        indexes = [
+            models.Index(fields=('user',), name='user_id'),
+        ]
 
     @property
     def notification(self):
@@ -929,6 +936,10 @@ class UserHistory(ModelBase):
     class Meta:
         db_table = 'users_history'
         ordering = ('-created',)
+        indexes = [
+            models.Index(fields=('email',), name='users_history_email'),
+            models.Index(fields=('user',), name='users_history_user_idx'),
+        ]
 
 
 @UserProfile.on_change

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -160,9 +160,9 @@ class Version(OnChangeMixin, ModelBase):
         ordering = ['-created', '-modified']
         indexes = [
             models.Index(fields=('version_int',), name='version_int_idx'),
-            models.Index(fields=('addon_id',), name='addon_id'),
+            models.Index(fields=('addon',), name='addon_id'),
             models.Index(fields=('release_notes',), name='versions_ibfk_2'),
-            models.Index(fields=('license_id',), name='license_id'),
+            models.Index(fields=('license',), name='license_id'),
         ]
 
     def __init__(self, *args, **kwargs):

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -26,7 +26,7 @@ from olympia import activity, amo
 from olympia.amo.decorators import use_primary_db
 from olympia.amo.fields import PositiveAutoField
 from olympia.amo.models import (
-    BasePreview, ManagerBase, ModelBase, OnChangeMixin)
+    BasePreview, LongNameIndex, ManagerBase, ModelBase, OnChangeMixin)
 from olympia.amo.urlresolvers import reverse
 from olympia.amo.utils import sorted_groupby, utc_millesecs_from_epoch
 from olympia.applications.models import AppVersion
@@ -158,6 +158,12 @@ class Version(OnChangeMixin, ModelBase):
         # description
         base_manager_name = 'unfiltered'
         ordering = ['-created', '-modified']
+        indexes = [
+            models.Index(fields=('version_int',), name='version_int_idx'),
+            models.Index(fields=('addon_id',), name='addon_id'),
+            models.Index(fields=('release_notes',), name='versions_ibfk_2'),
+            models.Index(fields=('license_id',), name='license_id'),
+        ]
 
     def __init__(self, *args, **kwargs):
         super(Version, self).__init__(*args, **kwargs)
@@ -670,6 +676,12 @@ class VersionPreview(BasePreview, ModelBase):
     class Meta:
         db_table = 'version_previews'
         ordering = ('position', 'created')
+        indexes = [
+            LongNameIndex(fields=('version',),
+                          name='version_previews_version_id_fk_versions_id'),
+            models.Index(fields=('version', 'position', 'created'),
+                         name='version_position_created_idx'),
+        ]
 
     @cached_property
     def caption(self):
@@ -801,6 +813,9 @@ class License(ModelBase):
 
     class Meta:
         db_table = 'licenses'
+        indexes = [
+            models.Index(fields=('builtin',), name='builtin_idx')
+        ]
 
     def __str__(self):
         license = self._constant or self


### PR DESCRIPTION
Part of #10917

This updates ~ half (*) of our models (to match existing schema in dev/stage/prod. The idea is to leverage Django index naming capabilities to avoid migrations as much as possible.

(*) Went through all the tables from `m` to `z`.