### PR TITLE
Update collection name to reflect name chosen by kinto devs

### DIFF
--- a/src/olympia/blocklist/utils.py
+++ b/src/olympia/blocklist/utils.py
@@ -10,7 +10,7 @@ log = olympia.core.logger.getLogger('z.amo.blocklist')
 
 KINTO_BUCKET = 'staging'
 KINTO_COLLECTION_LEGACY = 'addons'
-KINTO_COLLECTION_MLBF = 'addons-mlbf'
+KINTO_COLLECTION_MLBF = 'addons-bloomfilters'
 
 
 def add_version_log_for_blocked_versions(obj, al):


### PR DESCRIPTION
It was still using the previous name before it was updated.
Record should end up in https://settings.stage.mozaws.net/v1/buckets/blocklists/collections/addons-bloomfilters/records