### PR TITLE
Add sha256, mimetype and size to File information returned by reviewers APIs

### DIFF
--- a/docs/topics/api/reviewers.rst
+++ b/docs/topics/api/reviewers.rst
@@ -171,7 +171,7 @@ This endpoint allows you to browse through the contents of an Add-on version.
     :>json string|null file.download_url: The download url of the selected file or ``null`` in case of a directory.
     :>json string file.mimetype: The determined mimetype of the selected file or ``application/octet-stream`` if none could be determined.
     :>json string file.sha256: SHA256 hash of the selected file.
-    :>json string file.size: The size of the selected file in bytes.
+    :>json int file.size: The size of the selected file in bytes.
     :>json boolean uses_unknown_minified_code: Indicates that the selected file could be using minified code.
     :>json array file.entries[]: The complete file-tree of the extracted XPI.
     :>json int file.entries[].depth: Level of folder-tree depth, starting with 0.

--- a/docs/topics/api/reviewers.rst
+++ b/docs/topics/api/reviewers.rst
@@ -169,6 +169,9 @@ This endpoint allows you to browse through the contents of an Add-on version.
     :>json string file.content: Raw content of the requested file.
     :>json string file.selected_file: The selected file, either from the ``file`` parameter or the default (manifest.json, install.rdf or package.json for Add-ons as well as the XML file for search engines).
     :>json string|null file.download_url: The download url of the selected file or ``null`` in case of a directory.
+    :>json string file.mimetype: The determined mimetype of the selected file or ``application/octet-stream`` if none could be determined.
+    :>json string file.sha256: SHA256 hash of the selected file.
+    :>json string file.size: The size of the selected file in bytes.
     :>json boolean uses_unknown_minified_code: Indicates that the selected file could be using minified code.
     :>json array file.entries[]: The complete file-tree of the extracted XPI.
     :>json int file.entries[].depth: Level of folder-tree depth, starting with 0.

--- a/src/olympia/reviewers/serializers.py
+++ b/src/olympia/reviewers/serializers.py
@@ -54,11 +54,14 @@ class FileEntriesSerializer(FileSerializer):
     download_url = serializers.SerializerMethodField()
     entries = serializers.SerializerMethodField()
     selected_file = serializers.SerializerMethodField()
+    mimetype = serializers.SerializerMethodField()
+    sha256 = serializers.SerializerMethodField()
+    size = serializers.SerializerMethodField()
 
     class Meta:
         fields = FileSerializer.Meta.fields + (
             'content', 'entries', 'selected_file', 'download_url',
-            'uses_unknown_minified_code'
+            'uses_unknown_minified_code', 'mimetype', 'sha256', 'size'
         )
         model = File
 
@@ -173,6 +176,17 @@ class FileEntriesSerializer(FileSerializer):
         self._entries[self.get_selected_file(obj)]['sha256'] = sha256
 
         return self._entries
+
+    def get_mimetype(self, obj):
+        entries = self.get_entries(obj)
+        return entries[self.get_selected_file(obj)]['mimetype']
+
+    def get_sha256(self, obj):
+        return self._get_hash_for_selected_file(obj)
+
+    def get_size(self, obj):
+        entries = self.get_entries(obj)
+        return entries[self.get_selected_file(obj)]['size']
 
     def get_selected_file(self, obj):
         requested_file = self.context.get('file', None)
@@ -314,7 +328,8 @@ class FileEntriesDiffSerializer(FileEntriesSerializer):
     class Meta:
         fields = FileSerializer.Meta.fields + (
             'diff', 'entries', 'selected_file', 'download_url',
-            'uses_unknown_minified_code', 'base_file'
+            'uses_unknown_minified_code', 'base_file',
+            'sha256', 'size', 'mimetype'
         )
         model = File
 

--- a/src/olympia/reviewers/tests/test_serializers.py
+++ b/src/olympia/reviewers/tests/test_serializers.py
@@ -49,6 +49,10 @@ class TestFileEntriesSerializer(TestCase):
         return self.get_serializer(obj, **extra_context).data
 
     def test_basic(self):
+        expected_mimetype = 'application/json'
+        expected_sha256 = '71d4122c0f2f78e089136602f88dbf590f2fa04bb5bc417454bf21446d6cb4f0'
+        expected_size = 622
+
         file = self.addon.current_version.current_file
 
         data = self.serialize(file)
@@ -72,6 +76,9 @@ class TestFileEntriesSerializer(TestCase):
             }
         ))
         assert not data['uses_unknown_minified_code']
+        assert data['mimetype'] == expected_mimetype
+        assert data['sha256'] == expected_sha256
+        assert data['size'] == expected_size
 
         assert set(data['entries'].keys()) == {
             'README.md',
@@ -87,12 +94,11 @@ class TestFileEntriesSerializer(TestCase):
         manifest_data = data['entries']['manifest.json']
         assert manifest_data['depth'] == 0
         assert manifest_data['filename'] == u'manifest.json'
-        assert manifest_data['sha256'] == (
-            '71d4122c0f2f78e089136602f88dbf590f2fa04bb5bc417454bf21446d6cb4f0')
-        assert manifest_data['mimetype'] == 'application/json'
+        assert manifest_data['sha256'] == expected_sha256
+        assert manifest_data['mimetype'] == expected_mimetype
         assert manifest_data['mime_category'] == 'text'
         assert manifest_data['path'] == u'manifest.json'
-        assert manifest_data['size'] == 622
+        assert manifest_data['size'] == expected_size
 
         assert isinstance(manifest_data['modified'], datetime)
 
@@ -139,6 +145,9 @@ class TestFileEntriesSerializer(TestCase):
                 'filename': 'icons/LICENSE'
             }
         ))
+        assert data['mimetype'] == 'text/plain'
+        assert data['sha256'] == 'b48e66c02fe62dd47521def7c5ea11b86af91b94c23cfdf67592e1053952ed55'
+        assert data['size'] == 136
 
     def test_requested_file_with_non_existent_file(self):
         file = self.addon.current_version.current_file
@@ -280,6 +289,10 @@ class TestFileEntriesDiffSerializer(TestCase):
         return self.get_serializer(obj, **extra_context).data
 
     def test_basic(self):
+        expected_mimetype = 'application/json'
+        expected_sha256 = 'bf9b0744c0011cad5caa55236951eda523f17676e91353a64a32353eac798631'
+        expected_size = 621
+
         parent_version = self.addon.current_version
 
         new_version = version_factory(
@@ -320,6 +333,9 @@ class TestFileEntriesDiffSerializer(TestCase):
             }
         ))
         assert not data['uses_unknown_minified_code']
+        assert data['mimetype'] == expected_mimetype
+        assert data['sha256'] == expected_sha256
+        assert data['size'] == expected_size
 
         assert set(data['entries'].keys()) == {
             'manifest.json', 'README.md', 'test.txt'}
@@ -333,12 +349,11 @@ class TestFileEntriesDiffSerializer(TestCase):
         manifest_data = data['entries']['manifest.json']
         assert manifest_data['depth'] == 0
         assert manifest_data['filename'] == u'manifest.json'
-        assert manifest_data['sha256'] == (
-            'bf9b0744c0011cad5caa55236951eda523f17676e91353a64a32353eac798631')
-        assert manifest_data['mimetype'] == 'application/json'
+        assert manifest_data['sha256'] == expected_sha256
+        assert manifest_data['mimetype'] == expected_mimetype
         assert manifest_data['mime_category'] == 'text'
         assert manifest_data['path'] == u'manifest.json'
-        assert manifest_data['size'] == 621
+        assert manifest_data['size'] == expected_size
         assert manifest_data['status'] == ''
         assert isinstance(manifest_data['modified'], datetime)
 
@@ -386,6 +401,9 @@ class TestFileEntriesDiffSerializer(TestCase):
         # We deleted the selected file, so there should be a diff.
         assert data['diff'] is not None
         assert data['diff']['mode'] == 'D'
+        assert data['mimetype'] == 'application/json'
+        assert data['sha256'] is None
+        assert data['size'] is None
 
     def test_recreate_parent_dir_of_deleted_file(self):
         addon, repo, parent_version, new_version = \

--- a/src/olympia/reviewers/tests/test_serializers.py
+++ b/src/olympia/reviewers/tests/test_serializers.py
@@ -50,7 +50,9 @@ class TestFileEntriesSerializer(TestCase):
 
     def test_basic(self):
         expected_mimetype = 'application/json'
-        expected_sha256 = '71d4122c0f2f78e089136602f88dbf590f2fa04bb5bc417454bf21446d6cb4f0'
+        expected_sha256 = (
+            '71d4122c0f2f78e089136602f88dbf590f2fa04bb5bc417454bf21446d6cb4f0'
+        )
         expected_size = 622
 
         file = self.addon.current_version.current_file
@@ -146,7 +148,9 @@ class TestFileEntriesSerializer(TestCase):
             }
         ))
         assert data['mimetype'] == 'text/plain'
-        assert data['sha256'] == 'b48e66c02fe62dd47521def7c5ea11b86af91b94c23cfdf67592e1053952ed55'
+        assert data['sha256'] == (
+            'b48e66c02fe62dd47521def7c5ea11b86af91b94c23cfdf67592e1053952ed55'
+        )
         assert data['size'] == 136
 
     def test_requested_file_with_non_existent_file(self):
@@ -290,7 +294,9 @@ class TestFileEntriesDiffSerializer(TestCase):
 
     def test_basic(self):
         expected_mimetype = 'application/json'
-        expected_sha256 = 'bf9b0744c0011cad5caa55236951eda523f17676e91353a64a32353eac798631'
+        expected_sha256 = (
+            'bf9b0744c0011cad5caa55236951eda523f17676e91353a64a32353eac798631'
+        )
         expected_size = 621
 
         parent_version = self.addon.current_version


### PR DESCRIPTION
Fixes #14026

This will also fix https://github.com/mozilla/addons-code-manager/issues/1548
