### PR TITLE
Remove easy-thumbnails dependency #18679

### DIFF
--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -53,7 +53,6 @@ import basket
 
 from babel import Locale
 from django_statsd.clients import statsd
-from easy_thumbnails import processors
 from html5lib.serializer import HTMLSerializer
 from PIL import Image
 from rest_framework.utils.encoders import JSONEncoder
@@ -642,7 +641,19 @@ def resize_image(source, destination, size=None, *, format='png', quality=80):
             im.load()
     original_size = im.size
     if size:
-        im = processors.scale_and_crop(im.convert('RGBA'), size)
+        target_width, target_height = size
+        source_width, source_height = im.size
+        scale = min(target_width / source_width, target_height / source_height)
+        if scale <= 1:
+            im = im.convert('RGBA')
+            im = im.resize(
+                (
+                    int(round(source_width * scale)),
+                    int(round(source_height * scale)),
+                ),
+                # Antialias is deprecated and renamed to Lanczos in PIL
+                resample=Image.Resampling.LANCZOS,
+            )
 
     with storage.open(destination, 'wb') as dest_file:
         if format == 'png':


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/18679

Calculate scale based on a target to source size ratio and use the scale to calculate output dimensions. Used Lanczos filter as Antialias is renamed to Lanczos in PIL.