### PR TITLE
Specify a field when using random_score in ES to avoid deprecation warning

### DIFF
--- a/src/olympia/search/filters.py
+++ b/src/olympia/search/filters.py
@@ -1016,6 +1016,7 @@ class SortingFilter(BaseFilterBackend):
                             query.SF(
                                 'random_score',
                                 seed=date.today().toordinal(),
+                                field='id',
                             )
                         ],
                     )

--- a/src/olympia/search/tests/test_filters.py
+++ b/src/olympia/search/tests/test_filters.py
@@ -531,7 +531,7 @@ class TestSortingFilter(FilterTestsBase):
         # TestCombinedFilter.test_filter_featured_sort_random
         assert qs['sort'] == ['_score']
         assert qs['query']['function_score']['functions'] == [
-            {'random_score': {'seed': 737481}}
+            {'random_score': {'seed': 737481, 'field': 'id'}}
         ]
 
     @freeze_time('2020-02-27')
@@ -542,7 +542,7 @@ class TestSortingFilter(FilterTestsBase):
         # TestCombinedFilter.test_filter_promoted_sort_random
         assert qs['sort'] == ['_score']
         assert qs['query']['function_score']['functions'] == [
-            {'random_score': {'seed': 737482}}
+            {'random_score': {'seed': 737482, 'field': 'id'}}
         ]
 
     def test_sort_recommended_only(self):
@@ -1129,7 +1129,7 @@ class TestCombinedFilter(FilterTestsBase):
         assert qs['sort'] == ['_score']
 
         assert bool_['must'][0]['function_score']['functions'] == [
-            {'random_score': {'seed': 737481}}
+            {'random_score': {'seed': 737481, 'field': 'id'}}
         ]
 
     @freeze_time('2020-02-26')
@@ -1147,5 +1147,5 @@ class TestCombinedFilter(FilterTestsBase):
         assert qs['sort'] == ['_score']
 
         assert bool_['must'][0]['function_score']['functions'] == [
-            {'random_score': {'seed': 737481}}
+            {'random_score': {'seed': 737481, 'field': 'id'}}
         ]


### PR DESCRIPTION
According to documentation:
> It was possible to set a seed without setting a field, but this has been deprecated as this requires loading fielddata on the _id field which consumes a lot of memory.

Fixes #19386