### PR TITLE
Fix filter with more than one author ID (scanner results)

### DIFF
--- a/src/olympia/scanners/admin.py
+++ b/src/olympia/scanners/admin.py
@@ -334,7 +334,7 @@ class AbstractScannerResultAdminMixin(admin.ModelAdmin):
         return format_html(
             '<ul>{}</ul>'
             '<br>'
-            '[<a href="{}?authors={}">Other add-ons by these authors</a>]',
+            '[<a href="{}?authors__in={}">Other add-ons by these authors</a>]',
             contents,
             urljoin(
                 settings.EXTERNAL_SITE_URL,

--- a/src/olympia/scanners/tests/test_admin.py
+++ b/src/olympia/scanners/tests/test_admin.py
@@ -1166,7 +1166,7 @@ class TestScannerQueryResultAdmin(TestCase):
         )
         assert result == expected
         assert 'Other add-ons' in link_to_addons[0]
-        expected_querystring = '?authors={}'.format(
+        expected_querystring = '?authors__in={}'.format(
             ','.join(str(author.pk) for author in addon.authors.all())
         )
         assert expected_querystring in link_to_addons[1]


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/13767

---

It seems to work locally and I tried in stage too (by manually editing the URL).