### PR TITLE
Add admin buttons to allow/deny resubmission in the reviewer tools

### DIFF
--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -367,6 +367,7 @@ v4 API changelog
 * 2019-11-14: removed ``is_source_public`` property from addons API https://github.com/mozilla/addons-server/issues/12514
 * 2019-12-05: removed /addons/featured endpoint from v4+ and featured support from other addon api endpoints.  https://github.com/mozilla/addons-server/issues/12937
 * 2020-01-23: added /scanner/results (internal API endpoint).
+* 2020-02-06: added /reviewers/addon/(int:addon_id)/allow_resubmission/ and /reviewers/addon/(int:addon_id)/deny_resubmission/. https://github.com/mozilla/addons-server/issues/13409
 
 .. _`#11380`: https://github.com/mozilla/addons-server/issues/11380/
 .. _`#11379`: https://github.com/mozilla/addons-server/issues/11379/

--- a/docs/topics/api/reviewers.rst
+++ b/docs/topics/api/reviewers.rst
@@ -84,6 +84,37 @@ add-on.
     :>json boolean needs_admin_code_review: Boolean indicating whether the add-on needs its code to be reviewed by an admin or not.
     :>json boolean needs_admin_content_review: Boolean indicating whether the add-on needs its content to be reviewed by an admin or not.
 
+------------------
+Allow resubmission
+------------------
+
+This endpoint allows you to allow resubmission of an add-on that was previously
+denied.
+
+    .. note::
+        Requires authentication and the current user to have ``Reviews:Admin``
+        permission.
+
+.. http:post:: /api/v4/reviewers/addon/(int:addon_id)/allow_resubmission/
+
+    :statuscode 202: Success.
+    :statuscode 409: The add-on GUID was not previously denied.
+
+-----------------
+Deny resubmission
+-----------------
+
+This endpoint allows you to deny resubmission of an add-on that was not already
+denied.
+
+    .. note::
+        Requires authentication and the current user to have ``Reviews:Admin``
+        permission.
+
+.. http:post:: /api/v4/reviewers/addon/(int:addon_id)/deny_resubmission/
+
+    :statuscode 202: Success.
+    :statuscode 409: The add-on GUID was already denied.
 
 -------------
 List Versions

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -10,7 +10,7 @@ from urllib.parse import urlsplit
 
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
-from django.db import IntegrityError, models, transaction
+from django.db import models, transaction
 from django.db.models import F, Max, Q, signals as dbsignals
 from django.dispatch import receiver
 from django.utils import translation
@@ -516,6 +516,25 @@ class Addon(OnChangeMixin, ModelBase):
         # in a state that allows it to be public.
         self.update_status()
 
+    def deny_resubmission(self):
+        if self.is_guid_denied():
+            raise RuntimeError("GUID already denied")
+
+        activity.log_create(amo.LOG.DENIED_GUID_ADDED, self)
+        log.info('Deny resubmission for addon "%s"', self.slug)
+        DeniedGuid.objects.create(guid=self.guid)
+
+    def allow_resubmission(self):
+        if not self.is_guid_denied():
+            raise RuntimeError("GUID not denied")
+
+        activity.log_create(amo.LOG.DENIED_GUID_DELETED, self)
+        log.info('Allow resubmission for addon "%s"', self.slug)
+        DeniedGuid.objects.filter(guid=self.guid).delete()
+
+    def is_guid_denied(self):
+        return DeniedGuid.objects.filter(guid=self.guid).exists()
+
     def is_soft_deleteable(self):
         return self.status or Version.unfiltered.filter(addon=self).exists()
 
@@ -597,8 +616,8 @@ class Addon(OnChangeMixin, ModelBase):
             if self.status == amo.STATUS_DISABLED:
                 try:
                     with transaction.atomic():
-                        DeniedGuid.objects.create(guid=self.guid)
-                except IntegrityError:
+                        self.deny_resubmission()
+                except RuntimeError:
                     # If the guid is already in DeniedGuids, we are good.
                     pass
 

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -517,7 +517,7 @@ class Addon(OnChangeMixin, ModelBase):
         self.update_status()
 
     def deny_resubmission(self):
-        if self.is_guid_denied():
+        if self.is_guid_denied:
             raise RuntimeError("GUID already denied")
 
         activity.log_create(amo.LOG.DENIED_GUID_ADDED, self)
@@ -525,13 +525,14 @@ class Addon(OnChangeMixin, ModelBase):
         DeniedGuid.objects.create(guid=self.guid)
 
     def allow_resubmission(self):
-        if not self.is_guid_denied():
-            raise RuntimeError("GUID not denied")
+        if not self.is_guid_denied:
+            raise RuntimeError("GUID already denied")
 
         activity.log_create(amo.LOG.DENIED_GUID_DELETED, self)
         log.info('Allow resubmission for addon "%s"', self.slug)
         DeniedGuid.objects.filter(guid=self.guid).delete()
 
+    @property
     def is_guid_denied(self):
         return DeniedGuid.objects.filter(guid=self.guid).exists()
 

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -2661,9 +2661,9 @@ class TestAddonAndDeniedGuid(TestCase):
 
     def test_is_guid_denied(self):
         addon = addon_factory()
-        assert not addon.is_guid_denied()
+        assert not addon.is_guid_denied
         DeniedGuid.objects.create(guid=addon.guid)
-        assert addon.is_guid_denied()
+        assert addon.is_guid_denied
 
     def test_deny_resubmission(self):
         addon = addon_factory()

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -2649,3 +2649,46 @@ class TestMigratedLWTModel(TestCase):
     def test_getpersonas_id_lookup(self):
         match = MigratedLWT.objects.get(getpersonas_id=999)
         assert match.static_theme == self.static_theme
+
+
+class TestAddonAndDeniedGuid(TestCase):
+    def setUp(self):
+        # This is needed for the `ActivityLog`.
+        core.set_user(UserProfile.objects.create(pk=999))
+
+    def get_last_activity_log(self):
+        return ActivityLog.objects.order_by('id').last()
+
+    def test_is_guid_denied(self):
+        addon = addon_factory()
+        assert not addon.is_guid_denied()
+        DeniedGuid.objects.create(guid=addon.guid)
+        assert addon.is_guid_denied()
+
+    def test_deny_resubmission(self):
+        addon = addon_factory()
+        assert not DeniedGuid.objects.filter(guid=addon.guid).exists()
+        addon.deny_resubmission()
+        assert DeniedGuid.objects.filter(guid=addon.guid).exists()
+        last_activity = self.get_last_activity_log()
+        assert last_activity.action == amo.LOG.DENIED_GUID_ADDED.id
+
+    def test_deny_already_denied_guid(self):
+        addon = addon_factory()
+        addon.deny_resubmission()
+        with pytest.raises(RuntimeError):
+            addon.deny_resubmission()
+
+    def test_allow_resubmission(self):
+        addon = addon_factory()
+        addon.deny_resubmission()
+        assert DeniedGuid.objects.filter(guid=addon.guid).exists()
+        addon.allow_resubmission()
+        assert not DeniedGuid.objects.filter(guid=addon.guid).exists()
+        last_activity = self.get_last_activity_log()
+        assert last_activity.action == amo.LOG.DENIED_GUID_DELETED.id
+
+    def test_allow_resubmission_with_non_denied_guid(self):
+        addon = addon_factory()
+        with pytest.raises(RuntimeError):
+            addon.allow_resubmission()

--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -682,6 +682,20 @@ class BLOCKLIST_BLOCK_DELETED(_LOG):
     format = _('Block for {0} deleted from Blocklist.')
     short = _('Block deleted')
 
+class DENIED_GUID_ADDED(_LOG):
+    id = 159
+    keep = True
+    action_class = 'add'
+    hide_developer = True
+    format = _('GUID for {addon} added to DeniedGuid.')
+
+class DENIED_GUID_DELETED(_LOG):
+    id = 160
+    keep = True
+    action_class = 'delete'
+    hide_developer = True
+    format = _('GUID for {addon} removed from DeniedGuid.')
+
 
 LOGS = [x for x in vars().values()
         if isclass(x) and issubclass(x, _LOG) and x != _LOG]

--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -682,12 +682,14 @@ class BLOCKLIST_BLOCK_DELETED(_LOG):
     format = _('Block for {0} deleted from Blocklist.')
     short = _('Block deleted')
 
+
 class DENIED_GUID_ADDED(_LOG):
     id = 159
     keep = True
     action_class = 'add'
     hide_developer = True
     format = _('GUID for {addon} added to DeniedGuid.')
+
 
 class DENIED_GUID_DELETED(_LOG):
     id = 160

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -205,26 +205,12 @@
 </form>
 {% endif %}
 
+{% if not addon.is_deleted or is_admin %}
 <form class="more-actions" id="extra-review-actions" data-api-token="{{ api_token }}">
   <p><strong>{{ _('More Actions') }}</strong></p>
   <div class="more-actions-inner">
-  {% if addon.is_deleted %}
-    {% if is_admin %}
-    <ul class="admin_only">
-      <li {% if not addon.is_guid_denied %}class="hidden"{% endif %}>
-        <button data-api-url="{{ drf_url('reviewers-addon-allow-resubmission', addon.pk) }}"
-                data-toggle-button-selector="#deny_resubmission"
-                id="allow_resubmission" type="button">{{ _('Allow resubmission') }}</button>
-      </li>
-      <li {% if addon.is_guid_denied %}class="hidden"{% endif %}>
-        <button data-api-url="{{ drf_url('reviewers-addon-deny-resubmission', addon.pk) }}"
-                data-toggle-button-selector="#allow_resubmission"
-                id="deny_resubmission" type="button">{{ _('Deny resubmission') }}</button>
-      </li>
-    </ul>
-    {% endif %}
-  {% else %}
     <ul>
+      {% if not addon.is_deleted %}
       <li>
         <input type="checkbox" id="notify_new_listed_versions"
                data-api-url-subscribe="{{ drf_url('reviewers-addon-subscribe', addon.pk) }}"
@@ -232,9 +218,23 @@
                {% if subscribed %}checked="checked"{% endif %} autocomplete="off" />
           <label for="notify_new_listed_versions">{{ _('Notify me about new listed versions') }}</label>
       </li>
+      {% endif %}
     </ul>
+
     {% if is_admin %}
     <ul class="admin_only">
+      {% if addon.is_deleted %}
+        <li {% if not addon.is_guid_denied %}class="hidden"{% endif %}>
+          <button data-api-url="{{ drf_url('reviewers-addon-allow-resubmission', addon.pk) }}"
+                  data-toggle-button-selector="#deny_resubmission"
+                  id="allow_resubmission" type="button">{{ _('Allow resubmission') }}</button>
+        </li>
+        <li {% if addon.is_guid_denied %}class="hidden"{% endif %}>
+          <button data-api-url="{{ drf_url('reviewers-addon-deny-resubmission', addon.pk) }}"
+                  data-toggle-button-selector="#allow_resubmission"
+                  id="deny_resubmission" type="button">{{ _('Deny resubmission') }}</button>
+        </li>
+      {% else %}
         <li {% if addon.status == amo.STATUS_DISABLED %}class="hidden"{% endif %}>
           <button data-api-url="{{ drf_url('reviewers-addon-disable', addon.pk) }}"
                   data-toggle-button-selector="#force_enable_addon"
@@ -245,6 +245,7 @@
                   data-toggle-button-selector="#force_disable_addon"
                   id="force_enable_addon" type="button">{{ _('Force-enable add-on') }}</button>
         </li>
+
         {% if not addon.block %}
         <li>
           <a href="{{ url('admin:blocklist_blocksubmission_add') }}?guids={{ addon.guid }}" class="button"
@@ -256,6 +257,7 @@
                   id="edit_addon_block" type="button">{{ _('Update add-on block') }}</a>
         </li>
         {% endif %}
+
         {% if addon.type in (amo.ADDON_EXTENSION, amo.ADDON_LPAPP, amo.ADDON_DICT, amo.ADDON_SEARCH) %}
           <li {% if addon.auto_approval_disabled %}class="hidden"{% endif %}>
             <button data-api-url="{{ drf_url('reviewers-addon-flags', addon.pk) }}"
@@ -282,6 +284,7 @@
             </li>
           {% endif %}
         {% endif %}
+
         {% if addon.pending_info_request %}
           <li>
               <button data-api-url="{{ drf_url('reviewers-addon-flags', addon.pk) }}"
@@ -290,6 +293,7 @@
                       id="clear_pending_info_request" type="button">{{ _('Clear information request') }}</button>
           </li>
         {% endif %}
+
         {% if addon.needs_admin_code_review %}
           <li>
             <button data-api-url="{{ drf_url('reviewers-addon-flags', addon.pk) }}"
@@ -298,6 +302,7 @@
                     id="clear_admin_code_review"  type="button">{{ _('Clear Admin Code Review Flag') }}</button>
           </li>
         {% endif %}
+
         {% if addon.needs_admin_content_review %}
           <li>
             <button data-api-url="{{ drf_url('reviewers-addon-flags', addon.pk) }}"
@@ -306,6 +311,7 @@
                     id="clear_admin_content_review" type="button">{{ _('Clear Admin Content Review Flag') }}</button>
           </li>
         {% endif %}
+
         {% if addon.needs_admin_theme_review %}
           <li>
             <button data-api-url="{{ drf_url('reviewers-addon-flags', addon.pk) }}"
@@ -314,11 +320,12 @@
                     id="clear_admin_theme_review" type="button">{{ _('Clear Admin Static Theme Review Flag') }}</button>
           </li>
         {% endif %}
+      {% endif %}
     </ul>
-    {% endif %}
-  {% endif %}
+    {% endif %} {# /is-admin #}
   </div>
 </form>
+{% endif %}
 
 </div> {# /#primary #}
 

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -205,10 +205,25 @@
 </form>
 {% endif %}
 
-{% if not addon.is_deleted %}
 <form class="more-actions" id="extra-review-actions" data-api-token="{{ api_token }}">
   <p><strong>{{ _('More Actions') }}</strong></p>
   <div class="more-actions-inner">
+  {% if addon.is_deleted %}
+    {% if is_admin %}
+    <ul class="admin_only">
+      <li {% if not addon.is_guid_denied %}class="hidden"{% endif %}>
+        <button data-api-url="{{ drf_url('reviewers-addon-allow-resubmission', addon.pk) }}"
+                data-toggle-button-selector="#deny_resubmission"
+                id="allow_resubmission" type="button">{{ _('Allow resubmission') }}</button>
+      </li>
+      <li {% if addon.is_guid_denied %}class="hidden"{% endif %}>
+        <button data-api-url="{{ drf_url('reviewers-addon-deny-resubmission', addon.pk) }}"
+                data-toggle-button-selector="#allow_resubmission"
+                id="deny_resubmission" type="button">{{ _('Deny resubmission') }}</button>
+      </li>
+    </ul>
+    {% endif %}
+  {% else %}
     <ul>
       <li>
         <input type="checkbox" id="notify_new_listed_versions"
@@ -301,9 +316,9 @@
         {% endif %}
     </ul>
     {% endif %}
+  {% endif %}
   </div>
 </form>
-{% endif %}
 
 </div> {# /#primary #}
 

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -3563,7 +3563,7 @@ class TestReview(ReviewBase):
         elem = doc('#allow_resubmission')[0]
         assert 'hidden' in elem.getparent().attrib.get('class', '')
 
-    def test_resubmission_buttons_are_displayed_for_deleted_addons_and_denied_guid(self):
+    def test_resubmission_buttons_are_displayed_for_deleted_addons_and_denied_guid(self):  # noqa
         self.login_as_admin()
         self.addon.update(status=amo.STATUS_DELETED)
         self.addon.deny_resubmission()

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -938,7 +938,6 @@ def review(request, addon, channel=None):
         versions_flagged_by_scanners=versions_flagged_by_scanners,
         version=version, whiteboard_form=whiteboard_form,
         whiteboard_url=whiteboard_url,
-        is_denied_guid=addon.is_guid_denied()
     )
     return render(request, 'reviewers/review.html', ctx)
 

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -39,7 +39,7 @@ from olympia.accounts.views import API_TOKEN_COOKIE
 from olympia.activity.models import ActivityLog, CommentLog, DraftComment
 from olympia.addons.decorators import addon_view, owner_or_unlisted_reviewer
 from olympia.addons.models import (
-    Addon, AddonApprovalsCounter, AddonReviewerFlags, DeniedGuid, ReusedGUID)
+    Addon, AddonApprovalsCounter, AddonReviewerFlags, ReusedGUID)
 from olympia.amo.decorators import (
     json_view, login_required, permission_required, post_required)
 from olympia.amo.urlresolvers import reverse
@@ -937,8 +937,7 @@ def review(request, addon, channel=None):
         user_changes_log=user_changes_log, user_ratings=user_ratings,
         versions_flagged_by_scanners=versions_flagged_by_scanners,
         version=version, whiteboard_form=whiteboard_form,
-        whiteboard_url=whiteboard_url,
-    )
+        whiteboard_url=whiteboard_url)
     return render(request, 'reviewers/review.html', ctx)
 
 

--- a/static/css/zamboni/reviewers.less
+++ b/static/css/zamboni/reviewers.less
@@ -1143,7 +1143,8 @@ h2.addon {
       margin: 0 0 1em 0;
     }
 
-    #force_disable_addon, #force_enable_addon {
+    #force_disable_addon, #force_enable_addon,
+    #allow_resubmission, #deny_resubmission {
         background-color: #bc2b1a;
     }
 

--- a/static/js/zamboni/reviewers.js
+++ b/static/js/zamboni/reviewers.js
@@ -233,7 +233,14 @@ function initExtraReviewActions() {
     }));
 
     // Toggle-style buttons.
-    $('#force_disable_addon, #force_enable_addon, #disable_auto_approval, #enable_auto_approval').click(_pd(function() {
+    $([
+        '#force_disable_addon',
+        '#force_enable_addon',
+        '#disable_auto_approval',
+        '#enable_auto_approval',
+        '#allow_resubmission',
+        '#deny_resubmission'
+    ].join(',')).click(_pd(function() {
         var $button = $(this).prop('disabled', true);  // Prevent double-send.
         var $other_button = $($button.data('toggle-button-selector'));
         var apiUrl = $button.data('api-url');


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/13409

---

I changed the template so that admins always see the "more actions" box at the bottom of the page.
