### PR TITLE
Update reference to code of conduct file in repository

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 .. image:: https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg
-    :target: https://github.com/mozilla/addons-server/blob/master/CODE_OF_CONDUCT.md
+    :target: https://github.com/mozilla/addons-server/blob/master/.github/CODE_OF_CONDUCT.md
     :alt: Code of conduct
 
 .. image:: https://travis-ci.org/mozilla/addons-server.svg?branch=master


### PR DESCRIPTION
- Fixes #14666 
- Updated the reference to the code of conduct file in the repository (tested via clicking on the linking and ensuring the code of contributing section rendered without error)