### PR TITLE
Display theme images from current version in abuse admin addon card

### DIFF
--- a/src/olympia/abuse/admin.py
+++ b/src/olympia/abuse/admin.py
@@ -364,6 +364,7 @@ class AbuseReportAdmin(CommaSearchInAdminMixin, admin.ModelAdmin):
                 (Rating.without_replies
                     .filter(addon=addon, rating__lte=3, body__isnull=False)
                     .order_by('-created')), 5).page(1),
+            'version': addon.current_version,
         }
         return template.render(context)
     addon_card.short_description = ''

--- a/src/olympia/abuse/tests/test_admin.py
+++ b/src/olympia/abuse/tests/test_admin.py
@@ -20,6 +20,7 @@ from olympia.amo.tests import (
 )
 from olympia.ratings.models import Rating
 from olympia.reviewers.models import AutoApprovalSummary
+from olympia.versions.models import VersionPreview
 
 
 class TestAbuse(TestCase):
@@ -530,6 +531,14 @@ class TestAbuse(TestCase):
         assert len(doc('.reports-and-ratings a[href]'))
         for link in doc('.reports-and-ratings a[href]'):
             assert link.attrib['href'].startswith(settings.EXTERNAL_SITE_URL)
+        return response
+
+    def test_detail_static_theme_report(self):
+        self.addon1.update(type=amo.ADDON_STATICTHEME)
+        VersionPreview.objects.create(version=self.addon1.current_version)
+        response = self.test_detail_addon_report()
+        doc = pq(response.content)
+        assert doc('#addon-theme-previews-wrapper img')
 
     def test_detail_guid_report(self):
         self.detail_url = reverse(


### PR DESCRIPTION
Fixes #11365

Note: the goal isn't to completely emulate reviewer tools, and as such I didn't bother with the "all backgrounds" feature the reviewer tools have. I think just having the previews is enough to identify which theme we're talking about in this page.

**After:**
![abuse_theme_images](https://user-images.githubusercontent.com/187006/64173656-123de180-ce58-11e9-989b-5f0cb75959e9.png)
