### PR TITLE
only generate canonical user account profile urls (no double pagination)

### DIFF
--- a/src/olympia/amo/sitemap.py
+++ b/src/olympia/amo/sitemap.py
@@ -242,14 +242,14 @@ class AccountSitemap(Sitemap):
             theme_pages_needed = math.ceil(
                 (user.theme_count or 1) / THEMES_BY_AUTHORS_PAGE_SIZE
             )
-            page_combinations_needed = (
-                (ext_page, theme_page)
-                for ext_page in range(1, extension_pages_needed + 1)
-                for theme_page in range(1, theme_pages_needed + 1)
-            )
             items.extend(
-                self.item_tuple(user.addons_updated, user.id, ext_page, theme_page)
-                for ext_page, theme_page in page_combinations_needed
+                self.item_tuple(user.addons_updated, user.id, ext_page, 1)
+                for ext_page in range(1, extension_pages_needed + 1)
+            )
+            # start themes at 2 because we don't want (1, 1) twice
+            items.extend(
+                self.item_tuple(user.addons_updated, user.id, 1, theme_page)
+                for theme_page in range(2, theme_pages_needed + 1)
             )
         return items
 

--- a/src/olympia/amo/tests/test_sitemap.py
+++ b/src/olympia/amo/tests/test_sitemap.py
@@ -203,15 +203,7 @@ def test_accounts_sitemap():
         (extension.last_updated, user_with_extensions.id, 1, 1),
     ]
     for item in sitemap.items():
-        url = reverse('users.profile', args=[item.id])
-        if item[2] > 1 and item[3] > 1:
-            assert sitemap.location(item) == url + f'?page_e={item[2]}&page_t={item[3]}'
-        elif item[2] > 1:
-            assert sitemap.location(item) == url + f'?page_e={item[2]}'
-        elif item[3] > 1:
-            assert sitemap.location(item) == url + f'?page_t={item[3]}'
-        else:
-            assert sitemap.location(item) == url
+        assert sitemap.location(item) == reverse('users.profile', args=[item.id])
     # add some extra extensions and themes to test pagination
     extra_extension_a = addon_factory(users=(user_with_extensions, user_with_both))
     extra_extension_b = addon_factory(users=(user_with_extensions, user_with_both))
@@ -231,9 +223,8 @@ def test_accounts_sitemap():
         paginated_items = list(sitemap.items())
     assert paginated_items == [
         (extra_theme_c.last_updated, user_with_both.id, 1, 1),
-        (extra_theme_c.last_updated, user_with_both.id, 1, 2),
         (extra_theme_c.last_updated, user_with_both.id, 2, 1),
-        (extra_theme_c.last_updated, user_with_both.id, 2, 2),
+        (extra_theme_c.last_updated, user_with_both.id, 1, 2),
         (extra_theme_c.last_updated, user_with_themes.id, 1, 1),
         (extra_theme_c.last_updated, user_with_themes.id, 1, 2),
         (extra_extension_b.last_updated, user_with_extensions.id, 1, 1),


### PR DESCRIPTION
fixes #17071