### PR TITLE
Update hint regarding allowed extensions for uploads to remove .xml

### DIFF
--- a/static/js/common/upload-addon.js
+++ b/static/js/common/upload-addon.js
@@ -76,7 +76,7 @@
         }),
         ui_details = $('<div>', {
           class: 'upload-details',
-          text: gettext('Your add-on should end with .zip, .xpi, .crx or .xml'),
+          text: gettext('Your add-on should end with .zip, .xpi, or .crx'),
         });
 
       $upload_field.prop('disabled', false);

--- a/static/js/common/upload-addon.js
+++ b/static/js/common/upload-addon.js
@@ -76,7 +76,7 @@
         }),
         ui_details = $('<div>', {
           class: 'upload-details',
-          text: gettext('Your add-on should end with .zip, .xpi, or .crx'),
+          text: gettext('Your add-on should end with .zip, .xpi or .crx'),
         });
 
       $upload_field.prop('disabled', false);


### PR DESCRIPTION
Opensearch add-ons are gone.

Fixes #16090