### PR TITLE
Migrate yara results

### DIFF
--- a/src/olympia/scanners/admin.py
+++ b/src/olympia/scanners/admin.py
@@ -51,6 +51,8 @@ class ScannerResultAdmin(admin.ModelAdmin):
     fields = ('id', 'upload', 'formatted_addon', 'channel', 'scanner',
               'formatted_matches', 'formatted_results')
 
+    ordering = ('-created',)
+
     def get_queryset(self, request):
         # We already set list_select_related() so we don't need to repeat that.
         # We also need to fetch the add-ons though, and because we need their

--- a/src/olympia/scanners/migrations/0004_auto_20191018_0740.py
+++ b/src/olympia/scanners/migrations/0004_auto_20191018_0740.py
@@ -5,7 +5,10 @@ from olympia.constants.scanners import YARA
 
 class Migration(migrations.Migration):
 
-    dependencies = [('scanners', '0003_auto_20191017_1514')]
+    dependencies = [
+        ('scanners', '0003_auto_20191017_1514'),
+        ('yara', '0003_auto_20191010_1446'),
+    ]
 
     operations = [
         migrations.RunSQL(

--- a/src/olympia/scanners/migrations/0004_auto_20191018_0740.py
+++ b/src/olympia/scanners/migrations/0004_auto_20191018_0740.py
@@ -1,0 +1,38 @@
+from django.db import migrations
+
+from olympia.constants.scanners import YARA
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [('scanners', '0003_auto_20191017_1514')]
+
+    operations = [
+        migrations.RunSQL(
+            [
+                (
+                    'INSERT INTO scanners_results ('
+                    '  created,'
+                    '  modified,'
+                    '  upload_id,'
+                    '  results,'
+                    '  scanner,'
+                    '  version_id,'
+                    '  has_matches,'
+                    '  matches'
+                    ') '
+                    'SELECT '
+                    '  created,'
+                    '  modified,'
+                    '  upload_id,'
+                    '  %s,'
+                    '  %s,'
+                    '  version_id,'
+                    '  has_matches,'
+                    '  matches '
+                    'FROM yara_results;',
+                    ['[]', YARA],  # [`results`, `scanner`]
+                )
+            ]
+        )
+    ]


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/12648

~~:warning: depends on https://github.com/mozilla/addons-server/pull/12647~~

---

I added a default `ordering` in the scanner admin so that we won't have all the newly created yet old scanner results at the top of the page...