### PR TITLE
Don't flag add-ons for growth if no usage tiers are defined

### DIFF
--- a/src/olympia/addons/admin.py
+++ b/src/olympia/addons/admin.py
@@ -257,6 +257,7 @@ class AddonAdmin(AMOModelAdmin):
         'text_ratings_count',
         'weekly_downloads',
         'average_daily_users',
+        'hotness',
     )
 
     fieldsets = (
@@ -306,6 +307,7 @@ class AddonAdmin(AMOModelAdmin):
                     'text_ratings_count',
                     'weekly_downloads',
                     'average_daily_users',
+                    'hotness',
                 ),
             },
         ),

--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -449,6 +449,8 @@ def flag_high_hotness_according_to_review_tier():
             average_daily_users__lt=usage_tier.upper_adu_threshold,
             hotness__gte=usage_tier.growth_threshold_before_flagging / 100,
         )
+    if not tier_filters:
+        return
     qs = (
         Addon.unfiltered.exclude(status=amo.STATUS_DISABLED)
         .filter(type=amo.ADDON_EXTENSION)

--- a/src/olympia/addons/tests/test_tasks.py
+++ b/src/olympia/addons/tests/test_tasks.py
@@ -341,7 +341,7 @@ def test_flag_high_hotness_according_to_review_tier():
         version=flagged[-1].current_version, is_active=False
     )
 
-    # Prtend all files were signed otherwise they would not get flagged.
+    # Pretend all files were signed otherwise they would not get flagged.
     File.objects.update(is_signed=True)
     flag_high_hotness_according_to_review_tier()
 
@@ -377,6 +377,14 @@ def test_flag_high_hotness_according_to_review_tier():
         datetime(2023, 5, 19, 11, 0),
         datetime(2023, 5, 22, 11, 0),
     ]
+
+
+@pytest.mark.django_db
+def test_flag_high_hotness_according_to_review_tier_no_tiers_defined():
+    user_factory(pk=settings.TASK_USER_ID)
+    addon = addon_factory(average_daily_users=1001, file_kw={'is_signed': True})
+    flag_high_hotness_according_to_review_tier()
+    assert not addon.current_version.needshumanreview_set.exists()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Also expose hotness in admin for easier debugging

Fixes #20713

Data on dev/stage remains an issue but this needs to be solved outside of this repos.