### PR TITLE
 Remove properties from entries, and do not require entries to calculate file-level properties

### DIFF
--- a/docs/topics/api/reviewers.rst
+++ b/docs/topics/api/reviewers.rst
@@ -177,11 +177,7 @@ This endpoint allows you to browse through the contents of an Add-on version.
     :>json int file.entries[].depth: Level of folder-tree depth, starting with 0.
     :>json string file.entries[].filename: The filename of the file.
     :>json string file.entries[].path: The absolute path (from the root of the XPI) of the file.
-    :>json string|null file.entries[].sha256: SHA256 hash. This is only set for the currently selected file.
-    :>json string file.entries[].mimetype: The determined mimetype of the file or ``application/octet-stream`` if none could be determined.
     :>json string file.entries[].mime_category: The mime type category of this file. Can be ``image``, ``directory``, ``text`` or ``binary``.
-    :>json int file.entries[].size: The size in bytes.
-    :>json string file.entries[].modified: The exact time of the commit, should be equivalent with ``created``.
 
 
 -------
@@ -212,11 +208,7 @@ This endpoint allows you to compare two Add-on versions with each other.
     :>json int|null file.entries[].depth: Level of folder-tree depth, starting with 0.
     :>json string file.entries[].filename: The filename of the file.
     :>json string file.entries[].path: The absolute path (from the root of the XPI) of the file.
-    :>json string|null file.entries[].sha256: SHA256 hash. This is only set for the currently selected file. It may also be `null` for deleted files.
-    :>json string|null file.entries[].mimetype: The determined mimetype of the file or ``application/octet-stream`` if none could be determined. Can be ``null`` in case of a deleted file.
     :>json string|null file.entries[].mime_category: The mime type category of this file. Can be ``image``, ``directory``, ``text`` or ``binary``.
-    :>json int|null file.entries[].size: The size in bytes.
-    :>json string|null file.entries[].modified: The exact time of the commit, should be equivalent with ``created``.
     :>json object|null diff: See the following output with inline comments for a complete description.
     :>json object base_file: The file attached to the base version you're comparing against.
     :>json object base_file.id: The id of the base file.

--- a/docs/topics/api/reviewers.rst
+++ b/docs/topics/api/reviewers.rst
@@ -172,6 +172,8 @@ This endpoint allows you to browse through the contents of an Add-on version.
     :>json string file.mimetype: The determined mimetype of the selected file or ``application/octet-stream`` if none could be determined.
     :>json string file.sha256: SHA256 hash of the selected file.
     :>json int file.size: The size of the selected file in bytes.
+    :>json string file.filename: The filename of the file.
+    :>json string file.mime_category: The mime type category of this file. Can be ``image``, ``directory``, ``text`` or ``binary``.
     :>json boolean uses_unknown_minified_code: Indicates that the selected file could be using minified code.
     :>json array file.entries[]: The complete file-tree of the extracted XPI.
     :>json int file.entries[].depth: Level of folder-tree depth, starting with 0.

--- a/src/olympia/reviewers/serializers.py
+++ b/src/olympia/reviewers/serializers.py
@@ -47,6 +47,8 @@ class AddonReviewerFlagsSerializer(serializers.ModelSerializer):
         )
 
 
+# NOTE: Because of caching, this serializer cannot be reused and must be
+# created for each file. It cannot be used with DRF's many=True option.
 class FileEntriesSerializer(FileSerializer):
     content = serializers.SerializerMethodField()
     uses_unknown_minified_code = serializers.SerializerMethodField()
@@ -83,7 +85,6 @@ class FileEntriesSerializer(FileSerializer):
     def commit(self):
         """Return the pygit2 repository instance, preselect correct channel."""
         # Caching the commit to avoid calling revparse_single many times.
-        # Because of this, a new serializer must be created for each file.
         try:
             return self.git_repo.revparse_single(
                 self.get_instance().version.git_hash)

--- a/src/olympia/reviewers/serializers.py
+++ b/src/olympia/reviewers/serializers.py
@@ -58,11 +58,14 @@ class FileEntriesSerializer(FileSerializer):
     mimetype = serializers.SerializerMethodField()
     sha256 = serializers.SerializerMethodField()
     size = serializers.SerializerMethodField()
+    mime_category = serializers.SerializerMethodField()
+    filename = serializers.SerializerMethodField()
 
     class Meta:
         fields = FileSerializer.Meta.fields + (
             'content', 'entries', 'selected_file', 'download_url',
-            'uses_unknown_minified_code', 'mimetype', 'sha256', 'size'
+            'uses_unknown_minified_code', 'mimetype', 'sha256', 'size',
+            'mime_category', 'filename'
         )
         model = File
 
@@ -214,6 +217,14 @@ class FileEntriesSerializer(FileSerializer):
         entries = self._get_entries(obj)
         return entries[self.get_selected_file(obj)]['size']
 
+    def get_filename(self, obj):
+        entries = self._get_entries(obj)
+        return entries[self.get_selected_file(obj)]['filename']
+
+    def get_mime_category(self, obj):
+        entries = self._get_entries(obj)
+        return entries[self.get_selected_file(obj)]['mime_category']
+
     def get_selected_file(self, obj):
         requested_file = self.context.get('file', None)
         files = self._get_entries(obj)
@@ -342,7 +353,7 @@ class FileEntriesDiffSerializer(FileEntriesSerializer):
         fields = FileSerializer.Meta.fields + (
             'diff', 'entries', 'selected_file', 'download_url',
             'uses_unknown_minified_code', 'base_file',
-            'sha256', 'size', 'mimetype'
+            'sha256', 'size', 'mimetype', 'mime_category', 'filename'
         )
         model = File
 

--- a/src/olympia/reviewers/tests/test_serializers.py
+++ b/src/olympia/reviewers/tests/test_serializers.py
@@ -174,7 +174,7 @@ class TestFileEntriesSerializer(TestCase):
 
         # start serialization
         data = serializer.data
-        commit = serializer._get_commit(file)
+        commit = serializer.commit
 
         assert serializer._entries == data['entries']
 

--- a/src/olympia/reviewers/tests/test_serializers.py
+++ b/src/olympia/reviewers/tests/test_serializers.py
@@ -47,6 +47,8 @@ class TestFileEntriesSerializer(TestCase):
         return self.get_serializer(obj, **extra_context).data
 
     def test_basic(self):
+        expected_file_type = 'text'
+        expected_filename = 'manifest.json'
         expected_mimetype = 'application/json'
         expected_sha256 = (
             '71d4122c0f2f78e089136602f88dbf590f2fa04bb5bc417454bf21446d6cb4f0'
@@ -79,6 +81,8 @@ class TestFileEntriesSerializer(TestCase):
         assert data['mimetype'] == expected_mimetype
         assert data['sha256'] == expected_sha256
         assert data['size'] == expected_size
+        assert data['mime_category'] == expected_file_type
+        assert data['filename'] == expected_filename
 
         assert set(data['entries'].keys()) == {
             'README.md',
@@ -93,8 +97,8 @@ class TestFileEntriesSerializer(TestCase):
 
         manifest_data = data['entries']['manifest.json']
         assert manifest_data['depth'] == 0
-        assert manifest_data['filename'] == u'manifest.json'
-        assert manifest_data['mime_category'] == 'text'
+        assert manifest_data['filename'] == expected_filename
+        assert manifest_data['mime_category'] == expected_file_type
         assert manifest_data['path'] == u'manifest.json'
 
         ja_locale_data = data['entries']['_locales/ja']
@@ -141,6 +145,8 @@ class TestFileEntriesSerializer(TestCase):
             'b48e66c02fe62dd47521def7c5ea11b86af91b94c23cfdf67592e1053952ed55'
         )
         assert data['size'] == 136
+        assert data['mime_category'] == 'text'
+        assert data['filename'] == 'LICENSE'
 
     def test_requested_file_with_non_existent_file(self):
         file = self.addon.current_version.current_file
@@ -284,6 +290,8 @@ class TestFileEntriesDiffSerializer(TestCase):
         return self.get_serializer(obj, **extra_context).data
 
     def test_basic(self):
+        expected_file_type = 'text'
+        expected_filename = 'manifest.json'
         expected_mimetype = 'application/json'
         expected_sha256 = (
             'bf9b0744c0011cad5caa55236951eda523f17676e91353a64a32353eac798631'
@@ -333,6 +341,8 @@ class TestFileEntriesDiffSerializer(TestCase):
         assert data['mimetype'] == expected_mimetype
         assert data['sha256'] == expected_sha256
         assert data['size'] == expected_size
+        assert data['mime_category'] == expected_file_type
+        assert data['filename'] == expected_filename
 
         assert set(data['entries'].keys()) == {
             'manifest.json', 'README.md', 'test.txt'}
@@ -345,8 +355,8 @@ class TestFileEntriesDiffSerializer(TestCase):
         # Unmodified file
         manifest_data = data['entries']['manifest.json']
         assert manifest_data['depth'] == 0
-        assert manifest_data['filename'] == u'manifest.json'
-        assert manifest_data['mime_category'] == 'text'
+        assert manifest_data['filename'] == expected_filename
+        assert manifest_data['mime_category'] == expected_file_type
         assert manifest_data['path'] == u'manifest.json'
         assert manifest_data['status'] == ''
 
@@ -370,6 +380,7 @@ class TestFileEntriesDiffSerializer(TestCase):
         assert readme_data['path'] == u'README.md'
 
     def test_serialize_deleted_file(self):
+        expected_filename = 'manifest.json'
         parent_version = self.addon.current_version
         new_version = version_factory(
             addon=self.addon, file_kw={
@@ -379,7 +390,7 @@ class TestFileEntriesDiffSerializer(TestCase):
         )
 
         repo = AddonGitRepository.extract_and_commit_from_version(new_version)
-        apply_changes(repo, new_version, '', 'manifest.json', delete=True)
+        apply_changes(repo, new_version, '', expected_filename, delete=True)
 
         file = self.addon.current_version.current_file
         data = self.serialize(file, parent_version=parent_version)
@@ -391,6 +402,8 @@ class TestFileEntriesDiffSerializer(TestCase):
         assert data['mimetype'] == 'application/json'
         assert data['sha256'] is None
         assert data['size'] is None
+        assert data['mime_category'] is None
+        assert data['filename'] == expected_filename
 
     def test_recreate_parent_dir_of_deleted_file(self):
         addon, repo, parent_version, new_version = \

--- a/src/olympia/reviewers/tests/test_serializers.py
+++ b/src/olympia/reviewers/tests/test_serializers.py
@@ -207,14 +207,14 @@ class TestFileEntriesSerializer(TestCase):
     def test_sha256_only_calculated_or_fetched_for_selected_file(self):
         file = self.addon.current_version.current_file
         serializer = self.get_serializer(file, file='icons/LICENSE')
-        data = serializer.data
+        serializer.data
 
         assert serializer._entries['manifest.json']['sha256'] is None
         assert serializer._entries['icons/LICENSE']['sha256'] == (
             'b48e66c02fe62dd47521def7c5ea11b86af91b94c23cfdf67592e1053952ed55')
 
         serializer = self.get_serializer(file, file='manifest.json')
-        data = serializer.data
+        serializer.data
         assert serializer._entries['manifest.json']['sha256'] == (
             '71d4122c0f2f78e089136602f88dbf590f2fa04bb5bc417454bf21446d6cb4f0')
         assert serializer._entries['icons/LICENSE']['sha256'] is None

--- a/src/olympia/reviewers/tests/test_serializers.py
+++ b/src/olympia/reviewers/tests/test_serializers.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
 
-from datetime import datetime
-
 from django.core.cache import cache
 
 from rest_framework.exceptions import NotFound
@@ -96,24 +94,15 @@ class TestFileEntriesSerializer(TestCase):
         manifest_data = data['entries']['manifest.json']
         assert manifest_data['depth'] == 0
         assert manifest_data['filename'] == u'manifest.json'
-        assert manifest_data['sha256'] == expected_sha256
-        assert manifest_data['mimetype'] == expected_mimetype
         assert manifest_data['mime_category'] == 'text'
         assert manifest_data['path'] == u'manifest.json'
-        assert manifest_data['size'] == expected_size
-
-        assert isinstance(manifest_data['modified'], datetime)
 
         ja_locale_data = data['entries']['_locales/ja']
 
         assert ja_locale_data['depth'] == 1
         assert ja_locale_data['mime_category'] == 'directory'
         assert ja_locale_data['filename'] == 'ja'
-        assert ja_locale_data['sha256'] is None
-        assert ja_locale_data['mimetype'] == 'application/octet-stream'
         assert ja_locale_data['path'] == u'_locales/ja'
-        assert ja_locale_data['size'] is None
-        assert isinstance(ja_locale_data['modified'], datetime)
 
         assert '"manifest_version": 2' in data['content']
         assert 'id": "notify-link-clicks-i18n@notzilla.org' in data['content']
@@ -213,20 +202,6 @@ class TestFileEntriesSerializer(TestCase):
         file = self.addon.current_version.current_file
         data = self.serialize(file, file='icons/link-48.png')
         assert data['content'] == ''
-
-    def test_sha256_only_calculated_or_fetched_for_selected_file(self):
-        file = self.addon.current_version.current_file
-
-        data = self.serialize(file, file='icons/LICENSE')
-
-        assert data['entries']['manifest.json']['sha256'] is None
-        assert data['entries']['icons/LICENSE']['sha256'] == (
-            'b48e66c02fe62dd47521def7c5ea11b86af91b94c23cfdf67592e1053952ed55')
-
-        data = self.serialize(file, file='manifest.json')
-        assert data['entries']['manifest.json']['sha256'] == (
-            '71d4122c0f2f78e089136602f88dbf590f2fa04bb5bc417454bf21446d6cb4f0')
-        assert data['entries']['icons/LICENSE']['sha256'] is None
 
     def test_uses_unknown_minified_code(self):
         validation_data = {
@@ -355,23 +330,16 @@ class TestFileEntriesDiffSerializer(TestCase):
         manifest_data = data['entries']['manifest.json']
         assert manifest_data['depth'] == 0
         assert manifest_data['filename'] == u'manifest.json'
-        assert manifest_data['sha256'] == expected_sha256
-        assert manifest_data['mimetype'] == expected_mimetype
         assert manifest_data['mime_category'] == 'text'
         assert manifest_data['path'] == u'manifest.json'
-        assert manifest_data['size'] == expected_size
         assert manifest_data['status'] == ''
-        assert isinstance(manifest_data['modified'], datetime)
 
         # Added a new file
         test_txt_data = data['entries']['test.txt']
         assert test_txt_data['depth'] == 0
         assert test_txt_data['filename'] == u'test.txt'
-        assert test_txt_data['sha256'] is None
-        assert test_txt_data['mimetype'] == 'text/plain'
         assert test_txt_data['mime_category'] == 'text'
         assert test_txt_data['path'] == u'test.txt'
-        assert test_txt_data['size'] == 18
         assert test_txt_data['status'] == 'A'
 
         # Deleted file
@@ -379,14 +347,11 @@ class TestFileEntriesDiffSerializer(TestCase):
         assert readme_data['status'] == 'D'
         assert readme_data['depth'] == 0
         assert readme_data['filename'] == 'README.md'
-        assert readme_data['sha256'] is None
         # Not testing mimetype as text/markdown is missing in travis mimetypes
         # database. But it doesn't matter much here since we're primarily
         # after the git status.
         assert readme_data['mime_category'] is None
         assert readme_data['path'] == u'README.md'
-        assert readme_data['size'] is None
-        assert readme_data['modified'] is None
 
     def test_serialize_deleted_file(self):
         parent_version = self.addon.current_version
@@ -407,7 +372,8 @@ class TestFileEntriesDiffSerializer(TestCase):
         # We deleted the selected file, so there should be a diff.
         assert data['diff'] is not None
         assert data['diff']['mode'] == 'D'
-        assert data['mimetype'] == 'application/json'
+        # No file exists, so mimetype uses the default.
+        assert data['mimetype'] == 'application/octet-stream'
         assert data['sha256'] is None
         assert data['size'] is None
 
@@ -431,12 +397,8 @@ class TestFileEntriesDiffSerializer(TestCase):
         parent = entries_by_file[parent_dir]
         assert parent['depth'] == 0
         assert parent['filename'] == parent_dir
-        assert parent['sha256'] is None
         assert parent['mime_category'] == 'directory'
-        assert parent['mimetype'] == 'application/octet-stream'
         assert parent['path'] == parent_dir
-        assert parent['size'] is None
-        assert parent['modified'] is None
 
     def test_recreate_nested_parent_dir_of_deleted_file(self):
         addon, repo, parent_version, new_version = \
@@ -517,11 +479,7 @@ class TestFileEntriesDiffSerializer(TestCase):
 
         parent = entries_by_file[parent_dir]
         assert parent['mime_category'] == 'directory'
-        assert parent['mimetype'] == 'application/octet-stream'
         assert parent['path'] == parent_dir
-        # Since the directory is returned from git, it will have a real
-        # modified timestamp.
-        assert parent['modified'] is not None
 
     def test_expose_grandparent_dir_deleted_subfolders(self):
         addon, repo, parent_version, new_version = \
@@ -547,7 +505,6 @@ class TestFileEntriesDiffSerializer(TestCase):
 
         parent = entries_by_file[grandparent_dir]
         assert parent['mime_category'] == 'directory'
-        assert parent['mimetype'] == 'application/octet-stream'
         assert parent['path'] == grandparent_dir
         assert parent['depth'] == 0
 
@@ -572,14 +529,9 @@ class TestFileEntriesDiffSerializer(TestCase):
         manifest_data = data['entries']['manifest.json']
         assert manifest_data['depth'] == 0
         assert manifest_data['filename'] == u'manifest.json'
-        assert manifest_data['sha256'] == (
-            'bf9b0744c0011cad5caa55236951eda523f17676e91353a64a32353eac798631')
-        assert manifest_data['mimetype'] == 'application/json'
         assert manifest_data['mime_category'] == 'text'
         assert manifest_data['path'] == u'manifest.json'
-        assert manifest_data['size'] == 621
         assert manifest_data['status'] == ''
-        assert isinstance(manifest_data['modified'], datetime)
 
         assert data['diff'] is not None
 

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -1160,8 +1160,7 @@ def download_git_stored_file(request, version_id, filename):
         }
     )
 
-    commit = serializer._get_commit(file)
-    tree = serializer.repo.get_root_tree(commit)
+    tree = serializer.tree
 
     try:
         blob_or_tree = tree[serializer.get_selected_file(file)]
@@ -1176,7 +1175,7 @@ def download_git_stored_file(request, version_id, filename):
 
     response = http.HttpResponse(
         content=actual_blob.data,
-        content_type=selected_file['mimetype'])
+        content_type=serializer.get_mimetype(file))
 
     # Backported from Django 2.1 to handle unicode filenames properly
     selected_filename = selected_file['filename']

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -1176,7 +1176,7 @@ def download_git_stored_file(request, version_id, filename):
 
     response = http.HttpResponse(
         content=actual_blob.data,
-        content_type=selected_file['mimetype'])
+        content_type=serializer.get_mimetype(file))
 
     # Backported from Django 2.1 to handle unicode filenames properly
     selected_filename = selected_file['filename']

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -1176,7 +1176,7 @@ def download_git_stored_file(request, version_id, filename):
 
     response = http.HttpResponse(
         content=actual_blob.data,
-        content_type=serializer.get_mimetype(file))
+        content_type=selected_file['mimetype'])
 
     # Backported from Django 2.1 to handle unicode filenames properly
     selected_filename = selected_file['filename']


### PR DESCRIPTION
Fixes #14042 

This needs to land in the same push as https://github.com/mozilla/addons-code-manager/pull/1565, which is why I have marked it as "do not merge" for now.

This allows the next step, which will be to have a serializer that can return data for just a file, without having to calculate the `entries` beforehand. It also removes properties from `entries` that are no longer needed.

All data needed for a file can now be calculated and returned without having to generate `entries`. I had to add some extra logic to deal with deleted files, as they won't exist in the `tree`, but would have existed in `entries`. If we feel this is all too much, we could just allow the serializer to always need to calculate `entries` (as suggested by @diox in Matrix), knowing that those `entries` are cached for future requests. That would remove the need for a lot of this code.
