### PR TITLE
Show block buttons for admins regardless of add-on deleted state

### DIFF
--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -268,18 +268,6 @@
                   data-toggle-button-selector="#force_disable_addon"
                   id="force_enable_addon" class="toggle" type="button">{{ _('Force-enable add-on') }}</button>
         </li>
-        <li>
-        {% if addon.blocklistsubmission %}
-          <a href="{{ url('admin:blocklist_blocklistsubmission_change', addon.blocklistsubmission.id) }}" class="button"
-                  id="edit_addon_blocklistsubmission" type="button">{{ _('View Blocklist Submission') }}</a>
-        {% elif not addon.block %}
-          <a href="{{ url('admin:blocklist_block_addaddon', addon.pk) }}" class="button"
-                  id="block_addon" type="button">{{ _('Block add-on') }}</a>
-        {% else %}
-          <a href="{{ url('admin:blocklist_block_addaddon', addon.pk) }}" class="button"
-                  id="edit_addon_block" type="button">{{ _('Update add-on block') }}</a>
-        {% endif %}
-        </li>
 
         {% if addon.type in (amo.ADDON_EXTENSION, amo.ADDON_LPAPP, amo.ADDON_DICT) %}
           <li {% if addon.auto_approval_disabled %}class="hidden"{% endif %}>
@@ -356,6 +344,19 @@
           </li>
         {% endif %}
       {% endif %}
+
+      <li>
+        {% if addon.blocklistsubmission %}
+          <a href="{{ url('admin:blocklist_blocklistsubmission_change', addon.blocklistsubmission.id) }}" class="button"
+                  id="edit_addon_blocklistsubmission" type="button">{{ _('View Blocklist Submission') }}</a>
+        {% elif not addon.block %}
+          <a href="{{ url('admin:blocklist_block_addaddon', addon.pk) }}" class="button"
+                  id="block_addon" type="button">{{ _('Block add-on') }}</a>
+        {% else %}
+          <a href="{{ url('admin:blocklist_block_addaddon', addon.pk) }}" class="button"
+                  id="edit_addon_block" type="button">{{ _('Update add-on block') }}</a>
+        {% endif %}
+      </li>
     </ul>
     {% endif %} {# /is-admin #}
   </div>

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -4244,6 +4244,13 @@ class TestReview(ReviewBase):
             reverse('admin:blocklist_blocklistsubmission_change', args=(subm.id,))
         )
 
+    def test_admin_block_actions_deleted_addon(self):
+        # Use the id for the review page url because deleting the add-on will
+        # delete the slug as well.
+        self.url = reverse('reviewers.review', args=[self.addon.id])
+        self.addon.delete()
+        self.test_admin_block_actions()
+
     def test_unflag_option_forflagged_as_admin(self):
         self.login_as_admin()
         AddonReviewerFlags.objects.create(


### PR DESCRIPTION
Fix #16264.