### PR TITLE
Buttons made visible in DevHub mobile view

### DIFF
--- a/static/css/devhub/new-landing/base.less
+++ b/static/css/devhub/new-landing/base.less
@@ -3,6 +3,7 @@
 
 // Grid
 @grid-max: 960px;
+@small: ~"only screen and (min-width: 550px)";
 @medium: ~"only screen and (min-width: 700px)";
 @large: ~"only screen and (min-width: 960px)";
 @notlarge: ~"only screen and (max-width: 959px)";

--- a/static/css/devhub/new-landing/base.less
+++ b/static/css/devhub/new-landing/base.less
@@ -3,7 +3,6 @@
 
 // Grid
 @grid-max: 960px;
-@small: ~"only screen and (min-width: 550px)";
 @medium: ~"only screen and (min-width: 700px)";
 @large: ~"only screen and (min-width: 960px)";
 @notlarge: ~"only screen and (max-width: 959px)";

--- a/static/css/devhub/new-landing/sections/my-addons.less
+++ b/static/css/devhub/new-landing/sections/my-addons.less
@@ -121,7 +121,7 @@
   align-items: flex-start;
   justify-content: flex-start;
 
-  @media @large {
+  @media only screen and (min-width: 730px) {
     flex-direction: row;
   }
 }
@@ -140,8 +140,12 @@
     margin-right: auto;
     margin-left: 0;
   }
+}
 
-  @media @large {
-    display: inline;
+.DevHub-MyAddons-item-buttons-submit > .Button{
+  width: 100%;
+
+  @media @small{
+    width: auto;
   }
 }

--- a/static/css/devhub/new-landing/sections/my-addons.less
+++ b/static/css/devhub/new-landing/sections/my-addons.less
@@ -116,15 +116,6 @@
 
 .DevHub-MyAddons-item-buttons {
   margin-top: 20px;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: flex-start;
-
-  @media @medium {
-    flex-direction: row;
-    flex-wrap: wrap;
-  }
 }
 
 .DevHub-MyAddons-item-buttons-all {
@@ -136,11 +127,19 @@
 .DevHub-MyAddons-item-buttons-submit {
 
   margin-left: auto;
-  align-self: flex-end;
-
+  float: right;
 
   html[dir=rtl] & {
     margin-right: auto;
     margin-left: 0;
+    float: left;
+  }
+}
+
+.DevHub-MyAddons-item-buttons-submit > .Button {
+  width: 100%;
+
+  @media @medium {
+    width: auto;
   }
 }

--- a/static/css/devhub/new-landing/sections/my-addons.less
+++ b/static/css/devhub/new-landing/sections/my-addons.less
@@ -121,8 +121,9 @@
   align-items: flex-start;
   justify-content: flex-start;
 
-  @media only screen and (min-width: 730px) {
+  @media @medium {
     flex-direction: row;
+    flex-wrap: wrap;
   }
 }
 
@@ -135,17 +136,11 @@
 .DevHub-MyAddons-item-buttons-submit {
 
   margin-left: auto;
+  align-self: flex-end;
+
 
   html[dir=rtl] & {
     margin-right: auto;
     margin-left: 0;
-  }
-}
-
-.DevHub-MyAddons-item-buttons-submit > .Button{
-  width: 100%;
-
-  @media @small{
-    width: auto;
   }
 }

--- a/static/css/devhub/new-landing/sections/my-addons.less
+++ b/static/css/devhub/new-landing/sections/my-addons.less
@@ -117,9 +117,13 @@
 .DevHub-MyAddons-item-buttons {
   margin-top: 20px;
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   align-items: flex-start;
   justify-content: flex-start;
+
+  @media @large {
+    flex-direction: row;
+  }
 }
 
 .DevHub-MyAddons-item-buttons-all {
@@ -129,7 +133,6 @@
 }
 
 .DevHub-MyAddons-item-buttons-submit {
-  display: none;
 
   margin-left: auto;
 


### PR DESCRIPTION
Fixes #12594

New Add-on and Theme buttons were not visible in mobile view.
The issue is corrected by removing display none property and
changing flex direction of container to column for device-
width less than 960px.

before-
![Screenshot from 2019-11-07 15-10-25](https://user-images.githubusercontent.com/44079328/68377668-d6353e80-0170-11ea-9580-1033869fc6f4.png)

after-
![Screenshot from 2019-11-07 15-08-31](https://user-images.githubusercontent.com/44079328/68377683-dd5c4c80-0170-11ea-8915-1afe8221b10e.png)

