### PR TITLE
Show average daily users on django admin add-ons list

### DIFF
--- a/src/olympia/addons/admin.py
+++ b/src/olympia/addons/admin.py
@@ -158,6 +158,7 @@ class AddonAdmin(admin.ModelAdmin):
         'type',
         'guid',
         'status',
+        'average_daily_users',
         'average_rating',
         'authors_links',
         'reviewer_links',


### PR DESCRIPTION
Fix #16768.