### PR TITLE
Remove Send from devhubs footer Fixes  #15547

### DIFF
--- a/src/olympia/templates/photon-footer.html
+++ b/src/olympia/templates/photon-footer.html
@@ -37,7 +37,6 @@
             <ul class="Footer-links">
                 <li><a href="https://www.mozilla.org/firefox/lockwise/?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=footer-link">Lockwise</a></li>
                 <li><a href="https://monitor.firefox.com/?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=footer-link">Monitor</a></li>
-                <li><a href="https://send.firefox.com/?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=footer-link">Send</a></li>
                 <li><a href="https://www.mozilla.org/firefox/browsers/?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=footer-link">Browsers</a></li>
                 <li><a href="https://getpocket.com/?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=footer-link">Pocket</a></li>
             </ul>


### PR DESCRIPTION
Close  #15547
I removed the Send <a/> tag from src/olympia/templates/photon-footer.html