### PR TITLE
ManifestStaticFilesStorage with sourceMappingURL

### DIFF
--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1263,7 +1263,7 @@ STATIC_ROOT = path('site-static')
 STATIC_URL = '/static/'
 
 STATICFILES_DIRS = (path('static'),)
-STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
+STATICFILES_STORAGE = 'olympia.lib.storage.ManifestStaticFilesStorageNotMaps'
 
 # Path related settings. In dev/stage/prod `NETAPP_STORAGE_ROOT` environment
 # variable will be set and point to our NFS/EFS storage

--- a/src/olympia/lib/storage.py
+++ b/src/olympia/lib/storage.py
@@ -6,11 +6,14 @@ class ManifestStaticFilesStorageNotMaps(ManifestStaticFilesStorage):
         (
             '*.css',
             (
+                # These regexs are copied from HashedFilesMixin in django4.1+
                 r"""(?P<matched>url\(['"]{0,1}\s*(?P<url>.*?)["']{0,1}\))""",
                 (
                     r"""(?P<matched>@import\s*["']\s*(?P<url>.*?)["'])""",
                     """@import url("%(url)s")""",
                 ),
+                # We are ommiting the sourceMappingURL regexs for .css and .js as they
+                # don't work how we copy over the souces in Makefile-docker.copy_node_js
             ),
         ),
     )

--- a/src/olympia/lib/storage.py
+++ b/src/olympia/lib/storage.py
@@ -1,0 +1,16 @@
+from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
+
+
+class ManifestStaticFilesStorageNotMaps(ManifestStaticFilesStorage):
+    patterns = (
+        (
+            '*.css',
+            (
+                r"""(?P<matched>url\(['"]{0,1}\s*(?P<url>.*?)["']{0,1}\))""",
+                (
+                    r"""(?P<matched>@import\s*["']\s*(?P<url>.*?)["'])""",
+                    """@import url("%(url)s")""",
+                ),
+            ),
+        ),
+    )


### PR DESCRIPTION
fixes #19607 by effectively changing the patterns back to django3.2's regexs and ignoring linked map files.

(I looked into copying the map files but they need to be in certain locations and it just didn't seem worth it)