### PR TITLE
Iterate through deltas instead of patches to generate entries.

### DIFF
--- a/src/olympia/lib/tests/test_git.py
+++ b/src/olympia/lib/tests/test_git.py
@@ -1184,3 +1184,173 @@ def test_get_mime_type_for_blob(
 
     assert mime == expected_mimetype
     assert category == expected_category
+
+
+@pytest.mark.django_db
+def test_get_deltas_add_new_file():
+    addon = addon_factory(file_kw={'filename': 'notify-link-clicks-i18n.xpi'})
+
+    original_version = addon.current_version
+
+    AddonGitRepository.extract_and_commit_from_version(original_version)
+
+    version = version_factory(
+        addon=addon, file_kw={'filename': 'notify-link-clicks-i18n.xpi'})
+
+    repo = AddonGitRepository.extract_and_commit_from_version(version)
+
+    apply_changes(repo, version, '{"id": "random"}\n', 'new_file.json')
+
+    changes = repo.get_deltas(
+        commit=version.git_hash,
+        parent=original_version.git_hash)
+
+    assert changes[0]['mode'] == 'A'
+    assert changes[0]['old_path'] == 'new_file.json'
+    assert changes[0]['path'] == 'new_file.json'
+    assert changes[0]['parent'] == original_version.git_hash
+    assert changes[0]['hash'] == version.git_hash
+
+
+@pytest.mark.django_db
+def test_get_deltas_change_files():
+    addon = addon_factory(file_kw={'filename': 'notify-link-clicks-i18n.xpi'})
+
+    original_version = addon.current_version
+
+    AddonGitRepository.extract_and_commit_from_version(original_version)
+
+    version = version_factory(
+        addon=addon, file_kw={'filename': 'notify-link-clicks-i18n.xpi'})
+
+    repo = AddonGitRepository.extract_and_commit_from_version(version)
+
+    apply_changes(repo, version, '{"id": "random"}\n', 'manifest.json')
+    apply_changes(repo, version, 'Updated readme\n', 'README.md')
+
+    changes = repo.get_deltas(
+        commit=version.git_hash,
+        parent=original_version.git_hash)
+
+    assert len(changes) == 2
+
+    assert changes[0]
+    assert changes[0]['mode'] == 'M'
+    assert changes[0]['old_path'] == 'README.md'
+    assert changes[0]['path'] == 'README.md'
+    assert changes[0]['parent'] == original_version.git_hash
+    assert changes[0]['hash'] == version.git_hash
+
+
+@pytest.mark.django_db
+def test_get_deltas_initial_commit():
+    addon = addon_factory(file_kw={'filename': 'notify-link-clicks-i18n.xpi'})
+
+    version = addon.current_version
+    repo = AddonGitRepository.extract_and_commit_from_version(version)
+
+    changes = repo.get_deltas(
+        commit=version.git_hash,
+        parent=None)
+
+    # This makes sure that sub-directories are diffed properly too
+    assert changes[1]['mode'] == 'A'
+    assert changes[1]['old_path'] == '_locales/de/messages.json'
+    assert changes[1]['parent'] == version.git_hash
+    assert changes[1]['hash'] == version.git_hash
+    assert changes[1]['path'] == '_locales/de/messages.json'
+
+
+@pytest.mark.django_db
+def test_get_deltas_initial_commit_pathspec():
+    addon = addon_factory(file_kw={'filename': 'notify-link-clicks-i18n.xpi'})
+
+    version = addon.current_version
+    repo = AddonGitRepository.extract_and_commit_from_version(version)
+
+    changes = repo.get_deltas(
+        commit=version.git_hash,
+        parent=None,
+        pathspec=['_locales/de/messages.json'])
+
+    assert len(changes) == 1
+
+    # This makes sure that sub-directories are diffed properly too
+    assert changes[0]['mode'] == 'A'
+    assert changes[0]['old_path'] == '_locales/de/messages.json'
+    assert changes[0]['parent'] == version.git_hash
+    assert changes[0]['hash'] == version.git_hash
+    assert changes[0]['path'] == '_locales/de/messages.json'
+
+
+@pytest.mark.django_db
+def test_get_deltas_change_files_pathspec():
+    addon = addon_factory(file_kw={'filename': 'notify-link-clicks-i18n.xpi'})
+
+    original_version = addon.current_version
+
+    AddonGitRepository.extract_and_commit_from_version(original_version)
+
+    version = version_factory(
+        addon=addon, file_kw={'filename': 'notify-link-clicks-i18n.xpi'})
+
+    repo = AddonGitRepository.extract_and_commit_from_version(version)
+
+    apply_changes(repo, version, '{"id": "random"}\n', 'manifest.json')
+    apply_changes(repo, version, 'Updated readme\n', 'README.md')
+
+    changes = repo.get_deltas(
+        commit=version.git_hash,
+        parent=original_version.git_hash,
+        pathspec=['README.md'])
+
+    assert len(changes) == 1
+
+    assert changes[0]
+    assert changes[0]['mode'] == 'M'
+    assert changes[0]['old_path'] == 'README.md'
+    assert changes[0]['path'] == 'README.md'
+    assert changes[0]['parent'] == original_version.git_hash
+    assert changes[0]['hash'] == version.git_hash
+
+
+@pytest.mark.django_db
+def test_get_deltas_delete_file():
+    addon = addon_factory(file_kw={'filename': 'webextension_no_id.xpi'})
+
+    original_version = addon.current_version
+
+    AddonGitRepository.extract_and_commit_from_version(original_version)
+
+    version = version_factory(
+        addon=addon, file_kw={'filename': 'webextension_no_id.xpi'})
+
+    repo = AddonGitRepository.extract_and_commit_from_version(version)
+
+    apply_changes(repo, version, '', 'manifest.json', delete=True)
+
+    changes = repo.get_deltas(
+        commit=version.git_hash,
+        parent=original_version.git_hash)
+
+    assert changes[0]['mode'] == 'D'
+
+
+@pytest.mark.django_db
+def test_get_deltas_unmodified_file_by_default_not_rendered():
+    addon = addon_factory(file_kw={'filename': 'webextension_no_id.xpi'})
+
+    original_version = addon.current_version
+
+    AddonGitRepository.extract_and_commit_from_version(original_version)
+
+    version = version_factory(
+        addon=addon, file_kw={'filename': 'webextension_no_id.xpi'})
+
+    repo = AddonGitRepository.extract_and_commit_from_version(version)
+
+    changes = repo.get_deltas(
+        commit=version.git_hash,
+        parent=original_version.git_hash)
+
+    assert not changes

--- a/src/olympia/reviewers/serializers.py
+++ b/src/olympia/reviewers/serializers.py
@@ -309,7 +309,7 @@ class FileEntriesDiffSerializer(FileEntriesSerializer):
         # Initial commits have both set to the same version
         parent = parent if parent != commit else None
 
-        diff = self.repo.get_diff(
+        deltas = self.repo.get_deltas(
             commit=commit,
             parent=parent,
             pathspec=None)
@@ -320,9 +320,9 @@ class FileEntriesDiffSerializer(FileEntriesSerializer):
         for path, value in entries.items():
             entries[path].setdefault('status', '')
 
-        # Now let's overwrite that with data from the actual patch
-        for patch in diff:
-            path = patch['path']
+        # Now let's overwrite that with data from the actual delta
+        for delta in deltas:
+            path = delta['path']
 
             path_depth = path.count(os.sep)
             path_deleted = False
@@ -346,7 +346,7 @@ class FileEntriesDiffSerializer(FileEntriesSerializer):
                 }
 
             # Now we can set the git-status.
-            entries[path]['status'] = patch['mode']
+            entries[path]['status'] = delta['mode']
 
             parent_path = os.path.dirname(path)
             if (


### PR DESCRIPTION
Fixes #13291

This change will use a different pygit2 API to iterate through the
metadata of a diff without accessing it's textual representation.

That'll speed up the generation of `entries` for the compare views.

There might still be some significant time spent generating the diffs
and `entries` as we do fetch some data to figure out correct mimetype
but we should see at least some speedup (according to pygit2 issue
tracker it's significant, unsure how it compares to other places we
spend lots of time on)