### PR TITLE
refactor addon update nominated status

### DIFF
--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -587,12 +587,7 @@ class DeveloperVersionSerializer(VersionSerializer):
         if self.addon:
             # self.addon is None when creating a new add-on
             statsd.incr(f'addons.submission.version.{channel_text}')
-            if (
-                self.addon.status == amo.STATUS_NULL
-                and self.addon.has_complete_metadata()
-                and upload.channel == amo.CHANNEL_LISTED
-            ):
-                self.addon.update(status=amo.STATUS_NOMINATED)
+            self.addon.update_status()
         else:
             statsd.incr(f'addons.submission.addon.{channel_text}')
 
@@ -1201,12 +1196,7 @@ class AddonSerializer(serializers.ModelSerializer):
             {**validated_data.get('version', {}), 'addon': addon}
         )
 
-        if (
-            addon.status == amo.STATUS_NULL
-            and addon.has_complete_metadata()
-            and upload.channel == amo.CHANNEL_LISTED
-        ):
-            addon.update(status=amo.STATUS_NOMINATED)
+        addon.update_status()
 
         return addon
 

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -2120,7 +2120,7 @@ class TestUpdateStatus(TestCase):
 
         version_factory(addon=addon, file_kw={'status': amo.STATUS_AWAITING_REVIEW})
         addon.reload()
-        # Because it don't have complete metadata the status isn't changed
+        # Because it doesn't have complete metadata the status isn't changed
         assert not addon.has_complete_metadata(), addon.get_required_metadata()
         addon.update_status()
         assert addon.status == amo.STATUS_NULL

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -2916,7 +2916,7 @@ class TestExtensionsQueues(TestCase):
         )
         unexpected_addons['disabled_addon'] = addon_factory(status=amo.STATUS_DISABLED)
         version_review_flags_factory(
-            version=unexpected_addons['disabled_addon'].current_version,
+            version=unexpected_addons['disabled_addon'].versions.get(),
             needs_human_review_by_mad=True,
         )
         unexpected_addons['disabled_version_addon'] = addon_factory()

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -1689,7 +1689,7 @@ class TestReplacementAddonSerializer(TestCase):
         assert result['replacement'] == []
 
         # Double check that the test is good and it will work once public.
-        addon.update(status=amo.STATUS_APPROVED)
+        addon.versions.get().file.update(status=amo.STATUS_APPROVED)
         result = self.serialize(rep)
         assert result['replacement'] == ['newstuff@mozilla']
 
@@ -1745,7 +1745,7 @@ class TestReplacementAddonSerializer(TestCase):
         assert result['replacement'] == []
 
         # Double check that the test is good and it will work once public.
-        addon.update(status=amo.STATUS_APPROVED)
+        addon.versions.get().file.update(status=amo.STATUS_APPROVED)
         result = self.serialize(rep)
         assert result['replacement'] == ['newstuff@mozilla']
 

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -644,6 +644,7 @@ def _get_created(created):
 
 def addon_factory(status=amo.STATUS_APPROVED, version_kw=None, file_kw=None, **kw):
     version_kw = version_kw or {}
+    file_kw = file_kw or {}
 
     # Disconnect signals until the last save.
     post_save.disconnect(
@@ -703,6 +704,15 @@ def addon_factory(status=amo.STATUS_APPROVED, version_kw=None, file_kw=None, **k
         PromotedAddon.objects.create(addon=addon, group_id=promoted_group.id)
         if 'promotion_approved' not in version_kw:
             version_kw['promotion_approved'] = True
+
+    if 'status' not in file_kw and version_kw.get('channel') != amo.CHANNEL_UNLISTED:
+        match status:
+            case amo.STATUS_APPROVED:
+                file_kw['status'] = amo.STATUS_APPROVED
+            case amo.STATUS_NOMINATED:
+                file_kw['status'] = amo.STATUS_AWAITING_REVIEW
+            case _:
+                file_kw['status'] = amo.STATUS_DISABLED
 
     version = version_factory(file_kw, addon=addon, **version_kw)
     addon.update_version()

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -250,6 +250,7 @@ class TestDashboard(HubTest):
         self.make_addon_unlisted(self.addon)
         version = version_factory(addon=self.addon, channel=amo.CHANNEL_LISTED)
         version.update(license=None)
+        self.addon.update(status=amo.STATUS_NULL)
         self.addon.reload()
         assert not self.addon.has_complete_metadata()
 
@@ -1790,6 +1791,7 @@ class TestHasCompleteMetadataRedirects(TestCase):
         self.request = RequestFactory().get('developers/addon/a3615/edit')
         self.request.user = UserProfile.objects.get(email='admin@mozilla.com')
         self.addon = Addon.objects.get(id=3615)
+        self.addon.current_version.file.update(status=amo.STATUS_AWAITING_REVIEW)
         self.addon.update(status=amo.STATUS_NULL)
         self.addon = Addon.objects.get(id=3615)
         assert self.addon.has_complete_metadata(), self.addon.get_required_metadata()

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -1734,7 +1734,8 @@ class TestRequestReview(TestCase):
         orig_date = datetime.now() - timedelta(days=30)
         # Pretend it was nominated in the past:
         self.version.update(nomination=orig_date)
-        self.addon.update(status=amo.STATUS_NULL)
+        self.version.file.update(status=amo.STATUS_DISABLED)
+        self.addon.update_status()
         response = self.client.post(self.public_url)
         self.assert3xx(response, self.redirect_url)
         assert self.get_addon().status == amo.STATUS_NOMINATED

--- a/src/olympia/devhub/utils.py
+++ b/src/olympia/devhub/utils.py
@@ -350,6 +350,5 @@ def create_version_for_upload(addon, upload, channel, parsed_data=None):
         # The add-on's status will be STATUS_NULL when its first version is
         # created because the version has no files when it gets added and it
         # gets flagged as invalid. We need to manually set the status.
-        if addon.status == amo.STATUS_NULL and channel == amo.CHANNEL_LISTED:
-            addon.update(status=amo.STATUS_NOMINATED)
+        addon.update_status()
         return version

--- a/src/olympia/devhub/utils.py
+++ b/src/olympia/devhub/utils.py
@@ -347,8 +347,8 @@ def create_version_for_upload(addon, upload, channel, parsed_data=None):
         statsd.incr(
             f'signing.submission.{"addon" if new_addon else "version"}.{channel_name}'
         )
-        # The add-on's status will be STATUS_NULL when its first version is
-        # created because the version has no files when it gets added and it
-        # gets flagged as invalid. We need to manually set the status.
+        # The add-on's status will be STATUS_NULL when its first version is created
+        # because the version has no files when it gets added and it gets flagged as
+        # invalid. Addon.update_status will set the status to NOMINATATED.
         addon.update_status()
         return version

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -106,8 +106,6 @@ class TestReviewHelperBase(TestCase):
         human_review=True,
     ):
         mail.outbox = []
-        ActivityLog.objects.for_addons(self.helper.addon).delete()
-        self.addon.update(status=status, type=type)
         self.file.update(status=file_status)
         if channel == amo.CHANNEL_UNLISTED:
             self.make_addon_unlisted(self.addon)
@@ -117,6 +115,8 @@ class TestReviewHelperBase(TestCase):
         self.helper = self.get_helper(
             content_review=content_review, human_review=human_review
         )
+        self.addon.update(status=status, type=type)
+        ActivityLog.objects.for_addons(self.helper.addon).delete()
         data = self.get_data().copy()
         self.helper.set_data(data)
 

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -1033,7 +1033,8 @@ class ReviewBase:
         # is at least one public file or it won't make the addon public.
         self.set_file(amo.STATUS_APPROVED, self.file)
         self.set_promoted()
-        self.set_addon()
+        if self.set_addon_status:
+            self.set_addon()
 
         if self.human_review:
             # No need for a human review anymore in this channel.
@@ -1089,7 +1090,8 @@ class ReviewBase:
         status = self.addon.status
 
         self.set_file(amo.STATUS_DISABLED, self.file)
-        self.set_addon()
+        if self.set_addon_status:
+            self.set_addon()
 
         if self.human_review:
             # Clear needs human review flags, but only on the latest version:
@@ -1427,6 +1429,8 @@ class ReviewBase:
 
 
 class ReviewAddon(ReviewBase):
+    set_addon_status = True
+
     def log_public_message(self):
         log.info('Making %s public' % (self.addon))
 
@@ -1435,6 +1439,8 @@ class ReviewAddon(ReviewBase):
 
 
 class ReviewFiles(ReviewBase):
+    set_addon_status = False
+
     def log_public_message(self):
         log.info(
             'Making %s files %s public'

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -836,9 +836,9 @@ class ReviewBase:
         self.content_review = content_review
         self.redirect_url = None
 
-    def set_addon(self, **kw):
+    def set_addon(self):
         """Alter addon, set reviewed timestamp on version being reviewed."""
-        self.addon.update(**kw)
+        self.addon.update_status()
         self.version.update(reviewed=datetime.now())
 
     def set_data(self, data):
@@ -1033,8 +1033,7 @@ class ReviewBase:
         # is at least one public file or it won't make the addon public.
         self.set_file(amo.STATUS_APPROVED, self.file)
         self.set_promoted()
-        if self.set_addon_status:
-            self.set_addon(status=amo.STATUS_APPROVED)
+        self.set_addon()
 
         if self.human_review:
             # No need for a human review anymore in this channel.
@@ -1089,9 +1088,8 @@ class ReviewBase:
         # Hold onto the status before we change it.
         status = self.addon.status
 
-        if self.set_addon_status:
-            self.set_addon(status=amo.STATUS_NULL)
         self.set_file(amo.STATUS_DISABLED, self.file)
+        self.set_addon()
 
         if self.human_review:
             # Clear needs human review flags, but only on the latest version:
@@ -1429,8 +1427,6 @@ class ReviewBase:
 
 
 class ReviewAddon(ReviewBase):
-    set_addon_status = True
-
     def log_public_message(self):
         log.info('Making %s public' % (self.addon))
 
@@ -1439,8 +1435,6 @@ class ReviewAddon(ReviewBase):
 
 
 class ReviewFiles(ReviewBase):
-    set_addon_status = False
-
     def log_public_message(self):
         log.info(
             'Making %s files %s public'

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -1405,7 +1405,7 @@ class ReviewBase:
 
         if self.data['versions']:
             # if these are listed versions then the addon status may need updating
-            self.addon.update_nominated_status(self.user)
+            self.addon.update_status(self.user)
 
     def notify_about_auto_approval_delay(self, version):
         """Notify developers of the add-on when their version has not been


### PR DESCRIPTION
fixes #19773 - but restating what I noted in the issue:
- we've got to stop changing the add-on status manually for this to be a complete fix, really.  Which is a massive task when a) our tests do it **everywhere** and b) we still need to set the status manually for `STATUS_DELETED` and `STATUS_DISABLED`.  That said, with the signals what pretty much happens is: if the status is manually set to the wrong state it gets reset to the correct state which just means extra database writes and unnecessary logging in our tests.
- the case of setting `STATUS_NOMINATED` and requiring complete metadata was unclear.  I went with the closest scenario to now, where an existing `STATUS_NULL` requires complete metadata to upgrade, but other statuses will downgrade to `STATUS_NOMINATED` without requiring complete metadata.