### PR TITLE
Don't install js deps using production mode, but rather prune afterwards

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -98,10 +98,11 @@ FXA_CONFIG = {'default': {}, 'internal': {}}\n"\
 RUN DJANGO_SETTINGS_MODULE='settings_local' locale/compile-mo.sh locale
 
 # compile asssets
-RUN npm install --production \
+RUN npm install \
     && make -f Makefile-docker copy_node_js \
     && DJANGO_SETTINGS_MODULE='settings_local' python manage.py compress_assets \
     && DJANGO_SETTINGS_MODULE='settings_local' python manage.py generate_jsi18n_files \
-    && DJANGO_SETTINGS_MODULE='settings_local' python manage.py collectstatic --noinput
+    && DJANGO_SETTINGS_MODULE='settings_local' python manage.py collectstatic --noinput \
+    && npm prune --production
 
 RUN rm -f settings_local.py settings_local.pyc


### PR DESCRIPTION
This is because we need dev dependencies like terser for building the assets - but once this is done, we don't need to keep the packages in `node_modules/`

Fixes https://github.com/mozilla/addons-server/issues/16344 again