### PR TITLE
skips logging DELETE_RATING when addon is deleted

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -770,7 +770,8 @@ class Addon(OnChangeMixin, ModelBase):
 
             # Update or NULL out various fields.
             models.signals.pre_delete.send(sender=Addon, instance=self)
-            self._ratings.all().delete()
+            for rating in self._ratings.all():
+                rating.delete(skip_activity_log=True)
             # We avoid triggering signals for Version & File on purpose to
             # avoid extra work.
             self.disable_all_files()

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -2160,6 +2160,9 @@ class TestAddonDelete(TestCase):
         assert not Rating.objects.filter(pk=rating.pk).exists()
         assert not RatingFlag.objects.filter(pk=flag.pk).exists()
 
+        assert Rating.unfiltered.filter(pk=rating.pk).exists()
+        assert not ActivityLog.objects.filter(action=amo.LOG.DELETE_RATING.id).exists()
+
     def test_delete_with_deleted_versions(self):
         addon = Addon.objects.create(type=amo.ADDON_EXTENSION)
         version = Version.objects.create(addon=addon, version='1.0')

--- a/src/olympia/ratings/models.py
+++ b/src/olympia/ratings/models.py
@@ -174,11 +174,11 @@ class Rating(ModelBase):
             flag.delete()
         self.update(editorreview=False, _signal=False)
 
-    def delete(self):
-        # Log deleting ratings to moderation log, except if the author deletes
-        # it.
+    def delete(self, skip_activity_log=False):
         current_user = core.get_user()
-        if current_user != self.user:
+        # Log deleting ratings to moderation log, except if the rating user deletes it,
+        # or skip_activty_log=True (sent when the addon is being deleted).
+        if not (current_user == self.user or skip_activity_log):
             activity.log_create(
                 amo.LOG.DELETE_RATING,
                 self.addon,

--- a/src/olympia/ratings/tests/test_models.py
+++ b/src/olympia/ratings/tests/test_models.py
@@ -39,6 +39,7 @@ class TestRatingModel(TestCase):
 
         addon.reload()
         assert addon.average_rating == 4.0  # Has been computed after deletion.
+        assert not ActivityLog.objects.filter(action=amo.LOG.DELETE_RATING.id).exists()
 
     @mock.patch('olympia.ratings.models.log')
     def test_soft_delete_by_different_user(self, log_mock):
@@ -55,6 +56,14 @@ class TestRatingModel(TestCase):
         assert log_mock.info.call_args[0][2] == rating.pk
         assert log_mock.info.call_args[0][3] == str(rating.user)
         assert log_mock.info.call_args[0][4] == str(rating.body)
+        assert ActivityLog.objects.filter(action=amo.LOG.DELETE_RATING.id).exists()
+
+    def test_soft_delete_by_different_user_skip_activty_log(self):
+        different_user = user_factory()
+        core.set_user(different_user)
+        rating = Rating.objects.get(id=1)
+        rating.delete(skip_activity_log=True)
+        assert not ActivityLog.objects.filter(action=amo.LOG.DELETE_RATING.id).exists()
 
     def test_hard_delete(self):
         # Hard deletion is only for tests, but it's still useful to make sure
@@ -63,6 +72,7 @@ class TestRatingModel(TestCase):
         Rating.objects.filter(id=1).delete(hard_delete=True)
         assert Rating.unfiltered.count() == 1
         assert Rating.objects.filter(id=2).exists()
+        assert not ActivityLog.objects.filter(action=amo.LOG.DELETE_RATING.id).exists()
 
     def test_undelete(self):
         self.test_soft_delete()


### PR DESCRIPTION
fixes #20585 - I looked for a way to do it without passing an extra parameter but we don't change the add-on status to `STATUS_DELETED` until after the ratings are deleted so the Rating instance doesn't know at that point.  

(I considered checking `core.get_user()` against the addon authors too, but it seemed like there would be lot of extra queries generated per Rating instance, and it wouldn't catch admins deleting the add-on either)