### PR TITLE
Fix test_more_recent_version_pending_rejection_as_well intermittent failure

### DIFF
--- a/src/olympia/reviewers/tests/test_commands.py
+++ b/src/olympia/reviewers/tests/test_commands.py
@@ -907,7 +907,7 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
             ActivityLog.create(
                 amo.LOG.REJECT_VERSION_DELAYED,
                 addon, version, details={'comments': 'fôo'}, user=self.user)
-        more_recent_version = version_factory(addon=addon)
+        more_recent_version = version_factory(addon=addon, version='43.0')
         VersionReviewerFlags.objects.create(
             version=more_recent_version,
             pending_rejection=datetime.now() + timedelta(days=3))


### PR DESCRIPTION
Need to guarantee the version number won't be the same as the other the test is using.

Fixes #15632