### PR TITLE
fixed debugtool middleware be after GZip middleware

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -19,13 +19,15 @@ INSTALLED_APPS += (
     'debug_toolbar',
 )
 
-# If the DebugToolbar be before the GZip in MIDDLEWARE, appeared the WARNINGS.
+# django-debug-doolbar middleware needs to be inserted as high as possible
+# but after GZip middleware
 def insert_debug_toolbar_middleware(middlewares):
     ret_middleware = list(middlewares)
 
     for i, middleware in enumerate(ret_middleware):
         if 'GZipMiddleware' in middleware:
-            ret_middleware.insert(i+1, 'debug_toolbar.middleware.DebugToolbarMiddleware')
+            ret_middleware.insert(
+                i + 1, 'debug_toolbar.middleware.DebugToolbarMiddleware')
             break
 
     return tuple(ret_middleware)

--- a/settings.py
+++ b/settings.py
@@ -19,7 +19,18 @@ INSTALLED_APPS += (
     'debug_toolbar',
 )
 
-MIDDLEWARE = ('debug_toolbar.middleware.DebugToolbarMiddleware',) + MIDDLEWARE
+# If the DebugToolbar be before the GZip in MIDDLEWARE, appeared the WARNINGS.
+def insert_debug_toolbar_middleware(middlewares):
+    ret_middleware = list(middlewares)
+
+    for i, middleware in enumerate(ret_middleware):
+        if 'GZipMiddleware' in middleware:
+            ret_middleware.insert(i+1, 'debug_toolbar.middleware.DebugToolbarMiddleware')
+            break
+
+    return tuple(ret_middleware)
+
+MIDDLEWARE = insert_debug_toolbar_middleware(MIDDLEWARE)
 
 DEBUG_TOOLBAR_CONFIG = {
     # Enable django-debug-toolbar locally, if DEBUG is True.


### PR DESCRIPTION
Fixes #11819 

If the DebugToolbar be before the GZip, appeared the WARNINGS on local dev. I revised that debug tool middleware sequence be after GZip middleware.

**Before**
![debug_toolbar_warnings](https://user-images.githubusercontent.com/29684524/65733866-619bc880-e10b-11e9-974b-9996be01f291.png)

**After**
Not see the WARNINGS