### PR TITLE
Make sure auto-approve runs everything on primary database

### DIFF
--- a/src/olympia/reviewers/management/commands/auto_approve.py
+++ b/src/olympia/reviewers/management/commands/auto_approve.py
@@ -100,7 +100,7 @@ class Command(BaseCommand):
                         log.debug('Not running run_action() because it has '
                                   'already been executed')
                     else:
-                        run_action(version.id)
+                        run_action(version)
 
                 summary, info = AutoApprovalSummary.create_summary_for_version(
                     version, dry_run=self.dry_run)

--- a/src/olympia/reviewers/management/commands/auto_approve.py
+++ b/src/olympia/reviewers/management/commands/auto_approve.py
@@ -12,6 +12,7 @@ import waffle
 import olympia.core.logger
 
 from olympia import amo
+from olympia.amo.decorators import use_primary_db
 from olympia.files.utils import atomic_lock
 from olympia.lib.crypto.signing import SigningError
 from olympia.reviewers.models import (
@@ -46,6 +47,7 @@ class Command(BaseCommand):
         return Version.objects.auto_approvable().order_by(
             'nomination', 'created').distinct()
 
+    @use_primary_db
     def handle(self, *args, **options):
         """Command entry point."""
         self.dry_run = options.get('dry_run', False)

--- a/src/olympia/reviewers/tests/test_commands.py
+++ b/src/olympia/reviewers/tests/test_commands.py
@@ -473,7 +473,7 @@ class TestAutoApproveCommand(AutoApproveTestsMixin, TestCase):
         call_command('auto_approve')
 
         assert run_action_mock.called
-        run_action_mock.assert_called_with(self.version.id)
+        run_action_mock.assert_called_with(self.version)
 
     @mock.patch(
         'olympia.reviewers.management.commands.auto_approve.run_action'
@@ -486,7 +486,7 @@ class TestAutoApproveCommand(AutoApproveTestsMixin, TestCase):
         call_command('auto_approve')
 
         assert run_action_mock.called
-        run_action_mock.assert_called_with(self.version.id)
+        run_action_mock.assert_called_with(self.version)
 
         run_action_mock.reset_mock()
         call_command('auto_approve')

--- a/src/olympia/scanners/tasks.py
+++ b/src/olympia/scanners/tasks.py
@@ -24,7 +24,6 @@ from olympia.addons.models import AddonReviewerFlags
 from olympia.devhub.tasks import validation_task
 from olympia.files.models import FileUpload
 from olympia.files.utils import SafeZip
-from olympia.versions.models import Version
 
 from .models import ScannerResult, ScannerRule
 
@@ -229,14 +228,13 @@ def _delay_auto_approval_indefinitely(version):
         defaults={'auto_approval_delayed_until': datetime.max})
 
 
-def run_action(version_id):
+def run_action(version):
     """This function tries to find an action to execute for a given version,
     based on the scanner results and associated rules.
 
     It is not run as a Celery task but as a simple function, in the
     auto_approve CRON."""
-    log.info('Checking rules and actions for version %s.', version_id)
-    version = Version.objects.get(pk=version_id)
+    log.info('Checking rules and actions for version %s.', version.pk)
 
     rule = (
         ScannerRule.objects.filter(
@@ -250,7 +248,7 @@ def run_action(version_id):
     )
 
     if not rule:
-        log.info('No action to execute for version %s.', version_id)
+        log.info('No action to execute for version %s.', version.pk)
         return
 
     action_id = rule.action
@@ -272,6 +270,6 @@ def run_action(version_id):
         raise Exception("no implementation for action %s" % action_id)
 
     # We have a valid action to execute, so let's do it!
-    log.info('Starting action "%s" for version %s.', action_name, version_id)
+    log.info('Starting action "%s" for version %s.', action_name, version.pk)
     action_function(version)
-    log.info('Ending action "%s" for version %s.', action_name, version_id)
+    log.info('Ending action "%s" for version %s.', action_name, version.pk)

--- a/src/olympia/scanners/tests/test_tasks.py
+++ b/src/olympia/scanners/tests/test_tasks.py
@@ -441,7 +441,7 @@ class TestRunAction(TestCase):
     def test_runs_no_action(self, no_action_mock):
         self.scanner_rule.update(action=NO_ACTION)
 
-        run_action(self.version.id)
+        run_action(self.version)
 
         assert no_action_mock.called
         no_action_mock.assert_called_with(self.version)
@@ -450,7 +450,7 @@ class TestRunAction(TestCase):
     def test_runs_flag_for_human_review(self, flag_for_human_review_mock):
         self.scanner_rule.update(action=FLAG_FOR_HUMAN_REVIEW)
 
-        run_action(self.version.id)
+        run_action(self.version)
 
         assert flag_for_human_review_mock.called
         flag_for_human_review_mock.assert_called_with(self.version)
@@ -459,7 +459,7 @@ class TestRunAction(TestCase):
     def test_runs_delay_auto_approval(self, _delay_auto_approval_mock):
         self.scanner_rule.update(action=DELAY_AUTO_APPROVAL)
 
-        run_action(self.version.id)
+        run_action(self.version)
 
         assert _delay_auto_approval_mock.called
         _delay_auto_approval_mock.assert_called_with(self.version)
@@ -469,7 +469,7 @@ class TestRunAction(TestCase):
             self, _delay_auto_approval_indefinitely_mock):
         self.scanner_rule.update(action=DELAY_AUTO_APPROVAL_INDEFINITELY)
 
-        run_action(self.version.id)
+        run_action(self.version)
 
         assert _delay_auto_approval_indefinitely_mock.called
         _delay_auto_approval_indefinitely_mock.assert_called_with(self.version)
@@ -478,7 +478,7 @@ class TestRunAction(TestCase):
     def test_returns_when_no_action_found(self, log_mock):
         self.scanner_rule.delete()
 
-        run_action(self.version.id)
+        run_action(self.version)
 
         log_mock.assert_called_with(
             'No action to execute for version %s.', self.version.id
@@ -489,7 +489,7 @@ class TestRunAction(TestCase):
         self.scanner_rule.update(action=12345)
 
         with pytest.raises(Exception, match='invalid action 12345'):
-            run_action(self.version.id)
+            run_action(self.version)
 
     @mock.patch('olympia.scanners.tasks._no_action')
     @mock.patch('olympia.scanners.tasks._flag_for_human_review')
@@ -503,7 +503,7 @@ class TestRunAction(TestCase):
         )
         self.scanner_result.matched_rules.add(rule)
 
-        run_action(self.version.id)
+        run_action(self.version)
 
         assert not no_action_mock.called
         assert flag_for_human_review_mock.called
@@ -524,7 +524,7 @@ class TestRunAction(TestCase):
         )
         self.scanner_result.matched_rules.add(rule)
 
-        run_action(self.version.id)
+        run_action(self.version)
 
         assert no_action_mock.called
         assert not flag_for_human_review_mock.called


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/12896

Added a couple other commits to help in the future:
- A couple functional tests (were passing already)
- Re-using instance instead of passing the id in `run_action()` since it's not a real task