### PR TITLE
Fix scanner results rule exclusion when excluding multiple rules

### DIFF
--- a/src/olympia/scanners/tests/test_admin.py
+++ b/src/olympia/scanners/tests/test_admin.py
@@ -572,8 +572,10 @@ class TestScannerResultAdmin(TestCase):
 
         # And finally check that the correct options are selected.
         options = [
-            x.attrib['value'] for x in doc(
-                '#changelist-filter form select[name=exclude_rule] option[selected]')
+            x.attrib['value']
+            for x in doc(
+                '#changelist-filter form select[name=exclude_rule] option[selected]'
+            )
         ]
         expected = [str(rule_bar.pk), str(rule_hello.pk)]
         assert options == expected


### PR DESCRIPTION
Previous logic didn't work when you excluded X rules and you had results matching those X rules with X > 1.

Fixes #18040