### PR TITLE
Exclude null GUIDs in get_addons_and_average_daily_users_from_bigquery()

### DIFF
--- a/src/olympia/stats/tests/test_utils.py
+++ b/src/olympia/stats/tests/test_utils.py
@@ -242,6 +242,7 @@ GROUP BY addon_id"""
         results = [
             self.create_bigquery_row({'addon_id': 1, 'count': 123}),
             self.create_bigquery_row({'addon_id': 2, 'count': None}),
+            self.create_bigquery_row({'addon_id': None, 'count': 456}),
         ]
         client = self.create_mock_client(results=results)
         bigquery_client_mock.from_service_account_json.return_value = client

--- a/src/olympia/stats/utils.py
+++ b/src/olympia/stats/utils.py
@@ -107,4 +107,7 @@ GROUP BY addon_id"""
 
     rows = client.query(query).result()
 
-    return [(row['addon_id'], row['count']) for row in rows if row['count']]
+    return [
+        (row['addon_id'], row['count'])
+        for row in rows if row['addon_id'] and row['count']
+    ]


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/14853