### PR TITLE
Fix ActivityLog/UserRestrictionHistory not saved for API 403/429 errors

### DIFF
--- a/src/olympia/devhub/permissions.py
+++ b/src/olympia/devhub/permissions.py
@@ -14,6 +14,7 @@ class IsSubmissionAllowedFor(BasePermission):
         checker = UploadRestrictionChecker(request)
         if not checker.is_submission_allowed():
             self.message = checker.get_error_message()
+            self.code = 'permission_denied_restriction'
             return False
         return True
 

--- a/src/olympia/signing/views.py
+++ b/src/olympia/signing/views.py
@@ -137,13 +137,11 @@ class VersionView(APIView):
         """
         If request is not permitted, determine what kind of exception to raise.
 
-         (Lifted from DRF, but also passing the optional code argument to
-          the PermissionDenied exception)
+        (Lifted from DRF, but also passing the optional code argument to
+        the PermissionDenied exception)
         """
         if request.authenticators and not request.successful_authenticator:
             raise exceptions.NotAuthenticated()
-        # If I can't figure out how to properly get the code without breaking
-        # stuff, maybe I can cheat and return an entirely different class here
         raise exceptions.PermissionDenied(
             detail=message, code=code)
 

--- a/src/olympia/signing/views.py
+++ b/src/olympia/signing/views.py
@@ -3,6 +3,7 @@ import functools
 from django import forms
 from django.utils.translation import ugettext
 
+from rest_framework import exceptions
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -75,7 +76,7 @@ def with_addon(allow_missing=False):
 
 class BurstUserAddonUploadThrottle(
         ThrottleOnlyUnsafeMethodsMixin, GranularUserRateThrottle):
-    scope = 'burst_ip_addon_upload'
+    scope = 'burst_user_addon_upload'
     rate = '3/minute'
 
 
@@ -93,7 +94,7 @@ class BurstIPAddonUploadThrottle(
 
 class SustainedIPAddonUploadThrottle(
         ThrottleOnlyUnsafeMethodsMixin, GranularIPRateThrottle):
-    scope = 'sustained_user_addon_upload'
+    scope = 'sustained_ip_addon_upload'
     rate = '50/hour'
 
 
@@ -112,6 +113,39 @@ class VersionView(APIView):
         if acl.action_allowed(request, amo.permissions.LANGPACK_SUBMIT):
             return
         super().check_throttles(request)
+
+    # When DRF 3.12 is released, we can remove the custom check_permissions()
+    # and permission_denied() as it will contain the fix for
+    # https://github.com/encode/django-rest-framework/issues/7038
+    def check_permissions(self, request):
+        """
+        Check if the request should be permitted.
+        Raises an appropriate exception if the request is not permitted.
+
+        (Lifted from DRF, but also passing the code argument down to the
+        permission_denied() call if that property existed on the failed
+        permission class)
+        """
+        for permission in self.get_permissions():
+            if not permission.has_permission(request, self):
+                self.permission_denied(
+                    request, message=getattr(permission, 'message', None),
+                    code=getattr(permission, 'code', None),
+                )
+
+    def permission_denied(self, request, message=None, code=None):
+        """
+        If request is not permitted, determine what kind of exception to raise.
+
+         (Lifted from DRF, but also passing the optional code argument to
+          the PermissionDenied exception)
+        """
+        if request.authenticators and not request.successful_authenticator:
+            raise exceptions.NotAuthenticated()
+        # If I can't figure out how to properly get the code without breaking
+        # stuff, maybe I can cheat and return an entirely different class here
+        raise exceptions.PermissionDenied(
+            detail=message, code=code)
 
     def post(self, request, *args, **kwargs):
         version_string = request.data.get('version', None)


### PR DESCRIPTION
Fix `ActivityLog`/`UserRestrictionHistory` not saved for API 403/429 errors
     
DRF's default exception handler was rolling back the current transaction when those errors were triggered, causing any database inserts to not go through.

Fixes #14039
Fixes #13943