### PR TITLE
Remove references to deprecated Jinja extensions that are now built-in

### DIFF
--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -340,10 +340,8 @@ TEMPLATES = [
                 'olympia.amo.context_processors.static_url',
             ),
             'extensions': (
-                'jinja2.ext.autoescape',
                 'jinja2.ext.do',
                 'jinja2.ext.loopcontrols',
-                'jinja2.ext.with_',
                 'django_jinja.builtins.extensions.CsrfExtension',
                 'django_jinja.builtins.extensions.DjangoFiltersExtension',
                 'django_jinja.builtins.extensions.StaticFilesExtension',


### PR DESCRIPTION
Removed unnecessary references 

Fixes #17667 

