### PR TITLE
Remove icon selector from devhub +(js/css fixes for 128 size default)

### DIFF
--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -850,16 +850,12 @@ class TestEditMedia(BaseTestEdit):
 
         labels = doc('#icons_default li a~label')
 
-        assert labels.length == 18
+        assert labels.length == 1
 
         # First one is the default icon
         assert labels[0].get('for') == 'id_icon_type_0_0'
         assert labels[0].find('input').get('name') == 'icon_type'
         assert labels[0].find('input').get('value') == ''
-
-        assert labels[1].get('for') == 'id_icon_type_1_1'
-        assert labels[1].find('input').get('name') == 'icon_type'
-        assert labels[1].find('input').get('value') == 'icon/alerts'
 
         # Make sure we're rendering our <input> fields for custom icon
         # upload correctly.

--- a/src/olympia/landfill/generators.py
+++ b/src/olympia/landfill/generators.py
@@ -11,7 +11,6 @@ from olympia.amo.utils import slugify
 from olympia.constants.applications import APPS
 from olympia.constants.base import (
     ADDON_EXTENSION, ADDON_STATICTHEME, STATUS_APPROVED)
-from olympia.devhub.forms import icons
 
 from .categories import generate_categories
 from .collection import generate_collection
@@ -41,7 +40,7 @@ def _yield_name_and_cat(num, app=None, type=None):
         yield (addon_name, cat)
 
 
-def create_addon(name, icon_type, application, **extra_kwargs):
+def create_addon(name, application, **extra_kwargs):
     """Create an addon with the given `name` and his version."""
     kwargs = {
         'status': STATUS_APPROVED,
@@ -52,7 +51,6 @@ def create_addon(name, icon_type, application, **extra_kwargs):
         'weekly_downloads': random.randint(200, 2000),
         'created': datetime.now(),
         'last_updated': datetime.now(),
-        'icon_type': icon_type,
         'type': ADDON_EXTENSION,
     }
     kwargs.update(extra_kwargs)
@@ -75,12 +73,9 @@ def generate_addons(num, owner, app_name, addon_type=ADDON_EXTENSION):
     featured_categories = collections.defaultdict(int)
     user = generate_user(owner)
     app = APPS[app_name]
-    default_icons = [x[0] for x in icons() if x[0].startswith('icon/')]
     for name, category in _yield_name_and_cat(
             num, app=app, type=addon_type):
-        # Use one of the default icons at random.
-        icon_type = random.choice(default_icons)
-        addon = create_addon(name=name, icon_type=icon_type,
+        addon = create_addon(name=name,
                              application=app, type=addon_type)
         generate_addon_user_and_category(addon, user, category)
         generate_addon_preview(addon)

--- a/src/olympia/landfill/serializers.py
+++ b/src/olympia/landfill/serializers.py
@@ -3,7 +3,6 @@
 import collections
 import mimetypes
 import os
-import random
 import uuid
 
 from django.conf import settings
@@ -27,7 +26,6 @@ from olympia.constants.applications import APPS, FIREFOX
 from olympia.constants.base import (
     ADDON_EXTENSION, ADDON_STATICTHEME
 )
-from olympia.devhub.forms import icons
 from olympia.landfill.collection import generate_collection
 from olympia.ratings.models import Rating
 from olympia.users.models import UserProfile
@@ -179,7 +177,6 @@ class GenerateAddonsSerializer(serializers.Serializer):
         'ui-tester2'. It has a version number.
 
         """
-        default_icons = [x[0] for x in icons() if x[0].startswith('icon/')]
         addon = addon_factory(
             status=amo.STATUS_APPROVED,
             type=ADDON_EXTENSION,
@@ -191,7 +188,6 @@ class GenerateAddonsSerializer(serializers.Serializer):
                 'is_webextension': True
             },
             guid=generate_addon_guid(),
-            icon_type=random.choice(default_icons),
             name=u'Ui-Addon',
             recommended=True,
             slug='ui-test-2',
@@ -233,7 +229,6 @@ class GenerateAddonsSerializer(serializers.Serializer):
         It is an Android addon.
 
         """
-        default_icons = [x[0] for x in icons() if x[0].startswith('icon/')]
         addon = addon_factory(
             status=amo.STATUS_APPROVED,
             type=ADDON_EXTENSION,
@@ -245,7 +240,6 @@ class GenerateAddonsSerializer(serializers.Serializer):
                 'is_webextension': True
             },
             guid=generate_addon_guid(),
-            icon_type=random.choice(default_icons),
             name=u'Ui-Addon-Android',
             recommended=True,
             slug='ui-test-addon-android',
@@ -280,7 +274,6 @@ class GenerateAddonsSerializer(serializers.Serializer):
         'ui-tester2'. It has a version number.
 
         """
-        default_icons = [x[0] for x in icons() if x[0].startswith('icon/')]
         try:
             addon = Addon.objects.get(guid='@webextension-guid')
         except Addon.DoesNotExist:
@@ -291,7 +284,6 @@ class GenerateAddonsSerializer(serializers.Serializer):
                 average_rating=5,
                 description=u'My Addon description',
                 guid='@webextension-guid',
-                icon_type=random.choice(default_icons),
                 name=u'Ui-Addon-Install',
                 recommended=True,
                 slug='ui-test-install',

--- a/src/olympia/landfill/tests/test_generators.py
+++ b/src/olympia/landfill/tests/test_generators.py
@@ -66,7 +66,7 @@ class ThemeGeneratorTests(_BaseAddonGeneratorMixin, TestCase):
 class CreateGeneratorTests(TestCase):
 
     def test_create_addon(self):
-        addon = create_addon('foo', 'icon/default', APPS['android'])
+        addon = create_addon('foo', APPS['android'])
         assert Addon.objects.last().name == addon.name
         assert amo.STATUS_APPROVED == addon.status
         assert Version.objects.last() == addon._current_version

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -960,9 +960,6 @@ PYLIBMC_MIN_COMPRESS_LEN = 0  # disabled
 # External tools.
 JAVA_BIN = '/usr/bin/java'
 
-# File paths
-ADDON_ICONS_DEFAULT_PATH = os.path.join(ROOT, 'static', 'img', 'addon-icons')
-
 # URL paths
 # paths for images, e.g. mozcdn.com/amo or '/static'
 VAMO_URL = 'https://versioncheck.addons.mozilla.org'

--- a/static/css/impala/developers.less
+++ b/static/css/impala/developers.less
@@ -464,17 +464,6 @@
     }
 }
 
-#icon_preview_48 {
-    line-height: 48px;
-    width: 48px;
-    height: 48px;
-
-    img {
-        max-width: 48px;
-        max-height: 48px;
-    }
-}
-
 #icon_preview_64 {
     line-height: 64px;
     width: 64px;
@@ -483,6 +472,17 @@
     img {
         max-width: 64px;
         max-height: 64px;
+    }
+}
+
+#icon_preview_128 {
+    line-height: 128px;
+    width: 128px;
+    height: 128px;
+
+    img {
+        max-width: 128px;
+        max-height: 128px;
     }
 }
 

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -486,6 +486,10 @@ function initUploadIcon() {
         'src',
         $('img', $parent).attr('src').replace(/32/, '64'),
       );
+      $('#icon_preview_128 img').attr(
+        'src',
+        $('img', $parent).attr('src').replace(/32/, '128'),
+      );
 
       $error_list.html('');
     },


### PR DESCRIPTION
Fixes #10090 - the first step anyway, removing the selection.  Follow-ups are to migrate existing add-ons using the icons (copying the chosen icon to that particular add-on) (#16114); then deleting the supporting code for the `icon/xxx` `image_type` property.