### PR TITLE
Removing unnecessary `{% with %}` blocks which replaced `{% blocktrans %}` in #20209

### DIFF
--- a/src/olympia/blocklist/templates/admin/blocklist/block_change_list.html
+++ b/src/olympia/blocklist/templates/admin/blocklist/block_change_list.html
@@ -6,7 +6,7 @@
   <li>
     {% url cl.opts|admin_urlname:'delete_multiple' as delete_multiple_url %}
     <a href="{% add_preserved_filters delete_multiple_url %}" class="addlink">
-      {% with cl.opts.verbose_name_plural as name %}Delete Multiple {{ name }}{% endwith %}
+      Delete Multiple {{ cl.opts.verbose_name_plural }}
     </a>
   </li>
 {% endblock %}

--- a/src/olympia/blocklist/templates/admin/blocklist/blocklistsubmission_add_form.html
+++ b/src/olympia/blocklist/templates/admin/blocklist/blocklistsubmission_add_form.html
@@ -33,7 +33,7 @@
   <div>
     <div class="form-row horizontal-grid">
       <div>
-        <h3>{% with count=existing_guids|length v_min=form.min_version.value v_max=form.max_version.value %}{{ count }} Add-on GUIDs are already blocked for {{ v_min }} to {{ v_max }}{% endwith %}:</h3>
+        <h3>{{ existing_guids|length }} Add-on GUIDs are already blocked for {{ form.min_version.value }} to {{ form.max_version.value }}:</h3>
         <ul class="guid_list field-existing-guids">
           {% for guid in existing_guids %}
           <li>{{ guid }}</li>
@@ -41,7 +41,7 @@
         </ul>
       </div>
       <div>
-        <h3>{% with count=invalid_guids|length %}{{ count }} Add-on GUIDs were not found{% endwith %}:</h3>
+        <h3>{{ invalid_guids|length }} Add-on GUIDs were not found:</h3>
         <ul class="guid_list">
           {% for guid in invalid_guids %}
           <li>{{ guid }}</li>

--- a/src/olympia/blocklist/templates/admin/blocklist/includes/enhanced_blocks.html
+++ b/src/olympia/blocklist/templates/admin/blocklist/includes/enhanced_blocks.html
@@ -1,6 +1,6 @@
 {% load humanize %}
 
-<h3>{% with count=blocks|length|intcomma adu=total_adu|intcomma %}{{ count }} Add-on GUIDs with {{ adu }} users{% endwith %}:</h3>
+<h3>{{ blocks|length|intcomma }} Add-on GUIDs with {{ total_adu|intcomma }} users:</h3>
  <ul class="guid_list">
   {% for block_obj in blocks %}
     <li>

--- a/src/olympia/blocklist/templates/admin/blocklist/multi_guid_input.html
+++ b/src/olympia/blocklist/templates/admin/blocklist/multi_guid_input.html
@@ -17,7 +17,7 @@
 <a href="{% url 'admin:index' %}">Home</a>
 &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
 &rsaquo; {% if has_view_permission %}<a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>{% else %}{{ opts.verbose_name_plural|capfirst }}{% endif %}
-&rsaquo; {% if add %}{% with name=opts.verbose_name %}Add {{ name }}{% endwith %}{% else %}{{ original|truncatewords:"18" }}{% endif %}
+&rsaquo; {% if add %}Add {{ opts.verbose_name }}{% else %}{{ original|truncatewords:"18" }}{% endif %}
 </div>
 {% endblock %}
 


### PR DESCRIPTION
Fixes #20215

* [x] This PR relates to an existing open issue and there are no existing PRs open for the same issue.
* [x] Checked Locally

#### Add a description of the changes introduced in this PR.
Removed unnecessary `{% with %}` blocks and replaced the alias with actual variable names accordingly.

##### P.S As @diox asked, I checked other files for ``{% with %}`` blocks where variables created by ``with`` were being used only once and it seemed safe to remove `{% with %}`, and could find only [this file](https://github.com/mozilla/addons-server/blob/master/src/olympia/reviewers/templates/reviewers/includes/user_ratings_list.html), but I wasn't sure if this should be changed, please let me know and I'll make the changes.