### PR TITLE
Record set/clear needs human review and clear pending rejection by version

### DIFF
--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -869,6 +869,7 @@ class LOG_IN_API_TOKEN(_LOG):
     format = '{user_responsible} authenticated through an API token.'
 
 
+# Obsolete now that this is done per version.
 class CLEAR_NEEDS_HUMAN_REVIEWS(_LOG):
     id = 173
     format = '{addon} no longer flagged for human review.'
@@ -878,7 +879,7 @@ class CLEAR_NEEDS_HUMAN_REVIEWS(_LOG):
     reviewer_review_action = True
 
 
-class NEEDS_HUMAN_REVIEW(_LOG):
+class NEEDS_HUMAN_REVIEW_AUTOMATIC(_LOG):
     id = 174
     format = '{version} flagged for human review.'
     short = 'Flagged for human review'
@@ -906,11 +907,22 @@ class CLEAR_NEEDS_HUMAN_REVIEW_VERSION(_LOG):
 
 class CLEAR_PENDING_REJECTION(_LOG):
     id = 177
-    format = '{version} pending rejection cleared.'
-    short = 'Pending rejection cleared'
+    format = _('{version} pending rejection cleared.')
+    short = _('Pending rejection cleared')
     keep = True
     review_queue = True
     reviewer_review_action = True
+    # Not hiddden to developers.
+
+
+class NEEDS_HUMAN_REVIEW(_LOG):
+    id = 178
+    format = '{version} flagged for human review.'
+    short = 'Flagged for human review'
+    keep = True
+    review_queue = True
+    reviewer_review_action = True
+    hide_developer = True
 
 
 LOGS = [x for x in vars().values() if isclass(x) and issubclass(x, _LOG) and x != _LOG]

--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -880,7 +880,7 @@ class CLEAR_NEEDS_HUMAN_REVIEWS(_LOG):
 
 class NEEDS_HUMAN_REVIEW(_LOG):
     id = 174
-    format = '{version} flagged for human review because of {0}.'
+    format = '{version} flagged for human review.'
     short = 'Flagged for human review'
     keep = True
     hide_developer = True
@@ -892,6 +892,25 @@ class REPLY_RATING(_LOG):
     format = _('Reply to {rating} for {addon} written.')
     show_user_to_developer = True
     store_ip = True
+
+
+class CLEAR_NEEDS_HUMAN_REVIEW_VERSION(_LOG):
+    id = 176
+    format = '{version} no longer flagged for human review.'
+    short = 'Needs Human Review cleared'
+    admin_event = True
+    review_queue = True
+    reviewer_review_action = True
+    hide_developer = True
+
+
+class CLEAR_PENDING_REJECTION(_LOG):
+    id = 177
+    format = '{version} pending rejection cleared.'
+    short = 'Pending rejection cleared'
+    keep = True
+    review_queue = True
+    reviewer_review_action = True
 
 
 LOGS = [x for x in vars().values() if isclass(x) and issubclass(x, _LOG) and x != _LOG]

--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -870,7 +870,7 @@ class LOG_IN_API_TOKEN(_LOG):
 
 
 # Obsolete now that this is done per version.
-class CLEAR_NEEDS_HUMAN_REVIEWS(_LOG):
+class CLEAR_NEEDS_HUMAN_REVIEWS_LEGACY(_LOG):
     id = 173
     format = '{addon} no longer flagged for human review.'
     short = 'Needs Human Review cleared'
@@ -895,7 +895,7 @@ class REPLY_RATING(_LOG):
     store_ip = True
 
 
-class CLEAR_NEEDS_HUMAN_REVIEW_VERSION(_LOG):
+class CLEAR_NEEDS_HUMAN_REVIEW(_LOG):
     id = 176
     format = '{version} no longer flagged for human review.'
     short = 'Needs Human Review cleared'

--- a/src/olympia/reviewers/models.py
+++ b/src/olympia/reviewers/models.py
@@ -781,7 +781,8 @@ class NeedsHumanReview(ModelBase):
         return f'{self.version_id} - {self.get_reason_display()}'
 
     def save(self, *args, **kwargs):
-        if not self.pk:
+        automatic_activity_log = not kwargs.pop('_no_automatic_activity_log', False)
+        if not self.pk and automatic_activity_log:
             activity.log_create(
                 amo.LOG.NEEDS_HUMAN_REVIEW,
                 self.version,

--- a/src/olympia/reviewers/models.py
+++ b/src/olympia/reviewers/models.py
@@ -784,7 +784,7 @@ class NeedsHumanReview(ModelBase):
         automatic_activity_log = not kwargs.pop('_no_automatic_activity_log', False)
         if not self.pk and automatic_activity_log:
             activity.log_create(
-                amo.LOG.NEEDS_HUMAN_REVIEW,
+                amo.LOG.NEEDS_HUMAN_REVIEW_AUTOMATIC,
                 self.version,
                 details={'comments': self.get_reason_display()},
                 user=(

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -263,13 +263,6 @@
 
     {% if is_admin %}
     <ul class="admin_only">
-      {% if not addon.is_deleted and version %}
-        <li>
-          <button data-api-url="{{ drf_url('reviewers-addon-set-needs-human-review', addon.pk) }}"
-                  data-api-data="{&quot;version&quot;: {{ version.pk }}}"
-                  id="set_needs_human_review" type="button">Set "Needs Human Review"</button>
-        </li>
-      {% endif %}
       <li {% if not version.due_date %}class="hidden"{% endif %}>
         <label for="due_date_update">Change latest version review due date</label>
         <input type="datetime-local" id="due_date_update"
@@ -389,13 +382,6 @@
                       id="clear_auto_approval_delayed_until_unlisted" class="oneoff" type="button">Clear Unlisted Auto-Approval Extra Delay</button>
             </li>
           {% endif %}
-        {% endif %}
-
-        {% if has_versions_pending_rejection %}
-          <li>
-              <button data-api-url="{{ drf_url('reviewers-addon-clear-pending-rejections', addon.pk) }}"
-                      id="clear_pending_rejections" class="oneoff" type="button">Clear pending rejections</button>
-          </li>
         {% endif %}
 
         {% if addon.needs_admin_theme_review %}

--- a/src/olympia/reviewers/tests/test_forms.py
+++ b/src/olympia/reviewers/tests/test_forms.py
@@ -56,19 +56,29 @@ class TestReviewForm(TestCase):
         assert force_str(action).startswith('This will reject this version')
 
     def test_actions_addon_status_null(self):
-        # If the add-on is null we only show reply, comment and super review.
+        # If the add-on is null we only show set needs human review, reply,
+        # comment.
         self.grant_permission(self.request.user, 'Addons:Review')
         actions = self.set_statuses_and_get_actions(
             addon_status=amo.STATUS_NULL, file_status=amo.STATUS_DISABLED
         )
         self.version.update(human_review_date=datetime.now())
-        assert list(actions.keys()) == ['reply', 'comment']
+        assert list(actions.keys()) == [
+            'set_needs_human_review_multiple_versions',
+            'reply',
+            'comment',
+        ]
 
-        # If an admin reviewer we also show unreject_latest_version
+        # If an admin reviewer we also show unreject_latest_version and clear
+        # pending rejection/needs human review (though the versions form would
+        # be empty for the last 2 here).
         self.grant_permission(self.request.user, 'Reviews:Admin')
         actions = self.get_form().helper.get_actions()
         assert list(actions.keys()) == [
             'unreject_latest_version',
+            'clear_pending_rejection_multiple_versions',
+            'clear_needs_human_review_multiple_versions',
+            'set_needs_human_review_multiple_versions',
             'reply',
             'comment',
         ]
@@ -87,11 +97,13 @@ class TestReviewForm(TestCase):
             'reject_multiple_versions',
             'block_multiple_versions',
             'confirm_multiple_versions',
+            'set_needs_human_review_multiple_versions',
             'reply',
             'comment',
         ]
 
-        # If an admin reviewer we also show unreject_multiple_versions
+        # If an admin reviewer we also show unreject_multiple_versions,
+        # clear pending rejections/clear needs human review.
         self.grant_permission(self.request.user, 'Reviews:Admin')
         actions = self.get_form().helper.get_actions()
         assert list(actions.keys()) == [
@@ -100,6 +112,9 @@ class TestReviewForm(TestCase):
             'unreject_multiple_versions',
             'block_multiple_versions',
             'confirm_multiple_versions',
+            'clear_pending_rejection_multiple_versions',
+            'clear_needs_human_review_multiple_versions',
+            'set_needs_human_review_multiple_versions',
             'reply',
             'comment',
         ]
@@ -111,7 +126,11 @@ class TestReviewForm(TestCase):
         actions = self.set_statuses_and_get_actions(
             addon_status=amo.STATUS_DELETED, file_status=amo.STATUS_DISABLED
         )
-        assert list(actions.keys()) == ['reply', 'comment']
+        assert list(actions.keys()) == [
+            'set_needs_human_review_multiple_versions',
+            'reply',
+            'comment',
+        ]
 
     def test_actions_no_pending_files(self):
         # If the add-on has no pending files we only show
@@ -122,6 +141,7 @@ class TestReviewForm(TestCase):
         )
         assert list(actions.keys()) == [
             'reject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
             'reply',
             'comment',
         ]
@@ -131,7 +151,11 @@ class TestReviewForm(TestCase):
         actions = self.set_statuses_and_get_actions(
             addon_status=amo.STATUS_DISABLED, file_status=amo.STATUS_DISABLED
         )
-        assert list(actions.keys()) == ['reply', 'comment']
+        assert list(actions.keys()) == [
+            'set_needs_human_review_multiple_versions',
+            'reply',
+            'comment',
+        ]
 
     def test_reasons(self):
         self.reason_a = ReviewActionReason.objects.create(
@@ -316,7 +340,14 @@ class TestReviewForm(TestCase):
         assert form.fields['versions'].required is False
         assert list(form.fields['versions'].queryset) == [self.addon.current_version]
 
-    def test_versions_queryset_contains_pending_files_for_listed(self):
+    def test_versions_queryset_contains_pending_files_for_listed(
+        self, expected_select_data_value=None
+    ):
+        if expected_select_data_value is None:
+            expected_select_data_value = [
+                'reject_multiple_versions',
+                'set_needs_human_review_multiple_versions',
+            ]
         # We hide some of the versions using JavaScript + some data attributes on each
         # <option>.
         # The queryset should contain both pending, rejected, and approved versions.
@@ -363,55 +394,72 @@ class TestReviewForm(TestCase):
         # show/hide it depending on action in JavaScript.
         select = doc('select')[0]
         assert select.attrib.get('class') == 'data-toggle'
-        assert select.attrib.get('data-value') == 'reject_multiple_versions'
+        assert select.attrib.get('data-value').split(' ') == expected_select_data_value
 
         # <option>s should as well, and the value depends on which version:
         # the approved one and the pending one should have different values.
         assert len(doc('option')) == 4
         option1 = doc('option[value="%s"]' % self.version.pk)[0]
         assert option1.attrib.get('class') == 'data-toggle'
-        assert option1.attrib.get('data-value') == (
+        assert option1.attrib.get('data-value').split(' ') == [
             # That version is approved.
-            'block_multiple_versions reject_multiple_versions'
-        )
+            'block_multiple_versions',
+            'reject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
+        ]
         assert option1.attrib.get('value') == str(self.version.pk)
 
         option2 = doc('option[value="%s"]' % pending_version.pk)[0]
         assert option2.attrib.get('class') == 'data-toggle'
-        assert option2.attrib.get('data-value') == (
+        assert option2.attrib.get('data-value').split(' ') == [
             # That version is pending.
-            'approve_multiple_versions reject_multiple_versions'
-        )
+            'approve_multiple_versions',
+            'reject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
+        ]
         assert option2.attrib.get('value') == str(pending_version.pk)
 
         option3 = doc('option[value="%s"]' % rejected_version.pk)[0]
         assert option3.attrib.get('class') == 'data-toggle'
-        assert option3.attrib.get('data-value') == (
+        assert option3.attrib.get('data-value').split(' ') == [
             # That version is rejected.
-            'unreject_multiple_versions'
-        )
+            'unreject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
+        ]
         assert option3.attrib.get('value') == str(rejected_version.pk)
 
         option4 = doc('option[value="%s"]' % blocked_version.pk)[0]
         assert option4.attrib.get('class') == 'data-toggle'
-        assert option4.attrib.get('data-value') == (
+        assert option4.attrib.get('data-value').split(' ') == [
             # That version is blocked, so unreject_multiple_versions is unavailable.
-            ''
-        )
+            'set_needs_human_review_multiple_versions',
+        ]
         assert option4.attrib.get('value') == str(blocked_version.pk)
 
     def test_versions_queryset_contains_pending_files_for_listed_admin_reviewer(self):
         self.grant_permission(self.request.user, 'Reviews:Admin')
         # No change
-        self.test_versions_queryset_contains_pending_files_for_listed()
+        self.test_versions_queryset_contains_pending_files_for_listed(
+            expected_select_data_value=[
+                'reject_multiple_versions',
+                'clear_pending_rejection_multiple_versions',
+                'clear_needs_human_review_multiple_versions',
+                'set_needs_human_review_multiple_versions',
+            ]
+        )
 
     def test_versions_queryset_contains_pending_files_for_unlisted(
         self,
-        select_data_value=(
-            'approve_multiple_versions reject_multiple_versions '
-            'block_multiple_versions confirm_multiple_versions'
-        ),
+        expected_select_data_value=None,
     ):
+        if expected_select_data_value is None:
+            expected_select_data_value = [
+                'approve_multiple_versions',
+                'reject_multiple_versions',
+                'block_multiple_versions',
+                'confirm_multiple_versions',
+                'set_needs_human_review_multiple_versions',
+            ]
         # We hide some of the versions using JavaScript + some data attributes on each
         # <option>.
         # The queryset should contain both pending, rejected, and approved versions.
@@ -466,51 +514,61 @@ class TestReviewForm(TestCase):
         # show/hide it depending on action in JavaScript.
         select = doc('select')[0]
         assert select.attrib.get('class') == 'data-toggle'
-        assert select.attrib.get('data-value') == select_data_value
+        assert select.attrib.get('data-value').split(' ') == expected_select_data_value
 
         # <option>s should as well, and the value depends on which version:
         # the approved one and the pending one should have different values.
         assert len(doc('option')) == 4
         option1 = doc('option[value="%s"]' % self.version.pk)[0]
         assert option1.attrib.get('class') == 'data-toggle'
-        assert option1.attrib.get('data-value') == (
+        assert option1.attrib.get('data-value').split(' ') == [
             # That version is approved.
-            'block_multiple_versions confirm_multiple_versions'
-        )
+            'block_multiple_versions',
+            'confirm_multiple_versions',
+            'set_needs_human_review_multiple_versions',
+        ]
         assert option1.attrib.get('value') == str(self.version.pk)
 
         option2 = doc('option[value="%s"]' % pending_version.pk)[0]
         assert option2.attrib.get('class') == 'data-toggle'
-        assert option2.attrib.get('data-value') == (
+        assert option2.attrib.get('data-value').split(' ') == [
             # That version is pending.
-            'approve_multiple_versions reject_multiple_versions'
-        )
+            'approve_multiple_versions',
+            'reject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
+        ]
         assert option2.attrib.get('value') == str(pending_version.pk)
 
         option3 = doc('option[value="%s"]' % rejected_version.pk)[0]
         assert option3.attrib.get('class') == 'data-toggle'
-        assert option3.attrib.get('data-value') == (
+        assert option3.attrib.get('data-value').split(' ') == [
             # That version is rejected.
-            'unreject_multiple_versions'
-        )
+            'unreject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
+        ]
         assert option3.attrib.get('value') == str(rejected_version.pk)
 
         option4 = doc('option[value="%s"]' % blocked_version.pk)[0]
         assert option4.attrib.get('class') == 'data-toggle'
-        assert option4.attrib.get('data-value') == (
+        assert option4.attrib.get('data-value').split(' ') == [
             # That version is blocked, so unreject_multiple_versions is unavailable.
-            ''
-        )
+            'set_needs_human_review_multiple_versions',
+        ]
         assert option4.attrib.get('value') == str(blocked_version.pk)
 
     def test_versions_queryset_contains_pending_files_for_unlisted_admin_reviewer(self):
         self.grant_permission(self.request.user, 'Reviews:Admin')
         self.test_versions_queryset_contains_pending_files_for_unlisted(
-            select_data_value=(
-                'approve_multiple_versions reject_multiple_versions '
-                'unreject_multiple_versions block_multiple_versions '
-                'confirm_multiple_versions'
-            )
+            expected_select_data_value=[
+                'approve_multiple_versions',
+                'reject_multiple_versions',
+                'unreject_multiple_versions',
+                'block_multiple_versions',
+                'confirm_multiple_versions',
+                'clear_pending_rejection_multiple_versions',
+                'clear_needs_human_review_multiple_versions',
+                'set_needs_human_review_multiple_versions',
+            ]
         )
 
     def test_versions_required(self):

--- a/src/olympia/reviewers/tests/test_models.py
+++ b/src/olympia/reviewers/tests/test_models.py
@@ -1697,7 +1697,7 @@ class TestNeedsHumanReview(TestCase):
         assert needs_human_review.is_active  # Defaults to active.
         assert ActivityLog.objects.for_versions(self.version).count() == 1
         activity = ActivityLog.objects.for_versions(self.version).get()
-        assert activity.action == amo.LOG.NEEDS_HUMAN_REVIEW.id
+        assert activity.action == amo.LOG.NEEDS_HUMAN_REVIEW_AUTOMATIC.id
         assert activity.user.pk == settings.TASK_USER_ID
 
     def test_save_new_record_activity_with_core_get_user(self):
@@ -1709,7 +1709,7 @@ class TestNeedsHumanReview(TestCase):
         assert needs_human_review.is_active  # Defaults to active.
         assert ActivityLog.objects.for_versions(self.version).count() == 1
         activity = ActivityLog.objects.for_versions(self.version).get()
-        assert activity.action == amo.LOG.NEEDS_HUMAN_REVIEW.id
+        assert activity.action == amo.LOG.NEEDS_HUMAN_REVIEW_AUTOMATIC.id
         assert activity.user.pk == self.user.pk
 
     def test_save_existing_does_not_record_an_activity(self):

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -219,6 +219,7 @@ class TestReviewHelper(TestReviewHelperBase):
             'public',
             'reject',
             'reject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
             'reply',
             'comment',
         ]
@@ -238,6 +239,7 @@ class TestReviewHelper(TestReviewHelperBase):
             'public',
             'reject',
             'reject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
             'reply',
             'comment',
         ]
@@ -253,7 +255,12 @@ class TestReviewHelper(TestReviewHelperBase):
 
     def test_actions_full_nonpending(self):
         self.grant_permission(self.user, 'Addons:Review')
-        expected = ['reject_multiple_versions', 'reply', 'comment']
+        expected = [
+            'reject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
+            'reply',
+            'comment',
+        ]
         f_statuses = [amo.STATUS_APPROVED, amo.STATUS_DISABLED]
         for file_status in f_statuses:
             assert (
@@ -267,7 +274,12 @@ class TestReviewHelper(TestReviewHelperBase):
 
     def test_actions_public_post_review(self):
         self.grant_permission(self.user, 'Addons:Review')
-        expected = ['reject_multiple_versions', 'reply', 'comment']
+        expected = [
+            'reject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
+            'reply',
+            'comment',
+        ]
         assert (
             list(
                 self.get_review_actions(
@@ -284,6 +296,7 @@ class TestReviewHelper(TestReviewHelperBase):
         expected = [
             'confirm_auto_approved',
             'reject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
             'reply',
             'comment',
         ]
@@ -297,7 +310,8 @@ class TestReviewHelper(TestReviewHelperBase):
         )
 
         # Now make add a recommended promoted addon. The user should lose all
-        # approve/reject actions.
+        # approve/reject actions (they are no longer considered an
+        # "appropriate" reviewer for that add-on).
         self.make_addon_promoted(self.addon, RECOMMENDED)
         expected = ['reply', 'comment']
         assert (
@@ -314,6 +328,7 @@ class TestReviewHelper(TestReviewHelperBase):
         expected = [
             'approve_content',
             'reject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
             'reply',
             'comment',
         ]
@@ -335,6 +350,7 @@ class TestReviewHelper(TestReviewHelperBase):
         expected = [
             'approve_content',
             'reject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
             'reply',
             'comment',
         ]
@@ -373,6 +389,7 @@ class TestReviewHelper(TestReviewHelperBase):
             'public',
             'reject',
             'reject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
             'reply',
             'super',
             'comment',
@@ -432,6 +449,7 @@ class TestReviewHelper(TestReviewHelperBase):
             'public',
             'reject',
             'reject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
             'reply',
             'comment',
         ]
@@ -468,6 +486,7 @@ class TestReviewHelper(TestReviewHelperBase):
         expected = [
             'approve_content',
             'reject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
             'reply',
             'comment',
         ]
@@ -513,6 +532,7 @@ class TestReviewHelper(TestReviewHelperBase):
             'public',
             'reject',
             'reject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
             'reply',
             'comment',
         ]
@@ -547,6 +567,9 @@ class TestReviewHelper(TestReviewHelperBase):
             'public',
             'reject',
             'reject_multiple_versions',
+            'clear_pending_rejection_multiple_versions',
+            'clear_needs_human_review_multiple_versions',
+            'set_needs_human_review_multiple_versions',
             'reply',
             'comment',
         ]
@@ -583,6 +606,7 @@ class TestReviewHelper(TestReviewHelperBase):
             'reject_multiple_versions',
             'block_multiple_versions',
             'confirm_multiple_versions',
+            'set_needs_human_review_multiple_versions',
             'reply',
             'comment',
         ]
@@ -615,6 +639,9 @@ class TestReviewHelper(TestReviewHelperBase):
             'unreject_multiple_versions',
             'block_multiple_versions',
             'confirm_multiple_versions',
+            'clear_pending_rejection_multiple_versions',
+            'clear_needs_human_review_multiple_versions',
+            'set_needs_human_review_multiple_versions',
             'reply',
             'comment',
         ]
@@ -634,6 +661,7 @@ class TestReviewHelper(TestReviewHelperBase):
             'public',
             'reject',
             'reject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
             'reply',
             'comment',
         ]
@@ -650,7 +678,13 @@ class TestReviewHelper(TestReviewHelperBase):
         # But when the add-on is blocked 'public' shouldn't be available
         block = Block.objects.create(addon=self.addon, updated_by=self.user)
         del self.addon.block
-        expected = ['reject', 'reject_multiple_versions', 'reply', 'comment']
+        expected = [
+            'reject',
+            'reject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
+            'reply',
+            'comment',
+        ]
         assert (
             list(
                 self.get_review_actions(
@@ -667,6 +701,7 @@ class TestReviewHelper(TestReviewHelperBase):
             'public',
             'reject',
             'reject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
             'reply',
             'comment',
         ]
@@ -697,6 +732,7 @@ class TestReviewHelper(TestReviewHelperBase):
             'public',
             'reject',
             'reject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
             'reply',
             'comment',
         ]
@@ -727,6 +763,9 @@ class TestReviewHelper(TestReviewHelperBase):
         expected = [
             'confirm_auto_approved',
             'reject_multiple_versions',
+            'clear_pending_rejection_multiple_versions',
+            'clear_needs_human_review_multiple_versions',
+            'set_needs_human_review_multiple_versions',
             'reply',
             'comment',
         ]
@@ -749,6 +788,9 @@ class TestReviewHelper(TestReviewHelperBase):
             'reject',
             'confirm_auto_approved',
             'reject_multiple_versions',
+            'clear_pending_rejection_multiple_versions',
+            'clear_needs_human_review_multiple_versions',
+            'set_needs_human_review_multiple_versions',
             'reply',
             'comment',
         ]
@@ -766,7 +808,7 @@ class TestReviewHelper(TestReviewHelperBase):
 
     def test_actions_disabled_addon(self):
         self.grant_permission(self.user, 'Addons:Review')
-        expected = ['reply', 'comment']
+        expected = ['set_needs_human_review_multiple_versions', 'reply', 'comment']
         actions = list(
             self.get_review_actions(
                 addon_status=amo.STATUS_DISABLED,
@@ -781,7 +823,7 @@ class TestReviewHelper(TestReviewHelperBase):
 
     def test_actions_rejected_version(self):
         self.grant_permission(self.user, 'Addons:Review')
-        expected = ['reply', 'comment']
+        expected = ['set_needs_human_review_multiple_versions', 'reply', 'comment']
 
         self.file.update(status=amo.STATUS_DISABLED)
         self.file.version.update(human_review_date=datetime.now())
@@ -790,14 +832,24 @@ class TestReviewHelper(TestReviewHelperBase):
         assert expected == actions
 
         self.grant_permission(self.user, 'Reviews:Admin')
-        expected = ['unreject_latest_version', 'reply', 'comment']
+        expected = [
+            'unreject_latest_version',
+            'clear_pending_rejection_multiple_versions',
+            'clear_needs_human_review_multiple_versions',
+            'set_needs_human_review_multiple_versions',
+            'reply',
+            'comment',
+        ]
         actions = list(self.get_helper().actions.keys())
         assert expected == actions
 
     def test_actions_non_human_reviewer(self):
         # Note that we aren't granting permissions to our user.
         assert not self.user.groups.all()
-        expected = ['public', 'reject_multiple_versions']
+        expected = [
+            'public',
+            'reject_multiple_versions',
+        ]
         actions = list(
             self.get_review_actions(
                 addon_status=amo.STATUS_APPROVED,
@@ -809,7 +861,7 @@ class TestReviewHelper(TestReviewHelperBase):
 
     def test_actions_deleted_addon(self):
         self.grant_permission(self.user, 'Addons:Review')
-        expected = ['reply', 'comment']
+        expected = ['set_needs_human_review_multiple_versions', 'reply', 'comment']
         actions = list(
             self.get_review_actions(
                 addon_status=amo.STATUS_DELETED,
@@ -821,7 +873,7 @@ class TestReviewHelper(TestReviewHelperBase):
     def test_actions_versions_needing_human_review(self):
         NeedsHumanReview.objects.create(version=self.review_version)
         self.grant_permission(self.user, 'Addons:Review')
-        expected = ['reply', 'comment']
+        expected = ['set_needs_human_review_multiple_versions', 'reply', 'comment']
         actions = list(
             self.get_review_actions(
                 addon_status=amo.STATUS_DELETED,
@@ -831,7 +883,13 @@ class TestReviewHelper(TestReviewHelperBase):
         assert expected == actions
 
         self.grant_permission(self.user, 'Reviews:Admin')
-        expected = ['reply', 'comment', 'clear_needs_human_review']
+        expected = [
+            'clear_pending_rejection_multiple_versions',
+            'clear_needs_human_review_multiple_versions',
+            'set_needs_human_review_multiple_versions',
+            'reply',
+            'comment',
+        ]
         actions = list(
             self.get_review_actions(
                 addon_status=amo.STATUS_DELETED,
@@ -2794,7 +2852,7 @@ class TestReviewHelper(TestReviewHelperBase):
         with self.assertRaises(AssertionError):
             self.helper.handler.approve_latest_version()
 
-    def test_clear_needs_human_review(self):
+    def test_clear_needs_human_review_multiple_versions(self):
         self.setup_data(amo.STATUS_APPROVED, file_status=amo.STATUS_APPROVED)
         NeedsHumanReview.objects.create(version=self.review_version)
         # set needs_human_review_by_mad - it shouldn't be cleared
@@ -2812,23 +2870,31 @@ class TestReviewHelper(TestReviewHelperBase):
         )
         NeedsHumanReview.objects.create(version=deleted)
         deleted.delete()
-        # This is in a different channel so shouldn't be cleared
-        unlisted = version_factory(
+        # We won't select that one so it shouldn't be cleared
+        unselected = version_factory(
             addon=self.review_version.addon,
-            channel=amo.CHANNEL_UNLISTED,
         )
-        NeedsHumanReview.objects.create(version=unlisted)
+        NeedsHumanReview.objects.create(version=unselected)
 
-        self.helper.handler.clear_needs_human_review()
+        data = self.get_data().copy()
+        data['versions'] = (
+            self.addon.versions(manager='unfiltered_for_relations')
+            .all()
+            .exclude(pk=unselected.pk)
+            .order_by('pk')
+        )
+        self.helper.set_data(data)
+        self.helper.handler.clear_needs_human_review_multiple_versions()
 
-        log_type_id = amo.LOG.CLEAR_NEEDS_HUMAN_REVIEWS.id
+        log_type_id = amo.LOG.CLEAR_NEEDS_HUMAN_REVIEW.id
         assert self.check_log_count(log_type_id) == 1
-        assert (
-            ActivityLog.objects.for_addons(self.helper.addon)
-            .get(action=log_type_id)
-            .details.get('channel')
-            == 'listed'
-        )
+        assert ActivityLog.objects.for_addons(self.helper.addon).get(
+            action=log_type_id
+        ).details.get('versions') == [
+            self.review_version.version,
+            disabled.version,
+            deleted.version,
+        ]
         assert len(mail.outbox) == 0
         self.review_version.reload()
         assert not self.review_version.human_review_date  # its not been reviewed
@@ -2840,12 +2906,12 @@ class TestReviewHelper(TestReviewHelperBase):
         assert not self.review_version.due_date
         assert not disabled.due_date
         assert not deleted.due_date
-        assert unlisted.needshumanreview_set.filter(is_active=True).exists()
-        assert unlisted.due_date
+        assert unselected.needshumanreview_set.filter(is_active=True).exists()
+        assert unselected.due_date
 
-        # mad flag hasn't changed
-        assert flags.reload().needs_human_review_by_mad
-        assert self.review_version.needs_human_review_by_mad
+        # mad flag has changed too.
+        assert not flags.reload().needs_human_review_by_mad
+        assert not self.review_version.needs_human_review_by_mad
 
 
 @override_settings(ENABLE_ADDON_SIGNING=True)

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -6553,7 +6553,6 @@ class TestAddonReviewerViewSet(TestCase):
         self.assertCloseToNow(version.due_date, now=new_due_date)
 
     def test_set_needs_human_review(self):
-        user_factory(pk=settings.TASK_USER_ID)
         self.grant_permission(self.user, 'Reviews:Admin')
         self.client.login_api(self.user)
         version = self.addon.current_version
@@ -6569,7 +6568,9 @@ class TestAddonReviewerViewSet(TestCase):
             == version.needshumanreview_set.model.REASON_MANUALLY_SET_BY_REVIEWER
         )
         assert (
-            ActivityLog.objects.filter(action=amo.LOG.NEEDS_HUMAN_REVIEW.id).get().user
+            ActivityLog.objects.filter(action=amo.LOG.NEEDS_HUMAN_REVIEW_AUTOMATIC.id)
+            .get()
+            .user
             == self.user
         )
         # We strip off the milliseconds in the response

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -2352,6 +2352,7 @@ class TestReview(ReviewBase):
             'public',
             'reject',
             'reject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
             'reply',
             'comment',
         ]
@@ -2386,6 +2387,9 @@ class TestReview(ReviewBase):
             'public',
             'reject',
             'reject_multiple_versions',
+            'clear_pending_rejection_multiple_versions',
+            'clear_needs_human_review_multiple_versions',
+            'set_needs_human_review_multiple_versions',
             'reply',
             'comment',
         ]
@@ -2588,7 +2592,7 @@ class TestReview(ReviewBase):
             str(author.get_role_display()),
             self.addon,
         )
-        with self.assertNumQueries(54):
+        with self.assertNumQueries(52):
             # FIXME: obviously too high, but it's a starting point.
             # Potential further optimizations:
             # - Remove trivial... and not so trivial duplicates
@@ -2613,44 +2617,42 @@ class TestReview(ReviewBase):
             # 14. latest versions translations
             # 15. latest version in channel not disabled + file
             # 16. latest version in channel not disabled translations
-            # 17. addon reviewer flags
-            # 18. version reviewer flags
-            # 19. version reviewer flags (repeated)
-            # 20. version autoapprovalsummary
-            # 21. addonreusedguid
-            # 22. blocklist
-            # 23. versions needing human review in channel
-            # 24. abuse reports count against user or addon
-            # 25. low ratings count
-            # 26. base version pk for comparison
-            # 27. count of all versions in channel
-            # 28. paginated list of versions in channel
-            # 29. scanner results for paginated list of versions
-            # 30. translations for paginated list of versions
-            # 31. applications versions for  paginated list of versions
-            # 32. activity log for  paginated list of versions
-            # 33. files for  paginated list of versions
-            # 34. versionreviewer flags exists to find out if pending rejection
-            # 35. count versions needing human review on other pages
-            # 36. count versions needing human review by mad on other pages
-            # 37. count versions pending rejection on other pages
-            # 38. whiteboard
-            # 39. reviewer subscriptions for listed
-            # 40. reviewer subscriptions for unlisted
-            # 41. config for motd
-            # 42. release savepoint (?)
-            # 43. count add-ons the user is a developer of
-            # 44. config for site notice
-            # 45. other add-ons with same guid
-            # 46. translations for... (?! id=1)
-            # 47. important activity log about the add-on
-            # 48. user for the activity (from the ActivityLog foreignkey)
-            # 49. user for the activity (from the ActivityLog arguments)
-            # 50. add-on for the activity
-            # 51. translation for the add-on for the activity
-            # 52. select all versions in channel for versions dropdown widget
-            # 53. reviewer reasons for the reason dropdown
-            # 54. select users by role for this add-on (?)
+            # 17. version reviewer flags
+            # 18. version reviewer flags (repeated)
+            # 19. version autoapprovalsummary
+            # 20. addonreusedguid
+            # 21. blocklist
+            # 22. abuse reports count against user or addon
+            # 23. low ratings count
+            # 24. base version pk for comparison
+            # 25. count of all versions in channel
+            # 26. paginated list of versions in channel
+            # 27. scanner results for paginated list of versions
+            # 28. translations for paginated list of versions
+            # 29. applications versions for  paginated list of versions
+            # 30. activity log for  paginated list of versions
+            # 31. files for  paginated list of versions
+            # 32. versionreviewer flags exists to find out if pending rejection
+            # 33. count versions needing human review on other pages
+            # 34. count versions needing human review by mad on other pages
+            # 35. count versions pending rejection on other pages
+            # 36. whiteboard
+            # 37. reviewer subscriptions for listed
+            # 38. reviewer subscriptions for unlisted
+            # 39. config for motd
+            # 40. release savepoint (?)
+            # 41. count add-ons the user is a developer of
+            # 42. config for site notice
+            # 43. other add-ons with same guid
+            # 44. translations for... (?! id=1)
+            # 45. important activity log about the add-on
+            # 46. user for the activity (from the ActivityLog foreignkey)
+            # 47. user for the activity (from the ActivityLog arguments)
+            # 48. add-on for the activity
+            # 49. translation for the add-on for the activity
+            # 50. select all versions in channel for versions dropdown widget
+            # 51. reviewer reasons for the reason dropdown
+            # 52. select users by role for this add-on (?)
             response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
@@ -3495,21 +3497,6 @@ class TestReview(ReviewBase):
         doc = pq(response.content)
         assert not doc('#disable_auto_approval_until_next_approval')
         assert not doc('#enable_auto_approval_until_next_approval')
-
-    def test_clear_pending_rejections_as_admin(self):
-        self.login_as_admin()
-        response = self.client.get(self.url)
-        assert response.status_code == 200
-        doc = pq(response.content)
-        assert not doc('#clear_pending_rejections')
-
-        version_review_flags_factory(
-            version=self.addon.current_version, pending_rejection=datetime.now()
-        )
-        response = self.client.get(self.url)
-        assert response.status_code == 200
-        doc = pq(response.content)
-        assert doc('#clear_pending_rejections')
 
     def test_no_public(self):
         assert self.version.file.status == amo.STATUS_APPROVED
@@ -4489,14 +4476,28 @@ class TestReview(ReviewBase):
         GroupUser.objects.filter(user=self.reviewer).all().delete()
         self.grant_permission(self.reviewer, 'Addons:Review')
 
-        response = self.client.post(self.url, {'action': 'clear_needs_human_review'})
+        response = self.client.post(
+            self.url,
+            {
+                'comments': 'this does not need human review anymore!',
+                'versions': [old_version.pk, self.version.pk],
+                'action': 'clear_needs_human_review_multiple_versions',
+            },
+        )
         # the action needs an admin
         assert response.status_code == 200
         assert self.version.needshumanreview_set.filter(is_active=True).exists()
         assert old_version.needshumanreview_set.filter(is_active=True).exists()
 
         self.grant_permission(self.reviewer, 'Reviews:Admin')
-        response = self.client.post(self.url, {'action': 'clear_needs_human_review'})
+        response = self.client.post(
+            self.url,
+            {
+                'comments': 'this does not need human review anymore!',
+                'versions': [old_version.pk, self.version.pk],
+                'action': 'clear_needs_human_review_multiple_versions',
+            },
+        )
         assert response.status_code == 302
         assert not self.version.needshumanreview_set.filter(is_active=True).exists()
         assert not old_version.needshumanreview_set.filter(is_active=True).exists()
@@ -4882,6 +4883,7 @@ class TestReview(ReviewBase):
         expected_actions_values = [
             'confirm_auto_approved',
             'reject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
             'reply',
             'comment',
         ]
@@ -4889,25 +4891,27 @@ class TestReview(ReviewBase):
             act.attrib['data-value'] for act in doc('.data-toggle.review-actions-desc')
         ] == expected_actions_values
 
-        assert (
-            doc('select#id_versions.data-toggle')[0].attrib['data-value']
-            == 'reject_multiple_versions'
-        )
+        assert doc('select#id_versions.data-toggle')[0].attrib['data-value'].split(
+            ' '
+        ) == ['reject_multiple_versions', 'set_needs_human_review_multiple_versions']
 
         assert (
             doc('select#id_versions.data-toggle option')[0].text
             == f'{self.version.version} - Auto-approved, not Confirmed'
         )
 
-        assert (
-            doc('.data-toggle.review-comments')[0].attrib['data-value']
-            == 'reject_multiple_versions reply comment'
-        )
+        assert doc('.data-toggle.review-comments')[0].attrib['data-value'].split(
+            ' '
+        ) == [
+            'reject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
+            'reply',
+            'comment',
+        ]
 
-        assert (
-            doc('.data-toggle.review-actions-reasons')[0].attrib['data-value']
-            == 'reject_multiple_versions reply'
-        )
+        assert doc('.data-toggle.review-actions-reasons')[0].attrib['data-value'].split(
+            ' '
+        ) == ['reject_multiple_versions', 'reply']
 
         # We don't have approve/reject actions so these have an empty
         # data-value.
@@ -4933,6 +4937,7 @@ class TestReview(ReviewBase):
             'reject_multiple_versions',
             'block_multiple_versions',
             'confirm_multiple_versions',
+            'set_needs_human_review_multiple_versions',
             'reply',
             'comment',
         ]
@@ -4940,21 +4945,29 @@ class TestReview(ReviewBase):
             act.attrib['data-value'] for act in doc('.data-toggle.review-actions-desc')
         ] == expected_actions_values
 
-        assert (
-            doc('select#id_versions.data-toggle')[0].attrib['data-value']
-            == 'approve_multiple_versions reject_multiple_versions '
-            'block_multiple_versions confirm_multiple_versions'
-        )
+        assert doc('select#id_versions.data-toggle')[0].attrib['data-value'].split(
+            ' '
+        ) == [
+            'approve_multiple_versions',
+            'reject_multiple_versions',
+            'block_multiple_versions',
+            'confirm_multiple_versions',
+            'set_needs_human_review_multiple_versions',
+        ]
 
-        assert (
-            doc('.data-toggle.review-comments')[0].attrib['data-value']
-            == 'approve_multiple_versions reject_multiple_versions reply comment'
-        )
+        assert doc('.data-toggle.review-comments')[0].attrib['data-value'].split(
+            ' '
+        ) == [
+            'approve_multiple_versions',
+            'reject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
+            'reply',
+            'comment',
+        ]
 
-        assert (
-            doc('.data-toggle.review-actions-reasons')[0].attrib['data-value']
-            == 'approve_multiple_versions reject_multiple_versions reply'
-        )
+        assert doc('.data-toggle.review-actions-reasons')[0].attrib['data-value'].split(
+            ' '
+        ) == ['approve_multiple_versions', 'reject_multiple_versions', 'reply']
 
         # We don't have approve/reject actions so these have an empty
         # data-value.
@@ -5000,6 +5013,7 @@ class TestReview(ReviewBase):
             'public',
             'reject',
             'reject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
             'reply',
             'comment',
         ]
@@ -5009,20 +5023,27 @@ class TestReview(ReviewBase):
 
         assert 'data-value' not in doc('select#id_versions.data-toggle')[0]
 
-        assert (
-            doc('.data-toggle.review-comments')[0].attrib['data-value']
-            == 'public reject reject_multiple_versions reply comment'
-        )
-        assert (
-            doc('.data-toggle.review-files')[0].attrib['data-value'] == 'public reject'
-        )
-        assert (
-            doc('.data-toggle.review-tested')[0].attrib['data-value'] == 'public reject'
-        )
-        assert (
-            doc('.data-toggle.review-actions-reasons')[0].attrib['data-value']
-            == 'public reject reject_multiple_versions reply'
-        )
+        assert doc('.data-toggle.review-comments')[0].attrib['data-value'].split(
+            ' '
+        ) == [
+            'public',
+            'reject',
+            'reject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
+            'reply',
+            'comment',
+        ]
+        assert doc('.data-toggle.review-files')[0].attrib['data-value'].split(' ') == [
+            'public',
+            'reject',
+        ]
+        assert doc('.data-toggle.review-tested')[0].attrib['data-value'].split(' ') == [
+            'public',
+            'reject',
+        ]
+        assert doc('.data-toggle.review-actions-reasons')[0].attrib['data-value'].split(
+            ' '
+        ) == ['public', 'reject', 'reject_multiple_versions', 'reply']
 
     def test_data_value_attributes_static_theme(self):
         self.addon.update(type=amo.ADDON_STATICTHEME)
@@ -5036,6 +5057,7 @@ class TestReview(ReviewBase):
             'public',
             'reject',
             'reject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
             'reply',
             'super',
             'comment',
@@ -5046,16 +5068,22 @@ class TestReview(ReviewBase):
 
         assert 'data-value' not in doc('select#id_versions.data-toggle')[0]
 
-        assert (
-            doc('.data-toggle.review-comments')[0].attrib['data-value']
-            == 'public reject reject_multiple_versions reply super comment'
-        )
+        assert doc('.data-toggle.review-comments')[0].attrib['data-value'].split(
+            ' '
+        ) == [
+            'public',
+            'reject',
+            'reject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
+            'reply',
+            'super',
+            'comment',
+        ]
         # we don't show files, reasons, and tested with for any static theme actions
         assert doc('.data-toggle.review-files')[0].attrib['data-value'] == ''
-        assert (
-            doc('.data-toggle.review-actions-reasons')[0].attrib['data-value']
-            == 'reject reject_multiple_versions'
-        )
+        assert doc('.data-toggle.review-actions-reasons')[0].attrib['data-value'].split(
+            ' '
+        ) == ['reject', 'reject_multiple_versions']
         assert doc('.data-toggle.review-tested')[0].attrib['data-value'] == ''
 
     def test_post_review_ignore_disabled(self):
@@ -5071,6 +5099,7 @@ class TestReview(ReviewBase):
         expected_actions = [
             'confirm_auto_approved',
             'reject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
             'reply',
             'comment',
         ]
@@ -5090,6 +5119,7 @@ class TestReview(ReviewBase):
         expected_actions = [
             'approve_content',
             'reject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
             'reply',
             'comment',
         ]
@@ -5208,7 +5238,7 @@ class TestReview(ReviewBase):
                     results={'matchedRules': [customs_rule.name]},
                 )
 
-        with self.assertNumQueries(55):
+        with self.assertNumQueries(53):
             # See test_item_history_pagination() for more details about the
             # queries count. What's important here is that the extra versions
             # and scanner results don't cause extra queries.

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -728,6 +728,39 @@ class ReviewHelper:
                 not is_static_theme and version_is_unlisted and is_appropriate_reviewer
             ),
         }
+        actions['clear_pending_rejection_multiple_versions'] = {
+            'method': self.handler.clear_pending_rejection_multiple_versions,
+            'label': 'Clear pending rejection',
+            'details': (
+                'Clear pending rejection from selected versions, but '
+                "otherwise don't change the version(s) or add-on statuses."
+            ),
+            'multiple_versions': True,
+            'minimal': True,
+            'available': is_appropriate_admin_reviewer,
+        }
+        actions['clear_needs_human_review_multiple_versions'] = {
+            'method': self.handler.clear_needs_human_review_multiple_versions,
+            'label': 'Clear Needs Human Review',
+            'details': (
+                'Clear needs human review flag from selected versions, but '
+                "otherwise don't change the version(s) or add-on statuses."
+            ),
+            'multiple_versions': True,
+            'minimal': True,
+            'available': is_appropriate_admin_reviewer,
+        }
+        actions['set_needs_human_review_multiple_versions'] = {
+            'method': self.handler.set_needs_human_review_multiple_versions,
+            'label': 'Set Needs Human Review',
+            'details': (
+                'Set needs human review flag from selected versions, but '
+                "otherwise don't change the version(s) or add-on statuses."
+            ),
+            'multiple_versions': True,
+            'minimal': True,
+            'available': is_appropriate_reviewer,
+        }
         actions['reply'] = {
             'method': self.handler.reviewer_reply,
             'label': 'Reviewer reply',
@@ -763,39 +796,6 @@ class ReviewHelper:
                 'Make a comment on this version. The developer '
                 "won't be able to see this."
             ),
-            'minimal': True,
-            'available': (is_reviewer),
-        }
-        actions['clear_pending_rejection_multiple_versions'] = {
-            'method': self.handler.clear_pending_rejection_multiple_versions,
-            'label': 'Clear pending rejection',
-            'details': (
-                'Clear pending rejection from selected versions, but '
-                "otherwise don't change the version(s) or add-on statuses."
-            ),
-            'multiple_versions': True,
-            'minimal': True,
-            'available': is_appropriate_admin_reviewer,
-        }
-        actions['clear_needs_human_review_multiple_versions'] = {
-            'method': self.handler.clear_needs_human_review_multiple_versions,
-            'label': 'Clear Needs Human Review',
-            'details': (
-                'Clear needs human review flag from selected versions, but '
-                "otherwise don't change the version(s) or add-on statuses."
-            ),
-            'multiple_versions': True,
-            'minimal': True,
-            'available': is_appropriate_admin_reviewer,
-        }
-        actions['set_needs_human_review_multiple_versions'] = {
-            'method': self.handler.set_needs_human_review_multiple_versions,
-            'label': 'Set Needs Human Review',
-            'details': (
-                'Set needs human review flag from selected versions, but '
-                "otherwise don't change the version(s) or add-on statuses."
-            ),
-            'multiple_versions': True,
             'minimal': True,
             'available': is_reviewer,
         }
@@ -1392,7 +1392,7 @@ class ReviewBase:
             self.clear_specific_needs_human_review_flags(version)
         # Record a single activity log.
         self.log_action(
-            amo.LOG.CLEAR_NEEDS_HUMAN_REVIEW_VERSION, versions=self.data['versions']
+            amo.LOG.CLEAR_NEEDS_HUMAN_REVIEW, versions=self.data['versions']
         )
 
     def set_needs_human_review_multiple_versions(self):

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.core.cache import cache
 from django.core.exceptions import PermissionDenied
 from django.core.paginator import Paginator
-from django.db.models import Q
+from django.db.models import Exists, OuterRef, Q
 from django.db.transaction import non_atomic_requests
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, redirect
@@ -480,6 +480,9 @@ def review(request, addon, channel=None):
         amo.messages.warning(request, 'Self-reviews are not allowed.')
         return redirect(reverse('reviewers.dashboard'))
 
+    needs_human_review_qs = NeedsHumanReview.objects.filter(
+        is_active=True, version=OuterRef('pk')
+    )
     # Queryset to be paginated for versions. We use the default ordering to get
     # most recently created first (Note that the template displays each page
     # in reverse order, older first).
@@ -492,6 +495,9 @@ def review(request, addon, channel=None):
         .select_related('autoapprovalsummary')
         .select_related('reviewerflags')
         .select_related('file___webext_permissions')
+        # Prefetch needshumanreview existence into a property that the
+        # VersionsChoiceWidget will use.
+        .annotate(needs_human_review=Exists(needs_human_review_qs))
         # Prefetch scanner results and related rules...
         .prefetch_related('scannerresults')
         .prefetch_related('scannerresults__matched_rules')
@@ -642,7 +648,6 @@ def review(request, addon, channel=None):
     versions_pending_rejection_qs = versions_qs.filter(
         reviewerflags__pending_rejection__isnull=False
     )
-    has_versions_pending_rejection = versions_pending_rejection_qs.exists()
     # We want to notify the reviewer if there are versions needing extra
     # attention that are not present in the versions history (which is
     # paginated).
@@ -717,7 +722,6 @@ def review(request, addon, channel=None):
         flags=flags,
         form=form,
         format_matched_rules=formatted_matched_rules_with_files_and_data,
-        has_versions_pending_rejection=has_versions_pending_rejection,
         important_changes_log=important_changes_log,
         is_admin=is_admin,
         language_dict=dict(settings.LANGUAGES),


### PR DESCRIPTION
Rather than applying them through the API per add-on for all versions in the channel, treat them as an action applied to the selected versions.

Fixes #20813