### PR TITLE
Use absolute urls when rendering ActivityLogs

### DIFF
--- a/src/olympia/activity/models.py
+++ b/src/olympia/activity/models.py
@@ -576,7 +576,9 @@ class ActivityLog(ModelBase):
                 text = gettext('Version {0}')
                 if arg.channel == amo.RELEASE_CHANNEL_LISTED:
                     version = self.f(
-                        '<a href="{1}">%s</a>' % text, arg.version, arg.get_absolute_url()
+                        '<a href="{1}">%s</a>' % text,
+                        arg.version,
+                        arg.get_absolute_url(),
                     )
                 else:
                     version = self.f(text, arg.version)

--- a/src/olympia/activity/models.py
+++ b/src/olympia/activity/models.py
@@ -471,7 +471,7 @@ class ActivityLog(ModelBase):
                     # Most of the time, we're eventually going to call
                     # to_string() on each ActivityLog that we're processing
                     # here. For some of the models, that will result in a call
-                    # to <model>.get_url_path(), which in turn can cause an
+                    # to <model>.get_absolute_url(), which in turn can cause an
                     # extra SQL query because some parent model is needed to
                     # build the URL.
                     # It's difficult to predict what we'll need as ActivitLog
@@ -562,34 +562,34 @@ class ActivityLog(ModelBase):
             if isinstance(arg, Addon) and not addon:
                 if arg.has_listed_versions():
                     addon = self.f(
-                        '<a href="{0}">{1}</a>', arg.get_url_path(), arg.name
+                        '<a href="{0}">{1}</a>', arg.get_absolute_url(), arg.name
                     )
                 else:
                     addon = self.f('{0}', arg.name)
                 arguments.remove(arg)
             if isinstance(arg, Rating) and not rating:
                 rating = self.f(
-                    '<a href="{0}">{1}</a>', arg.get_url_path(), gettext('Review')
+                    '<a href="{0}">{1}</a>', arg.get_absolute_url(), gettext('Review')
                 )
                 arguments.remove(arg)
             if isinstance(arg, Version) and not version:
                 text = gettext('Version {0}')
                 if arg.channel == amo.RELEASE_CHANNEL_LISTED:
                     version = self.f(
-                        '<a href="{1}">%s</a>' % text, arg.version, arg.get_url_path()
+                        '<a href="{1}">%s</a>' % text, arg.version, arg.get_absolute_url()
                     )
                 else:
                     version = self.f(text, arg.version)
                 arguments.remove(arg)
             if isinstance(arg, Collection) and not collection:
                 collection = self.f(
-                    '<a href="{0}">{1}</a>', arg.get_url_path(), arg.name
+                    '<a href="{0}">{1}</a>', arg.get_absolute_url(), arg.name
                 )
                 arguments.remove(arg)
             if isinstance(arg, Tag) and not tag:
                 if arg.can_reverse():
                     tag = self.f(
-                        '<a href="{0}">{1}</a>', arg.get_url_path(), arg.tag_text
+                        '<a href="{0}">{1}</a>', arg.get_absolute_url(), arg.tag_text
                     )
                 else:
                     tag = self.f('{0}', arg.tag_text)
@@ -606,7 +606,7 @@ class ActivityLog(ModelBase):
 
                 file_ = self.f(
                     '<a href="{0}">{1}</a> (validation {2})',
-                    arg.get_url_path(),
+                    arg.get_absolute_url(),
                     arg.filename,
                     validation,
                 )

--- a/src/olympia/activity/tests/test_models.py
+++ b/src/olympia/activity/tests/test_models.py
@@ -225,16 +225,15 @@ class TestActivityLog(TestCase):
             # - 1 for all ratings
             activities = ActivityLog.objects.for_addons([addon, addon2]).order_by('pk')
             assert len(activities) == 2
+            addon_url = 'http://testserver/en-US/firefox/addon/a3615/'
             assert activities[0].to_string() == (
-                f'<a href="http://testserver/en-US/firefox/addon/a3615/reviews/{rating.pk}/">Review</a>'
-                ' for '
-                '<a href="http://testserver/en-US/firefox/addon/a3615/">Delicious Bookmarks</a> written.'
+                f'<a href="{addon_url}reviews/{rating.pk}/">Review</a> for '
+                f'<a href="{addon_url}">Delicious Bookmarks</a> written.'
             )
+            addon2_url = f'http://testserver/en-US/firefox/addon/{addon2.slug}/'
             assert activities[1].to_string() == (
-                f'<a href="http://testserver/en-US/firefox/addon/{addon2.slug}/reviews/{rating2.pk}/">'
-                'Review</a> for '
-                f'<a href="http://testserver/en-US/firefox/addon/{addon2.slug}/">{addon2.name}</a> '
-                'written.'
+                f'<a href="{addon2_url}reviews/{rating2.pk}/">Review</a> for '
+                f'<a href="{addon2_url}">{addon2.name}</a> written.'
             )
 
     def test_no_arguments(self):
@@ -293,10 +292,10 @@ class TestActivityLog(TestCase):
             # - 1 for all versions translations
             activities = ActivityLog.objects.for_addons([addon, addon2]).order_by('pk')
             assert len(activities) == 2
+            addon_url = 'http://testserver/en-US/firefox/addon/a3615/'
             assert activities[0].to_string() == (
-                '<a href="http://testserver/en-US/firefox/addon/a3615/versions/">Version 2.1.072</a>'
-                ' added to '
-                '<a href="http://testserver/en-US/firefox/addon/a3615/">Delicious Bookmarks</a>.'
+                f'<a href="{addon_url}versions/">Version 2.1.072</a> added to '
+                f'<a href="{addon_url}">Delicious Bookmarks</a>.'
             )
             assert activities[1].to_string()
 

--- a/src/olympia/activity/tests/test_models.py
+++ b/src/olympia/activity/tests/test_models.py
@@ -169,7 +169,7 @@ class TestActivityLog(TestCase):
         assert '>Review</a> for None written.' in activity_log.to_string()
         activity_log.action = amo.LOG.ADD_TO_COLLECTION.id
         activity_log.arguments = [activity_log, Collection.objects.create()]
-        assert 'None added to <a href="/' in activity_log.to_string()
+        assert 'None added to <a href="http://testserver/' in activity_log.to_string()
 
     def test_bad_arguments(self):
         activity_log = ActivityLog()
@@ -226,14 +226,14 @@ class TestActivityLog(TestCase):
             activities = ActivityLog.objects.for_addons([addon, addon2]).order_by('pk')
             assert len(activities) == 2
             assert activities[0].to_string() == (
-                f'<a href="/en-US/firefox/addon/a3615/reviews/{rating.pk}/">Review</a>'
+                f'<a href="http://testserver/en-US/firefox/addon/a3615/reviews/{rating.pk}/">Review</a>'
                 ' for '
-                '<a href="/en-US/firefox/addon/a3615/">Delicious Bookmarks</a> written.'
+                '<a href="http://testserver/en-US/firefox/addon/a3615/">Delicious Bookmarks</a> written.'
             )
             assert activities[1].to_string() == (
-                f'<a href="/en-US/firefox/addon/{addon2.slug}/reviews/{rating2.pk}/">'
+                f'<a href="http://testserver/en-US/firefox/addon/{addon2.slug}/reviews/{rating2.pk}/">'
                 'Review</a> for '
-                f'<a href="/en-US/firefox/addon/{addon2.slug}/">{addon2.name}</a> '
+                f'<a href="http://testserver/en-US/firefox/addon/{addon2.slug}/">{addon2.name}</a> '
                 'written.'
             )
 
@@ -294,9 +294,9 @@ class TestActivityLog(TestCase):
             activities = ActivityLog.objects.for_addons([addon, addon2]).order_by('pk')
             assert len(activities) == 2
             assert activities[0].to_string() == (
-                '<a href="/en-US/firefox/addon/a3615/versions/">Version 2.1.072</a>'
+                '<a href="http://testserver/en-US/firefox/addon/a3615/versions/">Version 2.1.072</a>'
                 ' added to '
-                '<a href="/en-US/firefox/addon/a3615/">Delicious Bookmarks</a>.'
+                '<a href="http://testserver/en-US/firefox/addon/a3615/">Delicious Bookmarks</a>.'
             )
             assert activities[1].to_string()
 
@@ -398,7 +398,7 @@ class TestActivityLog(TestCase):
         log = ActivityLog.objects.get()
 
         log_expected = (
-            'Yolo role changed to Owner for <a href="/en-US/'
+            'Yolo role changed to Owner for <a href="http://testserver/en-US/'
             'firefox/addon/a3615/">Delicious &lt;script src='
             '&#34;x.js&#34;&gt;Bookmarks</a>.'
         )
@@ -420,14 +420,14 @@ class TestActivityLog(TestCase):
         addon = Addon.objects.get()
         log = ActivityLog.create(amo.LOG.CHANGE_STATUS, addon, amo.STATUS_APPROVED)
         expected = (
-            '<a href="/en-US/firefox/addon/a3615/">'
+            '<a href="http://testserver/en-US/firefox/addon/a3615/">'
             'Delicious Bookmarks</a> status changed to Approved.'
         )
         assert str(log) == expected
 
         log.arguments = [amo.STATUS_DISABLED, addon]
         expected = (
-            '<a href="/en-US/firefox/addon/a3615/">'
+            '<a href="http://testserver/en-US/firefox/addon/a3615/">'
             'Delicious Bookmarks</a> status changed to '
             'Disabled by Mozilla.'
         )
@@ -435,21 +435,21 @@ class TestActivityLog(TestCase):
 
         log.arguments = [addon, amo.STATUS_NULL]
         expected = (
-            '<a href="/en-US/firefox/addon/a3615/">'
+            '<a href="http://testserver/en-US/firefox/addon/a3615/">'
             'Delicious Bookmarks</a> status changed to Incomplete.'
         )
         assert str(log) == expected
 
         log.arguments = [addon, 666]
         expected = (
-            '<a href="/en-US/firefox/addon/a3615/">'
+            '<a href="http://testserver/en-US/firefox/addon/a3615/">'
             'Delicious Bookmarks</a> status changed to 666.'
         )
         assert str(log) == expected
 
         log.arguments = [addon, 'Some String']
         expected = (
-            '<a href="/en-US/firefox/addon/a3615/">'
+            '<a href="http://testserver/en-US/firefox/addon/a3615/">'
             'Delicious Bookmarks</a> status changed to Some String.'
         )
         assert str(log) == expected
@@ -460,7 +460,7 @@ class TestActivityLog(TestCase):
             amo.LOG.UNLISTED_SIGNED, addon.current_version.current_file
         )
         assert str(log) == (
-            '<a href="/firefox/downloads/file/67442/'
+            '<a href="http://testserver/firefox/downloads/file/67442/'
             'delicious_bookmarks-2.1.072-fx.xpi">'
             'delicious_bookmarks-2.1.072-fx.xpi</a>'
             ' (validation ignored) was signed.'

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -1186,8 +1186,8 @@ class TagTestsMixin(object):
         assert result == ', '.join(sorted(self.tags))
         html = (
             '<a href="http://testserver/en-US/firefox/tag/tag4">tag4</a> added to '
-            '<a href="http://testserver/en-US/firefox/addon/a3615/">Delicious Bookmarks</a>'
-            '.'
+            '<a href="http://testserver/en-US/firefox/addon/a3615/">'
+            'Delicious Bookmarks</a>.'
         )
         assert (
             ActivityLog.objects.for_addons(self.addon)

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -1185,8 +1185,8 @@ class TagTestsMixin(object):
 
         assert result == ', '.join(sorted(self.tags))
         html = (
-            '<a href="/en-US/firefox/tag/tag4">tag4</a> added to '
-            '<a href="/en-US/firefox/addon/a3615/">Delicious Bookmarks</a>'
+            '<a href="http://testserver/en-US/firefox/tag/tag4">tag4</a> added to '
+            '<a href="http://testserver/en-US/firefox/addon/a3615/">Delicious Bookmarks</a>'
             '.'
         )
         assert (


### PR DESCRIPTION
This makes links from ActivityLogs shown in the admin work instead of generating a URL that would 500 when visiting it because it points to a frontend-only view.

Fixes https://github.com/mozilla/addons-server/issues/16131