### PR TITLE
Add reindex after addon creating for ui-tests.

### DIFF
--- a/Makefile-docker
+++ b/Makefile-docker
@@ -172,6 +172,8 @@ setup-ui-tests:
 	$(PYTHON_COMMAND) manage.py generate_themes $(NUM_THEMES)
 	$(PYTHON_COMMAND) manage.py generate_default_addons_for_frontend
 
+	# Now that addons have been generated, reindex.
+	$(PYTHON_COMMAND) manage.py reindex --force --noinput
 	# Also update category counts (denormalized field)
 	$(PYTHON_COMMAND) manage.py cron category_totals
 


### PR DESCRIPTION
Should fix the issue with the frontend not loading correct addons.

Fixes #13130