### PR TITLE
Fix for test_temporary_worktree test failure

### DIFF
--- a/src/olympia/git/tests/test_utils.py
+++ b/src/olympia/git/tests/test_utils.py
@@ -99,10 +99,10 @@ def apply_changes(repo, version, contents, path, delete=False):
 def test_temporary_worktree(settings):
     repo = AddonGitRepository(1)
 
-    output = _run_process('git worktree list', repo)
-    assert output.startswith(repo.git_repository.path)
-
     with TemporaryWorktree(repo.git_repository) as worktree:
+        output = _run_process('git worktree list', repo)
+        assert output.startswith(repo.git_repository.path)
+
         assert worktree.temp_directory.startswith(settings.TMP_PATH)
         assert worktree.path == os.path.join(worktree.temp_directory, worktree.name)
 

--- a/src/olympia/git/tests/test_utils.py
+++ b/src/olympia/git/tests/test_utils.py
@@ -100,9 +100,6 @@ def test_temporary_worktree(settings):
     repo = AddonGitRepository(1)
 
     with TemporaryWorktree(repo.git_repository) as worktree:
-        output = _run_process('git worktree list', repo)
-        assert output.startswith(repo.git_repository.path)
-
         assert worktree.temp_directory.startswith(settings.TMP_PATH)
         assert worktree.path == os.path.join(worktree.temp_directory, worktree.name)
 


### PR DESCRIPTION
Wait until we've initialized the worktree before running git worktree list, otherwise the behavior is undefined because there could be leftover data in the directory.

Fixes #17828 (hopefully)