### PR TITLE
Fix query for scanner results

### DIFF
--- a/src/olympia/scanners/tests/test_views.py
+++ b/src/olympia/scanners/tests/test_views.py
@@ -50,6 +50,7 @@ class TestScannerResultView(TestCase):
 
     def test_get(self):
         self.create_switch('enable-scanner-results-api', active=True)
+        task_user = user_factory()
         # result labelled as "bad" because its state is TRUE_POSITIVE
         bad_version = version_factory(addon=addon_factory())
         bad_result = ScannerResult.objects.create(
@@ -76,6 +77,14 @@ class TestScannerResultView(TestCase):
         good_version_2 = version_factory(addon=addon_factory())
         good_result_2 = ScannerResult.objects.create(
             scanner=CUSTOMS, version=good_version_2
+        )
+        VersionLog.objects.create(
+            activity_log=ActivityLog.create(
+                action=amo.LOG.APPROVE_VERSION,
+                version=good_version_2,
+                user=task_user,
+            ),
+            version=good_version_2,
         )
         VersionLog.objects.create(
             activity_log=ActivityLog.create(
@@ -107,7 +116,6 @@ class TestScannerResultView(TestCase):
             version=version_3,
         )
         # result NOT labelled as "good" because user is TASK_USER_ID
-        task_user = user_factory()
         version_4 = version_factory(addon=addon_factory())
         ScannerResult.objects.create(scanner=YARA, version=version_4)
         VersionLog.objects.create(

--- a/src/olympia/scanners/views.py
+++ b/src/olympia/scanners/views.py
@@ -53,8 +53,7 @@ class ScannerResultView(ListAPIView):
                         amo.LOG.CONFIRM_AUTO_APPROVED.id,
                         amo.LOG.APPROVE_VERSION.id,
                     )
-                )
-                & ~Q(
+                ) & ~Q(
                     version__versionlog__activity_log__user_id=settings.TASK_USER_ID  # noqa
                 )
             )

--- a/src/olympia/scanners/views.py
+++ b/src/olympia/scanners/views.py
@@ -1,7 +1,7 @@
 import waffle
 
 from django.conf import settings
-from django.db.models import CharField, Value
+from django.db.models import CharField, Value, Q
 from django.db.transaction import non_atomic_requests
 from django.http import Http404
 from rest_framework.exceptions import ParseError
@@ -47,13 +47,15 @@ class ScannerResultView(ListAPIView):
             good_results = good_results.filter(scanner=scanner)
 
         good_results = (
-            good_results.exclude(
-                version__versionlog__activity_log__user_id=settings.TASK_USER_ID  # noqa
-            )
-            .filter(
-                version__versionlog__activity_log__action__in=(
-                    amo.LOG.CONFIRM_AUTO_APPROVED.id,
-                    amo.LOG.APPROVE_VERSION.id,
+            good_results.filter(
+                Q(
+                    version__versionlog__activity_log__action__in=(
+                        amo.LOG.CONFIRM_AUTO_APPROVED.id,
+                        amo.LOG.APPROVE_VERSION.id,
+                    )
+                )
+                & ~Q(
+                    version__versionlog__activity_log__user_id=settings.TASK_USER_ID  # noqa
                 )
             )
             .annotate(label=Value(LABEL_GOOD, output_field=CharField()))


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/14161

---

This should allow to select scanner results bound to versions that have
activity log entries created by the task user and another user.