### PR TITLE
Drop license text from version list API endpoint

### DIFF
--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -380,7 +380,7 @@ This endpoint allows you to fetch a single version belonging to a specific add-o
     :>json object license: Object holding information about the license for the version.
     :>json boolean license.is_custom: Whether the license text has been provided by the developer, or not.  (When ``false`` the license is one of the common, predefined, licenses).
     :>json object|null license.name: The name of the license (See :ref:`translated fields <api-overview-translations>`).
-    :>json object|null license.text: The text of the license (See :ref:`translated fields <api-overview-translations>`). For performance reasons this field is omitted from add-on detail endpoint.
+    :>json object|null license.text: The text of the license (See :ref:`translated fields <api-overview-translations>`). For performance reasons this field is only present in version detail detail endpoint: all other endpoints omit it.
     :>json string|null license.url: The URL of the full text of license.
     :>json object|null release_notes: The release notes for this version (See :ref:`translated fields <api-overview-translations>`).
     :>json string reviewed: The date the version was reviewed at.

--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -418,7 +418,8 @@ These are `v5` specific changes - `v4` changes apply also.
 * 2021-02-25: made ``headline`` and ``footer_text`` in shelves endpoint translated fields. Also added shelves/editorial endpoint for the localization process. https://github.com/mozilla/addons-server/issues/16514
 * 2021-02-25: ``platform`` filtering was remoed from add-on search and autocomplete endpoints. https://github.com/mozilla/addons-server/issues/16463
 * 2021-03-04: replaced ``footer_pathname`` and ``footer_text`` with ``footer`` object in shelves api response.  https://github.com/mozilla/addons-server/issues/16575
-* 2021-03-18: removed ``platform`` from  file objects (it was always ``all``) in all endpoints. https://github.com/mozilla/addons-server/issues/16466
+* 2021-03-18: removed ``platform`` from file objects (it was always ``all``) in all endpoints. https://github.com/mozilla/addons-server/issues/16466
+* 2021-05-20: removed ``text`` from license objects in versions list endpoint. https://github.com/mozilla/addons-server/issues/17163
 
 .. _`#11380`: https://github.com/mozilla/addons-server/issues/11380/
 .. _`#11379`: https://github.com/mozilla/addons-server/issues/11379/

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -293,6 +293,12 @@ class VersionSerializer(SimpleVersionSerializer):
         )
 
 
+class VersionSerializerForListing(VersionSerializer):
+    # When we're listing versions, we don't want to include the full license
+    # text every time: we only do this for the version detail endpoint.
+    license = CompactLicenseSerializer()
+
+
 class CurrentVersionSerializer(SimpleVersionSerializer):
     def to_representation(self, obj):
         # If the add-on is a langpack, and `appversion` is passed, try to

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -293,7 +293,7 @@ class VersionSerializer(SimpleVersionSerializer):
         )
 
 
-class VersionSerializerForListing(VersionSerializer):
+class VersionListSerializer(VersionSerializer):
     # When we're listing versions, we don't want to include the full license
     # text every time: we only do this for the version detail endpoint.
     license = CompactLicenseSerializer()

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -1265,6 +1265,20 @@ class TestVersionSerializerOutput(TestCase):
         assert result['files'][0]['optional_permissions'] == (optional_permissions)
 
 
+class TestVersionSerializerForListingOutput(TestCase):
+    def setUp(self):
+        self.request = APIRequestFactory().get('/')
+
+    def serialize(self):
+        serializer = SimpleVersionSerializer(context={'request': self.request})
+        return serializer.to_representation(self.version)
+
+    def test_basic(self):
+        self.version = addon_factory().current_version
+        result = self.serialize()
+        assert 'text' not in result['license']
+
+
 class TestSimpleVersionSerializerOutput(TestCase):
     def setUp(self):
         self.request = APIRequestFactory().get('/')

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -1265,7 +1265,7 @@ class TestVersionSerializerOutput(TestCase):
         assert result['files'][0]['optional_permissions'] == (optional_permissions)
 
 
-class TestVersionSerializerForListingOutput(TestCase):
+class TestVersionListSerializerOutput(TestCase):
     def setUp(self):
         self.request = APIRequestFactory().get('/')
 

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -64,7 +64,7 @@ from .serializers import (
     ReplacementAddonSerializer,
     StaticCategorySerializer,
     VersionSerializer,
-    VersionSerializerForListing,
+    VersionListSerializer,
 )
 from .utils import (
     get_addon_recommendations,
@@ -337,7 +337,7 @@ class AddonVersionViewSet(
             and self.request
             and not is_gate_active(self.request, 'keep-license-text-in-version-list')
         ):
-            serializer_class = VersionSerializerForListing
+            serializer_class = VersionListSerializer
         else:
             serializer_class = VersionSerializer
         return serializer_class

--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -965,19 +965,31 @@ class LocalFileStorage(FileSystemStorage):
 
 
 def attach_trans_dict(model, objs):
-    """Put all translations into a translations dict."""
+    """Put all translations from all non-deferred translated fields from objs
+    into a translations dict on each instance."""
     # Get the ids of all the translations we need to fetch.
-    fields = model._meta.translated_fields
+    try:
+        deferred_fields = objs[0].get_deferred_fields()
+    except IndexError:
+        return
+    fields = [
+        field
+        for field in model._meta.translated_fields
+        if field.attname not in deferred_fields
+    ]
     ids = [
-        getattr(obj, f.attname)
-        for f in fields
+        getattr(obj, field.attname)
+        for field in fields
         for obj in objs
-        if getattr(obj, f.attname, None) is not None
+        if getattr(obj, field.attname, None) is not None
     ]
 
-    # Get translations in a dict, ids will be the keys. It's important to
-    # consume the result of sorted_groupby, which is an iterator.
-    qs = Translation.objects.filter(id__in=ids, localized_string__isnull=False)
+    if ids:
+        # Get translations in a dict, ids will be the keys. It's important to
+        # consume the result of sorted_groupby, which is an iterator.
+        qs = Translation.objects.filter(id__in=ids, localized_string__isnull=False)
+    else:
+        qs = []
     all_translations = {
         field_id: sorted(list(translations), key=lambda t: t.locale)
         for field_id, translations in sorted_groupby(qs, lambda t: t.id)

--- a/src/olympia/bandwagon/views.py
+++ b/src/olympia/bandwagon/views.py
@@ -198,6 +198,15 @@ class CollectionAddonViewSet(ModelViewSet):
 
     @classmethod
     def _locales_transformer(self, objs):
+        """
+        Transformer to fetch all translations from objects related to CollectionAddon.
+
+        This is necessary because the regular translation transformer only fetches
+        translations for the current language, and only for the model the queryset is
+        built from, not related objects.
+
+        Only used when `lang` is not passed.
+        """
         current_versions = [
             obj.addon._current_version for obj in objs if obj.addon._current_version
         ]

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1609,6 +1609,7 @@ DRF_API_GATES = {
         'disco-heading-and-description-shim',
         'wrap-outgoing-parameter',
         'platform-shim',
+        'keep-license-text-in-version-list',
     ),
     'v4': (
         'l10n_flat_input_output',
@@ -1617,6 +1618,7 @@ DRF_API_GATES = {
         'ratings-score-filter',
         'wrap-outgoing-parameter',
         'platform-shim',
+        'keep-license-text-in-version-list',
     ),
     'v5': (
         'addons-search-_score-field',

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -711,12 +711,19 @@ class Version(OnChangeMixin, ModelBase):
 
     @classmethod
     def transformer_license(cls, versions):
-        """Attach all the licenses to the versions."""
+        """Attach all the licenses to the versions.
+
+        Do not use if you need the license text: it's explicitly deferred in
+        this transformer, because it should only be used when listing multiple
+        versions, where returning license text is not supposed to be needed.
+
+        The translations app doesn't fully handle evaluating a deferred field,
+        so the callers need to make sure the license text will never be needed
+        on instances returned by a queryset transformed by this method."""
         if not versions:
             return
-
         license_ids = {ver.license_id for ver in versions}
-        licenses = License.objects.filter(id__in=license_ids)
+        licenses = License.objects.filter(id__in=license_ids).defer('text')
         license_dict = {lic.id: lic for lic in licenses}
 
         for version in versions:


### PR DESCRIPTION
Don't even fetch the license text from the database when it's not needed: defer it, and ensure the translations app doesn't try to fetch translations for deferred fields.

Fixes https://github.com/mozilla/addons-server/issues/17163