### PR TITLE
Enforce 2FA on extension submission flow, api keys page

### DIFF
--- a/src/olympia/accounts/decorators.py
+++ b/src/olympia/accounts/decorators.py
@@ -1,0 +1,23 @@
+import functools
+
+
+import olympia.core.logger
+from olympia.accounts.utils import redirect_for_login_with_two_factor_authentication
+
+
+# Needs to match accounts/views.py
+log = olympia.core.logger.getLogger('accounts')
+
+
+def two_factor_auth_required(f):
+    """Require the user to be authenticated and have 2FA enabled."""
+
+    @functools.wraps(f)
+    def wrapper(request, *args, **kw):
+        if not request.session.get('two_factor_authentication'):
+            # Note: Technically the user might not be logged in at this point.
+            log.info('Redirecting user %s to enforce 2FA', request.user)
+            return redirect_for_login_with_two_factor_authentication(request)
+        return f(request, *args, **kw)
+
+    return wrapper

--- a/src/olympia/accounts/decorators.py
+++ b/src/olympia/accounts/decorators.py
@@ -1,6 +1,5 @@
 import functools
 
-
 import olympia.core.logger
 from olympia.accounts.utils import redirect_for_login_with_two_factor_authentication
 

--- a/src/olympia/accounts/decorators.py
+++ b/src/olympia/accounts/decorators.py
@@ -16,8 +16,9 @@ def two_factor_auth_required(f):
         if not request.session.get('has_two_factor_authentication'):
             # Note: Technically the user might not be logged in or not, it does
             # not matter, if they are they need to go through FxA again anyway.
+            login_hint = request.user.email if request.user.is_authenticated else None
             log.info('Redirecting user %s to enforce 2FA', request.user)
-            return redirect_for_login_with_2fa_enforced(request)
+            return redirect_for_login_with_2fa_enforced(request, login_hint=login_hint)
         return f(request, *args, **kw)
 
     return wrapper

--- a/src/olympia/accounts/decorators.py
+++ b/src/olympia/accounts/decorators.py
@@ -14,7 +14,8 @@ def two_factor_auth_required(f):
     @functools.wraps(f)
     def wrapper(request, *args, **kw):
         if not request.session.get('has_two_factor_authentication'):
-            # Note: Technically the user might not be logged in at this point.
+            # Note: Technically the user might not be logged in or not, it does
+            # not matter, if they are they need to go through FxA again anyway.
             log.info('Redirecting user %s to enforce 2FA', request.user)
             return redirect_for_login_with_2fa_enforced(request)
         return f(request, *args, **kw)

--- a/src/olympia/accounts/decorators.py
+++ b/src/olympia/accounts/decorators.py
@@ -1,7 +1,7 @@
 import functools
 
 import olympia.core.logger
-from olympia.accounts.utils import redirect_for_login_with_two_factor_authentication
+from olympia.accounts.utils import redirect_for_login_with_2fa_enforced
 
 
 # Needs to match accounts/views.py
@@ -13,10 +13,10 @@ def two_factor_auth_required(f):
 
     @functools.wraps(f)
     def wrapper(request, *args, **kw):
-        if not request.session.get('two_factor_authentication'):
+        if not request.session.get('has_two_factor_authentication'):
             # Note: Technically the user might not be logged in at this point.
             log.info('Redirecting user %s to enforce 2FA', request.user)
-            return redirect_for_login_with_two_factor_authentication(request)
+            return redirect_for_login_with_2fa_enforced(request)
         return f(request, *args, **kw)
 
     return wrapper

--- a/src/olympia/accounts/tests/test_decorators.py
+++ b/src/olympia/accounts/tests/test_decorators.py
@@ -1,0 +1,45 @@
+from unittest import mock
+
+from django.contrib.auth.models import AnonymousUser
+from django.test.client import RequestFactory
+
+from olympia.accounts.decorators import two_factor_auth_required
+from olympia.accounts.utils import redirect_for_login_with_2fa_enforced
+from olympia.amo.tests import TestCase, user_factory
+
+
+class TestTwoFactorAuthRequired(TestCase):
+    def setUp(self):
+        self.user = user_factory()
+        self.f = mock.Mock()
+        self.f.__name__ = 'function'
+        self.f.return_value = 'FakeResponse'
+        self.request = RequestFactory().get('/')
+        self.request.session = {}
+        self.request.user = AnonymousUser()
+
+    def test_has_two_factor_auth(self):
+        self.request.session['has_two_factor_authentication'] = True
+        func = two_factor_auth_required(self.f)
+        response = func(self.request)
+        assert self.f.call_count == 1
+        assert response == 'FakeResponse'
+
+    def test_does_not_have_two_factor_auth_yet(self):
+        self.request.user = self.user
+        func = two_factor_auth_required(self.f)
+        response = func(self.request)
+        assert self.f.call_count == 0
+        expected_redirect_url = redirect_for_login_with_2fa_enforced(self.request)[
+            'location'
+        ]
+        self.assert3xx(response, expected_redirect_url)
+
+    def test_does_not_have_two_factor_auth_yet_anonymous(self):
+        func = two_factor_auth_required(self.f)
+        response = func(self.request)
+        assert self.f.call_count == 0
+        expected_redirect_url = redirect_for_login_with_2fa_enforced(self.request)[
+            'location'
+        ]
+        self.assert3xx(response, expected_redirect_url)

--- a/src/olympia/accounts/tests/test_decorators.py
+++ b/src/olympia/accounts/tests/test_decorators.py
@@ -30,9 +30,9 @@ class TestTwoFactorAuthRequired(TestCase):
         func = two_factor_auth_required(self.f)
         response = func(self.request)
         assert self.f.call_count == 0
-        expected_redirect_url = redirect_for_login_with_2fa_enforced(self.request)[
-            'location'
-        ]
+        expected_redirect_url = redirect_for_login_with_2fa_enforced(
+            self.request, login_hint=self.user.email
+        )['location']
         self.assert3xx(response, expected_redirect_url)
 
     def test_does_not_have_two_factor_auth_yet_anonymous(self):

--- a/src/olympia/accounts/tests/test_utils.py
+++ b/src/olympia/accounts/tests/test_utils.py
@@ -1,6 +1,6 @@
 from base64 import urlsafe_b64decode, urlsafe_b64encode
-from urllib.parse import parse_qs, urlparse
 from unittest import mock
+from urllib.parse import parse_qs, urlparse
 
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory

--- a/src/olympia/accounts/tests/test_utils.py
+++ b/src/olympia/accounts/tests/test_utils.py
@@ -28,8 +28,7 @@ def test_fxa_login_url_without_requiring_two_factor_auth():
         config=FXA_CONFIG['default'],
         state=request.session['fxa_state'],
         next_path=path,
-        action='signin',
-        force_two_factor=False,
+        enforce_2fa=False,
     )
 
     url = urlparse(raw_url)
@@ -40,7 +39,6 @@ def test_fxa_login_url_without_requiring_two_factor_auth():
     query = parse_qs(url.query)
     next_path = urlsafe_b64encode(path.encode('utf-8')).rstrip(b'=')
     assert query == {
-        'action': ['signin'],
         'client_id': ['foo'],
         'scope': ['profile openid'],
         'state': [f'myfxastate:{force_str(next_path)}'],
@@ -59,8 +57,7 @@ def test_fxa_login_url_requiring_two_factor_auth():
         config=FXA_CONFIG['default'],
         state=request.session['fxa_state'],
         next_path=path,
-        action='signin',
-        force_two_factor=True,
+        enforce_2fa=True,
     )
 
     url = urlparse(raw_url)
@@ -72,7 +69,6 @@ def test_fxa_login_url_requiring_two_factor_auth():
     next_path = urlsafe_b64encode(path.encode('utf-8')).rstrip(b'=')
     assert query == {
         'acr_values': ['AAL2'],
-        'action': ['signin'],
         'client_id': ['foo'],
         'scope': ['profile openid'],
         'state': [f'myfxastate:{force_str(next_path)}'],
@@ -91,9 +87,8 @@ def test_fxa_login_url_requiring_two_factor_auth_passing_token():
         config=FXA_CONFIG['default'],
         state=request.session['fxa_state'],
         next_path=path,
-        action='signin',
-        force_two_factor=True,
-        id_token='YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo=',
+        enforce_2fa=True,
+        id_token_hint='YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo=',
     )
 
     url = urlparse(raw_url)
@@ -105,7 +100,6 @@ def test_fxa_login_url_requiring_two_factor_auth_passing_token():
     next_path = urlsafe_b64encode(path.encode('utf-8')).rstrip(b'=')
     assert query == {
         'acr_values': ['AAL2'],
-        'action': ['signin'],
         'client_id': ['foo'],
         'id_token_hint': ['YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo='],
         'prompt': ['none'],
@@ -123,7 +117,6 @@ def test_unicode_next_path():
         config=FXA_CONFIG['default'],
         state=request.session['fxa_state'],
         next_path=utils.path_with_query(request),
-        action='signin',
     )
     state = parse_qs(urlparse(url).query)['state'][0]
     next_path = urlsafe_b64decode(state.split(':')[1] + '===')
@@ -139,7 +132,6 @@ def test_redirect_for_login():
         config=FXA_CONFIG['default'],
         state=request.session['fxa_state'],
         next_path='/somewhere',
-        action='signin',
     )
 
 
@@ -152,7 +144,6 @@ def test_fxa_login_url_when_faking_fxa_auth():
         config=FXA_CONFIG['default'],
         state=request.session['fxa_state'],
         next_path=path,
-        action='signin',
     )
     url = urlparse(raw_url)
     assert url.scheme == ''
@@ -161,7 +152,6 @@ def test_fxa_login_url_when_faking_fxa_auth():
     query = parse_qs(url.query)
     next_path = urlsafe_b64encode(path.encode('utf-8')).rstrip(b'=')
     assert query == {
-        'action': ['signin'],
         'client_id': ['foo'],
         'scope': ['profile openid'],
         'state': [f'myfxastate:{force_str(next_path)}'],

--- a/src/olympia/accounts/tests/test_utils.py
+++ b/src/olympia/accounts/tests/test_utils.py
@@ -115,41 +115,10 @@ def test_fxa_login_url_requiring_two_factor_auth_passing_token():
 
 @override_settings(FXA_CONFIG=FXA_CONFIG)
 @override_settings(FXA_OAUTH_HOST='https://accounts.firefox.com/oauth')
-def test_fxa_login_url_requiring_two_factor_auth_passing_nothing():
+def test_fxa_login_url_requiring_two_factor_auth_passing_request():
     path = '/en-US/addons/abp/?source=ddg'
     request = RequestFactory().get(path)
     request.session = {'fxa_state': 'myfxastate'}
-
-    raw_url = utils.fxa_login_url(
-        config=FXA_CONFIG['default'],
-        state=request.session['fxa_state'],
-        next_path=path,
-        enforce_2fa=True,
-    )
-
-    url = urlparse(raw_url)
-    base = '{scheme}://{netloc}{path}'.format(
-        scheme=url.scheme, netloc=url.netloc, path=url.path
-    )
-    assert base == 'https://accounts.firefox.com/oauth/authorization'
-    query = parse_qs(url.query)
-    next_path = urlsafe_b64encode(path.encode('utf-8')).rstrip(b'=')
-    assert query == {
-        'acr_values': ['AAL2'],
-        'client_id': ['foo'],
-        'scope': ['profile openid'],
-        'state': [f'myfxastate:{force_str(next_path)}'],
-        'access_type': ['offline'],
-    }
-
-
-@override_settings(FXA_CONFIG=FXA_CONFIG)
-@override_settings(FXA_OAUTH_HOST='https://accounts.firefox.com/oauth')
-def test_fxa_login_url_requiring_two_factor_auth_passing_nothing_with_anonymous_user():
-    path = '/en-US/addons/abp/?source=ddg'
-    request = RequestFactory().get(path)
-    request.session = {'fxa_state': 'myfxastate'}
-    request.user = AnonymousUser()
 
     raw_url = utils.fxa_login_url(
         config=FXA_CONFIG['default'],
@@ -181,7 +150,6 @@ def test_fxa_login_url_requiring_two_factor_auth_passing_login_hint():
     path = '/en-US/addons/abp/?source=ddg'
     request = RequestFactory().get(path)
     request.session = {'fxa_state': 'myfxastate'}
-    request.user = mock.Mock(is_authenticated=True, email='test@example.com')
 
     raw_url = utils.fxa_login_url(
         config=FXA_CONFIG['default'],
@@ -189,6 +157,7 @@ def test_fxa_login_url_requiring_two_factor_auth_passing_login_hint():
         next_path=path,
         enforce_2fa=True,
         request=request,
+        login_hint='test@example.com',
     )
 
     url = urlparse(raw_url)

--- a/src/olympia/accounts/tests/test_utils.py
+++ b/src/olympia/accounts/tests/test_utils.py
@@ -266,18 +266,21 @@ def test_fxa_login_url_when_faking_fxa_auth():
     },
     DEFAULT_FXA_CONFIG_NAME='baz',
 )
-class TestGetFxaConfig(TestCase):
+class TestGetFxaConfigAndName(TestCase):
     def test_no_config(self):
         request = RequestFactory().get('/login')
+        assert utils.get_fxa_config_name(request) == 'baz'
         config = utils.get_fxa_config(request)
         assert config == {'BAZ': 789}
 
     def test_config_alternate(self):
         request = RequestFactory().get('/login?config=bar')
+        assert utils.get_fxa_config_name(request) == 'bar'
         config = utils.get_fxa_config(request)
         assert config == {'BAR': 456}
 
     def test_config_is_default(self):
         request = RequestFactory().get('/login?config=baz')
+        assert utils.get_fxa_config_name(request) == 'baz'
         config = utils.get_fxa_config(request)
         assert config == {'BAZ': 789}

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -88,7 +88,6 @@ class TestLoginStartBaseView(WithDynamicEndpoints, TestCase):
         with mock.patch(
             'olympia.accounts.utils.generate_fxa_state', lambda: 'arandomstring'
         ):
-            # FIXME: I'm getting a next I shouldn't have, right ?
             response = self.client.get(self.url)
         assert response.status_code == 302
         assert (

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -521,7 +521,8 @@ class TestWithUser(TestCase):
             ),
         }
         response = self.fn(self.request)
-        self.assertRedirects(response, '/next', fetch_redirect_response=False)
+        # next path is ignored as state is not reliable.
+        self.assertRedirects(response, '/', fetch_redirect_response=False)
 
     @override_settings(
         FXA_CONFIG={'a_conf': {'client_id': 'clientid', 'client_secret': 'supersikret'}}
@@ -788,7 +789,8 @@ class TestAuthenticateView(TestCase, InitializeSessionMixin):
             response['Cache-Control']
             == 'max-age=0, no-cache, no-store, must-revalidate, private'
         )
-        assert_url_equal(response['location'], '/en-US/firefox/')
+        # next path is ignored as state is not reliable.
+        assert_url_equal(response['location'], '/')
         assert not self.login_user.called
         assert not self.register_user.called
         assert not self.reregister_user.called
@@ -800,7 +802,21 @@ class TestAuthenticateView(TestCase, InitializeSessionMixin):
             response['Cache-Control']
             == 'max-age=0, no-cache, no-store, must-revalidate, private'
         )
-        assert_url_equal(response['location'], '/en-US/firefox/')
+        # next path is ignored as state is not reliable.
+        assert_url_equal(response['location'], '/')
+        assert not self.login_user.called
+        assert not self.register_user.called
+        assert not self.reregister_user.called
+
+    def test_error_from_fxa(self):
+        response = self.client.get(self.url, {'error': 'foo', 'state': '9f865be0'})
+        assert response.status_code == 302
+        assert (
+            response['Cache-Control']
+            == 'max-age=0, no-cache, no-store, must-revalidate, private'
+        )
+        # next path is ignored as state is not reliable.
+        assert_url_equal(response['location'], '/')
         assert not self.login_user.called
         assert not self.register_user.called
         assert not self.reregister_user.called

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -675,7 +675,7 @@ class TestWithUser(TestCase):
         )
         # Since the authentication was successful and satistified our 2FA
         # requirement, we removed the property from the session.
-        assert 'enforce_2fa' in self.request.session
+        assert 'enforce_2fa' not in self.request.session
 
     def test_2fa_enforced_on_this_view_should_redirect_for_two_factor_auth(self):
         self.create_flag('2fa-enforcement-for-developers-and-special-users')

--- a/src/olympia/accounts/utils.py
+++ b/src/olympia/accounts/utils.py
@@ -3,13 +3,12 @@ import os
 from base64 import urlsafe_b64encode
 from urllib.parse import urlencode
 
-import olympia.core.logger
-
 from django.conf import settings
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.encoding import force_str
 
+import olympia.core.logger
 from olympia.amo.utils import is_safe_url, use_fake_fxa
 
 
@@ -70,13 +69,17 @@ def generate_fxa_state():
     return force_str(binascii.hexlify(os.urandom(32)))
 
 
-def get_fxa_config(request):
+def get_fxa_config_name(request):
     config_name = request.GET.get('config')
     if config_name not in settings.FXA_CONFIG:
         if config_name:
             log.info(f'Using default FxA config instead of {config_name}')
         config_name = settings.DEFAULT_FXA_CONFIG_NAME
-    return settings.FXA_CONFIG[config_name]
+    return config_name
+
+
+def get_fxa_config(request):
+    return settings.FXA_CONFIG[get_fxa_config_name(request)]
 
 
 def redirect_for_login(request, *, config=None, next_path=None):

--- a/src/olympia/accounts/utils.py
+++ b/src/olympia/accounts/utils.py
@@ -16,9 +16,9 @@ def fxa_login_url(
     state,
     next_path=None,
     action=None,
-    force_two_factor=False,
+    enforce_two_factor_authentication=False,
     request=None,
-    id_token=None,
+    id_token_hint=None,
 ):
     if next_path and is_safe_url(next_path, request):
         state += ':' + force_str(urlsafe_b64encode(next_path.encode('utf-8'))).rstrip(
@@ -32,18 +32,37 @@ def fxa_login_url(
     }
     if action is not None:
         query['action'] = action
-    if force_two_factor is True:
+    if enforce_two_factor_authentication is True:
         # Specifying AAL2 will require the token to have an authentication
         # assurance level >= 2 which corresponds to requiring 2FA.
         query['acr_values'] = 'AAL2'
-        # Requesting 'prompt=none' during authorization, together with passing
-        # a valid id token in 'id_token_hint', allows the user to not have to
-        # re-authenticate with FxA if they still have a valid session (which
-        # they should here: they went through FxA, back to AMO, and now we're
-        # redirecting them to FxA because we want them to have 2FA enabled).
-        if id_token:
+        # Requesting 'prompt=none' during authorization allows the user to not
+        # have to re-authenticate with FxA if they still have a valid session,
+        # in case they just went through FxA, then back to AMO only to find out
+        # we are requiring 2FA. To let FxA know who the user should be, we pass
+        # id_token_hint, which we have in this specific case.
+        # If we didn't just go through authentication, that means the user was
+        # alraedy logged in but we enforced 2FA at a later stage. We don't have
+        # id_token_hint, but we can pass login_hint instead.
+        # FIXME: this doesn't work, getting redirected to our callback with an
+        # unauthorized_client error from FxA. According to the docs usage of
+        # id_token_hint is always allowed but login_hint isn't, so we need to
+        # have our oauth client configs be explicitly allowed.
+        # https://mozilla.github.io/ecosystem-platform/reference/oauth-details
+        # #promptnone-support
+        # FIXME: this highlights the fact that we need to handle error cases
+        # and regenerate a new state to start from scratch - right now we're
+        # ignoring them, so the user can't recover. I'm not sure what's
+        # supposed to happen if the user goes to FxA with prompt=none and
+        # login_hint=email if they no longer have a valid FxA session (ideally
+        # FxA would handle that gracefully), but if an error is raised we'll
+        # need to handle it.
+        if id_token_hint:
             query['prompt'] = 'none'
-            query['id_token_hint'] = id_token
+            query['id_token_hint'] = id_token_hint
+        elif request and request.user.is_authenticated:
+            query['prompt'] = 'none'
+            query['login_hint'] = request.user.email
     if use_fake_fxa():
         base_url = reverse('fake-fxa-authorization')
     else:
@@ -62,6 +81,25 @@ def redirect_for_login(request):
         state=request.session['fxa_state'],
         next_path=path_with_query(request),
         action='signin',
+    )
+    return HttpResponseRedirect(url)
+
+
+def redirect_for_login_with_two_factor_authentication(
+    request, *, config=None, next_path=None, id_token_hint=None
+):
+    if config is None:
+        config = settings.FXA_CONFIG['default']
+    if next_path is None:
+        next_path = path_with_query(request)
+    request.session['enforce_two_factor_authentication'] = True
+    url = fxa_login_url(
+        config=config,
+        state=request.session['fxa_state'],
+        next_path=next_path,
+        action='signin',
+        enforce_two_factor_authentication=True,
+        id_token_hint=id_token_hint,
     )
     return HttpResponseRedirect(url)
 

--- a/src/olympia/accounts/utils.py
+++ b/src/olympia/accounts/utils.py
@@ -93,9 +93,9 @@ def redirect_for_login(request, *, config=None, next_path=None):
     # page they were on.
     request.session['enforce_2fa'] = False
     url = fxa_login_url(
-        config=get_fxa_config(request),
+        config=config,
         state=request.session['fxa_state'],
-        next_path=path_with_query(request),
+        next_path=next_path,
     )
     return HttpResponseRedirect(url)
 

--- a/src/olympia/accounts/utils.py
+++ b/src/olympia/accounts/utils.py
@@ -22,6 +22,7 @@ def fxa_login_url(
     enforce_2fa=False,
     request=None,
     id_token_hint=None,
+    login_hint=None,
 ):
     if next_path and is_safe_url(next_path, request):
         state += ':' + force_str(urlsafe_b64encode(next_path.encode('utf-8'))).rstrip(
@@ -55,9 +56,9 @@ def fxa_login_url(
         if id_token_hint:
             query['prompt'] = 'none'
             query['id_token_hint'] = id_token_hint
-        elif request and request.user.is_authenticated:
+        elif login_hint:
             query['prompt'] = 'none'
-            query['login_hint'] = request.user.email
+            query['login_hint'] = login_hint
     if use_fake_fxa():
         base_url = reverse('fake-fxa-authorization')
     else:
@@ -101,7 +102,7 @@ def redirect_for_login(request, *, config=None, next_path=None):
 
 
 def redirect_for_login_with_2fa_enforced(
-    request, *, config=None, next_path=None, id_token_hint=None
+    request, *, config=None, next_path=None, id_token_hint=None, login_hint=None
 ):
     if config is None:
         config = get_fxa_config(request)
@@ -115,6 +116,8 @@ def redirect_for_login_with_2fa_enforced(
         next_path=next_path,
         enforce_2fa=True,
         id_token_hint=id_token_hint,
+        login_hint=login_hint,
+        request=request,
     )
     return HttpResponseRedirect(url)
 

--- a/src/olympia/accounts/utils.py
+++ b/src/olympia/accounts/utils.py
@@ -92,6 +92,7 @@ def redirect_for_login_with_two_factor_authentication(
         config = settings.FXA_CONFIG['default']
     if next_path is None:
         next_path = path_with_query(request)
+    request.session.setdefault('fxa_state', generate_fxa_state())
     request.session['enforce_two_factor_authentication'] = True
     url = fxa_login_url(
         config=config,

--- a/src/olympia/accounts/utils.py
+++ b/src/olympia/accounts/utils.py
@@ -83,11 +83,11 @@ def get_fxa_config(request):
 
 
 def redirect_for_login(request, *, config=None, next_path=None):
-    request.session.setdefault('fxa_state', generate_fxa_state())
     if config is None:
         config = get_fxa_config(request)
     if next_path is None:
         next_path = path_with_query(request)
+    request.session.setdefault('fxa_state', generate_fxa_state())
     # Previous page in session might have required 2FA, but this page doesn't.
     # We override it in case the user didn't complete the flow for the previous
     # page they were on.

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -75,6 +75,7 @@ from .serializers import (
 from .tasks import clear_sessions_event, delete_user_event, primary_email_change_event
 from .utils import (
     get_fxa_config,
+    get_fxa_config_name,
     redirect_for_login,
     redirect_for_login_with_2fa_enforced,
 )
@@ -227,7 +228,7 @@ def with_user(f):
         # the old fxa state or 2FA enforcement active for future authentication
         # attempts.
         enforce_2fa_for_this_session = request.session.pop('enforce_2fa', False)
-        fxa_state_session = request.session.pop('fxa_state')
+        fxa_state_session = request.session.pop('fxa_state', None)
 
         fxa_config = get_fxa_config(request)
         if request.method == 'GET':
@@ -268,7 +269,7 @@ def with_user(f):
                 identity, token_data = verify.fxa_identify(
                     data['code'], config=fxa_config
                 )
-                token_data['config_name'] = self.get_config_name(request)
+                token_data['config_name'] = get_fxa_config_name(request)
                 id_token = token_data.get('id_token')
         except verify.IdentificationError:
             log.info('Profile not found. Code: {}'.format(data['code']))

--- a/src/olympia/amo/templates/amo/fake_fxa_authorization.html
+++ b/src/olympia/amo/templates/amo/fake_fxa_authorization.html
@@ -11,7 +11,7 @@
     {% endfor %}
     <input type="hidden" name="code" value="fakecode" />
     <label for="id_email">{{ _('Email:') }}</label> <input type="email" name="fake_fxa_email" id="id_email" />
-    <label><input type="checkbox" name="fake_two_factor_authentication" />{{ _('Two-step authentication') }}</label>
+    <label><input type="checkbox" name="fake_two_factor_authentication" value="true" />{{ _('Two-step authentication') }}</label>
     <input type="submit" value="{{ _('OK') }}" />
 
     {% if interesting_accounts %}

--- a/src/olympia/amo/templates/amo/fake_fxa_authorization.html
+++ b/src/olympia/amo/templates/amo/fake_fxa_authorization.html
@@ -11,6 +11,7 @@
     {% endfor %}
     <input type="hidden" name="code" value="fakecode" />
     <label for="id_email">{{ _('Email:') }}</label> <input type="email" name="fake_fxa_email" id="id_email" />
+    <label><input type="checkbox" name="fake_two_factor_authentication" />{{ _('Two-step authentication') }}</label>
     <input type="submit" value="{{ _('OK') }}" />
 
     {% if interesting_accounts %}

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -285,6 +285,17 @@ class TestClient(Client):
         else:
             raise AttributeError
 
+    def force_login_with_2fa(self, user, backend=None):
+        self.force_login(user, backend=backend)
+        # https://docs.djangoproject.com/en/dev/topics/testing/tools/
+        # #django.test.Client.session
+        # To modify the session and then save it, it must be stored in a
+        # variable first (because a new SessionStore is created every time this
+        # property is accessed)
+        session = self.session
+        session['has_two_factor_authentication'] = True
+        session.save()
+
 
 class APITestClientSessionID(APIClient):
     def create_session(self, user, **overrides):

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -393,7 +393,6 @@ def fxa_login_link(response=None, to=None, request=None):
         config=settings.FXA_CONFIG['default'],
         state=state,
         next_path=to,
-        action='signin',
     )
 
 

--- a/src/olympia/amo/tests/test_middleware.py
+++ b/src/olympia/amo/tests/test_middleware.py
@@ -352,7 +352,6 @@ class TestTokenValidMiddleware(TestCase):
             config=settings.FXA_CONFIG['default'],
             state=request.session['fxa_state'],
             next_path=path_with_query(request),
-            action='signin',
         )
 
     def test_anonymous_user(self):

--- a/src/olympia/devhub/decorators.py
+++ b/src/olympia/devhub/decorators.py
@@ -18,7 +18,7 @@ def dev_required(
     submitting=False,
     qs=Addon.objects.all,
 ):
-    """Requires user to be add-on owner or admin.
+    """Require user to be add-on owner or admin.
 
     When owner_for_post is True, only owners can make a POST request. That
     argument can also be a callable.
@@ -100,7 +100,7 @@ def dev_required(
 
 
 def no_admin_disabled(f):
-    """Requires the addon not be STATUS_DISABLED (mozilla admin disabled)."""
+    """Require the addon not be STATUS_DISABLED (mozilla admin disabled)."""
 
     @functools.wraps(f)
     def wrapper(*args, **kw):

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -840,7 +840,7 @@ class TestAPIKeyPage(TestCase):
     def setUp(self):
         super().setUp()
         self.url = reverse('devhub.api_key')
-        self.client.force_login(UserProfile.objects.get(email='del@icio.us'))
+        self.client.force_login_with_2fa(UserProfile.objects.get(email='del@icio.us'))
         self.user = UserProfile.objects.get(email='del@icio.us')
         self.user.update(last_login_ip='192.168.1.1')
 

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -38,6 +38,7 @@ from olympia.applications.models import AppVersion
 from olympia.constants.promoted import RECOMMENDED
 from olympia.devhub.decorators import dev_required
 from olympia.devhub.models import BlogPost
+from olympia.devhub.tasks import validate
 from olympia.devhub.views import get_next_version_number
 from olympia.files.models import FileUpload
 from olympia.files.tests.test_models import UploadMixin
@@ -1108,7 +1109,8 @@ class TestUpload(UploadMixin, TestCase):
 
     def setUp(self):
         super().setUp()
-        self.client.force_login(UserProfile.objects.get(email='regular@mozilla.com'))
+        self.user = UserProfile.objects.get(email='regular@mozilla.com')
+        self.client.force_login(self.user)
         self.url = reverse('devhub.upload')
         self.xpi_path = self.file_path('webextension_no_id.xpi')
 
@@ -1125,6 +1127,7 @@ class TestUpload(UploadMixin, TestCase):
         assert response.status_code == 302
 
     def test_create_fileupload(self):
+        self.client.force_login_with_2fa(self.user)
         self.post()
 
         upload = FileUpload.objects.filter().order_by('-created').first()
@@ -1141,15 +1144,16 @@ class TestUpload(UploadMixin, TestCase):
         assert manifest_data == original_manifest_data
 
     def test_fileupload_metadata(self):
-        user = UserProfile.objects.get(email='regular@mozilla.com')
-        self.client.force_login(user)
+        self.client.force_login_with_2fa(self.user)
+        self.client.force_login(self.user)
         self.post(REMOTE_ADDR='4.8.15.16.23.42')
         upload = FileUpload.objects.get()
-        assert upload.user == user
+        assert upload.user == self.user
         assert upload.source == amo.UPLOAD_SOURCE_DEVHUB
         assert upload.ip_address == '4.8.15.16.23.42'
 
     def test_fileupload_validation_not_a_xpi_file(self):
+        self.client.force_login_with_2fa(self.user)
         self.xpi_path = get_image_path('animated.png')  # not a xpi file.
         self.post()
         upload = FileUpload.objects.filter().order_by('-created').first()
@@ -1170,6 +1174,7 @@ class TestUpload(UploadMixin, TestCase):
         assert not msg['description']
 
     def test_redirect(self):
+        self.client.force_login_with_2fa(self.user)
         response = self.post()
         upload = FileUpload.objects.get()
         assert upload.channel == amo.CHANNEL_LISTED
@@ -1184,6 +1189,7 @@ class TestUpload(UploadMixin, TestCase):
     @mock.patch('olympia.devhub.tasks.validate')
     def test_upload_unlisted_addon(self, validate_mock):
         """Unlisted addons are validated as "self hosted" addons."""
+        self.client.force_login_with_2fa(self.user)
         validate_mock.return_value = json.dumps(amo.VALIDATOR_SKELETON_RESULTS)
         self.url = reverse('devhub.upload_unlisted')
         response = self.post()
@@ -1303,18 +1309,14 @@ class TestUploadDetail(UploadMixin, TestCase):
 
     def setUp(self):
         super().setUp()
-        self.client.force_login(UserProfile.objects.get(email='regular@mozilla.com'))
+        self.user = UserProfile.objects.get(email='regular@mozilla.com')
+        self.client.force_login(self.user)
 
     @classmethod
     def create_appversion(cls, application_name, version):
         return AppVersion.objects.create(
             application=amo.APPS[application_name].id, version=version
         )
-
-    def post(self):
-        # Has to be a binary, non xpi file.
-        data = open(get_image_path('animated.png'), 'rb')
-        return self.client.post(reverse('devhub.upload'), {'upload': data})
 
     def validation_ok(self):
         return {
@@ -1328,16 +1330,31 @@ class TestUploadDetail(UploadMixin, TestCase):
             'metadata': {},
         }
 
-    def upload_file(self, file, url='devhub.upload'):
-        addon = os.path.join(
-            settings.ROOT, 'src', 'olympia', 'devhub', 'tests', 'addons', file
+    def upload_dummy_file(self):
+        return self.upload_file(get_image_path('animated.png'))
+
+    def upload_file(self, filename):
+        path = (
+            os.path.join(
+                settings.ROOT, 'src', 'olympia', 'devhub', 'tests', 'addons', filename
+            )
+            if not filename.startswith('/')
+            else filename
         )
-        with open(addon, 'rb') as f:
-            response = self.client.post(reverse(url), {'upload': f})
-        assert response.status_code == 302
+        with open(path, 'rb') as f:
+            data = f.read()
+        upload = FileUpload.from_post(
+            [data],
+            filename=os.path.basename(filename),
+            size=42,
+            user=self.user,
+            source=amo.UPLOAD_SOURCE_DEVHUB,
+            channel=amo.CHANNEL_LISTED,
+        )
+        validate(upload)
 
     def test_detail_json(self):
-        self.post()
+        self.upload_dummy_file()
 
         upload = FileUpload.objects.get()
         response = self.client.get(
@@ -1363,7 +1380,7 @@ class TestUploadDetail(UploadMixin, TestCase):
         user = UserProfile.objects.get(email='regular@mozilla.com')
         addon = addon_factory()
         addon.addonuser_set.create(user=user)
-        self.post()
+        self.upload_dummy_file()
 
         upload = FileUpload.objects.get()
         response = self.client.get(
@@ -1385,7 +1402,7 @@ class TestUploadDetail(UploadMixin, TestCase):
         user = UserProfile.objects.get(email='regular@mozilla.com')
         addon = addon_factory()
         addon.addonuser_set.create(user=user)
-        self.post()
+        self.upload_dummy_file()
         upload = FileUpload.objects.get()
         self.client.force_login(user_factory())
 
@@ -1400,7 +1417,7 @@ class TestUploadDetail(UploadMixin, TestCase):
         user = UserProfile.objects.get(email='regular@mozilla.com')
         addon = addon_factory(version_kw={'channel': amo.CHANNEL_UNLISTED})
         addon.addonuser_set.create(user=user)
-        self.post()
+        self.upload_dummy_file()
 
         upload = FileUpload.objects.get()
         response = self.client.get(
@@ -1415,7 +1432,7 @@ class TestUploadDetail(UploadMixin, TestCase):
         addon = addon_factory()
         addon.addonuser_set.create(user=user)
         addon.delete()
-        self.post()
+        self.upload_dummy_file()
 
         upload = FileUpload.objects.get()
         response = self.client.get(
@@ -1426,7 +1443,7 @@ class TestUploadDetail(UploadMixin, TestCase):
         assert response.status_code == 404
 
     def test_detail_view(self):
-        self.post()
+        self.upload_dummy_file()
         upload = FileUpload.objects.filter().order_by('-created').first()
         response = self.client.get(
             reverse('devhub.upload_detail', args=[upload.uuid.hex])
@@ -1446,7 +1463,7 @@ class TestUploadDetail(UploadMixin, TestCase):
         assert response.status_code == 404
 
     def test_wrong_user(self):
-        self.post()
+        self.upload_dummy_file()
         upload = FileUpload.objects.filter().order_by('-created').first()
         self.client.force_login(user_factory())
         response = self.client.get(
@@ -1565,11 +1582,9 @@ class TestUploadDetail(UploadMixin, TestCase):
 
     @mock.patch('olympia.devhub.tasks.run_addons_linter')
     def test_restricted_guid_addon_allowed(self, run_addons_linter_mock):
-        user = user_factory()
-        self.grant_permission(user, 'SystemAddon:Submit')
-        self.client.force_login(user)
+        self.grant_permission(self.user, 'SystemAddon:Submit')
         run_addons_linter_mock.return_value = self.validation_ok()
-        self.upload_file('../../../files/fixtures/files/mozilla_guid.xpi')
+        self.upload_file(self.file_fixture_path('mozilla_guid.xpi'))
         upload = FileUpload.objects.get()
         response = self.client.get(
             reverse('devhub.upload_detail', args=[upload.uuid.hex, 'json'])
@@ -1579,10 +1594,8 @@ class TestUploadDetail(UploadMixin, TestCase):
 
     @mock.patch('olympia.devhub.tasks.run_addons_linter')
     def test_restricted_guid_addon_not_allowed(self, run_addons_linter_mock):
-        user = user_factory()
-        self.client.force_login(user)
         run_addons_linter_mock.return_value = self.validation_ok()
-        self.upload_file('../../../files/fixtures/files/mozilla_guid.xpi')
+        self.upload_file(self.file_fixture_path('mozilla_guid.xpi'))
         upload = FileUpload.objects.get()
         response = self.client.get(
             reverse('devhub.upload_detail', args=[upload.uuid.hex, 'json'])
@@ -1602,14 +1615,10 @@ class TestUploadDetail(UploadMixin, TestCase):
     @mock.patch('olympia.devhub.tasks.run_addons_linter')
     @mock.patch('olympia.files.utils.get_signer_organizational_unit_name')
     def test_mozilla_signed_allowed(self, get_signer_mock, run_addons_linter_mock):
-        user = user_factory()
-        self.client.force_login(user)
-        self.grant_permission(user, 'SystemAddon:Submit')
+        self.grant_permission(self.user, 'SystemAddon:Submit')
         run_addons_linter_mock.return_value = self.validation_ok()
         get_signer_mock.return_value = 'Mozilla Extensions'
-        self.upload_file(
-            '../../../files/fixtures/files/webextension_signed_already.xpi'
-        )
+        self.upload_file(self.file_fixture_path('webextension_signed_already.xpi'))
         upload = FileUpload.objects.get()
         response = self.client.get(
             reverse('devhub.upload_detail', args=[upload.uuid.hex, 'json'])
@@ -1619,12 +1628,8 @@ class TestUploadDetail(UploadMixin, TestCase):
 
     @mock.patch('olympia.files.utils.get_signer_organizational_unit_name')
     def test_mozilla_signed_not_allowed_not_allowed(self, get_signer_mock):
-        user_factory(email='redpanda@mozilla.com')
-        self.client.force_login(UserProfile.objects.get(email='redpanda@mozilla.com'))
         get_signer_mock.return_value = 'Mozilla Extensions'
-        self.upload_file(
-            '../../../files/fixtures/files/webextension_signed_already.xpi'
-        )
+        self.upload_file(self.file_fixture_path('webextension_signed_already.xpi'))
         upload = FileUpload.objects.get()
         response = self.client.get(
             reverse('devhub.upload_detail', args=[upload.uuid.hex, 'json'])
@@ -1644,12 +1649,10 @@ class TestUploadDetail(UploadMixin, TestCase):
     @mock.patch('olympia.devhub.tasks.run_addons_linter')
     def test_system_addon_update_allowed(self, run_addons_linter_mock):
         """Updates to system addons are allowed from anyone."""
-        user = user_factory(email='pinkpanda@notzilla.com')
         addon = addon_factory(guid='systemaddon@mozilla.org')
-        AddonUser.objects.create(addon=addon, user=user)
-        self.client.force_login(UserProfile.objects.get(email='pinkpanda@notzilla.com'))
+        AddonUser.objects.create(addon=addon, user=self.user)
         run_addons_linter_mock.return_value = self.validation_ok()
-        self.upload_file('../../../files/fixtures/files/mozilla_guid.xpi')
+        self.upload_file(self.file_fixture_path('mozilla_guid.xpi'))
         upload = FileUpload.objects.get()
         response = self.client.get(
             reverse(
@@ -1660,11 +1663,10 @@ class TestUploadDetail(UploadMixin, TestCase):
         assert data['validation']['messages'] == []
 
     def test_no_redirect_for_metadata(self):
-        user = UserProfile.objects.get(email='regular@mozilla.com')
         addon = addon_factory(status=amo.STATUS_NULL)
         AddonCategory.objects.filter(addon=addon).delete()
-        addon.addonuser_set.create(user=user)
-        self.post()
+        addon.addonuser_set.create(user=self.user)
+        self.upload_dummy_file()
 
         upload = FileUpload.objects.get()
         response = self.client.get(

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -20,6 +20,7 @@ from pyquery import PyQuery as pq
 from waffle.testutils import override_switch
 
 from olympia import amo
+from olympia.accounts.utils import fxa_login_url
 from olympia.activity.models import ActivityLog
 from olympia.addons.models import Addon, AddonCategory, AddonReviewerFlags
 from olympia.amo.tests import (
@@ -63,7 +64,7 @@ class TestSubmitBase(TestCase):
         super().setUp()
         self.user = UserProfile.objects.get(email='del@icio.us')
         self.client.force_login_with_2fa(self.user)
-        self.user.update(last_login_ip='192.168.1.1')
+        self.user.update(last_login_ip='192.0.2.1')
         self.addon = self.get_addon()
 
     def get_addon(self):
@@ -104,29 +105,38 @@ class TestSubmitBase(TestCase):
 
 
 class TestAddonSubmitAgreement(TestSubmitBase):
+    def setUp(self):
+        self.url = reverse('devhub.submit.agreement')
+        self.next_url = reverse('devhub.submit.distribution')
+        super().setUp()
+
     def test_set_read_dev_agreement(self):
         response = self.client.post(
-            reverse('devhub.submit.agreement'),
+            self.url,
             {
                 'distribution_agreement': 'on',
                 'review_policy': 'on',
             },
         )
-        assert response.status_code == 302
-        self.assert3xx(response, reverse('devhub.submit.distribution'))
+        self.assert3xx(response, self.next_url)
         self.user.reload()
         self.assertCloseToNow(self.user.read_dev_agreement)
 
     def test_set_read_dev_agreement_theme(self):
+        self.client.logout()  # Shouldn't need 2FA.
+        self.client.force_login(self.user)
+        # Make sure we still have a last login ip though.
+        self.user.update(last_login_ip='192.0.2.1')
+        self.url = reverse('devhub.submit.theme.agreement')
+        self.next_url = reverse('devhub.submit.theme.distribution')
         response = self.client.post(
-            reverse('devhub.submit.theme.agreement'),
+            self.url,
             {
                 'distribution_agreement': 'on',
                 'review_policy': 'on',
             },
         )
-        assert response.status_code == 302
-        self.assert3xx(response, reverse('devhub.submit.theme.distribution'))
+        self.assert3xx(response, self.next_url)
         self.user.reload()
         self.assertCloseToNow(self.user.read_dev_agreement)
 
@@ -134,7 +144,7 @@ class TestAddonSubmitAgreement(TestSubmitBase):
         set_config('last_dev_agreement_change_date', '2019-06-10 00:00')
         before_agreement_last_changed = datetime(2019, 6, 10) - timedelta(days=1)
         self.user.update(read_dev_agreement=before_agreement_last_changed)
-        response = self.client.post(reverse('devhub.submit.agreement'))
+        response = self.client.post(self.url)
         assert response.status_code == 200
         assert 'agreement_form' in response.context
         form = response.context['agreement_form']
@@ -152,21 +162,21 @@ class TestAddonSubmitAgreement(TestSubmitBase):
         set_config('last_dev_agreement_change_date', '2019-06-10 00:00')
         after_agreement_last_changed = datetime(2019, 6, 10) + timedelta(days=1)
         self.user.update(read_dev_agreement=after_agreement_last_changed)
-        response = self.client.get(reverse('devhub.submit.agreement'))
-        self.assert3xx(response, reverse('devhub.submit.distribution'))
+        response = self.client.get(self.url)
+        self.assert3xx(response, self.next_url)
 
     @override_settings(DEV_AGREEMENT_CHANGE_FALLBACK=datetime(2019, 6, 10, 12, 00))
     def test_read_dev_agreement_fallback_with_config_set_to_future(self):
         set_config('last_dev_agreement_change_date', '2099-12-31 00:00')
         read_dev_date = datetime(2019, 6, 11)
         self.user.update(read_dev_agreement=read_dev_date)
-        response = self.client.get(reverse('devhub.submit.agreement'))
-        self.assert3xx(response, reverse('devhub.submit.distribution'))
+        response = self.client.get(self.url)
+        self.assert3xx(response, self.next_url)
 
     def test_read_dev_agreement_fallback_with_conf_future_and_not_agreed(self):
         set_config('last_dev_agreement_change_date', '2099-12-31 00:00')
         self.user.update(read_dev_agreement=None)
-        response = self.client.get(reverse('devhub.submit.agreement'))
+        response = self.client.get(self.url)
         assert response.status_code == 200
         assert 'agreement_form' in response.context
 
@@ -175,30 +185,30 @@ class TestAddonSubmitAgreement(TestSubmitBase):
         set_config('last_dev_agreement_change_date', '2099-25-75 00:00')
         read_dev_date = datetime(2019, 6, 11)
         self.user.update(read_dev_agreement=read_dev_date)
-        response = self.client.get(reverse('devhub.submit.agreement'))
-        self.assert3xx(response, reverse('devhub.submit.distribution'))
+        response = self.client.get(self.url)
+        self.assert3xx(response, self.next_url)
 
     def test_read_dev_agreement_invalid_date_not_agreed_post_fallback(self):
         set_config('last_dev_agreement_change_date', '2099,31,12,0,0')
         self.user.update(read_dev_agreement=None)
-        response = self.client.get(reverse('devhub.submit.agreement'))
+        response = self.client.get(self.url)
         self.assertRaises(ValueError)
         assert response.status_code == 200
         assert 'agreement_form' in response.context
 
     def test_read_dev_agreement_no_date_configured_agreed_post_fallback(self):
-        response = self.client.get(reverse('devhub.submit.agreement'))
-        self.assert3xx(response, reverse('devhub.submit.distribution'))
+        response = self.client.get(self.url)
+        self.assert3xx(response, self.next_url)
 
     def test_read_dev_agreement_no_date_configured_not_agreed_post_fallb(self):
         self.user.update(read_dev_agreement=None)
-        response = self.client.get(reverse('devhub.submit.agreement'))
+        response = self.client.get(self.url)
         assert response.status_code == 200
         assert 'agreement_form' in response.context
 
     def test_read_dev_agreement_captcha_inactive(self):
         self.user.update(read_dev_agreement=None)
-        response = self.client.get(reverse('devhub.submit.agreement'))
+        response = self.client.get(self.url)
         assert response.status_code == 200
         form = response.context['agreement_form']
         assert 'recaptcha' not in form.fields
@@ -209,12 +219,12 @@ class TestAddonSubmitAgreement(TestSubmitBase):
     @override_switch('developer-agreement-captcha', active=True)
     def test_read_dev_agreement_captcha_active_error(self):
         self.user.update(read_dev_agreement=None)
-        response = self.client.get(reverse('devhub.submit.agreement'))
+        response = self.client.get(self.url)
         assert response.status_code == 200
         form = response.context['agreement_form']
         assert 'recaptcha' in form.fields
 
-        response = self.client.post(reverse('devhub.submit.agreement'))
+        response = self.client.post(self.url)
 
         # Captcha is properly rendered
         doc = pq(response.content)
@@ -225,7 +235,7 @@ class TestAddonSubmitAgreement(TestSubmitBase):
     @override_switch('developer-agreement-captcha', active=True)
     def test_read_dev_agreement_captcha_active_success(self):
         self.user.update(read_dev_agreement=None)
-        response = self.client.get(reverse('devhub.submit.agreement'))
+        response = self.client.get(self.url)
         assert response.status_code == 200
         form = response.context['agreement_form']
         assert 'recaptcha' in form.fields
@@ -248,22 +258,20 @@ class TestAddonSubmitAgreement(TestSubmitBase):
         )
 
         response = self.client.post(
-            reverse('devhub.submit.agreement'),
+            self.url,
             data={
                 'g-recaptcha-response': 'test',
                 'distribution_agreement': 'on',
                 'review_policy': 'on',
             },
         )
-
-        assert response.status_code == 302
-        assert response['Location'] == reverse('devhub.submit.distribution')
+        self.assert3xx(response, self.next_url)
 
     def test_cant_submit_agreement_if_restricted_functional(self):
         IPNetworkUserRestriction.objects.create(network='127.0.0.1/32')
         self.user.update(read_dev_agreement=None)
         response = self.client.post(
-            reverse('devhub.submit.agreement'),
+            self.url,
             data={
                 'distribution_agreement': 'on',
                 'review_policy': 'on',
@@ -284,23 +292,23 @@ class TestAddonSubmitAgreement(TestSubmitBase):
 
     def test_display_name_already_set_not_asked_again(self):
         self.user.update(read_dev_agreement=None, display_name='Foo')
-        response = self.client.get(reverse('devhub.submit.agreement'))
+        response = self.client.get(self.url)
         assert response.status_code == 200
         form = response.context['agreement_form']
         assert 'display_name' not in form.fields
         response = self.client.post(
-            reverse('devhub.submit.agreement'),
+            self.url,
             data={
                 'distribution_agreement': 'on',
                 'review_policy': 'on',
             },
         )
-        assert response.status_code == 302
+        self.assert3xx(response, self.next_url)
         assert self.user.reload().read_dev_agreement
 
     def test_display_name_required(self):
         self.user.update(read_dev_agreement=None, display_name='')
-        response = self.client.get(reverse('devhub.submit.agreement'))
+        response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
         form = response.context['agreement_form']
@@ -310,7 +318,7 @@ class TestAddonSubmitAgreement(TestSubmitBase):
             in doc('.addon-submission-process').text()
         )
         response = self.client.post(
-            reverse('devhub.submit.agreement'),
+            self.url,
             data={
                 'distribution_agreement': 'on',
                 'review_policy': 'on',
@@ -328,7 +336,7 @@ class TestAddonSubmitAgreement(TestSubmitBase):
     def test_display_name_submission(self):
         self.user.update(read_dev_agreement=None, display_name='')
         response = self.client.post(
-            reverse('devhub.submit.agreement'),
+            self.url,
             data={
                 'distribution_agreement': 'on',
                 'review_policy': 'on',
@@ -342,7 +350,7 @@ class TestAddonSubmitAgreement(TestSubmitBase):
         }
 
         response = self.client.post(
-            reverse('devhub.submit.agreement'),
+            self.url,
             data={
                 'distribution_agreement': 'on',
                 'review_policy': 'on',
@@ -356,17 +364,30 @@ class TestAddonSubmitAgreement(TestSubmitBase):
         }
 
         response = self.client.post(
-            reverse('devhub.submit.agreement'),
+            self.url,
             data={
                 'distribution_agreement': 'on',
                 'review_policy': 'on',
                 'display_name': 'Fôä',
             },
         )
-        assert response.status_code == 302
+        self.assert3xx(response, self.next_url)
         self.user.reload()
         self.assertCloseToNow(self.user.read_dev_agreement)
         assert self.user.display_name == 'Fôä'
+
+    def test_enforce_2fa(self):
+        self.user.update(read_dev_agreement=None)
+        self.client.logout()
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        expected_location = fxa_login_url(
+            config=settings.FXA_CONFIG['default'],
+            state=self.client.session['fxa_state'],
+            next_path=self.url,
+            enforce_2fa=True,
+        )
+        self.assert3xx(response, expected_location)
 
 
 class TestAddonSubmitDistribution(TestCase):
@@ -378,12 +399,13 @@ class TestAddonSubmitDistribution(TestCase):
             UserProfile.objects.get(email='regular@mozilla.com')
         )
         self.user = UserProfile.objects.get(email='regular@mozilla.com')
-        self.user.update(last_login_ip='192.168.1.1')
+        self.user.update(last_login_ip='192.0.2.1')
+        self.url = reverse('devhub.submit.distribution')
 
     def test_check_agreement_okay(self):
         response = self.client.post(reverse('devhub.submit.agreement'))
-        self.assert3xx(response, reverse('devhub.submit.distribution'))
-        response = self.client.get(reverse('devhub.submit.distribution'))
+        self.assert3xx(response, self.url)
+        response = self.client.get(self.url)
         assert response.status_code == 200
         # No error shown for a redirect from previous step.
         assert b'This field is required' not in response.content
@@ -393,7 +415,7 @@ class TestAddonSubmitDistribution(TestCase):
             key='submit_notification_warning',
             value='Text with <a href="http://example.com">a link</a>.',
         )
-        response = self.client.get(reverse('devhub.submit.distribution'))
+        response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
         assert doc('.notification-box.warning').html().strip() == config.value
@@ -401,7 +423,7 @@ class TestAddonSubmitDistribution(TestCase):
     def test_redirect_back_to_agreement(self):
         self.user.update(read_dev_agreement=None)
 
-        response = self.client.get(reverse('devhub.submit.distribution'), follow=True)
+        response = self.client.get(self.url, follow=True)
         self.assert3xx(response, reverse('devhub.submit.agreement'))
 
         # read_dev_agreement needs to be a more recent date than
@@ -409,7 +431,7 @@ class TestAddonSubmitDistribution(TestCase):
         set_config('last_dev_agreement_change_date', '2019-06-10 00:00')
         before_agreement_last_changed = datetime(2019, 6, 10) - timedelta(days=1)
         self.user.update(read_dev_agreement=before_agreement_last_changed)
-        response = self.client.get(reverse('devhub.submit.distribution'), follow=True)
+        response = self.client.get(self.url, follow=True)
         self.assert3xx(response, reverse('devhub.submit.agreement'))
 
     def test_redirect_back_to_agreement_theme(self):
@@ -432,19 +454,15 @@ class TestAddonSubmitDistribution(TestCase):
 
     def test_redirect_back_to_agreement_if_restricted(self):
         IPNetworkUserRestriction.objects.create(network='127.0.0.1/32')
-        response = self.client.get(reverse('devhub.submit.distribution'), follow=True)
+        response = self.client.get(self.url, follow=True)
         self.assert3xx(response, reverse('devhub.submit.agreement'))
 
     def test_listed_redirects_to_next_step(self):
-        response = self.client.post(
-            reverse('devhub.submit.distribution'), {'channel': 'listed'}
-        )
+        response = self.client.post(self.url, {'channel': 'listed'})
         self.assert3xx(response, reverse('devhub.submit.upload', args=['listed']))
 
     def test_unlisted_redirects_to_next_step(self):
-        response = self.client.post(
-            reverse('devhub.submit.distribution'), {'channel': 'unlisted'}
-        )
+        response = self.client.post(self.url, {'channel': 'unlisted'})
         self.assert3xx(response, reverse('devhub.submit.upload', args=['unlisted']))
 
     def test_listed_redirects_to_next_step_theme(self):
@@ -454,7 +472,7 @@ class TestAddonSubmitDistribution(TestCase):
         self.assert3xx(response, reverse('devhub.submit.theme.upload', args=['listed']))
 
     def test_channel_selection_error_shown(self):
-        url = reverse('devhub.submit.distribution')
+        url = self.url
         # First load should have no error
         assert b'This field is required' not in self.client.get(url).content
 
@@ -466,6 +484,18 @@ class TestAddonSubmitDistribution(TestCase):
 
         # A post submission without channel selection should be an error
         assert b'This field is required' in self.client.post(url).content
+
+    def test_enforce_2fa(self):
+        self.client.logout()
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        expected_location = fxa_login_url(
+            config=settings.FXA_CONFIG['default'],
+            state=self.client.session['fxa_state'],
+            next_path=self.url,
+            enforce_2fa=True,
+        )
+        self.assert3xx(response, expected_location)
 
 
 @override_settings(REPUTATION_SERVICE_URL=None)
@@ -482,7 +512,7 @@ class TestAddonSubmitUpload(UploadMixin, TestCase):
             UserProfile.objects.get(email='regular@mozilla.com')
         )
         self.user = UserProfile.objects.get(email='regular@mozilla.com')
-        self.user.update(last_login_ip='192.168.1.1')
+        self.user.update(last_login_ip='192.0.2.1')
         self.upload = self.get_upload('webextension_no_id.xpi', user=self.user)
         self.statsd_incr_mock = self.patch('olympia.devhub.views.statsd.incr')
 
@@ -661,6 +691,10 @@ class TestAddonSubmitUpload(UploadMixin, TestCase):
         )
 
     def test_theme_variant_has_theme_stuff_visible(self):
+        self.client.logout()  # Shouldn't need 2FA.
+        self.client.force_login(self.user)
+        # Make sure we still have a last login ip though.
+        self.user.update(last_login_ip='192.0.2.1')
         response = self.client.get(
             reverse('devhub.submit.theme.upload', args=['listed']), follow=True
         )
@@ -793,6 +827,29 @@ class TestAddonSubmitUpload(UploadMixin, TestCase):
         assert addon.type == amo.ADDON_STATICTHEME
         # Only listed submissions need a preview generated.
         assert latest_version.previews.all().count() == 0
+
+    def test_enforce_2fa(self):
+        self.client.logout()
+        self.client.force_login(self.user)
+        self.url = reverse('devhub.submit.upload', args=['listed'])
+        response = self.client.get(self.url)
+        expected_location = fxa_login_url(
+            config=settings.FXA_CONFIG['default'],
+            state=self.client.session['fxa_state'],
+            next_path=self.url,
+            enforce_2fa=True,
+        )
+        self.assert3xx(response, expected_location)
+
+        self.url = reverse('devhub.submit.upload', args=['unlisted'])
+        response = self.client.get(self.url)
+        expected_location = fxa_login_url(
+            config=settings.FXA_CONFIG['default'],
+            state=self.client.session['fxa_state'],
+            next_path=self.url,
+            enforce_2fa=True,
+        )
+        self.assert3xx(response, expected_location)
 
 
 class TestAddonSubmitSource(TestSubmitBase):
@@ -1583,6 +1640,9 @@ class TestAddonSubmitDetails(DetailsPageMixin, TestSubmitBase):
 class TestStaticThemeSubmitDetails(DetailsPageMixin, TestSubmitBase):
     def setUp(self):
         super().setUp()
+        self.client.logout()
+        self.client.force_login(self.user)
+        self.user.update(last_login_ip='192.0.2.0.1')
         self.url = reverse('devhub.submit.details', args=['a3615'])
 
         addon = self.get_addon()
@@ -1914,6 +1974,18 @@ class TestVersionSubmitDistribution(TestSubmitBase):
             response, reverse('devhub.submit.version.agreement', args=[self.addon.slug])
         )
 
+    def test_enforce_2fa(self):
+        self.client.logout()
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        expected_location = fxa_login_url(
+            config=settings.FXA_CONFIG['default'],
+            state=self.client.session['fxa_state'],
+            next_path=self.url,
+            enforce_2fa=True,
+        )
+        self.assert3xx(response, expected_location)
+
 
 class TestVersionSubmitAutoChannel(TestSubmitBase):
     """Just check we chose the right upload channel.  The upload tests
@@ -1978,7 +2050,7 @@ class VersionSubmitUploadMixin:
         self.addon.update(guid='@webextension-guid')
         self.user = UserProfile.objects.get(email='del@icio.us')
         self.client.force_login_with_2fa(self.user)
-        self.user.update(last_login_ip='192.168.1.1')
+        self.user.update(last_login_ip='192.0.2.1')
         self.addon.versions.update(channel=self.channel, version='0.0.0.99')
         channel = 'listed' if self.channel == amo.CHANNEL_LISTED else 'unlisted'
         self.url = reverse(
@@ -2268,6 +2340,18 @@ class VersionSubmitUploadMixin:
         doc = pq(response.content)
         assert doc('.notification-box.warning')
         assert doc('.notification-box.warning').html().strip() == config.value
+
+    def test_enforce_2fa(self):
+        self.client.logout()
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        expected_location = fxa_login_url(
+            config=settings.FXA_CONFIG['default'],
+            state=self.client.session['fxa_state'],
+            next_path=self.url,
+            enforce_2fa=True,
+        )
+        self.assert3xx(response, expected_location)
 
 
 class TestVersionSubmitUploadListed(VersionSubmitUploadMixin, UploadMixin, TestCase):

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -62,7 +62,7 @@ class TestSubmitBase(TestCase):
     def setUp(self):
         super().setUp()
         self.user = UserProfile.objects.get(email='del@icio.us')
-        self.client.force_login(self.user)
+        self.client.force_login_with_2fa(self.user)
         self.user.update(last_login_ip='192.168.1.1')
         self.addon = self.get_addon()
 
@@ -374,7 +374,9 @@ class TestAddonSubmitDistribution(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.client.force_login(UserProfile.objects.get(email='regular@mozilla.com'))
+        self.client.force_login_with_2fa(
+            UserProfile.objects.get(email='regular@mozilla.com')
+        )
         self.user = UserProfile.objects.get(email='regular@mozilla.com')
         self.user.update(last_login_ip='192.168.1.1')
 
@@ -476,7 +478,9 @@ class TestAddonSubmitUpload(UploadMixin, TestCase):
 
     def setUp(self):
         super().setUp()
-        self.client.force_login(UserProfile.objects.get(email='regular@mozilla.com'))
+        self.client.force_login_with_2fa(
+            UserProfile.objects.get(email='regular@mozilla.com')
+        )
         self.user = UserProfile.objects.get(email='regular@mozilla.com')
         self.user.update(last_login_ip='192.168.1.1')
         self.upload = self.get_upload('webextension_no_id.xpi', user=self.user)
@@ -1973,7 +1977,7 @@ class VersionSubmitUploadMixin:
         self.version = self.addon.current_version
         self.addon.update(guid='@webextension-guid')
         self.user = UserProfile.objects.get(email='del@icio.us')
-        self.client.force_login(self.user)
+        self.client.force_login_with_2fa(self.user)
         self.user.update(last_login_ip='192.168.1.1')
         self.addon.versions.update(channel=self.channel, version='0.0.0.99')
         channel = 'listed' if self.channel == amo.CHANNEL_LISTED else 'unlisted'

--- a/src/olympia/devhub/tests/test_views_validation.py
+++ b/src/olympia/devhub/tests/test_views_validation.py
@@ -26,7 +26,7 @@ class TestUploadValidation(ValidatorTestCase, UploadMixin, TestCase):
     def setUp(self):
         super().setUp()
         self.user = UserProfile.objects.get(email='regular@mozilla.com')
-        self.client.force_login(self.user)
+        self.client.force_login_with_2fa(self.user)
         self.validation = {
             'errors': 1,
             'detected_type': 'extension',
@@ -400,7 +400,9 @@ class TestValidateAddon(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.client.force_login(UserProfile.objects.get(email='regular@mozilla.com'))
+        self.client.force_login_with_2fa(
+            UserProfile.objects.get(email='regular@mozilla.com')
+        )
 
     def test_login_required(self):
         self.client.logout()
@@ -481,7 +483,9 @@ class TestUploadURLs(TestCase):
     def setUp(self):
         super().setUp()
         user = UserProfile.objects.get(email='regular@mozilla.com')
-        self.client.force_login(UserProfile.objects.get(email='regular@mozilla.com'))
+        self.client.force_login_with_2fa(
+            UserProfile.objects.get(email='regular@mozilla.com')
+        )
 
         self.addon = Addon.objects.create(
             guid='thing@stuff', slug='thing-stuff', status=amo.STATUS_APPROVED

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -1245,8 +1245,8 @@ def version_stats(request, addon_id, addon):
     return data
 
 
-@login_required
 @two_factor_auth_required
+@login_required
 def submit_addon(request):
     return render_agreement(
         request=request,
@@ -1264,8 +1264,8 @@ def submit_theme(request):
     )
 
 
-@dev_required
 @two_factor_auth_required
+@dev_required
 def submit_version_agreement(request, addon_id, addon):
     return render_agreement(
         request=request,
@@ -1304,8 +1304,8 @@ def _submit_distribution(request, addon, next_view):
     )
 
 
-@login_required
 @two_factor_auth_required
+@login_required
 def submit_addon_distribution(request):
     if not RestrictionChecker(request=request).is_submission_allowed():
         return redirect('devhub.submit.agreement')
@@ -1319,8 +1319,8 @@ def submit_theme_distribution(request):
     return _submit_distribution(request, None, 'devhub.submit.theme.upload')
 
 
-@dev_required(submitting=True)
 @two_factor_auth_required
+@dev_required(submitting=True)
 def submit_version_distribution(request, addon_id, addon):
     if not RestrictionChecker(request=request).is_submission_allowed():
         return redirect('devhub.submit.version.agreement', addon.slug)
@@ -1509,8 +1509,8 @@ def _submit_upload(
     )
 
 
-@login_required
 @two_factor_auth_required
+@login_required
 def submit_addon_upload(request, channel):
     if not RestrictionChecker(request=request).is_submission_allowed():
         return redirect('devhub.submit.agreement')
@@ -1528,8 +1528,8 @@ def submit_theme_upload(request, channel):
     )
 
 
-@dev_required(submitting=True)
 @two_factor_auth_required
+@dev_required(submitting=True)
 @no_admin_disabled
 def submit_version_upload(request, addon_id, addon, channel):
     if not RestrictionChecker(request=request).is_submission_allowed():
@@ -1538,8 +1538,8 @@ def submit_version_upload(request, addon_id, addon, channel):
     return _submit_upload(request, addon, channel_id, 'devhub.submit.version.source')
 
 
-@dev_required(submitting=True)
 @two_factor_auth_required
+@dev_required(submitting=True)
 @no_admin_disabled
 def submit_version_auto(request, addon_id, addon):
     if not RestrictionChecker(request=request).is_submission_allowed():
@@ -1900,8 +1900,8 @@ def render_agreement(request, template, next_step, **extra_context):
         return response
 
 
-@login_required
 @two_factor_auth_required
+@login_required
 @transaction.atomic
 def api_key(request):
     if not RestrictionChecker(request=request).is_submission_allowed():

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -27,6 +27,7 @@ from django_statsd.clients import statsd
 import olympia.core.logger
 from olympia import amo
 from olympia.access import acl
+from olympia.accounts.decorators import two_factor_auth_required
 from olympia.accounts.utils import redirect_for_login
 from olympia.accounts.views import logout_user
 from olympia.activity.models import ActivityLog, CommentLog
@@ -1245,6 +1246,7 @@ def version_stats(request, addon_id, addon):
 
 
 @login_required
+@two_factor_auth_required
 def submit_addon(request):
     return render_agreement(
         request=request,
@@ -1263,6 +1265,7 @@ def submit_theme(request):
 
 
 @dev_required
+@two_factor_auth_required
 def submit_version_agreement(request, addon_id, addon):
     return render_agreement(
         request=request,
@@ -1302,6 +1305,7 @@ def _submit_distribution(request, addon, next_view):
 
 
 @login_required
+@two_factor_auth_required
 def submit_addon_distribution(request):
     if not RestrictionChecker(request=request).is_submission_allowed():
         return redirect('devhub.submit.agreement')
@@ -1316,6 +1320,7 @@ def submit_theme_distribution(request):
 
 
 @dev_required(submitting=True)
+@two_factor_auth_required
 def submit_version_distribution(request, addon_id, addon):
     if not RestrictionChecker(request=request).is_submission_allowed():
         return redirect('devhub.submit.version.agreement', addon.slug)
@@ -1505,6 +1510,7 @@ def _submit_upload(
 
 
 @login_required
+@two_factor_auth_required
 def submit_addon_upload(request, channel):
     if not RestrictionChecker(request=request).is_submission_allowed():
         return redirect('devhub.submit.agreement')
@@ -1523,6 +1529,7 @@ def submit_theme_upload(request, channel):
 
 
 @dev_required(submitting=True)
+@two_factor_auth_required
 @no_admin_disabled
 def submit_version_upload(request, addon_id, addon, channel):
     if not RestrictionChecker(request=request).is_submission_allowed():
@@ -1532,6 +1539,7 @@ def submit_version_upload(request, addon_id, addon, channel):
 
 
 @dev_required(submitting=True)
+@two_factor_auth_required
 @no_admin_disabled
 def submit_version_auto(request, addon_id, addon):
     if not RestrictionChecker(request=request).is_submission_allowed():
@@ -1893,6 +1901,7 @@ def render_agreement(request, template, next_step, **extra_context):
 
 
 @login_required
+@two_factor_auth_required
 @transaction.atomic
 def api_key(request):
     if not RestrictionChecker(request=request).is_submission_allowed():


### PR DESCRIPTION
Fixes #20943
Fixes #21002

Note: when trying this, make sure `2fa-enforcement-for-developers-and-special-users` flag is active (and note that it's a flag, not a switch - to activate it, enable it for `everyone`). This should work both with fake and actual FxA implementations.

This could be split before review into 3 parts:
- FxA error handling
- All 2FA refactor bits (all `accounts` stuff)
- All `devhub` 2FA enforcement bits (essentially just using the decorator + condition in `upload()` + tests)