### PR TITLE
Revert "Update dependency terser to v5 (#15136)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5632,9 +5632,9 @@
       }
     },
     "terser": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.0.0.tgz",
-      "integrity": "sha512-olH2DwGINoSuEpSGd+BsPuAQaA3OrHnHnFL/rDB2TVNc3srUbz/rq/j2BlF4zDXI+JqAvGr86bIm1R2cJgZ3FA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
+      "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
       "requires": {
         "commander": "^2.20.0",
         "source-map": "~0.6.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "jszip": "3.5.0",
     "less": "3.12.2",
     "source-map": "0.7.3",
-    "terser": "5.0.0",
+    "terser": "4.8.0",
     "timeago": "1.6.7",
     "underscore": "1.10.2"
   },


### PR DESCRIPTION
This reverts commit 07d33ac6062ac3cc3e866abf924c9c060bf7cd4b.

Fixes https://github.com/mozilla/addons-server/issues/15173, maybe