### PR TITLE
Only migrate .xpi and .zip files

### DIFF
--- a/src/olympia/files/management/commands/migrate_files_to_new_structure.py
+++ b/src/olympia/files/management/commands/migrate_files_to_new_structure.py
@@ -61,7 +61,7 @@ class Command(BaseCommand):
         os.makedirs(new_dirpath, exist_ok=True)
         migrrated_count_in_dir = 0
         for entry in os.scandir(old_dirpath):
-            if entry.is_file():
+            if entry.is_file() and entry.name.endswith(('.zip', '.xpi')):
                 result = self.migrate_file(dirname, entry.name)
                 if result:
                     migrrated_count_in_dir += 1

--- a/src/olympia/files/management/commands/migrate_files_to_new_structure.py
+++ b/src/olympia/files/management/commands/migrate_files_to_new_structure.py
@@ -59,13 +59,13 @@ class Command(BaseCommand):
         old_dirpath = os.path.join(settings.ADDONS_PATH, dirname)
         new_dirpath = os.path.join(settings.ADDONS_PATH, id_to_path(dirname, breadth=2))
         os.makedirs(new_dirpath, exist_ok=True)
-        migrrated_count_in_dir = 0
+        migrated_count_in_dir = 0
         for entry in os.scandir(old_dirpath):
             if entry.is_file() and entry.name.endswith(('.zip', '.xpi')):
                 result = self.migrate_file(dirname, entry.name)
                 if result:
-                    migrrated_count_in_dir += 1
-        return migrrated_count_in_dir
+                    migrated_count_in_dir += 1
+        return migrated_count_in_dir
 
     def migrate_file(self, addon_pk, filename):
         filename_with_dirname = os.path.join(addon_pk, filename)

--- a/src/olympia/files/tests/test_commands.py
+++ b/src/olympia/files/tests/test_commands.py
@@ -135,6 +135,28 @@ class TestMigrateFilesToNewStructure(TestCase):
         assert migrate_file_mock.call_count == 1
         assert migrate_file_mock.call_args[0] == ('4815162342', 'bar.xpi')
 
+    def test_migrate_directory_contents_ignore_non_zip_or_xpi(self):
+        addon_path = os.path.join(settings.ADDONS_PATH, '4815162342')
+        os.makedirs(addon_path)
+        for filename in ('bar.xpi', 'baz.zip', 'xyz.png'):
+            file_path = os.path.join(addon_path, filename)
+            with open(file_path, 'w') as f:
+                f.write('a')
+        with mock.patch.object(self.command, 'migrate_file') as migrate_file_mock:
+            self.command.migrate_directory_contents('4815162342')
+        assert migrate_file_mock.call_count == 2
+        expected = [
+            ('4815162342', 'bar.xpi'),
+            ('4815162342', 'baz.zip'),
+        ]
+        actual = sorted(
+            (
+                migrate_file_mock.call_args_list[0][0],
+                migrate_file_mock.call_args_list[1][0],
+            )
+        )
+        assert actual == expected
+
     def test_migrate_directory_contents_empty_dir(self):
         addon_path = os.path.join(settings.ADDONS_PATH, '4815162342')
         os.makedirs(addon_path)


### PR DESCRIPTION
Prod doesn't contain any other file types in database.

Follow-up for https://github.com/mozilla/addons-server/issues/19193