### PR TITLE
workaround Response._headers going away; enable amo-lib-locales-and-signing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -661,39 +661,39 @@ workflows:
             parameters:
               djangoversion:
                 - django22
-#                - django32 # django3.2 tests still failing    
+                - django32
       - assets:
           matrix:
             parameters:
               djangoversion:
                 - django22
-                - django32      
+                - django32
       - codestyle
       - devhub:
           matrix:
             parameters:
               djangoversion:
                 - django22
-#                - django32 # django3.2 tests still failing     
+#                - django32 # django3.2 tests still failing
       - docs
       - main:
           matrix:
             parameters:
               djangoversion:
                 - django22
-#                - django32 # django3.2 tests still failing         
+#                - django32 # django3.2 tests still failing
       - reviewers-and-zadmin:
           matrix:
             parameters:
               djangoversion:
                 - django22
-                - django32      
+                - django32
       - es-tests:
           matrix:
             parameters:
               djangoversion:
                 - django22
-#                - django32 # django3.2 tests still failing          
+#                - django32 # django3.2 tests still failing
       - release-master:
           filters:
             branches:

--- a/src/olympia/amo/tests/test_amo_utils.py
+++ b/src/olympia/amo/tests/test_amo_utils.py
@@ -8,7 +8,7 @@ from django.core.validators import ValidationError
 from unittest import mock
 import pytest
 
-from olympia.amo.tests import DQUOTE_ESCAPED, TestCase
+from olympia.amo.tests import TestCase
 from olympia.amo.utils import (
     LocalFileStorage,
     cache_ns_key,
@@ -278,7 +278,7 @@ def test_no_jinja_autoescape():
     tpl = '{{ val }}'
     ctx = {'val': val}
     template = from_string(tpl)
-    assert template.render(ctx) == f'some double quote: {DQUOTE_ESCAPED} and a &lt;'
+    assert template.render(ctx) == 'some double quote: &#34; and a &lt;'
     with no_jinja_autoescape():
         template = from_string(tpl)
         assert template.render(ctx) == 'some double quote: " and a <'

--- a/src/olympia/amo/tests/test_views.py
+++ b/src/olympia/amo/tests/test_views.py
@@ -11,7 +11,6 @@ from django import test
 from django.conf import settings
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
-from django.utils.encoding import force_str
 
 import pytest
 
@@ -341,12 +340,11 @@ class TestOtherStuff(TestCase):
 
     def test_opensearch(self):
         client = test.Client()
-        page = client.get('/en-US/firefox/opensearch.xml')
+        result = client.get('/en-US/firefox/opensearch.xml')
 
-        wanted = ('Content-Type', 'text/xml')
-        assert page._headers['content-type'] == wanted
+        assert result.get('Content-Type') == 'text/xml'
 
-        doc = etree.fromstring(page.content)
+        doc = etree.fromstring(result.content)
         e = doc.find('{http://a9.com/-/spec/opensearch/1.1/}ShortName')
         assert e.text == 'Firefox Add-ons'
 
@@ -391,9 +389,9 @@ class TestCORS(TestCase):
 
 class TestContribute(TestCase):
     def test_contribute_json(self):
-        res = self.client.get('/contribute.json')
-        assert res.status_code == 200
-        assert res._headers['content-type'] == ('Content-Type', 'application/json')
+        result = self.client.get('/contribute.json')
+        assert result.status_code == 200
+        assert result.get('Content-Type') == 'application/json'
 
 
 class TestRobots(TestCase):
@@ -492,10 +490,10 @@ class TestAtomicRequests(WithDynamicEndpointsAndTransactions):
 
 class TestVersion(TestCase):
     def test_version_json(self):
-        res = self.client.get('/__version__')
-        assert res.status_code == 200
-        assert res._headers['content-type'] == ('Content-Type', 'application/json')
-        content = json.loads(force_str(res.content))
+        result = self.client.get('/__version__')
+        assert result.status_code == 200
+        assert result.get('Content-Type') == 'application/json'
+        content = result.json()
         assert content['python'] == '%s.%s' % (
             sys.version_info.major,
             sys.version_info.minor,


### PR DESCRIPTION
part of #16405 - some more test fixes so we can enable amo-lib-locales-and-signing CI job too