### PR TITLE
Prevent Notable from being added to Primary hero shelf

### DIFF
--- a/src/olympia/constants/promoted.py
+++ b/src/olympia/constants/promoted.py
@@ -137,7 +137,6 @@ NOTABLE = PromotedClass(
     warning=False,
     listed_pre_review=True,
     unlisted_pre_review=True,
-    can_primary_hero=True,
     flag_for_human_review=True,
 )
 

--- a/src/olympia/hero/tests/test_models.py
+++ b/src/olympia/hero/tests/test_models.py
@@ -72,7 +72,7 @@ class TestPrimaryHero(TestCase):
             ph.clean()
         assert context.exception.messages == [
             'Only add-ons that are Recommended, Sponsored, By Firefox, '
-            'Spotlight, Notable can be enabled for non-external primary shelves.'
+            'Spotlight can be enabled for non-external primary shelves.'
         ]
 
         # change to a different group that *can* be added as a primary hero


### PR DESCRIPTION
fixes #20682 