### PR TITLE
change discovery api l10n fields to have a consistent default

### DIFF
--- a/docs/topics/api/discovery.rst
+++ b/docs/topics/api/discovery.rst
@@ -38,7 +38,7 @@ Firefox (about:addons).
     :query string telemetry-client-id: Optional sha256 hash of the telemetry client ID to be passed to the TAAR service to enable recommendations. Must be the hex value of a sha256 hash, otherwise it will be ignored.
     :>json int count: The number of results for this query.
     :>json array results: The array containing the results for this query.
-    :>json object|null results[].description_text: The description for this item, if any. (See :ref:`translated fields <api-overview-translations>`.  Note: even when ``lang`` is not specified, a maximum of one locale will be returned).
+    :>json object|null results[].description_text: The description for this item, if any. (See :ref:`translated fields <api-overview-translations>`.  Note: when ``lang`` is not specified, not all locales will be returned, unlike other translated fields).
     :>json boolean results[].is_recommendation: If this item was from the recommendation service, rather than static curated content.
     :>json object results[].addon: The :ref:`add-on <addon-detail-object>` for this item. Only a subset of fields are present: ``id``, ``authors``, ``average_daily_users``, ``current_version`` (with only the ``id``, ``compatibility``, ``is_strict_compatibility_enabled`` and ``files`` fields present), ``guid``, ``icon_url``, ``name``, ``ratings``, ``previews``, ``slug``, ``theme_data``, ``type`` and ``url``.
 

--- a/src/olympia/api/fields.py
+++ b/src/olympia/api/fields.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.utils.encoding import smart_str
-from django.utils.translation import get_language, gettext, gettext_lazy as _
+from django.utils.translation import get_language, gettext, gettext_lazy as _, override
 
 from rest_framework import fields, serializers
 
@@ -402,27 +402,48 @@ class GetTextTranslationSerializerField(TranslationSerializerField):
     """A TranslationSerializerField that gets it's translations from .po files via
     gettext rather than the database with TranslatedField."""
 
+    def _fetch_some_translations(self, field, langs):
+        if not field:
+            return {}
+        base_locale = to_language(settings.LANGUAGE_CODE)
+        translations = {}
+        if base_locale in langs:
+            # we get the base_locale for free - it's just the field text
+            translations[base_locale] = str(field)
+            langs = (lang for lang in langs if lang != base_locale)
+        for lang in langs:
+            with override(lang):
+                value = gettext(field)
+                if value not in translations.values():
+                    translations[lang] = value
+        return translations
+
     def fetch_all_translations(self, obj, source, field):
-        # TODO: iterate through all/subset of locales to actually get all translations?
-        # gettext will try to get the translation in the current locale
-        value = gettext(field) if field else field
-        base_language = to_language(settings.LANGUAGE_CODE)
-        current_language = to_language(get_language())
-        if base_language == current_language or value == field:
-            return {base_language: value}
-        else:
-            # if the current locale differs from en-US return the base language too
-            return {base_language: str(field), current_language: value}
+        # TODO: get all locales or KEY_LOCALES_FOR_EDITORIAL_CONTENT at least?
+        base_locale = to_language(settings.LANGUAGE_CODE)
+        current_locale = to_language(get_language())
+        default_locale = obj.default_locale
+
+        return self._fetch_some_translations(
+            field, {base_locale, current_locale, default_locale}
+        )
 
     def fetch_single_translation(self, obj, source, field, requested_language):
-        value = gettext(field) if field else field
-        base_language = to_language(settings.LANGUAGE_CODE)
-        requested_language = to_language(requested_language)
-        if not value or requested_language == base_language or value != field:
-            actual_language = requested_language
-        else:
-            # we've fallen back to the locale the content was entered in
-            actual_language = base_language
+        base_locale = to_language(settings.LANGUAGE_CODE)
+        default_locale = obj.default_locale
+
+        translations = self._fetch_some_translations(
+            field, {base_locale, requested_language, default_locale}
+        )
+        actual_language = (
+            requested_language
+            if requested_language in translations
+            else default_locale
+            if default_locale in translations
+            else base_locale
+        )
+
+        value = translations.get(actual_language)
 
         return self._format_single_translation_response(
             value,

--- a/src/olympia/discovery/models.py
+++ b/src/olympia/discovery/models.py
@@ -54,3 +54,7 @@ class DiscoveryItem(OnChangeMixin, ModelBase):
     @property
     def should_fallback_to_addon_summary(self):
         return bool(self.addon.type == amo.ADDON_EXTENSION and self.addon.summary)
+
+    @property
+    def default_locale(self):
+        return self.addon.default_locale

--- a/src/olympia/discovery/serializers.py
+++ b/src/olympia/discovery/serializers.py
@@ -1,6 +1,5 @@
-from django.conf import settings
 from django.utils.html import format_html
-from django.utils.translation import gettext
+from django.utils.translation import get_language, gettext
 
 from rest_framework import serializers
 
@@ -79,12 +78,12 @@ class FieldAlwaysFlatWhenFlatGateActiveMixin:
 
     def get_requested_language(self):
         # For l10n_flat_input_output, if the request didn't specify a `lang=xx` then
-        # fake it as `lang=en-US` so we get a single (flat) result.
+        # fake it with the system language so we get a single (flat) result.
         requested = super().get_requested_language()
         if not requested:
             request = self.context.get('request', None)
             if is_gate_active(request, 'l10n_flat_input_output'):
-                requested = settings.LANGUAGE_CODE
+                requested = get_language()
         return requested
 
     def get_attribute(self, obj):

--- a/src/olympia/discovery/serializers.py
+++ b/src/olympia/discovery/serializers.py
@@ -78,7 +78,7 @@ class FieldAlwaysFlatWhenFlatGateActiveMixin:
 
     def get_requested_language(self):
         # For l10n_flat_input_output, if the request didn't specify a `lang=xx` then
-        # fake it with the system language so we get a single (flat) result.
+        # fake it with the current locale so we get a single (flat) result.
         requested = super().get_requested_language()
         if not requested:
             request = self.context.get('request', None)

--- a/src/olympia/discovery/tests/test_serializers.py
+++ b/src/olympia/discovery/tests/test_serializers.py
@@ -1,5 +1,6 @@
 from django.test.utils import override_settings
 
+import pytest
 from rest_framework.test import APIRequestFactory
 
 from olympia import amo
@@ -15,27 +16,69 @@ class TestDiscoverySerializer(TestCase):
         request.version = 'v5'
         return DiscoverySerializer(context={'request': request}).to_representation(item)
 
-    def test_description_text_custom(self):
+    @pytest.mark.needs_locales_compilation
+    def test_custom_description_text_no_lang(self):
         addon = addon_factory(summary='Foo', description='Bar')
-        item = DiscoveryItem.objects.create(
-            addon=addon, custom_description='Custôm Desc.'
+        custom_desc_en = (
+            # this is predefined in strings.jinja2 (and localized already)
+            'Block invisible trackers and spying ads that follow you around the web.'
         )
-        assert self.serialize(item)['description_text'] == {'en-US': 'Custôm Desc.'}
+        custom_desc_fr = (
+            'Bloquez les traqueurs invisibles et les publicités espionnes qui vous '
+            'suivent sur le Web.'
+        )
+        item = DiscoveryItem.objects.create(
+            addon=addon, custom_description=custom_desc_en
+        )
+        assert self.serialize(item)['description_text'] == {'en-US': custom_desc_en}
         with override_settings(DRF_API_GATES={'v5': ('l10n_flat_input_output',)}):
-            assert self.serialize(item)['description_text'] == 'Custôm Desc.'
+            assert self.serialize(item)['description_text'] == custom_desc_en
 
-        # and repeat with a lang specified
+        # repeat for the edge case when we have a different system language than en-US
+        with self.activate('fr'):
+            item.reload()
+            assert self.serialize(item)['description_text'] == {
+                'en-US': custom_desc_en,
+                'fr': custom_desc_fr,
+            }
+            with override_settings(DRF_API_GATES={'v5': ('l10n_flat_input_output',)}):
+                assert self.serialize(item)['description_text'] == custom_desc_fr
+
+    @pytest.mark.needs_locales_compilation
+    def test_custom_description_text_lang_specified(self):
+        addon = addon_factory(summary='Foo', description='Bar')
+        custom_desc_en = (
+            # this is predefined in strings.jinja2 (and localized already)
+            'Block invisible trackers and spying ads that follow you around the web.'
+        )
+        custom_desc_fr = (
+            'Bloquez les traqueurs invisibles et les publicités espionnes qui vous '
+            'suivent sur le Web.'
+        )
+        item = DiscoveryItem.objects.create(
+            addon=addon, custom_description=custom_desc_en
+        )
+        # we have l10n for fr
         with self.activate('fr'):
             item.reload()
             assert self.serialize(item, 'fr')['description_text'] == {
-                'en-US': 'Custôm Desc.',
-                'fr': None,
+                'fr': custom_desc_fr,
+            }
+            with override_settings(DRF_API_GATES={'v5': ('l10n_flat_input_output',)}):
+                assert self.serialize(item, 'fr')['description_text'] == custom_desc_fr
+
+        # but we don't for az
+        with self.activate('az'):
+            item.reload()
+            assert self.serialize(item, 'az')['description_text'] == {
+                'en-US': custom_desc_en,
+                'az': None,
                 '_default': 'en-US',
             }
             with override_settings(DRF_API_GATES={'v5': ('l10n_flat_input_output',)}):
-                assert self.serialize(item, 'fr')['description_text'] == 'Custôm Desc.'
+                assert self.serialize(item, 'az')['description_text'] == custom_desc_en
 
-    def test_description_text_custom_empty(self):
+    def test_description_text_empty(self):
         addon = addon_factory(summary='')
         item = DiscoveryItem.objects.create(addon=addon)
         assert self.serialize(item)['description_text'] is None
@@ -48,7 +91,7 @@ class TestDiscoverySerializer(TestCase):
             with override_settings(DRF_API_GATES={'v5': ('l10n_flat_input_output',)}):
                 assert self.serialize(item, 'fr')['description_text'] == ''
 
-    def test_description_text_custom_extension(self):
+    def test_no_custom_description_text_extension(self):
         addon = addon_factory(summary='Mÿ Summary')
         # Add a summary in fr too
         Translation.objects.create(
@@ -83,7 +126,7 @@ class TestDiscoverySerializer(TestCase):
             with override_settings(DRF_API_GATES={'v5': ('l10n_flat_input_output',)}):
                 assert self.serialize(item, 'fr')['description_text'] == 'Mes Summáry'
 
-    def test_description_text_custom_not_extension(self):
+    def test_no_custom_description_text_not_extension(self):
         item = DiscoveryItem.objects.create(addon=addon_factory(type=amo.ADDON_DICT))
         assert self.serialize(item)['description_text'] is None
         with override_settings(DRF_API_GATES={'v5': ('l10n_flat_input_output',)}):


### PR DESCRIPTION
fixes #16438 -

tbh still not sure how many locales we want to retrieve when no `lang` parameter is specified, but the code is generic enough now to support loading as many as we want (at the extreme, it could be all of `settings.LANGUAGES`).  Currently it's just `en-US` (that we get for free); the current locale (that will have already been loaded); and the addon default locale.