### PR TITLE
Add a check to restrict the access to the beta stats

### DIFF
--- a/src/olympia/stats/tests/test_views.py
+++ b/src/olympia/stats/tests/test_views.py
@@ -701,7 +701,7 @@ class TestStatsBeta(TestCase):
     def setUp(self):
         super().setUp()
 
-        self.user = user_factory()
+        self.user = user_factory(email='staff@mozilla.com')
         self.addon = addon_factory(users=[self.user])
         self.client.login(email=self.user.email)
 
@@ -735,3 +735,14 @@ class TestStatsBeta(TestCase):
 
         with self.assertRaises(NoReverseMatch):
             reverse('tats.statuses_series.beta', args=[self.addon.slug])
+
+    def test_no_beta_for_non_staff(self):
+        self.client.logout()
+        self.user.update(email='not.staff@yahoo.com')
+        self.client.login(email=self.user.email)
+
+        url = reverse('stats.overview.beta', args=[self.addon.slug])
+
+        response = self.client.get(url)
+
+        assert response.status_code == 404


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/14424

:warning: depends on #14403

---

~~The `User.is_staff` has been discussed with @diox.~~ switched to a homemade solution because `is_staff` is not working as I wished.