### PR TITLE
Support all badged add-ons in Return To AMO

### DIFF
--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -234,7 +234,7 @@ class CurrentVersionSerializer(SimpleVersionSerializer):
         try:
             # AddonAppVersionQueryParam.get_values() returns (app_id, min, max)
             # but we want {'min': min, 'max': max}.
-            value = AddonAppVersionQueryParam(request).get_values()
+            value = AddonAppVersionQueryParam(request.GET).get_values()
             application = value[0]
             appversions = dict(zip(('min', 'max'), value[1:]))
         except ValueError as exc:

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -28,7 +28,6 @@ from olympia.bandwagon.models import CollectionAddon
 from olympia.constants.categories import CATEGORIES, CATEGORIES_BY_ID
 from olympia.constants.promoted import (
     LINE, SPOTLIGHT, STRATEGIC, RECOMMENDED, VERIFIED_ONE, VERIFIED_TWO)
-from olympia.discovery.models import DiscoveryItem
 from olympia.users.models import UserProfile
 from olympia.versions.models import ApplicationsVersions, AppVersion
 

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -513,14 +513,15 @@ class LanguageToolsView(ListAPIView):
         """
         # app parameter is mandatory when calling this API.
         try:
-            application = AddonAppQueryParam(self.request).get_value()
+            application = AddonAppQueryParam(self.request.GET).get_value()
         except ValueError:
             raise exceptions.ParseError('Invalid or missing app parameter.')
 
         # appversion parameter is optional.
         if AddonAppVersionQueryParam.query_param in self.request.GET:
             try:
-                value = AddonAppVersionQueryParam(self.request).get_values()
+                value = AddonAppVersionQueryParam(
+                    self.request.GET).get_values()
                 appversions = {
                     'min': value[1],
                     'max': value[2]
@@ -537,7 +538,7 @@ class LanguageToolsView(ListAPIView):
         if AddonTypeQueryParam.query_param in self.request.GET or appversions:
             try:
                 addon_types = tuple(
-                    AddonTypeQueryParam(self.request).get_values())
+                    AddonTypeQueryParam(self.request.GET).get_values())
             except ValueError:
                 raise exceptions.ParseError(
                     'Invalid or missing type parameter while appversion '
@@ -548,7 +549,7 @@ class LanguageToolsView(ListAPIView):
         # author is optional. It's a string representing the username(s) we're
         # filtering on.
         if AddonAuthorQueryParam.query_param in self.request.GET:
-            authors = AddonAuthorQueryParam(self.request).get_values()
+            authors = AddonAuthorQueryParam(self.request.GET).get_values()
         else:
             authors = None
 

--- a/src/olympia/constants/promoted.py
+++ b/src/olympia/constants/promoted.py
@@ -122,9 +122,10 @@ PROMOTED_GROUPS = [
 
 PRE_REVIEW_GROUPS = [group for group in PROMOTED_GROUPS if group.pre_review]
 BADGED_GROUPS = [group for group in PROMOTED_GROUPS if group.badged]
+BADGED_API_NAME = 'badged'  # Special alias for all badged groups
 
 PROMOTED_GROUPS_BY_ID = {p.id: p for p in PROMOTED_GROUPS}
 PROMOTED_API_NAME_TO_IDS = {
     # we can replace this ugly syntax with dict | in 3.9 - see pep-0584
     **{p.api_name: [p.id] for p in PROMOTED_GROUPS if p},
-    **{'badged': list({p.id for p in BADGED_GROUPS})}}
+    **{BADGED_API_NAME: list({p.id for p in BADGED_GROUPS})}}

--- a/src/olympia/search/filters.py
+++ b/src/olympia/search/filters.py
@@ -16,7 +16,6 @@ from olympia.api.utils import is_gate_active
 from olympia.constants.categories import CATEGORIES, CATEGORIES_BY_ID
 from olympia.constants.promoted import (
     BADGED_API_NAME, PROMOTED_API_NAME_TO_IDS, PROMOTED_GROUPS)
-from olympia.discovery.models import DiscoveryItem
 from olympia.versions.compare import version_int
 
 


### PR DESCRIPTION
Slight behavior change: we now avoid the database query and return directly some results or an empty list if the parameter is not correct. Callers should always have expected the empty list, because the add-on could be in DiscoveryItems without necessarily being public at the time of the request.

Fixes #15732