### PR TITLE
Increased the padding-bottom of the banner

### DIFF
--- a/static/css/devhub/new-landing/sections/banner.less
+++ b/static/css/devhub/new-landing/sections/banner.less
@@ -4,7 +4,7 @@
 }
 .DevHub-callout-box--banner {
     margin: 20px 0 0;
-    padding-bottom: 160px;
+    padding-bottom: 180px;
     background-color: transparent;
 
     h2 {


### PR DESCRIPTION
fixes #12765 

There is no space between the banner link and the image.
I increased the space as 20px(padding-bottom).

**Before**
![12765_before](https://user-images.githubusercontent.com/29684524/68134202-1d4ee400-ff65-11e9-9e63-d5fa75c421ba.png)


**After**
![12765_after](https://user-images.githubusercontent.com/29684524/68134209-217b0180-ff65-11e9-84b7-dab3a2eb82a5.png)


If the size is not suitable, please let me know again.