### PR TITLE
Enhance VersionString to support full toolkit version strings

### DIFF
--- a/src/olympia/versions/compare.py
+++ b/src/olympia/versions/compare.py
@@ -40,72 +40,136 @@ def version_dict(version):
     return vdict
 
 
+def list_get(lst, idx, default):
+    return lst[idx] if idx < len(lst) else default
+
+
 class VersionString(str):
-    def _get_full_vdict(self):
-        if hasattr(self, '_full_vdict'):
-            return self._full_vdict
-        vdict = version_dict(self)
-        last_part_value = None
-        for part in NUMBERS:
-            part_value = vdict[part]
-            # reset last_part_value once we get to the alpha/pre parts
-            if part in ('alpha_ver', 'pre_ver'):
-                last_part_value = None
-            if part_value is None:
-                # if the part was missing it's 0, unless the last part was *;
-                # then it inherits the * and is max value.
-                vdict[part] = ASTERISK if last_part_value == ASTERISK else 0
-            else:
-                last_part_value = part_value
-        for part in LETTERS:
-            vdict[part] = vdict[part] or ''
-        self._full_vdict = vdict
-        return self._full_vdict
+    class Part:
+        """Each version part is itself parsed as a sequence of four parts:
+        <number-a><string-b><number-c><string-d>. Each of the parts is optional.
+        Numbers are integers base 10 (may be negative), strings are non-numeric
+        ASCII characters. Missing version parts are treated as if they were 0 or ''.
+        """
+
+        a = 0
+        b = ''
+        c = 0
+        d = ''
+
+        SPLIT_INT_REGEX = re.compile(r' *(?P<int>\-?[\d]+)(?P<rest>.*)')
+        SPLIT_STR_REGEX = re.compile(r'(?P<str>[^\d\-]+)(?P<int>\-?[\d]*)(?P<rest>.*)')
+
+        def __init__(self, part_string):
+            if not part_string:
+                return
+
+            # If the version part is a single asterisk, it is interpreted as an
+            # infinitely-large number.
+            if part_string == ASTERISK:
+                self.a = ASTERISK
+                return
+
+            split = self.SPLIT_INT_REGEX.match(part_string)
+            if not split:
+                return
+            try:
+                self.a = int(split['int'])
+            except ValueError:
+                return
+            rest = split['rest']
+
+            # If b starts with a plus sign, a is incremented to be compatible with
+            # the Firefox 1.0.x version format.
+            if rest.startswith('+'):
+                self.a += 1
+                self.b = 'pre'
+            elif rest:
+                split = self.SPLIT_STR_REGEX.match(rest)
+                if not split:
+                    self.b = rest
+                else:
+                    self.b = split['str']
+                    if split['int'] is not None:
+                        try:
+                            self.c = int(split['int'])
+                        except ValueError:
+                            return
+                        self.d = split['rest']
+
+        def __eq__(self, other):
+            return all(
+                getattr(self, sub) == getattr(other, sub, None) for sub in 'abcd'
+            )
+
+        def __gt__(self, other):
+            if self.a == ASTERISK:
+                return other.a != ASTERISK
+            if other.a == ASTERISK:
+                return False
+
+            for subpart in 'abcd':
+                self_subpart = getattr(self, subpart)
+                other_subpart = getattr(other, subpart)
+                if subpart != 'a' and not self_subpart:
+                    return bool(other_subpart)
+                elif subpart != 'a' and not other_subpart:
+                    return False
+                elif self_subpart != other_subpart:
+                    return self_subpart > other_subpart
+            return False
+
+        def __ge__(self, other):
+            return self.__eq__(other) or self.__gt__(other)
+
+        def __lt__(self, other):
+            return not self.__ge__(other)
+
+        def __le__(self, other):
+            return not self.__gt__(other)
+
+        def asdict(self):
+            return {key: getattr(self, key) for key in 'abcd'}
+
+        def __repr__(self):
+            return f'{self.asdict()}'
 
     @property
-    def parts(self):
-        return self._get_full_vdict().items()
-
-    def __getitem__(self, key):
-        if isinstance(key, str):
-            return self._get_full_vdict()[key]
-        else:
-            return super().__getitem__(key)
-
-    @classmethod
-    def _cmp_part(cls, part_a, part_b):
-        if part_a == ASTERISK and part_b != ASTERISK:
-            return 1
-        elif part_b == ASTERISK and part_a != ASTERISK:
-            return -1
-        return 0 if part_a == part_b else 1 if part_a > part_b else -1
+    def vparts(self):
+        if not hasattr(self, '_vparts'):
+            self._vparts = tuple(self.Part(vpart) for vpart in self.split('.'))
+        return self._vparts
 
     def __eq__(self, other):
         if other is None or (bool(self) ^ bool(other)):
             return False
         if not isinstance(other, self.__class__):
             other = self.__class__(other)
-        for part, value in self.parts:
-            cmp = self._cmp_part(value, other[part])
-            if cmp == 0:
-                continue
-            else:
+        self_part = self.Part('')
+        other_part = self.Part('')
+        for idx in range(0, max(len(self.vparts), len(other.vparts))):
+            self_part = list_get(
+                self.vparts,
+                idx,
+                self_part if self_part == self.Part('*') else self.Part(''),
+            )
+            other_part = list_get(
+                other.vparts,
+                idx,
+                other_part if other_part == self.Part('*') else self.Part(''),
+            )
+            if self_part != other_part:
                 return False
         return True
 
     def __gt__(self, other):
         if not isinstance(other, self.__class__):
             other = self.__class__(other)
-        for part, value in self.parts:
-            other_value = other[part]
-            if part in LETTERS:
-                cmp = self._cmp_part(value or 'z', other_value or 'z')
-            else:
-                cmp = self._cmp_part(value, other_value)
-            if cmp == 0:
-                continue
-            else:
-                return cmp == 1
+        for idx in range(0, max(len(self.vparts), len(other.vparts))):
+            self_part = list_get(self.vparts, idx, self.Part(''))
+            other_part = list_get(other.vparts, idx, self.Part(''))
+            if self_part != other_part:
+                return self_part > other_part
         return False
 
     def __ge__(self, other):
@@ -125,16 +189,25 @@ def version_int(version):
     single number for comparison.  To maintain compatibility the minor parts
     are limited to 99 making it unsuitable for comparing addon version strings.
     """
-    vdict = dict(VersionString(version).parts)
+    vdict = version_dict(str(version))
+    last_part_value = None
     for part in NUMBERS:
+        # reset last_part_value once we get to the alpha/pre parts
+        if part in ('alpha_ver', 'pre_ver'):
+            last_part_value = None
+        if vdict[part] is None:
+            # if the part was missing it's 0, unless the last part was *;
+            # then it inherits the * and is max value.
+            vdict[part] = ASTERISK if last_part_value == ASTERISK else 0
+        else:
+            last_part_value = vdict[part]
+
         max_num = (
             APP_MAJOR_VERSION_PART_MAX
             if part == 'major'
             else APP_MINOR_VERSION_PART_MAX
         )
-
-        number = vdict[part]
-        vdict[part] = max_num if number == ASTERISK else min(number, max_num)
+        vdict[part] = max_num if vdict[part] == ASTERISK else min(vdict[part], max_num)
     vdict['alpha'] = {'a': 0, 'b': 1}.get(vdict['alpha'], 2)
     vdict['pre'] = 0 if vdict['pre'] else 1
 

--- a/src/olympia/versions/utils.py
+++ b/src/olympia/versions/utils.py
@@ -26,7 +26,7 @@ def get_next_version_number(addon):
 
     version_counter = 1
     while True:
-        next_version = '%s.0' % (last_version.version['major'] + version_counter)
+        next_version = '%s.0' % (last_version.version.vparts[0].a + version_counter)
         if not Version.unfiltered.filter(addon=addon, version=next_version).exists():
             return next_version
         else:


### PR DESCRIPTION
fixes #19788 

references were:
https://github.com/mozilla/addons-moz-compare/blob/main/src/index.js and then original
https://searchfox.org/mozilla-central/source/xpcom/base/nsVersionComparator.cpp but the way the comparisons are done is different because `VersionString` builds up a tuple of `Part` objects representing each part first, and delegates the part comparisons to that class instead.  `parseVersionPart` is the key function in addons-moz-compare, and it's implemented in `Part.__init__` here.