### PR TITLE
Add filter on yara admin

### DIFF
--- a/src/olympia/yara/admin.py
+++ b/src/olympia/yara/admin.py
@@ -1,12 +1,41 @@
 import json
 
 from django.contrib import admin
+from django.contrib.admin import SimpleListFilter
+from django.db.models import Q
 from django.utils.html import format_html
+from django.utils.translation import ugettext
 
 from olympia import amo
 from olympia.amo.urlresolvers import reverse
 
 from .models import YaraResult
+
+
+class MatchesFilter(SimpleListFilter):
+    title = ugettext('matches')
+    parameter_name = 'matches'
+
+    def lookups(self, request, model_admin):
+        return (
+            (None, 'With matched rules only'),
+            ('all', 'With/without matched rules'),
+        )
+
+    def choices(self, cl):
+        for lookup, title in self.lookup_choices:
+            yield {
+                'selected': self.value() == lookup,
+                'query_string': cl.get_query_string({
+                    self.parameter_name: lookup,
+                }, []),
+                'display': title,
+            }
+
+    def queryset(self, request, queryset):
+        if self.value() == 'all':
+            return queryset
+        return queryset.filter(~Q(matches='[]'))
 
 
 @admin.register(YaraResult)
@@ -15,6 +44,7 @@ class YaraResultAdmin(admin.ModelAdmin):
     view_on_site = False
 
     list_display = ('id', 'formatted_addon', 'channel', 'matched_rules')
+    list_filter = (MatchesFilter,)
     list_select_related = ('version',)
 
     fields = ('id', 'upload', 'formatted_addon', 'channel',

--- a/src/olympia/yara/tests/test_admin.py
+++ b/src/olympia/yara/tests/test_admin.py
@@ -3,11 +3,13 @@ import json
 from django.contrib.admin.sites import AdminSite
 from django.utils.html import format_html
 
+from pyquery import PyQuery as pq
+
 from olympia import amo
 from olympia.amo.tests import (TestCase, addon_factory, user_factory,
                                version_factory)
 from olympia.amo.urlresolvers import reverse
-from olympia.yara.admin import YaraResultAdmin
+from olympia.yara.admin import YaraResultAdmin, MatchesFilter
 from olympia.yara.models import YaraResult
 
 
@@ -99,3 +101,30 @@ class TestYaraResultAdmin(TestCase):
         result = YaraResult()
 
         assert self.admin.formatted_matches(result) == '<pre>[]</pre>'
+
+    def test_list_shows_matches_only_by_default(self):
+        # Create one entry without matches
+        YaraResult.objects.create()
+        # Create one entry with matches
+        with_matches = YaraResult()
+        with_matches.add_match(rule='some-rule')
+        with_matches.save()
+
+        response = self.client.get(self.list_url)
+        html = pq(response.content)
+        assert html('#result_list tbody tr').length == 1
+
+    def test_list_can_show_all_entries(self):
+        # Create one entry without matches
+        YaraResult.objects.create()
+        # Create one entry with matches
+        with_matches = YaraResult()
+        with_matches.add_match(rule='some-rule')
+        with_matches.save()
+
+        response = self.client.get(self.list_url, {
+            MatchesFilter.parameter_name: 'all',
+        })
+        html = pq(response.content)
+        expected_length = YaraResult.objects.count()
+        assert html('#result_list tbody tr').length == expected_length


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/12549

---

This patch adds a simple filter to the YaraResult django admin, enabled by default.

