### PR TITLE
Show in reviewer tools when versions are scheduled for rejection

### DIFF
--- a/src/olympia/amo/templatetags/jinja_helpers.py
+++ b/src/olympia/amo/templatetags/jinja_helpers.py
@@ -245,6 +245,11 @@ def timesince(time):
     return ugettext(u'{0} ago').format(ago)
 
 
+@library.filter
+def timeuntil(time):
+    return defaultfilters.timeuntil(time)
+
+
 @library.global_function
 @library.render_with('amo/recaptcha.html')
 @jinja2.contextfunction

--- a/src/olympia/amo/tests/test_helpers.py
+++ b/src/olympia/amo/tests/test_helpers.py
@@ -378,6 +378,13 @@ def test_timesince():
     assert jinja_helpers.timesince(None) == u''
 
 
+def test_timeuntil():
+    a_month_in_the_future = datetime.now() + timedelta(days=31)
+    assert jinja_helpers.timeuntil(a_month_in_the_future) == '1 month'
+    a_week_in_the_future = datetime.now() + timedelta(days=14, hours=1)
+    assert jinja_helpers.timeuntil(a_week_in_the_future) == '2 weeks'
+
+
 def test_format_unicode():
     # This makes sure there's no UnicodeEncodeError when doing the string
     # interpolation.

--- a/src/olympia/reviewers/templates/reviewers/includes/paginator_history.html
+++ b/src/olympia/reviewers/templates/reviewers/includes/paginator_history.html
@@ -28,6 +28,9 @@
     {% endfor %}
   </ol>
   {% if versions_flagged_by_scanners %}
-    <strong class="risk-high">{{ _('{num} versions flagged by scanners on other pages.')|format_html(num=versions_flagged_by_scanners) }}</strong>
+    <strong class="other-needs-human-review risk-high">{{ _('{num} versions flagged by scanners on other pages.')|format_html(num=versions_flagged_by_scanners) }}</strong>
+  {% endif %}
+  {% if versions_pending_rejection %}
+    <strong class="other-pending-rejection risk-high">{{ _('{num} versions pending rejection on other pages.')|format_html(num=versions_pending_rejection) }}</strong>
   {% endif %}
 {% endif %}

--- a/src/olympia/reviewers/templates/reviewers/includes/version.html
+++ b/src/olympia/reviewers/templates/reviewers/includes/version.html
@@ -8,6 +8,10 @@
     <span class="light">{{ _("(Confirmed)") }}</span>
     {% endif %}
 
+    {% if version.pending_rejection %}
+    <span class="pending-rejection" title="{{ version.pending_rejection|datetime }}">&middot; {{ _("Scheduled for rejection in {0} "|format_html(version.pending_rejection|timeuntil)) }}</span>
+    {% endif %}
+
     {% if addon.block and addon.block.is_version_blocked(version.version) %}
     <span class="blocked-version">Blocked</span>
     {% endif %}

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -697,6 +697,13 @@ class Version(OnChangeMixin, ModelBase):
         block = self.addon.block
         return bool(block and block.is_version_blocked(self.version))
 
+    @property
+    def pending_rejection(self):
+        try:
+            return self.versionreviewerflags.pending_rejection
+        except VersionReviewerFlags.DoesNotExist:
+            return None
+
 
 class VersionReviewerFlags(ModelBase):
     version = models.OneToOneField(


### PR DESCRIPTION
Also prevent regular reviewers from reviewing add-ons when there are versions pending rejection, unless a new version has been posted since.

Fixes #14578