### PR TITLE
Only consider extensions in the `mad`/`scanner` reviewer queues and scanner actions

### DIFF
--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -349,7 +349,7 @@ class ContentReviewTable(AutoApprovedTable):
         return reverse('reviewers.review', args=['content', record.id])
 
 
-class ScannersReviewTable(AutoApprovedTable):
+class ScannersReviewTable(AddonQueueTable):
     listed_text = _('Listed versions needing human review ({0})')
     unlisted_text = _('Unlisted versions needing human review ({0})')
     show_count_in_dashboard = False

--- a/src/olympia/scanners/models.py
+++ b/src/olympia/scanners/models.py
@@ -14,6 +14,7 @@ from django.utils.translation import gettext_lazy as _
 import olympia.core.logger
 
 from olympia.amo.models import ModelBase
+from olympia.constants.base import ADDON_EXTENSION
 from olympia.constants.scanners import (
     ABORTED,
     ABORTING,
@@ -141,6 +142,13 @@ class AbstractScannerResult(ModelBase):
         a task.
         """
         log.info('Checking rules and actions for version %s.', version.pk)
+
+        if version.addon.type != ADDON_EXTENSION:
+            log.info(
+                'Not running action(s) on version %s which belongs to a non-extension.',
+                version.pk,
+            )
+            return
 
         try:
             mad_result = cls.objects.filter(version=version, scanner=MAD).get()

--- a/src/olympia/scanners/tests/test_actions.py
+++ b/src/olympia/scanners/tests/test_actions.py
@@ -377,6 +377,29 @@ class TestRunAction(TestCase):
         assert _delay_auto_approval_indefinitely_mock.called
         _delay_auto_approval_indefinitely_mock.assert_called_with(self.version)
 
+    @mock.patch('olympia.scanners.models._delay_auto_approval_indefinitely')
+    def test_returns_for_non_extension_addons(
+        self, _delay_auto_approval_indefinitely_mock
+    ):
+        self.scanner_rule.update(action=DELAY_AUTO_APPROVAL_INDEFINITELY)
+        self.version.addon.update(type=amo.ADDON_DICT)
+
+        ScannerResult.run_action(self.version)
+
+        assert not _delay_auto_approval_indefinitely_mock.called
+
+        self.version.addon.update(type=amo.ADDON_LPAPP)
+
+        ScannerResult.run_action(self.version)
+
+        assert not _delay_auto_approval_indefinitely_mock.called
+
+        self.version.addon.update(type=amo.ADDON_STATICTHEME)
+
+        ScannerResult.run_action(self.version)
+
+        assert not _delay_auto_approval_indefinitely_mock.called
+
     @mock.patch('olympia.scanners.models.log.info')
     def test_returns_when_no_action_found(self, log_mock):
         self.scanner_rule.delete()


### PR DESCRIPTION
This allows the query to look at fewer rows, making it faster - the scanner actions also avoid touching non-extensions to make things consistent and avoid the situation where something would trigger an action we wouldn't notice because it's not shown in the queues.

In addition, in the reviewer queues, the `COUNT()` is optimized using the same method already used for dashboard counts, by not returning columns we won't need and avoiding sorting in the subquery.

Fixes #19430