### PR TITLE
Revert "Re-enable z.* loggers (#14519)"

### DIFF
--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1362,14 +1362,6 @@ LOGGING = {
             'level': logging.WARNING,
             'propagate': False
         },
-        'z': {
-            'handlers': ['mozlog'],
-            'level': logging.INFO,
-            # We need to set `propagate` to `True` so that `z.*` loggers are
-            # able to log messages. That wouldn't work otherwise, likely
-            # because `disable_existing_loggers` is set to `False` now.
-            'propagate': True
-        },
         'z.celery': {
             'handlers': ['statsd'],
             'level': logging.ERROR,


### PR DESCRIPTION
This reverts commit f3806fcee27a4889df6064b2361a2467f8a57d00, which should fix https://github.com/mozilla/addons-server/issues/14712 hopefully. Locally, I can see logs in the log file as well as in the django toolbar (for view context).