### PR TITLE
Remove CI config that is relying on a non-existent file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,14 +88,6 @@ script:
       fi
       RUNNING_IN_CI=True tox
     fi
-  - |
-    if [ $TRAVIS_EVENT_TYPE == "cron" ]; then
-      # Only run the extraction on "main" environment to avoid creating
-      # 8 pull requests for each tox environment.
-      if [ $TOXENV == "main" ]; then
-          bash scripts/travis-extract-l10n.sh
-      fi
-    fi
 
 after_script:
   - docker stop autograph


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/15514

---

According to this commit https://github.com/mozilla/addons-server/commit/9134ca3679cd4722d4b8a6d2df176d70ef3c285b, travis support wasn't working correctly so let's remove this config entirely for now.