### PR TITLE
Make fewer SQL queries in reviewer pages displaying abuse reports

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1218,7 +1218,7 @@ class Addon(OnChangeMixin, ModelBase):
         return not self.is_deleted
 
     def has_listed_versions(self):
-        return self.versions.filter(
+        return self.current_version or self.versions.filter(
             channel=amo.RELEASE_CHANNEL_LISTED).exists()
 
     def has_unlisted_versions(self):

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1218,7 +1218,7 @@ class Addon(OnChangeMixin, ModelBase):
         return not self.is_deleted
 
     def has_listed_versions(self):
-        return self.current_version or self.versions.filter(
+        return self._current_version_id or self.versions.filter(
             channel=amo.RELEASE_CHANNEL_LISTED).exists()
 
     def has_unlisted_versions(self):

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -1735,7 +1735,7 @@ class TestHasListedAndUnlistedVersions(TestCase):
     def test_has_listed_versions_current_version_shortcut(self):
         # We shouldn't even do a exists() query if the add-on has a
         # current_version.
-        self.addon._current_version = Version()
+        self.addon._current_version_id = 123
         assert self.addon.has_listed_versions()
 
 

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -1732,6 +1732,12 @@ class TestHasListedAndUnlistedVersions(TestCase):
         assert self.addon.has_listed_versions()
         assert self.addon.has_unlisted_versions()
 
+    def test_has_listed_versions_current_version_shortcut(self):
+        # We shouldn't even do a exists() query if the add-on has a
+        # current_version.
+        self.addon._current_version = Version()
+        assert self.addon.has_listed_versions()
+
 
 class TestAddonNomination(TestCase):
     fixtures = ['base/addon_3615']

--- a/src/olympia/reviewers/templates/reviewers/abuse_reports.html
+++ b/src/olympia/reviewers/templates/reviewers/abuse_reports.html
@@ -8,8 +8,12 @@
   <hgroup>
     <h2>{{_('Abuse Reports for {addon} and its developers ({num})')|format_html(addon=addon.name, num=reports.paginator.count|numberfmt) }}</h2>
   </hgroup>
-  {% include 'reviewers/addon_details_box.html' %}
+  {% with reports=None %}
+    {# Include the addon details box, but without the abuse reports as we show them below #}
+    {% include 'reviewers/addon_details_box.html' %}
+  {% endwith %}
   <h3>{{ _('Abuse Reports') }}</h3>
+  {{ reports|paginator }}
   {% include "reviewers/includes/abuse_reports_list.html" %}
   {{ reports|paginator }}
 {% endblock %}

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -2812,6 +2812,7 @@ class TestReview(ReviewBase):
 
     def test_needs_unlisted_reviewer_for_only_unlisted(self):
         self.addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        self.addon.update_version()
         assert self.client.head(self.url).status_code == 404
         self.grant_permission(self.reviewer, 'Addons:ReviewUnlisted')
         assert self.client.head(self.url).status_code == 200
@@ -5820,8 +5821,8 @@ class TestReviewAddonVersionViewSetList(TestCase):
             addon=self.addon, channel=amo.RELEASE_CHANNEL_UNLISTED)
 
         # We have a .only() and .no_transforms or .only_translations
-        # querysets which reduces the amount of queries to "only" 11
-        with self.assertNumQueries(11):
+        # querysets which reduces the amount of queries to "only" 10
+        with self.assertNumQueries(10):
             response = self.client.get(self.url)
 
         assert response.status_code == 200


### PR DESCRIPTION
In addition, in the abuse reports view itself, prevent showing the abuse reports twice and display theme images from current version.

Fixes https://github.com/mozilla/addons-server/issues/12321
Fixes https://github.com/mozilla/addons-server/issues/11775
Fixes https://github.com/mozilla/addons-server/issues/11365
Helps https://github.com/mozilla/addons-server/issues/12043