### PR TITLE
Re-use AddonBrowseVersionSerializer for DraftComment API.

### DIFF
--- a/docs/topics/api/reviewers.rst
+++ b/docs/topics/api/reviewers.rst
@@ -337,7 +337,7 @@ These endpoints allow you to draft comments that can be submitted through the re
     :>json string comment: The comment that is being drafted as part of a review. Specific to a line in a file.
     :>json string|null filename: The filename a specific comment is related to. Can be ``null`` in case a comment doesn't belong to a specific file but the whole version.
     :>json int|null lineno: The line number a specific comment is related to. Please make sure that in case of comments for git diffs, that the `lineno` used here belongs to the file in the version that belongs to `version_id` and not it's parent. Can be ``null`` in case a comment belongs to the whole file and not to a specific line.
-    :>json object version: Object holding the :ref:`version <version-detail-object>`.
+    :>json object version: Object holding the :ref:`version <reviewers-versions-browse-detail>`.
     :>json int user.id: The id for an author.
     :>json string user.name: The name for an author.
     :>json string user.username: The username for an author.

--- a/src/olympia/reviewers/serializers.py
+++ b/src/olympia/reviewers/serializers.py
@@ -361,7 +361,7 @@ class DraftCommentSerializer(serializers.ModelSerializer):
     version = SplitField(
         serializers.PrimaryKeyRelatedField(
             queryset=Version.unfiltered.all()),
-        VersionSerializer())
+        AddonBrowseVersionSerializer())
     canned_response = SplitField(
         serializers.PrimaryKeyRelatedField(
             queryset=CannedResponse.objects.all(),
@@ -374,6 +374,12 @@ class DraftCommentSerializer(serializers.ModelSerializer):
             'id', 'filename', 'lineno', 'comment',
             'version', 'user', 'canned_response'
         )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Set the instance for `AddonBrowseVersionSerializer` which requires
+        # on `instance` being set correctly.
+        self.fields['version'].output.instance = self.context['version']
 
     def validate(self, data):
         if data.get('comment') and data.get('canned_response'):

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -35,7 +35,6 @@ from olympia.accounts.serializers import BaseUserSerializer
 from olympia.activity.models import ActivityLog, DraftComment
 from olympia.addons.models import (
     Addon, AddonApprovalsCounter, AddonReviewerFlags, AddonUser, ReusedGUID)
-from olympia.addons.serializers import VersionSerializer
 from olympia.amo.storage_utils import copy_stored_file
 from olympia.amo.templatetags.jinja_helpers import (
     absolutify, format_date, format_datetime)
@@ -53,7 +52,8 @@ from olympia.reviewers.models import (
     Whiteboard)
 from olympia.reviewers.utils import ContentReviewTable
 from olympia.reviewers.views import _queue
-from olympia.reviewers.serializers import CannedResponseSerializer
+from olympia.reviewers.serializers import (
+    CannedResponseSerializer, AddonBrowseVersionSerializer)
 from olympia.users.models import UserProfile
 from olympia.versions.models import ApplicationsVersions, AppVersion
 from olympia.versions.tasks import extract_version_to_git
@@ -5757,6 +5757,8 @@ class TestDraftCommentViewSet(TestCase):
             name=u'My Addôn', slug='my-addon',
             file_kw={'filename': 'webextension_no_id.xpi'})
 
+        extract_version_to_git(self.addon.current_version.pk)
+
         self.version = self.addon.current_version
         self.version.refresh_from_db()
 
@@ -5798,7 +5800,7 @@ class TestDraftCommentViewSet(TestCase):
             'comment': 'Some really fancy comment',
             'canned_response': None,
             'version': json.loads(json.dumps(
-                VersionSerializer(self.version).data,
+                AddonBrowseVersionSerializer(self.version).data,
                 cls=amo.utils.AMOJSONEncoder)),
             'user': json.loads(json.dumps(
                 BaseUserSerializer(
@@ -5997,7 +5999,7 @@ class TestDraftCommentViewSet(TestCase):
                 CannedResponseSerializer(canned_response).data,
                 cls=amo.utils.AMOJSONEncoder)),
             'version': json.loads(json.dumps(
-                VersionSerializer(self.version).data,
+                AddonBrowseVersionSerializer(self.version).data,
                 cls=amo.utils.AMOJSONEncoder)),
             'user': json.loads(json.dumps(
                 BaseUserSerializer(

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -1442,6 +1442,7 @@ class ReviewAddonVersionDraftCommentViewSet(
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
+        context['version'] = self.get_version_object()
         # Patch in `version` and `user` as those are required by the serializer
         # and not provided by the API client as part of the POST data.
         self.request.data.update(self.get_extra_comment_data())


### PR DESCRIPTION
Fixes #12275
