### PR TITLE
Add google-cloud-bigquery library and setting to allow auth.

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -398,3 +398,6 @@ yara-python==3.11.0 \
 zipp==3.0.0 \
     --hash=sha256:12248a63bbdf7548f89cb4c7cda4681e537031eda29c02ea29674bc6854460c2 \
     --hash=sha256:7c0f8e91abc0dc07a5068f315c52cb30c66bfbc581e5b50704c8a2f6ebae794a
+google-cloud-bigquery==1.24.0 \
+    --hash=sha256:23c9180e87f6093eb6f2ae880d7f7697fdab991a4616439ad0f95cd37014f0dd \
+    --hash=sha256:7ffcceed8becea20cb4ce4bdf9b924822780416ff1a9d497f9a1238a3f1442b1

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1924,3 +1924,9 @@ YARA_GIT_REPOSITORY = env('YARA_GIT_REPOSITORY', default=None)
 
 # Addon.average_daily_user count that forces dual sign-off for Blocklist Blocks
 DUAL_SIGNOFF_AVERAGE_DAILY_USERS_THRESHOLD = 100_000
+
+# The path to the current google service account configuration. This is
+# being used to query Google BigQuery as part of our stats processing.
+# If this is `None` we're going to use service mocks for testing
+GOOGLE_APPLICATION_CREDENTIALS = env(
+    'GOOGLE_APPLICATION_CREDENTIALS', default=None)


### PR DESCRIPTION
This fixes #13541 in a very basic way to so that we can continue more
in-depth experimentation on -dev and land the following parts (pytest integration, issuing actual queries) soon after

This doesn't contain any actual client code yet, that'll land in a follow-up PR.