### PR TITLE
prevent name and summary from having null values for addons with listed versions

### DIFF
--- a/src/olympia/addons/fields.py
+++ b/src/olympia/addons/fields.py
@@ -64,6 +64,8 @@ class CategoriesSerializerField(serializers.Field):
                 # Now double-check all the category names were found
                 if not all_cat_slugs.issuperset(category_names):
                     raise exceptions.ValidationError(gettext('Invalid category name.'))
+            if not categories and self.required:
+                self.fail('required')
             return categories
         except KeyError:
             raise exceptions.ValidationError(gettext('Invalid app name.'))

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -71,7 +71,12 @@ from .models import (
 )
 from .tasks import resize_icon, resize_preview
 from .utils import fetch_translations_from_addon
-from .validators import ValidateVersionLicense, VerifyMozillaTrademark
+from .validators import (
+    AddonMetadataValidator,
+    AddonMetadataNewVersionValidator,
+    ValidateVersionLicense,
+    VerifyMozillaTrademark,
+)
 
 
 class FileSerializer(serializers.ModelSerializer):
@@ -384,7 +389,7 @@ class DeveloperVersionSerializer(VersionSerializer):
 
     class Meta:
         model = Version
-        validators = (ValidateVersionLicense(),)
+        validators = (ValidateVersionLicense(), AddonMetadataNewVersionValidator())
         fields = (
             'id',
             'channel',
@@ -464,38 +469,17 @@ class DeveloperVersionSerializer(VersionSerializer):
             if self.addon:
                 self._check_for_existing_versions(self.parsed_data.get('version'))
 
-            channel = data['upload'].channel
-            # If this is a new version to an existing addon, check that all the required
-            # metadata is set. We test for new addons in AddonSerailizer.validate
-            # instead. Also check for submitting listed versions when disabled.
-            if channel == amo.RELEASE_CHANNEL_LISTED and self.addon:
-                if self.addon.disabled_by_user:
+                # Also check for submitting listed versions when disabled.
+                if (
+                    data['upload'].channel == amo.RELEASE_CHANNEL_LISTED
+                    and self.addon.disabled_by_user
+                ):
                     raise exceptions.ValidationError(
                         gettext(
                             'Listed versions cannot be submitted while add-on is '
                             'disabled.'
                         )
                     )
-                # This is replicating what Addon.get_required_metadata does
-                missing_addon_metadata = [
-                    field
-                    for field, value in (
-                        ('categories', self.addon.all_categories),
-                        ('name', self.addon.name),
-                        ('summary', self.addon.summary),
-                    )
-                    if not value
-                ]
-                if missing_addon_metadata:
-                    raise exceptions.ValidationError(
-                        gettext(
-                            'Add-on metadata is required to be set to create a listed '
-                            'version: {missing_addon_metadata}.'
-                        ).format(missing_addon_metadata=missing_addon_metadata),
-                        code='required',
-                    )
-        else:
-            data.pop('upload', None)  # upload can only be set during create
 
         return data
 
@@ -775,12 +759,15 @@ class AddonSerializer(serializers.ModelSerializer):
     )
     url = serializers.SerializerMethodField()
     version = DeveloperVersionSerializer(
-        write_only=True, validators=(CreateOnlyValidator(), ValidateVersionLicense())
+        write_only=True,
+        # Note: we're purposefully omitting AddonMetadataNewVersionValidator
+        validators=(CreateOnlyValidator(), ValidateVersionLicense()),
     )
     versions_url = serializers.SerializerMethodField()
 
     class Meta:
         model = Addon
+        validators = (AddonMetadataValidator(),)
         fields = (
             'id',
             'authors',
@@ -909,6 +896,16 @@ class AddonSerializer(serializers.ModelSerializer):
     def get_is_source_public(self, obj):
         return False
 
+    def run_validation(self, *args, **kwargs):
+        # We want name and summary to be required fields so they're not cleared, but
+        # *only* if this is an existing add-on with listed versions.
+        # - see AddonMetadataValidator for new add-ons/versions.
+        if self.instance and self.instance.has_listed_versions():
+            self.fields['name'].required = True
+            self.fields['summary'].required = True
+            self.fields['categories'].required = True
+        return super().run_validation(*args, **kwargs)
+
     def validate_slug(self, value):
         slug_validator(value)
 
@@ -922,32 +919,15 @@ class AddonSerializer(serializers.ModelSerializer):
         return value
 
     def validate(self, data):
-        if not self.instance:
-            parsed_data = self.fields['version'].parsed_data
-            addon_type = parsed_data['type']
-            channel = getattr(data.get('version', {}).get('upload'), 'channel', None)
-
-            # If this is a new addon, check that all the required metadata is set.
-            # We test for new versions in VersionSerailizer.validate instead
-            if channel == amo.RELEASE_CHANNEL_LISTED:
-                # This is replicating what Addon.get_required_metadata does
-                required_msg = gettext(
-                    'This field is required for add-ons with listed versions.'
-                )
-                missing_metadata = {
-                    field: required_msg
-                    for field, value in (
-                        ('categories', data.get('all_categories')),
-                        ('name', data.get('name', parsed_data.get('name'))),
-                        ('summary', data.get('summary', parsed_data.get('summary'))),
-                    )
-                    if not value
-                }
-                if missing_metadata:
-                    raise exceptions.ValidationError(missing_metadata, code='required')
-        else:
-            addon_type = self.instance.type
         if 'all_categories' in data:
+            # We can't do this in a validate_categories function because we need
+            # parsed_data from the version field; and we can't move this functionality
+            # out into a validator class because we need to change `data` to drop dupes.
+            addon_type = (
+                self.instance.type
+                if self.instance
+                else self.fields['version'].parsed_data['type']
+            )
             # filter out categories for the wrong type.
             # There might be dupes, e.g. "other" is a category for 2 types
             slugs = {cat.slug for cat in data['all_categories']}
@@ -1065,8 +1045,7 @@ class AddonSerializer(serializers.ModelSerializer):
 class AddonSerializerWithUnlistedData(AddonSerializer):
     latest_unlisted_version = SimpleVersionSerializer(read_only=True)
 
-    class Meta:
-        model = Addon
+    class Meta(AddonSerializer.Meta):
         fields = AddonSerializer.Meta.fields + ('latest_unlisted_version',)
         read_only_fields = tuple(
             set(fields) - set(AddonSerializer.Meta.writeable_fields)

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -933,6 +933,7 @@ class TestAddonViewSetCreate(UploadMixin, AddonViewSetCreateUpdateMixin, TestCas
                 self.url,
                 data={
                     'summary': {'en-US': 'replacement summary'},
+                    'name': {'en-US': None},  # None should be ignored
                     'version': {
                         'upload': self.upload.uuid,
                         'license': self.license.slug,
@@ -1919,6 +1920,22 @@ class TestAddonViewSetUpdate(AddonViewSetCreateUpdateMixin, TestCase):
             old_content_review
             == AddonApprovalsCounter.objects.get(addon=self.addon).last_content_review
         )
+
+    def test_metadata_required(self):
+        # name and summary are treated as required for updates
+        data = {'name': {'en-US': None}, 'summary': {'en-US': None}, 'categories': {}}
+        response = self.client.patch(self.url, data=data)
+        assert response.status_code == 400
+        assert response.data == {
+            'name': ['A value in the default locale of "en-US" is required.'],
+            'summary': ['A value in the default locale of "en-US" is required.'],
+            'categories': ['This field is required.'],
+        }
+
+        # this requirement isn't enforced for addons without listed versions though
+        self.addon.current_version.update(channel=amo.RELEASE_CHANNEL_UNLISTED)
+        response = self.client.patch(self.url, data=data)
+        assert response.status_code == 200
 
 
 class TestAddonViewSetUpdateJWTAuth(TestAddonViewSetUpdate):

--- a/src/olympia/addons/validators.py
+++ b/src/olympia/addons/validators.py
@@ -98,3 +98,61 @@ class ValidateVersionLicense:
                     )
                 },
             )
+
+
+class AddonMetadataValidator:
+    requires_context = True
+    fields = {'name': 'name', 'summary': 'summary', 'all_categories': 'categories'}
+
+    def has_metadata(self, data, addon, field):
+        data_value = data.get(field)
+        values = data_value.values() if isinstance(data_value, dict) else data_value
+        return (values and any(val for val in values if val)) or bool(addon.get(field))
+
+    def get_addon_data(self, serializer):
+        if hasattr(serializer.fields.get('version'), 'parsed_data'):
+            # if we have a version field it's a new addon, so get the parsed_data
+            parsed = serializer.fields['version'].parsed_data
+            return {field: parsed.get(field) for field in self.fields}
+        else:
+            # else it's a new version, so extract the existing addon data
+            addon = getattr(serializer, 'addon', None)
+            return {field: getattr(addon, field, None) for field in self.fields}
+
+    def get_channel(self, data):
+        upload = data.get('upload', data.get('version', {}).get('upload'))
+        return upload.channel if upload else None
+
+    def __call__(self, data, serializer):
+        if (
+            not serializer.instance
+            and self.get_channel(data) == amo.RELEASE_CHANNEL_LISTED
+        ):
+            # Check that the required metadata is set for an addon with listed versions
+            addon_data = self.get_addon_data(serializer)
+            # This is replicating what Addon.get_required_metadata does
+            required_msg = gettext(
+                'This field is required for add-ons with listed versions.'
+            )
+            missing_metadata = {
+                serializer_field: required_msg
+                for data_field, serializer_field in self.fields.items()
+                if not self.has_metadata(data, addon_data, data_field)
+            }
+            if missing_metadata:
+                raise exceptions.ValidationError(missing_metadata, code='required')
+
+
+class AddonMetadataNewVersionValidator(AddonMetadataValidator):
+    def __call__(self, data, serializer):
+        try:
+            return super().__call__(data=data, serializer=serializer)
+        except exceptions.ValidationError as exc:
+            # Reformat the validation error(s) into a single error
+            raise exceptions.ValidationError(
+                gettext(
+                    'Add-on metadata is required to be set to create a listed '
+                    'version: {missing_addon_metadata}.'
+                ).format(missing_addon_metadata=list(exc.detail)),
+                code='required',
+            )


### PR DESCRIPTION
fixes #19055 - plus refactors the metadata checking so it's the same code for new add-ons and new versions.  (I'd originally aimed to use the same validation for add-on updates too but it works much better to rely on the `required=True` code for `TranslatedField` that was added for #8816)