### PR TITLE
Use XSENDFILE in local dev

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -59,9 +59,6 @@ ALLOWED_HOSTS = ALLOWED_HOSTS + [SERVICES_DOMAIN]
 # Default AMO user id to use for tasks (from users.json fixture in zadmin).
 TASK_USER_ID = 10968
 
-# Set to True if we're allowed to use X-SENDFILE.
-XSENDFILE = False
-
 ALLOW_SELF_REVIEWS = True
 
 AES_KEYS = {

--- a/src/olympia/amo/tests/test_utils_.py
+++ b/src/olympia/amo/tests/test_utils_.py
@@ -16,8 +16,8 @@ from olympia import amo
 from olympia.addons.models import Addon
 from olympia.amo.tests import TestCase, addon_factory
 from olympia.amo.utils import (
-    attach_trans_dict, extract_colors_from_image, get_locale_from_lang,
-    pngcrush_image, utc_millesecs_from_epoch, walkfiles)
+    HttpResponseSendFile, attach_trans_dict, extract_colors_from_image,
+    get_locale_from_lang, pngcrush_image, utc_millesecs_from_epoch, walkfiles)
 
 
 pytestmark = pytest.mark.django_db
@@ -241,3 +241,10 @@ def test_extract_colors_from_image():
         {'h': 40, 'l': 201, 'ratio': 0.05934128722434598, 's': 83}
     ]
     assert extract_colors_from_image(path) == expected
+
+
+class TestHttpResponseSendFile(TestCase):
+    def test_normalizes_path(self):
+        path = '/some/../path/'
+        resp = HttpResponseSendFile(request=None, path=path)
+        assert resp.path == os.path.normpath(path)

--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -746,7 +746,9 @@ class HttpResponseSendFile(HttpResponse):
     def __init__(self, request, path, content=None, status=None,
                  content_type='application/octet-stream', etag=None):
         self.request = request
-        self.path = path
+        # We normalize the path because if it contains dots, nginx will flag
+        # the URI as unsafe when XSENDFILE is used.
+        self.path = os.path.normpath(path)
         super(HttpResponseSendFile, self).__init__('', status=status,
                                                    content_type=content_type)
         header_path = self.path

--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -94,8 +94,6 @@ REDIRECT_URL = 'https://outgoing.stage.mozaws.net/v1/'
 
 ADDONS_LINTER_BIN = 'node_modules/.bin/addons-linter'
 
-XSENDFILE_HEADER = 'X-Accel-Redirect'
-
 ALLOW_SELF_REVIEWS = True
 
 NEWRELIC_ENABLE = env.bool('NEWRELIC_ENABLE', default=False)

--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -76,8 +76,6 @@ NEW_FEATURES = True
 
 ADDONS_LINTER_BIN = 'node_modules/.bin/addons-linter'
 
-XSENDFILE_HEADER = 'X-Accel-Redirect'
-
 NEWRELIC_ENABLE = env.bool('NEWRELIC_ENABLE', default=False)
 
 if NEWRELIC_ENABLE:

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -88,8 +88,6 @@ REDIRECT_URL = 'https://outgoing.stage.mozaws.net/v1/'
 
 ADDONS_LINTER_BIN = 'node_modules/.bin/addons-linter'
 
-XSENDFILE_HEADER = 'X-Accel-Redirect'
-
 ALLOW_SELF_REVIEWS = True
 
 NEWRELIC_ENABLE = env.bool('NEWRELIC_ENABLE', default=False)

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1460,7 +1460,7 @@ UNLINK_SITE_STATS = True
 
 # Set to True if we're allowed to use X-SENDFILE.
 XSENDFILE = True
-XSENDFILE_HEADER = 'X-SENDFILE'
+XSENDFILE_HEADER = 'X-Accel-Redirect'
 
 MOBILE_COOKIE = 'mamo'
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/12313

---

⚠️ This patch requires `addons-nginx` with this patch: https://github.com/mozilla/addons-nginx/pull/15.

You can clone https://github.com/mozilla/addons-nginx, checkout the `sendfile-files` branch and build the image:

```
docker build -t addons/addons-nginx .
```

In addons-server, checkout this branch and re-up the containers.

## How to test it?

Since I was mostly focused on file uploads, one way to test this patch is to:

1. upload a test xpi at http://olympia.test/en-US/developers/addon/submit/upload-listed
2. open a django shell (`make djshell`) and retrieve the latest `FileUpload` download URL:

    ```
    FileUpload.objects.latest().get_authenticated_download_url()
    ```
3. Try to `curl` this URL

Example:

```
 curl -I -L http://olympia.test/files/uploads/9eab71a22f4f4ee99823f462b09caed3/\?access_token\=5LJtPr21fIqWQfNedr3dCm1ZK9MaQZCtnmS408e4
HTTP/1.1 301 Moved Permanently
Date: Tue, 10 Sep 2019 10:09:38 GMT
Content-Type: text/plain; charset=utf-8
Content-Length: 150
Connection: keep-alive
amo-request-id: 4ddd40f6-9f60-444f-977d-9c020466b27d
strict-transport-security: max-age=31536000
x-frame-options: DENY
x-content-type-options: nosniff
x-xss-protection: 1; mode=block
vary: user-agent, Accept
location: /en-US/firefox/files/uploads/9eab71a22f4f4ee99823f462b09caed3/?access_token=5LJtPr21fIqWQfNedr3dCm1ZK9MaQZCtnmS408e4
Vary: User-Agent

HTTP/1.1 200 OK
Server: nginx/1.17.3
Date: Tue, 10 Sep 2019 10:09:40 GMT
Content-Type: application/octet-stream
Content-Length: 14651
Last-Modified: Mon, 09 Sep 2019 16:24:01 GMT
Connection: keep-alive
Accept-Ranges: bytes
```