### PR TITLE
Revert "Write FileUploads to a directory under MEDIA_ROOT (/uploads/)"

### DIFF
--- a/src/olympia/files/models.py
+++ b/src/olympia/files/models.py
@@ -508,7 +508,7 @@ class FileUpload(ModelBase):
         if ext in amo.VALID_ADDON_FILE_EXTENSIONS:
             ext = '.xpi'
         self.path = os.path.join(
-            settings.MEDIA_ROOT, 'fileuploads', f'{uuid.uuid4().hex}{ext}'
+            user_media_path('addons'), 'temp', f'{uuid.uuid4().hex}{ext}'
         )
 
         hash_obj = None

--- a/src/olympia/files/tests/test_models.py
+++ b/src/olympia/files/tests/test_models.py
@@ -738,9 +738,7 @@ class TestFileUpload(UploadMixin, TestCase):
         assert upload.name == f'{force_str(upload.uuid.hex)}_filenamé.xpi'
         # Actual path on filesystem is different, fully random
         assert upload.name not in upload.path
-        assert re.match(
-            r'%s/fileuploads/[a-f0-9]{32}\.xpi$' % settings.MEDIA_ROOT, upload.path
-        )
+        assert re.match(r'.*/temp/[a-f0-9]{32}\.xpi$', upload.path)
 
     def test_from_post_hash(self):
         hashdigest = hashlib.sha256(self.data).hexdigest()


### PR DESCRIPTION
Reverts mozilla/addons-server#18991
ref https://github.com/mozilla/addons-server/issues/18871

The nginx config would need to be updated to serve the files through `X-Accel-Redirect` for customs. We will do that, but in the meantime let's unbreak things.