### PR TITLE
Add storage/ folder to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,5 @@
 .cache
 .tox
 node_modules/
+storage/
 logs/*


### PR DESCRIPTION
This makes locally built docker-images smaller and the build process faster.

Fixes https://github.com/mozilla/addons-server/issues/12386