### PR TITLE
replace git protocol with https

### DIFF
--- a/docs/topics/install/deprecated/installation.rst
+++ b/docs/topics/install/deprecated/installation.rst
@@ -80,7 +80,7 @@ Use the Source
 
 Grab olympia from github with::
 
-    git clone git://github.com/mozilla/olympia.git
+    git clone https://github.com/mozilla/olympia.git
     cd olympia
 
 ``olympia.git`` is all the source code.  :ref:`updating` is detailed later on.

--- a/docs/topics/install/docker.rst
+++ b/docs/topics/install/docker.rst
@@ -64,7 +64,7 @@ Next once you have Docker up and running follow these steps
 on your host machine::
 
     # Checkout the addons-server sourcecode.
-    git clone git://github.com/mozilla/addons-server.git
+    git clone https://github.com/mozilla/addons-server.git
     cd addons-server
     # Download the containers
     docker-compose pull  # Can take a while depending on your internet bandwidth.


### PR DESCRIPTION
Cloning via git:// is no longer supported on GitHub.com. 
Use https:// protocol on `git clone` procedure instead.