### PR TITLE
Record a single activity log for reviewer actions on multiple versions

### DIFF
--- a/src/olympia/activity/tests/test_admin.py
+++ b/src/olympia/activity/tests/test_admin.py
@@ -110,10 +110,9 @@ class TestActivityLogAdmin(TestCase):
             'logged in.'
         ) in content
         assert (
-            '<a href="http://testserver/en-US/admin/models/versions/version/'
-            f'{addon.current_version.pk}/change/">Version '
-            f'{addon.current_version.version}</a> added to '
-            f'<a href="http://testserver/en-US/admin/models/addons/addon/'
+            'Version <a href="http://testserver/en-US/admin/models/versions/version/'
+            f'{addon.current_version.pk}/change/">{addon.current_version.version}</a>'
+            f' added to <a href="http://testserver/en-US/admin/models/addons/addon/'
             f'{addon.pk}/change/">&lt;script&gt;alert(41)&lt;/script&gt;</a>'
         ) in content
 

--- a/src/olympia/activity/tests/test_models.py
+++ b/src/olympia/activity/tests/test_models.py
@@ -271,7 +271,7 @@ class TestActivityLog(TestCase):
             assert len(activities) == 2
             addon_url = 'http://testserver/en-US/firefox/addon/a3615/'
             assert activities[0].to_string() == (
-                f'<a href="{addon_url}versions/">Version 2.1.072</a> added to '
+                f'Version <a href="{addon_url}versions/">2.1.072</a> added to '
                 f'<a href="{addon_url}">Delicious Bookmarks</a>.'
             )
             assert activities[1].to_string()

--- a/src/olympia/blocklist/utils.py
+++ b/src/olympia/blocklist/utils.py
@@ -113,19 +113,16 @@ def disable_addon_for_block(block):
         review_type='pending',
         human_review=False,
     )
-    review.set_data(
-        {
-            'versions': [
-                ver
-                for ver in block.addon_versions
-                # We don't need to reject versions from older deleted instances
-                # and already disabled files
-                if ver.addon == block.addon
-                and block.is_version_blocked(ver.version)
-                and ver.file.status != amo.STATUS_DISABLED
-            ]
-        }
-    )
+    versions_to_reject = [
+        ver
+        for ver in block.addon_versions
+        # We don't need to reject versions from older deleted instances
+        # and already disabled files
+        if ver.addon == block.addon
+        and block.is_version_blocked(ver.version)
+        and ver.file.status != amo.STATUS_DISABLED
+    ]
+    review.set_data({'versions': versions_to_reject})
     review.reject_multiple_versions()
 
     for version in review.data['versions']:

--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -233,7 +233,7 @@ class REQUEST_SUPER_REVIEW(_LOG):
 
 class COMMENT_VERSION(_LOG):
     id = 49
-    format = _('Comment on {addon} {version}.')
+    format = '{addon} {version} reviewer comment.'
     short = _('Commented')
     keep = True
     review_queue = True
@@ -614,7 +614,7 @@ class SOURCE_CODE_UPLOADED(_LOG):
 
 class CONFIRM_AUTO_APPROVED(_LOG):
     id = 144
-    format = _('Auto-Approval confirmed for {addon} {version}.')
+    format = _('{addon} {version} auto-approval confirmed.')
     short = _('Auto-Approval confirmed')
     keep = True
     reviewer_review_action = True
@@ -816,7 +816,7 @@ class FORCE_DISABLE(_LOG):
     # add-on is likely malicious.
     hide_developer = True
     reviewer_review_action = True
-    format = '{user_responsible} force-disabled {addon}.'
+    format = '{addon} force-disabled by {user_responsible}.'
     short = 'Force disabled'
 
 
@@ -825,7 +825,7 @@ class FORCE_ENABLE(_LOG):
     keep = True
     hide_developer = True
     reviewer_review_action = True
-    format = '{user_responsible} force-enabled {addon}.'
+    format = '{addon} force-enabled by {user_responsible}.'
     short = 'Force enabled'
 
 

--- a/src/olympia/reviewers/templates/reviewers/reviewlog.html
+++ b/src/olympia/reviewers/templates/reviewers/reviewlog.html
@@ -38,23 +38,7 @@
               <td>{{ item.created|datetime }}</td>
               <td>
                 {% if item.arguments.0 %}
-                  <a href="{{ item.arguments.0.get_url_path() }}">{{ item.arguments.0.name }}</a>
-                  {% if item.arguments|count >= 2 %}
-                    {{ item.arguments[1] }}
-                    {% set channel = item.arguments[1].channel %}
-                  {% else %}
-                    {% set channel = 0 %}
-                  {% endif %}
-                  {% if item.action == amo.LOG.REJECT_CONTENT.id or item.action == amo.LOG.APPROVE_CONTENT.id %}
-                    {% set review_url = url('reviewers.review', 'content', item.arguments[0].pk ) %}
-                  {% elif channel == amo.CHANNEL_UNLISTED %}
-                    {% set review_url = url('reviewers.review', 'unlisted', item.arguments[0].pk) %}
-                  {% else %}
-                    {% set review_url = url('reviewers.review', item.arguments[0].pk) %}
-                  {% endif %}
-                  <a href="{{ review_url }}">
-                    {{ item.log.short }}
-                  </a>
+                  {{ item.to_string('reviewlog') }}
                 {% else %}
                     Add-on has been deleted.
                 {% endif %}

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -444,37 +444,32 @@ class TestReviewLog(ReviewerTest):
             'Add-on has been deleted.'
         )
 
-    def test_super_review_logs(self):
-        self.make_an_approval(amo.LOG.REQUEST_ADMIN_REVIEW_CODE)
-        response = self.client.get(self.url)
-        assert response.status_code == 200
-        assert pq(response.content)('#log-listing tr td a').eq(1).text() == (
-            'Admin add-on-review requested'
-        )
-
     def test_comment_logs(self):
         self.make_an_approval(amo.LOG.COMMENT_VERSION)
         response = self.client.get(self.url)
         assert response.status_code == 200
-        assert pq(response.content)('#log-listing tr td a').eq(1).text() == (
-            'Commented'
+        assert pq(response.content)('#log-listing tbody td').eq(1).html().strip() == (
+            '<a href="/en-US/reviewers/review/3615">Delicious Bookmarks</a> '
+            'Version 2.1.072 reviewer comment.'
         )
 
     def test_content_approval(self):
         self.make_an_approval(amo.LOG.APPROVE_CONTENT)
         response = self.client.get(self.url)
         assert response.status_code == 200
-        link = pq(response.content)('#log-listing tbody td a').eq(1)[0]
-        assert link.attrib['href'] == '/en-US/reviewers/review-content/3615'
-        assert link.text_content().strip() == 'Content approved'
+        assert pq(response.content)('#log-listing tbody td').eq(1).html().strip() == (
+            '<a href="/en-US/reviewers/review-content/3615">Delicious Bookmarks</a> '
+            'Version 2.1.072 content approved.'
+        )
 
     def test_content_rejection(self):
         self.make_an_approval(amo.LOG.REJECT_CONTENT)
         response = self.client.get(self.url)
         assert response.status_code == 200
-        link = pq(response.content)('#log-listing tbody td a').eq(1)[0]
-        assert link.attrib['href'] == '/en-US/reviewers/review-content/3615'
-        assert link.text_content().strip() == 'Content rejected'
+        assert pq(response.content)('#log-listing tbody td').eq(1).html().strip() == (
+            '<a href="/en-US/reviewers/review-content/3615">Delicious Bookmarks</a> '
+            'Version 2.1.072 content rejected.'
+        )
 
     @freeze_time('2017-08-03')
     def test_review_url(self):
@@ -493,8 +488,7 @@ class TestReviewLog(ReviewerTest):
         response = self.client.get(self.url)
         assert response.status_code == 200
         url = reverse('reviewers.review', args=[addon.pk])
-
-        link = pq(response.content)('#log-listing tbody tr[data-addonid] a').eq(1)
+        link = pq(response.content)('#log-listing tbody tr[data-addonid] a').eq(0)
         assert link.attr('href') == url
 
         entry = ActivityLog.create(
@@ -511,7 +505,7 @@ class TestReviewLog(ReviewerTest):
 
         response = self.client.get(self.url)
         url = reverse('reviewers.review', args=['unlisted', addon.pk])
-        assert pq(response.content)('#log-listing tr td a').eq(1).attr('href') == url
+        assert pq(response.content)('#log-listing tr td a').eq(0).attr('href') == url
 
     def test_review_url_force_disable(self):
         self.login_as_reviewer()
@@ -527,7 +521,7 @@ class TestReviewLog(ReviewerTest):
         assert response.status_code == 200
         url = reverse('reviewers.review', args=[addon.pk])
 
-        link = pq(response.content)('#log-listing tbody tr[data-addonid] a').eq(1)
+        link = pq(response.content)('#log-listing tbody tr[data-addonid] a').eq(0)
         assert link.attr('href') == url
 
     def test_reviewers_can_only_see_addon_types_they_have_perms_for(self):
@@ -4719,13 +4713,13 @@ class TestReview(ReviewBase):
         )
         assert 'class' not in important_changes[2].attrib
         assert important_changes[3].text_content() == (
-            f'{format_datetime(activity3.created)}: {activity1.user.name} '
-            'force-disabled Public.'
+            f'{format_datetime(activity3.created)}: Public force-disabled by '
+            f'{activity1.user.name}.'
         )
         assert important_changes[3].attrib['class'] == 'reviewer-review-action'
         assert important_changes[4].text_content() == (
-            f'{format_datetime(activity4.created)}: {activity1.user.name} '
-            'force-enabled Public.'
+            f'{format_datetime(activity4.created)}: Public force-enabled by '
+            f'{activity1.user.name}.'
         )
         assert important_changes[4].attrib['class'] == 'reviewer-review-action'
 

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -858,7 +858,7 @@ class ReviewBase:
         elif versions is not None:
             details['versions'] = [v.version for v in versions]
             details['files'] = [v.file.id for v in versions]
-            args = (self.addon,) + tuple(versions)
+            args = (self.addon, *versions)
         else:
             args = (self.addon,)
         if timestamp is None:

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -1,5 +1,5 @@
 import random
-from collections import OrderedDict
+from collections import defaultdict, OrderedDict
 from datetime import datetime, timedelta
 
 import django_tables2 as tables
@@ -831,7 +831,9 @@ class ReviewBase:
     def log_action(
         self,
         action,
+        *,
         version=None,
+        versions=None,
         file=None,
         timestamp=None,
         user=None,
@@ -842,22 +844,27 @@ class ReviewBase:
             'reviewtype': self.review_type.split('_')[1],
             **(extra_details or {}),
         }
-        if file is None and self.file:
-            file = self.file
-        if file is not None:
-            details['files'] = [file.id]
         if version is None and self.version:
             version = self.version
+
+        if file is not None:
+            details['files'] = [file.id]
+        elif self.file:
+            details['files'] = [self.file.id]
+
         if version is not None:
             details['version'] = version.version
             args = (self.addon, version)
+        elif versions is not None:
+            details['versions'] = [v.version for v in versions]
+            details['files'] = [v.file.id for v in versions]
+            args = (self.addon,) + tuple(versions)
         else:
             args = (self.addon,)
         if timestamp is None:
             timestamp = datetime.now()
 
         args = (*args, *self.data.get('reasons', []))
-
         kwargs = {'user': user or self.user, 'created': timestamp, 'details': details}
         self.log_entry = ActivityLog.create(action, *args, **kwargs)
 
@@ -1168,7 +1175,10 @@ class ReviewBase:
                 'Making %s versions %s disabled'
                 % (self.addon, ', '.join(str(v.pk) for v in self.data['versions']))
             )
-
+        # For a human review we record a single action, but for automated
+        # stuff, we need to split by type (content review or not) and by
+        # original user to match the original user(s) and action(s).
+        actions_to_record = defaultdict(lambda: defaultdict(list))
         for version in self.data['versions']:
             file = version.file
             if not pending_rejection_deadline:
@@ -1203,16 +1213,19 @@ class ReviewBase:
                     },
                 )
                 self.set_human_review_date(version)
-                user_to_attribute_action_to = self.user
+                actions_to_record[action_id][self.user].append(version)
             else:
-                user_to_attribute_action_to = version.pending_rejection_by
-            self.log_action(
-                action_id,
-                version=version,
-                file=file,
-                timestamp=now,
-                user=user_to_attribute_action_to,
-            )
+                actions_to_record[action_id][version.pending_rejection_by].append(
+                    version
+                )
+        for action_id, user_and_versions in actions_to_record.items():
+            for user, versions in user_and_versions.items():
+                self.log_action(
+                    action_id,
+                    versions=versions,
+                    timestamp=now,
+                    user=user,
+                )
 
         # A rejection (delayed or not) implies the next version should be
         # manually reviewed.
@@ -1290,13 +1303,12 @@ class ReviewBase:
         for version in self.data['versions']:
             self.set_file(amo.STATUS_AWAITING_REVIEW, version.file)
 
-            self.log_action(
-                action=amo.LOG.UNREJECT_VERSION,
-                version=version,
-                file=version.file,
-                timestamp=now,
-                user=self.user,
-            )
+        self.log_action(
+            action=amo.LOG.UNREJECT_VERSION,
+            versions=self.data['versions'],
+            timestamp=now,
+            user=self.user,
+        )
 
         if self.data['versions']:
             # if these are listed versions then the addon status may need updating
@@ -1401,12 +1413,14 @@ class ReviewUnlisted(ReviewBase):
         """Confirm approval on a list of versions."""
         # There shouldn't be any comments for this action.
         self.data['comments'] = ''
+        # self.version and self.file won't point to the versions we want to
+        # modify in this action, so set them to None so that the action is
+        # recorded against the specific versions we are confirming approval of.
+        self.version = None
+        self.file = None
 
         timestamp = datetime.now()
         for version in self.data['versions']:
-            self.log_action(
-                amo.LOG.CONFIRM_AUTO_APPROVED, version=version, timestamp=timestamp
-            )
             if self.human_review:
                 # Mark summary as confirmed if it exists.
                 try:
@@ -1418,10 +1432,19 @@ class ReviewUnlisted(ReviewBase):
                 self.clear_specific_needs_human_review_flags(version)
                 self.set_human_review_date(version)
 
+        self.log_action(
+            amo.LOG.CONFIRM_AUTO_APPROVED,
+            versions=self.data['versions'],
+            timestamp=timestamp,
+        )
+
     def approve_multiple_versions(self):
         """Set multiple unlisted add-on versions files to public."""
         assert self.version.channel == amo.CHANNEL_UNLISTED
         latest_version = self.version
+        # self.version and self.file won't point to the versions we want to
+        # modify in this action, so set them to None so that the action is
+        # recorded against the specific versions we are approving.
         self.version = None
         self.file = None
 
@@ -1436,13 +1459,13 @@ class ReviewUnlisted(ReviewBase):
                 sign_file(version.file)
             ActivityLog.create(amo.LOG.UNLISTED_SIGNED, version.file, user=self.user)
             self.set_file(amo.STATUS_APPROVED, version.file)
-            self.log_action(
-                amo.LOG.APPROVE_VERSION, version, version.file, timestamp=timestamp
-            )
             if self.human_review:
                 self.clear_specific_needs_human_review_flags(version)
-
             log.info('Making %s files %s public' % (self.addon, version.file.file.name))
+
+        self.log_action(
+            amo.LOG.APPROVE_VERSION, versions=self.data['versions'], timestamp=timestamp
+        )
 
         if self.human_review:
             template = 'approve_multiple_versions'


### PR DESCRIPTION
Adjust reviewlog page accordingly, using the `to_string()` method with a `type_='reviewlog'` parameter to do any formatting specific to the reviewlog.

Fixes #20045