### PR TITLE
Minor tweaks to make devhub buttons 100% for smaller viewports

### DIFF
--- a/static/css/devhub/new-landing/sections/my-addons.less
+++ b/static/css/devhub/new-landing/sections/my-addons.less
@@ -125,7 +125,7 @@
 }
 
 .DevHub-MyAddons-item-buttons-submit {
-
+  width: 100%;
   margin-left: auto;
   float: right;
 
@@ -134,12 +134,16 @@
     margin-left: 0;
     float: left;
   }
-}
 
-.DevHub-MyAddons-item-buttons-submit > .Button {
-  width: 100%;
+  .Button {
+    width: 100%;
+  }
 
   @media @medium {
     width: auto;
+
+    .Button {
+      width: auto;
+    }
   }
 }


### PR DESCRIPTION
Fixes #13183

This patch does a couple of things:

* Uses nesting a little bit more
* Removes a superfluous `>`.
* Makes the button container full-width at the same time as the buttons so they span the viewport when the buttons are 100% width.

Before:

<img width="898" alt="Developer_Hub____Add-ons_for_Firefox_-_Firefox_Nightly" src="https://user-images.githubusercontent.com/1514/71836438-e81d5a00-30ab-11ea-982a-b249cc653b9d.png">

After:

<img width="700" alt="Developer_Hub____Add-ons_for_Firefox_-_Firefox_Nightly" src="https://user-images.githubusercontent.com/1514/71836506-06835580-30ac-11ea-9884-37f8fb2af074.png">
