### PR TITLE
Ensure custom_license l10n has values in en-US

### DIFF
--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -81,6 +81,7 @@ from .validators import (
     MatchingGuidValidator,
     ReviewedSourceFileValidator,
     VersionAddonMetadataValidator,
+    NoFallbackDefaultLocaleValidator,
     VersionLicenseValidator,
     VerifyMozillaTrademark,
 )
@@ -259,6 +260,7 @@ class LicenseSerializer(serializers.ModelSerializer):
         fields = ('id', 'is_custom', 'name', 'slug', 'text', 'url')
         writeable_fields = ('name', 'text')
         read_only_fields = tuple(set(fields) - set(writeable_fields))
+        validators = (NoFallbackDefaultLocaleValidator(),)
 
     def get_is_custom(self, obj):
         return not bool(obj.builtin)

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -1404,12 +1404,7 @@ class TestAddonViewSetCreate(UploadMixin, AddonViewSetCreateUpdateMixin, TestCas
         # the default_locale isn't overriden from the xpi - it's en-US
         response = self.request(
             data={
-                'version': {
-                    'upload': upload.uuid,
-                    # This should also fail (but doesn't currently):
-                    # https://github.com/mozilla/addons-server/issues/19313
-                    'custom_license': {'name': {'it': 'test'}, 'text': {'it': 'test'}},
-                },
+                'version': {'upload': upload.uuid, 'license': self.license.slug},
                 'categories': {'firefox': ['other']},
                 'support_email': {  # this field has the required locales
                     'it': 'rusiczki.ioana@gmail.com',
@@ -1436,10 +1431,7 @@ class TestAddonViewSetCreate(UploadMixin, AddonViewSetCreateUpdateMixin, TestCas
         #  - added a summary value in en-US in addition to it
         response = self.request(
             data={
-                'version': {
-                    'upload': upload.uuid,
-                    'custom_license': {'name': {'it': 'test'}, 'text': {'it': 'test'}},
-                },
+                'version': {'upload': upload.uuid, 'license': self.license.slug},
                 'categories': {'firefox': ['other']},
                 'support_email': {
                     'it': 'rusiczki.ioana@gmail.com',
@@ -2799,6 +2791,19 @@ class VersionViewSetCreateUpdateMixin(RequestMixin):
             'custom_license': {
                 'name': ['This field is required.'],
                 'text': ['This field is required.'],
+            }
+        }
+
+    def test_custom_license_needs_default_locale_value(self):
+        response = self.request(
+            custom_license={'name': {'it': 'test'}, 'text': {'it': 'test'}}
+        )
+        assert response.status_code == 400, response.content
+        error_string = 'A value in the default locale of "en-US" is required.'
+        assert response.data == {
+            'custom_license': {
+                'name': [error_string],
+                'text': [error_string],
             }
         }
 

--- a/src/olympia/api/fields.py
+++ b/src/olympia/api/fields.py
@@ -206,6 +206,10 @@ class TranslationSerializerField(fields.CharField):
 
         return super().run_validation(data)
 
+    def get_es_instance(self):
+        """Returns the equivalent ElasticSearch compatible Serializer instance."""
+        return ESTranslationSerializerField(source=self.source)
+
 
 class ESTranslationSerializerField(TranslationSerializerField):
     """
@@ -280,6 +284,12 @@ class ESTranslationSerializerField(TranslationSerializerField):
         return self._format_single_translation_response(
             value, locale, requested_language
         )
+
+    def get_es_instance(self):
+        """We're already the ES field, but if we don't specify this,
+        TranslationSerializerField.get_es_instance will be used and return the wrong
+        class for subclasses."""
+        return self
 
 
 class SplitField(fields.Field):
@@ -432,7 +442,8 @@ class OutgoingURLField(OutgoingSerializerMixin, serializers.URLField):
 
 
 class OutgoingURLTranslationField(OutgoingSerializerMixin, URLTranslationField):
-    pass
+    def get_es_instance(self):
+        return OutgoingURLESTranslationField(source=self.source)
 
 
 class OutgoingURLESTranslationField(

--- a/src/olympia/api/serializers.py
+++ b/src/olympia/api/serializers.py
@@ -8,13 +8,6 @@ from rest_framework import serializers
 
 from olympia.zadmin.models import get_config
 
-from .fields import (
-    ESTranslationSerializerField,
-    OutgoingURLESTranslationField,
-    OutgoingURLTranslationField,
-    TranslationSerializerField,
-)
-
 
 class BaseESSerializer(serializers.ModelSerializer):
     """
@@ -32,15 +25,13 @@ class BaseESSerializer(serializers.ModelSerializer):
 
     def get_fields(self):
         """
-        Return all fields as normal, with one exception: replace every instance
-        of TranslationSerializerField with ESTranslationSerializerField.
+        Return all fields as normal, except if the class defines a `get_es_instance`
+        function - if it does then replace with the instance returned.
         """
         fields = super().get_fields()
         for key, field in fields.items():
-            if isinstance(field, OutgoingURLTranslationField):
-                fields[key] = OutgoingURLESTranslationField(source=field.source)
-            elif isinstance(field, TranslationSerializerField):
-                fields[key] = ESTranslationSerializerField(source=field.source)
+            if hasattr(field, 'get_es_instance'):
+                fields[key] = field.get_es_instance()
             # Set all fields as read_only just in case.
             fields[key].read_only = True
         return fields


### PR DESCRIPTION
fixes #19313

Also includes some refactoring of `LicenseNameSerializerField` and associated classes in an attempt to make `NoFallbackDefaultLocaleValidator` reusable for other models/serializers.

Potentially it would be possible to combine it and AddonDefaultLocaleValidator and make it work generally for all serializers, but default locale fallback fields and loading defaults from the xpi complicate it so I didn't bother.