### PR TITLE
Stop generating MLBF when we have stash + mlbf.py refactoring

### DIFF
--- a/src/olympia/blocklist/management/commands/export_blocklist.py
+++ b/src/olympia/blocklist/management/commands/export_blocklist.py
@@ -39,13 +39,13 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         log.debug('Exporting blocklist to file')
-        mlbf = MLBF(options.get('id'))
+        mlbf = MLBF.generate_from_db(options.get('id'))
 
         if options.get('block_guids_input'):
-            mlbf.blocked_json = list(MLBF.hash_filter_inputs(
+            mlbf.blocked_items = list(MLBF.hash_filter_inputs(
                 self.load_json(options.get('block_guids_input'))))
         if options.get('addon_guids_input'):
-            mlbf.not_blocked_json = list(MLBF.hash_filter_inputs(
+            mlbf.not_blocked_items = list(MLBF.hash_filter_inputs(
                 self.load_json(options.get('addon_guids_input'))))
 
-        mlbf.generate_and_write_mlbf()
+        mlbf.generate_and_write_filter()

--- a/src/olympia/blocklist/mlbf.py
+++ b/src/olympia/blocklist/mlbf.py
@@ -17,6 +17,78 @@ from olympia.constants.blocklist import BASE_REPLACE_THRESHOLD
 log = olympia.core.logger.getLogger('z.amo.blocklist')
 
 
+def generate_mlbf(stats, blocked, not_blocked):
+    log.info('Starting to generating bloomfilter')
+
+    cascade = FilterCascade(
+        defaultHashAlg=HashAlgorithm.SHA256,
+        salt=secrets.token_bytes(16),
+    )
+
+    error_rates = sorted((len(blocked), len(not_blocked)))
+    cascade.set_crlite_error_rates(
+        include_len=error_rates[0], exclude_len=error_rates[1])
+
+    stats['mlbf_blocked_count'] = len(blocked)
+    stats['mlbf_notblocked_count'] = len(not_blocked)
+
+    cascade.initialize(include=blocked, exclude=not_blocked)
+
+    stats['mlbf_version'] = cascade.version
+    stats['mlbf_layers'] = cascade.layerCount()
+    stats['mlbf_bits'] = cascade.bitCount()
+
+    log.info(
+        f'Filter cascade layers: {cascade.layerCount()}, '
+        f'bit: {cascade.bitCount()}')
+
+    cascade.verify(include=blocked, exclude=not_blocked)
+    return cascade
+
+
+def fetch_blocked_from_db():
+    from olympia.files.models import File
+    from olympia.blocklist.models import Block
+
+    blocks = Block.objects.all()
+    blocks_guids = [block.guid for block in blocks]
+
+    file_qs = File.objects.filter(
+        version__addon__addonguid__guid__in=blocks_guids,
+        is_signed=True,
+        is_webextension=True,
+    ).order_by('version_id').values(
+        'version__addon__addonguid__guid',
+        'version__version',
+        'version_id')
+    addons_versions = defaultdict(list)
+    for file_ in file_qs:
+        addon_key = file_['version__addon__addonguid__guid']
+        addons_versions[addon_key].append(
+            (file_['version__version'], file_['version_id']))
+
+    all_versions = {}
+    # collect all the blocked versions
+    for block in blocks:
+        is_all_versions = (
+            block.min_version == Block.MIN and
+            block.max_version == Block.MAX)
+        versions = {
+            version_id: (block.guid, version)
+            for version, version_id in addons_versions[block.guid]
+            if is_all_versions or block.is_version_blocked(version)}
+        all_versions.update(versions)
+    return all_versions
+
+
+def fetch_all_versions_from_db(excluding_version_ids=None):
+    from olympia.versions.models import Version
+
+    qs = (Version.unfiltered.exclude(id__in=excluding_version_ids or ())
+                 .values_list('addon__addonguid__guid', 'version'))
+    return list(qs)
+
+
 class MLBF():
     KEY_FORMAT = '{guid}:{version}'
 
@@ -25,89 +97,11 @@ class MLBF():
         self.id = str(id_)
 
     @classmethod
-    def fetch_blocked_from_db(cls):
-        from olympia.files.models import File
-        from olympia.blocklist.models import Block
-
-        blocks = Block.objects.all()
-        blocks_guids = [block.guid for block in blocks]
-
-        file_qs = File.objects.filter(
-            version__addon__addonguid__guid__in=blocks_guids,
-            is_signed=True,
-            is_webextension=True,
-        ).order_by('version_id').values(
-            'version__addon__addonguid__guid',
-            'version__version',
-            'version_id')
-        addons_versions = defaultdict(list)
-        for file_ in file_qs:
-            addon_key = file_['version__addon__addonguid__guid']
-            addons_versions[addon_key].append(
-                (file_['version__version'], file_['version_id']))
-
-        all_versions = {}
-        # collect all the blocked versions
-        for block in blocks:
-            is_all_versions = (
-                block.min_version == Block.MIN and
-                block.max_version == Block.MAX)
-            versions = {
-                version_id: (block.guid, version)
-                for version, version_id in addons_versions[block.guid]
-                if is_all_versions or block.is_version_blocked(version)}
-            all_versions.update(versions)
-        return all_versions
-
-    @classmethod
-    def fetch_all_versions_from_db(cls, excluding_version_ids=None):
-        from olympia.versions.models import Version
-
-        qs = (
-            Version.unfiltered.exclude(id__in=excluding_version_ids or ())
-                   .values_list('addon__addonguid__guid', 'version'))
-        return list(qs)
-
-    @classmethod
     def hash_filter_inputs(cls, input_list):
         """Returns a set"""
         return {
             cls.KEY_FORMAT.format(guid=guid, version=version)
             for (guid, version) in input_list}
-
-    @classmethod
-    def generate_mlbf(cls, stats, blocked, not_blocked):
-        log.info('Starting to generating bloomfilter')
-
-        cascade = FilterCascade(
-            defaultHashAlg=HashAlgorithm.SHA256,
-            salt=secrets.token_bytes(16),
-        )
-
-        error_rates = sorted((len(blocked), len(not_blocked)))
-        cascade.set_crlite_error_rates(
-            include_len=error_rates[0], exclude_len=error_rates[1])
-
-        stats['mlbf_blocked_count'] = len(blocked)
-        stats['mlbf_notblocked_count'] = len(not_blocked)
-
-        cascade.initialize(include=blocked, exclude=not_blocked)
-
-        stats['mlbf_version'] = cascade.version
-        stats['mlbf_layers'] = cascade.layerCount()
-        stats['mlbf_bits'] = cascade.bitCount()
-
-        log.info(
-            f'Filter cascade layers: {cascade.layerCount()}, '
-            f'bit: {cascade.bitCount()}')
-
-        cascade.verify(include=blocked, exclude=not_blocked)
-        return cascade
-
-    @property
-    def filter_path(self):
-        return os.path.join(
-            settings.MLBF_STORAGE_PATH, self.id, 'filter')
 
     @property
     def _blocked_path(self):
@@ -115,24 +109,14 @@ class MLBF():
             settings.MLBF_STORAGE_PATH, self.id, 'blocked.json')
 
     @cached_property
-    def blocked_json(self):
-        with storage.open(self._blocked_path, 'r') as json_file:
-            return json.load(json_file)
+    def blocked_items(self):
+        raise NotImplementedError
 
-    def fetch_blocked_json(self):
-        """A safer version of .blocked_json that will generate from the db
-        if the cached_property isn't set."""
-        try:
-            return self.blocked_json
-        except FileNotFoundError:
-            # when self._blocked_path doesn't exist
-            pass
-        blocked_ids_to_versions = self.fetch_blocked_from_db()
-        blocked = blocked_ids_to_versions.values()
-        # cache version ids so query in fetch_not_blocked_json is efficient
-        self._version_excludes = blocked_ids_to_versions.keys()
-        self.blocked_json = list(self.hash_filter_inputs(blocked))
-        return self.blocked_json
+    def write_blocked_items(self):
+        blocked_path = self._blocked_path
+        with storage.open(blocked_path, 'w') as json_file:
+            log.info("Writing to file {}".format(blocked_path))
+            json.dump(self.blocked_items, json_file)
 
     @property
     def _not_blocked_path(self):
@@ -140,30 +124,19 @@ class MLBF():
             settings.MLBF_STORAGE_PATH, self.id, 'notblocked.json')
 
     @cached_property
-    def not_blocked_json(self):
-        with storage.open(self._not_blocked_path, 'r') as json_file:
-            return json.load(json_file)
+    def not_blocked_items(self):
+        raise NotImplementedError
 
-    def fetch_not_blocked_json(self):
-        """A safer version of .not_blocked_json that will generate from the db
-        if the cached_property isn't set."""
-        try:
-            return self.not_blocked_json
-        except FileNotFoundError:
-            # when self._not_blocked_path doesn't exist
-            pass
-        # see fetch_blocked_json
-        version_excludes = getattr(
-            self, '_version_excludes', self.fetch_blocked_from_db().keys())
-        # even though we exclude all the version ids in the query there's an
-        # edge case where the version string occurs twice for an addon so we
-        # ensure not_blocked_json doesn't contain any blocked_json.
-        self.not_blocked_json = list(
-            self.hash_filter_inputs(
-                self.fetch_all_versions_from_db(version_excludes)) -
-            set(self.blocked_json))
+    def write_not_blocked_items(self):
+        not_blocked_path = self._not_blocked_path
+        with storage.open(not_blocked_path, 'w') as json_file:
+            log.info("Writing to file {}".format(not_blocked_path))
+            json.dump(self.not_blocked_items, json_file)
 
-        return self.not_blocked_json
+    @property
+    def filter_path(self):
+        return os.path.join(
+            settings.MLBF_STORAGE_PATH, self.id, 'filter')
 
     @property
     def _stash_path(self):
@@ -175,27 +148,16 @@ class MLBF():
         with storage.open(self._stash_path, 'r') as json_file:
             return json.load(json_file)
 
-    def generate_and_write_mlbf(self):
+    def generate_and_write_filter(self):
         stats = {}
 
-        blocked_json = self.fetch_blocked_json()
-        not_blocked_json = self.fetch_not_blocked_json()
+        self.write_blocked_items()
+        self.write_not_blocked_items()
 
-        # write blocked json
-        blocked_path = self._blocked_path
-        with storage.open(blocked_path, 'w') as json_file:
-            log.info("Writing to file {}".format(blocked_path))
-            json.dump(blocked_json, json_file)
-        # and the not blocked json
-        not_blocked_path = self._not_blocked_path
-        with storage.open(not_blocked_path, 'w') as json_file:
-            log.info("Writing to file {}".format(not_blocked_path))
-            json.dump(not_blocked_json, json_file)
-
-        bloomfilter = self.generate_mlbf(
+        bloomfilter = generate_mlbf(
             stats=stats,
-            blocked=blocked_json,
-            not_blocked=not_blocked_json)
+            blocked=self.blocked_items,
+            not_blocked=self.not_blocked_items)
 
         # write bloomfilter
         mlbf_path = self.filter_path
@@ -214,10 +176,13 @@ class MLBF():
         deletes = previous - current
         return extras, deletes
 
-    def write_stash(self, previous_mlbf):
+    def generate_and_write_stash(self, previous_mlbf):
+        self.write_blocked_items()
+        self.write_not_blocked_items()
+
         # compare previous with current blocks
         extras, deletes = self.generate_diffs(
-            previous_mlbf.blocked_json, self.blocked_json)
+            previous_mlbf.blocked_items, self.blocked_items)
         self.stash_json = {
             'blocked': list(extras),
             'unblocked': list(deletes),
@@ -228,23 +193,66 @@ class MLBF():
             log.info("Writing to file {}".format(stash_path))
             json.dump(self.stash_json, json_file)
 
-    def should_reset_base_filter(self, previous_base_mlbf):
+    def should_reset_base_filter(self, previous_bloom_filter):
         try:
             # compare base with current blocks
             extras, deletes = self.generate_diffs(
-                previous_base_mlbf.blocked_json, self.fetch_blocked_json())
+                previous_bloom_filter.blocked_items, self.blocked_items)
             return (len(extras) + len(deletes)) > BASE_REPLACE_THRESHOLD
         except FileNotFoundError:
             # when previous_base_mlfb._blocked_path doesn't exist
             return True
 
-    def blocks_changed_since_previous(self, previous_base_mlbf):
-        blocked_json = self.fetch_blocked_json()
+    def blocks_changed_since_previous(self, previous_bloom_filter):
         try:
             # compare base with current blocks
             extras, deletes = self.generate_diffs(
-                previous_base_mlbf.blocked_json, blocked_json)
+                previous_bloom_filter.blocked_items, self.blocked_items)
             return len(extras) + len(deletes)
         except FileNotFoundError:
-            # when previous_base_mlfb._blocked_path doesn't exist
-            return len(blocked_json)
+            # when previous_bloom_filter._blocked_path doesn't exist
+            return len(self.blocked_items)
+
+    @classmethod
+    def load_from_storage(cls, *args, **kwargs):
+        return StoredMLBF(*args, **kwargs)
+
+    @classmethod
+    def generate_from_db(cls, *args, **kwargs):
+        return DatabaseMLBF(*args, **kwargs)
+
+
+class StoredMLBF(MLBF):
+
+    @cached_property
+    def blocked_items(self):
+        with storage.open(self._blocked_path, 'r') as json_file:
+            return json.load(json_file)
+
+    @cached_property
+    def not_blocked_items(self):
+        with storage.open(self._not_blocked_path, 'r') as json_file:
+            return json.load(json_file)
+
+
+class DatabaseMLBF(MLBF):
+
+    @cached_property
+    def blocked_items(self):
+        blocked_ids_to_versions = fetch_blocked_from_db()
+        blocked = blocked_ids_to_versions.values()
+        # cache version ids so query in not_blocked_items is efficient
+        self._version_excludes = blocked_ids_to_versions.keys()
+        return list(self.hash_filter_inputs(blocked))
+
+    @cached_property
+    def not_blocked_items(self):
+        # see blocked_items - we need self._version_excludes populated
+        self.blocked_items
+        # even though we exclude all the version ids in the query there's an
+        # edge case where the version string occurs twice for an addon so we
+        # ensure not_blocked_items doesn't contain any blocked_items.
+        return list(
+            self.hash_filter_inputs(
+                fetch_all_versions_from_db(self._version_excludes)) -
+            set(self.blocked_items))


### PR DESCRIPTION
fixes #15426 - most of it ended up being refactoring in mlbf.py to remove some of the magic around how pre-existing data on disk was handled vs. newly generated blocklist data from the database.