### PR TITLE
Generate stats data when generating fake add-ons

### DIFF
--- a/src/olympia/landfill/generators.py
+++ b/src/olympia/landfill/generators.py
@@ -18,6 +18,7 @@ from .collection import generate_collection
 from .images import generate_addon_preview
 from .names import generate_names
 from .ratings import generate_ratings
+from .stats import generate_download_counts, generate_update_counts
 from .translations import generate_translations
 from .user import generate_addon_user_and_category, generate_user
 from .version import generate_version
@@ -90,6 +91,8 @@ def generate_addons(num, owner, app_name, addon_type=ADDON_EXTENSION):
             generate_collection(addon, app)
             featured_categories[category] += 1
         generate_ratings(addon, 5)
+        generate_download_counts(addon)
+        generate_update_counts(addon)
 
 
 def generate_themes(num, owner, **kwargs):

--- a/src/olympia/landfill/stats.py
+++ b/src/olympia/landfill/stats.py
@@ -1,0 +1,63 @@
+import random
+
+from datetime import datetime, timedelta
+
+from olympia.amo import FIREFOX
+from olympia.stats.models import DownloadCount, UpdateCount
+
+
+def generate_download_counts(addon, x_days=100):
+    """Generate download counts for the last X days."""
+    for days in range(x_days):
+        date = datetime.now().replace(microsecond=0) - timedelta(days=days)
+        source = {
+            0: None,
+            1: 'search',
+            2: 'dp-btn-primary',
+            3: None,
+            4: 'homepagepromo',
+            5: 'discovery-promo',
+        }[days % 5]
+        DownloadCount.objects.create(
+            addon=addon,
+            count=random.randrange(0, 1000),
+            date=date,
+            sources={source: random.randrange(0, 500)} if source else None,
+        )
+
+
+def generate_update_counts(addon, x_days=100):
+    """Generate update counts for the last X days."""
+    for days in range(x_days):
+        date = datetime.now().replace(microsecond=0) - timedelta(days=days)
+        versions = {}
+        applications = {
+            FIREFOX.guid: {
+                '70.0.0': random.randrange(0, 10),
+                '71.0.0': random.randrange(0, 10),
+                '72.0.0': random.randrange(0, 10),
+                '73.0.0': random.randrange(0, 10),
+                '74.0.0': random.randrange(0, 10),
+                '75.0.0': random.randrange(0, 10),
+                '76.0.0': random.randrange(0, 10),
+            }
+        }
+        oses = {
+            'Darwin': random.randrange(0, 10),
+            'Linux': random.randrange(0, 10),
+            'WINNT': random.randrange(0, 10),
+        }
+        locales = {
+            'de-DE': random.randrange(0, 10),
+            'en-US': random.randrange(0, 10),
+            'fr-FR': random.randrange(0, 10),
+        }
+        UpdateCount.objects.create(
+            addon=addon,
+            count=random.randrange(0, 100),
+            date=date,
+            versions=versions,
+            applications=applications,
+            oses=oses,
+            locales=locales,
+        )

--- a/src/olympia/landfill/tests/test_stats.py
+++ b/src/olympia/landfill/tests/test_stats.py
@@ -20,6 +20,10 @@ class TestGenerateDownloadCounts(TestCase):
         generate_download_counts(self.addon, x_days)
 
         assert DownloadCount.objects.all().count() == x_days
+        download_count = DownloadCount.objects.all()[0]
+        assert not download_count.sources
+        download_count = DownloadCount.objects.all()[1]
+        assert 'search' in download_count.sources
 
 
 class TestGenerateUpdateCounts(TestCase):

--- a/src/olympia/landfill/tests/test_stats.py
+++ b/src/olympia/landfill/tests/test_stats.py
@@ -1,0 +1,39 @@
+from olympia import amo
+from olympia.addons.models import Addon
+from olympia.amo.tests import TestCase
+from olympia.stats.models import DownloadCount, UpdateCount
+from olympia.landfill.stats import (
+    generate_download_counts,
+    generate_update_counts,
+)
+
+
+class TestGenerateDownloadCounts(TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.addon = Addon.objects.create(type=amo.ADDON_EXTENSION)
+
+    def test_generate_download_counts(self):
+        x_days = 10
+
+        generate_download_counts(self.addon, x_days)
+
+        assert DownloadCount.objects.all().count() == x_days
+
+
+class TestGenerateUpdateCounts(TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.addon = Addon.objects.create(type=amo.ADDON_EXTENSION)
+
+    def test_generate_update_counts(self):
+        x_days = 10
+
+        generate_update_counts(self.addon, x_days)
+
+        assert UpdateCount.objects.all().count() == x_days
+        update_count = UpdateCount.objects.all()[0]
+        assert 'Darwin' in update_count.oses
+        assert 'en-US' in update_count.locales


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/14396

---

With this patch, we can run `./manage.py index_stats` and the stats pages will work locally.