### PR TITLE
Change UserProfile.is_staff to be True for all mozilla.com emails

### DIFF
--- a/src/olympia/abuse/tests/test_admin.py
+++ b/src/olympia/abuse/tests/test_admin.py
@@ -32,8 +32,7 @@ class TestAbuse(TestCase):
             id=cls.addon1.name_id, locale='fr', localized_string='Elu')
         cls.addon2 = addon_factory(guid='@guid2', name='Two')
         cls.addon3 = addon_factory(guid='@guid3', name='Three')
-        cls.user = user_factory()
-        grant_permission(cls.user, 'Admin:Tools', 'Admin Group')
+        cls.user = user_factory(email='someone@mozilla.com')
         grant_permission(cls.user, 'AbuseReports:Edit', 'Abuse Report Triage')
         # Create a few abuse reports.
         cls.report1 = AbuseReport.objects.create(
@@ -62,10 +61,8 @@ class TestAbuse(TestCase):
         self.list_url = reverse('admin:abuse_abusereport_changelist')
 
     def test_list_no_permission(self):
-        user_without_abusereports_edit = user_factory()
-        grant_permission(
-            user_without_abusereports_edit, 'Admin:Tools', 'Admin Group')
-        self.client.login(email=user_without_abusereports_edit.email)
+        user = user_factory(email='nobody@mozilla.com')
+        self.client.login(email=user.email)
         response = self.client.get(self.list_url)
         assert response.status_code == 403
 

--- a/src/olympia/addons/tests/test_admin.py
+++ b/src/olympia/addons/tests/test_admin.py
@@ -77,8 +77,7 @@ class TestAddonAdmin(TestCase):
         self.list_url = reverse('admin:addons_addon_changelist')
 
     def test_can_see_addon_module_in_admin_with_addons_edit(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Addons:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.admin_home_url, follow=True)
@@ -88,8 +87,7 @@ class TestAddonAdmin(TestCase):
         assert modules == ['Addons']
 
     def test_can_not_see_addon_module_in_admin_without_permissions(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         response = self.client.get(self.admin_home_url, follow=True)
         assert response.status_code == 200
@@ -99,8 +97,7 @@ class TestAddonAdmin(TestCase):
 
     def test_can_list_with_addons_edit_permission(self):
         addon = addon_factory()
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Addons:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.list_url, follow=True)
@@ -110,8 +107,7 @@ class TestAddonAdmin(TestCase):
     def test_list_show_link_to_reviewer_tools_listed(self):
         addon = addon_factory()
         version_factory(addon=addon, channel=amo.RELEASE_CHANNEL_LISTED)
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Addons:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.list_url, follow=True)
@@ -121,8 +117,7 @@ class TestAddonAdmin(TestCase):
     def test_list_show_link_to_reviewer_tools_unlisted(self):
         version_kw = {'channel': amo.RELEASE_CHANNEL_UNLISTED}
         addon_factory(guid='@foo', version_kw=version_kw)
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Addons:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.list_url, follow=True)
@@ -133,8 +128,7 @@ class TestAddonAdmin(TestCase):
         addon = addon_factory()
         version_factory(addon=addon, channel=amo.RELEASE_CHANNEL_LISTED)
         version_factory(addon=addon, channel=amo.RELEASE_CHANNEL_UNLISTED)
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Addons:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.list_url, follow=True)
@@ -146,8 +140,7 @@ class TestAddonAdmin(TestCase):
         self.detail_url = reverse(
             'admin:addons_addon_change', args=(addon.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Addons:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.detail_url, follow=True)
@@ -178,8 +171,7 @@ class TestAddonAdmin(TestCase):
         addon = addon_factory(guid='@foo')
         version_factory(addon=addon, channel=amo.RELEASE_CHANNEL_LISTED)
         detail_url = reverse('admin:addons_addon_change', args=(addon.pk,))
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Addons:Edit')
         self.client.login(email=user.email)
         response = self.client.get(detail_url, follow=True)
@@ -190,8 +182,7 @@ class TestAddonAdmin(TestCase):
         version_kw = {'channel': amo.RELEASE_CHANNEL_UNLISTED}
         addon = addon_factory(guid='@foo', version_kw=version_kw)
         detail_url = reverse('admin:addons_addon_change', args=(addon.pk,))
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Addons:Edit')
         self.client.login(email=user.email)
         response = self.client.get(detail_url, follow=True)
@@ -203,8 +194,7 @@ class TestAddonAdmin(TestCase):
         version_factory(addon=addon, channel=amo.RELEASE_CHANNEL_LISTED)
         version_factory(addon=addon, channel=amo.RELEASE_CHANNEL_UNLISTED)
         detail_url = reverse('admin:addons_addon_change', args=(addon.pk,))
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Addons:Edit')
         self.client.login(email=user.email)
         response = self.client.get(detail_url, follow=True)
@@ -220,8 +210,7 @@ class TestAddonAdmin(TestCase):
 
     def test_can_not_list_without_addons_edit_permission(self):
         addon = addon_factory()
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         response = self.client.get(self.list_url, follow=True)
         assert response.status_code == 403
@@ -232,8 +221,7 @@ class TestAddonAdmin(TestCase):
         self.detail_url = reverse(
             'admin:addons_addon_change', args=(addon.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 403
@@ -266,8 +254,7 @@ class TestAddonAdmin(TestCase):
         detail_url_final = reverse(
             'admin:addons_addon_change', args=(addon.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Addons:Edit')
         self.client.login(email=user.email)
         response = self.client.get(detail_url_by_slug, follow=False)
@@ -281,8 +268,7 @@ class TestAddonAdmin(TestCase):
         detail_url_final = reverse(
             'admin:addons_addon_change', args=(addon.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Addons:Edit')
         self.client.login(email=user.email)
         response = self.client.get(detail_url_by_guid, follow=True)
@@ -294,8 +280,7 @@ class TestAddonAdmin(TestCase):
         self.detail_url = reverse(
             'admin:addons_addon_change', args=(addon.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Addons:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.detail_url, follow=True)
@@ -343,8 +328,7 @@ class TestAddonAdmin(TestCase):
         self.detail_url = reverse(
             'admin:addons_addon_change', args=(addon.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Addons:Edit')
         self.grant_permission(user, 'Admin:Advanced')
         self.client.login(email=user.email)
@@ -373,8 +357,7 @@ class TestAddonAdmin(TestCase):
         self.detail_url = reverse(
             'admin:addons_addon_change', args=(addon.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Addons:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.detail_url, follow=True)
@@ -405,8 +388,7 @@ class TestAddonAdmin(TestCase):
         self.detail_url = reverse(
             'admin:addons_addon_change', args=(addon.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Addons:Edit')
         self.grant_permission(user, 'Admin:Advanced')
         self.client.login(email=user.email)
@@ -455,8 +437,7 @@ class TestAddonAdmin(TestCase):
         self.detail_url = reverse(
             'admin:addons_addon_change', args=(addon.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Addons:Edit')
         self.grant_permission(user, 'Admin:Advanced')
         post_data = self._get_full_post_data(addon, addon.addonuser_set.get())
@@ -481,8 +462,7 @@ class TestAddonAdmin(TestCase):
         self.detail_url = reverse(
             'admin:addons_addon_change', args=(addon.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Addons:Edit')
         self.grant_permission(user, 'Admin:Advanced')
 
@@ -505,10 +485,9 @@ class TestAddonAdmin(TestCase):
 
     def test_query_count(self):
         addon = addon_factory(guid='@foo', users=[user_factory()])
-        user = user_factory()
         self.detail_url = reverse(
             'admin:addons_addon_change', args=(addon.pk,))
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Addons:Edit')
         self.grant_permission(user, 'Admin:Advanced')
         self.client.login(email=user.email)
@@ -530,10 +509,9 @@ class TestAddonAdmin(TestCase):
         addon = addon_factory(users=[user_factory()])
         first_file = addon.current_version.all_files[0]
         [version_factory(addon=addon) for i in range(0, 30)]
-        user = user_factory()
         self.detail_url = reverse(
             'admin:addons_addon_change', args=(addon.pk,))
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Addons:Edit')
         self.grant_permission(user, 'Admin:Advanced')
         self.client.login(email=user.email)
@@ -562,8 +540,7 @@ class TestReplacementAddonList(TestCase):
             ['guid', 'path', 'guid_slug', '_url'])
 
     def test_can_see_replacementaddon_module_in_admin_with_addons_edit(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Addons:Edit')
         self.client.login(email=user.email)
         url = reverse('admin:index')
@@ -577,7 +554,7 @@ class TestReplacementAddonList(TestCase):
         assert self.list_url in response.content.decode('utf-8')
 
     def test_can_see_replacementaddon_module_in_admin_with_admin_curate(self):
-        user = user_factory()
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Admin:Curation')
         self.client.login(email=user.email)
         url = reverse('admin:index')
@@ -593,8 +570,7 @@ class TestReplacementAddonList(TestCase):
     def test_can_list_with_addons_edit_permission(self):
         ReplacementAddon.objects.create(
             guid='@bar', path='/addon/bar-replacement/')
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Addons:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.list_url, follow=True)
@@ -607,8 +583,7 @@ class TestReplacementAddonList(TestCase):
         self.detail_url = reverse(
             'admin:addons_replacementaddon_change', args=(replacement.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Addons:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.detail_url, follow=True)
@@ -624,8 +599,7 @@ class TestReplacementAddonList(TestCase):
         self.delete_url = reverse(
             'admin:addons_replacementaddon_delete', args=(replacement.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Addons:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.delete_url, follow=True)
@@ -641,7 +615,7 @@ class TestReplacementAddonList(TestCase):
         self.detail_url = reverse(
             'admin:addons_replacementaddon_change', args=(replacement.pk,)
         )
-        user = user_factory()
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Admin:Curation')
         self.client.login(email=user.email)
         response = self.client.get(self.detail_url, follow=True)
@@ -661,7 +635,7 @@ class TestReplacementAddonList(TestCase):
         self.delete_url = reverse(
             'admin:addons_replacementaddon_delete', args=(replacement.pk,)
         )
-        user = user_factory()
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Admin:Curation')
         self.client.login(email=user.email)
         response = self.client.get(self.delete_url, follow=True)
@@ -672,7 +646,7 @@ class TestReplacementAddonList(TestCase):
         assert not ReplacementAddon.objects.filter(pk=replacement.pk).exists()
 
     def test_can_list_with_admin_curation_permission(self):
-        user = user_factory()
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Admin:Curation')
         self.client.login(email=user.email)
         # '@foofoo&foo' isn't a valid guid, because &, but testing urlencoding.

--- a/src/olympia/amo/tests/test_views.py
+++ b/src/olympia/amo/tests/test_views.py
@@ -44,7 +44,7 @@ class Test403(TestCase):
 
     def setUp(self):
         super(Test403, self).setUp()
-        assert self.client.login(email='regular@mozilla.com')
+        assert self.client.login(email='clouserw@gmail.com')
 
     def test_403_no_app(self):
         response = self.client.get('/en-US/admin/', follow=True)
@@ -152,8 +152,8 @@ class TestCommon(TestCase):
 
     def test_tools_regular_user(self):
         self.login('regular')
-        r = self.client.get(self.url, follow=True)
-        assert not r.context['request'].user.is_developer
+        response = self.client.get(self.url, follow=True)
+        assert not response.context['request'].user.is_developer
 
         expected = [
             ('Tools', '#'),
@@ -162,18 +162,19 @@ class TestCommon(TestCase):
             ('Developer Hub', reverse('devhub.index')),
             ('Manage API Keys', reverse('devhub.api_key')),
         ]
-        check_links(expected, pq(r.content)('#aux-nav .tools a'), verify=False)
+        check_links(
+            expected, pq(response.content)('#aux-nav .tools a'), verify=False)
 
     def test_tools_developer(self):
         # Make them a developer.
         user = self.login('regular', get=True)
         AddonUser.objects.create(user=user, addon=Addon.objects.all()[0])
 
-        group = Group.objects.create(name='Staff', rules='Admin:Tools')
+        group = Group.objects.create(name='Staff', rules='Admin:Advanced')
         GroupUser.objects.create(group=group, user=user)
 
-        r = self.client.get(self.url, follow=True)
-        assert r.context['request'].user.is_developer
+        response = self.client.get(self.url, follow=True)
+        assert response.context['request'].user.is_developer
 
         expected = [
             ('Tools', '#'),
@@ -183,12 +184,13 @@ class TestCommon(TestCase):
             ('Developer Hub', reverse('devhub.index')),
             ('Manage API Keys', reverse('devhub.api_key')),
         ]
-        check_links(expected, pq(r.content)('#aux-nav .tools a'), verify=False)
+        check_links(
+            expected, pq(response.content)('#aux-nav .tools a'), verify=False)
 
     def test_tools_reviewer(self):
         self.login('reviewer')
-        r = self.client.get(self.url, follow=True)
-        request = r.context['request']
+        response = self.client.get(self.url, follow=True)
+        request = response.context['request']
         assert not request.user.is_developer
         assert acl.action_allowed(request, amo.permissions.ADDONS_REVIEW)
 
@@ -200,15 +202,16 @@ class TestCommon(TestCase):
             ('Manage API Keys', reverse('devhub.api_key')),
             ('Reviewer Tools', reverse('reviewers.dashboard')),
         ]
-        check_links(expected, pq(r.content)('#aux-nav .tools a'), verify=False)
+        check_links(
+            expected, pq(response.content)('#aux-nav .tools a'), verify=False)
 
     def test_tools_developer_and_reviewer(self):
         # Make them a developer.
         user = self.login('reviewer', get=True)
         AddonUser.objects.create(user=user, addon=Addon.objects.all()[0])
 
-        r = self.client.get(self.url, follow=True)
-        request = r.context['request']
+        response = self.client.get(self.url, follow=True)
+        request = response.context['request']
         assert request.user.is_developer
         assert acl.action_allowed(request, amo.permissions.ADDONS_REVIEW)
 
@@ -221,7 +224,8 @@ class TestCommon(TestCase):
             ('Manage API Keys', reverse('devhub.api_key')),
             ('Reviewer Tools', reverse('reviewers.dashboard')),
         ]
-        check_links(expected, pq(r.content)('#aux-nav .tools a'), verify=False)
+        check_links(
+            expected, pq(response.content)('#aux-nav .tools a'), verify=False)
 
     def test_tools_admin(self):
         self.login('admin')

--- a/src/olympia/bandwagon/tests/test_admin.py
+++ b/src/olympia/bandwagon/tests/test_admin.py
@@ -14,8 +14,7 @@ class TestCollectionAdmin(TestCase):
         self.list_url = reverse('admin:bandwagon_collection_changelist')
 
     def test_can_see_bandwagon_module_in_admin_with_collections_edit(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Collections:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.admin_home_url, follow=True)
@@ -25,8 +24,7 @@ class TestCollectionAdmin(TestCase):
         assert modules == ['Bandwagon']
 
     def test_can_see_bandwagon_module_in_admin_with_admin_curation(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Admin:Curation')
         self.client.login(email=user.email)
         response = self.client.get(self.admin_home_url, follow=True)
@@ -37,8 +35,7 @@ class TestCollectionAdmin(TestCase):
         assert modules == ['Addons', 'Bandwagon']
 
     def test_can_not_see_bandwagon_module_in_admin_without_permissions(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         response = self.client.get(self.admin_home_url, follow=True)
         assert response.status_code == 200
@@ -48,8 +45,7 @@ class TestCollectionAdmin(TestCase):
 
     def test_can_list_with_collections_edit_permission(self):
         collection = Collection.objects.create(slug='floob')
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Collections:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.list_url, follow=True)
@@ -58,8 +54,7 @@ class TestCollectionAdmin(TestCase):
 
     def test_can_list_with_admin_curation_permission(self):
         collection = Collection.objects.create(slug='floob')
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Admin:Curation')
         self.client.login(email=user.email)
         response = self.client.get(self.list_url, follow=True)
@@ -68,8 +63,7 @@ class TestCollectionAdmin(TestCase):
 
     def test_cant_list_without_special_permission(self):
         collection = Collection.objects.create(slug='floob')
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         response = self.client.get(self.list_url, follow=True)
         assert response.status_code == 403
@@ -84,8 +78,7 @@ class TestCollectionAdmin(TestCase):
         self.detail_url = reverse(
             'admin:bandwagon_collection_change', args=(collection.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Collections:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.detail_url, follow=True)
@@ -120,8 +113,7 @@ class TestCollectionAdmin(TestCase):
 
     def test_can_not_list_without_collections_edit_permission(self):
         collection = Collection.objects.create(slug='floob')
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         response = self.client.get(self.list_url, follow=True)
         assert response.status_code == 403
@@ -132,8 +124,7 @@ class TestCollectionAdmin(TestCase):
         self.detail_url = reverse(
             'admin:bandwagon_collection_change', args=(collection.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 403
@@ -161,8 +152,7 @@ class TestCollectionAdmin(TestCase):
         self.detail_url = reverse(
             'admin:bandwagon_collection_change', args=(collection.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Admin:Curation')
         self.client.login(email=user.email)
         response = self.client.get(self.detail_url, follow=True)
@@ -280,8 +270,7 @@ class TestCollectionAdmin(TestCase):
         self.delete_url = reverse(
             'admin:bandwagon_collection_delete', args=(collection.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Collections:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.delete_url, follow=True)
@@ -296,8 +285,7 @@ class TestCollectionAdmin(TestCase):
         self.delete_url = reverse(
             'admin:bandwagon_collection_delete', args=(collection.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Admin:Curation')
         self.client.login(email=user.email)
         response = self.client.get(self.delete_url, follow=True)
@@ -322,8 +310,7 @@ class TestCollectionAdmin(TestCase):
         self.delete_url = reverse(
             'admin:bandwagon_collection_delete', args=(collection.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Admin:Advanced')
         self.client.login(email=user.email)
         response = self.client.post(

--- a/src/olympia/blocklist/tests/test_admin.py
+++ b/src/olympia/blocklist/tests/test_admin.py
@@ -30,8 +30,7 @@ class TestBlockAdmin(TestCase):
             'admin:blocklist_blocklistsubmission_add')
 
     def test_can_see_addon_module_in_admin_with_review_admin(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
         response = self.client.get(self.admin_home_url, follow=True)
@@ -41,8 +40,7 @@ class TestBlockAdmin(TestCase):
         assert modules == ['Blocklist']
 
     def test_can_not_see_addon_module_in_admin_without_permissions(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         response = self.client.get(self.admin_home_url, follow=True)
         assert response.status_code == 200
@@ -53,8 +51,7 @@ class TestBlockAdmin(TestCase):
     def test_can_list(self):
         addon = addon_factory()
         Block.objects.create(guid=addon.guid, updated_by=user_factory())
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
         response = self.client.get(self.list_url, follow=True)
@@ -64,16 +61,14 @@ class TestBlockAdmin(TestCase):
     def test_can_not_list_without_permission(self):
         addon = addon_factory()
         Block.objects.create(guid=addon.guid, updated_by=user_factory())
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         response = self.client.get(self.list_url, follow=True)
         assert response.status_code == 403
         assert addon.guid not in response.content.decode('utf-8')
 
     def test_add(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
 
@@ -113,8 +108,7 @@ class TestBlockAdmin(TestCase):
         )
 
     def test_add_restrictions(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
 
@@ -161,8 +155,7 @@ class TestBlockAdmin(TestCase):
                 response, self.submission_url, status_code=307)
 
     def test_add_from_addon_pk_view(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
 
@@ -229,8 +222,7 @@ class TestBlockAdmin(TestCase):
     def test_guid_redirects(self):
         block = Block.objects.create(
             guid='foo@baa', updated_by=user_factory())
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
 
@@ -251,8 +243,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
             'admin:blocklist_blocklistsubmission_changelist')
 
     def test_add_single(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
 
@@ -337,8 +328,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
 
     @override_switch('blocklist_legacy_submit', active=False)
     def test_legacy_id_property_readonly(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
 
@@ -376,8 +366,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
     @mock.patch('olympia.blocklist.models.legacy_publish_blocks')
     def test_legacy_id_enabled_with_legacy_submit_waffle_on(self, publish_mock,
                                                             delete_mock):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
 
@@ -433,8 +422,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
     def _test_add_multiple_submit(self, addon_adu):
         """addon_adu is important because whether dual signoff is needed is
         based on what the average_daily_users is."""
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
 
@@ -643,8 +631,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
 
     @override_switch('blocklist_admin_dualsignoff_disabled', active=True)
     def test_add_and_edit_with_different_min_max_versions(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
 
@@ -811,8 +798,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
 
     @mock.patch('olympia.blocklist.admin.GUID_FULL_LOAD_LIMIT', 1)
     def test_add_multiple_bulk_so_fake_block_objects(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
 
@@ -866,8 +852,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
         assert 'Review Unlisted' not in content
 
     def test_legacy_regex_warning(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
 
@@ -914,8 +899,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
             '.regexlegacywarning').text()
 
     def test_review_links(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
         post_kwargs = {
@@ -974,8 +958,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
         assert b'Review Unlisted' in response.content
 
     def test_can_not_set_min_version_above_max_version(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
 
@@ -1005,8 +988,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
         assert Block.objects.count() == 1
 
     def test_can_not_add_without_create_permission(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         # The signoff permission shouldn't be sufficient
         self.grant_permission(user, 'Blocklist:Signoff')
         self.client.login(email=user.email)
@@ -1076,8 +1058,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
              'average_daily_users': block.addon.average_daily_users},
         ]
 
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, permission)
         self.client.login(email=user.email)
 
@@ -1100,8 +1081,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
     def test_can_not_list_without_permission(self):
         BlocklistSubmission.objects.create(
             updated_by=user_factory(display_name='Bób'))
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
 
         response = self.client.get(self.submission_list_url, follow=True)
@@ -1121,8 +1101,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
              'id': None,
              'average_daily_users': addon.average_daily_users}]
 
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
         multi_url = reverse(
@@ -1185,8 +1164,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
              'id': None,
              'average_daily_users': addon.average_daily_users}]
 
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Signoff')
         self.client.login(email=user.email)
         multi_url = reverse(
@@ -1243,8 +1221,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
              'id': None,
              'average_daily_users': addon.average_daily_users}]
 
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Signoff')
         self.client.login(email=user.email)
         multi_url = reverse(
@@ -1347,8 +1324,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
              'id': None,
              'average_daily_users': addon.average_daily_users}]
 
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Signoff')
         self.client.login(email=user.email)
         multi_url = reverse(
@@ -1413,8 +1389,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
              'id': None,
              'average_daily_users': addon.average_daily_users}]
 
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
         multi_url = reverse(
@@ -1448,8 +1423,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
              'id': None,
              'average_daily_users': addon.average_daily_users}]
 
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
         change_url = reverse(
@@ -1520,8 +1494,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
         assert block.average_daily_users_snapshot == addon.average_daily_users
         addon.update(average_daily_users=1234)
 
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
         multi_view_url = reverse(
@@ -1542,8 +1515,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
             response.content.decode('utf-8'))
 
     def test_list_filters(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Signoff')
         self.client.login(email=user.email)
         addon_factory(guid='pending1@')
@@ -1614,7 +1586,6 @@ class TestBlockAdminEdit(TestCase):
             'admin:blocklist_blocklistsubmission_add')
 
     def _test_edit(self, user, signoff_state):
-        self.grant_permission(user, 'Admin:Tools')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
 
@@ -1681,7 +1652,7 @@ class TestBlockAdminEdit(TestCase):
         assert 'Included in legacy blocklist' not in content
 
     def test_edit_low_adu(self):
-        user = user_factory()
+        user = user_factory(email='someone@mozilla.com')
         self.addon.update(
             average_daily_users=(
                 settings.DUAL_SIGNOFF_AVERAGE_DAILY_USERS_THRESHOLD))
@@ -1689,7 +1660,7 @@ class TestBlockAdminEdit(TestCase):
         self._test_post_edit_logging(user)
 
     def test_edit_high_adu(self):
-        user = user_factory()
+        user = user_factory(email='someone@mozilla.com')
         self.addon.update(
             average_daily_users=(
                 settings.DUAL_SIGNOFF_AVERAGE_DAILY_USERS_THRESHOLD + 1))
@@ -1703,7 +1674,7 @@ class TestBlockAdminEdit(TestCase):
         self._test_post_edit_logging(user)
 
     def test_edit_high_adu_only_metadata(self):
-        user = user_factory()
+        user = user_factory(email='someone@mozilla.com')
         self.addon.update(
             average_daily_users=(
                 settings.DUAL_SIGNOFF_AVERAGE_DAILY_USERS_THRESHOLD + 1))
@@ -1712,8 +1683,7 @@ class TestBlockAdminEdit(TestCase):
         self._test_post_edit_logging(user)
 
     def test_invalid_versions_not_accepted(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
 
@@ -1783,8 +1753,7 @@ class TestBlockAdminEdit(TestCase):
         assert b'444.4a' not in response.content
 
     def test_can_not_edit_without_permission(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
 
         response = self.client.get(self.change_url, follow=True)
@@ -1806,8 +1775,7 @@ class TestBlockAdminEdit(TestCase):
         assert Block.objects.count() == 1
 
     def test_cannot_edit_when_guid_in_blocklistsubmission_change(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
         blocksubm = BlocklistSubmission.objects.create(
@@ -1847,8 +1815,7 @@ class TestBlockAdminEdit(TestCase):
         assert self.block.max_version == '*'  # not changed
 
     def test_cannot_edit_when_guid_in_blocklistsubmission_delete(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
         blocksubm = BlocklistSubmission.objects.create(
@@ -1887,8 +1854,7 @@ class TestBlockAdminEdit(TestCase):
         assert self.block.max_version == '*'  # not changed
 
     def test_imported_regex_block(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
         self.block.update(legacy_id='*foo@baa')
@@ -1904,8 +1870,7 @@ class TestBlockAdminEdit(TestCase):
 
     @override_switch('blocklist_legacy_submit', active=False)
     def test_cannot_edit_when_imported_block(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
         self.block.update(legacy_id='123456')
@@ -1937,8 +1902,7 @@ class TestBlockAdminEdit(TestCase):
     @override_switch('blocklist_legacy_submit', active=True)
     @mock.patch('olympia.blocklist.models.legacy_publish_blocks')
     def test_can_edit_imported_block_if_legacy_submit_waffle_on(self, pub_mck):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
         self.block.update(legacy_id='123456')
@@ -1977,8 +1941,7 @@ class TestBlockAdminEdit(TestCase):
 
     @override_switch('blocklist_legacy_submit', active=False)
     def test_legacy_id_property_is_readonly(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
         self.block.update(legacy_id='')
@@ -2010,8 +1973,7 @@ class TestBlockAdminEdit(TestCase):
     @mock.patch('olympia.blocklist.models.legacy_delete_blocks')
     def test_legacy_id_is_enabled_with_legacy_submit_waffle_on(self, del_mock):
         del_mock.side_effect = lambda blocks: blocks[0].update(legacy_id='')
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
         self.block.update(legacy_id='3467635')
@@ -2048,8 +2010,7 @@ class TestBlockAdminDelete(TestCase):
             'admin:blocklist_blocklistsubmission_add')
 
     def test_delete_input(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
 
@@ -2091,8 +2052,7 @@ class TestBlockAdminDelete(TestCase):
     def _test_delete_multiple_submit(self, addon_adu):
         """addon_adu is important because whether dual signoff is needed is
         based on what the average_daily_users is."""
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
 
@@ -2233,8 +2193,7 @@ class TestBlockAdminDelete(TestCase):
              'id': block.id,
              'average_daily_users': block.addon.average_daily_users}]
 
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
         multi_url = reverse(
@@ -2256,8 +2215,7 @@ class TestBlockAdminDelete(TestCase):
         django_delete_url = reverse(
             'admin:blocklist_block_delete', args=(block.pk,))
 
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Blocklist:Create')
         self.client.login(email=user.email)
         assert Block.objects.count() == 1
@@ -2282,8 +2240,7 @@ class TestBlockAdminDelete(TestCase):
             updated_by=user_factory())
         django_delete_url = reverse(
             'admin:blocklist_block_delete', args=(block.pk,))
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         assert Block.objects.count() == 1
 

--- a/src/olympia/constants/permissions.py
+++ b/src/olympia/constants/permissions.py
@@ -15,8 +15,6 @@ ANY_ADMIN = AclPermission('Admin', '%')
 # access to anything.
 SUPERPOWERS = AclPermission('*', '*')
 
-# Can access admin-specific tools.
-ADMIN_TOOLS = AclPermission('Admin', 'Tools')
 # Can modify editorial content on the site.
 ADMIN_CURATION = AclPermission('Admin', 'Curation')
 # Can edit the properties of any add-on (pseduo-admin).

--- a/src/olympia/discovery/tests/test_admin.py
+++ b/src/olympia/discovery/tests/test_admin.py
@@ -23,8 +23,7 @@ class TestDiscoveryAdmin(TestCase):
         self.list_url = reverse('admin:discovery_discoveryitem_changelist')
 
     def test_can_see_discovery_module_in_admin_with_discovery_edit(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         url = reverse('admin:index')
@@ -39,8 +38,7 @@ class TestDiscoveryAdmin(TestCase):
 
     def test_can_list_with_discovery_edit_permission(self):
         DiscoveryItem.objects.create(addon=addon_factory(name=u'FooBâr'))
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.list_url, follow=True)
@@ -51,8 +49,7 @@ class TestDiscoveryAdmin(TestCase):
         DiscoveryItem.objects.create(
             addon=addon_factory(name=u'FooBâr'), position=1)
         DiscoveryItem.objects.create(addon=addon_factory(name=u'Âbsent'))
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         response = self.client.get(
@@ -66,8 +63,7 @@ class TestDiscoveryAdmin(TestCase):
             addon=addon_factory(name=u'FooBâr'), position_china=42)
         DiscoveryItem.objects.create(
             addon=addon_factory(name=u'Âbsent'), position=1)
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.list_url + '?position=no', follow=True)
@@ -79,8 +75,7 @@ class TestDiscoveryAdmin(TestCase):
         DiscoveryItem.objects.create(
             addon=addon_factory(name=u'FooBâr'), position_china=1)
         DiscoveryItem.objects.create(addon=addon_factory(name=u'Âbsent'))
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         response = self.client.get(
@@ -94,8 +89,7 @@ class TestDiscoveryAdmin(TestCase):
             addon=addon_factory(name=u'FooBâr'), position=42)
         DiscoveryItem.objects.create(
             addon=addon_factory(name=u'Âbsent'), position_china=1)
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         response = self.client.get(
@@ -110,8 +104,7 @@ class TestDiscoveryAdmin(TestCase):
         self.detail_url = reverse(
             'admin:discovery_discoveryitem_change', args=(item.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.detail_url, follow=True)
@@ -145,8 +138,7 @@ class TestDiscoveryAdmin(TestCase):
         self.detail_url = reverse(
             'admin:discovery_discoveryitem_change', args=(item.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.detail_url, follow=True)
@@ -185,8 +177,7 @@ class TestDiscoveryAdmin(TestCase):
         self.detail_url = reverse(
             'admin:discovery_discoveryitem_change', args=(item.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.detail_url, follow=True)
@@ -220,8 +211,7 @@ class TestDiscoveryAdmin(TestCase):
         self.detail_url = reverse(
             'admin:discovery_discoveryitem_change', args=(item.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
 
@@ -266,8 +256,7 @@ class TestDiscoveryAdmin(TestCase):
         self.delete_url = reverse(
             'admin:discovery_discoveryitem_delete', args=(item.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         # Can access delete confirmation page.
@@ -286,8 +275,7 @@ class TestDiscoveryAdmin(TestCase):
     def test_can_add_with_discovery_edit_permission(self):
         addon = addon_factory(name=u'BarFöo')
         self.add_url = reverse('admin:discovery_discoveryitem_add')
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.add_url, follow=True)
@@ -313,8 +301,7 @@ class TestDiscoveryAdmin(TestCase):
     def test_can_not_add_without_discovery_edit_permission(self):
         addon = addon_factory(name=u'BarFöo')
         self.add_url = reverse('admin:discovery_discoveryitem_add')
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         response = self.client.get(self.add_url, follow=True)
         assert response.status_code == 403
@@ -331,8 +318,7 @@ class TestDiscoveryAdmin(TestCase):
         self.detail_url = reverse(
             'admin:discovery_discoveryitem_change', args=(item.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 403
@@ -357,8 +343,7 @@ class TestDiscoveryAdmin(TestCase):
         self.delete_url = reverse(
             'admin:discovery_discoveryitem_delete', args=(item.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         # Can not access delete confirmation page.
         response = self.client.get(self.delete_url, follow=True)
@@ -379,8 +364,7 @@ class TestDiscoveryAdmin(TestCase):
         DiscoveryItem.objects.create(addon=addon_factory(name=u'FooBâr 5'))
         DiscoveryItem.objects.create(addon=addon_factory(name=u'FooBâr 6'))
 
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
 
@@ -413,8 +397,7 @@ class TestPrimaryHeroImageAdmin(TestCase):
         self.detail_url_name = 'admin:discovery_primaryheroimageupload_change'
 
     def test_can_see_primary_hero_image_in_admin_with_discovery_edit(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         url = reverse('admin:index')
@@ -430,8 +413,7 @@ class TestPrimaryHeroImageAdmin(TestCase):
     def test_can_list_with_discovery_edit_permission(self):
         uploaded_photo = get_uploaded_file('transparent.png')
         PrimaryHeroImage.objects.create(custom_image=uploaded_photo)
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.list_url, follow=True)
@@ -444,8 +426,7 @@ class TestPrimaryHeroImageAdmin(TestCase):
         self.detail_url = reverse(
             'admin:discovery_primaryheroimageupload_change', args=(item.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.detail_url, follow=True)
@@ -487,8 +468,7 @@ class TestPrimaryHeroImageAdmin(TestCase):
         delete_url = reverse(
             'admin:discovery_primaryheroimageupload_delete', args=(item.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         # Can access delete confirmation page.
@@ -514,8 +494,7 @@ class TestPrimaryHeroImageAdmin(TestCase):
 
     def test_can_add_with_discovery_edit_permission(self):
         add_url = reverse('admin:discovery_primaryheroimageupload_add')
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         response = self.client.get(add_url, follow=True)
@@ -545,8 +524,7 @@ class TestPrimaryHeroImageAdmin(TestCase):
 
     def test_can_not_add_without_discovery_edit_permission(self):
         add_url = reverse('admin:discovery_primaryheroimageupload_add')
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         response = self.client.get(add_url, follow=True)
         assert response.status_code == 403
@@ -564,8 +542,7 @@ class TestPrimaryHeroImageAdmin(TestCase):
         detail_url = reverse(
             'admin:discovery_primaryheroimageupload_change', args=(item.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         response = self.client.get(detail_url, follow=True)
         assert response.status_code == 403
@@ -592,8 +569,7 @@ class TestPrimaryHeroImageAdmin(TestCase):
         delete_url = reverse(
             'admin:discovery_primaryheroimageupload_delete', args=(item.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         # Can not access delete confirmation page.
         response = self.client.get(delete_url, follow=True)
@@ -647,8 +623,7 @@ class TestSecondaryHeroShelfAdmin(TestCase):
         return out
 
     def test_can_see_secondary_hero_module_in_admin_with_discovery_edit(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         url = reverse('admin:index')
@@ -663,8 +638,7 @@ class TestSecondaryHeroShelfAdmin(TestCase):
 
     def test_can_list_with_discovery_edit_permission(self):
         SecondaryHero.objects.create(headline='FooBâr')
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.list_url, follow=True)
@@ -679,8 +653,7 @@ class TestSecondaryHeroShelfAdmin(TestCase):
             SecondaryHeroModule.objects.create(shelf=item),
         ]
         detail_url = reverse(self.detail_url_name, args=(item.pk,))
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         response = self.client.get(detail_url, follow=True)
@@ -731,8 +704,7 @@ class TestSecondaryHeroShelfAdmin(TestCase):
         delete_url = reverse(
             'admin:discovery_secondaryheroshelf_delete', args=(item.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         # Can access delete confirmation page.
@@ -769,8 +741,7 @@ class TestSecondaryHeroShelfAdmin(TestCase):
 
     def test_can_add_with_discovery_edit_permission(self):
         add_url = reverse('admin:discovery_secondaryheroshelf_add')
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         response = self.client.get(add_url, follow=True)
@@ -811,8 +782,7 @@ class TestSecondaryHeroShelfAdmin(TestCase):
 
     def test_can_not_add_without_discovery_edit_permission(self):
         add_url = reverse('admin:discovery_secondaryheroshelf_add')
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         response = self.client.get(add_url, follow=True)
         assert response.status_code == 403
@@ -830,8 +800,7 @@ class TestSecondaryHeroShelfAdmin(TestCase):
         detail_url = reverse(
             'admin:discovery_secondaryheroshelf_change', args=(item.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         response = self.client.get(detail_url, follow=True)
         assert response.status_code == 403
@@ -852,8 +821,7 @@ class TestSecondaryHeroShelfAdmin(TestCase):
         delete_url = reverse(
             'admin:discovery_secondaryheroshelf_delete', args=(item.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         # Can not access delete confirmation page.
         response = self.client.get(delete_url, follow=True)
@@ -868,8 +836,7 @@ class TestSecondaryHeroShelfAdmin(TestCase):
 
     def test_need_3_modules(self):
         add_url = reverse('admin:discovery_secondaryheroshelf_add')
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         response = self.client.get(add_url, follow=True)
@@ -902,8 +869,7 @@ class TestShelfAdmin(TestCase):
             json={'count': 103})
 
     def test_can_see_shelf_module_in_admin_with_discovery_edit(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         url = reverse('admin:index')
@@ -918,8 +884,7 @@ class TestShelfAdmin(TestCase):
 
     def test_can_list_with_discovery_edit_permission(self):
         Shelf.objects.create(title='FooBâr')
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.list_url, follow=True)
@@ -934,8 +899,7 @@ class TestShelfAdmin(TestCase):
             footer_text='See more',
             footer_pathname='/this/is/the/pathname')
         detail_url = reverse(self.detail_url_name, args=(item.pk,))
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         response = self.client.get(detail_url, follow=True)
@@ -974,8 +938,7 @@ class TestShelfAdmin(TestCase):
             footer_pathname='/this/is/the/pathname')
         delete_url = reverse(
             'admin:discovery_shelfmodule_delete', args=(item.pk,))
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         # Can access delete confirmation page.
@@ -991,8 +954,7 @@ class TestShelfAdmin(TestCase):
 
     def test_can_add_with_discovery_edit_permission(self):
         add_url = reverse('admin:discovery_shelfmodule_add')
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         response = self.client.get(add_url, follow=True)
@@ -1024,8 +986,7 @@ class TestShelfAdmin(TestCase):
 
     def test_can_not_add_without_discovery_edit_permission(self):
         add_url = reverse('admin:discovery_shelfmodule_add')
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         response = self.client.get(add_url, follow=True)
         assert response.status_code == 403
@@ -1052,8 +1013,7 @@ class TestShelfAdmin(TestCase):
             footer_pathname='/this/is/the/pathname')
         detail_url = reverse(
             'admin:discovery_shelfmodule_change', args=(item.pk,))
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         response = self.client.get(detail_url, follow=True)
         assert response.status_code == 403
@@ -1082,8 +1042,7 @@ class TestShelfAdmin(TestCase):
             footer_pathname='/this/is/the/pathname')
         delete_url = reverse(
             'admin:discovery_shelfmodule_delete', args=(item.pk,))
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         # Can not access delete confirmation page.
         response = self.client.get(delete_url, follow=True)
@@ -1109,8 +1068,7 @@ class TestHomepageShelvesAdmin(TestCase):
             criteria='?sort=users&type=statictheme')
 
     def test_can_see_homepage_shelves_in_admin_with_discovery_edit(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         url = reverse('admin:index')
@@ -1125,8 +1083,7 @@ class TestHomepageShelvesAdmin(TestCase):
 
     def test_can_list_with_discovery_edit_permission(self):
         ShelfManagement.objects.create(shelf=self.shelf)
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.list_url, follow=True)
@@ -1136,8 +1093,7 @@ class TestHomepageShelvesAdmin(TestCase):
     def test_can_edit_with_discovery_edit_permission(self):
         hpshelf = ShelfManagement.objects.create(shelf=self.shelf, position=1)
         detail_url = reverse(self.detail_url_name, args=(hpshelf.pk,))
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         response = self.client.get(detail_url, follow=True)
@@ -1161,8 +1117,7 @@ class TestHomepageShelvesAdmin(TestCase):
         hpshelf = ShelfManagement.objects.create(shelf=self.shelf)
         delete_url = reverse(
             'admin:discovery_homepageshelves_delete', args=(hpshelf.pk,))
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         # Can access delete confirmation page.
@@ -1178,8 +1133,7 @@ class TestHomepageShelvesAdmin(TestCase):
 
     def test_can_add_with_discovery_edit_permission(self):
         add_url = reverse('admin:discovery_homepageshelves_add')
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         response = self.client.get(add_url, follow=True)
@@ -1200,8 +1154,7 @@ class TestHomepageShelvesAdmin(TestCase):
 
     def test_can_not_add_without_discovery_edit_permission(self):
         add_url = reverse('admin:discovery_homepageshelves_add')
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         response = self.client.get(add_url, follow=True)
         assert response.status_code == 403
@@ -1216,8 +1169,7 @@ class TestHomepageShelvesAdmin(TestCase):
         hpshelf = ShelfManagement.objects.create(shelf=self.shelf)
         detail_url = reverse(
             'admin:discovery_homepageshelves_change', args=(hpshelf.pk,))
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         response = self.client.get(detail_url, follow=True)
         assert response.status_code == 403
@@ -1237,8 +1189,7 @@ class TestHomepageShelvesAdmin(TestCase):
         hpshelf = ShelfManagement.objects.create(shelf=self.shelf)
         delete_url = reverse(
             'admin:discovery_homepageshelves_delete', args=(hpshelf.pk,))
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         # Can not access delete confirmation page.
         response = self.client.get(delete_url, follow=True)

--- a/src/olympia/files/tests/test_admin.py
+++ b/src/olympia/files/tests/test_admin.py
@@ -11,8 +11,7 @@ class TestFileAdmin(TestCase):
     def test_can_list_files_with_admin_advanced_permission(self):
         addon = addon_factory()
         file_ = addon.current_version.all_files[0]
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Admin:Advanced')
         self.client.login(email=user.email)
         response = self.client.get(self.list_url, follow=True)
@@ -25,8 +24,7 @@ class TestFileAdmin(TestCase):
         detail_url = reverse(
             'admin:files_file_change', args=(file_.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Admin:Advanced')
         self.client.login(email=user.email)
         response = self.client.get(detail_url, follow=True)
@@ -52,8 +50,7 @@ class TestFileAdmin(TestCase):
         assert file_.is_webextension
 
     def test_can_not_list_without_admin_advanced_permission(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         response = self.client.get(self.list_url, follow=True)
         assert response.status_code == 403
@@ -70,8 +67,7 @@ class TestFileAdmin(TestCase):
         detail_url = reverse(
             'admin:files_file_change', args=(file_.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Admin:Advanced')
         self.client.login(email=user.email)
         response = self.client.get(detail_url, follow=True)

--- a/src/olympia/git/tests/test_admin.py
+++ b/src/olympia/git/tests/test_admin.py
@@ -12,7 +12,7 @@ class TestGitExtractionEntryAdmin(TestCase):
     def setUp(self):
         super().setUp()
 
-        self.user = user_factory()
+        self.user = user_factory(email='someone@mozilla.com')
         self.grant_permission(self.user, 'Admin:GitExtractionEdit')
         self.client.login(email=self.user.email)
         self.list_url = reverse('admin:git_gitextractionentry_changelist')
@@ -46,7 +46,7 @@ class TestGitExtractionEntryAdmin(TestCase):
         assert html('.actions option[value="delete_selected"]').length == 1
 
     def test_list_view_is_restricted(self):
-        user = user_factory()
+        user = user_factory(email='nobody@mozilla.com')
         self.grant_permission(user, 'Admin:Curation')
         self.client.login(email=user.email)
         response = self.client.get(self.list_url)

--- a/src/olympia/promoted/tests/test_admin.py
+++ b/src/olympia/promoted/tests/test_admin.py
@@ -48,8 +48,7 @@ class TestPromotedAddonAdmin(TestCase):
         }
 
     def test_can_see_in_admin_with_discovery_edit(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         url = reverse('admin:index')
@@ -64,8 +63,7 @@ class TestPromotedAddonAdmin(TestCase):
 
     def test_can_list_with_discovery_edit_permission(self):
         PromotedAddon.objects.create(addon=addon_factory(name='FooBâr'))
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
 
@@ -124,8 +122,7 @@ class TestPromotedAddonAdmin(TestCase):
         item.reload()
         assert item.approved_applications
         detail_url = reverse(self.detail_url_name, args=(item.pk,))
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         response = self.client.get(detail_url, follow=True)
@@ -175,8 +172,7 @@ class TestPromotedAddonAdmin(TestCase):
             version=ver1, group_id=RECOMMENDED.id,
             application_id=amo.FIREFOX.id)
         detail_url = reverse(self.detail_url_name, args=(item.pk,))
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
 
@@ -219,8 +215,7 @@ class TestPromotedAddonAdmin(TestCase):
         addon.reload()
         assert item.approved_applications
         detail_url = reverse(self.detail_url_name, args=(item.pk,))
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         # can't access
         response = self.client.get(detail_url, follow=True)
@@ -255,8 +250,7 @@ class TestPromotedAddonAdmin(TestCase):
         delete_url = reverse(
             'admin:discovery_promotedaddon_delete', args=(item.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         # Can access delete confirmation page.
@@ -281,8 +275,7 @@ class TestPromotedAddonAdmin(TestCase):
         delete_url = reverse(
             'admin:discovery_promotedaddon_delete', args=(item.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         # Can't access delete confirmation page.
         response = self.client.get(delete_url, follow=True)
@@ -300,8 +293,7 @@ class TestPromotedAddonAdmin(TestCase):
     def test_can_add_with_discovery_edit_permission(self):
         addon = addon_factory()
         add_url = reverse('admin:discovery_promotedaddon_add')
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         response = self.client.get(add_url, follow=True)
@@ -329,8 +321,7 @@ class TestPromotedAddonAdmin(TestCase):
     def test_can_add_when_existing_approval(self):
         addon = addon_factory(name='unattached')
         add_url = reverse('admin:discovery_promotedaddon_add')
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         # create an approval that doesn't have a matching PromotedAddon yet
@@ -360,8 +351,7 @@ class TestPromotedAddonAdmin(TestCase):
     def test_cannot_add_without_discovery_edit_permission(self):
         addon = addon_factory()
         add_url = reverse('admin:discovery_promotedaddon_add')
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         response = self.client.get(add_url, follow=True)
         assert response.status_code == 403
@@ -384,8 +374,7 @@ class TestPromotedAddonAdmin(TestCase):
         self.detail_url = reverse(
             self.detail_url_name, args=(item.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.detail_url, follow=True)
@@ -420,8 +409,7 @@ class TestPromotedAddonAdmin(TestCase):
         self.detail_url = reverse(
             self.detail_url_name, args=(item.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.detail_url, follow=True)
@@ -459,8 +447,7 @@ class TestPromotedAddonAdmin(TestCase):
         delete_url = reverse(
             'admin:discovery_promotedaddon_delete', args=(item.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
         self.client.login(email=user.email)
         # Can access delete confirmation page.

--- a/src/olympia/ratings/tests/test_admin.py
+++ b/src/olympia/ratings/tests/test_admin.py
@@ -42,7 +42,6 @@ class TestRatingAdmin(TestCase):
         Rating.objects.create(
             addon=addon, user=user, body=u'Réply', reply_to=self.rating)
 
-        self.grant_permission(user, 'Admin:Tools')
         self.grant_permission(user, 'Ratings:Moderate')
 
         self.client.login(email=user.email)
@@ -92,7 +91,6 @@ class TestRatingAdmin(TestCase):
         Rating.objects.create(
             addon=addon, user=user, body=u'Réply', reply_to=self.rating)
 
-        self.grant_permission(user, 'Admin:Tools')
         self.grant_permission(user, 'Ratings:Moderate')
 
         self.client.login(email=user.email)
@@ -109,8 +107,7 @@ class TestRatingAdmin(TestCase):
         assert doc('#result_list tbody tr').length == 4
 
     def test_can_not_access_detail_without_ratings_moderate_permission(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Addons:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.detail_url, follow=True)
@@ -118,8 +115,7 @@ class TestRatingAdmin(TestCase):
 
     def test_can_not_delete_without_admin_advanced_permission(self):
         assert Rating.objects.count() == 1
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Ratings:Moderate')  # Not enough!
         self.client.login(email=user.email)
         response = self.client.get(self.delete_url, follow=True)
@@ -133,8 +129,7 @@ class TestRatingAdmin(TestCase):
 
     def test_can_delete_with_admin_advanced_permission(self):
         assert Rating.objects.count() == 1
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Admin:Advanced')
         self.grant_permission(user, 'Ratings:Moderate')
         self.client.login(email=user.email)

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -4913,7 +4913,6 @@ class TestReview(ReviewBase):
         self.version = version_factory(addon=self.addon, version='3.0')
         self.make_addon_unlisted(self.addon)
         self.grant_permission(self.reviewer, 'Addons:ReviewUnlisted')
-        self.grant_permission(self.reviewer, 'Admin:Tools')
         self.grant_permission(self.reviewer, 'Reviews:Admin')
         self.grant_permission(self.reviewer, 'Blocklist:Create')
 

--- a/src/olympia/scanners/tests/test_admin.py
+++ b/src/olympia/scanners/tests/test_admin.py
@@ -59,7 +59,7 @@ class TestScannerResultAdmin(TestCase):
     def setUp(self):
         super().setUp()
 
-        self.user = user_factory()
+        self.user = user_factory(email='someone@mozilla.com')
         self.grant_permission(self.user, 'Admin:ScannersResultsEdit')
         self.grant_permission(self.user, 'Admin:ScannersResultsView')
         self.client.login(email=self.user.email)
@@ -88,7 +88,7 @@ class TestScannerResultAdmin(TestCase):
             version=addon_factory().current_version,
             results={'matchedRules': [rule.name]}
         )
-        user = user_factory()
+        user = user_factory(email='somebodyelse@mozilla.com')
         self.grant_permission(user, 'Admin:ScannersResultsView')
         self.client.login(email=user.email)
         response = self.client.get(self.list_url)
@@ -97,7 +97,7 @@ class TestScannerResultAdmin(TestCase):
         assert html('.column-result_actions').length == 0
 
     def test_list_view_is_restricted(self):
-        user = user_factory()
+        user = user_factory(email='curator@mozilla.com')
         self.grant_permission(user, 'Admin:Curation')
         self.client.login(email=user.email)
         response = self.client.get(self.list_url)
@@ -731,7 +731,7 @@ class TestScannerResultAdmin(TestCase):
 
     def test_handle_true_positive_and_non_admin_user(self):
         result = ScannerResult(scanner=CUSTOMS)
-        user = user_factory()
+        user = user_factory(email='somebodyelse@mozilla.com')
         self.grant_permission(user, 'Admin:ScannersResultsView')
         self.client.login(email=user.email)
         response = self.client.post(
@@ -744,7 +744,7 @@ class TestScannerResultAdmin(TestCase):
 
     def test_handle_false_positive_and_non_admin_user(self):
         result = ScannerResult(scanner=CUSTOMS)
-        user = user_factory()
+        user = user_factory(email='somebodyelse@mozilla.com')
         self.grant_permission(user, 'Admin:ScannersResultsView')
         self.client.login(email=user.email)
         response = self.client.post(
@@ -757,7 +757,7 @@ class TestScannerResultAdmin(TestCase):
 
     def test_handle_revert_report_and_non_admin_user(self):
         result = ScannerResult(scanner=CUSTOMS)
-        user = user_factory()
+        user = user_factory(email='somebodyelse@mozilla.com')
         self.grant_permission(user, 'Admin:ScannersResultsView')
         self.client.login(email=user.email)
         response = self.client.post(
@@ -845,7 +845,7 @@ class TestScannerRuleAdmin(TestCase):
     def setUp(self):
         super().setUp()
 
-        self.user = user_factory()
+        self.user = user_factory(email='someone@mozilla.com')
         self.grant_permission(self.user, 'Admin:*')
         self.client.login(email=self.user.email)
         self.list_url = reverse('admin:scanners_scannerrule_changelist')
@@ -859,7 +859,7 @@ class TestScannerRuleAdmin(TestCase):
         assert response.status_code == 200
 
     def test_list_view_is_restricted(self):
-        user = user_factory()
+        user = user_factory(email='curator@mozilla.com')
         self.grant_permission(user, 'Admin:Curation')
         self.client.login(email=user.email)
         response = self.client.get(self.list_url)
@@ -909,7 +909,7 @@ class TestScannerRuleAdmin(TestCase):
                 self.admin.get_fields(request=request))
 
     def test_get_fields_for_non_admins(self):
-        user = user_factory()
+        user = user_factory(email='somebodyelse@mozilla.com')
         self.grant_permission(user, 'Admin:ScannersRulesView')
         request = RequestFactory().get('/')
         request.user = user
@@ -927,7 +927,7 @@ class TestScannerQueryRuleAdmin(AMOPaths, TestCase):
     def setUp(self):
         super().setUp()
 
-        self.user = user_factory()
+        self.user = user_factory(email='someone@mozilla.com')
         self.grant_permission(self.user, 'Admin:ScannersQueryEdit')
         self.client.login(email=self.user.email)
         self.list_url = reverse('admin:scanners_scannerqueryrule_changelist')
@@ -962,7 +962,7 @@ class TestScannerQueryRuleAdmin(AMOPaths, TestCase):
         assert classes == expected_classes
 
     def test_list_view_is_restricted(self):
-        user = user_factory()
+        user = user_factory(email='curator@mozilla.com')
         self.grant_permission(user, 'Admin:Curation')
         self.client.login(email=user.email)
         response = self.client.get(self.list_url)
@@ -1171,7 +1171,7 @@ class TestScannerQueryRuleAdmin(AMOPaths, TestCase):
         assert rule.state == ABORTING
 
     def test_run_action_no_permission(self):
-        user = user_factory()
+        user = user_factory(email='somebodyelse@mozilla.com')
         self.grant_permission(user, 'Admin:ScannersQueryView')
         self.client.login(email=user.email)
         rule = ScannerQueryRule.objects.create(
@@ -1220,7 +1220,7 @@ class TestScannerQueryRuleAdmin(AMOPaths, TestCase):
         assert rule.state == COMPLETED
 
     def test_abort_action_no_permission(self):
-        user = user_factory()
+        user = user_factory(email='somebodyelse@mozilla.com')
         self.grant_permission(user, 'Admin:ScannersQueryView')
         self.client.login(email=user.email)
         rule = ScannerQueryRule.objects.create(
@@ -1256,7 +1256,7 @@ class TestScannerQueryResultAdmin(TestCase):
     def setUp(self):
         super().setUp()
 
-        self.user = user_factory()
+        self.user = user_factory(email='someone@mozilla.com')
         self.grant_permission(self.user, 'Admin:ScannersQueryEdit')
         self.client.login(email=self.user.email)
         self.list_url = reverse('admin:scanners_scannerqueryresult_changelist')
@@ -1310,7 +1310,7 @@ class TestScannerQueryResultAdmin(TestCase):
         result.add_yara_result(rule=rule.name)
         result.save()
 
-        self.user = user_factory()
+        self.user = user_factory(email='somebodyelse@mozilla.com')
         # Give the user permission to edit ScannersResults, but not
         # ScannerQueryResults.
         self.grant_permission(self.user, 'Admin:ScannersResultsEdit')
@@ -1319,7 +1319,7 @@ class TestScannerQueryResultAdmin(TestCase):
         assert response.status_code == 403
 
     def test_list_view_query_view_permission(self):
-        self.user = user_factory()
+        self.user = user_factory(email='somebodyelse@mozilla.com')
         self.grant_permission(self.user, 'Admin:ScannersQueryView')
         self.client.login(email=self.user.email)
         self.test_list_view()
@@ -1529,7 +1529,7 @@ class TestScannerQueryResultAdmin(TestCase):
         assert link_response.status_code == 200
 
     def test_change_view_no_query_permissions(self):
-        self.user = user_factory()
+        self.user = user_factory(email='somebodyelse@mozilla.com')
         # Give the user permission to edit ScannersResults, but not
         # ScannerQueryResults.
         self.grant_permission(self.user, 'Admin:ScannersResultsEdit')
@@ -1545,7 +1545,7 @@ class TestScannerQueryResultAdmin(TestCase):
         assert response.status_code == 403
 
     def test_change_view_query_view_permission(self):
-        self.user = user_factory()
+        self.user = user_factory(email='somebodyelse@mozilla.com')
         self.grant_permission(self.user, 'Admin:ScannersQueryView')
         self.client.login(email=self.user.email)
         self.test_change_page()

--- a/src/olympia/users/fixtures/users/test_backends.json
+++ b/src/olympia/users/fixtures/users/test_backends.json
@@ -43,26 +43,6 @@
         }
     },
     {
-        "pk": 5349055,
-        "model": "users.userprofile",
-        "fields": {
-            "display_collections": false,
-            "occupation": "",
-            "location": "",
-            "picture_type": "",
-            "averagerating": null,
-            "homepage": "",
-            "email": "testo@example.com",
-            "biography": null,
-            "deleted": false,
-            "username": "barry",
-            "display_name": "barry \u0627\u0644\u062a\u0637\u0628",
-            "created": "2010-07-03 23:03:11",
-            "notes": "",
-            "modified": "2010-07-23 00:37:10"
-        }
-    },
-    {
         "pk": 1,
         "model": "access.group",
         "fields": {
@@ -77,7 +57,7 @@
         "model": "access.groupuser",
         "fields": {
             "group": 1,
-            "user": 5349055
+            "user": 4043307
         }
     },
     {

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -223,12 +223,21 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
 
     @property
     def is_staff(self):
-        """Property indicating whether the user should be able to log in to
-        the django admin tools. Does not guarantee that the user will then
-        be able to do anything, as each module can have its own permission
-        checks. (see has_module_perms() and has_perm())"""
-        from olympia.access import acl
-        return acl.action_allowed_user(self, amo.permissions.ANY_ADMIN)
+        """Property indicating whether the user is considered to be a Mozilla
+        Employee.
+
+        Django admin uses this to allow logging in, though it doesn't give
+        access to the individual admin pages: each module has their own
+        permission checks (see has_module_perms() and has_perm() below). In
+        addition we also force users to use the VPN to access the admin.
+
+        It's also used by waffle Flag `staff` property, which allows a feature
+        behind a flag to be enabled just for users for which this property
+        returns True. This shouldn't be used as a replacement to a permission
+        check, but only for progressive rollouts of features that are intended
+        to eventually be enabled globally.
+        """
+        return self.email and self.email.endswith('@mozilla.com')
 
     def has_perm(self, perm, obj=None):
         """Determine what the user can do in the django admin tools.

--- a/src/olympia/users/tests/test_admin.py
+++ b/src/olympia/users/tests/test_admin.py
@@ -44,11 +44,10 @@ class TestUserAdmin(TestCase):
         )
 
     def test_search_for_multiple_users(self):
-        user = user_factory()
-        another_user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Users:Edit')
         self.client.login(email=user.email)
+        another_user = user_factory()
         response = self.client.get(
             self.list_url,
             {'q': '%s,%s,foobaa' % (self.user.pk, another_user.pk)},
@@ -60,11 +59,10 @@ class TestUserAdmin(TestCase):
 
     def test_search_for_multiple_user_ids(self):
         """Test the optimization when just searching for matching ids."""
-        user = user_factory()
-        another_user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Users:Edit')
         self.client.login(email=user.email)
+        another_user = user_factory()
         with CaptureQueriesContext(connection) as queries:
             response = self.client.get(
                 self.list_url,
@@ -80,8 +78,7 @@ class TestUserAdmin(TestCase):
         assert str(another_user.pk) in doc('#result_list').text()
 
     def test_can_not_edit_without_users_edit_permission(self):
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Addons:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.detail_url, follow=True)
@@ -94,8 +91,7 @@ class TestUserAdmin(TestCase):
 
     def test_can_edit_with_users_edit_permission(self):
         old_username = self.user.username
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Users:Edit')
         self.client.login(email=user.email)
         core.set_user(user)
@@ -114,10 +110,9 @@ class TestUserAdmin(TestCase):
     @mock.patch.object(UserProfile, '_delete_related_content')
     def test_can_not_delete_with_users_edit_permission(
             self, _delete_related_content_mock):
-        user = user_factory()
-        assert not user.deleted
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Users:Edit')
+        assert not user.deleted
         self.client.login(email=user.email)
         response = self.client.get(self.delete_url, follow=True)
         assert response.status_code == 403
@@ -132,10 +127,9 @@ class TestUserAdmin(TestCase):
     @mock.patch.object(UserProfile, '_delete_related_content')
     def test_can_delete_with_admin_advanced_permission(
             self, _delete_related_content_mock):
-        user = user_factory()
-        assert not self.user.deleted
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Admin:Advanced')
+        assert not self.user.deleted
         self.client.login(email=user.email)
         core.set_user(user)
         response = self.client.get(self.delete_url, follow=True)
@@ -183,10 +177,9 @@ class TestUserAdmin(TestCase):
         ]
 
         # Now test as normal.
-        user = user_factory()
-        assert not self.user.deleted
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Admin:Advanced')
+        assert not self.user.deleted
         self.client.login(email=user.email)
         core.set_user(user)
         response = self.client.get(self.delete_url, follow=True)
@@ -248,8 +241,7 @@ class TestUserAdmin(TestCase):
 
     def test_ban_button_in_change_view(self):
         ban_url = reverse('admin:users_userprofile_ban', args=(self.user.pk, ))
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Users:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.detail_url, follow=True)
@@ -323,8 +315,7 @@ class TestUserAdmin(TestCase):
     def test_reset_api_key_button_in_change_view(self):
         reset_api_key_url = reverse(
             'admin:users_userprofile_reset_api_key', args=(self.user.pk, ))
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Users:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.detail_url, follow=True)
@@ -334,8 +325,7 @@ class TestUserAdmin(TestCase):
     def test_session_button_in_change_view(self):
         reset_session_url = reverse(
             'admin:users_userprofile_reset_session', args=(self.user.pk, ))
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Users:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.detail_url, follow=True)
@@ -345,8 +335,7 @@ class TestUserAdmin(TestCase):
     def test_delete_picture_button_in_change_view(self):
         delete_picture_url = reverse('admin:users_userprofile_delete_picture',
                                      args=(self.user.pk, ))
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Users:Edit')
         self.client.login(email=user.email)
         response = self.client.get(self.detail_url, follow=True)
@@ -357,8 +346,7 @@ class TestUserAdmin(TestCase):
         ban_url = reverse('admin:users_userprofile_ban', args=(self.user.pk, ))
         wrong_ban_url = reverse(
             'admin:users_userprofile_ban', args=(self.user.pk + 42, ))
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         core.set_user(user)
         response = self.client.post(ban_url, follow=True)
@@ -391,8 +379,7 @@ class TestUserAdmin(TestCase):
             'admin:users_userprofile_reset_api_key', args=(self.user.pk, ))
         wrong_reset_api_key_url = reverse(
             'admin:users_userprofile_reset_api_key', args=(self.user.pk + 9, ))
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         core.set_user(user)
         response = self.client.post(reset_api_key_url, follow=True)
@@ -426,8 +413,7 @@ class TestUserAdmin(TestCase):
             'admin:users_userprofile_reset_session', args=(self.user.pk, ))
         wrong_reset_session_url = reverse(
             'admin:users_userprofile_reset_session', args=(self.user.pk + 9, ))
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         response = self.client.post(reset_session_url, follow=True)
         assert response.status_code == 403
@@ -456,8 +442,7 @@ class TestUserAdmin(TestCase):
         wrong_delete_picture_url = reverse(
             'admin:users_userprofile_delete_picture',
             args=(self.user.pk + 42, ))
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         core.set_user(user)
         response = self.client.post(delete_picture_url, follow=True)
@@ -673,8 +658,7 @@ class TestUserAdmin(TestCase):
         detail_url_final = reverse(
             'admin:users_userprofile_change', args=(lookup_user.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Addons:Edit')
         self.client.login(email=user.email)
         response = self.client.get(detail_url_by_email, follow=False)
@@ -683,8 +667,7 @@ class TestUserAdmin(TestCase):
 
 class TestEmailUserRestrictionAdmin(TestCase):
     def setUp(self):
-        self.user = user_factory()
-        self.grant_permission(self.user, 'Admin:Tools')
+        self.user = user_factory(email='someone@mozilla.com')
         self.grant_permission(self.user, 'Admin:Advanced')
 
         self.client.login(email=self.user.email)
@@ -698,8 +681,7 @@ class TestEmailUserRestrictionAdmin(TestCase):
 
 class TestIPNetworkUserRestrictionAdmin(TestCase):
     def setUp(self):
-        self.user = user_factory()
-        self.grant_permission(self.user, 'Admin:Tools')
+        self.user = user_factory(email='someone@mozilla.com')
         self.grant_permission(self.user, 'Admin:Advanced')
 
         self.client.login(email=self.user.email)
@@ -714,8 +696,7 @@ class TestIPNetworkUserRestrictionAdmin(TestCase):
 
 class TestUserRestrictionHistoryAdmin(TestCase):
     def setUp(self):
-        self.user = user_factory()
-        self.grant_permission(self.user, 'Admin:Tools')
+        self.user = user_factory(email='someone@mozilla.com')
         self.grant_permission(self.user, 'Admin:Advanced')
 
         self.client.login(email=self.user.email)

--- a/src/olympia/users/tests/test_forms.py
+++ b/src/olympia/users/tests/test_forms.py
@@ -10,20 +10,20 @@ class UserFormBase(TestCase):
 
     def setUp(self):
         super(UserFormBase, self).setUp()
-        self.user = self.user_profile = UserProfile.objects.get(id='4043307')
+        self.user = UserProfile.objects.get(pk=4043307)
 
 
 class TestDeniedNameAdminAddForm(UserFormBase):
 
     def test_no_usernames(self):
-        self.client.login(email='testo@example.com')
+        self.client.login(email=self.user.email)
         url = reverse('admin:users_deniedname_add')
         data = {'names': "\n\n", }
         r = self.client.post(url, data)
         self.assertFormError(r, 'form', 'names', u'This field is required.')
 
     def test_add(self):
-        self.client.login(email='testo@example.com')
+        self.client.login(email=self.user.email)
         url = reverse('admin:users_deniedname_add')
         data = {'names': "IE6Fan\nfubar\n\n", }
         r = self.client.post(url, data)
@@ -35,7 +35,7 @@ class TestDeniedNameAdminAddForm(UserFormBase):
 
 class TestIPNetworkUserRestrictionForm(UserFormBase):
     def test_add_converts_ipaddress_to_network(self):
-        self.client.login(email='testo@example.com')
+        self.client.login(email=self.user.email)
         url = reverse('admin:users_ipnetworkuserrestriction_add')
         data = {'ip_address': '192.168.1.32'}
         response = self.client.post(url, data)
@@ -46,7 +46,7 @@ class TestIPNetworkUserRestrictionForm(UserFormBase):
         assert restriction.network == ipaddress.IPv4Network('192.168.1.32/32')
 
     def test_add_validates_ip_address(self):
-        self.client.login(email='testo@example.com')
+        self.client.login(email=self.user.email)
         url = reverse('admin:users_ipnetworkuserrestriction_add')
         data = {'ip_address': '192.168.1.0/28'}
         response = self.client.post(url, data)

--- a/src/olympia/versions/tests/test_admin.py
+++ b/src/olympia/versions/tests/test_admin.py
@@ -12,8 +12,7 @@ class TestVersionAdmin(TestCase):
         detail_url = reverse(
             'admin:versions_version_change', args=(version.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Admin:Advanced')
         self.client.login(email=user.email)
         response = self.client.get(detail_url, follow=True)
@@ -28,8 +27,7 @@ class TestVersionAdmin(TestCase):
         detail_url = reverse(
             'admin:versions_version_change', args=(version.pk,)
         )
-        user = user_factory()
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
         self.client.login(email=user.email)
         response = self.client.get(detail_url, follow=True)
         assert response.status_code == 403

--- a/src/olympia/zadmin/tests/test_views.py
+++ b/src/olympia/zadmin/tests/test_views.py
@@ -45,13 +45,14 @@ class TestHomeAndIndex(TestCase):
 
         # Redirected when logged in without enough permissions.
         user = user_factory(username='staffperson', email='staffperson@m.c')
-        self.client.login(email='staffperson@m.c')
+        self.client.login(email=user.email)
         response = self.client.get(url)
         self.assert3xx(response, '/admin/models/login/?'
                                  'next=/en-US/admin/models/')
 
         # Can access with a "is_staff" user.
-        self.grant_permission(user, 'Admin:Something')
+        user.update(email='someone@mozilla.com')
+        self.client.login(email=user.email)
         response = self.client.get(url)
         assert response.status_code == 200
         doc = pq(response.content)
@@ -77,12 +78,12 @@ class TestHomeAndIndex(TestCase):
 
         # But if logged in and not enough permissions return a 403.
         user = user_factory(username='staffperson', email='staffperson@m.c')
-        self.client.login(email='staffperson@m.c')
+        self.client.login(email=user.email)
         response = self.client.get(url)
         assert response.status_code == 403
 
         # But can access with a "is_staff" user.
-        self.grant_permission(user, 'Admin:Tools')
+        user.update(email='someone@mozilla.com')
         response = self.client.get(url)
         self.assert3xx(response, '/en-US/admin/models/')
 
@@ -98,9 +99,8 @@ class TestHomeAndIndex(TestCase):
         self.assert3xx(response, '/en-US/admin/models/addon/')
 
         # Same with an "is_staff" user.
-        user = user_factory(username='staffperson', email='staffperson@m.c')
-        self.client.login(email='staffperson@m.c')
-        self.grant_permission(user, 'Admin:Tools')
+        user = user_factory(email='someone@mozilla.com')
+        self.client.login(email=user.email)
         response = self.client.get(url)
         self.assert3xx(response, '/en-US/admin/models/addon/')
 
@@ -172,7 +172,7 @@ class TestPerms(TestCase):
 
     def test_unprivileged_user(self):
         # Unprivileged user.
-        assert self.client.login(email='regular@mozilla.com')
+        assert self.client.login(email='clouserw@gmail.com')
         self.assert_status('admin:index', 403, follow=True)
         # Anonymous users should get a login redirect.
         self.client.logout()


### PR DESCRIPTION
Remove `Admin:Tools` in the process as it was only really used to ensure a given user could log in to the admin.

Fixes #15601