### PR TITLE
Remove custom datepicker from statistics page: <input type="date"> is enough

### DIFF
--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -739,7 +739,6 @@ MINIFY_BUNDLES = {
             'js/node_lib/ui/menu.js',
             'js/node_lib/ui/mouse.js',
             'js/node_lib/ui/autocomplete.js',
-            'js/node_lib/ui/datepicker.js',
             'js/node_lib/ui/sortable.js',
             'js/zamboni/helpers.js',
             'js/common/banners.js',

--- a/src/olympia/stats/templates/stats/popup.html
+++ b/src/olympia/stats/templates/stats/popup.html
@@ -12,14 +12,12 @@
           <label for="date-range-start">{{ _('From') }}</label>
           <input type="date" id="date-range-start">
         </p>
-        <div id="start-date-picker"></div>
       </fieldset>
       <fieldset>
         <p>
           <label for="date-range-end">{{ _('To') }}</label>
           <input type="date" id="date-range-end">
         </p>
-        <div id="end-date-picker"></div>
       </fieldset>
       <footer>
         <p>

--- a/static/js/impala/stats/controls.js
+++ b/static/js/impala/stats/controls.js
@@ -7,26 +7,9 @@
     minDate = Date.iso($('.primary').attr('data-min-date')),
     msDay = 24 * 60 * 60 * 1000; // One day in milliseconds.
 
-  $.datepicker.setDefaults({ showAnim: '' });
   var $customModal = $('#custom-criteria').modal('#custom-date-range', {
     width: 520,
     hideme: true,
-  });
-  var $startPicker = $('#start-date-picker').datepicker({
-    maxDate: 0,
-    minDate: minDate,
-    dateFormat: 'yy-mm-dd',
-    onSelect: function (dateText) {
-      $('#date-range-start').val(dateText);
-    },
-  });
-  var $endPicker = $('#end-date-picker').datepicker({
-    maxDate: 0,
-    minDate: minDate,
-    dateFormat: 'yy-mm-dd',
-    onSelect: function (dateText) {
-      $('#date-range-end').val(dateText);
-    },
   });
 
   $rangeSelector.click(function (e) {
@@ -61,9 +44,7 @@
       }
 
       $('#date-range-start').val(startStr);
-      $startPicker.datepicker('setDate', startStr);
       $('#date-range-end').val(endStr);
-      $endPicker.datepicker('setDate', endStr);
     }
     if (newState.range) {
       if (!newState.range.custom) {


### PR DESCRIPTION
Fixes #18738

We were *already* using an `<input type=date>` so the datepicker was redundant.

Screenshots:
**Before...** (note that clicking on the input shows a second calendar)
![before](https://user-images.githubusercontent.com/187006/152165914-a5bb0b04-041c-4912-af8f-aeeff76dfb30.png)

**After...** (when clicking on the input)
![after](https://user-images.githubusercontent.com/187006/152165631-6f0a58cd-2092-480a-8f6c-f3fe096f7ed1.png)
