### PR TITLE
Only generate new MLBF in cron if new/changed Blocks

### DIFF
--- a/src/olympia/blocklist/tests/test_cron.py
+++ b/src/olympia/blocklist/tests/test_cron.py
@@ -1,46 +1,72 @@
 import datetime
 from unittest import mock
 
-import pytest
 from freezegun import freeze_time
 from waffle.testutils import override_switch
 
-from olympia.amo.tests import addon_factory, user_factory
-from olympia.blocklist.cron import upload_mlbf_to_kinto
+from olympia.amo.tests import addon_factory, TestCase, user_factory
+from olympia.blocklist.cron import MLBF_TIME_CONFIG_KEY, upload_mlbf_to_kinto
 from olympia.blocklist.mlbf import get_mlbf_key_format
 from olympia.blocklist.models import Block
 from olympia.lib.kinto import KintoServer
+from olympia.zadmin.models import get_config, set_config
 
 
-@pytest.mark.django_db
-@freeze_time('2020-01-01 12:34:56')
-@override_switch('blocklist_mlbf_submit', active=True)
-@mock.patch('olympia.blocklist.cron.get_mlbf_key_format')
-@mock.patch.object(KintoServer, 'publish_attachment')
-def test_upload_mlbf_to_kinto(publish_mock, get_mlbf_key_format_mock):
-    key_format = get_mlbf_key_format()
-    get_mlbf_key_format_mock.return_value = key_format
-    addon_factory()
-    Block.objects.create(
-        addon=addon_factory(),
-        updated_by=user_factory())
-    upload_mlbf_to_kinto()
+class TestUploadToKinto(TestCase):
+    def setUp(self):
+        addon_factory()
+        self.block = Block.objects.create(
+            addon=addon_factory(),
+            updated_by=user_factory())
 
-    publish_mock.assert_called_with(
-        {'key_format': key_format,
-         'generation_time':
-            datetime.datetime(2020, 1, 1, 12, 34, 56).timestamp() * 1000},
-        ('filter.bin', mock.ANY, 'application/octet-stream'))
+    @freeze_time('2020-01-01 12:34:56')
+    @override_switch('blocklist_mlbf_submit', active=True)
+    @mock.patch('olympia.blocklist.cron.get_mlbf_key_format')
+    @mock.patch.object(KintoServer, 'publish_attachment')
+    def test_upload_mlbf_to_kinto(self, publish_mock, get_mlbf_key_mock):
+        key_format = get_mlbf_key_format()
+        get_mlbf_key_mock.return_value = key_format
 
+        upload_mlbf_to_kinto()
 
-@pytest.mark.django_db
-@override_switch('blocklist_mlbf_submit', active=False)
-@mock.patch.object(KintoServer, 'publish_attachment')
-def test_waffle_off_disables_publishing(publish_mock):
-    addon_factory()
-    Block.objects.create(
-        addon=addon_factory(),
-        updated_by=user_factory())
-    upload_mlbf_to_kinto()
+        publish_mock.assert_called_with(
+            {'key_format': key_format,
+             'generation_time':
+                datetime.datetime(2020, 1, 1, 12, 34, 56).timestamp() * 1000},
+            ('filter.bin', mock.ANY, 'application/octet-stream'))
+        assert (
+            get_config(MLBF_TIME_CONFIG_KEY, json_value=True) ==
+            int(datetime.datetime(2020, 1, 1, 12, 34, 56).timestamp() * 1000))
 
-    publish_mock.assert_not_called()
+    @override_switch('blocklist_mlbf_submit', active=False)
+    @mock.patch.object(KintoServer, 'publish_attachment')
+    def test_waffle_off_disables_publishing(self, publish_mock):
+        upload_mlbf_to_kinto()
+
+        publish_mock.assert_not_called()
+        assert not get_config(MLBF_TIME_CONFIG_KEY)
+
+    @freeze_time('2020-01-01 12:34:56')
+    @override_switch('blocklist_mlbf_submit', active=True)
+    @mock.patch.object(KintoServer, 'publish_attachment')
+    def test_no_need_for_new_mlbf(self, publish_mock):
+        # This was the last time the mlbf was generated
+        last_time = int(
+            datetime.datetime(2020, 1, 1, 12, 34, 1).timestamp() * 1000)
+        # And the Block was modified just before so would be included
+        self.block.update(modified=datetime.datetime(2020, 1, 1, 12, 34, 0))
+        set_config(MLBF_TIME_CONFIG_KEY, last_time, json_value=True)
+        upload_mlbf_to_kinto()
+        # So no need for a new bloomfilter
+        publish_mock.assert_not_called()
+
+        # But if we add a new Block a new filter is needed
+        addon_factory()
+        Block.objects.create(
+            addon=addon_factory(),
+            updated_by=user_factory())
+        upload_mlbf_to_kinto()
+        publish_mock.assert_called_once()
+        assert (
+            get_config(MLBF_TIME_CONFIG_KEY, json_value=True) ==
+            int(datetime.datetime(2020, 1, 1, 12, 34, 56).timestamp() * 1000))

--- a/src/olympia/zadmin/models.py
+++ b/src/olympia/zadmin/models.py
@@ -22,14 +22,15 @@ class Config(models.Model):
             return {}
 
 
-def get_config(conf):
+def get_config(conf, default=None, *, json_value=False):
     try:
-        return Config.objects.get(key=conf).value
+        config = Config.objects.get(key=conf)
+        return config.value if not json_value else config.json
     except Config.DoesNotExist:
-        return None
+        return default
 
 
-def set_config(conf, value):
+def set_config(conf, value, *, json_value=False):
     cf, created = Config.objects.get_or_create(key=conf)
-    cf.value = value
+    cf.value = (value if not json_value else json.dumps(value))
     cf.save()


### PR DESCRIPTION
fixes #13694 by only generating and uploading a new mlbf if the latest modified time of the block instances is later than the time we last generated one.