### PR TITLE
Add maxlength to textarea/input widgets and display missing errors in devhub

### DIFF
--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -1281,13 +1281,17 @@ class BaseModelSerializerAndFormMixin:
                     field.max_length = max_length
                     # Normally setting max_length on the field would be enough,
                     # but because we're late, after the field's __init__(), we
-                    # also need to convert that into a validator ourselves if
-                    # the field requires it. Unfortunately some fields
-                    # (FileField) do not work like that and instead deal with
-                    # max_length dynamically, with a custom error message that
-                    # is generated dynamically, so we need to avoid those.
-                    # # If a compatible error message for max_length is set, or
-                    # no message at all, we're good.
+                    # also need to:
+                    # - Update the widget attributes again, for form fields
+                    if hasattr(field, 'widget'):
+                        field.widget.attrs.update(field.widget_attrs(field.widget))
+                    # - Convert that max_length into a validator ourselves if
+                    #   the field requires it. Unfortunately some fields
+                    #   (FileField) do not work like that and instead deal with
+                    #   max_length dynamically, with a custom error message
+                    #   that is generated dynamically, so we need to avoid
+                    #   those. If a compatible error message for max_length is
+                    #   set, or no message at all, we're good.
                     message = getattr(field, 'error_messages', {}).get('max_length')
                     if message is None or re.findall(r'\{.*?\}', str(message)) == [
                         '{max_length}'

--- a/src/olympia/devhub/templates/devhub/addons/edit/technical.html
+++ b/src/olympia/devhub/templates/devhub/addons/edit/technical.html
@@ -69,6 +69,7 @@
             </th>
             <td>
               {% if editable %}
+                {{ whiteboard_form.public.errors }}
                 {{ whiteboard_form.public }}
               {% else %}
                 {% call empty_unless(whiteboard.public) %}{{ whiteboard.public }}{% endcall %}

--- a/src/olympia/devhub/templates/devhub/addons/submit/describe.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/describe.html
@@ -229,6 +229,7 @@
             </p>
           {% endif %}
         </div>
+        {{ reviewer_form.approval_notes.errors }}
         {{ reviewer_form.approval_notes }}
         <p>{{ _('These notes will only be visible to you and our reviewers.') }}</p>
       </div>

--- a/src/olympia/devhub/templates/devhub/addons/submit/describe_minimal.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/describe_minimal.html
@@ -13,6 +13,7 @@
       {{ _('Release Notes:') }}
       </label>
       <p>{{ _("Let your users know what's new and what's changed in this version.") }}</p>
+      {{ reviewer_form.release_notes.errors }}
       {{ reviewer_form.release_notes }}
       <p>{{ _('These notes will appear on the detail page.') }}</p>
     </div>
@@ -33,6 +34,7 @@
           </p>
         {% endif %}
       </div>
+      {{ reviewer_form.approval_notes.errors }}
       {{ reviewer_form.approval_notes }}
       <p>{{ _('These notes will only be visible to you and our reviewers.') }}</p>
     </div>

--- a/src/olympia/devhub/templates/devhub/versions/list.html
+++ b/src/olympia/devhub/templates/devhub/versions/list.html
@@ -127,7 +127,8 @@
             <div class="dev-review-reply">
               <form class="dev-review-reply-form" action="{{ drf_url('version-reviewnotes-list', addon.id, version.id) }}"
                     data-session-id="{{ session_id }}" data-history="#{{ version.id }}-review-history" data-no-csrf>
-                  <textarea name="comments" placeholder="{{ _('Leave a reply') }}"></textarea>
+                  {# This is not a django form, an XHR goes through to the form action on submit #}
+                  <textarea maxlength="{{ comments_maxlength }}" name="comments" placeholder="{{ _('Leave a reply') }}"></textarea>
                   <button type="submit" class="submit" >{{ _('Reply') }}</button>
               </form>
             </div>

--- a/src/olympia/devhub/tests/test_forms.py
+++ b/src/olympia/devhub/tests/test_forms.py
@@ -381,6 +381,8 @@ class TestPreviewForm(TestCase):
         form = forms.PreviewForm(
             {'caption': 'û' * 281, 'upload_hash': name, 'position': 1}
         )
+        assert form.fields['caption'].max_length == 280
+        assert form.fields['caption'].widget.attrs['maxlength'] == '280'
         assert not form.is_valid()
         assert form.errors == {
             'caption': ['Ensure this value has at most 280 characters (it has 281).']
@@ -605,6 +607,8 @@ class TestDescribeForm(TestCase):
             request=self.request,
             instance=Addon.objects.get(),
         )
+        assert form.fields['support_url'].max_length == 255
+        assert form.fields['support_url'].widget.attrs['maxlength'] == '255'
         assert not form.is_valid()
         assert form.errors['support_url'] == [
             'Enter a valid URL.',
@@ -617,6 +621,8 @@ class TestDescribeForm(TestCase):
             request=self.request,
             instance=Addon.objects.get(),
         )
+        assert form.fields['support_email'].max_length == 100
+        assert form.fields['support_email'].widget.attrs['maxlength'] == '100'
         assert not form.is_valid()
         assert form.errors['support_email'] == [
             'Ensure this value has at most 100 characters (it has 101).',
@@ -735,6 +741,8 @@ class TestDescribeForm(TestCase):
             request=self.request,
             instance=delicious,
         )
+        assert form.fields['description'].max_length == 15000
+        assert form.fields['description'].widget.attrs['maxlength'] == '15000'
         assert not form.is_valid()
         assert form.errors == {
             'description': [
@@ -982,6 +990,8 @@ class TestAdditionalDetailsForm(TestCase):
             request=self.request,
             instance=self.addon,
         )
+        assert form.fields['homepage'].max_length == 255
+        assert form.fields['homepage'].widget.attrs['maxlength'] == '255'
         assert not form.is_valid()
         assert form.errors['homepage'] == [
             'Enter a valid URL.',
@@ -1079,6 +1089,8 @@ class TestAddonFormTechnical(TestCase):
             instance=addon,
             request=request,
         )
+        assert form.fields['developer_comments'].max_length == 3000
+        assert form.fields['developer_comments'].widget.attrs['maxlength'] == '3000'
         assert not form.is_valid()
         assert form.errors == {
             'developer_comments': [

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -632,6 +632,8 @@ class TestVersion(TestCase):
         review_form.attrib['action'] == api_url
         review_form.attrib['data-session-id'] == self.client.session.session_key
         review_form.attrib['data-history'] == '#%s-review-history' % v2.id
+        textarea = doc('.dev-review-reply-form textarea')[0]
+        assert textarea.attrib['maxlength'] == '100000'
 
     def test_version_history_mixed_channels(self):
         v1 = self.version
@@ -760,6 +762,24 @@ class TestVersionEditDetails(TestVersionEditBase):
         data = self.formset(approval_notes='ü' * 3001, release_notes='è' * 3002)
         response = self.client.post(self.url, data)
         assert response.status_code == 200
+        assert (
+            response.context['version_form'].fields['approval_notes'].max_length == 3000
+        )
+        assert (
+            response.context['version_form'].fields['approval_notes'].max_length == 3000
+        )
+        assert (
+            response.context['version_form']
+            .fields['release_notes']
+            .widget.attrs['maxlength']
+            == '3000'
+        )
+        assert (
+            response.context['version_form']
+            .fields['release_notes']
+            .widget.attrs['maxlength']
+            == '3000'
+        )
         assert response.context['version_form'].errors == {
             'approval_notes': [
                 'Ensure this value has at most 3000 characters (it has 3001).'

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -31,7 +31,7 @@ from olympia import amo
 from olympia.access import acl
 from olympia.accounts.utils import redirect_for_login
 from olympia.accounts.views import logout_user
-from olympia.activity.models import ActivityLog, VersionLog
+from olympia.activity.models import ActivityLog, CommentLog, VersionLog
 from olympia.activity.utils import log_and_notify
 from olympia.addons.models import (
     Addon,
@@ -1252,6 +1252,7 @@ def version_list(request, addon_id, addon):
         'versions': versions,
         'session_id': request.session.session_key,
         'is_admin': is_admin,
+        'comments_maxlength': CommentLog._meta.get_field('comments').max_length,
     }
     return TemplateResponse(request, 'devhub/versions/list.html', context=data)
 


### PR DESCRIPTION
Fixes #20069
Fixes https://github.com/mozilla/addons-server/issues/20071

We could add more tests but I feel that's enough ?