### PR TITLE
Use add-on ID instead of slug in stats base URL (for deleted add-ons)

### DIFF
--- a/src/olympia/stats/views.py
+++ b/src/olympia/stats/views.py
@@ -334,7 +334,8 @@ def check_stats_permission(request, addon):
 @non_atomic_requests
 def stats_report(request, addon, report):
     check_stats_permission(request, addon)
-    stats_base_url = reverse('stats.overview', args=[addon.slug])
+    slug_or_id = addon.id if addon.is_deleted else addon.slug
+    stats_base_url = reverse('stats.overview', args=[slug_or_id])
     view = get_report_view(request)
 
     return render(


### PR DESCRIPTION
Fixes #17858

---

This is a quick fix to make the stats pages work today. The urls in the menu
are not working but it's "easy" to replace `None` with the add-on ID (not GUID
or slug).