### PR TITLE
update UserProfile.modified on ban (& expose modified in /admin)

### DIFF
--- a/src/olympia/users/admin.py
+++ b/src/olympia/users/admin.py
@@ -47,7 +47,7 @@ class UserAdmin(CommaSearchInAdminMixin, admin.ModelAdmin):
     inlines = (GroupUserInline, )
     show_full_result_count = False  # Turn off to avoid the query.
 
-    readonly_fields = ('id', 'created', 'picture_img',
+    readonly_fields = ('id', 'created', 'modified', 'picture_img',
                        'banned', 'deleted', 'is_public',
                        'last_login', 'last_login_ip', 'known_ip_adresses',
                        'last_known_activity_time', 'ratings_created',
@@ -58,8 +58,8 @@ class UserAdmin(CommaSearchInAdminMixin, admin.ModelAdmin):
                        'restriction_history_for_this_user')
     fieldsets = (
         (None, {
-            'fields': ('id', 'created', 'email', 'fxa_id', 'username',
-                       'display_name',
+            'fields': ('id', 'created', 'modified', 'email', 'fxa_id',
+                       'username', 'display_name',
                        'reviewer_name', 'biography', 'homepage', 'location',
                        'occupation', 'picture_img'),
         }),

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -521,11 +521,12 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
             log.info(
                 f'User ({user}: <{user.email}>) is being '
                 'anonymized and banned.')
-            user.banned = datetime.now()
+            user.banned = user.modified = datetime.now()
             user.deleted = True
         cls.anonymize_users(users)
         cls.objects.bulk_update(
-            users, fields=('banned', 'deleted') + cls.ANONYMIZED_FIELDS)
+            users,
+            fields=('banned', 'deleted', 'modified') + cls.ANONYMIZED_FIELDS)
 
     def _prepare_delete_email(self):
         site_url = settings.EXTERNAL_SITE_URL

--- a/src/olympia/users/tests/test_models.py
+++ b/src/olympia/users/tests/test_models.py
@@ -135,6 +135,7 @@ class TestUserProfile(TestCase):
         assert email.to == [user.email]
         assert f'message because your user account {name}' in email.body
         assert email.reply_to == ['amo-admins+deleted@mozilla.com']
+        self.assertCloseToNow(user.modified)
 
     @mock.patch.object(File, 'hide_disabled_file')
     def test_ban_and_disable_related_content_bulk(self, hide_disabled_mock):
@@ -182,12 +183,14 @@ class TestUserProfile(TestCase):
 
         assert user_sole.deleted
         self.assertCloseToNow(user_sole.banned)
+        self.assertCloseToNow(user_sole.modified)
         assert user_sole.email == 'sole@foo.baa'
         assert user_sole.auth_id
         assert user_sole.fxa_id == '13579'
         assert user_sole.last_login_ip == '127.0.0.1'
         assert user_multi.deleted
         self.assertCloseToNow(user_multi.banned)
+        self.assertCloseToNow(user_multi.modified)
         assert user_multi.email == 'multi@foo.baa'
         assert user_multi.auth_id
         assert user_multi.fxa_id == '24680'


### PR DESCRIPTION
fixes #14870 (deletes already updated `.modifed`, but added an assert to prove it)