### PR TITLE
Use `is_webextension` from linter results to determine whether to run yara

### DIFF
--- a/src/olympia/yara/tasks.py
+++ b/src/olympia/yara/tasks.py
@@ -33,9 +33,9 @@ def run_yara(results, upload_pk):
     log.info('Starting yara task for FileUpload %s.', upload_pk)
     upload = FileUpload.objects.get(pk=upload_pk)
 
-    if not upload.path.endswith('.xpi'):
-        log.info('Not running yara for FileUpload %s, it is not a xpi file.',
-                 upload_pk)
+    if not results['metadata']['is_webextension']:
+        log.info('Not running yara for FileUpload %s, it is not a '
+                 'webextension.', upload_pk)
         return results
 
     try:

--- a/src/olympia/yara/tests/test_task.py
+++ b/src/olympia/yara/tests/test_task.py
@@ -4,40 +4,51 @@ from unittest import mock
 
 from django.test.utils import override_settings
 
+from olympia import amo
 from olympia.amo.tests import TestCase
 from olympia.files.tests.test_models import UploadTest
+from olympia.files.utils import parse_addon
 from olympia.yara.models import YaraResult
 from olympia.yara.tasks import run_yara
 
 
 class TestRunYara(UploadTest, TestCase):
-    @mock.patch('yara.compile')
-    def test_skip_non_xpi_files_with_mocks(self, yara_compile_mock):
-        upload = self.get_upload('search.xml')
+    def setUp(self):
+        super(TestRunYara, self).setUp()
 
-        results = {'errors': 0}
+        self.upload = self.get_upload('webextension.xpi')
+        self.results = {**amo.VALIDATOR_SKELETON_RESULTS, 'metadata': {
+            'is_webextension': True,
+        }}
+
+    @mock.patch('yara.compile')
+    def test_skip_non_webextensions_with_mocks(self, yara_compile_mock):
+        upload = self.get_upload('search.xml')
+        results = {**amo.VALIDATOR_SKELETON_RESULTS, 'metadata': {
+            'is_webextension': False,
+        }}
+
         received_results = run_yara(results, upload.pk)
 
         assert not yara_compile_mock.called
-        assert results == received_results
+        # The task should always return the results.
+        assert received_results == results
 
     @mock.patch('olympia.yara.tasks.statsd.incr')
     def test_run_with_mocks(self, incr_mock):
-        results = {'errors': 0}
-        upload = self.get_upload('webextension.xpi')
         assert len(YaraResult.objects.all()) == 0
 
         # This compiled rule will match for all files in the xpi.
         rules = yara.compile(source='rule always_true { condition: true }')
         with mock.patch('yara.compile') as yara_compile_mock:
             yara_compile_mock.return_value = rules
-            received_results = run_yara(results, upload.pk)
+            received_results = run_yara(self.results, self.upload.pk)
 
         assert yara_compile_mock.called
         yara_results = YaraResult.objects.all()
         assert len(yara_results) == 1
         yara_result = yara_results[0]
-        assert yara_result.upload == upload
+        assert yara_result.upload == self.upload
         assert len(yara_result.matches) == 2
         assert yara_result.matches[0] == {
             'rule': 'always_true',
@@ -56,27 +67,27 @@ class TestRunYara(UploadTest, TestCase):
         assert incr_mock.called
         incr_mock.assert_called_with('devhub.yara.success')
         # The task should always return the results.
-        assert received_results == results
+        assert received_results == self.results
 
     def test_run_no_matches_with_mocks(self):
-        results = {'errors': 0}
-        upload = self.get_upload('webextension.xpi')
         assert len(YaraResult.objects.all()) == 0
 
         # This compiled rule will never match.
         rules = yara.compile(source='rule always_false { condition: false }')
         with mock.patch('yara.compile') as yara_compile_mock:
             yara_compile_mock.return_value = rules
-            received_results = run_yara(results, upload.pk)
+            received_results = run_yara(self.results, self.upload.pk)
 
         yara_result = YaraResult.objects.all()[0]
         assert yara_result.matches == []
         # The task should always return the results.
-        assert received_results == results
+        assert received_results == self.results
 
     def test_run_ignores_directories(self):
-        results = {'errors': 0}
         upload = self.get_upload('webextension_signed_already.xpi')
+        results = {**amo.VALIDATOR_SKELETON_RESULTS, 'metadata': {
+            'is_webextension': True,
+        }}
         # This compiled rule will match for all files in the xpi.
         rules = yara.compile(source='rule always_true { condition: true }')
 
@@ -95,34 +106,27 @@ class TestRunYara(UploadTest, TestCase):
     @override_settings(YARA_RULES_FILEPATH='unknown/path/to/rules.yar')
     @mock.patch('olympia.yara.tasks.statsd.incr')
     def test_run_does_not_raise(self, incr_mock):
-        results = {'errors': 0}
-        upload = self.get_upload('webextension.xpi')
-
         # This call should not raise even though there will be an error because
         # YARA_RULES_FILEPATH is configured with a wrong path.
-        received_results = run_yara(results, upload.pk)
+        received_results = run_yara(self.results, self.upload.pk)
 
         assert incr_mock.called
         incr_mock.assert_called_with('devhub.yara.failure')
         # The task should always return the results.
-        assert received_results == results
+        assert received_results == self.results
 
     @mock.patch('olympia.yara.tasks.statsd.timer')
     def test_calls_statsd_timer(self, timer_mock):
-        upload = self.get_upload('webextension.xpi')
-
-        results = {'errors': 0}
-        run_yara(results, upload.pk)
+        run_yara(self.results, self.upload.pk)
 
         assert timer_mock.called
         timer_mock.assert_called_with('devhub.yara')
 
     @mock.patch('yara.compile')
     def test_does_not_run_when_results_contain_errors(self, yara_compile_mock):
-        upload = self.get_upload('webextension.xpi')
-
-        results = {'errors': 1}
-        received_results = run_yara(results, upload.pk)
+        self.results.update({'errors': 1})
+        received_results = run_yara(self.results, self.upload.pk)
 
         assert not yara_compile_mock.called
-        assert results == received_results
+        # The task should always return the results.
+        assert received_results == self.results

--- a/src/olympia/yara/tests/test_task.py
+++ b/src/olympia/yara/tests/test_task.py
@@ -7,7 +7,6 @@ from django.test.utils import override_settings
 from olympia import amo
 from olympia.amo.tests import TestCase
 from olympia.files.tests.test_models import UploadTest
-from olympia.files.utils import parse_addon
 from olympia.yara.models import YaraResult
 from olympia.yara.tasks import run_yara
 


### PR DESCRIPTION
Fixes #12436 