### PR TITLE
Add new urls to redirect to file viewer

### DIFF
--- a/src/olympia/files/tests/test_views.py
+++ b/src/olympia/files/tests/test_views.py
@@ -783,6 +783,19 @@ class TestBrowseRedirect(TestCase):
             reverse('files.list', args=[self.version.current_file.id]),
         )
 
+    def test_redirects_to_file_viewer_with_file_query_param(self):
+        file = 'some/file.js'
+        response = self.client.get(self.browse_redirect_url + f'?file={file}')
+
+        self.assert3xx(
+            response,
+            reverse('files.list', args=[
+                self.version.current_file.id,
+                'file',
+                file,
+            ]),
+        )
+
     def test_returns_404_when_version_is_not_found(self):
         browse_redirect_url = reverse('files.browse_redirect', args=[123456])
 
@@ -803,7 +816,7 @@ class TestCompareRedirect(TestCase):
             args=[self.base_version.pk, self.head_version.pk],
         )
 
-    def test_redirects_to_file_viewer_with_file_id(self):
+    def test_redirects_to_file_viewer_with_file_ids(self):
         response = self.client.get(self.compare_redirect_url)
 
         self.assert3xx(
@@ -811,6 +824,20 @@ class TestCompareRedirect(TestCase):
             reverse('files.compare', args=[
                 self.base_version.current_file.id,
                 self.head_version.current_file.id,
+            ]),
+        )
+
+    def test_redirects_to_file_viewer_with_file_query_param(self):
+        file = 'some/file.js'
+        response = self.client.get(self.compare_redirect_url + f'?file={file}')
+
+        self.assert3xx(
+            response,
+            reverse('files.compare', args=[
+                self.base_version.current_file.id,
+                self.head_version.current_file.id,
+                'file',
+                file,
             ]),
         )
 

--- a/src/olympia/files/tests/test_views.py
+++ b/src/olympia/files/tests/test_views.py
@@ -16,7 +16,7 @@ from pyquery import PyQuery as pq
 
 from olympia import amo
 from olympia.addons.models import Addon
-from olympia.amo.tests import TestCase, version_factory
+from olympia.amo.tests import TestCase, version_factory, addon_factory
 from olympia.amo.urlresolvers import reverse
 from olympia.files.file_viewer import DiffHelper, FileViewer
 from olympia.files.models import File
@@ -764,3 +764,72 @@ class TestServeFileUpload(UploadTest, TestCase):
         resp = self.client.get(self.upload.get_authenticated_download_url())
 
         assert resp.status_code == 410
+
+
+class TestBrowseRedirect(TestCase):
+    def setUp(self):
+        super(TestBrowseRedirect, self).setUp()
+
+        self.version = version_factory(addon=addon_factory())
+        self.browse_redirect_url = reverse(
+            'files.browse_redirect', args=[self.version.pk]
+        )
+
+    def test_redirects_to_file_viewer_with_file_id(self):
+        response = self.client.get(self.browse_redirect_url)
+
+        self.assert3xx(
+            response,
+            reverse('files.list', args=[self.version.current_file.id]),
+        )
+
+    def test_returns_404_when_version_is_not_found(self):
+        browse_redirect_url = reverse('files.browse_redirect', args=[123456])
+
+        response = self.client.get(browse_redirect_url)
+
+        assert response.status_code == 404
+
+
+class TestCompareRedirect(TestCase):
+    def setUp(self):
+        super(TestCompareRedirect, self).setUp()
+
+        addon = addon_factory()
+        self.base_version = version_factory(addon=addon)
+        self.head_version = version_factory(addon=addon)
+        self.compare_redirect_url = reverse(
+            'files.compare_redirect',
+            args=[self.base_version.pk, self.head_version.pk],
+        )
+
+    def test_redirects_to_file_viewer_with_file_id(self):
+        response = self.client.get(self.compare_redirect_url)
+
+        self.assert3xx(
+            response,
+            reverse('files.compare', args=[
+                self.base_version.current_file.id,
+                self.head_version.current_file.id,
+            ]),
+        )
+
+    def test_returns_404_when_head_version_is_not_found(self):
+        compare_redirect_url = reverse('files.compare_redirect', args=[
+            self.base_version.pk,
+            123456,
+        ])
+
+        response = self.client.get(compare_redirect_url)
+
+        assert response.status_code == 404
+
+    def test_returns_404_when_base_version_is_not_found(self):
+        compare_redirect_url = reverse('files.compare_redirect', args=[
+            123456,
+            self.base_version.pk,
+        ])
+
+        response = self.client.get(compare_redirect_url)
+
+        assert response.status_code == 404

--- a/src/olympia/files/urls.py
+++ b/src/olympia/files/urls.py
@@ -24,6 +24,10 @@ urlpatterns = [
     url(r'^browse/(?P<file_id>\d+)/', include(file_patterns)),
     url(r'^compare/(?P<one_id>\d+)\.{3}(?P<two_id>\d+)/',
         include(compare_patterns)),
+    url(r'^browse-redirect/(?P<version_id>\d+)/', views.browse_redirect,
+        name='files.browse_redirect'),
+    url(r'^compare-redirect/(?P<base_id>\d+)\.{3}(?P<head_id>\d+)/',
+        views.compare_redirect, name='files.compare_redirect'),
 ]
 
 # This set of URL patterns is not included under `/files/` in

--- a/src/olympia/files/views.py
+++ b/src/olympia/files/views.py
@@ -125,17 +125,26 @@ def browse(request, viewer, key=None, type='file'):
 
 def browse_redirect(request, version_id):
     version = shortcuts.get_object_or_404(Version, pk=version_id)
-    url = reverse('files.list', args=[version.current_file.id])
+    url_args = [version.current_file.id]
+
+    file = request.GET.get('file')
+    if file:
+        url_args.extend(['file', file])
+    url = reverse('files.list', args=url_args)
+
     return http.HttpResponseRedirect(url)
 
 
 def compare_redirect(request, base_id, head_id):
     base_version = shortcuts.get_object_or_404(Version, pk=base_id)
     head_version = shortcuts.get_object_or_404(Version, pk=head_id)
-    url = reverse('files.compare', args=[
-        base_version.current_file.id,
-        head_version.current_file.id,
-    ])
+    url_args = [base_version.current_file.id, head_version.current_file.id]
+
+    file = request.GET.get('file')
+    if file:
+        url_args.extend(['file', file])
+
+    url = reverse('files.compare', args=url_args)
     return http.HttpResponseRedirect(url)
 
 

--- a/src/olympia/files/views.py
+++ b/src/olympia/files/views.py
@@ -21,6 +21,7 @@ from olympia.files.decorators import (
     compare_file_view, etag, file_view, file_view_token, last_modified)
 from olympia.files.file_viewer import extract_file
 from olympia.lib.cache import Message, Token
+from olympia.versions.models import Version
 
 from .models import FileUpload
 from . import forms
@@ -120,6 +121,22 @@ def browse(request, viewer, key=None, type='file'):
 
     tmpl = 'files/content.html' if type == 'fragment' else 'files/viewer.html'
     return render(request, tmpl, data)
+
+
+def browse_redirect(request, version_id):
+    version = shortcuts.get_object_or_404(Version, pk=version_id)
+    url = reverse('files.list', args=[version.current_file.id])
+    return http.HttpResponseRedirect(url)
+
+
+def compare_redirect(request, base_id, head_id):
+    base_version = shortcuts.get_object_or_404(Version, pk=base_id)
+    head_version = shortcuts.get_object_or_404(Version, pk=head_id)
+    url = reverse('files.compare', args=[
+        base_version.current_file.id,
+        head_version.current_file.id,
+    ])
+    return http.HttpResponseRedirect(url)
 
 
 @never_cache


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/13634

---

### Example 1

```
$  curl -I http://olympia.test/en-US/firefox/files/browse-redirect/104/
HTTP/1.1 302 Found
Server: nginx/1.17.3
Date: Thu, 02 Apr 2020 15:37:19 GMT
Content-Type: text/html; charset=utf-8
Content-Length: 0
Connection: keep-alive
Location: /en-US/firefox/files/browse/103/
```

- `104` is a version ID in the URL
- `103` is the file ID in the `Location` URL

### Example 2

```
$ curl -I http://olympia.test/en-US/firefox/files/compare-redirect/103...104/
HTTP/1.1 302 Found
Server: nginx/1.17.3
Date: Thu, 02 Apr 2020 15:37:40 GMT
Content-Type: text/html; charset=utf-8
Content-Length: 0
Connection: keep-alive
Location: /en-US/firefox/files/compare/102...103/
```

- `103` and `104` are version IDs in the URL
- `102` and `103` are file IDs in the `Location` URL

### Example 3

```
$ curl -I 'http://olympia.test/en-US/firefox/files/compare-redirect/103...104/?file=foo/bar/baz.js'
HTTP/1.1 302 Found
Server: nginx/1.17.3
Date: Thu, 02 Apr 2020 16:19:31 GMT
Content-Type: text/html; charset=utf-8
Content-Length: 0
Connection: keep-alive
Location: /en-US/firefox/files/compare/102...103/file/foo/bar/baz.js
```