### PR TITLE
Optimize queries made by ActivityLog in reviewer tools & devhub

### DIFF
--- a/src/olympia/activity/models.py
+++ b/src/olympia/activity/models.py
@@ -2,6 +2,7 @@ import json
 import string
 import uuid
 
+from collections import defaultdict
 from copy import copy
 from datetime import datetime
 
@@ -10,6 +11,7 @@ from django.conf import settings
 from django.db import models
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.functional import cached_property
 from django.utils.translation import ugettext
 
 import jinja2
@@ -20,7 +22,7 @@ from olympia import amo, constants
 from olympia.access.models import Group
 from olympia.addons.models import Addon
 from olympia.amo.fields import PositiveAutoField
-from olympia.amo.models import ManagerBase, ModelBase
+from olympia.amo.models import BaseQuerySet, ManagerBase, ModelBase
 from olympia.bandwagon.models import Collection
 from olympia.files.models import File
 from olympia.ratings.models import Rating
@@ -184,7 +186,19 @@ class DraftComment(ModelBase):
         db_table = 'log_activity_comment_draft'
 
 
+class ActivityLogQuerySet(BaseQuerySet):
+    def default_transformer(self, logs):
+        ActivityLog.arguments_builder(logs)
+
+
 class ActivityLogManager(ManagerBase):
+    _queryset_class = ActivityLogQuerySet
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        qs = qs.transform(qs.default_transformer).prefetch_related('user')
+        return qs
+
     def for_addons(self, addons):
         if isinstance(addons, Addon):
             addons = (addons,)
@@ -284,7 +298,7 @@ class ActivityLogManager(ManagerBase):
         return self.user_position(self.monthly_reviews(theme), user)
 
     def _by_type(self):
-        qs = super(ActivityLogManager, self).get_queryset()
+        qs = self.get_queryset()
         table = 'log_activity_addon'
         return qs.extra(
             tables=[table],
@@ -327,37 +341,90 @@ class ActivityLog(ModelBase):
         # SafeFormatter escapes everything so this is safe.
         return jinja2.Markup(self.formatter.format(*args, **kw))
 
-    @property
+    @classmethod
+    def arguments_builder(cls, activities):
+        # We need to do 2 passes on each log:
+        # - The first time, gather the references to every instance we need
+        # - The second time, we built querysets for all instances of the same
+        #   type, pick data from that queryset.
+        #
+        # Because it relies on in_bulk(), this method needs the pks to be of a
+        # consistent type, which doesn't appear to be guaranteed in our
+        # existing data. For this reason, it forces a conversion to int. If we
+        # ever want to store ActivityLog items pointing to models using a non
+        # integer PK field, we'll need to make this a little smarter.
+        instances_to_load = defaultdict(list)
+        instances = {}
+
+        for activity in activities:
+            try:
+                # `arguments_data` will be a list of dicts like:
+                # `[{'addons.addon':12}, {'addons.addon':1}, ... ]`
+                activity.arguments_data = json.loads(activity._arguments)
+            except Exception as e:
+                log.debug(
+                    'unserializing data from activity_log failed: %s',
+                    activity.id)
+                log.debug(e)
+                activity.arguments_data = []
+
+            for item in activity.arguments_data:
+                # Each 'item' should have one key and one value only.
+                name, pk = list(item.items())[0]
+                if name not in ('str', 'int', 'null') and pk:
+                    # Convert pk to int to have consistent data for when we
+                    # call .in_bulk() later.
+                    instances_to_load[name].append(int(pk))
+
+        # At this point, instances_to_load is a dict of "names" that
+        # each have a bunch of pks we want to load.
+        for name, pks in instances_to_load.items():
+            # Cope with renames of key models (use the original model name like
+            # it was in the ActivityLog as the key so that we can find it
+            # later)
+            key = name
+            if key == 'reviews.review':
+                name = 'ratings.rating'
+            (app_label, model_name) = name.split('.')
+            model = apps.get_model(app_label, model_name)
+            # Load the instances, avoiding transformers other than translations
+            # and coping with soft-deleted models and unlisted add-ons.
+            qs = model.get_unfiltered_manager().all()
+            if hasattr(qs, 'only_translations'):
+                qs = qs.only_translations()
+            instances[key] = qs.in_bulk(pks)
+
+        # instances is now a dict of "model names" that each have a dict of
+        # {pk: instance}. We do our second pass on the logs to build the
+        # "arguments" property from that data, which is a list of the instances
+        # that each particular log has, in the correct order.
+        for activity in activities:
+            objs = []
+            # We preloaded that property earlier
+            for item in activity.arguments_data:
+                # As above, each 'item' should have one key and one value only.
+                name, pk = list(item.items())[0]
+                if name in ('str', 'int', 'null'):
+                    # It's not actually a model reference, just return the
+                    # value directly.
+                    objs.append(pk)
+                elif pk:
+                    # Fetch the instance from the cache we built.
+                    objs.append(instances[name].get(int(pk)))
+            # Override the arguments cached_property with what we got.
+            activity.arguments = objs
+
+    @cached_property
     def arguments(self):
+        # This is a fallback : in 99% of the cases we should not be using this
+        # but go through the default transformer instead, which executes
+        # arguments_builder on the whole list of items in the queryset,
+        # allowing us to fetch the instances in arguments in an optimized
+        # manner.
+        self.arguments_builder([self])
+        return self.arguments
 
-        try:
-            # d is a structure:
-            # ``d = [{'addons.addon':12}, {'addons.addon':1}, ... ]``
-            d = json.loads(self._arguments)
-        except Exception as e:
-            log.debug('unserializing data from addon_log failed: %s' % self.id)
-            log.debug(e)
-            return None
-
-        objs = []
-        for item in d:
-            # item has only one element.
-            model_name, pk = list(item.items())[0]
-            if model_name in ('str', 'int', 'null'):
-                objs.append(pk)
-            else:
-                # Cope with renames of key models:
-                if model_name == 'reviews.review':
-                    model_name = 'ratings.rating'
-                (app_label, model_name) = model_name.split('.')
-                model = apps.get_model(app_label, model_name)
-                # Cope with soft deleted models and unlisted addons.
-                objs.extend(model.get_unfiltered_manager().filter(pk=pk))
-
-        return objs
-
-    @arguments.setter
-    def arguments(self, args=None):
+    def set_arguments(self, args=None):
         """
         Takes an object or a tuple of objects and serializes them and stores it
         in the db as a json string.
@@ -531,7 +598,7 @@ class ActivityLog(ModelBase):
         al = ActivityLog(
             user=user, action=action.id,
             created=kw.get('created', timezone.now()))
-        al.arguments = args
+        al.set_arguments(args)
         if 'details' in kw:
             al.details = kw['details']
         al.save()

--- a/src/olympia/activity/tests/test_models.py
+++ b/src/olympia/activity/tests/test_models.py
@@ -117,7 +117,7 @@ class TestActivityLog(TestCase):
         Addon.objects.get(pk=3615).
         """
         activity_log = ActivityLog()
-        activity_log.arguments = [(Addon, 3615)]
+        activity_log.set_arguments([(Addon, 3615)])
         assert activity_log.arguments[0] == Addon.objects.get(pk=3615)
 
     def test_addon_logging_pseudo(self):
@@ -170,7 +170,8 @@ class TestActivityLog(TestCase):
         entry = ActivityLog.objects.get()
         entry._arguments = 'failboat?'
         entry.save()
-        assert entry.arguments is None
+        del entry.arguments  # Cached version
+        assert entry.arguments == []
 
     def test_arguments_old_reviews_app(self):
         addon = Addon.objects.get()

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -722,7 +722,7 @@ class Addon(OnChangeMixin, ModelBase):
         return data
 
     def get_url_path(self, add_prefix=True):
-        if not self.current_version:
+        if not self._current_version_id:
             return ''
         return reverse(
             'addons.detail', args=[self.slug], add_prefix=add_prefix)

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -590,8 +590,10 @@ class ESAddonSerializer(BaseESSerializer, AddonSerializer):
         # Attach related models (also faking them). `current_version` is a
         # property we can't write to, so we use the underlying field which
         # begins with an underscore.
+        data_version = data.get('current_version') or {}
         obj._current_version = self.fake_version_object(
-            obj, data.get('current_version'), amo.RELEASE_CHANNEL_LISTED)
+            obj, data_version, amo.RELEASE_CHANNEL_LISTED)
+        obj._current_version_id = data_version.get('id')
 
         data_authors = data.get('listed_authors', [])
         obj.listed_authors = [
@@ -640,10 +642,10 @@ class ESAddonAutoCompleteSerializer(ESAddonSerializer):
 
     def get_url(self, obj):
         # Addon.get_absolute_url() calls get_url_path(), which wants
-        # current_version to exist, but that's just a safeguard. We don't care
-        # and don't want to fetch the current version field to improve perf, so
-        # give it a fake one.
-        obj._current_version = Version()
+        # _current_version_id to exist, but that's just a safeguard. We don't
+        # care and don't want to fetch the current version field to improve
+        # perf, so give it a fake one.
+        obj._current_version_id = 1
         return obj.get_absolute_url()
 
 

--- a/src/olympia/amo/models.py
+++ b/src/olympia/amo/models.py
@@ -75,8 +75,10 @@ class BaseQuerySet(models.QuerySet):
         """Remove all transforms except translations."""
         from olympia.translations import transformer
         # Add an extra select so these are cached separately.
-        return (self.no_transforms().extra(select={'_only_trans': 1})
-                .transform(transformer.get_trans))
+        qs = self.no_transforms()
+        if hasattr(self.model._meta, 'translated_fields'):
+            qs = qs.transform(transformer.get_trans)
+        return qs
 
 
 class RawQuerySet(models.query.RawQuerySet):

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -40,14 +40,14 @@
 
   {% include 'reviewers/addon_details_box.html' %}
 
-  {% if user_changes %}
+  {% if user_changes_log %}
   <div id="user-changes-history">
     <h3>
       {{ _('Add-on user change history') }}
     </h3>
     <ul id="user-changes">
-      {% for user_change in user_changes %}
-        <li>{{ user_change.activity_log.created }}: {{ user_change.activity_log }}</li>
+      {% for user_change_log in user_changes_log %}
+        <li>{{ user_change_log.created }}: {{ user_change_log }}</li>
       {% endfor %}
     </ul>
   </div>

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -7,7 +7,6 @@ from urllib.parse import parse_qs
 from collections import OrderedDict
 from datetime import datetime, timedelta
 from unittest import mock
-from unittest.mock import Mock, patch
 
 from django.conf import settings
 from django.core import mail
@@ -204,12 +203,35 @@ class TestReviewLog(ReviewerTest):
 
         # But they should have 2 showing for someone with the right perms.
         self.grant_permission(self.user, 'Addons:ReviewUnlisted')
-        response = self.client.get(self.url)
+        with self.assertNumQueries(15):
+            # 15 queries:
+            # - 2 savepoints because of tests
+            # - 2 user and its groups
+            # - 2 for motd config and site notice
+            # - 2 for collections and addons belonging to the user (menu bar)
+            # - 1 count for the pagination
+            # - 1 for the activities
+            # - 1 for the users for these activities
+            # - 1 for the addons for these activities
+            # - 1 for the translations of these add-ons
+            # - 1 for the versions for these activities
+            # - 1 for the translations of these versions
+            response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
         rows = doc('tbody tr')
         assert rows.filter(':not(.hide)').length == 2
         assert rows.filter('.hide').eq(0).text() == 'youwin'
+
+        # Add more activity, it'd still should not cause more queries.
+        self.make_an_approval(amo.LOG.APPROVE_CONTENT, addon=addon_factory())
+        self.make_an_approval(amo.LOG.REJECT_CONTENT, addon=addon_factory())
+        with self.assertNumQueries(15):
+            response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        rows = doc('tbody tr')
+        assert rows.filter(':not(.hide)').length == 4
 
     def test_xss(self):
         a = Addon.objects.all()[0]
@@ -377,9 +399,10 @@ class TestReviewLog(ReviewerTest):
         assert response.status_code == 200
         assert pq(response.content)('.no-results').length == 1
 
-    @patch('olympia.activity.models.ActivityLog.arguments', new=Mock)
     def test_addon_missing(self):
         self.make_approvals()
+        activity = ActivityLog.objects.latest('pk')
+        activity.update(_arguments='')
         response = self.client.get(self.url)
         assert response.status_code == 200
         assert pq(response.content)('#log-listing tr td').eq(1).text() == (
@@ -1172,9 +1195,9 @@ class TestQueueBasics(QueueTest):
         # No exceptions:
         assert response.status_code == 200
 
-    @patch.multiple('olympia.reviewers.views',
-                    REVIEWS_PER_PAGE_MAX=1,
-                    REVIEWS_PER_PAGE=1)
+    @mock.patch.multiple('olympia.reviewers.views',
+                         REVIEWS_PER_PAGE_MAX=1,
+                         REVIEWS_PER_PAGE=1)
     def test_max_per_page(self):
         self.generate_files()
 
@@ -1184,7 +1207,7 @@ class TestQueueBasics(QueueTest):
         assert doc('.data-grid-top .num-results').text() == (
             u'Results 1\u20131 of 4')
 
-    @patch('olympia.reviewers.views.REVIEWS_PER_PAGE', new=1)
+    @mock.patch('olympia.reviewers.views.REVIEWS_PER_PAGE', new=1)
     def test_reviews_per_page(self):
         self.generate_files()
 
@@ -2794,7 +2817,7 @@ class TestReview(ReviewBase):
         self.client.logout()
         self.assertLoginRedirects(self.client.head(self.url), to=self.url)
 
-    @patch.object(settings, 'ALLOW_SELF_REVIEWS', False)
+    @mock.patch.object(settings, 'ALLOW_SELF_REVIEWS', False)
     def test_not_author(self):
         AddonUser.objects.create(addon=self.addon, user=self.reviewer)
         assert self.client.head(self.url).status_code == 302
@@ -3525,7 +3548,7 @@ class TestReview(ReviewBase):
         self.assert3xx(response, reverse('reviewers.queue_extension'),
                        status_code=302)
 
-    @patch('olympia.reviewers.utils.sign_file')
+    @mock.patch('olympia.reviewers.utils.sign_file')
     def review_version(self, version, url, mock_sign):
         if version.channel == amo.RELEASE_CHANNEL_LISTED:
             version.files.all()[0].update(status=amo.STATUS_AWAITING_REVIEW)
@@ -3906,7 +3929,7 @@ class TestReview(ReviewBase):
         assert response.status_code == 200
         assert b'The developer has provided source code.' in response.content
 
-    @patch('olympia.reviewers.utils.sign_file')
+    @mock.patch('olympia.reviewers.utils.sign_file')
     def test_approve_recommended_addon(self, mock_sign_file):
         self.version.files.update(status=amo.STATUS_AWAITING_REVIEW)
         self.addon.update(status=amo.STATUS_NOMINATED)
@@ -3925,7 +3948,7 @@ class TestReview(ReviewBase):
         assert addon.current_version.recommendation_approved
         assert mock_sign_file.called
 
-    @patch('olympia.reviewers.utils.sign_file')
+    @mock.patch('olympia.reviewers.utils.sign_file')
     def test_admin_flagged_addon_actions_as_admin(self, mock_sign_file):
         self.version.files.update(status=amo.STATUS_AWAITING_REVIEW)
         self.addon.update(status=amo.STATUS_NOMINATED)
@@ -4105,7 +4128,7 @@ class TestReview(ReviewBase):
             assert ActivityLog.objects.filter(
                 action=amo.LOG.APPROVE_VERSION.id).count() == 0
 
-    @patch('olympia.reviewers.utils.sign_file')
+    @mock.patch('olympia.reviewers.utils.sign_file')
     def test_admin_can_review_statictheme_if_admin_theme_review_flag_set(
             self, mock_sign_file):
         self.version.files.update(status=amo.STATUS_AWAITING_REVIEW)
@@ -4189,9 +4212,9 @@ class TestReview(ReviewBase):
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
-        assert 'user_changes' in response.context
-        user_changes_log = response.context['user_changes']
-        actions = [log.activity_log.action for log in user_changes_log]
+        assert 'user_changes_log' in response.context
+        user_changes_log = response.context['user_changes_log']
+        actions = [log.action for log in user_changes_log]
         assert actions == [
             amo.LOG.ADD_USER_WITH_ROLE.id,
             amo.LOG.CHANGE_USER_WITH_ROLE.id,
@@ -4744,7 +4767,7 @@ class TestReviewPending(ReviewBase):
     def pending_dict(self):
         return self.get_dict(action='public')
 
-    @patch('olympia.reviewers.utils.sign_file')
+    @mock.patch('olympia.reviewers.utils.sign_file')
     def test_pending_to_public(self, mock_sign):
         statuses = (self.version.files.values_list('status', flat=True)
                     .order_by('status'))
@@ -4795,7 +4818,7 @@ class TestReviewPending(ReviewBase):
         assert unreviewed.filename in response.content
         assert self.file.filename in response.content
 
-    @patch('olympia.reviewers.utils.sign_file')
+    @mock.patch('olympia.reviewers.utils.sign_file')
     def test_review_unreviewed_files(self, mock_sign):
         """Review all the unreviewed files when submitting a review."""
         reviewed = File.objects.create(version=self.version,

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -35,7 +35,7 @@ from olympia.abuse.models import AbuseReport
 from olympia.access import acl
 from olympia.accounts.views import API_TOKEN_COOKIE
 from olympia.activity.models import (
-    ActivityLog, AddonLog, CommentLog, DraftComment)
+    ActivityLog, CommentLog, DraftComment)
 from olympia.addons.decorators import (
     addon_view, addon_view_factory, owner_or_unlisted_reviewer)
 from olympia.addons.models import (
@@ -884,9 +884,8 @@ def review(request, addon, channel=None):
         amo.LOG.ADD_USER_WITH_ROLE.id,
         amo.LOG.CHANGE_USER_WITH_ROLE.id,
         amo.LOG.REMOVE_USER_WITH_ROLE.id]
-    user_changes_log = AddonLog.objects.filter(
-        activity_log__action__in=user_changes_actions,
-        addon=addon).order_by('id')
+    user_changes_log = ActivityLog.objects.filter(
+        action__in=user_changes_actions, addonlog__addon=addon).order_by('id')
     ctx = context(
         actions=actions, actions_comments=actions_comments,
         actions_full=actions_full, addon=addon,
@@ -899,7 +898,7 @@ def review(request, addon, channel=None):
         subscribed=ReviewerSubscription.objects.filter(
             user=request.user, addon=addon).exists(),
         unlisted=(channel == amo.RELEASE_CHANNEL_UNLISTED),
-        user_changes=user_changes_log, user_ratings=user_ratings,
+        user_changes_log=user_changes_log, user_ratings=user_ratings,
         version=version, whiteboard_form=whiteboard_form,
         whiteboard_url=whiteboard_url)
     return render(request, 'reviewers/review.html', ctx)

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -387,10 +387,11 @@ class Version(OnChangeMixin, ModelBase):
 
     @cached_property
     def all_activity(self):
-        from olympia.activity.models import VersionLog  # yucky
-        al = (VersionLog.objects.filter(version=self.id).order_by('created')
-              .select_related('activity_log', 'version'))
-        return al
+        # prefetch_related() and not select_related() the ActivityLog to make
+        # sure its transformer is called.
+        return (
+            self.versionlog_set.prefetch_related('activity_log')
+                               .order_by('created'))
 
     @property
     def compatible_apps(self):
@@ -582,14 +583,22 @@ class Version(OnChangeMixin, ModelBase):
     @classmethod
     def transformer_activity(cls, versions):
         """Attach all the activity to the versions."""
-        from olympia.activity.models import VersionLog  # yucky
+        from olympia.activity.models import VersionLog
 
         ids = set(v.id for v in versions)
         if not versions:
             return
 
-        al = (VersionLog.objects.filter(version__in=ids).order_by('created')
-              .select_related('activity_log', 'version'))
+        # Ideally, we'd start from the ActivityLog, but because VersionLog
+        # to ActivityLog isn't a OneToOneField, we wouldn't be able to find
+        # the version easily afterwards - we can't even do a
+        # select_related('versionlog') and try to traverse the relation to find
+        # the version. So, instead, start from VersionLog, but make sure to use
+        # prefetch_related() (and not select_related() - yes, it's one extra
+        # query, but it's worth it to benefit from the default transformer) so
+        # that the ActivityLog default transformer is called.
+        al = VersionLog.objects.prefetch_related('activity_log').filter(
+            version__in=ids).order_by('created')
 
         def rollup(xs):
             groups = sorted_groupby(xs, 'version_id')


### PR DESCRIPTION
![9000](https://user-images.githubusercontent.com/187006/65326571-17b65e00-dbb2-11e9-8280-fb9215e203bf.gif)

- Cache `ActivityLog.arguments` on the instance to avoid making its queries multiple times when the property is called more than once
- Group all queries made by `ActivityLog.arguments` using a transformer by default
- Avoid loading the version (and therefore its files & applications versions) when figuring out the url for an `Addon`
- Prefetch the user when fetching `ActivityLog`
- Tweak review page and `Version.all_activity`/`activity_transformer` to benefit from those changes

Number of queries made by reviewer tools will differ a lot depending on the situation, but on my local environment, after spinning up lots of various activity:

Queries count in reviewlog page before: > 4500 queries
Queries count in reviewlog page after:    ~ 15 queries
Queries count in busy review page before: > 1000 queries
Queries count in busy review page after:  ~  100 queries

Still a lot to improve on the review page, but definitive improvements across the board in reviewer tools.

Fixes #12055