### PR TITLE
Store FileUpload paths as relative and not absolute

### DIFF
--- a/src/olympia/amo/cron.py
+++ b/src/olympia/amo/cron.py
@@ -55,7 +55,7 @@ def gc(test_result=True):
     for file_upload in stale_uploads:
         log.info(
             '[FileUpload:{uuid}] Removing file: {path}'.format(
-                uuid=file_upload.uuid, path=file_upload.path
+                uuid=file_upload.uuid, path=file_upload.file_path
             )
         )
         if file_upload.file_path:

--- a/src/olympia/amo/cron.py
+++ b/src/olympia/amo/cron.py
@@ -58,9 +58,9 @@ def gc(test_result=True):
                 uuid=file_upload.uuid, path=file_upload.path
             )
         )
-        if file_upload.path:
+        if file_upload.file_path:
             try:
-                storage.delete(file_upload.path)
+                storage.delete(file_upload.file_path)
             except OSError:
                 pass
         file_upload.delete()

--- a/src/olympia/devhub/tasks.py
+++ b/src/olympia/devhub/tasks.py
@@ -200,7 +200,7 @@ def validate_upload(results, upload_pk, channel):
 
     Should only be called directly by Validator."""
     upload = FileUpload.objects.get(pk=upload_pk)
-    data = validate_file_path(upload.path, channel)
+    data = validate_file_path(upload.file_path, channel)
     return {**results, **json.loads(force_str(data))}
 
 
@@ -286,16 +286,16 @@ def handle_upload_validation_result(results, upload_pk, channel, is_mozilla_sign
     delta = now_ts - upload_start
     statsd.timing('devhub.validation_results_processed', delta)
 
-    if not storage.exists(upload.path):
+    if not storage.exists(upload.file_path):
         # TODO: actually fix this so we can get stats. It seems that
         # the file maybe gets moved but it needs more investigation.
         log.warning(
             'Scaled upload stats were not tracked. File is '
-            'missing: {}'.format(upload.path)
+            'missing: {}'.format(upload.file_path)
         )
         return
 
-    size = Decimal(storage.size(upload.path))
+    size = Decimal(storage.size(upload.file_path))
     megabyte = Decimal(1024 * 1024)
 
     # Stash separate metrics for small / large files.
@@ -360,7 +360,7 @@ def check_for_api_keys_in_file(results, upload_pk):
 
     try:
         if len(keys) > 0:
-            zipfile = SafeZip(source=upload.path)
+            zipfile = SafeZip(source=upload.file_path)
             for zipinfo in zipfile.info_list:
                 if zipinfo.file_size >= 64:
                     file_ = zipfile.read(zipinfo)

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -1115,7 +1115,7 @@ class TestUpload(UploadMixin, TestCase):
         upload = FileUpload.objects.filter().order_by('-created').first()
         assert 'animated.png' in upload.name
         data = open(self.image_path, 'rb').read()
-        assert storage.open(upload.path).read() == data
+        assert storage.open(upload.file_path).read() == data
 
     def test_fileupload_metadata(self):
         user = UserProfile.objects.get(email='regular@mozilla.com')

--- a/src/olympia/devhub/tests/test_views_validation.py
+++ b/src/olympia/devhub/tests/test_views_validation.py
@@ -449,8 +449,10 @@ class TestValidateAddon(TestCase):
         fpath = 'src/olympia/files/fixtures/files/webextension_no_id.xpi'
 
         with open(fpath, 'rb') as file_:
-            self.client.post(url, {'upload': file_})
+            response = self.client.post(url, {'upload': file_})
 
+        assert response.status_code == 302
+        assert validate_mock.call_count == 1
         assert validate_mock.call_args[1]['channel'] == amo.CHANNEL_LISTED
         # No automated signing for listed add-ons.
         assert FileUpload.objects.get().channel == amo.CHANNEL_LISTED
@@ -464,8 +466,10 @@ class TestValidateAddon(TestCase):
         fpath = 'src/olympia/files/fixtures/files/webextension_no_id.xpi'
 
         with open(fpath, 'rb') as file_:
-            self.client.post(url, {'upload': file_})
+            response = self.client.post(url, {'upload': file_})
 
+        assert response.status_code == 302
+        assert validate_mock.call_count == 1
         assert validate_mock.call_args[1]['channel'] == amo.CHANNEL_UNLISTED
         # Automated signing enabled for unlisted add-ons.
         assert FileUpload.objects.get().channel == amo.CHANNEL_UNLISTED

--- a/src/olympia/files/models.py
+++ b/src/olympia/files/models.py
@@ -448,7 +448,10 @@ class FileUpload(ModelBase):
     def file_path(self):
         if self.path.startswith('/'):
             return self.path
-        return os.path.join(settings.ADDONS_PATH, self.path)
+        elif self.path:
+            return os.path.join(settings.ADDONS_PATH, self.path)
+        else:
+            return self.path
 
     def add_file(self, chunks, filename, size):
         if not self.uuid:

--- a/src/olympia/files/models.py
+++ b/src/olympia/files/models.py
@@ -160,7 +160,7 @@ class File(OnChangeMixin, ModelBase):
         assert parsed_data is not None
 
         file_ = cls(version=version)
-        upload_path = force_str(upload.path)
+        upload_path = force_str(upload.file_path)
         # Size in bytes.
         file_.size = storage.size(upload_path)
         file_.strict_compatibility = parsed_data.get('strict_compatibility', False)
@@ -434,7 +434,7 @@ class FileUpload(ModelBase):
 
     def write_data_to_path(self, chunks):
         hash_obj = hashlib.sha256()
-        with storage.open(self.path, 'wb') as file_destination:
+        with storage.open(self.file_path, 'wb') as file_destination:
             for chunk in chunks:
                 hash_obj.update(chunk)
                 file_destination.write(chunk)
@@ -442,7 +442,13 @@ class FileUpload(ModelBase):
 
     @classmethod
     def generate_path(cls, ext='.zip'):
-        return os.path.join(settings.ADDONS_PATH, 'temp', f'{uuid.uuid4().hex}{ext}')
+        return os.path.join('temp', f'{uuid.uuid4().hex}{ext}')
+
+    @property
+    def file_path(self):
+        if self.path.startswith('/'):
+            return self.path
+        return os.path.join(settings.ADDONS_PATH, self.path)
 
     def add_file(self, chunks, filename, size):
         if not self.uuid:
@@ -466,7 +472,7 @@ class FileUpload(ModelBase):
         hash_obj = None
         if was_crx:
             try:
-                hash_obj = write_crx_as_xpi(chunks, self.path)
+                hash_obj = write_crx_as_xpi(chunks, self.file_path)
             except InvalidOrUnsupportedCrx:
                 # We couldn't convert the crx file. Write it to the filesystem
                 # normally, the validation process should reject this with a

--- a/src/olympia/files/tests/test_models.py
+++ b/src/olympia/files/tests/test_models.py
@@ -729,7 +729,19 @@ class TestFileUpload(UploadMixin, TestCase):
         )
 
     def test_from_post_write_file(self):
-        assert storage.open(self.upload().path, 'rb').read() == self.data
+        assert storage.open(self.upload().file_path, 'rb').read() == self.data
+
+    def test_file_path(self):
+        upload = self.upload()
+        assert not upload.path.startswith('/')
+        assert upload.file_path != upload.path
+        assert upload.file_path == os.path.join(settings.ADDONS_PATH, upload.path)
+        assert os.path.exists(upload.file_path)
+
+        # If the absolute path is stored (old FileUploads) we use them as-is.
+        upload.update(path=upload.file_path)
+        assert upload.file_path == upload.path
+        assert os.path.exists(upload.file_path)
 
     def test_from_post_filename(self):
         upload = self.upload()
@@ -737,7 +749,7 @@ class TestFileUpload(UploadMixin, TestCase):
         assert upload.name == f'{force_str(upload.uuid.hex)}_filenamé.xpi'
         # Actual path on filesystem is different, fully random
         assert upload.name not in upload.path
-        assert re.match(r'.*/temp/[a-f0-9]{32}\.zip$', upload.path)
+        assert re.match(r'^temp/[a-f0-9]{32}\.zip$', upload.path)
 
     def test_from_post_hash(self):
         hashdigest = hashlib.sha256(self.data).hexdigest()
@@ -986,11 +998,11 @@ class TestFileUpload(UploadMixin, TestCase):
         """Test to ensure we accept ZIP uploads"""
         upload = self.get_upload(filename='webextension_no_id.zip')
         assert upload.path.endswith('.zip')
-        assert zipfile.is_zipfile(upload.path)
+        assert zipfile.is_zipfile(upload.file_path)
         assert upload.hash == (
             'sha256:7978b06704f4f80152f16a3ce7fe4e2590f950a99cefed15f9a8caa90fbafa23'
         )
-        storage.delete(upload.path)
+        storage.delete(upload.file_path)
 
     def test_webextension_crx(self):
         """Test to ensure we accept CRX uploads, but convert them into zip
@@ -998,11 +1010,11 @@ class TestFileUpload(UploadMixin, TestCase):
         """
         upload = self.get_upload('webextension.crx')
         assert upload.path.endswith('.zip')
-        assert zipfile.is_zipfile(upload.path)
+        assert zipfile.is_zipfile(upload.file_path)
         assert upload.hash == (
             'sha256:6eec73112c9912e4ef63973d38ea490ccc18fa6f3cf4357fb3052a748f799f9a'
         )
-        storage.delete(upload.path)
+        storage.delete(upload.file_path)
 
     def test_webextension_crx_large(self):
         """Test to ensure we accept large CRX uploads, because of how we
@@ -1010,11 +1022,11 @@ class TestFileUpload(UploadMixin, TestCase):
         """
         upload = self.get_upload('https-everywhere.crx')
         assert upload.path.endswith('.zip')
-        assert zipfile.is_zipfile(upload.path)
+        assert zipfile.is_zipfile(upload.file_path)
         assert upload.hash == (
             'sha256:82b71db5e6378ae888b2bcbb92fc8a24f417ef079e909db7fa51b253b13b3409'
         )
-        storage.delete(upload.path)
+        storage.delete(upload.file_path)
 
     def test_webextension_crx_version_3(self):
         """Test to ensure we accept CRX uploads (version 3), but convert them
@@ -1022,11 +1034,11 @@ class TestFileUpload(UploadMixin, TestCase):
         """
         upload = self.get_upload('webextension_crx3.crx')
         assert upload.path.endswith('.zip')
-        assert zipfile.is_zipfile(upload.path)
+        assert zipfile.is_zipfile(upload.file_path)
         assert upload.hash == (
             'sha256:8640cdcbd5e85403b0a08f1c42b9dff362ceca6a92bf61f424c9764189c58950'
         )
-        storage.delete(upload.path)
+        storage.delete(upload.file_path)
 
     def test_webextension_crx_not_a_crx(self):
         """Test to ensure we raise an explicit exception when a .crx file isn't
@@ -1043,7 +1055,7 @@ class TestFileUpload(UploadMixin, TestCase):
         # We couldn't convert it as it's an invalid or unsupported crx, so
         # re storing the file as-is.
         assert upload.hash == 'sha256:%s' % hashlib.sha256(data).hexdigest()
-        storage.delete(upload.path)
+        storage.delete(upload.file_path)
 
     def test_webextension_crx_version_unsupported(self):
         """Test to ensure we only support crx versions 2 and 3 and raise an
@@ -1061,7 +1073,7 @@ class TestFileUpload(UploadMixin, TestCase):
         # We couldn't convert it as it's an invalid or unsupported crx, so
         # re storing the file as-is.
         assert upload.hash == 'sha256:%s' % hashlib.sha256(data).hexdigest()
-        storage.delete(upload.path)
+        storage.delete(upload.file_path)
 
     def test_webextension_crx_version_cant_unpack(self):
         """Test to ensure we raise an explicit exception when we can't unpack
@@ -1077,19 +1089,19 @@ class TestFileUpload(UploadMixin, TestCase):
         )
         # We're storing the file as-is.
         assert upload.hash == 'sha256:%s' % hashlib.sha256(data).hexdigest()
-        storage.delete(upload.path)
+        storage.delete(upload.file_path)
 
     def test_extension_zip(self):
         upload = self.get_upload('recurse.zip')
         assert upload.path.endswith('.zip')
-        assert zipfile.is_zipfile(upload.path)
-        storage.delete(upload.path)
+        assert zipfile.is_zipfile(upload.file_path)
+        storage.delete(upload.file_path)
 
     def test_extension_xpi(self):
         upload = self.get_upload('webextension.xpi')
         assert upload.path.endswith('.zip')
-        assert zipfile.is_zipfile(upload.path)
-        storage.delete(upload.path)
+        assert zipfile.is_zipfile(upload.file_path)
+        storage.delete(upload.file_path)
 
     def test_generate_access_token_on_save(self):
         upload = FileUpload(
@@ -1195,11 +1207,8 @@ class TestFileFromUpload(UploadMixin, TestCase):
                 'metadata': {},
             }
         )
-        src_path = self.file_fixture_path(name)
-        dest_path = FileUpload.generate_path()
-        self.root_storage.copy_stored_file(src_path, dest_path)
-        return FileUpload.objects.create(
-            path=dest_path,
+        upload = FileUpload.objects.create(
+            path=FileUpload.generate_path(),
             name=name,
             hash='sha256:fake_hash',
             validation=validation_data,
@@ -1208,6 +1217,10 @@ class TestFileFromUpload(UploadMixin, TestCase):
             user=user_factory(),
             channel=amo.CHANNEL_LISTED,
         )
+        src_path = self.file_fixture_path(name)
+        dest_path = upload.file_path
+        self.root_storage.copy_stored_file(src_path, dest_path)
+        return upload
 
     def test_filename(self):
         upload = self.upload('webextension.xpi')
@@ -1316,7 +1329,7 @@ class TestFileFromUpload(UploadMixin, TestCase):
 
     def test_permissions(self):
         upload = self.upload('webextension_no_id.xpi')
-        with self.root_storage.open(upload.path, 'rb') as upload_file:
+        with self.root_storage.open(upload.file_path, 'rb') as upload_file:
             parsed_data = parse_addon(upload_file, user=user_factory())
         # 5 permissions; 2 content_scripts entries.
         assert len(parsed_data['permissions']) == 5
@@ -1349,7 +1362,7 @@ class TestFileFromUpload(UploadMixin, TestCase):
 
     def test_optional_permissions(self):
         upload = self.upload('webextension_no_id.xpi')
-        with self.root_storage.open(upload.path, 'rb') as upload_file:
+        with self.root_storage.open(upload.file_path, 'rb') as upload_file:
             parsed_data = parse_addon(upload_file, user=user_factory())
         assert len(parsed_data['optional_permissions']) == 2
         file_ = File.from_upload(upload, self.version, parsed_data=parsed_data)
@@ -1359,7 +1372,7 @@ class TestFileFromUpload(UploadMixin, TestCase):
 
     def test_host_permissions(self):
         upload = self.upload('webextension_mv3.xpi')
-        with self.root_storage.open(upload.path, 'rb') as upload_file:
+        with self.root_storage.open(upload.file_path, 'rb') as upload_file:
             parsed_data = parse_addon(upload_file, user=user_factory())
         assert len(parsed_data['host_permissions']) == 2
         file_ = File.from_upload(upload, self.version, parsed_data=parsed_data)
@@ -1369,7 +1382,7 @@ class TestFileFromUpload(UploadMixin, TestCase):
 
     def test_mv3_invalid_host_permissions(self):
         upload = self.upload('webextension_mv3_invalid_permissions.xpi')
-        with self.root_storage.open(upload.path, 'rb') as upload_file:
+        with self.root_storage.open(upload.file_path, 'rb') as upload_file:
             parsed_data = parse_addon(upload_file, user=user_factory())
         assert len(parsed_data['host_permissions']) == 2
         assert len(parsed_data['permissions']) == 2
@@ -1383,7 +1396,7 @@ class TestFileFromUpload(UploadMixin, TestCase):
 
     def test_mv2_invalid_host_permissions(self):
         upload = self.upload('webextension_mv2_invalid_permissions.xpi')
-        with self.root_storage.open(upload.path, 'rb') as upload_file:
+        with self.root_storage.open(upload.file_path, 'rb') as upload_file:
             parsed_data = parse_addon(upload_file, user=user_factory())
         assert len(parsed_data['host_permissions']) == 2
         assert len(parsed_data['permissions']) == 2

--- a/src/olympia/files/tests/test_models.py
+++ b/src/olympia/files/tests/test_models.py
@@ -743,6 +743,10 @@ class TestFileUpload(UploadMixin, TestCase):
         assert upload.file_path == upload.path
         assert os.path.exists(upload.file_path)
 
+        # If the path is empty, we return an empty string
+        upload.update(path='')
+        assert upload.file_path == ''
+
     def test_from_post_filename(self):
         upload = self.upload()
         assert upload.uuid

--- a/src/olympia/files/tests/test_tasks.py
+++ b/src/olympia/files/tests/test_tasks.py
@@ -71,7 +71,7 @@ class TestRepackFileUpload(AppVersionsMixin, UploadMixin, TestCase):
         assert upload.hash != original_hash
 
         # Test zip contents
-        with zipfile.ZipFile(upload.path) as z:
+        with zipfile.ZipFile(upload.file_path) as z:
             contents = sorted(z.namelist())
             assert contents == [
                 'index.js',
@@ -101,13 +101,13 @@ class TestRepackFileUpload(AppVersionsMixin, UploadMixin, TestCase):
             "description": "haupt\\u005fstra\\u00dfe"
         }
         """
-        with zipfile.ZipFile(upload.path, 'w') as z:
+        with zipfile.ZipFile(upload.file_path, 'w') as z:
             z.writestr('manifest.json', manifest_with_comments)
 
         repack_fileupload(fake_results, upload.pk)
         upload.reload()
 
-        with zipfile.ZipFile(upload.path) as z:
+        with zipfile.ZipFile(upload.file_path) as z:
             with z.open('manifest.json') as manifest:
                 assert manifest.read().decode() == manifest_with_comments
 
@@ -115,14 +115,14 @@ class TestRepackFileUpload(AppVersionsMixin, UploadMixin, TestCase):
     def test_does_not_normalize_manifest_json_when_addon_is_signed(self):
         upload = self.get_upload('webextension_signed_already.xpi')
         fake_results = {'errors': 0}
-        with zipfile.ZipFile(upload.path, 'r') as z:
+        with zipfile.ZipFile(upload.file_path, 'r') as z:
             with z.open('manifest.json') as manifest:
                 original_manifest = manifest.read().decode()
 
         repack_fileupload(fake_results, upload.pk)
         upload.reload()
 
-        with zipfile.ZipFile(upload.path) as z:
+        with zipfile.ZipFile(upload.file_path) as z:
             with z.open('manifest.json') as manifest:
                 assert manifest.read().decode() == original_manifest
 
@@ -130,14 +130,14 @@ class TestRepackFileUpload(AppVersionsMixin, UploadMixin, TestCase):
     def test_normalize_manifest_json_with_bom(self):
         upload = self.get_upload('webextension.xpi')
         fake_results = {'errors': 0}
-        with zipfile.ZipFile(upload.path, 'w') as z:
+        with zipfile.ZipFile(upload.file_path, 'w') as z:
             manifest = b'\xef\xbb\xbf{"manifest_version": 2, "name": "..."}'
             z.writestr('manifest.json', manifest)
 
         repack_fileupload(fake_results, upload.pk)
         upload.reload()
 
-        with zipfile.ZipFile(upload.path) as z:
+        with zipfile.ZipFile(upload.file_path) as z:
             with z.open('manifest.json') as manifest:
                 # Make sure it is valid JSON
                 assert json.loads(manifest.read())
@@ -168,7 +168,7 @@ class TestRepackFileUpload(AppVersionsMixin, UploadMixin, TestCase):
     def test_normalize_manifest_json_with_syntax_error(self):
         upload = self.get_upload('webextension.xpi')
         fake_results = {'errors': 0}
-        with zipfile.ZipFile(upload.path, 'w') as z:
+        with zipfile.ZipFile(upload.file_path, 'w') as z:
             manifest = b'{"manifest_version": 2, THIS_IS_INVALID }'
             z.writestr('manifest.json', manifest)
 
@@ -182,7 +182,7 @@ class TestRepackFileUpload(AppVersionsMixin, UploadMixin, TestCase):
     def test_normalize_manifest_json(self):
         upload = self.get_upload('webextension.xpi')
         fake_results = {'errors': 0}
-        with zipfile.ZipFile(upload.path, 'w') as z:
+        with zipfile.ZipFile(upload.file_path, 'w') as z:
             manifest_with_comments = """
             {
                 // Required
@@ -198,7 +198,7 @@ class TestRepackFileUpload(AppVersionsMixin, UploadMixin, TestCase):
         repack_fileupload(fake_results, upload.pk)
         upload.reload()
 
-        with zipfile.ZipFile(upload.path) as z:
+        with zipfile.ZipFile(upload.file_path) as z:
             with z.open('manifest.json') as manifest:
                 # Make sure it is valid JSON
                 assert json.loads(manifest.read())

--- a/src/olympia/files/tests/test_views.py
+++ b/src/olympia/files/tests/test_views.py
@@ -50,7 +50,7 @@ class TestServeFileUpload(UploadMixin, TestCase):
 
         assert resp.status_code == 200
         assert resp['content-type'] == 'application/octet-stream'
-        assert resp[settings.XSENDFILE_HEADER] == self.upload.path
+        assert resp[settings.XSENDFILE_HEADER] == self.upload.file_path
 
     def test_returns_410_when_upload_path_is_falsey(self):
         self.upload.path = ''

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -66,21 +66,24 @@ def get_filepath(fileorpath):
     elif isinstance(fileorpath, File):
         return fileorpath.file
     elif isinstance(fileorpath, FileUpload):
-        return fileorpath.path
+        return fileorpath.file_path
     elif hasattr(fileorpath, 'name'):  # file-like object
         return fileorpath.name
     return fileorpath
 
 
 def get_file(fileorpath):
-    """Get a file-like object, whether given a FileUpload object or a path."""
-    if hasattr(fileorpath, 'path'):  # FileUpload
+    """Get a file-like object, whether given a FileUpload, a (Django) File or
+    a path."""
+    if hasattr(fileorpath, 'file_path'):  # FileUpload
         if not fileorpath.path:
             # This upload has already been used to create a Version. Note that
             # we say "processed" but it's different than the `processed`
             # property on FileUpload, it's just used here as a generic term to
             # inform the developer this FileUpload has already been used.
             raise AlreadyUsedUpload(gettext('This upload has already been submitted.'))
+        return storage.open(fileorpath.file_path, 'rb')
+    elif hasattr(fileorpath, 'path'):
         return storage.open(fileorpath.path, 'rb')
     if hasattr(fileorpath, 'name'):
         return fileorpath

--- a/src/olympia/files/views.py
+++ b/src/olympia/files/views.py
@@ -45,12 +45,12 @@ def serve_file_upload(request, uuid):
         log.error('Denying access to %s, token invalid.', upload.id)
         raise PermissionDenied
 
-    if not upload.path:
+    if not upload.file_path:
         log.info('Preventing access to %s, upload path is falsey.' % upload.id)
         return http.HttpResponseGone('upload path does not exist anymore')
 
     return HttpResponseXSendFile(
-        request, upload.path, content_type='application/octet-stream'
+        request, upload.file_path, content_type='application/octet-stream'
     )
 
 

--- a/src/olympia/scanners/tasks.py
+++ b/src/olympia/scanners/tasks.py
@@ -67,8 +67,8 @@ def run_scanner(results, upload_pk, scanner, api_url, api_key):
     upload = FileUpload.objects.get(pk=upload_pk)
 
     try:
-        if not os.path.exists(upload.path):
-            raise ValueError(f'File "{upload.path}" does not exist.')
+        if not os.path.exists(upload.file_path):
+            raise ValueError(f'FileUpload "{upload.file_path}" does not exist.')
 
         scanner_result = ScannerResult(upload=upload, scanner=scanner)
 
@@ -179,7 +179,7 @@ def _run_yara(results, upload_pk):
     try:
         upload = FileUpload.objects.get(pk=upload_pk)
         scanner_result = ScannerResult(upload=upload, scanner=YARA)
-        _run_yara_for_path(scanner_result, upload.path)
+        _run_yara_for_path(scanner_result, upload.file_path)
         scanner_result.save()
 
         if scanner_result.has_matches:


### PR DESCRIPTION
Helps #20859

We can't migrate existing paths without breaking compatibility during the push window, so this doesn't migrate existing fileuploads, and instead handles both absolute and relative paths with a compatibility shim (`file_path`).

A database update will be needed specifically for dev (since it has old absolute paths invalid on GCP) but after 2 weeks (period after which the `gc` cron kicks in) everything should be clean again and in the future.