### PR TITLE
Make reviewer tools pages larger and stop displaying counts in queue tab bar

### DIFF
--- a/src/olympia/reviewers/templatetags/jinja_helpers.py
+++ b/src/olympia/reviewers/templatetags/jinja_helpers.py
@@ -2,7 +2,7 @@ import datetime
 
 from django.conf import settings
 from django.utils.encoding import force_text
-from django.utils.translation import ugettext, ungettext
+from django.utils.translation import ugettext
 
 import jinja2
 
@@ -58,7 +58,6 @@ def queue_tabnav(context):
 
     Each tuple contains three elements: (tab_code, page_url, tab_text)
     """
-    counts = context['queue_counts']
     request = context['request']
     listed = not context.get('unlisted')
 
@@ -67,77 +66,47 @@ def queue_tabnav(context):
         if acl.action_allowed(
                 request, amo.permissions.ADDONS_RECOMMENDED_REVIEW):
             tabnav.append(
-                ('recommended', 'queue_recommended',
-                 ugettext('Recommended ({0})').format(counts['recommended'])),
+                ('recommended', 'queue_recommended', ugettext('Recommended'))
             )
         if acl.action_allowed(request, amo.permissions.ADDONS_REVIEW):
-            new_text = ugettext('Other Pending Review ({0})')
-            tabnav.extend((
+            tabnav.append(
                 ('extension', 'queue_extension',
-                 '🛠️ ' + new_text.format(counts['extension'])),
-            ))
-            tabnav.append((
-                'scanners',
-                'queue_scanners',
-                (ungettext(
-                    'Flagged By Scanners ({0})',
-                    'Flagged By Scanners ({0})',
-                    counts['scanners']
-                ) .format(counts['scanners'])),
-            ))
-            tabnav.append((
-                'mad',
-                'queue_mad',
-                (ungettext(
-                    'Flagged for Human Review ({0})',
-                    'Flagged for Human Review ({0})',
-                    counts['mad']
-                ).format(counts['mad'])),
-            ))
+                 '🛠️ ' + ugettext('Other Pending Review'))
+            )
+            tabnav.append(
+                ('scanners', 'queue_scanners', ugettext('Flagged By Scanners'))
+            )
+            tabnav.append(
+                ('mad', 'queue_mad', ugettext('Flagged for Human Review'))
+            )
         if acl.action_allowed(request, amo.permissions.STATIC_THEMES_REVIEW):
-            new_text = ugettext('New ({0})')
-            update_text = ungettext(
-                'Update ({0})', 'Updates ({0})', counts['theme_pending'])
             tabnav.extend((
                 ('theme_nominated', 'queue_theme_nominated',
-                 '🎨 ' + new_text.format(counts['theme_nominated'])),
+                 '🎨 ' + ugettext('New')),
                 ('theme_pending', 'queue_theme_pending',
-                 '🎨 ' + update_text.format(counts['theme_pending'])),
+                 '🎨 ' + ugettext('Updates')),
             ))
         if acl.action_allowed(request, amo.permissions.RATINGS_MODERATE):
             tabnav.append(
-                ('moderated', 'queue_moderated',
-                 (ungettext('Rating Review ({0})',
-                            'Rating Reviews ({0})',
-                            counts['moderated'])
-                  .format(counts['moderated']))),
+                ('moderated', 'queue_moderated', ugettext('Rating Reviews'))
             )
 
         if acl.action_allowed(request, amo.permissions.ADDONS_REVIEW):
             tabnav.append(
                 ('auto_approved', 'queue_auto_approved',
-                 (ungettext('Auto Approved ({0})',
-                            'Auto Approved ({0})',
-                            counts['auto_approved'])
-                  .format(counts['auto_approved']))),
+                    ugettext('Auto Approved'))
             )
 
         if acl.action_allowed(request, amo.permissions.ADDONS_CONTENT_REVIEW):
             tabnav.append(
                 ('content_review', 'queue_content_review',
-                 (ungettext('Content Review ({0})',
-                            'Content Review ({0})',
-                            counts['content_review'])
-                  .format(counts['content_review']))),
+                    ugettext('Content Review'))
             )
 
         if acl.action_allowed(request, amo.permissions.REVIEWS_ADMIN):
             tabnav.append(
                 ('pending_rejection', 'queue_pending_rejection',
-                 (ungettext('Pending Rejection ({0})',
-                            'Pending Rejection ({0})',
-                            counts['pending_rejection'])
-                  .format(counts['pending_rejection']))),
+                    ugettext('Pending Rejection'))
             )
     else:
         tabnav = [

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -1100,7 +1100,7 @@ class QueueTest(ReviewerTest):
         link = links.eq(tab_position)
 
         assert links.length == total_queues
-        assert link.text() == '%s (%s)' % (name, total_addons)
+        assert link.text() == '%s' % name
         assert link.attr('href') == self.url
         if per_page:
             assert doc('.data-grid-top .num-results').text() == (
@@ -2115,13 +2115,10 @@ class TestAutoApprovedQueue(QueueTest):
     def test_results(self):
         self.login_with_permission()
         self.generate_files()
-        with self.assertNumQueries(26):
-            # 26 queries is a lot, but it used to be much much worse.
+        with self.assertNumQueries(16):
             # - 2 for savepoints because we're in tests
             # - 2 for user/groups
-            # - 11 for various queue counts, including current one
-            #      (unfortunately duplicated because it appears in two
-            #       completely different places)
+            # - 1 for the current queue count for pagination purposes
             # - 3 for the addons in the queues and their files (regardless of
             #     how many are in the queue - that's the important bit)
             # - 2 for config items (motd / site notice)
@@ -2308,13 +2305,10 @@ class TestContentReviewQueue(QueueTest):
     def test_results(self):
         self.login_with_permission()
         self.generate_files()
-        with self.assertNumQueries(26):
-            # 26 queries is a lot, but it used to be much much worse.
+        with self.assertNumQueries(16):
             # - 2 for savepoints because we're in tests
             # - 2 for user/groups
-            # - 11 for various queue counts, including current one
-            #      (unfortunately duplicated because it appears in two
-            #       completely different places)
+            # - 1 for the current queue count for pagination purposes
             # - 3 for the addons in the queues and their files (regardless of
             #     how many are in the queue - that's the important bit)
             # - 2 for config items (motd / site notice)
@@ -8114,14 +8108,12 @@ class TestMadQueue(QueueTest):
                                 mixed_addon_both]
 
     def test_results(self):
-        with self.assertNumQueries(34):
-            # 30 queries is a lot. Some of them are unfortunately scaling with
-            # the number of add-ons in the queue.
+        with self.assertNumQueries(24):
+            # That's a lot of queries. Some of them are unfortunately scaling
+            # with the number of add-ons in the queue.
             # - 2 for savepoints because we're in tests
             # - 2 for user/groups
-            # - 11 for various queue counts, including current one
-            #      (unfortunately duplicated because it appears in two
-            #       completely different places)
+            # - 1 for the current queue count for pagination purposes
             # - 3 for the addons in the queue and their files (regardless of
             #     how many are in the queue - that's the important bit)
             # - 2 for config items (motd / site notice)

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -484,14 +484,11 @@ def _queue(request, TableObj, tab, qs=None, unlisted=False,
     page = paginate(request, table.rows, per_page=per_page, count=qs.count())
     table.set_page(page)
 
-    queue_counts = fetch_queue_counts(admin_reviewer=admin_reviewer)
-
     return render(request, 'reviewers/queue.html',
                   context(table=table, page=page, tab=tab,
                           search_form=search_form,
                           point_types=amo.REVIEWED_AMO,
-                          unlisted=unlisted,
-                          queue_counts=queue_counts))
+                          unlisted=unlisted))
 
 
 def fetch_queue_counts(admin_reviewer):

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -586,15 +586,11 @@ def queue_moderated(request):
                     for e in reviews_formset.errors))
         return redirect(reverse('reviewers.queue_moderated'))
 
-    admin_reviewer = is_admin_reviewer(request)
-    queue_counts = fetch_queue_counts(admin_reviewer=admin_reviewer)
-
     return render(request, 'reviewers/queue.html',
                   context(reviews_formset=reviews_formset,
                           tab='moderated', page=page, flags=flags,
                           search_form=None,
-                          point_types=amo.REVIEWED_AMO,
-                          queue_counts=queue_counts))
+                          point_types=amo.REVIEWED_AMO))
 
 
 @any_reviewer_required

--- a/static/css/zamboni/reviewers.less
+++ b/static/css/zamboni/reviewers.less
@@ -1,9 +1,13 @@
 @flagged-by-scanners-color: orange;
 @flagged-for-human-review-color: green;
 
+.section .amo-header-wrapper, .section {
+    max-width: 120em;
+    width: auto;
+}
+
 .site-title {
     padding-top: 27px;
-    max-width: 530px;
 }
 .site-title a,
 .site-title a:visited,


### PR DESCRIPTION
The queue counts are costly and we can live without them in the tab bar. It's probably best to hide them rather than cache them and deal with them not always be up to date.

The width of all reviewer tools pages is also adjusted to make the layout a little nicer - now that we don't have the counts anymore, 120em should be enough.

Fixes https://github.com/mozilla/addons-server/issues/15502

![Screenshot_2020-09-16 Content Review – Add-ons for Firefox](https://user-images.githubusercontent.com/187006/93341639-a9d95c80-f82e-11ea-9183-17ba85dc13b4.png)
