### PR TITLE
Make scanner result admin template generic

### DIFF
--- a/src/olympia/scanners/admin.py
+++ b/src/olympia/scanners/admin.py
@@ -268,12 +268,15 @@ class AbstractScannerResultAdminMixin(admin.ModelAdmin):
     formatted_results.short_description = 'Results'
 
     def formatted_matched_rules(self, obj):
+        rule_model = self.model.matched_rules.rel.model
+        info = rule_model._meta.app_label, rule_model._meta.model_name
+
         return format_html(
             ', '.join(
                 [
                     '<a href="{}">{}</a>'.format(
                         reverse(
-                            'admin:scanners_scannerrule_change', args=[rule.pk]
+                            'admin:%s_%s_change' % info, args=[rule.pk]
                         ),
                         rule.name,
                     )
@@ -286,10 +289,13 @@ class AbstractScannerResultAdminMixin(admin.ModelAdmin):
 
     def formatted_matched_rules_with_files(self, obj):
         files_by_matched_rules = obj.get_files_by_matched_rules()
+        rule_model = self.model.matched_rules.rel.model
+        info = rule_model._meta.app_label, rule_model._meta.model_name
         return render_to_string(
             'admin/scanners/scannerresult/'
             'formatted_matched_rules_with_files.html',
             {
+                'rule_change_urlname': 'admin:%s_%s_change' % info,
                 'external_site_url': settings.EXTERNAL_SITE_URL,
                 'file_id': (obj.version.all_files[0].id if obj.version else
                             None),
@@ -430,8 +436,21 @@ class AbstractScannerResultAdminMixin(admin.ModelAdmin):
         return custom_urls + urls
 
     def result_actions(self, obj):
+        info = self.model._meta.app_label, self.model._meta.model_name
         return render_to_string(
-            'admin/scannerresult_actions.html', {'obj': obj}
+            'admin/scannerresult_actions.html', {
+                'handlefalsepositive_urlname': (
+                    'admin:%s_%s_handlefalsepositive' % info
+                ),
+                'handletruepositive_urlname': (
+                    'admin:%s_%s_handletruepositive' % info
+                ),
+                'handleinconclusive_urlname': (
+                    'admin:%s_%s_handleinconclusive' % info
+                ),
+                'handlerevert_urlname': 'admin:%s_%s_handlerevert' % info,
+                'obj': obj,
+            }
         )
 
     result_actions.short_description = 'Actions'

--- a/src/olympia/scanners/models.py
+++ b/src/olympia/scanners/models.py
@@ -107,7 +107,7 @@ class AbstractScannerResult(ModelBase):
         res = defaultdict(list)
         if self.scanner is YARA:
             for item in self.results:
-                res[item['rule']].append(item['meta']['filename'])
+                res[item['rule']].append(item['meta'].get('filename', '???'))
         elif self.scanner is CUSTOMS:
             scanMap = self.results.get('scanMap', {})
             for filename, rules in scanMap.items():

--- a/src/olympia/scanners/templates/admin/scannerresult_actions.html
+++ b/src/olympia/scanners/templates/admin/scannerresult_actions.html
@@ -1,27 +1,28 @@
 {% load i18n admin_urls %}
+{# This template can be used for both scanner results and scanner query results. Keep it generic. #}
 
 {% if obj.can_report_feedback %}
   <button
     class="button report-false-positive-button"
-    formaction="{% url 'admin:scanners_scannerresult_handlefalsepositive' obj.pk %}"
+    formaction="{% url handlefalsepositive_urlname obj.pk %}"
     formtarget="_blank"
   >
     {% trans 'Report as false positive' %}
   </button>
   &nbsp;
-  <button class="button default" formaction="{% url 'admin:scanners_scannerresult_handletruepositive' obj.pk %}">
+  <button class="button default" formaction="{% url handletruepositive_urlname obj.pk %}">
     {% trans 'Mark as true positive' %}
   </button>
   &nbsp;
   <button
     class="button secondary"
-    formaction="{% url 'admin:scanners_scannerresult_handleinconclusive' obj.pk %}"
+    formaction="{% url handleinconclusive_urlname obj.pk %}"
     title="{% trans 'Useful when the scanner result is a true positive but the add-on is not malicious' %}"
   >
     {% trans 'Mark as inconclusive' %}
   </button>
 {% elif obj.can_revert_feedback %}
-  <button class="button default" formaction="{% url 'admin:scanners_scannerresult_handlerevert' obj.pk %}">
+  <button class="button default" formaction="{% url handlerevert_urlname obj.pk %}">
     {% trans 'Revert report' %}
   </button>
 {% endif %}

--- a/src/olympia/scanners/templates/admin/scanners/scannerresult/formatted_matched_rules_with_files.html
+++ b/src/olympia/scanners/templates/admin/scanners/scannerresult/formatted_matched_rules_with_files.html
@@ -1,4 +1,5 @@
 {% load admin_urls %}
+{# This template can be used for both scanner results and scanner query results. Keep it generic. #}
 
 <table>
   <thead>
@@ -9,7 +10,7 @@
   </thead>
   {% for rule in matched_rules %}
   <tr>
-    <td><a href="{% url 'admin:scanners_scannerrule_change' rule.pk %}">{{ rule.name }}</a></td>
+    <td><a href="{% url rule_change_urlname rule.pk %}">{{ rule.name }}</a></td>
     <td>
       {% for file in rule.files %}
         {% if file_id %}

--- a/src/olympia/scanners/tests/test_models.py
+++ b/src/olympia/scanners/tests/test_models.py
@@ -238,6 +238,15 @@ class TestScannerResultMixin:
             rule2: [file2],
         }
 
+    def test_get_files_by_matched_rules_no_file_somehow(self):
+        result = self.create_yara_result()
+        rule = self.rule_model.objects.create(name='foobar', scanner=YARA)
+        result.add_yara_result(rule=rule.name)
+        result.save()
+        assert result.get_files_by_matched_rules() == {
+            'foobar': ['???'],
+        }
+
     def test_get_files_by_matched_rules_with_no_customs_results(self):
         result = self.create_customs_result()
         result.results = {'matchedRules': []}


### PR DESCRIPTION
This allows those templates to be re-used for scanners query results admin

Fixes #13372