### PR TITLE
move /authenticate api endpoint to new versionless api; update clients

### DIFF
--- a/docs/topics/api/auth_internal.rst
+++ b/docs/topics/api/auth_internal.rst
@@ -22,7 +22,7 @@ Fetching the token
 A fresh token, valid for 30 days, is automatically generated and added to the
 responses of the following endpoint:
 
-    * ``/api/v4/accounts/authenticate/``
+    * ``/api/auth/authenticate-callback/``
 
 The token is available in two forms:
 

--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -363,6 +363,7 @@ v4 API changelog
 * 2019-08-15: removed /addons/compat-override/ from v4 and above.  Still exists in /v3/ but will always return an empty response. https://github.com/mozilla/addons-server/issues/12063
 * 2019-08-22: added ``canned_response`` property to draft comment api. https://github.com/mozilla/addons-server/issues/11807
 * 2019-09-19: added /site/ endpoint to expose read-only mode and any site notice.  Also added the same response to the /accounts/account/ non-public response as a convenience for logged in users. https://github.com/mozilla/addons-server/issues/11493)
+* 2019-10-17: moved /authenticate endpoint from api/v4/accounts/authenticate to version-less api/auth/authenticate-callback https://github.com/mozilla/addons-server/issues/10487
 
 .. _`#11380`: https://github.com/mozilla/addons-server/issues/11380/
 .. _`#11379`: https://github.com/mozilla/addons-server/issues/11379/

--- a/settings.py
+++ b/settings.py
@@ -86,38 +86,31 @@ DATABASES = {
 # FxA config for local development only.
 FXA_CONFIG = {
     'default': {
-        'client_id': env('FXA_CLIENT_ID', default='f336377c014eacf0'),
+        'client_id': env('FXA_CLIENT_ID', default='a25796da7bc73ffa'),
         'client_secret': env(
             'FXA_CLIENT_SECRET',
-            default='5a36054059674b09ea56709c85b862c388f2d493d735070868ae8f476e16a80d'),  # noqa
-        # fxa redirects to 'http://olympia.test/api/v3/accounts/authenticate/',
+            default='4828af02f60a12738a79c7121b06d42b481f112dce1831440902a8412d2770c5'),  # noqa
+        # fxa redirects to http://olympia.test/api/auth/authenticate-callback/
     },
     'amo': {
         'client_id': env('FXA_CLIENT_ID', default='0f95f6474c24c1dc'),
         'client_secret': env(
             'FXA_CLIENT_SECRET',
             default='ca45e503a1b4ec9e2a3d4855d79849e098da18b7dfe42b6bc76dfed420fc1d38'),  # noqa
-        # fxa redirects to 'http://localhost:3000/fxa-authenticate',
+        # fxa redirects to http://localhost:3000/fxa-authenticate
     },
     'local': {
-        'client_id': env('FXA_CLIENT_ID', default='1778aef72d1adfb3'),
+        'client_id': env('FXA_CLIENT_ID', default='4dce1adfa7901c08'),
         'client_secret': env(
             'FXA_CLIENT_SECRET',
-            default='3feebe3c009c1a0acdedd009f3530eae2b88859f430fa8bb951ea41f2f859b18'),  # noqa
-        # fxa redirects to 'http://localhost:3000/api/v3/accounts/authenticate/?config=local', # noqa
-    },
-    'code-manager': {
-        'client_id': env('CODE_MANAGER_FXA_CLIENT_ID', default='a98b671fdd3dfcea'), # noqa
-        'client_secret': env(
-            'CODE_MANAGER_FXA_CLIENT_SECRET',
-            default='d9934865e34bed4739a2dc60046a90d09a5d8336cf92809992dec74a4cff4665'),  # noqa
-        # fxa redirects to 'http://olympia.test/api/v4/accounts/authenticate/?config=code-manager', # noqa
+            default='d7d5f1148a35b12c067fb9eafafc29d35165a90f5d8b0032f1fcd37468ae49fe'),  # noqa
+        # fxa redirects to http://localhost:3000/api/auth/authenticate-callback/?config=local  #noqa
     },
 }
 FXA_CONTENT_HOST = 'https://stable.dev.lcip.org'
 FXA_OAUTH_HOST = 'https://oauth-stable.dev.lcip.org/v1'
 FXA_PROFILE_HOST = 'https://stable.dev.lcip.org/profile/v1'
-ALLOWED_FXA_CONFIGS = ['default', 'amo', 'local', 'code-manager']
+ALLOWED_FXA_CONFIGS = ['default', 'amo', 'local']
 
 # CSP report endpoint which returns a 204 from addons-nginx in local dev.
 CSP_REPORT_URI = '/csp-report'

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -157,7 +157,7 @@ class TestLoginStartView(TestCase):
     def test_default_config_is_used(self):
         assert views.LoginStartView.DEFAULT_FXA_CONFIG_NAME == 'default'
         assert views.LoginStartView.ALLOWED_FXA_CONFIGS == (
-            ['default', 'amo', 'local', 'code-manager'])
+            ['default', 'amo', 'local'])
 
 
 class TestLoginUserAndRegisterUser(TestCase):
@@ -276,9 +276,11 @@ class TestFindUser(TestCase):
 
 
 class TestRenderErrorHTML(TestCase):
+    api_version = 'auth'
 
     def make_request(self):
-        request = APIRequestFactory().get(reverse_ns('accounts.authenticate'))
+        request = APIRequestFactory().get(
+            reverse_ns('accounts.authenticate', api_version=self.api_version))
         request.user = AnonymousUser()
         return self.enable_messages(request)
 
@@ -328,7 +330,12 @@ class TestRenderErrorHTML(TestCase):
         assert_url_equal(response['location'], '/')
 
 
+class TestRenderErrorHTMLV3(TestRenderErrorHTML):
+    api_version = 'v3'
+
+
 class TestRenderErrorJSON(TestCase):
+    api_version = 'auth'
 
     def setUp(self):
         patcher = mock.patch('olympia.accounts.views.Response')
@@ -336,7 +343,8 @@ class TestRenderErrorJSON(TestCase):
         self.addCleanup(patcher.stop)
 
     def make_request(self):
-        return APIRequestFactory().post(reverse_ns('accounts.authenticate'))
+        return APIRequestFactory().post(
+            reverse_ns('accounts.authenticate', api_version=self.api_version))
 
     def render_error(self, error):
         views.render_error(self.make_request(), error, format='json')
@@ -354,6 +362,10 @@ class TestRenderErrorJSON(TestCase):
         self.render_error(views.ERROR_STATE_MISMATCH)
         self.Response.assert_called_with(
             {'error': views.ERROR_STATE_MISMATCH}, status=400)
+
+
+class TestRenderErrorJSONV3(TestRenderErrorJSON):
+    api_version = 'v3'
 
 
 class TestWithUser(TestCase):
@@ -740,12 +752,13 @@ def empty_view(*args, **kwargs):
 class TestAuthenticateView(TestCase, PatchMixin, InitializeSessionMixin):
     view_name = 'accounts.authenticate'
     client_class = APIClient
+    api_version = 'auth'
 
     def setUp(self):
         super().setUp()
         self.fxa_identify = self.patch(
             'olympia.accounts.views.verify.fxa_identify')
-        self.url = reverse_ns(self.view_name)
+        self.url = reverse_ns(self.view_name, api_version=self.api_version)
         self.fxa_state = '1cd2ae9d'
         self.initialize_session({'fxa_state': self.fxa_state})
         self.login_user = self.patch('olympia.accounts.views.login_user')
@@ -1007,6 +1020,10 @@ class TestAuthenticateView(TestCase, PatchMixin, InitializeSessionMixin):
             })
         with mock.patch('olympia.amo.views._frontend_view', empty_view):
             self.assertRedirects(response, reverse('home'))
+
+
+class TestAuthenticateViewV3(TestAuthenticateView):
+    api_version = 'v3'
 
 
 class TestAccountViewSet(TestCase):
@@ -1610,6 +1627,8 @@ class TestParseNextPath(TestCase):
 
 
 class TestSessionView(TestCase):
+    api_version = 'auth'
+
     def login_user(self, user):
         identity = {
             'username': user.username,
@@ -1622,7 +1641,8 @@ class TestSessionView(TestCase):
                 lambda code, config: identity):
             response = self.client.get(
                 '{url}?code={code}&state={state}'.format(
-                    url=reverse_ns('accounts.authenticate'),
+                    url=reverse_ns(
+                        'accounts.authenticate', api_version=self.api_version),
                     state='myfxastate',
                     code='thecode'))
             token = response.cookies[views.API_TOKEN_COOKIE].value
@@ -1690,6 +1710,10 @@ class TestSessionView(TestCase):
         assert not response.has_header('Access-Control-Allow-Methods')
         assert not response.has_header('Access-Control-Allow-Origin')
         assert not response.has_header('Access-Control-Max-Age')
+
+
+class TestSessionViewV3(TestSessionView):
+    api_version = 'v3'
 
 
 class TestAccountNotificationViewSetList(TestCase):

--- a/src/olympia/accounts/urls.py
+++ b/src/olympia/accounts/urls.py
@@ -23,9 +23,7 @@ notifications = NestedSimpleRouter(accounts, r'account', lookup='user')
 notifications.register(r'notifications', views.AccountNotificationViewSet,
                        basename='notification')
 
-urlpatterns = [
-    url(r'^authenticate/$', views.AuthenticateView.as_view(),
-        name='accounts.authenticate'),
+accounts_v4 = [
     url(r'^login/start/$',
         views.LoginStartView.as_view(),
         name='accounts.login_start'),
@@ -41,4 +39,15 @@ urlpatterns = [
     url(r'', include(collections.urls)),
     url(r'', include(sub_collections.urls)),
     url(r'', include(notifications.urls)),
+]
+
+accounts_v3 = accounts_v4 + [
+    url(r'^authenticate/$', views.AuthenticateView.as_view(),
+        name='accounts.authenticate'),
+]
+
+auth_callback_patterns = [
+    url(r'^authenticate-callback/$', views.AuthenticateView.as_view(),
+        name='accounts.authenticate'),
+
 ]

--- a/src/olympia/api/urls.py
+++ b/src/olympia/api/urls.py
@@ -1,5 +1,7 @@
 from django.conf.urls import include, url
 
+from olympia.accounts.urls import (
+    accounts_v3, accounts_v4, auth_callback_patterns)
 from olympia.amo.urls import api_patterns as amo_api_patterns
 from olympia.addons.api_urls import addons_v3, addons_v4
 from olympia.ratings.api_urls import ratings_v3, ratings_v4
@@ -7,7 +9,7 @@ from olympia.ratings.api_urls import ratings_v3, ratings_v4
 
 v3_api_urls = [
     url(r'^abuse/', include('olympia.abuse.urls')),
-    url(r'^accounts/', include('olympia.accounts.urls')),
+    url(r'^accounts/', include(accounts_v3)),
     url(r'^addons/', include(addons_v3)),
     url(r'^', include('olympia.discovery.api_urls')),
     url(r'^reviews/', include(ratings_v3.urls)),
@@ -18,7 +20,7 @@ v3_api_urls = [
 
 v4_api_urls = [
     url(r'^abuse/', include('olympia.abuse.urls')),
-    url(r'^accounts/', include('olympia.accounts.urls')),
+    url(r'^accounts/', include(accounts_v4)),
     url(r'^activity/', include('olympia.activity.urls')),
     url(r'^addons/', include(addons_v4)),
     url(r'^', include('olympia.discovery.api_urls')),
@@ -30,6 +32,7 @@ v4_api_urls = [
 ]
 
 urlpatterns = [
+    url(r'^auth/', include((auth_callback_patterns, 'auth'))),
     url(r'^v3/', include((v3_api_urls, 'v3'))),
     url(r'^v4/', include((v4_api_urls, 'v4'))),
     url(r'^v5/', include((v4_api_urls, 'v5'))),

--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -105,29 +105,19 @@ FXA_CONFIG = {
     'default': {
         'client_id': env('FXA_CLIENT_ID'),
         'client_secret': env('FXA_CLIENT_SECRET'),
-        # fxa redirects to 'https://%s/api/v3/accounts/authenticate/' % DOMAIN,
-    },
-    'amo': {
-        'client_id': env('AMO_FXA_CLIENT_ID'),
-        'client_secret': env('AMO_FXA_CLIENT_SECRET'),
-        # fxa redirects to 'https://addons-dev.allizom.org/api/v3/accounts/authenticate/?config=amo', # noqa
+        # fxa redirects to https://%s/api/auth/authenticate-callback/ % DOMAIN
     },
     'local': {
         'client_id': env('DEVELOPMENT_FXA_CLIENT_ID'),
         'client_secret': env('DEVELOPMENT_FXA_CLIENT_SECRET'),
-        # fxa redirects to 'http://localhost:3000/api/v3/accounts/authenticate/?config=local', # noqa
-    },
-    'code-manager': {
-        'client_id': env('CODE_MANAGER_FXA_CLIENT_ID'),
-        'client_secret': env('CODE_MANAGER_FXA_CLIENT_SECRET'),
-        # fxa redirects to 'https://addons-dev.allizom.org/api/v4/accounts/authenticate/?config=code-manager', # noqa
+        # fxa redirects to http://localhost:3000/api/auth/authenticate-callback/?config=local  # noqa
     },
 }
 FXA_CONTENT_HOST = 'https://stable.dev.lcip.org'
 FXA_OAUTH_HOST = 'https://oauth-stable.dev.lcip.org/v1'
 FXA_PROFILE_HOST = 'https://stable.dev.lcip.org/profile/v1'
 DEFAULT_FXA_CONFIG_NAME = 'default'
-ALLOWED_FXA_CONFIGS = ['default', 'amo', 'local', 'code-manager']
+ALLOWED_FXA_CONFIGS = ['default', 'local']
 
 FXA_SQS_AWS_QUEUE_URL = (
     'https://sqs.us-east-1.amazonaws.com/927034868273/'

--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -85,21 +85,14 @@ FXA_CONFIG = {
     'default': {
         'client_id': env('FXA_CLIENT_ID'),
         'client_secret': env('FXA_CLIENT_SECRET'),
-        # fxa redirects to 'https://%s/api/v3/accounts/authenticate/' % DOMAIN,
-    },
-    'amo': {
-        'client_id': env('AMO_FXA_CLIENT_ID'),
-        'client_secret': env('AMO_FXA_CLIENT_SECRET'),
-        # fxa redirects to 'https://addons.mozilla.org/api/v3/accounts/authenticate/?config=amo', # noqa
-    },
-    'code-manager': {
-        'client_id': env('CODE_MANAGER_FXA_CLIENT_ID'),
-        'client_secret': env('CODE_MANAGER_FXA_CLIENT_SECRET'),
-        # fxa redirects to 'https://addons.mozilla.org/api/v4/accounts/authenticate/?config=code-manager', # noqa
+        # fxa redirects to https://%s/api/auth/authenticate-callback/ % DOMAIN
     },
 }
+FXA_CONTENT_HOST = 'https://accounts.firefox.com'
+FXA_OAUTH_HOST = 'https://oauth.accounts.firefox.com/v1'
+FXA_PROFILE_HOST = 'https://profile.accounts.firefox.com/v1'
 DEFAULT_FXA_CONFIG_NAME = 'default'
-ALLOWED_FXA_CONFIGS = ['default', 'amo', 'code-manager']
+ALLOWED_FXA_CONFIGS = ['default']
 
 ES_DEFAULT_NUM_SHARDS = 10
 

--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -88,9 +88,6 @@ FXA_CONFIG = {
         # fxa redirects to https://%s/api/auth/authenticate-callback/ % DOMAIN
     },
 }
-FXA_CONTENT_HOST = 'https://accounts.firefox.com'
-FXA_OAUTH_HOST = 'https://oauth.accounts.firefox.com/v1'
-FXA_PROFILE_HOST = 'https://profile.accounts.firefox.com/v1'
 DEFAULT_FXA_CONFIG_NAME = 'default'
 ALLOWED_FXA_CONFIGS = ['default']
 

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -99,26 +99,16 @@ FXA_CONFIG = {
     'default': {
         'client_id': env('FXA_CLIENT_ID'),
         'client_secret': env('FXA_CLIENT_SECRET'),
-        # fxa redirects to 'https://%s/api/v3/accounts/authenticate/' % DOMAIN,
-    },
-    'amo': {
-        'client_id': env('AMO_FXA_CLIENT_ID'),
-        'client_secret': env('AMO_FXA_CLIENT_SECRET'),
-        # fxa redirects to 'https://addons.allizom.org/api/v3/accounts/authenticate/?config=amo', # noqa
+        # fxa redirects to https://%s/api/auth/authenticate-callback/ % DOMAIN
     },
     'local': {
         'client_id': env('DEVELOPMENT_FXA_CLIENT_ID'),
         'client_secret': env('DEVELOPMENT_FXA_CLIENT_SECRET'),
-        # fxa redirects to 'http://localhost:3000/api/v3/accounts/authenticate/?config=local', # noqa
-    },
-    'code-manager': {
-        'client_id': env('CODE_MANAGER_FXA_CLIENT_ID'),
-        'client_secret': env('CODE_MANAGER_FXA_CLIENT_SECRET'),
-        # fxa redirects to 'https://addons.allizom.org/api/v4/accounts/authenticate/?config=code-manager', # noqa
+        # fxa redirects to http://localhost:3000/api/auth/authenticate-callback/?config=local  # noqa
     },
 }
 DEFAULT_FXA_CONFIG_NAME = 'default'
-ALLOWED_FXA_CONFIGS = ['default', 'amo', 'local', 'code-manager']
+ALLOWED_FXA_CONFIGS = ['default', 'local']
 
 TAAR_LITE_RECOMMENDATION_ENGINE_URL = env(
     'TAAR_LITE_RECOMMENDATION_ENGINE_URL',

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -96,8 +96,8 @@ ADDONS_LINTER_BIN = env(
 DELETION_EMAIL = 'amo-notifications+deletion@mozilla.org'
 THEMES_EMAIL = 'theme-reviews@mozilla.org'
 
-DRF_API_VERSIONS = ['v3', 'v4', 'v5']
-DRF_API_REGEX = r'^/?api/(?:v3|v4|v5)/'
+DRF_API_VERSIONS = ['auth', 'v3', 'v4', 'v5']
+DRF_API_REGEX = r'^/?api/(?:auth|v3|v4|v5)/'
 
 # Add Access-Control-Allow-Origin: * header for the new API with
 # django-cors-headers.
@@ -1663,6 +1663,7 @@ JWT_AUTH = {
 }
 
 DRF_API_GATES = {
+    'auth': (),
     'v3': (
         'ratings-rating-shim',
         'ratings-title-shim',


### PR DESCRIPTION
resurrecting this now the register redirects changes have been split out and landed.  Fixes #10487

It's going to require ops create new fxa clients for dev, stage and prod (+ admin internal instances for `default` at least). Though, because the v3 auth endpoint still exists, the existing fxa clients _should_* still work so there won't need to be a deploy time switchover.  *we'll see how well that "should" matches reality on addons-dev.