### PR TITLE
Don't add link to scanner rule result matches when creating a rule

### DIFF
--- a/src/olympia/scanners/admin.py
+++ b/src/olympia/scanners/admin.py
@@ -336,6 +336,8 @@ class ScannerRuleAdmin(admin.ModelAdmin):
     readonly_fields = ('created', 'modified', 'matched_results_link',)
 
     def matched_results_link(self, obj):
+        if not obj.pk or not obj.scanner:
+            return '-'
         count = ScannerResult.objects.filter(matched_rules=obj).count()
         url = reverse('admin:{}_{}_changelist'.format(
             ScannerResult._meta.app_label, ScannerResult._meta.model_name))

--- a/src/olympia/scanners/tests/test_admin.py
+++ b/src/olympia/scanners/tests/test_admin.py
@@ -428,3 +428,14 @@ class TestScannerRuleAdmin(TestCase):
         )
         assert link.attr('href') == expected_href
         assert link.text() == '1'
+
+    def test_create_view_doesnt_contain_link_to_results(self):
+        url = reverse('admin:scanners_scannerrule_add')
+        response = self.client.get(url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        field = doc('.field-matched_results_link')
+        assert field
+        assert field.text() == 'Matched Results:\n-'
+        link = doc('.field-matched_results_link a')
+        assert not link


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/13045