### PR TITLE
Remove MYSQL_ALLOW_EMPTY_PASSWORD env var in circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,7 +289,6 @@ references:
 
   mysql-config: &mysql-config
     environment:
-      MYSQL_ALLOW_EMPTY_PASSWORD: yes
       MYSQL_DATABASE: olympia
 
   defaults: &defaults


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/16781 (when CI is fixed)

---

It's already set in the base image we're using.