### PR TITLE
RE: Store uploaded hero images as JPGs 

### DIFF
--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -624,7 +624,7 @@ def pngcrush_image(src, **kw):
     return False
 
 
-def resize_image(source, destination, size=None):
+def resize_image(source, destination, size=None, hero_image=False):
     """Resizes and image from src, to dst.
     Returns a tuple of new width and height, original width and height.
 
@@ -641,11 +641,17 @@ def resize_image(source, destination, size=None):
         original_size = im.size
         if size:
             im = processors.scale_and_crop(im, size)
-    with storage.open(destination, 'wb') as fp:
-        # Save the image to PNG in destination file path. Don't keep the ICC
-        # profile as it can mess up pngcrush badly (mozilla/addons/issues/697).
-        im.save(fp, 'png', icc_profile=None)
-    pngcrush_image(destination)
+    if hero_image:
+        with storage.open(destination, 'wb') as fp:
+            im = im.convert('RGB')
+            im.save(fp, 'JPEG')
+    else:
+        with storage.open(destination, 'wb') as fp:
+            # Save the image to PNG in destination file path.
+            # Don't keep the ICC profile as it can mess up pngcrush badly
+            # (mozilla/addons/issues/697).
+            im.save(fp, 'png', icc_profile=None)
+        pngcrush_image(destination)
     return (im.size, original_size)
 
 

--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -624,7 +624,7 @@ def pngcrush_image(src, **kw):
     return False
 
 
-def resize_image(source, destination, size=None, hero_image=False):
+def resize_image(source, destination, size=None, format='png'):
     """Resizes and image from src, to dst.
     Returns a tuple of new width and height, original width and height.
 
@@ -641,7 +641,7 @@ def resize_image(source, destination, size=None, hero_image=False):
         original_size = im.size
         if size:
             im = processors.scale_and_crop(im, size)
-    if hero_image:
+    if not format:
         with storage.open(destination, 'wb') as fp:
             im = im.convert('RGB')
             im.save(fp, 'JPEG')

--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -641,17 +641,17 @@ def resize_image(source, destination, size=None, format='png'):
         original_size = im.size
         if size:
             im = processors.scale_and_crop(im, size)
-    if not format:
-        with storage.open(destination, 'wb') as fp:
-            im = im.convert('RGB')
-            im.save(fp, 'JPEG')
-    else:
+    if format == 'png':
         with storage.open(destination, 'wb') as fp:
             # Save the image to PNG in destination file path.
             # Don't keep the ICC profile as it can mess up pngcrush badly
             # (mozilla/addons/issues/697).
             im.save(fp, 'png', icc_profile=None)
         pngcrush_image(destination)
+    else:
+        with storage.open(destination, 'wb') as fp:
+            im = im.convert('RGB')
+            im.save(fp, 'JPEG', quality=80)
     return (im.size, original_size)
 
 

--- a/src/olympia/discovery/tests/test_admin.py
+++ b/src/olympia/discovery/tests/test_admin.py
@@ -588,7 +588,7 @@ class TestPrimaryHeroImageAdmin(TestCase):
         self.client.login(email=user.email)
         response = self.client.get(self.list_url, follow=True)
         assert response.status_code == 200
-        assert 'transparent.png' in response.content.decode('utf-8')
+        assert 'transparent.jpg' in response.content.decode('utf-8')
 
     def test_can_edit_with_discovery_edit_permission(self):
         uploaded_photo = get_uploaded_file('transparent.png')
@@ -603,7 +603,7 @@ class TestPrimaryHeroImageAdmin(TestCase):
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 200
         content = response.content.decode('utf-8')
-        assert u'transparent.png' in content
+        assert u'transparent.jpg' in content
 
         updated_photo = get_uploaded_file('preview_4x3.jpg')
         response = self.client.post(
@@ -613,17 +613,17 @@ class TestPrimaryHeroImageAdmin(TestCase):
         assert response.status_code == 200
         item.reload()
         assert PrimaryHeroImage.objects.count() == 1
-        assert item.custom_image == 'hero-featured-image/preview_4x3.png'
+        assert item.custom_image == 'hero-featured-image/preview_4x3.jpg'
         assert os.path.exists(os.path.join(
-            settings.MEDIA_ROOT, 'hero-featured-image', 'preview_4x3.png'))
+            settings.MEDIA_ROOT, 'hero-featured-image', 'preview_4x3.jpg'))
         assert os.path.exists(os.path.join(
             settings.MEDIA_ROOT, 'hero-featured-image',
-            'thumbs', 'preview_4x3.png'))
+            'thumbs', 'preview_4x3.jpg'))
         width, height = get_image_dimensions(os.path.join(
-            settings.MEDIA_ROOT, 'hero-featured-image', 'preview_4x3.png'))
+            settings.MEDIA_ROOT, 'hero-featured-image', 'preview_4x3.jpg'))
         t_width, t_height = get_image_dimensions(os.path.join(
             settings.MEDIA_ROOT, 'hero-featured-image',
-            'thumbs', 'preview_4x3.png'))
+            'thumbs', 'preview_4x3.jpg'))
         assert width <= 960 and height <= 640
         assert t_width <= 150 and t_height <= 120
 
@@ -631,10 +631,10 @@ class TestPrimaryHeroImageAdmin(TestCase):
         uploaded_photo = get_uploaded_file('transparent.png')
         item = PrimaryHeroImage.objects.create(custom_image=uploaded_photo)
         src = os.path.join(
-            settings.MEDIA_ROOT, 'hero-featured-image', 'transparent.png')
+            settings.MEDIA_ROOT, 'hero-featured-image', 'transparent.jpg')
         dest = os.path.join(
             settings.MEDIA_ROOT, 'hero-featured-image', 'thumbs',
-            'transparent.png')
+            'transparent.jpg')
         copy_stored_file(src, dest)
         delete_url = reverse(
             'admin:discovery_primaryheroimageupload_delete', args=(item.pk,)
@@ -648,10 +648,10 @@ class TestPrimaryHeroImageAdmin(TestCase):
         assert response.status_code == 200
         assert PrimaryHeroImage.objects.filter(pk=item.pk).exists()
         assert os.path.exists(os.path.join(
-            settings.MEDIA_ROOT, 'hero-featured-image', 'transparent.png'))
+            settings.MEDIA_ROOT, 'hero-featured-image', 'transparent.jpg'))
         assert os.path.exists(os.path.join(
             settings.MEDIA_ROOT, 'hero-featured-image', 'thumbs',
-            'transparent.png'))
+            'transparent.jpg'))
 
         # And can actually delete.
         response = self.client.post(
@@ -659,10 +659,10 @@ class TestPrimaryHeroImageAdmin(TestCase):
         assert response.status_code == 200
         assert not PrimaryHeroImage.objects.filter(pk=item.pk).exists()
         assert not os.path.exists(os.path.join(
-            settings.MEDIA_ROOT, 'hero-featured-image', 'transparent.png'))
+            settings.MEDIA_ROOT, 'hero-featured-image', 'transparent.jpg'))
         assert not os.path.exists(os.path.join(
             settings.MEDIA_ROOT, 'hero-featured-image',
-            'thumbs', 'transparent.png'))
+            'thumbs', 'transparent.jpg'))
 
     def test_can_add_with_discovery_edit_permission(self):
         add_url = reverse('admin:discovery_primaryheroimageupload_add')
@@ -673,7 +673,7 @@ class TestPrimaryHeroImageAdmin(TestCase):
         response = self.client.get(add_url, follow=True)
         assert response.status_code == 200
         assert PrimaryHeroImage.objects.count() == 0
-        photo = get_uploaded_file('preview_4x3.jpg')
+        photo = get_uploaded_file('transparent.png')
         response = self.client.post(
             add_url,
             dict(custom_image=photo),
@@ -681,17 +681,17 @@ class TestPrimaryHeroImageAdmin(TestCase):
         assert response.status_code == 200
         assert PrimaryHeroImage.objects.count() == 1
         item = PrimaryHeroImage.objects.get()
-        assert item.custom_image == 'hero-featured-image/preview_4x3.png'
+        assert item.custom_image == 'hero-featured-image/transparent.jpg'
         assert os.path.exists(os.path.join(
-            settings.MEDIA_ROOT, 'hero-featured-image', 'preview_4x3.png'))
+            settings.MEDIA_ROOT, 'hero-featured-image', 'transparent.jpg'))
         assert os.path.exists(os.path.join(
             settings.MEDIA_ROOT, 'hero-featured-image',
-            'thumbs', 'preview_4x3.png'))
+            'thumbs', 'transparent.jpg'))
         width, height = get_image_dimensions(os.path.join(
-            settings.MEDIA_ROOT, 'hero-featured-image', 'preview_4x3.png'))
+            settings.MEDIA_ROOT, 'hero-featured-image', 'transparent.jpg'))
         t_width, t_height = get_image_dimensions(os.path.join(
             settings.MEDIA_ROOT, 'hero-featured-image',
-            'thumbs', 'preview_4x3.png'))
+            'thumbs', 'transparent.jpg'))
         assert width <= 960 and height <= 640
         assert t_width <= 150 and t_height <= 120
 
@@ -730,16 +730,16 @@ class TestPrimaryHeroImageAdmin(TestCase):
         assert response.status_code == 403
         item.reload()
         assert PrimaryHeroImage.objects.count() == 1
-        assert item.custom_image == 'hero-featured-image/transparent.png'
+        assert item.custom_image == 'hero-featured-image/transparent.jpg'
 
     def test_can_not_delete_without_discovery_edit_permission(self):
         uploaded_photo = get_uploaded_file('transparent.png')
         item = PrimaryHeroImage.objects.create(custom_image=uploaded_photo)
         src = os.path.join(
-            settings.MEDIA_ROOT, 'hero-featured-image', 'transparent.png')
+            settings.MEDIA_ROOT, 'hero-featured-image', 'transparent.jpg')
         dest = os.path.join(
             settings.MEDIA_ROOT, 'hero-featured-image', 'thumbs',
-            'transparent.png')
+            'transparent.jpg')
         copy_stored_file(src, dest)
         delete_url = reverse(
             'admin:discovery_primaryheroimageupload_delete', args=(item.pk,)
@@ -752,10 +752,10 @@ class TestPrimaryHeroImageAdmin(TestCase):
         assert response.status_code == 403
         assert PrimaryHeroImage.objects.filter(pk=item.pk).exists()
         assert os.path.exists(os.path.join(
-            settings.MEDIA_ROOT, 'hero-featured-image', 'transparent.png'))
+            settings.MEDIA_ROOT, 'hero-featured-image', 'transparent.jpg'))
         assert os.path.exists(os.path.join(
             settings.MEDIA_ROOT, 'hero-featured-image', 'thumbs',
-            'transparent.png'))
+            'transparent.jpg'))
 
         # Can not actually delete either.
         response = self.client.post(
@@ -763,10 +763,10 @@ class TestPrimaryHeroImageAdmin(TestCase):
         assert response.status_code == 403
         assert PrimaryHeroImage.objects.filter(pk=item.pk).exists()
         assert os.path.exists(os.path.join(
-            settings.MEDIA_ROOT, 'hero-featured-image', 'transparent.png'))
+            settings.MEDIA_ROOT, 'hero-featured-image', 'transparent.jpg'))
         assert os.path.exists(os.path.join(
             settings.MEDIA_ROOT, 'hero-featured-image',
-            'thumbs', 'transparent.png'))
+            'thumbs', 'transparent.jpg'))
 
 
 class TestSecondaryHeroShelfAdmin(TestCase):

--- a/src/olympia/hero/admin.py
+++ b/src/olympia/hero/admin.py
@@ -71,11 +71,11 @@ class PrimaryHeroImageAdmin(admin.ModelAdmin):
         size_full = (960, 640)
 
         with tempfile.NamedTemporaryFile(dir=settings.TMP_PATH) as tmp:
-            resize_image(obj.custom_image.path, tmp.name, size_thumb)
+            resize_image(obj.custom_image.path, tmp.name, size_thumb, True)
             copy_stored_file(tmp.name, obj.thumbnail_path)
 
         with tempfile.NamedTemporaryFile(dir=settings.TMP_PATH) as tmp:
-            resize_image(obj.custom_image.path, tmp.name, size_full)
+            resize_image(obj.custom_image.path, tmp.name, size_full, True)
             copy_stored_file(tmp.name, obj.custom_image.path)
 
     def delete_queryset(self, request, queryset):

--- a/src/olympia/hero/admin.py
+++ b/src/olympia/hero/admin.py
@@ -71,11 +71,11 @@ class PrimaryHeroImageAdmin(admin.ModelAdmin):
         size_full = (960, 640)
 
         with tempfile.NamedTemporaryFile(dir=settings.TMP_PATH) as tmp:
-            resize_image(obj.custom_image.path, tmp.name, size_thumb, True)
+            resize_image(obj.custom_image.path, tmp.name, size_thumb, 'jpg')
             copy_stored_file(tmp.name, obj.thumbnail_path)
 
         with tempfile.NamedTemporaryFile(dir=settings.TMP_PATH) as tmp:
-            resize_image(obj.custom_image.path, tmp.name, size_full, True)
+            resize_image(obj.custom_image.path, tmp.name, size_full, 'jpg')
             copy_stored_file(tmp.name, obj.custom_image.path)
 
     def delete_queryset(self, request, queryset):

--- a/src/olympia/hero/models.py
+++ b/src/olympia/hero/models.py
@@ -93,7 +93,7 @@ class WidgetCharField(models.CharField):
 
 def hero_image_directory(instance, filename):
     prefix = os.path.splitext(filename)[0]
-    return f'hero-featured-image/{prefix}.png'
+    return f'hero-featured-image/{prefix}.jpg'
 
 
 class PrimaryHeroImage(ModelBase):


### PR DESCRIPTION
Fixes #14948 

This pull request converts the uploaded image for the primary hero area to jpg by updating `resize_image` in `utils.py`.

`discovery/tests/test_admin/.py` has been updated, and I also ran other tests that include `resize_image` (`amo/tests/test_amo_utils.py` and `versions/tests/test_tasks.py`) and they passed based on this revision as well.

In addition, please see below for the difference in size between the initial uploaded and resulting jpg for a few of the existing images:
201 KB -> 156 KB
179 KB -> 169 KB
39 KB -> 38 KB

Please review when you have a moment. Thank you!