### PR TITLE
Add guards in Version model

### DIFF
--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -291,26 +291,27 @@ class Version(OnChangeMixin, ModelBase):
 
         version_uploaded.send(instance=version, sender=Version)
 
-        if waffle.switch_is_active('enable-yara'):
-            try:
-                yara_result = YaraResult.objects.get(upload_id=upload.id)
-                yara_result.version = version
-                yara_result.save()
-            except YaraResult.DoesNotExist:
-                log.exception('Could not find a YaraResult for FileUpload %s',
-                            upload.id)
+        if version.is_webextension:
+            if waffle.switch_is_active('enable-yara'):
+                try:
+                    yara_result = YaraResult.objects.get(upload_id=upload.id)
+                    yara_result.version = version
+                    yara_result.save()
+                except YaraResult.DoesNotExist:
+                    log.exception('Could not find a YaraResult for FileUpload '
+                                  '%s', upload.id)
 
-        if (
-                waffle.switch_is_active('enable-customs') or
-                waffle.switch_is_active('enable-wat')
-        ):
-            try:
-                ScannersResult.objects.filter(upload_id=upload.id).update(
-                    version=version
-                )
-            except ScannersResult.DoesNotExist:
-                log.exception('Could not find ScannersResults for FileUpload '
-                              '%s', upload.id)
+            if (
+                    waffle.switch_is_active('enable-customs') or
+                    waffle.switch_is_active('enable-wat')
+            ):
+                try:
+                    ScannersResult.objects.filter(upload_id=upload.id).update(
+                        version=version
+                    )
+                except ScannersResult.DoesNotExist:
+                    log.exception('Could not find ScannersResults for '
+                                  'FileUpload %s', upload.id)
 
         # Extract this version into git repository
         transaction.on_commit(

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -305,13 +305,8 @@ class Version(OnChangeMixin, ModelBase):
                     waffle.switch_is_active('enable-customs') or
                     waffle.switch_is_active('enable-wat')
             ):
-                try:
-                    ScannersResult.objects.filter(upload_id=upload.id).update(
-                        version=version
-                    )
-                except ScannersResult.DoesNotExist:
-                    log.exception('Could not find ScannersResults for '
-                                  'FileUpload %s', upload.id)
+                ScannersResult.objects.filter(upload_id=upload.id).update(
+                    version=version)
 
         # Extract this version into git repository
         transaction.on_commit(

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -291,21 +291,26 @@ class Version(OnChangeMixin, ModelBase):
 
         version_uploaded.send(instance=version, sender=Version)
 
-        try:
-            yara_result = YaraResult.objects.get(upload_id=upload.id)
-            yara_result.version = version
-            yara_result.save()
-        except YaraResult.DoesNotExist:
-            log.exception('Could not find a YaraResult for FileUpload %s',
-                          upload.id)
+        if waffle.switch_is_active('enable-yara'):
+            try:
+                yara_result = YaraResult.objects.get(upload_id=upload.id)
+                yara_result.version = version
+                yara_result.save()
+            except YaraResult.DoesNotExist:
+                log.exception('Could not find a YaraResult for FileUpload %s',
+                            upload.id)
 
-        try:
-            ScannersResult.objects.filter(upload_id=upload.id).update(
-                version=version
-            )
-        except ScannersResult.DoesNotExist:
-            log.exception('Could not find ScannersResults for FileUpload %s',
-                          upload.id)
+        if (
+                waffle.switch_is_active('enable-customs') or
+                waffle.switch_is_active('enable-wat')
+        ):
+            try:
+                ScannersResult.objects.filter(upload_id=upload.id).update(
+                    version=version
+                )
+            except ScannersResult.DoesNotExist:
+                log.exception('Could not find ScannersResults for FileUpload '
+                              '%s', upload.id)
 
         # Extract this version into git repository
         transaction.on_commit(

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -909,6 +909,7 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
                                       amo.RELEASE_CHANNEL_LISTED,
                                       parsed_data=self.dummy_parsed_data)
 
+        assert version.is_webextension
         scanners_result.refresh_from_db()
         assert scanners_result.version == version
 
@@ -924,7 +925,7 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
                                       amo.RELEASE_CHANNEL_LISTED,
                                       parsed_data=self.dummy_parsed_data)
 
-        assert version.is_webextension == True
+        assert version.is_webextension
         scanners_result.refresh_from_db()
         assert scanners_result.version == version
 
@@ -978,6 +979,7 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
                                       amo.RELEASE_CHANNEL_LISTED,
                                       parsed_data=self.dummy_parsed_data)
 
+        assert version.is_webextension
         yara_result.refresh_from_db()
         assert yara_result.version == version
 

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -929,14 +929,6 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
         scanners_result.refresh_from_db()
         assert scanners_result.version == version
 
-    def test_does_not_raise_when_scanners_result_does_not_exist(self):
-        self.create_switch('enable-customs', active=True)
-        Version.from_upload(self.upload,
-                            self.addon,
-                            [self.selected_app],
-                            amo.RELEASE_CHANNEL_LISTED,
-                            parsed_data=self.dummy_parsed_data)
-
     def test_does_nothing_when_no_scanner_is_enabled(self):
         self.create_switch('enable-customs', active=False)
         self.create_switch('enable-wat', active=False)

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -23,7 +23,7 @@ from olympia.amo.tests import (
 from olympia.amo.tests.test_models import BasePreviewMixin
 from olympia.amo.utils import utc_millesecs_from_epoch
 from olympia.applications.models import AppVersion
-from olympia.constants.scanners import CUSTOMS
+from olympia.constants.scanners import CUSTOMS, WAT
 from olympia.files.models import File, FileUpload
 from olympia.files.tests.test_models import UploadTest
 from olympia.files.utils import parse_addon
@@ -893,7 +893,8 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
         # _current_version changes, which isn't the case here.
         assert sync_object_to_basket_mock.delay.call_count == 0
 
-    def test_set_version_to_scanners_result(self):
+    def test_set_version_to_customs_scanners_result(self):
+        self.create_switch('enable-customs', active=True)
         scanners_result = ScannersResult.objects.create(
             upload=self.upload, scanner=CUSTOMS)
         assert scanners_result.version is None
@@ -907,14 +908,47 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
         scanners_result.refresh_from_db()
         assert scanners_result.version == version
 
+    def test_set_version_to_wat_scanners_result(self):
+        self.create_switch('enable-wat', active=True)
+        scanners_result = ScannersResult.objects.create(
+            upload=self.upload, scanner=WAT)
+        assert scanners_result.version is None
+
+        version = Version.from_upload(self.upload,
+                                      self.addon,
+                                      [self.selected_app],
+                                      amo.RELEASE_CHANNEL_LISTED,
+                                      parsed_data=self.dummy_parsed_data)
+
+        scanners_result.refresh_from_db()
+        assert scanners_result.version == version
+
     def test_does_not_raise_when_scanners_result_does_not_exist(self):
+        self.create_switch('enable-customs', active=True)
         Version.from_upload(self.upload,
                             self.addon,
                             [self.selected_app],
                             amo.RELEASE_CHANNEL_LISTED,
                             parsed_data=self.dummy_parsed_data)
 
+    def test_does_nothing_when_no_scanner_is_enabled(self):
+        self.create_switch('enable-customs', active=False)
+        self.create_switch('enable-wat', active=False)
+        scanners_result = ScannersResult.objects.create(
+            upload=self.upload, scanner=CUSTOMS)
+        assert scanners_result.version is None
+
+        version = Version.from_upload(self.upload,
+                                      self.addon,
+                                      [self.selected_app],
+                                      amo.RELEASE_CHANNEL_LISTED,
+                                      parsed_data=self.dummy_parsed_data)
+
+        scanners_result.refresh_from_db()
+        assert scanners_result.version is None
+
     def test_set_version_to_yara_result(self):
+        self.create_switch('enable-yara', active=True)
         yara_result = YaraResult.objects.create(upload=self.upload)
         assert yara_result.version is None
 
@@ -927,10 +961,24 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
         assert yara_result.version == version
 
     def test_does_not_raise_when_yara_result_does_not_exist(self):
+        self.create_switch('enable-yara', active=True)
         Version.from_upload(self.upload, self.addon,
                             [self.selected_app],
                             amo.RELEASE_CHANNEL_LISTED,
                             parsed_data=self.dummy_parsed_data)
+
+    def test_does_nothing_when_yara_is_not_enabled(self):
+        self.create_switch('enable-yara', active=False)
+        yara_result = YaraResult.objects.create(upload=self.upload)
+        assert yara_result.version is None
+
+        version = Version.from_upload(self.upload, self.addon,
+                                      [self.selected_app],
+                                      amo.RELEASE_CHANNEL_LISTED,
+                                      parsed_data=self.dummy_parsed_data)
+
+        yara_result.refresh_from_db()
+        assert yara_result.version is None
 
 
 class TestExtensionVersionFromUploadTransactional(


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/12448

---

If Sentry was receiving the `log.exception()` calls (#12446), we would have noticed this before.