### PR TITLE
Fixes #15201 : Modify account deletion email to mention FxA deletion.

### DIFF
--- a/src/olympia/users/templates/users/emails/user_deleted.ltxt
+++ b/src/olympia/users/templates/users/emails/user_deleted.ltxt
@@ -1,6 +1,6 @@
 {% load i18n %}{# L10n: This is an email. Whitespace matters! #}{% blocktrans %}Hello,
 
-You’re receiving this message because your user account {{ name }} on {{ site_url }} has been deleted.
+You’re receiving this message because your user account {{ name }} on {{ site_url }} has been deleted. This could have been done automatically if you recently deleted your Firefox Account.
 
 If you didn’t do this or believe an unauthorized person has accessed your account, please reply to this email. Otherwise, there’s no further action to take.
 


### PR DESCRIPTION
Since, Firefox Account deletion can trigger AMO account deltion, This commit updates account deletion email to mention FxA deletion to make the text less suprising.

Fixes #15201