### PR TITLE
use FileResponse when returning sitemap files to stream response

### DIFF
--- a/src/olympia/amo/tests/test_views.py
+++ b/src/olympia/amo/tests/test_views.py
@@ -532,7 +532,7 @@ class TestSitemap(TestCase):
         assert result.get('Content-Type') == 'application/xml'
         assert (
             b'<sitemap><loc>http://testserver/sitemap.xml?section=amo</loc>'
-            in result.content
+            in result.getvalue()
         )
 
     @override_settings(SITEMAP_STORAGE_PATH=TEST_SITEMAPS_DIR)
@@ -542,7 +542,7 @@ class TestSitemap(TestCase):
         assert result.get('Content-Type') == 'application/xml'
         assert (
             b'<url><loc>http://testserver/en-US/about</loc><lastmod>2021-04-08<'
-            in result.content
+            in result.getvalue()
         )
 
         # a section with more than one page
@@ -551,7 +551,7 @@ class TestSitemap(TestCase):
         assert result.get('Content-Type') == 'application/xml'
         assert (
             b'<loc>http://testserver/en-US/firefox/addon/delicious-pierogi/</loc>'
-            in result.content
+            in result.getvalue()
         )
 
     @override_settings(SITEMAP_STORAGE_PATH=TEST_SITEMAPS_DIR)


### PR DESCRIPTION
fixes #16985 

I wasn't sure if I should switch the `?debug` responses to `StreamingResponse` too but it's unclear it'd provide much benefit there as the content is already full rendered and available.  (And it's an edge case for development anyway)