### PR TITLE
Rewrite the way recommendation server URLs are built for clarity

### DIFF
--- a/src/olympia/discovery/tests/test_utils.py
+++ b/src/olympia/discovery/tests/test_utils.py
@@ -64,10 +64,10 @@ def test_call_recommendation_server_some_parameters(requests_get, requests_post)
     url = 'http://example.com/whatever/'
     taar_timeout = settings.RECOMMENDATION_ENGINE_TIMEOUT
     requests_get.return_value = HttpResponse(json.dumps({'results': ['@lolwut']}))
-    data = {'some': 'params', 'and': 'more'}
+    data = {'some': 'params', 'and': 'moré'}
     call_recommendation_server(url, valid_client_id, data)
     requests_get.assert_called_with(
-        url + valid_client_id + '/?and=more&some=params', timeout=taar_timeout
+        url + valid_client_id + '/?and=mor%C3%A9&some=params', timeout=taar_timeout
     )
     assert not requests_post.called
 

--- a/src/olympia/discovery/utils.py
+++ b/src/olympia/discovery/utils.py
@@ -33,17 +33,12 @@ def call_recommendation_server(server, client_id_or_guid, data, verb='get'):
     ) and not amo.VALID_CLIENT_ID.match(client_id_or_guid):
         # That parameter was weird, don't call the recommendation server.
         return None
+    # Build the URL, always ending with a slash.
+    endpoint = urljoin(server, f'{client_id_or_guid}/')
     if verb == 'get':
-        params = OrderedDict(sorted(data.items(), key=lambda t: t[0]))
-        endpoint = urljoin(
-            server,
-            '{}/{}{}'.format(
-                client_id_or_guid, '?' if params else '', urlencode(params)
-            ),
-        )
-
+        if params := OrderedDict(sorted(data.items(), key=lambda t: t[0])):
+            endpoint += f'?{urlencode(params)}'
     else:
-        endpoint = urljoin(server, '%s/' % client_id_or_guid)
         request_kwargs['json'] = data
     try:
         with statsd.timer('services.recommendations'):


### PR DESCRIPTION
Supports #16063 (but no change in behavior, it turns out we were already doing the right thing)