### PR TITLE
RE: "addons": [] is empty for theme categories in the shelf API 

### DIFF
--- a/src/olympia/shelves/serializers.py
+++ b/src/olympia/shelves/serializers.py
@@ -43,11 +43,11 @@ class ShelfSerializer(serializers.ModelSerializer):
             criteria = obj.criteria.strip('?')
             params = dict(parse.parse_qsl(criteria))
             request = self.context.get('request', None)
+            tmp = request.GET
             request.GET = request.GET.copy()
             request.GET.update(params)
             addons = AddonSearchView(request=request).data
-            for key in request.GET.dict():
-                del request.GET[key]
+            request.GET = tmp
             return addons
         else:
             return None

--- a/src/olympia/shelves/serializers.py
+++ b/src/olympia/shelves/serializers.py
@@ -45,7 +45,10 @@ class ShelfSerializer(serializers.ModelSerializer):
             request = self.context.get('request', None)
             request.GET = request.GET.copy()
             request.GET.update(params)
-            return AddonSearchView(request=request).data
+            addons = AddonSearchView(request=request).data
+            for key in request.GET.dict():
+                del request.GET[key]
+            return addons
         else:
             return None
 

--- a/src/olympia/shelves/tests/test_serializers.py
+++ b/src/olympia/shelves/tests/test_serializers.py
@@ -61,7 +61,7 @@ class TestShelvesSerializer(ESTestCase):
             title='Holidây themes',
             endpoint='search',
             criteria=(
-                '?category=holiday&sort=recommended%2Cusers' + \
+                '?category=holiday&sort=recommended%2Cusers' +
                 '&type=statictheme&app=firefox'),
             footer_text='See more holidây themes')
 


### PR DESCRIPTION
Fixes #15688 
Fixes #15689 

This pull request revises the serializer to reset `request` before returning `get_addons`. 

The addons are now displayed for each shelf instead of an empty array or  `The "sort" parameter "random" can only be specified when the "featured" or "promoted" parameter is also present, and the "q" parameter absent.` error.

Please review when you have a moment. Thank you!