### PR TITLE
fixed "save change" button should not be displayed for static themes

### DIFF
--- a/src/olympia/devhub/templates/devhub/versions/edit.html
+++ b/src/olympia/devhub/templates/devhub/versions/edit.html
@@ -135,7 +135,9 @@
         </table>
       </div>
       <div class="listing-footer">
-        <button type="submit">{{ _('Save Changes') }}</button> {{ _('or') }}
+        {% if addon.type != amo.ADDON_STATICTHEME %}
+          <button type="submit">{{ _('Save Changes') }}</button> {{ _('or') }}
+        {% endif %}
         <a href="{{ addon.get_dev_url('versions') }}">{{ _('Cancel') }}</a>
       </div>
     </div>


### PR DESCRIPTION
Fixes #10219 

If the add-on is a static theme, I modified  that "save change" button should not be displayed.

**Before**
![issue_10219_before](https://user-images.githubusercontent.com/29684524/67095325-996ccc00-f1f0-11e9-9f19-27439b50ab97.png)

**After**
![issue_10219_after](https://user-images.githubusercontent.com/29684524/67095335-9d98e980-f1f0-11e9-9841-9d61350c5db7.png)
