### PR TITLE
Enable gzip middleware for everything again

### DIFF
--- a/src/olympia/amo/tests/test_middleware.py
+++ b/src/olympia/amo/tests/test_middleware.py
@@ -26,10 +26,10 @@ class TestMiddleware(TestCase):
         response = test.Client().get('/pages/appversions/')
         assert response['Vary'] == 'Accept-Language, User-Agent'
 
-        # No Vary after that (we should Vary on Cookie but avoid it for perf
-        # reasons).
+        # Only Vary on Accept-Encoding after that (because of gzip middleware).
+        # Crucially, we avoid Varying on Cookie.
         response = test.Client().get('/pages/appversions/', follow=True)
-        assert 'Vary' not in response
+        assert response['Vary'] == 'Accept-Encoding'
 
     @patch('django.contrib.auth.middleware.AuthenticationMiddleware.process_request')
     def test_authentication_used_outside_the_api(self, process_request):

--- a/src/olympia/api/middleware.py
+++ b/src/olympia/api/middleware.py
@@ -1,7 +1,6 @@
 import re
 
 from django.conf import settings
-from django.middleware.gzip import GZipMiddleware
 from django.utils.cache import patch_vary_headers
 from django.utils.deprecation import MiddlewareMixin
 
@@ -20,21 +19,3 @@ class APIRequestMiddleware(MiddlewareMixin):
 
     def process_exception(self, request, exception):
         self.identify_request(request)
-
-
-class GZipMiddlewareForAPIOnly(GZipMiddleware):
-    """
-    Wrapper around GZipMiddleware, which only enables gzip for API responses.
-    It specifically avoids enabling it for non-API responses because that might
-    leak security tokens through the BREACH attack.
-
-    https://www.djangoproject.com/weblog/2013/aug/06/breach-and-django/
-    http://breachattack.com/
-    https://bugzilla.mozilla.org/show_bug.cgi?id=960752
-    """
-
-    def process_response(self, request, response):
-        if not request.is_api:
-            return response
-
-        return super(GZipMiddlewareForAPIOnly, self).process_response(request, response)

--- a/src/olympia/api/tests/test_middleware.py
+++ b/src/olympia/api/tests/test_middleware.py
@@ -1,13 +1,9 @@
-import io
-
-from gzip import GzipFile
 from unittest import mock
 
-from django.conf import settings
 from django.http import HttpResponse
 
-from olympia.amo.tests import TestCase, addon_factory, reverse_ns
-from olympia.api.middleware import GZipMiddlewareForAPIOnly, APIRequestMiddleware
+from olympia.amo.tests import TestCase
+from olympia.api.middleware import APIRequestMiddleware
 
 
 class TestAPIRequestMiddleware(TestCase):
@@ -49,56 +45,3 @@ class TestAPIRequestMiddleware(TestCase):
         request.path = '/en-US/firefox/'
         APIRequestMiddleware().process_request(request)
         assert not request.is_api
-
-
-class TestGzipMiddleware(TestCase):
-    @mock.patch('django.middleware.gzip.GZipMiddleware.process_response')
-    def test_enabled_for_api(self, django_gzip_middleware):
-        """Test that we call the gzip middleware for API pages."""
-        request = mock.Mock()
-        request.is_api = True
-        GZipMiddlewareForAPIOnly().process_response(request, mock.Mock())
-        assert django_gzip_middleware.call_count == 1
-
-    @mock.patch('django.middleware.gzip.GZipMiddleware.process_response')
-    def test_disabled_for_the_rest(self, django_gzip_middleware):
-        """Test that we don't call gzip middleware for "regular" pages."""
-        request = mock.Mock()
-        request.is_api = False
-        GZipMiddlewareForAPIOnly().process_response(request, mock.Mock())
-        assert django_gzip_middleware.call_count == 0
-
-    def test_settings(self):
-        """Test that gzip middleware is near the top of the settings list."""
-        # Gzip middleware should be near the top of the list, so that it runs
-        # last in the process_response phase, in case the response body has
-        # been modified by another middleware.
-        assert (
-            settings.MIDDLEWARE[2] == 'olympia.api.middleware.GZipMiddlewareForAPIOnly'
-        )
-
-    def test_api_endpoint_gzipped(self):
-        """Test a simple API endpoint to make sure gzip is active there."""
-        addon = addon_factory()
-        url = reverse_ns('addon-detail', kwargs={'pk': addon.pk})
-        response = self.client.get(url)
-        assert response.status_code == 200
-        assert response.content
-        assert 'Content-Encoding' not in response
-
-        response_gzipped = self.client.get(
-            url,
-            HTTP_ACCEPT_ENCODING='gzip',
-            # Pretend that this happened over https, to test that this is still
-            # enabled even for https.
-            **{'wsgi.url_scheme': 'https'},
-        )
-        assert response_gzipped.status_code == 200
-        assert response_gzipped.content
-        assert response_gzipped['Content-Encoding'] == 'gzip'
-
-        assert len(response_gzipped.content) < len(response.content)
-        ungzipped_content = GzipFile(
-            '', 'r', 0, io.BytesIO(response_gzipped.content)
-        ).read()
-        assert ungzipped_content == response.content

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -403,9 +403,9 @@ MIDDLEWARE = (
     # Test if it's an API request first so later middlewares don't need to.
     # Also add relevant Vary header to API responses.
     'olympia.api.middleware.APIRequestMiddleware',
-    # Gzip (for API only) middleware needs to be executed after every
-    # modification to the response, so it's placed at the top of the list.
-    'olympia.api.middleware.GZipMiddlewareForAPIOnly',
+    # Gzip middleware needs to be executed after every modification to the
+    # response, so it's placed at the top of the list.
+    'django.middleware.gzip.GZipMiddleware',
     # Statsd and logging come first to get timings etc. Munging REMOTE_ADDR
     # must come before middlewares potentially using REMOTE_ADDR, so it's
     # also up there.
@@ -425,8 +425,8 @@ MIDDLEWARE = (
     'corsheaders.middleware.CorsMiddleware',
     # Enable conditional processing, e.g ETags.
     'django.middleware.http.ConditionalGetMiddleware',
-    'olympia.amo.middleware.CommonMiddleware',
     'olympia.amo.middleware.NoVarySessionMiddleware',
+    'olympia.amo.middleware.CommonMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'olympia.amo.middleware.AuthenticationMiddlewareWithoutAPI',
     # Our middleware that adds additional information for the user


### PR DESCRIPTION
This was previously disabled to mitigate [BREACH](https://en.wikipedia.org/wiki/BREACH) attacks. Nowadays we are using `SameSite=Lax` on all session/auth cookies (and `CSRF_USE_SESSIONS` is enabled) so it should be safe to re-enable gzip for everything.

Ref mozilla/addons#1217