### PR TITLE
Serve xpis through addons server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,8 +34,9 @@ services:
     command: supervisord -n -c /code/docker/supervisor.conf
 
   nginx:
-    image: addons/addons-nginx
+    image: nginx
     volumes:
+      - ./docker/nginx/addons.conf:/etc/nginx/conf.d/addons.conf
       - ./static:/srv/static
       - ./site-static:/srv/site-static
       - ./storage/shared_storage/uploads:/srv/user-media

--- a/docker/nginx/addons.conf
+++ b/docker/nginx/addons.conf
@@ -1,0 +1,118 @@
+client_max_body_size 50m;
+etag off;
+merge_slashes off;
+
+server {
+    listen  80 default;
+
+    location /code/storage/files/ {
+        internal;
+        # This matches where addons-server `docker-compose.yml` mounts
+        # `./storage/addons/` - as `/srv/user-media/addons/`
+        alias /srv/user-media/addons/;
+    }
+
+    location /code/storage/guarded-addons/ {
+        internal;
+        # This matches where addons-server `docker-compose.yml` mounts
+        # `./storage/guarded-addons/` - as `/srv/user-media/guarded-addons/`
+        alias /srv/user-media/guarded-addons/;
+    }
+
+    location /code/storage/sitemaps/ {
+        internal;
+        # This matches where addons-server `docker-compose.yml` mounts
+        # `./storage/sitemaps/` - as `/srv/user-media/sitemaps/`
+        alias /srv/user-media/sitemaps/;
+    }
+
+    location /static/ {
+        alias /srv/static/;
+    }
+
+    location /site-static/ {
+        alias /srv/site-static/;
+    }
+
+    location /user-media/ {
+        alias /srv/user-media/;
+    }
+
+    location /static/debug_toolbar/ {
+        alias /srv/site-static/debug_toolbar/;
+    }
+
+    location /static/admin/ {
+        alias /srv/site-static/admin/;
+    }
+
+    location ~ ^/api/ {
+        try_files $uri @olympia;
+    }
+
+    location ~ "^/\w{2,3}(?:-\w{2,6})?/(?:firefox|android)/addon/[^/<>\"']+/statistics(?:$|/)" {
+        try_files $uri @olympia;
+    }
+
+    location /__version__ {
+        try_files $uri @olympia;
+    }
+
+    location / {
+        try_files $uri @frontendamo;
+    }
+
+    location @olympia {
+        uwsgi_pass  web;
+        include     uwsgi_params;
+        uwsgi_buffering off;
+        uwsgi_read_timeout 120;
+        uwsgi_connect_timeout 120;
+
+        uwsgi_param   Host                  $http_host;
+        uwsgi_param   X-Real-IP             $remote_addr;
+        uwsgi_param   X-Forwarded-For       $proxy_add_x_forwarded_for;
+        uwsgi_param   X-Forwarded-Protocol  ssl;
+    }
+
+    location @frontendamo {
+        proxy_pass http://addons-frontend;
+        proxy_buffers 16 32k;
+        proxy_buffer_size 128k;
+        proxy_pass_header Server;
+        proxy_set_header X-FORWARDED-PROTOCOL "ssl";
+        proxy_set_header Host $http_host;
+        proxy_redirect off;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Scheme $scheme;
+        proxy_connect_timeout 30;
+        proxy_read_timeout 30;
+
+        # A small workaround to redirect everything that would 404
+        # on addons-frontend to the django server.
+        # This way we don't have to copy the hundreds of entries
+        # from our prod config.
+        error_page 404 = @olympia;
+
+        # This is required to actually bubble up the 404 error from
+        # addons frontend so that nginx can act on it.
+        proxy_intercept_errors on;
+
+    }
+
+    # Return 204 for CSP reports to save sending them
+    # into Django.
+    location /csp-report {
+        return 204;
+    }
+}
+
+# Use the names from our docker setup
+upstream web {
+    server web:8001;
+}
+
+upstream addons-frontend {
+    # This port is set in the `docker-compose.yml` file of addons-server.
+    server addons-frontend:7010;
+}

--- a/src/olympia/versions/urls.py
+++ b/src/olympia/versions/urls.py
@@ -19,7 +19,7 @@ download_patterns = [
     # .* at the end to match filenames.
     # /file/:id/type:attachment
     re_path(
-        r'^file/(?P<file_id>\d+)(?:/type:(?P<type>\w+))?(?:/.*)?',
+        r'^file/(?P<file_id>\d+)(?:/type:(?P<type_>\w+))?(?:/.*)?',
         views.download_file,
         name='downloads.file',
     ),
@@ -28,7 +28,7 @@ download_patterns = [
     ),
     # /latest/1865/type:xpi/platform:5
     re_path(
-        r'^latest/%s/(?:type:(?P<type>\w+)/)?'
+        r'^latest/%s/(?:type:(?P<type_>\w+)/)?'
         r'(?:platform:(?P<platform>\d+)/)?.*' % ADDON_ID,
         views.download_latest,
         name='downloads.latest',

--- a/src/olympia/versions/views.py
+++ b/src/olympia/versions/views.py
@@ -1,11 +1,9 @@
-import os
-
 from django import http
 from django.db.transaction import non_atomic_requests
 from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
-from django.utils.cache import patch_vary_headers
+from django.utils.cache import patch_cache_control, patch_vary_headers
 
 import olympia.core.logger
 
@@ -13,7 +11,7 @@ from olympia import amo
 from olympia.access import acl
 from olympia.addons.decorators import addon_view_factory
 from olympia.addons.models import Addon, AddonRegionalRestrictions
-from olympia.amo.utils import HttpResponseXSendFile, urlparams
+from olympia.amo.utils import HttpResponseXSendFile
 from olympia.files.models import File
 from olympia.versions.models import Version
 
@@ -59,11 +57,9 @@ def update_info_redirect(request, version_id):
 
 # Should accept junk at the end for filename goodness.
 @non_atomic_requests
-def download_file(request, file_id, type=None, file_=None, addon=None):
+def download_file(request, file_id, type_=None):
     """
-    Download given file.
-
-    `addon` and `file_` parameters can be passed to avoid the database query.
+    Download the file identified by `file_id` parameter.
 
     If the file is disabled or belongs to an unlisted version, requires an
     add-on developer or appropriate reviewer for the channel. If the file is
@@ -78,18 +74,18 @@ def download_file(request, file_id, type=None, file_=None, addon=None):
             else acl.check_unlisted_addons_viewer_or_reviewer(request)
         )
 
-    if not file_:
-        file_ = get_object_or_404(File.objects, pk=file_id)
-    if not addon:
-        # Include deleted add-ons in the queryset, we'll check for that below.
-        addon = get_object_or_404(Addon.unfiltered, pk=file_.version.addon_id)
+    file_ = get_object_or_404(File.objects, pk=file_id)
+    # Include deleted add-ons in the queryset, we'll check for that below.
+    addon = get_object_or_404(
+        Addon.unfiltered.all().no_transforms, pk=file_.version.addon_id
+    )
     version = file_.version
     channel = version.channel
 
     if version.deleted or addon.is_deleted:
         # Only the appropriate reviewer can see deleted things.
-        use_cdn = False
         has_permission = is_appropriate_reviewer(addon, channel)
+        apply_georestrictions = False
     elif (
         addon.is_disabled
         or file_.status == amo.STATUS_DISABLED
@@ -97,7 +93,6 @@ def download_file(request, file_id, type=None, file_=None, addon=None):
     ):
         # Only the appropriate reviewer or developers of the add-on can see
         # disabled or unlisted things.
-        use_cdn = False
         has_permission = is_appropriate_reviewer(
             addon, channel
         ) or acl.check_addon_ownership(
@@ -107,11 +102,19 @@ def download_file(request, file_id, type=None, file_=None, addon=None):
             allow_mozilla_disabled_addon=True,
             allow_site_permission=True,
         )
+        apply_georestrictions = False
     else:
-        # Everyone can see public things, and we can use the CDN in that case.
-        use_cdn = True
+        # Public case: we're either directly downloading the file or
+        # redirecting, but in any case we have permission in the general sense,
+        # though georestrictions are in effect.
         has_permission = True
+        apply_georestrictions = True
 
+    region_code = request.META.get('HTTP_X_COUNTRY_CODE', None)
+    # Whether to set Content-Disposition: attachment header or not, to force
+    # the file to be downloaded rather than installed (used by admin/reviewer
+    # tools).
+    attachment = type_ == 'attachment'
     if not has_permission:
         log.debug(
             'download file {file_id}: addon/version/file not public and '
@@ -119,36 +122,19 @@ def download_file(request, file_id, type=None, file_=None, addon=None):
                 file_id=file_id, user_id=request.user.pk
             )
         )
-        raise http.Http404()  # Not owner or admin.
-
-    attachment = bool(type == 'attachment')
-    if use_cdn:
-        # When serving the file for the general public through the CDN, we need
-        # to obey regional restrictions
-        region_code = request.META.get('HTTP_X_COUNTRY_CODE', None)
-        if (
-            region_code
-            and AddonRegionalRestrictions.objects.filter(
-                addon=addon, excluded_regions__contains=region_code.upper()
-            ).exists()
-        ):
-            response = http.HttpResponse(status=451)
-            url = 'https://www.mozilla.org/about/policy/transparency/'
-            response['Link'] = f'<{url}>; rel="blocked-by"'
-        else:
-            # When using the CDN URL, we do a redirect, so we can't set
-            # Content-Disposition: attachment for attachments. To work around
-            # this, if attachment=True, get_file_cdn_url() changes the path to
-            # something we recognize in the nginx config.
-            loc = urlparams(
-                file_.get_file_cdn_url(attachment=attachment), filehash=file_.hash
-            )
-            response = http.HttpResponseRedirect(loc)
-            response['X-Target-Digest'] = file_.hash
-        # Always add a Vary header to deal with caching in different regions.
-        patch_vary_headers(response, ['X-Country-Code'])
+        response = http.HttpResponseNotFound()
+    elif (
+        apply_georestrictions
+        and region_code
+        and AddonRegionalRestrictions.objects.filter(
+            addon=addon, excluded_regions__contains=region_code.upper()
+        ).exists()
+    ):
+        response = http.HttpResponse(status=451)
+        url = 'https://www.mozilla.org/about/policy/transparency/'
+        response['Link'] = f'<{url}>; rel="blocked-by"'
     else:
-        # Here we're returning a X-Accel-Redirect, we can set
+        # We're returning a X-Accel-Redirect, we can set
         # Content-Disposition: attachment ourselves in HttpResponseXSendFile:
         # nginx won't override it if present.
         response = HttpResponseXSendFile(
@@ -157,27 +143,28 @@ def download_file(request, file_id, type=None, file_=None, addon=None):
             content_type='application/x-xpinstall',
             attachment=attachment,
         )
+    # Always add a few headers to the response (even errors).
+    patch_cache_control(response, max_age=60 * 60 * 24)
+    patch_vary_headers(response, ['X-Country-Code'])
     response['Access-Control-Allow-Origin'] = '*'
     return response
 
 
-def guard():
-    return Addon.objects.filter(_current_version__isnull=False)
-
-
-@addon_view_factory(guard)
+@addon_view_factory(Addon.objects.public)
 @non_atomic_requests
-def download_latest(request, addon, type='xpi', platform=None):
+def download_latest(request, addon, type_='xpi', platform=None):
     """
-    Download file from 'current' (latest public listed) version for an add-on.
+    Redirect to the URL to download the file from 'current'
+    (latest public listed) version of an add-on.
 
-    Requires same permissions as download_file() does for this file.
+    Returns a 404 for add-ons that are deleted/disabled/non-public/without an
+    approved listed version.
     """
-    try:
-        file_ = addon.current_version.file
-    except IndexError:
-        raise http.Http404()
-    return download_file(request, file_.id, type=type, file_=file_, addon=addon)
+    file_ = addon.current_version.file
+    response = http.HttpResponseRedirect(file_.get_absolute_url())
+    patch_cache_control(response, max_age=60 * 60 * 24)
+    response['Access-Control-Allow-Origin'] = '*'
+    return response
 
 
 @non_atomic_requests


### PR DESCRIPTION
Serve xpis through X-Accel-Redirect instead of redirecting to dedicated domain

The so called "CDN URLs" for files are less useful now that even AMO main domain is behind a CDN, and we want to move away from it because internally it exposes paths on EFS that nginx is serving directly, making directory structure changes difficult.

This commit focuses on the download_file/download_latest endpoints addons-server exposes, and leaves the old dedicated CDN domain intact for the moment - it is still used by the update service but will go away in a future commit.

Fixes #18844