### PR TITLE
Update collection modified when triggering collection_meta task

### DIFF
--- a/src/olympia/bandwagon/tests/test_models.py
+++ b/src/olympia/bandwagon/tests/test_models.py
@@ -61,12 +61,16 @@ class TestCollections(TestCase):
         assert isinstance(c.uuid, uuid.UUID)
 
     def test_collection_meta(self):
-        c = Collection.objects.create(author=self.user)
-        assert c.addon_count == 0
-        c.add_addon(Addon.objects.all()[0])
+        some_time_ago = self.days_ago(442)
+        collection = Collection.objects.create(author=self.user)
+        collection.update(modified=some_time_ago)
+        assert collection.addon_count == 0
+        self.assertCloseToNow(collection.modified, now=some_time_ago)
+        collection.add_addon(Addon.objects.all()[0])
         assert activitylog_count(amo.LOG.ADD_TO_COLLECTION) == 1
-        c = Collection.objects.get(id=c.id)
-        assert c.addon_count == 1
+        collection.reload()
+        assert collection.addon_count == 1
+        self.assertCloseToNow(collection.modified)
 
     def test_favorites_slug(self):
         c = Collection.objects.create(author=self.user, slug='favorites')

--- a/src/olympia/bandwagon/tests/test_views.py
+++ b/src/olympia/bandwagon/tests/test_views.py
@@ -90,9 +90,9 @@ class TestCollectionViewSetList(TestCase):
         col_a = collection_factory(author=self.user)
         col_b = collection_factory(author=self.user)
         col_c = collection_factory(author=self.user)
-        col_a.update(modified=self.days_ago(3))
-        col_b.update(modified=self.days_ago(1))
-        col_c.update(modified=self.days_ago(6))
+        col_a.update(modified=self.days_ago(3), _signal=False)
+        col_b.update(modified=self.days_ago(1), _signal=False)
+        col_c.update(modified=self.days_ago(6), _signal=False)
 
         self.client.login_api(self.user)
         response = self.client.get(self.url)


### PR DESCRIPTION
Includes drive-by micro-optimization that is probably completely unnecessary but I find it makes things easier to read.

Fixes #13937 