### PR TITLE
consolidate sparse info into table classes

### DIFF
--- a/src/olympia/reviewers/templates/reviewers/queue.html
+++ b/src/olympia/reviewers/templates/reviewers/queue.html
@@ -1,16 +1,10 @@
 {% extends "reviewers/base.html" %}
 
 {% block title %}
-  {% if tab == "content_review" %}
-    Content Review – Add-ons for Firefox
-  {% elif tab == "auto_approved" %}
-    Auto-approved Add-ons – Add-ons for Firefox
-  {% elif tab == "moderated" %}
+  {% if tab == "moderated" %}
     Review Moderation – Add-ons for Firefox
-  {% elif tab == "unlisted_queue_all" %}
-    Unlisted Add-ons – Add-ons for Firefox
-  {% elif tab == "pending_rejection" %}
-    Pending Rejection – Add-ons for Firefox
+  {% elif title %}
+    {{ title }} - Add-ons for Firefox
   {% else %}
     {{ super() }}
   {% endif %}

--- a/src/olympia/reviewers/templates/reviewers/queue.html
+++ b/src/olympia/reviewers/templates/reviewers/queue.html
@@ -15,7 +15,7 @@
 {% block content %}
 
 <ul class="tabnav">
-  {% for this, loc, text in queue_tabnav() %}
+  {% for this, loc, text in queue_tabnav(registry) %}
   <li class="{% if tab==this %}selected{% endif %}"><a href="{{ url('reviewers.%s' % loc) }}">{{ text }}</a></li>
   {% endfor %}
 </ul>

--- a/src/olympia/reviewers/templatetags/jinja_helpers.py
+++ b/src/olympia/reviewers/templatetags/jinja_helpers.py
@@ -21,56 +21,27 @@ def queue_tabnav(context, reviewer_tables_registry):
     request = context['request']
     tabnav = []
 
-    if acl.action_allowed_for(request.user, amo.permissions.ADDONS_REVIEW):
-        tabnav.extend(
-            (
+    for queue in (
+        'extension',
+        'mad',
+        'theme_nominated',
+        'theme_pending',
+        'moderation',
+        'content_review',
+        'pending_rejection',
+    ):
+        if queue in reviewer_tables_registry and acl.action_allowed_for(
+            request.user, reviewer_tables_registry[queue].permission
+        ):
+            tabnav.append(
                 (
-                    'extension',
-                    reviewer_tables_registry['extension'].urlname,
-                    reviewer_tables_registry['extension'].title,
-                ),
-                (
-                    'mad',
-                    reviewer_tables_registry['mad'].urlname,
-                    reviewer_tables_registry['mad'].title,
-                ),
+                    queue,
+                    reviewer_tables_registry[queue].urlname,
+                    reviewer_tables_registry[queue].title,
+                )
             )
-        )
-    if acl.action_allowed_for(request.user, amo.permissions.STATIC_THEMES_REVIEW):
-        tabnav.extend(
-            (
-                (
-                    'theme_nominated',
-                    reviewer_tables_registry['theme_nominated'].urlname,
-                    reviewer_tables_registry['theme_nominated'].title,
-                ),
-                (
-                    'theme_pending',
-                    reviewer_tables_registry['theme_pending'].urlname,
-                    reviewer_tables_registry['theme_pending'].title,
-                ),
-            )
-        )
-    if acl.action_allowed_for(request.user, amo.permissions.RATINGS_MODERATE):
-        tabnav.append(('moderated', 'queue_moderated', 'Rating Reviews'))
-
-    if acl.action_allowed_for(request.user, amo.permissions.ADDONS_CONTENT_REVIEW):
-        tabnav.append(
-            (
-                'content_review',
-                reviewer_tables_registry['content_review'].urlname,
-                reviewer_tables_registry['content_review'].title,
-            )
-        )
-
-    if acl.action_allowed_for(request.user, amo.permissions.REVIEWS_ADMIN):
-        tabnav.append(
-            (
-                'pending_rejection',
-                reviewer_tables_registry['pending_rejection'].urlname,
-                reviewer_tables_registry['pending_rejection'].title,
-            )
-        )
+        elif acl.action_allowed_for(request.user, amo.permissions.RATINGS_MODERATE):
+            tabnav.append(('moderated', 'queue_moderated', 'Rating Reviews'))
 
     return tabnav
 

--- a/src/olympia/reviewers/templatetags/jinja_helpers.py
+++ b/src/olympia/reviewers/templatetags/jinja_helpers.py
@@ -40,7 +40,9 @@ def queue_tabnav(context, reviewer_tables_registry):
                     reviewer_tables_registry[queue].title,
                 )
             )
-        elif acl.action_allowed_for(request.user, amo.permissions.RATINGS_MODERATE):
+        elif queue not in reviewer_tables_registry and acl.action_allowed_for(
+            request.user, amo.permissions.RATINGS_MODERATE
+        ):
             tabnav.append(('moderated', 'queue_moderated', 'Rating Reviews'))
 
     return tabnav

--- a/src/olympia/reviewers/templatetags/jinja_helpers.py
+++ b/src/olympia/reviewers/templatetags/jinja_helpers.py
@@ -13,22 +13,27 @@ from olympia.reviewers.templatetags import code_manager
 
 @library.global_function
 @jinja2.pass_context
-def queue_tabnav(context):
+def queue_tabnav(context, reviewer_tables_registry):
     """Returns tuple of tab navigation for the queue pages.
 
     Each tuple contains three elements: (tab_code, page_url, tab_text)
     """
     request = context['request']
     tabnav = []
+
     if acl.action_allowed_for(request.user, amo.permissions.ADDONS_REVIEW):
         tabnav.extend(
             (
                 (
                     'extension',
-                    'queue_extension',
-                    '🛠️ Manual Review',
+                    reviewer_tables_registry['extension'].urlname,
+                    reviewer_tables_registry['extension'].title,
                 ),
-                ('mad', 'queue_mad', 'Flagged by MAD for Human Review'),
+                (
+                    'mad',
+                    reviewer_tables_registry['mad'].urlname,
+                    reviewer_tables_registry['mad'].title,
+                ),
             )
         )
     if acl.action_allowed_for(request.user, amo.permissions.STATIC_THEMES_REVIEW):
@@ -36,13 +41,13 @@ def queue_tabnav(context):
             (
                 (
                     'theme_nominated',
-                    'queue_theme_nominated',
-                    '🎨 New',
+                    reviewer_tables_registry['theme_nominated'].urlname,
+                    reviewer_tables_registry['theme_nominated'].title,
                 ),
                 (
                     'theme_pending',
-                    'queue_theme_pending',
-                    '🎨 Updates',
+                    reviewer_tables_registry['theme_pending'].urlname,
+                    reviewer_tables_registry['theme_pending'].title,
                 ),
             )
         )
@@ -50,14 +55,20 @@ def queue_tabnav(context):
         tabnav.append(('moderated', 'queue_moderated', 'Rating Reviews'))
 
     if acl.action_allowed_for(request.user, amo.permissions.ADDONS_CONTENT_REVIEW):
-        tabnav.append(('content_review', 'queue_content_review', 'Content Review'))
+        tabnav.append(
+            (
+                'content_review',
+                reviewer_tables_registry['content_review'].urlname,
+                reviewer_tables_registry['content_review'].title,
+            )
+        )
 
     if acl.action_allowed_for(request.user, amo.permissions.REVIEWS_ADMIN):
         tabnav.append(
             (
                 'pending_rejection',
-                'queue_pending_rejection',
-                'Pending Rejection',
+                reviewer_tables_registry['pending_rejection'].urlname,
+                reviewer_tables_registry['pending_rejection'].title,
             )
         )
 

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -71,7 +71,7 @@ from olympia.reviewers.models import (
     Whiteboard,
 )
 from olympia.reviewers.templatetags.jinja_helpers import code_manager_url
-from olympia.reviewers.views import _queue
+from olympia.reviewers.views import queue
 from olympia.scanners.models import ScannerResult, ScannerRule
 from olympia.users.models import UserProfile
 from olympia.versions.models import (
@@ -1374,7 +1374,7 @@ class TestQueueBasics(QueueTest):
 
     @override_settings(DEBUG=True, LESS_PREPROCESS=False)
     def test_queue_is_never_executing_the_full_query(self):
-        """Test that _queue() is paginating without accidentally executing the
+        """Test that queue() is paginating without accidentally executing the
         full query."""
         self.grant_permission(self.user, 'Addons:ContentReview')
         request = RequestFactory().get('/')
@@ -1383,7 +1383,7 @@ class TestQueueBasics(QueueTest):
         self.generate_files()
         qs = Addon.objects.all().no_transforms()
 
-        # Execute the queryset we're passing to the _queue() so that we have
+        # Execute the queryset we're passing to the queue() so that we have
         # the exact query to compare to later (we can't use str(qs.query) to do
         # that, it has subtle differences in representation because of the way
         # params are passed for the lang=lang hack).
@@ -1393,7 +1393,7 @@ class TestQueueBasics(QueueTest):
         full_query = connection.queries[0]['sql']
 
         reset_queries()
-        response = _queue(request, 'content_review')
+        response = queue(request, 'content_review')
         response.render()
         assert connection.queries
         assert full_query not in [item['sql'] for item in connection.queries]
@@ -1404,7 +1404,7 @@ class TestQueueBasics(QueueTest):
         request = RequestFactory().get('/', {'per_page': 2})
         request.user = self.user
         reset_queries()
-        response = _queue(request, 'content_review')
+        response = queue(request, 'content_review')
         response.render()
         assert connection.queries
         assert full_query not in [item['sql'] for item in connection.queries]
@@ -1415,7 +1415,7 @@ class TestQueueBasics(QueueTest):
         request = RequestFactory().get('/', {'per_page': 2, 'page': 2})
         request.user = self.user
         reset_queries()
-        response = _queue(request, 'content_review')
+        response = queue(request, 'content_review')
         response.render()
         assert connection.queries
         assert full_query not in [item['sql'] for item in connection.queries]

--- a/src/olympia/reviewers/urls.py
+++ b/src/olympia/reviewers/urls.py
@@ -6,50 +6,27 @@ from olympia.reviewers import views
 from olympia.users.urls import USER_ID
 
 
+def queue_urls():
+    return [
+        re_path(
+            views.reviewer_tables_registry[queue].url,
+            views.queue,
+            kwargs={'tab': queue},
+            name='reviewers.' + views.reviewer_tables_registry[queue].urlname,
+        )
+        for queue in views.reviewer_tables_registry
+    ]
+
+
 # All URLs under /reviewers/
 urlpatterns = (
     re_path(r'^$', views.dashboard, name='reviewers.dashboard'),
     re_path(
         r'^dashboard$', lambda request: redirect('reviewers.dashboard', permanent=True)
     ),
-    re_path(
-        views.reviewer_tables_registry['extension'].url,
-        views.queue,
-        kwargs={'tab': 'extension'},
-        name=views.reviewer_tables_registry['extension'].urlname,
-    ),
-    re_path(
-        views.reviewer_tables_registry['theme_nominated'].url,
-        views.queue,
-        kwargs={'tab': 'theme_nominated'},
-        name=views.reviewer_tables_registry['theme_nominated'].urlname,
-    ),
-    re_path(
-        views.reviewer_tables_registry['theme_pending'].url,
-        views.queue,
-        kwargs={'tab': 'theme_pending'},
-        name=views.reviewer_tables_registry['theme_pending'].urlname,
-    ),
+    re_path(r'^queue/', include(queue_urls())),
     re_path(
         r'^queue/reviews$', views.queue_moderated, name='reviewers.queue_moderated'
-    ),
-    re_path(
-        views.reviewer_tables_registry['content_review'].url,
-        views.queue,
-        kwargs={'tab': 'content_review'},
-        name=views.reviewer_tables_registry['content_review'].urlname,
-    ),
-    re_path(
-        views.reviewer_tables_registry['mad'].url,
-        views.queue,
-        kwargs={'tab': 'mad'},
-        name=views.reviewer_tables_registry['mad'].urlname,
-    ),
-    re_path(
-        views.reviewer_tables_registry['pending_rejection'].url,
-        views.queue,
-        kwargs={'tab': 'pending_rejection'},
-        name=views.reviewer_tables_registry['pending_rejection'].urlname,
     ),
     re_path(
         r'^moderationlog$',

--- a/src/olympia/reviewers/urls.py
+++ b/src/olympia/reviewers/urls.py
@@ -13,31 +13,43 @@ urlpatterns = (
         r'^dashboard$', lambda request: redirect('reviewers.dashboard', permanent=True)
     ),
     re_path(
-        r'^queue/extension$', views.queue_extension, name='reviewers.queue_extension'
+        getattr(views.reviewer_tables_registry['extension'], 'url'),
+        views.queue,
+        kwargs={'tab': 'extension'}, 
+        name=getattr(views.reviewer_tables_registry['extension'], 'urlname'),
     ),
     re_path(
-        r'^queue/theme_new$',
-        views.queue_theme_nominated,
-        name='reviewers.queue_theme_nominated',
+        getattr(views.reviewer_tables_registry['theme_nominated'], 'url'),
+        views.queue,
+        kwargs={'tab': 'theme_nominated'},
+        name=getattr(views.reviewer_tables_registry['theme_nominated'], 'urlname'),
     ),
     re_path(
-        r'^queue/theme_updates$',
-        views.queue_theme_pending,
-        name='reviewers.queue_theme_pending',
+        getattr(views.reviewer_tables_registry['theme_pending'], 'url'),
+        views.queue,
+        kwargs={'tab': 'theme_pending'},
+        name=getattr(views.reviewer_tables_registry['theme_pending'], 'urlname'),
     ),
     re_path(
         r'^queue/reviews$', views.queue_moderated, name='reviewers.queue_moderated'
     ),
     re_path(
-        r'^queue/content_review',
-        views.queue_content_review,
-        name='reviewers.queue_content_review',
+        getattr(views.reviewer_tables_registry['content_review'], 'url'),
+        views.queue,
+        kwargs={'tab': 'content_review'},
+        name=getattr(views.reviewer_tables_registry['content_review'], 'urlname'),
     ),
-    re_path(r'^queue/mad', views.queue_mad, name='reviewers.queue_mad'),
     re_path(
-        r'queue/pending_rejection',
-        views.queue_pending_rejection,
-        name='reviewers.queue_pending_rejection',
+        getattr(views.reviewer_tables_registry['mad'], 'url'),
+        views.queue,
+        kwargs={'tab': 'mad'},
+        name=getattr(views.reviewer_tables_registry['mad'], 'urlname'),
+    ),
+    re_path(
+        getattr(views.reviewer_tables_registry['pending_rejection'], 'url'),
+        views.queue,
+        kwargs={'tab': 'pending_rejection'},
+        name=getattr(views.reviewer_tables_registry['pending_rejection'], 'urlname'),
     ),
     re_path(
         r'^moderationlog$',

--- a/src/olympia/reviewers/urls.py
+++ b/src/olympia/reviewers/urls.py
@@ -1,4 +1,4 @@
-from django.urls import re_path
+from django.urls import re_path, include
 from django.shortcuts import redirect
 
 from olympia.addons.urls import ADDON_ID
@@ -13,43 +13,43 @@ urlpatterns = (
         r'^dashboard$', lambda request: redirect('reviewers.dashboard', permanent=True)
     ),
     re_path(
-        getattr(views.reviewer_tables_registry['extension'], 'url'),
+        views.reviewer_tables_registry['extension'].url,
         views.queue,
-        kwargs={'tab': 'extension'}, 
-        name=getattr(views.reviewer_tables_registry['extension'], 'urlname'),
+        kwargs={'tab': 'extension'},
+        name=views.reviewer_tables_registry['extension'].urlname,
     ),
     re_path(
-        getattr(views.reviewer_tables_registry['theme_nominated'], 'url'),
+        views.reviewer_tables_registry['theme_nominated'].url,
         views.queue,
         kwargs={'tab': 'theme_nominated'},
-        name=getattr(views.reviewer_tables_registry['theme_nominated'], 'urlname'),
+        name=views.reviewer_tables_registry['theme_nominated'].urlname,
     ),
     re_path(
-        getattr(views.reviewer_tables_registry['theme_pending'], 'url'),
+        views.reviewer_tables_registry['theme_pending'].url,
         views.queue,
         kwargs={'tab': 'theme_pending'},
-        name=getattr(views.reviewer_tables_registry['theme_pending'], 'urlname'),
+        name=views.reviewer_tables_registry['theme_pending'].urlname,
     ),
     re_path(
         r'^queue/reviews$', views.queue_moderated, name='reviewers.queue_moderated'
     ),
     re_path(
-        getattr(views.reviewer_tables_registry['content_review'], 'url'),
+        views.reviewer_tables_registry['content_review'].url,
         views.queue,
         kwargs={'tab': 'content_review'},
-        name=getattr(views.reviewer_tables_registry['content_review'], 'urlname'),
+        name=views.reviewer_tables_registry['content_review'].urlname,
     ),
     re_path(
-        getattr(views.reviewer_tables_registry['mad'], 'url'),
+        views.reviewer_tables_registry['mad'].url,
         views.queue,
         kwargs={'tab': 'mad'},
-        name=getattr(views.reviewer_tables_registry['mad'], 'urlname'),
+        name=views.reviewer_tables_registry['mad'].urlname,
     ),
     re_path(
-        getattr(views.reviewer_tables_registry['pending_rejection'], 'url'),
+        views.reviewer_tables_registry['pending_rejection'].url,
         views.queue,
         kwargs={'tab': 'pending_rejection'},
-        name=getattr(views.reviewer_tables_registry['pending_rejection'], 'urlname'),
+        name=views.reviewer_tables_registry['pending_rejection'].urlname,
     ),
     re_path(
         r'^moderationlog$',

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -142,6 +142,10 @@ class PendingManualApprovalQueueTable(AddonQueueTable):
         verbose_name='Maliciousness Score',
         accessor='first_pending_version__autoapprovalsummary__score',
     )
+    title = 'Manual Review'
+    urlname = 'reviewers.queue_extension'
+    url = r'^queue/extension$'
+    permission = amo.permissions.ADDONS_REVIEW
 
     class Meta:
         fields = ('addon_name', 'addon_type', 'due_date', 'flags', 'score')
@@ -189,6 +193,10 @@ class PendingManualApprovalQueueTable(AddonQueueTable):
 
 
 class NewThemesQueueTable(PendingManualApprovalQueueTable):
+    title = 'New Themes'
+    urlname = 'reviewers.queue_theme_nominated'
+    url = r'^queue/theme_new'
+    permission = amo.permissions.STATIC_THEMES_REVIEW
     class Meta(AddonQueueTable.Meta):
         exclude = (
             'score',
@@ -207,6 +215,10 @@ class NewThemesQueueTable(PendingManualApprovalQueueTable):
 
 
 class UpdatedThemesQueueTable(NewThemesQueueTable):
+    title = 'Updated Themes'
+    urlname = 'reviewers.queue_theme_pending'
+    url = r'^queue/theme_updates'
+
     @classmethod
     def get_queryset(cls, request, **kw):
         return Addon.objects.get_queryset_for_pending_queues(
@@ -235,7 +247,10 @@ class PendingRejectionTable(AddonQueueTable):
         verbose_name='Maliciousness Score',
         accessor='first_pending_version__autoapprovalsummary__score',
     )
-
+    title = 'Pending Rejection'
+    urlname = 'reviewers.queue_pending_rejection'
+    url = r'^queue/pending_rejection'
+    permission = amo.permissions.REVIEWS_ADMIN
     class Meta(PendingManualApprovalQueueTable.Meta):
         fields = (
             'addon_name',
@@ -266,6 +281,10 @@ class PendingRejectionTable(AddonQueueTable):
 
 class ContentReviewTable(AddonQueueTable):
     last_updated = tables.DateTimeColumn(verbose_name='Last Updated')
+    title = 'Content Review'
+    urlname = 'reviewers.queue_content_review'
+    url = r'^queue/content_review'
+    permission = amo.permissions.ADDONS_CONTENT_REVIEW
 
     class Meta(AddonQueueTable.Meta):
         fields = ('addon_name', 'flags', 'last_updated')
@@ -295,6 +314,10 @@ class MadReviewTable(AddonQueueTable):
     listed_text = 'Listed version'
     unlisted_text = 'Unlisted versions ({0})'
     show_count_in_dashboard = False
+    title = 'MAD Flagged'
+    urlname = 'reviewers.queue_mad'
+    url = r'^queue/mad'
+    permission = amo.permissions.ADDONS_REVIEW
 
     def render_addon_name(self, record):
         rval = [markupsafe.escape(record.name)]

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -142,9 +142,9 @@ class PendingManualApprovalQueueTable(AddonQueueTable):
         verbose_name='Maliciousness Score',
         accessor='first_pending_version__autoapprovalsummary__score',
     )
-    title = 'Manual Review'
-    urlname = 'reviewers.queue_extension'
-    url = r'^queue/extension$'
+    title = '🛠️ Manual Review'
+    urlname = 'queue_extension'
+    url = r'^extension$'
     permission = amo.permissions.ADDONS_REVIEW
 
     class Meta:
@@ -193,9 +193,9 @@ class PendingManualApprovalQueueTable(AddonQueueTable):
 
 
 class NewThemesQueueTable(PendingManualApprovalQueueTable):
-    title = 'New Themes'
-    urlname = 'reviewers.queue_theme_nominated'
-    url = r'^queue/theme_new'
+    title = '🎨 New'
+    urlname = 'queue_theme_nominated'
+    url = r'^theme_new$'
     permission = amo.permissions.STATIC_THEMES_REVIEW
 
     class Meta(AddonQueueTable.Meta):
@@ -216,9 +216,9 @@ class NewThemesQueueTable(PendingManualApprovalQueueTable):
 
 
 class UpdatedThemesQueueTable(NewThemesQueueTable):
-    title = 'Updated Themes'
-    urlname = 'reviewers.queue_theme_pending'
-    url = r'^queue/theme_updates'
+    title = '🎨 Updates'
+    urlname = 'queue_theme_pending'
+    url = r'^theme_updates$'
 
     @classmethod
     def get_queryset(cls, request, **kw):
@@ -249,8 +249,8 @@ class PendingRejectionTable(AddonQueueTable):
         accessor='first_pending_version__autoapprovalsummary__score',
     )
     title = 'Pending Rejection'
-    urlname = 'reviewers.queue_pending_rejection'
-    url = r'^queue/pending_rejection'
+    urlname = 'queue_pending_rejection'
+    url = r'^pending_rejection$'
     permission = amo.permissions.REVIEWS_ADMIN
 
     class Meta(PendingManualApprovalQueueTable.Meta):
@@ -284,8 +284,8 @@ class PendingRejectionTable(AddonQueueTable):
 class ContentReviewTable(AddonQueueTable):
     last_updated = tables.DateTimeColumn(verbose_name='Last Updated')
     title = 'Content Review'
-    urlname = 'reviewers.queue_content_review'
-    url = r'^queue/content_review'
+    urlname = 'queue_content_review'
+    url = r'^content_review$'
     permission = amo.permissions.ADDONS_CONTENT_REVIEW
 
     class Meta(AddonQueueTable.Meta):
@@ -316,9 +316,9 @@ class MadReviewTable(AddonQueueTable):
     listed_text = 'Listed version'
     unlisted_text = 'Unlisted versions ({0})'
     show_count_in_dashboard = False
-    title = 'MAD Flagged'
-    urlname = 'reviewers.queue_mad'
-    url = r'^queue/mad'
+    title = 'Flagged by MAD for Human Review'
+    urlname = 'queue_mad'
+    url = r'^mad$'
     permission = amo.permissions.ADDONS_REVIEW
 
     def render_addon_name(self, record):

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -197,6 +197,7 @@ class NewThemesQueueTable(PendingManualApprovalQueueTable):
     urlname = 'reviewers.queue_theme_nominated'
     url = r'^queue/theme_new'
     permission = amo.permissions.STATIC_THEMES_REVIEW
+
     class Meta(AddonQueueTable.Meta):
         exclude = (
             'score',
@@ -251,6 +252,7 @@ class PendingRejectionTable(AddonQueueTable):
     urlname = 'reviewers.queue_pending_rejection'
     url = r'^queue/pending_rejection'
     permission = amo.permissions.REVIEWS_ADMIN
+
     class Meta(PendingManualApprovalQueueTable.Meta):
         fields = (
             'addon_name',

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -298,37 +298,44 @@ def save_motd(request):
     data = context(form=form)
     return TemplateResponse(request, 'reviewers/motd.html', context=data)
 
+def queue(request, tab):
+    @permission_or_tools_listed_view_required(getattr(reviewer_tables_registry[tab], 'permission', None))
+    def _queue(request, tab, unlisted=False):
+        TableObj = reviewer_tables_registry[tab]
+        qs = TableObj.get_queryset(request=request, upcoming_due_date_focus=True)
+        params = {}
+        order_by = request.GET.get('sort')
+        if order_by is None and hasattr(TableObj, 'default_order_by'):
+            order_by = TableObj.default_order_by()
+        if order_by is not None:
+            params['order_by'] = order_by
+        table = TableObj(data=qs, **params)
+        per_page = request.GET.get('per_page', REVIEWS_PER_PAGE)
+        try:
+            per_page = int(per_page)
+        except ValueError:
+            per_page = REVIEWS_PER_PAGE
+        if per_page <= 0 or per_page > REVIEWS_PER_PAGE_MAX:
+            per_page = REVIEWS_PER_PAGE
+        count = construct_count_queryset_from_queryset(qs)()
+        page = paginate(request, table.rows, per_page=per_page, count=count)
 
-def _queue(request, tab, unlisted=False):
-    TableObj = reviewer_tables_registry[tab]
-    qs = TableObj.get_queryset(request=request, upcoming_due_date_focus=True)
-    params = {}
-    order_by = request.GET.get('sort')
-    if order_by is None and hasattr(TableObj, 'default_order_by'):
-        order_by = TableObj.default_order_by()
-    if order_by is not None:
-        params['order_by'] = order_by
-    table = TableObj(data=qs, **params)
-    per_page = request.GET.get('per_page', REVIEWS_PER_PAGE)
-    try:
-        per_page = int(per_page)
-    except ValueError:
-        per_page = REVIEWS_PER_PAGE
-    if per_page <= 0 or per_page > REVIEWS_PER_PAGE_MAX:
-        per_page = REVIEWS_PER_PAGE
-    count = construct_count_queryset_from_queryset(qs)()
-    page = paginate(request, table.rows, per_page=per_page, count=count)
+        # get the title attribute from the table class
+        title = getattr(TableObj, 'title', None)
 
-    return TemplateResponse(
-        request,
-        'reviewers/queue.html',
-        context=context(
-            table=table,
-            page=page,
-            tab=tab,
-            unlisted=unlisted,
-        ),
-    )
+        return TemplateResponse(
+            request,
+            'reviewers/queue.html',
+            context=context(
+                table=table,
+                page=page,
+                tab=tab,
+                unlisted=unlisted,
+                title=title,
+            ),
+        )
+
+    return _queue(request, tab)
 
 
 reviewer_tables_registry = {
@@ -366,21 +373,6 @@ def fetch_queue_counts(request):
     return {queue: count() for (queue, count) in counts.items()}
 
 
-@permission_or_tools_listed_view_required(amo.permissions.ADDONS_REVIEW)
-def queue_extension(request):
-    return _queue(request, 'extension')
-
-
-@permission_or_tools_listed_view_required(amo.permissions.STATIC_THEMES_REVIEW)
-def queue_theme_nominated(request):
-    return _queue(request, 'theme_nominated')
-
-
-@permission_or_tools_listed_view_required(amo.permissions.STATIC_THEMES_REVIEW)
-def queue_theme_pending(request):
-    return _queue(request, 'theme_pending')
-
-
 @permission_or_tools_listed_view_required(amo.permissions.RATINGS_MODERATE)
 def queue_moderated(request):
     qs = Rating.objects.all().to_moderate().order_by('ratingflag__created')
@@ -415,21 +407,6 @@ def queue_moderated(request):
             flags=flags,
         ),
     )
-
-
-@permission_or_tools_listed_view_required(amo.permissions.ADDONS_CONTENT_REVIEW)
-def queue_content_review(request):
-    return _queue(request, 'content_review')
-
-
-@permission_or_tools_listed_view_required(amo.permissions.ADDONS_REVIEW)
-def queue_mad(request):
-    return _queue(request, 'mad')
-
-
-@permission_or_tools_listed_view_required(amo.permissions.REVIEWS_ADMIN)
-def queue_pending_rejection(request):
-    return _queue(request, 'pending_rejection')
 
 
 def determine_channel(channel_as_text):

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -298,10 +298,12 @@ def save_motd(request):
     data = context(form=form)
     return TemplateResponse(request, 'reviewers/motd.html', context=data)
 
+
 def queue(request, tab):
-    @permission_or_tools_listed_view_required(getattr(reviewer_tables_registry[tab], 'permission', None))
-    def _queue(request, tab, unlisted=False):
-        TableObj = reviewer_tables_registry[tab]
+    TableObj = reviewer_tables_registry[tab]
+
+    @permission_or_tools_listed_view_required(TableObj.permission)
+    def _queue(request, tab):
         qs = TableObj.get_queryset(request=request, upcoming_due_date_focus=True)
         params = {}
         order_by = request.GET.get('sort')
@@ -330,7 +332,6 @@ def queue(request, tab):
                 table=table,
                 page=page,
                 tab=tab,
-                unlisted=unlisted,
                 title=title,
             ),
         )

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -333,6 +333,7 @@ def queue(request, tab):
                 page=page,
                 tab=tab,
                 title=title,
+                registry=reviewer_tables_registry,
             ),
         )
 
@@ -406,6 +407,7 @@ def queue_moderated(request):
             tab='moderated',
             page=page,
             flags=flags,
+            registry=reviewer_tables_registry,
         ),
     )
 


### PR DESCRIPTION
Fixes #20174 

Move much of the information of reviewer queues into their table classes. Remove the need for alias queue functions. 
