### PR TITLE
Replace clear admin review button with an action

### DIFF
--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -943,6 +943,16 @@ class BLOCKLIST_VERSION_UNBLOCKED(_LOG):
     short = _('Version Unblocked')
 
 
+class CLEAR_ADMIN_REVIEW_THEME(_LOG):
+    id = 181
+    format = _('{addon} {version} admin add-on-review cleared.')
+    short = _('Admin add-on-review cleared')
+    keep = True
+    review_queue = True
+    reviewer_review_action = True
+    admin_event = True
+
+
 LOGS = [x for x in vars().values() if isclass(x) and issubclass(x, _LOG) and x != _LOG]
 # Make sure there's no duplicate IDs.
 assert len(LOGS) == len({log.id for log in LOGS})

--- a/src/olympia/reviewers/serializers.py
+++ b/src/olympia/reviewers/serializers.py
@@ -46,7 +46,6 @@ class AddonReviewerFlagsSerializer(AMOModelSerializer):
             'auto_approval_disabled_unlisted',
             'auto_approval_disabled_until_next_approval',
             'auto_approval_disabled_until_next_approval_unlisted',
-            'needs_admin_theme_review',
         )
 
     def update(self, instance, validated_data):

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -383,15 +383,6 @@
             </li>
           {% endif %}
         {% endif %}
-
-        {% if addon.needs_admin_theme_review %}
-          <li>
-            <button data-api-url="{{ drf_url('reviewers-addon-flags', addon.pk) }}"
-                    data-api-method="patch"
-                    data-api-data="{&quot;needs_admin_theme_review&quot;: false}"
-                    id="clear_admin_theme_review" class="oneoff" type="button">Clear Admin Static Theme Review Flag</button>
-          </li>
-        {% endif %}
       {% endif %}
 
       <li>


### PR DESCRIPTION
Still for the entire add-on, still only clearable by admins, but now an explicit action that logs an activity.

Fixes #20844