### PR TITLE
Using html.unescape() instead of HTMLParser.unescape()

### DIFF
--- a/src/olympia/activity/utils.py
+++ b/src/olympia/activity/utils.py
@@ -2,7 +2,7 @@ import re
 
 from datetime import datetime, timedelta
 from email.utils import formataddr
-from html.parser import HTMLParser
+from html import unescape
 
 from django.conf import settings
 from django.forms import ValidationError
@@ -242,8 +242,7 @@ def notify_about_activity_log(addon, version, note, perm_setting=None,
         with translation.override(settings.LANGUAGE_CODE):
             comments = '%s' % amo.LOG_BY_ID[note.action].short
     else:
-        htmlparser = HTMLParser()
-        comments = htmlparser.unescape(comments)
+        comments = unescape(comments)
 
     # Collect add-on authors (excl. the person who sent the email.) and build
     # the context for them.


### PR DESCRIPTION
Fixes #13689 

Using `html.unescape()` instead of `HTMLParser.unescape()`.
The unescape method is deprecated and will be removed in 3.5

**Before**
![Screenshot from 2020-03-23 16-48-23](https://user-images.githubusercontent.com/29684524/77295997-35fc4280-6d2a-11ea-8f69-4170cc7bf362.png)

**After**
Not happened related warning