### PR TITLE
Move user restriction info out of an inline in user admin tool

### DIFF
--- a/src/olympia/constants/permissions.py
+++ b/src/olympia/constants/permissions.py
@@ -189,6 +189,7 @@ DJANGO_PERMISSIONS_MAPPING.update({
     'users.delete_disposableemaildomainrestriction,': ADMIN_ADVANCED,
     'users.delete_emailuserrestriction': ADMIN_ADVANCED,
     'users.delete_ipnetworkuserrestriction': ADMIN_ADVANCED,
+    'users.view_userrestrictionhistory': ADMIN_ADVANCED,
 
     'ratings.change_rating': RATINGS_MODERATE,
     'ratings.delete_rating': ADMIN_ADVANCED,

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -935,6 +935,9 @@ class UserRestrictionHistory(ModelBase):
     ip_address = models.CharField(default='', max_length=45)
     last_login_ip = models.CharField(default='', max_length=45)
 
+    class Meta:
+        verbose_name_plural = _('User Restriction History')
+
 
 class UserHistory(ModelBase):
     id = PositiveAutoField(primary_key=True)


### PR DESCRIPTION
For users with too many restrictions it's too slow/inefficient.

Fixes #14517