### PR TITLE
Update Browse and Compare API endpoints to allow for `file_only`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -242,5 +242,4 @@ nitpick_ignore = [
     ('http:obj', 'string|null'),
     ('http:obj', 'array|null'),
     ('http:obj', 'int|null'),
-    ('http:obj', 'boolean|string'),  # FIXME: should be removed in #10685
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ sys.path.append(os.path.abspath('..'))
 # -- General configuration ----------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be
-#extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest',
               'sphinx.ext.intersphinx', 'sphinx.ext.todo',
               'sphinx.ext.coverage', 'extensions.src_role',
@@ -240,6 +240,7 @@ nitpick_ignore = [
     ('http:obj', 'string|object|null'),
     ('http:obj', 'string|object'),
     ('http:obj', 'string|null'),
+    ('http:obj', 'array|null'),
     ('http:obj', 'int|null'),
     ('http:obj', 'boolean|string'),  # FIXME: should be removed in #10685
 ]

--- a/docs/topics/api/reviewers.rst
+++ b/docs/topics/api/reviewers.rst
@@ -161,6 +161,7 @@ This endpoint allows you to browse through the contents of an Add-on version.
     .. _reviewers-versions-browse-detail:
 
     :param file: The specific file in the XPI to retrieve. Defaults to manifest.json, install.rdf or package.json for Add-ons as well as the XML file for search engines.
+    :param file_only: Indicates that the API should only return data for the requested file, and not version data. If this is ``true`` then the only property returned of those listed below is the ``file`` property.
     :>json string validation_url_json: The absolute url to the addons-linter validation report, rendered as JSON.
     :>json string validation_url: The absolute url to the addons-linter validation report, rendered as HTML.
     :>json boolean has_been_validated: ``True`` if the version has been validated through addons-linter.
@@ -176,7 +177,7 @@ This endpoint allows you to browse through the contents of an Add-on version.
     :>json string file.filename: The filename of the file.
     :>json string file.mime_category: The mime type category of this file. Can be ``image``, ``directory``, ``text`` or ``binary``.
     :>json boolean uses_unknown_minified_code: Indicates that the selected file could be using minified code.
-    :>json array file.entries[]: The complete file-tree of the extracted XPI.
+    :>json array|null file.entries[]: The complete file-tree of the extracted XPI. Returns ``null`` when ``file_only`` is ``true``.
     :>json int file.entries[].depth: Level of folder-tree depth, starting with 0.
     :>json string file.entries[].filename: The filename of the file.
     :>json string file.entries[].path: The absolute path (from the root of the XPI) of the file.
@@ -206,6 +207,7 @@ This endpoint allows you to compare two Add-on versions with each other.
 
     Properties specific to this endpoint:
 
+    :>json array|null file.entries[]: The complete file-tree of the extracted XPI. Returns ``null`` when ``file_only`` is ``true``.
     :>json array file.entries[]: The complete file-tree of the extracted XPI.
     :>json string file.entries[].status: Status of this file, see https://git-scm.com/docs/git-status#_short_format
     :>json int|null file.entries[].depth: Level of folder-tree depth, starting with 0.

--- a/docs/topics/api/reviewers.rst
+++ b/docs/topics/api/reviewers.rst
@@ -160,8 +160,8 @@ This endpoint allows you to browse through the contents of an Add-on version.
 
     .. _reviewers-versions-browse-detail:
 
-    :param file: The specific file in the XPI to retrieve. Defaults to manifest.json, install.rdf or package.json for Add-ons as well as the XML file for search engines.
-    :param file_only: Indicates that the API should only return data for the requested file, and not version data. If this is ``true`` then the only property returned of those listed below is the ``file`` property.
+    :param string file: The specific file in the XPI to retrieve. Defaults to manifest.json, install.rdf or package.json for Add-ons as well as the XML file for search engines.
+    :param boolean file_only: Indicates that the API should only return data for the requested file, and not version data. If this is ``true`` then the only property returned of those listed below is the ``file`` property.
     :>json string validation_url_json: The absolute url to the addons-linter validation report, rendered as JSON.
     :>json string validation_url: The absolute url to the addons-linter validation report, rendered as HTML.
     :>json boolean has_been_validated: ``True`` if the version has been validated through addons-linter.

--- a/src/olympia/reviewers/api_urls.py
+++ b/src/olympia/reviewers/api_urls.py
@@ -6,7 +6,8 @@ from rest_framework_nested.routers import NestedSimpleRouter
 from .views import (
     AddonReviewerViewSet, ReviewAddonVersionViewSet,
     ReviewAddonVersionCompareViewSet, CannedResponseViewSet,
-    ReviewAddonVersionDraftCommentViewSet)
+    ReviewAddonVersionDraftCommentViewSet, ReviewVersionFileViewSet,
+    ReviewVersionFileCompareViewSet)
 
 
 addons = SimpleRouter()
@@ -16,10 +17,20 @@ versions = NestedSimpleRouter(addons, r'addon', lookup='addon')
 versions.register(
     r'versions', ReviewAddonVersionViewSet, basename='reviewers-versions')
 
+files = NestedSimpleRouter(addons, r'addon', lookup='addon')
+files.register(
+    r'files', ReviewVersionFileViewSet, basename='reviewers-files')
+
+
 compare = NestedSimpleRouter(versions, r'versions', lookup='version')
 compare.register(
     r'compare_to', ReviewAddonVersionCompareViewSet,
     basename='reviewers-versions-compare')
+
+compare_file = NestedSimpleRouter(versions, r'versions', lookup='version')
+compare_file.register(
+    r'compare_file', ReviewVersionFileCompareViewSet,
+    basename='reviewers-compare-file')
 
 draft_comments = NestedSimpleRouter(versions, r'versions', lookup='version')
 draft_comments.register(
@@ -29,7 +40,9 @@ draft_comments.register(
 urlpatterns = [
     url(r'', include(addons.urls)),
     url(r'', include(versions.urls)),
+    url(r'', include(files.urls)),
     url(r'', include(compare.urls)),
+    url(r'', include(compare_file.urls)),
     url(r'', include(draft_comments.urls)),
     url(r'^canned-responses/$', CannedResponseViewSet.as_view(),
         name='reviewers-canned-response-list'),

--- a/src/olympia/reviewers/api_urls.py
+++ b/src/olympia/reviewers/api_urls.py
@@ -6,8 +6,7 @@ from rest_framework_nested.routers import NestedSimpleRouter
 from .views import (
     AddonReviewerViewSet, ReviewAddonVersionViewSet,
     ReviewAddonVersionCompareViewSet, CannedResponseViewSet,
-    ReviewAddonVersionDraftCommentViewSet, ReviewVersionFileViewSet,
-    ReviewVersionFileCompareViewSet)
+    ReviewAddonVersionDraftCommentViewSet)
 
 
 addons = SimpleRouter()
@@ -17,20 +16,10 @@ versions = NestedSimpleRouter(addons, r'addon', lookup='addon')
 versions.register(
     r'versions', ReviewAddonVersionViewSet, basename='reviewers-versions')
 
-files = NestedSimpleRouter(addons, r'addon', lookup='addon')
-files.register(
-    r'files', ReviewVersionFileViewSet, basename='reviewers-files')
-
-
 compare = NestedSimpleRouter(versions, r'versions', lookup='version')
 compare.register(
     r'compare_to', ReviewAddonVersionCompareViewSet,
     basename='reviewers-versions-compare')
-
-compare_file = NestedSimpleRouter(versions, r'versions', lookup='version')
-compare_file.register(
-    r'compare_file', ReviewVersionFileCompareViewSet,
-    basename='reviewers-compare-file')
 
 draft_comments = NestedSimpleRouter(versions, r'versions', lookup='version')
 draft_comments.register(
@@ -40,9 +29,7 @@ draft_comments.register(
 urlpatterns = [
     url(r'', include(addons.urls)),
     url(r'', include(versions.urls)),
-    url(r'', include(files.urls)),
     url(r'', include(compare.urls)),
-    url(r'', include(compare_file.urls)),
     url(r'', include(draft_comments.urls)),
     url(r'^canned-responses/$', CannedResponseViewSet.as_view(),
         name='reviewers-canned-response-list'),

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -6426,50 +6426,7 @@ class TestReviewAddonVersionViewSetDetail(
         response = self.client.get(url)
         assert response.status_code == 404
 
-
-class TestReviewVersionFileViewSetDetail(
-        TestCase, AddonReviewerViewSetPermissionMixin):
-    client_class = APITestClient
-    __test__ = True
-
-    def setUp(self):
-        super(TestReviewVersionFileViewSetDetail, self).setUp()
-
-        # TODO: Most of the initial setup could be moved to
-        # setUpTestData but unfortunately paths are setup in pytest via a
-        # regular autouse fixture that has function-scope so functions in
-        # setUpTestData doesn't use proper paths (cgrebs)
-        self.addon = addon_factory(
-            name=u'My Addôn', slug='my-addon',
-            file_kw={'filename': 'webextension_no_id.xpi'})
-
-        extract_version_to_git(self.addon.current_version.pk)
-
-        self.version = self.addon.current_version
-        self.version.refresh_from_db()
-
-        self._set_tested_url()
-
-    def _test_url(self):
-        response = self.client.get(self.url)
-        assert response.status_code == 200
-        result = json.loads(response.content)
-        assert result['id'] == self.version.current_file.pk
-
-        # part of manifest.json
-        assert '"name": "Beastify"' in result['content']
-
-    def _set_tested_url(self):
-        self.url = reverse_ns('reviewers-files-detail', kwargs={
-            'addon_pk': self.addon.pk,
-            'pk': self.version.pk
-        })
-
-    def test_anonymous(self):
-        response = self.client.get(self.url)
-        assert response.status_code == 401
-
-    def test_requested_file(self):
+    def test_file_only_requested_file(self):
         user = UserProfile.objects.create(username='reviewer')
         self.grant_permission(user, 'Addons:Review')
         self.client.login_api(user)
@@ -6481,15 +6438,16 @@ class TestReviewVersionFileViewSetDetail(
             # - 1 add-on author check
             # - 1 version
             # - 2 file and file validation
-            response = self.client.get(self.url + '?file=README.md&lang=en-US')
+            response = self.client.get(
+                self.url + '?file=README.md&lang=en-US&file_only=true')
         assert response.status_code == 200
         result = json.loads(response.content)
 
-        assert result['content'] == '# beastify\n'
-        assert result['entries'] is None
+        assert result['file']['content'] == '# beastify\n'
+        assert result['file']['entries'] is None
 
         # make sure the correct download url is correctly generated
-        assert result['download_url'] == absolutify(reverse(
+        assert result['file']['download_url'] == absolutify(reverse(
             'reviewers.download_git_file',
             kwargs={
                 'version_id': self.version.pk,
@@ -6497,116 +6455,8 @@ class TestReviewVersionFileViewSetDetail(
             }
         ))
 
-    def test_non_existent_requested_file_returns_404(self):
-        user = UserProfile.objects.create(username='reviewer')
-        self.grant_permission(user, 'Addons:Review')
-        self.client.login_api(user)
-
-        response = self.client.get(self.url + '?file=UNKNOWN_FILE')
-        assert response.status_code == 404
-
-    def test_requested_file_contains_whitespace(self):
-        new_version = version_factory(
-            addon=self.addon, file_kw={'filename': 'webextension_no_id.xpi'})
-
-        repo = AddonGitRepository.extract_and_commit_from_version(new_version)
-
-        apply_changes(
-            repo, new_version, '(function() {})\n', 'content script.js')
-
-        user = UserProfile.objects.create(username='reviewer')
-        self.grant_permission(user, 'Addons:Review')
-        self.client.login_api(user)
-
-        url = reverse_ns('reviewers-files-detail', kwargs={
-            'addon_pk': self.addon.pk,
-            'pk': new_version.pk})
-
-        response = self.client.get(url + '?file=content script.js')
-        assert response.status_code == 200
-        result = json.loads(response.content)
-
-        assert result['content'] == '(function() {})\n'
-
-        # make sure the correct download url is correctly generated
-        assert result['download_url'] == absolutify(reverse(
-            'reviewers.download_git_file',
-            kwargs={
-                'version_id': new_version.pk,
-                'filename': 'content script.js'
-            }
-        ))
-
-    def test_supports_search_plugins(self):
-        self.addon = addon_factory(
-            name=u'My Addôn', slug='my-addon',
-            file_kw={'filename': 'search.xml'})
-
-        extract_version_to_git(self.addon.current_version.pk)
-
-        self.version = self.addon.current_version
-        self.version.refresh_from_db()
-
-        self._set_tested_url()
-
-        user = UserProfile.objects.create(username='reviewer')
-        self.grant_permission(user, 'Addons:Review')
-        self.client.login_api(user)
-
-        response = self.client.get(self.url)
-        assert response.status_code == 200
-        result = json.loads(response.content)
-
-        assert result['content'].startswith(
-            '<?xml version="1.0" encoding="utf-8"?>')
-
-        # make sure the correct download url is correctly generated
-        assert result['download_url'] == absolutify(reverse(
-            'reviewers.download_git_file',
-            kwargs={
-                'version_id': self.version.pk,
-                'filename': 'search.xml'
-            }
-        ))
-
-    def test_version_get_not_found(self):
-        user = UserProfile.objects.create(username='reviewer')
-        self.grant_permission(user, 'Addons:Review')
-        self.client.login_api(user)
-        self.url = reverse_ns('reviewers-files-detail', kwargs={
-            'addon_pk': self.addon.pk,
-            'pk': self.version.current_file.pk + 42})
-        response = self.client.get(self.url)
-        assert response.status_code == 404
-
-    def test_mixed_channel_only_listed_without_unlisted_perm(self):
-        user = UserProfile.objects.create(username='admin')
-
-        # User doesn't have ReviewUnlisted permission
-        self.grant_permission(user, 'Addons:Review')
-
-        self.client.login_api(user)
-
-        # Add an unlisted version to the mix
-        unlisted_version = version_factory(
-            addon=self.addon, channel=amo.RELEASE_CHANNEL_UNLISTED)
-
-        # Now the add-on has both, listed and unlisted versions
-        # but only reviewers with Addons:ReviewUnlisted are able
-        # to see them
-        url = reverse_ns('reviewers-files-detail', kwargs={
-            'addon_pk': self.addon.pk,
-            'pk': self.version.pk})
-
-        response = self.client.get(url)
-        assert response.status_code == 200
-
-        url = reverse_ns('reviewers-files-detail', kwargs={
-            'addon_pk': self.addon.pk,
-            'pk': unlisted_version.pk})
-
-        response = self.client.get(url)
-        assert response.status_code == 404
+        # make sure we did not return any version properties
+        assert len(result.keys()) == 1
 
 
 class TestReviewAddonVersionViewSetList(TestCase):
@@ -7535,281 +7385,24 @@ class TestReviewAddonVersionCompareViewSet(
         result = json.loads(response.content)
         assert result['file']['download_url']
 
-
-class TestReviewVersionFileCompareViewSet(
-        TestCase, AddonReviewerViewSetPermissionMixin):
-    client_class = APITestClient
-    __test__ = True
-
-    def setUp(self):
-        super(TestReviewVersionFileCompareViewSet, self).setUp()
-
-        self.addon = addon_factory(
-            name=u'My Addôn', slug='my-addon',
-            file_kw={'filename': 'webextension_no_id.xpi'})
-
-        extract_version_to_git(self.addon.current_version.pk)
-
-        self.version = self.addon.current_version
-        self.version.refresh_from_db()
-
-        # Default to initial commit for simplicity
-        self.compare_to_version = self.version
-
-        self._set_tested_url()
-
-    def _test_url(self):
-        response = self.client.get(self.url)
-        assert response.status_code == 200
-        result = json.loads(response.content)
-
-        assert result['id'] == self.version.current_file.pk
-        assert result['diff']['path'] == 'manifest.json'
-
-        change = result['diff']['hunks'][0]['changes'][3]
-
-        assert '"name": "Beastify"' in change['content']
-        assert change['type'] == 'insert'
-
-    def _set_tested_url(self):
-        self.url = reverse_ns('reviewers-compare-file-detail', kwargs={
-            'addon_pk': self.addon.pk,
-            'version_pk': self.version.pk,
-            'pk': self.compare_to_version.pk})
-
-    def test_anonymous(self):
-        response = self.client.get(self.url)
-        assert response.status_code == 401
-
-    def test_requested_file(self):
+    def test_file_only_requested_file(self):
         user = UserProfile.objects.create(username='reviewer')
         self.grant_permission(user, 'Addons:Review')
         self.client.login_api(user)
 
-        response = self.client.get(self.url + '?file=README.md')
+        response = self.client.get(self.url + '?file=README.md&file_only=true')
         assert response.status_code == 200
         result = json.loads(response.content)
-        assert result['diff']['path'] == 'README.md'
 
-        change = result['diff']['hunks'][0]['changes'][0]
+        assert result['file']['entries'] is None
+        assert result['file']['diff']['path'] == 'README.md'
+        change = result['file']['diff']['hunks'][0]['changes'][0]
 
         assert change['content'] == '# beastify'
         assert change['type'] == 'insert'
 
-    def test_requested_file_contains_whitespace(self):
-        new_version = version_factory(
-            addon=self.addon, file_kw={'filename': 'webextension_no_id.xpi'})
-
-        repo = AddonGitRepository.extract_and_commit_from_version(new_version)
-
-        apply_changes(
-            repo, new_version, '(function() {})\n', 'content script.js')
-
-        user = UserProfile.objects.create(username='reviewer')
-        self.grant_permission(user, 'Addons:Review')
-        self.client.login_api(user)
-
-        url = reverse_ns('reviewers-compare-file-detail', kwargs={
-            'addon_pk': self.addon.pk,
-            'version_pk': self.version.pk,
-            'pk': new_version.pk})
-
-        response = self.client.get(url + '?file=content script.js')
-        assert response.status_code == 200
-        result = json.loads(response.content)
-        change = result['diff']['hunks'][0]['changes'][0]
-
-        assert result['diff']['path'] == 'content script.js'
-        assert change['content'] == '(function() {})'
-        assert change['type'] == 'insert'
-
-    def test_supports_search_plugins(self):
-        self.addon = addon_factory(
-            name=u'My Addôn', slug='my-addon',
-            file_kw={'filename': 'search.xml'})
-
-        extract_version_to_git(self.addon.current_version.pk)
-
-        self.version = self.addon.current_version
-        self.version.refresh_from_db()
-
-        new_version = version_factory(
-            addon=self.addon, file_kw={'filename': 'search.xml'})
-
-        repo = AddonGitRepository.extract_and_commit_from_version(new_version)
-
-        apply_changes(repo, new_version, '<xml></xml>\n', 'search.xml')
-
-        user = UserProfile.objects.create(username='reviewer')
-        self.grant_permission(user, 'Addons:Review')
-        self.client.login_api(user)
-
-        self.url = reverse_ns('reviewers-compare-file-detail', kwargs={
-            'addon_pk': self.addon.pk,
-            'version_pk': self.version.pk,
-            'pk': new_version.pk})
-
-        response = self.client.get(self.url)
-        assert response.status_code == 200
-        result = json.loads(response.content)
-        changes = result['diff']['hunks'][0]['changes']
-
-        assert result['diff']['path'] == 'search.xml'
-        assert changes[-1] == {
-            'content': '<xml></xml>',
-            'new_line_number': 1,
-            'old_line_number': -1,
-            'type': 'insert'
-        }
-
-        assert all(x['type'] == 'delete' for x in changes[:-1])
-
-    def test_version_get_not_found(self):
-        user = UserProfile.objects.create(username='reviewer')
-        self.grant_permission(user, 'Addons:Review')
-        self.client.login_api(user)
-        self.url = reverse_ns('reviewers-compare-file-detail', kwargs={
-            'addon_pk': self.addon.pk,
-            'version_pk': self.version.pk + 42,
-            'pk': self.compare_to_version.pk})
-        response = self.client.get(self.url)
-        assert response.status_code == 404
-
-    def test_compare_basic(self):
-        new_version = version_factory(
-            addon=self.addon, file_kw={'filename': 'webextension_no_id.xpi'})
-
-        repo = AddonGitRepository.extract_and_commit_from_version(new_version)
-
-        apply_changes(repo, new_version, '{"id": "random"}\n', 'manifest.json')
-        apply_changes(repo, new_version, 'Updated readme\n', 'README.md')
-
-        user = UserProfile.objects.create(username='reviewer')
-        self.grant_permission(user, 'Addons:Review')
-        self.client.login_api(user)
-
-        self.url = reverse_ns('reviewers-compare-file-detail', kwargs={
-            'addon_pk': self.addon.pk,
-            'version_pk': self.version.pk,
-            'pk': new_version.pk})
-
-        with self.assertNumQueries(10):
-            # - 2 savepoints because of tests
-            # - 2 user and groups
-            # - 2 add-on and translations
-            # - 1 add-on author check
-            # - 1 all versions
-            # - 1 all files
-            # - 1 all file validation
-            response = self.client.get(self.url + '?file=README.md&lang=en-US')
-        assert response.status_code == 200
-
-        result = json.loads(response.content)
-
-        assert result['diff']['path'] == 'README.md'
-        assert result['diff']['hunks'][0]['changes'] == [
-            {
-                'content': '# beastify',
-                'new_line_number': -1,
-                'old_line_number': 1,
-                'type': 'delete'
-            },
-            {
-                'content': 'Updated readme',
-                'new_line_number': 1,
-                'old_line_number': -1,
-                'type': 'insert'
-            }
-        ]
-
-    def test_compare_with_deleted_file(self):
-        new_version = version_factory(
-            addon=self.addon, file_kw={'filename': 'webextension_no_id.xpi'})
-
-        repo = AddonGitRepository.extract_and_commit_from_version(new_version)
-
-        deleted_file = 'README.md'
-        apply_changes(repo, new_version, '', deleted_file, delete=True)
-
-        user = UserProfile.objects.create(username='reviewer')
-        self.grant_permission(user, 'Addons:Review')
-        self.client.login_api(user)
-
-        self.url = reverse_ns('reviewers-compare-file-detail', kwargs={
-            'addon_pk': self.addon.pk,
-            'version_pk': self.version.pk,
-            'pk': new_version.pk})
-
-        response = self.client.get(self.url + '?file=' + deleted_file)
-        assert response.status_code == 200
-        result = json.loads(response.content)
-        assert result['download_url'] is None
-
-    def test_dont_servererror_on_binary_file(self):
-        """Regression test for
-        https://github.com/mozilla/addons-server/issues/11712"""
-        new_version = version_factory(
-            addon=self.addon, file_kw={
-                'filename': 'webextension_no_id.xpi',
-                'is_webextension': True,
-            }
-        )
-
-        repo = AddonGitRepository.extract_and_commit_from_version(new_version)
-        apply_changes(repo, new_version, EMPTY_PNG, 'foo.png')
-
-        next_version = version_factory(
-            addon=self.addon, file_kw={
-                'filename': 'webextension_no_id.xpi',
-                'is_webextension': True,
-            }
-        )
-
-        repo = AddonGitRepository.extract_and_commit_from_version(next_version)
-        apply_changes(repo, next_version, EMPTY_PNG, 'foo.png')
-
-        user = UserProfile.objects.create(username='reviewer')
-        self.grant_permission(user, 'Addons:Review')
-        self.client.login_api(user)
-
-        self.url = reverse_ns('reviewers-compare-file-detail', kwargs={
-            'addon_pk': self.addon.pk,
-            'version_pk': new_version.pk,
-            'pk': next_version.pk})
-
-        response = self.client.get(self.url + '?file=foo.png')
-        assert response.status_code == 200
-        result = json.loads(response.content)
-        assert result['download_url']
-
-    def test_compare_with_deleted_version(self):
-        new_version = version_factory(
-            addon=self.addon, file_kw={'filename': 'webextension_no_id.xpi'})
-
-        # We need to run extraction first and delete afterwards, otherwise
-        # we'll end up with errors because files don't exist anymore.
-        AddonGitRepository.extract_and_commit_from_version(new_version)
-
-        new_version.delete()
-
-        user = UserProfile.objects.create(username='reviewer')
-        self.grant_permission(user, 'Addons:Review')
-
-        # A reviewer needs the `Addons:ViewDeleted` permission to view and
-        # compare deleted versions
-        self.grant_permission(user, 'Addons:ViewDeleted')
-
-        self.client.login_api(user)
-
-        self.url = reverse_ns('reviewers-compare-file-detail', kwargs={
-            'addon_pk': self.addon.pk,
-            'version_pk': self.version.pk,
-            'pk': new_version.pk})
-
-        response = self.client.get(self.url)
-        assert response.status_code == 200
-        result = json.loads(response.content)
-        assert result['download_url']
+        # make sure we did not return any version properties
+        assert len(result.keys()) == 1
 
 
 class TestDownloadGitFileView(TestCase):

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -1363,8 +1363,9 @@ class ReviewAddonVersionViewSet(ReviewAddonVersionMixin, ListModelMixin,
         return Response(serializer.data)
 
     def retrieve(self, request, *args, **kwargs):
+        version = self.get_object()
+
         if self.request.GET.get('file_only', False):
-            version = self.get_object()
             serializer = FileEntriesSerializer(
                 instance=version.current_file,
                 context={
@@ -1376,7 +1377,7 @@ class ReviewAddonVersionViewSet(ReviewAddonVersionMixin, ListModelMixin,
             return Response({'file': serializer.data})
 
         serializer = AddonBrowseVersionSerializer(
-            instance=self.get_object(),
+            instance=version,
             context={
                 'file': self.request.GET.get('file', None),
                 'request': self.request


### PR DESCRIPTION
Fixes #14020 

This adds a new URL param to the Browse and Compare endpoints called `file_only`. When that is set to `true` then only file data is returned to the client. The file data is in a top-level property called `file`, and none of the other `version` properties are returned in the API response.