### PR TITLE
Add Addon.disable_all_files() and use it in force_disable()

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -506,6 +506,8 @@ class Addon(OnChangeMixin, ModelBase):
                  self.slug, amo.STATUS_DISABLED)
         self.update(status=amo.STATUS_DISABLED)
         self.update_version()
+        # See: https://github.com/mozilla/addons-server/issues/13194
+        self.disable_files()
 
     def force_enable(self):
         activity.log_create(amo.LOG.CHANGE_STATUS, self, amo.STATUS_APPROVED)
@@ -531,6 +533,10 @@ class Addon(OnChangeMixin, ModelBase):
         activity.log_create(amo.LOG.DENIED_GUID_DELETED, self)
         log.info('Allow resubmission for addon "%s"', self.slug)
         DeniedGuid.objects.filter(guid=self.guid).delete()
+
+    def disable_files(self):
+        File.objects.filter(version__addon=self).update(
+            status=amo.STATUS_DISABLED)
 
     @property
     def is_guid_denied(self):
@@ -630,8 +636,7 @@ class Addon(OnChangeMixin, ModelBase):
             # avoid extra work. Files will be moved to the correct storage
             # location with hide_disabled_files task or hide_disabled_files
             # cron as a fallback.
-            File.objects.filter(version__addon=self).update(
-                status=amo.STATUS_DISABLED)
+            self.disable_files()
             file_tasks.hide_disabled_files.delay(addon_id=self.id)
 
             self.versions.all().update(deleted=True)

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -507,7 +507,7 @@ class Addon(OnChangeMixin, ModelBase):
         self.update(status=amo.STATUS_DISABLED)
         self.update_version()
         # See: https://github.com/mozilla/addons-server/issues/13194
-        self.disable_files()
+        self.disable_all_files()
 
     def force_enable(self):
         activity.log_create(amo.LOG.CHANGE_STATUS, self, amo.STATUS_APPROVED)
@@ -534,7 +534,7 @@ class Addon(OnChangeMixin, ModelBase):
         log.info('Allow resubmission for addon "%s"', self.slug)
         DeniedGuid.objects.filter(guid=self.guid).delete()
 
-    def disable_files(self):
+    def disable_all_files(self):
         File.objects.filter(version__addon=self).update(
             status=amo.STATUS_DISABLED)
 
@@ -636,7 +636,7 @@ class Addon(OnChangeMixin, ModelBase):
             # avoid extra work. Files will be moved to the correct storage
             # location with hide_disabled_files task or hide_disabled_files
             # cron as a fallback.
-            self.disable_files()
+            self.disable_all_files()
             file_tasks.hide_disabled_files.delay(addon_id=self.id)
 
             self.versions.all().update(deleted=True)

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -639,6 +639,22 @@ class TestAddonModels(TestCase):
         for version in versions:
             assert version.deleted
 
+    def test_force_disable(self):
+        addon = Addon.unfiltered.get(pk=3615)
+        assert addon.status != amo.STATUS_DISABLED
+        files = File.objects.filter(version__addon=addon)
+        assert files
+        for file_ in files:
+            assert file_.status != amo.STATUS_DISABLED
+
+        addon.force_disable()
+
+        assert addon.status == amo.STATUS_DISABLED
+        files = File.objects.filter(version__addon=addon)
+        assert files
+        for file_ in files:
+            assert file_.status == amo.STATUS_DISABLED
+
     def test_incompatible_latest_apps(self):
         a = Addon.objects.get(pk=3615)
         assert a.incompatible_latest_apps() == []


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/13194

---

This patch makes sure we disable the files when we "force disable" an add-on.