### PR TITLE
Set a due date on versions belonging to add-ons with `auto_approval_delayed_until_unlisted`

### DIFF
--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -176,12 +176,10 @@ class VersionManager(ManagerBase):
         due date instead."""
         method = getattr(self, 'exclude' if negate else 'filter')
         is_theme = Q(addon__type__in=amo.GROUP_TYPE_THEME)
-        has_auto_approval_delayed = Q(
-            addon__reviewerflags__auto_approval_delayed_until__isnull=False
-        )
         requires_manual_listed_approval_and_is_listed = Q(
             Q(addon__reviewerflags__auto_approval_disabled=True)
             | Q(addon__reviewerflags__auto_approval_disabled_until_next_approval=True)
+            | Q(addon__reviewerflags__auto_approval_delayed_until__isnull=False)
             | Q(addon__promotedaddon__group_id__in=(g.id for g in PRE_REVIEW_GROUPS)),
             addon__status__in=(amo.VALID_ADDON_STATUSES),
             channel=amo.CHANNEL_LISTED,
@@ -190,6 +188,9 @@ class VersionManager(ManagerBase):
             Q(addon__reviewerflags__auto_approval_disabled_unlisted=True)
             | Q(
                 addon__reviewerflags__auto_approval_disabled_until_next_approval_unlisted=True  # noqa
+            )
+            | Q(
+                addon__reviewerflags__auto_approval_delayed_until_unlisted__isnull=False
             ),
             channel=amo.CHANNEL_UNLISTED,
         )
@@ -198,7 +199,6 @@ class VersionManager(ManagerBase):
             & Q(reviewerflags__pending_rejection__isnull=True)
             & Q(
                 is_theme
-                | has_auto_approval_delayed
                 | requires_manual_listed_approval_and_is_listed
                 | requires_manual_unlisted_approval_and_is_unlisted
             )

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -846,6 +846,7 @@ class TestVersion(TestCase):
         addon.reviewerflags.update(
             auto_approval_disabled=False,
             auto_approval_disabled_unlisted=True,
+            auto_approval_delayed_until_unlisted=datetime.now() + timedelta(hours=1),
             auto_approval_disabled_until_next_approval_unlisted=True,
         )
         assert not version.should_have_due_date
@@ -911,6 +912,7 @@ class TestVersion(TestCase):
         addon.reviewerflags.update(
             auto_approval_disabled_unlisted=False,
             auto_approval_disabled=True,
+            auto_approval_delayed_until=datetime.now() + timedelta(hours=1),
             auto_approval_disabled_until_next_approval=True,
         )
         assert not version.should_have_due_date
@@ -942,11 +944,11 @@ class TestVersion(TestCase):
         )
         assert version.should_have_due_date
 
-        # If auto_approval_delayed_until is present it should also have a
+        # If auto_approval_delayed_until_unlisted is present it should also have a
         # due_date
         addon.reviewerflags.update(
             auto_approval_disabled_until_next_approval_unlisted=False,
-            auto_approval_delayed_until=datetime.now() + timedelta(hours=1),
+            auto_approval_delayed_until_unlisted=datetime.now() + timedelta(hours=1),
         )
         assert version.should_have_due_date
 


### PR DESCRIPTION
Follow-up for https://github.com/mozilla/addons-server/issues/20250