### PR TITLE
Limit the number of entries processed by a single execution (and change queue to stack)

### DIFF
--- a/src/olympia/git/admin.py
+++ b/src/olympia/git/admin.py
@@ -21,7 +21,7 @@ class GitExtractionEntryAdmin(admin.ModelAdmin):
         'modified',
     )
 
-    ordering = ('created',)
+    ordering = ('-created',)
 
     # Remove the "add" button
     def has_add_permission(self, request):

--- a/src/olympia/git/management/commands/git_extraction.py
+++ b/src/olympia/git/management/commands/git_extraction.py
@@ -28,6 +28,8 @@ BATCH_SIZE = 10
 LOCK_NAME = 'git-extraction'
 # Name of the waffle switch.
 SWITCH_NAME = 'enable-git-extraction-cron'
+# The number of entries to process when the command is invoked.
+LIMIT = 20
 
 
 class Command(BaseCommand):
@@ -53,7 +55,9 @@ class Command(BaseCommand):
             # If an add-on ID is present more than once, the `extract_addon()`
             # method will skip all but the first occurrence because the add-on
             # will be locked for git extraction.
-            entries = GitExtractionEntry.objects.order_by('created').all()
+            entries = GitExtractionEntry.objects.order_by('-created').all()[
+                : options.get('limit', LIMIT)
+            ]
             for entry in entries:
                 self.extract_addon(entry)
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/14319

---

I set the limit to `20` for now, I don't know if that's too high or okay for now (maybe too high).

With this configuration, we should only have up to 20 add-ons that are git-extracted in parallel. If we have 20 add-ons still being git extracted and no new add-on, this would mean a new execution of the CRON task wouldn't do anything but I think it is what we want, no?