### PR TITLE
Add link to view all the add-ons of authors (scanner results)

### DIFF
--- a/src/olympia/scanners/admin.py
+++ b/src/olympia/scanners/admin.py
@@ -313,13 +313,35 @@ class AbstractScannerResultAdminMixin(admin.ModelAdmin):
     def authors(self, obj):
         if not obj.version:
             return '-'
+
+        authors = obj.version.addon.authors.all()
         contents = format_html_join(
-            '', '<li><a href="{}">{}</a></li>',
-            ((urljoin(
+            '',
+            '<li><a href="{}">{}</a></li>',
+            (
+                (
+                    urljoin(
+                        settings.EXTERNAL_SITE_URL,
+                        reverse(
+                            'admin:users_userprofile_change', args=(author.pk,)
+                        ),
+                    ),
+                    author.email,
+                )
+                for author in authors
+            ),
+        )
+        return format_html(
+            '<ul>{}</ul>'
+            '<br>'
+            '[<a href="{}?authors={}">Other add-ons by these authors</a>]',
+            contents,
+            urljoin(
                 settings.EXTERNAL_SITE_URL,
-                reverse('admin:users_userprofile_change', args=(author.pk,))),
-             author.email) for author in obj.version.addon.authors.all()))
-        return format_html('<ul>{}</ul>', contents)
+                reverse('admin:addons_addon_changelist'),
+            ),
+            ','.join(str(author.pk) for author in authors),
+        )
 
     def guid(self, obj):
         if obj.version:

--- a/static/css/admin/scannerresult.css
+++ b/static/css/admin/scannerresult.css
@@ -24,7 +24,11 @@
   float: none;
 }
 
-.field-matching_filenames ul, .field-authors ul {
+.field-matching_filenames ul,
+.field-authors ul,
+/* This rule is for the change page. */
+.aligned .field-authors ul
+{
     display: block;
     margin: 0;
     padding: 0;


### PR DESCRIPTION
Fixes #13721

---

The link will be available everywhere we display the list of authors.

It looks like this (with brackets to distinguish this link from the list of authors):

![Screen Shot 2020-03-16 at 11 44 08](https://user-images.githubusercontent.com/217628/76748689-7fbdb980-677b-11ea-892c-afd1260da079.png)

This patch also fixes a UI issue in the change page (before the list of authors was weirdly centered):

![Screen Shot 2020-03-16 at 11 46 53](https://user-images.githubusercontent.com/217628/76748891-daefac00-677b-11ea-8550-191991023b14.png)
