### PR TITLE
Log both addon ID and GUID when averages aren't available in update_addon_hotness task

### DIFF
--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -270,6 +270,13 @@ def update_addon_hotness(averages):
 
     for addon in addons:
         average = averages.get(addon.guid)
+
+        # See: https://github.com/mozilla/addons-server/issues/15525
+        if not average:
+            log.error('Averages not found for addon with id=%s and GUID=%s.',
+                      addon.id, addon.guid)
+            continue
+
         this = average['avg_this_week']
         three = average['avg_three_weeks_before']
 


### PR DESCRIPTION
Refs https://github.com/mozilla/addons-server/issues/15525

---

Let's try to have more info about this error and also update other add-ons.