### PR TITLE
change version checkboxes to make it clearer between blocking and already blocked

### DIFF
--- a/src/olympia/blocklist/admin.py
+++ b/src/olympia/blocklist/admin.py
@@ -259,13 +259,14 @@ class BlocklistSubmissionAdmin(AMOModelAdmin):
         else:
             edit_title = 'Proposed New Blocks'
 
+        changed_version_ids = ('changed_version_ids',) if not obj else ()
         add_change = (
             edit_title,
             {
                 'fields': (
                     'blocks',
                     'disable_addon',
-                    'changed_version_ids',
+                    *changed_version_ids,
                     'url',
                     'reason',
                     'updated_by',
@@ -403,6 +404,7 @@ class BlocklistSubmissionAdmin(AMOModelAdmin):
             'site_title': None,
             'is_popup': False,
             'form_url': '',
+            'is_delete': is_delete,
         }
         return TemplateResponse(
             request, 'admin/blocklist/blocklistsubmission_add_form.html', context
@@ -432,9 +434,8 @@ class BlocklistSubmissionAdmin(AMOModelAdmin):
     def render_change_form(
         self, request, context, add=False, change=False, form_url='', obj=None
     ):
-        if change:
-            # add this to the instance so blocks() below can reference it.
-            obj._blocks = context['adminform'].form.blocks
+        # add this to the instance so blocks() below can reference it.
+        obj._blocks = context['adminform'].form.blocks
         return super().render_change_form(
             request, context, add=add, change=change, form_url=form_url, obj=obj
         )
@@ -507,6 +508,8 @@ class BlocklistSubmissionAdmin(AMOModelAdmin):
             {
                 'form': SimpleNamespace(blocks=obj._blocks),
                 'submission_published': is_published,
+                'instance': obj,
+                'is_delete': obj.action == BlocklistSubmission.ACTION_DELETE,
             },
         )
 

--- a/src/olympia/blocklist/templates/admin/blocklist/includes/enhanced_blocks.html
+++ b/src/olympia/blocklist/templates/admin/blocklist/includes/enhanced_blocks.html
@@ -25,20 +25,21 @@
       <ul>
         {% for version in block_obj.addon_versions %}
           <li data-version-id="{{ version.id }}">
+          {% if version.id in form.changed_version_ids_choices or version.id in instance.changed_version_ids %}
             <label><input
               type="checkbox"
               name="changed_version_ids"
               value="{{ version.id }}"
-              {% if version.id in form.changed_version_ids_choices %}
-                {% if version.id in form.changed_version_ids.value %}checked{% endif %}
-              {% else %}
-                disabled
-                {% if version.is_blocked %}checked{% endif %}
+              {% if version.id in form.changed_version_ids.value %}checked{% endif %}
+              {% if version.id in instance.changed_version_ids %}checked disabled{% endif %}
+            > {% if is_delete %}Unblock{% else %}Block{% endif %} {{ version.version }}</label>
+          {% else %}
+            <!-- Red Hexagonal stop sign for Blocked; Green cirle for not blocked -->
+            {% if version.is_blocked %}&#x1F6D1;{% else %}&#x1F7E2;{% endif %}{{ version.version }}
+              {% if version.blocklist_submission_id %}
+                [<a href="{% url 'admin:blocklist_blocklistsubmission_change' version.blocklist_submission_id %}">Edit Submission</a>]
               {% endif %}
-            >{{ version.version }}</label>
-            {% if version.blocklist_submission_id %}
-              [<a href="{% url 'admin:blocklist_blocklistsubmission_change' version.blocklist_submission_id %}">Edit Submission</a>]
-            {% endif %}
+          {% endif %}
           </li>
         {% endfor %}
       </ul>

--- a/src/olympia/blocklist/templates/admin/blocklist/includes/enhanced_blocks.html
+++ b/src/olympia/blocklist/templates/admin/blocklist/includes/enhanced_blocks.html
@@ -34,11 +34,14 @@
               {% if version.id in instance.changed_version_ids %}checked disabled{% endif %}
             > {% if is_delete %}Unblock{% else %}Block{% endif %} {{ version.version }}</label>
           {% else %}
-            <!-- Red Hexagonal stop sign for Blocked; Green cirle for not blocked -->
-            {% if version.is_blocked %}&#x1F6D1;{% else %}&#x1F7E2;{% endif %}{{ version.version }}
+            <span title="{% if version.is_blocked %}Blocked{% else %}Not blocked{% endif %}">
+              <!-- Red Hexagonal stop sign for Blocked; Green cirle for not blocked -->
+              {% if version.is_blocked %}&#x1F6D1;{% else %}&#x1F7E2;{% endif %}{{ version.version }}
               {% if version.blocklist_submission_id %}
                 [<a href="{% url 'admin:blocklist_blocklistsubmission_change' version.blocklist_submission_id %}">Edit Submission</a>]
               {% endif %}
+            </span>
+
           {% endif %}
           </li>
         {% endfor %}

--- a/src/olympia/blocklist/tests/test_admin.py
+++ b/src/olympia/blocklist/tests/test_admin.py
@@ -272,6 +272,9 @@ class TestBlocklistSubmissionAdmin(TestCase):
         assert doc(f'li[data-version-id="{ver_add_subm.id}"]').text() == (
             f'\U0001F7E2{ver_add_subm.version} [Edit Submission]'
         )
+        assert doc(f'li[data-version-id="{ver_add_subm.id}"] span').attr('title') == (
+            'Not blocked'
+        )
         submission_link = doc(f'li[data-version-id="{ver_add_subm.id}"] a')
         assert submission_link.text() == 'Edit Submission'
         assert submission_link.attr['href'] == reverse(
@@ -282,6 +285,9 @@ class TestBlocklistSubmissionAdmin(TestCase):
         # not a checkbox because blocked already and this is an add action
         assert doc(f'li[data-version-id="{ver_block.id}"]').text() == (
             f'\U0001F6D1{ver_block.version}'
+        )
+        assert doc(f'li[data-version-id="{ver_block.id}"] span').attr('title') == (
+            'Blocked'
         )
 
         # Now with an existing submission
@@ -2058,9 +2064,15 @@ class TestBlockAdminDelete(TestCase):
         assert doc(f'li[data-version-id="{ver_add_subm.id}"]').text() == (
             f'\U0001F7E2{ver_add_subm.version} [Edit Submission]'
         )
+        assert doc(f'li[data-version-id="{ver_add_subm.id}"] span').attr('title') == (
+            'Not blocked'
+        )
         # not a checkbox because in a submission, red hexagon because not blocked
         assert doc(f'li[data-version-id="{ver_del_subm.id}"]').text() == (
             f'\U0001F6D1{ver_del_subm.version} [Edit Submission]'
+        )
+        assert doc(f'li[data-version-id="{ver_del_subm.id}"] span').attr('title') == (
+            'Blocked'
         )
         # not a checkbox because not blocked, and this is a delete action
         assert doc(f'li[data-version-id="{ver.id}"]').text() == (

--- a/static/css/admin/blocklist_blocklistsubmission.css
+++ b/static/css/admin/blocklist_blocklistsubmission.css
@@ -17,7 +17,7 @@ form .guid_list li ul {
     margin: 0;
 }
 
-form ul.guid_list li {
+form ul.guid_list >li {
     list-style-type: disc;
 }
 


### PR DESCRIPTION
fixes #20882 - the UI isn't great still, imo, but it's better than now, where we mix up a version that's _already_ blocked, with a version that the submission will be blocking. 

Two things I'd like to improve on at some point:
a) a way to better indicate what the checkbox will do than write "Block" or "Unblock" next to it, like a custom toggle button with block and unblock on it (but started falling down the CSS rabbit hole)
b) the red hexagon and green circle visually are just coloured blobs at the normal font size and don't incontrovertibly indicate "blocked version" and "not blocked version"