### PR TITLE
use expected django admin context when rendering add template

### DIFF
--- a/src/olympia/blocklist/admin.py
+++ b/src/olympia/blocklist/admin.py
@@ -159,6 +159,7 @@ class BlocklistSubmissionAdmin(AMOModelAdmin):
     view_on_site = False
     list_select_related = ('updated_by', 'signoff_by')
     change_form_template = 'admin/blocklist/blocklistsubmission_change_form.html'
+    add_form_template = 'admin/blocklist/blocklistsubmission_add_form.html'
     form = BlocklistSubmissionForm
 
     class Media:
@@ -390,27 +391,34 @@ class BlocklistSubmissionAdmin(AMOModelAdmin):
         else:
             # if its not a POST and no ?guids there's nothing to do so go back
             return redirect('admin:blocklist_block_add')
+
+        formsets = self.get_fieldsets(request, None)
+        admin_form = admin.helpers.AdminForm(
+            form,
+            list(formsets),
+            self.get_prepopulated_fields(request, None),
+            self.get_readonly_fields(request, None),
+            model_admin=self,
+        )
         context = {
-            'form': form,
-            'fieldsets': self.get_fieldsets(request, None),
-            'add': True,
-            'change': False,
-            'has_view_permission': self.has_view_permission(request, None),
-            'has_add_permission': self.has_add_permission(request),
-            'app_label': 'blocklist',
-            'opts': self.model._meta,
+            # standard context django admin expects
             'title': 'Delete Blocks' if is_delete else 'Block Add-ons',
-            'save_as': False,
+            'subtitle': None,
+            'adminform': admin_form,
+            'object_id': None,
+            'original': None,
+            'is_popup': False,
+            'to_field': None,
+            'media': self.media + admin_form.media,
+            'inline_admin_formsets': [],
+            'errors': admin.helpers.AdminErrorList(form, formsets),
+            'preserved_filters': self.get_preserved_filters(request),
+            # extra context we use in our custom template
+            'is_delete': is_delete,
             'block_history': self.block_history(self.model(input_guids=guids_data)),
             'submission_published': False,
-            'site_title': None,
-            'is_popup': False,
-            'form_url': '',
-            'is_delete': is_delete,
         }
-        return TemplateResponse(
-            request, 'admin/blocklist/blocklistsubmission_add_form.html', context
-        )
+        return self.render_change_form(request, context, add=True)
 
     def change_view(self, request, object_id, form_url='', extra_context=None):
         extra_context = extra_context or {}
@@ -436,8 +444,9 @@ class BlocklistSubmissionAdmin(AMOModelAdmin):
     def render_change_form(
         self, request, context, add=False, change=False, form_url='', obj=None
     ):
-        # add this to the instance so blocks() below can reference it.
-        obj._blocks = context['adminform'].form.blocks
+        if obj:
+            # add this to the instance so blocks() below can reference it.
+            obj._blocks = context['adminform'].form.blocks
         return super().render_change_form(
             request, context, add=add, change=change, form_url=form_url, obj=obj
         )

--- a/src/olympia/blocklist/templates/admin/blocklist/blocklistsubmission_add_form.html
+++ b/src/olympia/blocklist/templates/admin/blocklist/blocklistsubmission_add_form.html
@@ -28,23 +28,23 @@
 {% block content %}<div id="content-main">
   <form action="{{ form_url }}" method="post" id="{{ opts.model_name }}_form" novalidate>
   {% csrf_token %}
-  {{ form.action }}
-  {{ form.input_guids }}
-  {% if not form.existing_guids|length == 0 or not form.invalid_guids|length == 0 %}
+  {{ adminform.form.action }}
+  {{ adminform.form.input_guids }}
+  {% if not adminform.form.existing_guids|length == 0 or not adminform.form.invalid_guids|length == 0 %}
   <div>
     <div class="form-row horizontal-grid">
       <div>
-        <h3>{{ form.existing_guids|length }} Add-on GUIDs already completely blocked:</h3>
+        <h3>{{ adminform.form.existing_guids|length }} Add-on GUIDs already completely blocked:</h3>
         <ul class="guid_list field-existing-guids">
-          {% for guid in form.existing_guids %}
+          {% for guid in adminform.form.existing_guids %}
           <li>{{ guid }}</li>
           {% endfor %}
         </ul>
       </div>
       <div>
-        <h3>{{ form.invalid_guids|length }} Add-on GUIDs were not found:</h3>
+        <h3>{{ adminform.form.invalid_guids|length }} Add-on GUIDs were not found:</h3>
         <ul class="guid_list">
-          {% for guid in form.invalid_guids %}
+          {% for guid in adminform.form.invalid_guids %}
           <li>{{ guid }}</li>
           {% endfor %}
         </ul>
@@ -56,9 +56,9 @@
     <h2>{{ fieldsets.2.0 }}</h2>
     <div class="form-row field-blocks-to-add">
       <div>
-        {% include 'admin/blocklist/includes/enhanced_blocks.html' %}
+        {% include 'admin/blocklist/includes/enhanced_blocks.html' with form=adminform.form %}
       </div>
-      {{ form.changed_version_ids.errors }}
+      {{ adminform.form.changed_version_ids.errors }}
     </div>
     {% if block_history %}
     <div class="form-row field-block_history">
@@ -66,39 +66,39 @@
       <div class="readonly">{{ block_history }}</div>
     </div>
     {% endif %}
-    {% if form.non_field_errors %}
+    {% if adminform.form.non_field_errors %}
     <div class="form-row">
-      {{ form.non_field_errors }}
+      {{ adminform.form.non_field_errors }}
     </div>
     {% endif %}
     <div class="form-row">
-      {{ form.disable_addon.errors }}
-      {{ form.disable_addon.label_tag }}
-      {{ form.disable_addon }}
-      <p class="help">{{ form.disable_addon.help_text }}</p>
+      {{ adminform.form.disable_addon.errors }}
+      {{ adminform.form.disable_addon.label_tag }}
+      {{ adminform.form.disable_addon }}
+      <p class="help">{{ adminform.form.disable_addon.help_text }}</p>
     </div>
     <div class="form-row">
-      {{ form.update_url_value }}
-      {{ form.update_url_value.errors }}
-      {{ form.url.errors }}
-      {{ form.url.label_tag }}
-      {{ form.url }}
-      <p class="help">{{ form.url.help_text }}</p>
+      {{ adminform.form.update_url_value }}
+      {{ adminform.form.update_url_value.errors }}
+      {{ adminform.form.url.errors }}
+      {{ adminform.form.url.label_tag }}
+      {{ adminform.form.url }}
+      <p class="help">{{ adminform.form.url.help_text }}</p>
     </div>
     <div class="form-row">
-      {{ form.update_reason_value }}
-      {{ form.update_reason_value.errors }}
-      {{ form.reason.errors }}
-      {{ form.reason.label_tag }}
-      {{ form.reason }}
-      <p class="help">{{ form.reason.help_text }}</p>
+      {{ adminform.form.update_reason_value }}
+      {{ adminform.form.update_reason_value.errors }}
+      {{ adminform.form.reason.errors }}
+      {{ adminform.form.reason.label_tag }}
+      {{ adminform.form.reason }}
+      <p class="help">{{ adminform.form.reason.help_text }}</p>
     </div>
     <div class="form-row">
-      {{ form.delay_days.errors }}
-      {{ form.delayed_until.errors }}
-      {{ form.delay_days.label_tag }}
-      {{ form.delay_days }}
-      <p class="help">{{ form.delay_days.help_text }}</p>
+      {{ adminform.form.delay_days.errors }}
+      {{ adminform.form.delayed_until.errors }}
+      {{ adminform.form.delay_days.label_tag }}
+      {{ adminform.form.delay_days }}
+      <p class="help">{{ adminform.form.delay_days.help_text }}</p>
     </div>
     {% block submit_buttons_bottom %}
     <div class="submit-row">


### PR DESCRIPTION
fixes #20950 - maybe some rainy day I'll spend the time to refactor away our custom `add_view` entirely (for some definition of "away" that would mean moving the logic around the admin class and form)