### PR TITLE
add logging for review replies + test

### DIFF
--- a/src/olympia/ratings/models.py
+++ b/src/olympia/ratings/models.py
@@ -279,12 +279,10 @@ class Rating(ModelBase):
             else:
                 log.info(f'{action} rating: {instance.pk}')
 
-            # For new ratings - not replies - and all edits (including replies
-            # this time) by users we want to insert a new ActivityLog.
-            new_rating_or_edit = not instance.reply_to or not created
-            if new_rating_or_edit:
-                action = amo.LOG.ADD_RATING if created else amo.LOG.EDIT_RATING
-                activity.log_create(action, instance.addon, instance)
+            # For new ratings, replies, and all edits by users we want 
+            # to insert a new ActivityLog.
+            action = amo.LOG.ADD_RATING if created else amo.LOG.EDIT_RATING
+            activity.log_create(action, instance.addon, instance)
 
             # For new ratings and new replies we want to send an email.
             if created:

--- a/src/olympia/ratings/tests/test_models.py
+++ b/src/olympia/ratings/tests/test_models.py
@@ -229,7 +229,7 @@ class TestRatingModel(TestCase):
         assert email.to == [addon_author.email]
         assert email.from_email == 'Mozilla Add-ons <nobody@mozilla.org>'
 
-    def test_reply_triggers_email_but_no_logging(self):
+    def test_reply_triggers_email_and_logging(self):
         rating = Rating.objects.get(id=1)
         user = user_factory()
         core.set_user(user)
@@ -240,7 +240,7 @@ class TestRatingModel(TestCase):
             body='Rêply',
         )
 
-        assert not ActivityLog.objects.exists()
+        assert ActivityLog.objects.exists()
         assert len(mail.outbox) == 1
         email = mail.outbox[0]
         reply_url = jinja_helpers.absolutify(


### PR DESCRIPTION
Fixes #20168 

Remove the blocking of ADD_RATING logging for review replies. Update the associated test name & assertion.