### PR TITLE
Fix review logs layout

### DIFF
--- a/static/css/zamboni/reviewers.less
+++ b/static/css/zamboni/reviewers.less
@@ -403,7 +403,7 @@ ul.tabnav a:hover {
 table.data-grid tr.comments td {
     border-top: none;
     background: #def;
-    overflow-wrap: break-word;
+    word-break: break-all;
     hyphens: auto;
 }
 


### PR DESCRIPTION
Fixes #3447

`overflow-wrap` doesn't work for tables without `table-layout: fixed` (The `<td>` expands to content size and there's no overflow to trigger the wrapping).

`table-layout: fixed` causes a regression (Ref: #12547).