### PR TITLE
The images for the primary hero items are aligned at discovery admin

### DIFF
--- a/static/css/admin/discovery.css
+++ b/static/css/admin/discovery.css
@@ -53,7 +53,7 @@
 
 .dynamic-primaryhero .field-gradient_color li,
 .dynamic-primaryhero .field-image li {
-    display: inline-block;
+    display: inline-flex;
 }
 
 .dynamic-primaryhero .field-gradient_color li div,


### PR DESCRIPTION
#12901 

The images for the primary hero items are aligned at admin
admin -> DISCOVERY -> Discovery items -> Add page

**before**
![12901_before](https://user-images.githubusercontent.com/29684524/81047071-a505b300-8ef4-11ea-97c7-58b9eb07f201.png)

**after**
![12901_after](https://user-images.githubusercontent.com/29684524/81047084-aafb9400-8ef4-11ea-8fd5-b754f6648044.png)
