### PR TITLE
Do load add-on translations in code manager APIs (we want the name)

### DIFF
--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -6076,9 +6076,18 @@ class TestReviewAddonVersionViewSetDetail(
         self.grant_permission(user, 'Addons:Review')
         self.client.login_api(user)
 
-        response = self.client.get(self.url + '?file=README.md')
+        with self.assertNumQueries(10):
+            # - 2 savepoints because tests
+            # - 2 user and groups
+            # - 2 add-on and translations
+            # - 1 add-on author check
+            # - 1 version
+            # - 2 file and file validation
+            response = self.client.get(self.url + '?file=README.md&lang=en-US')
         assert response.status_code == 200
         result = json.loads(response.content)
+
+        assert result['addon']['name'] == str(self.addon.name)
 
         assert result['file']['content'] == '# beastify\n'
 
@@ -6299,10 +6308,13 @@ class TestReviewAddonVersionViewSetList(TestCase):
         unlisted_version = version_factory(
             addon=self.addon, channel=amo.RELEASE_CHANNEL_UNLISTED)
 
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(8):
             # - 2 savepoints because of tests
             # - 2 user and groups
             # - 1 add-on
+            # - 1 add-on translations (not needed, could be avoided, but we
+            #     currently re-use the same get_addon_object() implementation
+            #     for other APIs where we do need the add-on name)
             # - 1 versions exists to figure out if add-on is listed
             # - 1 versions
             response = self.client.get(self.url)
@@ -6979,10 +6991,15 @@ class TestReviewAddonVersionCompareViewSet(
             'version_pk': self.version.pk,
             'pk': new_version.pk})
 
-        response = self.client.get(self.url + '?file=README.md')
+        with self.assertNumQueries(12):
+            # FIXME: check queries and see if there is a need to optimize, 12
+            # seems too high.
+            response = self.client.get(self.url + '?file=README.md&lang=en-US')
         assert response.status_code == 200
 
         result = json.loads(response.content)
+
+        assert result['addon']['name'] == str(self.addon.name)
 
         assert result['file']['diff']['path'] == 'README.md'
         assert result['file']['diff']['hunks'][0]['changes'] == [

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -1339,10 +1339,9 @@ class ReviewAddonVersionMixin(object):
 
     def get_addon_object(self):
         if not hasattr(self, 'addon_object'):
-            # We don't need any transforms on the add-on: we'll only need basic
-            # fields for it, not even translations.
+            # We only need translations on the add-on, no other transforms.
             self.addon_object = get_object_or_404(
-                Addon.objects.get_queryset().no_transforms(),
+                Addon.objects.get_queryset().only_translations(),
                 pk=self.kwargs.get('addon_pk'))
         return self.addon_object
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/13665