### PR TITLE
Handle when `version` in manifest is not a string more gracefully

### DIFF
--- a/src/olympia/files/tests/test_utils.py
+++ b/src/olympia/files/tests/test_utils.py
@@ -527,10 +527,22 @@ class TestManifestJSONExtractor(AppVersionsMixin, TestCase):
     def test_version_not_string(self):
         """Test parsing doesn't fail if version is not a string - that error
         should be handled downstream by the linter."""
-        data = {
-            'version': 42
-        }
+        data = {'version': 42}
         assert self.parse(data)['version'] == '42'
+
+        data = {'version': 42.0}
+        assert self.parse(data)['version'] == '42.0'
+
+        # These are even worse, but what matters is that version stays a string
+        # in the result.
+        data = {'version': {}}
+        assert self.parse(data)['version'] == '{}'
+
+        data = {'version': []}
+        assert self.parse(data)['version'] == '[]'
+
+        data = {'version': None}
+        assert self.parse(data)['version'] == 'None'
 
 
 class TestLanguagePackAndDictionaries(AppVersionsMixin, TestCase):

--- a/src/olympia/files/tests/test_utils.py
+++ b/src/olympia/files/tests/test_utils.py
@@ -524,6 +524,14 @@ class TestManifestJSONExtractor(AppVersionsMixin, TestCase):
 
         assert parsed_data['devtools_page'] == 'devtools/my-page.html'
 
+    def test_version_not_string(self):
+        """Test parsing doesn't fail if version is not a string - that error
+        should be handled downstream by the linter."""
+        data = {
+            'version': 42
+        }
+        assert self.parse(data)['version'] == '42'
+
 
 class TestLanguagePackAndDictionaries(AppVersionsMixin, TestCase):
     def test_parse_langpack(self):

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -545,7 +545,7 @@ class ManifestJSONExtractor(object):
         data = {
             'guid': self.guid,
             'type': self.type,
-            'version': self.get('version', ''),
+            'version': str(self.get('version', '')),
             'is_webextension': True,
             'name': self.get('name'),
             'summary': self.get('description'),


### PR DESCRIPTION
The linter will handle the error, we just need not to fail on it we do some checks on the length of the value.

Fixes #16338