### PR TITLE
Add scanner action that adds restrictions on top of delaying auto-approval

### DIFF
--- a/src/olympia/amo/cron.py
+++ b/src/olympia/amo/cron.py
@@ -43,18 +43,18 @@ def gc(test_result=True):
     for chunk in chunked(collections_to_delete, 100):
         tasks.delete_anonymous_collections.delay(chunk)
 
-    a_week_ago = days_ago(7)
+    two_weeks_ago = days_ago(15)
     # Delete stale add-ons with no versions. Should soft-delete add-ons that
     # are somehow not in incomplete status, hard-delete the rest. No email
     # should be sent in either case.
     versionless_addons = Addon.objects.filter(
-        versions__pk=None, created__lte=a_week_ago
+        versions__pk=None, created__lte=two_weeks_ago
     ).values_list('pk', flat=True)
     for chunk in chunked(versionless_addons, 100):
         delete_addons.delay(chunk)
 
     # Delete stale FileUploads.
-    stale_uploads = FileUpload.objects.filter(created__lte=a_week_ago).order_by('id')
+    stale_uploads = FileUpload.objects.filter(created__lte=two_weeks_ago).order_by('id')
     for file_upload in stale_uploads:
         log.info(
             '[FileUpload:{uuid}] Removing file: {path}'.format(

--- a/src/olympia/amo/tests/test_cron.py
+++ b/src/olympia/amo/tests/test_cron.py
@@ -17,7 +17,7 @@ class TestGC(TestCase):
         fu_new = FileUpload.objects.create(path='/tmp/new', name='new')
         fu_new.update(created=self.days_ago(6))
         fu_old = FileUpload.objects.create(path='/tmp/old', name='old')
-        fu_old.update(created=self.days_ago(8))
+        fu_old.update(created=self.days_ago(16))
 
         gc()
 
@@ -27,7 +27,7 @@ class TestGC(TestCase):
 
     def test_file_uploads_deletion_no_path_somehow(self, storage_mock):
         fu_old = FileUpload.objects.create(path='', name='foo')
-        fu_old.update(created=self.days_ago(8))
+        fu_old.update(created=self.days_ago(16))
 
         gc()
 
@@ -38,7 +38,7 @@ class TestGC(TestCase):
         fu_older = FileUpload.objects.create(path='/tmp/older', name='older')
         fu_older.update(created=self.days_ago(300))
         fu_old = FileUpload.objects.create(path='/tmp/old', name='old')
-        fu_old.update(created=self.days_ago(8))
+        fu_old.update(created=self.days_ago(16))
 
         storage_mock.delete.side_effect = OSError
 
@@ -54,7 +54,7 @@ class TestGC(TestCase):
 
     def test_scanner_results_deletion(self, storage_mock):
         old_upload = FileUpload.objects.create(path='/tmp/old', name='old')
-        old_upload.update(created=self.days_ago(8))
+        old_upload.update(created=self.days_ago(16))
 
         new_upload = FileUpload.objects.create(path='/tmp/new', name='new')
         new_upload.update(created=self.days_ago(6))
@@ -81,7 +81,7 @@ class TestGC(TestCase):
         assert storage_mock.delete.call_count == 1
 
     def test_stale_addons_deletion(self, storage_mock):
-        in_the_past = self.days_ago(8)
+        in_the_past = self.days_ago(16)
         to_delete = [
             Addon.objects.create(),
             Addon.objects.create(status=amo.STATUS_NULL),

--- a/src/olympia/constants/scanners.py
+++ b/src/olympia/constants/scanners.py
@@ -14,12 +14,14 @@ NO_ACTION = 1
 FLAG_FOR_HUMAN_REVIEW = 20
 DELAY_AUTO_APPROVAL = 100
 DELAY_AUTO_APPROVAL_INDEFINITELY = 200
+DELAY_AUTO_APPROVAL_INDEFINITELY_AND_RESTRICT = 300
 
 ACTIONS = {
     NO_ACTION: _('No action'),
     FLAG_FOR_HUMAN_REVIEW: _('Flag for human review'),
     DELAY_AUTO_APPROVAL: _('Delay auto-approval'),
     DELAY_AUTO_APPROVAL_INDEFINITELY: _('Delay auto-approval indefinitely'),
+    DELAY_AUTO_APPROVAL_INDEFINITELY_AND_RESTRICT: _('Delay auto-approval indefinitely and add restrictions'),
 }
 
 UNKNOWN = None

--- a/src/olympia/constants/scanners.py
+++ b/src/olympia/constants/scanners.py
@@ -21,7 +21,9 @@ ACTIONS = {
     FLAG_FOR_HUMAN_REVIEW: _('Flag for human review'),
     DELAY_AUTO_APPROVAL: _('Delay auto-approval'),
     DELAY_AUTO_APPROVAL_INDEFINITELY: _('Delay auto-approval indefinitely'),
-    DELAY_AUTO_APPROVAL_INDEFINITELY_AND_RESTRICT: _('Delay auto-approval indefinitely and add restrictions'),
+    DELAY_AUTO_APPROVAL_INDEFINITELY_AND_RESTRICT: _(
+        'Delay auto-approval indefinitely and add restrictions'
+    ),
 }
 
 UNKNOWN = None

--- a/src/olympia/scanners/models.py
+++ b/src/olympia/scanners/models.py
@@ -191,7 +191,9 @@ class AbstractScannerResult(ModelBase):
             FLAG_FOR_HUMAN_REVIEW: _flag_for_human_review,
             DELAY_AUTO_APPROVAL: _delay_auto_approval,
             DELAY_AUTO_APPROVAL_INDEFINITELY: _delay_auto_approval_indefinitely,
-            DELAY_AUTO_APPROVAL_INDEFINITELY_AND_RESTRICT: _delay_auto_approval_indefinitely_and_restrict,
+            DELAY_AUTO_APPROVAL_INDEFINITELY_AND_RESTRICT: (
+                _delay_auto_approval_indefinitely_and_restrict
+            ),
         }
 
         action_function = ACTION_FUNCTIONS.get(action_id, None)

--- a/src/olympia/scanners/models.py
+++ b/src/olympia/scanners/models.py
@@ -23,6 +23,7 @@ from olympia.constants.scanners import (
     CUSTOMS,
     DELAY_AUTO_APPROVAL,
     DELAY_AUTO_APPROVAL_INDEFINITELY,
+    DELAY_AUTO_APPROVAL_INDEFINITELY_AND_RESTRICT,
     FLAG_FOR_HUMAN_REVIEW,
     QUERY_RULE_STATES,
     MAD,
@@ -40,6 +41,7 @@ from olympia.files.models import FileUpload
 from olympia.scanners.actions import (
     _delay_auto_approval,
     _delay_auto_approval_indefinitely,
+    _delay_auto_approval_indefinitely_and_restrict,
     _flag_for_human_review,
     _flag_for_human_review_by_scanner,
     _no_action,
@@ -188,7 +190,8 @@ class AbstractScannerResult(ModelBase):
             NO_ACTION: _no_action,
             FLAG_FOR_HUMAN_REVIEW: _flag_for_human_review,
             DELAY_AUTO_APPROVAL: _delay_auto_approval,
-            DELAY_AUTO_APPROVAL_INDEFINITELY: (_delay_auto_approval_indefinitely),
+            DELAY_AUTO_APPROVAL_INDEFINITELY: _delay_auto_approval_indefinitely,
+            DELAY_AUTO_APPROVAL_INDEFINITELY_AND_RESTRICT: _delay_auto_approval_indefinitely_and_restrict,
         }
 
         action_function = ACTION_FUNCTIONS.get(action_id, None)

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -241,9 +241,7 @@ class Version(OnChangeMixin, ModelBase):
             )
 
         if upload.addon and upload.addon != addon:
-            raise VersionCreateError(
-                'FileUpload was made for a different Addon'
-            )
+            raise VersionCreateError('FileUpload was made for a different Addon')
 
         license_id = None
         if channel == amo.RELEASE_CHANNEL_LISTED:


### PR DESCRIPTION
Contains a couple changes that go with that:
- Keep stale add-ons and fileuploads for a little while longer
- Prevent using `FileUpload` belonging to another add-on to create a `Version`
- Link the `FileUpload` to the `Addon` after creating a Version (if none was set)

Fixes https://github.com/mozilla/addons-server/issues/16504