### PR TITLE
Add heartbeat endpoint for background services monitoring (Fixes #20602)

### DIFF
--- a/src/olympia/amo/monitors.py
+++ b/src/olympia/amo/monitors.py
@@ -197,3 +197,26 @@ def database():
                 monitor_log.critical(status)
 
     return status, None
+
+
+def remotesettings():
+    # check Remote Settings connection
+
+    from olympia.lib.remote_settings import RemoteSettings
+    from olympia.constants.blocklist import REMOTE_SETTINGS_COLLECTION_MLBF
+
+    client = RemoteSettings(
+        settings.REMOTE_SETTINGS_WRITER_BUCKET,
+        REMOTE_SETTINGS_COLLECTION_MLBF,
+    )
+
+    status = ''
+    try:
+        client.heartbeat()
+    except Exception as e:
+        status = f'Failed to contact Remote Settings server: {e}'
+    if not status and not client.authenticated():
+        status = 'Invalid credentials for Remote Settings server'
+    if status:
+        monitor_log.critical(status)
+    return status, None

--- a/src/olympia/amo/monitors.py
+++ b/src/olympia/amo/monitors.py
@@ -219,5 +219,5 @@ def remotesettings():
     from olympia.blocklist.tasks import monitor_remote_settings
 
     result = monitor_remote_settings.delay()
-    status = result.get()
+    status = result.get(timetout=settings.REMOTE_SETTINGS_CHECK_TIMEOUT_SECONDS)
     return status, None

--- a/src/olympia/amo/tests/test_monitor.py
+++ b/src/olympia/amo/tests/test_monitor.py
@@ -1,3 +1,5 @@
+import json
+
 from django.conf import settings
 from django.test.utils import override_settings
 
@@ -77,3 +79,51 @@ class TestMonitor(TestCase):
             status, result = monitors.database()
         assert status == ''
         assert result is None
+
+    def test_remotesettings_success(self):
+        responses.add(
+            responses.GET,
+            f'{settings.REMOTE_SETTINGS_WRITER_URL}__heartbeat__',
+            status=200,
+            body=json.dumps({'check': True}),
+        )
+        responses.add(
+            responses.GET,
+            settings.REMOTE_SETTINGS_WRITER_URL,
+            status=200,
+            body=json.dumps({'user': {'id': 'account:amo'}}),
+        )
+        obtained, _ = monitors.remotesettings()
+        assert obtained == ''
+
+    def test_remotesettings_bad_credentials(self):
+        responses.add(
+            responses.GET,
+            f'{settings.REMOTE_SETTINGS_WRITER_URL}__heartbeat__',
+            status=200,
+            body=json.dumps({'check': True}),
+        )
+        responses.add(
+            responses.GET,
+            settings.REMOTE_SETTINGS_WRITER_URL,
+            status=200,
+            body=json.dumps({}),
+        )
+        obtained, _ = monitors.remotesettings()
+        assert 'Invalid credentials' in obtained
+
+    def test_remotesettings_fail(self):
+        responses.add(
+            responses.GET,
+            f'{settings.REMOTE_SETTINGS_WRITER_URL}__heartbeat__',
+            status=503,
+            body=json.dumps({'check': False}),
+        )
+        responses.add(
+            responses.GET,
+            settings.REMOTE_SETTINGS_WRITER_URL,
+            status=200,
+            body=json.dumps({}),
+        )
+        obtained, _ = monitors.remotesettings()
+        assert '503 Server Error: Service Unavailable' in obtained

--- a/src/olympia/amo/tests/test_views.py
+++ b/src/olympia/amo/tests/test_views.py
@@ -383,11 +383,11 @@ class TestHeartbeat(TestCase):
         assert response.status_code >= 500
         assert response.json()['database']['status'] == 'boom'
 
-    def test_front_heartbeat_success(self):
+    def test_services_heartbeat_success(self):
         response = self.client.get(reverse('amo.services_heartbeat'))
         assert response.status_code == 200
 
-    def test_front_heartbeat_failure(self):
+    def test_services_heartbeat_failure(self):
         self.mocks['rabbitmq'].return_value = ('boom', None)
 
         response = self.client.get(reverse('amo.services_heartbeat'))

--- a/src/olympia/amo/tests/test_views.py
+++ b/src/olympia/amo/tests/test_views.py
@@ -67,7 +67,7 @@ class Test404(TestCase):
     def test_404_no_app(self):
         """Make sure a 404 without an app doesn't turn into a 500."""
         # That could happen if helpers or templates expect APP to be defined.
-        url = reverse('amo.monitor')
+        url = reverse('amo.services_monitor')
         response = self.client.get(url + 'nonsense')
         assert response.status_code == 404
         self.assertTemplateUsed(response, 'amo/404.html')
@@ -349,6 +349,51 @@ class TestOtherStuff(TestCase):
         doc = etree.fromstring(result.content)
         e = doc.find('{http://a9.com/-/spec/opensearch/1.1/}ShortName')
         assert e.text == 'Firefox Add-ons'
+
+
+class TestHeartbeat(TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.mocks = {}
+        for check in [
+            'memcache',
+            'libraries',
+            'elastic',
+            'path',
+            'database',
+            'rabbitmq',
+            'signer',
+            'remotesettings',
+        ]:
+            patcher = mock.patch(f'olympia.amo.monitors.{check}')
+            self.mocks[check] = patcher.start()
+            self.mocks[check].return_value = ('', None)
+            self.addCleanup(patcher.stop)
+
+    def test_front_heartbeat_success(self):
+        response = self.client.get(reverse('amo.front_heartbeat'))
+        assert response.status_code == 200
+
+    def test_front_heartbeat_failure(self):
+        self.mocks['database'].return_value = ('boom', None)
+
+        response = self.client.get(reverse('amo.front_heartbeat'))
+
+        assert response.status_code >= 500
+        assert response.json()['database']['status'] == 'boom'
+
+    def test_front_heartbeat_success(self):
+        response = self.client.get(reverse('amo.services_heartbeat'))
+        assert response.status_code == 200
+
+    def test_front_heartbeat_failure(self):
+        self.mocks['rabbitmq'].return_value = ('boom', None)
+
+        response = self.client.get(reverse('amo.services_heartbeat'))
+
+        assert response.status_code >= 500
+        assert response.json()['rabbitmq']['status'] == 'boom'
 
 
 class TestCORS(TestCase):

--- a/src/olympia/amo/urls.py
+++ b/src/olympia/amo/urls.py
@@ -4,7 +4,10 @@ from django.views.generic.base import TemplateView
 from . import views
 
 services_patterns = [
-    re_path(r'^monitor\.json$', views.heartbeat, name='amo.monitor'),
+    re_path(
+        r'^__heartbeat__$', views.services_heartbeat, name='amo.services_heartbeat'
+    ),
+    re_path(r'^monitor\.json$', views.services_heartbeat, name='amo.services_monitor'),
     re_path(r'^client_info', views.client_info, name='amo.client_info'),
     re_path(r'^403', views.handler403),
     re_path(r'^404', views.handler404),
@@ -20,7 +23,7 @@ urlpatterns = [
     re_path(r'^contribute\.json$', views.contribute, name='contribute.json'),
     re_path(r'^services/', include(services_patterns)),
     re_path(r'^__version__$', views.version, name='version.json'),
-    re_path(r'^__heartbeat__$', views.heartbeat, name='amo.heartbeat'),
+    re_path(r'^__heartbeat__$', views.front_heartbeat, name='amo.front_heartbeat'),
     re_path(
         r'^opensearch\.xml$',
         TemplateView.as_view(

--- a/src/olympia/amo/views.py
+++ b/src/olympia/amo/views.py
@@ -15,7 +15,6 @@ from django.template.response import TemplateResponse
 from django.utils.cache import patch_cache_control
 from django.views.decorators.cache import never_cache
 
-from django_statsd.clients import statsd
 from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -32,27 +31,34 @@ from .sitemap import get_sitemap_path, get_sitemaps, InvalidSection, render_inde
 
 @never_cache
 @non_atomic_requests
-def heartbeat(request):
+def front_heartbeat(request):
     # For each check, a boolean pass/fail status to show in the template
-    status_summary = {}
+    status_summary = monitors.execute_checks(
+        [
+            'memcache',
+            'libraries',
+            'elastic',
+            'path',
+            'database',
+        ]
+    )
+    # If anything broke, send HTTP 500.
+    status_code = 200 if all(a['state'] for a in status_summary.values()) else 500
 
-    checks = [
-        'memcache',
-        'libraries',
-        'elastic',
-        'path',
-        'rabbitmq',
-        'signer',
-        'database',
-        'remotesettings',
-    ]
+    return JsonResponse(status_summary, status=status_code)
 
-    for check in checks:
-        with statsd.timer('monitor.%s' % check):
-            status, _ = getattr(monitors, check)()
-        # state is a string. If it is empty, that means everything is fine.
-        status_summary[check] = {'state': not status, 'status': status}
 
+@never_cache
+@non_atomic_requests
+def services_heartbeat(request):
+    # For each check, a boolean pass/fail status to show in the template
+    status_summary = monitors.execute_checks(
+        [
+            'rabbitmq',
+            'signer',
+            'remotesettings',
+        ]
+    )
     # If anything broke, send HTTP 500.
     status_code = 200 if all(a['state'] for a in status_summary.values()) else 500
 

--- a/src/olympia/amo/views.py
+++ b/src/olympia/amo/views.py
@@ -44,6 +44,7 @@ def heartbeat(request):
         'rabbitmq',
         'signer',
         'database',
+        'remotesettings',
     ]
 
     for check in checks:

--- a/src/olympia/blocklist/tasks.py
+++ b/src/olympia/blocklist/tasks.py
@@ -64,7 +64,7 @@ def process_blocklistsubmission(multi_block_submit_id, **kw):
         raise exc
 
 
-@task
+@task(ignore_result=False)
 def monitor_remote_settings():
     # check Remote Settings connection
     client = RemoteSettings(

--- a/src/olympia/blocklist/tasks.py
+++ b/src/olympia/blocklist/tasks.py
@@ -64,6 +64,9 @@ def process_blocklistsubmission(multi_block_submit_id, **kw):
         raise exc
 
 
+# We rarely care about task results and ignore them by default
+# (CELERY_TASK_IGNORE_RESULT=True) but here we need the result of that task to
+# return it to the monitor view.
 @task(ignore_result=False)
 def monitor_remote_settings():
     # check Remote Settings connection

--- a/src/olympia/blocklist/tasks.py
+++ b/src/olympia/blocklist/tasks.py
@@ -65,6 +65,25 @@ def process_blocklistsubmission(multi_block_submit_id, **kw):
 
 
 @task
+def monitor_remote_settings():
+    # check Remote Settings connection
+    client = RemoteSettings(
+        settings.REMOTE_SETTINGS_WRITER_BUCKET,
+        REMOTE_SETTINGS_COLLECTION_MLBF,
+    )
+    status = ''
+    try:
+        client.heartbeat()
+    except Exception as e:
+        status = f'Failed to contact Remote Settings server: {e}'
+    if not status and not client.authenticated():
+        status = 'Invalid credentials for Remote Settings server'
+    if status:
+        log.critical(status)
+    return status
+
+
+@task
 def upload_filter(generation_time, is_base=True):
     bucket = settings.REMOTE_SETTINGS_WRITER_BUCKET
     server = RemoteSettings(

--- a/src/olympia/lib/remote_settings.py
+++ b/src/olympia/lib/remote_settings.py
@@ -42,6 +42,19 @@ class RemoteSettings:
         b64 = b64encode(f'{self.username}:{self.password}'.encode()).decode()
         return {'Content-Type': 'application/json', 'Authorization': f'Basic {b64}'}
 
+    def heartbeat(self):
+        url = f'{settings.REMOTE_SETTINGS_WRITER_URL}__heartbeat__'
+        response = requests.get(url, headers=self.headers)
+        response.raise_for_status()
+        return response.json()
+
+    def authenticated(self):
+        # Return True if configured credentials can authenticate.
+        response = requests.get(
+            settings.REMOTE_SETTINGS_WRITER_URL, headers=self.headers
+        )
+        return 'id' in response.json().get('user', {})
+
     def setup_test_server_auth(self):
         # check if the user already exists in remote setting's accounts
         host = settings.REMOTE_SETTINGS_WRITER_URL

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -823,7 +823,6 @@ CELERY_TASK_ROUTES = {
     'olympia.addons.tasks.index_addons': {'queue': 'priority'},
     'olympia.blocklist.tasks.process_blocklistsubmission': {'queue': 'priority'},
     'olympia.blocklist.tasks.upload_filter': {'queue': 'priority'},
-    'olympia.blocklist.tasks.monitor_remote_settings': {'queue': 'priority'},
     'olympia.versions.tasks.generate_static_theme_preview': {'queue': 'priority'},
     # Adhoc
     # A queue to be used for one-off tasks that could be resource intensive or
@@ -840,6 +839,7 @@ CELERY_TASK_ROUTES = {
     'olympia.activity.tasks.create_ratinglog': {'queue': 'adhoc'},
     'olympia.files.tasks.extract_host_permissions': {'queue': 'adhoc'},
     # Misc AMO tasks.
+    'olympia.blocklist.tasks.monitor_remote_settings': {'queue': 'amo'},
     'olympia.accounts.tasks.clear_sessions_event': {'queue': 'amo'},
     'olympia.accounts.tasks.delete_user_event': {'queue': 'amo'},
     'olympia.accounts.tasks.primary_email_change_event': {'queue': 'amo'},

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1480,6 +1480,7 @@ DUAL_SIGNOFF_AVERAGE_DAILY_USERS_THRESHOLD = 100_000
 REMOTE_SETTINGS_API_URL = 'https://remote-settings-dev.allizom.org/v1/'
 REMOTE_SETTINGS_WRITER_URL = 'https://remote-settings-dev.allizom.org/v1/'
 REMOTE_SETTINGS_WRITER_BUCKET = 'blocklists'
+REMOTE_SETTINGS_CHECK_TIMEOUT_SECONDS = 10
 
 # The remote settings test server needs accounts and setting up before using.
 REMOTE_SETTINGS_IS_TEST_SERVER = False

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -823,6 +823,7 @@ CELERY_TASK_ROUTES = {
     'olympia.addons.tasks.index_addons': {'queue': 'priority'},
     'olympia.blocklist.tasks.process_blocklistsubmission': {'queue': 'priority'},
     'olympia.blocklist.tasks.upload_filter': {'queue': 'priority'},
+    'olympia.blocklist.tasks.monitor_remote_settings': {'queue': 'priority'},
     'olympia.versions.tasks.generate_static_theme_preview': {'queue': 'priority'},
     # Adhoc
     # A queue to be used for one-off tasks that could be resource intensive or


### PR DESCRIPTION
Fixes #20602

This pull-requests adds a simple monitor check that will read the heartbeat of the configured Remote Settings server

* [x] This PR relates to an existing open issue and there are no existing
      PRs open for the same issue.
* [x] Add `Fixes #ISSUENUM` at the top of your PR.
* [x] Add a description of the changes introduced in this PR.
* [x] The change has been successfully run locally.
* [x] Add tests to cover the changes added in this PR.
* [x] ~~Add before and after screenshots (Only for changes that impact the UI).~~
