### PR TITLE
Fix standalone validator - the upload JS code requires `theme_specific` to be present

### DIFF
--- a/src/olympia/devhub/templates/devhub/validate_addon.html
+++ b/src/olympia/devhub/templates/devhub/validate_addon.html
@@ -22,6 +22,7 @@
       <label>{{ _('Do you want your add-on to be distributed on this site?') }}</label>
       {{ new_addon_form.channel }}
     </div>
+    <input type="hidden" id="id_theme_specific" name="theme_specific" value="false" />
     <input type="file" id="upload-addon"
       data-upload-url="{{ url('devhub.standalone_upload') }}"
       data-upload-url-listed="{{ url('devhub.standalone_upload') }}"

--- a/src/olympia/devhub/tests/test_views_validation.py
+++ b/src/olympia/devhub/tests/test_views_validation.py
@@ -414,6 +414,9 @@ class TestValidateAddon(TestCase):
         assert b'this tool only works with legacy' not in response.content
 
         doc = pq(response.content)
+
+        assert doc('#id_theme_specific').attr('value') == 'false'
+
         assert doc('#upload-addon').attr('data-upload-url') == (
             reverse('devhub.standalone_upload')
         )


### PR DESCRIPTION
Fixes #21024