### PR TITLE
Handle long blocklistsubmission urls via fxa

### DIFF
--- a/src/olympia/blocklist/admin.py
+++ b/src/olympia/blocklist/admin.py
@@ -101,10 +101,10 @@ class BlockAdminAddMixin():
 
     def add_from_addon_pk_view(self, request, pk, **kwargs):
         addon = get_object_or_404(Addon.unfiltered, pk=pk or kwargs.get('pk'))
-        get_params = [f'{key}={value}' for key, value in request.GET.items()]
+        get_params = request.GET.urlencode()
         return redirect(
-            reverse('admin:blocklist_blocklistsubmission_add') + '?' +
-            '&'.join([f'guids={addon.guid}'] + get_params))
+            reverse('admin:blocklist_blocklistsubmission_add') +
+            f'?guids={addon.guid}&{get_params}')
 
 
 @admin.register(BlocklistSubmission)

--- a/src/olympia/blocklist/admin.py
+++ b/src/olympia/blocklist/admin.py
@@ -2,13 +2,14 @@ from django.contrib import admin, auth, contenttypes
 from django.core.exceptions import PermissionDenied
 from django.forms.fields import ChoiceField
 from django.forms.widgets import HiddenInput
-from django.shortcuts import redirect
+from django.shortcuts import get_object_or_404, redirect
 from django.template.loader import render_to_string
 from django.template.response import TemplateResponse
 from django.urls import path
 from django.utils.html import format_html
 
 from olympia.activity.models import ActivityLog
+from olympia.addons.models import Addon
 from olympia.amo.urlresolvers import reverse
 from olympia.amo.utils import HttpResponseTemporaryRedirect
 
@@ -49,6 +50,10 @@ class BlockAdminAddMixin():
                 'delete_multiple/',
                 self.admin_site.admin_view(self.delete_multiple_view),
                 name='blocklist_block_delete_multiple'),
+            path(
+                'add_addon/<path:pk>/',
+                self.admin_site.admin_view(self.add_from_addon_pk_view),
+                name='blocklist_block_addaddon'),
         ]
         return my_urls + super().get_urls()
 
@@ -93,6 +98,13 @@ class BlockAdminAddMixin():
         }
         return TemplateResponse(
             request, 'blocklist/multi_guid_input.html', context)
+
+    def add_from_addon_pk_view(self, request, pk, **kwargs):
+        addon = get_object_or_404(Addon.unfiltered, pk=pk or kwargs.get('pk'))
+        get_params = [f'{key}={value}' for key, value in request.GET.items()]
+        return redirect(
+            reverse('admin:blocklist_blocklistsubmission_add') + '?' +
+            '&'.join([f'guids={addon.guid}'] + get_params))
 
 
 @admin.register(BlocklistSubmission)

--- a/src/olympia/blocklist/tests/test_admin.py
+++ b/src/olympia/blocklist/tests/test_admin.py
@@ -123,6 +123,23 @@ class TestBlockAdmin(TestCase):
             reverse('admin:blocklist_block_change', args=(block.pk,))
         )
 
+    def test_add_from_addon_pk_view(self):
+        user = user_factory()
+        self.grant_permission(user, 'Admin:Tools')
+        self.grant_permission(user, 'Blocklist:Create')
+        self.client.login(email=user.email)
+
+        addon = addon_factory()
+        url = reverse('admin:blocklist_block_addaddon', args=(addon.id,))
+        response = self.client.post(url, follow=True)
+        self.assertRedirects(
+            response, self.submission_url + f'?guids={addon.guid}')
+
+        response = self.client.post(url + '?min_version=23', follow=True)
+        self.assertRedirects(
+            response,
+            self.submission_url + f'?guids={addon.guid}&min_version=23')
+
 
 class TestBlocklistSubmissionAdmin(TestCase):
     def setUp(self):

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -260,7 +260,7 @@
           <a href="{{ url('admin:blocklist_blocklistsubmission_change', addon.blocklistsubmission.id) }}" class="button"
                   id="edit_addon_blocklistsubmission" type="button">{{ _('View Blocklist Submission') }}</a>
         {% elif not addon.block %}
-          <a href="{{ url('admin:blocklist_blocklistsubmission_add') }}?guids={{ addon.guid }}" class="button"
+          <a href="{{ url('admin:blocklist_block_addaddon', addon.pk) }}" class="button"
                   id="block_addon" type="button">{{ _('Block add-on') }}</a>
         {% else %}
           <a href="{{ url('admin:blocklist_block_change', addon.block.id) }}" class="button"

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -1590,8 +1590,8 @@ class TestReviewHelper(TestReviewHelperBase):
 
     def test_new_block_multiple_unlisted_versions(self):
         redirect_url = (
-            reverse('admin:blocklist_blocklistsubmission_add') +
-            '?min_version=%s&max_version=%s&guids=' + self.addon.guid)
+            reverse('admin:blocklist_block_addaddon', args=(self.addon.id,)) +
+            '?min_version=%s&max_version=%s')
         assert Block.objects.count() == 0
         self._test_block_multiple_unlisted_versions(redirect_url)
 

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -3639,8 +3639,7 @@ class TestReview(ReviewBase):
         assert not doc('#edit_addon_block')
         assert not doc('#edit_addon_blocklistsubmission')
         assert doc('#block_addon')[0].attrib.get('href') == (
-            reverse('admin:blocklist_blocklistsubmission_add') + '?guids=' +
-            self.addon.guid)
+            reverse('admin:blocklist_block_addaddon', args=(self.addon.id,)))
 
         block = Block.objects.create(
             addon=self.addon, updated_by=user_factory())
@@ -4630,11 +4629,12 @@ class TestReview(ReviewBase):
         self.grant_permission(self.reviewer, 'Reviews:Admin')
         self.grant_permission(self.reviewer, 'Blocklist:Create')
 
-        response = self.client.post(self.url, {
-            'action': 'block_multiple_versions',
-            'comments': 'multiblock!',  # should be ignored anyway
-            'versions': [old_version.pk, self.version.pk],
-        })
+        response = self.client.post(
+            self.url, {
+                'action': 'block_multiple_versions',
+                'comments': 'multiblock!',  # should be ignored anyway
+                'versions': [old_version.pk, self.version.pk],
+            }, follow=True)
 
         for version in [old_version, self.version]:
             version.reload()
@@ -4642,7 +4642,6 @@ class TestReview(ReviewBase):
             file_ = version.files.all().get()
             assert file_.status == amo.STATUS_DISABLED
 
-        assert response.status_code == 302
         new_block_url = (
             reverse('admin:blocklist_blocklistsubmission_add') +
             '?guids=%s&min_version=%s&max_version=%s' % (

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -1082,8 +1082,9 @@ class ReviewUnlisted(ReviewBase):
                 ) + params)
         else:
             self.redirect_url = (
-                reverse('admin:blocklist_blocklistsubmission_add') + params +
-                f'&guids={self.addon.guid}')
+                reverse(
+                    'admin:blocklist_block_addaddon', args=(self.addon.pk,)
+                ) + params)
 
     def confirm_multiple_versions(self):
         """Confirm approval on a list of versions."""

--- a/src/olympia/zadmin/tests/test_views.py
+++ b/src/olympia/zadmin/tests/test_views.py
@@ -117,6 +117,24 @@ class TestHomeAndIndex(TestCase):
         response = self.client.get(url)
         self.assert3xx(response, '/en-US/admin/models/')
 
+    @mock.patch('olympia.accounts.utils.default_fxa_login_url')
+    def test_django_login_page_with_next(self, default_fxa_login_url):
+        login_url = 'https://example.com/fxalogin'
+        default_fxa_login_url.return_value = login_url
+
+        # if django admin passes on a next param, check we use it.
+        url = reverse('admin:login') + '?next=/en-US/admin/models/addon/'
+        response = self.client.get(url)
+        # redirect to the correct page
+        self.assert3xx(response, '/en-US/admin/models/addon/')
+
+        # Same with an "is_staff" user.
+        user = user_factory(username='staffperson', email='staffperson@m.c')
+        self.client.login(email='staffperson@m.c')
+        self.grant_permission(user, 'Admin:Tools')
+        response = self.client.get(url)
+        self.assert3xx(response, '/en-US/admin/models/addon/')
+
     def test_django_admin_logout(self):
         url = reverse('admin:logout')
         response = self.client.get(url, follow=False)

--- a/src/olympia/zadmin/urls.py
+++ b/src/olympia/zadmin/urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls import include, url
 from django.contrib import admin
+from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import redirect
 
@@ -13,7 +14,8 @@ from . import views
 def login(request):
     # if the user has permission, just send them to the index page
     if request.method == 'GET' and admin.site.has_permission(request):
-        return redirect('admin:index')
+        next_path = request.GET.get(REDIRECT_FIELD_NAME)
+        return redirect(next_path or 'admin:index')
     # otherwise, they're logged in but don't have permission return a 403.
     elif request.user.is_authenticated:
         raise PermissionDenied


### PR DESCRIPTION
fixes #13752 by:
1) adding a shortcut url for adding a single addon guid by addon pk (so we're not creating a state that's too long) via `/admin/models/block/block_add_addon/<pk>/` and
2) correctly redirect a url that has a `?next=...` param, which django admin adds when a login is forced.  (not strictly related to this issue, because we've always failed to properly redirect direct urls to /model/ pages through a login via django admin, but without it makes the fix in (1) a bit pointless)