### PR TITLE
rm user_media_url and user_media_path jinja helpers

### DIFF
--- a/src/olympia/accounts/serializers.py
+++ b/src/olympia/accounts/serializers.py
@@ -176,7 +176,7 @@ class UserProfileSerializer(PublicUserProfileSerializer):
         if photo:
             original = instance.picture_path_original
 
-            storage = SafeStorage(user_media='userpics')
+            storage = SafeStorage(root_setting='MEDIA_ROOT', rel_location='userpics')
             with storage.open(original, 'wb') as original_file:
                 for chunk in photo.chunks():
                     original_file.write(chunk)

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1141,7 +1141,7 @@ class Addon(OnChangeMixin, ModelBase):
 
     def get_icon_dir(self):
         return os.path.join(
-            jinja_helpers.user_media_path('addon_icons'), '%s' % (self.id // 1000)
+            settings.MEDIA_ROOT, 'addon_icons', '%s' % (self.id // 1000)
         )
 
     def get_icon_url(self, size):

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1174,7 +1174,7 @@ class Addon(OnChangeMixin, ModelBase):
                     f'{self.id}-{size}.png?modified={suffix}',
                 ]
             )
-            return jinja_helpers.user_media_url('addon_icons') + path
+            return f'{settings.MEDIA_URL}addon_icons/{path}'
 
     def get_default_icon_url(self, size):
         return staticfiles_storage.url(f'img/addon-icons/default-{size}.png')

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -212,7 +212,7 @@ class PreviewSerializer(serializers.ModelSerializer):
         image = validated_data.pop('image')
         instance = super().create(validated_data)
 
-        storage = SafeStorage(user_media='previews')
+        storage = SafeStorage(root_setting='MEDIA_ROOT', rel_location='previews')
         with storage.open(instance.original_path, 'wb') as original_file:
             for chunk in image.chunks():
                 original_file.write(chunk)
@@ -1103,7 +1103,7 @@ class AddonSerializer(serializers.ModelSerializer):
         if uploaded_icon:
             original = f'{destination}-original.png'
 
-            storage = SafeStorage(user_media='addon_icons')
+            storage = SafeStorage(root_setting='MEDIA_ROOT', rel_location='addon_icons')
             with storage.open(original, 'wb') as original_file:
                 for chunk in uploaded_icon.chunks():
                     original_file.write(chunk)

--- a/src/olympia/addons/tests/test_tasks.py
+++ b/src/olympia/addons/tests/test_tasks.py
@@ -12,7 +12,6 @@ from waffle.testutils import override_switch
 from olympia import amo
 from olympia.activity.models import ActivityLog
 from olympia.addons.indexers import AddonIndexer
-from olympia.amo.templatetags.jinja_helpers import user_media_path
 from olympia.amo.tests import addon_factory, TestCase
 from olympia.amo.tests.test_helpers import get_image_path
 from olympia.amo.utils import image_size
@@ -284,7 +283,7 @@ class TestResizeIcon(TestCase):
         if not isinstance(final_size, list):
             final_size = [final_size]
             resize_size = [resize_size]
-        uploadto = user_media_path('addon_icons')
+        uploadto = os.path.join(settings.MEDIA_ROOT, 'addon_icons')
         try:
             os.makedirs(uploadto)
         except OSError:

--- a/src/olympia/amo/models.py
+++ b/src/olympia/amo/models.py
@@ -467,8 +467,6 @@ class BasePreview:
     media_folder = 'previews'
 
     def _image_url(self, folder, file_ext):
-        from olympia.amo.templatetags.jinja_helpers import user_media_url
-
         modified = int(time.mktime(self.modified.timetuple())) if self.modified else 0
 
         url = '/'.join(
@@ -478,7 +476,7 @@ class BasePreview:
                 f'{self.id}.{file_ext}?modified={modified}',
             )
         )
-        return user_media_url(self.media_folder) + url
+        return f'{settings.MEDIA_URL}{self.media_folder}/{url}'
 
     def _image_path(self, folder, file_ext):
         from olympia.amo.templatetags.jinja_helpers import user_media_path

--- a/src/olympia/amo/models.py
+++ b/src/olympia/amo/models.py
@@ -479,10 +479,9 @@ class BasePreview:
         return f'{settings.MEDIA_URL}{self.media_folder}/{url}'
 
     def _image_path(self, folder, file_ext):
-        from olympia.amo.templatetags.jinja_helpers import user_media_path
-
         url = os.path.join(
-            user_media_path(self.media_folder),
+            settings.MEDIA_ROOT,
+            self.media_folder,
             folder,
             str(self.id // 1000),
             f'{self.id}.{file_ext}',

--- a/src/olympia/amo/monitors.py
+++ b/src/olympia/amo/monitors.py
@@ -14,7 +14,6 @@ import olympia.core.logger
 
 from olympia.search.utils import get_es
 from olympia.amo.models import use_primary_db
-from olympia.amo.templatetags.jinja_helpers import user_media_path
 
 
 monitor_log = olympia.core.logger.getLogger('z.monitor')
@@ -98,10 +97,10 @@ def path():
     read_and_write = (
         settings.TMP_PATH,
         settings.MEDIA_ROOT,
-        user_media_path('addons'),
-        user_media_path('addon_icons'),
-        user_media_path('previews'),
-        user_media_path('userpics'),
+        settings.ADDONS_PATH,
+        os.path.join(settings.MEDIA_ROOT, 'addon_icons'),
+        os.path.join(settings.MEDIA_ROOT, 'previews'),
+        os.path.join(settings.MEDIA_ROOT, 'userpics'),
     )
     read_only = [os.path.join(settings.ROOT, 'locale')]
     filepaths = [

--- a/src/olympia/amo/templatetags/jinja_helpers.py
+++ b/src/olympia/amo/templatetags/jinja_helpers.py
@@ -207,17 +207,6 @@ def user_media_path(what):
     return getattr(settings, key, default)
 
 
-# A (temporary?) copy of this is in services/utils.py. See bug 1055654.
-def user_media_url(what):
-    """
-    Generate default media url, and make possible to override it from
-    settings.
-    """
-    default = f'{settings.MEDIA_URL}{what}/'
-    key = '{}_URL'.format(what.upper().replace('-', '_'))
-    return getattr(settings, key, default)
-
-
 @library.filter
 def format_html(string, *args, **kwargs):
     """Uses ``str.format`` for string interpolation.

--- a/src/olympia/amo/templatetags/jinja_helpers.py
+++ b/src/olympia/amo/templatetags/jinja_helpers.py
@@ -1,5 +1,4 @@
 import json as jsonlib
-import os
 
 from urllib.parse import urljoin
 
@@ -191,20 +190,6 @@ def is_choice_field(value):
         return isinstance(value.field.widget, CheckboxInput)
     except AttributeError:
         pass
-
-
-# A (temporary?) copy of this is in services/utils.py. See bug 1055654.
-def user_media_path(what):
-    """Make it possible to override storage paths in settings.
-
-    By default, all storage paths are in the MEDIA_ROOT.
-
-    This is backwards compatible.
-
-    """
-    default = os.path.join(settings.MEDIA_ROOT, what)
-    key = f'{what.upper()}_PATH'
-    return getattr(settings, key, default)
 
 
 @library.filter

--- a/src/olympia/amo/tests/test_helpers.py
+++ b/src/olympia/amo/tests/test_helpers.py
@@ -8,7 +8,6 @@ from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import NoReverseMatch
 from django.test.client import RequestFactory
-from django.test.utils import override_settings
 from django.utils.encoding import force_bytes
 
 import pytest
@@ -410,19 +409,6 @@ def test_format_unicode():
     # This makes sure there's no UnicodeEncodeError when doing the string
     # interpolation.
     assert render('{{ "foo {0}"|format_html("baré") }}') == 'foo baré'
-
-
-class TestStoragePath(TestCase):
-    @override_settings(ADDONS_PATH=None, MEDIA_ROOT='/path/')
-    def test_without_settings(self):
-        del settings.ADDONS_PATH
-        path = jinja_helpers.user_media_path('addons')
-        assert path == '/path/addons'
-
-    @override_settings(ADDONS_PATH='/another/path/')
-    def test_with_settings(self):
-        path = jinja_helpers.user_media_path('addons')
-        assert path == '/another/path/'
 
 
 SPACELESS_TEMPLATE = """

--- a/src/olympia/amo/tests/test_helpers.py
+++ b/src/olympia/amo/tests/test_helpers.py
@@ -425,15 +425,6 @@ class TestStoragePath(TestCase):
         assert path == '/another/path/'
 
 
-class TestMediaUrl(TestCase):
-    @override_settings(USERPICS_URL=None)
-    def test_without_settings(self):
-        del settings.USERPICS_URL
-        settings.MEDIA_URL = '/mediapath/'
-        url = jinja_helpers.user_media_url('userpics')
-        assert url == '/mediapath/userpics/'
-
-
 SPACELESS_TEMPLATE = """
 <div>    <div>outside</div>
 

--- a/src/olympia/amo/tests/test_storage_utils.py
+++ b/src/olympia/amo/tests/test_storage_utils.py
@@ -19,7 +19,7 @@ pytestmark = pytest.mark.django_db
 def test_storage_walk():
     tmp = force_str(tempfile.mkdtemp(dir=settings.TMP_PATH))
     jn = partial(os.path.join, tmp)
-    storage = SafeStorage(user_media='tmp')
+    storage = SafeStorage(root_setting='TMP_PATH')
     try:
         storage.save(jn('file1.txt'), ContentFile(''))
         storage.save(jn('one/file1.txt'), ContentFile(''))
@@ -57,7 +57,7 @@ def test_storage_walk():
 def test_rm_stored_dir():
     tmp = tempfile.mkdtemp(dir=settings.TMP_PATH)
     jn = partial(os.path.join, tmp)
-    storage = SafeStorage(user_media='tmp')
+    storage = SafeStorage(root_setting='TMP_PATH')
     try:
         storage.save(jn('file1.txt'), ContentFile('<stuff>'))
         storage.save(jn('one/file1.txt'), ContentFile(''))
@@ -80,7 +80,7 @@ class TestFileOps(TestCase):
     def setUp(self):
         super().setUp()
         self.tmp = tempfile.mkdtemp(dir=settings.TMP_PATH)
-        self.storage = SafeStorage(user_media='tmp')
+        self.storage = SafeStorage(root_setting='TMP_PATH')
 
     def tearDown(self):
         rm_local_tmp_dir(self.tmp)

--- a/src/olympia/blocklist/mlbf.py
+++ b/src/olympia/blocklist/mlbf.py
@@ -99,7 +99,7 @@ class MLBF:
     def __init__(self, id_):
         # simplify later code by assuming always a string
         self.id = str(id_)
-        self.storage = SafeStorage(user_media='mlbf_storage')
+        self.storage = SafeStorage(root_setting='MLBF_STORAGE_PATH')
 
     @classmethod
     def hash_filter_inputs(cls, input_list):

--- a/src/olympia/blocklist/tasks.py
+++ b/src/olympia/blocklist/tasks.py
@@ -81,7 +81,7 @@ def upload_filter(generation_time, is_base=True):
             'generation_time': generation_time,
             'attachment_type': BLOCKLIST_RECORD_MLBF_BASE,
         }
-        storage = SafeStorage(user_media='mlbf_storage')
+        storage = SafeStorage(root_setting='MLBF_STORAGE_PATH')
         with storage.open(mlbf.filter_path, 'rb') as filter_file:
             attachment = ('filter.bin', filter_file, 'application/octet-stream')
             server.publish_attachment(data, attachment)
@@ -108,7 +108,7 @@ def cleanup_old_files(*, base_filter_id):
     log.info('Starting clean up of old MLBF folders...')
     six_months_ago = datetime_to_ts(datetime.now() - timedelta(weeks=26))
     base_filter_ts = int(base_filter_id)
-    storage = SafeStorage(user_media='mlbf_storage')
+    storage = SafeStorage(root_setting='MLBF_STORAGE_PATH')
     for dir in storage.listdir(settings.MLBF_STORAGE_PATH)[0]:
         dir = force_str(dir)
         # skip non-numeric folder names

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -1,6 +1,7 @@
 import json
 import os
 
+from django.conf import settings
 from django.core.files.storage import default_storage as storage
 from django.urls import reverse
 from django.utils.encoding import force_str
@@ -11,7 +12,6 @@ from waffle.testutils import override_switch
 from olympia import amo
 from olympia.activity.models import ActivityLog
 from olympia.addons.models import Addon, AddonApprovalsCounter, AddonCategory
-from olympia.amo.templatetags.jinja_helpers import user_media_path
 from olympia.amo.tests import (
     addon_factory,
     formset,
@@ -860,7 +860,7 @@ class TestEditMedia(BaseTestEdit):
 
         # Check that it was actually uploaded
         dirname = os.path.join(
-            user_media_path('addon_icons'), '%s' % (addon.id // 1000)
+            settings.MEDIA_ROOT, 'addon_icons', '%s' % (addon.id // 1000)
         )
         dest = os.path.join(dirname, '%s-32.png' % addon.id)
 
@@ -908,7 +908,7 @@ class TestEditMedia(BaseTestEdit):
 
         # Check that it was actually uploaded
         dirname = os.path.join(
-            user_media_path('addon_icons'), '%s' % (addon.id // 1000)
+            settings.MEDIA_ROOT, 'addon_icons', '%s' % (addon.id // 1000)
         )
         dest = os.path.join(dirname, '%s-64.png' % addon.id)
 

--- a/src/olympia/files/models.py
+++ b/src/olympia/files/models.py
@@ -25,7 +25,6 @@ from olympia import amo, core
 from olympia.amo.decorators import use_primary_db
 from olympia.amo.fields import PositiveAutoField
 from olympia.amo.models import ManagerBase, ModelBase, OnChangeMixin
-from olympia.amo.templatetags.jinja_helpers import user_media_path
 from olympia.amo.utils import SafeStorage
 from olympia.files.fields import FilenameFileField
 from olympia.files.utils import (
@@ -84,7 +83,7 @@ def files_upload_to_callback(instance, filename):
 
 
 def files_storage():
-    return SafeStorage(user_media='addons')
+    return SafeStorage(root_setting='ADDONS_PATH')
 
 
 class File(OnChangeMixin, ModelBase):
@@ -444,9 +443,7 @@ class FileUpload(ModelBase):
 
     @classmethod
     def generate_path(cls, ext='.zip'):
-        return os.path.join(
-            user_media_path('addons'), 'temp', f'{uuid.uuid4().hex}{ext}'
-        )
+        return os.path.join(settings.ADDONS_PATH, 'temp', f'{uuid.uuid4().hex}{ext}')
 
     def add_file(self, chunks, filename, size):
         if not self.uuid:

--- a/src/olympia/hero/models.py
+++ b/src/olympia/hero/models.py
@@ -106,7 +106,7 @@ def hero_image_directory(instance, filename):
 
 
 def hero_image_storage():
-    return SafeStorage(user_media='')
+    return SafeStorage(root_setting='MEDIA_ROOT')
 
 
 class PrimaryHeroImage(ModelBase):

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -337,11 +337,10 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
 
     @property
     def picture_dir(self):
-        from olympia.amo.templatetags.jinja_helpers import user_media_path
-
         split_id = re.match(r'((\d*?)(\d{0,3}?))\d{1,3}$', str(self.id))
         return os.path.join(
-            user_media_path('userpics'),
+            settings.MEDIA_ROOT,
+            'userpics',
             split_id.group(2) or '0',
             split_id.group(1) or '0',
         )
@@ -456,7 +455,7 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
         # Recursive import
         from olympia.users.tasks import delete_photo
 
-        storage = SafeStorage(user_media='userpics')
+        storage = SafeStorage(root_setting='MEDIA_ROOT', rel_location='userpics')
 
         if storage.exists(self.picture_path):
             delete_photo.delay(self.picture_path)

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -356,8 +356,6 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
 
     @property
     def picture_url(self):
-        from olympia.amo.templatetags.jinja_helpers import user_media_url
-
         if not self.picture_type:
             return static('img/zamboni/anon_user.png')
         else:
@@ -370,7 +368,7 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
                     f'{self.id}.png?modified={modified}',
                 ]
             )
-            return user_media_url('userpics') + path
+            return f'{settings.MEDIA_URL}userpics/{path}'
 
     @cached_property
     def cached_developer_status(self):

--- a/src/olympia/users/tasks.py
+++ b/src/olympia/users/tasks.py
@@ -2,7 +2,6 @@ import olympia.core.logger
 
 from olympia.amo.celery import task
 from olympia.amo.decorators import set_modified_on
-from olympia.amo.templatetags.jinja_helpers import user_media_path
 from olympia.amo.utils import resize_image, SafeStorage
 
 from .models import UserProfile
@@ -15,12 +14,8 @@ task_log = olympia.core.logger.getLogger('z.task')
 def delete_photo(dst, **kw):
     task_log.info('[1@None] Deleting photo: %s.' % dst)
 
-    if not dst.startswith(user_media_path('userpics')):
-        task_log.error("Someone tried deleting something they shouldn't: %s" % dst)
-        return
-
     try:
-        SafeStorage(user_media='userpics').delete(dst)
+        SafeStorage(root_setting='MEDIA_ROOT', rel_location='userpics').delete(dst)
     except Exception as e:
         task_log.error('Error deleting userpic: %s' % e)
 

--- a/src/olympia/users/tests/test_models.py
+++ b/src/olympia/users/tests/test_models.py
@@ -43,7 +43,7 @@ class TestUserProfile(TestCase):
     fixtures = ('base/addon_3615', 'base/user_2519', 'users/test_backends')
 
     def setUp(self):
-        self.storage = SafeStorage(user_media='userpics')
+        self.storage = SafeStorage(root_setting='MEDIA_ROOT', rel_location='userpics')
 
     def test_is_addon_developer(self):
         user = user_factory()

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -195,7 +195,7 @@ def source_upload_path(instance, filename):
 
 
 def source_upload_storage():
-    return SafeStorage(user_media='')
+    return SafeStorage(root_setting='MEDIA_ROOT')
 
 
 class VersionCreateError(ValueError):

--- a/src/olympia/versions/tasks.py
+++ b/src/olympia/versions/tasks.py
@@ -130,7 +130,9 @@ def render_to_svg(template, context, preview, thumbnail_dimensions, theme_manife
     finished_svg = template.render(with_ui_context).encode('utf-8')
 
     # and write that svg to preview.image_path
-    storage = SafeStorage(user_media=VersionPreview.media_folder)
+    storage = SafeStorage(
+        root_setting='MEDIA_ROOT', rel_location=VersionPreview.media_folder
+    )
     with storage.open(preview.image_path, 'wb') as image_path:
         image_path.write(finished_svg)
 


### PR DESCRIPTION
fixes #18999 - also needed a reworking of `SafeStorage` because it used `user_media_path` (which affected a lot more things than the jinja helpers directly)