### PR TITLE
Extract install_origins from the root of the manifest

### DIFF
--- a/src/olympia/files/tests/test_utils.py
+++ b/src/olympia/files/tests/test_utils.py
@@ -467,18 +467,12 @@ class TestManifestJSONExtractor(AppVersionsMixin, TestCase):
 
     def test_install_origins(self):
         self.parse({})['install_origins'] == []
-        self.parse(
-            {'applications': {'gecko': {'install_origins': ['https://fôo.com']}}}
-        )['install_origins'] == ['https://fôo.com']
-        self.parse(
-            {
-                'browser_specific_settings': {
-                    'gecko': {
-                        'install_origins': ['https://bâr.net', 'https://alice.org']
-                    }
-                }
-            }
-        )['install_origins'] == ['https://bâr.net', 'https://alice.org']
+        self.parse({'install_origins': ['https://fôo.com']})['install_origins'] == [
+            'https://fôo.com'
+        ]
+        self.parse({'install_origins': ['https://bâr.net', 'https://alice.org']})[
+            'install_origins'
+        ] == ['https://bâr.net', 'https://alice.org']
 
 
 class TestLanguagePackAndDictionaries(AppVersionsMixin, TestCase):

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -262,7 +262,7 @@ class ManifestJSONExtractor:
 
     @property
     def install_origins(self):
-        return self.gecko.get('install_origins', [])
+        return self.get('install_origins', [])
 
     def apps(self):
         """Get `AppVersion`s for the application."""


### PR DESCRIPTION
We aren't going to have it in `browser_specific_settings` > `gecko` because at the moment the schema for gecko specific properties doesn't allow new properties, so this wouldn't be backwards-compatible.

Fixes mozilla/addons#8588