### PR TITLE
Hide disabled files when delete an add-on

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       - ./site-static:/srv/site-static
       - ./storage/shared_storage/uploads:/srv/user-media
       - ./storage/files:/srv/user-media/addons
+      - ./storage/guarded-addons:/srv/user-media/guarded-addons
     ports:
       - "80:80"
 

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -628,10 +628,11 @@ class Addon(OnChangeMixin, ModelBase):
             self._ratings.all().delete()
             # We avoid triggering signals for Version & File on purpose to
             # avoid extra work. Files will be moved to the correct storage
-            # location with hide_disabled_files cron later.
+            # location with hide_disabled_files task or hide_disabled_files
+            # cron as a fallback.
             File.objects.filter(version__addon=self).update(
                 status=amo.STATUS_DISABLED)
-            file_tasks.hide_disabled_files.delay(version__addon=self.id)
+            file_tasks.hide_disabled_files.delay(addon_id=self.id)
 
             self.versions.all().update(deleted=True)
             # The last parameter is needed to automagically create an AddonLog.

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -527,6 +527,13 @@ class TestAddonModels(TestCase):
         dpf_vesions_mock.assert_called_with(
             sender=None, instance=version_preview)
 
+    @patch('olympia.files.tasks.hide_disabled_files')
+    def test_delete_hides_files(self, hide_disabled_files_mock):
+        addon = addon_factory()
+        addon.delete()
+        hide_disabled_files_mock.delay.assert_called_with(
+            version__addon=addon.id)
+
     def _delete_url(self):
         """Test deleting addon has URL in the email."""
         a = Addon.objects.get(pk=4594)

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -532,7 +532,7 @@ class TestAddonModels(TestCase):
         addon = addon_factory()
         addon.delete()
         hide_disabled_files_mock.delay.assert_called_with(
-            version__addon=addon.id)
+            addon_id=addon.id)
 
     def _delete_url(self):
         """Test deleting addon has URL in the email."""

--- a/src/olympia/files/tasks.py
+++ b/src/olympia/files/tasks.py
@@ -90,6 +90,6 @@ def repack_fileupload(results, upload_pk):
 
 @task
 @use_primary_db
-def hide_disabled_files(**kw):
-    for file_ in File.objects.filter(**kw):
+def hide_disabled_files(addon_id):
+    for file_ in File.objects.filter(version__addon=addon_id):
         file_.hide_disabled_file()

--- a/src/olympia/files/tasks.py
+++ b/src/olympia/files/tasks.py
@@ -86,3 +86,10 @@ def repack_fileupload(results, upload_pk):
     else:
         log.info('Not repackaging upload %s, it is not a xpi file.', upload_pk)
     return results
+
+
+@task
+@use_primary_db
+def hide_disabled_files(**kw):
+    for file_ in File.objects.filter(**kw):
+        file_.hide_disabled_file()

--- a/src/olympia/files/tests/test_tasks.py
+++ b/src/olympia/files/tests/test_tasks.py
@@ -102,7 +102,7 @@ class TestHideDisabledFile(TestCase):
 
     @mock.patch('olympia.files.models.File.move_file')
     def test_hide_disabled_files(self, move_file_mock):
-        hide_disabled_files.delay(version__addon=self.addon1.id)
+        hide_disabled_files.delay(addon_id=self.addon1.id)
         move_file_mock.assert_called_once_with(
             self.file1.file_path,
             self.file1.guarded_file_path,

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1137,7 +1137,6 @@ CELERY_TASK_ROUTES = {
     'olympia.devhub.tasks.validate_file': {'queue': 'devhub'},
     'olympia.devhub.tasks.validate_upload': {'queue': 'devhub'},
     'olympia.files.tasks.repack_fileupload': {'queue': 'devhub'},
-    'olympia.files.tasks.hide_disabled_files': {'queue': 'devhub'},
     'olympia.scanners.tasks.run_customs': {'queue': 'devhub'},
     'olympia.scanners.tasks.run_wat': {'queue': 'devhub'},
     'olympia.scanners.tasks.run_yara': {'queue': 'devhub'},
@@ -1174,6 +1173,7 @@ CELERY_TASK_ROUTES = {
     },
     'olympia.addons.tasks.version_changed': {'queue': 'addons'},
     'olympia.files.tasks.extract_webext_permissions': {'queue': 'addons'},
+    'olympia.files.tasks.hide_disabled_files': {'queue': 'addons'},
     'olympia.versions.tasks.delete_preview_files': {'queue': 'addons'},
     'olympia.versions.tasks.extract_version_to_git': {'queue': 'addons'},
     'olympia.versions.tasks.extract_version_source_to_git': {

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1137,6 +1137,7 @@ CELERY_TASK_ROUTES = {
     'olympia.devhub.tasks.validate_file': {'queue': 'devhub'},
     'olympia.devhub.tasks.validate_upload': {'queue': 'devhub'},
     'olympia.files.tasks.repack_fileupload': {'queue': 'devhub'},
+    'olympia.files.tasks.hide_disabled_files': {'queue': 'devhub'},
     'olympia.scanners.tasks.run_customs': {'queue': 'devhub'},
     'olympia.scanners.tasks.run_wat': {'queue': 'devhub'},
     'olympia.scanners.tasks.run_yara': {'queue': 'devhub'},


### PR DESCRIPTION
Fixes #13433.

I added `file.tasks.hide_disabled_file` and let `addon.delete` fire up that task. 

As to force-disabled and user-disabled add-ons, I found that we disabled the add-on by [calling `addon.update`](https://github.com/mozilla/addons-server/blob/8785d836caecf8df192e5ccb3141dd3eb38b538b/src/olympia/addons/models.py#L507) which [triggers watcher to hide the files](https://github.com/mozilla/addons-server/blob/8785d836caecf8df192e5ccb3141dd3eb38b538b/src/olympia/addons/models.py#L1584). So I guess we do not need changes for these two cases (?).

I also updated the `docker-compose.yml` for mounting `guarded-addons` folder, and created a PR https://github.com/mozilla/addons-nginx/pull/16