### PR TITLE
Group scanner query results by add-on and channel

### DIFF
--- a/static/css/admin/scannerresult.css
+++ b/static/css/admin/scannerresult.css
@@ -47,3 +47,25 @@
 .field-authors li {
     max-width: 24em;
 }
+
+.model-scannerqueryresult #result_list td, .model-scannerqueryresult #result_list th {
+  border-bottom: 0;
+  border-top: 1px solid #ddd;
+  vertical-align: top;
+}
+
+.model-scannerqueryresult #result_list .row1, .model-scannerqueryresult #result_list .row2 {
+  background: transparent;
+}
+
+.model-scannerqueryresult #result_list .different-addon {
+  border-top: 2px solid #aaa;
+}
+
+.model-scannerqueryresult #result_list .different-channel td, .model-scannerqueryresult #result_list .different-channel th {
+  border-top: 2px solid #ccc;
+}
+
+.model-scannerqueryresult #result_list .same-addon td.field-formatted_addon {
+  border-top: 1px solid transparent;
+}

--- a/static/js/admin/scannerqueryresult.js
+++ b/static/js/admin/scannerqueryresult.js
@@ -1,0 +1,65 @@
+document.addEventListener('DOMContentLoaded', () => {
+  if (!document.body.matches('.change-list.model-scannerqueryresult')) {
+    // This is only for the scanners query result change list page.
+    return;
+  }
+
+  let current_addon = {
+    cell: null,
+    link: null,
+  };
+
+  for (row of result_list.tBodies[0].rows) {
+    let new_addon = {
+      cell: row.querySelector('.field-formatted_addon'),
+      link: row.querySelector('.field-formatted_addon a'),
+    };
+
+    // FIXME: for performance, it might be better to store the elements we
+    // want to change in a list and change them in one go outside of this
+    // loop ?
+    if (new_addon.link) {
+      let classNames = [];
+
+      if (
+        current_addon.cell &&
+        current_addon.link &&
+        new_addon.link.text == current_addon.link.text
+      ) {
+        // That new row contains the same add-on as the previous one.
+        classNames.push('same-addon');
+        if (new_addon.link.href == current_addon.link.href) {
+          // If it's the same link as before, we remove the cell and
+          // increment the rowspwan of the first cell of the row we
+          // found for that add-on.
+          current_addon.cell.rowSpan++;
+          new_addon.cell.parentElement.removeChild(new_addon.cell);
+        } else {
+          // If it's not the same link, then we have just changed
+          // channels for the same add-on. We don't do anything to
+          // the cell, but add a classname to differentiate.
+          classNames.push('different-channel');
+          // The "new_addon" need to be updated so that we
+          // "start" the row from there.
+          current_addon = {
+            cell: new_addon.cell,
+            link: new_addon.link,
+          };
+        }
+      } else {
+        // New add-on, we add a different class to the row and store
+        // this add-on as the current one.
+        classNames.push('different-addon');
+        current_addon = {
+          cell: new_addon.cell,
+          link: new_addon.link,
+        };
+      }
+      // Add the className(s) now that we're done determining what we
+      // need.
+      if (classNames) {
+        row.classList.add(...classNames);
+      }
+    }
+  }
+});

--- a/static/js/admin/scannerqueryresult.js
+++ b/static/js/admin/scannerqueryresult.js
@@ -1,5 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
-  let result_list = document.querySelector(
+  'use strict';
+
+  const result_list = document.querySelector(
     'body.change-list.model-scannerqueryresult #result_list',
   );
 
@@ -13,7 +15,7 @@ document.addEventListener('DOMContentLoaded', () => {
     link: null,
   };
 
-  for (row of result_list.tBodies[0].rows) {
+  for (const row of result_list.tBodies[0].rows) {
     let new_addon = {
       cell: row.querySelector('.field-formatted_addon'),
       link: row.querySelector('.field-formatted_addon a'),

--- a/static/js/admin/scannerqueryresult.js
+++ b/static/js/admin/scannerqueryresult.js
@@ -1,5 +1,9 @@
 document.addEventListener('DOMContentLoaded', () => {
-  if (!document.body.matches('.change-list.model-scannerqueryresult')) {
+  let result_list = document.querySelector(
+    'body.change-list.model-scannerqueryresult #result_list',
+  );
+
+  if (!result_list) {
     // This is only for the scanners query result change list page.
     return;
   }


### PR DESCRIPTION
The way django generates the changelist makes it a bit tricky to customize, so we run some javascript once the dom is loaded to tweak the rowspans, remove duplicate cells and add relevant css classnames.

Fixes #12947

![Screenshot_2020-09-25 Select scanner query result to view Django site admin(1)](https://user-images.githubusercontent.com/187006/94291990-a3e52900-ff5c-11ea-85df-390366305b0d.png)
