### PR TITLE
include_in_legacy readonly unless blocklist_legacy_submit is enabled

### DIFF
--- a/src/olympia/blocklist/management/commands/bulk_add_blocks.py
+++ b/src/olympia/blocklist/management/commands/bulk_add_blocks.py
@@ -39,7 +39,8 @@ class Command(BaseCommand):
         submission = BlocklistSubmission(**block_args)
 
         for guids_chunk in chunked(guids, 100):
-            blocks = save_guids_to_blocks(guids_chunk, submission)
+            blocks = save_guids_to_blocks(
+                guids_chunk, submission, fields_to_set=block_args.keys())
             print(
                 f'Added/Updated {len(blocks)} blocks from {len(guids_chunk)} '
                 'guids')

--- a/src/olympia/blocklist/models.py
+++ b/src/olympia/blocklist/models.py
@@ -505,11 +505,23 @@ class BlocklistSubmission(ModelBase):
         assert self.is_submission_ready
         assert self.action == self.ACTION_ADDCHANGE
 
-        all_guids_to_block = [block['guid'] for block in self.to_block]
         kinto_submit_legacy_switch = waffle.switch_is_active(
             'blocklist_legacy_submit')
+        fields_to_set = [
+            'min_version',
+            'max_version',
+            'url',
+            'reason',
+            'updated_by',
+        ]
+        if kinto_submit_legacy_switch:
+            fields_to_set.append('include_in_legacy')
+
+        all_guids_to_block = [block['guid'] for block in self.to_block]
+
         for guids_chunk in chunked(all_guids_to_block, 100):
-            blocks = save_guids_to_blocks(guids_chunk, self)
+            blocks = save_guids_to_blocks(
+                guids_chunk, self, fields_to_set=fields_to_set)
             if kinto_submit_legacy_switch:
                 legacy_publish_blocks(blocks)
             self.save()

--- a/src/olympia/blocklist/utils.py
+++ b/src/olympia/blocklist/utils.py
@@ -196,17 +196,11 @@ def split_regex_to_list(guid_re):
     return GUID_SPLIT.split(trimmed)
 
 
-def save_guids_to_blocks(guids, submission):
+def save_guids_to_blocks(guids, submission, *, fields_to_set):
     from .models import Block
 
     common_args = {
-        'min_version': submission.min_version,
-        'max_version': submission.max_version,
-        'url': submission.url,
-        'reason': submission.reason,
-        'updated_by': submission.updated_by,
-        'include_in_legacy': submission.include_in_legacy,
-    }
+        field: getattr(submission, field) for field in fields_to_set}
     modified_datetime = datetime.datetime.now()
 
     blocks = Block.get_blocks_from_guids(guids)


### PR DESCRIPTION
fixes #14222 -
I gave up on the refactoring to drop `Block.include_in_legacy` - too many things broke - so I logged it as #14262 for followup.