### PR TITLE
Avoid pyenv shim and use dennis-cmd directly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -538,6 +538,10 @@ jobs:
           command: pytest -n 2 -m 'not es_tests and not needs_locales_compilation and not static_assets' -v src/olympia/amo/ src/olympia/lib/ src/olympia/signing
           environment:
             AUTOGRAPH_SERVER_URL: http://127.0.0.1:5500
+      # After having removed `tox`, we noticed that this job was a lot slower.
+      # The reason seems to be related to pyenv shims, which add a huge
+      # overhead to CLIs like `dennis-cmd`. By updating the path below, we
+      # should use `dennis-cmd` directly instead of the pyenv shim.
       - run: echo "export PATH=\"$(pyenv prefix)/bin:$PATH\"" >> $BASH_ENV
       - run: bash ./locale/compile-mo.sh ./locale/
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -538,6 +538,7 @@ jobs:
           command: pytest -n 2 -m 'not es_tests and not needs_locales_compilation and not static_assets' -v src/olympia/amo/ src/olympia/lib/ src/olympia/signing
           environment:
             AUTOGRAPH_SERVER_URL: http://127.0.0.1:5500
+      - run: echo "export PATH=\"$(pyenv prefix)/bin:$PATH\"" >> $BASH_ENV
       - run: bash ./locale/compile-mo.sh ./locale/
       - run:
           command: pytest -n 2 -m 'needs_locales_compilation' -v src/olympia/


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/17102

---

Looks like it works, see: https://app.circleci.com/pipelines/github/mozilla/addons-server/17211/workflows/af2da5e2-5e58-451b-bc6a-42bdea15e03b