### PR TITLE
Return a HTTP 409 for conflicts when creating add-ons/versions through the API

### DIFF
--- a/src/olympia/api/exceptions.py
+++ b/src/olympia/api/exceptions.py
@@ -18,6 +18,12 @@ class UnavailableForLegalReasons(exceptions.APIException):
     default_code = 'unavailable_for_legal_reasons'
 
 
+class Conflict(exceptions.APIException):
+    status_code = status.HTTP_409_CONFLICT
+    default_detail = 'Conflict'
+    default_code = 'conflict'
+
+
 def custom_exception_handler(exc, context=None):
     """
     Custom exception handler for DRF, which ensures every exception we throw

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -124,6 +124,10 @@ class AlreadyUsedUpload(forms.ValidationError):
     pass
 
 
+class DuplicateAddonID(forms.ValidationError):
+    pass
+
+
 def get_appversions(app, min_version, max_version):
     """Return the `AppVersion`s that correspond to the given versions."""
     qs = AppVersion.objects.filter(application=app.id)
@@ -871,7 +875,7 @@ def check_xpi_info(xpi_info, addon=None, xpi_file=None, user=None):
             Addon.unfiltered.filter(guid=guid).exists()
             or DeniedGuid.objects.filter(guid=guid).exists()
         ):
-            raise forms.ValidationError(gettext('Duplicate add-on ID found.'))
+            raise DuplicateAddonID(gettext('Duplicate add-on ID found.'))
 
     version_field_max_length = Version.version.field.max_length
     if len(xpi_info['version']) > version_field_max_length:


### PR DESCRIPTION
Also add a few more add-on creation tests

Fixes #20387