### PR TITLE
fix admin override on upload feature

### DIFF
--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -2249,6 +2249,24 @@ class VersionSubmitUploadMixin:
         else:
             assert version.previews.all().count() == 0
 
+    def test_admin_override(self):
+        self.grant_permission(self.user, ':'.join(amo.permissions.REVIEWS_ADMIN))
+        assert not AddonReviewerFlags.objects.filter(
+            addon=self.addon, needs_admin_code_review=True
+        ).exists()
+        response = self.post(override_validation=True)
+        assert response.status_code == 302
+        assert AddonReviewerFlags.objects.filter(
+            addon=self.addon, needs_admin_code_review=True
+        ).exists()
+
+    def test_admin_override_no_permission(self):
+        response = self.post(override_validation=True)
+        assert response.status_code == 302
+        assert not AddonReviewerFlags.objects.filter(
+            addon=self.addon, needs_admin_code_review=True
+        ).exists()
+
 
 class TestVersionSubmitUploadListed(VersionSubmitUploadMixin, UploadMixin, TestCase):
     channel = amo.CHANNEL_LISTED

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -1218,8 +1218,12 @@ def version_reenable(request, addon_id, addon):
 
 
 def check_validation_override(request, form, addon, version):
-    if version and form.cleaned_data.get('admin_override_validation'):
-        helper = ReviewHelper(request=request, addon=addon, version=version)
+    if (
+        version
+        and form.cleaned_data.get('admin_override_validation')
+        and acl.action_allowed_for(request.user, amo.permissions.REVIEWS_ADMIN)
+    ):
+        helper = ReviewHelper(addon=addon, version=version, user=request.user)
         helper.set_data(
             {
                 'operating_systems': '',
@@ -1231,7 +1235,7 @@ def check_validation_override(request, form, addon, version):
                 ),
             }
         )
-        helper.actions['super']['method']()
+        helper.handler.process_super_review()
 
 
 @dev_required


### PR DESCRIPTION
fixes #20258 

As there were no tests I don't really know how it was _supposed_ to work exactly, or when it stopped working, but I think previously if you didn't have `Addons:Review` permission the request would have failed because that was needed to make the `super` action available.  Which was different than the `Reviews:Admin` permission you'd need to actually use the checkbox to override a failed validation.  (I'm assuming that the users who used the checkbox happened to have both so no-one noticed).

This patch checks `Reviews:Admin` directly, then calls the `process_super_review` method.