### PR TITLE
Fixes #12626

### DIFF
--- a/static/css/devhub/new-landing/common.less
+++ b/static/css/devhub/new-landing/common.less
@@ -158,6 +158,7 @@
     html[dir=rtl] & {
       padding-left: 0;
       padding-right: 30px;
+      float: left;
     }
   }
 


### PR DESCRIPTION
Fixes #12626 

Description:
add `float: left;` to override `float: right`
like this
![image](https://user-images.githubusercontent.com/7900936/68319804-dc3c0880-00f9-11ea-9bff-c1f759961fa8.png)

Before
![image](https://user-images.githubusercontent.com/7900936/68319872-f8d84080-00f9-11ea-8b32-ce0703bf39fd.png)


After
![image](https://user-images.githubusercontent.com/7900936/68319840-eeb64200-00f9-11ea-8a40-12d218da5a54.png)

