### PR TITLE
Remove Django 1.11 cache_get_or_set backport

### DIFF
--- a/src/olympia/applications/views.py
+++ b/src/olympia/applications/views.py
@@ -1,3 +1,4 @@
+from django.core.cache import cache
 from django.db.transaction import non_atomic_requests
 from django.utils.translation import ugettext
 
@@ -5,7 +6,6 @@ from olympia import amo
 from olympia.amo.feeds import BaseFeed
 from olympia.amo.templatetags.jinja_helpers import absolutify, url
 from olympia.amo.utils import render
-from olympia.lib.cache import cache_get_or_set
 
 from .models import AppVersion
 
@@ -20,7 +20,7 @@ def get_versions(order=('application', 'version_int')):
         for app, version in qs:
             versions[app].append(version)
         return apps, versions
-    return cache_get_or_set('getv' + ':'.join(order), fetch_versions)
+    return cache.get_or_set('getv' + ':'.join(order), fetch_versions)
 
 
 @non_atomic_requests

--- a/src/olympia/files/file_viewer.py
+++ b/src/olympia/files/file_viewer.py
@@ -8,6 +8,7 @@ from collections import OrderedDict
 from datetime import datetime
 
 from django.conf import settings
+from django.core.cache import cache
 from django.core.files.storage import default_storage as storage
 from django.template.defaultfilters import filesizeformat
 from django.utils.encoding import force_text
@@ -18,7 +19,7 @@ import olympia.core.logger
 from olympia import amo
 from olympia.amo.urlresolvers import reverse
 from olympia.amo.utils import rm_local_tmp_dir
-from olympia.lib.cache import cache_get_or_set, Message
+from olympia.lib.cache import Message
 from olympia.files.utils import (
     lock, extract_xpi, get_all_files, get_sha256)
 
@@ -260,7 +261,7 @@ class FileViewer(object):
         if not self.is_extracted():
             extract_file(self)
 
-        self._files = cache_get_or_set(self._cache_key(), self._get_files)
+        self._files = cache.get_or_set(self._cache_key(), self._get_files)
         return self._files
 
     def truncate(self, filename, pre_length=15,

--- a/src/olympia/lib/cache.py
+++ b/src/olympia/lib/cache.py
@@ -22,32 +22,6 @@ def make_key(key, with_locale=True, normalize=False):
     return force_text(key)
 
 
-def cache_get_or_set(key, default, timeout=DEFAULT_TIMEOUT, version=None):
-    """
-    Fetch a given key from the cache. If the key does not exist,
-    the key is added and set to the default value. The default value can
-    also be any callable. If timeout is given, that timeout will be used
-    for the key; otherwise the default cache timeout will be used.
-
-    Return the value of the key stored or retrieved.
-
-    Backport from Django 1.11.
-    """
-    val = cache.get(key, version=version)
-
-    if val is None:
-        if callable(default):
-            default = default()
-
-        if default is not None:
-            cache.add(key, default, timeout=timeout, version=version)
-            # Fetch the value again to avoid a race condition if another
-            # caller added a value between the first get() and the add()
-            # above.
-            return cache.get(key, default, version=version)
-    return val
-
-
 def memoize_key(prefix, *args, **kwargs):
     """
     For a prefix and arguments returns a key suitable for use in memcache.
@@ -83,7 +57,7 @@ def memoize(prefix, timeout=60):
             def wrapped_func():
                 return func(*args, **kwargs)
             key = memoize_key(prefix, *args, **kwargs)
-            return cache_get_or_set(key, wrapped_func, timeout=timeout)
+            return cache.get_or_set(key, wrapped_func, timeout=DEFAULT_TIMEOUT)
         return wrapper
     return decorator
 

--- a/src/olympia/lib/tests/test_cache.py
+++ b/src/olympia/lib/tests/test_cache.py
@@ -4,8 +4,7 @@ from django.core.cache import cache
 
 from unittest import TestCase
 from olympia.lib.cache import (
-    Message, Token, memoize, memoize_key, cache_get_or_set,
-    make_key)
+    Message, Token, memoize, memoize_key, make_key)
 
 
 def test_make_key():
@@ -31,21 +30,6 @@ def test_make_key():
         assert (
             make_key(u'é@øel', normalize=True) ==
             'bc5208e905c8dfcc521e4196e16cfa1a')
-
-
-def test_cache_get_or_set():
-    # Compatibility test, since cache_get_or_set is a 1:1 backport from
-    # Django 1.11, their unittests apply.
-
-    def some_function():
-        some_function.call_count += 1
-        return 'something'  # Needed for cache_get_or_set() to work.
-    some_function.call_count = 0
-
-    cache_get_or_set('my-key', some_function)
-    cache_get_or_set('my-key', some_function)
-
-    assert some_function.call_count == 1
 
 
 def test_memoize_key():

--- a/src/olympia/ratings/tasks.py
+++ b/src/olympia/ratings/tasks.py
@@ -1,7 +1,8 @@
 from datetime import datetime
 
-from django.db.models import Avg, Count, F
+from django.core.cache import cache
 from django.conf import settings
+from django.db.models import Avg, Count, F
 
 import olympia.core.logger
 
@@ -9,7 +10,6 @@ from olympia.addons.models import Addon
 from olympia.addons.tasks import index_addons
 from olympia.amo.celery import task
 from olympia.amo.decorators import use_primary_db
-from olympia.lib.cache import cache_get_or_set
 from olympia.users.models import UserProfile
 
 from .models import GroupedRating, Rating
@@ -96,7 +96,7 @@ def addon_bayesian_rating(*addons, **kw):
     log.info('[%s@%s] Updating bayesian ratings.' %
              (len(addons), addon_bayesian_rating.rate_limit))
 
-    avg = cache_get_or_set('task.bayes.avg', addon_aggregates, 60 * 60 * 60)
+    avg = cache.get_or_set('task.bayes.avg', addon_aggregates, 60 * 60 * 60)
     # Rating can be NULL in the DB, so don't update it if it's not there.
     if avg['rating'] is None:
         return

--- a/src/olympia/reviewers/serializers.py
+++ b/src/olympia/reviewers/serializers.py
@@ -9,6 +9,7 @@ import pygit2
 from rest_framework import serializers
 from rest_framework.exceptions import NotFound
 
+from django.core.cache import cache
 from django.utils.functional import cached_property
 from django.utils.encoding import force_text
 from django.utils.timezone import FixedOffset
@@ -30,7 +31,6 @@ from olympia.reviewers.models import CannedResponse
 from olympia.versions.models import Version
 from olympia.lib.git import AddonGitRepository, get_mime_type_for_blob
 from olympia.lib import unicodehelper
-from olympia.lib.cache import cache_get_or_set
 
 
 class AddonReviewerFlagsSerializer(serializers.ModelSerializer):
@@ -123,7 +123,7 @@ class FileEntriesSerializer(FileSerializer):
                 }
             return result
 
-        self._entries = cache_get_or_set(
+        self._entries = cache.get_or_set(
             'reviewers:fileentriesserializer:entries:{}'.format(commit.hex),
             _fetch_entries,
             # Store information about this commit for 24h which should be

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -15,6 +15,7 @@ from django.conf import settings
 from django.contrib.auth.models import AbstractBaseUser, BaseUserManager
 from django.contrib.auth.signals import user_logged_in
 from django.core import validators
+from django.core.cache import cache
 from django.core.files.storage import default_storage as storage
 from django.db import models
 from django.utils import timezone
@@ -32,7 +33,6 @@ from olympia.amo.fields import PositiveAutoField, CIDRField
 from olympia.amo.models import ManagerBase, ModelBase, OnChangeMixin
 from olympia.amo.urlresolvers import reverse
 from olympia.amo.validators import OneOrMorePrintableCharacterValidator
-from olympia.lib.cache import cache_get_or_set
 from olympia.translations.query import order_by_translation
 from olympia.users.notifications import NOTIFICATIONS_BY_ID
 
@@ -646,7 +646,7 @@ class DeniedName(ModelBase):
         def fetch_names():
             return [n.lower() for n in qs.values_list('name', flat=True)]
 
-        blocked_list = cache_get_or_set('denied-name:blocked', fetch_names)
+        blocked_list = cache.get_or_set('denied-name:blocked', fetch_names)
         return any(n in name for n in blocked_list)
 
 


### PR DESCRIPTION
Fix #13236 - removes ```cache_get_or_set()```in favour of ```django.core.cache.get_or_set```
