### PR TITLE
Fix rating URL showing for non staff reviewers

### DIFF
--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -5637,8 +5637,7 @@ class TestReview(ReviewBase):
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
-        assert doc('.addon-rating strong')
-        assert doc('.addon-rating strong').text() == '1 review'
+        assert not doc('.addon-rating a')
 
     def test_user_ratings_unlisted_addon(self):
         user = UserProfile.objects.get(email='reviewer@mozilla.com')

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -6096,6 +6096,25 @@ class TestReview(ReviewBase):
 
         self.assertRedirects(response, self.url)
 
+    def test_review_moderator_addon_rating_read_only(self):
+        user = user_factory()
+        Rating.objects.create(
+            body='Lorem ipsum dolor',
+            rating=3,
+            ip_address='10.5.6.7',
+            addon=self.addon,
+            user=user,
+        )
+
+        self.grant_permission(self.reviewer, 'Rating:Modarate')
+        self.reviewer.update(email='reviewer@nonmozilla.com')
+
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        assert doc('.addon-rating strong')
+        assert doc('.addon-rating strong').text() == '1 review'
+
 
 class TestAbuseReportsView(ReviewerTest):
     def setUp(self):

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -5632,6 +5632,14 @@ class TestReview(ReviewBase):
         )
         assert doc('.addon-rating a').attr['href'] == rating_url
 
+        self.reviewer.update(email='reviewer@nonmozilla.com')
+
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        assert doc('.addon-rating strong')
+        assert doc('.addon-rating strong').text() == '1 review'
+
     def test_user_ratings_unlisted_addon(self):
         user = UserProfile.objects.get(email='reviewer@mozilla.com')
         self.grant_permission(user, 'Addons:ReviewUnlisted')
@@ -6095,25 +6103,6 @@ class TestReview(ReviewBase):
         )
 
         self.assertRedirects(response, self.url)
-
-    def test_review_moderator_addon_rating_read_only(self):
-        user = user_factory()
-        Rating.objects.create(
-            body='Lorem ipsum dolor',
-            rating=3,
-            ip_address='10.5.6.7',
-            addon=self.addon,
-            user=user,
-        )
-
-        self.grant_permission(self.reviewer, 'Rating:Modarate')
-        self.reviewer.update(email='reviewer@nonmozilla.com')
-
-        response = self.client.get(self.url)
-        assert response.status_code == 200
-        doc = pq(response.content)
-        assert doc('.addon-rating strong')
-        assert doc('.addon-rating strong').text() == '1 review'
 
 
 class TestAbuseReportsView(ReviewerTest):

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -985,8 +985,9 @@ def review(request, addon, channel=None):
         # Used for reviewer subscription check, don't use global `is_reviewer`
         # since that actually is `is_user_any_kind_of_reviewer`.
         acl_is_reviewer=acl.is_reviewer(request, addon),
-        acl_is_review_moderator=acl.action_allowed(
-            request, amo.permissions.RATINGS_MODERATE
+        acl_is_review_moderator=(
+            acl.action_allowed(request, amo.permissions.RATINGS_MODERATE)
+            and request.user.is_staff
         ),
         actions=actions,
         actions_comments=actions_comments,


### PR DESCRIPTION
Fixes #15930

The ```acl_is_review_moderator``` value now checks if the user is of the staff(have a Mozilla e-mail address).