### PR TITLE
Add the list of files related to the matched rules

### DIFF
--- a/src/olympia/scanners/admin.py
+++ b/src/olympia/scanners/admin.py
@@ -239,7 +239,7 @@ class ScannerResultAdmin(admin.ModelAdmin):
     formatted_matched_rules.short_description = 'Matched rules'
 
     def formatted_matched_rules_with_files(self, obj):
-        files_by_matched_rule = obj.get_files_by_matched_rules()
+        files_by_matched_rules = obj.get_files_by_matched_rules()
         return render_to_string(
             'admin/scanners/scannerresult/formatted_matched_rules_with_files.html',
             {
@@ -248,7 +248,7 @@ class ScannerResultAdmin(admin.ModelAdmin):
                     {
                         'pk': rule.pk,
                         'name': rule.name,
-                        'files': files_by_matched_rule[rule.name],
+                        'files': files_by_matched_rules[rule.name],
                     }
                     for rule in obj.matched_rules.all()
                 ]

--- a/src/olympia/scanners/admin.py
+++ b/src/olympia/scanners/admin.py
@@ -140,7 +140,7 @@ class ScannerResultAdmin(admin.ModelAdmin):
         'scanner',
         'created',
         'state',
-        'formatted_matched_rules',
+        'formatted_matched_rules_with_files',
         'formatted_results',
         'result_actions',
     )
@@ -237,6 +237,25 @@ class ScannerResultAdmin(admin.ModelAdmin):
         )
 
     formatted_matched_rules.short_description = 'Matched rules'
+
+    def formatted_matched_rules_with_files(self, obj):
+        files_by_matched_rule = obj.get_files_by_matched_rules()
+        return render_to_string(
+            'admin/scanners/scannerresult/formatted_matched_rules_with_files.html',
+            {
+                'addon_id': obj.version.addon.id if obj.version else None,
+                'matched_rules': [
+                    {
+                        'pk': rule.pk,
+                        'name': rule.name,
+                        'files': files_by_matched_rule[rule.name],
+                    }
+                    for rule in obj.matched_rules.all()
+                ]
+            },
+        )
+
+    formatted_matched_rules_with_files.short_description = 'Matched rules'
 
     def handle_true_positive(self, request, pk, *args, **kwargs):
         if request.method != "POST":

--- a/src/olympia/scanners/admin.py
+++ b/src/olympia/scanners/admin.py
@@ -241,7 +241,7 @@ class ScannerResultAdmin(admin.ModelAdmin):
     def formatted_matched_rules_with_files(self, obj):
         files_by_matched_rules = obj.get_files_by_matched_rules()
         return render_to_string(
-            'admin/scanners/scannerresult/formatted_matched_rules_with_files.html',
+            'admin/scanners/scannerresult/formatted_matched_rules_with_files.html',  # noqa
             {
                 'addon_id': obj.version.addon.id if obj.version else None,
                 'matched_rules': [

--- a/src/olympia/scanners/models.py
+++ b/src/olympia/scanners/models.py
@@ -1,6 +1,8 @@
 import json
 import re
 
+from collections import defaultdict
+
 import yara
 
 from django.conf import settings
@@ -95,20 +97,15 @@ class AbstractScannerResult(ModelBase):
         return json.dumps(self.results, indent=2)
 
     def get_files_by_matched_rules(self):
-        res = dict()
+        res = defaultdict(list)
         if self.scanner is YARA:
             for item in self.results:
-                if item['rule'] not in res:
-                    res[item['rule']] = []
                 res[item['rule']].append(item['meta']['filename'])
         elif self.scanner is CUSTOMS:
-            scanMap = (self.results['scanMap'] if 'scanMap' in self.results
-                       else {})
+            scanMap = self.results.get('scanMap', {})
             for filename, rules in scanMap.items():
                 for ruleId, data in rules.items():
                     if data.get('RULE_HAS_MATCHED', False):
-                        if ruleId not in res:
-                            res[ruleId] = []
                         res[ruleId].append(filename)
         return res
 

--- a/src/olympia/scanners/models.py
+++ b/src/olympia/scanners/models.py
@@ -94,6 +94,24 @@ class AbstractScannerResult(ModelBase):
     def get_pretty_results(self):
         return json.dumps(self.results, indent=2)
 
+    def get_files_by_matched_rules(self):
+        res = dict()
+        if self.scanner is YARA:
+            for item in self.results:
+                if item['rule'] not in res:
+                    res[item['rule']] = []
+                res[item['rule']].append(item['meta']['filename'])
+        elif self.scanner is CUSTOMS:
+            scanMap = (self.results['scanMap'] if 'scanMap' in self.results
+                       else {})
+            for filename, rules in scanMap.items():
+                for ruleId, data in rules.items():
+                    if data.get('RULE_HAS_MATCHED', False):
+                        if ruleId not in res:
+                            res[ruleId] = []
+                        res[ruleId].append(filename)
+        return res
+
     def can_report_feedback(self):
         return (
             self.has_matches and self.state == UNKNOWN and self.scanner != WAT

--- a/src/olympia/scanners/templates/admin/scanners/scannerresult/formatted_matched_rules_with_files.html
+++ b/src/olympia/scanners/templates/admin/scanners/scannerresult/formatted_matched_rules_with_files.html
@@ -1,0 +1,25 @@
+{% load admin_urls %}
+
+<table>
+  <thead>
+    <tr>
+      <th>Rule name</th>
+      <th>Files</th>
+    </tr>
+  </thead>
+  {% for rule in matched_rules %}
+  <tr>
+    <td><a href="{% url 'admin:scanners_scannerrule_change' rule.pk %}">{{ rule.name }}</a></td>
+    <td>
+      {% for file in rule.files %}
+        {% if addon_id %}
+          <a href="{% url 'files.list' addon_id 'file' file %}">{{ file }}</a>
+        {% else %}
+          {{ file }}
+        {% endif %}
+        <br>
+      {% endfor %}
+    </td>
+  </tr>
+  {% endfor %}
+</table>

--- a/src/olympia/scanners/tests/test_models.py
+++ b/src/olympia/scanners/tests/test_models.py
@@ -265,6 +265,7 @@ class TestScannerResultMixin:
             rule3: [file3, file4],
         }
 
+
 class TestScannerResult(TestScannerResultMixin, TestCase):
     __test__ = True
     model = ScannerResult

--- a/src/olympia/scanners/tests/test_models.py
+++ b/src/olympia/scanners/tests/test_models.py
@@ -30,10 +30,16 @@ class TestScannerResultMixin:
         return self.model.objects.create(scanner=WAT)
 
     def create_fake_yara_match(
-        self, rule='some-yara-rule', tags=None, description='some description'
+        self, rule='some-yara-rule', tags=None, description='some description',
+        filename='some/file.js'
     ):
         return FakeYaraMatch(
-            rule=rule, tags=tags or [], meta={'description': description}
+            rule=rule,
+            tags=tags or [],
+            meta={
+                'description': description,
+                'filename': filename,
+            }
         )
 
     def create_yara_result(self):
@@ -177,6 +183,87 @@ class TestScannerResultMixin:
         assert result.state == UNKNOWN
         assert not result.can_revert_feedback()
 
+    def test_get_files_by_matched_rules_for_wat(self):
+        result = self.create_wat_result()
+        assert result.get_files_by_matched_rules() == {}
+
+    def test_get_files_by_matched_rules_with_no_yara_results(self):
+        result = self.create_yara_result()
+        assert result.get_files_by_matched_rules() == {}
+
+    def test_get_files_by_matched_rules_for_yara(self):
+        result = self.create_yara_result()
+        rule1 = 'rule-1'
+        file1 = 'file/1.js'
+        match1 = self.create_fake_yara_match(rule=rule1, filename=file1)
+        result.add_yara_result(
+            rule=match1.rule, tags=match1.tags, meta=match1.meta
+        )
+        rule2 = 'rule-2'
+        file2 = 'file/2.js'
+        match2 = self.create_fake_yara_match(rule=rule2, filename=file2)
+        result.add_yara_result(
+            rule=match2.rule, tags=match2.tags, meta=match2.meta
+        )
+        # rule1 with file2
+        match3 = self.create_fake_yara_match(rule=rule1, filename=file2)
+        result.add_yara_result(
+            rule=match3.rule, tags=match3.tags, meta=match3.meta
+        )
+        assert result.get_files_by_matched_rules() == {
+            rule1: [file1, file2],
+            rule2: [file2],
+        }
+
+    def test_get_files_by_matched_rules_with_no_customs_results(self):
+        result = self.create_customs_result()
+        result.results = {'matchedRules': []}
+        assert result.get_files_by_matched_rules() == {}
+
+    def test_get_files_by_matched_rules_for_customs(self):
+        result = self.create_customs_result()
+        file1 = 'file/1.js'
+        rule1 = 'rule1'
+        file2 = 'file/2.js'
+        rule2 = 'rule2'
+        file3 = 'file/3.js'
+        rule3 = 'rule3'
+        file4 = 'file/4.js'
+        result.results = {
+            'scanMap': {
+                file1: {
+                    rule1: {
+                        'RULE_HAS_MATCHED': True,
+                    },
+                    rule2: {},
+                    # no rule3
+                },
+                file2: {
+                    rule1: {
+                        'RULE_HAS_MATCHED': False,
+                    },
+                    rule2: {},
+                    # no rule3
+                },
+                file3: {
+                    rule1: {},
+                    rule2: {},
+                    rule3: {
+                        'RULE_HAS_MATCHED': True,
+                    },
+                },
+                file4: {
+                    # no rule1 or rule2
+                    rule3: {
+                        'RULE_HAS_MATCHED': True,
+                    },
+                },
+            }
+        }
+        assert result.get_files_by_matched_rules() == {
+            rule1: [file1],
+            rule3: [file3, file4],
+        }
 
 class TestScannerResult(TestScannerResultMixin, TestCase):
     __test__ = True


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/13220

---

This patch changes the way we render the matched rules in the django admin. In
the "change view" of a scanner result, we now show both the matched rules and
the associated files (in a table). When possible, we add links to the reviewer
tools.

![](https://usercontent.irccloud-cdn.com/file/9RUrgf2U/Screen%20Shot%202020-01-13%20at%2015.45.56.png)