### PR TITLE
Allow client_id to be explicitly null in Abuse reports API

### DIFF
--- a/src/olympia/abuse/serializers.py
+++ b/src/olympia/abuse/serializers.py
@@ -126,7 +126,7 @@ class AddonAbuseReportSerializer(BaseAbuseReportSerializer):
         return data
 
     def validate_client_id(self, value):
-        if not amo.VALID_CLIENT_ID.match(value):
+        if value and not amo.VALID_CLIENT_ID.match(str(value)):
             raise serializers.ValidationError(_('Invalid value'))
         return value
 


### PR DESCRIPTION
Fixes #19715