### PR TITLE
change import settings of include()

### DIFF
--- a/src/olympia/abuse/urls.py
+++ b/src/olympia/abuse/urls.py
@@ -1,4 +1,4 @@
-from django.urls import re_path, include
+from django.urls import include, re_path
 
 from rest_framework.routers import SimpleRouter
 from .views import AddonAbuseViewSet, UserAbuseViewSet

--- a/src/olympia/abuse/urls.py
+++ b/src/olympia/abuse/urls.py
@@ -1,5 +1,4 @@
-from django.conf.urls import include
-from django.urls import re_path
+from django.urls import re_path, include
 
 from rest_framework.routers import SimpleRouter
 from .views import AddonAbuseViewSet, UserAbuseViewSet

--- a/src/olympia/accounts/urls.py
+++ b/src/olympia/accounts/urls.py
@@ -1,5 +1,4 @@
-from django.conf.urls import include
-from django.urls import re_path
+from django.urls import re_path, include
 
 from rest_framework.routers import SimpleRouter
 from rest_framework_nested.routers import NestedSimpleRouter

--- a/src/olympia/accounts/urls.py
+++ b/src/olympia/accounts/urls.py
@@ -1,4 +1,4 @@
-from django.urls import re_path, include
+from django.urls import include, re_path
 
 from rest_framework.routers import SimpleRouter
 from rest_framework_nested.routers import NestedSimpleRouter

--- a/src/olympia/addons/api_urls.py
+++ b/src/olympia/addons/api_urls.py
@@ -1,5 +1,4 @@
-from django.conf.urls import include
-from django.urls import re_path
+from django.urls import re_path, include
 
 from rest_framework.routers import SimpleRouter
 from rest_framework_nested.routers import NestedSimpleRouter

--- a/src/olympia/addons/api_urls.py
+++ b/src/olympia/addons/api_urls.py
@@ -1,4 +1,4 @@
-from django.urls import re_path, include
+from django.urls import include, re_path
 
 from rest_framework.routers import SimpleRouter
 from rest_framework_nested.routers import NestedSimpleRouter

--- a/src/olympia/addons/urls.py
+++ b/src/olympia/addons/urls.py
@@ -1,4 +1,4 @@
-from django.urls import re_path, include
+from django.urls import include, re_path
 
 from olympia.amo.views import frontend_view
 from olympia.stats.urls import stats_patterns

--- a/src/olympia/addons/urls.py
+++ b/src/olympia/addons/urls.py
@@ -1,5 +1,4 @@
-from django.conf.urls import include
-from django.urls import re_path
+from django.urls import re_path, include
 
 from olympia.amo.views import frontend_view
 from olympia.stats.urls import stats_patterns

--- a/src/olympia/amo/urls.py
+++ b/src/olympia/amo/urls.py
@@ -1,4 +1,4 @@
-from django.urls import re_path, include
+from django.urls import include, re_path
 from django.views.decorators.cache import never_cache
 
 from . import views

--- a/src/olympia/amo/urls.py
+++ b/src/olympia/amo/urls.py
@@ -1,5 +1,4 @@
-from django.conf.urls import include
-from django.urls import re_path
+from django.urls import re_path, include
 from django.views.decorators.cache import never_cache
 
 from . import views

--- a/src/olympia/api/urls.py
+++ b/src/olympia/api/urls.py
@@ -1,5 +1,4 @@
-from django.conf.urls import include
-from django.urls import re_path
+from django.urls import re_path, include
 
 from olympia.accounts.urls import (
     accounts_v3, accounts_v4, auth_callback_patterns)

--- a/src/olympia/api/urls.py
+++ b/src/olympia/api/urls.py
@@ -1,4 +1,4 @@
-from django.urls import re_path, include
+from django.urls import include, re_path
 
 from olympia.accounts.urls import (
     accounts_v3, accounts_v4, auth_callback_patterns)

--- a/src/olympia/blocklist/urls.py
+++ b/src/olympia/blocklist/urls.py
@@ -1,4 +1,4 @@
-from django.urls import re_path, include
+from django.urls import include, re_path
 
 from rest_framework.routers import SimpleRouter
 

--- a/src/olympia/blocklist/urls.py
+++ b/src/olympia/blocklist/urls.py
@@ -1,5 +1,4 @@
-from django.conf.urls import include
-from django.urls import re_path
+from django.urls import re_path, include
 
 from rest_framework.routers import SimpleRouter
 

--- a/src/olympia/devhub/urls.py
+++ b/src/olympia/devhub/urls.py
@@ -1,5 +1,4 @@
-from django.conf.urls import include
-from django.urls import re_path
+from django.urls import re_path, include
 from django.shortcuts import redirect
 
 from olympia.addons.urls import ADDON_ID

--- a/src/olympia/devhub/urls.py
+++ b/src/olympia/devhub/urls.py
@@ -1,4 +1,4 @@
-from django.urls import re_path, include
+from django.urls import include, re_path
 from django.shortcuts import redirect
 
 from olympia.addons.urls import ADDON_ID

--- a/src/olympia/discovery/api_urls.py
+++ b/src/olympia/discovery/api_urls.py
@@ -1,4 +1,4 @@
-from django.urls import re_path, include
+from django.urls import include, re_path
 
 from rest_framework.routers import SimpleRouter
 

--- a/src/olympia/discovery/api_urls.py
+++ b/src/olympia/discovery/api_urls.py
@@ -1,5 +1,4 @@
-from django.conf.urls import include
-from django.urls import re_path
+from django.urls import re_path, include
 
 from rest_framework.routers import SimpleRouter
 

--- a/src/olympia/hero/urls.py
+++ b/src/olympia/hero/urls.py
@@ -1,4 +1,4 @@
-from django.urls import re_path, include
+from django.urls import include, re_path
 
 from rest_framework.routers import SimpleRouter
 

--- a/src/olympia/hero/urls.py
+++ b/src/olympia/hero/urls.py
@@ -1,5 +1,4 @@
-from django.conf.urls import include
-from django.urls import re_path
+from django.urls import re_path, include
 
 from rest_framework.routers import SimpleRouter
 

--- a/src/olympia/reviewers/api_urls.py
+++ b/src/olympia/reviewers/api_urls.py
@@ -1,5 +1,4 @@
-from django.conf.urls import include
-from django.urls import re_path
+from django.urls import re_path, include
 
 from rest_framework.routers import SimpleRouter
 from rest_framework_nested.routers import NestedSimpleRouter

--- a/src/olympia/reviewers/api_urls.py
+++ b/src/olympia/reviewers/api_urls.py
@@ -1,4 +1,4 @@
-from django.urls import re_path, include
+from django.urls import include, re_path
 
 from rest_framework.routers import SimpleRouter
 from rest_framework_nested.routers import NestedSimpleRouter

--- a/src/olympia/shelves/urls.py
+++ b/src/olympia/shelves/urls.py
@@ -1,4 +1,4 @@
-from django.urls import re_path, include
+from django.urls import include, re_path
 
 from rest_framework.routers import SimpleRouter
 

--- a/src/olympia/shelves/urls.py
+++ b/src/olympia/shelves/urls.py
@@ -1,5 +1,4 @@
-from django.conf.urls import include
-from django.urls import re_path
+from django.urls import re_path, include
 
 from rest_framework.routers import SimpleRouter
 

--- a/src/olympia/urls.py
+++ b/src/olympia/urls.py
@@ -1,6 +1,5 @@
 from django.conf import settings
-from django.conf.urls import include
-from django.urls import re_path
+from django.urls import re_path, include
 from django.contrib import admin
 from django.shortcuts import redirect
 from django.views.static import serve as serve_static

--- a/src/olympia/urls.py
+++ b/src/olympia/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.urls import re_path, include
+from django.urls import include, re_path
 from django.contrib import admin
 from django.shortcuts import redirect
 from django.views.static import serve as serve_static

--- a/src/olympia/users/urls.py
+++ b/src/olympia/users/urls.py
@@ -1,5 +1,4 @@
-from django.conf.urls import include
-from django.urls import re_path
+from django.urls import re_path, include
 
 from olympia.amo.views import frontend_view
 

--- a/src/olympia/users/urls.py
+++ b/src/olympia/users/urls.py
@@ -1,4 +1,4 @@
-from django.urls import re_path, include
+from django.urls import include, re_path
 
 from olympia.amo.views import frontend_view
 

--- a/src/olympia/zadmin/urls.py
+++ b/src/olympia/zadmin/urls.py
@@ -1,5 +1,4 @@
-from django.conf.urls import include
-from django.urls import re_path
+from django.urls import re_path, include
 from django.contrib import admin
 from django.shortcuts import redirect
 

--- a/src/olympia/zadmin/urls.py
+++ b/src/olympia/zadmin/urls.py
@@ -1,4 +1,4 @@
-from django.urls import re_path, include
+from django.urls import include, re_path
 from django.contrib import admin
 from django.shortcuts import redirect
 


### PR DESCRIPTION
Fixes #15616 

I have imported `include()` function from new `django.urls` instead of old `django.conf.urls` in all the required `urls.py` files.

* [x] This PR relates to an existing open issue and there are no existing
      PRs open for the same issue.
* [x] Add `Fixes #ISSUENUM` at the top of your PR.
* [x] Add a description of the changes introduced in this PR.
* [x] The change has been successfully run locally.


