### PR TITLE
Don't try migrating directories when migrating user photos

### DIFF
--- a/src/olympia/users/management/commands/migrate_user_photos.py
+++ b/src/olympia/users/management/commands/migrate_user_photos.py
@@ -33,9 +33,15 @@ class Command(BaseCommand):
                     os.path.join(basedirname, dirname, subdirname)
                 ):
                     fullpath = os.path.join(basedirname, dirname, subdirname, filename)
+                    # If fullpath is a directory, we need to ignore it: it's
+                    # one of the directories created for the new structure.
+                    if os.path.isdir(fullpath):
+                        continue
                     user = None
                     try:
                         # Valid filenames are {pk}.png or {pk}_original.png
+                        if not filename.endswith('.png'):
+                            raise ValueError
                         pk = int(
                             os.path.splitext(filename)[0].removesuffix('_original')
                         )

--- a/src/olympia/users/tests/test_commands.py
+++ b/src/olympia/users/tests/test_commands.py
@@ -399,7 +399,7 @@ class TestMigrateUserPhotos(TestCase):
         self.garbage_path = 'somewhere/deep/whatever.png'
         self.other_garbage_path = f'{self.get_old_picture_dir(self.user)}/føøøøø.png'
         self.yet_another_garbage_path = (
-            f'{self.get_old_picture_dir(self.user)}/{self.user.pk}_nopé.png'
+            f'{self.get_old_picture_dir(self.user)}/{self.user.pk}_nopé.bin'
         )
 
         # Files that need to be migrated.
@@ -447,3 +447,8 @@ class TestMigrateUserPhotos(TestCase):
             f'{self.user.pk}.png',
             f'{self.user.pk}_original.png',
         }
+
+    def test_migrate_twice(self):
+        self.test_migrate()
+        # Running the migration command again shouldn't do anything.
+        call_command('migrate_user_photos')


### PR DESCRIPTION
This allows the command to be ran multiple times to pick up where it left off, ignoring already migrated content (that uses a deeper directory structure)

Addition to https://github.com/mozilla/addons-server/issues/19709