### PR TITLE
RE: Include the contents of the shelves in the API

### DIFF
--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -382,6 +382,13 @@ class AddonSearchView(ListAPIView):
         view = super(AddonSearchView, cls).as_view(**kwargs)
         return non_atomic_requests(view)
 
+    @property
+    def data(self):
+        self.initial(self.request)
+        queryset = self.filter_queryset(self.get_queryset())
+        serializer = self.get_serializer(queryset, many=True)
+        return serializer.data
+
 
 class AddonAutoCompleteSearchView(AddonSearchView):
     pagination_class = None

--- a/src/olympia/shelves/serializers.py
+++ b/src/olympia/shelves/serializers.py
@@ -1,17 +1,22 @@
+from urllib import parse
+
 from rest_framework import serializers
 from rest_framework.reverse import reverse as drf_reverse
 
 from django.conf import settings
 
+from olympia.addons.views import AddonSearchView
 from olympia.shelves.models import Shelf
 
 
 class ShelfSerializer(serializers.ModelSerializer):
     url = serializers.SerializerMethodField()
+    addons = serializers.SerializerMethodField()
 
     class Meta:
         model = Shelf
-        fields = ['title', 'url', 'footer_text', 'footer_pathname']
+        fields = ['title', 'url', 'endpoint', 'criteria', 'footer_text',
+                  'footer_pathname', 'addons']
 
     def get_url(self, obj):
         if obj.endpoint == 'search':
@@ -30,3 +35,14 @@ class ShelfSerializer(serializers.ModelSerializer):
             url = None
 
         return url
+
+    def get_addons(self, obj):
+        if obj.endpoint == 'search':
+            criteria = obj.criteria.strip('?')
+            params = dict(parse.parse_qsl(criteria))
+            request = self.context.get('request', None)
+            request.GET = request.GET.copy()
+            request.GET.update(params)
+            return AddonSearchView(request=request).data
+        else:
+            return None

--- a/src/olympia/shelves/tests/test_serializers.py
+++ b/src/olympia/shelves/tests/test_serializers.py
@@ -43,8 +43,12 @@ class TestShelvesSerializer(TestCase):
         assert data == {
             'title': 'Populâr themes',
             'url': search_url,
+            'endpoint': self.search_shelf.endpoint,
+            'criteria': self.search_shelf.criteria,
             'footer_text': 'See more populâr themes',
-            'footer_pathname': ''}
+            'footer_pathname': '',
+            'addons': None
+        }
 
     def test_shelf_serializer_collections(self):
         data = self.serialize(instance=self.collections_shelf)
@@ -54,5 +58,9 @@ class TestShelvesSerializer(TestCase):
         assert data == {
             'title': 'Enhanced privacy extensions',
             'url': collections_url,
+            'endpoint': self.collections_shelf.endpoint,
+            'criteria': self.collections_shelf.criteria,
             'footer_text': 'See more enhanced privacy extensions',
-            'footer_pathname': ''}
+            'footer_pathname': '',
+            'addons': None
+        }

--- a/src/olympia/shelves/tests/test_views.py
+++ b/src/olympia/shelves/tests/test_views.py
@@ -1,5 +1,7 @@
 import json
 
+from django.conf import settings
+
 from olympia.amo.tests import TestCase, reverse_ns
 from olympia.shelves.models import Shelf, ShelfManagement
 
@@ -7,17 +9,6 @@ from olympia.shelves.models import Shelf, ShelfManagement
 class TestShelfViewSet(TestCase):
     def setUp(self):
         self.url = reverse_ns('shelves-list')
-
-    def test_basic(self):
-        response = self.client.get(self.url)
-        assert response.status_code == 200
-        assert response.json() == {
-            'count': 0,
-            'next': None,
-            'page_count': 1,
-            'page_size': 25,
-            'previous': None,
-            'results': []}
 
         shelf_a = Shelf.objects.create(
             title='Recommended extensions',
@@ -35,18 +26,25 @@ class TestShelfViewSet(TestCase):
             criteria='?sort=users&type=statictheme',
             footer_text='See more popular themes')
 
-        hpshelf_a = ShelfManagement.objects.create(
+        self.hpshelf_a = ShelfManagement.objects.create(
             shelf=shelf_a,
             position=3)
-        hpshelf_b = ShelfManagement.objects.create(
+        self.hpshelf_b = ShelfManagement.objects.create(
             shelf=shelf_b,
             position=2)
         ShelfManagement.objects.create(
             shelf=shelf_c,
             position=1)
 
-        # The shelves aren't enabled so they won't show up
+        self.search_url = reverse_ns('addon-search') + shelf_a.criteria
+
+        self.collections_url = reverse_ns('collection-addon-list', kwargs={
+            'user_pk': settings.TASK_USER_ID,
+            'collection_slug': shelf_b.criteria})
+
+    def test_no_enabled_shelves_empty_view(self):
         response = self.client.get(self.url)
+        assert response.status_code == 200
         assert response.json() == {
             'count': 0,
             'next': None,
@@ -55,14 +53,34 @@ class TestShelfViewSet(TestCase):
             'previous': None,
             'results': []}
 
-        hpshelf_a.update(enabled=True)
-        hpshelf_b.update(enabled=True)
-        # don't enable the last homepage shelf
+    def test_only_enabled_shelves_in_view(self):
+        self.hpshelf_a.update(enabled=True)
+        self.hpshelf_b.update(enabled=True)
+        # don't enable shelf_c
+
         with self.assertNumQueries(4):
             response = self.client.get(self.url)
         assert response.status_code == 200
-        result = json.loads(response.content)
 
+        result = json.loads(response.content)
         assert len(result['results']) == 2
-        assert result['results'][0]['title'] == 'Enhanced privacy extensions'
-        assert result['results'][1]['title'] == 'Recommended extensions'
+        assert result['results'] == [
+            {
+                'title': 'Enhanced privacy extensions',
+                'url': self.collections_url,
+                'endpoint': 'collections',
+                'criteria': 'privacy-matters',
+                'footer_text': 'See more enhanced privacy extensions',
+                'footer_pathname': '',
+                'addons': None
+            },
+            {
+                'title': 'Recommended extensions',
+                'url': self.search_url,
+                'endpoint': 'search',
+                'criteria': '?promoted=recommended&sort=random&type=extension',
+                'footer_text': 'See more recommended extensions',
+                'footer_pathname': '',
+                'addons': []
+            },
+        ]

--- a/src/olympia/shelves/tests/test_views.py
+++ b/src/olympia/shelves/tests/test_views.py
@@ -2,11 +2,44 @@ import json
 
 from django.conf import settings
 
-from olympia.amo.tests import TestCase, reverse_ns
+from olympia import amo
+from olympia.amo.tests import addon_factory, ESTestCase, reverse_ns
+from olympia.constants.promoted import RECOMMENDED
+from olympia.promoted.models import PromotedAddon
 from olympia.shelves.models import Shelf, ShelfManagement
 
 
-class TestShelfViewSet(TestCase):
+class TestShelfViewSet(ESTestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        # Shouldn't be necessary, but just in case.
+        cls.empty_index('default')
+
+        addon_factory(
+            name='test addon test01', type=amo.ADDON_EXTENSION,
+            average_daily_users=46812, weekly_downloads=132, summary=None)
+        addon_factory(
+            name='test addon test02', type=amo.ADDON_STATICTHEME,
+            average_daily_users=18981, weekly_downloads=145, summary=None)
+        addon_ext = addon_factory(
+            name='test addon test03', type=amo.ADDON_EXTENSION,
+            average_daily_users=482, weekly_downloads=506, summary=None)
+        addon_theme = addon_factory(
+            name='test addon test04', type=amo.ADDON_STATICTHEME,
+            average_daily_users=8838, weekly_downloads=358, summary=None)
+
+        PromotedAddon.objects.create(
+            addon=addon_ext, group_id=RECOMMENDED.id
+        ).approve_for_version(version=addon_ext.current_version)
+
+        PromotedAddon.objects.create(
+            addon=addon_theme, group_id=RECOMMENDED.id
+        ).approve_for_version(version=addon_theme.current_version)
+
+        cls.refresh()
+
     def setUp(self):
         self.url = reverse_ns('shelves-list')
 
@@ -63,24 +96,28 @@ class TestShelfViewSet(TestCase):
         assert response.status_code == 200
 
         result = json.loads(response.content)
+
         assert len(result['results']) == 2
-        assert result['results'] == [
-            {
-                'title': 'Enhanced privacy extensions',
-                'url': self.collections_url,
-                'endpoint': 'collections',
-                'criteria': 'privacy-matters',
-                'footer_text': 'See more enhanced privacy extensions',
-                'footer_pathname': '',
-                'addons': None
-            },
-            {
-                'title': 'Recommended extensions',
-                'url': self.search_url,
-                'endpoint': 'search',
-                'criteria': '?promoted=recommended&sort=random&type=extension',
-                'footer_text': 'See more recommended extensions',
-                'footer_pathname': '',
-                'addons': []
-            },
-        ]
+
+        assert result['results'][0]['title'] == 'Enhanced privacy extensions'
+        assert result['results'][0]['url'] == self.collections_url
+        assert result['results'][0]['endpoint'] == 'collections'
+        assert result['results'][0]['criteria'] == 'privacy-matters'
+        assert result['results'][0]['footer_text'] == (
+            'See more enhanced privacy extensions')
+        assert result['results'][0]['footer_pathname'] == ''
+        assert result['results'][0]['addons'] is None
+
+        assert result['results'][1]['title'] == 'Recommended extensions'
+        assert result['results'][1]['url'] == self.search_url
+        assert result['results'][1]['endpoint'] == 'search'
+        assert result['results'][1]['criteria'] == (
+            '?promoted=recommended&sort=random&type=extension')
+        assert result['results'][1]['footer_text'] == (
+            'See more recommended extensions')
+        assert result['results'][1]['footer_pathname'] == ''
+        assert result['results'][1]['addons'][0]['name']['en-US'] == (
+            'test addon test03')
+        assert result['results'][1]['addons'][0]['promoted']['category'] == (
+            'recommended')
+        assert result['results'][1]['addons'][0]['type'] == 'extension'

--- a/src/olympia/shelves/urls.py
+++ b/src/olympia/shelves/urls.py
@@ -5,9 +5,8 @@ from rest_framework.routers import SimpleRouter
 from olympia.shelves import views
 
 router = SimpleRouter()
-router.register('info', views.ShelfViewSet, basename='shelves-info')
+router.register('', views.ShelfViewSet, basename='shelves')
 
 urlpatterns = [
     url(r'', include(router.urls)),
-    url(r'', views.HomepageView.as_view(), name='shelves'),
 ]

--- a/src/olympia/shelves/urls.py
+++ b/src/olympia/shelves/urls.py
@@ -2,11 +2,12 @@ from django.conf.urls import include, url
 
 from rest_framework.routers import SimpleRouter
 
-from olympia.shelves.views import ShelfViewSet
+from olympia.shelves import views
 
 router = SimpleRouter()
-router.register('', ShelfViewSet, basename='shelves')
+router.register('info', views.ShelfViewSet, basename='shelves-info')
 
 urlpatterns = [
     url(r'', include(router.urls)),
+    url(r'', views.HomepageView.as_view(), name='shelves'),
 ]

--- a/src/olympia/shelves/views.py
+++ b/src/olympia/shelves/views.py
@@ -1,12 +1,25 @@
 from rest_framework import viewsets
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from olympia.shelves.models import Shelf
 from olympia.shelves.serializers import ShelfSerializer
 
 
 class ShelfViewSet(viewsets.ModelViewSet):
+    format_kwarg = None
     queryset = Shelf.objects.filter(
         shelfmanagement__enabled=True).order_by('shelfmanagement__position')
-    permission_classes = []
-
     serializer_class = ShelfSerializer
+
+    def get_shelves(self):
+        return self.get_serializer(self.queryset, many=True)
+
+
+class HomepageView(APIView):
+    def get(self, request, format=None):
+        output = {
+            'info': ShelfViewSet(
+                request=request).get_shelves().data,
+        }
+        return Response(output)

--- a/src/olympia/shelves/views.py
+++ b/src/olympia/shelves/views.py
@@ -1,25 +1,10 @@
 from rest_framework import viewsets
-from rest_framework.response import Response
-from rest_framework.views import APIView
 
 from olympia.shelves.models import Shelf
 from olympia.shelves.serializers import ShelfSerializer
 
 
 class ShelfViewSet(viewsets.ModelViewSet):
-    format_kwarg = None
     queryset = Shelf.objects.filter(
         shelfmanagement__enabled=True).order_by('shelfmanagement__position')
     serializer_class = ShelfSerializer
-
-    def get_shelves(self):
-        return self.get_serializer(self.queryset, many=True)
-
-
-class HomepageView(APIView):
-    def get(self, request, format=None):
-        output = {
-            'info': ShelfViewSet(
-                request=request).get_shelves().data,
-        }
-        return Response(output)

--- a/src/olympia/shelves/views.py
+++ b/src/olympia/shelves/views.py
@@ -7,4 +7,5 @@ from olympia.shelves.serializers import ShelfSerializer
 class ShelfViewSet(viewsets.ModelViewSet):
     queryset = Shelf.objects.filter(
         shelfmanagement__enabled=True).order_by('shelfmanagement__position')
+    permission_classes = []
     serializer_class = ShelfSerializer


### PR DESCRIPTION
Fixes #15284 
Dependent on #15283 (`settings_test.py`)

This pull requests updates the homepage shelves with the endpoint `search` by including the add-ons based on the shelves' crtieria within the API.

I am not sure if I am on the right track - I updated the serializer to add a field for the returned addons. As the container is not configured to call the search API, I had to repeat the code in `def clean` from `forms.py` - would it be better to save the url so it can be reused here?

Please review when you have a moment. Thank you! 