### PR TITLE
RE: Add code to resize and otherwise adjust images uploaded via the admin 

### DIFF
--- a/src/olympia/discovery/tests/test_admin.py
+++ b/src/olympia/discovery/tests/test_admin.py
@@ -656,7 +656,7 @@ class TestPrimaryHeroImageAdmin(TestCase):
         response = self.client.get(add_url, follow=True)
         assert response.status_code == 200
         assert PrimaryHeroImage.objects.count() == 0
-        photo = get_uploaded_file('transparent.png')
+        photo = get_uploaded_file('preview_4x3.jpg')
         response = self.client.post(
             add_url,
             dict(custom_image=photo),
@@ -664,17 +664,17 @@ class TestPrimaryHeroImageAdmin(TestCase):
         assert response.status_code == 200
         assert PrimaryHeroImage.objects.count() == 1
         item = PrimaryHeroImage.objects.get()
-        assert item.custom_image == 'hero-featured-image/transparent.png'
+        assert item.custom_image == 'hero-featured-image/preview_4x3.jpg'
         assert os.path.exists(os.path.join(
-            settings.MEDIA_ROOT, 'hero-featured-image', 'transparent.png'))
+            settings.MEDIA_ROOT, 'hero-featured-image', 'preview_4x3.jpg'))
         assert os.path.exists(os.path.join(
             settings.MEDIA_ROOT, 'hero-featured-image',
-            'thumbs', 'transparent.png'))
+            'thumbs', 'preview_4x3.jpg'))
         width, height = get_image_dimensions(os.path.join(
-            settings.MEDIA_ROOT, 'hero-featured-image', 'transparent.png'))
+            settings.MEDIA_ROOT, 'hero-featured-image', 'preview_4x3.jpg'))
         t_width, t_height = get_image_dimensions(os.path.join(
             settings.MEDIA_ROOT, 'hero-featured-image',
-            'thumbs', 'transparent.png'))
+            'thumbs', 'preview_4x3.jpg'))
         assert width <= 960 and height <= 640
         assert t_width <= 150 and t_height <= 120
 

--- a/src/olympia/hero/admin.py
+++ b/src/olympia/hero/admin.py
@@ -13,7 +13,7 @@ class ImageChoiceField(forms.ModelChoiceField):
     def label_from_instance(self, obj):
         return mark_safe(
             '<img class="select-image-preview" src="{}" />'.format(
-                obj.custom_image.url))
+                obj.preview_url))
 
 
 class PrimaryHeroInline(admin.StackedInline):

--- a/src/olympia/hero/models.py
+++ b/src/olympia/hero/models.py
@@ -8,7 +8,6 @@ from django.forms.widgets import RadioSelect
 from django.utils.safestring import mark_safe
 
 from olympia.amo.models import LongNameIndex, ModelBase
-from olympia.amo.utils import resize_image
 from olympia.discovery.models import DiscoveryItem
 
 
@@ -101,8 +100,7 @@ class PrimaryHeroImage(ModelBase):
 
     @property
     def preview_url(self):
-        (path, fn) = os.path.split(self.custom_image.path)
-        fn = fn.decode('utf-8')
+        fn = os.path.basename(self.custom_image.path).decode('utf-8')
         return f'{HERO_PREVIEW_URL}{fn}'
 
     def preview_image(self):
@@ -114,17 +112,6 @@ class PrimaryHeroImage(ModelBase):
             return None
     preview_image.short_description = "Image"
     preview_image.allow_tags = True
-
-    def save(self, *args, **kwargs):
-        super().save(*args, **kwargs)
-        (path, fn) = os.path.split(self.custom_image.path)
-        dest_thumb = path + b'/thumbs/' + fn
-
-        size_full = (960, 640)
-        size_thumb = (150, 120)
-
-        resize_image(self.custom_image, self.custom_image.path, size_full)
-        resize_image(self.custom_image, dest_thumb, size_thumb)
 
 
 class PrimaryHero(ModelBase):

--- a/src/olympia/hero/models.py
+++ b/src/olympia/hero/models.py
@@ -28,6 +28,7 @@ MODULE_ICON_PATH = os.path.join(
     settings.ROOT, 'static', 'img', 'hero', 'icons')
 FEATURED_IMAGE_URL = f'{settings.STATIC_URL}img/hero/featured/'
 MODULE_ICON_URL = f'{settings.STATIC_URL}img/hero/icons/'
+HERO_PREVIEW_URL = f'{settings.MEDIA_URL}hero-featured-image/thumbs/'
 
 
 class GradientChoiceWidget(RadioSelect):
@@ -98,10 +99,16 @@ class PrimaryHeroImage(ModelBase):
     def __str__(self):
         return f'{self.custom_image}'
 
+    @property
+    def preview_url(self):
+        (path, fn) = os.path.split(self.custom_image.path)
+        fn = fn.decode('utf-8')
+        return f'{HERO_PREVIEW_URL}{fn}'
+
     def preview_image(self):
         if self.custom_image:
             return mark_safe('<img class="prmhero-preview" src="{}" />'.format(
-                self.custom_image.url)
+                self.preview_url)
             )
         else:
             return None

--- a/src/olympia/hero/models.py
+++ b/src/olympia/hero/models.py
@@ -8,6 +8,7 @@ from django.forms.widgets import RadioSelect
 from django.utils.safestring import mark_safe
 
 from olympia.amo.models import LongNameIndex, ModelBase
+from olympia.amo.utils import resize_image
 from olympia.discovery.models import DiscoveryItem
 
 
@@ -106,6 +107,17 @@ class PrimaryHeroImage(ModelBase):
             return None
     preview_image.short_description = "Image"
     preview_image.allow_tags = True
+
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+        (path, fn) = os.path.split(self.custom_image.path)
+        dest_thumb = path + b'/thumbs/' + fn
+
+        size_full = (960, 640)
+        size_thumb = (150, 120)
+
+        resize_image(self.custom_image, self.custom_image.path, size_full)
+        resize_image(self.custom_image, dest_thumb, size_thumb)
 
 
 class PrimaryHero(ModelBase):


### PR DESCRIPTION
Fixes #14475 

The following changes have been made with this pull request:
- Images uploaded to Primary Hero Images are resized upon saving to two dimensions: 960x640 and 150x120
- Images displayed in Primary Hero Images are thumbnails of the primary hero images
- Within Discovery Items, the primary hero images displayed are the thumbnails as well
- `/discovery/tests/test_admin.py` has been revised to check that the primary hero images exist in two sizes, as well as checks their dimensions