### PR TITLE
add USER_DELETED activity class

### DIFF
--- a/src/olympia/accounts/tasks.py
+++ b/src/olympia/accounts/tasks.py
@@ -5,6 +5,8 @@ from waffle import switch_is_active
 
 import olympia.core.logger
 
+from olympia import amo
+from olympia.activity.models import ActivityLog
 from olympia.amo.celery import task
 from olympia.amo.decorators import use_primary_db
 from olympia.users.models import UserProfile
@@ -54,6 +56,7 @@ def primary_email_change_event(user, event_date, email):
 def delete_user_event(user, event_date):
     """Process the delete user event."""
     if switch_is_active('fxa-account-delete'):
+        ActivityLog.create(amo.LOG.USER_DELETED, user, user=user)
         user.delete(addon_msg='Deleted via FxA account deletion')
         log.info(f'Account pk [{user.id}] deleted from FxA on {event_date}')
     else:

--- a/src/olympia/accounts/tests/test_tasks.py
+++ b/src/olympia/accounts/tests/test_tasks.py
@@ -10,6 +10,7 @@ from olympia.accounts.tasks import (
     primary_email_change_event,
 )
 from olympia.accounts.tests.test_utils import totimestamp
+from olympia.activity.models import UserLog
 from olympia.amo.tests import addon_factory, collection_factory, TestCase, user_factory
 from olympia.bandwagon.models import Collection
 from olympia.ratings.models import Rating
@@ -80,6 +81,12 @@ class TestDeleteUserEvent(TestCase):
         assert not Collection.objects.filter(id=collection.id).exists()
         assert not another_addon.ratings.all().exists()
         delete_picture_mock.assert_called()
+        # Two UserLog instances get created - one for request.user, one for the instance
+        assert UserLog.objects.filter(user=self.user).count() == 2
+        alog = UserLog.objects.filter(user=self.user).first().activity_log
+        # For a user deleting their own account, they're just duplicates
+        assert alog == UserLog.objects.filter(user=self.user).last().activity_log
+        assert alog.arguments == [self.user]
 
     @override_switch('fxa-account-delete', active=True)
     def test_success_addons(self):

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -54,6 +54,7 @@ import olympia.core.logger
 from olympia import amo
 from olympia.access import acl
 from olympia.access.models import GroupUser
+from olympia.activity.models import ActivityLog
 from olympia.amo.decorators import use_primary_db
 from olympia.amo.reverse import get_url_prefix
 from olympia.amo.utils import fetch_subscribed_newsletters, is_safe_url, use_fake_fxa
@@ -571,6 +572,7 @@ class AccountViewSet(
 
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()
+        ActivityLog.create(amo.LOG.USER_DELETED, instance)
         self.perform_destroy(instance)
         response = Response(status=HTTP_204_NO_CONTENT)
         if instance == request.user:

--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -397,6 +397,11 @@ class USER_EDITED(_LOG):
     format = _('Account updated.')
 
 
+class USER_DELETED(_LOG):
+    id = 61
+    format = _('Account {user} deleted.')
+
+
 class CUSTOM_TEXT(_LOG):
     id = 98
     format = '{0}'


### PR DESCRIPTION
fixes #18773

fwiw, `USER_EDITED` doesn't seem to be used any longer - we should probably add those events to user profile edits (in the serializer) - or comment that it's unused.