### PR TITLE
Stop exposing reviewer names to developers in activity emails

### DIFF
--- a/src/olympia/activity/templates/activity/emails/from_reviewer.txt
+++ b/src/olympia/activity/templates/activity/emails/from_reviewer.txt
@@ -1,6 +1,6 @@
 Hello,
 
-{{ author }}, a reviewer at addons.mozilla.org, found an issue when reviewing version {{ number }} of the add-on {{ name }} and requests additional information. You are receiving this email because {{ email_reason }}.
+A reviewer at addons.mozilla.org, found an issue when reviewing version {{ number }} of the add-on {{ name }} and requests additional information. You are receiving this email because {{ email_reason }}.
 
 *********
 {{ author }} wrote:

--- a/src/olympia/activity/templates/activity/emails/from_reviewer.txt
+++ b/src/olympia/activity/templates/activity/emails/from_reviewer.txt
@@ -1,6 +1,6 @@
 Hello,
 
-A reviewer at addons.mozilla.org, found an issue when reviewing version {{ number }} of the add-on {{ name }} and requests additional information. You are receiving this email because {{ email_reason }}.
+A reviewer at addons.mozilla.org found an issue when reviewing version {{ number }} of the add-on {{ name }} and requests additional information. You are receiving this email because {{ email_reason }}.
 
 *********
 {{ author }} wrote:

--- a/src/olympia/activity/tests/test_utils.py
+++ b/src/olympia/activity/tests/test_utils.py
@@ -19,7 +19,7 @@ from olympia.access.models import Group, GroupUser
 from olympia.activity.models import MAX_TOKEN_USE_COUNT, ActivityLog, ActivityLogToken
 from olympia.activity.utils import (
     ACTIVITY_MAIL_GROUP,
-    ADDON_REVIEWER,
+    ADDON_REVIEWER_NAME,
     ActivityEmailEncodingError,
     ActivityEmailError,
     ActivityEmailParser,
@@ -309,6 +309,7 @@ class TestLogAndNotify(TestCase):
         call,
         url,
         reason_text,
+        *,
         author,
         is_from_developer=False,
         is_to_developer=False,
@@ -324,7 +325,7 @@ class TestLogAndNotify(TestCase):
         assert 'If we do not hear from you within' not in body
         assert self.reviewer.name not in body
         if is_to_developer and not is_from_developer:
-            assert ('%s wrote:' % ADDON_REVIEWER) in body
+            assert ('%s wrote:' % ADDON_REVIEWER_NAME) in body
         else:
             assert ('%s wrote:' % author.name) in body
 
@@ -356,9 +357,9 @@ class TestLogAndNotify(TestCase):
             send_mail_mock.call_args_list[0],
             absolutify(self.addon.get_dev_url('versions')),
             'you are listed as an author of this add-on.',
-            self.developer,
-            True,
-            True,
+            author=self.developer,
+            is_from_developer=True,
+            is_to_developer=True,
         )
         review_url = absolutify(
             reverse(
@@ -371,9 +372,9 @@ class TestLogAndNotify(TestCase):
             send_mail_mock.call_args_list[1],
             review_url,
             'you reviewed this add-on.',
-            self.developer,
-            True,
-            True,
+            author=self.developer,
+            is_from_developer=True,
+            is_to_developer=True,
         )
 
     @mock.patch('olympia.activity.utils.send_mail')
@@ -391,7 +392,7 @@ class TestLogAndNotify(TestCase):
         assert logs[0].details['comments'] == 'Thîs ïs a revïewer replyîng'
 
         assert send_mail_mock.call_count == 2  # Both authors.
-        sender = formataddr((ADDON_REVIEWER, NOTIFICATIONS_FROM_EMAIL))
+        sender = formataddr((ADDON_REVIEWER_NAME, NOTIFICATIONS_FROM_EMAIL))
         assert sender == send_mail_mock.call_args_list[0][1]['from_email']
         recipients = self._recipients(send_mail_mock)
         assert len(recipients) == 2
@@ -404,17 +405,17 @@ class TestLogAndNotify(TestCase):
             send_mail_mock.call_args_list[0],
             absolutify(self.addon.get_dev_url('versions')),
             'you are listed as an author of this add-on.',
-            self.developer,
-            False,
-            True,
+            author=self.reviewer,
+            is_from_developer=False,
+            is_to_developer=True,
         )
         self._check_email(
             send_mail_mock.call_args_list[1],
             absolutify(self.addon.get_dev_url('versions')),
             'you are listed as an author of this add-on.',
-            self.developer,
-            False,
-            True,
+            author=self.reviewer,
+            is_from_developer=False,
+            is_to_developer=True,
         )
 
     @mock.patch('olympia.activity.utils.send_mail')
@@ -476,7 +477,7 @@ class TestLogAndNotify(TestCase):
             send_mail_mock.call_args_list[1],
             review_url,
             'you are member of the activity email cc group.',
-            self.developer,
+            author=self.developer,
         )
 
     @mock.patch('olympia.activity.utils.send_mail')
@@ -544,7 +545,7 @@ class TestLogAndNotify(TestCase):
             send_mail_mock.call_args_list[0],
             absolutify(self.addon.get_dev_url('versions')),
             'you are listed as an author of this add-on.',
-            self.developer,
+            author=self.developer,
         )
         review_url = absolutify(
             reverse(
@@ -557,7 +558,7 @@ class TestLogAndNotify(TestCase):
             send_mail_mock.call_args_list[1],
             review_url,
             'you reviewed this add-on.',
-            self.developer,
+            author=self.developer,
         )
 
     @mock.patch('olympia.activity.utils.send_mail')
@@ -590,7 +591,7 @@ class TestLogAndNotify(TestCase):
             send_mail_mock.call_args_list[0],
             absolutify(self.addon.get_dev_url('versions')),
             'you are listed as an author of this add-on.',
-            self.developer,
+            author=self.developer,
         )
         review_url = absolutify(
             reverse(
@@ -603,7 +604,7 @@ class TestLogAndNotify(TestCase):
             send_mail_mock.call_args_list[1],
             review_url,
             'you reviewed this add-on.',
-            self.developer,
+            author=self.developer,
         )
 
     @mock.patch('olympia.activity.utils.send_mail')
@@ -643,7 +644,7 @@ class TestLogAndNotify(TestCase):
         assert ActivityLog.objects.count() == 1  # No new activity created.
 
         assert send_mail_mock.call_count == 2  # Both authors.
-        sender = formataddr((ADDON_REVIEWER, NOTIFICATIONS_FROM_EMAIL))
+        sender = formataddr((ADDON_REVIEWER_NAME, NOTIFICATIONS_FROM_EMAIL))
         assert sender == send_mail_mock.call_args_list[0][1]['from_email']
         recipients = self._recipients(send_mail_mock)
         assert len(recipients) == 2
@@ -656,17 +657,17 @@ class TestLogAndNotify(TestCase):
             send_mail_mock.call_args_list[0],
             absolutify(self.addon.get_dev_url('versions')),
             'you are listed as an author of this add-on.',
-            self.reviewer,
-            False,
-            True,
+            author=self.reviewer,
+            is_from_developer=False,
+            is_to_developer=True,
         )
         self._check_email(
             send_mail_mock.call_args_list[1],
             absolutify(self.addon.get_dev_url('versions')),
             'you are listed as an author of this add-on.',
-            self.reviewer,
-            False,
-            True,
+            author=self.reviewer,
+            is_from_developer=False,
+            is_to_developer=True,
         )
 
 

--- a/src/olympia/activity/utils.py
+++ b/src/olympia/activity/utils.py
@@ -34,8 +34,9 @@ ACTIVITY_MAIL_GROUP = 'Activity Mail CC'
 NOTIFICATIONS_FROM_EMAIL = 'notifications@%s' % settings.INBOUND_EMAIL_DOMAIN
 SOCKETLABS_SPAM_THRESHOLD = 10.0
 # Types of users who might be sending or receiving emails.
-ADDON_AUTHOR = 'An add-on author'
-ADDON_REVIEWER = 'An add-on reviewer'
+USER_TYPE_ADDON_AUTHOR = 1
+USER_TYPE_ADDON_REVIEWER = 2
+ADDON_REVIEWER_NAME = 'An add-on reviewer'
 
 
 class ActivityEmailError(ValueError):
@@ -209,23 +210,23 @@ def add_email_to_activity_log(parser):
 
 def type_of_user(user, version):
     if version.addon.authors.filter(pk=user.pk).exists():
-        return ADDON_AUTHOR
+        return USER_TYPE_ADDON_AUTHOR
     if acl.is_user_any_kind_of_reviewer(user):
-        return ADDON_REVIEWER
+        return USER_TYPE_ADDON_REVIEWER
 
 
 def action_from_user(user, version):
-    if type_of_user(user, version) == ADDON_AUTHOR:
+    if type_of_user(user, version) == USER_TYPE_ADDON_AUTHOR:
         return amo.LOG.DEVELOPER_REPLY_VERSION
-    if type_of_user(user, version) == ADDON_REVIEWER:
+    if type_of_user(user, version) == USER_TYPE_ADDON_REVIEWER:
         return amo.LOG.REVIEWER_REPLY_VERSION
 
 
 def template_from_user(user, version):
     template = 'activity/emails/developer.txt'
     if (
-        type_of_user(user, version) != ADDON_AUTHOR
-        and type_of_user(user, version) == ADDON_REVIEWER
+        type_of_user(user, version) != USER_TYPE_ADDON_AUTHOR
+        and type_of_user(user, version) == USER_TYPE_ADDON_REVIEWER
     ):
         template = 'activity/emails/from_reviewer.txt'
     return loader.get_template(template)
@@ -271,7 +272,9 @@ def notify_about_activity_log(
 
     type_of_sender = type_of_user(note.user, version)
     sender_name = (
-        ADDON_REVIEWER if type_of_sender == ADDON_REVIEWER else note.author_name
+        ADDON_REVIEWER_NAME
+        if type_of_sender == USER_TYPE_ADDON_REVIEWER
+        else note.author_name
     )
 
     # Collect add-on authors (excl. the person who sent the email.) and build
@@ -313,15 +316,15 @@ def notify_about_activity_log(
             task_user = {get_task_user()}
         except UserProfile.DoesNotExist:
             task_user = set()
-        # Update the author and from_email to use the real name in all cases.
+        # Update the author and from_email to use the real name because it will
+        # be used in emails to reviewers and staff, and not add-on developers.
         from_email = formataddr((note.author_name, NOTIFICATIONS_FROM_EMAIL))
         reviewer_context_dict = author_context_dict.copy()
         reviewer_context_dict['author'] = note.author_name
 
     if send_to_reviewers:
         # Collect reviewers on the thread (excl. the email sender and task user
-        # for automated messages), build the context for them and send them
-        # their copy.
+        # for automated messages) and send them their copy.
         log_users = {
             alog.user
             for alog in ActivityLog.objects.for_versions(version)


### PR DESCRIPTION
Fixes #18566 