### PR TITLE
return grouped ratings with addon detail api

### DIFF
--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -136,6 +136,7 @@ This endpoint allows you to fetch a specific add-on by id, slug or guid.
     :query string app: Used in conjunction with ``appversion`` below to alter ``current_version`` behaviour. Need to be a valid :ref:`add-on application <addon-detail-application>`.
     :query string appversion: Make ``current_version`` return the latest public version of the add-on compatible with the given application version, if possible, otherwise fall back on the generic implementation. Pass the full version as a string, e.g. ``46.0``. Only valid when the ``app`` parameter is also present. Currently only compatible with language packs through the add-on detail API, ignored for other types of add-ons and APIs.
     :query string lang: Activate translations in the specific language for that query. (See :ref:`Translated Fields <api-overview-translations>`)
+    :query boolean show_grouped_ratings: Whether or not to show ratings aggregates in the ``ratings`` object (Use "true"/"1" as truthy values, "0"/"false" as falsy ones).
     :>json int id: The add-on id on AMO.
     :>json array authors: Array holding information about the authors for the add-on.
     :>json int authors[].id: The id for an author.
@@ -181,6 +182,12 @@ This endpoint allows you to fetch a specific add-on by id, slug or guid.
     :>json string ratings_url: The URL to the user ratings list page for the add-on.
     :>json float ratings.average: The average user rating for the add-on.
     :>json float ratings.bayesian_average: The bayesian average user rating for the add-on.
+    :>json object ratings.grouped_counts: Object with aggregate counts for ratings.  Only included when ``show_grouped_ratings`` is present in the request.
+    :>json int ratings.grouped_counts.1: the count of ratings with a score of 1.
+    :>json int ratings.grouped_counts.2: the count of ratings with a score of 2.
+    :>json int ratings.grouped_counts.3: the count of ratings with a score of 3.
+    :>json int ratings.grouped_counts.4: the count of ratings with a score of 4.
+    :>json int ratings.grouped_counts.5: the count of ratings with a score of 5.
     :>json boolean requires_payment: Does the add-on require payment, non-free services or software, or additional hardware.
     :>json string review_url: The URL to the reviewer review page for the add-on.
     :>json string slug: The add-on slug.

--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -410,6 +410,7 @@ These are `v5` specific changes - `v4` changes apply also.
 * 2021-01-28: made ``description_text`` in discovery endpoint a translated field in the response. (It was always localized, we just didn't return it as such). https://github.com/mozilla/addons-server/issues/8712
 * 2021-02-04: dropped /shelves/sponsored endpoint https://github.com/mozilla/addons-server/issues/16390
 * 2021-02-11: removed Stripe webhook endpoint https://github.com/mozilla/addons-server/issues/16391
+* 2021-02-11: added ``show_grouped_ratings`` to addon detail endpoint. https://github.com/mozilla/addons-server/issues/16459
 
 .. _`#11380`: https://github.com/mozilla/addons-server/issues/11380/
 .. _`#11379`: https://github.com/mozilla/addons-server/issues/11379/

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -644,6 +644,24 @@ class TestAddonViewSetDetail(AddonAndVersionViewSetDetailMixin, TestCase):
         data = json.loads(force_str(response.content))
         assert data == {'detail': 'Invalid "app" parameter.'}
 
+    def test_with_grouped_ratings(self):
+        assert 'grouped_counts' not in self.client.get(self.url).json()['ratings']
+
+        response = self.client.get(self.url, {'show_grouped_ratings': 'true'})
+        assert 'grouped_counts' in response.json()['ratings']
+        assert response.json()['ratings']['grouped_counts'] == {
+            '1': 0,
+            '2': 0,
+            '3': 0,
+            '4': 0,
+            '5': 0,
+        }
+
+        response = self.client.get(self.url, {'show_grouped_ratings': '58.0'})
+        assert response.status_code == 400
+        data = json.loads(force_str(response.content))
+        assert data == {'detail': 'show_grouped_ratings parameter should be a boolean'}
+
 
 class TestVersionViewSetDetail(AddonAndVersionViewSetDetailMixin, TestCase):
     client_class = APITestClient

--- a/src/olympia/ratings/utils.py
+++ b/src/olympia/ratings/utils.py
@@ -1,0 +1,16 @@
+from rest_framework import serializers
+from rest_framework.exceptions import ParseError
+
+from .models import GroupedRating
+
+
+def get_grouped_ratings(request, addon):
+    if 'show_grouped_ratings' in request.GET:
+        try:
+            show_grouped_ratings = serializers.BooleanField().to_internal_value(
+                request.GET['show_grouped_ratings']
+            )
+        except serializers.ValidationError:
+            raise ParseError('show_grouped_ratings parameter should be a boolean')
+        if show_grouped_ratings and addon:
+            return dict(GroupedRating.get(addon.id))


### PR DESCRIPTION
fixes #16459 - uses the exact same method as the ratings list api does currently.  Filed #16467 to consider an alternative.