### PR TITLE
fxa notification webhook

### DIFF
--- a/docs/topics/api/auth_internal.rst
+++ b/docs/topics/api/auth_internal.rst
@@ -38,3 +38,18 @@ When making an authenticated API request, put your generated API Token into an
 HTTP Authorization header prefixed with ``Bearer``, like this::
 
     Authorization: Bearer eyJhdXRoX2hhc2giOiJiY2E0MTZkN2RiMGU3NjFmYTA2NDE4MjAzZWU1NTMwOTM4OGZhNzcxIiwidXNlcl9pZCI6MTIzNDV9:1cqe2Q:cPMlmz8ejIkutD-gNo3EWU8IfL8
+
+
+========================
+FxA Notification Webhook
+========================
+
+To integrate with Firefox Account's `webhook <https://mozilla.github.io/ecosystem-platform/platform/firefox-accounts/integration-with-fxa#webhook-events>`_
+the following endpoint is available:
+
+``/api/auth/fxa-notification/``
+
+Authentication is accomplished by decoding using the known `JWT keys available` <https://oauth.accounts.firefox.com/v1/jwks>`_
+- normal AMO authentication is not used.
+
+This endpoint is not usable for anything other than AMOs internal integration with Firefox Accounts.

--- a/src/olympia/accounts/tests/test_verify.py
+++ b/src/olympia/accounts/tests/test_verify.py
@@ -18,7 +18,7 @@ class TestProfile(TestCase):
         profile_data = {'email': 'yo@oy.com'}
         self.get.return_value.status_code = 200
         self.get.return_value.json.return_value = profile_data
-        profile = verify.get_fxa_profile('profile-plz', {})
+        profile = verify.get_fxa_profile('profile-plz')
         assert profile == profile_data
         self.get.assert_called_with(
             'https://app.fxa/v1/profile',
@@ -33,7 +33,7 @@ class TestProfile(TestCase):
         self.get.return_value.status_code = 200
         self.get.return_value.json.return_value = profile_data
         with pytest.raises(verify.IdentificationError):
-            verify.get_fxa_profile('profile-plz', {})
+            verify.get_fxa_profile('profile-plz')
         self.get.assert_called_with(
             'https://app.fxa/v1/profile',
             headers={
@@ -47,7 +47,7 @@ class TestProfile(TestCase):
         self.get.return_value.status_code = 400
         self.get.json.return_value = profile_data
         with pytest.raises(verify.IdentificationError):
-            verify.get_fxa_profile('profile-plz', {})
+            verify.get_fxa_profile('profile-plz')
         self.get.assert_called_with(
             'https://app.fxa/v1/profile',
             headers={
@@ -154,7 +154,7 @@ class TestIdentify(TestCase):
         with pytest.raises(verify.IdentificationError):
             verify.fxa_identify('heya', self.CONFIG)
         self.get_token.assert_called_with('heya', self.CONFIG)
-        self.get_profile.assert_called_with('bee5', self.CONFIG)
+        self.get_profile.assert_called_with('bee5')
 
     def test_all_good(self):
         self.get_token.return_value = {'access_token': 'cafe'}
@@ -162,7 +162,7 @@ class TestIdentify(TestCase):
         identity = verify.fxa_identify('heya', self.CONFIG)
         assert identity == ({'email': 'me@em.hi'}, None)
         self.get_token.assert_called_with('heya', self.CONFIG)
-        self.get_profile.assert_called_with('cafe', self.CONFIG)
+        self.get_profile.assert_called_with('cafe')
 
     def test_with_id_token(self):
         self.get_token.return_value = {
@@ -173,4 +173,4 @@ class TestIdentify(TestCase):
         identity = verify.fxa_identify('heya', self.CONFIG)
         assert identity == ({'email': 'me@em.hi'}, 'openidisawesome')
         self.get_token.assert_called_with('heya', self.CONFIG)
-        self.get_profile.assert_called_with('cafe', self.CONFIG)
+        self.get_profile.assert_called_with('cafe')

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -1,6 +1,6 @@
 import base64
-import datetime
 import json
+from datetime import datetime
 from unittest import mock
 
 from os import path
@@ -14,10 +14,13 @@ from django.test import RequestFactory
 from django.test.utils import override_settings
 from django.utils.encoding import force_str
 
-from rest_framework.exceptions import PermissionDenied
+import freezegun
+import responses
+from rest_framework import exceptions
 from rest_framework.settings import api_settings
 from rest_framework.test import APIClient, APIRequestFactory
 from waffle.models import Switch
+from waffle.testutils import override_switch
 
 from olympia import amo
 from olympia.access.acl import action_allowed_user
@@ -287,9 +290,9 @@ class TestFindUser(TestCase):
             fxa_id='abc',
             email='me@amo.ca',
             deleted=True,
-            banned=datetime.datetime.now(),
+            banned=datetime.now(),
         )
-        with self.assertRaises(PermissionDenied):
+        with self.assertRaises(exceptions.PermissionDenied):
             views.find_user({'uid': 'abc', 'email': 'you@amo.ca'})
 
     def test_find_user_deleted(self):
@@ -298,9 +301,9 @@ class TestFindUser(TestCase):
 
     def test_find_user_mozilla(self):
         task_user = user_factory(id=settings.TASK_USER_ID, fxa_id='abc')
-        with self.assertRaises(PermissionDenied):
+        with self.assertRaises(exceptions.PermissionDenied):
             views.find_user({'uid': '123456', 'email': task_user.email})
-        with self.assertRaises(PermissionDenied):
+        with self.assertRaises(exceptions.PermissionDenied):
             views.find_user({'uid': task_user.fxa_id, 'email': 'doesnt@matta'})
 
 
@@ -1024,7 +1027,7 @@ class TestAuthenticateView(TestCase, PatchMixin, InitializeSessionMixin):
             email='real@yeahoo.com',
             fxa_id='10',
             deleted=True,
-            banned=datetime.datetime.now(),
+            banned=datetime.now(),
         )
         identity = {'email': 'real@yeahoo.com', 'uid': '9001'}
         self.fxa_identify.return_value = identity, 'someopenidtoken'
@@ -2269,3 +2272,168 @@ class TestAccountNotificationUnsubscribe(TestCase):
         response = self.client.post(self.url, data=data)
         assert response.status_code == 403
         assert response.data == {'detail': 'Email address not found.'}
+
+
+class TestFxaNotificationView(TestCase):
+    FXA_ID = 'ABCDEF012345689'
+    FXA_EVENT = {
+        'iss': 'https://accounts.firefox.com/',
+        'sub': FXA_ID,
+        'aud': 'REMOTE_SYSTEM',
+        'iat': 1565720808,
+        'jti': 'e19ed6c5-4816-4171-aa43-56ffe80dbda1',
+        'events': {
+            'https://schemas.accounts.firefox.com/event/profile-change': {
+                'email': 'example@mozilla.com'
+            }
+        },
+    }
+    JWKS_RESPONSE = {
+        'keys': [
+            {
+                'kty': 'RSA',
+                'alg': 'RS256',
+                'kid': '20190730-15e473fd',
+                'fxa-createdAt': 1564502400,
+                'use': 'sig',
+                'n': '15OpVGC7ws_SlU0gRbRh1Iwo8_gR8ElX2CDnbN5blKyXLg-ll0ogktoDXc-tDvTab'
+                'RTxi7AXU0wWQ247odhHT47y5uz0GASYXdfPponynQ_xR9CpNn1eEL1gvDhQN9rfPIzfncl'
+                '8FUi9V4WMd5f600QC81yDw9dX-Z8gdkru0aDaoEKF9-wU2TqrCNcQdiJCX9BISotjz_9cm'
+                'GwKXFEekQNJWBeRQxH2bUmgwUK0HaqwW9WbYOs-zstNXXWFsgK9fbDQqQeGehXLZM4Cy5M'
+                'gl_iuSvnT3rLzPo2BmlxMLUvRqBx3_v8BTtwmNGA0v9O0FJS_mnDq0Iue0Dz8BssQCQ',
+                'e': 'AQAB',
+            }
+        ]
+    }
+
+    def test_get_fxa_verifying_keys(self):
+        responses.add(
+            responses.GET,
+            f'{settings.FXA_OAUTH_HOST}/jwks',
+            json=self.JWKS_RESPONSE,
+        )
+        responses.add(
+            responses.GET,
+            f'{settings.FXA_OAUTH_HOST}/jwks',
+            json={},
+        )
+        view = views.FxaNotificationView()
+        assert view.get_fxa_verifying_keys() == self.JWKS_RESPONSE['keys']
+        # the call is cached on .fxa_verifiying_keys after the first call
+        assert view.get_fxa_verifying_keys() == self.JWKS_RESPONSE['keys']
+        del view.fxa_verifying_keys
+        with self.assertRaises(exceptions.AuthenticationFailed):
+            view.get_fxa_verifying_keys()
+
+    @mock.patch('olympia.accounts.views.jwt.decode')
+    def test_get_jwt(self, decode_mock):
+        view = views.FxaNotificationView()
+        view.fxa_verifying_keys = [
+            {'kty': 'RSA', 'alg': 'fooo'},  # should be ignored
+            *self.JWKS_RESPONSE['keys'],
+        ]
+        decode_mock.return_value = self.FXA_EVENT
+        request = RequestFactory().get('/', HTTP_AUTHORIZATION='Bearer fooo')
+
+        authd_jwt = view.get_jwt(request)
+        assert authd_jwt == self.FXA_EVENT
+
+    def test_post(self):
+        url = reverse_ns('fxa-notification', api_version='auth')
+        class_path = (
+            f'{views.FxaNotificationView.__module__}.'
+            f'{views.FxaNotificationView.__name__}'
+        )
+        with (
+            mock.patch(f'{class_path}.get_jwt') as get_jwt_mock,
+            mock.patch(f'{class_path}.process_event') as process_event_mock,
+            freezegun.freeze_time(),
+        ):
+            get_jwt_mock.return_value = self.FXA_EVENT
+            response = self.client.post(url)
+            process_event_mock.assert_called_with(
+                self.FXA_ID,
+                views.FxaNotificationView.FXA_PROFILE_CHANGE_EVENT,
+                {'email': 'example@mozilla.com'},
+            )
+        assert response.status_code == 202
+
+    @mock.patch('olympia.accounts.utils.primary_email_change_event.delay')
+    def test_process_event_email_change(self, event_mock):
+        view = views.FxaNotificationView()
+        with freezegun.freeze_time():
+            view.process_event(
+                self.FXA_ID,
+                view.FXA_PROFILE_CHANGE_EVENT,
+                {'email': 'new-email@example.com'},
+            )
+            event_mock.assert_called_with(
+                self.FXA_ID, datetime.now().timestamp(), 'new-email@example.com'
+            )
+
+    def test_process_event_email_change_integration(self):
+        user = user_factory(
+            email='old-email@example.com',
+            fxa_id=self.FXA_ID,
+            email_changed=datetime(2017, 10, 11),
+        )
+        view = views.FxaNotificationView()
+        with freezegun.freeze_time():
+            view.process_event(
+                self.FXA_ID,
+                view.FXA_PROFILE_CHANGE_EVENT,
+                {'email': 'new-email@example.com'},
+            )
+            now = datetime.now()
+        user.reload()
+        assert user.email == 'new-email@example.com'
+        assert user.email_changed == now
+
+    @mock.patch('olympia.accounts.utils.delete_user_event.delay')
+    def test_process_event_delete(self, event_mock):
+        view = views.FxaNotificationView()
+        with freezegun.freeze_time():
+            view.process_event(
+                self.FXA_ID,
+                view.FXA_DELETE_EVENT,
+                {},
+            )
+            event_mock.assert_called_with(self.FXA_ID, datetime.now().timestamp())
+
+    @override_switch('fxa-account-delete', active=True)
+    def test_process_event_delete_integration(self):
+        user = user_factory(fxa_id=self.FXA_ID)
+        view = views.FxaNotificationView()
+        view.process_event(
+            self.FXA_ID,
+            view.FXA_DELETE_EVENT,
+            {},
+        )
+        user.reload()
+        assert user.email is not None
+        assert user.deleted
+        assert user.fxa_id is not None
+
+    @mock.patch('olympia.accounts.utils.clear_sessions_event.delay')
+    def test_process_event_password_change(self, event_mock):
+        view = views.FxaNotificationView()
+        with freezegun.freeze_time():
+            view.process_event(
+                self.FXA_ID,
+                view.FXA_PASSWORDCHANGE_EVENT,
+                {},
+            )
+            event_mock.assert_called_with(
+                self.FXA_ID, datetime.now().timestamp(), 'password-change'
+            )
+
+    def test_process_event_password_change_integration(self):
+        user = user_factory(fxa_id=self.FXA_ID)
+        view = views.FxaNotificationView()
+        view.process_event(
+            self.FXA_ID,
+            view.FXA_PASSWORDCHANGE_EVENT,
+            {},
+        )
+        user.reload()
+        assert user.auth_id is None

--- a/src/olympia/accounts/urls.py
+++ b/src/olympia/accounts/urls.py
@@ -51,10 +51,15 @@ accounts_v3 = accounts_v4 + [
     ),
 ]
 
-auth_callback_patterns = [
+auth_urls = [
     re_path(
         r'^authenticate-callback/$',
         views.AuthenticateView.as_view(),
         name='accounts.authenticate',
+    ),
+    re_path(
+        r'^fxa-notification',
+        views.FxaNotificationView.as_view(),
+        name='fxa-notification',
     ),
 ]

--- a/src/olympia/accounts/verify.py
+++ b/src/olympia/accounts/verify.py
@@ -22,7 +22,7 @@ def fxa_identify(code, config=None):
     try:
         with statsd.timer('accounts.fxa.identify.all'):
             data = get_fxa_token(code, config)
-            profile = get_fxa_profile(data['access_token'], config)
+            profile = get_fxa_profile(data['access_token'])
     except Exception:
         statsd.incr('accounts.fxa.identify.all.fail')
         raise
@@ -63,7 +63,7 @@ def get_fxa_token(code, config):
         raise IdentificationError(f'Could not get access token for {code}')
 
 
-def get_fxa_profile(token, config):
+def get_fxa_profile(token):
     """Given a FxA access token, return profile information for the
     corresponding user."""
     with statsd.timer('accounts.fxa.identify.profile'):

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -3,6 +3,7 @@ import binascii
 import functools
 import os
 
+from datetime import datetime
 from urllib.parse import quote_plus
 
 from django.conf import settings
@@ -17,6 +18,8 @@ from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.cache import never_cache
 
+import jwt
+import requests
 import waffle
 
 from corsheaders.conf import conf as corsheaders_conf
@@ -28,10 +31,10 @@ from corsheaders.middleware import (
     ACCESS_CONTROL_MAX_AGE,
 )
 from django_statsd.clients import statsd
+from rest_framework import exceptions
 from rest_framework import serializers
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import action
-from rest_framework.exceptions import PermissionDenied
 from rest_framework.generics import GenericAPIView
 from rest_framework.mixins import (
     DestroyModelMixin,
@@ -73,6 +76,7 @@ from .serializers import (
     UserNotificationSerializer,
     UserProfileSerializer,
 )
+from .tasks import clear_sessions_event, delete_user_event, primary_email_change_event
 from .utils import fxa_login_url, generate_fxa_state
 
 
@@ -134,7 +138,7 @@ def find_user(identity):
             # Alternatively if someone tried to log in as the task user then
             # prevent that because that user "owns" a number of important
             # addons and collections, and it's actions are special cased.
-            raise PermissionDenied()
+            raise exceptions.PermissionDenied()
         return user
     except UserProfile.DoesNotExist:
         return None
@@ -774,3 +778,88 @@ class AccountNotificationUnsubscribeView(AccountNotificationMixin, GenericAPIVie
                 _('Notification [%s] does not exist') % notification_name
             )
         return Response(serializer.data)
+
+
+class FxaNotificationView(FxAConfigMixin, APIView):
+    authentication_classes = []  # TODO: reimplement FxA auth in authentication_class?
+    permission_classes = []
+
+    FXA_PROFILE_CHANGE_EVENT = (
+        'https://schemas.accounts.firefox.com/event/profile-change'
+    )
+    FXA_DELETE_EVENT = 'https://schemas.accounts.firefox.com/event/delete-user'
+    FXA_PASSWORDCHANGE_EVENT = (
+        'https://schemas.accounts.firefox.com/event/password-change'
+    )
+
+    def get_fxa_verifying_keys(self):
+        if not hasattr(self, 'fxa_verifying_keys'):
+            response = requests.get(f'{settings.FXA_OAUTH_HOST}/jwks')
+            self.fxa_verifying_keys = (
+                response.json().get('keys') if response.status_code == 200 else []
+            )
+
+        if not self.fxa_verifying_keys:
+            raise exceptions.AuthenticationFailed(
+                'FXA verifying keys are not available.'
+            )
+
+        return self.fxa_verifying_keys
+
+    def get_jwt(self, request):
+        request_jwt = request.headers['Authorization'].split('Bearer ')[1]
+        client_id = self.get_fxa_config(request)['client_id']
+
+        for verifying_key in self.get_fxa_verifying_keys():
+            if verifying_key['alg'] != 'RS256':
+                # we only support RS256
+                continue
+            algorithm = jwt.algorithms.RSAAlgorithm.from_jwk(verifying_key)
+            authenticated_jwt = jwt.decode(
+                request_jwt,
+                algorithm,
+                audience=client_id,
+                algorithms=[verifying_key['alg']],
+            )
+
+        if not authenticated_jwt:
+            raise exceptions.AuthenticationFailed(
+                'Could not authenticate JWT with FXA key.'
+            )
+
+        return authenticated_jwt
+
+    def process_event(self, uid, event_key, event_data):
+        timestamp = event_data.get('changeTime') or datetime.now().timestamp()
+        if event_key == self.FXA_PROFILE_CHANGE_EVENT:
+            log.info(f'Fxa Webhook: Got profile change event for {uid}')
+            new_email = event_data.get('email')
+            if not new_email:
+                log.info(
+                    'Email property missing/empty for "%s" event; ignoring' % event_key
+                )
+            else:
+                primary_email_change_event.delay(uid, timestamp, new_email)
+        if event_key == self.FXA_DELETE_EVENT:
+            log.info(f'Fxa Webhook: Got delete event for {uid}')
+            delete_user_event.delay(uid, timestamp)
+        if event_key == self.FXA_PASSWORDCHANGE_EVENT:
+            log.info(f'Fxa Webhook: Got password-change event for {uid}')
+            clear_sessions_event.delay(uid, timestamp, 'password-change')
+
+    def post(self, request):
+        jwt = self.get_jwt(request)
+        events = jwt.get('events', {})
+        uid = jwt.get('sub')
+        for event_key, event_data in events.items():
+            log.debug(
+                'fxa webhook',
+                extra={
+                    'jwt': jwt,
+                    'event_key': event_key,
+                    'event_data': event_data,
+                },
+            )
+            self.process_event(uid, event_key, event_data)
+
+        return Response('202 Accepted', status=202)

--- a/src/olympia/api/urls.py
+++ b/src/olympia/api/urls.py
@@ -1,6 +1,6 @@
 from django.urls import include, re_path
 
-from olympia.accounts.urls import accounts_v3, accounts_v4, auth_callback_patterns
+from olympia.accounts.urls import accounts_v3, accounts_v4, auth_urls
 from olympia.amo.urls import api_patterns as amo_api_patterns
 from olympia.addons.api_urls import addons_v3, addons_v4, addons_v5
 from olympia.ratings.api_urls import ratings_v3, ratings_v4
@@ -51,7 +51,7 @@ v5_api_urls = [
 ]
 
 urlpatterns = [
-    re_path(r'^auth/', include((auth_callback_patterns, 'auth'))),
+    re_path(r'^auth/', include((auth_urls, 'auth'))),
     re_path(r'^v3/', include((v3_api_urls, 'v3'))),
     re_path(r'^v4/', include((v4_api_urls, 'v4'))),
     re_path(r'^v5/', include((v5_api_urls, 'v5'))),


### PR DESCRIPTION
fixes #14730 - on the code side, anyway.  We will need to liaise with FxA to enable notifications to the web-hook on dev, stage, and prod; AMO ops will need to stop the SQS monitoring command.  (Then clean-up)

Note: this can't be tested locally - it relies on FxA sending signed JWTs to a specific url - so we'll only really find out on addons-dev if it's working as expected.