### PR TITLE
Don't try backfilling ratinglogs if there is already one

### DIFF
--- a/src/olympia/activity/management/commands/backfill_ratinglog.py
+++ b/src/olympia/activity/management/commands/backfill_ratinglog.py
@@ -22,6 +22,6 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         alog_ids = ActivityLog.objects.filter(
-            action__in=self.rating_actions
+            action__in=self.rating_actions, ratinglog__id__isnull=True
         ).values_list('id', flat=True)
         create_chunked_tasks_signatures(create_ratinglog, alog_ids, 100).apply_async()


### PR DESCRIPTION
Helps https://github.com/mozilla/addons-server/issues/20266

I don't know why these ratings are missing a `RatingLog`, so I'm tweaking the command to make it faster to re-run and hopefully fix those ratings activity logs.