### PR TITLE
Create an empty commit when a version has no files

### DIFF
--- a/src/olympia/lib/git.py
+++ b/src/olympia/lib/git.py
@@ -345,12 +345,12 @@ class AddonGitRepository(object):
             translation.activate('en-US')
 
             repo = cls(version.addon.id, package_type='addon')
-            file_obj = version.all_files[0]
+            file_obj = version.all_files[0] if version.all_files else None
             branch = repo.find_or_create_branch(BRANCHES[version.channel])
             note = ' ({})'.format(note) if note else ''
 
             commit = repo._commit_through_worktree(
-                path=file_obj.current_file_path,
+                path=file_obj.current_file_path if file_obj else None,
                 message=(
                     'Create new version {version} ({version_id}) for '
                     '{addon} from {file_obj}{note}'.format(
@@ -431,11 +431,12 @@ class AddonGitRepository(object):
         temporary directory where we extract to.
         """
         with TemporaryWorktree(self.git_repository) as worktree:
-            # Now extract the extension to the workdir
-            extract_extension_to_dest(
-                source=path,
-                dest=worktree.extraction_target_path,
-                force_fsync=True)
+            if path:
+                # Now extract the extension to the workdir
+                extract_extension_to_dest(
+                    source=path,
+                    dest=worktree.extraction_target_path,
+                    force_fsync=True)
 
             # Stage changes, `TemporaryWorktree` always cleans the whole
             # directory so we can simply add all changes and have the correct

--- a/src/olympia/lib/tests/test_git.py
+++ b/src/olympia/lib/tests/test_git.py
@@ -526,6 +526,21 @@ def test_extract_and_commit_from_version_commits_files(
 
 
 @pytest.mark.django_db
+def test_extract_and_commit_without_files():
+    addon = addon_factory()
+    # Simulate no files for the current version. We cannot delete the file
+    # because of the ON_DELETE constraint.
+    addon.current_version.all_files = []
+
+    repo = AddonGitRepository.extract_and_commit_from_version(
+        addon.current_version)
+
+    output = _run_process('git rev-list --count listed', repo)
+    # 1 initial commit + 1 for the commit created above.
+    assert output == '2\n'
+
+
+@pytest.mark.django_db
 def test_extract_and_commit_from_version_reverts_active_locale():
     from django.utils.translation import get_language
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/14098

---

This patch creates an empty commit when a version has no files. It shouldn't be possible anymore but we probably have versions without any file in the wild..