### PR TITLE
RE: Delete PrimaryHeroImages files when instance is deleted 

### DIFF
--- a/src/olympia/discovery/tests/test_admin.py
+++ b/src/olympia/discovery/tests/test_admin.py
@@ -3,6 +3,7 @@ from pyquery import PyQuery as pq
 
 import os
 
+from olympia.amo.storage_utils import copy_stored_file
 from olympia.amo.tests import TestCase, addon_factory, user_factory
 from olympia.amo.tests.test_helpers import get_uploaded_file
 from olympia.amo.urlresolvers import django_reverse, reverse
@@ -629,6 +630,12 @@ class TestPrimaryHeroImageAdmin(TestCase):
     def test_can_delete_with_discovery_edit_permission(self):
         uploaded_photo = get_uploaded_file('transparent.png')
         item = PrimaryHeroImage.objects.create(custom_image=uploaded_photo)
+        src = os.path.join(
+            settings.MEDIA_ROOT, 'hero-featured-image', 'transparent.png')
+        dest = os.path.join(
+            settings.MEDIA_ROOT, 'hero-featured-image', 'thumbs',
+            'transparent.png')
+        copy_stored_file(src, dest)
         delete_url = reverse(
             'admin:discovery_primaryheroimageupload_delete', args=(item.pk,)
         )
@@ -640,12 +647,22 @@ class TestPrimaryHeroImageAdmin(TestCase):
         response = self.client.get(delete_url, follow=True)
         assert response.status_code == 200
         assert PrimaryHeroImage.objects.filter(pk=item.pk).exists()
+        assert os.path.exists(os.path.join(
+            settings.MEDIA_ROOT, 'hero-featured-image', 'transparent.png'))
+        assert os.path.exists(os.path.join(
+            settings.MEDIA_ROOT, 'hero-featured-image', 'thumbs',
+            'transparent.png'))
 
         # And can actually delete.
         response = self.client.post(
             delete_url, data={'post': 'yes'}, follow=True)
         assert response.status_code == 200
         assert not PrimaryHeroImage.objects.filter(pk=item.pk).exists()
+        assert not os.path.exists(os.path.join(
+            settings.MEDIA_ROOT, 'hero-featured-image', 'transparent.png'))
+        assert not os.path.exists(os.path.join(
+            settings.MEDIA_ROOT, 'hero-featured-image',
+            'thumbs', 'transparent.png'))
 
     def test_can_add_with_discovery_edit_permission(self):
         add_url = reverse('admin:discovery_primaryheroimageupload_add')
@@ -718,6 +735,12 @@ class TestPrimaryHeroImageAdmin(TestCase):
     def test_can_not_delete_without_discovery_edit_permission(self):
         uploaded_photo = get_uploaded_file('transparent.png')
         item = PrimaryHeroImage.objects.create(custom_image=uploaded_photo)
+        src = os.path.join(
+            settings.MEDIA_ROOT, 'hero-featured-image', 'transparent.png')
+        dest = os.path.join(
+            settings.MEDIA_ROOT, 'hero-featured-image', 'thumbs',
+            'transparent.png')
+        copy_stored_file(src, dest)
         delete_url = reverse(
             'admin:discovery_primaryheroimageupload_delete', args=(item.pk,)
         )
@@ -728,12 +751,22 @@ class TestPrimaryHeroImageAdmin(TestCase):
         response = self.client.get(delete_url, follow=True)
         assert response.status_code == 403
         assert PrimaryHeroImage.objects.filter(pk=item.pk).exists()
+        assert os.path.exists(os.path.join(
+            settings.MEDIA_ROOT, 'hero-featured-image', 'transparent.png'))
+        assert os.path.exists(os.path.join(
+            settings.MEDIA_ROOT, 'hero-featured-image', 'thumbs',
+            'transparent.png'))
 
         # Can not actually delete either.
         response = self.client.post(
             delete_url, data={'post': 'yes'}, follow=True)
         assert response.status_code == 403
         assert PrimaryHeroImage.objects.filter(pk=item.pk).exists()
+        assert os.path.exists(os.path.join(
+            settings.MEDIA_ROOT, 'hero-featured-image', 'transparent.png'))
+        assert os.path.exists(os.path.join(
+            settings.MEDIA_ROOT, 'hero-featured-image',
+            'thumbs', 'transparent.png'))
 
 
 class TestSecondaryHeroShelfAdmin(TestCase):

--- a/src/olympia/hero/admin.py
+++ b/src/olympia/hero/admin.py
@@ -67,13 +67,14 @@ class PrimaryHeroImageAdmin(admin.ModelAdmin):
 
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)
-        (path, fn) = os.path.split(obj.custom_image.path)
-        dest_thumb = path + b'/thumbs/' + fn
 
         size_thumb = (150, 120)
         size_full = (960, 640)
 
-        resize_image(obj.custom_image.path, dest_thumb, size_thumb)
+        with tempfile.NamedTemporaryFile(dir=settings.TMP_PATH) as tmp:
+            resize_image(obj.custom_image.path, tmp.name, size_thumb)
+            copy_stored_file(tmp.name, obj.thumbnail_path)
+
         with tempfile.NamedTemporaryFile(dir=settings.TMP_PATH) as tmp:
             resize_image(obj.custom_image.path, tmp.name, size_full)
             copy_stored_file(tmp.name, obj.custom_image.path)

--- a/src/olympia/hero/admin.py
+++ b/src/olympia/hero/admin.py
@@ -78,6 +78,10 @@ class PrimaryHeroImageAdmin(admin.ModelAdmin):
             resize_image(obj.custom_image.path, tmp.name, size_full)
             copy_stored_file(tmp.name, obj.custom_image.path)
 
+    def delete_queryset(self, request, queryset):
+        for obj in queryset:
+            obj.delete()
+
 
 class HeroModuleInlineFormSet(BaseInlineFormSet):
     def clean(self):

--- a/src/olympia/hero/admin.py
+++ b/src/olympia/hero/admin.py
@@ -1,4 +1,3 @@
-import os
 import tempfile
 
 from django import forms

--- a/src/olympia/hero/models.py
+++ b/src/olympia/hero/models.py
@@ -113,6 +113,14 @@ class PrimaryHeroImage(ModelBase):
     preview_image.short_description = "Image"
     preview_image.allow_tags = True
 
+    def delete(self, *args, **kwargs):
+        (path, fn) = os.path.split(self.custom_image.path)
+        dest_thumb = path + b'/thumbs/' + fn
+
+        os.remove(dest_thumb)
+        os.remove(self.custom_image.path)
+        super().delete(*args, **kwargs)
+
 
 class PrimaryHero(ModelBase):
     select_image = models.ForeignKey(


### PR DESCRIPTION
Fixes #14729 

The following updates have been made with this pull request:
- Image files are deleted upon deleting PrimaryHeroImage instance
- `discovery/tests/test_admin.py` has been updated

I had tried to place what's in `models.py` in `admin.py` (changing `self` to `obj`, etc) and experimented with `delete_model` as well. However, I'd either (1) get an error (`'basequeryset' has not attribute custom_image`) and the files would not delete while all tests in `test_admin`would pass, or (2) the images would get deleted upon deleting the instance, but the tests would fail. 🤨 Please review when you have a moment. Thanks!