### PR TITLE
Allow admins to reset API keys for a developer or group of developers

### DIFF
--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -650,6 +650,12 @@ class CREATE_STATICTHEME_FROM_PERSONA(_LOG):
     keep = True
 
 
+class ADMIN_API_KEY_RESET(_LOG):
+    id = 155
+    format = _(u'User {user} api key reset.')
+    admin_event = True
+
+
 LOGS = [x for x in vars().values()
         if isclass(x) and issubclass(x, _LOG) and x != _LOG]
 # Make sure there's no duplicate IDs.

--- a/src/olympia/users/admin.py
+++ b/src/olympia/users/admin.py
@@ -18,6 +18,7 @@ from olympia.activity.models import ActivityLog, UserLog
 from olympia.addons.models import Addon
 from olympia.amo.admin import CommaSearchInAdminMixin
 from olympia.amo.utils import render
+from olympia.api.models import APIKey, APIKeyConfirmation
 from olympia.bandwagon.models import Collection
 from olympia.ratings.models import Rating
 from olympia.zadmin.admin import related_content_link
@@ -61,7 +62,8 @@ class UserAdmin(CommaSearchInAdminMixin, admin.ModelAdmin):
                        'last_known_activity_time', 'ratings_created',
                        'collections_created', 'addons_created', 'activity',
                        'abuse_reports_by_this_user',
-                       'abuse_reports_for_this_user')
+                       'abuse_reports_for_this_user',
+                       'has_active_api_key')
     fieldsets = (
         (None, {
             'fields': ('id', 'email', 'fxa_id', 'username', 'display_name',
@@ -82,11 +84,11 @@ class UserAdmin(CommaSearchInAdminMixin, admin.ModelAdmin):
         ('Admin', {
             'fields': ('last_login', 'last_known_activity_time', 'activity',
                        'last_login_ip', 'known_ip_adresses', 'banned', 'notes',
-                       'bypass_upload_restrictions')
+                       'bypass_upload_restrictions', 'has_active_api_key')
         }),
     )
 
-    actions = ['ban_action']
+    actions = ['ban_action', 'reset_api_key_action']
 
     def get_urls(self):
         def wrap(view):
@@ -96,8 +98,12 @@ class UserAdmin(CommaSearchInAdminMixin, admin.ModelAdmin):
 
         urlpatterns = super(UserAdmin, self).get_urls()
         custom_urlpatterns = [
-            url(r'^(?P<object_id>.+)/ban/$', wrap(self.ban_view),
+            url(r'^(?P<object_id>.+)/ban/$',
+                wrap(self.ban_view),
                 name='users_userprofile_ban'),
+            url(r'^(?P<object_id>.+)/reset_api_key/$',
+                wrap(self.reset_api_key_view),
+                name='users_userprofile_reset_api_key'),
             url(r'^(?P<object_id>.+)/delete_picture/$',
                 wrap(self.delete_picture_view),
                 name='users_userprofile_delete_picture')
@@ -107,13 +113,15 @@ class UserAdmin(CommaSearchInAdminMixin, admin.ModelAdmin):
     def get_actions(self, request):
         actions = super(UserAdmin, self).get_actions(request)
         if not acl.action_allowed(request, amo.permissions.USERS_EDIT):
-            # You need Users:Edit to be able to ban users.
+            # You need Users:Edit to be able to ban users and reset their api
+            # key confirmation.
             actions.pop('ban_action')
+            actions.pop('reset_api_key_action')
         return actions
 
     def change_view(self, request, object_id, form_url='', extra_context=None):
         extra_context = extra_context or {}
-        extra_context['can_ban'] = acl.action_allowed(
+        extra_context['has_users_edit_permission'] = acl.action_allowed(
             request, amo.permissions.USERS_EDIT)
         return super(UserAdmin, self).change_view(
             request, object_id, form_url, extra_context=extra_context,
@@ -150,6 +158,21 @@ class UserAdmin(CommaSearchInAdminMixin, admin.ModelAdmin):
             request, ugettext('The user "%(user)s" has been banned.' % kw))
         return HttpResponseRedirect('../')
 
+    def reset_api_key_view(self, request, object_id, extra_context=None):
+        if request.method != 'POST':
+            return HttpResponseNotAllowed(['POST'])
+
+        obj = self.get_object(request, unquote(object_id))
+        if obj is None:
+            raise Http404()
+
+        if not acl.action_allowed(request, amo.permissions.USERS_EDIT):
+            return HttpResponseForbidden()
+
+        self.reset_api_key_action(request, [obj])
+
+        return HttpResponseRedirect('../')
+
     def delete_picture_view(self, request, object_id, extra_context=None):
         if request.method != 'POST':
             return HttpResponseNotAllowed(['POST'])
@@ -181,6 +204,19 @@ class UserAdmin(CommaSearchInAdminMixin, admin.ModelAdmin):
             request, ugettext('The users "%(users)s" have been banned.' % kw))
     ban_action.short_description = _('Ban selected users')
 
+    def reset_api_key_action(self, request, qs):
+        users = []
+        APIKeyConfirmation.objects.filter(user__in=qs).delete()
+        APIKey.objects.filter(user__in=qs).update(is_active=None)
+        for user in qs:
+            ActivityLog.create(amo.LOG.ADMIN_API_KEY_RESET, user)
+            users.append(force_text(user))
+        kw = {'users': u', '.join(users)}
+        self.message_user(
+            request,
+            ugettext('The users "%(users)s" had their API Key reset.' % kw))
+    reset_api_key_action.short_description = _('Reset API Key')
+
     def picture_img(self, obj):
         return format_html(u'<img src="{}" />', obj.picture_url)
     picture_img.short_description = _(u'Profile Photo')
@@ -202,6 +238,10 @@ class UserAdmin(CommaSearchInAdminMixin, admin.ModelAdmin):
             UserLog.objects.filter(user=obj)
             .values_list('created', flat=True).first())
         return display_for_value(user_log, '')
+
+    def has_active_api_key(self, obj):
+        return obj.api_keys.filter(is_active=True).exists()
+    has_active_api_key.boolean = True
 
     def collections_created(self, obj):
         return related_content_link(obj, Collection, 'author')

--- a/src/olympia/users/templates/admin/users/userprofile/change_form.html
+++ b/src/olympia/users/templates/admin/users/userprofile/change_form.html
@@ -10,10 +10,6 @@
               They have to be *after* the other submit buttons, otherwise they
               could become the default submit button of the page
              {% endcomment %}
-             {% if can_ban %}
-                 <button formaction="{% url 'admin:users_userprofile_ban' original.pk|admin_urlquote %}"
-                         type="submit">{% trans "Ban" %}</button>
-             {% endif %}
              {% if has_users_edit_permission %}
                  <button formaction="{% url 'admin:users_userprofile_ban' original.pk|admin_urlquote %}"
                          type="submit">{% trans "Ban" %}</button>

--- a/src/olympia/users/templates/admin/users/userprofile/change_form.html
+++ b/src/olympia/users/templates/admin/users/userprofile/change_form.html
@@ -14,6 +14,12 @@
                  <button formaction="{% url 'admin:users_userprofile_ban' original.pk|admin_urlquote %}"
                          type="submit">{% trans "Ban" %}</button>
              {% endif %}
+             {% if has_users_edit_permission %}
+                 <button formaction="{% url 'admin:users_userprofile_ban' original.pk|admin_urlquote %}"
+                         type="submit">{% trans "Ban" %}</button>
+                 <button formaction="{% url 'admin:users_userprofile_reset_api_key' original.pk|admin_urlquote %}"
+                         type="submit">{% trans "Reset API Key" %}</button>
+             {% endif %}
              <button formaction="{% url 'admin:users_userprofile_delete_picture' original.pk|admin_urlquote %}"
                      type="submit">{% trans "Delete picture" %}</button>
         </div>

--- a/src/olympia/users/tests/test_admin.py
+++ b/src/olympia/users/tests/test_admin.py
@@ -19,6 +19,7 @@ from olympia.addons.models import AddonUser
 from olympia.amo.tests import (
     addon_factory, collection_factory, TestCase, user_factory, version_factory)
 from olympia.amo.urlresolvers import reverse
+from olympia.api.models import APIKey, APIKeyConfirmation
 from olympia.bandwagon.models import Collection
 from olympia.ratings.models import Rating
 from olympia.reviewers.models import ReviewerScore
@@ -218,7 +219,9 @@ class TestUserAdmin(TestCase):
 
         request.user = user_factory()
         self.grant_permission(request.user, 'Users:Edit')
-        assert list(user_admin.get_actions(request).keys()) == ['ban_action']
+        assert list(user_admin.get_actions(request).keys()) == [
+            'ban_action', 'reset_api_key_action'
+        ]
 
     def test_ban_action(self):
         another_user = user_factory()
@@ -254,6 +257,57 @@ class TestUserAdmin(TestCase):
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 200
         assert ban_url in response.content.decode('utf-8')
+
+    def test_reset_api_key_action(self):
+        another_user = user_factory()
+        a_third_user = user_factory()
+
+        APIKey.objects.create(user=self.user, is_active=True, key='foo')
+        APIKeyConfirmation.objects.create(user=self.user)
+
+        APIKeyConfirmation.objects.create(user=another_user)
+
+        APIKey.objects.create(user=a_third_user, is_active=True, key='bar')
+        APIKeyConfirmation.objects.create(user=a_third_user)
+
+        users = UserProfile.objects.filter(
+            pk__in=(another_user.pk, self.user.pk))
+        user_admin = UserAdmin(UserProfile, admin.site)
+        request = RequestFactory().get('/')
+        request.user = user_factory()
+        core.set_user(request.user)
+        request._messages = default_messages_storage(request)
+        user_admin.reset_api_key_action(request, users)
+        # APIKeys should have been deactivated, APIKeyConfirmation deleted.
+        assert self.user.api_keys.exists()
+        assert not self.user.api_keys.filter(is_active=True).exists()
+        assert not APIKeyConfirmation.objects.filter(user=self.user).exists()
+
+        # This user didn't have api keys before, it shouldn't matter.
+        assert not another_user.api_keys.exists()
+        assert not another_user.api_keys.filter(is_active=True).exists()
+        assert not APIKeyConfirmation.objects.filter(
+            user=another_user).exists()
+
+        # The 3rd user should be unaffected.
+        assert a_third_user.api_keys.exists()
+        assert a_third_user.api_keys.filter(is_active=True).exists()
+        assert APIKeyConfirmation.objects.filter(user=a_third_user).exists()
+
+        # We should see 2 activity logs.
+        assert ActivityLog.objects.filter(
+            action=amo.LOG.ADMIN_API_KEY_RESET.id).count() == 2
+
+    def test_reset_api_key_button_in_change_view(self):
+        reset_api_key_url = reverse(
+            'admin:users_userprofile_reset_api_key', args=(self.user.pk, ))
+        user = user_factory()
+        self.grant_permission(user, 'Admin:Tools')
+        self.grant_permission(user, 'Users:Edit')
+        self.client.login(email=user.email)
+        response = self.client.get(self.detail_url, follow=True)
+        assert response.status_code == 200
+        assert reset_api_key_url in response.content.decode('utf-8')
 
     def test_delete_picture_button_in_change_view(self):
         delete_picture_url = reverse('admin:users_userprofile_delete_picture',
@@ -295,6 +349,43 @@ class TestUserAdmin(TestCase):
         alog = ActivityLog.objects.latest('pk')
         assert alog.action == amo.LOG.ADMIN_USER_BANNED.id
         assert alog.arguments == [self.user]
+
+    def test_reset_api_key(self):
+        APIKey.objects.create(user=self.user, is_active=True, key='foo')
+        APIKeyConfirmation.objects.create(user=self.user)
+
+        reset_api_key_url = reverse(
+            'admin:users_userprofile_reset_api_key', args=(self.user.pk, ))
+        wrong_reset_api_key_url = reverse(
+            'admin:users_userprofile_reset_api_key', args=(self.user.pk + 9, ))
+        user = user_factory()
+        self.grant_permission(user, 'Admin:Tools')
+        self.client.login(email=user.email)
+        core.set_user(user)
+        response = self.client.post(reset_api_key_url, follow=True)
+        assert response.status_code == 403
+        self.grant_permission(user, 'Users:Edit')
+        response = self.client.get(reset_api_key_url, follow=True)
+        assert response.status_code == 405  # Wrong http method.
+        response = self.client.post(wrong_reset_api_key_url, follow=True)
+        assert response.status_code == 404  # Wrong pk.
+
+        assert self.user.api_keys.filter(is_active=True).exists()
+        assert APIKeyConfirmation.objects.filter(user=self.user).exists()
+
+        response = self.client.post(reset_api_key_url, follow=True)
+        assert response.status_code == 200
+        assert response.redirect_chain[-1][0].endswith(self.detail_url)
+        assert response.redirect_chain[-1][1] == 302
+
+        alog = ActivityLog.objects.latest('pk')
+        assert alog.action == amo.LOG.ADMIN_API_KEY_RESET.id
+        assert alog.arguments == [self.user]
+
+        # APIKeys should have been deactivated, APIKeyConfirmation deleted.
+        assert self.user.api_keys.exists()
+        assert not self.user.api_keys.filter(is_active=True).exists()
+        assert not APIKeyConfirmation.objects.filter(user=self.user).exists()
 
     @mock.patch.object(UserProfile, 'delete_picture')
     def test_delete_picture(self, delete_picture_mock):


### PR DESCRIPTION
This includes the API Credentials Confirmation state, so any affected developers will have to go through the email confirmation again.

Fixes #12280