### PR TITLE
Fix broken locale

### DIFF
--- a/locale/bn/LC_MESSAGES/djangojs.po
+++ b/locale/bn/LC_MESSAGES/djangojs.po
@@ -515,7 +515,7 @@ msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
 msgid "Add-ons Downloaded from {0} to {1}"
-msgstr "অ্যাডস-অন ডাউনলোড হয়েছে {০} থেকে {১} "
+msgstr "অ্যাডস-অন ডাউনলোড হয়েছে {0} থেকে {1} "
 
 #. L10n: {0} is an integer.
 msgid "Add-ons Created, last {0} days"
@@ -523,7 +523,7 @@ msgstr ""
 
 #. L10n: both {0} and {1} are dates in YYYY-MM-DD format.
 msgid "Add-ons Created from {0} to {1}"
-msgstr "অ্যাড-অন তৈরী করা হয়েছে {০} থেকে {১}"
+msgstr "অ্যাড-অন তৈরী করা হয়েছে {0} থেকে {1}"
 
 #. L10n: {0} is an integer.
 msgid "Add-ons Updated, last {0} days"
@@ -781,7 +781,7 @@ msgid "Warning"
 msgstr "সর্তকবার্তা"
 
 msgid "{0} line {1} column {2}"
-msgstr "{ 0} লাইন { 1} কলাম { 2}"
+msgstr "{0} লাইন {1} কলাম {2}"
 
 msgid "{0} line {1}"
 msgstr "{0} এর {1}"


### PR DESCRIPTION
```
>>> Working on: /home/travis/build/mozilla/addons-server/locale/bn/LC_MESSAGES/djangojs.po

E201: invalid variables: {০}, {১}

516:#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.

517:msgid "Add-ons Downloaded from {0} to {1}"

518:msgstr "অ্যাডস-অন ডাউনলোড হয়েছে {০} থেকে {১} "

E201: invalid variables: {০}, {১}

524:#. L10n: both {0} and {1} are dates in YYYY-MM-DD format.

525:msgid "Add-ons Created from {0} to {1}"

526:msgstr "অ্যাড-অন তৈরী করা হয়েছে {০} থেকে {১}"

E201: invalid variables: { 0}, { 1}, { 2}

783:msgid "{0} line {1} column {2}"

784:msgstr "{ 0} লাইন { 1} কলাম { 2}"

Totals

  Errors:       3
```

(https://travis-ci.org/mozilla/addons-server/jobs/595026400)