### PR TITLE
Send download_url to the scanners

### DIFF
--- a/docker-compose.private.yml
+++ b/docker-compose.private.yml
@@ -9,7 +9,17 @@ services:
   customs:
     build:
       context: ./private/addons-customs-scanner
+    environment:
+      - ALLOWED_ORIGIN=http://olympia.test
+      - PORT=10101
+    links:
+      - "nginx:olympia.test"
 
   wat:
     build:
       context: ./private/addons-wat
+    environment:
+      - ALLOWED_ORIGIN=http://olympia.test
+      - PORT=10102
+    links:
+      - "nginx:olympia.test"

--- a/docker-compose.private.yml
+++ b/docker-compose.private.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 
 services:
-  web:
+  worker:
     depends_on:
       - customs
       - wat
@@ -14,6 +14,8 @@ services:
       - PORT=10101
     links:
       - "nginx:olympia.test"
+    depends_on:
+      - web
 
   wat:
     build:
@@ -23,3 +25,5 @@ services:
       - PORT=10102
     links:
       - "nginx:olympia.test"
+    depends_on:
+      - web

--- a/src/olympia/scanners/tests/test_tasks.py
+++ b/src/olympia/scanners/tests/test_tasks.py
@@ -52,8 +52,10 @@ class TestRunScanner(UploadTest, TestCase):
         assert requests_mock.called
         requests_mock.assert_called_with(
             url=self.API_URL,
-            files={'xpi': mock.ANY},
-            headers={'Authorization': 'Bearer {}'.format(self.API_KEY)},
+            json={
+                'api_key': self.API_KEY,
+                'download_url': upload.get_authenticated_download_url(),
+            },
             timeout=123
         )
         result = ScannersResult.objects.all()[0]


### PR DESCRIPTION
Fixes #12236

---

You need to checkout the `aws` branch in the customs repo and the rebuild the `customs` Docker image.


You need to checkout the `functions` branch in the wat repo and the rebuild the `wat` Docker image.

~~⚠️ the `wat` repo has not been updated yet, so it does not work with wat.~~