### PR TITLE
Cache bust stats session cache

### DIFF
--- a/src/olympia/stats/templates/stats/stats.html
+++ b/src/olympia/stats/templates/stats/stats.html
@@ -143,7 +143,8 @@
     data-start_date="{{ view.start }}"
     data-end_date="{{ view.end }}"
     {% endif %}
-    data-base_url="{{ stats_base_url }}">
+    data-base_url="{{ stats_base_url }}"
+    data-is-beta="{{ beta }}">
     <div class="island chart">
       <div id="head-chart">
       </div>

--- a/static/js/impala/stats/manager.js
+++ b/static/js/impala/stats/manager.js
@@ -14,7 +14,7 @@ z.StatsManager = (function() {
     // strictly the same and the cache might contain mixed data so we
     // cache-bust the (session) cache when users switch between the two stats
     // features.
-    var isBeta = $primary.attr("data-is-beta") === 'True';
+    var isBeta = $primary.data("is-beta") === 'True';
     if (isBeta) {
         STATS_VERSION += '-beta';
     }
@@ -24,8 +24,8 @@ z.StatsManager = (function() {
         dataStore       = {},
         currentView     = {},
         siteEvents      = [],
-        addonId         = parseInt($primary.attr("data-addon_id"), 10),
-        baseURL         = $primary.attr("data-base_url"),
+        addonId         = parseInt($primary.data("addon_id"), 10),
+        baseURL         = $primary.data("base_url"),
         pendingFetches  = 0,
         siteEventsEnabled = true,
         writeInterval   = false,

--- a/static/js/impala/stats/manager.js
+++ b/static/js/impala/stats/manager.js
@@ -8,13 +8,24 @@ z.StatsManager = (function() {
     var STATS_VERSION = '2011-12-12';
     var PRECISION = 2;
 
+    var $primary = $(".primary");
+
+    // Users can navigate between "old" and "beta" stats pages. Data isn't
+    // strictly the same and the cache might contain mixed data so we
+    // cache-bust the (session) cache when users switch between the two stats
+    // features.
+    var isBeta = $primary.attr("data-is-beta") === 'True';
+    if (isBeta) {
+        STATS_VERSION += '-beta';
+    }
+
     var storage         = z.Storage("stats"),
         storageCache    = z.SessionStorage("statscache"),
         dataStore       = {},
         currentView     = {},
         siteEvents      = [],
-        addonId         = parseInt($(".primary").attr("data-addon_id"), 10),
-        baseURL         = $(".primary").attr("data-base_url"),
+        addonId         = parseInt($primary.attr("data-addon_id"), 10),
+        baseURL         = $primary.attr("data-base_url"),
         pendingFetches  = 0,
         siteEventsEnabled = true,
         writeInterval   = false,


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/14430

---

Note: this is a patch I'd like to cherry-pick because users might want to look at the diff between old and beta stats and the cache might show mixed data.