### PR TITLE
fix #12701 (#12701)

### DIFF
--- a/src/olympia/devhub/templates/devhub/new-landing/components/connect.html
+++ b/src/olympia/devhub/templates/devhub/new-landing/components/connect.html
@@ -7,8 +7,8 @@
       <div class="DevHub-Connect-section">
         <h4>{{ _('Twitter') }}</h4>
         <ul class="DevHub-content-copy--Connect-twitter-list">
-          <li>{{ _('For developers') }}:<a class="Before-Icon Before-Icon-twitter" href="https://twitter.com/mozamo" target="_blank" rel="noopener noreferrer">@mozamo</a></li>
-          <li>{{ _('For end users') }}:<a class="Before-Icon Before-Icon-twitter" href="https://twitter.com/rockyourfirefox" target="_blank" rel="noopener noreferrer">@rockyourfirefox</a></li>
+          <li>{{ _('For developers') }}:<a class="Before-Icon Before-Icon-twitter" href="https://twitter.com/mozamo" target="_self" rel="noopener noreferrer">@mozamo</a></li>
+          <li>{{ _('For end users') }}:<a class="Before-Icon Before-Icon-twitter" href="https://twitter.com/rockyourfirefox" target="_self" rel="noopener noreferrer">@rockyourfirefox</a></li>
         </ul>
       </div>
       <div class="DevHub-Connect-section">

--- a/src/olympia/devhub/templates/devhub/new-landing/components/connect.html
+++ b/src/olympia/devhub/templates/devhub/new-landing/components/connect.html
@@ -7,8 +7,8 @@
       <div class="DevHub-Connect-section">
         <h4>{{ _('Twitter') }}</h4>
         <ul class="DevHub-content-copy--Connect-twitter-list">
-          <li>{{ _('For developers') }}:<a class="Before-Icon Before-Icon-twitter" href="https://twitter.com/mozamo" target="_self" rel="noopener noreferrer">@mozamo</a></li>
-          <li>{{ _('For end users') }}:<a class="Before-Icon Before-Icon-twitter" href="https://twitter.com/rockyourfirefox" target="_self" rel="noopener noreferrer">@rockyourfirefox</a></li>
+          <li>{{ _('For developers') }}:<a class="Before-Icon Before-Icon-twitter" href="https://twitter.com/mozamo">@mozamo</a></li>
+          <li>{{ _('For end users') }}:<a class="Before-Icon Before-Icon-twitter" href="https://twitter.com/rockyourfirefox">@rockyourfirefox</a></li>
         </ul>
       </div>
       <div class="DevHub-Connect-section">


### PR DESCRIPTION
Fixes #12701 

The issue was to maintain consistency in the website by opening all the twitter links on same page(initially which was on different tab). To solve this issue in target "_blank" was replaced by "_self". The changes are working fine.
