### PR TITLE
When extracting a non-existing file, try its alternate location

### DIFF
--- a/src/olympia/files/models.py
+++ b/src/olympia/files/models.py
@@ -275,6 +275,17 @@ class File(OnChangeMixin, ModelBase):
             return self.file_path
 
     @property
+    def fallback_file_path(self):
+        """Fallback path in case the file was disabled/re-enabled and not yet
+        moved - sort of the opposite to current_file_path. This should only be
+        used for things like code search or git extraction where we really want
+        the file contents no matter what."""
+        return (
+            self.file_path if self.current_file_path == self.guarded_file_path
+            else self.guarded_file_path
+        )
+
+    @property
     def extension(self):
         return os.path.splitext(self.filename)[-1]
 

--- a/src/olympia/files/tests/test_models.py
+++ b/src/olympia/files/tests/test_models.py
@@ -320,6 +320,39 @@ class TestFile(TestCase, amo.tests.AMOPaths):
         f.addon.update(status=amo.STATUS_DISABLED)
         assert f.current_file_path.endswith(guarded_fp)
 
+    def test_fallback_file_path(self):
+        public_fp = '/storage/files/3615/delicious_bookmarks-2.1.072-fx.xpi'
+        guarded_fp = '/guarded-addons/3615/delicious_bookmarks-2.1.072-fx.xpi'
+
+        # Add-on enabled, file approved
+        f = File.objects.get(pk=67442)
+        assert f.fallback_file_path.endswith(guarded_fp)
+
+        # Add-on user-disabled, file approved
+        f.addon.update(disabled_by_user=True)
+        assert f.fallback_file_path.endswith(public_fp)
+        f.addon.update(disabled_by_user=False)
+
+        # Add-on mozilla-disabled, file approved
+        f.addon.update(status=amo.STATUS_DISABLED)
+        assert f.fallback_file_path.endswith(public_fp)
+        f.addon.update(status=amo.STATUS_APPROVED)
+
+        # Add-on enabled, file disabled
+        f.update(status=amo.STATUS_DISABLED)
+        f = File.objects.get(pk=67442)
+        assert f.fallback_file_path.endswith(public_fp)
+
+        # Add-on user-disabled, file disabled
+        f.addon.update(disabled_by_user=True)
+        assert f.fallback_file_path.endswith(public_fp)
+        f.addon.update(disabled_by_user=False)
+
+        # Add-on mozilla-disabled, file disabled
+        f.addon.update(status=amo.STATUS_DISABLED)
+        assert f.fallback_file_path.endswith(public_fp)
+
+
     def test_has_been_validated_returns_false_when_no_validation(self):
         file = File()
         assert not file.has_been_validated

--- a/src/olympia/files/tests/test_models.py
+++ b/src/olympia/files/tests/test_models.py
@@ -352,7 +352,6 @@ class TestFile(TestCase, amo.tests.AMOPaths):
         f.addon.update(status=amo.STATUS_DISABLED)
         assert f.fallback_file_path.endswith(public_fp)
 
-
     def test_has_been_validated_returns_false_when_no_validation(self):
         file = File()
         assert not file.has_been_validated

--- a/src/olympia/files/tests/test_utils.py
+++ b/src/olympia/files/tests/test_utils.py
@@ -792,14 +792,27 @@ def test_extract_extension_to_dest_call_fsync(filename):
     assert fsync_mock.called
 
 
-def test_extract_extension_to_dest_invalid_archive():
+def test_extract_extension_to_dest_non_existing_archive():
     extension_file = 'src/olympia/files/fixtures/files/doesntexist.zip'
+
+    with mock.patch('olympia.files.utils.shutil.rmtree') as mock_rmtree:
+        with pytest.raises(FileNotFoundError):
+            utils.extract_extension_to_dest(extension_file)
+
+    # Make sure we are cleaning up our temporary directory if possible
+    assert mock_rmtree.called
+
+
+def test_extract_extension_to_dest_invalid_archive():
+    extension_file = (
+        'src/olympia/files/fixtures/files/invalid-cp437-encoding.xpi'
+    )
 
     with mock.patch('olympia.files.utils.shutil.rmtree') as mock_rmtree:
         with pytest.raises(forms.ValidationError):
             utils.extract_extension_to_dest(extension_file)
 
-    # Make sure we are cleaning up our temprary directory if possible
+    # Make sure we are cleaning up our temporary directory if possible
     assert mock_rmtree.called
 
 

--- a/src/olympia/scanners/tasks.py
+++ b/src/olympia/scanners/tasks.py
@@ -369,15 +369,9 @@ def _run_yara_query_rule_on_version(version, rule):
             scanner_result, file_.current_file_path,
             definition=rule.definition)
     except FileNotFoundError:
-        # Fallback in case the file was disabled/re-enabled and not yet moved,
-        # we try the other possible path. This shouldn't happen too often.
-        tried_path = file_.current_file_path
-        fallback_path = (
-            file_.file_path if tried_path == file_.guarded_file_path
-            else file_.guarded_file_path
-        )
         _run_yara_for_path(
-            scanner_result, fallback_path, definition=rule.definition)
+            scanner_result, file_.fallback_file_path,
+            definition=rule.definition)
     # Unlike ScannerResult, we only want to save ScannerQueryResult if there is
     # a match, there would be too many things to save otherwise and we don't
     # really care about non-matches.

--- a/src/olympia/scanners/tests/test_tasks.py
+++ b/src/olympia/scanners/tests/test_tasks.py
@@ -724,7 +724,7 @@ class TestRunYaraQueryRule(AMOPaths, TestCase):
         self.rule.reload()
         assert self.rule.state == RUNNING  # Not touched by this task.
 
-    def test_run_on_chunk_fallback_path(self):
+    def test_run_on_chunk_fallback_file_path(self):
         # Make sure it still works when a file has been disabled but the path
         # has not been moved to the guarded location yet (we fall back to the
         # other path).
@@ -735,11 +735,11 @@ class TestRunYaraQueryRule(AMOPaths, TestCase):
         )
         self.test_run_on_chunk()
 
-    def test_run_on_chunk_fallback_path_guarded(self):
-        # Like test_run_on_chunk_fallback_path() but starting with a public
-        # File instance that somehow still has its file in the guarded path
-        # (Would happen if the whole add-on was disabled then re-enabled and
-        # the files haven't been moved back to the public location yet).
+    def test_run_on_chunk_fallback_file_path_guarded(self):
+        # Like test_run_on_chunk_fallback_file_path() but starting with a
+        # public File instance that somehow still has its file in the guarded
+        # path (Would happen if the whole add-on was disabled then re-enabled
+        # and the files haven't been moved back to the public location yet).
         file_ = self.version.all_files[0]
         if not os.path.exists(os.path.dirname(file_.guarded_file_path)):
             os.makedirs(os.path.dirname(file_.guarded_file_path))


### PR DESCRIPTION
Also delete code to handle source files that was in the way, it's obsolete since we stopped extracting source in #14174

Fixes #14232