### PR TITLE
Update CircleCI executor config to use an explicitly supported ubuntu image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,7 +344,8 @@ references:
             AUTOGRAPH_CONFIG: *autograph_config
 
   defaults-release: &defaults-release
-    machine: true
+    machine:
+      - image: ubuntu-2004:202201-02
     working_directory: &working-directory
 
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,7 +345,7 @@ references:
 
   defaults-release: &defaults-release
     machine:
-      - image: ubuntu-2004:202201-02
+      image: ubuntu-2004:202201-02
     working_directory: &working-directory
 
 commands:


### PR DESCRIPTION
Fixes #18843