### PR TITLE
Update filtercascade from 0.3.1 to 0.4.0

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -219,8 +219,8 @@ feedparser==5.2.1 \
     --hash=sha256:ce875495c90ebd74b179855449040003a1beb40cd13d5f037a0654251e260b02 \
     --hash=sha256:bd030652c2d08532c034c27fcd7c85868e7fa3cb2b17f230a44a6bbc92519bf9 \
     --hash=sha256:cd2485472e41471632ed3029d44033ee420ad0b57111db95c240c9160a85831c
-filtercascade==0.3.1 \
-    --hash=sha256:494478995f46d97354da7f6b99ff6206ef00003a830d01a53b12dafe8f04ad41
+filtercascade==0.4.0 \
+    --hash=sha256:30a74d4d6dcfc8e5bc76e18662193f3d2fb1aec73c6777ebaf65605b78925d3b
 # funcsigs is required by mock
 funcsigs==1.0.2 \
     --hash=sha256:330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca \

--- a/src/olympia/blocklist/mlbf.py
+++ b/src/olympia/blocklist/mlbf.py
@@ -90,7 +90,6 @@ class MLBF():
 
         log.info("Generating filter")
         cascade = FilterCascade(
-            filters=[],
             error_rates=fprs,
             defaultHashAlg=HashAlgorithm.SHA256,
             salt=salt,

--- a/src/olympia/blocklist/tests/test_mlbf.py
+++ b/src/olympia/blocklist/tests/test_mlbf.py
@@ -98,7 +98,7 @@ class TestMLBF(TestCase):
     def test_get_blocked_versions(self):
         blocked_versions = MLBF.get_blocked_versions()
         blocked_guids = blocked_versions.values()
-        assert len(blocked_guids) == 5
+        assert len(blocked_guids) == 5, blocked_guids
         assert (self.five_ver.guid, '123.40') in blocked_guids
         assert (self.five_ver.guid, '123.5') in blocked_guids
         assert (self.five_ver.guid, '123.45.1') not in blocked_guids
@@ -155,10 +155,10 @@ class TestMLBF(TestCase):
             assert key not in bfilter
         assert stats['mlbf_version'] == 2
         assert stats['mlbf_layers'] == 1
-        assert stats['mlbf_bits'] == 21608
+        assert stats['mlbf_bits'] == 2160
         with tempfile.NamedTemporaryFile() as out:
             bfilter.tofile(out)
-            assert os.stat(out.name).st_size == 2731
+            assert os.stat(out.name).st_size == 300
 
     def test_generate_and_write_mlbf(self):
         mlbf = MLBF(123456)
@@ -168,17 +168,15 @@ class TestMLBF(TestCase):
             buffer = filter_file.read()
             bfilter = FilterCascade.from_buf(buffer)
 
-        assert bfilter.bitCount() == 30024
-        # This isn't working currently due to upstream bug:
-        # https://github.com/mozilla/filter-cascade/issues/16
-        # blocked_versions = mlbf.get_blocked_versions()
-        # for guid, version_str in blocked_versions.values():
-        #     key = mlbf.KEY_FORMAT.format(guid=guid, version=version_str)
-        #     assert key in bfilter
-        # for guid, version_str in mlbf.get_all_guids(blocked_versions.keys()):
-        #     key = mlbf.KEY_FORMAT.format(guid=guid, version=version_str)
-        #     assert key not in bfilter
-        assert os.stat(mlbf.filter_path).st_size == 3783
+        assert bfilter.bitCount() == 3008
+        blocked_versions = mlbf.get_blocked_versions()
+        for guid, version_str in blocked_versions.values():
+            key = mlbf.KEY_FORMAT.format(guid=guid, version=version_str)
+            assert key in bfilter
+        for guid, version_str in mlbf.get_all_guids(blocked_versions.keys()):
+            key = mlbf.KEY_FORMAT.format(guid=guid, version=version_str)
+            assert key not in bfilter
+        assert os.stat(mlbf.filter_path).st_size == 406
 
     def test_generate_diffs(self):
         old_versions = [


### PR DESCRIPTION
Not sure why pyup hasn't picked this up, but needed some test fixes anyway.