### PR TITLE
Fix `jinja_helpers.absolutify` to handle https

### DIFF
--- a/src/olympia/amo/templatetags/jinja_helpers.py
+++ b/src/olympia/amo/templatetags/jinja_helpers.py
@@ -185,11 +185,11 @@ def json(s):
 
 @library.filter
 def absolutify(url, site=None):
-    """Takes a URL and prepends the EXTERNAL_SITE_URL"""
-    if url.startswith(('http://', 'http://')):
+    """Take an URL and prepend the EXTERNAL_SITE_URL."""
+    if url and url.startswith(('http://', 'https://')):
         return url
-    else:
-        return urljoin(site or settings.EXTERNAL_SITE_URL, url)
+
+    return urljoin(site or settings.EXTERNAL_SITE_URL, url)
 
 
 @library.filter


### PR DESCRIPTION
Fix `jinja_helpers.absolutify` to handle https. This PR also improves tests to cover possible cases.

* [x] This PR relates to an existing open issue and there are no existing
      PRs open for the same issue.
* [ ] The change has been successfully run locally.
* [x] Add tests to cover the changes added in this PR.

Fixes #17189
