### PR TITLE
Add two trusted GCP domains

### DIFF
--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -27,6 +27,8 @@ if os.path.exists(ENVIRON_SETTINGS_FILE_PATH):
 
 ALLOWED_HOSTS = [
     '.allizom.org',
+    '.amo.nonprod.webservices.mozgcp.net',
+    '.amo.prod.webservices.mozgcp.net',
     '.mozilla.org',
     '.mozilla.com',
     '.mozilla.net',


### PR DESCRIPTION
Fixes #20804 

Since we're moving AMO to GCP, we'd like to add two trusted domains to the ALLOWED_HOSTS list. These are domains managed and controlled by us and in our GCP projects.

