### PR TITLE
Add new "By" download stats pages

### DIFF
--- a/src/olympia/stats/templates/stats/addon_report_menu.html
+++ b/src/olympia/stats/templates/stats/addon_report_menu.html
@@ -10,6 +10,17 @@
       <li data-report="sources">
         <a href="{{ url('stats.sources', addon.slug) }}">{{ _('by Source') }}</a>
       </li>
+      {% if bigquery_download_stats %}
+        <li data-report="mediums">
+          <a href="{{ url('stats.mediums', addon.slug) }}">{{ _('by Medium') }}</a>
+        </li>
+        <li data-report="contents">
+          <a href="{{ url('stats.contents', addon.slug) }}">{{ _('by Content') }}</a>
+        </li>
+         <li data-report="campaigns">
+          <a href="{{ url('stats.campaigns', addon.slug) }}">{{ _('by Campaign') }}</a>
+        </li>
+      {% endif %}
     </ul>
     <li data-report="usage">
       <a href="{{ url('stats.usage', addon.slug) }}">{{ _('Daily Users') }}</a>

--- a/src/olympia/stats/templates/stats/reports/campaigns.html
+++ b/src/olympia/stats/templates/stats/reports/campaigns.html
@@ -1,0 +1,3 @@
+{% extends 'stats/report.html' %}
+
+{% set title = _('Download campaigns by Date') %}

--- a/src/olympia/stats/templates/stats/reports/contents.html
+++ b/src/olympia/stats/templates/stats/reports/contents.html
@@ -1,0 +1,3 @@
+{% extends 'stats/report.html' %}
+
+{% set title = _('Download contents by Date') %}

--- a/src/olympia/stats/templates/stats/reports/mediums.html
+++ b/src/olympia/stats/templates/stats/reports/mediums.html
@@ -1,0 +1,3 @@
+{% extends 'stats/report.html' %}
+
+{% set title = _('Download mediums by Date') %}

--- a/src/olympia/stats/templates/stats/stats.html
+++ b/src/olympia/stats/templates/stats/stats.html
@@ -125,6 +125,7 @@
     data-start_date="{{ view.start }}"
     data-end_date="{{ view.end }}"
     {% endif %}
+    data-bigquery-download-stats="{{ bigquery_download_stats }}"
     data-base_url="{{ stats_base_url }}">
     <div class="island chart">
       <div id="head-chart">

--- a/src/olympia/stats/templatetags/jinja_helpers.py
+++ b/src/olympia/stats/templatetags/jinja_helpers.py
@@ -1,11 +1,10 @@
 from django.template import loader
 
 import jinja2
+import waffle
 
 from django_jinja import library
 
-from olympia import amo
-from olympia.access import acl
 from olympia.addons.models import Addon
 
 
@@ -14,15 +13,11 @@ from olympia.addons.models import Addon
 def report_menu(context, request, report, obj):
     """Renders navigation for the various statistic reports."""
     if isinstance(obj, Addon):
-        has_privs = False
-        if request.user.is_authenticated and (
-            acl.action_allowed(request, amo.permissions.STATS_VIEW) or
-            obj.has_author(request.user)
-        ):
-            has_privs = True
         tpl = loader.get_template('stats/addon_report_menu.html')
         ctx = {
             'addon': obj,
-            'has_privs': has_privs,
+            'bigquery_download_stats': waffle.flag_is_active(
+                request, 'bigquery-download-stats'
+            ),
         }
         return jinja2.Markup(tpl.render(ctx))

--- a/src/olympia/stats/urls.py
+++ b/src/olympia/stats/urls.py
@@ -22,6 +22,15 @@ stats_patterns = [
     url(r'^downloads/sources/$', views.stats_report, name='stats.sources',
         kwargs={'report': 'sources'}),
 
+    url(r'^downloads/mediums/$', views.stats_report, name='stats.mediums',
+        kwargs={'report': 'mediums'}),
+
+    url(r'^downloads/contents/$', views.stats_report, name='stats.contents',
+        kwargs={'report': 'contents'}),
+
+    url(r'^downloads/campaigns/$', views.stats_report, name='stats.campaigns',
+        kwargs={'report': 'campaigns'}),
+
     url(r'^usage/$', views.stats_report, name='stats.usage',
         kwargs={'report': 'usage'}),
 
@@ -52,6 +61,15 @@ stats_patterns = [
 
     url(series['sources'], views.download_breakdown_series,
         name='stats.sources_series', kwargs={'source': 'sources'}),
+
+    url(series['mediums'], views.download_breakdown_series,
+        name='stats.mediums_series', kwargs={'source': 'mediums'}),
+
+    url(series['contents'], views.download_breakdown_series,
+        name='stats.contents_series', kwargs={'source': 'contents'}),
+
+    url(series['campaigns'], views.download_breakdown_series,
+        name='stats.campaigns_series', kwargs={'source': 'campaigns'}),
 
     url(series['os'], views.usage_breakdown_series,
         name='stats.os_series', kwargs={'field': 'oses'}),

--- a/src/olympia/stats/utils.py
+++ b/src/olympia/stats/utils.py
@@ -18,7 +18,12 @@ AMO_TO_BQ_DAU_COLUMN_MAPPING = {
 
 # This is the mapping between the AMO download stats `sources` and the BigQuery
 # columns.
-AMO_TO_BQ_DOWNLOAD_COLUMN_MAPPING = {'sources': 'downloads_per_source'}
+AMO_TO_BQ_DOWNLOAD_COLUMN_MAPPING = {
+    'campaigns': 'downloads_per_campaign',
+    'contents': 'downloads_per_content',
+    'mediums': 'downloads_per_medium',
+    'sources': 'downloads_per_source',
+}
 
 AMO_STATS_DAU_VIEW = 'amo_stats_dau'
 # NOTE: We currently use the `v2` table instead of the actual view because we

--- a/src/olympia/stats/views.py
+++ b/src/olympia/stats/views.py
@@ -37,7 +37,7 @@ SERIES_GROUPS = ('day', 'week', 'month')
 SERIES_GROUPS_DATE = ('date', 'week', 'month')  # Backwards compat.
 SERIES_FORMATS = ('json', 'csv')
 SERIES = ('downloads', 'usage', 'overview', 'sources', 'os', 'locales',
-          'versions', 'apps', 'countries',)
+          'versions', 'apps', 'countries', 'mediums', 'contents', 'campaigns')
 
 
 storage = get_storage_class()()
@@ -229,6 +229,10 @@ def download_breakdown_series(
             source=source,
         )
     else:
+        # Legacy stats only have download stats "by source".
+        if source != 'sources':
+            raise http.Http404
+
         series = get_series(
             DownloadCount,
             addon=addon.id,
@@ -373,6 +377,9 @@ def stats_report(request, addon, report):
             'report': report,
             'stats_base_url': stats_base_url,
             'view': view,
+            'bigquery_download_stats': waffle.flag_is_active(
+                request, 'bigquery-download-stats'
+            ),
         }
     )
 

--- a/static/js/impala/stats/chart.js
+++ b/static/js/impala/stats/chart.js
@@ -98,6 +98,9 @@
         "refunds"            : "refunds",
         "installs"           : "installs",
         "countries"          : "users",
+        "contents"           : "downloads",
+        "mediums"            : "downloads",
+        "campaigns"          : "downloads",
     };
 
     var acceptedGroups = {

--- a/static/js/impala/stats/csv_keys.js
+++ b/static/js/impala/stats/csv_keys.js
@@ -190,6 +190,24 @@ var csv_keys = {
             // L10n: both {0} and {1} are dates in YYYY-MM-DD format.
             gettext("Download Sources from {0} to {1}")
         ],
+        "mediums"  : [
+            // L10n: {0} is an integer.
+            gettext("Download Mediums, last {0} days"),
+            // L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+            gettext("Download Mediums from {0} to {1}")
+        ],
+        "contents"  : [
+            // L10n: {0} is an integer.
+            gettext("Download Contents, last {0} days"),
+            // L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+            gettext("Download Contents from {0} to {1}")
+        ],
+        "campaigns"  : [
+            // L10n: {0} is an integer.
+            gettext("Download Campaigns, last {0} days"),
+            // L10n: both {0} and {1} are dates in YYYY-MM-DD format.
+            gettext("Download Campaigns from {0} to {1}")
+        ],
         "contributions"  : [
             // L10n: {0} is an integer.
             gettext("Contributions, last {0} days"),

--- a/static/js/impala/stats/manager.js
+++ b/static/js/impala/stats/manager.js
@@ -10,6 +10,12 @@ z.StatsManager = (function() {
 
     var $primary = $(".primary");
 
+    // Make sure to use a different session cache when users have the waffle
+    // flag enabled or disabled.
+    if ($primary.data("bigquery-download-stats") === 'True') {
+        STATS_VERSION += '-preview';
+    }
+
     var storage         = z.Storage("stats"),
         storageCache    = z.SessionStorage("statscache"),
         dataStore       = {},
@@ -38,6 +44,9 @@ z.StatsManager = (function() {
         "overview": true,
         "site": true,
         "countries": true,
+        "contents": true,
+        "mediums": true,
+        "campaigns": true,
     };
 
     // is a metric an average or a sum?
@@ -52,6 +61,9 @@ z.StatsManager = (function() {
         "sources"       : "sum",
         "contributions" : "sum",
         "countries"     : "mean",
+        "contents"      : "sum",
+        "mediums"       : "sum",
+        "campaigns"     : "sum",
     };
 
     // Initialize from localStorage when dom is ready.


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/15012

~~:warning: depends on #15031~~

---

This patch adds new "By" pages behind the same flag introduced in #15031. The data for each new page still needs to be collected in Firefox, but BigQuery does return data for each anyway (all with an `unknown` key).

There is some more work to document how data is collected, see https://github.com/mozilla/addons-server/issues/15013