### PR TITLE
Associate customs lint rules with scanner rules

### DIFF
--- a/src/olympia/scanners/models.py
+++ b/src/olympia/scanners/models.py
@@ -54,9 +54,9 @@ class ScannerResult(ModelBase):
     def extract_rule_names(self):
         """This method parses the raw results and returns the (matched) rule
         names. Not all scanners have rules that necessarily match."""
-        if self.scanner is YARA:
+        if self.scanner == YARA:
             return sorted({result['rule'] for result in self.results})
-        if self.scanner is CUSTOMS and 'matchedRules' in self.results:
+        if self.scanner == CUSTOMS and 'matchedRules' in self.results:
             return self.results['matchedRules']
         # We do not have support for the remaining scanners (yet).
         return []

--- a/src/olympia/scanners/tests/test_models.py
+++ b/src/olympia/scanners/tests/test_models.py
@@ -70,8 +70,7 @@ class TestScannerResult(TestCase):
     def test_save_set_has_matches(self):
         result = self.create_yara_result()
         rule = ScannerRule.objects.create(
-            name='some rule name',
-            scanner=result.scanner
+            name='some rule name', scanner=result.scanner
         )
 
         result.has_matches = None
@@ -122,6 +121,25 @@ class TestScannerResult(TestCase):
 
         assert result.extract_rule_names() == [rule1, rule2]
 
-    def test_extract_rule_names_returns_empty_list_when_not_yara(self):
-        result = self.create_customs_result()
+    def test_extract_rule_names_returns_empty_list_for_unsupported_scanner(
+        self
+    ):
+        upload = self.create_file_upload()
+        result = ScannerResult.objects.create(upload=upload, scanner=WAT)
         assert result.extract_rule_names() == []
+
+    def test_extract_rule_names_with_no_customs_matched_rules_attribute(self):
+        result = self.create_customs_result()
+        result.results = {}
+        assert result.extract_rule_names() == []
+
+    def test_extract_rule_names_with_no_customs_results(self):
+        result = self.create_customs_result()
+        result.results = {'matchedRules': []}
+        assert result.extract_rule_names() == []
+
+    def test_extract_rule_names_with_customs_results(self):
+        result = self.create_customs_result()
+        rules = ['rule-1', 'rule-2']
+        result.results = {'matchedRules': rules}
+        assert result.extract_rule_names() == rules


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/12803

---

This patch updates the `extract_rule_names()` method to support `customs`. By doing this, we can associate scanner rules with matched customs rules.

In order to try it, you should either use the latest version of customs locally **or** you update a known scanner result to specify `matchedRules: ["some-name"]`. You will have to register the scanner rules beforehand.