### PR TITLE
Clean up unused code around opensearch plugins

### DIFF
--- a/src/olympia/addons/management/commands/process_addons.py
+++ b/src/olympia/addons/management/commands/process_addons.py
@@ -77,7 +77,7 @@ tasks = {
             # created before the 5th of April
             Q(status=amo.STATUS_APPROVED,
               _current_version__created__lt=datetime(2019, 4, 5)) &
-            ~Q(type=amo.ADDON_SEARCH)
+            ~Q(type=amo._ADDON_SEARCH)
         ]
     },
     'recreate_previews': {
@@ -130,7 +130,7 @@ tasks = {
         # deletes
         'method': delete_addons,
         'qs': [
-            Q(type=amo.ADDON_SEARCH)
+            Q(type=amo._ADDON_SEARCH)
         ],
         'allowed_kwargs': ('with_deleted',),
     }

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1177,9 +1177,6 @@ class Addon(OnChangeMixin, ModelBase):
 
         return addon_dict
 
-    def show_adu(self):
-        return self.type != amo.ADDON_SEARCH
-
     @property
     def contribution_url(self, lang=settings.LANGUAGE_CODE,
                          app=settings.DEFAULT_APP):

--- a/src/olympia/addons/tests/test_commands.py
+++ b/src/olympia/addons/tests/test_commands.py
@@ -533,6 +533,40 @@ class TestDeleteObsoleteAddons(TestCase):
         assert Addon.objects.get(id=self.dictionary.id)
 
 
+class TestDeleteOpenSearchAddons(TestCase):
+    def setUp(self):
+        # Some add-ons that shouldn't be deleted
+        self.extension = addon_factory()
+        self.dictionary = addon_factory(type=amo.ADDON_DICT)
+
+        # And some opensearch plugins
+        addon_factory(type=amo._ADDON_SEARCH)
+        addon_factory(type=amo._ADDON_SEARCH)
+
+        assert Addon.objects.count() == 4
+        assert Addon.unfiltered.count() == 4
+
+    def test_basic(self):
+        call_command(
+            'process_addons', task='disable_opensearch_addons')
+
+        assert Addon.objects.count() == 2
+        # They have only been disabled and not hard deleted
+        assert Addon.unfiltered.count() == 4
+        assert Addon.objects.get(id=self.extension.id)
+        assert Addon.objects.get(id=self.dictionary.id)
+
+    def test_hard(self):
+        call_command(
+            'process_addons', task='disable_opensearch_addons',
+            with_deleted=True)
+
+        assert Addon.objects.count() == 2
+        assert Addon.unfiltered.count() == 2
+        assert Addon.objects.get(id=self.extension.id)
+        assert Addon.objects.get(id=self.dictionary.id)
+
+
 class TestFixLangpacksWithMaxVersionStar(TestCase):
     def setUp(self):
         addon = addon_factory(  # Should autocreate the AppVersions for Firefox

--- a/src/olympia/addons/tests/test_commands.py
+++ b/src/olympia/addons/tests/test_commands.py
@@ -469,7 +469,7 @@ class TestResignAddonsForCose(TestCase):
 
         # Search add-ons won't get re-signed, same with deleted and disabled
         # versions. Also, only public addons are being resigned
-        addon_factory(type=amo.ADDON_SEARCH, file_kw=file_kw)
+        addon_factory(type=amo._ADDON_SEARCH, file_kw=file_kw)
         addon_factory(status=amo.STATUS_DISABLED, file_kw=file_kw)
         addon_factory(status=amo.STATUS_AWAITING_REVIEW, file_kw=file_kw)
         addon_factory(status=amo.STATUS_NULL, file_kw=file_kw)
@@ -530,40 +530,6 @@ class TestDeleteObsoleteAddons(TestCase):
         assert Addon.objects.count() == 3
         assert Addon.objects.get(id=self.extension.id)
         assert Addon.objects.get(id=self.static_theme.id)
-        assert Addon.objects.get(id=self.dictionary.id)
-
-
-class TestDeleteOpenSearchAddons(TestCase):
-    def setUp(self):
-        # Some add-ons that shouldn't be deleted
-        self.extension = addon_factory()
-        self.dictionary = addon_factory(type=amo.ADDON_DICT)
-
-        # And some opensearch plugins
-        addon_factory(type=amo.ADDON_SEARCH)
-        addon_factory(type=amo.ADDON_SEARCH)
-
-        assert Addon.objects.count() == 4
-        assert Addon.unfiltered.count() == 4
-
-    def test_basic(self):
-        call_command(
-            'process_addons', task='disable_opensearch_addons')
-
-        assert Addon.objects.count() == 2
-        # They have only been disabled and not hard deleted
-        assert Addon.unfiltered.count() == 4
-        assert Addon.objects.get(id=self.extension.id)
-        assert Addon.objects.get(id=self.dictionary.id)
-
-    def test_hard(self):
-        call_command(
-            'process_addons', task='disable_opensearch_addons',
-            with_deleted=True)
-
-        assert Addon.objects.count() == 2
-        assert Addon.unfiltered.count() == 2
-        assert Addon.objects.get(id=self.extension.id)
         assert Addon.objects.get(id=self.dictionary.id)
 
 

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -2425,7 +2425,7 @@ class TestAddonFromUpload(UploadTest):
                                   parsed_data=parsed_data)
         assert addon.name == 'search tool'
         assert addon.guid is None
-        assert addon.type == amo.ADDON_SEARCH
+        assert addon.type == amo._ADDON_SEARCH
         assert addon.status == amo.STATUS_NULL
         assert addon.homepage is None
         assert addon.description is None

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -587,7 +587,7 @@ class AddonSerializerOutputTestMixin(object):
 
         # Test with some compatibility info but that should be ignored because
         # its type is in NO_COMPAT.
-        self.addon.update(type=amo.ADDON_SEARCH)
+        self.addon.update(type=amo._ADDON_SEARCH)
         result_version = self.serialize()['current_version']
         assert result_version['compatibility'] == {
             'android': {'max': '65535', 'min': '11.0'},

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -1204,7 +1204,7 @@ class TestAddonSearchView(ESTestCase):
         theme = addon_factory(slug='my-theme', name=u'My Thème',
                               type=amo.ADDON_STATICTHEME)
         addon_factory(slug='my-search', name=u'My Seárch',
-                      type=amo.ADDON_SEARCH)
+                      type=amo._ADDON_SEARCH)
         self.refresh()
 
         data = self.perform_search(self.url, {'type': 'extension'})

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -708,7 +708,7 @@ def addon_factory(
     if 'summary' not in kw:
         # Assign a dummy summary if none was specified in keyword args.
         kwargs['summary'] = u'Summary for %s' % name
-    if type_ not in [amo.ADDON_SEARCH]:
+    if type_ not in [amo._ADDON_SEARCH]:
         # Search engines don't need guids
         kwargs['guid'] = kw.pop('guid', '{%s}' % str(uuid.uuid4()))
     kwargs.update(kw)

--- a/src/olympia/constants/applications.py
+++ b/src/olympia/constants/applications.py
@@ -4,7 +4,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from .base import (
     ADDON_DICT, ADDON_EXTENSION, ADDON_LPAPP, ADDON_PLUGIN,
-    ADDON_SEARCH, ADDON_STATICTHEME)
+    ADDON_STATICTHEME)
 
 from olympia.versions.compare import version_int as vint
 
@@ -22,7 +22,7 @@ class FIREFOX(App):
     short = 'firefox'
     pretty = _(u'Firefox')
     browser = True
-    types = [ADDON_EXTENSION, ADDON_DICT, ADDON_SEARCH, ADDON_LPAPP,
+    types = [ADDON_EXTENSION, ADDON_DICT, ADDON_LPAPP,
              ADDON_PLUGIN, ADDON_STATICTHEME]
     guid = '{ec8030f7-c20a-464f-9b0e-13a3a9e97384}'
     min_display_version = 3.0
@@ -59,7 +59,7 @@ class SEAMONKEY(App):
     shortername = 'sm'
     pretty = _(u'SeaMonkey')
     browser = True
-    types = [ADDON_EXTENSION, ADDON_DICT, ADDON_SEARCH,
+    types = [ADDON_EXTENSION, ADDON_DICT,
              ADDON_LPAPP, ADDON_PLUGIN]
     guid = '{92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}'
     min_display_version = 1.0
@@ -94,7 +94,7 @@ class MOBILE(App):
     shortername = 'fn'
     pretty = _(u'Mobile')
     browser = True
-    types = [ADDON_EXTENSION, ADDON_DICT, ADDON_SEARCH, ADDON_LPAPP]
+    types = [ADDON_EXTENSION, ADDON_DICT, ADDON_LPAPP]
     guid = '{a23983c0-fd0e-11dc-95ff-0800200c9a66}'
     min_display_version = 0.1
     user_agent_string = 'Fennec'
@@ -108,7 +108,7 @@ class ANDROID(App):
     shortername = 'an'
     pretty = _(u'Firefox for Android')
     browser = True
-    types = [ADDON_EXTENSION, ADDON_DICT, ADDON_SEARCH, ADDON_LPAPP]
+    types = [ADDON_EXTENSION, ADDON_DICT, ADDON_LPAPP]
     guid = '{aa3c5121-dab2-40e2-81ca-7ea25febc110}'
     min_display_version = 11.0
     user_agent_string = 'Fennec'
@@ -142,7 +142,7 @@ class MOZILLA(App):
     shortername = 'mz'
     pretty = _(u'Mozilla')
     browser = True
-    types = [ADDON_EXTENSION, ADDON_DICT, ADDON_SEARCH,
+    types = [ADDON_EXTENSION, ADDON_DICT,
              ADDON_LPAPP, ADDON_PLUGIN]
     guid = '{86c18b42-e466-45a9-ae7a-9b95ba6f5640}'
     platforms = 'desktop'  # DESKTOP_PLATFORMS (set in constants.platforms)

--- a/src/olympia/constants/base.py
+++ b/src/olympia/constants/base.py
@@ -103,7 +103,7 @@ ADDON_ANY = 0
 ADDON_EXTENSION = 1
 _ADDON_THEME = 2
 ADDON_DICT = 3
-ADDON_SEARCH = 4
+_ADDON_SEARCH = 4
 ADDON_LPAPP = 5
 ADDON_LPADDON = 6
 ADDON_PLUGIN = 7
@@ -113,7 +113,7 @@ ADDON_STATICTHEME = 10
 _ADDON_WEBAPP = 11  # Deprecated.  Marketplace cruft.
 
 # Addon type groupings.
-GROUP_TYPE_ADDON = [ADDON_EXTENSION, ADDON_DICT, ADDON_SEARCH, ADDON_LPAPP,
+GROUP_TYPE_ADDON = [ADDON_EXTENSION, ADDON_DICT, _ADDON_SEARCH, ADDON_LPAPP,
                     ADDON_LPADDON, ADDON_PLUGIN, ADDON_API]
 GROUP_TYPE_THEME = [ADDON_STATICTHEME]
 
@@ -122,7 +122,7 @@ ADDON_TYPE = {
     ADDON_EXTENSION: _(u'Extension'),
     _ADDON_THEME: _(u'Deprecated Complete Theme'),
     ADDON_DICT: _(u'Dictionary'),
-    ADDON_SEARCH: _(u'Search Engine'),
+    _ADDON_SEARCH: _(u'Search Engine'),
     ADDON_LPAPP: _(u'Language Pack (Application)'),
     ADDON_LPADDON: _(u'Language Pack (Add-on)'),
     ADDON_PLUGIN: _(u'Plugin'),
@@ -135,7 +135,7 @@ ADDON_TYPES = {
     ADDON_EXTENSION: _(u'Extensions'),
     _ADDON_THEME: _(u'Deprecated Complete Themes'),
     ADDON_DICT: _(u'Dictionaries'),
-    ADDON_SEARCH: _(u'Search Tools'),
+    _ADDON_SEARCH: _(u'Search Tools'),
     ADDON_LPAPP: _(u'Language Packs (Application)'),
     ADDON_LPADDON: _(u'Language Packs (Add-on)'),
     ADDON_PLUGIN: _(u'Plugins'),
@@ -149,7 +149,7 @@ ADDON_SEARCH_TYPES = [
     ADDON_EXTENSION,
     _ADDON_THEME,
     ADDON_DICT,
-    ADDON_SEARCH,
+    _ADDON_SEARCH,
     ADDON_LPAPP,
     _ADDON_PERSONA,
     ADDON_STATICTHEME,
@@ -160,7 +160,7 @@ ADDON_SLUGS = {
     ADDON_EXTENSION: 'extensions',
     ADDON_DICT: 'language-tools',
     ADDON_LPAPP: 'language-tools',
-    ADDON_SEARCH: 'search-tools',
+    _ADDON_SEARCH: 'search-tools',
     ADDON_STATICTHEME: 'themes',
 }
 
@@ -169,7 +169,7 @@ ADDON_SLUGS_UPDATE = {
     ADDON_EXTENSION: 'extension',
     _ADDON_THEME: 'theme',
     ADDON_DICT: 'extension',
-    ADDON_SEARCH: 'search',
+    _ADDON_SEARCH: 'search',
     ADDON_LPAPP: 'item',
     ADDON_LPADDON: 'extension',
     _ADDON_PERSONA: 'background-theme',
@@ -184,7 +184,7 @@ ADDON_SEARCH_SLUGS = {
     'extension': ADDON_EXTENSION,
     'theme': _ADDON_THEME,
     'dictionary': ADDON_DICT,
-    'search': ADDON_SEARCH,
+    'search': _ADDON_SEARCH,
     'language': ADDON_LPAPP,
     'persona': _ADDON_PERSONA,
     'statictheme': ADDON_STATICTHEME,
@@ -194,7 +194,7 @@ ADDON_TYPE_CHOICES_API = {
     ADDON_EXTENSION: 'extension',
     _ADDON_THEME: 'theme',
     ADDON_DICT: 'dictionary',
-    ADDON_SEARCH: 'search',
+    _ADDON_SEARCH: 'search',
     ADDON_LPAPP: 'language',
     _ADDON_PERSONA: 'persona',
     ADDON_STATICTHEME: 'statictheme',
@@ -270,7 +270,7 @@ VALID_ADDON_FILE_EXTENSIONS = ('.crx', '.xpi', '.xml', '.zip')
 
 # These types don't maintain app compatibility in the db.  Instead, we look at
 # APP.types and APP_TYPE_SUPPORT to figure out where they are compatible.
-NO_COMPAT = (ADDON_SEARCH, ADDON_DICT)
+NO_COMPAT = (_ADDON_SEARCH, ADDON_DICT)
 HAS_COMPAT = {t: t not in NO_COMPAT for t in ADDON_TYPES}
 
 # Collections.

--- a/src/olympia/constants/categories.py
+++ b/src/olympia/constants/categories.py
@@ -9,7 +9,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from olympia.constants.applications import ANDROID, FIREFOX
 from olympia.constants.base import (
-    ADDON_DICT, ADDON_EXTENSION, ADDON_LPAPP, ADDON_SEARCH,
+    ADDON_DICT, ADDON_EXTENSION, ADDON_LPAPP, _ADDON_SEARCH,
     ADDON_SLUGS, ADDON_STATICTHEME, _ADDON_THEME, _ADDON_PERSONA)
 
 
@@ -386,7 +386,7 @@ CATEGORIES_NO_APP = {
     ADDON_DICT: {
         'general': StaticCategory(name=_(u'General'))
     },
-    ADDON_SEARCH: {
+    _ADDON_SEARCH: {
         'bookmarks': StaticCategory(name=_(u'Bookmarks')),
         'business': StaticCategory(name=_(u'Business')),
         'dictionaries-encyclopedias': StaticCategory(

--- a/src/olympia/devhub/tests/test_forms.py
+++ b/src/olympia/devhub/tests/test_forms.py
@@ -868,9 +868,9 @@ class TestIconForm(TestCase):
 class TestCategoryForm(TestCase):
 
     def test_no_possible_categories(self):
-        Category.objects.create(type=amo.ADDON_SEARCH,
+        Category.objects.create(type=amo._ADDON_SEARCH,
                                 application=amo.FIREFOX.id)
-        addon = addon_factory(type=amo.ADDON_SEARCH)
+        addon = addon_factory(type=amo._ADDON_SEARCH)
         request = req_factory_factory('/')
         form = forms.CategoryFormSet(addon=addon, request=request)
         apps = [f.app for f in form.forms]

--- a/src/olympia/devhub/tests/test_utils.py
+++ b/src/olympia/devhub/tests/test_utils.py
@@ -138,7 +138,7 @@ class TestAddonsLinterListed(UploadTest, TestCase):
             'version': '20140103',
         }
 
-        addon = addon_factory(type=amo.ADDON_SEARCH,
+        addon = addon_factory(type=amo._ADDON_SEARCH,
                               version_kw={'version': '20140101'})
         assert addon.guid is None
         self.check_upload(self.file_upload)
@@ -151,7 +151,7 @@ class TestAddonsLinterListed(UploadTest, TestCase):
             'version': '20140103',
         }
 
-        addon = addon_factory(type=amo.ADDON_SEARCH,
+        addon = addon_factory(type=amo._ADDON_SEARCH,
                               version_kw={'version': '20140101'})
         version = version_factory(addon=addon, version='20140102')
         self.check_file(version.files.get())

--- a/src/olympia/files/tests/test_models.py
+++ b/src/olympia/files/tests/test_models.py
@@ -1454,7 +1454,7 @@ class TestParseSearch(TestCase, amo.tests.AMOPaths):
             'is_webextension': False,
             'version': datetime.now().strftime('%Y%m%d'),
             'summary': u'Search Engine for Firefox',
-            'type': amo.ADDON_SEARCH
+            'type': amo._ADDON_SEARCH
         }
 
     @mock.patch('olympia.files.utils.extract_search')

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -640,7 +640,7 @@ def parse_search(fileorpath, addon=None):
         raise forms.ValidationError(ugettext('Could not parse uploaded file.'))
 
     return {'guid': None,
-            'type': amo.ADDON_SEARCH,
+            'type': amo._ADDON_SEARCH,
             'name': data['name'],
             'is_restart_required': False,
             'is_webextension': False,

--- a/src/olympia/lib/crypto/signing.py
+++ b/src/olympia/lib/crypto/signing.py
@@ -145,7 +145,7 @@ def sign_file(file_obj):
     """
     from olympia.git.utils import create_git_extraction_entry
 
-    if (file_obj.version.addon.type == amo.ADDON_SEARCH and
+    if (file_obj.version.addon.type == amo._ADDON_SEARCH and
             file_obj.version.is_webextension is False):
         # Those aren't meant to be signed, we shouldn't be here.
         return file_obj

--- a/src/olympia/lib/crypto/tests/test_signing.py
+++ b/src/olympia/lib/crypto/tests/test_signing.py
@@ -186,7 +186,7 @@ class TestSigning(TestCase):
         assert not signing.is_signed(self.file_.file_path)
 
     def test_dont_sign_search_plugins(self):
-        self.addon.update(type=amo.ADDON_SEARCH)
+        self.addon.update(type=amo._ADDON_SEARCH)
         self.file_.update(is_webextension=False)
         signing.sign_file(self.file_)
         self.assert_not_signed()

--- a/src/olympia/reviewers/models.py
+++ b/src/olympia/reviewers/models.py
@@ -247,7 +247,7 @@ class ExtensionQueueMixin:
     def base_query(self):
         query = super().base_query()
         types = _int_join(
-            set(amo.GROUP_TYPE_ADDON) - {amo.ADDON_SEARCH})
+            set(amo.GROUP_TYPE_ADDON) - {amo._ADDON_SEARCH})
         flags_table = 'addons_addonreviewerflags'
         promoted_groups = _int_join(
             group.id for group in PRE_REVIEW_GROUPS)
@@ -534,7 +534,7 @@ class ReviewerScore(ModelBase):
                 reviewed_score_name = 'REVIEWED_DICT_FULL'
             elif addon.type in [amo.ADDON_LPAPP, amo.ADDON_LPADDON]:
                 reviewed_score_name = 'REVIEWED_LP_FULL'
-            elif addon.type == amo.ADDON_SEARCH:
+            elif addon.type == amo._ADDON_SEARCH:
                 reviewed_score_name = 'REVIEWED_SEARCH_FULL'
             elif weight > amo.POST_REVIEW_WEIGHT_HIGHEST_RISK:
                 reviewed_score_name = 'REVIEWED_EXTENSION_HIGHEST_RISK'
@@ -561,7 +561,7 @@ class ReviewerScore(ModelBase):
                 reviewed_score_name = 'REVIEWED_LP_%s' % queue
             elif addon.type == amo.ADDON_STATICTHEME:
                 reviewed_score_name = 'REVIEWED_STATICTHEME'
-            elif addon.type == amo.ADDON_SEARCH and queue:
+            elif addon.type == amo._ADDON_SEARCH and queue:
                 reviewed_score_name = 'REVIEWED_SEARCH_%s' % queue
 
         if reviewed_score_name:

--- a/src/olympia/reviewers/tests/test_commands.py
+++ b/src/olympia/reviewers/tests/test_commands.py
@@ -106,14 +106,6 @@ class AutoApproveTestsMixin(object):
         dictionary_version.update(
             created=self.days_ago(4), nomination=self.days_ago(4))
 
-        # search engine plugins are considered now
-        search_addon = addon_factory(name='Search', type=amo.ADDON_SEARCH)
-        search_addon_version = version_factory(
-            addon=search_addon, file_kw={
-                'status': amo.STATUS_AWAITING_REVIEW,
-                'is_webextension': True},
-            created=self.days_ago(5), nomination=self.days_ago(5))
-
         # Some recommended add-ons - one nominated and one update.
         # They should be considered by fetch_candidates(), so that they get a
         # weight assigned etc - they will not be auto-approved but that's

--- a/src/olympia/reviewers/tests/test_models.py
+++ b/src/olympia/reviewers/tests/test_models.py
@@ -33,7 +33,7 @@ def create_search_ext(name, version_str, addon_status, file_status,
                       channel):
     addon, created_ = Addon.objects.get_or_create(
         name__localized_string=name,
-        defaults={'type': amo.ADDON_SEARCH, 'name': name})
+        defaults={'type': amo._ADDON_SEARCH, 'name': name})
     version, created_ = Version.objects.get_or_create(
         addon=addon, version=version_str, defaults={'channel': channel})
     File.objects.create(version=version, filename=u"%s.xpi" % name,
@@ -83,7 +83,7 @@ class TestQueue(TestCase):
         self.new_search_ext('Search Tool', '0.1')
         row = self.Queue.objects.get()
         assert row.addon_name == u'Search Tool'
-        assert row.addon_type_id == amo.ADDON_SEARCH
+        assert row.addon_type_id == amo._ADDON_SEARCH
 
     def test_count_all(self):
         # Create two new addons and give each another version.
@@ -581,7 +581,6 @@ class TestReviewerScore(TestCase):
             amo.ADDON_ANY: None,
             amo.ADDON_EXTENSION: 'ADDON',
             amo.ADDON_DICT: 'DICT',
-            amo.ADDON_SEARCH: 'SEARCH',
             amo.ADDON_LPAPP: 'LP',
             amo.ADDON_LPADDON: 'LP',
             amo.ADDON_PLUGIN: 'ADDON',

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -66,7 +66,7 @@ class TestViewExtensionQueueTable(TestCase):
 
     def test_addon_type_id(self):
         row = Mock()
-        row.addon_type_id = amo.ADDON_SEARCH
+        row.addon_type_id = amo._ADDON_SEARCH
         assert str(self.table.render_addon_type_id(row)) == (
             u'Search Engine')
 

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -1379,7 +1379,7 @@ class TestSearchVersionFromUpload(TestVersionFromUpload):
     def setUp(self):
         super(TestSearchVersionFromUpload, self).setUp()
         self.addon.versions.all().delete()
-        self.addon.update(type=amo.ADDON_SEARCH)
+        self.addon.update(type=amo._ADDON_SEARCH)
         self.now = datetime.now().strftime('%Y%m%d')
 
     def test_version_number(self):


### PR DESCRIPTION
Fixes [#13729](https://github.com/mozilla/addons-server/issues/13729)

I have updated all the code around open search plugins.
 - Changed constant `ADDON_SEARCH` to `_ADDON_SEARCH`
 - Removed some function and classes using this constant.

* [x] This PR relates to an existing open issue and there are no existing
      PRs open for the same issue.
* [x] Add `Fixes #ISSUENUM` at the top of your PR.
* [x] Add a description of the changes introduced in this PR.