### PR TITLE
Move the `entries` from the `file` object into the version object for Browse and Compare APIs

### DIFF
--- a/docs/topics/api/reviewers.rst
+++ b/docs/topics/api/reviewers.rst
@@ -166,6 +166,11 @@ This endpoint allows you to browse through the contents of an Add-on version.
     :>json string validation_url: The absolute url to the addons-linter validation report, rendered as HTML.
     :>json boolean has_been_validated: ``True`` if the version has been validated through addons-linter.
     :>json object addon: A simplified :ref:`add-on <addon-detail-object>` object that contains only a few properties: ``id``, ``name``, ``icon_url`` and ``slug``.
+    :>json array file_entries[]: The complete file-tree of the extracted XPI.
+    :>json int file_entries[].depth: Level of folder-tree depth, starting with 0.
+    :>json string file_entries[].filename: The filename of the file.
+    :>json string file_entries[].path: The absolute path (from the root of the XPI) of the file.
+    :>json string file_entries[].mime_category: The mime type category of this file. Can be ``image``, ``directory``, ``text`` or ``binary``.
     :>json object file: The requested file.
     :>json int file.id: The id of the submitted file (i.e., the xpi file).
     :>json string file.content: Raw content of the requested file.
@@ -177,11 +182,6 @@ This endpoint allows you to browse through the contents of an Add-on version.
     :>json string file.filename: The filename of the file.
     :>json string file.mime_category: The mime type category of this file. Can be ``image``, ``directory``, ``text`` or ``binary``.
     :>json boolean uses_unknown_minified_code: Indicates that the selected file could be using minified code.
-    :>json array|null file.entries[]: The complete file-tree of the extracted XPI. Returns ``null`` when ``file_only`` is ``true``.
-    :>json int file.entries[].depth: Level of folder-tree depth, starting with 0.
-    :>json string file.entries[].filename: The filename of the file.
-    :>json string file.entries[].path: The absolute path (from the root of the XPI) of the file.
-    :>json string file.entries[].mime_category: The mime type category of this file. Can be ``image``, ``directory``, ``text`` or ``binary``.
 
 
 -------
@@ -207,13 +207,12 @@ This endpoint allows you to compare two Add-on versions with each other.
 
     Properties specific to this endpoint:
 
-    :>json array|null file.entries[]: The complete file-tree of the extracted XPI. Returns ``null`` when ``file_only`` is ``true``.
-    :>json array file.entries[]: The complete file-tree of the extracted XPI.
+    :>json array file_entries[]: The complete file-tree of the extracted XPI.
     :>json string file.entries[].status: Status of this file, see https://git-scm.com/docs/git-status#_short_format
-    :>json int|null file.entries[].depth: Level of folder-tree depth, starting with 0.
-    :>json string file.entries[].filename: The filename of the file.
-    :>json string file.entries[].path: The absolute path (from the root of the XPI) of the file.
-    :>json string|null file.entries[].mime_category: The mime type category of this file. Can be ``image``, ``directory``, ``text`` or ``binary``.
+    :>json int file_entries[].depth: Level of folder-tree depth, starting with 0.
+    :>json string file_entries[].filename: The filename of the file.
+    :>json string file_entries[].path: The absolute path (from the root of the XPI) of the file.
+    :>json string file_entries[].mime_category: The mime type category of this file. Can be ``image``, ``directory``, ``text`` or ``binary``.
     :>json object|null diff: See the following output with inline comments for a complete description.
     :>json object base_file: The file attached to the base version you're comparing against.
     :>json object base_file.id: The id of the base file.

--- a/src/olympia/reviewers/tests/test_serializers.py
+++ b/src/olympia/reviewers/tests/test_serializers.py
@@ -4,8 +4,6 @@ import json
 from django.core.cache import cache
 
 from rest_framework.exceptions import NotFound
-from rest_framework.settings import api_settings
-from rest_framework.test import APIRequestFactory
 
 from olympia import amo
 from olympia.amo.templatetags.jinja_helpers import absolutify

--- a/src/olympia/reviewers/tests/test_serializers.py
+++ b/src/olympia/reviewers/tests/test_serializers.py
@@ -42,11 +42,6 @@ class TestFileInfoSerializer(TestCase):
         self.file = self.addon.current_version.current_file
 
     def get_serializer(self, **extra_context):
-        api_version = api_settings.DEFAULT_VERSION
-        request = APIRequestFactory().get('/api/%s/' % api_version)
-        request.versioning_scheme = api_settings.DEFAULT_VERSIONING_CLASS()
-        request.version = api_version
-        extra_context.setdefault('request', request)
         extra_context.setdefault('version', self.version)
 
         return FileInfoSerializer(
@@ -162,11 +157,6 @@ class TestFileInfoDiffSerializer(TestCase):
         self.file = self.addon.current_version.current_file
 
     def get_serializer(self, **extra_context):
-        api_version = api_settings.DEFAULT_VERSION
-        request = APIRequestFactory().get('/api/%s/' % api_version)
-        request.versioning_scheme = api_settings.DEFAULT_VERSIONING_CLASS()
-        request.version = api_version
-        extra_context.setdefault('request', request)
         extra_context.setdefault('version', self.version)
 
         return FileInfoDiffSerializer(
@@ -358,12 +348,6 @@ class TestAddonBrowseVersionSerializerFileOnly(TestCase):
         self.version = self.addon.current_version
 
     def get_serializer(self, **extra_context):
-        api_version = api_settings.DEFAULT_VERSION
-        request = APIRequestFactory().get('/api/%s/' % api_version)
-        request.versioning_scheme = api_settings.DEFAULT_VERSIONING_CLASS()
-        request.version = api_version
-        extra_context.setdefault('request', request)
-
         return AddonBrowseVersionSerializerFileOnly(
             instance=self.version, context=extra_context)
 
@@ -420,12 +404,6 @@ class TestAddonBrowseVersionSerializer(TestCase):
         self.version = self.addon.current_version
 
     def get_serializer(self, **extra_context):
-        api_version = api_settings.DEFAULT_VERSION
-        request = APIRequestFactory().get('/api/%s/' % api_version)
-        request.versioning_scheme = api_settings.DEFAULT_VERSIONING_CLASS()
-        request.version = api_version
-        extra_context.setdefault('request', request)
-
         return AddonBrowseVersionSerializer(
             instance=self.version, context=extra_context)
 
@@ -545,12 +523,6 @@ class TestAddonCompareVersionSerializerFileOnly(TestCase):
         self.version = self.addon.current_version
 
     def get_serializer(self, **extra_context):
-        api_version = api_settings.DEFAULT_VERSION
-        request = APIRequestFactory().get('/api/%s/' % api_version)
-        request.versioning_scheme = api_settings.DEFAULT_VERSIONING_CLASS()
-        request.version = api_version
-        extra_context.setdefault('request', request)
-
         return AddonCompareVersionSerializerFileOnly(
             instance=self.version, context=extra_context)
 
@@ -601,12 +573,6 @@ class TestAddonCompareVersionSerializer(TestCase):
         return addon, repo, parent_version, new_version
 
     def get_serializer(self, **extra_context):
-        api_version = api_settings.DEFAULT_VERSION
-        request = APIRequestFactory().get('/api/%s/' % api_version)
-        request.versioning_scheme = api_settings.DEFAULT_VERSIONING_CLASS()
-        request.version = api_version
-        extra_context.setdefault('request', request)
-
         return AddonCompareVersionSerializer(
             instance=self.version, context=extra_context)
 

--- a/src/olympia/reviewers/tests/test_serializers.py
+++ b/src/olympia/reviewers/tests/test_serializers.py
@@ -17,14 +17,15 @@ from olympia.git.tests.test_utils import apply_changes
 from olympia.reviewers.models import CannedResponse
 from olympia.reviewers.serializers import (
     AddonBrowseVersionSerializer, AddonBrowseVersionSerializerFileOnly,
-    CannedResponseSerializer, FileEntriesDiffSerializer, FileEntriesSerializer)
+    AddonCompareVersionSerializerFileOnly, AddonCompareVersionSerializer,
+    CannedResponseSerializer, FileInfoDiffSerializer, FileInfoSerializer)
 from olympia.versions.models import License
 from olympia.versions.tasks import extract_version_to_git
 
 
-class TestFileEntriesSerializer(TestCase):
+class TestFileInfoSerializer(TestCase):
     def setUp(self):
-        super(TestFileEntriesSerializer, self).setUp()
+        super(TestFileInfoSerializer, self).setUp()
 
         self.addon = addon_factory(
             file_kw={
@@ -33,18 +34,39 @@ class TestFileEntriesSerializer(TestCase):
         extract_version_to_git(self.addon.current_version.pk)
         self.addon.current_version.refresh_from_db()
 
-    def get_serializer(self, obj, **extra_context):
+        extract_version_to_git(self.addon.current_version.pk)
+        self.addon.current_version.reload()
+        assert (self.addon.current_version.current_file.filename ==
+                'notify-link-clicks-i18n.xpi')
+        self.version = self.addon.current_version
+        self.file = self.addon.current_version.current_file
+
+    def get_serializer(self, **extra_context):
         api_version = api_settings.DEFAULT_VERSION
         request = APIRequestFactory().get('/api/%s/' % api_version)
         request.versioning_scheme = api_settings.DEFAULT_VERSIONING_CLASS()
         request.version = api_version
         extra_context.setdefault('request', request)
+        extra_context.setdefault('version', self.version)
 
-        return FileEntriesSerializer(
-            instance=obj, context=extra_context)
+        return FileInfoSerializer(
+            instance=self.file, context=extra_context)
 
-    def serialize(self, obj, **extra_context):
-        return self.get_serializer(obj, **extra_context).data
+    def serialize(self, **extra_context):
+        return self.get_serializer(**extra_context).data
+
+    def test_raises_without_version(self):
+        file = self.addon.current_version.current_file
+        serializer = FileInfoSerializer(instance=file)
+
+        with self.assertRaises(RuntimeError):
+            serializer.data
+
+    def test_can_access_version_from_parent(self):
+        serializer = AddonBrowseVersionSerializer(
+            instance=self.addon.current_version)
+        file = serializer.data['file']
+        assert file['id'] == self.addon.current_version.current_file.pk
 
     def test_basic(self):
         expected_file_type = 'text'
@@ -55,11 +77,9 @@ class TestFileEntriesSerializer(TestCase):
         )
         expected_size = 622
 
-        file = self.addon.current_version.current_file
+        data = self.serialize()
 
-        data = self.serialize(file)
-
-        assert data['id'] == file.pk
+        assert data['id'] == self.addon.current_version.current_file.pk
         assert data['selected_file'] == 'manifest.json'
         assert data['download_url'] == absolutify(reverse(
             'reviewers.download_git_file',
@@ -75,50 +95,13 @@ class TestFileEntriesSerializer(TestCase):
         assert data['mime_category'] == expected_file_type
         assert data['filename'] == expected_filename
 
-        assert set(data['entries'].keys()) == {
-            'README.md',
-            '_locales', '_locales/de', '_locales/en', '_locales/nb_NO',
-            '_locales/nl', '_locales/ru', '_locales/sv', '_locales/ja',
-            '_locales/de/messages.json', '_locales/en/messages.json',
-            '_locales/ja/messages.json', '_locales/nb_NO/messages.json',
-            '_locales/nl/messages.json', '_locales/ru/messages.json',
-            '_locales/sv/messages.json', 'background-script.js',
-            'content-script.js', 'icons', 'icons/LICENSE', 'icons/link-48.png',
-            'manifest.json'}
-
-        manifest_data = data['entries']['manifest.json']
-        assert manifest_data['depth'] == 0
-        assert manifest_data['filename'] == expected_filename
-        assert manifest_data['mime_category'] == expected_file_type
-        assert manifest_data['path'] == u'manifest.json'
-
-        ja_locale_data = data['entries']['_locales/ja']
-
-        assert ja_locale_data['depth'] == 1
-        assert ja_locale_data['mime_category'] == 'directory'
-        assert ja_locale_data['filename'] == 'ja'
-        assert ja_locale_data['path'] == u'_locales/ja'
-
         assert '"manifest_version": 2' in data['content']
         assert 'id": "notify-link-clicks-i18n@notzilla.org' in data['content']
 
     def test_requested_file(self):
-        file = self.addon.current_version.current_file
+        data = self.serialize(file='icons/LICENSE')
 
-        data = self.serialize(file, file='icons/LICENSE')
-
-        assert data['id'] == file.pk
-        assert set(data['entries'].keys()) == {
-            'README.md',
-            '_locales', '_locales/de', '_locales/en', '_locales/nb_NO',
-            '_locales/nl', '_locales/ru', '_locales/sv', '_locales/ja',
-            '_locales/de/messages.json', '_locales/en/messages.json',
-            '_locales/ja/messages.json', '_locales/nb_NO/messages.json',
-            '_locales/nl/messages.json', '_locales/ru/messages.json',
-            '_locales/sv/messages.json', 'background-script.js',
-            'content-script.js', 'icons', 'icons/LICENSE', 'icons/link-48.png',
-            'manifest.json'}
-
+        assert data['id'] == self.addon.current_version.current_file.pk
         assert data['selected_file'] == 'icons/LICENSE'
         assert data['content'].startswith(
             'The "link-48.png" icon is taken from the Geomicons')
@@ -138,60 +121,12 @@ class TestFileEntriesSerializer(TestCase):
         assert data['filename'] == 'LICENSE'
 
     def test_requested_file_with_non_existent_file(self):
-        file = self.addon.current_version.current_file
         with self.assertRaises(NotFound):
-            self.serialize(file, file='UNKNOWN_FILE')
-
-    def test_get_entries_cached(self):
-        file = self.addon.current_version.current_file
-        serializer = self.get_serializer(file)
-
-        # start serialization
-        data = serializer.data
-        commit = serializer.commit
-
-        assert serializer._trim_entries(serializer._entries) == data['entries']
-
-        key = 'reviewers:fileentriesserializer:entries:{}'.format(commit.hex)
-        cached_data = cache.get(key)
-
-        # We exclude `manifest.json` here to test that in a separate step
-        # because the sha256 calculation will overwrite `serializer._entries`
-        # but doesn't update the cache (yet at least) to avoid cache
-        # cache syncronisation issues
-        expected_keys = {
-            'README.md',
-            '_locales', '_locales/de', '_locales/en', '_locales/nb_NO',
-            '_locales/nl', '_locales/ru', '_locales/sv', '_locales/ja',
-            '_locales/de/messages.json', '_locales/en/messages.json',
-            '_locales/ja/messages.json', '_locales/nb_NO/messages.json',
-            '_locales/nl/messages.json', '_locales/ru/messages.json',
-            '_locales/sv/messages.json', 'background-script.js',
-            'content-script.js', 'icons', 'icons/LICENSE', 'icons/link-48.png'}
-
-        for key in expected_keys:
-            assert serializer._trim_entry(
-                cached_data[key]) == data['entries'][key]
+            self.serialize(file='UNKNOWN_FILE')
 
     def test_dont_render_content_binary_file(self):
-        file = self.addon.current_version.current_file
-        data = self.serialize(file, file='icons/link-48.png')
+        data = self.serialize(file='icons/link-48.png')
         assert data['content'] == ''
-
-    def test_sha256_only_calculated_or_fetched_for_selected_file(self):
-        file = self.addon.current_version.current_file
-        serializer = self.get_serializer(file, file='icons/LICENSE')
-        serializer.data
-
-        assert serializer._entries['manifest.json']['sha256'] is None
-        assert serializer._entries['icons/LICENSE']['sha256'] == (
-            'b48e66c02fe62dd47521def7c5ea11b86af91b94c23cfdf67592e1053952ed55')
-
-        serializer = self.get_serializer(file, file='manifest.json')
-        serializer.data
-        assert serializer._entries['manifest.json']['sha256'] == (
-            '71d4122c0f2f78e089136602f88dbf590f2fa04bb5bc417454bf21446d6cb4f0')
-        assert serializer._entries['icons/LICENSE']['sha256'] is None
 
     def test_uses_unknown_minified_code(self):
         validation_data = {
@@ -205,36 +140,16 @@ class TestFileEntriesSerializer(TestCase):
         FileValidation.objects.create(
             file=fobj, validation=json.dumps(validation_data))
 
-        data = self.serialize(fobj, file='content-script.js')
+        data = self.serialize(file='content-script.js')
         assert data['uses_unknown_minified_code']
 
-        data = self.serialize(fobj, file='background-script.js')
+        data = self.serialize(file='background-script.js')
         assert not data['uses_unknown_minified_code']
 
-    def test_can_exclude_entries(self):
-        file = self.addon.current_version.current_file
 
-        data = self.serialize(file, exclude_entries=True)
-
-        assert data['id'] == file.pk
-        assert data['selected_file'] == 'manifest.json'
-        assert data['mimetype'] == 'application/json'
-        assert data['entries'] is None
-
-    def test_can_exclude_entries_and_specify_a_file(self):
-        file = self.addon.current_version.current_file
-
-        data = self.serialize(file, file='icons/LICENSE', exclude_entries=True)
-
-        assert data['id'] == file.pk
-        assert data['selected_file'] == 'icons/LICENSE'
-        assert data['mimetype'] == 'text/plain'
-        assert data['entries'] is None
-
-
-class TestFileEntriesDiffSerializer(TestCase):
+class TestFileInfoDiffSerializer(TestCase):
     def setUp(self):
-        super(TestFileEntriesDiffSerializer, self).setUp()
+        super(TestFileInfoDiffSerializer, self).setUp()
 
         self.addon = addon_factory(
             name=u'My Addôn', slug='my-addon',
@@ -243,40 +158,47 @@ class TestFileEntriesDiffSerializer(TestCase):
 
         extract_version_to_git(self.addon.current_version.pk)
         self.addon.current_version.refresh_from_db()
+        self.version = self.addon.current_version
+        self.file = self.addon.current_version.current_file
 
-    def create_new_version_for_addon(self, xpi_filename):
-        addon = addon_factory(
-            name=u'My Addôn', slug='my-addon',
-            file_kw={'filename': xpi_filename, 'is_webextension': True})
-
-        extract_version_to_git(addon.current_version.pk)
-
-        addon.current_version.refresh_from_db()
-        parent_version = addon.current_version
-
-        new_version = version_factory(
-            addon=addon, file_kw={
-                'filename': xpi_filename,
-                'is_webextension': True,
-            }
-        )
-
-        repo = AddonGitRepository.extract_and_commit_from_version(new_version)
-
-        return addon, repo, parent_version, new_version
-
-    def get_serializer(self, obj, **extra_context):
+    def get_serializer(self, **extra_context):
         api_version = api_settings.DEFAULT_VERSION
         request = APIRequestFactory().get('/api/%s/' % api_version)
         request.versioning_scheme = api_settings.DEFAULT_VERSIONING_CLASS()
         request.version = api_version
         extra_context.setdefault('request', request)
+        extra_context.setdefault('version', self.version)
 
-        return FileEntriesDiffSerializer(
-            instance=obj, context=extra_context)
+        return FileInfoDiffSerializer(
+            instance=self.file, context=extra_context)
 
-    def serialize(self, obj, **extra_context):
-        return self.get_serializer(obj, **extra_context).data
+    def serialize(self, **extra_context):
+        return self.get_serializer(**extra_context).data
+
+    def test_raises_without_version(self):
+        file = self.addon.current_version.current_file
+        serializer = FileInfoDiffSerializer(instance=file)
+
+        with self.assertRaises(RuntimeError):
+            serializer.data
+
+    def test_can_access_version_from_parent(self):
+        parent_version = self.addon.current_version
+
+        new_version = version_factory(
+            addon=self.addon, file_kw={
+                'filename': 'webextension_no_id.xpi',
+                'is_webextension': True,
+            }
+        )
+
+        AddonGitRepository.extract_and_commit_from_version(new_version)
+
+        serializer = AddonCompareVersionSerializer(
+            instance=new_version,
+            context={'parent_version': parent_version})
+        file = serializer.data['file']
+        assert file['id'] == new_version.current_file.pk
 
     def test_basic(self):
         expected_file_type = 'text'
@@ -301,11 +223,11 @@ class TestFileEntriesDiffSerializer(TestCase):
         apply_changes(repo, new_version, 'Updated test file\n', 'test.txt')
         apply_changes(repo, new_version, '', 'README.md', delete=True)
 
-        file = self.addon.current_version.current_file
+        self.version = new_version
+        self.file = new_version.current_file
+        data = self.serialize(parent_version=parent_version)
 
-        data = self.serialize(file, parent_version=parent_version)
-
-        assert data['id'] == file.pk
+        assert data['id'] == new_version.current_file.pk
         assert data['base_file'] == {
             'id': parent_version.current_file.pk
         }
@@ -324,40 +246,8 @@ class TestFileEntriesDiffSerializer(TestCase):
         assert data['mime_category'] == expected_file_type
         assert data['filename'] == expected_filename
 
-        assert set(data['entries'].keys()) == {
-            'manifest.json', 'README.md', 'test.txt'}
-
         # The API always renders a diff, even for unmodified files.
         assert data['diff'] is not None
-
-        assert not data['uses_unknown_minified_code']
-
-        # Unmodified file
-        manifest_data = data['entries']['manifest.json']
-        assert manifest_data['depth'] == 0
-        assert manifest_data['filename'] == expected_filename
-        assert manifest_data['mime_category'] == expected_file_type
-        assert manifest_data['path'] == u'manifest.json'
-        assert manifest_data['status'] == ''
-
-        # Added a new file
-        test_txt_data = data['entries']['test.txt']
-        assert test_txt_data['depth'] == 0
-        assert test_txt_data['filename'] == u'test.txt'
-        assert test_txt_data['mime_category'] == 'text'
-        assert test_txt_data['path'] == u'test.txt'
-        assert test_txt_data['status'] == 'A'
-
-        # Deleted file
-        readme_data = data['entries']['README.md']
-        assert readme_data['status'] == 'D'
-        assert readme_data['depth'] == 0
-        assert readme_data['filename'] == 'README.md'
-        # Not testing mimetype as text/markdown is missing in travis mimetypes
-        # database. But it doesn't matter much here since we're primarily
-        # after the git status.
-        assert readme_data['mime_category'] is None
-        assert readme_data['path'] == u'README.md'
 
     def test_serialize_deleted_file(self):
         expected_filename = 'manifest.json'
@@ -372,8 +262,9 @@ class TestFileEntriesDiffSerializer(TestCase):
         repo = AddonGitRepository.extract_and_commit_from_version(new_version)
         apply_changes(repo, new_version, '', expected_filename, delete=True)
 
-        file = self.addon.current_version.current_file
-        data = self.serialize(file, parent_version=parent_version)
+        self.version = new_version
+        self.file = new_version.current_file
+        data = self.serialize(parent_version=parent_version)
 
         assert data['download_url'] is None
         # We deleted the selected file, so there should be a diff.
@@ -384,137 +275,6 @@ class TestFileEntriesDiffSerializer(TestCase):
         assert data['size'] is None
         assert data['mime_category'] is None
         assert data['filename'] == expected_filename
-
-    def test_recreate_parent_dir_of_deleted_file(self):
-        addon, repo, parent_version, new_version = \
-            self.create_new_version_for_addon(
-                'webextension_signed_already.xpi')
-
-        apply_changes(
-            repo, new_version, '', 'META-INF/mozilla.rsa', delete=True)
-
-        data = self.serialize(
-            new_version.current_file, parent_version=parent_version)
-
-        entries_by_file = {
-            e['path']: e for e in data['entries'].values()
-        }
-        parent_dir = 'META-INF'
-        assert parent_dir in entries_by_file.keys()
-
-        parent = entries_by_file[parent_dir]
-        assert parent['depth'] == 0
-        assert parent['filename'] == parent_dir
-        assert parent['mime_category'] == 'directory'
-        assert parent['path'] == parent_dir
-
-    def test_recreate_nested_parent_dir_of_deleted_file(self):
-        addon, repo, parent_version, new_version = \
-            self.create_new_version_for_addon('https-everywhere.xpi')
-
-        apply_changes(
-            repo,
-            new_version,
-            '',
-            '_locales/ru/messages.json',
-            delete=True)
-
-        data = self.serialize(
-            new_version.current_file, parent_version=parent_version)
-
-        entries_by_file = {
-            e['path']: e for e in data['entries'].values()
-        }
-        parent_dir = '_locales/ru'
-        assert parent_dir in entries_by_file.keys()
-
-        parent = entries_by_file[parent_dir]
-        assert parent['depth'] == 1
-        assert parent['filename'] == 'ru'
-        assert parent['path'] == parent_dir
-
-    def test_do_not_recreate_parent_dir_of_deleted_root_file(self):
-        addon, repo, parent_version, new_version = \
-            self.create_new_version_for_addon(
-                'webextension_signed_already.xpi')
-
-        apply_changes(
-            repo, new_version, '', 'manifest.json', delete=True)
-
-        data = self.serialize(
-            new_version.current_file, parent_version=parent_version)
-
-        entries_by_file = {
-            e['path']: e for e in data['entries'].values()
-        }
-
-        # Since we just deleted a root file, no additional entries
-        # should have been added for its parent directory.
-        assert list(sorted(entries_by_file.keys())) == [
-            'META-INF',
-            'META-INF/mozilla.rsa',
-            'index.js',
-            'manifest.json',
-        ]
-
-    def test_do_not_recreate_parent_dir_if_it_exists(self):
-        addon, repo, parent_version, new_version = \
-            self.create_new_version_for_addon('https-everywhere.xpi')
-
-        # Delete a file within a directory but modify another file.
-        # This will preserve the directory, i.e. we won't have to
-        # recreate it.
-        apply_changes(
-            repo,
-            new_version,
-            '',
-            'chrome-resources/css/chrome_shared.css',
-            delete=True)
-        apply_changes(
-            repo,
-            new_version,
-            '/* new content */',
-            'chrome-resources/css/widgets.css')
-
-        data = self.serialize(
-            new_version.current_file, parent_version=parent_version)
-
-        entries_by_file = {
-            e['path']: e for e in data['entries'].values()
-        }
-        parent_dir = 'chrome-resources/css'
-        assert parent_dir in entries_by_file.keys()
-
-        parent = entries_by_file[parent_dir]
-        assert parent['mime_category'] == 'directory'
-        assert parent['path'] == parent_dir
-
-    def test_expose_grandparent_dir_deleted_subfolders(self):
-        addon, repo, parent_version, new_version = \
-            self.create_new_version_for_addon('deeply-nested.zip')
-
-        apply_changes(
-            repo,
-            new_version,
-            '',
-            'chrome/icons/de/foo.png',
-            delete=True)
-
-        data = self.serialize(
-            new_version.current_file, parent_version=parent_version)
-
-        entries_by_file = {
-            e['path']: e for e in data['entries'].values()
-        }
-        # Check that we correctly include grand-parent folders too
-        # See https://github.com/mozilla/addons-server/issues/13092
-        grandparent_dir = 'chrome'
-        assert grandparent_dir in entries_by_file.keys()
-
-        parent = entries_by_file[grandparent_dir]
-        assert parent['mime_category'] == 'directory'
-        assert parent['path'] == grandparent_dir
-        assert parent['depth'] == 0
 
     def test_selected_file_unmodified(self):
         parent_version = self.addon.current_version
@@ -527,20 +287,12 @@ class TestFileEntriesDiffSerializer(TestCase):
         )
         AddonGitRepository.extract_and_commit_from_version(new_version)
 
-        file = self.addon.current_version.current_file
+        self.version = new_version
+        self.file = new_version.current_file
+        data = self.serialize(parent_version=parent_version)
 
-        data = self.serialize(file, parent_version=parent_version)
-
-        assert data['id'] == file.pk
-
-        # Unmodified file
-        manifest_data = data['entries']['manifest.json']
-        assert manifest_data['depth'] == 0
-        assert manifest_data['filename'] == u'manifest.json'
-        assert manifest_data['mime_category'] == 'text'
-        assert manifest_data['path'] == u'manifest.json'
-        assert manifest_data['status'] == ''
-
+        assert data['id'] == self.addon.current_version.current_file.pk
+        assert data['filename'] == u'manifest.json'
         assert data['diff'] is not None
 
     def test_uses_unknown_minified_code(self):
@@ -554,8 +306,6 @@ class TestFileEntriesDiffSerializer(TestCase):
         )
         AddonGitRepository.extract_and_commit_from_version(new_version)
 
-        file = self.addon.current_version.current_file
-
         validation_data = {
             'metadata': {
                 'unknownMinifiedFiles': ['README.md']
@@ -566,74 +316,33 @@ class TestFileEntriesDiffSerializer(TestCase):
         # which will result in us notifying the frontend of a minified file
         # as well
         current_validation = FileValidation.objects.create(
-            file=file, validation=json.dumps(validation_data))
+            file=parent_version.current_file,
+            validation=json.dumps(validation_data))
 
-        data = self.serialize(
-            file, parent_version=parent_version, file='README.md')
+        self.version = new_version
+        self.file = new_version.current_file
+        data = self.serialize(parent_version=parent_version,
+                              file='README.md')
         assert data['uses_unknown_minified_code']
 
-        data = self.serialize(
-            file, parent_version=parent_version, file='manifest.json')
+        data = self.serialize(parent_version=parent_version,
+                              file='manifest.json')
         assert not data['uses_unknown_minified_code']
 
         current_validation.delete()
 
         # Creating a validation object for the current one works as well
         FileValidation.objects.create(
-            file=parent_version.current_file,
+            file=self.version.current_file,
             validation=json.dumps(validation_data))
 
         data = self.serialize(
-            file, parent_version=parent_version, file='README.md')
+            parent_version=parent_version, file='README.md')
         assert data['uses_unknown_minified_code']
 
         data = self.serialize(
-            file, parent_version=parent_version, file='manifest.json')
+            parent_version=parent_version, file='manifest.json')
         assert not data['uses_unknown_minified_code']
-
-    def test_can_exclude_entries(self):
-        parent_version = self.addon.current_version
-
-        new_version = version_factory(
-            addon=self.addon, file_kw={
-                'filename': 'webextension_no_id.xpi',
-                'is_webextension': True,
-            }
-        )
-        AddonGitRepository.extract_and_commit_from_version(new_version)
-
-        file = self.addon.current_version.current_file
-
-        data = self.serialize(file, exclude_entries=True,
-                              parent_version=parent_version)
-
-        assert data['id'] == file.pk
-        assert data['selected_file'] == 'manifest.json'
-        assert data['mimetype'] == 'application/json'
-        assert data['entries'] is None
-        assert data['diff'] is not None
-
-    def test_can_exclude_entries_and_specify_a_file(self):
-        parent_version = self.addon.current_version
-
-        new_version = version_factory(
-            addon=self.addon, file_kw={
-                'filename': 'webextension_no_id.xpi',
-                'is_webextension': True,
-            }
-        )
-        AddonGitRepository.extract_and_commit_from_version(new_version)
-
-        file = self.addon.current_version.current_file
-
-        data = self.serialize(file, file='README.md', exclude_entries=True,
-                              parent_version=parent_version)
-
-        assert data['id'] == file.pk
-        assert data['selected_file'] == 'README.md'
-        assert data['mimetype'] == 'text/markdown'
-        assert data['entries'] is None
-        assert data['diff'] is not None
 
 
 class TestAddonBrowseVersionSerializerFileOnly(TestCase):
@@ -724,8 +433,6 @@ class TestAddonBrowseVersionSerializer(TestCase):
         return self.get_serializer(**extra_context).data
 
     def test_basic(self):
-        # Overwritten partially to remove `files` related tests since we don't
-        # include it in our simplified serializer version
         data = self.serialize()
         assert data['id'] == self.version.pk
 
@@ -755,6 +462,75 @@ class TestAddonBrowseVersionSerializer(TestCase):
             'icon_url': absolutify(self.addon.get_icon_url(64))
         }
 
+        assert set(data['file_entries'].keys()) == {
+            'README.md',
+            '_locales', '_locales/de', '_locales/en', '_locales/nb_NO',
+            '_locales/nl', '_locales/ru', '_locales/sv', '_locales/ja',
+            '_locales/de/messages.json', '_locales/en/messages.json',
+            '_locales/ja/messages.json', '_locales/nb_NO/messages.json',
+            '_locales/nl/messages.json', '_locales/ru/messages.json',
+            '_locales/sv/messages.json', 'background-script.js',
+            'content-script.js', 'icons', 'icons/LICENSE', 'icons/link-48.png',
+            'manifest.json'}
+
+        manifest_data = data['file_entries']['manifest.json']
+        assert manifest_data['depth'] == 0
+        assert manifest_data['filename'] == 'manifest.json'
+        assert manifest_data['mime_category'] == 'text'
+        assert manifest_data['path'] == u'manifest.json'
+
+        ja_locale_data = data['file_entries']['_locales/ja']
+
+        assert ja_locale_data['depth'] == 1
+        assert ja_locale_data['mime_category'] == 'directory'
+        assert ja_locale_data['filename'] == 'ja'
+        assert ja_locale_data['path'] == u'_locales/ja'
+
+    def test_get_entries_cached(self):
+        serializer = self.get_serializer()
+
+        # start serialization
+        data = serializer.data
+        commit = serializer.commit
+
+        assert serializer._trim_entries(
+            serializer._entries) == data['file_entries']
+
+        key = 'reviewers:fileentriesserializer:entries:{}'.format(commit.hex)
+        cached_data = cache.get(key)
+
+        # We exclude `manifest.json` here to test that in a separate step
+        # because the sha256 calculation will overwrite `serializer._entries`
+        # but doesn't update the cache (yet at least) to avoid cache
+        # cache syncronisation issues
+        expected_keys = {
+            'README.md',
+            '_locales', '_locales/de', '_locales/en', '_locales/nb_NO',
+            '_locales/nl', '_locales/ru', '_locales/sv', '_locales/ja',
+            '_locales/de/messages.json', '_locales/en/messages.json',
+            '_locales/ja/messages.json', '_locales/nb_NO/messages.json',
+            '_locales/nl/messages.json', '_locales/ru/messages.json',
+            '_locales/sv/messages.json', 'background-script.js',
+            'content-script.js', 'icons', 'icons/LICENSE', 'icons/link-48.png'}
+
+        for key in expected_keys:
+            assert serializer._trim_entry(
+                cached_data[key]) == data['file_entries'][key]
+
+    def test_sha256_only_calculated_or_fetched_for_selected_file(self):
+        serializer = self.get_serializer(file='icons/LICENSE')
+        serializer.data
+
+        assert serializer._entries['manifest.json']['sha256'] is None
+        assert serializer._entries['icons/LICENSE']['sha256'] == (
+            'b48e66c02fe62dd47521def7c5ea11b86af91b94c23cfdf67592e1053952ed55')
+
+        serializer = self.get_serializer(file='manifest.json')
+        serializer.data
+        assert serializer._entries['manifest.json']['sha256'] == (
+            '71d4122c0f2f78e089136602f88dbf590f2fa04bb5bc417454bf21446d6cb4f0')
+        assert serializer._entries['icons/LICENSE']['sha256'] is None
+
 
 class TestAddonCompareVersionSerializerFileOnly(TestCase):
     def setUp(self):
@@ -775,17 +551,249 @@ class TestAddonCompareVersionSerializerFileOnly(TestCase):
         request.version = api_version
         extra_context.setdefault('request', request)
 
-        return AddonBrowseVersionSerializerFileOnly(
+        return AddonCompareVersionSerializerFileOnly(
             instance=self.version, context=extra_context)
 
     def serialize(self, **extra_context):
         return self.get_serializer(**extra_context).data
 
     def test_basic(self):
-        data = self.serialize()
+        parent_version = self.addon.current_version
+
+        data = self.serialize(parent_version=parent_version)
         assert data['id'] == self.version.pk
         assert 'file' in data
         assert len(data.keys()) == 2
+
+
+class TestAddonCompareVersionSerializer(TestCase):
+    def setUp(self):
+        super(TestAddonCompareVersionSerializer, self).setUp()
+
+        self.addon = addon_factory(
+            name=u'My Addôn', slug='my-addon',
+            file_kw={'filename': 'webextension_no_id.xpi',
+                     'is_webextension': True})
+
+        extract_version_to_git(self.addon.current_version.pk)
+        self.addon.current_version.refresh_from_db()
+        self.version = self.addon.current_version
+
+    def create_new_version_for_addon(self, xpi_filename):
+        addon = addon_factory(
+            name=u'My Addôn', slug='my-addon',
+            file_kw={'filename': xpi_filename, 'is_webextension': True})
+
+        extract_version_to_git(addon.current_version.pk)
+
+        addon.current_version.refresh_from_db()
+        parent_version = addon.current_version
+
+        new_version = version_factory(
+            addon=addon, file_kw={
+                'filename': xpi_filename,
+                'is_webextension': True,
+            }
+        )
+
+        repo = AddonGitRepository.extract_and_commit_from_version(new_version)
+
+        return addon, repo, parent_version, new_version
+
+    def get_serializer(self, **extra_context):
+        api_version = api_settings.DEFAULT_VERSION
+        request = APIRequestFactory().get('/api/%s/' % api_version)
+        request.versioning_scheme = api_settings.DEFAULT_VERSIONING_CLASS()
+        request.version = api_version
+        extra_context.setdefault('request', request)
+
+        return AddonCompareVersionSerializer(
+            instance=self.version, context=extra_context)
+
+    def serialize(self, **extra_context):
+        return self.get_serializer(**extra_context).data
+
+    def test_basic(self):
+        expected_file_type = 'text'
+        expected_filename = 'manifest.json'
+
+        parent_version = self.addon.current_version
+
+        new_version = version_factory(
+            addon=self.addon, file_kw={
+                'filename': 'webextension_no_id.xpi',
+                'is_webextension': True,
+            }
+        )
+
+        repo = AddonGitRepository.extract_and_commit_from_version(new_version)
+
+        apply_changes(repo, new_version, 'Updated test file\n', 'test.txt')
+        apply_changes(repo, new_version, '', 'README.md', delete=True)
+
+        self.version = new_version
+        data = self.serialize(parent_version=parent_version)
+
+        assert set(data['file_entries'].keys()) == {
+            'manifest.json', 'README.md', 'test.txt'}
+
+        # Unmodified file
+        manifest_data = data['file_entries']['manifest.json']
+        assert manifest_data['depth'] == 0
+        assert manifest_data['filename'] == expected_filename
+        assert manifest_data['mime_category'] == expected_file_type
+        assert manifest_data['path'] == u'manifest.json'
+        assert manifest_data['status'] == ''
+
+        # Added a new file
+        test_txt_data = data['file_entries']['test.txt']
+        assert test_txt_data['depth'] == 0
+        assert test_txt_data['filename'] == u'test.txt'
+        assert test_txt_data['mime_category'] == 'text'
+        assert test_txt_data['path'] == u'test.txt'
+        assert test_txt_data['status'] == 'A'
+
+        # Deleted file
+        readme_data = data['file_entries']['README.md']
+        assert readme_data['status'] == 'D'
+        assert readme_data['depth'] == 0
+        assert readme_data['filename'] == 'README.md'
+        # Not testing mimetype as text/markdown is missing in travis mimetypes
+        # database. But it doesn't matter much here since we're primarily
+        # after the git status.
+        assert readme_data['mime_category'] is None
+        assert readme_data['path'] == u'README.md'
+
+    def test_recreate_parent_dir_of_deleted_file(self):
+        addon, repo, parent_version, new_version = \
+            self.create_new_version_for_addon(
+                'webextension_signed_already.xpi')
+
+        apply_changes(
+            repo, new_version, '', 'META-INF/mozilla.rsa', delete=True)
+
+        self.version = new_version
+        data = self.serialize(parent_version=parent_version)
+
+        entries_by_file = {
+            e['path']: e for e in data['file_entries'].values()
+        }
+        parent_dir = 'META-INF'
+        assert parent_dir in entries_by_file.keys()
+
+        parent = entries_by_file[parent_dir]
+        assert parent['depth'] == 0
+        assert parent['filename'] == parent_dir
+        assert parent['mime_category'] == 'directory'
+        assert parent['path'] == parent_dir
+
+    def test_recreate_nested_parent_dir_of_deleted_file(self):
+        addon, repo, parent_version, new_version = \
+            self.create_new_version_for_addon('https-everywhere.xpi')
+
+        apply_changes(
+            repo,
+            new_version,
+            '',
+            '_locales/ru/messages.json',
+            delete=True)
+
+        self.version = new_version
+        data = self.serialize(parent_version=parent_version)
+
+        entries_by_file = {
+            e['path']: e for e in data['file_entries'].values()
+        }
+        parent_dir = '_locales/ru'
+        assert parent_dir in entries_by_file.keys()
+
+        parent = entries_by_file[parent_dir]
+        assert parent['depth'] == 1
+        assert parent['filename'] == 'ru'
+        assert parent['path'] == parent_dir
+
+    def test_do_not_recreate_parent_dir_of_deleted_root_file(self):
+        addon, repo, parent_version, new_version = \
+            self.create_new_version_for_addon(
+                'webextension_signed_already.xpi')
+
+        apply_changes(
+            repo, new_version, '', 'manifest.json', delete=True)
+
+        self.version = new_version
+        data = self.serialize(parent_version=parent_version)
+
+        entries_by_file = {
+            e['path']: e for e in data['file_entries'].values()
+        }
+
+        # Since we just deleted a root file, no additional entries
+        # should have been added for its parent directory.
+        assert list(sorted(entries_by_file.keys())) == [
+            'META-INF',
+            'META-INF/mozilla.rsa',
+            'index.js',
+            'manifest.json',
+        ]
+
+    def test_do_not_recreate_parent_dir_if_it_exists(self):
+        addon, repo, parent_version, new_version = \
+            self.create_new_version_for_addon('https-everywhere.xpi')
+
+        # Delete a file within a directory but modify another file.
+        # This will preserve the directory, i.e. we won't have to
+        # recreate it.
+        apply_changes(
+            repo,
+            new_version,
+            '',
+            'chrome-resources/css/chrome_shared.css',
+            delete=True)
+        apply_changes(
+            repo,
+            new_version,
+            '/* new content */',
+            'chrome-resources/css/widgets.css')
+
+        self.version = new_version
+        data = self.serialize(parent_version=parent_version)
+
+        entries_by_file = {
+            e['path']: e for e in data['file_entries'].values()
+        }
+        parent_dir = 'chrome-resources/css'
+        assert parent_dir in entries_by_file.keys()
+
+        parent = entries_by_file[parent_dir]
+        assert parent['mime_category'] == 'directory'
+        assert parent['path'] == parent_dir
+
+    def test_expose_grandparent_dir_deleted_subfolders(self):
+        addon, repo, parent_version, new_version = \
+            self.create_new_version_for_addon('deeply-nested.zip')
+
+        apply_changes(
+            repo,
+            new_version,
+            '',
+            'chrome/icons/de/foo.png',
+            delete=True)
+
+        self.version = new_version
+        data = self.serialize(parent_version=parent_version)
+
+        entries_by_file = {
+            e['path']: e for e in data['file_entries'].values()
+        }
+        # Check that we correctly include grand-parent folders too
+        # See https://github.com/mozilla/addons-server/issues/13092
+        grandparent_dir = 'chrome'
+        assert grandparent_dir in entries_by_file.keys()
+
+        parent = entries_by_file[grandparent_dir]
+        assert parent['mime_category'] == 'directory'
+        assert parent['path'] == grandparent_dir
+        assert parent['depth'] == 0
 
 
 class TestCannedResponseSerializer(TestCase):


### PR DESCRIPTION
Fixes #14212 
