### PR TITLE
Handle BrokenRefError errors

### DIFF
--- a/src/olympia/git/tests/test_commands.py
+++ b/src/olympia/git/tests/test_commands.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from unittest import mock
 
+import pytest
+
 from django.test.utils import override_settings
 
 from olympia.amo.tests import (
@@ -9,7 +11,7 @@ from olympia.amo.tests import (
     create_switch,
     version_factory,
 )
-from olympia.lib.git import AddonGitRepository
+from olympia.lib.git import AddonGitRepository, BrokenRefError
 from olympia.git.models import GitExtractionEntry
 from olympia.git.tasks import (
     extract_versions_to_git,
@@ -158,7 +160,7 @@ class TestGitExtraction(TestCase):
     # (because we run Celery in eager mode in the test env). That being said,
     # Celery still raises errors so... we have to catch the exception too.
     @override_settings(CELERY_TASK_EAGER_PROPAGATES=False)
-    def test_extract_addon_with_error_during_extraction(self):
+    def test_extract_addon_with_broken_ref_error_during_extraction(self):
         addon = addon_factory(file_kw={'filename': 'webextension_no_id.xpi'})
         version = addon.current_version
         repo = AddonGitRepository(addon)
@@ -170,13 +172,14 @@ class TestGitExtraction(TestCase):
         Path(f'{repo.git_repository_path}/.git/refs/heads/listed').touch()
         entry = GitExtractionEntry.objects.create(addon=addon)
 
-        try:
+        with pytest.raises(BrokenRefError):
             self.command.extract_addon(entry)
-        except Exception:
-            pass
+
         addon.refresh_from_db()
         version.refresh_from_db()
 
-        assert repo.is_extracted
+        assert not repo.is_extracted
         assert not GitExtractionEntry.objects.filter(pk=entry.pk).exists()
         assert not version.git_hash
+        new_entry = GitExtractionEntry.objects.get(addon_id=addon.pk)
+        assert new_entry and new_entry.in_progress is None


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/13590

---

This patch handles the git errors related to broken git references (see issue above). The strategy is to re-extract everything because we cannot repair the git repository.