### PR TITLE
Consolidate celery queues

### DIFF
--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -803,21 +803,13 @@ CELERY_IMPORTS = (
 )
 
 CELERY_TASK_QUEUES = (
-    Queue('addons', routing_key='addons'),
     Queue('adhoc', routing_key='adhoc'),
     Queue('amo', routing_key='amo'),
-    Queue('bandwagon', routing_key='bandwagon'),
     Queue('cron', routing_key='cron'),
-    Queue('crypto', routing_key='crypto'),
     Queue('default', routing_key='default'),
     Queue('devhub', routing_key='devhub'),
-    Queue('images', routing_key='images'),
     Queue('priority', routing_key='priority'),
-    Queue('ratings', routing_key='ratings'),
     Queue('reviewers', routing_key='reviewers'),
-    Queue('search', routing_key='search'),
-    Queue('tags', routing_key='tags'),
-    Queue('users', routing_key='users'),
     Queue('zadmin', routing_key='zadmin'),
 )
 
@@ -884,6 +876,7 @@ CELERY_TASK_ROUTES = {
     'celery.backend_cleanup': {'queue': 'default'},
     'celery.chain': {'queue': 'default'},
     'celery.chord': {'queue': 'default'},
+    'celery.chord_unlock': {'queue': 'default'},
     'celery.chunks': {'queue': 'default'},
     'celery.group': {'queue': 'default'},
     'celery.map': {'queue': 'default'},


### PR DESCRIPTION
- Move reindex-related to `adhoc`
- Move `chord_unlock` back to `default` (we no longer need to force it to use the `devhub` queue since Celery 5.2, it will automatically be assigned to the same queue as the chord body)
- Merge `amo`, `addons`, `bandwagon`, `images`, `ratings`, `tags`, `users` together
- Move `recalculate_post_review_weight` (which we don't currently run) to `cron`, as it's supposed to be run as a cron if we ever enable it back
- Replace `crypto` with `reviewers`
- Sort every block

No new queue should be created as a result of this, so it should be safe to deploy.

Fixes #19344