### PR TITLE
Display more accurate error messages to users when zip file is invalid

### DIFF
--- a/src/olympia/devhub/tasks.py
+++ b/src/olympia/devhub/tasks.py
@@ -47,6 +47,7 @@ from olympia.files.utils import (
     parse_addon,
     SafeZip,
     UnsupportedFileType,
+    InvalidZipFile,
 )
 from olympia.versions.models import Version
 from olympia.devhub import file_validation_annotations as annotations
@@ -201,6 +202,15 @@ def validation_task(fn):
                 type_='error',
                 message=exc.message,
                 msg_id='unsupported_filetype',
+            )
+            return results
+        except InvalidZipFile as exc:
+            results = deepcopy(amo.VALIDATOR_SKELETON_RESULTS)
+            annotations.insert_validation_message(
+                results,
+                type_='error',
+                message=exc.message,
+                msg_id='invalid_zip_file',
             )
             return results
         except BadZipFile:

--- a/src/olympia/files/tests/test_utils.py
+++ b/src/olympia/files/tests/test_utils.py
@@ -1095,12 +1095,12 @@ class TestSafeZip(TestCase):
             'src/olympia/files/'
             'fixtures/files/archive-with-invalid-chars-in-filenames.zip'
         )
-        with pytest.raises(forms.ValidationError):
+        with pytest.raises(utils.InvalidZipFile):
             utils.SafeZip(filename)
 
     def test_raises_validation_error_when_uncompressed_size_is_too_large(self):
         with override_settings(MAX_ZIP_UNCOMPRESSED_SIZE=1000):
-            with pytest.raises(forms.ValidationError):
+            with pytest.raises(utils.InvalidZipFile):
                 # total uncompressed size of this xpi is 126kb
                 utils.SafeZip(get_addon_file('mozilla_static_theme.zip'))
 
@@ -1110,27 +1110,27 @@ class TestArchiveMemberValidator(TestCase):
     # `_validate_archive_member_name_and_size` instead.
 
     def test_raises_when_filename_is_none(self):
-        with pytest.raises(forms.ValidationError):
+        with pytest.raises(utils.InvalidZipFile):
             utils._validate_archive_member_name_and_size(None, 123)
 
     def test_raises_when_filesize_is_none(self):
-        with pytest.raises(forms.ValidationError):
+        with pytest.raises(utils.InvalidZipFile):
             utils._validate_archive_member_name_and_size('filename', None)
 
     def test_raises_when_filename_is_dot_dot_slash(self):
-        with pytest.raises(forms.ValidationError):
+        with pytest.raises(utils.InvalidZipFile):
             utils._validate_archive_member_name_and_size('../', 123)
 
     def test_raises_when_filename_starts_with_slash(self):
-        with pytest.raises(forms.ValidationError):
+        with pytest.raises(utils.InvalidZipFile):
             utils._validate_archive_member_name_and_size('/..', 123)
 
     def test_raises_when_filename_contains_backslashes(self):
-        with pytest.raises(forms.ValidationError):
+        with pytest.raises(utils.InvalidZipFile):
             utils._validate_archive_member_name_and_size('path\\to\\file.txt', 123)
 
     def test_raises_when_filename_is_dot_dot(self):
-        with pytest.raises(forms.ValidationError):
+        with pytest.raises(utils.InvalidZipFile):
             utils._validate_archive_member_name_and_size('..', 123)
 
     def test_does_not_raise_when_filename_is_dot_dot_extension(self):
@@ -1138,7 +1138,7 @@ class TestArchiveMemberValidator(TestCase):
 
     @override_settings(FILE_UNZIP_SIZE_LIMIT=100)
     def test_raises_when_filesize_is_above_limit(self):
-        with pytest.raises(forms.ValidationError):
+        with pytest.raises(utils.InvalidZipFile):
             utils._validate_archive_member_name_and_size(
                 'filename', settings.FILE_UNZIP_SIZE_LIMIT + 100
             )


### PR DESCRIPTION
Fixes #18061 

---

Limited to `SafeZip` exceptions for now but should be useful to end users already.

You can test this change by uploading an add-on like the one provided in https://github.com/mozilla/addons-server/issues/6111#issuecomment-934422791 or another add-on (from the repo).