### PR TITLE
Fix #13102: update usage of `set_context` in DRF default/validator classes

### DIFF
--- a/src/olympia/bandwagon/serializers.py
+++ b/src/olympia/bandwagon/serializers.py
@@ -75,11 +75,11 @@ class CollectionSerializer(serializers.ModelSerializer):
 
 
 class ThisCollectionDefault(object):
-    def set_context(self, serializer_field):
+    requires_context = True
+
+    def __call__(self, serializer_field):
         viewset = serializer_field.context['view']
         self.collection = viewset.get_collection()
-
-    def __call__(self):
         return self.collection
 
 


### PR DESCRIPTION
* [x] This PR relates to an existing open issue and there are no existing
      PRs open for the same issue.
* [x] Add `Fixes #ISSUENUM` at the top of your PR.
* [x] Add a description of the changes introduced in this PR.
* [x] The change has been successfully run locally.

Linked issue: fixes #13102

Description:
Update declaration of a default context object in accordance to DRF 3.11. Source of guidance used: https://www.django-rest-framework.org/community/3.11-announcement/#validator-default-context
