### PR TITLE
Better handle http timeout in `run_scanner`

### DIFF
--- a/src/olympia/scanners/tasks.py
+++ b/src/olympia/scanners/tasks.py
@@ -54,7 +54,7 @@ def run_scanner(upload_pk, scanner, api_url, api_key):
             # Log the response body when JSON decoding has failed.
             raise ValueError(response.text)
 
-        if 'error' in results:
+        if response.status_code != 200 or 'error' in results:
             raise ValueError(results)
 
         result.results = results


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/12510

---

API Gateway returns a 504 HTTP error with a JSON payload when a call has reached the Gateway timeout (30s).