### PR TITLE
reset AddonApprovalsCounter.last_content_review when addon metadata changes

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1837,6 +1837,17 @@ class AddonApprovalsCounter(ModelBase):
             addon=addon, defaults={'last_content_review': now})
         return obj
 
+    @classmethod
+    def reset_content_for_addon(cls, addon):
+        """
+        Reset the last_content_review date for this addon so it triggers
+        another review.
+        """
+        try:
+            cls.objects.update(addon=addon, last_content_review=None)
+        except cls.NotFoundException:
+            pass
+
 
 class DeniedGuid(ModelBase):
     id = PositiveAutoField(primary_key=True)

--- a/src/olympia/devhub/utils.py
+++ b/src/olympia/devhub/utils.py
@@ -18,6 +18,7 @@ from olympia.files.tasks import repack_fileupload
 from olympia.files.utils import parse_addon, parse_xpi
 from olympia.scanners.tasks import run_customs, run_wat, run_yara
 from olympia.tags.models import Tag
+from olympia.translations.models import Translation
 from olympia.users.models import (
     DeveloperAgreementRestriction, UserRestrictionHistory
 )
@@ -384,3 +385,13 @@ class UploadRestrictionChecker:
         except IndexError:
             msg = None
         return msg
+
+
+def fetch_existing_translations_from_addon(addon, properties):
+    translation_ids_gen = (
+        getattr(addon, prop + '_id', None) for prop in properties)
+    translation_ids = [id_ for id_ in translation_ids_gen if id_]
+    # Just get all the values together to make it simplier
+    return {
+        str(value)
+        for value in Translation.objects.filter(id__in=translation_ids)}


### PR DESCRIPTION
fixes #13044 - brings back `fetch_existing_translations_from_addon` from the akismet days (removed in #12389)