### PR TITLE
Remove click from codestyle.txt as it's already in prod.txt now

### DIFF
--- a/requirements/codestyle.txt
+++ b/requirements/codestyle.txt
@@ -31,10 +31,6 @@ attrs==21.2.0 \
 parsy==1.3.0 \
     --hash=sha256:bea54186c3da470944dafe2314b57ac53d0dc2b0a168dc32f644b1b93dc6ca64 \
     --hash=sha256:bfc941ea5a69e6ac16bd4f7d9f807bbc17e35edd8b95bcd2499a25b059359012
-# click is required by curlylint
-click==8.0.1 \
-    --hash=sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6 \
-    --hash=sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a
 # pathspec is required by curlylint
 pathspec==0.9.0 \
     --hash=sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a \


### PR DESCRIPTION
Fix for https://github.com/mozilla/addons-server/issues/17539 locally (because it's also the wrong version for celery)