### PR TITLE
Fix permissions required to download source code

### DIFF
--- a/src/olympia/versions/tests/test_views.py
+++ b/src/olympia/versions/tests/test_views.py
@@ -522,6 +522,7 @@ class TestDownloadSource(TestCase):
     def test_download_for_admin(self):
         """File downloading is allowed for admins."""
         self.grant_permission(self.user, 'Reviews:Admin')
+        self.addon.authors.clear()
         self.client.login(email=self.user.email)
         assert self.client.get(self.url).status_code == 200
 


### PR DESCRIPTION
Admins should be allowed by default, not just when the addon/version
is deleted.

Fixes https://github.com/mozilla/addons-server/issues/13006