### PR TITLE
Link to AMO stats in review pages (reviewer tools)

### DIFF
--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -399,14 +399,16 @@
     {% elif not unlisted and acl_check_unlisted_addons_viewer_or_reviewer and addon.has_unlisted_versions(include_deleted=True) %}
       <li><a href="{{ url('reviewers.review', 'unlisted', addon.id) }}">{{ _('Unlisted Review Page') }}</a></li>
     {% endif %}
+
     {% if is_admin %}
       {% if not addon.is_deleted %}
         <li><a href="{{ addon.get_dev_url() }}">{{ _('Edit') }}</a> <em>{{ _('(admin)') }}</em></li>
       {% endif %}
-    <li><a href="{{ url('admin:addons_addon_change', addon.id) }}">{{ _('Admin Page') }}</a> <em>{{ _('(admin)') }}</em></li>
+
+      <li><a href="{{ url('admin:addons_addon_change', addon.id) }}">{{ _('Admin Page') }}</a> <em>{{ _('(admin)') }}</em></li>
+      <li><a href="{{ url('stats.overview', addon.id) }}">{{ _('Statistics') }}</a></li>
     {% endif %}
   </ul>
-
 
   <strong>{{ _('Review This Add-on') }}</strong>
   <ul>

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -3442,6 +3442,7 @@ class TestReview(ReviewBase):
             ('View Product Page', self.addon.get_url_path()),
             ('Edit', self.addon.get_dev_url()),
             ('Admin Page', reverse('admin:addons_addon_change', args=[self.addon.id])),
+            ('Statistics', reverse('stats.overview', args=[self.addon.id])),
         ]
         check_links(expected, doc('#actions-addon a'), verify=False)
 
@@ -3460,6 +3461,7 @@ class TestReview(ReviewBase):
             ),
             ('Edit', self.addon.get_dev_url()),
             ('Admin Page', reverse('admin:addons_addon_change', args=[self.addon.id])),
+            ('Statistics', reverse('stats.overview', args=[self.addon.id])),
         ]
         check_links(expected, doc('#actions-addon a'), verify=False)
 
@@ -3483,6 +3485,7 @@ class TestReview(ReviewBase):
             ),
             ('Edit', self.addon.get_dev_url()),
             ('Admin Page', reverse('admin:addons_addon_change', args=[self.addon.id])),
+            ('Statistics', reverse('stats.overview', args=[self.addon.id])),
         ]
         check_links(expected, doc('#actions-addon a'), verify=False)
 
@@ -3504,6 +3507,7 @@ class TestReview(ReviewBase):
             ('Listed Review Page', reverse('reviewers.review', args=(self.addon.id,))),
             ('Edit', self.addon.get_dev_url()),
             ('Admin Page', reverse('admin:addons_addon_change', args=[self.addon.id])),
+            ('Statistics', reverse('stats.overview', args=[self.addon.id])),
         ]
         check_links(expected, doc('#actions-addon a'), verify=False)
 
@@ -3527,6 +3531,7 @@ class TestReview(ReviewBase):
                 reverse('reviewers.review', args=('unlisted', self.addon.id)),
             ),
             ('Admin Page', reverse('admin:addons_addon_change', args=[self.addon.id])),
+            ('Statistics', reverse('stats.overview', args=[self.addon.id])),
         ]
         check_links(expected, doc('#actions-addon a'), verify=False)
 
@@ -3547,6 +3552,7 @@ class TestReview(ReviewBase):
         expected = [
             ('Listed Review Page', reverse('reviewers.review', args=(self.addon.id,))),
             ('Admin Page', reverse('admin:addons_addon_change', args=[self.addon.id])),
+            ('Statistics', reverse('stats.overview', args=[self.addon.id])),
         ]
         check_links(expected, doc('#actions-addon a'), verify=False)
 


### PR DESCRIPTION
Fixes #17883

---

All review detail pages should now have a link to the AMO stats, including deleted add-ons.