### PR TITLE
Add retry strategy in call_mad_api()

### DIFF
--- a/src/olympia/scanners/tasks.py
+++ b/src/olympia/scanners/tasks.py
@@ -448,7 +448,8 @@ def call_mad_api(all_results, upload_pk):
                         status_forcelist=[500, 502, 503, 504],
                     )
                 )
-                http.mount(settings.MAD_API_URL, adapter)
+                http.mount("http://", adapter)
+                http.mount("https://", adapter)
 
                 json_payload = {
                     'scanners': {'customs': customs_results.results}


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/14934

---

[We can't use responses to test the retry strategy](https://github.com/getsentry/responses/issues/135) unfortunartely, so there is no new test case. I tried locally, though.