### PR TITLE
Update link to ratings in reviewer tools for disabled addons.

### DIFF
--- a/src/olympia/reviewers/templates/reviewers/addon_details_box.html
+++ b/src/olympia/reviewers/templates/reviewers/addon_details_box.html
@@ -95,15 +95,12 @@
                   {{ addon.average_rating|float|stars }}
                   {% with count='<span itemprop="count">{0}</span>'|format_html(num|numberfmt) %}
                     {# Using num=count so we don't change an L10n string. #}
+                    {% set review_url_text = ngettext('{num} review', '{num} reviews', num)|format_html(num=count) %}
                     {% if acl_is_review_moderator %}
                       {% set review_url = url('admin:ratings_rating_changelist')|urlparams(addon=addon.pk) %}
-                      <a href="{{ review_url|absolutify }}"><strong>{{
-                        ngettext('{num} review', '{num} reviews', num)|format_html(num=count)
-                      }}</strong></a>
+                      <a href="{{ review_url|absolutify }}"><strong>{{ review_url_text }}</strong></a>
                     {% else %}
-                      <strong>{{
-                        ngettext('{num} review', '{num} reviews', num)|format_html(num=count)
-                      }}</strong>
+                      <strong>{{ review_url_text }}</strong>
                     {% endif %}
                   {% endwith %}
                   {% else %}

--- a/src/olympia/reviewers/templates/reviewers/addon_details_box.html
+++ b/src/olympia/reviewers/templates/reviewers/addon_details_box.html
@@ -106,7 +106,7 @@
                     {% else %}
                       <strong>{{
                         ngettext('{num} review', '{num} reviews', num)|format_html(num=count)
-                      }}</strong
+                      }}</strong>
                     {% endif %}
                   {% endwith %}
                   {% else %}

--- a/src/olympia/reviewers/templates/reviewers/addon_details_box.html
+++ b/src/olympia/reviewers/templates/reviewers/addon_details_box.html
@@ -95,11 +95,8 @@
                   {{ addon.average_rating|float|stars }}
                   {% with count='<span itemprop="count">{0}</span>'|format_html(num|numberfmt) %}
                     {# Using num=count so we don't change an L10n string. #}
-                    {% if not addon.is_disabled or action_allowed(amo.permissions.RATINGS_MODERATE) %}
-                      {% set review_url = url('addons.ratings.list', addon.slug) %}
-                      {% if addon.is_disabled %}
-                        {% set review_url = 'admin/models/ratings/rating/'|urlparams(addon=addon.pk) %}
-                      {% endif %}
+                    {% if action_allowed(amo.permissions.RATINGS_MODERATE) %}
+                      {% set review_url = 'admin/models/ratings/rating/'|urlparams(addon=addon.pk) %}
                       <a href="{{ review_url|absolutify }}"><strong>{{
                         ngettext('{num} review', '{num} reviews', num)|format_html(num=count)
                       }}</strong></a>

--- a/src/olympia/reviewers/templates/reviewers/addon_details_box.html
+++ b/src/olympia/reviewers/templates/reviewers/addon_details_box.html
@@ -88,7 +88,33 @@
           {# XXX future feature: 'Localizations' ... #}
           <tr class="meta-rating">
             <th>{{ _('Rating') }}</th>
-            <td>{{ reviews_link(addon) }}</td>
+            <td>
+              <p class="addon-rating">
+                {% with num=addon.total_ratings %}
+                  {% if num %}
+                  {{ addon.average_rating|float|stars }}
+                  {% with count='<span itemprop="count">{0}</span>'|format_html(num|numberfmt) %}
+                    {# Using num=count so we don't change an L10n string. #}
+                    {% if not addon.is_disabled or action_allowed(amo.permissions.RATINGS_MODERATE) %}
+                      {% set review_url = url('addons.ratings.list', addon.slug) %}
+                      {% if addon.is_disabled %}
+                        {% set review_url = 'admin/models/ratings/rating/'|urlparams(addon=addon.pk) %}
+                      {% endif %}
+                      <a href="{{ review_url|absolutify }}"><strong>{{
+                        ngettext('{num} review', '{num} reviews', num)|format_html(num=count)
+                      }}</strong></a>
+                    {% else %}
+                      <strong>{{
+                        ngettext('{num} review', '{num} reviews', num)|format_html(num=count)
+                      }}</strong
+                    {% endif %}
+                  {% endwith %}
+                  {% else %}
+                    <strong>{{ _('Not yet rated') }}</strong>
+                  {% endif %}
+                {% endwith %}
+              </p>
+            </td>
           </tr>
           <tr class="meta-stats">
             <th>{{ _('Weekly Downloads') }}</th>

--- a/src/olympia/reviewers/templates/reviewers/addon_details_box.html
+++ b/src/olympia/reviewers/templates/reviewers/addon_details_box.html
@@ -96,7 +96,7 @@
                   {% with count='<span itemprop="count">{0}</span>'|format_html(num|numberfmt) %}
                     {# Using num=count so we don't change an L10n string. #}
                     {% if action_allowed(amo.permissions.RATINGS_MODERATE) %}
-                      {% set review_url = 'admin/models/ratings/rating/'|urlparams(addon=addon.pk) %}
+                      {% set review_url = url('admin:ratings_rating_changelist')|urlparams(addon=addon.pk) %}
                       <a href="{{ review_url|absolutify }}"><strong>{{
                         ngettext('{num} review', '{num} reviews', num)|format_html(num=count)
                       }}</strong></a>

--- a/src/olympia/reviewers/templates/reviewers/addon_details_box.html
+++ b/src/olympia/reviewers/templates/reviewers/addon_details_box.html
@@ -95,7 +95,7 @@
                   {{ addon.average_rating|float|stars }}
                   {% with count='<span itemprop="count">{0}</span>'|format_html(num|numberfmt) %}
                     {# Using num=count so we don't change an L10n string. #}
-                    {% if action_allowed(amo.permissions.RATINGS_MODERATE) %}
+                    {% if acl_is_review_moderator %}
                       {% set review_url = url('admin:ratings_rating_changelist')|urlparams(addon=addon.pk) %}
                       <a href="{{ review_url|absolutify }}"><strong>{{
                         ngettext('{num} review', '{num} reviews', num)|format_html(num=count)

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -5175,6 +5175,26 @@ class TestReview(ReviewBase):
                 user.name, created_at
             )
         )
+        # Addon details box contains the rating but link is absent
+        assert doc('.addon-rating')
+        assert not doc('.addon-rating a')
+
+    def test_review_moderator_addon_rating_present(self):
+        user = user_factory()
+        Rating.objects.create(
+            body=u'Lôrem ipsum dolor', rating=3, ip_address='10.5.6.7',
+            addon=self.addon, user=user)
+
+        self.grant_permission(self.reviewer, 'Ratings:Moderate')
+
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        assert doc('.addon-rating a')
+        rating_url = '{}?addon={}'.format(reverse_ns(
+            'admin:ratings_rating_changelist'
+        ), self.addon.pk)
+        assert doc('.addon-rating a').attr["href"] == rating_url
 
     def test_user_ratings_unlisted_addon(self):
         user = UserProfile.objects.get(email='reviewer@mozilla.com')

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -894,6 +894,7 @@ def review(request, addon, channel=None):
         # Used for reviewer subscription check, don't use global `is_reviewer`
         # since that actually is `is_user_any_kind_of_reviewer`.
         acl_is_reviewer=acl.is_reviewer(request, addon),
+        acl_is_review_moderator = acl.action_allowed(request, amo.permissions.RATINGS_MODERATE),
         actions=actions,
         actions_comments=actions_comments,
         actions_delayable=actions_delayable,

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -894,7 +894,9 @@ def review(request, addon, channel=None):
         # Used for reviewer subscription check, don't use global `is_reviewer`
         # since that actually is `is_user_any_kind_of_reviewer`.
         acl_is_reviewer=acl.is_reviewer(request, addon),
-        acl_is_review_moderator = acl.action_allowed(request, amo.permissions.RATINGS_MODERATE),
+        acl_is_review_moderator=acl.action_allowed(
+            request, amo.permissions.RATINGS_MODERATE
+        ),
         actions=actions,
         actions_comments=actions_comments,
         actions_delayable=actions_delayable,


### PR DESCRIPTION
Fixes #10113 

If the addon is public, `X reviews` points to the public ratings page
If the addon is not public and user has the `Ratings:Moderate` permission, pointing to /admin/models/ratings/rating/?addon=<id>. For users that don't have that permission (ie regular reviewers, they would still see that text, but without a link.

* [x] This PR relates to an existing open issue and there are no existing
      PRs open for the same issue.
* [x] Add `Fixes #ISSUENUM` at the top of your PR.
* [x] Add a description of the changes introduced in this PR.
* [x] The change has been successfully run locally.

