### PR TITLE
add clear_needs_human_review action; enable some actions for deleted addons

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1013,7 +1013,7 @@ class Addon(OnChangeMixin, ModelBase):
         exclude -- exclude versions for which all files have one of those statuses
                    (default STATUS_DISABLED).  `exclude=()` to include all statuses.
         deleted -- include deleted addons and versions. You probably want `exclude=()`
-                   too as files are typically set to STATUS_DELETED on delete."""
+                   too as files are typically set to STATUS_DISABLED on delete."""
 
         # If the add-on hasn't been saved yet, it should not have a latest version.
         # Nor if it's deleted, unless specified.

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1002,18 +1002,22 @@ class Addon(OnChangeMixin, ModelBase):
             .last()
         )
 
-    def find_latest_version(self, channel, exclude=((amo.STATUS_DISABLED,))):
+    def find_latest_version(
+        self, channel, exclude=((amo.STATUS_DISABLED,)), deleted=False
+    ):
         """Retrieve the latest version of an add-on for the specified channel.
 
         If channel is None either channel is returned.
 
         Keyword arguments:
-        exclude -- exclude versions for which all files have one
-                   of those statuses (default STATUS_DISABLED)."""
+        exclude -- exclude versions for which all files have one of those statuses
+                   (default STATUS_DISABLED).  `exclude=()` to include all statuses.
+        deleted -- include deleted addons and versions. You probably want `exclude=()`
+                   too as files are typically set to STATUS_DELETED on delete."""
 
-        # If the add-on is deleted or hasn't been saved yet, it should not
-        # have a latest version.
-        if not self.id or self.status == amo.STATUS_DELETED:
+        # If the add-on hasn't been saved yet, it should not have a latest version.
+        # Nor if it's deleted, unless specified.
+        if not self.id or (self.status == amo.STATUS_DELETED and not deleted):
             return None
 
         # Avoid most transformers - keep translations because they don't
@@ -1021,8 +1025,10 @@ class Addon(OnChangeMixin, ModelBase):
         # having made the query beforehand, and we don't know what callers
         # will want ; but for the rest of them, since it's a single
         # instance there is no reason to call the default transformers.
+        manager = 'objects' if not deleted else 'unfiltered_for_relations'
         return (
-            self.versions.exclude(file__status__in=exclude)
+            self.versions(manager=manager)
+            .exclude(file__status__in=exclude)
             .filter(
                 **{'channel': channel} if channel is not None else {},
                 file__isnull=False,

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -472,6 +472,20 @@ class TestAddonModels(TestCase):
         # set to listed, and version 4.0 is unlisted.
         assert addon.find_latest_version(amo.CHANNEL_LISTED, exclude=()).id == v2.id
 
+    def test_find_latest_version_include_deleted(self):
+        addon = Addon.objects.get(pk=3615)
+        v0 = addon.current_version
+
+        v1 = version_factory(addon=addon, version='1.0')
+        v1.update(created=self.days_ago(1))
+        v1.delete()
+        assert addon.find_latest_version(None, exclude=()).id == v0.id
+        assert addon.find_latest_version(None, exclude=(), deleted=True).id == v1.id
+
+        addon.delete()
+        assert addon.find_latest_version(None, exclude=()) is None
+        assert addon.find_latest_version(None, exclude=(), deleted=True).id == v1.id
+
     def test_current_version_unsaved(self):
         addon = Addon()
         addon._current_version = Version()

--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -870,7 +870,7 @@ class LOG_IN_API_TOKEN(_LOG):
 
 class CLEAR_NEEDS_HUMAN_REVIEWS(_LOG):
     id = 173
-    format = _('{addon} {version} needs_human_review flag cleared.')
+    format = _('{addon} needs_human_review flag cleared.')
     short = _('Needs Human Review cleared')
     admin_event = True
     review_queue = True

--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -868,6 +868,15 @@ class LOG_IN_API_TOKEN(_LOG):
     format = '{user_responsible} authenticated through an API token.'
 
 
+class CLEAR_NEEDS_HUMAN_REVIEWS(_LOG):
+    id = 173
+    format = _('{addon} {version} needs_human_review flag cleared.')
+    short = _('Needs Human Review cleared')
+    admin_event = True
+    review_queue = True
+    reviewer_review_action = True
+
+
 LOGS = [x for x in vars().values() if isclass(x) and issubclass(x, _LOG) and x != _LOG]
 # Make sure there's no duplicate IDs.
 assert len(LOGS) == len({log.id for log in LOGS})

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -256,7 +256,7 @@
 
     {% if is_admin %}
     <ul class="admin_only">
-      {% if not version.needs_human_review %}
+      {% if not addon.is_deleted and version and not version.needs_human_review %}
         <li>
           <button data-api-url="{{ drf_url('reviewers-addon-set-needs-human-review', addon.pk) }}"
                   data-api-data="{&quot;version&quot;: {{ version.pk }}}"

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -855,10 +855,19 @@ class ReviewBase:
         if version.needs_human_review_by_mad:
             version.reviewerflags.update(needs_human_review_by_mad=False)
 
-    def log_action(self, action, version=None, file=None, timestamp=None, user=None):
+    def log_action(
+        self,
+        action,
+        version=None,
+        file=None,
+        timestamp=None,
+        user=None,
+        extra_details=None,
+    ):
         details = {
             'comments': self.data.get('comments', ''),
             'reviewtype': self.review_type.split('_')[1],
+            **(extra_details or {}),
         }
         if file is None and self.file:
             file = self.file
@@ -1329,7 +1338,11 @@ class ReviewBase:
     def clear_needs_human_review(self):
         """clears human review all versions in this channel."""
         self.clear_all_needs_human_review_flags_in_channel(mad_too=False)
-        self.log_action(amo.LOG.CLEAR_NEEDS_HUMAN_REVIEWS)
+        channel = amo.CHANNEL_CHOICES_API.get(self.version.channel)
+        self.version = None  # we don't want to associate the log with a version
+        self.log_action(
+            amo.LOG.CLEAR_NEEDS_HUMAN_REVIEWS, extra_details={'channel': channel}
+        )
 
 
 class ReviewAddon(ReviewBase):

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -491,8 +491,8 @@ def review(request, addon, channel=None):
 
     # Other cases are handled in ReviewHelper by limiting what actions are
     # available depending on user permissions and add-on/version state.
-
-    version = addon.find_latest_version(channel=channel, exclude=())
+    is_admin = acl.action_allowed_for(request.user, amo.permissions.REVIEWS_ADMIN)
+    version = addon.find_latest_version(channel=channel, exclude=(), deleted=is_admin)
     latest_not_disabled_version = addon.find_latest_version(channel=channel)
 
     if not settings.ALLOW_SELF_REVIEWS and addon.has_author(request.user):
@@ -532,7 +532,6 @@ def review(request, addon, channel=None):
     form = ReviewForm(
         request.POST if request.method == 'POST' else None, helper=form_helper
     )
-    is_admin = acl.action_allowed_for(request.user, amo.permissions.REVIEWS_ADMIN)
 
     reports = Paginator(AbuseReport.objects.for_addon(addon), 5).page(1)
     user_ratings = Paginator(


### PR DESCRIPTION
fixes #20326 by fixing the review page to work with deleted add-ons (previously there was no version found for deleted addons, so no channel), and then adding a specific action to clear all needs_human_review flags in a channel (that's only present for admins when there is >0 versions in that channel that are needs_human_review).

I went with an action (rather than a button) because it's analogus with the the other actions that clear the flag, and so an activity log can be created for the clearing; clearing _all_ the needs_human_review flags wasn't the opposite of enabling `needs_human_review` for the latest version either.