### PR TITLE
Revert "Re-enable API throttling on dev"

### DIFF
--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -13,7 +13,7 @@ EMAIL_HOST_PASSWORD = EMAIL_URL['EMAIL_HOST_PASSWORD']
 ENV = env('ENV')
 RAISE_ON_SIGNAL_ERROR = True
 
-API_THROTTLING = True
+API_THROTTLING = False
 
 DOMAIN = env('DOMAIN', default='addons-dev.allizom.org')
 SERVER_EMAIL = 'zdev@addons.mozilla.org'


### PR DESCRIPTION
Reverts mozilla/addons-server#18463

We want a better solution for bypasses before doing that.