### PR TITLE
add api endpoint to list, get, and update add-on authors

### DIFF
--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -149,7 +149,7 @@ This endpoint allows you to fetch a specific add-on by id, slug or guid.
     :query boolean show_grouped_ratings: Whether or not to show ratings aggregates in the ``ratings`` object (Use "true"/"1" as truthy values, "0"/"false" as falsy ones).
     :>json int id: The add-on id on AMO.
     :>json array authors: Array holding information about the authors for the add-on.
-    :>json int authors[].id: The id for an author.
+    :>json int authors[].id: The user id for an author.
     :>json string authors[].name: The name for an author.
     :>json string authors[].url: The link to the profile page for an author.
     :>json string authors[].username: The username for an author.
@@ -730,6 +730,82 @@ This endpoint allows the metadata for an existing preview for a non-theme add-on
         This API requires :doc:`authentication <auth>`, and for the user to be an author of the add-on.
 
 .. http:delete:: /api/v5/addons/addon/(int:addon_id|string:addon_slug|string:addon_guid)/previews/(int:id)/
+
+
+-----------
+Author List
+-----------
+
+.. _addon-author-list:
+
+This endpoint returns a list of all the authors of an add-on.  No pagination is supported.
+
+    .. note::
+        This API requires :doc:`authentication <auth>`, and for the user to be an author of the add-on.
+
+
+.. http:get:: /api/v5/addons/addon/(int:id|string:slug|string:guid)/authors/
+
+
+-------------
+Author Detail
+-------------
+
+.. _addon-author-detail:
+
+This endpoint allows the properties of an add-on author to be retrieved, given a user (account) id.
+
+    .. note::
+        This API requires :doc:`authentication <auth>`, and for the user to be an author of the add-on.
+
+
+.. http:get:: /api/v5/addons/addon/(int:id|string:slug|string:guid)/authors/(int:user_id)/
+
+    .. _addon-author-detail-object:
+
+    :>json int user_id: The user id for an author.
+    :>json string name: The name for an author.
+    :>json string email: The email address for an author.
+    :>json string role: The :ref:`role <addon-author-detail-role>` the author holds on this add-on.
+    :>json boolean listed: If ``true`` the user will be listed as an add-on author publicly on the add-on detail page. (If ``false`` the user is not exposed as an author.)
+    :>json int position: The position the author should be returned in the list of authors of the add-on :ref:`detail <addon-detail-object>`. Order is ascending so lower positions are placed earlier.
+
+
+.. _addon-author-detail-role:
+
+    Possible values for the ``role`` field:
+
+    ==============  ==============================================================
+             Value  Description
+    ==============  ==============================================================
+         developer  A developer of the add-on. Developers can change all add-on
+                    metadata and create, delete, and edit versions of the add-on.
+             owner  An owner of the add-on. Owners have all the abilities of a
+                    developer, plus they can add, remove, and edit add-on authors,
+                    and delete the add-on.
+    ==============  ==============================================================
+
+-----------
+Author Edit
+-----------
+
+.. _addon-author-edit:
+
+This endpoint allows the properties of an add-on author to be edited.
+
+    .. note::
+        This API requires :doc:`authentication <auth>`, and for the user to be an owner of the add-on.
+
+    .. warning::
+        If you change your own author role to developer from owner you will lose permission to make any further author changes.
+
+.. http:patch:: /api/v5/addons/addon/(int:addon_id|string:addon_slug|string:addon_guid)/authors/(int:user_id)/
+
+    .. _addon-author-edit-request:
+
+    :<json string role: The :ref:`role <addon-author-detail-role>` the author holds on this add-on.  Add-ons must have at least one owner author.
+    :<json boolean listed: If ``true`` the user will be listed as an add-on author publicly on the add-on detail page. (If ``false`` the user is not exposed as an author.)  Add-ons must have at least one listed author.
+    :<json int position: The position the author should be returned in the list of authors of the add-on :ref:`detail <addon-detail-object>`. Order is ascending so lower positions are placed earlier.
 
 
 -------------

--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -441,6 +441,7 @@ These are `v5` specific changes - `v4` changes apply also.
 * 2022-03-24: added ``icon`` to be set or changed via addon update endpoints. https://github.com/mozilla/addons-server/issues/18232
 * 2022-04-14: added a ``previews`` endpoint under /addon/ that can be used to create, update, and delete add-on previews for non-themes. https://github.com/mozilla/addons-server/issues/18236
 * 2022-04-28: added the ability to delete add-ons via addon detail api endpoint. https://github.com/mozilla/addons-server/issues/19072
+* 2022-05-05: added the ability to list and edit add-on authors. https://github.com/mozilla/addons-server/issues/18231
 
 .. _`#11380`: https://github.com/mozilla/addons-server/issues/11380/
 .. _`#11379`: https://github.com/mozilla/addons-server/issues/11379/

--- a/src/olympia/addons/api_urls.py
+++ b/src/olympia/addons/api_urls.py
@@ -8,6 +8,7 @@ from olympia.files.views import FileUploadViewSet
 from olympia.tags.views import TagListView
 
 from .views import (
+    AddonAuthorViewSet,
     AddonAutoCompleteSearchView,
     AddonFeaturedView,
     AddonRecommendationView,
@@ -29,6 +30,7 @@ addons.register(r'addon', AddonViewSet, basename='addon')
 sub_addons = NestedSimpleRouter(addons, r'addon', lookup='addon')
 sub_addons.register('versions', AddonVersionViewSet, basename='addon-version')
 sub_addons.register('previews', AddonPreviewViewSet, basename='addon-preview')
+sub_addons.register('authors', AddonAuthorViewSet, basename='addon-author')
 sub_versions = NestedSimpleRouter(sub_addons, r'versions', lookup='version')
 sub_versions.register(
     r'reviewnotes', VersionReviewNotesViewSet, basename='version-reviewnotes'

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -714,7 +714,6 @@ class AddonAuthorSerializer(serializers.ModelSerializer):
         read_only_fields = tuple(set(fields) - set(writeable_fields))
 
     def validate_role(self, value):
-        # we need at least one listed user
         if (
             value != amo.AUTHOR_ROLE_OWNER
             and not AddonUser.objects.filter(
@@ -729,7 +728,6 @@ class AddonAuthorSerializer(serializers.ModelSerializer):
         return value
 
     def validate_listed(self, value):
-        # we need at least one addon owner
         if (
             value is not True
             and not AddonUser.objects.filter(

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -65,6 +65,7 @@ from .models import (
     Addon,
     AddonApprovalsCounter,
     AddonReviewerFlags,
+    AddonUser,
     DeniedSlug,
     Preview,
     ReplacementAddon,
@@ -693,6 +694,54 @@ class AddonDeveloperSerializer(BaseUserSerializer):
     class Meta(BaseUserSerializer.Meta):
         fields = BaseUserSerializer.Meta.fields + ('picture_url',)
         read_only_fields = fields
+
+
+class AddonAuthorSerializer(serializers.ModelSerializer):
+    user_id = serializers.IntegerField(source='user.id', read_only=True)
+    name = serializers.CharField(source='user.name', read_only=True)
+    email = serializers.CharField(source='user.email', read_only=True)
+    role = ReverseChoiceField(choices=list(amo.AUTHOR_CHOICES_API.items()))
+
+    class Meta:
+        model = AddonUser
+        fields = ('user_id', 'name', 'email', 'listed', 'position', 'role')
+
+        writeable_fields = (
+            'listed',
+            'position',
+            'role',
+        )
+        read_only_fields = tuple(set(fields) - set(writeable_fields))
+
+    def validate_role(self, value):
+        # we need at least one listed user
+        if (
+            value != amo.AUTHOR_ROLE_OWNER
+            and not AddonUser.objects.filter(
+                addon_id=self.instance.addon_id, role=amo.AUTHOR_ROLE_OWNER
+            )
+            .exclude(id=self.instance.id)
+            .exists()
+        ):
+            raise serializers.ValidationError(
+                gettext('Add-ons need at least one owner.')
+            )
+        return value
+
+    def validate_listed(self, value):
+        # we need at least one addon owner
+        if (
+            value is not True
+            and not AddonUser.objects.filter(
+                addon_id=self.instance.addon_id, listed=True
+            )
+            .exclude(id=self.instance.id)
+            .exists()
+        ):
+            raise serializers.ValidationError(
+                gettext('Add-ons need at least one listed author.')
+            )
+        return value
 
 
 class PromotedAddonSerializer(serializers.ModelSerializer):

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -16,6 +16,7 @@ from olympia.addons.models import (
     ReplacementAddon,
 )
 from olympia.addons.serializers import (
+    AddonAuthorSerializer,
     AddonBasketSyncSerializer,
     AddonDeveloperSerializer,
     AddonSerializer,
@@ -1763,3 +1764,20 @@ class TestReplacementAddonSerializer(TestCase):
         addon.update(status=amo.STATUS_APPROVED)
         result = self.serialize(rep)
         assert result['replacement'] == ['newstuff@mozilla']
+
+
+class TestAddonAuthorSerializer(TestCase):
+    def test_basic(self):
+        user = user_factory(read_dev_agreement=self.days_ago(0))
+        addon = addon_factory(users=(user,))
+        addonuser = addon.addonuser_set.get()
+
+        data = AddonAuthorSerializer().to_representation(instance=addonuser)
+        assert data == {
+            'user_id': user.id,
+            'role': 'owner',
+            'position': 0,
+            'listed': True,
+            'name': user.name,
+            'email': user.email,
+        }

--- a/src/olympia/constants/base.py
+++ b/src/olympia/constants/base.py
@@ -98,6 +98,11 @@ AUTHOR_CHOICES = (
     (AUTHOR_ROLE_DEV, _('Developer')),
 )
 
+AUTHOR_CHOICES_API = {
+    AUTHOR_ROLE_OWNER: 'owner',
+    AUTHOR_ROLE_DEV: 'developer',
+}
+
 AUTHOR_CHOICES_UNFILTERED = AUTHOR_CHOICES + ((AUTHOR_ROLE_DELETED, _('(Deleted)')),)
 
 # Addon types


### PR DESCRIPTION
fixes #18231 - just the getting, listing, and updating.  

Delete and create is being spun off into separate issues (delete is tricky because we want validation to prevent the only owner/listed author from being deleted; create is a whole separate model with confirmation from the new author)