### PR TITLE
drop is-source-public field except for v3 api

### DIFF
--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -190,7 +190,6 @@ This endpoint allows you to fetch a specific add-on by id, slug or guid.
     :>json boolean is_experimental: Whether the add-on has been marked by the developer as experimental or not.
     :>json boolean is_featured: The add-on appears in a featured collection.
     :>json boolean is_recommended: The add-on is recommended by Mozilla.
-    :>json boolean is_source_public: Whether the add-on source is publicly viewable or not.
     :>json string|object|null name: The add-on name (See :ref:`translated fields <api-overview-translations>`).
     :>json string last_updated: The date of the last time the add-on was updated by its developer(s).
     :>json object|null latest_unlisted_version: Object holding the latest unlisted :ref:`version <version-detail-object>` of the add-on. This field is only present if the user has unlisted reviewer permissions, or is listed as a developer of the add-on.

--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -364,6 +364,7 @@ v4 API changelog
 * 2019-08-22: added ``canned_response`` property to draft comment api. https://github.com/mozilla/addons-server/issues/11807
 * 2019-09-19: added /site/ endpoint to expose read-only mode and any site notice.  Also added the same response to the /accounts/account/ non-public response as a convenience for logged in users. https://github.com/mozilla/addons-server/issues/11493)
 * 2019-10-17: moved /authenticate endpoint from api/v4/accounts/authenticate to version-less api/auth/authenticate-callback https://github.com/mozilla/addons-server/issues/10487
+* 2019-11-14: removed ``is_source_public`` property from addons API https://github.com/mozilla/addons-server/issues/12514
 
 .. _`#11380`: https://github.com/mozilla/addons-server/issues/11380/
 .. _`#11379`: https://github.com/mozilla/addons-server/issues/11379/

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -299,7 +299,7 @@ class AddonSerializer(serializers.ModelSerializer):
     homepage = TranslationSerializerField()
     icon_url = serializers.SerializerMethodField()
     icons = serializers.SerializerMethodField()
-    is_source_public = serializers.BooleanField(source='view_source')
+    is_source_public = serializers.SerializerMethodField()
     is_featured = serializers.SerializerMethodField()
     name = TranslationSerializerField()
     previews = PreviewSerializer(many=True, source='current_previews')
@@ -369,6 +369,8 @@ class AddonSerializer(serializers.ModelSerializer):
                     data[key] = self.outgoingify(data[key])
         if request and is_gate_active(request, 'del-addons-created-field'):
             data.pop('created', None)
+        if request and not is_gate_active(request, 'is-source-public-shim'):
+            data.pop('is_source_public', None)
         return data
 
     def outgoingify(self, data):
@@ -439,6 +441,9 @@ class AddonSerializer(serializers.ModelSerializer):
             'count': obj.total_ratings,
             'text_count': obj.text_ratings_count,
         }
+
+    def get_is_source_public(self, obj):
+        return False
 
 
 class AddonSerializerWithUnlistedData(AddonSerializer):

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -229,7 +229,6 @@ class AddonSerializerOutputTestMixin(object):
         assert result['is_experimental'] == self.addon.is_experimental is False
         assert result['is_featured'] == self.addon.is_featured() is False
         assert result['is_recommended'] == self.addon.is_recommended is False
-        assert result['is_source_public'] == self.addon.view_source
         assert result['last_updated'] == (
             self.addon.last_updated.replace(microsecond=0).isoformat() + 'Z')
         assert result['name'] == {'en-US': self.addon.name}
@@ -354,10 +353,16 @@ class AddonSerializerOutputTestMixin(object):
         assert result['is_disabled'] is True
 
     def test_is_source_public(self):
-        self.addon = addon_factory(view_source=True)
+        self.addon = addon_factory()
         result = self.serialize()
 
-        assert result['is_source_public'] is True
+        assert 'is_source_public' not in result
+
+        # It's only present in v3
+        gates = {None: ('is-source-public-shim',)}
+        with override_settings(DRF_API_GATES=gates):
+            result = self.serialize()
+            assert result['is_source_public'] is False
 
     def test_is_experimental(self):
         self.addon = addon_factory(is_experimental=True)

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1683,6 +1683,7 @@ DRF_API_GATES = {
         'del-ratings-flags',
         'activity-user-shim',
         'autocomplete-sort-param',
+        'is-source-public-shim',
     ),
     'v4': (
         'l10n_flat_input_output',


### PR DESCRIPTION
#12514 
I modified so that is_source_public field can be returned only from v3 api. I checked to run test case and If it work right on my locally.
Let me know if there's anything wrong with a misprint or something.