### PR TITLE
Fixes #16744 Extension Workshop URLS must end with a trailing slash to not lose query params

### DIFF
--- a/src/olympia/devhub/templates/devhub/nav.html
+++ b/src/olympia/devhub/templates/devhub/nav.html
@@ -34,11 +34,11 @@
     <li>
       <a href="#" class="controller">{{ _('Documentation') }}</a>
       <ul>
-        <li><a href="https://extensionworkshop.com/documentation/develop?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=dev-hub-legacy-menu-link">
+        <li><a href="https://extensionworkshop.com/documentation/develop/?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=dev-hub-legacy-menu-link">
           {{ _('Extension Development') }}</a></li>
-        <li><a href="https://extensionworkshop.com/documentation/themes?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=dev-hub-legacy-menu-link">
+        <li><a href="https://extensionworkshop.com/documentation/themes/?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=dev-hub-legacy-menu-link">
           {{ _('Themes') }}</a></li>
-        <li><a href="https://extensionworkshop.com/documentation/publish/add-on-policies?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=dev-hub-legacy-menu-link">
+        <li><a href="https://extensionworkshop.com/documentation/publish/add-on-policies/?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=dev-hub-legacy-menu-link">
           {{ _('Developer Policies') }}</a></li>
       </ul>
     </li>


### PR DESCRIPTION
Fixes #16744 

Added **/** before **?** in three links inside src/olympia/devhub/templates/devhub/nav.html