### PR TITLE
drop redundant string limit in VERSION_RE

### DIFF
--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -43,7 +43,7 @@ class ParseError(forms.ValidationError):
     pass
 
 
-VERSION_RE = re.compile(r'^[-+*.\w]{,32}$')
+VERSION_RE = re.compile(r'^[-+*.\w]*$', re.ASCII)
 SIGNED_RE = re.compile(r'^META\-INF/(\w+)\.(rsa|sf)$')
 
 # This is essentially what Firefox matches


### PR DESCRIPTION
fixes #19842 again 🙃

The length limit in the regex was redundant as we only ever use it just after a string length check that would raise if the string length exceeded 255 (and the linter before that would return an error for a string length above 100)