### PR TITLE
add throttling to file uploads

### DIFF
--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -43,7 +43,7 @@ from olympia.api.permissions import (
     GroupPermission,
     RegionalRestriction,
 )
-from olympia.api.throttling import addon_upload_throttles
+from olympia.api.throttling import addon_submission_throttles
 from olympia.api.utils import is_gate_active
 from olympia.constants.categories import CATEGORIES_BY_ID
 from olympia.devhub.permissions import IsSubmissionAllowedFor
@@ -207,7 +207,7 @@ class AddonViewSet(
     serializer_class = AddonSerializer
     serializer_class_with_unlisted_data = AddonSerializerWithUnlistedData
     lookup_value_regex = '[^/]+'  # Allow '.' for email-like guids.
-    throttle_classes = addon_upload_throttles
+    throttle_classes = addon_submission_throttles
 
     def get_queryset(self):
         """Return queryset to be used for the view."""
@@ -363,7 +363,7 @@ class AddonVersionViewSet(
     # what the client is requesting to see.
     permission_classes = []
     authentication_classes = [JWTKeyAuthentication, WebTokenAuthentication]
-    throttle_classes = addon_upload_throttles
+    throttle_classes = addon_submission_throttles
 
     def get_serializer_class(self):
         if (

--- a/src/olympia/api/throttling.py
+++ b/src/olympia/api/throttling.py
@@ -96,45 +96,79 @@ class ThrottleOnlyUnsafeMethodsMixin:
             return True
 
 
-class BurstUserAddonUploadThrottle(
+class BurstUserAddonSubmissionThrottle(
     ThrottleOnlyUnsafeMethodsMixin, GranularUserRateThrottle
 ):
-    scope = 'burst_user_addon_upload'
+    scope = 'burst_user_addon_submission'
     rate = '3/minute'
 
 
-class HourlyUserAddonUploadThrottle(
+class HourlyUserAddonSubmissionThrottle(
     ThrottleOnlyUnsafeMethodsMixin, GranularUserRateThrottle
 ):
-    scope = 'hourly_user_addon_upload'
+    scope = 'hourly_user_addon_submission'
     rate = '10/hour'
 
 
-class DailyUserAddonUploadThrottle(
+class DailyUserAddonSubmissionThrottle(
     ThrottleOnlyUnsafeMethodsMixin, GranularUserRateThrottle
 ):
-    scope = 'daily_user_addon_upload'
+    scope = 'daily_user_addon_submission'
     rate = '24/day'
 
 
-class BurstIPAddonUploadThrottle(
+class BurstIPAddonSubmissionThrottle(
     ThrottleOnlyUnsafeMethodsMixin, GranularIPRateThrottle
 ):
-    scope = 'burst_ip_addon_upload'
+    scope = 'burst_ip_addon_submission'
     rate = '6/minute'
 
 
-class HourlyIPAddonUploadThrottle(
+class HourlyIPAddonSubmissionThrottle(
     ThrottleOnlyUnsafeMethodsMixin, GranularIPRateThrottle
 ):
-    scope = 'hourly_ip_addon_upload'
+    scope = 'hourly_ip_addon_submission'
     rate = '50/hour'
 
 
-addon_upload_throttles = (
-    BurstUserAddonUploadThrottle,
-    HourlyUserAddonUploadThrottle,
-    DailyUserAddonUploadThrottle,
-    BurstIPAddonUploadThrottle,
-    HourlyIPAddonUploadThrottle,
+addon_submission_throttles = (
+    BurstUserAddonSubmissionThrottle,
+    HourlyUserAddonSubmissionThrottle,
+    DailyUserAddonSubmissionThrottle,
+    BurstIPAddonSubmissionThrottle,
+    HourlyIPAddonSubmissionThrottle,
+)
+
+
+class BurstUserFileUploadThrottle(BurstUserAddonSubmissionThrottle):
+    scope = 'burst_user_file_upload'
+    rate = '6/minute'
+
+
+class HourlyUserFileUploadThrottle(HourlyUserAddonSubmissionThrottle):
+    scope = 'hourly_user_file_upload'
+    rate = '20/hour'
+
+
+class DailyUserFileUploadThrottle(DailyUserAddonSubmissionThrottle):
+    scope = 'daily_user_file_upload'
+    rate = '48/day'
+
+
+class BurstIPFileUploadThrottle(BurstIPAddonSubmissionThrottle):
+    scope = 'burst_ip_file_upload'
+    rate = '6/minute'
+
+
+class HourlyIPFileUploadThrottle(HourlyIPAddonSubmissionThrottle):
+    scope = 'hourly_ip_file_upload'
+    rate = '50/hour'
+
+
+file_upload_throttles = (
+    BurstUserFileUploadThrottle,
+    HourlyUserFileUploadThrottle,
+    DailyUserFileUploadThrottle,
+    BurstIPFileUploadThrottle,
+    HourlyIPFileUploadThrottle,
 )

--- a/src/olympia/files/tests/test_views.py
+++ b/src/olympia/files/tests/test_views.py
@@ -199,7 +199,7 @@ class TestFileUploadViewSet(TestCase):
             response = self._create_post(ip=ip)
             assert response.status_code == 201, response.content
 
-    def test_throttling_verb_ip_hourly(self):
+    def test_throttling_ip_hourly(self):
         ip = '63.245.208.194'
         with freeze_time('2019-04-08 15:16:23.42') as frozen_time:
             for _ in range(0, 50):
@@ -212,7 +212,7 @@ class TestFileUploadViewSet(TestCase):
 
             # At this point we should be throttled since we're using the same
             # IP. (we're still inside the frozen time context).
-            response = self._create_post(ip='63.245.208.194')
+            response = self._create_post(ip=ip)
             assert response.status_code == 429, response.content
 
             # One minute later, past the 'burst' throttling period, we're still
@@ -238,7 +238,7 @@ class TestFileUploadViewSet(TestCase):
                 )
 
             # At this point we should be throttled since we're using the same
-            # IP. (we're still inside the frozen time context).
+            # user. (we're still inside the frozen time context).
             response = self._create_post(ip=get_random_ip())
             assert response.status_code == 429, response.content
 
@@ -259,7 +259,7 @@ class TestFileUploadViewSet(TestCase):
                 )
 
             # At this point we should be throttled since we're using the same
-            # IP. (we're still inside the frozen time context).
+            # user. (we're still inside the frozen time context).
             response = self._create_post(ip=get_random_ip())
             assert response.status_code == 429, response.content
 
@@ -285,7 +285,7 @@ class TestFileUploadViewSet(TestCase):
                 )
 
             # At this point we should be throttled since we're using the same
-            # IP. (we're still inside the frozen time context).
+            # user. (we're still inside the frozen time context).
             response = self._create_post(ip=get_random_ip())
             assert response.status_code == 429, response.content
 

--- a/src/olympia/files/tests/test_views.py
+++ b/src/olympia/files/tests/test_views.py
@@ -1,13 +1,17 @@
 import os
+from datetime import timedelta
 
 from django.conf import settings
 from django.test.utils import override_settings
 from django.urls import reverse
 
+from freezegun import freeze_time
+
 from olympia import amo
 from olympia.amo.tests import (
     APITestClient,
     JWTAPITestClient,
+    get_random_ip,
     reverse_ns,
     TestCase,
     user_factory,
@@ -15,6 +19,7 @@ from olympia.amo.tests import (
 
 from .test_models import UploadMixin
 from ..models import FileUpload
+from ..views import FileUploadViewSet
 
 
 files_fixtures = 'src/olympia/files/fixtures/files/'
@@ -56,7 +61,9 @@ class TestServeFileUpload(UploadMixin, TestCase):
         assert resp.status_code == 410
 
 
-class FileUploadTestMixin:
+class TestFileUploadViewSet(TestCase):
+    client_class = APITestClient
+
     def setUp(self):
         super().setUp()
         self.list_url = reverse_ns('addon-upload-list', api_version='v5')
@@ -83,36 +90,8 @@ class FileUploadTestMixin:
             f'{guid}-{version}.xpi',
         )
 
-    def test_not_authenticated(self):
-        self.client.logout_api()
-        response = self.client.get(
-            self.list_url,
-        )
-        assert response.status_code == 401
-
-    def test_no_developer_agreement(self):
-        self.user.update(read_dev_agreement=None)
-        filepath = self._xpi_filepath('@upload-version', '3.0')
-
-        with open(filepath, 'rb') as upload:
-            data = {
-                'upload': upload,
-                'channel': 'listed',
-            }
-
-            response = self.client.post(
-                self.list_url,
-                data,
-                format='multipart',
-                REMOTE_ADDR='127.0.3.1',
-            )
-        assert response.status_code in [401, 403]  # JWT auth is a 401; web auth is 403
-
-    def _test_create(self, channel, channel_name):
-        upload_count_before = FileUpload.objects.count()
-        filepath = self._xpi_filepath('@upload-version', '3.0')
-
-        with open(filepath, 'rb') as upload:
+    def _create_post(self, channel_name='listed', ip='63.245.208.194'):
+        with open(self._xpi_filepath('@upload-version', '3.0'), 'rb') as upload:
             data = {
                 'upload': upload,
                 'channel': channel_name,
@@ -122,9 +101,27 @@ class FileUploadTestMixin:
                 self.list_url,
                 data,
                 format='multipart',
-                REMOTE_ADDR='127.0.3.1',
+                REMOTE_ADDR=ip,
+                HTTP_X_FORWARDED_FOR=f'{ip}, {get_random_ip()}',
             )
+        return response
 
+    def test_not_authenticated(self):
+        self.client.logout_api()
+        response = self.client.get(
+            self.list_url,
+        )
+        assert response.status_code == 401
+
+    def test_no_developer_agreement(self):
+        self.user.update(read_dev_agreement=None)
+        response = self._create_post()
+        assert response.status_code in [401, 403]  # JWT auth is a 401; web auth is 403
+
+    def _test_create(self, channel, channel_name):
+        upload_count_before = FileUpload.objects.count()
+
+        response = self._create_post(channel_name)
         assert response.status_code == 201
 
         assert FileUpload.objects.count() == upload_count_before + 1
@@ -134,7 +131,7 @@ class FileUploadTestMixin:
         assert upload.source == amo.UPLOAD_SOURCE_ADDON_API
         assert upload.user == self.user
         assert upload.version == '3.0'
-        assert upload.ip_address == '127.0.3.1'
+        assert upload.ip_address == '63.245.208.194'
         assert upload.channel == channel
 
         data = response.json()
@@ -180,10 +177,134 @@ class FileUploadTestMixin:
         )
         assert response.status_code == 404
 
+    def test_throttling_ip_burst(self):
+        ip = '63.245.208.194'
+        with freeze_time('2019-04-08 15:16:23.42') as frozen_time:
+            for _ in range(0, 6):
+                self._add_fake_throttling_action(
+                    view_class=FileUploadViewSet,
+                    url=self.list_url,
+                    user=user_factory(),
+                    remote_addr=ip,
+                )
 
-class TestFileUploadViewSetJWTAuth(FileUploadTestMixin, TestCase):
+            # At this point we should be throttled since we're using the same
+            # IP. (we're still inside the frozen time context).
+            response = self._create_post(ip=ip)
+            assert response.status_code == 429, response.content
+
+            # 'Burst' throttling is 1 minute, so 61 seconds later we should be
+            # allowed again.
+            frozen_time.tick(delta=timedelta(seconds=61))
+            response = self._create_post(ip=ip)
+            assert response.status_code == 201, response.content
+
+    def test_throttling_verb_ip_hourly(self):
+        ip = '63.245.208.194'
+        with freeze_time('2019-04-08 15:16:23.42') as frozen_time:
+            for _ in range(0, 50):
+                self._add_fake_throttling_action(
+                    view_class=FileUploadViewSet,
+                    url=self.list_url,
+                    user=user_factory(),
+                    remote_addr=ip,
+                )
+
+            # At this point we should be throttled since we're using the same
+            # IP. (we're still inside the frozen time context).
+            response = self._create_post(ip='63.245.208.194')
+            assert response.status_code == 429, response.content
+
+            # One minute later, past the 'burst' throttling period, we're still
+            # blocked by the 'hourly' limit.
+            frozen_time.tick(delta=timedelta(seconds=61))
+            response = self._create_post(ip=ip)
+            assert response.status_code == 429
+
+            # 'hourly' throttling is 1 hour, so 3601 seconds later we should
+            # be allowed again.
+            frozen_time.tick(delta=timedelta(seconds=3601))
+            response = self._create_post(ip=ip)
+            assert response.status_code == 201
+
+    def test_throttling_user_burst(self):
+        with freeze_time('2019-04-08 15:16:23.42') as frozen_time:
+            for _ in range(0, 6):
+                self._add_fake_throttling_action(
+                    view_class=FileUploadViewSet,
+                    url=self.list_url,
+                    user=self.user,
+                    remote_addr=get_random_ip(),
+                )
+
+            # At this point we should be throttled since we're using the same
+            # IP. (we're still inside the frozen time context).
+            response = self._create_post(ip=get_random_ip())
+            assert response.status_code == 429, response.content
+
+            # 'Burst' throttling is 1 minute, so 61 seconds later we should be
+            # allowed again.
+            frozen_time.tick(delta=timedelta(seconds=61))
+            response = self._create_post(ip=get_random_ip())
+            assert response.status_code == 201, response.content
+
+    def test_throttling_user_hourly(self):
+        with freeze_time('2019-04-08 15:16:23.42') as frozen_time:
+            for _ in range(0, 20):
+                self._add_fake_throttling_action(
+                    view_class=FileUploadViewSet,
+                    url=self.list_url,
+                    user=self.user,
+                    remote_addr=get_random_ip(),
+                )
+
+            # At this point we should be throttled since we're using the same
+            # IP. (we're still inside the frozen time context).
+            response = self._create_post(ip=get_random_ip())
+            assert response.status_code == 429, response.content
+
+            # One minute later, past the 'burst' throttling period, we're still
+            # blocked by the 'hourly' limit.
+            frozen_time.tick(delta=timedelta(seconds=61))
+            response = self._create_post(ip=get_random_ip())
+            assert response.status_code == 429, response.content
+
+            # 3601 seconds later we should be allowed again.
+            frozen_time.tick(delta=timedelta(seconds=3601))
+            response = self._create_post(ip=get_random_ip())
+            assert response.status_code == 201, response.content
+
+    def test_throttling_user_daily(self):
+        with freeze_time('2019-04-08 15:16:23.42') as frozen_time:
+            for _ in range(0, 48):
+                self._add_fake_throttling_action(
+                    view_class=FileUploadViewSet,
+                    url=self.list_url,
+                    user=self.user,
+                    remote_addr=get_random_ip(),
+                )
+
+            # At this point we should be throttled since we're using the same
+            # IP. (we're still inside the frozen time context).
+            response = self._create_post(ip=get_random_ip())
+            assert response.status_code == 429, response.content
+
+            # One minute later, past the 'burst' throttling period, we're still
+            # blocked by the 'hourly' limit.
+            frozen_time.tick(delta=timedelta(seconds=61))
+            response = self._create_post(ip=get_random_ip())
+            assert response.status_code == 429, response.content
+
+            # After the hourly limit, still blocked.
+            frozen_time.tick(delta=timedelta(seconds=3601))
+            response = self._create_post(ip=get_random_ip())
+            assert response.status_code == 429, response.content
+
+            # 86401 seconds later we should be allowed again (24h + 1s).
+            frozen_time.tick(delta=timedelta(seconds=86401))
+            response = self._create_post(ip=get_random_ip())
+            assert response.status_code == 201, response.content
+
+
+class TestFileUploadViewSetJWTAuth(TestFileUploadViewSet):
     client_class = JWTAPITestClient
-
-
-class TestFileUploadViewSetWebTokenAuth(FileUploadTestMixin, TestCase):
-    client_class = APITestClient

--- a/src/olympia/files/views.py
+++ b/src/olympia/files/views.py
@@ -14,6 +14,7 @@ from olympia.amo.decorators import use_primary_db
 from olympia.amo.utils import HttpResponseXSendFile
 from olympia.api.authentication import JWTKeyAuthentication, WebTokenAuthentication
 from olympia.api.permissions import AllowOwner, APIGatePermission
+from olympia.api.throttling import file_upload_throttles
 from olympia.devhub import tasks as devhub_tasks
 from olympia.devhub.permissions import IsSubmissionAllowedFor
 
@@ -60,6 +61,7 @@ class FileUploadViewSet(CreateModelMixin, ReadOnlyModelViewSet):
     ]
     authentication_classes = [JWTKeyAuthentication, WebTokenAuthentication]
     lookup_field = 'uuid'
+    throttle_classes = file_upload_throttles
 
     def get_queryset(self):
         return super().get_queryset().filter(user=self.request.user)

--- a/src/olympia/signing/views.py
+++ b/src/olympia/signing/views.py
@@ -17,7 +17,7 @@ from olympia.addons.models import Addon
 from olympia.amo.decorators import use_primary_db
 from olympia.api.authentication import JWTKeyAuthentication
 from olympia.amo.templatetags.jinja_helpers import absolutify
-from olympia.api.throttling import addon_upload_throttles
+from olympia.api.throttling import addon_submission_throttles
 from olympia.blocklist.models import Block
 from olympia.devhub.views import handle_upload as devhub_handle_upload
 from olympia.devhub.permissions import IsSubmissionAllowedFor
@@ -80,7 +80,7 @@ def with_addon(allow_missing=False):
 class VersionView(APIView):
     authentication_classes = [JWTKeyAuthentication]
     permission_classes = [IsAuthenticated, IsSubmissionAllowedFor]
-    throttle_classes = addon_upload_throttles
+    throttle_classes = addon_submission_throttles
 
     def check_throttles(self, request):
         # Let users with LanguagePack:Submit permission bypass throttles.


### PR DESCRIPTION
fixes #18114 - renames the existing add-on submission throttles to differentiate them better.  Most of the code is throttling tests that I duplicated from the signing api (because they're different, and one day the signing api and it's tests will be deleted)