### PR TITLE
Create pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,24 @@
 repos:
   - repo: local
     hooks:
-      - id: format
-        name: format with black and prettier
+      - id: black
+        name: format python with black
         language: system
-        entry: docker-compose exec -T web make format
-      - id: lint
-        name: check code formatting
+        entry: docker-compose exec -T web black
+        types: [python]
+      - id: prettier
+        name: format javascript with prettier
         language: system
-        entry: docker-compose exec -T web make lint
-fail_fast: true
+        entry: docker-compose exec -T web $(shell npm $(NPM_ARGS) bin)/prettier
+        args: [--write]
+        types: [javascript]
+      - id: flake8
+        name: lint python with flake8
+        language: system
+        entry: docker-compose exec -T web flake8
+        types: [python]
+      - id: curlylint
+        name: lint html with curlylint
+        language: system
+        entry: docker-compose exec -T web curlylint
+        types: [html]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: local
+    hooks:
+      - id: format
+        name: format with black and prettier
+        language: system
+        entry: docker-compose exec -T web make format
+      - id: lint
+        name: check code formatting
+        language: system
+        entry: docker-compose exec -T web make lint
+fail_fast: true
+default_stages: [push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,4 +10,3 @@ repos:
         language: system
         entry: docker-compose exec -T web make lint
 fail_fast: true
-default_stages: [push]

--- a/requirements/codestyle.txt
+++ b/requirements/codestyle.txt
@@ -129,3 +129,6 @@ typed-ast==1.4.2 \
     --hash=sha256:9fc0b3cb5d1720e7141d103cf4819aea239f7d136acf9ee4a69b047b7986175a
 flake8-quotes==3.2.0 \
     --hash=sha256:3f1116e985ef437c130431ac92f9b3155f8f652fda7405ac22ffdfd7a9d1055e
+pre-commit==2.10.1 \
+    --hash=sha256:16212d1fde2bed88159287da88ff03796863854b04dc9f838a55979325a3d20e
+


### PR DESCRIPTION
Fixes #14249

This adds [pre-commit](https://pre-commit.com/) as a dependency to requirements/codestyle.txt and .pre-commit-config.yaml in the root directory.

Pre-commit will run a selection of black, prettier, flake8 and curlylint from within the docker container on specific files being committed, depending on type, and will hold them in staging if they don't pass.

e.g. `docker-compose exec -T web curlylint <changed files>`

Requires a developer to have pre-commit installed in their local environment, and to manually install the hook with `pre-commit install`