### PR TITLE
Remove leading/trailing newlines in translated content in emails

### DIFF
--- a/src/olympia/devhub/templates/devhub/emails/api_key_confirmation.ltxt
+++ b/src/olympia/devhub/templates/devhub/emails/api_key_confirmation.ltxt
@@ -9,5 +9,4 @@ If you didn't request this, please notify amo-admins@mozilla.com.
 
 Regards,
 
-The Mozilla Add-ons Team
-{% endblocktrans %}
+The Mozilla Add-ons Team{% endblocktrans %}

--- a/src/olympia/devhub/templates/devhub/emails/new-key-email.ltxt
+++ b/src/olympia/devhub/templates/devhub/emails/new-key-email.ltxt
@@ -5,5 +5,4 @@
 If you believe this key was created in error, you can remove the key and
 disable access at the following location:
 
-{{ url }}
-{% endblocktrans %}
+{{ url }}{% endblocktrans %}

--- a/src/olympia/devhub/templates/devhub/emails/revoked-key-email.ltxt
+++ b/src/olympia/devhub/templates/devhub/emails/revoked-key-email.ltxt
@@ -5,5 +5,4 @@
 If you believe this key was revoked in error, you can create a new one
 at the following location:
 
-{{ url }}
-{% endblocktrans %}
+{{ url }}{% endblocktrans %}

--- a/src/olympia/devhub/templates/devhub/emails/submission_api_key_revocation.txt
+++ b/src/olympia/devhub/templates/devhub/emails/submission_api_key_revocation.txt
@@ -6,5 +6,4 @@ You can generate new API credentials at {{ api_keys_url }}
 Please make sure you never share your credentials with anyone. Never include them in a public repository, add-on or any other public place. We encourage you to review your code repositories and your extensions to remove any references to your AMO credentials.
 
 Thank you,
-The Mozilla Add-ons team
-{% endblocktrans %}
+The Mozilla Add-ons team{% endblocktrans %}

--- a/src/olympia/users/templates/users/emails/author_added.ltxt
+++ b/src/olympia/users/templates/users/emails/author_added.ltxt
@@ -1,5 +1,3 @@
-{% load i18n %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans with addon_url=addon.get_absolute_url addon_name=addon.name author_url=author.user.get_absolute_url author_name=author.user.name author_role=author.get_role_display %}
-The following author has been added to your addon {{ addon_name }} ( {{ addon_url }} ):
+{% load i18n %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans with addon_url=addon.get_absolute_url addon_name=addon.name author_url=author.user.get_absolute_url author_name=author.user.name author_role=author.get_role_display %}The following author has been added to your addon {{ addon_name }} ( {{ addon_url }} ):
 
-{{ author_name }} ( {{ author_url }} ): {{ author_role }}
-{% endblocktrans %}
+{{ author_name }} ( {{ author_url }} ): {{ author_role }}{% endblocktrans %}

--- a/src/olympia/users/templates/users/emails/author_added_confirmation.ltxt
+++ b/src/olympia/users/templates/users/emails/author_added_confirmation.ltxt
@@ -1,5 +1,4 @@
-{% load i18n %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans with addon_name=addon.name author_name=author.user.name domain=DOMAIN %}
-Greetings {{ author_name }},
+{% load i18n %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans with addon_name=addon.name author_name=author.user.name domain=DOMAIN %}Greetings {{ author_name }},
 
 You have been invited to become an author of {{ addon_name }} on {{ domain }}. Accepting the invitation will give you access to edit the add-on, and may show your name in the authors list on the website.
 
@@ -10,5 +9,4 @@ Click on the link below to respond if you want to be added as an author for {{ a
 If you didn't expect to receive this invitation, please send an email to amo-admins@mozilla.com.
 
 Kind regards,
-The Mozilla Add-ons Team
-{% endblocktrans %}
+The Mozilla Add-ons Team{% endblocktrans %}

--- a/src/olympia/users/templates/users/emails/author_changed.ltxt
+++ b/src/olympia/users/templates/users/emails/author_changed.ltxt
@@ -1,5 +1,3 @@
-{% load i18n %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans with addon_url=addon.get_absolute_url addon_name=addon.name author_url=author.user.get_absolute_url author_name=author.user.name author_role=author.get_role_display %}
-The following author has been changed on your addon {{ addon_name }} ( {{ addon_url }} ):
+{% load i18n %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans with addon_url=addon.get_absolute_url addon_name=addon.name author_url=author.user.get_absolute_url author_name=author.user.name author_role=author.get_role_display %}The following author has been changed on your addon {{ addon_name }} ( {{ addon_url }} ):
 
-{{ author_name }} ( {{ author_url }} ): {{ author_role }}
-{% endblocktrans %}
+{{ author_name }} ( {{ author_url }} ): {{ author_role }}{% endblocktrans %}

--- a/src/olympia/users/templates/users/emails/author_removed.ltxt
+++ b/src/olympia/users/templates/users/emails/author_removed.ltxt
@@ -1,5 +1,3 @@
-{% load i18n %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans with addon_url=addon.get_absolute_url addon_name=addon.name author_url=author.user.get_absolute_url author_name=author.user.name %}
-The following author has been removed from addon {{ addon_name }} ( {{ addon_url }} ):
+{% load i18n %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans with addon_url=addon.get_absolute_url addon_name=addon.name author_url=author.user.get_absolute_url author_name=author.user.name %}The following author has been removed from addon {{ addon_name }} ( {{ addon_url }} ):
 
-{{ author_name }} ( {{ author_url }} )
-{% endblocktrans %}
+{{ author_name }} ( {{ author_url }} ){% endblocktrans %}


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/14044