### PR TITLE
Move hard-deletion tasks to adhoc queue

### DIFF
--- a/src/olympia/addons/management/commands/process_addons.py
+++ b/src/olympia/addons/management/commands/process_addons.py
@@ -140,6 +140,7 @@ tasks = {
                 .filter(files__is_webextension=True)
             )
         ],
+        'distinct': True,
     },
     'hard_delete_legacy_versions': {
         'method': hard_delete_legacy_versions,

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1099,8 +1099,6 @@ CELERY_TASK_ROUTES = {
     'olympia.addons.tasks.delete_preview_files': {'queue': 'addons'},
     'olympia.addons.tasks.version_changed': {'queue': 'addons'},
     'olympia.addons.tasks.create_custom_icon_from_predefined': {'queue': 'addons'},
-    'olympia.addons.tasks.hard_delete_extra_files': {'queue': 'addons'},
-    'olympia.addons.tasks.hard_delete_legacy_versions': {'queue': 'addons'},
     'olympia.files.tasks.hide_disabled_files': {'queue': 'addons'},
     'olympia.versions.tasks.delete_preview_files': {'queue': 'addons'},
     'olympia.git.tasks.continue_git_extraction': {'queue': 'addons'},
@@ -1115,6 +1113,8 @@ CELERY_TASK_ROUTES = {
     'olympia.addons.tasks.recreate_theme_previews': {'queue': 'addons'},
     # Adhoc
     # A queue to be used for one-off tasks that could be resource intensive.
+    'olympia.addons.tasks.hard_delete_extra_files': {'queue': 'adhoc'},
+    'olympia.addons.tasks.hard_delete_legacy_versions': {'queue': 'adhoc'},
     'olympia.files.tasks.extract_optional_permissions': {'queue': 'adhoc'},
     # Crons
     'olympia.addons.tasks.update_addon_average_daily_users': {'queue': 'cron'},


### PR DESCRIPTION
Also ensure `hard_delete_extra_files` uses `distinct()` to avoid pointlessly going over the same add-on multiple times.

Fixes #16530