### PR TITLE
import post_request_task earlier so that it catches the first request_started

### DIFF
--- a/src/olympia/core/apps.py
+++ b/src/olympia/core/apps.py
@@ -22,7 +22,14 @@ class CoreConfig(AppConfig):
 
         self.enable_urllib_certificate_checking()
 
+        self.enable_post_request_task()
+
     def enable_urllib_certificate_checking(self):
         # From requests's packages/urllib3/contrib/pyopenssl.py
         import urllib3.contrib.pyopenssl
         urllib3.contrib.pyopenssl.inject_into_urllib3()
+
+    def enable_post_request_task(self):
+        """Import post_request_task so that it can listen to `request_started`
+        signal before the first request is handled."""
+        import post_request_task.task  # noqa


### PR DESCRIPTION
To be enabled for the current thread, `post_request_task` first needs to be activated, as it defaults to being deactivated to make firing tasks from non-request context such as management commands possible.

Activating it in a request-response cycle happens automatically thanks to django's `request_started` and `request_finished` signals. Unfortunately, if the request_started is triggered before `post_request_task` has been imported, any tasks fired from that thread will be fired immediately, without benefiting from `post_request_task`.

This is precisely what was happening before this patch, for the very first request handled by each thread (so it was more commonly occurring when deploying new code), because we typically import tasks deep in the code and not at the top to avoid circular imports - so the import would take place, just too late, after the signal had been fired.

Fixes #12572