### PR TITLE
Catch form criteria edge cases

### DIFF
--- a/src/olympia/shelves/forms.py
+++ b/src/olympia/shelves/forms.py
@@ -27,8 +27,11 @@ class ShelfForm(forms.ModelForm):
 
         try:
             if endpoint == 'search':
-                api = drf_reverse('v4:addon-search')
-                url = baseUrl + api + criteria
+                if not criteria.startswith('?') or criteria.count('?') > 1:
+                    raise forms.ValidationError('Check criteria field.')
+                else:
+                    api = drf_reverse('v4:addon-search')
+                    url = baseUrl + api + criteria
             elif endpoint == 'collections':
                 api = drf_reverse('v4:collection-addon-list', kwargs={
                     'user_pk': settings.TASK_USER_ID,

--- a/src/olympia/shelves/tests/test_forms.py
+++ b/src/olympia/shelves/tests/test_forms.py
@@ -93,6 +93,28 @@ class TestShelfForm(TestCase):
         assert not form.is_valid()
         assert form.errors == {'criteria': ['This field is required.']}
 
+    def test_clean_search_criteria_does_not_start_with_qmark(self):
+        form = ShelfForm({
+            'title': 'Recommended extensions',
+            'endpoint': 'search',
+            'criteria': '..?recommended-true'})
+        assert not form.is_valid()
+        with self.assertRaises(ValidationError) as exc:
+            form.clean()
+        assert exc.exception.message == (
+            'Check criteria field.')
+
+    def test_clean_search_criteria_has_multiple_qmark(self):
+        form = ShelfForm({
+            'title': 'Recommended extensions',
+            'endpoint': 'search',
+            'criteria': '??recommended-true'})
+        assert not form.is_valid()
+        with self.assertRaises(ValidationError) as exc:
+            form.clean()
+        assert exc.exception.message == (
+            'Check criteria field.')
+
     def test_clean_form_throws_error_for_NoReverseMatch(self):
         form = ShelfForm({
             'title': 'New collection',
@@ -103,18 +125,6 @@ class TestShelfForm(TestCase):
             form.clean()
         assert exc.exception.message == (
             'No data found - check criteria parameters.')
-
-    def test_clean_search_returns_404(self):
-        data = {
-            'title': 'Popular themes',
-            'endpoint': 'search',
-            'criteria': self.criteria_404}
-        form = ShelfForm(data)
-        assert not form.is_valid()
-        with self.assertRaises(ValidationError) as exc:
-            form.clean()
-        assert exc.exception.message == (
-            'Check criteria - No data found')
 
     def test_clean_col_returns_404(self):
         data = {


### PR DESCRIPTION
Fixes #15349 
Fixes #15350 

This pull request updates `shelves/forms.py` to check that the search criteria field starts with a `?` and cannot include multiple `?`.

The following tests have been added to `test_forms.py`:
- `def test_clean_search_criteria_does_not_start_with_qmark`
- `def test_clean_search_criteria_has_multiple_qmark`

`test_clean_search_returns_404`  has been removed since the criteria example used to return the 404 started without a `?` and therefore is now caught by the conditional that it needs to start with `?`. I could not figure out a combo that would return a 404 for search.

In addition, I am not sure how to prevent the admin user from entering in a criteria, such as `?#####`, `?//////`, `?hi`, which allows a shelf module to be saved as it returns valid results. 

Please review when you have a moment. Thank you!