### PR TITLE
Can reject a previously approved theme

### DIFF
--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -379,7 +379,8 @@ class TestReviewHelper(TestReviewHelperBase):
         # Themes reviewers get access to everything.
         self.request.user.groupuser_set.all().delete()
         self.grant_permission(self.request.user, 'Addons:ThemeReview')
-        expected = ['public', 'reject', 'reply', 'super', 'comment']
+        expected = ['public', 'reject', 'reject_multiple_versions',
+                    'reply', 'super', 'comment']
         assert list(self.get_review_actions(
             addon_status=amo.STATUS_APPROVED,
             file_status=amo.STATUS_AWAITING_REVIEW).keys()) == expected

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -4922,7 +4922,8 @@ class TestReview(ReviewBase):
         doc = pq(response.content)
 
         expected_actions_values = [
-            'public|', 'reject|', 'reply|', 'super|', 'comment|']
+            'public|', 'reject|', 'reject_multiple_versions|',
+            'reply|', 'super|', 'comment|']
         assert [
             act.attrib['data-value'] for act in
             doc('.data-toggle.review-actions-desc')] == expected_actions_values
@@ -4931,7 +4932,7 @@ class TestReview(ReviewBase):
 
         assert (
             doc('.data-toggle.review-comments')[0].attrib['data-value'] ==
-            'public|reject|reply|super|comment|')
+            'public|reject|reject_multiple_versions|reply|super|comment|')
         # we don't show files and tested with for any static theme actions
         assert (
             doc('.data-toggle.review-files')[0].attrib['data-value'] ==

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -386,6 +386,7 @@ class ReviewHelper(object):
                 is_appropriate_reviewer or
                 (acl.action_allowed_user(
                     request.user, amo.permissions.ADDONS_POST_REVIEW) and
+                 self.addon.type != amo.ADDON_STATICTHEME and
                  not is_admin_needed)
             )
 
@@ -467,7 +468,6 @@ class ReviewHelper(object):
                          'versions. The comments will be sent to the '
                          'developer.'),
             'available': (
-                self.addon.type != amo.ADDON_STATICTHEME and
                 addon_is_valid_and_version_is_listed and
                 can_reject_multiple
             ),


### PR DESCRIPTION
Fixes #13072 
This patch has been modified to allow reject a previously approved theme.


**Before**
![13072_before](https://user-images.githubusercontent.com/29684524/76845477-491e9680-6882-11ea-8d1e-6aadcceb2313.png)

**After**
![13072_after](https://user-images.githubusercontent.com/29684524/76845507-52a7fe80-6882-11ea-9d38-c7763c0e370c.png)
