### PR TITLE
Add a chord() to the validation chain()

### DIFF
--- a/src/olympia/devhub/tasks.py
+++ b/src/olympia/devhub/tasks.py
@@ -279,7 +279,7 @@ def forward_linter_results(results, upload_pk):
     linter results to `handle_upload_validation_result()` (the callback of the
     chord).
     """
-    log.info('Called forward_linter_results() for upload_pk = %d' % upload_pk)
+    log.info('Called forward_linter_results() for upload_pk = %d', upload_pk)
     return results
 
 
@@ -288,7 +288,12 @@ def forward_linter_results(results, upload_pk):
 def handle_upload_validation_result(all_results, upload_pk, channel,
                                     is_mozilla_signed):
     """Annotate a set of validation results and save them to the given
-    FileUpload instance."""
+    FileUpload instance.
+
+    This task is the callback of the Celery chord in the validation chain. It
+    receives all the results returned by all the tasks in this chord (in
+    `all_results`).
+    """
     # This task is the callback of a Celery chord and receives all the results
     # returned by all the tasks in this chord. The first task registered in the
     # chord is `forward_linter_results()`:

--- a/src/olympia/devhub/tasks.py
+++ b/src/olympia/devhub/tasks.py
@@ -273,12 +273,27 @@ def validate_file_path(path, channel):
     return run_addons_linter(path, channel=channel)
 
 
+@validation_task
+def forward_linter_results(results, upload_pk):
+    """This task is used in the chord of the validation chain to pass the
+    linter results to `handle_upload_validation_result()` (the callback of the
+    chord).
+    """
+    log.info('Called forward_linter_results() for upload_pk = %d' % upload_pk)
+    return results
+
+
 @task
 @use_primary_db
-def handle_upload_validation_result(
-        results, upload_pk, channel, is_mozilla_signed):
+def handle_upload_validation_result(all_results, upload_pk, channel,
+                                    is_mozilla_signed):
     """Annotate a set of validation results and save them to the given
     FileUpload instance."""
+    # This task is the callback of a Celery chord and receives all the results
+    # returned by all the tasks in this chord. The first task registered in the
+    # chord is `forward_linter_results()`:
+    results = all_results[0]
+
     upload = FileUpload.objects.get(pk=upload_pk)
 
     if waffle.switch_is_active('enable-yara') and results['errors'] == 0:

--- a/src/olympia/devhub/tests/test_tasks.py
+++ b/src/olympia/devhub/tests/test_tasks.py
@@ -224,8 +224,8 @@ class TestMeasureValidationTime(UploadTest, TestCase):
 
     def handle_upload_validation_result(self,
                                         channel=amo.RELEASE_CHANNEL_LISTED):
-        validation = amo.VALIDATOR_SKELETON_RESULTS.copy()
-        tasks.handle_upload_validation_result(validation, self.upload.pk,
+        results = [amo.VALIDATOR_SKELETON_RESULTS.copy()]
+        tasks.handle_upload_validation_result(results, self.upload.pk,
                                               channel, False)
 
     def test_track_upload_validation_results_time(self):
@@ -1266,7 +1266,7 @@ class TestHandleUploadValidationResult(UploadTest, TestCase):
         )
 
         tasks.handle_upload_validation_result(
-            results=amo.VALIDATOR_SKELETON_RESULTS.copy(),
+            all_results=[amo.VALIDATOR_SKELETON_RESULTS.copy()],
             upload_pk=upload.pk,
             channel=amo.RELEASE_CHANNEL_LISTED,
             is_mozilla_signed=False
@@ -1285,7 +1285,7 @@ class TestHandleUploadValidationResult(UploadTest, TestCase):
         )
 
         tasks.handle_upload_validation_result(
-            results=amo.VALIDATOR_SKELETON_EXCEPTION_WEBEXT.copy(),
+            all_results=[amo.VALIDATOR_SKELETON_EXCEPTION_WEBEXT.copy()],
             upload_pk=upload.pk,
             channel=amo.RELEASE_CHANNEL_LISTED,
             is_mozilla_signed=False
@@ -1303,7 +1303,7 @@ class TestHandleUploadValidationResult(UploadTest, TestCase):
         )
 
         tasks.handle_upload_validation_result(
-            results=amo.VALIDATOR_SKELETON_RESULTS.copy(),
+            all_results=[amo.VALIDATOR_SKELETON_RESULTS.copy()],
             upload_pk=upload.pk,
             channel=amo.RELEASE_CHANNEL_LISTED,
             is_mozilla_signed=False
@@ -1320,7 +1320,7 @@ class TestHandleUploadValidationResult(UploadTest, TestCase):
         )
 
         tasks.handle_upload_validation_result(
-            results=amo.VALIDATOR_SKELETON_RESULTS.copy(),
+            all_results=[amo.VALIDATOR_SKELETON_RESULTS.copy()],
             upload_pk=upload.pk,
             channel=amo.RELEASE_CHANNEL_LISTED,
             is_mozilla_signed=False
@@ -1339,7 +1339,7 @@ class TestHandleUploadValidationResult(UploadTest, TestCase):
         )
 
         tasks.handle_upload_validation_result(
-            results=amo.VALIDATOR_SKELETON_EXCEPTION_WEBEXT.copy(),
+            all_results=[amo.VALIDATOR_SKELETON_EXCEPTION_WEBEXT.copy()],
             upload_pk=upload.pk,
             channel=amo.RELEASE_CHANNEL_LISTED,
             is_mozilla_signed=False
@@ -1357,7 +1357,7 @@ class TestHandleUploadValidationResult(UploadTest, TestCase):
         )
 
         tasks.handle_upload_validation_result(
-            results=amo.VALIDATOR_SKELETON_RESULTS.copy(),
+            all_results=[amo.VALIDATOR_SKELETON_RESULTS.copy()],
             upload_pk=upload.pk,
             channel=amo.RELEASE_CHANNEL_LISTED,
             is_mozilla_signed=False
@@ -1374,7 +1374,7 @@ class TestHandleUploadValidationResult(UploadTest, TestCase):
         )
 
         tasks.handle_upload_validation_result(
-            results=amo.VALIDATOR_SKELETON_RESULTS.copy(),
+            all_results=[amo.VALIDATOR_SKELETON_RESULTS.copy()],
             upload_pk=upload.pk,
             channel=amo.RELEASE_CHANNEL_LISTED,
             is_mozilla_signed=False
@@ -1393,7 +1393,7 @@ class TestHandleUploadValidationResult(UploadTest, TestCase):
         )
 
         tasks.handle_upload_validation_result(
-            results=amo.VALIDATOR_SKELETON_EXCEPTION_WEBEXT.copy(),
+            all_results=[amo.VALIDATOR_SKELETON_EXCEPTION_WEBEXT.copy()],
             upload_pk=upload.pk,
             channel=amo.RELEASE_CHANNEL_LISTED,
             is_mozilla_signed=False
@@ -1411,7 +1411,7 @@ class TestHandleUploadValidationResult(UploadTest, TestCase):
         )
 
         tasks.handle_upload_validation_result(
-            results=amo.VALIDATOR_SKELETON_RESULTS.copy(),
+            all_results=[amo.VALIDATOR_SKELETON_RESULTS.copy()],
             upload_pk=upload.pk,
             channel=amo.RELEASE_CHANNEL_LISTED,
             is_mozilla_signed=False
@@ -1447,3 +1447,11 @@ class TestValidationTask(TestCase):
         assert TestValidationTask.fake_task_has_been_called
         assert results != returned_results
         assert 'fake_task_results' in returned_results
+
+
+class TestForwardLinterResults(TestCase):
+
+    def test_returns_received_results(self):
+        results = {'errors': 1}
+        returned_results = tasks.forward_linter_results(results, 123)
+        assert results == returned_results

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1094,6 +1094,7 @@ CELERY_TASK_ROUTES = {
     # AMO Devhub.
     'olympia.devhub.tasks.create_initial_validation_results': {
         'queue': 'devhub'},
+    'olympia.devhub.tasks.forward_linter_results': {'queue': 'devhub'},
     'olympia.devhub.tasks.get_preview_sizes': {'queue': 'devhub'},
     'olympia.devhub.tasks.handle_file_validation_result': {'queue': 'devhub'},
     'olympia.devhub.tasks.handle_upload_validation_result': {


### PR DESCRIPTION
Fixes #11984  
~~⚠️ depends on #12491~~

---

This patch adds a Celery `chord` and a task that forwards the linter results to the chord's callback.