### PR TITLE
Return direct release notes endpoint (and not a redirect) from update service

### DIFF
--- a/src/olympia/addons/tests/test_update.py
+++ b/src/olympia/addons/tests/test_update.py
@@ -485,7 +485,11 @@ class TestResponse(VersionCheckMixin, TestCase):
         content = self.get_update_instance(self.data).get_output()
         data = json.loads(content)
         guid = '{2fa4ed95-0317-4c6a-a74c-5f3e3912c1f9}'
-        assert data['addons'][guid]['updates'][0]['update_info_url']
+        expected_url = (
+            'http://testserver/%APP_LOCALE%/firefox/'
+            'addon/a3615/versions/2.1.072/updateinfo/'
+        )
+        assert data['addons'][guid]['updates'][0]['update_info_url'] == expected_url
 
         version = Version.objects.get(pk=81551)
         version.update(release_notes=None)
@@ -493,6 +497,21 @@ class TestResponse(VersionCheckMixin, TestCase):
         content = self.get_update_instance(self.data).get_output()
         data = json.loads(content)
         assert 'update_info_url' not in data['addons'][guid]['updates'][0]
+
+    def test_release_notes_android(self):
+        # Quick & dirty way to make the add-on compatible with android and
+        # force the update request to be from Android as well.
+        AppVersion.objects.update(application=amo.ANDROID.id)
+        self.data['appID'] = amo.ANDROID.guid
+
+        content = self.get_update_instance(self.data).get_output()
+        data = json.loads(content)
+        guid = '{2fa4ed95-0317-4c6a-a74c-5f3e3912c1f9}'
+        expected_url = (
+            'http://testserver/%APP_LOCALE%/android/'
+            'addon/a3615/versions/2.1.072/updateinfo/'
+        )
+        assert data['addons'][guid]['updates'][0]['update_info_url'] == expected_url
 
     def test_no_updates_at_all(self):
         self.addon_one.versions.all().delete()

--- a/src/olympia/versions/tests/test_views.py
+++ b/src/olympia/versions/tests/test_views.py
@@ -76,6 +76,7 @@ class TestUpdateInfo(UpdateInfoMixin, TestCase):
         self.version.save()
         response = self.client.get(self.url)
         assert response.status_code == 200
+        assert response['Cache-Control'] == 'max-age=3600'
         assert response['Content-Type'] == 'application/xhtml+xml'
 
         # pyquery is annoying to use with XML and namespaces. Use the HTML
@@ -146,6 +147,7 @@ class TestUpdateInfoLegacyRedirect(UpdateInfoMixin, TestCase):
         )
 
         response = self.client.get(self.url)
+        assert response['Cache-Control'] == 'max-age=3600'
         self.assert3xx(response, expected_redirect_url, status_code=301)
 
         # It should also work without the locale+app prefix, but that does

--- a/src/olympia/versions/views.py
+++ b/src/olympia/versions/views.py
@@ -30,12 +30,14 @@ def update_info(request, addon, version_num):
         .only_translations(),
         version=version_num,
     )
-    return TemplateResponse(
+    response = TemplateResponse(
         request,
         'versions/update_info.html',
         context={'version': version},
         content_type='application/xhtml+xml',
     )
+    patch_cache_control(response, max_age=60 * 60)
+    return response
 
 
 @non_atomic_requests
@@ -49,12 +51,14 @@ def update_info_redirect(request, version_id):
     )
     if not version.addon.is_public():
         raise http.Http404()
-    return redirect(
+    response = redirect(
         reverse(
             'addons.versions.update_info', args=(version.addon.slug, version.version)
         ),
         permanent=True,
     )
+    patch_cache_control(response, max_age=60 * 60)
+    return response
 
 
 @non_atomic_requests


### PR DESCRIPTION
Also cache that endpoint for one hour.

Fixes #18973 in a simpler approach without introducing a new api endpoint.