### PR TITLE
Clarify that authentication is not mandatory in API calls

### DIFF
--- a/docs/topics/api/auth.rst
+++ b/docs/topics/api/auth.rst
@@ -4,8 +4,10 @@
 Authentication (External)
 =========================
 
-To execute authenticated calls against the API as an external consumer, you need to
-include a `JSON Web Token (JWT)`_ in the ``Authorization`` header for every request.
+To execute authenticated calls against the API as an external consumer (See the
+documentation for individual endpoints where it will indicate if that endpoint
+requires, or would benefit from, authentication), you need to include a
+`JSON Web Token (JWT)`_ in the ``Authorization`` header for every request.
 This header acts as a one-time token that authenticates your user account.
 No JWT claims are made about the actual API request you are making.
 

--- a/docs/topics/api/auth.rst
+++ b/docs/topics/api/auth.rst
@@ -4,7 +4,7 @@
 Authentication (External)
 =========================
 
-To execute authenticated calls against the API as an external consumer (See the
+To execute authenticated calls against the API as an external consumer, (see the
 documentation for individual endpoints where it will indicate if that endpoint
 requires, or would benefit from, authentication), you need to include a
 `JSON Web Token (JWT)`_ in the ``Authorization`` header for every request.

--- a/docs/topics/api/auth.rst
+++ b/docs/topics/api/auth.rst
@@ -4,8 +4,8 @@
 Authentication (External)
 =========================
 
-To access the API as an external consumer, you need to include a
-`JSON Web Token (JWT)`_ in the ``Authorization`` header for every request.
+To execute authenticated calls against the API as an external consumer, you need to
+include a `JSON Web Token (JWT)`_ in the ``Authorization`` header for every request.
 This header acts as a one-time token that authenticates your user account.
 No JWT claims are made about the actual API request you are making.
 


### PR DESCRIPTION
The previous wording sort of implied you had to make authenticated calls using JWT at all time.