### PR TITLE
Use absolute urls for the files linked in the scannerresult change view

### DIFF
--- a/src/olympia/scanners/admin.py
+++ b/src/olympia/scanners/admin.py
@@ -259,6 +259,7 @@ class ScannerResultAdmin(admin.ModelAdmin):
             'admin/scanners/scannerresult/formatted_matched_rules_with_files.html',  # noqa
             {
                 'addon_id': obj.version.addon.id if obj.version else None,
+                'external_site_url': settings.EXTERNAL_SITE_URL,
                 'matched_rules': [
                     {
                         'pk': rule.pk,

--- a/src/olympia/scanners/admin.py
+++ b/src/olympia/scanners/admin.py
@@ -258,8 +258,9 @@ class ScannerResultAdmin(admin.ModelAdmin):
         return render_to_string(
             'admin/scanners/scannerresult/formatted_matched_rules_with_files.html',  # noqa
             {
-                'addon_id': obj.version.addon.id if obj.version else None,
                 'external_site_url': settings.EXTERNAL_SITE_URL,
+                'file_id': (obj.version.all_files[0].id if obj.version else
+                            None),
                 'matched_rules': [
                     {
                         'pk': rule.pk,

--- a/src/olympia/scanners/templates/admin/scanners/scannerresult/formatted_matched_rules_with_files.html
+++ b/src/olympia/scanners/templates/admin/scanners/scannerresult/formatted_matched_rules_with_files.html
@@ -13,7 +13,7 @@
     <td>
       {% for file in rule.files %}
         {% if addon_id %}
-          <a href="{% url 'files.list' addon_id 'file' file %}">{{ file }}</a>
+          <a href="{{ external_site_url }}{% url 'files.list' addon_id 'file' file %}">{{ file }}</a>
         {% else %}
           {{ file }}
         {% endif %}

--- a/src/olympia/scanners/templates/admin/scanners/scannerresult/formatted_matched_rules_with_files.html
+++ b/src/olympia/scanners/templates/admin/scanners/scannerresult/formatted_matched_rules_with_files.html
@@ -12,8 +12,8 @@
     <td><a href="{% url 'admin:scanners_scannerrule_change' rule.pk %}">{{ rule.name }}</a></td>
     <td>
       {% for file in rule.files %}
-        {% if addon_id %}
-          <a href="{{ external_site_url }}{% url 'files.list' addon_id 'file' file %}">{{ file }}</a>
+        {% if file_id %}
+          <a href="{{ external_site_url }}{% url 'files.list' file_id 'file' file %}">{{ file }}</a>
         {% else %}
           {{ file }}
         {% endif %}

--- a/src/olympia/scanners/tests/test_admin.py
+++ b/src/olympia/scanners/tests/test_admin.py
@@ -177,9 +177,9 @@ class TestScannerResultAdmin(TestCase):
         assert self.admin.formatted_results(result) == '<pre>[]</pre>'
 
     def test_formatted_matched_rules_with_files(self):
-        addon = addon_factory()
+        version = addon_factory().current_version
         result = ScannerResult.objects.create(
-            scanner=YARA, version=addon.current_version
+            scanner=YARA, version=version
         )
         rule = ScannerRule.objects.create(name='bar', scanner=YARA)
         filename = 'some/file.js'
@@ -187,9 +187,11 @@ class TestScannerResultAdmin(TestCase):
         result.save()
 
         external_site_url = 'http://example.org'
+        file_id = version.all_files[0].id
+        assert file_id is not None
         expect_file_item = '<a href="{}{}">{}</a>'.format(
             external_site_url,
-            reverse('files.list', args=[addon.id, 'file', filename]),
+            reverse('files.list', args=[file_id, 'file', filename]),
             filename
         )
         with override_settings(EXTERNAL_SITE_URL=external_site_url):

--- a/src/olympia/scanners/tests/test_admin.py
+++ b/src/olympia/scanners/tests/test_admin.py
@@ -186,12 +186,15 @@ class TestScannerResultAdmin(TestCase):
         result.add_yara_result(rule=rule.name, meta={'filename': filename})
         result.save()
 
-        expect_file_item = '<a href="{}">{}</a>'.format(
+        external_site_url = 'http://example.org'
+        expect_file_item = '<a href="{}{}">{}</a>'.format(
+            external_site_url,
             reverse('files.list', args=[addon.id, 'file', filename]),
             filename
         )
-        assert (expect_file_item in
-                self.admin.formatted_matched_rules_with_files(result))
+        with override_settings(EXTERNAL_SITE_URL=external_site_url):
+            assert (expect_file_item in
+                    self.admin.formatted_matched_rules_with_files(result))
 
     def test_formatted_matched_rules_with_files_without_version(self):
         result = ScannerResult.objects.create(scanner=YARA)


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/13248

---

This patch should fix the issue mentioned above by:

- adding the external base URL to each URL to a file
- changing the ID in the generated URL (from addon ID to file ID)