### PR TITLE
Remove baseurl command line flag from integration tests.

### DIFF
--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -13,6 +13,7 @@ MOBILE = (414, 738)
 def base_url(base_url):
     return "http://olympia.test"
 
+
 @pytest.fixture
 def firefox_options(firefox_options):
     """Firefox options.

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -9,6 +9,10 @@ DESKTOP = (1080, 1920)
 MOBILE = (414, 738)
 
 
+@pytest.fixture(scope="session")
+def base_url(base_url):
+    return "http://olympia.test"
+
 @pytest.fixture
 def firefox_options(firefox_options):
     """Firefox options.

--- a/tests/ui/setup.cfg
+++ b/tests/ui/setup.cfg
@@ -3,4 +3,3 @@ addopts = -vs --tb=long --showlocals --html=ui-test.html --self-contained-html
 sensitive_url = mozilla\.(com|org)
 xfail_strict = true
 DJANGO_SETTINGS_MODULE = settings
-base_url = http://olympia.test


### PR DESCRIPTION
Fixes the errors for the tests running on Addons-frontend circleci.
