### PR TITLE
Migrations to bring dev/stage/prod columns and constraints closer to django

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1896,7 +1896,6 @@ class Preview(BasePreview, ModelBase):
         ordering = ('position', 'created')
         indexes = [
             models.Index(fields=('addon',), name='addon_id'),
-            models.Index(fields=('caption',), name='previews_ibfk_2'),
             models.Index(fields=('addon', 'position', 'created'),
                          name='addon_position_created_idx'),
         ]

--- a/src/olympia/migrations/1161-migrated-personas.sql
+++ b/src/olympia/migrations/1161-migrated-personas.sql
@@ -1,0 +1,9 @@
+ALTER TABLE `migrated_personas`
+    DROP FOREIGN KEY `migrated_personas_static_theme_id_fk_addons_id`,
+    DROP INDEX `migrated_personas_lightweight_theme_id_fk_addons_id`,
+    CHANGE COLUMN `lightweight_theme_id` `lightweight_theme_id` INT (10) UNSIGNED NOT NULL,
+    CHANGE COLUMN `getpersonas_id` `getpersonas_id` INT (10) UNSIGNED NOT NULL,
+    CHANGE COLUMN `static_theme_id` `static_theme_id` INT (10) UNSIGNED NOT NULL,
+    ADD UNIQUE INDEX `static_theme_id` (`static_theme_id`),
+    ADD INDEX `migrated_personas_static_theme_id_6f4985a7_fk_addons_id` (`static_theme_id`),
+    ADD CONSTRAINT `migrated_personas_static_theme_id_6f4985a7_fk_addons_id` FOREIGN KEY (`static_theme_id`) REFERENCES `addons` (`id`);

--- a/src/olympia/migrations/1162-previews.sql
+++ b/src/olympia/migrations/1162-previews.sql
@@ -1,0 +1,15 @@
+ALTER TABLE `previews`
+    DROP FOREIGN KEY `previews_ibfk_1`,
+    DROP FOREIGN KEY `previews_ibfk_2`,
+    DROP INDEX `previews_ibfk_2`,
+    CHANGE COLUMN `modified` `modified` DATETIME (6) NOT NULL,
+    CHANGE COLUMN `id` `id` INT (10) UNSIGNED NOT NULL AUTO_INCREMENT,
+    CHANGE COLUMN `addon_id` `addon_id` INT (10) UNSIGNED NOT NULL,
+    CHANGE COLUMN `caption` `caption` INT (10) UNSIGNED DEFAULT NULL,
+    CHANGE COLUMN `position` `position` INT (11) NOT NULL,
+    CHANGE COLUMN `created` `created` DATETIME (6) NOT NULL,
+    ADD INDEX `previews_caption_f5d9791a_fk_translations_id` (`caption`),
+    ADD INDEX `previews_addon_id_320f2325_fk_addons_id` (`addon_id`),
+    ADD UNIQUE INDEX `caption` (`caption`),
+    ADD CONSTRAINT `previews_addon_id_320f2325_fk_addons_id` FOREIGN KEY (`addon_id`) REFERENCES `addons` (`id`),
+    ADD CONSTRAINT `previews_caption_f5d9791a_fk_translations_id` FOREIGN KEY (`caption`) REFERENCES `translations` (`id`);

--- a/src/olympia/migrations/1163-replacement_addons.sql
+++ b/src/olympia/migrations/1163-replacement_addons.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `replacement_addons`
+    CHANGE COLUMN `path` `path` VARCHAR (255) DEFAULT NULL,
+    CHANGE COLUMN `created` `created` DATETIME (6) NOT NULL,
+    CHANGE COLUMN `modified` `modified` DATETIME (6) NOT NULL,
+    CHANGE COLUMN `guid` `guid` VARCHAR (255) DEFAULT NULL;

--- a/src/olympia/migrations/1164-review-whiteboard.sql
+++ b/src/olympia/migrations/1164-review-whiteboard.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `review_whiteboard`
+    DROP FOREIGN KEY `addon_id_refs_id_3aa22f51`,
+    ADD CONSTRAINT `review_whiteboard_addon_id_249c0a4a_fk_addons_id` FOREIGN KEY (`addon_id`) REFERENCES `addons` (`id`);

--- a/src/olympia/migrations/1165-reviewer_scores.sql
+++ b/src/olympia/migrations/1165-reviewer_scores.sql
@@ -1,0 +1,11 @@
+ALTER TABLE `reviewer_scores`
+    DROP FOREIGN KEY `reviewer_scores_addon_id_fk`,
+    DROP FOREIGN KEY `reviewer_scores_user_id_fk`,
+    CHANGE COLUMN `id` `id` INT (10) UNSIGNED NOT NULL AUTO_INCREMENT,
+    CHANGE COLUMN `addon_id` `addon_id` INT (10) UNSIGNED DEFAULT NULL,
+    CHANGE COLUMN `created` `created` DATETIME (6) NOT NULL,
+    CHANGE COLUMN `modified` `modified` DATETIME (6) NOT NULL,
+    CHANGE COLUMN `note_key` `note_key` SMALLINT (6) NOT NULL,
+    ADD CONSTRAINT `reviewer_scores_user_id_930c6267_fk_users_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+    ADD CONSTRAINT `reviewer_scores_version_id_0b46ae70_fk_versions_id` FOREIGN KEY (`version_id`) REFERENCES `versions` (`id`),
+    ADD CONSTRAINT `reviewer_scores_addon_id_ccc7c6e4_fk_addons_id` FOREIGN KEY (`addon_id`) REFERENCES `addons` (`id`);

--- a/src/olympia/migrations/1166-reviews_moderation_flags.sql
+++ b/src/olympia/migrations/1166-reviews_moderation_flags.sql
@@ -1,0 +1,10 @@
+ALTER TABLE `reviews_moderation_flags`
+    DROP FOREIGN KEY `reviews_moderation_flags_ibfk_2`,
+    DROP FOREIGN KEY `reviews_moderation_flags_ibfk_1`,
+    CHANGE COLUMN `created` `created` DATETIME (6) NOT NULL,
+    CHANGE COLUMN `modified` `modified` DATETIME (6) NOT NULL,
+    CHANGE COLUMN `review_id` `review_id` INT (10) UNSIGNED NOT NULL,
+    CHANGE COLUMN `flag_name` `flag_name` VARCHAR (64) NOT NULL,
+    CHANGE COLUMN `flag_notes` `flag_notes` VARCHAR (100) NOT NULL,
+    ADD CONSTRAINT `reviews_moderation_flags_user_id_1d97f36e_fk_users_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+    ADD CONSTRAINT `reviews_moderation_flags_review_id_3201518d_fk_reviews_id` FOREIGN KEY (`review_id`) REFERENCES `reviews` (`id`);

--- a/src/olympia/migrations/1167-tags.sql
+++ b/src/olympia/migrations/1167-tags.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `tags`
+    CHANGE COLUMN `modified` `modified` DATETIME (6) NOT NULL,
+    CHANGE COLUMN `id` `id` INT (10) UNSIGNED NOT NULL AUTO_INCREMENT,
+    CHANGE COLUMN `num_addons` `num_addons` INT (11) NOT NULL,
+    CHANGE COLUMN `created` `created` DATETIME (6) NOT NULL;

--- a/src/olympia/migrations/1168-translations_seq.sql
+++ b/src/olympia/migrations/1168-translations_seq.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `translations_seq`
+    CHANGE COLUMN `id` `id` INT (11) NOT NULL,
+    ADD PRIMARY KEY (`id`);

--- a/src/olympia/migrations/1169-users_denied_name.sql
+++ b/src/olympia/migrations/1169-users_denied_name.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `users_denied_name`
+    DROP INDEX `username`,
+    CHANGE COLUMN `created` `created` DATETIME (6) NOT NULL,
+    CHANGE COLUMN `modified` `modified` DATETIME (6) NOT NULL;

--- a/src/olympia/migrations/1170-users_history.sql
+++ b/src/olympia/migrations/1170-users_history.sql
@@ -1,0 +1,8 @@
+ALTER TABLE `users_history`
+    CHANGE COLUMN `user_id` `user_id` INT (11) NOT NULL,
+    CHANGE COLUMN `created` `created` DATETIME (6) NOT NULL,
+    CHANGE COLUMN `modified` `modified` DATETIME (6) NOT NULL,
+    CHANGE COLUMN `id` `id` INT (10) UNSIGNED NOT NULL AUTO_INCREMENT,
+    CHANGE COLUMN `email` `email` VARCHAR (75) NOT NULL,
+    ADD INDEX `users_history_user_id_358ca354_fk_users_id` (`user_id`),
+    ADD CONSTRAINT `users_history_user_id_358ca354_fk_users_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`);

--- a/src/olympia/migrations/1171-users_notifications.sql
+++ b/src/olympia/migrations/1171-users_notifications.sql
@@ -1,0 +1,7 @@
+ALTER TABLE `users_notifications`
+    DROP FOREIGN KEY `users_notifications_ibfk_1`,
+    CHANGE   COLUMN `modified` `modified` DATETIME (6) NOT NULL,
+    CHANGE COLUMN `enabled` `enabled` TINYINT (1) NOT NULL,
+    CHANGE COLUMN `created` `created` DATETIME (6) NOT NULL,
+    ADD INDEX `users_notifications_user_id_d8bb60d3_fk_users_id` (`user_id`),
+    ADD CONSTRAINT `users_notifications_user_id_d8bb60d3_fk_users_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`);

--- a/src/olympia/migrations/1172-users_tags_addons.sql
+++ b/src/olympia/migrations/1172-users_tags_addons.sql
@@ -1,0 +1,11 @@
+ALTER TABLE `users_tags_addons`
+    DROP FOREIGN KEY `users_tags_addons_ibfk_2`,
+    DROP FOREIGN KEY `users_tags_addons_ibfk_3`,
+    CHANGE COLUMN `created` `created` DATETIME (6) NOT NULL,
+    CHANGE COLUMN `modified` `modified` DATETIME (6) NOT NULL,
+    CHANGE COLUMN `addon_id` `addon_id` INT (10) UNSIGNED NOT NULL,
+    CHANGE COLUMN `tag_id` `tag_id` INT (10) UNSIGNED NOT NULL,
+    ADD INDEX `users_tags_addons_tag_id_db2035d3_fk_tags_id` (`tag_id`),
+    ADD INDEX `users_tags_addons_addon_id_3ca01209_fk_addons_id` (`addon_id`),
+    ADD CONSTRAINT `users_tags_addons_addon_id_3ca01209_fk_addons_id` FOREIGN KEY (`addon_id`) REFERENCES `addons` (`id`),
+    ADD CONSTRAINT `users_tags_addons_tag_id_db2035d3_fk_tags_id` FOREIGN KEY (`tag_id`) REFERENCES `tags` (`id`);

--- a/src/olympia/migrations/1173-version_previews.sql
+++ b/src/olympia/migrations/1173-version_previews.sql
@@ -1,0 +1,6 @@
+ALTER TABLE `version_previews`
+    DROP FOREIGN KEY `version_previews_version_id_fk_versions_id`,
+    CHANGE COLUMN `version_id` `version_id` INT (10) UNSIGNED NOT NULL,
+    CHANGE COLUMN `position` `position` INT (11) NOT NULL,
+    ADD INDEX `version_previews_version_id_49b254c1_fk_versions_id` (`version_id`),
+    ADD CONSTRAINT `version_previews_version_id_49b254c1_fk_versions_id` FOREIGN KEY (`version_id`) REFERENCES `versions` (`id`);

--- a/src/olympia/migrations/1174-webext_permissions.sql
+++ b/src/olympia/migrations/1174-webext_permissions.sql
@@ -1,0 +1,8 @@
+ALTER TABLE `webext_permissions`
+    DROP FOREIGN KEY `webext_permissions_file`,
+    CHANGE COLUMN `created` `created` DATETIME (6) NOT NULL,
+    CHANGE COLUMN `modified` `modified` DATETIME (6) NOT NULL,
+    CHANGE COLUMN `permissions` `permissions` LONGTEXT NOT NULL,
+    CHANGE COLUMN `file_id` `file_id` INT (10) UNSIGNED NOT NULL,
+    ADD INDEX `webext_permissions_file_id_a54af0b1_fk_files_id` (`file_id`),
+    ADD CONSTRAINT `webext_permissions_file_id_a54af0b1_fk_files_id` FOREIGN KEY (`file_id`) REFERENCES `files` (`id`);

--- a/src/olympia/migrations/1175-yara-results.sql
+++ b/src/olympia/migrations/1175-yara-results.sql
@@ -1,0 +1,8 @@
+-- Has to be done in 2 ALTER TABLE because we're dropping and re-adding a constraint by the same
+-- name, just to remove the ON DELETE CASCADE bit.
+ALTER TABLE `yara_results`
+    DROP FOREIGN KEY `yara_results_upload_id_5cf355f9_fk_file_uploads_id`,
+    DROP FOREIGN KEY `yara_results_version_id_b32a0f70_fk_versions_id`;
+ALTER TABLE `yara_results`
+    ADD CONSTRAINT `yara_results_upload_id_5cf355f9_fk_file_uploads_id` FOREIGN KEY (`upload_id`) REFERENCES `file_uploads` (`id`),
+    ADD CONSTRAINT `yara_results_version_id_b32a0f70_fk_versions_id` FOREIGN KEY (`version_id`) REFERENCES `versions` (`id`);

--- a/src/olympia/migrations/1176-zadmin_reindexing.sql
+++ b/src/olympia/migrations/1176-zadmin_reindexing.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `zadmin_reindexing` CHANGE COLUMN `start_date` `start_date` DATETIME (6) NOT NULL;


### PR DESCRIPTION
Tables m to z, except for the following which are not included on purpose:
- `translations`, `update_counts`, `users`, `versions`: waiting for next push window so that the migration step of the push doesn't take too much time
- `waffle_flag`, `waffle_flag_groups`, `waffle_flag_users`, `waffle_sample`, `waffle_switch`: since those are coming from the external `waffle` app, need additional investigation into whether they should be done via schematic or via django-migrations

Part of #10917