### PR TITLE
Detect and handle missing master branch in git repos

### DIFF
--- a/src/olympia/git/management/commands/git_extraction.py
+++ b/src/olympia/git/management/commands/git_extraction.py
@@ -60,7 +60,7 @@ class Command(BaseCommand):
         It does not run if the add-on is locked for git extraction.
         """
         addon = entry.addon
-        log.info('Starting extraction of add-on "{}".'.format(addon.pk))
+        log.info('Starting git extraction of add-on "{}".'.format(addon.pk))
 
         # We cannot use `entry.in_progress` because we have to be sure of the
         # add-on state and `entry` might not reflect the most up-to-date
@@ -85,7 +85,7 @@ class Command(BaseCommand):
 
         if len(versions_to_extract) == 0:
             log.info(
-                'No version to extract for add-on "{}", '
+                'No version to git-extract for add-on "{}", '
                 'exiting.'.format(addon.pk)
             )
             # We can safely delete the entry because there is no version to
@@ -104,7 +104,7 @@ class Command(BaseCommand):
         tasks.append(remove_git_extraction_entry.si(addon.pk))
 
         log.info(
-            'Submitted {} tasks to extract {} versions for add-on '
+            'Submitted {} tasks to git-extract {} versions for add-on '
             '"{}".'.format(len(tasks), len(versions_to_extract), addon.pk)
         )
         # Attach an error handler on the chain and run it. The error

--- a/src/olympia/lib/git.py
+++ b/src/olympia/lib/git.py
@@ -105,6 +105,10 @@ class BrokenRefError(RuntimeError):
     pass
 
 
+class MissingMasterBranchError(RuntimeError):
+    pass
+
+
 def get_mime_type_for_blob(tree_or_blob, name, blob):
     """Returns the mimetype and type category for a git blob.
 
@@ -250,7 +254,7 @@ class AddonGitRepository(object):
                 path=self.git_repository_path,
                 bare=False)
             # Write first commit to 'master' to act as HEAD
-            tree = self.git_repository.TreeBuilder().write()
+            tree = git_repository.TreeBuilder().write()
             git_repository.create_commit(
                 'HEAD',  # ref
                 self.get_author(),  # author, using addons-robot
@@ -263,6 +267,17 @@ class AddonGitRepository(object):
                 path=self.git_repository_path))
         else:
             git_repository = pygit2.Repository(self.git_repository_path)
+
+            # We have to verify that the 'master' branch exists because we
+            # might have mis-initialized repositories in the past.
+            # See: https://github.com/mozilla/addons-server/issues/14127
+            try:
+                master_ref = 'refs/heads/master'
+                git_repository.lookup_reference(master_ref)
+            except KeyError:
+                message = 'Reference "{}" not found'.format(master_ref)
+                log.exception(message)
+                raise MissingMasterBranchError(message)
 
         return git_repository
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/14127

---

This patch fixes an issue described in the link above. Because of a small
mistake in our code, some repositories have been created without a `master`
branch and that is a problem for git extraction.

With this patch, we detect this problem. Without the cron-based git extraction
feature, it does nothing more than before. The error in Sentry will be
different but that's it. With the feature enabled, we will handle this error by
deleting the git repository and re-extracting all the versions of the add-on.