### PR TITLE
Updated the API docs for homepage shelves endpoint

### DIFF
--- a/docs/topics/api/shelves.rst
+++ b/docs/topics/api/shelves.rst
@@ -97,7 +97,7 @@ small number of shelves this endpoint is not paginated.
 
     :query string lang: Activate translations in the specific language for that query. (See :ref:`translated fields <api-overview-translations>`)
     :>json array results: The array of shelves displayed on the AMO Homepage.
-    :>json object|null results[].headline: The title of the shelf. (See :ref:`translated fields <api-overview-translations>`.  Note: when ``lang`` is not specified, not all locales will be returned, unlike other translated fields).
+    :>json object|null results[].title: The title of the shelf. (See :ref:`translated fields <api-overview-translations>`.  Note: when ``lang`` is not specified, not all locales will be returned, unlike other translated fields).
     :>json string results[].url: The configured URL using the shelf's endpoint and criteria; links to the shelf's returned add-ons.
     :>json string results[].endpoint: The :ref:`endpoint type <shelf-endpoint-type>` selected for the shelf.
     :>json string results[].addon_type: The :ref:`add-on type <addon-detail-type>` selected for the shelf.
@@ -105,7 +105,7 @@ small number of shelves this endpoint is not paginated.
     :>json object|null results[].footer: The optional footer to be displayed with the shelf.
     :>json string results[].footer.url: The optional url for the footer text.
     :>json string results[].footer.outgoing: url wrapped with outgoing (See :ref:`Outgoing Links <api-overview-outgoing>`)
-    :>json object|null results[].cta.text: The optional text in the footer of the shelf. (See :ref:`translated fields <api-overview-translations>`.  Note: when ``lang`` is not specified, not all locales will be returned, unlike other translated fields).
+    :>json object|null results[].footer.text: The optional text in the footer of the shelf. (See :ref:`translated fields <api-overview-translations>`.  Note: when ``lang`` is not specified, not all locales will be returned, unlike other translated fields).
     :>json array results[].addons: An array of :ref:`add-ons <addon-detail-object>`.
     :>json object primary: A :ref:`primary hero shelf <primary-hero-shelf>`.
     :>json object secondary: A :ref:`secondary hero shelf <secondary-hero-shelf>`.


### PR DESCRIPTION
Fixes #17038 

The API response was incorrect for the `/shelves/` endpoint. It mentions
`headline` instead of `title` and `cta.text` instead of `footer.text`. The
documentation needs to be updated to reflect the actual API response.

Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.

Please delete anything that isn't relevant to your patch.

* [x] This PR relates to an existing open issue and there are no existing
      PRs open for the same issue.
* [x] Add `Fixes #ISSUENUM` at the top of your PR.
* [x] Add a description of the changes introduced in this PR.
* [x] The change has been successfully run locally.
* [x] Add tests to cover the changes added in this PR.
* [x] Add before and after screenshots (Only for changes that impact the UI).

