### PR TITLE
Implement addon PUT as full-update or create

### DIFF
--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -383,6 +383,27 @@ Note: as form-data can not include objects, and creating an add-on requires the 
     :reqheader Content-Type: multipart/form-data
 
 
+--------------------
+Put - Create or Edit
+--------------------
+
+.. _addon-put:
+
+This endpoint allows a submission of an upload, which will either update an existing add-on and create a new version if the guid already exists, or will create a new add-on if the guid does not exist.
+See the :ref:`Add-on Create <addon-create>` documentation for details of the request and restrictions.
+
+    .. note::
+        This API requires :doc:`authentication <auth>`, and for the user to be an author of the add-on if the add-on exists already.
+
+    .. note::
+        If the add-on guid is specified in the manifest it must match the the guid in the url.
+
+    .. note::
+        A submission that results in a new add-on will have metadata defaults taken from the manifest (e.g. name), but a submission that updates an existing listing will not use data from the manifest.
+
+.. http:put:: /api/v5/addons/addon/(string:guid)/
+
+
 ------
 Delete
 ------

--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -396,7 +396,7 @@ See the :ref:`Add-on Create <addon-create>` documentation for details of the req
         This API requires :doc:`authentication <auth>`, and for the user to be an author of the add-on if the add-on exists already.
 
     .. note::
-        If the add-on guid is specified in the manifest it must match the the guid in the url.
+        The guid in the url must match a guid specified in the manifest.
 
     .. note::
         A submission that results in a new add-on will have metadata defaults taken from the manifest (e.g. name), but a submission that updates an existing listing will not use data from the manifest.

--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -443,6 +443,7 @@ These are `v5` specific changes - `v4` changes apply also.
 * 2022-05-05: added the ability to delete add-on authors. https://github.com/mozilla/addons-server/issues/19163
 * 2022-05-12: added the ability to add new add-on authors, as pending authors. https://github.com/mozilla/addons-server/issues/19164
 * 2022-06-02: enabled setting ``default_locale`` via addon submission and edit endpoints. https://github.com/mozilla/addons-server/issues/18235
+* 2022-06-16: added the ability to "PUT" an add-on upload to either create or update an add-on. https://github.com/mozilla/addons-server/issues/15353
 
 .. _`#11380`: https://github.com/mozilla/addons-server/issues/11380/
 .. _`#11379`: https://github.com/mozilla/addons-server/issues/11379/

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -21,6 +21,7 @@ from olympia.amo.utils import remove_icons, SafeStorage, slug_validator
 from olympia.amo.validators import (
     CreateOnlyValidator,
     OneOrMoreLetterOrNumberCharacterValidator,
+    PreventPartialUpdateValidator,
 )
 from olympia.api.fields import (
     EmailTranslationField,
@@ -863,7 +864,11 @@ class AddonSerializer(serializers.ModelSerializer):
     version = DeveloperVersionSerializer(
         write_only=True,
         # Note: we're purposefully omitting VersionAddonMetadataValidator
-        validators=(CreateOnlyValidator(), VersionLicenseValidator()),
+        validators=(
+            PreventPartialUpdateValidator(),
+            VersionLicenseValidator(),
+            MatchingGuidValidator(),
+        ),
     )
     versions_url = serializers.SerializerMethodField()
 
@@ -1163,13 +1168,6 @@ class AddonSerializerWithUnlistedData(AddonSerializer):
         read_only_fields = tuple(
             set(fields) - set(AddonSerializer.Meta.writeable_fields)
         )
-
-
-class AddonSerializerFromPut(AddonSerializerWithUnlistedData):
-    version = DeveloperVersionSerializer(
-        write_only=True,
-        validators=(VersionLicenseValidator(), MatchingGuidValidator()),
-    )
 
 
 class SimpleAddonSerializer(AddonSerializer):

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -1429,6 +1429,19 @@ class TestAddonViewSetCreatePut(TestAddonViewSetCreate):
             }
         }
 
+    def test_no_guid_in_manifest(self):
+        def parse_xpi_mock(pkg, addon, minimal, user):
+            return {**parse_xpi(pkg, addon, minimal, user), 'guid': None}
+
+        with patch('olympia.files.utils.parse_xpi', side_effect=parse_xpi_mock):
+            response = self.request()
+        assert response.status_code == 400, response.content
+        assert response.data == {
+            'version': {
+                'non_field_errors': ['A GUID must be specified in the manifest.']
+            }
+        }
+
     def test_only_guid_works_in_url(self):
         self.url = reverse_ns('addon-detail', kwargs={'pk': 'slug'}, api_version='v5')
         response = self.request()

--- a/src/olympia/addons/validators.py
+++ b/src/olympia/addons/validators.py
@@ -229,11 +229,12 @@ class MatchingGuidValidator:
     requires_context = True
 
     def __call__(self, data, serializer):
-        if (
-            (manifest_guid := serializer.parsed_data.get('guid'))
-            and (view_guid := serializer.context['view'].kwargs.get('guid'))
-            and manifest_guid != view_guid
-        ):
-            raise exceptions.ValidationError(
-                gettext('GUID mismatch between the URL and manifest.')
-            )
+        if view_guid := serializer.context['view'].kwargs.get('guid'):
+            if not (manifest_guid := serializer.parsed_data.get('guid')):
+                raise exceptions.ValidationError(
+                    gettext('A GUID must be specified in the manifest.')
+                )
+            elif manifest_guid != view_guid:
+                raise exceptions.ValidationError(
+                    gettext('GUID mismatch between the URL and manifest.')
+                )

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -383,6 +383,7 @@ class AddonViewSet(
             return super().update(request, *args, **kwargs)
 
         # otherwise we create a new add-on
+        self.action = 'create'
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         serializer.save(guid=self.kwargs['guid'])

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -381,14 +381,10 @@ class AddonViewSet(
         if instance:
             # if the add-on exists we can use the standard update
             return super().update(request, *args, **kwargs)
-
-        # otherwise we create a new add-on
-        self.action = 'create'
-        serializer = self.get_serializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        serializer.save(guid=self.kwargs['guid'])
-
-        return Response(serializer.data, status=status.HTTP_201_CREATED)
+        else:
+            # otherwise we create a new add-on
+            self.action = 'create'
+            return self.create(request, *args, **kwargs)
 
 
 class AddonChildMixin:

--- a/src/olympia/amo/validators.py
+++ b/src/olympia/amo/validators.py
@@ -47,3 +47,16 @@ class CreateOnlyValidator:
     def __call__(self, value, serializer_field):
         if serializer_field.parent.instance is not None:
             raise fields.SkipField()
+
+
+class PreventPartialUpdateValidator:
+    """
+    This validator raises SkipField if the field is used in a partial=True
+    (partial_update / PATCH) serializer instance.
+    """
+
+    requires_context = True
+
+    def __call__(self, value, serializer_field):
+        if serializer_field.parent.partial:
+            raise fields.SkipField()

--- a/src/olympia/files/tests/test_models.py
+++ b/src/olympia/files/tests/test_models.py
@@ -52,6 +52,7 @@ class UploadMixin(amo.tests.AMOPaths):
     """
 
     def setUp(self):
+        super().setUp()
         create_default_webext_appversion()
 
     def file_path(self, *args, **kw):


### PR DESCRIPTION
fixes #15353

This allows submission of all types of add-on, not just langpacks (as #15353 talks about), but should we limit PUT on `addon/<slug>/` to just langpacks as per issue?  Pros: The existing signing API allowed this style PUT to create or update so it'd be restoring that functionality. Cons: it's generally not a "good idea" to have an API where you don't know what the request will do - it _could_ create a new version for an existing add-on, or it _could_ create a new add-on - both outcomes could be a surprise if you weren't expecting it.  There's also some subtle differences around metadata in the manifest (the name, description, and homepage would be extracted for a new add-on; they wouldn't be for a new version) which are non-obvious.

Another feature this patch restores from the signing API (partially) is the ability to specify the GUID via the url if it's not in the manifest.  Pros: It's a convenient feature; Cons: it's against the direction of travel regarding future changes to require the manifest specify the guid explicitly so it's possibly unwise to encourage that use.  

Note: the issue talks about auto-generating the summary + license + category for a langpack - the patch doesn't do that as it's now trivial for the client to supply this in the POST data.