### PR TITLE
Raise error when an unknown `strict_max_version` is specified in manifest

### DIFF
--- a/src/olympia/files/tests/test_utils.py
+++ b/src/olympia/files/tests/test_utils.py
@@ -243,28 +243,21 @@ class TestManifestJSONExtractor(AppVersionsMixin, TestCase):
         with pytest.raises(forms.ValidationError) as exc:
             self.parse(data)
         assert exc.value.message == (
-            u'Unknown "strict_min_version" 76.0 for Firefox')
+            'Unknown "strict_min_version" 76.0 for Firefox')
 
     def test_unknown_strict_max_version(self):
         data = {
             'applications': {
                 'gecko': {
                     'strict_max_version': '76.0',
-                    'id': '@unknown_strict_min_version'
+                    'id': '@unknown_strict_max_version'
                 }
             }
         }
-        apps = self.parse(data)['apps']
-        assert len(apps) == 2
-        app = apps[0]
-        assert app.appdata == amo.FIREFOX
-        assert app.min.version == amo.DEFAULT_WEBEXT_MIN_VERSION
-        assert app.max.version == amo.DEFAULT_WEBEXT_MAX_VERSION
-
-        app = apps[1]
-        assert app.appdata == amo.ANDROID
-        assert app.min.version == amo.DEFAULT_WEBEXT_MIN_VERSION_ANDROID
-        assert app.max.version == amo.DEFAULT_WEBEXT_MAX_VERSION
+        with pytest.raises(forms.ValidationError) as exc:
+            self.parse(data)
+        assert exc.value.message == (
+            'Unknown "strict_max_version" 76.0 for Firefox')
 
     def test_strict_min_version_needs_to_be_higher_then_42_if_specified(self):
         """strict_min_version needs to be higher than 42.0 if specified."""
@@ -717,21 +710,14 @@ class TestManifestJSONExtractorStaticTheme(TestManifestJSONExtractor):
             'applications': {
                 'gecko': {
                     'strict_max_version': '76.0',
-                    'id': '@unknown_strict_min_version'
+                    'id': '@unknown_strict_max_version'
                 }
             }
         }
-        apps = self.parse(data)['apps']
-        assert len(apps) == 2
-        app = apps[0]
-        assert app.appdata == amo.FIREFOX
-        assert app.min.version == amo.DEFAULT_STATIC_THEME_MIN_VERSION_FIREFOX
-        assert app.max.version == amo.DEFAULT_WEBEXT_MAX_VERSION
-
-        app = apps[1]
-        assert app.appdata == amo.ANDROID
-        assert app.min.version == amo.DEFAULT_STATIC_THEME_MIN_VERSION_ANDROID
-        assert app.max.version == amo.DEFAULT_WEBEXT_MAX_VERSION
+        with pytest.raises(forms.ValidationError) as exc:
+            self.parse(data)
+        assert exc.value.message == (
+            'Unknown "strict_max_version" 76.0 for Firefox')
 
     def test_dont_skip_apps_because_of_strict_version_incompatibility(self):
         # In the parent class this method would bump the min_version to 48.0

--- a/src/olympia/files/tests/test_utils.py
+++ b/src/olympia/files/tests/test_utils.py
@@ -259,7 +259,7 @@ class TestManifestJSONExtractor(AppVersionsMixin, TestCase):
         assert exc.value.message == (
             'Unknown "strict_max_version" 76.0 for Firefox')
 
-    def test_strict_min_version_needs_to_be_higher_then_42_if_specified(self):
+    def test_strict_min_version_needs_to_be_higher_than_42_if_specified(self):
         """strict_min_version needs to be higher than 42.0 if specified."""
         data = {
             'applications': {

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -506,20 +506,22 @@ class ManifestJSONExtractor(object):
             try:
                 min_appver = qs.get(version=strict_min_version)
             except AppVersion.DoesNotExist:
-                # If the specified strict_min_version can't be found, raise an
-                # error, we can't guess an appropriate one.
                 msg = ugettext(
-                    u'Unknown "strict_min_version" {appver} for {app}'.format(
+                    'Unknown "strict_min_version" {appver} for {app}'.format(
                         app=app.pretty, appver=strict_min_version))
                 raise forms.ValidationError(msg)
 
             try:
                 max_appver = qs.get(version=strict_max_version)
             except AppVersion.DoesNotExist:
-                # If the specified strict_max_version can't be found, this is
-                # less of a problem, ignore and replace with '*'.
-                # https://github.com/mozilla/addons-server/issues/7160
-                max_appver = qs.get(version=amo.DEFAULT_WEBEXT_MAX_VERSION)
+                # If the specified strict_max_version can't be found, raise an
+                # error: we used to use '*' instead but this caused more
+                # problems, especially with langpacks that are really specific
+                # to a given Firefox version.
+                msg = ugettext(
+                    'Unknown "strict_max_version" {appver} for {app}'.format(
+                        app=app.pretty, appver=strict_max_version))
+                raise forms.ValidationError(msg)
 
             yield Extractor.App(
                 appdata=app, id=app.id, min=min_appver, max=max_appver)


### PR DESCRIPTION
We used to ignore those and set `*` instead but that causes issues with langpacks.

Fixes #14654