### PR TITLE
#16888 Update links in base.ltxt email to developers

### DIFF
--- a/src/olympia/reviewers/templates/reviewers/emails/base.ltxt
+++ b/src/olympia/reviewers/templates/reviewers/emails/base.ltxt
@@ -8,11 +8,11 @@ Developer Resources
 
 To respond, please reply to this email or visit: {{ dev_versions_url }}
 
-You can also get in touch with us using these channels: https://developer.mozilla.org/Add-ons#Contact_us
+You can also get in touch with us using these channels: https://wiki.mozilla.org/Add-ons#Contact_us
 
-For tips on how to attract more users by updating your add-on’s listing, please visit: https://developer.mozilla.org/Add-ons/Listing
+For tips on how to attract more users by updating your add-on’s listing, please visit: https://extensionworkshop.com/documentation/develop/create-an-appealing-listing
 
-To learn more about the review process, please visit: https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Reviews
+To learn more about the review process, please visit: https://extensionworkshop.com/documentation/publish/add-on-policies/
 
 -- 
 Mozilla Add-ons Team


### PR DESCRIPTION
Fixes #16888 

Update of the links used in [base.ltxt](https://github.com/mozilla/addons-server/blob/master/src/olympia/reviewers/templates/reviewers/emails/base.ltxt) by those proposed by @caitmuenster .

> Get in touch with us using these channels --> https://wiki.mozilla.org/Add-ons#Contact_us
> Tips for updating your add-on's listing --> https://extensionworkshop.com/documentation/develop/create-an-appealing-listing/
> Learn more about the review process --> https://extensionworkshop.com/documentation/publish/add-on-policies/
