### PR TITLE
Add a message to the comments box when Approve or a Reject action is selected.

### DIFF
--- a/src/olympia/reviewers/tests/test_forms.py
+++ b/src/olympia/reviewers/tests/test_forms.py
@@ -272,6 +272,28 @@ class TestReviewForm(TestCase):
         assert form.is_valid()
         assert not form.errors
 
+    def test_boilerplate(self):
+        self.grant_permission(self.request.user, 'Addons:Review')
+        self.addon.update(status=amo.STATUS_NOMINATED)
+        self.version.file.update(status=amo.STATUS_AWAITING_REVIEW)
+        form = self.get_form()
+        doc = pq(str(form['action']))
+        assert (
+            doc('input')[0].attrib.get('data-value')
+            == 'Thank you for your contribution.'
+        )
+        assert doc('input')[1].attrib.get('data-value') == (
+            "This add-on didn't pass review because of the following "
+            'problems:\n\n1) '
+        )
+        assert doc('input')[2].attrib.get('data-value') == (
+            "This add-on didn't pass review because of the following "
+            'problems:\n\n1) '
+        )
+        assert doc('input')[3].attrib.get('data-value') is None
+        assert doc('input')[4].attrib.get('data-value') is None
+        assert doc('input')[5].attrib.get('data-value') is None
+
     def test_comments_and_action_required_by_default(self):
         self.grant_permission(self.request.user, 'Addons:Review')
         form = self.get_form()

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -614,8 +614,8 @@ class ReviewHelper:
             can_approve_multiple = False
 
         # Definitions for all actions.
-        boilerplate_for_approve = _('Thank you for your contribution.')
-        boilerplate_for_reject = _(
+        boilerplate_for_approve = 'Thank you for your contribution.'
+        boilerplate_for_reject = (
             "This add-on didn't pass review because of the following problems:\n\n1) "
         )
 

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -614,6 +614,11 @@ class ReviewHelper:
             can_approve_multiple = False
 
         # Definitions for all actions.
+        boilerplate_for_approve = _('Thank you for your contribution.')
+        boilerplate_for_reject = _(
+            "This add-on didn't pass review because of the following problems:\n\n1) "
+        )
+
         actions['public'] = {
             'method': self.handler.approve_latest_version,
             'minimal': False,
@@ -632,6 +637,7 @@ class ReviewHelper:
             ),
             'allows_reasons': not is_static_theme,
             'requires_reasons': False,
+            'boilerplate_text': boilerplate_for_approve,
         }
         actions['reject'] = {
             'method': self.handler.reject_latest_version,
@@ -653,6 +659,7 @@ class ReviewHelper:
             ),
             'allows_reasons': True,
             'requires_reasons': not is_static_theme,
+            'boilerplate_text': boilerplate_for_reject,
         }
         actions['approve_content'] = {
             'method': self.handler.approve_content,
@@ -719,6 +726,7 @@ class ReviewHelper:
             'available': (can_reject_multiple),
             'allows_reasons': True,
             'requires_reasons': not is_static_theme,
+            'boilerplate_text': boilerplate_for_reject,
         }
         actions['unreject_multiple_versions'] = {
             'method': self.handler.unreject_multiple_versions,

--- a/static/js/zamboni/reviewers.js
+++ b/static/js/zamboni/reviewers.js
@@ -60,13 +60,27 @@ function initReviewActions() {
   function showForm(element, pageload) {
     var $element = $(element),
       value = $element.find('input').val(),
-      $data_toggle = $('form.review-form').find('.data-toggle');
+      $data_toggle = $('form.review-form').find('.data-toggle'),
+      $comments = $('#id_comments');
 
     pageload = pageload || false;
     $element.closest('.review-actions').addClass('on');
     $('.review-actions .action_nav ul li').removeClass('on-tab');
     $element.find('input').prop('checked', true);
 
+    // Input message into empty comments textbox.
+    if ($comments.val().length === 0) {
+      if ($element.text().trim() === 'Approve') {
+        insertAtCursor($comments, 'Thank you for your contribution.');
+      } else if (
+        ['Reject', 'Reject Multiple Versions'].includes($element.text().trim())
+      ) {
+        insertAtCursor(
+          $comments,
+          "This add-on didn't pass review because of the following problems:\n\n1)",
+        );
+      }
+    }
     $element.addClass('on-tab');
 
     if (pageload) {

--- a/static/js/zamboni/reviewers.js
+++ b/static/js/zamboni/reviewers.js
@@ -61,7 +61,8 @@ function initReviewActions() {
     var $element = $(element),
       value = $element.find('input').val(),
       $data_toggle = $('form.review-form').find('.data-toggle'),
-      $comments = $('#id_comments');
+      $comments = $('#id_comments'),
+      boilerplate_text = $element.find('input').attr('data-value');
 
     pageload = pageload || false;
     $element.closest('.review-actions').addClass('on');
@@ -69,17 +70,8 @@ function initReviewActions() {
     $element.find('input').prop('checked', true);
 
     // Input message into empty comments textbox.
-    if ($comments.val().length === 0) {
-      if ($element.text().trim() === 'Approve') {
-        insertAtCursor($comments, 'Thank you for your contribution.');
-      } else if (
-        ['Reject', 'Reject Multiple Versions'].includes($element.text().trim())
-      ) {
-        insertAtCursor(
-          $comments,
-          "This add-on didn't pass review because of the following problems:\n\n1)",
-        );
-      }
+    if ($comments.val().length === 0 && boilerplate_text) {
+      insertAtCursor($comments, boilerplate_text);
     }
     $element.addClass('on-tab');
 


### PR DESCRIPTION
Fixes #19981 

This is a quick and dirty way of implementing this. If we don't need these messages to be translated this might be good enough. Otherwise we probably have to get tricky with the Django form.
