### PR TITLE
Return `icons` object in autocomplete API response

### DIFF
--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -115,7 +115,7 @@ for autocomplete though, there are a couple key differences:
     :query string lang: Activate translations in the specific language for that query. (See :ref:`translated fields <api-overview-translations>`)
     :query string tag: Filter by exact tag name. Multiple tag names can be specified, separated by comma(s), in which case add-ons containing *all* specified tags are returned. See :ref:`available tags <tag-list>`
     :query string type: Filter by :ref:`add-on type <addon-detail-type>`.
-    :>json array results: An array of :ref:`add-ons <addon-detail-object>`. Only the ``id``, ``icon_url``, ``name``, ``promoted``, ``type`` and ``url`` fields are supported though.
+    :>json array results: An array of :ref:`add-ons <addon-detail-object>`. Only the ``id``, ``icon_url``, ``icons``, ``name``, ``promoted``, ``type`` and ``url`` fields are supported though.
 
 
 ------

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -1492,7 +1492,7 @@ class ESAddonSerializer(BaseESSerializer, AddonSerializer):
 
 class ESAddonAutoCompleteSerializer(ESAddonSerializer):
     class Meta(ESAddonSerializer.Meta):
-        fields = ('id', 'icon_url', 'name', 'promoted', 'type', 'url')
+        fields = ('id', 'icon_url', 'icons', 'name', 'promoted', 'type', 'url')
         model = Addon
 
     def get_url(self, obj):

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -1545,6 +1545,7 @@ class TestESAddonAutoCompleteSerializer(ESTestCase):
             'id',
             'name',
             'icon_url',
+            'icons',
             'type',
             'url',
             'promoted',
@@ -1552,6 +1553,11 @@ class TestESAddonAutoCompleteSerializer(ESTestCase):
         assert result['id'] == self.addon.pk
         assert result['name'] == {'en-US': str(self.addon.name)}
         assert result['icon_url'] == absolutify(self.addon.get_icon_url(64))
+        assert result['icons'] == {
+            '32': absolutify(self.addon.get_icon_url(32)),
+            '64': absolutify(self.addon.get_icon_url(64)),
+            '128': absolutify(self.addon.get_icon_url(128)),
+        }
         assert result['type'] == 'extension'
         assert result['url'] == self.addon.get_absolute_url()
         assert result['promoted'] == self.addon.promoted is None


### PR DESCRIPTION
Fixes #19838
