### PR TITLE
Display creation date in scanner result list

### DIFF
--- a/src/olympia/scanners/admin.py
+++ b/src/olympia/scanners/admin.py
@@ -46,6 +46,7 @@ class ScannerResultAdmin(admin.ModelAdmin):
         'channel',
         'scanner',
         'formatted_matched_rules',
+        'created',
     )
     list_filter = ('scanner', MatchesFilter)
     list_select_related = ('version',)


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/12759

---

Given that the default order is `-created`, it makes sense to display this column too so that it is clear what the default order is.