### PR TITLE
change url to path in olympia.urls.py

### DIFF
--- a/src/olympia/urls.py
+++ b/src/olympia/urls.py
@@ -1,5 +1,18 @@
+#
+# from django.contrib import admin
+# from django.urls import path
+# from django.conf.urls import include
+# from firstapp import views
+#
+# urlpatterns = [
+#     path('first/',include('firstapp.urls')),
+#     path('',views.index,name ='index'),
+#     path('admin/', admin.site.urls),
+# ]
+
 from django.conf import settings
-from django.conf.urls import include, url
+from django.conf.urls import include
+from django.urls import path , re_path
 from django.contrib import admin
 from django.shortcuts import redirect
 from django.views.static import serve as serve_static
@@ -21,84 +34,84 @@ handler500 = 'olympia.amo.views.handler500'
 
 urlpatterns = [
     # Legacy Discovery pane is first for undetectable efficiency wins.
-    url(r'^discovery/.*', lambda request: redirect(
+    re_path(r'^discovery/.*', lambda request: redirect(
         'https://www.mozilla.org/firefox/new/', permanent=True)),
 
     # Home.
-    url(r'^$', frontend_view, name='home'),
+    path('', frontend_view, name='home'),
 
     # Add-ons.
-    url(r'', include('olympia.addons.urls')),
+    path('', include('olympia.addons.urls')),
 
     # Browse pages.
-    url(r'', include('olympia.browse.urls')),
+    path('', include('olympia.browse.urls')),
 
     # Tags.
-    url(r'', include('olympia.tags.urls')),
+    path('', include('olympia.tags.urls')),
 
     # Collections.
-    url(r'', include('olympia.bandwagon.urls')),
+    path('', include('olympia.bandwagon.urls')),
 
     # Do not expose the `upload_patterns` under `files/` because of this issue:
     # https://github.com/mozilla/addons-server/issues/12322
-    url(r'^uploads/', include(upload_patterns)),
+    path('uploads/', include(upload_patterns)),
 
     # Downloads.
-    url(r'^downloads/', include(download_patterns)),
+    path('downloads/', include(download_patterns)),
 
     # Users
-    url(r'', include('olympia.users.urls')),
+    path('', include('olympia.users.urls')),
 
     # Developer Hub.
-    url(r'^developers/', include('olympia.devhub.urls')),
+    path('developers/', include('olympia.devhub.urls')),
 
     # Reviewers Hub.
-    url(r'^reviewers/', include('olympia.reviewers.urls')),
+    path('reviewers/', include('olympia.reviewers.urls')),
 
     # Redirect everything under editors/ (old reviewer urls) to reviewers/.
-    url(r'^editors/(.*)',
+    path('editors/<str:path>/',
         lambda r, path: redirect('/reviewers/%s' % path, permanent=True)),
 
     # AMO admin (not django admin).
-    url(r'^admin/', include('olympia.zadmin.urls')),
+    path('admin', include('olympia.zadmin.urls')),
 
     # Localizable pages.
-    url(r'', include('olympia.pages.urls')),
+    path('', include('olympia.pages.urls')),
 
     # App versions.
-    url(r'pages/appversions/', include('olympia.applications.urls')),
+    path('pages/appversions/', include('olympia.applications.urls')),
 
     # Services
-    url(r'', include('olympia.amo.urls')),
+    path('', include('olympia.amo.urls')),
 
     # Search
-    url(r'^search/', include('olympia.search.urls')),
+    path('search/', include('olympia.search.urls')),
 
     # API v3+.
-    url(r'^api/', include('olympia.api.urls')),
+    path('api/', include('olympia.api.urls')),
 
     # Redirect for all global stats URLs.
-    url(r'^statistics/', lambda r: redirect('/'), name='statistics.dashboard'),
+    path('statistics/', lambda r: redirect('/'), name='statistics.dashboard'),
 
     # Redirect patterns.
-    url(r'^bookmarks/?$',
+    path('bookmarks/',
         lambda r: redirect('browse.extensions', 'bookmarks', permanent=True)),
 
-    url(r'^pages/about$',
+    path('pages/about/',
         lambda r: redirect('pages.about', permanent=True)),
 
-    url(r'^addons/versions/(\d+)/?$',
+    path('addons/versions/<int:id>/',
         lambda r, id: redirect('addons.versions', id, permanent=True)),
 
     # Legacy redirect. Requires a view to get extra data not provided in URL.
-    url(r'^versions/updateInfo/(?P<version_id>\d+)',
+    path('versions/updateInfo/<int:version_id>/',
         version_views.update_info_redirect),
 
-    url(r'^search-engines.*$',
+    re_path(r'^search-engines.*$',
         lambda r: redirect(urlparams(reverse('search.search'), atype=4),
                            permanent=True)),
 
-    url(r'^addons/contribute/(\d+)/?$',
+    path('addons/contribute/<int:id>/',
         lambda r, id: redirect('addons.contribute', id, permanent=True)),
 ]
 
@@ -109,8 +122,8 @@ if settings.DEBUG:
     media_url = settings.MEDIA_URL.lstrip('/').rstrip('/')
 
     urlpatterns.extend([
-        url(r'^%s/(?P<path>.*)$' % media_url,
+        re_path(r'^%s/(?P<path>.*)$' % media_url,
             serve_static,
             {'document_root': settings.MEDIA_ROOT}),
-        url(r'__debug__/', include(debug_toolbar.urls)),
+        re_path(r'__debug__/', include(debug_toolbar.urls)),
     ])

--- a/src/olympia/urls.py
+++ b/src/olympia/urls.py
@@ -1,15 +1,3 @@
-#
-# from django.contrib import admin
-# from django.urls import path
-# from django.conf.urls import include
-# from firstapp import views
-#
-# urlpatterns = [
-#     path('first/',include('firstapp.urls')),
-#     path('',views.index,name ='index'),
-#     path('admin/', admin.site.urls),
-# ]
-
 from django.conf import settings
 from django.conf.urls import include
 from django.urls import path , re_path

--- a/src/olympia/urls.py
+++ b/src/olympia/urls.py
@@ -1,6 +1,5 @@
 from django.conf import settings
-from django.conf.urls import include
-from django.urls import path , re_path
+from django.urls import path , re_path ,include
 from django.contrib import admin
 from django.shortcuts import redirect
 from django.views.static import serve as serve_static


### PR DESCRIPTION
The old django.conf.urls.url() function is replaced with new django.urls.path() function for routing .
The old django.conf.urls.include() function is now importable from django.urls so it is also changed.
The new django.urls.path() function allows a simpler, more readable URL routing syntax.
The django.urls.re_path() is used for complex url mapping.
For Django-2.x , Its more efficient to use the latest path() and re_path() instead of url().
The django.conf.urls.url() function from previous versions is now available as django.urls.re_path(). The old location remains for backwards compatibility, without an imminent deprecation.
