### PR TITLE
Fixes #13097: The user clicks the link in confirmation email that the automated test passed, will jump to an unknown URL.

### DIFF
--- a/src/olympia/reviewers/templates/reviewers/emails/unlisted_to_reviewed_auto.ltxt
+++ b/src/olympia/reviewers/templates/reviewers/emails/unlisted_to_reviewed_auto.ltxt
@@ -1,6 +1,6 @@
 Hi there,
 
-Your add-on, {{ name }}, has passed our automatic tests. Version {{ number }} is now signed and ready for you to download at {{ dev_versions_url }}. Note that you need to be logged in as a developer of the add-on before downloading.
+Your add-on, {{ name }}, has passed our automatic tests. Version {{ number }} is now signed and ready for you to download at {{ dev_versions_url }} . Note that you need to be logged in as a developer of the add-on before downloading.
 
 -- 
 Mozilla Add-ons Team


### PR DESCRIPTION
[Fixes #13097 ](https://github.com/mozilla/addons-server/issues/13097)

Added a space between "{{ dev_versions_url }}" and ".". This should solve the issue
