### PR TITLE
Make "Cancel and Disable Version" in devhub follow the channel the version was uploaded to

### DIFF
--- a/src/olympia/devhub/templates/devhub/addons/submit/describe.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/describe.html
@@ -5,6 +5,7 @@
 {% block title %}{{ dev_page_title(_('Describe Add-on'), addon) }}{% endblock %}
 
 {% block primary %}
+  {% set channel_param = 'listed' if version.channel == amo.RELEASE_CHANNEL_LISTED else 'unlisted' %}
   <h3>{{ _('Describe Add-on') }}</h3>
   <form method="post" id="submit-describe" class="item">
     {{ form.non_field_errors() }}
@@ -240,7 +241,7 @@
       <button class="button delete-button confirm-submission-cancel"
               formnovalidate
               type="button"
-              formaction="{{ url('devhub.addons.cancel', addon.slug) }}">
+              formaction="{{ url('devhub.addons.cancel', addon.slug, channel_param) }}">
           {{ _('Cancel and Disable Version') }}
       </button>
     </div>

--- a/src/olympia/devhub/templates/devhub/addons/submit/describe_minimal.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/describe_minimal.html
@@ -4,6 +4,7 @@
 {% block title %}{{ dev_page_title(_('Describe Add-on'), addon) }}{% endblock %}
 
 {% block primary %}
+  {% set channel_param = 'listed' if version.channel == amo.RELEASE_CHANNEL_LISTED else 'unlisted' %}
   <h3>{{ _('Describe Version') }}</h3>
   <form method="post" id="submit-describe" class="item">
     {% csrf_token %}
@@ -43,7 +44,7 @@
       <button class="button delete-button confirm-submission-cancel"
               formnovalidate
               type="button"
-              formaction="{{ url('devhub.addons.cancel', addon.slug) }}">
+              formaction="{{ url('devhub.addons.cancel', addon.slug, channel_param) }}">
           {{ _('Cancel and Disable Version') }}
       </button>
     </div>

--- a/src/olympia/devhub/templates/devhub/addons/submit/source.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/source.html
@@ -4,7 +4,7 @@
 
 {% block primary %}
 
-{% set channel_param = 'listed' if channel == amo.RELEASE_CHANNEL_LISTED else 'unlisted' %}
+{% set channel_param = 'listed' if version.channel == amo.RELEASE_CHANNEL_LISTED else 'unlisted' %}
 
 <form method="post" enctype="multipart/form-data" id="submit-source">
     {% csrf_token %}
@@ -93,7 +93,7 @@
       <button class="button delete-button confirm-submission-cancel"
               formnovalidate
               type="button"
-              formaction="{{ url('devhub.addons.cancel', addon.slug) }}">
+              formaction="{{ url('devhub.addons.cancel', addon.slug, channel_param) }}">
           {{ _('Cancel and Disable Version') }}
       </button>
     </div>

--- a/src/olympia/devhub/templates/devhub/versions/list.html
+++ b/src/olympia/devhub/templates/devhub/versions/list.html
@@ -97,7 +97,7 @@
   </tr>
   {% set can_request_review=addon.can_request_review() %}
   {% set can_cancel=(not addon.is_disabled and addon.status==amo.STATUS_NOMINATED) %}
-  {% if full_info and check_addon_ownership(request, addon, dev=True) and (can_request_review or can_cancel) %}
+  {% if full_info and check_addon_ownership(request, addon, dev=True) and version.channel == amo.RELEASE_CHANNEL_LISTED and (can_request_review or can_cancel) %}
     <tr>
       <td colspan="0" class="version-status-actions item-actions">
         {% if can_request_review %}
@@ -348,8 +348,11 @@
   {% endif %}
 
   {% if not addon.is_disabled and addon.status == amo.STATUS_NOMINATED %}
+  {# Note: devhub.addons.cancel will cancel the latest version in the specified channel.
+   # This particular modal is only shown for listed versions though, so we can safely
+   # hardcode the channel parameter. #}
   <div id="modal-cancel" class="modal">
-    <form method="post" action="{{ url('devhub.addons.cancel', addon.slug) }}">
+    <form method="post" action="{{ url('devhub.addons.cancel', addon.slug, 'listed') }}">
       <h3>{{ _('Cancel Review Request') }}</h3>
       <p>
         {% trans %}

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -1047,7 +1047,7 @@ class DetailsPageMixin:
         addon = self.get_addon()
         addon.versions.latest().files.update(status=amo.STATUS_AWAITING_REVIEW)
 
-        cancel_url = reverse('devhub.addons.cancel', args=['a3615'])
+        cancel_url = reverse('devhub.addons.cancel', args=['a3615', 'listed'])
         versions_url = reverse('devhub.addons.versions', args=['a3615'])
         response = self.client.post(cancel_url)
         self.assert3xx(response, versions_url)
@@ -2391,7 +2391,7 @@ class TestVersionSubmitDetails(TestSubmitBase):
         addon_status = addon.status
         addon.versions.latest().files.update(status=amo.STATUS_AWAITING_REVIEW)
 
-        cancel_url = reverse('devhub.addons.cancel', args=['a3615'])
+        cancel_url = reverse('devhub.addons.cancel', args=['a3615', 'listed'])
         versions_url = reverse('devhub.addons.versions', args=['a3615'])
         response = self.client.post(cancel_url)
         self.assert3xx(response, versions_url)

--- a/src/olympia/devhub/urls.py
+++ b/src/olympia/devhub/urls.py
@@ -20,7 +20,11 @@ detail_patterns = [
     re_path(r'^delete$', views.delete, name='devhub.addons.delete'),
     re_path(r'^disable$', views.disable, name='devhub.addons.disable'),
     re_path(r'^enable$', views.enable, name='devhub.addons.enable'),
-    re_path(r'^cancel$', views.cancel, name='devhub.addons.cancel'),
+    re_path(
+        r'^cancel-latest-(?P<channel>listed|unlisted)$',
+        views.cancel,
+        name='devhub.addons.cancel',
+    ),
     re_path(r'^ownership$', views.ownership, name='devhub.addons.owner'),
     re_path(r'^invitation$', views.invitation, name='devhub.addons.invitation'),
     re_path(
@@ -102,7 +106,7 @@ detail_patterns = [
         name='devhub.submit.version.wizard',
     ),
     re_path(
-        '^versions/submit/wizard-(?P<channel>listed|unlisted)/background$',
+        r'^versions/submit/wizard-(?P<channel>listed|unlisted)/background$',
         views.theme_background_image,
         name='devhub.submit.version.previous_background',
     ),


### PR DESCRIPTION
This avoids mistakenly disabling a listed version awaiting review when you cancel the submission of an unlisted version.

Fixes #16562