### PR TITLE
add ko-fi.com to contribution domains

### DIFF
--- a/src/olympia/constants/base.py
+++ b/src/olympia/constants/base.py
@@ -207,6 +207,7 @@ VALID_CONTRIBUTION_DOMAINS = (
     'buymeacoffee.com',
     'donate.mozilla.org',
     'flattr.com',
+    'ko-fi.com',
     'liberapay.com',
     'micropayment.de',
     'opencollective.com',


### PR DESCRIPTION
Fixes #14551

This PR adds ko-fi.com in VALID_CONTRIBUTION_DOMAINS.

* [x] This PR relates to an existing open issue and there are no existing
      PRs open for the same issue.
* [x] Add `Fixes #ISSUENUM` at the top of your PR.
* [x] Add a description of the changes introduced in this PR.
* [x] The change has been successfully run locally.
