### PR TITLE
Only extract BATCH_SIZE versions per add-on in the CRON task

### DIFF
--- a/src/olympia/git/management/commands/git_extraction.py
+++ b/src/olympia/git/management/commands/git_extraction.py
@@ -21,6 +21,7 @@ log = olympia.core.logger.getLogger('z.git.git_extraction')
 
 # Number of versions to extract in a single task. If you change this value,
 # please adjust the soft time limit of the `extract_versions_to_git` task.
+# See: https://github.com/mozilla/addons-server/issues/14104
 BATCH_SIZE = 10
 # Name of the lock() used.
 LOCK_NAME = 'git-extraction'

--- a/src/olympia/git/tasks.py
+++ b/src/olympia/git/tasks.py
@@ -30,6 +30,18 @@ def remove_git_extraction_entry(addon_pk):
 
 @task
 @use_primary_db
+def continue_git_extraction(addon_pk):
+    log.info(
+        'Keeping add-on "{}" in the git extraction queue because there are '
+        'still versions to git-extract.'.format(addon_pk)
+    )
+    GitExtractionEntry.objects.filter(
+        addon_id=addon_pk, in_progress=True
+    ).update(in_progress=False)
+
+
+@task
+@use_primary_db
 def on_extraction_error(request, exc, traceback, addon_pk):
     log.error('Git extraction failed for add-on "{}".'.format(addon_pk))
 

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1179,6 +1179,7 @@ CELERY_TASK_ROUTES = {
     'olympia.files.tasks.hide_disabled_files': {'queue': 'addons'},
     'olympia.versions.tasks.delete_preview_files': {'queue': 'addons'},
     'olympia.versions.tasks.extract_version_to_git': {'queue': 'addons'},
+    'olympia.git.tasks.continue_git_extraction': {'queue': 'addons'},
     'olympia.git.tasks.delete_source_git_repositories': {'queue': 'addons'},
     'olympia.git.tasks.extract_versions_to_git': {'queue': 'addons'},
     'olympia.git.tasks.on_extraction_error': {'queue': 'addons'},


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/14230

---

The idea behind this is that celery does not handle workflows very well so chains with more than a few tasks become very fragile. In production, we created chains of more than 1K tasks and that did not work very well.

This approach guarantees what the chain used to guarantee (sequential order) without the chain. It should be more robust. We shouldn't have to extract more than 1 version per add-on at the same time, except when we need to fix this add-on (either re-creating the repo and everything _or_ extracting missing versions).