### PR TITLE
Adjust the hero API to serve uploaded PrimaryHeroImage

### DIFF
--- a/src/olympia/hero/admin.py
+++ b/src/olympia/hero/admin.py
@@ -31,7 +31,6 @@ class PrimaryHeroInline(admin.StackedInline):
     fields = (
         'description',
         'promoted_addon',
-        'image',
         'select_image',
         'gradient_color',
         'is_external',

--- a/src/olympia/hero/models.py
+++ b/src/olympia/hero/models.py
@@ -138,9 +138,6 @@ class PrimaryHeroImage(ModelBase):
 class PrimaryHero(ModelBase):
     select_image = models.ForeignKey(
         PrimaryHeroImage, null=True, on_delete=models.SET_NULL)
-    image = WidgetCharField(
-        choices=DirImageChoices(path=FEATURED_IMAGE_PATH), max_length=255,
-        widget=ImageChoiceWidget, blank=True)
     gradient_color = WidgetCharField(
         choices=GRADIENT_COLORS.items(), max_length=7,
         widget=GradientChoiceWidget, blank=True)
@@ -158,7 +155,9 @@ class PrimaryHero(ModelBase):
 
     @property
     def image_url(self):
-        return f'{FEATURED_IMAGE_URL}{self.image}' if self.image else None
+        return (
+            f'{self.select_image.custom_image.url}'
+            if self.select_image else None)
 
     @property
     def gradient(self):

--- a/src/olympia/hero/tests/test_models.py
+++ b/src/olympia/hero/tests/test_models.py
@@ -1,19 +1,25 @@
 from django.core.exceptions import ValidationError
 
 from olympia.amo.tests import addon_factory, TestCase
+from olympia.amo.tests.test_helpers import get_uploaded_file
 from olympia.constants.promoted import RECOMMENDED
-from olympia.hero.models import PrimaryHero, SecondaryHero, SecondaryHeroModule
+from olympia.hero.models import (
+    PrimaryHero, PrimaryHeroImage, SecondaryHero, SecondaryHeroModule)
 from olympia.promoted.models import PromotedAddon
 
 
 class TestPrimaryHero(TestCase):
+    def setUp(self):
+        uploaded_photo = get_uploaded_file('transparent.png')
+        self.phi = PrimaryHeroImage.objects.create(custom_image=uploaded_photo)
+
     def test_image_url(self):
         ph = PrimaryHero.objects.create(
             promoted_addon=PromotedAddon.objects.create(addon=addon_factory()),
-            image='foo.png')
+            select_image=self.phi)
         assert ph.image_url == (
-            'http://testserver/static/img/hero/featured/foo.png')
-        ph.update(image='')
+            'http://testserver/user-media/hero-featured-image/transparent.jpg')
+        ph.update(select_image=None)
         assert ph.image_url is None
 
     def test_gradiant(self):
@@ -26,7 +32,7 @@ class TestPrimaryHero(TestCase):
         ph = PrimaryHero.objects.create(
             promoted_addon=PromotedAddon.objects.create(
                 addon=addon_factory(), group_id=RECOMMENDED.id),
-            gradient_color='#C60184', image='foo.png')
+            gradient_color='#C60184', select_image=self.phi)
         assert not ph.enabled
         ph.clean()  # it raises if there's an error
         ph.enabled = True
@@ -43,7 +49,7 @@ class TestPrimaryHero(TestCase):
     def test_clean_external_requires_homepage(self):
         ph = PrimaryHero.objects.create(
             promoted_addon=PromotedAddon.objects.create(addon=addon_factory()),
-            is_external=True, gradient_color='#C60184', image='foo.png')
+            is_external=True, gradient_color='#C60184', select_image=self.phi)
         assert not ph.enabled
         ph.clean()  # it raises if there's an error
         ph.enabled = True
@@ -68,22 +74,22 @@ class TestPrimaryHero(TestCase):
         with self.assertRaises(ValidationError) as ve:
             ph.clean()
         assert 'gradient_color' in ve.exception.error_dict
-        assert 'image' not in ve.exception.error_dict
+        assert 'select_image' not in ve.exception.error_dict
 
-        ph.update(image='foo.png')
+        ph.update(select_image=self.phi)
         with self.assertRaises(ValidationError) as ve:
             ph.clean()
         assert 'gradient_color' in ve.exception.error_dict
-        assert 'image' not in ve.exception.error_dict
+        assert 'select_image' not in ve.exception.error_dict
 
-        ph.update(image='', gradient_color='#123456')
+        ph.update(select_image=None, gradient_color='#123456')
         ph.clean()  # it raises if there's an error
 
     def test_clean_only_enabled(self):
         hero = PrimaryHero.objects.create(
             promoted_addon=PromotedAddon.objects.create(
                 addon=addon_factory(), group_id=RECOMMENDED.id),
-            gradient_color='#C60184', image='foo.png')
+            gradient_color='#C60184', select_image=self.phi)
         hero.promoted_addon.approve_for_version(
             hero.promoted_addon.addon.current_version)
         hero.reload()

--- a/src/olympia/hero/tests/test_serializers.py
+++ b/src/olympia/hero/tests/test_serializers.py
@@ -1,27 +1,34 @@
 from olympia import amo
 from olympia.amo.tests import addon_factory, TestCase
+from olympia.amo.tests.test_helpers import get_uploaded_file
 from olympia.discovery.serializers import DiscoveryAddonSerializer
 from olympia.promoted.models import PromotedAddon
 
 from ..models import (
-    GRADIENT_START_COLOR, PrimaryHero, SecondaryHero, SecondaryHeroModule)
+    GRADIENT_START_COLOR, PrimaryHero, PrimaryHeroImage, SecondaryHero,
+    SecondaryHeroModule)
 from ..serializers import (
     ExternalAddonSerializer, PrimaryHeroShelfSerializer,
     SecondaryHeroShelfSerializer)
 
 
 class TestPrimaryHeroShelfSerializer(TestCase):
+    def setUp(self):
+        uploaded_photo = get_uploaded_file('transparent.png')
+        self.phi = PrimaryHeroImage.objects.create(custom_image=uploaded_photo)
+        self.image = (
+            'http://testserver/user-media/hero-featured-image/transparent.jpg')
+
     def test_basic(self):
         addon = addon_factory()
         hero = PrimaryHero.objects.create(
             promoted_addon=PromotedAddon.objects.create(addon=addon),
             description='Déscription',
-            image='foo.png',
+            select_image=self.phi,
             gradient_color='#008787')
         data = PrimaryHeroShelfSerializer(instance=hero).data
         assert data == {
-            'featured_image': (
-                'http://testserver/static/img/hero/featured/foo.png'),
+            'featured_image': self.image,
             'description': 'Déscription',
             'gradient': {
                 'start': GRADIENT_START_COLOR[1],
@@ -55,12 +62,11 @@ class TestPrimaryHeroShelfSerializer(TestCase):
                 'channel': amo.RELEASE_CHANNEL_UNLISTED})
         hero = PrimaryHero.objects.create(
             promoted_addon=PromotedAddon.objects.create(addon=addon),
-            image='foo.png',
+            select_image=self.phi,
             gradient_color='#008787',
             is_external=True)
         assert PrimaryHeroShelfSerializer(instance=hero).data == {
-            'featured_image': (
-                'http://testserver/static/img/hero/featured/foo.png'),
+            'featured_image': self.image,
             'description': 'Summary',
             'gradient': {
                 'start': GRADIENT_START_COLOR[1],

--- a/src/olympia/hero/tests/test_views.py
+++ b/src/olympia/hero/tests/test_views.py
@@ -2,9 +2,11 @@ import json
 
 from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.amo.tests import addon_factory, TestCase, reverse_ns
+from olympia.amo.tests.test_helpers import get_uploaded_file
 from olympia.promoted.models import PromotedAddon
 
-from ..models import PrimaryHero, SecondaryHero, SecondaryHeroModule
+from ..models import (
+    PrimaryHero, PrimaryHeroImage, SecondaryHero, SecondaryHeroModule)
 from ..serializers import (
     PrimaryHeroShelfSerializer, SecondaryHeroShelfSerializer)
 
@@ -12,6 +14,19 @@ from ..serializers import (
 class TestPrimaryHeroShelfViewSet(TestCase):
     def setUp(self):
         self.url = reverse_ns('hero-primary-list', api_version='v5')
+        uploaded_photo_1 = get_uploaded_file('animated.png')
+        uploaded_photo_2 = get_uploaded_file('non-animated.png')
+        uploaded_photo_3 = get_uploaded_file('preview_4x3.jpg')
+        uploaded_photo_4 = get_uploaded_file('transparent.png')
+
+        self.phi_a = PrimaryHeroImage.objects.create(
+            custom_image=uploaded_photo_1)
+        self.phi_b = PrimaryHeroImage.objects.create(
+            custom_image=uploaded_photo_2)
+        self.phi_c = PrimaryHeroImage.objects.create(
+            custom_image=uploaded_photo_3)
+        self.phi_d = PrimaryHeroImage.objects.create(
+            custom_image=uploaded_photo_4)
 
     def test_basic(self):
         response = self.client.get(self.url)
@@ -22,23 +37,23 @@ class TestPrimaryHeroShelfViewSet(TestCase):
             promoted_addon=PromotedAddon.objects.create(
                 addon=addon_factory()),
             description='Its a déscription!',
-            image='foo.png',
+            select_image=self.phi_a,
             gradient_color='#123456')
         hero_b = PrimaryHero.objects.create(
             promoted_addon=PromotedAddon.objects.create(
                 addon=addon_factory(summary='fooo')),
-            image='baa.png',
+            select_image=self.phi_b,
             gradient_color='#987654')
         hero_external = PrimaryHero.objects.create(
             promoted_addon=PromotedAddon.objects.create(
                 addon=addon_factory(homepage='https://mozilla.org/')),
-            image='external.png',
+            select_image=self.phi_c,
             gradient_color='#FABFAB',
             is_external=True)
         PrimaryHero.objects.create(
             promoted_addon=PromotedAddon.objects.create(
                 addon=addon_factory()),
-            image='wah.png',
+            select_image=self.phi_d,
             gradient_color='#989898')
 
         # The shelves aren't enabled so still won't show up
@@ -81,7 +96,7 @@ class TestPrimaryHeroShelfViewSet(TestCase):
         PrimaryHero.objects.create(
             promoted_addon=PromotedAddon.objects.create(
                 addon=addon_factory(homepage='https://mozilla.org/')),
-            image='external.png',
+            select_image=self.phi_a,
             gradient_color='#FABFAB',
             is_external=True,
             enabled=True)
@@ -97,19 +112,19 @@ class TestPrimaryHeroShelfViewSet(TestCase):
         PrimaryHero.objects.create(
             promoted_addon=PromotedAddon.objects.create(
                 addon=addon_factory()),
-            image='wah.png',
+            select_image=self.phi_a,
             gradient_color='#989898',
             enabled=True)
         PrimaryHero.objects.create(
             promoted_addon=PromotedAddon.objects.create(
                 addon=addon_factory()),
-            image='wah.png',
+            select_image=self.phi_b,
             gradient_color='#989898',
             enabled=True)
         PrimaryHero.objects.create(
             promoted_addon=PromotedAddon.objects.create(
                 addon=addon_factory()),
-            image='wah.png',
+            select_image=self.phi_c,
             gradient_color='#989898',
             enabled=False)
 
@@ -125,20 +140,20 @@ class TestPrimaryHeroShelfViewSet(TestCase):
         PrimaryHero.objects.create(
             promoted_addon=PromotedAddon.objects.create(
                 addon=addon_factory(summary='addon')),
-            image='wah.png',
+            select_image=self.phi_a,
             gradient_color='#989898',
             enabled=True)
         PrimaryHero.objects.create(
             promoted_addon=PromotedAddon.objects.create(
                 addon=addon_factory()),
             description='hero',
-            image='wah.png',
+            select_image=self.phi_b,
             gradient_color='#989898',
             enabled=True)
         PrimaryHero.objects.create(
             promoted_addon=PromotedAddon.objects.create(
                 addon=addon_factory(summary=None)),
-            image='wah.png',
+            select_image=self.phi_c,
             gradient_color='#989898',
             enabled=True)
 

--- a/src/olympia/hero/views.py
+++ b/src/olympia/hero/views.py
@@ -44,7 +44,7 @@ class PrimaryHeroShelfViewSet(ShelfViewSet):
 
     def get_queryset(self):
         qs = super().get_queryset()
-        qs = (qs.select_related('promoted_addon')
+        qs = (qs.select_related('promoted_addon', 'select_image')
                 .prefetch_related(
                     'promoted_addon__addon___current_version__previews'))
         return qs

--- a/static/css/admin/discovery.css
+++ b/static/css/admin/discovery.css
@@ -95,7 +95,6 @@
 }
 
 .select-image-preview {
-    width: 150px;
     height: 120px;
 }
 


### PR DESCRIPTION
re-lands @xlisachan's commit to switch the hero api to use `PrimaryHeroImage` defined images, so closes #14473 again