### PR TITLE
Bump minimum Firefox version required for MV3

### DIFF
--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -2860,9 +2860,9 @@ class VersionViewSetCreateUpdateMixin(RequestMixin):
         }
         assert list(version.compatible_apps.keys()) == [amo.FIREFOX, amo.ANDROID]
 
-    def test_compatibility_dict_100(self):
-        # 100.0 is valid per setUpTestData()
-        response = self.request(compatibility={'firefox': {'min': '100.0'}})
+    def test_compatibility_dict_109(self):
+        # 109.0 is valid per setUpTestData()
+        response = self.request(compatibility={'firefox': {'min': '109.0'}})
         assert response.status_code == self.SUCCESS_STATUS_CODE, response.content
         data = response.data
         self.addon.reload()
@@ -2870,7 +2870,7 @@ class VersionViewSetCreateUpdateMixin(RequestMixin):
         version = self.addon.find_latest_version(channel=None)
         assert data['compatibility'] == {
             # firefox max wasn't specified, so is the default max app version
-            'firefox': {'max': '*', 'min': '100.0'},
+            'firefox': {'max': '*', 'min': '109.0'},
         }
         assert list(version.compatible_apps.keys()) == [amo.FIREFOX]
 

--- a/src/olympia/constants/base.py
+++ b/src/olympia/constants/base.py
@@ -350,9 +350,8 @@ DEFAULT_STATIC_THEME_MIN_VERSION_ANDROID = '65.0'
 # Dicts are not compatible with Firefox for Android, only desktop is relevant.
 DEFAULT_WEBEXT_DICT_MIN_VERSION_FIREFOX = '61.0'
 
-# The default version of Firefox that (is planned to) support manifest version 3 (MV3)
-# This will probably have to be adjusted later.
-DEFAULT_WEBEXT_MIN_VERSION_MV3_FIREFOX = '100.0'
+# The version of Firefox that first supported manifest version 3 (MV3)
+DEFAULT_WEBEXT_MIN_VERSION_MV3_FIREFOX = '109.0'
 # We don't know if the Android min version will be different, but assume it might be.
 DEFAULT_WEBEXT_MIN_VERSION_MV3_ANDROID = DEFAULT_WEBEXT_MIN_VERSION_MV3_FIREFOX
 


### PR DESCRIPTION
Goes with https://github.com/mozilla/addons-server/issues/19766