### PR TITLE
drop 'files' from v5 addons api endpoints

### DIFF
--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -242,13 +242,9 @@ class MinimalVersionSerializer(serializers.ModelSerializer):
     def to_representation(self, instance):
         repr = super().to_representation(instance)
         request = self.context.get('request', None)
-        if 'file' in repr:
-            # TODO: rewrite this after once frontend supports file in v5 only include
-            # file, and files otherwise.
+        if 'file' in repr and request and is_gate_active(request, 'version-files'):
             # In v3/v4 files is expected to be a list but now we only have one file.
-            repr['files'] = [repr['file']]
-            if request and is_gate_active(request, 'version-files'):
-                del repr['file']
+            repr['files'] = [repr.pop('file')]
         return repr
 
 

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -1256,15 +1256,16 @@ class TestVersionSerializerOutput(TestCase):
     def test_version_files_or_file(self):
         self.version = addon_factory().current_version
         result = self.serialize()
-        # default case, both file and files (until frontend supports file in v5)
+        # default case, file
         assert 'file' in result
-        assert 'files' in result
-        assert result['files'] == [result['file']]
+        assert 'files' not in result
+        default_file_result = result['file']
 
         with override_settings(DRF_API_GATES={self.request.version: ['version-files']}):
             result = self.serialize()
             assert 'file' not in result
             assert 'files' in result
+            assert result['files'] == [default_file_result]
 
 
 class TestVersionListSerializerOutput(TestCase):
@@ -1378,7 +1379,6 @@ class TestLanguageToolsSerializerOutput(TestCase):
         assert set(result['current_compatible_version'].keys()) == {
             'id',
             'file',
-            'files',
             'reviewed',
             'version',
         }

--- a/src/olympia/reviewers/tests/test_serializers.py
+++ b/src/olympia/reviewers/tests/test_serializers.py
@@ -380,7 +380,7 @@ class TestAddonBrowseVersionSerializerFileOnly(TestCase):
         data = self.serialize()
         assert data['id'] == self.version.pk
         assert 'file' in data
-        assert len(data.keys()) == 3  # temporarily we have an extra 'files' item
+        assert len(data.keys()) == 2
 
 
 class TestAddonBrowseVersionSerializer(TestCase):
@@ -600,7 +600,7 @@ class TestAddonCompareVersionSerializerFileOnly(TestCase):
         data = self.serialize(parent_version=parent_version)
         assert data['id'] == self.version.pk
         assert 'file' in data
-        assert len(data.keys()) == 3  # temporarily we have an extra 'files' item
+        assert len(data.keys()) == 2
 
 
 class TestAddonCompareVersionSerializer(TestCase):

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -7119,7 +7119,7 @@ class TestReviewAddonVersionViewSetDetail(
         )
 
         # make sure we only returned `id` and `file` properties
-        assert len(result.keys()) == 3  # temporarily we have an extra 'files' item
+        assert len(result.keys()) == 2
 
     def test_file_only_false(self):
         user = UserProfile.objects.create(username='reviewer')
@@ -8214,7 +8214,7 @@ class TestReviewAddonVersionCompareViewSet(
         assert change['type'] == 'insert'
 
         # make sure we only returned `id` and `file` properties
-        assert len(result.keys()) == 3  # temporarily we have an extra 'files' item
+        assert len(result.keys()) == 2
 
     def test_file_only_false(self):
         user = UserProfile.objects.create(username='reviewer')


### PR DESCRIPTION
fixes #17955 - don't merge until after the 2021.09.30 tag