### PR TITLE
Revert "Bump docutils from 0.17.1 to 0.18.1 in /requirements"

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -21,9 +21,9 @@ Babel==2.10.1 \
     --hash=sha256:3f349e85ad3154559ac4930c3918247d319f21910d5ce4b25d439ed8693b98d2 \
     --hash=sha256:98aeaca086133efb3e1e2aad0396987490c8425929ddbcfe0550184fdc54cd13
 # docutils is required by Sphinx
-docutils==0.18.1 \
-    --hash=sha256:23010f129180089fbcd3bc08cfefccb3b890b0050e1ca00c867036e9d161b98c \
-    --hash=sha256:679987caf361a7539d76e584cbeddc311e3aee937877c87346f31debc63e9d06
+docutils==0.17.1 \
+    --hash=sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61 \
+    --hash=sha256:686577d2e4c32380bb50cbb22f575ed742d58168cee37e99117a854bcd88f125
 # imagesize is required by Sphinx
 imagesize==1.3.0 \
     --hash=sha256:1db2f82529e53c3e929e8926a1fa9235aa82d0bd0c580359c67ec31b2fddaa8c \


### PR DESCRIPTION
Reverts mozilla/addons-server#18391

It's unfortunately incompatible with `sphinx-rtd-theme` at the moment (it looks fine to me, but `sphinx-rtd-theme`'s `setup.py` asks for `docutils<0.18`