### PR TITLE
Prevent request.user from being evaluated in middlewares

### DIFF
--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -429,7 +429,9 @@ MIDDLEWARE = (
     # must come before middlewares potentially using REMOTE_ADDR, so it's
     # also up there.
     'django_statsd.middleware.GraphiteRequestTimingMiddleware',
-    'django_statsd.middleware.GraphiteMiddleware',
+    # GraphiteMiddlewareNoAuth is a custom GraphiteMiddleware that doesn't
+    # handle response.auth, to avoid evaluating request.user.
+    'olympia.amo.middleware.GraphiteMiddlewareNoAuth',
     'olympia.amo.middleware.SetRemoteAddrFromForwardedFor',
     # AMO URL middleware is as high as possible to get locale/app aware URLs.
     'olympia.amo.middleware.LocaleAndAppURLMiddleware',


### PR DESCRIPTION
When dealing with a request with auth credentials, `GraphiteMiddleware`'s default implementation forces `request.user` to be evaluated to send a `response.auth` statsd ping, causing a database query even if the view didn't use auth at all. We don't need that ping, so replace the middleware with a custom one that doesn't do this, avoiding the database query in those cases.

Fixes #18841