### PR TITLE
Only force greater version numbers against approved versions.

### DIFF
--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -75,7 +75,7 @@ from .models import (
 from .tasks import resize_icon, resize_preview
 from .utils import (
     fetch_translations_from_addon,
-    is_version_number_not_greater_than_current,
+    validate_version_number_is_greater,
 )
 from .validators import (
     AddonMetadataValidator,
@@ -525,7 +525,7 @@ class DeveloperVersionSerializer(VersionSerializer):
                 self._check_for_existing_versions(version_string)
 
                 if data['upload'].channel == amo.CHANNEL_LISTED:
-                    if error_message := is_version_number_not_greater_than_current(
+                    if error_message := validate_version_number_is_greater(
                         self.addon, version_string
                     ):
                         raise exceptions.ValidationError({'version': error_message})

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -75,7 +75,7 @@ from .models import (
 from .tasks import resize_icon, resize_preview
 from .utils import (
     fetch_translations_from_addon,
-    validate_version_number_is_greater,
+    validate_version_number_is_gt_latest_signed_listed_version,
 )
 from .validators import (
     AddonMetadataValidator,
@@ -525,8 +525,10 @@ class DeveloperVersionSerializer(VersionSerializer):
                 self._check_for_existing_versions(version_string)
 
                 if data['upload'].channel == amo.CHANNEL_LISTED:
-                    if error_message := validate_version_number_is_greater(
-                        self.addon, version_string
+                    if error_message := (
+                        validate_version_number_is_gt_latest_signed_listed_version(
+                            self.addon, version_string
+                        )
                     ):
                         raise exceptions.ValidationError({'version': error_message})
                     # Also check for submitting listed versions when disabled.

--- a/src/olympia/addons/tests/test_utils_.py
+++ b/src/olympia/addons/tests/test_utils_.py
@@ -14,7 +14,7 @@ from freezegun import freeze_time
 
 from olympia import amo, core
 from olympia.activity.models import ActivityLog
-from olympia.amo.tests import TestCase, addon_factory, user_factory
+from olympia.amo.tests import TestCase, addon_factory, user_factory, version_factory
 from olympia.files.models import FileUpload
 from olympia.users.models import (
     EmailUserRestriction,
@@ -38,7 +38,7 @@ from ..utils import (
     TAAR_LITE_OUTCOME_REAL_FAIL,
     TAAR_LITE_OUTCOME_REAL_SUCCESS,
     TAAR_LITE_FALLBACK_REASON_INVALID,
-    validate_version_number_is_greater,
+    validate_version_number_is_gt_latest_signed_listed_version,
     verify_mozilla_trademark,
     webext_version_stats,
 )
@@ -494,28 +494,52 @@ def test_webext_version_stats():
         incr_mock.assert_called_with('prefix.for.logging.webext_version.12_34_56')
 
 
-def test_validate_version_number_is_greater():
-    addon = addon_factory(version_kw={'version': '123.0'})
+def test_validate_version_number_is_gt_latest_signed_listed_version():
+    addon = addon_factory(version_kw={'version': '123.0'}, file_kw={'is_signed': True})
+    # add an unlisted version, which should be ignored.
+    latest_unlisted = version_factory(
+        addon=addon,
+        version='124',
+        channel=amo.CHANNEL_UNLISTED,
+        file_kw={'is_signed': True},
+    )
+    # Version number is greater, but doesn't matter, because the check is listed only.
+    assert latest_unlisted.version > addon.current_version.version
+
     # version number isn't greater (its the same).
-    assert validate_version_number_is_greater(addon, '123') == (
+    assert validate_version_number_is_gt_latest_signed_listed_version(addon, '123') == (
         'Version 123 must be greater than the previous approved version 123.0.'
     )
-    # version number is less than the current version.
-    assert validate_version_number_is_greater(addon, '122.9') == (
-        'Version 122.9 must be greater than the previous approved version 123.0.'
-    )
+    # version number is less than the current listed version.
+    assert validate_version_number_is_gt_latest_signed_listed_version(
+        addon, '122.9'
+    ) == ('Version 122.9 must be greater than the previous approved version 123.0.')
     # version number is greater, so no error message.
-    assert not validate_version_number_is_greater(addon, '123.1')
+    assert not validate_version_number_is_gt_latest_signed_listed_version(
+        addon, '123.1'
+    )
 
-    addon.current_version.file.update(status=amo.STATUS_AWAITING_REVIEW)
-    # Same as current but check only applies to approved versions, so no error message.
-    assert not validate_version_number_is_greater(addon, '123')
+    addon.current_version.file.update(is_signed=False)
+    # Same as current but check only applies to signed versions, so no error message.
+    assert not validate_version_number_is_gt_latest_signed_listed_version(addon, '123')
 
-    addon.current_version.file.update(status=amo.STATUS_DISABLED)
+    # Set up the scenario when a newer version has been signed, but then disabled
+    addon.current_version.file.update(is_signed=True)
+    disabled = version_factory(
+        addon=addon,
+        version='123.5',
+        file_kw={'is_signed': True, 'status': amo.STATUS_DISABLED},
+    )
     addon.reload()
-    assert not addon.current_version
-    # No current version, so no error message.
-    assert not validate_version_number_is_greater(addon, '123')
+    assert validate_version_number_is_gt_latest_signed_listed_version(
+        addon, '123.1'
+    ) == ('Version 123.1 must be greater than the previous approved version 123.5.')
+
+    disabled.delete()
+    # Shouldn't make a difference even if it's deleted - it was still signed.
+    assert validate_version_number_is_gt_latest_signed_listed_version(
+        addon, '123.1'
+    ) == ('Version 123.1 must be greater than the previous approved version 123.5.')
 
     # Also check the edge case when addon is None
-    assert not validate_version_number_is_greater(None, '123')
+    assert not validate_version_number_is_gt_latest_signed_listed_version(None, '123')

--- a/src/olympia/addons/tests/test_utils_.py
+++ b/src/olympia/addons/tests/test_utils_.py
@@ -30,7 +30,6 @@ from ..utils import (
     get_addon_recommendations,
     get_addon_recommendations_invalid,
     is_outcome_recommended,
-    is_version_number_not_greater_than_current,
     RestrictionChecker,
     TAAR_LITE_FALLBACK_REASON_EMPTY,
     TAAR_LITE_FALLBACK_REASON_TIMEOUT,
@@ -39,6 +38,7 @@ from ..utils import (
     TAAR_LITE_OUTCOME_REAL_FAIL,
     TAAR_LITE_OUTCOME_REAL_SUCCESS,
     TAAR_LITE_FALLBACK_REASON_INVALID,
+    validate_version_number_is_greater,
     verify_mozilla_trademark,
     webext_version_stats,
 )
@@ -494,18 +494,28 @@ def test_webext_version_stats():
         incr_mock.assert_called_with('prefix.for.logging.webext_version.12_34_56')
 
 
-def test_is_version_number_not_greater_than_current():
+def test_validate_version_number_is_greater():
     addon = addon_factory(version_kw={'version': '123.0'})
-    # version number isn't greater (its the same)
-    assert is_version_number_not_greater_than_current(addon, '123')
-    # version number is less than the current version
-    assert is_version_number_not_greater_than_current(addon, '122.9')
-    # version number is greater, so it's okay
-    assert not is_version_number_not_greater_than_current(addon, '123.1')
+    # version number isn't greater (its the same).
+    assert validate_version_number_is_greater(addon, '123') == (
+        'Version 123 must be greater than the previous approved version 123.0.'
+    )
+    # version number is less than the current version.
+    assert validate_version_number_is_greater(addon, '122.9') == (
+        'Version 122.9 must be greater than the previous approved version 123.0.'
+    )
+    # version number is greater, so no error message.
+    assert not validate_version_number_is_greater(addon, '123.1')
+
+    addon.current_version.file.update(status=amo.STATUS_AWAITING_REVIEW)
+    # Same as current but check only applies to approved versions, so no error message.
+    assert not validate_version_number_is_greater(addon, '123')
 
     addon.current_version.file.update(status=amo.STATUS_DISABLED)
+    addon.reload()
     assert not addon.current_version
-    # with no current version, it's okay
-    assert not is_version_number_not_greater_than_current(addon, '123.1')
-    # also check the edge case when addon is None
-    assert not is_version_number_not_greater_than_current(None, '123.0')
+    # No current version, so no error message.
+    assert not validate_version_number_is_greater(addon, '123')
+
+    # Also check the edge case when addon is None
+    assert not validate_version_number_is_greater(None, '123')

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -3305,6 +3305,7 @@ class TestVersionViewSetCreate(UploadMixin, VersionViewSetCreateUpdateMixin, Tes
 
     def test_greater_version_number_error(self):
         self.addon.current_version.update(version='0.0.2')
+        self.addon.current_version.file.update(is_signed=True)
         self.upload.update(channel=amo.CHANNEL_LISTED)
         response = self.client.post(
             self.url,

--- a/src/olympia/addons/utils.py
+++ b/src/olympia/addons/utils.py
@@ -302,10 +302,13 @@ def webext_version_stats(request, source):
     log.info('webext_version_stats no match')
 
 
-def is_version_number_not_greater_than_current(addon, version_string):
+def validate_version_number_is_greater(addon, version_string):
+    """Returns an error string if `version_string` isn't greater than the current
+    approved listed version."""
     if (
         addon
         and (previous_version := addon.current_version)
+        and previous_version.file.status == amo.STATUS_APPROVED
         and previous_version.version >= version_string
     ):
         msg = gettext(

--- a/src/olympia/devhub/forms.py
+++ b/src/olympia/devhub/forms.py
@@ -37,7 +37,7 @@ from olympia.addons.models import (
 from olympia.addons.utils import (
     fetch_translations_from_addon,
     RestrictionChecker,
-    validate_version_number_is_greater,
+    validate_version_number_is_gt_latest_signed_listed_version,
     verify_mozilla_trademark,
 )
 from olympia.amo.fields import HttpHttpsOnlyURLField, ReCaptchaField
@@ -1104,8 +1104,10 @@ class NewUploadForm(CheckThrottlesMixin, forms.Form):
             if self.addon:
                 self.check_for_existing_versions(parsed_data.get('version'))
                 if self.cleaned_data['upload'].channel == amo.CHANNEL_LISTED:
-                    if error_message := validate_version_number_is_greater(
-                        self.addon, parsed_data.get('version')
+                    if error_message := (
+                        validate_version_number_is_gt_latest_signed_listed_version(
+                            self.addon, parsed_data.get('version')
+                        )
                     ):
                         raise forms.ValidationError(error_message)
 

--- a/src/olympia/devhub/forms.py
+++ b/src/olympia/devhub/forms.py
@@ -36,8 +36,8 @@ from olympia.addons.models import (
 )
 from olympia.addons.utils import (
     fetch_translations_from_addon,
-    is_version_number_not_greater_than_current,
     RestrictionChecker,
+    validate_version_number_is_greater,
     verify_mozilla_trademark,
 )
 from olympia.amo.fields import HttpHttpsOnlyURLField, ReCaptchaField
@@ -1104,7 +1104,7 @@ class NewUploadForm(CheckThrottlesMixin, forms.Form):
             if self.addon:
                 self.check_for_existing_versions(parsed_data.get('version'))
                 if self.cleaned_data['upload'].channel == amo.CHANNEL_LISTED:
-                    if error_message := is_version_number_not_greater_than_current(
+                    if error_message := validate_version_number_is_greater(
                         self.addon, parsed_data.get('version')
                     ):
                         raise forms.ValidationError(error_message)

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -2372,6 +2372,7 @@ class TestVersionSubmitUploadListed(VersionSubmitUploadMixin, UploadMixin, TestC
 
     def test_version_num_must_be_greater(self):
         self.version.update(version='0.0.2')
+        self.version.file.update(is_signed=True)
         response = self.post(expected_status=200)
         assert pq(response.content)('ul.errorlist').text() == (
             'Version 0.0.1 must be greater than the previous approved version 0.0.2.'
@@ -2379,6 +2380,7 @@ class TestVersionSubmitUploadListed(VersionSubmitUploadMixin, UploadMixin, TestC
 
     def test_version_num_must_be_numerically_greater(self):
         self.version.update(version='0.0.1.0')
+        self.version.file.update(is_signed=True)
         response = self.post(expected_status=200)
         assert pq(response.content)('ul.errorlist').text() == (
             'Version 0.0.1 must be greater than the previous approved version 0.0.1.0.'

--- a/src/olympia/signing/tests/test_views.py
+++ b/src/olympia/signing/tests/test_views.py
@@ -275,9 +275,9 @@ class TestUploadVersion(BaseUploadVersionTestMixin, TestCase):
         assert 'processed' in response.data
 
     def test_version_num_must_be_greater(self):
-        Version.objects.filter(addon__guid=self.guid, version='2.1.072').update(
-            version='3.1'
-        )
+        version = Version.objects.filter(addon__guid=self.guid, version='2.1.072')[0]
+        version.update(version='3.1')
+        version.file.update(is_signed=True)
 
         response = self.request('PUT', self.url(self.guid, '3.0'), channel='listed')
         assert response.status_code == 409
@@ -286,9 +286,9 @@ class TestUploadVersion(BaseUploadVersionTestMixin, TestCase):
         )
 
     def test_version_num_must_be_numerically_greater(self):
-        Version.objects.filter(addon__guid=self.guid, version='2.1.072').update(
-            version='3.0.0'
-        )
+        version = Version.objects.filter(addon__guid=self.guid, version='2.1.072')[0]
+        version.update(version='3.0.0')
+        version.file.update(is_signed=True)
 
         response = self.request('PUT', self.url(self.guid, '3.0'), channel='listed')
         assert response.status_code == 409

--- a/src/olympia/signing/views.py
+++ b/src/olympia/signing/views.py
@@ -15,7 +15,7 @@ from olympia import amo
 from olympia.access import acl
 from olympia.addons.models import Addon
 from olympia.addons.utils import (
-    is_version_number_not_greater_than_current,
+    validate_version_number_is_greater,
     webext_version_stats,
 )
 from olympia.amo.decorators import use_primary_db
@@ -240,9 +240,7 @@ class VersionView(APIView):
                     status.HTTP_400_BAD_REQUEST,
                 )
         if channel == amo.CHANNEL_LISTED and (
-            error_message := is_version_number_not_greater_than_current(
-                addon, version_string
-            )
+            error_message := validate_version_number_is_greater(addon, version_string)
         ):
             raise forms.ValidationError(
                 error_message,

--- a/src/olympia/signing/views.py
+++ b/src/olympia/signing/views.py
@@ -15,7 +15,7 @@ from olympia import amo
 from olympia.access import acl
 from olympia.addons.models import Addon
 from olympia.addons.utils import (
-    validate_version_number_is_greater,
+    validate_version_number_is_gt_latest_signed_listed_version,
     webext_version_stats,
 )
 from olympia.amo.decorators import use_primary_db
@@ -240,7 +240,9 @@ class VersionView(APIView):
                     status.HTTP_400_BAD_REQUEST,
                 )
         if channel == amo.CHANNEL_LISTED and (
-            error_message := validate_version_number_is_greater(addon, version_string)
+            error_message := validate_version_number_is_gt_latest_signed_listed_version(
+                addon, version_string
+            )
         ):
             raise forms.ValidationError(
                 error_message,


### PR DESCRIPTION
fixes #19964 (includes yet-another-rename of the utility function)