### PR TITLE
Reverse 4f6095887cd0e94b94754019635e3e74fa182b1f: process all emails using Jinja2

### DIFF
--- a/src/olympia/activity/tests/test_utils.py
+++ b/src/olympia/activity/tests/test_utils.py
@@ -80,7 +80,7 @@ class TestEmailBouncing(TestCase):
     BOUNCE_REPLY = (
         'Hello,\n\nAn email was received, apparently from you. Unfortunately '
         'we couldn\'t process it because of:\n%s\n\nPlease visit %s to leave '
-        'a reply instead.\n--\nMozilla Add-ons\n%s\n')
+        'a reply instead.\n--\nMozilla Add-ons\n%s')
 
     def setUp(self):
         self.bounce_reply = (

--- a/src/olympia/devhub/templates/devhub/emails/api_key_confirmation.ltxt
+++ b/src/olympia/devhub/templates/devhub/emails/api_key_confirmation.ltxt
@@ -1,4 +1,4 @@
-{% load i18n %}{# L10n: This is an email. Whitespace matters #}{% blocktrans %}Hello,
+{# L10n: This is an email. Whitespace matters #}{% trans %}Hello,
 
 You're receiving this message because you requested new developer API keys for
 {{ domain }}. To finish this process, please click on the link below:
@@ -10,4 +10,4 @@ If you didn't request this, please notify amo-admins@mozilla.com.
 Regards,
 
 The Mozilla Add-ons Team
-{% endblocktrans %}
+{% endtrans %}

--- a/src/olympia/devhub/templates/devhub/emails/new-key-email.ltxt
+++ b/src/olympia/devhub/templates/devhub/emails/new-key-email.ltxt
@@ -1,4 +1,4 @@
-{% load i18n %}{# L10n: This is an email. Whitespace matters #}{% blocktrans %}The following API Key was added to your account:
+{# L10n: This is an email. Whitespace matters #}{% trans %}The following API Key was added to your account:
 
 {{ key }}
 
@@ -6,4 +6,4 @@ If you believe this key was created in error, you can remove the key and
 disable access at the following location:
 
 {{ url }}
-{% endblocktrans %}
+{% endtrans %}

--- a/src/olympia/devhub/templates/devhub/emails/revoked-key-email.ltxt
+++ b/src/olympia/devhub/templates/devhub/emails/revoked-key-email.ltxt
@@ -1,4 +1,4 @@
-{% load i18n %}{# L10n: This is an email. Whitespace matters #}{% blocktrans %}The API Key was revoked from your account:
+{# L10n: This is an email. Whitespace matters #}{% trans %}The API Key was revoked from your account:
 
 {{ key }}
 
@@ -6,4 +6,4 @@ If you believe this key was revoked in error, you can create a new one
 at the following location:
 
 {{ url }}
-{% endblocktrans %}
+{% endtrans %}

--- a/src/olympia/devhub/templates/devhub/emails/submission_api_key_revocation.txt
+++ b/src/olympia/devhub/templates/devhub/emails/submission_api_key_revocation.txt
@@ -1,4 +1,4 @@
-{% load i18n %}{# L10n: This is an email. Whitespace matters #}{% blocktrans %}Dear add-on developer,
+{# L10n: This is an email. Whitespace matters #}{% trans %}Dear add-on developer,
 
 We noticed that your secret AMO API credentials were included in an add-on submitted to addons.mozilla.org. In order to protect your account and your add-on(s), we revoked the leaked credentials.
 You can generate new API credentials at {{ api_keys_url }}
@@ -7,4 +7,4 @@ Please make sure you never share your credentials with anyone. Never include the
 
 Thank you,
 The Mozilla Add-ons team
-{% endblocktrans %}
+{% endtrans %}

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -274,9 +274,6 @@ SECRET_KEY = env(
 # Templates configuration.
 # List of path patterns for which we should be using Django Template Language.
 JINJA_EXCLUDE_TEMPLATE_PATHS = (
-    # All emails should be processed with Django for consistency.
-    r'^.*\/emails\/',
-
     # ^admin\/ covers most django admin templates, since their path should
     # follow /admin/<app>/<model>/*
     r'^admin\/',
@@ -541,13 +538,9 @@ PUENTE = {
             # it's not in templates/ with a .html extension.
             (EDITORIAL_CONTENT_FILENAME, 'jinja2'),
 
-            # Make sure we're parsing django-admin & email templates with the
+            # Make sure we're parsing django-admin templates with the
             # django template extractor. This should match the behavior of
             # JINJA_EXCLUDE_TEMPLATE_PATHS
-            (
-                'src/olympia/**/templates/**/emails/**.*',
-                'django_babel.extract.extract_django'
-            ),
             (
                 '**/templates/admin/**.html',
                 'django_babel.extract.extract_django'

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -687,7 +687,7 @@ class ReviewBase(object):
                 args=[self.addon.id])
         else:
             dev_ver_url = self.addon.get_dev_url('versions')
-        return {'name': addon.name,
+        return {'name': str(addon.name),
                 'number': self.version.version if self.version else '',
                 'reviewer': self.user.reviewer_name or self.user.name,
                 'addon_url': absolutify(addon_url),

--- a/src/olympia/users/templates/users/emails/author_added.ltxt
+++ b/src/olympia/users/templates/users/emails/author_added.ltxt
@@ -1,4 +1,4 @@
-{# L10n: This is an email. Whitespace matters! #}{% trans with addon_url=addon.get_absolute_url addon_name=addon.name author_url=author.user.get_absolute_url author_name=author.user.name author_role=author.get_role_display %}
+{# L10n: This is an email. Whitespace matters! #}{% trans addon_url=addon.get_absolute_url(), addon_name=addon.name, author_url=author.user.get_absolute_url(), author_name=author.user.name, author_role=author.get_role_display() %}
 The following author has been added to your addon {{ addon_name }} ( {{ addon_url }} ):
 
 {{ author_name }} ( {{ author_url }} ): {{ author_role }}

--- a/src/olympia/users/templates/users/emails/author_added.ltxt
+++ b/src/olympia/users/templates/users/emails/author_added.ltxt
@@ -1,5 +1,5 @@
-{% load i18n %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans with addon_url=addon.get_absolute_url addon_name=addon.name author_url=author.user.get_absolute_url author_name=author.user.name author_role=author.get_role_display %}
+{# L10n: This is an email. Whitespace matters! #}{% trans with addon_url=addon.get_absolute_url addon_name=addon.name author_url=author.user.get_absolute_url author_name=author.user.name author_role=author.get_role_display %}
 The following author has been added to your addon {{ addon_name }} ( {{ addon_url }} ):
 
 {{ author_name }} ( {{ author_url }} ): {{ author_role }}
-{% endblocktrans %}
+{% endtrans %}

--- a/src/olympia/users/templates/users/emails/author_added_confirmation.ltxt
+++ b/src/olympia/users/templates/users/emails/author_added_confirmation.ltxt
@@ -1,4 +1,4 @@
-{% load i18n %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans with addon_name=addon.name author_name=author.user.name domain=DOMAIN %}
+{# L10n: This is an email. Whitespace matters! #}{% trans with addon_name=addon.name author_name=author.user.name domain=DOMAIN %}
 Greetings {{ author_name }},
 
 You have been invited to become an author of {{ addon_name }} on {{ domain }}. Accepting the invitation will give you access to edit the add-on, and may show your name in the authors list on the website.
@@ -11,4 +11,4 @@ If you didn't expect to receive this invitation, please send an email to amo-adm
 
 Kind regards,
 The Mozilla Add-ons Team
-{% endblocktrans %}
+{% endtrans %}

--- a/src/olympia/users/templates/users/emails/author_added_confirmation.ltxt
+++ b/src/olympia/users/templates/users/emails/author_added_confirmation.ltxt
@@ -1,4 +1,4 @@
-{# L10n: This is an email. Whitespace matters! #}{% trans with addon_name=addon.name author_name=author.user.name domain=DOMAIN %}
+{# L10n: This is an email. Whitespace matters! #}{% trans addon_name=addon.name, author_name=author.user.name, domain=DOMAIN %}
 Greetings {{ author_name }},
 
 You have been invited to become an author of {{ addon_name }} on {{ domain }}. Accepting the invitation will give you access to edit the add-on, and may show your name in the authors list on the website.

--- a/src/olympia/users/templates/users/emails/author_changed.ltxt
+++ b/src/olympia/users/templates/users/emails/author_changed.ltxt
@@ -1,5 +1,5 @@
-{% load i18n %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans with addon_url=addon.get_absolute_url addon_name=addon.name author_url=author.user.get_absolute_url author_name=author.user.name author_role=author.get_role_display %}
+{# L10n: This is an email. Whitespace matters! #}{% trans with addon_url=addon.get_absolute_url addon_name=addon.name author_url=author.user.get_absolute_url author_name=author.user.name author_role=author.get_role_display %}
 The following author has been changed on your addon {{ addon_name }} ( {{ addon_url }} ):
 
 {{ author_name }} ( {{ author_url }} ): {{ author_role }}
-{% endblocktrans %}
+{% endtrans %}

--- a/src/olympia/users/templates/users/emails/author_changed.ltxt
+++ b/src/olympia/users/templates/users/emails/author_changed.ltxt
@@ -1,4 +1,4 @@
-{# L10n: This is an email. Whitespace matters! #}{% trans with addon_url=addon.get_absolute_url addon_name=addon.name author_url=author.user.get_absolute_url author_name=author.user.name author_role=author.get_role_display %}
+{# L10n: This is an email. Whitespace matters! #}{% trans addon_url=addon.get_absolute_url(), addon_name=addon.name, author_url=author.user.get_absolute_url(), author_name=author.user.name, author_role=author.get_role_display() %}
 The following author has been changed on your addon {{ addon_name }} ( {{ addon_url }} ):
 
 {{ author_name }} ( {{ author_url }} ): {{ author_role }}

--- a/src/olympia/users/templates/users/emails/author_removed.ltxt
+++ b/src/olympia/users/templates/users/emails/author_removed.ltxt
@@ -1,4 +1,4 @@
-{# L10n: This is an email. Whitespace matters! #}{% trans with addon_url=addon.get_absolute_url addon_name=addon.name author_url=author.user.get_absolute_url author_name=author.user.name %}
+{# L10n: This is an email. Whitespace matters! #}{% trans addon_url=addon.get_absolute_url(), addon_name=addon.name, author_url=author.user.get_absolute_url(), author_name=author.user.name %}
 The following author has been removed from addon {{ addon_name }} ( {{ addon_url }} ):
 
 {{ author_name }} ( {{ author_url }} )

--- a/src/olympia/users/templates/users/emails/author_removed.ltxt
+++ b/src/olympia/users/templates/users/emails/author_removed.ltxt
@@ -1,5 +1,5 @@
-{% load i18n %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans with addon_url=addon.get_absolute_url addon_name=addon.name author_url=author.user.get_absolute_url author_name=author.user.name %}
+{# L10n: This is an email. Whitespace matters! #}{% trans with addon_url=addon.get_absolute_url addon_name=addon.name author_url=author.user.get_absolute_url author_name=author.user.name %}
 The following author has been removed from addon {{ addon_name }} ( {{ addon_url }} ):
 
 {{ author_name }} ( {{ author_url }} )
-{% endblocktrans %}
+{% endtrans %}


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/14044 (again)

Django Template Engine creates newlines we want to avoid because of localization
issues.

