### PR TITLE
Remove "By Add-on Status" stats in beta mode

### DIFF
--- a/src/olympia/stats/templates/stats/addon_report_menu.html
+++ b/src/olympia/stats/templates/stats/addon_report_menu.html
@@ -27,9 +27,11 @@
       <li data-report="os">
         <a href="{{ stats_url('stats.os', addon.slug) }}">{{ _('by Platform') }}</a>
       </li>
+      {% if not beta %}
       <li data-report="statuses">
-        <a href="{{ stats_url('stats.statuses', addon.slug) }}">{{ _('by Add-on Status') }}</a>
+        <a href="{{ url('stats.statuses', addon.slug) }}">{{ _('by Add-on Status') }}</a>
       </li>
+      {% endif %}
     </ul>
   </ul>
 </nav>

--- a/src/olympia/stats/tests/test_views.py
+++ b/src/olympia/stats/tests/test_views.py
@@ -4,6 +4,7 @@ import json
 
 from django.http import Http404
 from django.test.client import RequestFactory
+from django.urls.exceptions import NoReverseMatch
 from django.utils.encoding import force_text
 
 from pyquery import PyQuery as pq
@@ -721,3 +722,16 @@ class TestStatsBeta(TestCase):
         match = resolve(url)
 
         assert match.kwargs['beta']
+
+    def test_no_status_page(self):
+        url = reverse('stats.overview.beta', args=[self.addon.slug])
+
+        response = self.client.get(url)
+
+        assert b'by Add-on Status' not in response.content
+
+        with self.assertRaises(NoReverseMatch):
+            reverse('stats.statuses.beta', args=[self.addon.slug])
+
+        with self.assertRaises(NoReverseMatch):
+            reverse('tats.statuses_series.beta', args=[self.addon.slug])

--- a/src/olympia/stats/urls.py
+++ b/src/olympia/stats/urls.py
@@ -50,9 +50,6 @@ stats_patterns = [
 
     url(r'^usage/status/$', views.stats_report, name='stats.statuses',
         kwargs={'report': 'statuses'}),
-    url(r'^beta/usage/status/$', views.stats_report,
-        name='stats.statuses.beta',
-        kwargs={'report': 'statuses', 'beta': True}),
 
     url(r'^usage/applications/$', views.stats_report, name='stats.apps',
         kwargs={'report': 'apps'}),
@@ -97,9 +94,6 @@ stats_patterns = [
 
     url(series['statuses'], views.usage_breakdown_series,
         name='stats.statuses_series', kwargs={'field': 'statuses'}),
-    url(beta_series['statuses'], views.usage_breakdown_series,
-        name='stats.statuses_series.beta',
-        kwargs={'field': 'statuses', 'beta': True}),
 
     url(series['versions'], views.usage_breakdown_series,
         name='stats.versions_series', kwargs={'field': 'versions'}),


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/14409

:warning: depends on https://github.com/mozilla/addons-server/pull/14403