### PR TITLE
Don't repeat tests from TestBaseUserSerializer

### DIFF
--- a/src/olympia/accounts/tests/test_serializers.py
+++ b/src/olympia/accounts/tests/test_serializers.py
@@ -18,13 +18,7 @@ from olympia.users.notifications import NOTIFICATIONS_BY_SHORT
 from olympia.zadmin.models import Config, set_config
 
 
-class TestBaseUserSerializer(TestCase):
-    serializer_class = BaseUserSerializer
-
-    def setUp(self):
-        self.request = APIRequestFactory().get('/')
-        self.user = user_factory()
-
+class BaseTestUserMixin(object):
     def serialize(self):
         # Manually reload the user first to clear any cached properties.
         self.user = UserProfile.objects.get(pk=self.user.pk)
@@ -61,6 +55,14 @@ class TestBaseUserSerializer(TestCase):
     def test_username(self):
         serialized = self.serialize()
         assert serialized['username'] == self.user.username
+
+
+class TestBaseUserSerializer(TestCase, BaseTestUserMixin):
+    serializer_class = BaseUserSerializer
+
+    def setUp(self):
+        self.request = APIRequestFactory().get('/')
+        self.user = user_factory()
 
 
 class TestPublicUserProfileSerializer(TestCase):

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -6,7 +6,7 @@ from django.utils.translation import override
 from rest_framework.test import APIRequestFactory
 
 from olympia import amo
-from olympia.accounts.tests.test_serializers import TestBaseUserSerializer
+from olympia.accounts.tests.test_serializers import BaseTestUserMixin
 from olympia.addons.models import (
     Addon, AddonCategory, AddonUser, Category, Preview, ReplacementAddon)
 from olympia.addons.serializers import (
@@ -1299,8 +1299,12 @@ class TestESAddonAutoCompleteSerializer(ESTestCase):
         assert result['name'] == translated_name['fr']
 
 
-class TestAddonDeveloperSerializer(TestBaseUserSerializer):
+class TestAddonDeveloperSerializer(TestCase, BaseTestUserMixin):
     serializer_class = AddonDeveloperSerializer
+
+    def setUp(self):
+        self.request = APIRequestFactory().get('/')
+        self.user = user_factory()
 
     def test_picture(self):
         serialized = self.serialize()


### PR DESCRIPTION
Fixes [#15679](https://github.com/mozilla/addons-server/issues/15679)

I have created a mixin that contains all the base test of `TestBaseUserSerializer` in `accounts.tests.test_serializers` and importing that mixin in `addons.tests.test_serializers` instead of the actual testcase class , so to avoid running it two times.

* [x] This PR relates to an existing open issue and there are no existing
      PRs open for the same issue.
* [x] Add `Fixes #ISSUENUM` at the top of your PR.
* [x] Add a description of the changes introduced in this PR.
* [x] The change has been successfully run locally.
