### PR TITLE
Preserve IP addresses for deleted users for 6 months

### DIFF
--- a/src/olympia/users/management/commands/clear_old_last_login_ip.py
+++ b/src/olympia/users/management/commands/clear_old_last_login_ip.py
@@ -13,9 +13,10 @@ class Command(BaseCommand):
     help = 'Clear last_login_ip on users banned more than a year ago'
 
     def handle(self, *args, **options):
-        a_year_ago = datetime.now() - timedelta(days=365)
+        six_months_ago = datetime.now() - timedelta(days=183)
         qs = UserProfile.objects.filter(
-            deleted=True, banned__lt=a_year_ago).exclude(last_login_ip='')
+            deleted=True,
+            modified__lt=six_months_ago).exclude(last_login_ip='')
         log.info('Clearing last_login_ip for %d users', qs.count())
         for user in qs:
             user.update(last_login_ip='', _signal=False)

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -547,7 +547,8 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
                     self, self.email))
                 self.email = None
                 self.fxa_id = None
-                self.last_login_ip = ''
+            # last_login_ip is kept, deleted by clear_old_last_login_ip
+            # command after 6 months.
             self.biography = ''
             self.display_name = None
             self.homepage = ''

--- a/src/olympia/users/tests/test_commands.py
+++ b/src/olympia/users/tests/test_commands.py
@@ -75,23 +75,24 @@ class TestCreateSuperUser(TestCase):
 class TestClearOldLastLoginIp(TestCase):
     def test_basic(self):
         # Old but not deleted
-        old_date = self.days_ago(366)
-        user1 = user_factory(last_login_ip='127.0.0.1', banned=old_date)
+        old_date = self.days_ago(184)
+        user1 = user_factory(last_login_ip='127.0.0.1')
+        user1.update(modified=old_date)
 
         # Deleted but recent
-        user2 = user_factory(
-            last_login_ip='127.0.0.1', deleted=True, banned=self.days_ago(1))
+        user2 = user_factory(last_login_ip='127.0.0.1', deleted=True)
+        user2.update(modified=self.days_ago(1))
 
         # Deleted and old: last_login_ip must be cleared.
-        user3 = user_factory(
-            last_login_ip='127.0.0.1', deleted=True, banned=old_date)
+        user3 = user_factory(last_login_ip='127.0.0.1', deleted=True)
+        user3.update(modified=old_date)
 
         call_command('clear_old_last_login_ip')
 
         user1.reload()
         assert user1.last_login_ip == '127.0.0.1'
         assert user1.deleted is False
-        assert user1.banned == old_date
+        assert user1.modified == old_date
 
         user2.reload()
         assert user2.last_login_ip == '127.0.0.1'
@@ -100,4 +101,4 @@ class TestClearOldLastLoginIp(TestCase):
         user3.reload()
         assert user3.last_login_ip == ''
         assert user3.deleted is True
-        assert user3.banned == old_date
+        assert user3.modified == old_date

--- a/src/olympia/users/tests/test_models.py
+++ b/src/olympia/users/tests/test_models.py
@@ -107,7 +107,9 @@ class TestUserProfile(TestCase):
         assert user.display_name is None
         assert user.homepage == ''
         assert user.picture_type is None
-        assert user.last_login_ip == ''
+        # last_login_ip is kept during deletion, deleted 6 months later via
+        # clear_old_last_login_ip command
+        assert user.last_login_ip
         assert user.has_anonymous_username
         assert not storage.exists(user.picture_path)
         assert not storage.exists(user.picture_path_original)


### PR DESCRIPTION
Previously this was done only for banned users and their IP was kept for a year, now this behavior applies to all deleted accounts, but the delay is reduced to 6 months.

Fixes #12522