### PR TITLE
RE: Update shelves - collections shelves with themes

### DIFF
--- a/src/olympia/shelves/forms.py
+++ b/src/olympia/shelves/forms.py
@@ -38,21 +38,22 @@ class ShelfForm(forms.ModelForm):
         if criteria is None:
             return
 
-        params = criteria[1:].split('&')
-        if addon_type == amo.ADDON_EXTENSION and 'type=statictheme' in params:
-            raise forms.ValidationError(
-                'Use "Theme (Static)" in Addon type field for type=statictheme.'
-            )
-        elif addon_type == amo.ADDON_STATICTHEME and 'type=statictheme' not in params:
-            raise forms.ValidationError(
-                'Check fields - for "Theme (Static)" addon type, use type=statictheme. '
-                'For non theme addons, use "Extension" in Addon type field, '
-                'not "Theme (Static)".'
-            )
-
         if endpoint == 'search':
             if not criteria.startswith('?') or criteria.count('?') > 1:
                 raise forms.ValidationError('Check criteria field.')
+            params = criteria[1:].split('&')
+            if addon_type == amo.ADDON_EXTENSION and 'type=statictheme' in params:
+                raise forms.ValidationError(
+                    'Use "Theme (Static)" in Addon type field for type=statictheme.'
+                )
+            elif (
+                addon_type == amo.ADDON_STATICTHEME and 'type=statictheme' not in params
+            ):
+                raise forms.ValidationError(
+                    'Check fields - for "Theme (Static)" addon type, use type=statictheme. '
+                    'For non theme addons, use "Extension" in Addon type field, '
+                    'not "Theme (Static)".'
+                )
             api = reverse(f'{api_settings.DEFAULT_VERSION}:addon-search')
             url = base_url + api + criteria
         elif endpoint == 'collections':

--- a/src/olympia/shelves/forms.py
+++ b/src/olympia/shelves/forms.py
@@ -50,9 +50,9 @@ class ShelfForm(forms.ModelForm):
                 addon_type == amo.ADDON_STATICTHEME and 'type=statictheme' not in params
             ):
                 raise forms.ValidationError(
-                    'Check fields - for "Theme (Static)" addon type, use type=statictheme. '
-                    'For non theme addons, use "Extension" in Addon type field, '
-                    'not "Theme (Static)".'
+                    'Check fields - for "Theme (Static)" addon type, use '
+                    'type=statictheme. For non theme addons, use "Extension" in Addon '
+                    'type field, not "Theme (Static)".'
                 )
             api = reverse(f'{api_settings.DEFAULT_VERSION}:addon-search')
             url = base_url + api + criteria


### PR DESCRIPTION
Fixes #16997

This pull request updates `forms.py` to check the params only when `search` is selected as the endpoint, as `collections` would not have `type=` in its criteria slug.

To be more thorough with the tests, there are now four distinct tests in `test_forms.py` to check each combination:
-`test_clean_search_extensions`,
-`test_clean_search_themes`,
-`test_clean_collections_extensions`,
-`test_clean_collections_themes`

In addition, the last two tests within `test_forms.py` were also updated. I have also updated the titles for clarification:
- `test_clean_cannot_use_theme_addontype_without_type_statictheme`
- `test_clean_cannot_use_extensions_addontype_with_type_statictheme`

Note, with this update, the admin is able to now create a shelf with the `collections` endpoint using either addon type. The code, however, is not checking whether the slug will return extensions or themes. Should this be a concern?

@eviljeff, please review when you have a moment. Thank you!
