### PR TITLE
Don't allow modifications of a Scanner Query Rule if it's not NEW

### DIFF
--- a/src/olympia/scanners/admin.py
+++ b/src/olympia/scanners/admin.py
@@ -543,6 +543,11 @@ class ScannerQueryRuleAdmin(AbstractScannerRuleAdminMixin, admin.ModelAdmin):
         'created', 'modified', 'matched_results_link', 'state_with_actions',
     )
 
+    def has_change_permission(self, request, obj=None):
+        if obj and obj.state != NEW:
+            return False
+        return super().has_change_permission(request, obj=obj)
+
     def handle_run(self, request, pk, *args, **kwargs):
         is_admin = acl.action_allowed(
             request, amo.permissions.ADMIN_SCANNERS_QUERY)

--- a/src/olympia/scanners/tests/test_admin.py
+++ b/src/olympia/scanners/tests/test_admin.py
@@ -1032,6 +1032,24 @@ class TestScannerQueryRuleAdmin(AMOPaths, TestCase):
         )
         assert response.status_code == 404
 
+    def test_cannot_change_non_new_query_rule(self):
+        rule = ScannerQueryRule.objects.create(name='bar', scanner=YARA)
+        url = reverse(
+            'admin:scanners_scannerqueryrule_change', args=(rule.pk,))
+        response = self.client.get(url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+
+        # NEW query rule, it can be modified.
+        assert not doc('.field-formatted_definition .readonly')
+
+        # RUNNING query rule, it can not be modified
+        rule.update(state=RUNNING)
+        response = self.client.get(url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        assert doc('.field-formatted_definition .readonly')
+
 
 class TestScannerQueryResultAdmin(TestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes #13271