### PR TITLE
refactor so we're using the exact same throttles for both apis

### DIFF
--- a/src/olympia/api/throttling.py
+++ b/src/olympia/api/throttling.py
@@ -94,3 +94,47 @@ class ThrottleOnlyUnsafeMethodsMixin:
             return super().allow_request(request, view)
         else:
             return True
+
+
+class BurstUserAddonUploadThrottle(
+    ThrottleOnlyUnsafeMethodsMixin, GranularUserRateThrottle
+):
+    scope = 'burst_user_addon_upload'
+    rate = '3/minute'
+
+
+class HourlyUserAddonUploadThrottle(
+    ThrottleOnlyUnsafeMethodsMixin, GranularUserRateThrottle
+):
+    scope = 'hourly_user_addon_upload'
+    rate = '10/hour'
+
+
+class DailyUserAddonUploadThrottle(
+    ThrottleOnlyUnsafeMethodsMixin, GranularUserRateThrottle
+):
+    scope = 'daily_user_addon_upload'
+    rate = '24/day'
+
+
+class BurstIPAddonUploadThrottle(
+    ThrottleOnlyUnsafeMethodsMixin, GranularIPRateThrottle
+):
+    scope = 'burst_ip_addon_upload'
+    rate = '6/minute'
+
+
+class HourlyIPAddonUploadThrottle(
+    ThrottleOnlyUnsafeMethodsMixin, GranularIPRateThrottle
+):
+    scope = 'hourly_ip_addon_upload'
+    rate = '50/hour'
+
+
+addon_upload_throttles = (
+    BurstUserAddonUploadThrottle,
+    HourlyUserAddonUploadThrottle,
+    DailyUserAddonUploadThrottle,
+    BurstIPAddonUploadThrottle,
+    HourlyIPAddonUploadThrottle,
+)


### PR DESCRIPTION
fixes #18023 - not much actual changes in the end

nb. not replicating the langpack bypass was intentional - releng will need a special endpoint anyway