### PR TITLE
Migrate user photos to new directory structure, removing orphans along the way

### DIFF
--- a/src/olympia/amo/sitemap.py
+++ b/src/olympia/amo/sitemap.py
@@ -16,10 +16,10 @@ from olympia import amo
 from olympia.addons.models import Addon, AddonCategory
 from olympia.amo.reverse import get_url_prefix, override_url_prefix
 from olympia.amo.templatetags.jinja_helpers import absolutify
+from olympia.amo.utils import id_to_path
 from olympia.constants.categories import CATEGORIES
 from olympia.constants.promoted import RECOMMENDED
 from olympia.bandwagon.models import Collection
-from olympia.files.utils import id_to_path
 from olympia.promoted.models import PromotedAddon
 from olympia.tags.models import AddonTag, Tag
 from olympia.users.models import UserProfile

--- a/src/olympia/amo/tests/test_utils.py
+++ b/src/olympia/amo/tests/test_utils.py
@@ -24,6 +24,7 @@ from olympia.amo.utils import (
     attach_trans_dict,
     extract_colors_from_image,
     get_locale_from_lang,
+    id_to_path,
     is_safe_url,
     pngcrush_image,
     utc_millesecs_from_epoch,
@@ -385,3 +386,32 @@ class TestIsSafeUrl(TestCase):
         request = RequestFactory().get('/')
         assert is_safe_url('https://mozilla.com', request)
         assert not is_safe_url('https://mozilla.com:7000', request)
+
+
+@pytest.mark.parametrize(
+    'value, expected',
+    [
+        (1, '1/01/1'),
+        (12, '2/12/12'),
+        (123, '3/23/123'),
+        (1234, '4/34/1234'),
+        (123456789, '9/89/123456789'),
+    ],
+)
+def test_id_to_path(value, expected):
+    assert id_to_path(value) == expected
+
+
+@pytest.mark.parametrize(
+    'value, expected',
+    [
+        (1, '01/0001/1'),
+        (12, '12/0012/12'),
+        (123, '23/0123/123'),
+        (1234, '34/1234/1234'),
+        (123456, '56/3456/123456'),
+        (123456789, '89/6789/123456789'),
+    ],
+)
+def test_id_to_path_breadth(value, expected):
+    assert id_to_path(value, breadth=2) == expected

--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -1215,3 +1215,34 @@ def is_safe_url(url, request, allowed_hosts=None):
     return url_has_allowed_host_and_scheme(
         url, allowed_hosts=allowed_hosts, require_https=require_https
     )
+
+
+def id_to_path(pk, breadth=1):
+    """
+    Generate a path from a pk, to distribute folders in the file system. There
+    are 2 sublevels made from the last digits of the pk.
+
+    The breadth argument (defaults to 1) controls the number of digits used at
+    each sublevel. Zero-padding is applied to always have a fixed number of
+    directories for each sublevel.
+
+    At breadth=1, there should be 10 * 10 * x directories, resulting in:
+    1 => 1/01/1
+    12 => 2/12/12
+    123456 => 6/56/123456
+
+
+    At breadth=2, there should be 100 * 100 * x directories, resulting in:
+    1 => 01/0001/1
+    12 => 12/0012/12
+    123 => 23/0123/0123
+    1234 => 34/1234/1234
+    123456 => 56/3456/123456
+    123456789 => 89/6789/123456789
+    """
+    pk = str(pk)
+    padded_pk = pk.zfill(2 * breadth)
+    path = [padded_pk[-breadth:], padded_pk[-breadth * 2 :]]
+    # We always append the unpadded pk as the final directory.
+    path.append(pk)
+    return os.path.join(*path)

--- a/src/olympia/files/models.py
+++ b/src/olympia/files/models.py
@@ -25,11 +25,10 @@ from olympia import amo, core
 from olympia.amo.decorators import use_primary_db
 from olympia.amo.fields import PositiveAutoField
 from olympia.amo.models import ManagerBase, ModelBase, OnChangeMixin
-from olympia.amo.utils import SafeStorage
+from olympia.amo.utils import id_to_path, SafeStorage
 from olympia.files.fields import FilenameFileField
 from olympia.files.utils import (
     get_sha256,
-    id_to_path,
     InvalidOrUnsupportedCrx,
     write_crx_as_xpi,
 )

--- a/src/olympia/files/tests/test_utils.py
+++ b/src/olympia/files/tests/test_utils.py
@@ -1191,35 +1191,6 @@ class TestGetBackgroundImages(TestCase):
         assert len(images['empty.png']) == 332
 
 
-@pytest.mark.parametrize(
-    'value, expected',
-    [
-        (1, '1/01/1'),
-        (12, '2/12/12'),
-        (123, '3/23/123'),
-        (1234, '4/34/1234'),
-        (123456789, '9/89/123456789'),
-    ],
-)
-def test_id_to_path(value, expected):
-    assert utils.id_to_path(value) == expected
-
-
-@pytest.mark.parametrize(
-    'value, expected',
-    [
-        (1, '01/0001/1'),
-        (12, '12/0012/12'),
-        (123, '23/0123/123'),
-        (1234, '34/1234/1234'),
-        (123456, '56/3456/123456'),
-        (123456789, '89/6789/123456789'),
-    ],
-)
-def test_id_to_path_depth(value, expected):
-    assert utils.id_to_path(value, breadth=2) == expected
-
-
 class TestSafeZip(TestCase):
     def test_raises_error_for_invalid_webextension_xpi(self):
         with pytest.raises(zipfile.BadZipFile):

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -72,37 +72,6 @@ def get_filepath(fileorpath):
     return fileorpath
 
 
-def id_to_path(pk, breadth=1):
-    """
-    Generate a path from a pk, to distribute folders in the file system. There
-    are 2 sublevels made from the last digits of the pk.
-
-    The breadth argument (defaults to 1) controls the number of digits used at
-    each sublevel. Zero-padding is applied to always have a fixed number of
-    directories for each sublevel.
-
-    At breadth=1, there should be 10 * 10 * x directories, resulting in:
-    1 => 1/01/1
-    12 => 2/12/12
-    123456 => 6/56/123456
-
-
-    At breadth=2, there should be 100 * 100 * x directories, resulting in:
-    1 => 01/0001/1
-    12 => 12/0012/12
-    123 => 23/0123/0123
-    1234 => 34/1234/1234
-    123456 => 56/3456/123456
-    123456789 => 89/6789/123456789
-    """
-    pk = str(pk)
-    padded_pk = pk.zfill(2 * breadth)
-    path = [padded_pk[-breadth:], padded_pk[-breadth * 2 :]]
-    # We always append the unpadded pk as the final directory.
-    path.append(pk)
-    return os.path.join(*path)
-
-
 def get_file(fileorpath):
     """Get a file-like object, whether given a FileUpload object or a path."""
     if hasattr(fileorpath, 'path'):  # FileUpload

--- a/src/olympia/git/utils.py
+++ b/src/olympia/git/utils.py
@@ -21,8 +21,9 @@ from django.utils.functional import cached_property
 import olympia.core.logger
 
 from olympia import amo
+from olympia.amo.utils import id_to_path
 from olympia.versions.models import Version
-from olympia.files.utils import id_to_path, extract_extension_to_dest, get_all_files
+from olympia.files.utils import extract_extension_to_dest, get_all_files
 
 from .models import GitExtractionEntry
 

--- a/src/olympia/users/management/commands/migrate_user_photos.py
+++ b/src/olympia/users/management/commands/migrate_user_photos.py
@@ -1,0 +1,53 @@
+import os
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+import olympia.core.logger
+from olympia.users.models import UserProfile
+
+
+log = olympia.core.logger.getLogger('z.users.migrate_user_photos')
+
+
+class Command(BaseCommand):
+    help = 'Migrate user photos to new directory structure and remove orphaned ones'
+
+    # Note: because avatars are only displayed on developer profiles and
+    # heavily cached, we're directly migrating in-place without
+    # backwards-compatibility - UserProfile.picture_dir has already been
+    # to point to the new location. There will be some 404s until the migration
+    # is finished, but CDN caching should help avoid some of them.
+
+    def handle(self, *args, **options):
+        basedirname = os.path.join(settings.MEDIA_ROOT, 'userpics')
+        for dirname in os.listdir(basedirname):
+            dirpath = os.path.join(basedirname, dirname)
+            subdirs_count = os.stat(dirpath).st_nlink - 2
+            log.info(
+                'Migrating files inside %s/ (%d subdirectories)', dirname, subdirs_count
+            )
+            for subdirname in os.listdir(dirpath):
+                for filename in os.listdir(
+                    os.path.join(basedirname, dirname, subdirname)
+                ):
+                    fullpath = os.path.join(basedirname, dirname, subdirname, filename)
+                    user = None
+                    try:
+                        # Valid filenames are {pk}.png or {pk}_original.png
+                        pk = int(
+                            os.path.splitext(filename)[0].removesuffix('_original')
+                        )
+                        user = (
+                            UserProfile.objects.only('pk')
+                            .filter(pk=pk, deleted=False)
+                            .get()
+                        )
+                    except (ValueError, UserProfile.DoesNotExist):
+                        log.info('Deleting orphaned file %s', fullpath)
+                        os.remove(fullpath)
+                        continue
+                    log.info('Migrating file %s', fullpath)
+                    os.makedirs(user.picture_dir, exist_ok=True)
+                    new_path = os.path.join(user.picture_dir, filename)
+                    os.rename(fullpath, new_path)

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -34,6 +34,7 @@ from olympia.access.models import Group, GroupUser
 from olympia.amo.decorators import use_primary_db
 from olympia.amo.fields import PositiveAutoField, CIDRField
 from olympia.amo.models import LongNameIndex, ManagerBase, ModelBase, OnChangeMixin
+from olympia.amo.utils import id_to_path
 from olympia.amo.validators import OneOrMorePrintableCharacterValidator
 from olympia.translations.query import order_by_translation
 from olympia.users.notifications import NOTIFICATIONS_BY_ID
@@ -336,34 +337,28 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
 
     @property
     def picture_dir(self):
-        split_id = re.match(r'((\d*?)(\d{0,3}?))\d{1,3}$', str(self.id))
         return os.path.join(
-            settings.MEDIA_ROOT,
-            'userpics',
-            split_id.group(2) or '0',
-            split_id.group(1) or '0',
+            settings.MEDIA_ROOT, 'userpics', id_to_path(self.pk, breadth=2)
         )
 
     @property
     def picture_path(self):
-        return os.path.join(self.picture_dir, str(self.id) + '.png')
+        return os.path.join(self.picture_dir, str(self.pk) + '.png')
 
     @property
     def picture_path_original(self):
-        return os.path.join(self.picture_dir, str(self.id) + '_original.png')
+        return os.path.join(self.picture_dir, str(self.pk) + '_original.png')
 
     @property
     def picture_url(self):
         if not self.picture_type:
             return static('img/zamboni/anon_user.png')
         else:
-            split_id = re.match(r'((\d*?)(\d{0,3}?))\d{1,3}$', str(self.id))
             modified = int(time.mktime(self.modified.timetuple()))
             path = '/'.join(
                 [
-                    split_id.group(2) or '0',
-                    split_id.group(1) or '0',
-                    f'{self.id}.png?modified={modified}',
+                    id_to_path(self.pk, breadth=2),
+                    f'{self.pk}.png?modified={modified}',
                 ]
             )
             return f'{settings.MEDIA_URL}userpics/{path}'

--- a/src/olympia/users/tests/test_models.py
+++ b/src/olympia/users/tests/test_models.py
@@ -495,12 +495,12 @@ class TestUserProfile(TestCase):
         u = UserProfile.objects.create(
             id=1234, picture_type='image/png', modified=date.today(), username='a'
         )
-        u.picture_url.index('/userpics/0/1/1234.png?modified=')
+        u.picture_url.index('/userpics/34/1234/1234/1234.png?modified=')
 
         u = UserProfile.objects.create(
             id=1234567890, picture_type='image/png', modified=date.today(), username='b'
         )
-        u.picture_url.index('/userpics/1234/1234567/1234567890.png?modified=')
+        u.picture_url.index('/userpics/90/7890/1234567890/1234567890.png?modified=')
 
         u = UserProfile.objects.create(id=123456, picture_type=None, username='c')
         assert u.picture_url.endswith('/anon_user.png')

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -35,7 +35,12 @@ from olympia.amo.models import (
     ModelBase,
     OnChangeMixin,
 )
-from olympia.amo.utils import sorted_groupby, SafeStorage, utc_millesecs_from_epoch
+from olympia.amo.utils import (
+    id_to_path,
+    sorted_groupby,
+    SafeStorage,
+    utc_millesecs_from_epoch,
+)
 from olympia.applications.models import AppVersion
 from olympia.constants.licenses import CC_LICENSES, FORM_LICENSES, LICENSES_BY_BUILTIN
 from olympia.constants.promoted import PROMOTED_GROUPS_BY_ID
@@ -189,7 +194,7 @@ def source_upload_path(instance, filename):
 
     return os.path.join(
         'version_source',
-        utils.id_to_path(instance.pk),
+        id_to_path(instance.pk),
         f'{instance.addon.slug}-{instance.version}-src{ext}',
     )
 


### PR DESCRIPTION
Also move `id_to_path()` to `amo.utils` to avoid circular import when using it from `users/models.py` (it makes sense anyway since it's a generic util).

Fixes #19709