### PR TITLE
RE: Include add-ons based on the collections endpoint/criteria in the homepage shelves API

### DIFF
--- a/src/olympia/bandwagon/views.py
+++ b/src/olympia/bandwagon/views.py
@@ -186,3 +186,10 @@ class CollectionAddonViewSet(ModelViewSet):
         elif not include_all_with_deleted:
             qs = qs.exclude(addon__status=amo.STATUS_DELETED)
         return qs
+
+    @property
+    def data(self):
+        self.initial(self.request)
+        queryset = self.filter_queryset(self.get_queryset())
+        serializer = self.get_serializer(queryset, many=True)
+        return serializer.data

--- a/src/olympia/shelves/serializers.py
+++ b/src/olympia/shelves/serializers.py
@@ -33,7 +33,7 @@ class ShelfSerializer(serializers.ModelSerializer):
                 'collection-addon-list',
                 request=self.context.get('request'),
                 kwargs={
-                    'user_pk': settings.TASK_USER_ID,
+                    'user_pk': str(settings.TASK_USER_ID),
                     'collection_slug': obj.criteria})
         else:
             url = None

--- a/src/olympia/shelves/serializers.py
+++ b/src/olympia/shelves/serializers.py
@@ -8,6 +8,7 @@ from rest_framework.reverse import reverse as drf_reverse
 
 from olympia.addons.serializers import ESAddonSerializer
 from olympia.addons.views import AddonSearchView
+from olympia.bandwagon.views import CollectionAddonViewSet
 
 from .models import Shelf
 
@@ -50,6 +51,13 @@ class ShelfSerializer(serializers.ModelSerializer):
             addons = AddonSearchView(request=request).data
             request.GET = tmp
             return addons
+        elif obj.endpoint == 'collections':
+            request = self.context.get('request', None)
+            kwargs = {
+                'user_pk': str(settings.TASK_USER_ID),
+                'collection_slug': obj.criteria}
+            return CollectionAddonViewSet(request=request, action='list',
+                                          kwargs=kwargs).data
         else:
             return None
 

--- a/src/olympia/shelves/serializers.py
+++ b/src/olympia/shelves/serializers.py
@@ -44,7 +44,7 @@ class ShelfSerializer(serializers.ModelSerializer):
         if obj.endpoint == 'search':
             criteria = obj.criteria.strip('?')
             params = dict(parse.parse_qsl(criteria))
-            request = self.context.get('request', None)
+            request = self.context.get('request')
             tmp = request.GET
             request.GET = request.GET.copy()
             request.GET.update(params)
@@ -52,7 +52,7 @@ class ShelfSerializer(serializers.ModelSerializer):
             request.GET = tmp
             return addons
         elif obj.endpoint == 'collections':
-            request = self.context.get('request', None)
+            request = self.context.get('request')
             kwargs = {
                 'user_pk': str(settings.TASK_USER_ID),
                 'collection_slug': obj.criteria}

--- a/src/olympia/shelves/tests/test_serializers.py
+++ b/src/olympia/shelves/tests/test_serializers.py
@@ -81,16 +81,16 @@ class TestShelvesSerializer(ESTestCase):
         self.request.version = api_version
         self.request.user = user_factory()
 
-    def serialize(self, instance, **extra_context):
+    def serialize(self, instance, **context):
         self.request.query_params = dict(parse.parse_qsl(
             instance.criteria))
-        extra_context['request'] = self.request
+        context['request'] = self.request
         if instance.endpoint == 'collections':
-            extra_context['action'] = 'list'
-            extra_context['kwargs'] = {
+            context['action'] = 'list'
+            context['kwargs'] = {
                 'user_pk': self.request.user.pk,
                 'collection_slug': instance.criteria}
-        return ShelfSerializer(instance, context=extra_context).data
+        return ShelfSerializer(instance, context=context).data
 
     def _get_url(self, instance):
         if instance.endpoint == 'search':

--- a/src/olympia/shelves/tests/test_serializers.py
+++ b/src/olympia/shelves/tests/test_serializers.py
@@ -139,6 +139,7 @@ class TestShelvesSerializer(ESTestCase):
 
     def test_url_and_addons_collections(self):
         data = self.serialize(self.collections_shelf)
+        assert data['url'] == self._get_url(self.collections_shelf)
         assert data['addons'][0]['addon']['name']['en-US'] == (
             'test addon privacy01')
 

--- a/src/olympia/shelves/tests/test_serializers.py
+++ b/src/olympia/shelves/tests/test_serializers.py
@@ -85,11 +85,6 @@ class TestShelvesSerializer(ESTestCase):
         self.request.query_params = dict(parse.parse_qsl(
             instance.criteria))
         context['request'] = self.request
-        if instance.endpoint == 'collections':
-            context['action'] = 'list'
-            context['kwargs'] = {
-                'user_pk': self.request.user.pk,
-                'collection_slug': instance.criteria}
         return ShelfSerializer(instance, context=context).data
 
     def _get_url(self, instance):

--- a/src/olympia/shelves/tests/test_serializers.py
+++ b/src/olympia/shelves/tests/test_serializers.py
@@ -15,8 +15,6 @@ from olympia.addons.tests.test_serializers import (
 from olympia.amo.tests import (
     addon_factory, collection_factory, ESTestCase, reverse_ns)
 from olympia.bandwagon.models import CollectionAddon
-from olympia.constants.promoted import RECOMMENDED
-from olympia.promoted.models import PromotedAddon
 from olympia.users.models import UserProfile
 
 from ..models import Shelf
@@ -38,20 +36,14 @@ class TestShelvesSerializer(ESTestCase):
         addon_factory(
             name='test addon test02', type=amo.ADDON_STATICTHEME,
             average_daily_users=18981, weekly_downloads=145, summary=None)
-        addon_ext = addon_factory(
+        addon_factory(
             name='test addon test03', type=amo.ADDON_EXTENSION,
-            average_daily_users=482, weekly_downloads=506, summary=None)
-        addon_theme = addon_factory(
+            average_daily_users=482, weekly_downloads=506, summary=None,
+            recommended=True)
+        addon_factory(
             name='test addon test04', type=amo.ADDON_STATICTHEME,
-            average_daily_users=8838, weekly_downloads=358, summary=None)
-
-        PromotedAddon.objects.create(
-            addon=addon_ext, group_id=RECOMMENDED.id
-        ).approve_for_version(version=addon_ext.current_version)
-
-        PromotedAddon.objects.create(
-            addon=addon_theme, group_id=RECOMMENDED.id
-        ).approve_for_version(version=addon_theme.current_version)
+            average_daily_users=8838, weekly_downloads=358, summary=None,
+            recommended=True)
 
         user = UserProfile.objects.create(pk=settings.TASK_USER_ID)
         collection = collection_factory(author=user, slug='privacy-matters')


### PR DESCRIPTION
Fixes #15614 

This pull request updates the shelves' serializer to include add-ons to shelves with a `collections` endpoint. The update to `serializers.py` populates the add-ons for collections in the API, but I am having trouble with updating `test_serializers.py`.

I am getting the error, `AttributeError: 'WSGIRequest' object has no attribute 'query_params'`, but `query_params` were not needed when updating the serializer for collections. If `query_params` are added for collections in the test though, it leads to the following error, `django.http.response.Http404: No UserProfile matches the given query.

 I'm not sure how to resolve the error, can you please review and provide guidance when you have a moment? Thank you!

