### PR TITLE
Don't try to order querysets when counting in the admin

### DIFF
--- a/src/olympia/amo/admin.py
+++ b/src/olympia/amo/admin.py
@@ -76,6 +76,13 @@ class AMOModelAdminChangeList(ChangeList):
         self.root_queryset = old_root_queryset
         return queryset.count()
 
+    def get_ordering(self, request, queryset):
+        # Don't try to order results when counting, the annotations the
+        # ordering depends on do not exist and it's pointless anyway.
+        if 'for_count' in queryset.query.annotations:
+            return []
+        return super().get_ordering(request, queryset)
+
     def get_filters(self, request):
         # Cache added because our custom get_results()/get_results_count() will
         # cause get_filters() to be called twice, and it can generate some db


### PR DESCRIPTION
That fixes ordering by IP, without that changes with the optimizations made to querysets for counts we'd try ordering on an annotation that doesn't exist for that queryset... It'd be thrown away before reaching MySQL, but Django still complains that the field is invalid anyway.

Also fix the test in test_search_by_ip() to make sure to actually order by IP...

Fixes https://github.com/mozilla/addons-server/issues/20230