### PR TITLE
Hide download stats links in menu when add-on is purely unlisted

### DIFF
--- a/src/olympia/stats/templates/stats/addon_report_menu.html
+++ b/src/olympia/stats/templates/stats/addon_report_menu.html
@@ -3,7 +3,7 @@
     <li data-report="overview" data-layout="overview">
       <a href="{{ url('stats.overview', addon.slug) }}">{{ _('Overview') }}</a>
     </li>
-    {% if addon.has_listed_versions() %}
+    {% if addon.has_listed_versions(include_deleted=True) %}
     <li data-report="downloads">
       <a href="{{ url('stats.downloads', addon.slug) }}">{{ _('Downloads') }}</a>
     </li>

--- a/src/olympia/stats/templates/stats/addon_report_menu.html
+++ b/src/olympia/stats/templates/stats/addon_report_menu.html
@@ -3,6 +3,7 @@
     <li data-report="overview" data-layout="overview">
       <a href="{{ url('stats.overview', addon.slug) }}">{{ _('Overview') }}</a>
     </li>
+    {% if addon.has_listed_versions() %}
     <li data-report="downloads">
       <a href="{{ url('stats.downloads', addon.slug) }}">{{ _('Downloads') }}</a>
     </li>
@@ -22,6 +23,7 @@
         </li>
       {% endif %}
     </ul>
+    {% endif %}
     <li data-report="usage">
       <a href="{{ url('stats.usage', addon.slug) }}">{{ _('Daily Users') }}</a>
     </li>

--- a/src/olympia/stats/tests/test_views.py
+++ b/src/olympia/stats/tests/test_views.py
@@ -1329,6 +1329,18 @@ class TestStatsWithBigQuery(TestCase):
         assert b'by Content' in response.content
         assert b'by Campaign' in response.content
 
+    def test_no_download_stats_for_purely_unlisted_addons(self):
+        self.make_addon_unlisted(self.addon)
+        assert not self.addon.has_listed_versions()
+
+        url = reverse('stats.overview', args=[self.addon.slug])
+        response = self.client.get(url)
+
+        assert b'by Source' not in response.content
+        assert b'by Medium' not in response.content
+        assert b'by Content' not in response.content
+        assert b'by Campaign' not in response.content
+
     def test_download_stats(self):
         url = reverse('stats.downloads', args=[self.addon.slug])
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/15487