### PR TITLE
use curlylint (and existing fix template problems)

### DIFF
--- a/Makefile-docker
+++ b/Makefile-docker
@@ -191,6 +191,7 @@ setup-codestyle:
 lint: ## lint the code
 	flake8 src/ services/ tests/
 	$(shell npm $(NPM_ARGS) bin)/prettier --check '**'
+	curlylint src/
 
 lint-codestyle: lint
 

--- a/requirements/codestyle.txt
+++ b/requirements/codestyle.txt
@@ -23,3 +23,25 @@ pyflakes==2.2.0 \
 entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451
+# attrs is required by curlylint
+attrs==20.2.0 \
+    --hash=sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc \
+    --hash=sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594
+# parsy is required by curlylint
+parsy==1.3.0 \
+    --hash=sha256:bea54186c3da470944dafe2314b57ac53d0dc2b0a168dc32f644b1b93dc6ca64 \
+    --hash=sha256:bfc941ea5a69e6ac16bd4f7d9f807bbc17e35edd8b95bcd2499a25b059359012
+# click is required by curlylint
+click==7.1.2 \
+    --hash=sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc \
+    --hash=sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a
+# pathspec is required by curlylint
+pathspec==0.8.0 \
+    --hash=sha256:7d91249d21749788d07a2d0f94147accd8f845507400749ea19c1ec9054a12b0 \
+    --hash=sha256:da45173eb3a6f2a5a487efba21f050af2b41948be6ab52b6a1e3ff22bb8b7061
+curlylint==0.12.0 \
+    --hash=sha256:b03a200914a4c315169993c205054b86a49c1934a7d30d2583755a5a0939fed4 \
+    --hash=sha256:e1b09acb26f5d2a3a5f9ee81c541ad76f1311e174e4c08be8e4f7ebd62c20bc0
+toml==0.10.1 \
+    --hash=sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88 \
+    --hash=sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f

--- a/src/olympia/amo/templates/amo/403.html
+++ b/src/olympia/amo/templates/amo/403.html
@@ -20,6 +20,7 @@
         sent. This header is required for security reasons, to ensure
         that your browser is not being hijacked by third parties.
         {% endtrans %}
+      </p>
       <p>
         {% trans %}
         If you have configured your browser to disable 'Referer' headers,

--- a/src/olympia/devhub/templates/devhub/addons/listing/item_actions.html
+++ b/src/olympia/devhub/templates/devhub/addons/listing/item_actions.html
@@ -74,5 +74,5 @@
       </ul>
     </div>
   </li>
-</ul>
 {% endif %}
+</ul>

--- a/src/olympia/devhub/templates/devhub/addons/submit/describe.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/describe.html
@@ -170,14 +170,12 @@
       {{ form.support_url.errors }}
     </div>
     {% if license_form %}
-        <b>{{ _('License:') }}<span class="req" title="{{ _('required') }}">*</span></b>
-        {{ license_form.builtin.errors }}
-        {% if addon.type == amo.ADDON_STATICTHEME %}
-          {% include 'devhub/addons/includes/cc_license_chooser.html' %}
-          <div class="addon-submission-field" id="license-list">
-        {% else %}
-          <div class="addon-submission-field">
-        {% endif %}
+      <b>{{ _('License:') }}<span class="req" title="{{ _('required') }}">*</span></b>
+      {{ license_form.builtin.errors }}
+      {% if addon.type == amo.ADDON_STATICTHEME %}
+        {% include 'devhub/addons/includes/cc_license_chooser.html' %}
+      {% endif %}
+      <div class="addon-submission-field" {% if addon.type == amo.ADDON_STATICTHEME %} id="license-list" {% endif %}>
         {{ _('Please choose a license appropriate for the rights you grant.') }}
         {{ license_form.builtin }}
         {% set show_other = (license_form.initial.builtin == license_other_val or

--- a/src/olympia/devhub/templates/devhub/addons/submit/distribute.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/distribute.html
@@ -22,6 +22,5 @@
         {{ _('Continue') }}
       </button>
     </div>
-  </section>
 </form>
 {% endblock primary %}

--- a/src/olympia/devhub/templates/devhub/addons/submit/done.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/done.html
@@ -66,12 +66,13 @@
 {% endif %}
 
 <p>
-  {% if addon.type == amo.ADDON_STATICTHEME %}
-    <a class="button" href="{{ url('devhub.themes') }}">
-  {% else %}
-    <a class="button" href="{{ url('devhub.addons') }}">
-  {% endif %}
-    {{ _("Go to My Submissions") }}</a>
+  {% with link_text=_("Go to My Submissions") %}
+    {% if addon.type == amo.ADDON_STATICTHEME %}
+      <a class="button" href="{{ url('devhub.themes') }}">{{ link_text }}</a>
+    {% else %}
+      <a class="button" href="{{ url('devhub.addons') }}">{{ link_text }}</a>
+    {% endif %}
+  {% endwith %}
 </p>
 
 {% endblock %}

--- a/src/olympia/devhub/templates/devhub/addons/submit/done.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/done.html
@@ -66,12 +66,8 @@
 {% endif %}
 
 <p>
-  {% with link_text=_("Go to My Submissions") %}
-    {% if addon.type == amo.ADDON_STATICTHEME %}
-      <a class="button" href="{{ url('devhub.themes') }}">{{ link_text }}</a>
-    {% else %}
-      <a class="button" href="{{ url('devhub.addons') }}">{{ link_text }}</a>
-    {% endif %}
+  {% with link=url('devhub.themes') if addon.type == amo.ADDON_STATICTHEME else url('devhub.addons') %}
+    <a class="button" href="{{ link }}">{{ _("Go to My Submissions") }}</a>
   {% endwith %}
 </p>
 

--- a/src/olympia/devhub/templates/devhub/addons/submit/wizard.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/wizard.html
@@ -26,7 +26,6 @@
         {% if addon %}
           <input type="hidden" id="theme-name" value="{{ addon.name }}"/>
           {{ addon.name }}
-      </ul>
         {% else %}
           <input type="text" id="theme-name"/>
           <ul class="general-validation-error errorlist validator">
@@ -58,11 +57,7 @@
         {% set property_list_left = ['tab_background_text','bookmark_text', 'toolbar_field_text'] %}
         {% set existing_colors = existing_properties['colors'] or {} %}
         {% for (property, label, tip, val_default) in colors %}
-          {% if property in property_list_left  %}
-            <li class="row left">
-          {% else %}
-            <li class="row">
-          {% endif %}
+        <li class="row{{ 'left' if property in property_list_left else '' }}">
           <label class="row" for="{{ property }}">
             {{ label }}
             <span>

--- a/src/olympia/devhub/templates/devhub/forms/widgets/compat_app_input_option.html
+++ b/src/olympia/devhub/templates/devhub/forms/widgets/compat_app_input_option.html
@@ -1,1 +1,10 @@
-{% if wrap_label or widget.wrap_label %}<label class="app {{ widget.compat_app_short }}" {% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %}>{% endif %}{% include "django/forms/widgets/input.html" %}{% if wrap_label or widget.wrap_label %} {{ widget.label }}</label>{% endif %}
+{% spaceless %}
+{% if wrap_label or widget.wrap_label %}
+  {% with attr_id=widget.attrs.id|stringformat:'for="%s",' %}
+    <label class="app {{ widget.compat_app_short }}" {{ widget.attrs.id|yesno:attr_id }}>
+        {% include "django/forms/widgets/input.html" %}{{ widget.label }}</label>
+  {% endwith %}
+{% else %}
+    {% include "django/forms/widgets/input.html" %}
+{% endif %}
+{% endspaceless %}

--- a/src/olympia/devhub/templates/devhub/includes/macros.html
+++ b/src/olympia/devhub/templates/devhub/includes/macros.html
@@ -23,7 +23,7 @@
     <div>
       {{ element }}
       {{ element.errors }}
-      <label for="id_{{ element.html_name }}">{{ text }}
+      <label for="id_{{ element.html_name }}">{{ text }}</label>
     </div>
   {% elif element %}
     {{ text }}

--- a/src/olympia/devhub/templates/devhub/versions/list.html
+++ b/src/olympia/devhub/templates/devhub/versions/list.html
@@ -125,7 +125,7 @@
               </div>
               <div class="review-entry-empty hidden">
                   <p><strong class="action">$action_label</strong> {{ _('by') }}
-                  <em class="user_name">$user_name</em> <time class="timeago" datetime=$date>$date</time></p>
+                  <em class="user_name">$user_name</em> <time class="timeago" datetime="$date">$date</time></p>
                   <pre>$comments</pre>
               </div>
           </div>
@@ -134,7 +134,7 @@
               <form class="dev-review-reply-form" action="{{ drf_url('version-reviewnotes-list', addon.id, version.id) }}"
                     data-token="{{ token }}" data-history="#{{ version.id }}-review-history" data-no-csrf>
                   <textarea name="comments" placeholder="{{ _('Leave a reply') }}"></textarea>
-                  <button type="submit" class="submit" >{{ _('Reply') }}</button ty>
+                  <button type="submit" class="submit" >{{ _('Reply') }}</button>
               </form>
             </div>
           {% else %}
@@ -284,6 +284,7 @@
         Once a version has been deleted, you may not upload a new
         version with the same version number.
       {% endtrans %}
+      </p>
       <p>{{ _('Are you sure you wish to delete this version?') }}</p>
       {% csrf_token %}
       <div class="modal-actions">

--- a/src/olympia/pages/templates/pages/pioneer.html
+++ b/src/olympia/pages/templates/pages/pioneer.html
@@ -71,7 +71,7 @@
           </ul>
         </section>
         <section class="program-thanks">
-          <h2 class="program-header">You Help Make Firefox Better</h1>
+          <h2 class="program-header">You Help Make Firefox Better</h2>
           <p>At Mozilla, we pride ourselves on building products for you, the user! That’s why we need your help.</p>
           <p>By participating in this group, you will help us to make better decisions on your behalf and shape the future of Firefox!</p>
           <a href="https://addons.mozilla.org/firefox/downloads/latest/firefox-pioneer/?src=shield-study-16" class="enroll-button">Enroll in Firefox Pioneer</a>

--- a/src/olympia/ratings/templates/ratings/reviews_link.html
+++ b/src/olympia/ratings/templates/ratings/reviews_link.html
@@ -7,12 +7,12 @@
   {% with num=addon.total_ratings %}
     {% if num %}
     {{ addon.average_rating|float|stars }}
-    <a href="{{ base|absolutify }}">
-      {% with count='<span itemprop="count">{0}</span>'|format_html(num|numberfmt) %}
-        {# Using num=count so we don't change an L10n string. #}
-        <strong>{{ ngettext('{num} review', '{num} reviews',
-                            num)|format_html(num=count) }}</strong></a>
-      {% endwith %}
+    {% with count='<span itemprop="count">{0}</span>'|format_html(num|numberfmt) %}
+      {# Using num=count so we don't change an L10n string. #}
+      <a href="{{ base|absolutify }}"><strong>{{
+        ngettext('{num} review', '{num} reviews', num)|format_html(num=count)
+      }}</strong></a>
+    {% endwith %}
     {% else %}
       <strong>{{ _('Not yet rated') }}</strong>
     {% endif %}

--- a/src/olympia/reviewers/templates/reviewers/addon_details_box.html
+++ b/src/olympia/reviewers/templates/reviewers/addon_details_box.html
@@ -144,7 +144,7 @@
           {% if approvals_info %}
             <tr class="last-approval-date">
               <th> {{ _('Last Approval Date') }} </th>
-              <td> {{ approvals_info.last_human_review|date }}
+              <td> {{ approvals_info.last_human_review|date }}</td>
             </tr>
           {% endif %}
         </tbody>

--- a/src/olympia/stats/templates/stats/reports/overview.html
+++ b/src/olympia/stats/templates/stats/reports/overview.html
@@ -18,7 +18,7 @@
     <div class="toplists">
       <div class="toplist">
         <div class="island statbox">
-          <h2>{{ _('Top Applications') }}</h3>
+          <h2>{{ _('Top Applications') }}</h2>
           <div class="piechart"></div>
           <table data-metric="apps">
           </table>
@@ -30,7 +30,7 @@
       </div>
       <div class="toplist">
         <div class="island statbox">
-          <h2>{{ _('Top Languages') }}</h3>
+          <h2>{{ _('Top Languages') }}</h2>
           <div class="piechart"></div>
           <table data-metric="locales">
           </table>
@@ -42,7 +42,7 @@
       </div>
       <div class="toplist">
         <div class='island statbox'>
-          <h2>{{ _('Top Platforms') }}</h3>
+          <h2>{{ _('Top Platforms') }}</h2>
           <div class="piechart"></div>
           <table data-metric="os">
           </table>

--- a/src/olympia/stats/templates/stats/reports/sources.html
+++ b/src/olympia/stats/templates/stats/reports/sources.html
@@ -3,13 +3,13 @@
 {% set title = _('Download sources by Date') %}
 
 {% block stats_note_link %}
-  {% if bigquery_download_stats %}
-  <a href="{{ settings.EXTENSION_WORKSHOP_URL }}/documentation/manage/monitoring-extension-usage-statistics/" target="_blank" rel="noopener noreferrer">
-  {% else %}
-  <a href="#" id="stats-note-link">
-  {% endif %}
-    {{ _('About tracking external sources...') }}
-  </a>
+  {% with link_text=_('About tracking external sources...') %}
+    {% if bigquery_download_stats %}
+    <a href="{{ settings.EXTENSION_WORKSHOP_URL }}/documentation/manage/monitoring-extension-usage-statistics/" target="_blank" rel="noopener noreferrer">{{ link_text }}</a>
+    {% else %}
+    <a href="#" id="stats-note-link">{{ link_text }}</a>
+    {% endif %}
+  {% endwith %}
 {% endblock %}
 
 {% block stats_note %}
@@ -21,6 +21,7 @@
       external site, such as your blog or website, you can append a parameter to be
       tracked as an additional download source on this page. For example, the
       following links would appear as sourced by your blog:
+    </p>
     <dl>
       <dt>Add-on Details Page</dt>
       <dd>https://addons.mozilla.org/addon/{{ slug }}?src=<b>external-blog</b></dd>
@@ -32,6 +33,7 @@
       additional characters. Any text after "external-" can be used to describe the
       source, such as "external-blog", "external-sidebar", "external-campaign225",
       etc. The following URL-safe characters are allowed: <code>a-z A-Z - . _ ~ % +</code>
+    </p>
   {% endtrans %}
 {% endif %}
 {% endblock %}

--- a/src/olympia/users/templates/admin/users/userprofile/change_form.html
+++ b/src/olympia/users/templates/admin/users/userprofile/change_form.html
@@ -6,20 +6,20 @@
     <div class="submit-row">
         <div class="align-left">
             {% comment %}
-              Add custom <button>s for the actions we want on the change form.
+              Add custom buttons for the actions we want on the change form.
               They have to be *after* the other submit buttons, otherwise they
               could become the default submit button of the page
-             {% endcomment %}
-             {% if has_users_edit_permission %}
-                 <input formaction="{% url 'admin:users_userprofile_ban' original.pk|admin_urlquote %}"
-                        type="submit" value="{% trans 'Ban' %}" />
-                 <input formaction="{% url 'admin:users_userprofile_reset_api_key' original.pk|admin_urlquote %}"
-                        type="submit" value="{% trans 'Reset API Key' %}" />
-                 <input formaction="{% url 'admin:users_userprofile_reset_session' original.pk|admin_urlquote %}"
-                        type="submit" value="{% trans 'Reset session(s)' %}" />
-             {% endif %}
-             <input formaction="{% url 'admin:users_userprofile_delete_picture' original.pk|admin_urlquote %}"
-                    type="submit" value="{% trans 'Delete picture' %}" />
+            {% endcomment %}
+            {% if has_users_edit_permission %}
+                <input formaction="{% url 'admin:users_userprofile_ban' original.pk|admin_urlquote %}"
+                       type="submit" value="{% trans 'Ban' %}" />
+                <input formaction="{% url 'admin:users_userprofile_reset_api_key' original.pk|admin_urlquote %}"
+                       type="submit" value="{% trans 'Reset API Key' %}" />
+                <input formaction="{% url 'admin:users_userprofile_reset_session' original.pk|admin_urlquote %}"
+                       type="submit" value="{% trans 'Reset session(s)' %}" />
+            {% endif %}
+            <input formaction="{% url 'admin:users_userprofile_delete_picture' original.pk|admin_urlquote %}"
+                   type="submit" value="{% trans 'Delete picture' %}" />
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
fixes #15535 - most of the fixes were minor, but some needed a bit of reworking to not have fragments of tags spread over `{% if .... endif %}` blocks.   compat_app_input_option.html was a ... challenge (it's django template rather than jinja too which means a more restrictive syntax)