### PR TITLE
Listen to "charge.failed" Stripe events and send emails

### DIFF
--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1128,6 +1128,7 @@ CELERY_TASK_ROUTES = {
     'olympia.devhub.tasks.validate_file': {'queue': 'devhub'},
     'olympia.devhub.tasks.validate_upload': {'queue': 'devhub'},
     'olympia.files.tasks.repack_fileupload': {'queue': 'devhub'},
+    'olympia.promoted.tasks.on_stripe_charge_failed': {'queue': 'devhub'},
     'olympia.scanners.tasks.run_customs': {'queue': 'devhub'},
     'olympia.scanners.tasks.run_wat': {'queue': 'devhub'},
     'olympia.scanners.tasks.run_yara': {'queue': 'devhub'},

--- a/src/olympia/promoted/tasks.py
+++ b/src/olympia/promoted/tasks.py
@@ -1,0 +1,108 @@
+import olympia.core.logger
+
+from django.conf import settings
+from django.template import loader
+
+from olympia.amo.celery import task
+from olympia.amo.templatetags.jinja_helpers import absolutify
+from olympia.amo.urlresolvers import reverse
+from olympia.amo.utils import send_mail
+
+from .models import PromotedSubscription
+from .utils import retrieve_stripe_subscription_for_invoice
+
+
+log = olympia.core.logger.getLogger("z.promoted.task")
+
+
+@task
+def on_stripe_charge_failed(event):
+    event_id = event.get("id")
+    event_type = event.get("type")
+
+    if event_type != "charge.failed":
+        log.error(
+            'invalid event "%s" received (event_id=%s).', event_type, event_id
+        )
+        return
+
+    # This event should contain a `charge` object.
+    charge = event.get("data", {}).get("object")
+    if not charge:
+        log.error("no charge object in event (event_id=%s).", event_id)
+        return
+
+    charge_id = charge["id"]
+    log.info('received "%s" event with charge_id=%s.', event_type, charge_id)
+
+    # It is possible that a `charge` object isn't bound to an invoice, e.g.,
+    # when a Stripe admin manually attempts to charge a customer.
+    if not charge["invoice"]:
+        log.error(
+            '"charge.failed" events without an invoice are not supported'
+        )
+        return
+
+    try:
+        # Retrieve the `PromotedSubscription` for the current `charge` object.
+        # We need to retreive the Stripe Subscription first (via the Stripe
+        # Invoice because a Stripe Charge isn't directly linked to a
+        # Subscription).
+        stripe_sub = retrieve_stripe_subscription_for_invoice(
+            invoice_id=charge["invoice"]
+        )
+        subscription_id = stripe_sub["id"]
+        log.debug(
+            "retrieved stripe subscription with subscription_id=%s.",
+            subscription_id,
+        )
+
+        sub = PromotedSubscription.objects.get(
+            stripe_subscription_id=subscription_id
+        )
+    except PromotedSubscription.DoesNotExist:
+        log.error(
+            'received a "%s" event (event_id=%s) for a non-existent'
+            " promoted subscription (subscription_id=%s).",
+            event_type,
+            event_id,
+            subscription_id,
+        )
+        return
+    except Exception:
+        log.error(
+            'error while trying to retrieve a subscription for "%s"'
+            " event with event_id=%s and charge_id=%s.",
+            event_type,
+            event_id,
+            charge_id,
+        )
+        return
+
+    addon = sub.promoted_addon.addon
+
+    # Create the Stripe URL pointing to the Stripe subscription.
+    stripe_sub_url = "https://dashboard.stripe.com"
+    if not stripe_sub["livemode"]:
+        stripe_sub_url = stripe_sub_url + "/test"
+    stripe_sub_url = stripe_sub_url + f"/subscriptions/{subscription_id}"
+
+    subject = f"Stripe payment failure detected for add-on: {addon.name}"
+    template = loader.get_template("promoted/emails/stripe_charge_failed.txt")
+    context = {
+        "addon_url": absolutify(addon.get_detail_url()),
+        "admin_url": absolutify(
+            reverse(
+                "admin:discovery_promotedaddon_change",
+                args=[sub.promoted_addon_id],
+            )
+        ),
+        "stripe_sub_url": stripe_sub_url,
+    }
+
+    send_mail(
+        subject,
+        template.render(context),
+        from_email=settings.ADDONS_EMAIL,
+        recipient_list=["amo-admins@mozilla.com"],
+    )

--- a/src/olympia/promoted/tasks.py
+++ b/src/olympia/promoted/tasks.py
@@ -85,7 +85,7 @@ def on_stripe_charge_failed(event):
     stripe_sub_url = "https://dashboard.stripe.com"
     if not stripe_sub["livemode"]:
         stripe_sub_url = stripe_sub_url + "/test"
-    stripe_sub_url = stripe_sub_url + f"/subscriptions/{subscription_id}"
+    stripe_sub_url = f"{stripe_sub_url}/subscriptions/{subscription_id}"
 
     subject = f"Stripe payment failure detected for add-on: {addon.name}"
     template = loader.get_template("promoted/emails/stripe_charge_failed.txt")

--- a/src/olympia/promoted/tasks.py
+++ b/src/olympia/promoted/tasks.py
@@ -70,7 +70,7 @@ def on_stripe_charge_failed(event):
         )
         return
     except Exception:
-        log.error(
+        log.exception(
             'error while trying to retrieve a subscription for "%s"'
             " event with event_id=%s and charge_id=%s.",
             event_type,

--- a/src/olympia/promoted/tasks.py
+++ b/src/olympia/promoted/tasks.py
@@ -45,7 +45,7 @@ def on_stripe_charge_failed(event):
 
     try:
         # Retrieve the `PromotedSubscription` for the current `charge` object.
-        # We need to retreive the Stripe Subscription first (via the Stripe
+        # We need to retrieve the Stripe Subscription first (via the Stripe
         # Invoice because a Stripe Charge isn't directly linked to a
         # Subscription).
         stripe_sub = retrieve_stripe_subscription_for_invoice(

--- a/src/olympia/promoted/templates/promoted/emails/stripe_charge_failed.txt
+++ b/src/olympia/promoted/templates/promoted/emails/stripe_charge_failed.txt
@@ -1,0 +1,11 @@
+{% block content %}
+Hello,
+
+We received a notification from Stripe about a payment failure for the following add-on: {{ addon_url }}
+
+The promoted subscription/add-on is available at: {{ admin_url }}
+
+The Stripe subscription is available at: {{ stripe_sub_url }}
+
+Yours.
+{% endblock %}

--- a/src/olympia/promoted/tests/test_tasks.py
+++ b/src/olympia/promoted/tests/test_tasks.py
@@ -1,0 +1,160 @@
+from unittest import mock
+
+from django.core import mail
+
+from olympia.amo.templatetags.jinja_helpers import absolutify
+from olympia.amo.tests import (
+    addon_factory,
+    TestCase,
+)
+from olympia.amo.urlresolvers import reverse
+from olympia.constants.promoted import VERIFIED
+from olympia.promoted.models import PromotedAddon
+from olympia.promoted.tasks import on_stripe_charge_failed
+
+
+class TestOnStripeChargeFailed(TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.addon = addon_factory()
+        self.promoted_addon = PromotedAddon.objects.create(
+            addon=self.addon, group_id=VERIFIED.id
+        )
+
+    def create_stripe_event(
+        self, event_id="some-id", event_type="charge.failed", **kwargs
+    ):
+        return {
+            "id": event_id,
+            "type": event_type,
+            **kwargs,
+        }
+
+    @mock.patch(
+        "olympia.promoted.tasks.retrieve_stripe_subscription_for_invoice"
+    )
+    def test_ignores_invalid_event_type(self, retrieve_sub_mock):
+        event = self.create_stripe_event(event_type="not-charge-failed")
+
+        on_stripe_charge_failed(event=event)
+
+        retrieve_sub_mock.assert_not_called()
+
+    @mock.patch(
+        "olympia.promoted.tasks.retrieve_stripe_subscription_for_invoice"
+    )
+    def test_ignores_events_without_data(self, retrieve_sub_mock):
+        event = self.create_stripe_event(data={})
+
+        on_stripe_charge_failed(event=event)
+
+        retrieve_sub_mock.assert_not_called()
+
+    @mock.patch(
+        "olympia.promoted.tasks.retrieve_stripe_subscription_for_invoice"
+    )
+    def test_ignores_events_without_data_object(self, retrieve_sub_mock):
+        event = self.create_stripe_event(data={"object": None})
+
+        on_stripe_charge_failed(event=event)
+
+        retrieve_sub_mock.assert_not_called()
+
+    @mock.patch(
+        "olympia.promoted.tasks.retrieve_stripe_subscription_for_invoice"
+    )
+    def test_ignores_unknown_promoted_subscriptions(self, retrieve_sub_mock):
+        subscription_id = "subscription-id"
+        retrieve_sub_mock.return_value = {
+            "id": subscription_id,
+            "livemode": False,
+        }
+        invoice_id = "invoice-id"
+        fake_charge = {"id": "charge-id", "invoice": invoice_id}
+        event = self.create_stripe_event(data={"object": fake_charge})
+
+        on_stripe_charge_failed(event=event)
+
+        retrieve_sub_mock.assert_called_once_with(invoice_id=invoice_id)
+        assert len(mail.outbox) == 0
+
+    @mock.patch(
+        "olympia.promoted.tasks.retrieve_stripe_subscription_for_invoice"
+    )
+    def test_ignores_stripe_errors(self, retrieve_sub_mock):
+        retrieve_sub_mock.side_effect = ValueError("stripe error")
+        invoice_id = "invoice-id"
+        fake_charge = {"id": "charge-id", "invoice": invoice_id}
+        event = self.create_stripe_event(data={"object": fake_charge})
+
+        on_stripe_charge_failed(event=event)
+
+        retrieve_sub_mock.assert_called_once_with(invoice_id=invoice_id)
+        assert len(mail.outbox) == 0
+
+    @mock.patch(
+        "olympia.promoted.tasks.retrieve_stripe_subscription_for_invoice"
+    )
+    def test_sends_email_to_amo_admins(self, retrieve_sub_mock):
+        subscription_id = "subscription-id"
+        self.promoted_addon.promotedsubscription.update(
+            stripe_subscription_id=subscription_id
+        )
+        retrieve_sub_mock.return_value = {
+            "id": subscription_id,
+            "livemode": False,
+        }
+        invoice_id = "invoice-id"
+        fake_charge = {"id": "charge-id", "invoice": invoice_id}
+        event = self.create_stripe_event(data={"object": fake_charge})
+
+        on_stripe_charge_failed(event=event)
+
+        retrieve_sub_mock.assert_called_once_with(invoice_id=invoice_id)
+        assert len(mail.outbox) == 1
+        email = mail.outbox[0]
+        assert (
+            email.subject ==
+            f"Stripe payment failure detected for add-on: {self.addon.name}"
+        )
+        assert email.to == ["amo-admins@mozilla.com"]
+        assert (
+            f"following add-on: {absolutify(self.addon.get_detail_url())}"
+            in email.body
+        )
+        assert (
+            absolutify(
+                reverse(
+                    "admin:discovery_promotedaddon_change",
+                    args=[self.promoted_addon.id],
+                )
+            )
+            in email.body
+        )
+        assert (
+            f"//dashboard.stripe.com/test/subscriptions/{subscription_id}"
+            in email.body
+        )
+
+    @mock.patch(
+        "olympia.promoted.tasks.retrieve_stripe_subscription_for_invoice"
+    )
+    def test_sends_email_to_amo_admins_in_livemode(self, retrieve_sub_mock):
+        subscription_id = "subscription-id"
+        self.promoted_addon.promotedsubscription.update(
+            stripe_subscription_id=subscription_id
+        )
+        retrieve_sub_mock.return_value = {
+            "id": subscription_id,
+            "livemode": True,
+        }
+        fake_charge = {"id": "charge-id", "invoice": "invoice-id"}
+        event = self.create_stripe_event(data={"object": fake_charge})
+
+        on_stripe_charge_failed(event=event)
+
+        assert (
+            f"//dashboard.stripe.com/subscriptions/{subscription_id}"
+            in mail.outbox[0].body
+        )

--- a/src/olympia/promoted/tests/test_utils.py
+++ b/src/olympia/promoted/tests/test_utils.py
@@ -21,6 +21,7 @@ from olympia.promoted.utils import (
     create_stripe_webhook_event,
     retrieve_stripe_checkout_session,
     retrieve_stripe_subscription,
+    retrieve_stripe_subscription_for_invoice,
 )
 
 
@@ -438,3 +439,24 @@ def test_retrieve_stripe_subscription():
 
         assert stripe_sub == fake_subscription
         stripe_retrieve.assert_called_once_with(stripe_subscription_id)
+
+
+def test_retrieve_stripe_subscription_for_invoice():
+    invoice_id = "invoice-id"
+    subscription_id = "subscription-id"
+    fake_invoice = {"subscription": subscription_id}
+    fake_subscription = "fake-stripe-subscription"
+
+    with mock.patch(
+        "olympia.promoted.utils.stripe.Invoice.retrieve"
+    ) as invoice_mock, mock.patch(
+        "olympia.promoted.utils.stripe.Subscription.retrieve"
+    ) as subscription_mock:
+        invoice_mock.return_value = fake_invoice
+        subscription_mock.return_value = fake_subscription
+
+        sub = retrieve_stripe_subscription_for_invoice(invoice_id=invoice_id)
+
+        assert sub == fake_subscription
+        invoice_mock.assert_called_once_with(invoice_id)
+        subscription_mock.assert_called_once_with(subscription_id)

--- a/src/olympia/promoted/tests/test_views.py
+++ b/src/olympia/promoted/tests/test_views.py
@@ -57,3 +57,14 @@ class TestStripeWebhook(TestCase):
         create_mock.assert_called_once_with(
             payload=payload, sig_header=sig_header
         )
+
+    @mock.patch("olympia.promoted.views.on_stripe_charge_failed.delay")
+    @mock.patch("olympia.promoted.views.create_stripe_webhook_event")
+    def test_charge_failed(self, create_mock, task_mock):
+        fake_event = mock.MagicMock(type="charge.failed")
+        create_mock.return_value = fake_event
+
+        response = self.client.post(self.url)
+
+        assert response.status_code == 202
+        task_mock.assert_called_once_with(event=fake_event)

--- a/src/olympia/promoted/utils.py
+++ b/src/olympia/promoted/utils.py
@@ -126,3 +126,10 @@ def create_stripe_webhook_event(payload, sig_header):
     stripe.api_key = settings.STRIPE_API_SECRET_KEY
     webhook_secret = settings.STRIPE_API_WEBHOOK_SECRET
     return stripe.Webhook.construct_event(payload, sig_header, webhook_secret)
+
+
+def retrieve_stripe_subscription_for_invoice(invoice_id):
+    """This function returns a Stripe Subscription object or raises errors."""
+    stripe.api_key = settings.STRIPE_API_SECRET_KEY
+    invoice = stripe.Invoice.retrieve(invoice_id)
+    return stripe.Subscription.retrieve(invoice["subscription"])


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/15837
~~:warning: depends on https://github.com/mozilla/addons-server/pull/15918~~