### PR TITLE
Stop displaying status changes in review page

### DIFF
--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -5337,9 +5337,8 @@ class TestReview(ReviewBase):
         # Make sure the logs are displayed in the page.
         important_changes = doc('#important-changes-history li')
         assert len(important_changes) == 5
-        assert 'class' not in important_changes[0].attrib
         assert '(Owner) added to ' in important_changes[0].text_content()
-        assert 'class' not in important_changes[0].attrib
+        assert 'class' not in important_changes[1].attrib
         assert 'role changed to Owner for ' in important_changes[1].text_content()
         assert 'class' not in important_changes[1].attrib
         assert '(Owner) removed from ' in important_changes[2].text_content()

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -974,9 +974,7 @@ def review(request, addon, channel=None):
         amo.LOG.FORCE_ENABLE.id,
     )
     important_changes_log = ActivityLog.objects.filter(
-        action__in=(
-            user_changes_actions + admin_changes_actions
-        ),
+        action__in=(user_changes_actions + admin_changes_actions),
         addonlog__addon=addon,
     ).order_by('id')
 

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -973,10 +973,9 @@ def review(request, addon, channel=None):
         amo.LOG.FORCE_DISABLE.id,
         amo.LOG.FORCE_ENABLE.id,
     )
-    status_changes_actions = (amo.LOG.CHANGE_STATUS.id,)
     important_changes_log = ActivityLog.objects.filter(
         action__in=(
-            user_changes_actions + admin_changes_actions + status_changes_actions
+            user_changes_actions + admin_changes_actions
         ),
         addonlog__addon=addon,
     ).order_by('id')


### PR DESCRIPTION
We currently record an `ActivityLog` everytime we go through `update_status()` roughly, even when the status doesn't actually change (like going from 'Approved' to... 'Approved'). So displaying them all while this is happening is not a good idea.

This also attempts to make the tests around query counts more stable for the future if we ever re-implement displaying the status changes, by forcing those tests to either do more activity log related stuff (`test_item_history_pagination()`) or ignore them completely (`test_versions_that_are_flagged_by_scanners_are_highlighted()`)

Fixes #16808