### PR TITLE
Update docs

### DIFF
--- a/docs/topics/install/docker.rst
+++ b/docs/topics/install/docker.rst
@@ -157,13 +157,13 @@ Another way to find out what's wrong is to run ``docker-compose logs``.
 Getting "Programming error [table] doesn't exist"?
 --------------------------------------------------
 
-Make sure you've run the ``make initialize_docker`` step as detailed in
+Make sure you've run the ``make initialize`` step as detailed in
 the initial setup instructions.
 
 
-ConnectionError during initialize_docker (elasticsearch container fails to start)
+ConnectionError during initialize (elasticsearch container fails to start)
 ---------------------------------------------------------------------------------
-When running ``make initialize_docker`` without a working elasticsearch container,
+When running ``make initialize`` without a working elasticsearch container,
 you'll get a ConnectionError. Check the logs with ``docker-compose logs``.
 If elasticsearch is complaining about ``vm.max_map_count``, run this command on your computer
 or your docker-machine VM:


### PR DESCRIPTION
`initialize_docker` was removed in 6748a96 but some mentions managed to stay in the docs.