### PR TITLE
Add conversion tracking to Adzerk; refactor click into generic events

### DIFF
--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -382,6 +382,7 @@ v4 API changelog
 * 2020-10-15: added /shelves/sponsored/ endpoint https://github.com/mozilla/addons-server/issues/15617
 * 2020-10-15: added /shelves/sponsored/impression and /shelves/sponsored/click endpoints https://github.com/mozilla/addons-server/issues/15618 and https://github.com/mozilla/addons-server/issues/15619
 * 2020-10-22: added ``promoted`` to primary hero shelf addon object. https://github.com/mozilla/addons-server/issues/15741
+* 2020-10-22: added /shelves/sponsored/event eventpoint for conversions, and to replace click endpoint https://github.com/mozilla/addons-server/issues/15718
 
 .. _`#11380`: https://github.com/mozilla/addons-server/issues/11380/
 .. _`#11379`: https://github.com/mozilla/addons-server/issues/11379/

--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -382,7 +382,7 @@ v4 API changelog
 * 2020-10-15: added /shelves/sponsored/ endpoint https://github.com/mozilla/addons-server/issues/15617
 * 2020-10-15: added /shelves/sponsored/impression and /shelves/sponsored/click endpoints https://github.com/mozilla/addons-server/issues/15618 and https://github.com/mozilla/addons-server/issues/15619
 * 2020-10-22: added ``promoted`` to primary hero shelf addon object. https://github.com/mozilla/addons-server/issues/15741
-* 2020-10-22: added /shelves/sponsored/event eventpoint for conversions, and to replace click endpoint https://github.com/mozilla/addons-server/issues/15718
+* 2020-10-22: added /shelves/sponsored/event endpoint for conversions, and to replace click endpoint https://github.com/mozilla/addons-server/issues/15718
 
 .. _`#11380`: https://github.com/mozilla/addons-server/issues/11380/
 .. _`#11379`: https://github.com/mozilla/addons-server/issues/11379/

--- a/docs/topics/api/shelves.rst
+++ b/docs/topics/api/shelves.rst
@@ -98,9 +98,9 @@ Current implementation relies on Adzerk to determine which addons are returned a
     :query int page_size: specify how many addons should be returned.  Defaults to 6.  Note: fewer addons could be returned if there are fewer than specifed sponsored addons currently, or the Adzerk service is unavailable.
     :query string wrap_outgoing_links: If this parameter is present, wrap outgoing links through ``outgoing.prod.mozaws.net`` (See :ref:`Outgoing Links <api-overview-outgoing>`)
     :>json array results: The array containing the addon results for this query.  The object is a :ref:`add-on <addon-detail-object>` as returned by :ref:`add-on search endpoint <addon-search>` with an extra field of ``events``
-    :>json object results[].events: contains data that for different events that can be recorded.
-    :>json string results[].events.click: the signed data payload to send to the :ref:`event endpoint <sponsored-shelf-event>` that identifies the sponsored placement clicked on.
-    :>json string results[].events.conversion: the signed data payload to send to the :ref:`event endpoint <sponsored-shelf-event>` that identifies the conversion (install) event for the sponsored addon placement.
+    :>json object results[].event_data: contains data that for different events that can be recorded.
+    :>json string results[].event_data.click: the signed data payload to send to the :ref:`event endpoint <sponsored-shelf-event>` that identifies the sponsored placement clicked on.
+    :>json string results[].event_data.conversion: the signed data payload to send to the :ref:`event endpoint <sponsored-shelf-event>` that identifies the conversion (install) event for the sponsored addon placement.
     :>json string impression_url: the url to ping when the contents of this sponsored shelf is rendered on screen to the user.
     :>json string impression_data: the signed data payload to send to ``impression_url`` that identifies all of the sponsored placements displayed.
 

--- a/docs/topics/api/shelves.rst
+++ b/docs/topics/api/shelves.rst
@@ -97,11 +97,12 @@ Current implementation relies on Adzerk to determine which addons are returned a
     :query string lang: Activate translations in the specific language for that query. (See :ref:`translated fields <api-overview-translations>`)
     :query int page_size: specify how many addons should be returned.  Defaults to 6.  Note: fewer addons could be returned if there are fewer than specifed sponsored addons currently, or the Adzerk service is unavailable.
     :query string wrap_outgoing_links: If this parameter is present, wrap outgoing links through ``outgoing.prod.mozaws.net`` (See :ref:`Outgoing Links <api-overview-outgoing>`)
-    :>json array results: The array containing the addon results for this query.  The object is a :ref:`add-on <addon-detail-object>` as returned by :ref:`add-on search endpoint <addon-search>` with extra fields of ``click_url`` and ``click_data``
-    :>json string results[].click_url: the url to ping if the sponsored addon's detail page is navigated to.
-    :>json string results[].click_data: the signed data payload to send to ``click_url`` that identifies the sponsored placement clicked on.
+    :>json array results: The array containing the addon results for this query.  The object is a :ref:`add-on <addon-detail-object>` as returned by :ref:`add-on search endpoint <addon-search>` with an extra field of ``events``
+    :>json object results[].events: contains data that for different events that can be recorded.
+    :>json string results[].events.click: the signed data payload to send to the :ref:`event endpoint <sponsored-shelf-event>` that identifies the sponsored placement clicked on.
+    :>json string results[].events.conversion: the signed data payload to send to the :ref:`event endpoint <sponsored-shelf-event>` that identifies the conversion (install) event for the sponsored addon placement.
     :>json string impression_url: the url to ping when the contents of this sponsored shelf is rendered on screen to the user.
-    :>json string impression_data: the signed data payload to send to ``impression_url`` that identifies the sponsored placements displayed.
+    :>json string impression_data: the signed data payload to send to ``impression_url`` that identifies all of the sponsored placements displayed.
 
 
 ---------------------------
@@ -119,16 +120,17 @@ The current implemenation forwards these impression pings to Adzerk.
     :form string impression_data: the signed data payload that was sent in the :ref:`sponsored shelf <sponsored-shelf>` response.
 
 
----------------------
-Sponsored Shelf Click
----------------------
+----------------------
+Sponsored Shelf Events
+----------------------
 
-.. _sponsored-shelf-click:
+.. _sponsored-shelf-event:
 
-When an item on the sponsored shelf is clicked on by the user, to navigate to the detail page, this endpoint should be used to record the click.
-The current implemenation forwards these clicks to Adzerk.
+When an item on the sponsored shelf is clicked on by the user, to navigate to the detail page, or the addon is subsequently installed from the detail page, this endpoint should be used to record that event.
+The current implemenation forwards these events to Adzerk.
 
 
-.. http:post:: /api/v4/shelves/sponsored/click/
+.. http:post:: /api/v4/shelves/sponsored/event/
 
-    :form string click_data: the signed data payload that was sent in addon data in the :ref:`sponsored shelf <sponsored-shelf>` response.
+    :form string data: the signed data payload that was sent in addon data in the :ref:`sponsored shelf <sponsored-shelf>` response.
+    :form string type: the type of event.  Supported types are ``click`` and ``conversion``.

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1930,7 +1930,6 @@ ADZERK_TIMEOUT = 5  # seconds
 ADZERK_NETWORK_ID = env('ADZERK_NETWORK_ID', default=10521)
 ADZERK_SITE_ID = env('ADZERK_SITE_ID', default=1133496)
 ADZERK_URL = f'https://e-{ADZERK_NETWORK_ID}.adzerk.net/api/v2'
-ADZERK_IMPRESSION_URL = f'https://e-{ADZERK_NETWORK_ID}.adzerk.net/i.gif?'
 ADZERK_IMPRESSION_TIMEOUT = 60  # seconds
-ADZERK_CLICK_URL = f'https://e-{ADZERK_NETWORK_ID}.adzerk.net/r?'
-ADZERK_CLICK_TIMEOUT = 60 * 60  # seconds
+ADZERK_EVENT_URL = f'https://e-{ADZERK_NETWORK_ID}.adzerk.net/'
+ADZERK_EVENT_TIMEOUT = 60 * 60 * 24  # seconds

--- a/src/olympia/shelves/serializers.py
+++ b/src/olympia/shelves/serializers.py
@@ -54,12 +54,12 @@ class ShelfSerializer(serializers.ModelSerializer):
 class ESSponsoredAddonSerializer(ESAddonSerializer):
     click_url = serializers.SerializerMethodField()
     click_data = serializers.SerializerMethodField()
-    events = serializers.SerializerMethodField()
+    event_data = serializers.SerializerMethodField()
     _signer = TimestampSigner()
 
     class Meta(ESAddonSerializer.Meta):
         fields = ESAddonSerializer.Meta.fields + (
-            'click_url', 'click_data', 'events')
+            'click_url', 'click_data', 'event_data')
 
     def get_click_url(self, obj):
         return drf_reverse(
@@ -71,7 +71,7 @@ class ESSponsoredAddonSerializer(ESAddonSerializer):
         click_data = view.adzerk_results.get(str(obj.id), {}).get('click')
         return self._signer.sign(click_data) if click_data else None
 
-    def get_events(self, obj):
+    def get_event_data(self, obj):
         view = self.context['view']
         event_data = view.adzerk_results.get(str(obj.id), {})
         events = {

--- a/src/olympia/shelves/tests/adzerk/adzerk_2.json
+++ b/src/olympia/shelves/tests/adzerk/adzerk_2.json
@@ -25,7 +25,10 @@
             }],
             "height": 250,
             "width": 300,
-            "events": []
+            "events": [{
+                "id": 2,
+                "url": "https://e-1234.adzerk.net/e.gif?jefoijef3ddfijdf"
+            }]
         },
         "div1": {
             "adId": 20682923,
@@ -49,7 +52,10 @@
             }],
             "height": 250,
             "width": 300,
-            "events": []
+            "events": [{
+                "id": 2,
+                "url": "https://e-1234.adzerk.net/e.gif?e=e3jfiojef&f=dfef"
+            }]
         }
     }
 }

--- a/src/olympia/shelves/tests/test_serializers.py
+++ b/src/olympia/shelves/tests/test_serializers.py
@@ -201,7 +201,7 @@ class TestESSponsoredAddonSerializer(AddonSerializerOutputTestMixin,
             }
         }
         result = self.serialize(adzerk_results)
-        assert result['events'] == {
+        assert result['event_data'] == {
             'click': 'foobar:1imRQe:mJEcjX6cM3cvkSbb2qMMPPHWC8o',
             'conversion': 'hyhyhy:1imRQe:NQyj05lumKmHaj5Zj4yF69Q9bS4',
         }

--- a/src/olympia/shelves/tests/test_serializers.py
+++ b/src/olympia/shelves/tests/test_serializers.py
@@ -189,3 +189,19 @@ class TestESSponsoredAddonSerializer(AddonSerializerOutputTestMixin,
             'http://testserver/api/v5/shelves/sponsored/click/')
         assert result['click_data'] == (
             'foobar:1imRQe:mJEcjX6cM3cvkSbb2qMMPPHWC8o')
+
+    @freeze_time('2020-01-01')
+    def test_events(self):
+        self.addon = addon_factory()
+        adzerk_results = {
+            str(self.addon.id): {
+                'click': 'foobar',
+                'impression': 'impressive',
+                'conversion': 'hyhyhy',
+            }
+        }
+        result = self.serialize(adzerk_results)
+        assert result['events'] == {
+            'click': 'foobar:1imRQe:mJEcjX6cM3cvkSbb2qMMPPHWC8o',
+            'conversion': 'hyhyhy:1imRQe:NQyj05lumKmHaj5Zj4yF69Q9bS4',
+        }


### PR DESCRIPTION
fixes #15718 

@bobsilverberg this also deprecates the /click endpoint and `click_data` and `click_url` in the response but I didn't remove them in this pr.