### PR TITLE
GitHub Sponsor path validation & tests

### DIFF
--- a/src/olympia/constants/base.py
+++ b/src/olympia/constants/base.py
@@ -215,6 +215,7 @@ VALID_CONTRIBUTION_DOMAINS = (
     'buymeacoffee.com',
     'donate.mozilla.org',
     'flattr.com',
+    'github.com',
     'ko-fi.com',
     'liberapay.com',
     'micropayment.de',

--- a/src/olympia/devhub/forms.py
+++ b/src/olympia/devhub/forms.py
@@ -342,11 +342,20 @@ class AdditionalDetailsForm(AddonFormBase):
 
     def clean_contributions(self):
         if self.cleaned_data['contributions']:
-            hostname = urlsplit(self.cleaned_data['contributions']).hostname
+            parsed_url = urlsplit(self.cleaned_data['contributions'])
+            hostname = parsed_url.hostname
+            path = parsed_url.path
+            
             if not hostname.endswith(amo.VALID_CONTRIBUTION_DOMAINS):
                 raise forms.ValidationError(ugettext(
                     'URL domain must be one of [%s], or a subdomain.'
                 ) % ', '.join(amo.VALID_CONTRIBUTION_DOMAINS))
+            elif hostname == 'github.com' and not path.startswith('/sponsors/'):
+                # Issue 15497, validate path for GitHub Sponsor
+                raise forms.ValidationError(ugettext(
+                    'URL path for GitHub Sponsor must contain /sponsors/.'
+                ))
+
         return self.cleaned_data['contributions']
 
     def clean(self):

--- a/src/olympia/devhub/forms.py
+++ b/src/olympia/devhub/forms.py
@@ -345,15 +345,16 @@ class AdditionalDetailsForm(AddonFormBase):
             parsed_url = urlsplit(self.cleaned_data['contributions'])
             hostname = parsed_url.hostname
             path = parsed_url.path
-            
+
             if not hostname.endswith(amo.VALID_CONTRIBUTION_DOMAINS):
                 raise forms.ValidationError(ugettext(
                     'URL domain must be one of [%s], or a subdomain.'
                 ) % ', '.join(amo.VALID_CONTRIBUTION_DOMAINS))
-            elif hostname == 'github.com' and not path.startswith('/sponsors/'):
-                # Issue 15497, validate path for GitHub Sponsor
+            elif (hostname == 'github.com' and
+                    not path.startswith('/sponsors/')):
+                # Issue 15497, validate path for GitHub Sponsors
                 raise forms.ValidationError(ugettext(
-                    'URL path for GitHub Sponsor must contain /sponsors/.'
+                    'URL path for GitHub Sponsors must contain /sponsors/.'
                 ))
 
         return self.cleaned_data['contributions']

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -1314,7 +1314,7 @@ class ContributionsTestsMixin(object):
         assert response.status_code == 200
         self.assertFormError(
             response, 'form', 'contributions',
-            'URL path for GitHub Sponsor must contain /sponsors/.'
+            'URL path for GitHub Sponsors must contain /sponsors/.'
         )
 
     def test_contributions_url_valid_domain(self):

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -1306,6 +1306,17 @@ class ContributionsTestsMixin(object):
             'URL domain must be one of [%s], or a subdomain.' %
             ', '.join(amo.VALID_CONTRIBUTION_DOMAINS))
 
+    def test_contributions_url_not_valid_github_sponsors_path(self):
+        assert 'github.com' in amo.VALID_CONTRIBUTION_DOMAINS
+        data = self.get_dict(
+            default_locale='en-US', contributions='https://github.com/random/')
+        response = self.client.post(self.details_edit_url, data)
+        assert response.status_code == 200
+        self.assertFormError(
+            response, 'form', 'contributions',
+            'URL path for GitHub Sponsor must contain /sponsors/.'
+        )
+
     def test_contributions_url_valid_domain(self):
         assert 'paypal.me' in amo.VALID_CONTRIBUTION_DOMAINS
         data = self.get_dict(
@@ -1327,6 +1338,14 @@ class ContributionsTestsMixin(object):
         assert self.addon.reload().contributions == (
             'http://sub.paypal.me/random/?path')
 
+    def test_contributions_url_valid_github_sponsors_path(self):
+        assert 'github.com' in amo.VALID_CONTRIBUTION_DOMAINS
+        data = self.get_dict(
+            default_locale='en-US', contributions='https://github.com/sponsors/random/')
+        response = self.client.post(self.details_edit_url, data)
+        assert response.status_code == 200
+        self.assertNoFormErrors(response)
+        assert self.addon.reload().contributions == 'https://github.com/sponsors/random/'
 
 class BaseTestEditAdditionalDetails(BaseTestEdit):
     __test__ = False

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -1341,11 +1341,15 @@ class ContributionsTestsMixin(object):
     def test_contributions_url_valid_github_sponsors_path(self):
         assert 'github.com' in amo.VALID_CONTRIBUTION_DOMAINS
         data = self.get_dict(
-            default_locale='en-US', contributions='https://github.com/sponsors/random/')
+            default_locale='en-US',
+            contributions='https://github.com/sponsors/random/'
+        )
         response = self.client.post(self.details_edit_url, data)
         assert response.status_code == 200
         self.assertNoFormErrors(response)
-        assert self.addon.reload().contributions == 'https://github.com/sponsors/random/'
+        assert self.addon.reload().contributions == (
+            'https://github.com/sponsors/random/')
+
 
 class BaseTestEditAdditionalDetails(BaseTestEdit):
     __test__ = False


### PR DESCRIPTION
Fixes #15497
The PR implements a special-case path validator for GitHub Sponsor as described by @diox's [reply](https://github.com/mozilla/addons-server/issues/15497#issuecomment-693619605) and adds two tests. 

![immagine](https://user-images.githubusercontent.com/12801153/94745319-bc00e200-037a-11eb-97b8-0347ec73889c.png)
