### PR TITLE
delete any update_counts records that won't be able to satisfy new fk constraint

### DIFF
--- a/src/olympia/migrations/1200-update-counts.sql
+++ b/src/olympia/migrations/1200-update-counts.sql
@@ -1,3 +1,7 @@
+DELETE FROM `update_counts` USING `update_counts`
+    LEFT JOIN `addons` ON `addon_id` = `addons`.`id`
+    WHERE `addons`.`id` IS NULL AND `addon_id` IS NOT NULL;
+
 ALTER TABLE `update_counts`
     CHANGE COLUMN `addon_id` `addon_id` INT (10) UNSIGNED NOT NULL,
     CHANGE COLUMN `count` `count` INT (10) UNSIGNED NOT NULL,


### PR DESCRIPTION
pre-empting migration 1200 failing
