### PR TITLE
implemented issue #8262 as required

### DIFF
--- a/static/css/zamboni/reviewers.less
+++ b/static/css/zamboni/reviewers.less
@@ -1119,6 +1119,10 @@ h2.addon {
             border: 1px solid #AFBDD3;
             height: 200px;
         }
+        textarea:empty {
+            border: 1px solid #AFBDD3;
+            height: 20px;
+        }
         .whiteboard-actions {
             text-align: right;
         }

--- a/static/js/zamboni/reviewers.js
+++ b/static/js/zamboni/reviewers.js
@@ -58,6 +58,37 @@
         window.location.hash = "id=" + $("#addon, #persona").attr("data-id");
       });
     }
+
+    // Toggle expansion for whiteboard
+    $("#id_whiteboard-public").click(function(){
+        $("#id_whiteboard-public").css("height", "200px");
+    });
+
+    // Toggle expansion for whiteboard private
+    $("#id_whiteboard-private").click(function(){
+        $("#id_whiteboard-private").css("height", "200px");
+    });
+
+    // When clicking on areas other than whiteboard/whiteboard private on the page
+    $('html').click(function(e) {
+        // When whiteboard is clicked
+        if (!$(e.target).is("#id_whiteboard-public")) {
+            console.log("Non-id_whiteboard-public clicked");
+            // When whiteboard is still empty, collapse
+            if (!$("#id_whiteboard-public").val()) {
+                $("#id_whiteboard-public").css("height", "20px");
+            }
+        }
+        // When whiteboard private is clicked
+        if (!$(e.target).is("#id_whiteboard-private")) {
+            console.log("Non-id_whiteboard-private clicked");
+            // When whiteboard private is still empty, collapse
+            if (!$("#id_whiteboard-private").val()) {
+                $("#id_whiteboard-private").css("height", "20px");
+            }
+        }
+    });
+
 })();
 
 


### PR DESCRIPTION
Fixes #8262 

Here is the fix process and the files that are changed:

1. static/css/zamboni/reviewers.less
Added textarea:empty for default empty style

2. static/js/zamboni/reviewers.js
Added click listener for whiteboard and private whiteboard in order to have expanding functionalities for these two boards. Also added click listener for elements other than the two boards in order to collapse back.

Here is the fixed screenshots:

1. When whiteboards are empty, whiteboards are collapsed to height of one line:
<img width="1601" alt="Screen Shot 2020-03-19 at 7 20 28 PM" src="https://user-images.githubusercontent.com/46657851/77123601-ef9ba080-6a16-11ea-8d3f-7ef28a536631.png">

2. When an empty whiteboard is clicked, it will be expanded to the original height. If no contents are added and clicked on somewhere else, the whiteboard will be collapsed again:
<img width="1601" alt="Screen Shot 2020-03-19 at 7 20 41 PM" src="https://user-images.githubusercontent.com/46657851/77123708-473a0c00-6a17-11ea-848a-58a08d52b70b.png">


3. When whiteboards are with content, whiteboards are expanded to the original height:
<img width="1601" alt="Screen Shot 2020-03-19 at 7 21 17 PM" src="https://user-images.githubusercontent.com/46657851/77123663-27a2e380-6a17-11ea-9f4a-2164c6fa028f.png">

