### PR TITLE
Reload version in `auto_approve` before determining auto-approval verdict

### DIFF
--- a/src/olympia/blocklist/utils.py
+++ b/src/olympia/blocklist/utils.py
@@ -107,11 +107,11 @@ def disable_addon_for_block(block):
     from olympia.reviewers.utils import ReviewBase
 
     review = ReviewBase(
-        request=None,
         addon=block.addon,
         version=None,
-        review_type='pending',
         user=get_task_user(),
+        review_type='pending',
+        human_review=False,
     )
     review.set_data(
         {

--- a/src/olympia/reviewers/management/commands/auto_reject.py
+++ b/src/olympia/reviewers/management/commands/auto_reject.py
@@ -66,7 +66,7 @@ class Command(BaseCommand):
                 addon,
             )
             return
-        helper = ReviewHelper(addon=addon, version=latest_version)
+        helper = ReviewHelper(addon=addon, version=latest_version, human_review=False)
         helper.handler.data = {
             'comments': 'Automatic rejection after grace period ended.',
             'versions': versions,

--- a/src/olympia/reviewers/management/commands/notify_about_auto_approve_delay.py
+++ b/src/olympia/reviewers/management/commands/notify_about_auto_approve_delay.py
@@ -51,7 +51,7 @@ class Command(BaseCommand):
         Trigger task sending email notifying developer(s) of the add-on that
         this version hasn't been auto-approved yet.
         """
-        helper = ReviewHelper(addon=version.addon, version=version)
+        helper = ReviewHelper(addon=version.addon, version=version, human_review=False)
         helper.handler.data = {}
         helper.handler.notify_about_auto_approval_delay(version)
 

--- a/src/olympia/reviewers/management/commands/send_pending_rejection_last_warning_notifications.py
+++ b/src/olympia/reviewers/management/commands/send_pending_rejection_last_warning_notifications.py
@@ -85,7 +85,7 @@ class Command(BaseCommand):
             return
         log.info('Sending email for %s' % addon)
         # Set up ReviewHelper with the data needed to send the notification.
-        helper = ReviewHelper(addon=addon)
+        helper = ReviewHelper(addon=addon, human_review=False)
         helper.handler.data = {
             'comments': getattr(relevant_activity_log, 'details', {}).get(
                 'comments', ''

--- a/src/olympia/reviewers/tests/test_forms.py
+++ b/src/olympia/reviewers/tests/test_forms.py
@@ -35,7 +35,7 @@ class TestReviewForm(TestCase):
         return ReviewForm(
             data=data,
             helper=ReviewHelper(
-                request=self.request, addon=self.addon, version=self.version
+                addon=self.addon, version=self.version, user=self.request.user
             ),
         )
 
@@ -43,7 +43,7 @@ class TestReviewForm(TestCase):
         self.file.update(status=file_status)
         self.addon.update(status=addon_status)
         form = self.get_form()
-        return form.helper.get_actions(self.request)
+        return form.helper.get_actions()
 
     def test_actions_reject(self):
         self.grant_permission(self.request.user, 'Addons:Review')

--- a/src/olympia/reviewers/tests/test_review_scenarios.py
+++ b/src/olympia/reviewers/tests/test_review_scenarios.py
@@ -11,13 +11,6 @@ from olympia.amo.tests import addon_factory, user_factory
 from olympia.reviewers.utils import ReviewAddon, ReviewFiles, ReviewHelper
 
 
-@pytest.fixture
-def mock_request(rf, db):  # rf is a RequestFactory provided by pytest-django.
-    request = rf.get('/')
-    request.user = user_factory()
-    return request
-
-
 @mock.patch('olympia.reviewers.utils.sign_file', lambda f: None)
 @pytest.mark.parametrize(
     'review_action,addon_status,file_status,review_class,review_type,'
@@ -68,7 +61,6 @@ def mock_request(rf, db):  # rf is a RequestFactory provided by pytest-django.
     ],
 )
 def test_review_scenario(
-    mock_request,
     review_action,
     addon_status,
     file_status,
@@ -86,9 +78,8 @@ def test_review_scenario(
     )
     version = addon.versions.get()
     # Get the review helper.
-    helper = ReviewHelper(mock_request, addon, version)
+    helper = ReviewHelper(addon=addon, version=version, user=user_factory())
     assert isinstance(helper.handler, review_class)
-    helper.set_review_handler(mock_request)
     assert helper.handler.review_type == review_type
     helper.set_data({'comments': 'testing review scenarios'})
     # Run the action (approve_latest_version, reject_latest_version).

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -131,9 +131,9 @@ class TestReviewHelperBase(TestCase):
 
     def get_helper(self, content_review=False):
         return ReviewHelper(
-            request=self.request,
             addon=self.addon,
             version=self.version,
+            user=self.request.user,
             content_review=content_review,
         )
 
@@ -174,7 +174,7 @@ class TestReviewHelper(TestReviewHelperBase):
         assert self.setup_type(amo.STATUS_DISABLED) == 'extension_pending'
 
     def test_no_version(self):
-        helper = ReviewHelper(request=self.request, addon=self.addon, version=None)
+        helper = ReviewHelper(addon=self.addon, version=None, user=self.request.user)
         assert helper.handler.review_type == 'extension_pending'
 
     def test_review_files(self):

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -617,7 +617,11 @@ def review(request, addon, channel=None):
     )
 
     form_helper = ReviewHelper(
-        request=request, addon=addon, version=version, content_review=content_review
+        addon=addon,
+        version=version,
+        user=request.user,
+        content_review=content_review,
+        human_review=True,
     )
     form = ReviewForm(
         request.POST if request.method == 'POST' else None, helper=form_helper


### PR DESCRIPTION
A couple refactors were needed:
- Instead of receiving a `request` object, `ReviewHelper` now has a specific argument to differentiate human from non human reviews as well as an user argument. This allows `auto_approve` to check for action availability even though it's a non-human review.
- Most of `access.acl` functions now receive a request or a user and deal with it accordingly (needed since `ReviewHelper` no longer passes a request object)

Fixes https://github.com/mozilla/addons-server/issues/19136