### PR TITLE
Handle License.name using our existing translation fields

### DIFF
--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -1,7 +1,6 @@
 import re
 from urllib.parse import urlsplit, urlunsplit
 
-from django.conf import settings
 from django.http.request import QueryDict
 from django.urls import reverse
 

--- a/src/olympia/api/fields.py
+++ b/src/olympia/api/fields.py
@@ -414,13 +414,13 @@ class GetTextTranslationSerializerField(TranslationSerializerField):
         base_locale = to_language(settings.LANGUAGE_CODE)
         translations = {}
         if base_locale in langs:
-            # we get the base_locale for free - it's just the field text
-            translations[base_locale] = str(field)
-            langs = (lang for lang in langs if lang != base_locale)
+            with override(base_locale):
+                translations[base_locale] = str(field)
+                langs = (lang for lang in langs if lang != base_locale)
         for lang in langs:
             with override(lang):
                 value = gettext(field)
-                if value not in translations.values():
+                if value != translations.get(base_locale):
                     translations[lang] = value
         return translations
 

--- a/src/olympia/api/tests/test_fields.py
+++ b/src/olympia/api/tests/test_fields.py
@@ -538,18 +538,21 @@ class TestGetTextTranslationSerializerField(TestCase):
         thing.desc = self.desc_en
         thing.default_locale = 'de'
 
-        assert self.serialize(thing)['desc'] == {
-            'en-US': self.desc_en,
-            'de': self.desc_de,
-        }
-
-        # repeat for the edge case when we have a different system language than en-US
+        # No lang specified, so we're returning the default + the one currently
+        # activated in the thread + the base system one.
         with self.activate('fr'):
             assert self.serialize(thing)['desc'] == {
                 'en-US': self.desc_en,
                 'fr': self.desc_fr,
                 'de': self.desc_de,
             }
+
+        # No lang specified but the one currently activated should be en-US,
+        # and it's only returned once.
+        assert self.serialize(thing)['desc'] == {
+            'en-US': self.desc_en,
+            'de': self.desc_de,
+        }
 
     def test_lang_specified(self):
         thing = Thing()


### PR DESCRIPTION
Because of builtin licenses and the way they have their names translated using `gettext()`, we were previously handling `License.name` in a completely custom way, emulating the behavior of `TranslationField`, but we didn't update that for v5.

This makes it use the existing fields so that it will automatically follow their behavior in the future.

Fixes #16952