### PR TITLE
Adding a timeout parameter to the HTTP request

### DIFF
--- a/src/olympia/lib/remote_settings.py
+++ b/src/olympia/lib/remote_settings.py
@@ -67,7 +67,8 @@ class RemoteSettings:
         # check if the bucket exists
         bucket_url = f'{settings.REMOTE_SETTINGS_WRITER_URL}buckets/{self.bucket}'
         headers = self.headers
-        response = requests.get(bucket_url, headers=headers)
+        # Warning: The 'requests.get' method does not use any 'timeout' threshold which may cause program to hang indefinitely.
+        response = requests.get(bucket_url, headers=headers, timeout=0.4)
         data = {'permissions': {'read': ['system.Everyone']}}
         if response.status_code == 403:
             # lets create them


### PR DESCRIPTION
In the file: remote_settings.py, method: setup_test_server_collection, a request is made without a timeout parameter. The requests.get method in Python does not use any default timeout value and should be explicitly set. Otherwise, if the recipient server is unavailable to service the request, the application making the request may stall indefinitely.  

What should be the timeout value? A good practice is to set it under 500ms. This PR proposes the value to be 400ms. However, this may vary depending on the use case. More information is available in: https://docs.python-requests.org/en/latest/user/advanced/#timeouts