### PR TITLE
Update links in submission emails #16650

### DIFF
--- a/src/olympia/devhub/templates/devhub/emails/submission.html
+++ b/src/olympia/devhub/templates/devhub/emails/submission.html
@@ -2,7 +2,7 @@
 
 <p>Please keep in mind that while your add-on has been screened and approved for listing, other reviewers may look into it in the future and determine that it requires changes or should be removed from the gallery. If that occurs, you will receive a separate notification with details and next steps.</p>
 
-<p>For more information about the review process and policies, please visit <a href="https://developer.mozilla.org/Add-ons/AMO/Policy/Reviews">https://developer.mozilla.org/Add-ons/AMO/Policy/Reviews</a>.</p>
+<p>For more information about the review process and policies, please visit <a href="https://extensionworkshop.com/documentation/publish/add-on-policies/">https://extensionworkshop.com/documentation/publish/add-on-policies/</a>.</p>
 
 <hr />
 Attract Users, Stay Updated, &amp; Get in Touch
@@ -10,9 +10,7 @@ Attract Users, Stay Updated, &amp; Get in Touch
 
 <p>Add-ons help personalize the web experience for millions of users who have installed Firefox, and we want to help make your users happy!</p>
 
-<p>To learn how to help users discover your extension, stay up-to-date with news from the add-ons community, or contact the add-ons team, please visit <a href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/Distribution/Resources_for_publishers">https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/Distribution/Resources_for_publishers</a>.</p>>
-
-<p>If you are interested in getting more involved with Mozilla and want to help keep the add-ons ecosystem safe and healthy, please consider becoming a volunteer add-on reviewer. You can learn more at <a href="https://wiki.mozilla.org/Add-ons/Reviewers">https://wiki.mozilla.org/Add-ons/Reviewers</a>.</p>
+<p>To learn how to help users discover your extension, stay up-to-date with news from the add-ons community, or contact the add-ons team, please visit <a href="https://extensionworkshop.com/documentation/manage/resources-for-publishers/">https://extensionworkshop.com/documentation/manage/resources-for-publishers/</a>.</p>>
 
 <p>Happy developing!</p>
 


### PR DESCRIPTION
[Update links in submission emails](https://github.com/mozilla/addons-server/issues/16650) #16650 

The following changes were made:

- `https://developer.mozilla.org/Add-ons/AMO/Policy/Reviews` is changed to `https://extensionworkshop.com/documentation/publish/add-on-policies/`

- `https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/Distribution/Resources_for_publishers` is changed to `https://extensionworkshop.com/documentation/manage/resources-for-publishers/`

- Line 15 of the email is deleted.

![image](https://user-images.githubusercontent.com/55190574/109636932-2c9e6b80-7b72-11eb-952e-0bd8a7553d0d.png)
