### PR TITLE
Update relevant due dates when clearing pending rejections

### DIFF
--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -6602,7 +6602,9 @@ class TestAddonReviewerViewSet(TestCase):
     def test_clear_pending_rejections(self):
         self.grant_permission(self.user, 'Reviews:Admin')
         self.client.login_api(self.user)
-        version_factory(addon=self.addon)
+        version_factory(
+            addon=self.addon, file_kw={'status': amo.STATUS_AWAITING_REVIEW}
+        )
         for version in self.addon.versions.all():
             version_review_flags_factory(
                 version=version,
@@ -6621,6 +6623,40 @@ class TestAddonReviewerViewSet(TestCase):
         assert not VersionReviewerFlags.objects.filter(
             version__addon=self.addon, pending_content_rejection__isnull=False
         ).exists()
+
+    def test_clear_pending_rejections_triggers_reset_due_date(self):
+        AddonReviewerFlags.objects.create(
+            addon=self.addon, auto_approval_disabled_until_next_approval=True
+        )
+        version = version_factory(
+            addon=self.addon, file_kw={'status': amo.STATUS_AWAITING_REVIEW}
+        )
+        # Awaiting review and auto-approval disabled: gets a due date.
+        assert version.due_date
+        VersionReviewerFlags.objects.create(
+            version=version,
+            pending_rejection=datetime.now() + timedelta(days=7),
+            pending_rejection_by=user_factory(),
+            pending_content_rejection=False,
+        )
+        # Version is pending rejection: loses its due date.
+        assert not version.due_date
+        self.grant_permission(self.user, 'Reviews:Admin')
+        self.client.login_api(self.user)
+        response = self.client.post(self.clear_pending_rejections_url)
+        assert response.status_code == 202
+        assert not VersionReviewerFlags.objects.filter(
+            version__addon=self.addon, pending_rejection__isnull=False
+        ).exists()
+        assert not VersionReviewerFlags.objects.filter(
+            version__addon=self.addon, pending_rejection_by__isnull=False
+        ).exists()
+        assert not VersionReviewerFlags.objects.filter(
+            version__addon=self.addon, pending_content_rejection__isnull=False
+        ).exists()
+        version.reload()
+        # Version is no longer pending rejection: gets a due date.
+        assert version.due_date
 
     def test_due_date(self):
         self.grant_permission(self.user, 'Reviews:Admin')

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -1197,6 +1197,10 @@ class AddonReviewerViewSet(GenericViewSet):
             pending_rejection_by=None,
             pending_content_rejection=None,
         )
+        # Since we're clearing pending rejection on multiple versions through
+        # a queryset .update(), we are not going through post_save callbacks,
+        # so we might be missing due dates on affected versions.
+        addon.update_all_due_dates()
         return Response(status=status_code)
 
     @drf_action(


### PR DESCRIPTION
Since clearing pending rejection affects multiple versions through a queryset, we have to trigger `update_all_due_dates()` on the addon.

Fixes #20224