### PR TITLE
Remove `version` from retrieve and list draft_comments API responses

### DIFF
--- a/docs/topics/api/reviewers.rst
+++ b/docs/topics/api/reviewers.rst
@@ -371,8 +371,7 @@ These endpoints allow you to draft comments that can be submitted through the re
     :>json string comment: The comment that is being drafted as part of a review. Specific to a line in a file.
     :>json string|null filename: The full file path a specific comment is related to. Can be ``null`` in case a comment doesn't belong to a specific file but the whole version.
     :>json int|null lineno: The line number a specific comment is related to. Please make sure that in case of comments for git diffs, that the `lineno` used here belongs to the file in the version that belongs to `version_id` and not it's parent. Can be ``null`` in case a comment belongs to the whole file and not to a specific line.
-    :>json object version: The version that corresponds to the comment.
-    :>json int version.id: The id of the version.
+    :>json int version: The id of the version.
     :>json int user.id: The id for an author.
     :>json string user.name: The name for an author.
     :>json string user.username: The username for an author.

--- a/docs/topics/api/reviewers.rst
+++ b/docs/topics/api/reviewers.rst
@@ -371,7 +371,7 @@ These endpoints allow you to draft comments that can be submitted through the re
     :>json string comment: The comment that is being drafted as part of a review. Specific to a line in a file.
     :>json string|null filename: The full file path a specific comment is related to. Can be ``null`` in case a comment doesn't belong to a specific file but the whole version.
     :>json int|null lineno: The line number a specific comment is related to. Please make sure that in case of comments for git diffs, that the `lineno` used here belongs to the file in the version that belongs to `version_id` and not it's parent. Can be ``null`` in case a comment belongs to the whole file and not to a specific line.
-    :>json int version: The id of the version.
+    :>json int version_id: The id of the version.
     :>json int user.id: The id for an author.
     :>json string user.name: The name for an author.
     :>json string user.username: The username for an author.

--- a/docs/topics/api/reviewers.rst
+++ b/docs/topics/api/reviewers.rst
@@ -371,7 +371,8 @@ These endpoints allow you to draft comments that can be submitted through the re
     :>json string comment: The comment that is being drafted as part of a review. Specific to a line in a file.
     :>json string|null filename: The full file path a specific comment is related to. Can be ``null`` in case a comment doesn't belong to a specific file but the whole version.
     :>json int|null lineno: The line number a specific comment is related to. Please make sure that in case of comments for git diffs, that the `lineno` used here belongs to the file in the version that belongs to `version_id` and not it's parent. Can be ``null`` in case a comment belongs to the whole file and not to a specific line.
-    :>json object version: Object holding the :ref:`version <reviewers-versions-browse-detail>`.
+    :>json object version: The version that corresponds to the comment.
+    :>json int version.id: The id of the version.
     :>json int user.id: The id for an author.
     :>json string user.name: The name for an author.
     :>json string user.username: The username for an author.

--- a/src/olympia/reviewers/serializers.py
+++ b/src/olympia/reviewers/serializers.py
@@ -522,8 +522,8 @@ class DraftCommentSerializer(serializers.ModelSerializer):
     user = SplitField(
         serializers.PrimaryKeyRelatedField(queryset=UserProfile.objects.all()),
         BaseUserSerializer())
-    version = serializers.PrimaryKeyRelatedField(
-        queryset=Version.unfiltered.all())
+    version_id = serializers.PrimaryKeyRelatedField(
+        queryset=Version.unfiltered.all(), source='version')
     canned_response = SplitField(
         serializers.PrimaryKeyRelatedField(
             queryset=CannedResponse.objects.all(),
@@ -536,7 +536,7 @@ class DraftCommentSerializer(serializers.ModelSerializer):
         model = DraftComment
         fields = (
             'id', 'filename', 'lineno', 'comment',
-            'version', 'user', 'canned_response'
+            'version_id', 'user', 'canned_response'
         )
 
     def get_or_default(self, key, data, default=''):
@@ -577,9 +577,4 @@ class DraftCommentSerializer(serializers.ModelSerializer):
                 {'comment': ugettext(
                     'You can\'t submit a line number without associating '
                     'it to a filename.')})
-        return data
-
-    def to_representation(self, obj):
-        data = super(DraftCommentSerializer, self).to_representation(obj)
-        data['version_id'] = data.pop('version')
         return data

--- a/src/olympia/reviewers/serializers.py
+++ b/src/olympia/reviewers/serializers.py
@@ -518,10 +518,21 @@ class CannedResponseSerializer(serializers.ModelSerializer):
         return amo.CANNED_RESPONSE_CATEGORY_CHOICES[obj.category]
 
 
+class VersionIdOnlySerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Version
+        fields = ['id']
+
+
 class DraftCommentSerializer(serializers.ModelSerializer):
     user = SplitField(
         serializers.PrimaryKeyRelatedField(queryset=UserProfile.objects.all()),
         BaseUserSerializer())
+    version = SplitField(
+        serializers.PrimaryKeyRelatedField(
+            queryset=Version.unfiltered.all()),
+        VersionIdOnlySerializer())
     canned_response = SplitField(
         serializers.PrimaryKeyRelatedField(
             queryset=CannedResponse.objects.all(),
@@ -534,7 +545,7 @@ class DraftCommentSerializer(serializers.ModelSerializer):
         model = DraftComment
         fields = (
             'id', 'filename', 'lineno', 'comment',
-            'version_id', 'user', 'canned_response'
+            'version', 'user', 'canned_response'
         )
 
     def get_or_default(self, key, data, default=''):

--- a/src/olympia/reviewers/serializers.py
+++ b/src/olympia/reviewers/serializers.py
@@ -541,12 +541,6 @@ class DraftCommentSerializer(serializers.ModelSerializer):
             'version', 'user', 'canned_response'
         )
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # Set the instance for `AddonBrowseVersionSerializer` which requires
-        # on `instance` being set correctly.
-        self.fields['version'].output.instance = self.context['version']
-
     def get_or_default(self, key, data, default=''):
         """Return the value of ``key`` in ``data``
 
@@ -586,3 +580,16 @@ class DraftCommentSerializer(serializers.ModelSerializer):
                     'You can\'t submit a line number without associating '
                     'it to a filename.')})
         return data
+
+
+class DraftCommentSerializerReadOnly(DraftCommentSerializer):
+    version_id = serializers.SerializerMethodField()
+
+    class Meta(DraftCommentSerializer.Meta):
+        fields = (
+            'id', 'filename', 'lineno', 'comment',
+            'version_id', 'user', 'canned_response'
+        )
+
+    def get_version_id(self, obj):
+        return obj.version.id

--- a/src/olympia/reviewers/serializers.py
+++ b/src/olympia/reviewers/serializers.py
@@ -578,3 +578,8 @@ class DraftCommentSerializer(serializers.ModelSerializer):
                     'You can\'t submit a line number without associating '
                     'it to a filename.')})
         return data
+
+    def to_representation(self, obj):
+        data = super(DraftCommentSerializer, self).to_representation(obj)
+        data['version_id'] = data.pop('version')
+        return data

--- a/src/olympia/reviewers/serializers.py
+++ b/src/olympia/reviewers/serializers.py
@@ -518,21 +518,12 @@ class CannedResponseSerializer(serializers.ModelSerializer):
         return amo.CANNED_RESPONSE_CATEGORY_CHOICES[obj.category]
 
 
-class VersionIdOnlySerializer(serializers.ModelSerializer):
-
-    class Meta:
-        model = Version
-        fields = ['id']
-
-
 class DraftCommentSerializer(serializers.ModelSerializer):
     user = SplitField(
         serializers.PrimaryKeyRelatedField(queryset=UserProfile.objects.all()),
         BaseUserSerializer())
-    version = SplitField(
-        serializers.PrimaryKeyRelatedField(
-            queryset=Version.unfiltered.all()),
-        VersionIdOnlySerializer())
+    version = serializers.PrimaryKeyRelatedField(
+        queryset=Version.unfiltered.all())
     canned_response = SplitField(
         serializers.PrimaryKeyRelatedField(
             queryset=CannedResponse.objects.all(),

--- a/src/olympia/reviewers/serializers.py
+++ b/src/olympia/reviewers/serializers.py
@@ -522,10 +522,6 @@ class DraftCommentSerializer(serializers.ModelSerializer):
     user = SplitField(
         serializers.PrimaryKeyRelatedField(queryset=UserProfile.objects.all()),
         BaseUserSerializer())
-    version = SplitField(
-        serializers.PrimaryKeyRelatedField(
-            queryset=Version.unfiltered.all()),
-        AddonBrowseVersionSerializer())
     canned_response = SplitField(
         serializers.PrimaryKeyRelatedField(
             queryset=CannedResponse.objects.all(),
@@ -538,7 +534,7 @@ class DraftCommentSerializer(serializers.ModelSerializer):
         model = DraftComment
         fields = (
             'id', 'filename', 'lineno', 'comment',
-            'version', 'user', 'canned_response'
+            'version_id', 'user', 'canned_response'
         )
 
     def get_or_default(self, key, data, default=''):
@@ -580,16 +576,3 @@ class DraftCommentSerializer(serializers.ModelSerializer):
                     'You can\'t submit a line number without associating '
                     'it to a filename.')})
         return data
-
-
-class DraftCommentSerializerReadOnly(DraftCommentSerializer):
-    version_id = serializers.SerializerMethodField()
-
-    class Meta(DraftCommentSerializer.Meta):
-        fields = (
-            'id', 'filename', 'lineno', 'comment',
-            'version_id', 'user', 'canned_response'
-        )
-
-    def get_version_id(self, obj):
-        return obj.version.id

--- a/src/olympia/reviewers/tests/test_serializers.py
+++ b/src/olympia/reviewers/tests/test_serializers.py
@@ -6,10 +6,9 @@ from django.core.cache import cache
 from rest_framework.exceptions import NotFound
 
 from olympia import amo
-from olympia.activity.models import DraftComment
 from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.amo.tests import (
-    TestCase, addon_factory, user_factory, version_factory)
+    TestCase, addon_factory, version_factory)
 from olympia.amo.urlresolvers import reverse
 from olympia.files.models import FileValidation
 from olympia.git.utils import AddonGitRepository
@@ -18,7 +17,7 @@ from olympia.reviewers.models import CannedResponse
 from olympia.reviewers.serializers import (
     AddonBrowseVersionSerializer, AddonBrowseVersionSerializerFileOnly,
     AddonCompareVersionSerializerFileOnly, AddonCompareVersionSerializer,
-    CannedResponseSerializer, DraftCommentSerializerReadOnly,
+    CannedResponseSerializer,
     FileInfoDiffSerializer, FileInfoSerializer)
 from olympia.versions.models import License
 from olympia.versions.tasks import extract_version_to_git
@@ -780,26 +779,3 @@ class TestCannedResponseSerializer(TestCase):
             'response': 'test',
             'category': 'Other',
         }
-
-
-class TestDraftCommentSerializerReadOnly(TestCase):
-
-    def test_basic(self):
-        addon = addon_factory()
-        comment_text = 'Some comment'
-        filename = 'somefile.js'
-        lineno = 19
-        user = user_factory()
-        comment = DraftComment.objects.create(
-            comment=comment_text, filename=filename, lineno=lineno,
-            user=user, version=addon.current_version)
-
-        data = DraftCommentSerializerReadOnly(instance=comment).data
-
-        assert data['comment'] == comment_text
-        assert data['filename'] == filename
-        assert data['id'] == comment.id
-        assert data['lineno'] == lineno
-        assert data['user']['id'] == user.id
-        assert data['version_id'] == addon.current_version.id
-        assert 'version' not in data

--- a/src/olympia/reviewers/tests/test_serializers.py
+++ b/src/olympia/reviewers/tests/test_serializers.py
@@ -801,4 +801,4 @@ class TestDraftCommentSerializer(TestCase):
         assert data['id'] == comment.id
         assert data['lineno'] == lineno
         assert data['user']['id'] == user.id
-        assert data['version'] == addon.current_version.id
+        assert data['version_id'] == addon.current_version.id

--- a/src/olympia/reviewers/tests/test_serializers.py
+++ b/src/olympia/reviewers/tests/test_serializers.py
@@ -801,4 +801,4 @@ class TestDraftCommentSerializer(TestCase):
         assert data['id'] == comment.id
         assert data['lineno'] == lineno
         assert data['user']['id'] == user.id
-        assert data['version']['id'] == addon.current_version.id
+        assert data['version'] == addon.current_version.id

--- a/src/olympia/reviewers/tests/test_serializers.py
+++ b/src/olympia/reviewers/tests/test_serializers.py
@@ -6,8 +6,10 @@ from django.core.cache import cache
 from rest_framework.exceptions import NotFound
 
 from olympia import amo
+from olympia.activity.models import DraftComment
 from olympia.amo.templatetags.jinja_helpers import absolutify
-from olympia.amo.tests import TestCase, addon_factory, version_factory
+from olympia.amo.tests import (
+    TestCase, addon_factory, user_factory, version_factory)
 from olympia.amo.urlresolvers import reverse
 from olympia.files.models import FileValidation
 from olympia.git.utils import AddonGitRepository
@@ -16,7 +18,8 @@ from olympia.reviewers.models import CannedResponse
 from olympia.reviewers.serializers import (
     AddonBrowseVersionSerializer, AddonBrowseVersionSerializerFileOnly,
     AddonCompareVersionSerializerFileOnly, AddonCompareVersionSerializer,
-    CannedResponseSerializer, FileInfoDiffSerializer, FileInfoSerializer)
+    CannedResponseSerializer, DraftCommentSerializerReadOnly,
+    FileInfoDiffSerializer, FileInfoSerializer)
 from olympia.versions.models import License
 from olympia.versions.tasks import extract_version_to_git
 
@@ -777,3 +780,26 @@ class TestCannedResponseSerializer(TestCase):
             'response': 'test',
             'category': 'Other',
         }
+
+
+class TestDraftCommentSerializerReadOnly(TestCase):
+
+    def test_basic(self):
+        addon = addon_factory()
+        comment_text = 'Some comment'
+        filename = 'somefile.js'
+        lineno = 19
+        user = user_factory()
+        comment = DraftComment.objects.create(
+            comment=comment_text, filename=filename, lineno=lineno,
+            user=user, version=addon.current_version)
+
+        data = DraftCommentSerializerReadOnly(instance=comment).data
+
+        assert data['comment'] == comment_text
+        assert data['filename'] == filename
+        assert data['id'] == comment.id
+        assert data['lineno'] == lineno
+        assert data['user']['id'] == user.id
+        assert data['version_id'] == addon.current_version.id
+        assert 'version' not in data

--- a/src/olympia/reviewers/tests/test_serializers.py
+++ b/src/olympia/reviewers/tests/test_serializers.py
@@ -6,9 +6,10 @@ from django.core.cache import cache
 from rest_framework.exceptions import NotFound
 
 from olympia import amo
+from olympia.activity.models import DraftComment
 from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.amo.tests import (
-    TestCase, addon_factory, version_factory)
+    TestCase, addon_factory, user_factory, version_factory)
 from olympia.amo.urlresolvers import reverse
 from olympia.files.models import FileValidation
 from olympia.git.utils import AddonGitRepository
@@ -17,7 +18,7 @@ from olympia.reviewers.models import CannedResponse
 from olympia.reviewers.serializers import (
     AddonBrowseVersionSerializer, AddonBrowseVersionSerializerFileOnly,
     AddonCompareVersionSerializerFileOnly, AddonCompareVersionSerializer,
-    CannedResponseSerializer,
+    CannedResponseSerializer, DraftCommentSerializer,
     FileInfoDiffSerializer, FileInfoSerializer)
 from olympia.versions.models import License
 from olympia.versions.tasks import extract_version_to_git
@@ -779,3 +780,25 @@ class TestCannedResponseSerializer(TestCase):
             'response': 'test',
             'category': 'Other',
         }
+
+
+class TestDraftCommentSerializer(TestCase):
+
+    def test_basic(self):
+        addon = addon_factory()
+        comment_text = 'Some comment'
+        filename = 'somefile.js'
+        lineno = 19
+        user = user_factory()
+        comment = DraftComment.objects.create(
+            comment=comment_text, filename=filename, lineno=lineno,
+            user=user, version=addon.current_version)
+
+        data = DraftCommentSerializer(instance=comment).data
+
+        assert data['comment'] == comment_text
+        assert data['filename'] == filename
+        assert data['id'] == comment.id
+        assert data['lineno'] == lineno
+        assert data['user']['id'] == user.id
+        assert data['version']['id'] == addon.current_version.id

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -6720,7 +6720,7 @@ class TestDraftCommentViewSet(TestCase):
             'lineno': 20,
             'comment': 'Some really fancy comment',
             'canned_response': None,
-            'version': {'id': self.version.pk},
+            'version': self.version.pk,
             'user': json.loads(json.dumps(
                 BaseUserSerializer(
                     user, context={'request': request}).data,
@@ -7009,7 +7009,7 @@ class TestDraftCommentViewSet(TestCase):
             'canned_response': json.loads(json.dumps(
                 CannedResponseSerializer(canned_response).data,
                 cls=amo.utils.AMOJSONEncoder)),
-            'version': {'id': self.version.id},
+            'version': self.version.id,
             'user': json.loads(json.dumps(
                 BaseUserSerializer(
                     user, context={'request': request}).data,

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -6720,7 +6720,7 @@ class TestDraftCommentViewSet(TestCase):
             'lineno': 20,
             'comment': 'Some really fancy comment',
             'canned_response': None,
-            'version_id': self.version.pk,
+            'version': {'id': self.version.pk},
             'user': json.loads(json.dumps(
                 BaseUserSerializer(
                     user, context={'request': request}).data,
@@ -6753,23 +6753,6 @@ class TestDraftCommentViewSet(TestCase):
             # - 1 drafts
             response = self.client.get(url, {'lang': 'en-US'})
         assert response.json()['count'] == 3
-
-    def test_retrieve_uses_read_only_serializer(self):
-        user = user_factory(username='reviewer')
-        self.grant_permission(user, 'Addons:Review')
-        self.client.login_api(user)
-        comment = DraftComment.objects.create(
-            version=self.version, comment='test1', user=user,
-            lineno=0, filename='manifest.json')
-        url = reverse_ns('reviewers-versions-draft-comment-detail', kwargs={
-            'addon_pk': self.addon.pk,
-            'version_pk': self.version.pk,
-            'pk': comment.id
-        })
-
-        response = self.client.get(url, {'lang': 'en-US'})
-        assert response.json()['version_id'] == self.version.id
-        assert 'version' not in response.json()
 
     def test_create_retrieve_and_update(self):
         user = user_factory(username='reviewer')
@@ -7026,7 +7009,7 @@ class TestDraftCommentViewSet(TestCase):
             'canned_response': json.loads(json.dumps(
                 CannedResponseSerializer(canned_response).data,
                 cls=amo.utils.AMOJSONEncoder)),
-            'version_id': self.version.id,
+            'version': {'id': self.version.id},
             'user': json.loads(json.dumps(
                 BaseUserSerializer(
                     user, context={'request': request}).data,

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -6720,7 +6720,7 @@ class TestDraftCommentViewSet(TestCase):
             'lineno': 20,
             'comment': 'Some really fancy comment',
             'canned_response': None,
-            'version': self.version.pk,
+            'version_id': self.version.pk,
             'user': json.loads(json.dumps(
                 BaseUserSerializer(
                     user, context={'request': request}).data,
@@ -7009,7 +7009,7 @@ class TestDraftCommentViewSet(TestCase):
             'canned_response': json.loads(json.dumps(
                 CannedResponseSerializer(canned_response).data,
                 cls=amo.utils.AMOJSONEncoder)),
-            'version': self.version.id,
+            'version_id': self.version.id,
             'user': json.loads(json.dumps(
                 BaseUserSerializer(
                     user, context={'request': request}).data,

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -1462,7 +1462,7 @@ class ReviewAddonVersionDraftCommentViewSet(
 
     def get_extra_comment_data(self):
         return {
-            'version': self.get_version_object().pk,
+            'version_id': self.get_version_object().pk,
             'user': self.request.user.pk
         }
 

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -65,7 +65,8 @@ from olympia.reviewers.serializers import (
     AddonBrowseVersionSerializer, AddonBrowseVersionSerializerFileOnly,
     AddonCompareVersionSerializer, AddonCompareVersionSerializerFileOnly,
     AddonReviewerFlagsSerializer, CannedResponseSerializer,
-    DiffableVersionSerializer, DraftCommentSerializer, FileInfoSerializer,
+    DiffableVersionSerializer, DraftCommentSerializer,
+    DraftCommentSerializerReadOnly, FileInfoSerializer,
 )
 from olympia.reviewers.utils import (
     AutoApprovedTable, ContentReviewTable, ExpiredInfoRequestsTable,
@@ -1398,7 +1399,6 @@ class ReviewAddonVersionDraftCommentViewSet(
     )]
 
     queryset = DraftComment.objects.all()
-    serializer_class = DraftCommentSerializer
 
     def check_object_permissions(self, request, obj):
         """Check permissions against the parent add-on object."""
@@ -1480,6 +1480,11 @@ class ReviewAddonVersionDraftCommentViewSet(
         # and not provided by the API client as part of the POST data.
         self.request.data.update(self.get_extra_comment_data())
         return context
+
+    def get_serializer_class(self):
+        if self.action in ['list', 'retrieve']:
+            return DraftCommentSerializerReadOnly
+        return DraftCommentSerializer
 
 
 class ReviewAddonVersionCompareViewSet(ReviewAddonVersionMixin,

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -65,8 +65,7 @@ from olympia.reviewers.serializers import (
     AddonBrowseVersionSerializer, AddonBrowseVersionSerializerFileOnly,
     AddonCompareVersionSerializer, AddonCompareVersionSerializerFileOnly,
     AddonReviewerFlagsSerializer, CannedResponseSerializer,
-    DiffableVersionSerializer, DraftCommentSerializer,
-    DraftCommentSerializerReadOnly, FileInfoSerializer,
+    DiffableVersionSerializer, DraftCommentSerializer, FileInfoSerializer,
 )
 from olympia.reviewers.utils import (
     AutoApprovedTable, ContentReviewTable, ExpiredInfoRequestsTable,
@@ -1399,6 +1398,7 @@ class ReviewAddonVersionDraftCommentViewSet(
     )]
 
     queryset = DraftComment.objects.all()
+    serializer_class = DraftCommentSerializer
 
     def check_object_permissions(self, request, obj):
         """Check permissions against the parent add-on object."""
@@ -1480,11 +1480,6 @@ class ReviewAddonVersionDraftCommentViewSet(
         # and not provided by the API client as part of the POST data.
         self.request.data.update(self.get_extra_comment_data())
         return context
-
-    def get_serializer_class(self):
-        if self.action in ['list', 'retrieve']:
-            return DraftCommentSerializerReadOnly
-        return DraftCommentSerializer
 
 
 class ReviewAddonVersionCompareViewSet(ReviewAddonVersionMixin,


### PR DESCRIPTION
Fixes #14360 

This needs to land along with https://github.com/mozilla/addons-code-manager/pull/1602, otherwise Code Manager will break.
