### PR TITLE
Add more style to the (newsletter) sign up button in devhub

### DIFF
--- a/static/css/devhub/new-landing/sections/connect.less
+++ b/static/css/devhub/new-landing/sections/connect.less
@@ -111,8 +111,10 @@
             height: 32px;
             .button(@color-scheme-dark-background, @color-scheme-dark-text);
             font-size: 14px;
-            border-radius: 4px;
+            border-radius: 0.25rem;
             border-width: 0;
+            cursor: pointer;
+            transition: background-color 0.25s ease-out;
         }
     }
 

--- a/static/css/devhub/new-landing/sections/connect.less
+++ b/static/css/devhub/new-landing/sections/connect.less
@@ -114,7 +114,13 @@
             border-radius: 0.25rem;
             border-width: 0;
             cursor: pointer;
-            transition: background-color 0.25s ease-out;
+            transition: all 0.25s ease-out;
+
+            &:active,
+            &:hover,
+            &:focus {
+                color: @color-button-register;
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #12700

**BEFORE (all states)** 
![beforeAllStates](https://user-images.githubusercontent.com/15162247/68180955-eb348680-ff52-11e9-81ed-97d4033bc9a3.png)


 **AFTER default** 
![afterDefault](https://user-images.githubusercontent.com/15162247/68180966-f4bdee80-ff52-11e9-8019-bc8d202c1c9b.png)

 **AFTER active** 
![afterActive](https://user-images.githubusercontent.com/15162247/68180970-f7b8df00-ff52-11e9-8a4d-8406696c5960.png)

 **AFTER hover** 
![afterHover](https://user-images.githubusercontent.com/15162247/68180974-fab3cf80-ff52-11e9-858c-c8e1cebbeefc.png)

