### PR TITLE
Update 1155-db-schema-download-counts.sql

### DIFF
--- a/src/olympia/migrations/1155-db-schema-download-counts.sql
+++ b/src/olympia/migrations/1155-db-schema-download-counts.sql
@@ -1,3 +1,9 @@
+/* There are some old entries in download_counts where the addon has already been hard-deleted so there is no matching id in addons.
+As we're adding a foreign key constraint to the table we need to first delete the invalid data or the ALTER TABLE fails.*/
+DELETE FROM `download_counts` USING `download_counts`
+    LEFT JOIN `addons` ON `addon_id` = `addons`.`id`
+    WHERE `addons`.`id` IS NULL AND `addon_id` IS NOT NULL;
+
 ALTER TABLE `download_counts`
     MODIFY `addon_id` int(10) unsigned NOT NULL,
     MODIFY `count` int(10) unsigned NOT NULL,


### PR DESCRIPTION
This is the fix I used directly on the dev db to unblock the deploys, but we might need it on stage and prod too.  It's more than 1 or 2 records so makes sense to do it in the migiration.