### PR TITLE
Use Remote Settings new STAGE URL

### DIFF
--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -113,6 +113,6 @@ EXTENSION_WORKSHOP_URL = env(
     'EXTENSION_WORKSHOP_URL', default='https://extensionworkshop.allizom.org'
 )
 
-REMOTE_SETTINGS_API_URL = 'https://settings.stage.mozaws.net/v1/'
+REMOTE_SETTINGS_API_URL = 'https://settings-cdn.stage.mozaws.net/v1/'
 REMOTE_SETTINGS_WRITER_URL = 'https://settings-writer.stage.mozaws.net/v1/'
 REMOTE_SETTINGS_WRITER_BUCKET = 'staging'


### PR DESCRIPTION
In [Bug 1594573](https://bugzilla.mozilla.org/show_bug.cgi?id=1594573), we fixed some inconsistencies between our prod and stage URLs.

This is the new URL to be used for the STAGE public server.

