### PR TITLE
Create stale.yml

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -16,7 +16,7 @@ exemptLabels:
   - "contrib: good first bug"
   - "contrib: welcome"
   - "component: security"
-  - "type: papercut"
+  - "neverstale"
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: true

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -22,10 +22,10 @@ exemptLabels:
 exemptProjects: true
 
 # Set to true to ignore issues in a milestone (defaults to false)
-exemptMilestones: false
+exemptMilestones: true
 
 # Set to true to ignore issues with an assignee (defaults to false)
-exemptAssignees: false
+exemptAssignees: true
 
 # Label to use when marking as stale
 staleLabel: "state: stale"

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,11 +1,11 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 60
+daysUntilStale: 180
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
-daysUntilClose: 7
+daysUntilClose: 14
 
 # Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
 onlyLabels: []
@@ -33,8 +33,8 @@ staleLabel: "state: stale"
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
+  recent activity. If you think this bug should stay open, please comment on 
+  the issue with further details. Thank you for your contributions.
 
 # Comment to post when removing the stale label.
 # unmarkComment: >

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -16,12 +16,13 @@ exemptLabels:
   - "contrib: good first bug"
   - "contrib: welcome"
   - "component: security"
+  - "type: papercut"
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: true
 
 # Set to true to ignore issues in a milestone (defaults to false)
-exemptMilestones: true
+exemptMilestones: false
 
 # Set to true to ignore issues with an assignee (defaults to false)
 exemptAssignees: false

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,62 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 60
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 7
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels: []
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - "contrib: maybe good first bug"
+  - "contrib: good first bug"
+  - "contrib: welcome"
+  - "component: security"
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: true
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: true
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: "state: stale"
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+# closeComment: >
+#   Your comment here.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+# only: issues
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+# pulls:
+#   daysUntilStale: 30
+#   markComment: >
+#     This pull request has been automatically marked as stale because it has not had
+#     recent activity. It will be closed if no further activity occurs. Thank you
+#     for your contributions.
+
+# issues:
+#   exemptLabels:
+#     - confirmed


### PR DESCRIPTION
Fixes  #12288

This patch adds a stale config. Once this is good, this process can be run for all other add-ons repos since probot stale has been enabled on all of them.

Should we add a `state: never-stale` label to the label exemptions list for an explicit opt-out?
