### PR TITLE
Make AMO ID the canonical identifier in reviewer tools

### DIFF
--- a/src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html
+++ b/src/olympia/devhub/templates/devhub/includes/addons_edit_nav.html
@@ -36,9 +36,9 @@
         {{ _('View Product Page') }}</a></li>
       {% endif %}
       {% if action_allowed(amo.permissions.ADDONS_EDIT) %}
-        <li><a href="{{ url('reviewers.review', addon.slug) }}">
+        <li><a href="{{ url('reviewers.review', addon.pk) }}">
           {{ _('Listed Review Page') }}</a></li>
-        <li><a href="{{ url('reviewers.review', 'unlisted', addon.slug) }}">
+        <li><a href="{{ url('reviewers.review', 'unlisted', addon.pk) }}">
           {{ _('Unlisted Review Page') }}</a></li>
       {% endif %}
       {% if action_allowed(amo.permissions.REVIEWS_ADMIN) %}

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -619,10 +619,10 @@ class TestEditDescribeListed(BaseTestEditDescribe, L10nTestsMixin):
         doc = pq(response.content)('#edit-addon-nav')
         links = doc('ul:last').find('li a')
         assert links.eq(1).attr('href') == reverse(
-            'reviewers.review', args=[self.addon.slug]
+            'reviewers.review', args=[self.addon.pk]
         )
         assert links.eq(2).attr('href') == reverse(
-            'reviewers.review', args=['unlisted', self.addon.slug]
+            'reviewers.review', args=['unlisted', self.addon.pk]
         )
         assert links.eq(3).attr('href') == reverse(
             'admin:addons_addon_change', args=[self.addon.id]

--- a/src/olympia/reviewers/decorators.py
+++ b/src/olympia/reviewers/decorators.py
@@ -7,7 +7,6 @@ from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404
 
 from olympia.access import acl
-from olympia.addons.decorators import owner_or_unlisted_viewer_or_reviewer
 from olympia.addons.models import Addon
 from olympia.amo.decorators import login_required
 from olympia.constants import permissions

--- a/src/olympia/reviewers/decorators.py
+++ b/src/olympia/reviewers/decorators.py
@@ -1,8 +1,14 @@
 import functools
 
+from urllib.parse import quote
+
+from django import http
 from django.core.exceptions import PermissionDenied
+from django.shortcuts import get_object_or_404
 
 from olympia.access import acl
+from olympia.addons.decorators import owner_or_unlisted_viewer_or_reviewer
+from olympia.addons.models import Addon
 from olympia.amo.decorators import login_required
 from olympia.constants import permissions
 
@@ -88,5 +94,46 @@ def any_reviewer_or_moderator_required(f):
         if allow_access:
             return f(request, *args, **kw)
         raise PermissionDenied
+
+    return wrapper
+
+
+def reviewer_addon_view(
+    f, qs=Addon.objects.all, include_deleted_when_checking_versions=False
+):
+    """Use a separate view decorator here so we can make the AMO ID the canonical
+    identifier in reviewer tools urls."""
+
+    @functools.wraps(f)
+    def wrapper(request, addon_id=None, *args, **kw):
+        """Provides an addon instance to the view given addon_id, which can be
+        an Addon pk, guid or a slug."""
+        assert addon_id, 'Must provide addon id, guid or slug'
+
+        lookup_field = Addon.get_lookup_field(addon_id)
+        if lookup_field == 'pk':
+            addon = get_object_or_404(qs(), pk=addon_id)
+        else:
+            addon = get_object_or_404(qs(), **{lookup_field: addon_id})
+            # FIXME: what about a slug called 'addon' ? And are we sure that
+            # request.path will always already be quoted ? If not that would
+            # break the redirect.
+            # Maybe instead resolve() it and replace the first parameter with
+            # addon.pk, then reverse() the url ?
+            url = request.path.replace(quote(addon_id), str(addon.pk), 1)
+            if request.GET:
+                url += '?' + request.GET.urlencode()
+            return http.HttpResponsePermanentRedirect(url)
+
+        # If the addon has no listed versions it needs either an author
+        # (owner/viewer/dev/support) or an unlisted addon reviewer.
+        has_listed_versions = addon.has_listed_versions(
+            include_deleted=include_deleted_when_checking_versions
+        )
+        if not (
+            has_listed_versions or owner_or_unlisted_viewer_or_reviewer(request, addon)
+        ):
+            raise http.Http404
+        return f(request, addon, *args, **kw)
 
     return wrapper

--- a/src/olympia/reviewers/templates/reviewers/addon_details_box.html
+++ b/src/olympia/reviewers/templates/reviewers/addon_details_box.html
@@ -149,7 +149,7 @@
           <tr class="meta-abuse">
             <th>{{ _('Abuse Reports') }}</th>
             <td>
-                <a href="{{ url('reviewers.abuse_reports', addon.slug)|absolutify }}{{ '?channel=unlisted' if unlisted else '' }}">
+                <a href="{{ url('reviewers.abuse_reports', addon.pk)|absolutify }}{{ '?channel=unlisted' if unlisted else '' }}">
                   <strong>{{ reports.paginator.count|numberfmt }}</strong>
                 </a>
             </td>
@@ -159,7 +159,7 @@
             <tr>
               <th>{{ _('Privacy Policy') }}</th>
               <td>
-                <a href="{{ url('reviewers.privacy', addon.slug)|absolutify }}{{ '?channel=unlisted' if unlisted else '' }}">
+                <a href="{{ url('reviewers.privacy', addon.pk)|absolutify }}{{ '?channel=unlisted' if unlisted else '' }}">
                   {{ _('View Privacy Policy') }}</a>
               </td>
             </tr>
@@ -174,7 +174,7 @@
             <tr>
               <th>{{ _('EULA') }}</th>
               <td>
-                <a href="{{ url('reviewers.eula', addon.slug)|absolutify }}{{ '?channel=unlisted' if unlisted else '' }}">
+                <a href="{{ url('reviewers.eula', addon.pk)|absolutify }}{{ '?channel=unlisted' if unlisted else '' }}">
                   {{ _('View End-User License Agreement') }}</a>
               </td>
             </tr>
@@ -193,12 +193,12 @@
 
   <div class="reports-and-ratings">
     {% if reports %}
-      <h3><a href="{{ url('reviewers.abuse_reports', addon.slug)|absolutify }}">{{_('Abuse Reports ({num})')|format_html(num=reports.paginator.count|numberfmt) }}</a></h3>
+      <h3><a href="{{ url('reviewers.abuse_reports', addon.pk)|absolutify }}">{{_('Abuse Reports ({num})')|format_html(num=reports.paginator.count|numberfmt) }}</a></h3>
       {% include "reviewers/includes/abuse_reports_list.html" %}
     {% endif %}
 
     {% if user_ratings %}
-      <h3><a href="{{ url('addons.ratings.list', addon.slug)|absolutify }}">{{_('Bad User Ratings ({num})')|format_html(num=user_ratings.paginator.count|numberfmt) }}</a></h3>
+      <h3><a href="{{ url('addons.ratings.list', addon.pk)|absolutify }}">{{_('Bad User Ratings ({num})')|format_html(num=user_ratings.paginator.count|numberfmt) }}</a></h3>
       {% include "reviewers/includes/user_ratings_list.html" %}
     {% endif %}
   </div>

--- a/src/olympia/reviewers/templates/reviewers/reviewlog.html
+++ b/src/olympia/reviewers/templates/reviewers/reviewlog.html
@@ -49,11 +49,11 @@
                     {% set channel = 0 %}
                   {% endif %}
                   {% if item.action == amo.LOG.REJECT_CONTENT.id or item.action == amo.LOG.APPROVE_CONTENT.id %}
-                    {% set review_url = url('reviewers.review', 'content', item.arguments[0].slug ) %}
+                    {% set review_url = url('reviewers.review', 'content', item.arguments[0].pk ) %}
                   {% elif channel == amo.RELEASE_CHANNEL_UNLISTED %}
-                    {% set review_url = url('reviewers.review', 'unlisted', item.arguments[0].slug) %}
+                    {% set review_url = url('reviewers.review', 'unlisted', item.arguments[0].pk) %}
                   {% else %}
-                    {% set review_url = url('reviewers.review', item.arguments[0].slug) %}
+                    {% set review_url = url('reviewers.review', item.arguments[0].pk) %}
                   {% endif %}
                   <a href="{{ review_url }}">
                     {{ item.log.short }}

--- a/src/olympia/reviewers/tests/test_decorators.py
+++ b/src/olympia/reviewers/tests/test_decorators.py
@@ -5,7 +5,6 @@ from urllib.parse import quote
 
 from olympia.amo.tests import TestCase, addon_factory
 from olympia.reviewers import decorators as dec
-from olympia.reviewers.views import reviewer_addon_view_factory
 
 
 class TestReviewerAddonView(TestCase):
@@ -69,31 +68,3 @@ class TestReviewerAddonView(TestCase):
         assert res == mock.sentinel.OK
         request, addon_ = self.func.call_args[0]
         assert addon_ == addon
-
-
-class TestReviewerAddonViewWithUnlisted(TestReviewerAddonView):
-    def setUp(self):
-        super().setUp()
-        self.view = reviewer_addon_view_factory(self.func)
-
-    @mock.patch(
-        'olympia.access.acl.check_unlisted_addons_viewer_or_reviewer', lambda r: False
-    )
-    @mock.patch(
-        'olympia.access.acl.check_addon_ownership', lambda *args, **kwargs: False
-    )
-    def test_unlisted_addon(self):
-        """Return a 404 for non authorized access."""
-        self.make_addon_unlisted(self.addon)
-        with self.assertRaises(http.Http404):
-            self.view(self.request, str(self.addon.id))
-
-    @mock.patch(
-        'olympia.access.acl.check_unlisted_addons_viewer_or_reviewer', lambda r: True
-    )
-    def test_unlisted_addon_unlisted_reviewer(self):
-        """Unlisted addon reviewers have access."""
-        self.make_addon_unlisted(self.addon)
-        assert self.view(self.request, str(self.addon.id)) == mock.sentinel.OK
-        request, addon = self.func.call_args[0]
-        assert addon == self.addon

--- a/src/olympia/reviewers/tests/test_decorators.py
+++ b/src/olympia/reviewers/tests/test_decorators.py
@@ -1,0 +1,99 @@
+from django import http
+
+from unittest import mock
+from urllib.parse import quote
+
+from olympia.amo.tests import TestCase, addon_factory
+from olympia.reviewers import decorators as dec
+from olympia.reviewers.views import reviewer_addon_view_factory
+
+
+class TestReviewerAddonView(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.addon = addon_factory()
+        self.func = mock.Mock()
+        self.func.return_value = mock.sentinel.OK
+        self.func.__name__ = 'mock_function'
+        self.view = dec.reviewer_addon_view(self.func)
+        self.request = mock.Mock()
+        self.slug_path = 'http://testserver/addon/%s/reviews' % quote(
+            self.addon.slug.encode('utf-8')
+        )
+        self.request.path = self.id_path = (
+            'http://testserver/addon/%s/reviews' % self.addon.id
+        )
+        self.request.GET = {}
+
+    def test_200_by_id(self):
+        res = self.view(self.request, str(self.addon.id))
+        assert res == mock.sentinel.OK
+
+    def test_301_by_slug(self):
+        self.request.path = self.slug_path
+        res = self.view(self.request, self.addon.slug)
+        self.assert3xx(res, self.id_path, 301)
+
+    def test_301_by_guid(self):
+        self.request.path = f'http://testserver/addon/{quote(self.addon.guid)}/reviews'
+        res = self.view(self.request, self.addon.guid)
+        self.assert3xx(res, self.id_path, 301)
+
+    def test_slug_replace_no_conflict(self):
+        slug = quote(self.addon.slug.encode('utf8'))
+        self.request.path = f'http://testserver/addon/{slug}/reviews/{slug}/path'
+
+        res = self.view(self.request, self.addon.slug)
+        redirection = f'http://testserver/addon/{self.addon.id}/reviews/{slug}/path'
+
+        self.assert3xx(res, redirection, 301)
+
+    def test_301_with_querystring(self):
+        self.request.GET = mock.Mock()
+        self.request.GET.urlencode.return_value = 'q=1'
+        res = self.view(self.request, self.addon.slug)
+        self.assert3xx(res, self.id_path + '?q=1', 301)
+
+    def test_404_by_id(self):
+        with self.assertRaises(http.Http404):
+            self.view(self.request, str(self.addon.id * 2))
+
+    def test_404_by_slug(self):
+        with self.assertRaises(http.Http404):
+            self.view(self.request, self.addon.slug + 'xx')
+
+    def test_slug_isdigit(self):
+        addon = addon_factory()
+        addon.update(slug=str(addon.id))
+        res = self.view(self.request, addon.slug)
+        assert res == mock.sentinel.OK
+        request, addon_ = self.func.call_args[0]
+        assert addon_ == addon
+
+
+class TestReviewerAddonViewWithUnlisted(TestReviewerAddonView):
+    def setUp(self):
+        super().setUp()
+        self.view = reviewer_addon_view_factory(self.func)
+
+    @mock.patch(
+        'olympia.access.acl.check_unlisted_addons_viewer_or_reviewer', lambda r: False
+    )
+    @mock.patch(
+        'olympia.access.acl.check_addon_ownership', lambda *args, **kwargs: False
+    )
+    def test_unlisted_addon(self):
+        """Return a 404 for non authorized access."""
+        self.make_addon_unlisted(self.addon)
+        with self.assertRaises(http.Http404):
+            self.view(self.request, str(self.addon.id))
+
+    @mock.patch(
+        'olympia.access.acl.check_unlisted_addons_viewer_or_reviewer', lambda r: True
+    )
+    def test_unlisted_addon_unlisted_reviewer(self):
+        """Unlisted addon reviewers have access."""
+        self.make_addon_unlisted(self.addon)
+        assert self.view(self.request, str(self.addon.id)) == mock.sentinel.OK
+        request, addon = self.func.call_args[0]
+        assert addon == self.addon

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -74,14 +74,12 @@ class TestViewExtensionQueueTable(TestCase):
         page.start_index = Mock()
         page.start_index.return_value = 1
         row.addon_name = 'フォクすけといっしょ'
-        row.addon_slug = 'test'
+        row.id = 12345
         row.latest_version = '0.12'
         self.table.set_page(page)
         a = pq(self.table.render_addon_name(row))
 
-        assert a.attr('href') == (
-            reverse('reviewers.review', args=[str(row.addon_slug)])
-        )
+        assert a.attr('href') == (reverse('reviewers.review', args=[str(row.id)]))
         assert a.text() == 'フォクすけといっしょ 0.12'
 
     def test_addon_type_id(self):
@@ -141,12 +139,12 @@ class TestUnlistedViewAllListTable(TestCase):
         page.start_index = Mock()
         page.start_index.return_value = 1
         row.addon_name = 'フォクすけといっしょ'
-        row.addon_slug = 'test'
+        row.id = 12345
         self.table.set_page(page)
         a = pq(self.table.render_addon_name(row))
 
         assert a.attr('href') == reverse(
-            'reviewers.review', args=['unlisted', str(row.addon_slug)]
+            'reviewers.review', args=['unlisted', str(row.id)]
         )
         assert a.text() == 'フォクすけといっしょ'
 

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -3382,7 +3382,7 @@ class TestReview(ReviewBase):
         self.addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
         self.addon.update_version()
         self.url = reverse('reviewers.review', args=('unlisted', self.addon.pk))
-        assert self.client.head(self.url).status_code == 404
+        assert self.client.head(self.url).status_code == 403
 
         # Adding a listed version makes it pass @reviewer_addon_view_factory
         # decorator that only depends on the addon being purely unlisted or
@@ -3402,7 +3402,7 @@ class TestReview(ReviewBase):
         self.addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
         self.addon.update_version()
         self.url = reverse('reviewers.review', args=('unlisted', self.addon.pk))
-        assert self.client.head(self.url).status_code == 404
+        assert self.client.head(self.url).status_code == 403
 
         # Adding a listed version makes it pass @reviewer_addon_view_factory
         # decorator that only depends on the addon being purely unlisted or
@@ -4694,7 +4694,7 @@ class TestReview(ReviewBase):
         # Now they need unlisted permission cause we can't find a listed
         # version, even deleted.
         self.version.delete(hard=True)
-        assert self.client.get(self.url).status_code == 404
+        assert self.client.get(self.url).status_code == 403
 
         # Unlisted viewers can view but not submit reviews.
         self.grant_permission(self.reviewer, 'ReviewerTools:ViewUnlisted')
@@ -6745,10 +6745,8 @@ class TestWhiteboard(ReviewBase):
                 'whiteboard-public': public_whiteboard_info,
             },
         )
-        # Not an unlisted reviewer, we'll get a 404 from the
-        # @reviewer_addon_view_factory decorator as it uses addon_view
-        # under the hood.
-        assert response.status_code == 404  # Not an unlisted reviewer.
+        # Not an unlisted reviewer, raise PermissionDenied
+        assert response.status_code == 403  # Not an unlisted reviewer.
 
         # Now the addon is not purely unlisted, but because we've requested the
         # unlisted channel we'll still get an error - this time it's a 403 from
@@ -6937,7 +6935,7 @@ class TestPolicyView(ReviewerTest):
         self.addon.save()
         assert bool(self.addon.eula)
         response = self.client.get(self.eula_url + '?channel=unlisted')
-        assert response.status_code == 404
+        assert response.status_code == 403
 
         user = UserProfile.objects.get(email='regular@mozilla.com')
         self.grant_permission(user, 'Addons:ReviewUnlisted')
@@ -6975,7 +6973,7 @@ class TestPolicyView(ReviewerTest):
         self.addon.save()
         assert bool(self.addon.privacy_policy)
         response = self.client.get(self.privacy_url + '?channel=unlisted')
-        assert response.status_code == 404
+        assert response.status_code == 403
 
         user = UserProfile.objects.get(email='regular@mozilla.com')
         self.grant_permission(user, 'Addons:ReviewUnlisted')

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -468,7 +468,7 @@ class TestReviewLog(ReviewerTest):
         response = self.client.get(self.url)
         assert response.status_code == 200
         link = pq(response.content)('#log-listing tbody td a').eq(1)[0]
-        assert link.attrib['href'] == '/en-US/reviewers/review-content/a3615'
+        assert link.attrib['href'] == '/en-US/reviewers/review-content/3615'
         assert link.text_content().strip() == 'Content approved'
 
     def test_content_rejection(self):
@@ -476,7 +476,7 @@ class TestReviewLog(ReviewerTest):
         response = self.client.get(self.url)
         assert response.status_code == 200
         link = pq(response.content)('#log-listing tbody td a').eq(1)[0]
-        assert link.attrib['href'] == '/en-US/reviewers/review-content/a3615'
+        assert link.attrib['href'] == '/en-US/reviewers/review-content/3615'
         assert link.text_content().strip() == 'Content rejected'
 
     @freeze_time('2017-08-03')
@@ -497,7 +497,7 @@ class TestReviewLog(ReviewerTest):
 
         response = self.client.get(self.url)
         assert response.status_code == 200
-        url = reverse('reviewers.review', args=[addon.slug])
+        url = reverse('reviewers.review', args=[addon.pk])
 
         link = pq(response.content)('#log-listing tbody tr[data-addonid] a').eq(1)
         assert link.attr('href') == url
@@ -515,7 +515,7 @@ class TestReviewLog(ReviewerTest):
         entry.update(created=datetime.now() + timedelta(days=1))
 
         response = self.client.get(self.url)
-        url = reverse('reviewers.review', args=['unlisted', addon.slug])
+        url = reverse('reviewers.review', args=['unlisted', addon.pk])
         assert pq(response.content)('#log-listing tr td a').eq(1).attr('href') == url
 
     def test_review_url_force_disable(self):
@@ -530,7 +530,7 @@ class TestReviewLog(ReviewerTest):
 
         response = self.client.get(self.url)
         assert response.status_code == 200
-        url = reverse('reviewers.review', args=[addon.slug])
+        url = reverse('reviewers.review', args=[addon.pk])
 
         link = pq(response.content)('#log-listing tbody tr[data-addonid] a').eq(1)
         assert link.attr('href') == url
@@ -1244,7 +1244,7 @@ class QueueTest(ReviewerTest):
                 latest_version = self.get_addon_latest_version(addon)
                 assert latest_version
                 name = f'{str(addon.name)} {latest_version.version}'
-            url = reverse('reviewers.review', args=channel + [addon.slug])
+            url = reverse('reviewers.review', args=channel + [addon.pk])
             expected.append((name, url))
         doc = pq(response.content)
         links = doc('#addon-queue tr.addon-row td a:not(.app-icon)')
@@ -1603,11 +1603,11 @@ class TestExtensionQueue(QueueTest):
         expected = [
             (
                 'Nominated One 0.1',
-                reverse('reviewers.review', args=[version1.addon.slug]),
+                reverse('reviewers.review', args=[version1.addon.pk]),
             ),
             (
                 'Nominated Two 0.2',
-                reverse('reviewers.review', args=[version2.addon.slug]),
+                reverse('reviewers.review', args=[version2.addon.pk]),
             ),
         ]
         doc = pq(response.content)
@@ -1838,11 +1838,11 @@ class TestThemeNominatedQueue(QueueTest):
         expected = [
             (
                 'Nominated One 0.1',
-                reverse('reviewers.review', args=[version1.addon.slug]),
+                reverse('reviewers.review', args=[version1.addon.pk]),
             ),
             (
                 'Nominated Two 0.2',
-                reverse('reviewers.review', args=[version2.addon.slug]),
+                reverse('reviewers.review', args=[version2.addon.pk]),
             ),
         ]
         doc = pq(response.content)
@@ -1910,11 +1910,11 @@ class TestRecommendedQueue(QueueTest):
         expected = [
             (
                 'Nominated One 0.1',
-                reverse('reviewers.review', args=[version1.addon.slug]),
+                reverse('reviewers.review', args=[version1.addon.pk]),
             ),
             (
                 'Nominated Two 0.2',
-                reverse('reviewers.review', args=[version2.addon.slug]),
+                reverse('reviewers.review', args=[version2.addon.pk]),
             ),
         ]
         doc = pq(response.content)
@@ -2676,7 +2676,7 @@ class TestScannersReviewQueue(QueueTest):
         expected.append(
             (
                 'Listed versions needing human review (2)',
-                reverse('reviewers.review', args=[addon.slug]),
+                reverse('reviewers.review', args=[addon.pk]),
             )
         )
         # addon2
@@ -2684,13 +2684,13 @@ class TestScannersReviewQueue(QueueTest):
         expected.append(
             (
                 'Listed versions needing human review (1)',
-                reverse('reviewers.review', args=[addon.slug]),
+                reverse('reviewers.review', args=[addon.pk]),
             )
         )
         expected.append(
             (
                 'Unlisted versions needing human review (1)',
-                reverse('reviewers.review', args=['unlisted', addon.slug]),
+                reverse('reviewers.review', args=['unlisted', addon.pk]),
             )
         )
         # addon3
@@ -2698,7 +2698,7 @@ class TestScannersReviewQueue(QueueTest):
         expected.append(
             (
                 'Unlisted versions needing human review (1)',
-                reverse('reviewers.review', args=['unlisted', addon.slug]),
+                reverse('reviewers.review', args=['unlisted', addon.pk]),
             )
         )
 
@@ -3324,7 +3324,7 @@ class ReviewBase(QueueTest):
         self.file = self.version.files.get()
         self.reviewer = UserProfile.objects.get(username='reviewer')
         self.reviewer.update(display_name='A Reviêwer')
-        self.url = reverse('reviewers.review', args=[self.addon.slug])
+        self.url = reverse('reviewers.review', args=[self.addon.pk])
 
         AddonUser.objects.create(addon=self.addon, user_id=999)
 
@@ -3362,7 +3362,7 @@ class TestReview(ReviewBase):
             file_kw={'status': amo.STATUS_AWAITING_REVIEW},
         )
         self.addon.update(status=amo.STATUS_NOMINATED, slug='awaiting')
-        self.url = reverse('reviewers.review', args=('unlisted', self.addon.slug))
+        self.url = reverse('reviewers.review', args=('unlisted', self.addon.pk))
         self.grant_permission(self.reviewer, 'Addons:ReviewUnlisted')
         assert self.client.get(self.url).status_code == 200
 
@@ -3374,14 +3374,14 @@ class TestReview(ReviewBase):
             file_kw={'status': amo.STATUS_AWAITING_REVIEW},
         )
         self.addon.update(status=amo.STATUS_NOMINATED, slug='awaiting')
-        self.url = reverse('reviewers.review', args=('unlisted', self.addon.slug))
+        self.url = reverse('reviewers.review', args=('unlisted', self.addon.pk))
         self.grant_permission(self.reviewer, 'ReviewerTools:ViewUnlisted')
         assert self.client.get(self.url).status_code == 200
 
     def test_needs_unlisted_reviewer_for_only_unlisted(self):
         self.addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
         self.addon.update_version()
-        self.url = reverse('reviewers.review', args=('unlisted', self.addon.slug))
+        self.url = reverse('reviewers.review', args=('unlisted', self.addon.pk))
         assert self.client.head(self.url).status_code == 404
 
         # Adding a listed version makes it pass @reviewer_addon_view_factory
@@ -3401,7 +3401,7 @@ class TestReview(ReviewBase):
     def test_needs_unlisted_viewer_for_only_unlisted(self):
         self.addon.versions.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
         self.addon.update_version()
-        self.url = reverse('reviewers.review', args=('unlisted', self.addon.slug))
+        self.url = reverse('reviewers.review', args=('unlisted', self.addon.pk))
         assert self.client.head(self.url).status_code == 404
 
         # Adding a listed version makes it pass @reviewer_addon_view_factory
@@ -3532,7 +3532,7 @@ class TestReview(ReviewBase):
         doc = pq(response.content)
         assert (
             doc('#whiteboard_form').attr('action')
-            == '/en-US/reviewers/whiteboard/listed/public'
+            == f'/en-US/reviewers/whiteboard/listed/{self.addon.pk}'
         )
         assert doc('#id_whiteboard-public')
         assert doc('#id_whiteboard-private')
@@ -3542,25 +3542,25 @@ class TestReview(ReviewBase):
         AutoApprovalSummary.objects.create(
             version=self.addon.current_version, verdict=amo.AUTO_APPROVED
         )
-        self.url = reverse('reviewers.review', args=['content', self.addon.slug])
+        self.url = reverse('reviewers.review', args=['content', self.addon.pk])
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
         assert (
             doc('#whiteboard_form').attr('action')
-            == '/en-US/reviewers/whiteboard/content/public'
+            == f'/en-US/reviewers/whiteboard/content/{self.addon.pk}'
         )
 
         # Unlisted review.
         self.grant_permission(self.reviewer, 'Addons:ReviewUnlisted')
         version_factory(addon=self.addon, channel=amo.RELEASE_CHANNEL_UNLISTED)
-        self.url = reverse('reviewers.review', args=['unlisted', self.addon.slug])
+        self.url = reverse('reviewers.review', args=['unlisted', self.addon.pk])
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
         assert (
             doc('#whiteboard_form').attr('action')
-            == '/en-US/reviewers/whiteboard/unlisted/public'
+            == f'/en-US/reviewers/whiteboard/unlisted/{self.addon.pk}'
         )
 
         # Listed review, but deleted.
@@ -3571,7 +3571,7 @@ class TestReview(ReviewBase):
         doc = pq(response.content)
         assert (
             doc('#whiteboard_form').attr('action')
-            == '/en-US/reviewers/whiteboard/listed/%d' % self.addon.pk
+            == f'/en-US/reviewers/whiteboard/listed/{self.addon.pk}'
         )
 
     def test_whiteboard_for_static_themes(self):
@@ -3582,7 +3582,7 @@ class TestReview(ReviewBase):
         doc = pq(response.content)
         assert (
             doc('#whiteboard_form').attr('action')
-            == '/en-US/reviewers/whiteboard/listed/public'
+            == f'/en-US/reviewers/whiteboard/listed/{self.addon.pk}'
         )
         assert doc('#id_whiteboard-public')
         assert not doc('#id_whiteboard-private')
@@ -3822,7 +3822,7 @@ class TestReview(ReviewBase):
             channel=amo.RELEASE_CHANNEL_LISTED,
             file_kw={'status': amo.STATUS_APPROVED},
         )
-        self.url = reverse('reviewers.review', args=['unlisted', self.addon.slug])
+        self.url = reverse('reviewers.review', args=['unlisted', self.addon.pk])
         self.grant_permission(self.reviewer, 'Addons:ReviewUnlisted')
         self.test_item_history(channel=amo.RELEASE_CHANNEL_UNLISTED)
 
@@ -3836,7 +3836,7 @@ class TestReview(ReviewBase):
             channel=amo.RELEASE_CHANNEL_LISTED,
             file_kw={'status': amo.STATUS_APPROVED},
         )
-        self.url = reverse('reviewers.review', args=['unlisted', self.addon.slug])
+        self.url = reverse('reviewers.review', args=['unlisted', self.addon.pk])
         self.grant_permission(self.reviewer, 'ReviewerTools:ViewUnlisted')
         self.test_item_history(channel=amo.RELEASE_CHANNEL_UNLISTED)
 
@@ -3850,7 +3850,7 @@ class TestReview(ReviewBase):
         )
 
         assert self.addon.versions.count() == 1
-        url = reverse('reviewers.review', args=[self.addon.slug])
+        url = reverse('reviewers.review', args=[self.addon.pk])
 
         response = self.client.get(url)
         assert response.status_code == 200
@@ -3870,7 +3870,7 @@ class TestReview(ReviewBase):
             weight_info={'fôo': 42, 'bär': 84, 'oof': 105, 'rab': 95},
         )
         self.grant_permission(self.reviewer, 'Addons:Review')
-        url = reverse('reviewers.review', args=[self.addon.slug])
+        url = reverse('reviewers.review', args=[self.addon.pk])
         response = self.client.get(url)
         assert response.status_code == 200
         doc = pq(response.content)
@@ -3880,7 +3880,7 @@ class TestReview(ReviewBase):
 
     def test_maliciousness_score(self):
         self.grant_permission(self.reviewer, 'Addons:Review')
-        url = reverse('reviewers.review', args=[self.addon.slug])
+        url = reverse('reviewers.review', args=[self.addon.pk])
         # Without a score.
         response = self.client.get(url)
         assert response.status_code == 200
@@ -4108,7 +4108,7 @@ class TestReview(ReviewBase):
         )
         self.addon.update(status=amo.STATUS_NOMINATED)
         self.login_as_admin()
-        self.url = reverse('reviewers.review', args=('unlisted', self.addon.slug))
+        self.url = reverse('reviewers.review', args=('unlisted', self.addon.pk))
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
@@ -4536,7 +4536,7 @@ class TestReview(ReviewBase):
         AddonReviewerFlags.objects.create(
             addon=self.addon, auto_approval_disabled_until_next_approval_unlisted=True
         )
-        unlisted_url = reverse('reviewers.review', args=['unlisted', self.addon.slug])
+        unlisted_url = reverse('reviewers.review', args=['unlisted', self.addon.pk])
         response = self.client.get(unlisted_url)
         assert response.status_code == 200
         doc = pq(response.content)
@@ -4582,7 +4582,7 @@ class TestReview(ReviewBase):
 
         # They both should be absent on the unlisted review page, since those
         # are for listed only.
-        unlisted_url = reverse('reviewers.review', args=['unlisted', self.addon.slug])
+        unlisted_url = reverse('reviewers.review', args=['unlisted', self.addon.pk])
         response = self.client.get(unlisted_url)
         assert response.status_code == 200
         doc = pq(response.content)
@@ -4758,16 +4758,16 @@ class TestReview(ReviewBase):
         response = self.client.get(self.url)
         assert response.status_code == 200
         self.assertContains(response, 'View End-User License Agreement')
-        eula_url = reverse('reviewers.eula', args=(self.addon.slug,))
+        eula_url = reverse('reviewers.eula', args=(self.addon.pk,))
         self.assertContains(response, eula_url + '"')
 
         # The url should pass on the channel param so the backlink works
         self.make_addon_unlisted(self.addon)
         self.login_as_admin()
-        unlisted_url = reverse('reviewers.review', args=['unlisted', self.addon.slug])
+        unlisted_url = reverse('reviewers.review', args=['unlisted', self.addon.pk])
         response = self.client.get(unlisted_url)
         assert response.status_code == 200
-        eula_url = reverse('reviewers.eula', args=(self.addon.slug,))
+        eula_url = reverse('reviewers.eula', args=(self.addon.pk,))
         self.assertContains(response, eula_url + '?channel=unlisted"')
 
     def test_privacy_policy_displayed(self):
@@ -4781,15 +4781,15 @@ class TestReview(ReviewBase):
         response = self.client.get(self.url)
         assert response.status_code == 200
         self.assertContains(response, 'View Privacy Policy')
-        privacy_url = reverse('reviewers.privacy', args=(self.addon.slug,))
+        privacy_url = reverse('reviewers.privacy', args=(self.addon.pk,))
         self.assertContains(response, privacy_url + '"')
 
         self.make_addon_unlisted(self.addon)
         self.login_as_admin()
-        unlisted_url = reverse('reviewers.review', args=['unlisted', self.addon.slug])
+        unlisted_url = reverse('reviewers.review', args=['unlisted', self.addon.pk])
         response = self.client.get(unlisted_url)
         assert response.status_code == 200
-        privacy_url = reverse('reviewers.privacy', args=(self.addon.slug,))
+        privacy_url = reverse('reviewers.privacy', args=(self.addon.pk,))
         self.assertContains(response, privacy_url + '?channel=unlisted"')
 
     def test_requires_payment_indicator(self):
@@ -5200,7 +5200,7 @@ class TestReview(ReviewBase):
         )
         GroupUser.objects.filter(user=self.reviewer).all().delete()
         self.grant_permission(self.reviewer, 'Addons:ContentReview')
-        self.url = reverse('reviewers.review', args=['content', self.addon.slug])
+        self.url = reverse('reviewers.review', args=['content', self.addon.pk])
         response = self.client.post(self.url, self.get_dict(action='approve_content'))
         assert response.status_code == 302
         summary.reload()
@@ -5219,7 +5219,7 @@ class TestReview(ReviewBase):
 
     def test_approve_content_content_review(self):
         GroupUser.objects.filter(user=self.reviewer).all().delete()
-        self.url = reverse('reviewers.review', args=['content', self.addon.slug])
+        self.url = reverse('reviewers.review', args=['content', self.addon.pk])
         summary = AutoApprovalSummary.objects.create(
             version=self.addon.current_version, verdict=amo.AUTO_APPROVED
         )
@@ -5248,7 +5248,7 @@ class TestReview(ReviewBase):
 
     def test_cant_contentreview_if_admin_content_review_flag_is_set(self):
         GroupUser.objects.filter(user=self.reviewer).all().delete()
-        self.url = reverse('reviewers.review', args=['content', self.addon.slug])
+        self.url = reverse('reviewers.review', args=['content', self.addon.pk])
         AutoApprovalSummary.objects.create(
             version=self.addon.current_version, verdict=amo.AUTO_APPROVED
         )
@@ -5378,7 +5378,7 @@ class TestReview(ReviewBase):
 
     def test_admin_can_contentreview_if_admin_content_review_flag_is_set(self):
         GroupUser.objects.filter(user=self.reviewer).all().delete()
-        self.url = reverse('reviewers.review', args=['content', self.addon.slug])
+        self.url = reverse('reviewers.review', args=['content', self.addon.pk])
         summary = AutoApprovalSummary.objects.create(
             version=self.addon.current_version, verdict=amo.AUTO_APPROVED
         )
@@ -5533,7 +5533,7 @@ class TestReview(ReviewBase):
             self.assertCloseToNow(version.pending_rejection, now=in_the_future)
 
     def test_block_multiple_versions(self):
-        self.url = reverse('reviewers.review', args=('unlisted', self.addon.slug))
+        self.url = reverse('reviewers.review', args=('unlisted', self.addon.pk))
         old_version = self.version
         old_version.update(needs_human_review=True)
         self.version = version_factory(addon=self.addon, version='3.0')
@@ -5663,11 +5663,9 @@ class TestReview(ReviewBase):
         assert not validate.called
 
     def test_review_is_review_listed(self):
-        review_page = self.client.get(
-            reverse('reviewers.review', args=[self.addon.slug])
-        )
+        review_page = self.client.get(reverse('reviewers.review', args=[self.addon.pk]))
         listed_review_page = self.client.get(
-            reverse('reviewers.review', args=['listed', self.addon.slug])
+            reverse('reviewers.review', args=['listed', self.addon.pk])
         )
         assert (
             pq(review_page.content)('#versions-history').text()
@@ -5956,7 +5954,7 @@ class TestReview(ReviewBase):
             verdict=amo.AUTO_APPROVED, version=self.version
         )
         self.grant_permission(self.reviewer, 'Addons:ReviewUnlisted')
-        unlisted_url = reverse('reviewers.review', args=['unlisted', self.addon.slug])
+        unlisted_url = reverse('reviewers.review', args=['unlisted', self.addon.pk])
         response = self.client.get(unlisted_url)
 
         assert response.status_code == 200
@@ -6003,7 +6001,7 @@ class TestReview(ReviewBase):
         self.grant_permission(unlisted_viewer, 'ReviewerTools:ViewUnlisted')
         self.client.logout()
         self.client.login(email='unlisted_viewer@mozilla.com')
-        unlisted_url = reverse('reviewers.review', args=['unlisted', self.addon.slug])
+        unlisted_url = reverse('reviewers.review', args=['unlisted', self.addon.pk])
         response = self.client.get(unlisted_url)
 
         assert response.status_code == 200
@@ -6106,7 +6104,7 @@ class TestReview(ReviewBase):
         )
         version_factory(addon=self.addon, file_kw={'status': amo.STATUS_DISABLED})
         self.grant_permission(self.reviewer, 'Addons:ContentReview')
-        self.url = reverse('reviewers.review', args=['content', self.addon.slug])
+        self.url = reverse('reviewers.review', args=['content', self.addon.pk])
         response = self.client.get(self.url)
         assert response.status_code == 200
         expected_actions = [
@@ -6172,7 +6170,7 @@ class TestReview(ReviewBase):
         self.make_addon_unlisted(self.addon)
         self.login_as_admin()
         response = self.client.get(
-            reverse('reviewers.review', args=['unlisted', self.addon.slug])
+            reverse('reviewers.review', args=['unlisted', self.addon.pk])
         )
         assert response.status_code == 200
         expected = [
@@ -6392,7 +6390,7 @@ class TestReview(ReviewBase):
         )
 
     def test_redirect_after_review_unlisted(self):
-        self.url = reverse('reviewers.review', args=('unlisted', self.addon.slug))
+        self.url = reverse('reviewers.review', args=('unlisted', self.addon.pk))
         self.version = version_factory(addon=self.addon, version='3.0')
         self.make_addon_unlisted(self.addon)
         self.grant_permission(self.reviewer, 'Addons:ReviewUnlisted')
@@ -6413,7 +6411,7 @@ class TestAbuseReportsView(ReviewerTest):
     def setUp(self):
         self.addon_developer = user_factory()
         self.addon = addon_factory(name='Flôp', users=[self.addon_developer])
-        self.url = reverse('reviewers.abuse_reports', args=[self.addon.slug])
+        self.url = reverse('reviewers.abuse_reports', args=[self.addon.pk])
         self.login_as_reviewer()
 
     def test_abuse_reports(self):
@@ -6644,14 +6642,10 @@ class TestStatusFile(ReviewBase):
 
 
 class TestWhiteboard(ReviewBase):
-    @property
-    def addon_param(self):
-        return self.addon.pk if self.addon.is_deleted else self.addon.slug
-
     def test_whiteboard_addition(self):
         public_whiteboard_info = 'Public whiteboard info.'
         private_whiteboard_info = 'Private whiteboard info.'
-        url = reverse('reviewers.whiteboard', args=['listed', self.addon_param])
+        url = reverse('reviewers.whiteboard', args=['listed', self.addon.pk])
         self.client.login(email='regular@mozilla.com')  # No permissions.
         response = self.client.post(
             url,
@@ -6671,7 +6665,7 @@ class TestWhiteboard(ReviewBase):
             },
         )
         self.assert3xx(
-            response, reverse('reviewers.review', args=('listed', self.addon_param))
+            response, reverse('reviewers.review', args=('listed', self.addon.pk))
         )
 
         whiteboard = self.addon.whiteboard.reload()
@@ -6681,7 +6675,7 @@ class TestWhiteboard(ReviewBase):
     def test_whiteboard_addition_content_review(self):
         public_whiteboard_info = 'Public whiteboard info for content.'
         private_whiteboard_info = 'Private whiteboard info for content.'
-        url = reverse('reviewers.whiteboard', args=['content', self.addon_param])
+        url = reverse('reviewers.whiteboard', args=['content', self.addon.pk])
         self.client.login(email='regular@mozilla.com')  # No permissions.
         response = self.client.post(
             url,
@@ -6702,7 +6696,7 @@ class TestWhiteboard(ReviewBase):
             },
         )
         self.assert3xx(
-            response, reverse('reviewers.review', args=('content', self.addon_param))
+            response, reverse('reviewers.review', args=('content', self.addon.pk))
         )
         addon = self.addon.reload()
         assert addon.whiteboard.public == public_whiteboard_info
@@ -6720,7 +6714,7 @@ class TestWhiteboard(ReviewBase):
             },
         )
         self.assert3xx(
-            response, reverse('reviewers.review', args=('content', self.addon_param))
+            response, reverse('reviewers.review', args=('content', self.addon.pk))
         )
 
         whiteboard = self.addon.whiteboard.reload()
@@ -6731,7 +6725,7 @@ class TestWhiteboard(ReviewBase):
         self.make_addon_unlisted(self.addon)
         public_whiteboard_info = 'Public whiteboard info unlisted.'
         private_whiteboard_info = 'Private whiteboard info unlisted.'
-        url = reverse('reviewers.whiteboard', args=['unlisted', self.addon_param])
+        url = reverse('reviewers.whiteboard', args=['unlisted', self.addon.pk])
 
         self.client.login(email='regular@mozilla.com')  # No permissions.
         response = self.client.post(
@@ -6782,19 +6776,19 @@ class TestWhiteboard(ReviewBase):
             },
         )
         self.assert3xx(
-            response, reverse('reviewers.review', args=('unlisted', self.addon_param))
+            response, reverse('reviewers.review', args=('unlisted', self.addon.pk))
         )
         whiteboard = self.addon.whiteboard.reload()
         assert whiteboard.public == public_whiteboard_info
         assert whiteboard.private == private_whiteboard_info
 
     def test_delete_empty(self):
-        url = reverse('reviewers.whiteboard', args=['listed', self.addon_param])
+        url = reverse('reviewers.whiteboard', args=['listed', self.addon.pk])
         response = self.client.post(
             url, {'whiteboard-private': '', 'whiteboard-public': ''}
         )
         self.assert3xx(
-            response, reverse('reviewers.review', args=('listed', self.addon_param))
+            response, reverse('reviewers.review', args=('listed', self.addon.pk))
         )
         assert not Whiteboard.objects.filter(pk=self.addon.pk)
 
@@ -6892,11 +6886,11 @@ class TestLeaderboard(ReviewerTest):
 
 class TestXssOnAddonName(amo.tests.TestXss):
     def test_reviewers_abuse_report_page(self):
-        url = reverse('reviewers.abuse_reports', args=[self.addon.slug])
+        url = reverse('reviewers.abuse_reports', args=[self.addon.pk])
         self.assertNameAndNoXSS(url)
 
     def test_reviewers_review_page(self):
-        url = reverse('reviewers.review', args=[self.addon.slug])
+        url = reverse('reviewers.review', args=[self.addon.pk])
         self.assertNameAndNoXSS(url)
 
 
@@ -6904,14 +6898,14 @@ class TestPolicyView(ReviewerTest):
     def setUp(self):
         super().setUp()
         self.addon = addon_factory()
-        self.eula_url = reverse('reviewers.eula', args=[self.addon.slug])
-        self.privacy_url = reverse('reviewers.privacy', args=[self.addon.slug])
+        self.eula_url = reverse('reviewers.eula', args=[self.addon.pk])
+        self.privacy_url = reverse('reviewers.privacy', args=[self.addon.pk])
         self.login_as_reviewer()
         self.review_url = reverse(
             'reviewers.review',
             args=(
                 'listed',
-                self.addon.slug,
+                self.addon.pk,
             ),
         )
 
@@ -6936,7 +6930,7 @@ class TestPolicyView(ReviewerTest):
             'reviewers.review',
             args=(
                 'unlisted',
-                self.addon.slug,
+                self.addon.pk,
             ),
         )
         self.addon.eula = 'Eulá!'
@@ -6974,7 +6968,7 @@ class TestPolicyView(ReviewerTest):
             'reviewers.review',
             args=(
                 'unlisted',
-                self.addon.slug,
+                self.addon.pk,
             ),
         )
         self.addon.privacy_policy = 'Prívacy Pólicy?'
@@ -9347,14 +9341,14 @@ class TestMadQueue(QueueTest):
         expected = []
         addon = self.expected_addons[0]
         expected.append(
-            ('Listed version', reverse('reviewers.review', args=[addon.slug]))
+            ('Listed version', reverse('reviewers.review', args=[addon.pk]))
         )
         # unlisted
         addon = self.expected_addons[1]
         expected.append(
             (
                 'Unlisted versions (2)',
-                reverse('reviewers.review', args=['unlisted', addon.slug]),
+                reverse('reviewers.review', args=['unlisted', addon.pk]),
             )
         )
         # mixed, only unlisted flagged
@@ -9362,18 +9356,18 @@ class TestMadQueue(QueueTest):
         expected.append(
             (
                 'Unlisted versions (1)',
-                reverse('reviewers.review', args=['unlisted', addon.slug]),
+                reverse('reviewers.review', args=['unlisted', addon.pk]),
             )
         )
         # mixed, both channels flagged
         addon = self.expected_addons[3]
         expected.append(
-            ('Listed version', reverse('reviewers.review', args=[addon.slug]))
+            ('Listed version', reverse('reviewers.review', args=[addon.pk]))
         )
         expected.append(
             (
                 'Unlisted versions (1)',
-                reverse('reviewers.review', args=['unlisted', addon.slug]),
+                reverse('reviewers.review', args=['unlisted', addon.pk]),
             )
         )
 

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -66,7 +66,7 @@ class ReviewerQueueTable(tables.Table, ItemStateTable):
         return cls.Meta.model.objects.all()
 
     def render_addon_name(self, record):
-        url = reverse('reviewers.review', args=[record.addon_slug])
+        url = reverse('reviewers.review', args=[record.id])
         self.increment_item()
         return markupsafe.Markup(
             '<a href="%s">%s <em>%s</em></a>'
@@ -139,7 +139,7 @@ class ViewUnlistedAllListTable(tables.Table, ItemStateTable):
             'reviewers.review',
             args=[
                 'unlisted',
-                record.addon_slug if record.addon_slug is not None else record.id,
+                record.id,
             ],
         )
         self.increment_item()
@@ -233,7 +233,7 @@ class ModernAddonQueueTable(ReviewerQueueTable):
         return super().render_flags(record)
 
     def _get_addon_name_url(self, record):
-        return reverse('reviewers.review', args=[record.slug])
+        return reverse('reviewers.review', args=[record.id])
 
     def render_addon_name(self, record):
         url = self._get_addon_name_url(record)
@@ -285,7 +285,7 @@ class UnlistedPendingManualApprovalQueueTable(tables.Table, ItemStateTable):
         return Addon.objects.get_unlisted_pending_manual_approval_queue()
 
     def _get_addon_name_url(self, record):
-        return reverse('reviewers.review', args=['unlisted', record.slug])
+        return reverse('reviewers.review', args=['unlisted', record.id])
 
     def render_addon_name(self, record):
         url = self._get_addon_name_url(record)
@@ -361,7 +361,7 @@ class ContentReviewTable(AutoApprovedTable):
         return naturaltime(value) if value else ''
 
     def _get_addon_name_url(self, record):
-        return reverse('reviewers.review', args=['content', record.slug])
+        return reverse('reviewers.review', args=['content', record.id])
 
 
 class ScannersReviewTable(AutoApprovedTable):
@@ -391,7 +391,7 @@ class ScannersReviewTable(AutoApprovedTable):
         rval = [markupsafe.escape(record.name)]
 
         if record.listed_versions_that_need_human_review:
-            url = reverse('reviewers.review', args=[record.slug])
+            url = reverse('reviewers.review', args=[record.id])
             rval.append(
                 '<a href="%s">%s</a>'
                 % (
@@ -403,7 +403,7 @@ class ScannersReviewTable(AutoApprovedTable):
             )
 
         if record.unlisted_versions_that_need_human_review:
-            url = reverse('reviewers.review', args=['unlisted', record.slug])
+            url = reverse('reviewers.review', args=['unlisted', record.id])
             rval.append(
                 '<a href="%s">%s</a>'
                 % (

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -43,7 +43,7 @@ from olympia.abuse.models import AbuseReport
 from olympia.access import acl
 from olympia.accounts.views import API_TOKEN_COOKIE
 from olympia.activity.models import ActivityLog, CommentLog, DraftComment
-from olympia.addons.decorators import addon_view, owner_or_unlisted_viewer_or_reviewer
+from olympia.addons.decorators import owner_or_unlisted_viewer_or_reviewer
 from olympia.addons.models import (
     Addon,
     AddonApprovalsCounter,
@@ -128,12 +128,15 @@ from .decorators import (
     any_reviewer_required,
     permission_or_tools_listed_view_required,
     permission_or_tools_unlisted_view_required,
+    reviewer_addon_view,
 )
 
 
 def reviewer_addon_view_factory(f):
     decorator = functools.partial(
-        addon_view, qs=Addon.unfiltered.all, include_deleted_when_checking_versions=True
+        reviewer_addon_view,
+        qs=Addon.unfiltered.all,
+        include_deleted_when_checking_versions=True,
     )
     return decorator(f)
 
@@ -725,7 +728,7 @@ def determine_channel(channel_as_text):
 def review(request, addon, channel=None):
     whiteboard_url = reverse(
         'reviewers.whiteboard',
-        args=(channel or 'listed', addon.slug if addon.slug else addon.pk),
+        args=(channel or 'listed', addon.pk),
     )
     channel, content_review = determine_channel(channel)
 
@@ -1219,9 +1222,7 @@ def whiteboard(request, addon, channel):
         else:
             whiteboard.delete()
 
-        return redirect(
-            'reviewers.review', channel_as_text, addon.slug if addon.slug else addon.pk
-        )
+        return redirect('reviewers.review', channel_as_text, addon.pk)
     raise PermissionDenied
 
 
@@ -1255,7 +1256,7 @@ def policy_viewer(request, addon, eula_or_privacy, page_title, long_title):
 
     review_url = reverse(
         'reviewers.review',
-        args=(channel_text or 'listed', addon.slug if addon.slug else addon.pk),
+        args=(channel_text or 'listed', addon.pk),
     )
     return render(
         request,

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -1,4 +1,3 @@
-import functools
 import json
 import time
 


### PR DESCRIPTION
Fix #17644.