### PR TITLE
Always use most up-to-date reference of a branch to commit

### DIFF
--- a/src/olympia/lib/git.py
+++ b/src/olympia/lib/git.py
@@ -489,7 +489,11 @@ class AddonGitRepository(object):
                 tree,
                 # Set the current branch HEAD as the parent of this commit
                 # so that it'll go straight into the branches commit log
-                [branch.target]
+                #
+                # We use `lookup_reference` to fetch the most up-to-date
+                # reference to the branch in order to avoid an error described
+                # in: https://github.com/mozilla/addons-server/issues/13932
+                [self.git_repository.lookup_reference(branch.name).target]
             )
 
             # Fetch the commit object
@@ -498,7 +502,13 @@ class AddonGitRepository(object):
             # And set the commit we just created as HEAD of the relevant
             # branch, and updates the reflog. This does not require any
             # merges.
-            branch.set_target(commit.hex)
+            #
+            # We use `lookup_reference` to fetch the most up-to-date reference
+            # to the branch in order to avoid an error described in:
+            # https://github.com/mozilla/addons-server/issues/13932
+            self.git_repository.lookup_reference(branch.name).set_target(
+                commit.hex
+            )
 
         return commit
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/13932

---

This patch fixes an issue we're only having in production for obscure reasons.
This issue happens frequently so fixing it seems like a good idea. I am not sure
why it occurs, though. It could be the filesystem lagging or parallel extraction?

The test case fails with the same error as the one described in the issue above
(without the fixes in `lib/git.py`). In libgit2, the error message only appears
once (and it is not referenced elsewhere like pygit2 or any other layers) so, by
being able to simulate this error in the test case, I am confident that it does
reproduce the issue correctly (even if the test case setup looks unrealistic).