### PR TITLE
Admins should have access to stats for deleted add-ons

### DIFF
--- a/src/olympia/stats/decorators.py
+++ b/src/olympia/stats/decorators.py
@@ -14,7 +14,7 @@ def addon_view_stats(f):
     def wrapper(request, addon_id=None, *args, **kw):
         # Admins can see stats for every add-on regardless of its status.
         if acl.action_allowed(request, permissions.STATS_VIEW):
-            qs = Addon.objects.all
+            qs = Addon.unfiltered.all
         else:
             qs = Addon.objects.not_disabled_by_mozilla
 

--- a/src/olympia/stats/tests/test_views.py
+++ b/src/olympia/stats/tests/test_views.py
@@ -187,6 +187,23 @@ class TestListedAddons(StatsTestCase):
         self.login_as_admin()
         self._check_it(self.public_views_gen(format='json'), 200)
 
+    def test_stats_for_deleted_addon(self):
+        self.addon_4.update(status=amo.STATUS_DELETED)
+
+        # Public users should not see stats
+        self.client.logout()
+        # It is a 404 (and not a 403) before the decorator first tries to
+        # retrieve the add-on.
+        self._check_it(self.public_views_gen(format='json'), 404)
+
+        # Developers should not see stats
+        self.client.login(email=self.someuser.email)
+        self._check_it(self.public_views_gen(format='json'), 404)
+
+        # Admins should see stats
+        self.login_as_admin()
+        self._check_it(self.public_views_gen(format='json'), 200)
+
 
 class TestSeriesSecurity(StatsTestCase):
     """Tests to make sure all restricted data remains restricted."""


### PR DESCRIPTION
Fixes #17858

---

This is a small change to allow admins and privileged users (with the
`STATS_VIEW` permission) to access stats pages for deleted add-ons.