### PR TITLE
make Addon.auto_approval_delayed_temporarily_unlisted apply until unset

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1695,7 +1695,6 @@ class Addon(OnChangeMixin, ModelBase):
         return (
             bool(self.auto_approval_delayed_until_unlisted)
             and self.auto_approval_delayed_until_unlisted != datetime.max
-            and self.auto_approval_delayed_until_unlisted > datetime.now()
         )
 
     def set_auto_approval_delay_if_higher_than_existing(

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -1642,7 +1642,7 @@ class TestAddonModels(TestCase):
         # Flag present, value is a date.
         in_the_past = self.days_ago(1)
         flags.update(auto_approval_delayed_until_unlisted=in_the_past)
-        assert addon.auto_approval_delayed_temporarily_unlisted is False
+        assert addon.auto_approval_delayed_temporarily_unlisted is True
         # Flag present, now properly in the future.
         in_the_future = datetime.now() + timedelta(hours=24)
         flags.update(auto_approval_delayed_until_unlisted=in_the_future)


### PR DESCRIPTION
minimally fixes #20444 by just dropping the restriction on the property/flag that that date should be in the future.