### PR TITLE
Add new 'confirm multiple versions' action for unlisted review

### DIFF
--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -288,7 +288,9 @@ class ReviewForm(forms.Form):
         widget=forms.SelectMultiple(
             attrs={
                 'class': 'data-toggle',
-                'data-value': 'reject_multiple_versions|'
+                'data-value': (
+                    'reject_multiple_versions|confirm_multiple_versions|'
+                )
             }),
         required=False,
         queryset=Version.objects.none())  # queryset is set later in __init__.
@@ -336,12 +338,17 @@ class ReviewForm(forms.Form):
 
         # With the helper, we now have the add-on and can set queryset on the
         # versions field correctly. Small optimization: we only need to do this
-        # if the reject_multiple_versions action is available, otherwise we
-        # don't really care about this field.
-        if 'reject_multiple_versions' in self.helper.actions:
+        # if the reject_multiple_versions/confirm_multiple_versions actions are
+        # available, otherwise we don't really care about this field.
+        if ('reject_multiple_versions' in self.helper.actions or
+                'confirm_multiple_versions' in self.helper.actions):
+            if self.helper.version:
+                channel = self.helper.version.channel
+            else:
+                channel = amo.RELEASE_CHANNEL_LISTED
             self.fields['versions'].queryset = (
                 self.helper.addon.versions.distinct().filter(
-                    channel=amo.RELEASE_CHANNEL_LISTED,
+                    channel=channel,
                     files__status__in=(amo.STATUS_APPROVED,
                                        amo.STATUS_AWAITING_REVIEW)).
                 order_by('created'))

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -4729,7 +4729,7 @@ class TestReview(ReviewBase):
 
         assert (
             doc('select#id_versions.data-toggle')[0].attrib['data-value'] ==
-            'reject_multiple_versions|')
+            'reject_multiple_versions|confirm_multiple_versions|')
 
         assert (
             doc('.data-toggle.review-comments')[0].attrib['data-value'] ==
@@ -4760,7 +4760,7 @@ class TestReview(ReviewBase):
 
         assert (
             doc('select#id_versions.data-toggle')[0].attrib['data-value'] ==
-            'reject_multiple_versions|')
+            'reject_multiple_versions|confirm_multiple_versions|')
 
         assert (
             doc('.data-toggle.review-comments')[0].attrib['data-value'] ==
@@ -4788,7 +4788,7 @@ class TestReview(ReviewBase):
 
         assert (
             doc('select#id_versions.data-toggle')[0].attrib['data-value'] ==
-            'reject_multiple_versions|')
+            'reject_multiple_versions|confirm_multiple_versions|')
 
         assert (
             doc('.data-toggle.review-comments')[0].attrib['data-value'] ==


### PR DESCRIPTION
This replaces the confirm auto-approval action for unlisted

Fixes #12792