### PR TITLE
Add admin for promoted subscriptions

### DIFF
--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -25,7 +25,7 @@ from olympia.bandwagon.models import Collection
 from olympia.blocklist.models import Block, BlocklistSubmission
 from olympia.constants.categories import CATEGORIES
 from olympia.constants.promoted import (
-    NOT_PROMOTED, RECOMMENDED, SPOTLIGHT, VERIFIED_ONE)
+    NOT_PROMOTED, RECOMMENDED, SPOTLIGHT, SPONSORED)
 from olympia.devhub.models import RssKey
 from olympia.files.models import File
 from olympia.files.tests.test_models import UploadTest
@@ -1573,18 +1573,18 @@ class TestAddonModels(TestCase):
 
         # if the group has changes the approval for the current version isn't
         # valid
-        promoted.update(group_id=VERIFIED_ONE.id)
+        promoted.update(group_id=SPONSORED.id)
         assert not addon.promoted_group()
         assert addon.promoted_group(currently_approved=False)
-        assert addon.promoted_group(currently_approved=False) == VERIFIED_ONE
+        assert addon.promoted_group(currently_approved=False) == SPONSORED
 
         promoted.approve_for_version(version=addon.current_version)
         del addon.current_version.approved_for_groups
-        assert addon.promoted_group() == VERIFIED_ONE
+        assert addon.promoted_group() == SPONSORED
 
         # Application specific group membership should work too
         # if no app is specifed in the PromotedAddon everything should match
-        assert addon.promoted_group() == VERIFIED_ONE
+        assert addon.promoted_group() == SPONSORED
         # update to mobile app
         promoted.update(application_id=amo.ANDROID.id)
         assert addon.promoted_group()
@@ -1594,7 +1594,7 @@ class TestAddonModels(TestCase):
         del addon.current_version.approved_for_groups
         assert not addon.promoted_group()
         promoted.update(application_id=amo.FIREFOX.id)
-        assert addon.promoted_group() == VERIFIED_ONE
+        assert addon.promoted_group() == SPONSORED
 
         # check it doesn't error if there's no current_version
         addon.current_version.all_files[0].update(status=amo.STATUS_DISABLED)
@@ -1621,7 +1621,7 @@ class TestAddonModels(TestCase):
 
         # If the group changes the approval for the current version isn't
         # valid.
-        promoted.update(group_id=VERIFIED_ONE.id)
+        promoted.update(group_id=SPONSORED.id)
         del addon.promoted
         assert addon.promoted is None
 

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -27,7 +27,8 @@ from olympia.amo.urlresolvers import get_outgoing_url, reverse
 from olympia.bandwagon.models import CollectionAddon
 from olympia.constants.categories import CATEGORIES, CATEGORIES_BY_ID
 from olympia.constants.promoted import (
-    LINE, SPOTLIGHT, STRATEGIC, RECOMMENDED, VERIFIED_ONE, VERIFIED_TWO)
+    LINE, SPOTLIGHT, STRATEGIC, RECOMMENDED, SPONSORED, VERIFIED)
+from olympia.discovery.models import DiscoveryItem
 from olympia.users.models import UserProfile
 from olympia.versions.models import ApplicationsVersions, AppVersion
 
@@ -1282,7 +1283,7 @@ class TestAddonSearchView(ESTestCase):
         # addon2 was for Firefox only
 
         # test with other other promotions
-        for promo in (VERIFIED_ONE, VERIFIED_TWO, LINE, SPOTLIGHT, STRATEGIC):
+        for promo in (SPONSORED, VERIFIED, LINE, SPOTLIGHT, STRATEGIC):
             self.make_addon_promoted(addon, promo, approve_version=True)
             self.reindex(Addon)
             data = self.perform_search(
@@ -2007,7 +2008,7 @@ class TestAddonAutoCompleteSearchView(ESTestCase):
     def test_promoted(self):
         not_promoted = addon_factory(name='not promoted')
         sponsored = addon_factory(name='is promoted')
-        self.make_addon_promoted(sponsored, VERIFIED_ONE, approve_version=True)
+        self.make_addon_promoted(sponsored, SPONSORED, approve_version=True)
         addon_factory(name='something')
 
         self.refresh()

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -28,7 +28,6 @@ from olympia.bandwagon.models import CollectionAddon
 from olympia.constants.categories import CATEGORIES, CATEGORIES_BY_ID
 from olympia.constants.promoted import (
     LINE, SPOTLIGHT, STRATEGIC, RECOMMENDED, SPONSORED, VERIFIED)
-from olympia.discovery.models import DiscoveryItem
 from olympia.users.models import UserProfile
 from olympia.versions.models import ApplicationsVersions, AppVersion
 

--- a/src/olympia/constants/promoted.py
+++ b/src/olympia/constants/promoted.py
@@ -60,7 +60,7 @@ RECOMMENDED = PromotedClass(
     can_primary_hero=True,
 )
 
-VERIFIED_ONE = PromotedClass(
+SPONSORED = PromotedClass(
     id=2,
     name=_('Sponsored'),
     api_name='sponsored',
@@ -73,7 +73,7 @@ VERIFIED_ONE = PromotedClass(
     can_primary_hero=True,
 )
 
-VERIFIED_TWO = PromotedClass(
+VERIFIED = PromotedClass(
     id=3,
     name=_('Verified'),
     api_name='verified',
@@ -119,8 +119,8 @@ STRATEGIC = PromotedClass(
 PROMOTED_GROUPS = [
     NOT_PROMOTED,
     RECOMMENDED,
-    VERIFIED_ONE,
-    VERIFIED_TWO,
+    SPONSORED,
+    VERIFIED,
     LINE,
     SPOTLIGHT,
     STRATEGIC,
@@ -136,4 +136,4 @@ PROMOTED_API_NAME_TO_IDS = {
     **{p.api_name: [p.id] for p in PROMOTED_GROUPS if p},
     **{BADGED_API_NAME: list({p.id for p in BADGED_GROUPS})}}
 
-PROMOTED_GROUPS_FOR_SUBSCRIPTION = [VERIFIED_ONE, VERIFIED_TWO]
+PROMOTED_GROUPS_FOR_SUBSCRIPTION = [SPONSORED, VERIFIED]

--- a/src/olympia/hero/tests/test_models.py
+++ b/src/olympia/hero/tests/test_models.py
@@ -2,7 +2,7 @@ from django.core.exceptions import ValidationError
 
 from olympia.amo.tests import addon_factory, TestCase
 from olympia.amo.tests.test_helpers import get_uploaded_file
-from olympia.constants.promoted import RECOMMENDED, SPOTLIGHT, VERIFIED_TWO
+from olympia.constants.promoted import RECOMMENDED, SPOTLIGHT, VERIFIED
 from olympia.hero.models import (
     PrimaryHero, PrimaryHeroImage, SecondaryHero, SecondaryHeroModule)
 from olympia.promoted.models import PromotedAddon
@@ -48,12 +48,12 @@ class TestPrimaryHero(TestCase):
         ph.clean()  # it raises if there's an error
 
         # change to a different group
-        ph.promoted_addon.update(group_id=VERIFIED_TWO.id)
+        ph.promoted_addon.update(group_id=VERIFIED.id)
         ph.promoted_addon.approve_for_version(
             ph.promoted_addon.addon.current_version)
         ph.reload()
         ph.enabled = True
-        assert ph.promoted_addon.addon.promoted_group() == VERIFIED_TWO
+        assert ph.promoted_addon.addon.promoted_group() == VERIFIED
         with self.assertRaises(ValidationError) as context:
             # VERIFIED isn't a group that can be added as a primary hero
             ph.clean()

--- a/src/olympia/promoted/models.py
+++ b/src/olympia/promoted/models.py
@@ -7,7 +7,8 @@ from olympia.addons.models import Addon
 from olympia.amo.models import ModelBase
 from olympia.constants.applications import APP_IDS, APPS_CHOICES, APP_USAGE
 from olympia.constants.promoted import (
-    NOT_PROMOTED, PRE_REVIEW_GROUPS, PROMOTED_GROUPS, PROMOTED_GROUPS_BY_ID)
+    NOT_PROMOTED, PRE_REVIEW_GROUPS, PROMOTED_GROUPS, PROMOTED_GROUPS_BY_ID,
+    PROMOTED_GROUPS_FOR_SUBSCRIPTION)
 from olympia.versions.models import Version
 
 
@@ -64,6 +65,17 @@ class PromotedAddon(ModelBase):
                 version=version,
                 group_id=self.group_id,
                 application_id=app.id)
+
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+
+        if (
+            self.group in PROMOTED_GROUPS_FOR_SUBSCRIPTION and
+            not PromotedSubscription.objects.filter(
+                promoted_addon=self
+            ).exists()
+        ):
+            PromotedSubscription.objects.create(promoted_addon=self)
 
 
 class PromotedTheme(PromotedAddon):

--- a/src/olympia/promoted/tests/test_admin.py
+++ b/src/olympia/promoted/tests/test_admin.py
@@ -4,7 +4,7 @@ from olympia.amo.tests import (
 from olympia.amo.tests.test_helpers import get_uploaded_file
 from olympia.amo.urlresolvers import django_reverse, reverse
 from olympia.constants.promoted import (
-    LINE, RECOMMENDED, VERIFIED_TWO, VERIFIED_ONE)
+    LINE, RECOMMENDED, VERIFIED, SPONSORED)
 from olympia.hero.models import PrimaryHero, PrimaryHeroImage
 from olympia.promoted.models import PromotedAddon, PromotedApproval
 
@@ -507,7 +507,7 @@ class TestPromotedAddonAdmin(TestCase):
     def test_show_subscription_when_group_is_verified(self):
         addon = addon_factory()
         item = PromotedAddon.objects.create(
-            addon=addon, group_id=VERIFIED_TWO.id
+            addon=addon, group_id=VERIFIED.id
         )
         user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')
@@ -527,7 +527,7 @@ class TestPromotedAddonAdmin(TestCase):
     def test_show_subscription_when_group_is_sponsored(self):
         addon = addon_factory()
         item = PromotedAddon.objects.create(
-            addon=addon, group_id=VERIFIED_ONE.id
+            addon=addon, group_id=SPONSORED.id
         )
         user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Discovery:Edit')

--- a/src/olympia/promoted/tests/test_models.py
+++ b/src/olympia/promoted/tests/test_models.py
@@ -8,8 +8,8 @@ class TestPromotedAddon(TestCase):
 
     def test_basic(self):
         promoted_addon = PromotedAddon.objects.create(
-            addon=addon_factory(), group_id=promoted.VERIFIED_ONE.id)
-        assert promoted_addon.group == promoted.VERIFIED_ONE
+            addon=addon_factory(), group_id=promoted.SPONSORED.id)
+        assert promoted_addon.group == promoted.SPONSORED
         assert promoted_addon.application_id is None
         assert promoted_addon.all_applications == [
             applications.FIREFOX, applications.ANDROID]
@@ -32,11 +32,11 @@ class TestPromotedAddon(TestCase):
             applications.FIREFOX, applications.ANDROID]
 
         # but not if it's for a different type of promotion
-        promoted_addon.update(group_id=promoted.VERIFIED_ONE.id)
+        promoted_addon.update(group_id=promoted.SPONSORED.id)
         assert addon.promotedaddon.approved_applications == []
         # unless that group has an approval too
         PromotedApproval.objects.create(
-            version=addon.current_version, group_id=promoted.VERIFIED_ONE.id,
+            version=addon.current_version, group_id=promoted.SPONSORED.id,
             application_id=applications.FIREFOX.id)
         addon.reload()
         assert addon.promotedaddon.approved_applications == [
@@ -53,7 +53,7 @@ class TestPromotedAddon(TestCase):
         assert PromotedSubscription.objects.count() == 0
 
         promoted_addon = PromotedAddon.objects.create(
-            addon=addon_factory(), group_id=promoted.VERIFIED_ONE.id
+            addon=addon_factory(), group_id=promoted.SPONSORED.id
         )
 
         assert PromotedSubscription.objects.count() == 1
@@ -82,7 +82,7 @@ class TestPromotedSubscription(TestCase):
 
     def test_get_onboarding_url(self):
         promoted_addon = PromotedAddon.objects.create(
-            addon=addon_factory(), group_id=promoted.VERIFIED_ONE.id
+            addon=addon_factory(), group_id=promoted.SPONSORED.id
         )
         sub = PromotedSubscription.objects.filter(
             promoted_addon=promoted_addon

--- a/src/olympia/reviewers/tests/test_models.py
+++ b/src/olympia/reviewers/tests/test_models.py
@@ -15,7 +15,7 @@ from olympia.amo.tests import (
     TestCase, addon_factory, file_factory, user_factory, version_factory)
 from olympia.blocklist.models import Block
 from olympia.constants.promoted import (
-    LINE, NOT_PROMOTED, RECOMMENDED, STRATEGIC, VERIFIED_ONE)
+    LINE, NOT_PROMOTED, RECOMMENDED, STRATEGIC, SPONSORED)
 from olympia.files.models import File, FileValidation, WebextPermission
 from olympia.promoted.models import PromotedAddon
 from olympia.ratings.models import Rating
@@ -172,7 +172,7 @@ class TestExtensionQueueWithAwaitingReview(TestQueue):
         addon = self.new_addon()
         assert self.Queue.objects.get().flags == []
 
-        self.make_addon_promoted(addon, VERIFIED_ONE)
+        self.make_addon_promoted(addon, SPONSORED)
         assert self.Queue.objects.get().flags == [
             ('promoted-sponsored', 'Sponsored')]
 

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -21,7 +21,7 @@ from olympia.amo.urlresolvers import reverse
 from olympia.amo.utils import send_mail
 from olympia.blocklist.models import Block, BlocklistSubmission
 from olympia.constants.promoted import (
-    LINE, RECOMMENDED, SPOTLIGHT, STRATEGIC, VERIFIED_ONE)
+    LINE, RECOMMENDED, SPOTLIGHT, STRATEGIC, SPONSORED)
 from olympia.files.models import File
 from olympia.lib.crypto.tests.test_signing import (
     _get_recommendation_data, _get_signature_details)
@@ -466,7 +466,7 @@ class TestReviewHelper(TestReviewHelperBase):
             file_status=amo.STATUS_AWAITING_REVIEW).keys()) == expected
 
         # only for groups that are admin_review though
-        self.make_addon_promoted(self.addon, VERIFIED_ONE)
+        self.make_addon_promoted(self.addon, SPONSORED)
         expected = ['public', 'reject', 'reject_multiple_versions',
                     'reply', 'super', 'comment']
         assert list(self.get_review_actions(

--- a/src/olympia/search/tests/test_filters.py
+++ b/src/olympia/search/tests/test_filters.py
@@ -16,7 +16,7 @@ from olympia.amo.tests import TestCase
 from olympia.constants.categories import CATEGORIES
 from olympia.constants.promoted import (
     BADGED_GROUPS, PROMOTED_API_NAME_TO_IDS, RECOMMENDED, LINE, STRATEGIC,
-    VERIFIED_ONE, VERIFIED_TWO)
+    SPONSORED, VERIFIED)
 from olympia.search.filters import (
     ReviewedContentFilter, SearchParameterFilter, SearchQueryFilter,
     SortingFilter)
@@ -962,7 +962,7 @@ class TestSearchParameterFilter(FilterTestsBase):
         assert [
             {'terms': {'promoted.group_id': [
                 # recommended shouldn't be there twice
-                RECOMMENDED.id, VERIFIED_ONE.id, VERIFIED_TWO.id, LINE.id,
+                RECOMMENDED.id, SPONSORED.id, VERIFIED.id, LINE.id,
                 STRATEGIC.id]}}
         ] == filter_
 

--- a/src/olympia/shelves/tests/test_views.py
+++ b/src/olympia/shelves/tests/test_views.py
@@ -11,7 +11,7 @@ from freezegun import freeze_time
 from olympia import amo
 from olympia.amo.tests import (
     addon_factory, APITestClient, ESTestCase, reverse_ns)
-from olympia.constants.promoted import RECOMMENDED, VERIFIED_ONE, VERIFIED_TWO
+from olympia.constants.promoted import RECOMMENDED, SPONSORED, VERIFIED
 from olympia.promoted.models import PromotedAddon
 from olympia.shelves.models import Shelf, ShelfManagement
 
@@ -143,15 +143,15 @@ class TestSponsoredShelfViewSet(ESTestCase):
         self.sponsored_ext = addon_factory(
             name='test addon test01', type=amo.ADDON_EXTENSION)
         self.make_addon_promoted(
-            self.sponsored_ext, VERIFIED_ONE, approve_version=True)
+            self.sponsored_ext, SPONSORED, approve_version=True)
         self.sponsored_theme = addon_factory(
             name='test addon test02', type=amo.ADDON_STATICTHEME)
         self.make_addon_promoted(
-            self.sponsored_theme, VERIFIED_ONE, approve_version=True)
+            self.sponsored_theme, SPONSORED, approve_version=True)
         self.verified_ext = addon_factory(
             name='test addon test03', type=amo.ADDON_EXTENSION)
         self.make_addon_promoted(
-            self.verified_ext, VERIFIED_TWO, approve_version=True)
+            self.verified_ext, VERIFIED, approve_version=True)
         self.not_promoted = addon_factory(name='test addon test04')
         if refresh:
             self.refresh()
@@ -247,7 +247,7 @@ class TestSponsoredShelfViewSet(ESTestCase):
         another_ext = addon_factory(
             name='test addon test01', type=amo.ADDON_EXTENSION)
         self.make_addon_promoted(
-            another_ext, VERIFIED_ONE, approve_version=True)
+            another_ext, SPONSORED, approve_version=True)
         self.refresh()
         adzerk_results = {
             str(another_ext.id): {},

--- a/src/olympia/shelves/views.py
+++ b/src/olympia/shelves/views.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 
 from olympia.addons.views import AddonSearchView
 from olympia.api.pagination import ESPageNumberPagination
-from olympia.constants.promoted import VERIFIED_ONE
+from olympia.constants.promoted import SPONSORED
 from olympia.search.filters import ReviewedContentFilter
 
 from .models import Shelf
@@ -63,7 +63,7 @@ class SponsoredShelfViewSet(viewsets.ViewSetMixin, AddonSearchView):
         ids = list(self.adzerk_results.keys())
         results_qs = qs.query(query.Bool(must=[
             Q('terms', id=ids),
-            Q('term', **{'promoted.group_id': VERIFIED_ONE.id})]))
+            Q('term', **{'promoted.group_id': SPONSORED.id})]))
         results_qs.execute()  # To cache the results.
         filter_adzerk_results_to_es_results_qs(
             self.adzerk_results, results_qs)


### PR DESCRIPTION
Fixes #15723

---

We refined the onboarding flow with Product and here it is:

> (1) developer requests to be added by a sign-up form, (2) we choose the next
> add-on to be added (from the sign-up list) and pre-review the add-on to make
> sure it meets our standards, (3) if the add-on passes we add it to the
> promoted group and email the dev with the payment link, (4) if that succeeds,
> then next version approval should finalize the process and show the badge

As we can see in (3), admins will add an add-on to the promoted group before
sending the email to the developer so it makes sense to inline the subscription
admin in the existing promoted add-on admin: there is no reason to have a
different admin for subscriptions.

### Screenshots

When creating a new promoted add-on, we don't show the subscription info:

<img width="1612" alt="Screenshot 2020-10-16 at 12 31 19" src="https://user-images.githubusercontent.com/217628/96248743-546aa980-0fac-11eb-8e0f-5c4955a780c7.png">

When editing an existing promoted add-on that does not require payment, we don't show the subscription info:

<img width="1612" alt="Screenshot 2020-10-16 at 12 38 08" src="https://user-images.githubusercontent.com/217628/96248820-749a6880-0fac-11eb-85f9-a6ae93ef7eca.png">

When editing an existing promoted add-on that does require payment, we show the subscription info:

<img width="1612" alt="Screenshot 2020-10-16 at 12 37 14" src="https://user-images.githubusercontent.com/217628/96248740-53d21300-0fac-11eb-8895-a4eac1a4cbe4.png">