### PR TITLE
Add 1 second leeway when decoding JWT from FxA notifications

### DIFF
--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -788,6 +788,7 @@ class FxaNotificationView(FxAConfigMixin, APIView):
                         request_jwt,
                         algorithm,
                         audience=client_id,
+                        leeway=1,
                         algorithms=[verifying_key['alg']],
                     )
                 except (ValueError, TypeError, jwt.exceptions.PyJWTError) as e:


### PR DESCRIPTION
FxA sends `iat` as a float with milliseconds, pyjwt 2.6.0 compares with `datetime.now()` in seconds, causing issues. We add a short 1-second leeway to work around that.

Fixes #20197