### PR TITLE
drop warning about locale deleting not working 

### DIFF
--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -216,8 +216,6 @@ Then the resulting translations would be::
 "name": {"en-US": "Fun", "fr": "Jeux","kn": "ಆಟಗಳು"}
 
 To delete a translation, pass ``null`` as the value for that language.
-(Note: this behavior is currently buggy/broken - see
-https://github.com/mozilla/addons-server/issues/8816 for more details)
 
 
 .. _api-overview-outgoing:


### PR DESCRIPTION
follow-up for #8816 - deleting localizations by passing `None` should now work.