### PR TITLE
Add UserRestrictions for Rating submission and auto moderation

### DIFF
--- a/src/olympia/addons/tests/test_utils_.py
+++ b/src/olympia/addons/tests/test_utils_.py
@@ -241,7 +241,7 @@ class TestRestrictionChecker(TestCase):
         checker = RestrictionChecker(request=self.request)
         assert not checker.is_submission_allowed()
         assert checker.get_error_message() == (
-            'Multiple add-ons violating our policies have been submitted '
+            'Multiple submissions violating our policies have been sent '
             'from your location. The IP address has been blocked.'
         )
         assert incr_mock.call_count == 2
@@ -267,8 +267,7 @@ class TestRestrictionChecker(TestCase):
         checker = RestrictionChecker(request=self.request)
         assert not checker.is_submission_allowed()
         assert checker.get_error_message() == (
-            'The email address used for your account is not '
-            'allowed for add-on submission.'
+            'The email address used for your account is not allowed for submissions.'
         )
         assert incr_mock.call_count == 2
         assert incr_mock.call_args_list[0][0] == (
@@ -300,8 +299,7 @@ class TestRestrictionChecker(TestCase):
         checker = RestrictionChecker(request=self.request)
         assert not checker.is_submission_allowed(check_dev_agreement=False)
         assert checker.get_error_message() == (
-            'The email address used for your account is not '
-            'allowed for add-on submission.'
+            'The email address used for your account is not allowed for submissions.'
         )
         assert incr_mock.call_count == 2
         assert incr_mock.call_args_list[0][0] == (

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -7041,8 +7041,8 @@ class TestAddonPendingAuthorViewSet(TestCase):
         assert response.status_code == 400, response.content
         assert response.data == {
             'user_id': [
-                'The email address used for your account is not allowed for add-on '
-                'submission.'
+                'The email address used for your account is not allowed for '
+                'submissions.'
             ]
         }
 

--- a/src/olympia/addons/utils.py
+++ b/src/olympia/addons/utils.py
@@ -174,11 +174,8 @@ class RestrictionChecker:
     def _is_action_allowed(self, action_type, *, restriction_choices=None):
         if restriction_choices is None:
             restriction_choices = self.restriction_choices
-        argument = None
-        if action_type == 'submission':
-            argument = self.request
-        elif action_type == 'auto_approval':
-            argument = self.upload
+        # Default to self.request because most action_types expect it
+        argument = self.upload if action_type == 'auto_approval' else self.request
         for restriction_number, cls in restriction_choices:
             if not hasattr(cls, f'allow_{action_type}'):
                 continue
@@ -250,6 +247,22 @@ class RestrictionChecker:
             )
 
         return self._is_action_allowed('auto_approval')
+
+    def is_rating_allowed(self):
+        """
+        Check whether the `request` passed to the instance is allowed to submit a
+        rating. Will check all classes declared in self.restriction_classes, but ignore
+        those that don't have a allow_rating() method.
+        """
+        return self._is_action_allowed('rating')
+
+    def should_moderate_rating(self):
+        """
+        Check whether the `request` passed to the instance should have ratings
+        moderated. Will check all classes declared in self.restriction_classes, but
+        ignore those that don't have a allow_rating_without_moderation() method.
+        """
+        return not self._is_action_allowed('rating_without_moderation')
 
     def get_error_message(self):
         """

--- a/src/olympia/api/permissions.py
+++ b/src/olympia/api/permissions.py
@@ -302,17 +302,27 @@ class ByHttpMethod(BasePermission):
             perm = self.method_permissions[request.method.lower()]
         except KeyError:
             raise MethodNotAllowed(request.method)
-        return perm.has_permission(request, view)
+        result = perm.has_permission(request, view)
+        if not result and hasattr(perm, 'message'):
+            self.message = perm.message
+        return result
 
     def has_object_permission(self, request, view, obj):
         try:
             perm = self.method_permissions[request.method.lower()]
         except KeyError:
             raise MethodNotAllowed(request.method)
-        return perm.has_object_permission(request, view, obj)
+        result = perm.has_object_permission(request, view, obj)
+        if not result and hasattr(perm, 'message'):
+            self.message = perm.message
+        return result
 
     def __call__(self):
         return self
+
+    @property
+    def default_detail(self):
+        return getattr(self, 'message', super.default_detail)
 
 
 class AllowRelatedObjectPermissions(BasePermission):

--- a/src/olympia/devhub/tests/test_permissions.py
+++ b/src/olympia/devhub/tests/test_permissions.py
@@ -50,8 +50,7 @@ class TestIsSubmissionAllowedFor(TestCase):
         DisposableEmailDomainRestriction.objects.create(domain='example.com')
         assert not self.permission.has_permission(self.request, self.view)
         assert self.permission.message == (
-            'The email address used for your account is not '
-            'allowed for add-on submission.'
+            'The email address used for your account is not allowed for submissions.'
         )
 
     def test_has_permission_user_ip_restricted(self):
@@ -59,7 +58,7 @@ class TestIsSubmissionAllowedFor(TestCase):
         IPNetworkUserRestriction.objects.create(network='127.0.0.1/32')
         assert not self.permission.has_permission(self.request, self.view)
         assert self.permission.message == (
-            'Multiple add-ons violating our policies have been submitted '
+            'Multiple submissions violating our policies have been sent '
             'from your location. The IP address has been blocked.'
         )
 
@@ -67,8 +66,7 @@ class TestIsSubmissionAllowedFor(TestCase):
         EmailUserRestriction.objects.create(email_pattern='test@example.com')
         assert not self.permission.has_permission(self.request, self.view)
         assert self.permission.message == (
-            'The email address used for your account is not '
-            'allowed for add-on submission.'
+            'The email address used for your account is not allowed for submissions.'
         )
 
     def test_has_permission_both_user_ip_and_email_restricted(self):
@@ -77,6 +75,5 @@ class TestIsSubmissionAllowedFor(TestCase):
         EmailUserRestriction.objects.create(email_pattern='test@example.com')
         assert not self.permission.has_permission(self.request, self.view)
         assert self.permission.message == (
-            'The email address used for your account is not '
-            'allowed for add-on submission.'
+            'The email address used for your account is not allowed for submissions.'
         )

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -901,7 +901,7 @@ class TestDeveloperAgreement(TestCase):
         assert response.context['agreement_form'].is_valid() is False
         doc = pq(response.content)
         assert doc('.addon-submission-process').text() == (
-            'Multiple add-ons violating our policies have been submitted '
+            'Multiple submissions violating our policies have been sent '
             'from your location. The IP address has been blocked.\n'
             'More information on Developer Accounts'
         )

--- a/src/olympia/devhub/tests/test_views_ownership.py
+++ b/src/olympia/devhub/tests/test_views_ownership.py
@@ -514,7 +514,7 @@ class TestEditAuthor(TestOwnership):
             {
                 'user': [
                     'The email address used for your account is not '
-                    'allowed for add-on submission.'
+                    'allowed for submissions.'
                 ]
             }
         ]

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -265,7 +265,7 @@ class TestAddonSubmitAgreement(TestSubmitBase):
             doc('.addon-submission-process')
             .text()
             .endswith(
-                'Multiple add-ons violating our policies have been submitted '
+                'Multiple submissions violating our policies have been sent '
                 'from your location. The IP address has been blocked.\n'
                 'More information on Developer Accounts'
             )

--- a/src/olympia/ratings/models.py
+++ b/src/olympia/ratings/models.py
@@ -319,7 +319,7 @@ class RatingFlag(ModelBase):
     )
     FLAGS = (
         *USER_FLAGS,
-        (AUTO, _('Auto-flagged due to word match')),
+        (AUTO, _('Auto-flagged due to word match or user restriction')),
     )
 
     rating = models.ForeignKey(Rating, db_column='review_id', on_delete=models.CASCADE)

--- a/src/olympia/ratings/permissions.py
+++ b/src/olympia/ratings/permissions.py
@@ -2,6 +2,7 @@ from rest_framework.permissions import BasePermission
 
 from olympia import amo
 from olympia.access import acl
+from olympia.addons.utils import RestrictionChecker
 
 
 def user_can_delete_rating(request, rating):
@@ -39,3 +40,18 @@ class CanDeleteRatingPermission(BasePermission):
 
     def has_object_permission(self, request, view, obj):
         return user_can_delete_rating(request, obj)
+
+
+class CanCreateRatingPermission(BasePermission):
+    def has_permission(self, request, view):
+        if not request.user.is_authenticated:
+            return False
+        checker = RestrictionChecker(request=request)
+        if not checker.is_rating_allowed():
+            self.message = checker.get_error_message()
+            self.code = 'permission_denied_restriction'
+            return False
+        return True
+
+    def has_object_permission(self, request, view, obj):
+        return self.has_permission(request)

--- a/src/olympia/ratings/tests/test_views.py
+++ b/src/olympia/ratings/tests/test_views.py
@@ -23,6 +23,12 @@ from olympia.amo.tests import (
     user_factory,
     version_factory,
 )
+from olympia.users.models import (
+    DisposableEmailDomainRestriction,
+    EmailUserRestriction,
+    IPNetworkUserRestriction,
+    RESTRICTION_TYPES,
+)
 
 from ..models import DeniedRatingWord, Rating, RatingFlag
 from ..tasks import addon_rating_aggregates
@@ -2544,6 +2550,150 @@ class TestRatingViewSetPost(TestCase):
         flag = rating.ratingflag_set.get()
         assert flag.flag == RatingFlag.AUTO
         assert flag.note == 'Words matched: [body]'
+
+    def test_user_restriction_deny_by_email(self):
+        self.user = user_factory()
+        EmailUserRestriction.objects.create(
+            email_pattern=self.user.email,
+            restriction_type=RESTRICTION_TYPES.RATING,
+        )
+        self.client.login_api(self.user)
+        assert not Rating.objects.exists()
+        response = self.client.post(
+            self.url,
+            {
+                'addon': self.addon.pk,
+                'body': 'test bOdyé',
+                'score': 5,
+                'version': self.addon.current_version.pk,
+            },
+        )
+        assert response.status_code == 403
+        assert response.data == {'detail': str(EmailUserRestriction.error_message)}
+        assert not Rating.objects.exists()
+
+    def test_user_restriction_deny_by_disposable_email(self):
+        self.user = user_factory(email='foo@baa.com')
+        DisposableEmailDomainRestriction.objects.create(
+            domain='baa.com',
+            restriction_type=RESTRICTION_TYPES.RATING,
+        )
+        self.client.login_api(self.user)
+        assert not Rating.objects.exists()
+        response = self.client.post(
+            self.url,
+            {
+                'addon': self.addon.pk,
+                'body': 'test bOdyé',
+                'score': 5,
+                'version': self.addon.current_version.pk,
+            },
+        )
+        assert response.status_code == 403
+        assert response.data == {
+            'detail': str(DisposableEmailDomainRestriction.error_message)
+        }
+        assert not Rating.objects.exists()
+
+    def test_user_restriction_deny_by_ip(self):
+        self.user = user_factory()
+        ip = '123.45.67.89'
+        IPNetworkUserRestriction.objects.create(
+            network=ip,
+            restriction_type=RESTRICTION_TYPES.RATING,
+        )
+        self.client.login_api(self.user)
+        assert not Rating.objects.exists()
+        response = self.client.post(
+            self.url,
+            data={'addon': str(self.addon.pk), 'message': 'again!'},
+            REMOTE_ADDR=ip,
+            HTTP_X_FORWARDED_FOR=f'{ip}, {get_random_ip()}',
+        )
+        assert response.status_code == 403
+        assert response.data == {'detail': str(IPNetworkUserRestriction.error_message)}
+        assert not Rating.objects.exists()
+
+    def test_user_restriction_flag_by_email(self):
+        user_factory(id=settings.TASK_USER_ID)
+        self.user = user_factory()
+        EmailUserRestriction.objects.create(
+            email_pattern=self.user.email,
+            restriction_type=RESTRICTION_TYPES.RATING_MODERATE,
+        )
+        self.client.login_api(self.user)
+        assert not Rating.objects.exists()
+        response = self.client.post(
+            self.url,
+            {
+                'addon': self.addon.pk,
+                'body': 'test bOdyé',
+                'score': 5,
+                'version': self.addon.current_version.pk,
+            },
+        )
+        assert response.status_code == 201
+        assert Rating.objects.exists()
+        rating = Rating.objects.get()
+        assert rating.editorreview
+        flag = rating.ratingflag_set.get()
+        assert flag.flag == RatingFlag.AUTO
+        assert flag.note == 'Email or IP address matched a UserRestriction'
+
+    def test_user_restriction_flag_by_disposable_email(self):
+        user_factory(id=settings.TASK_USER_ID)
+        self.user = user_factory(email='foo@baa.com')
+        DisposableEmailDomainRestriction.objects.create(
+            domain='baa.com',
+            restriction_type=RESTRICTION_TYPES.RATING_MODERATE,
+        )
+        self.client.login_api(self.user)
+        assert not Rating.objects.exists()
+        response = self.client.post(
+            self.url,
+            {
+                'addon': self.addon.pk,
+                'body': 'test bOdyé',
+                'score': 5,
+                'version': self.addon.current_version.pk,
+            },
+        )
+        assert response.status_code == 201
+        assert Rating.objects.exists()
+        rating = Rating.objects.get()
+        assert rating.editorreview
+        flag = rating.ratingflag_set.get()
+        assert flag.flag == RatingFlag.AUTO
+        assert flag.note == 'Email or IP address matched a UserRestriction'
+
+    def test_user_restriction_flag_by_ip(self):
+        user_factory(id=settings.TASK_USER_ID)
+        self.user = user_factory()
+        ip = '123.45.67.89'
+        IPNetworkUserRestriction.objects.create(
+            network=ip,
+            restriction_type=RESTRICTION_TYPES.RATING_MODERATE,
+        )
+        self.client.login_api(self.user)
+        assert not Rating.objects.exists()
+        response = self.client.post(
+            self.url,
+            {
+                'addon': self.addon.pk,
+                'body': 'test bOdyé',
+                'score': 5,
+                'version': self.addon.current_version.pk,
+            },
+            REMOTE_ADDR=ip,
+            HTTP_X_FORWARDED_FOR=f'{ip}, {get_random_ip()}',
+        )
+        assert response.status_code == 201
+        assert Rating.objects.exists()
+        rating = Rating.objects.get()
+        assert rating.editorreview
+        flag = rating.ratingflag_set.get()
+        assert flag.flag == RatingFlag.AUTO
+        assert flag.note == 'Email or IP address matched a UserRestriction'
 
 
 class TestRatingViewSetFlag(TestCase):

--- a/src/olympia/ratings/views.py
+++ b/src/olympia/ratings/views.py
@@ -4,7 +4,7 @@ from django.utils.encoding import force_str
 from rest_framework import serializers
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotAuthenticated, ParseError, PermissionDenied
-from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.status import HTTP_202_ACCEPTED
 from rest_framework.viewsets import ModelViewSet
@@ -27,7 +27,7 @@ from olympia.api.throttling import GranularIPRateThrottle, GranularUserRateThrot
 from olympia.api.utils import is_gate_active
 
 from .models import Rating, RatingFlag
-from .permissions import CanDeleteRatingPermission
+from .permissions import CanDeleteRatingPermission, CanCreateRatingPermission
 from .serializers import RatingFlagSerializer, RatingSerializer, RatingSerializerReply
 from .utils import get_grouped_ratings
 
@@ -117,7 +117,7 @@ class RatingViewSet(AddonChildMixin, ModelViewSet):
                 # Deletion requires a specific permission check.
                 'delete': CanDeleteRatingPermission,
                 # To post a rating you just need to be authenticated.
-                'post': IsAuthenticated,
+                'post': CanCreateRatingPermission,
                 # To edit a rating you need to be the author or be an admin.
                 'patch': AnyOf(
                     AllowOwner, GroupPermission(amo.permissions.ADDONS_EDIT)

--- a/src/olympia/signing/tests/test_views.py
+++ b/src/olympia/signing/tests/test_views.py
@@ -1022,7 +1022,7 @@ class TestUploadVersionWebextension(BaseUploadVersionTestMixin, TestCase):
         assert response.status_code == 403
         assert json.loads(response.content.decode('utf-8')) == {
             'detail': 'The email address used for your account is not '
-            'allowed for add-on submission.'
+            'allowed for submissions.'
         }
         EmailUserRestriction.objects.all().delete()
         IPNetworkUserRestriction.objects.create(network='127.0.0.1/32')
@@ -1034,9 +1034,8 @@ class TestUploadVersionWebextension(BaseUploadVersionTestMixin, TestCase):
         )
         assert response.status_code == 403
         assert json.loads(response.content.decode('utf-8')) == {
-            'detail': 'Multiple add-ons violating our policies have been '
-            'submitted from your location. The IP address has been '
-            'blocked.'
+            'detail': 'Multiple submissions violating our policies have been sent from '
+            'your location. The IP address has been blocked.'
         }
         assert Addon.objects.count() == 0
 
@@ -1067,9 +1066,8 @@ class TestUploadVersionWebextension(BaseUploadVersionTestMixin, TestCase):
         )
         assert response.status_code == 403
         assert json.loads(response.content.decode('utf-8')) == {
-            'detail': 'Multiple add-ons violating our policies have been '
-            'submitted from your location. The IP address has been '
-            'blocked.'
+            'detail': 'Multiple submissions violating our policies have been sent from '
+            'your location. The IP address has been blocked.'
         }
         assert len(responses.calls) == 2
         assert Addon.objects.count() == 0
@@ -1102,7 +1100,7 @@ class TestUploadVersionWebextension(BaseUploadVersionTestMixin, TestCase):
         assert response.status_code == 403
         assert json.loads(response.content.decode('utf-8')) == {
             'detail': 'The email address used for your account is not '
-            'allowed for add-on submission.'
+            'allowed for submissions.'
         }
         assert len(responses.calls) == 2
         assert Addon.objects.count() == 0

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -642,6 +642,8 @@ class DeniedName(ModelBase):
 RESTRICTION_TYPES = Choices(
     ('SUBMISSION', 1, 'Submission'),
     ('APPROVAL', 2, 'Approval'),
+    ('RATING', 3, 'Rating'),
+    ('RATING_MODERATE', 4, 'Rating Flag for Moderation'),
 )
 
 
@@ -661,6 +663,21 @@ class RestrictionAbstractBase:
         """
         Return whether the specified version should be allowed to be proceed
         through auto-approval process.
+        """
+        return True
+
+    @classmethod
+    def allow_rating(cls, request):
+        """
+        Return whether the specified request should be allowed to submit ratings.
+        """
+        return True
+
+    @classmethod
+    def allow_rating_without_moderation(cls, request):
+        """
+        Return whether ratings from the specified request should not be flagged for
+        moderation.
         """
         return True
 
@@ -695,9 +712,8 @@ class IPNetworkUserRestriction(RestrictionAbstractBaseModel):
     )
 
     error_message = _(
-        'Multiple add-ons violating our policies have been'
-        ' submitted from your location. The IP address has been'
-        ' blocked.'
+        'Multiple submissions violating our policies have been sent from your '
+        'location. The IP address has been blocked.'
     )
 
     class Meta:
@@ -709,25 +725,9 @@ class IPNetworkUserRestriction(RestrictionAbstractBaseModel):
     @classmethod
     def allow_submission(cls, request):
         """
-        Return whether the specified request should be allowed to submit
-        add-ons.
+        Return whether the specified request should be allowed to submit add-ons.
         """
-        try:
-            remote_addr = ipaddress.ip_address(request.META.get('REMOTE_ADDR'))
-            user_last_login_ip = (
-                ipaddress.ip_address(request.user.last_login_ip)
-                if request.user
-                else None
-            )
-        except ValueError:
-            # If we don't have a valid ip address, let's deny
-            return False
-
-        return cls.allow_ips(
-            remote_addr,
-            user_last_login_ip,
-            restriction_type=RESTRICTION_TYPES.SUBMISSION,
-        )
+        return cls.allow_request(request, restriction_type=RESTRICTION_TYPES.SUBMISSION)
 
     @classmethod
     def allow_auto_approval(cls, upload):
@@ -743,6 +743,33 @@ class IPNetworkUserRestriction(RestrictionAbstractBaseModel):
 
         return cls.allow_ips(
             remote_addr, user_last_login_ip, restriction_type=RESTRICTION_TYPES.APPROVAL
+        )
+
+    @classmethod
+    def allow_rating(cls, request):
+        return cls.allow_request(request, restriction_type=RESTRICTION_TYPES.RATING)
+
+    @classmethod
+    def allow_rating_without_moderation(cls, request):
+        return cls.allow_request(
+            request, restriction_type=RESTRICTION_TYPES.RATING_MODERATE
+        )
+
+    @classmethod
+    def allow_request(cls, request, *, restriction_type):
+        try:
+            remote_addr = ipaddress.ip_address(request.META.get('REMOTE_ADDR'))
+            user_last_login_ip = (
+                ipaddress.ip_address(request.user.last_login_ip)
+                if request.user
+                else None
+            )
+        except ValueError:
+            # If we don't have a valid ip address, let's deny
+            return False
+
+        return cls.allow_ips(
+            remote_addr, user_last_login_ip, restriction_type=restriction_type
         )
 
     @classmethod
@@ -803,7 +830,7 @@ class EmailUserRestriction(RestrictionAbstractBaseModel, NormalizeEmailMixin):
     )
 
     error_message = _(
-        'The email address used for your account is not allowed for add-on submission.'
+        'The email address used for your account is not allowed for submissions.'
     )
 
     class Meta:
@@ -823,12 +850,7 @@ class EmailUserRestriction(RestrictionAbstractBaseModel, NormalizeEmailMixin):
         Return whether the specified request should be allowed to submit
         add-ons.
         """
-        if not request.user.is_authenticated:
-            return False
-
-        return cls.allow_email(
-            request.user.email, restriction_type=RESTRICTION_TYPES.SUBMISSION
-        )
+        return cls.allow_request(request, restriction_type=RESTRICTION_TYPES.SUBMISSION)
 
     @classmethod
     def allow_auto_approval(cls, upload):
@@ -837,6 +859,23 @@ class EmailUserRestriction(RestrictionAbstractBaseModel, NormalizeEmailMixin):
         return cls.allow_email(
             upload.user.email, restriction_type=RESTRICTION_TYPES.APPROVAL
         )
+
+    @classmethod
+    def allow_rating(cls, request):
+        return cls.allow_request(request, restriction_type=RESTRICTION_TYPES.RATING)
+
+    @classmethod
+    def allow_rating_without_moderation(cls, request):
+        return cls.allow_request(
+            request, restriction_type=RESTRICTION_TYPES.RATING_MODERATE
+        )
+
+    @classmethod
+    def allow_request(cls, request, *, restriction_type):
+        if not request.user.is_authenticated:
+            return False
+
+        return cls.allow_email(request.user.email, restriction_type=restriction_type)
 
     @classmethod
     def allow_email(cls, email, *, restriction_type):
@@ -889,12 +928,7 @@ class DisposableEmailDomainRestriction(RestrictionAbstractBaseModel):
         Return whether the specified request should be allowed to submit
         add-ons.
         """
-        if not request.user.is_authenticated:
-            return False
-
-        return cls.allow_email(
-            request.user.email, restriction_type=RESTRICTION_TYPES.SUBMISSION
-        )
+        return cls.allow_request(request, restriction_type=RESTRICTION_TYPES.SUBMISSION)
 
     @classmethod
     def allow_auto_approval(cls, upload):
@@ -903,6 +937,23 @@ class DisposableEmailDomainRestriction(RestrictionAbstractBaseModel):
         return cls.allow_email(
             upload.user.email, restriction_type=RESTRICTION_TYPES.APPROVAL
         )
+
+    @classmethod
+    def allow_rating(cls, request):
+        return cls.allow_request(request, restriction_type=RESTRICTION_TYPES.RATING)
+
+    @classmethod
+    def allow_rating_without_moderation(cls, request):
+        return cls.allow_request(
+            request, restriction_type=RESTRICTION_TYPES.RATING_MODERATE
+        )
+
+    @classmethod
+    def allow_request(cls, request, *, restriction_type):
+        if not request.user.is_authenticated:
+            return False
+
+        return cls.allow_email(request.user.email, restriction_type=restriction_type)
 
     @classmethod
     def allow_email(cls, email, *, restriction_type):


### PR DESCRIPTION
fixes #20569 (threw in support for bulk email restrictions too because it was easier than making an exception for that type)

I had to reword the restriction error messages to make them more generic... I think they still read okay.  If not we need to complicate how `error_message` and `get_error_message` works to pass the action as an arg each time.]