### PR TITLE
RE: Build an API endpoint for shelves

### DIFF
--- a/src/olympia/api/urls.py
+++ b/src/olympia/api/urls.py
@@ -32,6 +32,7 @@ v4_api_urls = [
     url(r'^', include('olympia.signing.urls')),
     url(r'^', include(amo_api_patterns)),
     url(r'^scanner/', include('olympia.scanners.api_urls')),
+    url(r'^shelves/', include('olympia.shelves.urls')),
 ]
 
 urlpatterns = [

--- a/src/olympia/shelves/serializers.py
+++ b/src/olympia/shelves/serializers.py
@@ -14,13 +14,16 @@ class ShelfSerializer(serializers.ModelSerializer):
         fields = ['title', 'url', 'footer_text', 'footer_pathname']
 
     def get_url(self, obj):
-        baseUrl = settings.INTERNAL_SITE_URL
         if obj.endpoint == 'search':
-            api = drf_reverse('v4:addon-search')
-            url = baseUrl + api + obj.criteria
+            api = drf_reverse(
+                'addon-search',
+                request=self.context.get('request'))
+            url = api + obj.criteria
         elif obj.endpoint == 'collections':
-            api = drf_reverse('v4:collection-addon-list', kwargs={
-                'user_pk': settings.TASK_USER_ID,
-                'collection_slug': obj.criteria})
-            url = baseUrl + api
+            url = drf_reverse(
+                'collection-addon-list',
+                request=self.context.get('request'),
+                kwargs={
+                    'user_pk': settings.TASK_USER_ID,
+                    'collection_slug': obj.criteria})
         return url

--- a/src/olympia/shelves/serializers.py
+++ b/src/olympia/shelves/serializers.py
@@ -1,18 +1,26 @@
 from rest_framework import serializers
+from rest_framework.reverse import reverse as drf_reverse
 
-from olympia.shelves.models import Shelf, ShelfManagement
+from django.conf import settings
+
+from olympia.shelves.models import Shelf
 
 
 class ShelfSerializer(serializers.ModelSerializer):
+    url = serializers.SerializerMethodField()
+
     class Meta:
         model = Shelf
-        fields = ['id', 'title', 'endpoint', 'criteria',
-                  'footer_text', 'footer_pathname']
+        fields = ['title', 'url', 'footer_text', 'footer_pathname']
 
-
-class HomepageSerializer(serializers.ModelSerializer):
-    shelf = ShelfSerializer(required=True)
-
-    class Meta:
-        model = ShelfManagement
-        fields = ['position', 'shelf', 'enabled']
+    def get_url(self, obj):
+        baseUrl = settings.INTERNAL_SITE_URL
+        if obj.endpoint == 'search':
+            api = drf_reverse('v4:addon-search')
+            url = baseUrl + api + obj.criteria
+        elif obj.endpoint == 'collections':
+            api = drf_reverse('v4:collection-addon-list', kwargs={
+                'user_pk': settings.TASK_USER_ID,
+                'collection_slug': obj.criteria})
+            url = baseUrl + api
+        return url

--- a/src/olympia/shelves/serializers.py
+++ b/src/olympia/shelves/serializers.py
@@ -1,0 +1,18 @@
+from rest_framework import serializers
+
+from olympia.shelves.models import Shelf, ShelfManagement
+
+
+class ShelfSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Shelf
+        fields = ['id', 'title', 'endpoint', 'criteria',
+                  'footer_text', 'footer_pathname']
+
+
+class HomepageSerializer(serializers.ModelSerializer):
+    shelf = ShelfSerializer(required=True)
+
+    class Meta:
+        model = ShelfManagement
+        fields = ['position', 'shelf', 'enabled']

--- a/src/olympia/shelves/tests/test_serializers.py
+++ b/src/olympia/shelves/tests/test_serializers.py
@@ -1,6 +1,10 @@
+from rest_framework.reverse import reverse as drf_reverse
+
+from django.conf import settings
+
 from olympia.amo.tests import TestCase
-from olympia.shelves.models import Shelf, ShelfManagement
-from olympia.shelves.serializers import ShelfSerializer, HomepageSerializer
+from olympia.shelves.models import Shelf
+from olympia.shelves.serializers import ShelfSerializer
 
 
 class TestShelvesSerializer(TestCase):
@@ -8,28 +12,16 @@ class TestShelvesSerializer(TestCase):
         self.shelf = Shelf.objects.create(
             title='Populâr themes',
             endpoint='search',
-            criteria='?sort=users&type=statictheme')
-        self.hpshelf = ShelfManagement.objects.create(
-            position=0,
-            shelf=self.shelf,
-            enabled=False)
+            criteria='?sort=users&type=statictheme',
+            footer_text='See more populâr themes')
 
     def test_shelf_serializer(self):
         serializer = ShelfSerializer(instance=self.shelf)
         assert serializer.data == {
-            'id': self.shelf.id,
             'title': 'Populâr themes',
-            'endpoint': 'search',
-            'criteria': '?sort=users&type=statictheme',
-            'footer_text': '',
+            'url': (settings.INTERNAL_SITE_URL +
+                    drf_reverse('v4:addon-search') +
+                    self.shelf.criteria),
+            'footer_text': 'See more populâr themes',
             'footer_pathname': '',
-        }
-
-    def test_homepage_serializer(self):
-        serializer = HomepageSerializer(instance=self.hpshelf)
-        serialized_shelf = ShelfSerializer(self.shelf).data
-        assert serializer.data == {
-            'shelf': serialized_shelf,
-            'position': 0,
-            'enabled': False
         }

--- a/src/olympia/shelves/tests/test_serializers.py
+++ b/src/olympia/shelves/tests/test_serializers.py
@@ -1,27 +1,58 @@
-from rest_framework.reverse import reverse as drf_reverse
+from rest_framework.settings import api_settings
+from rest_framework.test import APIRequestFactory
 
 from django.conf import settings
 
-from olympia.amo.tests import TestCase
+from olympia.amo.tests import TestCase, reverse_ns
 from olympia.shelves.models import Shelf
 from olympia.shelves.serializers import ShelfSerializer
 
 
 class TestShelvesSerializer(TestCase):
     def setUp(self):
-        self.shelf = Shelf.objects.create(
+        self.search_shelf = Shelf.objects.create(
             title='Populâr themes',
             endpoint='search',
             criteria='?sort=users&type=statictheme',
             footer_text='See more populâr themes')
 
-    def test_shelf_serializer(self):
-        serializer = ShelfSerializer(instance=self.shelf)
-        assert serializer.data == {
+        self.collections_shelf = Shelf.objects.create(
+            title='Enhanced privacy extensions',
+            endpoint='collections',
+            criteria='privacy-matters',
+            footer_text='See more enhanced privacy extensions')
+
+        # Set up the request to support drf_reverse
+        api_version = api_settings.DEFAULT_VERSION
+        self.request = APIRequestFactory().get('/api/%s/' % api_version)
+        self.request.versioning_scheme = (
+            api_settings.DEFAULT_VERSIONING_CLASS()
+        )
+        self.request.version = api_version
+
+    def get_serializer(self, instance, **extra_context):
+        extra_context['request'] = self.request
+        return ShelfSerializer(instance=instance, context=extra_context)
+
+    def serialize(self, instance, **extra_context):
+        return self.get_serializer(instance, **extra_context).data
+
+    def test_shelf_serializer_search(self):
+        data = self.serialize(instance=self.search_shelf)
+        search_url = reverse_ns('addon-search') + self.search_shelf.criteria
+        assert data == {
             'title': 'Populâr themes',
-            'url': (settings.INTERNAL_SITE_URL +
-                    drf_reverse('v4:addon-search') +
-                    self.shelf.criteria),
+            'url': search_url,
             'footer_text': 'See more populâr themes',
-            'footer_pathname': '',
-        }
+            'footer_pathname': ''}
+
+    def test_shelf_serializer_collections(self):
+        data = self.serialize(instance=self.collections_shelf)
+        collections_url = reverse_ns('collection-addon-list', kwargs={
+            'user_pk': settings.TASK_USER_ID,
+            'collection_slug': self.collections_shelf.criteria})
+        assert data == {
+            'title': 'Enhanced privacy extensions',
+            'url': collections_url,
+            'footer_text': 'See more enhanced privacy extensions',
+            'footer_pathname': ''}

--- a/src/olympia/shelves/tests/test_serializers.py
+++ b/src/olympia/shelves/tests/test_serializers.py
@@ -1,0 +1,35 @@
+from olympia.amo.tests import TestCase
+from olympia.shelves.models import Shelf, ShelfManagement
+from olympia.shelves.serializers import ShelfSerializer, HomepageSerializer
+
+
+class TestShelvesSerializer(TestCase):
+    def setUp(self):
+        self.shelf = Shelf.objects.create(
+            title='Populâr themes',
+            endpoint='search',
+            criteria='?sort=users&type=statictheme')
+        self.hpshelf = ShelfManagement.objects.create(
+            position=0,
+            shelf=self.shelf,
+            enabled=False)
+
+    def test_shelf_serializer(self):
+        serializer = ShelfSerializer(instance=self.shelf)
+        assert serializer.data == {
+            'id': self.shelf.id,
+            'title': 'Populâr themes',
+            'endpoint': 'search',
+            'criteria': '?sort=users&type=statictheme',
+            'footer_text': '',
+            'footer_pathname': '',
+        }
+
+    def test_homepage_serializer(self):
+        serializer = HomepageSerializer(instance=self.hpshelf)
+        serialized_shelf = ShelfSerializer(self.shelf).data
+        assert serializer.data == {
+            'shelf': serialized_shelf,
+            'position': 0,
+            'enabled': False
+        }

--- a/src/olympia/shelves/tests/test_views.py
+++ b/src/olympia/shelves/tests/test_views.py
@@ -6,7 +6,7 @@ from olympia.shelves.models import Shelf, ShelfManagement
 
 class TestShelfViewSet(TestCase):
     def setUp(self):
-        self.url = reverse_ns('shelves-list', api_version='v4')
+        self.url = reverse_ns('shelves-list')
 
     def test_basic(self):
         response = self.client.get(self.url)

--- a/src/olympia/shelves/tests/test_views.py
+++ b/src/olympia/shelves/tests/test_views.py
@@ -1,0 +1,68 @@
+import json
+
+from olympia.amo.tests import TestCase, reverse_ns
+from olympia.shelves.models import Shelf, ShelfManagement
+
+
+class TestShelfViewSet(TestCase):
+    def setUp(self):
+        self.url = reverse_ns('shelves-list', api_version='v4')
+
+    def test_basic(self):
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        assert response.json() == {
+            'count': 0,
+            'next': None,
+            'page_count': 1,
+            'page_size': 25,
+            'previous': None,
+            'results': []}
+
+        shelf_a = Shelf.objects.create(
+            title='Recommended extensions',
+            endpoint='search',
+            criteria='?recommended=true&sort=random&type=extension',
+            footer_text='See more recommended extensions')
+        shelf_b = Shelf.objects.create(
+            title='Enhanced privacy extensions',
+            endpoint='collections',
+            criteria='privacy-matters',
+            footer_text='See more enhanced privacy extensions')
+        shelf_c = Shelf.objects.create(
+            title='Popular themes',
+            endpoint='search',
+            criteria='?sort=users&type=statictheme',
+            footer_text='See more popular themes')
+
+        hpshelf_a = ShelfManagement.objects.create(
+            shelf=shelf_a,
+            position=3)
+        hpshelf_b = ShelfManagement.objects.create(
+            shelf=shelf_b,
+            position=2)
+        ShelfManagement.objects.create(
+            shelf=shelf_c,
+            position=1)
+
+        # The shelves aren't enabled so they won't show up
+        response = self.client.get(self.url)
+        assert response.json() == {
+            'count': 0,
+            'next': None,
+            'page_count': 1,
+            'page_size': 25,
+            'previous': None,
+            'results': []}
+
+        hpshelf_a.update(enabled=True)
+        hpshelf_b.update(enabled=True)
+        # don't enable the last homepage shelf
+        with self.assertNumQueries(4):
+            response = self.client.get(self.url)
+        assert response.status_code == 200
+        result = json.loads(response.content)
+
+        assert len(result['results']) == 2
+        assert result['results'][0]['title'] == 'Enhanced privacy extensions'
+        assert result['results'][1]['title'] == 'Recommended extensions'

--- a/src/olympia/shelves/urls.py
+++ b/src/olympia/shelves/urls.py
@@ -1,0 +1,12 @@
+from django.conf.urls import include, url
+
+from rest_framework.routers import SimpleRouter
+
+from olympia.shelves.views import ShelfViewSet
+
+router = SimpleRouter()
+router.register('', ShelfViewSet, basename='shelves')
+
+urlpatterns = [
+    url(r'', include(router.urls)),
+]

--- a/src/olympia/shelves/views.py
+++ b/src/olympia/shelves/views.py
@@ -1,0 +1,13 @@
+from rest_framework import permissions, viewsets
+
+from olympia.shelves.models import ShelfManagement
+from olympia.shelves.serializers import HomepageSerializer
+
+
+class ShelfViewSet(viewsets.ModelViewSet):
+    queryset = ShelfManagement.objects.all()
+    permission_classes = [
+        permissions.AllowAny
+    ]
+
+    serializer_class = HomepageSerializer

--- a/src/olympia/shelves/views.py
+++ b/src/olympia/shelves/views.py
@@ -1,13 +1,12 @@
-from rest_framework import permissions, viewsets
+from rest_framework import viewsets
 
-from olympia.shelves.models import ShelfManagement
-from olympia.shelves.serializers import HomepageSerializer
+from olympia.shelves.models import Shelf
+from olympia.shelves.serializers import ShelfSerializer
 
 
 class ShelfViewSet(viewsets.ModelViewSet):
-    queryset = ShelfManagement.objects.all()
-    permission_classes = [
-        permissions.AllowAny
-    ]
+    queryset = Shelf.objects.filter(
+        shelfmanagement__enabled=True).order_by('shelfmanagement__position')
+    permission_classes = []
 
-    serializer_class = HomepageSerializer
+    serializer_class = ShelfSerializer


### PR DESCRIPTION
Fixes #14873 
** Currently failing Travis, as it is dependent on the migration file in #15242 **

This pull request builds an API endpoint (`/api/v4/shelves/` - or should this be `/api/shelves`?) that represents a list of shelves to appear on the AMO homepage.

I'm not 100% sure about the value for `permission_classes` within `shelves/views.py`.

Please review when you have a moment. Thank you!