### PR TITLE
Change SetRemoteAddrFromForwardedFor to update REMOTE_ADDR only if behind the CDN

### DIFF
--- a/src/olympia/amo/middleware.py
+++ b/src/olympia/amo/middleware.py
@@ -273,11 +273,11 @@ class SetRemoteAddrFromForwardedFor(MiddlewareMixin):
         )
 
     def process_request(self, request):
-        HTTP_X_FORWARDED_FOR = request.META.get('HTTP_X_FORWARDED_FOR')
-        if HTTP_X_FORWARDED_FOR and self.is_request_from_cdn(request):
+        x_forwarded_for_header = request.META.get('HTTP_X_FORWARDED_FOR')
+        if x_forwarded_for_header and self.is_request_from_cdn(request):
             # We only have to split twice from the right to find what we're looking for.
             split = [
-                ip.strip() for ip in HTTP_X_FORWARDED_FOR.rsplit(sep=',', maxsplit=2)
+                ip.strip() for ip in x_forwarded_for_header.rsplit(sep=',', maxsplit=2)
             ]
             try:
                 value = split[-2]

--- a/src/olympia/amo/middleware.py
+++ b/src/olympia/amo/middleware.py
@@ -276,11 +276,8 @@ class SetRemoteAddrFromForwardedFor(MiddlewareMixin):
         x_forwarded_for_header = request.META.get('HTTP_X_FORWARDED_FOR')
         if x_forwarded_for_header and self.is_request_from_cdn(request):
             # We only have to split twice from the right to find what we're looking for.
-            split = [
-                ip.strip() for ip in x_forwarded_for_header.rsplit(sep=',', maxsplit=2)
-            ]
             try:
-                value = split[-2]
+                value = x_forwarded_for_header.rsplit(sep=',', maxsplit=2)[-2].strip()
                 if not value:
                     raise IndexError
                 request.META['REMOTE_ADDR'] = value

--- a/src/olympia/amo/tests/test_middleware.py
+++ b/src/olympia/amo/tests/test_middleware.py
@@ -150,7 +150,9 @@ class TestSetRemoteAddrFromForwardedFor(TestCase):
     @override_settings(SECRET_CDN_TOKEN=None)
     def test_request_not_from_cdn_because_setting_is_none(self):
         request = RequestFactory().get(
-            '/', REMOTE_ADDR='4.8.15.16', HTTP_X_FORWARDED_FOR='2.3.4.2,4.8.15.16',
+            '/',
+            REMOTE_ADDR='4.8.15.16',
+            HTTP_X_FORWARDED_FOR='2.3.4.2,4.8.15.16',
             HTTP_X_REQUEST_VIA_CDN=None,
         )
         assert not self.middleware.is_request_from_cdn(request)
@@ -160,8 +162,10 @@ class TestSetRemoteAddrFromForwardedFor(TestCase):
     @override_settings(SECRET_CDN_TOKEN='foo')
     def test_request_not_from_cdn_because_header_secret_is_invalid(self):
         request = RequestFactory().get(
-            '/', REMOTE_ADDR='4.8.15.16', HTTP_X_FORWARDED_FOR='2.3.4.2,4.8.15.16',
-            HTTP_X_REQUEST_VIA_CDN='not-foo'
+            '/',
+            REMOTE_ADDR='4.8.15.16',
+            HTTP_X_FORWARDED_FOR='2.3.4.2,4.8.15.16',
+            HTTP_X_REQUEST_VIA_CDN='not-foo',
         )
         assert not self.middleware.is_request_from_cdn(request)
         self.middleware.process_request(request)
@@ -170,8 +174,10 @@ class TestSetRemoteAddrFromForwardedFor(TestCase):
     @override_settings(SECRET_CDN_TOKEN='foo')
     def test_request_from_cdn_but_only_one_ip_in_x_forwarded_for(self):
         request = RequestFactory().get(
-            '/', REMOTE_ADDR='4.8.15.16', HTTP_X_FORWARDED_FOR='4.8.15.16',
-            HTTP_X_REQUEST_VIA_CDN='foo'
+            '/',
+            REMOTE_ADDR='4.8.15.16',
+            HTTP_X_FORWARDED_FOR='4.8.15.16',
+            HTTP_X_REQUEST_VIA_CDN='foo',
         )
         assert self.middleware.is_request_from_cdn(request)
         with self.assertRaises(ImproperlyConfigured):
@@ -180,8 +186,10 @@ class TestSetRemoteAddrFromForwardedFor(TestCase):
     @override_settings(SECRET_CDN_TOKEN='foo')
     def test_request_from_cdn_but_empty_values_in_x_forwarded_for(self):
         request = RequestFactory().get(
-            '/', REMOTE_ADDR='4.8.15.16', HTTP_X_FORWARDED_FOR=',',
-            HTTP_X_REQUEST_VIA_CDN='foo'
+            '/',
+            REMOTE_ADDR='4.8.15.16',
+            HTTP_X_FORWARDED_FOR=',',
+            HTTP_X_REQUEST_VIA_CDN='foo',
         )
         assert self.middleware.is_request_from_cdn(request)
         with self.assertRaises(ImproperlyConfigured):
@@ -190,8 +198,10 @@ class TestSetRemoteAddrFromForwardedFor(TestCase):
     @override_settings(SECRET_CDN_TOKEN='foo')
     def test_request_from_cdn_pick_second_to_last_ip_in_x_forwarded_for(self):
         request = RequestFactory().get(
-            '/', REMOTE_ADDR='4.8.15.16', HTTP_X_FORWARDED_FOR=',, 2.3.4.2,  4.8.15.16',
-            HTTP_X_REQUEST_VIA_CDN='foo'
+            '/',
+            REMOTE_ADDR='4.8.15.16',
+            HTTP_X_FORWARDED_FOR=',, 2.3.4.2,  4.8.15.16',
+            HTTP_X_REQUEST_VIA_CDN='foo',
         )
         assert self.middleware.is_request_from_cdn(request)
         self.middleware.process_request(request)

--- a/src/olympia/amo/views.py
+++ b/src/olympia/amo/views.py
@@ -64,7 +64,6 @@ def client_info(request):
         'HTTP_USER_AGENT',
         'HTTP_X_COUNTRY_CODE',
         'HTTP_X_FORWARDED_FOR',
-        'HTTP_X_REQUEST_VIA_CDN',
         'REMOTE_ADDR',
     )
     data = {key: request.META.get(key) for key in keys}

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -290,6 +290,11 @@ SECRET_KEY = env(
     'SECRET_KEY', default='this-is-a-dummy-key-and-its-overridden-for-prod-servers'
 )
 
+# This is a unique key shared between us and the CDN to prove that a request
+# came from the CDN. It will be passed as a HTTP_X_REQUEST_VIA_CDN header to
+# all requests from the CDN
+SECRET_CDN_TOKEN = env('SECRET_CDN_TOKEN', default=None)
+
 # Templates configuration.
 # List of path patterns for which we should be using Django Template Language.
 # If you add things here, don't forget to also change PUENTE config below.

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1446,9 +1446,6 @@ GRAPHITE_PREFIX = env('GRAPHITE_PREFIX', default='amo')
 GRAPHITE_PORT = 2003
 GRAPHITE_TIMEOUT = 1
 
-# IP addresses of servers we use as proxies.
-KNOWN_PROXIES = []
-
 # Blog URL
 DEVELOPER_BLOG_URL = 'https://blog.mozilla.org/addons/wp-json/wp/v2/posts'
 


### PR DESCRIPTION
`SetRemoteAddrFromForwardedFor` as it was before, without being behind the CDN, was useless because `KNOWN_PROXIES` is always empty, and it always added the `REMOTE_ADDR` as passed by nginx last. That value was already correct, so it
wasn't doing any harm, it was just useless.

With the introduction of the CDN, this changes. There are now 2 cases:

1. This is a request originating from the CDN on the behalf of a client. The CDN will forward the client IP in X-Forwarded-For, which is then forwarded to us by nginx in `HTTP_X_FORWARDED_FOR`. Our load balancer also appends to that header, so the value we're looking for will always be second to last regardless of what the client passed. (see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html#RequestCustomIPAddresses)

   To validate that this is indeed a CDN request we use an extra header and secret shared between us and the CDN, and if it matches, we set `REMOTE_ADDR` to that second to last value in `HTTP_X_FORWARDED_FOR`.

2. This is a request made directly to the origin. `HTTP_X_FORWARDED_FOR` is ignored completely, we don't update `REMOTE_ADDR` at all (it should already match the IP of the client)

Fixes https://github.com/mozilla/addons-server/issues/17727
