### PR TITLE
Add importlib-metadata to doc.txt builds as required by Sphinx >= 4.4.0

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -101,3 +101,11 @@ snowballstemmer==2.2.0 \
 chardet==4.0.0 \
     --hash=sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5 \
     --hash=sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa
+# importlib-metadata is required by sphinx
+importlib-metadata==4.10.1 \
+    --hash=sha256:899e2a40a8c4a1aec681feef45733de8a6c58f3f6a0dbed2eb6574b4387a77b6 \
+    --hash=sha256:951f0d8a5b7260e9db5e41d429285b5f451e928479f19d80818878527d36e95e
+# zipp is required by importlib-metadata
+zipp==3.7.0 \
+    --hash=sha256:b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375 \
+    --hash=sha256:9f50f446828eb9d45b267433fd3e9da8d801f614129124863f9c51ebceafb87d


### PR DESCRIPTION
Fixes... https://readthedocs.org/projects/addons-server/builds/15807681/