### PR TITLE
expose privacy policy, eula, and license links

### DIFF
--- a/src/olympia/addons/urls.py
+++ b/src/olympia/addons/urls.py
@@ -11,8 +11,10 @@ ADDON_ID = r"""(?P<addon_id>[^/<>"']+)"""
 # These will all start with /addon/<addon_id>/
 detail_patterns = [
     re_path(r'^$', frontend_view, name='addons.detail'),
+    re_path(r'^eula/', frontend_view, name='addons.eula'),
     re_path(r'^license/(?P<version>[^/]+)?', frontend_view, name='addons.license'),
     re_path(r'^reviews/', include('olympia.ratings.urls')),
+    re_path(r'^privacy/', frontend_view, name='addons.privacy'),
     re_path(r'^statistics/', include(stats_patterns)),
     re_path(r'^versions/', include('olympia.versions.urls')),
 ]

--- a/src/olympia/amo/tests/test_sitemap.py
+++ b/src/olympia/amo/tests/test_sitemap.py
@@ -16,25 +16,46 @@ from olympia.amo.sitemap import (
     get_sitemap_section_pages,
     sitemaps,
 )
-from olympia.amo.tests import addon_factory, collection_factory, user_factory
+from olympia.amo.tests import (
+    addon_factory,
+    collection_factory,
+    license_factory,
+    user_factory,
+)
 
 from .test_views import TEST_SITEMAPS_DIR
 
 
 def test_addon_sitemap():
-    addon_a = addon_factory()
+    addon_a = addon_factory(
+        privacy_policy='privacy!',
+        eula='eula!',
+        version_kw={'license': license_factory()},
+    )
+    # addon_factory generates licenses by default, but always with a builtin >0
     addon_b = addon_factory()
-    addon_c = addon_factory()
     addon_b.update(last_updated=datetime.datetime(2020, 1, 1, 1, 1, 1))
+    addon_c = addon_factory(
+        eula='only eula', version_kw={'license': license_factory(builtin=1)}
+    )
+    addon_d = addon_factory(privacy_policy='only privacy')
     addon_factory(status=amo.STATUS_NOMINATED)  # shouldn't show up
     sitemap = AddonSitemap()
     assert list(sitemap.items()) == [
-        (addon_c.last_updated, addon_c.slug),
-        (addon_a.last_updated, addon_a.slug),
-        (addon_b.last_updated, addon_b.slug),
+        (addon_d.last_updated, addon_d.slug, 'detail'),
+        (addon_c.last_updated, addon_c.slug, 'detail'),
+        (addon_a.last_updated, addon_a.slug, 'detail'),
+        (addon_b.last_updated, addon_b.slug, 'detail'),
+        (addon_d.last_updated, addon_d.slug, 'privacy'),
+        (addon_a.last_updated, addon_a.slug, 'privacy'),
+        (addon_c.last_updated, addon_c.slug, 'eula'),
+        (addon_a.last_updated, addon_a.slug, 'eula'),
+        (addon_a.last_updated, addon_a.slug, 'license'),
     ]
     for item in sitemap.items():
-        assert sitemap.location(item) == reverse('addons.detail', args=[item.slug])
+        assert sitemap.location(item) == reverse(
+            'addons.' + item.urlname, args=[item.slug]
+        )
         assert '/en-US/firefox/' in sitemap.location(item)
         assert sitemap.lastmod(item) == item.last_updated
 
@@ -104,13 +125,17 @@ def test_build_sitemap():
 
     # then a section build
     def items_mock(self):
-        AddonValuesList = namedtuple('AddonValuesList', 'last_updated,slug')
+        AddonValuesList = namedtuple('AddonValuesList', 'last_updated,slug,urlname')
         return [
             AddonValuesList(
-                datetime.datetime(2020, 10, 2, 0, 0, 0), 'delicious-pierogi'
+                datetime.datetime(2020, 10, 2, 0, 0, 0), 'delicious-pierogi', 'detail'
             ),
-            AddonValuesList(datetime.datetime(2020, 10, 1, 0, 0, 0), 'swanky-curry'),
-            AddonValuesList(datetime.datetime(2020, 9, 30, 0, 0, 0), 'spicy-pierogi'),
+            AddonValuesList(
+                datetime.datetime(2020, 10, 1, 0, 0, 0), 'swanky-curry', 'detail'
+            ),
+            AddonValuesList(
+                datetime.datetime(2020, 9, 30, 0, 0, 0), 'spicy-pierogi', 'detail'
+            ),
         ]
 
     with mock.patch.object(AddonSitemap, 'items', items_mock):


### PR DESCRIPTION
fixes #16907 - just eula, privacy, and licenses.  I'm going to leave ratings and versions to a separate issue because pagination.