### PR TITLE
RE: Build an API endpoint for shelves

### DIFF
--- a/src/olympia/shelves/serializers.py
+++ b/src/olympia/shelves/serializers.py
@@ -26,4 +26,7 @@ class ShelfSerializer(serializers.ModelSerializer):
                 kwargs={
                     'user_pk': settings.TASK_USER_ID,
                     'collection_slug': obj.criteria})
+        else:
+            url = None
+
         return url


### PR DESCRIPTION
Fixes #14873 

This pull request updates `def get_url`. An `else` statement was added to prevent the error of referencing the `url` variable before assignment, in cases that `obj.endpoint` does not match either `search` or `collections`.

Please review when you have a moment. Thank you!