### PR TITLE
Make double-escaping tests for _TransWidget more robust

### DIFF
--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -139,25 +139,6 @@ class BaseTestEditDescribe(BaseTestEdit):
         doc = pq(response.content)
         assert doc('form').attr('action') != old_edit
 
-    def test_edit_summary_escaping(self):
-        data = self.get_dict()
-        data['summary'] = '<b>oh my</b>'
-        response = self.client.post(self.describe_edit_url, data)
-        assert response.status_code == 200
-
-        addon = self.get_addon()
-
-        # Fetch the page so the LinkifiedTranslation gets in cache.
-        response = self.client.get(reverse('devhub.addons.edit', args=[addon.slug]))
-        assert pq(response.content)('[data-name=summary]').html().strip() == (
-            '<span lang="en-us">&lt;b&gt;oh my&lt;/b&gt;</span>'
-        )
-
-        # Now make sure we don't have escaped content in the rendered form.
-        form = DescribeForm(instance=addon, request=req_factory_factory('/'))
-        html = pq('<body>%s</body>' % form['summary'])('[lang="en-us"]').html()
-        assert html.strip() == '<b>oh my</b>'
-
     def test_edit_as_developer(self):
         self.client.force_login(UserProfile.objects.get(email='regular@mozilla.com'))
         data = self.get_dict()

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -17,14 +17,12 @@ from olympia.amo.tests import (
     addon_factory,
     formset,
     initial,
-    req_factory_factory,
     SQUOTE_ESCAPED,
     TestCase,
     user_factory,
 )
 from olympia.amo.tests.test_helpers import get_image_path
 from olympia.amo.utils import image_size
-from olympia.devhub.forms import DescribeForm
 from olympia.tags.models import AddonTag, Tag
 from olympia.users.models import UserProfile
 from olympia.versions.models import VersionPreview

--- a/src/olympia/translations/tests/test_widgets.py
+++ b/src/olympia/translations/tests/test_widgets.py
@@ -7,22 +7,25 @@ from olympia.translations import models, widgets
 class TestWidget(TestCase):
     def test_avoid_purified_translation(self):
         # Even if we pass in a LinkifiedTranslation the widget switches to a
-        # normal Translation before rendering.
-        w = widgets.TransTextarea.widget()
+        # normal Translation before rendering (avoiding double-escaping)
+        widget = widgets.TransTextarea.widget()
         link = models.LinkifiedTranslation(
             localized_string='<b>yum yum</b>', locale='fr', id=10
         )
         link.clean()
-        widget = w.render('name', link)
-        assert pq(widget).html().strip() == '<b>yum yum</b>'
+        result = widget.render('name', link)
+        assert result == (
+            '<textarea name="name_fr" cols="40" rows="10" lang="fr">\n'
+            '&lt;b&gt;yum yum&lt;/b&gt;</textarea>'
+        )
 
     def test_default_locale(self):
-        w = widgets.TransTextarea()
-        result = w.render('name', '')
+        widget = widgets.TransTextarea()
+        result = widget.render('name', '')
         assert pq(result)('textarea:not([lang=init])').attr('lang') == 'en-us'
 
-        w.default_locale = 'pl'
-        result = w.render('name', '')
+        widget.default_locale = 'pl'
+        result = widget.render('name', '')
         assert pq(result)('textarea:not([lang=init])').attr('lang') == 'pl'
 
     def test_transinput(self):


### PR DESCRIPTION
The existing tests were misleading: the content _is_ escaped at some point, it has to before being displayed to the user (pyquery was buggy and unescaping...)

What we want to make sure is that we aren't rendering already escaped content, escaping it twice (once per the translation field, once per the django form widget render method)

Should fix tests in https://github.com/mozilla/addons-server/pull/20121