### PR TITLE
re-add the PrimaryHero admin tool inline in PromotedAddon

### DIFF
--- a/src/olympia/discovery/admin.py
+++ b/src/olympia/discovery/admin.py
@@ -9,7 +9,7 @@ from django.db.models import Prefetch
 from olympia.addons.models import Addon
 from olympia.discovery.models import DiscoveryItem
 from olympia.hero.admin import SecondaryHeroAdmin, PrimaryHeroImageAdmin
-from olympia.hero.models import PrimaryHero, SecondaryHero, PrimaryHeroImage
+from olympia.hero.models import SecondaryHero, PrimaryHeroImage
 from olympia.shelves.admin import ShelfAdmin
 from olympia.shelves.models import Shelf
 
@@ -131,12 +131,6 @@ class DiscoveryItemAdmin(admin.ModelAdmin):
                 translations.append(
                     conditional_escape(self.build_preview(obj, locale)))
         return mark_safe(''.join(translations))
-
-    def has_delete_permission(self, request, obj=None):
-        qs = PrimaryHero.objects.filter(enabled=True)
-        if obj and list(qs) == [getattr(obj, 'primaryhero', None)]:
-            return False
-        return super().has_delete_permission(request=request, obj=obj)
 
 
 class PrimaryHeroImageUpload(PrimaryHeroImage):

--- a/src/olympia/hero/admin.py
+++ b/src/olympia/hero/admin.py
@@ -22,7 +22,7 @@ class ImageChoiceField(forms.ModelChoiceField):
                 obj.preview_url))
 
 
-class PrimaryHeroAdmin(admin.ModelAdmin):
+class PrimaryHeroInline(admin.StackedInline):
     class Media:
         css = {
             'all': ('css/admin/discovery.css',)

--- a/src/olympia/promoted/admin.py
+++ b/src/olympia/promoted/admin.py
@@ -112,6 +112,7 @@ class PromotedAddonAdmin(admin.ModelAdmin):
 
     def has_delete_permission(self, request, obj=None):
         qs = PrimaryHeroInline.model.objects.filter(enabled=True)
-        if obj and list(qs) == [getattr(obj, 'primaryhero', None)]:
+        shelf = getattr(obj, 'primaryhero', None)
+        if shelf and shelf.enabled and qs.count() == 1:
             return False
         return super().has_delete_permission(request=request, obj=obj)

--- a/src/olympia/promoted/models.py
+++ b/src/olympia/promoted/models.py
@@ -11,7 +11,7 @@ from olympia.versions.models import Version
 
 class PromotedAddon(ModelBase):
     GROUP_CHOICES = [(group.id, group.name) for group in PROMOTED_GROUPS]
-    APPLICATION_CHOICES = ((None, 'All'),) + APPS_CHOICES
+    APPLICATION_CHOICES = ((None, 'All Applications'),) + APPS_CHOICES
     group_id = models.SmallIntegerField(
         choices=GROUP_CHOICES, default=NOT_PROMOTED.id, verbose_name='Group',
         help_text='Can be set to Not Promoted to disable promotion without '

--- a/src/olympia/promoted/tests/test_admin.py
+++ b/src/olympia/promoted/tests/test_admin.py
@@ -62,8 +62,7 @@ class TestPromotedAddonAdmin(TestCase):
         assert self.list_url in response.content.decode('utf-8')
 
     def test_can_list_with_discovery_edit_permission(self):
-        pro = PromotedAddon.objects.create(addon=addon_factory(name='FooBâr'))
-        PrimaryHero.objects.create(promoted_addon=pro)
+        PromotedAddon.objects.create(addon=addon_factory(name='FooBâr'))
         user = user_factory()
         self.grant_permission(user, 'Admin:Tools')
         self.grant_permission(user, 'Discovery:Edit')


### PR DESCRIPTION
fixes #15028 - the queryset lookup is unoptimized (just copied from DiscoveryItemAdmin to skip some of the default transforms on Addon) because addressing that turned out to be a rabbit hole so will be in a follow-up.