### PR TITLE
Fixed deprecated warning issue due to FixedOffset

### DIFF
--- a/src/olympia/reviewers/serializers.py
+++ b/src/olympia/reviewers/serializers.py
@@ -4,7 +4,7 @@ import mimetypes
 import pathlib
 import json
 from collections import OrderedDict
-from datetime import datetime
+from datetime import datetime, timezone, timedelta
 
 import pygit2
 
@@ -14,7 +14,6 @@ from rest_framework.exceptions import NotFound
 from django.core.cache import cache
 from django.utils.functional import cached_property
 from django.utils.encoding import force_text
-from django.utils.timezone import FixedOffset
 from django.utils.translation import ugettext
 
 from olympia import amo
@@ -140,7 +139,8 @@ class FileEntriesSerializer(FileSerializer):
                 path = force_text(entry_wrapper.path)
                 blob = entry_wrapper.blob
 
-                commit_tzinfo = datetime.timezone
+                commit_tzinfo = timezone(timedelta(
+                    minutes=commit.commit_time_offset))
                 commit_time = datetime.fromtimestamp(
                     float(commit.commit_time),
                     commit_tzinfo)

--- a/src/olympia/reviewers/serializers.py
+++ b/src/olympia/reviewers/serializers.py
@@ -140,7 +140,7 @@ class FileEntriesSerializer(FileSerializer):
                 path = force_text(entry_wrapper.path)
                 blob = entry_wrapper.blob
 
-                commit_tzinfo = FixedOffset(commit.commit_time_offset)
+                commit_tzinfo = datetime.timezone
                 commit_time = datetime.fromtimestamp(
                     float(commit.commit_time),
                     commit_tzinfo)


### PR DESCRIPTION
Fixes: #13690 

Changed `FixedOffset(commit.commit_time_offset)` to `datetime.timezone`

* [x] This PR relates to an existing open issue and there are no existing
      PRs open for the same issue.
* [x] Add `Fixes #ISSUENUM` at the top of your PR.
* [x] Add a description of the changes introduced in this PR.