### PR TITLE
Revert "Update dependency uglify-js to v3.10.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "less": "3.11.3",
     "source-map": "0.7.3",
     "timeago": "1.6.7",
-    "uglify-js": "3.10.0",
+    "uglify-js": "3.9.4",
     "underscore": "1.10.2"
   },
   "devDependencies": {}


### PR DESCRIPTION
Reverts mozilla/addons-server#14690

Fixes https://github.com/mozilla/addons-server/issues/14726

We need to investigate why this didn't break our tests, but locally I see this with 3.10.0:
```
Minifying /code/src/olympia/../../static/js/preload-all.js (using UglifyJS)
uglify-js 3.10.0
```

And this results in `preload-min.js` being missing. Same for every other js file. Where as with 3.9.4:
```
Minifying /code/src/olympia/../../static/js/preload-all.js (using UglifyJS)
```

And the `-min.js` file is present.