### PR TITLE
Fix reviewer tools pagination regression from cfee9add

### DIFF
--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -75,7 +75,8 @@
   <div class="results">
     <div class="results-inner">
       <table id="review-files" class="item-history">
-        {% for version in pager.object_list %}
+        {# We're paginating by newest first, but want to display the current page by oldest first #}
+        {% for version in pager.object_list|reverse %}
         <tr class="listing-header">
           <th colspan="2">
             {% trans version = version.version, created = version.created|date, version_status = version_status(addon, version) %}

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -833,6 +833,9 @@ def review(request, addon, channel=None):
     # the comments form).
     actions_comments = [k for (k, a) in actions if a.get('comments', True)]
 
+    # Queryset to be paginated for versions. We use the default ordering to get
+    # most recently created first (Note that the template displays each page
+    # in reverse order, older first).
     versions_qs = (
         # We want to load all Versions, even deleted ones, while using the
         # addon.versions related manager to get `addon` property pre-cached on
@@ -840,7 +843,6 @@ def review(request, addon, channel=None):
         addon.versions(manager='unfiltered_for_relations')
              .filter(channel=channel)
              .select_related('autoapprovalsummary')
-             .order_by('created')
         # Add activity transformer to prefetch all related activity logs on
         # top of the regular transformers.
              .transform(Version.transformer_activity)


### PR DESCRIPTION
We're paginating versions by newest first, but want to display them on each page in chronological order (oldest first).

Fixes https://github.com/mozilla/addons-server/issues/12373