### PR TITLE
implement fileupload api, part of new addon submisison api

### DIFF
--- a/src/olympia/addons/api_urls.py
+++ b/src/olympia/addons/api_urls.py
@@ -4,6 +4,7 @@ from rest_framework.routers import SimpleRouter
 from rest_framework_nested.routers import NestedSimpleRouter
 
 from olympia.activity.views import VersionReviewNotesViewSet
+from olympia.files.views import FileUploadViewSet
 
 from .views import (
     AddonAutoCompleteSearchView,
@@ -29,6 +30,9 @@ sub_versions = NestedSimpleRouter(sub_addons, r'versions', lookup='version')
 sub_versions.register(
     r'reviewnotes', VersionReviewNotesViewSet, basename='version-reviewnotes'
 )
+
+uploads = SimpleRouter()
+uploads.register(r'upload', FileUploadViewSet, basename='addon-upload')
 
 urls = [
     re_path(r'', include(addons.urls)),
@@ -66,3 +70,7 @@ addons_v3 = urls + [
 ]
 
 addons_v4 = urls
+
+addons_v5 = addons_v4 + [
+    re_path(r'', include(uploads.urls)),
+]

--- a/src/olympia/api/permissions.py
+++ b/src/olympia/api/permissions.py
@@ -5,6 +5,8 @@ from olympia.access import acl
 from olympia.addons.models import AddonRegionalRestrictions
 from olympia.amo import permissions
 
+from .utils import is_gate_active
+
 
 # Most of these classes come from zamboni, check out
 # https://github.com/mozilla/zamboni/blob/master/mkt/api/permissions.py for
@@ -351,6 +353,20 @@ class RegionalRestriction(BasePermission):
             addon=obj, excluded_regions__contains=region_code.upper()
         )
         return not (region_code and qs.exists())
+
+    def __call__(self, *a):
+        return self
+
+
+class APIGatePermission(BasePermission):
+    def __init__(self, gate):
+        self.gate = gate
+
+    def has_permission(self, request, view):
+        return is_gate_active(request, self.gate)
+
+    def has_object_permission(self, request, view, obj):
+        return self.has_permission(request, view)
 
     def __call__(self, *a):
         return self

--- a/src/olympia/api/urls.py
+++ b/src/olympia/api/urls.py
@@ -2,7 +2,7 @@ from django.urls import include, re_path
 
 from olympia.accounts.urls import accounts_v3, accounts_v4, auth_callback_patterns
 from olympia.amo.urls import api_patterns as amo_api_patterns
-from olympia.addons.api_urls import addons_v3, addons_v4
+from olympia.addons.api_urls import addons_v3, addons_v4, addons_v5
 from olympia.ratings.api_urls import ratings_v3, ratings_v4
 
 
@@ -33,7 +33,20 @@ v4_api_urls = [
     re_path(r'^scanner/', include('olympia.scanners.api_urls')),
 ]
 
-v5_api_urls = v4_api_urls + [
+v5_api_urls = [
+    re_path(r'^abuse/', include('olympia.abuse.urls')),
+    re_path(r'^accounts/', include(accounts_v4)),
+    re_path(r'^activity/', include('olympia.activity.urls')),
+    re_path(r'^addons/', include(addons_v5)),
+    re_path(r'^applications/', include('olympia.applications.api_urls')),
+    re_path(r'^blocklist/', include('olympia.blocklist.urls')),
+    re_path(r'^', include('olympia.discovery.api_urls')),
+    re_path(r'^hero/', include('olympia.hero.urls')),
+    re_path(r'^ratings/', include(ratings_v4.urls)),
+    re_path(r'^reviewers/', include('olympia.reviewers.api_urls')),
+    re_path(r'^', include('olympia.signing.urls')),
+    re_path(r'^', include(amo_api_patterns)),
+    re_path(r'^scanner/', include('olympia.scanners.api_urls')),
     re_path(r'^shelves/', include('olympia.shelves.urls')),
 ]
 

--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -102,3 +102,6 @@ REMOTE_SETTINGS_WRITER_BUCKET = 'staging'
 
 # See: https://bugzilla.mozilla.org/show_bug.cgi?id=1633746
 BIGQUERY_AMO_DATASET = 'amo_prod'
+
+# We don't want to enable the new addon submission on prod yet
+DRF_API_GATES['v5'].pop('addon-submission-api', None)

--- a/src/olympia/files/models.py
+++ b/src/olympia/files/models.py
@@ -577,6 +577,10 @@ class FileUpload(ModelBase):
         return bool(self.valid or self.validation)
 
     @property
+    def submitted(self):
+        return bool(self.addon)
+
+    @property
     def validation_timeout(self):
         if self.processed:
             validation = self.load_validation()

--- a/src/olympia/files/serializers.py
+++ b/src/olympia/files/serializers.py
@@ -1,0 +1,48 @@
+from rest_framework import serializers
+from rest_framework.reverse import reverse as drf_reverse
+
+from olympia import amo
+from olympia.amo.templatetags.jinja_helpers import absolutify
+from olympia.api.fields import ReverseChoiceField
+
+from .models import FileUpload
+
+
+class FileUploadSerializer(serializers.ModelSerializer):
+    uuid = serializers.UUIDField(format='hex')
+    channel = ReverseChoiceField(
+        choices=[
+            (False, amo.CHANNEL_CHOICES_API[amo.RELEASE_CHANNEL_UNLISTED]),
+            (True, amo.CHANNEL_CHOICES_API[amo.RELEASE_CHANNEL_LISTED]),
+        ],
+        source='automated_signing',
+    )
+    processed = serializers.BooleanField()
+    valid = serializers.BooleanField(source='passed_all_validations')
+    validation = serializers.SerializerMethodField()
+    url = serializers.SerializerMethodField()
+
+    class Meta:
+        model = FileUpload
+        fields = [
+            'uuid',
+            'channel',
+            'processed',
+            'submitted',
+            'url',
+            'valid',
+            'validation',
+            'version',
+        ]
+
+    def get_validation(self, instance):
+        return instance.load_validation() if instance.validation else None
+
+    def get_url(self, instance):
+        return absolutify(
+            drf_reverse(
+                'addon-upload-detail',
+                request=self.context.get('request'),
+                args=[instance.uuid.hex],
+            )
+        )

--- a/src/olympia/files/tests/test_serializers.py
+++ b/src/olympia/files/tests/test_serializers.py
@@ -1,0 +1,50 @@
+import json
+
+from django.conf import settings
+
+from rest_framework.settings import api_settings
+from rest_framework.test import APIRequestFactory
+
+from olympia.amo.tests import TestCase
+from olympia.amo.reverse import reverse
+
+from ..models import FileUpload
+from ..serializers import FileUploadSerializer
+
+
+class TestFileUploadSerializer(TestCase):
+    def setUp(self):
+        api_version = api_settings.DEFAULT_VERSION
+        self.request = APIRequestFactory().get('/api/%s/' % api_version)
+        self.request.versioning_scheme = api_settings.DEFAULT_VERSIONING_CLASS()
+        self.request.version = api_version
+
+    def test_basic(self):
+        file_upload = FileUpload(version='123')
+        data = FileUploadSerializer(
+            instance=file_upload, context={'request': self.request}
+        ).data
+        assert data == {
+            'uuid': file_upload.uuid.hex,
+            'channel': 'unlisted',
+            'processed': False,
+            'submitted': False,
+            'url': settings.EXTERNAL_SITE_URL
+            + reverse(
+                'v5:addon-upload-detail',
+                args=[file_upload.uuid.hex],
+            ),
+            'valid': False,
+            'validation': None,
+            'version': '123',
+        }
+
+        file_upload.update(
+            automated_signing=True,
+            validation=json.dumps([{'something': 'happened'}]),
+        )
+        data = FileUploadSerializer(
+            instance=file_upload, context={'request': self.request}
+        ).data
+        assert data['channel'] == 'listed'
+        assert data['validation'] == [{'something': 'happened'}]

--- a/src/olympia/files/tests/test_views.py
+++ b/src/olympia/files/tests/test_views.py
@@ -1,9 +1,20 @@
+import os
+
 from django.conf import settings
+from django.test.utils import override_settings
 from django.urls import reverse
 
-from olympia.amo.tests import TestCase
+from olympia import amo
+from olympia.amo.tests import (
+    APITestClient,
+    JWTAPITestClient,
+    reverse_ns,
+    TestCase,
+    user_factory,
+)
 
 from .test_models import UploadMixin
+from ..models import FileUpload
 
 
 files_fixtures = 'src/olympia/files/fixtures/files/'
@@ -43,3 +54,128 @@ class TestServeFileUpload(UploadMixin, TestCase):
         resp = self.client.get(self.upload.get_authenticated_download_url())
 
         assert resp.status_code == 410
+
+
+class FileUploadTestMixin:
+    def setUp(self):
+        super().setUp()
+        self.list_url = reverse_ns('addon-upload-list', api_version='v5')
+        self.user = user_factory(read_dev_agreement=self.days_ago(0))
+        # Add a file upload
+        self.upload = FileUpload.objects.create(user=self.user)
+        # Add some other ones from other users
+        self.other_user_upload = FileUpload.objects.create(user=user_factory())
+        FileUpload.objects.create()
+
+        self.detail_url = reverse_ns(
+            'addon-upload-detail',
+            kwargs={'uuid': self.upload.uuid.hex},
+            api_version='v5',
+        )
+        self.client.login_api(self.user)
+
+    def _xpi_filepath(self, guid, version):
+        return os.path.join(
+            'src',
+            'olympia',
+            'signing',
+            'fixtures',
+            f'{guid}-{version}.xpi',
+        )
+
+    def test_not_authenticated(self):
+        self.client.logout_api()
+        response = self.client.get(
+            self.list_url,
+        )
+        assert response.status_code == 401
+
+    def test_no_developer_agreement(self):
+        self.user.update(read_dev_agreement=None)
+        filepath = self._xpi_filepath('@upload-version', '3.0')
+
+        with open(filepath, 'rb') as upload:
+            data = {
+                'upload': upload,
+                'channel': 'listed',
+            }
+
+            response = self.client.post(
+                self.list_url,
+                data,
+                format='multipart',
+                REMOTE_ADDR='127.0.3.1',
+            )
+        assert response.status_code in [401, 403]  # JWT auth is a 401; web auth is 403
+
+    def test_create(self):
+        upload_count_before = FileUpload.objects.count()
+        filepath = self._xpi_filepath('@upload-version', '3.0')
+
+        with open(filepath, 'rb') as upload:
+            data = {
+                'upload': upload,
+                'channel': 'listed',
+            }
+
+            response = self.client.post(
+                self.list_url,
+                data,
+                format='multipart',
+                REMOTE_ADDR='127.0.3.1',
+            )
+
+        assert response.status_code == 201
+
+        assert FileUpload.objects.count() != upload_count_before
+        upload = FileUpload.objects.last()
+
+        assert upload.name == f'{upload.uuid.hex}_@upload-version-3.0.xpi'
+        assert upload.source == amo.UPLOAD_SOURCE_ADDON_API
+        assert upload.user == self.user
+        assert upload.version == '3.0'
+        assert upload.ip_address == '127.0.3.1'
+
+        data = response.json()
+        assert data['uuid'] == upload.uuid.hex
+
+    def test_list(self):
+        response = self.client.get(
+            self.list_url,
+        )
+        data = response.json()['results']
+        assert len(data) == 1  # only the users own uploads
+        assert data[0]['uuid'] == self.upload.uuid.hex
+        assert data[0]['url'] == self.detail_url
+
+    def test_api_unavailable(self):
+        with override_settings(DRF_API_GATES={'v5': []}):
+            response = self.client.get(
+                self.list_url,
+            )
+        assert response.status_code == 403
+
+    def test_retrieve(self):
+        response = self.client.get(self.detail_url)
+        data = response.json()
+        assert data['uuid'] == self.upload.uuid.hex
+        assert data['url'] == self.detail_url
+
+    def test_cannot_retrieve_other_uploads(self):
+        detail_url = reverse_ns(
+            'addon-upload-detail',
+            kwargs={'uuid': self.other_user_upload.uuid.hex},
+            api_version='v5',
+        )
+        response = self.client.get(
+            detail_url,
+        )
+        assert response.status_code == 404
+
+
+class TestFileUploadViewSetJWTAuth(FileUploadTestMixin, TestCase):
+    client_class = JWTAPITestClient
+
+
+class TestFileUploadViewSetWebTokenAuth(FileUploadTestMixin, TestCase):
+    client_class = APITestClient

--- a/src/olympia/files/tests/test_views.py
+++ b/src/olympia/files/tests/test_views.py
@@ -127,7 +127,7 @@ class FileUploadTestMixin:
 
         assert response.status_code == 201
 
-        assert FileUpload.objects.count() != upload_count_before
+        assert FileUpload.objects.count() == upload_count_before + 1
         upload = FileUpload.objects.last()
 
         assert upload.name == f'{upload.uuid.hex}_@upload-version-3.0.xpi'

--- a/src/olympia/files/views.py
+++ b/src/olympia/files/views.py
@@ -65,7 +65,6 @@ class FileUploadViewSet(CreateModelMixin, ReadOnlyModelViewSet):
         return super().get_queryset().filter(user=self.request.user)
 
     def create(self, request):
-        # TODO: move most/all of this logic to the serializer
         if 'upload' in request.FILES:
             filedata = request.FILES['upload']
         else:

--- a/src/olympia/files/views.py
+++ b/src/olympia/files/views.py
@@ -2,12 +2,23 @@ from django.core.exceptions import PermissionDenied
 from django import http, shortcuts
 from django.utils.crypto import constant_time_compare
 
+from rest_framework import exceptions, status
+from rest_framework.mixins import CreateModelMixin
+from rest_framework.response import Response
+from rest_framework.viewsets import ReadOnlyModelViewSet
+
 import olympia.core.logger
 
+from olympia import amo
 from olympia.amo.decorators import use_primary_db
 from olympia.amo.utils import HttpResponseXSendFile
+from olympia.api.authentication import JWTKeyAuthentication, WebTokenAuthentication
+from olympia.api.permissions import AllowOwner, APIGatePermission
+from olympia.devhub import tasks as devhub_tasks
+from olympia.devhub.permissions import IsSubmissionAllowedFor
 
 from .models import FileUpload
+from .serializers import FileUploadSerializer
 
 
 log = olympia.core.logger.getLogger('z.addons')
@@ -37,3 +48,48 @@ def serve_file_upload(request, uuid):
     return HttpResponseXSendFile(
         request, upload.path, content_type='application/octet-stream'
     )
+
+
+class FileUploadViewSet(CreateModelMixin, ReadOnlyModelViewSet):
+    queryset = FileUpload.objects.all()
+    serializer_class = FileUploadSerializer
+    permission_classes = [
+        APIGatePermission('addon-submission-api'),
+        AllowOwner,
+        IsSubmissionAllowedFor,
+    ]
+    authentication_classes = [JWTKeyAuthentication, WebTokenAuthentication]
+    lookup_field = 'uuid'
+
+    def get_queryset(self):
+        return super().get_queryset().filter(user=self.request.user)
+
+    def create(self, request):
+        # TODO: move most/all of this logic to the serializer
+        if 'upload' in request.FILES:
+            filedata = request.FILES['upload']
+        else:
+            raise exceptions.ValidationError(
+                'Missing "upload" key in multipart file data.',
+                status.HTTP_400_BAD_REQUEST,
+            )
+        channel = amo.CHANNEL_CHOICES_LOOKUP.get(request.POST.get('channel'))
+        if not channel:
+            raise exceptions.ValidationError(
+                'Missing "channel" arg.',
+                status.HTTP_400_BAD_REQUEST,
+            )
+
+        upload = FileUpload.from_post(
+            filedata,
+            filedata.name,
+            filedata.size,
+            channel=channel,
+            source=amo.UPLOAD_SOURCE_ADDON_API,
+            user=request.user,
+        )
+
+        devhub_tasks.validate(upload, listed=(channel == amo.RELEASE_CHANNEL_LISTED))
+        headers = self.get_success_headers({})
+        data = self.get_serializer(instance=upload).data
+        return Response(data, status=status.HTTP_201_CREATED, headers=headers)

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1612,6 +1612,7 @@ DRF_API_GATES = {
         'addons-search-_score-field',
         'ratings-can_reply',
         'ratings-score-filter',
+        'addon-submission-api',
     ),
 }
 


### PR DESCRIPTION
part of #7811 - just the file upload

1). Upload the file to be validated via POSTing to `api/v5/addons/upload/` to create a FileUpload (returns a serialized response that contains the upload UUID). The upload is where channel is set.
2) optional - you can check on validation status at `api/v5/addons/upload/<uuid>`