### PR TITLE
Use addon id instead of slug in filenames if slug is empty

### DIFF
--- a/src/olympia/files/models.py
+++ b/src/olympia/files/models.py
@@ -70,7 +70,9 @@ def files_upload_to_callback(instance, filename):
     """
     # Start with the add-on slug, but make it go through django's slugify() to
     # drop unicode characters.
-    name = slugify(instance.addon.slug).replace('-', '_') or 'addon'
+    name = (
+        slugify(instance.addon.slug or instance.addon.pk).replace('-', '_') or 'addon'
+    )
     parts = (name, instance.version.version)
     file_extension = '.xpi' if instance.is_signed else '.zip'
     return os.path.join(

--- a/src/olympia/files/models.py
+++ b/src/olympia/files/models.py
@@ -51,8 +51,10 @@ def files_upload_to_callback(instance, filename):
     called saved yet.
 
     For new uploads, the returned path is:
-    {directories}/addon_slug}-{version}.{extension}, where {directories} is
-    {addon_id last 2 digits}/{addon_id last 4 digits}/{addon_id}
+    {directories}/{addon_slug}-{version}.{extension}, where {directories} is
+    {addon_id last 2 digits}/{addon_id last 4 digits}/{addon_id}. We drop all
+    non-ascii chars from the slug, and if the result is empty, fall back on the
+    addon id.
 
     For older uploads, the returned path used to be in the format of
     {addon_id}/{addon_name}-{version}.{extension} (and even used to contain
@@ -71,8 +73,8 @@ def files_upload_to_callback(instance, filename):
     # Start with the add-on slug, but make it go through django's slugify() to
     # drop unicode characters.
     name = (
-        slugify(instance.addon.slug or instance.addon.pk).replace('-', '_') or 'addon'
-    )
+        instance.addon.slug and slugify(instance.addon.slug).replace('-', '_')
+    ) or str(instance.addon.pk)
     parts = (name, instance.version.version)
     file_extension = '.xpi' if instance.is_signed else '.zip'
     return os.path.join(

--- a/src/olympia/files/tests/test_models.py
+++ b/src/olympia/files/tests/test_models.py
@@ -213,7 +213,7 @@ class TestFile(TestCase, amo.tests.AMOPaths):
         file_.is_signed = True
         assert (
             file_._meta.get_field('file').upload_to(file_, None)
-            == '42/4242/4242/addon-0.1.7.xpi'
+            == '42/4242/4242/4242-0.1.7.xpi'
         )
 
     def test_generate_filename_no_slug(self):

--- a/src/olympia/files/tests/test_models.py
+++ b/src/olympia/files/tests/test_models.py
@@ -216,6 +216,17 @@ class TestFile(TestCase, amo.tests.AMOPaths):
             == '42/4242/4242/addon-0.1.7.xpi'
         )
 
+    def test_generate_filename_no_slug(self):
+        file_ = File()
+        file_.version = Version(version='0.1.7')
+        file_.version.compatible_apps = {amo.FIREFOX: None}
+        file_.version.addon = Addon(slug='', pk=4242)
+        file_.is_signed = True
+        assert (
+            file_._meta.get_field('file').upload_to(file_, None)
+            == '42/4242/4242/4242-0.1.7.xpi'
+        )
+
     def test_filename_new_file_deep_directory_structure(self):
         # New files should be stored in deep directory structure
         file_ = addon_factory(

--- a/src/olympia/files/tests/test_models.py
+++ b/src/olympia/files/tests/test_models.py
@@ -216,11 +216,22 @@ class TestFile(TestCase, amo.tests.AMOPaths):
             == '42/4242/4242/4242-0.1.7.xpi'
         )
 
-    def test_generate_filename_no_slug(self):
+    def test_generate_filename_slug_empty(self):
         file_ = File()
         file_.version = Version(version='0.1.7')
         file_.version.compatible_apps = {amo.FIREFOX: None}
         file_.version.addon = Addon(slug='', pk=4242)
+        file_.is_signed = True
+        assert (
+            file_._meta.get_field('file').upload_to(file_, None)
+            == '42/4242/4242/4242-0.1.7.xpi'
+        )
+
+    def test_generate_filename_no_slug(self):
+        file_ = File()
+        file_.version = Version(version='0.1.7')
+        file_.version.compatible_apps = {amo.FIREFOX: None}
+        file_.version.addon = Addon(slug=None, pk=4242)
         file_.is_signed = True
         assert (
             file_._meta.get_field('file').upload_to(file_, None)


### PR DESCRIPTION
Follow-up for https://github.com/mozilla/addons-server/issues/19193