### PR TITLE
attempt to optimize sitemap generation by caching loading template

### DIFF
--- a/src/olympia/amo/cron.py
+++ b/src/olympia/amo/cron.py
@@ -89,5 +89,4 @@ def write_sitemaps(section=None, app_name=None):
             sitemap_object = sitemaps.get((_section, amo.APPS.get(_app_name)))
             if not sitemap_object:
                 continue
-            content = sitemap_object.render_xml(_app_name, _page)
-            sitemap_file.write(content)
+            sitemap_file.write(sitemap_object.render(app_name=_app_name, page=_page))

--- a/src/olympia/amo/tests/test_sitemap.py
+++ b/src/olympia/amo/tests/test_sitemap.py
@@ -439,7 +439,7 @@ def test_render_index_xml():
             assert built == sitemap.read()
 
 
-def test_sitemap_render_xml():
+def test_sitemap_render():
     def items_mock(self):
         return [
             AddonSitemap.item_tuple(
@@ -472,13 +472,13 @@ def test_sitemap_render_xml():
         ]
 
     with mock.patch.object(AddonSitemap, 'items', items_mock):
-        firefox_built = AddonSitemap().render_xml('firefox', 1)
+        firefox_built = AddonSitemap().render('firefox', 1)
 
         firefox_file = os.path.join(TEST_SITEMAPS_DIR, 'sitemap-addons-firefox.xml')
         with open(firefox_file) as sitemap:
             assert firefox_built == sitemap.read()
 
-        android_built = AddonSitemap().render_xml('android', 1)
+        android_built = AddonSitemap().render('android', 1)
         android_file = os.path.join(TEST_SITEMAPS_DIR, 'sitemap-addons-android.xml')
         with open(android_file) as sitemap:
             assert android_built == sitemap.read()

--- a/src/olympia/amo/views.py
+++ b/src/olympia/amo/views.py
@@ -204,7 +204,7 @@ def sitemap(request):
                 sitemap_object = sitemaps.get((section, amo.APPS.get(app)))
                 if not sitemap_object:
                     raise InvalidSection
-                content = sitemap_object.render_xml(app, page)
+                content = sitemap_object.render(app, page)
         except EmptyPage:
             raise Http404('Page %s empty' % page)
         except PageNotAnInteger:


### PR DESCRIPTION
This is part of #17311 - there wasn't a way to directly write to file (that I could see) so I just optimized the template loading (now we do it once for each Sitemap subclass, rather than for each page) for some presumed speed increase.