### PR TITLE
manually set due_date and needs_human_review

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1784,7 +1784,12 @@ class Addon(OnChangeMixin, ModelBase):
         for version in self.versions.should_have_due_date(negate=True).filter(
             due_date__isnull=False
         ):
-            log.info('Version %r (%s) due_date cleared', version, version.id)
+            log.info(
+                'Version %r (%s) due_date of %s cleared',
+                version,
+                version.id,
+                version.due_date,
+            )
             version.update(due_date=None, _signal=False)
 
 

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -255,6 +255,21 @@
 
     {% if is_admin %}
     <ul class="admin_only">
+      {% if not version.needs_human_review %}
+        <li>
+          <button data-api-url="{{ drf_url('reviewers-addon-set-needs-human-review', addon.pk) }}"
+                  data-api-data="{&quot;version&quot;: {{ version.pk }}}"
+                  id="set_needs_human_review" type="button">{{ _('Set Needs Human Review') }}</button>
+        </li>
+      {% endif %}
+      <li {% if not version.due_date %}class="hidden"{% endif %}>
+        <label for="due_date_update">{{ _('Change Version Review Due Date') }}</label>
+        <input type="datetime-local" id="due_date_update"
+                {% if version.due_date %} value="{{ version.due_date.isoformat(timespec='seconds') }}" {% endif %}
+                data-api-data="{{ version.pk }}"
+                data-api-url="{{ drf_url('reviewers-addon-due-date', addon.pk) }}"
+        />
+      </li>
       {% if addon.is_deleted %}
         <li {% if not addon.is_guid_denied %}class="hidden"{% endif %}>
           <button data-api-url="{{ drf_url('reviewers-addon-allow-resubmission', addon.pk) }}"

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -1556,12 +1556,12 @@ class TestExtensionQueue(QueueTest):
         file_ = version2.file
 
         # Create another version for Nominated Two, v0.2, by "cloning" v0.1.
-        # Its creation date must be more recent than v0.1 for version ordering
-        # to work. Its due date must be coherent with that, but also
-        # not cause the queue order to change with respect to the other
-        # add-ons.
+        # Its creation date must be more recent than v0.1 for version ordering to work.
+        # Its due date must be coherent with that, but also not cause the queue order to
+        # change with respect to the other add-ons.
         version2.created = version2.created + timedelta(minutes=1)
-        version2.due_date = version2.due_date + timedelta(minutes=1)
+        version2_due_date = version2.due_date + timedelta(minutes=1)
+        version2.due_date = version2_due_date
         version2.pk = None
         version2.version = '0.2'
         version2.save()
@@ -1573,6 +1573,7 @@ class TestExtensionQueue(QueueTest):
 
         # disable old files like Version.from_upload() would.
         version2.disable_old_files()
+        version2.update(due_date=version2_due_date)
 
         response = self.client.get(self.url)
         assert response.status_code == 200
@@ -6368,6 +6369,12 @@ class TestAddonReviewerViewSet(TestCase):
         self.clear_pending_rejections_url = reverse_ns(
             'reviewers-addon-clear-pending-rejections', kwargs={'pk': self.addon.pk}
         )
+        self.due_date_url = reverse_ns(
+            'reviewers-addon-due-date', kwargs={'pk': self.addon.pk}
+        )
+        self.set_needs_human_review_url = reverse_ns(
+            'reviewers-addon-set-needs-human-review', kwargs={'pk': self.addon.pk}
+        )
 
     def test_subscribe_not_logged_in(self):
         response = self.client.post(self.subscribe_url_listed)
@@ -6802,6 +6809,40 @@ class TestAddonReviewerViewSet(TestCase):
         assert not VersionReviewerFlags.objects.filter(
             version__addon=self.addon, pending_content_rejection__isnull=False
         ).exists()
+
+    def test_due_date(self):
+        self.grant_permission(self.user, 'Reviews:Admin')
+        self.client.login_api(self.user)
+        version = self.addon.current_version
+        version.update(needs_human_review=True)
+        assert version.due_date
+        new_due_date = datetime.now() - timedelta(weeks=1)
+        response = self.client.post(
+            self.due_date_url,
+            data={
+                'version': version.id,
+                'due_date': new_due_date.isoformat(timespec='seconds'),
+            },
+        )
+        assert response.status_code == 202
+        version.reload()
+        self.assertCloseToNow(version.due_date, now=new_due_date)
+
+    def test_set_needs_human_review(self):
+        self.grant_permission(self.user, 'Reviews:Admin')
+        self.client.login_api(self.user)
+        version = self.addon.current_version
+        assert not version.needs_human_review
+        response = self.client.post(
+            self.set_needs_human_review_url, data={'version': version.id}
+        )
+        assert response.status_code == 202
+        version.reload()
+        assert version.needs_human_review
+        # We strip off the milliseconds in the response
+        assert response.data == {
+            'due_date': version.due_date.isoformat(timespec='seconds')
+        }
 
 
 class TestAddonReviewerViewSetJsonValidation(TestCase):

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -1295,6 +1295,38 @@ class AddonReviewerViewSet(GenericViewSet):
             }
         )
 
+    @drf_action(
+        detail=True,
+        methods=['post'],
+        permission_classes=[GroupPermission(amo.permissions.REVIEWS_ADMIN)],
+    )
+    def due_date(self, request, **kwargs):
+        version = get_object_or_404(
+            Version, pk=request.data.get('version'), addon_id=kwargs['pk']
+        )
+        status_code = status.HTTP_202_ACCEPTED
+        try:
+            due_date = datetime.fromisoformat(request.data.get('due_date'))
+            version.update(due_date=due_date)
+        except TypeError:
+            status_code = status.HTTP_400_BAD_REQUEST
+        return Response(status=status_code)
+
+    @drf_action(
+        detail=True,
+        methods=['post'],
+        permission_classes=[GroupPermission(amo.permissions.REVIEWS_ADMIN)],
+    )
+    def set_needs_human_review(self, request, **kwargs):
+        version = get_object_or_404(
+            Version, pk=request.data.get('version'), addon_id=kwargs['pk']
+        )
+        status_code = status.HTTP_202_ACCEPTED
+        version.update(needs_human_review=True)
+        due_date = version.reload().due_date
+        due_date_string = due_date.isoformat(timespec='seconds') if due_date else None
+        return Response(status=status_code, data={'due_date': due_date_string})
+
 
 class ReviewAddonVersionMixin:
     permission_classes = [

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -192,7 +192,7 @@ class VersionManager(ManagerBase):
             ),
             channel=amo.CHANNEL_UNLISTED,
         )
-        return method(
+        is_pre_review_version = Q(
             Q(file__status=amo.STATUS_AWAITING_REVIEW)
             & Q(reviewerflags__pending_rejection__isnull=True)
             & Q(
@@ -201,7 +201,10 @@ class VersionManager(ManagerBase):
                 | requires_manual_listed_approval_and_is_listed
                 | requires_manual_unlisted_approval_and_is_unlisted
             )
-        ).using('default')
+        )
+        return method(Q(needs_human_review=True) | is_pre_review_version).using(
+            'default'
+        )
 
 
 class UnfilteredVersionManagerForRelations(VersionManager):
@@ -848,7 +851,9 @@ class Version(OnChangeMixin, ModelBase):
                 self.update(due_date=due_date, _signal=False)
         elif self.due_date:
             # otherwise it shouldn't have a due_date so clear it.
-            log.info('Version %r (%s) due_date cleared', self, self.id)
+            log.info(
+                'Version %r (%s) due_date of %s cleared', self, self.id, self.due_date
+            )
             self.update(due_date=None, _signal=False)
 
     @use_primary_db
@@ -1038,6 +1043,18 @@ class Version(OnChangeMixin, ModelBase):
             and self.get_review_status_for_auto_approval_and_delay_reject()
             or status
         )
+
+
+@receiver(
+    models.signals.post_save,
+    sender=Version,
+    dispatch_uid='version',
+)
+def update_due_date_for_needs_human_review_change(
+    sender, instance=None, update_fields=None, **kwargs
+):
+    if update_fields is None or 'needs_human_review' in update_fields:
+        instance.reset_due_date()
 
 
 class VersionReviewerFlags(ModelBase):

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -825,7 +825,13 @@ class TestVersion(TestCase):
         addon = Addon.objects.get(id=3615)
         version = addon.current_version
 
+        assert not version.should_have_due_date
+        # having the needs_human_review flag means a due dute is needed
+        version.update(needs_human_review=True)
+        assert version.should_have_due_date
+
         # Just a version awaiting review will be auto approved so won't need a due date
+        version.update(needs_human_review=False)
         version.file.update(status=amo.STATUS_AWAITING_REVIEW)
         assert not version.should_have_due_date
 
@@ -892,7 +898,13 @@ class TestVersion(TestCase):
         self.make_addon_unlisted(addon)
         version = addon.versions.first()
 
+        assert not version.should_have_due_date
+        # having the needs_human_review flag means a due dute is needed
+        version.update(needs_human_review=True)
+        assert version.should_have_due_date
+
         # Just a version awaiting review will be auto approved so won't need a due date
+        version.update(needs_human_review=False)
         version.file.update(status=amo.STATUS_AWAITING_REVIEW)
         assert not version.should_have_due_date
 
@@ -1001,6 +1013,17 @@ class TestVersion(TestCase):
             pending_content_rejection=None,
         )
         assert version.reload().due_date
+
+    def test_needs_human_review_signal(self):
+        addon = addon_factory()
+        version = addon.current_version
+        assert not version.due_date
+
+        version.update(needs_human_review=True)
+        assert version.reload().due_date
+
+        version.update(needs_human_review=False)
+        assert not version.reload().due_date
 
     def test_transformer_license(self):
         addon = Addon.objects.get(id=3615)

--- a/static/js/zamboni/reviewers.js
+++ b/static/js/zamboni/reviewers.js
@@ -256,6 +256,29 @@ function initExtraReviewActions() {
     }),
   );
 
+  $('#due_date_update').change(
+    _pd(function () {
+      var $input = $(this).prop('disabled', true); // Prevent double-send.
+      var apiUrl = $input.data('api-url');
+      var data = { due_date: $input.val(), version: $input.data('api-data') };
+      callReviewersAPI(apiUrl, 'post', data);
+    }),
+  );
+
+  $('#set_needs_human_review').click(
+    _pd(function () {
+      var $button = $(this).prop('disabled', true); // Prevent double-send.
+      var apiUrl = $button.data('api-url');
+      var data = $button.data('api-data') || null;
+      var $due_date_update_input = $('#due_date_update');
+      callReviewersAPI(apiUrl, 'post', data, function (response) {
+        $button.remove();
+        $due_date_update_input.parents('li').removeClass('hidden').show();
+        $due_date_update_input.val(response.due_date);
+      });
+    }),
+  );
+
   // One-off-style buttons.
   $('.more-actions button.oneoff[data-api-url]').click(
     _pd(function () {
@@ -263,7 +286,7 @@ function initExtraReviewActions() {
       var apiUrl = $button.data('api-url');
       var data = $button.data('api-data') || null;
       var method = $button.data('api-method') || 'post';
-      callReviewersAPI(apiUrl, method, data, function () {
+      callReviewersAPI(apiUrl, method, data, function (response) {
         $button.remove();
       });
     }),


### PR DESCRIPTION
fixes #19986 and fixes #20152 - `should_have_due_date` now sets a `due_date` for _any_ version that has `needs_human_review=True`, regardless of the other properties of the version/file/addon.  

Reviewer tools has an input to change the due date if one is already set (immediate update upon change with xhr request); and also set `needs_human_review` on a version, which will then show the due date widget if not already visible.

![Screenshot 2023-01-25 21 52 58](https://user-images.githubusercontent.com/768592/214700772-c7dfcb51-158c-4639-9e20-07ddb04756a1.png)
