### PR TITLE
add (single) versions page to AddonSitemap

### DIFF
--- a/src/olympia/amo/sitemap.py
+++ b/src/olympia/amo/sitemap.py
@@ -73,6 +73,10 @@ class AddonSitemap(Sitemap):
                 for addon in addons
             ),
             *(
+                self.item_tuple(addon.last_updated, addon.slug, 'versions')
+                for addon in addons
+            ),
+            *(
                 self.item_tuple(addon.last_updated, addon.slug, 'privacy')
                 for addon in addons
                 if addon.has_privacy

--- a/src/olympia/amo/tests/test_sitemap.py
+++ b/src/olympia/amo/tests/test_sitemap.py
@@ -72,6 +72,11 @@ def test_addon_sitemap():
         it(addon_c.last_updated, addon_c.slug, 'detail', 1),
         it(addon_a.last_updated, addon_a.slug, 'detail', 1),
         it(addon_b.last_updated, addon_b.slug, 'detail', 1),
+        it(addon_e.last_updated, addon_e.slug, 'versions', 1),
+        it(addon_d.last_updated, addon_d.slug, 'versions', 1),
+        it(addon_c.last_updated, addon_c.slug, 'versions', 1),
+        it(addon_a.last_updated, addon_a.slug, 'versions', 1),
+        it(addon_b.last_updated, addon_b.slug, 'versions', 1),
         it(addon_d.last_updated, addon_d.slug, 'privacy', 1),
         it(addon_a.last_updated, addon_a.slug, 'privacy', 1),
         it(addon_c.last_updated, addon_c.slug, 'eula', 1),
@@ -300,7 +305,7 @@ def test_get_sitemap_section_pages():
         ('collections', 1),
         ('users', 1),
     ]
-    with mock.patch.object(AddonSitemap, 'limit', 3):
+    with mock.patch.object(AddonSitemap, 'limit', 5):
         pages = get_sitemap_section_pages()
         assert pages == [
             ('amo', 1),


### PR DESCRIPTION
fixes #17019 

We don't need any complex logic for the versions page because every public addon has one (and only one) - as Bob pointed out in #17048, we don't have paginated versions pages on AMO frontend.