### PR TITLE
Move fileupload url to a different url pattern

### DIFF
--- a/src/olympia/files/urls.py
+++ b/src/olympia/files/urls.py
@@ -24,6 +24,11 @@ urlpatterns = [
     url(r'^browse/(?P<file_id>\d+)/', include(file_patterns)),
     url(r'^compare/(?P<one_id>\d+)\.{3}(?P<two_id>\d+)/',
         include(compare_patterns)),
-    url(r'^uploads/(?P<uuid>[0-9a-f]{32})/', views.serve_file_upload,
+]
+
+# This set of URL patterns is not included under `/files/` in
+# `src/olympia/urls.py`:
+upload_patterns = [
+    url(r'^file/(?P<uuid>[0-9a-f]{32})/', views.serve_file_upload,
         name='files.serve_file_upload'),
 ]

--- a/src/olympia/urls.py
+++ b/src/olympia/urls.py
@@ -9,6 +9,7 @@ from django.views.static import serve as serve_static
 from olympia.amo.urlresolvers import reverse
 from olympia.amo.utils import urlparams
 from olympia.amo.views import frontend_view
+from olympia.files.urls import upload_patterns
 from olympia.versions import views as version_views
 from olympia.versions.urls import download_patterns
 
@@ -42,6 +43,9 @@ urlpatterns = [
 
     # Files
     url(r'^files/', include('olympia.files.urls')),
+    # Do not expose the `upload_patterns` under `files/` because of this issue:
+    # https://github.com/mozilla/addons-server/issues/12322
+    url(r'^uploads/', include(upload_patterns)),
 
     # Downloads.
     url(r'^downloads/', include(download_patterns)),


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/12322

---

This patch creates a new set of URL patterns in the `files` package so that we can include it under a different URL prefix.