### PR TITLE
Stop filtering ES queries on doc type

### DIFF
--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -472,7 +472,6 @@ class AddonSearchView(ListAPIView):
             Search(
                 using=amo.search.get_es(),
                 index=AddonIndexer.get_index_alias(),
-                doc_type=AddonIndexer.get_doctype_name(),
             )
             .extra(_source={'excludes': AddonIndexer.hidden_fields})
             .params(search_type='dfs_query_then_fetch')
@@ -524,7 +523,6 @@ class AddonAutoCompleteSearchView(AddonSearchView):
         qset = Search(
             using=amo.search.get_es(),
             index=AddonIndexer.get_index_alias(),
-            doc_type=AddonIndexer.get_doctype_name(),
         ).extra(_source={'includes': included_fields})
 
         return qset


### PR DESCRIPTION
doc type is deprecated and will eventually be removed. We need to stop passing it at index creation in the mapping and at indexing time, and stop passing it when searching.

Because we are still currently passing it to search queries, if we were to remove it right away from index creation/bulk indexing, search would break and never find any results. So the first step is to remove it from search queries, and then later remove it from everywhere else too.

Fixes #17447