### PR TITLE
Don't require Addon slug in `ModelForm`s (and therefore django admin)

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -483,7 +483,7 @@ class Addon(OnChangeMixin, ModelBase):
     STATUS_CHOICES = amo.STATUS_CHOICES_ADDON
 
     guid = models.CharField(max_length=255, unique=True, null=True)
-    slug = models.CharField(max_length=30, unique=True, null=True)
+    slug = models.CharField(max_length=30, unique=True, null=True, blank=True)
     name = TranslatedField(max_length=50)
     default_locale = models.CharField(
         max_length=10, default=settings.LANGUAGE_CODE, db_column='defaultlocale'

--- a/src/olympia/addons/tests/test_admin.py
+++ b/src/olympia/addons/tests/test_admin.py
@@ -367,7 +367,7 @@ class TestAddonAdmin(TestCase):
         assert response.status_code == 200
         addon.reload()
         assert addon.guid == '@foo'  # no change
-        assert addon.slug is None # no change
+        assert addon.slug is None  # no change
         assert addon.default_locale == 'fr'
 
     def test_show_link_to_reviewer_tools_listed(self):


### PR DESCRIPTION
It can be empty if it's a deleted add-ons. Devhub forms are already using an explicit field to make them required (and also have tests).

Fixes #20305