### PR TITLE
allow custom licenses to be created and updated per version

### DIFF
--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -472,6 +472,9 @@ This endpoint allows a submission of an upload to an existing add-on to create a
         production environments. See :ref:`the older signing API <upload-version>` for
         how to submit new add-ons/versions on AMO today.
 
+    .. note::
+        This API requires :doc:`authentication <auth>`.
+
 .. http:post:: /api/v5/addons/addon/(int:addon_id|string:addon_slug|string:addon_guid)/versions/
 
     .. _version-create-request:
@@ -482,7 +485,7 @@ This endpoint allows a submission of an upload to an existing add-on to create a
         where min/max versions from the manifest, or defaults, will be used.  See :ref:`examples <version-compatibility-examples>`.
     :<json string compatibility[app_name].max: Maximum version of the corresponding app the version is compatible with. Should only be enforced by clients if ``is_strict_compatibility_enabled`` is ``true``.
     :<json string compatibility[app_name].min: Minimum version of the corresponding app the version is compatible with.
-    :<json int license: The id of a non-custom license. The license must match the add-on type. The license must match the add-on type. Either provide ``license`` or ``custom_license``, not both.
+    :<json int license: The id of a non-custom license. The license must match the add-on type. Either provide ``license`` or ``custom_license``, not both.
     :<json object|null custom_license.name: The name of the license (See :ref:`translated fields <api-overview-translations>`). Custom licenses are not supported for themes.
     :<json object|null custom_license.text: The text of the license (See :ref:`translated fields <api-overview-translations>`). Custom licenses are not supported for themes.
     :<json object|null release_notes: The release notes for this version (See :ref:`translated fields <api-overview-translations>`).
@@ -554,6 +557,9 @@ This endpoint allows the metadata for an existing version to be edited.
         production environments. The only supported method of editing metadata today is
         via developer hub.
 
+    .. note::
+        This API requires :doc:`authentication <auth>`.
+
 .. http:patch:: /api/v5/addons/addon/(int:addon_id|string:addon_slug|string:addon_guid)/versions/(int:id)/
 
     .. _version-edit-request:
@@ -579,6 +585,9 @@ This endpoint is for uploading an addon file, to then be submitted to create a n
         This is an in-progress API that is not yet available on addons.mozilla.org
         production environments. See :ref:`the older signing API <upload-version>` for
         how to submit new add-ons/versions on AMO today.
+
+    .. note::
+        This API requires :doc:`authentication <auth>`.
 
 .. http:post:: /api/v5/addons/upload/
 

--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -482,7 +482,9 @@ This endpoint allows a submission of an upload to an existing add-on to create a
         where min/max versions from the manifest, or defaults, will be used.  See :ref:`examples <version-compatibility-examples>`.
     :<json string compatibility[app_name].max: Maximum version of the corresponding app the version is compatible with. Should only be enforced by clients if ``is_strict_compatibility_enabled`` is ``true``.
     :<json string compatibility[app_name].min: Minimum version of the corresponding app the version is compatible with.
-    :<json int license: The license id.
+    :<json int license: The id of a non-custom license. The license must match the add-on type. The license must match the add-on type. Either provide ``license`` or ``custom_license``, not both.
+    :<json object|null custom_license.name: The name of the license (See :ref:`translated fields <api-overview-translations>`). Custom licenses are not supported for themes.
+    :<json object|null custom_license.text: The text of the license (See :ref:`translated fields <api-overview-translations>`). Custom licenses are not supported for themes.
     :<json object|null release_notes: The release notes for this version (See :ref:`translated fields <api-overview-translations>`).
     :<json string upload: The uuid for the xpi upload to create this version with.
 
@@ -559,7 +561,9 @@ This endpoint allows the metadata for an existing version to be edited.
     :<json object|array compatibility: Either an object detailing which :ref:`applications <addon-detail-application>` and versions the version is compatible with; or an array of :ref:`applications <addon-detail-application>`, where default min/max versions will be used if not already defined.  See :ref:`examples <version-compatibility-examples>`.
     :<json string compatibility[app_name].max: Maximum version of the corresponding app the version is compatible with. Should only be enforced by clients if ``is_strict_compatibility_enabled`` is ``true``.
     :<json string compatibility[app_name].min: Minimum version of the corresponding app the version is compatible with.
-    :<json int license: The license id.
+    :<json int license: The id of a non-custom license. The license must match the add-on type. Either provide ``license`` or ``custom_license``, not both.
+    :<json object|null custom_license.name: The name of the license (See :ref:`translated fields <api-overview-translations>`). Custom licenses are not supported for themes.
+    :<json object|null custom_license.text: The text of the license (See :ref:`translated fields <api-overview-translations>`). Custom licenses are not supported for themes.
     :<json object|null release_notes: The release notes for this version (See :ref:`translated fields <api-overview-translations>`).
 
 

--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -428,6 +428,7 @@ These are `v5` specific changes - `v4` changes apply also.
 * 2021-09-23: flattened ``files`` in version detail from an array to a single ``file``. https://github.com/mozilla/addons-server/issues/17839
 * 2021-09-30: removed ``is_webextension`` from file objects (all addons have been webextensions for a while now) in all endpoints. https://github.com/mozilla/addons-server/issues/17658
 * 2021-11-18: added docs for the under-development addon submission & edit apis.
+* 2021-11-25: added `custom_license` to version create/edit endpoints to allow non-predefined licenses to be created and updated. https://github.com/mozilla/addons-server/issues/18034
 
 .. _`#11380`: https://github.com/mozilla/addons-server/issues/11380/
 .. _`#11379`: https://github.com/mozilla/addons-server/issues/11379/

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -498,6 +498,16 @@ class VersionSerializer(SimpleVersionSerializer):
             data.pop('upload', None)  # upload can only be set during create
             addon_type = self.addon.type
 
+        # We have to check the raw request data because data from both fields will be
+        # under `license` at this point.
+        if (
+            (request := self.context.get('request'))
+            and 'license' in request.data
+            and 'custom_license' in request.data
+        ):
+            raise exceptions.ValidationError(
+                'Both `license` and `custom_license` cannot be provided together.'
+            )
         if (
             'license' in data
             and isinstance(data['license'], License)

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -1784,6 +1784,26 @@ class TestVersionViewSetCreate(UploadMixin, TestCase):
             'url': 'http://testserver' + version.license_url(),
         }
 
+    def test_cannot_supply_both_custom_and_license_id(self):
+        license_data = {
+            'name': {'en-US': 'custom license name'},
+            'text': {'en-US': 'custom license text'},
+        }
+        response = self.client.post(
+            self.url,
+            data={
+                **self.minimal_data,
+                'license': self.license.id,
+                'custom_license': license_data,
+            },
+        )
+        assert response.status_code == 400, response.content
+        assert response.data == {
+            'non_field_errors': [
+                'Both `license` and `custom_license` cannot be provided together.'
+            ]
+        }
+
 
 class TestVersionViewSetCreateJWTAuth(TestVersionViewSetCreate):
     client_class = JWTAPITestClient
@@ -2113,6 +2133,22 @@ class TestVersionViewSetUpdate(UploadMixin, TestCase):
         )
         assert response.status_code == 400, response.content
         assert response.data == {'license': ['Wrong addon type for this license.']}
+
+    def test_cannot_supply_both_custom_and_license_id(self):
+        license_data = {
+            'name': {'en-US': 'custom license name'},
+            'text': {'en-US': 'custom license text'},
+        }
+        response = self.client.patch(
+            self.url,
+            data={'license': self.version.license.id, 'custom_license': license_data},
+        )
+        assert response.status_code == 400, response.content
+        assert response.data == {
+            'non_field_errors': [
+                'Both `license` and `custom_license` cannot be provided together.'
+            ]
+        }
 
 
 class TestVersionViewSetUpdateJWTAuth(TestVersionViewSetUpdate):

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -743,7 +743,10 @@ class TestAddonViewSetCreate(UploadMixin, TestCase):
             self.url,
             data={
                 'categories': {'firefox': ['bookmarks']},
-                'version': {'upload': self.upload.uuid, 'license': self.license.id},
+                'version': {
+                    'upload': self.upload.uuid,
+                    'license': self.license.id,
+                },
             },
         )
         assert response.status_code == 201, response.content
@@ -769,7 +772,11 @@ class TestAddonViewSetCreate(UploadMixin, TestCase):
         )
         assert response.status_code == 400, response.content
         assert response.data == {
-            'version': {'license': ['This field is required for listed versions.']},
+            'version': {
+                'license': [
+                    'This field, or custom_license, is required for listed versions.'
+                ]
+            },
         }
 
         # If the license is set we'll get further validation errors from addon
@@ -785,7 +792,10 @@ class TestAddonViewSetCreate(UploadMixin, TestCase):
                 self.url,
                 data={
                     'summary': {'en-US': 'replacement summary'},
-                    'version': {'upload': self.upload.uuid, 'license': self.license.id},
+                    'version': {
+                        'upload': self.upload.uuid,
+                        'license': self.license.id,
+                    },
                 },
             )
         assert response.status_code == 400, response.content
@@ -1609,7 +1619,9 @@ class TestVersionViewSetCreate(UploadMixin, TestCase):
         )
         assert response.status_code == 400, response.content
         assert response.data == {
-            'license': ['This field is required for listed versions.'],
+            'license': [
+                'This field, or custom_license, is required for listed versions.'
+            ],
         }
 
         # If the license is set we'll get further validation errors from about the addon
@@ -1738,6 +1750,39 @@ class TestVersionViewSetCreate(UploadMixin, TestCase):
         assert response.status_code == 400
         assert 'Version 0.0.1 matches ' in str(response.data['non_field_errors'])
         assert self.addon.reload().versions.count() == 1
+
+    def test_custom_license(self):
+        self.upload.update(automated_signing=False)
+        self.addon.current_version.file.update(status=amo.STATUS_DISABLED)
+        self.addon.update_status()
+        assert self.addon.status == amo.STATUS_NULL
+        license_data = {
+            'name': {'en-US': 'my custom license name'},
+            'text': {'en-US': 'my custom license text'},
+        }
+        response = self.client.post(
+            self.url,
+            data={**self.minimal_data, 'custom_license': license_data},
+        )
+        assert response.status_code == 201, response.content
+        data = response.data
+
+        self.addon.reload()
+        assert self.addon.versions.count() == 2
+        version = self.addon.find_latest_version(channel=None)
+        assert version.channel == amo.RELEASE_CHANNEL_LISTED
+        assert self.addon.status == amo.STATUS_NOMINATED
+
+        new_license = License.objects.latest('created')
+        assert version.license == new_license
+
+        assert data['license'] == {
+            'id': new_license.id,
+            'name': license_data['name'],
+            'text': license_data['text'],
+            'is_custom': True,
+            'url': 'http://testserver' + version.license_url(),
+        }
 
 
 class TestVersionViewSetCreateJWTAuth(TestVersionViewSetCreate):
@@ -1946,6 +1991,128 @@ class TestVersionViewSetUpdate(UploadMixin, TestCase):
             },
         )
         assert response.data == {'compatibility': ['Unknown app version specified']}
+
+    def test_custom_license(self):
+        # First assume no license - edge case because we enforce a license for listed
+        # versions, but possible.
+        self.version.update(license=None)
+        license_data = {
+            'name': {'en-US': 'custom license name'},
+            'text': {'en-US': 'custom license text'},
+        }
+        response = self.client.patch(
+            self.url,
+            data={'custom_license': license_data},
+        )
+        assert response.status_code == 200, response.content
+        data = response.data
+
+        self.version.reload()
+        new_license = License.objects.latest('created')
+        assert self.version.license == new_license
+        assert data['license'] == {
+            'id': new_license.id,
+            'name': license_data['name'],
+            'text': license_data['text'],
+            'is_custom': True,
+            'url': 'http://testserver' + self.version.license_url(),
+        }
+
+        # And then check we can update an existing custom license
+        num_licenses = License.objects.count()
+        response = self.client.patch(
+            self.url,
+            data={'custom_license': {'name': {'en-US': 'neú name'}}},
+        )
+        assert response.status_code == 200, response.content
+        data = response.data
+
+        self.version.reload()
+        new_license.reload()
+        assert self.version.license == new_license
+        assert data['license'] == {
+            'id': new_license.id,
+            'name': {'en-US': 'neú name'},
+            'text': license_data['text'],  # no change
+            'is_custom': True,
+            'url': 'http://testserver' + self.version.license_url(),
+        }
+        assert new_license.name == 'neú name'
+        assert License.objects.count() == num_licenses
+
+    def test_custom_license_from_builtin(self):
+        assert self.version.license.builtin != License.OTHER
+        builtin_license = self.version.license
+        license_data = {
+            'name': {'en-US': 'custom license name'},
+            'text': {'en-US': 'custom license text'},
+        }
+        response = self.client.patch(
+            self.url,
+            data={'custom_license': license_data},
+        )
+        assert response.status_code == 200, response.content
+        data = response.data
+
+        self.version.reload()
+        new_license = License.objects.latest('created')
+        assert self.version.license == new_license
+        assert new_license != builtin_license
+        assert data['license'] == {
+            'id': new_license.id,
+            'name': license_data['name'],
+            'text': license_data['text'],
+            'is_custom': True,
+            'url': 'http://testserver' + self.version.license_url(),
+        }
+
+        # and check we can change back to a builtin from a custom license
+        response = self.client.patch(
+            self.url,
+            data={'license': builtin_license.id},
+        )
+        assert response.status_code == 200, response.content
+        data = response.data
+
+        self.version.reload()
+        assert self.version.license == builtin_license
+        assert data['license']['id'] == builtin_license.id
+        assert data['license']['name']['en-US'] == builtin_license.name
+        assert data['license']['is_custom'] is False
+        assert data['license']['url'] == builtin_license.url
+
+    def test_no_custom_license_for_themes(self):
+        self.addon.update(type=amo.ADDON_STATICTHEME)
+        license_data = {
+            'name': {'en-US': 'custom license name'},
+            'text': {'en-US': 'custom license text'},
+        }
+        response = self.client.patch(
+            self.url,
+            data={'custom_license': license_data},
+        )
+        assert response.status_code == 400, response.content
+        assert response.data == {
+            'custom_license': ['Custom licenses are not supported for themes.']
+        }
+
+    def test_license_type_matches_addon_type(self):
+        self.addon.update(type=amo.ADDON_STATICTHEME)
+        response = self.client.patch(
+            self.url,
+            data={'license': self.version.license.id},
+        )
+        assert response.status_code == 400, response.content
+        assert response.data == {'license': ['Wrong addon type for this license.']}
+
+        self.addon.update(type=amo.ADDON_EXTENSION)
+        self.version.license.update(creative_commons=True)
+        response = self.client.patch(
+            self.url,
+            data={'license': self.version.license.id},
+        )
+        assert response.status_code == 400, response.content
+        assert response.data == {'license': ['Wrong addon type for this license.']}
 
 
 class TestVersionViewSetUpdateJWTAuth(TestVersionViewSetUpdate):


### PR DESCRIPTION
fixes #18034 - note you still need to know the license id unless you are specifying a custom license, which makes it a little impractical for general use (see #18361)