### PR TITLE
Provide a validation.json url via the reviewers app

### DIFF
--- a/src/olympia/devhub/tests/test_views_validation.py
+++ b/src/olympia/devhub/tests/test_views_validation.py
@@ -2,7 +2,6 @@
 import json
 
 from django.core.files.storage import default_storage as storage
-from django.test.utils import override_settings
 
 from unittest import mock
 import waffle
@@ -243,16 +242,6 @@ class TestFileValidation(TestCase):
         assert msg['description'][0] == '&lt;iframe&gt;'
         assert msg['context'] == (
             [u'<em:description>...', u'<foo/>'])
-
-    def test_cors_headers_are_sent(self):
-        code_manager_url = 'https://my-code-manager-url.example.org'
-        with override_settings(CODE_MANAGER_URL=code_manager_url):
-            response = self.client.get(self.json_url)
-
-        assert response['Access-Control-Allow-Origin'] == code_manager_url
-        assert response['Access-Control-Allow-Methods'] == 'GET, OPTIONS'
-        assert response['Access-Control-Allow-Headers'] == 'Content-Type'
-        assert response['Access-Control-Allow-Credentials'] == 'true'
 
     def test_linkify_validation_messages(self):
         self.file_validation.update(validation=json.dumps({

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -687,16 +687,10 @@ def json_file_validation(request, addon_id, addon, file_id):
         result = file.validation
     except File.validation.RelatedObjectDoesNotExist:
         raise http.Http404
-    response = JsonResponse({
+    return JsonResponse({
         'validation': result.processed_validation,
         'error': None,
     })
-    # See: https://github.com/mozilla/addons-server/issues/11048
-    response['Access-Control-Allow-Origin'] = settings.CODE_MANAGER_URL
-    response['Access-Control-Allow-Methods'] = 'GET, OPTIONS'
-    response['Access-Control-Allow-Headers'] = 'Content-Type'
-    response['Access-Control-Allow-Credentials'] = 'true'
-    return response
 
 
 @json_view

--- a/src/olympia/reviewers/serializers.py
+++ b/src/olympia/reviewers/serializers.py
@@ -411,7 +411,7 @@ class AddonBrowseVersionSerializer(
                 ) if key in entry}
 
     def get_validation_url_json(self, obj):
-        return absolutify(reverse('devhub.json_file_validation', args=[
+        return absolutify(reverse('reviewers.json_file_validation', args=[
             obj.addon.pk, obj.current_file.id
         ]))
 

--- a/src/olympia/reviewers/tests/test_serializers.py
+++ b/src/olympia/reviewers/tests/test_serializers.py
@@ -420,7 +420,7 @@ class TestAddonBrowseVersionSerializer(TestCase):
 
         # Custom fields
         validation_url_json = absolutify(reverse(
-            'devhub.json_file_validation', args=[
+            'reviewers.json_file_validation', args=[
                 self.addon.pk, self.version.current_file.id]))
         validation_url = absolutify(reverse('devhub.file_validation', args=[
             self.addon.pk, self.version.current_file.id]))

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -7938,3 +7938,49 @@ class TestMadQueue(QueueTest):
 
         self._test_queue_layout('Flagged for Human Review', tab_position=2,
                                 total_addons=3, total_queues=4, per_page=1)
+
+
+class TestValidationJson(TestCase):
+    fixtures = ['base/users', 'devhub/addon-validation-1']
+
+    def setUp(self):
+        super(TestValidationJson, self).setUp()
+        assert self.client.login(email='del@icio.us')
+        self.user = UserProfile.objects.get(email='del@icio.us')
+        self.file_validation = FileValidation.objects.get(pk=1)
+        self.file = self.file_validation.file
+        self.addon = self.file.version.addon
+        args = [self.addon.pk, self.file.id]
+        self.url = reverse('reviewers.json_file_validation', args=args)
+
+    def test_non_reviewer_cannot_see_json_results(self):
+        self.client.logout()
+        assert self.client.login(email='regular@mozilla.com')
+        assert self.client.head(self.url, follow=False).status_code == 403
+
+    def test_reviewer_can_see_json_results(self):
+        self.client.logout()
+        assert self.client.login(email='reviewer@mozilla.com')
+        assert self.client.head(self.url, follow=False).status_code == 200
+
+    def test_cors_headers_are_sent(self):
+        self.client.logout()
+        assert self.client.login(email='reviewer@mozilla.com')
+        code_manager_url = 'https://my-code-manager-url.example.org'
+        with override_settings(CODE_MANAGER_URL=code_manager_url):
+            response = self.client.get(self.url)
+
+        assert response['Access-Control-Allow-Origin'] == code_manager_url
+        assert response['Access-Control-Allow-Methods'] == 'GET, OPTIONS'
+        assert response['Access-Control-Allow-Headers'] == 'Content-Type'
+        assert response['Access-Control-Allow-Credentials'] == 'true'
+
+    def test_deleted_addon(self):
+        self.client.logout()
+        assert self.client.login(email='reviewer@mozilla.com')
+        self.grant_permission(
+            UserProfile.objects.get(email='reviewer@mozilla.com'),
+            'Addons:ReviewUnlisted')
+
+        self.addon.delete()
+        assert self.client.head(self.url, follow=False).status_code == 200

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -7951,7 +7951,7 @@ class TestValidationJson(TestCase):
         self.file_validation = FileValidation.objects.get(pk=1)
         self.file = self.file_validation.file
         self.addon = self.file.version.addon
-        args = [self.addon.slug, self.file.id]
+        args = [self.addon.pk, self.file.id]
         self.url = reverse('reviewers.json_file_validation', args=args)
 
     def test_reviewer_can_see_json_results(self):
@@ -7979,10 +7979,7 @@ class TestValidationJson(TestCase):
             'Addons:ReviewUnlisted')
 
         self.addon.delete()
-        # Must use pk for a deleted add-on as it has no slug.
-        args = [self.addon.pk, self.file.id]
-        url = reverse('reviewers.json_file_validation', args=args)
-        assert self.client.head(url, follow=False).status_code == 200
+        assert self.client.head(self.url, follow=False).status_code == 200
 
     def test_non_reviewer_cannot_see_json_results(self):
         self.client.logout()
@@ -7999,4 +7996,4 @@ class TestValidationJson(TestCase):
         self.client.logout()
         assert self.client.login(email='reviewer@mozilla.com')
         self.make_addon_unlisted(self.addon)
-        assert self.client.head(self.url, follow=False).status_code == 404
+        assert self.client.head(self.url, follow=False).status_code == 403

--- a/src/olympia/reviewers/urls.py
+++ b/src/olympia/reviewers/urls.py
@@ -68,4 +68,7 @@ urlpatterns = (
     url(r'^download-git-file/(?P<version_id>\d+)/(?P<filename>.*)/',
         views.download_git_stored_file,
         name='reviewers.download_git_file'),
+    url(r'^addon/%s/file/(?P<file_id>[^/]+)/validation\.json$' % ADDON_ID,
+        views.json_file_validation,
+        name='reviewers.json_file_validation'),
 )

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -1156,8 +1156,10 @@ def theme_background_images(request, version_id):
 
 
 @any_reviewer_required
-def json_file_validation(request, addon_id, file_id):
-    addon = get_object_or_404(Addon.unfiltered.id_or_slug(addon_id))
+@reviewer_addon_view_factory
+def json_file_validation(request, addon, file_id):
+    if not acl.is_reviewer(request, addon):
+        raise PermissionDenied
     file = get_object_or_404(File, version__addon=addon, id=file_id)
     try:
         result = file.validation

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -1156,11 +1156,14 @@ def theme_background_images(request, version_id):
 
 
 @any_reviewer_required
-@reviewer_addon_view_factory
-def json_file_validation(request, addon, file_id):
-    if not acl.is_reviewer(request, addon):
-        raise PermissionDenied
+def json_file_validation(request, addon_id, file_id):
+    addon = get_object_or_404(Addon.unfiltered.id_or_slug(addon_id))
     file = get_object_or_404(File, version__addon=addon, id=file_id)
+    if file.version.channel == amo.RELEASE_CHANNEL_UNLISTED:
+        if not acl.check_unlisted_addons_reviewer(request):
+            raise PermissionDenied
+    elif not acl.is_reviewer(request, addon):
+        raise PermissionDenied
     try:
         result = file.validation
     except File.validation.RelatedObjectDoesNotExist:


### PR DESCRIPTION
Fixes #14655 

Note that this also removes support for the CORS headers from the `devhub.json_file_validation` view as that was only needed for code manager, and now this view is no longer used by code manager. Perhaps we should also back out the changes from https://github.com/mozilla/addons-server/commit/9e421a5c5927b8ca2de8eccb3cba60b74f779adb which allowed for access to validation.json for deleted add-ons? My understanding is that that was also only needed for code manager, so perhaps those changes should be undone for the `devhub` view?