### PR TITLE
Reverting use of settings.EXTENSION_WORKSHOP_URL inside trans tags

### DIFF
--- a/src/olympia/devhub/templates/devhub/addons/submit/source.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/source.html
@@ -17,7 +17,7 @@
         {% endtrans %}
         </p>
         <p class="list-header">
-        {% trans a_attrs = 'href="{{ settings.EXTENSION_WORKSHOP_URL }}/documentation/publish/source-code-submission/" target="_blank" rel="noopener noreferrer"'|safe %}
+        {% trans a_attrs = 'href="https://extensionworkshop.com/documentation/publish/source-code-submission/" target="_blank" rel="noopener noreferrer"'|safe %}
             Please review the <a {{ a_attrs }}>source code submission policy</a>.
         {% endtrans %}
             <span class="instruction-emphasis">
@@ -51,7 +51,7 @@
     <div id="option_yes_source">
         <h3>{{ _('Your Submission Requires Source Code.') }}</h3>
         <p class="instruction-emphasis list-header">
-        {% trans a_attrs = 'href="{{ settings.EXTENSION_WORKSHOP_URL }}/documentation/publish/source-code-submission/" target="_blank" rel="noopener noreferrer"'|safe %}
+        {% trans a_attrs = 'href="https://extensionworkshop.com/documentation/publish/source-code-submission/" target="_blank" rel="noopener noreferrer"'|safe %}
             The source code must meet <a {{ a_attrs }}>policy requirements</a>, which includes:
         {% endtrans %}
         </p>


### PR DESCRIPTION
Fixes #17181 

Reverting the change which causes the issue. Caused by #17154 while replacing extensionworkshop.com links with`settings.EXTENSION_WORKSHOP_URL`

* [x] This PR relates to an existing open issue and there are no existing
      PRs open for the same issue.
* [x] Add `Fixes #ISSUENUM` at the top of your PR.
* [x] Add a description of the changes introduced in this PR.
* [ ] The change has been successfully run locally.
* [ ] Add tests to cover the changes added in this PR.
* [ ] Add before and after screenshots (Only for changes that impact the UI).