### PR TITLE
Move the error message for `reasons` so it isn't part of the scrollable area

### DIFF
--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -170,6 +170,8 @@
             <label for="id_reasons">{{ form.reasons.label }}</label>
             <div class="review-actions-reasons-select">
               {{ form.reasons }}
+            </div>
+            <div class="review-actions-reasons-error">
               {{ form.reasons.errors }}
             </div>
           </div>


### PR DESCRIPTION
Fixes #19854 