### PR TITLE
Fix error message not appearing on reviewer actions with invalid form

### DIFF
--- a/static/js/zamboni/reviewers.js
+++ b/static/js/zamboni/reviewers.js
@@ -97,7 +97,7 @@ function initReviewActions() {
 
   var review_checked = $('#review-actions [name=action]:checked');
   if (review_checked.length > 0) {
-    showForm(review_checked.closest('li'), true);
+    showForm(review_checked.parentsUntil('#id_action', 'div'), true);
   }
 
   /* Review action reason stuff */


### PR DESCRIPTION
The actions are no longer wrapped in a `<li>` following Django 4.2 upgrade.

Fixes #20810