### PR TITLE
correct FileUpload serializer's channel field

### DIFF
--- a/src/olympia/files/serializers.py
+++ b/src/olympia/files/serializers.py
@@ -12,8 +12,8 @@ class FileUploadSerializer(serializers.ModelSerializer):
     uuid = serializers.UUIDField(format='hex')
     channel = ReverseChoiceField(
         choices=[
-            (False, amo.CHANNEL_CHOICES_API[amo.RELEASE_CHANNEL_UNLISTED]),
-            (True, amo.CHANNEL_CHOICES_API[amo.RELEASE_CHANNEL_LISTED]),
+            (True, amo.CHANNEL_CHOICES_API[amo.RELEASE_CHANNEL_UNLISTED]),
+            (False, amo.CHANNEL_CHOICES_API[amo.RELEASE_CHANNEL_LISTED]),
         ],
         source='automated_signing',
     )

--- a/src/olympia/files/tests/test_serializers.py
+++ b/src/olympia/files/tests/test_serializers.py
@@ -20,7 +20,7 @@ class TestFileUploadSerializer(TestCase):
         self.request.version = api_version
 
     def test_basic(self):
-        file_upload = FileUpload(version='123')
+        file_upload = FileUpload(version='123', automated_signing=True)
         data = FileUploadSerializer(
             instance=file_upload, context={'request': self.request}
         ).data
@@ -40,7 +40,7 @@ class TestFileUploadSerializer(TestCase):
         }
 
         file_upload.update(
-            automated_signing=True,
+            automated_signing=False,
             validation=json.dumps([{'something': 'happened'}]),
         )
         data = FileUploadSerializer(


### PR DESCRIPTION
fixes mozilla/addons#8546