### PR TITLE
Fixes #12753

### DIFF
--- a/src/olympia/devhub/templates/devhub/new-landing/components/connect.html
+++ b/src/olympia/devhub/templates/devhub/new-landing/components/connect.html
@@ -27,7 +27,7 @@
         <form class="DevHub-Connect-newsletter-form" id="newsletter_form" name="newsletter_form" action="https://www.mozilla.org/en-US/newsletter/" method="post" data-no-csrf>
           <input type="hidden" id="fmt" name="fmt" value="H">
           <input type="hidden" id="newsletters" name="newsletters" value="about-addons">
-          <div id="newsletter_errors" class="newsletter_errors"><br /></div>
+          <div id="newsletter_errors" class="newsletter_errors"></div>
 
           <div id="newsletter_email" class="form_group">
               <label for="email">{{ _('Email Address') }}</label>

--- a/src/olympia/devhub/templates/devhub/new-landing/components/connect.html
+++ b/src/olympia/devhub/templates/devhub/new-landing/components/connect.html
@@ -27,7 +27,7 @@
         <form class="DevHub-Connect-newsletter-form" id="newsletter_form" name="newsletter_form" action="https://www.mozilla.org/en-US/newsletter/" method="post" data-no-csrf>
           <input type="hidden" id="fmt" name="fmt" value="H">
           <input type="hidden" id="newsletters" name="newsletters" value="about-addons">
-          <div id="newsletter_errors" class="newsletter_errors"></div>
+          <div id="newsletter_errors" class="newsletter_errors"><br /></div>
 
           <div id="newsletter_email" class="form_group">
               <label for="email">{{ _('Email Address') }}</label>

--- a/static/css/devhub/new-landing/sections/connect.less
+++ b/static/css/devhub/new-landing/sections/connect.less
@@ -128,6 +128,7 @@
         display: none; /* hide by default */
         margin-bottom: 10px;
         padding: 0 10px;
+        width: 100%;
 
         ul {
             list-style-type: disc;


### PR DESCRIPTION
Adding break line for the newletter-error div element after the error message for invalid email.

* [x] This PR relates to an existing open issue and there are no existing
      PRs open for the same issue.
* [x] Add `Fixes #ISSUENUM` at the top of your PR.
* [x] Add a description of the changes introduced in this PR.
* [ ] The change has been successfully run locally.
* [ ] Add tests to cover the changes added in this PR.
* [ ] Add before and after screenshots (Only for changes that impact the UI).

The changes couldn't be tested locally due to various issues at setting up the project in Arch Linux. 

Fixes #12753 