### PR TITLE
Set fields with an expensive default when initializing models in `ESAddonSerializer`

### DIFF
--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -838,6 +838,8 @@ def user_factory(**kw):
     email = kw.pop('email', '%s@mozîlla.com' % identifier)
     if 'last_login_ip' not in kw:
         kw['last_login_ip'] = '127.0.0.1'
+    if 'auth_id' not in kw:
+        kw['auth_id'] = random.randint(1, 42)  # Cheaper default.
     user = UserProfile.objects.create(username=username, email=email, **kw)
     return user
 


### PR DESCRIPTION
When a model `__init__()` is called, fields are set to their default values, which can sometimes have a significant cost when they are callables. This is notably the case for `UserProfile.auth_id`, and to a lesser extend `created`.

While we're at it also provide a cheaper default for `auth_id` in tests.

Fixes #20022