### PR TITLE
Don't deal with multiple data types at the same time in reindex command

### DIFF
--- a/src/olympia/lib/es/management/commands/reindex.py
+++ b/src/olympia/lib/es/management/commands/reindex.py
@@ -5,7 +5,6 @@ import time
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
-from celery import group
 from elasticsearch.exceptions import NotFoundError
 
 import olympia.core.logger
@@ -16,29 +15,39 @@ from olympia.amo.search import get_es
 from olympia.lib.es.utils import (
     flag_reindexing_amo, is_reindexing_amo, timestamp_index,
     unflag_reindexing_amo)
-from olympia.stats import search as stats_search
+from olympia.stats import search as stats_indexer
 
 
 logger = olympia.core.logger.getLogger('z.elasticsearch')
 ES = get_es()
 
 
-def get_modules(with_stats=True):
-    """Return python modules containing functions reindex needs.
-
-    The `with_stats` parameter can be passed to omit the stats index module.
+def get_indexer(alias):
+    """Return indexer python module for a given alias.
 
     This needs to be dynamic to work with testing correctly, since tests change
-    the value of settings.ES_INDEXES to hit test-specific aliases."""
-    rval = {
-        # The keys are the index alias names, the values the python modules.
-        # The 'default' in ES_INDEXES is actually named 'addons'
+    the value of settings.ES_INDEXES to hit test-specific aliases.
+    """
+    modules = {
         settings.ES_INDEXES['default']: addons_indexer,
+        settings.ES_INDEXES['stats']: stats_indexer
     }
-    if with_stats:
-        rval[settings.ES_INDEXES['stats']] = stats_search
+    return modules[alias]
 
-    return rval
+
+def get_alias(data_name):
+    """
+    Return ES alias name for the kind of data we're interested in
+    ("addons" or "stats").
+
+    This needs to be dynamic to work with testing correctly, since tests change
+    the value of settings.ES_INDEXES to hit test-specific aliases.
+    """
+    aliases = {
+        'addons': settings.ES_INDEXES['default'],
+        'stats': settings.ES_INDEXES['stats']
+    }
+    return aliases[data_name]
 
 
 @task
@@ -58,7 +67,7 @@ def update_aliases(actions):
 def create_new_index(alias, new_index):
     logger.info(
         'Create the index {0}, for alias: {1}'.format(new_index, alias))
-    get_modules()[alias].create_new_index(new_index)
+    get_indexer(alias).create_new_index(new_index)
 
 
 @task(ignore_result=False)
@@ -80,13 +89,11 @@ def gather_index_data_tasks(alias, index):
     Return a group of indexing tasks for that index.
     """
     logger.info('Returning reindexing group for {0}'.format(index))
-    return get_modules()[alias].reindex_tasks_group(index)
+    return get_indexer(alias).reindex_tasks_group(index)
 
 
 _SUMMARY = """
 *** Reindexation done ***
-
-Reindexed %d indexes.
 
 Current Aliases configuration:
 
@@ -111,10 +118,11 @@ class Command(BaseCommand):
             help=('Deletes AMO indexes prior to reindexing.'),
             default=False),
         parser.add_argument(
-            '--with-stats',
-            action='store_true',
-            help=('Whether to also reindex AMO stats. Default: False'),
-            default=False),
+            '--data',
+            action='store',
+            help=('Data to reindex. Can be "addons" or "stats". '
+                  'Default: "addons".'),
+            default='addons'),
         parser.add_argument(
             '--noinput',
             action='store_true',
@@ -125,23 +133,25 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         """Reindexing work.
 
-        Creates a task chain that creates new indexes
-        over the old ones so the search feature
-        works while the indexation occurs.
+        Creates a task chain that creates new indexes over the old ones so the
+        search feature works while the indexation occurs.
 
         """
-        force = kwargs.get('force', False)
+        force = kwargs['force']
 
         if is_reindexing_amo() and not force:
             raise CommandError('Indexation already occurring - use --force to '
                                'bypass')
 
+        if kwargs['data'] not in ('addons', 'stats'):
+            raise CommandError('--data should be "addons" or "stats".')
+
+        alias = get_alias(kwargs['data'])
+
         self.stdout.write('Starting the reindexation')
 
-        modules = get_modules(with_stats=kwargs.get('with_stats', False))
-
-        if kwargs.get('wipe', False):
-            skip_confirmation = kwargs.get('noinput', False)
+        if kwargs['wipe']:
+            skip_confirmation = kwargs['noinput']
             confirm = ''
             if not skip_confirmation:
                 confirm = input('Are you sure you want to wipe all AMO '
@@ -152,13 +162,16 @@ class Command(BaseCommand):
 
             if (confirm == 'yes' or skip_confirmation):
                 unflag_database()
-                for index in set(modules.keys()):
-                    ES.indices.delete(index, ignore=404)
+                ES.indices.delete(alias, ignore=404)
             else:
-                raise CommandError("Aborted.")
+                raise CommandError('Aborted.')
         elif force:
             unflag_database()
 
+        workflow = self.create_workflow(alias)
+        self.execute_workflow(workflow)
+
+    def create_workflow(self, alias):
         alias_actions = []
 
         def add_alias_action(action, index, alias):
@@ -171,59 +184,51 @@ class Command(BaseCommand):
         self.stdout.write('Building the task chain')
 
         to_remove = []
-        workflow = []
+        old_index = None
 
-        # For each alias, we create a new time-stamped index.
-        for alias, module in modules.items():
-            old_index = None
+        try:
+            olds = ES.indices.get_alias(alias)
+            for old_index in olds:
+                # Mark the index to be removed later.
+                to_remove.append(old_index)
+                # Mark the alias to be removed from that index.
+                add_alias_action('remove', old_index, alias)
+        except NotFoundError:
+            # If the alias dit not exist, ignore it, don't try to remove
+            # it.
+            pass
 
-            try:
-                olds = ES.indices.get_alias(alias)
-                for old_index in olds:
-                    # Mark the index to be removed later.
-                    to_remove.append(old_index)
-                    # Mark the alias to be removed from that index.
-                    add_alias_action('remove', old_index, alias)
-            except NotFoundError:
-                # If the alias dit not exist, ignore it, don't try to remove
-                # it.
-                pass
+        # Create a new index, using the alias name with a timestamp.
+        new_index = timestamp_index(alias)
+        # Mark the alias to be added at the end.
+        add_alias_action('add', new_index, alias)
 
-            # Create a new index, using the alias name with a timestamp.
-            new_index = timestamp_index(alias)
+        # If old_index is None that could mean it's a full index.
+        # In that case we want to continue index in it.
+        if ES.indices.exists(alias):
+            old_index = alias
 
-            # If old_index is None that could mean it's a full index.
-            # In that case we want to continue index in it.
-            if ES.indices.exists(alias):
-                old_index = alias
+        # Main chain for this alias that:
+        # - creates the new index
+        # - then, flags the database (which in turn makes every index call
+        #   index data on both the old and the new index).
+        workflow = (
+            create_new_index.si(alias, new_index) |
+            flag_database.si(new_index, old_index, alias)
+        )
+        # ... Then start indexing data. gather_index_data_tasks() is a
+        # function returning a group of indexing tasks.
+        index_data_tasks = gather_index_data_tasks(alias, new_index)
 
-            # Main chain for this alias: flag the database, then create the new
-            # index...
-            _chain = (
-                flag_database.si(new_index, old_index, alias) |
-                create_new_index.si(alias, new_index)
-            )
-            # ... Then start indexing data. gather_index_data_tasks() is a
-            # function returning a group of indexing tasks.
-            index_data_tasks = gather_index_data_tasks(alias, new_index)
-            if index_data_tasks.tasks:
-                _chain |= index_data_tasks
+        if index_data_tasks.tasks:
+            # Add the group to the chain, if it's not empty.
+            workflow |= index_data_tasks
 
-            # Append that chain to the workflow we're going to execute.
-            workflow.append(_chain)
-
-            # Adding new index to the alias.
-            add_alias_action('add', new_index, alias)
-
-        # Group each alias chain so that they are executed in parallel if there
-        # is more than one alias to deal with.
-        workflow = group(workflow)
-
-        # Chain the global group with a task that updates the aliases to point
-        # to the new indexes and remove the old aliases, if any.
+        # Chain with a task that updates the aliases to point to the new
+        # index and remove the old aliases, if any.
         workflow |= update_aliases.si(alias_actions)
 
-        # Chain that with a task that unflags the database - there's no need to
+        # Chain with a task that unflags the database - there's no need to
         # duplicate the indexing anymore.
         workflow |= unflag_database.si()
 
@@ -231,6 +236,9 @@ class Command(BaseCommand):
         if to_remove:
             workflow |= delete_indexes.si(to_remove)
 
+        return workflow
+
+    def execute_workflow(self, workflow):
         # Let's do it.
         self.stdout.write('Running all indexation tasks')
 
@@ -239,7 +247,7 @@ class Command(BaseCommand):
         try:
             workflow.apply_async()
 
-            if not getattr(settings, 'CELERY_ALWAYS_EAGER', False):
+            if not getattr(settings, 'CELERY_TASK_ALWAYS_EAGER', False):
                 time.sleep(10)   # give celeryd some time to flag the DB
             while is_reindexing_amo():
                 self.stdout.write('.')
@@ -253,5 +261,5 @@ class Command(BaseCommand):
         # Let's return the /_aliases values.
         aliases = ES.indices.get_alias()
         aliases = json.dumps(aliases, sort_keys=True, indent=4)
-        summary = _SUMMARY % (len(modules), aliases)
+        summary = _SUMMARY % aliases
         self.stdout.write(summary)

--- a/src/olympia/lib/es/tests/test_commands.py
+++ b/src/olympia/lib/es/tests/test_commands.py
@@ -1,15 +1,26 @@
+import re
 import threading
 import time
 import io
+from unittest import mock
 
 from django.core import management
 from django.db import connection
 from django.test.testcases import TransactionTestCase
 
+from celery import group, task
+from celery.canvas import _chain
+
 from olympia.amo.tests import (
     addon_factory, create_switch, ESTestCase, reverse_ns)
 from olympia.amo.utils import urlparams
+from olympia.lib.es.management.commands import reindex
 from olympia.lib.es.utils import is_reindexing_amo, unflag_reindexing_amo
+
+
+@task
+def dummy_task():
+    return None
 
 
 class TestIndexCommand(ESTestCase):
@@ -151,6 +162,82 @@ class TestIndexCommand(ESTestCase):
         self.refresh()
         self.check_results(self.expected)
         self._test_reindexation()
+
+    def test_stats(self):
+        old_indices = self.get_indices_aliases()
+        stdout = io.StringIO()
+        management.call_command('reindex', data='stats', stdout=stdout)
+        stdout.seek(0)
+        buf = stdout.read()
+        new_indices = self.get_indices_aliases()
+        assert len(new_indices)
+        assert old_indices != new_indices, (buf, old_indices, new_indices)
+
+    @mock.patch.object(reindex, 'gather_index_data_tasks')
+    def _test_workflow(self, index, gather_index_data_tasks_mock):
+        command = reindex.Command()
+        alias = reindex.get_alias(index)
+        # Patch reindex.gather_index_data_tasks so that it returns a group of
+        # dummy tasks - otherwise the chain would not contain the indexation
+        # tasks and that's what we really care about.
+        gather_index_data_tasks_mock.return_value = group(
+            [dummy_task.si()] * 42
+        )
+        workflow = command.create_workflow(alias)
+
+        # Make sure we called gather_index_data_tasks_mock with the alias and
+        # timestamped index.
+        expected_index = alias
+        assert gather_index_data_tasks_mock.call_args[0][0] == expected_index
+        assert gather_index_data_tasks_mock.call_args[0][1].startswith(
+            expected_index
+        )
+        assert re.search(
+            '[0-9]{14}$', gather_index_data_tasks_mock.call_args[0][1]
+        )
+
+        # Inspect workflow to make sure it contains what we expect. We should
+        # have a chain with a few startup tasks, then a chord that indexes the
+        # data and finishes with cleanup tasks.
+        assert isinstance(workflow, _chain)
+
+        expected_tasks = [
+            'olympia.lib.es.management.commands.reindex.create_new_index',
+            'olympia.lib.es.management.commands.reindex.flag_database',
+            'celery.chord'
+        ]
+        assert expected_tasks == [task.name for task in workflow.tasks]
+
+        reindex_chord = workflow.tasks[2]
+
+        expected_header = [
+            'olympia.lib.es.tests.test_commands.dummy_task'
+        ] * 42
+        assert expected_header == [task.name for task in reindex_chord.tasks]
+
+        expected_body = [
+            'olympia.lib.es.management.commands.reindex.update_aliases',
+            'olympia.lib.es.management.commands.reindex.unflag_database',
+        ]
+        assert isinstance(reindex_chord.body, _chain)
+        for i, task_name in enumerate(expected_body):
+            assert task_name == reindex_chord.body.tasks[i].name
+        # Note: there might be an extra task at the end of the chain to delete
+        # existing indexes depending on how tests are called/set up.
+
+    def test_create_workflow_addons(self):
+        """
+        Test tasks returned by create_workflow() as used by reindex command,
+        for addons.
+        """
+        self._test_workflow('addons')
+
+    def test_create_workflow_stats(self):
+        """
+        Test tasks returned by create_workflow() as used by reindex command,
+        for stats.
+        """
+        self._test_workflow('stats')
 
 
 class TestIndexCommandClassicAlgorithm(TestIndexCommand):

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1062,6 +1062,7 @@ CELERY_TASK_SOFT_TIME_LIMIT = 60 * 30
 CELERY_IMPORTS = (
     'olympia.lib.crypto.tasks',
     'olympia.lib.es.management.commands.reindex',
+    'olympia.stats.management.commands.index_stats',
 )
 
 CELERY_TASK_QUEUES = (

--- a/src/olympia/stats/management/commands/index_stats.py
+++ b/src/olympia/stats/management/commands/index_stats.py
@@ -34,7 +34,7 @@ To limit the  date range:
 
 def gather_index_stats_tasks(index, addons=None, dates=None):
     """
-    Return the list of task groups to execute to index statistics for the given
+    Return list of tasks to execute to index statistics for the given
     index/dates/addons.
     """
     queries = [
@@ -85,11 +85,12 @@ def gather_index_stats_tasks(index, addons=None, dates=None):
                     '%s__range' % date_field: date_range
                 }))
                 if data:
-                    jobs.append(create_chunked_tasks_signatures(
-                        task, data, CHUNK_SIZE, task_args=(index,)))
+                    jobs.extend(create_chunked_tasks_signatures(
+                        task, data, CHUNK_SIZE, task_args=(index,)).tasks)
         else:
-            jobs.append(create_chunked_tasks_signatures(
-                task, list(qs), CHUNK_SIZE, task_args=(index,)))
+            jobs.extend(create_chunked_tasks_signatures(
+                task, list(qs), CHUNK_SIZE, task_args=(index,)).tasks)
+
     return jobs
 
 

--- a/src/olympia/stats/search.py
+++ b/src/olympia/stats/search.py
@@ -2,6 +2,8 @@ import collections
 
 from django.conf import settings
 
+from celery import group
+
 from olympia import amo
 from olympia.applications.models import AppVersion
 from olympia.lib.es.utils import create_index
@@ -142,7 +144,7 @@ def reindex_tasks_group(index_name):
     from olympia.stats.management.commands.index_stats import (
         gather_index_stats_tasks
     )
-    return gather_index_stats_tasks(index_name)
+    return group(gather_index_stats_tasks(index_name))
 
 
 def get_mappings():

--- a/src/olympia/stats/tests/test_cron.py
+++ b/src/olympia/stats/tests/test_cron.py
@@ -24,56 +24,45 @@ class TestIndexStats(TestCase):
     def test_by_date(self, group_mock):
         call_command('index_stats', addons=None, date='2009-06-01')
         qs = self.downloads.filter(date='2009-06-01')
-        download_group = group_mock.call_args[0][0][1]
-        assert len(download_group) == 1
-        task = download_group.tasks[0]
-        assert task.task == 'olympia.stats.tasks.index_download_counts'
-        assert task.args == (list(qs), None)
+        calls = group_mock.call_args[0][0]
+        assert calls[0].task == 'olympia.stats.tasks.index_update_counts'
+        assert calls[1].task == 'olympia.stats.tasks.index_download_counts'
+        assert calls[0].args == calls[1].args == (list(qs), None)
 
-    def test_called_three(self, group_mock):
-        call_command('index_stats', addons=None, date='2009-06-01')
-        assert len(group_mock.call_args[0][0]) == 2
-
-    def test_called_three_with_addons_param(self, group_mock):
+    def test_by_addon_and_date_no_match(self, group_mock):
         call_command('index_stats', addons='5', date='2009-06-01')
-        assert len(group_mock.call_args[0][0]) == 2
+        calls = group_mock.call_args[0][0]
+        assert len(calls) == 0
 
     def test_by_date_range(self, group_mock):
         call_command('index_stats', addons=None,
                      date='2009-06-01:2009-06-07')
         qs = self.downloads.filter(date__range=('2009-06-01', '2009-06-07'))
-        download_group = group_mock.call_args[0][0][1]
-        assert len(download_group) == 1
-        task = download_group.tasks[0]
-        assert task.task == 'olympia.stats.tasks.index_download_counts'
-        assert task.args == (list(qs), None)
+        calls = group_mock.call_args[0][0]
+        assert calls[0].task == 'olympia.stats.tasks.index_update_counts'
+        assert calls[1].task == 'olympia.stats.tasks.index_download_counts'
+        assert calls[0].args == calls[1].args == (list(qs), None)
 
     def test_by_addon(self, group_mock):
         call_command('index_stats', addons='5', date=None)
         qs = self.downloads.filter(addon=5)
-        download_group = group_mock.call_args[0][0][1]
-        assert len(download_group) == 1
-        task = download_group.tasks[0]
-        assert task.task == 'olympia.stats.tasks.index_download_counts'
-        assert task.args == (list(qs), None)
+        calls = group_mock.call_args[0][0]
+        assert calls[0].task == 'olympia.stats.tasks.index_download_counts'
+        assert calls[0].args == (list(qs), None)
 
     def test_by_addon_and_date(self, group_mock):
         call_command('index_stats', addons='4', date='2009-06-01')
         qs = self.downloads.filter(addon=4, date='2009-06-01')
-        download_group = group_mock.call_args[0][0][1]
-        assert len(download_group) == 1
-        task = download_group.tasks[0]
-        assert task.task == 'olympia.stats.tasks.index_download_counts'
-        assert task.args == (list(qs), None)
+        calls = group_mock.call_args[0][0]
+        assert calls[0].task == 'olympia.stats.tasks.index_update_counts'
+        assert calls[0].args == (list(qs), None)
 
     def test_multiple_addons_and_date(self, group_mock):
         call_command('index_stats', addons='4, 5', date='2009-10-03')
         qs = self.downloads.filter(addon__in=[4, 5], date='2009-10-03')
-        download_group = group_mock.call_args[0][0][1]
-        assert len(download_group) == 1
-        task = download_group.tasks[0]
-        assert task.task == 'olympia.stats.tasks.index_download_counts'
-        assert task.args == (list(qs), None)
+        calls = group_mock.call_args[0][0]
+        assert calls[0].task == 'olympia.stats.tasks.index_download_counts'
+        assert calls[0].args == (list(qs), None)
 
     def test_no_addon_or_date(self, group_mock):
         call_command('index_stats', addons=None, date=None)
@@ -83,8 +72,8 @@ class TestIndexStats(TestCase):
         # together that they'll be indexed in the same chunk, so we should have
         # 2 calls.
         update_counts_calls = [
-            c.tasks[0].args for c in calls
-            if c.tasks[0].task == 'olympia.stats.tasks.index_update_counts'
+            call.args for call in calls
+            if call.task == 'olympia.stats.tasks.index_update_counts'
         ]
         assert len(update_counts_calls) == 2
 
@@ -92,8 +81,8 @@ class TestIndexStats(TestCase):
         # together that they'll be indexed in the same chunk, so we should have
         # 9 calls.
         download_counts_calls = [
-            c.tasks[0].args for c in calls
-            if c.tasks[0].task == 'olympia.stats.tasks.index_download_counts'
+            call.args for call in calls
+            if call.task == 'olympia.stats.tasks.index_download_counts'
         ]
         assert len(download_counts_calls) == 9
 


### PR DESCRIPTION
This simplification allows us to fix an issue with the reindex workflow being wrong with Celery > 4.1.1, which completely broke reindexing of a single index.

A new `--data` parameter is introduced for when we want to reindex stats and not addons. We'll have to fire the command twice if we want to reindex both.

Fixes #13049

(I'm hoping it would also fix #13051 but I'm not sure yet)