### PR TITLE
implement new uploads to the addon api, for listed too.

### DIFF
--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -7,8 +7,6 @@ Add-ons
     These APIs are not frozen and can change at any time without warning.
     See :ref:`the API versions available<api-versions-list>` for alternatives
     if you need stability.
-    The only authentication method available at
-    the moment is :ref:`the internal one<api-auth-internal>`.
 
 
 ------

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -6,7 +6,8 @@ from django.urls import reverse
 
 from rest_framework import exceptions, serializers
 
-from olympia import amo
+import olympia.core.logger
+from olympia import activity, amo
 from olympia.accounts.serializers import (
     BaseUserSerializer,
     UserProfileBasketSyncSerializer,
@@ -18,17 +19,20 @@ from olympia.api.fields import (
     OutgoingTranslationField,
     OutgoingURLField,
     ReverseChoiceField,
+    SplitField,
     TranslationSerializerField,
 )
 from olympia.api.serializers import BaseESSerializer
 from olympia.api.utils import is_gate_active
 from olympia.applications.models import AppVersion
 from olympia.bandwagon.models import Collection
-from olympia.constants.applications import APPS_ALL, APP_IDS
+from olympia.blocklist.models import Block
+from olympia.constants.applications import APPS, APPS_ALL, APP_IDS
 from olympia.constants.base import ADDON_TYPE_CHOICES_API
-from olympia.constants.categories import CATEGORIES_BY_ID
+from olympia.constants.categories import CATEGORIES, CATEGORIES_BY_ID
 from olympia.constants.promoted import PROMOTED_GROUPS, RECOMMENDED
-from olympia.files.models import File
+from olympia.files.models import File, FileUpload
+from olympia.files.utils import parse_addon
 from olympia.promoted.models import PromotedAddon
 from olympia.search.filters import AddonAppVersionQueryParam
 from olympia.ratings.utils import get_grouped_ratings
@@ -40,7 +44,7 @@ from olympia.versions.models import (
     VersionPreview,
 )
 
-from .models import Addon, Preview, ReplacementAddon, attach_tags
+from .models import Addon, AddonCategory, Preview, ReplacementAddon, attach_tags
 
 
 class FileSerializer(serializers.ModelSerializer):
@@ -233,11 +237,12 @@ class CompactLicenseSerializer(LicenseSerializer):
 
 
 class MinimalVersionSerializer(serializers.ModelSerializer):
-    file = FileSerializer()
+    file = FileSerializer(read_only=True)
 
     class Meta:
         model = Version
         fields = ('id', 'file', 'reviewed', 'version')
+        read_only_fields = fields
 
     def to_representation(self, instance):
         repr = super().to_representation(instance)
@@ -252,14 +257,43 @@ class MinimalVersionSerializer(serializers.ModelSerializer):
         return repr
 
 
+class VersionCompatabilityField(serializers.Field):
+    def to_internal_value(self, data):
+        if isinstance(data, dict):
+            # if it's a dict, just translate the app name
+            return {amo.APPS[key]: value for key, value in data.items()}
+        elif isinstance(data, list):
+            # if it's a list of apps, normalize into a dict
+            return {amo.APPS[key]: None for key in data}
+        else:
+            # if it's neither it's not a valid input
+            raise exceptions.ValidationError()
+
+    def to_representation(self, value):
+        return {
+            app.short: {
+                'min': compat.min.version
+                if compat
+                else (amo.D2C_MIN_VERSIONS.get(app.id, '1.0')),
+                'max': compat.max.version if compat else amo.FAKE_MAX_VERSION,
+            }
+            for app, compat in value.items()
+        }
+
+
 class SimpleVersionSerializer(MinimalVersionSerializer):
-    compatibility = serializers.SerializerMethodField()
+    compatibility = VersionCompatabilityField(
+        # default to just Desktop Firefox; most of the times developers don't develop
+        # their WebExtensions for Android.  See https://bit.ly/2QaMicU
+        source='compatible_apps',
+        default={amo.APPS['firefox']: None},
+    )
     edit_url = serializers.SerializerMethodField()
     is_strict_compatibility_enabled = serializers.BooleanField(
-        source='file.strict_compatibility'
+        source='file.strict_compatibility', read_only=True
     )
     license = CompactLicenseSerializer()
-    release_notes = TranslationSerializerField()
+    release_notes = TranslationSerializerField(required=False)
 
     class Meta:
         model = Version
@@ -274,24 +308,13 @@ class SimpleVersionSerializer(MinimalVersionSerializer):
             'reviewed',
             'version',
         )
+        read_only_fields = fields
 
     def to_representation(self, instance):
-        # Help the LicenseSerializer find the version we're currently
-        # serializing.
+        # Help the LicenseSerializer find the version we're currently serializing.
         if 'license' in self.fields and instance.license:
             instance.license.version_instance = instance
         return super().to_representation(instance)
-
-    def get_compatibility(self, obj):
-        return {
-            app.short: {
-                'min': compat.min.version
-                if compat
-                else (amo.D2C_MIN_VERSIONS.get(app.id, '1.0')),
-                'max': compat.max.version if compat else amo.FAKE_MAX_VERSION,
-            }
-            for app, compat in obj.compatible_apps.items()
-        }
 
     def get_edit_url(self, obj):
         return absolutify(
@@ -300,8 +323,16 @@ class SimpleVersionSerializer(MinimalVersionSerializer):
 
 
 class VersionSerializer(SimpleVersionSerializer):
-    channel = ReverseChoiceField(choices=list(amo.CHANNEL_CHOICES_API.items()))
-    license = LicenseSerializer()
+    channel = ReverseChoiceField(
+        choices=list(amo.CHANNEL_CHOICES_API.items()), read_only=True
+    )
+    license = SplitField(
+        serializers.PrimaryKeyRelatedField(queryset=License.objects.builtins()),
+        LicenseSerializer(),
+    )
+    upload = serializers.SlugRelatedField(
+        slug_field='uuid', queryset=FileUpload.objects.all(), write_only=True
+    )
 
     class Meta:
         model = Version
@@ -315,8 +346,74 @@ class VersionSerializer(SimpleVersionSerializer):
             'license',
             'release_notes',
             'reviewed',
+            'upload',
             'version',
         )
+        writeable_fields = (
+            'compatibility',
+            'license',
+            'release_notes',
+            'upload',
+        )
+        read_only_fields = tuple(set(fields) - set(writeable_fields))
+
+    def __init__(self, *args, **kwargs):
+        self.addon = kwargs.pop('addon', None)
+        super().__init__(*args, **kwargs)
+
+    def validate_upload(self, value):
+        own_upload = (request := self.context.get('request')) and (
+            request.user == value.user
+        )
+        if not own_upload or not value.valid or value.validation_timeout:
+            raise exceptions.ValidationError('Upload is not valid.')
+        return value
+
+    def _check_blocklist(self, guid, version_string):
+        # check the guid/version isn't in the addon blocklist
+        block_qs = Block.objects.filter(guid=guid) if guid else ()
+        if block_qs and block_qs.first().is_version_blocked(version_string):
+            msg = (
+                'Version {version} matches {block_link} for this add-on. '
+                'You can contact {amo_admins} for additional information.'
+            )
+            raise exceptions.ValidationError(
+                msg.format(
+                    version=version_string,
+                    block_link=absolutify(reverse('blocklist.block', args=[guid])),
+                    amo_admins='amo-admins@mozilla.com',
+                ),
+            )
+
+    def validate(self, data):
+        if not self.instance:
+            # Parse the file to get and validate package data with the addon.
+            self.parsed_data = parse_addon(
+                data.get('upload'), addon=self.addon, user=self.context['request'].user
+            )
+            guid = self.addon.guid if self.addon else self.parsed_data.get('guid')
+            self._check_blocklist(guid, self.parsed_data.get('version'))
+        else:
+            data.pop('upload', None)  # upload can only be set during create
+        return data
+
+    def create(self, validated_data):
+        upload = validated_data.get('upload')
+        parsed_and_validated_data = {
+            **self.parsed_data,
+            **validated_data,
+            'license_id': validated_data['license'].id,
+        }
+        version = Version.from_upload(
+            upload=upload,
+            addon=self.addon or validated_data.get('addon'),
+            # TODO: change Version.from_upload to take the compat values into account
+            selected_apps=[app.id for app in validated_data.get('compatible_apps')],
+            channel=upload.channel,
+            parsed_data=parsed_and_validated_data,
+        )
+        upload.update(addon=version.addon)
+        return version
 
 
 class VersionListSerializer(VersionSerializer):
@@ -426,6 +523,18 @@ class PromotedAddonSerializer(serializers.ModelSerializer):
         return [app.short for app in obj.approved_applications]
 
 
+class CategoriesSerializerField(serializers.Field):
+    def to_internal_value(self, data):
+        # Can't do any transformation/validation here because we don't know addon_type
+        return data
+
+    def to_representation(self, value):
+        return {
+            app_short_name: [cat.slug for cat in categories]
+            for app_short_name, categories in value.items()
+        }
+
+
 class ContributionSerializerField(OutgoingURLField):
     def to_representation(self, value):
         if not value:
@@ -448,33 +557,42 @@ class ContributionSerializerField(OutgoingURLField):
 
 
 class AddonSerializer(serializers.ModelSerializer):
-    authors = AddonDeveloperSerializer(many=True, source='listed_authors')
-    categories = serializers.SerializerMethodField()
-    contributions_url = ContributionSerializerField(source='contributions')
-    current_version = CurrentVersionSerializer()
-    description = TranslationSerializerField()
-    developer_comments = TranslationSerializerField()
+    authors = AddonDeveloperSerializer(
+        many=True, source='listed_authors', read_only=True
+    )
+    categories = CategoriesSerializerField(source='app_categories')
+    contributions_url = ContributionSerializerField(
+        source='contributions', read_only=True
+    )
+    current_version = CurrentVersionSerializer(read_only=True)
+    description = TranslationSerializerField(required=False)
+    developer_comments = TranslationSerializerField(required=False)
     edit_url = serializers.SerializerMethodField()
     has_eula = serializers.SerializerMethodField()
     has_privacy_policy = serializers.SerializerMethodField()
-    homepage = OutgoingTranslationField()
+    homepage = OutgoingTranslationField(required=False)
     icon_url = serializers.SerializerMethodField()
     icons = serializers.SerializerMethodField()
     is_source_public = serializers.SerializerMethodField()
     is_featured = serializers.SerializerMethodField()
-    name = TranslationSerializerField()
-    previews = PreviewSerializer(many=True, source='current_previews')
-    promoted = PromotedAddonSerializer()
+    name = TranslationSerializerField(required=False)
+    previews = PreviewSerializer(many=True, source='current_previews', read_only=True)
+    promoted = PromotedAddonSerializer(read_only=True)
     ratings = serializers.SerializerMethodField()
     ratings_url = serializers.SerializerMethodField()
     review_url = serializers.SerializerMethodField()
-    status = ReverseChoiceField(choices=list(amo.STATUS_CHOICES_API.items()))
-    summary = TranslationSerializerField()
-    support_email = TranslationSerializerField()
-    support_url = OutgoingTranslationField()
+    status = ReverseChoiceField(
+        choices=list(amo.STATUS_CHOICES_API.items()), read_only=True
+    )
+    summary = TranslationSerializerField(required=False)
+    support_email = TranslationSerializerField(required=False)
+    support_url = OutgoingTranslationField(required=False)
     tags = serializers.SerializerMethodField()
-    type = ReverseChoiceField(choices=list(amo.ADDON_TYPE_CHOICES_API.items()))
+    type = ReverseChoiceField(
+        choices=list(amo.ADDON_TYPE_CHOICES_API.items()), read_only=True
+    )
     url = serializers.SerializerMethodField()
+    version = VersionSerializer(write_only=True)
     versions_url = serializers.SerializerMethodField()
 
     class Meta:
@@ -517,9 +635,23 @@ class AddonSerializer(serializers.ModelSerializer):
             'tags',
             'type',
             'url',
+            'version',
             'versions_url',
             'weekly_downloads',
         )
+        writeable_fields = (
+            'categories',
+            'description',
+            'developer_comments',
+            'homepage',
+            'name',
+            'slug',
+            'summary',
+            'support_email',
+            'support_url',
+            'version',
+        )
+        read_only_fields = tuple(set(fields) - set(writeable_fields))
 
     def to_representation(self, obj):
         data = super().to_representation(obj)
@@ -532,12 +664,6 @@ class AddonSerializer(serializers.ModelSerializer):
         if request and not is_gate_active(request, 'is-featured-addon-shim'):
             data.pop('is_featured', None)
         return data
-
-    def get_categories(self, obj):
-        return {
-            app_short_name: [cat.slug for cat in categories]
-            for app_short_name, categories in obj.app_categories.items()
-        }
 
     def get_has_eula(self, obj):
         return bool(getattr(obj, 'has_eula', obj.eula))
@@ -599,13 +725,68 @@ class AddonSerializer(serializers.ModelSerializer):
     def get_is_source_public(self, obj):
         return False
 
+    def validate(self, data):
+        if not self.instance:
+            addon_type = self.fields['version'].parsed_data['type']
+        else:
+            addon_type = self.instance.type
+        if 'app_categories' in data:
+            try:
+                category_ids = []
+                for app_name, category_names in data['app_categories'].items():
+                    app = APPS[app_name]
+                    category_ids.extend(
+                        CATEGORIES[app.id][addon_type][name] for name in category_names
+                    )
+                data['app_categories'] = category_ids
+            except KeyError:
+                raise exceptions.ValidationError(
+                    {'categories': 'Invalid app or category name.'}
+                )
+
+        return data
+
+    def create(self, validated_data):
+        upload = validated_data.get('version').get('upload')
+
+        addon = Addon.initialize_addon_from_upload(
+            data={**self.fields['version'].parsed_data, **validated_data},
+            upload=upload,
+            channel=upload.channel,
+            user=self.context['request'].user,
+        )
+        # Add categories
+        for category in validated_data.get('app_categories', ()):
+            AddonCategory.objects.create(addon=addon, category_id=category.id)
+
+        self.fields['version'].create(
+            {**validated_data.get('version', {}), 'addon': addon}
+        )
+
+        activity.log_create(amo.LOG.CREATE_ADDON, addon)
+        olympia.core.logger.getLogger('z.addons').info(
+            f'New addon {addon!r} from {upload!r}'
+        )
+
+        if (
+            addon.status == amo.STATUS_NULL
+            and addon.has_complete_metadata()
+            and upload.channel == amo.RELEASE_CHANNEL_LISTED
+        ):
+            addon.update(status=amo.STATUS_NOMINATED)
+
+        return addon
+
 
 class AddonSerializerWithUnlistedData(AddonSerializer):
-    latest_unlisted_version = SimpleVersionSerializer()
+    latest_unlisted_version = SimpleVersionSerializer(read_only=True)
 
     class Meta:
         model = Addon
         fields = AddonSerializer.Meta.fields + ('latest_unlisted_version',)
+        read_only_fields = tuple(
+            set(fields) - set(AddonSerializer.Meta.writeable_fields)
+        )
 
 
 class SimpleAddonSerializer(AddonSerializer):

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -959,6 +959,13 @@ class TestAddonSerializerOutput(AddonSerializerOutputTestMixin, TestCase):
             self.addon.latest_unlisted_version, result['latest_unlisted_version']
         )
 
+    def test_readonly_fields(self):
+        serializer = self.serializer_class()
+        fields_read_only = {
+            name for name, field in serializer.get_fields().items() if field.read_only
+        }
+        assert fields_read_only == set(serializer.Meta.read_only_fields)
+
 
 class TestESAddonSerializerOutput(AddonSerializerOutputTestMixin, ESTestCase):
     serializer_class = ESAddonSerializer

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -12,7 +12,8 @@ from elasticsearch_dsl import Q, query, Search
 from rest_framework import exceptions, serializers
 from rest_framework.decorators import action
 from rest_framework.generics import ListAPIView
-from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
+from rest_framework.mixins import CreateModelMixin, ListModelMixin, RetrieveModelMixin
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
 from rest_framework.views import APIView
@@ -23,6 +24,7 @@ import olympia.core.logger
 from olympia import amo
 from olympia.access import acl
 from olympia.amo.urlresolvers import get_outgoing_url
+from olympia.api.authentication import JWTKeyAuthentication, WebTokenAuthentication
 from olympia.api.exceptions import UnavailableForLegalReasons
 from olympia.api.pagination import ESPageNumberPagination
 from olympia.api.permissions import (
@@ -32,11 +34,13 @@ from olympia.api.permissions import (
     AllowListedViewerOrReviewer,
     AllowUnlistedViewerOrReviewer,
     AnyOf,
+    APIGatePermission,
     GroupPermission,
     RegionalRestriction,
 )
 from olympia.api.utils import is_gate_active
 from olympia.constants.categories import CATEGORIES_BY_ID
+from olympia.devhub.permissions import IsSubmissionAllowedFor
 from olympia.search.filters import (
     AddonAppQueryParam,
     AddonAppVersionQueryParam,
@@ -174,7 +178,7 @@ def find_replacement_addon(request):
     return redirect(replace_url, permanent=False)
 
 
-class AddonViewSet(RetrieveModelMixin, GenericViewSet):
+class AddonViewSet(CreateModelMixin, RetrieveModelMixin, GenericViewSet):
     permission_classes = [
         AnyOf(
             AllowReadOnlyIfPublic,
@@ -183,6 +187,7 @@ class AddonViewSet(RetrieveModelMixin, GenericViewSet):
             AllowUnlistedViewerOrReviewer,
         ),
     ]
+    authentication_classes = [JWTKeyAuthentication, WebTokenAuthentication]
     georestriction_classes = [
         RegionalRestriction | GroupPermission(amo.permissions.ADDONS_EDIT)
     ]
@@ -216,7 +221,7 @@ class AddonViewSet(RetrieveModelMixin, GenericViewSet):
     def get_serializer_class(self):
         # Override serializer to use serializer_class_with_unlisted_data if
         # we are allowed to access unlisted data.
-        obj = getattr(self, 'instance')
+        obj = getattr(self, 'instance', None)
         request = self.request
         if acl.check_unlisted_addons_viewer_or_reviewer(request) or (
             obj
@@ -240,7 +245,12 @@ class AddonViewSet(RetrieveModelMixin, GenericViewSet):
         for restriction in self.get_georestrictions():
             if not restriction.has_permission(request, self):
                 raise UnavailableForLegalReasons()
-
+        if self.action == 'create':
+            self.permission_classes = [
+                APIGatePermission('addon-submission-api'),
+                IsAuthenticated,
+                IsSubmissionAllowedFor,
+            ]
         super().check_permissions(request)
 
     def check_object_permissions(self, request, obj):
@@ -285,6 +295,13 @@ class AddonViewSet(RetrieveModelMixin, GenericViewSet):
         )
         return Response(serializer.data)
 
+    def create(self, request, *args, **kwargs):
+        from olympia.signing.views import VersionView  # circular import
+
+        # TODO: consolidate/replicate this behaviour.
+        VersionView().check_throttles(request)
+        return super().create(request, *args, **kwargs)
+
 
 class AddonChildMixin:
     """Mixin containing method to retrieve the parent add-on object."""
@@ -322,7 +339,11 @@ class AddonChildMixin:
 
 
 class AddonVersionViewSet(
-    AddonChildMixin, RetrieveModelMixin, ListModelMixin, GenericViewSet
+    AddonChildMixin,
+    CreateModelMixin,
+    RetrieveModelMixin,
+    ListModelMixin,
+    GenericViewSet,
 ):
     # Permissions are always checked against the parent add-on in
     # get_addon_object() using AddonViewSet.permission_classes so we don't need
@@ -330,6 +351,7 @@ class AddonVersionViewSet(
     # below in check_permissions() and check_object_permissions() depending on
     # what the client is requesting to see.
     permission_classes = []
+    authentication_classes = [JWTKeyAuthentication, WebTokenAuthentication]
 
     def get_serializer_class(self):
         if (
@@ -342,9 +364,14 @@ class AddonVersionViewSet(
             serializer_class = VersionSerializer
         return serializer_class
 
+    def get_serializer(self, *args, **kwargs):
+        return super().get_serializer(
+            *args, **{**kwargs, 'addon': self.get_addon_object()}
+        )
+
     def check_permissions(self, request):
-        requested = self.request.GET.get('filter')
         if self.action == 'list':
+            requested = self.request.GET.get('filter')
             if requested == 'all_with_deleted':
                 # To see deleted versions, you need Addons:ViewDeleted.
                 self.permission_classes = [
@@ -372,6 +399,12 @@ class AddonVersionViewSet(
             # super + check_object_permission() ourselves, passing down the
             # addon object directly.
             return super().check_object_permissions(request, self.get_addon_object())
+        elif self.action == 'create':
+            self.permission_classes = [
+                APIGatePermission('addon-submission-api'),
+                IsAuthenticated,
+                IsSubmissionAllowedFor,
+            ]
         super().check_permissions(request)
 
     def check_object_permissions(self, request, obj):
@@ -451,6 +484,13 @@ class AddonVersionViewSet(
             # doesn't scale as nicely in those versions.
             queryset = queryset.transform(Version.transformer_license)
         return queryset
+
+    def create(self, request, *args, **kwargs):
+        from olympia.signing.views import VersionView  # circular import
+
+        # TODO: consolidate/replicate this behaviour.
+        VersionView().check_throttles(request)
+        return super().create(request, *args, **kwargs)
 
 
 class AddonSearchView(ListAPIView):

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -256,8 +256,8 @@ class Version(OnChangeMixin, ModelBase):
                 'FileUpload user does not have some required fields'
             )
 
-        license_id = None
-        if channel == amo.RELEASE_CHANNEL_LISTED:
+        license_id = parsed_data.get('license_id')
+        if not license_id and channel == amo.RELEASE_CHANNEL_LISTED:
             previous_version = addon.find_latest_version(channel=channel, exclude=())
             if previous_version and previous_version.license_id:
                 license_id = previous_version.license_id
@@ -272,6 +272,7 @@ class Version(OnChangeMixin, ModelBase):
             version=parsed_data['version'],
             license_id=license_id,
             channel=channel,
+            release_notes=parsed_data.get('release_notes'),
         )
         email = upload.user.email if upload.user and upload.user.email else ''
         with core.override_remote_addr(upload.ip_address):


### PR DESCRIPTION
fixes #7811 ... or the base work for it at least.  (draft PR was #17765 - copied text over from it)

Basic flow:
1) Upload the file to be validated via POSTing to `api/v5/addons/submission/` to create a FileUpload (returns a serialized response that contains the upload UUID).  Upload was added in #17919.
2) with a valid upload, submit it as a new addon to `api/v5/addons/addon/` with json like `{"categories": {"firefox": ["bookmarks"]}, "version": {"upload": "<uuid>", "license": 7}}`
3) or can be submitted as a new version to an existing addon via `api/v5/addons/addon/<addon slug or id or guid>/versions/` with json like `{"upload": "<uuid>", "license": 7}`

Known limitations:
- you can only select from pre-defined licenses - and only by specifying a numeric license id.  So worked needed to:
  - implement the ability to create a custom license
  - select from predefined licenses by slug or some other mnemonic 
  - maybe make the field optional (for listed versions only?) and default to all rights reserved, or the previous license for subsequent versions
- categories are required to create an add-on but aren't really needed unless the add-on has listed versions
- For the first listed version we want to require all the necessary metadata (name, summary, categories, version license) being defined if not available in the manifest, but not really for unlisted versions.  This will necessitate some refactoring - probably moving some validation from `AddonSerializer` to `VersionSerializer`.
- source code submission isn't implemented
- there are some fields on `AddonSerializer` that should be writable but are currently either `SerializerMethodField`s or custom `Field`s/`Serializer`s that don't have a working write implementation.
- setting `default_locale` did unexpected things during Addon creation with respect to data in the manifest so left it read only.
- Only `CreateModelMixin` has been added to the views to limit the scope of the changes/tests.  The serializers should handle updates without a massive amount of extra work (in theory!).
- probably many other things