### PR TITLE
adjust amo theme thumbnail size; save as jpg instead

### DIFF
--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -76,6 +76,8 @@ class PreviewSerializer(serializers.ModelSerializer):
     caption = TranslationSerializerField()
     image_url = serializers.SerializerMethodField()
     thumbnail_url = serializers.SerializerMethodField()
+    image_size = serializers.ReadOnlyField(source='image_dimensions')
+    thumbnail_size = serializers.ReadOnlyField(source='thumbnail_dimensions')
 
     class Meta:
         # Note: this serializer can also be used for VersionPreview.

--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -205,7 +205,7 @@ def recreate_theme_previews(addon_ids, **kw):
                     .exclude(sizes={})
                     .count()
                 )
-                if with_size == len(amo.THEME_PREVIEW_SIZES):
+                if with_size == len(amo.THEME_PREVIEW_RENDERINGS):
                     continue
             log.info('Recreating previews for theme: %s' % addon.id)
             VersionPreview.objects.filter(version=version).delete()

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -288,8 +288,8 @@ class AddonSerializerOutputTestMixin(object):
         assert result_preview['thumbnail_url'] == absolutify(
             first_preview.thumbnail_url
         )
-        assert result_preview['image_size'] == first_preview.image_size
-        assert result_preview['thumbnail_size'] == first_preview.thumbnail_size
+        assert result_preview['image_size'] == first_preview.image_dimensions
+        assert result_preview['thumbnail_size'] == first_preview.thumbnail_dimensions
 
         result_preview = result['previews'][1]
         assert result_preview['id'] == second_preview.pk
@@ -298,10 +298,14 @@ class AddonSerializerOutputTestMixin(object):
         assert result_preview['thumbnail_url'] == absolutify(
             second_preview.thumbnail_url
         )
-        assert result_preview['image_size'] == second_preview.image_size == [567, 780]
+        assert (
+            result_preview['image_size']
+            == second_preview.image_dimensions
+            == [567, 780]
+        )
         assert (
             result_preview['thumbnail_size']
-            == second_preview.thumbnail_size
+            == second_preview.thumbnail_dimensions
             == [199, 99]
         )
 
@@ -716,9 +720,9 @@ class AddonSerializerOutputTestMixin(object):
         assert result['previews'][0]['thumbnail_url'] == absolutify(
             current_preview.thumbnail_url
         )
-        assert result['previews'][0]['image_size'] == (current_preview.image_size)
+        assert result['previews'][0]['image_size'] == current_preview.image_dimensions
         assert result['previews'][0]['thumbnail_size'] == (
-            current_preview.thumbnail_size
+            current_preview.thumbnail_dimensions
         )
 
         # Make sure we don't fail if somehow there is no current version.

--- a/src/olympia/addons/tests/test_tasks.py
+++ b/src/olympia/addons/tests/test_tasks.py
@@ -43,18 +43,22 @@ def test_recreate_theme_previews():
     assert addon_without_previews.reload().current_previews.count() == 3
     assert addon_with_previews.reload().current_previews.count() == 3
     sizes = addon_without_previews.current_previews.values_list('sizes', flat=True)
+    renderings = amo.THEME_PREVIEW_RENDERINGS
     assert list(sizes) == [
         {
-            'image': list(amo.THEME_PREVIEW_SIZES['header']['full']),
-            'thumbnail': list(amo.THEME_PREVIEW_SIZES['header']['thumbnail']),
+            'image': list(renderings['header']['full']),
+            'thumbnail': list(renderings['header']['thumbnail']),
+            'thumbnail_format': renderings['header']['thumbnail_format'],
         },
         {
-            'image': list(amo.THEME_PREVIEW_SIZES['list']['full']),
-            'thumbnail': list(amo.THEME_PREVIEW_SIZES['list']['thumbnail']),
+            'image': list(renderings['list']['full']),
+            'thumbnail': list(renderings['list']['thumbnail']),
+            'thumbnail_format': renderings['list']['thumbnail_format'],
         },
         {
-            'image': list(amo.THEME_PREVIEW_SIZES['single']['full']),
-            'thumbnail': list(amo.THEME_PREVIEW_SIZES['single']['thumbnail']),
+            'image': list(renderings['single']['full']),
+            'thumbnail': list(renderings['single']['thumbnail']),
+            'thumbnail_format': renderings['single']['thumbnail_format'],
         },
     ]
 

--- a/src/olympia/amo/tests/test_models.py
+++ b/src/olympia/amo/tests/test_models.py
@@ -361,10 +361,21 @@ class BasePreviewMixin(object):
         assert preview.image_path.endswith('.png')
         assert preview.original_path.endswith('.png')
 
+        # now set the format in .sizes
+        preview.update(sizes={'thumbnail_format': 'jpg', 'image_format': 'gif'})
+        assert preview.thumbnail_path.endswith('.jpg')
+        assert preview.image_path.endswith('.gif')
+        assert preview.original_path.endswith('.png')
+
     def test_filename_in_url(self):
         preview = self.get_object()
         assert '.png?modified=' in preview.thumbnail_url
         assert '.png?modified=' in preview.image_url
+
+        # now set the format in .sizes
+        preview.update(sizes={'thumbnail_format': 'jpg', 'image_format': 'gif'})
+        assert '.jpg?modified=' in preview.thumbnail_url
+        assert '.gif?modified=' in preview.image_url
 
     def check_delete(self, preview, filename):
         """

--- a/src/olympia/constants/base.py
+++ b/src/olympia/constants/base.py
@@ -226,31 +226,33 @@ VALID_CONTRIBUTION_DOMAINS = (
 # Icon upload sizes
 ADDON_ICON_SIZES = [32, 64, 128]
 
-_size_tuple = namedtuple('SizeTuple', 'width height')
+_dimensions = namedtuple('SizeTuple', 'width height')
 # Preview upload sizes - see mozilla/addons-server#9487 for background.
 ADDON_PREVIEW_SIZES = {
-    'thumb': _size_tuple(640, 480),
-    'min': _size_tuple(1000, 750),
-    'full': _size_tuple(2400, 1800),
+    'thumb': _dimensions(640, 480),
+    'min': _dimensions(1000, 750),
+    'full': _dimensions(2400, 1800),
 }
 
-# Static theme preview sizes
-THEME_PREVIEW_SIZES = {
+# Static theme preview renderings, with different dimensions
+THEME_PREVIEW_RENDERINGS = {
     'header': {
-        'thumbnail': _size_tuple(473, 64),
-        'full': _size_tuple(680, 92),
+        'thumbnail': _dimensions(473, 64),
+        'full': _dimensions(680, 92),
         'position': 0,
+        'thumbnail_format': 'png',
     },
     'list': {
-        'thumbnail': _size_tuple(529, 64),
-        'full': _size_tuple(760, 92),
+        'thumbnail': _dimensions(529, 64),
+        'full': _dimensions(760, 92),
         'position': 1,
+        'thumbnail_format': 'png',
     },
-    # single is planned to be the new default size in 2019 Q1.
     'single': {
-        'thumbnail': _size_tuple(501, 64),
-        'full': _size_tuple(720, 92),
+        'thumbnail': _dimensions(383, 49),
+        'full': _dimensions(720, 92),
         'position': 2,
+        'thumbnail_format': 'jpg',
     },
 }
 THEME_FRAME_COLOR_DEFAULT = 'rgba(229,230,232,1)'

--- a/src/olympia/constants/base.py
+++ b/src/olympia/constants/base.py
@@ -249,7 +249,7 @@ THEME_PREVIEW_RENDERINGS = {
         'thumbnail_format': 'png',
     },
     'single': {
-        'thumbnail': _dimensions(383, 49),
+        'thumbnail': _dimensions(720, 92),
         'full': _dimensions(720, 92),
         'position': 2,
         'thumbnail_format': 'jpg',

--- a/src/olympia/devhub/templates/devhub/addons/submit/wizard.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/wizard.html
@@ -80,7 +80,7 @@
     <div>
         <h3>{{ _('Browser preview') }}</h3>
         <div id="browser-preview" dir="ltr">
-            {% set svg_render_size = amo.THEME_PREVIEW_SIZES['header']['full'] %}
+            {% set svg_render_size = amo.THEME_PREVIEW_RENDERINGS['header']['full'] %}
             {% include 'devhub/addons/includes/static_theme_preview_svg.xml' %}
         </div>
     </div>

--- a/src/olympia/versions/tests/test_tasks.py
+++ b/src/olympia/versions/tests/test_tasks.py
@@ -71,6 +71,7 @@ def check_preview(
     assert preview_instance.sizes == {
         'image': list(theme_size_constant['full']),
         'thumbnail': list(theme_size_constant['thumbnail']),
+        'thumbnail_format': theme_size_constant['thumbnail_format'],
     }
     resize_path, thumb_path, thumb_size = resize_image_mock_args
     assert resize_path == png_path
@@ -148,11 +149,11 @@ def test_generate_static_theme_preview(
     # First check the header Preview is good
     header_preview = VersionPreview.objects.get(
         version=addon.current_version,
-        position=amo.THEME_PREVIEW_SIZES['header']['position'],
+        position=amo.THEME_PREVIEW_RENDERINGS['header']['position'],
     )
     check_preview(
         header_preview,
-        amo.THEME_PREVIEW_SIZES['header'],
+        amo.THEME_PREVIEW_RENDERINGS['header'],
         write_svg_to_png_mock.call_args_list[0][0],
         resize_image_mock.call_args_list[0][0],
         pngcrush_image_mock.call_args_list[0][0],
@@ -161,11 +162,11 @@ def test_generate_static_theme_preview(
     # Then the list Preview
     list_preview = VersionPreview.objects.get(
         version=addon.current_version,
-        position=amo.THEME_PREVIEW_SIZES['list']['position'],
+        position=amo.THEME_PREVIEW_RENDERINGS['list']['position'],
     )
     check_preview(
         list_preview,
-        amo.THEME_PREVIEW_SIZES['list'],
+        amo.THEME_PREVIEW_RENDERINGS['list'],
         write_svg_to_png_mock.call_args_list[1][0],
         resize_image_mock.call_args_list[1][0],
         pngcrush_image_mock.call_args_list[1][0],
@@ -174,11 +175,11 @@ def test_generate_static_theme_preview(
     # And finally the new single Preview
     single_preview = VersionPreview.objects.get(
         version=addon.current_version,
-        position=amo.THEME_PREVIEW_SIZES['single']['position'],
+        position=amo.THEME_PREVIEW_RENDERINGS['single']['position'],
     )
     check_preview(
         single_preview,
-        amo.THEME_PREVIEW_SIZES['single'],
+        amo.THEME_PREVIEW_RENDERINGS['single'],
         write_svg_to_png_mock.call_args_list[2][0],
         resize_image_mock.call_args_list[2][0],
         pngcrush_image_mock.call_args_list[2][0],
@@ -320,11 +321,11 @@ def test_generate_static_theme_preview_with_alternative_properties(
     # First check the header Preview is good
     header_preview = VersionPreview.objects.get(
         version=addon.current_version,
-        position=amo.THEME_PREVIEW_SIZES['header']['position'],
+        position=amo.THEME_PREVIEW_RENDERINGS['header']['position'],
     )
     check_preview(
         header_preview,
-        amo.THEME_PREVIEW_SIZES['header'],
+        amo.THEME_PREVIEW_RENDERINGS['header'],
         write_svg_to_png_mock.call_args_list[0][0],
         resize_image_mock.call_args_list[0][0],
         pngcrush_image_mock.call_args_list[0][0],
@@ -333,11 +334,11 @@ def test_generate_static_theme_preview_with_alternative_properties(
     # Then the list Preview
     list_preview = VersionPreview.objects.get(
         version=addon.current_version,
-        position=amo.THEME_PREVIEW_SIZES['list']['position'],
+        position=amo.THEME_PREVIEW_RENDERINGS['list']['position'],
     )
     check_preview(
         list_preview,
-        amo.THEME_PREVIEW_SIZES['list'],
+        amo.THEME_PREVIEW_RENDERINGS['list'],
         write_svg_to_png_mock.call_args_list[1][0],
         resize_image_mock.call_args_list[1][0],
         pngcrush_image_mock.call_args_list[1][0],
@@ -346,11 +347,11 @@ def test_generate_static_theme_preview_with_alternative_properties(
     # And finally the new single Preview
     single_preview = VersionPreview.objects.get(
         version=addon.current_version,
-        position=amo.THEME_PREVIEW_SIZES['single']['position'],
+        position=amo.THEME_PREVIEW_RENDERINGS['single']['position'],
     )
     check_preview(
         single_preview,
-        amo.THEME_PREVIEW_SIZES['single'],
+        amo.THEME_PREVIEW_RENDERINGS['single'],
         write_svg_to_png_mock.call_args_list[2][0],
         resize_image_mock.call_args_list[2][0],
         pngcrush_image_mock.call_args_list[2][0],
@@ -480,11 +481,11 @@ def test_generate_preview_with_additional_backgrounds(
     # First check the header Preview is good
     header_preview = VersionPreview.objects.get(
         version=addon.current_version,
-        position=amo.THEME_PREVIEW_SIZES['header']['position'],
+        position=amo.THEME_PREVIEW_RENDERINGS['header']['position'],
     )
     check_preview(
         header_preview,
-        amo.THEME_PREVIEW_SIZES['header'],
+        amo.THEME_PREVIEW_RENDERINGS['header'],
         write_svg_to_png_mock.call_args_list[0][0],
         resize_image_mock.call_args_list[0][0],
         pngcrush_image_mock.call_args_list[0][0],
@@ -493,11 +494,11 @@ def test_generate_preview_with_additional_backgrounds(
     # Then the list Preview
     list_preview = VersionPreview.objects.get(
         version=addon.current_version,
-        position=amo.THEME_PREVIEW_SIZES['list']['position'],
+        position=amo.THEME_PREVIEW_RENDERINGS['list']['position'],
     )
     check_preview(
         list_preview,
-        amo.THEME_PREVIEW_SIZES['list'],
+        amo.THEME_PREVIEW_RENDERINGS['list'],
         write_svg_to_png_mock.call_args_list[1][0],
         resize_image_mock.call_args_list[1][0],
         pngcrush_image_mock.call_args_list[1][0],
@@ -506,11 +507,11 @@ def test_generate_preview_with_additional_backgrounds(
     # And finally the new single Preview
     single_preview = VersionPreview.objects.get(
         version=addon.current_version,
-        position=amo.THEME_PREVIEW_SIZES['single']['position'],
+        position=amo.THEME_PREVIEW_RENDERINGS['single']['position'],
     )
     check_preview(
         single_preview,
-        amo.THEME_PREVIEW_SIZES['single'],
+        amo.THEME_PREVIEW_RENDERINGS['single'],
         write_svg_to_png_mock.call_args_list[2][0],
         resize_image_mock.call_args_list[2][0],
         pngcrush_image_mock.call_args_list[2][0],

--- a/src/olympia/versions/tests/test_utils.py
+++ b/src/olympia/versions/tests/test_utils.py
@@ -116,8 +116,8 @@ def test_additional_background(
     assert background.width == image_width
     assert background.height == image_height
     background.calculate_pattern_offsets(
-        amo.THEME_PREVIEW_SIZES['header']['full'].width,
-        amo.THEME_PREVIEW_SIZES['header']['full'].height,
+        amo.THEME_PREVIEW_RENDERINGS['header']['full'].width,
+        amo.THEME_PREVIEW_RENDERINGS['header']['full'].height,
     )
     assert background.pattern_width == pattern_width
     assert background.pattern_height == pattern_height


### PR DESCRIPTION
fixes #16639 - also renames some things - referring to: the different renderings (full, list, single), the different image sizes (original, full, thumbnail), and the actual image dimensions (width*height), all as "sizes" started to get very confusing.