### PR TITLE
Remove code allowing developers to re-use their deleted guids

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -845,17 +845,7 @@ class Addon(OnChangeMixin, ModelBase):
         timer.start()
         fields = [field.name for field in cls._meta.get_fields()]
         guid = data.get('guid')
-        old_guid_addon = None
-        if guid:  # It's an extension.
-            if waffle.switch_is_active('allow-deleted-guid-reuse'):
-                # Reclaim GUID from deleted add-on.
-                try:
-                    old_guid_addon = Addon.unfiltered.get(guid=guid)
-                    old_guid_addon.update(guid=None)
-                except ObjectDoesNotExist:
-                    pass
-
-        if not data.get('guid'):
+        if not guid:
             data['guid'] = guid = generate_addon_guid()
         timer.log_interval('1.guids')
 
@@ -879,24 +869,16 @@ class Addon(OnChangeMixin, ModelBase):
             addon.default_locale = to_language(trans_real.get_language())
         timer.log_interval('5.default_locale')
 
-        # Note: if 'allow-deleted-guid-reuse' waffle switch check above is
-        # falsy (or there is a race condition with an add-on with the same guid
-        # added in the meantime), then trying to create an add-on with a guid
-        # that is already used will trigger an IntegrityError here, which is
-        # fine: we want to prevent the creation in that case and it's too late
-        # to handle the error elegantly as we'll likely be in a task - this
-        # should happen before, at validation.
+        # Note: Trying to create an add-on with a guid that is already used
+        # will trigger an IntegrityError here, which is fine: we want to
+        # prevent the creation in that case and it's too late to handle the
+        # error elegantly as we'll likely be in a task - this should happen
+        # before, at validation.
         addon.save()
         timer.log_interval('6.addon_save')
 
-        if guid:
-            AddonGUID.objects.create(addon=addon, guid=guid)
-        if old_guid_addon:
-            old_guid_addon.update(guid=GUID_REUSE_FORMAT.format(addon.pk))
-            log.info(
-                f'GUID {guid} from addon [{old_guid_addon.pk}] reused '
-                f'by addon [{addon.pk}].'
-            )
+        AddonGUID.objects.create(addon=addon, guid=guid)
+
         AddonUser(addon=addon, user=user).save()
         activity.log_create(amo.LOG.CREATE_ADDON, addon, user=user)
         log.info(f'New addon {addon!r} from {upload!r}')

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -20,8 +20,6 @@ from django.utils import translation
 from django.utils.functional import cached_property
 from django.utils.translation import trans_real, gettext_lazy as _
 
-import waffle
-
 from django_statsd.clients import statsd
 
 import olympia.core.logger

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -2313,8 +2313,7 @@ class TestAddonFromUpload(UploadMixin, TestCase):
             parse_addon(self.upload, user=self.user)
         assert e.exception.messages == ['Duplicate add-on ID found.']
 
-    @override_switch('allow-deleted-guid-reuse', active=True)
-    def test_existing_guid_same_author(self):
+    def test_existing_guid_same_author_still_forbidden(self):
         # Upload addon so we can delete it.
         self.upload = self.get_upload('webextension.xpi')
         parsed_data = parse_addon(self.upload, user=self.user)
@@ -2328,41 +2327,27 @@ class TestAddonFromUpload(UploadMixin, TestCase):
         deleted.delete()
         assert deleted.guid == '@webextension-guid'
 
-        # Now upload the same add-on again (so same guid), checking no
-        # validationError is raised this time.
+        # Now upload the same add-on again (so same guid). We're building
+        # parsed_data manually to avoid the ValidationError from parse_addon()
+        # because we're interested in the error coming after that.
         self.upload = self.get_upload('webextension.xpi')
-        parsed_data = parse_addon(self.upload, user=self.user)
-        addon = Addon.from_upload(
-            self.upload, selected_apps=[self.selected_app], parsed_data=parsed_data
-        )
-        deleted.reload()
-        assert addon.guid == '@webextension-guid'
-        assert deleted.guid == 'guid-reused-by-pk-%s' % addon.pk
-        assert AddonGUID.objects.filter(guid='@webextension-guid').count() == 2
-        assert AddonGUID.objects.filter(guid='@webextension-guid').first().addon == (
-            deleted
-        )
-
-    def test_existing_guid_same_author_but_switch_allowing_reuse_is_off(self):
-        # Upload addon so we can delete it.
-        self.upload = self.get_upload('webextension.xpi')
-        parsed_data = parse_addon(self.upload, user=self.user)
-        deleted = Addon.from_upload(
-            self.upload, selected_apps=[self.selected_app], parsed_data=parsed_data
-        )
-        assert AddonGUID.objects.filter(guid='@webextension-guid').count() == 1
-        # Claim the add-on.
-        AddonUser(addon=deleted, user=self.user).save()
-        deleted.update(status=amo.STATUS_APPROVED)
-        deleted.delete()
-        assert deleted.guid == '@webextension-guid'
-
-        # Now upload the same add-on again (so same guid). ValidationError
-        # would be raised if we didn't override the switch, we're bypassing
-        # it because we're interested in the error coming after that.
-        with override_switch('allow-deleted-guid-reuse', active=True):
-            self.upload = self.get_upload('webextension.xpi')
-            parsed_data = parse_addon(self.upload, user=self.user)
+        parsed_data = {
+            'guid': '@webextension-guid',
+            'type': 1,
+            'version': '0.0.1',
+            'name': 'My WebExtension Addon',
+            'summary': 'just a test addon with the manifest.json format',
+            'homepage': None,
+            'default_locale': None,
+            'manifest_version': 2,
+            'install_origins': [],
+            'apps': [],
+            'strict_compatibility': False,
+            'is_experiment': False,
+            'optional_permissions': [],
+            'permissions': [],
+            'content_scripts': [],
+        }
 
         with self.assertRaises(IntegrityError):
             Addon.from_upload(

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -11,8 +11,6 @@ from django.utils import translation
 
 import pytest
 
-from waffle.testutils import override_switch
-
 from olympia import amo, core
 from olympia.activity.models import ActivityLog, AddonLog
 from olympia.addons import models as addons_models

--- a/src/olympia/devhub/templates/devhub/addons/listing/_delete_warning.html
+++ b/src/olympia/devhub/templates/devhub/addons/listing/_delete_warning.html
@@ -2,6 +2,7 @@
   Deleting your add-on will permanently delete all versions and files you
   have submitted for this add-on, listed or not.
 {% endtrans %}
+
 {% trans %}
   The add-on ID cannot be restored and will forever be unusable for submission.
 {% endtrans %}

--- a/src/olympia/devhub/templates/devhub/addons/listing/_delete_warning.html
+++ b/src/olympia/devhub/templates/devhub/addons/listing/_delete_warning.html
@@ -5,4 +5,3 @@
 {% trans %}
   The add-on ID cannot be restored and will forever be unusable for submission.
 {% endtrans %}
-{% endif %}

--- a/src/olympia/devhub/templates/devhub/addons/listing/_delete_warning.html
+++ b/src/olympia/devhub/templates/devhub/addons/listing/_delete_warning.html
@@ -2,12 +2,7 @@
   Deleting your add-on will permanently delete all versions and files you
   have submitted for this add-on, listed or not.
 {% endtrans %}
-{% if waffle.switch('allow-deleted-guid-reuse') %}
-  {% trans %}
-    The add-on ID will continue to be linked to your account, so others won't be able to submit versions using the same ID.
-  {% endtrans %}
-{% else %}
-  {% trans %}
-    The add-on ID cannot be restored and will forever be unusable for submission.
-  {% endtrans %}
+{% trans %}
+  The add-on ID cannot be restored and will forever be unusable for submission.
+{% endtrans %}
 {% endif %}

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -109,17 +109,6 @@ class TestVersion(TestCase):
             'for submission.'
         )
 
-    @override_switch('allow-deleted-guid-reuse', active=True)
-    def test_delete_message_if_allow_deleted_guid_reuse_is_on(self):
-        response = self.client.get(self.url)
-        doc = pq(response.content)
-        assert doc('#modal-delete p').eq(0).text() == (
-            'Deleting your add-on will permanently delete all versions and '
-            'files you have submitted for this add-on, listed or not. '
-            'The add-on ID will continue to be linked to your account, so '
-            "others won't be able to submit versions using the same ID."
-        )
-
     def test_delete_message_incomplete(self):
         """
         If an addon has status = 0, they shouldn't be bothered with a

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -10,7 +10,6 @@ from django.urls import reverse
 from unittest import mock
 
 from pyquery import PyQuery as pq
-from waffle.testutils import override_switch
 
 from olympia import amo
 from olympia.activity.models import ActivityLog

--- a/src/olympia/files/tests/test_models.py
+++ b/src/olympia/files/tests/test_models.py
@@ -18,7 +18,6 @@ from django.urls import reverse
 from django.utils.encoding import force_str
 
 import pytest
-from waffle.testutils import override_switch
 
 from olympia import amo, core
 from olympia.addons.models import Addon

--- a/src/olympia/files/tests/test_models.py
+++ b/src/olympia/files/tests/test_models.py
@@ -554,13 +554,6 @@ class TestParseXpi(amo.tests.AMOPaths, TestCase):
             self.parse(filename='webextension.xpi')
         assert e.exception.messages == ['Duplicate add-on ID found.']
 
-    @override_switch('allow-deleted-guid-reuse', active=True)
-    def test_guid_dupe_deleted_addon_allowed_if_same_author_and_switch_is_on(self):
-        addon = addon_factory(guid='@webextension-guid', users=[self.user])
-        addon.delete()
-        data = self.parse(filename='webextension.xpi')
-        assert data['guid'] == '@webextension-guid'
-
     def test_guid_dupe_deleted_addon_not_allowed_if_same_author_and_switch_is_off(self):
         addon = addon_factory(guid='@webextension-guid', users=[self.user])
         addon.delete()

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -23,8 +23,6 @@ from django.utils.encoding import force_str
 from django.utils.jslex import JsLexer
 from django.utils.translation import gettext
 
-import waffle
-
 import olympia.core.logger
 
 from olympia import amo


### PR DESCRIPTION
That functionality used to available, then was put behind a waffle switch defaulting to off in 39a8ee56 in case we needed to go back, but that never happened, so we can remove it now.

Fixes #19501