### PR TITLE
Avoid 500s when changing the group of a promoted add-on

### DIFF
--- a/src/olympia/promoted/admin.py
+++ b/src/olympia/promoted/admin.py
@@ -102,7 +102,8 @@ class PromotedAddonAdmin(admin.ModelAdmin):
 
     def get_inline_instances(self, request, obj=None):
         inlines = self.inlines
-        if obj and obj.group in PROMOTED_GROUPS_FOR_SUBSCRIPTION:
+        if (obj and obj.group in PROMOTED_GROUPS_FOR_SUBSCRIPTION and
+                request.method != "POST"):
             inlines = inlines + (PromotedSubscriptionInline,)
         return [inline(self.model, self.admin_site) for inline in inlines]
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/15795

---

Not sure if this is the right way :tm: but it works and given that we don't
allow subscription data updates on this admin page, it should be fine.

This issue linked above should be fixed before this week's push.