### PR TITLE
addons api raise when empty app compatibility is specified for version create/update

### DIFF
--- a/src/olympia/addons/fields.py
+++ b/src/olympia/addons/fields.py
@@ -238,7 +238,7 @@ class VersionCompatabilityField(serializers.Field):
             if isinstance(data, list):
                 # if it's a list of apps, normalize into a dict first
                 data = {key: {} for key in data}
-            if not isinstance(data, dict) or len(data) == 0:
+            if not isinstance(data, dict) or data == {}:
                 # if it's neither it's not a valid input
                 raise exceptions.ValidationError('Invalid value')
 


### PR DESCRIPTION
fixes #19093 - the change (raising when `len(data) == 0`) is much more minimal than the diff implies but I rearranged some of the code and took the opportunity to de-duplicate some of the tests in `TestVersionViewCreate` and `TestVersionViewUpdate` that were doing the same thing.