### PR TITLE
Remove obsolete tasks

### DIFF
--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -853,8 +853,6 @@ CELERY_TASK_ROUTES = {
     'olympia.amo.tasks.set_modified_on_object': {'queue': 'amo'},
     'olympia.bandwagon.tasks.collection_meta': {'queue': 'amo'},
     'olympia.blocklist.tasks.cleanup_old_files': {'queue': 'amo'},
-    'olympia.devhub.tasks.pngcrush_existing_icons': {'queue': 'amo'},
-    'olympia.devhub.tasks.pngcrush_existing_preview': {'queue': 'amo'},
     'olympia.devhub.tasks.recreate_previews': {'queue': 'amo'},
     'olympia.git.tasks.continue_git_extraction': {'queue': 'amo'},
     'olympia.git.tasks.extract_versions_to_git': {'queue': 'amo'},


### PR DESCRIPTION
Fixes #19718

- Removed obsolete tasks: `pngcrush_existing_icons`, `pngcrush_existing_preview` and their respective unused imports 
- Removed both tasks from `amo` queue