### PR TITLE
Cleanup HttpResponseSendFile and remove XSENDFILE config param

### DIFF
--- a/settings_test.py
+++ b/settings_test.py
@@ -56,9 +56,6 @@ TASK_USER_ID = 1337
 ES_DEFAULT_NUM_REPLICAS = 0
 ES_DEFAULT_NUM_SHARDS = 1
 
-# Set to True if we're allowed to use X-SENDFILE.
-XSENDFILE = True
-
 # Don't enable the signing by default in tests, many would fail trying to sign
 # empty or bad zip files, or try posting to the endpoints. We don't want that.
 SIGNING_SERVER = ''

--- a/src/olympia/amo/tests/test_utils_.py
+++ b/src/olympia/amo/tests/test_utils_.py
@@ -5,6 +5,7 @@ import tempfile
 
 from django.conf import settings
 from django.utils.functional import cached_property
+from django.utils.http import quote_etag
 
 import freezegun
 from unittest import mock
@@ -247,4 +248,9 @@ class TestHttpResponseSendFile(TestCase):
     def test_normalizes_path(self):
         path = '/some/../path/'
         resp = HttpResponseSendFile(request=None, path=path)
-        assert resp.path == os.path.normpath(path)
+        assert resp[settings.XSENDFILE_HEADER] == os.path.normpath(path)
+
+    def test_adds_etag_header(self):
+        etag = '123'
+        resp = HttpResponseSendFile(request=None, path='/', etag=etag)
+        assert resp['ETag'] == quote_etag(etag)

--- a/src/olympia/files/tests/test_views.py
+++ b/src/olympia/files/tests/test_views.py
@@ -750,7 +750,6 @@ class TestServeFileUpload(UploadTest, TestCase):
 
         assert resp.status_code == 403
 
-    @override_settings(XSENDFILE=True)
     def test_get(self):
         resp = self.client.get(self.upload.get_authenticated_download_url())
 

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1458,8 +1458,7 @@ VALIDATOR_MESSAGE_LIMIT = 500
 # Feature flags
 UNLINK_SITE_STATS = True
 
-# Set to True if we're allowed to use X-SENDFILE.
-XSENDFILE = True
+# See: https://www.nginx.com/resources/wiki/start/topics/examples/xsendfile/
 XSENDFILE_HEADER = 'X-Accel-Redirect'
 
 MOBILE_COOKIE = 'mamo'

--- a/src/olympia/versions/tests/test_views.py
+++ b/src/olympia/versions/tests/test_views.py
@@ -355,7 +355,6 @@ class TestDownloadsLatest(TestDownloadsBase):
         self.assert_served_locally(self.client.get(url), file_=f)
 
 
-@override_settings(XSENDFILE=True)
 class TestDownloadSource(TestCase):
     fixtures = ['base/addon_3615', 'base/admin']
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/12314

---

This patch:

- removes the `XSENDFILE` config parameter
- removes the logic to stream the content of an `HttpResponseSendFile`
when `XSENDFILE = False`
- adds a new test case for `HttpResponseSendFile`
- removes some more code in `HttpResponseSendFile`, which I think is not
needed. According to this code:
https://github.com/django/django/blob/b616908ce1ad46457c4b49fe098320bb27e09581/django/http/response.py#L107-L137,
Django automatically does the conversion and it uses
[`email.header.Header`](https://docs.python.org/3/library/email.header.html#email.header.Header)
to mime encode the value of the header