### PR TITLE
chore(remote-settings): update dev & stage urls after gcp migration

### DIFF
--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -80,6 +80,6 @@ EXTENSION_WORKSHOP_URL = env(
     'EXTENSION_WORKSHOP_URL', default='https://extensionworkshop.allizom.org'
 )
 
-REMOTE_SETTINGS_API_URL = 'https://settings-cdn.stage.mozaws.net/v1/'
+REMOTE_SETTINGS_API_URL = 'https://firefox.settings.services.allizom.org/v1/'
 REMOTE_SETTINGS_WRITER_URL = 'https://settings-writer.stage.mozaws.net/v1/'
 REMOTE_SETTINGS_WRITER_BUCKET = 'staging'

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1476,8 +1476,8 @@ CUSTOMS_GIT_REPOSITORY = env('CUSTOMS_GIT_REPOSITORY', default=None)
 
 # Addon.average_daily_user count that forces dual sign-off for Blocklist Blocks
 DUAL_SIGNOFF_AVERAGE_DAILY_USERS_THRESHOLD = 100_000
-REMOTE_SETTINGS_API_URL = 'https://kinto.dev.mozaws.net/v1/'
-REMOTE_SETTINGS_WRITER_URL = 'https://kinto.dev.mozaws.net/v1/'
+REMOTE_SETTINGS_API_URL = 'https://remote-settings-dev.allizom.org/v1/'
+REMOTE_SETTINGS_WRITER_URL = 'https://remote-settings-dev.allizom.org/v1/'
 REMOTE_SETTINGS_WRITER_BUCKET = 'blocklists'
 
 # The remote settings test server needs accounts and setting up before using.


### PR DESCRIPTION
This is updating remote-settings dev & stage URLs after GCP migration, writer & reader endpoints have changed.