### PR TITLE
Avoid git-extraction loops based on the git repo creation time

### DIFF
--- a/src/olympia/git/tests/test_commands.py
+++ b/src/olympia/git/tests/test_commands.py
@@ -1,3 +1,5 @@
+import datetime
+
 from pathlib import Path
 from unittest import mock
 
@@ -22,6 +24,8 @@ from olympia.git.management.commands.git_extraction import (
     SWITCH_NAME,
     Command as GitExtractionCommand,
 )
+
+from olympia.lib.tests.test_git import update_git_repo_creation_time
 
 
 class TestGitExtraction(TestCase):
@@ -167,6 +171,9 @@ class TestGitExtraction(TestCase):
         # Force the creation of the git repository.
         repo.git_repository
         assert repo.is_extracted
+        # Set the "creation time" of the git repository to something older than
+        # 1 hour.
+        update_git_repo_creation_time(repo, time=datetime.datetime(2020, 1, 1))
         # Create a broken ref, see:
         # https://github.com/mozilla/addons-server/issues/13590
         Path(f'{repo.git_repository_path}/.git/refs/heads/listed').touch()


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/14176

---

Theoretically, the new git-extraction process might be subject to infinite loops if the same add-on fails with a recoverable error over and over again. In this case, we would waste resources for nothing.

This patch should prevent infinite loops by making sure we are not deleting/re-creating a git repository too "soon". In order to do this, we need to know the git repository "creation time". We cannot retrieve this time from the FS (because UNIX systems don't expose that) so this patch uses a file that is present in all git repositories and that never changes (`.git/description`).