### PR TITLE
fxa auth flow changes

### DIFF
--- a/docs/topics/api/auth_internal.rst
+++ b/docs/topics/api/auth_internal.rst
@@ -22,7 +22,7 @@ Fetching the token
 A fresh token, valid for 30 days, is automatically generated and added to the
 responses of the following endpoint:
 
-    * ``/api/v4/accounts/authenticate/``
+    * ``/api/auth/authenticate-callback/``
 
 The token is available in two forms:
 

--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -363,6 +363,7 @@ v4 API changelog
 * 2019-08-15: removed /addons/compat-override/ from v4 and above.  Still exists in /v3/ but will always return an empty response. https://github.com/mozilla/addons-server/issues/12063
 * 2019-08-22: added ``canned_response`` property to draft comment api. https://github.com/mozilla/addons-server/issues/11807
 * 2019-09-19: added /site/ endpoint to expose read-only mode and any site notice.  Also added the same response to the /accounts/account/ non-public response as a convenience for logged in users. https://github.com/mozilla/addons-server/issues/11493)
+* 2019-09-26: moved /authenticate endpoint from api/v4/accounts/authenticate to version-less api/auth/authenticate-callback https://github.com/mozilla/addons-server/issues/10487
 
 .. _`#11380`: https://github.com/mozilla/addons-server/issues/11380/
 .. _`#11379`: https://github.com/mozilla/addons-server/issues/11379/

--- a/settings.py
+++ b/settings.py
@@ -77,44 +77,28 @@ FXA_CONFIG = {
         'client_secret': env(
             'FXA_CLIENT_SECRET',
             default='5a36054059674b09ea56709c85b862c388f2d493d735070868ae8f476e16a80d'),  # noqa
-        'content_host': 'https://stable.dev.lcip.org',
-        'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
-        'profile_host': 'https://stable.dev.lcip.org/profile/v1',
         'redirect_url': 'http://olympia.test/api/v3/accounts/authenticate/',
-        'scope': 'profile',
     },
     'amo': {
         'client_id': env('FXA_CLIENT_ID', default='0f95f6474c24c1dc'),
         'client_secret': env(
             'FXA_CLIENT_SECRET',
             default='ca45e503a1b4ec9e2a3d4855d79849e098da18b7dfe42b6bc76dfed420fc1d38'),  # noqa
-        'content_host': 'https://stable.dev.lcip.org',
-        'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
-        'profile_host': 'https://stable.dev.lcip.org/profile/v1',
         'redirect_url': 'http://localhost:3000/fxa-authenticate',
-        'scope': 'profile',
     },
     'local': {
         'client_id': env('FXA_CLIENT_ID', default='1778aef72d1adfb3'),
         'client_secret': env(
             'FXA_CLIENT_SECRET',
             default='3feebe3c009c1a0acdedd009f3530eae2b88859f430fa8bb951ea41f2f859b18'),  # noqa
-        'content_host': 'https://stable.dev.lcip.org',
-        'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
-        'profile_host': 'https://stable.dev.lcip.org/profile/v1',
         'redirect_url': 'http://localhost:3000/api/v3/accounts/authenticate/?config=local', # noqa
-        'scope': 'profile',
     },
     'code-manager': {
         'client_id': env('CODE_MANAGER_FXA_CLIENT_ID', default='a98b671fdd3dfcea'), # noqa
         'client_secret': env(
             'CODE_MANAGER_FXA_CLIENT_SECRET',
             default='d9934865e34bed4739a2dc60046a90d09a5d8336cf92809992dec74a4cff4665'),  # noqa
-        'content_host': 'https://stable.dev.lcip.org',
-        'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
-        'profile_host': 'https://stable.dev.lcip.org/profile/v1',
         'redirect_url': 'http://olympia.test/api/v4/accounts/authenticate/?config=code-manager', # noqa
-        'scope': 'profile',
     },
 }
 ALLOWED_FXA_CONFIGS = ['default', 'amo', 'local', 'code-manager']

--- a/settings.py
+++ b/settings.py
@@ -73,35 +73,28 @@ DATABASES = {
 # FxA config for local development only.
 FXA_CONFIG = {
     'default': {
-        'client_id': env('FXA_CLIENT_ID', default='f336377c014eacf0'),
+        'client_id': env('FXA_CLIENT_ID', default='a25796da7bc73ffa'),
         'client_secret': env(
             'FXA_CLIENT_SECRET',
-            default='5a36054059674b09ea56709c85b862c388f2d493d735070868ae8f476e16a80d'),  # noqa
-        'redirect_url': 'http://olympia.test/api/v3/accounts/authenticate/',
+            default='4828af02f60a12738a79c7121b06d42b481f112dce1831440902a8412d2770c5'),  # noqa
+        # redirect_uri = 'http://olympia.test/api/auth/authenticate-callback/'
     },
     'amo': {
         'client_id': env('FXA_CLIENT_ID', default='0f95f6474c24c1dc'),
         'client_secret': env(
             'FXA_CLIENT_SECRET',
             default='ca45e503a1b4ec9e2a3d4855d79849e098da18b7dfe42b6bc76dfed420fc1d38'),  # noqa
-        'redirect_url': 'http://localhost:3000/fxa-authenticate',
+        # redirect_uri = 'http://localhost:3000/fxa-authenticate'
     },
     'local': {
-        'client_id': env('FXA_CLIENT_ID', default='1778aef72d1adfb3'),
+        'client_id': env('FXA_CLIENT_ID', default='4dce1adfa7901c08'),
         'client_secret': env(
             'FXA_CLIENT_SECRET',
-            default='3feebe3c009c1a0acdedd009f3530eae2b88859f430fa8bb951ea41f2f859b18'),  # noqa
-        'redirect_url': 'http://localhost:3000/api/v3/accounts/authenticate/?config=local', # noqa
-    },
-    'code-manager': {
-        'client_id': env('CODE_MANAGER_FXA_CLIENT_ID', default='a98b671fdd3dfcea'), # noqa
-        'client_secret': env(
-            'CODE_MANAGER_FXA_CLIENT_SECRET',
-            default='d9934865e34bed4739a2dc60046a90d09a5d8336cf92809992dec74a4cff4665'),  # noqa
-        'redirect_url': 'http://olympia.test/api/v4/accounts/authenticate/?config=code-manager', # noqa
+            default='d7d5f1148a35b12c067fb9eafafc29d35165a90f5d8b0032f1fcd37468ae49fe'),  # noqa
+        # redirect_uri = 'http://localhost:3000/api/auth/authenticate-callback/?config=local'  #noqa
     },
 }
-ALLOWED_FXA_CONFIGS = ['default', 'amo', 'local', 'code-manager']
+ALLOWED_FXA_CONFIGS = ['default', 'amo', 'local']
 
 # CSP report endpoint which returns a 204 from addons-nginx in local dev.
 CSP_REPORT_URI = '/csp-report'

--- a/src/olympia/accounts/serializers.py
+++ b/src/olympia/accounts/serializers.py
@@ -103,7 +103,7 @@ class UserProfileSerializer(PublicUserProfileSerializer):
 
     def get_fxa_edit_email_url(self, user):
         base_url = '{}/settings'.format(
-            settings.FXA_CONFIG['default']['content_host']
+            settings.FXA_CONTENT_HOST
         )
         return urlparams(base_url, uid=user.fxa_id, email=user.email,
                          entrypoint='addons')

--- a/src/olympia/accounts/tests/test_serializers.py
+++ b/src/olympia/accounts/tests/test_serializers.py
@@ -218,15 +218,10 @@ class TestUserProfileSerializer(TestPublicUserProfileSerializer,
 
     def test_expose_fxa_edit_email_url(self):
         fxa_host = 'http://example.com'
-        fxa_config = {
-            'default': {
-                'content_host': fxa_host,
-            },
-        }
         user_fxa_id = 'ufxa-id-123'
         self.user.update(fxa_id=user_fxa_id)
 
-        with override_settings(FXA_CONFIG=fxa_config):
+        with override_settings(FXA_CONTENT_HOST=fxa_host):
             expected_url = urlparams('{}/settings'.format(fxa_host),
                                      uid=user_fxa_id, email=self.user_email,
                                      entrypoint='addons')

--- a/src/olympia/accounts/tests/test_utils.py
+++ b/src/olympia/accounts/tests/test_utils.py
@@ -22,9 +22,7 @@ FXA_CONFIG = {
     'default': {
         'client_id': 'foo',
         'client_secret': 'bar',
-        'oauth_host': 'https://accounts.firefox.com/oauth',
         'redirect_url': 'https://testserver/fxa',
-        'scope': 'profile',
     },
 }
 
@@ -37,7 +35,9 @@ def test_fxa_config_anonymous():
     assert utils.fxa_config(request) == {
         'clientId': 'foo',
         'state': 'thestate!',
-        'oauthHost': 'https://accounts.firefox.com/oauth',
+        'oauthHost': 'https://oauth-stable.dev.lcip.org/v1',
+        'contentHost': 'https://stable.dev.lcip.org',
+        'profileHost': 'https://stable.dev.lcip.org/profile/v1',
         'redirectUrl': 'https://testserver/fxa',
         'scope': 'profile',
     }
@@ -52,13 +52,16 @@ def test_fxa_config_logged_in():
         'clientId': 'foo',
         'state': 'thestate!',
         'email': 'me@mozilla.org',
-        'oauthHost': 'https://accounts.firefox.com/oauth',
+        'oauthHost': 'https://oauth-stable.dev.lcip.org/v1',
+        'contentHost': 'https://stable.dev.lcip.org',
+        'profileHost': 'https://stable.dev.lcip.org/profile/v1',
         'redirectUrl': 'https://testserver/fxa',
         'scope': 'profile',
     }
 
 
 @override_settings(FXA_CONFIG=FXA_CONFIG)
+@override_settings(FXA_OAUTH_HOST='https://accounts.firefox.com/oauth')
 def test_default_fxa_login_url_with_state():
     path = u'/en-US/addons/abp/?source=ddg'
     request = RequestFactory().get(path)
@@ -81,6 +84,7 @@ def test_default_fxa_login_url_with_state():
 
 
 @override_settings(FXA_CONFIG=FXA_CONFIG)
+@override_settings(FXA_OAUTH_HOST='https://accounts.firefox.com/oauth')
 def test_default_fxa_register_url_with_state():
     path = '/en-US/addons/abp/?source=ddg'
     request = RequestFactory().get(path)
@@ -103,6 +107,7 @@ def test_default_fxa_register_url_with_state():
 
 
 @override_settings(FXA_CONFIG=FXA_CONFIG)
+@override_settings(FXA_OAUTH_HOST='https://accounts.firefox.com/oauth')
 def test_fxa_login_url_without_requiring_two_factor_auth():
     path = '/en-US/addons/abp/?source=ddg'
     request = RequestFactory().get(path)
@@ -130,6 +135,7 @@ def test_fxa_login_url_without_requiring_two_factor_auth():
 
 
 @override_settings(FXA_CONFIG=FXA_CONFIG)
+@override_settings(FXA_OAUTH_HOST='https://accounts.firefox.com/oauth')
 def test_fxa_login_url_requiring_two_factor_auth():
     path = u'/en-US/addons/abp/?source=ddg'
     request = RequestFactory().get(path)

--- a/src/olympia/accounts/tests/test_utils.py
+++ b/src/olympia/accounts/tests/test_utils.py
@@ -22,7 +22,6 @@ FXA_CONFIG = {
     'default': {
         'client_id': 'foo',
         'client_secret': 'bar',
-        'redirect_url': 'https://testserver/fxa',
     },
 }
 
@@ -38,7 +37,6 @@ def test_fxa_config_anonymous():
         'oauthHost': 'https://oauth-stable.dev.lcip.org/v1',
         'contentHost': 'https://stable.dev.lcip.org',
         'profileHost': 'https://stable.dev.lcip.org/profile/v1',
-        'redirectUrl': 'https://testserver/fxa',
         'scope': 'profile',
     }
 
@@ -55,7 +53,6 @@ def test_fxa_config_logged_in():
         'oauthHost': 'https://oauth-stable.dev.lcip.org/v1',
         'contentHost': 'https://stable.dev.lcip.org',
         'profileHost': 'https://stable.dev.lcip.org/profile/v1',
-        'redirectUrl': 'https://testserver/fxa',
         'scope': 'profile',
     }
 
@@ -76,7 +73,6 @@ def test_default_fxa_login_url_with_state():
     assert query == {
         'action': ['signin'],
         'client_id': ['foo'],
-        'redirect_url': ['https://testserver/fxa'],
         'scope': ['profile'],
         'state': ['myfxastate:{next_path}'.format(
             next_path=force_text(next_path))],
@@ -99,7 +95,6 @@ def test_default_fxa_register_url_with_state():
     assert query == {
         'action': ['signup'],
         'client_id': ['foo'],
-        'redirect_url': ['https://testserver/fxa'],
         'scope': ['profile'],
         'state': ['myfxastate:{next_path}'.format(
             next_path=force_text(next_path))],
@@ -127,7 +122,6 @@ def test_fxa_login_url_without_requiring_two_factor_auth():
     assert query == {
         'action': ['signin'],
         'client_id': ['foo'],
-        'redirect_url': ['https://testserver/fxa'],
         'scope': ['profile'],
         'state': ['myfxastate:{next_path}'.format(
             next_path=force_text(next_path))],
@@ -156,7 +150,6 @@ def test_fxa_login_url_requiring_two_factor_auth():
         'acr_values': ['AAL2'],
         'action': ['signin'],
         'client_id': ['foo'],
-        'redirect_url': ['https://testserver/fxa'],
         'scope': ['profile'],
         'state': ['myfxastate:{next_path}'.format(
             next_path=force_text(next_path))],

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -71,11 +71,11 @@ class BaseAuthenticationView(TestCase, PatchMixin,
 @override_settings(FXA_CONFIG={'current-config': FXA_CONFIG})
 class TestLoginStartBaseView(WithDynamicEndpoints, TestCase):
 
-    class LoginStartView(views.LoginStartBaseView):
+    class LoginStartView(views.LoginStartView):
         DEFAULT_FXA_CONFIG_NAME = 'current-config'
 
     def setUp(self):
-        super(TestLoginStartBaseView, self).setUp()
+        super().setUp()
         self.endpoint(self.LoginStartView, r'^login/start/')
         self.url = '/en-US/firefox/login/start/'
         self.initialize_session({})
@@ -388,6 +388,9 @@ class TestWithUser(TestCase):
         self.user = AnonymousUser()
         self.request.user = self.user
         self.request.session = {'fxa_state': 'some-blob'}
+
+    def get_fxa_config(self, request):
+        return settings.FXA_CONFIG[settings.DEFAULT_FXA_CONFIG_NAME]
 
     @views.with_user(format='json')
     def fn(*args, **kwargs):

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -40,16 +40,12 @@ from olympia.users.utils import UnsubscribeCode
 
 
 FXA_CONFIG = {
-    'oauth_host': 'https://accounts.firefox.com/v1',
     'client_id': 'amodefault',
     'redirect_url': 'https://addons.mozilla.org/fxa-authenticate',
-    'scope': 'profile',
 }
 SKIP_REDIRECT_FXA_CONFIG = {
-    'oauth_host': 'https://accounts.firefox.com/v1',
     'client_id': 'amodefault',
     'redirect_url': 'https://addons.mozilla.org/fxa-authenticate',
-    'scope': 'profile',
     'skip_register_redirect': True,
 }
 
@@ -69,6 +65,7 @@ class BaseAuthenticationView(TestCase, PatchMixin,
 
 
 @override_settings(FXA_CONFIG={'current-config': FXA_CONFIG})
+@override_settings(FXA_OAUTH_HOST='https://accounts.firefox.com/v1')
 class TestLoginStartBaseView(WithDynamicEndpoints, TestCase):
 
     class LoginStartView(views.LoginStartView):
@@ -627,7 +624,7 @@ class TestWithUser(TestCase):
             scheme=url.scheme, netloc=url.netloc, path=url.path)
         fxa_config = settings.FXA_CONFIG[settings.DEFAULT_FXA_CONFIG_NAME]
         assert base == '{host}{path}'.format(
-            host=fxa_config['oauth_host'],
+            host=settings.FXA_OAUTH_HOST,
             path='/authorization')
         query = parse_qs(url.query)
         next_path = base64.urlsafe_b64encode(b'/a/path/?').rstrip(b'=')
@@ -636,7 +633,7 @@ class TestWithUser(TestCase):
             'action': ['signin'],
             'client_id': [fxa_config['client_id']],
             'redirect_url': [fxa_config['redirect_url']],
-            'scope': [fxa_config['scope']],
+            'scope': ['profile'],
             'state': ['some-blob:{next_path}'.format(
                 next_path=force_text(next_path))],
         }

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -41,12 +41,9 @@ from olympia.users.utils import UnsubscribeCode
 
 FXA_CONFIG = {
     'client_id': 'amodefault',
-    'redirect_url': 'https://addons.mozilla.org/fxa-authenticate',
 }
 SKIP_REDIRECT_FXA_CONFIG = {
     'client_id': 'amodefault',
-    'redirect_url': 'https://addons.mozilla.org/fxa-authenticate',
-    'skip_register_redirect': True,
 }
 
 
@@ -86,7 +83,6 @@ class TestLoginStartBaseView(WithDynamicEndpoints, TestCase):
         assert parse_qs(url.query) == {
             'action': ['signin'],
             'client_id': ['amodefault'],
-            'redirect_url': ['https://addons.mozilla.org/fxa-authenticate'],
             'scope': ['profile'],
             'state': ['arandomstring'],
         }
@@ -161,7 +157,7 @@ class TestLoginStartView(TestCase):
     def test_default_config_is_used(self):
         assert views.LoginStartView.DEFAULT_FXA_CONFIG_NAME == 'default'
         assert views.LoginStartView.ALLOWED_FXA_CONFIGS == (
-            ['default', 'amo', 'local', 'code-manager'])
+            ['default', 'amo', 'local'])
 
 
 class TestLoginUserAndRegisterUser(TestCase):
@@ -630,7 +626,6 @@ class TestWithUser(TestCase):
             'acr_values': ['AAL2'],
             'action': ['signin'],
             'client_id': [fxa_config['client_id']],
-            'redirect_url': [fxa_config['redirect_url']],
             'scope': ['profile'],
             'state': ['some-blob:{next_path}'.format(
                 next_path=force_text(next_path))],
@@ -894,30 +889,6 @@ class TestAuthenticateView(TestCase, PatchMixin, InitializeSessionMixin):
                 reverse('users.edit'),  # No '?to=...'
                 target_status_code=200)
         self.fxa_identify.assert_called_with('codes!!', config=FXA_CONFIG)
-        assert not self.login_user.called
-        self.register_user.assert_called_with(
-            views.AuthenticateView, mock.ANY, identity)
-
-    @mock.patch('olympia.accounts.views.AuthenticateView.ALLOWED_FXA_CONFIGS',
-                ['default', 'skip'])
-    def test_register_redirects_next_when_config_says_to(self):
-        user_qs = UserProfile.objects.filter(email='me@yeahoo.com')
-        assert not user_qs.exists()
-        identity = {u'email': u'me@yeahoo.com', u'uid': u'e0b6f'}
-        self.fxa_identify.return_value = identity
-        user = UserProfile(username='foo', email='me@yeahoo.com')
-        self.register_user.return_value = user
-        response = self.client.get(self.url, {
-            'code': 'codes!!',
-            'state': ':'.join(
-                [self.fxa_state,
-                 force_text(base64.urlsafe_b64encode(b'/go/here'))]),
-            'config': 'skip',
-        })
-        self.fxa_identify.assert_called_with(
-            'codes!!', config=SKIP_REDIRECT_FXA_CONFIG)
-        self.assertRedirects(
-            response, '/go/here', fetch_redirect_response=False)
         assert not self.login_user.called
         self.register_user.assert_called_with(
             views.AuthenticateView, mock.ANY, identity)

--- a/src/olympia/accounts/urls.py
+++ b/src/olympia/accounts/urls.py
@@ -23,9 +23,7 @@ notifications = NestedSimpleRouter(accounts, r'account', lookup='user')
 notifications.register(r'notifications', views.AccountNotificationViewSet,
                        basename='notification')
 
-urlpatterns = [
-    url(r'^authenticate/$', views.AuthenticateView.as_view(),
-        name='accounts.authenticate'),
+accounts_v4 = [
     url(r'^login/start/$',
         views.LoginStartView.as_view(),
         name='accounts.login_start'),
@@ -41,4 +39,15 @@ urlpatterns = [
     url(r'', include(collections.urls)),
     url(r'', include(sub_collections.urls)),
     url(r'', include(notifications.urls)),
+]
+
+accounts_v3 = accounts_v4 + [
+    url(r'^authenticate/$', views.AuthenticateView.as_view(),
+        name='accounts.authenticate'),
+]
+
+auth_callback_patterns = [
+    url(r'^authenticate-callback/$', views.AuthenticateView.as_view(),
+        name='accounts.authenticate'),
+
 ]

--- a/src/olympia/accounts/utils.py
+++ b/src/olympia/accounts/utils.py
@@ -53,7 +53,6 @@ def fxa_login_url(config, state, next_path=None, action=None,
             urlsafe_b64encode(next_path.encode('utf-8'))).rstrip('=')
     query = {
         'client_id': config['client_id'],
-        'redirect_url': config['redirect_url'],
         'scope': 'profile',
         'state': state,
     }

--- a/src/olympia/accounts/verify.py
+++ b/src/olympia/accounts/verify.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+
 import requests
 
 from django_statsd.clients import statsd
@@ -27,7 +29,7 @@ def fxa_identify(code, config=None):
 def get_fxa_token(code, config):
     log.debug('Getting token [{code}]'.format(code=code))
     with statsd.timer('accounts.fxa.identify.token'):
-        response = requests.post(config['oauth_host'] + '/token', data={
+        response = requests.post(settings.FXA_OAUTH_HOST + '/token', data={
             'code': code,
             'client_id': config['client_id'],
             'client_secret': config['client_secret'],
@@ -53,9 +55,11 @@ def get_fxa_token(code, config):
 def get_fxa_profile(token, config):
     log.debug('Getting profile [{token}]'.format(token=token))
     with statsd.timer('accounts.fxa.identify.profile'):
-        response = requests.get(config['profile_host'] + '/profile', headers={
-            'Authorization': 'Bearer {token}'.format(token=token),
-        })
+        response = requests.get(
+            settings.FXA_PROFILE_HOST + '/profile', headers={
+                'Authorization': 'Bearer {token}'.format(token=token),
+            }
+        )
     if response.status_code == 200:
         profile = response.json()
         if profile.get('email'):

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -323,15 +323,15 @@ class FxAConfigMixin(object):
     ALLOWED_FXA_CONFIGS = settings.ALLOWED_FXA_CONFIGS
 
     def get_config_name(self, request):
-        return request.GET.get('config', self.DEFAULT_FXA_CONFIG_NAME)
-
-    def get_fxa_config(self, request):
-        config_name = self.get_config_name(request)
+        config_name = request.GET.get('config', self.DEFAULT_FXA_CONFIG_NAME)
         if config_name not in self.ALLOWED_FXA_CONFIGS:
             log.info('Using default FxA config instead of {}'.format(
                 config_name))
             config_name = self.DEFAULT_FXA_CONFIG_NAME
-        return settings.FXA_CONFIG[config_name]
+        return config_name
+
+    def get_fxa_config(self, request):
+        return settings.FXA_CONFIG[self.get_config_name(request)]
 
 
 class LoginStartView(FxAConfigMixin, APIView):

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -360,13 +360,11 @@ class AuthenticateView(FxAConfigMixin, APIView):
         # logging them on.
         if user is None:
             user = register_user(self.__class__, request, identity)
-            fxa_config = self.get_fxa_config(request)
-            if fxa_config.get('skip_register_redirect') is not True:
-                edit_page = reverse('users.edit')
-                if _is_safe_url(next_path, request):
-                    next_path = f'{edit_page}?to={quote_plus(next_path)}'
-                else:
-                    next_path = edit_page
+            edit_page = reverse('users.edit')
+            if _is_safe_url(next_path, request):
+                next_path = f'{edit_page}?to={quote_plus(next_path)}'
+            else:
+                next_path = edit_page
             response = safe_redirect(next_path, 'register', request)
         else:
             login_user(self.__class__, request, user, identity)

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -213,21 +213,13 @@ def parse_next_path(state_parts, request=None):
     return next_path
 
 
-def with_user(format, config=None):
+def with_user(format):
 
     def outer(fn):
         @functools.wraps(fn)
         @use_primary_db
         def inner(self, request):
-            if config is None:
-                if hasattr(self, 'get_fxa_config'):
-                    fxa_config = self.get_fxa_config(request)
-                else:
-                    fxa_config = (
-                        settings.FXA_CONFIG[settings.DEFAULT_FXA_CONFIG_NAME])
-            else:
-                fxa_config = config
-
+            fxa_config = self.get_fxa_config(request)
             if request.method == 'GET':
                 data = request.query_params
             else:
@@ -327,23 +319,22 @@ def add_api_token_to_response(response, user):
 
 
 class FxAConfigMixin(object):
+    DEFAULT_FXA_CONFIG_NAME = settings.DEFAULT_FXA_CONFIG_NAME
+    ALLOWED_FXA_CONFIGS = settings.ALLOWED_FXA_CONFIGS
 
     def get_config_name(self, request):
         return request.GET.get('config', self.DEFAULT_FXA_CONFIG_NAME)
 
-    def get_allowed_configs(self):
-        return getattr(
-            self, 'ALLOWED_FXA_CONFIGS', [self.DEFAULT_FXA_CONFIG_NAME])
-
     def get_fxa_config(self, request):
         config_name = self.get_config_name(request)
-        if config_name in self.get_allowed_configs():
-            return settings.FXA_CONFIG[config_name]
-        log.info('Using default FxA config instead of {}'.format(config_name))
-        return settings.FXA_CONFIG[self.DEFAULT_FXA_CONFIG_NAME]
+        if config_name not in self.ALLOWED_FXA_CONFIGS:
+            log.info('Using default FxA config instead of {}'.format(
+                config_name))
+            config_name = self.DEFAULT_FXA_CONFIG_NAME
+        return settings.FXA_CONFIG[config_name]
 
 
-class LoginStartBaseView(FxAConfigMixin, APIView):
+class LoginStartView(FxAConfigMixin, APIView):
 
     def get(self, request):
         request.session.setdefault('fxa_state', generate_fxa_state())
@@ -358,14 +349,7 @@ class LoginStartBaseView(FxAConfigMixin, APIView):
         )
 
 
-class LoginStartView(LoginStartBaseView):
-    DEFAULT_FXA_CONFIG_NAME = settings.DEFAULT_FXA_CONFIG_NAME
-    ALLOWED_FXA_CONFIGS = settings.ALLOWED_FXA_CONFIGS
-
-
 class AuthenticateView(FxAConfigMixin, APIView):
-    DEFAULT_FXA_CONFIG_NAME = settings.DEFAULT_FXA_CONFIG_NAME
-    ALLOWED_FXA_CONFIGS = settings.ALLOWED_FXA_CONFIGS
 
     authentication_classes = (SessionAuthentication,)
 

--- a/src/olympia/amo/tests/test_readonly.py
+++ b/src/olympia/amo/tests/test_readonly.py
@@ -20,7 +20,10 @@ def read_only_mode(client, settings, db):
 
     from olympia.lib.settings_base import read_only_mode
 
-    env = {key: getattr(settings, key) for key in settings._explicit_settings}
+    env = {
+        'REPLICA_DATABASES': settings.REPLICA_DATABASES,
+        'DATABASES': settings.DATABASES,
+    }
 
     read_only_mode(env)
 
@@ -41,7 +44,7 @@ def test_db_error(read_only_mode):
 
 
 def test_bail_on_post(read_only_mode, client):
-    response = client.post('/en-US/firefox/')
+    response = client.post('/en-US/developers/')
     assert response.status_code == 503
     title = pq(response.content)('title').text()
     assert title.startswith('Maintenance in progress'), title

--- a/src/olympia/api/urls.py
+++ b/src/olympia/api/urls.py
@@ -1,5 +1,7 @@
 from django.conf.urls import include, url
 
+from olympia.accounts.urls import (
+    accounts_v3, accounts_v4, auth_callback_patterns)
 from olympia.amo.urls import api_patterns as amo_api_patterns
 from olympia.addons.api_urls import addons_v3, addons_v4
 from olympia.ratings.api_urls import ratings_v3, ratings_v4
@@ -7,7 +9,7 @@ from olympia.ratings.api_urls import ratings_v3, ratings_v4
 
 v3_api_urls = [
     url(r'^abuse/', include('olympia.abuse.urls')),
-    url(r'^accounts/', include('olympia.accounts.urls')),
+    url(r'^accounts/', include(accounts_v3)),
     url(r'^addons/', include(addons_v3)),
     url(r'^', include('olympia.discovery.api_urls')),
     url(r'^reviews/', include(ratings_v3.urls)),
@@ -18,7 +20,7 @@ v3_api_urls = [
 
 v4_api_urls = [
     url(r'^abuse/', include('olympia.abuse.urls')),
-    url(r'^accounts/', include('olympia.accounts.urls')),
+    url(r'^accounts/', include(accounts_v4)),
     url(r'^activity/', include('olympia.activity.urls')),
     url(r'^addons/', include(addons_v4)),
     url(r'^', include('olympia.discovery.api_urls')),
@@ -30,6 +32,7 @@ v4_api_urls = [
 ]
 
 urlpatterns = [
+    url(r'^auth/', include((auth_callback_patterns, 'auth'))),
     url(r'^v3/', include((v3_api_urls, 'v3'))),
     url(r'^v4/', include((v4_api_urls, 'v4'))),
     url(r'^v5/', include((v4_api_urls, 'v5'))),

--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -105,39 +105,23 @@ FXA_CONFIG = {
     'default': {
         'client_id': env('FXA_CLIENT_ID'),
         'client_secret': env('FXA_CLIENT_SECRET'),
-        'content_host': 'https://stable.dev.lcip.org',
-        'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
-        'profile_host': 'https://stable.dev.lcip.org/profile/v1',
         'redirect_url':
             'https://%s/api/v3/accounts/authenticate/' % DOMAIN,
-        'scope': 'profile',
     },
     'amo': {
         'client_id': env('AMO_FXA_CLIENT_ID'),
         'client_secret': env('AMO_FXA_CLIENT_SECRET'),
-        'content_host': 'https://stable.dev.lcip.org',
-        'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
-        'profile_host': 'https://stable.dev.lcip.org/profile/v1',
         'redirect_url': 'https://addons-dev.allizom.org/api/v3/accounts/authenticate/?config=amo', # noqa
-        'scope': 'profile',
     },
     'local': {
         'client_id': env('DEVELOPMENT_FXA_CLIENT_ID'),
         'client_secret': env('DEVELOPMENT_FXA_CLIENT_SECRET'),
-        'content_host': 'https://stable.dev.lcip.org',
-        'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
-        'profile_host': 'https://stable.dev.lcip.org/profile/v1',
         'redirect_url': 'http://localhost:3000/api/v3/accounts/authenticate/?config=local', # noqa
-        'scope': 'profile',
     },
     'code-manager': {
         'client_id': env('CODE_MANAGER_FXA_CLIENT_ID'),
         'client_secret': env('CODE_MANAGER_FXA_CLIENT_SECRET'),
-        'content_host': 'https://stable.dev.lcip.org',
-        'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
-        'profile_host': 'https://stable.dev.lcip.org/profile/v1',
         'redirect_url': 'https://addons-dev.allizom.org/api/v4/accounts/authenticate/?config=code-manager', # noqa
-        'scope': 'profile',
     },
 }
 DEFAULT_FXA_CONFIG_NAME = 'default'

--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -105,27 +105,16 @@ FXA_CONFIG = {
     'default': {
         'client_id': env('FXA_CLIENT_ID'),
         'client_secret': env('FXA_CLIENT_SECRET'),
-        'redirect_url':
-            'https://%s/api/v3/accounts/authenticate/' % DOMAIN,
-    },
-    'amo': {
-        'client_id': env('AMO_FXA_CLIENT_ID'),
-        'client_secret': env('AMO_FXA_CLIENT_SECRET'),
-        'redirect_url': 'https://addons-dev.allizom.org/api/v3/accounts/authenticate/?config=amo', # noqa
+        # redirect_uri = 'https://%s/api/auth/authenticate-callback/' % DOMAIN,
     },
     'local': {
         'client_id': env('DEVELOPMENT_FXA_CLIENT_ID'),
         'client_secret': env('DEVELOPMENT_FXA_CLIENT_SECRET'),
-        'redirect_url': 'http://localhost:3000/api/v3/accounts/authenticate/?config=local', # noqa
-    },
-    'code-manager': {
-        'client_id': env('CODE_MANAGER_FXA_CLIENT_ID'),
-        'client_secret': env('CODE_MANAGER_FXA_CLIENT_SECRET'),
-        'redirect_url': 'https://addons-dev.allizom.org/api/v4/accounts/authenticate/?config=code-manager', # noqa
+        # redirect_uri = 'http://localhost:3000/api/auth/authenticate-callback/?config=local', # noqa
     },
 }
 DEFAULT_FXA_CONFIG_NAME = 'default'
-ALLOWED_FXA_CONFIGS = ['default', 'amo', 'local', 'code-manager']
+ALLOWED_FXA_CONFIGS = ['default', 'local']
 
 FXA_SQS_AWS_QUEUE_URL = (
     'https://sqs.us-east-1.amazonaws.com/927034868273/'

--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -85,34 +85,25 @@ FXA_CONFIG = {
     'default': {
         'client_id': env('FXA_CLIENT_ID'),
         'client_secret': env('FXA_CLIENT_SECRET'),
-        'content_host': 'https://accounts.firefox.com',
-        'oauth_host': 'https://oauth.accounts.firefox.com/v1',
-        'profile_host': 'https://profile.accounts.firefox.com/v1',
         'redirect_url':
             'https://%s/api/v3/accounts/authenticate/' % DOMAIN,
-        'scope': 'profile',
     },
     'amo': {
         'client_id': env('AMO_FXA_CLIENT_ID'),
         'client_secret': env('AMO_FXA_CLIENT_SECRET'),
-        'content_host': 'https://accounts.firefox.com',
-        'oauth_host': 'https://oauth.accounts.firefox.com/v1',
-        'profile_host': 'https://profile.accounts.firefox.com/v1',
         'redirect_url': 'https://addons.mozilla.org/api/v3/accounts/authenticate/?config=amo', # noqa
-        'scope': 'profile',
         'skip_register_redirect': True,
     },
     'code-manager': {
         'client_id': env('CODE_MANAGER_FXA_CLIENT_ID'),
         'client_secret': env('CODE_MANAGER_FXA_CLIENT_SECRET'),
-        'content_host': 'https://accounts.firefox.com',
-        'oauth_host': 'https://oauth.accounts.firefox.com/v1',
-        'profile_host': 'https://profile.accounts.firefox.com/v1',
         'redirect_url': 'https://addons.mozilla.org/api/v4/accounts/authenticate/?config=code-manager', # noqa
-        'scope': 'profile',
         'skip_register_redirect': True,
     },
 }
+FXA_CONTENT_HOST = 'https://accounts.firefox.com'
+FXA_OAUTH_HOST = 'https://oauth.accounts.firefox.com/v1'
+FXA_PROFILE_HOST = 'https://profile.accounts.firefox.com/v1'
 DEFAULT_FXA_CONFIG_NAME = 'default'
 ALLOWED_FXA_CONFIGS = ['default', 'amo', 'code-manager']
 

--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -85,27 +85,14 @@ FXA_CONFIG = {
     'default': {
         'client_id': env('FXA_CLIENT_ID'),
         'client_secret': env('FXA_CLIENT_SECRET'),
-        'redirect_url':
-            'https://%s/api/v3/accounts/authenticate/' % DOMAIN,
-    },
-    'amo': {
-        'client_id': env('AMO_FXA_CLIENT_ID'),
-        'client_secret': env('AMO_FXA_CLIENT_SECRET'),
-        'redirect_url': 'https://addons.mozilla.org/api/v3/accounts/authenticate/?config=amo', # noqa
-        'skip_register_redirect': True,
-    },
-    'code-manager': {
-        'client_id': env('CODE_MANAGER_FXA_CLIENT_ID'),
-        'client_secret': env('CODE_MANAGER_FXA_CLIENT_SECRET'),
-        'redirect_url': 'https://addons.mozilla.org/api/v4/accounts/authenticate/?config=code-manager', # noqa
-        'skip_register_redirect': True,
+        # redirect_uri = 'https://%s/api/auth/authenticate-callback/' % DOMAIN,
     },
 }
 FXA_CONTENT_HOST = 'https://accounts.firefox.com'
 FXA_OAUTH_HOST = 'https://oauth.accounts.firefox.com/v1'
 FXA_PROFILE_HOST = 'https://profile.accounts.firefox.com/v1'
 DEFAULT_FXA_CONFIG_NAME = 'default'
-ALLOWED_FXA_CONFIGS = ['default', 'amo', 'code-manager']
+ALLOWED_FXA_CONFIGS = ['default']
 
 ES_DEFAULT_NUM_SHARDS = 10
 

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -99,29 +99,16 @@ FXA_CONFIG = {
     'default': {
         'client_id': env('FXA_CLIENT_ID'),
         'client_secret': env('FXA_CLIENT_SECRET'),
-        'redirect_url':
-            'https://%s/api/v3/accounts/authenticate/' % DOMAIN,
-    },
-    'amo': {
-        'client_id': env('AMO_FXA_CLIENT_ID'),
-        'client_secret': env('AMO_FXA_CLIENT_SECRET'),
-        'redirect_url': 'https://addons.allizom.org/api/v3/accounts/authenticate/?config=amo', # noqa
-        'skip_register_redirect': True,
+        # redirect_uri = 'https://%s/api/auth/authenticate-callback/' % DOMAIN,
     },
     'local': {
         'client_id': env('DEVELOPMENT_FXA_CLIENT_ID'),
         'client_secret': env('DEVELOPMENT_FXA_CLIENT_SECRET'),
-        'redirect_url': 'http://localhost:3000/api/v3/accounts/authenticate/?config=local', # noqa
-    },
-    'code-manager': {
-        'client_id': env('CODE_MANAGER_FXA_CLIENT_ID'),
-        'client_secret': env('CODE_MANAGER_FXA_CLIENT_SECRET'),
-        'redirect_url': 'https://addons.allizom.org/api/v4/accounts/authenticate/?config=code-manager', # noqa
-        'skip_register_redirect': True,
+        # redirect_uri = 'http://localhost:3000/api/auth/authenticate-callback/?config=local', # noqa
     },
 }
 DEFAULT_FXA_CONFIG_NAME = 'default'
-ALLOWED_FXA_CONFIGS = ['default', 'amo', 'local', 'code-manager']
+ALLOWED_FXA_CONFIGS = ['default', 'local']
 
 TAAR_LITE_RECOMMENDATION_ENGINE_URL = env(
     'TAAR_LITE_RECOMMENDATION_ENGINE_URL',

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -99,40 +99,24 @@ FXA_CONFIG = {
     'default': {
         'client_id': env('FXA_CLIENT_ID'),
         'client_secret': env('FXA_CLIENT_SECRET'),
-        'content_host': 'https://accounts.firefox.com',
-        'oauth_host': 'https://oauth.accounts.firefox.com/v1',
-        'profile_host': 'https://profile.accounts.firefox.com/v1',
         'redirect_url':
             'https://%s/api/v3/accounts/authenticate/' % DOMAIN,
-        'scope': 'profile',
     },
     'amo': {
         'client_id': env('AMO_FXA_CLIENT_ID'),
         'client_secret': env('AMO_FXA_CLIENT_SECRET'),
-        'content_host': 'https://accounts.firefox.com',
-        'oauth_host': 'https://oauth.accounts.firefox.com/v1',
-        'profile_host': 'https://profile.accounts.firefox.com/v1',
         'redirect_url': 'https://addons.allizom.org/api/v3/accounts/authenticate/?config=amo', # noqa
-        'scope': 'profile',
         'skip_register_redirect': True,
     },
     'local': {
         'client_id': env('DEVELOPMENT_FXA_CLIENT_ID'),
         'client_secret': env('DEVELOPMENT_FXA_CLIENT_SECRET'),
-        'content_host': 'https://stable.dev.lcip.org',
-        'oauth_host': 'https://oauth-stable.dev.lcip.org/v1',
-        'profile_host': 'https://stable.dev.lcip.org/profile/v1',
         'redirect_url': 'http://localhost:3000/api/v3/accounts/authenticate/?config=local', # noqa
-        'scope': 'profile',
     },
     'code-manager': {
         'client_id': env('CODE_MANAGER_FXA_CLIENT_ID'),
         'client_secret': env('CODE_MANAGER_FXA_CLIENT_SECRET'),
-        'content_host': 'https://accounts.firefox.com',
-        'oauth_host': 'https://oauth.accounts.firefox.com/v1',
-        'profile_host': 'https://profile.accounts.firefox.com/v1',
         'redirect_url': 'https://addons.allizom.org/api/v4/accounts/authenticate/?config=code-manager', # noqa
-        'scope': 'profile',
         'skip_register_redirect': True,
     },
 }

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1782,6 +1782,9 @@ SHELL_PLUS_POST_IMPORTS = (
     ('olympia', 'amo'),
 )
 
+FXA_CONTENT_HOST = 'https://stable.dev.lcip.org'
+FXA_OAUTH_HOST = 'https://oauth-stable.dev.lcip.org/v1'
+FXA_PROFILE_HOST = 'https://stable.dev.lcip.org/profile/v1'
 DEFAULT_FXA_CONFIG_NAME = 'default'
 ALLOWED_FXA_CONFIGS = ['default']
 

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -96,8 +96,8 @@ ADDONS_LINTER_BIN = env(
 DELETION_EMAIL = 'amo-notifications+deletion@mozilla.org'
 THEMES_EMAIL = 'theme-reviews@mozilla.org'
 
-DRF_API_VERSIONS = ['v3', 'v4', 'v5']
-DRF_API_REGEX = r'^/?api/(?:v3|v4|v5)/'
+DRF_API_VERSIONS = ['auth', 'v3', 'v4', 'v5']
+DRF_API_REGEX = r'^/?api/(?:auth|v3|v4|v5)/'
 
 # Add Access-Control-Allow-Origin: * header for the new API with
 # django-cors-headers.
@@ -1671,6 +1671,7 @@ JWT_AUTH = {
 }
 
 DRF_API_GATES = {
+    'auth': (),
     'v3': (
         'ratings-rating-shim',
         'ratings-title-shim',


### PR DESCRIPTION
this would fix #10487 - and #12417 if the outcome of that issue is to always redirect for new users (if it's something else the pr would need changes).

It drops the most of the configs because undefined config names will fall back to `default` - without the `skip_register_redirect` differences they will be the same, apart from on local dev which has some extra functionality, and `config=local` which always redirects to a localhost url.

I generated some new fxa clients (id/secret pairs) for local dev; dev, stage, and prod will need ones generating by ops and adding to the env files.  I left the `api/v3/accounts/authenticate` in place for the meantime so localhost callbacks from fxa on dev & stage should work until there is a new deploy that updates the env.