### PR TITLE
Upgrade UglifyJS to 3.10.0, fixing compatibility with that version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "less": "3.11.3",
     "source-map": "0.7.3",
     "timeago": "1.6.7",
-    "uglify-js": "3.9.4",
+    "uglify-js": "3.10.0",
     "underscore": "1.10.2"
   },
   "devDependencies": {}

--- a/src/olympia/amo/management/commands/compress_assets.py
+++ b/src/olympia/amo/management/commands/compress_assets.py
@@ -198,7 +198,7 @@ class Command(BaseCommand):
         """Run the proper minifier on the file."""
         if ftype == 'js' and hasattr(settings, 'UGLIFY_BIN'):
             opts = {'method': 'UglifyJS', 'bin': settings.UGLIFY_BIN}
-            run_command('{uglify} -v -o {target} {source} -m'.format(
+            run_command('{uglify} -o {target} {source} -m'.format(
                 uglify=opts['bin'],
                 target=file_out,
                 source=file_in))


### PR DESCRIPTION
Also added a test proving we do compress js files correctly.

Fixes #14779