### PR TITLE
replaces `make_addon_recommended` with `make_addon_promoted` in tests

### DIFF
--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -1555,7 +1555,7 @@ class TestAddonModels(TestCase):
         # default case - no discovery item so not recommended
         assert not addon.is_recommended
 
-        self.make_addon_recommended(addon, approve_version=True)
+        self.make_addon_promoted(addon, RECOMMENDED, approve_version=True)
         del addon.is_recommended
         # It's a recommended group promoted addon;
         # and the latest version is approved too.
@@ -1588,7 +1588,7 @@ class TestAddonModels(TestCase):
         # default case - no discovery item so not recommended
         assert not addon.is_recommended
 
-        self.make_addon_recommended(addon, approve_version=True)
+        self.make_addon_promoted(addon, RECOMMENDED, approve_version=True)
         del addon.is_recommended
         # It's a recommended group promoted addon;
         # and the latest version is approved too.

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -26,6 +26,7 @@ from olympia.amo.tests import (
 from olympia.amo.urlresolvers import get_outgoing_url, reverse
 from olympia.bandwagon.models import CollectionAddon
 from olympia.constants.categories import CATEGORIES, CATEGORIES_BY_ID
+from olympia.constants.promoted import RECOMMENDED
 from olympia.discovery.models import DiscoveryItem
 from olympia.users.models import UserProfile
 from olympia.versions.models import ApplicationsVersions, AppVersion
@@ -1778,8 +1779,8 @@ class TestAddonSearchView(ESTestCase):
         assert ids == [addon1.id, addon2.id, addon3.id, addon4.id, addon5.id]
 
         # Now made some of the add-ons recommended
-        self.make_addon_recommended(addon2, approve_version=True)
-        self.make_addon_recommended(addon4, approve_version=True)
+        self.make_addon_promoted(addon2, RECOMMENDED, approve_version=True)
+        self.make_addon_promoted(addon4, RECOMMENDED, approve_version=True)
         self.refresh()
 
         data = self.perform_search(self.url)  # No query.

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -588,10 +588,6 @@ class TestCase(PatchMixin, InitializeSessionMixin, test.TestCase):
                 manager='unfiltered_for_relations').all():
             version.update(channel=channel)
 
-    def make_addon_recommended(self, addon, approve_version=False):
-        self.make_addon_promoted(
-            addon, RECOMMENDED, approve_version=approve_version)
-
     def make_addon_promoted(self, addon, group, approve_version=False):
         _, created = PromotedAddon.objects.update_or_create(
             addon=addon, defaults={'group_id': group.id})

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -532,7 +532,7 @@ class TestHome(TestCase):
             '.DevHub-MyAddons-list .DevHub-MyAddons-item').length == 0
 
     def test_my_addons_recommended(self):
-        self.make_addon_recommended(self.addon)
+        self.make_addon_promoted(self.addon, RECOMMENDED)
         latest_version = self.addon.find_latest_version(
             amo.RELEASE_CHANNEL_LISTED)
         latest_file = latest_version.files.all()[0]

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -164,7 +164,7 @@ class TestVersion(TestCase):
     def test_cant_disable_or_delete_current_version_recommended(self):
         # If the add-on is recommended you can't disable or delete the current
         # version.
-        self.make_addon_recommended(self.addon, approve_version=True)
+        self.make_addon_promoted(self.addon, RECOMMENDED, approve_version=True)
         assert self.version == self.addon.current_version
         self.client.post(self.delete_url, self.delete_data)
         assert Version.objects.filter(pk=81551).exists()
@@ -186,7 +186,7 @@ class TestVersion(TestCase):
     def test_can_disable_or_delete_current_ver_if_previous_recommended(self):
         # If the add-on is recommended you *can* disable or delete the current
         # version if the previous version is approved for recommendation too.
-        self.make_addon_recommended(self.addon)
+        self.make_addon_promoted(self.addon, RECOMMENDED)
         previous_version = self.version
         PromotedApproval.objects.create(
             version=previous_version, group_id=RECOMMENDED.id)
@@ -221,7 +221,7 @@ class TestVersion(TestCase):
     def test_can_still_disable_or_delete_old_version_recommended(self):
         # If the add-on is recommended, you can still disable or delete older
         # versions than the current one.
-        self.make_addon_recommended(self.addon)
+        self.make_addon_promoted(self.addon, RECOMMENDED)
         PromotedApproval.objects.create(
             version=self.version, group_id=RECOMMENDED.id)
         version_factory(addon=self.addon, recommendation_approved=True)
@@ -248,7 +248,7 @@ class TestVersion(TestCase):
     def test_can_still_disable_or_delete_current_version_unapproved(self):
         # If the add-on is in recommended group but hasn't got approval yet,
         # then deleting the current version is fine.
-        self.make_addon_recommended(self.addon)
+        self.make_addon_promoted(self.addon, RECOMMENDED)
         assert self.version == self.addon.current_version
 
         self.delete_data['disable_version'] = ''

--- a/src/olympia/reviewers/tests/test_models.py
+++ b/src/olympia/reviewers/tests/test_models.py
@@ -251,7 +251,7 @@ class TestRecommendedQueue(TestQueue):
         addon = create_search_ext(
             name, version, amo.STATUS_NOMINATED, amo.STATUS_AWAITING_REVIEW,
             channel=self.channel, **kw)
-        self.make_addon_recommended(addon)
+        self.make_addon_promoted(addon, RECOMMENDED)
         return addon
 
     def test_new_submissions_and_updates_present(self):

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -350,7 +350,7 @@ class TestReviewHelper(TestReviewHelperBase):
 
         # Now make add a recommended promoted addon. The user should lose all
         # approve/reject actions.
-        self.make_addon_recommended(self.addon)
+        self.make_addon_promoted(self.addon, RECOMMENDED)
         expected = ['reply', 'super', 'comment']
         assert list(self.get_review_actions(
             addon_status=amo.STATUS_APPROVED,
@@ -410,7 +410,7 @@ class TestReviewHelper(TestReviewHelperBase):
     def test_actions_recommended(self):
         # Having Addons:PostReview or Addons:Review is not enough to review
         # recommended extensions.
-        self.make_addon_recommended(self.addon)
+        self.make_addon_promoted(self.addon, RECOMMENDED)
         self.grant_permission(self.request.user, 'Addons:PostReview')
         expected = ['reply', 'super', 'comment']
         assert list(self.get_review_actions(
@@ -434,7 +434,7 @@ class TestReviewHelper(TestReviewHelperBase):
     def test_actions_recommended_content_review(self):
         # Having Addons:ContentReview is not enough to content review
         # recommended extensions.
-        self.make_addon_recommended(self.addon)
+        self.make_addon_promoted(self.addon, RECOMMENDED)
         self.grant_permission(self.request.user, 'Addons:ContentReview')
         expected = ['reply', 'super', 'comment']
         assert list(self.get_review_actions(
@@ -1975,7 +1975,7 @@ class TestReviewHelper(TestReviewHelperBase):
             reverse('devhub.addons.versions', args=[self.addon.id]))
 
     def test_nominated_to_approved_recommended(self):
-        self.make_addon_recommended(self.addon)
+        self.make_addon_promoted(self.addon, RECOMMENDED)
         assert not self.addon.is_recommended
         self.test_nomination_to_public()
         del self.addon.is_recommended
@@ -1992,7 +1992,7 @@ class TestReviewHelper(TestReviewHelperBase):
         assert self.addon.promoted_group() == LINE
 
     def test_approved_update_recommended(self):
-        self.make_addon_recommended(self.addon)
+        self.make_addon_promoted(self.addon, RECOMMENDED)
         assert not self.addon.is_recommended
         self.test_public_addon_with_version_awaiting_review_to_public()
         del self.addon.is_recommended
@@ -2171,7 +2171,7 @@ class TestReviewHelperSigning(TestReviewHelperBase):
     def test_nominated_to_public_recommended(self):
         self.setup_data(amo.STATUS_NOMINATED)
 
-        self.make_addon_recommended(self.addon)
+        self.make_addon_promoted(self.addon, RECOMMENDED)
         assert not self.addon.is_recommended
 
         self.helper.handler.approve_latest_version()

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -1768,7 +1768,7 @@ class TestRecommendedQueue(QueueTest):
         self.expected_addons = self.get_expected_addons_by_names(
             ['Pending One', 'Pending Two', 'Nominated One', 'Nominated Two'])
         for addon in self.expected_addons:
-            self.make_addon_recommended(addon)
+            self.make_addon_promoted(addon, RECOMMENDED)
         self.url = reverse('reviewers.queue_recommended')
 
     def test_results(self):
@@ -3124,7 +3124,7 @@ class TestReview(ReviewBase):
         assert self.client.head(self.url).status_code == 200
 
     def test_need_recommended_reviewer_for_recommendable_addon(self):
-        self.make_addon_recommended(self.addon)
+        self.make_addon_promoted(self.addon, RECOMMENDED)
         self.file.update(status=amo.STATUS_AWAITING_REVIEW)
         response = self.client.get(self.url)
         assert response.status_code == 200
@@ -4500,7 +4500,7 @@ class TestReview(ReviewBase):
     def test_approve_recommended_addon(self, mock_sign_file):
         self.version.files.update(status=amo.STATUS_AWAITING_REVIEW)
         self.addon.update(status=amo.STATUS_NOMINATED)
-        self.make_addon_recommended(self.addon)
+        self.make_addon_promoted(self.addon, RECOMMENDED)
         self.grant_permission(self.reviewer, 'Addons:RecommendedReview')
         response = self.client.post(self.url, {
             'action': 'public',

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -686,7 +686,7 @@ class TestVersion(TestCase):
     def test_can_be_disabled_and_deleted_querycount(self):
         addon = Addon.objects.get(id=3615)
         version_factory(addon=addon)
-        self.make_addon_recommended(addon, approve_version=True)
+        self.make_addon_promoted(addon, RECOMMENDED, approve_version=True)
         addon.reload()
         with self.assertNumQueries(3):
             # 1. check the addon's promoted group


### PR DESCRIPTION
fixes #15162 - no functional changes, just some test rewriting.