### PR TITLE
Handle invalid slug/choices with a validation error

### DIFF
--- a/src/olympia/api/fields.py
+++ b/src/olympia/api/fields.py
@@ -47,7 +47,7 @@ class ReverseChoiceField(fields.ChoiceField):
         """
         try:
             value = self.reversed_choices[value]
-        except KeyError:
+        except (KeyError, TypeError):
             self.fail('invalid_choice', input=value)
         return super().to_internal_value(value)
 

--- a/src/olympia/api/tests/test_fields.py
+++ b/src/olympia/api/tests/test_fields.py
@@ -50,8 +50,9 @@ class TestReverseChoiceField(TestCase):
         """Test that choices still matter, and you can't a) send the internal
         value or b) send an invalid value."""
         field = ReverseChoiceField(choices=(('internal', 'human'),))
-        with self.assertRaises(serializers.ValidationError):
-            field.to_internal_value('internal')
+        for invalid_value in ('internal', {}, [], None, 0):
+            with self.assertRaises(serializers.ValidationError):
+                field.to_internal_value(invalid_value)
 
 
 class TestTranslationSerializerField(TestCase):


### PR DESCRIPTION
fixes #19080 (and returns a nicer error message for an invalid license slug)