### PR TITLE
Ignore whitespace changes in AddonGitRepository diff handling

### DIFF
--- a/src/olympia/lib/git.py
+++ b/src/olympia/lib/git.py
@@ -520,7 +520,9 @@ class AddonGitRepository(object):
         """
         diff_cache = getattr(self, '_diff_cache', {})
 
-        flags = pygit2.GIT_DIFF_NORMAL
+        flags = (
+            pygit2.GIT_DIFF_NORMAL | pygit2.GIT_DIFF_IGNORE_WHITESPACE_CHANGE
+        )
 
         if include_unmodifed:
             flags |= pygit2.GIT_DIFF_INCLUDE_UNMODIFIED

--- a/src/olympia/lib/tests/test_git.py
+++ b/src/olympia/lib/tests/test_git.py
@@ -861,6 +861,7 @@ def test_get_diff_newline_new_file():
     # The file has been modified, so as far as git is concerned there should
     # be one change.
     assert len(changes) == 1
+    assert changes[0]['mode'] == 'M'
     assert changes[0]['new_ending_new_line'] is True
     assert changes[0]['old_ending_new_line'] is True
 
@@ -903,6 +904,7 @@ def test_get_diff_eol_changes():
     # The file has been modified, so as far as git is concerned there should
     # be one change.
     assert len(changes) == 1
+    assert changes[0]['mode'] == 'M'
 
     # We are ignoring all whitespace modifications so there is no diff.
     assert not changes[0]['hunks']

--- a/src/olympia/lib/tests/test_git.py
+++ b/src/olympia/lib/tests/test_git.py
@@ -858,11 +858,14 @@ def test_get_diff_newline_new_file():
         commit=version.git_hash,
         parent=parent_version.git_hash)
 
+    # The file has been modified, so as far as git is concerned there should
+    # be one change.
     assert len(changes) == 1
     assert changes[0]['new_ending_new_line'] is True
     assert changes[0]['old_ending_new_line'] is True
 
-    assert len(changes[0]['hunks']) == 0
+    # We are ignoring all whitespace modifications so there is no diff.
+    assert not changes[0]['hunks']
 
 
 @pytest.mark.django_db
@@ -897,8 +900,12 @@ def test_get_diff_eol_changes():
         commit=version.git_hash,
         parent=parent_version.git_hash)
 
+    # The file has been modified, so as far as git is concerned there should
+    # be one change.
     assert len(changes) == 1
-    assert len(changes[0]['hunks']) == 0
+
+    # We are ignoring all whitespace modifications so there is no diff.
+    assert not changes[0]['hunks']
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
(For parity with old file viewer)

Fixes #13662