### PR TITLE
Avoid some duplicate queries around versions

### DIFF
--- a/src/olympia/devhub/templates/devhub/versions/list.html
+++ b/src/olympia/devhub/templates/devhub/versions/list.html
@@ -3,10 +3,15 @@
 {% set title = _('Status & Versions') %}
 {% block title %}{{ dev_page_title(title, addon) }}{% endblock %}
 
-{% if addon.has_listed_versions() %}
+{% set current_version=addon.current_version %}
+{% set latest_listed_version_including_disabled = addon.find_latest_version(channel=amo.RELEASE_CHANNEL_LISTED, exclude=()) %}
+{% set latest_unlisted_version_including_disabled = addon.find_latest_version(channel=amo.RELEASE_CHANNEL_UNLISTED, exclude=()) %}
+{% set latest_listed_version=addon.find_latest_version(channel=amo.RELEASE_CHANNEL_LISTED) %}
+
+{% if latest_listed_version_including_disabled %}
   {% set has_listed_versions = True %}
 {% endif %}
-{% if addon.has_unlisted_versions() %}
+{% if latest_unlisted_version_including_disabled %}
   {% set has_unlisted_versions = True %}
 {% endif %}
 
@@ -27,7 +32,7 @@
 {% endif %}
 
 {% macro version_details(version, full_info=False) %}
-  {% set latest_version_in_channel = version.addon.find_latest_version(channel=version.channel, exclude=()) %}
+{% set latest_version_in_channel_including_disabled = latest_listed_version_including_disabled if version.channel == amo.RELEASE_CHANNEL_LISTED else latest_unlisted_version_including_disabled %}
   <tr{% if version_disabled(version) %} class="version-disabled"{% endif %}>
     <td>
       <strong>
@@ -61,7 +66,7 @@
           <a href="#" class="review-history-show" data-div="#{{ version.id }}-review-history"
             id="review-history-show-{{ version.id }}" data-version="{{ version.id }}">{{ _('Review History') }}</a>
           <a href="#" class="review-history-hide hidden">{{ _('Close Review History') }}</a>
-          {% if latest_version_in_channel == version %}
+          {% if latest_version_in_channel_including_disabled == version %}
               {% set pending_count = pending_activity_log_count_for_developer(version) %}
               {% if pending_count > 0 %}
                   <b class="review-history-pending-count">{{ pending_count }}</b>
@@ -126,7 +131,7 @@
                   <pre>$comments</pre>
               </div>
           </div>
-          {% if latest_version_in_channel == version %}
+          {% if latest_version_in_channel_including_disabled == version %}
             <div class="dev-review-reply">
               <form class="dev-review-reply-form" action="{{ drf_url('version-reviewnotes-list', addon.id, version.id) }}"
                     data-token="{{ token }}" data-history="#{{ version.id }}-review-history" data-no-csrf>
@@ -136,7 +141,7 @@
             </div>
           {% else %}
             <div>
-              <a href="#" class="review-history-show" data-version="{{ latest_version_in_channel.id }}">{{ _('Leave a reply') }}</a>
+              <a href="#" class="review-history-show" data-version="{{ latest_version_in_channel_including_disabled.id }}">{{ _('Leave a reply') }}</a>
             </div>
           {% endif %}
       </td>
@@ -172,10 +177,6 @@
              label_open='<strong>'|safe, label_close='</strong>'|safe) }}</label>
       </div>
     </div>
-
-    {% set latest_listed_version=addon.find_latest_version(channel=amo.RELEASE_CHANNEL_LISTED) %}
-    {% set current_version=addon.current_version %}
-
     {% if latest_listed_version or current_version %}
         <h3>{{ distro_tag(amo.RELEASE_CHANNEL_LISTED)}} {{ _('Listed versions') }}</h3>
     {% endif %}
@@ -234,7 +235,6 @@
           <th class="version-delete">{{ _('Delete/Disable') }}</th>
         </tr>
 
-        {% set latest_listed_version_including_disabled = addon.find_latest_version(channel=amo.RELEASE_CHANNEL_LISTED, exclude=()) %}
         {% for version in versions.object_list %}
           {% if version != current_version and version != latest_listed_version %}
             {{ version_details(version, full_info=version==latest_listed_version_including_disabled) }}

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -164,10 +164,11 @@ def ajax_compat_error(request, addon_id, addon):
 def ajax_compat_update(request, addon_id, addon, version_id):
     if not addon.accepts_compatible_apps():
         raise http.Http404()
-    version = get_object_or_404(Version.objects, pk=version_id, addon=addon)
-    compat_form = forms.CompatFormSet(request.POST or None,
-                                      queryset=version.apps.all(),
-                                      form_kwargs={'version': version})
+    version = get_object_or_404(addon.versions.all(), pk=version_id)
+    compat_form = forms.CompatFormSet(
+        request.POST or None,
+        queryset=version.apps.all().select_related('min', 'max'),
+        form_kwargs={'version': version})
     if request.method == 'POST' and compat_form.is_valid():
         for compat in compat_form.save(commit=False):
             compat.version = version
@@ -1022,7 +1023,7 @@ def upload_image(request, addon_id, addon, upload_type):
 
 @dev_required
 def version_edit(request, addon_id, addon, version_id):
-    version = get_object_or_404(Version.objects, pk=version_id, addon=addon)
+    version = get_object_or_404(addon.versions.all(), pk=version_id)
     static_theme = addon.type == amo.ADDON_STATICTHEME
     version_form = forms.VersionForm(
         request.POST or None,
@@ -1040,7 +1041,7 @@ def version_edit(request, addon_id, addon, version_id):
                                   amo.permissions.REVIEWS_ADMIN)
 
     if not static_theme and addon.accepts_compatible_apps():
-        qs = version.apps.all()
+        qs = version.apps.all().select_related('min', 'max')
         compat_form = forms.CompatFormSet(
             request.POST or None, queryset=qs,
             form_kwargs={'version': version})
@@ -1123,7 +1124,7 @@ def _log_max_version_change(addon, version, appversion):
 @transaction.atomic
 def version_delete(request, addon_id, addon):
     version_id = request.POST.get('version_id')
-    version = get_object_or_404(Version.objects, pk=version_id, addon=addon)
+    version = get_object_or_404(addon.versions.all(), pk=version_id)
     if (addon.is_recommended and
             version.recommendation_approved and
             version == addon.current_version):
@@ -1152,7 +1153,7 @@ def version_delete(request, addon_id, addon):
 @transaction.atomic
 def version_reenable(request, addon_id, addon):
     version_id = request.POST.get('version_id')
-    version = get_object_or_404(Version.objects, pk=version_id, addon=addon)
+    version = get_object_or_404(addon.versions.all(), pk=version_id)
     messages.success(
         request,
         ugettext('Version %s re-enabled.') % version.version)
@@ -1200,7 +1201,7 @@ def auto_sign_version(version, **kwargs):
 
 @dev_required
 def version_list(request, addon_id, addon):
-    qs = addon.versions.order_by('-created').transform(Version.transformer)
+    qs = addon.versions.order_by('-created')
     versions = amo_utils.paginate(request, qs)
     is_admin = acl.action_allowed(request,
                                   amo.permissions.REVIEWS_ADMIN)
@@ -1217,10 +1218,9 @@ def version_list(request, addon_id, addon):
 @dev_required
 def version_bounce(request, addon_id, addon, version):
     # Use filter since there could be dupes.
-    vs = (Version.objects.filter(version=version, addon=addon)
-          .order_by('-created'))
+    vs = addon.versions.filter(version=version).order_by('-created').first()
     if vs:
-        return redirect('devhub.versions.edit', addon.slug, vs[0].id)
+        return redirect('devhub.versions.edit', addon.slug, vs.id)
     else:
         raise http.Http404()
 
@@ -1228,7 +1228,7 @@ def version_bounce(request, addon_id, addon, version):
 @json_view
 @dev_required
 def version_stats(request, addon_id, addon):
-    qs = Version.objects.filter(addon=addon)
+    qs = addon.versions.all()
     reviews = (qs.annotate(review_count=Count('ratings'))
                .values('id', 'version', 'review_count'))
     data = {v['id']: v for v in reviews}
@@ -1511,7 +1511,7 @@ def submit_addon_source(request, addon_id, addon):
 
 @dev_required(submitting=True)
 def submit_version_source(request, addon_id, addon, version_id):
-    version = get_object_or_404(Version, id=version_id)
+    version = get_object_or_404(addon.versions.all(), id=version_id)
     return _submit_source(
         request, addon, version, 'devhub.submit.version.details')
 
@@ -1612,7 +1612,7 @@ def submit_addon_details(request, addon_id, addon):
 
 @dev_required(submitting=True)
 def submit_version_details(request, addon_id, addon, version_id):
-    version = get_object_or_404(Version, id=version_id)
+    version = get_object_or_404(addon.versions.all(), id=version_id)
     return _submit_details(request, addon, version)
 
 
@@ -1668,7 +1668,7 @@ def submit_addon_finish(request, addon_id, addon):
 
 @dev_required
 def submit_version_finish(request, addon_id, addon, version_id):
-    version = get_object_or_404(Version, id=version_id)
+    version = get_object_or_404(addon.versions.all(), id=version_id)
     return _submit_finish(request, addon, version)
 
 

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -407,27 +407,12 @@ class Version(OnChangeMixin, ModelBase):
     @cached_property
     def _compatible_apps(self):
         """Get a mapping of {APP: ApplicationsVersions}."""
-        return self._compat_map(self.apps.all())
+        return self._compat_map(self.apps.all().select_related('min', 'max'))
 
     @cached_property
     def compatible_apps_ordered(self):
         apps = self.compatible_apps.items()
         return sorted(apps, key=lambda v: v[0].short)
-
-    def compatible_platforms(self):
-        """Returns a dict of compatible file platforms for this version.
-
-        The result is based on which app(s) the version targets.
-        """
-        app_ids = [a.application for a in self.apps.all()]
-        targets_mobile = amo.ANDROID.id in app_ids
-        targets_other = any((id_ != amo.ANDROID.id) for id_ in app_ids)
-        all_plats = {}
-        if targets_other:
-            all_plats.update(amo.DESKTOP_PLATFORMS)
-        if targets_mobile:
-            all_plats.update(amo.MOBILE_PLATFORMS)
-        return all_plats
 
     @cached_property
     def is_compatible_by_default(self):

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -201,21 +201,6 @@ class TestVersion(TestCase):
         v = Version.objects.get(pk=81551)
         assert amo.PLATFORM_ALL in v.supported_platforms
 
-    def test_mobile_version_supports_only_mobile_platforms(self):
-        self.version.apps.all().delete()
-        self.target_mobile()
-        assert (sorted(self.named_plat(self.version.compatible_platforms())) ==
-                [u'android'])
-
-    def test_mixed_version_supports_all_platforms(self):
-        self.target_mobile()
-        assert (sorted(self.named_plat(self.version.compatible_platforms())) ==
-                ['all', 'android', 'linux', 'mac', 'windows'])
-
-    def test_non_mobile_version_supports_non_mobile_platforms(self):
-        assert (sorted(self.named_plat(self.version.compatible_platforms())) ==
-                ['all', 'linux', 'mac', 'windows'])
-
     def test_major_minor(self):
         """Check that major/minor/alpha is getting set."""
         v = Version(version='3.0.12b2')


### PR DESCRIPTION
- Avoid calling find_latest_version() too many times in devhub versions list page
- Make sure all devhub views call `<Addon>.versions` when needing to fetch a version, so that the addon property is preloaded on the version
- Avoid default transformer (except translations) in `find_latest_version()` : it's a single instance, we can just let the queries happen normally when they are needed, pre-running them brings us nothing (impacts many devhub & reviewer tools views)

Fixes #12397