### PR TITLE
Handle moderation queue case for reviewer queues

### DIFF
--- a/src/olympia/reviewers/templates/reviewers/queue.html
+++ b/src/olympia/reviewers/templates/reviewers/queue.html
@@ -1,9 +1,7 @@
 {% extends "reviewers/base.html" %}
 
 {% block title %}
-  {% if tab == "moderated" %}
-    Review Moderation – Add-ons for Firefox
-  {% elif title %}
+  {% if title %}
     {{ title }} - Add-ons for Firefox
   {% else %}
     {{ super() }}

--- a/src/olympia/reviewers/templatetags/jinja_helpers.py
+++ b/src/olympia/reviewers/templatetags/jinja_helpers.py
@@ -3,7 +3,6 @@ import datetime
 import jinja2
 from django_jinja import library
 
-from olympia import amo
 from olympia.access import acl
 from olympia.amo.templatetags.jinja_helpers import new_context
 from olympia.ratings.permissions import user_can_delete_rating
@@ -25,11 +24,11 @@ def queue_tabnav(context, reviewer_tables_registry):
         'mad',
         'theme_nominated',
         'theme_pending',
-        'moderation',
+        'moderated',
         'content_review',
         'pending_rejection',
     ):
-        if queue in reviewer_tables_registry and acl.action_allowed_for(
+        if acl.action_allowed_for(
             request.user, reviewer_tables_registry[queue].permission
         ):
             tabnav.append(
@@ -39,10 +38,6 @@ def queue_tabnav(context, reviewer_tables_registry):
                     reviewer_tables_registry[queue].title,
                 )
             )
-        elif queue not in reviewer_tables_registry and acl.action_allowed_for(
-            request.user, amo.permissions.RATINGS_MODERATE
-        ):
-            tabnav.append(('moderated', 'queue_moderated', 'Rating Reviews'))
 
     return tabnav
 

--- a/src/olympia/reviewers/urls.py
+++ b/src/olympia/reviewers/urls.py
@@ -10,7 +10,7 @@ def queue_urls():
     return [
         re_path(
             views.reviewer_tables_registry[queue].url,
-            views.queue,
+            views.reviewer_tables_registry[queue].view,
             kwargs={'tab': queue},
             name='reviewers.' + views.reviewer_tables_registry[queue].urlname,
         )

--- a/src/olympia/reviewers/urls.py
+++ b/src/olympia/reviewers/urls.py
@@ -10,7 +10,7 @@ def queue_urls():
     return [
         re_path(
             views.reviewer_tables_registry[queue].url,
-            views.reviewer_tables_registry[queue].view,
+            getattr(views, views.reviewer_tables_registry[queue].view_name),
             kwargs={'tab': queue},
             name='reviewers.' + views.reviewer_tables_registry[queue].urlname,
         )

--- a/src/olympia/reviewers/urls.py
+++ b/src/olympia/reviewers/urls.py
@@ -26,9 +26,6 @@ urlpatterns = (
     ),
     re_path(r'^queue/', include(queue_urls())),
     re_path(
-        r'^queue/reviews$', views.queue_moderated, name='reviewers.queue_moderated'
-    ),
-    re_path(
         r'^moderationlog$',
         views.ratings_moderation_log,
         name='reviewers.ratings_moderation_log',

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -370,7 +370,7 @@ class MadReviewTable(AddonQueueTable):
         )
 
 
-class ModerationQueueFields:
+class ModerationQueueTable:
     title = 'Rating Reviews'
     urlname = 'queue_moderated'
     url = r'^reviews$'

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -369,6 +369,14 @@ class MadReviewTable(AddonQueueTable):
         )
 
 
+class ModerationQueueFields:
+    title = 'Rating Reviews'
+    urlname = 'queue_moderated'
+    url = r'^reviews$'
+    permission = amo.permissions.RATINGS_MODERATE
+    show_count_in_dashboard = False
+
+
 class ReviewHelper:
     """
     A class that builds enough to render the form back to the user and

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -66,7 +66,7 @@ class AddonQueueTable(tables.Table):
         accessor='_current_version__autoapprovalsummary__score',
     )
     show_count_in_dashboard = True
-    view = None
+    view_name = 'queue'
 
     class Meta:
         fields = (
@@ -376,7 +376,7 @@ class ModerationQueueFields:
     url = r'^reviews$'
     permission = amo.permissions.RATINGS_MODERATE
     show_count_in_dashboard = False
-    view = None
+    view_name = 'queue_moderated'
 
 
 class ReviewHelper:

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -66,6 +66,7 @@ class AddonQueueTable(tables.Table):
         accessor='_current_version__autoapprovalsummary__score',
     )
     show_count_in_dashboard = True
+    view = None
 
     class Meta:
         fields = (
@@ -375,6 +376,7 @@ class ModerationQueueFields:
     url = r'^reviews$'
     permission = amo.permissions.RATINGS_MODERATE
     show_count_in_dashboard = False
+    view = None
 
 
 class ReviewHelper:

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -93,7 +93,7 @@ from olympia.reviewers.serializers import (
 from olympia.reviewers.utils import (
     ContentReviewTable,
     MadReviewTable,
-    ModerationQueueFields,
+    ModerationQueueTable,
     NewThemesQueueTable,
     PendingManualApprovalQueueTable,
     PendingRejectionTable,
@@ -306,9 +306,6 @@ def save_motd(request):
 
 
 def queue(request, tab):
-    # if tab == 'moderated':
-    #     return queue_moderated(request, tab)
-
     TableObj = reviewer_tables_registry[tab]
 
     @permission_or_tools_listed_view_required(TableObj.permission)
@@ -417,7 +414,7 @@ reviewer_tables_registry = {
     'content_review': ContentReviewTable,
     'mad': MadReviewTable,
     'pending_rejection': PendingRejectionTable,
-    'moderated': ModerationQueueFields,
+    'moderated': ModerationQueueTable,
 }
 
 

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -420,12 +420,6 @@ reviewer_tables_registry = {
     'moderated': ModerationQueueFields,
 }
 
-for queue_type in reviewer_tables_registry:
-    if queue_type == 'moderated':
-        reviewer_tables_registry[queue_type].view = queue_moderated
-    else:
-        reviewer_tables_registry[queue_type].view = queue
-
 
 def determine_channel(channel_as_text):
     """Determine which channel the review is for according to the channel

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -306,8 +306,8 @@ def save_motd(request):
 
 
 def queue(request, tab):
-    if tab == 'moderated':
-        return queue_moderated(request, tab)
+    # if tab == 'moderated':
+    #     return queue_moderated(request, tab)
 
     TableObj = reviewer_tables_registry[tab]
 
@@ -419,6 +419,12 @@ reviewer_tables_registry = {
     'pending_rejection': PendingRejectionTable,
     'moderated': ModerationQueueFields,
 }
+
+for queue_type in reviewer_tables_registry:
+    if queue_type == 'moderated':
+        reviewer_tables_registry[queue_type].view = queue_moderated
+    else:
+        reviewer_tables_registry[queue_type].view = queue
 
 
 def determine_channel(channel_as_text):


### PR DESCRIPTION
Fixes #20721 

Make a table object in utils with the attributes required to be consistent with other queues. Put it in the registry so that the mod queue case is handled everywhere else.
