### PR TITLE
Introduce a base ModelAdmin class, use it everywhere

### DIFF
--- a/src/olympia/abuse/admin.py
+++ b/src/olympia/abuse/admin.py
@@ -12,7 +12,7 @@ from rangefilter.filter import DateRangeFilter as DateRangeFilterBase
 from olympia import amo
 from olympia.access import acl
 from olympia.addons.models import Addon, AddonApprovalsCounter
-from olympia.amo.admin import CommaSearchInAdminMixin
+from olympia.amo.admin import AMOModelAdmin
 from olympia.ratings.models import Rating
 from olympia.translations.utils import truncate_text
 
@@ -159,7 +159,7 @@ class DateRangeFilter(FakeChoicesMixin, DateRangeFilterBase):
         yield all_choice
 
 
-class AbuseReportAdmin(CommaSearchInAdminMixin, admin.ModelAdmin):
+class AbuseReportAdmin(AMOModelAdmin):
     class Media:
         css = {'all': ('css/admin/abuse_reports.css',)}
 

--- a/src/olympia/abuse/tests/test_admin.py
+++ b/src/olympia/abuse/tests/test_admin.py
@@ -86,10 +86,10 @@ class TestAbuse(TestCase):
         assert response.status_code == 403
 
     def test_list(self):
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(8):
             # - 2 queries to get the user and their permissions
-            # - 2 queries for a count of the total number of items
-            #   (duplicated by django itself)
+            # - 1 query for a count of the total number of items
+            #     (show_full_result_count=False so we avoid the duplicate)
             # - 2 savepoints
             # - 1 to get the abuse reports
             # - 2 for the date hierarchy

--- a/src/olympia/access/admin.py
+++ b/src/olympia/access/admin.py
@@ -2,6 +2,8 @@ from django.urls import reverse
 from django.contrib import admin
 from django.utils.html import format_html
 
+from olympia.amo.admin import AMOModelAdmin
+
 from .models import Group, GroupUser
 
 
@@ -22,7 +24,7 @@ class GroupUserInline(admin.TabularInline):
     user_profile_link.short_description = 'User Profile'
 
 
-class GroupAdmin(admin.ModelAdmin):
+class GroupAdmin(AMOModelAdmin):
     raw_id_fields = ('users',)
     ordering = ('name',)
     list_display = ('name', 'rules', 'notes')

--- a/src/olympia/activity/admin.py
+++ b/src/olympia/activity/admin.py
@@ -1,10 +1,12 @@
 from django.contrib import admin
 
-from .models import ActivityLog, ReviewActionReasonLog
+from olympia.amo.admin import AMOModelAdmin
 from olympia.reviewers.models import ReviewActionReason
 
+from .models import ActivityLog, ReviewActionReasonLog
 
-class ActivityLogAdmin(admin.ModelAdmin):
+
+class ActivityLogAdmin(AMOModelAdmin):
     list_display = (
         'created',
         'user',
@@ -37,7 +39,7 @@ class ActivityLogAdmin(admin.ModelAdmin):
         return False
 
 
-class ReviewActionReasonLogAdmin(admin.ModelAdmin):
+class ReviewActionReasonLogAdmin(AMOModelAdmin):
     date_hierarchy = 'created'
     fields = (
         'created',

--- a/src/olympia/addons/admin.py
+++ b/src/olympia/addons/admin.py
@@ -22,6 +22,7 @@ from olympia import amo
 from olympia.access import acl
 from olympia.activity.models import ActivityLog
 from olympia.addons.models import Addon, AddonUser
+from olympia.amo.admin import AMOModelAdmin
 from olympia.amo.forms import AMOModelForm
 from olympia.amo.utils import send_mail
 from olympia.files.models import File
@@ -143,7 +144,7 @@ class FileInline(admin.TabularInline):
         return qs.select_related('version')
 
 
-class AddonAdmin(admin.ModelAdmin):
+class AddonAdmin(AMOModelAdmin):
     class Media:
         css = {
             'all': (
@@ -464,7 +465,7 @@ class AddonAdmin(admin.ModelAdmin):
     activity.short_description = _('Activity Logs')
 
 
-class FrozenAddonAdmin(admin.ModelAdmin):
+class FrozenAddonAdmin(AMOModelAdmin):
     raw_id_fields = ('addon',)
 
 
@@ -492,7 +493,7 @@ class ReplacementAddonForm(AMOModelForm):
         return path
 
 
-class ReplacementAddonAdmin(admin.ModelAdmin):
+class ReplacementAddonAdmin(AMOModelAdmin):
     list_display = ('guid', 'path', 'guid_slug', '_url')
     form = ReplacementAddonForm
 
@@ -528,7 +529,7 @@ class ReplacementAddonAdmin(admin.ModelAdmin):
 
 
 @admin.register(models.AddonRegionalRestrictions)
-class AddonRegionalRestrictionsAdmin(admin.ModelAdmin):
+class AddonRegionalRestrictionsAdmin(AMOModelAdmin):
     list_display = ('created', 'modified', 'addon__name', 'excluded_regions')
     fields = ('created', 'modified', 'addon', 'excluded_regions')
     raw_id_fields = ('addon',)

--- a/src/olympia/addons/tests/test_admin.py
+++ b/src/olympia/addons/tests/test_admin.py
@@ -163,10 +163,11 @@ class TestAddonAdmin(TestCase):
         self.grant_permission(user, 'Addons:Edit')
         self.client.force_login(user)
 
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(8):
             # - 2 savepoints
             # - 2 user and groups
-            # - 2 count (repeated, django admin limitation)
+            # - 1 count
+            #    (show_full_result_count=False so we avoid the duplicate)
             # - 1 main query
             # - 1 translations
             # - 1 all authors in one query

--- a/src/olympia/applications/admin.py
+++ b/src/olympia/applications/admin.py
@@ -1,9 +1,11 @@
 from django.contrib import admin
 
+from olympia.amo.admin import AMOModelAdmin
+
 from .models import AppVersion
 
 
-class AppVersionAdmin(admin.ModelAdmin):
+class AppVersionAdmin(AMOModelAdmin):
     list_display = (
         'version',
         'application',

--- a/src/olympia/bandwagon/admin.py
+++ b/src/olympia/bandwagon/admin.py
@@ -3,6 +3,7 @@ from django.contrib import admin
 
 from olympia import amo
 from olympia.access import acl
+from olympia.amo.admin import AMOModelAdmin
 
 from .models import Collection, CollectionAddon
 
@@ -33,7 +34,7 @@ class CollectionAddonInline(admin.TabularInline):
         return CollectionAdmin(Collection, self.admin_site).has_add_permission(request)
 
 
-class CollectionAdmin(admin.ModelAdmin):
+class CollectionAdmin(AMOModelAdmin):
     list_display = (
         'name',
         'slug',

--- a/src/olympia/blocklist/admin.py
+++ b/src/olympia/blocklist/admin.py
@@ -12,6 +12,7 @@ from django.utils.translation import gettext
 
 from olympia.activity.models import ActivityLog
 from olympia.addons.models import Addon
+from olympia.amo.admin import AMOModelAdmin
 from olympia.amo.utils import HttpResponseTemporaryRedirect
 from olympia.versions.models import Version
 
@@ -186,7 +187,7 @@ class BlockAdminAddMixin:
 
 
 @admin.register(BlocklistSubmission)
-class BlocklistSubmissionAdmin(admin.ModelAdmin):
+class BlocklistSubmissionAdmin(AMOModelAdmin):
     list_display = (
         'blocks_count',
         'action',
@@ -585,7 +586,7 @@ class BlocklistSubmissionAdmin(admin.ModelAdmin):
 
 
 @admin.register(Block)
-class BlockAdmin(BlockAdminAddMixin, admin.ModelAdmin):
+class BlockAdmin(BlockAdminAddMixin, AMOModelAdmin):
     list_display = ('guid', 'min_version', 'max_version', 'updated_by', 'modified')
     readonly_fields = (
         'addon_guid',

--- a/src/olympia/discovery/admin.py
+++ b/src/olympia/discovery/admin.py
@@ -9,6 +9,7 @@ from django.db.models import Prefetch
 
 from olympia import promoted
 from olympia.addons.models import Addon
+from olympia.amo.admin import AMOModelAdmin
 from olympia.discovery.models import DiscoveryItem
 from olympia.hero.admin import SecondaryHeroAdmin, PrimaryHeroImageAdmin
 from olympia.hero.models import SecondaryHero, PrimaryHeroImage
@@ -75,7 +76,7 @@ class PositionChinaFilter(PositionFilter):
     parameter_name = 'position_china'
 
 
-class DiscoveryItemAdmin(admin.ModelAdmin):
+class DiscoveryItemAdmin(AMOModelAdmin):
     class Media:
         css = {'all': ('css/admin/discovery.css',)}
 

--- a/src/olympia/discovery/tests/test_admin.py
+++ b/src/olympia/discovery/tests/test_admin.py
@@ -333,19 +333,19 @@ class TestDiscoveryAdmin(TestCase):
         # 2. savepoint (because we're in tests)
         # 3. select groups
         # 4. pagination count
-        # 5. pagination count (double…)
-        # 6. select list of discovery items, ordered
-        # 7. prefetch add-ons
-        # 8. select translations for add-ons from 7.
-        # 9. savepoint (because we're in tests)
-        with self.assertNumQueries(9):
+        #    (show_full_result_count=False so we avoid the duplicate)
+        # 5. select list of discovery items, ordered
+        # 6. prefetch add-ons
+        # 7. select translations for add-ons from 7.
+        # 8. savepoint (because we're in tests)
+        with self.assertNumQueries(8):
             response = self.client.get(self.list_url, follow=True)
 
         DiscoveryItem.objects.create(addon=addon_factory(name='FooBâr 5'))
         DiscoveryItem.objects.create(addon=addon_factory(name='FooBâr 6'))
 
         # Ensure the count is stable
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(8):
             response = self.client.get(self.list_url, follow=True)
 
         assert response.status_code == 200

--- a/src/olympia/files/admin.py
+++ b/src/olympia/files/admin.py
@@ -1,11 +1,13 @@
 from django.contrib import admin
 from django.utils.html import format_html
 
+from olympia.amo.admin import AMOModelAdmin
+
 from .models import File
 
 
 @admin.register(File)
-class FileAdmin(admin.ModelAdmin):
+class FileAdmin(AMOModelAdmin):
     view_on_site = False
 
     raw_id_fields = ('version',)

--- a/src/olympia/git/admin.py
+++ b/src/olympia/git/admin.py
@@ -4,12 +4,12 @@ from django.urls import reverse
 from django.utils.html import format_html
 
 from olympia.addons.models import Addon
-
+from olympia.amo.admin import AMOModelAdmin
 from .models import GitExtractionEntry
 
 
 @admin.register(GitExtractionEntry)
-class GitExtractionEntryAdmin(admin.ModelAdmin):
+class GitExtractionEntryAdmin(AMOModelAdmin):
     actions = ['delete_selected']
     view_on_site = False
 

--- a/src/olympia/git/tests/test_admin.py
+++ b/src/olympia/git/tests/test_admin.py
@@ -30,14 +30,15 @@ class TestGitExtractionEntryAdmin(TestCase):
     def test_list_view(self):
         GitExtractionEntry.objects.create(addon=addon_factory())
 
-        # 9 queries:
+        # 8 queries:
         # - 2 transaction savepoints because of tests
         # - 2 request user and groups
-        # - 2 COUNT(*) on extraction entries for pagination and total display
+        # - 1 COUNT(*) on extraction entries for pagination
+        #     (show_full_result_count=False so we avoid the duplicate)
         # - 1 all git extraction entries in one query
         # - 1 all add-ons in one query
         # - 1 all add-ons translations in one query
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(8):
             response = self.client.get(self.list_url)
 
         assert response.status_code == 200

--- a/src/olympia/hero/admin.py
+++ b/src/olympia/hero/admin.py
@@ -8,6 +8,7 @@ from django.core.files.storage import default_storage as storage
 from django.forms import BaseInlineFormSet
 from django.utils.safestring import mark_safe
 
+from olympia.amo.admin import AMOModelAdmin
 from olympia.amo.utils import resize_image
 
 from .models import PrimaryHero, SecondaryHeroModule, PrimaryHeroImage
@@ -54,7 +55,7 @@ class PrimaryHeroInline(admin.StackedInline):
         return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
 
-class PrimaryHeroImageAdmin(admin.ModelAdmin):
+class PrimaryHeroImageAdmin(AMOModelAdmin):
     class Media:
         css = {'all': ('css/admin/discovery.css',)}
 
@@ -97,7 +98,7 @@ class SecondaryHeroModuleInline(admin.StackedInline):
     formset = HeroModuleInlineFormSet
 
 
-class SecondaryHeroAdmin(admin.ModelAdmin):
+class SecondaryHeroAdmin(AMOModelAdmin):
     class Media:
         css = {'all': ('css/admin/discovery.css',)}
 

--- a/src/olympia/promoted/admin.py
+++ b/src/olympia/promoted/admin.py
@@ -3,6 +3,7 @@ from django.db.models import Prefetch
 from django.forms.models import modelformset_factory
 
 from olympia.addons.models import Addon
+from olympia.amo.admin import AMOModelAdmin
 from olympia.hero.admin import PrimaryHeroInline
 from olympia.versions.models import Version
 
@@ -57,7 +58,7 @@ class PromotedApprovalInline(admin.TabularInline):
         return qs
 
 
-class PromotedAddonAdmin(admin.ModelAdmin):
+class PromotedAddonAdmin(AMOModelAdmin):
     list_display = (
         'addon__name',
         'group_id',

--- a/src/olympia/promoted/tests/test_admin.py
+++ b/src/olympia/promoted/tests/test_admin.py
@@ -73,17 +73,17 @@ class TestPromotedAddonAdmin(TestCase):
         self.grant_permission(user, 'Discovery:Edit')
         self.client.force_login(user)
 
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(9):
             # 1. select current user
             # 2. savepoint (because we're in tests)
             # 3. select groups
             # 4. pagination count
-            # 5. pagination count (double…)
-            # 6. select list of promoted addons, ordered
-            # 7. prefetch add-ons
-            # 8. select translations for add-ons from 7.
-            # 9. prefetch PromotedApprovals for add-ons current_versions
-            # 10. savepoint (because we're in tests)
+            #    (show_full_result_count=False so we avoid the duplicate)
+            # 5. select list of promoted addons, ordered
+            # 6. prefetch add-ons
+            # 7. select translations for add-ons from 7.
+            # 8. prefetch PromotedApprovals for add-ons current_versions
+            # 9. savepoint (because we're in tests)
             response = self.client.get(self.list_url, follow=True)
 
         assert response.status_code == 200
@@ -99,7 +99,7 @@ class TestPromotedAddonAdmin(TestCase):
         )
         assert not unlisted.addon.current_version
         assert not unlisted.addon._current_version
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(9):
             self.client.get(self.list_url, follow=True)
 
     def test_can_edit_with_discovery_edit_permission(self):

--- a/src/olympia/ratings/admin.py
+++ b/src/olympia/ratings/admin.py
@@ -5,6 +5,7 @@ from django.utils.translation import gettext_lazy as _
 from django.urls import reverse
 
 from olympia.addons.models import Addon
+from olympia.amo.admin import AMOModelAdmin
 from olympia.translations.utils import truncate_text
 from olympia.zadmin.admin import related_single_content_link
 
@@ -45,7 +46,7 @@ class RatingTypeFilter(admin.SimpleListFilter):
         return queryset
 
 
-class RatingAdmin(admin.ModelAdmin):
+class RatingAdmin(AMOModelAdmin):
     raw_id_fields = (
         'addon',
         'version',

--- a/src/olympia/ratings/tests/test_admin.py
+++ b/src/olympia/ratings/tests/test_admin.py
@@ -95,10 +95,11 @@ class TestRatingAdmin(TestCase):
         self.grant_permission(user, 'Ratings:Moderate')
 
         self.client.force_login(user)
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(9):
             # - 2 Savepoint/release
             # - 2 user and its groups
-            # - 2 COUNT(*) (duplicated because of django)
+            # - 1 COUNT(*)
+            #     (show_full_result_count=False so we avoid the duplicate)
             # - 1 ratings themselves
             # - 1 related add-ons
             # - 1 related add-ons translations

--- a/src/olympia/reviewers/admin.py
+++ b/src/olympia/reviewers/admin.py
@@ -1,11 +1,12 @@
 from django.contrib import admin
 
+from olympia.amo.admin import AMOModelAdmin
 from olympia.translations.templatetags.jinja_helpers import truncate
 
 from .models import CannedResponse, ReviewActionReason, ReviewerScore
 
 
-class CannedResponseAdmin(admin.ModelAdmin):
+class CannedResponseAdmin(AMOModelAdmin):
     def truncate_response(obj):
         return truncate(obj.response, 50)
 
@@ -15,7 +16,7 @@ class CannedResponseAdmin(admin.ModelAdmin):
     list_filter = ('type',)
 
 
-class ReviewerScoreAdmin(admin.ModelAdmin):
+class ReviewerScoreAdmin(AMOModelAdmin):
     list_display = ('user', 'score', 'note_key', 'note', 'created')
     raw_id_fields = ('user', 'addon')
     fieldsets = (
@@ -29,7 +30,7 @@ class ReviewerScoreAdmin(admin.ModelAdmin):
     list_filter = ('note_key',)
 
 
-class ReviewActionReasonAdmin(admin.ModelAdmin):
+class ReviewActionReasonAdmin(AMOModelAdmin):
     list_display = ('name', 'addon_type', 'is_active')
     list_filter = (
         'addon_type',

--- a/src/olympia/scanners/admin.py
+++ b/src/olympia/scanners/admin.py
@@ -18,6 +18,7 @@ from urllib.parse import urljoin, urlparse
 from olympia import amo
 from olympia.access import acl
 from olympia.addons.models import Addon
+from olympia.amo.admin import AMOModelAdmin
 from olympia.amo.utils import is_safe_url
 from olympia.constants import scanners
 from olympia.constants.scanners import (
@@ -314,7 +315,7 @@ class ScannerResultChangeList(ChangeList):
         return '?%s' % p.urlencode()
 
 
-class AbstractScannerResultAdminMixin(admin.ModelAdmin):
+class AbstractScannerResultAdminMixin:
     actions = None
     view_on_site = False
     list_select_related = ('version',)
@@ -501,7 +502,7 @@ class AbstractScannerResultAdminMixin(admin.ModelAdmin):
     formatted_matched_rules.short_description = 'Matched rules'
 
 
-class AbstractScannerRuleAdminMixin(admin.ModelAdmin):
+class AbstractScannerRuleAdminMixin:
     view_on_site = False
 
     list_display = ('__str__', 'scanner', 'action', 'is_active')
@@ -580,7 +581,7 @@ class AbstractScannerRuleAdminMixin(admin.ModelAdmin):
 
 
 @admin.register(ScannerResult)
-class ScannerResultAdmin(AbstractScannerResultAdminMixin, admin.ModelAdmin):
+class ScannerResultAdmin(AbstractScannerResultAdminMixin, AMOModelAdmin):
     fields = (
         'id',
         'upload',
@@ -783,7 +784,7 @@ class ScannerResultAdmin(AbstractScannerResultAdminMixin, admin.ModelAdmin):
 
 
 @admin.register(ScannerQueryResult)
-class ScannerQueryResultAdmin(AbstractScannerResultAdminMixin, admin.ModelAdmin):
+class ScannerQueryResultAdmin(AbstractScannerResultAdminMixin, AMOModelAdmin):
     fields = (
         'id',
         'formatted_addon',
@@ -907,12 +908,12 @@ class ScannerQueryResultAdmin(AbstractScannerResultAdminMixin, admin.ModelAdmin)
 
 
 @admin.register(ScannerRule)
-class ScannerRuleAdmin(AbstractScannerRuleAdminMixin, admin.ModelAdmin):
+class ScannerRuleAdmin(AbstractScannerRuleAdminMixin, AMOModelAdmin):
     pass
 
 
 @admin.register(ScannerQueryRule)
-class ScannerQueryRuleAdmin(AbstractScannerRuleAdminMixin, admin.ModelAdmin):
+class ScannerQueryRuleAdmin(AbstractScannerRuleAdminMixin, AMOModelAdmin):
     list_display = (
         '__str__',
         'scanner',

--- a/src/olympia/scanners/tests/test_admin.py
+++ b/src/olympia/scanners/tests/test_admin.py
@@ -262,11 +262,12 @@ class TestScannerResultAdmin(TestCase):
         )
         deleted_addon.delete()
 
-        with self.assertNumQueries(14):
+        with self.assertNumQueries(13):
             # 14 queries:
             # - 2 transaction savepoints because of tests
             # - 2 request user and groups
-            # - 2 COUNT(*) on scanners results for pagination and total display
+            # - 1 COUNT(*) on scanners results for pagination
+            #     (show_full_result_count=False so we avoid the duplicate)
             # - 2 get all available rules for filtering
             # - 1 scanners results and versions in one query
             # - 1 all add-ons in one query

--- a/src/olympia/tags/admin.py
+++ b/src/olympia/tags/admin.py
@@ -1,9 +1,11 @@
 from django.contrib import admin
 
+from olympia.amo.admin import AMOModelAdmin
+
 from .models import Tag
 
 
-class TagAdmin(admin.ModelAdmin):
+class TagAdmin(AMOModelAdmin):
     list_display = ('tag_text', 'num_addons', 'created', 'enable_for_random_shelf')
     ordering = ('-created',)
     search_fields = ('^tag_text',)

--- a/src/olympia/users/admin.py
+++ b/src/olympia/users/admin.py
@@ -31,8 +31,8 @@ from olympia.access import acl
 from olympia.activity.models import ActivityLog, IPLog
 from olympia.addons.models import Addon, AddonUser
 from olympia.amo.admin import (
-    CommaSearchInAdminMixin,
-    CommaSearchInAdminChangeListSearchForm,
+    AMOModelAdmin,
+    AMOModelAdminChangeListSearchForm,
     SEARCH_VAR,
 )
 from olympia.amo.fields import IPAddressBinaryField
@@ -61,10 +61,10 @@ class GroupUserInline(admin.TabularInline):
 
 
 @admin.register(UserProfile)
-class UserAdmin(CommaSearchInAdminMixin, admin.ModelAdmin):
+class UserAdmin(AMOModelAdmin):
     list_display = ('__str__', 'email', 'last_login', 'is_public', 'deleted')
     # pk and IP address search are supported without needing to specify them in
-    # search_fields (see `CommaSearchInAdminMixin.get_search_results()` and
+    # search_fields (see `AMOModelAdminMixin.get_search_results()` and
     # `get_search_id_field()` as well as `get_search_results()` below)
     search_fields = ('email__like',)
     # We can trigger search by ids with only one search term, if somehow an
@@ -79,7 +79,6 @@ class UserAdmin(CommaSearchInAdminMixin, admin.ModelAdmin):
     # A custom field used in search json in zadmin, not django.admin.
     search_fields_response = 'email'
     inlines = (GroupUserInline,)
-    show_full_result_count = False  # Turn off to avoid the query.
 
     readonly_fields = (
         'abuse_reports_by_this_user',
@@ -174,7 +173,7 @@ class UserAdmin(CommaSearchInAdminMixin, admin.ModelAdmin):
         # We don't have access to the _search_form instance the ChangeList
         # creates, so make our own just for this method to grab the cleaned
         # search term.
-        search_form = CommaSearchInAdminChangeListSearchForm(request.GET)
+        search_form = AMOModelAdminChangeListSearchForm(request.GET)
         search_term = (
             search_form.cleaned_data.get(SEARCH_VAR) if search_form.is_valid() else None
         )
@@ -595,7 +594,7 @@ class UserAdmin(CommaSearchInAdminMixin, admin.ModelAdmin):
 
 
 @admin.register(DeniedName)
-class DeniedNameAdmin(admin.ModelAdmin):
+class DeniedNameAdmin(AMOModelAdmin):
     list_display = search_fields = ('name',)
     view_on_site = False
     model = DeniedName
@@ -649,7 +648,7 @@ class DeniedNameAdmin(admin.ModelAdmin):
 
 
 @admin.register(IPNetworkUserRestriction)
-class IPNetworkUserRestrictionAdmin(admin.ModelAdmin):
+class IPNetworkUserRestrictionAdmin(AMOModelAdmin):
     list_display = ('network', 'restriction_type')
     list_filter = ('restriction_type',)
     search_fields = ('=network',)
@@ -657,21 +656,21 @@ class IPNetworkUserRestrictionAdmin(admin.ModelAdmin):
 
 
 @admin.register(EmailUserRestriction)
-class EmailUserRestrictionAdmin(admin.ModelAdmin):
+class EmailUserRestrictionAdmin(AMOModelAdmin):
     list_display = ('email_pattern', 'restriction_type')
     list_filter = ('restriction_type',)
     search_fields = ('^email_pattern',)
 
 
 @admin.register(DisposableEmailDomainRestriction)
-class DisposableEmailDomainRestrictionAdmin(admin.ModelAdmin):
+class DisposableEmailDomainRestrictionAdmin(AMOModelAdmin):
     list_display = ('domain', 'restriction_type')
     list_filter = ('restriction_type',)
     search_fields = ('^domain',)
 
 
 @admin.register(UserRestrictionHistory)
-class UserRestrictionHistoryAdmin(admin.ModelAdmin):
+class UserRestrictionHistoryAdmin(AMOModelAdmin):
     raw_id_fields = ('user',)
     readonly_fields = (
         'restriction',
@@ -705,7 +704,7 @@ class UserRestrictionHistoryAdmin(admin.ModelAdmin):
 
 
 @admin.register(UserHistory)
-class UserHistoryAdmin(admin.ModelAdmin):
+class UserHistoryAdmin(AMOModelAdmin):
     view_on_site = False
     search_fields = ('=user__id', '^email')
 

--- a/src/olympia/versions/admin.py
+++ b/src/olympia/versions/admin.py
@@ -1,5 +1,7 @@
 from django.contrib import admin
 
+from olympia.amo.admin import AMOModelAdmin
+
 from .models import (
     DeniedInstallOrigin,
     InstallOrigin,
@@ -17,13 +19,13 @@ class VersionReviewerFlagsInline(admin.StackedInline):
     view_on_site = False
 
 
-class LicenseAdmin(admin.ModelAdmin):
+class LicenseAdmin(AMOModelAdmin):
     list_display = ('id', 'name', 'builtin', 'url')
     list_filter = ('builtin',)
     ordering = ('builtin',)
 
 
-class VersionAdmin(admin.ModelAdmin):
+class VersionAdmin(AMOModelAdmin):
     class Media:
         css = {'all': ('css/admin/l10n.css',)}
         js = ('js/admin/l10n.js',)
@@ -55,7 +57,7 @@ class VersionAdmin(admin.ModelAdmin):
     inlines = (VersionReviewerFlagsInline,)
 
 
-class InstallOriginAdmin(admin.ModelAdmin):
+class InstallOriginAdmin(AMOModelAdmin):
     view_on_site = False
     raw_id_fields = ('version',)
     list_display = ('id', 'addon_guid', 'version_version', 'origin', 'base_domain')
@@ -84,7 +86,7 @@ class InstallOriginAdmin(admin.ModelAdmin):
     version_version.short_description = 'Version'
 
 
-class DeniedInstallOriginAdmin(admin.ModelAdmin):
+class DeniedInstallOriginAdmin(AMOModelAdmin):
     view_on_site = False
     list_display = ('id', 'hostname_pattern', 'include_subdomains')
     search_fields = ('hostname_pattern',)

--- a/src/olympia/versions/tests/test_admin.py
+++ b/src/olympia/versions/tests/test_admin.py
@@ -51,10 +51,11 @@ class TestInstallOriginAdmin(TestCase):
         user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, '*:*')
         self.client.force_login(user)
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(6):
             # - 2 SAVEPOINTs
             # - 2 user & groups
-            # - 2 counts (total + pagination)
+            # - 1 count
+            #     (show_full_result_count=False so we avoid the duplicate)
             # - 1 install origins
             response = self.client.get(list_url, follow=True)
         assert response.status_code == 200


### PR DESCRIPTION
Set `show_full_result_count = False` on it to avoid a useless `COUNT(*)` query (Used by django to show the full total of objets in the db with no filters/search applied, which we don't need most of the time)

Fixes #19801