### PR TITLE
Add js confirm() to warn admins about promoted group updates

### DIFF
--- a/src/olympia/promoted/admin.py
+++ b/src/olympia/promoted/admin.py
@@ -132,6 +132,11 @@ class PromotedAddonAdmin(admin.ModelAdmin):
     inlines = (PromotedApprovalInline, PrimaryHeroInline,
                PromotedSubscriptionInline)
 
+    class Media:
+        js = (
+            'js/admin/promotedaddon.js',
+        )
+
     @classmethod
     def _transformer(self, objs):
         Version.transformer_promoted(

--- a/static/js/admin/promotedaddon.js
+++ b/static/js/admin/promotedaddon.js
@@ -1,0 +1,27 @@
+document.addEventListener('DOMContentLoaded', () => {
+  'use strict';
+
+  const promotedAddonForm = document.getElementById('promotedaddon_form');
+
+  if (!promotedAddonForm) {
+    return;
+  }
+
+  const groupSelect = promotedAddonForm.querySelector('#id_group_id');
+  let initialIndex = groupSelect.selectedIndex;
+  const initialGroup = groupSelect.options[initialIndex].label || '';
+
+  // Enable the listener only when loading a promoted add-on belonging to a
+  // group that requires a subscription.
+  if (['sponsored', 'verified'].includes(initialGroup.toLowerCase())) {
+    groupSelect.addEventListener('change', () => {
+      if (
+        !confirm(
+          "This promoted add-on belongs to a group that requires a Stripe subscription, which should be cancelled in Stripe first. If you confirm this action, you will be able to update the group but Stripe won't be notified and the Stripe subscription will remain active. Do you really want to continue?",
+        )
+      ) {
+        groupSelect.selectedIndex = initialIndex;
+      }
+    });
+  }
+});


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/15863

---

This isn't what I had in mind when I filed the issue but that looks like it
would work anyway and it is likely good enough for now.