### PR TITLE
Eliminate a few duplicate queries in reviewer tools

### DIFF
--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -75,7 +75,7 @@
   <div class="results">
     <div class="results-inner">
       <table id="review-files" class="item-history">
-        {% for version in pager.object_list|reverse %}
+        {% for version in pager.object_list %}
         <tr class="listing-header">
           <th colspan="2">
             {% trans version = version.version, created = version.created|date, version_status = version_status(addon, version) %}

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -1,7 +1,7 @@
 import json
 import time
 
-from collections import OrderedDict, defaultdict
+from collections import OrderedDict
 from datetime import date, datetime, timedelta
 
 from django import http
@@ -629,49 +629,6 @@ def queue_expired_info_requests(request):
                   qs=qs, SearchForm=None)
 
 
-def _get_comments_for_hard_deleted_versions(addon):
-    """Versions are soft-deleted now but we need to grab review history for
-    older deleted versions that were hard-deleted so the only record we have
-    of them is in the review log.  Hard deletion was pre Feb 2016.
-
-    We don't know if they were unlisted or listed but given the time overlap
-    they're most likely listed so we assume that."""
-    class PseudoVersion(object):
-        def __init__(self):
-            self.all_activity = []
-
-        all_files = ()
-        approval_notes = None
-        compatible_apps_ordered = ()
-        release_notes = None
-        status = 'Deleted'
-        deleted = True
-        channel = amo.RELEASE_CHANNEL_LISTED
-        is_ready_for_auto_approval = False
-
-        @property
-        def created(self):
-            return self.all_activity[0].created
-
-        @property
-        def version(self):
-            return (self.all_activity[0].activity_log
-                        .details.get('version', '[deleted]'))
-
-    comments = (CommentLog.objects
-                .filter(activity_log__action__in=amo.LOG_REVIEW_QUEUE,
-                        activity_log__versionlog=None,
-                        activity_log__addonlog__addon=addon)
-                .order_by('created')
-                .select_related('activity_log'))
-
-    comment_versions = defaultdict(PseudoVersion)
-    for c in comments:
-        c.version = c.activity_log.details.get('version', c.created)
-        comment_versions[c.version].all_activity.append(c)
-    return list(comment_versions.values())
-
-
 def perform_review_permission_checks(
         request, addon, channel, content_review_only=False):
     """Perform the permission checks needed by the review() view or anything
@@ -876,25 +833,24 @@ def review(request, addon, channel=None):
     # the comments form).
     actions_comments = [k for (k, a) in actions if a.get('comments', True)]
 
-    versions = (Version.unfiltered.filter(addon=addon, channel=channel)
-                                  .select_related('autoapprovalsummary')
-                                  .order_by('-created')
-                                  .transform(Version.transformer_activity)
-                                  .transform(Version.transformer))
-
-    # We assume comments on old deleted versions are for listed versions.
-    # See _get_comments_for_hard_deleted_versions above for more detail.
-    all_versions = (_get_comments_for_hard_deleted_versions(addon)
-                    if channel == amo.RELEASE_CHANNEL_LISTED else [])
-    all_versions.extend(versions)
-    all_versions.sort(key=lambda v: v.created,
-                      reverse=True)
+    versions_qs = (
+        # We want to load all Versions, even deleted ones, while using the
+        # addon.versions related manager to get `addon` property pre-cached on
+        # each version.
+        addon.versions(manager='unfiltered_for_relations')
+             .filter(channel=channel)
+             .select_related('autoapprovalsummary')
+             .order_by('created')
+        # Add activity transformer to prefetch all related activity logs on
+        # top of the regular transformers.
+             .transform(Version.transformer_activity)
+    )
 
     deleted_addon_ids = (
         ReusedGUID.objects.filter(guid=addon.guid).values_list(
             'addon_id', flat=True) if addon.guid else [])
 
-    pager = paginate(request, all_versions, 10)
+    pager = paginate(request, versions_qs, 10)
     num_pages = pager.paginator.num_pages
     count = pager.paginator.count
 


### PR DESCRIPTION
- Stop fetching all `CommentLog` and `Version`. This was done to display comments from hard-deleted versions, but versions   have been soft-deleted for more than 3 years now.
- Stop re-fetching the add-on and re-calling its default transformer once per version being displayed (7 duplicate queries per version)
- Stop calling the Version transformer twice (2 duplicate queries per version)

Fixes https://github.com/mozilla/addons-server/issues/12344