### PR TITLE
Tell dependabot to ignore google-cloud-bigquery >= 3.0.0 for now

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,3 +39,6 @@ updates:
   - dependency-name: click
     versions:
     - ">= 9"
+  - dependency-name: google-cloud-bigquery
+    versions:
+    - ">= 3.0.0"


### PR DESCRIPTION
See https://github.com/mozilla/addons-server/pull/19272#issuecomment-1133171403
