### PR TITLE
Re-enable API throttling on dev

### DIFF
--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -13,7 +13,7 @@ EMAIL_HOST_PASSWORD = EMAIL_URL['EMAIL_HOST_PASSWORD']
 ENV = env('ENV')
 RAISE_ON_SIGNAL_ERROR = True
 
-API_THROTTLING = False
+API_THROTTLING = True
 
 DOMAIN = env('DOMAIN', default='addons-dev.allizom.org')
 SERVER_EMAIL = 'zdev@addons.mozilla.org'


### PR DESCRIPTION
If throttling gets in the way it can be bypassed by giving specific permissions to users. Enabling throttling back on dev ensures QA can test rate limiting scenarios on dev.

Fixes #18122