### PR TITLE
only create one ActivityLog for all versions blocked; use bulk_create

### DIFF
--- a/src/olympia/activity/models.py
+++ b/src/olympia/activity/models.py
@@ -685,6 +685,7 @@ class ActivityLog(ModelBase):
                 created=kw.get('created', timezone.now()),
             )
 
+        bulk_objects = defaultdict(list)
         for arg in args:
             create_kwargs = {
                 'activity_log': al,
@@ -698,17 +699,27 @@ class ActivityLog(ModelBase):
                 id_ = arg.id if isinstance(arg, ModelBase) else None
 
             if class_ == Addon:
-                AddonLog.objects.create(addon_id=id_, **create_kwargs)
+                bulk_objects[AddonLog].append(AddonLog(addon_id=id_, **create_kwargs))
             elif class_ == Version:
-                VersionLog.objects.create(version_id=id_, **create_kwargs)
+                bulk_objects[VersionLog].append(
+                    VersionLog(version_id=id_, **create_kwargs)
+                )
             elif class_ == Group:
-                GroupLog.objects.create(group_id=id_, **create_kwargs)
+                bulk_objects[GroupLog].append(GroupLog(group_id=id_, **create_kwargs))
             elif class_ == Block:
-                BlockLog.objects.create(block_id=id_, guid=arg.guid, **create_kwargs)
+                bulk_objects[BlockLog].append(
+                    BlockLog(block_id=id_, guid=arg.guid, **create_kwargs)
+                )
             elif class_ == ReviewActionReason:
-                ReviewActionReasonLog.objects.create(reason_id=id_, **create_kwargs)
+                bulk_objects[ReviewActionReasonLog].append(
+                    ReviewActionReasonLog(reason_id=id_, **create_kwargs)
+                )
             elif class_ == Rating:
-                RatingLog.objects.create(rating_id=id_, **create_kwargs)
+                bulk_objects[RatingLog].append(
+                    RatingLog(rating_id=id_, **create_kwargs)
+                )
+        for klass, instances in bulk_objects.items():
+            klass.objects.bulk_create(instances)
 
         if getattr(action, 'store_ip', False) and (
             ip_address := core.get_remote_addr()

--- a/src/olympia/blocklist/utils.py
+++ b/src/olympia/blocklist/utils.py
@@ -44,13 +44,12 @@ def block_activity_log_save(
             details['signoff_by'] = submission_obj.signoff_by.id
 
     log_create(action, obj.addon, obj.guid, obj, details=details, user=obj.updated_by)
-    for version_id in changed_version_ids:
-        log_create(
-            amo.LOG.BLOCKLIST_VERSION_BLOCKED,
-            (Version, version_id),
-            obj,
-            user=obj.updated_by,
-        )
+    log_create(
+        amo.LOG.BLOCKLIST_VERSION_BLOCKED,
+        *((Version, version_id) for version_id in changed_version_ids),
+        obj,
+        user=obj.updated_by,
+    )
 
     if submission_obj and submission_obj.signoff_by:
         log_create(
@@ -109,13 +108,12 @@ def block_activity_log_delete(obj, deleted, *, submission_obj=None, delete_user=
         details=details,
         user=submission_obj.updated_by if submission_obj else delete_user,
     )
-    for version_id in changed_version_ids:
-        log_create(
-            amo.LOG.BLOCKLIST_VERSION_UNBLOCKED,
-            (Version, version_id),
-            obj,
-            user=obj.updated_by,
-        )
+    log_create(
+        amo.LOG.BLOCKLIST_VERSION_UNBLOCKED,
+        *((Version, version_id) for version_id in changed_version_ids),
+        obj,
+        user=obj.updated_by,
+    )
 
     if submission_obj and submission_obj.signoff_by:
         args = [


### PR DESCRIPTION
fixes #20948 - with bonus: the bulk_create optimization will work for anywhere we create ActivityLogs with multiple args of the same class.