### PR TITLE
Set 'Access-Control-Allow-Origin: *' to '/__version__' endpoint

### DIFF
--- a/src/olympia/amo/tests/test_views.py
+++ b/src/olympia/amo/tests/test_views.py
@@ -519,6 +519,7 @@ class TestVersion(TestCase):
         result = self.client.get('/__version__')
         assert result.status_code == 200
         assert result.get('Content-Type') == 'application/json'
+        assert result.get('Access-Control-Allow-Origin') == '*'
         content = result.json()
         assert content['python'] == '{}.{}'.format(
             sys.version_info.major,

--- a/src/olympia/amo/views.py
+++ b/src/olympia/amo/views.py
@@ -135,7 +135,9 @@ def version(request):
     contents['django'] = '{major}.{minor}'.format(
         major=django.VERSION[0], minor=django.VERSION[1]
     )
-    return HttpResponse(json.dumps(contents), content_type='application/json')
+    res = HttpResponse(json.dumps(contents), content_type='application/json')
+    res.headers['Access-Control-Allow-Origin'] = '*'
+    return res
 
 
 def _frontend_view(*args, **kwargs):


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/17674

---

I am not sure how we can test that locally, `/__version__` is served by addons-frontend it seems 🤷 