### PR TITLE
replace `|` in reviewer actions lists with space padding

### DIFF
--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -149,8 +149,8 @@ class VersionsChoiceWidget(forms.SelectMultiple):
             # Add our special `data-toggle` class and the right `data-value` depending
             # on status.
             option['attrs']['class'] = 'data-toggle'
-            option['attrs']['data-value'] = ''.join(
-                f' {a} ' for a in self.actions_filters[obj.channel].get(status, ())
+            option['attrs']['data-value'] = ' '.join(
+                self.actions_filters[obj.channel].get(status, ())
             )
         # Just in case, let's now force the label to be a string (it would be
         # converted anyway, but it's probably safer that way).
@@ -302,7 +302,7 @@ class ReviewForm(forms.Form):
         # if the relevant actions are available, otherwise we don't really care
         # about this field.
         versions_actions = [
-            f' {k} '
+            k
             for k in self.helper.actions
             if self.helper.actions[k].get('multiple_versions')
         ]
@@ -321,9 +321,8 @@ class ReviewForm(forms.Form):
                 .select_related('reviewerflags')
                 .order_by('created')
             )
-            # Reset data-value depending on widget depending on actions
-            # available.
-            self.fields['versions'].widget.attrs['data-value'] = ''.join(
+            # Reset data-value depending on widget depending on actions available.
+            self.fields['versions'].widget.attrs['data-value'] = ' '.join(
                 versions_actions
             )
         # For the canned responses, we're starting with an empty one, which

--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -149,8 +149,8 @@ class VersionsChoiceWidget(forms.SelectMultiple):
             # Add our special `data-toggle` class and the right `data-value` depending
             # on status.
             option['attrs']['class'] = 'data-toggle'
-            option['attrs']['data-value'] = '|'.join(
-                self.actions_filters[obj.channel].get(status, ()) + ('',)
+            option['attrs']['data-value'] = ''.join(
+                f' {a} ' for a in self.actions_filters[obj.channel].get(status, ())
             )
         # Just in case, let's now force the label to be a string (it would be
         # converted anyway, but it's probably safer that way).
@@ -302,7 +302,7 @@ class ReviewForm(forms.Form):
         # if the relevant actions are available, otherwise we don't really care
         # about this field.
         versions_actions = [
-            k
+            f' {k} '
             for k in self.helper.actions
             if self.helper.actions[k].get('multiple_versions')
         ]
@@ -322,9 +322,9 @@ class ReviewForm(forms.Form):
                 .order_by('created')
             )
             # Reset data-value depending on widget depending on actions
-            # available ([''] added to get an extra '|' at the end).
-            self.fields['versions'].widget.attrs['data-value'] = '|'.join(
-                versions_actions + ['']
+            # available.
+            self.fields['versions'].widget.attrs['data-value'] = ''.join(
+                versions_actions
             )
         # For the canned responses, we're starting with an empty one, which
         # will be hidden via CSS.

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -138,7 +138,7 @@
     <div id="review-actions-form">
 
       {% for (setting, action) in actions %}
-      <div class="data-toggle review-actions-desc" data-value=" {{ setting }} ">
+      <div class="data-toggle review-actions-desc" data-value="{{ setting }}">
         {{ action['details'] }}
 
         {# We don't have a better place to display versions error messages, so let's do it here.
@@ -158,7 +158,7 @@
       {{ form.versions.errors }}
 
       <div class="review-actions-section data-toggle review-comments"
-           data-value="{{ actions_comments|join('') }}">
+           data-value="{{ actions_comments|join(' ') }}">
         <div class="review-actions-comments-reasons">
           <div class="review-actions-comments">
             <label for="id_comments">{{ form.comments.label }}</label>
@@ -166,7 +166,7 @@
             {{ form.comments.errors }}
           </div>
           <div class="data-toggle review-actions-reasons"
-            data-value="{{ actions_reasons|join('') }}">
+            data-value="{{ actions_reasons|join(' ') }}">
             <label for="id_reasons">{{ form.reasons.label }}</label>
             <div class="review-actions-reasons-select">
               {{ form.reasons }}
@@ -183,7 +183,7 @@
       </div>
 
       <div class="review-actions-section review-actions-files data-toggle review-files"
-           data-value="{{ actions_full|join('') }}">
+           data-value="{{ actions_full|join(' ') }}">
         <label><strong>{{ _('Files:') }}</strong></label>
         <ul>
           {% for file in form.unreviewed_files %}
@@ -196,7 +196,7 @@
       </div>
 
       <div class="review-actions-section review-actions-tested data-toggle review-tested"
-           data-value="{{ actions_full|join('') }}">
+           data-value="{{ actions_full|join(' ') }}">
         <strong>{{ _('Tested on:') }}</strong>
         <label>
           {{ form.operating_systems.label }}
@@ -210,7 +210,7 @@
         {{ form.applications.errors }}
       </div>
       <div class="review-actions-section data-toggle review-delayed-rejection"
-           data-value="{{ actions_delayable|join('') }}">
+           data-value="{{ actions_delayable|join(' ') }}">
         <div class="review-delayed-rejection-inner">
           {{ form.delayed_rejection }}
           {{ form.delayed_rejection.errors }}

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -138,7 +138,7 @@
     <div id="review-actions-form">
 
       {% for (setting, action) in actions %}
-      <div class="data-toggle review-actions-desc" data-value="{{ setting }}|">
+      <div class="data-toggle review-actions-desc" data-value=" {{ setting }} ">
         {{ action['details'] }}
 
         {# We don't have a better place to display versions error messages, so let's do it here.
@@ -158,7 +158,7 @@
       {{ form.versions.errors }}
 
       <div class="review-actions-section data-toggle review-comments"
-           data-value="{{ actions_comments|join('|') }}|">
+           data-value="{{ actions_comments|join('') }}">
         <div class="review-actions-comments-reasons">
           <div class="review-actions-comments">
             <label for="id_comments">{{ form.comments.label }}</label>
@@ -166,7 +166,7 @@
             {{ form.comments.errors }}
           </div>
           <div class="data-toggle review-actions-reasons"
-            data-value="{{ actions_reasons|join('|') }}|">
+            data-value="{{ actions_reasons|join('') }}">
             <label for="id_reasons">{{ form.reasons.label }}</label>
             <div class="review-actions-reasons-select">
               {{ form.reasons }}
@@ -183,7 +183,7 @@
       </div>
 
       <div class="review-actions-section review-actions-files data-toggle review-files"
-           data-value="{{ actions_full|join('|') }}|">
+           data-value="{{ actions_full|join('') }}">
         <label><strong>{{ _('Files:') }}</strong></label>
         <ul>
           {% for file in form.unreviewed_files %}
@@ -196,7 +196,7 @@
       </div>
 
       <div class="review-actions-section review-actions-tested data-toggle review-tested"
-           data-value="{{ actions_full|join('|') }}|">
+           data-value="{{ actions_full|join('') }}">
         <strong>{{ _('Tested on:') }}</strong>
         <label>
           {{ form.operating_systems.label }}
@@ -210,7 +210,7 @@
         {{ form.applications.errors }}
       </div>
       <div class="review-actions-section data-toggle review-delayed-rejection"
-           data-value="{{ actions_delayable|join('|') }}|">
+           data-value="{{ actions_delayable|join('') }}">
         <div class="review-delayed-rejection-inner">
           {{ form.delayed_rejection }}
           {{ form.delayed_rejection.errors }}

--- a/src/olympia/reviewers/tests/test_forms.py
+++ b/src/olympia/reviewers/tests/test_forms.py
@@ -297,7 +297,7 @@ class TestReviewForm(TestCase):
         assert list(form.fields['versions'].queryset) == [self.addon.current_version]
 
     def test_versions_queryset_contains_pending_files_for_listed(
-        self, select_data_value=' reject_multiple_versions '
+        self, select_data_value='reject_multiple_versions'
     ):
         # We hide some of the versions using JavaScript + some data attributes on each
         # <option>.
@@ -354,7 +354,7 @@ class TestReviewForm(TestCase):
         assert option1.attrib.get('class') == 'data-toggle'
         assert option1.attrib.get('data-value') == (
             # That version is approved.
-            ' block_multiple_versions  reject_multiple_versions '
+            'block_multiple_versions reject_multiple_versions'
         )
         assert option1.attrib.get('value') == str(self.version.pk)
 
@@ -362,7 +362,7 @@ class TestReviewForm(TestCase):
         assert option2.attrib.get('class') == 'data-toggle'
         assert option2.attrib.get('data-value') == (
             # That version is pending.
-            ' approve_multiple_versions  reject_multiple_versions '
+            'approve_multiple_versions reject_multiple_versions'
         )
         assert option2.attrib.get('value') == str(pending_version.pk)
 
@@ -370,7 +370,7 @@ class TestReviewForm(TestCase):
         assert option3.attrib.get('class') == 'data-toggle'
         assert option3.attrib.get('data-value') == (
             # That version is rejected.
-            ' unreject_multiple_versions '
+            'unreject_multiple_versions'
         )
         assert option3.attrib.get('value') == str(rejected_version.pk)
 
@@ -385,14 +385,14 @@ class TestReviewForm(TestCase):
     def test_versions_queryset_contains_pending_files_for_listed_admin_reviewer(self):
         self.grant_permission(self.request.user, 'Reviews:Admin')
         self.test_versions_queryset_contains_pending_files_for_listed(
-            select_data_value=' reject_multiple_versions  unreject_multiple_versions '
+            select_data_value='reject_multiple_versions unreject_multiple_versions'
         )
 
     def test_versions_queryset_contains_pending_files_for_unlisted(
         self,
         select_data_value=(
-            ' approve_multiple_versions  reject_multiple_versions '
-            ' block_multiple_versions  confirm_multiple_versions '
+            'approve_multiple_versions reject_multiple_versions '
+            'block_multiple_versions confirm_multiple_versions'
         ),
     ):
         # We hide some of the versions using JavaScript + some data attributes on each
@@ -458,7 +458,7 @@ class TestReviewForm(TestCase):
         assert option1.attrib.get('class') == 'data-toggle'
         assert option1.attrib.get('data-value') == (
             # That version is approved.
-            ' block_multiple_versions  confirm_multiple_versions '
+            'block_multiple_versions confirm_multiple_versions'
         )
         assert option1.attrib.get('value') == str(self.version.pk)
 
@@ -466,7 +466,7 @@ class TestReviewForm(TestCase):
         assert option2.attrib.get('class') == 'data-toggle'
         assert option2.attrib.get('data-value') == (
             # That version is pending.
-            ' approve_multiple_versions  reject_multiple_versions '
+            'approve_multiple_versions reject_multiple_versions'
         )
         assert option2.attrib.get('value') == str(pending_version.pk)
 
@@ -474,7 +474,7 @@ class TestReviewForm(TestCase):
         assert option3.attrib.get('class') == 'data-toggle'
         assert option3.attrib.get('data-value') == (
             # That version is rejected.
-            ' unreject_multiple_versions '
+            'unreject_multiple_versions'
         )
         assert option3.attrib.get('value') == str(rejected_version.pk)
 
@@ -490,9 +490,9 @@ class TestReviewForm(TestCase):
         self.grant_permission(self.request.user, 'Reviews:Admin')
         self.test_versions_queryset_contains_pending_files_for_unlisted(
             select_data_value=(
-                ' approve_multiple_versions  reject_multiple_versions '
-                ' unreject_multiple_versions  block_multiple_versions '
-                ' confirm_multiple_versions '
+                'approve_multiple_versions reject_multiple_versions '
+                'unreject_multiple_versions block_multiple_versions '
+                'confirm_multiple_versions'
             )
         )
 

--- a/src/olympia/reviewers/tests/test_forms.py
+++ b/src/olympia/reviewers/tests/test_forms.py
@@ -297,7 +297,7 @@ class TestReviewForm(TestCase):
         assert list(form.fields['versions'].queryset) == [self.addon.current_version]
 
     def test_versions_queryset_contains_pending_files_for_listed(
-        self, select_data_value='reject_multiple_versions|'
+        self, select_data_value=' reject_multiple_versions '
     ):
         # We hide some of the versions using JavaScript + some data attributes on each
         # <option>.
@@ -354,7 +354,7 @@ class TestReviewForm(TestCase):
         assert option1.attrib.get('class') == 'data-toggle'
         assert option1.attrib.get('data-value') == (
             # That version is approved.
-            'block_multiple_versions|reject_multiple_versions|'
+            ' block_multiple_versions  reject_multiple_versions '
         )
         assert option1.attrib.get('value') == str(self.version.pk)
 
@@ -362,7 +362,7 @@ class TestReviewForm(TestCase):
         assert option2.attrib.get('class') == 'data-toggle'
         assert option2.attrib.get('data-value') == (
             # That version is pending.
-            'approve_multiple_versions|reject_multiple_versions|'
+            ' approve_multiple_versions  reject_multiple_versions '
         )
         assert option2.attrib.get('value') == str(pending_version.pk)
 
@@ -370,7 +370,7 @@ class TestReviewForm(TestCase):
         assert option3.attrib.get('class') == 'data-toggle'
         assert option3.attrib.get('data-value') == (
             # That version is rejected.
-            'unreject_multiple_versions|'
+            ' unreject_multiple_versions '
         )
         assert option3.attrib.get('value') == str(rejected_version.pk)
 
@@ -385,14 +385,14 @@ class TestReviewForm(TestCase):
     def test_versions_queryset_contains_pending_files_for_listed_admin_reviewer(self):
         self.grant_permission(self.request.user, 'Reviews:Admin')
         self.test_versions_queryset_contains_pending_files_for_listed(
-            select_data_value='reject_multiple_versions|unreject_multiple_versions|'
+            select_data_value=' reject_multiple_versions  unreject_multiple_versions '
         )
 
     def test_versions_queryset_contains_pending_files_for_unlisted(
         self,
         select_data_value=(
-            'approve_multiple_versions|reject_multiple_versions|'
-            'block_multiple_versions|confirm_multiple_versions|'
+            ' approve_multiple_versions  reject_multiple_versions '
+            ' block_multiple_versions  confirm_multiple_versions '
         ),
     ):
         # We hide some of the versions using JavaScript + some data attributes on each
@@ -458,7 +458,7 @@ class TestReviewForm(TestCase):
         assert option1.attrib.get('class') == 'data-toggle'
         assert option1.attrib.get('data-value') == (
             # That version is approved.
-            'block_multiple_versions|confirm_multiple_versions|'
+            ' block_multiple_versions  confirm_multiple_versions '
         )
         assert option1.attrib.get('value') == str(self.version.pk)
 
@@ -466,7 +466,7 @@ class TestReviewForm(TestCase):
         assert option2.attrib.get('class') == 'data-toggle'
         assert option2.attrib.get('data-value') == (
             # That version is pending.
-            'approve_multiple_versions|reject_multiple_versions|'
+            ' approve_multiple_versions  reject_multiple_versions '
         )
         assert option2.attrib.get('value') == str(pending_version.pk)
 
@@ -474,7 +474,7 @@ class TestReviewForm(TestCase):
         assert option3.attrib.get('class') == 'data-toggle'
         assert option3.attrib.get('data-value') == (
             # That version is rejected.
-            'unreject_multiple_versions|'
+            ' unreject_multiple_versions '
         )
         assert option3.attrib.get('value') == str(rejected_version.pk)
 
@@ -490,9 +490,9 @@ class TestReviewForm(TestCase):
         self.grant_permission(self.request.user, 'Reviews:Admin')
         self.test_versions_queryset_contains_pending_files_for_unlisted(
             select_data_value=(
-                'approve_multiple_versions|reject_multiple_versions|'
-                'unreject_multiple_versions|block_multiple_versions|'
-                'confirm_multiple_versions|'
+                ' approve_multiple_versions  reject_multiple_versions '
+                ' unreject_multiple_versions  block_multiple_versions '
+                ' confirm_multiple_versions '
             )
         )
 

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -5461,11 +5461,11 @@ class TestReview(ReviewBase):
         doc = pq(response.content)
 
         expected_actions_values = [
-            ' confirm_auto_approved ',
-            ' reject_multiple_versions ',
-            ' reply ',
-            ' super ',
-            ' comment ',
+            'confirm_auto_approved',
+            'reject_multiple_versions',
+            'reply',
+            'super',
+            'comment',
         ]
         assert [
             act.attrib['data-value'] for act in doc('.data-toggle.review-actions-desc')
@@ -5473,7 +5473,7 @@ class TestReview(ReviewBase):
 
         assert (
             doc('select#id_versions.data-toggle')[0].attrib['data-value']
-            == ' reject_multiple_versions '
+            == 'reject_multiple_versions'
         )
 
         assert (
@@ -5483,12 +5483,12 @@ class TestReview(ReviewBase):
 
         assert (
             doc('.data-toggle.review-comments')[0].attrib['data-value']
-            == ' reject_multiple_versions  reply  super  comment '
+            == 'reject_multiple_versions reply super comment'
         )
 
         assert (
             doc('.data-toggle.review-actions-reasons')[0].attrib['data-value']
-            == ' reject_multiple_versions  reply '
+            == 'reject_multiple_versions reply'
         )
 
         # We don't have approve/reject actions so these have an empty
@@ -5496,7 +5496,7 @@ class TestReview(ReviewBase):
         assert doc('.data-toggle.review-files')[0].attrib['data-value'] == ''
         assert doc('.data-toggle.review-tested')[0].attrib['data-value'] == ''
         elm = doc('.data-toggle.review-delayed-rejection')[0]
-        assert elm.attrib['data-value'] == ' reject_multiple_versions '
+        assert elm.attrib['data-value'] == 'reject_multiple_versions'
 
     def test_data_value_attributes_unlisted(self):
         self.version.update(channel=amo.CHANNEL_UNLISTED)
@@ -5511,13 +5511,13 @@ class TestReview(ReviewBase):
         doc = pq(response.content)
 
         expected_actions_values = [
-            ' approve_multiple_versions ',
-            ' reject_multiple_versions ',
-            ' block_multiple_versions ',
-            ' confirm_multiple_versions ',
-            ' reply ',
-            ' super ',
-            ' comment ',
+            'approve_multiple_versions',
+            'reject_multiple_versions',
+            'block_multiple_versions',
+            'confirm_multiple_versions',
+            'reply',
+            'super',
+            'comment',
         ]
         assert [
             act.attrib['data-value'] for act in doc('.data-toggle.review-actions-desc')
@@ -5525,19 +5525,18 @@ class TestReview(ReviewBase):
 
         assert (
             doc('select#id_versions.data-toggle')[0].attrib['data-value']
-            == ' approve_multiple_versions  reject_multiple_versions '
-            ' block_multiple_versions  confirm_multiple_versions '
+            == 'approve_multiple_versions reject_multiple_versions '
+            'block_multiple_versions confirm_multiple_versions'
         )
 
         assert (
             doc('.data-toggle.review-comments')[0].attrib['data-value']
-            == ' approve_multiple_versions  reject_multiple_versions  reply  super '
-            ' comment '
+            == 'approve_multiple_versions reject_multiple_versions reply super comment'
         )
 
         assert (
             doc('.data-toggle.review-actions-reasons')[0].attrib['data-value']
-            == ' approve_multiple_versions  reject_multiple_versions  reply '
+            == 'approve_multiple_versions reject_multiple_versions reply'
         )
 
         # We don't have approve/reject actions so these have an empty
@@ -5581,12 +5580,12 @@ class TestReview(ReviewBase):
         doc = pq(response.content)
 
         expected_actions_values = [
-            ' public ',
-            ' reject ',
-            ' reject_multiple_versions ',
-            ' reply ',
-            ' super ',
-            ' comment ',
+            'public',
+            'reject',
+            'reject_multiple_versions',
+            'reply',
+            'super',
+            'comment',
         ]
         assert [
             act.attrib['data-value'] for act in doc('.data-toggle.review-actions-desc')
@@ -5596,19 +5595,17 @@ class TestReview(ReviewBase):
 
         assert (
             doc('.data-toggle.review-comments')[0].attrib['data-value']
-            == ' public  reject  reject_multiple_versions  reply  super  comment '
+            == 'public reject reject_multiple_versions reply super comment'
         )
         assert (
-            doc('.data-toggle.review-files')[0].attrib['data-value']
-            == ' public  reject '
+            doc('.data-toggle.review-files')[0].attrib['data-value'] == 'public reject'
         )
         assert (
-            doc('.data-toggle.review-tested')[0].attrib['data-value']
-            == ' public  reject '
+            doc('.data-toggle.review-tested')[0].attrib['data-value'] == 'public reject'
         )
         assert (
             doc('.data-toggle.review-actions-reasons')[0].attrib['data-value']
-            == ' public  reject  reject_multiple_versions  reply '
+            == 'public reject reject_multiple_versions reply'
         )
 
     def test_data_value_attributes_static_theme(self):
@@ -5620,12 +5617,12 @@ class TestReview(ReviewBase):
         doc = pq(response.content)
 
         expected_actions_values = [
-            ' public ',
-            ' reject ',
-            ' reject_multiple_versions ',
-            ' reply ',
-            ' super ',
-            ' comment ',
+            'public',
+            'reject',
+            'reject_multiple_versions',
+            'reply',
+            'super',
+            'comment',
         ]
         assert [
             act.attrib['data-value'] for act in doc('.data-toggle.review-actions-desc')
@@ -5635,7 +5632,7 @@ class TestReview(ReviewBase):
 
         assert (
             doc('.data-toggle.review-comments')[0].attrib['data-value']
-            == ' public  reject  reject_multiple_versions  reply  super  comment '
+            == 'public reject reject_multiple_versions reply super comment'
         )
         # we don't show files, reasons, and tested with for any static theme actions
         assert doc('.data-toggle.review-files')[0].attrib['data-value'] == ''

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -5461,11 +5461,11 @@ class TestReview(ReviewBase):
         doc = pq(response.content)
 
         expected_actions_values = [
-            'confirm_auto_approved|',
-            'reject_multiple_versions|',
-            'reply|',
-            'super|',
-            'comment|',
+            ' confirm_auto_approved ',
+            ' reject_multiple_versions ',
+            ' reply ',
+            ' super ',
+            ' comment ',
         ]
         assert [
             act.attrib['data-value'] for act in doc('.data-toggle.review-actions-desc')
@@ -5473,7 +5473,7 @@ class TestReview(ReviewBase):
 
         assert (
             doc('select#id_versions.data-toggle')[0].attrib['data-value']
-            == 'reject_multiple_versions|'
+            == ' reject_multiple_versions '
         )
 
         assert (
@@ -5483,20 +5483,20 @@ class TestReview(ReviewBase):
 
         assert (
             doc('.data-toggle.review-comments')[0].attrib['data-value']
-            == 'reject_multiple_versions|reply|super|comment|'
+            == ' reject_multiple_versions  reply  super  comment '
         )
 
         assert (
             doc('.data-toggle.review-actions-reasons')[0].attrib['data-value']
-            == 'reject_multiple_versions|reply|'
+            == ' reject_multiple_versions  reply '
         )
 
         # We don't have approve/reject actions so these have an empty
         # data-value.
-        assert doc('.data-toggle.review-files')[0].attrib['data-value'] == '|'
-        assert doc('.data-toggle.review-tested')[0].attrib['data-value'] == '|'
+        assert doc('.data-toggle.review-files')[0].attrib['data-value'] == ''
+        assert doc('.data-toggle.review-tested')[0].attrib['data-value'] == ''
         elm = doc('.data-toggle.review-delayed-rejection')[0]
-        assert elm.attrib['data-value'] == 'reject_multiple_versions|'
+        assert elm.attrib['data-value'] == ' reject_multiple_versions '
 
     def test_data_value_attributes_unlisted(self):
         self.version.update(channel=amo.CHANNEL_UNLISTED)
@@ -5511,13 +5511,13 @@ class TestReview(ReviewBase):
         doc = pq(response.content)
 
         expected_actions_values = [
-            'approve_multiple_versions|',
-            'reject_multiple_versions|',
-            'block_multiple_versions|',
-            'confirm_multiple_versions|',
-            'reply|',
-            'super|',
-            'comment|',
+            ' approve_multiple_versions ',
+            ' reject_multiple_versions ',
+            ' block_multiple_versions ',
+            ' confirm_multiple_versions ',
+            ' reply ',
+            ' super ',
+            ' comment ',
         ]
         assert [
             act.attrib['data-value'] for act in doc('.data-toggle.review-actions-desc')
@@ -5525,30 +5525,29 @@ class TestReview(ReviewBase):
 
         assert (
             doc('select#id_versions.data-toggle')[0].attrib['data-value']
-            == 'approve_multiple_versions|'
-            'reject_multiple_versions|'
-            'block_multiple_versions|'
-            'confirm_multiple_versions|'
+            == ' approve_multiple_versions  reject_multiple_versions '
+            ' block_multiple_versions  confirm_multiple_versions '
         )
 
         assert (
             doc('.data-toggle.review-comments')[0].attrib['data-value']
-            == 'approve_multiple_versions|reject_multiple_versions|reply|super|comment|'
+            == ' approve_multiple_versions  reject_multiple_versions  reply  super '
+            ' comment '
         )
 
         assert (
             doc('.data-toggle.review-actions-reasons')[0].attrib['data-value']
-            == 'approve_multiple_versions|reject_multiple_versions|reply|'
+            == ' approve_multiple_versions  reject_multiple_versions  reply '
         )
 
         # We don't have approve/reject actions so these have an empty
         # data-value.
-        assert doc('.data-toggle.review-files')[0].attrib['data-value'] == '|'
-        assert doc('.data-toggle.review-tested')[0].attrib['data-value'] == '|'
+        assert doc('.data-toggle.review-files')[0].attrib['data-value'] == ''
+        assert doc('.data-toggle.review-tested')[0].attrib['data-value'] == ''
         # Unlisted versions can't be rejected with a delay so the data-value of
         # the field is empty as well.
         elm = doc('.data-toggle.review-delayed-rejection')[0]
-        assert elm.attrib['data-value'] == '|'
+        assert elm.attrib['data-value'] == ''
 
     def test_no_data_value_attributes_unlisted_for_viewer(self):
         self.version.update(channel=amo.CHANNEL_UNLISTED)
@@ -5567,12 +5566,13 @@ class TestReview(ReviewBase):
 
         assert not doc('.data-toggle.review-actions-desc')
         assert not doc('select#id_versions.data-toggle')[0]
-        assert doc('.data-toggle.review-comments')[0].attrib['data-value'] == '|'
-        assert doc('.data-toggle.review-actions-reasons')[0].attrib['data-value'] == '|'
-        assert doc('.data-toggle.review-files')[0].attrib['data-value'] == '|'
-        assert doc('.data-toggle.review-tested')[0].attrib['data-value'] == '|'
-        elm = doc('.data-toggle.review-delayed-rejection')[0]
-        assert elm.attrib['data-value'] == '|'
+        assert doc('.data-toggle.review-comments')[0].attrib['data-value'] == ''
+        assert doc('.data-toggle.review-actions-reasons')[0].attrib['data-value'] == ''
+        assert doc('.data-toggle.review-files')[0].attrib['data-value'] == ''
+        assert doc('.data-toggle.review-tested')[0].attrib['data-value'] == ''
+        assert (
+            doc('.data-toggle.review-delayed-rejection')[0].attrib['data-value'] == ''
+        )
 
     def test_data_value_attributes_unreviewed(self):
         self.file.update(status=amo.STATUS_AWAITING_REVIEW)
@@ -5581,12 +5581,12 @@ class TestReview(ReviewBase):
         doc = pq(response.content)
 
         expected_actions_values = [
-            'public|',
-            'reject|',
-            'reject_multiple_versions|',
-            'reply|',
-            'super|',
-            'comment|',
+            ' public ',
+            ' reject ',
+            ' reject_multiple_versions ',
+            ' reply ',
+            ' super ',
+            ' comment ',
         ]
         assert [
             act.attrib['data-value'] for act in doc('.data-toggle.review-actions-desc')
@@ -5596,18 +5596,19 @@ class TestReview(ReviewBase):
 
         assert (
             doc('.data-toggle.review-comments')[0].attrib['data-value']
-            == 'public|reject|reject_multiple_versions|reply|super|comment|'
+            == ' public  reject  reject_multiple_versions  reply  super  comment '
         )
         assert (
-            doc('.data-toggle.review-files')[0].attrib['data-value'] == 'public|reject|'
+            doc('.data-toggle.review-files')[0].attrib['data-value']
+            == ' public  reject '
         )
         assert (
             doc('.data-toggle.review-tested')[0].attrib['data-value']
-            == 'public|reject|'
+            == ' public  reject '
         )
         assert (
             doc('.data-toggle.review-actions-reasons')[0].attrib['data-value']
-            == 'public|reject|reject_multiple_versions|reply|'
+            == ' public  reject  reject_multiple_versions  reply '
         )
 
     def test_data_value_attributes_static_theme(self):
@@ -5619,12 +5620,12 @@ class TestReview(ReviewBase):
         doc = pq(response.content)
 
         expected_actions_values = [
-            'public|',
-            'reject|',
-            'reject_multiple_versions|',
-            'reply|',
-            'super|',
-            'comment|',
+            ' public ',
+            ' reject ',
+            ' reject_multiple_versions ',
+            ' reply ',
+            ' super ',
+            ' comment ',
         ]
         assert [
             act.attrib['data-value'] for act in doc('.data-toggle.review-actions-desc')
@@ -5634,12 +5635,12 @@ class TestReview(ReviewBase):
 
         assert (
             doc('.data-toggle.review-comments')[0].attrib['data-value']
-            == 'public|reject|reject_multiple_versions|reply|super|comment|'
+            == ' public  reject  reject_multiple_versions  reply  super  comment '
         )
         # we don't show files, reasons, and tested with for any static theme actions
-        assert doc('.data-toggle.review-files')[0].attrib['data-value'] == '|'
-        assert doc('.data-toggle.review-actions-reasons')[0].attrib['data-value'] == '|'
-        assert doc('.data-toggle.review-tested')[0].attrib['data-value'] == '|'
+        assert doc('.data-toggle.review-files')[0].attrib['data-value'] == ''
+        assert doc('.data-toggle.review-actions-reasons')[0].attrib['data-value'] == ''
+        assert doc('.data-toggle.review-tested')[0].attrib['data-value'] == ''
 
     def test_post_review_ignore_disabled(self):
         # Though the latest version will be disabled, the add-on is public and

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -701,13 +701,13 @@ def review(request, addon, channel=None):
 
     for key, action in actions:
         if not (is_static_theme or action.get('minimal')):
-            actions_full.append(f' {key} ')
+            actions_full.append(key)
         if action.get('comments', True):
-            actions_comments.append(f' {key} ')
+            actions_comments.append(key)
         if action.get('delayable', False):
-            actions_delayable.append(f' {key} ')
+            actions_delayable.append(key)
         if action.get('allows_reasons', False):
-            actions_reasons.append(f' {key} ')
+            actions_reasons.append(key)
 
     addons_sharing_same_guid = (
         Addon.unfiltered.all()

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -701,13 +701,13 @@ def review(request, addon, channel=None):
 
     for key, action in actions:
         if not (is_static_theme or action.get('minimal')):
-            actions_full.append(key)
+            actions_full.append(f' {key} ')
         if action.get('comments', True):
-            actions_comments.append(key)
+            actions_comments.append(f' {key} ')
         if action.get('delayable', False):
-            actions_delayable.append(key)
+            actions_delayable.append(f' {key} ')
         if action.get('allows_reasons', False):
-            actions_reasons.append(key)
+            actions_reasons.append(f' {key} ')
 
     addons_sharing_same_guid = (
         Addon.unfiltered.all()

--- a/static/js/zamboni/reviewers.js
+++ b/static/js/zamboni/reviewers.js
@@ -77,12 +77,9 @@ function initReviewActions() {
     }
 
     // Hide everything, then show the ones containing the value we're
-    // interested in. An extra | (the separator used) is added at the end
-    // to make sure we don't match things with a common prefix (i.e. don't
-    // show elements with data-value="reject_multiple_versions" when the
-    // value is "reject".)
+    // interested in. Values are padded with spaces so we don't match a substring.)
     $data_toggle.hide();
-    $data_toggle.filter('[data-value*="' + value + '|"]').show();
+    $data_toggle.filter('[data-value*=" ' + value + ' "]').show();
 
     /* Fade out canned responses */
     var label = $element.text().trim();

--- a/static/js/zamboni/reviewers.js
+++ b/static/js/zamboni/reviewers.js
@@ -76,10 +76,9 @@ function initReviewActions() {
       $('#review-actions').find('.errorlist').remove();
     }
 
-    // Hide everything, then show the ones containing the value we're
-    // interested in. Values are padded with spaces so we don't match a substring.)
+    // Hide everything, then show the ones containing the value we're interested in.
     $data_toggle.hide();
-    $data_toggle.filter('[data-value*=" ' + value + ' "]').show();
+    $data_toggle.filter('[data-value~="' + value + '"]').show();
 
     /* Fade out canned responses */
     var label = $element.text().trim();


### PR DESCRIPTION
fixes #19807 - took a few attempts playing around with prefixing `|` or ` ` and edge cases with empty lists but this works - and the extra spaces read much better than extra `|` characters.