### PR TITLE
Use weekly_downloads and skip update task when flag/switch are active

### DIFF
--- a/scripts/crontab/crontab.tpl
+++ b/scripts/crontab/crontab.tpl
@@ -37,7 +37,7 @@ HOME=/tmp
 00 12 * * * %(django)s download_counts_from_file
 
 # Once per day after metrics import is done
-30 12 * * * %(z_cron)s update_addon_download_totals
+30 12 * * * %(z_cron)s update_addon_total_downloads
 35 12 * * * %(z_cron)s weekly_downloads
 30 13 * * * %(z_cron)s update_addon_average_daily_users
 00 14 * * * %(z_cron)s index_latest_stats

--- a/src/olympia/addons/admin.py
+++ b/src/olympia/addons/admin.py
@@ -138,8 +138,7 @@ class AddonAdmin(admin.ModelAdmin):
     readonly_fields = ('id', 'created', 'status_with_admin_manage_link',
                        'average_rating', 'bayesian_rating', 'guid',
                        'total_ratings_link', 'text_ratings_count',
-                       'weekly_downloads', 'total_downloads',
-                       'average_daily_users')
+                       'weekly_downloads', 'average_daily_users')
 
     fieldsets = (
         (None, {
@@ -158,8 +157,7 @@ class AddonAdmin(admin.ModelAdmin):
         ('Stats', {
             'fields': ('total_ratings_link', 'average_rating',
                        'bayesian_rating', 'text_ratings_count',
-                       'weekly_downloads', 'total_downloads',
-                       'average_daily_users'),
+                       'weekly_downloads', 'average_daily_users'),
         }),
         ('Flags', {
             'fields': ('disabled_by_user', 'requires_payment',

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -560,7 +560,7 @@ class Addon(OnChangeMixin, ModelBase):
             'reason': reason,
             'name': self.name,
             'slug': self.slug,
-            'total_downloads': self.total_downloads,
+            'weekly_downloads': self.weekly_downloads,
             'url': jinja_helpers.absolutify(self.get_url_path()),
             'user_str': (
                 "%s, %s (%s)" % (user.name, user.email, user.id) if user
@@ -575,7 +575,7 @@ class Addon(OnChangeMixin, ModelBase):
         ID: %(id)s
         GUID: %(guid)s
         AUTHORS: %(authors)s
-        TOTAL DOWNLOADS: %(total_downloads)s
+        WEEKLY DOWNLOADS: %(weekly_downloads)s
         AVERAGE DAILY USERS: %(adu)s
         NOTES: %(msg)s
         REASON GIVEN BY USER FOR DELETION: %(reason)s

--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -101,7 +101,7 @@ def update_addon_average_daily_users(data, **kw):
 
 
 @task
-def update_addon_download_totals(data, **kw):
+def update_addon_total_downloads(data, **kw):
     log.info('[%s] Updating add-ons download+average totals.' % (len(data)))
 
     if not waffle.switch_is_active('local-statistics-processing'):

--- a/src/olympia/addons/tests/test_cron.py
+++ b/src/olympia/addons/tests/test_cron.py
@@ -369,7 +369,7 @@ class TestAvgDailyUserCountTestCase(TestCase):
 
         addon_factory()  # No downloads for this add-on
 
-        cron.update_addon_download_totals()
+        cron.update_addon_total_downloads()
 
         addon.reload()
         assert addon.total_downloads != old_total_downloads
@@ -387,7 +387,15 @@ class TestAvgDailyUserCountTestCase(TestCase):
         get_mock.side_effect = Addon.DoesNotExist()
 
         # Make sure that we don't raise an error when logging
-        cron.update_addon_download_totals()
+        cron.update_addon_total_downloads()
+
+    @mock.patch('olympia.addons.cron._update_addon_total_downloads')
+    def test_skips_cron_when_switch_is_enabled(self, update_task_mock):
+        self.create_switch('use-bigquery-for-download-stats-cron')
+
+        cron.update_addon_total_downloads()
+
+        update_task_mock.assert_not_called()
 
 
 class TestDeliverHotness(TestCase):

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1196,7 +1196,7 @@ CELERY_TASK_ROUTES = {
 
     # Crons
     'olympia.addons.tasks.update_addon_average_daily_users': {'queue': 'cron'},
-    'olympia.addons.tasks.update_addon_download_totals': {'queue': 'cron'},
+    'olympia.addons.tasks.update_addon_total_downloads': {'queue': 'cron'},
     'olympia.addons.tasks.update_addon_hotness': {'queue': 'cron'},
     'olympia.addons.tasks.update_appsupport': {'queue': 'cron'},
 
@@ -1856,7 +1856,7 @@ ALLOWED_FXA_CONFIGS = ['default']
 # syntax is: job_and_method_name: full.package.path
 CRON_JOBS = {
     'update_addon_average_daily_users': 'olympia.addons.cron',
-    'update_addon_download_totals': 'olympia.addons.cron',
+    'update_addon_total_downloads': 'olympia.addons.cron',
     'addon_last_updated': 'olympia.addons.cron',
     'update_addon_appsupport': 'olympia.addons.cron',
     'hide_disabled_files': 'olympia.addons.cron',

--- a/src/olympia/reviewers/templates/reviewers/addon_details_box.html
+++ b/src/olympia/reviewers/templates/reviewers/addon_details_box.html
@@ -91,10 +91,11 @@
             <td>{{ reviews_link(addon) }}</td>
           </tr>
           <tr class="meta-stats">
-            <th>{{ _('Downloads') }}</th>
+            <th>{{ _('Weekly Downloads') }}</th>
             <td>
-              <strong class="downloads">{{
-                addon.total_downloads|numberfmt }}</strong>
+              <strong class="downloads">
+                {{ addon.weekly_downloads|numberfmt }}
+              </strong>
             </td>
           </tr>
           {% if addon.average_daily_users %}

--- a/src/olympia/stats/templates/stats/reports/overview.html
+++ b/src/olympia/stats/templates/stats/reports/overview.html
@@ -5,7 +5,13 @@
 {% block stats %}
     <section class="island two-up">
       <div>
-        <a href="downloads/">{{ _('<b>{0}</b> Downloads')|format_html(addon.total_downloads|numberfmt) }}</a>
+        <a href="downloads/">
+        {% if waffle.flag('bigquery-download-stats') %}
+          {{ _('<b>{0}</b> Weekly Downloads')|format_html(addon.weekly_downloads|numberfmt) }}
+        {% else %}
+          {{ _('<b>{0}</b> Downloads')|format_html(addon.total_downloads|numberfmt) }}
+        {% endif %}
+        </a>
         <small id="downloads-in-range">{{ _('Loading...') }}</small>
       </div>
       <div>

--- a/src/olympia/stats/tests/test_views.py
+++ b/src/olympia/stats/tests/test_views.py
@@ -1166,6 +1166,7 @@ class TestXss(amo.tests.TestXss):
         assert views.get_report_view(req) == {}
 
 
+@override_flag('bigquery-download-stats', active=True)
 class TestStatsWithBigQuery(TestCase):
     def setUp(self):
         super().setUp()
@@ -1267,7 +1268,6 @@ class TestStatsWithBigQuery(TestCase):
 
         assert response.status_code == 200
 
-    @override_flag('bigquery-download-stats', active=True)
     @mock.patch('olympia.stats.views.get_updates_series')
     @mock.patch('olympia.stats.views.get_download_series')
     def test_overview_series_with_bigquery_download_stats(
@@ -1296,18 +1296,17 @@ class TestStatsWithBigQuery(TestCase):
         assert b'by Content' not in response.content
         assert b'by Campaign' not in response.content
 
-    @override_flag('bigquery-download-stats', active=True)
     def test_overview_shows_links_to_bigquery_download_stats(self):
         url = reverse('stats.overview', args=[self.addon.slug])
 
         response = self.client.get(url)
 
+        assert b'Weekly Downloads' in response.content
         assert b'by Source' in response.content
         assert b'by Medium' in response.content
         assert b'by Content' in response.content
         assert b'by Campaign' in response.content
 
-    @override_flag('bigquery-download-stats', active=True)
     def test_download_stats_by_source(self):
         url = reverse('stats.sources', args=[self.addon.slug])
 
@@ -1315,7 +1314,6 @@ class TestStatsWithBigQuery(TestCase):
 
         assert b'Download sources by Date' in response.content
 
-    @override_flag('bigquery-download-stats', active=True)
     def test_download_stats_by_medium(self):
         url = reverse('stats.mediums', args=[self.addon.slug])
 
@@ -1323,7 +1321,6 @@ class TestStatsWithBigQuery(TestCase):
 
         assert b'Download mediums by Date' in response.content
 
-    @override_flag('bigquery-download-stats', active=True)
     def test_download_stats_by_content(self):
         url = reverse('stats.contents', args=[self.addon.slug])
 
@@ -1331,7 +1328,6 @@ class TestStatsWithBigQuery(TestCase):
 
         assert b'Download contents by Date' in response.content
 
-    @override_flag('bigquery-download-stats', active=True)
     def test_download_stats_by_campaign(self):
         url = reverse('stats.campaigns', args=[self.addon.slug])
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/15055

Fixes https://github.com/mozilla/addons-server/issues/15033

---

This patch does two things:

1. it skips the update total downloads cron task when a waffle switch is enabled. This waffle switch will be enabled once ALL users have access to the new download stats (see below). I renamed the task name for consistency too (even if we're going to remove this task in the future)

2. it shows the `weekly_downloads` instead of `total_downloads` in the stats overview when the user has access to the new download stats. We control users who have access to the new download stats using a waffle flag (and not a switch). Admins and reviewers will see the weekly downloads now (and not the total downloads anymore).

Once all users have access to the new download stats, we'll remove the field.