### PR TITLE
Update dependency addons-linter to v1.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": ">= 8.10"
   },
   "dependencies": {
-    "addons-linter": "1.21.0",
+    "addons-linter": "1.22.0",
     "clean-css": "4.2.3",
     "clean-css-cli": "4.3.0",
     "jqmodal": "1.4.2",


### PR DESCRIPTION
* Various dependency updates
* Firefox 74 schema import (mozilla/addons-linter#2955)
* Use webpack-node-externals to avoid bundling node_modules
* support multi-version BCD and ignore versions with flags (mozilla/addons-linter#2944)
* Validate manifest CSP properties in v3 format (mozilla/addons-linter#3053)

pinging @eviljeff on this as ideally I'd like to cherry-pick this into todays tag. The biggest change with an actual user impact is the firefox 74 schema update which should be low risk from what changed.

The release came so late because we had problems with releasing the new package because of some changed travis configs :(