### PR TITLE
Support browser_specific_settings.gecko_android manifest key

### DIFF
--- a/src/olympia/constants/base.py
+++ b/src/olympia/constants/base.py
@@ -349,8 +349,12 @@ DEFAULT_WEBEXT_DICT_MIN_VERSION_FIREFOX = '61.0'
 
 # The version of Firefox that first supported manifest version 3 (MV3)
 DEFAULT_WEBEXT_MIN_VERSION_MV3_FIREFOX = '109.0a1'
+
 # We don't know if the Android min version will be different, but assume it might be.
 DEFAULT_WEBEXT_MIN_VERSION_MV3_ANDROID = DEFAULT_WEBEXT_MIN_VERSION_MV3_FIREFOX
+
+# The version of Firefox for Android that first supported `gecko_android` key.
+DEFAULT_WEBEXT_MIN_VERSION_GECKO_ANDROID = '113.0'
 
 ADDON_GUID_PATTERN = re.compile(
     # Match {uuid} or something@host.tld ("something" being optional)

--- a/src/olympia/files/tests/test_utils.py
+++ b/src/olympia/files/tests/test_utils.py
@@ -57,10 +57,13 @@ class AppVersionsMixin:
         cls.create_appversion('android', amo.DEFAULT_WEBEXT_MIN_VERSION_MV3_ANDROID)
         cls.create_appversion('firefox', amo.DEFAULT_WEBEXT_MIN_VERSION_GECKO_ANDROID)
         cls.create_appversion('android', amo.DEFAULT_WEBEXT_MIN_VERSION_GECKO_ANDROID)
-        cls.create_appversion('firefox', '114.0')
-        cls.create_appversion('android', '114.0')
-        cls.create_appversion('firefox', '114.*')
-        cls.create_appversion('android', '114.*')
+        # Some additional test versions:
+        cls.HIGHER_THAN_EVERYTHING_ELSE = '114.0'
+        cls.HIGHER_THAN_EVERYTHING_ELSE_STAR = '114.*'
+        cls.create_appversion('firefox', cls.HIGHER_THAN_EVERYTHING_ELSE)
+        cls.create_appversion('android', cls.HIGHER_THAN_EVERYTHING_ELSE)
+        cls.create_appversion('firefox', cls.HIGHER_THAN_EVERYTHING_ELSE_STAR)
+        cls.create_appversion('android', cls.HIGHER_THAN_EVERYTHING_ELSE_STAR)
 
 
 class TestManifestJSONExtractor(AppVersionsMixin, TestCase):
@@ -368,8 +371,8 @@ class TestManifestJSONExtractor(AppVersionsMixin, TestCase):
         data = {
             'browser_specific_settings': {
                 'gecko_android': {
-                    'strict_min_version': '114.0',
-                    'strict_max_version': '114.*',
+                    'strict_min_version': self.HIGHER_THAN_EVERYTHING_ELSE,
+                    'strict_max_version': self.HIGHER_THAN_EVERYTHING_ELSE_STAR,
                 }
             }
         }
@@ -383,8 +386,8 @@ class TestManifestJSONExtractor(AppVersionsMixin, TestCase):
         # gecko_android is present with both min and max versions.
         app = apps[1]
         assert app.appdata == amo.ANDROID
-        assert app.min.version == '114.0'
-        assert app.max.version == '114.*'
+        assert app.min.version == self.HIGHER_THAN_EVERYTHING_ELSE
+        assert app.max.version == self.HIGHER_THAN_EVERYTHING_ELSE_STAR
 
     def test_gecko_android_strict_min_max_with_gecko_alongside(self):
         data = {
@@ -393,8 +396,8 @@ class TestManifestJSONExtractor(AppVersionsMixin, TestCase):
                     'strict_min_version': '53.0',
                 },
                 'gecko_android': {
-                    'strict_min_version': '114.0',
-                    'strict_max_version': '114.*',
+                    'strict_min_version': self.HIGHER_THAN_EVERYTHING_ELSE,
+                    'strict_max_version': self.HIGHER_THAN_EVERYTHING_ELSE_STAR,
                 },
             }
         }
@@ -408,17 +411,17 @@ class TestManifestJSONExtractor(AppVersionsMixin, TestCase):
         # gecko_android is present with both min and max versions.
         app = apps[1]
         assert app.appdata == amo.ANDROID
-        assert app.min.version == '114.0'
-        assert app.max.version == '114.*'
+        assert app.min.version == self.HIGHER_THAN_EVERYTHING_ELSE
+        assert app.max.version == self.HIGHER_THAN_EVERYTHING_ELSE_STAR
 
     def test_gecko_android_strict_min_default_max_with_gecko_alongside(self):
         data = {
             'browser_specific_settings': {
                 'gecko': {
-                    'strict_max_version': '114.*',
+                    'strict_max_version': self.HIGHER_THAN_EVERYTHING_ELSE_STAR,
                 },
                 'gecko_android': {
-                    'strict_min_version': '114.0',
+                    'strict_min_version': self.HIGHER_THAN_EVERYTHING_ELSE,
                 },
             }
         }
@@ -427,13 +430,13 @@ class TestManifestJSONExtractor(AppVersionsMixin, TestCase):
         app = apps[0]
         assert app.appdata == amo.FIREFOX
         assert app.min.version == amo.DEFAULT_WEBEXT_MIN_VERSION_NO_ID
-        assert app.max.version == '114.*'
+        assert app.max.version == self.HIGHER_THAN_EVERYTHING_ELSE_STAR
 
         # we fall back on gecko's strict_max_version since it was specified.
         app = apps[1]
         assert app.appdata == amo.ANDROID
-        assert app.min.version == '114.0'
-        assert app.max.version == '114.*'
+        assert app.min.version == self.HIGHER_THAN_EVERYTHING_ELSE
+        assert app.max.version == self.HIGHER_THAN_EVERYTHING_ELSE_STAR
 
     def test_gecko_android_min_too_low(self):
         data = {
@@ -955,8 +958,8 @@ class TestManifestJSONExtractorStaticTheme(TestManifestJSONExtractor):
         data = {
             'browser_specific_settings': {
                 'gecko_android': {
-                    'strict_min_version': '114.0',
-                    'strict_max_version': '114.*',
+                    'strict_min_version': self.HIGHER_THAN_EVERYTHING_ELSE,
+                    'strict_max_version': self.HIGHER_THAN_EVERYTHING_ELSE_STAR,
                 }
             }
         }
@@ -975,8 +978,8 @@ class TestManifestJSONExtractorStaticTheme(TestManifestJSONExtractor):
                     'strict_min_version': '53.0',
                 },
                 'gecko_android': {
-                    'strict_min_version': '114.0',
-                    'strict_max_version': '114.*',
+                    'strict_min_version': self.HIGHER_THAN_EVERYTHING_ELSE,
+                    'strict_max_version': self.HIGHER_THAN_EVERYTHING_ELSE_STAR,
                 },
             }
         }
@@ -992,10 +995,10 @@ class TestManifestJSONExtractorStaticTheme(TestManifestJSONExtractor):
         data = {
             'browser_specific_settings': {
                 'gecko': {
-                    'strict_max_version': '114.*',
+                    'strict_max_version': self.HIGHER_THAN_EVERYTHING_ELSE_STAR,
                 },
                 'gecko_android': {
-                    'strict_min_version': '114.0',
+                    'strict_min_version': self.HIGHER_THAN_EVERYTHING_ELSE,
                 },
             }
         }
@@ -1004,7 +1007,7 @@ class TestManifestJSONExtractorStaticTheme(TestManifestJSONExtractor):
         app = apps[0]
         assert app.appdata == amo.FIREFOX
         assert app.min.version == amo.DEFAULT_STATIC_THEME_MIN_VERSION_FIREFOX
-        assert app.max.version == '114.*'
+        assert app.max.version == self.HIGHER_THAN_EVERYTHING_ELSE_STAR
 
     def test_gecko_android_min_too_low(self):
         # Overridden because static themes are not compatible with Android.

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -229,13 +229,14 @@ class ManifestJSONExtractor:
     def get_strict_version_for(self, *, key, application):
         strict_key = f'strict_{key}_version'
         if application == amo.FIREFOX:
-            return get_simple_version(self.gecko.get(strict_key))
+            strict_version_value = self.gecko.get(strict_key)
         elif application == amo.ANDROID:
-            return get_simple_version(
-                self.gecko_android.get(strict_key, self.gecko.get(strict_key))
+            strict_version_value = self.gecko_android.get(
+                strict_key, self.gecko.get(strict_key)
             )
         else:
-            return get_simple_version(None)
+            strict_version_value = None
+        return get_simple_version(strict_version_value)
 
     @property
     def install_origins(self):

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -127,14 +127,6 @@ class DuplicateAddonID(forms.ValidationError):
     pass
 
 
-def get_appversions(app, min_version, max_version):
-    """Return the `AppVersion`s that correspond to the given versions."""
-    qs = AppVersion.objects.filter(application=app.id)
-    min_appver = qs.get(version=min_version)
-    max_appver = qs.get(version=max_version)
-    return min_appver, max_appver
-
-
 def get_simple_version(version_string):
     """Extract the version number without the ><= requirements, returning a
     VersionString instance.
@@ -214,6 +206,11 @@ class ManifestJSONExtractor:
         return parent_block.get('gecko', {})
 
     @property
+    def gecko_android(self):
+        """Return `browser_specific_settings.gecko_android` if present."""
+        return self.get('browser_specific_settings', {}).get('gecko_android', {})
+
+    @property
     def guid(self):
         return str(self.gecko.get('id', None) or '') or None
 
@@ -229,13 +226,16 @@ class ManifestJSONExtractor:
             else amo.ADDON_EXTENSION
         )
 
-    @property
-    def strict_max_version(self):
-        return get_simple_version(self.gecko.get('strict_max_version'))
-
-    @property
-    def strict_min_version(self):
-        return get_simple_version(self.gecko.get('strict_min_version'))
+    def get_strict_version_for(self, *, key, application):
+        strict_key = f'strict_{key}_version'
+        if application == amo.FIREFOX:
+            return get_simple_version(self.gecko.get(strict_key))
+        elif application == amo.ANDROID:
+            return get_simple_version(
+                self.gecko_android.get(strict_key, self.gecko.get(strict_key))
+            )
+        else:
+            return get_simple_version(None)
 
     @property
     def install_origins(self):
@@ -267,17 +267,19 @@ class ManifestJSONExtractor:
             # WebExt dicts are only compatible with Firefox desktop >= 61.
             apps = ((amo.FIREFOX, amo.DEFAULT_WEBEXT_DICT_MIN_VERSION_FIREFOX),)
         else:
-            webext_min = (
+            webext_min_firefox = (
                 amo.DEFAULT_WEBEXT_MIN_VERSION
                 if self.get('browser_specific_settings', None) is None
                 else amo.DEFAULT_WEBEXT_MIN_VERSION_BROWSER_SPECIFIC
             )
-            # amo.DEFAULT_WEBEXT_MIN_VERSION_BROWSER_SPECIFIC should be 48.0,
-            # which is the same as amo.DEFAULT_WEBEXT_MIN_VERSION_ANDROID, so
-            # no specific treatment for Android.
+            webext_min_android = (
+                amo.DEFAULT_WEBEXT_MIN_VERSION_GECKO_ANDROID
+                if self.gecko_android
+                else amo.DEFAULT_WEBEXT_MIN_VERSION_ANDROID
+            )
             apps = (
-                (amo.FIREFOX, webext_min),
-                (amo.ANDROID, amo.DEFAULT_WEBEXT_MIN_VERSION_ANDROID),
+                (amo.FIREFOX, webext_min_firefox),
+                (amo.ANDROID, webext_min_android),
             )
 
         if self.get('manifest_version') == 3:
@@ -291,9 +293,13 @@ class ManifestJSONExtractor:
                 for app, ver in apps
             )
 
+        strict_min_version_firefox = self.get_strict_version_for(
+            key='min', application=amo.FIREFOX
+        )
+
         doesnt_support_no_id = (
-            self.strict_min_version
-            and self.strict_min_version
+            strict_min_version_firefox
+            and strict_min_version_firefox
             < VersionString(amo.DEFAULT_WEBEXT_MIN_VERSION_NO_ID)
         )
 
@@ -305,15 +311,17 @@ class ManifestJSONExtractor:
         # If a minimum strict version is specified, it needs to be higher
         # than the version when Firefox started supporting WebExtensions.
         unsupported_no_matter_what = (
-            self.strict_min_version
-            and self.strict_min_version < VersionString(amo.DEFAULT_WEBEXT_MIN_VERSION)
+            strict_min_version_firefox
+            and strict_min_version_firefox
+            < VersionString(amo.DEFAULT_WEBEXT_MIN_VERSION)
         )
         if unsupported_no_matter_what:
             msg = gettext('Lowest supported "strict_min_version" is 42.0.')
             raise forms.ValidationError(msg)
 
         for app, default_min_version in apps:
-            if self.guid is None and not self.strict_min_version:
+            strict_min_version = self.get_strict_version_for(key='min', application=app)
+            if self.guid is None and not strict_min_version:
                 strict_min_version = max(
                     VersionString(amo.DEFAULT_WEBEXT_MIN_VERSION_NO_ID),
                     VersionString(default_min_version),
@@ -322,12 +330,12 @@ class ManifestJSONExtractor:
                 # strict_min_version for this app shouldn't be lower than the
                 # default min version for this app.
                 strict_min_version = max(
-                    self.strict_min_version, VersionString(default_min_version)
+                    strict_min_version, VersionString(default_min_version)
                 )
 
-            strict_max_version = self.strict_max_version or VersionString(
-                amo.DEFAULT_WEBEXT_MAX_VERSION
-            )
+            strict_max_version = self.get_strict_version_for(
+                key='max', application=app
+            ) or VersionString(amo.DEFAULT_WEBEXT_MAX_VERSION)
 
             if strict_max_version < strict_min_version:
                 strict_max_version = strict_min_version


### PR DESCRIPTION
Note: if an add-on uses `gecko_android`, AMO will force the  minimum Firefox for Android version it's compatible with to be 113.0 (or higher if it was specified). That matches the first Firefox for Android version that was released with support for that manifest key.

Fixes #20530