### PR TITLE
Fix typo in error message s/symbolink/symbolic/

### DIFF
--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -561,7 +561,7 @@ class SafeTar:
                     raise InvalidArchiveFile(
                         gettext(
                             'This archive contains a forbidden special file '
-                            '(symbolink / hard link or device / block file)'
+                            '(symbolic / hard link or device / block file)'
                         )
                     )
         return archive


### PR DESCRIPTION
Follow-up for https://github.com/mozilla/addons-server/issues/19721