### PR TITLE
drop unused import to fix codestyle tests

### DIFF
--- a/src/olympia/ratings/tests/test_views.py
+++ b/src/olympia/ratings/tests/test_views.py
@@ -8,8 +8,6 @@ from django.core import mail
 from django.test.utils import override_settings
 from django.utils.encoding import force_text
 
-from unittest import mock
-
 from freezegun import freeze_time
 from rest_framework.exceptions import ErrorDetail
 


### PR DESCRIPTION
in between #12389 being created, and merged, the last remaining use of `mock` in ratings/tests/test_views.py seems to have been removed so the master codestyle tests are failing.