### PR TITLE
Add Django admin for `ScannerRule`

### DIFF
--- a/src/olympia/constants/permissions.py
+++ b/src/olympia/constants/permissions.py
@@ -129,6 +129,9 @@ DJANGO_PERMISSIONS_MAPPING.update({
 
     'reviewers.delete_reviewerscore': ADMIN_ADVANCED,
 
+    'scanners.add_scannerrule': ADMIN_ADVANCED,
+    'scanners.change_scannerrule': ADMIN_ADVANCED,
+    'scanners.delete_scannerrule': ADMIN_ADVANCED,
     'scanners.view_scannerresult': ADMIN_ADVANCED,
 
     'users.change_userprofile': USERS_EDIT,

--- a/src/olympia/scanners/admin.py
+++ b/src/olympia/scanners/admin.py
@@ -9,7 +9,7 @@ from django.utils.translation import ugettext
 from olympia.addons.models import Addon
 from olympia.amo.urlresolvers import reverse
 
-from .models import ScannerResult
+from .models import ScannerResult, ScannerRule
 
 
 class MatchesFilter(SimpleListFilter):
@@ -102,3 +102,11 @@ class ScannerResultAdmin(admin.ModelAdmin):
     def formatted_matches(self, obj):
         return format_html('<pre>{}</pre>', json.dumps(obj.matches, indent=4))
     formatted_matches.short_description = 'Matches'
+
+
+@admin.register(ScannerRule)
+class ScannerRuleAdmin(admin.ModelAdmin):
+    view_on_site = False
+
+    list_display = ('name', 'action', 'is_active')
+    list_filter = ('action', 'is_active')

--- a/src/olympia/scanners/tests/test_admin.py
+++ b/src/olympia/scanners/tests/test_admin.py
@@ -14,12 +14,8 @@ from olympia.amo.tests import (
 )
 from olympia.amo.urlresolvers import reverse
 from olympia.constants.scanners import CUSTOMS, WAT, YARA
-from olympia.scanners.admin import (
-    MatchesFilter,
-    ScannerResultAdmin,
-    ScannerRuleAdmin,
-)
-from olympia.scanners.models import ScannerResult, ScannerRule
+from olympia.scanners.admin import MatchesFilter, ScannerResultAdmin
+from olympia.scanners.models import ScannerResult
 
 
 class TestScannerResultAdmin(TestCase):
@@ -187,10 +183,6 @@ class TestScannerRuleAdmin(TestCase):
         self.grant_permission(self.user, 'Admin:Advanced')
         self.client.login(email=self.user.email)
         self.list_url = reverse('admin:scanners_scannerrule_changelist')
-
-        self.admin = ScannerRuleAdmin(
-            model=ScannerRule, admin_site=AdminSite()
-        )
 
     def test_list_view(self):
         response = self.client.get(self.list_url)


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/12674

---

Add a django admin for the `ScannerRule` model.

![Screen Shot 2019-10-21 at 17 55 14](https://user-images.githubusercontent.com/217628/67221568-f7d1be80-f42b-11e9-836b-fab98789bbe7.png)
