### PR TITLE
Store collections description as text, not HTML

### DIFF
--- a/src/olympia/amo/management/__init__.py
+++ b/src/olympia/amo/management/__init__.py
@@ -88,8 +88,9 @@ class ProcessObjectsCommand(BaseCommand):
             help=f'Split the {verbose_name_plural} into X size chunks. Default 100.',
         )
 
-    def get_pks(self, manager, q_objects, distinct=False):
-        pks = manager.filter(q_objects).values_list('pk', flat=True).order_by('id')
+    def get_pks(self, manager, q_objects, *, distinct=False):
+        qs = manager.filter(*q_objects)
+        pks = qs.values_list('pk', flat=True).order_by('pk')
         if distinct:
             pks = pks.distinct()
         return pks
@@ -115,7 +116,7 @@ class ProcessObjectsCommand(BaseCommand):
         base_qs = self.get_base_queryset(options)
         pks = self.get_pks(
             base_qs,
-            *task_info['queryset_filters'],
+            task_info['queryset_filters'],
             distinct=task_info.get('distinct'),
         )
         if options.get('limit'):

--- a/src/olympia/bandwagon/migrations/0001_initial.py
+++ b/src/olympia/bandwagon/migrations/0001_initial.py
@@ -91,7 +91,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='collection',
             name='description',
-            field=olympia.translations.fields.NoLinksNoMarkupField(blank=True, db_column='description', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='Collection_description_set+', require_locale=False, short=True, to='translations.NoLinksNoMarkupTranslation', to_field='id', unique=True),
+            field=olympia.translations.fields.NoURLsField(blank=True, db_column='description', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='Collection_description_set+', require_locale=False, short=True, to='translations.NoURLsTranslation', to_field='id', unique=True),
         ),
         migrations.AddField(
             model_name='collection',

--- a/src/olympia/bandwagon/models.py
+++ b/src/olympia/bandwagon/models.py
@@ -30,9 +30,9 @@ class Collection(ModelBase):
     name = TranslatedField(require_locale=False)
     slug = models.CharField(max_length=30, blank=True, null=True)
 
-    # biography can (and sometimes does) contain html and other unsanitized
+    # description can (and sometimes does) contain html and other unsanitized
     # content. It must be cleaned before display - NoURLsField just strips the
-    # URL without escaping.
+    # URL without doing any escaping.
     description = NoURLsField(require_locale=False)
     default_locale = models.CharField(
         max_length=10, default='en-US', db_column='defaultlocale'

--- a/src/olympia/bandwagon/models.py
+++ b/src/olympia/bandwagon/models.py
@@ -10,7 +10,7 @@ from olympia.amo.fields import PositiveAutoField
 from olympia.amo.models import ManagerBase, ModelBase
 from olympia.translations.fields import (
     LinkifiedField,
-    NoLinksNoMarkupField,
+    NoURLsField,
     TranslatedField,
     save_signal,
 )
@@ -30,7 +30,10 @@ class Collection(ModelBase):
     name = TranslatedField(require_locale=False)
     slug = models.CharField(max_length=30, blank=True, null=True)
 
-    description = NoLinksNoMarkupField(require_locale=False)
+    # biography can (and sometimes does) contain html and other unsanitized
+    # content. It must be cleaned before display - NoURLsField just strips the
+    # URL without escaping.
+    description = NoURLsField(require_locale=False)
     default_locale = models.CharField(
         max_length=10, default='en-US', db_column='defaultlocale'
     )

--- a/src/olympia/bandwagon/tests/test_models.py
+++ b/src/olympia/bandwagon/tests/test_models.py
@@ -33,12 +33,13 @@ class TestCollections(TestCase):
         core.set_user(self.user)
 
     def test_description(self):
-        c = Collection.objects.create(
+        collection = Collection.objects.create(
             description='<a href="http://example.com">example.com</a> '
-            'http://example.com <b>foo</b> some text'
+            'http://example.com <b>foo</b> some text lol.com'
         )
-        # All markup escaped, links are stripped.
-        assert str(c.description) == '&lt;b&gt;foo&lt;/b&gt; some text'
+        # All markup kept (since this is a text field, not parsing HTML, clients will
+        # escape it), but URLs are removed.
+        assert str(collection.description) == '<a href=""></a>  <b>foo</b> some text'
 
     def test_translation_default(self):
         """Make sure we're getting strings from the default locale."""

--- a/src/olympia/bandwagon/tests/test_views.py
+++ b/src/olympia/bandwagon/tests/test_views.py
@@ -384,7 +384,7 @@ class CollectionViewSetDataMixin(object):
         assert response.status_code == 400
         assert json.loads(response.content) == {'name': ['Name cannot be empty.']}
 
-    def test_biography_no_links(self):
+    def test_description_no_links(self):
         self.client.login_api(self.user)
         data = dict(self.data)
         data.update(description='<a href="https://google.com">google</a>')
@@ -402,7 +402,7 @@ class CollectionViewSetDataMixin(object):
         }
 
     @override_settings(DRF_API_GATES={'v5': ('l10n_flat_input_output',)})
-    def test_biography_no_links_flat_input(self):
+    def test_description_no_links_flat_input(self):
         self.client.login_api(self.user)
         data = dict(self.data)
         data.update(description='<a href="https://google.com">google</a>')

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1136,6 +1136,7 @@ CELERY_TASK_ROUTES = {
     # A queue to be used for one-off tasks that could be resource intensive.
     'olympia.versions.tasks.delete_list_theme_previews': {'queue': 'adhoc'},
     'olympia.versions.tasks.hard_delete_versions': {'queue': 'adhoc'},
+    'olympia.translations.tasks.reclean_collection_descriptions': {'queue': 'adhoc'},
     # Crons
     'olympia.addons.tasks.update_addon_average_daily_users': {'queue': 'cron'},
     'olympia.addons.tasks.update_addon_hotness': {'queue': 'cron'},

--- a/src/olympia/translations/fields.py
+++ b/src/olympia/translations/fields.py
@@ -202,8 +202,8 @@ class LinkifiedField(TranslatedField):
     to = 'translations.LinkifiedTranslation'
 
 
-class NoLinksNoMarkupField(TranslatedField):
-    to = 'translations.NoLinksNoMarkupTranslation'
+class NoURLsField(TranslatedField):
+    to = 'translations.NoURLsTranslation'
 
 
 def switch(obj, new_model):

--- a/src/olympia/translations/management/commands/process_translations.py
+++ b/src/olympia/translations/management/commands/process_translations.py
@@ -1,0 +1,31 @@
+from django.db.models import F, Q
+
+from olympia.amo.management import ProcessObjectsCommand
+from olympia.bandwagon.models import Collection
+from olympia.translations.models import Translation
+from olympia.translations.tasks import reclean_collection_descriptions
+
+
+class Command(ProcessObjectsCommand):
+    def get_model(self):
+        return Translation
+
+    def get_tasks(self):
+        return {
+            'reclean_collection_descriptions': {
+                'task': reclean_collection_descriptions,
+                # Need to fetch ids of translations that belong to collection
+                # descriptions (there might be more than one per collection!)
+                # and then find those where the cleaned string is not the same
+                # as the original: those are the ones we need to re-clean.
+                'queryset_filters': [
+                    Q(
+                        id__in=Collection.objects.all()
+                        .filter(description__isnull=False)
+                        .values_list('description', flat=True)
+                    ),
+                    Q(localized_string_clean__isnull=False),
+                    ~Q(localized_string_clean=F('localized_string')),
+                ],
+            },
+        }

--- a/src/olympia/translations/migrations/0001_initial.py
+++ b/src/olympia/translations/migrations/0001_initial.py
@@ -66,7 +66,7 @@ class Migration(migrations.Migration):
             bases=('translations.purifiedtranslation',),
         ),
         migrations.CreateModel(
-            name='NoLinksNoMarkupTranslation',
+            name='NoURLsTranslation',
             fields=[
             ],
             options={

--- a/src/olympia/translations/tasks.py
+++ b/src/olympia/translations/tasks.py
@@ -1,0 +1,16 @@
+import olympia.core.logger
+from olympia.amo.celery import task
+from olympia.amo.decorators import use_primary_db
+from olympia.translations.models import NoURLsTranslation
+
+
+log = olympia.core.logger.getLogger('z.task')
+
+
+@task
+@use_primary_db
+def reclean_collection_descriptions(ids, **kw):
+    log.info('Recleaning translation of ids %d-%d [%d].', ids[0], ids[-1], len(ids))
+    translations = NoURLsTranslation.objects.filter(pk__in=ids)
+    for translation in translations:
+        translation.save()

--- a/src/olympia/translations/templatetags/jinja_helpers.py
+++ b/src/olympia/translations/templatetags/jinja_helpers.py
@@ -113,16 +113,3 @@ def clean(string, strip_all_html=False):
         string = bleach.clean(str(string))
 
     return jinja2.Markup(clean_nl(string).strip())
-
-
-@library.filter
-def no_links(string):
-    """Leave text links untouched, keep only inner text on URLs."""
-    if not string:
-        return string
-    if hasattr(string, '__html__'):
-        string = string.__html__()
-    allowed_tags = bleach.ALLOWED_TAGS[:]
-    allowed_tags.remove('a')
-    no_links = bleach.clean(string, tags=allowed_tags, strip=True)
-    return jinja2.Markup(clean_nl(no_links).strip())

--- a/src/olympia/translations/tests/test_commands.py
+++ b/src/olympia/translations/tests/test_commands.py
@@ -1,0 +1,70 @@
+from django.core.management import call_command
+
+from olympia.amo.tests import addon_factory, TestCase
+from olympia.bandwagon.models import Collection
+from olympia.translations.models import Translation
+from olympia.translations.management.commands.process_translations import (
+    Command as ProcessTranslationsCommand,
+)
+
+
+class TestTranslationCommands(TestCase):
+    def setUp(self):
+        self.collection = Collection.objects.create(
+            name='foo_collection_name', description='foo_collection_description'
+        )
+        # Orphaned translation: should not be touched.
+        Translation.objects.create(
+            id=667, localized_string='foo', localized_string_clean='bar', locale='de'
+        )
+        # Orphaned translation for the same string in a different locale:
+        # should not be touched.
+        Translation.objects.create(
+            id=667,
+            localized_string='foo2',
+            localized_string_clean='bar2',
+            locale='fr',
+        )
+
+        # Translation belonging to a collection name: should not be touched.
+        self.collection.name.localized_string_clean = 'bar_collection_name'
+        self.collection.name.save()
+        # Translation belonging to an add-on: should not be touched.
+        addon = addon_factory(name='foo_addon')
+        addon.name.localized_string_clean = 'bar_addon'
+        addon.name.save()
+        # Translation belonging to a collection description that we don't need to bother
+        # with (because its localized string clean should already match its localized
+        # string): should not be touched.
+        extra_collection = Collection.objects.create(
+            name='foo_collection_name2', description='foo_collection_description2'
+        )
+        extra_collection.description.update(modified=self.days_ago(42))
+
+        # The command should fix this one.
+        self.collection.description.update(
+            localized_string_clean='bar_collection_description',
+            modified=self.days_ago(42),
+        )
+        self.collection.description.reload()
+
+    def test_queryset(self):
+        command = ProcessTranslationsCommand()
+        qs = command.get_base_queryset({})
+        pks = command.get_pks(
+            qs,
+            command.get_tasks()['reclean_collection_descriptions']['queryset_filters'],
+        )
+        assert list(pks) == [self.collection.description.pk]
+
+    def test_reclean_collection_descriptions(self):
+        call_command('process_translations', task='reclean_collection_descriptions')
+
+        # We forcibly set localized_string_clean to be different than localized_string.
+        # Firing the command should have changed it back.
+        self.collection.description.reload()
+        self.assertCloseToNow(self.collection.description.modified)
+        assert (
+            self.collection.description.localized_string_clean
+            == self.collection.description.localized_string
+        )

--- a/src/olympia/translations/tests/test_commands.py
+++ b/src/olympia/translations/tests/test_commands.py
@@ -10,9 +10,6 @@ from olympia.translations.management.commands.process_translations import (
 
 class TestTranslationCommands(TestCase):
     def setUp(self):
-        self.collection = Collection.objects.create(
-            name='foo_collection_name', description='foo_collection_description'
-        )
         # Orphaned translation: should not be touched.
         Translation.objects.create(
             id=667, localized_string='foo', localized_string_clean='bar', locale='de'
@@ -25,10 +22,6 @@ class TestTranslationCommands(TestCase):
             localized_string_clean='bar2',
             locale='fr',
         )
-
-        # Translation belonging to a collection name: should not be touched.
-        self.collection.name.localized_string_clean = 'bar_collection_name'
-        self.collection.name.save()
         # Translation belonging to an add-on: should not be touched.
         addon = addon_factory(name='foo_addon')
         addon.name.localized_string_clean = 'bar_addon'
@@ -41,7 +34,14 @@ class TestTranslationCommands(TestCase):
         )
         extra_collection.description.update(modified=self.days_ago(42))
 
-        # The command should fix this one.
+        self.collection = Collection.objects.create(
+            name='foo_collection_name', description='foo_collection_description'
+        )
+        # Translation belonging to a collection name: should not be touched.
+        self.collection.name.localized_string_clean = 'bar_collection_name'
+        self.collection.name.save()
+        # Translation belonging to the same collection, but this time the
+        # description. The command should fix this one.
         self.collection.description.update(
             localized_string_clean='bar_collection_description',
             modified=self.days_ago(42),

--- a/src/olympia/translations/tests/test_helpers.py
+++ b/src/olympia/translations/tests/test_helpers.py
@@ -93,22 +93,6 @@ def test_clean_strip_all_html():
     assert from_string('{{ s|clean(true) }}').render({'s': s}) == expected
 
 
-def test_no_links():
-    template = from_string('{{ s|no_links }}')
-
-    s = 'a <a href="http://url.link">http://example.com</a>, http://text.link'
-    expected = 'a http://example.com, http://text.link'
-    assert template.render({'s': s}) == expected
-
-    # Bad markup.
-    s = '<http://bad.markup.com'
-    assert template.render({'s': s}) == ''
-
-    # Bad markup.
-    s = 'some text <http://bad.markup.com'
-    assert template.render({'s': s}) == 'some text'
-
-
 def test_l10n_menu():
     # No remove_locale_url provided.
     menu = jinja_helpers.l10n_menu({})

--- a/src/olympia/translations/tests/test_models.py
+++ b/src/olympia/translations/tests/test_models.py
@@ -821,13 +821,13 @@ class NoURLsTranslationTest(TestCase):
         translation = NoURLsTranslation.objects.create(
             id=1003,
             localized_string='foo http://example.com',
-            localized_string_clean='foo',
+            localized_string_clean=None,
         )
         assert translation.localized_string == 'foo http://example.com'
         assert translation.localized_string_clean == 'foo'
 
         translation.localized_string_clean = 'xaxaxa'
-        translation.save()  # Will overwrite localized_string_clean.
+        translation.save()
         assert translation.localized_string == 'foo http://example.com'
         assert translation.localized_string_clean == 'foo'
 

--- a/src/olympia/translations/tests/test_models.py
+++ b/src/olympia/translations/tests/test_models.py
@@ -21,7 +21,7 @@ from olympia.amo.tests import TestCase
 from olympia.translations.hold import translation_saved
 from olympia.translations.models import (
     LinkifiedTranslation,
-    NoLinksNoMarkupTranslation,
+    NoURLsTranslation,
     PurifiedTranslation,
     Translation,
     TranslationSequence,
@@ -734,37 +734,102 @@ class LinkifiedTranslationTest(TestCase):
         )
 
 
-class NoLinksNoMarkupTranslationTest(TestCase):
-    def test_forbidden_tags(self):
-        s = '<script>some naughty xss</script> <b>bold</b>'
-        x = NoLinksNoMarkupTranslation(localized_string=s)
-        assert x.__html__() == (
-            '&lt;script&gt;some naughty xss&lt;/script&gt; &lt;b&gt;bold&lt;/b&gt;'
-        )
+class NoURLsTranslationTest(TestCase):
+    def test_no_escaping(self):
+        # HTML is not escaped by this model as this is just storing as text.
+        value = '<script>some naughty xss</script> & <b>bold</b>'
+        translation = NoURLsTranslation(localized_string=value)
+        assert str(translation) == str(value)
 
-    def test_links_stripped(self):
-        # Link with markup.
-        s = 'a <a href="http://example.com">link</a> with markup'
-        x = NoLinksNoMarkupTranslation(localized_string=s)
-        assert x.__html__() == 'a  with markup'
+    def test_urls_stripped(self):
+        # Link with markup. Link text is preserved because it doesn't contain
+        # an URL.
+        value = 'a <a href="http://example.com">link</a> with markup'
+        translation = NoURLsTranslation(localized_string=value)
+        assert str(translation) == 'a <a href="">link</a> with markup'
+
+        # Link with markup but this time the text is also an URL. It's stripped
+        value = 'a <a href="http://example.com">example.com</a> with markup'
+        translation = NoURLsTranslation(localized_string=value)
+        assert str(translation) == 'a <a href=""></a> with markup'
 
         # Text link.
         s = 'a text http://example.com link'
-        x = NoLinksNoMarkupTranslation(localized_string=s)
-        assert x.__html__() == 'a text  link'
+        translation = NoURLsTranslation(localized_string=s)
+        assert str(translation) == 'a text  link'
 
-        # Text link, markup link, forbidden tags and bad markup.
-        s = (
+        # Test less obvious link
+        s = 'a text foo.is link'
+        translation = NoURLsTranslation(localized_string=s)
+        assert str(translation) == 'a text  link'
+
+        # Another.
+        s = 'a text t.to link'
+        translation = NoURLsTranslation(localized_string=s)
+        assert str(translation) == 'a text  link'
+
+    def test_uppercase(self):
+        value = (
             'a <a href="http://example.com">link</a> with markup, a text '
-            'http://example.com link, <b>with forbidden tags</b>, '
-            '<script>forbidden tags</script> and <http://bad.markup.com'
+            'http://example.com link, and some raw <b>html://</b>. I <3 HTTP!'
         )
-        x = NoLinksNoMarkupTranslation(localized_string=s)
-        assert x.__html__() == (
-            'a  with markup, a text  link, '
-            '&lt;b&gt;with forbidden tags&lt;/b&gt;, '
-            '&lt;script&gt;forbidden tags&lt;/script&gt; and'
+        translation = NoURLsTranslation(localized_string=value)
+        assert str(translation) == (
+            'a <a href="">link</a> with markup, a text '
+            ' link, and some raw <b>html://</b>. I <3 HTTP!'
         )
+
+    def test_with_newlines(self):
+        value = (
+            'a <a href="http://example.com">link</a> with markup \n, a text '
+            'http://example.com link, and some raw <b>HTML</b>. I <3 http!'
+        )
+        translation = NoURLsTranslation(localized_string=value)
+        assert str(translation) == (
+            'a <a href="">link</a> with markup \n, a text '
+            ' link, and some raw <b>HTML</b>. I <3 http!'
+        )
+
+    def test_bit_of_everything(self):
+        value = (
+            'a <a href="http://example.com">link</a> with markup,\n'
+            'a newline with a more complex link <a href="http://foo.is">lol.com</a>,\n'
+            'another http://example.com link, <b>with forbidden tags</b>,\n'
+            'and <script>forbidden tags</script> as well as <http:/bad.markup.com'
+        )
+        translation = NoURLsTranslation(localized_string=value)
+        assert str(translation) == (
+            'a <a href="">link</a> with markup,\n'
+            'a newline with a more complex link <a href=""></a>,\n'
+            'another  link, <b>with forbidden tags</b>,\n'
+            'and <script>forbidden tags</script> as well as <'
+        )
+
+    def test_clean_on_save(self):
+        translation = NoURLsTranslation.objects.create(id=1001, localized_string='foo')
+        assert (
+            translation.localized_string_clean == translation.localized_string == 'foo'
+        )
+
+        translation = NoURLsTranslation.objects.create(
+            id=1002, localized_string='foo', localized_string_clean='bar'
+        )
+        assert (
+            translation.localized_string_clean == translation.localized_string == 'foo'
+        )
+
+        translation = NoURLsTranslation.objects.create(
+            id=1003,
+            localized_string='foo http://example.com',
+            localized_string_clean='foo',
+        )
+        assert translation.localized_string == 'foo http://example.com'
+        assert translation.localized_string_clean == 'foo'
+
+        translation.localized_string_clean = 'xaxaxa'
+        translation.save()  # Will overwrite localized_string_clean.
+        assert translation.localized_string == 'foo http://example.com'
+        assert translation.localized_string_clean == 'foo'
 
 
 def test_translation_bool():


### PR DESCRIPTION
URLs should still be stripped, but we should store (and return) text, and let clients escape it as needed - it's not supposed to contain
any HTML.

Includes a command to fix existing translations in the database.

Fixes #7648