### PR TITLE
enable addon submission api on prod; remove warnings in api docs

### DIFF
--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -296,11 +296,6 @@ Create
 This endpoint allows a submission of an upload to create a new add-on and setting other AMO metadata.
 
     .. note::
-        This is an in-progress API that is not yet available on addons.mozilla.org
-        production environments. See :ref:`the older signing API <upload-version>` for
-        how to submit new add-ons/versions on AMO today.
-
-    .. note::
         This API requires :doc:`authentication <auth>`.
 
 .. http:post:: /api/v5/addons/addon/
@@ -329,11 +324,6 @@ Edit
 .. _addon-edit:
 
 This endpoint allows an add-on's AMO metadata to be edited.
-
-    .. note::
-        This is an in-progress API that is not yet available on addons.mozilla.org
-        production environments. The only supported method of editing metadata today is
-        via developer hub.
 
     .. note::
         This API requires :doc:`authentication <auth>`.
@@ -472,11 +462,6 @@ Version Create
 This endpoint allows a submission of an upload to an existing add-on to create a new version, and setting other AMO metadata.
 
     .. note::
-        This is an in-progress API that is not yet available on addons.mozilla.org
-        production environments. See :ref:`the older signing API <upload-version>` for
-        how to submit new add-ons/versions on AMO today.
-
-    .. note::
         This API requires :doc:`authentication <auth>`.
 
 .. http:post:: /api/v5/addons/addon/(int:addon_id|string:addon_slug|string:addon_guid)/versions/
@@ -584,11 +569,6 @@ Version Edit
 This endpoint allows the metadata for an existing version to be edited.
 
     .. note::
-        This is an in-progress API that is not yet available on addons.mozilla.org
-        production environments. The only supported method of editing metadata today is
-        via developer hub.
-
-    .. note::
         This API requires :doc:`authentication <auth>`.
 
 .. http:patch:: /api/v5/addons/addon/(int:addon_id|string:addon_slug|string:addon_guid)/versions/(int:id)/
@@ -612,11 +592,6 @@ Upload Create
 .. _upload-create:
 
 This endpoint is for uploading an addon file, to then be submitted to create a new addon or version.
-
-    .. note::
-        This is an in-progress API that is not yet available on addons.mozilla.org
-        production environments. See :ref:`the older signing API <upload-version>` for
-        how to submit new add-ons/versions on AMO today.
 
     .. note::
         This API requires :doc:`authentication <auth>`.
@@ -645,9 +620,7 @@ Upload List
 This endpoint is for listing your previous uploads.
 
     .. note::
-        This is an in-progress API that is not yet available on addons.mozilla.org
-        production environments. See :ref:`the older signing API <upload-version>` for
-        how to submit new add-ons/versions on AMO today.
+        This API requires :doc:`authentication <auth>`.
 
 .. http:get:: /api/v5/addons/upload/
 
@@ -668,9 +641,7 @@ Upload Detail
 This endpoint is for fetching a single previous upload by uuid.
 
     .. note::
-        This is an in-progress API that is not yet available on addons.mozilla.org
-        production environments. See :ref:`the older signing API <upload-version>` for
-        how to submit new add-ons/versions on AMO today.
+        This API requires :doc:`authentication <auth>`.
 
 .. http:get:: /api/v5/addons/upload/<string:uuid>/
 

--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -95,8 +95,3 @@ REMOTE_SETTINGS_WRITER_BUCKET = 'staging'
 
 # See: https://bugzilla.mozilla.org/show_bug.cgi?id=1633746
 BIGQUERY_AMO_DATASET = 'amo_prod'
-
-# We don't want to enable the new addon submission on prod yet
-DRF_API_GATES['v5'] = tuple(
-    gate for gate in DRF_API_GATES['v5'] if gate != 'addon-submission-api'
-)


### PR DESCRIPTION
fixes #18371 - we might decide to gate merging this on some sort of announcement?  But I'm not sure it's a blocker