### PR TITLE
Allow reviewers to enable/disable auto-approval for dictionaries and search plugins

### DIFF
--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -334,7 +334,7 @@
                   data-toggle-button-selector="#force_disable_addon"
                   id="force_enable_addon" type="button">{{ _('Force-enable add-on') }}</button>
         </li>
-        {% if addon.type in (amo.ADDON_EXTENSION, amo.ADDON_LPAPP) %}
+        {% if addon.type in (amo.ADDON_EXTENSION, amo.ADDON_LPAPP, amo.ADDON_DICT, amo.ADDON_SEARCH) %}
           <li {% if addon.auto_approval_disabled %}class="hidden"{% endif %}>
             <button data-api-url="{{ drf_url('reviewers-addon-flags', addon.pk) }}"
                     data-api-method="patch"

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -3382,6 +3382,22 @@ class TestReview(ReviewBase):
         elem = doc('#enable_auto_approval')[0]
         assert 'hidden' in elem.getparent().attrib.get('class', '')
 
+        # Still present for dictionaries
+        self.addon.update(type=amo.ADDON_DICT)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        assert doc('#disable_auto_approval')
+        assert doc('#enable_auto_approval')
+
+        # And search plugins
+        self.addon.update(type=amo.ADDON_SEARCH)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        assert doc('#disable_auto_approval')
+        assert doc('#enable_auto_approval')
+
         # Both of them should be absent on static themes, which are not
         # auto-approved.
         self.addon.update(type=amo.ADDON_STATICTHEME)


### PR DESCRIPTION
Fixes #9736

Can't use `is_ready_for_auto_approval()` cause it filters out disabled add-ons... 