### PR TITLE
twitter links in "connect with us" footer open in same tab

### DIFF
--- a/src/olympia/devhub/templates/devhub/new-landing/components/connect.html
+++ b/src/olympia/devhub/templates/devhub/new-landing/components/connect.html
@@ -7,8 +7,8 @@
       <div class="DevHub-Connect-section">
         <h4>{{ _('Twitter') }}</h4>
         <ul class="DevHub-content-copy--Connect-twitter-list">
-          <li>{{ _('For developers') }}:<a class="Before-Icon Before-Icon-twitter" href="https://twitter.com/mozamo" target="_blank" rel="noopener noreferrer">@mozamo</a></li>
-          <li>{{ _('For end users') }}:<a class="Before-Icon Before-Icon-twitter" href="https://twitter.com/rockyourfirefox" target="_blank" rel="noopener noreferrer">@rockyourfirefox</a></li>
+          <li>{{ _('For developers') }}:<a class="Before-Icon Before-Icon-twitter" href="https://twitter.com/mozamo" rel="noopener noreferrer">@mozamo</a></li>
+          <li>{{ _('For end users') }}:<a class="Before-Icon Before-Icon-twitter" href="https://twitter.com/rockyourfirefox" rel="noopener noreferrer">@rockyourfirefox</a></li>
         </ul>
       </div>
       <div class="DevHub-Connect-section">


### PR DESCRIPTION
Fixes #12701 

The issue this change fixes requested consistency in link opening behavior for 2 Twitter links. The removal of the target attribute will make these links open within the same tab.

The change has been tested locally. Here are some screenshots of the change:

![change_before_click](https://user-images.githubusercontent.com/48775802/68309174-e4953480-0062-11ea-9336-e86565f4f742.png)

![change_after_click](https://user-images.githubusercontent.com/48775802/68309204-ee1e9c80-0062-11ea-8961-71b61882a414.png)

No tests were added, as I'm not sure how. If one should be added for this change, could I get some guidance? I'll be sure to quickly follow-up with changes.

_Author's follow-up note_: I provide screenshots of the change, but what would be better (since this change is functionality) is a GIF like in the issue that this fixes. If anyone has a quick how-to on making those, I'd appreciate the knowledge :)