### PR TITLE
Improve search tooltip in amo admins

### DIFF
--- a/src/olympia/addons/tests/test_admin.py
+++ b/src/olympia/addons/tests/test_admin.py
@@ -248,12 +248,12 @@ class TestAddonAdmin(TestCase):
             'slug__startswith.'
         )
         assert doc('#searchbar-wrapper li').eq(0).text() == (
-            'If the query contains only numeric terms, search will be performed '
-            'against pk instead.'
+            'If the query contains only numeric terms, and there are at least 2 terms, '
+            'search will be performed against pk instead.'
         )
         assert doc('#searchbar-wrapper li').eq(1).text() == (
-            'If the query contains only IP addresses or networks, search will be '
-            'performed against IP addresses recorded for ADD_VERSION.'
+            'If the query contains only IP addresses or networks, separated by commas, '
+            'search will be performed against IP addresses recorded for ADD_VERSION.'
         )
 
     def test_search_by_ip(self):

--- a/src/olympia/addons/tests/test_admin.py
+++ b/src/olympia/addons/tests/test_admin.py
@@ -248,7 +248,7 @@ class TestAddonAdmin(TestCase):
             'slug__startswith.'
         )
         assert doc('#searchbar-wrapper li').eq(0).text() == (
-            'If the query contains only numeric terms, and there are at least 2 terms, '
+            'If the query contains only numeric terms, and there are 2 or more terms, '
             'search will be performed against pk instead.'
         )
         assert doc('#searchbar-wrapper li').eq(1).text() == (

--- a/src/olympia/amo/admin.py
+++ b/src/olympia/amo/admin.py
@@ -213,6 +213,9 @@ class AMOModelAdmin(admin.ModelAdmin):
                 'search_by_ip_actions_names': [
                     LOG_BY_ID[action].__name__ for action in self.search_by_ip_actions
                 ],
+                'minimum_search_terms_to_search_by_id': (
+                    self.minimum_search_terms_to_search_by_id
+                ),
             }
         )
         return super().changelist_view(request, extra_context=extra_context)

--- a/src/olympia/amo/templates/admin/change_list.html
+++ b/src/olympia/amo/templates/admin/change_list.html
@@ -11,7 +11,7 @@
                 {% if search_id_field or search_by_ip_actions_names or cl.model_admin.extra_list_filter_for_ip_searches %}
                     <ul>
                     {% if search_id_field %}
-                        <li>If the query contains only numeric terms,{% if minimum_search_terms_to_search_by_id %} and there are at least <strong>{{ minimum_search_terms_to_search_by_id }}</strong> terms,{% endif %} search will be performed against <strong>{{ search_id_field }}</strong> instead.</li>
+                        <li>If the query contains only numeric terms,{% if minimum_search_terms_to_search_by_id %} and there are <strong>{{ minimum_search_terms_to_search_by_id }}</strong> or more terms,{% endif %} search will be performed against <strong>{{ search_id_field }}</strong> instead.</li>
                     {% endif %}
                     {% if search_by_ip_actions_names %}
                         <li>If the query contains only IP addresses or networks, separated by commas, search will be performed against IP addresses recorded for {% for action in search_by_ip_actions_names %}<strong>{{ action }}</strong>{% if not forloop.last %}, {% endif %}{% endfor %}.</li>

--- a/src/olympia/amo/templates/admin/change_list.html
+++ b/src/olympia/amo/templates/admin/change_list.html
@@ -3,27 +3,27 @@
 {% block search %}
     <div id="searchbar-wrapper">
         {{ block.super }}
-        <div id="searchbar-explainer">
-            {% if search_fields %}
+        {% if search_fields %}
+            <div id="searchbar-explainer">
                 <p>
                     By default, search will be performed against {% for field in search_fields %}<strong>{{ field }}</strong>{% if not forloop.last %}, {% endif %}{% endfor %}.
                 </p>
                 {% if search_id_field or search_by_ip_actions_names or cl.model_admin.extra_list_filter_for_ip_searches %}
                     <ul>
                     {% if search_id_field %}
-                        <li>If the query contains only numeric terms, search will be performed against <strong>{{ search_id_field }}</strong> instead.</li>
+                        <li>If the query contains only numeric terms,{% if minimum_search_terms_to_search_by_id %} and there are at least <strong>{{ minimum_search_terms_to_search_by_id }}</strong> terms,{% endif %} search will be performed against <strong>{{ search_id_field }}</strong> instead.</li>
                     {% endif %}
                     {% if search_by_ip_actions_names %}
-                        <li>If the query contains only IP addresses or networks, search will be performed against IP addresses recorded for {% for action in search_by_ip_actions_names %}<strong>{{ action }}</strong>{% if not forloop.last %}, {% endif %}{% endfor %}.</li>
+                        <li>If the query contains only IP addresses or networks, separated by commas, search will be performed against IP addresses recorded for {% for action in search_by_ip_actions_names %}<strong>{{ action }}</strong>{% if not forloop.last %}, {% endif %}{% endfor %}.</li>
                     {% endif %}
                     </ul>
                 {% endif %}
-            {% endif %}
-            <p> To join multiple search terms, choose one of the following options: </p>
-            <ul>
-                <li>Separate multiple terms with a <code>,</code> (comma) to return {{ module_name|capfirst }} matching any term (joining terms with a <em>OR</em>).</li>
-                <li>Separate multiple terms with a <code>&nbsp;</code> (space) to return {{ module_name|capfirst }} matching any term (joining terms with a <em>OR</em>).</li>
-            </ul>
-        </div>
+                <p> To join multiple search terms, choose one of the following options: </p>
+                <ul>
+                    <li>Separate multiple terms with a <code>,</code> (comma) to return {{ module_name|capfirst }} matching any term (joining terms with a <em>OR</em>).</li>
+                    <li>Separate multiple terms with a <code>&nbsp;</code> (space) to return {{ module_name|capfirst }} matching any term (joining terms with a <em>AND</em>).</li>
+                </ul>
+            </div>
+        {% endif %}
     </div>
 {% endblock %}

--- a/src/olympia/ratings/tests/test_admin.py
+++ b/src/olympia/ratings/tests/test_admin.py
@@ -128,7 +128,7 @@ class TestRatingAdmin(TestCase):
             'By default, search will be performed against body.'
         )
         assert doc('#searchbar-wrapper li').eq(0).text() == (
-            'If the query contains only numeric terms, and there are at least 2 terms, '
+            'If the query contains only numeric terms, and there are 2 or more terms, '
             'search will be performed against addon instead.'
         )
         assert doc('#searchbar-wrapper li').eq(1).text() == (

--- a/src/olympia/ratings/tests/test_admin.py
+++ b/src/olympia/ratings/tests/test_admin.py
@@ -128,12 +128,13 @@ class TestRatingAdmin(TestCase):
             'By default, search will be performed against body.'
         )
         assert doc('#searchbar-wrapper li').eq(0).text() == (
-            'If the query contains only numeric terms, search will be performed '
-            'against addon instead.'
+            'If the query contains only numeric terms, and there are at least 2 terms, '
+            'search will be performed against addon instead.'
         )
         assert doc('#searchbar-wrapper li').eq(1).text() == (
-            'If the query contains only IP addresses or networks, search will be '
-            'performed against IP addresses recorded for ADD_RATING, EDIT_RATING.'
+            'If the query contains only IP addresses or networks, separated by commas, '
+            'search will be performed against IP addresses recorded for ADD_RATING, '
+            'EDIT_RATING.'
         )
 
     def test_search_by_ip(self):


### PR DESCRIPTION
- Fix description of `AND` queries
- Clarify IP search only works with `OR` (comma-separated)
- Obey `minimum_search_terms_to_search_by_id`
- Don't show on admins without search

Fixes #20180