### PR TITLE
still show deleted add-ons and versions in review queues

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1785,15 +1785,14 @@ class Addon(OnChangeMixin, ModelBase):
         """
         Update all due dates on versions of this add-on.
         """
-        for version in self.versions.should_have_due_date().filter(
-            due_date__isnull=True
-        ):
+        versions = self.versions(manager='unfiltered_for_relations')
+        for version in versions.should_have_due_date().filter(due_date__isnull=True):
             due_date = get_review_due_date()
             log.info(
                 'Version %r (%s) due_date set to %s', version, version.id, due_date
             )
             version.update(due_date=due_date, _signal=False)
-        for version in self.versions.should_have_due_date(negate=True).filter(
+        for version in versions.should_have_due_date(negate=True).filter(
             due_date__isnull=False
         ):
             log.info(
@@ -1863,6 +1862,15 @@ def watch_status(old_attr=None, new_attr=None, instance=None, sender=None, **kwa
     else:
         # New: will (re)set due date only if it's None.
         latest_version.reset_due_date()
+
+
+@receiver(
+    models.signals.post_delete,
+    sender=Addon,
+    dispatch_uid='addon-delete',
+)
+def update_due_date_for_addon_delete(sender, instance, **kw):
+    instance.update_all_due_dates()
 
 
 def attach_translations_dict(addons):

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -3169,6 +3169,29 @@ class TestExtensionsQueues(TestCase):
                 file_kw={'status': amo.STATUS_AWAITING_REVIEW},
             ).addon,
         ]
+        deleted_addon_human_review = addon_factory(
+            name='Deleted add-on - human review',
+            file_kw={'status': amo.STATUS_AWAITING_REVIEW, 'is_signed': True},
+            version_kw={'needs_human_review': True},
+        )
+        deleted_addon_human_review.delete()
+        expected_addons.append(deleted_addon_human_review)
+        deleted_unlisted_version_human_review = addon_factory(
+            name='Deleted unlisted version - human review',
+            version_kw={'channel': amo.CHANNEL_UNLISTED, 'needs_human_review': True},
+            file_kw={'status': amo.STATUS_AWAITING_REVIEW, 'is_signed': True},
+            reviewer_flags={'auto_approval_disabled_unlisted': True},
+        )
+        deleted_unlisted_version_human_review.versions.all()[0].delete()
+        expected_addons.append(deleted_unlisted_version_human_review)
+        deleted_listed_version_human_review = addon_factory(
+            name='Deleted listed version - human review',
+            version_kw={'channel': amo.CHANNEL_LISTED, 'needs_human_review': True},
+            file_kw={'status': amo.STATUS_AWAITING_REVIEW, 'is_signed': True},
+            reviewer_flags={'auto_approval_disabled': True},
+        )
+        deleted_listed_version_human_review.versions.all()[0].delete()
+        expected_addons.append(deleted_listed_version_human_review)
 
         # Add add-ons that should not appear. For some it's because of
         # something we're explicitly filtering out, for others it's because of
@@ -3234,21 +3257,24 @@ class TestExtensionsQueues(TestCase):
                 'needs_admin_code_review': True,
             },
         )
-        addons = Addon.objects.get_queryset_for_pending_queues()
+        addons = Addon.unfiltered.get_queryset_for_pending_queues()
         assert list(addons.order_by('pk')) == expected_addons
 
         # Test that we picked the version with the oldest due date and that we
         # added the first_pending_version property.
         for addon in addons:
             expected_version = (
-                addon.versions.exclude(due_date=None).order_by('due_date').first()
+                addon.versions(manager='unfiltered_for_relations')
+                .exclude(due_date=None)
+                .order_by('due_date')
+                .first()
             )
             assert expected_version
             assert addon.first_pending_version == expected_version
 
         # Admins should be able to see addons needing admin code review.
         expected_addons.append(addon_needing_admin_code_review)
-        addons = Addon.objects.get_queryset_for_pending_queues(admin_reviewer=True)
+        addons = Addon.unfiltered.get_queryset_for_pending_queues(admin_reviewer=True)
         assert set(addons) == set(expected_addons)
 
 

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -158,7 +158,7 @@ class PendingManualApprovalQueueTable(AddonQueueTable):
 
     @classmethod
     def get_queryset(cls, admin_reviewer=False):
-        return Addon.objects.get_queryset_for_pending_queues(
+        return Addon.unfiltered.get_queryset_for_pending_queues(
             admin_reviewer=admin_reviewer
         )
 


### PR DESCRIPTION
fixes #20256 - after a lot of debugging, it turned out to need a few more subtle changes than the 3 places mentioned.  

Andreas in other issues said that we only want the `due_date` for deleted add-ons that have already been signed, so I added that restriction at the same time.