### PR TITLE
Set `SameSite` attribute on API token cookie when deleting it

### DIFF
--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -1476,7 +1476,15 @@ class TestAccountViewSetDelete(TestCase):
         response = self.client.delete(self.url)
         assert response.status_code == 204
         assert response.cookies[views.API_TOKEN_COOKIE].value == ''
+        assert (
+            response.cookies[views.API_TOKEN_COOKIE].get('samesite') ==
+            settings.SESSION_COOKIE_SAMESITE
+        )
         assert response.cookies[settings.SESSION_COOKIE_NAME].value == ''
+        assert (
+            response.cookies[settings.SESSION_COOKIE_NAME].get('samesite') ==
+            settings.SESSION_COOKIE_SAMESITE
+        )
         assert 'dontremoveme' not in response.cookies
         assert self.client.cookies[views.API_TOKEN_COOKIE].value == ''
         assert self.client.cookies[settings.SESSION_COOKIE_NAME].value == ''

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -403,7 +403,9 @@ class AuthenticateView(FxAConfigMixin, APIView):
 def logout_user(request, response):
     logout(request)
     response.delete_cookie(
-        API_TOKEN_COOKIE, domain=settings.SESSION_COOKIE_DOMAIN)
+        API_TOKEN_COOKIE,
+        domain=settings.SESSION_COOKIE_DOMAIN,
+        samesite=settings.SESSION_COOKIE_SAMESITE)
 
 
 # This view is not covered by the CORS middleware, see:


### PR DESCRIPTION
Fixes #15165