### PR TITLE
Fix API 403 error for "all_with_unlisted" when there are no unlisted.

### DIFF
--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -4608,7 +4608,7 @@ class TestVersionViewSetList(AddonAndVersionViewSetDetailMixin, TestCase):
         # And that without_unlisted doesn't fail when there are no unlisted
         response = self.client.get(self.url, data={'filter': 'all_without_unlisted'})
         assert response.status_code == 200
-    
+
     def test_all_with_unlisted_when_no_unlisted_versions_viewer(self):
         user = UserProfile.objects.create(username='reviewer')
         self.grant_permission(user, 'ReviewerTools:ViewUnlisted')

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -511,7 +511,11 @@ class AddonVersionViewSet(
             # To see unlisted versions, you need to be add-on author or
             # unlisted reviewer.
             self.permission_classes = [
-                AnyOf(AllowUnlistedViewerOrReviewer, AllowAddonAuthor)
+                AnyOf(
+                    GroupPermission(amo.permissions.ADDONS_REVIEW_UNLISTED),
+                    GroupPermission(amo.permissions.REVIEWER_TOOLS_UNLISTED_VIEW),
+                    AllowAddonAuthor,
+                )
             ]
         elif requested == 'all_without_unlisted':
             # To see all listed versions (not just public ones) you need to


### PR DESCRIPTION
Fixes #21063 

Previously, there would be a 403 error no matter the permission classes when requesting an addon with no unlisted versions with the filter of all_with_unlisted. This fixes that and returns whatever listed versions exist.
