### PR TITLE
Replace deprecated log.warn by log.warning

### DIFF
--- a/src/olympia/activity/utils.py
+++ b/src/olympia/activity/utils.py
@@ -174,7 +174,7 @@ def add_email_to_activity_log(parser):
                 'have to be a listed developer currently, or an AMO reviewer.')
     else:
         log.warning('%s tried to use an invalid activity email token for '
-                 'version %s.', user.email, version.id)
+                    'version %s.', user.email, version.id)
         reason = ('it\'s for an old version of the addon'
                   if not token.is_expired() else
                   'there have been too many replies')

--- a/src/olympia/activity/utils.py
+++ b/src/olympia/activity/utils.py
@@ -173,7 +173,7 @@ def add_email_to_activity_log(parser):
                 'You don\'t have permission to reply to this add-on. You '
                 'have to be a listed developer currently, or an AMO reviewer.')
     else:
-        log.warn('%s tried to use an invalid activity email token for '
+        log.warning('%s tried to use an invalid activity email token for '
                  'version %s.', user.email, version.id)
         reason = ('it\'s for an old version of the addon'
                   if not token.is_expired() else

--- a/src/olympia/addons/management/commands/fix_langpacks_with_max_version_star.py
+++ b/src/olympia/addons/management/commands/fix_langpacks_with_max_version_star.py
@@ -33,7 +33,7 @@ class Command(BaseCommand):
             min_appversion_str = version.compatible_apps[app].min.version
             max_appversion_str = '%d.*' % version_dict(
                 min_appversion_str)['major']
-            log.warn(
+            log.warning(
                 'Version %s for addon %s min version is %s for %s app, '
                 'max will be changed to %s instead of *',
                 version, version.addon, min_appversion_str, app.pretty,


### PR DESCRIPTION
Quick fix for:
```
  /home/travis/build/wagnerand/addons-server/src/olympia/activity/utils.py:176: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead

    log.warn('%s tried to use an invalid activity email token for '
```