### PR TITLE
Expose reviewer name for specific actions in review page important changes log

### DIFF
--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -779,7 +779,7 @@ class FORCE_DISABLE(_LOG):
     # add-on is likely malicious.
     hide_developer = True
     reviewer_review_action = True
-    format = _('{addon} status force-disabled.')
+    format = _('{user} force-disabled {addon}.')
     short = _('Force disabled')
 
 
@@ -788,7 +788,7 @@ class FORCE_ENABLE(_LOG):
     keep = True
     hide_developer = True
     reviewer_review_action = True
-    format = _('{addon} status force-enabled.')
+    format = _('{user} force-enabled {addon}.')
     short = _('Force enabled')
 
 

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -5358,9 +5358,15 @@ class TestReview(ReviewBase):
         assert 'class' not in important_changes[2].attrib
         assert '(Owner) removed from ' in important_changes[3].text_content()
         assert 'class' not in important_changes[3].attrib
-        assert 'status force-disabled.' in important_changes[4].text_content()
+        assert (
+            'regularuser التطب force-disabled Public.'
+            in important_changes[4].text_content()
+        )
         assert important_changes[4].attrib['class'] == 'reviewer-review-action'
-        assert 'status force-enabled.' in important_changes[5].text_content()
+        assert (
+            'regularuser التطب force-enabled Public.'
+            in important_changes[5].text_content()
+        )
         assert important_changes[5].attrib['class'] == 'reviewer-review-action'
 
     @override_settings(CELERY_TASK_ALWAYS_EAGER=True)


### PR DESCRIPTION
Fixes #16765

Forgot this while implementing the actions in https://github.com/mozilla/addons-server/issues/16637