### PR TITLE
log all metadata updates via addon api

### DIFF
--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -334,10 +334,10 @@ class CHANGE_POLICY(_LOG):
     show_user_to_developer = True
 
 
-class CHANGE_ICON(_LOG):
+class CHANGE_MEDIA(_LOG):
     id = 39
     action_class = 'edit'
-    format = _('{addon} icon changed.')
+    format = _('{addon} icon or previews changed.')
     show_user_to_developer = True
 
 

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -886,7 +886,7 @@ class TestEditMedia(BaseTestEdit):
         self.test_edit_media_uploadedicon()
         log = ActivityLog.objects.all()
         assert log.count() == 1
-        assert log[0].action == amo.LOG.CHANGE_ICON.id
+        assert log[0].action == amo.LOG.CHANGE_MEDIA.id
 
     def test_edit_media_uploadedicon_noresize(self):
         img = 'static/img/notifications/error.png'

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -989,7 +989,7 @@ def addons_section(request, addon_id, addon, section, editable=False):
 
                 editable = False
                 if section == 'media':
-                    ActivityLog.create(amo.LOG.CHANGE_ICON, addon)
+                    ActivityLog.create(amo.LOG.CHANGE_MEDIA, addon)
                 else:
                     ActivityLog.create(amo.LOG.EDIT_PROPERTIES, addon)
 


### PR DESCRIPTION
fixes #19008 - this turned out to be a lot more involved than I thought.  

It renames `CHANGE_ICON` but otherwise replicates the logging that devhub has (largely - it at least logs the metadata fields that have changed, which devhub doesn't).

There's certainly an argument for fixing the inconsistencies in logging overall, but that will have to be a follow-up.  Inconsistencies found so far:
- icons and media have their own activity log type
- `EDIT_PROPERTIES` is used for all other add-on meta-data changes, but without specifying what's actually been changed (the patch includes the fields that have changes in the api - but is that enough?)
- tags have logging _per tag_ that's added or removed, and it's buried in the model's functions rather than the views.
- version changes don't have a generic `EDIT_PROPERTIES` style activity so only certain changes are logged
- tags and source code upload have activity logs on _create_, but all the others are only logged on update.
- `MAX_APPVERSION_UPDATED` is super specific compared to the other activity logs