### PR TITLE
Fix reviewers review log filtering to include force disable/enable for listed reviewers

### DIFF
--- a/src/olympia/reviewers/templates/reviewers/reviewlog.html
+++ b/src/olympia/reviewers/templates/reviewers/reviewlog.html
@@ -50,10 +50,10 @@
                   {% endif %}
                   {% if item.action == amo.LOG.REJECT_CONTENT.id or item.action == amo.LOG.APPROVE_CONTENT.id %}
                     {% set review_url = url('reviewers.review', 'content', item.arguments[0].slug ) %}
-                  {% elif channel == amo.RELEASE_CHANNEL_LISTED %}
-                    {% set review_url = url('reviewers.review', item.arguments[0].slug) %}
-                  {% else %}
+                  {% elif channel == amo.RELEASE_CHANNEL_UNLISTED %}
                     {% set review_url = url('reviewers.review', 'unlisted', item.arguments[0].slug) %}
+                  {% else %}
+                    {% set review_url = url('reviewers.review', item.arguments[0].slug) %}
                   {% endif %}
                   <a href="{{ review_url }}">
                     {{ item.log.short }}

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -519,6 +519,23 @@ class TestReviewLog(ReviewerTest):
         url = reverse('reviewers.review', args=['unlisted', addon.slug])
         assert pq(response.content)('#log-listing tr td a').eq(1).attr('href') == url
 
+    def test_review_url_force_disable(self):
+        self.login_as_reviewer()
+        addon = addon_factory()
+
+        ActivityLog.create(
+            amo.LOG.FORCE_DISABLE,
+            addon,
+            user=self.get_user(),
+        )
+
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        url = reverse('reviewers.review', args=[addon.slug])
+
+        link = pq(response.content)('#log-listing tbody tr[data-addonid] a').eq(1)
+        assert link.attr('href') == url
+
     def test_reviewers_can_only_see_addon_types_they_have_perms_for(self):
         def check_two_showing():
             response = self.client.get(self.url)

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -1155,8 +1155,9 @@ def reviewlog(request):
     if not acl.check_unlisted_addons_viewer_or_reviewer(request):
         # Only display logs related to unlisted versions to users with the
         # right permission.
-        list_channel = amo.RELEASE_CHANNEL_LISTED
-        approvals = approvals.filter(versionlog__version__channel=list_channel)
+        approvals = approvals.exclude(
+            versionlog__version__channel=amo.RELEASE_CHANNEL_UNLISTED
+        )
     if not acl.check_listed_addons_reviewer(request):
         approvals = approvals.exclude(
             versionlog__version__addon__type__in=amo.GROUP_TYPE_ADDON


### PR DESCRIPTION
Flip the logic around: if the user doesn't have unlisted permission, instead of filtering to only show activities linked to a version on listed channel, exclude those on unlisted channel. That makes activities not linked to a particular version, like force disable/enable, visible for those users.

Same idea applied to the review link URL: instead of defaulting to unlisted and changing that if the activity is linked to a listed version, default to listed and only link to unlisted review page if the activity is linked to an unlisted version.

Fixes #16743