### PR TITLE
add delete_user_event task

### DIFF
--- a/src/olympia/accounts/tasks.py
+++ b/src/olympia/accounts/tasks.py
@@ -1,3 +1,4 @@
+import functools
 from datetime import datetime
 
 import olympia.core.logger
@@ -10,24 +11,45 @@ from olympia.users.models import UserProfile
 log = olympia.core.logger.getLogger('z.accounts')
 
 
+def user_profile_from_uid(f):
+    @functools.wraps(f)
+    def wrapper(uid, timestamp, *args, **kw):
+        try:
+            timestamp = datetime.fromtimestamp(timestamp)
+            profile = UserProfile.objects.get(fxa_id=uid)
+            return f(profile, timestamp, *args, **kw)
+        except ValueError as e:
+            log.warning(e)
+        except UserProfile.MultipleObjectsReturned:
+            log.warning('Multiple profile matches for FxA id %s' % uid)
+        except UserProfile.DoesNotExist:
+            log.info('No profile match for FxA id %s' % uid)
+    return wrapper
+
+
 @task
 @use_primary_db
-def primary_email_change_event(email, uid, timestamp):
+@user_profile_from_uid
+def primary_email_change_event(profile, changed_date, email):
     """Process the primaryEmailChangedEvent."""
-    try:
-        profile = UserProfile.objects.get(fxa_id=uid)
-        changed_date = datetime.fromtimestamp(timestamp)
-        if (not profile.email_changed or
-                profile.email_changed < changed_date):
-            profile.update(email=email, email_changed=changed_date)
-            log.info('Account [%s] email [%s] changed from FxA on %s' %
-                     (profile.id, email, changed_date))
-        else:
-            log.warning('Account [%s] email updated ignored, %s > %s' %
-                        (profile.id, profile.email_changed, changed_date))
-    except ValueError as e:
-        log.warning(e)
-    except UserProfile.MultipleObjectsReturned:
-        log.warning('Multiple profile matches for FxA id %s' % uid)
-    except UserProfile.DoesNotExist:
-        log.info('No profile match for FxA id %s' % uid)
+    if (not profile.email_changed or
+            profile.email_changed < changed_date):
+        profile.update(email=email, email_changed=changed_date)
+        log.info(
+            'Account pk [%s] email [%s] changed from FxA on %s' % (
+                profile.id, email, changed_date))
+    else:
+        log.warning('Account pk [%s] email updated ignored, %s > %s' %
+                    (profile.id, profile.email_changed, changed_date))
+
+
+@task
+@use_primary_db
+@user_profile_from_uid
+def delete_user_event(user, deleted_date):
+    """Process the delete user event."""
+    user.delete(
+        related_content=True,
+        addon_msg='Deleted via FxA account deletion')
+    log.info(
+        'Account pk [%s] deleted from FxA on %s' % (user.id, deleted_date))

--- a/src/olympia/accounts/tests/test_tasks.py
+++ b/src/olympia/accounts/tests/test_tasks.py
@@ -1,8 +1,14 @@
 from datetime import datetime
+from unittest import mock
 
-from olympia.accounts.tasks import primary_email_change_event
+from olympia import amo
+from olympia.accounts.tasks import (
+    delete_user_event, primary_email_change_event)
 from olympia.accounts.tests.test_utils import totimestamp
-from olympia.amo.tests import TestCase, user_factory
+from olympia.amo.tests import (
+    addon_factory, collection_factory, TestCase, user_factory)
+from olympia.bandwagon.models import Collection
+from olympia.ratings.models import Rating
 
 
 class TestPrimaryEmailChangeEvent(TestCase):
@@ -11,8 +17,9 @@ class TestPrimaryEmailChangeEvent(TestCase):
         user = user_factory(email='old-email@example.com',
                             fxa_id='ABCDEF012345689')
         primary_email_change_event(
-            'new-email@example.com', 'ABCDEF012345689',
-            totimestamp(datetime(2017, 10, 11)))
+            'ABCDEF012345689',
+            totimestamp(datetime(2017, 10, 11)),
+            'new-email@example.com')
         user.reload()
         assert user.email == 'new-email@example.com'
         assert user.email_changed == datetime(2017, 10, 11, 0, 0)
@@ -25,20 +32,67 @@ class TestPrimaryEmailChangeEvent(TestCase):
         tomorrow = datetime(2017, 10, 3)
 
         primary_email_change_event(
-            'today@example.com', 'ABCDEF012345689', totimestamp(today))
+            'ABCDEF012345689',
+            totimestamp(today),
+            'today@example.com')
         assert user.reload().email == 'today@example.com'
 
         primary_email_change_event(
-            'tomorrow@example.com', 'ABCDEF012345689', totimestamp(tomorrow))
+            'ABCDEF012345689',
+            totimestamp(tomorrow),
+            'tomorrow@example.com')
         assert user.reload().email == 'tomorrow@example.com'
 
         primary_email_change_event(
-            'yesterday@example.com', 'ABCDEF012345689', totimestamp(yesterday))
+            'ABCDEF012345689',
+            totimestamp(yesterday),
+            'yesterday@example.com')
         assert user.reload().email != 'yesterday@example.com'
         assert user.reload().email == 'tomorrow@example.com'
 
     def test_ignored_if_user_not_found(self):
         """Check that this doesn't throw"""
         primary_email_change_event(
-            'email@example.com', 'ABCDEF012345689',
+            'ABCDEF012345689',
+            totimestamp(datetime(2017, 10, 11)),
+            'email@example.com')
+
+
+class TestDeleteUserEvent(TestCase):
+    def setUp(self):
+        self.user = user_factory(fxa_id='ABCDEF012345689')
+
+    def _fire_event(self):
+        delete_user_event(
+            'ABCDEF012345689',
             totimestamp(datetime(2017, 10, 11)))
+        self.user.reload()
+        assert self.user.email is None
+        assert self.user.deleted
+        assert self.user.fxa_id is None
+
+    @mock.patch('olympia.users.models.UserProfile.delete_picture')
+    def test_success_basic(self, delete_picture_mock):
+        collection = collection_factory(author=self.user)
+        another_addon = addon_factory()
+        Rating.objects.create(addon=another_addon, user=self.user, rating=5)
+        assert list(another_addon.ratings.all().values('rating', 'user')) == [{
+            'user': self.user.id, 'rating': 5}]
+        self._fire_event()
+        assert not Collection.objects.filter(id=collection.id).exists()
+        assert not another_addon.ratings.all().exists()
+        delete_picture_mock.assert_called()
+
+    def test_success_addons(self):
+        addon = addon_factory(users=[self.user])
+        self._fire_event()
+        addon.reload()
+        assert addon.status == amo.STATUS_DELETED
+
+    def test_success_addons_other_owners(self):
+        other_owner = user_factory()
+        addon = addon_factory(users=[self.user, other_owner])
+        self._fire_event()
+        addon.reload()
+        assert addon.status != amo.STATUS_DELETED
+        assert list(addon.authors.all()) == [other_owner]

--- a/src/olympia/accounts/tests/test_tasks.py
+++ b/src/olympia/accounts/tests/test_tasks.py
@@ -12,12 +12,13 @@ from olympia.ratings.models import Rating
 
 
 class TestPrimaryEmailChangeEvent(TestCase):
+    fxa_id = 'ABCDEF012345689'
 
     def test_success(self):
         user = user_factory(email='old-email@example.com',
-                            fxa_id='ABCDEF012345689')
+                            fxa_id=self.fxa_id)
         primary_email_change_event(
-            'ABCDEF012345689',
+            self.fxa_id,
             totimestamp(datetime(2017, 10, 11)),
             'new-email@example.com')
         user.reload()
@@ -26,25 +27,25 @@ class TestPrimaryEmailChangeEvent(TestCase):
 
     def test_ignored_because_old_timestamp(self):
         user = user_factory(email='old-email@example.com',
-                            fxa_id='ABCDEF012345689')
+                            fxa_id=self.fxa_id)
         yesterday = datetime(2017, 10, 1)
         today = datetime(2017, 10, 2)
         tomorrow = datetime(2017, 10, 3)
 
         primary_email_change_event(
-            'ABCDEF012345689',
+            self.fxa_id,
             totimestamp(today),
             'today@example.com')
         assert user.reload().email == 'today@example.com'
 
         primary_email_change_event(
-            'ABCDEF012345689',
+            self.fxa_id,
             totimestamp(tomorrow),
             'tomorrow@example.com')
         assert user.reload().email == 'tomorrow@example.com'
 
         primary_email_change_event(
-            'ABCDEF012345689',
+            self.fxa_id,
             totimestamp(yesterday),
             'yesterday@example.com')
         assert user.reload().email != 'yesterday@example.com'
@@ -53,18 +54,20 @@ class TestPrimaryEmailChangeEvent(TestCase):
     def test_ignored_if_user_not_found(self):
         """Check that this doesn't throw"""
         primary_email_change_event(
-            'ABCDEF012345689',
+            self.fxa_id,
             totimestamp(datetime(2017, 10, 11)),
             'email@example.com')
 
 
 class TestDeleteUserEvent(TestCase):
+    fxa_id = 'ABCDEF012345689'
+
     def setUp(self):
-        self.user = user_factory(fxa_id='ABCDEF012345689')
+        self.user = user_factory(fxa_id=self.fxa_id)
 
     def _fire_event(self):
         delete_user_event(
-            'ABCDEF012345689',
+            self.fxa_id,
             totimestamp(datetime(2017, 10, 11)))
         self.user.reload()
         assert self.user.email is None

--- a/src/olympia/accounts/tests/test_utils.py
+++ b/src/olympia/accounts/tests/test_utils.py
@@ -12,6 +12,8 @@ from django.test import RequestFactory
 from django.test.utils import override_settings
 from django.utils.encoding import force_bytes, force_text
 
+from waffle.testutils import override_switch
+
 from olympia.accounts import utils
 from olympia.accounts.utils import process_fxa_event
 from olympia.amo.tests import TestCase, user_factory
@@ -212,12 +214,31 @@ class TestProcessSqsQueue(TestCase):
             QueueUrl='https://sqs.nowh-ere.aws.com/123456789/',
             ReceiptHandle='$$$')
 
+    @mock.patch('olympia.accounts.utils.primary_email_change_event.delay')
+    @mock.patch('olympia.accounts.utils.delete_user_event.delay')
+    def test_malformed_body_doesnt_throw(self, email_mock, delete_mock):
+        process_fxa_event('')
+        process_fxa_event(json.dumps({'Message': ''}))
+        process_fxa_event(json.dumps({'Message': 'ddfdfd'}))
+        # No timestamps
+        process_fxa_event(json.dumps({'Message': json.dumps(
+            {'email': 'foo@baa', 'event': 'primaryEmailChanged',
+             'uid': '999'})}))
+        process_fxa_event(json.dumps({'Message': json.dumps(
+            {'event': 'delete', 'uid': '999'})}))
+        # Not a supported event type
+        process_fxa_event(json.dumps({'Message': json.dumps(
+            {'email': 'foo@baa', 'event': 'not-an-event', 'uid': '999',
+             'ts': totimestamp(datetime.now())})}))
+        delete_mock.assert_not_called()
+        email_mock.assert_not_called()
+
 
 def totimestamp(datetime_obj):
     return time.mktime(datetime_obj.timetuple())
 
 
-class TestProcessFxAEvent(TestCase):
+class TestProcessFxAEventEmail(TestCase):
     def setUp(self):
         self.email_changed_date = self.days_ago(42)
         self.body = json.dumps({'Message': json.dumps(
@@ -247,20 +268,39 @@ class TestProcessFxAEvent(TestCase):
         process_fxa_event(self.body)
         primary_email_change_event.assert_called()
         primary_email_change_event.assert_called_with(
-            'new-email@example.com', 'ABCDEF012345689',
+            'ABCDEF012345689',
+            totimestamp(self.email_changed_date),
+            'new-email@example.com')
+
+
+class TestProcessFxAEventDelete(TestCase):
+    def setUp(self):
+        self.email_changed_date = self.days_ago(42)
+        self.body = json.dumps({'Message': json.dumps(
+            {'event': 'delete',
+             'uid': 'ABCDEF012345689',
+             'ts': totimestamp(self.email_changed_date)})})
+
+    @override_switch('fxa-account-delete', active=True)
+    def test_success_integration(self):
+        user = user_factory(fxa_id='ABCDEF012345689')
+        process_fxa_event(self.body)
+        user.reload()
+        assert user.email is None
+        assert user.deleted
+        assert user.fxa_id is None
+
+    @override_switch('fxa-account-delete', active=True)
+    @mock.patch('olympia.accounts.utils.delete_user_event.delay')
+    def test_success(self, delete_user_event_mock):
+        process_fxa_event(self.body)
+        delete_user_event_mock.assert_called()
+        delete_user_event_mock.assert_called_with(
+            'ABCDEF012345689',
             totimestamp(self.email_changed_date))
 
-    @mock.patch('olympia.accounts.utils.primary_email_change_event.delay')
-    def test_malformed_body_doesnt_throw(self, primary_email_change_event):
-        process_fxa_event('')
-        process_fxa_event(json.dumps({'Message': ''}))
-        process_fxa_event(json.dumps({'Message': 'ddfdfd'}))
-        # No timestamp
-        process_fxa_event(json.dumps({'Message': json.dumps(
-            {'email': 'foo@baa', 'event': 'primaryEmailChanged',
-             'uid': '999'})}))
-        # Not a supported event type
-        process_fxa_event(json.dumps({'Message': json.dumps(
-            {'email': 'foo@baa', 'event': 'not-an-event', 'uid': '999',
-             'ts': totimestamp(datetime.now())})}))
-        primary_email_change_event.assert_not_called()
+    @override_switch('fxa-account-delete', active=False)
+    @mock.patch('olympia.accounts.utils.delete_user_event.delay')
+    def test_waffle_off(self, delete_user_event_mock):
+        process_fxa_event(self.body)
+        delete_user_event_mock.assert_not_called()

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1240,6 +1240,7 @@ CELERY_TASK_ROUTES = {
     'olympia.accounts.tasks.primary_email_change_event': {'queue': 'users'},
     'olympia.users.tasks.delete_photo': {'queue': 'users'},
     'olympia.users.tasks.update_user_ratings_task': {'queue': 'users'},
+    'olympia.accounts.tasks.delete_user_event': {'queue': 'users'},
 
     # Zadmin
     'olympia.scanners.tasks.run_yara_query_rule': {'queue': 'zadmin'},


### PR DESCRIPTION
fixes #13896 apart from:
- adding the post-delete data scrubbing after x years (split out to #14494 
- reconciling the differences with AMO (frontend via the API) triggered deletes (will be split out when jorge confirms)

The code is behind a waffle switch until FxA have made the changes on their end.