### PR TITLE
Update redis docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
     mem_limit: 2g
 
   redis:
-    image: redis:2.8
+    image: redis:6.2
 
   rabbitmq:
     image: rabbitmq:3.8


### PR DESCRIPTION
This is needed to run addons-server with Apple silicons. I don't know we
want to do that upfront given I don't know which version we're using on
production but this PR can serve as "documentation" in the meantime.