### PR TITLE
Remove ip_address from sentry events completely instead of redacting it

### DIFF
--- a/src/olympia/amo/tests/test_settings.py
+++ b/src/olympia/amo/tests/test_settings.py
@@ -104,13 +104,15 @@ def test_sentry_data_scrubbing():
     assert '172.18.0.1' not in event_raw
     assert '127.0.0.42' not in event_raw
 
-    # We keep cookies, user dict
+    # We keep cookies, user dict.
     assert event['payload']['request']['cookies']
     assert event['payload']['user']['id']
 
-    # Email and ip_address are redacted though
+    # Email is redacted though.
     assert event['payload']['user']['email'] == '*** redacted ***'
-    assert event['payload']['user']['ip_address'] == '*** redacted ***'
+
+    # ip_adress is removed completely because sentry checks its format.
+    assert 'ip_address' not in event['payload']['user']
 
     # Modify old_request_data according to what we should have done and see if
     # it matches what before_send() did in reality.

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1515,6 +1515,8 @@ def scrub_sensitive_data(event, hint):
         event = _scrub_sensitive_data_recursively(event)
     except Exception:
         pass
+    if 'ip_address' in event.get('payload', {}).get('user', {}):
+        event['payload']['user'].pop('ip_address')
     return event
 
 


### PR DESCRIPTION
Fixes #18917