### PR TITLE
Fix the startup order of nginx and frontend containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,13 @@ services:
       - ./storage/guarded-addons:/srv/user-media/guarded-addons
     ports:
       - "80:80"
+    networks:
+      default:
+        aliases:
+          - olympia.test
+    depends_on:
+      - web
+      - addons-frontend
 
   memcached:
     image: memcached:1.4
@@ -100,5 +107,3 @@ services:
       - "3000:3000"
       - "3001:3001"
     command: yarn amo
-    links:
-      - "nginx:olympia.test"


### PR DESCRIPTION
Fixes #10856
The dependency expressed by `links` makes nginx container startup first, then fail due to "not found upstream frontend..."). I tried to use `networks` and `depends_on` to replace `links` to make `addons-frontend` start first. It looks like work well on my machine. Maybe we do not need [a script to check if the port 3000 is ready](https://github.com/mozilla/addons-server/issues/10856#issuecomment-471931960), but I am not very sure.