### PR TITLE
Use `hashed_guid`/`hashed_addon_id` for the download stats

### DIFF
--- a/src/olympia/addons/cron.py
+++ b/src/olympia/addons/cron.py
@@ -206,15 +206,15 @@ def update_addon_weekly_downloads(chunk_size=250):
     if waffle.switch_is_active('use-bigquery-for-download-stats-cron'):
         counts = dict(
             # In order to reset the `weekly_downloads` values of add-ons that
-            # don't exist in BigQuery, we prepare a set of `(guid, 0)` for most
-            # add-ons.
+            # don't exist in BigQuery, we prepare a set of `(hashed_guid, 0)`
+            # for most add-ons.
             Addon.objects
             .filter(type__in=amo.ADDON_TYPES_WITH_STATS)
             .exclude(guid__isnull=True)
             .exclude(guid__exact='')
             .exclude(weekly_downloads=0)
             .annotate(count=Value(0, IntegerField()))
-            .values_list('guid', 'count')
+            .values_list('addonguid__hashed_guid', 'count')
         )
         # Update the `counts` with values from BigQuery.
         counts.update(get_addons_and_weekly_downloads_from_bigquery())

--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -291,11 +291,11 @@ def update_addon_weekly_downloads(data):
 
     for hashed_guid, count in data:
         try:
-            addon = AddonGUID.objects.get(hashed_guid=hashed_guid).addon
-        except AddonGUID.DoesNotExist:
+            addon = Addon.objects.get(addonguid__hashed_guid=hashed_guid)
+        except Addon.DoesNotExist:
             # The processing input comes from metrics which might be out of
             # date in regards to currently existing add-ons.
-            log.info('Got a weekly_downloads update (%s) but the add-on GUID '
+            log.info('Got a weekly_downloads update (%s) but the add-on '
                      'doesn\'t exist (hashed_guid=%s).', count, hashed_guid)
             continue
 

--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -289,14 +289,14 @@ def update_addon_hotness(averages):
 def update_addon_weekly_downloads(data):
     log.info('[%s] Updating add-ons weekly downloads.', len(data))
 
-    for addon_guid, count in data:
+    for hashed_guid, count in data:
         try:
-            addon = Addon.objects.get(guid=addon_guid)
-        except Addon.DoesNotExist:
+            addon = AddonGUID.objects.get(hashed_guid=hashed_guid).addon
+        except AddonGUID.DoesNotExist:
             # The processing input comes from metrics which might be out of
             # date in regards to currently existing add-ons.
-            log.info('Got a weekly_downloads update (%s) but the add-on '
-                     'doesn\'t exist (%s).', count, addon_guid)
+            log.info('Got a weekly_downloads update (%s) but the add-on GUID '
+                     'doesn\'t exist (hashed_guid=%s).', count, hashed_guid)
             continue
 
         addon.update(weekly_downloads=int(float(count)))

--- a/src/olympia/addons/tests/test_cron.py
+++ b/src/olympia/addons/tests/test_cron.py
@@ -470,9 +470,9 @@ class TestUpdateAddonWeeklyDownloads(TestCase):
         # This one should be ignored as well.
         addon_factory(guid='', type=amo.ADDON_LPAPP)
         get_mock.return_value = [
-            (addon.guid, count),
-            (langpack.guid, langpack_count),
-            (dictionary.guid, dictionary_count),
+            (addon.addonguid.hashed_guid, count),
+            (langpack.addonguid.hashed_guid, langpack_count),
+            (dictionary.addonguid.hashed_guid, dictionary_count),
         ]
 
         chunk_size = 123
@@ -481,10 +481,10 @@ class TestUpdateAddonWeeklyDownloads(TestCase):
         create_chunked_mock.assert_called_with(
             update_addon_weekly_downloads,
             [
-                (addon_without_count.guid, 0),
-                (addon.guid, count),
-                (langpack.guid, langpack_count),
-                (dictionary.guid, dictionary_count),
+                (addon_without_count.addonguid.hashed_guid, 0),
+                (addon.addonguid.hashed_guid, count),
+                (langpack.addonguid.hashed_guid, langpack_count),
+                (dictionary.addonguid.hashed_guid, dictionary_count),
             ],
             chunk_size
         )
@@ -495,7 +495,7 @@ class TestUpdateAddonWeeklyDownloads(TestCase):
     def test_update_weekly_downloads(self, get_mock):
         addon = addon_factory(weekly_downloads=0)
         count = 56789
-        get_mock.return_value = [(addon.guid, count)]
+        get_mock.return_value = [(addon.addonguid.hashed_guid, count)]
 
         cron.update_addon_weekly_downloads()
         addon.refresh_from_db()

--- a/src/olympia/addons/tests/test_tasks.py
+++ b/src/olympia/addons/tests/test_tasks.py
@@ -152,7 +152,7 @@ def test_update_addon_hotness():
 def test_update_addon_weekly_downloads():
     addon = addon_factory(weekly_downloads=0)
     count = 123
-    data = [(addon.guid, count)]
+    data = [(addon.addonguid.hashed_guid, count)]
     assert addon.weekly_downloads == 0
 
     update_addon_weekly_downloads(data)
@@ -164,8 +164,8 @@ def test_update_addon_weekly_downloads():
 def test_update_addon_weekly_downloads_skips_non_existent_addons():
     addon = addon_factory(weekly_downloads=0)
     count = 123
-    invalid_addon_guid = 'does.not@exist'
-    data = [(invalid_addon_guid, 0), (addon.guid, count)]
+    invalid_hashed_guid = 'does.not@exist'
+    data = [(invalid_hashed_guid, 0), (addon.addonguid.hashed_guid, count)]
     assert addon.weekly_downloads == 0
 
     update_addon_weekly_downloads(data)

--- a/src/olympia/addons/tests/test_tasks.py
+++ b/src/olympia/addons/tests/test_tasks.py
@@ -161,6 +161,22 @@ def test_update_addon_weekly_downloads():
     assert addon.weekly_downloads == count
 
 
+def test_update_addon_weekly_downloads_ignores_deleted_addons():
+    guid = 'some@guid'
+    deleted_addon = addon_factory(guid=guid)
+    deleted_addon.delete()
+    deleted_addon.update(guid=None)
+    addon = addon_factory(guid=guid, weekly_downloads=0)
+    count = 123
+    data = [(addon.addonguid.hashed_guid, count)]
+    assert addon.weekly_downloads == 0
+
+    update_addon_weekly_downloads(data)
+    addon.refresh_from_db()
+
+    assert addon.weekly_downloads == count
+
+
 def test_update_addon_weekly_downloads_skips_non_existent_addons():
     addon = addon_factory(weekly_downloads=0)
     count = 123

--- a/src/olympia/stats/tests/test_utils.py
+++ b/src/olympia/stats/tests/test_utils.py
@@ -532,7 +532,7 @@ class TestGetDownloadSeries(BigQueryTestMixin, TestCase):
         expected_query = f"""
 SELECT submission_date, total_downloads
 FROM `project.dataset.{AMO_STATS_DOWNLOAD_VIEW}`
-WHERE addon_id = @addon_id
+WHERE hashed_addon_id = @hashed_addon_id
 AND submission_date BETWEEN @submission_date_start AND @submission_date_end
 ORDER BY submission_date DESC
 LIMIT 365"""
@@ -548,8 +548,8 @@ LIMIT 365"""
         assert parameters == [
             {
                 'parameterType': {'type': 'STRING'},
-                'parameterValue': {'value': self.addon.guid},
-                'name': 'addon_id',
+                'parameterValue': {'value': self.addon.addonguid.hashed_guid},
+                'name': 'hashed_addon_id',
             },
             {
                 'parameterType': {'type': 'DATE'},
@@ -578,7 +578,7 @@ LIMIT 365"""
             expected_query = f"""
 SELECT submission_date, total_downloads, {column}
 FROM `project.dataset.{AMO_STATS_DOWNLOAD_VIEW}`
-WHERE addon_id = @addon_id
+WHERE hashed_addon_id = @hashed_addon_id
 AND submission_date BETWEEN @submission_date_start AND @submission_date_end
 ORDER BY submission_date DESC
 LIMIT 365"""
@@ -620,10 +620,10 @@ class TestGetAddonsAndWeeklyDownloadsFromBigQuery(
         client = self.create_mock_client()
         bigquery_client_mock.from_service_account_json.return_value = client
         expected_query = f"""
-SELECT addon_id, SUM(total_downloads) AS count
+SELECT hashed_addon_id, SUM(total_downloads) AS count
 FROM `project.dataset.{AMO_STATS_DOWNLOAD_VIEW}`
 WHERE submission_date >= DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY)
-GROUP BY addon_id"""
+GROUP BY hashed_addon_id"""
 
         get_addons_and_weekly_downloads_from_bigquery()
 
@@ -632,8 +632,8 @@ GROUP BY addon_id"""
     @mock.patch('google.cloud.bigquery.Client')
     def test_returned_results(self, bigquery_client_mock):
         results = [
-            self.create_bigquery_row({'addon_id': 1, 'count': 123}),
-            self.create_bigquery_row({'addon_id': 2, 'count': 456}),
+            self.create_bigquery_row({'hashed_addon_id': 1, 'count': 123}),
+            self.create_bigquery_row({'hashed_addon_id': 2, 'count': 456}),
         ]
         client = self.create_mock_client(results=results)
         bigquery_client_mock.from_service_account_json.return_value = client
@@ -644,9 +644,9 @@ GROUP BY addon_id"""
     @mock.patch('google.cloud.bigquery.Client')
     def test_skips_null_values(self, bigquery_client_mock):
         results = [
-            self.create_bigquery_row({'addon_id': 1, 'count': 123}),
-            self.create_bigquery_row({'addon_id': 2, 'count': None}),
-            self.create_bigquery_row({'addon_id': None, 'count': 456}),
+            self.create_bigquery_row({'hashed_addon_id': 1, 'count': 123}),
+            self.create_bigquery_row({'hashed_addon_id': 2, 'count': None}),
+            self.create_bigquery_row({'hashed_addon_id': None, 'count': 456}),
         ]
         client = self.create_mock_client(results=results)
         bigquery_client_mock.from_service_account_json.return_value = client


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/15213

---

This patch updates the stats code to make it compatible with the latest version of the "installs" view in BigQuery.