### PR TITLE
Send fxa_id, not email, in user basket sync

### DIFF
--- a/docs/topics/basket.rst
+++ b/docs/topics/basket.rst
@@ -36,10 +36,10 @@ User Accounts
     :<json int id: The numeric user id.
     :<json boolean deleted: Is the account deleted.
     :<json string|null display_name: The name chosen by the user.
-    :<json string email: Email address used by the user to login and create this account.
+    :<json string|null homepage: The user's website.
+    :<json string fxa_id|null: The user FxA Identifier
     :<json string|null last_login: The date of the last successful log in to the website.
     :<json string|null location: The location of the user.
-    :<json string|null homepage: The user's website.
 
 Add-ons
 ~~~~~~~
@@ -80,8 +80,8 @@ Here is an example of the full json that would be sent for an add-on:
             {
                 "id": 11263,
                 "deleted": false,
-                "display_name": "serses",
-                "email": "mozilla@virgule.net",
+                "display_name": "qwerty",
+                "fxa_id": "1209e9bf1eeb59d0934579b6db0ccad1",
                 "homepage": "",
                 "last_login": "2019-08-06T10:39:44Z",
                 "location": ""

--- a/src/olympia/accounts/serializers.py
+++ b/src/olympia/accounts/serializers.py
@@ -265,6 +265,6 @@ class UserNotificationSerializer(serializers.Serializer):
 class UserProfileBasketSyncSerializer(UserProfileSerializer):
     class Meta(UserProfileSerializer.Meta):
         model = UserProfile
-        fields = ('id', 'deleted', 'display_name', 'email', 'homepage',
+        fields = ('id', 'deleted', 'display_name', 'homepage', 'fxa_id',
                   'last_login', 'location')
         read_only_fields = fields

--- a/src/olympia/accounts/tests/test_serializers.py
+++ b/src/olympia/accounts/tests/test_serializers.py
@@ -279,14 +279,15 @@ class TestUserProfileSerializer(TestPublicUserProfileSerializer,
 class TestUserProfileBasketSyncSerializer(TestCase):
     def setUp(self):
         self.user = user_factory(
-            display_name=None, last_login=self.days_ago(1))
+            display_name=None, last_login=self.days_ago(1),
+            fxa_id='qsdfghjklmù')
 
     def test_basic(self):
         serializer = UserProfileBasketSyncSerializer(self.user)
         assert serializer.data == {
             'deleted': False,
             'display_name': None,
-            'email': self.user.email,
+            'fxa_id': self.user.fxa_id,
             'homepage': '',
             'id': self.user.pk,
             'last_login': self.user.last_login.replace(
@@ -304,7 +305,7 @@ class TestUserProfileBasketSyncSerializer(TestCase):
         assert serializer.data == {
             'deleted': True,
             'display_name': None,
-            'email': None,
+            'fxa_id': None,
             'homepage': '',
             'id': self.user.pk,
             'last_login': self.user.last_login.replace(

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -1329,8 +1329,8 @@ class TestAddonBasketSyncSerializer(TestCase):
 
     def test_non_listed_author(self):
         self.addon = addon_factory()
-        user1 = user_factory()
-        user2 = user_factory()
+        user1 = user_factory(fxa_id='azerty')
+        user2 = user_factory(fxa_id=None)  # somehow no fxa_id.
         AddonUser.objects.create(
             addon=self.addon, user=user1, listed=True,
             role=amo.AUTHOR_ROLE_OWNER, position=1)
@@ -1342,7 +1342,7 @@ class TestAddonBasketSyncSerializer(TestCase):
             'id': user1.pk,
             'deleted': False,
             'display_name': '',
-            'email': user1.email,
+            'fxa_id': user1.fxa_id,
             'homepage': user1.homepage,
             'last_login': user1.last_login,
             'location': user1.location
@@ -1350,7 +1350,7 @@ class TestAddonBasketSyncSerializer(TestCase):
             'id': user2.pk,
             'deleted': False,
             'display_name': '',
-            'email': user2.email,
+            'fxa_id': user2.fxa_id,
             'homepage': user2.homepage,
             'last_login': user2.last_login,
             'location': user2.location

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -968,7 +968,7 @@ def watch_changes(old_attr=None, new_attr=None, instance=None,
             index_addons.delay(ids)
 
     basket_relevant_changes = (
-        'deleted', 'display_name', 'email', 'homepage', 'last_login',
+        'deleted', 'display_name', 'fxa_id', 'homepage', 'last_login',
         'location'
     )
     if any(field in changes for field in basket_relevant_changes):

--- a/src/olympia/users/tests/test_models.py
+++ b/src/olympia/users/tests/test_models.py
@@ -608,7 +608,7 @@ class TestUserProfile(TestCase):
         user = UserProfile.objects.get(id=4043307)
         # Note that basket_token is for newsletters, and is irrelevant here.
         user.update(
-            basket_token='FOO', fxa_id='BAR', is_public=True,
+            basket_token='FOO', email='newemail@example.com', is_public=True,
             read_dev_agreement=self.days_ago(42), notes='Blah',
             biography='Something', auth_id=12345)
         assert sync_object_to_basket_mock.delay.call_count == 0
@@ -624,6 +624,12 @@ class TestUserProfile(TestCase):
 
         sync_object_to_basket_mock.reset_mock()
         user.update(display_name='Fôoo')
+        assert sync_object_to_basket_mock.delay.call_count == 1
+        assert sync_object_to_basket_mock.delay.called_with(
+            'userprofile', 4043307)
+
+        sync_object_to_basket_mock.reset_mock()
+        user.update(fxa_id='wât')  # Can technically happen if admins do it.
         assert sync_object_to_basket_mock.delay.call_count == 1
         assert sync_object_to_basket_mock.delay.called_with(
             'userprofile', 4043307)


### PR DESCRIPTION
Salesforce already have FxA data so it's best not to send the email as it would be duplicate info anyway. FxA is the source of truth for emails.

Fixes #14318