### PR TITLE
Use BigQuery for the "user" (updates) stats in beta mode

### DIFF
--- a/src/olympia/stats/tests/test_utils.py
+++ b/src/olympia/stats/tests/test_utils.py
@@ -1,0 +1,175 @@
+from datetime import date
+from unittest import mock
+
+from django.test.utils import override_settings
+from google.cloud import bigquery
+
+from olympia.amo.tests import TestCase, addon_factory
+from olympia.constants.applications import FIREFOX
+from olympia.stats.utils import (
+    AMO_TO_BIGQUERY_COLUMN_MAPPING,
+    rows_to_series,
+    get_updates_series,
+)
+
+
+class TestRowsToSeries(TestCase):
+    def create_fake_bigquery_row(
+        self, dau=123, submission_date=date(2020, 5, 28), **kwargs
+    ):
+        data = {'dau': dau, 'submission_date': submission_date, **kwargs}
+        return bigquery.Row(
+            list(data.values()),
+            {key: idx for idx, key in enumerate(data.keys())},
+        )
+
+    def test_no_rows(self):
+        rows = []
+
+        series = list(rows_to_series(rows))
+
+        assert series == []
+
+    def test_returns_items(self):
+        dau = 456
+        submission_date = date(2020, 5, 24)
+        rows = [
+            self.create_fake_bigquery_row(
+                dau=dau, submission_date=submission_date
+            ),
+            self.create_fake_bigquery_row(),
+            self.create_fake_bigquery_row(),
+        ]
+
+        series = list(rows_to_series(rows))
+
+        assert len(series) == len(rows)
+        item = series[0]
+        assert 'count' in item
+        assert item['count'] == dau
+        assert 'date' in item
+        assert item['date'] == submission_date
+        assert 'end' in item
+        assert item['end'] == submission_date
+        # By default there should be no 'data' attribute.
+        assert 'data' not in series
+
+    def test_ignores_other_columns(self):
+        dau = 456
+        submission_date = date(2020, 5, 24)
+        rows = [
+            self.create_fake_bigquery_row(
+                dau=dau, submission_date=submission_date, other_column=123
+            )
+        ]
+
+        series = list(rows_to_series(rows))
+
+        assert series[0] == {
+            'count': dau,
+            'date': submission_date,
+            'end': submission_date,
+        }
+
+    def test_filter_by(self):
+        filter_by = 'column_with_data'
+        data = [{'key': 'k1', 'value': 123}, {'key': 'k2', 'value': 678}]
+        rows = [self.create_fake_bigquery_row(column_with_data=data)]
+
+        series = list(rows_to_series(rows, filter_by=filter_by))
+
+        assert 'data' in series[0]
+        assert series[0]['data'] == {'k1': 123, 'k2': 678}
+
+    def test_filter_by_dau_by_app_version(self):
+        filter_by = 'dau_by_app_version'
+        data = [
+            {'key': '77.0.0', 'value': 123},
+            {'key': '76.0.1', 'value': 678},
+        ]
+        rows = [self.create_fake_bigquery_row(dau_by_app_version=data)]
+
+        series = list(rows_to_series(rows, filter_by=filter_by))
+
+        assert 'data' in series[0]
+        assert series[0]['data'] == {
+            FIREFOX.guid: {'77.0.0': 123, '76.0.1': 678}
+        }
+
+
+class TestGetUpdatesSeries(TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.addon = addon_factory()
+
+    def create_mock_client(self):
+        client = mock.Mock()
+        result_mock = mock.Mock()
+        result_mock.return_value = []
+        client.query.return_value = result_mock
+        return client
+
+    @mock.patch('google.cloud.bigquery.Client')
+    def test_create_client(self, bigquery_client_mock):
+        credentials = 'path/to/credentials.json'
+        with override_settings(GOOGLE_APPLICATION_CREDENTIALS=credentials):
+            bigquery_client_mock.from_service_account_json = mock.Mock()
+            get_updates_series(
+                addon=self.addon,
+                start_date=date(2020, 5, 27),
+                end_date=date(2020, 5, 28),
+            )
+
+        bigquery_client_mock.from_service_account_json.assert_called_once_with(
+            credentials
+        )
+
+    @mock.patch('google.cloud.bigquery.Client')
+    def test_create_query(self, bigquery_client_mock):
+        client = self.create_mock_client()
+        bigquery_client_mock.from_service_account_json.return_value = client
+        start_date = date(2020, 5, 27)
+        end_date = date(2020, 5, 28)
+        expected_query = """
+SELECT submission_date, dau
+FROM `moz-fx-data-shared-prod.telemetry.amo_stats_dau`
+WHERE addon_id = @addon_id
+AND submission_date BETWEEN @submission_date_start AND @submission_date_end
+ORDER BY submission_date DESC
+LIMIT 365"""
+
+        get_updates_series(
+            addon=self.addon, start_date=start_date, end_date=end_date
+        )
+
+        client.query.assert_called_once_with(
+            expected_query, job_config=mock.ANY
+        )
+
+    @mock.patch('google.cloud.bigquery.Client')
+    def test_create_query_with_source(self, bigquery_client_mock):
+        client = self.create_mock_client()
+        bigquery_client_mock.from_service_account_json.return_value = client
+        start_date = date(2020, 5, 27)
+        end_date = date(2020, 5, 28)
+
+        for source, column in AMO_TO_BIGQUERY_COLUMN_MAPPING.items():
+            expected_query = f"""
+SELECT submission_date, dau, {column}
+FROM `moz-fx-data-shared-prod.telemetry.amo_stats_dau`
+WHERE addon_id = @addon_id
+AND submission_date BETWEEN @submission_date_start AND @submission_date_end
+ORDER BY submission_date DESC
+LIMIT 365"""
+
+            get_updates_series(
+                addon=self.addon,
+                start_date=start_date,
+                end_date=end_date,
+                source=source,
+            )
+
+            client.query.assert_called_with(
+                expected_query, job_config=mock.ANY
+            )

--- a/src/olympia/stats/utils.py
+++ b/src/olympia/stats/utils.py
@@ -1,0 +1,69 @@
+from django.conf import settings
+from google.cloud import bigquery
+
+from olympia.constants.applications import FIREFOX
+
+# This is the mapping between the AMO stats `sources` and the BigQuery columns.
+AMO_TO_BIGQUERY_COLUMN_MAPPING = {
+    'apps': 'dau_by_app_version',
+    'locales': 'dau_by_locale',
+    'os': 'dau_by_app_os',
+    'versions': 'dau_by_addon_version',
+}
+
+
+def rows_to_series(rows, filter_by=None):
+    """Transforms BigQuery rows into series items suitable for the rest of the
+    AMO stats logic."""
+    for row in rows:
+        item = {
+            'count': row.dau,
+            'date': row.submission_date,
+            'end': row.submission_date,
+        }
+        if filter_by:
+            item['data'] = {d['key']: d['value'] for d in row[filter_by]}
+
+            # See: https://github.com/mozilla/addons-server/issues/14411
+            if filter_by == 'dau_by_app_version':
+                item['data'] = {FIREFOX.guid: item['data']}
+
+        yield item
+
+
+def get_updates_series(addon, start_date, end_date, source=None):
+    client = bigquery.Client.from_service_account_json(
+        settings.GOOGLE_APPLICATION_CREDENTIALS
+    )
+
+    filter_by = AMO_TO_BIGQUERY_COLUMN_MAPPING[source] if source else None
+
+    select_clause = 'SELECT submission_date, dau'
+    if filter_by:
+        select_clause = f'{select_clause}, {filter_by}'
+    query = f"""
+{select_clause}
+FROM `moz-fx-data-shared-prod.telemetry.amo_stats_dau`
+WHERE addon_id = @addon_id
+AND submission_date BETWEEN @submission_date_start AND @submission_date_end
+ORDER BY submission_date DESC
+LIMIT 365"""
+
+    rows = client.query(
+        query,
+        job_config=bigquery.QueryJobConfig(
+            query_parameters=[
+                bigquery.ScalarQueryParameter(
+                    'addon_id', 'STRING', addon.guid
+                ),
+                bigquery.ScalarQueryParameter(
+                    'submission_date_start', 'DATE', start_date
+                ),
+                bigquery.ScalarQueryParameter(
+                    'submission_date_end', 'DATE', end_date
+                ),
+            ]
+        ),
+    ).result()
+
+    return rows_to_series(rows, filter_by=filter_by)

--- a/src/olympia/stats/views.py
+++ b/src/olympia/stats/views.py
@@ -304,7 +304,7 @@ def process_locales(series):
             new = {}
             for key, count in row['data'].items():
                 if key and key.lower() in languages:
-                    k = u'%s (%s)' % (languages[key.lower()], key)
+                    k = '%s (%s)' % (languages[key.lower()], key)
                     new[k] = count
             row['data'] = new
         yield row

--- a/src/olympia/stats/views.py
+++ b/src/olympia/stats/views.py
@@ -5,14 +5,13 @@ import itertools
 
 from datetime import timedelta
 
+from dateutil.parser import parse
 from django import http
 from django.core.exceptions import PermissionDenied
 from django.core.files.storage import get_storage_class
 from django.db.transaction import non_atomic_requests
 from django.utils.cache import add_never_cache_headers, patch_cache_control
 from django.utils.encoding import force_text
-
-from dateutil.parser import parse
 
 import olympia.core.logger
 
@@ -26,6 +25,7 @@ from olympia.stats.decorators import addon_view_stats
 from olympia.stats.forms import DateForm
 
 from .models import DownloadCount, UpdateCount
+from .utils import get_updates_series
 
 
 logger = olympia.core.logger.getLogger('z.apps.stats.views')
@@ -134,7 +134,14 @@ def overview_series(request, addon, group, start, end, format, beta=False):
     check_stats_permission(request, addon, beta)
 
     dls = get_series(DownloadCount, addon=addon.id, date__range=date_range)
-    updates = get_series(UpdateCount, addon=addon.id, date__range=date_range)
+
+    if beta:
+        updates = get_updates_series(addon=addon,
+                                     start_date=date_range[0],
+                                     end_date=date_range[1])
+    else:
+        updates = get_series(UpdateCount, addon=addon.id,
+                             date__range=date_range)
 
     series = zip_overview(dls, updates)
 
@@ -215,9 +222,14 @@ def usage_series(request, addon, group, start, end, format, beta=False):
     date_range = check_series_params_or_404(group, start, end, format)
     check_stats_permission(request, addon, beta)
 
-    series = get_series(
-        UpdateCount,
-        addon=addon.id, date__range=date_range)
+    if beta:
+        series = get_updates_series(addon=addon,
+                                    start_date=date_range[0],
+                                    end_date=date_range[1])
+    else:
+        series = get_series(
+            UpdateCount,
+            addon=addon.id, date__range=date_range)
 
     if format == 'csv':
         return render_csv(request, addon, series, ['date', 'count'])
@@ -237,11 +249,19 @@ def usage_breakdown_series(request, addon, group, start, end, format, field,
         'applications': 'apps',
         'locales': 'locales',
         'oses': 'os',
-        'versions': 'versions',
         'statuses': 'status',
+        'versions': 'versions',
     }
-    series = get_series(UpdateCount, source=fields[field],
-                        addon=addon.id, date__range=date_range)
+    source = fields[field]
+
+    if beta:
+        series = get_updates_series(addon=addon,
+                                    start_date=date_range[0],
+                                    end_date=date_range[1], source=source)
+    else:
+        series = get_series(UpdateCount, source=source, addon=addon.id,
+                            date__range=date_range)
+
     if field == 'locales':
         series = process_locales(series)
 
@@ -283,8 +303,8 @@ def process_locales(series):
         if 'data' in row:
             new = {}
             for key, count in row['data'].items():
-                if key in languages:
-                    k = u'%s (%s)' % (languages[key], key)
+                if key and key.lower() in languages:
+                    k = u'%s (%s)' % (languages[key.lower()], key)
                     new[k] = count
             row['data'] = new
         yield row


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/14412

~~:warning: depends on https://github.com/mozilla/addons-server/pull/14403~~

---

This patch implements a new data source (BigQuery) but only for the "beta" stats. It is possible to test it locally but you need to:

1. fetch the credentials (a json file) in -dev (using -ssh, path is in `settings.GOOGLE_APPLICATION_CREDENTIALS`)
2. configure `GOOGLE_APPLICATION_CREDENTIALS` in `local_settings.py`
3. update a local add-on with a known GUID like the one mentioned [here](https://bugzilla.mozilla.org/show_bug.cgi?id=1633746#c0)

To access the beta, append `beta/` to the URL of the main (overview) stats page and make sure your local account as a `@mozilla.com` email address.

Other notes:

- the fact that we call BigQuery directly was decided before and it looks like a good idea. It works quite well but we'll see in production. We might want to add some caching layer later, though.
- all the rendering logic has been kept so that's why we do not have lots of tests for the views. We'll tackle that when/if we'll change the stats pages.