### PR TITLE
Log a specific action for force disable/enable, show it in reviewer tools

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1150,8 +1150,13 @@ class Addon(OnChangeMixin, ModelBase):
                 % (self.id, self.status, status, reason)
             )
             self.update(status=status)
+            # If task_user doesn't exist that's no big issue (i.e. in tests)
+            try:
+                task_user = get_task_user()
+            except UserProfile.DoesNotExist:
+                task_user = None
             activity.log_create(
-                amo.LOG.CHANGE_STATUS, self, self.status, user=get_task_user()
+                amo.LOG.CHANGE_STATUS, self, self.status, user=task_user
             )
 
         self.update_version(ignore=ignore_version)

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -66,6 +66,7 @@ from olympia.translations.fields import (
 from olympia.translations.hold import translation_saved
 from olympia.translations.models import Translation
 from olympia.users.models import UserProfile
+from olympia.users.utils import get_task_user
 from olympia.versions.compare import version_int
 from olympia.versions.models import (
     Version,
@@ -539,16 +540,20 @@ class Addon(OnChangeMixin, ModelBase):
         clean_slug(self, slug_field)
 
     def force_disable(self):
-        activity.log_create(amo.LOG.CHANGE_STATUS, self, amo.STATUS_DISABLED)
-        log.info('Addon "%s" status changed to: %s', self.slug, amo.STATUS_DISABLED)
+        activity.log_create(amo.LOG.FORCE_DISABLE, self)
+        log.info(
+            'Addon "%s" status force-changed to: %s', self.slug, amo.STATUS_DISABLED
+        )
         self.update(status=amo.STATUS_DISABLED)
         self.update_version()
         # See: https://github.com/mozilla/addons-server/issues/13194
         self.disable_all_files()
 
     def force_enable(self):
-        activity.log_create(amo.LOG.CHANGE_STATUS, self, amo.STATUS_APPROVED)
-        log.info('Addon "%s" status changed to: %s', self.slug, amo.STATUS_APPROVED)
+        activity.log_create(amo.LOG.FORCE_ENABLE, self)
+        log.info(
+            'Addon "%s" status force-changed to: %s', self.slug, amo.STATUS_APPROVED
+        )
         self.update(status=amo.STATUS_APPROVED)
         # Call update_status() to fix the status if the add-on is not actually
         # in a state that allows it to be public.
@@ -1145,7 +1150,9 @@ class Addon(OnChangeMixin, ModelBase):
                 % (self.id, self.status, status, reason)
             )
             self.update(status=status)
-            activity.log_create(amo.LOG.CHANGE_STATUS, self, self.status)
+            activity.log_create(
+                amo.LOG.CHANGE_STATUS, self, self.status, user=get_task_user()
+            )
 
         self.update_version(ignore=ignore_version)
 

--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -772,6 +772,26 @@ class VERSION_RESIGNED(_LOG):
     review_queue = True
 
 
+class FORCE_DISABLE(_LOG):
+    id = 167
+    keep = True
+    # We don't want to notify developers, this is not a regular rejection - the
+    # add-on is likely malicious.
+    hide_developer = True
+    reviewer_review_action = True
+    format = _('{addon} status force-disabled.')
+    short = _('Force disabled')
+
+
+class FORCE_ENABLE(_LOG):
+    id = 168
+    keep = True
+    hide_developer = True
+    reviewer_review_action = True
+    format = _('{addon} status force-enabled.')
+    short = _('Force enabled')
+
+
 LOGS = [x for x in vars().values() if isclass(x) and issubclass(x, _LOG) and x != _LOG]
 # Make sure there's no duplicate IDs.
 assert len(LOGS) == len(set(log.id for log in LOGS))

--- a/src/olympia/devhub/tests/test_feeds.py
+++ b/src/olympia/devhub/tests/test_feeds.py
@@ -26,6 +26,7 @@ class TestActivity(HubTest):
         self.clone_addon(2)
         core.set_user(self.user_profile)
         self.addon, self.addon2 = list(self.user_profile.addons.all())
+        ActivityLog.objects.all().delete()
 
     def log_creates(self, num, addon=None):
         if not addon:

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -615,6 +615,7 @@ class TestActivityFeed(TestCase):
         self.addon = Addon.objects.get(id=3615)
         self.version = self.addon.versions.first()
         self.action_user = UserProfile.objects.get(email='reviewer@mozilla.com')
+        ActivityLog.objects.all().delete()
 
     def test_feed_for_all(self):
         response = self.client.get(reverse('devhub.feed_all'))
@@ -665,7 +666,7 @@ class TestActivityFeed(TestCase):
         self.add_log()
         res = self.client.get(reverse('devhub.addons'))
         doc = pq(res.content)
-        assert len(doc('.recent-activity li.item')) == 1
+        assert len(doc('.recent-activity li.item')) == 2
 
     def test_unlisted_addons_feed_sidebar(self):
         """Unlisted addons are displayed in the left side in the feed page."""
@@ -682,7 +683,7 @@ class TestActivityFeed(TestCase):
         self.add_log()
         res = self.client.get(reverse('devhub.feed_all'))
         doc = pq(res.content)
-        assert len(doc('#recent-activity .item')) == 1
+        assert len(doc('#recent-activity .item')) == 2
 
     def test_unlisted_addons_feed_filter(self):
         """Feed page can be filtered on unlisted addon."""
@@ -690,7 +691,7 @@ class TestActivityFeed(TestCase):
         self.add_log()
         res = self.client.get(reverse('devhub.feed', args=[self.addon.slug]))
         doc = pq(res.content)
-        assert len(doc('#recent-activity .item')) == 1
+        assert len(doc('#recent-activity .item')) == 2
 
     def test_reviewer_name_is_used_for_reviewer_actions(self):
         self.action_user.update(display_name='HîdeMe', reviewer_name='ShöwMe')

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -361,7 +361,7 @@ class TestVersion(TestCase):
             != new_version
         )
 
-        entry = ActivityLog.objects.get()
+        entry = ActivityLog.objects.latest('pk')
         assert entry.action == amo.LOG.USER_DISABLE.id
         msg = entry.to_string()
         assert str(self.addon.name) in msg, 'Unexpected: %r' % msg

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -374,6 +374,10 @@ TEMPLATES = [
     },
 ]
 
+# Default datetime format in templates
+# https://docs.djangoproject.com/en/3.2/ref/templates/builtins/#std:templatefilter-date
+DATETIME_FORMAT = 'N j, Y, H:i'
+
 
 X_FRAME_OPTIONS = 'DENY'
 SECURE_BROWSER_XSS_FILTER = True

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -40,14 +40,14 @@
 
   {% include 'reviewers/addon_details_box.html' %}
 
-  {% if user_changes_log %}
-  <div id="user-changes-history">
+  {% if important_changes_log %}
+  <div id="important-changes-history">
     <h3>
-      {{ _('Add-on user change history') }}
+      {{ _('Add-on important changes history') }}
     </h3>
-    <ul id="user-changes">
-      {% for user_change_log in user_changes_log %}
-        <li>{{ user_change_log.created }}: {{ user_change_log }}</li>
+    <ul>
+      {% for activity in important_changes_log %}
+        <li {% if activity.log.reviewer_review_action %}class="reviewer-review-action"{% endif %}>{{ activity.created|datetime }}: {{ activity }}</li>
       {% endfor %}
     </ul>
   </div>

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -3576,8 +3576,8 @@ class TestReview(ReviewBase):
             version_factory(
                 addon=addon, version=f'1.{i}', created=self.days_ago(365 - i)
             )
-        with self.assertNumQueries(59):
-            # FIXME: 59 is obviously still too high, but it's a starting point.
+        with self.assertNumQueries(62):
+            # FIXME: 62 is obviously still too high, but it's a starting point.
             # Potential further optimizations:
             # - Remove trivial... and not so trivial duplicates
             # - Group similar queries
@@ -3590,60 +3590,63 @@ class TestReview(ReviewBase):
             # 3. groups
             # 4. add-on by slug
             # 5. add-on translations
-            # 6. current version
-            # 7. version translations
-            # 8. applications versions
-            # 9. files
-            # 10. authors
-            # 11. previews
-            # 12. autoapprovalsummary for current version
-            # 13. promoted info for the add-on
-            # 14. latest version
-            # 15. latest version translations
-            # 16. latest version (repeated)
-            # 17. latest version translations (repeated)
-            # 18. addon reviewer flags
-            # 19. version reviewer flags
-            # 20. version reviewer flags (repeated)
-            # 21. files
-            # 22. autoapprovalsummary (repeated)
-            # 23. addonreusedguid
-            # 24. blocklist
-            # 25. canned responses
-            # 26. abuse reports count against user or addon
-            # 27. low ratings count
-            # 28. base version for comparison
-            # 29. translations for base version
-            # 30. applications versions for base version
-            # 31. files for base version
-            # 32. count of all versions in channel
-            # 33. paginated list of versions in channel
-            # 34. scanner results for paginated list of versions
-            # 35. translations for  paginated list of versions
-            # 36. applications versions for  paginated list of versions
-            # 37. files for  paginated list of versions
-            # 38. activity log for  paginated list of versions
-            # 39. ready for auto-approval info for  paginated list of versions
-            # 40. versionreviewer flags exists to find out if pending rejection
-            # 41. count versions needing human review on other pages
-            # 42. count versions needing human review by mad on other pages
-            # 43. count versions pending rejection on other pages
-            # 44. whiteboard
-            # 45. reviewer subscriptions for listed
-            # 46. reviewer subscriptions for unlisted
-            # 47. config for motd
-            # 48. my favorite collection for the current user
-            # 49. add-on list for the current user
-            # 50. config for site notice
-            # 51. translations for... (?)
-            # 52. specific log activity about the add-on
-            # 53. reusedguid (repeated)
-            # 54. select all versions in channel for versions dropdown widget
-            # 55. select files for those versions
-            # 56. select files waiting for review for particular version
-            # 57. select users by role for this add-on (?)
-            # 58. select categories (repeated)
-            # 59. savepoint
+            # 6. add-on categories
+            # 7. current version
+            # 8. version translations
+            # 9. applications versions
+            # 10. files
+            # 11. authors
+            # 12. previews
+            # 13. autoapprovalsummary for current version
+            # 14. promoted info for the add-on
+            # 15. latest version
+            # 16. latest version translations
+            # 17. latest version (repeated because different status filter)
+            # 18. latest version translations (repeated because different qs)
+            # 19. addon reviewer flags
+            # 20. version reviewer flags
+            # 21. version reviewer flags (repeated)
+            # 22. files
+            # 23. autoapprovalsummary (repeated)
+            # 24. addonreusedguid
+            # 25. blocklist
+            # 26. canned responses
+            # 27. abuse reports count against user or addon
+            # 28. low ratings count
+            # 29. base version for comparison
+            # 30. translations for base version
+            # 31. applications versions for base version
+            # 32. files for base version
+            # 33. count of all versions in channel
+            # 34. paginated list of versions in channel
+            # 35. scanner results for paginated list of versions
+            # 36. translations for  paginated list of versions
+            # 37. applications versions for  paginated list of versions
+            # 38. files for  paginated list of versions
+            # 39. activity log for  paginated list of versions
+            # 40. ready for auto-approval info for  paginated list of versions
+            # 41. versionreviewer flags exists to find out if pending rejection
+            # 42. count versions needing human review on other pages
+            # 43. count versions needing human review by mad on other pages
+            # 44. count versions pending rejection on other pages
+            # 45. whiteboard
+            # 46. reviewer subscriptions for listed
+            # 47. reviewer subscriptions for unlisted
+            # 48. config for motd
+            # 49. my favorite collection for the current user
+            # 50. count add-ons the user is a developer of
+            # 51. config for site notice
+            # 52. translations for... (?! id=1)
+            # 53. important activity log about the add-on
+            # 54. user for the activity
+            # 55. add-on for the activity
+            # 56. translation for the add-on for the activity
+            # 57. reusedguid (repeated)
+            # 58. select all versions in channel for versions dropdown widget
+            # 59. select files for those versions
+            # 60. select files waiting for review for particular version
+            # 61. select users by role for this add-on (?)
+            # 62. savepoint
             response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
@@ -5907,7 +5910,7 @@ class TestReview(ReviewBase):
                     results={'matchedResults': [customs_rule.name]},
                 )
 
-        with self.assertNumQueries(59):
+        with self.assertNumQueries(62):
             # See test_item_history_pagination() for more details about the
             # queries count. What's important here is that the extra versions
             # and scanner results don't cause extra queries.
@@ -5966,7 +5969,7 @@ class TestReview(ReviewBase):
                     results={'matchedResults': [customs_rule.name]},
                 )
 
-        with self.assertNumQueries(61):
+        with self.assertNumQueries(64):
             # See test_item_history_pagination() for more details about the
             # queries count. What's important here is that the extra versions
             # and scanner results don't cause extra queries.

--- a/src/olympia/scanners/tests/test_admin.py
+++ b/src/olympia/scanners/tests/test_admin.py
@@ -1070,14 +1070,14 @@ class TestScannerQueryRuleAdmin(AMOPaths, TestCase):
             name='bar',
             scanner=YARA,
             state=COMPLETED,
-            completed=datetime(2020, 9, 29, 14, 0, 1),
+            completed=datetime(2020, 9, 29, 14, 1, 2),
         )
         response = self.client.get(self.list_url)
         assert response.status_code == 200
         doc = pq(response.content)
         field = doc('.field-state_with_actions')
         assert field
-        assert field.text() == 'Completed (Sept. 29, 2020, 2 p.m.)'
+        assert field.text() == 'Completed (Sept. 29, 2020, 14:01)'
         assert not field.find('button')
 
         rule.update(completed=None)  # If somehow None (unknown finished time)

--- a/static/css/zamboni/reviewers.less
+++ b/static/css/zamboni/reviewers.less
@@ -672,6 +672,10 @@ div.reviewer-stats-table > div.reviewer-stats-dark {
     top: 10px;
 }
 
+.reviewer-review-action {
+    font-weight: bold;
+}
+
 .review-files {
     margin: 0;
     width: 100%;


### PR DESCRIPTION
Also set change status action user to the task user at all times, because it's an automated action normal users aren't responsible for.

Fixes #16637