### PR TITLE
ignore waffle option for upload to kinto cronjob

### DIFF
--- a/src/olympia/amo/tests/test_commands.py
+++ b/src/olympia/amo/tests/test_commands.py
@@ -26,6 +26,10 @@ def test_cron_command(_mock):
     assert _mock.call_count == 1
     _mock.assert_called_with('arg1', 'arg2')
 
+    call_command('cron', 'sample_cron_job', 'kwarg1=a', 'kwarg2=b')
+    assert _mock.call_count == 2
+    _mock.assert_called_with(kwarg1='a', kwarg2='b')
+
 
 @override_settings(
     CRON_JOBS={'sample_cron_job': 'olympia.amo.tests.test_commands'})

--- a/src/olympia/blocklist/cron.py
+++ b/src/olympia/blocklist/cron.py
@@ -22,8 +22,13 @@ def get_blocklist_last_modified_time():
     return int(latest_block.modified.timestamp() * 1000) if latest_block else 0
 
 
-def upload_mlbf_to_kinto():
-    if not waffle.switch_is_active('blocklist_mlbf_submit'):
+def upload_mlbf_to_kinto(*, bypass_switch=False):
+    """Creates a bloomfilter, and possibly a stash json blob, and uploads to
+    remote-settings.
+    bypass_switch=<Truthy value> will bypass the "blocklist_mlbf_submit" switch
+    for manual use/testing."""
+    bypass_switch = bool(bypass_switch)
+    if not (bypass_switch or waffle.switch_is_active('blocklist_mlbf_submit')):
         log.info('Upload MLBF to kinto cron job disabled.')
         return
     last_generation_time = get_config(MLBF_TIME_CONFIG_KEY, 0, json_value=True)

--- a/src/olympia/blocklist/cron.py
+++ b/src/olympia/blocklist/cron.py
@@ -5,12 +5,14 @@ from django.core.management import call_command
 import waffle
 
 import olympia.core.logger
+from olympia.constants.blocklist import (
+    MLBF_BASE_ID_CONFIG_KEY, MLBF_TIME_CONFIG_KEY)
 from olympia.zadmin.models import get_config
 
 from .mlbf import MLBF
 from .models import Block
-from .tasks import (
-    MLBF_BASE_ID_CONFIG_KEY, MLBF_TIME_CONFIG_KEY, upload_filter_to_kinto)
+from .tasks import upload_filter_to_kinto
+
 
 log = olympia.core.logger.getLogger('z.cron')
 

--- a/src/olympia/blocklist/management/commands/import_blocklist.py
+++ b/src/olympia/blocklist/management/commands/import_blocklist.py
@@ -8,7 +8,7 @@ import olympia.core.logger
 from olympia.blocklist.models import KintoImport
 from olympia.blocklist.tasks import (
     delete_imported_block_from_blocklist, import_block_from_blocklist)
-from olympia.blocklist.utils import KINTO_COLLECTION_LEGACY
+from olympia.constants.blocklist import REMOTE_SETTINGS_COLLECTION_LEGACY
 
 
 log = olympia.core.logger.getLogger('z.amo.blocklist')
@@ -22,7 +22,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         LEGACY_BLOCKLIST_URL = (
             f'{settings.REMOTE_SETTINGS_API_URL}buckets/blocklists/'
-            f'collections/{KINTO_COLLECTION_LEGACY}/records')
+            f'collections/{REMOTE_SETTINGS_COLLECTION_LEGACY}/records')
         log.debug('Downloading blocklist from %s', LEGACY_BLOCKLIST_URL)
         response = requests.get(LEGACY_BLOCKLIST_URL)
 

--- a/src/olympia/blocklist/mlbf.py
+++ b/src/olympia/blocklist/mlbf.py
@@ -11,6 +11,7 @@ from filtercascade import FilterCascade
 from filtercascade.fileformats import HashAlgorithm
 
 import olympia.core.logger
+from olympia.constants.blocklist import BASE_REPLACE_THRESHOLD
 
 
 log = olympia.core.logger.getLogger('z.amo.blocklist')
@@ -18,8 +19,6 @@ log = olympia.core.logger.getLogger('z.amo.blocklist')
 
 class MLBF():
     KEY_FORMAT = '{guid}:{version}'
-    # How many guids should there be in the stashs before we make a new base.
-    BASE_REPLACE_THRESHOLD = 5_000
 
     def __init__(self, id_):
         # simplify later code by assuming always a string
@@ -226,7 +225,7 @@ class MLBF():
             # compare base with current blocks
             extras, deletes = self.generate_diffs(
                 previous_base_mlbf.blocked_json, self.fetch_blocked_json())
-            return (len(extras) + len(deletes)) > self.BASE_REPLACE_THRESHOLD
+            return (len(extras) + len(deletes)) > BASE_REPLACE_THRESHOLD
         except FileNotFoundError:
             # when previous_base_mlfb._blocked_path doesn't exist
             return True

--- a/src/olympia/blocklist/tasks.py
+++ b/src/olympia/blocklist/tasks.py
@@ -13,6 +13,10 @@ from olympia import amo
 from olympia.addons.models import Addon
 from olympia.amo.celery import task
 from olympia.amo.decorators import use_primary_db
+from olympia.constants.blocklist import (
+    MLBF_TIME_CONFIG_KEY,
+    MLBF_BASE_ID_CONFIG_KEY,
+    REMOTE_SETTINGS_COLLECTION_MLBF)
 from olympia.files.models import File
 from olympia.lib.kinto import KintoServer
 from olympia.users.utils import get_task_user
@@ -21,17 +25,13 @@ from olympia.zadmin.models import set_config
 from .mlbf import MLBF
 from .models import Block, BlocklistSubmission, KintoImport
 from .utils import (
-    block_activity_log_delete, block_activity_log_save,
-    KINTO_COLLECTION_MLBF, split_regex_to_list)
+    block_activity_log_delete, block_activity_log_save, split_regex_to_list)
 
 
 log = olympia.core.logger.getLogger('z.amo.blocklist')
 
 bracket_open_regex = re.compile(r'(?<!\\){')
 bracket_close_regex = re.compile(r'(?<!\\)}')
-
-MLBF_TIME_CONFIG_KEY = 'blocklist_mlbf_generation_time'
-MLBF_BASE_ID_CONFIG_KEY = 'blocklist_mlbf_base_id'
 
 BLOCKLIST_RECORD_MLBF_BASE = 'bloomfilter-base'
 BLOCKLIST_RECORD_MLBF_UPDATE = 'bloomfilter-full'
@@ -184,7 +184,7 @@ def delete_imported_block_from_blocklist(kinto_id):
 def upload_filter_to_kinto(generation_time, is_base=True, upload_stash=False):
     bucket = settings.REMOTE_SETTINGS_WRITER_BUCKET
     server = KintoServer(
-        bucket, KINTO_COLLECTION_MLBF, kinto_sign_off_needed=False)
+        bucket, REMOTE_SETTINGS_COLLECTION_MLBF, kinto_sign_off_needed=False)
     mlbf = MLBF(generation_time)
     if is_base:
         # clear the collection for the base - we want to be the only filter

--- a/src/olympia/blocklist/tests/test_cron.py
+++ b/src/olympia/blocklist/tests/test_cron.py
@@ -190,6 +190,11 @@ class TestUploadToKinto(TestCase):
         self.publish_record_mock.assert_not_called()
         assert not get_config(MLBF_TIME_CONFIG_KEY)
 
+        # except when 'bypass_switch' kwarg is passed
+        upload_mlbf_to_kinto(bypass_switch=True)
+        self.publish_attachment_mock.assert_called()
+        assert get_config(MLBF_TIME_CONFIG_KEY)
+
     @freeze_time('2020-01-01 12:34:56', as_arg=True)
     def test_no_block_changes(frozen_time, self):
         # This was the last time the mlbf was generated

--- a/src/olympia/blocklist/tests/test_cron.py
+++ b/src/olympia/blocklist/tests/test_cron.py
@@ -17,7 +17,7 @@ from olympia.blocklist.cron import (
     upload_mlbf_to_kinto)
 from olympia.blocklist.mlbf import MLBF
 from olympia.blocklist.models import Block
-from olympia.blocklist.tasks import (
+from olympia.constants.blocklist import (
     MLBF_TIME_CONFIG_KEY, MLBF_BASE_ID_CONFIG_KEY)
 from olympia.lib.kinto import KintoServer
 from olympia.zadmin.models import get_config, set_config

--- a/src/olympia/blocklist/tests/test_mlbf.py
+++ b/src/olympia/blocklist/tests/test_mlbf.py
@@ -295,7 +295,7 @@ class TestMLBF(TestCase):
             {'fooo@baaaa:999'}, {f'{self.five_ver_block.guid}:123.5'})
 
         # so lower the threshold
-        to_patch = 'olympia.blocklist.mlbf.MLBF.BASE_REPLACE_THRESHOLD'
+        to_patch = 'olympia.blocklist.mlbf.BASE_REPLACE_THRESHOLD'
         with mock.patch(to_patch, 1):
             assert small_change_mlbf.should_reset_base_filter(base_mlbf)
             assert small_change_mlbf.blocks_changed_since_previous(base_mlbf)

--- a/src/olympia/blocklist/utils.py
+++ b/src/olympia/blocklist/utils.py
@@ -6,13 +6,11 @@ from django.conf import settings
 import olympia.core.logger
 from olympia import amo
 from olympia.activity import log_create
+from olympia.constants.blocklist import REMOTE_SETTINGS_COLLECTION_LEGACY
 from olympia.lib.kinto import KintoServer
 
 
 log = olympia.core.logger.getLogger('z.amo.blocklist')
-
-KINTO_COLLECTION_LEGACY = 'addons'
-KINTO_COLLECTION_MLBF = 'addons-bloomfilters'
 
 
 def add_version_log_for_blocked_versions(obj, al):
@@ -97,7 +95,7 @@ def splitlines(text):
 
 def legacy_publish_blocks(blocks):
     bucket = settings.REMOTE_SETTINGS_WRITER_BUCKET
-    server = KintoServer(bucket, KINTO_COLLECTION_LEGACY)
+    server = KintoServer(bucket, REMOTE_SETTINGS_COLLECTION_LEGACY)
     for block in blocks:
         needs_updating = block.include_in_legacy and block.kinto_id
         needs_creating = block.include_in_legacy and not block.kinto_id
@@ -142,7 +140,7 @@ def legacy_publish_blocks(blocks):
 
 def legacy_delete_blocks(blocks):
     bucket = settings.REMOTE_SETTINGS_WRITER_BUCKET
-    server = KintoServer(bucket, KINTO_COLLECTION_LEGACY)
+    server = KintoServer(bucket, REMOTE_SETTINGS_COLLECTION_LEGACY)
     for block in blocks:
         if block.kinto_id and block.include_in_legacy:
             if block.is_imported_from_kinto_regex:

--- a/src/olympia/constants/blocklist.py
+++ b/src/olympia/constants/blocklist.py
@@ -1,0 +1,9 @@
+# How many guids should there be in the stashes before we make a new base.
+BASE_REPLACE_THRESHOLD = 5_000
+
+# Config keys used to track recent mlbf ids
+MLBF_TIME_CONFIG_KEY = 'blocklist_mlbf_generation_time'
+MLBF_BASE_ID_CONFIG_KEY = 'blocklist_mlbf_base_id'
+
+REMOTE_SETTINGS_COLLECTION_LEGACY = 'addons'
+REMOTE_SETTINGS_COLLECTION_MLBF = 'addons-bloomfilters'


### PR DESCRIPTION
fixes #14256

3 commits that:
- refactor constants so they're in one file rather than spread throughout different files
- enhance the cron management command to accept arbitrary keyword args (as `foo=baa`)
- add ignore waffle option using cron keyword args for upload to kinto cronjob