### PR TITLE
pin mysql to v8.0.25 in circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,7 +285,7 @@ references:
     - &python "cimg/python:3.8"
     - &redis "redis:2.8"
     - &memcached "memcached:1.4"
-    - &mysql "circleci/mysql:8.0"
+    - &mysql "circleci/mysql:8.0.25"
 
   mysql-config: &mysql-config
     environment:


### PR DESCRIPTION
circleci builds have started failing one test: src/olympia/reviewers/tests/test_views.py::TestExtensionQueue::test_results_two_versions
and it seems to have only happened once the 8.0 branch of mysql images switched from 8.0.25 to 8.0.26

pinning to a specific version of mysql isn't a long term solution but this fixes our CI woes in the short term