### PR TITLE
Add back missing `request` parameter when calling super().list() in CollectionAddonViewSet

### DIFF
--- a/src/olympia/bandwagon/views.py
+++ b/src/olympia/bandwagon/views.py
@@ -160,7 +160,7 @@ class CollectionAddonViewSet(ModelViewSet):
         ):
             return self._cached_list(request, *args, **kwargs)
         else:
-            return super().list(*args, *kwargs)
+            return super().list(request, *args, *kwargs)
 
     def get_collection(self):
         if not hasattr(self, 'collection'):


### PR DESCRIPTION
This didn't have any consequences because DRF list() implementation doesn't use `request` or `*args` at the moment.

Fixes https://github.com/mozilla/addons-server/pull/16187#discussion_r551238837