### PR TITLE
Update python classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'Programming Language :: Python',
         'Framework :: Django',
         'Topic :: Internet :: WWW/HTTP :: Browsers',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
     ],
 )


### PR DESCRIPTION
Classifiers in `setup.py` were left outdated, and indicated that this was a python 2.7 project.