### PR TITLE
Allow reviewers to reject unlisted versions waiting for review

### DIFF
--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -450,6 +450,27 @@ class TestReviewHelper(TestReviewHelperBase):
             file_status=amo.STATUS_APPROVED,
             content_review=True).keys()) == expected
 
+    def test_actions_unlisted(self):
+        # Just regular review permissions don't let you do much on an unlisted
+        # review page.
+        self.version.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        self.grant_permission(self.request.user, 'Addons:Review')
+        self.grant_permission(self.request.user, 'Addons:PostReview')
+        expected = ['reply', 'super', 'comment']
+        assert list(self.get_review_actions(
+            addon_status=amo.STATUS_NULL,
+            file_status=amo.STATUS_AWAITING_REVIEW).keys()) == expected
+
+        # Once you have ReviewUnlisted more actions are available.
+        self.grant_permission(self.request.user, 'Addons:ReviewUnlisted')
+        expected = [
+            'public', 'reject_multiple_versions',
+            'block_multiple_versions', 'confirm_multiple_versions',
+            'reply', 'super', 'comment']
+        assert list(self.get_review_actions(
+            addon_status=amo.STATUS_NULL,
+            file_status=amo.STATUS_AWAITING_REVIEW).keys()) == expected
+
     def test_set_files(self):
         self.file.update(datestatuschanged=yesterday)
         self.helper.handler.set_files(amo.STATUS_APPROVED,
@@ -1466,6 +1487,58 @@ class TestReviewHelper(TestReviewHelperBase):
         assert self.check_log_count(amo.LOG.REJECT_VERSION.id) == 0
         assert self.check_log_count(amo.LOG.REJECT_CONTENT.id) == 2
 
+    def test_reject_multiple_versions_unlisted(self):
+        old_version = self.version
+        self.make_addon_unlisted(self.addon)
+        self.version = version_factory(
+            addon=self.addon, version='3.0',
+            channel=amo.RELEASE_CHANNEL_UNLISTED,
+            file_kw={'status': amo.STATUS_AWAITING_REVIEW})
+        AutoApprovalSummary.objects.create(
+            version=self.version, verdict=amo.AUTO_APPROVED, weight=101)
+        # An extra file should not change anything.
+        file_factory(version=self.version, platform=amo.PLATFORM_LINUX.id)
+        self.setup_data(
+            amo.STATUS_NULL, file_status=amo.STATUS_AWAITING_REVIEW)
+
+        # Safeguards.
+        assert isinstance(self.helper.handler, ReviewUnlisted)
+        assert self.addon.status == amo.STATUS_NULL
+        assert self.file.status == amo.STATUS_AWAITING_REVIEW
+
+        data = self.get_data().copy()
+        data['versions'] = self.addon.versions.all()
+        self.helper.set_data(data)
+        self.helper.handler.reject_multiple_versions()
+
+        self.addon.reload()
+        self.file.reload()
+        assert self.addon.status == amo.STATUS_NULL
+        assert self.addon.current_version is None
+        assert list(self.addon.versions.all()) == [self.version, old_version]
+        assert self.file.status == amo.STATUS_DISABLED
+
+        assert len(mail.outbox) == 1
+        assert mail.outbox[0].to == [self.addon.authors.all()[0].email]
+        assert mail.outbox[0].subject == (
+            'Mozilla Add-ons: Versions disabled for Delicious Bookmarks')
+        assert (
+            'versions of your add-on Delicious Bookmarks have been disabled'
+            in mail.outbox[0].body
+        )
+        log_token = ActivityLogToken.objects.get()
+        assert log_token.uuid.hex in mail.outbox[0].reply_to[0]
+
+        assert self.check_log_count(amo.LOG.REJECT_VERSION.id) == 2
+        assert self.check_log_count(amo.LOG.REJECT_CONTENT.id) == 0
+
+        logs = (ActivityLog.objects.for_addons(self.addon)
+                                   .filter(action=amo.LOG.REJECT_VERSION.id))
+        assert logs[0].created == logs[1].created
+
+        # Check points awarded.
+        self._check_score(amo.REVIEWED_EXTENSION_MEDIUM_RISK)
+
     def test_approve_content_content_review(self):
         self.grant_permission(self.request.user, 'Addons:ContentReview')
         self.setup_data(
@@ -1555,7 +1628,7 @@ class TestReviewHelper(TestReviewHelperBase):
         data = self.get_data().copy()
         data['versions'] = self.addon.versions.all()
         self.helper.set_data(data)
-        self.helper.handler.reject_multiple_versions()
+        self.helper.handler.block_multiple_versions()
 
         self.addon.reload()
         self.file.reload()

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -388,25 +388,14 @@ class ReviewHelper(object):
         is_appropriate_reviewer = acl.action_allowed_user(
             request.user, permission)
 
-        # Special logic for availability of reject multiple action:
-        if (self.content_review or
-                is_recommendable or
-                self.addon.type == amo.ADDON_STATICTHEME):
-            can_reject_multiple = is_appropriate_reviewer
-        else:
-            # When doing a code review, this action is also available to
-            # users with Addons:PostReview even if the current version hasn't
-            # been auto-approved, provided that the add-on isn't marked as
-            # needing admin review.
-            can_reject_multiple = (
-                is_appropriate_reviewer or
-                (acl.action_allowed_user(
-                    request.user, amo.permissions.ADDONS_POST_REVIEW) and
-                 not is_admin_needed)
-            )
-
         addon_is_complete = self.addon.status not in (
             amo.STATUS_NULL, amo.STATUS_DELETED)
+        addon_is_incomplete_and_version_is_unlisted = (
+            self.addon.status == amo.STATUS_NULL and version_is_unlisted
+        )
+        addon_is_reviewable = (
+            addon_is_complete or addon_is_incomplete_and_version_is_unlisted
+        )
         version_is_unreviewed = self.version and self.version.is_unreviewed
         addon_is_valid = self.addon.is_public() or self.addon.is_unreviewed()
         addon_is_valid_and_version_is_listed = (
@@ -414,6 +403,28 @@ class ReviewHelper(object):
             self.version and
             self.version.channel == amo.RELEASE_CHANNEL_LISTED
         )
+
+        # Special logic for availability of reject multiple action:
+        if version_is_unlisted:
+            can_reject_multiple = is_appropriate_reviewer
+        elif (self.content_review or
+                is_recommendable or
+                self.addon.type == amo.ADDON_STATICTHEME):
+            can_reject_multiple = (
+                addon_is_valid_and_version_is_listed and
+                is_appropriate_reviewer
+            )
+        else:
+            # When doing a code review, this action is also available to
+            # users with Addons:PostReview even if the current version hasn't
+            # been auto-approved, provided that the add-on isn't marked as
+            # needing admin review.
+            can_reject_multiple = addon_is_valid_and_version_is_listed and (
+                is_appropriate_reviewer or
+                (acl.action_allowed_user(
+                    request.user, amo.permissions.ADDONS_POST_REVIEW) and
+                 not is_admin_needed)
+            )
 
         # Definitions for all actions.
         actions['public'] = {
@@ -425,7 +436,7 @@ class ReviewHelper(object):
             'label': _('Approve'),
             'available': (
                 not self.content_review and
-                addon_is_complete and
+                addon_is_reviewable and
                 version_is_unreviewed and
                 is_appropriate_reviewer
             )
@@ -439,7 +450,10 @@ class ReviewHelper(object):
             'minimal': False,
             'available': (
                 not self.content_review and
-                addon_is_complete and
+                # We specifically don't let the individual reject action be
+                # available for unlisted review. `process_sandbox` isn't
+                # currently implemented for unlisted.
+                addon_is_valid_and_version_is_listed and
                 version_is_unreviewed and
                 is_appropriate_reviewer
             )
@@ -479,16 +493,14 @@ class ReviewHelper(object):
             'label': _('Reject Multiple Versions'),
             'minimal': True,
             'versions': True,
-            'details': _('This will reject the selected public '
-                         'versions. The comments will be sent to the '
-                         'developer.'),
+            'details': _('This will reject the selected versions. '
+                         'The comments will be sent to the developer.'),
             'available': (
-                addon_is_valid_and_version_is_listed and
                 can_reject_multiple
             ),
         }
         actions['block_multiple_versions'] = {
-            'method': self.handler.reject_multiple_versions,
+            'method': self.handler.block_multiple_versions,
             'label': _('Block Multiple Versions'),
             'minimal': True,
             'versions': True,
@@ -955,6 +967,7 @@ class ReviewBase(object):
         # modify in this action, so set them to None before finding the right
         # versions.
         status = self.addon.status
+        channel = self.version.channel
         latest_version = self.version
         self.version = None
         self.files = None
@@ -980,7 +993,8 @@ class ReviewBase(object):
         # of the add-on instead of one of the versions we rejected, it will be
         # used to generate a token allowing the developer to reply, and that
         # only works with the latest version.
-        if self.addon.status != amo.STATUS_APPROVED:
+        if (self.addon.status != amo.STATUS_APPROVED and
+                channel == amo.RELEASE_CHANNEL_LISTED):
             template = u'reject_multiple_versions_disabled_addon'
             subject = (u'Mozilla Add-ons: %s%s has been disabled on '
                        u'addons.mozilla.org')
@@ -1002,6 +1016,9 @@ class ReviewBase(object):
                 post_review=True, content_review=self.content_review)
 
     def confirm_multiple_versions(self):
+        raise NotImplementedError  # only implemented for unlisted below.
+
+    def block_multiple_versions(self):
         raise NotImplementedError  # only implemented for unlisted below.
 
 
@@ -1050,7 +1067,7 @@ class ReviewUnlisted(ReviewBase):
                  (self.addon, ', '.join([f.filename for f in self.files])))
         log.info(u'Sending email for %s' % (self.addon))
 
-    def reject_multiple_versions(self):
+    def block_multiple_versions(self):
         # self.version and self.files won't point to the versions we want to
         # modify in this action, so set them to None before finding the right
         # versions.


### PR DESCRIPTION
Also let them approve the latest unlisted awaiting review when the add-on
is incomplete (like when there were no listed versions submitted)

Fixes #14024