### PR TITLE
Trying to get validation.json to work

### DIFF
--- a/src/olympia/devhub/decorators.py
+++ b/src/olympia/devhub/decorators.py
@@ -19,7 +19,7 @@ def dev_required(owner_for_post=False, allow_reviewers_for_read=False,
     When allow_reviewers is True, reviewers can view the page.
     """
     def decorator(f):
-        @addon_view_factory(qs=Addon.objects.all)
+        @addon_view_factory(qs=Addon.unfiltered.all)
         @login_required
         @functools.wraps(f)
         def wrapper(request, addon, *args, **kw):

--- a/src/olympia/devhub/decorators.py
+++ b/src/olympia/devhub/decorators.py
@@ -13,13 +13,13 @@ from olympia.constants import permissions
 
 
 def dev_required(owner_for_post=False, allow_reviewers_for_read=False,
-                 submitting=False):
+                 submitting=False, qs=Addon.objects.all):
     """Requires user to be add-on owner or admin.
 
     When allow_reviewers is True, reviewers can view the page.
     """
     def decorator(f):
-        @addon_view_factory(qs=Addon.unfiltered.all)
+        @addon_view_factory(qs=qs)
         @login_required
         @functools.wraps(f)
         def wrapper(request, addon, *args, **kw):

--- a/src/olympia/devhub/tests/test_views_validation.py
+++ b/src/olympia/devhub/tests/test_views_validation.py
@@ -276,6 +276,13 @@ class TestFileValidation(TestCase):
         assert link.text == 'https://bugzilla.mozilla.org/'
         assert link.attrib['href'] == 'https://bugzilla.mozilla.org/'
 
+    def test_can_see_json_results_for_deleted_addon(self):
+        self.client.logout()
+        assert self.client.login(email='admin@mozilla.com')
+        self.addon.delete()
+
+        assert self.client.head(self.json_url, follow=False).status_code == 200
+
 
 class TestValidateAddon(TestCase):
     fixtures = ['base/users']

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -675,7 +675,7 @@ def file_validation(request, addon_id, addon, file_id):
 
 
 @csrf_exempt
-@dev_required(allow_reviewers_for_read=True)
+@dev_required(allow_reviewers_for_read=True, qs=Addon.unfiltered.all)
 def json_file_validation(request, addon_id, addon, file_id):
     file = get_object_or_404(File, version__addon=addon, id=file_id)
     try:


### PR DESCRIPTION
The `json_file_validation` view in devhub returns a 404 when the add-on has been deleted. 

I am trying to fix that, and I've traced the current source of the 404 to the call to https://github.com/mozilla/addons-server/blob/master/src/olympia/addons/decorators.py#L28. I changed the `qs` that is being passed into `addon_view` via the `dev_required` decorator from `Addon.objects.all` to `Addon.unfiltered.all` (as can be seen in the attached patch), thinking that would allow it to find the deleted add-on, but I'm still getting a 404 at https://github.com/mozilla/addons-server/blob/master/src/olympia/addons/decorators.py#L28.

I realize that I might not be able to make this change to `dev_required` without some undesirable repercussions, but at this point I'm just trying to debug it and figure out how to eliminate the 404.
