### PR TITLE
Replace devhub links with extensionworkshop links

### DIFF
--- a/src/olympia/devhub/templates/devhub/addons/submit/describe.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/describe.html
@@ -220,7 +220,7 @@
           {% if sources_provided %}
             <p>
               <span class="req">{{ _('Remember') }}</span>:
-              {% trans policy_requirements_open='<a href="https://extensionworkshop.com/documentation/publish/source-code-submission">'|safe, policy_requirements_close='</a>'|safe %}
+              {% trans policy_requirements_open='<a href="{{ settings.EXTENSION_WORKSHOP_URL }}/documentation/publish/source-code-submission">'|safe, policy_requirements_close='</a>'|safe %}
               If you submitted source code, but did not include instructions, you must provide them here.
               Enter step-by-step build instructions to create an exact copy of the add-on code, per
               {{ policy_requirements_open }}policy requirements{{ policy_requirements_close }}.

--- a/src/olympia/devhub/templates/devhub/addons/submit/describe_minimal.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/describe_minimal.html
@@ -24,7 +24,7 @@
         {% if sources_provided %}
           <p>
             <span class="req">{{ _('Remember') }}</span>:
-            {% trans policy_requirements_open='<a href="https://extensionworkshop.com/documentation/publish/source-code-submission/">'|safe, policy_requirements_close='</a>'|safe %}
+            {% trans policy_requirements_open='<a href="{{ settings.EXTENSION_WORKSHOP_URL }}/documentation/publish/source-code-submission/">'|safe, policy_requirements_close='</a>'|safe %}
             If you submitted source code, but did not include instructions, you must provide them here.
             Enter step-by-step build instructions to create an exact copy of the add-on code, per
             {{ policy_requirements_open }}policy requirements{{ policy_requirements_close }}.

--- a/src/olympia/devhub/templates/devhub/addons/submit/distribute.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/distribute.html
@@ -14,7 +14,7 @@
         {{ distribution_form.channel }}
     </div>
     <p>{{ distribution_form.channel.errors }}</p>
-    <p><a href="https://extensionworkshop.com/documentation/publish/signing-and-distribution-overview/"
+    <p><a href="{{ settings.EXTENSION_WORKSHOP_URL }}/documentation/publish/signing-and-distribution-overview/"
           target="_blank" rel="noopener noreferrer">
         {{ _('More information on Add-on Distribution and Signing') }}</a></p>
     <div class="submission-buttons addon-submission-field">

--- a/src/olympia/devhub/templates/devhub/addons/submit/source.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/source.html
@@ -17,7 +17,7 @@
         {% endtrans %}
         </p>
         <p class="list-header">
-        {% trans a_attrs = 'href="https://extensionworkshop.com/documentation/publish/source-code-submission/" target="_blank" rel="noopener noreferrer"'|safe %}
+        {% trans a_attrs = 'href="{{ settings.EXTENSION_WORKSHOP_URL }}/documentation/publish/source-code-submission/" target="_blank" rel="noopener noreferrer"'|safe %}
             Please review the <a {{ a_attrs }}>source code submission policy</a>.
         {% endtrans %}
             <span class="instruction-emphasis">
@@ -51,7 +51,7 @@
     <div id="option_yes_source">
         <h3>{{ _('Your Submission Requires Source Code.') }}</h3>
         <p class="instruction-emphasis list-header">
-        {% trans a_attrs = 'href="https://extensionworkshop.com/documentation/publish/source-code-submission/" target="_blank" rel="noopener noreferrer"'|safe %}
+        {% trans a_attrs = 'href="{{ settings.EXTENSION_WORKSHOP_URL }}/documentation/publish/source-code-submission/" target="_blank" rel="noopener noreferrer"'|safe %}
             The source code must meet <a {{ a_attrs }}>policy requirements</a>, which includes:
         {% endtrans %}
         </p>

--- a/src/olympia/devhub/templates/devhub/agreement.html
+++ b/src/olympia/devhub/templates/devhub/agreement.html
@@ -39,4 +39,4 @@
     {{ agreement_form.non_field_errors() }}
   {% endif %}
 </form>
-<p><a href="https://extensionworkshop.com/documentation/publish/developer-accounts/">{{ _('More information on Developer Accounts') }}</a></p>
+<p><a href="{{ settings.EXTENSION_WORKSHOP_URL }}/documentation/publish/developer-accounts/">{{ _('More information on Developer Accounts') }}</a></p>

--- a/src/olympia/devhub/templates/devhub/emails/submission.html
+++ b/src/olympia/devhub/templates/devhub/emails/submission.html
@@ -2,7 +2,7 @@
 
 <p>Please keep in mind that while your add-on has been screened and approved for listing, other reviewers may look into it in the future and determine that it requires changes or should be removed from the gallery. If that occurs, you will receive a separate notification with details and next steps.</p>
 
-<p>For more information about the review process and policies, please visit <a href="https://extensionworkshop.com/documentation/publish/add-on-policies/">https://extensionworkshop.com/documentation/publish/add-on-policies/</a>.</p>
+<p>For more information about the review process and policies, please visit <a href="{{ settings.EXTENSION_WORKSHOP_URL }}/documentation/publish/add-on-policies/">{{ settings.EXTENSION_WORKSHOP_URL }}/documentation/publish/add-on-policies/</a>.</p>
 
 <hr />
 Attract Users, Stay Updated, &amp; Get in Touch
@@ -10,7 +10,7 @@ Attract Users, Stay Updated, &amp; Get in Touch
 
 <p>Add-ons help personalize the web experience for millions of users who have installed Firefox, and we want to help make your users happy!</p>
 
-<p>To learn how to help users discover your extension, stay up-to-date with news from the add-ons community, or contact the add-ons team, please visit <a href="https://extensionworkshop.com/documentation/manage/resources-for-publishers/">https://extensionworkshop.com/documentation/manage/resources-for-publishers/</a>.</p>>
+<p>To learn how to help users discover your extension, stay up-to-date with news from the add-ons community, or contact the add-ons team, please visit <a href="{{ settings.EXTENSION_WORKSHOP_URL }}/documentation/manage/resources-for-publishers/">{{ settings.EXTENSION_WORKSHOP_URL }}/documentation/manage/resources-for-publishers/</a>.</p>>
 
 <p>Happy developing!</p>
 

--- a/src/olympia/devhub/templates/devhub/emails/submission.txt
+++ b/src/olympia/devhub/templates/devhub/emails/submission.txt
@@ -2,7 +2,7 @@ Thanks for submitting your {{ addon_name }} add-on to addons.mozilla.org (AMO)! 
 
 Please keep in mind that while your add-on has been screened and approved for listing, other reviewers may look into it in the future and determine that it requires changes or should be removed from the gallery. If that occurs, you will receive a separate notification with details and next steps.
 
-For more information about the review process and policies, please visit https://extensionworkshop.com/documentation/publish/add-on-policies/
+For more information about the review process and policies, please visit {{ settings.EXTENSION_WORKSHOP_URL }}/documentation/publish/add-on-policies/
 
 ********
 Attract Users, Stay Updated, & Get in Touch
@@ -10,7 +10,7 @@ Attract Users, Stay Updated, & Get in Touch
 
 Add-ons help personalize the web experience for millions of users who have installed Firefox, and we want to help make your users happy!
 
-To learn how to help users discover your extension, stay up-to-date with news from the add-ons community, or contact the add-ons team, please visit https://extensionworkshop.com/documentation/manage/resources-for-publishers/
+To learn how to help users discover your extension, stay up-to-date with news from the add-ons community, or contact the add-ons team, please visit {{ settings.EXTENSION_WORKSHOP_URL }}/documentation/manage/resources-for-publishers/
 
 Happy developing!
 

--- a/src/olympia/devhub/templates/devhub/includes/source_form_field.html
+++ b/src/olympia/devhub/templates/devhub/includes/source_form_field.html
@@ -4,7 +4,7 @@
          'libraries, upload its sources for review.') }}<br />
     {{ _('Please include instructions on how to reproduce the final add-on file, '
          'either in a README file or the Notes to Reviewer for this version.') }}<br />
-    <a href="https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Reviews#Source_Code_Submission"
+    <a href="{{ settings.EXTENSION_WORKSHOP_URL }}/documentation/publish/source-code-submission/?utm_source=addons.mozilla.org&utm_medium=devhub&utm_content=submission-flow"
       target="_blank" rel="noopener noreferrer">{{
       _('Read more about the source code review policy.') }}</a>
   </p>

--- a/src/olympia/devhub/templates/devhub/nav.html
+++ b/src/olympia/devhub/templates/devhub/nav.html
@@ -34,11 +34,11 @@
     <li>
       <a href="#" class="controller">{{ _('Documentation') }}</a>
       <ul>
-        <li><a href="https://extensionworkshop.com/documentation/develop/?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=dev-hub-legacy-menu-link">
+        <li><a href="{{ settings.EXTENSION_WORKSHOP_URL }}/documentation/develop/?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=dev-hub-legacy-menu-link">
           {{ _('Extension Development') }}</a></li>
-        <li><a href="https://extensionworkshop.com/documentation/themes/?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=dev-hub-legacy-menu-link">
+        <li><a href="{{ settings.EXTENSION_WORKSHOP_URL }}/documentation/themes/?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=dev-hub-legacy-menu-link">
           {{ _('Themes') }}</a></li>
-        <li><a href="https://extensionworkshop.com/documentation/publish/add-on-policies/?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=dev-hub-legacy-menu-link">
+        <li><a href="{{ settings.EXTENSION_WORKSHOP_URL }}/documentation/publish/add-on-policies/?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=dev-hub-legacy-menu-link">
           {{ _('Developer Policies') }}</a></li>
       </ul>
     </li>

--- a/src/olympia/reviewers/templates/reviewers/emails/base.ltxt
+++ b/src/olympia/reviewers/templates/reviewers/emails/base.ltxt
@@ -10,9 +10,9 @@ To respond, please reply to this email or visit: {{ dev_versions_url }}
 
 You can also get in touch with us using these channels: https://wiki.mozilla.org/Add-ons#Contact_us
 
-For tips on how to attract more users by updating your add-on’s listing, please visit: https://extensionworkshop.com/documentation/develop/create-an-appealing-listing
+For tips on how to attract more users by updating your add-on’s listing, please visit: {{ settings.EXTENSION_WORKSHOP_URL }}/documentation/develop/create-an-appealing-listing
 
-To learn more about the review process, please visit: https://extensionworkshop.com/documentation/publish/add-on-policies/
+To learn more about the review process, please visit: {{ settings.EXTENSION_WORKSHOP_URL }}/documentation/publish/add-on-policies/
 
 -- 
 Mozilla Add-ons Team

--- a/src/olympia/templates/copyright.html
+++ b/src/olympia/templates/copyright.html
@@ -15,7 +15,7 @@
           &nbsp;|&nbsp;<a class="mobile-link" href="#" title="{{ _('The new website supports mobile and desktop clients') }}">{{ _('View the new site') }}</a>
         {% endif %}
         &nbsp;|&nbsp;<a href="https://status.mozilla.org">{{ _('Site Status')}}</a>
-        &nbsp;|&nbsp;<a href="https://developer.mozilla.org/en-US/Add-ons/AMO/Policy/Contact">{{ _('Report a bug')}}</a>
+        &nbsp;|&nbsp;<a href="https://github.com/mozilla/addons/issues/new">{{ _('Report a bug')}}</a>
       {% endblock %}
     {% endblock %}
   </p>

--- a/src/olympia/templates/photon-footer.html
+++ b/src/olympia/templates/photon-footer.html
@@ -12,9 +12,9 @@
                 <li><a href="https://blog.mozilla.com/addons">Blog</a></li>
                 <li><a class="Footer-extension-workshop-link" href="{{ settings.EXTENSION_WORKSHOP_URL }}/?utm_source=addons.mozilla.org&amp;utm_medium=referral&amp;utm_content=footer-link">Extension Workshop</a></li>
                 <li><a href="{{ url('devhub.index') }}">Developer Hub</a></li>
-                <li><a href="https://developer.mozilla.org/docs/Mozilla/Add-ons/AMO/Policy">Developer Policies</a></li>
+                <li><a href="{{ settings.EXTENSION_WORKSHOP_URL }}/documentation/publish/add-on-policies/?utm_source=addons.mozilla.org&utm_medium=photon-footer">Developer Policies</a></li>
                 <li><a href="https://discourse.mozilla-community.org/c/add-ons">Forum</a></li>
-                <li><a class="Footer-bug-report-link" href="https://developer.mozilla.org/docs/Mozilla/Add-ons/Contact_us">Report a bug</a></li>
+                <li><a class="Footer-bug-report-link" href="https://github.com/mozilla/addons/issues/new">Report a bug</a></li>
                 <li><a href="{{ url('pages.review_guide') }}">Review Guide</a></li>
                 <li><a href="https://status.mozilla.org/">Site Status</a></li>
             </ul>


### PR DESCRIPTION
Fixes #16753 

Some links still referenced devhub. These were udpated to extensionworkshop links.
Also, updated all hard coded `https://extensionworkshop.com` references to `settings.EXTENSION_WORKSHOP_URL`

* [x] This PR relates to an existing open issue and there are no existing
      PRs open for the same issue.
* [x] Add `Fixes #ISSUENUM` at the top of your PR.
* [x] Add a description of the changes introduced in this PR.
* [x] The change has been successfully run locally.
* [ ] Add tests to cover the changes added in this PR.
* [ ] Add before and after screenshots (Only for changes that impact the UI).

