### PR TITLE
Enable isort

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -100,8 +100,9 @@ def pytest_configure(config):
 def instrument_jinja():
     """Make sure the "templates" list in a response is properly updated, even
     though we're using Jinja2 and not the default django template engine."""
-    import jinja2
     from django import test
+
+    import jinja2
 
     old_render = jinja2.Template.render
 
@@ -117,6 +118,7 @@ def instrument_jinja():
 def default_prefixer(settings):
     """Make sure each test starts with a default URL prefixer."""
     from django import http
+
     from olympia import amo
 
     request = http.HttpRequest()
@@ -131,10 +133,11 @@ def default_prefixer(settings):
 def test_pre_setup(request, tmpdir, settings):
     from django.core.cache import caches
     from django.utils import translation
+
     from olympia import amo, core
     from olympia.translations.hold import clean_translations
-    from waffle.utils import get_cache as waffle_get_cache
     from waffle import models as waffle_models
+    from waffle.utils import get_cache as waffle_get_cache
 
     # Clear all cache-instances. They'll be re-initialized by Django
     # This will make sure that our random `KEY_PREFIX` is applied

--- a/locale/generate_category_po_files.py
+++ b/locale/generate_category_po_files.py
@@ -6,6 +6,7 @@
 import json
 import os
 
+
 translations_dump = {}
 translations_reordered = {}
 

--- a/manage.py
+++ b/manage.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import sys
 import os
+import sys
 
 
 if __name__ == '__main__':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,12 +27,20 @@ select = [
     "B",
     "E",
     "F",
+    "I",
     "Q",
     "W",
 ]
 
 [tool.ruff.flake8-quotes]
 inline-quotes = "single"
+
+[tool.ruff.isort]
+combine-as-imports = true
+lines-after-imports = 2
+section-order = ["future", "standard-library", "django", "third-party", "first-party", "local-folder"]
+[tool.ruff.isort.sections]
+"django" = ["django"]
 
 [tool.pytest.ini_options]
 addopts = "-vs --reuse-db --showlocals --tb=short"

--- a/scripts/generate_build.py
+++ b/scripts/generate_build.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import uuid
 
+
 # Generate build id for docker image.
 print('BUILD_ID = "%s"' % uuid.uuid4())

--- a/settings.py
+++ b/settings.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 
 from olympia.lib.settings_base import *  # noqa
 
+
 WSGI_APPLICATION = 'olympia.wsgi.application'
 
 INTERNAL_ROUTES_ALLOWED = True
@@ -134,8 +135,8 @@ REMOTE_SETTINGS_IS_TEST_SERVER = True
 try:
     from local_settings import *  # noqa
 except ImportError:
-    import warnings
     import traceback
+    import warnings
 
     warnings.warn(
         'Could not import local_settings module. {}'.format(traceback.format_exc())

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 
 setup(

--- a/src/olympia/abuse/serializers.py
+++ b/src/olympia/abuse/serializers.py
@@ -1,10 +1,9 @@
-from rest_framework import serializers
-
 from django.http import Http404
 from django.utils.translation import gettext_lazy as _
 
-import olympia.core.logger
+from rest_framework import serializers
 
+import olympia.core.logger
 from olympia import amo
 from olympia.abuse.models import AbuseReport
 from olympia.accounts.serializers import BaseUserSerializer

--- a/src/olympia/abuse/tests/test_admin.py
+++ b/src/olympia/abuse/tests/test_admin.py
@@ -14,10 +14,10 @@ from olympia.abuse.admin import AbuseReportAdmin
 from olympia.abuse.models import AbuseReport
 from olympia.addons.models import AddonApprovalsCounter
 from olympia.amo.tests import (
+    TestCase,
     addon_factory,
     days_ago,
     grant_permission,
-    TestCase,
     user_factory,
 )
 from olympia.ratings.models import Rating

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -1,5 +1,5 @@
 from olympia.abuse.models import AbuseReport
-from olympia.amo.tests import addon_factory, TestCase, user_factory
+from olympia.amo.tests import TestCase, addon_factory, user_factory
 
 
 class TestAbuse(TestCase):

--- a/src/olympia/abuse/tests/test_serializers.py
+++ b/src/olympia/abuse/tests/test_serializers.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-
 from unittest.mock import Mock
 
 from django.contrib.auth.models import AnonymousUser

--- a/src/olympia/abuse/urls.py
+++ b/src/olympia/abuse/urls.py
@@ -1,6 +1,7 @@
 from django.urls import include, re_path
 
 from rest_framework.routers import SimpleRouter
+
 from .views import AddonAbuseViewSet, UserAbuseViewSet
 
 

--- a/src/olympia/access/admin.py
+++ b/src/olympia/access/admin.py
@@ -1,5 +1,5 @@
-from django.urls import reverse
 from django.contrib import admin
+from django.urls import reverse
 from django.utils.html import format_html
 
 from olympia.amo.admin import AMOModelAdmin

--- a/src/olympia/access/models.py
+++ b/src/olympia/access/models.py
@@ -3,7 +3,6 @@ from django.db import models
 from django.db.models import signals
 
 import olympia.core.logger
-
 from olympia import activity, amo
 from olympia.amo.fields import PositiveAutoField
 from olympia.amo.models import ModelBase

--- a/src/olympia/access/tests.py
+++ b/src/olympia/access/tests.py
@@ -1,21 +1,21 @@
-import pytest
-
 from django.contrib.auth.models import AnonymousUser
+
+import pytest
 
 from olympia import amo
 from olympia.access.models import Group, GroupUser
 from olympia.addons.models import Addon, AddonUser
-from olympia.amo.tests import addon_factory, TestCase, user_factory
+from olympia.amo.tests import TestCase, addon_factory, user_factory
 from olympia.users.models import UserProfile
 
 from .acl import (
     action_allowed_for,
     check_addon_ownership,
     is_listed_addons_reviewer,
+    is_reviewer,
     is_static_theme_reviewer,
     is_unlisted_addons_reviewer,
     is_unlisted_addons_viewer_or_reviewer,
-    is_reviewer,
     is_user_any_kind_of_reviewer,
     match_rules,
     reserved_guid_addon_submission_allowed,

--- a/src/olympia/accounts/serializers.py
+++ b/src/olympia/accounts/serializers.py
@@ -4,16 +4,15 @@ from django.utils.translation import gettext
 from rest_framework import serializers
 
 import olympia.core.logger
-
 from olympia import amo
 from olympia.access import acl
 from olympia.access.models import Group
 from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.amo.utils import (
-    clean_nl,
-    has_links,
     ImageCheck,
     SafeStorage,
+    clean_nl,
+    has_links,
     subscribe_newsletter,
     unsubscribe_newsletter,
     urlparams,

--- a/src/olympia/accounts/tasks.py
+++ b/src/olympia/accounts/tasks.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from waffle import switch_is_active
 
 import olympia.core.logger
-
 from olympia import amo
 from olympia.activity.models import ActivityLog
 from olympia.amo.celery import task

--- a/src/olympia/accounts/templatetags/jinja_helpers.py
+++ b/src/olympia/accounts/templatetags/jinja_helpers.py
@@ -1,7 +1,7 @@
 from urllib.parse import quote_plus
 
-from django_jinja import library
 import jinja2
+from django_jinja import library
 
 from olympia.accounts.utils import path_with_query
 from olympia.amo.templatetags.jinja_helpers import drf_url

--- a/src/olympia/accounts/tests/test_tasks.py
+++ b/src/olympia/accounts/tests/test_tasks.py
@@ -11,7 +11,7 @@ from olympia.accounts.tasks import (
     primary_email_change_event,
 )
 from olympia.activity.models import ActivityLog
-from olympia.amo.tests import addon_factory, collection_factory, TestCase, user_factory
+from olympia.amo.tests import TestCase, addon_factory, collection_factory, user_factory
 from olympia.bandwagon.models import Collection
 from olympia.ratings.models import Rating
 

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -1,7 +1,6 @@
 import base64
 import json
 import time
-
 from datetime import datetime
 from ipaddress import IPv4Address
 from os import path
@@ -12,9 +11,9 @@ from django import http
 from django.conf import settings
 from django.contrib.auth import login
 from django.contrib.auth.models import AnonymousUser
-from django.urls import reverse
 from django.test import RequestFactory
 from django.test.utils import override_settings
+from django.urls import reverse
 from django.utils.encoding import force_str
 
 import freezegun

--- a/src/olympia/accounts/utils.py
+++ b/src/olympia/accounts/utils.py
@@ -1,6 +1,5 @@
 import binascii
 import os
-
 from base64 import urlsafe_b64encode
 from urllib.parse import urlencode
 

--- a/src/olympia/accounts/verify.py
+++ b/src/olympia/accounts/verify.py
@@ -3,7 +3,6 @@ import time
 from django.conf import settings
 
 import requests
-
 from django_statsd.clients import statsd
 
 import olympia.core.logger

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -3,7 +3,6 @@ import binascii
 import functools
 import os
 import time
-
 from urllib.parse import quote_plus
 
 from django.conf import settings
@@ -20,18 +19,16 @@ from django.views.decorators.cache import never_cache
 import jwt
 import requests
 import waffle
-
 from corsheaders.conf import conf as corsheaders_conf
 from corsheaders.middleware import (
-    ACCESS_CONTROL_ALLOW_ORIGIN,
     ACCESS_CONTROL_ALLOW_CREDENTIALS,
     ACCESS_CONTROL_ALLOW_HEADERS,
     ACCESS_CONTROL_ALLOW_METHODS,
+    ACCESS_CONTROL_ALLOW_ORIGIN,
     ACCESS_CONTROL_MAX_AGE,
 )
 from django_statsd.clients import statsd
-from rest_framework import exceptions
-from rest_framework import serializers
+from rest_framework import exceptions, serializers
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import action
 from rest_framework.generics import GenericAPIView
@@ -49,7 +46,6 @@ from rest_framework.viewsets import GenericViewSet
 from waffle.decorators import waffle_switch
 
 import olympia.core.logger
-
 from olympia import amo
 from olympia.access import acl
 from olympia.access.models import GroupUser

--- a/src/olympia/activity/management/commands/backfill_ratinglog.py
+++ b/src/olympia/activity/management/commands/backfill_ratinglog.py
@@ -1,7 +1,6 @@
 from django.core.management.base import BaseCommand
 
 import olympia.core.logger
-
 from olympia import amo
 from olympia.activity.models import ActivityLog
 from olympia.activity.tasks import create_ratinglog

--- a/src/olympia/activity/management/commands/repudiate_token.py
+++ b/src/olympia/activity/management/commands/repudiate_token.py
@@ -1,7 +1,6 @@
 from django.core.management.base import BaseCommand, CommandError
 
 import olympia.core.logger
-
 from olympia.activity.models import ActivityLogToken
 
 

--- a/src/olympia/activity/models.py
+++ b/src/olympia/activity/models.py
@@ -1,6 +1,5 @@
 import json
 import uuid
-
 from collections import defaultdict
 from copy import copy
 
@@ -14,7 +13,6 @@ from django.utils.html import format_html, mark_safe
 from django.utils.translation import gettext, ngettext
 
 import olympia.core.logger
-
 from olympia import amo, constants
 from olympia.access.models import Group
 from olympia.addons.models import Addon
@@ -25,7 +23,6 @@ from olympia.blocklist.models import Block
 from olympia.files.models import File
 from olympia.ratings.models import Rating
 from olympia.reviewers.models import ReviewActionReason
-
 from olympia.tags.models import Tag
 from olympia.users.models import UserProfile
 from olympia.versions.models import Version

--- a/src/olympia/activity/tasks.py
+++ b/src/olympia/activity/tasks.py
@@ -1,5 +1,4 @@
 import olympia.core.logger
-
 from olympia.activity.models import ActivityLog, ActivityLogEmails, RatingLog
 from olympia.activity.utils import add_email_to_activity_log_wrapper
 from olympia.amo.celery import task

--- a/src/olympia/activity/tests/test_admin.py
+++ b/src/olympia/activity/tests/test_admin.py
@@ -2,10 +2,9 @@ from django.urls import reverse
 
 from pyquery import PyQuery as pq
 
-from olympia import amo, core
-from olympia import activity
-from olympia.amo.tests import TestCase, addon_factory, user_factory
+from olympia import activity, amo, core
 from olympia.activity.models import ActivityLog, ReviewActionReasonLog
+from olympia.amo.tests import TestCase, addon_factory, user_factory
 from olympia.reviewers.models import ReviewActionReason
 
 

--- a/src/olympia/activity/tests/test_models.py
+++ b/src/olympia/activity/tests/test_models.py
@@ -1,7 +1,7 @@
 from ipaddress import IPv4Address
+from unittest.mock import Mock
 from uuid import UUID
 
-from unittest.mock import Mock
 from pyquery import PyQuery as pq
 
 from olympia import amo, core
@@ -18,8 +18,8 @@ from olympia.activity.models import (
 )
 from olympia.addons.models import Addon, AddonUser
 from olympia.amo.tests import (
-    addon_factory,
     TestCase,
+    addon_factory,
     user_factory,
     version_factory,
 )

--- a/src/olympia/activity/tests/test_tasks.py
+++ b/src/olympia/activity/tests/test_tasks.py
@@ -1,4 +1,5 @@
 from unittest import mock
+
 import pytest
 
 from olympia.activity.models import ActivityLogEmails

--- a/src/olympia/activity/tests/test_utils.py
+++ b/src/olympia/activity/tests/test_utils.py
@@ -2,16 +2,14 @@ import copy
 import datetime
 import json
 import os
-
 from email.utils import formataddr
+from unittest import mock
 
 from django.conf import settings
 from django.core import mail
 from django.urls import reverse
 
-from unittest import mock
 import pytest
-
 from waffle.testutils import override_switch
 
 from olympia import amo
@@ -20,6 +18,7 @@ from olympia.activity.models import MAX_TOKEN_USE_COUNT, ActivityLog, ActivityLo
 from olympia.activity.utils import (
     ACTIVITY_MAIL_GROUP,
     ADDON_REVIEWER_NAME,
+    NOTIFICATIONS_FROM_EMAIL,
     ActivityEmailEncodingError,
     ActivityEmailError,
     ActivityEmailParser,
@@ -29,11 +28,10 @@ from olympia.activity.utils import (
     add_email_to_activity_log_wrapper,
     log_and_notify,
     notify_about_activity_log,
-    NOTIFICATIONS_FROM_EMAIL,
     send_activity_mail,
 )
 from olympia.amo.templatetags.jinja_helpers import absolutify
-from olympia.amo.tests import TestCase, addon_factory, SQUOTE_ESCAPED, user_factory
+from olympia.amo.tests import SQUOTE_ESCAPED, TestCase, addon_factory, user_factory
 
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/src/olympia/activity/tests/test_views.py
+++ b/src/olympia/activity/tests/test_views.py
@@ -1,8 +1,7 @@
-import json
 import io
-from unittest import mock
-
+import json
 from datetime import datetime, timedelta
+from unittest import mock
 
 from django.conf import settings
 from django.test.utils import override_settings
@@ -11,14 +10,14 @@ from rest_framework.exceptions import ErrorDetail
 from rest_framework.test import APIRequestFactory
 
 from olympia import amo
-from olympia.activity.models import ActivityLog, ActivityLogToken, GENERIC_USER_NAME
+from olympia.activity.models import GENERIC_USER_NAME, ActivityLog, ActivityLogToken
 from olympia.activity.tests.test_serializers import LogMixin
 from olympia.activity.tests.test_utils import sample_message_content
-from olympia.activity.views import inbound_email, InboundEmailIPPermission
+from olympia.activity.views import InboundEmailIPPermission, inbound_email
 from olympia.addons.models import (
-    AddonUser,
     AddonRegionalRestrictions,
     AddonReviewerFlags,
+    AddonUser,
 )
 from olympia.addons.utils import generate_addon_guid
 from olympia.amo.tests import (

--- a/src/olympia/activity/utils.py
+++ b/src/olympia/activity/utils.py
@@ -1,5 +1,4 @@
 import re
-
 from datetime import datetime
 from email.utils import formataddr
 from html import unescape
@@ -12,11 +11,9 @@ from django.urls import reverse
 from django.utils import translation
 
 import waffle
-
 from email_reply_parser import EmailReplyParser
 
 import olympia.core.logger
-
 from olympia import amo
 from olympia.access import acl
 from olympia.activity.models import ActivityLog, ActivityLogToken

--- a/src/olympia/activity/views.py
+++ b/src/olympia/activity/views.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from django.shortcuts import get_object_or_404
-
 from django.utils.translation import gettext, gettext_lazy as _
 
 from rest_framework import exceptions, status
@@ -14,7 +13,6 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 import olympia.core.logger
-
 from olympia import amo
 from olympia.access import acl
 from olympia.activity.models import ActivityLog
@@ -24,11 +22,11 @@ from olympia.activity.serializers import (
 )
 from olympia.activity.tasks import process_email
 from olympia.activity.utils import (
+    USER_TYPE_ADDON_AUTHOR,
     action_from_user,
     filter_queryset_to_pending_replies,
     log_and_notify,
     type_of_user,
-    USER_TYPE_ADDON_AUTHOR,
 )
 from olympia.addons.views import AddonChildMixin
 from olympia.api.permissions import (

--- a/src/olympia/addons/admin.py
+++ b/src/olympia/addons/admin.py
@@ -1,7 +1,7 @@
 import functools
 from urllib.parse import urlencode, urljoin
 
-from django import http, forms
+from django import forms, http
 from django.conf import settings
 from django.contrib import admin
 from django.contrib.admin.utils import display_for_field

--- a/src/olympia/addons/api_urls.py
+++ b/src/olympia/addons/api_urls.py
@@ -9,11 +9,11 @@ from olympia.tags.views import TagListView
 
 from .views import (
     AddonAuthorViewSet,
-    AddonPendingAuthorViewSet,
     AddonAutoCompleteSearchView,
     AddonFeaturedView,
-    AddonRecommendationView,
+    AddonPendingAuthorViewSet,
     AddonPreviewViewSet,
+    AddonRecommendationView,
     AddonSearchView,
     AddonVersionViewSet,
     AddonViewSet,

--- a/src/olympia/addons/cron.py
+++ b/src/olympia/addons/cron.py
@@ -1,9 +1,8 @@
 from datetime import date
 
-from django.db.models import Value, IntegerField
+from django.db.models import IntegerField, Value
 
 import olympia.core.logger
-
 from olympia import amo
 from olympia.addons.models import Addon, FrozenAddon
 from olympia.addons.tasks import (

--- a/src/olympia/addons/fields.py
+++ b/src/olympia/addons/fields.py
@@ -2,21 +2,20 @@ import copy
 import os
 import tarfile
 import zipfile
-
 from urllib.parse import urlsplit, urlunsplit
 
 from django.conf import settings
 from django.db.models import Q
 from django.http.request import QueryDict
+from django.urls import reverse
 from django.utils.encoding import smart_str
 from django.utils.translation import gettext, gettext_lazy as _
-from django.urls import reverse
 
 from rest_framework import exceptions, serializers
 
 from olympia import amo
-from olympia.amo.utils import ImageCheck, sorted_groupby
 from olympia.amo.templatetags.jinja_helpers import absolutify
+from olympia.amo.utils import ImageCheck, sorted_groupby
 from olympia.api.fields import (
     ESTranslationSerializerField,
     GetTextTranslationSerializerField,
@@ -29,9 +28,9 @@ from olympia.constants.categories import CATEGORIES
 from olympia.constants.licenses import LICENSES_BY_SLUG
 from olympia.files.utils import SafeTar, SafeZip
 from olympia.versions.models import (
+    VALID_SOURCE_EXTENSIONS,
     ApplicationsVersions,
     License,
-    VALID_SOURCE_EXTENSIONS,
 )
 
 

--- a/src/olympia/addons/indexers.py
+++ b/src/olympia/addons/indexers.py
@@ -1,11 +1,10 @@
 from django.conf import settings
-from olympia.constants.promoted import RECOMMENDED
 
 import olympia.core.logger
 from olympia import amo
-from olympia.amo.utils import attach_trans_dict
 from olympia.amo.celery import create_chunked_tasks_signatures
-from olympia.amo.utils import to_language
+from olympia.amo.utils import attach_trans_dict, to_language
+from olympia.constants.promoted import RECOMMENDED
 from olympia.constants.search import SEARCH_LANGUAGE_TO_ANALYZER
 from olympia.search.utils import create_index
 from olympia.versions.compare import version_int

--- a/src/olympia/addons/management/commands/fix_langpacks_with_max_version_star.py
+++ b/src/olympia/addons/management/commands/fix_langpacks_with_max_version_star.py
@@ -5,6 +5,7 @@ from olympia.core.logger import getLogger
 from olympia.versions.compare import version_dict
 from olympia.versions.models import AppVersion, Version
 
+
 log = getLogger('z.fix_langpacks_with_max_version_star')
 
 

--- a/src/olympia/addons/management/commands/process_addons.py
+++ b/src/olympia/addons/management/commands/process_addons.py
@@ -13,6 +13,7 @@ from olympia.addons.tasks import (
     find_inconsistencies_between_es_and_db,
     recreate_theme_previews,
 )
+from olympia.amo.management import ProcessObjectsCommand
 from olympia.blocklist.models import Block
 from olympia.constants.base import (
     _ADDON_LPADDON,
@@ -21,7 +22,6 @@ from olympia.constants.base import (
     _ADDON_THEME,
     _ADDON_WEBAPP,
 )
-from olympia.amo.management import ProcessObjectsCommand
 from olympia.devhub.tasks import get_preview_sizes, recreate_previews
 from olympia.lib.crypto.tasks import sign_addons
 from olympia.ratings.tasks import addon_rating_aggregates

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -4,7 +4,6 @@ import os
 import re
 import time
 import uuid
-
 from datetime import datetime
 from urllib.parse import urlsplit
 
@@ -26,12 +25,11 @@ from django.dispatch import receiver
 from django.urls import reverse
 from django.utils import translation
 from django.utils.functional import cached_property
-from django.utils.translation import trans_real, gettext_lazy as _
+from django.utils.translation import gettext_lazy as _, trans_real
 
 from django_statsd.clients import statsd
 
 import olympia.core.logger
-
 from olympia import activity, amo, core
 from olympia.addons.utils import generate_addon_guid
 from olympia.amo.decorators import use_primary_db
@@ -778,8 +776,9 @@ class Addon(OnChangeMixin, ModelBase):
     @transaction.atomic
     def delete(self, msg='', reason='', send_delete_email=True):
         # To avoid a circular import
-        from . import tasks
         from olympia.versions import tasks as version_tasks
+
+        from . import tasks
 
         # Check for soft deletion path. Happens only if the addon status isn't
         # 0 (STATUS_INCOMPLETE) with no versions.

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -13,7 +13,7 @@ from olympia import amo
 from olympia.accounts.serializers import BaseUserSerializer
 from olympia.activity.models import ActivityLog
 from olympia.amo.templatetags.jinja_helpers import absolutify
-from olympia.amo.utils import remove_icons, SafeStorage, slug_validator
+from olympia.amo.utils import SafeStorage, remove_icons, slug_validator
 from olympia.amo.validators import (
     CreateOnlyValidator,
     OneOrMoreLetterOrNumberCharacterValidator,
@@ -28,12 +28,12 @@ from olympia.api.fields import (
     SplitField,
     TranslationSerializerField,
 )
-from olympia.api.serializers import BaseESSerializer, AMOModelSerializer
+from olympia.api.serializers import AMOModelSerializer, BaseESSerializer
 from olympia.api.utils import is_gate_active
 from olympia.applications.models import AppVersion
 from olympia.bandwagon.models import Collection
 from olympia.blocklist.models import Block
-from olympia.constants.applications import APPS_ALL, APP_IDS
+from olympia.constants.applications import APP_IDS, APPS_ALL
 from olympia.constants.base import ADDON_TYPE_CHOICES_API
 from olympia.constants.categories import CATEGORIES_BY_ID
 from olympia.constants.promoted import PROMOTED_GROUPS, RECOMMENDED
@@ -41,10 +41,10 @@ from olympia.core.languages import AMO_LANGUAGES
 from olympia.files.models import File, FileUpload
 from olympia.files.utils import DuplicateAddonID, parse_addon
 from olympia.promoted.models import PromotedAddon
-from olympia.search.filters import AddonAppVersionQueryParam
 from olympia.ratings.utils import get_grouped_ratings
+from olympia.search.filters import AddonAppVersionQueryParam
 from olympia.tags.models import Tag
-from olympia.users.models import EmailUserRestriction, RESTRICTION_TYPES, UserProfile
+from olympia.users.models import RESTRICTION_TYPES, EmailUserRestriction, UserProfile
 from olympia.versions.models import (
     ApplicationsVersions,
     License,
@@ -77,15 +77,15 @@ from .utils import (
     validate_version_number_is_gt_latest_signed_listed_version,
 )
 from .validators import (
-    AddonMetadataValidator,
     AddonDefaultLocaleValidator,
+    AddonMetadataValidator,
     CanSetCompatibilityValidator,
     MatchingGuidValidator,
-    ReviewedSourceFileValidator,
-    VersionAddonMetadataValidator,
     NoFallbackDefaultLocaleValidator,
-    VersionLicenseValidator,
+    ReviewedSourceFileValidator,
     VerifyMozillaTrademark,
+    VersionAddonMetadataValidator,
+    VersionLicenseValidator,
 )
 
 

--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -8,7 +8,6 @@ from django.db.models.functions import Collate
 from elasticsearch_dsl import Search
 
 import olympia.core
-
 from olympia import activity, amo
 from olympia.addons.indexers import AddonIndexer
 from olympia.addons.models import (

--- a/src/olympia/addons/tests/test_admin.py
+++ b/src/olympia/addons/tests/test_admin.py
@@ -1,7 +1,5 @@
 from datetime import datetime, timedelta
 
-from pyquery import PyQuery as pq
-
 from django.conf import settings
 from django.contrib import admin
 from django.contrib.messages.storage import default_storage as default_messages_storage
@@ -10,10 +8,13 @@ from django.test.client import RequestFactory
 from django.urls import reverse
 from django.utils import formats, timezone
 
+from pyquery import PyQuery as pq
+
 from olympia import amo, core
 from olympia.activity.models import ActivityLog
 from olympia.addons.admin import AddonAdmin, ReplacementAddonAdmin
 from olympia.addons.models import Addon, AddonRegionalRestrictions, ReplacementAddon
+from olympia.amo.reverse import django_reverse
 from olympia.amo.tests import (
     TestCase,
     addon_factory,
@@ -21,7 +22,6 @@ from olympia.amo.tests import (
     user_factory,
     version_factory,
 )
-from olympia.amo.reverse import django_reverse
 from olympia.blocklist.models import Block
 from olympia.git.models import GitExtractionEntry
 

--- a/src/olympia/addons/tests/test_commands.py
+++ b/src/olympia/addons/tests/test_commands.py
@@ -1,22 +1,22 @@
 import random
 from contextlib import contextmanager
 from datetime import timedelta
+from unittest import mock
 
 from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import CommandError
 
-from freezegun import freeze_time
-from unittest import mock
 import pytest
+from freezegun import freeze_time
 
 from olympia import amo
+from olympia.abuse.models import AbuseReport
 from olympia.addons.management.commands import (
     fix_langpacks_with_max_version_star,
     process_addons,
 )
 from olympia.addons.models import Addon, DeniedGuid
-from olympia.abuse.models import AbuseReport
 from olympia.amo.tests import (
     TestCase,
     addon_factory,

--- a/src/olympia/addons/tests/test_cron.py
+++ b/src/olympia/addons/tests/test_cron.py
@@ -1,15 +1,15 @@
-from celery import group
-
 from unittest import mock
+
+from celery import group
 
 from olympia import amo
 from olympia.addons import cron
+from olympia.addons.models import Addon, FrozenAddon
 from olympia.addons.tasks import (
     update_addon_average_daily_users,
     update_addon_weekly_downloads,
 )
-from olympia.addons.models import Addon, FrozenAddon
-from olympia.amo.tests import addon_factory, TestCase
+from olympia.amo.tests import TestCase, addon_factory
 from olympia.files.models import File
 
 

--- a/src/olympia/addons/tests/test_decorators.py
+++ b/src/olympia/addons/tests/test_decorators.py
@@ -1,7 +1,7 @@
-from django import http
-
 from unittest import mock
 from urllib.parse import quote
+
+from django import http
 
 from olympia.addons import decorators as dec
 from olympia.addons.models import Addon

--- a/src/olympia/addons/tests/test_indexers.py
+++ b/src/olympia/addons/tests/test_indexers.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from olympia import amo
 from olympia.addons.indexers import AddonIndexer
 from olympia.addons.models import Addon, Preview, attach_tags, attach_translations_dict
-from olympia.amo.tests import addon_factory, ESTestCase, TestCase
+from olympia.amo.tests import ESTestCase, TestCase, addon_factory
 from olympia.bandwagon.models import Collection
 from olympia.constants.applications import FIREFOX
 from olympia.constants.licenses import LICENSES_BY_BUILTIN

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -15,9 +15,11 @@ from olympia import amo, core
 from olympia.activity.models import ActivityLog, AddonLog
 from olympia.addons import models as addons_models
 from olympia.addons.models import (
+    UPCOMING_DUE_DATE_CUT_OFF_DAYS_CONFIG_KEY,
     Addon,
     AddonApprovalsCounter,
     AddonCategory,
+    AddonGUID,
     AddonRegionalRestrictions,
     AddonReviewerFlags,
     AddonUser,
@@ -27,9 +29,7 @@ from olympia.addons.models import (
     GuidAlreadyDeniedError,
     MigratedLWT,
     Preview,
-    AddonGUID,
     track_addon_status_change,
-    UPCOMING_DUE_DATE_CUT_OFF_DAYS_CONFIG_KEY,
 )
 from olympia.amo.tests import (
     TestCase,

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -21,11 +21,10 @@ from olympia.addons.models import (
 )
 from olympia.addons.serializers import (
     AddonAuthorSerializer,
-    UserSerializerWithPictureUrl,
     AddonSerializer,
     DeveloperAddonSerializer,
-    DeveloperVersionSerializer,
     DeveloperListVersionSerializer,
+    DeveloperVersionSerializer,
     ESAddonAutoCompleteSerializer,
     ESAddonSerializer,
     LanguageToolsSerializer,
@@ -33,6 +32,7 @@ from olympia.addons.serializers import (
     ListVersionSerializer,
     ReplacementAddonSerializer,
     SimpleVersionSerializer,
+    UserSerializerWithPictureUrl,
     VersionSerializer,
 )
 from olympia.addons.utils import generate_addon_guid
@@ -53,11 +53,12 @@ from olympia.amo.tests import (
 from olympia.amo.urlresolvers import get_outgoing_url
 from olympia.bandwagon.models import Collection
 from olympia.constants.categories import CATEGORIES
-from olympia.constants.licenses import LICENSES_BY_BUILTIN, LICENSE_GPL3
+from olympia.constants.licenses import LICENSE_GPL3, LICENSES_BY_BUILTIN
 from olympia.constants.promoted import RECOMMENDED
 from olympia.files.models import WebextPermission
 from olympia.promoted.models import PromotedAddon
 from olympia.ratings.models import Rating
+from olympia.users.models import UserProfile
 from olympia.versions.models import (
     ApplicationsVersions,
     AppVersion,
@@ -65,7 +66,6 @@ from olympia.versions.models import (
     Version,
     VersionPreview,
 )
-from olympia.users.models import UserProfile
 
 
 class AddonSerializerOutputTestMixin:

--- a/src/olympia/addons/tests/test_tasks.py
+++ b/src/olympia/addons/tests/test_tasks.py
@@ -14,7 +14,7 @@ from waffle.testutils import override_switch
 from olympia import amo
 from olympia.activity.models import ActivityLog
 from olympia.addons.indexers import AddonIndexer
-from olympia.amo.tests import addon_factory, TestCase, user_factory
+from olympia.amo.tests import TestCase, addon_factory, user_factory
 from olympia.amo.tests.test_helpers import get_image_path
 from olympia.amo.utils import image_size
 from olympia.constants.reviewers import EXTRA_REVIEW_TARGET_PER_DAY_CONFIG_KEY

--- a/src/olympia/addons/tests/test_utils_.py
+++ b/src/olympia/addons/tests/test_utils_.py
@@ -6,7 +6,6 @@ from django.forms import ValidationError
 from django.test.client import RequestFactory
 
 import pytest
-
 from freezegun import freeze_time
 
 from olympia import amo
@@ -14,17 +13,17 @@ from olympia.amo.tests import TestCase, addon_factory, user_factory, version_fac
 from olympia.users.models import Group, GroupUser
 
 from ..utils import (
-    DeleteTokenSigner,
-    get_addon_recommendations,
-    get_addon_recommendations_invalid,
-    is_outcome_recommended,
     TAAR_LITE_FALLBACK_REASON_EMPTY,
+    TAAR_LITE_FALLBACK_REASON_INVALID,
     TAAR_LITE_FALLBACK_REASON_TIMEOUT,
     TAAR_LITE_FALLBACKS,
     TAAR_LITE_OUTCOME_CURATED,
     TAAR_LITE_OUTCOME_REAL_FAIL,
     TAAR_LITE_OUTCOME_REAL_SUCCESS,
-    TAAR_LITE_FALLBACK_REASON_INVALID,
+    DeleteTokenSigner,
+    get_addon_recommendations,
+    get_addon_recommendations_invalid,
+    is_outcome_recommended,
     validate_version_number_is_gt_latest_signed_listed_version,
     verify_mozilla_trademark,
     webext_version_stats,

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -6,7 +6,6 @@ import stat
 import tarfile
 import tempfile
 import zipfile
-
 from collections import Counter, OrderedDict
 from datetime import datetime, timedelta
 from unittest import mock
@@ -22,7 +21,6 @@ from django.utils.encoding import force_bytes, force_str
 from django.utils.http import urlsafe_base64_encode
 
 import pytest
-
 from elasticsearch import Elasticsearch
 from freezegun import freeze_time
 from rest_framework.exceptions import ErrorDetail
@@ -34,9 +32,9 @@ from olympia import amo
 from olympia.activity.models import ActivityLog
 from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.amo.tests import (
-    ESTestCase,
     APITestClientJWT,
     APITestClientSessionID,
+    ESTestCase,
     TestCase,
     addon_factory,
     collection_factory,
@@ -52,14 +50,14 @@ from olympia.constants.categories import CATEGORIES, CATEGORIES_BY_ID
 from olympia.constants.licenses import LICENSE_GPL3
 from olympia.constants.promoted import (
     LINE,
-    SPOTLIGHT,
-    STRATEGIC,
     RECOMMENDED,
     SPONSORED,
+    SPOTLIGHT,
+    STRATEGIC,
     VERIFIED,
 )
-from olympia.files.utils import parse_addon, parse_xpi
 from olympia.files.tests.test_models import UploadMixin
+from olympia.files.utils import parse_addon, parse_xpi
 from olympia.ratings.models import Rating
 from olympia.reviewers.models import AutoApprovalSummary
 from olympia.search.utils import get_es
@@ -76,21 +74,21 @@ from olympia.versions.models import (
 
 from ..models import (
     Addon,
-    AddonCategory,
     AddonApprovalsCounter,
+    AddonCategory,
     AddonRegionalRestrictions,
     AddonReviewerFlags,
     AddonUser,
     AddonUserPendingConfirmation,
     DeniedSlug,
-    ReplacementAddon,
     Preview,
+    ReplacementAddon,
 )
 from ..serializers import (
     AddonAuthorSerializer,
     AddonPendingAuthorSerializer,
-    DeveloperAddonSerializer,
     CompactLicenseSerializer,
+    DeveloperAddonSerializer,
     DeveloperVersionSerializer,
     LicenseSerializer,
 )

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -7,7 +7,7 @@ from django.shortcuts import redirect
 from django.utils.cache import patch_cache_control
 from django.utils.translation import gettext
 
-from elasticsearch_dsl import Q, query, Search
+from elasticsearch_dsl import Q, Search, query
 from rest_framework import exceptions, serializers, status
 from rest_framework.decorators import action
 from rest_framework.generics import ListAPIView
@@ -25,7 +25,6 @@ from rest_framework.views import APIView
 from rest_framework.viewsets import GenericViewSet
 
 import olympia.core.logger
-
 from olympia import amo
 from olympia.access import acl
 from olympia.activity.models import ActivityLog
@@ -41,9 +40,9 @@ from olympia.api.permissions import (
     AllowAddonAuthor,
     AllowAddonOwner,
     AllowIfNotMozillaDisabled,
+    AllowListedViewerOrReviewer,
     AllowReadOnlyIfPublic,
     AllowRelatedObjectPermissions,
-    AllowListedViewerOrReviewer,
     AllowUnlistedViewerOrReviewer,
     AnyOf,
     APIGatePermission,
@@ -78,21 +77,21 @@ from .decorators import addon_view_factory
 from .indexers import AddonIndexer
 from .models import Addon, AddonUser, AddonUserPendingConfirmation, ReplacementAddon
 from .serializers import (
-    AddonEulaPolicySerializer,
     AddonAuthorSerializer,
+    AddonEulaPolicySerializer,
+    AddonPendingAuthorSerializer,
     AddonSerializer,
     DeveloperAddonSerializer,
-    DeveloperVersionSerializer,
     DeveloperListVersionSerializer,
+    DeveloperVersionSerializer,
     ESAddonAutoCompleteSerializer,
     ESAddonSerializer,
     LanguageToolsSerializer,
-    ReplacementAddonSerializer,
-    AddonPendingAuthorSerializer,
+    ListVersionSerializer,
     PreviewSerializer,
+    ReplacementAddonSerializer,
     StaticCategorySerializer,
     VersionSerializer,
-    ListVersionSerializer,
 )
 from .utils import (
     DeleteTokenSigner,

--- a/src/olympia/amo/admin.py
+++ b/src/olympia/amo/admin.py
@@ -3,17 +3,15 @@ import ipaddress
 import operator
 from collections import OrderedDict
 
-from rangefilter.filter import DateRangeFilter as DateRangeFilterBase
-
 from django import forms
 from django.contrib import admin
 from django.contrib.admin.options import IncorrectLookupParameters
 from django.contrib.admin.views.main import (
-    ChangeList,
-    ChangeListSearchForm,
     ERROR_FLAG,
     PAGE_VAR,
     SEARCH_VAR,
+    ChangeList,
+    ChangeListSearchForm,
 )
 from django.core.exceptions import FieldDoesNotExist
 from django.core.paginator import InvalidPage
@@ -22,9 +20,12 @@ from django.db.models.constants import LOOKUP_SEP
 from django.http.request import QueryDict
 from django.utils.html import format_html, format_html_join
 
+from rangefilter.filter import DateRangeFilter as DateRangeFilterBase
+
 from olympia.activity.models import IPLog
 from olympia.amo.models import GroupConcat, Inet6Ntoa
 from olympia.constants.activity import LOG_BY_ID
+
 from .models import FakeEmail
 
 

--- a/src/olympia/amo/context_processors.py
+++ b/src/olympia/amo/context_processors.py
@@ -1,3 +1,5 @@
+from urllib.parse import quote
+
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.urls import reverse
@@ -5,8 +7,6 @@ from django.utils.translation import get_language, get_language_bidi, gettext
 
 from olympia import amo
 from olympia.access import acl
-
-from urllib.parse import quote
 
 
 def i18n(request):

--- a/src/olympia/amo/cron.py
+++ b/src/olympia/amo/cron.py
@@ -1,23 +1,23 @@
 from datetime import datetime, timedelta
+
 from django.core.files.storage import default_storage as storage
 
 import olympia.core.logger
-
 from olympia import amo
 from olympia.activity.models import ActivityLog
-from olympia.constants.activity import RETENTION_DAYS
 from olympia.addons.models import Addon
 from olympia.addons.tasks import delete_addons
+from olympia.amo.models import FakeEmail
 from olympia.amo.utils import chunked
+from olympia.constants.activity import RETENTION_DAYS
 from olympia.files.models import FileUpload
 from olympia.scanners.models import ScannerResult
-from olympia.amo.models import FakeEmail
 
 from . import tasks
 from .sitemap import (
     get_sitemap_path,
-    get_sitemaps,
     get_sitemap_section_pages,
+    get_sitemaps,
     render_index_xml,
 )
 

--- a/src/olympia/amo/decorators.py
+++ b/src/olympia/amo/decorators.py
@@ -192,7 +192,7 @@ def api_authentication(f):
     already have been attempted by this point so api auth will only be tried for
     anonymous (unauthenticated) requests."""
 
-    from olympia.api.authentication import SessionIDAuthentication, JWTKeyAuthentication
+    from olympia.api.authentication import JWTKeyAuthentication, SessionIDAuthentication
 
     @functools.wraps(f)
     def wrapper(request, *args, **kw):

--- a/src/olympia/amo/fields.py
+++ b/src/olympia/amo/fields.py
@@ -1,5 +1,5 @@
-import re
 import ipaddress
+import re
 
 from django.conf import settings
 from django.core import exceptions

--- a/src/olympia/amo/forms.py
+++ b/src/olympia/amo/forms.py
@@ -1,8 +1,8 @@
 from django import forms
+from django.utils.functional import cached_property
 
 from olympia.amo.utils import BaseModelSerializerAndFormMixin
 from olympia.translations.fields import TranslatedField
-from django.utils.functional import cached_property
 
 
 class AMOModelForm(BaseModelSerializerAndFormMixin, forms.ModelForm):

--- a/src/olympia/amo/mail.py
+++ b/src/olympia/amo/mail.py
@@ -3,7 +3,6 @@ from django.core import mail
 from django.core.mail.backends.base import BaseEmailBackend
 
 import olympia.core.logger
-
 from olympia.amo.models import FakeEmail
 
 

--- a/src/olympia/amo/management/commands/addnewversion.py
+++ b/src/olympia/amo/management/commands/addnewversion.py
@@ -2,7 +2,6 @@ from django.core.management.base import BaseCommand, CommandError
 from django.db import IntegrityError
 
 import olympia.core.logger
-
 from olympia import amo
 from olympia.applications.models import AppVersion
 

--- a/src/olympia/amo/management/commands/compress_assets.py
+++ b/src/olympia/amo/management/commands/compress_assets.py
@@ -3,8 +3,8 @@ import os
 import subprocess
 
 from django.conf import settings
-from django.core.management.base import BaseCommand, CommandError
 from django.contrib.staticfiles.finders import find as find_static_path
+from django.core.management.base import BaseCommand, CommandError
 
 from olympia.lib.jingo_minify_helpers import ensure_path_exists
 

--- a/src/olympia/amo/management/commands/cron.py
+++ b/src/olympia/amo/management/commands/cron.py
@@ -1,5 +1,4 @@
 import argparse
-
 from datetime import datetime
 from importlib import import_module
 

--- a/src/olympia/amo/management/commands/get_changed_files.py
+++ b/src/olympia/amo/management/commands/get_changed_files.py
@@ -1,5 +1,4 @@
 import os
-
 from datetime import datetime, timedelta
 from os import scandir
 

--- a/src/olympia/amo/messages.py
+++ b/src/olympia/amo/messages.py
@@ -5,7 +5,6 @@ from django.template import loader
 from django.utils import safestring
 
 import markupsafe
-
 from rest_framework.request import Request
 
 

--- a/src/olympia/amo/middleware.py
+++ b/src/olympia/amo/middleware.py
@@ -1,7 +1,6 @@
 import contextlib
 import re
 import uuid
-
 from urllib.parse import quote
 
 from django.conf import settings
@@ -20,6 +19,7 @@ from django.http import (
 )
 from django.middleware import common
 from django.template.response import TemplateResponse
+from django.urls import is_valid_path
 from django.utils.cache import (
     add_never_cache_headers,
     get_max_age,
@@ -30,19 +30,17 @@ from django.utils.crypto import constant_time_compare
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.encoding import force_str, iri_to_uri
 from django.utils.translation import activate, gettext_lazy as _
-from django.urls import is_valid_path
-
-from django_statsd.clients import statsd
-from rest_framework import permissions
 
 import MySQLdb as mysql
+from django_statsd.clients import statsd
+from rest_framework import permissions
 
 import olympia.core.logger
 from olympia import amo
 from olympia.accounts.utils import redirect_for_login
 from olympia.accounts.verify import (
-    check_and_update_fxa_access_token,
     IdentificationError,
+    check_and_update_fxa_access_token,
 )
 
 from . import urlresolvers

--- a/src/olympia/amo/models.py
+++ b/src/olympia/amo/models.py
@@ -1,7 +1,6 @@
 import contextlib
 import os
 import time
-
 from urllib.parse import urljoin
 
 from django.conf import settings
@@ -20,7 +19,6 @@ from django.utils.functional import cached_property
 import multidb.pinning
 
 import olympia.core.logger
-
 from olympia.translations.hold import save_translations
 
 
@@ -131,8 +129,9 @@ class ManagerBase(models.Manager):
         return self._with_translations(qs)
 
     def _with_translations(self, qs):
-        from olympia.translations import transformer
         from django.db.models import Value
+
+        from olympia.translations import transformer
 
         if hasattr(self.model._meta, 'translated_fields'):
             qs = qs.transform(transformer.get_trans)

--- a/src/olympia/amo/monitors.py
+++ b/src/olympia/amo/monitors.py
@@ -1,5 +1,5 @@
-import os
 import io
+import os
 import socket
 import traceback
 
@@ -7,13 +7,11 @@ from django.conf import settings
 
 import celery
 import requests
-
 from django_statsd.clients import statsd
 from kombu import Connection
 from PIL import Image
 
 import olympia.core.logger
-
 from olympia.amo.models import use_primary_db
 from olympia.blocklist.tasks import monitor_remote_settings
 from olympia.search.utils import get_es

--- a/src/olympia/amo/sitemap.py
+++ b/src/olympia/amo/sitemap.py
@@ -10,17 +10,17 @@ from django.contrib.sitemaps import Sitemap as DjangoSitemap
 from django.core.paginator import PageNotAnInteger
 from django.db.models import Count, Max, Q
 from django.template import loader
-from django.utils.functional import cached_property
 from django.urls import reverse
+from django.utils.functional import cached_property
 
 from olympia import amo
 from olympia.addons.models import Addon, AddonCategory
 from olympia.amo.reverse import get_url_prefix, override_url_prefix
 from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.amo.utils import id_to_path
+from olympia.bandwagon.models import Collection
 from olympia.constants.categories import CATEGORIES
 from olympia.constants.promoted import RECOMMENDED
-from olympia.bandwagon.models import Collection
 from olympia.promoted.models import PromotedAddon
 from olympia.tags.models import AddonTag, Tag
 from olympia.users.models import UserProfile

--- a/src/olympia/amo/tasks.py
+++ b/src/olympia/amo/tasks.py
@@ -4,7 +4,6 @@ from django.apps import apps
 from django.core.mail import EmailMessage, EmailMultiAlternatives
 
 import olympia.core.logger
-
 from olympia import amo
 from olympia.amo.celery import task
 from olympia.amo.utils import get_email_backend

--- a/src/olympia/amo/templatetags/jinja_helpers.py
+++ b/src/olympia/amo/templatetags/jinja_helpers.py
@@ -1,10 +1,9 @@
 import json as jsonlib
-
 from urllib.parse import urljoin
 
 from django.conf import settings
 from django.forms import CheckboxInput
-from django.template import defaultfilters, Library, loader
+from django.template import Library, defaultfilters, loader
 from django.templatetags.static import static
 from django.urls import reverse
 from django.utils.encoding import smart_str
@@ -18,10 +17,9 @@ from django.utils.translation import get_language, gettext
 import jinja2
 import markupsafe
 import waffle
-from jinja2.ext import Extension
-
 from babel.support import Format
 from django_jinja import library
+from jinja2.ext import Extension
 from rest_framework.reverse import reverse as drf_reverse
 from rest_framework.settings import api_settings
 

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -9,9 +9,9 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta
 from functools import partial
 from importlib import import_module
-from urllib.parse import parse_qs, urlparse
-from unittest import mock
 from tempfile import NamedTemporaryFile
+from unittest import mock
+from urllib.parse import parse_qs, urlparse
 
 from django import forms, test
 from django.conf import settings
@@ -46,10 +46,10 @@ from olympia.addons.models import (
     AddonReviewerFlags,
     update_search_index as addon_update_search_index,
 )
+from olympia.addons.tasks import compute_last_updated
 from olympia.amo.reverse import get_url_prefix, set_url_prefix
 from olympia.amo.urlresolvers import Prefixer
 from olympia.amo.utils import SafeStorage, use_fake_fxa
-from olympia.addons.tasks import compute_last_updated
 from olympia.api.tests import JWTAuthKeyTester
 from olympia.applications.models import AppVersion
 from olympia.bandwagon.models import Collection
@@ -64,13 +64,13 @@ from olympia.promoted.models import (
 from olympia.search.utils import get_es, timestamp_index
 from olympia.tags.models import Tag
 from olympia.translations.models import Translation
+from olympia.users.models import UserProfile
 from olympia.versions.models import (
     ApplicationsVersions,
     License,
     Version,
     VersionReviewerFlags,
 )
-from olympia.users.models import UserProfile
 
 from . import dynamic_urls
 

--- a/src/olympia/amo/tests/test_amo_utils.py
+++ b/src/olympia/amo/tests/test_amo_utils.py
@@ -1,13 +1,13 @@
 import os
 import tempfile
+from unittest import mock
 
 from django.conf import settings
 from django.core.validators import ValidationError
 
-from unittest import mock
 import pytest
 
-from olympia.amo.tests import get_temp_filename, TestCase
+from olympia.amo.tests import TestCase, get_temp_filename
 from olympia.amo.utils import (
     SafeStorage,
     escape_all,

--- a/src/olympia/amo/tests/test_celery.py
+++ b/src/olympia/amo/tests/test_celery.py
@@ -1,7 +1,6 @@
+import datetime
 import importlib
 import time
-import datetime
-
 from datetime import timedelta
 from unittest import mock
 
@@ -12,8 +11,8 @@ from django.test.testcases import TransactionTestCase
 from celery import group
 from post_request_task.task import _discard_tasks, _stop_queuing_tasks
 
-from olympia.amo.tests import TestCase
 from olympia.amo.celery import app, create_chunked_tasks_signatures, task
+from olympia.amo.tests import TestCase
 from olympia.amo.utils import utc_millesecs_from_epoch
 
 

--- a/src/olympia/amo/tests/test_commands.py
+++ b/src/olympia/amo/tests/test_commands.py
@@ -1,35 +1,35 @@
-import os
 import io
+import os
 from datetime import datetime, timedelta
 from importlib import import_module
+from unittest import mock
 
 from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test.utils import override_settings
 
-from unittest import mock
 import pytest
 
 from olympia.addons.models import Preview
 from olympia.amo.management.commands.get_changed_files import (
-    collect_user_pics,
-    collect_files,
-    collect_sources,
-    collect_addon_previews,
-    collect_theme_previews,
     collect_addon_icons,
-    collect_editoral,
-    collect_git,
+    collect_addon_previews,
     collect_blocklist,
+    collect_editoral,
+    collect_files,
+    collect_git,
+    collect_sources,
+    collect_theme_previews,
+    collect_user_pics,
 )
-from olympia.amo.tests import addon_factory, TestCase, user_factory, version_factory
+from olympia.amo.tests import TestCase, addon_factory, user_factory, version_factory
 from olympia.amo.utils import id_to_path
 from olympia.blocklist.utils import datetime_to_ts
 from olympia.files.models import File, files_upload_to_callback
 from olympia.git.utils import AddonGitRepository
 from olympia.hero.models import PrimaryHeroImage
-from olympia.versions.models import source_upload_path, VersionPreview
+from olympia.versions.models import VersionPreview, source_upload_path
 
 
 def sample_cron_job(*args):

--- a/src/olympia/amo/tests/test_decorators.py
+++ b/src/olympia/amo/tests/test_decorators.py
@@ -8,7 +8,6 @@ from django.test import RequestFactory
 from django.utils.encoding import force_str
 
 import pytest
-
 from rest_framework import exceptions as drf_exceptions
 
 from olympia import amo

--- a/src/olympia/amo/tests/test_fields.py
+++ b/src/olympia/amo/tests/test_fields.py
@@ -1,7 +1,7 @@
 from ipaddress import IPv4Address, IPv6Address
 
 from django.core import exceptions
-from django.db import connection, DataError
+from django.db import DataError, connection
 from django.test.utils import override_settings
 
 from olympia.access.models import Group

--- a/src/olympia/amo/tests/test_helpers.py
+++ b/src/olympia/amo/tests/test_helpers.py
@@ -1,21 +1,18 @@
 import mimetypes
 import os
-
 from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
 
 from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.urls import NoReverseMatch
 from django.test.client import RequestFactory
+from django.urls import NoReverseMatch
 from django.utils.encoding import force_bytes
 
 import pytest
-
 from pyquery import PyQuery
 
 import olympia
-
 from olympia import amo
 from olympia.amo import urlresolvers, utils
 from olympia.amo.reverse import set_url_prefix

--- a/src/olympia/amo/tests/test_messages.py
+++ b/src/olympia/amo/tests/test_messages.py
@@ -1,5 +1,4 @@
 import django.contrib.messages as django_messages
-
 from django.contrib.messages.storage import default_storage
 from django.http import HttpRequest
 from django.template import loader

--- a/src/olympia/amo/tests/test_middleware.py
+++ b/src/olympia/amo/tests/test_middleware.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock, PropertyMock, patch
+
 from django import test
 from django.conf import settings
 from django.contrib.auth import SESSION_KEY
@@ -8,8 +10,6 @@ from django.test.utils import override_settings
 from django.urls import reverse
 
 import pytest
-
-from unittest.mock import patch, Mock, PropertyMock
 from pyquery import PyQuery as pq
 
 from olympia.accounts.utils import fxa_login_url, path_with_query
@@ -22,7 +22,7 @@ from olympia.amo.middleware import (
     SetRemoteAddrFromForwardedFor,
     TokenValidMiddleware,
 )
-from olympia.amo.tests import addon_factory, reverse_ns, TestCase, user_factory
+from olympia.amo.tests import TestCase, addon_factory, reverse_ns, user_factory
 from olympia.zadmin.models import Config
 
 

--- a/src/olympia/amo/tests/test_models.py
+++ b/src/olympia/amo/tests/test_models.py
@@ -1,11 +1,12 @@
 import os
-import pytest
 from unittest.mock import Mock
 
 from django.conf import settings
 from django.core.files.storage import default_storage as storage
 from django.test.utils import override_settings
 from django.urls import reverse
+
+import pytest
 
 from olympia import amo
 from olympia.addons.models import Addon

--- a/src/olympia/amo/tests/test_monitor.py
+++ b/src/olympia/amo/tests/test_monitor.py
@@ -1,11 +1,10 @@
 import json
+from unittest.mock import Mock, patch
 
 from django.conf import settings
 from django.test.utils import override_settings
 
 import responses
-
-from unittest.mock import Mock, patch
 
 from olympia.amo import monitors
 from olympia.amo.tests import TestCase

--- a/src/olympia/amo/tests/test_pagination.py
+++ b/src/olympia/amo/tests/test_pagination.py
@@ -1,8 +1,8 @@
+from unittest.mock import MagicMock, Mock
+
 from django.core.paginator import EmptyPage, InvalidPage, PageNotAnInteger, Paginator
 
 import pytest
-
-from unittest.mock import MagicMock, Mock
 
 from olympia.amo.pagination import ESPaginator
 from olympia.amo.templatetags.jinja_helpers import PaginationRenderer

--- a/src/olympia/amo/tests/test_pytest_fixtures.py
+++ b/src/olympia/amo/tests/test_pytest_fixtures.py
@@ -1,8 +1,7 @@
 """Testing the pytest fixtures themselves which are declared in conftest.py."""
 import pytest
-import responses
 import requests
-
+import responses
 from requests.exceptions import ConnectionError
 
 from olympia.access.models import Group

--- a/src/olympia/amo/tests/test_readonly.py
+++ b/src/olympia/amo/tests/test_readonly.py
@@ -2,7 +2,6 @@ from django.db import models
 
 import MySQLdb as mysql
 import pytest
-
 from pyquery import PyQuery as pq
 
 from olympia.addons.models import Addon

--- a/src/olympia/amo/tests/test_send_mail.py
+++ b/src/olympia/amo/tests/test_send_mail.py
@@ -1,12 +1,11 @@
 import mimetypes
 import os.path
+from unittest import mock
 
 from django.conf import settings
 from django.core import mail
 from django.core.mail import EmailMessage
 from django.utils import translation
-
-from unittest import mock
 
 from celery.exceptions import Retry
 

--- a/src/olympia/amo/tests/test_settings.py
+++ b/src/olympia/amo/tests/test_settings.py
@@ -1,11 +1,10 @@
-import os
 import json
-
+import os
 from copy import deepcopy
 
-from sentry_sdk.hub import Hub
-
 from django.conf import settings
+
+from sentry_sdk.hub import Hub
 
 from olympia.core.sentry import get_sentry_release
 

--- a/src/olympia/amo/tests/test_sitemap.py
+++ b/src/olympia/amo/tests/test_sitemap.py
@@ -1,6 +1,6 @@
 import os
-from unittest import mock
 from datetime import datetime
+from unittest import mock
 
 from django.conf import settings
 from django.core.paginator import PageNotAnInteger
@@ -11,24 +11,24 @@ import pytest
 
 from olympia import amo
 from olympia.addons.models import AddonCategory
+from olympia.amo.reverse import override_url_prefix
 from olympia.amo.sitemap import (
     AccountSitemap,
     AddonSitemap,
     AMOSitemap,
     CategoriesSitemap,
     CollectionSitemap,
+    InvalidSection,
+    TagPagesSitemap,
     get_sitemap_path,
     get_sitemap_section_pages,
     get_sitemaps,
-    InvalidSection,
     render_index_xml,
-    TagPagesSitemap,
 )
-from olympia.amo.reverse import override_url_prefix
 from olympia.amo.tests import (
+    TestCase,
     addon_factory,
     collection_factory,
-    TestCase,
     user_factory,
     version_factory,
 )

--- a/src/olympia/amo/tests/test_storage_utils.py
+++ b/src/olympia/amo/tests/test_storage_utils.py
@@ -1,6 +1,5 @@
 import os
 import tempfile
-
 from functools import partial
 
 from django.conf import settings
@@ -10,7 +9,7 @@ from django.utils.encoding import force_str
 import pytest
 
 from olympia.amo.tests import TestCase
-from olympia.amo.utils import rm_local_tmp_dir, SafeStorage
+from olympia.amo.utils import SafeStorage, rm_local_tmp_dir
 
 
 pytestmark = pytest.mark.django_db

--- a/src/olympia/amo/tests/test_url_prefix.py
+++ b/src/olympia/amo/tests/test_url_prefix.py
@@ -1,14 +1,14 @@
 from django import shortcuts
 from django.conf import settings
-from django.urls import resolve, reverse, set_script_prefix
 from django.test.client import Client, RequestFactory
+from django.urls import resolve, reverse, set_script_prefix
 
 import pytest
 
 from olympia.amo import urlresolvers
 from olympia.amo.middleware import LocaleAndAppURLMiddleware
 from olympia.amo.reverse import clean_url_prefixes, set_url_prefix
-from olympia.amo.tests import addon_factory, TestCase
+from olympia.amo.tests import TestCase, addon_factory
 
 
 pytestmark = pytest.mark.django_db

--- a/src/olympia/amo/tests/test_utils.py
+++ b/src/olympia/amo/tests/test_utils.py
@@ -2,6 +2,7 @@ import collections
 import datetime
 import os.path
 import tempfile
+from unittest import mock
 from urllib.parse import urlparse
 
 from django.conf import settings
@@ -11,9 +12,7 @@ from django.utils.functional import cached_property
 from django.utils.http import quote_etag
 
 import freezegun
-from unittest import mock
 import pytest
-
 from babel import Locale
 
 from olympia import amo

--- a/src/olympia/amo/tests/test_views.py
+++ b/src/olympia/amo/tests/test_views.py
@@ -2,8 +2,8 @@ import json
 import os
 import re
 import sys
-
 from unittest import mock
+from unittest.mock import patch
 from urllib.parse import urlparse
 
 import django
@@ -14,9 +14,7 @@ from django.test.utils import override_settings
 from django.urls import reverse
 
 import pytest
-
 from lxml import etree
-from unittest.mock import patch
 from pyquery import PyQuery as pq
 
 from olympia import amo, core

--- a/src/olympia/amo/urlresolvers.py
+++ b/src/olympia/amo/urlresolvers.py
@@ -1,7 +1,6 @@
 import hashlib
 import hmac
 import re
-
 from urllib.parse import quote
 
 from django.conf import settings

--- a/src/olympia/amo/urls.py
+++ b/src/olympia/amo/urls.py
@@ -3,6 +3,7 @@ from django.views.generic.base import TemplateView
 
 from . import views
 
+
 services_patterns = [
     re_path(
         r'^__heartbeat__$', views.services_heartbeat, name='amo.services_heartbeat'

--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -14,17 +14,15 @@ import subprocess
 import tempfile
 import time
 import unicodedata
-
 from urllib.parse import (
-    parse_qsl,
     ParseResult,
+    parse_qsl,
     unquote_to_bytes,
     urlencode as urllib_urlencode,
     urlparse,
 )
 
 import django.core.mail
-
 from django.conf import settings
 from django.core.exceptions import FieldDoesNotExist
 from django.core.files.storage import FileSystemStorage, default_storage as storage
@@ -36,21 +34,20 @@ from django.http.response import HttpResponseRedirectBase
 from django.template import engines, loader
 from django.urls import reverse
 from django.utils import translation
-from django.utils.functional import cached_property
 from django.utils.encoding import force_bytes, force_str
+from django.utils.functional import cached_property
 from django.utils.http import (
     _urlparse as django_urlparse,
     quote_etag,
     url_has_allowed_host_and_scheme,
 )
 
+import basket
 import bleach
 import colorgram
 import html5lib
 import markupsafe
 import pytz
-import basket
-
 from babel import Locale
 from django_statsd.clients import statsd
 from html5lib.serializer import HTMLSerializer
@@ -58,12 +55,12 @@ from PIL import Image
 from rest_framework.utils.encoders import JSONEncoder
 from rest_framework.utils.formatting import lazy_format
 
-from olympia.core.logger import getLogger
 from olympia.amo import ADDON_ICON_SIZES
 from olympia.amo.urlresolvers import linkify_with_outgoing
+from olympia.core.logger import getLogger
+from olympia.lib import unicodehelper
 from olympia.translations.models import Translation
 from olympia.users.utils import UnsubscribeCode
-from olympia.lib import unicodehelper
 
 
 log = getLogger('z.amo')
@@ -187,8 +184,8 @@ def send_mail(
 
     Adds deny checking and error logging.
     """
-    from olympia.amo.templatetags.jinja_helpers import absolutify
     from olympia.amo.tasks import send_email
+    from olympia.amo.templatetags.jinja_helpers import absolutify
     from olympia.users import notifications
     from olympia.users.models import UserNotification
 

--- a/src/olympia/amo/views.py
+++ b/src/olympia/amo/views.py
@@ -26,7 +26,7 @@ from olympia.api.serializers import SiteStatusSerializer
 from olympia.users.models import UserProfile
 
 from . import monitors
-from .sitemap import get_sitemap_path, get_sitemaps, InvalidSection, render_index_xml
+from .sitemap import InvalidSection, get_sitemap_path, get_sitemaps, render_index_xml
 
 
 @never_cache
@@ -147,7 +147,7 @@ def handler500(request, **kwargs):
 
 @non_atomic_requests
 def csrf_failure(request, reason=''):
-    from django.middleware.csrf import REASON_NO_REFERER, REASON_NO_CSRF_COOKIE
+    from django.middleware.csrf import REASON_NO_CSRF_COOKIE, REASON_NO_REFERER
 
     ctx = {
         'reason': reason,

--- a/src/olympia/api/authentication.py
+++ b/src/olympia/api/authentication.py
@@ -4,16 +4,14 @@ from django.utils.encoding import force_str, smart_str
 from django.utils.translation import gettext
 
 import jwt
-
 from rest_framework import exceptions
 from rest_framework.authentication import BaseAuthentication, get_authorization_header
 
 import olympia.core.logger
-
 from olympia import core
 from olympia.accounts.verify import (
-    check_and_update_fxa_access_token,
     IdentificationError,
+    check_and_update_fxa_access_token,
 )
 from olympia.api import jwt_auth
 from olympia.api.models import APIKey

--- a/src/olympia/api/exceptions.py
+++ b/src/olympia/api/exceptions.py
@@ -6,8 +6,7 @@ from django.core.signals import got_request_exception
 from django.http import Http404
 from django.utils.translation import gettext_lazy as _
 
-from rest_framework import exceptions
-from rest_framework import status
+from rest_framework import exceptions, status
 from rest_framework.response import Response
 from rest_framework.views import set_rollback
 

--- a/src/olympia/api/jwt_auth.py
+++ b/src/olympia/api/jwt_auth.py
@@ -19,11 +19,9 @@ from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 
 import jwt
-
 from rest_framework import exceptions
 
 import olympia.core.logger
-
 from olympia.api.models import APIKey
 
 

--- a/src/olympia/api/tests/test_authentication.py
+++ b/src/olympia/api/tests/test_authentication.py
@@ -1,6 +1,5 @@
 import json
 import time
-
 from calendar import timegm
 from datetime import datetime, timedelta
 from unittest import mock
@@ -10,7 +9,6 @@ from django.test import RequestFactory
 from django.urls import reverse
 
 import jwt
-
 from freezegun import freeze_time
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.permissions import IsAuthenticated
@@ -22,8 +20,8 @@ from olympia.accounts.verify import IdentificationError
 from olympia.activity.models import ActivityLog
 from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.amo.tests import (
-    APITestClientSessionID,
     APITestClientJWT,
+    APITestClientSessionID,
     TestCase,
     WithDynamicEndpoints,
     user_factory,

--- a/src/olympia/api/tests/test_commands.py
+++ b/src/olympia/api/tests/test_commands.py
@@ -1,5 +1,5 @@
-import os.path
 import io
+import os.path
 
 from django.conf import settings
 from django.core.management import call_command

--- a/src/olympia/api/tests/test_exceptions.py
+++ b/src/olympia/api/tests/test_exceptions.py
@@ -1,8 +1,8 @@
-from django.urls import reverse
+from unittest import mock
+
 from django.http import Http404
 from django.test import TestCase, override_settings
-
-from unittest import mock
+from django.urls import reverse
 
 from rest_framework.exceptions import APIException, PermissionDenied
 from rest_framework.request import Request

--- a/src/olympia/api/tests/test_fields.py
+++ b/src/olympia/api/tests/test_fields.py
@@ -1,10 +1,10 @@
 from collections import OrderedDict
+from unittest.mock import Mock
 
 from django.conf import settings
 from django.test.utils import override_settings
 
 import pytest
-from unittest.mock import Mock
 from rest_framework import exceptions, serializers
 from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
@@ -16,10 +16,10 @@ from olympia.amo.urlresolvers import get_outgoing_url
 from olympia.api.fields import (
     AbsoluteOutgoingURLField,
     ESTranslationSerializerField,
+    FallbackField,
     GetTextTranslationSerializerField,
     GetTextTranslationSerializerFieldFlat,
     LazyChoiceField,
-    FallbackField,
     OutgoingURLField,
     ReverseChoiceField,
     SlugOrPrimaryKeyRelatedField,

--- a/src/olympia/api/tests/test_jwt_auth.py
+++ b/src/olympia/api/tests/test_jwt_auth.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 from django.conf import settings
 
 import jwt
-
 from rest_framework.exceptions import AuthenticationFailed
 
 from olympia.amo.tests import TestCase

--- a/src/olympia/api/tests/test_namespace.py
+++ b/src/olympia/api/tests/test_namespace.py
@@ -1,10 +1,10 @@
-from django.urls import include, NoReverseMatch, re_path
+from django.urls import NoReverseMatch, include, re_path
 
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
 from rest_framework.viewsets import GenericViewSet
 
-from olympia.amo.tests import addon_factory, reverse_ns, TestCase, WithDynamicEndpoints
+from olympia.amo.tests import TestCase, WithDynamicEndpoints, addon_factory, reverse_ns
 
 
 class EmptyViewSet(GenericViewSet):

--- a/src/olympia/api/tests/test_permissions.py
+++ b/src/olympia/api/tests/test_permissions.py
@@ -1,8 +1,9 @@
+from unittest.mock import Mock
+
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
 from django.urls import reverse
 
-from unittest.mock import Mock
 from rest_framework.exceptions import MethodNotAllowed
 from rest_framework.permissions import AllowAny, BasePermission
 from rest_framework.response import Response
@@ -23,11 +24,11 @@ from olympia.api.permissions import (
     AllowAnyKindOfReviewer,
     AllowIfNotMozillaDisabled,
     AllowIfPublic,
+    AllowListedViewerOrReviewer,
     AllowNone,
     AllowOwner,
     AllowReadOnlyIfPublic,
     AllowRelatedObjectPermissions,
-    AllowListedViewerOrReviewer,
     AllowUnlistedViewerOrReviewer,
     AnyOf,
     ByHttpMethod,

--- a/src/olympia/api/tests/test_serializers.py
+++ b/src/olympia/api/tests/test_serializers.py
@@ -1,10 +1,9 @@
 from datetime import datetime
-
 from importlib import import_module
-import pytest
 
 from django.conf import settings
 
+import pytest
 from rest_framework.serializers import BaseSerializer
 
 from olympia.addons.models import Addon

--- a/src/olympia/api/tests/test_throttling.py
+++ b/src/olympia/api/tests/test_throttling.py
@@ -1,3 +1,4 @@
+from importlib import import_module
 from unittest import mock
 
 from django.conf import settings
@@ -5,9 +6,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 
-from importlib import import_module
 import pytest
-
 from freezegun import freeze_time
 from rest_framework.test import APIRequestFactory, force_authenticate
 from rest_framework.throttling import BaseThrottle

--- a/src/olympia/api/tests/test_utils.py
+++ b/src/olympia/api/tests/test_utils.py
@@ -4,6 +4,7 @@ from rest_framework.test import APIRequestFactory
 
 from olympia.api.utils import is_gate_active
 
+
 factory = APIRequestFactory()
 
 

--- a/src/olympia/api/urls.py
+++ b/src/olympia/api/urls.py
@@ -1,8 +1,8 @@
 from django.urls import include, re_path
 
 from olympia.accounts.urls import accounts_v3, accounts_v4, auth_urls
-from olympia.amo.urls import api_patterns as amo_api_patterns
 from olympia.addons.api_urls import addons_v3, addons_v4, addons_v5
+from olympia.amo.urls import api_patterns as amo_api_patterns
 from olympia.ratings.api_urls import ratings_v3, ratings_v4
 
 

--- a/src/olympia/api/validators.py
+++ b/src/olympia/api/validators.py
@@ -1,8 +1,8 @@
 from django.core.exceptions import ValidationError as DjangoValidationError
 
-from olympia.amo.validators import OneOrMorePrintableCharacterValidator
-
 from rest_framework import serializers
+
+from olympia.amo.validators import OneOrMorePrintableCharacterValidator
 
 
 class OneOrMorePrintableCharacterAPIValidator(OneOrMorePrintableCharacterValidator):

--- a/src/olympia/applications/tests.py
+++ b/src/olympia/applications/tests.py
@@ -5,8 +5,7 @@ from django.db import IntegrityError
 import responses
 
 from olympia import amo
-from olympia.amo.tests import APITestClientSessionID, reverse_ns, TestCase
-
+from olympia.amo.tests import APITestClientSessionID, TestCase, reverse_ns
 from olympia.api.tests.utils import APIKeyAuthTestMixin
 from olympia.applications.models import AppVersion
 

--- a/src/olympia/applications/views.py
+++ b/src/olympia/applications/views.py
@@ -1,8 +1,8 @@
 from django.utils.cache import patch_cache_control
 
 from rest_framework.exceptions import ParseError
-from rest_framework.response import Response
 from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
 from rest_framework.status import HTTP_201_CREATED, HTTP_202_ACCEPTED
 from rest_framework.views import APIView
 

--- a/src/olympia/bandwagon/tasks.py
+++ b/src/olympia/bandwagon/tasks.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from django.db.models import Count
 
 import olympia.core.logger
-
 from olympia.amo.celery import task
 from olympia.amo.decorators import use_primary_db
 

--- a/src/olympia/bandwagon/tests/test_models.py
+++ b/src/olympia/bandwagon/tests/test_models.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from olympia import amo, core
 from olympia.activity.models import ActivityLog
 from olympia.addons.models import Addon
-from olympia.amo.tests import addon_factory, TestCase
+from olympia.amo.tests import TestCase, addon_factory
 from olympia.bandwagon.models import Collection
 from olympia.users.models import UserProfile
 

--- a/src/olympia/bandwagon/tests/test_serializers.py
+++ b/src/olympia/bandwagon/tests/test_serializers.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 from olympia.amo.templatetags.jinja_helpers import absolutify
-from olympia.amo.tests import addon_factory, collection_factory, TestCase, user_factory
+from olympia.amo.tests import TestCase, addon_factory, collection_factory, user_factory
 from olympia.bandwagon.models import CollectionAddon
 from olympia.bandwagon.serializers import (
     CollectionAddonSerializer,

--- a/src/olympia/bandwagon/tests/test_views.py
+++ b/src/olympia/bandwagon/tests/test_views.py
@@ -1,7 +1,6 @@
 import json
 
 import django.test
-
 from django.conf import settings
 from django.test.utils import override_settings
 from django.utils.cache import get_max_age

--- a/src/olympia/bandwagon/views.py
+++ b/src/olympia/bandwagon/views.py
@@ -15,8 +15,8 @@ from olympia.api.permissions import (
     AnyOf,
     PreventActionPermission,
 )
-from olympia.versions.models import License, Version
 from olympia.translations.query import order_by_translation
+from olympia.versions.models import License, Version
 
 from .models import Collection, CollectionAddon
 from .permissions import (

--- a/src/olympia/blocklist/management/commands/export_blocklist.py
+++ b/src/olympia/blocklist/management/commands/export_blocklist.py
@@ -3,7 +3,6 @@ import json
 from django.core.management.base import BaseCommand
 
 import olympia.core.logger
-
 from olympia.blocklist.mlbf import MLBF
 
 

--- a/src/olympia/blocklist/mlbf.py
+++ b/src/olympia/blocklist/mlbf.py
@@ -48,8 +48,8 @@ def generate_mlbf(stats, blocked, not_blocked):
 
 
 def fetch_blocked_from_db():
-    from olympia.files.models import File
     from olympia.blocklist.models import Block
+    from olympia.files.models import File
 
     blocks = Block.objects.all()
     blocks_guids = [block.guid for block in blocks]

--- a/src/olympia/blocklist/models.py
+++ b/src/olympia/blocklist/models.py
@@ -5,8 +5,8 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.urls import reverse
-from django.utils.html import format_html
 from django.utils.functional import cached_property
+from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 
 from multidb import get_replica

--- a/src/olympia/blocklist/serializers.py
+++ b/src/olympia/blocklist/serializers.py
@@ -1,5 +1,5 @@
-from olympia.api.serializers import AMOModelSerializer
 from olympia.api.fields import OutgoingURLField, TranslationSerializerField
+from olympia.api.serializers import AMOModelSerializer
 
 from .models import Block
 

--- a/src/olympia/blocklist/tasks.py
+++ b/src/olympia/blocklist/tasks.py
@@ -15,8 +15,8 @@ from olympia.amo.celery import task
 from olympia.amo.decorators import use_primary_db
 from olympia.amo.utils import SafeStorage
 from olympia.constants.blocklist import (
-    MLBF_TIME_CONFIG_KEY,
     MLBF_BASE_ID_CONFIG_KEY,
+    MLBF_TIME_CONFIG_KEY,
     REMOTE_SETTINGS_COLLECTION_MLBF,
 )
 from olympia.lib.remote_settings import RemoteSettings

--- a/src/olympia/blocklist/tests/test_admin.py
+++ b/src/olympia/blocklist/tests/test_admin.py
@@ -1,14 +1,13 @@
 import json
 from datetime import datetime, timedelta
-
-from freezegun import freeze_time
 from unittest import mock
 
 from django.conf import settings
-from django.contrib.admin.models import LogEntry, ADDITION
+from django.contrib.admin.models import ADDITION, LogEntry
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 
+from freezegun import freeze_time
 from pyquery import PyQuery as pq
 from waffle.testutils import override_switch
 

--- a/src/olympia/blocklist/tests/test_commands.py
+++ b/src/olympia/blocklist/tests/test_commands.py
@@ -1,12 +1,12 @@
-import os
 import json
+import os
 
+from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import CommandError
-from django.conf import settings
 
 from olympia import amo
-from olympia.amo.tests import addon_factory, TestCase, user_factory
+from olympia.amo.tests import TestCase, addon_factory, user_factory
 
 from ..models import Block
 

--- a/src/olympia/blocklist/tests/test_cron.py
+++ b/src/olympia/blocklist/tests/test_cron.py
@@ -3,23 +3,22 @@ import os
 from datetime import datetime, timedelta
 from unittest import mock
 
-import pytest
-
 from django.conf import settings
 from django.core.files.storage import default_storage as storage
 
+import pytest
 from freezegun import freeze_time
 from waffle.testutils import override_switch
 
-from olympia.amo.tests import addon_factory, TestCase, user_factory, version_factory
+from olympia.amo.tests import TestCase, addon_factory, user_factory, version_factory
 from olympia.blocklist.cron import (
-    process_blocklistsubmissions,
     get_blocklist_last_modified_time,
+    process_blocklistsubmissions,
     upload_mlbf_to_remote_settings,
 )
 from olympia.blocklist.mlbf import MLBF
 from olympia.blocklist.models import Block, BlocklistSubmission
-from olympia.constants.blocklist import MLBF_TIME_CONFIG_KEY, MLBF_BASE_ID_CONFIG_KEY
+from olympia.constants.blocklist import MLBF_BASE_ID_CONFIG_KEY, MLBF_TIME_CONFIG_KEY
 from olympia.lib.remote_settings import RemoteSettings
 from olympia.zadmin.models import get_config, set_config
 

--- a/src/olympia/blocklist/tests/test_forms.py
+++ b/src/olympia/blocklist/tests/test_forms.py
@@ -2,7 +2,7 @@ from django.contrib import admin as admin_site
 from django.core.exceptions import ValidationError
 from django.test import RequestFactory
 
-from olympia.amo.tests import addon_factory, TestCase, user_factory
+from olympia.amo.tests import TestCase, addon_factory, user_factory
 from olympia.blocklist.admin import BlocklistSubmissionAdmin
 from olympia.blocklist.forms import MultiAddForm, MultiDeleteForm
 from olympia.blocklist.models import Block, BlocklistSubmission

--- a/src/olympia/blocklist/tests/test_mlbf.py
+++ b/src/olympia/blocklist/tests/test_mlbf.py
@@ -7,14 +7,14 @@ from filtercascade import FilterCascade
 
 from olympia import amo
 from olympia.addons.models import GUID_REUSE_FORMAT
-from olympia.amo.tests import addon_factory, TestCase, user_factory, version_factory
+from olympia.amo.tests import TestCase, addon_factory, user_factory, version_factory
 from olympia.files.models import File
 
 from ..mlbf import (
+    MLBF,
     fetch_all_versions_from_db,
     fetch_blocked_from_db,
     generate_mlbf,
-    MLBF,
 )
 from ..models import Block
 

--- a/src/olympia/blocklist/tests/test_models.py
+++ b/src/olympia/blocklist/tests/test_models.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from django.core.exceptions import ValidationError
 from django.test.utils import override_settings
 
-from olympia.amo.tests import addon_factory, TestCase, user_factory
+from olympia.amo.tests import TestCase, addon_factory, user_factory
 
 from ..models import Block, BlocklistSubmission
 

--- a/src/olympia/blocklist/tests/test_serializers.py
+++ b/src/olympia/blocklist/tests/test_serializers.py
@@ -1,4 +1,4 @@
-from olympia.amo.tests import addon_factory, TestCase, user_factory
+from olympia.amo.tests import TestCase, addon_factory, user_factory
 from olympia.amo.urlresolvers import get_outgoing_url
 from olympia.blocklist.models import Block
 from olympia.blocklist.serializers import BlockSerializer

--- a/src/olympia/blocklist/tests/test_tasks.py
+++ b/src/olympia/blocklist/tests/test_tasks.py
@@ -1,6 +1,5 @@
 import os
 from datetime import datetime, timedelta
-
 from unittest import mock
 
 from django.conf import settings

--- a/src/olympia/blocklist/tests/test_views.py
+++ b/src/olympia/blocklist/tests/test_views.py
@@ -1,6 +1,6 @@
 from django.test.utils import override_settings
 
-from olympia.amo.tests import addon_factory, reverse_ns, TestCase, user_factory
+from olympia.amo.tests import TestCase, addon_factory, reverse_ns, user_factory
 from olympia.amo.urlresolvers import get_outgoing_url
 from olympia.blocklist.models import Block
 from olympia.blocklist.serializers import BlockSerializer

--- a/src/olympia/blocklist/utils.py
+++ b/src/olympia/blocklist/utils.py
@@ -102,9 +102,10 @@ def datetime_to_ts(dt=None):
 def disable_addon_for_block(block):
     """Disable appropriate addon versions that are affected by the Block, and
     the addon too if 0 - *."""
-    from .models import Block
     from olympia.addons.models import GuidAlreadyDeniedError
     from olympia.reviewers.utils import ReviewBase
+
+    from .models import Block
 
     review = ReviewBase(
         addon=block.addon,

--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -3,6 +3,7 @@ from inspect import isclass
 
 from django.utils.translation import gettext_lazy as _
 
+
 RETENTION_DAYS = 365
 
 __all__ = (

--- a/src/olympia/constants/applications.py
+++ b/src/olympia/constants/applications.py
@@ -2,6 +2,8 @@ import re
 
 from django.utils.translation import gettext_lazy as _
 
+from olympia.versions.compare import version_int as vint
+
 from .base import (
     ADDON_DICT,
     ADDON_EXTENSION,
@@ -10,8 +12,6 @@ from .base import (
     DEFAULT_WEBEXT_MIN_VERSION,
     DEFAULT_WEBEXT_MIN_VERSION_ANDROID,
 )
-
-from olympia.versions.compare import version_int as vint
 
 
 class App:

--- a/src/olympia/constants/categories.py
+++ b/src/olympia/constants/categories.py
@@ -1,5 +1,4 @@
 import copy
-
 from functools import total_ordering
 
 from django.urls import reverse
@@ -8,14 +7,14 @@ from django.utils.translation import gettext_lazy as _
 
 from olympia.constants.applications import ANDROID, FIREFOX
 from olympia.constants.base import (
+    _ADDON_PERSONA,
+    _ADDON_SEARCH,
+    _ADDON_THEME,
     ADDON_DICT,
     ADDON_EXTENSION,
     ADDON_LPAPP,
-    _ADDON_SEARCH,
     ADDON_SLUGS,
     ADDON_STATICTHEME,
-    _ADDON_THEME,
-    _ADDON_PERSONA,
 )
 
 

--- a/src/olympia/core/babel.py
+++ b/src/olympia/core/babel.py
@@ -1,5 +1,6 @@
 import django
 from django.conf import settings
+
 from jinja2.ext import babel_extract
 
 

--- a/src/olympia/core/sentry.py
+++ b/src/olympia/core/sentry.py
@@ -3,6 +3,7 @@ import os
 import re
 import urllib.parse
 
+
 # List of fields to scrub in our custom sentry_before_send() callback.
 # /!\ Each value needs to be in lowercase !
 SENTRY_SENSITIVE_FIELDS = (

--- a/src/olympia/core/tests/test_db_migrations.py
+++ b/src/olympia/core/tests/test_db_migrations.py
@@ -1,12 +1,11 @@
-from unittest import mock
-
-import pytest
-
-from waffle.models import Switch
-
 # Note: unit testing custom migration operations is a pain, so we cheat and
 # test with mocks for the state and schema editor, passing current app state.
+from unittest import mock
+
 from django.apps.registry import apps
+
+import pytest
+from waffle.models import Switch
 
 from olympia.core.db.migrations import CreateWaffleSwitch, DeleteWaffleSwitch
 

--- a/src/olympia/core/tests/test_logger.py
+++ b/src/olympia/core/tests/test_logger.py
@@ -1,10 +1,8 @@
 import json
 import logging
-
 from unittest import mock
 
 import olympia.core.logger
-
 from olympia.amo.tests import TestCase
 from olympia.users.models import UserProfile
 

--- a/src/olympia/devhub/cron.py
+++ b/src/olympia/devhub/cron.py
@@ -7,7 +7,6 @@ from django.core.exceptions import BadRequest
 import requests
 
 import olympia.core.logger
-
 from olympia.devhub.models import BlogPost
 
 

--- a/src/olympia/devhub/file_validation_annotations.py
+++ b/src/olympia/devhub/file_validation_annotations.py
@@ -1,6 +1,6 @@
-import waffle
-
 from django.utils.translation import gettext
+
+import waffle
 
 from olympia import amo
 from olympia.amo.urlresolvers import linkify_and_clean

--- a/src/olympia/devhub/forms.py
+++ b/src/olympia/devhub/forms.py
@@ -1,7 +1,6 @@
 import os
 import tarfile
 import zipfile
-
 from urllib.parse import urlsplit
 
 from django import forms
@@ -58,8 +57,8 @@ from olympia.translations.forms import TranslationFormMixin
 from olympia.translations.models import Translation, delete_translation
 from olympia.translations.widgets import TranslationTextarea, TranslationTextInput
 from olympia.users.models import (
-    EmailUserRestriction,
     RESTRICTION_TYPES,
+    EmailUserRestriction,
     UserEmailField,
     UserProfile,
 )

--- a/src/olympia/devhub/models.py
+++ b/src/olympia/devhub/models.py
@@ -1,11 +1,9 @@
 import uuid
-
 from datetime import datetime
 
 from django.db import models
 
 import olympia.core.logger
-
 from olympia.addons.models import Addon
 from olympia.amo.fields import PositiveAutoField
 from olympia.amo.models import ModelBase

--- a/src/olympia/devhub/tasks.py
+++ b/src/olympia/devhub/tasks.py
@@ -3,13 +3,10 @@ import json
 import os
 import subprocess
 import tempfile
-
 from copy import deepcopy
 from decimal import Decimal
 from functools import wraps
 from zipfile import BadZipFile
-
-import waffle
 
 from django.conf import settings
 from django.core.cache import cache
@@ -21,11 +18,11 @@ from django.urls import reverse
 from django.utils.encoding import force_str
 from django.utils.translation import gettext
 
+import waffle
 from celery.result import AsyncResult
 from django_statsd.clients import statsd
 
 import olympia.core.logger
-
 from olympia import amo
 from olympia.addons.models import Addon
 from olympia.amo.celery import task
@@ -42,12 +39,12 @@ from olympia.api.models import SYMMETRIC_JWT_TYPE, APIKey
 from olympia.devhub import file_validation_annotations as annotations
 from olympia.files.models import File, FileUpload, FileValidation
 from olympia.files.utils import (
+    InvalidArchiveFile,
     InvalidManifest,
     NoManifestFound,
-    parse_addon,
     SafeZip,
     UnsupportedFileType,
-    InvalidArchiveFile,
+    parse_addon,
 )
 
 

--- a/src/olympia/devhub/templatetags/jinja_helpers.py
+++ b/src/olympia/devhub/templatetags/jinja_helpers.py
@@ -1,7 +1,6 @@
 from django.utils.translation import gettext, ngettext
 
 import jinja2
-
 from django_jinja import library
 
 from olympia import amo

--- a/src/olympia/devhub/tests/test_feeds.py
+++ b/src/olympia/devhub/tests/test_feeds.py
@@ -1,5 +1,4 @@
 import uuid
-
 from urllib.parse import urlencode
 
 from django.urls import reverse

--- a/src/olympia/devhub/tests/test_forms.py
+++ b/src/olympia/devhub/tests/test_forms.py
@@ -10,7 +10,6 @@ from django.utils import translation
 
 import pytest
 from freezegun import freeze_time
-
 from pyquery import PyQuery as pq
 from waffle.testutils import override_switch
 
@@ -18,10 +17,10 @@ from olympia import amo, core
 from olympia.addons.models import Addon
 from olympia.addons.views import AddonViewSet
 from olympia.amo.tests import (
+    TestCase,
     addon_factory,
     get_random_ip,
     req_factory_factory,
-    TestCase,
     user_factory,
 )
 from olympia.amo.tests.test_helpers import get_image_path

--- a/src/olympia/devhub/tests/test_helpers.py
+++ b/src/olympia/devhub/tests/test_helpers.py
@@ -1,8 +1,8 @@
+from unittest.mock import Mock
+
 from django.utils import translation
 
 import pytest
-
-from unittest.mock import Mock
 
 from olympia import amo
 from olympia.activity.models import ActivityLog

--- a/src/olympia/devhub/tests/test_tasks.py
+++ b/src/olympia/devhub/tests/test_tasks.py
@@ -1,25 +1,23 @@
 import json
 import shutil
 import tempfile
-
 from contextlib import contextmanager
 from datetime import datetime, timedelta
 from decimal import Decimal
+from unittest import mock
 
 from django.conf import settings
 from django.core import mail
 from django.core.files.storage import default_storage as storage
 from django.test.utils import override_settings
 
-from unittest import mock
 import pytest
-
 from waffle.testutils import override_switch
 
 from olympia import amo
 from olympia.addons.models import Addon, AddonUser, Preview
 from olympia.amo.templatetags.jinja_helpers import absolutify
-from olympia.amo.tests import TestCase, addon_factory, user_factory, root_storage
+from olympia.amo.tests import TestCase, addon_factory, root_storage, user_factory
 from olympia.amo.tests.test_helpers import get_addon_file, get_image_path
 from olympia.amo.utils import utc_millesecs_from_epoch
 from olympia.api.models import SYMMETRIC_JWT_TYPE, APIKey
@@ -27,8 +25,8 @@ from olympia.applications.models import AppVersion
 from olympia.constants.base import VALIDATOR_SKELETON_RESULTS
 from olympia.devhub import tasks
 from olympia.files.models import File
-from olympia.files.utils import NoManifestFound
 from olympia.files.tests.test_models import UploadMixin
+from olympia.files.utils import NoManifestFound
 
 
 pytestmark = pytest.mark.django_db

--- a/src/olympia/devhub/tests/test_utils.py
+++ b/src/olympia/devhub/tests/test_utils.py
@@ -7,15 +7,14 @@ from django.conf import settings
 from django.test.utils import override_settings
 
 import pytest
-
 from celery import chord
 from celery.result import AsyncResult
 
 from olympia import amo
 from olympia.addons.models import Addon
 from olympia.amo.tests import (
-    addon_factory,
     TestCase,
+    addon_factory,
     user_factory,
     version_factory,
 )
@@ -24,7 +23,7 @@ from olympia.applications.models import AppVersion
 from olympia.devhub import tasks, utils
 from olympia.files.tasks import repack_fileupload
 from olympia.files.tests.test_models import UploadMixin
-from olympia.scanners.tasks import run_customs, run_yara, call_mad_api
+from olympia.scanners.tasks import call_mad_api, run_customs, run_yara
 from olympia.versions.models import Version
 
 

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -1,7 +1,7 @@
 import json
 import os
-
 from datetime import datetime, timedelta
+from unittest import mock
 from urllib.parse import quote, urlencode
 
 from django.conf import settings
@@ -12,10 +12,8 @@ from django.urls import reverse
 from django.utils.encoding import force_str
 from django.utils.translation import trim_whitespace
 
-from unittest import mock
 import pytest
 import responses
-
 from pyquery import PyQuery as pq
 from waffle.testutils import override_switch
 

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -14,11 +14,11 @@ from olympia import amo
 from olympia.activity.models import ActivityLog
 from olympia.addons.models import Addon, AddonApprovalsCounter, AddonCategory
 from olympia.amo.tests import (
+    SQUOTE_ESCAPED,
+    TestCase,
     addon_factory,
     formset,
     initial,
-    SQUOTE_ESCAPED,
-    TestCase,
     user_factory,
 )
 from olympia.amo.tests.test_helpers import get_image_path

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -1,12 +1,12 @@
+import io
 import json
 import os
-import io
 import stat
 import tarfile
 import zipfile
-
 from datetime import datetime, timedelta
 from ipaddress import IPv4Address
+from unittest import mock
 from urllib.parse import urlencode
 
 from django.conf import settings
@@ -15,9 +15,7 @@ from django.core.files.storage import default_storage as storage
 from django.test.utils import override_settings
 from django.urls import reverse
 
-from unittest import mock
 import responses
-
 from pyquery import PyQuery as pq
 from waffle.testutils import override_switch
 

--- a/src/olympia/devhub/tests/test_views_validation.py
+++ b/src/olympia/devhub/tests/test_views_validation.py
@@ -1,17 +1,17 @@
 import json
 from datetime import datetime
+from unittest import mock
 
 from django.core.files.storage import default_storage as storage
 from django.urls import reverse
 
 import waffle
-from unittest import mock
 from pyquery import PyQuery as pq
 
 from olympia import amo
 from olympia.addons.models import Addon, AddonUser
+from olympia.amo.tests import TestCase, addon_factory, user_factory
 from olympia.amo.tests.test_helpers import get_addon_file
-from olympia.amo.tests import addon_factory, TestCase, user_factory
 from olympia.devhub.tests.test_tasks import ValidatorTestCase
 from olympia.files.models import File, FileUpload, FileValidation
 from olympia.files.tests.test_models import UploadMixin

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -1,14 +1,12 @@
 import os.path
 import zipfile
-
 from datetime import datetime, timedelta
+from unittest import mock
 
 from django.core import mail
 from django.core.files import temp
 from django.core.files.base import File as DjangoFile
 from django.urls import reverse
-
-from unittest import mock
 
 from pyquery import PyQuery as pq
 
@@ -22,8 +20,8 @@ from olympia.amo.tests import (
     formset,
     initial,
     reverse_ns,
-    version_factory,
     user_factory,
+    version_factory,
 )
 from olympia.applications.models import AppVersion
 from olympia.constants.promoted import RECOMMENDED

--- a/src/olympia/devhub/urls.py
+++ b/src/olympia/devhub/urls.py
@@ -1,5 +1,5 @@
-from django.urls import include, re_path
 from django.shortcuts import redirect
+from django.urls import include, re_path
 
 from olympia.addons.urls import ADDON_ID
 from olympia.amo.decorators import use_primary_db

--- a/src/olympia/devhub/utils.py
+++ b/src/olympia/devhub/utils.py
@@ -6,18 +6,16 @@ from django.forms import ValidationError
 from django.utils.translation import gettext
 
 import waffle
-
 from celery import chain, chord
 from django_statsd.clients import statsd
 
 import olympia.core.logger
-
 from olympia import amo, core
 from olympia.amo.urlresolvers import linkify_and_clean
 from olympia.files.models import File, FileUpload
 from olympia.files.tasks import repack_fileupload
 from olympia.files.utils import parse_addon, parse_xpi
-from olympia.scanners.tasks import run_customs, run_yara, call_mad_api
+from olympia.scanners.tasks import call_mad_api, run_customs, run_yara
 from olympia.versions.models import Version
 from olympia.versions.utils import process_color_value
 

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -1,7 +1,6 @@
 import datetime
 import os
 import time
-
 from urllib.parse import quote
 from uuid import UUID, uuid4
 
@@ -21,12 +20,10 @@ from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt
 
 import waffle
-
 from csp.decorators import csp_update
 from django_statsd.clients import statsd
 
 import olympia.core.logger
-
 from olympia import amo
 from olympia.access import acl
 from olympia.accounts.utils import redirect_for_login
@@ -40,8 +37,8 @@ from olympia.addons.models import (
 from olympia.addons.views import BaseFilter
 from olympia.amo import messages, utils as amo_utils
 from olympia.amo.decorators import json_view, login_required, post_required
-from olympia.amo.templatetags.jinja_helpers import absolutify, urlparams
 from olympia.amo.reverse import get_url_prefix
+from olympia.amo.templatetags.jinja_helpers import absolutify, urlparams
 from olympia.amo.utils import (
     MenuItem,
     StopWatch,

--- a/src/olympia/devhub/widgets.py
+++ b/src/olympia/devhub/widgets.py
@@ -5,7 +5,6 @@ from django.utils.html import conditional_escape, format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext
 
-
 from olympia.constants.categories import CATEGORIES_BY_ID
 
 

--- a/src/olympia/discovery/admin.py
+++ b/src/olympia/discovery/admin.py
@@ -1,18 +1,18 @@
 from django import forms
 from django.contrib import admin
 from django.contrib.admin.widgets import ForeignKeyRawIdWidget
+from django.db.models import Prefetch
 from django.utils import translation
 from django.utils.html import conditional_escape, format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext
-from django.db.models import Prefetch
 
 from olympia import promoted
 from olympia.addons.models import Addon
 from olympia.amo.admin import AMOModelAdmin
 from olympia.discovery.models import DiscoveryItem
-from olympia.hero.admin import SecondaryHeroAdmin, PrimaryHeroImageAdmin
-from olympia.hero.models import SecondaryHero, PrimaryHeroImage
+from olympia.hero.admin import PrimaryHeroImageAdmin, SecondaryHeroAdmin
+from olympia.hero.models import PrimaryHeroImage, SecondaryHero
 from olympia.promoted.admin import PromotedAddonAdmin
 from olympia.shelves.admin import ShelfAdmin
 from olympia.shelves.models import Shelf

--- a/src/olympia/discovery/tests/test_admin.py
+++ b/src/olympia/discovery/tests/test_admin.py
@@ -1,6 +1,8 @@
 import os
 from unittest import mock
 
+from django.conf import settings
+from django.core.files.images import get_image_dimensions
 from django.urls import reverse
 
 import responses
@@ -10,9 +12,6 @@ from olympia import amo
 from olympia.amo.reverse import django_reverse
 from olympia.amo.tests import TestCase, addon_factory, reverse_ns, user_factory
 from olympia.amo.tests.test_helpers import get_uploaded_file
-from django.conf import settings
-from django.core.files.images import get_image_dimensions
-
 from olympia.discovery.models import DiscoveryItem
 from olympia.hero.models import PrimaryHeroImage, SecondaryHero, SecondaryHeroModule
 from olympia.shelves.models import Shelf

--- a/src/olympia/discovery/tests/test_commands.py
+++ b/src/olympia/discovery/tests/test_commands.py
@@ -9,6 +9,7 @@ import responses
 
 from olympia.amo.tests import TestCase
 
+
 disco_fake_data = {
     'results': [
         {'custom_description': 'greât custom description'},

--- a/src/olympia/discovery/tests/test_serializers.py
+++ b/src/olympia/discovery/tests/test_serializers.py
@@ -4,7 +4,7 @@ import pytest
 from rest_framework.test import APIRequestFactory
 
 from olympia import amo
-from olympia.amo.tests import addon_factory, TestCase
+from olympia.amo.tests import TestCase, addon_factory
 from olympia.discovery.models import DiscoveryItem
 from olympia.discovery.serializers import DiscoverySerializer
 from olympia.translations.models import Translation

--- a/src/olympia/discovery/tests/test_utils.py
+++ b/src/olympia/discovery/tests/test_utils.py
@@ -1,15 +1,15 @@
 import json
+from unittest import mock
 
 from django.conf import settings
 from django.http import HttpResponse
 
 import pytest
 import requests
-from unittest import mock
 from waffle.testutils import override_switch
 
 from olympia import amo
-from olympia.amo.tests import addon_factory, TestCase
+from olympia.amo.tests import TestCase, addon_factory
 from olympia.discovery.models import DiscoveryItem
 from olympia.discovery.utils import (
     call_recommendation_server,

--- a/src/olympia/discovery/tests/test_views.py
+++ b/src/olympia/discovery/tests/test_views.py
@@ -1,6 +1,6 @@
-from django.test.utils import override_settings
-
 from unittest import mock
+
+from django.test.utils import override_settings
 
 from waffle import switch_is_active
 from waffle.testutils import override_switch

--- a/src/olympia/discovery/utils.py
+++ b/src/olympia/discovery/utils.py
@@ -7,7 +7,6 @@ from django.utils.http import urlencode
 
 import requests
 import waffle
-
 from django_statsd.clients import statsd
 
 import olympia.core.logger

--- a/src/olympia/files/models.py
+++ b/src/olympia/files/models.py
@@ -3,7 +3,6 @@ import json
 import os
 import re
 import uuid
-
 from urllib.parse import urljoin
 
 from django.conf import settings
@@ -12,24 +11,23 @@ from django.core.files.storage import default_storage as storage
 from django.db import models
 from django.dispatch import receiver
 from django.urls import reverse
-from django.utils.translation import gettext
 from django.utils.crypto import get_random_string
 from django.utils.encoding import force_str
 from django.utils.functional import cached_property
 from django.utils.text import slugify
+from django.utils.translation import gettext
 
 from django_statsd.clients import statsd
 
 import olympia.core.logger
-
 from olympia import amo, core
 from olympia.amo.decorators import use_primary_db
 from olympia.amo.fields import PositiveAutoField
 from olympia.amo.models import ManagerBase, ModelBase, OnChangeMixin
-from olympia.amo.utils import id_to_path, SafeStorage
+from olympia.amo.utils import SafeStorage, id_to_path
 from olympia.files.utils import (
-    get_sha256,
     InvalidOrUnsupportedCrx,
+    get_sha256,
     write_crx_as_xpi,
 )
 

--- a/src/olympia/files/tasks.py
+++ b/src/olympia/files/tasks.py
@@ -2,7 +2,6 @@ import json
 import os
 import shutil
 import tempfile
-
 from pathlib import Path
 
 from django.conf import settings
@@ -11,7 +10,6 @@ from django.core.files.storage import default_storage as storage
 import waffle
 
 import olympia.core.logger
-
 from olympia.amo.celery import task
 from olympia.amo.decorators import use_primary_db
 from olympia.amo.utils import StopWatch

--- a/src/olympia/files/tests/test_commands.py
+++ b/src/olympia/files/tests/test_commands.py
@@ -1,18 +1,18 @@
 # -*- coding: utf-8 -*-
+from unittest import mock
+
 from django.conf import settings
 from django.core.management import call_command
 
-from unittest import mock
-
 from olympia import amo
-from olympia.amo.tests import TestCase
 from olympia.addons.models import Addon
+from olympia.amo.tests import TestCase
 from olympia.applications.models import AppVersion
 from olympia.files.models import File
 from olympia.files.tests.test_models import UploadMixin
 from olympia.files.utils import parse_addon
-from olympia.versions.models import Version
 from olympia.users.models import UserProfile
+from olympia.versions.models import Version
 
 
 class TestExtractHostPermissions(UploadMixin, TestCase):

--- a/src/olympia/files/tests/test_models.py
+++ b/src/olympia/files/tests/test_models.py
@@ -38,9 +38,9 @@ from olympia.files.models import (
     track_file_status_change,
 )
 from olympia.files.utils import (
-    check_xpi_info,
     DuplicateAddonID,
     ManifestJSONExtractor,
+    check_xpi_info,
     parse_addon,
 )
 from olympia.users.models import UserProfile

--- a/src/olympia/files/tests/test_serializers.py
+++ b/src/olympia/files/tests/test_serializers.py
@@ -6,8 +6,8 @@ from rest_framework.settings import api_settings
 from rest_framework.test import APIRequestFactory
 
 from olympia import amo
-from olympia.amo.tests import TestCase
 from olympia.amo.reverse import reverse
+from olympia.amo.tests import TestCase
 
 from ..models import FileUpload
 from ..serializers import FileUploadSerializer

--- a/src/olympia/files/tests/test_tasks.py
+++ b/src/olympia/files/tests/test_tasks.py
@@ -2,18 +2,18 @@ import json
 import os
 import tempfile
 import zipfile
-
-import pytest
 from unittest import mock
-from waffle.testutils import override_switch
 
 from django.conf import settings
+
+import pytest
+from waffle.testutils import override_switch
 
 from olympia.amo.tests import TestCase
 from olympia.files.tasks import repack_fileupload
 from olympia.files.tests.test_models import UploadMixin
-from olympia.files.utils import SafeZip
 from olympia.files.tests.test_utils import AppVersionsMixin
+from olympia.files.utils import SafeZip
 
 
 class TestRepackFileUpload(AppVersionsMixin, UploadMixin, TestCase):

--- a/src/olympia/files/tests/test_utils.py
+++ b/src/olympia/files/tests/test_utils.py
@@ -1,13 +1,12 @@
+import contextlib
 import json
+import multiprocessing
 import os
 import shutil
 import tarfile
 import tempfile
 import time
 import zipfile
-import multiprocessing
-import contextlib
-
 from unittest import mock
 
 from django import forms
@@ -20,7 +19,7 @@ from django.test.utils import override_settings
 import pytest
 
 from olympia import amo
-from olympia.amo.tests import addon_factory, TestCase, user_factory
+from olympia.amo.tests import TestCase, addon_factory, user_factory
 from olympia.amo.tests.test_helpers import get_addon_file
 from olympia.applications.models import AppVersion
 from olympia.files import utils

--- a/src/olympia/files/tests/test_views.py
+++ b/src/olympia/files/tests/test_views.py
@@ -9,17 +9,17 @@ from freezegun import freeze_time
 
 from olympia import amo
 from olympia.amo.tests import (
-    APITestClientSessionID,
     APITestClientJWT,
+    APITestClientSessionID,
+    TestCase,
     get_random_ip,
     reverse_ns,
-    TestCase,
     user_factory,
 )
 
-from .test_models import UploadMixin
 from ..models import FileUpload
 from ..views import FileUploadViewSet
+from .test_models import UploadMixin
 
 
 files_fixtures = 'src/olympia/files/fixtures/files/'

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -1,10 +1,11 @@
 import collections
 import contextlib
 import errno
+import fcntl
 import hashlib
+import io
 import json
 import os
-import io
 import re
 import shutil
 import signal
@@ -13,7 +14,6 @@ import struct
 import tarfile
 import tempfile
 import zipfile
-import fcntl
 
 from django import forms
 from django.conf import settings
@@ -25,15 +25,13 @@ from django.utils.jslex import JsLexer
 from django.utils.translation import gettext
 
 import olympia.core.logger
-
 from olympia import amo
 from olympia.access import acl
 from olympia.addons.utils import verify_mozilla_trademark
 from olympia.amo.utils import decode_json, find_language, rm_local_tmp_dir
 from olympia.applications.models import AppVersion
-from olympia.lib.crypto.signing import get_signer_organizational_unit_name
 from olympia.lib import unicodehelper
-
+from olympia.lib.crypto.signing import get_signer_organizational_unit_name
 from olympia.versions.compare import VersionString
 
 

--- a/src/olympia/files/views.py
+++ b/src/olympia/files/views.py
@@ -1,5 +1,5 @@
-from django.core.exceptions import PermissionDenied
 from django import http, shortcuts
+from django.core.exceptions import PermissionDenied
 from django.utils.crypto import constant_time_compare
 from django.utils.translation import gettext
 
@@ -9,7 +9,6 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ReadOnlyModelViewSet
 
 import olympia.core.logger
-
 from olympia import amo
 from olympia.amo.decorators import use_primary_db
 from olympia.amo.utils import HttpResponseXSendFile

--- a/src/olympia/git/admin.py
+++ b/src/olympia/git/admin.py
@@ -5,6 +5,7 @@ from django.utils.html import format_html
 
 from olympia.addons.models import Addon
 from olympia.amo.admin import AMOModelAdmin
+
 from .models import GitExtractionEntry
 
 

--- a/src/olympia/git/management/commands/git_extraction.py
+++ b/src/olympia/git/management/commands/git_extraction.py
@@ -1,11 +1,9 @@
-import waffle
-
-from celery import chain
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
 import olympia.core.logger
-
+import waffle
+from celery import chain
 from olympia import amo
 from olympia.amo.decorators import use_primary_db
 from olympia.files.utils import lock

--- a/src/olympia/git/tasks.py
+++ b/src/olympia/git/tasks.py
@@ -1,7 +1,6 @@
 from django_statsd.clients import statsd
 
 import olympia.core.logger
-
 from olympia.amo.celery import task
 from olympia.amo.decorators import use_primary_db
 

--- a/src/olympia/git/tests/test_commands.py
+++ b/src/olympia/git/tests/test_commands.py
@@ -1,11 +1,10 @@
 import datetime
-
 from pathlib import Path
 from unittest import mock
 
-import pytest
-
 from django.test.utils import override_settings
+
+import pytest
 
 from olympia import amo
 from olympia.amo.tests import (
@@ -14,18 +13,17 @@ from olympia.amo.tests import (
     create_switch,
     version_factory,
 )
-from olympia.git.utils import AddonGitRepository, BrokenRefError
+from olympia.git.management.commands.git_extraction import (
+    SWITCH_NAME,
+    Command as GitExtractionCommand,
+)
 from olympia.git.models import GitExtractionEntry
 from olympia.git.tasks import (
     continue_git_extraction,
     extract_versions_to_git,
     remove_git_extraction_entry,
 )
-
-from olympia.git.management.commands.git_extraction import (
-    SWITCH_NAME,
-    Command as GitExtractionCommand,
-)
+from olympia.git.utils import AddonGitRepository, BrokenRefError
 
 from .test_utils import update_git_repo_creation_time
 

--- a/src/olympia/git/tests/test_tasks.py
+++ b/src/olympia/git/tests/test_tasks.py
@@ -1,5 +1,4 @@
 import datetime
-
 from unittest import mock
 
 from olympia.amo.tests import TestCase, addon_factory, version_factory

--- a/src/olympia/git/tests/test_utils.py
+++ b/src/olympia/git/tests/test_utils.py
@@ -1,32 +1,33 @@
 import datetime
 import os
 import subprocess
-
-import pytest
-import pygit2
+from pathlib import Path
 from unittest import mock
 from unittest.mock import MagicMock
-from pathlib import Path
 
 from django.conf import settings
 
+import pygit2
+import pytest
+
 from olympia import amo
 from olympia.amo.tests import (
-    addon_factory,
-    version_factory,
-    user_factory,
     activate_locale,
+    addon_factory,
+    user_factory,
+    version_factory,
 )
 from olympia.git.utils import (
+    BRANCHES,
+    EXTRACTED_PREFIX,
     AddonGitRepository,
     BrokenRefError,
     MissingMasterBranchError,
     TemporaryWorktree,
-    BRANCHES,
-    EXTRACTED_PREFIX,
-    get_mime_type_for_blob,
     extract_version_to_git,
+    get_mime_type_for_blob,
 )
+
 
 # Aliases for easier and shorter access
 _blob_type = pygit2.GIT_OBJ_BLOB

--- a/src/olympia/git/utils.py
+++ b/src/olympia/git/utils.py
@@ -4,26 +4,23 @@ import shutil
 import sys
 import tempfile
 import uuid
-
-from datetime import datetime, timedelta
 from collections import namedtuple
-
-import pygit2
-
-from celery import current_task
-from django_statsd.clients import statsd
+from datetime import datetime, timedelta
 
 from django.conf import settings
 from django.db import connections
 from django.utils import translation
 from django.utils.functional import cached_property
 
-import olympia.core.logger
+import pygit2
+from celery import current_task
+from django_statsd.clients import statsd
 
+import olympia.core.logger
 from olympia import amo
 from olympia.amo.utils import id_to_path
-from olympia.versions.models import Version
 from olympia.files.utils import extract_extension_to_dest, get_all_files
+from olympia.versions.models import Version
 
 from .models import GitExtractionEntry
 

--- a/src/olympia/hero/admin.py
+++ b/src/olympia/hero/admin.py
@@ -11,7 +11,7 @@ from django.utils.safestring import mark_safe
 from olympia.amo.admin import AMOModelAdmin
 from olympia.amo.utils import resize_image
 
-from .models import PrimaryHero, SecondaryHeroModule, PrimaryHeroImage
+from .models import PrimaryHero, PrimaryHeroImage, SecondaryHeroModule
 
 
 class ImageChoiceField(forms.ModelChoiceField):

--- a/src/olympia/hero/models.py
+++ b/src/olympia/hero/models.py
@@ -8,8 +8,8 @@ from django.db import models
 from django.db.models.fields import BLANK_CHOICE_DASH
 from django.forms.widgets import RadioSelect
 from django.templatetags.static import static
-from django.utils.safestring import mark_safe
 from django.urls import Resolver404
+from django.utils.safestring import mark_safe
 
 from olympia.amo.models import LongNameIndex, ModelBase
 from olympia.amo.reverse import resolve_with_trailing_slash, reverse

--- a/src/olympia/hero/tests/test_models.py
+++ b/src/olympia/hero/tests/test_models.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from django.core.exceptions import ValidationError
 from django.test.utils import override_settings
 
-from olympia.amo.tests import addon_factory, TestCase
+from olympia.amo.tests import TestCase, addon_factory
 from olympia.amo.tests.test_helpers import get_uploaded_file
 from olympia.constants.promoted import RECOMMENDED, SPOTLIGHT, VERIFIED
 from olympia.hero.models import (

--- a/src/olympia/hero/tests/test_serializers.py
+++ b/src/olympia/hero/tests/test_serializers.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from olympia import amo
-from olympia.amo.tests import addon_factory, TestCase
+from olympia.amo.tests import TestCase, addon_factory
 from olympia.amo.tests.test_helpers import get_uploaded_file
 from olympia.amo.urlresolvers import get_outgoing_url
 from olympia.constants.promoted import RECOMMENDED

--- a/src/olympia/hero/tests/test_views.py
+++ b/src/olympia/hero/tests/test_views.py
@@ -7,7 +7,7 @@ from rest_framework.test import APIRequestFactory
 
 from olympia import amo
 from olympia.amo.templatetags.jinja_helpers import absolutify
-from olympia.amo.tests import addon_factory, TestCase, reverse_ns
+from olympia.amo.tests import TestCase, addon_factory, reverse_ns
 from olympia.amo.tests.test_helpers import get_uploaded_file
 from olympia.promoted.models import PromotedAddon
 

--- a/src/olympia/landfill/collection.py
+++ b/src/olympia/landfill/collection.py
@@ -1,5 +1,4 @@
 import random
-
 from datetime import datetime
 
 from olympia.amo.utils import slugify

--- a/src/olympia/landfill/generators.py
+++ b/src/olympia/landfill/generators.py
@@ -1,6 +1,5 @@
 import collections
 import random
-
 from datetime import datetime
 from itertools import cycle, islice
 

--- a/src/olympia/landfill/management/commands/fetch_prod_addons.py
+++ b/src/olympia/landfill/management/commands/fetch_prod_addons.py
@@ -1,14 +1,15 @@
-import requests
 import uuid
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.db.transaction import atomic
 
+import requests
+
 from olympia import amo
+from olympia.addons.models import Addon
 from olympia.amo.tests import addon_factory, user_factory
 from olympia.constants.categories import CATEGORIES
-from olympia.addons.models import Addon
 from olympia.users.models import UserProfile
 
 

--- a/src/olympia/landfill/management/commands/fetch_prod_versions.py
+++ b/src/olympia/landfill/management/commands/fetch_prod_versions.py
@@ -1,13 +1,13 @@
-import requests
-
 from django.conf import settings
 from django.core.files.base import ContentFile
 from django.core.management.base import BaseCommand, CommandError
 from django.db.transaction import atomic
 
+import requests
+
 from olympia import amo
-from olympia.amo.tests import version_factory
 from olympia.addons.models import Addon
+from olympia.amo.tests import version_factory
 
 
 class KeyboardInterruptError(Exception):

--- a/src/olympia/landfill/management/commands/generate_default_addons_for_frontend.py
+++ b/src/olympia/landfill/management/commands/generate_default_addons_for_frontend.py
@@ -1,10 +1,10 @@
 from django.core.management.base import BaseCommand
-from django.utils import translation
-from django.test.utils import override_settings
 from django.db.models.signals import post_save
+from django.test.utils import override_settings
+from django.utils import translation
 
-from olympia.landfill.serializers import GenerateAddonsSerializer
 from olympia.addons.models import Addon, update_search_index
+from olympia.landfill.serializers import GenerateAddonsSerializer
 
 
 #  Featured collections on the homepage.

--- a/src/olympia/landfill/serializers.py
+++ b/src/olympia/landfill/serializers.py
@@ -4,29 +4,29 @@ import os
 import uuid
 
 from django.conf import settings
-from django.utils.translation import activate
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test.client import RequestFactory
+from django.utils.translation import activate
+
 from fxa.constants import ENVIRONMENT_URLS
 from fxa.core import Client
 from fxa.tests.utils import TestEmailAccount
 from rest_framework import serializers
 
 import olympia.core.logger
-
 from olympia import amo
 from olympia.access.models import Group, GroupUser
-from olympia.addons.models import AddonUser, Preview, Addon
+from olympia.addons.models import Addon, AddonUser, Preview
 from olympia.addons.utils import generate_addon_guid
-from olympia.amo.tests import user_factory, addon_factory, copy_file_to_temp
+from olympia.amo.tests import addon_factory, copy_file_to_temp, user_factory
 from olympia.constants.applications import FIREFOX
 from olympia.constants.base import ADDON_EXTENSION, ADDON_STATICTHEME
+from olympia.constants.promoted import RECOMMENDED
+from olympia.devhub.utils import create_version_for_upload
+from olympia.hero.models import PrimaryHero, SecondaryHero
 from olympia.landfill.collection import generate_collection
 from olympia.ratings.models import Rating
 from olympia.users.models import UserProfile
-from olympia.devhub.utils import create_version_for_upload
-from olympia.hero.models import PrimaryHero, SecondaryHero
-from olympia.constants.promoted import RECOMMENDED
 
 from .version import generate_version
 

--- a/src/olympia/landfill/version.py
+++ b/src/olympia/landfill/version.py
@@ -1,5 +1,4 @@
 import random
-
 from datetime import datetime
 
 from olympia import amo

--- a/src/olympia/lib/crypto/signing.py
+++ b/src/olympia/lib/crypto/signing.py
@@ -3,24 +3,21 @@ import io
 import json
 import os
 import zipfile
-
 from base64 import b64decode, b64encode
 
-from django.db import transaction
 from django.conf import settings
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage as storage
+from django.db import transaction
 from django.utils.encoding import force_bytes, force_str
 
 import requests
 import waffle
-
+from asn1crypto import cms
 from django_statsd.clients import statsd
 from requests_hawk import HawkAuth
-from asn1crypto import cms
 
 import olympia.core.logger
-
 from olympia import amo
 
 

--- a/src/olympia/lib/crypto/tasks.py
+++ b/src/olympia/lib/crypto/tasks.py
@@ -3,14 +3,12 @@ import re
 import shutil
 
 import olympia.core.logger
-
 from olympia import amo
 from olympia.activity.models import ActivityLog
-from olympia.addons.models import AddonUser
+from olympia.addons.models import Addon, AddonUser
 from olympia.amo.celery import task
 from olympia.files.utils import update_version_number
 from olympia.lib.crypto.signing import sign_file
-from olympia.addons.models import Addon
 from olympia.users.utils import get_task_user
 from olympia.versions.models import Version
 

--- a/src/olympia/lib/crypto/tests/test_signing.py
+++ b/src/olympia/lib/crypto/tests/test_signing.py
@@ -5,25 +5,24 @@ import io
 import json
 import os
 import zipfile
+from unittest import mock
 
-from django.db import transaction
 from django.conf import settings
 from django.core import mail
 from django.core.files.storage import default_storage as storage
-from django.test.utils import override_settings
+from django.db import transaction
 from django.test.testcases import TransactionTestCase
+from django.test.utils import override_settings
 from django.utils.encoding import force_bytes, force_str
 
-from unittest import mock
 import pytest
-import responses
 import pytz
-
+import responses
 from waffle.testutils import override_switch
 
 from olympia import amo
 from olympia.addons.models import AddonUser
-from olympia.amo.tests import addon_factory, TestCase, version_factory
+from olympia.amo.tests import TestCase, addon_factory, version_factory
 from olympia.constants.promoted import LINE, RECOMMENDED, SPOTLIGHT
 from olympia.lib.crypto import signing, tasks
 from olympia.versions.compare import version_int

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1,12 +1,11 @@
 # Django settings for addons-server project.
 
-import environ
 import logging
 import os
 import socket
-
 from datetime import datetime
 
+import environ
 import sentry_sdk
 from corsheaders.defaults import default_headers
 from kombu import Queue

--- a/src/olympia/lib/tests/test_jingo_minify_helpers.py
+++ b/src/olympia/lib/tests/test_jingo_minify_helpers.py
@@ -1,9 +1,8 @@
 import os
+from unittest import mock
 
 from django.conf import settings
 from django.test.utils import override_settings
-
-from unittest import mock
 
 from olympia.amo.utils import from_string
 

--- a/src/olympia/lib/tests/test_unicodehelper.py
+++ b/src/olympia/lib/tests/test_unicodehelper.py
@@ -1,4 +1,5 @@
 import os
+
 from olympia.lib import unicodehelper
 
 

--- a/src/olympia/lib/unicodehelper.py
+++ b/src/olympia/lib/unicodehelper.py
@@ -1,6 +1,7 @@
 import codecs
 import re
 
+
 UNICODE_BOMS = [
     (codecs.BOM_UTF8, 'utf-8'),
     (codecs.BOM_UTF32_LE, 'utf-32-le'),

--- a/src/olympia/pages/urls.py
+++ b/src/olympia/pages/urls.py
@@ -1,10 +1,10 @@
 from django.conf import settings
-from django.urls import re_path
 from django.http import HttpResponsePermanentRedirect as perma_redirect
-from django.urls import reverse
+from django.urls import re_path, reverse
 from django.views.generic.base import TemplateView
 
 from olympia.amo.views import frontend_view
+
 
 urlpatterns = [
     re_path(

--- a/src/olympia/promoted/models.py
+++ b/src/olympia/promoted/models.py
@@ -3,7 +3,7 @@ from django.dispatch import receiver
 
 from olympia.addons.models import Addon
 from olympia.amo.models import ModelBase
-from olympia.constants.applications import APP_IDS, APPS_CHOICES, APP_USAGE
+from olympia.constants.applications import APP_IDS, APP_USAGE, APPS_CHOICES
 from olympia.constants.promoted import (
     NOT_PROMOTED,
     PROMOTED_GROUPS,

--- a/src/olympia/promoted/tasks.py
+++ b/src/olympia/promoted/tasks.py
@@ -5,11 +5,12 @@ from olympia import amo
 from olympia.addons.models import Addon
 from olympia.amo.celery import task
 from olympia.amo.decorators import use_primary_db
-from olympia.constants.promoted import NOTABLE, NOT_PROMOTED
+from olympia.constants.promoted import NOT_PROMOTED, NOTABLE
 from olympia.versions.utils import get_staggered_review_due_date_generator
 from olympia.zadmin.models import get_config
 
 from .models import PromotedAddon
+
 
 log = olympia.core.logger.getLogger('z.promoted.tasks')
 

--- a/src/olympia/promoted/tests/test_admin.py
+++ b/src/olympia/promoted/tests/test_admin.py
@@ -1,14 +1,14 @@
 from django.urls import reverse
 
 from olympia import amo
-from olympia.amo.tests import addon_factory, TestCase, user_factory, version_factory
-from olympia.amo.tests.test_helpers import get_uploaded_file
 from olympia.amo.reverse import django_reverse
+from olympia.amo.tests import TestCase, addon_factory, user_factory, version_factory
+from olympia.amo.tests.test_helpers import get_uploaded_file
 from olympia.constants.promoted import (
     LINE,
+    NOT_PROMOTED,
     RECOMMENDED,
     VERIFIED,
-    NOT_PROMOTED,
 )
 from olympia.hero.models import PrimaryHero, PrimaryHeroImage
 from olympia.promoted.models import PromotedAddon, PromotedApproval

--- a/src/olympia/promoted/tests/test_models.py
+++ b/src/olympia/promoted/tests/test_models.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from olympia import amo, core
 from olympia.activity.models import ActivityLog
 from olympia.addons.models import AddonReviewerFlags
-from olympia.amo.tests import addon_factory, TestCase, user_factory, version_factory
+from olympia.amo.tests import TestCase, addon_factory, user_factory, version_factory
 from olympia.constants import applications, promoted
 from olympia.promoted.models import (
     PromotedAddon,

--- a/src/olympia/promoted/tests/test_tasks.py
+++ b/src/olympia/promoted/tests/test_tasks.py
@@ -1,21 +1,20 @@
 from datetime import datetime
 
-import pytest
-
-from freezegun import freeze_time
-
 from django.conf import settings
+
+import pytest
+from freezegun import freeze_time
 
 from olympia import amo
 from olympia.amo.tests import addon_factory, user_factory, version_factory
-from olympia.constants.promoted import LINE, NOTABLE, NOT_PROMOTED
+from olympia.constants.promoted import LINE, NOT_PROMOTED, NOTABLE
 from olympia.promoted.models import PromotedAddon
 from olympia.versions.utils import get_staggered_review_due_date_generator
 from olympia.zadmin.models import set_config
 
 from ..tasks import (
-    add_high_adu_extensions_to_notable,
     NOTABLE_ADU_LIMIT_CONFIG_KEY,
+    add_high_adu_extensions_to_notable,
 )
 
 

--- a/src/olympia/ratings/admin.py
+++ b/src/olympia/ratings/admin.py
@@ -11,7 +11,7 @@ from olympia.amo.admin import (
 from olympia.translations.utils import truncate_text
 from olympia.zadmin.admin import related_single_content_link
 
-from .models import Rating, DeniedRatingWord
+from .models import DeniedRatingWord, Rating
 
 
 class RatingTypeFilter(admin.SimpleListFilter):

--- a/src/olympia/ratings/models.py
+++ b/src/olympia/ratings/models.py
@@ -7,7 +7,6 @@ from django.dispatch import receiver
 from django.utils.translation import gettext_lazy as _
 
 import olympia.core.logger
-
 from olympia import activity, amo, core
 from olympia.amo.fields import PositiveAutoField
 from olympia.amo.models import ManagerBase, ModelBase
@@ -265,6 +264,7 @@ class Rating(ModelBase):
 
     def post_save(sender, instance, created, **kwargs):
         from olympia.addons.models import update_search_index
+
         from . import tasks
 
         if kwargs.get('raw'):

--- a/src/olympia/ratings/serializers.py
+++ b/src/olympia/ratings/serializers.py
@@ -1,5 +1,4 @@
 import re
-
 from collections import OrderedDict
 from urllib.parse import unquote
 

--- a/src/olympia/ratings/tasks.py
+++ b/src/olympia/ratings/tasks.py
@@ -4,7 +4,6 @@ from django.core.cache import cache
 from django.db.models import Avg, Count, F
 
 import olympia.core.logger
-
 from olympia.addons.models import Addon
 from olympia.amo.celery import task
 from olympia.amo.decorators import use_primary_db

--- a/src/olympia/ratings/templatetags/jinja_helpers.py
+++ b/src/olympia/ratings/templatetags/jinja_helpers.py
@@ -2,7 +2,6 @@ from django.template.loader import get_template
 from django.utils.translation import gettext
 
 import markupsafe
-
 from django_jinja import library
 
 

--- a/src/olympia/ratings/tests/test_views.py
+++ b/src/olympia/ratings/tests/test_views.py
@@ -1,5 +1,4 @@
 import json
-
 from datetime import timedelta
 from ipaddress import IPv4Address
 
@@ -24,10 +23,10 @@ from olympia.amo.tests import (
     version_factory,
 )
 from olympia.users.models import (
+    RESTRICTION_TYPES,
     DisposableEmailDomainRestriction,
     EmailUserRestriction,
     IPNetworkUserRestriction,
-    RESTRICTION_TYPES,
 )
 
 from ..models import DeniedRatingWord, Rating, RatingFlag

--- a/src/olympia/ratings/views.py
+++ b/src/olympia/ratings/views.py
@@ -27,7 +27,7 @@ from olympia.api.throttling import GranularIPRateThrottle, GranularUserRateThrot
 from olympia.api.utils import is_gate_active
 
 from .models import Rating, RatingFlag
-from .permissions import CanDeleteRatingPermission, CanCreateRatingPermission
+from .permissions import CanCreateRatingPermission, CanDeleteRatingPermission
 from .serializers import RatingFlagSerializer, RatingSerializer, RatingSerializerReply
 from .utils import get_grouped_ratings
 

--- a/src/olympia/reviewers/api_urls.py
+++ b/src/olympia/reviewers/api_urls.py
@@ -5,9 +5,9 @@ from rest_framework_nested.routers import NestedSimpleRouter
 
 from .views import (
     AddonReviewerViewSet,
-    ReviewAddonVersionViewSet,
     ReviewAddonVersionCompareViewSet,
     ReviewAddonVersionDraftCommentViewSet,
+    ReviewAddonVersionViewSet,
 )
 
 

--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -9,8 +9,9 @@ from django.forms.models import (
     modelformset_factory,
 )
 
-import olympia.core.logger
+import markupsafe
 
+import olympia.core.logger
 from olympia import amo, ratings
 from olympia.access import acl
 from olympia.amo.forms import AMOModelForm
@@ -20,7 +21,6 @@ from olympia.ratings.permissions import user_can_delete_rating
 from olympia.reviewers.models import ReviewActionReason, Whiteboard
 from olympia.versions.models import Version
 
-import markupsafe
 
 log = olympia.core.logger.getLogger('z.reviewers.forms')
 

--- a/src/olympia/reviewers/management/commands/auto_approve.py
+++ b/src/olympia/reviewers/management/commands/auto_approve.py
@@ -5,17 +5,15 @@ from django.core.management.base import BaseCommand
 from django.db import transaction
 
 import waffle
-
 from django_statsd.clients import statsd
 from post_request_task.task import (
     _discard_tasks,
-    _start_queuing_tasks,
     _send_tasks_and_stop_queuing,
+    _start_queuing_tasks,
     _stop_queuing_tasks,
 )
 
 import olympia.core.logger
-
 from olympia import amo
 from olympia.amo.decorators import use_primary_db
 from olympia.files.utils import lock

--- a/src/olympia/reviewers/management/commands/auto_reject.py
+++ b/src/olympia/reviewers/management/commands/auto_reject.py
@@ -5,7 +5,6 @@ from django.core.management.base import BaseCommand
 from django.db import transaction
 
 import olympia.core.logger
-
 from olympia import amo
 from olympia.addons.models import Addon
 from olympia.amo.decorators import use_primary_db

--- a/src/olympia/reviewers/management/commands/review_reports.py
+++ b/src/olympia/reviewers/management/commands/review_reports.py
@@ -1,19 +1,17 @@
-from datetime import date, timedelta
-
 import os
-import settings
+from datetime import date, timedelta
 
 from django.core.management.base import BaseCommand
 from django.db import connection
 from django.utils.encoding import force_str
 
 import olympia.core.logger
-
+import settings
 from olympia import amo
 from olympia.amo.utils import send_mail
 from olympia.constants.reviewers import (
-    POST_REVIEW_WEIGHT_HIGHEST_RISK,
     POST_REVIEW_WEIGHT_HIGH_RISK,
+    POST_REVIEW_WEIGHT_HIGHEST_RISK,
     POST_REVIEW_WEIGHT_MEDIUM_RISK,
 )
 

--- a/src/olympia/reviewers/management/commands/send_pending_rejection_last_warning_notifications.py
+++ b/src/olympia/reviewers/management/commands/send_pending_rejection_last_warning_notifications.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 from django.core.management.base import BaseCommand
 
 import olympia.core.logger
-
 from olympia import amo
 from olympia.activity.models import ActivityLog
 from olympia.addons.models import Addon, AddonReviewerFlags

--- a/src/olympia/reviewers/models.py
+++ b/src/olympia/reviewers/models.py
@@ -1,5 +1,4 @@
 import json
-
 from datetime import datetime, timedelta
 
 from django.conf import settings
@@ -11,7 +10,6 @@ from django.template import loader
 from django.urls import reverse
 
 import olympia.core.logger
-
 from olympia import activity, amo, core
 from olympia.abuse.models import AbuseReport
 from olympia.access import acl
@@ -724,7 +722,8 @@ class UsageTier(ModelBase):
     growth_threshold_before_flagging = models.IntegerField(
         default=None,
         null=True,
-        help_text="Usage growth percentage threshold before we start automatically flagging the add-on for human review.",
+        help_text='Usage growth percentage threshold before we start automatically '
+        'flagging the add-on for human review.',
     )
 
     class Meta:

--- a/src/olympia/reviewers/serializers.py
+++ b/src/olympia/reviewers/serializers.py
@@ -1,40 +1,39 @@
 import hashlib
 import io
-import os
-import mimetypes
-import pathlib
 import json
+import mimetypes
+import os
+import pathlib
 from collections import OrderedDict
 
-import pygit2
+from django.core.cache import cache
+from django.urls import reverse
+from django.utils.encoding import force_bytes, force_str
+from django.utils.functional import cached_property
 
+import pygit2
 from rest_framework import serializers
 from rest_framework.exceptions import NotFound
 from rest_framework.reverse import reverse as drf_reverse
 
-from django.core.cache import cache
-from django.urls import reverse
-from django.utils.functional import cached_property
-from django.utils.encoding import force_bytes, force_str
-
 from olympia import amo
-from olympia.activity.models import DraftComment
 from olympia.accounts.serializers import BaseUserSerializer
-from olympia.amo.templatetags.jinja_helpers import absolutify
+from olympia.activity.models import DraftComment
+from olympia.addons.models import AddonReviewerFlags
 from olympia.addons.serializers import (
     FileSerializer,
     MinimalVersionSerializer,
     SimpleAddonSerializer,
 )
-from olympia.addons.models import AddonReviewerFlags
+from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.api.fields import ReverseChoiceField, SplitField
 from olympia.api.serializers import AMOModelSerializer
-from olympia.users.models import UserProfile
-from olympia.files.utils import get_sha256
 from olympia.files.models import File, FileValidation
-from olympia.versions.models import Version
+from olympia.files.utils import get_sha256
 from olympia.git.utils import AddonGitRepository, get_mime_type_for_blob
 from olympia.lib import unicodehelper
+from olympia.users.models import UserProfile
+from olympia.versions.models import Version
 
 
 class AddonReviewerFlagsSerializer(AMOModelSerializer):

--- a/src/olympia/reviewers/tasks.py
+++ b/src/olympia/reviewers/tasks.py
@@ -1,5 +1,4 @@
 import olympia.core.logger
-
 from olympia.addons.models import Addon
 from olympia.amo.celery import task
 from olympia.amo.decorators import use_primary_db

--- a/src/olympia/reviewers/templatetags/code_manager.py
+++ b/src/olympia/reviewers/templatetags/code_manager.py
@@ -1,6 +1,7 @@
 from django import template
 from django.conf import settings
 
+
 register = template.Library()
 
 

--- a/src/olympia/reviewers/templatetags/jinja_helpers.py
+++ b/src/olympia/reviewers/templatetags/jinja_helpers.py
@@ -1,7 +1,6 @@
 import datetime
 
 import jinja2
-
 from django_jinja import library
 
 from olympia import amo

--- a/src/olympia/reviewers/tests/test_code_manager_tags.py
+++ b/src/olympia/reviewers/tests/test_code_manager_tags.py
@@ -1,7 +1,7 @@
 from django.test.utils import override_settings
 
-from olympia.reviewers.templatetags import code_manager
 from olympia.amo.tests import TestCase
+from olympia.reviewers.templatetags import code_manager
 
 
 class TestCodeManagerUrl(TestCase):

--- a/src/olympia/reviewers/tests/test_decorators.py
+++ b/src/olympia/reviewers/tests/test_decorators.py
@@ -1,7 +1,7 @@
-from django import http
-
 from unittest import mock
 from urllib.parse import quote
+
+from django import http
 
 from olympia.amo.tests import TestCase, addon_factory
 from olympia.reviewers import decorators as dec

--- a/src/olympia/reviewers/tests/test_review_reports.py
+++ b/src/olympia/reviewers/tests/test_review_reports.py
@@ -1,9 +1,9 @@
 from datetime import date, timedelta
 
-from freezegun import freeze_time
-import pytest
-
 from django.core import mail
+
+import pytest
+from freezegun import freeze_time
 
 from olympia import amo
 from olympia.activity.models import ActivityLog

--- a/src/olympia/reviewers/tests/test_review_scenarios.py
+++ b/src/olympia/reviewers/tests/test_review_scenarios.py
@@ -4,6 +4,7 @@ For different add-on and file statuses, test reviewing them, and make sure then
 end up in the correct state.
 """
 from unittest import mock
+
 import pytest
 
 from olympia import amo

--- a/src/olympia/reviewers/tests/test_serializers.py
+++ b/src/olympia/reviewers/tests/test_serializers.py
@@ -17,13 +17,13 @@ from olympia.amo.tests import (
     version_factory,
 )
 from olympia.files.models import FileValidation
-from olympia.git.utils import AddonGitRepository, extract_version_to_git
 from olympia.git.tests.test_utils import apply_changes
+from olympia.git.utils import AddonGitRepository, extract_version_to_git
 from olympia.reviewers.serializers import (
     AddonBrowseVersionSerializer,
     AddonBrowseVersionSerializerFileOnly,
-    AddonCompareVersionSerializerFileOnly,
     AddonCompareVersionSerializer,
+    AddonCompareVersionSerializerFileOnly,
     DraftCommentSerializer,
     FileInfoDiffSerializer,
     FileInfoSerializer,

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -28,9 +28,9 @@ from olympia.constants.promoted import (
     LINE,
     NOTABLE,
     RECOMMENDED,
+    SPONSORED,
     SPOTLIGHT,
     STRATEGIC,
-    SPONSORED,
 )
 from olympia.files.models import File
 from olympia.lib.crypto.tests.test_signing import (

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -1,7 +1,6 @@
 import json
 import os
 import time
-
 from collections import OrderedDict
 from datetime import datetime, timedelta
 from unittest import mock
@@ -31,12 +30,12 @@ from olympia.access.models import Group, GroupUser
 from olympia.accounts.serializers import BaseUserSerializer
 from olympia.activity.models import ActivityLog, DraftComment
 from olympia.addons.models import (
+    UPCOMING_DUE_DATE_CUT_OFF_DAYS_CONFIG_DEFAULT,
     Addon,
     AddonApprovalsCounter,
     AddonReviewerFlags,
     AddonUser,
     DeniedGuid,
-    UPCOMING_DUE_DATE_CUT_OFF_DAYS_CONFIG_DEFAULT,
 )
 from olympia.amo.templatetags.jinja_helpers import (
     absolutify,
@@ -61,8 +60,8 @@ from olympia.constants.promoted import LINE, NOTABLE, RECOMMENDED, SPOTLIGHT, ST
 from olympia.constants.reviewers import REVIEWER_DELAYED_REJECTION_PERIOD_DAYS_DEFAULT
 from olympia.constants.scanners import CUSTOMS, MAD, YARA
 from olympia.files.models import FileValidation, WebextPermission
-from olympia.git.utils import AddonGitRepository, extract_version_to_git
 from olympia.git.tests.test_utils import apply_changes
+from olympia.git.utils import AddonGitRepository, extract_version_to_git
 from olympia.ratings.models import Rating, RatingFlag
 from olympia.reviewers.models import (
     AutoApprovalSummary,

--- a/src/olympia/reviewers/urls.py
+++ b/src/olympia/reviewers/urls.py
@@ -1,5 +1,5 @@
-from django.urls import re_path, include
 from django.shortcuts import redirect
+from django.urls import include, re_path
 
 from olympia.addons.urls import ADDON_ID
 from olympia.reviewers import views

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -1,9 +1,7 @@
 import random
-from collections import defaultdict, OrderedDict
+from collections import OrderedDict, defaultdict
 from datetime import datetime, timedelta
 
-import django_tables2 as tables
-import olympia.core.logger
 from django.conf import settings
 from django.contrib.humanize.templatetags.humanize import naturaltime
 from django.db.models import Count, F, Q
@@ -11,6 +9,10 @@ from django.template import loader
 from django.urls import reverse
 from django.utils import translation
 
+import django_tables2 as tables
+import markupsafe
+
+import olympia.core.logger
 from olympia import amo
 from olympia.access import acl
 from olympia.activity.models import ActivityLog
@@ -29,8 +31,6 @@ from olympia.reviewers.models import (
 from olympia.reviewers.templatetags.jinja_helpers import format_score
 from olympia.users.utils import get_task_user
 from olympia.versions.models import VersionReviewerFlags
-
-import markupsafe
 
 
 log = olympia.core.logger.getLogger('z.mailer')

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 from datetime import date, datetime
+from urllib.parse import quote
 
 from django import http
 from django.conf import settings
@@ -15,9 +16,6 @@ from django.urls import reverse
 from django.views.decorators.cache import never_cache
 
 import pygit2
-
-from urllib.parse import quote
-
 from csp.decorators import csp as set_csp
 from rest_framework import status
 from rest_framework.decorators import action as drf_action
@@ -33,7 +31,6 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 import olympia.core.logger
-
 from olympia import amo
 from olympia.abuse.models import AbuseReport
 from olympia.access import acl
@@ -105,8 +102,8 @@ from olympia.reviewers.utils import (
 from olympia.scanners.admin import formatted_matched_rules_with_files_and_data
 from olympia.stats.decorators import bigquery_api_view
 from olympia.stats.utils import (
-    get_average_daily_users_per_version_from_bigquery,
     VERSION_ADU_LIMIT,
+    get_average_daily_users_per_version_from_bigquery,
 )
 from olympia.users.models import UserProfile
 from olympia.versions.models import Version, VersionReviewerFlags

--- a/src/olympia/scanners/actions.py
+++ b/src/olympia/scanners/actions.py
@@ -2,9 +2,9 @@ from datetime import datetime, timedelta
 
 from olympia.constants.scanners import MAD
 from olympia.users.models import (
+    RESTRICTION_TYPES,
     EmailUserRestriction,
     IPNetworkUserRestriction,
-    RESTRICTION_TYPES,
 )
 
 

--- a/src/olympia/scanners/admin.py
+++ b/src/olympia/scanners/admin.py
@@ -1,3 +1,5 @@
+from urllib.parse import urljoin, urlparse
+
 from django.conf import settings
 from django.contrib import admin, messages
 from django.contrib.admin import SimpleListFilter
@@ -8,9 +10,6 @@ from django.template.loader import render_to_string
 from django.urls import re_path, reverse
 from django.utils.html import format_html, format_html_join
 from django.utils.http import urlencode
-
-
-from urllib.parse import urljoin, urlparse
 
 from olympia import amo
 from olympia.access import acl

--- a/src/olympia/scanners/models.py
+++ b/src/olympia/scanners/models.py
@@ -1,10 +1,7 @@
 import json
 import re
-
 from collections import defaultdict
 from datetime import datetime
-
-import yara
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -12,8 +9,9 @@ from django.db import models
 from django.utils.functional import classproperty
 from django.utils.translation import gettext_lazy as _
 
-import olympia.core.logger
+import yara
 
+import olympia.core.logger
 from olympia.amo.models import ModelBase
 from olympia.constants.base import ADDON_EXTENSION
 from olympia.constants.scanners import (
@@ -27,10 +25,10 @@ from olympia.constants.scanners import (
     DELAY_AUTO_APPROVAL_INDEFINITELY_AND_RESTRICT,
     DELAY_AUTO_APPROVAL_INDEFINITELY_AND_RESTRICT_FUTURE_APPROVALS,
     FLAG_FOR_HUMAN_REVIEW,
-    QUERY_RULE_STATES,
     MAD,
     NEW,
     NO_ACTION,
+    QUERY_RULE_STATES,
     RESULT_STATES,
     RUNNING,
     SCANNERS,

--- a/src/olympia/scanners/tasks.py
+++ b/src/olympia/scanners/tasks.py
@@ -6,13 +6,11 @@ from django.conf import settings
 import requests
 import waffle
 import yara
-
 from django_statsd.clients import statsd
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util import Retry
 
 import olympia.core.logger
-
 from olympia import amo
 from olympia.amo.celery import create_chunked_tasks_signatures, task
 from olympia.amo.decorators import use_primary_db

--- a/src/olympia/scanners/templatetags/scanners.py
+++ b/src/olympia/scanners/templatetags/scanners.py
@@ -1,8 +1,8 @@
-from django.utils.html import conditional_escape, format_html, format_html_join
-
 from django import template
 from django.conf import settings
 from django.urls import reverse
+from django.utils.html import conditional_escape, format_html, format_html_join
+
 
 register = template.Library()
 

--- a/src/olympia/scanners/tests/test_actions.py
+++ b/src/olympia/scanners/tests/test_actions.py
@@ -1,9 +1,9 @@
 from datetime import datetime, timedelta
 from unittest import mock
 
-import pytest
-
 from django.conf import settings
+
+import pytest
 
 from olympia import amo
 from olympia.amo.tests import (
@@ -23,10 +23,6 @@ from olympia.constants.scanners import (
     YARA,
 )
 from olympia.files.models import FileUpload
-from olympia.scanners.models import (
-    ScannerResult,
-    ScannerRule,
-)
 from olympia.scanners.actions import (
     _delay_auto_approval,
     _delay_auto_approval_indefinitely,
@@ -36,10 +32,14 @@ from olympia.scanners.actions import (
     _flag_for_human_review_by_scanner,
     _no_action,
 )
+from olympia.scanners.models import (
+    ScannerResult,
+    ScannerRule,
+)
 from olympia.users.models import (
+    RESTRICTION_TYPES,
     EmailUserRestriction,
     IPNetworkUserRestriction,
-    RESTRICTION_TYPES,
 )
 from olympia.versions.models import VersionReviewerFlags
 

--- a/src/olympia/scanners/tests/test_admin.py
+++ b/src/olympia/scanners/tests/test_admin.py
@@ -1,7 +1,7 @@
 import json
-
 from datetime import datetime
 from unittest import mock
+from urllib.parse import urljoin
 
 from django.conf import settings
 from django.contrib.admin.sites import AdminSite
@@ -13,7 +13,6 @@ from django.utils.html import format_html
 from django.utils.http import urlencode
 
 from pyquery import PyQuery as pq
-from urllib.parse import urljoin
 
 from olympia import amo
 from olympia.amo.tests import (
@@ -39,7 +38,6 @@ from olympia.constants.scanners import (
 from olympia.files.models import FileUpload
 from olympia.reviewers.templatetags.code_manager import code_manager_url
 from olympia.scanners.admin import (
-    formatted_matched_rules_with_files_and_data,
     ExcludeMatchedRulesFilter,
     MatchesFilter,
     ScannerQueryResultAdmin,
@@ -47,6 +45,7 @@ from olympia.scanners.admin import (
     ScannerRuleAdmin,
     StateFilter,
     WithVersionFilter,
+    formatted_matched_rules_with_files_and_data,
 )
 from olympia.scanners.models import (
     ScannerQueryResult,

--- a/src/olympia/scanners/tests/test_models.py
+++ b/src/olympia/scanners/tests/test_models.py
@@ -1,11 +1,11 @@
-import pytest
 import uuid
+from unittest import mock
 
 from django.core.exceptions import ValidationError
 from django.test.utils import override_settings
 
+import pytest
 from freezegun import freeze_time
-from unittest import mock
 
 from olympia import amo
 from olympia.amo.tests import TestCase, addon_factory, user_factory

--- a/src/olympia/scanners/tests/test_tasks.py
+++ b/src/olympia/scanners/tests/test_tasks.py
@@ -1,15 +1,15 @@
 from decimal import Decimal
 from unittest import mock
 
-import requests
-
 from django.conf import settings
 from django.test.utils import override_settings
 
+import requests
+
 from olympia import amo
 from olympia.amo.tests import (
-    addon_factory,
     TestCase,
+    addon_factory,
     user_factory,
     version_factory,
 )

--- a/src/olympia/scanners/tests/test_views.py
+++ b/src/olympia/scanners/tests/test_views.py
@@ -1,7 +1,7 @@
-import pytest
-
 from django.test.utils import override_settings
 from django.urls.exceptions import NoReverseMatch
+
+import pytest
 
 from olympia import amo
 from olympia.activity.models import ActivityLog, VersionLog
@@ -14,6 +14,8 @@ from olympia.amo.tests import (
     version_factory,
 )
 from olympia.api.tests.utils import APIKeyAuthTestMixin
+from olympia.blocklist.models import Block
+from olympia.blocklist.utils import block_activity_log_save
 from olympia.constants.scanners import (
     CUSTOMS,
     LABEL_BAD,
@@ -21,8 +23,6 @@ from olympia.constants.scanners import (
     TRUE_POSITIVE,
     YARA,
 )
-from olympia.blocklist.models import Block
-from olympia.blocklist.utils import block_activity_log_save
 from olympia.scanners.models import ScannerResult
 from olympia.scanners.serializers import ScannerResultSerializer
 

--- a/src/olympia/scanners/views.py
+++ b/src/olympia/scanners/views.py
@@ -1,6 +1,7 @@
 from django.conf import settings
-from django.db.models import CharField, Value, Q
+from django.db.models import CharField, Q, Value
 from django.db.transaction import non_atomic_requests
+
 from rest_framework.exceptions import ParseError
 from rest_framework.generics import ListAPIView
 
@@ -9,13 +10,13 @@ from olympia.api.authentication import (
     JWTKeyAuthentication,
     SessionIDAuthentication,
 )
+from olympia.api.permissions import GroupPermission
 from olympia.constants.scanners import (
     LABEL_BAD,
     LABEL_GOOD,
     SCANNERS,
     TRUE_POSITIVE,
 )
-from olympia.api.permissions import GroupPermission
 
 from .models import ScannerResult
 from .serializers import ScannerResultSerializer

--- a/src/olympia/search/management/commands/reindex.py
+++ b/src/olympia/search/management/commands/reindex.py
@@ -8,7 +8,6 @@ from django.core.management.base import BaseCommand, CommandError
 from elasticsearch.exceptions import NotFoundError
 
 import olympia.core.logger
-
 from olympia.addons.indexers import AddonIndexer
 from olympia.amo.celery import task
 from olympia.search.models import Reindexing

--- a/src/olympia/search/tests/test_commands.py
+++ b/src/olympia/search/tests/test_commands.py
@@ -1,7 +1,7 @@
+import io
 import re
 import threading
 import time
-import io
 from unittest import mock
 
 from django.conf import settings
@@ -13,7 +13,7 @@ from celery import group, shared_task
 from celery.canvas import _chain
 
 from olympia.addons.models import Addon
-from olympia.amo.tests import addon_factory, ESTestCaseMixin, PatchMixin, reverse_ns
+from olympia.amo.tests import ESTestCaseMixin, PatchMixin, addon_factory, reverse_ns
 from olympia.amo.utils import urlparams
 from olympia.search.management.commands import reindex
 from olympia.search.models import Reindexing

--- a/src/olympia/search/tests/test_filters.py
+++ b/src/olympia/search/tests/test_filters.py
@@ -1,5 +1,4 @@
 import copy
-
 from unittest.mock import Mock, patch
 
 from django.test.client import RequestFactory
@@ -15,11 +14,11 @@ from olympia.amo.tests import TestCase
 from olympia.constants.categories import CATEGORIES
 from olympia.constants.promoted import (
     BADGED_GROUPS,
+    LINE,
     PROMOTED_API_NAME_TO_IDS,
     RECOMMENDED,
-    LINE,
-    STRATEGIC,
     SPONSORED,
+    STRATEGIC,
     VERIFIED,
 )
 from olympia.search.filters import (

--- a/src/olympia/search/tests/test_utils.py
+++ b/src/olympia/search/tests/test_utils.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 from olympia.addons.indexers import AddonIndexer
 from olympia.addons.models import Addon
-from olympia.amo.tests import addon_factory, ESTestCase, TestCase
+from olympia.amo.tests import ESTestCase, TestCase, addon_factory
 from olympia.search.models import Reindexing
 from olympia.search.utils import get_es, index_objects, unindex_objects
 

--- a/src/olympia/search/utils.py
+++ b/src/olympia/search/utils.py
@@ -1,12 +1,11 @@
 import datetime
 import os
-
 from copy import deepcopy
 
 from django.conf import settings
 from django.core.management.base import CommandError
 
-from elasticsearch import Elasticsearch, helpers, transport, TransportError
+from elasticsearch import Elasticsearch, TransportError, helpers, transport
 
 from .models import Reindexing
 

--- a/src/olympia/shelves/forms.py
+++ b/src/olympia/shelves/forms.py
@@ -1,11 +1,11 @@
-import requests
 from urllib import parse
-
-from rest_framework.settings import api_settings
 
 from django import forms
 from django.conf import settings
 from django.urls import NoReverseMatch, reverse
+
+import requests
+from rest_framework.settings import api_settings
 
 import olympia.core.logger
 from olympia import amo

--- a/src/olympia/shelves/tests/test_forms.py
+++ b/src/olympia/shelves/tests/test_forms.py
@@ -1,6 +1,6 @@
-import responses
-
 from django.conf import settings
+
+import responses
 
 from olympia import amo
 from olympia.amo.tests import TestCase, reverse_ns

--- a/src/olympia/shelves/tests/test_serializers.py
+++ b/src/olympia/shelves/tests/test_serializers.py
@@ -1,20 +1,20 @@
-from rest_framework.request import Request as DRFRequest
-from rest_framework.settings import api_settings
-from rest_framework.test import APIRequestFactory
-
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.test.utils import override_settings
+
+from rest_framework.request import Request as DRFRequest
+from rest_framework.settings import api_settings
+from rest_framework.test import APIRequestFactory
 
 from olympia import amo
 from olympia.addons.models import Addon
 from olympia.amo.reverse import reverse
 from olympia.amo.tests import (
+    ESTestCase,
+    TestCase,
     addon_factory,
     collection_factory,
-    ESTestCase,
     reverse_ns,
-    TestCase,
 )
 from olympia.amo.urlresolvers import get_outgoing_url
 from olympia.bandwagon.models import CollectionAddon
@@ -22,7 +22,7 @@ from olympia.constants.promoted import RECOMMENDED
 from olympia.users.models import UserProfile
 
 from ..models import Shelf
-from ..serializers import ShelfSerializer, ShelfEditorialSerializer
+from ..serializers import ShelfEditorialSerializer, ShelfSerializer
 
 
 class TestShelvesSerializer(ESTestCase):

--- a/src/olympia/shelves/tests/test_views.py
+++ b/src/olympia/shelves/tests/test_views.py
@@ -8,12 +8,12 @@ from rest_framework.test import APIRequestFactory
 
 from olympia import amo
 from olympia.amo.tests import (
-    addon_factory,
     APITestClientSessionID,
-    collection_factory,
     ESTestCase,
-    reverse_ns,
     TestCase,
+    addon_factory,
+    collection_factory,
+    reverse_ns,
 )
 from olympia.bandwagon.models import CollectionAddon
 from olympia.constants.promoted import RECOMMENDED

--- a/src/olympia/shelves/views.py
+++ b/src/olympia/shelves/views.py
@@ -7,7 +7,7 @@ from rest_framework.response import Response
 from olympia.hero.views import PrimaryHeroShelfViewSet, SecondaryHeroShelfViewSet
 
 from .models import Shelf
-from .serializers import ShelfSerializer, ShelfEditorialSerializer
+from .serializers import ShelfEditorialSerializer, ShelfSerializer
 
 
 class ShelfViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):

--- a/src/olympia/signing/views.py
+++ b/src/olympia/signing/views.py
@@ -10,7 +10,6 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 import olympia.core.logger
-
 from olympia import amo
 from olympia.access import acl
 from olympia.addons.models import Addon
@@ -19,18 +18,19 @@ from olympia.addons.utils import (
     webext_version_stats,
 )
 from olympia.amo.decorators import use_primary_db
-from olympia.api.authentication import JWTKeyAuthentication
 from olympia.amo.templatetags.jinja_helpers import absolutify
+from olympia.api.authentication import JWTKeyAuthentication
 from olympia.api.throttling import addon_submission_throttles
 from olympia.blocklist.models import Block
-from olympia.devhub.views import handle_upload as devhub_handle_upload
 from olympia.devhub.permissions import IsSubmissionAllowedFor
+from olympia.devhub.views import handle_upload as devhub_handle_upload
 from olympia.files.models import FileUpload
 from olympia.files.utils import parse_addon
 from olympia.versions import views as version_views
 from olympia.versions.models import Version
 
 from .serializers import SigningFileUploadSerializer
+
 
 log = olympia.core.logger.getLogger('signing')
 

--- a/src/olympia/stats/decorators.py
+++ b/src/olympia/stats/decorators.py
@@ -1,6 +1,7 @@
 import functools
 
 from django import http
+
 from waffle import switch_is_active
 
 from olympia.access import acl

--- a/src/olympia/stats/templatetags/jinja_helpers.py
+++ b/src/olympia/stats/templatetags/jinja_helpers.py
@@ -2,7 +2,6 @@ from django.template import loader
 
 import jinja2
 import markupsafe
-
 from django_jinja import library
 
 from olympia.addons.models import Addon

--- a/src/olympia/stats/tests/test_utils.py
+++ b/src/olympia/stats/tests/test_utils.py
@@ -2,6 +2,7 @@ from datetime import date
 from unittest import mock
 
 from django.test.utils import override_settings
+
 from google.cloud import bigquery
 
 from olympia.amo.tests import TestCase, addon_factory
@@ -13,8 +14,8 @@ from olympia.stats.utils import (
     AMO_TO_BQ_DOWNLOAD_COLUMN_MAPPING,
     get_addons_and_average_daily_users_from_bigquery,
     get_addons_and_weekly_downloads_from_bigquery,
-    get_averages_by_addon_from_bigquery,
     get_average_daily_users_per_version_from_bigquery,
+    get_averages_by_addon_from_bigquery,
     get_download_series,
     get_updates_series,
     rows_to_series,

--- a/src/olympia/stats/tests/test_views.py
+++ b/src/olympia/stats/tests/test_views.py
@@ -1,13 +1,12 @@
 import csv
 import json
-
 from datetime import date
 from unittest import mock
 
 from django.http import Http404
 from django.test.client import RequestFactory
 from django.urls import reverse
-from django.utils.encoding import force_str, force_bytes
+from django.utils.encoding import force_bytes, force_str
 
 from waffle.testutils import override_switch
 

--- a/src/olympia/stats/utils.py
+++ b/src/olympia/stats/utils.py
@@ -1,10 +1,12 @@
 from datetime import timedelta
 
 from django.conf import settings
+
 from django_statsd.clients import statsd
 from google.cloud import bigquery
 
 from olympia.constants.applications import ANDROID, FIREFOX
+
 
 # This is the mapping between the AMO usage stats `sources` and the BigQuery
 # columns.

--- a/src/olympia/stats/views.py
+++ b/src/olympia/stats/views.py
@@ -1,8 +1,7 @@
 import csv
+import itertools
 import json
 import time
-import itertools
-
 from datetime import timedelta
 
 from django import http
@@ -17,7 +16,6 @@ from django.utils.cache import add_never_cache_headers, patch_cache_control
 from django.utils.encoding import force_str
 
 import olympia.core.logger
-
 from olympia import amo
 from olympia.access import acl
 from olympia.amo.decorators import allow_cross_site_request
@@ -26,7 +24,7 @@ from olympia.core.languages import ALL_LANGUAGES
 from olympia.stats.decorators import addon_view_stats, bigquery_api_view
 from olympia.stats.forms import DateForm
 
-from .utils import get_updates_series, get_download_series
+from .utils import get_download_series, get_updates_series
 
 
 logger = olympia.core.logger.getLogger('z.apps.stats.views')

--- a/src/olympia/tags/tasks.py
+++ b/src/olympia/tags/tasks.py
@@ -1,5 +1,4 @@
 import olympia.core.logger
-
 from olympia.amo.celery import task
 from olympia.tags.models import Tag
 

--- a/src/olympia/translations/hold.py
+++ b/src/olympia/translations/hold.py
@@ -1,7 +1,6 @@
 from threading import local
 
 import django.dispatch
-
 from django.core.signals import request_finished
 
 

--- a/src/olympia/translations/models.py
+++ b/src/olympia/translations/models.py
@@ -7,7 +7,6 @@ import bleach
 from bleach.linkifier import URL_RE  # build_url_re() with good defaults.
 
 import olympia.core.logger
-
 from olympia.amo.fields import PositiveAutoField
 from olympia.amo.models import ManagerBase, ModelBase
 from olympia.amo.urlresolvers import linkify_bounce_url_callback

--- a/src/olympia/translations/templatetags/jinja_helpers.py
+++ b/src/olympia/translations/templatetags/jinja_helpers.py
@@ -6,7 +6,6 @@ from django.utils.translation.trans_real import to_language
 
 import jinja2
 import markupsafe
-
 from django_jinja import library
 
 

--- a/src/olympia/translations/tests/test_helpers.py
+++ b/src/olympia/translations/tests/test_helpers.py
@@ -1,9 +1,9 @@
+from unittest.mock import Mock
+
 from django.conf import settings
 from django.utils import translation
 
 import pytest
-
-from unittest.mock import Mock
 
 from olympia.addons.models import Addon
 from olympia.amo.tests import TestCase

--- a/src/olympia/translations/tests/test_models.py
+++ b/src/olympia/translations/tests/test_models.py
@@ -1,7 +1,7 @@
 import re
+from unittest.mock import patch
 
 import django
-
 from django.conf import settings
 from django.db import connections, reset_queries
 from django.test import TransactionTestCase
@@ -11,8 +11,6 @@ from django.utils.functional import lazy
 
 import jinja2
 import pytest
-
-from unittest.mock import patch
 from pyquery import PyQuery as pq
 
 from olympia.amo.models import use_primary_db
@@ -31,9 +29,9 @@ from olympia.translations.tests.testapp.models import (
     ContainsTranslatedThrough,
     FancyModel,
     TranslatedModel,
-    UntranslatedModel,
-    TranslatedModelWithDefaultNull,
     TranslatedModelLinkedAsForeignKey,
+    TranslatedModelWithDefaultNull,
+    UntranslatedModel,
 )
 
 

--- a/src/olympia/translations/widgets.py
+++ b/src/olympia/translations/widgets.py
@@ -1,8 +1,8 @@
 from django import forms
 from django.utils import translation
 from django.utils.encoding import force_str
-from django.utils.translation.trans_real import to_language
 from django.utils.safestring import mark_safe
+from django.utils.translation.trans_real import to_language
 
 from .models import Translation
 

--- a/src/olympia/urls.py
+++ b/src/olympia/urls.py
@@ -1,8 +1,7 @@
 from django.conf import settings
-from django.urls import include, re_path
 from django.contrib import admin
 from django.shortcuts import redirect
-from django.urls import reverse
+from django.urls import include, re_path, reverse
 from django.views.static import serve as serve_static
 
 from olympia.amo.utils import urlparams

--- a/src/olympia/users/cron.py
+++ b/src/olympia/users/cron.py
@@ -1,11 +1,9 @@
 from django.db import connections
 
 import multidb
-
 from celery import group
 
 import olympia.core.logger
-
 from olympia.amo import VALID_ADDON_STATUSES
 from olympia.amo.utils import chunked
 

--- a/src/olympia/users/management/commands/createsuperuser.py
+++ b/src/olympia/users/management/commands/createsuperuser.py
@@ -5,7 +5,6 @@ Inspired by django.contrib.auth.management.commands.createsuperuser.
 (http://bit.ly/2cTgsNV)
 """
 import json
-
 from datetime import datetime
 
 from django.contrib.auth import get_user_model

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -1,15 +1,12 @@
 import binascii
+import ipaddress
 import os
 import random
 import re
 import time
-import ipaddress
-from urllib.parse import urljoin
-
 from datetime import datetime
-from extended_choices import Choices
 from fnmatch import fnmatchcase
-import requests
+from urllib.parse import urljoin
 
 from django import forms
 from django.conf import settings
@@ -27,12 +24,14 @@ from django.utils.encoding import force_str
 from django.utils.functional import cached_property
 from django.utils.translation import gettext, gettext_lazy as _
 
-import olympia.core.logger
+import requests
+from extended_choices import Choices
 
-from olympia import amo, activity, core
+import olympia.core.logger
+from olympia import activity, amo, core
 from olympia.access.models import Group, GroupUser
 from olympia.amo.decorators import use_primary_db
-from olympia.amo.fields import PositiveAutoField, CIDRField
+from olympia.amo.fields import CIDRField, PositiveAutoField
 from olympia.amo.models import LongNameIndex, ManagerBase, ModelBase, OnChangeMixin
 from olympia.amo.utils import id_to_path
 from olympia.amo.validators import OneOrMorePrintableCharacterValidator

--- a/src/olympia/users/tasks.py
+++ b/src/olympia/users/tasks.py
@@ -1,8 +1,7 @@
 import olympia.core.logger
-
 from olympia.amo.celery import task
 from olympia.amo.decorators import set_modified_on
-from olympia.amo.utils import resize_image, SafeStorage
+from olympia.amo.utils import SafeStorage, resize_image
 
 from .models import UserProfile
 

--- a/src/olympia/users/templatetags/jinja_helpers.py
+++ b/src/olympia/users/templatetags/jinja_helpers.py
@@ -1,7 +1,6 @@
 from django.utils.encoding import force_str
 
 import markupsafe
-
 from django_jinja import library
 
 

--- a/src/olympia/users/tests/test_admin.py
+++ b/src/olympia/users/tests/test_admin.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from django.contrib import admin
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.messages.storage import default_storage as default_messages_storage
@@ -7,8 +9,6 @@ from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from django.utils.formats import localize
 
-from unittest import mock
-
 from pyquery import PyQuery as pq
 
 from olympia import amo, core
@@ -16,9 +16,9 @@ from olympia.abuse.models import AbuseReport
 from olympia.activity.models import ActivityLog
 from olympia.addons.models import AddonUser
 from olympia.amo.tests import (
+    TestCase,
     addon_factory,
     collection_factory,
-    TestCase,
     user_factory,
     version_factory,
 )

--- a/src/olympia/users/tests/test_commands.py
+++ b/src/olympia/users/tests/test_commands.py
@@ -4,16 +4,15 @@ import os
 import re
 import uuid
 from ipaddress import IPv4Address
+from unittest.mock import ANY, patch
 
 from django.core.files.base import ContentFile
 from django.core.management import call_command
 
-from unittest.mock import ANY, patch
-
 from olympia import amo
 from olympia.activity.models import ActivityLog, IPLog
 from olympia.addons.models import Addon
-from olympia.amo.tests import addon_factory, TestCase, user_factory
+from olympia.amo.tests import TestCase, addon_factory, user_factory
 from olympia.amo.utils import SafeStorage
 from olympia.users.management.commands.createsuperuser import Command as CreateSuperUser
 from olympia.users.models import UserProfile, UserRestrictionHistory

--- a/src/olympia/users/tests/test_cron.py
+++ b/src/olympia/users/tests/test_cron.py
@@ -1,4 +1,4 @@
-from olympia.amo.tests import addon_factory, TestCase, user_factory
+from olympia.amo.tests import TestCase, addon_factory, user_factory
 from olympia.ratings.models import Rating
 from olympia.users.cron import update_user_ratings
 

--- a/src/olympia/users/tests/test_forms.py
+++ b/src/olympia/users/tests/test_forms.py
@@ -4,8 +4,8 @@ from django.urls import reverse
 
 from olympia.amo.tests import TestCase
 from olympia.users.models import (
-    IPNetworkUserRestriction,
     RESTRICTION_TYPES,
+    IPNetworkUserRestriction,
     UserProfile,
 )
 

--- a/src/olympia/users/tests/test_models.py
+++ b/src/olympia/users/tests/test_models.py
@@ -1,42 +1,39 @@
-from datetime import date, datetime, timedelta
-from ipaddress import IPv4Address
-
 import django  # noqa
-
+from datetime import date, datetime, timedelta
 from django import forms
-from django.db import models
 from django.contrib.auth import get_user
 from django.contrib.auth.models import AnonymousUser
 from django.core import mail
+from django.db import models
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
+from ipaddress import IPv4Address
 
 import pytest
 import responses
 
 import olympia  # noqa
-
 from olympia import amo, core
 from olympia.access.models import Group, GroupUser
 from olympia.activity.models import ActivityLog
 from olympia.addons.models import Addon, AddonUser
-from olympia.amo.tests import addon_factory, collection_factory, TestCase, user_factory
+from olympia.amo.tests import TestCase, addon_factory, collection_factory, user_factory
 from olympia.amo.utils import SafeStorage
 from olympia.bandwagon.models import Collection
 from olympia.files.models import File, FileUpload
 from olympia.ratings.models import Rating
 from olympia.users.models import (
+    RESTRICTION_TYPES,
     DeniedName,
     DisposableEmailDomainRestriction,
-    generate_auth_id,
-    get_anonymized_username,
     EmailReputationRestriction,
     EmailUserRestriction,
     IPNetworkUserRestriction,
     IPReputationRestriction,
-    RESTRICTION_TYPES,
     UserEmailField,
     UserProfile,
+    generate_auth_id,
+    get_anonymized_username,
 )
 from olympia.zadmin.models import set_config
 

--- a/src/olympia/users/tests/test_tasks.py
+++ b/src/olympia/users/tests/test_tasks.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from django.test.utils import override_settings
 
 import pytest
-
 from PIL import Image
 
 from olympia.amo.tests.test_helpers import get_image_path

--- a/src/olympia/users/tests/test_user_utils.py
+++ b/src/olympia/users/tests/test_user_utils.py
@@ -13,9 +13,9 @@ from olympia.amo.tests import TestCase, user_factory
 from olympia.files.models import FileUpload
 
 from ..models import (
+    RESTRICTION_TYPES,
     EmailUserRestriction,
     IPNetworkUserRestriction,
-    RESTRICTION_TYPES,
     UserRestrictionHistory,
 )
 from ..utils import RestrictionChecker, UnsubscribeCode

--- a/src/olympia/users/tests/test_views.py
+++ b/src/olympia/users/tests/test_views.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from pyquery import PyQuery as pq
 
 from olympia import amo
-from olympia.amo.tests import addon_factory, TestCase
+from olympia.amo.tests import TestCase, addon_factory
 from olympia.users.models import UserProfile
 
 

--- a/src/olympia/users/utils.py
+++ b/src/olympia/users/utils.py
@@ -12,7 +12,6 @@ from django.utils.translation import gettext
 from django_statsd.clients import statsd
 
 import olympia.core.logger
-
 from olympia import activity, amo, core
 from olympia.activity import log_create
 

--- a/src/olympia/versions/admin.py
+++ b/src/olympia/versions/admin.py
@@ -2,7 +2,6 @@ from django import forms
 from django.contrib import admin
 
 from olympia.amo.admin import AMOModelAdmin
-
 from olympia.reviewers.models import NeedsHumanReview
 
 from .models import (

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -1,12 +1,10 @@
 import os
-from datetime import datetime, timedelta
-
 from base64 import b64encode
-from urllib.parse import urlparse
+from datetime import datetime, timedelta
 from fnmatch import fnmatch
+from urllib.parse import urlparse
 
 import django.dispatch
-
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.storage import default_storage as storage
 from django.db import models, transaction
@@ -18,14 +16,11 @@ from django.utils.functional import cached_property
 from django.utils.translation import gettext, gettext_lazy as _
 
 import markupsafe
-from olympia.constants.applications import APP_IDS
 import waffle
-
 from django_statsd.clients import statsd
 from publicsuffix2 import get_sld
 
 import olympia.core.logger
-
 from olympia import activity, amo, core
 from olympia.amo.decorators import use_primary_db
 from olympia.amo.fields import PositiveAutoField
@@ -37,24 +32,25 @@ from olympia.amo.models import (
     OnChangeMixin,
 )
 from olympia.amo.utils import (
+    SafeStorage,
     id_to_path,
     sorted_groupby,
-    SafeStorage,
     utc_millesecs_from_epoch,
 )
 from olympia.applications.models import AppVersion
+from olympia.constants.applications import APP_IDS
 from olympia.constants.licenses import CC_LICENSES, FORM_LICENSES, LICENSES_BY_BUILTIN
 from olympia.constants.promoted import PROMOTED_GROUPS, PROMOTED_GROUPS_BY_ID
 from olympia.constants.scanners import MAD
 from olympia.files import utils
 from olympia.files.models import File, cleanup_file
+from olympia.scanners.models import ScannerResult
 from olympia.translations.fields import (
     LinkifiedField,
     PurifiedField,
     TranslatedField,
     save_signal,
 )
-from olympia.scanners.models import ScannerResult
 from olympia.users.models import UserProfile
 from olympia.users.utils import RestrictionChecker
 from olympia.zadmin.models import get_config
@@ -365,8 +361,8 @@ class Version(OnChangeMixin, ModelBase):
         """
         from olympia.addons.models import AddonReviewerFlags
         from olympia.devhub.tasks import send_initial_submission_acknowledgement_email
-        from olympia.reviewers.models import NeedsHumanReview
         from olympia.git.utils import create_git_extraction_entry
+        from olympia.reviewers.models import NeedsHumanReview
 
         assert parsed_data is not None
 

--- a/src/olympia/versions/tasks.py
+++ b/src/olympia/versions/tasks.py
@@ -1,21 +1,20 @@
+import itertools
 import operator
 import os
-import itertools
 import tempfile
 from io import BytesIO
 
-from django.db import transaction
 from django.conf import settings
+from django.db import transaction
 from django.template import loader
 
 from PIL import Image
 
 import olympia.core.logger
-
 from olympia import amo
 from olympia.amo.celery import task
 from olympia.amo.decorators import use_primary_db
-from olympia.amo.utils import extract_colors_from_image, pngcrush_image, SafeStorage
+from olympia.amo.utils import SafeStorage, extract_colors_from_image, pngcrush_image
 from olympia.devhub.tasks import resize_image
 from olympia.files.models import File
 from olympia.files.utils import get_background_images

--- a/src/olympia/versions/tests/test_compare.py
+++ b/src/olympia/versions/tests/test_compare.py
@@ -1,8 +1,8 @@
 from olympia.versions.compare import (
     APP_MAJOR_VERSION_PART_MAX,
+    VersionString,
     version_dict,
     version_int,
-    VersionString,
 )
 
 

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -1,15 +1,13 @@
 import os.path
-
 from datetime import datetime, timedelta
+from unittest import mock
 
-from django.db import transaction
 from django.conf import settings
+from django.db import transaction
 from django.test.testcases import TransactionTestCase
 
-from unittest import mock
 import pytest
 import waffle
-
 from waffle.testutils import override_switch
 
 from olympia import amo, core
@@ -30,13 +28,13 @@ from olympia.applications.models import AppVersion
 from olympia.blocklist.models import Block
 from olympia.constants.promoted import (
     LINE,
-    NOTABLE,
     NOT_PROMOTED,
+    NOTABLE,
     RECOMMENDED,
     SPOTLIGHT,
     STRATEGIC,
 )
-from olympia.constants.scanners import CUSTOMS, YARA, MAD
+from olympia.constants.scanners import CUSTOMS, MAD, YARA
 from olympia.files.models import File
 from olympia.files.tests.test_models import UploadMixin
 from olympia.files.utils import parse_addon
@@ -44,20 +42,20 @@ from olympia.promoted.models import PromotedAddon, PromotedApproval
 from olympia.reviewers.models import AutoApprovalSummary, NeedsHumanReview
 from olympia.scanners.models import ScannerResult
 from olympia.users.models import (
+    RESTRICTION_TYPES,
     EmailUserRestriction,
     IPNetworkUserRestriction,
-    RESTRICTION_TYPES,
     UserProfile,
 )
 from olympia.users.utils import get_task_user
 from olympia.zadmin.models import set_config
 
-from ..compare import version_int, VersionString
+from ..compare import VersionString, version_int
 from ..models import (
     ApplicationsVersions,
     DeniedInstallOrigin,
-    License,
     InstallOrigin,
+    License,
     Version,
     VersionCreateError,
     VersionPreview,

--- a/src/olympia/versions/tests/test_tasks.py
+++ b/src/olympia/versions/tests/test_tasks.py
@@ -1,19 +1,19 @@
 import os
 from base64 import b64encode
+from unittest import mock
 
 from django.conf import settings
 from django.utils.encoding import force_str
 
-from unittest import mock
 import pytest
 
 from olympia import amo
 from olympia.amo.tests import addon_factory, root_storage, version_factory
 from olympia.versions.models import Version, VersionPreview
 from olympia.versions.tasks import (
+    UI_FIELDS,
     generate_static_theme_preview,
     hard_delete_versions,
-    UI_FIELDS,
 )
 
 

--- a/src/olympia/versions/tests/test_update.py
+++ b/src/olympia/versions/tests/test_update.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 import pytest
 
 from olympia import amo
-from olympia.amo.tests import addon_factory, TestCase, version_factory
+from olympia.amo.tests import TestCase, addon_factory, version_factory
 from olympia.constants.applications import APP_GUIDS
 from olympia.versions.models import ApplicationsVersions, AppVersion
 

--- a/src/olympia/versions/tests/test_utils.py
+++ b/src/olympia/versions/tests/test_utils.py
@@ -2,17 +2,16 @@ import math
 import os
 import shutil
 import tempfile
-
 from base64 import b64encode
 from datetime import datetime
+from unittest import mock
 
 from django.conf import settings
 from django.utils.encoding import force_str
 
-from unittest import mock
 import pytest
-from PIL import Image, ImageChops
 from freezegun import freeze_time
+from PIL import Image, ImageChops
 
 from olympia import amo
 from olympia.amo.tests import root_storage

--- a/src/olympia/versions/tests/test_views.py
+++ b/src/olympia/versions/tests/test_views.py
@@ -1,15 +1,14 @@
 import os
-
 from unittest import mock
 
 from django.conf import settings
-from django.utils.encoding import smart_str
 from django.core.files import temp
 from django.core.files.base import File as DjangoFile
 from django.urls import reverse
+from django.utils.encoding import smart_str
 
-from rest_framework import exceptions as drf_exceptions
 from pyquery import PyQuery
+from rest_framework import exceptions as drf_exceptions
 
 from olympia import amo
 from olympia.access import acl

--- a/src/olympia/versions/update.py
+++ b/src/olympia/versions/update.py
@@ -1,12 +1,12 @@
 from django.db.models import F
 from django.db.transaction import non_atomic_requests
 from django.http import JsonResponse
-from django.views.decorators.cache import cache_control
 from django.urls import reverse
+from django.views.decorators.cache import cache_control
 
 from olympia.addons.models import Addon
-from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.amo.reverse import override_url_prefix
+from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.constants import applications
 from olympia.versions.compare import version_int
 from olympia.versions.models import Version

--- a/src/olympia/versions/utils.py
+++ b/src/olympia/versions/utils.py
@@ -1,8 +1,7 @@
-import os
 import io
+import os
 import re
 import tempfile
-
 from base64 import b64encode
 from datetime import datetime, timedelta
 
@@ -18,6 +17,7 @@ from olympia.constants.reviewers import (
 )
 from olympia.core import logger
 from olympia.zadmin.models import get_config
+
 
 log = logger.getLogger('z.versions.utils')
 

--- a/src/olympia/versions/views.py
+++ b/src/olympia/versions/views.py
@@ -8,7 +8,6 @@ from django.urls import reverse
 from django.utils.cache import patch_cache_control, patch_vary_headers
 
 import olympia.core.logger
-
 from olympia import amo
 from olympia.access import acl
 from olympia.addons.decorators import addon_view_factory

--- a/src/olympia/zadmin/admin.py
+++ b/src/olympia/zadmin/admin.py
@@ -2,8 +2,8 @@ from django.conf import settings
 from django.contrib import admin, auth
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import redirect
-from django.utils.html import format_html
 from django.urls import reverse
+from django.utils.html import format_html
 
 from olympia.accounts.utils import redirect_for_login
 

--- a/src/olympia/zadmin/management/commands/addusertogroup.py
+++ b/src/olympia/zadmin/management/commands/addusertogroup.py
@@ -2,7 +2,6 @@ from django.core.management.base import BaseCommand, CommandError
 from django.db import IntegrityError
 
 import olympia.core.logger
-
 from olympia.access.models import Group, GroupUser
 from olympia.users.models import UserProfile
 

--- a/src/olympia/zadmin/management/commands/removeuserfromgroup.py
+++ b/src/olympia/zadmin/management/commands/removeuserfromgroup.py
@@ -1,7 +1,6 @@
 from django.core.management.base import BaseCommand, CommandError
 
 import olympia.core.logger
-
 from olympia.access.models import Group, GroupUser
 from olympia.users.models import UserProfile
 

--- a/src/olympia/zadmin/tasks.py
+++ b/src/olympia/zadmin/tasks.py
@@ -1,5 +1,4 @@
 import olympia.core.logger
-
 from olympia.amo.celery import task
 
 

--- a/src/olympia/zadmin/tests/test_models.py
+++ b/src/olympia/zadmin/tests/test_models.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 
-from olympia.zadmin.models import get_config, set_config, Config
+from olympia.zadmin.models import Config, get_config, set_config
 
 
 @pytest.mark.django_db

--- a/src/olympia/zadmin/urls.py
+++ b/src/olympia/zadmin/urls.py
@@ -1,6 +1,6 @@
-from django.urls import include, re_path
 from django.contrib import admin
 from django.shortcuts import redirect
+from django.urls import include, re_path
 
 
 urlpatterns = [


### PR DESCRIPTION
fixes #20670 

ruff supports most (all?) of the isort configuration so I tried to match it closely to our current ideal "style" - there may be other tweaks but I'm not sure we even need all the ones enabled, strictly.  

`ruff . --fix`  did it all without any manual changes, btw - if we wanted to play around it's just a matter of adding/changing the config and running fix again. 