### PR TITLE
RE: Update install doc regarding elasticsearch timed out error

### DIFF
--- a/docs/topics/install/docker.rst
+++ b/docs/topics/install/docker.rst
@@ -14,7 +14,7 @@ There are two options for running docker depending on the platform
 you are running.
 
  * Run docker on the host machine directly (recommended)
-    - Update default settings in Docker Desktop - we suggest increasing RAM limit to at least 4 GB in the Resources/Advanced section and click on “Apply and Restart".
+    - Update default settings in Docker Desktop - we suggest increasing RAM limit to at least 4 GB in the Resources/Advanced section and click on "Apply and Restart".
  * Run docker-machine which will run docker inside a virtual-machine
 
 Historically Mac and Windows could only run Docker via a vm. That has
@@ -197,7 +197,7 @@ Connection to elasticsearch timed out (elasticsearch container exits with code 1
 ``make initialize`` causes the elasticsearch container to go down. Running
 ``docker-compose ps`` shows ``Exited (137)`` against it.
 
-Update default settings in Docker Desktop - we suggest increasing RAM limit to at least 4 GB in the Resources/Advanced section and click on “Apply and Restart".
+Update default settings in Docker Desktop - we suggest increasing RAM limit to at least 4 GB in the Resources/Advanced section and click on "Apply and Restart".
 
 
 Port collisions (nginx container fails to start)

--- a/docs/topics/install/docker.rst
+++ b/docs/topics/install/docker.rst
@@ -14,7 +14,7 @@ There are two options for running docker depending on the platform
 you are running.
 
  * Run docker on the host machine directly (recommended)
-    - Update default settings in Docker Desktop - increase RAM limit from 2 GB (preferably 4 GB) in the Resources/Advanced section and click on "Apply and Restart".
+    - Update default settings in Docker Desktop - we suggest increasing RAM limit to at least 4 GB in the Resources/Advanced section and click on “Apply and Restart".
  * Run docker-machine which will run docker inside a virtual-machine
 
 Historically Mac and Windows could only run Docker via a vm. That has
@@ -197,8 +197,7 @@ Connection to elasticsearch timed out (elasticsearch container exits with code 1
 ``make initialize`` causes the elasticsearch container to go down. Running
 ``docker-compose ps`` shows ``Exited (137)`` against it.
 
-Increase RAM limit from 2 GB (preferably 4 GB) in Resources section of
-Docker Desktop settings and click on "Apply and Restart".
+Update default settings in Docker Desktop - we suggest increasing RAM limit to at least 4 GB in the Resources/Advanced section and click on “Apply and Restart".
 
 
 Port collisions (nginx container fails to start)

--- a/docs/topics/install/docker.rst
+++ b/docs/topics/install/docker.rst
@@ -14,6 +14,7 @@ There are two options for running docker depending on the platform
 you are running.
 
  * Run docker on the host machine directly (recommended)
+    - Update default settings in Docker Desktop - increase RAM limit from 2 GB (preferably 4 GB) in the Resources/Advanced section and click on "Apply and Restart".
  * Run docker-machine which will run docker inside a virtual-machine
 
 Historically Mac and Windows could only run Docker via a vm. That has
@@ -189,7 +190,7 @@ or your docker-machine VM:
 This allows processes to allocate more `memory map areas`_.
 
 
-Docker for Windows only: elasticsearch container exits with code 137
+Connection to elasticsearch timed out (elasticsearch container exits with code 137)
 --------------------------------------------------------------------
 
 ``docker-compose up -d`` brings up all containers, but running

--- a/docs/topics/install/docker.rst
+++ b/docs/topics/install/docker.rst
@@ -191,7 +191,7 @@ This allows processes to allocate more `memory map areas`_.
 
 
 Connection to elasticsearch timed out (elasticsearch container exits with code 137)
---------------------------------------------------------------------
+------------------------------------------------------------------------------------
 
 ``docker-compose up -d`` brings up all containers, but running
 ``make initialize`` causes the elasticsearch container to go down. Running


### PR DESCRIPTION
Fixes #14356 

The following revisions to the install doc have been made:

1. Added a line to prompt update of default RAM limit settings when selecting Docker to install project
2. Updated elasticsearch gotcha note from "Docker for Windows only: elasticsearch container exits with code 137" to the actual error message of "Connection to elasticsearch timed out"

