### PR TITLE
Always show Listing Visibility for add-ons that are set to invisible

### DIFF
--- a/src/olympia/devhub/templates/devhub/versions/list.html
+++ b/src/olympia/devhub/templates/devhub/versions/list.html
@@ -151,7 +151,9 @@
   <h2>{{ addon.name }}</h2>
 </header>
 <section id="edit-addon" class="primary devhub-form" role="main">
-  {% if has_listed_versions %}
+  {# Only show listing visibility if there are listed versions... or if somehow the add-on is already invisible,
+     to allow developers to toggle it back so that they can upload listed versions #}
+  {% if has_listed_versions or addon.disabled_by_user %}
     <h3>{{ distro_tag(amo.RELEASE_CHANNEL_LISTED)}} {{ _('Listing visibility') }}</h3>
     <div class="item" id="addon-current-state">
       <div class="item_wrapper">

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -464,6 +464,28 @@ class TestVersion(TestCase):
         assert doc('.disable-addon').attr('checked') == 'checked'
         assert doc('.disable-addon').attr('disabled') == 'disabled'
 
+    def test_no_listed_versions_already_enabled(self):
+        self.addon.versions.all().delete()
+        response = self.client.get(self.url)
+        doc = pq(response.content)
+        assert not doc('.enable-addon')
+        assert not doc('.disable-addon')
+
+    def test_no_listed_versions_already_disabled(self):
+        # If somehow the add-on has no listed versions but is invisible, we
+        # allow them to switch back to visible so that they can submit listed
+        # versions.
+        self.addon.versions.all().delete()
+        self.addon.update(disabled_by_user=True)
+        response = self.client.get(self.url)
+        doc = pq(response.content)
+        assert doc('.enable-addon')
+        assert doc('.disable-addon')
+        assert not doc('.enable-addon').attr('checked')
+        assert not doc('.enable-addon').attr('disabled')
+        assert doc('.disable-addon').attr('checked') == 'checked'
+        assert not doc('.disable-addon').attr('disabled')
+
     def test_cancel_get(self):
         cancel_url = reverse('devhub.addons.cancel', args=['a3615'])
         assert self.client.get(cancel_url).status_code == 405


### PR DESCRIPTION
This allows developers that submitted listed versions, then switched to invisible, then deleted the listed versions, to switch back visibility to listed... letting them submit new listed versions again. 

Fixes #13973