### PR TITLE
Add collections-themes to shelf-endpoint-type

### DIFF
--- a/docs/topics/api/shelves.rst
+++ b/docs/topics/api/shelves.rst
@@ -113,14 +113,16 @@ small number of shelves this endpoint is not paginated.
 
     Possible values for the ``endpoint`` field:
 
-    ==============  ====================================================================
-             Value  Description
-    ==============  ====================================================================
-            search  an :ref:`addon search<addon-search>`, excluding ``?type=statictheme``
-     search-themes  an :ref:`addon search<addon-search>`, with ``?type=statictheme``
-       collections  a mozilla :ref:`collection<collection-addon-list>`.
-                    The collection slug will be in ``criteria``
-    ==============  ====================================================================
+    ===================  ====================================================================
+                  Value  Description
+    ===================  ====================================================================
+                 search  an :ref:`addon search<addon-search>`, excluding ``?type=statictheme``
+          search-themes  an :ref:`addon search<addon-search>`, with ``?type=statictheme``
+            collections  a mozilla :ref:`collection<collection-addon-list>`.
+                         The collection slug for these extensions will be in ``criteria``
+     collections-themes  a mozilla :ref:`collection<collection-addon-list>`.
+                         The collection slug for these themes will be in ``criteria``
+    ===================  ====================================================================
 
 
 ----------------------------------

--- a/src/olympia/shelves/forms.py
+++ b/src/olympia/shelves/forms.py
@@ -50,7 +50,7 @@ class ShelfForm(forms.ModelForm):
                 )
             api = reverse(f'{api_settings.DEFAULT_VERSION}:addon-search')
             url = base_url + api + criteria
-        elif endpoint == 'collections':
+        elif endpoint in ('collections', 'collections-themes'):
             try:
                 api = reverse(
                     f'{api_settings.DEFAULT_VERSION}:collection-addon-list',

--- a/src/olympia/shelves/models.py
+++ b/src/olympia/shelves/models.py
@@ -2,7 +2,7 @@ from django.db import models
 
 from olympia.amo.models import ModelBase
 
-ENDPOINTS = ('collections', 'search', 'search-themes')
+ENDPOINTS = ('collections', 'collections-themes', 'search', 'search-themes')
 
 ENDPOINT_CHOICES = tuple((ty, ty) for ty in ENDPOINTS)
 

--- a/src/olympia/shelves/tests/test_forms.py
+++ b/src/olympia/shelves/tests/test_forms.py
@@ -11,6 +11,7 @@ class TestShelfForm(TestCase):
     def setUp(self):
         self.criteria_sea = '?promoted=recommended&sort=random&type=extension'
         self.criteria_col = 'password-managers'
+        self.criteria_col_themes = 'olympicgames-rio-by-lucky9'
         self.criteria_col_404 = 'passwordmanagers'
         self.criteria_not_200 = '?sort=user&type=extension'
         self.criteria_empty = '?sort=users&type=theme'
@@ -28,6 +29,18 @@ class TestShelfForm(TestCase):
                 kwargs={
                     'user_pk': settings.TASK_USER_ID,
                     'collection_slug': self.criteria_col,
+                },
+            ),
+            status=200,
+            json={'count': 1},
+        )
+        responses.add(
+            responses.GET,
+            reverse_ns(
+                'collection-addon-list',
+                kwargs={
+                    'user_pk': settings.TASK_USER_ID,
+                    'collection_slug': self.criteria_col_themes,
                 },
             ),
             status=200,
@@ -83,6 +96,18 @@ class TestShelfForm(TestCase):
         )
         assert form.is_valid(), form.errors
         assert form.cleaned_data['criteria'] == 'password-managers'
+
+    def test_clean_collections_themes(self):
+        form = ShelfForm(
+            {
+                'title': 'Olympic Themes (Collections)',
+                'endpoint': 'collections-themes',
+                'criteria': self.criteria_col_themes,
+                'addon_count': '0',
+            },
+        )
+        assert form.is_valid(), form.errors
+        assert form.cleaned_data['criteria'] == 'olympicgames-rio-by-lucky9'
 
     def test_clean_form_is_missing_title_field(self):
         form = ShelfForm(


### PR DESCRIPTION
This pull request adds `collections-themes` as a shelf endpoint type to help differentiate collections for extensions and collections for themes.

The update has been reflected within the following:
- `api/shelves.rst`
- `shelves/forms.py`
- `shelves/models.py`
- `shelves/tests/test_forms.py`

Please review when you have a moment. Thank you!