### PR TITLE
Allow blocklisting when the add-on already has its guid resubmission denied

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -714,7 +714,7 @@ class Addon(OnChangeMixin, ModelBase):
                 try:
                     with transaction.atomic():
                         self.deny_resubmission()
-                except GuidAlreadyDeniedError:
+                except RuntimeError:
                     # If the guid is already in DeniedGuids, we are good.
                     pass
 

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -22,6 +22,7 @@ from olympia.addons.models import (
     DeniedGuid,
     DeniedSlug,
     FrozenAddon,
+    GuidAlreadyDeniedError,
     MigratedLWT,
     Preview,
     AddonGUID,
@@ -2948,8 +2949,10 @@ class TestAddonAndDeniedGuid(TestCase):
     def test_deny_already_denied_guid(self):
         addon = addon_factory()
         addon.deny_resubmission()
-        with pytest.raises(RuntimeError):
+        with pytest.raises(GuidAlreadyDeniedError) as exc_info:
             addon.deny_resubmission()
+        # Exception raised is also a child of the more generic RuntimeError.
+        assert isinstance(exc_info.value, RuntimeError)
 
     def test_deny_empty_guid(self):
         addon = addon_factory(guid=None)

--- a/src/olympia/blocklist/tests/test_admin.py
+++ b/src/olympia/blocklist/tests/test_admin.py
@@ -1823,6 +1823,48 @@ class TestBlocklistSubmissionAdmin(TestCase):
         assert deleted_addon.status == amo.STATUS_DELETED  # Should stay deleted
         assert DeniedGuid.objects.filter(guid=deleted_addon.guid).exists()
 
+    def test_blocking_addon_guid_already_denied(self):
+        user = user_factory(email='someone@mozilla.com')
+        self.grant_permission(user, 'Blocklist:Create')
+        self.client.login(email=user.email)
+
+        deleted_addon = addon_factory(guid='guid@', version_kw={'version': '1.2.5'})
+        deleted_addon.delete()
+        assert deleted_addon.status == amo.STATUS_DELETED
+        deleted_addon.deny_resubmission()
+        assert DeniedGuid.objects.filter(guid=deleted_addon.guid).exists()
+
+        response = self.client.get(self.submission_url + '?guids=guid@', follow=True)
+        content = response.content.decode('utf-8')
+        assert 'Add-on GUIDs (one per line)' not in content
+        assert deleted_addon.guid in content
+        assert Block.objects.count() == 0  # Check we didn't create it already
+        assert 'Block History' in content
+
+        # Create the block
+        response = self.client.post(
+            self.submission_url,
+            {
+                'input_guids': 'guid@',
+                'action': '0',
+                'min_version': '0',
+                'max_version': '*',
+                'existing_min_version': '0',
+                'existing_max_version': '*',
+                'url': 'dfd',
+                'reason': 'some reason',
+                '_save': 'Save',
+            },
+            follow=True,
+        )
+        assert response.status_code == 200
+        assert Block.objects.count() == 1
+        block = Block.objects.first()
+        assert block.addon == deleted_addon
+        deleted_addon.reload()
+        assert deleted_addon.status == amo.STATUS_DELETED  # Should stay deleted
+        assert DeniedGuid.objects.filter(guid=deleted_addon.guid).exists()
+
 
 class TestBlockAdminEdit(TestCase):
     def setUp(self):

--- a/src/olympia/blocklist/utils.py
+++ b/src/olympia/blocklist/utils.py
@@ -209,6 +209,7 @@ def disable_addon_for_block(block):
     """Disable appropriate addon versions that are affected by the Block, and
     the addon too if 0 - *."""
     from .models import Block
+    from olympia.addons.models import GuidAlreadyDeniedError
     from olympia.reviewers.utils import ReviewBase
 
     review = ReviewBase(
@@ -237,7 +238,10 @@ def disable_addon_for_block(block):
 
     if block.min_version == Block.MIN and block.max_version == Block.MAX:
         if block.addon.status == amo.STATUS_DELETED:
-            block.addon.deny_resubmission()
+            try:
+                block.addon.deny_resubmission()
+            except GuidAlreadyDeniedError:
+                pass
         else:
             block.addon.update(status=amo.STATUS_DISABLED)
 


### PR DESCRIPTION
Fixes #17489