### PR TITLE
log web-ext version on api create requests

### DIFF
--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -750,6 +750,7 @@ class RequestMixin:
             self.url,
             data={**getattr(self, 'minimal_data', {}), **(data or kwargs)},
             format=format,
+            HTTP_USER_AGENT='web-ext/12.34',
         )
 
 
@@ -883,6 +884,7 @@ class TestAddonViewSetCreate(UploadMixin, AddonViewSetCreateUpdateMixin, TestCas
             == 1
         )
         self.statsd_incr_mock.assert_any_call('addons.submission.addon.unlisted')
+        self.statsd_incr_mock.assert_any_call('addons.submission.webext_version.12_34')
 
     def test_basic_listed(self):
         self.upload.update(channel=amo.CHANNEL_LISTED)
@@ -914,6 +916,7 @@ class TestAddonViewSetCreate(UploadMixin, AddonViewSetCreateUpdateMixin, TestCas
             == 1
         )
         self.statsd_incr_mock.assert_any_call('addons.submission.addon.listed')
+        self.statsd_incr_mock.assert_any_call('addons.submission.webext_version.12_34')
 
     def test_listed_metadata_missing(self):
         self.upload.update(channel=amo.CHANNEL_LISTED)
@@ -2989,6 +2992,7 @@ class TestVersionViewSetCreate(UploadMixin, VersionViewSetCreateUpdateMixin, Tes
         response = self.client.post(
             self.url,
             data=self.minimal_data,
+            HTTP_USER_AGENT='web-ext/12.34',
         )
         assert response.status_code == 201, response.content
         data = response.data
@@ -3007,6 +3011,7 @@ class TestVersionViewSetCreate(UploadMixin, VersionViewSetCreateUpdateMixin, Tes
         ).to_representation(version)
         assert version.channel == amo.CHANNEL_UNLISTED
         self.statsd_incr_mock.assert_any_call('addons.submission.version.unlisted')
+        self.statsd_incr_mock.assert_any_call('addons.submission.webext_version.12_34')
 
     @mock.patch('olympia.addons.views.log')
     def test_does_not_log_without_source(self, log_mock):
@@ -3025,6 +3030,7 @@ class TestVersionViewSetCreate(UploadMixin, VersionViewSetCreateUpdateMixin, Tes
         response = self.client.post(
             self.url,
             data={**self.minimal_data, 'license': self.license.slug},
+            HTTP_USER_AGENT='web-ext/12.34',
         )
         assert response.status_code == 201, response.content
         data = response.data
@@ -3041,6 +3047,7 @@ class TestVersionViewSetCreate(UploadMixin, VersionViewSetCreateUpdateMixin, Tes
         assert version.channel == amo.CHANNEL_LISTED
         assert self.addon.status == amo.STATUS_NOMINATED
         self.statsd_incr_mock.assert_any_call('addons.submission.version.listed')
+        self.statsd_incr_mock.assert_any_call('addons.submission.webext_version.12_34')
 
     def test_not_authenticated(self):
         self.client.logout_api()

--- a/src/olympia/addons/utils.py
+++ b/src/olympia/addons/utils.py
@@ -1,3 +1,4 @@
+import re
 import uuid
 
 from django import forms
@@ -303,3 +304,12 @@ def check_version_number_is_greater_than_current(addon, version_string):
             version_string=version_string,
             previous_version_string=previous_version.version,
         )
+
+
+def webext_version_stats(request, source):
+    webext_version_match = re.match(
+        r'web-ext/([\d\.]+)$', request.META.get('HTTP_USER_AGENT') or ''
+    )
+    if webext_version_match:
+        webext_version = webext_version_match[1].replace('.', '_')
+        statsd.incr(f'{source}.webext_version.{webext_version}')

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -100,6 +100,7 @@ from .utils import (
     get_addon_recommendations,
     get_addon_recommendations_invalid,
     is_outcome_recommended,
+    webext_version_stats,
 )
 
 
@@ -385,6 +386,11 @@ class AddonViewSet(
             self.action = 'create'
             return self.create(request, *args, **kwargs)
 
+    def create(self, request, *args, **kwargs):
+        response = super().create(request, *args, **kwargs)
+        webext_version_stats(request, 'addons.submission')
+        return response
+
 
 class AddonChildMixin:
     """Mixin containing method to retrieve the parent add-on object."""
@@ -625,6 +631,7 @@ class AddonVersionViewSet(
             timer.log_interval('4.data_saved')
 
         headers = self.get_success_headers(serializer.data)
+        webext_version_stats(request, 'addons.submission')
         return Response(
             serializer.data, status=status.HTTP_201_CREATED, headers=headers
         )

--- a/src/olympia/signing/views.py
+++ b/src/olympia/signing/views.py
@@ -14,7 +14,10 @@ import olympia.core.logger
 from olympia import amo
 from olympia.access import acl
 from olympia.addons.models import Addon
-from olympia.addons.utils import check_version_number_is_greater_than_current
+from olympia.addons.utils import (
+    check_version_number_is_greater_than_current,
+    webext_version_stats,
+)
 from olympia.amo.decorators import use_primary_db
 from olympia.api.authentication import JWTKeyAuthentication
 from olympia.amo.templatetags.jinja_helpers import absolutify
@@ -257,6 +260,8 @@ class VersionView(APIView):
             channel=channel,
             source=amo.UPLOAD_SOURCE_SIGNING_API,
         )
+
+        webext_version_stats(request, 'signing.submission')
 
         return file_upload, created
 


### PR DESCRIPTION
fixes #18803 - added statsd pings so we can start to chart webext versions used for creating new add-ons and versions.