### PR TITLE
Add Admin:ScannersResultsEdit permision

### DIFF
--- a/src/olympia/constants/permissions.py
+++ b/src/olympia/constants/permissions.py
@@ -82,6 +82,8 @@ LANGPACK_SUBMIT = AclPermission('LanguagePack', 'Submit')
 
 # Can access the scanners results admin.
 ADMIN_SCANNERS_RESULTS_VIEW = AclPermission('Admin', 'ScannersResultsView')
+# Can use "actions" on the scanners results.
+ADMIN_SCANNERS_RESULTS_EDIT = AclPermission('Admin', 'ScannersResultsEdit')
 # Can access the scanners rules admin.
 ADMIN_SCANNERS_RULES_VIEW = AclPermission('Admin', 'ScannersRulesView')
 # Can edit the scanners rules.

--- a/src/olympia/scanners/admin.py
+++ b/src/olympia/scanners/admin.py
@@ -190,7 +190,8 @@ class ScannerResultAdmin(admin.ModelAdmin):
         return self._excludes_admin_fields(request=request, fields=fields)
 
     def _excludes_admin_fields(self, request, fields):
-        is_admin = acl.action_allowed(request, amo.permissions.ADMIN_ADVANCED)
+        is_admin = acl.action_allowed(
+            request, amo.permissions.ADMIN_SCANNERS_RESULTS_EDIT)
         if not is_admin:
             return list(filter(lambda x: x != 'result_actions', fields))
         return fields
@@ -277,7 +278,8 @@ class ScannerResultAdmin(admin.ModelAdmin):
     formatted_matched_rules_with_files.short_description = 'Matched rules'
 
     def handle_true_positive(self, request, pk, *args, **kwargs):
-        is_admin = acl.action_allowed(request, amo.permissions.ADMIN_ADVANCED)
+        is_admin = acl.action_allowed(
+            request, amo.permissions.ADMIN_SCANNERS_RESULTS_EDIT)
         if not is_admin or request.method != "POST":
             raise Http404
 
@@ -293,7 +295,8 @@ class ScannerResultAdmin(admin.ModelAdmin):
         return redirect('admin:scanners_scannerresult_changelist')
 
     def handle_false_positive(self, request, pk, *args, **kwargs):
-        is_admin = acl.action_allowed(request, amo.permissions.ADMIN_ADVANCED)
+        is_admin = acl.action_allowed(
+            request, amo.permissions.ADMIN_SCANNERS_RESULTS_EDIT)
         if not is_admin or request.method != "POST":
             raise Http404
 
@@ -328,7 +331,8 @@ class ScannerResultAdmin(admin.ModelAdmin):
         )
 
     def handle_revert(self, request, pk, *args, **kwargs):
-        is_admin = acl.action_allowed(request, amo.permissions.ADMIN_ADVANCED)
+        is_admin = acl.action_allowed(
+            request, amo.permissions.ADMIN_SCANNERS_RESULTS_EDIT)
         if not is_admin or request.method != "POST":
             raise Http404
 

--- a/src/olympia/scanners/tests/test_admin.py
+++ b/src/olympia/scanners/tests/test_admin.py
@@ -39,7 +39,8 @@ class TestScannerResultAdmin(TestCase):
         super().setUp()
 
         self.user = user_factory()
-        self.grant_permission(self.user, 'Admin:*')
+        self.grant_permission(self.user, 'Admin:ScannersResultsEdit')
+        self.grant_permission(self.user, 'Admin:ScannersResultsView')
         self.client.login(email=self.user.email)
         self.list_url = reverse('admin:scanners_scannerresult_changelist')
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/13263

---

`Admin:Advanced` was used before but it seems a bit better to have a dedicated permissions.