### PR TITLE
override ALLOWED_HOSTS for prod to disallow non-production hosts

### DIFF
--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -1,6 +1,13 @@
 # ruff: noqa: F405
 from olympia.lib.settings_base import *  # noqa
 
+ALLOWED_HOSTS = [
+    '.amo.prod.webservices.mozgcp.net',
+    '.mozilla.org',
+    '.mozilla.com',
+    '.mozilla.net',
+    '.mozaws.net',
+]
 
 ENGAGE_ROBOTS = True
 


### PR DESCRIPTION
fixes #20806 ? 
Though we could maybe tighten it up further - I can't think where we'd run addons-server on a `.mozilla.com` or `.mozilla.net` domain (or a gcp domain right now, but it'd be annoying to have to change it later).