### PR TITLE
Support ranges and networks in IP admin search

### DIFF
--- a/Makefile-docker
+++ b/Makefile-docker
@@ -36,6 +36,7 @@ jquery.cookie/jquery.cookie.js \
 jszip/dist/jszip.js \
 timeago/jquery.timeago.js \
 underscore/underscore.js \
+netmask/lib/netmask.js \
 
 NODE_LIBS_JQUERY_UI := \
 jquery-ui/ui/data.js \

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "jquery.cookie": "1.4.1",
         "jszip": "3.10.1",
         "less": "4.1.3",
+        "netmask": "^2.0.2",
         "source-map": "0.7.4",
         "timeago": "1.6.7",
         "underscore": "1.13.4"
@@ -4707,6 +4708,14 @@
       "optional": true,
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/node-int64": {
@@ -9989,6 +9998,11 @@
           }
         }
       }
+    },
+    "netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -18,14 +18,15 @@
     "jquery.cookie": "1.4.1",
     "jszip": "3.10.1",
     "less": "4.1.3",
+    "netmask": "^2.0.2",
     "source-map": "0.7.4",
     "timeago": "1.6.7",
     "underscore": "1.13.4"
   },
   "devDependencies": {
     "jest": "^29.0.0",
-    "jest-environment-jsdom": "^29.0.0",
     "jest-date-mock": "^1.0.8",
+    "jest-environment-jsdom": "^29.0.0",
     "lodash": "^4.17.21",
     "prettier": "^2.0.5",
     "terser": "^5.14.2"

--- a/src/olympia/users/admin.py
+++ b/src/olympia/users/admin.py
@@ -230,7 +230,8 @@ class UserAdmin(CommaSearchInAdminMixin, admin.ModelAdmin):
                 for network in ips_and_networks['networks']:
                     condition |= Q(
                         activitylog__iplog__ip_address_binary__range=(
-                            network[0], network[-1],
+                            network[0],
+                            network[-1],
                         )
                     )
             # We want to duplicate the joins against activitylog + iplog so

--- a/src/olympia/users/admin.py
+++ b/src/olympia/users/admin.py
@@ -159,7 +159,7 @@ class UserAdmin(CommaSearchInAdminMixin, admin.ModelAdmin):
     actions = ['ban_action', 'reset_api_key_action', 'reset_session_action']
 
     class Media:
-        js = ('js/admin/userprofile.js',)
+        js = ('js/admin/userprofile.js', 'js/exports.js', 'js/node_lib/netmask.js')
         css = {'all': ('css/admin/userprofile.css',)}
 
     def get_list_display(self, request):
@@ -171,37 +171,68 @@ class UserAdmin(CommaSearchInAdminMixin, admin.ModelAdmin):
         search_term = (
             search_form.cleaned_data.get(SEARCH_VAR) if search_form.is_valid() else None
         )
-        if search_term and self.ip_addresses_if_query_is_all_ip_addresses(search_term):
+        if search_term and self.ip_addresses_and_networks_from_query(search_term):
             return (*self.list_display, *self.extra_list_display_for_ip_searches)
         return self.list_display
 
-    def ip_addresses_if_query_is_all_ip_addresses(self, search_term):
+    def ip_addresses_and_networks_from_query(self, search_term):
         # Caller should already have cleaned up search_term at this point,
         # removing whitespace etc if there is a comma separating multiple
         # terms.
         search_terms = search_term.split(',')
         ips = []
+        networks = []
         for term in search_terms:
+            # If term is a number, skip trying to recognize an IP address
+            # entirely, because ip_address() is able to understand IP addresses
+            # as integers, and we don't want that, it's likely an user ID.
+            if term.isdigit():
+                return None
+            # Is the search term an IP ?
             try:
-                ip = ipaddress.ip_address(term)
-                ip_str = str(ip)
-                if ip_str != term:
-                    raise ValueError
-                ips.append(ip_str)
+                ips.append(ipaddress.ip_address(term))
+                continue
             except ValueError:
-                break
-        if search_terms == ips:
-            # If all we are searching for are IPs, we'll use our custom IP
-            # search.
-            # Note that this comparison relies on ips being stored as strings,
-            # if that were to change that it would break.
-            return ips
-        return None
+                pass
+            # Is the search term a network ?
+            try:
+                networks.append(ipaddress.ip_network(term))
+                continue
+            except ValueError:
+                pass
+            # Is the search term an IP range ?
+            if term.count('-') == 1:
+                try:
+                    networks.extend(
+                        ipaddress.summarize_address_range(
+                            *(ipaddress.ip_address(i.strip()) for i in term.split('-'))
+                        )
+                    )
+                    continue
+                except (ValueError, TypeError):
+                    pass
+            # That search term doesn't look like an IP, network or range, so
+            # we're not doing an IP search.
+            return None
+        return {'ips': ips, 'networks': networks}
 
     def get_search_results(self, request, queryset, search_term):
-        ips = self.ip_addresses_if_query_is_all_ip_addresses(search_term)
-        if ips:
-            condition = Q(activitylog__iplog__ip_address_binary__in=ips)
+        ips_and_networks = self.ip_addresses_and_networks_from_query(search_term)
+        if ips_and_networks:
+            condition = Q()
+            if ips_and_networks['ips']:
+                # IPs search can be implemented in a single __in=() query.
+                condition |= Q(
+                    activitylog__iplog__ip_address_binary__in=ips_and_networks['ips']
+                )
+            if ips_and_networks['networks']:
+                # Networks search need one __range conditions for each network.
+                for network in ips_and_networks['networks']:
+                    condition |= Q(
+                        activitylog__iplog__ip_address_binary__range=(
+                            network[0], network[-1],
+                        )
+                    )
             # We want to duplicate the joins against activitylog + iplog so
             # that one is used for the search, and the other for the group
             # concat showing all IPs for activities of that user. Django

--- a/static/css/admin/userprofile.css
+++ b/static/css/admin/userprofile.css
@@ -28,6 +28,18 @@
     font-weight: bold;
 }
 
+#changelist-search > div {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+}
+
+#toolbar #searchbar {
+    font-size: 18px;
+    height: auto;
+    width: 42em;
+}
+
 #toolbar #searchbar.dirty {
     border-color: orange;
 }

--- a/static/js/admin/userprofile.js
+++ b/static/js/admin/userprofile.js
@@ -54,13 +54,13 @@ document.addEventListener('DOMContentLoaded', () => {
       // in the corresponding block (Netmask(ip) returns a block with only that
       // IP in it).
       let found = false;
-      values.forEach(item => {
+      values.forEach((item) => {
         let block = new Netmask(item);
         if (block.contains(ip)) {
           found = true;
           return;
         }
-      })
+      });
 
       if (!found) {
         field.classList.add('notinsearch');

--- a/static/js/exports.js
+++ b/static/js/exports.js
@@ -1,0 +1,2 @@
+// Minimal hack to be able to use JavaScript modules client-side
+var exports = {};


### PR DESCRIPTION
Fixes #19663

This adds support for searching for `192.168.0.1-192.168.0.254` or `192.168.0.0/24`, and mixing it up with multiple networks/IPs separated by commas. The JavaScript on the frontend doesn't have nice UI to remove networks, but won't suggest the addition of a single IP when it's part of a network already in the search query.