### PR TITLE
Tweak rejection scheduled deadline message in review page

### DIFF
--- a/src/olympia/reviewers/templates/reviewers/includes/version.html
+++ b/src/olympia/reviewers/templates/reviewers/includes/version.html
@@ -9,7 +9,13 @@
     {% endif %}
 
     {% if version.pending_rejection %}
-    <span class="pending-rejection" title="{{ version.pending_rejection|datetime }}">&middot; {{ _("Scheduled for rejection in {0} "|format_html(version.pending_rejection|timeuntil)) }}</span>
+    <span class="pending-rejection" title="{{ version.pending_rejection|datetime }}">&middot;
+      {% if latest_version_is_unreviewed_and_not_pending_rejection %}
+        {{ _("Pending Rejection on review of new version") }}
+      {% else %}
+        {{ _("Scheduled for rejection in {0} "|format_html(version.pending_rejection|timeuntil)) }}
+      {% endif %}
+    </span>
     {% endif %}
 
     {% if addon.block and addon.block.is_version_blocked(version.version) %}

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -914,6 +914,9 @@ def review(request, addon, channel=None):
         form=form,
         has_versions_pending_rejection=has_versions_pending_rejection,
         is_admin=is_admin,
+        latest_version_is_unreviewed_and_not_pending_rejection=(
+            version and version.channel == amo.RELEASE_CHANNEL_LISTED and
+            version.is_unreviewed and not version.pending_rejection),
         promoted_group=promoted_group,
         name_translations=name_translations,
         now=datetime.now(),


### PR DESCRIPTION
When there is a newer version, and it's unreviewed and not pending rejection itself, we "pause" delayed rejections until review of that newer version has been done, this changes reflects that condition in the message shown next to each version pending rejection.

Fixes #15429