### PR TITLE
Simplify `pretty_filename` implementation ; use it when we display filenames

### DIFF
--- a/src/olympia/activity/models.py
+++ b/src/olympia/activity/models.py
@@ -635,7 +635,7 @@ class ActivityLog(ModelBase):
                 file_ = self.f(
                     '<a href="{0}">{1}</a> (validation {2})',
                     arg.get_absolute_url(),
-                    arg.filename,
+                    arg.pretty_filename,
                     validation,
                 )
                 arguments.remove(arg)

--- a/src/olympia/amo/tests/test_models.py
+++ b/src/olympia/amo/tests/test_models.py
@@ -322,7 +322,8 @@ class TestModelBase(TestCase):
         file = Addon.objects.get(pk=3615).current_version.file
         relative = os.path.join(
             reverse(
-                'downloads.file', kwargs={'file_id': file.id, 'filename': file.filename}
+                'downloads.file',
+                kwargs={'file_id': file.id, 'filename': file.pretty_filename},
             )
         )
         with override_settings(EXTERNAL_SITE_URL=settings.SITE_URL):

--- a/src/olympia/devhub/templates/devhub/includes/version_file.html
+++ b/src/olympia/devhub/templates/devhub/includes/version_file.html
@@ -1,7 +1,7 @@
 <tr>
   <td>
     <a href="{{ file.get_absolute_url() }}">
-      {{ file.pretty_filename() }}</a>
+      {{ file.pretty_filename }}</a>
   </td>
   <td>{{ file.size|filesizeformat(binary=True) }}</td>
   <td>{{ choices[file.status] }}</td>

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -786,7 +786,7 @@ def file_validation(request, addon_id, addon, file_id):
         'validate_url': validate_url,
         'file_url': file_url,
         'file': file_,
-        'filename': file_.filename,
+        'filename': file_.pretty_filename,
         'timestamp': file_.created,
         'addon': addon,
     }

--- a/src/olympia/files/admin.py
+++ b/src/olympia/files/admin.py
@@ -31,7 +31,6 @@ class FileAdmin(admin.ModelAdmin):
                     'id',
                     'created',
                     'version',
-                    'filename',
                     'size',
                     'hash',
                     'original_hash',
@@ -68,7 +67,9 @@ class FileAdmin(admin.ModelAdmin):
 
     def file_download_url(self, instance):
         return format_html(
-            '<a href="{}">Download file</a>', instance.get_absolute_url(attachment=True)
+            '<a href="{}">{}</a>',
+            instance.get_absolute_url(attachment=True),
+            instance.pretty_filename or 'Download',
         )
 
     file_download_url.short_description = 'Download this file'

--- a/src/olympia/files/models.py
+++ b/src/olympia/files/models.py
@@ -99,7 +99,7 @@ class File(OnChangeMixin, ModelBase):
         # See https://github.com/mozilla-mobile/fenix/blob/
         # 07d43971c0767fc023996dc32eb73e3e37c6517a/app/src/main/java/org/mozilla/fenix/
         # AppRequestInterceptor.kt#L173
-        kwargs = {'file_id': self.pk, 'filename': self.filename}
+        kwargs = {'file_id': self.pk, 'filename': self.pretty_filename}
         if attachment:
             kwargs['download_type'] = 'attachment'
         return reverse('downloads.file', kwargs=kwargs)
@@ -203,19 +203,9 @@ class File(OnChangeMixin, ModelBase):
         file_extension = '.xpi' if self.is_signed else '.zip'
         return '-'.join(parts) + file_extension
 
-    _pretty_filename = re.compile(r'(?P<slug>[a-z0-7_]+)(?P<suffix>.*)')
-
-    def pretty_filename(self, maxlen=20):
-        """Displayable filename.
-
-        Truncates filename so that the slug part fits maxlen.
-        """
-        m = self._pretty_filename.match(self.filename)
-        if not m:
-            return self.filename
-        if len(m.group('slug')) < maxlen:
-            return self.filename
-        return '{}...{}'.format(m.group('slug')[0 : (maxlen - 3)], m.group('suffix'))
+    def pretty_filename(self):
+        """Displayable filename."""
+        return os.path.basename(self.filename) if self.filename else ''
 
     def latest_xpi_url(self, attachment=False):
         addon = self.version.addon

--- a/src/olympia/files/models.py
+++ b/src/olympia/files/models.py
@@ -1,7 +1,6 @@
 import hashlib
 import json
 import os
-import re
 import unicodedata
 import uuid
 
@@ -203,6 +202,7 @@ class File(OnChangeMixin, ModelBase):
         file_extension = '.xpi' if self.is_signed else '.zip'
         return '-'.join(parts) + file_extension
 
+    @property
     def pretty_filename(self):
         """Displayable filename."""
         return os.path.basename(self.filename) if self.filename else ''

--- a/src/olympia/files/tests/test_admin.py
+++ b/src/olympia/files/tests/test_admin.py
@@ -33,7 +33,6 @@ class TestFileAdmin(TestCase):
 
         post_data = {
             'version': file_.version.pk,
-            'filename': file_.filename,
             'size': file_.size,
             'hash': 'xxx',
             'original_hash': 'xxx',

--- a/src/olympia/files/tests/test_models.py
+++ b/src/olympia/files/tests/test_models.py
@@ -199,14 +199,7 @@ class TestFile(TestCase, amo.tests.AMOPaths):
     def test_pretty_filename(self):
         file_ = File.objects.get(id=67442)
         file_.generate_filename()
-        assert file_.pretty_filename() == 'delicious_bookmarks-2.1.072-fx.xpi'
-
-    def test_pretty_filename_short(self):
-        file_ = File.objects.get(id=67442)
-        file_.is_signed = True
-        file_.version.addon.name = 'A Place Where The Sea Remembers Your Name'
-        file_.filename = file_.generate_filename()
-        assert file_.pretty_filename() == 'a_place_where_the...-2.1.072-fx.xpi'
+        assert file_.pretty_filename == 'delicious_bookmarks-2.1.072-fx.xpi'
 
     def test_generate_filename_many_apps(self):
         file_ = File.objects.get(id=67442)

--- a/src/olympia/reviewers/templates/reviewers/emails/files.ltxt
+++ b/src/olympia/reviewers/templates/reviewers/emails/files.ltxt
@@ -1,3 +1,3 @@
 {% if files %}
 Files approved:
-{% for file in files %}{{ file.filename }}{% endfor %}{% endif %}
+{% for file in files %}{{ file.pretty_filename }}{% endfor %}{% endif %}

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -138,7 +138,7 @@
         <ul>
           {% for file in form.unreviewed_files %}
           <li>
-            {{ file.filename }} &middot;
+            {{ file.pretty_filename }} &middot;
             {{ file_review_status(addon, file) }}
           </li>
           {% endfor %}

--- a/src/olympia/signing/serializers.py
+++ b/src/olympia/signing/serializers.py
@@ -63,7 +63,7 @@ class SigningFileUploadSerializer(serializers.ModelSerializer):
         url = drf_reverse(
             'signing.file',
             request=self._context.get('request'),
-            kwargs={'file_id': file_.id, 'filename': file_.filename},
+            kwargs={'file_id': file_.id, 'filename': file_.pretty_filename},
         )
         return absolutify(url)
 

--- a/src/olympia/signing/tests/test_views.py
+++ b/src/olympia/signing/tests/test_views.py
@@ -1384,7 +1384,7 @@ class TestCheckVersion(BaseUploadVersionTestMixin, TestCase):
         file_ = qs.get()
         assert response.data['files'][0]['download_url'] == absolutify(
             reverse_ns('signing.file', kwargs={'file_id': file_.id})
-            + f'/{file_.filename}'
+            + f'/{file_.pretty_filename}'
         )
 
     def test_file_hash(self):

--- a/src/olympia/versions/tests/test_views.py
+++ b/src/olympia/versions/tests/test_views.py
@@ -349,7 +349,7 @@ class TestDownloads(TestDownloadsBase):
         self.assert_served_internally(self.client.get(url), attachment=True)
 
     def test_trailing_filename(self):
-        url = self.file_url + self.file.filename
+        url = self.file_url + self.file.pretty_filename
         self.assert_served_internally(self.client.get(url))
 
     def test_null_datestatuschanged(self):
@@ -621,7 +621,7 @@ class TestDownloadsLatest(TestDownloadsBase):
         expected_redirect_url = absolutify(
             reverse(
                 'downloads.file',
-                kwargs={'file_id': self.file.pk, 'filename': self.file.filename},
+                kwargs={'file_id': self.file.pk, 'filename': self.file.pretty_filename},
             )
         )
         self.assert3xx(response, expected_redirect_url, 302)
@@ -646,7 +646,7 @@ class TestDownloadsLatest(TestDownloadsBase):
                 kwargs={
                     'file_id': self.file.pk,
                     'download_type': 'attachment',
-                    'filename': self.file.filename,
+                    'filename': self.file.pretty_filename,
                 },
             )
         )
@@ -671,7 +671,7 @@ class TestDownloadsLatest(TestDownloadsBase):
                 kwargs={
                     'file_id': self.file.pk,
                     'download_type': 'attachment',
-                    'filename': self.file.filename,
+                    'filename': self.file.pretty_filename,
                 },
             )
         )
@@ -695,7 +695,7 @@ class TestDownloadsLatest(TestDownloadsBase):
                 kwargs={
                     'file_id': self.file.pk,
                     'download_type': 'attachment',
-                    'filename': self.file.filename,
+                    'filename': self.file.pretty_filename,
                 },
             )
         )
@@ -712,7 +712,7 @@ class TestDownloadsLatest(TestDownloadsBase):
         expected_redirect_url = absolutify(
             reverse(
                 'downloads.file',
-                kwargs={'file_id': self.file.pk, 'filename': self.file.filename},
+                kwargs={'file_id': self.file.pk, 'filename': self.file.pretty_filename},
             )
         )
         response = self.client.get(self.latest_url)

--- a/static/css/zamboni/developers.css
+++ b/static/css/zamboni/developers.css
@@ -282,6 +282,17 @@ form .char-count b {
     margin-bottom: 5px;
 }
 
+#file-list td {
+    white-space: nowrap;
+}
+
+#file-list td a {
+    display: inline-block;
+    max-width: 20em;
+    text-overflow: ellipsis;
+    overflow: hidden;
+}
+
 #file-list .preview {
     overflow: auto;
     margin-bottom: 15px;


### PR DESCRIPTION
Make `File.pretty_filename` a property, and make it the main way to display filenames in URLs & UI, to prepare for the replacement of the filename field later.

See #19207 (this is split from a bunch of other changes to fix this issue)