### PR TITLE
Relax restrictions for google-cloud-bigquery and protobuf

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,9 +41,6 @@ updates:
   - dependency-name: click
     versions:
     - ">= 9"
-  - dependency-name: google-cloud-bigquery
-    versions:
-    - ">= 3.0.0"
   - dependency-name: protobuf
     versions:
-    - ">= 4.0.0"
+    - ">= 5.0.0"


### PR DESCRIPTION
Since 3.4.1 google-cloud-bigquery now has `pyarrow` as an optional dependency, and it is compatible with protobuf > 4.21.5 (but < 5.0.0)