### PR TITLE
workaround django admin broken js18n

### DIFF
--- a/src/olympia/amo/tests/test_views.py
+++ b/src/olympia/amo/tests/test_views.py
@@ -3,7 +3,6 @@ import json
 import re
 import sys
 
-from datetime import datetime, timedelta
 from unittest import mock
 from urllib.parse import urlparse
 
@@ -292,26 +291,6 @@ class TestOtherStuff(TestCase):
         assert set_remote_addr_mock.call_count == 2
         assert set_remote_addr_mock.call_args_list[0] == (('1.1.1.1',), {})
         assert set_remote_addr_mock.call_args_list[1] == ((None,), {})
-
-    @pytest.mark.needs_locales_compilation
-    def test_jsi18n(self):
-        """Test that the jsi18n library has an actual catalog of translations
-        rather than just identity functions."""
-
-        response = self.client.get(reverse('jsi18n'))
-        self.assertCloseToNow(response['Expires'],
-                              now=datetime.now() + timedelta(days=365))
-
-        en = self.client.get(reverse('jsi18n')).content.decode('utf-8')
-
-        with self.activate('fr'):
-            fr = self.client.get(reverse('jsi18n')).content.decode('utf-8')
-
-        assert en != fr
-
-        for content in (en, fr):
-            assert 'django.catalog = ' in content
-            assert '/* gettext identity library */' not in content
 
     def test_opensearch(self):
         client = test.Client()

--- a/src/olympia/blocklist/admin.py
+++ b/src/olympia/blocklist/admin.py
@@ -117,6 +117,7 @@ class BlockSubmissionAdmin(admin.ModelAdmin):
         css = {
             'all': ('css/admin/blocklist_blocksubmission.css',)
         }
+        js = ('js/i18n/en-US.js',)
 
     def has_delete_permission(self, request, obj=None):
         # For now, keep all BlockSubmission records.
@@ -507,6 +508,7 @@ class BlockAdmin(BlockAdminAddMixin, admin.ModelAdmin):
         css = {
             'all': ('css/admin/blocklist_block.css',)
         }
+        js = ('js/i18n/en-US.js',)
 
     def addon_guid(self, obj):
         return obj.guid

--- a/src/olympia/blocklist/templates/blocklist/block_submission_add_form.html
+++ b/src/olympia/blocklist/templates/blocklist/block_submission_add_form.html
@@ -2,7 +2,7 @@
 {% load i18n admin_urls static admin_modify %}
 
 {% block extrahead %}{{ block.super }}
-<script type="text/javascript" src="{% url 'admin:jsi18n' %}"></script>
+<script type="text/javascript" src="{% static 'js/i18n/en-US.js' %}"></script>
 {{ media }}
 {% endblock %}
 

--- a/src/olympia/blocklist/templates/blocklist/multi_guid_input.html
+++ b/src/olympia/blocklist/templates/blocklist/multi_guid_input.html
@@ -2,7 +2,7 @@
 {% load i18n admin_urls static admin_modify %}
 
 {% block extrahead %}{{ block.super }}
-<script type="text/javascript" src="{% url 'admin:jsi18n' %}"></script>
+<script type="text/javascript" src="{% static 'js/i18n/en-US.js' %}"></script>
 {{ media }}
 {% endblock %}
 

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -251,7 +251,7 @@ SUPPORTED_NONAPPS_NONLOCALES_REGEX = DRF_API_REGEX
 SUPPORTED_NONAPPS = (
     'about', 'admin', 'apps', 'contribute.json',
     'developer_agreement', 'developers', 'editors',
-    'jsi18n', 'review_guide', 'google1f3e37b7351799a5.html',
+    'review_guide', 'google1f3e37b7351799a5.html',
     'google231a41e803e464e9.html', 'reviewers', 'robots.txt', 'statistics',
     'services', 'static', 'user-media', '__version__',
 )

--- a/src/olympia/urls.py
+++ b/src/olympia/urls.py
@@ -2,8 +2,6 @@ from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
 from django.shortcuts import redirect
-from django.views.decorators.cache import cache_page
-from django.views.i18n import JavaScriptCatalog
 from django.views.static import serve as serve_static
 
 from olympia.amo.urlresolvers import reverse
@@ -77,14 +75,6 @@ urlpatterns = [
 
     # Search
     url(r'^search/', include('olympia.search.urls')),
-
-    # Javascript translations.
-    # Should always be called with a cache-busting querystring.
-    # Still served for the moment, but superseded by a fully static version we
-    # generate at deploy-time through our generate_jsi18n_files command.
-    url(r'^jsi18n\.js$',
-        cache_page(60 * 60 * 24 * 365)(JavaScriptCatalog.as_view()),
-        {'domain': 'djangojs', 'packages': []}, name='jsi18n'),
 
     # API v3+.
     url(r'^api/', include('olympia.api.urls')),


### PR DESCRIPTION
hacky fix to workaround django served urls failing the javascript CSP on dev/stage/prod + rm obsolete dynamic `jsi18n` url.  fixes #13485 