### PR TITLE
Expose addons-linter version at /__version__

### DIFF
--- a/src/olympia/amo/tests/test_views.py
+++ b/src/olympia/amo/tests/test_views.py
@@ -529,6 +529,8 @@ class TestVersion(TestCase):
             sys.version_info.minor,
         )
         assert content['django'] == f'{django.VERSION[0]}.{django.VERSION[1]}'
+        assert 'addons-linter' in content
+        assert '.' in content['addons-linter']
 
 
 class TestSiteStatusAPI(TestCase):

--- a/src/olympia/amo/views.py
+++ b/src/olympia/amo/views.py
@@ -141,15 +141,22 @@ def loaded(request):
 @non_atomic_requests
 def version(request):
     path = os.path.join(settings.ROOT, 'version.json')
-    py_info = sys.version_info
     with open(path) as f:
         contents = json.loads(f.read())
+
+    py_info = sys.version_info
     contents['python'] = '{major}.{minor}'.format(
         major=py_info.major, minor=py_info.minor
     )
     contents['django'] = '{major}.{minor}'.format(
         major=django.VERSION[0], minor=django.VERSION[1]
     )
+
+    path = os.path.join(settings.ROOT, 'package.json')
+    with open(path) as f:
+        data = json.loads(f.read())
+        contents['addons-linter'] = data['dependencies']['addons-linter']
+
     res = HttpResponse(json.dumps(contents), content_type='application/json')
     res.headers['Access-Control-Allow-Origin'] = '*'
     return res


### PR DESCRIPTION
Fixes #17939

---

This patch adds the addons-linter version to the `__version__` response.

#### QA instructions for localdev

Please build https://github.com/mozilla/addons-nginx locally to test this patch:

```
git clone https://github.com/mozilla/addons-nginx
cd addons-nginx
docker build -t addons/addons-nginx .
```

Then reload your addons-server stack:

```
cd ../addons-server
docker-compose up -d
# the command above should say something like "Recreating addons-server_nginx_1 ... done"
```