### PR TITLE
Handle add-on ID in manifest not being a string

### DIFF
--- a/src/olympia/files/tests/test_utils.py
+++ b/src/olympia/files/tests/test_utils.py
@@ -123,6 +123,17 @@ class TestManifestJSONExtractor(AppVersionsMixin, TestCase):
             == 'some-id'
         )
 
+    def test_non_string_guid(self):
+        """Test that guid is converted to a string (or None)"""
+        assert (
+            self.parse({'browser_specific_settings': {'gecko': {'id': 12345}}})['guid']
+            == '12345'
+        )
+        assert (
+            self.parse({'browser_specific_settings': {'gecko': {'id': None}}})['guid']
+            is None
+        )
+
     def test_name_for_guid_if_no_id(self):
         """Don't use the name for the guid if there is no id."""
         assert self.parse({'name': 'addon-name'})['guid'] is None

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -232,7 +232,7 @@ class ManifestJSONExtractor:
 
     @property
     def guid(self):
-        return self.gecko.get('id', None)
+        return str(self.gecko.get('id', None) or '') or None
 
     @property
     def type(self):


### PR DESCRIPTION
The linter validates that, but we want to avoid failing in code that runs on parsed add-on data before validation takes place.

Fixes #17874
