### PR TITLE
Display matching filenames & authors in scanner query results changelist

### DIFF
--- a/src/olympia/scanners/admin.py
+++ b/src/olympia/scanners/admin.py
@@ -6,7 +6,7 @@ from django.db.models import FieldDoesNotExist, Prefetch
 from django.http import Http404
 from django.shortcuts import redirect
 from django.template.loader import render_to_string
-from django.utils.html import format_html
+from django.utils.html import format_html, format_html_join
 from django.utils.http import urlencode, is_safe_url
 from django.utils.translation import ugettext, gettext_lazy as _
 
@@ -180,6 +180,7 @@ class AbstractScannerResultAdminMixin(admin.ModelAdmin):
     list_display = (
         'id',
         'formatted_addon',
+        'authors',
         'guid',
         'channel',
         'scanner',
@@ -202,6 +203,7 @@ class AbstractScannerResultAdminMixin(admin.ModelAdmin):
         'id',
         'upload',
         'formatted_addon',
+        'authors',
         'guid',
         'channel',
         'scanner',
@@ -230,6 +232,8 @@ class AbstractScannerResultAdminMixin(admin.ModelAdmin):
                 # including the deleted ones.
                 queryset=Addon.unfiltered.all().only_translations(),
             ),
+            'version__files',
+            'version__addon__authors',
             'matched_rules',
         )
 
@@ -292,6 +296,15 @@ class AbstractScannerResultAdminMixin(admin.ModelAdmin):
 
     formatted_addon.short_description = 'Add-on'
 
+    def authors(self, obj):
+        contents = format_html_join(
+            '', '<li><a href="{}">{}</a></li>',
+            ((urljoin(
+                settings.EXTERNAL_SITE_URL,
+                reverse('admin:users_userprofile_change', args=(author.pk,))),
+             author.email) for author in obj.version.addon.authors.all()))
+        return format_html('<ul>{}</ul>', contents)
+
     def guid(self, obj):
         if obj.version:
             return obj.version.addon.guid
@@ -332,13 +345,13 @@ class AbstractScannerResultAdminMixin(admin.ModelAdmin):
 
     formatted_matched_rules.short_description = 'Matched rules'
 
-    def formatted_matched_rules_with_files(self, obj):
+    def formatted_matched_rules_with_files(
+            self, obj, template_name='formatted_matched_rules_with_files'):
         files_by_matched_rules = obj.get_files_by_matched_rules()
         rule_model = self.model.matched_rules.rel.model
         info = rule_model._meta.app_label, rule_model._meta.model_name
         return render_to_string(
-            'admin/scanners/scannerresult/'
-            'formatted_matched_rules_with_files.html',
+            f'admin/scanners/scannerresult/{template_name}.html',
             {
                 'rule_change_urlname': 'admin:%s_%s_change' % info,
                 'external_site_url': settings.EXTERNAL_SITE_URL,
@@ -562,6 +575,17 @@ class ScannerResultAdmin(AbstractScannerResultAdminMixin, admin.ModelAdmin):
 class ScannerQueryResultAdmin(
         AbstractScannerResultAdminMixin, admin.ModelAdmin):
     raw_id_fields = ('version',)
+    list_display = (
+        'id',
+        'formatted_addon',
+        'authors',
+        'guid',
+        'channel',
+        'scanner',
+        'formatted_matched_rules',
+        'matching_filenames',
+        'created',
+    )
     list_filter = (
         ('matched_rules', ScannerRuleListFilter),
         ('version__channel', VersionChannelFilter),
@@ -570,6 +594,10 @@ class ScannerQueryResultAdmin(
         ('version__files__status', FileStatusFiler),
         ('version__files__is_signed', FileIsSigned),
     )
+
+    def matching_filenames(self, obj):
+        return self.formatted_matched_rules_with_files(
+            obj, template_name='formatted_matching_files')
 
     def has_actions_permission(self, request):
         return acl.action_allowed(

--- a/src/olympia/scanners/admin.py
+++ b/src/olympia/scanners/admin.py
@@ -297,6 +297,8 @@ class AbstractScannerResultAdminMixin(admin.ModelAdmin):
     formatted_addon.short_description = 'Add-on'
 
     def authors(self, obj):
+        if not obj.version:
+            return '-'
         contents = format_html_join(
             '', '<li><a href="{}">{}</a></li>',
             ((urljoin(

--- a/src/olympia/scanners/templates/admin/scanners/scannerresult/formatted_matching_files.html
+++ b/src/olympia/scanners/templates/admin/scanners/scannerresult/formatted_matching_files.html
@@ -1,0 +1,16 @@
+{% load admin_urls %}
+{# This template can be used for both scanner results and scanner query results. Keep it generic. #}
+
+<ul>
+  {% for rule in matched_rules %}
+    {% for file in rule.files %}
+      <li>
+        {% if file_id %}
+          <a href="{{ external_site_url }}{% url 'files.list' file_id 'file' file %}">{{ file }}</a>
+        {% else %}
+          {{ file }}
+        {% endif %}
+      </li>
+    {% endfor %}
+  {% endfor %}
+</ul>

--- a/src/olympia/scanners/tests/test_admin.py
+++ b/src/olympia/scanners/tests/test_admin.py
@@ -242,14 +242,16 @@ class TestScannerResultAdmin(TestCase):
         )
         deleted_addon.delete()
 
-        with self.assertNumQueries(11):
-            # 10 queries:
+        with self.assertNumQueries(13):
+            # 13 queries:
             # - 2 transaction savepoints because of tests
-            # - 2 user and groups
+            # - 2 request user and groups
             # - 2 COUNT(*) on scanners results for pagination and total display
             # - 1 get all available rules for filtering
             # - 1 scanners results and versions in one query
             # - 1 all add-ons in one query
+            # - 1 all files in one query
+            # - 1 all authors in one query
             # - 1 all add-ons translations in one query
             # - 1 all scanner rules in one query
             response = self.client.get(

--- a/static/css/admin/scannerresult.css
+++ b/static/css/admin/scannerresult.css
@@ -10,3 +10,21 @@
 .field-result_actions .button.default {
   float: none;
 }
+
+.field-matching_filenames ul, .field-authors ul {
+    display: block;
+    margin: 0;
+    padding: 0;
+}
+
+.field-matching_filenames li, .field-authors li {
+    display: block;
+    max-width: 36em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.field-authors li {
+    max-width: 24em;
+}


### PR DESCRIPTION
Also stop displaying action buttons, we don't want them in the query results
at this time.

Fixes #13206