### PR TITLE
set USE_L10N=True and use locale specific number/date/time formatting

### DIFF
--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -190,6 +190,9 @@ LOCALE_PATHS = (path('locale'),)
 # to load the internationalization machinery.
 USE_I18N = True
 
+# This enables localized formatting of numbers and dates/times. Deprecated in Django4.1
+USE_L10N = True
+
 # The host currently running the site.  Only use this in code for good reason;
 # the site is designed to run on a cluster and should continue to support that
 HOSTNAME = socket.gethostname()
@@ -393,11 +396,6 @@ TEMPLATES = [
         },
     },
 ]
-
-# Default datetime format in templates
-# https://docs.djangoproject.com/en/3.2/ref/templates/builtins/#std:templatefilter-date
-DATETIME_FORMAT = 'N j, Y, H:i'
-
 
 X_FRAME_OPTIONS = 'DENY'
 SECURE_CONTENT_TYPE_NOSNIFF = True

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -15,6 +15,7 @@ from django.db import connection, reset_queries
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from django.urls import reverse
+from django.utils.formats import localize
 
 from rest_framework.test import APIRequestFactory
 
@@ -147,7 +148,9 @@ class TestRatingsModerationLog(ReviewerTest):
 
         response = self.client.get(self.url, {'end': '2011-01-01'})
         assert response.status_code == 200
-        assert pq(response.content)('tbody td').eq(0).text() == ('Jan. 1, 2011, 00:00')
+        assert pq(response.content)('tbody td').eq(0).text() == localize(
+            datetime(2011, 1, 1)
+        )
 
     def test_action_filter(self):
         """

--- a/src/olympia/scanners/tests/test_admin.py
+++ b/src/olympia/scanners/tests/test_admin.py
@@ -8,6 +8,7 @@ from django.contrib.admin.sites import AdminSite
 from django.test import RequestFactory
 from django.test.utils import override_settings
 from django.urls import reverse
+from django.utils.formats import localize
 from django.utils.html import format_html
 from django.utils.http import urlencode
 
@@ -1220,18 +1221,16 @@ class TestScannerQueryRuleAdmin(TestCase):
         assert button.attrib['formaction'] == url
 
     def test_no_button_for_completed_rule_query(self):
+        completed = datetime(2020, 9, 29, 14, 1, 2)
         rule = ScannerQueryRule.objects.create(
-            name='bar',
-            scanner=YARA,
-            state=COMPLETED,
-            completed=datetime(2020, 9, 29, 14, 1, 2),
+            name='bar', scanner=YARA, state=COMPLETED, completed=completed
         )
         response = self.client.get(self.list_url)
         assert response.status_code == 200
         doc = pq(response.content)
         field = doc('.field-state_with_actions')
         assert field
-        assert field.text() == 'Completed (Sept. 29, 2020, 14:01)'
+        assert field.text() == f'Completed ({localize(completed)})'
         assert not field.find('button')
 
         rule.update(completed=None)  # If somehow None (unknown finished time)

--- a/src/olympia/users/tests/test_admin.py
+++ b/src/olympia/users/tests/test_admin.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.contrib import admin
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.messages.storage import default_storage as default_messages_storage
@@ -6,7 +5,7 @@ from django.db import connection
 from django.test import RequestFactory
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
-from django.utils.dateformat import DateFormat
+from django.utils.formats import localize
 
 from unittest import mock
 
@@ -770,7 +769,7 @@ class TestUserAdmin(TestCase):
         core.set_user(someone_else)
         activity = ActivityLog.create(amo.LOG.EDIT_PROPERTIES, addon)
 
-        expected_result = DateFormat(expected_date).format(settings.DATETIME_FORMAT)
+        expected_result = localize(expected_date)
 
         assert str(model_admin.last_known_activity_time(self.user)) == expected_result
 


### PR DESCRIPTION
fixes #19609 by enabling `USE_L10N` - it defaults to `False` in django3.2; then `True` in django4.0; then will be removed (so effectively permanently `True`) in django5.0.  Because `DATETIME_FORMAT` is ignored when `USE_L10N` is enabled I dropped our setting value too.