### PR TITLE
Allow users with Ratings:BypassThrottling permission to bypass ratings API throttling

### DIFF
--- a/src/olympia/constants/permissions.py
+++ b/src/olympia/constants/permissions.py
@@ -62,6 +62,9 @@ USERS_EDIT = AclPermission('Users', 'Edit')
 # Can moderate add-on ratings submitted by users.
 RATINGS_MODERATE = AclPermission('Ratings', 'Moderate')
 
+# Can bypass ratings throttling
+RATINGS_BYPASS_THROTTLING = AclPermission('Ratings', 'BypassThrottling')
+
 # Can access advanced reviewer features meant for admins, such as disabling an
 # add-on or clearing needs admin review flags.
 REVIEWS_ADMIN = AclPermission('Reviews', 'Admin')

--- a/src/olympia/ratings/tests/test_views.py
+++ b/src/olympia/ratings/tests/test_views.py
@@ -1510,7 +1510,9 @@ class TestRatingViewSetEdit(TestCase):
         with freeze_time('2021-08-09') as frozen_time:
             for x in range(1, 6):
                 response = self.client.patch(
-                    self.url, {'score': x, 'body': f'Blâh {x}'}
+                    self.url,
+                    {'score': x, 'body': f'Blâh {x}'},
+                    REMOTE_ADDR='127.0.0.42',
                 )
                 assert response.status_code == 200
                 self.rating.reload()
@@ -1518,7 +1520,11 @@ class TestRatingViewSetEdit(TestCase):
                 assert self.rating.rating == x
 
             # Over the limit now...
-            response = self.client.patch(self.url, {'score': 1, 'body': 'Ooops'})
+            response = self.client.patch(
+                self.url,
+                {'score': 1, 'body': 'Ooops'},
+                REMOTE_ADDR='127.0.0.42',
+            )
             assert response.status_code == 429
             self.rating.reload()
             assert str(self.rating.body) == 'Blâh 5'
@@ -1526,7 +1532,11 @@ class TestRatingViewSetEdit(TestCase):
 
             # Now with the permission we should be ok.
             self.grant_permission(self.user, 'Ratings:BypassThrottling')
-            response = self.client.patch(self.url, {'score': 1, 'body': 'Eheheh'})
+            response = self.client.patch(
+                self.url,
+                {'score': 1, 'body': 'Eheheh'},
+                REMOTE_ADDR='127.0.0.42',
+            )
             assert response.status_code == 200
             self.rating.reload()
             assert str(self.rating.body) == 'Eheheh'
@@ -1543,7 +1553,11 @@ class TestRatingViewSetEdit(TestCase):
             )
             new_url = reverse_ns(self.detail_url_name, kwargs={'pk': new_rating.pk})
             self.client.login_api(new_user)
-            response = self.client.patch(new_url, {'score': 2, 'body': 'Ooops'})
+            response = self.client.patch(
+                new_url,
+                {'score': 2, 'body': 'Ooops'},
+                REMOTE_ADDR='127.0.0.42',
+            )
             assert response.status_code == 429
             new_rating.reload()
             assert str(new_rating.body) == 'Another'
@@ -1551,7 +1565,11 @@ class TestRatingViewSetEdit(TestCase):
 
             # Everything back to normal after waiting a minute.
             frozen_time.tick(delta=timedelta(minutes=1))
-            response = self.client.patch(new_url, {'score': 1, 'body': 'I did it'})
+            response = self.client.patch(
+                new_url,
+                {'score': 1, 'body': 'I did it'},
+                REMOTE_ADDR='127.0.0.42',
+            )
             assert response.status_code == 200
             new_rating.reload()
             assert str(new_rating.body) == 'I did it'

--- a/src/olympia/ratings/tests/test_views.py
+++ b/src/olympia/ratings/tests/test_views.py
@@ -1503,6 +1503,60 @@ class TestRatingViewSetEdit(TestCase):
             assert str(self.rating.body) == 'I did it'
             assert self.rating.rating == 1
 
+    @override_settings(CACHES=locmem_cache)
+    def test_no_throttling_with_relevant_permission(self):
+        self.client.login_api(self.user)
+
+        with freeze_time('2021-08-09') as frozen_time:
+            for x in range(1, 6):
+                response = self.client.patch(
+                    self.url, {'score': x, 'body': f'Blâh {x}'}
+                )
+                assert response.status_code == 200
+                self.rating.reload()
+                assert str(self.rating.body) == f'Blâh {x}'
+                assert self.rating.rating == x
+
+            # Over the limit now...
+            response = self.client.patch(self.url, {'score': 1, 'body': 'Ooops'})
+            assert response.status_code == 429
+            self.rating.reload()
+            assert str(self.rating.body) == 'Blâh 5'
+            assert self.rating.rating == 5
+
+            # Now with the permission we should be ok.
+            self.grant_permission(self.user, 'Ratings:BypassThrottling')
+            response = self.client.patch(self.url, {'score': 1, 'body': 'Eheheh'})
+            assert response.status_code == 200
+            self.rating.reload()
+            assert str(self.rating.body) == 'Eheheh'
+            assert self.rating.rating == 1
+
+            # Someone else with the same IP would still be stuck.
+            new_user = user_factory()
+            new_rating = Rating.objects.create(
+                addon=self.addon,
+                version=self.addon.current_version,
+                body='Another',
+                rating=4,
+                user=new_user,
+            )
+            new_url = reverse_ns(self.detail_url_name, kwargs={'pk': new_rating.pk})
+            self.client.login_api(new_user)
+            response = self.client.patch(new_url, {'score': 2, 'body': 'Ooops'})
+            assert response.status_code == 429
+            new_rating.reload()
+            assert str(new_rating.body) == 'Another'
+            assert new_rating.rating == 4
+
+            # Everything back to normal after waiting a minute.
+            frozen_time.tick(delta=timedelta(minutes=1))
+            response = self.client.patch(new_url, {'score': 1, 'body': 'I did it'})
+            assert response.status_code == 200
+            new_rating.reload()
+            assert str(new_rating.body) == 'I did it'
+            assert new_rating.rating == 1
+
 
 class TestRatingViewSetPost(TestCase):
     client_class = APITestClient

--- a/src/olympia/ratings/views.py
+++ b/src/olympia/ratings/views.py
@@ -123,6 +123,13 @@ class RatingViewSet(AddonChildMixin, ModelViewSet):
         RatingEditDeleteUserThrottle,
     )
 
+    def check_throttles(self, request):
+        # Let users with Ratings:BypassThrottling bypass rate-limiting
+        # completely. Used by QA automated release tests on stage.
+        if acl.action_allowed(request, amo.permissions.RATINGS_BYPASS_THROTTLING):
+            return
+        super().check_throttles(request)
+
     def set_addon_object_from_rating(self, rating):
         """Set addon object on the instance from a rating object."""
         # At this point it's likely we didn't have an addon in the request, so


### PR DESCRIPTION
Fixes #17659