### PR TITLE
theme previews can be generated as svgs

### DIFF
--- a/src/olympia/addons/management/commands/process_addons.py
+++ b/src/olympia/addons/management/commands/process_addons.py
@@ -93,7 +93,7 @@ tasks = {
         'qs': [
             Q(
                 type=amo.ADDON_STATICTHEME,
-                status__in=[amo.STATUS_APPROVED, amo.STATUS_AWAITING_REVIEW],
+                status__in=[amo.STATUS_APPROVED, amo.STATUS_NOMINATED],
             )
         ],
         'kwargs': {'only_missing': False},

--- a/src/olympia/addons/tests/test_tasks.py
+++ b/src/olympia/addons/tests/test_tasks.py
@@ -48,11 +48,13 @@ def test_recreate_theme_previews():
         {
             'image': list(renderings['firefox']['full']),
             'thumbnail': list(renderings['firefox']['thumbnail']),
+            'image_format': renderings['firefox']['image_format'],
             'thumbnail_format': renderings['firefox']['thumbnail_format'],
         },
         {
             'image': list(renderings['amo']['full']),
             'thumbnail': list(renderings['amo']['thumbnail']),
+            'image_format': renderings['amo']['image_format'],
             'thumbnail_format': renderings['amo']['thumbnail_format'],
         },
     ]

--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -667,11 +667,13 @@ def pngcrush_image(src, **kw):
 
 
 def resize_image(source, destination, size=None, *, format='png', quality=80):
-    """Resizes and image from src, to dst.
+    """Resizes and image from source, to destination.
     Returns a tuple of new width and height, original width and height.
 
     When dealing with local files it's up to you to ensure that all directories
     exist leading up to the dst filename.
+
+    destination can be a string filename, a Path, or a file object.
 
     quality kwarg is only valid for jpeg format - it's ignored for png.
     """

--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -671,9 +671,9 @@ def resize_image(source, destination, size=None, *, format='png', quality=80):
     Returns a tuple of new width and height, original width and height.
 
     When dealing with local files it's up to you to ensure that all directories
-    exist leading up to the dst filename.
+    exist leading up to the destination filename.
 
-    destination can be a string filename, a Path, or a file object.
+    destination can be a string filename, or a file object.
 
     quality kwarg is only valid for jpeg format - it's ignored for png.
     """
@@ -686,17 +686,16 @@ def resize_image(source, destination, size=None, *, format='png', quality=80):
         original_size = im.size
         if size:
             im = processors.scale_and_crop(im, size)
-    if format == 'png':
-        with storage.open(destination, 'wb') as fp:
+    with storage.open(destination, 'wb') as dest_file:
+        if format == 'png':
             # Save the image to PNG in destination file path.
             # Don't keep the ICC profile as it can mess up pngcrush badly
             # (mozilla/addons/issues/697).
-            im.save(fp, 'png', icc_profile=None)
-        pngcrush_image(destination)
-    else:
-        with storage.open(destination, 'wb') as fp:
+            im.save(dest_file, 'png', icc_profile=None)
+            pngcrush_image(destination)
+        else:
             im = im.convert('RGB')
-            im.save(fp, 'JPEG', quality=quality)
+            im.save(dest_file, 'JPEG', quality=quality)
     return (im.size, original_size)
 
 

--- a/src/olympia/constants/base.py
+++ b/src/olympia/constants/base.py
@@ -241,12 +241,14 @@ THEME_PREVIEW_RENDERINGS = {
         'thumbnail': _dimensions(473, 64),
         'full': _dimensions(680, 92),
         'position': 0,
+        'image_format': 'png',
         'thumbnail_format': 'png',
     },
     'amo': {
         'thumbnail': _dimensions(720, 92),
         'full': _dimensions(720, 92),
         'position': 2,
+        'image_format': 'svg',
         'thumbnail_format': 'jpg',
     },
 }

--- a/src/olympia/versions/tasks.py
+++ b/src/olympia/versions/tasks.py
@@ -21,8 +21,9 @@ from olympia.versions.models import Version, VersionPreview
 
 from .utils import (
     AdditionalBackground,
-    process_color_value,
+    convert_svg_to_png,
     encode_header,
+    process_color_value,
     write_svg_to_png,
 )
 
@@ -139,9 +140,8 @@ def render_to_svg(template, context, preview, theme_manifest):
             # and write that svg to preview.image_path
             image_path.write(finished_svg)
         # then also write a fully rendered svg to original for thumbsnails
-        # TODO: change/allow write_svg_to_png to use a file path to avoid writing twice
         # TODO: don't write to original_path, write to a temp file instead?
-        if write_svg_to_png(finished_svg, preview.original_path):
+        if convert_svg_to_png(preview.image_path, preview.original_path):
             return preview.original_path
 
 

--- a/src/olympia/versions/tasks.py
+++ b/src/olympia/versions/tasks.py
@@ -2,7 +2,10 @@ from __future__ import division
 import operator
 import os
 import itertools
+import tempfile
 
+from django.conf import settings
+from django.core.files.storage import default_storage as storage
 from django.template import loader
 
 import olympia.core.logger
@@ -68,6 +71,86 @@ def _build_static_theme_preview_context(theme_manifest, file_):
     return context
 
 
+def _build_static_theme_preview_partial_context(colors, prerendered_background_file):
+    context = {'amo': amo}
+    # we only want the colors from the manifest
+    context.update(
+        dict(process_color_value(prop, color) for prop, color in colors.items())
+    )
+    with open(prerendered_background_file, 'rb') as background_file:
+        prerendered_background = background_file.read()
+
+    header_src, _, _ = encode_header(
+        prerendered_background, 'png'
+    )
+    context['header_src'] = header_src
+    return context
+
+
+UI_FIELDS = (
+    'toolbar',
+    'tab_selected',
+    'tab_line',
+    'bookmark_text',
+    'tab_background_text',
+    'toolbar_field',
+    'toolbar_field_text',
+    'icons',
+)
+TRANSPARENT_UI = {field: 'rgb(0,0,0,0)' for field in UI_FIELDS}
+
+
+def render_to_svg(template, context, preview, theme_manifest):
+    # first stage - just the images
+    image_only_svg = template.render(context).encode('utf-8')
+
+    tmp_args = {
+        'dir': settings.TMP_PATH,
+        'mode': 'wb',
+        'delete': not settings.DEBUG,
+    }
+    with tempfile.NamedTemporaryFile(
+        suffix='.png', **tmp_args
+    ) as background_orig, tempfile.NamedTemporaryFile(
+        suffix='.jpg', **tmp_args
+    ) as background_opti:
+        # write the image only background to a file
+        if not write_svg_to_png(image_only_svg, background_orig.name):
+            return
+        # TODO: improvement - only jpg backgrounds re-encode as jpg?
+        # TODO: resize and return the jpeg as a blob so we don't have to reload it from
+        #       disk again in _build_static_theme_preview_partial_context?
+        resize_image(background_orig.name, background_opti.name, format='jpg')
+        # then rebuild a context with it and render
+        try:
+            with_ui_context = _build_static_theme_preview_partial_context(
+                theme_manifest.get('colors', {}), background_opti.name
+            )
+        except Exception as exc:
+            log.info('Exception during svg preview generation %s', exc)
+            return
+        with_ui_context.update(**{
+            'svg_render_size': context['svg_render_size'],
+            'header_src_height': context['svg_render_size'].height,
+            'header_width': context['svg_render_size'].width,
+        })
+        finished_svg = template.render(with_ui_context).encode('utf-8')
+        with storage.open(preview.image_path, 'wb') as image_path:
+            # and write that svg to preview.image_path
+            image_path.write(finished_svg)
+        # then also write a fully rendered svg to original for thumbsnails
+        # TODO: change/allow write_svg_to_png to use a file path to avoid writing twice
+        # TODO: don't write to original_path, write to a temp file instead?
+        if write_svg_to_png(finished_svg, preview.original_path):
+            return preview.original_path
+
+
+def render_to_png(template, context, preview):
+    svg = template.render(context).encode('utf-8')
+    if write_svg_to_png(svg, preview.image_path):
+        return preview.image_path
+
+
 @task
 @use_primary_db
 def generate_static_theme_preview(theme_manifest, version_pk):
@@ -79,7 +162,7 @@ def generate_static_theme_preview(theme_manifest, version_pk):
     file_ = File.objects.filter(version_id=version_pk).first()
     if not file_:
         return
-    context = _build_static_theme_preview_context(theme_manifest, file_)
+    complete_context = _build_static_theme_preview_context(theme_manifest, file_)
     renderings = sorted(
         amo.THEME_PREVIEW_RENDERINGS.values(), key=operator.itemgetter('position')
     )
@@ -89,20 +172,29 @@ def generate_static_theme_preview(theme_manifest, version_pk):
         preview = VersionPreview.objects.create(
             version_id=version_pk,
             position=rendering['position'],
-            sizes={'thumbnail_format': rendering['thumbnail_format']},
+            sizes={
+                'image_format': rendering['image_format'],
+                'thumbnail_format': rendering['thumbnail_format'],
+            },
         )
+
         # Add the size to the context and render
-        context.update(svg_render_size=rendering['full'])
-        svg = tmpl.render(context).encode('utf-8')
-        if write_svg_to_png(svg, preview.image_path):
+        complete_context.update(svg_render_size=rendering['full'])
+        if rendering['image_format'] == 'svg':
+            png_path = render_to_svg(
+                tmpl, {**complete_context, **TRANSPARENT_UI}, preview, theme_manifest
+            )
+        else:
+            png_path = render_to_png(tmpl, complete_context, preview)
+        if png_path:
             resize_image(
-                preview.image_path,
+                png_path,
                 preview.thumbnail_path,
                 rendering['thumbnail'],
                 format=rendering['thumbnail_format'],
                 quality=35,  # It's ignored for png format, so it's fine to always set.
             )
-            pngcrush_image(preview.image_path)
+            pngcrush_image(png_path)
             # Extract colors once and store it for all previews.
             # Use the thumbnail for extra speed, we don't need to be super accurate.
             if colors is None:
@@ -111,6 +203,7 @@ def generate_static_theme_preview(theme_manifest, version_pk):
                 'sizes': {
                     'image': rendering['full'],
                     'thumbnail': rendering['thumbnail'],
+                    'image_format': rendering['image_format'],
                     'thumbnail_format': rendering['thumbnail_format'],
                 },
                 'colors': colors,

--- a/src/olympia/versions/tests/test_tasks.py
+++ b/src/olympia/versions/tests/test_tasks.py
@@ -100,6 +100,7 @@ def check_preview(
 @mock.patch('olympia.versions.tasks.pngcrush_image')
 @mock.patch('olympia.versions.tasks.resize_image')
 @mock.patch('olympia.versions.tasks.write_svg_to_png')
+@mock.patch('olympia.versions.tasks.convert_svg_to_png')
 @pytest.mark.parametrize(
     'header_url, header_height, preserve_aspect_ratio, mimetype, valid_img',
     (
@@ -120,6 +121,7 @@ def check_preview(
     ),
 )
 def test_generate_static_theme_preview(
+    convert_svg_to_png_mock,
     write_svg_to_png_mock,
     resize_image_mock,
     pngcrush_image_mock,
@@ -132,6 +134,7 @@ def test_generate_static_theme_preview(
     valid_img,
 ):
     write_svg_to_png_mock.return_value = True
+    convert_svg_to_png_mock.return_value = True
     extract_colors_from_image_mock.return_value = [
         {'h': 9, 's': 8, 'l': 7, 'ratio': 0.6}
     ]
@@ -157,7 +160,8 @@ def test_generate_static_theme_preview(
 
     # for svg preview we resize the intermediate background and write the svg twice
     assert resize_image_mock.call_count == 3
-    assert write_svg_to_png_mock.call_count == 3
+    assert write_svg_to_png_mock.call_count == 2
+    assert convert_svg_to_png_mock.call_count == 1
     assert pngcrush_image_mock.call_count == 2
 
     # First check the firefox Preview is good
@@ -187,6 +191,7 @@ def test_generate_static_theme_preview(
         amo_preview,
         amo.THEME_PREVIEW_RENDERINGS['amo'],
     )
+    assert convert_svg_to_png_mock.call_args_list[0][0][0] == amo_preview.image_path
     check_thumbnail(
         amo_preview,
         amo.THEME_PREVIEW_RENDERINGS['amo'],
@@ -198,7 +203,8 @@ def test_generate_static_theme_preview(
     # Now check the svg renders
     firefox_svg = write_svg_to_png_mock.call_args_list[0][0][0]
     interim_amo_svg = write_svg_to_png_mock.call_args_list[1][0][0]
-    amo_svg = write_svg_to_png_mock.call_args_list[2][0][0]
+    with open(amo_preview.image_path) as svg:
+        amo_svg = svg.read()
     colors = [
         'class="%s" fill="%s"' % (key, color)
         for (key, color) in theme_manifest['colors'].items()
@@ -255,6 +261,7 @@ def test_generate_static_theme_preview(
 @mock.patch('olympia.versions.tasks.pngcrush_image')
 @mock.patch('olympia.versions.tasks.resize_image')
 @mock.patch('olympia.versions.tasks.write_svg_to_png')
+@mock.patch('olympia.versions.tasks.convert_svg_to_png')
 @pytest.mark.parametrize(
     'manifest_images, manifest_colors, svg_colors',
     (
@@ -302,6 +309,7 @@ def test_generate_static_theme_preview(
     ),
 )
 def test_generate_static_theme_preview_with_alternative_properties(
+    convert_svg_to_png_mock,
     write_svg_to_png_mock,
     resize_image_mock,
     pngcrush_image_mock,
@@ -312,6 +320,7 @@ def test_generate_static_theme_preview_with_alternative_properties(
     svg_colors,
 ):
     write_svg_to_png_mock.return_value = True
+    convert_svg_to_png_mock.return_value = True
     extract_colors_from_image_mock.return_value = [
         {'h': 9, 's': 8, 'l': 7, 'ratio': 0.6}
     ]
@@ -327,7 +336,8 @@ def test_generate_static_theme_preview_with_alternative_properties(
 
     # for svg preview we resize the intermediate background and write the svg twice
     assert resize_image_mock.call_count == 3
-    assert write_svg_to_png_mock.call_count == 3
+    assert write_svg_to_png_mock.call_count == 2
+    assert convert_svg_to_png_mock.call_count == 1
     assert pngcrush_image_mock.call_count == 2
 
     # First check the firefox Preview is good
@@ -357,6 +367,7 @@ def test_generate_static_theme_preview_with_alternative_properties(
         amo_preview,
         amo.THEME_PREVIEW_RENDERINGS['amo'],
     )
+    assert convert_svg_to_png_mock.call_args_list[0][0][0] == amo_preview.image_path
     check_thumbnail(
         amo_preview,
         amo.THEME_PREVIEW_RENDERINGS['amo'],
@@ -371,7 +382,8 @@ def test_generate_static_theme_preview_with_alternative_properties(
 
     firefox_svg = write_svg_to_png_mock.call_args_list[0][0][0]
     interim_amo_svg = write_svg_to_png_mock.call_args_list[1][0][0]
-    amo_svg = write_svg_to_png_mock.call_args_list[2][0][0]
+    with open(amo_preview.image_path) as svg:
+        amo_svg = svg.read()
     check_render(
         force_str(firefox_svg),
         'transparent.gif',
@@ -448,7 +460,9 @@ def check_render_additional(svg_content, inner_svg_width, colors):
 @mock.patch('olympia.versions.tasks.pngcrush_image')
 @mock.patch('olympia.versions.tasks.resize_image')
 @mock.patch('olympia.versions.tasks.write_svg_to_png')
+@mock.patch('olympia.versions.tasks.convert_svg_to_png')
 def test_generate_preview_with_additional_backgrounds(
+    convert_svg_to_png_mock,
     write_svg_to_png_mock,
     resize_image_mock,
     pngcrush_image_mock,
@@ -456,6 +470,7 @@ def test_generate_preview_with_additional_backgrounds(
     index_addons_mock,
 ):
     write_svg_to_png_mock.return_value = True
+    convert_svg_to_png_mock.return_value = True
     extract_colors_from_image_mock.return_value = [
         {'h': 9, 's': 8, 'l': 7, 'ratio': 0.6}
     ]
@@ -484,7 +499,8 @@ def test_generate_preview_with_additional_backgrounds(
 
     # for svg preview we resize the intermediate background and write the svg twice
     assert resize_image_mock.call_count == 3
-    assert write_svg_to_png_mock.call_count == 3
+    assert write_svg_to_png_mock.call_count == 2
+    assert convert_svg_to_png_mock.call_count == 1
     assert pngcrush_image_mock.call_count == 2
 
     # First check the firefox Preview is good
@@ -514,6 +530,7 @@ def test_generate_preview_with_additional_backgrounds(
         amo_preview,
         amo.THEME_PREVIEW_RENDERINGS['amo'],
     )
+    assert convert_svg_to_png_mock.call_args_list[0][0][0] == amo_preview.image_path
     check_thumbnail(
         amo_preview,
         amo.THEME_PREVIEW_RENDERINGS['amo'],
@@ -538,7 +555,8 @@ def test_generate_preview_with_additional_backgrounds(
 
     firefox_svg = write_svg_to_png_mock.call_args_list[0][0][0]
     interim_amo_svg = write_svg_to_png_mock.call_args_list[1][0][0]
-    amo_svg = write_svg_to_png_mock.call_args_list[2][0][0]
+    with open(amo_preview.image_path) as svg:
+        amo_svg = svg.read()
     check_render_additional(force_str(firefox_svg), 680, colors)
     check_render_additional(force_str(interim_amo_svg), 720, transparent_colors)
     check_render(

--- a/src/olympia/versions/tests/test_tasks.py
+++ b/src/olympia/versions/tests/test_tasks.py
@@ -19,7 +19,8 @@ HEADER_ROOT = os.path.join(settings.ROOT, 'src/olympia/versions/tests/static_the
 
 transparent_colors = [
     'class="%s" fill="rgb(0,0,0,0)"' % (field)
-    for field in UI_FIELDS if field != 'icons'  # bookmark_text class used instead
+    for field in UI_FIELDS
+    if field != 'icons'  # bookmark_text class used instead
 ]
 
 
@@ -68,13 +69,14 @@ def check_thumbnail(
     theme_size_constant,
     source_png_path,
     resize_image_mock_args_kwargs,
-    png_crush_mock_args,
+    png_crush_mock_args=None,
 ):
     (resize_path, thumb_path, thumb_size), resize_kwargs = resize_image_mock_args_kwargs
     assert resize_path == source_png_path
     assert thumb_path == preview_instance.thumbnail_path
     assert thumb_size == tuple(preview_instance.thumbnail_dimensions)
-    assert png_crush_mock_args[0] == source_png_path
+    if png_crush_mock_args:
+        assert png_crush_mock_args[0] == source_png_path
     assert preview_instance.colors
     assert resize_kwargs == {
         'format': theme_size_constant['thumbnail_format'],
@@ -162,7 +164,7 @@ def test_generate_static_theme_preview(
     assert resize_image_mock.call_count == 3
     assert write_svg_to_png_mock.call_count == 2
     assert convert_svg_to_png_mock.call_count == 1
-    assert pngcrush_image_mock.call_count == 2
+    assert pngcrush_image_mock.call_count == 1
 
     # First check the firefox Preview is good
     firefox_preview = VersionPreview.objects.get(
@@ -195,9 +197,8 @@ def test_generate_static_theme_preview(
     check_thumbnail(
         amo_preview,
         amo.THEME_PREVIEW_RENDERINGS['amo'],
-        amo_preview.original_path,
+        convert_svg_to_png_mock.call_args_list[0][0][1],
         resize_image_mock.call_args_list[2],
-        pngcrush_image_mock.call_args_list[1][0],
     )
 
     # Now check the svg renders
@@ -338,7 +339,7 @@ def test_generate_static_theme_preview_with_alternative_properties(
     assert resize_image_mock.call_count == 3
     assert write_svg_to_png_mock.call_count == 2
     assert convert_svg_to_png_mock.call_count == 1
-    assert pngcrush_image_mock.call_count == 2
+    assert pngcrush_image_mock.call_count == 1
 
     # First check the firefox Preview is good
     firefox_preview = VersionPreview.objects.get(
@@ -371,9 +372,8 @@ def test_generate_static_theme_preview_with_alternative_properties(
     check_thumbnail(
         amo_preview,
         amo.THEME_PREVIEW_RENDERINGS['amo'],
-        amo_preview.original_path,
+        convert_svg_to_png_mock.call_args_list[0][0][1],
         resize_image_mock.call_args_list[2],
-        pngcrush_image_mock.call_args_list[1][0],
     )
 
     colors = [
@@ -501,7 +501,7 @@ def test_generate_preview_with_additional_backgrounds(
     assert resize_image_mock.call_count == 3
     assert write_svg_to_png_mock.call_count == 2
     assert convert_svg_to_png_mock.call_count == 1
-    assert pngcrush_image_mock.call_count == 2
+    assert pngcrush_image_mock.call_count == 1
 
     # First check the firefox Preview is good
     firefox_preview = VersionPreview.objects.get(
@@ -534,9 +534,8 @@ def test_generate_preview_with_additional_backgrounds(
     check_thumbnail(
         amo_preview,
         amo.THEME_PREVIEW_RENDERINGS['amo'],
-        amo_preview.original_path,
+        convert_svg_to_png_mock.call_args_list[0][0][1],
         resize_image_mock.call_args_list[2],
-        pngcrush_image_mock.call_args_list[1][0],
     )
 
     # These defaults are mostly defined in the xml template

--- a/src/olympia/versions/utils.py
+++ b/src/olympia/versions/utils.py
@@ -55,6 +55,7 @@ def convert_svg_to_png(svg_file, png_file):
     except subprocess.CalledProcessError as process_error:
         log.info(process_error)
         return False
+    return True
 
 
 def write_svg_to_png(svg_content, out):

--- a/src/olympia/versions/utils.py
+++ b/src/olympia/versions/utils.py
@@ -38,6 +38,25 @@ def get_next_version_number(addon):
             version_counter += 1
 
 
+def convert_svg_to_png(svg_file, png_file):
+    try:
+        if not os.path.exists(os.path.dirname(png_file)):
+            os.makedirs(os.path.dirname(png_file))
+        command = [
+            settings.RSVG_CONVERT_BIN,
+            '--output',
+            png_file,
+            svg_file,
+        ]
+        subprocess.check_call(command)
+    except IOError as io_error:
+        log.info(io_error)
+        return False
+    except subprocess.CalledProcessError as process_error:
+        log.info(process_error)
+        return False
+
+
 def write_svg_to_png(svg_content, out):
     # when settings.DEBUG is on (i.e. locally) don't delete the svgs.
     tmp_args = {
@@ -49,24 +68,7 @@ def write_svg_to_png(svg_content, out):
     with tempfile.NamedTemporaryFile(**tmp_args) as temporary_svg:
         temporary_svg.write(svg_content)
         temporary_svg.flush()
-
-        try:
-            if not os.path.exists(os.path.dirname(out)):
-                os.makedirs(os.path.dirname(out))
-            command = [
-                settings.RSVG_CONVERT_BIN,
-                '--output',
-                out,
-                temporary_svg.name,
-            ]
-            subprocess.check_call(command)
-        except IOError as io_error:
-            log.info(io_error)
-            return False
-        except subprocess.CalledProcessError as process_error:
-            log.info(process_error)
-            return False
-    return True
+        return convert_svg_to_png(temporary_svg.name, out)
 
 
 def encode_header(header_blob, file_ext):


### PR DESCRIPTION
fixes #16755 - for new uploads at least.  I'll look into migrating existing previews after, though I think `process_addons --task=recreate_theme_previews` will work as is (`task=create_missing_theme_previews` wouldn't)