### PR TITLE
Run watchmedo through supervisor in local envs instead of through uwsgi

### DIFF
--- a/docker/supervisor-celery.conf
+++ b/docker/supervisor-celery.conf
@@ -3,10 +3,9 @@ logfile=/code/logs/supervisord-celery.log
 
 [program:olympia-worker]
 # Local env setup for celery. This is similar to prod, but with only two workers
-# and auto-restart through watchmedo (which may not work in 100% of the cases)
 # Prod config for reference:
 # https://github.com/mozilla-services/cloudops-deployment/blob/master/projects/amo/puppet/modules/olympia/manifests/celery.pp
-command=watchmedo auto-restart -d src/ -p '*.py' -- celery -A olympia.amo.celery:app worker -E -c 2 --loglevel=INFO
+command=watchmedo auto-restart --directory /code/src --pattern '*.py' --recursive -- celery -A olympia.amo.celery:app worker -E -c 2 --loglevel=INFO
 directory=/code
 stopasgroup=true
 autostart=true

--- a/docker/supervisor.conf
+++ b/docker/supervisor.conf
@@ -27,7 +27,7 @@ priority=600
 autostart=true
 autorestart=false
 directory=/tmp
-command=watchmedo shell-command --patterns="*.py" --recursive --command='/usr/bin/touch docker/artifacts/uwsgi-reload-monitor'
+command=watchmedo shell-command --patterns="*.py" --recursive --command='/usr/bin/touch /code/docker/artifacts/uwsgi-reload-monitor'
 priority=991
 
 # The following sections enable supervisorctl.

--- a/docker/supervisor.conf
+++ b/docker/supervisor.conf
@@ -27,7 +27,7 @@ priority=600
 autostart=true
 autorestart=false
 directory=/tmp
-command=watchmedo shell-command --patterns="*.py" --recursive --command='/usr/bin/touch /code/docker/artifacts/uwsgi-reload-monitor'
+command=watchmedo shell-command --pattern '*.py' --recursive --command='/usr/bin/touch /code/docker/artifacts/uwsgi-reload-monitor' /code/src
 priority=991
 
 # The following sections enable supervisorctl.

--- a/docker/supervisor.conf
+++ b/docker/supervisor.conf
@@ -10,6 +10,7 @@ redirect_stderr=true
 stdout_logfile=logs/docker.log
 stdout_logfile_maxbytes=1MB
 stopsignal=KILL
+priority=500
 
 [program:versioncheck]
 command=uwsgi --ini /code/docker/uwsgi.versioncheck.ini
@@ -20,6 +21,14 @@ redirect_stderr=true
 stdout_logfile=logs/docker-versioncheck.log
 stdout_logfile_maxbytes=1MB
 stopsignal=KILL
+priority=600
+
+[program:watcher]
+autostart=true
+autorestart=false
+directory=/tmp
+command=watchmedo shell-command --patterns="*.py" --recursive --command='/usr/bin/touch docker/artifacts/uwsgi-reload-monitor'
+priority=991
 
 # The following sections enable supervisorctl.
 

--- a/docker/uwsgi.ini
+++ b/docker/uwsgi.ini
@@ -15,28 +15,9 @@ gid             = olympia
 memory-report   = true
 enable-threads  = true
 
-# Run watchmedo (via watchdog) to implement unrestricted
-# autoreload capability.
-fs-reload = %(base)/docker/artifacts/
-
-# `CIRCLECI` is empty by default and only set to `true` by CircleCI.
-# See addons-server issue #12064
-# First copy the environment value
-if-env = CIRCLECI
-running-circleci = %(_)
-endif =
-
-# But default to it being set to `none`
-if-not-env = CIRCLECI
-running-circleci = none
-endif =
-
-# If the value is actually set to `true` (which it is in CircleCI)
-# then don't run the autoreload
-if-not-opt = running-circleci=true
-safe-pidfile = %(base)/docker/artifacts/addons-server-uwsgi-master.pid
-attach-daemon = setsid watchmedo shell-command --patterns="*.py" --recursive --command='/usr/bin/touch %(safe-pidfile)' %(base)
-endif =
+# supervisor runs watchmedo (via watchdog) which is configured to touch this
+# file when changes are detected. we set uwsgi to reload when that happens.
+fs-reload = %(base)/docker/artifacts/uwsgi-reload-monitor
 
 max-requests = 5000
 

--- a/docker/uwsgi.ini
+++ b/docker/uwsgi.ini
@@ -15,6 +15,8 @@ gid             = olympia
 memory-report   = true
 enable-threads  = true
 
+safe-pidfile = %(base)/docker/artifacts/addons-server-uwsgi-master.pid
+
 # supervisor runs watchmedo (via watchdog) which is configured to touch this
 # file when changes are detected. we set uwsgi to reload when that happens.
 fs-reload = %(base)/docker/artifacts/uwsgi-reload-monitor


### PR DESCRIPTION
This should prevent a storm of watchmedo processes when there are changes, as this should keep the same long-lived watchmedo process instead of spawning new ones.

Also, watch a specific file instead of the whole directory to avoid reloads when just opening a shell (since bash_history is written to the artifacts dir)

Fixes #19512