### PR TITLE
deploy stage with django32

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -646,6 +646,8 @@ jobs:
 
   release-tag:
     <<: *defaults-release
+    environment:
+      DJANGO_VERSION: "django32"
     steps:
       - checkout
       - make_release:


### PR DESCRIPTION
config could be refactored now django32 is used for all release jobs but this is lowest impact (and we'll clean up the config in a few weeks anyway once we stop CI for django22)