### PR TITLE
Update mysql-apt-config package in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -464,7 +464,7 @@ commands:
       - run:
           name: Initial setup
           command: |
-            curl -sL https://dev.mysql.com/get/mysql-apt-config_0.8.22-1_all.deb --output mysql-apt-config.deb
+            curl -sL https://dev.mysql.com/get/mysql-apt-config_0.8.24-1_all.deb --output mysql-apt-config.deb
             sudo dpkg -i mysql-apt-config.deb
             sudo apt-get update -q
             sudo apt-get install -y gettext pngcrush librsvg2-bin libmysqlclient-dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -464,7 +464,7 @@ commands:
       - run:
           name: Initial setup
           command: |
-            curl -sL https://dev.mysql.com/get/mysql-apt-config_0.8.24-1_all.deb --output mysql-apt-config.deb
+            curl -sL https://repo.mysql.com/mysql-apt-config_0.8.24-1_all.deb --output mysql-apt-config.deb
             sudo dpkg -i mysql-apt-config.deb
             sudo apt-get update -q
             sudo apt-get install -y gettext pngcrush librsvg2-bin libmysqlclient-dev


### PR DESCRIPTION
Also switch to the domain that should match MySQL's debian repository, with the hope that it could help our CI intermittent failures.