### PR TITLE
Add Accept-Language to Vary headers in the API responses

### DIFF
--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -278,7 +278,7 @@ class AddonAndVersionViewSetDetailMixin(object):
         assert response.status_code == 401
         # Response is short enough that it won't be compressed, so it doesn't
         # depend on Accept-Encoding.
-        assert response['Vary'] == 'Origin, X-Country-Code'
+        assert response['Vary'] == 'Origin, X-Country-Code, Accept-Language'
 
     def test_get_not_listed_no_rights(self):
         user = UserProfile.objects.create(username='simpleuser')
@@ -301,7 +301,7 @@ class AddonAndVersionViewSetDetailMixin(object):
         assert response.status_code == 403
         # Response is short enough that it won't be compressed, so it doesn't
         # depend on Accept-Encoding.
-        assert response['Vary'] == 'Origin, X-Country-Code'
+        assert response['Vary'] == 'Origin, X-Country-Code, Accept-Language'
 
     def test_get_not_listed_simple_reviewer(self):
         user = UserProfile.objects.create(username='reviewer')
@@ -413,14 +413,17 @@ class AddonAndVersionViewSetDetailMixin(object):
         assert response.status_code == 404
         # Response is short enough that it won't be compressed, so it doesn't
         # depend on Accept-Encoding.
-        assert response['Vary'] == 'Origin, X-Country-Code'
+        assert response['Vary'] == 'Origin, X-Country-Code, Accept-Language'
 
     def test_addon_regional_restrictions(self):
         response = self.client.get(
             self.url, {'lang': 'en-US'}, HTTP_X_COUNTRY_CODE='fr'
         )
         assert response.status_code == 200
-        assert response['Vary'] == 'Origin, Accept-Encoding, X-Country-Code'
+        assert (
+            response['Vary']
+            == 'Origin, Accept-Encoding, X-Country-Code, Accept-Language'
+        )
 
         AddonRegionalRestrictions.objects.create(
             addon=self.addon, excluded_regions=['AB', 'CD']
@@ -429,7 +432,10 @@ class AddonAndVersionViewSetDetailMixin(object):
             self.url, {'lang': 'en-US'}, HTTP_X_COUNTRY_CODE='fr'
         )
         assert response.status_code == 200
-        assert response['Vary'] == 'Origin, Accept-Encoding, X-Country-Code'
+        assert (
+            response['Vary']
+            == 'Origin, Accept-Encoding, X-Country-Code, Accept-Language'
+        )
 
         AddonRegionalRestrictions.objects.filter(addon=self.addon).update(
             excluded_regions=['AB', 'CD', 'FR']
@@ -440,7 +446,7 @@ class AddonAndVersionViewSetDetailMixin(object):
         assert response.status_code == 451
         # Response is short enough that it won't be compressed, so it doesn't
         # depend on Accept-Encoding.
-        assert response['Vary'] == 'Origin, X-Country-Code'
+        assert response['Vary'] == 'Origin, X-Country-Code, Accept-Language'
         assert response['Link'] == (
             '<https://www.mozilla.org/about/policy/transparency/>; rel="blocked-by"'
         )
@@ -473,7 +479,10 @@ class TestAddonViewSetDetail(AddonAndVersionViewSetDetailMixin, TestCase):
         response = self.client.get(self.url, data=kwargs, **extra)
         assert response.status_code == 200
         result = json.loads(force_text(response.content))
-        assert response['Vary'] == 'Origin, Accept-Encoding, X-Country-Code'
+        assert (
+            response['Vary']
+            == 'Origin, Accept-Encoding, X-Country-Code, Accept-Language'
+        )
         assert result['id'] == self.addon.pk
         assert result['name'] == {'en-US': 'My Addôn'}
         assert result['slug'] == self.addon.slug
@@ -653,7 +662,10 @@ class TestVersionViewSetDetail(AddonAndVersionViewSetDetailMixin, TestCase):
     def _test_url(self):
         response = self.client.get(self.url)
         assert response.status_code == 200
-        assert response['Vary'] == 'Origin, Accept-Encoding, X-Country-Code'
+        assert (
+            response['Vary']
+            == 'Origin, Accept-Encoding, X-Country-Code, Accept-Language'
+        )
         result = json.loads(force_text(response.content))
         assert result['id'] == self.version.pk
         assert result['version'] == self.version.version

--- a/src/olympia/api/middleware.py
+++ b/src/olympia/api/middleware.py
@@ -15,7 +15,7 @@ class APIRequestMiddleware(MiddlewareMixin):
 
     def process_response(self, request, response):
         if request.is_api:
-            patch_vary_headers(response, ['X-Country-Code'])
+            patch_vary_headers(response, ['X-Country-Code', 'Accept-Language'])
         return response
 
     def process_exception(self, request, exception):

--- a/src/olympia/api/tests/test_middleware.py
+++ b/src/olympia/api/tests/test_middleware.py
@@ -22,11 +22,11 @@ class TestAPIRequestMiddleware(TestCase):
         request.is_api = True
         response = HttpResponse()
         APIRequestMiddleware().process_response(request, response)
-        assert response['Vary'] == 'X-Country-Code'
+        assert response['Vary'] == 'X-Country-Code, Accept-Language'
 
         response['Vary'] = 'Foo, Bar'
         APIRequestMiddleware().process_response(request, response)
-        assert response['Vary'] == 'Foo, Bar, X-Country-Code'
+        assert response['Vary'] == 'Foo, Bar, X-Country-Code, Accept-Language'
 
     def test_vary_not_applied_outside_api(self):
         request = mock.Mock()


### PR DESCRIPTION
When there is no `lang` in the URL, the activated language for the request will depend on `Accept-Language` header, so we need to `Vary` on it in case we did return translated content (not necessarily translations, could also be URLs that contain a locale prefix) depending on language.

Requests outside the API could technically have the same problem, but for 99% of them `LocaleAndAppURLMiddleware` will force a redirect to a locale-aware URL (adding correct vary header to the redirect), sidestepping the issue.

Fixes #16214