### PR TITLE
Add 'utm' parameters to Source code submission links

### DIFF
--- a/src/olympia/devhub/templates/devhub/addons/submit/describe_minimal.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/describe_minimal.html
@@ -25,7 +25,7 @@
         {% if sources_provided %}
           <p>
             <span class="req">{{ _('Remember') }}</span>:
-            {% trans policy_requirements_open='<a href="https://extensionworkshop.com/documentation/publish/source-code-submission/">'|safe, policy_requirements_close='</a>'|safe %}
+            {% trans policy_requirements_open='<a href="https://extensionworkshop.com/documentation/publish/source-code-submission/?utm_source=addons.mozilla.org&utm_medium=devhub&utm_content=submission-flow">'|safe, policy_requirements_close='</a>'|safe %}
             If you submitted source code, but did not include instructions, you must provide them here.
             Enter step-by-step build instructions to create an exact copy of the add-on code, per
             {{ policy_requirements_open }}policy requirements{{ policy_requirements_close }}.


### PR DESCRIPTION
Fixes [#17723](https://github.com/mozilla/addons-server/issues/17723)
Added the `utm` parameters to the add-on source code submission upload links displayed in the add-on submission flow