### PR TITLE
Use the git shortref as tag for Docker images.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ commands:
           name: Build docker image and push to repo
           command: |
             docker version
-            docker build -t app:build -f << parameters.dockerfile >> .
+            docker build -t app:build -f << parameters.dockerfile >> --label git.commit="$CIRCLE_SHA1" .
             docker tag app:build "${DOCKERHUB_REPO}":<< parameters.image_tag >>
             docker login -u "${DOCKERHUB_USER}" -p "${DOCKERHUB_PASS}"
             docker push "${DOCKERHUB_REPO}":<< parameters.image_tag >>


### PR DESCRIPTION
When pushing the `latest` tag to Docker Hub, this change will tag the same image with an abbreviated version of the git SHA1 hash that triggered the build. We can use this tag in Jenkins to trigger the actual build, so the Slack messages contain the git commit hash that was deployed.

This is one step towards implementing https://bugzilla.mozilla.org/show_bug.cgi?id=1411598.