### PR TITLE
Use referer in scanner feedback actions

### DIFF
--- a/src/olympia/scanners/admin.py
+++ b/src/olympia/scanners/admin.py
@@ -296,7 +296,10 @@ class ScannerResultAdmin(admin.ModelAdmin):
             'Scanner result {} has been marked as true positive.'.format(pk),
         )
 
-        return redirect('admin:scanners_scannerresult_changelist')
+        return redirect(request.META.get(
+            'HTTP_REFERER',
+            'admin:scanners_scannerresult_changelist'
+        ))
 
     def handle_false_positive(self, request, pk, *args, **kwargs):
         is_admin = acl.action_allowed(
@@ -349,7 +352,10 @@ class ScannerResultAdmin(admin.ModelAdmin):
             'Scanner result {} report has been reverted.'.format(pk),
         )
 
-        return redirect('admin:scanners_scannerresult_changelist')
+        return redirect(request.META.get(
+            'HTTP_REFERER',
+            'admin:scanners_scannerresult_changelist'
+        ))
 
     def get_urls(self):
         urls = super().get_urls()


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/13221

---

Instead of redirecting to the list all the time, we redirect to the "current" page (where the action buttons are displayed). For the list view, it is the list and that's how we fix the issue mentioned above. For the change view, it redirects to the same change view.