### PR TITLE
Allow code manager APIs to return data for deleted add-ons

### DIFF
--- a/src/olympia/devhub/decorators.py
+++ b/src/olympia/devhub/decorators.py
@@ -13,13 +13,13 @@ from olympia.constants import permissions
 
 
 def dev_required(owner_for_post=False, allow_reviewers_for_read=False,
-                 submitting=False):
+                 submitting=False, qs=Addon.objects.all):
     """Requires user to be add-on owner or admin.
 
     When allow_reviewers is True, reviewers can view the page.
     """
     def decorator(f):
-        @addon_view_factory(qs=Addon.objects.all)
+        @addon_view_factory(qs=qs)
         @login_required
         @functools.wraps(f)
         def wrapper(request, addon, *args, **kw):

--- a/src/olympia/devhub/tests/test_views_validation.py
+++ b/src/olympia/devhub/tests/test_views_validation.py
@@ -284,6 +284,15 @@ class TestFileValidation(TestCase):
         doc = pq(response.content)
         assert doc('#addon-validator-suite').attr['data-file-url'] == file_url
 
+    def test_can_see_json_results_for_deleted_addon(self):
+        self.client.logout()
+        assert self.client.login(email='admin@mozilla.com')
+        self.addon.delete()
+        args = [self.addon.pk, self.file.id]
+        json_url = reverse('devhub.json_file_validation', args=args)
+
+        assert self.client.head(json_url, follow=False).status_code == 200
+
 
 class TestValidateAddon(TestCase):
     fixtures = ['base/users']

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -678,7 +678,7 @@ def file_validation(request, addon_id, addon, file_id):
 
 
 @csrf_exempt
-@dev_required(allow_reviewers_for_read=True)
+@dev_required(allow_reviewers_for_read=True, qs=Addon.unfiltered.all)
 def json_file_validation(request, addon_id, addon, file_id):
     file = get_object_or_404(File, version__addon=addon, id=file_id)
     try:

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -678,6 +678,8 @@ def file_validation(request, addon_id, addon, file_id):
 
 
 @csrf_exempt
+# This allows read-only access to deleted add-ons for reviewers
+# but not developers.
 @dev_required(allow_reviewers_for_read=True, qs=Addon.unfiltered.all)
 def json_file_validation(request, addon_id, addon, file_id):
     file = get_object_or_404(File, version__addon=addon, id=file_id)

--- a/src/olympia/reviewers/serializers.py
+++ b/src/olympia/reviewers/serializers.py
@@ -412,12 +412,12 @@ class AddonBrowseVersionSerializer(
 
     def get_validation_url_json(self, obj):
         return absolutify(reverse('devhub.json_file_validation', args=[
-            obj.addon.slug, obj.current_file.id
+            obj.addon.pk, obj.current_file.id
         ]))
 
     def get_validation_url(self, obj):
         return absolutify(reverse('devhub.file_validation', args=[
-            obj.addon.slug, obj.current_file.id
+            obj.addon.pk, obj.current_file.id
         ]))
 
     def get_has_been_validated(self, obj):

--- a/src/olympia/reviewers/tests/test_serializers.py
+++ b/src/olympia/reviewers/tests/test_serializers.py
@@ -421,9 +421,9 @@ class TestAddonBrowseVersionSerializer(TestCase):
         # Custom fields
         validation_url_json = absolutify(reverse(
             'devhub.json_file_validation', args=[
-                self.addon.slug, self.version.current_file.id]))
+                self.addon.pk, self.version.current_file.id]))
         validation_url = absolutify(reverse('devhub.file_validation', args=[
-            self.addon.slug, self.version.current_file.id]))
+            self.addon.pk, self.version.current_file.id]))
 
         assert data['validation_url_json'] == validation_url_json
         assert data['validation_url'] == validation_url

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -1327,7 +1327,7 @@ class ReviewAddonVersionMixin(object):
         if not hasattr(self, 'addon_object'):
             # We only need translations on the add-on, no other transforms.
             self.addon_object = get_object_or_404(
-                Addon.objects.get_queryset().only_translations(),
+                Addon.unfiltered.all().only_translations(),
                 pk=self.kwargs.get('addon_pk'))
         return self.addon_object
 
@@ -1439,7 +1439,7 @@ class ReviewAddonVersionDraftCommentViewSet(
                 # The serializer will not need to return much info about the
                 # addon, so we can use just the translations transformer and
                 # avoid the rest.
-                Addon.objects.get_queryset().only_translations(),
+                Addon.unfiltered.all().only_translations(),
                 pk=self.kwargs['addon_pk'])
         return self.addon_object
 


### PR DESCRIPTION
~~Depends on https://github.com/mozilla/addons-server/pull/14611~~
Fixes #14498 
