### PR TITLE
Add about-sync's addon ID to the accepted list.

### DIFF
--- a/src/olympia/constants/base.py
+++ b/src/olympia/constants/base.py
@@ -386,6 +386,8 @@ RESERVED_ADDON_GUIDS = (
     '@mozillaonline.com',
     '@mozillafoundation.org',
     '@rally.mozilla.org',
+    # A temporary special case for aboutsync, which has a "legacy" ID.
+    'aboutsync@mhammond.github.com',
     # Temporary add-ons as defined in Firefox. Should not be submitted to AMO.
     '@temporary-addon',
 )


### PR DESCRIPTION
As discussed with @wagnerand, this PR adds the ID of the [about-sync](https://github.com/mozilla-extensions/aboutsync) addon to the set of acceptable addons. Even though all code referencing this list uses `.endsWith()`, I still put the entire ID in the list for clarity - let me know if you think that should change.

See also https://github.com/mozilla-extensions/xpi-manifest/pull/160