### PR TITLE
Add actions to report feedback on ScannerResult

### DIFF
--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1863,3 +1863,6 @@ CUSTOMS_API_URL = env('CUSTOMS_API_URL', default=None)
 CUSTOMS_API_KEY = env('CUSTOMS_API_KEY', default=None)
 WAT_API_URL = env('WAT_API_URL', default=None)
 WAT_API_KEY = env('WAT_API_KEY', default=None)
+# Git(Hub) repository names, e.g., `owner/repo-name`
+CUSTOMS_GIT_REPOSITORY = env('CUSTOMS_GIT_REPOSITORY', default=None)
+YARA_GIT_REPOSITORY = env('YARA_GIT_REPOSITORY', default=None)

--- a/src/olympia/scanners/models.py
+++ b/src/olympia/scanners/models.py
@@ -1,5 +1,6 @@
 import json
 
+from django.conf import settings
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from django_extensions.db.fields.json import JSONField
@@ -12,6 +13,7 @@ from olympia.constants.scanners import (
     RESULT_STATES,
     SCANNERS,
     UNKNOWN,
+    WAT,
     YARA,
 )
 from olympia.files.models import FileUpload
@@ -87,6 +89,17 @@ class ScannerResult(ModelBase):
 
     def get_pretty_results(self):
         return json.dumps(self.results, indent=2)
+
+    def can_report_feedback(self):
+        return (
+            self.has_matches and self.state == UNKNOWN and self.scanner != WAT
+        )
+
+    def get_git_repository(self):
+        return {
+            CUSTOMS: settings.CUSTOMS_GIT_REPOSITORY,
+            YARA: settings.YARA_GIT_REPOSITORY,
+        }.get(self.scanner)
 
 
 class ScannerRule(ModelBase):

--- a/src/olympia/scanners/templates/admin/false_positive_report.md
+++ b/src/olympia/scanners/templates/admin/false_positive_report.md
@@ -1,0 +1,34 @@
+### Report
+
+The [scanner result {{ result.id }}]({{ result.get_admin_absolute_url }}) reports matches of the following _{{ result.get_scanner_name }}_ rules:
+
+{% for rule in result.matched_rules.all %}
+- `{{ rule.name }}`
+{% endfor %}
+
+However, it is not correct for the following reasons:
+
+<!-- Please explain why you are reporting a false positive here. -->
+
+### Metadata
+
+| Name        | Value                           |
+|-------------|---------------------------------|
+| Add-on GUID | {{ result.version.addon.guid }} ([product page]({{ result.version.addon.get_absolute_url }})) |
+| Version ID  | {{ result.version.id }} |
+| Channel     | {{ result.version.get_channel_display }} |
+| Scanner     | {{ result.get_scanner_name }} |
+
+{% if not result.version %}
+:warning: Some information is missing because there is no version attached to these results.
+{% endif %}
+
+### Raw scanner results
+
+<details>
+<summary>show raw scanner results</summary>
+
+```json
+{{ result.get_pretty_results|safe }}
+```
+</details>


### PR DESCRIPTION
Fixes #12853

---

This patch adds the following features:

- mark a scanner result as true positive
- report a scanner result as false positive
- list view hides triaged scanner results by default (only showing results with `state = UNKNOWN`)

I ignored the WAT scanner for now. Its collected data cannot really be true or false positive. We might need a new state value in the future to mark a result as "handled only".