### PR TITLE
Add 'manage add-on' button on success page (subscription)

### DIFF
--- a/src/olympia/devhub/templates/devhub/addons/onboarding_subscription.html
+++ b/src/olympia/devhub/templates/devhub/addons/onboarding_subscription.html
@@ -40,6 +40,11 @@
         {% endtrans %}
       {% endif %}
     </p>
+    <p>
+      <a class="button" href="{{ addon.get_dev_url() }}">
+        {{ _('Manage add-on') }}
+      </a>
+    </p>
     {% else %}
     {% if stripe_checkout_cancelled %}
     <div class="notification-box error">

--- a/src/olympia/devhub/tests/test_views_subscription.py
+++ b/src/olympia/devhub/tests/test_views_subscription.py
@@ -142,6 +142,8 @@ class TestOnboardingSubscription(OnboardingSubscriptionTestCase):
             b"There was an error while setting up payment for your add-on."
             in response.content
         )
+        assert b"Continue to Stripe Checkout" in response.content
+        assert b"Manage add-on" not in response.content
         create_mock.assert_called_with(
             self.subscription, customer_email=self.user.email
         )
@@ -158,6 +160,8 @@ class TestOnboardingSubscription(OnboardingSubscriptionTestCase):
         response = self.client.get(self.url)
 
         assert b"You're almost done!" in response.content
+        assert b"Continue to Stripe Checkout" not in response.content
+        assert b"Manage add-on" in response.content
         retrieve_mock.assert_called_with(self.subscription)
 
     @mock.patch("olympia.devhub.views.retrieve_stripe_checkout_session")


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/15806