### PR TITLE
Replace email based checks for add-ons with permission checks

### DIFF
--- a/src/olympia/access/acl.py
+++ b/src/olympia/access/acl.py
@@ -46,7 +46,8 @@ def action_allowed_user(user, permission):
 
 
 def experiments_submission_allowed(user, parsed_addon_data):
-    """Experiments can only be submitted by the people with the right group.
+    """Experiments can only be submitted by the people with the right
+    permission.
 
     See bug 1220097.
     """
@@ -56,7 +57,8 @@ def experiments_submission_allowed(user, parsed_addon_data):
 
 
 def langpack_submission_allowed(user, parsed_addon_data):
-    """Language packs can only be submitted by people in the right group.
+    """Language packs can only be submitted by people with the right
+    permission.
 
     See https://github.com/mozilla/addons-server/issues/11788 and
     https://github.com/mozilla/addons-server/issues/11793
@@ -64,6 +66,25 @@ def langpack_submission_allowed(user, parsed_addon_data):
     return (
         not parsed_addon_data.get('type') == amo.ADDON_LPAPP or
         action_allowed_user(user, amo.permissions.LANGPACK_SUBMIT))
+
+
+def system_addon_submission_allowed(user, parsed_addon_data):
+    """Add-ons with a guid ending with reserved suffixes can only be submitted
+    by people with the right permission.
+    """
+    guid = parsed_addon_data.get('guid') or ''
+    return (
+        not guid.lower().endswith(amo.SYSTEM_ADDON_GUIDS) or
+        action_allowed_user(user, amo.permissions.SYSTEM_ADDON_SUBMIT))
+
+
+def mozilla_signed_extension_submission_allowed(user, parsed_addon_data):
+    """Add-ons already signed with mozilla internal certificate can only be
+    submitted by people with the right permission.
+    """
+    return (
+        not parsed_addon_data.get('is_mozilla_signed_extension') or
+        action_allowed_user(user, amo.permissions.SYSTEM_ADDON_SUBMIT))
 
 
 def check_ownership(request, obj, require_owner=False, require_author=False,

--- a/src/olympia/addons/utils.py
+++ b/src/olympia/addons/utils.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.utils.translation import ugettext
 
 from olympia import amo
+from olympia.access.acl import action_allowed_user
 from olympia.amo.utils import normalize_string
 from olympia.discovery.utils import call_recommendation_server
 from olympia.translations.fields import LocaleErrorMessage
@@ -16,8 +17,8 @@ def generate_addon_guid():
 
 def verify_mozilla_trademark(name, user, form=None):
     skip_trademark_check = (
-        user and user.is_authenticated and user.email and
-        user.email.endswith(amo.ALLOWED_TRADEMARK_SUBMITTING_EMAILS))
+        user and user.is_authenticated and action_allowed_user(
+            user, amo.permissions.TRADEMARK_BYPASS))
 
     def _check(name):
         name = normalize_string(name, strip_punctuation=True).lower()

--- a/src/olympia/constants/base.py
+++ b/src/olympia/constants/base.py
@@ -405,9 +405,6 @@ SYSTEM_ADDON_GUIDS = (
 MOZILLA_TRADEMARK_SYMBOLS = (
     'mozilla', 'firefox')
 
-ALLOWED_TRADEMARK_SUBMITTING_EMAILS = (
-    '@mozilla.com', '@mozilla.org')
-
 # If you add/remove any sources, update the docs: /api/download_sources.html
 # Note there are some additional sources here for historical/backwards compat.
 DOWNLOAD_SOURCES_FULL = (

--- a/src/olympia/constants/permissions.py
+++ b/src/olympia/constants/permissions.py
@@ -78,6 +78,13 @@ ABUSEREPORTS_EDIT = AclPermission('AbuseReports', 'Edit')
 # Can submit language packs. #11788 and #11793
 LANGPACK_SUBMIT = AclPermission('LanguagePack', 'Submit')
 
+# Can submit add-ons signed with Mozilla internal certificate, or add-ons with
+# a guid ending with reserved suffixes like @mozilla.com
+SYSTEM_ADDON_SUBMIT = AclPermission('SystemAddon', 'Submit')
+
+# Can automatically bypass trademark checks
+TRADEMARK_BYPASS = AclPermission('Trademark', 'Bypass')
+
 # Can create AppVersion instances
 APPVERSIONS_CREATE = AclPermission('AppVersions', 'Create')
 

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -1380,9 +1380,9 @@ class TestUploadDetail(BaseUploadTest):
 
     @mock.patch('olympia.devhub.tasks.run_addons_linter')
     def test_system_addon_allowed(self, mock_validator):
-        user = user_factory(email='redpanda@mozilla.com')
+        user = user_factory()
         self.grant_permission(user, 'SystemAddon:Submit')
-        assert self.client.login(email='redpanda@mozilla.com')
+        assert self.client.login(email=user.email)
         mock_validator.return_value = json.dumps(self.validation_ok())
         self.upload_file(
             '../../../files/fixtures/files/mozilla_guid.xpi')
@@ -1415,8 +1415,8 @@ class TestUploadDetail(BaseUploadTest):
     @mock.patch('olympia.devhub.tasks.run_addons_linter')
     @mock.patch('olympia.files.utils.get_signer_organizational_unit_name')
     def test_mozilla_signed_allowed(self, mock_get_signature, mock_validator):
-        user = user_factory(email='redpanda@mozilla.com')
-        assert self.client.login(email='redpanda@mozilla.com')
+        user = user_factory()
+        assert self.client.login(email=user.email)
         self.grant_permission(user, 'SystemAddon:Submit')
         mock_validator.return_value = json.dumps(self.validation_ok())
         mock_get_signature.return_value = "Mozilla Extensions"
@@ -1455,9 +1455,9 @@ class TestUploadDetail(BaseUploadTest):
         We also don't call amo-validator on them but we issue a warning
         about being legacy add-ons.
         """
-        user = user_factory(email='verypinkpanda@mozilla.com')
+        user = user_factory()
         self.grant_permission(user, 'SystemAddon:Submit')
-        assert self.client.login(email='verypinkpanda@mozilla.com')
+        assert self.client.login(email=user.email)
         self.upload_file(os.path.join(
             settings.ROOT, 'src', 'olympia', 'files', 'fixtures', 'files',
             'legacy-addon-already-signed-0.1.0.xpi'))

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -1380,7 +1380,8 @@ class TestUploadDetail(BaseUploadTest):
 
     @mock.patch('olympia.devhub.tasks.run_addons_linter')
     def test_system_addon_allowed(self, mock_validator):
-        user_factory(email='redpanda@mozilla.com')
+        user = user_factory(email='redpanda@mozilla.com')
+        self.grant_permission(user, 'SystemAddon:Submit')
         assert self.client.login(email='redpanda@mozilla.com')
         mock_validator.return_value = json.dumps(self.validation_ok())
         self.upload_file(
@@ -1392,9 +1393,9 @@ class TestUploadDetail(BaseUploadTest):
         assert data['validation']['messages'] == []
 
     @mock.patch('olympia.devhub.tasks.run_addons_linter')
-    def test_system_addon_not_allowed_not_mozilla(self, mock_validator):
-        user_factory(email='bluepanda@notzilla.com')
-        assert self.client.login(email='bluepanda@notzilla.com')
+    def test_system_addon_not_allowed_not_allowed(self, mock_validator):
+        user_factory(email='redpanda@mozilla.com')
+        assert self.client.login(email='redpanda@mozilla.com')
         mock_validator.return_value = json.dumps(self.validation_ok())
         self.upload_file(
             '../../../files/fixtures/files/mozilla_guid.xpi')
@@ -1414,8 +1415,9 @@ class TestUploadDetail(BaseUploadTest):
     @mock.patch('olympia.devhub.tasks.run_addons_linter')
     @mock.patch('olympia.files.utils.get_signer_organizational_unit_name')
     def test_mozilla_signed_allowed(self, mock_get_signature, mock_validator):
-        user_factory(email='redpanda@mozilla.com')
+        user = user_factory(email='redpanda@mozilla.com')
         assert self.client.login(email='redpanda@mozilla.com')
+        self.grant_permission(user, 'SystemAddon:Submit')
         mock_validator.return_value = json.dumps(self.validation_ok())
         mock_get_signature.return_value = "Mozilla Extensions"
         self.upload_file(
@@ -1427,9 +1429,9 @@ class TestUploadDetail(BaseUploadTest):
         assert data['validation']['messages'] == []
 
     @mock.patch('olympia.files.utils.get_signer_organizational_unit_name')
-    def test_mozilla_signed_not_allowed_not_mozilla(self, mock_get_signature):
-        user_factory(email='bluepanda@notzilla.com')
-        assert self.client.login(email='bluepanda@notzilla.com')
+    def test_mozilla_signed_not_allowed_not_allowed(self, mock_get_signature):
+        user_factory(email='redpanda@mozilla.com')
+        assert self.client.login(email='redpanda@mozilla.com')
         mock_get_signature.return_value = 'Mozilla Extensions'
         self.upload_file(
             '../../../files/fixtures/files/webextension_signed_already.xpi')
@@ -1453,7 +1455,8 @@ class TestUploadDetail(BaseUploadTest):
         We also don't call amo-validator on them but we issue a warning
         about being legacy add-ons.
         """
-        user_factory(email='verypinkpanda@mozilla.com')
+        user = user_factory(email='verypinkpanda@mozilla.com')
+        self.grant_permission(user, 'SystemAddon:Submit')
         assert self.client.login(email='verypinkpanda@mozilla.com')
         self.upload_file(os.path.join(
             settings.ROOT, 'src', 'olympia', 'files', 'fixtures', 'files',

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -700,7 +700,7 @@ class TestAddonSubmitUpload(UploadTest, TestCase):
         assert Addon.objects.count() == 0
         path = os.path.join(
             settings.ROOT,
-            'src/olympia/devhub/tests/addons/valid_webextension.xpi')
+            'src/olympia/files/fixtures/files/webextension.xpi')
         self.upload = self.get_upload(abspath=path)
         response = self.post()
         addon = Addon.objects.get()
@@ -714,7 +714,7 @@ class TestAddonSubmitUpload(UploadTest, TestCase):
         assert Addon.objects.count() == 0
         path = os.path.join(
             settings.ROOT,
-            'src/olympia/devhub/tests/addons/valid_webextension.xpi')
+            'src/olympia/files/fixtures/files/webextension.xpi')
         self.upload = self.get_upload(abspath=path)
         response = self.post(listed=False)
         addon = Addon.objects.get()

--- a/src/olympia/files/tests/test_commands.py
+++ b/src/olympia/files/tests/test_commands.py
@@ -39,7 +39,7 @@ class TestExtractOptionalPermissions(UploadTest):
 
     def test_extract(self):
         upload = self.get_upload('webextension_no_id.xpi')
-        parsed_data = parse_addon(upload, user=mock.Mock())
+        parsed_data = parse_addon(upload, user=mock.Mock(groups_list=[]))
 
         # Remove the optional permissions from the parsed data so they aren't
         # added.

--- a/src/olympia/files/tests/test_models.py
+++ b/src/olympia/files/tests/test_models.py
@@ -653,7 +653,7 @@ class TestParseXpi(TestCase):
         assert parsed['is_experiment']
 
     def test_match_mozilla_signed_extension(self):
-        self.user.update(email='foo@mozilla.com')
+        self.grant_permission(self.user, 'SystemAddon:Submit')
         parsed = self.parse(filename='webextension_signed_already.xpi')
         assert parsed['is_mozilla_signed_extension']
 

--- a/src/olympia/files/tests/test_utils.py
+++ b/src/olympia/files/tests/test_utils.py
@@ -352,7 +352,8 @@ class TestManifestJSONExtractor(AppVersionsMixin, TestCase):
 
     def test_moz_signed_extension_no_strict_compat(self):
         addon = amo.tests.addon_factory()
-        user = amo.tests.user_factory(email='foo@mozilla.com')
+        user = amo.tests.user_factory()
+        self.grant_permission(user, 'SystemAddon:Submit')
         file_obj = addon.current_version.all_files[0]
         file_obj.update(is_mozilla_signed_extension=True)
         fixture = (
@@ -366,7 +367,8 @@ class TestManifestJSONExtractor(AppVersionsMixin, TestCase):
 
     def test_moz_signed_extension_reuse_strict_compat(self):
         addon = amo.tests.addon_factory()
-        user = amo.tests.user_factory(email='foo@mozilla.com')
+        user = amo.tests.user_factory()
+        self.grant_permission(user, 'SystemAddon:Submit')
         file_obj = addon.current_version.all_files[0]
         file_obj.update(is_mozilla_signed_extension=True)
         fixture = (

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -42,9 +42,6 @@ from olympia.amo.utils import decode_json, find_language, rm_local_tmp_dir
 from olympia.applications.models import AppVersion
 from olympia.lib.crypto.signing import get_signer_organizational_unit_name
 from olympia.lib import unicodehelper
-from olympia.users.utils import (
-    mozilla_signed_extension_submission_allowed,
-    system_addon_submission_allowed)
 
 from olympia.versions.compare import version_int as vint
 
@@ -1072,7 +1069,7 @@ def check_xpi_info(xpi_info, addon=None, xpi_file=None, user=None):
         raise forms.ValidationError(
             ugettext(u'You cannot submit this type of add-on'))
 
-    if not addon and not system_addon_submission_allowed(
+    if not addon and not acl.system_addon_submission_allowed(
             user, xpi_info):
         guids = ' or '.join(
                 '"' + guid + '"' for guid in amo.SYSTEM_ADDON_GUIDS)
@@ -1080,7 +1077,7 @@ def check_xpi_info(xpi_info, addon=None, xpi_file=None, user=None):
             ugettext('You cannot submit an add-on using an ID ending with '
                      '%s' % guids))
 
-    if not mozilla_signed_extension_submission_allowed(user, xpi_info):
+    if not acl.mozilla_signed_extension_submission_allowed(user, xpi_info):
         raise forms.ValidationError(
             ugettext(u'You cannot submit a Mozilla Signed Extension'))
 

--- a/src/olympia/signing/tests/test_views.py
+++ b/src/olympia/signing/tests/test_views.py
@@ -262,7 +262,7 @@ class TestUploadVersion(BaseUploadVersionTestMixin, TestCase):
 
     def test_mozilla_signed_allowed(self):
         guid = '@webextension-guid'
-        self.user.update(email='redpanda@mozilla.com')
+        self.grant_permission(self.user, 'SystemAddon:Submit')
         qs = Addon.unfiltered.filter(guid=guid)
         assert not qs.exists()
         response = self.request(
@@ -281,9 +281,8 @@ class TestUploadVersion(BaseUploadVersionTestMixin, TestCase):
         assert latest_version.channel == amo.RELEASE_CHANNEL_UNLISTED
         assert latest_version.all_files[0].is_mozilla_signed_extension
 
-    def test_mozilla_signed_not_allowed_not_mozilla(self):
+    def test_mozilla_signed_not_allowed(self):
         guid = '@webextension-guid'
-        self.user.update(email='yellowpanda@notzilla.com')
         qs = Addon.unfiltered.filter(guid=guid)
         assert not qs.exists()
         response = self.request(
@@ -297,7 +296,7 @@ class TestUploadVersion(BaseUploadVersionTestMixin, TestCase):
 
     def test_system_addon_allowed(self):
         guid = 'systemaddon@mozilla.org'
-        self.user.update(email='redpanda@mozilla.com')
+        self.grant_permission(self.user, 'SystemAddon:Submit')
         qs = Addon.unfiltered.filter(guid=guid)
         assert not qs.exists()
         response = self.request(
@@ -315,9 +314,8 @@ class TestUploadVersion(BaseUploadVersionTestMixin, TestCase):
         assert latest_version
         assert latest_version.channel == amo.RELEASE_CHANNEL_UNLISTED
 
-    def test_system_addon_not_allowed_not_mozilla(self):
+    def test_system_addon_not_allowed(self):
         guid = 'systemaddon@mozilla.com'
-        self.user.update(email='yellowpanda@notzilla.com')
         qs = Addon.unfiltered.filter(guid=guid)
         assert not qs.exists()
         response = self.request(

--- a/src/olympia/users/tests/test_user_utils.py
+++ b/src/olympia/users/tests/test_user_utils.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from olympia.amo.tests import user_factory
-from olympia.users.utils import (
-    UnsubscribeCode, system_addon_submission_allowed)
+from olympia.users.utils import UnsubscribeCode
 
 
 def test_email_unsubscribe_code_parse():
@@ -18,28 +16,3 @@ def test_email_unsubscribe_code_parse():
         UnsubscribeCode.parse(token, hash_[:-5])
     with pytest.raises(ValueError):
         UnsubscribeCode.parse(token[5:], hash_)
-
-
-system_guids = pytest.mark.parametrize('guid', [
-    'foø@mozilla.org', 'baa@shield.mozilla.org', 'moo@pioneer.mozilla.org',
-    'blâh@mozilla.com', 'foø@Mozilla.Org', 'addon@shield.moZilla.com',
-    'baa@ShielD.MozillA.OrG', 'moo@PIONEER.mozilla.org', 'blâh@MOZILLA.COM',
-    'flop@search.mozilla.org', 'user@mozillaonline.com',
-    'tester@MoZiLlAoNlInE.CoM'
-])
-
-
-@system_guids
-@pytest.mark.django_db
-def test_system_addon_submission_allowed_mozilla_allowed(guid):
-    user = user_factory(email='firefox@mozilla.com')
-    data = {'guid': guid}
-    assert system_addon_submission_allowed(user, data)
-
-
-@system_guids
-@pytest.mark.django_db
-def test_system_addon_submission_allowed_not_mozilla_not_allowed(guid):
-    user = user_factory(email='waterbadger@notzilla.org')
-    data = {'guid': guid}
-    assert not system_addon_submission_allowed(user, data)

--- a/src/olympia/users/utils.py
+++ b/src/olympia/users/utils.py
@@ -7,7 +7,6 @@ from django.utils.encoding import force_bytes, force_text
 
 import olympia.core.logger
 
-from olympia import amo
 from olympia.users.models import UserProfile
 
 
@@ -52,16 +51,3 @@ def get_task_user():
     cron jobs or long running tasks.
     """
     return UserProfile.objects.get(pk=settings.TASK_USER_ID)
-
-
-def system_addon_submission_allowed(user, parsed_addon_data):
-    guid = parsed_addon_data.get('guid') or ''
-    return (
-        not guid.lower().endswith(amo.SYSTEM_ADDON_GUIDS) or
-        user.email.endswith(u'@mozilla.com'))
-
-
-def mozilla_signed_extension_submission_allowed(user, parsed_addon_data):
-    return (
-        not parsed_addon_data.get('is_mozilla_signed_extension') or
-        user.email.endswith(u'@mozilla.com'))

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -848,6 +848,7 @@ class TestVersionFromUpload(UploadTest, TestCase):
         self.addon.update(guid='guid@xpi')
         self.selected_app = amo.FIREFOX.id
         self.dummy_parsed_data = {'version': '0.1'}
+        self.fake_user = mock.Mock(groups_list=[])
 
 
 class TestExtensionVersionFromUpload(TestVersionFromUpload):
@@ -950,7 +951,7 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
         assert version.license_id is None
 
     def test_app_versions(self):
-        parsed_data = parse_addon(self.upload, self.addon, user=mock.Mock())
+        parsed_data = parse_addon(self.upload, self.addon, user=self.fake_user)
         version = Version.from_upload(
             self.upload, self.addon, [self.selected_app],
             amo.RELEASE_CHANNEL_LISTED,
@@ -967,7 +968,7 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
         self.filename = 'duplicate_target_applications.xpi'
         self.addon.update(guid='duplicatetargetapps@xpi')
         self.upload = self.get_upload(self.filename)
-        parsed_data = parse_addon(self.upload, self.addon, user=mock.Mock())
+        parsed_data = parse_addon(self.upload, self.addon, user=self.fake_user)
         version = Version.from_upload(
             self.upload, self.addon, [self.selected_app],
             amo.RELEASE_CHANNEL_LISTED, parsed_data=parsed_data)
@@ -979,7 +980,7 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
         assert app.max.version == '3.6.*'
 
     def test_compatible_apps_is_pre_generated(self):
-        parsed_data = parse_addon(self.upload, self.addon, user=mock.Mock())
+        parsed_data = parse_addon(self.upload, self.addon, user=self.fake_user)
         # We mock File.from_upload() to prevent it from accessing
         # version.compatible_apps early - we want to test that the cache has
         # been generated regardless.
@@ -1004,7 +1005,7 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
         assert app.max.version == '3.6.*'
 
     def test_version_number(self):
-        parsed_data = parse_addon(self.upload, self.addon, user=mock.Mock())
+        parsed_data = parse_addon(self.upload, self.addon, user=self.fake_user)
         version = Version.from_upload(
             self.upload, self.addon, [self.selected_app],
             amo.RELEASE_CHANNEL_LISTED,
@@ -1012,7 +1013,7 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
         assert version.version == '0.1'
 
     def test_file_platform(self):
-        parsed_data = parse_addon(self.upload, self.addon, user=mock.Mock())
+        parsed_data = parse_addon(self.upload, self.addon, user=self.fake_user)
         version = Version.from_upload(
             self.upload, self.addon, [self.selected_app],
             amo.RELEASE_CHANNEL_LISTED,
@@ -1022,7 +1023,7 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
         assert files[0].platform == amo.PLATFORM_ALL.id
 
     def test_file_name(self):
-        parsed_data = parse_addon(self.upload, self.addon, user=mock.Mock())
+        parsed_data = parse_addon(self.upload, self.addon, user=self.fake_user)
         version = Version.from_upload(
             self.upload, self.addon, [self.selected_app],
             amo.RELEASE_CHANNEL_LISTED,
@@ -1035,7 +1036,7 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
 
     def test_creates_platform_files(self):
         # We are creating files for 'all' platforms every time, #8752
-        parsed_data = parse_addon(self.upload, self.addon, user=mock.Mock())
+        parsed_data = parse_addon(self.upload, self.addon, user=self.fake_user)
         version = Version.from_upload(
             self.upload, self.addon, [self.selected_app],
             amo.RELEASE_CHANNEL_LISTED,
@@ -1046,7 +1047,7 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
 
     def test_desktop_creates_all_platform_files(self):
         # We are creating files for 'all' platforms every time, #8752
-        parsed_data = parse_addon(self.upload, self.addon, user=mock.Mock())
+        parsed_data = parse_addon(self.upload, self.addon, user=self.fake_user)
         version = Version.from_upload(
             self.upload,
             self.addon,
@@ -1060,7 +1061,7 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
 
     def test_android_creates_all_platform_files(self):
         # We are creating files for 'all' platforms every time, #8752
-        parsed_data = parse_addon(self.upload, self.addon, user=mock.Mock())
+        parsed_data = parse_addon(self.upload, self.addon, user=self.fake_user)
         version = Version.from_upload(
             self.upload,
             self.addon,
@@ -1077,7 +1078,7 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
         assert storage.exists(path)
         with storage.open(path) as file_:
             uploaded_hash = hashlib.sha256(file_.read()).hexdigest()
-        parsed_data = parse_addon(self.upload, self.addon, user=mock.Mock())
+        parsed_data = parse_addon(self.upload, self.addon, user=self.fake_user)
         version = Version.from_upload(
             self.upload, self.addon, [amo.FIREFOX.id, amo.ANDROID.id],
             amo.RELEASE_CHANNEL_LISTED,
@@ -1131,7 +1132,7 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
 
     @mock.patch('olympia.amo.tasks.sync_object_to_basket')
     def test_from_upload_unlisted(self, sync_object_to_basket_mock):
-        parsed_data = parse_addon(self.upload, self.addon, user=mock.Mock())
+        parsed_data = parse_addon(self.upload, self.addon, user=self.fake_user)
         version = Version.from_upload(
             self.upload,
             self.addon,
@@ -1151,7 +1152,7 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
     @mock.patch('olympia.amo.tasks.sync_object_to_basket')
     def test_from_upload_listed_not_synced_with_basket(
             self, sync_object_to_basket_mock):
-        parsed_data = parse_addon(self.upload, self.addon, user=mock.Mock())
+        parsed_data = parse_addon(self.upload, self.addon, user=self.fake_user)
         version = Version.from_upload(
             self.upload,
             self.addon,
@@ -1347,7 +1348,7 @@ class TestSearchVersionFromUpload(TestVersionFromUpload):
         self.now = datetime.now().strftime('%Y%m%d')
 
     def test_version_number(self):
-        parsed_data = parse_addon(self.upload, self.addon, user=mock.Mock())
+        parsed_data = parse_addon(self.upload, self.addon, user=self.fake_user)
         version = Version.from_upload(
             self.upload, self.addon, [self.selected_app],
             amo.RELEASE_CHANNEL_LISTED,
@@ -1355,7 +1356,7 @@ class TestSearchVersionFromUpload(TestVersionFromUpload):
         assert version.version == self.now
 
     def test_file_name(self):
-        parsed_data = parse_addon(self.upload, self.addon, user=mock.Mock())
+        parsed_data = parse_addon(self.upload, self.addon, user=self.fake_user)
         version = Version.from_upload(
             self.upload, self.addon, [self.selected_app],
             amo.RELEASE_CHANNEL_LISTED,
@@ -1365,7 +1366,7 @@ class TestSearchVersionFromUpload(TestVersionFromUpload):
             u'delicious_bookmarks-%s.xml' % self.now)
 
     def test_file_platform_is_always_all(self):
-        parsed_data = parse_addon(self.upload, self.addon, user=mock.Mock())
+        parsed_data = parse_addon(self.upload, self.addon, user=self.fake_user)
         version = Version.from_upload(
             self.upload, self.addon, [self.selected_app],
             amo.RELEASE_CHANNEL_LISTED,
@@ -1401,7 +1402,7 @@ class TestPermissionsFromUpload(TestVersionFromUpload):
         self.current = self.addon.current_version
 
     def test_permissions_includes_devtools(self):
-        parsed_data = parse_addon(self.upload, self.addon, user=mock.Mock())
+        parsed_data = parse_addon(self.upload, self.addon, user=self.fake_user)
         version = Version.from_upload(
             self.upload,
             self.addon,


### PR DESCRIPTION
- `SystemAddon:Submit` allows you to submit add-ons with reserved guids and xpis already signed with internal certificate
- `Trademark:Bypass` allows you to bypass trademark checks

Fixes #15655