### PR TITLE
Add new `ADMIN_SCANNERS_*` permissions

### DIFF
--- a/src/olympia/constants/permissions.py
+++ b/src/olympia/constants/permissions.py
@@ -81,9 +81,11 @@ ABUSEREPORTS_EDIT = AclPermission('AbuseReports', 'Edit')
 LANGPACK_SUBMIT = AclPermission('LanguagePack', 'Submit')
 
 # Can access the scanners results admin.
-ADMIN_SCANNERS_RESULTS = AclPermission('Admin', 'ScannersResults')
+ADMIN_SCANNERS_RESULTS_VIEW = AclPermission('Admin', 'ScannersResultsView')
 # Can access the scanners rules admin.
-ADMIN_SCANNERS_RULES = AclPermission('Admin', 'ScannersRules')
+ADMIN_SCANNERS_RULES_VIEW = AclPermission('Admin', 'ScannersRulesView')
+# Can edit the scanners rules.
+ADMIN_SCANNERS_RULES_EDIT = AclPermission('Admin', 'ScannersRulesEdit')
 
 # All permissions, for easy introspection
 PERMISSIONS_LIST = [
@@ -141,11 +143,11 @@ DJANGO_PERMISSIONS_MAPPING.update({
 
     'reviewers.delete_reviewerscore': ADMIN_ADVANCED,
 
-    'scanners.add_scannerrule': ADMIN_ADVANCED,
-    'scanners.change_scannerrule': ADMIN_ADVANCED,
-    'scanners.delete_scannerrule': ADMIN_ADVANCED,
-    'scanners.view_scannerrule': ADMIN_SCANNERS_RULES,
-    'scanners.view_scannerresult': ADMIN_SCANNERS_RESULTS,
+    'scanners.add_scannerrule': ADMIN_SCANNERS_RULES_EDIT,
+    'scanners.change_scannerrule': ADMIN_SCANNERS_RULES_EDIT,
+    'scanners.delete_scannerrule': ADMIN_SCANNERS_RULES_EDIT,
+    'scanners.view_scannerrule': ADMIN_SCANNERS_RULES_VIEW,
+    'scanners.view_scannerresult': ADMIN_SCANNERS_RESULTS_VIEW,
 
     'users.change_userprofile': USERS_EDIT,
     'users.delete_userprofile': ADMIN_ADVANCED,

--- a/src/olympia/constants/permissions.py
+++ b/src/olympia/constants/permissions.py
@@ -80,6 +80,10 @@ ABUSEREPORTS_EDIT = AclPermission('AbuseReports', 'Edit')
 # Can submit language packs. #11788 and #11793
 LANGPACK_SUBMIT = AclPermission('LanguagePack', 'Submit')
 
+# Can access the scanners results admin.
+ADMIN_SCANNERS_RESULTS = AclPermission('Admin', 'ScannersResults')
+# Can access the scanners rules admin.
+ADMIN_SCANNERS_RULES = AclPermission('Admin', 'ScannersRules')
 
 # All permissions, for easy introspection
 PERMISSIONS_LIST = [
@@ -140,7 +144,8 @@ DJANGO_PERMISSIONS_MAPPING.update({
     'scanners.add_scannerrule': ADMIN_ADVANCED,
     'scanners.change_scannerrule': ADMIN_ADVANCED,
     'scanners.delete_scannerrule': ADMIN_ADVANCED,
-    'scanners.view_scannerresult': ADMIN_ADVANCED,
+    'scanners.view_scannerrule': ADMIN_SCANNERS_RULES,
+    'scanners.view_scannerresult': ADMIN_SCANNERS_RESULTS,
 
     'users.change_userprofile': USERS_EDIT,
     'users.delete_userprofile': ADMIN_ADVANCED,

--- a/src/olympia/scanners/admin.py
+++ b/src/olympia/scanners/admin.py
@@ -203,12 +203,8 @@ class ScannerResultAdmin(admin.ModelAdmin):
                     reverse(
                         'reviewers.review',
                         args=[
-                            (
-                                'listed'
-                                if obj.version.channel
-                                == amo.RELEASE_CHANNEL_LISTED
-                                else 'unlisted'
-                            ),
+                            ('listed' if obj.version.channel ==
+                             amo.RELEASE_CHANNEL_LISTED else 'unlisted'),
                             obj.version.addon.id,
                         ],
                     ),

--- a/src/olympia/scanners/tests/test_admin.py
+++ b/src/olympia/scanners/tests/test_admin.py
@@ -39,7 +39,7 @@ class TestScannerResultAdmin(TestCase):
         super().setUp()
 
         self.user = user_factory()
-        self.grant_permission(self.user, 'Admin:Advanced')
+        self.grant_permission(self.user, 'Admin:*')
         self.client.login(email=self.user.email)
         self.list_url = reverse('admin:scanners_scannerresult_changelist')
 
@@ -430,13 +430,52 @@ class TestScannerResultAdmin(TestCase):
         # A confirmation message should also appear.
         assert html('.messagelist .info').length == 1
 
+    def test_handle_true_positive_and_non_admin_user(self):
+        result = ScannerResult(scanner=CUSTOMS)
+        user = user_factory()
+        self.grant_permission(user, 'Admin:ScannersResultsView')
+        self.client.login(email=user.email)
+        response = self.client.post(
+            reverse(
+                'admin:scanners_scannerresult_handletruepositive',
+                args=[result.pk],
+            )
+        )
+        assert response.status_code == 404
+
+    def test_handle_false_positive_and_non_admin_user(self):
+        result = ScannerResult(scanner=CUSTOMS)
+        user = user_factory()
+        self.grant_permission(user, 'Admin:ScannersResultsView')
+        self.client.login(email=user.email)
+        response = self.client.post(
+            reverse(
+                'admin:scanners_scannerresult_handlefalsepositive',
+                args=[result.pk],
+            )
+        )
+        assert response.status_code == 404
+
+    def test_handle_revert_report_and_non_admin_user(self):
+        result = ScannerResult(scanner=CUSTOMS)
+        user = user_factory()
+        self.grant_permission(user, 'Admin:ScannersResultsView')
+        self.client.login(email=user.email)
+        response = self.client.post(
+            reverse(
+                'admin:scanners_scannerresult_handlerevert',
+                args=[result.pk],
+            )
+        )
+        assert response.status_code == 404
+
 
 class TestScannerRuleAdmin(TestCase):
     def setUp(self):
         super().setUp()
 
         self.user = user_factory()
-        self.grant_permission(self.user, 'Admin:Advanced')
+        self.grant_permission(self.user, 'Admin:*')
         self.client.login(email=self.user.email)
         self.list_url = reverse('admin:scanners_scannerrule_changelist')
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/13239

---

This patch adds news permissions for accessing the scanners admin. Because admins have some actions to triage the scanner results, some code was added to handle permissions for those actions.