### PR TITLE
Removes  `local-staticstics-processing` waffle flag

### DIFF
--- a/src/olympia/addons/cron.py
+++ b/src/olympia/addons/cron.py
@@ -35,9 +35,6 @@ task_log = olympia.core.logger.getLogger('z.task')
 
 def update_addon_average_daily_users(chunk_size=250):
     """Update add-ons ADU totals."""
-    if not waffle.switch_is_active('local-statistics-processing'):
-        return False
-
     counts = dict(
         # In order to reset the `average_daily_users` values of add-ons that
         # don't exist in BigQuery, we prepare a set of `(guid, 0)` for most
@@ -67,9 +64,6 @@ def update_addon_average_daily_users(chunk_size=250):
 
 def update_addon_total_downloads():
     """Update add-on total and average downloads."""
-    if not waffle.switch_is_active('local-statistics-processing'):
-        return False
-
     if waffle.switch_is_active('use-bigquery-for-download-stats-cron'):
         log.info('Not running `update_addon_total_downloads()` because waffle '
                  'switch is active.')
@@ -228,9 +222,6 @@ def update_addon_weekly_downloads(chunk_size=250):
     """
     Update 7-day add-on download counts.
     """
-    if not waffle.switch_is_active('local-statistics-processing'):
-        return False
-
     if waffle.switch_is_active('use-bigquery-for-download-stats-cron'):
         counts = dict(
             # In order to reset the `weekly_downloads` values of add-ons that

--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -2,8 +2,6 @@ import hashlib
 
 from django.db import transaction
 
-import waffle
-
 from elasticsearch_dsl import Search
 
 import olympia.core

--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -84,9 +84,6 @@ def update_appsupport(ids, **kw):
 def update_addon_average_daily_users(data, **kw):
     log.info("[%s] Updating add-ons ADU totals." % (len(data)))
 
-    if not waffle.switch_is_active('local-statistics-processing'):
-        return False
-
     for addon_guid, count in data:
         try:
             addon = Addon.objects.get(guid=addon_guid)
@@ -103,9 +100,6 @@ def update_addon_average_daily_users(data, **kw):
 @task
 def update_addon_total_downloads(data, **kw):
     log.info('[%s] Updating add-ons download+average totals.' % (len(data)))
-
-    if not waffle.switch_is_active('local-statistics-processing'):
-        return False
 
     for pk, sum_download_counts in data:
         try:

--- a/src/olympia/addons/tests/test_cron.py
+++ b/src/olympia/addons/tests/test_cron.py
@@ -269,8 +269,6 @@ class TestAvgDailyUserCountTestCase(TestCase):
     def setUp(self):
         super().setUp()
 
-        self.create_switch('local-statistics-processing')
-
     @mock.patch(
         'olympia.addons.cron.get_addons_and_average_daily_users_from_bigquery'
     )
@@ -489,7 +487,6 @@ class TestUpdateAddonWeeklyDownloads(TestCase):
     def setUp(self):
         super().setUp()
 
-        self.create_switch('local-statistics-processing')
         self.create_switch('use-bigquery-for-download-stats-cron')
 
     @mock.patch('olympia.addons.cron.create_chunked_tasks_signatures')

--- a/src/olympia/addons/tests/test_tasks.py
+++ b/src/olympia/addons/tests/test_tasks.py
@@ -86,7 +86,6 @@ def test_create_missing_theme_previews(parse_addon_mock):
 
 
 @pytest.mark.django_db
-@override_switch('local-statistics-processing', active=True)
 def test_update_addon_average_daily_users():
     addon = addon_factory(average_daily_users=0)
     count = 123
@@ -133,7 +132,6 @@ def test_update_addon_hotness():
     assert addon3.hotness == 123
 
 
-@override_switch('local-statistics-processing', active=True)
 def test_update_addon_weekly_downloads():
     addon = addon_factory(weekly_downloads=0)
     count = 123
@@ -146,7 +144,6 @@ def test_update_addon_weekly_downloads():
     assert addon.weekly_downloads == count
 
 
-@override_switch('local-statistics-processing', active=True)
 def test_update_addon_weekly_downloads_skips_non_existent_addons():
     addon = addon_factory(weekly_downloads=0)
     count = 123

--- a/src/olympia/addons/tests/test_tasks.py
+++ b/src/olympia/addons/tests/test_tasks.py
@@ -3,7 +3,6 @@ import os
 import pytest
 
 from django.conf import settings
-from waffle.testutils import override_switch
 
 from olympia import amo
 from olympia.addons.tasks import (recreate_theme_previews,

--- a/src/olympia/stats/cron.py
+++ b/src/olympia/stats/cron.py
@@ -2,8 +2,6 @@ import datetime
 
 from django.core.management import call_command
 
-import waffle
-
 import olympia.core.logger
 from olympia.lib.es.utils import raise_if_reindex_in_progress
 
@@ -14,9 +12,6 @@ log = olympia.core.logger.getLogger('z.cron')
 
 
 def index_latest_stats(index=None):
-    if not waffle.switch_is_active('local-statistics-processing'):
-        return False
-
     def fmt(d):
         return d.strftime('%Y-%m-%d')
 

--- a/src/olympia/stats/templates/stats/stats.html
+++ b/src/olympia/stats/templates/stats/stats.html
@@ -89,15 +89,6 @@
 {% endblock %}
 
 {% block content %}
-  {% if not waffle.switch('local-statistics-processing') %}
-  <div class="notification-box warning">
-    {% trans %}
-      Statistics processing is currently disabled, so recent data is unavailable.
-      The statistics are still being collected and this page will be updated soon with the missing data.
-    {% endtrans %}
-  </div>
-  {% endif %}
-
   <div id="lm" class="loadmessage"><span>{{ _('Loading the latest data&hellip;') }}</span></div>
   <div class="secondary">
     {% if addon %}

--- a/src/olympia/stats/tests/test_cron.py
+++ b/src/olympia/stats/tests/test_cron.py
@@ -76,7 +76,6 @@ class TestIndexStats(TestCase):
 class TestIndexLatest(amo.tests.ESTestCase):
 
     def test_index_latest(self):
-        self.create_switch('local-statistics-processing')
         latest = datetime.date.today() - datetime.timedelta(days=5)
         DownloadCount.index({'date': latest})
         self.refresh('stats_download_counts')


### PR DESCRIPTION
Fixes #15216 
This PR removes `local-statistics-processing` flag and related usages. 