### PR TITLE
command to return folders with (potentially) changed files instead

### DIFF
--- a/src/olympia/amo/management/commands/get_changed_files.py
+++ b/src/olympia/amo/management/commands/get_changed_files.py
@@ -1,0 +1,158 @@
+import os
+
+from datetime import datetime, timedelta
+from os import scandir
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+import olympia.core.logger
+
+from olympia.addons.models import Addon, Preview
+from olympia.amo.utils import id_to_path
+from olympia.blocklist.utils import datetime_to_ts
+from olympia.files.models import File
+from olympia.hero.models import PrimaryHeroImage
+from olympia.users.models import UserProfile
+from olympia.versions.models import Version, VersionPreview
+
+
+def get_modified_folders(since, *, path, manager, datefield, id_to_path_breadth):
+    qs = manager.filter(**{f'{datefield}__gt': since}).values_list('id', flat=True)
+    return [
+        os.path.join(path, id_to_path(id_, breadth=id_to_path_breadth), '')
+        for id_ in qs
+    ]
+
+
+def collect_user_pics(since):
+    return get_modified_folders(
+        since,
+        path=os.path.join(settings.MEDIA_ROOT, 'userpics'),
+        manager=UserProfile.objects,
+        datefield='modified',
+        id_to_path_breadth=2,
+    )
+
+
+def collect_files(since):
+    path = settings.ADDONS_PATH
+    qs = File.objects.filter(modified__gt=since).values_list(
+        'version__addon_id', flat=True
+    )
+    return list({os.path.join(path, id_to_path(id_, breadth=2), '') for id_ in qs})
+
+
+def collect_sources(since):
+    return get_modified_folders(
+        since,
+        path=os.path.join(settings.MEDIA_ROOT, 'version_source'),
+        manager=Version.unfiltered,
+        datefield='modified',
+        id_to_path_breadth=1,
+    )
+
+
+def collect_xpi_uploads(since):
+    # all the files are in a single folder so return it
+    return [os.path.join(settings.ADDONS_PATH, 'temp')]
+
+
+def get_previews(since, path, manager):
+    out = set()
+    qs = manager.filter(created__gt=since).values_list('id', flat=True)
+    for preview_id in qs:
+        subdir = str(preview_id // 1000)
+        out = out | {
+            os.path.join(path, 'thumbs', subdir, ''),
+            os.path.join(path, 'full', subdir, ''),
+            os.path.join(path, 'original', subdir, ''),
+        }
+    return list(out)
+
+
+def collect_addon_previews(since):
+    return get_previews(
+        since, os.path.join(settings.MEDIA_ROOT, 'previews'), Preview.objects
+    )
+
+
+def collect_theme_previews(since):
+    return get_previews(
+        since,
+        os.path.join(settings.MEDIA_ROOT, 'version-previews'),
+        VersionPreview.objects,
+    )
+
+
+def collect_addon_icons(since):
+    path = os.path.join(settings.MEDIA_ROOT, 'addon_icons')
+    qs = Addon.unfiltered.filter(modified__gt=since).values_list('id', flat=True)
+    return list({os.path.join(path, str(preview_id // 1000), '') for preview_id in qs})
+
+
+def collect_editoral(since):
+    return (
+        [os.path.join(settings.MEDIA_ROOT, 'hero-featured-image')]
+        if PrimaryHeroImage.objects.filter(modified__gt=since).exists()
+        else []
+    )
+
+
+def collect_sitemaps(since):
+    return [settings.SITEMAP_STORAGE_PATH]  # sitemaps change each day
+
+
+def collect_git(since):
+    path = settings.GIT_FILE_STORAGE_PATH
+    qs = File.objects.filter(modified__gt=since).values_list(
+        'version__addon_id', flat=True
+    )
+    return list(
+        {
+            os.path.join(path, id_to_path(addon_id, breadth=2), 'addon', '')
+            for addon_id in qs
+        }
+    )
+
+
+def collect_blocklist(since):
+    path = settings.MLBF_STORAGE_PATH
+    since_ts = datetime_to_ts(since)
+    return [
+        file_.path
+        for file_ in scandir(path)
+        if file_.is_dir() and file_.name.isdigit() and int(file_.name) >= since_ts
+    ]
+
+
+class Command(BaseCommand):
+    help = (
+        'Get folders containing files that have changed on the filesystem in the past '
+        'X seconds'
+    )
+    log = olympia.core.logger.getLogger('z.appversions')
+
+    def add_arguments(self, parser):
+        parser.add_argument('since', type=int)
+
+    def get_collectors(self):
+        return [
+            collect_user_pics,
+            collect_files,
+            collect_sources,
+            collect_xpi_uploads,
+            collect_addon_previews,
+            collect_theme_previews,
+            collect_addon_icons,
+            collect_editoral,
+            collect_sitemaps,
+            collect_git,
+            collect_blocklist,
+        ]
+
+    def handle(self, *args, **options):
+        since = datetime.now() - timedelta(seconds=options['since'])
+        for func in self.get_collectors():
+            items = func(since)
+            [self.stdout.write(os.path.normpath(item)) for item in items]

--- a/src/olympia/amo/management/commands/get_changed_files.py
+++ b/src/olympia/amo/management/commands/get_changed_files.py
@@ -6,8 +6,6 @@ from os import scandir
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
-import olympia.core.logger
-
 from olympia.addons.models import Addon, Preview
 from olympia.amo.utils import id_to_path
 from olympia.blocklist.utils import datetime_to_ts
@@ -53,11 +51,6 @@ def collect_sources(since):
     )
 
 
-def collect_xpi_uploads(since):
-    # all the files are in a single folder so return it
-    return [os.path.join(settings.ADDONS_PATH, 'temp')]
-
-
 def get_previews(since, path, manager):
     out = set()
     qs = manager.filter(created__gt=since).values_list('id', flat=True)
@@ -99,10 +92,6 @@ def collect_editoral(since):
     )
 
 
-def collect_sitemaps(since):
-    return [settings.SITEMAP_STORAGE_PATH]  # sitemaps change each day
-
-
 def collect_git(since):
     path = settings.GIT_FILE_STORAGE_PATH
     qs = File.objects.filter(modified__gt=since).values_list(
@@ -131,7 +120,6 @@ class Command(BaseCommand):
         'Get folders containing files that have changed on the filesystem in the past '
         'X seconds'
     )
-    log = olympia.core.logger.getLogger('z.appversions')
 
     def add_arguments(self, parser):
         parser.add_argument('since', type=int)
@@ -141,12 +129,10 @@ class Command(BaseCommand):
             collect_user_pics,
             collect_files,
             collect_sources,
-            collect_xpi_uploads,
             collect_addon_previews,
             collect_theme_previews,
             collect_addon_icons,
             collect_editoral,
-            collect_sitemaps,
             collect_git,
             collect_blocklist,
         ]

--- a/src/olympia/amo/management/commands/get_changed_files.py
+++ b/src/olympia/amo/management/commands/get_changed_files.py
@@ -23,9 +23,11 @@ def collect_user_pics(since):
 
 def collect_files(since):
     path = settings.ADDONS_PATH
-    id_iter = File.objects.filter(modified__gt=since).values_list(
-        'version__addon_id', flat=True
-    ).iterator()
+    id_iter = (
+        File.objects.filter(modified__gt=since)
+        .values_list('version__addon_id', flat=True)
+        .iterator()
+    )
     return list({os.path.join(path, id_to_path(id_, breadth=2)) for id_ in id_iter})
 
 

--- a/src/olympia/amo/management/commands/get_changed_files.py
+++ b/src/olympia/amo/management/commands/get_changed_files.py
@@ -73,12 +73,7 @@ def collect_git(since):
     qs = File.objects.filter(modified__gt=since).values_list(
         'version__addon_id', flat=True
     )
-    return list(
-        {
-            AddonGitRepository(addon_id).git_repository_path
-            for addon_id in qs
-        }
-    )
+    return list({AddonGitRepository(addon_id).git_repository_path for addon_id in qs})
 
 
 def collect_blocklist(since):

--- a/src/olympia/amo/tests/test_commands.py
+++ b/src/olympia/amo/tests/test_commands.py
@@ -189,7 +189,7 @@ class TestGetChangedFilesCommand(TestCase):
         unchanged = user_factory()
         unchanged.update(modified=self.older)
         assert unchanged.modified < self.yesterday
-        assert collect_user_pics(self.yesterday) == [f'{changed.picture_dir}/']
+        assert collect_user_pics(self.yesterday) == [changed.picture_dir]
 
     def test_collect_files(self):
         new_file = File.objects.get(id=33046)
@@ -199,7 +199,7 @@ class TestGetChangedFilesCommand(TestCase):
         old_file.update(modified=self.older)
         assert old_file.modified < self.yesterday
         assert collect_files(self.yesterday) == [
-            f'{os.path.dirname(new_file.file.path)}/'
+            os.path.dirname(new_file.file.path)
         ]
 
     def test_collect_sources(self):
@@ -209,7 +209,7 @@ class TestGetChangedFilesCommand(TestCase):
         unchanged.update(modified=self.older)
         assert unchanged.modified < self.yesterday
         assert collect_sources(self.yesterday) == [
-            f'{os.path.dirname(changed.source.path)}/'
+            os.path.dirname(changed.source.path)
         ]
 
     def test_collect_addon_previews(self):
@@ -226,9 +226,9 @@ class TestGetChangedFilesCommand(TestCase):
         )
         assert sorted(collect_addon_previews(self.yesterday)) == [
             # only one set of dirs because 1 and 2 are in same subdirs
-            f'{os.path.dirname(preview1.image_path)}/',
-            f'{os.path.dirname(preview1.original_path)}/',
-            f'{os.path.dirname(preview1.thumbnail_path)}/',
+            os.path.dirname(preview1.image_path),
+            os.path.dirname(preview1.original_path),
+            os.path.dirname(preview1.thumbnail_path),
         ]
 
     def test_collect_theme_previews(self):
@@ -249,9 +249,9 @@ class TestGetChangedFilesCommand(TestCase):
         )
         assert sorted(collect_theme_previews(self.yesterday)) == [
             # only one set of dirs because 1 and 2 are in same subdirs
-            f'{os.path.dirname(preview1.image_path)}/',
-            f'{os.path.dirname(preview1.original_path)}/',
-            f'{os.path.dirname(preview1.thumbnail_path)}/',
+            os.path.dirname(preview1.image_path),
+            os.path.dirname(preview1.original_path),
+            os.path.dirname(preview1.thumbnail_path),
         ]
 
     def test_collect_addon_icons(self):
@@ -259,7 +259,7 @@ class TestGetChangedFilesCommand(TestCase):
         unchanged = addon_factory()
         unchanged.update(modified=self.older)
         assert unchanged.modified < self.yesterday
-        assert collect_addon_icons(self.yesterday) == [f'{changed.get_icon_dir()}/']
+        assert collect_addon_icons(self.yesterday) == [changed.get_icon_dir()]
 
     def test_collect_editoral(self):
         image1 = PrimaryHeroImage.objects.create()
@@ -283,7 +283,7 @@ class TestGetChangedFilesCommand(TestCase):
         old_file.update(modified=self.older)
         assert old_file.modified < self.yesterday
         assert collect_git(self.yesterday) == [
-            f'{AddonGitRepository(new_file.addon).git_repository_path}/'
+            AddonGitRepository(new_file.addon).git_repository_path
         ]
 
     def test_collect_blocklist(self):

--- a/src/olympia/amo/tests/test_commands.py
+++ b/src/olympia/amo/tests/test_commands.py
@@ -1,6 +1,6 @@
 import os
 import io
-
+from datetime import datetime, timedelta
 from importlib import import_module
 
 from django.conf import settings
@@ -10,6 +10,27 @@ from django.test.utils import override_settings
 
 from unittest import mock
 import pytest
+
+from olympia.addons.models import Preview
+from olympia.amo.management.commands.get_changed_files import (
+    collect_user_pics,
+    collect_files,
+    collect_sources,
+    collect_xpi_uploads,
+    collect_addon_previews,
+    collect_theme_previews,
+    collect_addon_icons,
+    collect_editoral,
+    collect_sitemaps,
+    collect_git,
+    collect_blocklist,
+)
+from olympia.amo.tests import addon_factory, TestCase, user_factory, version_factory
+from olympia.blocklist.utils import datetime_to_ts
+from olympia.files.models import File
+from olympia.git.utils import AddonGitRepository
+from olympia.hero.models import PrimaryHeroImage
+from olympia.versions.models import source_upload_path, VersionPreview
 
 
 def sample_cron_job(*args):
@@ -144,3 +165,158 @@ def test_generate_jsi18n_files():
     with open(filename) as f:
         content = f.read()
         assert 'Erreur' in content
+
+
+class TestGetChangedFilesCommand(TestCase):
+    fixtures = ['base/addon_5299_gcal']
+
+    def setUp(self):
+        self.yesterday = datetime.now() - timedelta(hours=24)
+        self.newer = self.yesterday + timedelta(seconds=10)
+        self.older = self.yesterday - timedelta(seconds=10)
+
+    def test_command(self):
+        with io.StringIO() as out:
+            call_command('get_changed_files', '1', stdout=out)
+            # These two dirs are always returned as we can't track modification
+            assert out.getvalue() == (
+                f'{os.path.join(settings.ADDONS_PATH, "temp")}\n'
+                f'{settings.SITEMAP_STORAGE_PATH}\n'
+            )
+
+    def test_collect_user_pics(self):
+        changed = user_factory()
+        unchanged = user_factory()
+        unchanged.update(modified=self.older)
+        assert unchanged.modified < self.yesterday
+        assert collect_user_pics(self.yesterday) == [f'{changed.picture_dir}/']
+
+    def test_collect_files(self):
+        new_file = File.objects.get(id=33046)
+        new_file.update(modified=self.newer)
+        version_factory(addon=new_file.addon)  # an extra file to check de-duping
+        old_file = addon_factory().current_version.file
+        old_file.update(modified=self.older)
+        assert old_file.modified < self.yesterday
+        assert collect_files(self.yesterday) == [
+            f'{os.path.dirname(new_file.file.path)}/'
+        ]
+
+    def test_collect_sources(self):
+        changed = addon_factory().current_version
+        changed.update(source=source_upload_path(changed, 'foo.zip'))
+        unchanged = addon_factory().current_version
+        unchanged.update(modified=self.older)
+        assert unchanged.modified < self.yesterday
+        assert collect_sources(self.yesterday) == [
+            f'{os.path.dirname(changed.source.path)}/'
+        ]
+
+    def test_collect_xpi_uploads(self):
+        assert collect_xpi_uploads(self.yesterday) == [
+            os.path.join(settings.ADDONS_PATH, 'temp')
+        ]
+
+    def test_collect_addon_previews(self):
+        preview1 = Preview.objects.create(addon=addon_factory())
+        preview2 = Preview.objects.create(addon=addon_factory())
+        older_preview = Preview.objects.create(
+            addon=addon_factory(), id=preview1.id + 1000
+        )
+        older_preview.update(created=self.older)
+        assert (preview1.id // 1000) == (preview2.id // 1000)
+        assert (preview1.id // 1000) != (older_preview.id // 1000)
+        assert os.path.dirname(preview1.image_path) == os.path.dirname(
+            preview2.image_path
+        )
+        assert sorted(collect_addon_previews(self.yesterday)) == [
+            # only one set of dirs because 1 and 2 are in same subdirs
+            f'{os.path.dirname(preview1.image_path)}/',
+            f'{os.path.dirname(preview1.original_path)}/',
+            f'{os.path.dirname(preview1.thumbnail_path)}/',
+        ]
+
+    def test_collect_theme_previews(self):
+        preview1 = VersionPreview.objects.create(
+            version=addon_factory().current_version
+        )
+        preview2 = VersionPreview.objects.create(
+            version=addon_factory().current_version
+        )
+        older_preview = VersionPreview.objects.create(
+            version=addon_factory().current_version, id=preview1.id + 1000
+        )
+        older_preview.update(created=self.older)
+        assert (preview1.id // 1000) == (preview2.id // 1000)
+        assert (preview1.id // 1000) != (older_preview.id // 1000)
+        assert os.path.dirname(preview1.image_path) == os.path.dirname(
+            preview2.image_path
+        )
+        assert sorted(collect_theme_previews(self.yesterday)) == [
+            # only one set of dirs because 1 and 2 are in same subdirs
+            f'{os.path.dirname(preview1.image_path)}/',
+            f'{os.path.dirname(preview1.original_path)}/',
+            f'{os.path.dirname(preview1.thumbnail_path)}/',
+        ]
+
+    def test_collect_addon_icons(self):
+        changed = addon_factory()
+        unchanged = addon_factory()
+        unchanged.update(modified=self.older)
+        assert unchanged.modified < self.yesterday
+        assert collect_addon_icons(self.yesterday) == [f'{changed.get_icon_dir()}/']
+
+    def test_collect_editoral(self):
+        image1 = PrimaryHeroImage.objects.create()
+        image1.update(modified=self.older)
+        image2 = PrimaryHeroImage.objects.create()
+        image2.update(modified=self.older)
+        # no new hero images so no dir
+        assert collect_editoral(self.yesterday) == []
+        image1.update(modified=self.newer)
+        image2.update(modified=self.newer)
+        # one or more updated hero images match then the root should be returned
+        assert collect_editoral(self.yesterday) == [
+            os.path.join(settings.MEDIA_ROOT, 'hero-featured-image')
+        ]
+
+    def test_collect_sitemaps(self):
+        assert collect_sitemaps(self.yesterday) == [settings.SITEMAP_STORAGE_PATH]
+
+    def test_collect_git(self):
+        new_file = File.objects.get(id=33046)
+        new_file.update(modified=self.newer)
+        version_factory(addon=new_file.addon)  # an extra file to check de-duping
+        old_file = addon_factory().current_version.file
+        old_file.update(modified=self.older)
+        assert old_file.modified < self.yesterday
+        assert collect_git(self.yesterday) == [
+            f'{AddonGitRepository(new_file.addon).git_repository_path}/'
+        ]
+
+    def test_collect_blocklist(self):
+        class FakeEntry:
+            def __init__(self, name, is_dir=True):
+                self.name = str(name)
+                self._is_dir = is_dir
+
+            def is_dir(self):
+                return self._is_dir
+
+            @property
+            def path(self):
+                return f'foo/{self.name}'
+
+        newerer = self.newer + timedelta(seconds=10)
+        with mock.patch(
+            'olympia.amo.management.commands.get_changed_files.scandir'
+        ) as scandir_mock:
+            scandir_mock.return_value = [
+                FakeEntry('fooo'),  # not a datetime
+                FakeEntry(datetime_to_ts(self.older)),  # too old
+                FakeEntry(datetime_to_ts(self.newer), False),  # not a dir
+                FakeEntry(datetime_to_ts(newerer)),  # yes
+            ]
+            assert collect_blocklist(self.yesterday) == [
+                f'foo/{datetime_to_ts(newerer)}'
+            ]

--- a/src/olympia/amo/tests/test_commands.py
+++ b/src/olympia/amo/tests/test_commands.py
@@ -198,9 +198,7 @@ class TestGetChangedFilesCommand(TestCase):
         old_file = addon_factory().current_version.file
         old_file.update(modified=self.older)
         assert old_file.modified < self.yesterday
-        assert collect_files(self.yesterday) == [
-            os.path.dirname(new_file.file.path)
-        ]
+        assert collect_files(self.yesterday) == [os.path.dirname(new_file.file.path)]
 
     def test_collect_sources(self):
         changed = addon_factory().current_version
@@ -208,9 +206,7 @@ class TestGetChangedFilesCommand(TestCase):
         unchanged = addon_factory().current_version
         unchanged.update(modified=self.older)
         assert unchanged.modified < self.yesterday
-        assert collect_sources(self.yesterday) == [
-            os.path.dirname(changed.source.path)
-        ]
+        assert collect_sources(self.yesterday) == [os.path.dirname(changed.source.path)]
 
     def test_collect_addon_previews(self):
         preview1 = Preview.objects.create(addon=addon_factory())


### PR DESCRIPTION
fixes #20289 ?  I'm not 100% on if this what we need, or if directories are going to be useful (rather than individual files) but first pass on solving the issue.