### PR TITLE
Don't return direct link to FxA for login/register, use our API endpoint

### DIFF
--- a/src/olympia/accounts/templatetags/jinja_helpers.py
+++ b/src/olympia/accounts/templatetags/jinja_helpers.py
@@ -1,3 +1,5 @@
+from urllib.parse import quote_plus
+
 from django_jinja import library
 import jinja2
 
@@ -10,7 +12,7 @@ from olympia.amo.templatetags.jinja_helpers import drf_url
 def login_link(context):
     next_path = path_with_query(context['request'])
     login_start = drf_url(context, 'accounts.login_start')
-    return f'{login_start}?to={next_path}'
+    return f'{login_start}?to={quote_plus(next_path)}'
 
 
 @library.global_function

--- a/src/olympia/accounts/templatetags/jinja_helpers.py
+++ b/src/olympia/accounts/templatetags/jinja_helpers.py
@@ -13,9 +13,3 @@ def login_link(context):
     next_path = path_with_query(context['request'])
     login_start = drf_url(context, 'accounts.login_start')
     return f'{login_start}?to={quote_plus(next_path)}'
-
-
-@library.global_function
-@jinja2.pass_context
-def register_link(context):
-    return login_link(context)

--- a/src/olympia/accounts/templatetags/jinja_helpers.py
+++ b/src/olympia/accounts/templatetags/jinja_helpers.py
@@ -1,23 +1,19 @@
+from django_jinja import library
 import jinja2
 
-from django_jinja import library
-
-from olympia.accounts import utils
+from olympia.accounts.utils import path_with_query
+from olympia.amo.templatetags.jinja_helpers import drf_url
 
 
 @library.global_function
 @jinja2.pass_context
 def login_link(context):
-    return utils.default_fxa_login_url(context['request'])
+    next_path = path_with_query(context['request'])
+    login_start = drf_url(context, 'accounts.login_start')
+    return f'{login_start}?to={next_path}'
 
 
 @library.global_function
 @jinja2.pass_context
 def register_link(context):
-    return utils.default_fxa_register_url(context['request'])
-
-
-@library.global_function
-@jinja2.pass_context
-def fxa_config(context):
-    return utils.fxa_config(context['request'])
+    return login_link(context)

--- a/src/olympia/accounts/tests/test_helpers.py
+++ b/src/olympia/accounts/tests/test_helpers.py
@@ -1,23 +1,31 @@
 from django.test import RequestFactory
 
-from unittest import mock
-
 from olympia.accounts.templatetags import jinja_helpers
 
 
-@mock.patch(
-    'olympia.accounts.templatetags.jinja_helpers.utils.default_fxa_login_url',
-    lambda c: 'http://auth.ca',
-)
 def test_login_link():
     request = RequestFactory().get('/en-US/firefox/addons')
-    assert jinja_helpers.login_link({'request': request}) == ('http://auth.ca')
+    assert jinja_helpers.login_link({'request': request}) == (
+        'http://testserver/api/v5/accounts/login/start/'
+        '?to=%2Fen-US%2Ffirefox%2Faddons'
+    )
+
+    request = RequestFactory().get('/en-US/firefox/addons?blah=1')
+    assert jinja_helpers.login_link({'request': request}) == (
+        'http://testserver/api/v5/accounts/login/start/'
+        '?to=%2Fen-US%2Ffirefox%2Faddons%3Fblah%3D1'
+    )
+
+    request = RequestFactory().get('/en-US/firefox/addons?blah=1&bâr=2')
+    assert jinja_helpers.login_link({'request': request}) == (
+        'http://testserver/api/v5/accounts/login/start/'
+        '?to=%2Fen-US%2Ffirefox%2Faddons%3Fblah%3D1%26b%25C3%25A2r%3D2'
+    )
 
 
-@mock.patch(
-    'olympia.accounts.templatetags.jinja_helpers.utils.default_fxa_register_url',
-    lambda c: 'http://auth.ca',
-)
 def test_register_link():
     request = RequestFactory().get('/en-US/firefox/addons')
-    assert jinja_helpers.register_link({'request': request}) == ('http://auth.ca')
+    assert jinja_helpers.register_link({'request': request}) == (
+        'http://testserver/api/v5/accounts/login/start/'
+        '?to=%2Fen-US%2Ffirefox%2Faddons'
+    )

--- a/src/olympia/accounts/tests/test_helpers.py
+++ b/src/olympia/accounts/tests/test_helpers.py
@@ -21,11 +21,3 @@ def test_login_link():
         'http://testserver/api/v5/accounts/login/start/'
         '?to=%2Fen-US%2Ffirefox%2Faddons%3Fblah%3D1%26b%25C3%25A2r%3D2'
     )
-
-
-def test_register_link():
-    request = RequestFactory().get('/en-US/firefox/addons')
-    assert jinja_helpers.register_link({'request': request}) == (
-        'http://testserver/api/v5/accounts/login/start/'
-        '?to=%2Fen-US%2Ffirefox%2Faddons'
-    )

--- a/src/olympia/accounts/tests/test_utils.py
+++ b/src/olympia/accounts/tests/test_utils.py
@@ -6,18 +6,16 @@ from datetime import datetime
 from urllib.parse import parse_qs, urlparse
 from unittest import mock
 
-from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
 from django.test.utils import override_settings
 from django.urls import reverse
-from django.utils.encoding import force_bytes, force_str
+from django.utils.encoding import force_str
 
 from waffle.testutils import override_switch
 
 from olympia.accounts import utils
 from olympia.accounts.utils import process_fxa_event
 from olympia.amo.tests import TestCase, user_factory
-from olympia.users.models import UserProfile
 
 
 FXA_CONFIG = {
@@ -26,81 +24,6 @@ FXA_CONFIG = {
         'client_secret': 'bar',
     },
 }
-
-
-@override_settings(FXA_CONFIG=FXA_CONFIG)
-def test_fxa_config_anonymous():
-    request = RequestFactory().get('/en-US/firefox/addons')
-    request.session = {'fxa_state': 'thestate!'}
-    request.user = AnonymousUser()
-    assert utils.fxa_config(request) == {
-        'clientId': 'foo',
-        'state': 'thestate!',
-        'oauthHost': 'https://oauth-stable.dev.lcip.org/v1',
-        'contentHost': 'https://stable.dev.lcip.org',
-        'profileHost': 'https://stable.dev.lcip.org/profile/v1',
-        'scope': 'profile openid',
-    }
-
-
-@override_settings(FXA_CONFIG=FXA_CONFIG)
-def test_fxa_config_logged_in():
-    request = RequestFactory().get('/en-US/firefox/addons')
-    request.session = {'fxa_state': 'thestate!'}
-    request.user = UserProfile(email='me@mozilla.org')
-    assert utils.fxa_config(request) == {
-        'clientId': 'foo',
-        'state': 'thestate!',
-        'email': 'me@mozilla.org',
-        'oauthHost': 'https://oauth-stable.dev.lcip.org/v1',
-        'contentHost': 'https://stable.dev.lcip.org',
-        'profileHost': 'https://stable.dev.lcip.org/profile/v1',
-        'scope': 'profile openid',
-    }
-
-
-@override_settings(FXA_CONFIG=FXA_CONFIG)
-@override_settings(FXA_OAUTH_HOST='https://accounts.firefox.com/oauth')
-def test_default_fxa_login_url_with_state():
-    path = '/en-US/addons/abp/?source=ddg'
-    request = RequestFactory().get(path)
-    request.session = {'fxa_state': 'myfxastate'}
-    raw_url = utils.default_fxa_login_url(request)
-    url = urlparse(raw_url)
-    base = '{scheme}://{netloc}{path}'.format(
-        scheme=url.scheme, netloc=url.netloc, path=url.path
-    )
-    assert base == 'https://accounts.firefox.com/oauth/authorization'
-    query = parse_qs(url.query)
-    next_path = urlsafe_b64encode(force_bytes(path)).rstrip(b'=')
-    assert query == {
-        'action': ['signin'],
-        'client_id': ['foo'],
-        'scope': ['profile openid'],
-        'state': [f'myfxastate:{force_str(next_path)}'],
-    }
-
-
-@override_settings(FXA_CONFIG=FXA_CONFIG)
-@override_settings(FXA_OAUTH_HOST='https://accounts.firefox.com/oauth')
-def test_default_fxa_register_url_with_state():
-    path = '/en-US/addons/abp/?source=ddg'
-    request = RequestFactory().get(path)
-    request.session = {'fxa_state': 'myfxastate'}
-    raw_url = utils.default_fxa_register_url(request)
-    url = urlparse(raw_url)
-    base = '{scheme}://{netloc}{path}'.format(
-        scheme=url.scheme, netloc=url.netloc, path=url.path
-    )
-    assert base == 'https://accounts.firefox.com/oauth/authorization'
-    query = parse_qs(url.query)
-    next_path = urlsafe_b64encode(force_bytes(path)).rstrip(b'=')
-    assert query == {
-        'action': ['signup'],
-        'client_id': ['foo'],
-        'scope': ['profile openid'],
-        'state': [f'myfxastate:{force_str(next_path)}'],
-    }
 
 
 @override_settings(FXA_CONFIG=FXA_CONFIG)
@@ -201,21 +124,29 @@ def test_fxa_login_url_requiring_two_factor_auth_passing_token():
 def test_unicode_next_path():
     path = '/en-US/føø/bãr'
     request = RequestFactory().get(path)
-    request.session = {}
-    url = utils.default_fxa_login_url(request)
+    request.session = {'fxa_state': 'fake-state'}
+    url = utils.fxa_login_url(
+        config=FXA_CONFIG['default'],
+        state=request.session['fxa_state'],
+        next_path=utils.path_with_query(request),
+        action='signin',
+    )
     state = parse_qs(urlparse(url).query)['state'][0]
     next_path = urlsafe_b64decode(state.split(':')[1] + '===')
     assert next_path.decode('utf-8') == path
 
 
-@mock.patch('olympia.accounts.utils.default_fxa_login_url')
-def test_redirect_for_login(default_fxa_login_url):
-    login_url = 'https://example.com/login'
-    default_fxa_login_url.return_value = login_url
-    request = mock.MagicMock()
+@override_settings(FXA_CONFIG=FXA_CONFIG)
+def test_redirect_for_login():
+    request = RequestFactory().get('/somewhere')
+    request.session = {'fxa_state': 'fake-state'}
     response = utils.redirect_for_login(request)
-    default_fxa_login_url.assert_called_with(request)
-    assert response['location'] == login_url
+    assert response['location'] == utils.fxa_login_url(
+        config=FXA_CONFIG['default'],
+        state=request.session['fxa_state'],
+        next_path='/somewhere',
+        action='signin',
+    )
 
 
 @override_settings(DEBUG=True, USE_FAKE_FXA_AUTH=True)

--- a/src/olympia/accounts/utils.py
+++ b/src/olympia/accounts/utils.py
@@ -18,28 +18,6 @@ from olympia.core.logger import getLogger
 from .tasks import clear_sessions_event, delete_user_event, primary_email_change_event
 
 
-def fxa_config(request):
-    config = {
-        camel_case(key): value
-        for key, value in settings.FXA_CONFIG['default'].items()
-        if key != 'client_secret'
-    }
-    request.session.setdefault('fxa_state', generate_fxa_state())
-
-    config.update(
-        **{
-            'contentHost': settings.FXA_CONTENT_HOST,
-            'oauthHost': settings.FXA_OAUTH_HOST,
-            'profileHost': settings.FXA_PROFILE_HOST,
-            'scope': 'profile openid',
-            'state': request.session['fxa_state'],
-        }
-    )
-    if request.user.is_authenticated:
-        config['email'] = request.user.email
-    return config
-
-
 def fxa_login_url(
     config,
     state,

--- a/src/olympia/accounts/utils.py
+++ b/src/olympia/accounts/utils.py
@@ -79,32 +79,19 @@ def fxa_login_url(
     return f'{base_url}?{urlencode(query)}'
 
 
-def default_fxa_register_url(request):
-    request.session.setdefault('fxa_state', generate_fxa_state())
-    return fxa_login_url(
-        config=settings.FXA_CONFIG['default'],
-        state=request.session['fxa_state'],
-        next_path=path_with_query(request),
-        action='signup',
-    )
-
-
-def default_fxa_login_url(request):
-    request.session.setdefault('fxa_state', generate_fxa_state())
-    return fxa_login_url(
-        config=settings.FXA_CONFIG['default'],
-        state=request.session['fxa_state'],
-        next_path=path_with_query(request),
-        action='signin',
-    )
-
-
 def generate_fxa_state():
     return force_str(binascii.hexlify(os.urandom(32)))
 
 
 def redirect_for_login(request):
-    return HttpResponseRedirect(default_fxa_login_url(request))
+    request.session.setdefault('fxa_state', generate_fxa_state())
+    url = fxa_login_url(
+        config=settings.FXA_CONFIG['default'],
+        state=request.session['fxa_state'],
+        next_path=path_with_query(request),
+        action='signin',
+    )
+    return HttpResponseRedirect(url)
 
 
 def path_with_query(request):

--- a/src/olympia/amo/decorators.py
+++ b/src/olympia/amo/decorators.py
@@ -181,22 +181,3 @@ def allow_cross_site_request(f):
         return response
 
     return wrapper
-
-
-def allow_mine(f):
-    @functools.wraps(f)
-    def wrapper(request, user_id, *args, **kw):
-        """
-        If the author is `mine` then show the current user's collection
-        (or something).
-        """
-        # Prevent circular ref in accounts.utils
-        from olympia.accounts.utils import redirect_for_login
-
-        if user_id == 'mine':
-            if not request.user.is_authenticated:
-                return redirect_for_login(request)
-            user_id = request.user.id
-        return f(request, user_id, *args, **kw)
-
-    return wrapper

--- a/src/olympia/amo/tests/test_views.py
+++ b/src/olympia/amo/tests/test_views.py
@@ -296,7 +296,7 @@ class TestOtherStuff(TestCase):
         doc = pq(response.content)
         expected_link = (
             'http://testserver/api/v5/accounts/login/start/'
-            '?to=/en-US/firefox/pages/appversions/'
+            '?to=%2Fen-US%2Ffirefox%2Fpages%2Fappversions%2F'
         )
         assert doc('.account.anonymous a')[1].attrib['href'] == expected_link
 

--- a/src/olympia/amo/tests/test_views.py
+++ b/src/olympia/amo/tests/test_views.py
@@ -291,26 +291,28 @@ class TestOtherStuff(TestCase):
 
         title_eq('/firefox/', 'Firefox', 'Add-ons')
 
-    @patch(
-        'olympia.accounts.utils.default_fxa_login_url',
-        lambda request: 'https://login.com',
-    )
     def test_login_link(self):
-        r = self.client.get(reverse('apps.appversions'), follow=True)
-        doc = pq(r.content)
-        assert 'https://login.com' == (doc('.account.anonymous a')[1].attrib['href'])
+        response = self.client.get(reverse('apps.appversions'), follow=True)
+        doc = pq(response.content)
+        expected_link = (
+            'http://testserver/api/v5/accounts/login/start/'
+            '?to=/en-US/firefox/pages/appversions/'
+        )
+        assert doc('.account.anonymous a')[1].attrib['href'] == expected_link
 
     def test_tools_loggedout(self):
-        r = self.client.get(reverse('apps.appversions'), follow=True)
-        assert pq(r.content)('#aux-nav .tools').length == 0
+        response = self.client.get(reverse('apps.appversions'), follow=True)
+        assert pq(response.content)('#aux-nav .tools').length == 0
 
     def test_language_selector(self):
         doc = pq(test.Client().get('/en-US/firefox/pages/appversions/').content)
         assert doc('form.languages option[selected]').attr('value') == 'en-us'
 
     def test_language_selector_variables(self):
-        r = self.client.get('/en-US/firefox/pages/appversions/?foo=fooval&bar=barval')
-        doc = pq(r.content)('form.languages')
+        response = self.client.get(
+            '/en-US/firefox/pages/appversions/?foo=fooval&bar=barval'
+        )
+        doc = pq(response.content)('form.languages')
 
         assert doc('input[type=hidden][name=foo]').attr('value') == 'fooval'
         assert doc('input[type=hidden][name=bar]').attr('value') == 'barval'

--- a/src/olympia/devhub/templates/devhub/new-landing/components/submit_or_manage_extension.html
+++ b/src/olympia/devhub/templates/devhub/new-landing/components/submit_or_manage_extension.html
@@ -8,7 +8,7 @@
         Sign in to the Developer Hub to submit or manage extensions and themes.
         {% endtrans %}
       </p>
-      <a href="{{ register_link() }}">{{ _('Register for a developer account or log in to the Developer Hub') }}</a>
+      <a href="{{ login_link() }}">{{ _('Register for a developer account or log in to the Developer Hub') }}</a>
     </div>
     <div class="DevHub-content-image-wrapper DevHub-content-image-wrapper--submit-or-manage">
       <img class="DevHub-content-image DevHub-content-image--submit-or-manage"

--- a/src/olympia/templates/impala/base.html
+++ b/src/olympia/templates/impala/base.html
@@ -40,7 +40,6 @@
         data-readonly="{{ settings.READ_ONLY|json }}"
         data-media-url="{{ MEDIA_URL }}"
         data-static-url="{{ STATIC_URL }}"
-        data-fxa-config="{{ fxa_config()|json }}"
         {% block bodyattrs %}{% endblock %}>
 
     <div id="main-wrapper">

--- a/src/olympia/templates/impala/user_login.html
+++ b/src/olympia/templates/impala/user_login.html
@@ -21,7 +21,7 @@
   </li>
 {% elif request.session %}
   <li class="account anonymous nomenu login legacy">
-    {% trans reg=register_link(), login=login_link() %}
+    {% trans reg=login_link(), login=login_link() %}
         <a href="{{ reg }}">Register</a> or <a href="{{ login }}">Log in</a>
     {% endtrans %}
   </li>

--- a/src/olympia/zadmin/tests/test_views.py
+++ b/src/olympia/zadmin/tests/test_views.py
@@ -2,6 +2,7 @@ import json
 
 from unittest import mock
 
+from django.http import HttpResponseRedirect
 from django.urls import reverse
 
 from pyquery import PyQuery as pq
@@ -59,10 +60,10 @@ class TestHomeAndIndex(TestCase):
         # but they don't see any modules.
         assert len(modules) == 0
 
-    @mock.patch('olympia.accounts.utils.default_fxa_login_url')
-    def test_django_login_page(self, default_fxa_login_url):
+    @mock.patch('olympia.zadmin.admin.redirect_for_login')
+    def test_django_login_page(self, redirect_for_login):
         login_url = 'https://example.com/fxalogin'
-        default_fxa_login_url.return_value = login_url
+        redirect_for_login.return_value = HttpResponseRedirect(login_url)
         # Check we can actually access the /login page - django admin uses it.
         url = reverse('admin:login')
         response = self.client.get(url)
@@ -85,10 +86,10 @@ class TestHomeAndIndex(TestCase):
         response = self.client.get(url)
         self.assert3xx(response, '/en-US/admin/models/')
 
-    @mock.patch('olympia.accounts.utils.default_fxa_login_url')
-    def test_django_login_page_with_next(self, default_fxa_login_url):
+    @mock.patch('olympia.zadmin.admin.redirect_for_login')
+    def test_django_login_page_with_next(self, redirect_for_login):
         login_url = 'https://example.com/fxalogin'
-        default_fxa_login_url.return_value = login_url
+        redirect_for_login.return_value = HttpResponseRedirect(login_url)
 
         # if django admin passes on a next param, check we use it.
         url = reverse('admin:login') + '?next=/en-US/admin/models/addon/'


### PR DESCRIPTION
This allows us to avoid modifying the session on pages that just want to display a login/register link, which in turn avoids creating a new session and potentially returning a session cookie to anonymous users.

Fixes https://github.com/mozilla/addons-server/issues/18556