### PR TITLE
Move CREATE_ADDON activity log to always log addon creation regardless of source

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -892,6 +892,8 @@ class Addon(OnChangeMixin, ModelBase):
             )
         if user:
             AddonUser(addon=addon, user=user).save()
+        activity.log_create(amo.LOG.CREATE_ADDON, addon)
+        log.info(f'New addon {addon!r} from {upload!r}')
         timer.log_interval('7.end')
         return addon
 
@@ -916,7 +918,6 @@ class Addon(OnChangeMixin, ModelBase):
         assert parsed_data is not None
 
         addon = cls.initialize_addon_from_upload(parsed_data, upload, channel, user)
-
         Version.from_upload(
             upload=upload,
             addon=addon,
@@ -924,10 +925,6 @@ class Addon(OnChangeMixin, ModelBase):
             selected_apps=selected_apps,
             parsed_data=parsed_data,
         )
-
-        activity.log_create(amo.LOG.CREATE_ADDON, addon)
-        log.info(f'New addon {addon!r} from {upload!r}')
-
         return addon
 
     @classmethod

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -2721,6 +2721,20 @@ class TestAddonFromUpload(UploadMixin, TestCase):
         # Normalized from `en` to `en-US`
         assert addon.default_locale == 'en-US'
 
+    def test_activity_log(self):
+        core.set_user(self.user)
+        self.upload = self.get_upload('webextension.xpi')
+        parsed_data = parse_addon(self.upload, user=self.user)
+        addon = Addon.from_upload(
+            self.upload, [self.selected_app], parsed_data=parsed_data
+        )
+        assert addon
+        assert (
+            ActivityLog.objects.for_addons(addon)
+            .filter(action=amo.LOG.CREATE_ADDON.id)
+            .exists()
+        )
+
 
 REDIRECT_URL = 'https://outgoing.prod.mozaws.net/v1/'
 

--- a/src/olympia/signing/tests/test_views.py
+++ b/src/olympia/signing/tests/test_views.py
@@ -142,6 +142,11 @@ class TestUploadVersion(BaseUploadVersionTestMixin, TestCase):
         latest_version = addon.find_latest_version(channel=amo.RELEASE_CHANNEL_UNLISTED)
         assert latest_version
         assert latest_version.channel == amo.RELEASE_CHANNEL_UNLISTED
+        assert (
+            ActivityLog.objects.for_addons(addon)
+            .filter(action=amo.LOG.CREATE_ADDON.id)
+            .exists()
+        )
 
     def test_new_addon_random_slug_unlisted_channel(self):
         guid = '@create-webextension'


### PR DESCRIPTION
Fixes #14190