### PR TITLE
enable patches for Version detail api

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1594,8 +1594,8 @@ class Addon(OnChangeMixin, ModelBase):
         for category in set(self.all_categories) - set(categories):
             AddonCategory.objects.filter(addon=self, category_id=category.id).delete()
 
-        # Remove old, outdated categories cache on the model.
-        del self.all_categories
+        # Update categories cache on the model.
+        self.all_categories = categories
 
         # Make sure the add-on is properly re-indexed
         update_search_index(Addon, self)

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -1272,6 +1272,13 @@ class TestVersionSerializerOutput(TestCase):
             assert 'files' in result
             assert result['files'] == [default_file_result]
 
+    def test_readonly_fields(self):
+        serializer = VersionSerializer()
+        fields_read_only = {
+            name for name, field in serializer.get_fields().items() if field.read_only
+        }
+        assert fields_read_only == set(serializer.Meta.read_only_fields)
+
 
 class TestVersionListSerializerOutput(TestCase):
     def setUp(self):

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -349,6 +349,7 @@ class AddonVersionViewSet(
     AddonChildMixin,
     CreateModelMixin,
     RetrieveModelMixin,
+    UpdateModelMixin,
     ListModelMixin,
     GenericViewSet,
 ):
@@ -407,7 +408,7 @@ class AddonVersionViewSet(
             # super + check_object_permission() ourselves, passing down the
             # addon object directly.
             return super().check_object_permissions(request, self.get_addon_object())
-        elif self.action == 'create':
+        elif self.action in ('create', 'update', 'partial_update'):
             self.permission_classes = [
                 APIGatePermission('addon-submission-api'),
                 IsAuthenticated,
@@ -439,6 +440,12 @@ class AddonVersionViewSet(
                     'addon', [AnyOf(AllowListedViewerOrReviewer, AllowAddonAuthor)]
                 )
             ]
+        if self.action in ('update', 'partial_update'):
+            self.permission_classes = [
+                APIGatePermission('addon-submission-api'),
+                AllowRelatedObjectPermissions('addon', [AllowAddonAuthor]),
+            ]
+
         super().check_object_permissions(request, obj)
 
     def get_queryset(self):

--- a/src/olympia/constants/applications.py
+++ b/src/olympia/constants/applications.py
@@ -8,6 +8,8 @@ from .base import (
     ADDON_LPAPP,
     ADDON_PLUGIN,
     ADDON_STATICTHEME,
+    DEFAULT_WEBEXT_MIN_VERSION,
+    DEFAULT_WEBEXT_MIN_VERSION_ANDROID,
 )
 
 from olympia.versions.compare import version_int as vint
@@ -174,6 +176,11 @@ FAKE_MAX_VERSION = '65535'
 D2C_MIN_VERSIONS = {
     FIREFOX.id: '4.0',
     ANDROID.id: '11.0',
+}
+
+DEFAULT_WEBEXT_MIN_VERSIONS = {
+    FIREFOX: DEFAULT_WEBEXT_MIN_VERSION,
+    ANDROID: DEFAULT_WEBEXT_MIN_VERSION_ANDROID,
 }
 
 for _app in APPS_ALL.values():


### PR DESCRIPTION
fixes mozilla/addons#8527

I went backwards and forwards with a few different ways of handling the problem we have with writing to fields that are `cached_property`s wrapped around one-to-many fields - we have it here with `compatible_apps`, and did with Addon with categories. Implementing full serializers for the underlying models is an option but: we can't set the values with the contents of our ES index, (and there's no in-built support in DRF for creating new instances anyway, so it's not a complete solution).  

I've gone with defining a separate `set_compatible_apps` method, like with categories, and creating the unsaved instances in the field.  

Other options I played around with: could change the `compatible_apps` setter to actually save the instances (anywhere that intended to just set a cached value, such as the ES serializer initialization, would have to be changed so we don't actually try to save the values); still have the setter property as now but also flag (with `ModelState`) when the cached value has been set outside of the model transformer/initialization, and then override the model `save` method to also save the `compatible_apps` instances if they've been flagged (added extra complexity that could end up being pretty confusing to future us).