### PR TITLE
and empty block.url should still be empty with wrap_outgoing_links=True

### DIFF
--- a/src/olympia/blocklist/serializers.py
+++ b/src/olympia/blocklist/serializers.py
@@ -20,7 +20,7 @@ class BlockSerializer(serializers.ModelSerializer):
 
         if ('request' in self.context and
                 'wrap_outgoing_links' in self.context['request'].GET and
-                'url' in data):
+                data.get('url')):
             data['url'] = get_outgoing_url(data['url'])
 
         return data

--- a/src/olympia/blocklist/tests/test_serializers.py
+++ b/src/olympia/blocklist/tests/test_serializers.py
@@ -41,3 +41,8 @@ class TestBlockSerializer(TestCase):
             instance=self.block, context={'request': request})
 
         assert serializer.data['url'] == get_outgoing_url(self.block.url)
+
+        self.block.update(url='')
+        serializer = BlockSerializer(
+            instance=self.block, context={'request': request})
+        assert serializer.data['url'] == ''


### PR DESCRIPTION
fixes #13812 