### PR TITLE
compare blocked versions to detect block deletions too

### DIFF
--- a/src/olympia/blocklist/management/commands/export_blocklist.py
+++ b/src/olympia/blocklist/management/commands/export_blocklist.py
@@ -39,12 +39,13 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         log.debug('Exporting blocklist to file')
-        generate_kw = {}
+        mlbf = MLBF(options.get('id'))
+
         if options.get('block_guids_input'):
-            generate_kw['blocked'] = (
+            mlbf.blocked_json = MLBF.hash_filter_inputs(
                 self.load_json(options.get('block_guids_input')))
         if options.get('addon_guids_input'):
-            generate_kw['not_blocked'] = (
+            mlbf.not_blocked_json = MLBF.hash_filter_inputs(
                 self.load_json(options.get('addon_guids_input')))
 
-        MLBF(options.get('id')).generate_and_write_mlbf(**generate_kw)
+        mlbf.generate_and_write_mlbf()

--- a/src/olympia/blocklist/mlbf.py
+++ b/src/olympia/blocklist/mlbf.py
@@ -25,6 +25,10 @@ class MLBF():
         # simplify later code by assuming always a string
         self.id = str(id_)
 
+    @cached_property
+    def blocked_versions(self):
+        return self.get_blocked_versions()
+
     @classmethod
     def get_blocked_versions(cls):
         from olympia.files.models import File
@@ -141,7 +145,7 @@ class MLBF():
         stats = {}
 
         if not blocked:
-            blocked_versions = self.get_blocked_versions()
+            blocked_versions = self.blocked_versions
             blocked = blocked_versions.values()
             version_excludes = blocked_versions.keys()
         else:

--- a/src/olympia/blocklist/mlbf.py
+++ b/src/olympia/blocklist/mlbf.py
@@ -61,7 +61,7 @@ class MLBF():
         return all_versions
 
     @classmethod
-    def fetch_all_addons_from_db(cls, excluding_version_ids=None):
+    def fetch_all_versions_from_db(cls, excluding_version_ids=None):
         from olympia.versions.models import Version
 
         return (
@@ -154,7 +154,7 @@ class MLBF():
         version_excludes = getattr(
             self, '_version_excludes', self.fetch_blocked_from_db().keys())
         self.not_blocked_json = self.hash_filter_inputs(
-            self.fetch_all_addons_from_db(version_excludes))
+            self.fetch_all_versions_from_db(version_excludes))
         return self.not_blocked_json
 
     @property

--- a/src/olympia/blocklist/mlbf.py
+++ b/src/olympia/blocklist/mlbf.py
@@ -25,12 +25,8 @@ class MLBF():
         # simplify later code by assuming always a string
         self.id = str(id_)
 
-    @cached_property
-    def blocked_versions(self):
-        return self.get_blocked_versions()
-
     @classmethod
-    def get_blocked_versions(cls):
+    def fetch_blocked_from_db(cls):
         from olympia.files.models import File
         from olympia.blocklist.models import Block
 
@@ -65,7 +61,7 @@ class MLBF():
         return all_versions
 
     @classmethod
-    def get_all_guids(cls, excluding_version_ids=None):
+    def fetch_all_addons_from_db(cls, excluding_version_ids=None):
         from olympia.versions.models import Version
 
         return (
@@ -121,6 +117,21 @@ class MLBF():
         with storage.open(self._blocked_path, 'r') as json_file:
             return json.load(json_file)
 
+    def fetch_blocked_json(self):
+        """A safer version of .blocked_json that will generate from the db
+        if the cached_property isn't set."""
+        try:
+            return self.blocked_json
+        except FileNotFoundError:
+            # when self._blocked_path doesn't exist
+            pass
+        blocked_versions = self.fetch_blocked_from_db()
+        blocked = blocked_versions.values()
+        # cache version ids so query in fetch_not_blocked_json is efficient
+        self._version_excludes = blocked_versions.keys()
+        self.blocked_json = self.hash_filter_inputs(blocked)
+        return self.blocked_json
+
     @property
     def _not_blocked_path(self):
         return os.path.join(
@@ -131,34 +142,38 @@ class MLBF():
         with storage.open(self._not_blocked_path, 'r') as json_file:
             return json.load(json_file)
 
+    def fetch_not_blocked_json(self):
+        """A safer version of .not_blocked_json that will generate from the db
+        if the cached_property isn't set."""
+        try:
+            return self.not_blocked_json
+        except FileNotFoundError:
+            # when self._not_blocked_path doesn't exist
+            pass
+        # see fetch_blocked_json
+        version_excludes = getattr(
+            self, '_version_excludes', self.fetch_blocked_from_db().keys())
+        self.not_blocked_json = self.hash_filter_inputs(
+            self.fetch_all_addons_from_db(version_excludes))
+        return self.not_blocked_json
+
     @property
-    def stash_path(self):
+    def _stash_path(self):
         return os.path.join(
             settings.MLBF_STORAGE_PATH, self.id, 'stash.json')
 
     @cached_property
     def stash_json(self):
-        with storage.open(self.stash_path, 'r') as json_file:
+        with storage.open(self._stash_path, 'r') as json_file:
             return json.load(json_file)
 
-    def generate_and_write_mlbf(self, *, blocked=None, not_blocked=None):
+    def generate_and_write_mlbf(self):
         stats = {}
-
-        if not blocked:
-            blocked_versions = self.blocked_versions
-            blocked = blocked_versions.values()
-            version_excludes = blocked_versions.keys()
-        else:
-            version_excludes = ()
-
-        self.blocked_json = self.hash_filter_inputs(blocked)
-        self.not_blocked_json = self.hash_filter_inputs(
-            not_blocked or self.get_all_guids(version_excludes))
 
         bloomfilter = self.generate_mlbf(
             stats=stats,
-            blocked=self.blocked_json,
-            not_blocked=self.not_blocked_json)
+            blocked=self.fetch_blocked_json(),
+            not_blocked=self.fetch_not_blocked_json())
         # write bloomfilter
         mlbf_path = self.filter_path
         with storage.open(mlbf_path, 'wb') as filter_file:
@@ -195,7 +210,7 @@ class MLBF():
             'unblocked': list(deletes),
         }
         # write stash
-        stash_path = self.stash_path
+        stash_path = self._stash_path
         with storage.open(stash_path, 'w') as json_file:
             log.info("Writing to file {}".format(stash_path))
             json.dump(self.stash_json, json_file)
@@ -204,8 +219,18 @@ class MLBF():
         try:
             # compare base with current blocks
             extras, deletes = self.generate_diffs(
-                previous_base_mlbf.blocked_json, self.blocked_json)
+                previous_base_mlbf.blocked_json, self.fetch_blocked_json())
             return (len(extras) + len(deletes)) > self.BASE_REPLACE_THRESHOLD
+        except FileNotFoundError:
+            # when previous_base_mlfb._blocked_path doesn't exist
+            return True
+
+    def blocks_changed_since_previous(self, previous_base_mlbf):
+        try:
+            # compare base with current blocks
+            extras, deletes = self.generate_diffs(
+                previous_base_mlbf.blocked_json, self.fetch_blocked_json())
+            return bool(extras) or bool(deletes)
         except FileNotFoundError:
             # when previous_base_mlfb._blocked_path doesn't exist
             return True

--- a/src/olympia/blocklist/tasks.py
+++ b/src/olympia/blocklist/tasks.py
@@ -31,6 +31,7 @@ bracket_close_regex = re.compile(r'(?<!\\)}')
 
 MLBF_TIME_CONFIG_KEY = 'blocklist_mlbf_generation_time'
 MLBF_BASE_ID_CONFIG_KEY = 'blocklist_mlbf_base_id'
+MLBF_COUNT_CONFIG_KEY = 'blocklist_mlbf_blocked_count'
 
 BLOCKLIST_RECORD_MLBF_BASE = 'bloomfilter-base'
 BLOCKLIST_RECORD_MLBF_UPDATE = 'bloomfilter-full'
@@ -178,5 +179,6 @@ def upload_filter_to_kinto(generation_time, is_base=True, upload_stash=False):
         server.publish_attachment(data, attachment)
     server.complete_session()
     set_config(MLBF_TIME_CONFIG_KEY, generation_time, json_value=True)
+    set_config(MLBF_COUNT_CONFIG_KEY, len(mlbf.blocked_json), json_value=True)
     if is_base:
         set_config(MLBF_BASE_ID_CONFIG_KEY, generation_time, json_value=True)

--- a/src/olympia/blocklist/tasks.py
+++ b/src/olympia/blocklist/tasks.py
@@ -31,7 +31,6 @@ bracket_close_regex = re.compile(r'(?<!\\)}')
 
 MLBF_TIME_CONFIG_KEY = 'blocklist_mlbf_generation_time'
 MLBF_BASE_ID_CONFIG_KEY = 'blocklist_mlbf_base_id'
-MLBF_COUNT_CONFIG_KEY = 'blocklist_mlbf_blocked_count'
 
 BLOCKLIST_RECORD_MLBF_BASE = 'bloomfilter-base'
 BLOCKLIST_RECORD_MLBF_UPDATE = 'bloomfilter-full'
@@ -179,6 +178,5 @@ def upload_filter_to_kinto(generation_time, is_base=True, upload_stash=False):
         server.publish_attachment(data, attachment)
     server.complete_session()
     set_config(MLBF_TIME_CONFIG_KEY, generation_time, json_value=True)
-    set_config(MLBF_COUNT_CONFIG_KEY, len(mlbf.blocked_json), json_value=True)
     if is_base:
         set_config(MLBF_BASE_ID_CONFIG_KEY, generation_time, json_value=True)

--- a/src/olympia/blocklist/tests/test_cron.py
+++ b/src/olympia/blocklist/tests/test_cron.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import os
+from datetime import timedelta
 from unittest import mock
 
 from django.conf import settings
@@ -191,9 +192,9 @@ class TestUploadToKinto(TestCase):
     def test_no_block_changes(frozen_time, self):
         # This was the last time the mlbf was generated
         last_time = int(
-            datetime.datetime(2020, 1, 1, 12, 34, 1).timestamp() * 1000)
-        # And the Block was modified just before so would be included
-        self.block.update(modified=datetime.datetime(2020, 1, 1, 12, 34, 0))
+            (frozen_time() - timedelta(seconds=1)).timestamp() * 1000)
+        # And the Block was modified just that before so would be included
+        self.block.update(modified=(frozen_time() - timedelta(seconds=2)))
         set_config(MLBF_TIME_CONFIG_KEY, last_time, json_value=True)
         prev_blocked_path = os.path.join(
             settings.MLBF_STORAGE_PATH, str(last_time), 'blocked.json')

--- a/src/olympia/blocklist/tests/test_mlbf.py
+++ b/src/olympia/blocklist/tests/test_mlbf.py
@@ -68,34 +68,34 @@ class TestMLBF(TestCase):
             updated_by=user_factory(),
             min_version='9999')
 
-    def test_all_guids(self):
-        all_guids = MLBF.fetch_all_addons_from_db()
-        assert len(all_guids) == File.objects.count() == 10 + 10
-        assert (self.five_ver.guid, '123.40') in all_guids
-        assert (self.five_ver.guid, '123.5') in all_guids
-        assert (self.five_ver.guid, '123.45.1') in all_guids
-        assert (self.five_ver.guid, '123.5.1') in all_guids
-        assert (self.five_ver.guid, '123.5.2') in all_guids
+    def test_fetch_all_versions_from_db(self):
+        all_versions = MLBF.fetch_all_versions_from_db()
+        assert len(all_versions) == File.objects.count() == 10 + 10
+        assert (self.five_ver.guid, '123.40') in all_versions
+        assert (self.five_ver.guid, '123.5') in all_versions
+        assert (self.five_ver.guid, '123.45.1') in all_versions
+        assert (self.five_ver.guid, '123.5.1') in all_versions
+        assert (self.five_ver.guid, '123.5.2') in all_versions
         over_tuple = (self.over.guid, self.over.addon.current_version.version)
         under_tuple = (
             self.under.guid, self.under.addon.current_version.version)
-        assert over_tuple in all_guids
-        assert under_tuple in all_guids
+        assert over_tuple in all_versions
+        assert under_tuple in all_versions
 
         # repeat, but with excluded version ids
         excludes = [self.five_ver_123_45.id, self.five_ver_123_5.id]
-        all_guids = MLBF.fetch_all_addons_from_db(excludes)
-        assert len(all_guids) == 18
-        assert (self.five_ver.guid, '123.40') not in all_guids
-        assert (self.five_ver.guid, '123.5') not in all_guids
-        assert (self.five_ver.guid, '123.45.1') in all_guids
-        assert (self.five_ver.guid, '123.5.1') in all_guids
-        assert (self.five_ver.guid, '123.5.2') in all_guids
+        all_versions = MLBF.fetch_all_versions_from_db(excludes)
+        assert len(all_versions) == 18
+        assert (self.five_ver.guid, '123.40') not in all_versions
+        assert (self.five_ver.guid, '123.5') not in all_versions
+        assert (self.five_ver.guid, '123.45.1') in all_versions
+        assert (self.five_ver.guid, '123.5.1') in all_versions
+        assert (self.five_ver.guid, '123.5.2') in all_versions
         over_tuple = (self.over.guid, self.over.addon.current_version.version)
         under_tuple = (
             self.under.guid, self.under.addon.current_version.version)
-        assert over_tuple in all_guids
-        assert under_tuple in all_guids
+        assert over_tuple in all_versions
+        assert under_tuple in all_versions
 
     def test_fetch_blocked_from_db(self):
         blocked_versions = MLBF.fetch_blocked_from_db()
@@ -191,7 +191,7 @@ class TestMLBF(TestCase):
             key = mlbf.KEY_FORMAT.format(guid=guid, version=version_str)
             assert key in bfilter
 
-        all_addons = mlbf.fetch_all_addons_from_db(blocked_versions.keys())
+        all_addons = mlbf.fetch_all_versions_from_db(blocked_versions.keys())
         for guid, version_str in all_addons:
             key = mlbf.KEY_FORMAT.format(guid=guid, version=version_str)
             assert key not in bfilter
@@ -236,7 +236,7 @@ class TestMLBF(TestCase):
             assert json.load(stash_file) == full_stash
         assert newer_mlbf.stash_json == full_stash
 
-    def test_should_reset_base_filter(self):
+    def test_should_reset_base_filter_and_blocks_changed_since_previous(self):
         base_mlbf = MLBF('base')
         # should handle the files not existing
         assert MLBF('no_files').should_reset_base_filter(base_mlbf)


### PR DESCRIPTION
fixes #14107 - the other solution to doing this is to load the previous blocked json and I'm not sure if that is a better idea. We'd have to load and parse an extra JSON file but we wouldn't have to keep track of a config value.