### PR TITLE
add heartbeat urls

### DIFF
--- a/src/olympia/amo/tests/test_middleware.py
+++ b/src/olympia/amo/tests/test_middleware.py
@@ -66,6 +66,18 @@ class TestMiddleware(TestCase):
         AuthenticationMiddlewareWithoutAPI().process_request(req)
         assert process_request.call_count == 3
 
+    def test_lbheartbeat_middleware(self):
+        # /__lbheartbeat__ should be return a 200 from middleware, bypassing later
+        # middleware and view code.
+
+        with self.assertNumQueries(0):
+            response = test.Client().get('/__lbheartbeat__', SERVER_NAME='elb-internal')
+        assert response.status_code == 200
+        assert response.content == b''
+        assert response['Cache-Control'] == (
+            'max-age=0, no-cache, no-store, must-revalidate, private'
+        )
+
 
 def test_redirect_with_unicode_get():
     response = test.Client().get(

--- a/src/olympia/amo/tests/test_monitor.py
+++ b/src/olympia/amo/tests/test_monitor.py
@@ -71,3 +71,9 @@ class TestMonitor(TestCase):
 
         status, signer_result = monitors.signer()
         assert status == ''
+
+    def test_database(self):
+        with self.assertNumQueries(2):
+            status, result = monitors.database()
+        assert status == ''
+        assert result is None

--- a/src/olympia/amo/urls.py
+++ b/src/olympia/amo/urls.py
@@ -5,7 +5,7 @@ from django.views.decorators.cache import never_cache
 from . import views
 
 services_patterns = [
-    re_path(r'^monitor\.json$', never_cache(views.monitor), name='amo.monitor'),
+    re_path(r'^monitor\.json$', never_cache(views.heartbeat), name='amo.monitor'),
     re_path(r'^client_info', views.client_info, name='amo.client_info'),
     re_path(r'^loaded$', never_cache(views.loaded), name='amo.loaded'),
     re_path(r'^403', views.handler403),
@@ -22,6 +22,10 @@ urlpatterns = [
     re_path(r'^contribute\.json$', views.contribute, name='contribute.json'),
     re_path(r'^services/', include(services_patterns)),
     re_path(r'^__version__$', views.version, name='version.json'),
+    re_path(r'^__heartbeat__$', never_cache(views.heartbeat), name='amo.heartbeat'),
+    re_path(
+        r'^__lbheartbeat__$', never_cache(views.lbheartbeat), name='amo.lbheartbeat'
+    ),
     re_path(
         r'^opensearch\.xml$',
         TemplateView.as_view(

--- a/src/olympia/amo/urls.py
+++ b/src/olympia/amo/urls.py
@@ -1,13 +1,12 @@
 from django.urls import include, path, re_path
 from django.views.generic.base import TemplateView
-from django.views.decorators.cache import never_cache
 
 from . import views
 
 services_patterns = [
-    re_path(r'^monitor\.json$', never_cache(views.heartbeat), name='amo.monitor'),
+    re_path(r'^monitor\.json$', views.heartbeat, name='amo.monitor'),
     re_path(r'^client_info', views.client_info, name='amo.client_info'),
-    re_path(r'^loaded$', never_cache(views.loaded), name='amo.loaded'),
+    re_path(r'^loaded$', views.loaded, name='amo.loaded'),
     re_path(r'^403', views.handler403),
     re_path(r'^404', views.handler404),
     re_path(r'^500', views.handler500),
@@ -22,10 +21,7 @@ urlpatterns = [
     re_path(r'^contribute\.json$', views.contribute, name='contribute.json'),
     re_path(r'^services/', include(services_patterns)),
     re_path(r'^__version__$', views.version, name='version.json'),
-    re_path(r'^__heartbeat__$', never_cache(views.heartbeat), name='amo.heartbeat'),
-    re_path(
-        r'^__lbheartbeat__$', never_cache(views.lbheartbeat), name='amo.lbheartbeat'
-    ),
+    re_path(r'^__heartbeat__$', views.heartbeat, name='amo.heartbeat'),
     re_path(
         r'^opensearch\.xml$',
         TemplateView.as_view(

--- a/src/olympia/amo/views.py
+++ b/src/olympia/amo/views.py
@@ -20,7 +20,6 @@ from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-import olympia
 from olympia import amo
 from olympia.amo.utils import HttpResponseXSendFile, use_fake_fxa
 from olympia.api.exceptions import base_500_data
@@ -31,12 +30,9 @@ from . import monitors
 from .sitemap import get_sitemap_path, get_sitemaps, render_index_xml
 
 
-sitemap_log = olympia.core.logger.getLogger('z.monitor')
-
-
 @never_cache
 @non_atomic_requests
-def monitor(request):
+def heartbeat(request):
     # For each check, a boolean pass/fail status to show in the template
     status_summary = {}
     results = {}
@@ -54,7 +50,13 @@ def monitor(request):
     # If anything broke, send HTTP 500.
     status_code = 200 if all(a['state'] for a in status_summary.values()) else 500
 
-    return http.HttpResponse(json.dumps(status_summary), status=status_code)
+    return JsonResponse(status_summary, status=status_code)
+
+
+@never_cache
+@non_atomic_requests
+def lbheartbeat(request):
+    return HttpResponse(status=200)
 
 
 @never_cache

--- a/src/olympia/amo/views.py
+++ b/src/olympia/amo/views.py
@@ -60,12 +60,6 @@ def heartbeat(request):
 
 @never_cache
 @non_atomic_requests
-def lbheartbeat(request):
-    return HttpResponse(status=200)
-
-
-@never_cache
-@non_atomic_requests
 def client_info(request):
     if getattr(settings, 'ENV', None) != 'dev':
         raise PermissionDenied
@@ -148,6 +142,7 @@ def csrf_failure(request, reason=''):
 
 
 @non_atomic_requests
+@never_cache
 def loaded(request):
     return http.HttpResponse(
         '%s' % request.META['wsgi.loaded'], content_type='text/plain'

--- a/src/olympia/amo/views.py
+++ b/src/olympia/amo/views.py
@@ -35,17 +35,22 @@ from .sitemap import get_sitemap_path, get_sitemaps, render_index_xml
 def heartbeat(request):
     # For each check, a boolean pass/fail status to show in the template
     status_summary = {}
-    results = {}
 
-    checks = ['memcache', 'libraries', 'elastic', 'path', 'rabbitmq', 'signer']
+    checks = [
+        'memcache',
+        'libraries',
+        'elastic',
+        'path',
+        'rabbitmq',
+        'signer',
+        'database',
+    ]
 
     for check in checks:
-        with statsd.timer('monitor.%s' % check) as timer:
-            status, result = getattr(monitors, check)()
+        with statsd.timer('monitor.%s' % check):
+            status, _ = getattr(monitors, check)()
         # state is a string. If it is empty, that means everything is fine.
         status_summary[check] = {'state': not status, 'status': status}
-        results['%s_results' % check] = result
-        results['%s_timer' % check] = timer.ms
 
     # If anything broke, send HTTP 500.
     status_code = 200 if all(a['state'] for a in status_summary.values()) else 500

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -270,6 +270,8 @@ SUPPORTED_NONAPPS = (
     'sitemap.xml',
     'static',
     'user-media',
+    '__heartbeat__',
+    '__lbheartbeat__',
     '__version__',
 )
 DEFAULT_APP = 'firefox'
@@ -287,6 +289,8 @@ SUPPORTED_NONLOCALES = (
     'downloads',
     'static',
     'user-media',
+    '__heartbeat__',
+    '__lbheartbeat__',
     '__version__',
 )
 

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -441,6 +441,7 @@ MIDDLEWARE = (
     # Enable conditional processing, e.g ETags.
     'django.middleware.http.ConditionalGetMiddleware',
     'olympia.amo.middleware.NoVarySessionMiddleware',
+    'olympia.amo.middleware.LBHeartbeatMiddleware',
     'olympia.amo.middleware.CommonMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'olympia.amo.middleware.AuthenticationMiddlewareWithoutAPI',


### PR DESCRIPTION
fixes #18510 
- repurposes `/services/monitor.json` as `/__heartbeat__` (but leaves the url alone as an alias for now)
- adds `/__lbheartbeat__`
- adds a database check for replica and primary databases.