### PR TITLE
fix shelves tests

### DIFF
--- a/src/olympia/shelves/tests/test_forms.py
+++ b/src/olympia/shelves/tests/test_forms.py
@@ -16,7 +16,7 @@ class TestShelfForm(TestCase):
         self.criteria_col_thm = 'featured-personas'
         self.criteria_col_404 = 'passwordmanagers'
         self.criteria_not_200 = '?sort=user&type=extension'
-        tag_text = Tag.objects.create(tag_text='foo').tag_text
+        tag_text = Tag.objects.first().tag_text
 
         responses.add(
             responses.GET,


### PR DESCRIPTION
fixes #17526 (#17481 added default tags in a migration which meant relying on creating a single tag and knowing it's value in the tests in #17503 was broken)