### PR TITLE
expose the last version time before the filter was generated

### DIFF
--- a/src/olympia/blocklist/cron.py
+++ b/src/olympia/blocklist/cron.py
@@ -1,5 +1,6 @@
 import json
 import tempfile
+import time
 
 import waffle
 
@@ -21,12 +22,15 @@ def upload_mlbf_to_kinto():
         KINTO_BUCKET, KINTO_COLLECTION_MLBF, kinto_sign_off_needed=False)
     stats = {}
     key_format = get_mlbf_key_format()
+    last_version_time = int(time.time() * 1000)
     bloomfilter = generate_mlbf(stats, key_format)
     with tempfile.NamedTemporaryFile() as filter_file:
         bloomfilter.tofile(filter_file)
         filter_file.seek(0)
-        # TODO: sign filter blob
-        data = {'key_format': key_format}
+        data = {
+            'key_format': key_format,
+            'last_version_time': last_version_time,
+        }
         attachment = ('filter.bin', filter_file, 'application/octet-stream')
         server.publish_attachment(data, attachment)
     server.complete_session()

--- a/src/olympia/blocklist/cron.py
+++ b/src/olympia/blocklist/cron.py
@@ -22,6 +22,13 @@ def upload_mlbf_to_kinto():
         KINTO_BUCKET, KINTO_COLLECTION_MLBF, kinto_sign_off_needed=False)
     stats = {}
     key_format = get_mlbf_key_format()
+    # This timestamp represents the point in time when all previous addon
+    # guid + versions and blocks were used to generate the bloomfilter.
+    # An add-on version/file from before this time will definitely be accounted
+    # for in the bloomfilter so we can reliably assert if it's blocked or not.
+    # An add-on version/file from after this time can't be reliably asserted -
+    # there may be false positives or false negatives.
+    # https://github.com/mozilla/addons-server/issues/13695
     generation_time = int(time.time() * 1000)
     bloomfilter = generate_mlbf(stats, key_format)
     with tempfile.NamedTemporaryFile() as filter_file:

--- a/src/olympia/blocklist/cron.py
+++ b/src/olympia/blocklist/cron.py
@@ -22,14 +22,14 @@ def upload_mlbf_to_kinto():
         KINTO_BUCKET, KINTO_COLLECTION_MLBF, kinto_sign_off_needed=False)
     stats = {}
     key_format = get_mlbf_key_format()
-    last_version_time = int(time.time() * 1000)
+    generation_time = int(time.time() * 1000)
     bloomfilter = generate_mlbf(stats, key_format)
     with tempfile.NamedTemporaryFile() as filter_file:
         bloomfilter.tofile(filter_file)
         filter_file.seek(0)
         data = {
             'key_format': key_format,
-            'last_version_time': last_version_time,
+            'generation_time': generation_time,
         }
         attachment = ('filter.bin', filter_file, 'application/octet-stream')
         server.publish_attachment(data, attachment)

--- a/src/olympia/blocklist/tests/test_cron.py
+++ b/src/olympia/blocklist/tests/test_cron.py
@@ -28,7 +28,7 @@ def test_upload_mlbf_to_kinto(publish_mock, get_mlbf_key_format_mock):
 
     publish_mock.assert_called_with(
         {'key_format': key_format,
-         'last_version_time':
+         'generation_time':
             datetime.datetime(2020, 1, 1, 12, 34, 56).timestamp() * 1000},
         ('filter.bin', mock.ANY, 'application/octet-stream'))
 

--- a/src/olympia/blocklist/tests/test_cron.py
+++ b/src/olympia/blocklist/tests/test_cron.py
@@ -1,6 +1,8 @@
+import datetime
 from unittest import mock
 
 import pytest
+from freezegun import freeze_time
 from waffle.testutils import override_switch
 
 from olympia.amo.tests import addon_factory, user_factory
@@ -11,6 +13,7 @@ from olympia.lib.kinto import KintoServer
 
 
 @pytest.mark.django_db
+@freeze_time('2020-01-01 12:34:56')
 @override_switch('blocklist_mlbf_submit', active=True)
 @mock.patch('olympia.blocklist.cron.get_mlbf_key_format')
 @mock.patch.object(KintoServer, 'publish_attachment')
@@ -24,7 +27,9 @@ def test_upload_mlbf_to_kinto(publish_mock, get_mlbf_key_format_mock):
     upload_mlbf_to_kinto()
 
     publish_mock.assert_called_with(
-        {'key_format': key_format},
+        {'key_format': key_format,
+         'last_version_time':
+            datetime.datetime(2020, 1, 1, 12, 34, 56).timestamp() * 1000},
         ('filter.bin', mock.ANY, 'application/octet-stream'))
 
 


### PR DESCRIPTION
fixes #13695 

@Rob--W the field is called `last_version_time` now because its not strictly connected to signing - though obviously a version can't be signed before it's been created.  (alternate names welcome)