### PR TITLE
Use download stats for updating `addon.average_daily_users` for dictionaries and langpacks

### DIFF
--- a/src/olympia/addons/cron.py
+++ b/src/olympia/addons/cron.py
@@ -38,7 +38,18 @@ def update_addon_average_daily_users():
 
     kwargs = {'id_field': 'pk'}
     if waffle.switch_is_active('use-bigquery-for-addon-adu'):
-        d = get_addons_and_average_daily_users_from_bigquery()
+        # BigQuery does not have data for add-ons with type other than those in
+        # `ADDON_TYPES_WITH_STATS` so we use download counts instead.
+        # See: https://github.com/mozilla/addons-server/issues/14609
+        d = list(
+            Addon.objects
+            .exclude(type__in=amo.ADDON_TYPES_WITH_STATS)
+            .annotate(count=Sum('downloadcount__count'))
+            .values_list('guid', 'count')
+            .order_by('guid')
+            .all()
+        )
+        d += get_addons_and_average_daily_users_from_bigquery()
         # BigQuery stores GUIDs, not AMO primary keys.
         kwargs['id_field'] = 'guid'
     else:

--- a/src/olympia/addons/tests/test_cron.py
+++ b/src/olympia/addons/tests/test_cron.py
@@ -312,12 +312,35 @@ class TestAvgDailyUserCountTestCase(TestCase):
         addon.update(average_daily_users=0)
         count = 56789
         get_mock.return_value = [(addon.guid, count)]
+        # We use download counts for langpacks.
+        langpack = addon_factory(type=amo.ADDON_LPAPP, average_daily_users=0)
+        langpack_count = 12345
+        DownloadCount.objects.update_or_create(
+            addon=langpack,
+            date=datetime.date.today(),
+            defaults={'count': langpack_count}
+        )
+        # We use download counts for dictionaries.
+        dictionary = addon_factory(type=amo.ADDON_DICT, average_daily_users=0)
+        dictionary_count = 5567
+        DownloadCount.objects.update_or_create(
+            addon=dictionary,
+            date=datetime.date.today(),
+            defaults={'count': dictionary_count}
+        )
+        assert addon.average_daily_users == 0
+        assert langpack.average_daily_users == 0
+        assert dictionary.average_daily_users == 0
 
         cron.update_addon_average_daily_users()
         addon.refresh_from_db()
+        langpack.refresh_from_db()
+        dictionary.refresh_from_db()
 
         get_mock.assert_called
         assert addon.average_daily_users == count
+        assert langpack.average_daily_users == langpack_count
+        assert dictionary.average_daily_users == dictionary_count
 
     def test_adu_flag(self):
         addon = Addon.objects.get(pk=3615)


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/14609