### PR TITLE
Introduce a truly supported release notes API endpoint for Firefox

### DIFF
--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -457,6 +457,19 @@ This endpoint allows you to fetch a single version belonging to a specific add-o
     :>json string|null source: The (absolute) URL to download the submitted source for this version. This field is only present for authenticated users, for their own add-ons.
     :>json string version: The version number string for the version.
 
+---------------------
+Version Release Notes
+---------------------
+
+.. _version-release_notes:
+
+This endpoint allows you to fetch release notes for a version belonging to a specific add-on. The response will be an XHTML document. It is not meant for third-party consumption - use the version detail endpoint instead.
+
+.. http:get:: /api/v5/addons/addon/(int:addon_id|string:addon_slug|string:addon_guid)/versions/(int:id)/release_notes/
+
+    .. _version-detail-release_notes:
+
+    :query string lang: Activate translations in the specific language for that query. (See :ref:`translated fields <api-overview-translations>`)
 
 --------------
 Version Create

--- a/docs/topics/api/v4_frozen/addons.rst
+++ b/docs/topics/api/v4_frozen/addons.rst
@@ -394,6 +394,20 @@ This endpoint allows you to fetch a single version belonging to a specific add-o
     :>json boolean is_strict_compatibility_enabled: Whether or not this version has `strictCompatibility <https://developer.mozilla.org/en-US/Add-ons/Install_Manifests#strictCompatibility>`_. set.
     :>json string version: The version number string for the version.
 
+---------------------
+Version Release Notes
+---------------------
+
+.. _v4-version-release_notes:
+
+This endpoint allows you to fetch release notes for a version belonging to a specific add-on. The response will be an XHTML document. It is not meant for third-party consumption - use the version detail endpoint instead.
+
+.. http:get:: /api/v5/addons/addon/(int:addon_id|string:addon_slug|string:addon_guid)/versions/(int:id)/release_notes/
+
+    .. _v4-version-detail-release_notes:
+
+    :query string lang: Activate translations in the specific language for that query. (See :ref:`translated fields <api-overview-translations>`)
+
 
 ------------------------------
 Add-on EULA and Privacy Policy

--- a/services/update.py
+++ b/services/update.py
@@ -202,10 +202,11 @@ class Update:
         if data['hash']:
             update['update_hash'] = data['hash']
         if data['releasenotes']:
-            update['update_info_url'] = '{}{}{}/%APP_LOCALE%/'.format(
-                settings.SITE_URL,
-                '/versions/updateInfo/',
-                data['version_id'],
+            update['update_info_url'] = (
+                f"{settings.SERVICES_URL}/api/v4/"
+                f"addons/addon/{data['addon_id']}/"
+                f"versions/{data['version_id']}/release_notes/"
+                f"?lang=%APP_LOCALE%"
             )
         return {'addons': {self.data['guid']: {'updates': [update]}}}
 


### PR DESCRIPTION
Document it, return it directly in the update service (redirecting previous undocumented endpoints), add a bit of caching to it.

Fixes #18973