### PR TITLE
add add-ons without a current_version to Notable group too

### DIFF
--- a/src/olympia/constants/promoted.py
+++ b/src/olympia/constants/promoted.py
@@ -25,6 +25,7 @@ _PromotedSuperClass = namedtuple(
     defaults=(
         # "Since fields with a default value must come after any fields without
         # a default, the defaults are applied to the rightmost parameters"
+        # No defaults for: id, name, api_name.
         0.0,  # search_ranking_bump
         True,  # warning
         False,  # pre_review

--- a/src/olympia/promoted/models.py
+++ b/src/olympia/promoted/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.dispatch import receiver
 
+from olympia import amo
 from olympia.addons.models import Addon
 from olympia.amo.models import ModelBase
 from olympia.constants.applications import APP_IDS, APPS_CHOICES, APP_USAGE
@@ -127,7 +128,14 @@ class PromotedAddon(ModelBase):
             self.approve_for_addon()
         elif (
             self.group.flag_for_human_review
-            and (version := self.addon.current_version)
+            and (
+                version := (
+                    self.addon.current_version
+                    or self.addon.find_latest_version(
+                        amo.CHANNEL_LISTED, exclude=(), deleted=True
+                    )
+                )
+            )
             and not version.needs_human_review
             and not version.human_review_date
             and not self._get_approved_applications_for_version(version)

--- a/src/olympia/promoted/tasks.py
+++ b/src/olympia/promoted/tasks.py
@@ -26,15 +26,12 @@ def add_high_adu_extensions_to_notable():
         return
     adu_limit = int(adu_limit)
 
-    addons_ids_and_slugs = (
-        Addon.objects.public()
-        .filter(
-            Q(promotedaddon=None) | Q(promotedaddon__group_id=NOT_PROMOTED.id),
-            average_daily_users__gte=adu_limit,
-            type=amo.ADDON_EXTENSION,
-        )
-        .values_list('id', 'slug', 'average_daily_users')
-    )
+    addons_ids_and_slugs = Addon.unfiltered.filter(
+        ~Q(status=amo.STATUS_DISABLED),
+        Q(promotedaddon=None) | Q(promotedaddon__group_id=NOT_PROMOTED.id),
+        average_daily_users__gte=adu_limit,
+        type=amo.ADDON_EXTENSION,
+    ).values_list('id', 'slug', 'average_daily_users')
     count = len(addons_ids_and_slugs)
     log.info('Starting adding %s addons to %s', count, NOTABLE.name)
     for addon_id, addon_slug, adu in addons_ids_and_slugs:

--- a/src/olympia/promoted/tests/test_models.py
+++ b/src/olympia/promoted/tests/test_models.py
@@ -131,6 +131,7 @@ class TestPromotedAddon(TestCase):
         assert not PromotedApproval.objects.exists()
         assert promo.addon.promoted_group() == promoted.NOT_PROMOTED
         assert not listed_ver.reload().needs_human_review
+        assert not unlisted_ver.reload().needs_human_review
 
         # then with a group thats flag_for_human_review == True without the
         # version having been reviewed by a human (it should be flagged).

--- a/src/olympia/promoted/tests/test_models.py
+++ b/src/olympia/promoted/tests/test_models.py
@@ -10,6 +10,7 @@ from olympia.promoted.models import (
     PromotedAddon,
     PromotedApproval,
 )
+from olympia.versions.utils import get_review_due_date
 
 
 class TestPromotedAddon(TestCase):
@@ -102,6 +103,9 @@ class TestPromotedAddon(TestCase):
         promo = PromotedAddon.objects.create(
             addon=addon_factory(), application_id=amo.FIREFOX.id
         )
+        listed_ver = promo.addon.current_version
+        # throw in an unlisted version too
+        unlisted_ver = version_factory(addon=promo.addon, channel=amo.CHANNEL_UNLISTED)
         assert promo.group == promoted.NOT_PROMOTED
         assert promo.approved_applications == []
         assert not PromotedApproval.objects.exists()
@@ -113,7 +117,8 @@ class TestPromotedAddon(TestCase):
         assert promo.approved_applications == []
         assert not PromotedApproval.objects.exists()
         assert promo.addon.promoted_group() == promoted.NOT_PROMOTED
-        assert not promo.addon.current_version.needs_human_review
+        assert not listed_ver.reload().needs_human_review
+        assert not unlisted_ver.reload().needs_human_review
 
         # then with a group thats flag_for_human_review == True but pretend
         # the version has already been reviewed by a human (so it's not
@@ -136,15 +141,18 @@ class TestPromotedAddon(TestCase):
         assert promo.approved_applications == []  # doesn't approve immediately
         assert not PromotedApproval.objects.exists()
         assert promo.addon.promoted_group() == promoted.NOT_PROMOTED
-        assert promo.addon.current_version.needs_human_review
+        assert listed_ver.reload().needs_human_review
+        assert not unlisted_ver.reload().needs_human_review
+        self.assertCloseToNow(listed_ver.due_date, now=get_review_due_date())
+        assert not unlisted_ver.due_date
 
         # But we should only flag before the add-on is approved for Promoted
-        promo.addon.current_version.update(needs_human_review=False)
-        promo.approve_for_version(promo.addon.current_version)
-        assert promo.addon.promoted_group() == promoted.NOTABLE
+        listed_ver.update(needs_human_review=False)
+        promo.approve_for_version(listed_ver)
+        assert promo.addon.reload().promoted_group() == promoted.NOTABLE
         promo.save()
         promo.addon.reload()
-        assert not promo.addon.current_version.needs_human_review
+        assert not listed_ver.reload().needs_human_review
 
     @mock.patch('olympia.lib.crypto.tasks.sign_file')
     def test_approve_for_addon(self, mock_sign_file):
@@ -207,19 +215,6 @@ class TestPromotedAddon(TestCase):
         addon.reload()
         assert addon.current_version is None
         assert promo.get_resigned_version_number() is None
-
-    def test_has_approvals(self):
-        addon = addon_factory()
-        promoted_addon = PromotedAddon.objects.create(
-            addon=addon, group_id=promoted.SPONSORED.id
-        )
-
-        assert not promoted_addon.has_approvals
-
-        promoted_addon.approve_for_version(addon.current_version)
-        promoted_addon.reload()
-
-        assert promoted_addon.has_approvals
 
     def test_signal(self):
         addon = addon_factory(file_kw={'status': amo.STATUS_AWAITING_REVIEW})

--- a/src/olympia/promoted/tests/test_tasks.py
+++ b/src/olympia/promoted/tests/test_tasks.py
@@ -27,11 +27,17 @@ def test_add_high_adu_extensions_to_notable():
     unlisted_only_extension = addon_factory(
         average_daily_users=adu_limit + 1, version_kw={'channel': amo.CHANNEL_UNLISTED}
     )
-    mixed_extension = addon_factory(average_daily_users=adu_limit + 1)
+    mixed_extension = addon_factory(
+        average_daily_users=adu_limit + 1, file_kw={'is_signed': True}
+    )
     mixed_extension_listed_version = mixed_extension.current_version
     mixed_extension_listed_version.delete()
-    version_factory(addon=mixed_extension, channel=amo.CHANNEL_UNLISTED)
-    deleted_extension = addon_factory(average_daily_users=adu_limit + 1)
+    mixed_extension_unlisted_version = version_factory(
+        addon=mixed_extension, channel=amo.CHANNEL_UNLISTED
+    )
+    deleted_extension = addon_factory(
+        average_daily_users=adu_limit + 1, file_kw={'is_signed': True}
+    )
     deleted_extension_version = deleted_extension.current_version
     deleted_extension.delete()
 
@@ -63,12 +69,9 @@ def test_add_high_adu_extensions_to_notable():
     unlisted_latest_version = unlisted_only_extension.find_latest_version(channel=None)
     assert not unlisted_latest_version.needs_human_review
     assert not unlisted_latest_version.due_date
-    mixed_latest_version = mixed_extension.find_latest_version(
-        channel=amo.CHANNEL_UNLISTED
-    )
-    assert not mixed_latest_version.needs_human_review
-    assert not mixed_latest_version.due_date
-    assert not mixed_extension_listed_version.reload().needs_human_review
-    assert not mixed_extension_listed_version.due_date
-    assert not deleted_extension_version.reload().needs_human_review
-    assert not deleted_extension_version.due_date
+    assert not mixed_extension_unlisted_version.needs_human_review
+    assert not mixed_extension_unlisted_version.due_date
+    assert mixed_extension_listed_version.reload().needs_human_review
+    assert mixed_extension_listed_version.due_date
+    assert deleted_extension_version.reload().needs_human_review
+    assert deleted_extension_version.due_date

--- a/src/olympia/promoted/tests/test_tasks.py
+++ b/src/olympia/promoted/tests/test_tasks.py
@@ -1,7 +1,7 @@
 import pytest
 
 from olympia import amo
-from olympia.amo.tests import addon_factory
+from olympia.amo.tests import addon_factory, version_factory
 from olympia.constants.promoted import LINE, NOTABLE, NOT_PROMOTED
 from olympia.promoted.models import PromotedAddon
 from olympia.zadmin.models import set_config
@@ -24,6 +24,16 @@ def test_add_high_adu_extensions_to_notable():
     PromotedAddon.objects.create(addon=already_promoted, group_id=LINE.id)
     promoted_record_exists = addon_factory(average_daily_users=adu_limit + 1)
     PromotedAddon.objects.create(addon=promoted_record_exists, group_id=NOT_PROMOTED.id)
+    unlisted_only_extension = addon_factory(
+        average_daily_users=adu_limit + 1, version_kw={'channel': amo.CHANNEL_UNLISTED}
+    )
+    mixed_extension = addon_factory(average_daily_users=adu_limit + 1)
+    mixed_extension_listed_version = mixed_extension.current_version
+    mixed_extension_listed_version.delete()
+    version_factory(addon=mixed_extension, channel=amo.CHANNEL_UNLISTED)
+    deleted_extension = addon_factory(average_daily_users=adu_limit + 1)
+    deleted_extension_version = deleted_extension.current_version
+    deleted_extension.delete()
 
     add_high_adu_extensions_to_notable()
 
@@ -42,6 +52,23 @@ def test_add_high_adu_extensions_to_notable():
     assert already_promoted.promoted_group(currently_approved=False) == LINE
     promoted_record_exists.reload().promotedaddon.reload()
     assert promoted_record_exists.promoted_group(currently_approved=False) == NOTABLE
+    assert unlisted_only_extension.promoted_group(currently_approved=False) == NOTABLE
+    assert mixed_extension.promoted_group(currently_approved=False) == NOTABLE
+    assert deleted_extension.promoted_group(currently_approved=False) == NOTABLE
 
     assert extension_with_high_adu.current_version.needs_human_review
+    assert extension_with_high_adu.current_version.due_date
     assert promoted_record_exists.current_version.needs_human_review
+    assert promoted_record_exists.current_version.due_date
+    unlisted_latest_version = unlisted_only_extension.find_latest_version(channel=None)
+    assert not unlisted_latest_version.needs_human_review
+    assert not unlisted_latest_version.due_date
+    mixed_latest_version = mixed_extension.find_latest_version(
+        channel=amo.CHANNEL_UNLISTED
+    )
+    assert not mixed_latest_version.needs_human_review
+    assert not mixed_latest_version.due_date
+    assert not mixed_extension_listed_version.reload().needs_human_review
+    assert not mixed_extension_listed_version.due_date
+    assert not deleted_extension_version.reload().needs_human_review
+    assert not deleted_extension_version.due_date

--- a/src/olympia/reviewers/models.py
+++ b/src/olympia/reviewers/models.py
@@ -600,13 +600,11 @@ class AutoApprovalSummary(ModelBase):
     @classmethod
     def check_is_promoted_prereview(cls, version):
         """Check whether the add-on is a promoted addon group that requires
-        pre-review.
-
-        Only applies to listed versions."""
-        if not version.channel == amo.CHANNEL_LISTED:
-            return False
-        promo_group = version.addon.promoted_group(currently_approved=False)
-        return bool(promo_group and promo_group.pre_review)
+        pre-review."""
+        return bool(
+            version.channel == amo.CHANNEL_LISTED
+            and version.addon.promoted_group(currently_approved=False).pre_review
+        )
 
     @classmethod
     def check_should_be_delayed(cls, version):

--- a/src/olympia/reviewers/tests/test_models.py
+++ b/src/olympia/reviewers/tests/test_models.py
@@ -1209,6 +1209,9 @@ class TestAutoApprovalSummary(TestCase):
         promoted.update(group_id=LINE.id)  # LINE is though
         assert AutoApprovalSummary.check_is_promoted_prereview(self.version) is True
 
+        self.version.update(channel=amo.CHANNEL_UNLISTED)  # not for unlisted though
+        assert AutoApprovalSummary.check_is_promoted_prereview(self.version) is False
+
     def test_check_should_be_delayed(self):
         assert AutoApprovalSummary.check_should_be_delayed(self.version) is False
 

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -789,7 +789,7 @@ class ReviewBase:
 
     def set_promoted(self):
         group = self.addon.promoted_group(currently_approved=False)
-        if group and group.pre_review:
+        if self.version.channel == amo.CHANNEL_LISTED and group.pre_review:
             # These addons shouldn't be be attempted for auto approval anyway,
             # but double check that the cron job isn't trying to approve it.
             assert not self.user.id == settings.TASK_USER_ID


### PR DESCRIPTION
fixes #20422

~This patch (currently) doesn't change how existing versions are handled - only `Addon.current_version` is flagged with `needs_human_review` so if there isn't a current version (i.e. there aren't any listed versions that are non-deleted and not status=amo.STATUS_DISABLED) then no existing version is flagged.  But because the add-on is then Notable a subsequent new version would be held for pre-review.~