### PR TITLE
Refactor how we render changed_version_ids so they can be changed

### DIFF
--- a/src/olympia/blocklist/templates/admin/blocklist/blocklistsubmission_add_form.html
+++ b/src/olympia/blocklist/templates/admin/blocklist/blocklistsubmission_add_form.html
@@ -56,7 +56,7 @@
     <h2>{{ fieldsets.2.0 }}</h2>
     <div class="form-row field-blocks-to-add">
       <div>
-        {% include 'admin/blocklist/includes/enhanced_blocks.html' with form=adminform.form %}
+        {{ adminform.form.changed_version_ids }}
       </div>
       {{ adminform.form.changed_version_ids.errors }}
     </div>

--- a/src/olympia/blocklist/templates/admin/blocklist/includes/blocks.html
+++ b/src/olympia/blocklist/templates/admin/blocklist/includes/blocks.html
@@ -1,0 +1,33 @@
+{% load humanize %}
+
+<h3>{{ blocks|length|intcomma }} Add-on GUIDs with {{ total_adu|intcomma }} users:</h3>
+ <ul class="guid_list">
+  {% for block_obj in blocks %}
+    <li>
+      {{ block_obj.guid }}.
+      {% if block_obj.addon %}
+        <span class="addon-name">{{ block_obj.addon.name }}</span>
+      {% endif %}
+
+      {% if block_obj.average_daily_users_snapshot is not None %}
+        ({{ block_obj.average_daily_users_snapshot }} users).
+      {% endif %}
+
+      {{ block_obj.review_listed_link }}
+      {{ block_obj.review_unlisted_link }}
+      {% if block_obj.id %}
+        <span class="existing_block">[<a href="{% url 'admin:blocklist_block_change' block_obj.id %}">Edit Block</a>]</span>
+      {% else %}
+        <span class="existing_block">[Block Deleted]</span>
+      {% endif %}
+
+      <ul>
+        {% for version in block_obj.addon_versions %}
+          {% if version.id in instance.changed_version_ids %}
+            <li data-version-id="{{ version.id }}">{{ version.version }}</li>
+          {% endif %}
+        {% endfor %}
+      </ul>
+    </li>
+  {% endfor %}
+</ul>

--- a/src/olympia/blocklist/templates/admin/blocklist/widgets/blocks.html
+++ b/src/olympia/blocklist/templates/admin/blocklist/widgets/blocks.html
@@ -1,19 +1,15 @@
 {% load humanize %}
 
-<h3>{{ form.blocks|length|intcomma }} Add-on GUIDs with {{ form.total_adu|intcomma }} users:</h3>
+<h3>{{ blocks|length|intcomma }} Add-on GUIDs with {{ total_adu|intcomma }} users:</h3>
  <ul class="guid_list">
-  {% for block_obj in form.blocks %}
+  {% for block_obj in blocks %}
     <li>
       {{ block_obj.guid }}.
       {% if block_obj.addon %}
         <span class="addon-name">{{ block_obj.addon.name }}</span>
       {% endif %}
 
-      {% if submission_published|default_if_none:False %}
-        {% if block_obj.average_daily_users_snapshot is not None %}
-          ({{ block_obj.average_daily_users_snapshot }} users).
-        {% endif %}
-      {% elif block_obj.current_adu is not None %}
+      {% if block_obj.current_adu is not None %}
         ({{ block_obj.current_adu }} users).
       {% endif %}
 
@@ -27,13 +23,12 @@
       <ul>
         {% for version in block_obj.addon_versions %}
           <li data-version-id="{{ version.id }}">
-          {% if version.id in form.changed_version_ids_choices or version.id in instance.changed_version_ids %}
+          {% if version.id in widget.choices %}
             <label><input
               type="checkbox"
               name="changed_version_ids"
               value="{{ version.id }}"
-              {% if version.id in form.changed_version_ids.value %}checked{% endif %}
-              {% if version.id in instance.changed_version_ids %}checked disabled{% endif %}
+              {% if version.id in widget.value %}checked{% endif %}
             > {% if is_delete %}Unblock{% else %}Block{% endif %} {{ version.version }}</label>
           {% else %}
             <span title="{% if version.is_blocked %}Blocked{% else %}Not blocked{% endif %}">
@@ -43,7 +38,6 @@
                 [<a href="{% url 'admin:blocklist_blocklistsubmission_change' version.blocklist_submission_id %}">Edit Submission</a>]
               {% endif %}
             </span>
-
           {% endif %}
           </li>
         {% endfor %}


### PR DESCRIPTION
fixes #20902 (and fixes #20922 and fixes #20998 along the way)

Using a widget to render a chunk of template is a bit of a hack, I know, but working to a point where we can drop the custom add view template and the blocks template was a major part of the customization.  Functionality in forms.py is also a lot easier to test than full functional tests of admin.py.