### PR TITLE
Add '@mozillafoundation.org' to patterns for system guids

### DIFF
--- a/src/olympia/constants/base.py
+++ b/src/olympia/constants/base.py
@@ -371,6 +371,8 @@ SYSTEM_ADDON_GUIDS = (
     '@shield.mozilla.com',
     '@shield.mozilla.org',
     '@mozillaonline.com',
+    '@mozillafoundation.org',
+    '@rally.mozilla.org',
 )
 
 MOZILLA_TRADEMARK_SYMBOLS = ('mozilla', 'firefox')

--- a/src/olympia/constants/base.py
+++ b/src/olympia/constants/base.py
@@ -363,6 +363,8 @@ ADDON_GUID_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
+# Changes to this list need to be synced with the privileged add-ons signing pipeline.
+# Please reach out to the Operations Team (awagner) before making any changes!
 SYSTEM_ADDON_GUIDS = (
     '@mozilla.com',
     '@mozilla.org',

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -1470,7 +1470,8 @@ class TestUploadDetail(BaseUploadTest):
                 '"@mozilla.com" or "@mozilla.org" or '
                 '"@pioneer.mozilla.org" or "@search.mozilla.org" or '
                 '"@shield.mozilla.com" or "@shield.mozilla.org" or '
-                '"@mozillaonline.com"',
+                '"@mozillaonline.com" or "@mozillafoundation.org" or '
+                '"@rally.mozilla.org"',
                 'fatal': True,
                 'type': 'error',
             }

--- a/src/olympia/signing/tests/test_views.py
+++ b/src/olympia/signing/tests/test_views.py
@@ -367,7 +367,8 @@ class TestUploadVersion(BaseUploadVersionTestMixin, TestCase):
             'You cannot submit an add-on using an ID ending with '
             '"@mozilla.com" or "@mozilla.org" or "@pioneer.mozilla.org" or '
             '"@search.mozilla.org" or "@shield.mozilla.com" or '
-            '"@shield.mozilla.org" or "@mozillaonline.com"'
+            '"@shield.mozilla.org" or "@mozillaonline.com" or '
+            '"@mozillafoundation.org" or "@rally.mozilla.org"'
         )
 
     def test_system_addon_update_allowed(self):


### PR DESCRIPTION
Fix #17271.