### PR TITLE
Convert IP addresses to strings in MySQL before calling `GROUP_CONCAT()`

### DIFF
--- a/src/olympia/amo/models.py
+++ b/src/olympia/amo/models.py
@@ -7,6 +7,8 @@ from urllib.parse import urljoin
 from django.conf import settings
 from django.core.files.storage import default_storage as storage
 from django.db import models
+from django.db.models.expressions import Func
+from django.db.models.fields import CharField
 from django.db.models.fields.related_descriptors import ManyToManyDescriptor
 from django.db.models.query import ModelIterable
 from django.urls import resolve, reverse
@@ -633,3 +635,8 @@ class FilterableManyToManyField(models.fields.related.ManyToManyField):
 class GroupConcat(models.Aggregate):
     function = 'GROUP_CONCAT'
     allow_distinct = True
+
+
+class Inet6Ntoa(Func):
+    function = 'INET6_NTOA'
+    output_field = CharField()

--- a/src/olympia/users/admin.py
+++ b/src/olympia/users/admin.py
@@ -6,7 +6,6 @@ from django import http
 from django.contrib import admin, messages
 from django.contrib.admin.utils import unquote
 from django.db.models import (
-    CharField,
     Count,
     F,
     FilteredRelation,

--- a/src/olympia/users/admin.py
+++ b/src/olympia/users/admin.py
@@ -37,7 +37,7 @@ from olympia.amo.admin import (
     SEARCH_VAR,
 )
 from olympia.amo.fields import IPAddressBinaryField
-from olympia.amo.models import GroupConcat
+from olympia.amo.models import GroupConcat, Inet6Ntoa
 from olympia.api.models import APIKey, APIKeyConfirmation
 from olympia.bandwagon.models import Collection
 from olympia.ratings.models import Rating
@@ -242,7 +242,7 @@ class UserAdmin(CommaSearchInAdminMixin, admin.ModelAdmin):
             # FilteredRelation we can force it...
             annotations = {
                 'activity_ips': GroupConcat(
-                    'activitylog__iplog__ip_address_binary',
+                    Inet6Ntoa('activitylog__iplog__ip_address_binary'),
                     distinct=True,
                     # You can't have multiple ip addresses in an IPv[4|6]Address object
                     # so we store the binary values in a CharField instead.
@@ -482,11 +482,12 @@ class UserAdmin(CommaSearchInAdminMixin, admin.ModelAdmin):
         # extra queries for each row of results), otherwise, look everywhere
         # we can.
         activity_ips = getattr(obj, 'activity_ips', None)
-        to_ipaddress = IPAddressBinaryField().to_python
         if activity_ips is not None:
-            # The GroupConcat value is a comma seperated string of the binary values.
-            ip_addresses = {to_ipaddress(ip) for ip in activity_ips.split(b',')}
+            # The GroupConcat value is a comma seperated string of the ip
+            # addresses (already converted to string thanks to INET6_NTOA).
+            ip_addresses = set(activity_ips.split(','))
         else:
+            to_ipaddress = IPAddressBinaryField().to_python
             ip_addresses = set(
                 Rating.objects.filter(user=obj)
                 .values_list('ip_address', flat=True)

--- a/src/olympia/users/admin.py
+++ b/src/olympia/users/admin.py
@@ -244,9 +244,6 @@ class UserAdmin(CommaSearchInAdminMixin, admin.ModelAdmin):
                 'activity_ips': GroupConcat(
                     Inet6Ntoa('activitylog__iplog__ip_address_binary'),
                     distinct=True,
-                    # You can't have multiple ip addresses in an IPv[4|6]Address object
-                    # so we store the binary values in a CharField instead.
-                    output_field=CharField(),
                 ),
                 'activitylog_filtered': FilteredRelation(
                     'activitylog__iplog', condition=condition


### PR DESCRIPTION
This avoids issues with commas inside the bytestring representation of the binary value, which can happen for some IPs if they contain a `44`.

Fixes #19781