### PR TITLE
Report a bug link at bottom of extension edit page goes to 404 error

### DIFF
--- a/src/olympia/templates/photon-footer.html
+++ b/src/olympia/templates/photon-footer.html
@@ -14,7 +14,7 @@
                 <li><a href="{{ url('devhub.index') }}">Developer Hub</a></li>
                 <li><a href="https://developer.mozilla.org/docs/Mozilla/Add-ons/AMO/Policy">Developer Policies</a></li>
                 <li><a href="https://discourse.mozilla-community.org/c/add-ons">Forum</a></li>
-                <li><a class="Footer-bug-report-link" href="https://developer.mozilla.org/docs/Mozilla/Add-ons/Contact_us">Report a bug</a></li>
+                <li><a class="Footer-bug-report-link" href="https://addons.mozilla.org/en-US/about">Report a bug</a></li>
                 <li><a href="{{ url('pages.review_guide') }}">Review Guide</a></li>
                 <li><a href="https://status.mozilla.org/">Site Status</a></li>
             </ul>


### PR DESCRIPTION
Fixes #16884 

@willdurand 