### PR TITLE
Stop git-extraction of version sources

### DIFF
--- a/src/olympia/addons/management/commands/process_addons.py
+++ b/src/olympia/addons/management/commands/process_addons.py
@@ -19,9 +19,11 @@ from olympia.abuse.models import AbuseReport
 from olympia.constants.base import _ADDON_PERSONA, _ADDON_THEME, _ADDON_WEBAPP
 from olympia.amo.utils import chunked
 from olympia.devhub.tasks import get_preview_sizes, recreate_previews
+from olympia.git.tasks import delete_source_git_repositories
 from olympia.lib.crypto.tasks import sign_addons
 from olympia.reviewers.tasks import recalculate_post_review_weight
 from olympia.versions.compare import version_int
+from olympia.versions.models import Version
 
 
 firefox_56_star = version_int('56.*')
@@ -124,6 +126,21 @@ tasks = {
     'extract_colors_from_static_themes': {
         'method': extract_colors_from_static_themes,
         'qs': [Q(type=amo.ADDON_STATICTHEME)]
+    },
+    'delete_source_git_repositories': {
+        'method': delete_source_git_repositories,
+        'distinct': True,
+        'qs': [
+            Q(
+                # Retrieve a list of add-on IDs that have at least one version
+                # with a source git hash (which means source files have been
+                # git-extracted).
+                pk__in=Version.unfiltered.exclude(source_git_hash__exact='')
+                .values_list('addon_id', flat=True)
+                .distinct()
+            )
+        ],
+        'allowed_kwargs': ('with_deleted',),
     },
     'delete_obsolete_addons': {
         'method': delete_addons,

--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -208,8 +208,7 @@ def add_dynamic_theme_tag(ids, **kw):
 @task(rate_limit='1/m')
 def migrate_webextensions_to_git_storage(ids, **kw):
     # recursive imports...
-    from olympia.versions.tasks import (
-        extract_version_to_git, extract_version_source_to_git)
+    from olympia.versions.tasks import extract_version_to_git
 
     log.info(
         'Migrating add-ons to git storage %d-%d [%d].',
@@ -255,9 +254,6 @@ def migrate_webextensions_to_git_storage(ids, **kw):
                     file_id=file_id))
 
                 extract_version_to_git(version.pk)
-
-                if version.source:
-                    extract_version_source_to_git(version.pk)
 
                 log.info(
                     'Extraction of file {file_id} into git storage succeeded'

--- a/src/olympia/addons/tests/test_commands.py
+++ b/src/olympia/addons/tests/test_commands.py
@@ -16,6 +16,7 @@ from olympia.abuse.models import AbuseReport
 from olympia.amo.tests import (
     TestCase, addon_factory, user_factory, version_factory)
 from olympia.files.models import FileValidation, WebextPermission
+from olympia.lib.git import AddonGitRepository
 from olympia.ratings.models import Rating
 from olympia.reviewers.models import AutoApprovalSummary
 from olympia.versions.models import VersionPreview
@@ -649,3 +650,34 @@ class TestDeleteOpenSearchAddons(TestCase):
         assert Addon.unfiltered.count() == 2
         assert Addon.objects.get(id=self.extension.id)
         assert Addon.objects.get(id=self.dictionary.id)
+
+
+class TestDeleteSourceGitRepositories(TestCase):
+    def setUp(self):
+        self.addon = addon_factory()
+        self.version = version_factory(addon=self.addon,
+                                       source_git_hash='something')
+        self.repo = AddonGitRepository(self.version.addon_id, 'source')
+        self.repo.git_repository
+        assert self.repo.is_extracted
+
+    def test_basic(self):
+        call_command('process_addons', task='delete_source_git_repositories')
+
+        assert not self.repo.is_extracted
+
+    def test_with_deleted_addons(self):
+        self.addon.delete()
+
+        call_command('process_addons', task='delete_source_git_repositories')
+        assert self.repo.is_extracted
+
+        call_command('process_addons', task='delete_source_git_repositories',
+                     with_deleted=True)
+        assert not self.repo.is_extracted
+
+    def test_with_deleted_versions(self):
+        self.version.delete()
+
+        call_command('process_addons', task='delete_source_git_repositories')
+        assert not self.repo.is_extracted

--- a/src/olympia/addons/tests/test_tasks.py
+++ b/src/olympia/addons/tests/test_tasks.py
@@ -11,7 +11,7 @@ from olympia.amo.storage_utils import copy_stored_file
 from olympia.amo.tests import (
     addon_factory, TestCase, version_factory)
 from olympia.files.utils import id_to_path
-from olympia.versions.models import VersionPreview, source_upload_path
+from olympia.versions.models import VersionPreview
 from olympia.lib.git import AddonGitRepository
 
 
@@ -68,26 +68,6 @@ class TestMigrateWebextensionsToGitStorage(TestCase):
         assert extract_mock.call_args_list[0][0][0] == oldest_version.pk
         assert extract_mock.call_args_list[1][0][0] == older_version.pk
         assert extract_mock.call_args_list[2][0][0] == most_recent.pk
-
-    @mock.patch('olympia.versions.tasks.extract_version_to_git')
-    @mock.patch('olympia.versions.tasks.extract_version_source_to_git')
-    def test_migrate_versions_extracts_source(
-            self, extract_source_mock, extract_mock):
-        addon = addon_factory(file_kw={'filename': 'webextension_no_id.xpi'})
-        version_to_migrate = addon.current_version
-        version_to_migrate.update(
-            source=source_upload_path(version_to_migrate, 'foo.tar.gz'))
-
-        version_without_source = version_factory(
-            addon=addon, file_kw={'filename': 'webextension_no_id.xpi'})
-
-        migrate_webextensions_to_git_storage([addon.pk])
-
-        extract_source_mock.assert_called_once_with(version_to_migrate.pk)
-        extract_mock.assert_has_calls([
-            mock.call(version_to_migrate.pk),
-            mock.call(version_without_source.pk)
-        ])
 
 
 @pytest.mark.django_db

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -944,18 +944,6 @@ class TestAddonSubmitSource(TestSubmitBase):
         repo = AddonGitRepository(self.addon.pk, package_type='source')
         assert os.path.exists(repo.git_repository_path)
 
-    @override_switch('enable-uploads-commit-to-git-storage', active=True)
-    @mock.patch('olympia.devhub.views.extract_version_source_to_git.delay')
-    def test_submit_source_commits_to_git_asnychronously(self, extract_mock):
-        response = self.post(
-            has_source=True, source=self.generate_source_zip())
-        self.assert3xx(response, self.next_url)
-        self.addon = self.addon.reload()
-        assert self.get_version().source
-        extract_mock.assert_called_once_with(
-            version_id=self.addon.current_version.pk,
-            author_id=self.user.pk)
-
 
 class DetailsPageMixin(object):
     """ Some common methods between TestAddonSubmitDetails and

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -33,7 +33,6 @@ from olympia.constants.licenses import LICENSES_BY_BUILTIN
 from olympia.devhub import views
 from olympia.files.tests.test_models import UploadTest
 from olympia.files.utils import parse_addon
-from olympia.lib.git import AddonGitRepository
 from olympia.users.models import IPNetworkUserRestriction, UserProfile
 from olympia.versions.models import License, VersionPreview
 from olympia.zadmin.models import Config, set_config
@@ -920,29 +919,6 @@ class TestAddonSubmitSource(TestSubmitBase):
         self.addon.update(type=amo.ADDON_DICT)
         response = self.client.get(self.url)
         self.assert3xx(response, self.next_url)
-
-    @override_settings(FILE_UPLOAD_MAX_MEMORY_SIZE=1)
-    @override_switch('enable-uploads-commit-to-git-storage', active=False)
-    def test_submit_source_doesnt_commit_to_git_by_default(self):
-        response = self.post(
-            has_source=True, source=self.generate_source_zip())
-        self.assert3xx(response, self.next_url)
-        self.addon = self.addon.reload()
-        assert self.get_version().source
-
-        repo = AddonGitRepository(self.addon.pk, package_type='source')
-        assert not os.path.exists(repo.git_repository_path)
-
-    @override_switch('enable-uploads-commit-to-git-storage', active=True)
-    def test_submit_source_commits_to_git(self):
-        response = self.post(
-            has_source=True, source=self.generate_source_zip())
-        self.assert3xx(response, self.next_url)
-        self.addon = self.addon.reload()
-        assert self.get_version().source
-
-        repo = AddonGitRepository(self.addon.pk, package_type='source')
-        assert os.path.exists(repo.git_repository_path)
 
 
 class DetailsPageMixin(object):

--- a/src/olympia/git/tests/test_tasks.py
+++ b/src/olympia/git/tests/test_tasks.py
@@ -167,8 +167,7 @@ class TestExtractVersionsToGit(TestCase):
 
 class TestDeleteSourceGitRepositories(TestCase):
     def test_deletes_source_repositories(self):
-        deleted_addon = addon_factory()
-        addon_ids = [1, 2, 3, deleted_addon.pk]
+        addon_ids = [1, 2, 3]
 
         for addon_id in addon_ids:
             repo = AddonGitRepository(addon_id, 'source')

--- a/src/olympia/git/tests/test_tasks.py
+++ b/src/olympia/git/tests/test_tasks.py
@@ -6,6 +6,7 @@ from olympia.amo.tests import TestCase, addon_factory
 
 from olympia.git.models import GitExtractionEntry
 from olympia.git.tasks import (
+    delete_source_git_repositories,
     remove_git_extraction_entry,
     on_extraction_error,
     extract_versions_to_git,
@@ -162,3 +163,21 @@ class TestExtractVersionsToGit(TestCase):
                 mock.call(version_id=3, force_extraction=True),
             ]
         )
+
+
+class TestDeleteSourceGitRepositories(TestCase):
+    def test_deletes_source_repositories(self):
+        deleted_addon = addon_factory()
+        addon_ids = [1, 2, 3, deleted_addon.pk]
+
+        for addon_id in addon_ids:
+            repo = AddonGitRepository(addon_id, 'source')
+            # Create the git repo
+            repo.git_repository
+            assert repo.is_extracted
+
+        delete_source_git_repositories(ids=addon_ids)
+
+        for addon_id in addon_ids:
+            repo = AddonGitRepository(addon_id, 'source')
+            assert not repo.is_extracted

--- a/src/olympia/lib/git.py
+++ b/src/olympia/lib/git.py
@@ -245,6 +245,8 @@ class AddonGitRepository(object):
             id_to_path(self.addon_id),
             package_type)
 
+        self.package_type = package_type
+
     @property
     def is_extracted(self):
         return os.path.exists(self.git_repository_path)
@@ -305,9 +307,18 @@ class AddonGitRepository(object):
         if not self.is_extracted:
             log.error('called delete() on a non-extracted git repository')
             return
-        # Reset the git hash of each version of the add-on related to this git
-        # repository.
-        Version.unfiltered.filter(addon_id=self.addon_id).update(git_hash='')
+        if self.package_type == 'source':
+            # Reset the source git hash of each version of the add-on related
+            # to this git repository.
+            Version.unfiltered.filter(addon_id=self.addon_id).update(
+                source_git_hash=''
+            )
+        else:
+            # Reset the git hash of each version of the add-on related to this
+            # git repository.
+            Version.unfiltered.filter(addon_id=self.addon_id).update(
+                git_hash=''
+            )
         shutil.rmtree(self.git_repository_path)
 
     @classmethod

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1179,6 +1179,7 @@ CELERY_TASK_ROUTES = {
     'olympia.files.tasks.hide_disabled_files': {'queue': 'addons'},
     'olympia.versions.tasks.delete_preview_files': {'queue': 'addons'},
     'olympia.versions.tasks.extract_version_to_git': {'queue': 'addons'},
+    'olympia.git.tasks.delete_source_git_repository': {'queue': 'addons'},
     'olympia.git.tasks.extract_versions_to_git': {'queue': 'addons'},
     'olympia.git.tasks.on_extraction_error': {'queue': 'addons'},
     'olympia.git.tasks.remove_git_extraction_entry': {'queue': 'addons'},

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1179,7 +1179,7 @@ CELERY_TASK_ROUTES = {
     'olympia.files.tasks.hide_disabled_files': {'queue': 'addons'},
     'olympia.versions.tasks.delete_preview_files': {'queue': 'addons'},
     'olympia.versions.tasks.extract_version_to_git': {'queue': 'addons'},
-    'olympia.git.tasks.delete_source_git_repository': {'queue': 'addons'},
+    'olympia.git.tasks.delete_source_git_repositories': {'queue': 'addons'},
     'olympia.git.tasks.extract_versions_to_git': {'queue': 'addons'},
     'olympia.git.tasks.on_extraction_error': {'queue': 'addons'},
     'olympia.git.tasks.remove_git_extraction_entry': {'queue': 'addons'},

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1179,9 +1179,6 @@ CELERY_TASK_ROUTES = {
     'olympia.files.tasks.hide_disabled_files': {'queue': 'addons'},
     'olympia.versions.tasks.delete_preview_files': {'queue': 'addons'},
     'olympia.versions.tasks.extract_version_to_git': {'queue': 'addons'},
-    'olympia.versions.tasks.extract_version_source_to_git': {
-        'queue': 'addons'
-    },
     'olympia.git.tasks.extract_versions_to_git': {'queue': 'addons'},
     'olympia.git.tasks.on_extraction_error': {'queue': 'addons'},
     'olympia.git.tasks.remove_git_extraction_entry': {'queue': 'addons'},


### PR DESCRIPTION
Fixes #14174

---

This patch removes the task that is used to git-extract the source files of a version and update the `AddonGitRepository.delete()` method to be able to delete `source` repos. This allows us to implement a new `delete_source_git_repositories` task for `process_addons`.