### PR TITLE
fixed nav menu isn’t highlighted with kanji characters in devhub

### DIFF
--- a/src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html
+++ b/src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html
@@ -27,7 +27,7 @@
   <div class="highlight" id="edit-addon-nav">
     <ul class="refinements">
       {% for url, title in urls %}
-        <li {% if url in request.path %}class="selected"{% endif %}>
+        <li {% if url in request.path|urlencode %}class="selected"{% endif %}>
           <a href="{{ url }}">{{ title }}</a></li>
       {% endfor %}
     </ul>

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -304,6 +304,15 @@ class BaseTestEditDescribe(BaseTestEdit):
         self.addon.find_latest_version(None).files.update(is_webextension=True)
         self.test_nav_links()
 
+    def test_nav_links_uri_match(self):
+        self.get_addon().update(slug='모질라')
+
+        response = self.client.get(self.get_addon().get_dev_url())
+        selected_link = (pq(response.content)('#edit-addon-nav').find('li')
+                         .hasClass('selected'))
+
+        assert selected_link is True
+
     def _feature_addon(self, addon_id=3615):
         c_addon = CollectionAddon.objects.create(
             addon_id=addon_id, collection=Collection.objects.create())


### PR DESCRIPTION
Fixes #12157 

This problem not same request.path and url (i.e addon.get_dev_url() value).
I converted `request.path` from iri to uri using urlencode tag.

**Before**
![12157_before](https://user-images.githubusercontent.com/29684524/64425338-5f36e780-d0e6-11e9-8272-d0ab5c66637c.png)

**After**
![12157_after](https://user-images.githubusercontent.com/29684524/64425346-64943200-d0e6-11e9-8c9e-9c0df28576a7.png)

Note)
IRI fully supports international characters.
URI supports only ASCI encoding.