### PR TITLE
Display add-on previews as proper thumbnails in abuse report admin

### DIFF
--- a/static/css/admin/abuse_reports.css
+++ b/static/css/admin/abuse_reports.css
@@ -31,3 +31,16 @@ form ul.user_ratings {
     margin-left: 0;
     padding-left: 0;
 }
+.screenshot.thumbnail {
+    border: 3px solid #C9E8F3;
+    float: left;
+    margin-right: 1em;
+    margin-bottom: 1em;
+    height: 150px;
+    width: 200px;
+}
+.screenshot.thumbnail img {
+    display: block;
+    max-height: 150px;
+    max-width: 200px;
+}


### PR DESCRIPTION
We were already referencing a thumbnail, the same used on reviewer tools, but we didn't have the styles in place for that so it was a little too prominent.

**Before:**
![abusethumb-before](https://user-images.githubusercontent.com/187006/64171480-14517180-ce53-11e9-86b1-158a1f13c2cc.png)
**After:**
![abusethumb](https://user-images.githubusercontent.com/187006/64171481-14517180-ce53-11e9-9c89-e7b5af23f1f6.png)


Fixes #11569