### PR TITLE
Add get_download_series() to retrieve download data from BQ

### DIFF
--- a/src/olympia/stats/tests/test_utils.py
+++ b/src/olympia/stats/tests/test_utils.py
@@ -8,10 +8,13 @@ from olympia.amo.tests import TestCase, addon_factory
 from olympia.constants.applications import ANDROID, FIREFOX
 from olympia.stats.utils import (
     AMO_STATS_DAU_VIEW,
-    AMO_TO_BIGQUERY_COLUMN_MAPPING,
+    AMO_STATS_INSTALLS_VIEW,
+    AMO_TO_BQ_DAU_COLUMN_MAPPING,
+    AMO_TO_BQ_INSTALLS_COLUMN_MAPPING,
     get_addons_and_average_daily_users_from_bigquery,
     get_averages_by_addon_from_bigquery,
     get_updates_series,
+    get_download_series,
     rows_to_series,
 )
 
@@ -39,7 +42,7 @@ class BigQueryTestMixin(object):
         return job_config['query']['queryParameters']
 
 
-class TestRowsToSeries(BigQueryTestMixin, TestCase):
+class TestRowsToSeriesForUsageStats(BigQueryTestMixin, TestCase):
     def create_fake_bigquery_row(
         self, dau=123, submission_date=date(2020, 5, 28), **kwargs
     ):
@@ -50,7 +53,7 @@ class TestRowsToSeries(BigQueryTestMixin, TestCase):
     def test_no_rows(self):
         rows = []
 
-        series = list(rows_to_series(rows))
+        series = list(rows_to_series(rows, count_column='dau'))
 
         assert series == []
 
@@ -65,7 +68,7 @@ class TestRowsToSeries(BigQueryTestMixin, TestCase):
             self.create_fake_bigquery_row(),
         ]
 
-        series = list(rows_to_series(rows))
+        series = list(rows_to_series(rows, count_column='dau'))
 
         assert len(series) == len(rows)
         item = series[0]
@@ -87,7 +90,7 @@ class TestRowsToSeries(BigQueryTestMixin, TestCase):
             )
         ]
 
-        series = list(rows_to_series(rows))
+        series = list(rows_to_series(rows, count_column='dau'))
 
         assert series[0] == {
             'count': dau,
@@ -100,13 +103,15 @@ class TestRowsToSeries(BigQueryTestMixin, TestCase):
         data = [{'key': 'k1', 'value': 123}, {'key': 'k2', 'value': 678}]
         rows = [self.create_fake_bigquery_row(column_with_data=data)]
 
-        series = list(rows_to_series(rows, filter_by=filter_by))
+        series = list(
+            rows_to_series(rows, count_column='dau', filter_by=filter_by)
+        )
 
         assert 'data' in series[0]
         assert series[0]['data'] == {'k1': 123, 'k2': 678}
 
     def test_filter_by_dau_by_app_version_and_fenix_build(self):
-        filter_by = AMO_TO_BIGQUERY_COLUMN_MAPPING.get('apps')
+        filter_by = AMO_TO_BQ_DAU_COLUMN_MAPPING.get('apps')
         android_data = [{'key': '79.0.0', 'value': 987}]
         firefox_data = [
             {'key': '77.0.0', 'value': 123},
@@ -119,7 +124,9 @@ class TestRowsToSeries(BigQueryTestMixin, TestCase):
             )
         ]
 
-        series = list(rows_to_series(rows, filter_by=filter_by))
+        series = list(
+            rows_to_series(rows, count_column='dau', filter_by=filter_by)
+        )
 
         assert 'data' in series[0]
         assert series[0]['data'] == {
@@ -128,7 +135,7 @@ class TestRowsToSeries(BigQueryTestMixin, TestCase):
         }
 
     def test_filter_by_dau_by_app_version_and_no_fenix_data(self):
-        filter_by = AMO_TO_BIGQUERY_COLUMN_MAPPING.get('apps')
+        filter_by = AMO_TO_BQ_DAU_COLUMN_MAPPING.get('apps')
         android_data = []
         firefox_data = [
             {'key': '77.0.0', 'value': 123},
@@ -141,13 +148,48 @@ class TestRowsToSeries(BigQueryTestMixin, TestCase):
             )
         ]
 
-        series = list(rows_to_series(rows, filter_by=filter_by))
+        series = list(
+            rows_to_series(rows, count_column='dau', filter_by=filter_by)
+        )
 
         assert 'data' in series[0]
         assert series[0]['data'] == {
             ANDROID.guid: {},
             FIREFOX.guid: {'77.0.0': 123, '76.0.1': 678},
         }
+
+
+class TestRowsToSeriesForInstallStats(BigQueryTestMixin, TestCase):
+    def create_fake_bigquery_row(
+        self, total_downloads=123, submission_date=date(2020, 5, 28), **kwargs
+    ):
+        return self.create_bigquery_row(
+            {
+                'total_downloads': total_downloads,
+                'submission_date': submission_date,
+                **kwargs,
+            }
+        )
+
+    def test_returns_series(self):
+        total_downloads = 1234
+        submission_date = date(2020, 5, 24)
+        rows = [
+            self.create_fake_bigquery_row(
+                total_downloads=total_downloads,
+                submission_date=submission_date,
+            )
+        ]
+
+        series = list(rows_to_series(rows, count_column='total_downloads'))
+
+        assert series == [
+            {
+                'count': total_downloads,
+                'date': submission_date,
+                'end': submission_date,
+            }
+        ]
 
 
 @override_settings(BIGQUERY_PROJECT='project', BIGQUERY_AMO_DATASET='dataset')
@@ -208,7 +250,7 @@ LIMIT 365"""
         start_date = date(2020, 5, 27)
         end_date = date(2020, 5, 28)
 
-        for source, column in AMO_TO_BIGQUERY_COLUMN_MAPPING.items():
+        for source, column in AMO_TO_BQ_DAU_COLUMN_MAPPING.items():
             expected_query = f"""
 SELECT submission_date, dau, {column}
 FROM `project.dataset.{AMO_STATS_DAU_VIEW}`
@@ -435,3 +477,85 @@ USING
             'guid': {'avg_this_week': 123, 'avg_three_weeks_before': 456},
             'guid2': {'avg_this_week': 45, 'avg_three_weeks_before': 40},
         }
+
+
+@override_settings(BIGQUERY_PROJECT='project', BIGQUERY_AMO_DATASET='dataset')
+class TestGetDownloadSeries(BigQueryTestMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.addon = addon_factory()
+
+    @mock.patch('google.cloud.bigquery.Client')
+    def test_create_client(self, bigquery_client_mock):
+        client = self.create_mock_client()
+        bigquery_client_mock.from_service_account_json.return_value = client
+
+        credentials = 'path/to/credentials.json'
+        with override_settings(GOOGLE_APPLICATION_CREDENTIALS=credentials):
+            get_download_series(
+                addon=self.addon,
+                start_date=date(2020, 5, 27),
+                end_date=date(2020, 5, 28),
+            )
+
+        bigquery_client_mock.from_service_account_json.assert_called_once_with(
+            credentials
+        )
+
+    @mock.patch('olympia.stats.utils.statsd.timer')
+    @mock.patch('google.cloud.bigquery.Client')
+    def test_create_query(self, bigquery_client_mock, timer_mock):
+        client = self.create_mock_client()
+        bigquery_client_mock.from_service_account_json.return_value = client
+        start_date = date(2020, 5, 27)
+        end_date = date(2020, 5, 28)
+        expected_query = f"""
+SELECT submission_date, total_downloads
+FROM `project.dataset.{AMO_STATS_INSTALLS_VIEW}`
+WHERE addon_id = @addon_id
+AND submission_date BETWEEN @submission_date_start AND @submission_date_end
+ORDER BY submission_date DESC
+LIMIT 365"""
+
+        get_download_series(
+            addon=self.addon, start_date=start_date, end_date=end_date
+        )
+
+        client.query.assert_called_once_with(
+            expected_query, job_config=mock.ANY
+        )
+        timer_mock.assert_called_once_with(
+            'stats.get_download_series.bigquery.no_source'
+        )
+
+    @mock.patch('olympia.stats.utils.statsd.timer')
+    @mock.patch('google.cloud.bigquery.Client')
+    def test_create_query_with_source(self, bigquery_client_mock, timer_mock):
+        client = self.create_mock_client()
+        bigquery_client_mock.from_service_account_json.return_value = client
+        start_date = date(2020, 5, 27)
+        end_date = date(2020, 5, 28)
+
+        for source, column in AMO_TO_BQ_INSTALLS_COLUMN_MAPPING.items():
+            expected_query = f"""
+SELECT submission_date, total_downloads, {column}
+FROM `project.dataset.{AMO_STATS_INSTALLS_VIEW}`
+WHERE addon_id = @addon_id
+AND submission_date BETWEEN @submission_date_start AND @submission_date_end
+ORDER BY submission_date DESC
+LIMIT 365"""
+
+            get_download_series(
+                addon=self.addon,
+                start_date=start_date,
+                end_date=end_date,
+                source=source,
+            )
+
+            client.query.assert_called_with(
+                expected_query, job_config=mock.ANY
+            )
+            timer_mock.assert_called_with(
+                f'stats.get_download_series.bigquery.{source}'
+            )

--- a/src/olympia/stats/utils.py
+++ b/src/olympia/stats/utils.py
@@ -18,12 +18,12 @@ AMO_TO_BQ_DAU_COLUMN_MAPPING = {
 
 # This is the mapping between the AMO download stats `sources` and the BigQuery
 # columns.
-AMO_TO_BQ_INSTALLS_COLUMN_MAPPING = {'sources': 'downloads_per_source'}
+AMO_TO_BQ_DOWNLOAD_COLUMN_MAPPING = {'sources': 'downloads_per_source'}
 
 AMO_STATS_DAU_VIEW = 'amo_stats_dau'
 # NOTE: We currently use the `v2` table instead of the actual view because we
 # are still experimenting with this new dataset.
-AMO_STATS_INSTALLS_VIEW = 'amo_stats_installs_v2'
+AMO_STATS_DOWNLOAD_VIEW = 'amo_stats_installs_v2'
 
 
 def make_fully_qualified_view_name(view):
@@ -36,8 +36,8 @@ def get_amo_stats_dau_view_name():
     return make_fully_qualified_view_name(AMO_STATS_DAU_VIEW)
 
 
-def get_amo_stats_installs_view_name():
-    return make_fully_qualified_view_name(AMO_STATS_INSTALLS_VIEW)
+def get_amo_stats_download_view_name():
+    return make_fully_qualified_view_name(AMO_STATS_DOWNLOAD_VIEW)
 
 
 def create_client():
@@ -121,13 +121,13 @@ def get_download_series(addon, start_date, end_date, source=None):
     client = create_client()
 
     select_clause = 'SELECT submission_date, total_downloads'
-    filter_by = AMO_TO_BQ_INSTALLS_COLUMN_MAPPING.get(source)
+    filter_by = AMO_TO_BQ_DOWNLOAD_COLUMN_MAPPING.get(source)
     if filter_by:
         select_clause = f'{select_clause}, {filter_by}'
 
     query = f"""
 {select_clause}
-FROM `{get_amo_stats_installs_view_name()}`
+FROM `{get_amo_stats_download_view_name()}`
 WHERE addon_id = @addon_id
 AND submission_date BETWEEN @submission_date_start AND @submission_date_end
 ORDER BY submission_date DESC

--- a/src/olympia/stats/utils.py
+++ b/src/olympia/stats/utils.py
@@ -6,8 +6,9 @@ from google.cloud import bigquery
 
 from olympia.constants.applications import ANDROID, FIREFOX
 
-# This is the mapping between the AMO stats `sources` and the BigQuery columns.
-AMO_TO_BIGQUERY_COLUMN_MAPPING = {
+# This is the mapping between the AMO usage stats `sources` and the BigQuery
+# columns.
+AMO_TO_BQ_DAU_COLUMN_MAPPING = {
     'apps': 'dau_by_app_version, dau_by_fenix_build',
     'countries': 'dau_by_country',
     'locales': 'dau_by_locale',
@@ -15,26 +16,42 @@ AMO_TO_BIGQUERY_COLUMN_MAPPING = {
     'versions': 'dau_by_addon_version',
 }
 
+# This is the mapping between the AMO download stats `sources` and the BigQuery
+# columns.
+AMO_TO_BQ_INSTALLS_COLUMN_MAPPING = {'sources': 'downloads_per_source'}
 
 AMO_STATS_DAU_VIEW = 'amo_stats_dau'
+# NOTE: We currently use the `v2` table instead of the actual view because we
+# are still experimenting with this new dataset.
+AMO_STATS_INSTALLS_VIEW = 'amo_stats_installs_v2'
 
 
-def get_amo_stats_dau_view_name():
+def make_fully_qualified_view_name(view):
     return '.'.join(
-        [
-            settings.BIGQUERY_PROJECT,
-            settings.BIGQUERY_AMO_DATASET,
-            AMO_STATS_DAU_VIEW,
-        ]
+        [settings.BIGQUERY_PROJECT, settings.BIGQUERY_AMO_DATASET, view]
     )
 
 
-def rows_to_series(rows, filter_by=None):
+def get_amo_stats_dau_view_name():
+    return make_fully_qualified_view_name(AMO_STATS_DAU_VIEW)
+
+
+def get_amo_stats_installs_view_name():
+    return make_fully_qualified_view_name(AMO_STATS_INSTALLS_VIEW)
+
+
+def create_client():
+    return bigquery.Client.from_service_account_json(
+        settings.GOOGLE_APPLICATION_CREDENTIALS
+    )
+
+
+def rows_to_series(rows, count_column, filter_by=None):
     """Transforms BigQuery rows into series items suitable for the rest of the
     AMO stats logic."""
     for row in rows:
         item = {
-            'count': row['dau'],
+            'count': row[count_column],
             'date': row['submission_date'],
             'end': row['submission_date'],
         }
@@ -43,7 +60,7 @@ def rows_to_series(rows, filter_by=None):
             # one.
             # See: https://github.com/mozilla/addons-server/issues/14411
             # See: https://github.com/mozilla/addons-server/issues/14832
-            if filter_by == AMO_TO_BIGQUERY_COLUMN_MAPPING['apps']:
+            if filter_by == AMO_TO_BQ_DAU_COLUMN_MAPPING['apps']:
                 item['data'] = {
                     ANDROID.guid: {
                         d['key']: d['value']
@@ -63,13 +80,10 @@ def rows_to_series(rows, filter_by=None):
 
 
 def get_updates_series(addon, start_date, end_date, source=None):
-    client = bigquery.Client.from_service_account_json(
-        settings.GOOGLE_APPLICATION_CREDENTIALS
-    )
-
-    filter_by = AMO_TO_BIGQUERY_COLUMN_MAPPING.get(source)
+    client = create_client()
 
     select_clause = 'SELECT submission_date, dau'
+    filter_by = AMO_TO_BQ_DAU_COLUMN_MAPPING.get(source)
     if filter_by:
         select_clause = f'{select_clause}, {filter_by}'
 
@@ -100,15 +114,55 @@ LIMIT 365"""
             ),
         ).result()
 
-    return rows_to_series(rows, filter_by=filter_by)
+    return rows_to_series(rows, count_column='dau', filter_by=filter_by)
+
+
+def get_download_series(addon, start_date, end_date, source=None):
+    client = create_client()
+
+    select_clause = 'SELECT submission_date, total_downloads'
+    filter_by = AMO_TO_BQ_INSTALLS_COLUMN_MAPPING.get(source)
+    if filter_by:
+        select_clause = f'{select_clause}, {filter_by}'
+
+    query = f"""
+{select_clause}
+FROM `{get_amo_stats_installs_view_name()}`
+WHERE addon_id = @addon_id
+AND submission_date BETWEEN @submission_date_start AND @submission_date_end
+ORDER BY submission_date DESC
+LIMIT 365"""
+
+    statsd_timer = (
+        f'stats.get_download_series.bigquery.{source or "no_source"}'
+    )
+    with statsd.timer(statsd_timer):
+        rows = client.query(
+            query,
+            job_config=bigquery.QueryJobConfig(
+                query_parameters=[
+                    bigquery.ScalarQueryParameter(
+                        'addon_id', 'STRING', addon.guid
+                    ),
+                    bigquery.ScalarQueryParameter(
+                        'submission_date_start', 'DATE', start_date
+                    ),
+                    bigquery.ScalarQueryParameter(
+                        'submission_date_end', 'DATE', end_date
+                    ),
+                ]
+            ),
+        ).result()
+
+    return rows_to_series(
+        rows, count_column='total_downloads', filter_by=filter_by
+    )
 
 
 def get_addons_and_average_daily_users_from_bigquery():
     """This function is used to compute the 'average_daily_users' value of each
     add-on (see `update_addon_average_daily_users()` cron task)."""
-    client = bigquery.Client.from_service_account_json(
-        settings.GOOGLE_APPLICATION_CREDENTIALS
-    )
+    client = create_client()
 
     query = f"""
 SELECT addon_id, AVG(dau) AS count
@@ -128,9 +182,7 @@ def get_averages_by_addon_from_bigquery(today, exclude=None):
     """This function is used to compute the 'hotness' score of each add-on (see
     also `deliver_hotness()` cron task). It returns a dict with top-level keys
     being add-on GUIDs and values being dicts containing average values."""
-    client = bigquery.Client.from_service_account_json(
-        settings.GOOGLE_APPLICATION_CREDENTIALS
-    )
+    client = create_client()
 
     one_week_date = today - timedelta(days=7)
     four_weeks_date = today - timedelta(days=28)


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/15011

---

This is similar to what we have for usage stats. We rely on the table until we
have a productionized view in BigQuery.