### PR TITLE
Allow clients to cache non-authenticated API responses for 3 minutes

### DIFF
--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -1563,6 +1563,7 @@ class TestAccountViewSetDelete(TestCase):
             response.cookies[settings.SESSION_COOKIE_NAME].get('samesite')
             == settings.SESSION_COOKIE_SAMESITE
         )
+        assert 'Cache-Control' not in response
         assert 'dontremoveme' not in response.cookies
         assert self.client.cookies[views.API_TOKEN_COOKIE].value == ''
         assert self.client.cookies[settings.SESSION_COOKIE_NAME].value == ''

--- a/src/olympia/api/middleware.py
+++ b/src/olympia/api/middleware.py
@@ -40,5 +40,5 @@ class APICacheControlMiddleware:
             and get_max_age(response) is None
         )
         if request_conditions and response_conditions:
-            patch_cache_control(response, max_age=3 * 60)
+            patch_cache_control(response, max_age=settings.API_CACHE_DURATION)
         return response

--- a/src/olympia/api/middleware.py
+++ b/src/olympia/api/middleware.py
@@ -1,7 +1,7 @@
 import re
 
 from django.conf import settings
-from django.utils.cache import patch_vary_headers
+from django.utils.cache import get_max_age, patch_cache_control, patch_vary_headers
 from django.utils.deprecation import MiddlewareMixin
 
 
@@ -19,3 +19,25 @@ class APIRequestMiddleware(MiddlewareMixin):
 
     def process_exception(self, request, exception):
         self.identify_request(request)
+
+
+class APICacheControlMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        request_conditions = (
+            request.is_api
+            and request.method in ('GET', 'HEAD')
+            and 'HTTP_AUTHORIZATION' not in request.META
+            and 'disable_caching' not in request.GET
+        )
+        response_conditions = (
+            not response.cookies
+            and response.status_code >= 200 and response.status_code < 400
+            and get_max_age(response) is None
+        )
+        if request_conditions and response_conditions:
+            patch_cache_control(response, max_age=3 * 60)
+        return response

--- a/src/olympia/api/middleware.py
+++ b/src/olympia/api/middleware.py
@@ -35,7 +35,8 @@ class APICacheControlMiddleware:
         )
         response_conditions = (
             not response.cookies
-            and response.status_code >= 200 and response.status_code < 400
+            and response.status_code >= 200
+            and response.status_code < 400
             and get_max_age(response) is None
         )
         if request_conditions and response_conditions:

--- a/src/olympia/api/tests/test_middleware.py
+++ b/src/olympia/api/tests/test_middleware.py
@@ -1,20 +1,21 @@
-from unittest import mock
-
 from django.http import HttpResponse
+from django.test.client import RequestFactory
 
-from olympia.amo.tests import TestCase
-from olympia.api.middleware import APIRequestMiddleware
+from olympia.amo.tests import reverse_ns, TestCase
+from olympia.api.middleware import APICacheControlMiddleware, APIRequestMiddleware
 
 
 class TestAPIRequestMiddleware(TestCase):
+    def setUp(self):
+        self.request_factory = RequestFactory()
+
     def test_api_identified(self):
-        request = mock.Mock()
-        request.path_info = '/api/v3/lol/'
+        request = self.request_factory.get('/api/v3/lol/')
         APIRequestMiddleware().process_request(request)
         assert request.is_api
 
     def test_vary_applied(self):
-        request = mock.Mock()
+        request = self.request_factory.get('/api/v5/foo')
         request.is_api = True
         response = HttpResponse()
         APIRequestMiddleware().process_response(request, response)
@@ -25,7 +26,7 @@ class TestAPIRequestMiddleware(TestCase):
         assert response['Vary'] == 'Foo, Bar, X-Country-Code, Accept-Language'
 
     def test_vary_not_applied_outside_api(self):
-        request = mock.Mock()
+        request = self.request_factory.get('/somewhere')
         request.is_api = False
         response = HttpResponse()
         APIRequestMiddleware().process_response(request, response)
@@ -37,11 +38,92 @@ class TestAPIRequestMiddleware(TestCase):
 
     def test_disabled_for_the_rest(self):
         """Test that we don't tag the request as API on "regular" pages."""
-        request = mock.Mock()
-        request.path_info = '/'
+        request = self.request_factory.get('/overtherainbow')
         APIRequestMiddleware().process_request(request)
         assert not request.is_api
 
-        request.path = '/en-US/firefox/'
+        request = self.request_factory.get('/overtherainbow')
         APIRequestMiddleware().process_request(request)
         assert not request.is_api
+
+
+class TestAPICacheControlMiddleware(TestCase):
+    def setUp(self):
+        self.request_factory = RequestFactory()
+
+    def test_not_api_should_not_cache(self):
+        request = self.request_factory.get('/bar')
+        request.is_api = False
+        response = HttpResponse()
+        response = APICacheControlMiddleware(lambda x: response)(request)
+        assert 'Cache-Control' not in response
+
+    def test_authenticated_should_not_cache(self):
+        request = self.request_factory.get('/api/v5/foo')
+        request.is_api = True
+        request.META = {'HTTP_AUTHORIZATION': 'foo'}
+        response = HttpResponse()
+        response = APICacheControlMiddleware(lambda x: response)(request)
+        assert 'Cache-Control' not in response
+
+    def test_non_read_only_http_method_should_not_cache(self):
+        request = self.request_factory.get('/api/v5/foo')
+        request.is_api = True
+        for method in ('POST', 'DELETE', 'PUT', 'PATCH'):
+            request.method = method
+            response = HttpResponse()
+            response = APICacheControlMiddleware(lambda x: response)(request)
+            assert 'Cache-Control' not in response
+
+    def test_disable_caching_arg_should_not_cache(self):
+        request = self.request_factory.get('/api/v5/foo')
+        request.is_api = True
+        request.GET = {'disable_caching': '1'}
+        response = HttpResponse()
+        response = APICacheControlMiddleware(lambda x: response)(request)
+        assert 'Cache-Control' not in response
+
+    def test_cookies_in_response_should_not_cache(self):
+        request = self.request_factory.get('/api/v5/foo')
+        request.is_api = True
+        response = HttpResponse()
+        response.set_cookie('foo', 'bar')
+        response = APICacheControlMiddleware(lambda x: response)(request)
+        assert 'Cache-Control' not in response
+
+    def test_cache_control_already_set_should_not_override(self):
+        request = self.request_factory.get('/api/v5/foo')
+        request.is_api = True
+        response = HttpResponse()
+        response['Cache-Control'] = 'max-age=3600'
+        response = APICacheControlMiddleware(lambda x: response)(request)
+        assert response['Cache-Control'] == 'max-age=3600'
+
+    def test_non_success_status_code_should_not_cache(self):
+        request = self.request_factory.get('/api/v5/foo')
+        request.is_api = True
+        response = HttpResponse()
+        for status_code in (400, 401, 403, 404, 429, 500, 502, 503, 504):
+            response.status_code = status_code
+            response = APICacheControlMiddleware(lambda x: response)(request)
+            assert 'Cache-Control' not in response
+
+    def test_everything_ok_should_cache_for_3_minutes(self):
+        request = self.request_factory.get('/api/v5/foo')
+        request.is_api = True
+        response = HttpResponse()
+        for status_code in (200, 201, 202, 204, 301, 302, 303, 304):
+            response.status_code = status_code
+            response = APICacheControlMiddleware(lambda x: response)(request)
+            assert response['Cache-Control'] == 'max-age=180'
+
+    def test_functional_should_cache(self):
+        response = self.client.get(reverse_ns('amo-site-status'))
+        assert response.status_code == 200
+        assert 'Cache-Control' in response
+        assert response['Cache-Control'] == 'max-age=180'
+
+    def test_functional_should_not_cache(self):
+        response = self.client.get(reverse_ns('amo-site-status'), HTTP_AUTHORIZATION='blah')
+        assert response.status_code == 200
+        assert 'Cache-Control' not in response

--- a/src/olympia/api/tests/test_middleware.py
+++ b/src/olympia/api/tests/test_middleware.py
@@ -124,6 +124,8 @@ class TestAPICacheControlMiddleware(TestCase):
         assert response['Cache-Control'] == 'max-age=180'
 
     def test_functional_should_not_cache(self):
-        response = self.client.get(reverse_ns('amo-site-status'), HTTP_AUTHORIZATION='blah')
+        response = self.client.get(
+            reverse_ns('amo-site-status'), HTTP_AUTHORIZATION='blah'
+        )
         assert response.status_code == 200
         assert 'Cache-Control' not in response

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -401,6 +401,7 @@ MIDDLEWARE = (
     # Test if it's an API request first so later middlewares don't need to.
     # Also add relevant Vary header to API responses.
     'olympia.api.middleware.APIRequestMiddleware',
+    'olympia.api.middleware.APICacheControlMiddleware',
     # Gzip middleware needs to be executed after every modification to the
     # response, so it's placed at the top of the list.
     'django.middleware.gzip.GZipMiddleware',

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1560,6 +1560,9 @@ MAX_APIKEY_JWT_AUTH_TOKEN_LIFETIME = 5 * 60
 # means it's sent instantaneously.
 API_KEY_CONFIRMATION_DELAY = None
 
+# Default cache duration for the API, in seconds.
+API_CACHE_DURATION = 3 * 60
+
 # JWT authentication related settings:
 JWT_AUTH = {
     # Use HMAC using SHA-256 hash algorithm. It should be the default, but we


### PR DESCRIPTION
This will also be the duration that nginx will use to cache the responses.

Fixes #16311