### PR TITLE
Update links on legacy DevHub #16649

### DIFF
--- a/src/olympia/devhub/templates/devhub/nav.html
+++ b/src/olympia/devhub/templates/devhub/nav.html
@@ -34,11 +34,11 @@
     <li>
       <a href="#" class="controller">{{ _('Documentation') }}</a>
       <ul>
-        <li><a href="https://developer.mozilla.org/en-US/Add-ons">
+        <li><a href="https://extensionworkshop.com/documentation/develop?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=dev-hub-legacy-menu-link">
           {{ _('Extension Development') }}</a></li>
-        <li><a href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/Themes">
+        <li><a href="https://extensionworkshop.com/documentation/themes?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=dev-hub-legacy-menu-link">
           {{ _('Themes') }}</a></li>
-        <li><a href="{{ url('devhub.docs', 'policies') }}">
+        <li><a href="https://extensionworkshop.com/documentation/publish/add-on-policies?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=dev-hub-legacy-menu-link">
           {{ _('Developer Policies') }}</a></li>
       </ul>
     </li>


### PR DESCRIPTION
Fixes #16649
Update links on legacy DevHub.
Links for the documentation section of the header in the legacy DevHub has been changed.

- Extension Development is linked to https://extensionworkshop.com/documentation/develop?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=dev-hub-legacy-menu-link

- Themes is linked to https://extensionworkshop.com/documentation/themes?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=dev-hub-legacy-menu-link

- Developer Policies is linked to https://extensionworkshop.com/documentation/publish/add-on-policies?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=dev-hub-legacy-menu-link