### PR TITLE
Add regex parsing to import_blocklist

### DIFF
--- a/src/olympia/blocklist/tasks.py
+++ b/src/olympia/blocklist/tasks.py
@@ -75,21 +75,20 @@ def import_block_from_blocklist(record):
         # need to escape the {} brackets or mysql chokes.
         guid_regexp = bracket_open_regex.sub(r'\{', guid[1:-1])
         guid_regexp = bracket_close_regex.sub(r'\}', guid_regexp)
-        log.debug(
-            'Kinto %s: Attempting to create Blocks for addons matching [%s]',
-            kinto_id, guid_regexp)
         # we're going to try to split the regex into a list for efficiency.
         guids_list = split_regex_to_list(guid_regexp)
         if guids_list:
             log.debug(
-                'Kinto %s: Broke down regex into list of guids [%s]',
+                'Kinto %s: Broke down regex into list; '
+                'attempting to create Blocks for guids in %s',
                 kinto_id, guids_list)
             addons_guids_qs = Addon.unfiltered.using(using_db).filter(
                 guid__in=guids_list).values_list('guid', flat=True)
         else:
             log.debug(
-                'Kinto %s: Unable to break down regex into list of guids',
-                kinto_id)
+                'Kinto %s: Unable to break down regex into list; '
+                'attempting to create Blocks for guids matching [%s]',
+                kinto_id, guid_regexp)
             addons_guids_qs = Addon.unfiltered.using(using_db).filter(
                 guid__regex=guid_regexp).values_list('guid', flat=True)
         # We need to mark this id in a way so we know its from a

--- a/src/olympia/blocklist/tasks.py
+++ b/src/olympia/blocklist/tasks.py
@@ -13,7 +13,7 @@ from olympia.amo.decorators import use_primary_db
 from olympia.users.utils import get_task_user
 
 from .models import Block, BlocklistSubmission, KintoImport
-from .utils import block_activity_log_save
+from .utils import block_activity_log_save, split_regex_to_list
 
 
 log = olympia.core.logger.getLogger('z.amo.blocklist')
@@ -62,8 +62,8 @@ def import_block_from_blocklist(record):
     block_kw = {
         'min_version': version_range.get('minVersion', '0'),
         'max_version': version_range.get('maxVersion', '*'),
-        'url': record.get('details', {}).get('bug'),
-        'reason': record.get('details', {}).get('why', ''),
+        'url': record.get('details', {}).get('bug') or '',
+        'reason': record.get('details', {}).get('why') or '',
         'kinto_id': kinto_id,
         'include_in_legacy': True,
         'updated_by': get_task_user(),
@@ -78,8 +78,20 @@ def import_block_from_blocklist(record):
         log.debug(
             'Kinto %s: Attempting to create Blocks for addons matching [%s]',
             kinto_id, guid_regexp)
-        addons_guids_qs = Addon.unfiltered.using(using_db).filter(
-            guid__regex=guid_regexp).values_list('guid', flat=True)
+        # we're going to try to split the regex into a list for efficiency.
+        guids_list = split_regex_to_list(guid_regexp)
+        if guids_list:
+            log.debug(
+                'Kinto %s: Broke down regex into list of guids [%s]',
+                kinto_id, guids_list)
+            addons_guids_qs = Addon.unfiltered.using(using_db).filter(
+                guid__in=guids_list).values_list('guid', flat=True)
+        else:
+            log.debug(
+                'Kinto %s: Unable to break down regex into list of guids',
+                kinto_id)
+            addons_guids_qs = Addon.unfiltered.using(using_db).filter(
+                guid__regex=guid_regexp).values_list('guid', flat=True)
         # We need to mark this id in a way so we know its from a
         # regex guid - otherwise we might accidentally overwrite it.
         block_kw['kinto_id'] = '*' + block_kw['kinto_id']

--- a/src/olympia/blocklist/tests/blocklists/blocklist.json
+++ b/src/olympia/blocklist/tests/blocklists/blocklist.json
@@ -139,6 +139,45 @@
       ],
       "id": "9085fdba-8598-46a9-b9fd-4e7343a15c62",
       "last_modified": 1490653926191
+    },
+    {
+      "guid": "/(__TEMPLATE__APPLICATION__@puua-mapa\\.com)|(\\{84aebb36-1433-4082-b7ec-29b790d12c17\\})/",
+      "prefs": [],
+      "schema": 1523216496621,
+      "details": {
+        "bug": null,
+        "why": "Those add-ons do not provide a real functionality for users, other than silently tracking browsing behavior.",
+        "name": "Tracking Add-ons (harmful)"
+      },
+      "enabled": true,
+      "versionRange": [
+        {
+          "severity": 3,
+          "maxVersion": "*",
+          "minVersion": "0"
+        }
+      ],
+      "id": "36f97298-8bef-4372-a548-eb829413bee9",
+      "last_modified": 1523286321447
+    },
+    {
+      "guid": "/{0c9970a2-6874-493b-a486-2295cfe251c2}|{fc0d52bd-3c50-4139-9109-7df6c1115a9d}/",
+      "prefs": [],
+      "schema": 1519766961483,
+      "details": {
+        "why": "This malicious add-on claims to be a Firefox \"helper\" or \"updater\" or similar.",
+        "name": "FF updater (malware)"
+      },
+      "enabled": true,
+      "versionRange": [
+        {
+          "severity": 3,
+          "maxVersion": "*",
+          "minVersion": "0"
+        }
+      ],
+      "id": "48b14881-5f6b-4e48-afc5-3d9a7fae26a3",
+      "last_modified": 1519826648080
     }
   ]
 }

--- a/src/olympia/blocklist/tests/test_utils.py
+++ b/src/olympia/blocklist/tests/test_utils.py
@@ -4,7 +4,8 @@ import pytest
 
 from olympia.amo.tests import user_factory
 from olympia.blocklist.models import Block
-from olympia.blocklist.utils import legacy_delete_blocks, legacy_publish_blocks
+from olympia.blocklist.utils import (
+    legacy_delete_blocks, legacy_publish_blocks, split_regex_to_list)
 from olympia.lib.kinto import KintoServer
 
 
@@ -84,3 +85,37 @@ def test_legacy_delete_blocks(delete_record_mock):
     assert delete_record_mock.call_args_list == [mock.call('legacy')]
     assert block.kinto_id == ''
     assert block_regex.kinto_id == ''  # cleared anyway
+
+
+def test_split_regex_to_list():
+    regex_list = (
+        '^('
+        '(\\{df59cc82-3d49-4d2c-8069-70a7d71d387a\\})|'
+        '(\\{ef78ae03-b232-46c0-8715-d562db1ace23\\})|'
+        '(\\{98f556db-837c-489e-9c45-a06a6997492c\\})'
+        ')$'
+    )
+    assert split_regex_to_list(regex_list) == [
+        '{df59cc82-3d49-4d2c-8069-70a7d71d387a}',
+        '{ef78ae03-b232-46c0-8715-d562db1ace23}',
+        '{98f556db-837c-489e-9c45-a06a6997492c}',
+    ]
+
+    regex_no_outer_brackets_list = (
+        '^'
+        '(\\{df59cc82-3d49-4d2c-8069-70a7d71d387a\\})|'
+        '(\\{ef78ae03-b232-46c0-8715-d562db1ace23\\})|'
+        '(\\{98f556db-837c-489e-9c45-a06a6997492c\\})'
+        '$'
+    )
+    assert split_regex_to_list(regex_no_outer_brackets_list) == [
+        '{df59cc82-3d49-4d2c-8069-70a7d71d387a}',
+        '{ef78ae03-b232-46c0-8715-d562db1ace23}',
+        '{98f556db-837c-489e-9c45-a06a6997492c}',
+    ]
+
+    real_regex = '^pink@.*\\.info$'
+    assert split_regex_to_list(real_regex) is None
+
+    real_regex_brackets = '^(pink@.*\\.info)$'
+    assert split_regex_to_list(real_regex_brackets) is None


### PR DESCRIPTION
fixes the `import_blocklist` command choking on complex regular expressions by expanding them to lists of guids instead.  Only works on well-formed lists-as-regexs that start with a `^`, end with a `$`, and the guids themselves are wrapped in `(` `)`.