### PR TITLE
Allow access to review page to most reviewers while restricting actions

### DIFF
--- a/src/olympia/access/acl.py
+++ b/src/olympia/access/acl.py
@@ -151,10 +151,11 @@ def is_reviewer(request, addon):
     return check_addons_reviewer(request)
 
 
-def is_user_any_kind_of_reviewer(user):
+def is_user_any_kind_of_reviewer(user, allow_viewers=False):
     """More lax version of is_reviewer: does not check what kind of reviewer
     the user is, and accepts unlisted reviewers, post reviewers, content
-    reviewers, or people with just revierwer tools view access.
+    reviewers. If allow_viewers is passed and truthy, also allows users with
+    just reviewer tools view access.
 
     Don't use on anything that would alter add-on data.
 

--- a/src/olympia/access/acl.py
+++ b/src/olympia/access/acl.py
@@ -164,7 +164,8 @@ def is_user_any_kind_of_reviewer(user, allow_viewers=False):
     add-on but still need to be restricted to reviewers only.
     """
     allow_access = (
-        action_allowed_user(user, amo.permissions.REVIEWER_TOOLS_VIEW) or
+        (allow_viewers and
+            action_allowed_user(user, amo.permissions.REVIEWER_TOOLS_VIEW)) or
         action_allowed_user(user, amo.permissions.ADDONS_REVIEW) or
         action_allowed_user(user, amo.permissions.ADDONS_REVIEW_UNLISTED) or
         action_allowed_user(user, amo.permissions.ADDONS_CONTENT_REVIEW) or

--- a/src/olympia/access/tests.py
+++ b/src/olympia/access/tests.py
@@ -245,3 +245,14 @@ class TestCheckReviewer(TestCase):
 
         assert check_addons_reviewer(request)
         assert is_reviewer(request, self.addon)
+
+    def test_perm_reviewertools_view(self):
+        self.grant_permission(self.user, 'ReviewerTools:View')
+        request = req_factory_factory('noop', user=self.user)
+        assert is_user_any_kind_of_reviewer(request.user, allow_viewers=True)
+        assert not is_user_any_kind_of_reviewer(request.user)
+        assert not check_unlisted_addons_reviewer(request)
+        assert not check_static_theme_reviewer(request)
+        assert not is_reviewer(request, self.statictheme)
+        assert not check_addons_reviewer(request)
+        assert not is_reviewer(request, self.addon)

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -576,7 +576,8 @@ class TestCase(PatchMixin, InitializeSessionMixin, test.TestCase):
     def change_channel_for_addon(self, addon, listed):
         channel = (amo.RELEASE_CHANNEL_LISTED if listed else
                    amo.RELEASE_CHANNEL_UNLISTED)
-        for version in addon.versions.all():
+        for version in addon.versions(
+                manager='unfiltered_for_relations').all():
             version.update(channel=channel)
 
     def _add_fake_throttling_action(

--- a/src/olympia/api/permissions.py
+++ b/src/olympia/api/permissions.py
@@ -180,7 +180,7 @@ class AllowAnyKindOfReviewer(BasePermission):
     alter add-on data.
 
     Allows access to users with any of those permissions:
-    - ReviewerTools:View
+    - ReviewerTools:View (if request is safe)
     - Addons:Review
     - Addons:ReviewUnlisted
     - Addons:ContentReview
@@ -190,7 +190,9 @@ class AllowAnyKindOfReviewer(BasePermission):
     See also any_reviewer_required() decorator.
     """
     def has_permission(self, request, view):
-        return acl.is_user_any_kind_of_reviewer(request.user)
+        allow_viewers = request.method in SAFE_METHODS
+        return acl.is_user_any_kind_of_reviewer(
+            request.user, allow_viewers=allow_viewers)
 
     def has_object_permission(self, request, view, obj):
         return self.has_permission(request, view)

--- a/src/olympia/reviewers/decorators.py
+++ b/src/olympia/reviewers/decorators.py
@@ -54,7 +54,7 @@ def any_reviewer_required(f):
     dashboard.
 
     Allows access to users with any of those permissions:
-    - ReviewerTools:View
+    - ReviewerTools:View (for GET requests only)
     - Addons:Review
     - Addons:ReviewUnlisted
     - Addons:ContentReview
@@ -64,7 +64,8 @@ def any_reviewer_required(f):
     """
     @functools.wraps(f)
     def wrapper(request, *args, **kw):
-        if acl.is_user_any_kind_of_reviewer(request.user):
+        if acl.is_user_any_kind_of_reviewer(
+                request.user, allow_viewers=(request.method == 'GET')):
             return f(request, *args, **kw)
         raise PermissionDenied
     return wrapper
@@ -76,7 +77,8 @@ def any_reviewer_or_moderator_required(f):
     @functools.wraps(f)
     def wrapper(request, *args, **kw):
         allow_access = (
-            acl.is_user_any_kind_of_reviewer(request.user) or
+            acl.is_user_any_kind_of_reviewer(
+                request.user, allow_viewers=(request.method == 'GET')) or
             acl.action_allowed(request, permissions.RATINGS_MODERATE))
         if allow_access:
             return f(request, *args, **kw)

--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -379,10 +379,14 @@ class ReviewForm(forms.Form):
                 canned_choices.append([action['label'], action_choices])
 
         # Now, add everything not in a group.
-        for r in responses:
-            if not r.sort_group:
-                canned_choices.append([r.response, r.name])
+        for canned_response in responses:
+            if not canned_response.sort_group:
+                canned_choices.append(
+                    [canned_response.response, canned_response.name])
         self.fields['canned_response'].choices = canned_choices
+
+        # Set choices on the action field dynamically to raise an error when
+        # someone tries to use an action they don't have access to.
         self.fields['action'].choices = [
             (k, v['label']) for k, v in self.helper.actions.items()]
 

--- a/src/olympia/reviewers/models.py
+++ b/src/olympia/reviewers/models.py
@@ -408,7 +408,7 @@ def send_notifications(sender=None, instance=None, signal=None, **kw):
         user = subscriber.user
         is_reviewer = (
             user and not user.deleted and user.email and
-            acl.is_user_any_kind_of_reviewer(user))
+            acl.is_user_any_kind_of_reviewer(user, allow_viewers=True))
         if is_reviewer:
             subscriber.send_notification(instance)
 

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -8,14 +8,14 @@
   {{ reviewer_page_title(title=addon.name) }}
 {% endblock %}
 
-{% block bodyclass %}{{ super() }} inverse{{ " content-review" if content_review_only else ""}}{% endblock %}
+{% block bodyclass %}{{ super() }} inverse{{ " content-review" if content_review else ""}}{% endblock %}
 
 {% block content %}
 
 <hgroup>
   <h2 class="addon"{{ addon.name|locale_html }}>
     <img src="{{ addon.get_icon_url(32) }}" class="icon" alt="" />
-    {% if content_review_only %}
+    {% if content_review %}
       {# L10n: "Content Review [add-on name]" #}
       <span>
         {{ _('Content Review {0}')|format_html(addon.name) }}

--- a/src/olympia/reviewers/tests/test_forms.py
+++ b/src/olympia/reviewers/tests/test_forms.py
@@ -1,15 +1,14 @@
 from django.utils.encoding import force_text
 
-from unittest import mock
-
 from olympia import amo
 from olympia.addons.models import Addon, AddonReviewerFlags
 from olympia.amo.tests import (
     TestCase, addon_factory, file_factory, version_factory)
 from olympia.reviewers.forms import ReviewForm
-from olympia.reviewers.models import CannedResponse
+from olympia.reviewers.models import AutoApprovalSummary, CannedResponse
 from olympia.reviewers.utils import ReviewHelper
 from olympia.users.models import UserProfile
+from olympia.versions.models import Version
 
 
 class TestReviewForm(TestCase):
@@ -41,43 +40,58 @@ class TestReviewForm(TestCase):
         return form.helper.get_actions(self.request)
 
     def test_actions_reject(self):
+        self.grant_permission(self.request.user, 'Addons:Review')
         actions = self.set_statuses_and_get_actions(
             addon_status=amo.STATUS_NOMINATED,
-            file_status=amo.STATUS_AWAITING_REVIEW)['reject']['details']
-        assert force_text(actions).startswith('This will reject this version')
+            file_status=amo.STATUS_AWAITING_REVIEW)
+        action = actions['reject']['details']
+        assert force_text(action).startswith('This will reject this version')
 
     def test_actions_addon_status_null(self):
-        # If the add-on is null we only show info, comment and super review.
-        assert len(self.set_statuses_and_get_actions(
-            addon_status=amo.STATUS_NULL, file_status=amo.STATUS_NULL)) == 3
+        # If the add-on is null we only show reply, comment and super review.
+        self.grant_permission(self.request.user, 'Addons:Review')
+        actions = self.set_statuses_and_get_actions(
+            addon_status=amo.STATUS_NULL, file_status=amo.STATUS_NULL)
+        assert list(actions.keys()) == ['reply', 'super', 'comment']
 
     def test_actions_addon_status_deleted(self):
-        # If the add-on is deleted we only show info, comment and super review.
-        assert len(self.set_statuses_and_get_actions(
-            addon_status=amo.STATUS_DELETED, file_status=amo.STATUS_NULL)) == 3
+        # If the add-on is deleted we only show reply, comment and
+        # super review.
+        self.grant_permission(self.request.user, 'Addons:Review')
+        actions = self.set_statuses_and_get_actions(
+            addon_status=amo.STATUS_DELETED, file_status=amo.STATUS_NULL)
+        assert list(actions.keys()) == ['reply', 'super', 'comment']
 
     def test_actions_no_pending_files(self):
-        # If the add-on has no pending files we only show info, comment and
-        # super review.
-        assert len(self.set_statuses_and_get_actions(
+        # If the add-on has no pending files we only show
+        # reject_multiple_versions, reply, comment and super review.
+        self.grant_permission(self.request.user, 'Addons:Review')
+        actions = self.set_statuses_and_get_actions(
             addon_status=amo.STATUS_APPROVED,
-            file_status=amo.STATUS_APPROVED)) == 3
-        assert len(self.set_statuses_and_get_actions(
-            addon_status=amo.STATUS_DISABLED,
-            file_status=amo.STATUS_DISABLED)) == 3
+            file_status=amo.STATUS_APPROVED)
+        assert list(actions.keys()) == [
+            'reject_multiple_versions', 'reply', 'super', 'comment'
+        ]
 
-    @mock.patch('olympia.access.acl.action_allowed')
-    def test_actions_admin_flagged_addon_actions(self, action_allowed_mock):
+        # The add-on is already disabled so we don't show
+        # reject_multiple_versions, but reply/super/comment are still present.
+        actions = self.set_statuses_and_get_actions(
+            addon_status=amo.STATUS_DISABLED,
+            file_status=amo.STATUS_DISABLED)
+        assert list(actions.keys()) == ['reply', 'super', 'comment']
+
+    def test_actions_admin_flagged_addon_actions(self):
         AddonReviewerFlags.objects.create(
             addon=self.addon, needs_admin_code_review=True)
         # Test with an admin reviewer.
-        action_allowed_mock.return_value = True
+        self.grant_permission(self.request.user, 'Reviews:Admin')
         actions = self.set_statuses_and_get_actions(
             addon_status=amo.STATUS_NOMINATED,
             file_status=amo.STATUS_AWAITING_REVIEW)
         assert 'public' in actions.keys()
         # Test with an non-admin reviewer.
-        action_allowed_mock.return_value = False
+        self.request.user.groupuser_set.all().delete()
+        self.grant_permission(self.request.user, 'Addons:Review')
         actions = self.set_statuses_and_get_actions(
             addon_status=amo.STATUS_NOMINATED,
             file_status=amo.STATUS_AWAITING_REVIEW)
@@ -90,6 +104,7 @@ class TestReviewForm(TestCase):
         self.cr_theme = CannedResponse.objects.create(
             name=u'theme reason', response=u'theme reason body',
             sort_group=u'public', type=amo.CANNED_RESPONSE_TYPE_THEME)
+        self.grant_permission(self.request.user, 'Addons:Review')
         self.set_statuses_and_get_actions(
             addon_status=amo.STATUS_NOMINATED,
             file_status=amo.STATUS_AWAITING_REVIEW)
@@ -104,6 +119,7 @@ class TestReviewForm(TestCase):
         assert self.cr_addon.response in choices[0]
 
         # Check we get different canned responses for static themes.
+        self.grant_permission(self.request.user, 'Addons:ThemeReview')
         self.addon.update(type=amo.ADDON_STATICTHEME)
         form = self.get_form()
         choices = form.fields['canned_response'].choices[1][1]
@@ -111,6 +127,7 @@ class TestReviewForm(TestCase):
         assert len(choices) == 1  # No addon response
 
     def test_comments_and_action_required_by_default(self):
+        self.grant_permission(self.request.user, 'Addons:Review')
         form = self.get_form()
         assert not form.is_bound
         form = self.get_form(data={})
@@ -131,9 +148,15 @@ class TestReviewForm(TestCase):
         assert not form.errors
 
     def test_versions_queryset(self):
+        # Add a bunch of extra data that shouldn't be picked up.
         addon_factory()
         file_factory(version=self.addon.current_version)
         version_factory(addon=self.addon, channel=amo.RELEASE_CHANNEL_UNLISTED)
+        # auto-approve everything (including self.addon.current_version)
+        for version in Version.unfiltered.all():
+            AutoApprovalSummary.objects.create(
+                version=version, verdict=amo.AUTO_APPROVED)
+
         form = self.get_form()
         assert not form.is_bound
         assert form.fields['versions'].required is False
@@ -152,6 +175,10 @@ class TestReviewForm(TestCase):
         addon_factory()  # Extra add-on, shouldn't be included.
         version_factory(addon=self.addon, channel=amo.RELEASE_CHANNEL_LISTED,
                         file_kw={'status': amo.STATUS_AWAITING_REVIEW})
+        # auto-approve everything (including self.addon.current_version)
+        for version in Version.unfiltered.all():
+            AutoApprovalSummary.objects.create(
+                version=version, verdict=amo.AUTO_APPROVED)
         form = self.get_form()
         assert not form.is_bound
         assert form.fields['versions'].required is False
@@ -172,6 +199,10 @@ class TestReviewForm(TestCase):
         version_factory(addon=self.addon, channel=amo.RELEASE_CHANNEL_UNLISTED,
                         file_kw={'status': amo.STATUS_AWAITING_REVIEW})
         self.version.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        # auto-approve everything (including self.addon.current_version)
+        for version in Version.unfiltered.all():
+            AutoApprovalSummary.objects.create(
+                version=version, verdict=amo.AUTO_APPROVED)
         form = self.get_form()
         assert not form.is_bound
         assert form.fields['versions'].required is False
@@ -188,6 +219,10 @@ class TestReviewForm(TestCase):
         assert list(form.fields['versions'].queryset) == [self.version]
 
     def test_versions_required(self):
+        # auto-approve everything (including self.addon.current_version)
+        for version in Version.unfiltered.all():
+            AutoApprovalSummary.objects.create(
+                version=version, verdict=amo.AUTO_APPROVED)
         self.grant_permission(self.request.user, 'Addons:PostReview')
         form = self.get_form(data={
             'action': 'reject_multiple_versions', 'comments': 'lol'})

--- a/src/olympia/reviewers/urls.py
+++ b/src/olympia/reviewers/urls.py
@@ -5,7 +5,7 @@ from olympia.addons.urls import ADDON_ID
 from olympia.reviewers import views
 
 
-# All URLs under /editors/
+# All URLs under /reviewers/
 urlpatterns = (
     url(r'^$', views.dashboard, name='reviewers.dashboard'),
     url(r'^dashboard$',

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -275,12 +275,12 @@ class ReviewHelper(object):
     process off to the correct handler.
     """
     def __init__(self, request=None, addon=None, version=None,
-                 content_review_only=False):
+                 content_review=False):
         self.handler = None
         self.required = {}
         self.addon = addon
         self.version = version
-        self.content_review_only = content_review_only
+        self.content_review = content_review
         self.set_review_handler(request)
         self.actions = self.get_actions(request)
 
@@ -292,19 +292,20 @@ class ReviewHelper(object):
         self.handler.set_data(data)
 
     def set_review_handler(self, request):
+        """Set the handler property."""
         if (self.version and
                 self.version.channel == amo.RELEASE_CHANNEL_UNLISTED):
             self.handler = ReviewUnlisted(
                 request, self.addon, self.version, 'unlisted',
-                content_review_only=self.content_review_only)
+                content_review=self.content_review)
         elif self.addon.status == amo.STATUS_NOMINATED:
             self.handler = ReviewAddon(
                 request, self.addon, self.version, 'nominated',
-                content_review_only=self.content_review_only)
+                content_review=self.content_review)
         else:
             self.handler = ReviewFiles(
                 request, self.addon, self.version, 'pending',
-                content_review_only=self.content_review_only)
+                content_review=self.content_review)
 
     def get_actions(self, request):
         actions = OrderedDict()
@@ -314,58 +315,89 @@ class ReviewHelper(object):
             # the actions.
             return actions
 
-        # Conditions used below.
-        is_post_reviewer = acl.action_allowed(
-            request, amo.permissions.ADDONS_POST_REVIEW)
-        is_unlisted_reviewer = acl.action_allowed(
-            request, amo.permissions.ADDONS_REVIEW_UNLISTED)
-        is_content_reviewer = acl.action_allowed(
-            request, amo.permissions.ADDONS_CONTENT_REVIEW)
-        is_admin_tools_viewer = acl.action_allowed(
-            request, amo.permissions.REVIEWS_ADMIN)
-        reviewable_because_complete = self.addon.status not in (
-            amo.STATUS_NULL, amo.STATUS_DELETED)
-        regular_addon_review_is_allowed = (
-            not self.content_review_only and
-            not self.addon.needs_admin_code_review and
-            not self.addon.needs_admin_content_review and
-            not self.addon.needs_admin_theme_review
-        )
-        regular_content_review_is_allowed = (
-            self.content_review_only and
-            not self.addon.needs_admin_content_review)
-        reviewable_because_not_reserved_for_admins_or_user_is_admin = (
-            is_admin_tools_viewer or
-            (
-                self.version and
-                (
-                    regular_addon_review_is_allowed or
-                    regular_content_review_is_allowed
-                )
-            ))
-        reviewable_because_pending = (
-            self.version and self.version.is_unreviewed)
-        is_listed_was_auto_approved_and_user_can_post_review = (
+        # 2 kind of checks are made for the review page.
+        # - Base permission checks to access the review page itself, done in
+        #   the review() view
+        # - A more specific check for each action, done below, restricting
+        #   their availability while not affecting whether the user can see
+        #   the review page or not.
+        permission = None
+        version_is_unlisted = (
+            self.version and
+            self.version.channel == amo.RELEASE_CHANNEL_UNLISTED)
+        try:
+            is_recommendable = self.addon.discoveryitem.recommendable
+        except DiscoveryItem.DoesNotExist:
+            is_recommendable = False
+        current_version_is_listed_and_auto_approved = (
             self.version and
             self.version.channel == amo.RELEASE_CHANNEL_LISTED and
             self.addon.current_version and
-            self.addon.current_version.was_auto_approved and
-            is_post_reviewer and
-            not self.content_review_only)
-        is_unlisted_and_user_can_review_unlisted = (
+            self.addon.current_version.was_auto_approved)
+
+        if self.content_review:
+            is_admin_needed = self.addon.needs_admin_content_review
+            permission = amo.permissions.ADDONS_CONTENT_REVIEW
+        elif is_recommendable:
+            is_admin_needed = (
+                self.addon.needs_admin_content_review or
+                self.addon.needs_admin_code_review)
+            permission = amo.permissions.ADDONS_RECOMMENDED_REVIEW
+        elif version_is_unlisted:
+            is_admin_needed = self.addon.needs_admin_code_review
+            permission = amo.permissions.ADDONS_REVIEW_UNLISTED
+        elif self.addon.type == amo.ADDON_STATICTHEME:
+            is_admin_needed = self.addon.needs_admin_theme_review
+            permission = amo.permissions.STATIC_THEMES_REVIEW
+        elif current_version_is_listed_and_auto_approved:
+            is_admin_needed = (
+                self.addon.needs_admin_content_review or
+                self.addon.needs_admin_code_review)
+            permission = amo.permissions.ADDONS_POST_REVIEW
+        else:
+            is_admin_needed = (
+                self.addon.needs_admin_content_review or
+                self.addon.needs_admin_code_review)
+            permission = amo.permissions.ADDONS_REVIEW
+
+        assert permission is not None
+
+        if is_admin_needed:
+            permission = amo.permissions.REVIEWS_ADMIN
+
+        # Is the current user a reviewer for this kind of add-on ?
+        is_reviewer = acl.is_reviewer(request, self.addon)
+
+        # Is the current user an appropriate reviewer, noy only for this kind
+        # of add-on, but also for the state the add-on is in ? (Allows more
+        # impactful actions).
+        is_appropriate_reviewer = acl.action_allowed_user(
+            request.user, permission)
+
+        # Special logic for availability of reject multiple action:
+        if self.content_review:
+            can_reject_multiple = is_appropriate_reviewer
+        else:
+            # When doing a code review, this action is also available to
+            # users with Addons:PostReview even if the current version hasn't
+            # been auto-approved, provided that the add-on isn't marked as
+            # needing admin review.
+            can_reject_multiple = (
+                is_appropriate_reviewer or
+                (acl.action_allowed_user(
+                    request.user, amo.permissions.ADDONS_POST_REVIEW) and
+                 not is_admin_needed)
+            )
+
+        addon_is_complete = self.addon.status not in (
+            amo.STATUS_NULL, amo.STATUS_DELETED)
+        version_is_unreviewed = self.version and self.version.is_unreviewed
+        addon_is_valid = self.addon.is_public() or self.addon.is_unreviewed()
+        addon_is_valid_and_version_is_listed = (
+            addon_is_valid and
             self.version and
-            self.version.channel == amo.RELEASE_CHANNEL_UNLISTED and
-            is_unlisted_reviewer)
-        is_public_and_listed_and_user_can_post_review = (
-            self.version and
-            self.addon.status == amo.STATUS_APPROVED and
-            self.version.channel == amo.RELEASE_CHANNEL_LISTED and
-            is_post_reviewer)
-        is_valid_and_listed_and_user_can_content_review = (
-            self.version and
-            (self.addon.is_public() or self.addon.is_unreviewed()) and
-            self.version.channel == amo.RELEASE_CHANNEL_LISTED and
-            is_content_reviewer and self.content_review_only)
+            self.version.channel == amo.RELEASE_CHANNEL_LISTED
+        )
 
         # Definitions for all actions.
         actions['public'] = {
@@ -376,10 +408,11 @@ class ReviewHelper(object):
                          'developer.'),
             'label': _('Approve'),
             'available': (
-                reviewable_because_complete and
-                reviewable_because_not_reserved_for_admins_or_user_is_admin and
-                reviewable_because_pending and
-                not self.content_review_only)
+                not self.content_review and
+                addon_is_complete and
+                version_is_unreviewed and
+                is_appropriate_reviewer
+            )
         }
         actions['reject'] = {
             'method': self.handler.process_sandbox,
@@ -388,7 +421,12 @@ class ReviewHelper(object):
                          'from the queue. The comments will be sent '
                          'to the developer.'),
             'minimal': False,
-            'available': actions['public']['available'],
+            'available': (
+                not self.content_review and
+                addon_is_complete and
+                version_is_unreviewed and
+                is_appropriate_reviewer
+            )
         }
         actions['approve_content'] = {
             'method': self.handler.approve_content,
@@ -399,8 +437,9 @@ class ReviewHelper(object):
             'minimal': False,
             'comments': False,
             'available': (
-                reviewable_because_not_reserved_for_admins_or_user_is_admin and
-                is_valid_and_listed_and_user_can_content_review
+                self.content_review and
+                addon_is_valid_and_version_is_listed and
+                is_appropriate_reviewer
             ),
         }
         actions['confirm_auto_approved'] = {
@@ -413,8 +452,10 @@ class ReviewHelper(object):
             'minimal': True,
             'comments': False,
             'available': (
-                reviewable_because_not_reserved_for_admins_or_user_is_admin and
-                is_listed_was_auto_approved_and_user_can_post_review
+                not self.content_review and
+                addon_is_valid_and_version_is_listed and
+                current_version_is_listed_and_auto_approved and
+                is_appropriate_reviewer
             ),
         }
         actions['reject_multiple_versions'] = {
@@ -427,9 +468,8 @@ class ReviewHelper(object):
                          'developer.'),
             'available': (
                 self.addon.type != amo.ADDON_STATICTHEME and
-                reviewable_because_not_reserved_for_admins_or_user_is_admin and
-                (is_public_and_listed_and_user_can_post_review or
-                 is_valid_and_listed_and_user_can_content_review)
+                addon_is_valid_and_version_is_listed and
+                can_reject_multiple
             ),
         }
         actions['block_multiple_versions'] = {
@@ -443,8 +483,8 @@ class ReviewHelper(object):
                          'admin page.'),
             'available': (
                 self.addon.type != amo.ADDON_STATICTHEME and
-                reviewable_because_not_reserved_for_admins_or_user_is_admin and
-                is_unlisted_and_user_can_review_unlisted
+                version_is_unlisted and
+                is_appropriate_reviewer
             ),
         }
         actions['confirm_multiple_versions'] = {
@@ -456,7 +496,9 @@ class ReviewHelper(object):
                          'versions without notifying the developer.'),
             'comments': False,
             'available': (
-                is_unlisted_and_user_can_review_unlisted
+                self.addon.type != amo.ADDON_STATICTHEME and
+                version_is_unlisted and
+                is_appropriate_reviewer
             ),
         }
         actions['reply'] = {
@@ -465,7 +507,10 @@ class ReviewHelper(object):
             'details': _('This will send a message to the developer. '
                          'You will be notified when they reply.'),
             'minimal': True,
-            'available': self.version is not None,
+            'available': (
+                self.version is not None and
+                is_reviewer
+            )
         }
         actions['super'] = {
             'method': self.handler.process_super_review,
@@ -475,7 +520,10 @@ class ReviewHelper(object):
                          'your comments in the area below. They will '
                          'not be sent to the developer.'),
             'minimal': True,
-            'available': self.version is not None,
+            'available': (
+                self.version is not None and
+                is_reviewer
+            )
         }
         actions['comment'] = {
             'method': self.handler.process_comment,
@@ -483,7 +531,9 @@ class ReviewHelper(object):
             'details': _('Make a comment on this version. The developer '
                          'won\'t be able to see this.'),
             'minimal': True,
-            'available': True,
+            'available': (
+                is_reviewer
+            )
         }
 
         return OrderedDict(
@@ -501,7 +551,7 @@ class ReviewHelper(object):
 class ReviewBase(object):
 
     def __init__(self, request, addon, version, review_type,
-                 content_review_only=False):
+                 content_review=False):
         self.request = request
         if request:
             self.user = self.request.user
@@ -517,7 +567,7 @@ class ReviewBase(object):
             ('theme_%s' if addon.type == amo.ADDON_STATICTHEME
              else 'extension_%s') % review_type)
         self.files = self.version.unreviewed_files if self.version else []
-        self.content_review_only = content_review_only
+        self.content_review = content_review
         self.redirect_url = None
 
     def set_addon(self, **kw):
@@ -707,7 +757,7 @@ class ReviewBase(object):
 
         # Safeguard to make sure this action is not used for content review
         # (it should use confirm_auto_approved instead).
-        assert not self.content_review_only
+        assert not self.content_review
 
         # Sign addon.
         self.sign_files()
@@ -758,7 +808,7 @@ class ReviewBase(object):
 
         # Safeguard to make sure this action is not used for content review
         # (it should use reject_multiple_versions instead).
-        assert not self.content_review_only
+        assert not self.content_review
 
         # Hold onto the status before we change it.
         status = self.addon.status
@@ -793,7 +843,7 @@ class ReviewBase(object):
         if addon_type == amo.ADDON_STATICTHEME:
             needs_admin_property = 'needs_admin_theme_review'
             log_action_type = amo.LOG.REQUEST_ADMIN_REVIEW_THEME
-        elif self.content_review_only:
+        elif self.content_review:
             needs_admin_property = 'needs_admin_content_review'
             log_action_type = amo.LOG.REQUEST_ADMIN_REVIEW_CONTENT
         else:
@@ -812,7 +862,7 @@ class ReviewBase(object):
         version = self.addon.current_version
 
         # Content review only action.
-        assert self.content_review_only
+        assert self.content_review
 
         # Doesn't make sense for unlisted versions.
         assert channel == amo.RELEASE_CHANNEL_LISTED
@@ -834,7 +884,7 @@ class ReviewBase(object):
             ReviewerScore.award_points(
                 self.user, self.addon, self.addon.status,
                 version=version, post_review=is_post_review,
-                content_review=self.content_review_only)
+                content_review=self.content_review)
 
     def confirm_auto_approved(self):
         """Confirm an auto-approval decision."""
@@ -879,7 +929,7 @@ class ReviewBase(object):
             ReviewerScore.award_points(
                 self.user, self.addon, self.addon.status,
                 version=version, post_review=is_post_review,
-                content_review=self.content_review_only)
+                content_review=self.content_review)
 
     def reject_multiple_versions(self):
         """Reject a list of versions."""
@@ -890,7 +940,7 @@ class ReviewBase(object):
         latest_version = self.version
         self.version = None
         self.files = None
-        action_id = (amo.LOG.REJECT_CONTENT if self.content_review_only
+        action_id = (amo.LOG.REJECT_CONTENT if self.content_review
                      else amo.LOG.REJECT_VERSION)
         timestamp = datetime.now()
         for version in self.data['versions']:
@@ -931,7 +981,7 @@ class ReviewBase(object):
         if self.human_review:
             ReviewerScore.award_points(
                 self.user, self.addon, status, version=latest_version,
-                post_review=True, content_review=self.content_review_only)
+                post_review=True, content_review=self.content_review)
 
     def confirm_multiple_versions(self):
         raise NotImplementedError  # only implemented for unlisted below.

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -607,10 +607,9 @@ def queue_moderated(request):
 
 
 @any_reviewer_required
-@post_required
 @json_view
 def application_versions_json(request):
-    app_id = request.POST['application_id']
+    app_id = request.GET.get('application_id', amo.FIREFOX.id)
     form = QueueSearchForm()
     return {'choices': form.version_choices_for_app_id(app_id)}
 
@@ -655,83 +654,30 @@ def queue_needs_human_review(request):
                   qs=qs, SearchForm=None)
 
 
-def perform_review_permission_checks(
-        request, addon, channel, content_review_only=False):
-    """Perform the permission checks needed by the review() view or anything
-    that follows the same behavior, such as the whiteboard() view.
-
-    Raises PermissionDenied when the current user on the request does not have
-    the right permissions for the context defined by addon, channel and
-    content_review_only boolean.
-    """
-    unlisted_only = (
-        channel == amo.RELEASE_CHANNEL_UNLISTED or
-        not addon.has_listed_versions(include_deleted=True))
-    was_auto_approved = (
-        channel == amo.RELEASE_CHANNEL_LISTED and
-        addon.current_version and addon.current_version.was_auto_approved)
-    static_theme = addon.type == amo.ADDON_STATICTHEME
-    try:
-        is_recommendable = addon.discoveryitem.recommendable
-    except DiscoveryItem.DoesNotExist:
-        is_recommendable = False
-
-    # Are we looking at an unlisted review page, or (weirdly) the listed
-    # review page of an unlisted-only add-on?
-    if unlisted_only and not acl.check_unlisted_addons_reviewer(request):
-        raise PermissionDenied
-    # Recommended add-ons need special treatment.
-    if is_recommendable and not acl.action_allowed(
-            request, amo.permissions.ADDONS_RECOMMENDED_REVIEW):
-        raise PermissionDenied
-    # If we're only doing a content review, we just need to check for the
-    # content review permission, otherwise it's the "main" review page.
-    if content_review_only:
-        if not acl.action_allowed(
-                request, amo.permissions.ADDONS_CONTENT_REVIEW):
-            raise PermissionDenied
-    elif static_theme:
-        if not acl.action_allowed(
-                request, amo.permissions.STATIC_THEMES_REVIEW):
-            raise PermissionDenied
-    else:
-        # Was the add-on auto-approved?
-        if was_auto_approved and not acl.action_allowed(
-                request, amo.permissions.ADDONS_POST_REVIEW):
-            raise PermissionDenied
-
-        # Finally, if it wasn't auto-approved, check for legacy reviewer
-        # permission.
-        if not was_auto_approved and not acl.action_allowed(
-                request, amo.permissions.ADDONS_REVIEW):
-            raise PermissionDenied
-
-
 def determine_channel(channel_as_text):
     """Determine which channel the review is for according to the channel
     parameter as text, and whether we should be in content-review only mode."""
     if channel_as_text == 'content':
         # 'content' is not a real channel, just a different review mode for
         # listed add-ons.
-        content_review_only = True
+        content_review = True
         channel = 'listed'
     else:
-        content_review_only = False
+        content_review = False
     # channel is passed in as text, but we want the constant.
     channel = amo.CHANNEL_CHOICES_LOOKUP.get(
         channel_as_text, amo.RELEASE_CHANNEL_LISTED)
-    return channel, content_review_only
+    return channel, content_review
 
 
-# Permission checks for this view are done inside, depending on type of review
-# needed, using perform_review_permission_checks().
 @login_required
+@any_reviewer_required  # Additional permission checks are done inside.
 @reviewer_addon_view_factory
 def review(request, addon, channel=None):
     whiteboard_url = reverse(
         'reviewers.whiteboard',
         args=(channel or 'listed', addon.slug if addon.slug else addon.pk))
-    channel, content_review_only = determine_channel(channel)
+    channel, content_review = determine_channel(channel)
 
     was_auto_approved = (
         channel == amo.RELEASE_CHANNEL_LISTED and
@@ -742,15 +688,16 @@ def review(request, addon, channel=None):
     except DiscoveryItem.DoesNotExist:
         is_recommendable = False
 
-    # If we're just looking (GET) we can bypass the specific permissions checks
-    # if we have ReviewerTools:View.
-    bypass_more_specific_permissions_because_read_only = (
-        request.method == 'GET' and acl.action_allowed(
-            request, amo.permissions.REVIEWER_TOOLS_VIEW))
+    # Are we looking at an unlisted review page, or (weirdly) the listed
+    # review page of an unlisted-only add-on?
+    unlisted_only = (
+        channel == amo.RELEASE_CHANNEL_UNLISTED or
+        not addon.has_listed_versions(include_deleted=True))
+    if unlisted_only and not acl.check_unlisted_addons_reviewer(request):
+        raise PermissionDenied
 
-    if not bypass_more_specific_permissions_because_read_only:
-        perform_review_permission_checks(
-            request, addon, channel, content_review_only=content_review_only)
+    # Other cases are handled in ReviewHelper by limiting what actions are
+    # available depending on user permissions and add-on/version state.
 
     version = addon.find_latest_version(channel=channel, exclude=())
 
@@ -781,7 +728,7 @@ def review(request, addon, channel=None):
 
     form_helper = ReviewHelper(
         request=request, addon=addon, version=version,
-        content_review_only=content_review_only)
+        content_review=content_review)
     form = ReviewForm(request.POST if request.method == 'POST' else None,
                       helper=form_helper, initial=form_initial)
     is_admin = acl.action_allowed(request, amo.permissions.REVIEWS_ADMIN)
@@ -811,7 +758,7 @@ def review(request, addon, channel=None):
             except AddonApprovalsCounter.DoesNotExist:
                 pass
 
-        if content_review_only:
+        if content_review:
             queue_type = 'content_review'
         elif is_recommendable:
             queue_type = 'recommended'
@@ -826,6 +773,8 @@ def review(request, addon, channel=None):
         redirect_url = reverse('reviewers.unlisted_queue_all')
 
     if request.method == 'POST' and form.is_valid():
+        # Execute the action (is_valid() ensures the action is available to the
+        # reviewer)
         form.helper.process()
 
         amo.messages.success(
@@ -927,7 +876,7 @@ def review(request, addon, channel=None):
         actions_full=actions_full, addon=addon,
         api_token=request.COOKIES.get(API_TOKEN_COOKIE, None),
         approvals_info=approvals_info, auto_approval_info=auto_approval_info,
-        content_review_only=content_review_only, count=count,
+        content_review=content_review, count=count,
         deleted_addon_ids=deleted_addon_ids, flags=flags,
         form=form, is_admin=is_admin, now=datetime.now(), num_pages=num_pages,
         pager=pager, reports=reports, show_diff=show_diff,
@@ -943,6 +892,9 @@ def review(request, addon, channel=None):
 
 @never_cache
 @json_view
+# This will 403 for users with only ReviewerTools:View, but they shouldn't
+# acquire reviewer locks anyway, and it's not a big deal if they don't see
+# existing locks.
 @any_reviewer_required
 def review_viewing(request):
     if 'addon_id' not in request.POST:
@@ -1087,15 +1039,17 @@ def leaderboard(request):
         context(scores=ReviewerScore.all_users_by_score()))
 
 
-# Permission checks for this view are done inside, depending on type of review
-# needed, using perform_review_permission_checks().
-@login_required
+@any_reviewer_required
 @reviewer_addon_view_factory
 def whiteboard(request, addon, channel):
     channel_as_text = channel
-    channel, content_review_only = determine_channel(channel)
-    perform_review_permission_checks(
-        request, addon, channel, content_review_only=content_review_only)
+    channel, content_review = determine_channel(channel)
+
+    unlisted_only = (
+        channel == amo.RELEASE_CHANNEL_UNLISTED or
+        not addon.has_listed_versions(include_deleted=True))
+    if unlisted_only and not acl.check_unlisted_addons_reviewer(request):
+        raise PermissionDenied
 
     whiteboard, _ = Whiteboard.objects.get_or_create(pk=addon.pk)
     form = WhiteboardForm(request.POST or None, instance=whiteboard,
@@ -1122,15 +1076,7 @@ def policy_viewer(request, addon, eula_or_privacy, page_title, long_title):
     if not eula_or_privacy:
         raise http.Http404
     channel_text = request.GET.get('channel')
-    channel, content_review_only = determine_channel(channel_text)
-    # It's a read-only view so we can bypass the specific permissions checks
-    # if we have ReviewerTools:View.
-    bypass_more_specific_permissions_because_read_only = (
-        acl.action_allowed(
-            request, amo.permissions.REVIEWER_TOOLS_VIEW))
-    if not bypass_more_specific_permissions_because_read_only:
-        perform_review_permission_checks(
-            request, addon, channel, content_review_only=content_review_only)
+    channel, content_review = determine_channel(channel_text)
 
     review_url = reverse(
         'reviewers.review',
@@ -1142,7 +1088,7 @@ def policy_viewer(request, addon, eula_or_privacy, page_title, long_title):
                    'page_title': page_title, 'long_title': long_title})
 
 
-@login_required
+@any_reviewer_required
 @reviewer_addon_view_factory
 def eula(request, addon):
     return policy_viewer(request, addon, addon.eula,
@@ -1150,7 +1096,7 @@ def eula(request, addon):
                          long_title=ugettext('End-User License Agreement'))
 
 
-@login_required
+@any_reviewer_required
 @reviewer_addon_view_factory
 def privacy(request, addon):
     return policy_viewer(request, addon, addon.privacy_policy,

--- a/static/js/zamboni/reviewers.js
+++ b/static/js/zamboni/reviewers.js
@@ -437,7 +437,7 @@ function initQueueSearch(doc) {
                                  ['', gettext('Select an application first')]));
             return;
         }
-        $.post(sel.attr('data-url'), {'application_id': appId}, function(d) {
+        $.get(sel.attr('data-url'), {'application_id': appId}, function(d) {
             $('option', maxVer).remove();
             $.each(d.choices, function(i, ch) {
                 maxVer.append(format('<option value="{0}">{1}</option>',


### PR DESCRIPTION
This kinda reverses the previous behavior, allowing users with any kind of reviewer permission to see listed review pages, but restrict the actions depending on the permissions they have.

Unlisted continue to be restricted to unlisted reviewers.

Fixes #13566 (and more)