### PR TITLE
limits all our logging to 10MB per log, with one backup

### DIFF
--- a/docker/supervisor-celery.conf
+++ b/docker/supervisor-celery.conf
@@ -1,5 +1,7 @@
 [supervisord]
 logfile=/code/logs/supervisord-celery.log
+logfile_maxbytes=1048576
+logfile_backups=1
 
 [program:olympia-worker]
 # Local env setup for celery. This is similar to prod, but with only two workers
@@ -11,7 +13,8 @@ stopasgroup=true
 autostart=true
 redirect_stderr=true
 stdout_logfile=logs/docker-celery.log
-stdout_logfile_maxbytes=1MB
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=1
 stopsignal=KILL
 environment=DJANGO_SETTINGS_MODULE='settings'
 

--- a/docker/supervisor.conf
+++ b/docker/supervisor.conf
@@ -1,5 +1,7 @@
 [supervisord]
-logfile=/code/logs/supervisord.log
+logfile=/code/logs/supervisord-olympia.log
+logfile_maxbytes=1048576
+logfile_backups=1
 
 [program:olympia]
 command=uwsgi --ini /code/docker/uwsgi.ini
@@ -7,8 +9,9 @@ directory=/code
 stopasgroup=true
 autostart=true
 redirect_stderr=true
-stdout_logfile=logs/docker.log
-stdout_logfile_maxbytes=1MB
+stdout_logfile=logs/docker-olympia.log
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=1
 stopsignal=KILL
 priority=500
 
@@ -19,7 +22,8 @@ stopasgroup=true
 autostart=true
 redirect_stderr=true
 stdout_logfile=logs/docker-versioncheck.log
-stdout_logfile_maxbytes=1MB
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=1
 stopsignal=KILL
 priority=600
 

--- a/docker/uwsgi.ini
+++ b/docker/uwsgi.ini
@@ -29,7 +29,13 @@ lazy-apps = true
 # Open log file after we dropped privileges so that the file is being owned
 # by olympia:olympia and has proper permissions to be readable outside
 # of docker
-logto2 = %(base)/logs/uwsgi-master.log
+logto2 = %(base)/logs/uwsgi-olympia.log
+
+# Limit log file size to 10MB
+log-maxsize = 1048576
+
+# And set the name for the previous log
+log-backupname = %(base)/logs/uwsgi-olympia.log.1
 
 # Set default settings as originally done by manage.py
 env = DJANGO_SETTINGS_MODULE=settings

--- a/docker/uwsgi.versioncheck.ini
+++ b/docker/uwsgi.versioncheck.ini
@@ -29,5 +29,11 @@ lazy-apps = true
 # of docker
 logto2 = %(base)/logs/uwsgi-versioncheck.log
 
+# Limit log file size to 10MB
+log-maxsize = 1048576
+
+# And set the name for the previous log
+log-backupname = %(base)/logs/uwsgi-versioncheck.log.1
+
 # Set default settings as originally done by manage.py
 env = DJANGO_SETTINGS_MODULE=settings


### PR DESCRIPTION
fixes #19599 and changes all the logs to be a consistent size (10MB) with a single backup (because that's all uwsgi seemed to support).  Also slightly adjusts the names for consistency. (you'll need to manually delete your existing 1/2 GB uwsgi-master.log file I'm afraid)