### PR TITLE
Use slug and not name when generating filenames

### DIFF
--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -673,7 +673,7 @@ class TestAddonSubmitUpload(UploadMixin, TestCase):
         addon = Addon.unfiltered.get()
         latest_version = addon.find_latest_version(channel=amo.RELEASE_CHANNEL_UNLISTED)
         self.assert3xx(response, reverse('devhub.submit.finish', args=[addon.slug]))
-        assert latest_version.file.filename.endswith(f'{addon.pk}/weta_fade-1.0.zip')
+        assert latest_version.file.filename.endswith(f'{addon.pk}/{addon.slug}-1.0.zip')
         assert addon.type == amo.ADDON_STATICTHEME
         # Only listed submissions need a preview generated.
         assert latest_version.previews.all().count() == 0
@@ -730,7 +730,7 @@ class TestAddonSubmitUpload(UploadMixin, TestCase):
         latest_version = addon.find_latest_version(channel=amo.RELEASE_CHANNEL_UNLISTED)
         # Next step is same as non-wizard flow too.
         self.assert3xx(response, reverse('devhub.submit.finish', args=[addon.slug]))
-        assert latest_version.file.filename.endswith(f'{addon.pk}/weta_fade-1.0.zip')
+        assert latest_version.file.filename.endswith(f'{addon.pk}/{addon.slug}-1.0.zip')
         assert addon.type == amo.ADDON_STATICTHEME
         # Only listed submissions need a preview generated.
         assert latest_version.previews.all().count() == 0

--- a/src/olympia/files/models.py
+++ b/src/olympia/files/models.py
@@ -51,7 +51,7 @@ def files_upload_to_callback(instance, filename):
     called saved yet.
 
     For new uploads, the returned path is:
-    {directories}/addon_name}-{version}.{extension}, where {directories} is
+    {directories}/addon_slug}-{version}.{extension}, where {directories} is
     {addon_id last 2 digits}/{addon_id last 4 digits}/{addon_id}
 
     For older uploads, the returned path used to be in the format of
@@ -68,9 +68,9 @@ def files_upload_to_callback(instance, filename):
     a filename, but the filename is completely ignored here (it's meant to
     represent the user-provided filename in user uploads).
     """
-    # slugify drops unicode so we may end up with an empty string.
-    # Apache did not like serving unicode filenames (bug 626587).
-    name = slugify(instance.addon.name).replace('-', '_') or 'addon'
+    # Start with the add-on slug, but make it go through django's slugify() to
+    # drop unicode characters.
+    name = slugify(instance.addon.slug).replace('-', '_') or 'addon'
     parts = (name, instance.version.version)
     file_extension = '.xpi' if instance.is_signed else '.zip'
     return os.path.join(

--- a/src/olympia/files/tests/test_models.py
+++ b/src/olympia/files/tests/test_models.py
@@ -192,12 +192,12 @@ class TestFile(TestCase, amo.tests.AMOPaths):
         file_ = File.objects.get(id=67442)
         assert (
             file_._meta.get_field('file').upload_to(file_, None)
-            == '15/3615/3615/delicious_bookmarks-2.1.072.zip'  # zip extension.
+            == '15/3615/3615/a3615-2.1.072.zip'  # zip extension.
         )
         file_.is_signed = True
         assert (
             file_._meta.get_field('file').upload_to(file_, None)
-            == '15/3615/3615/delicious_bookmarks-2.1.072.xpi'  # xpi extension.
+            == '15/3615/3615/a3615-2.1.072.xpi'  # xpi extension.
         )
 
     def test_pretty_filename(self):
@@ -209,7 +209,7 @@ class TestFile(TestCase, amo.tests.AMOPaths):
         file_ = File()
         file_.version = Version(version='0.1.7')
         file_.version.compatible_apps = {amo.FIREFOX: None}
-        file_.version.addon = Addon(name=' フォクすけ  といっしょ', pk=4242)
+        file_.version.addon = Addon(slug=' フォクすけ  といっしょ', pk=4242)
         file_.is_signed = True
         assert (
             file_._meta.get_field('file').upload_to(file_, None)
@@ -220,7 +220,7 @@ class TestFile(TestCase, amo.tests.AMOPaths):
         # New files should be stored in deep directory structure
         file_ = addon_factory(
             pk=14071789,
-            name='My äDødôn',
+            slug='My äDødôn',
             version_kw={'version': '4.8.15.16'},
             file_kw={'filename': 'https-everywhere.xpi'},
         ).current_version.file
@@ -1084,7 +1084,8 @@ class TestFileFromUpload(UploadMixin, TestCase):
         self.addon = Addon.objects.create(
             guid='@webextension-guid',
             type=amo.ADDON_EXTENSION,
-            name='xxx',
+            slug='xxx',
+            name='Addon XXX',
             pk=123456,
         )
         self.version = Version.objects.create(addon=self.addon)
@@ -1134,9 +1135,9 @@ class TestFileFromUpload(UploadMixin, TestCase):
         assert fv.warnings == 1
         assert fv.notices == 2
 
-    def test_utf8_addon_name(self):
+    def test_filename_utf8_addon_slug(self):
         upload = self.upload('webextension.xpi')
-        self.version.addon.name = 'jéts!'
+        self.version.addon.slug = 'jéts!'
         file_ = File.from_upload(upload, self.version, parsed_data={})
         assert file_.filename == '56/3456/123456/jets-0.1.zip'
 

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -1354,7 +1354,7 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
         )
         assert version.version == '0.0.1'
 
-    def test_file_name(self):
+    def test_filename(self):
         parsed_data = parse_addon(self.upload, self.addon, user=self.fake_user)
         version = Version.from_upload(
             self.upload,
@@ -1363,7 +1363,7 @@ class TestExtensionVersionFromUpload(TestVersionFromUpload):
             selected_apps=[self.selected_app],
             parsed_data=parsed_data,
         )
-        assert version.file.filename == '15/3615/3615/delicious_bookmarks-0.0.1.zip'
+        assert version.file.filename == '15/3615/3615/a3615-0.0.1.zip'
 
     def test_track_upload_time(self):
         # Set created time back (just for sanity) otherwise the delta


### PR DESCRIPTION
Slugs don't depend on translations and have a db-enforced max length

Follow-up to https://github.com/mozilla/addons-server/issues/11510 to ensure filenames are a bit more predictable & safe.