### PR TITLE
fix: remove "xml" as allowed filetype from uploader

### DIFF
--- a/static/js/common/upload-addon.js
+++ b/static/js/common/upload-addon.js
@@ -32,7 +32,7 @@
 
   $.fn.addonUploader = function (options) {
     var settings = {
-      filetypes: ['zip', 'xpi', 'crx', 'xml'],
+      filetypes: ['zip', 'xpi', 'crx'],
       getErrors: getErrors,
       cancel: $(),
       maxSize: 200 * 1024 * 1024, // 200M


### PR DESCRIPTION
Follow-up to #13729 and #16090

I came across this small issue when I investigated the current state for https://github.com/mozilla/extension-workshop/pull/990