### PR TITLE
Only calculate sha256 hash of currently selected file.

### DIFF
--- a/docs/topics/api/reviewers.rst
+++ b/docs/topics/api/reviewers.rst
@@ -142,7 +142,7 @@ This endpoint allows you to browse through the contents of an Add-on version.
     :>json int file.entries[].depth: Level of folder-tree depth, starting with 0.
     :>json string file.entries[].filename: The filename of the file.
     :>json string file.entries[].path: The absolute path (from the root of the XPI) of the file.
-    :>json string file.entries[].sha256: SHA256 hash.
+    :>json string|null file.entries[].sha256: SHA256 hash. This is only set for the currently selected file.
     :>json string file.entries[].mimetype: The determined mimetype of the file or ``application/octet-stream`` if none could be determined.
     :>json string files.entries[].mime_category: The mime type category of this file. Can be ``image``, ``directory``, ``text`` or ``binary``.
     :>json int file.entries[].size: The size in bytes.
@@ -177,7 +177,7 @@ This endpoint allows you to compare two Add-on versions with each other.
     :>json int|null file.entries[].depth: Level of folder-tree depth, starting with 0.
     :>json string file.entries[].filename: The filename of the file.
     :>json string file.entries[].path: The absolute path (from the root of the XPI) of the file.
-    :>json string|null file.entries[].sha256: SHA256 hash.
+    :>json string|null file.entries[].sha256: SHA256 hash. This is only set for the currently selected file. It may also be `null` for deleted files.
     :>json string|null file.entries[].mimetype: The determined mimetype of the file or ``application/octet-stream`` if none could be determined. Can be ``null`` in case of a deleted file.
     :>json string|null files.entries[].mime_category: The mime type category of this file. Can be ``image``, ``directory``, ``text`` or ``binary``.
     :>json int|null file.entries[].size: The size in bytes.

--- a/src/olympia/reviewers/serializers.py
+++ b/src/olympia/reviewers/serializers.py
@@ -88,7 +88,7 @@ class FileEntriesSerializer(FileSerializer):
         # `self._entries` dictionary.
         _entries = getattr(self, '_entries', {})
 
-        if _entries:
+        if _entries and _entries[selected_file]['sha256']:
             return _entries[selected_file]['sha256']
 
         commit = self._get_commit(obj)

--- a/src/olympia/reviewers/serializers.py
+++ b/src/olympia/reviewers/serializers.py
@@ -84,8 +84,12 @@ class FileEntriesSerializer(FileSerializer):
     def _get_hash_for_selected_file(self, obj):
         selected_file = self.get_selected_file(obj)
 
-        if hasattr(self, '_entries') and self._entries[selected_file]['sha256']:
-            return self._entries[selected_file]['sha256']
+        # Return the hash if we already saved it to the locally cached
+        # `self._entries` dictionary.
+        _entries = getattr(self, '_entries', {})
+
+        if _entries:
+            return _entries[selected_file]['sha256']
 
         commit = self._get_commit(obj)
         tree = self.repo.get_root_tree(commit)


### PR DESCRIPTION
This will calculate the hash only for the currently selected file which
will reduce the delay of the initial request significantly because we
won't have to calculate sha256 hashes for hundreds of files.

The additional calculation time when selecting a file should be fairly
low because we already have the content in memory and the code-manager
does prefetch some usual usage patterns which will ensure most of the
data is already rendered.

Fixes #12920