### PR TITLE
Use `Addon.unfiltered` manager in abuse report querysets

### DIFF
--- a/src/olympia/abuse/admin.py
+++ b/src/olympia/abuse/admin.py
@@ -323,7 +323,7 @@ class AbuseReportAdmin(CommaSearchInAdminMixin, admin.ModelAdmin):
         # the other transforms).
         return qs.prefetch_related(
             Prefetch(
-                'addon', queryset=Addon.objects.all().only_translations()),
+                'addon', queryset=Addon.unfiltered.all().only_translations()),
         )
 
     def get_fieldsets(self, request, obj=None):

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -4837,6 +4837,14 @@ class TestReview(ReviewBase):
 
         assert doc('.abuse_reports').text().split('\n') == expected
 
+        self.addon.delete()
+        self.url = reverse('reviewers.review', args=[self.addon.id])
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        assert doc('.abuse_reports')
+        assert doc('.abuse_reports').text().split('\n') == expected
+
     def test_abuse_reports_unlisted_addon(self):
         user = UserProfile.objects.get(email='reviewer@mozilla.com')
         self.grant_permission(user, 'Addons:ReviewUnlisted')
@@ -5217,6 +5225,13 @@ class TestAbuseReportsView(ReviewerTest):
             'Et mël mazim ludus.',
         ]
 
+        assert doc('.abuse_reports').text().split('\n') == expected
+
+        self.addon.delete()
+        self.url = reverse('reviewers.abuse_reports', args=[self.addon.id])
+        assert response.status_code == 200
+        doc = pq(response.content)
+        assert len(doc('.abuse_reports')) == 1
         assert doc('.abuse_reports').text().split('\n') == expected
 
     def test_queries(self):

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -755,7 +755,8 @@ def review(request, addon, channel=None):
                 # a ton of potentially duplicate queries with all the useless
                 # Addon transforms.
                 Prefetch(
-                    'addon', queryset=Addon.objects.all().only_translations())
+                    'addon',
+                    queryset=Addon.unfiltered.all().only_translations())
             )
             .order_by('-created')), 5).page(1)
     user_ratings = Paginator(
@@ -1045,7 +1046,7 @@ def abuse_reports(request, addon):
         Q(addon=addon) | Q(user__in=developers)
     ).select_related('user').prefetch_related(
         # See review(): we only need the add-on objects and their translations.
-        Prefetch('addon', queryset=Addon.objects.all().only_translations()),
+        Prefetch('addon', queryset=Addon.unfiltered.all().only_translations()),
     ).order_by('-created')
     reports = amo.utils.paginate(request, reports)
     data = context(addon=addon, reports=reports, version=addon.current_version)


### PR DESCRIPTION
Fixes #12742 

I changed code for showing deleted addon.

path) Admin - abuse - abuse report
**Before**
![12742_before](https://user-images.githubusercontent.com/29684524/78133575-9e010600-7459-11ea-8e51-ec6f809c045a.png)

**After**
![12742_after](https://user-images.githubusercontent.com/29684524/78133580-a35e5080-7459-11ea-850b-fe457ebad806.png)