### PR TITLE
Disable renovate for Python

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,9 @@
       "rangeStrategy": "replace"
     }
   ],
+  "python": {
+    "enabled": false
+  },
   "pip_requirements": {
     "fileMatch": [
       "^requirements/.*\\.txt$"


### PR DESCRIPTION
Fixes #14778 

I decided to leave the `pip_requirements` in there in case we ever decide we want to use Renovate for Python again. Simply adding the `"python": { "enabled": false }` is supposed to be enough to disable Python support.