### PR TITLE
Ci jobs - move amo lib signing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -529,15 +529,11 @@ jobs:
       - run:
           command: pytest -n 2 -m 'not es_tests and not needs_locales_compilation and not static_assets' -v src/olympia/addons/ src/olympia/versions/ src/olympia/files/ src/olympia/ratings/
 
-  amo-lib-locales-and-signing:
-    <<: *defaults-with-autograph
+  locales:
+    <<: *defaults-with-services
     steps:
       - setup_container:
           install_node_dependencies: true
-      - run:
-          command: pytest -n 2 -m 'not es_tests and not needs_locales_compilation and not static_assets' -v src/olympia/amo/ src/olympia/lib/ src/olympia/signing
-          environment:
-            AUTOGRAPH_SERVER_URL: http://127.0.0.1:5500
       - run: bash ./locale/compile-mo.sh ./locale/
       - run:
           command: pytest -n 2 -m 'needs_locales_compilation' -v src/olympia/
@@ -592,20 +588,20 @@ jobs:
               --ignore src/olympia/addons/ \
               --ignore src/olympia/devhub/ \
               --ignore src/olympia/files/ \
+              --ignore src/olympia/lib/crypto/ \
               --ignore src/olympia/reviewers/ \
               --ignore src/olympia/ratings/ \
-              --ignore src/olympia/amo/ \
-              --ignore src/olympia/lib/ \
               --ignore src/olympia/signing \
               --ignore src/olympia/versions/ \
               --ignore src/olympia/zadmin
 
-  reviewers-and-zadmin:
+  reviewers-signing-zadmin:
     <<: *defaults-with-autograph
     steps:
-      - setup_container
+      - setup_container:
+          install_node_dependencies: true
       - run:
-          command: pytest -n 2 -m 'not es_tests and not needs_locales_compilation and not static_assets' -v src/olympia/reviewers/ src/olympia/zadmin/
+          command: pytest -n 2 -m 'not es_tests and not needs_locales_compilation and not static_assets' -v src/olympia/reviewers/ src/olympia/zadmin/ src/olympia/signing/ src/olympia/lib/crypto/
           environment:
             AUTOGRAPH_SERVER_URL: http://127.0.0.1:5500
       - run:
@@ -655,7 +651,7 @@ workflows:
               djangoversion:
                 - django22
                 - django32
-      - amo-lib-locales-and-signing:
+      - locales:
           matrix:
             parameters:
               djangoversion:
@@ -681,7 +677,7 @@ workflows:
               djangoversion:
                 - django22
                 - django32
-      - reviewers-and-zadmin:
+      - reviewers-signing-zadmin:
           matrix:
             parameters:
               djangoversion:

--- a/src/olympia/amo/tests/test_fields.py
+++ b/src/olympia/amo/tests/test_fields.py
@@ -91,8 +91,8 @@ class TestPositiveAutoField(TestCase):
 
     def test_unsigned_int_limits(self):
         self.ClassUsingPositiveAutoField.objects.create(id=1)
-        mysql_max_int_size = 4294967295
-        self.ClassUsingPositiveAutoField.objects.create(id=mysql_max_int_size)
+        mysql_max_signed_int = 2147483647
+        self.ClassUsingPositiveAutoField.objects.create(id=mysql_max_signed_int + 10)
         with self.assertRaises(DataError):
             self.ClassUsingPositiveAutoField.objects.create(id=-1)
 

--- a/src/olympia/amo/tests/test_monitor.py
+++ b/src/olympia/amo/tests/test_monitor.py
@@ -1,7 +1,4 @@
-from django.conf import settings
 from django.test.utils import override_settings
-
-import responses
 
 from unittest.mock import Mock, patch
 
@@ -65,9 +62,3 @@ class TestMonitor(TestCase):
         status, rabbitmq_results = monitors.rabbitmq()
         assert status == ''
         assert rabbitmq_results[0][1]
-
-    def test_signer(self):
-        responses.add_passthru(settings.AUTOGRAPH_CONFIG['server_url'])
-
-        status, signer_result = monitors.signer()
-        assert status == ''

--- a/src/olympia/lib/crypto/tests/test_signing.py
+++ b/src/olympia/lib/crypto/tests/test_signing.py
@@ -867,3 +867,10 @@ class TestSignatureInfo(object):
         )
 
         assert self.info.signer_certificate == expected
+
+
+def test_signer_monitor():
+    responses.add_passthru(settings.AUTOGRAPH_CONFIG['server_url'])
+
+    status, signer_result = amo.monitors.signer()
+    assert status == ''


### PR DESCRIPTION
fixes #17102 - moves the non-locales tests into other jobs (signing related tests to reviewers, which already set up autograph; the rest to main)