### PR TITLE
Make it clear reminder email does not relate to new issue

### DIFF
--- a/src/olympia/reviewers/management/commands/send_pending_rejection_last_warning_notifications.py
+++ b/src/olympia/reviewers/management/commands/send_pending_rejection_last_warning_notifications.py
@@ -95,7 +95,7 @@ class Command(BaseCommand):
             'delayed_rejection_days': self.EXPIRING_PERIOD_DAYS,
         }
         template = 'reject_multiple_versions_with_delay'
-        subject = 'Mozilla Add-ons: %s%s will be disabled on addons.mozilla.org'
+        subject = 'Reminder - Mozilla Add-ons: %s%s will be disabled on addons.mozilla.org'
         # This re-sends the notification sent when the versions were scheduled
         # for rejection, but with the new delay in the body of the email now
         # that the notification is about to expire.

--- a/src/olympia/reviewers/management/commands/send_pending_rejection_last_warning_notifications.py
+++ b/src/olympia/reviewers/management/commands/send_pending_rejection_last_warning_notifications.py
@@ -95,7 +95,9 @@ class Command(BaseCommand):
             'delayed_rejection_days': self.EXPIRING_PERIOD_DAYS,
         }
         template = 'reject_multiple_versions_with_delay'
-        subject = 'Reminder - Mozilla Add-ons: %s%s will be disabled on addons.mozilla.org'
+        subject = (
+            'Reminder - Mozilla Add-ons: %s%s will be disabled on addons.mozilla.org'
+        )
         # This re-sends the notification sent when the versions were scheduled
         # for rejection, but with the new delay in the body of the email now
         # that the notification is about to expire.

--- a/src/olympia/reviewers/tests/test_commands.py
+++ b/src/olympia/reviewers/tests/test_commands.py
@@ -861,7 +861,7 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
         assert addon.reviewerflags.notified_about_expiring_delayed_rejections
         message = mail.outbox[0]
         assert message.subject == (
-            'Mozilla Add-ons: %s will be disabled on addons.mozilla.org'
+            'Reminder - Mozilla Add-ons: %s will be disabled on addons.mozilla.org'
             % str(addon.name)
         )
         assert message.to == [author.email]


### PR DESCRIPTION
Fixes #11758 - Makes it clear pending rejection email doesn't relate to a new issue
