### PR TITLE
'Cancel and disable version' should ask for confirmation

### DIFF
--- a/src/olympia/devhub/templates/devhub/addons/submit/base.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/base.html
@@ -24,4 +24,21 @@
 <section class="addon-submission-process" role="main">
   {% block primary %}{% endblock %}
 </section>
+
+<div id="modals">
+  <div id="modal-confirm-submission-cancel" class="modal modal-confirm-submission-cancel">
+      <form method="POST" action="#">
+          <h3>{{ _("Cancel and Disable Version") }}</h3>
+          <p>
+              {% trans %}
+                Are you sure you wish to cancel and disable version?
+              {% endtrans %}
+          </p>
+          <div class="modal-actions">
+              <button class="delete-button" type="submit">{{ _("Yes, Cancel") }}</button>
+              <a href="#" class="close">{{ _("No, don't cancel") }}</a>
+          </div>
+      </form>
+  </div>
+</div>
 {% endblock content %}

--- a/src/olympia/devhub/templates/devhub/addons/submit/describe.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/describe.html
@@ -239,7 +239,9 @@
         {{ _('Submit Version') }}
       </button>
       &nbsp;
-      <button class="delete-button" formnovalidate  type="submit"
+      <button class="button delete-button confirm-submission-cancel"
+              formnovalidate
+              type="button"
               formaction="{{ url('devhub.addons.cancel', addon.slug) }}">
           {{ _('Cancel and Disable Version') }}
       </button>

--- a/src/olympia/devhub/templates/devhub/addons/submit/describe_minimal.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/describe_minimal.html
@@ -41,7 +41,9 @@
         {{ _('Submit Version') }}
       </button>
       &nbsp;
-      <button class="delete-button" formnovalidate  type="submit"
+      <button class="button delete-button confirm-submission-cancel"
+              formnovalidate
+              type="button"
               formaction="{{ url('devhub.addons.cancel', addon.slug) }}">
           {{ _('Cancel and Disable Version') }}
       </button>

--- a/src/olympia/devhub/templates/devhub/addons/submit/source.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/source.html
@@ -90,7 +90,9 @@
         {{ _('Continue') }}
       </button>
       &nbsp;
-      <button class="delete-button" formnovalidate  type="submit"
+      <button class="button delete-button confirm-submission-cancel"
+              formnovalidate
+              type="button"
               formaction="{{ url('devhub.addons.cancel', addon.slug) }}">
           {{ _('Cancel and Disable Version') }}
       </button>

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -741,6 +741,7 @@ function initSubmit() {
   $('#id_slug').each(slugify);
   showNameSummaryCroppingWarnings();
   reorderPreviews();
+  initSubmitModals();
   $('.invisible-upload [disabled]').prop('disabled', false);
   $('.invisible-upload .disabled').removeClass('disabled');
 }
@@ -1402,4 +1403,37 @@ function initSourceSubmitOutcomes() {
       }
     });
   });
+}
+
+function initSubmitModals() {
+  // Called during the submit addon step
+
+  // Hide the primary container of all modals
+  $('#modals').hide();
+
+  // Used by "Cancel and disable version" button during submission process
+  if ($('#modal-confirm-submission-cancel').length > 0) {
+    var $modalForm = $('#modal-confirm-submission-cancel'),
+      $modalDelete = $modalForm.modal('.confirm-submission-cancel', {
+        width: 400,
+      });
+
+    // Submitting the form in the modal is not useful. Instead, after
+    // receiving user confirmation, form that contains the
+    // "confirm-submission-cancel" button should POST to an alternate URL
+    $modalForm.find('form').on('submit', function onSubmit(e) {
+      e.preventDefault();
+
+      // this alternate URL is stored in this modal's submit button
+      // so change the form action attribute and submit it
+      var $confirmButton = $('.confirm-submission-cancel'),
+        $mainForm = $confirmButton.closest('form'),
+        cancelUrl = $confirmButton.attr('formaction');
+
+      $mainForm.attr('action', cancelUrl);
+      $mainForm.trigger('submit');
+
+      return false; // don't follow the a.href link
+    });
+  }
 }


### PR DESCRIPTION
Fixes #10314

Old PR was closed due to inactivity (#14144)

Added a modal for confirmation when user clicks on "Cancel and disable version"
button during addon submission process. There were three pages where this
button was visible, and tested those pages work.

This PR relates to an existing open issue and there are no existing
PRs open for the same issue.
Add a description of the changes introduced in this PR.
The change has been successfully run locally.

    Add tests to cover the changes added in this PR.

    Could not find tests for UI change in developer submission pages. Please advice.

Add before and after screenshots (Only for changes that impact the UI).
cancel-and-disable

![image](https://user-images.githubusercontent.com/676751/89172443-2ca1a300-d572-11ea-86ab-801eee0cbc37.png)
