### PR TITLE
Only send updated fields to the database UPDATE queries where possible

### DIFF
--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -16,6 +16,7 @@ from olympia.addons.models import (
     attach_tags,
     attach_translations_dict,
 )
+from olympia.addons.utils import compute_last_updated
 from olympia.amo.celery import task
 from olympia.amo.decorators import use_primary_db
 from olympia.amo.utils import LocalFileStorage, extract_colors_from_image
@@ -41,21 +42,6 @@ def version_changed(addon_id, **kw):
     log.info('[1@None] Updating last updated for %s.' % addon.pk)
     addon.update(last_updated=compute_last_updated(addon))
     update_appsupport([addon.pk])
-
-
-def compute_last_updated(addon):
-    queries = Addon._last_updated_queries()
-    if addon.status == amo.STATUS_APPROVED:
-        q = 'public'
-    else:
-        q = 'exp'
-    values = (
-        queries[q]
-        .filter(pk=addon.pk)
-        .using('default')
-        .values_list('last_updated', flat=True)
-    )
-    return values[0] if values else None
 
 
 @task

--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -55,8 +55,7 @@ def compute_last_updated(addon):
         .using('default')
         .values_list('last_updated', flat=True)
     )
-    if values:
-        addon.update(last_updated=values[0])
+    return values[0] if values else None
 
 
 @task

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -477,6 +477,9 @@ class TestAddonViewSetDetail(AddonAndVersionViewSetDetailMixin, TestCase):
         assert result['id'] == self.addon.pk
         assert result['name'] == {'en-US': 'My Addôn'}
         assert result['slug'] == self.addon.slug
+        assert result['last_updated'] == (
+            self.addon.last_updated.replace(microsecond=0).isoformat() + 'Z'
+        )
         return result
 
     def _set_tested_url(self, param):
@@ -1147,6 +1150,9 @@ class TestAddonSearchView(ESTestCase):
         assert result['id'] == addon.pk
         assert result['name'] == {'en-US': 'My Addôn'}
         assert result['slug'] == 'my-addon'
+        assert result['last_updated'] == (
+            addon.last_updated.replace(microsecond=0).isoformat() + 'Z'
+        )
 
         # latest_unlisted_version should never be exposed in public search.
         assert 'latest_unlisted_version' not in result

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -477,9 +477,6 @@ class TestAddonViewSetDetail(AddonAndVersionViewSetDetailMixin, TestCase):
         assert result['id'] == self.addon.pk
         assert result['name'] == {'en-US': 'My Addôn'}
         assert result['slug'] == self.addon.slug
-        assert result['last_updated'] == (
-            self.addon.last_updated.replace(microsecond=0).isoformat() + 'Z'
-        )
         return result
 
     def _set_tested_url(self, param):
@@ -1150,9 +1147,6 @@ class TestAddonSearchView(ESTestCase):
         assert result['id'] == addon.pk
         assert result['name'] == {'en-US': 'My Addôn'}
         assert result['slug'] == 'my-addon'
-        assert result['last_updated'] == (
-            addon.last_updated.replace(microsecond=0).isoformat() + 'Z'
-        )
 
         # latest_unlisted_version should never be exposed in public search.
         assert 'latest_unlisted_version' not in result

--- a/src/olympia/addons/utils.py
+++ b/src/olympia/addons/utils.py
@@ -105,3 +105,21 @@ def get_addon_recommendations_invalid():
         TAAR_LITE_OUTCOME_REAL_FAIL,
         TAAR_LITE_FALLBACK_REASON_INVALID,
     )
+
+
+def compute_last_updated(addon):
+    """Compute the value of last_updated for a single add-on."""
+    from olympia.addons.models import Addon
+
+    queries = Addon._last_updated_queries()
+    if addon.status == amo.STATUS_APPROVED:
+        q = 'public'
+    else:
+        q = 'exp'
+    values = (
+        queries[q]
+        .filter(pk=addon.pk)
+        .using('default')
+        .values_list('last_updated', flat=True)
+    )
+    return values[0] if values else None

--- a/src/olympia/amo/models.py
+++ b/src/olympia/amo/models.py
@@ -191,7 +191,9 @@ class OnChangeMixin(object):
     def _reset_initial_attrs(self, attrs=None):
         if attrs is None:
             self._initial_attrs = {
-                k: v for k, v in self.__dict__.items() if k not in ('_state', '_initial_attrs')
+                k: v
+                for k, v in self.__dict__.items()
+                if k not in ('_state', '_initial_attrs')
             }
         else:
             self._initial_attrs.update(attrs)

--- a/src/olympia/amo/models.py
+++ b/src/olympia/amo/models.py
@@ -292,9 +292,14 @@ class OnChangeMixin(object):
         signal = kwargs.pop('_signal', True)
         result = super(OnChangeMixin, self).save(*args, **kwargs)
         if signal and self.__class__ in _on_change_callbacks:
-            self._send_changes(self._initial_attrs, dict(self.__dict__))
+            self._send_changes(self._initial_attrs.copy(), dict(self.__dict__))
         # Reset initial_attr to be ready for the next save.
-        self._reset_initial_attrs()
+        updated_fields = kwargs.get('update_fields')
+        self._reset_initial_attrs(
+            attrs={k: self.__dict__[k] for k in updated_fields}
+            if updated_fields
+            else None
+        )
         return result
 
     def update(self, **kwargs):

--- a/src/olympia/amo/models.py
+++ b/src/olympia/amo/models.py
@@ -270,7 +270,7 @@ class OnChangeMixin(object):
             kwargs['update_fields'] = list(
                 dict(
                     {(k, self.__dict__[k]) for k in initial_attrs}
-                    - set(initial_attrs)
+                    - set(initial_attrs.items())
                     # Never include primary key field - it might be set to None
                     # initially in initial_attr right after a call to create()
                     # even though self.pk is set.
@@ -296,6 +296,8 @@ class OnChangeMixin(object):
         result = super(OnChangeMixin, self).update(_signal=signal, **kwargs)
         if signal and self.__class__ in _on_change_callbacks:
             self._send_changes(old_attr, kwargs)
+        # Reset initial_attr to be ready for the next save.
+        self._initial_attr = dict(self.__dict__)
         return result
 
 

--- a/src/olympia/amo/models.py
+++ b/src/olympia/amo/models.py
@@ -279,11 +279,10 @@ class OnChangeMixin(object):
             concrete_initial_attrs = [
                 (k, v) for k, v in self._initial_attrs.items() if k in fields
             ]
-            current_attrs = [
-                (k, self.__dict__[k]) for k, v in concrete_initial_attrs
-            ]
+            current_attrs = [(k, self.__dict__[k]) for k, v in concrete_initial_attrs]
             changed_attrs = (
-                set(current_attrs) - set(concrete_initial_attrs)
+                set(current_attrs)
+                - set(concrete_initial_attrs)
                 # Never include primary key field - it might be set to None
                 # initially in _initial_attrs right after a call to create()
                 # even though self.pk is set.

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -733,13 +733,18 @@ def addon_factory(status=amo.STATUS_APPROVED, version_kw=None, file_kw=None, **k
 
     version = version_factory(file_kw, addon=addon, **version_kw)
     addon.update_version()
-    addon.status = status
     # version_changed task will be triggered and will update last_updated in
     # database for this add-on depending on the state of the version / files.
     # We're calling the function it uses to compute the value ourselves and=
     # sticking that into the attribute ourselves so that we already have the
     # correct value in the instance we are going to return.
+    # Note: the aim is to have the instance consistent with what will be in the
+    # database because of the task, *not* to be consistent with the status of
+    # the add-on. Because we force the add-on status without forcing the status
+    # of the latest file, the value we end up with might not make sense in some
+    # cases.
     addon.last_updated = compute_last_updated(addon)
+    addon.status = status
 
     for tag in tags:
         Tag(tag_text=tag).save_tag(addon)

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -51,7 +51,7 @@ from olympia.addons.models import (
 )
 from olympia.amo.urlresolvers import get_url_prefix, Prefixer, set_url_prefix
 from olympia.amo.storage_utils import copy_stored_file
-from olympia.addons.tasks import unindex_addons
+from olympia.addons.tasks import compute_last_updated, unindex_addons
 from olympia.applications.models import AppVersion
 from olympia.bandwagon.models import Collection
 from olympia.constants.categories import CATEGORIES
@@ -730,10 +730,16 @@ def addon_factory(status=amo.STATUS_APPROVED, version_kw=None, file_kw=None, **k
         PromotedAddon.objects.create(addon=addon, group_id=promoted_group.id)
         if 'promotion_approved' not in version_kw:
             version_kw['promotion_approved'] = True
-    version = version_factory(file_kw, addon=addon, **version_kw)
 
+    version = version_factory(file_kw, addon=addon, **version_kw)
     addon.update_version()
     addon.status = status
+    # version_changed task will be triggered and will update last_updated in
+    # database for this add-on depending on the state of the version / files.
+    # We're calling the function it uses to compute the value ourselves and=
+    # sticking that into the attribute ourselves so that we already have the
+    # correct value in the instance we are going to return.
+    addon.last_updated = compute_last_updated(addon)
 
     for tag in tags:
         Tag(tag_text=tag).save_tag(addon)
@@ -902,7 +908,7 @@ def version_factory(file_kw=None, **kw):
             kw['license'] = license_factory(**license_kw)
     promotion_approved = kw.pop('promotion_approved', False)
     ver = Version.objects.create(version=version_str, **kw)
-    ver.created = ver.last_updated = _get_created(kw.pop('created', 'now'))
+    ver.created = _get_created(kw.pop('created', 'now'))
     ver.save()
     if addon_type not in amo.NO_COMPAT:
         av_min, _ = AppVersion.objects.get_or_create(

--- a/src/olympia/devhub/forms.py
+++ b/src/olympia/devhub/forms.py
@@ -859,7 +859,7 @@ class SourceFileInput(forms.widgets.ClearableFileInput):
 class VersionForm(WithSourceMixin, forms.ModelForm):
     release_notes = TransField(widget=TransTextarea(), required=False)
     approval_notes = forms.CharField(
-        widget=TranslationTextarea(attrs={'rows': 4}), required=False
+        widget=forms.Textarea(attrs={'rows': 4}), required=False
     )
     source = forms.FileField(required=False, widget=SourceFileInput)
 

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -1059,8 +1059,12 @@ def watch_changes(old_attr=None, new_attr=None, instance=None, sender=None, **kw
     }
 
     # Log email changes.
-    if 'email' in changes and new_attr['email'] is not None:
-        log.info('Creating user history for user: %s' % instance.pk)
+    if (
+        'email' in changes
+        and new_attr['email'] is not None
+        and old_attr.get('email') is not None
+    ):
+        log.info('Creating user history for user: %s', instance.pk)
         UserHistory.objects.create(email=old_attr.get('email'), user_id=instance.pk)
     # If username or display_name changes, reindex the user add-ons, if there
     # are any.

--- a/src/olympia/versions/compare.py
+++ b/src/olympia/versions/compare.py
@@ -118,6 +118,8 @@ class VersionString(str):
     def __le__(self, other):
         return not self.__gt__(other)
 
+    __hash__ = str.__hash__
+
 
 def version_int(version):
     """This is used for converting an app version's version string into a


### PR DESCRIPTION
This avoids accidentally overwriting fields that have been modified in parallel

Fixes https://github.com/mozilla/addons-server/issues/16259