### PR TITLE
Handle download stats without source

### DIFF
--- a/src/olympia/stats/fixtures/files/src/download_counts.hive
+++ b/src/olympia/stats/fixtures/files/src/download_counts.hive
@@ -8,3 +8,4 @@
 2014-07-10	1	 a3615	search
 2014-07-10	1	 disabled-addon	search
 2014-07-10	1	 incomplete-addon	search
+2014-07-10	1	 7661	\N


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/15560

---

Thanks to ops, I was able to review some hive files from production. We have a lot more NULL than before:

```
cat ~/Desktop/2020-09-16_prod.hive |grep -v '\N' |wc -l
   47796

~/projects/mozilla/addons-server fix-download-counts*
❯ cat ~/Desktop/2020-09-28_prod.hive |grep -v '\N' |wc -l
    1506
```

We need to handle those and that's what the patch does.

I created a `DownloadCount` instance manually:

```
DownloadCount.objects.create(addon=addon, count=3, date='2020-09-28', sources={'search': 2, 'null': 1})
```

and ran the `index_stats` command. After that I was able to see the following:

<img width="974" alt="Screenshot 2020-09-29 at 17 41 18" src="https://user-images.githubusercontent.com/217628/94581121-fd11cd00-027a-11eb-80c1-e1a8ff15b54e.png">
