### PR TITLE
Add an admin for ReviewActionReasonLog

### DIFF
--- a/src/olympia/activity/admin.py
+++ b/src/olympia/activity/admin.py
@@ -65,18 +65,15 @@ class ReviewActionReasonLogAdmin(admin.ModelAdmin):
     def has_delete_permission(self, request, obj=None):
         return False
 
-    def formfield_for_foreignkey(self, db_field, request, **kwargs):
-        if db_field.name == 'reason':
-            kwargs['queryset'] = ReviewActionReason.objects.filter(
-                is_active__exact=True
-            )
-        return super().formfield_for_foreignkey(db_field, request, **kwargs)
-
     def get_form(self, request, obj=None, **kwargs):
         form = super(ReviewActionReasonLogAdmin, self).get_form(request, obj, **kwargs)
         form.base_fields['reason'].widget.can_add_related = False
         form.base_fields['reason'].widget.can_change_related = False
         form.base_fields['reason'].empty_label = None
+        form.base_fields['reason'].choices = [
+            (reason.id, reason.labelled_name())
+            for reason in ReviewActionReason.objects.all()
+        ]
         return form
 
 

--- a/src/olympia/activity/admin.py
+++ b/src/olympia/activity/admin.py
@@ -37,26 +37,26 @@ class ReviewActionReasonLogAdmin(admin.ModelAdmin):
     fields = (
         'created',
         'activity_log',
-        'user_email',
+        'activity_log__user__email',
         'reason',
     )
     list_display = (
         'created',
         'activity_log',
         'reason',
-        'user_email',
+        'activity_log__user__email',
     )
     list_filter = ('reason',)
+    list_select_related = ('activity_log__user',)
     readonly_fields = (
         'created',
         'activity_log',
-        'user_email',
+        'activity_log__user__email',
     )
     search_fields = ('activity_log__user__email',)
     view_on_site = False
 
-    @admin.display()
-    def user_email(self, obj):
+    def activity_log__user__email(self, obj):
         return obj.activity_log.user.email
 
     def has_add_permission(self, request):
@@ -76,6 +76,7 @@ class ReviewActionReasonLogAdmin(admin.ModelAdmin):
         form = super(ReviewActionReasonLogAdmin, self).get_form(request, obj, **kwargs)
         form.base_fields['reason'].widget.can_add_related = False
         form.base_fields['reason'].widget.can_change_related = False
+        form.base_fields['reason'].empty_label = None
         return form
 
 

--- a/src/olympia/activity/admin.py
+++ b/src/olympia/activity/admin.py
@@ -67,7 +67,7 @@ class ReviewActionReasonLogAdmin(admin.ModelAdmin):
 
     def formfield_for_foreignkey(self, db_field, request, **kwargs):
         if db_field.name == 'reason':
-            kwargs["queryset"] = ReviewActionReason.objects.filter(
+            kwargs['queryset'] = ReviewActionReason.objects.filter(
                 is_active__exact=True
             )
         return super().formfield_for_foreignkey(db_field, request, **kwargs)

--- a/src/olympia/activity/admin.py
+++ b/src/olympia/activity/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 
 from .models import ActivityLog, ReviewActionReasonLog
-from olympia.reviewers.models import CannedResponse, ReviewActionReason
+from olympia.reviewers.models import ReviewActionReason
 
 
 class ActivityLogAdmin(admin.ModelAdmin):
@@ -71,6 +71,12 @@ class ReviewActionReasonLogAdmin(admin.ModelAdmin):
                 is_active__exact=True
             )
         return super().formfield_for_foreignkey(db_field, request, **kwargs)
+
+    def get_form(self, request, obj=None, **kwargs):
+        form = super(ReviewActionReasonLogAdmin, self).get_form(request, obj, **kwargs)
+        form.base_fields['reason'].widget.can_add_related = False
+        form.base_fields['reason'].widget.can_change_related = False
+        return form
 
 
 admin.site.register(ActivityLog, ActivityLogAdmin)

--- a/src/olympia/activity/admin.py
+++ b/src/olympia/activity/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 
 from .models import ActivityLog, ReviewActionReasonLog
+from olympia.reviewers.models import CannedResponse, ReviewActionReason
 
 
 class ActivityLogAdmin(admin.ModelAdmin):
@@ -63,6 +64,13 @@ class ReviewActionReasonLogAdmin(admin.ModelAdmin):
 
     def has_delete_permission(self, request, obj=None):
         return False
+
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        if db_field.name == 'reason':
+            kwargs["queryset"] = ReviewActionReason.objects.filter(
+                is_active__exact=True
+            )
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
 
 admin.site.register(ActivityLog, ActivityLogAdmin)

--- a/src/olympia/activity/admin.py
+++ b/src/olympia/activity/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import ActivityLog
+from .models import ActivityLog, ReviewActionReasonLog
 
 
 class ActivityLogAdmin(admin.ModelAdmin):
@@ -31,4 +31,39 @@ class ActivityLogAdmin(admin.ModelAdmin):
         return False
 
 
+class ReviewActionReasonLogAdmin(admin.ModelAdmin):
+    date_hierarchy = 'created'
+    fields = (
+        'created',
+        'activity_log',
+        'user_email',
+        'reason',
+    )
+    list_display = (
+        'created',
+        'activity_log',
+        'reason',
+        'user_email',
+    )
+    list_filter = ('reason',)
+    readonly_fields = (
+        'created',
+        'activity_log',
+        'user_email',
+    )
+    search_fields = ('activity_log__user__email',)
+    view_on_site = False
+
+    @admin.display()
+    def user_email(self, obj):
+        return obj.activity_log.user.email
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+
 admin.site.register(ActivityLog, ActivityLogAdmin)
+admin.site.register(ReviewActionReasonLog, ReviewActionReasonLogAdmin)

--- a/src/olympia/activity/tests/test_admin.py
+++ b/src/olympia/activity/tests/test_admin.py
@@ -1,0 +1,85 @@
+from django.urls import reverse
+
+from pyquery import PyQuery as pq
+
+from olympia import amo
+from olympia.amo.tests import TestCase, user_factory
+from olympia.activity.models import ActivityLog, ReviewActionReasonLog
+from olympia.reviewers.models import ReviewActionReason
+
+
+class TestReviewActionReasonLogAdmin(TestCase):
+    def setUp(self):
+        self.admin_home_url = reverse('admin:index')
+        self.list_url = reverse('admin:activity_reviewactionreasonlog_changelist')
+        self.reason_1 = ReviewActionReason.objects.create(
+            name='reason 1',
+            is_active=True,
+        )
+        self.reason_2 = ReviewActionReason.objects.create(
+            name='reason 2',
+            is_active=True,
+        )
+        self.inactive_reason = ReviewActionReason.objects.create(
+            name='b inactive reason',
+            is_active=False,
+        )
+
+    def test_can_see_module_in_admin_with_super_access(self):
+        user = user_factory(email='someone@mozilla.com')
+        self.grant_permission(user, '*:*')
+        self.client.login(email=user.email)
+        response = self.client.get(self.admin_home_url, follow=True)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        assert doc('.model-reviewactionreasonlog')
+
+    def test_can_not_see_module_in_admin_without_permissions(self):
+        user = user_factory(email='someone@mozilla.com')
+        self.client.login(email=user.email)
+        response = self.client.get(self.admin_home_url, follow=True)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        assert not doc('.model-reviewactionreasonlog')
+
+    def test_select_includes_only_active_reasons(self):
+        user = user_factory(email='someone@mozilla.com')
+        self.grant_permission(user, '*:*')
+        self.client.login(email=user.email)
+        activity_log = ActivityLog.objects.create(action=amo.LOG.APPROVE_VERSION.id)
+        reason_log = ReviewActionReasonLog.objects.create(
+            activity_log=activity_log,
+            reason=self.reason_1,
+        )
+
+        detail_url = reverse(
+            'admin:activity_reviewactionreasonlog_change', args=(reason_log.pk,)
+        )
+        response = self.client.get(detail_url, follow=True)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        # Only the two active reasons should be available.
+        reason_options = doc('#id_reason option')
+        assert len(reason_options) == 2
+        assert reason_options.eq(0).text() == self.reason_1.name
+        assert reason_options.eq(1).text() == self.reason_1.name
+
+    def test_select_includes_inactive_reason_if_current_reason(self):
+        user = user_factory(email='someone@mozilla.com')
+        self.grant_permission(user, '*:*')
+        self.client.login(email=user.email)
+        activity_log = ActivityLog.objects.create(action=amo.LOG.APPROVE_VERSION.id)
+        reason_log = ReviewActionReasonLog.objects.create(
+            activity_log=activity_log,
+            reason=self.inactive_reason,
+        )
+
+        detail_url = reverse(
+            'admin:activity_reviewactionreasonlog_change', args=(reason_log.pk,)
+        )
+        response = self.client.get(detail_url, follow=True)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        # All three reasons should be available, as the inactive one is current.
+        reason_options = doc('#id_reason option')
+        assert len(reason_options) == 3

--- a/src/olympia/activity/tests/test_admin.py
+++ b/src/olympia/activity/tests/test_admin.py
@@ -62,7 +62,7 @@ class TestReviewActionReasonLogAdmin(TestCase):
         reason_options = doc('#id_reason option')
         assert len(reason_options) == 2
         assert reason_options.eq(0).text() == self.reason_1.name
-        assert reason_options.eq(1).text() == self.reason_1.name
+        assert reason_options.eq(1).text() == self.reason_2.name
 
     def test_select_includes_inactive_reason_if_current_reason(self):
         user = user_factory(email='someone@mozilla.com')

--- a/src/olympia/activity/tests/test_admin.py
+++ b/src/olympia/activity/tests/test_admin.py
@@ -56,5 +56,5 @@ class TestReviewActionReasonLogAdmin(TestCase):
         doc = pq(response.content)
         reason_options = doc('#id_reason option')
         assert len(reason_options) == 2
-        assert reason_options.eq(0).text() == inactive_reason.name + ' (** inactive **)'
+        assert reason_options.eq(0).text() == '(** inactive **) ' + inactive_reason.name
         assert reason_options.eq(1).text() == reason_1.name

--- a/src/olympia/activity/tests/test_admin.py
+++ b/src/olympia/activity/tests/test_admin.py
@@ -12,18 +12,6 @@ class TestReviewActionReasonLogAdmin(TestCase):
     def setUp(self):
         self.admin_home_url = reverse('admin:index')
         self.list_url = reverse('admin:activity_reviewactionreasonlog_changelist')
-        self.reason_1 = ReviewActionReason.objects.create(
-            name='reason 1',
-            is_active=True,
-        )
-        self.reason_2 = ReviewActionReason.objects.create(
-            name='reason 2',
-            is_active=True,
-        )
-        self.inactive_reason = ReviewActionReason.objects.create(
-            name='b inactive reason',
-            is_active=False,
-        )
 
     def test_can_see_module_in_admin_with_super_access(self):
         user = user_factory(email='someone@mozilla.com')
@@ -42,14 +30,22 @@ class TestReviewActionReasonLogAdmin(TestCase):
         doc = pq(response.content)
         assert not doc('.model-reviewactionreasonlog')
 
-    def test_select_includes_only_active_reasons(self):
+    def test_select_labels_inactive_reasons(self):
+        reason_1 = ReviewActionReason.objects.create(
+            name='reason 1',
+            is_active=True,
+        )
+        inactive_reason = ReviewActionReason.objects.create(
+            name='inactive reason',
+            is_active=False,
+        )
         user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, '*:*')
         self.client.login(email=user.email)
         activity_log = ActivityLog.objects.create(action=amo.LOG.APPROVE_VERSION.id)
         reason_log = ReviewActionReasonLog.objects.create(
             activity_log=activity_log,
-            reason=self.reason_1,
+            reason=reason_1,
         )
 
         detail_url = reverse(
@@ -58,28 +54,7 @@ class TestReviewActionReasonLogAdmin(TestCase):
         response = self.client.get(detail_url, follow=True)
         assert response.status_code == 200
         doc = pq(response.content)
-        # Only the two active reasons should be available.
         reason_options = doc('#id_reason option')
         assert len(reason_options) == 2
-        assert reason_options.eq(0).text() == self.reason_1.name
-        assert reason_options.eq(1).text() == self.reason_2.name
-
-    def test_select_includes_inactive_reason_if_current_reason(self):
-        user = user_factory(email='someone@mozilla.com')
-        self.grant_permission(user, '*:*')
-        self.client.login(email=user.email)
-        activity_log = ActivityLog.objects.create(action=amo.LOG.APPROVE_VERSION.id)
-        reason_log = ReviewActionReasonLog.objects.create(
-            activity_log=activity_log,
-            reason=self.inactive_reason,
-        )
-
-        detail_url = reverse(
-            'admin:activity_reviewactionreasonlog_change', args=(reason_log.pk,)
-        )
-        response = self.client.get(detail_url, follow=True)
-        assert response.status_code == 200
-        doc = pq(response.content)
-        # All three reasons should be available, as the inactive one is current.
-        reason_options = doc('#id_reason option')
-        assert len(reason_options) == 3
+        assert reason_options.eq(0).text() == inactive_reason.name + ' (** inactive **)'
+        assert reason_options.eq(1).text() == reason_1.name

--- a/src/olympia/reviewers/models.py
+++ b/src/olympia/reviewers/models.py
@@ -1133,7 +1133,7 @@ class ReviewActionReason(ModelBase):
     name = models.CharField(max_length=255)
 
     def labelled_name(self):
-        return self.name + ' (** inactive **)' if not self.is_active else self.name
+        return '(** inactive **) ' + self.name if not self.is_active else self.name
 
     class Meta:
         ordering = ('name',)

--- a/src/olympia/reviewers/models.py
+++ b/src/olympia/reviewers/models.py
@@ -1132,6 +1132,9 @@ class ReviewActionReason(ModelBase):
     )
     name = models.CharField(max_length=255)
 
+    def labelled_name(self):
+        return self.name + ' (** inactive **)' if not self.is_active else self.name
+
     class Meta:
         ordering = ('name',)
 


### PR DESCRIPTION
Fixes #18301 

This is my first stab at this. I think it will be fairly helpful in terms of being able to find the log that needs to be fixed. There is a filter for `reason`, and I added a search that can be used for the reviewer's email address. It's not perfect, but it might do for now, or maybe someone has some suggestions for improvements.

~~One problem that does exist, that I was unable to figure out how to deal with, is the fact that the select that can be used to change the `reason` includes all reasons, not just active reasons, and that is less than ideal. I imagine there is a way to define a queryset to be used to populate this select, but I couldn't find anything in the basic Django admin docs. Suggestions appreciated!~~
- I figured it out! (It *was* in the docs)
