### PR TITLE
Use `check_for_api_keys_in_file()` as a validation task

### DIFF
--- a/src/olympia/devhub/tasks.py
+++ b/src/olympia/devhub/tasks.py
@@ -298,13 +298,6 @@ def handle_upload_validation_result(all_results, upload_pk, channel,
 
     upload = FileUpload.objects.get(pk=upload_pk)
 
-    # Check for API keys in submissions.
-    # Make sure it is extension-like, e.g. no search plugin
-    try:
-        results = check_for_api_keys_in_file(results=results, upload=upload)
-    except (ValidationError, BadZipfile, IOError):
-        pass
-
     # Annotate results with potential webext warnings on new versions.
     if upload.addon_id and upload.version:
         annotations.annotate_webext_incompatibilities(
@@ -376,7 +369,10 @@ def handle_file_validation_result(results, file_id, *args):
     return FileValidation.from_json(file_, results).pk
 
 
-def check_for_api_keys_in_file(results, upload):
+@validation_task
+def check_for_api_keys_in_file(results, upload_pk):
+    upload = FileUpload.objects.get(pk=upload_pk)
+
     if upload.addon:
         users = upload.addon.authors.all()
     else:
@@ -390,35 +386,39 @@ def check_for_api_keys_in_file(results, upload):
         except APIKey.DoesNotExist:
             pass
 
-    if len(keys) > 0:
-        zipfile = SafeZip(source=upload.path)
-        for zipinfo in zipfile.info_list:
-            if zipinfo.file_size >= 64:
-                file_ = zipfile.read(zipinfo)
-                for key in keys:
-                    if key.secret in file_.decode(errors="ignore"):
-                        log.info('Developer API key for user %s found in '
-                                 'submission.' % key.user)
-                        if key.user == upload.user:
-                            msg = ugettext('Your developer API key was found '
-                                           'in the submitted file. To protect '
-                                           'your account, the key will be '
-                                           'revoked.')
-                        else:
-                            msg = ugettext('The developer API key of a '
-                                           'coauthor was found in the '
-                                           'submitted file. To protect your '
-                                           'add-on, the key will be revoked.')
-                        annotations.insert_validation_message(
-                            results, type_='error',
-                            message=msg, msg_id='api_key_detected',
-                            compatibility_type=None)
+    try:
+        if len(keys) > 0:
+            zipfile = SafeZip(source=upload.path)
+            for zipinfo in zipfile.info_list:
+                if zipinfo.file_size >= 64:
+                    file_ = zipfile.read(zipinfo)
+                    for key in keys:
+                        if key.secret in file_.decode(errors="ignore"):
+                            log.info('Developer API key for user %s found in '
+                                     'submission.' % key.user)
+                            if key.user == upload.user:
+                                msg = ugettext('Your developer API key was '
+                                               'found in the submitted file. '
+                                               'To protect your account, the '
+                                               'key will be revoked.')
+                            else:
+                                msg = ugettext('The developer API key of a '
+                                               'coauthor was found in the '
+                                               'submitted file. To protect '
+                                               'your add-on, the key will be '
+                                               'revoked.')
+                            annotations.insert_validation_message(
+                                results, type_='error',
+                                message=msg, msg_id='api_key_detected',
+                                compatibility_type=None)
 
-                        # Revoke after 2 minutes to allow the developer to
-                        # fetch the validation results
-                        revoke_api_key.apply_async(
-                            kwargs={'key_id': key.id}, countdown=120)
-        zipfile.close()
+                            # Revoke after 2 minutes to allow the developer to
+                            # fetch the validation results
+                            revoke_api_key.apply_async(
+                                kwargs={'key_id': key.id}, countdown=120)
+            zipfile.close()
+    except (ValidationError, BadZipfile, IOError):
+        pass
 
     return results
 

--- a/src/olympia/devhub/tests/test_utils.py
+++ b/src/olympia/devhub/tests/test_utils.py
@@ -60,6 +60,7 @@ class TestAddonsLinterListed(UploadTest, TestCase):
             tasks.create_initial_validation_results.si(),
             repack_fileupload.s(file_upload.pk),
             tasks.validate_upload.s(file_upload.pk, channel),
+            tasks.check_for_api_keys_in_file.s(file_upload.pk),
             chord(
                 [tasks.forward_linter_results.s(file_upload.pk)],
                 tasks.handle_upload_validation_result.s(file_upload.pk,
@@ -462,6 +463,7 @@ class TestValidator(UploadTest, TestCase):
             tasks.create_initial_validation_results.si(),
             repack_fileupload.s(file_upload.pk),
             tasks.validate_upload.s(file_upload.pk, channel),
+            tasks.check_for_api_keys_in_file.s(file_upload.pk),
             chord(
                 [tasks.forward_linter_results.s(file_upload.pk)],
                 tasks.handle_upload_validation_result.s(file_upload.pk,
@@ -498,6 +500,7 @@ class TestValidator(UploadTest, TestCase):
             tasks.create_initial_validation_results.si(),
             repack_fileupload.s(file_upload.pk),
             tasks.validate_upload.s(file_upload.pk, channel),
+            tasks.check_for_api_keys_in_file.s(file_upload.pk),
             chord(
                 [
                     tasks.forward_linter_results.s(file_upload.pk),
@@ -522,6 +525,7 @@ class TestValidator(UploadTest, TestCase):
             tasks.create_initial_validation_results.si(),
             repack_fileupload.s(file_upload.pk),
             tasks.validate_upload.s(file_upload.pk, channel),
+            tasks.check_for_api_keys_in_file.s(file_upload.pk),
             chord(
                 [tasks.forward_linter_results.s(file_upload.pk)],
                 tasks.handle_upload_validation_result.s(file_upload.pk,
@@ -543,6 +547,7 @@ class TestValidator(UploadTest, TestCase):
             tasks.create_initial_validation_results.si(),
             repack_fileupload.s(file_upload.pk),
             tasks.validate_upload.s(file_upload.pk, channel),
+            tasks.check_for_api_keys_in_file.s(file_upload.pk),
             chord(
                 [
                     tasks.forward_linter_results.s(file_upload.pk),
@@ -567,6 +572,7 @@ class TestValidator(UploadTest, TestCase):
             tasks.create_initial_validation_results.si(),
             repack_fileupload.s(file_upload.pk),
             tasks.validate_upload.s(file_upload.pk, channel),
+            tasks.check_for_api_keys_in_file.s(file_upload.pk),
             chord(
                 [tasks.forward_linter_results.s(file_upload.pk)],
                 tasks.handle_upload_validation_result.s(file_upload.pk,
@@ -588,6 +594,7 @@ class TestValidator(UploadTest, TestCase):
             tasks.create_initial_validation_results.si(),
             repack_fileupload.s(file_upload.pk),
             tasks.validate_upload.s(file_upload.pk, channel),
+            tasks.check_for_api_keys_in_file.s(file_upload.pk),
             chord(
                 [
                     tasks.forward_linter_results.s(file_upload.pk),
@@ -612,6 +619,7 @@ class TestValidator(UploadTest, TestCase):
             tasks.create_initial_validation_results.si(),
             repack_fileupload.s(file_upload.pk),
             tasks.validate_upload.s(file_upload.pk, channel),
+            tasks.check_for_api_keys_in_file.s(file_upload.pk),
             chord(
                 [tasks.forward_linter_results.s(file_upload.pk)],
                 tasks.handle_upload_validation_result.s(file_upload.pk,
@@ -634,6 +642,7 @@ class TestValidator(UploadTest, TestCase):
             tasks.create_initial_validation_results.si(),
             repack_fileupload.s(file_upload.pk),
             tasks.validate_upload.s(file_upload.pk, channel),
+            tasks.check_for_api_keys_in_file.s(file_upload.pk),
             chord(
                 [
                     tasks.forward_linter_results.s(file_upload.pk),
@@ -661,6 +670,7 @@ class TestValidator(UploadTest, TestCase):
             tasks.create_initial_validation_results.si(),
             repack_fileupload.s(file_upload.pk),
             tasks.validate_upload.s(file_upload.pk, channel),
+            tasks.check_for_api_keys_in_file.s(file_upload.pk),
             chord(
                 [
                     tasks.forward_linter_results.s(file_upload.pk),

--- a/src/olympia/devhub/utils.py
+++ b/src/olympia/devhub/utils.py
@@ -270,6 +270,7 @@ class Validator(object):
                 tasks.create_initial_validation_results.si(),
                 repack_fileupload.s(file_.pk),
                 tasks.validate_upload.s(file_.pk, channel),
+                tasks.check_for_api_keys_in_file.s(file_.pk),
                 chord(
                     tasks_in_parallel,
                     tasks.handle_upload_validation_result.s(file_.pk,

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1096,6 +1096,7 @@ CELERY_TASK_ROUTES = {
     # Other queues we prioritize below.
 
     # AMO Devhub.
+    'olympia.devhub.tasks.check_for_api_keys_in_file': {'queue': 'devhub'},
     'olympia.devhub.tasks.create_initial_validation_results': {
         'queue': 'devhub'},
     'olympia.devhub.tasks.forward_linter_results': {'queue': 'devhub'},


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/12571

---

This patch removes the `check_for_api_keys_in_file()` call in `handle_upload_validation_result()` and runs it as a validation task in the validation chain (after the linter).