### PR TITLE
Add test to verify comparing with deleted version works.

### DIFF
--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -6872,6 +6872,9 @@ class TestReviewAddonVersionCompareViewSet(
 
         user = UserProfile.objects.create(username='reviewer')
         self.grant_permission(user, 'Addons:Review')
+
+        # A reviewer needs the `Addons:ViewDeleted` permission to view and
+        # compare deleted versions
         self.grant_permission(user, 'Addons:ViewDeleted')
 
         self.client.login_api(user)


### PR DESCRIPTION
Fixes #12726

The issue from #12726 is kinda a "worksforme" - you need the `Addons:ViewDeleted` permission to do such comparisons.

Maybe that'll make #12725 clearer too but I'll add another test to verify it's working as expected too.

pinging @bobsilverberg and @wagnerand to make sure that's the expected behavior and works for everyone.