### PR TITLE
Fix default preview format for extensions

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -2198,6 +2198,16 @@ class Preview(BasePreview, ModelBase):
             ),
         ]
 
+    def get_format(self, for_size):
+        return self.sizes.get(
+            f'{for_size}_format',
+            # If self.sizes doesn't contain the requested format, it's probably
+            # because the Preview was just created but not yet resized down.
+            # We try to guess the format if it's in ADDON_PREVIEW_SIZES,
+            # falling back to `png` like BasePreview does otherwise.
+            amo.ADDON_PREVIEW_SIZES.get(f'{for_size}_format', 'png'),
+        )
+
 
 dbsignals.pre_save.connect(
     save_signal, sender=Preview, dispatch_uid='preview_translations'

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -820,7 +820,7 @@ class TestAddonModels(TestCase):
         url.
         """
         a = Addon.objects.get(pk=4664)
-        a.thumbnail_url.index('/previews/thumbs/20/20397.png?modified=')
+        a.thumbnail_url.index('/previews/thumbs/20/20397.jpg?modified=')
         a = Addon.objects.get(pk=5299)
         assert a.thumbnail_url.endswith('/icons/no-preview.png'), (
             'No match for %s' % a.thumbnail_url
@@ -2393,6 +2393,29 @@ class TestPreviewModel(BasePreviewMixin, TestCase):
 
     def get_object(self):
         return Preview.objects.get(pk=24)
+
+    def test_filename(self):
+        preview = self.get_object()
+        assert preview.thumbnail_path.endswith('.jpg')
+        assert preview.image_path.endswith('.png')
+        assert preview.original_path.endswith('.png')
+
+        # now set the format in .sizes. Set thumbnail_format to a weird one
+        # on purpose to make sure it's followed.
+        preview.update(sizes={'thumbnail_format': 'abc', 'image_format': 'gif'})
+        assert preview.thumbnail_path.endswith('.abc')
+        assert preview.image_path.endswith('.gif')
+        assert preview.original_path.endswith('.png')
+
+    def test_filename_in_url(self):
+        preview = self.get_object()
+        assert '.jpg?modified=' in preview.thumbnail_url
+        assert '.png?modified=' in preview.image_url
+
+        # now set the format in .sizes.
+        preview.update(sizes={'thumbnail_format': 'abc', 'image_format': 'gif'})
+        assert '.abc?modified=' in preview.thumbnail_url
+        assert '.gif?modified=' in preview.image_url
 
 
 class TestListedAddonTwoVersions(TestCase):

--- a/src/olympia/constants/base.py
+++ b/src/olympia/constants/base.py
@@ -231,6 +231,7 @@ ADDON_PREVIEW_SIZES = {
     'thumbnail': _dimensions(533, 400),
     'min': _dimensions(1000, 750),
     'full': _dimensions(2400, 1800),
+    'image_format': 'png',
     'thumbnail_format': 'jpg',
 }
 


### PR DESCRIPTION
The hardcoded `png` was wrong since we changed the format for the thumbnails to `jpg`. This caused an issue when uploading previews in devhub, the URL was wrong while the Preview was still being resized.

Fixes https://github.com/mozilla/addons-server/issues/17561