### PR TITLE
Update valid system addon guid list and add new guid variations to tests

### DIFF
--- a/src/olympia/constants/base.py
+++ b/src/olympia/constants/base.py
@@ -392,7 +392,8 @@ SYSTEM_ADDON_GUIDS = (
     '@mozilla.org',
     '@pioneer.mozilla.org',
     '@search.mozilla.org',
-    '@shield.mozilla.org'
+    '@shield.mozilla.org',
+    '@mozillaonline.com'
 )
 
 MOZILLA_TRADEMARK_SYMBOLS = (

--- a/src/olympia/constants/blocklist.py
+++ b/src/olympia/constants/blocklist.py
@@ -1,5 +1,5 @@
 # How many guids should there be in the stashes before we make a new base.
-BASE_REPLACE_THRESHOLD = 6_000
+BASE_REPLACE_THRESHOLD = 5_000
 
 # Config keys used to track recent mlbf ids
 MLBF_TIME_CONFIG_KEY = 'blocklist_mlbf_generation_time'

--- a/src/olympia/constants/blocklist.py
+++ b/src/olympia/constants/blocklist.py
@@ -1,5 +1,5 @@
 # How many guids should there be in the stashes before we make a new base.
-BASE_REPLACE_THRESHOLD = 5_000
+BASE_REPLACE_THRESHOLD = 6_000
 
 # Config keys used to track recent mlbf ids
 MLBF_TIME_CONFIG_KEY = 'blocklist_mlbf_generation_time'

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -1404,7 +1404,7 @@ class TestUploadDetail(BaseUploadTest):
              'message': 'You cannot submit an add-on using an ID ending with '
                         '"@mozilla.com" or "@mozilla.org" or '
                         '"@pioneer.mozilla.org" or "@search.mozilla.org" or '
-                        '"@shield.mozilla.org"',
+                        '"@shield.mozilla.org" or "@mozillaonline.com"',
              'fatal': True, 'type': 'error'}]
 
     @mock.patch('olympia.devhub.tasks.run_addons_linter')

--- a/src/olympia/signing/tests/test_views.py
+++ b/src/olympia/signing/tests/test_views.py
@@ -329,7 +329,7 @@ class TestUploadVersion(BaseUploadVersionTestMixin, TestCase):
         assert response.data['error'] == (
             'You cannot submit an add-on using an ID ending with '
             '"@mozilla.com" or "@mozilla.org" or "@pioneer.mozilla.org" or '
-            '"@search.mozilla.org" or "@shield.mozilla.org"')
+            '"@search.mozilla.org" or "@shield.mozilla.org" or "@mozillaonline.com"')
 
     def test_system_addon_update_allowed(self):
         """Updates to system addons are allowed from anyone."""

--- a/src/olympia/signing/tests/test_views.py
+++ b/src/olympia/signing/tests/test_views.py
@@ -329,7 +329,8 @@ class TestUploadVersion(BaseUploadVersionTestMixin, TestCase):
         assert response.data['error'] == (
             'You cannot submit an add-on using an ID ending with '
             '"@mozilla.com" or "@mozilla.org" or "@pioneer.mozilla.org" or '
-            '"@search.mozilla.org" or "@shield.mozilla.org" or "@mozillaonline.com"')
+            '"@search.mozilla.org" or "@shield.mozilla.org" or '
+            '"@mozillaonline.com"')
 
     def test_system_addon_update_allowed(self):
         """Updates to system addons are allowed from anyone."""

--- a/src/olympia/users/tests/test_user_utils.py
+++ b/src/olympia/users/tests/test_user_utils.py
@@ -23,7 +23,7 @@ def test_email_unsubscribe_code_parse():
 system_guids = pytest.mark.parametrize('guid', [
     'foø@mozilla.org', 'baa@shield.mozilla.org', 'moo@pioneer.mozilla.org',
     'blâh@mozilla.com', 'foø@Mozilla.Org', 'baa@ShielD.MozillA.OrG',
-    'moo@PIONEER.mozilla.org', 'blâh@MOZILLA.COM', 'flop@search.mozilla.org'
+    'moo@PIONEER.mozilla.org', 'blâh@MOZILLA.COM', 'flop@search.mozilla.org',
     'user@mozillaonline.com', 'tester@MoZiLlAoNlInE.CoM'
 ])
 

--- a/src/olympia/users/tests/test_user_utils.py
+++ b/src/olympia/users/tests/test_user_utils.py
@@ -23,7 +23,8 @@ def test_email_unsubscribe_code_parse():
 system_guids = pytest.mark.parametrize('guid', [
     'foø@mozilla.org', 'baa@shield.mozilla.org', 'moo@pioneer.mozilla.org',
     'blâh@mozilla.com', 'foø@Mozilla.Org', 'baa@ShielD.MozillA.OrG',
-    'moo@PIONEER.mozilla.org', 'blâh@MOZILLA.COM', 'flop@search.mozilla.org',
+    'moo@PIONEER.mozilla.org', 'blâh@MOZILLA.COM', 'flop@search.mozilla.org'
+    'user@mozillaonline.com', 'tester@MoZiLlAoNlInE.CoM'
 ])
 
 


### PR DESCRIPTION
- Fixes #14916 
- Updated valid system guides to include `@mozillaonline.com`
- Updated unit tests to include variations of `@mozillaonline.com`
- Tested by building docker image locally and running `make test` and checking the Travis CI build results

