### PR TITLE
Optimize Version queries around file/permissions

### DIFF
--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -140,6 +140,21 @@ class FileSerializer(serializers.ModelSerializer):
         return True
 
 
+class LanguageToolFileSerializer(FileSerializer):
+    permissions = serializers.SerializerMethodField()
+    optional_permissions = serializers.SerializerMethodField()
+
+    def get_permissions(self, obj):
+        # Language tools are not "real" webextensions, they don't have
+        # permissions.
+        return []
+
+    def get_optional_permissions(self, obj):
+        # Language tools are not "real" webextensions, they don't have
+        # optional permissions.
+        return []
+
+
 class ThisAddonDefault:
     requires_context = True
 
@@ -299,6 +314,10 @@ class MinimalVersionSerializer(serializers.ModelSerializer):
             # In v3/v4 files is expected to be a list but now we only have one file.
             repr['files'] = [repr.pop('file')]
         return repr
+
+
+class LanguageToolVersionSerializer(MinimalVersionSerializer):
+    file = LanguageToolFileSerializer(read_only=True)
 
 
 class SimpleVersionSerializer(MinimalVersionSerializer):
@@ -1459,7 +1478,7 @@ class LanguageToolsSerializer(AddonSerializer):
     def get_current_compatible_version(self, obj):
         compatible_versions = getattr(obj, 'compatible_versions', None)
         if compatible_versions is not None:
-            data = MinimalVersionSerializer(
+            data = LanguageToolVersionSerializer(
                 compatible_versions, context=self.context, many=True
             ).data
             try:

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -573,7 +573,7 @@ class AddonVersionViewSet(
             queryset = addon.versions.filter(
                 file__status=amo.STATUS_APPROVED, channel=amo.RELEASE_CHANNEL_LISTED
             )
-        # FIXME: we want to prefetch file.webext_permission instances in here
+        queryset = queryset.select_related('file___webext_permissions')
         if (
             self.action == 'list'
             and self.request
@@ -1099,8 +1099,7 @@ class LanguageToolsView(ListAPIView):
         # Version queryset we'll prefetch once for all results. We need to
         # find the ones compatible with the app+appversion requested, and we
         # can avoid loading translations by removing transforms and then
-        # re-applying the default one that takes care of the files and compat
-        # info.
+        # re-applying the default one that takes care of the compat info.
         versions_qs = (
             Version.objects.latest_public_compatible_with(application, appversions)
             .no_transforms()

--- a/src/olympia/bandwagon/tests/test_views.py
+++ b/src/olympia/bandwagon/tests/test_views.py
@@ -256,7 +256,7 @@ class TestCollectionViewSetDetail(TestCase):
         self.collection.add_addon(addon_factory())
         self.collection.add_addon(addon_factory())
         # see TestCollectionAddonViewSetList.test_basic for the query breakdown
-        with self.assertNumQueries(30):
+        with self.assertNumQueries(29):
             response = self.client.get(self.url + '?with_addons')
         assert len(response.data['addons']) == 4
         patched_drf_setting = dict(settings.REST_FRAMEWORK)
@@ -1016,7 +1016,7 @@ class TestCollectionAddonViewSetList(CollectionAddonViewSetMixin, TestCase):
         )
         self.client.login_api(self.user)
         # Passing authentication makes an extra query. We should not be caching.
-        self._test_no_caching(expected_num_queries=27)
+        self._test_no_caching(expected_num_queries=26)
 
     def test_no_caching_authenticated_by_username(self):
         self.user.update(username='notmozilla')
@@ -1029,7 +1029,7 @@ class TestCollectionAddonViewSetList(CollectionAddonViewSetMixin, TestCase):
         )
         self.client.login_api(self.user)
         # Passing authentication makes an extra query. We should not be caching.
-        self._test_no_caching(expected_num_queries=27)
+        self._test_no_caching(expected_num_queries=26)
 
     def test_no_caching_anonymous_not_mozilla_collection(self):
         # No caching done by addons-server, but we get the Cache-Control set
@@ -1067,7 +1067,7 @@ class TestCollectionAddonViewSetList(CollectionAddonViewSetMixin, TestCase):
         )
         self._test_caching()
 
-    def _test_no_caching(self, expected_num_queries=26, expected_max_age=None):
+    def _test_no_caching(self, expected_num_queries=25, expected_max_age=None):
         with self.assertNumQueries(expected_num_queries):
             response = self.client.get(self.url)
         # We aren't caching so we should be swapping DRF's Response with HttpResponse.
@@ -1100,7 +1100,7 @@ class TestCollectionAddonViewSetList(CollectionAddonViewSetMixin, TestCase):
         # See test_basic() below for the queries breakdown. What matters here
         # is that when we're being served a cached response we aren't doing
         # any queries besides the 2 savepoints.
-        with self.assertNumQueries(26):
+        with self.assertNumQueries(25):
             response = self.client.get(self.url)
         # For this API we're returning a HttpResponse directly, not a Response,
         # to improve pickled size to help caching.
@@ -1122,7 +1122,7 @@ class TestCollectionAddonViewSetList(CollectionAddonViewSetMixin, TestCase):
 
         # Any URL parameter added creates a separate cache key as well, so we
         # see the updated results with a new URL.
-        with self.assertNumQueries(26):
+        with self.assertNumQueries(25):
             response = self.client.get(self.url, {'foo': 'bar'})
         assert isinstance(response, HttpResponse)
         assert response['Content-Type'] == 'application/json'
@@ -1140,33 +1140,32 @@ class TestCollectionAddonViewSetList(CollectionAddonViewSetMixin, TestCase):
         assert response['Cache-Control'] == 'max-age=3600'
 
     def test_basic(self):
-        with self.assertNumQueries(26):
-            # 1 start savepoint
-            # 2 get user
-            # 3 get collections of user
-            # 4 get collection object
-            # 5 get user (again)
-            # 6 collection addon count
-            # 7 collectionaddons
-            # 8 addons
-            # 9 l10n for addons
-            # 10 addon categories
-            # 11 addons current versions
-            # 12 addons current versions release notes l10n
-            # 13 applicationversions
-            # 14 addons current_version files
-            # 15 addons addon_users (authors)
-            # 16 previews
-            # 17 promoted addons
-            # 18 collectionaddons notes for addons
-            # 19 promoted approvals for versions
-            # 20 licenses for versions
-            # 21 l10n for licenses
-            # 22 user tags
-            # 23 l10n for addons in all locales
-            # 24 l10n for licenses in all locales
-            # 25 webext permissions for files
-            # 26 end savepoint
+        with self.assertNumQueries(25):
+            #  1. start savepoint
+            #  2. get user
+            #  3. get collections of user
+            #  4. get collection object
+            #  5. get user (again)
+            #  6. collection addon count
+            #  7. collectionaddons
+            #  8. addons
+            #  9. l10n for addons
+            # 10. addon categories
+            # 11. addons current versions, files
+            # 12. addons current versions release notes l10n
+            # 13. applicationversions
+            # 14. addons addon_users (authors)
+            # 15. previews
+            # 16. promoted addons
+            # 17. file permissions
+            # 18. collectionaddons notes for addons
+            # 19. promoted approvals for versions
+            # 20. licenses for versions
+            # 21. l10n for licenses
+            # 22. user tags
+            # 23. l10n for addons in all locales
+            # 24. l10n for licenses in all locales
+            # 25. end savepoint
             super().test_basic()
 
     def test_transforms(self):

--- a/src/olympia/discovery/tests/test_views.py
+++ b/src/olympia/discovery/tests/test_views.py
@@ -114,17 +114,16 @@ class TestDiscoveryViewList(DiscoveryTestMixin, TestCase):
         # Precache waffle-switch to not rely on switch caching behavior
         switch_is_active('disco-recommendations')
 
-        with self.assertNumQueries(12):
+        with self.assertNumQueries(11):
             # 12 queries:
             # - 1 to fetch the discovery items
             # - 1 to fetch the add-ons (can't be joined with the previous one
             #   because we want to hit the Addon transformer)
             # - 1 to fetch add-ons translations
             # - 1 to fetch add-ons categories
-            # - 1 to fetch add-ons current_version
+            # - 1 to fetch add-ons current_version + file
             # - 1 to fetch the versions translations
             # - 1 to fetch the versions applications_versions
-            # - 1 to fetch the versions files
             # - 1 to fetch the add-ons authors
             # - 1 to fetch the add-ons version previews (for static themes)
             # - 1 to fetch the add-ons previews

--- a/src/olympia/hero/tests/test_views.py
+++ b/src/olympia/hero/tests/test_views.py
@@ -74,17 +74,16 @@ class TestPrimaryHeroShelfViewSet(TestCase):
         hero_b.update(enabled=True)
         hero_external.update(enabled=True)
         # don't enable the 3rd PrimaryHero object
-        with self.assertNumQueries(12):
-            # 12 queries:
+        with self.assertNumQueries(11):
+            # 11 queries:
             # - 1 to fetch the primaryhero/discoveryitem items
             # - 1 to fetch the add-ons (can't be joined with the previous one
             #   because we want to hit the Addon transformer)
             # - 1 to fetch add-ons translations
             # - 1 to fetch add-ons categories
-            # - 1 to fetch add-ons current_version
+            # - 1 to fetch add-ons current_version + file
             # - 1 to fetch the versions translations
             # - 1 to fetch the versions applications_versions
-            # - 1 to fetch the versions files
             # - 1 to fetch the add-ons authors
             # - 1 to fetch the add-ons version previews (for static themes)
             # - 1 to fetch the add-ons previews
@@ -400,9 +399,9 @@ class TestHeroShelvesView(TestCase):
         request = APIRequestFactory().get('/')
         request.version = api_settings.DEFAULT_VERSION
 
-        with self.assertNumQueries(14):
-            # 14 queries:
-            # - 12 as TestPrimaryHeroShelfViewSet.test_basic above
+        with self.assertNumQueries(13):
+            # 13 queries:
+            # - 11 as TestPrimaryHeroShelfViewSet.test_basic above
             # - 2 as TestSecondaryHeroShelfViewSet.test_basic above
             response = self.client.get(self.url, {'lang': 'en-US'})
         assert response.status_code == 200

--- a/src/olympia/reviewers/templates/reviewers/includes/files_view.html
+++ b/src/olympia/reviewers/templates/reviewers/includes/files_view.html
@@ -15,11 +15,11 @@
       >
         {{ _('Contents') }}
     </a>
-    {% if base_version and version == latest_not_disabled_version %}
+    {% if base_version_pk and version == latest_not_disabled_version %}
     &middot;
     <a
       class="compare"
-      href="{{ code_manager_url('compare', addon.pk, version.pk, base_version.pk) }}"
+      href="{{ code_manager_url('compare', addon.pk, version.pk, base_version_pk) }}"
       title="{{ _('Compare this version to the last reviewed version') }}"
     >
       {{ _('Compare') }}

--- a/src/olympia/reviewers/templatetags/jinja_helpers.py
+++ b/src/olympia/reviewers/templatetags/jinja_helpers.py
@@ -136,17 +136,17 @@ def reviewers_score_bar(context, types=None, addon_type=None):
 @jinja2.pass_context
 def file_view(context, version):
     return new_context(
-        dict(
+        {
             # We don't need the hashes in the template.
-            file=version.file,
-            amo=context.get('amo'),
-            addon=context.get('addon'),
-            latest_not_disabled_version=context.get('latest_not_disabled_version'),
+            'file': version.file,
+            'amo': context.get('amo'),
+            'addon': context.get('addon'),
+            'latest_not_disabled_version': context.get('latest_not_disabled_version'),
             # This allows the template to call waffle.flag().
-            request=context.get('request'),
-            base_version=context.get('base_version'),
-            version=version,
-        )
+            'request': context.get('request'),
+            'base_version_pk': context.get('base_version_pk'),
+            'version': version,
+        }
     )
 
 

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -5626,7 +5626,7 @@ class TestReview(ReviewBase):
         # Delete ActivityLog to make the query count easier to follow. We have
         # other tests for the ActivityLog related stuff.
         ActivityLog.objects.for_addons(self.addon).delete()
-        with self.assertNumQueries(67):
+        with self.assertNumQueries(51):
             # See test_item_history_pagination() for more details about the
             # queries count. What's important here is that the extra versions
             # and scanner results don't cause extra queries.
@@ -5685,7 +5685,7 @@ class TestReview(ReviewBase):
                     results={'matchedResults': [customs_rule.name]},
                 )
 
-        with self.assertNumQueries(69):
+        with self.assertNumQueries(53):
             # See test_item_history_pagination() for more details about the
             # queries count. What's important here is that the extra versions
             # and scanner results don't cause extra queries.
@@ -5882,12 +5882,12 @@ class TestAbuseReportsView(ReviewerTest):
         AbuseReport.objects.create(addon=self.addon, message='Two')
         AbuseReport.objects.create(addon=self.addon, message='Three')
         AbuseReport.objects.create(user=self.addon_developer, message='Four')
-        with self.assertNumQueries(21):
+        with self.assertNumQueries(20):
             # - 2 savepoint/release savepoint
             # - 2 for user and groups
             # - 1 for the add-on
             # - 1 for its translations
-            # - 7 for the add-on default transformer
+            # - 6 for the add-on / current version default transformer
             # - 1 for reviewer motd config
             # - 1 for site notice config
             # - 1 for add-ons from logged in user
@@ -7006,13 +7006,13 @@ class TestReviewAddonVersionViewSetDetail(
         self.grant_permission(user, 'Addons:Review')
         self.client.login_api(user)
 
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(9):
             # - 2 savepoints because tests
             # - 2 user and groups
             # - 2 add-on and translations
             # - 1 add-on author check
-            # - 1 version
-            # - 2 file and file validation
+            # - 1 version + file
+            # - 1 file validation
             response = self.client.get(self.url + '?file=README.md&lang=en-US')
         assert response.status_code == 200
         result = json.loads(response.content)
@@ -7119,13 +7119,13 @@ class TestReviewAddonVersionViewSetDetail(
         self.grant_permission(user, 'Addons:Review')
         self.client.login_api(user)
 
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(9):
             # - 2 savepoints because tests
             # - 2 user and groups
             # - 2 add-on and translations
             # - 1 add-on author check
-            # - 1 version
-            # - 2 file and file validation
+            # - 1 version + file
+            # - 1 file validation
             response = self.client.get(
                 self.url + '?file=README.md&lang=en-US&file_only=true'
             )

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -3082,7 +3082,7 @@ class TestReview(ReviewBase):
             str(author.get_role_display()),
             self.addon,
         )
-        with self.assertNumQueries(71):
+        with self.assertNumQueries(55):
             # FIXME: obviously too high, but it's a starting point.
             # Potential further optimizations:
             # - Remove trivial... and not so trivial duplicates
@@ -3097,62 +3097,55 @@ class TestReview(ReviewBase):
             # 4. add-on by slug
             # 5. add-on translations
             # 6. add-on categories
-            # 7. current version
-            # 8. version translations
-            # 9. applications versions
-            # 10. files
-            # 11. authors
-            # 12. previews
-            # 13. autoapprovalsummary for current version
-            # 14. promoted info for the add-on
-            # 15. latest version
-            # 16. latest version translations
-            # 17. latest version (repeated because different status filter)
-            # 18. latest version translations (repeated because different qs)
-            # 19. addon reviewer flags
-            # 20. version reviewer flags
-            # 21. version reviewer flags (repeated)
-            # 22. files
-            # 23. autoapprovalsummary (repeated)
-            # 24. addonreusedguid
-            # 25. blocklist
-            # 26. canned responses
-            # 27. abuse reports count against user or addon
-            # 28. low ratings count
-            # 29. base version for comparison
-            # 30. translations for base version
-            # 31. applications versions for base version
-            # 32. files for base version
-            # 33. count of all versions in channel
-            # 34. paginated list of versions in channel
-            # 35. scanner results for paginated list of versions
-            # 36. translations for  paginated list of versions
-            # 37. applications versions for  paginated list of versions
-            # 38. files for  paginated list of versions
-            # 39. activity log for  paginated list of versions
-            # 40. ready for auto-approval info for  paginated list of versions
-            # 41. versionreviewer flags exists to find out if pending rejection
-            # 42. count versions needing human review on other pages
-            # 43. count versions needing human review by mad on other pages
-            # 44. count versions pending rejection on other pages
-            # 45. whiteboard
-            # 46. reviewer subscriptions for listed
-            # 47. reviewer subscriptions for unlisted
-            # 48. config for motd
-            # 49. count add-ons the user is a developer of
-            # 50. config for site notice
-            # 51. translations for... (?! id=1)
-            # 52. important activity log about the add-on
-            # 53. user for the activity (from the ActivityLog foreignkey)
-            # 54. user for the activity (from the ActivityLog arguments)
-            # 55. add-on for the activity
-            # 56. translation for the add-on for the activity
-            # 57. reusedguid (repeated)
-            # 58. select all versions in channel for versions dropdown widget
-            # 59. select users by role for this add-on (?)
-            # 60. savepoint
-            # + 10! queries for webext_permissions - FIXME - there should only be 1
-            # + 1 for reviewers_reviewactionreason
+            # 7. current version + file
+            # 8. current version translations
+            # 9. current version applications versions
+            # 10. authors
+            # 11. previews
+            # 12. autoapprovalsummary for current version
+            # 13. promoted info for the add-on
+            # 14. latest version + file
+            # 15. latest version translations
+            # 16. latest version (repeated because different status filter)
+            # 17. latest version translations (repeated because different qs)
+            # 18. addon reviewer flags
+            # 19. version reviewer flags
+            # 20. version reviewer flags (repeated)
+            # 21. autoapprovalsummary (repeated)
+            # 22. addonreusedguid
+            # 23. blocklist
+            # 24. canned responses
+            # 25. abuse reports count against user or addon
+            # 26. low ratings count
+            # 27. base version pk for comparison
+            # 28. count of all versions in channel
+            # 29. paginated list of versions in channel
+            # 30. scanner results for paginated list of versions
+            # 31. translations for  paginated list of versions
+            # 32. applications versions for  paginated list of versions
+            # 33. files for  paginated list of versions
+            # 34. activity log for  paginated list of versions
+            # 35. ready for auto-approval info for  paginated list of versions
+            # 36. versionreviewer flags exists to find out if pending rejection
+            # 37. count versions needing human review on other pages
+            # 38. count versions needing human review by mad on other pages
+            # 39. count versions pending rejection on other pages
+            # 40. whiteboard
+            # 41. reviewer subscriptions for listed
+            # 42. reviewer subscriptions for unlisted
+            # 43. release savepoint (?)
+            # 44. config for motd
+            # 45. count add-ons the user is a developer of
+            # 46. config for site notice
+            # 47. translations for... (?! id=1)
+            # 48. important activity log about the add-on
+            # 49. user for the activity (from the ActivityLog foreignkey)
+            # 50. user for the activity (from the ActivityLog arguments)
+            # 51. add-on for the activity
+            # 52. translation for the add-on for the activity
+            # 53. select all versions in channel for versions dropdown widget
+            # 54. reviewer reasons for the reason dropdown
+            # 55. select users by role for this add-on (?)
             response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
@@ -4326,7 +4319,7 @@ class TestReview(ReviewBase):
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
-        assert response.context['base_version']
+        assert response.context['base_version_pk']
         links = doc('#versions-history .file-info .compare')
 
         expected = [
@@ -4360,7 +4353,7 @@ class TestReview(ReviewBase):
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
-        assert response.context['base_version']
+        assert response.context['base_version_pk']
         links = doc('#versions-history .file-info .compare')
         # Comparison should be between the last version and the first,
         # ignoring the interim version because it was auto-approved and not
@@ -4400,7 +4393,7 @@ class TestReview(ReviewBase):
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
-        assert response.context['base_version']
+        assert response.context['base_version_pk']
         links = doc('#versions-history .file-info .compare')
         # Comparison should be between the last version and the second,
         # ignoring the third version because it was auto-approved and not
@@ -4435,7 +4428,7 @@ class TestReview(ReviewBase):
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
-        assert response.context['base_version']
+        assert response.context['base_version_pk']
         links = doc('#versions-history .file-info .compare')
         # Comparison should be between the last version and the second,
         # because second was approved by human before auto-approval ran on it

--- a/src/olympia/shelves/tests/test_views.py
+++ b/src/olympia/shelves/tests/test_views.py
@@ -148,8 +148,8 @@ class TestShelfViewSet(ESTestCase):
         # don't enable shelf_c
         self.shelf_d.update(enabled=True)
 
-        # would be 27 but we mocked Shelf.tag that does a query.
-        with self.assertNumQueries(26):
+        # would be 26 but we mocked Shelf.tag that does a query.
+        with self.assertNumQueries(25):
             response = self.client.get(self.url)
         assert response.status_code == 200
 
@@ -235,10 +235,10 @@ class TestShelfViewSet(ESTestCase):
         request = APIRequestFactory().get('/')
         request.version = api_settings.DEFAULT_VERSION
 
-        with self.assertNumQueries(15):
-            # 15 queries:
+        with self.assertNumQueries(14):
+            # 14 queries:
             # - 1 to get the shelves
-            # - 12 as TestPrimaryHeroShelfViewSet.test_basic
+            # - 11 as TestPrimaryHeroShelfViewSet.test_basic
             # - 2 as TestSecondaryHeroShelfViewSet.test_basic
             response = self.client.get(self.url, {'lang': 'en-US'})
         assert response.status_code == 200
@@ -267,10 +267,10 @@ class TestShelfViewSet(ESTestCase):
 
         self.shelf_a.update(enabled=True)
 
-        with self.assertNumQueries(17):
-            # 17 queries:
+        with self.assertNumQueries(16):
+            # 16 queries:
             # - 3 to get the shelves
-            # - 12 as TestPrimaryHeroShelfViewSet.test_basic
+            # - 11 as TestPrimaryHeroShelfViewSet.test_basic
             # - 2 as TestSecondaryHeroShelfViewSet.test_basic
             response = self.client.get(self.url)
         assert response.status_code == 200

--- a/src/olympia/versions/views.py
+++ b/src/olympia/versions/views.py
@@ -28,6 +28,7 @@ def update_info(request, addon, version_num):
     version = get_object_or_404(
         addon.versions.reviewed()
         .filter(channel=amo.RELEASE_CHANNEL_LISTED)
+        .select_related(None)
         .only_translations(),
         version=version_num,
     )
@@ -46,6 +47,7 @@ def update_info_redirect(request, version_id):
     version = get_object_or_404(
         Version.objects.reviewed()
         .filter(channel=amo.RELEASE_CHANNEL_LISTED)
+        .select_related(None)
         .no_transforms()
         .select_related('addon'),
         pk=version_id,


### PR DESCRIPTION
- Add a `select_related()` on `file` in Version's default queryset instead of making another query in the transformer to fetch the files.
- Add a `select_related(None)` on querysets that really don't need the `file` for the versions they are fetching (most do)
- Add a `select_related()` on `file__webext_permissions` in `review()` and `AddonVersionViewSet` now that the files are no longer fetched separately
- Avoid loading permissions entirely for `LanguageToolView` - we don't need them there.
- Stop loading the entire base version in `review()` - we just need the pk

This significantly reduces the number of queries made by language tools API, addon versions API and the review page.

Fixes #18047