### PR TITLE
Handle manifest not being a dict when parsing xpi before validation

### DIFF
--- a/src/olympia/files/tests/test_utils.py
+++ b/src/olympia/files/tests/test_utils.py
@@ -59,6 +59,12 @@ class AppVersionsMixin:
 
 
 class TestManifestJSONExtractor(AppVersionsMixin, TestCase):
+    def test_not_dict(self):
+        with self.assertRaises(utils.InvalidManifest) as exc:
+            utils.ManifestJSONExtractor('"foo@bar.com"').parse()
+        assert isinstance(exc.exception, forms.ValidationError)
+        assert exc.exception.message == 'Could not parse the manifest file.'
+
     def test_parse_xpi_no_manifest(self):
         fake_zip = utils.make_xpi({'dummy': 'dummy'})
 

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -206,6 +206,8 @@ class ManifestJSONExtractor:
 
         try:
             self.data = json.loads(json_string)
+            if not isinstance(self.data, dict):
+                raise TypeError()
         except Exception:
             raise InvalidManifest(gettext('Could not parse the manifest file.'))
 


### PR DESCRIPTION
Fixes #19734