### PR TITLE
Also apply auto approval indefinite delay to unlisted in scanner action

### DIFF
--- a/src/olympia/scanners/actions.py
+++ b/src/olympia/scanners/actions.py
@@ -42,7 +42,11 @@ def _delay_auto_approval_indefinitely(version):
 
     _flag_for_human_review(version)
     AddonReviewerFlags.objects.update_or_create(
-        addon=version.addon, defaults={'auto_approval_delayed_until': datetime.max}
+        addon=version.addon,
+        defaults={
+            'auto_approval_delayed_until': datetime.max,
+            'auto_approval_delayed_until_unlisted': datetime.max,
+        },
     )
 
 

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -516,10 +516,11 @@ class Version(OnChangeMixin, ModelBase):
 
         # Unlisted versions approval is delayed depending on how far we are
         # from creation of the add-on. This is applied only once, during the
-        # first unlisted version creation (so the flag can be dropped by admins
-        # or reviewers, not affecting subsequent versions).
+        # first unlisted version creation of an extension (so the flag can be
+        # dropped by admins or reviewers, not affecting subsequent versions).
         if (
             channel == amo.CHANNEL_UNLISTED
+            and addon.type == amo.ADDON_EXTENSION
             and not addon.versions(manager='unfiltered_for_relations')
             .filter(channel=amo.CHANNEL_UNLISTED)
             .exclude(pk=version.pk)

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -2246,6 +2246,36 @@ class TestExtensionVersionFromUploadUnlistedDelay(TestVersionFromUpload):
         assert not self.addon.auto_approval_delayed_until
         assert not self.addon.auto_approval_delayed_until_unlisted
 
+    def test_set_in_future_but_addon_is_a_theme(self):
+        set_config('INITIAL_DELAY_FOR_UNLISTED', '3600')
+        self.addon.update(
+            type=amo.ADDON_STATICTHEME, created=datetime.now() - timedelta(seconds=600)
+        )
+        Version.from_upload(
+            self.upload,
+            self.addon,
+            amo.CHANNEL_UNLISTED,
+            selected_apps=[self.selected_app],
+            parsed_data=self.dummy_parsed_data,
+        )
+        assert not self.addon.auto_approval_delayed_until
+        assert not self.addon.auto_approval_delayed_until_unlisted
+
+    def test_set_in_future_but_addon_is_a_langpack(self):
+        set_config('INITIAL_DELAY_FOR_UNLISTED', '3600')
+        self.addon.update(
+            type=amo.ADDON_LPAPP, created=datetime.now() - timedelta(seconds=600)
+        )
+        Version.from_upload(
+            self.upload,
+            self.addon,
+            amo.CHANNEL_UNLISTED,
+            selected_apps=[self.selected_app],
+            parsed_data=self.dummy_parsed_data,
+        )
+        assert not self.addon.auto_approval_delayed_until
+        assert not self.addon.auto_approval_delayed_until_unlisted
+
     def test_set_in_future_overwrite_existing_lower_delay(self):
         set_config('INITIAL_DELAY_FOR_UNLISTED', '3600')
         self.addon.update(created=datetime.now() - timedelta(seconds=600))


### PR DESCRIPTION
But also restrict the submission delay to just extensions, not all add-ons.

Fixes #20291