### PR TITLE
[WIP] Remove broken git ref file when GitError is raised

### DIFF
--- a/src/olympia/lib/tests/test_git.py
+++ b/src/olympia/lib/tests/test_git.py
@@ -6,6 +6,7 @@ import pytest
 import pygit2
 from unittest import mock
 from unittest.mock import MagicMock
+from pathlib import Path
 
 from django.conf import settings
 from django.core.files import temp
@@ -171,6 +172,21 @@ def test_extract_and_commit_from_version(settings):
         repr(addon.current_version), addon.current_version.id, repr(addon),
         repr(addon.current_version.all_files[0]))
     assert expected in output
+
+
+@pytest.mark.django_db
+def test_find_or_create_branch_repairs_broken_ref(settings):
+    repo = AddonGitRepository(addon_factory(
+        file_kw={'filename': 'webextension_no_id.xpi'}))
+    branch = 'listed'
+    # Create the git repo
+    repo.git_repository
+    assert repo.is_extracted
+    # Create a broken ref
+    Path(f'{repo.git_repository_path}/.git/refs/heads/{branch}').touch()
+
+    # This should create a branch
+    assert repo.find_or_create_branch(branch)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/13590

---

After having investigated this issue, I think this is the right patch assuming
branches are not corrupted after some time. ~~The git repos from prod I reviewed
were created in April 2019 and I did not find any other commit so I believe the
branch was not created correctly the first time and no extraction was ever 
committed to this branch.~~

~~Theoretically, no git commit can be lost so if a branch is corrupted after some
time (which I don't think is the case but I cannot be 100% sure), deleting and
recreating this branch will fix the extraction issue and we could still
re-attach the commits (cherry-pick actually) to the newly created branch (or we
re-extract the missing versions).~~

**EDIT:** so I found a different command to retrieve unreachable git commits
and there were in fact other git commits :( So that invalidates my theory here.
Ugh.

We could use a waffle switch if we want to be extra careful about this change.

Other (nuclear) option: we delete the entire repository and re-extract
everything but I don't know how to do this from within the
`find_or_create_branch()` function.

WDYT?