### PR TITLE
Rewrite deliver_hotness() cron task

### DIFF
--- a/src/olympia/addons/cron.py
+++ b/src/olympia/addons/cron.py
@@ -192,7 +192,6 @@ def deliver_hotness(chunk_size=300):
         Addon.objects.filter(status__in=amo.REVIEWED_STATUSES)
         .filter(hotness__gt=0)
         .exclude(guid__in=averages.keys())
-        .no_transforms()
         .values_list('id', flat=True)
     )
     create_chunked_tasks_signatures(

--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -310,3 +310,12 @@ def update_addon_hotness(averages):
         else:
             if addon.hotness != 0:
                 addon.update(hotness=0)
+
+@task
+@use_primary_db
+def reset_addon_hotness(addon_ids):
+    log.info("[%s] Resetting add-ons hotness scores.", (len(addon_ids)))
+    addons = Addon.objects.filter(id__in=addon_ids).all().no_transforms()
+
+    for addon in addons:
+        addon.update(hotness=0)

--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -281,3 +281,32 @@ def delete_addons(addon_ids, with_deleted=False, **kw):
     else:
         for addon in addons:
             addon.delete(send_delete_email=False)
+
+
+@task
+@use_primary_db
+def update_addon_hotness(averages, frozen_ids):
+    log.info("[%s] Updating add-ons hotness scores.", (len(averages)))
+
+    addons = (
+        Addon.objects.filter(guid__in=averages.keys())
+        .filter(status__in=amo.REVIEWED_STATUSES)
+        .exclude(id__in=frozen_ids)
+        .no_transforms()
+    )
+
+    for addon in addons:
+        average = averages.get(addon.guid)
+        this = average['avg_this_week']
+        three = average['avg_three_weeks_before']
+
+        # Update the hotness score but only update hotness if necessary. We
+        # don't want to cause unnecessary re-indexes.
+        threshold = 250 if addon.type == amo.ADDON_STATICTHEME else 1000
+        if this > threshold and three > 1:
+            hotness = (this - three) / float(three)
+            if addon.hotness != hotness:
+                addon.update(hotness=hotness)
+        else:
+            if addon.hotness != 0:
+                addon.update(hotness=0)

--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -311,6 +311,7 @@ def update_addon_hotness(averages):
             if addon.hotness != 0:
                 addon.update(hotness=0)
 
+
 @task
 @use_primary_db
 def reset_addon_hotness(addon_ids):

--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -285,13 +285,13 @@ def delete_addons(addon_ids, with_deleted=False, **kw):
 
 @task
 @use_primary_db
-def update_addon_hotness(averages, frozen_ids):
+def update_addon_hotness(averages):
     log.info("[%s] Updating add-ons hotness scores.", (len(averages)))
 
+    averages = dict(averages)
     addons = (
         Addon.objects.filter(guid__in=averages.keys())
         .filter(status__in=amo.REVIEWED_STATUSES)
-        .exclude(id__in=frozen_ids)
         .no_transforms()
     )
 

--- a/src/olympia/addons/tests/test_cron.py
+++ b/src/olympia/addons/tests/test_cron.py
@@ -434,7 +434,6 @@ class TestDeliverHotness(TestCase):
 
         FrozenAddon.objects.create(addon=self.frozen_extension)
 
-    @mock.patch('olympia.addons.cron.time.sleep', lambda *a, **kw: None)
     @mock.patch('olympia.addons.cron.get_averages_by_addon_from_bigquery')
     def test_basic(self, get_averages_mock):
         get_averages_mock.return_value = {
@@ -497,7 +496,6 @@ class TestDeliverHotness(TestCase):
         # Exclude frozen add-ons too.
         assert self.frozen_extension.reload().hotness == 0
 
-    @mock.patch('olympia.addons.cron.time.sleep', lambda *a, **kw: None)
     @mock.patch('olympia.addons.cron.group')
     @mock.patch('olympia.addons.cron.get_averages_by_addon_from_bigquery')
     def test_chunks(self, get_averages_mock, group_mock):

--- a/src/olympia/addons/tests/test_cron.py
+++ b/src/olympia/addons/tests/test_cron.py
@@ -10,7 +10,6 @@ from unittest import mock
 from olympia import amo
 from olympia.addons import cron
 from olympia.addons.models import Addon, AppSupport, FrozenAddon
-from olympia.addons.tasks import update_addon_hotness
 from olympia.amo.tests import addon_factory, file_factory, TestCase
 from olympia.files.models import File
 from olympia.stats.models import DownloadCount
@@ -430,9 +429,11 @@ class TestDeliverHotness(TestCase):
         self.unpopular_theme = addon_factory(type=amo.ADDON_STATICTHEME)
         self.barely_popular_theme = addon_factory(type=amo.ADDON_STATICTHEME)
         self.awaiting_review = addon_factory(status=amo.STATUS_NOMINATED)
-        self.frozen_extension = addon_factory()
 
+        self.frozen_extension = addon_factory()
         FrozenAddon.objects.create(addon=self.frozen_extension)
+
+        self.not_in_bigquery = addon_factory(hotness=123)
 
     @mock.patch('olympia.addons.cron.get_averages_by_addon_from_bigquery')
     def test_basic(self, get_averages_mock):
@@ -469,10 +470,6 @@ class TestDeliverHotness(TestCase):
                 'avg_this_week': 827080,
                 'avg_three_weeks_before': 787930,
             },
-            self.frozen_extension.guid: {
-                'avg_this_week': 827080,
-                'avg_three_weeks_before': 787930,
-            },
         }
 
         cron.deliver_hotness()
@@ -495,47 +492,8 @@ class TestDeliverHotness(TestCase):
 
         # Exclude frozen add-ons too.
         assert self.frozen_extension.reload().hotness == 0
-
-    @mock.patch('olympia.addons.cron.group')
-    @mock.patch('olympia.addons.cron.get_averages_by_addon_from_bigquery')
-    def test_chunks(self, get_averages_mock, group_mock):
-        get_averages_mock.return_value = {
-            'guid-1': {'avg_this_week': 1, 'avg_three_weeks_before': 4561},
-            'guid-2': {'avg_this_week': 2, 'avg_three_weeks_before': 4562},
-            'guid-3': {'avg_this_week': 3, 'avg_three_weeks_before': 4563},
-            'guid-4': {'avg_this_week': 4, 'avg_three_weeks_before': 4564},
-        }
-        frozen_ids = [self.frozen_extension.id]
-
-        cron.deliver_hotness(chunk_size=2)
-
-        group_mock.assert_called_with(
-            [
-                update_addon_hotness.si(
-                    averages={
-                        'guid-1': {
-                            'avg_this_week': 1,
-                            'avg_three_weeks_before': 4561,
-                        },
-                        'guid-2': {
-                            'avg_this_week': 2,
-                            'avg_three_weeks_before': 4562,
-                        },
-                    },
-                    frozen_ids=frozen_ids,
-                ),
-                update_addon_hotness.si(
-                    averages={
-                        'guid-3': {
-                            'avg_this_week': 3,
-                            'avg_three_weeks_before': 4563,
-                        },
-                        'guid-4': {
-                            'avg_this_week': 4,
-                            'avg_three_weeks_before': 4564,
-                        },
-                    },
-                    frozen_ids=frozen_ids,
-                ),
-            ]
+        get_averages_mock.assert_called_once_with(
+            today=mock.ANY, exclude=[self.frozen_extension.guid]
         )
+
+        assert self.not_in_bigquery.reload().hotness == 0

--- a/src/olympia/addons/tests/test_tasks.py
+++ b/src/olympia/addons/tests/test_tasks.py
@@ -8,7 +8,7 @@ from waffle.testutils import override_switch
 from olympia import amo
 from olympia.addons.tasks import (recreate_theme_previews,
                                   update_addon_average_daily_users,
-                                  update_addon_hotness)
+                                  update_addon_hotness, reset_addon_hotness)
 from olympia.amo.storage_utils import copy_stored_file
 from olympia.amo.tests import addon_factory
 from olympia.versions.models import VersionPreview
@@ -130,3 +130,16 @@ def test_update_addon_hotness():
     assert addon2.hotness == 0
     # We shouldn't have processed this add-on.
     assert addon3.hotness == 123
+
+
+@pytest.mark.django_db
+def test_reset_addon_hotness():
+    addon1 = addon_factory(hotness=1)
+    addon2 = addon_factory(hotness=2)
+
+    reset_addon_hotness(addon_ids=[addon1.id, addon2.id])
+    addon1.refresh_from_db()
+    addon2.refresh_from_db()
+
+    assert addon1.hotness == 0
+    assert addon2.hotness == 0

--- a/src/olympia/addons/tests/test_tasks.py
+++ b/src/olympia/addons/tests/test_tasks.py
@@ -7,7 +7,8 @@ from waffle.testutils import override_switch
 
 from olympia import amo
 from olympia.addons.tasks import (recreate_theme_previews,
-                                  update_addon_average_daily_users)
+                                  update_addon_average_daily_users,
+                                  update_addon_hotness)
 from olympia.amo.storage_utils import copy_stored_file
 from olympia.amo.tests import addon_factory
 from olympia.versions.models import VersionPreview
@@ -95,3 +96,46 @@ def test_update_addon_average_daily_users():
     addon.refresh_from_db()
 
     assert addon.average_daily_users == count
+
+
+@pytest.mark.django_db
+def test_update_addon_hotness():
+    addon1 = addon_factory(hotness=0, status=amo.STATUS_APPROVED)
+    addon2 = addon_factory(hotness=123,
+                           status=amo.STATUS_APPROVED)
+    addon3 = addon_factory(hotness=123,
+                           status=amo.STATUS_APPROVED)
+    addon4 = addon_factory(hotness=123,
+                           status=amo.STATUS_AWAITING_REVIEW)
+    averages = {
+        addon1.guid: {
+            'avg_this_week': 213467,
+            'avg_three_weeks_before': 123467
+        },
+        addon2.guid: {
+            'avg_this_week': 1,
+            'avg_three_weeks_before': 1,
+        },
+        addon3.guid: {
+            'avg_this_week': 213467,
+            'avg_three_weeks_before': 123467
+        },
+        addon4.guid: {
+            'avg_this_week': 213467,
+            'avg_three_weeks_before': 123467
+        },
+    }
+    frozen_ids = [addon3.id]
+
+    update_addon_hotness(averages, frozen_ids=frozen_ids)
+    addon1.refresh_from_db()
+    addon2.refresh_from_db()
+    addon3.refresh_from_db()
+    addon4.refresh_from_db()
+
+    assert addon1.hotness > 0
+    # Too low averages so we set the hotness to 0.
+    assert addon2.hotness == 0
+    # We shouldn't have processed these add-ons.
+    assert addon3.hotness == 123
+    assert addon4.hotness == 123

--- a/src/olympia/addons/tests/test_tasks.py
+++ b/src/olympia/addons/tests/test_tasks.py
@@ -104,8 +104,6 @@ def test_update_addon_hotness():
     addon2 = addon_factory(hotness=123,
                            status=amo.STATUS_APPROVED)
     addon3 = addon_factory(hotness=123,
-                           status=amo.STATUS_APPROVED)
-    addon4 = addon_factory(hotness=123,
                            status=amo.STATUS_AWAITING_REVIEW)
     averages = {
         addon1.guid: {
@@ -120,22 +118,15 @@ def test_update_addon_hotness():
             'avg_this_week': 213467,
             'avg_three_weeks_before': 123467
         },
-        addon4.guid: {
-            'avg_this_week': 213467,
-            'avg_three_weeks_before': 123467
-        },
     }
-    frozen_ids = [addon3.id]
 
-    update_addon_hotness(averages, frozen_ids=frozen_ids)
+    update_addon_hotness(averages=averages.items())
     addon1.refresh_from_db()
     addon2.refresh_from_db()
     addon3.refresh_from_db()
-    addon4.refresh_from_db()
 
     assert addon1.hotness > 0
     # Too low averages so we set the hotness to 0.
     assert addon2.hotness == 0
-    # We shouldn't have processed these add-ons.
+    # We shouldn't have processed this add-on.
     assert addon3.hotness == 123
-    assert addon4.hotness == 123

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1191,6 +1191,7 @@ CELERY_TASK_ROUTES = {
     'olympia.addons.tasks.recreate_theme_previews': {'queue': 'addons'},
 
     # Crons
+    'olympia.addons.tasks.reset_addon_hotness': {'queue': 'cron'},
     'olympia.addons.tasks.update_addon_average_daily_users': {'queue': 'cron'},
     'olympia.addons.tasks.update_addon_download_totals': {'queue': 'cron'},
     'olympia.addons.tasks.update_addon_hotness': {'queue': 'cron'},

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1193,6 +1193,7 @@ CELERY_TASK_ROUTES = {
     # Crons
     'olympia.addons.tasks.update_addon_average_daily_users': {'queue': 'cron'},
     'olympia.addons.tasks.update_addon_download_totals': {'queue': 'cron'},
+    'olympia.addons.tasks.update_addon_hotness': {'queue': 'cron'},
     'olympia.addons.tasks.update_appsupport': {'queue': 'cron'},
 
     # Bandwagon


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/14900

---

This patch updates the `deliver_hotness()` cron task to be asynchronous by
creating a Celery task for up to 300 add-ons.

I tried locally with 500K GUIDs in the `averages` dict and it does not eat a
lot memory and the command returns after a 20 seconds. We have to create small
dicts for each task because we cannot use `chunked` on a `dict`.