### PR TITLE
Change text_ratings_count back to total_ratings

### DIFF
--- a/src/olympia/ratings/templates/ratings/impala/reviews_link.html
+++ b/src/olympia/ratings/templates/ratings/impala/reviews_link.html
@@ -4,7 +4,7 @@
 {% endif %}
 
 <span class="rating">
-  {% with num=addon.text_ratings_count %}
+  {% with num=addon.total_ratings %}
     {% if num %}
       {{ addon.average_rating|float|stars }}
       <a href="{{ base|absolutify }}">({{ num|numberfmt }})</a>

--- a/src/olympia/ratings/templates/ratings/reviews_link.html
+++ b/src/olympia/ratings/templates/ratings/reviews_link.html
@@ -4,7 +4,7 @@
 {% endif %}
 
 <p class="addon-rating">
-  {% with num=addon.text_ratings_count %}
+  {% with num=addon.total_ratings %}
     {% if num %}
     {{ addon.average_rating|float|stars }}
     <a href="{{ base|absolutify }}">

--- a/src/olympia/ratings/tests/test_helpers.py
+++ b/src/olympia/ratings/tests/test_helpers.py
@@ -35,7 +35,7 @@ class HelpersTest(TestCase):
 
     def test_reviews_link(self):
         addon = addon_factory(
-            average_rating=4, text_ratings_count=37, id=1, slug='xx')
+            average_rating=4, total_ratings=37, id=1, slug='xx')
         content = self.render(
             '{{ reviews_link(myaddon) }}', {'myaddon': addon})
         assert pq(content)('strong').text() == '37 reviews'
@@ -66,7 +66,7 @@ class HelpersTest(TestCase):
 
     def test_impala_reviews_link(self):
         addon = addon_factory(
-            average_rating=4, text_ratings_count=37, id=1, slug='xx')
+            average_rating=4, total_ratings=37, id=1, slug='xx')
         content = self.render(
             '{{ impala_reviews_link(myaddon) }}', {'myaddon': addon})
         assert pq(content)('a').text() == '(37)'


### PR DESCRIPTION
Fixes #7540 
This changes PR #12411 and changes `text_ratings_count` back to `total-ratings`.

* [x] This PR relates to an existing open issue and there are no existing
      PRs open for the same issue.
* [x] Add `Fixes #ISSUENUM` at the top of your PR.
* [x] Add a description of the changes introduced in this PR.
