### PR TITLE
Add add-on id to git admin list

### DIFF
--- a/src/olympia/git/admin.py
+++ b/src/olympia/git/admin.py
@@ -49,7 +49,7 @@ class GitExtractionEntryAdmin(admin.ModelAdmin):
         return format_html(
             '<a href="{}">{}</a>',
             reverse('admin:addons_addon_change', args=(obj.addon.pk,)),
-            obj.addon.name,
+            str(obj.addon),
         )
 
     formatted_addon.short_description = 'Add-on'

--- a/src/olympia/git/tests/test_admin.py
+++ b/src/olympia/git/tests/test_admin.py
@@ -61,4 +61,4 @@ class TestGitExtractionEntryAdmin(TestCase):
             reverse('admin:addons_addon_change', args=(addon.pk,))
             in formatted_addon
         )
-        assert str(addon.name) in formatted_addon
+        assert str(addon) in formatted_addon


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/14231

---

It looks like this now:

<img width="400" alt="Screen Shot 2020-05-11 at 18 21 56" src="https://user-images.githubusercontent.com/217628/81585504-8dc33b80-93b4-11ea-8b04-413d91c592dd.png">
