### PR TITLE
Allow the serializer to return file info without entries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ before_install:
   - echo "deb http://archive.ubuntu.com/ubuntu eoan main" | sudo tee -a /etc/apt/sources.list
   - sudo apt-get update -qq
   - sudo apt-get install -t eoan libmagic-dev libmagic1 libmagic-mgc
+  - echo "text/markdown                                   md markdown" | sudo tee -a /etc/mime.types
 
 install:
   - nvm current

--- a/src/olympia/reviewers/serializers.py
+++ b/src/olympia/reviewers/serializers.py
@@ -191,6 +191,9 @@ class FileEntriesSerializer(serializers.ModelSerializer):
         return self._entries
 
     def get_entries(self, obj):
+        file_only = self.context.get('file_only', False)
+        if file_only:
+            return None
         entries = self._get_entries(obj)
         return self._trim_entries(entries)
 

--- a/src/olympia/reviewers/serializers.py
+++ b/src/olympia/reviewers/serializers.py
@@ -191,8 +191,7 @@ class FileEntriesSerializer(serializers.ModelSerializer):
         return self._entries
 
     def get_entries(self, obj):
-        file_only = self.context.get('file_only', False)
-        if file_only:
+        if self.context.get('exclude_entries', False):
             return None
         entries = self._get_entries(obj)
         return self._trim_entries(entries)

--- a/src/olympia/reviewers/tests/test_serializers.py
+++ b/src/olympia/reviewers/tests/test_serializers.py
@@ -232,6 +232,26 @@ class TestFileEntriesSerializer(TestCase):
         data = self.serialize(fobj, file='background-script.js')
         assert not data['uses_unknown_minified_code']
 
+    def test_can_exclude_entries(self):
+        file = self.addon.current_version.current_file
+
+        data = self.serialize(file, file_only=True)
+
+        assert data['id'] == file.pk
+        assert data['selected_file'] == 'manifest.json'
+        assert data['mimetype'] == 'application/json'
+        assert data['entries'] is None
+
+    def test_can_exclude_entries_and_specify_a_file(self):
+        file = self.addon.current_version.current_file
+
+        data = self.serialize(file, file='icons/LICENSE', file_only=True)
+
+        assert data['id'] == file.pk
+        assert data['selected_file'] == 'icons/LICENSE'
+        assert data['mimetype'] == 'text/plain'
+        assert data['entries'] is None
+
 
 class TestFileEntriesDiffSerializer(TestCase):
     def setUp(self):
@@ -590,6 +610,50 @@ class TestFileEntriesDiffSerializer(TestCase):
         data = self.serialize(
             file, parent_version=parent_version, file='manifest.json')
         assert not data['uses_unknown_minified_code']
+
+    def test_can_exclude_entries(self):
+        parent_version = self.addon.current_version
+
+        new_version = version_factory(
+            addon=self.addon, file_kw={
+                'filename': 'webextension_no_id.xpi',
+                'is_webextension': True,
+            }
+        )
+        AddonGitRepository.extract_and_commit_from_version(new_version)
+
+        file = self.addon.current_version.current_file
+
+        data = self.serialize(file, file_only=True,
+                              parent_version=parent_version)
+
+        assert data['id'] == file.pk
+        assert data['selected_file'] == 'manifest.json'
+        assert data['mimetype'] == 'application/json'
+        assert data['entries'] is None
+        assert data['diff'] is not None
+
+    def test_can_exclude_entries_and_specify_a_file(self):
+        parent_version = self.addon.current_version
+
+        new_version = version_factory(
+            addon=self.addon, file_kw={
+                'filename': 'webextension_no_id.xpi',
+                'is_webextension': True,
+            }
+        )
+        AddonGitRepository.extract_and_commit_from_version(new_version)
+
+        file = self.addon.current_version.current_file
+
+        data = self.serialize(file, file='README.md', file_only=True,
+                              parent_version=parent_version)
+
+        assert data['id'] == file.pk
+        assert data['selected_file'] == 'README.md'
+        assert data['mimetype'] == 'text/markdown'
+        assert data['entries'] is None
+        assert data['diff'] is not None
 
 
 class TestAddonBrowseVersionSerializer(TestCase):

--- a/src/olympia/reviewers/tests/test_serializers.py
+++ b/src/olympia/reviewers/tests/test_serializers.py
@@ -235,7 +235,7 @@ class TestFileEntriesSerializer(TestCase):
     def test_can_exclude_entries(self):
         file = self.addon.current_version.current_file
 
-        data = self.serialize(file, file_only=True)
+        data = self.serialize(file, exclude_entries=True)
 
         assert data['id'] == file.pk
         assert data['selected_file'] == 'manifest.json'
@@ -245,7 +245,7 @@ class TestFileEntriesSerializer(TestCase):
     def test_can_exclude_entries_and_specify_a_file(self):
         file = self.addon.current_version.current_file
 
-        data = self.serialize(file, file='icons/LICENSE', file_only=True)
+        data = self.serialize(file, file='icons/LICENSE', exclude_entries=True)
 
         assert data['id'] == file.pk
         assert data['selected_file'] == 'icons/LICENSE'
@@ -624,7 +624,7 @@ class TestFileEntriesDiffSerializer(TestCase):
 
         file = self.addon.current_version.current_file
 
-        data = self.serialize(file, file_only=True,
+        data = self.serialize(file, exclude_entries=True,
                               parent_version=parent_version)
 
         assert data['id'] == file.pk
@@ -646,7 +646,7 @@ class TestFileEntriesDiffSerializer(TestCase):
 
         file = self.addon.current_version.current_file
 
-        data = self.serialize(file, file='README.md', file_only=True,
+        data = self.serialize(file, file='README.md', exclude_entries=True,
                               parent_version=parent_version)
 
         assert data['id'] == file.pk


### PR DESCRIPTION
Fixes #14072 

This is just a small change to allow a serializer to return a file without entries. Once this lands work can be done to create an API endpoint that returns this limited information for a file.