### PR TITLE
Introduce minimal config to make versioncheck works locally

### DIFF
--- a/docker/nginx/addons.conf
+++ b/docker/nginx/addons.conf
@@ -5,6 +5,10 @@ merge_slashes off;
 server {
     listen  80 default;
 
+    location ~ ^/update/.* {
+        try_files $uri @update;
+    }
+
     location /code/storage/files/ {
         internal;
         # This matches where addons-server `docker-compose.yml` mounts
@@ -100,6 +104,12 @@ server {
 
     }
 
+    location @update {
+        uwsgi_pass  versioncheck;
+        include     uwsgi_params;
+        uwsgi_param Host $http_host;
+    }
+
     # Return 204 for CSP reports to save sending them
     # into Django.
     location /csp-report {
@@ -110,6 +120,10 @@ server {
 # Use the names from our docker setup
 upstream web {
     server web:8001;
+}
+
+upstream versioncheck {
+    server web:8002;
 }
 
 upstream addons-frontend {

--- a/docker/supervisor.conf
+++ b/docker/supervisor.conf
@@ -11,6 +11,16 @@ stdout_logfile=logs/docker.log
 stdout_logfile_maxbytes=1MB
 stopsignal=KILL
 
+[program:versioncheck]
+command=uwsgi --ini /code/docker/uwsgi.versioncheck.ini
+directory=/code
+stopasgroup=true
+autostart=true
+redirect_stderr=true
+stdout_logfile=logs/docker-versioncheck.log
+stdout_logfile_maxbytes=1MB
+stopsignal=KILL
+
 # The following sections enable supervisorctl.
 
 [inet_http_server]

--- a/docker/uwsgi.ini
+++ b/docker/uwsgi.ini
@@ -1,4 +1,4 @@
-# mysite_uwsgi.ini file
+# addons-server uwsgi config for local envs
 [uwsgi]
 base            = /code
 chdir           = %(base)

--- a/docker/uwsgi.versioncheck.ini
+++ b/docker/uwsgi.versioncheck.ini
@@ -1,0 +1,33 @@
+# versioncheck (services/update) uwsgi config for local envs
+# Note that we don't use a single config and uwsgi routing, to mimic what we
+# do in production.
+[uwsgi]
+base            = /code
+chdir           = %(base)
+module          = services.wsgi.versioncheck:application
+
+# process-related settings
+master          = true
+# maximum number of worker processes
+processes       = 2
+vaccum          = true
+socket          = :8002
+uid             = olympia
+gid             = olympia
+memory-report   = true
+enable-threads  = true
+
+# autoreload is not enabled to save ressources.
+
+max-requests = 1000
+
+# Load apps in workers and not only in master
+lazy-apps = true
+
+# Open log file after we dropped privileges so that the file is being owned
+# by olympia:olympia and has proper permissions to be readable outside
+# of docker
+logto2 = %(base)/logs/uwsgi-versioncheck.log
+
+# Set default settings as originally done by manage.py
+env = DJANGO_SETTINGS_MODULE=settings

--- a/docs/topics/development/services.rst
+++ b/docs/topics/development/services.rst
@@ -4,23 +4,9 @@
 Services
 ==========================
 
-Services contain a couple of scripts that are run as separate wsgi instances on
-the services. Usually they are hosted on separate domains. They are stand alone
-wsgi scripts. The goal is to avoid a whole pile of Django imports, middleware,
-sessions and so on that we really don't need.
+The services directory contain a special separate piece of code that deals with the update service Firefox calls to get updates about installed add-ons (though the ``extensions.update.background.url`` and ``extensions.update.background.url`` preferences).
 
-To run the scripts you'll want a wsgi server. You can do this using
-`gunicorn`_, for example::
+In dev/stage/prod, this would have its own domain, but locally, we re-use the same as
+the rest of addons-server, and our nginx configuration answers using the separate ``versioncheck`` wsgi service for all requests with a /update/ prefix as their path. This minimal configuration has autoreload disabled to stay as lean as possible, so to you'll need to manually restart the web docker service to see changes.
 
-    pip install gunicorn
-
-Then you can do::
-
-    cd services
-    gunicorn --log-level=DEBUG -c wsgi/receiptverify.py -b 127.0.0.1:9000 --debug verify:application
-
-To test::
-
-    curl -d "this is a bogus receipt" http://127.0.0.1:9000/verify/123
-
-.. _`Gunicorn`: http://gunicorn.org/
+A typical URL to test with would look like this: ``http://olympia.test/update/?reqVersion=1&id=addon@guid&version=0.1&appID={ec8030f7-c20a-464f-9b0e-13a3a9e97384}&appVersion=99.0``


### PR DESCRIPTION
This is nicer than having to remember to look up the docs to do it manually, make it work with docker etc. It works out of the box.

Companion to https://github.com/mozilla/addons-server/pull/19043 for local testing