### PR TITLE
Fix: View on site button on django activity log entries

### DIFF
--- a/src/olympia/activity/admin.py
+++ b/src/olympia/activity/admin.py
@@ -22,6 +22,7 @@ class ActivityLogAdmin(admin.ModelAdmin):
         '__str__',
     )
     raw_id_fields = ('user',)
+    view_on_site = False
 
     def has_add_permission(self, request):
         return False


### PR DESCRIPTION
Fixes #17179 

Add `view_on_site = False` in ActivityLogAdmin Class to not to display the **View on Site** link.