### PR TITLE
refactor version_dict usage; update blocklist tests

### DIFF
--- a/src/olympia/versions/tests/test_compare.py
+++ b/src/olympia/versions/tests/test_compare.py
@@ -1,5 +1,5 @@
 from olympia.versions.compare import (
-    MAX_VERSION_PART,
+    APP_MAJOR_VERSION_PART_MAX,
     version_dict,
     version_int,
     VersionString,
@@ -13,9 +13,9 @@ def test_version_int():
     assert version_int('0') == 200100
     assert version_int('*') == 65535999999200100
     assert version_int('*.0') == 65535000000200100
-    assert version_int(MAX_VERSION_PART) == 65535000000200100
-    assert version_int(MAX_VERSION_PART + 1) == 65535000000200100
-    assert version_int(f'{MAX_VERSION_PART}.100') == 65535990000200100
+    assert version_int(APP_MAJOR_VERSION_PART_MAX) == 65535000000200100
+    assert version_int(APP_MAJOR_VERSION_PART_MAX + 1) == 65535000000200100
+    assert version_int(f'{APP_MAJOR_VERSION_PART_MAX}.100') == 65535990000200100
 
 
 def test_version_int_compare():
@@ -121,33 +121,7 @@ def test_version_dict():
         {
             'major': 5,
             'minor1': 0,
-            'minor2': 65535,
-            'minor3': None,
-            'alpha': None,
-            'alpha_ver': None,
-            'pre': None,
-            'pre_ver': None,
-        }
-    )
-
-    assert version_dict('5.0.*', asterisk_value=1234) == (
-        {
-            'major': 5,
-            'minor1': 0,
-            'minor2': 1234,
-            'minor3': None,
-            'alpha': None,
-            'alpha_ver': None,
-            'pre': None,
-            'pre_ver': None,
-        }
-    )
-
-    assert version_dict('*.0.*', asterisk_value='@') == (
-        {
-            'major': '@',
-            'minor1': 0,
-            'minor2': '@',
+            'minor2': '*',
             'minor3': None,
             'alpha': None,
             'alpha_ver': None,

--- a/src/olympia/versions/utils.py
+++ b/src/olympia/versions/utils.py
@@ -13,7 +13,6 @@ from PIL import Image
 from olympia.amo.utils import convert_svg_to_png
 from olympia.core import logger
 
-from . import compare
 from .models import Version
 
 
@@ -24,11 +23,10 @@ def get_next_version_number(addon):
     if not addon:
         return '1.0'
     last_version = Version.unfiltered.filter(addon=addon).order_by('id').last()
-    version_dict = compare.version_dict(last_version.version)
 
     version_counter = 1
     while True:
-        next_version = '%s.0' % (version_dict['major'] + version_counter)
+        next_version = '%s.0' % (last_version.version['major'] + version_counter)
         if not Version.unfiltered.filter(addon=addon, version=next_version).exists():
             return next_version
         else:


### PR DESCRIPTION
closes #19809 - there weren't any fixes needed, but I updated the blocklist tests to prove it, and tidied up / simplified some usage. 