### PR TITLE
pin celery & it's dependants to < 5.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,10 @@ updates:
   ignore:
   - dependency-name: billiard
     versions:
-    - ">= 4.0"
+    - ">= 5"
+  - dependency-name: celery
+    versions:
+    - ">= 5"
   - dependency-name: Django
     versions:
     - ">= 3.0"
@@ -21,6 +24,12 @@ updates:
   - dependency-name: elasticsearch-dsl
     versions:
     - ">= 7"
+  - dependency-name: kombu
+    versions:
+    - ">= 5"
   - dependency-name: pygit2
     versions:
     - ">= 1.2.0"
+  - dependency-name: vine
+    versions:
+    - ">= 5"

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,6 +1,6 @@
 Django==2.2.16 \
     --hash=sha256:83ced795a0f239f41d8ecabf51cc5fad4b97462a6008dc12e5af3cb9288724ec \
-    --hash=sha256:62cf45e5ee425c52e411c0742e641a6588b7e8af0d2c274a27940931b2786594 # pyup: <3.0
+    --hash=sha256:62cf45e5ee425c52e411c0742e641a6588b7e8af0d2c274a27940931b2786594
 Babel==2.8.0 \
     --hash=sha256:1aac2ae2d0d8ea368fa90906567f5c08463d98ade155c0c4bfedd6a0f7160e38 \
     --hash=sha256:d670ea0b10f8b723672d3a6abeb87b565b244da220d76b4dba1b66269ec152d4
@@ -146,7 +146,7 @@ argparse==1.4.0 \
 # supports it.
 billiard==3.6.3.0 \
     --hash=sha256:bff575450859a6e0fbc2f9877d9b715b0bbc07c3565bb7ed2280526a0cdf5ede \
-    --hash=sha256:d91725ce6425f33a97dfa72fb6bfef0e47d4652acd98a032bd1a7fbf06d5fa6a # pyup: <4.0
+    --hash=sha256:d91725ce6425f33a97dfa72fb6bfef0e47d4652acd98a032bd1a7fbf06d5fa6a
 # bitarray is required by filtercascade
 bitarray == 1.6.0 \
     --hash=sha256:ba157ddebddc723fe021fc80595b3c70924d69ee58286b62bfca21da48edfc9d
@@ -230,7 +230,7 @@ django-statsd-mozilla==0.4.0 \
     --hash=sha256:81084f3d426f5184f0a0f1dbfe035cc26b66f041d2184559d916a228d856f0d3 \
     --hash=sha256:0d87cb63de8107279cbb748caad9aa74c6a44e7e96ccc5dbf07b89f77285a4b8
 django-tables2==1.21.2 \
-    --hash=sha256:c5c979201b7a2f7e88f2784dcd478e0c809d3a2053dea576cb71ce51676bbf7a # pyup: <2
+    --hash=sha256:c5c979201b7a2f7e88f2784dcd478e0c809d3a2053dea576cb71ce51676bbf7a
 django-waffle==2.0.0 \
     --hash=sha256:e079cb530d3c8d62e204cfc08c7494a71cb08626630c09cd00e844bed1df0044 \
     --hash=sha256:1973801b2bfdebb2d4ac3a7e5871a51f4d4b91ef712bdf46cc65d89b9dc3c988
@@ -252,10 +252,10 @@ easy-thumbnails==2.7 \
 # elasticsearch is required by elasticsearch-dsl
 elasticsearch==6.8.1 \
     --hash=sha256:540d633afcc0a32972e4b489c4559c9a96e294850853238f7a18b1cbd267c2ed \
-    --hash=sha256:a8062a00b61bc7babeea028530667583a68ecb1a9f59ab0b22ff7feaf70d3564 # pyup: <6
+    --hash=sha256:a8062a00b61bc7babeea028530667583a68ecb1a9f59ab0b22ff7feaf70d3564
 elasticsearch-dsl==6.4.0 \
     --hash=sha256:f60aea7fd756ac1fbe7ce114bbf4949aefbf495dfe8896640e787c67344f12f6 \
-    --hash=sha256:26416f4dd46ceca43d62ef74970d9de4bdd6f4b0f163316f0b432c9e61a08bec # pyup: <6
+    --hash=sha256:26416f4dd46ceca43d62ef74970d9de4bdd6f4b0f163316f0b432c9e61a08bec
 email-reply-parser==0.5.12 \
     --hash=sha256:d051cfa8f54046f7399553aae57f17f62bf1652f83e3e9970fd109c0f24a880c \
     --hash=sha256:3499c02284679e020acf8aa30ef9e43c62f9ab5ccee0a35bfac85a0c1fa685fd \
@@ -433,7 +433,7 @@ pygit2==1.1.1 \
     --hash=sha256:9255d507d5d87bf22dfd57997a78908010331fc21f9a83eca121a53f657beb3c \
     --hash=sha256:94a64011590f46d026f933f6cbfa09b0617529a4c328634d81ee0db503ab2c6e \
     --hash=sha256:aef29a3727f75a085c49ca505613554f40629d125c1d11c351e579ca12ee37ba \
-    --hash=sha256:e58f3f52167eb03195592770b743b6b5d929b49042997bd8ade6054195d59e2c # pyup: <1.2.0
+    --hash=sha256:e58f3f52167eb03195592770b743b6b5d929b49042997bd8ade6054195d59e2c
 webencodings==0.5.1 \
     --hash=sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78 \
     --hash=sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923


### PR DESCRIPTION
fixes #15677 closes #15419 closes #15420 closes #15573

Billiard is called out as another celery dependant that was previously pinned due to celery versions, but it doesn't seem to have been updated for a while so I'm not sure if we need to remove the version pinning, or change it to <5.0 like the others. @diox 