### PR TITLE
replace admin addon manage with inline formsets

### DIFF
--- a/src/olympia/addons/admin.py
+++ b/src/olympia/addons/admin.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from django.contrib import admin
 from django.core import validators
 from django.forms.models import modelformset_factory
-from django.shortcuts import get_object_or_404
 from django.urls import resolve
 from django.utils.html import format_html
 from django.utils.translation import ugettext, ugettext_lazy as _
@@ -163,14 +162,12 @@ class AddonAdmin(admin.ModelAdmin):
 
     def change_view(self, request, object_id, form_url='', extra_context=None):
         lookup_field = Addon.get_lookup_field(object_id)
-        if lookup_field == 'pk':
-            addon = get_object_or_404(Addon.unfiltered.all(), id=object_id)
-        else:
+        if lookup_field != 'pk':
             try:
                 if lookup_field == 'slug':
-                    addon = Addon.unfiltered.all().get(slug=object_id)
+                    addon = self.queryset(request).all().get(slug=object_id)
                 elif lookup_field == 'guid':
-                    addon = Addon.unfiltered.all().get(guid=object_id)
+                    addon = self.queryset(request).get(guid=object_id)
             except Addon.DoesNotExist:
                 raise http.Http404
             # Don't get in an infinite loop if addon.slug.isdigit().

--- a/src/olympia/addons/admin.py
+++ b/src/olympia/addons/admin.py
@@ -44,6 +44,14 @@ class AddonUserInline(admin.TabularInline):
     user_profile_link.short_description = 'User Profile'
 
 
+class FileInlineChecks(admin.checks.InlineModelAdminChecks):
+    def _check_relation(self, obj, parent_model):
+        """File doesn't have a direct FK to Addon (it's via Version) so we have
+        to bypass this check.
+        """
+        return []
+
+
 class FileInline(admin.TabularInline):
     model = File
     extra = 0
@@ -56,6 +64,7 @@ class FileInline(admin.TabularInline):
     can_delete = False
     view_on_site = False
     template = 'addons/admin/file_inline.html'
+    checks_class = FileInlineChecks
 
     def version__version(self, obj):
         return obj.version.version + (

--- a/src/olympia/addons/forms.py
+++ b/src/olympia/addons/forms.py
@@ -41,7 +41,8 @@ class AdminBaseFileFormSet(BaseModelFormSet):
         if not hasattr(self, '_queryset'):
             self.pager = amo.utils.paginate(
                 self.request,
-                Version.unfiltered.filter(addon=self.instance),
+                Version.unfiltered.filter(addon=self.instance).values_list(
+                    'pk', flat=True),
                 30)
             # A list coercion so this doesn't result in a subquery with a LIMIT
             # which MySQL doesn't support (at this time).

--- a/src/olympia/addons/forms.py
+++ b/src/olympia/addons/forms.py
@@ -1,0 +1,68 @@
+from django.forms import ModelForm
+from django.forms.models import BaseModelFormSet
+
+import olympia.core.logger
+from olympia import amo
+from olympia.files.models import File
+from olympia.versions.models import Version
+
+
+admin_log = olympia.core.logger.getLogger('z.addons.admin')
+
+
+class FileStatusForm(ModelForm):
+    class Meta:
+        model = File
+        fields = ('status',)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        try:
+            if self.instance.version.deleted:
+                self.fields['status'].disabled = True
+                self.fields['status'].widget.attrs.update({'disabled': 'true'})
+        except File.version.RelatedObjectDoesNotExist:
+            pass
+
+
+class AdminBaseFileFormSet(BaseModelFormSet):
+    def __init__(self, instance=None, **kwargs):
+        self.instance = instance
+
+        if kwargs.pop('save_as_new', False):
+            raise NotImplementedError
+        super().__init__(**kwargs)
+
+    @classmethod
+    def get_default_prefix(cls):
+        return 'files'
+
+    def get_queryset(self):
+        if not hasattr(self, '_queryset'):
+            self.pager = amo.utils.paginate(
+                self.request,
+                Version.unfiltered.filter(addon=self.instance),
+                30)
+            # A list coercion so this doesn't result in a subquery with a LIMIT
+            # which MySQL doesn't support (at this time).
+            versions = list(self.pager.object_list)
+            qs = super().get_queryset().filter(
+                version__in=versions).order_by('-version__id')
+
+            self._queryset = qs.select_related('version')
+        return self._queryset
+
+    def save_existing_objects(self, commit=True):
+        objs = super().save_existing_objects(commit=commit)
+        for form in self.initial_forms:
+            if 'status' in form.changed_data:
+                admin_log.info(
+                    'Addon "%s" file (ID:%d) status changed to: %s' % (
+                        self.instance.slug, form.instance.id,
+                        form.cleaned_data['status']))
+        return objs
+
+    def save_new_objects(self, commit=True):
+        # We don't support adding new File instances through this form
+        self.new_objects = []
+        return self.new_objects

--- a/src/olympia/addons/forms.py
+++ b/src/olympia/addons/forms.py
@@ -2,9 +2,7 @@ from django.forms import ModelForm
 from django.forms.models import BaseModelFormSet
 
 import olympia.core.logger
-from olympia import amo
 from olympia.files.models import File
-from olympia.versions.models import Version
 
 
 admin_log = olympia.core.logger.getLogger('z.addons.admin')
@@ -36,22 +34,6 @@ class AdminBaseFileFormSet(BaseModelFormSet):
     @classmethod
     def get_default_prefix(cls):
         return 'files'
-
-    def get_queryset(self):
-        if not hasattr(self, '_queryset'):
-            self.pager = amo.utils.paginate(
-                self.request,
-                Version.unfiltered.filter(addon=self.instance).values_list(
-                    'pk', flat=True),
-                30)
-            # A list coercion so this doesn't result in a subquery with a LIMIT
-            # which MySQL doesn't support (at this time).
-            versions = list(self.pager.object_list)
-            qs = super().get_queryset().filter(
-                version__in=versions).order_by('-version__id')
-
-            self._queryset = qs.select_related('version')
-        return self._queryset
 
     def save_existing_objects(self, commit=True):
         objs = super().save_existing_objects(commit=commit)

--- a/src/olympia/addons/templates/addons/admin/file_inline.html
+++ b/src/olympia/addons/templates/addons/admin/file_inline.html
@@ -1,0 +1,3 @@
+{% include "admin/edit_inline/tabular.html" %}
+{% load i18n admin_urls jinja_helpers %}
+{{ inline_admin_formset.formset.pager|dj_paginator }}

--- a/src/olympia/addons/templates/addons/admin/file_inline.html
+++ b/src/olympia/addons/templates/addons/admin/file_inline.html
@@ -1,3 +1,3 @@
 {% include "admin/edit_inline/tabular.html" %}
 {% load i18n admin_urls jinja_helpers %}
-{{ inline_admin_formset.formset.pager|dj_paginator }}
+{{ inline_admin_formset.opts.pager|dj_paginator }}

--- a/src/olympia/addons/tests/test_admin.py
+++ b/src/olympia/addons/tests/test_admin.py
@@ -409,7 +409,7 @@ class TestAddonAdmin(TestCase):
         self.grant_permission(user, 'Addons:Edit')
         self.grant_permission(user, 'Admin:Advanced')
         self.client.login(email=user.email)
-        with self.assertNumQueries(35):
+        with self.assertNumQueries(23):
             # It's very high because most of AddonAdmin is unoptimized but we
             # don't want it unexpectedly increasing.
             response = self.client.get(self.detail_url, follow=True)
@@ -417,7 +417,7 @@ class TestAddonAdmin(TestCase):
         assert addon.guid in response.content.decode('utf-8')
 
         version_factory(addon=addon)
-        with self.assertNumQueries(35):
+        with self.assertNumQueries(23):
             # confirm it scales
             response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 200

--- a/src/olympia/addons/tests/test_admin.py
+++ b/src/olympia/addons/tests/test_admin.py
@@ -416,6 +416,13 @@ class TestAddonAdmin(TestCase):
         assert response.status_code == 200
         assert addon.guid in response.content.decode('utf-8')
 
+        version_factory(addon=addon)
+        with self.assertNumQueries(35):
+            # confirm it scales
+            response = self.client.get(self.detail_url, follow=True)
+        assert response.status_code == 200
+        assert addon.guid in response.content.decode('utf-8')
+
     def test_version_pagination(self):
         addon = addon_factory(users=[user_factory()])
         first_file = addon.current_version.all_files[0]

--- a/src/olympia/addons/tests/test_admin.py
+++ b/src/olympia/addons/tests/test_admin.py
@@ -4,10 +4,11 @@ from django.conf import settings
 from django.contrib import admin
 
 from olympia import amo
+from olympia.activity.models import ActivityLog
 from olympia.addons.admin import ReplacementAddonAdmin
 from olympia.addons.models import ReplacementAddon
 from olympia.amo.tests import (
-    TestCase, addon_factory, collection_factory, user_factory)
+    TestCase, addon_factory, collection_factory, user_factory, version_factory)
 from olympia.amo.urlresolvers import django_reverse, reverse
 
 
@@ -130,7 +131,8 @@ class TestAddonAdmin(TestCase):
             'bayesian_rating': addon.bayesian_rating,
             'reputation': addon.reputation,
             'type': addon.type,
-            'slug': addon.slug
+            'slug': addon.slug,
+            'status': addon.status,
         }
         post_data['guid'] = '@bar'
         response = self.client.post(self.detail_url, post_data, follow=True)
@@ -170,7 +172,8 @@ class TestAddonAdmin(TestCase):
             'average_daily_users': addon.average_daily_users,
             'bayesian_rating': addon.bayesian_rating,
             'type': addon.type,
-            'slug': addon.slug
+            'slug': addon.slug,
+            'status': addon.status,
         }
         post_data['guid'] = '@bar'
         response = self.client.post(self.detail_url, post_data, follow=True)
@@ -222,8 +225,44 @@ class TestAddonAdmin(TestCase):
         assert response.status_code == 200
         assert addon.guid in response.content.decode('utf-8')
 
-    def test_can_edit_addonuser_if_has_admin_advanced(self):
+    def _get_full_post_data(self, addon, addonuser):
+        return {
+            # Django wants the whole form to be submitted, unfortunately.
+            'total_ratings': addon.total_ratings,
+            'text_ratings_count': addon.text_ratings_count,
+            'default_locale': addon.default_locale,
+            'weekly_downloads': addon.weekly_downloads,
+            'total_downloads': addon.total_downloads,
+            'average_rating': addon.average_rating,
+            'average_daily_users': addon.average_daily_users,
+            'bayesian_rating': addon.bayesian_rating,
+            'reputation': addon.reputation,
+            'type': addon.type,
+            'slug': addon.slug,
+            'status': addon.status,
+            'guid': addon.guid,
+            'addonuser_set-TOTAL_FORMS': 1,
+            'addonuser_set-INITIAL_FORMS': 1,
+            'addonuser_set-MIN_NUM_FORMS': 0,
+            'addonuser_set-MAX_NUM_FORMS': 1000,
+            'addonuser_set-0-id': addonuser.pk,
+            'addonuser_set-0-addon': addon.pk,
+            'addonuser_set-0-user': addonuser.user.pk,
+            'addonuser_set-0-role': amo.AUTHOR_ROLE_OWNER,
+            'addonuser_set-0-listed': 'on',
+            'addonuser_set-0-position': 0,
+
+            'files-TOTAL_FORMS': 1,
+            'files-INITIAL_FORMS': 1,
+            'files-MIN_NUM_FORMS': 0,
+            'files-MAX_NUM_FORMS': 0,
+            'files-0-id': addon.current_version.all_files[0].pk,
+            'files-0-status': addon.current_version.all_files[0].status,
+        }
+
+    def test_can_edit_addonuser_and_files_if_has_admin_advanced(self):
         addon = addon_factory(guid='@foo', users=[user_factory()])
+        file = addon.current_version.all_files[0]
         addonuser = addon.addonuser_set.get()
         self.detail_url = reverse(
             'admin:addons_addon_change', args=(addon.pk,)
@@ -236,42 +275,24 @@ class TestAddonAdmin(TestCase):
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 200
         assert addon.guid in response.content.decode('utf-8')
-
-        post_data = {
-            # Django wants the whole form to be submitted, unfortunately.
-            'total_ratings': addon.total_ratings,
-            'text_ratings_count': addon.text_ratings_count,
-            'default_locale': addon.default_locale,
-            'weekly_downloads': addon.weekly_downloads,
-            'total_downloads': addon.total_downloads,
-            'average_rating': addon.average_rating,
-            'average_daily_users': addon.average_daily_users,
-            'bayesian_rating': addon.bayesian_rating,
-            'reputation': addon.reputation,
-            'type': addon.type,
-            'slug': addon.slug,
-            'addonuser_set-TOTAL_FORMS': 1,
-            'addonuser_set-INITIAL_FORMS': 1,
-            'addonuser_set-MIN_NUM_FORMS': 0,
-            'addonuser_set-MAX_NUM_FORMS': 1000,
-            'addonuser_set-0-id': addonuser.pk,
-            'addonuser_set-0-addon': addon.pk,
+        post_data = self._get_full_post_data(addon, addonuser)
+        post_data.update(**{
+            'guid': '@bar',  # update it.
             'addonuser_set-0-user': user.pk,  # Different user than initial.
-            'addonuser_set-0-role': amo.AUTHOR_ROLE_OWNER,
-            'addonuser_set-0-listed': 'on',
-            'addonuser_set-0-position': 0,
-
-        }
-        post_data['guid'] = '@bar'
+            'files-0-status': amo.STATUS_AWAITING_REVIEW,  # Different status.
+        })
         response = self.client.post(self.detail_url, post_data, follow=True)
         assert response.status_code == 200
         addon.reload()
         assert addon.guid == '@bar'
         addonuser.reload()
         assert addonuser.user == user
+        file.reload()
+        assert file.status == amo.STATUS_AWAITING_REVIEW
 
-    def test_can_not_edit_addonuser_if_doesnt_have_admin_advanced(self):
+    def test_can_not_edit_addonuser_files_if_doesnt_have_admin_advanced(self):
         addon = addon_factory(guid='@foo', users=[user_factory()])
+        file = addon.current_version.all_files[0]
         addonuser = addon.addonuser_set.get()
         self.detail_url = reverse(
             'admin:addons_addon_change', args=(addon.pk,)
@@ -284,40 +305,140 @@ class TestAddonAdmin(TestCase):
         assert response.status_code == 200
         assert addon.guid in response.content.decode('utf-8')
 
-        post_data = {
-            # Django wants the whole form to be submitted, unfortunately.
-            'total_ratings': addon.total_ratings,
-            'text_ratings_count': addon.text_ratings_count,
-            'default_locale': addon.default_locale,
-            'weekly_downloads': addon.weekly_downloads,
-            'total_downloads': addon.total_downloads,
-            'average_rating': addon.average_rating,
-            'average_daily_users': addon.average_daily_users,
-            'bayesian_rating': addon.bayesian_rating,
-            'reputation': addon.reputation,
-            'type': addon.type,
-            'slug': addon.slug,
-
-            # This won't work:
-            'addonuser_set-TOTAL_FORMS': 1,
-            'addonuser_set-INITIAL_FORMS': 1,
-            'addonuser_set-MIN_NUM_FORMS': 0,
-            'addonuser_set-MAX_NUM_FORMS': 1000,
-            'addonuser_set-0-id': addonuser.pk,
-            'addonuser_set-0-addon': addon.pk,
+        post_data = self._get_full_post_data(addon, addonuser)
+        post_data.update(**{
+            'guid': '@bar',  # update it.
             'addonuser_set-0-user': user.pk,  # Different user than initial.
-            'addonuser_set-0-role': amo.AUTHOR_ROLE_OWNER,
-            'addonuser_set-0-listed': 'on',
-            'addonuser_set-0-position': 0,
-
-        }
-        post_data['guid'] = '@bar'
+            'files-0-status': amo.STATUS_AWAITING_REVIEW,  # Different status.
+        })
         response = self.client.post(self.detail_url, post_data, follow=True)
         assert response.status_code == 200
         addon.reload()
         assert addon.guid == '@bar'
         addonuser.reload()
         assert addonuser.user != user
+        file.reload()
+        assert file.status != amo.STATUS_AWAITING_REVIEW
+
+    def test_can_manage_unlisted_versions_and_change_addon_status(self):
+        addon = addon_factory(guid='@foo', users=[user_factory()])
+        unlisted_version = version_factory(
+            addon=addon, channel=amo.RELEASE_CHANNEL_UNLISTED)
+        listed_version = addon.current_version
+        addonuser = addon.addonuser_set.get()
+        self.detail_url = reverse(
+            'admin:addons_addon_change', args=(addon.pk,)
+        )
+        user = user_factory()
+        self.grant_permission(user, 'Admin:Tools')
+        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, 'Admin:Advanced')
+        self.client.login(email=user.email)
+        response = self.client.get(self.detail_url, follow=True)
+        assert response.status_code == 200
+        assert addon.guid in response.content.decode('utf-8')
+        doc = pq(response.content)
+        assert doc('#id_files-0-id').attr('value') == str(
+            unlisted_version.all_files[0].id)
+        assert doc('#id_files-1-id').attr('value') == str(
+            addon.current_version.all_files[0].id)
+
+        # pagination links aren't shown for less than page size (30) files.
+        next_url = self.detail_url + '?page=2'
+        assert next_url not in response.content.decode('utf-8')
+
+        post_data = self._get_full_post_data(addon, addonuser)
+        post_data.update(**{
+            'status': amo.STATUS_DISABLED,
+            'files-TOTAL_FORMS': 2,
+            'files-INITIAL_FORMS': 2,
+            'files-0-id': unlisted_version.all_files[0].pk,
+            'files-0-status': amo.STATUS_DISABLED,
+            'files-1-id': listed_version.all_files[0].pk,
+            'files-1-status': amo.STATUS_AWAITING_REVIEW,  # Different status.
+        })
+        # Confirm the original statuses so we know they're actually changing.
+        assert addon.status != amo.STATUS_DISABLED
+        assert listed_version.all_files[0].status != amo.STATUS_AWAITING_REVIEW
+        assert unlisted_version.all_files[0].status != amo.STATUS_DISABLED
+
+        response = self.client.post(self.detail_url, post_data, follow=True)
+        assert response.status_code == 200
+        addon.reload()
+        assert addon.status == amo.STATUS_DISABLED
+        assert ActivityLog.objects.filter(
+            action=amo.LOG.CHANGE_STATUS.id).exists()
+        listed_version = addon.versions.get(id=listed_version.id)
+        assert listed_version.all_files[0].status == amo.STATUS_AWAITING_REVIEW
+        unlisted_version = addon.versions.get(id=unlisted_version.id)
+        assert unlisted_version.all_files[0].status == amo.STATUS_DISABLED
+
+    def test_status_cannot_change_for_deleted_version(self):
+        addon = addon_factory(guid='@foo', users=[user_factory()])
+        file = addon.current_version.all_files[0]
+        self.detail_url = reverse(
+            'admin:addons_addon_change', args=(addon.pk,)
+        )
+        user = user_factory()
+        self.grant_permission(user, 'Admin:Tools')
+        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, 'Admin:Advanced')
+        post_data = self._get_full_post_data(addon, addon.addonuser_set.get())
+        file.version.delete()
+
+        self.client.login(email=user.email)
+        response = self.client.get(self.detail_url, follow=True)
+        assert response.status_code == 200
+        assert f'{file.version} - Deleted' in response.content.decode('utf-8')
+        assert 'disabled' in (
+            pq(response.content)('#id_files-0-status')[0].attrib)
+        post_data.update(**{
+            'files-0-status': amo.STATUS_AWAITING_REVIEW,  # Different status.
+        })
+        response = self.client.post(self.detail_url, post_data, follow=True)
+        assert response.status_code == 200
+        file.reload()
+        assert file.status != amo.STATUS_AWAITING_REVIEW
+
+    def test_query_count(self):
+        addon = addon_factory(guid='@foo', users=[user_factory()])
+        user = user_factory()
+        self.detail_url = reverse(
+            'admin:addons_addon_change', args=(addon.pk,))
+        self.grant_permission(user, 'Admin:Tools')
+        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, 'Admin:Advanced')
+        self.client.login(email=user.email)
+        with self.assertNumQueries(35):
+            # It's very high because most of AddonAdmin is unoptimized but we
+            # don't want it unexpectedly increasing.
+            response = self.client.get(self.detail_url, follow=True)
+        assert response.status_code == 200
+        assert addon.guid in response.content.decode('utf-8')
+
+    def test_version_pagination(self):
+        addon = addon_factory(users=[user_factory()])
+        first_file = addon.current_version.all_files[0]
+        [version_factory(addon=addon) for i in range(0, 30)]
+        user = user_factory()
+        self.detail_url = reverse(
+            'admin:addons_addon_change', args=(addon.pk,))
+        self.grant_permission(user, 'Admin:Tools')
+        self.grant_permission(user, 'Addons:Edit')
+        self.grant_permission(user, 'Admin:Advanced')
+        self.client.login(email=user.email)
+        response = self.client.get(self.detail_url, follow=True)
+        assert response.status_code == 200
+        assert addon.guid in response.content.decode('utf-8')
+        assert len(pq(response.content)('.field-version__version')) == 30
+        next_url = self.detail_url + '?page=2'
+        assert next_url in response.content.decode('utf-8')
+        response = self.client.get(next_url, follow=True)
+        assert response.status_code == 200
+        assert addon.guid in response.content.decode('utf-8')
+        assert len(pq(response.content)('.field-version__version')) == 1
+        assert pq(response.content)('#id_files-0-id')[0].attrib['value'] == (
+            str(first_file.id))
 
 
 class TestReplacementAddonList(TestCase):

--- a/src/olympia/amo/templatetags/jinja_helpers.py
+++ b/src/olympia/amo/templatetags/jinja_helpers.py
@@ -7,7 +7,7 @@ from urllib.parse import urljoin
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.forms import CheckboxInput
-from django.template import defaultfilters, loader
+from django.template import defaultfilters, Library, loader
 from django.utils.encoding import smart_text
 from django.utils.html import format_html as django_format_html
 from django.utils.safestring import mark_safe
@@ -25,6 +25,9 @@ from rest_framework.settings import api_settings
 from olympia.amo import urlresolvers, utils
 from olympia.lib.jingo_minify_helpers import (
     _build_html, get_css_urls, get_js_urls)
+
+
+register = Library()
 
 
 # Registering some utils as filters:
@@ -105,6 +108,11 @@ def services_url(viewname, *args, **kwargs):
 @library.filter
 def paginator(pager):
     return PaginationRenderer(pager).render()
+
+
+@register.filter(needs_autoescape=True)
+def dj_paginator(pager, autoescape=True):
+    return mark_safe(PaginationRenderer(pager).render())
 
 
 @library.filter

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -283,6 +283,7 @@ JINJA_EXCLUDE_TEMPLATE_PATHS = (
     r'^devhub\/email\/submission_api_key_revocation.txt',
     r'^devhub\/email\/api_key_confirmation.ltxt',
     r'^blocklist\/',
+    r'^addons\/admin\/',
 
     # Django specific templates
     r'^registration\/',

--- a/src/olympia/zadmin/tests/test_views.py
+++ b/src/olympia/zadmin/tests/test_views.py
@@ -278,6 +278,14 @@ class TestAddonManagement(TestCase):
         # But no change.
         assert file.status == 4
 
+
+class TestRecalculateHash(TestCase):
+    fixtures = ['base/addon_3615', 'base/users']
+
+    def setUp(self):
+        super().setUp()
+        self.client.login(email='admin@mozilla.com')
+
     @mock.patch.object(File, 'file_path',
                        amo.tests.AMOPaths().file_fixture_path(
                            'delicious_bookmarks-2.1.106-fx.xpi'))

--- a/static/js/admin/recalc_hash.js
+++ b/static/js/admin/recalc_hash.js
@@ -1,31 +1,31 @@
 django.jQuery(document).ready(function ($){
     "use strict";
 
-    $(document).ajaxSend(function(event, xhr, ajaxSettings) {
-        var csrf;
-        // Block anything that starts with 'http:', 'https:', '://' or '//'.
-        if (!/^((https?:)|:?[/]{2})/.test(ajaxSettings.url)) {
-            // Only send the token to relative URLs i.e. locally.
-            csrf = $("input[name='csrfmiddlewaretoken']").val();
-            if (csrf) {
-                xhr.setRequestHeader('X-CSRFToken', csrf);
-            }
-        }
-    });
-
     // Recalculate Hash
     $('.recalc').click(function(e) {
+        var $this = $(this),
+            csrf = $("input[name='csrfmiddlewaretoken']").val();
         e.preventDefault();
-        var $this = $(this);
-        $this.html('Recalcing&hellip;');
-        $.post($this.attr('href'), function() {
-            $this.text('Done!');
-        }).fail(function() {
-            $this.text('Error :(');
-        }).always(function() {
-            setTimeout(function() {
-                $this.text('Recalc Hash');
-            }, 2000);
+
+        $.ajax($this.attr('href'), {
+
+            "headers": {'X-CSRFToken': csrf},
+            "dataType": "json",
+            "method": "POST",
+            "beforeSend": function () {
+                $this.html('Recalcing&hellip;');
+            },
+            "success": function() {
+                $this.text('Done!');
+            },
+            "error": function() {
+                $this.text('Error :(');
+            },
+            "complete": function() {
+                setTimeout(function() {
+                    $this.text('Recalc Hash');
+                }, 2000);
+            }
         });
     });
 });

--- a/static/js/admin/recalc_hash.js
+++ b/static/js/admin/recalc_hash.js
@@ -1,0 +1,31 @@
+django.jQuery(document).ready(function ($){
+    "use strict";
+
+    $(document).ajaxSend(function(event, xhr, ajaxSettings) {
+        var csrf;
+        // Block anything that starts with 'http:', 'https:', '://' or '//'.
+        if (!/^((https?:)|:?[/]{2})/.test(ajaxSettings.url)) {
+            // Only send the token to relative URLs i.e. locally.
+            csrf = $("input[name='csrfmiddlewaretoken']").val();
+            if (csrf) {
+                xhr.setRequestHeader('X-CSRFToken', csrf);
+            }
+        }
+    });
+
+    // Recalculate Hash
+    $('.recalc').click(function(e) {
+        e.preventDefault();
+        var $this = $(this);
+        $this.html('Recalcing&hellip;');
+        $.post($this.attr('href'), function() {
+            $this.text('Done!');
+        }).fail(function() {
+            $this.text('Error :(');
+        }).always(function() {
+            setTimeout(function() {
+                $this.text('Recalc Hash');
+            }, 2000);
+        });
+    });
+});


### PR DESCRIPTION
fixes #8410 - replicates the admin manage functionality but doesn't remove the old tool (yet).  The aim is the be feature comparable in this mvp.