### PR TITLE
Allow deleting scanner query rules (by allowing deletion of scanner query results)

### DIFF
--- a/src/olympia/constants/permissions.py
+++ b/src/olympia/constants/permissions.py
@@ -188,6 +188,7 @@ DJANGO_PERMISSIONS_MAPPING.update(
         'scanners.change_scannerqueryrule': ADMIN_SCANNERS_QUERY_EDIT,
         'scanners.delete_scannerqueryrule': ADMIN_SCANNERS_QUERY_EDIT,
         'scanners.change_scannerqueryresult': ADMIN_SCANNERS_QUERY_EDIT,
+        'scanners.delete_scannerqueryresult': ADMIN_SCANNERS_QUERY_EDIT,
         'scanners.view_scannerqueryrule': ADMIN_SCANNERS_QUERY_VIEW,
         'scanners.view_scannerqueryresult': ADMIN_SCANNERS_QUERY_VIEW,
         'tags.add_tag': DISCOVERY_EDIT,

--- a/src/olympia/scanners/admin.py
+++ b/src/olympia/scanners/admin.py
@@ -315,10 +315,6 @@ class AbstractScannerResultAdminMixin(admin.ModelAdmin):
     def has_add_permission(self, request):
         return False
 
-    # Remove the "delete" button
-    def has_delete_permission(self, request, obj=None):
-        return False
-
     # Read-only mode
     def has_change_permission(self, request, obj=None):
         return False
@@ -764,6 +760,10 @@ class ScannerResultAdmin(AbstractScannerResultAdminMixin, admin.ModelAdmin):
 
     result_actions.short_description = 'Actions'
     result_actions.allow_tags = True
+
+    # Remove the "delete" button
+    def has_delete_permission(self, request, obj=None):
+        return False
 
 
 @admin.register(ScannerQueryResult)


### PR DESCRIPTION
This is necessary now that query results are directly tied to query rules: deleting a query rule will delete the query results associated with it, so Django ensures you have delete permission for both.

Follow-up for https://github.com/mozilla/addons-server/issues/19797