### PR TITLE
Don't default to delayed rejections in unlisted reviews

### DIFF
--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -382,6 +382,17 @@ class ReviewForm(forms.Form):
         self.helper = kw.pop('helper')
         super(ReviewForm, self).__init__(*args, **kw)
 
+        if self.helper.version:
+            channel = self.helper.version.channel
+        else:
+            channel = amo.RELEASE_CHANNEL_LISTED
+
+        # We default to delayed rejection for listed, but for unlisted the
+        # input will never be shown for any action, so it should default to
+        # False.
+        if channel == amo.RELEASE_CHANNEL_UNLISTED:
+            self.fields['delayed_rejection'].initial = False
+
         # Delayed rejection period needs to be readonly unless we're an admin.
         user = self.helper.handler.user
         rejection_period_widget_attributes = {}
@@ -405,10 +416,6 @@ class ReviewForm(forms.Form):
             if self.helper.actions[k].get('versions')
         ]
         if versions_actions:
-            if self.helper.version:
-                channel = self.helper.version.channel
-            else:
-                channel = amo.RELEASE_CHANNEL_LISTED
             statuses = (amo.STATUS_APPROVED, amo.STATUS_AWAITING_REVIEW)
             self.fields['versions'].widget.versions_actions = versions_actions
             self.fields['versions'].queryset = (

--- a/src/olympia/reviewers/tests/test_forms.py
+++ b/src/olympia/reviewers/tests/test_forms.py
@@ -289,6 +289,16 @@ class TestReviewForm(TestCase):
             'versions': [u'This field is required.']
         }
 
+    def test_immediate_rejection_defaults(self):
+        # When doing a listed review, the default is to reject with a delay.
+        form = self.get_form()
+        form.fields['delayed_rejection'].initial is True
+        # When doing an unlisted review, we'll hide delayed rejection inputs,
+        # so we should always default to delayed rejection being off.
+        self.version.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        form = self.get_form()
+        form.fields['delayed_rejection'].initial is False
+
     def test_delayed_rejection_days_widget_attributes(self):
         # Regular reviewers can't customize the delayed rejection period.
         form = self.get_form()


### PR DESCRIPTION
The choice isn't even present for unlisted reviews, so we should default to immediate rejections in that case.

Fixes #15023