### PR TITLE
Add links to reviewer tools in addon admin

### DIFF
--- a/src/olympia/addons/admin.py
+++ b/src/olympia/addons/admin.py
@@ -194,22 +194,26 @@ class AddonAdmin(admin.ModelAdmin):
                     url += '?' + request.GET.urlencode()
                 return http.HttpResponsePermanentRedirect(url)
 
-        response = super(AddonAdmin, self).change_view(
-            request, object_id, form_url, extra_context=extra_context
+        return super().change_view(request, object_id, form_url,
+                                   extra_context=extra_context)
+
+    def render_change_form(self, request, context, add=False, change=False,
+                           form_url='', obj=None):
+        context.update(
+            {
+                'has_listed_versions': obj.has_listed_versions(
+                    include_deleted=True
+                ),
+                'has_unlisted_versions': obj.has_unlisted_versions(
+                    include_deleted=True
+                )
+            }
         )
-        if response.status_code == 200:
-            obj = response.context_data.get('original', None)
-            response.context_data.update(
-                {
-                    'has_listed_versions': obj.has_listed_versions(
-                        include_deleted=True
-                    ) if obj else False,
-                    'has_unlisted_versions': obj.has_unlisted_versions(
-                        include_deleted=True
-                    ) if obj else False,
-                }
-            )
-        return response
+
+        return super().render_change_form(request=request, context=context,
+                                          add=add, change=change,
+                                          form_url=form_url, obj=obj)
+
 
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)

--- a/src/olympia/addons/admin.py
+++ b/src/olympia/addons/admin.py
@@ -194,9 +194,22 @@ class AddonAdmin(admin.ModelAdmin):
                     url += '?' + request.GET.urlencode()
                 return http.HttpResponsePermanentRedirect(url)
 
-        return super(AddonAdmin, self).change_view(
-            request, object_id, form_url, extra_context=None,
+        response = super(AddonAdmin, self).change_view(
+            request, object_id, form_url, extra_context=extra_context
         )
+        if request.method == 'GET':
+            obj = response.context_data.get('original', None)
+            response.context_data.update(
+                {
+                    'has_listed_versions': obj.has_listed_versions(
+                        include_deleted=True
+                    ) if obj else False,
+                    'has_unlisted_versions': obj.has_unlisted_versions(
+                        include_deleted=True
+                    ) if obj else False,
+                }
+            )
+        return response
 
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)

--- a/src/olympia/addons/admin.py
+++ b/src/olympia/addons/admin.py
@@ -197,7 +197,7 @@ class AddonAdmin(admin.ModelAdmin):
         response = super(AddonAdmin, self).change_view(
             request, object_id, form_url, extra_context=extra_context
         )
-        if request.method == 'GET':
+        if response.status_code == 200:
             obj = response.context_data.get('original', None)
             response.context_data.update(
                 {

--- a/src/olympia/addons/admin.py
+++ b/src/olympia/addons/admin.py
@@ -214,7 +214,6 @@ class AddonAdmin(admin.ModelAdmin):
                                           add=add, change=change,
                                           form_url=form_url, obj=obj)
 
-
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)
         if 'status' in form.changed_data:

--- a/src/olympia/addons/templates/admin/addons/addon/change_form.html
+++ b/src/olympia/addons/templates/admin/addons/addon/change_form.html
@@ -1,0 +1,22 @@
+{% extends "admin/change_form.html" %}
+{% load i18n %}
+
+{% block object-tools-items %}
+  {% if has_listed_versions %}
+  <li>
+    <a href="{% url 'reviewers.review' 'listed' object_id %}">
+      {% trans 'Reviewer Tools (listed)' %}
+    </a>
+  </li>
+  {% endif %}
+
+  {% if has_unlisted_versions %}
+  <li>
+    <a href="{% url 'reviewers.review' 'unlisted' object_id %}">
+      {% trans 'Reviewer Tools (unlisted)' %}
+    </a>
+  </li>
+  {% endif %}
+
+  {{ block.super }}
+{% endblock %}

--- a/src/olympia/addons/tests/test_admin.py
+++ b/src/olympia/addons/tests/test_admin.py
@@ -149,9 +149,8 @@ class TestAddonAdmin(TestCase):
         self.grant_permission(user, 'Addons:Edit')
         self.client.login(email=user.email)
         response = self.client.get(detail_url, follow=True)
-        assert 'Reviewer Tools (listed)' in response.content.decode('utf-8')
-        assert ('Reviewer Tools (unlisted)' not in
-                response.content.decode('utf-8'))
+        assert b'Reviewer Tools (listed)' in response.content
+        assert b'Reviewer Tools (unlisted)' not in response.content
 
     def test_show_link_to_reviewer_tools_unlisted(self):
         version_kw = {'channel': amo.RELEASE_CHANNEL_UNLISTED}
@@ -162,9 +161,8 @@ class TestAddonAdmin(TestCase):
         self.grant_permission(user, 'Addons:Edit')
         self.client.login(email=user.email)
         response = self.client.get(detail_url, follow=True)
-        assert ('Reviewer Tools (listed)' not in
-                response.content.decode('utf-8'))
-        assert 'Reviewer Tools (unlisted)' in response.content.decode('utf-8')
+        assert b'Reviewer Tools (listed)' not in response.content
+        assert b'Reviewer Tools (unlisted)' in response.content
 
     def test_show_links_to_reviewer_tools_with_both_channels(self):
         addon = addon_factory(guid='@foo')
@@ -176,8 +174,8 @@ class TestAddonAdmin(TestCase):
         self.grant_permission(user, 'Addons:Edit')
         self.client.login(email=user.email)
         response = self.client.get(detail_url, follow=True)
-        assert 'Reviewer Tools (listed)' in response.content.decode('utf-8')
-        assert 'Reviewer Tools (unlisted)' in response.content.decode('utf-8')
+        assert b'Reviewer Tools (listed)' in response.content
+        assert b'Reviewer Tools (unlisted)' in response.content
 
     def test_can_not_list_without_addons_edit_permission(self):
         addon = addon_factory()

--- a/src/olympia/addons/tests/test_admin.py
+++ b/src/olympia/addons/tests/test_admin.py
@@ -140,6 +140,45 @@ class TestAddonAdmin(TestCase):
         addon.reload()
         assert addon.guid == '@bar'
 
+    def test_show_link_to_reviewer_tools_listed(self):
+        addon = addon_factory(guid='@foo')
+        version_factory(addon=addon, channel=amo.RELEASE_CHANNEL_LISTED)
+        detail_url = reverse('admin:addons_addon_change', args=(addon.pk,))
+        user = user_factory()
+        self.grant_permission(user, 'Admin:Tools')
+        self.grant_permission(user, 'Addons:Edit')
+        self.client.login(email=user.email)
+        response = self.client.get(detail_url, follow=True)
+        assert 'Reviewer Tools (listed)' in response.content.decode('utf-8')
+        assert ('Reviewer Tools (unlisted)' not in
+                response.content.decode('utf-8'))
+
+    def test_show_link_to_reviewer_tools_unlisted(self):
+        version_kw = {'channel': amo.RELEASE_CHANNEL_UNLISTED}
+        addon = addon_factory(guid='@foo', version_kw=version_kw)
+        detail_url = reverse('admin:addons_addon_change', args=(addon.pk,))
+        user = user_factory()
+        self.grant_permission(user, 'Admin:Tools')
+        self.grant_permission(user, 'Addons:Edit')
+        self.client.login(email=user.email)
+        response = self.client.get(detail_url, follow=True)
+        assert ('Reviewer Tools (listed)' not in
+                response.content.decode('utf-8'))
+        assert 'Reviewer Tools (unlisted)' in response.content.decode('utf-8')
+
+    def test_show_links_to_reviewer_tools_with_both_channels(self):
+        addon = addon_factory(guid='@foo')
+        version_factory(addon=addon, channel=amo.RELEASE_CHANNEL_LISTED)
+        version_factory(addon=addon, channel=amo.RELEASE_CHANNEL_UNLISTED)
+        detail_url = reverse('admin:addons_addon_change', args=(addon.pk,))
+        user = user_factory()
+        self.grant_permission(user, 'Admin:Tools')
+        self.grant_permission(user, 'Addons:Edit')
+        self.client.login(email=user.email)
+        response = self.client.get(detail_url, follow=True)
+        assert 'Reviewer Tools (listed)' in response.content.decode('utf-8')
+        assert 'Reviewer Tools (unlisted)' in response.content.decode('utf-8')
+
     def test_can_not_list_without_addons_edit_permission(self):
         addon = addon_factory()
         user = user_factory()
@@ -409,7 +448,7 @@ class TestAddonAdmin(TestCase):
         self.grant_permission(user, 'Addons:Edit')
         self.grant_permission(user, 'Admin:Advanced')
         self.client.login(email=user.email)
-        with self.assertNumQueries(23):
+        with self.assertNumQueries(24):
             # It's very high because most of AddonAdmin is unoptimized but we
             # don't want it unexpectedly increasing.
             response = self.client.get(self.detail_url, follow=True)
@@ -417,7 +456,7 @@ class TestAddonAdmin(TestCase):
         assert addon.guid in response.content.decode('utf-8')
 
         version_factory(addon=addon)
-        with self.assertNumQueries(23):
+        with self.assertNumQueries(24):
             # confirm it scales
             response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 200


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/13199

---

This patch adds new links in the admin, for example:

![Screen Shot 2020-03-17 at 16 55 18](https://user-images.githubusercontent.com/217628/76874899-19669300-6870-11ea-8adf-3613f65342a7.png)

It adds:

- a "listed" link when the add-on has at least one listed version
- an "unlisted" link when the add-on has at least one unlisted version
