### PR TITLE
update outgoing server to GCP

### DIFF
--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -2628,9 +2628,6 @@ class TestAddonFromUpload(UploadMixin, TestCase):
         assert log.user == self.user
 
 
-REDIRECT_URL = 'https://outgoing.prod.mozaws.net/v1/'
-
-
 class TestFrozenAddons(TestCase):
     def test_immediate_freeze(self):
         # Adding a FrozenAddon should immediately drop the addon's hotness.

--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -65,8 +65,6 @@ CEF_PRODUCT = STATSD_PREFIX
 
 NEW_FEATURES = True
 
-REDIRECT_URL = env('REDIRECT_URL', default='https://outgoing.stage.mozaws.net/v1/')
-
 ADDONS_LINTER_BIN = 'node_modules/.bin/addons-linter'
 
 ALLOW_SELF_REVIEWS = True

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -62,8 +62,6 @@ CEF_PRODUCT = STATSD_PREFIX
 
 NEW_FEATURES = True
 
-REDIRECT_URL = env('REDIRECT_URL', default='https://outgoing.stage.mozaws.net/v1/')
-
 ADDONS_LINTER_BIN = 'node_modules/.bin/addons-linter'
 
 ALLOW_SELF_REVIEWS = True

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -710,7 +710,9 @@ CACHES['default']['BACKEND'] = 'django.core.cache.backends.memcached.PyMemcacheC
 CACHES['default']['KEY_PREFIX'] = 'amo:%s:' % BUILD_ID
 
 # Outgoing URL bouncer
-REDIRECT_URL = env('REDIRECT_URL', default='https://outgoing.prod.mozaws.net/v1/')
+REDIRECT_URL = env(
+    'REDIRECT_URL', default='https://prod.outgoing.prod.webservices.mozgcp.net/v1/'
+)
 REDIRECT_SECRET_KEY = env('REDIRECT_SECRET_KEY', default='')
 
 # Allow URLs from these servers. Use full domain names.

--- a/src/olympia/search/tests/test_search_ranking.py
+++ b/src/olympia/search/tests/test_search_ranking.py
@@ -725,7 +725,7 @@ class TestRankingScenarios(ESTestCase):
             'Open Image in New Tab',
             (
                 ['Open Image in New Tab', 5553],
-                ['Open image in a new tab', 1735],
+                ['Open image in a new tab', 1736],
             ),
         )
 
@@ -735,7 +735,7 @@ class TestRankingScenarios(ESTestCase):
             'CoinHive',
             (
                 ['Coinhive Blocker', 1899],
-                ['NoMiners', 69],  # via description
+                ['NoMiners', 70],  # via description
                 # ['CoinBlock', 0],  # via prefix search
             ),
         )
@@ -822,9 +822,9 @@ class TestRankingScenarios(ESTestCase):
         self._check_scenario(
             'No Flash',
             (
-                ['No Flash', 7230],
+                ['No Flash', 7226],
                 ['Download Flash and Video', 1565],
-                ['YouTube Flash Player', 1370],
+                ['YouTube Flash Player', 1371],
                 ['YouTube Flash Video Player', 1260],
             ),
         )
@@ -833,9 +833,9 @@ class TestRankingScenarios(ESTestCase):
         self._check_scenario(
             'no flash',
             (
-                ['No Flash', 7230],
+                ['No Flash', 7226],
                 ['Download Flash and Video', 1565],
-                ['YouTube Flash Player', 1370],
+                ['YouTube Flash Player', 1371],
                 ['YouTube Flash Video Player', 1260],
             ),
         )
@@ -846,8 +846,8 @@ class TestRankingScenarios(ESTestCase):
         self._check_scenario(
             'Youtube html5 Player',
             (
-                ['YouTube Flash Player', 472],
-                ['No Flash', 205],
+                ['YouTube Flash Player', 474],
+                ['No Flash', 193],
             ),
         )
 
@@ -1001,12 +1001,12 @@ class TestRankingScenarios(ESTestCase):
         self._check_scenario(
             'tab',
             (
-                ['Tabby Cat', 3729],
-                ['Tab Mix Plus', 1351],
+                ['Tabby Cat', 3730],
+                ['Tab Mix Plus', 1352],
                 ['OneTab', 1144],
-                ['Tab Center Redux', 960],
+                ['Tab Center Redux', 961],
                 ['FoxyTab', 902],
-                ['Open Bookmarks in New Tab', 886],
+                ['Open Bookmarks in New Tab', 887],
                 ['Open image in a new tab', 715],
                 ['Open Image in New Tab', 560],
             ),

--- a/src/olympia/translations/tests/test_commands.py
+++ b/src/olympia/translations/tests/test_commands.py
@@ -2,7 +2,6 @@ from unittest import mock
 
 from django.conf import settings
 from django.core.management import call_command
-from django.test.utils import override_settings
 
 from olympia.amo.tests import TestCase
 from olympia.translations.models import (
@@ -59,9 +58,6 @@ class TestTranslationCommands(TestCase):
         for translation in self.translations:
             translation.save()
 
-    @override_settings(
-        REDIRECT_URL='https://prod.outgoing.prod.webservices.mozgcp.net/v1/'
-    )
     def test_update_outgoing_url(self):
         self.expected = {}
         for translation in self.translations:
@@ -83,9 +79,6 @@ class TestTranslationCommands(TestCase):
             assert translation.localized_string == expected_values[0]
             assert translation.localized_string_clean == expected_values[1]
 
-    @override_settings(
-        REDIRECT_URL='https://stage.outgoing.nonprod.webservices.mozgcp.net/v1/'
-    )
     def test_update_outgoing_url_custom_url(self):
         self.expected = {}
         for translation in self.translations:


### PR DESCRIPTION
fixes #19733 + drops the per env settings because the servers are defined in .env files so it's redundant.