### PR TITLE
In reindexation tests, refresh all indices to avoid intermittent failures

### DIFF
--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -942,11 +942,7 @@ class ESTestCase(TestCase):
 
     @classmethod
     def refresh(cls, index='default'):
-        if index in settings.ES_INDEXES:
-            target = settings.ES_INDEXES[index]
-        else:
-            target = index
-        cls.es.indices.refresh(target)
+        cls.es.indices.refresh(settings.ES_INDEXES.get(index, index))
 
     @classmethod
     def reindex(cls, model, index='default'):

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -942,7 +942,11 @@ class ESTestCase(TestCase):
 
     @classmethod
     def refresh(cls, index='default'):
-        cls.es.indices.refresh(settings.ES_INDEXES[index])
+        if index in settings.ES_INDEXES:
+            target = settings.ES_INDEXES[index]
+        else:
+            target = index
+        cls.es.indices.refresh(target)
 
     @classmethod
     def reindex(cls, model, index='default'):

--- a/src/olympia/lib/es/tests/test_commands.py
+++ b/src/olympia/lib/es/tests/test_commands.py
@@ -130,7 +130,9 @@ class TestIndexCommand(ESTestCase):
                 self.expected.append(addon_factory())
                 connection._commit()
                 connection.clean_savepoints()
-                self.refresh()
+                # We don't know where the search will happen, the reindexing
+                # could be over by now. So force a refresh on *all* indices.
+                self.refresh(None)
                 self.check_results(self.expected)
 
             if len(self.expected) == old_addons_count:


### PR DESCRIPTION
If we only refresh the default index, by the time we check results we might have switched to a new default index that hasn't been refreshed yet (this happens in parallel, as the reindex is done asynchronously). To avoid this, refresh all indices inside `_test_reindexation()` before checking results.

Fixes #14467 (hopefully)