### PR TITLE
Change docker-compose nginx path to serve installable addon.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - ./static:/srv/static
       - ./site-static:/srv/site-static
       - ./storage/shared_storage/uploads:/srv/user-media
-      - ./storage/files:/srv/user-media/addons
+      - ./storage/files:/user-media/addons
     ports:
       - "80:80"
 


### PR DESCRIPTION
The install-able addon that gets created for the integration tests was not being served correctly from nginx. This should fix that.