### PR TITLE
Sync users with basket when they are banned

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1812,18 +1812,18 @@ def watch_changes(old_attr=None, new_attr=None, instance=None, sender=None, **kw
         'disabled_by_user',
     )
     if any(field in changes for field in basket_relevant_changes):
-        from olympia.amo.tasks import trigger_sync_object_to_basket
+        from olympia.amo.tasks import trigger_sync_objects_to_basket
 
-        trigger_sync_object_to_basket('addon', instance.pk, 'attribute change')
+        trigger_sync_objects_to_basket('addon', [instance.pk], 'attribute change')
 
 
 @receiver(translation_saved, sender=Addon, dispatch_uid='watch_addon_name_changes')
 def watch_addon_name_changes(sender=None, instance=None, **kw):
     field_name = kw.get('field_name')
     if instance and field_name == 'name':
-        from olympia.amo.tasks import trigger_sync_object_to_basket
+        from olympia.amo.tasks import trigger_sync_objects_to_basket
 
-        trigger_sync_object_to_basket('addon', instance.pk, 'name change')
+        trigger_sync_objects_to_basket('addon', [instance.pk], 'name change')
 
 
 def attach_translations_dict(addons):
@@ -1988,10 +1988,10 @@ def addon_user_sync(sender=None, instance=None, **kwargs):
     # or not, it just needs to be updated whenever an author is added/removed.
     created_or_deleted = kwargs.get('created', True) or instance.is_deleted
     if created_or_deleted and instance.addon.status != amo.STATUS_DELETED:
-        from olympia.amo.tasks import trigger_sync_object_to_basket
+        from olympia.amo.tasks import trigger_sync_objects_to_basket
 
-        trigger_sync_object_to_basket(
-            'addon', instance.addon.pk, 'addonuser change'
+        trigger_sync_objects_to_basket(
+            'addon', [instance.addon.pk], 'addonuser change'
         )
 
 

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1990,9 +1990,7 @@ def addon_user_sync(sender=None, instance=None, **kwargs):
     if created_or_deleted and instance.addon.status != amo.STATUS_DELETED:
         from olympia.amo.tasks import trigger_sync_objects_to_basket
 
-        trigger_sync_objects_to_basket(
-            'addon', [instance.addon.pk], 'addonuser change'
-        )
+        trigger_sync_objects_to_basket('addon', [instance.addon.pk], 'addonuser change')
 
 
 models.signals.post_delete.connect(

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1801,7 +1801,7 @@ def watch_changes(old_attr=None, new_attr=None, instance=None, sender=None, **kw
         # Some changes are not tracked here:
         # - Any authors changes (separate model)
         # - Creation/Deletion of unlisted version (separate model)
-        # - Name change (separate model, not implemented yet)
+        # - Name change (separate model/signal, see below)
         # - Categories changes (separate model, ignored for now)
         # - average_rating changes (ignored for now, happens too often)
         # - average_daily_users changes (ignored for now, happens too often)
@@ -1812,30 +1812,18 @@ def watch_changes(old_attr=None, new_attr=None, instance=None, sender=None, **kw
         'disabled_by_user',
     )
     if any(field in changes for field in basket_relevant_changes):
-        from olympia.amo.tasks import sync_object_to_basket
+        from olympia.amo.tasks import trigger_sync_object_to_basket
 
-        log.info(
-            'Triggering a sync of %s %s with basket because of %s change',
-            'addon',
-            instance.pk,
-            'attribute',
-        )
-        sync_object_to_basket.delay('addon', instance.pk)
+        trigger_sync_object_to_basket('addon', instance.pk, 'attribute change')
 
 
 @receiver(translation_saved, sender=Addon, dispatch_uid='watch_addon_name_changes')
 def watch_addon_name_changes(sender=None, instance=None, **kw):
     field_name = kw.get('field_name')
     if instance and field_name == 'name':
-        from olympia.amo.tasks import sync_object_to_basket
+        from olympia.amo.tasks import trigger_sync_object_to_basket
 
-        log.info(
-            'Triggering a sync of %s %s with basket because of %s change',
-            'addon',
-            instance.pk,
-            'name',
-        )
-        sync_object_to_basket.delay('addon', instance.pk)
+        trigger_sync_object_to_basket('addon', instance.pk, 'name change')
 
 
 def attach_translations_dict(addons):
@@ -2000,15 +1988,11 @@ def addon_user_sync(sender=None, instance=None, **kwargs):
     # or not, it just needs to be updated whenever an author is added/removed.
     created_or_deleted = kwargs.get('created', True) or instance.is_deleted
     if created_or_deleted and instance.addon.status != amo.STATUS_DELETED:
-        from olympia.amo.tasks import sync_object_to_basket
+        from olympia.amo.tasks import trigger_sync_object_to_basket
 
-        log.info(
-            'Triggering a sync of %s %s with basket because of %s change',
-            'addon',
-            instance.addon.pk,
-            'addonuser',
+        trigger_sync_object_to_basket(
+            'addon', instance.addon.pk, 'addonuser change'
         )
-        sync_object_to_basket.delay('addon', instance.addon.pk)
 
 
 models.signals.post_delete.connect(

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -1759,8 +1759,10 @@ class TestAddonModels(TestCase):
         # but not when it's removed.
         assert addon.promoted is None
 
-    @patch('olympia.amo.tasks.sync_objects_to_basket')
-    def test_addon_field_changes_not_synced_to_basket(self, sync_objects_to_basket_mock):
+    @patch('olympia.amo.tasks.trigger_sync_objects_to_basket')
+    def test_addon_field_changes_not_synced_to_basket(
+        self, trigger_sync_objects_to_basket_mock
+    ):
         addon = Addon.objects.get(id=3615)
         addon.update(
             average_rating=4.5,
@@ -1770,107 +1772,133 @@ class TestAddonModels(TestCase):
             contributions='http://payme.example.com/',
             is_experimental=True,
         )
-        assert sync_objects_to_basket_mock.delay.call_count == 0
+        assert trigger_sync_objects_to_basket_mock.call_count == 0
 
         addon.homepage = 'http://home.example.com/'
         addon.description = 'Blâh Desc'
         addon.summary = 'Blâh Sum'
         addon.save()
-        assert sync_objects_to_basket_mock.delay.call_count == 0
+        assert trigger_sync_objects_to_basket_mock.call_count == 0
 
-    @patch('olympia.amo.tasks.sync_objects_to_basket')
-    def test_addon_field_changes_synced_to_basket(self, sync_objects_to_basket_mock):
+    @patch('olympia.amo.tasks.trigger_sync_objects_to_basket')
+    def test_addon_field_changes_synced_to_basket(
+        self, trigger_sync_objects_to_basket_mock
+    ):
         addon = Addon.objects.get(id=3615)
         addon.update(default_locale='es')
-        assert sync_objects_to_basket_mock.delay.call_count == 1
-        assert sync_objects_to_basket_mock.delay.called_with('addon', 3615)
+        assert trigger_sync_objects_to_basket_mock.call_count == 1
+        trigger_sync_objects_to_basket_mock.assert_called_with(
+            'addon', [3615], 'attribute change'
+        )
 
-        sync_objects_to_basket_mock.reset_mock()
+        trigger_sync_objects_to_basket_mock.reset_mock()
         addon.update(slug='some-fancy-slug')
         addon = Addon.objects.get(pk=3615)
         assert addon.slug == 'some-fancy-slug'
-        assert sync_objects_to_basket_mock.delay.call_count == 1
-        assert sync_objects_to_basket_mock.delay.called_with('addon', 3615)
+        assert trigger_sync_objects_to_basket_mock.call_count == 1
+        trigger_sync_objects_to_basket_mock.assert_called_with(
+            'addon', [3615], 'attribute change'
+        )
 
-        sync_objects_to_basket_mock.reset_mock()
+        trigger_sync_objects_to_basket_mock.reset_mock()
         addon.update(disabled_by_user=True)
-        assert sync_objects_to_basket_mock.delay.call_count == 1
-        assert sync_objects_to_basket_mock.delay.called_with('addon', 3615)
+        assert trigger_sync_objects_to_basket_mock.call_count == 1
+        trigger_sync_objects_to_basket_mock.assert_called_with(
+            'addon', [3615], 'attribute change'
+        )
 
-    @patch('olympia.amo.tasks.sync_objects_to_basket')
-    def test_addon_name_changes_synced_to_basket(self, sync_objects_to_basket_mock):
+    @patch('olympia.amo.tasks.trigger_sync_objects_to_basket')
+    def test_addon_name_changes_synced_to_basket(
+        self, trigger_sync_objects_to_basket_mock
+    ):
         addon = Addon.objects.get(id=3615)
         addon.name = 'Blah'
         addon.save()
 
-        assert sync_objects_to_basket_mock.delay.call_count == 1
-        assert sync_objects_to_basket_mock.delay.called_with('addon', 3615)
+        assert trigger_sync_objects_to_basket_mock.call_count == 1
+        trigger_sync_objects_to_basket_mock.assert_called_with(
+            'addon', [3615], 'name change'
+        )
 
-    @patch('olympia.amo.tasks.sync_objects_to_basket')
-    def test_addon_deletion_synced_to_basket(self, sync_objects_to_basket_mock):
+    @patch('olympia.amo.tasks.trigger_sync_objects_to_basket')
+    def test_addon_deletion_synced_to_basket(self, trigger_sync_objects_to_basket_mock):
         addon = Addon.objects.get(id=3615)
         addon.delete()
-        assert sync_objects_to_basket_mock.delay.call_count == 1
-        assert sync_objects_to_basket_mock.delay.called_with('addon', 3615)
+        assert trigger_sync_objects_to_basket_mock.call_count == 1
+        trigger_sync_objects_to_basket_mock.assert_called_with(
+            'addon', [3615], 'attribute change'
+        )
 
-    @patch('olympia.amo.tasks.sync_objects_to_basket')
-    def test_addon_author_add_synced_to_basket(self, sync_objects_to_basket_mock):
+    @patch('olympia.amo.tasks.trigger_sync_objects_to_basket')
+    def test_addon_author_add_synced_to_basket(
+        self, trigger_sync_objects_to_basket_mock
+    ):
         addon = Addon.objects.get(id=3615)
         user = UserProfile.objects.get(pk=999)
         AddonUser.objects.create(addon=addon, user=user)
-        assert sync_objects_to_basket_mock.delay.call_count == 1
-        assert sync_objects_to_basket_mock.delay.called_with('addon', 3615)
+        assert trigger_sync_objects_to_basket_mock.call_count == 1
+        trigger_sync_objects_to_basket_mock.assert_called_with(
+            'addon', [3615], 'addonuser change'
+        )
 
-    @patch('olympia.amo.tasks.sync_objects_to_basket')
-    def test_addon_author_change_not_synced_to_basket(self, sync_objects_to_basket_mock):
+    @patch('olympia.amo.tasks.trigger_sync_objects_to_basket')
+    def test_addon_author_change_not_synced_to_basket(
+        self, trigger_sync_objects_to_basket_mock
+    ):
         addon = Addon.objects.get(id=3615)
         user = UserProfile.objects.get(pk=999)
         extra_author = AddonUser.objects.create(addon=addon, user=user)
 
-        sync_objects_to_basket_mock.reset_mock()
+        trigger_sync_objects_to_basket_mock.reset_mock()
         extra_author.update(role=amo.AUTHOR_ROLE_DEV, listed=False)
-        assert sync_objects_to_basket_mock.delay.call_count == 0
+        assert trigger_sync_objects_to_basket_mock.call_count == 0
 
-    @patch('olympia.amo.tasks.sync_objects_to_basket')
-    def test_addon_author_delete_synced_to_basket(self, sync_objects_to_basket_mock):
+    @patch('olympia.amo.tasks.trigger_sync_objects_to_basket')
+    def test_addon_author_delete_synced_to_basket(
+        self, trigger_sync_objects_to_basket_mock
+    ):
         addon = Addon.objects.get(id=3615)
         user = UserProfile.objects.get(pk=999)
         extra_author = AddonUser.objects.create(addon=addon, user=user)
 
-        sync_objects_to_basket_mock.reset_mock()
+        trigger_sync_objects_to_basket_mock.reset_mock()
         extra_author.delete()
         extra_author.reload()
         assert extra_author.role == amo.AUTHOR_ROLE_DELETED
         assert AddonUser.unfiltered.filter(id=extra_author.id).exists()
-        assert sync_objects_to_basket_mock.delay.call_count == 1
-        assert sync_objects_to_basket_mock.delay.called_with('addon', 3615)
+        assert trigger_sync_objects_to_basket_mock.call_count == 1
+        trigger_sync_objects_to_basket_mock.assert_called_with(
+            'addon', [3615], 'addonuser change'
+        )
 
-    @patch('olympia.amo.tasks.sync_objects_to_basket')
+    @patch('olympia.amo.tasks.trigger_sync_objects_to_basket')
     def test_addon_author_hard_delete_synced_to_basket(
-        self, sync_objects_to_basket_mock
+        self, trigger_sync_objects_to_basket_mock
     ):
         addon = Addon.objects.get(id=3615)
         user = UserProfile.objects.get(pk=999)
         extra_author = AddonUser.objects.create(addon=addon, user=user)
 
-        sync_objects_to_basket_mock.reset_mock()
+        trigger_sync_objects_to_basket_mock.reset_mock()
         AddonUser.objects.filter(id=extra_author.id).delete()
         assert not AddonUser.unfiltered.filter(id=extra_author.id).exists()
-        assert sync_objects_to_basket_mock.delay.call_count == 1
-        assert sync_objects_to_basket_mock.delay.called_with('addon', 3615)
+        assert trigger_sync_objects_to_basket_mock.call_count == 1
+        trigger_sync_objects_to_basket_mock.assert_called_with(
+            'addon', [3615], 'addonuser change'
+        )
 
-    @patch('olympia.amo.tasks.sync_objects_to_basket')
+    @patch('olympia.amo.tasks.trigger_sync_objects_to_basket')
     def test_addon_author_delete_not_synced_to_basket_if_addon_is_deleted(
-        self, sync_objects_to_basket_mock
+        self, trigger_sync_objects_to_basket_mock
     ):
         addon = Addon.objects.get(id=3615)
         user = UserProfile.objects.get(pk=999)
         extra_author = AddonUser.objects.create(addon=addon, user=user)
         addon.delete()
 
-        sync_objects_to_basket_mock.reset_mock()
+        trigger_sync_objects_to_basket_mock.reset_mock()
         extra_author.delete()
-        assert sync_objects_to_basket_mock.delay.call_count == 0
+        assert trigger_sync_objects_to_basket_mock.call_count == 0
 
     def test_block_property(self):
         addon = Addon.objects.get(id=3615)

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -1759,8 +1759,8 @@ class TestAddonModels(TestCase):
         # but not when it's removed.
         assert addon.promoted is None
 
-    @patch('olympia.amo.tasks.sync_object_to_basket')
-    def test_addon_field_changes_not_synced_to_basket(self, sync_object_to_basket_mock):
+    @patch('olympia.amo.tasks.sync_objects_to_basket')
+    def test_addon_field_changes_not_synced_to_basket(self, sync_objects_to_basket_mock):
         addon = Addon.objects.get(id=3615)
         addon.update(
             average_rating=4.5,
@@ -1770,107 +1770,107 @@ class TestAddonModels(TestCase):
             contributions='http://payme.example.com/',
             is_experimental=True,
         )
-        assert sync_object_to_basket_mock.delay.call_count == 0
+        assert sync_objects_to_basket_mock.delay.call_count == 0
 
         addon.homepage = 'http://home.example.com/'
         addon.description = 'Blâh Desc'
         addon.summary = 'Blâh Sum'
         addon.save()
-        assert sync_object_to_basket_mock.delay.call_count == 0
+        assert sync_objects_to_basket_mock.delay.call_count == 0
 
-    @patch('olympia.amo.tasks.sync_object_to_basket')
-    def test_addon_field_changes_synced_to_basket(self, sync_object_to_basket_mock):
+    @patch('olympia.amo.tasks.sync_objects_to_basket')
+    def test_addon_field_changes_synced_to_basket(self, sync_objects_to_basket_mock):
         addon = Addon.objects.get(id=3615)
         addon.update(default_locale='es')
-        assert sync_object_to_basket_mock.delay.call_count == 1
-        assert sync_object_to_basket_mock.delay.called_with('addon', 3615)
+        assert sync_objects_to_basket_mock.delay.call_count == 1
+        assert sync_objects_to_basket_mock.delay.called_with('addon', 3615)
 
-        sync_object_to_basket_mock.reset_mock()
+        sync_objects_to_basket_mock.reset_mock()
         addon.update(slug='some-fancy-slug')
         addon = Addon.objects.get(pk=3615)
         assert addon.slug == 'some-fancy-slug'
-        assert sync_object_to_basket_mock.delay.call_count == 1
-        assert sync_object_to_basket_mock.delay.called_with('addon', 3615)
+        assert sync_objects_to_basket_mock.delay.call_count == 1
+        assert sync_objects_to_basket_mock.delay.called_with('addon', 3615)
 
-        sync_object_to_basket_mock.reset_mock()
+        sync_objects_to_basket_mock.reset_mock()
         addon.update(disabled_by_user=True)
-        assert sync_object_to_basket_mock.delay.call_count == 1
-        assert sync_object_to_basket_mock.delay.called_with('addon', 3615)
+        assert sync_objects_to_basket_mock.delay.call_count == 1
+        assert sync_objects_to_basket_mock.delay.called_with('addon', 3615)
 
-    @patch('olympia.amo.tasks.sync_object_to_basket')
-    def test_addon_name_changes_synced_to_basket(self, sync_object_to_basket_mock):
+    @patch('olympia.amo.tasks.sync_objects_to_basket')
+    def test_addon_name_changes_synced_to_basket(self, sync_objects_to_basket_mock):
         addon = Addon.objects.get(id=3615)
         addon.name = 'Blah'
         addon.save()
 
-        assert sync_object_to_basket_mock.delay.call_count == 1
-        assert sync_object_to_basket_mock.delay.called_with('addon', 3615)
+        assert sync_objects_to_basket_mock.delay.call_count == 1
+        assert sync_objects_to_basket_mock.delay.called_with('addon', 3615)
 
-    @patch('olympia.amo.tasks.sync_object_to_basket')
-    def test_addon_deletion_synced_to_basket(self, sync_object_to_basket_mock):
+    @patch('olympia.amo.tasks.sync_objects_to_basket')
+    def test_addon_deletion_synced_to_basket(self, sync_objects_to_basket_mock):
         addon = Addon.objects.get(id=3615)
         addon.delete()
-        assert sync_object_to_basket_mock.delay.call_count == 1
-        assert sync_object_to_basket_mock.delay.called_with('addon', 3615)
+        assert sync_objects_to_basket_mock.delay.call_count == 1
+        assert sync_objects_to_basket_mock.delay.called_with('addon', 3615)
 
-    @patch('olympia.amo.tasks.sync_object_to_basket')
-    def test_addon_author_add_synced_to_basket(self, sync_object_to_basket_mock):
+    @patch('olympia.amo.tasks.sync_objects_to_basket')
+    def test_addon_author_add_synced_to_basket(self, sync_objects_to_basket_mock):
         addon = Addon.objects.get(id=3615)
         user = UserProfile.objects.get(pk=999)
         AddonUser.objects.create(addon=addon, user=user)
-        assert sync_object_to_basket_mock.delay.call_count == 1
-        assert sync_object_to_basket_mock.delay.called_with('addon', 3615)
+        assert sync_objects_to_basket_mock.delay.call_count == 1
+        assert sync_objects_to_basket_mock.delay.called_with('addon', 3615)
 
-    @patch('olympia.amo.tasks.sync_object_to_basket')
-    def test_addon_author_change_not_synced_to_basket(self, sync_object_to_basket_mock):
+    @patch('olympia.amo.tasks.sync_objects_to_basket')
+    def test_addon_author_change_not_synced_to_basket(self, sync_objects_to_basket_mock):
         addon = Addon.objects.get(id=3615)
         user = UserProfile.objects.get(pk=999)
         extra_author = AddonUser.objects.create(addon=addon, user=user)
 
-        sync_object_to_basket_mock.reset_mock()
+        sync_objects_to_basket_mock.reset_mock()
         extra_author.update(role=amo.AUTHOR_ROLE_DEV, listed=False)
-        assert sync_object_to_basket_mock.delay.call_count == 0
+        assert sync_objects_to_basket_mock.delay.call_count == 0
 
-    @patch('olympia.amo.tasks.sync_object_to_basket')
-    def test_addon_author_delete_synced_to_basket(self, sync_object_to_basket_mock):
+    @patch('olympia.amo.tasks.sync_objects_to_basket')
+    def test_addon_author_delete_synced_to_basket(self, sync_objects_to_basket_mock):
         addon = Addon.objects.get(id=3615)
         user = UserProfile.objects.get(pk=999)
         extra_author = AddonUser.objects.create(addon=addon, user=user)
 
-        sync_object_to_basket_mock.reset_mock()
+        sync_objects_to_basket_mock.reset_mock()
         extra_author.delete()
         extra_author.reload()
         assert extra_author.role == amo.AUTHOR_ROLE_DELETED
         assert AddonUser.unfiltered.filter(id=extra_author.id).exists()
-        assert sync_object_to_basket_mock.delay.call_count == 1
-        assert sync_object_to_basket_mock.delay.called_with('addon', 3615)
+        assert sync_objects_to_basket_mock.delay.call_count == 1
+        assert sync_objects_to_basket_mock.delay.called_with('addon', 3615)
 
-    @patch('olympia.amo.tasks.sync_object_to_basket')
+    @patch('olympia.amo.tasks.sync_objects_to_basket')
     def test_addon_author_hard_delete_synced_to_basket(
-        self, sync_object_to_basket_mock
+        self, sync_objects_to_basket_mock
     ):
         addon = Addon.objects.get(id=3615)
         user = UserProfile.objects.get(pk=999)
         extra_author = AddonUser.objects.create(addon=addon, user=user)
 
-        sync_object_to_basket_mock.reset_mock()
+        sync_objects_to_basket_mock.reset_mock()
         AddonUser.objects.filter(id=extra_author.id).delete()
         assert not AddonUser.unfiltered.filter(id=extra_author.id).exists()
-        assert sync_object_to_basket_mock.delay.call_count == 1
-        assert sync_object_to_basket_mock.delay.called_with('addon', 3615)
+        assert sync_objects_to_basket_mock.delay.call_count == 1
+        assert sync_objects_to_basket_mock.delay.called_with('addon', 3615)
 
-    @patch('olympia.amo.tasks.sync_object_to_basket')
+    @patch('olympia.amo.tasks.sync_objects_to_basket')
     def test_addon_author_delete_not_synced_to_basket_if_addon_is_deleted(
-        self, sync_object_to_basket_mock
+        self, sync_objects_to_basket_mock
     ):
         addon = Addon.objects.get(id=3615)
         user = UserProfile.objects.get(pk=999)
         extra_author = AddonUser.objects.create(addon=addon, user=user)
         addon.delete()
 
-        sync_object_to_basket_mock.reset_mock()
+        sync_objects_to_basket_mock.reset_mock()
         extra_author.delete()
-        assert sync_object_to_basket_mock.delay.call_count == 0
+        assert sync_objects_to_basket_mock.delay.call_count == 0
 
     def test_block_property(self):
         addon = Addon.objects.get(id=3615)

--- a/src/olympia/amo/tasks.py
+++ b/src/olympia/amo/tasks.py
@@ -155,9 +155,9 @@ def sync_objects_to_basket(model_name, pks):
         )
     model = serializer_class.Meta.model
     manager = getattr(model, 'unfiltered', model.objects)
-    objs = manager.get(pk__in=pks)
+    objs = manager.filter(pk__in=pks)
     for obj in objs:
-        # FIXME: if basket would support synchronizing multiple objects of the same type
+        # FIXME: if basket supported synchronizing multiple objects of the same type
         # at the same time, we'd do a single call. 99% of the time we're only going to
         # sync a single object at a time though, so it shouldn't matter much for now.
         locale_to_use = getattr(obj, 'default_locale', settings.LANGUAGE_CODE)

--- a/src/olympia/amo/tasks.py
+++ b/src/olympia/amo/tasks.py
@@ -91,9 +91,9 @@ def delete_anonymous_collections(items, **kw):
     Collection.objects.filter(type=amo.COLLECTION_ANONYMOUS, pk__in=items).delete()
 
 
-def trigger_sync_object_to_basket(model_name, pk, reason):
+def trigger_sync_objects_to_basket(model_name, pks, reason):
     """
-    Wrapper around sync_object_to_basket task to avoid queuing the task if the waffle
+    Wrapper around sync_objects_to_basket task to avoid queuing the task if the waffle
     switch is off.
     """
     if not switch_is_active('basket-amo-sync'):
@@ -101,30 +101,30 @@ def trigger_sync_object_to_basket(model_name, pk, reason):
             'Should have triggered a sync of %s %s with basket because of %s '
             'but "basket-amo-sync" is off',
             model_name,
-            pk,
+            pks,
             reason,
         )
     else:
         log.debug(
             'Triggering a sync of %s %s with basket because of %s',
             model_name,
-            pk,
+            pks,
             reason,
         )
-        sync_object_to_basket.delay(model_name, pk)
+        sync_objects_to_basket.delay(model_name, pks)
 
 
 @task
 @use_primary_db
-def sync_object_to_basket(model_name, pk):
+def sync_objects_to_basket(model_name, pks):
     """
     Celery task to sync an object (UserProfile or Addon instance) with Basket.
 
-    Don't call directly, use trigger_sync_object_to_basket().
+    Don't call directly, use trigger_sync_objects_to_basket().
     """
     if not switch_is_active('basket-amo-sync'):
         # If the waffle is off we really shouldn't be here: we should have gone through
-        # trigger_sync_object_to_basket() wrapper which does this check and avoids
+        # trigger_sync_objects_to_basket() wrapper which does this check and avoids
         # calling the task if it's off, so something is wrong, warn about it.
         # (There is a small edge case where the waffle could be turned off right after
         # some tasks have been queued, but it's not likely to happen a lot)
@@ -132,11 +132,11 @@ def sync_object_to_basket(model_name, pk):
             'Not synchronizing %s %s with basket because "basket-amo-sync" '
             'switch is off.',
             model_name,
-            pk,
+            pks,
         )
         return
     else:
-        log.info('Synchronizing %s %s with basket.', model_name, pk)
+        log.info('Synchronizing %s %s with basket.', model_name, pks)
     from olympia.accounts.serializers import UserProfileBasketSyncSerializer
     from olympia.addons.serializers import AddonBasketSyncSerializer
 
@@ -155,26 +155,22 @@ def sync_object_to_basket(model_name, pk):
         )
     model = serializer_class.Meta.model
     manager = getattr(model, 'unfiltered', model.objects)
-    try:
-        obj = manager.get(pk=pk)
-    except model.DoesNotExist:
-        log.exception(
-            'Not synchronizing %s %s with basket because it does not exist',
-            model_name,
-            pk,
-        )
-        return
-    locale_to_use = getattr(obj, 'default_locale', settings.LANGUAGE_CODE)
-    with translation.override(locale_to_use):
-        serializer = serializer_class(obj)
-        data = serializer.data
+    objs = manager.get(pk__in=pks)
+    for obj in objs:
+        # FIXME: if basket would support synchronizing multiple objects of the same type
+        # at the same time, we'd do a single call. 99% of the time we're only going to
+        # sync a single object at a time though, so it shouldn't matter much for now.
+        locale_to_use = getattr(obj, 'default_locale', settings.LANGUAGE_CODE)
+        with translation.override(locale_to_use):
+            serializer = serializer_class(obj)
+            data = serializer.data
 
-    basket_endpoint = f'{settings.BASKET_URL}/amo-sync/{model_name}/'
-    response = requests.post(
-        basket_endpoint,
-        json=data,
-        timeout=settings.BASKET_TIMEOUT,
-        headers={'x-api-key': settings.BASKET_API_KEY or ''},
-    )
-    # Explicitly raise for errors so that we see them in Sentry.
-    response.raise_for_status()
+        basket_endpoint = f'{settings.BASKET_URL}/amo-sync/{model_name}/'
+        response = requests.post(
+            basket_endpoint,
+            json=data,
+            timeout=settings.BASKET_TIMEOUT,
+            headers={'x-api-key': settings.BASKET_API_KEY or ''},
+        )
+        # Explicitly raise for errors so that we see them in Sentry.
+        response.raise_for_status()

--- a/src/olympia/amo/tests/test_tasks.py
+++ b/src/olympia/amo/tests/test_tasks.py
@@ -1,4 +1,5 @@
 import json
+from unittest import mock
 
 import responses
 from requests.exceptions import HTTPError
@@ -10,7 +11,7 @@ from django.test.utils import override_settings
 
 from olympia.accounts.serializers import UserProfileBasketSyncSerializer
 from olympia.addons.serializers import AddonBasketSyncSerializer
-from olympia.amo.tasks import sync_objects_to_basket
+from olympia.amo.tasks import sync_objects_to_basket, trigger_sync_objects_to_basket
 from olympia.amo.tests import addon_factory, TestCase, user_factory
 
 
@@ -18,13 +19,29 @@ from olympia.amo.tests import addon_factory, TestCase, user_factory
 class TestSyncObjectToBasket(TestCase):
     def test_unsupported(self):
         with self.assertRaises(ImproperlyConfigured):
-            sync_objects_to_basket('version', 42)
+            sync_objects_to_basket('version', [42])
 
     @override_switch('basket-amo-sync', active=False)
     def test_switch_is_not_active(self):
         addon = addon_factory()
-        sync_objects_to_basket('addon', addon.pk)
+        sync_objects_to_basket('addon', [addon.pk])
         assert len(responses.calls) == 0
+
+    @mock.patch('olympia.amo.tasks.sync_objects_to_basket')
+    def test_trigger_sync_to_basket_wrapper(self, sync_objects_to_basket_mock):
+        trigger_sync_objects_to_basket('blah', [4815162342], 'reason')
+
+        assert sync_objects_to_basket_mock.delay.call_count == 1
+        sync_objects_to_basket_mock.delay.assert_called_with('blah', [4815162342])
+
+    @override_switch('basket-amo-sync', active=False)
+    @mock.patch('olympia.amo.tasks.sync_objects_to_basket')
+    def test_trigger_sync_to_basket_wrapper_switch_is_not_active(
+        self, sync_objects_to_basket_mock
+    ):
+        trigger_sync_objects_to_basket('blah', [4815162342], 'reason')
+
+        assert sync_objects_to_basket_mock.delay.call_count == 0
 
     @override_settings(BASKET_API_KEY='a-basket-key')
     def test_addon(self):
@@ -35,7 +52,7 @@ class TestSyncObjectToBasket(TestCase):
             # Gotta deactivate the sync when calling addon_factory() because
             # the change to _current_version inside will trigger a sync.
             addon = addon_factory()
-        sync_objects_to_basket('addon', addon.pk)
+        sync_objects_to_basket('addon', [addon.pk])
         assert len(responses.calls) == 1
         request = responses.calls[0].request
         assert request.headers['x-api-key'] == settings.BASKET_API_KEY
@@ -58,7 +75,7 @@ class TestSyncObjectToBasket(TestCase):
             # the change to _current_version inside will trigger a sync.
             addon = addon_factory()
         with self.assertRaises(HTTPError):
-            sync_objects_to_basket('addon', addon.pk)
+            sync_objects_to_basket('addon', [addon.pk])
 
         assert len(responses.calls) == 1
         request = responses.calls[0].request
@@ -77,7 +94,7 @@ class TestSyncObjectToBasket(TestCase):
             json=True,
         )
         user = user_factory()
-        sync_objects_to_basket('userprofile', user.pk)
+        sync_objects_to_basket('userprofile', [user.pk])
         assert len(responses.calls) == 1
         request = responses.calls[0].request
         assert request.headers['x-api-key'] == settings.BASKET_API_KEY

--- a/src/olympia/amo/tests/test_tasks.py
+++ b/src/olympia/amo/tests/test_tasks.py
@@ -10,7 +10,7 @@ from django.test.utils import override_settings
 
 from olympia.accounts.serializers import UserProfileBasketSyncSerializer
 from olympia.addons.serializers import AddonBasketSyncSerializer
-from olympia.amo.tasks import sync_object_to_basket
+from olympia.amo.tasks import sync_objects_to_basket
 from olympia.amo.tests import addon_factory, TestCase, user_factory
 
 
@@ -18,12 +18,12 @@ from olympia.amo.tests import addon_factory, TestCase, user_factory
 class TestSyncObjectToBasket(TestCase):
     def test_unsupported(self):
         with self.assertRaises(ImproperlyConfigured):
-            sync_object_to_basket('version', 42)
+            sync_objects_to_basket('version', 42)
 
     @override_switch('basket-amo-sync', active=False)
     def test_switch_is_not_active(self):
         addon = addon_factory()
-        sync_object_to_basket('addon', addon.pk)
+        sync_objects_to_basket('addon', addon.pk)
         assert len(responses.calls) == 0
 
     @override_settings(BASKET_API_KEY='a-basket-key')
@@ -35,7 +35,7 @@ class TestSyncObjectToBasket(TestCase):
             # Gotta deactivate the sync when calling addon_factory() because
             # the change to _current_version inside will trigger a sync.
             addon = addon_factory()
-        sync_object_to_basket('addon', addon.pk)
+        sync_objects_to_basket('addon', addon.pk)
         assert len(responses.calls) == 1
         request = responses.calls[0].request
         assert request.headers['x-api-key'] == settings.BASKET_API_KEY
@@ -58,7 +58,7 @@ class TestSyncObjectToBasket(TestCase):
             # the change to _current_version inside will trigger a sync.
             addon = addon_factory()
         with self.assertRaises(HTTPError):
-            sync_object_to_basket('addon', addon.pk)
+            sync_objects_to_basket('addon', addon.pk)
 
         assert len(responses.calls) == 1
         request = responses.calls[0].request
@@ -77,7 +77,7 @@ class TestSyncObjectToBasket(TestCase):
             json=True,
         )
         user = user_factory()
-        sync_object_to_basket('userprofile', user.pk)
+        sync_objects_to_basket('userprofile', user.pk)
         assert len(responses.calls) == 1
         request = responses.calls[0].request
         assert request.headers['x-api-key'] == settings.BASKET_API_KEY

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1098,7 +1098,7 @@ CELERY_TASK_ROUTES = {
     'olympia.amo.tasks.delete_logs': {'queue': 'amo'},
     'olympia.amo.tasks.send_email': {'queue': 'amo'},
     'olympia.amo.tasks.set_modified_on_object': {'queue': 'amo'},
-    'olympia.amo.tasks.sync_object_to_basket': {'queue': 'amo'},
+    'olympia.amo.tasks.sync_objects_to_basket': {'queue': 'amo'},
     'olympia.blocklist.tasks.cleanup_old_files': {'queue': 'amo'},
     # Addons
     'olympia.addons.tasks.add_dynamic_theme_tag': {'queue': 'addons'},

--- a/src/olympia/promoted/models.py
+++ b/src/olympia/promoted/models.py
@@ -198,13 +198,13 @@ class PromotedApproval(ModelBase):
 )
 def update_es_for_promoted(sender, instance, **kw):
     from olympia.addons.models import update_search_index
-    from olympia.amo.tasks import trigger_sync_object_to_basket
+    from olympia.amo.tasks import trigger_sync_objects_to_basket
 
     # Update ES because Addon.promoted depends on it.
     update_search_index(sender=sender, instance=instance.addon, **kw)
 
     # Sync the related add-on to basket when promoted groups is changed
-    trigger_sync_object_to_basket('addon', instance.addon.pk, 'promoted change')
+    trigger_sync_objects_to_basket('addon', [instance.addon.pk], 'promoted change')
 
 
 @receiver(

--- a/src/olympia/promoted/models.py
+++ b/src/olympia/promoted/models.py
@@ -198,13 +198,13 @@ class PromotedApproval(ModelBase):
 )
 def update_es_for_promoted(sender, instance, **kw):
     from olympia.addons.models import update_search_index
-    from olympia.amo.tasks import sync_object_to_basket
+    from olympia.amo.tasks import trigger_sync_object_to_basket
 
     # Update ES because Addon.promoted depends on it.
     update_search_index(sender=sender, instance=instance.addon, **kw)
 
     # Sync the related add-on to basket when promoted groups is changed
-    sync_object_to_basket.delay('addon', instance.addon.pk)
+    trigger_sync_object_to_basket('addon', instance.addon.pk, 'promoted change')
 
 
 @receiver(

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -552,6 +552,7 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
             users, fields=('banned', 'deleted', 'modified') + cls.ANONYMIZED_FIELDS
         )
         from olympia.amo.tasks import trigger_sync_objects_to_basket
+
         trigger_sync_objects_to_basket('userprofile', ids, 'user ban')
 
     def _prepare_delete_email(self):
@@ -1078,6 +1079,7 @@ def watch_changes(old_attr=None, new_attr=None, instance=None, sender=None, **kw
     )
     if any(field in changes for field in basket_relevant_changes):
         from olympia.amo.tasks import trigger_sync_objects_to_basket
+
         trigger_sync_objects_to_basket('userprofile', [instance.pk], 'attribute change')
 
 

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -1073,15 +1073,8 @@ def watch_changes(old_attr=None, new_attr=None, instance=None, sender=None, **kw
         'location',
     )
     if any(field in changes for field in basket_relevant_changes):
-        from olympia.amo.tasks import sync_object_to_basket
-
-        log.info(
-            'Triggering a sync of %s %s with basket because of %s change',
-            'userprofile',
-            instance.pk,
-            'attribute',
-        )
-        sync_object_to_basket.delay('userprofile', instance.pk)
+        from olympia.amo.tasks import trigger_sync_object_to_basket
+        trigger_sync_object_to_basket('userprofile', instance.pk, 'attribute change')
 
 
 user_logged_in.connect(UserProfile.user_logged_in)

--- a/src/olympia/users/tests/test_models.py
+++ b/src/olympia/users/tests/test_models.py
@@ -669,7 +669,9 @@ class TestUserProfile(TestCase):
         assert not user.reload().is_public
 
     @mock.patch('olympia.amo.tasks.trigger_sync_objects_to_basket')
-    def test_user_field_changes_not_synced_to_basket(self, trigger_sync_objects_to_basket_mock):
+    def test_user_field_changes_not_synced_to_basket(
+        self, trigger_sync_objects_to_basket_mock
+    ):
         user = UserProfile.objects.get(id=4043307)
         # Note that basket_token is for newsletters, and is irrelevant here.
         user.update(
@@ -684,28 +686,38 @@ class TestUserProfile(TestCase):
         assert trigger_sync_objects_to_basket_mock.call_count == 0
 
     @mock.patch('olympia.amo.tasks.trigger_sync_objects_to_basket')
-    def test_user_field_changes_synced_to_basket(self, trigger_sync_objects_to_basket_mock):
+    def test_user_field_changes_synced_to_basket(
+        self, trigger_sync_objects_to_basket_mock
+    ):
         user = UserProfile.objects.get(id=4043307)
         user.update(last_login=self.days_ago(0))
         assert trigger_sync_objects_to_basket_mock.call_count == 1
-        trigger_sync_objects_to_basket_mock.assert_called_with('userprofile', [4043307], 'attribute change')
+        trigger_sync_objects_to_basket_mock.assert_called_with(
+            'userprofile', [4043307], 'attribute change'
+        )
 
         trigger_sync_objects_to_basket_mock.reset_mock()
         user.update(display_name='Fôoo')
         assert trigger_sync_objects_to_basket_mock.call_count == 1
-        trigger_sync_objects_to_basket_mock.assert_called_with('userprofile', [4043307], 'attribute change')
+        trigger_sync_objects_to_basket_mock.assert_called_with(
+            'userprofile', [4043307], 'attribute change'
+        )
 
         trigger_sync_objects_to_basket_mock.reset_mock()
         user.update(fxa_id='wât')  # Can technically happen if admins do it.
         assert trigger_sync_objects_to_basket_mock.call_count == 1
-        trigger_sync_objects_to_basket_mock.assert_called_with('userprofile', [4043307], 'attribute change')
+        trigger_sync_objects_to_basket_mock.assert_called_with(
+            'userprofile', [4043307], 'attribute change'
+        )
 
     @mock.patch('olympia.amo.tasks.trigger_sync_objects_to_basket')
     def test_user_deletion_synced_to_basket(self, trigger_sync_objects_to_basket_mock):
         user = UserProfile.objects.get(id=4043307)
         user.delete()
         assert trigger_sync_objects_to_basket_mock.call_count == 1
-        trigger_sync_objects_to_basket_mock.assert_called_with('userprofile', [4043307], 'attribute change')
+        trigger_sync_objects_to_basket_mock.assert_called_with(
+            'userprofile', [4043307], 'attribute change'
+        )
 
     def test_get_lookup_field(self):
         user = UserProfile.objects.get(id=55021)

--- a/src/olympia/users/tests/test_models.py
+++ b/src/olympia/users/tests/test_models.py
@@ -668,8 +668,8 @@ class TestUserProfile(TestCase):
         addon.delete()
         assert not user.reload().is_public
 
-    @mock.patch('olympia.amo.tasks.sync_object_to_basket')
-    def test_user_field_changes_not_synced_to_basket(self, sync_object_to_basket_mock):
+    @mock.patch('olympia.amo.tasks.sync_objects_to_basket')
+    def test_user_field_changes_not_synced_to_basket(self, sync_objects_to_basket_mock):
         user = UserProfile.objects.get(id=4043307)
         # Note that basket_token is for newsletters, and is irrelevant here.
         user.update(
@@ -681,31 +681,31 @@ class TestUserProfile(TestCase):
             biography='Something',
             auth_id=12345,
         )
-        assert sync_object_to_basket_mock.delay.call_count == 0
+        assert sync_objects_to_basket_mock.delay.call_count == 0
 
-    @mock.patch('olympia.amo.tasks.sync_object_to_basket')
-    def test_user_field_changes_synced_to_basket(self, sync_object_to_basket_mock):
+    @mock.patch('olympia.amo.tasks.sync_objects_to_basket')
+    def test_user_field_changes_synced_to_basket(self, sync_objects_to_basket_mock):
         user = UserProfile.objects.get(id=4043307)
         user.update(last_login=self.days_ago(0))
-        assert sync_object_to_basket_mock.delay.call_count == 1
-        assert sync_object_to_basket_mock.delay.called_with('userprofile', 4043307)
+        assert sync_objects_to_basket_mock.delay.call_count == 1
+        assert sync_objects_to_basket_mock.delay.called_with('userprofile', 4043307)
 
-        sync_object_to_basket_mock.reset_mock()
+        sync_objects_to_basket_mock.reset_mock()
         user.update(display_name='Fôoo')
-        assert sync_object_to_basket_mock.delay.call_count == 1
-        assert sync_object_to_basket_mock.delay.called_with('userprofile', 4043307)
+        assert sync_objects_to_basket_mock.delay.call_count == 1
+        assert sync_objects_to_basket_mock.delay.called_with('userprofile', 4043307)
 
-        sync_object_to_basket_mock.reset_mock()
+        sync_objects_to_basket_mock.reset_mock()
         user.update(fxa_id='wât')  # Can technically happen if admins do it.
-        assert sync_object_to_basket_mock.delay.call_count == 1
-        assert sync_object_to_basket_mock.delay.called_with('userprofile', 4043307)
+        assert sync_objects_to_basket_mock.delay.call_count == 1
+        assert sync_objects_to_basket_mock.delay.called_with('userprofile', 4043307)
 
-    @mock.patch('olympia.amo.tasks.sync_object_to_basket')
-    def test_user_deletion_synced_to_basket(self, sync_object_to_basket_mock):
+    @mock.patch('olympia.amo.tasks.sync_objects_to_basket')
+    def test_user_deletion_synced_to_basket(self, sync_objects_to_basket_mock):
         user = UserProfile.objects.get(id=4043307)
         user.delete()
-        assert sync_object_to_basket_mock.delay.call_count == 1
-        assert sync_object_to_basket_mock.delay.called_with('userprofile', 4043307)
+        assert sync_objects_to_basket_mock.delay.call_count == 1
+        assert sync_objects_to_basket_mock.delay.called_with('userprofile', 4043307)
 
     def test_get_lookup_field(self):
         user = UserProfile.objects.get(id=55021)

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -990,9 +990,11 @@ def watch_changes(old_attr=None, new_attr=None, instance=None, sender=None, **kw
         # deleted. (When a listed version is deleted, watch_changes() in
         # olympia.addon.models should take care of it (since _current_version
         # will change).
-        from olympia.amo.tasks import sync_object_to_basket
+        from olympia.amo.tasks import trigger_sync_object_to_basket
 
-        sync_object_to_basket.delay('addon', instance.addon.pk)
+        trigger_sync_object_to_basket(
+            'addon', instance.addon.pk, 'unlisted version deleted'
+        )
 
 
 def watch_new_unlisted_version(sender=None, instance=None, **kwargs):
@@ -1002,9 +1004,11 @@ def watch_new_unlisted_version(sender=None, instance=None, **kwargs):
     # in olympia.addon.models (since _current_version will change).
     # What's left here is unlisted version upload.
     if instance and instance.channel == amo.RELEASE_CHANNEL_UNLISTED:
-        from olympia.amo.tasks import sync_object_to_basket
+        from olympia.amo.tasks import trigger_sync_object_to_basket
 
-        sync_object_to_basket.delay('addon', instance.addon.pk)
+        trigger_sync_object_to_basket(
+            'addon', instance.addon.pk, 'new unlisted version'
+        )
 
 
 version_uploaded = django.dispatch.Signal()

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -990,10 +990,10 @@ def watch_changes(old_attr=None, new_attr=None, instance=None, sender=None, **kw
         # deleted. (When a listed version is deleted, watch_changes() in
         # olympia.addon.models should take care of it (since _current_version
         # will change).
-        from olympia.amo.tasks import trigger_sync_object_to_basket
+        from olympia.amo.tasks import trigger_sync_objects_to_basket
 
-        trigger_sync_object_to_basket(
-            'addon', instance.addon.pk, 'unlisted version deleted'
+        trigger_sync_objects_to_basket(
+            'addon', [instance.addon.pk], 'unlisted version deleted'
         )
 
 
@@ -1004,10 +1004,10 @@ def watch_new_unlisted_version(sender=None, instance=None, **kwargs):
     # in olympia.addon.models (since _current_version will change).
     # What's left here is unlisted version upload.
     if instance and instance.channel == amo.RELEASE_CHANNEL_UNLISTED:
-        from olympia.amo.tasks import trigger_sync_object_to_basket
+        from olympia.amo.tasks import trigger_sync_objects_to_basket
 
-        trigger_sync_object_to_basket(
-            'addon', instance.addon.pk, 'new unlisted version'
+        trigger_sync_objects_to_basket(
+            'addon', [instance.addon.pk], 'new unlisted version'
         )
 
 

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -1506,7 +1506,9 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
         # It's a new unlisted version, we should be syncing the add-on with
         # basket.
         assert trigger_sync_objects_to_basket_mock.call_count == 1
-        trigger_sync_objects_to_basket_mock.assert_called_with('addon', self.addon.pk)
+        trigger_sync_objects_to_basket_mock.assert_called_with(
+            'addon', [self.addon.pk], 'new unlisted version'
+        )
 
     @mock.patch('olympia.amo.tasks.trigger_sync_objects_to_basket')
     def test_from_upload_listed_not_synced_with_basket(

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -805,9 +805,9 @@ class TestVersion(TestCase):
         del version.all_files  # Reset all_files cache.
         assert not version.was_auto_approved
 
-    @mock.patch('olympia.amo.tasks.sync_object_to_basket')
+    @mock.patch('olympia.amo.tasks.sync_objects_to_basket')
     def test_version_field_changes_not_synced_to_basket(
-        self, sync_object_to_basket_mock
+        self, sync_objects_to_basket_mock
     ):
         addon = Addon.objects.get(id=3615)
         version = addon.current_version
@@ -817,34 +817,34 @@ class TestVersion(TestCase):
             nomination=self.days_ago(2),
             version='1.42',
         )
-        assert sync_object_to_basket_mock.delay.call_count == 0
+        assert sync_objects_to_basket_mock.delay.call_count == 0
 
-    @mock.patch('olympia.amo.tasks.sync_object_to_basket')
-    def test_version_field_changes_synced_to_basket(self, sync_object_to_basket_mock):
+    @mock.patch('olympia.amo.tasks.sync_objects_to_basket')
+    def test_version_field_changes_synced_to_basket(self, sync_objects_to_basket_mock):
         addon = Addon.objects.get(id=3615)
         PromotedApproval.objects.create(
             version=addon.current_version,
             group_id=RECOMMENDED.id,
             application_id=amo.FIREFOX.id,
         )
-        assert sync_object_to_basket_mock.delay.call_count == 1
-        sync_object_to_basket_mock.delay.assert_called_with('addon', addon.pk)
+        assert sync_objects_to_basket_mock.delay.call_count == 1
+        sync_objects_to_basket_mock.delay.assert_called_with('addon', addon.pk)
 
-    @mock.patch('olympia.amo.tasks.sync_object_to_basket')
+    @mock.patch('olympia.amo.tasks.sync_objects_to_basket')
     def test_unlisted_version_deleted_synced_to_basket(
-        self, sync_object_to_basket_mock
+        self, sync_objects_to_basket_mock
     ):
         addon = Addon.objects.get(id=3615)
         version = addon.current_version
         version.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
-        sync_object_to_basket_mock.reset_mock()
+        sync_objects_to_basket_mock.reset_mock()
 
         version.delete()
-        assert sync_object_to_basket_mock.delay.call_count == 1
-        sync_object_to_basket_mock.delay.assert_called_with('addon', addon.pk)
+        assert sync_objects_to_basket_mock.delay.call_count == 1
+        sync_objects_to_basket_mock.delay.assert_called_with('addon', addon.pk)
 
-    @mock.patch('olympia.amo.tasks.sync_object_to_basket')
-    def test_version_deleted_not_synced_to_basket(self, sync_object_to_basket_mock):
+    @mock.patch('olympia.amo.tasks.sync_objects_to_basket')
+    def test_version_deleted_not_synced_to_basket(self, sync_objects_to_basket_mock):
         addon = Addon.objects.get(id=3615)
         # We need to create a new version, if we delete current_version this
         # would be synced to basket because _current_version would change.
@@ -852,7 +852,7 @@ class TestVersion(TestCase):
             addon=addon, file_kw={'status': amo.STATUS_NOMINATED}
         )
         new_version.delete()
-        assert sync_object_to_basket_mock.delay.call_count == 0
+        assert sync_objects_to_basket_mock.delay.call_count == 0
 
     def test_promoted_can_be_disabled_and_deleted(self):
         addon = Addon.objects.get(id=3615)
@@ -1481,8 +1481,8 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
         )
         assert upload_version.nomination == pending_version.nomination
 
-    @mock.patch('olympia.amo.tasks.sync_object_to_basket')
-    def test_from_upload_unlisted(self, sync_object_to_basket_mock):
+    @mock.patch('olympia.amo.tasks.sync_objects_to_basket')
+    def test_from_upload_unlisted(self, sync_objects_to_basket_mock):
         parsed_data = parse_addon(self.upload, self.addon, user=self.fake_user)
         version = Version.from_upload(
             self.upload,
@@ -1495,12 +1495,12 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
         assert sorted(amo.PLATFORMS[f.platform].shortname for f in files) == (['all'])
         # It's a new unlisted version, we should be syncing the add-on with
         # basket.
-        assert sync_object_to_basket_mock.delay.call_count == 1
-        assert sync_object_to_basket_mock.delay.called_with('addon', self.addon.pk)
+        assert sync_objects_to_basket_mock.delay.call_count == 1
+        assert sync_objects_to_basket_mock.delay.called_with('addon', self.addon.pk)
 
-    @mock.patch('olympia.amo.tasks.sync_object_to_basket')
+    @mock.patch('olympia.amo.tasks.sync_objects_to_basket')
     def test_from_upload_listed_not_synced_with_basket(
-        self, sync_object_to_basket_mock
+        self, sync_objects_to_basket_mock
     ):
         parsed_data = parse_addon(self.upload, self.addon, user=self.fake_user)
         version = Version.from_upload(
@@ -1515,7 +1515,7 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
         # It's a new listed version, we should *not* be syncing the add-on with
         # basket through version_uploaded signal, but only when
         # _current_version changes, which isn't the case here.
-        assert sync_object_to_basket_mock.delay.call_count == 0
+        assert sync_objects_to_basket_mock.delay.call_count == 0
 
     def test_set_version_to_customs_scanners_result(self):
         self.create_switch('enable-customs', active=True)


### PR DESCRIPTION
Also avoids queuing the task needlessly while the waffle is off and reduce logging 

Fixes #16188