### PR TITLE
Fix typo in django admin

### DIFF
--- a/src/olympia/users/migrations/0001_initial.py
+++ b/src/olympia/users/migrations/0001_initial.py
@@ -100,7 +100,7 @@ class Migration(migrations.Migration):
                 ('created', models.DateTimeField(blank=True, default=django.utils.timezone.now, editable=False)),
                 ('modified', models.DateTimeField(auto_now=True)),
                 ('id', olympia.amo.fields.PositiveAutoField(primary_key=True, serialize=False)),
-                ('network', olympia.amo.fields.CIDRField(blank=True, help_text='Enter a valid IPv6 or IPv6 CIDR network range, eg. 127.0.0.1/28', null=True)),
+                ('network', olympia.amo.fields.CIDRField(blank=True, help_text='Enter a valid IPv4 or IPv6 CIDR network range, eg. 127.0.0.1/28', null=True)),
             ],
             options={
                 'db_table': 'users_user_network_restriction',

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -695,7 +695,7 @@ class IPNetworkUserRestriction(RestrictionAbstractBaseModel):
     network = CIDRField(
         blank=True,
         null=True,
-        help_text=_('Enter a valid IPv6 or IPv6 CIDR network range, eg. 127.0.0.1/28'),
+        help_text=_('Enter a valid IPv4 or IPv6 CIDR network range, eg. 127.0.0.1/28'),
     )
 
     error_message = _(


### PR DESCRIPTION
This fixes a typo in django admin. Note that I also updated the help text in the inital migration, I hope this doesn't break anything, and I don't think it warrants writing a migration to change the text in existing environments. It would only have an effect for environments being set up after this has landed.

cc @diox for the migration change.