### PR TITLE
set needs_human_review if auto approved after auto_approval_delayed_until_unlisted

### DIFF
--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -1098,6 +1098,32 @@ class TestReviewHelper(TestReviewHelperBase):
         # Not changed this this is not a human approval.
         assert addon_flags.auto_approval_disabled_until_next_approval_unlisted
 
+    def _unlisted_approve_flag_if_passed_auto_approval_delayed_setup(self, delay):
+        self.setup_data(
+            amo.STATUS_NULL, channel=amo.CHANNEL_UNLISTED, human_review=False
+        )
+        AddonReviewerFlags.objects.create(
+            addon=self.addon, auto_approval_delayed_until_unlisted=delay
+        )
+        assert not self.review_version.needs_human_review
+
+        self.helper.handler.approve_latest_version()
+        self.addon.reload()
+        self.review_version.reload()
+        self.file.reload()
+        assert self.addon.status == amo.STATUS_NULL
+        assert self.file.status == amo.STATUS_APPROVED
+
+    def test_unlisted_approve_flag_if_passed_auto_approval_delayed(self):
+        yesterday = datetime.now() - timedelta(days=1)
+        self._unlisted_approve_flag_if_passed_auto_approval_delayed_setup(yesterday)
+        assert self.review_version.needs_human_review
+
+    def test_unlisted_approve_dont_flag_if_not_past_auto_approval_delayed(self):
+        tomorrow = datetime.now() + timedelta(days=1)
+        self._unlisted_approve_flag_if_passed_auto_approval_delayed_setup(tomorrow)
+        assert not self.review_version.needs_human_review
+
     def test_nomination_to_public_with_version_reviewer_flags(self):
         flags = version_review_flags_factory(
             version=self.addon.current_version,

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -1385,6 +1385,13 @@ class ReviewUnlisted(ReviewBase):
                 defaults={'auto_approval_disabled_until_next_approval_unlisted': False},
             )
             self.set_human_review_date()
+        elif (
+            not self.version.needs_human_review
+            and (delay := self.addon.auto_approval_delayed_until_unlisted)
+            and delay < datetime.now()
+        ):
+            # if we're auto-approving because its past the approval delay, flag it.
+            self.version.update(needs_human_review=True)
 
         self.notify_email(template, subject, perm_setting=None)
 


### PR DESCRIPTION
fixes #20421 ?  

I think this matches what the issue specified, but I'm still a little unclear where (and/or in what circumstances) `auto_approval_delayed_until_unlisted` is cleared.  If it's _not_ cleared at some point then _every_ unlisted version after that datetime will be flagged `needs_human_review` which I doubt is desirable.