### PR TITLE
allow reason & url to be changed/cleared on blocklistsubmission

### DIFF
--- a/src/olympia/blocklist/admin.py
+++ b/src/olympia/blocklist/admin.py
@@ -172,6 +172,12 @@ class BlocklistSubmissionAdmin(AMOModelAdmin):
 
     state.admin_order_field = '-signoff_state'
 
+    def update_url_value(self, obj):
+        return obj.url is None
+
+    def update_reason_value(self, obj):
+        return obj.reason is None
+
     def has_delete_permission(self, request, obj=None):
         # For now, keep all BlocklistSubmission records.
         # TODO: define under what cirumstances records can be safely deleted.
@@ -266,7 +272,9 @@ class BlocklistSubmissionAdmin(AMOModelAdmin):
                     'blocks',
                     'disable_addon',
                     *changed_version_ids,
+                    'update_url_value',
                     'url',
+                    'update_reason_value',
                     'reason',
                     'updated_by',
                     'signoff_by',

--- a/src/olympia/blocklist/forms.py
+++ b/src/olympia/blocklist/forms.py
@@ -81,8 +81,8 @@ class BlocklistSubmissionForm(AMOModelForm):
     changed_version_ids = forms.fields.TypedMultipleChoiceField(
         choices=(), coerce=int, required=False
     )
-    update_reason = forms.fields.BooleanField(required=False, initial=True)
-    update_url = forms.fields.BooleanField(required=False, initial=True)
+    update_reason_value = forms.fields.BooleanField(required=False, initial=True)
+    update_url_value = forms.fields.BooleanField(required=False, initial=True)
 
     def __init__(self, data=None, *args, **kw):
         instance = kw.get('instance')
@@ -137,7 +137,7 @@ class BlocklistSubmissionForm(AMOModelForm):
                     for block in objects['blocks']
                     if block.id
                 }
-                update_field_name = f'update_{field_name}'
+                update_field_name = f'update_{field_name}_value'
                 if len(values) == 1 and (value := tuple(values)[0]):
                     # if there's just one existing value, prefill the field
                     self.initial[field_name] = value
@@ -172,7 +172,8 @@ class BlocklistSubmissionForm(AMOModelForm):
         data = self.cleaned_data
         if delay_days := data.get('delay_days', 0):
             data['delayed_until'] = datetime.now() + timedelta(days=delay_days)
-        if not data.get('update_reason'):
-            data['reason'] = None
-        if not data.get('update_url'):
-            data['url'] = None
+        for field_name in ('reason', 'url'):
+            if not data.get(f'update_{field_name}_value'):
+                data[field_name] = None
+            elif field_name in data and data[field_name] is None:
+                data[field_name] = ''

--- a/src/olympia/blocklist/templates/admin/blocklist/blocklistsubmission_add_form.html
+++ b/src/olympia/blocklist/templates/admin/blocklist/blocklistsubmission_add_form.html
@@ -78,16 +78,16 @@
       <p class="help">{{ form.disable_addon.help_text }}</p>
     </div>
     <div class="form-row">
-      {{ form.update_url }}
-      {{ form.update_url.errors }}
+      {{ form.update_url_value }}
+      {{ form.update_url_value.errors }}
       {{ form.url.errors }}
       {{ form.url.label_tag }}
       {{ form.url }}
       <p class="help">{{ form.url.help_text }}</p>
     </div>
     <div class="form-row">
-      {{ form.update_reason }}
-      {{ form.update_reason.errors }}
+      {{ form.update_reason_value }}
+      {{ form.update_reason_value.errors }}
       {{ form.reason.errors }}
       {{ form.reason.label_tag }}
       {{ form.reason }}

--- a/src/olympia/blocklist/templates/admin/blocklist/blocklistsubmission_change_form.html
+++ b/src/olympia/blocklist/templates/admin/blocklist/blocklistsubmission_change_form.html
@@ -1,5 +1,9 @@
 {% extends "admin/change_form.html" %}
-{% load admin_urls %}
+{% load admin_urls static %}
+{% block admin_change_form_document_ready %}
+{{ block.super }}
+<script type="text/javascript" src="{% static 'js/admin/blocklist_blocklistsubmission.js' %}"></script>
+{% endblock %}
 
 {% block submit_buttons_bottom %}
   <div class="submit-row">

--- a/src/olympia/blocklist/tests/test_admin.py
+++ b/src/olympia/blocklist/tests/test_admin.py
@@ -393,8 +393,8 @@ class TestBlocklistSubmissionAdmin(TestCase):
                 'changed_version_ids': changed_version_ids,
                 'url': 'dfd',
                 'reason': 'some reason',
-                'update_url': True,
-                'update_reason': True,
+                'update_url_value': True,
+                'update_reason_value': True,
                 '_save': 'Save',
             },
             follow=True,
@@ -559,8 +559,8 @@ class TestBlocklistSubmissionAdmin(TestCase):
                 'disable_addon': True,
                 'url': 'dfd',
                 'reason': 'some reason',
-                'update_url': True,
-                'update_reason': True,
+                'update_url_value': True,
+                'update_reason_value': True,
                 'delay_days': delay,
                 '_save': 'Save',
             },
@@ -827,10 +827,10 @@ class TestBlocklistSubmissionAdmin(TestCase):
                     partial_addon.current_version.id,
                 ],
                 'disable_addon': True,
-                'url': 'new url that will be ignored because no update_url=True',
+                'url': 'new url that will be ignored because no update_url_value=True',
                 'reason': 'new reason',
-                # no 'update_url'
-                'update_reason': True,
+                # no 'update_url_value'
+                'update_reason_value': True,
                 '_save': 'Save',
             },
             follow=True,
@@ -990,8 +990,8 @@ class TestBlocklistSubmissionAdmin(TestCase):
                 'action': str(BlocklistSubmission.ACTION_ADDCHANGE),
                 'url': 'dfd',
                 'reason': 'some reason',
-                'update_url': True,
-                'update_reason': True,
+                'update_url_value': True,
+                'update_reason_value': True,
                 '_save': 'Save',
             },
             follow=True,
@@ -1114,8 +1114,8 @@ class TestBlocklistSubmissionAdmin(TestCase):
                 'url': 'new.url',
                 # disable_addon defaults to True, so omitting it is changing to False
                 'reason': 'a new reason thats longer than 40 charactors',
-                'update_url': True,
-                'update_reason': True,
+                'update_url_value': True,
+                'update_reason_value': True,
                 '_save': 'Update',
             },
             follow=True,
@@ -1194,8 +1194,8 @@ class TestBlocklistSubmissionAdmin(TestCase):
                 'changed_version_ids': [],
                 'url': 'new.url',
                 'reason': 'a reason',
-                'update_url': True,
-                'update_reason': True,
+                'update_url_value': True,
+                'update_reason_value': True,
                 '_save': 'Update',
             },
             follow=True,
@@ -1244,8 +1244,8 @@ class TestBlocklistSubmissionAdmin(TestCase):
                 'changed_version_ids': [],  # should be ignored
                 'url': 'new.url',  # should be ignored
                 'reason': 'a reason',  # should be ignored
-                'update_url': True,
-                'update_reason': True,
+                'update_url_value': True,
+                'update_reason_value': True,
                 '_approve': 'Approve Submission',
             },
             follow=True,
@@ -1370,8 +1370,8 @@ class TestBlocklistSubmissionAdmin(TestCase):
                 'changed_version_ids': [],  # should be ignored
                 'url': 'new.url',  # should be ignored
                 'reason': 'a reason',  # should be ignored
-                'update_url': True,
-                'update_reason': True,
+                'update_url_value': True,
+                'update_reason_value': True,
                 '_reject': 'Reject Submission',
             },
             follow=True,
@@ -1443,8 +1443,8 @@ class TestBlocklistSubmissionAdmin(TestCase):
                 'changed_version_ids': [],  # should be ignored
                 'url': 'new.url',  # could be updated with this permission
                 'reason': 'a reason',  # could be updated with this permission
-                'update_url': True,
-                'update_reason': True,
+                'update_url_value': True,
+                'update_reason_value': True,
                 '_approve': 'Approve Submission',
             },
             follow=True,
@@ -1484,8 +1484,8 @@ class TestBlocklistSubmissionAdmin(TestCase):
                 'changed_version_ids': [],  # should be ignored
                 'url': 'new.url',  # could be updated with this permission
                 'reason': 'a reason',  # could be updated with this permission
-                'update_url': True,
-                'update_reason': True,
+                'update_url_value': True,
+                'update_reason_value': True,
                 '_reject': 'Reject Submission',
             },
             follow=True,
@@ -1517,8 +1517,8 @@ class TestBlocklistSubmissionAdmin(TestCase):
                 'changed_version_ids': [],  # should be ignored
                 'url': 'new.url',  # could be updated with this permission
                 'reason': 'a reason',  # could be updated with this permission
-                'update_url': True,
-                'update_reason': True,
+                'update_url_value': True,
+                'update_reason_value': True,
                 '_reject': 'Reject Submission',
             },
             follow=True,
@@ -1680,8 +1680,8 @@ class TestBlocklistSubmissionAdmin(TestCase):
                 'disable_addon': True,
                 'url': 'dfd',
                 'reason': 'some reason',
-                'update_url': True,
-                'update_reason': True,
+                'update_url_value': True,
+                'update_reason_value': True,
                 '_save': 'Save',
             },
             follow=True,
@@ -1726,8 +1726,8 @@ class TestBlocklistSubmissionAdmin(TestCase):
                 'changed_version_ids': [version.id],
                 'url': 'dfd',
                 'reason': 'some reason',
-                'update_url': True,
-                'update_reason': True,
+                'update_url_value': True,
+                'update_reason_value': True,
                 '_save': 'Save',
             },
             follow=True,
@@ -1838,8 +1838,8 @@ class TestBlocklistSubmissionAdmin(TestCase):
                 'changed_version_ids': [],  # should be ignored
                 'url': 'new.url',  # should be ignored
                 'reason': 'a reason',  # should be ignored
-                'update_url': True,
-                'update_reason': True,
+                'update_url_value': True,
+                'update_reason_value': True,
                 '_reject': 'Reject Submission',
             },
             follow=True,
@@ -1975,8 +1975,8 @@ class TestBlocklistSubmissionAdmin(TestCase):
                 # 'disable_addon' it's a checkbox so leaving it out is False
                 'url': 'dfd',
                 'reason': 'some reason',
-                'update_url': True,
-                'update_reason': True,
+                'update_url_value': True,
+                'update_reason_field': True,
                 'delay_days': 0,
                 '_save': 'Save',
             },

--- a/static/js/admin/blocklist_blocklistsubmission.js
+++ b/static/js/admin/blocklist_blocklistsubmission.js
@@ -27,20 +27,23 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   document
-    .querySelector('#id_update_reason')
+    .querySelector('#id_update_reason_value')
     .addEventListener('click', (e) =>
       enableIfChecked(e.target.checked, 'id_reason'),
     );
 
   document
-    .querySelector('#id_update_url')
+    .querySelector('#id_update_url_value')
     .addEventListener('click', (e) =>
       enableIfChecked(e.target.checked, 'id_url'),
     );
 
   enableIfChecked(
-    document.querySelector('#id_update_reason').checked,
+    document.querySelector('#id_update_reason_value').checked,
     'id_reason',
   );
-  enableIfChecked(document.querySelector('#id_update_url').checked, 'id_url');
+  enableIfChecked(
+    document.querySelector('#id_update_url_value').checked,
+    'id_url',
+  );
 });


### PR DESCRIPTION
fixes #20930 and fixes #20935 - because fun differences:  an empty `url` value from an input type=text into a `CharField `gets parsed as `None`; an empty `reason` value from a textarea into a `TextField `gets parsed as `''`.  (and a field defined only in the form needs to exist in fieldsets if you're relying on the default changeform template)