### PR TITLE
Fix feedback button style

### DIFF
--- a/src/olympia/scanners/admin.py
+++ b/src/olympia/scanners/admin.py
@@ -104,6 +104,11 @@ class ScannerResultAdmin(admin.ModelAdmin):
 
     ordering = ('-created',)
 
+    class Media:
+        css = {
+            'all': ('css/admin/scannerresult.css',)
+        }
+
     def get_queryset(self, request):
         # We already set list_select_related() so we don't need to repeat that.
         # We also need to fetch the add-ons though, and because we need their
@@ -234,7 +239,7 @@ class ScannerResultAdmin(admin.ModelAdmin):
         return format_html(
             '<a class="button" href="{}">Report as false positive</a>'
             '&nbsp;'
-            '<a class="button" href="{}">Mark as true positive</a>',
+            '<a class="button default" href="{}">Mark as true positive</a>',
             reverse(
                 'admin:scanners_scannerresult_handlefalsepositive',
                 args=[obj.pk],

--- a/static/css/admin/scannerresult.css
+++ b/static/css/admin/scannerresult.css
@@ -1,0 +1,8 @@
+.field-result_actions {
+  text-align: center;
+  white-space: nowrap;
+}
+
+.button.default {
+  float: none;
+}


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/12882

---

I also added a different style for the "default" button (we should hopefully not report too many false positives).

Before:

![](https://user-images.githubusercontent.com/217628/68945556-f38d8c80-07b0-11ea-80e6-7dbc610cb289.png)

After:

![Screen Shot 2019-11-15 at 14 15 38](https://user-images.githubusercontent.com/217628/68946140-87ac2380-07b2-11ea-948a-79c475ee83e6.png)
