### PR TITLE
Further tweaks  to code search results display

### DIFF
--- a/src/olympia/scanners/tests/test_admin.py
+++ b/src/olympia/scanners/tests/test_admin.py
@@ -1278,7 +1278,7 @@ class TestScannerQueryResultAdmin(TestCase):
         response = self.client.get(self.list_url)
         assert response.status_code == 200
         html = pq(response.content)
-        assert html('.field-formatted_addon').length == 1
+        assert html('.field-addon_name').length == 1
         authors = html('.field-authors a')
         assert authors.length == 3
         authors_links = list((a.text, a.attrib['href']) for a in
@@ -1396,8 +1396,7 @@ class TestScannerQueryResultAdmin(TestCase):
         assert response.status_code == 200
         doc = pq(response.content)
         assert doc('#result_list tbody > tr').length == 1
-        assert doc('.field-formatted_addon a').text().startswith(
-            unlisted_addon.guid)
+        assert doc('.field-guid').text() == unlisted_addon.guid
 
         response = self.client.get(self.list_url, {
             'version__channel__exact': amo.RELEASE_CHANNEL_LISTED,
@@ -1405,7 +1404,7 @@ class TestScannerQueryResultAdmin(TestCase):
         assert response.status_code == 200
         doc = pq(response.content)
         assert doc('#result_list tbody > tr').length == 1
-        assert doc('.field-formatted_addon a').text().startswith(addon.guid)
+        assert doc('.field-guid').text() == addon.guid
 
     def test_list_filter_addon_status(self):
         incomplete_addon = addon_factory(status=amo.STATUS_NULL)
@@ -1421,8 +1420,7 @@ class TestScannerQueryResultAdmin(TestCase):
         assert response.status_code == 200
         doc = pq(response.content)
         assert doc('#result_list tbody > tr').length == 1
-        assert doc('.field-formatted_addon a').text().startswith(
-            incomplete_addon.guid)
+        assert doc('.field-guid').text() == incomplete_addon.guid
 
         response = self.client.get(self.list_url, {
             'version__addon__status__exact': amo.STATUS_DELETED,
@@ -1430,8 +1428,7 @@ class TestScannerQueryResultAdmin(TestCase):
         assert response.status_code == 200
         doc = pq(response.content)
         assert doc('#result_list tbody > tr').length == 1
-        assert doc('.field-formatted_addon a').text().startswith(
-            deleted_addon.guid)
+        assert doc('.field-guid').text() == deleted_addon.guid
 
     def test_list_filter_addon_visibility(self):
         visible_addon = addon_factory()
@@ -1447,8 +1444,7 @@ class TestScannerQueryResultAdmin(TestCase):
         assert response.status_code == 200
         doc = pq(response.content)
         assert doc('#result_list tbody > tr').length == 1
-        assert doc('.field-formatted_addon a').text().startswith(
-            invisible_addon.guid)
+        assert doc('.field-guid').text() == invisible_addon.guid
 
         response = self.client.get(self.list_url, {
             'version__addon__disabled_by_user__exact': '0',
@@ -1456,8 +1452,7 @@ class TestScannerQueryResultAdmin(TestCase):
         assert response.status_code == 200
         doc = pq(response.content)
         assert doc('#result_list tbody > tr').length == 1
-        assert doc('.field-formatted_addon a').text().startswith(
-            visible_addon.guid)
+        assert doc('.field-guid').text() == visible_addon.guid
 
     def test_list_filter_file_status(self):
         addon_disabled_file = addon_factory()
@@ -1475,8 +1470,7 @@ class TestScannerQueryResultAdmin(TestCase):
         assert response.status_code == 200
         doc = pq(response.content)
         assert doc('#result_list tbody > tr').length == 1
-        assert doc('.field-formatted_addon a').text().startswith(
-            addon_disabled_file.guid)
+        assert doc('.field-guid').text() == addon_disabled_file.guid
 
         response = self.client.get(self.list_url, {
             'version__files__status': '4',
@@ -1484,8 +1478,7 @@ class TestScannerQueryResultAdmin(TestCase):
         assert response.status_code == 200
         doc = pq(response.content)
         assert doc('#result_list tbody > tr').length == 1
-        assert doc('.field-formatted_addon a').text().startswith(
-            addon_approved_file.guid)
+        assert doc('.field-guid').text() == addon_approved_file.guid
 
     def test_list_filter_file_is_signed(self):
         signed_addon = addon_factory(file_kw={'is_signed': True})
@@ -1501,8 +1494,7 @@ class TestScannerQueryResultAdmin(TestCase):
         assert response.status_code == 200
         doc = pq(response.content)
         assert doc('#result_list tbody > tr').length == 1
-        assert doc('.field-formatted_addon a').text().startswith(
-            signed_addon.guid)
+        assert doc('.field-guid').text() == signed_addon.guid
 
         response = self.client.get(self.list_url, {
             'version__files__is_signed': '0',
@@ -1510,8 +1502,7 @@ class TestScannerQueryResultAdmin(TestCase):
         assert response.status_code == 200
         doc = pq(response.content)
         assert doc('#result_list tbody > tr').length == 1
-        assert doc('.field-formatted_addon a').text().startswith(
-            unsigned_addon.guid)
+        assert doc('.field-guid').text() == unsigned_addon.guid
 
     def test_change_page(self):
         rule = ScannerQueryRule.objects.create(name='darule', scanner=YARA)

--- a/static/css/admin/scannerresult.css
+++ b/static/css/admin/scannerresult.css
@@ -16,6 +16,7 @@
 
 #changelist .field-guid {
   min-width: 250px;
+  font-family: monospace;
 }
 
 .field-result_actions .button {

--- a/static/js/admin/scannerqueryresult.js
+++ b/static/js/admin/scannerqueryresult.js
@@ -11,55 +11,52 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   let current_addon = {
-    cell: null,
-    link: null,
+    name_cell: null,
+    guid_cell: null,
+    channel_cell: null,
   };
 
   for (const row of result_list.tBodies[0].rows) {
     let new_addon = {
-      cell: row.querySelector('.field-formatted_addon'),
-      link: row.querySelector('.field-formatted_addon a'),
+      name_cell: row.querySelector('.field-addon_name'),
+      guid_cell: row.querySelector('.field-guid'),
+      channel_cell: row.querySelector('.field-formatted_channel'),
     };
 
     // FIXME: for performance, it might be better to store the elements we
     // want to change in a list and change them in one go outside of this
     // loop ?
-    if (new_addon.link) {
+    if (new_addon.guid_cell && new_addon.name_cell && new_addon.channel_cell) {
       let classNames = [];
 
       if (
-        current_addon.cell &&
-        current_addon.link &&
-        new_addon.link.text == current_addon.link.text
+        current_addon.name_cell &&
+        current_addon.guid_cell &&
+        new_addon.guid_cell.textContent == current_addon.guid_cell.textContent
       ) {
-        // That new row contains the same add-on as the previous one.
+        // That new row contains the same add-on as the previous one. Mark it
+        // as such, remove the new guid & name cell as they are duplicates.
         classNames.push('same-addon');
-        if (new_addon.link.href == current_addon.link.href) {
-          // If it's the same link as before, we remove the cell and
-          // increment the rowspwan of the first cell of the row we
-          // found for that add-on.
-          current_addon.cell.rowSpan++;
-          new_addon.cell.parentElement.removeChild(new_addon.cell);
-        } else {
-          // If it's not the same link, then we have just changed
-          // channels for the same add-on. We don't do anything to
-          // the cell, but add a classname to differentiate.
+        current_addon.guid_cell.rowSpan++;
+        row.removeChild(new_addon.guid_cell);
+        current_addon.name_cell.rowSpan++;
+        row.removeChild(new_addon.name_cell);
+
+        if (
+          new_addon.channel_cell.textContent !=
+          current_addon.channel_cell.textContent
+        ) {
+          // Still the same add-on, but different channel. We don't do
+          // anything to the cell, but add a classname to the row to
+          // differentiate it.
           classNames.push('different-channel');
-          // The "new_addon" need to be updated so that we
-          // "start" the row from there.
-          current_addon = {
-            cell: new_addon.cell,
-            link: new_addon.link,
-          };
+          current_addon.channel_cell = new_addon.channel_cell;
         }
       } else {
         // New add-on, we add a different class to the row and store
         // this add-on as the current one.
         classNames.push('different-addon');
-        current_addon = {
-          cell: new_addon.cell,
-          link: new_addon.link,
-        };
+        current_addon = new_addon;
       }
       // Add the className(s) now that we're done determining what we
       // need.


### PR DESCRIPTION
- Review link is now on the channel column, always repeated
- Guid is now back to being a separate column (with a monospace font to differentiate it from the add-on name)
- Name and guid duplicates are now always eliminated
- Download link column has been added

Fixes https://github.com/mozilla/addons-server/issues/15628