### PR TITLE
"Upgrade" datetime.strptime()/dateutil.parser.parse() where possible

### DIFF
--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -30,7 +30,6 @@ from django.utils.encoding import force_str
 from django.utils.html import escape
 
 import pytest
-from dateutil.parser import parse as dateutil_parser
 from rest_framework.reverse import reverse as drf_reverse
 from rest_framework.settings import api_settings
 from rest_framework.test import APIClient, APIRequestFactory
@@ -490,15 +489,7 @@ class TestCase(PatchMixin, InitializeSessionMixin, test.TestCase):
         """
         Make sure the datetime is within a minute from `now`.
         """
-
-        # Try parsing the string if it's not a datetime.
-        if isinstance(dt, str):
-            try:
-                dt = dateutil_parser(dt)
-            except ValueError as e:
-                raise AssertionError(f'Expected valid date; got {dt}\n{e}')
-
-        if not dt:
+        if not dt or not isinstance(dt, datetime.datetime):
             raise AssertionError('Expected datetime; got %s' % dt)
 
         dt_later_ts = time.mktime((dt + timedelta(minutes=1)).timetuple())

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -489,7 +489,7 @@ class TestCase(PatchMixin, InitializeSessionMixin, test.TestCase):
         """
         Make sure the datetime is within a minute from `now`.
         """
-        if not dt or not isinstance(dt, datetime.datetime):
+        if not dt or not isinstance(dt, datetime):
             raise AssertionError('Expected datetime; got %s' % dt)
 
         dt_later_ts = time.mktime((dt + timedelta(minutes=1)).timetuple())

--- a/src/olympia/api/serializers.py
+++ b/src/olympia/api/serializers.py
@@ -63,8 +63,7 @@ class BaseESSerializer(serializers.ModelSerializer):
         # Don't be picky about microseconds here. We get them some time
         # so we have to support them. So let's strip microseconds and handle
         # the datetime in a unified way.
-        value = value.partition('.')[0]
-        return datetime.strptime(value, '%Y-%m-%dT%H:%M:%S')
+        return datetime.fromisoformat(value.partition('.')[0])
 
     def _attach_fields(self, obj, data, field_names):
         """Attach fields to fake instance."""

--- a/src/olympia/users/tests/test_views.py
+++ b/src/olympia/users/tests/test_views.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 from django.conf import settings
 from django.urls import reverse
 
-from dateutil.parser import parse
 from pyquery import PyQuery as pq
 
 from olympia import amo
@@ -59,7 +58,9 @@ class TestSessionLength(UserViewBase):
         # The user's session should be valid for at least four weeks (near a
         # month).
         four_weeks_from_now = datetime.now() + timedelta(days=28)
-        expiry = parse(cookie['expires']).replace(tzinfo=None)
+        expiry = datetime.strptime(
+            cookie['expires'], '%a, %d %b %Y %H:%M:%S %Z'
+        ).replace(tzinfo=None)
 
         assert cookie.value != ''
         assert expiry >= four_weeks_from_now


### PR DESCRIPTION
- `strptime()` is faster than `dateutile.parser.parse()` to parse a fixed format
- `fromisoformat()` is faster than `strptime()` to parse an iso 8601 date

Fixes #20003