### PR TITLE
Changed the icon, text and link of mailing list in connect section

### DIFF
--- a/src/olympia/devhub/templates/devhub/new-landing/components/connect.html
+++ b/src/olympia/devhub/templates/devhub/new-landing/components/connect.html
@@ -15,7 +15,7 @@
         <h4>{{ _('More') }}</h4>
         <ul>
           <li><a class="Before-Icon Before-Icon-matrix" href="https://chat.mozilla.org/#/room/#addons:mozilla.org">{{ _('Matrix') }}</a></li>
-          <li><a class="Before-Icon Before-Icon-mail" href="https://mail.mozilla.org/listinfo/dev-addons">{{ _('Add-on Developers Mailing List') }}</a></li>
+          <li><a class="Before-Icon Before-Icon-matrix" href="https://discourse.mozilla.org/c/add-ons/">{{ _('Community forum') }}</a></li>
         </ul>
       </div>
      <div class="DevHub-Connect-section">


### PR DESCRIPTION
Fixes #16750 

The link is currently dead and it has been updated to point to https://discourse.mozilla.org/c/add-ons/. 
The text has been updated to Community forum and the icon changed to the Matrix one.

Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.

Please delete anything that isn't relevant to your patch.

* [x] This PR relates to an existing open issue and there are no existing PRs open for the same issue.
* [x] Add `Fixes #ISSUENUM` at the top of your PR.
* [x] Add a description of the changes introduced in this PR.
* [x] The change has been successfully run locally.
* [ ] Add before and after screenshots (Only for changes that impact the UI).

