### PR TITLE
Only set auto-approval delay for unlisted on the first submission

### DIFF
--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -512,8 +512,16 @@ class Version(OnChangeMixin, ModelBase):
             )
 
         # Unlisted versions approval is delayed depending on how far we are
-        # from creation of the add-on.
-        if channel == amo.CHANNEL_UNLISTED:
+        # from creation of the add-on. This is applied only once, during the
+        # first unlisted version creation (so the flag can be dropped by admins
+        # or reviewers, not affecting subsequent versions).
+        if (
+            channel == amo.CHANNEL_UNLISTED
+            and not addon.versions(manager='unfiltered_for_relations')
+            .filter(channel=amo.CHANNEL_UNLISTED)
+            .exclude(pk=version.pk)
+            .exists()
+        ):
             try:
                 INITIAL_DELAY_FOR_UNLISTED = int(
                     get_config('INITIAL_DELAY_FOR_UNLISTED')

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -2240,6 +2240,36 @@ class TestExtensionVersionFromUploadUnlistedDelay(TestVersionFromUpload):
             now=self.addon.created + timedelta(seconds=3600),
         )
 
+    def test_second_unlisted_version(self):
+        set_config('INITIAL_DELAY_FOR_UNLISTED', '3600')
+        self.addon.update(created=datetime.now() - timedelta(seconds=600))
+        self.make_addon_unlisted(self.addon)
+        Version.from_upload(
+            self.upload,
+            self.addon,
+            amo.CHANNEL_UNLISTED,
+            selected_apps=[self.selected_app],
+            parsed_data=self.dummy_parsed_data,
+        )
+        assert not self.addon.auto_approval_delayed_until
+        assert not self.addon.auto_approval_delayed_until_unlisted
+
+    def test_second_unlisted_version_deleted(self):
+        set_config('INITIAL_DELAY_FOR_UNLISTED', '3600')
+        self.addon.update(created=datetime.now() - timedelta(seconds=600))
+        version = self.addon.current_version
+        self.make_addon_unlisted(self.addon)
+        version.delete()
+        Version.from_upload(
+            self.upload,
+            self.addon,
+            amo.CHANNEL_UNLISTED,
+            selected_apps=[self.selected_app],
+            parsed_data=self.dummy_parsed_data,
+        )
+        assert not self.addon.auto_approval_delayed_until
+        assert not self.addon.auto_approval_delayed_until_unlisted
+
     def test_set_in_future(self):
         set_config('INITIAL_DELAY_FOR_UNLISTED', '3600')
         self.addon.update(created=datetime.now() - timedelta(seconds=600))


### PR DESCRIPTION
Since the flag lives on the add-on, we don't need to set it multiple times, we want to give admins/reviewers the ability to drop it and not affect future versions even if posted during the delay period.

Follow-up for #20250