### PR TITLE
make TranslationSerializerField inherit from CharField; add URLTranslationField

### DIFF
--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -15,10 +15,11 @@ from olympia.accounts.serializers import (
 from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.amo.utils import sorted_groupby
 from olympia.api.fields import (
+    EmailTranslationField,
     ESTranslationSerializerField,
     GetTextTranslationSerializerField,
-    OutgoingTranslationField,
     OutgoingURLField,
+    OutgoingURLTranslationField,
     ReverseChoiceField,
     SplitField,
     TranslationSerializerField,
@@ -688,7 +689,7 @@ class AddonSerializer(serializers.ModelSerializer):
     edit_url = serializers.SerializerMethodField()
     has_eula = serializers.SerializerMethodField()
     has_privacy_policy = serializers.SerializerMethodField()
-    homepage = OutgoingTranslationField(required=False)
+    homepage = OutgoingURLTranslationField(required=False)
     icon_url = serializers.SerializerMethodField()
     icons = serializers.SerializerMethodField()
     is_disabled = SplitField(
@@ -707,8 +708,8 @@ class AddonSerializer(serializers.ModelSerializer):
         choices=list(amo.STATUS_CHOICES_API.items()), read_only=True
     )
     summary = TranslationSerializerField(required=False)
-    support_email = TranslationSerializerField(required=False)
-    support_url = OutgoingTranslationField(required=False)
+    support_email = EmailTranslationField(required=False)
+    support_url = OutgoingURLTranslationField(required=False)
     tags = serializers.SerializerMethodField()
     type = ReverseChoiceField(
         choices=list(amo.ADDON_TYPE_CHOICES_API.items()), read_only=True

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -927,7 +927,7 @@ class TestAddonViewSetCreate(UploadMixin, TestCase):
             # 'name'  # don't update - should retain name from the manifest
             'slug': 'addon-slug',
             'summary': {'en-US': 'new summary'},
-            'support_email': {'en-US': 'email@me'},
+            'support_email': {'en-US': 'email@me.me'},
             'support_url': {'en-US': 'https://my.home.page/support/'},
             'version': {'upload': self.upload.uuid, 'license': self.license.id},
         }
@@ -958,8 +958,8 @@ class TestAddonViewSetCreate(UploadMixin, TestCase):
         assert data['slug'] == 'addon-slug' == addon.slug
         assert data['summary'] == {'en-US': 'new summary'}
         assert addon.summary == 'new summary'
-        assert data['support_email'] == {'en-US': 'email@me'}
-        assert addon.support_email == 'email@me'
+        assert data['support_email'] == {'en-US': 'email@me.me'}
+        assert addon.support_email == 'email@me.me'
         assert data['support_url']['url'] == {'en-US': 'https://my.home.page/support/'}
         assert addon.support_url == 'https://my.home.page/support/'
 
@@ -978,6 +978,25 @@ class TestAddonViewSetCreate(UploadMixin, TestCase):
         assert response.data['is_disabled'] is True
         assert addon.is_disabled is True
         assert addon.disabled_by_user is True  # sets the user property
+
+    def test_set_homepage_support_url_email(self):
+        data = {
+            **self.minimal_data,
+            'homepage': {'ro': '#%^%&&%^&^&^*'},
+            'support_email': {'en-US': '#%^%&&%^&^&^*'},
+            'support_url': {'fr': '#%^%&&%^&^&^*'},
+        }
+        response = self.client.post(
+            self.url,
+            data=data,
+        )
+
+        assert response.status_code == 400, response.content
+        assert response.data == {
+            'homepage': ['Enter a valid URL.'],
+            'support_email': ['Enter a valid email address.'],
+            'support_url': ['Enter a valid URL.'],
+        }
 
 
 class TestAddonViewSetCreateJWTAuth(TestAddonViewSetCreate):
@@ -1140,7 +1159,7 @@ class TestAddonViewSetUpdate(TestCase):
             'requires_payment': True,
             'slug': 'addon-slug',
             'summary': {'en-US': 'new summary'},
-            'support_email': {'en-US': 'email@me'},
+            'support_email': {'en-US': 'email@me.me'},
             'support_url': {'en-US': 'https://my.home.page/support/'},
         }
         response = self.client.patch(
@@ -1166,8 +1185,8 @@ class TestAddonViewSetUpdate(TestCase):
         assert data['slug'] == 'addon-slug' == addon.slug
         assert data['summary'] == {'en-US': 'new summary'}
         assert addon.summary == 'new summary'
-        assert data['support_email'] == {'en-US': 'email@me'}
-        assert addon.support_email == 'email@me'
+        assert data['support_email'] == {'en-US': 'email@me.me'}
+        assert addon.support_email == 'email@me.me'
         assert data['support_url']['url'] == {'en-US': 'https://my.home.page/support/'}
         assert addon.support_url == 'https://my.home.page/support/'
 
@@ -1196,6 +1215,24 @@ class TestAddonViewSetUpdate(TestCase):
         assert data['is_disabled'] is True  # still True
         assert addon.is_disabled is True  # still True
         assert addon.disabled_by_user is False  # user property is False,
+
+    def test_set_homepage_support_url_email(self):
+        data = {
+            'homepage': {'ro': '#%^%&&%^&^&^*'},
+            'support_email': {'en-US': '#%^%&&%^&^&^*'},
+            'support_url': {'fr': '#%^%&&%^&^&^*'},
+        }
+        response = self.client.patch(
+            self.url,
+            data=data,
+        )
+
+        assert response.status_code == 400, response.content
+        assert response.data == {
+            'homepage': ['Enter a valid URL.'],
+            'support_email': ['Enter a valid email address.'],
+            'support_url': ['Enter a valid URL.'],
+        }
 
 
 class TestAddonViewSetUpdateJWTAuth(TestAddonViewSetUpdate):

--- a/src/olympia/api/fields.py
+++ b/src/olympia/api/fields.py
@@ -378,7 +378,9 @@ class OutgoingURLTranslationField(OutgoingSerializerMixin, URLTranslationField):
     pass
 
 
-class OutgoingESTranslationField(OutgoingSerializerMixin, ESTranslationSerializerField):
+class OutgoingURLESTranslationField(
+    OutgoingSerializerMixin, ESTranslationSerializerField
+):
     pass
 
 

--- a/src/olympia/api/serializers.py
+++ b/src/olympia/api/serializers.py
@@ -10,7 +10,7 @@ from olympia.zadmin.models import get_config
 
 from .fields import (
     ESTranslationSerializerField,
-    OutgoingESTranslationField,
+    OutgoingURLESTranslationField,
     OutgoingURLTranslationField,
     TranslationSerializerField,
 )
@@ -45,7 +45,7 @@ class BaseESSerializer(serializers.ModelSerializer):
         fields = super().get_fields()
         for key, field in fields.items():
             if isinstance(field, OutgoingURLTranslationField):
-                fields[key] = OutgoingESTranslationField(source=field.source)
+                fields[key] = OutgoingURLESTranslationField(source=field.source)
             elif isinstance(field, TranslationSerializerField):
                 fields[key] = ESTranslationSerializerField(source=field.source)
         return fields

--- a/src/olympia/api/serializers.py
+++ b/src/olympia/api/serializers.py
@@ -11,7 +11,7 @@ from olympia.zadmin.models import get_config
 from .fields import (
     ESTranslationSerializerField,
     OutgoingESTranslationField,
-    OutgoingTranslationField,
+    OutgoingURLTranslationField,
     TranslationSerializerField,
 )
 
@@ -44,7 +44,7 @@ class BaseESSerializer(serializers.ModelSerializer):
         """
         fields = super().get_fields()
         for key, field in fields.items():
-            if isinstance(field, OutgoingTranslationField):
+            if isinstance(field, OutgoingURLTranslationField):
                 fields[key] = OutgoingESTranslationField(source=field.source)
             elif isinstance(field, TranslationSerializerField):
                 fields[key] = ESTranslationSerializerField(source=field.source)

--- a/src/olympia/api/tests/test_fields.py
+++ b/src/olympia/api/tests/test_fields.py
@@ -122,16 +122,16 @@ class TestTranslationSerializerField(TestCase):
         data = {'fr': 'Non mais Allô quoi !', 'en-US': 'No But Hello what!'}
         field = self.field_class()
         # Multiple translations
-        result = field.to_internal_value(data)
+        result = field.run_validation(data)
         assert result == data
         # Single translation
         data.pop('en-US')
         assert len(data) == 1
-        result = field.to_internal_value(data)
+        result = field.run_validation(data)
         assert result == data
         # A flat string value is forbidden now
         with self.assertRaises(ValidationError) as exc:
-            field.to_internal_value(data['fr'])
+            field.run_validation(data['fr'])
         assert exc.exception.message == (
             'You must provide an object of {lang-code:value}.'
         )
@@ -139,7 +139,7 @@ class TestTranslationSerializerField(TestCase):
     def test_to_internal_value_strip(self):
         data = {'fr': '  Non mais Allô quoi ! ', 'en-US': ''}
         field = self.field_class()
-        result = field.to_internal_value(data)
+        result = field.run_validation(data)
         assert result == {'fr': 'Non mais Allô quoi !', 'en-US': ''}
 
     def test_wrong_locale_code(self):
@@ -148,7 +148,7 @@ class TestTranslationSerializerField(TestCase):
         }
         field = self.field_class()
         with self.assertRaises(ValidationError) as exc:
-            field.to_internal_value(data)
+            field.run_validation(data)
         assert exc.exception.message == (
             "The language code 'unknown-locale' is invalid."
         )
@@ -160,8 +160,8 @@ class TestTranslationSerializerField(TestCase):
             'en-US': None,
         }
         field = self.field_class()
-        result = field.to_internal_value(data)
-        field.validate(result)
+        result = field.run_validation(data)
+        field.run_validation(result)
         assert result == data
 
     def test_get_attribute(self):
@@ -271,10 +271,10 @@ class TestTranslationSerializerFieldFlat(TestTranslationSerializerField):
         data = {'fr': 'Non mais Allô quoi !', 'en-US': 'No But Hello what!'}
         field = self.field_class()
         # Multiple translations
-        result = field.to_internal_value(data)
+        result = field.run_validation(data)
         assert result == data
         # Single translation
-        result = field.to_internal_value(data['fr'])
+        result = field.run_validation(data['fr'])
         assert result == data['fr']
 
 


### PR DESCRIPTION
Most of the changes here were adjusting our `TranslationSerializerField` class to work in a "rest framework"-y way with regards to validation on fields, so we could inherit from `CharField`.  Then subclassing `URLField` or `EmailField` was an easy change to get the validation associated with those classes.  Fixes #18202