### PR TITLE
ensure soft-deleted AddonUser instances are filtered out

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -810,7 +810,7 @@ class Addon(OnChangeMixin, ModelBase):
 
     @cached_property
     def listed_authors(self):
-        return UserProfile.objects.filter(
+        return self.authors.filter(
             addons=self,
             addonuser__listed=True).order_by('addonuser__position')
 
@@ -1108,7 +1108,9 @@ class Addon(OnChangeMixin, ModelBase):
             addon_dict = {addon.id: addon for addon in addons}
 
         qs = (UserProfile.objects
-              .filter(addons__in=addons, addonuser__listed=True)
+              .filter(addons__in=addons,
+                      addonuser__listed=True)
+              .exclude(addonuser__role=amo.AUTHOR_ROLE_DELETED)
               .extra(select={'addon_id': 'addons_users.addon_id',
                              'position': 'addons_users.position'}))
         qs = sorted(qs, key=lambda u: (u.addon_id, u.position))

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -450,6 +450,10 @@ class TestAddonModels(TestCase):
         new_author = AddonUser.objects.create(
             addon_id=3615, user=UserProfile.objects.create(username='abda'),
             listed=True).user
+        # Deleted, so shouldn't show up below.
+        AddonUser.objects.create(
+            addon_id=3615, user=user_factory(),
+            listed=True, role=amo.AUTHOR_ROLE_DELETED).user
 
         addon = Addon.objects.get(pk=3615)
 

--- a/src/olympia/devhub/feeds.py
+++ b/src/olympia/devhub/feeds.py
@@ -8,7 +8,6 @@ from django.utils.translation import ugettext
 
 from olympia import amo
 from olympia.activity.models import ActivityLog
-from olympia.addons.models import Addon
 from olympia.amo.templatetags.jinja_helpers import absolutify, url
 from olympia.devhub.models import RssKey
 from olympia.translations.templatetags.jinja_helpers import clean as clean_html
@@ -31,7 +30,7 @@ class ActivityFeedRSS(Feed):
         if key.addon:
             addons = key.addon
         else:  # We are showing all the add-ons
-            addons = Addon.objects.filter(authors=key.user)
+            addons = key.user.addons.all()
 
         return (ActivityLog.objects.for_addons(addons)
                            .exclude(action__in=amo.LOG_HIDE_DEVELOPER))[:20]

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -57,6 +57,11 @@ class HubTest(TestCase):
         assert self.client.login(email='regular@mozilla.com')
         assert self.client.get(self.url).status_code == 200
         self.user_profile = UserProfile.objects.get(id=999)
+        not_their_addon = addon_factory(users=[user_factory()])
+        AddonUser.unfiltered.create(
+            addon=not_their_addon,
+            user=self.user_profile,
+            role=amo.AUTHOR_ROLE_DELETED)
 
     def clone_addon(self, num, addon_id=3615):
         addons = []


### PR DESCRIPTION
follow-up fix #14681 - I missed some places where we directly filtered on Addon/UserProfile directly.