### PR TITLE
Add ability to enforce 2FA in the authenticate callback for a particular session

### DIFF
--- a/src/olympia/accounts/tests/test_utils.py
+++ b/src/olympia/accounts/tests/test_utils.py
@@ -1,8 +1,6 @@
 from base64 import urlsafe_b64decode, urlsafe_b64encode
-from unittest import mock
 from urllib.parse import parse_qs, urlparse
 
-from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
 from django.test.utils import override_settings
 from django.urls import reverse

--- a/src/olympia/accounts/tests/test_utils.py
+++ b/src/olympia/accounts/tests/test_utils.py
@@ -1,12 +1,15 @@
 from base64 import urlsafe_b64decode, urlsafe_b64encode
+from unittest import mock
 from urllib.parse import parse_qs, urlparse
 
+from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
 from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils.encoding import force_str
 
 from olympia.accounts import utils
+from olympia.amo.tests import TestCase
 
 
 FXA_CONFIG = {
@@ -14,6 +17,7 @@ FXA_CONFIG = {
         'client_id': 'foo',
         'client_secret': 'bar',
     },
+    'other': {'client_id': 'foo_other', 'client_secret': 'bar_other'},
 }
 
 
@@ -28,8 +32,7 @@ def test_fxa_login_url_without_requiring_two_factor_auth():
         config=FXA_CONFIG['default'],
         state=request.session['fxa_state'],
         next_path=path,
-        action='signin',
-        force_two_factor=False,
+        enforce_2fa=False,
     )
 
     url = urlparse(raw_url)
@@ -40,7 +43,6 @@ def test_fxa_login_url_without_requiring_two_factor_auth():
     query = parse_qs(url.query)
     next_path = urlsafe_b64encode(path.encode('utf-8')).rstrip(b'=')
     assert query == {
-        'action': ['signin'],
         'client_id': ['foo'],
         'scope': ['profile openid'],
         'state': [f'myfxastate:{force_str(next_path)}'],
@@ -59,8 +61,7 @@ def test_fxa_login_url_requiring_two_factor_auth():
         config=FXA_CONFIG['default'],
         state=request.session['fxa_state'],
         next_path=path,
-        action='signin',
-        force_two_factor=True,
+        enforce_2fa=True,
     )
 
     url = urlparse(raw_url)
@@ -72,7 +73,6 @@ def test_fxa_login_url_requiring_two_factor_auth():
     next_path = urlsafe_b64encode(path.encode('utf-8')).rstrip(b'=')
     assert query == {
         'acr_values': ['AAL2'],
-        'action': ['signin'],
         'client_id': ['foo'],
         'scope': ['profile openid'],
         'state': [f'myfxastate:{force_str(next_path)}'],
@@ -91,9 +91,8 @@ def test_fxa_login_url_requiring_two_factor_auth_passing_token():
         config=FXA_CONFIG['default'],
         state=request.session['fxa_state'],
         next_path=path,
-        action='signin',
-        force_two_factor=True,
-        id_token='YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo=',
+        enforce_2fa=True,
+        id_token_hint='YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo=',
     )
 
     url = urlparse(raw_url)
@@ -105,9 +104,73 @@ def test_fxa_login_url_requiring_two_factor_auth_passing_token():
     next_path = urlsafe_b64encode(path.encode('utf-8')).rstrip(b'=')
     assert query == {
         'acr_values': ['AAL2'],
-        'action': ['signin'],
         'client_id': ['foo'],
         'id_token_hint': ['YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo='],
+        'prompt': ['none'],
+        'scope': ['profile openid'],
+        'state': [f'myfxastate:{force_str(next_path)}'],
+        'access_type': ['offline'],
+    }
+
+
+@override_settings(FXA_CONFIG=FXA_CONFIG)
+@override_settings(FXA_OAUTH_HOST='https://accounts.firefox.com/oauth')
+def test_fxa_login_url_requiring_two_factor_auth_passing_request():
+    path = '/en-US/addons/abp/?source=ddg'
+    request = RequestFactory().get(path)
+    request.session = {'fxa_state': 'myfxastate'}
+
+    raw_url = utils.fxa_login_url(
+        config=FXA_CONFIG['default'],
+        state=request.session['fxa_state'],
+        next_path=path,
+        enforce_2fa=True,
+        request=request,
+    )
+
+    url = urlparse(raw_url)
+    base = '{scheme}://{netloc}{path}'.format(
+        scheme=url.scheme, netloc=url.netloc, path=url.path
+    )
+    assert base == 'https://accounts.firefox.com/oauth/authorization'
+    query = parse_qs(url.query)
+    next_path = urlsafe_b64encode(path.encode('utf-8')).rstrip(b'=')
+    assert query == {
+        'acr_values': ['AAL2'],
+        'client_id': ['foo'],
+        'scope': ['profile openid'],
+        'state': [f'myfxastate:{force_str(next_path)}'],
+        'access_type': ['offline'],
+    }
+
+
+@override_settings(FXA_CONFIG=FXA_CONFIG)
+@override_settings(FXA_OAUTH_HOST='https://accounts.firefox.com/oauth')
+def test_fxa_login_url_requiring_two_factor_auth_passing_login_hint():
+    path = '/en-US/addons/abp/?source=ddg'
+    request = RequestFactory().get(path)
+    request.session = {'fxa_state': 'myfxastate'}
+
+    raw_url = utils.fxa_login_url(
+        config=FXA_CONFIG['default'],
+        state=request.session['fxa_state'],
+        next_path=path,
+        enforce_2fa=True,
+        request=request,
+        login_hint='test@example.com',
+    )
+
+    url = urlparse(raw_url)
+    base = '{scheme}://{netloc}{path}'.format(
+        scheme=url.scheme, netloc=url.netloc, path=url.path
+    )
+    assert base == 'https://accounts.firefox.com/oauth/authorization'
+    query = parse_qs(url.query)
+    next_path = urlsafe_b64encode(path.encode('utf-8')).rstrip(b'=')
+    assert query == {
+        'acr_values': ['AAL2'],
+        'client_id': ['foo'],
+        'login_hint': ['test@example.com'],
         'prompt': ['none'],
         'scope': ['profile openid'],
         'state': [f'myfxastate:{force_str(next_path)}'],
@@ -123,7 +186,6 @@ def test_unicode_next_path():
         config=FXA_CONFIG['default'],
         state=request.session['fxa_state'],
         next_path=utils.path_with_query(request),
-        action='signin',
     )
     state = parse_qs(urlparse(url).query)['state'][0]
     next_path = urlsafe_b64decode(state.split(':')[1] + '===')
@@ -139,8 +201,97 @@ def test_redirect_for_login():
         config=FXA_CONFIG['default'],
         state=request.session['fxa_state'],
         next_path='/somewhere',
-        action='signin',
     )
+    assert request.session['enforce_2fa'] is False
+
+
+@override_settings(FXA_CONFIG=FXA_CONFIG)
+def test_redirect_for_login_with_next_path():
+    request = RequestFactory().get('/somewhere')
+    request.session = {'fxa_state': 'fake-state'}
+    response = utils.redirect_for_login(request, next_path='/over/the/rainbow')
+    assert response['location'] == utils.fxa_login_url(
+        config=FXA_CONFIG['default'],
+        state=request.session['fxa_state'],
+        next_path='/over/the/rainbow',
+    )
+    assert request.session['enforce_2fa'] is False
+
+
+@override_settings(FXA_CONFIG=FXA_CONFIG)
+def test_redirect_for_login_with_config():
+    request = RequestFactory().get('/somewhere')
+    request.session = {'fxa_state': 'fake-state'}
+    response = utils.redirect_for_login(request, config=FXA_CONFIG['other'])
+    assert response['location'] == utils.fxa_login_url(
+        config=FXA_CONFIG['other'],
+        state=request.session['fxa_state'],
+        next_path='/somewhere',
+    )
+    assert request.session['enforce_2fa'] is False
+
+
+@override_settings(FXA_CONFIG=FXA_CONFIG)
+def test_redirect_for_login_with_2fa_enforced():
+    request = RequestFactory().get('/somewhere')
+    request.session = {'fxa_state': 'fake-state'}
+    response = utils.redirect_for_login_with_2fa_enforced(request)
+    assert response['location'] == utils.fxa_login_url(
+        config=FXA_CONFIG['default'],
+        state=request.session['fxa_state'],
+        next_path='/somewhere',
+        enforce_2fa=True,
+    )
+    assert request.session['enforce_2fa'] is True
+
+
+@override_settings(FXA_CONFIG=FXA_CONFIG)
+def test_redirect_for_login_with_2fa_enforced_id_token_hint():
+    request = RequestFactory().get('/somewhere')
+    request.session = {'fxa_state': 'fake-state'}
+    response = utils.redirect_for_login_with_2fa_enforced(
+        request, id_token_hint='some_token_hint'
+    )
+    assert response['location'] == utils.fxa_login_url(
+        config=FXA_CONFIG['default'],
+        state=request.session['fxa_state'],
+        next_path='/somewhere',
+        enforce_2fa=True,
+        id_token_hint='some_token_hint',
+    )
+    assert request.session['enforce_2fa'] is True
+
+
+@override_settings(FXA_CONFIG=FXA_CONFIG)
+def test_redirect_for_login_with_2fa_enforced_and_next_path():
+    request = RequestFactory().get('/somewhere')
+    request.session = {'fxa_state': 'fake-state'}
+    response = utils.redirect_for_login_with_2fa_enforced(
+        request, next_path='/over/the/rainbow'
+    )
+    assert response['location'] == utils.fxa_login_url(
+        config=FXA_CONFIG['default'],
+        state=request.session['fxa_state'],
+        next_path='/over/the/rainbow',
+        enforce_2fa=True,
+    )
+    assert request.session['enforce_2fa'] is True
+
+
+@override_settings(FXA_CONFIG=FXA_CONFIG)
+def test_redirect_for_login_with_2fa_enforced_and_config():
+    request = RequestFactory().get('/somewhere')
+    request.session = {'fxa_state': 'fake-state'}
+    response = utils.redirect_for_login_with_2fa_enforced(
+        request, config=FXA_CONFIG['other']
+    )
+    assert response['location'] == utils.fxa_login_url(
+        config=FXA_CONFIG['other'],
+        state=request.session['fxa_state'],
+        next_path='/somewhere',
+        enforce_2fa=True,
+    )
+    assert request.session['enforce_2fa'] is True
 
 
 @override_settings(DEBUG=True, USE_FAKE_FXA_AUTH=True)
@@ -152,7 +303,6 @@ def test_fxa_login_url_when_faking_fxa_auth():
         config=FXA_CONFIG['default'],
         state=request.session['fxa_state'],
         next_path=path,
-        action='signin',
     )
     url = urlparse(raw_url)
     assert url.scheme == ''
@@ -161,9 +311,36 @@ def test_fxa_login_url_when_faking_fxa_auth():
     query = parse_qs(url.query)
     next_path = urlsafe_b64encode(path.encode('utf-8')).rstrip(b'=')
     assert query == {
-        'action': ['signin'],
         'client_id': ['foo'],
         'scope': ['profile openid'],
         'state': [f'myfxastate:{force_str(next_path)}'],
         'access_type': ['offline'],
     }
+
+
+@override_settings(
+    FXA_CONFIG={
+        'foo': {'FOO': 123},
+        'bar': {'BAR': 456},
+        'baz': {'BAZ': 789},
+    },
+    DEFAULT_FXA_CONFIG_NAME='baz',
+)
+class TestGetFxaConfigAndName(TestCase):
+    def test_no_config(self):
+        request = RequestFactory().get('/login')
+        assert utils.get_fxa_config_name(request) == 'baz'
+        config = utils.get_fxa_config(request)
+        assert config == {'BAZ': 789}
+
+    def test_config_alternate(self):
+        request = RequestFactory().get('/login?config=bar')
+        assert utils.get_fxa_config_name(request) == 'bar'
+        config = utils.get_fxa_config(request)
+        assert config == {'BAR': 456}
+
+    def test_config_is_default(self):
+        request = RequestFactory().get('/login?config=baz')
+        assert utils.get_fxa_config_name(request) == 'baz'
+        config = utils.get_fxa_config(request)
+        assert config == {'BAZ': 789}

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -11,7 +11,6 @@ from django import http
 from django.conf import settings
 from django.contrib.auth import login
 from django.contrib.auth.models import AnonymousUser
-from django.test import RequestFactory
 from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils.encoding import force_str
@@ -22,6 +21,7 @@ import responses
 from rest_framework import exceptions
 from rest_framework.settings import api_settings
 from rest_framework.test import APIClient, APIRequestFactory
+from rest_framework.views import APIView
 from waffle.models import Switch
 from waffle.testutils import override_switch
 
@@ -78,7 +78,7 @@ class TestLoginStartBaseView(WithDynamicEndpoints, TestCase):
         self.initialize_session({})
         assert 'fxa_state' not in self.client.session
         state = 'somerandomstate'
-        with mock.patch('olympia.accounts.views.generate_fxa_state', lambda: state):
+        with mock.patch('olympia.accounts.utils.generate_fxa_state', lambda: state):
             self.client.get(self.url)
         assert 'fxa_state' in self.client.session
         assert self.client.session['fxa_state'] == state
@@ -86,7 +86,7 @@ class TestLoginStartBaseView(WithDynamicEndpoints, TestCase):
     def test_redirect_url_is_correct(self):
         self.initialize_session({})
         with mock.patch(
-            'olympia.accounts.views.generate_fxa_state', lambda: 'arandomstring'
+            'olympia.accounts.utils.generate_fxa_state', lambda: 'arandomstring'
         ):
             response = self.client.get(self.url)
         assert response.status_code == 302
@@ -101,7 +101,6 @@ class TestLoginStartBaseView(WithDynamicEndpoints, TestCase):
         assert redirect == 'https://accounts.firefox.com/v1/authorization'
         assert parse_qs(url.query) == {
             'access_type': ['offline'],
-            'action': ['signin'],
             'client_id': ['amodefault'],
             'scope': ['profile openid'],
             'state': ['arandomstring'],
@@ -123,7 +122,7 @@ class TestLoginStartBaseView(WithDynamicEndpoints, TestCase):
         assert b'=' in base64.urlsafe_b64encode(path)
         state = 'somenewstatestring'
         self.initialize_session({})
-        with mock.patch('olympia.accounts.views.generate_fxa_state', lambda: state):
+        with mock.patch('olympia.accounts.utils.generate_fxa_state', lambda: state):
             response = self.client.get(self.url, data={'to': path})
         assert self.client.session['fxa_state'] == state
         url = urlparse(response['location'])
@@ -522,28 +521,35 @@ class TestWithUser(TestCase):
             ),
         }
         response = self.fn(self.request)
-        self.assertRedirects(response, '/next', fetch_redirect_response=False)
+        # next path is ignored as state is not reliable.
+        self.assertRedirects(response, '/', fetch_redirect_response=False)
 
-    def test_dynamic_configuration(self):
-        fxa_config = {'some': 'config'}
-
-        class LoginView:
-            def get_fxa_config(self, request):
-                return fxa_config
-
-            def get_config_name(self, request):
-                return 'some_config_name'
-
+    @override_settings(
+        FXA_CONFIG={'a_conf': {'client_id': 'clientid', 'client_secret': 'supersikret'}}
+    )
+    def test_non_default_fxa_configuration_with_actual_apiview(self):
+        class LoginView(APIView):
             @views.with_user
-            def post(*args, **kwargs):
-                return args, kwargs
+            def get(*args, **kwargs):
+                return super().get(*args, **kwargs)
 
+        fxa_config_name = 'a_conf'
+        fxa_state = 'someblob'
+        fxa_code = 'foo'
         identity = {'uid': '1234', 'email': 'hey@yo.it'}
         self.fxa_identify.return_value = identity, self.token_data
         self.find_user.return_value = self.user
-        self.request.data = {'code': 'foo', 'state': 'some-blob'}
-        LoginView().post(self.request)
-        self.fxa_identify.assert_called_with('foo', config=fxa_config)
+        # We're emulating an APIView, so we have to provide a true request
+        # object and let DRF processing make a DRF Request out of it by calling
+        # dispatch().
+        self.request = APIRequestFactory().get(
+            f'/?config={fxa_config_name}&code={fxa_code}&state={fxa_state}'
+        )
+        self.request.session = {'fxa_state': fxa_state}
+        LoginView().dispatch(self.request)
+        self.fxa_identify.assert_called_with(
+            fxa_code, config={'client_id': 'clientid', 'client_secret': 'supersikret'}
+        )
 
     def _test_should_redirect_for_two_factor_auth(self):
         identity = {'uid': '1234', 'email': 'hey@yo.it'}
@@ -576,7 +582,6 @@ class TestWithUser(TestCase):
         assert query == {
             'access_type': ['offline'],
             'acr_values': ['AAL2'],
-            'action': ['signin'],
             'client_id': [fxa_config['client_id']],
             'id_token_hint': ['someopenidtoken'],
             'prompt': ['none'],
@@ -657,12 +662,42 @@ class TestWithUser(TestCase):
             identity=identity
         )
 
+    def test_2fa_enforced_already_using_two_factor_should_continue(self):
+        self.create_flag('2fa-enforcement-for-developers-and-special-users')
+        self.user = user_factory()
+        identity = {
+            'uid': '1234',
+            'email': 'hey@yo.it',
+            'twoFactorAuthentication': True,
+        }
+        self.request.session['enforce_2fa'] = True
+        self._test_should_continue_without_redirect_for_two_factor_auth(
+            identity=identity
+        )
+        # Since the authentication was successful and satistified our 2FA
+        # requirement, we removed the property from the session.
+        assert 'enforce_2fa' not in self.request.session
+
+    def test_2fa_enforced_on_this_view_should_redirect_for_two_factor_auth(self):
+        self.create_flag('2fa-enforcement-for-developers-and-special-users')
+        self.user = user_factory()
+        self.request.session['enforce_2fa'] = True
+        self._test_should_redirect_for_two_factor_auth()
+
     def test_waffle_flag_off_developer_without_2fa_should_continue(self):
         self.create_flag(
             '2fa-enforcement-for-developers-and-special-users', everyone=False
         )
         self.user = user_factory()
         addon_factory(users=[self.user])
+        self._test_should_continue_without_redirect_for_two_factor_auth()
+
+    def test_waffle_flag_off_enforced_2fa_should_have_no_effect(self):
+        self.create_flag(
+            '2fa-enforcement-for-developers-and-special-users', everyone=False
+        )
+        self.user = user_factory()
+        self.request.session['enforce_2fa'] = True
         self._test_should_continue_without_redirect_for_two_factor_auth()
 
     @override_settings(DEBUG=True, USE_FAKE_FXA_AUTH=True)
@@ -682,33 +717,31 @@ class TestWithUser(TestCase):
         assert kwargs['identity']['email'] == self.user.email
         assert kwargs['identity']['uid'].startswith('fake_fxa_id-')
         assert len(kwargs['identity']['uid']) == 44  # 32 random chars + prefix
+        assert kwargs['identity']['twoFactorAuthentication'] is None
         assert kwargs['next_path'] == '/a/path/?'
         assert self.fxa_identify.call_count == 0
 
-
-@override_settings(
-    FXA_CONFIG={
-        'foo': {'FOO': 123},
-        'bar': {'BAR': 456},
-        'baz': {'BAZ': 789},
-    },
-    DEFAULT_FXA_CONFIG_NAME='baz',
-)
-class TestFxAConfigMixin(TestCase):
-    def test_no_config(self):
-        request = RequestFactory().get('/login')
-        config = views.FxAConfigMixin().get_fxa_config(request)
-        assert config == {'BAZ': 789}
-
-    def test_config_alternate(self):
-        request = RequestFactory().get('/login?config=bar')
-        config = views.FxAConfigMixin().get_fxa_config(request)
-        assert config == {'BAR': 456}
-
-    def test_config_is_default(self):
-        request = RequestFactory().get('/login?config=baz')
-        config = views.FxAConfigMixin().get_fxa_config(request)
-        assert config == {'BAZ': 789}
+    @override_settings(DEBUG=True, USE_FAKE_FXA_AUTH=True)
+    def test_fake_fxa_auth_with_2fa(self):
+        self.user = user_factory()
+        self.find_user.return_value = self.user
+        self.request.data = {
+            'code': 'foo',
+            'fake_fxa_email': self.user.email,
+            'fake_two_factor_authentication': 'true',
+            'state': 'some-blob:{next_path}'.format(
+                next_path=force_str(base64.urlsafe_b64encode(b'/a/path/?'))
+            ),
+        }
+        args, kwargs = self.fn(self.request)
+        assert args == (self, self.request)
+        assert kwargs['user'] == self.user
+        assert kwargs['identity']['email'] == self.user.email
+        assert kwargs['identity']['uid'].startswith('fake_fxa_id-')
+        assert len(kwargs['identity']['uid']) == 44  # 32 random chars + prefix
+        assert kwargs['identity']['twoFactorAuthentication'] == 'true'
+        assert kwargs['next_path'] == '/a/path/?'
+        assert self.fxa_identify.call_count == 0
 
 
 def empty_view(*args, **kwargs):
@@ -756,7 +789,8 @@ class TestAuthenticateView(TestCase, InitializeSessionMixin):
             response['Cache-Control']
             == 'max-age=0, no-cache, no-store, must-revalidate, private'
         )
-        assert_url_equal(response['location'], '/en-US/firefox/')
+        # next path is ignored as state is not reliable.
+        assert_url_equal(response['location'], '/')
         assert not self.login_user.called
         assert not self.register_user.called
         assert not self.reregister_user.called
@@ -768,7 +802,21 @@ class TestAuthenticateView(TestCase, InitializeSessionMixin):
             response['Cache-Control']
             == 'max-age=0, no-cache, no-store, must-revalidate, private'
         )
-        assert_url_equal(response['location'], '/en-US/firefox/')
+        # next path is ignored as state is not reliable.
+        assert_url_equal(response['location'], '/')
+        assert not self.login_user.called
+        assert not self.register_user.called
+        assert not self.reregister_user.called
+
+    def test_error_from_fxa(self):
+        response = self.client.get(self.url, {'error': 'foo', 'state': '9f865be0'})
+        assert response.status_code == 302
+        assert (
+            response['Cache-Control']
+            == 'max-age=0, no-cache, no-store, must-revalidate, private'
+        )
+        # next path is ignored as state is not reliable.
+        assert_url_equal(response['location'], '/')
         assert not self.login_user.called
         assert not self.register_user.called
         assert not self.reregister_user.called
@@ -2291,7 +2339,7 @@ class TestFxaNotificationView(TestCase):
             *self.JWKS_RESPONSE['keys'],
         ]
         decode_mock.return_value = self.FXA_EVENT
-        request_factory = RequestFactory()
+        request_factory = APIRequestFactory()
 
         authd_jwt = FxaNotificationView().get_jwt_payload(
             request_factory.get('/', HTTP_AUTHORIZATION='Bearer fooo')

--- a/src/olympia/accounts/utils.py
+++ b/src/olympia/accounts/utils.py
@@ -8,17 +8,21 @@ from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.encoding import force_str
 
+import olympia.core.logger
 from olympia.amo.utils import is_safe_url, use_fake_fxa
+
+
+log = olympia.core.logger.getLogger('accounts')
 
 
 def fxa_login_url(
     config,
     state,
     next_path=None,
-    action=None,
-    force_two_factor=False,
+    enforce_2fa=False,
     request=None,
-    id_token=None,
+    id_token_hint=None,
+    login_hint=None,
 ):
     if next_path and is_safe_url(next_path, request):
         state += ':' + force_str(urlsafe_b64encode(next_path.encode('utf-8'))).rstrip(
@@ -30,20 +34,31 @@ def fxa_login_url(
         'state': state,
         'access_type': 'offline',
     }
-    if action is not None:
-        query['action'] = action
-    if force_two_factor is True:
+    if enforce_2fa is True:
         # Specifying AAL2 will require the token to have an authentication
         # assurance level >= 2 which corresponds to requiring 2FA.
         query['acr_values'] = 'AAL2'
-        # Requesting 'prompt=none' during authorization, together with passing
-        # a valid id token in 'id_token_hint', allows the user to not have to
-        # re-authenticate with FxA if they still have a valid session (which
-        # they should here: they went through FxA, back to AMO, and now we're
-        # redirecting them to FxA because we want them to have 2FA enabled).
-        if id_token:
+        # https://mozilla.github.io/ecosystem-platform/reference/oauth-details
+        # #promptnone-support
+        # Requesting 'prompt=none' during authorization allows the user to not
+        # have to re-authenticate with FxA if they still have a valid session.
+        # We have 2 use cases for this:
+        # - The user just logged in through FxA without 2FA, was redirected
+        #   back to AMO where we noticed they are a developer and are requiring
+        #   2FA for their account. We have id_token_hint in that case that we
+        #   pass down.
+        # - The user was already logged in but we enforced 2FA on a specific
+        #   view they tried to access. We don't have id_token_hint in that case
+        #   but our clients are explicitly allowed to pass login_hint instead
+        #   (See https://mozilla-hub.atlassian.net/browse/SVCSE-1358).
+        # In both cases, the user should then see the 2FA enrollment flow when
+        # they get redirected back to FxA.
+        if id_token_hint:
             query['prompt'] = 'none'
-            query['id_token_hint'] = id_token
+            query['id_token_hint'] = id_token_hint
+        elif login_hint:
+            query['prompt'] = 'none'
+            query['login_hint'] = login_hint
     if use_fake_fxa():
         base_url = reverse('fake-fxa-authorization')
     else:
@@ -55,13 +70,54 @@ def generate_fxa_state():
     return force_str(binascii.hexlify(os.urandom(32)))
 
 
-def redirect_for_login(request):
+def get_fxa_config_name(request):
+    config_name = request.GET.get('config')
+    if config_name not in settings.FXA_CONFIG:
+        if config_name:
+            log.info(f'Using default FxA config instead of {config_name}')
+        config_name = settings.DEFAULT_FXA_CONFIG_NAME
+    return config_name
+
+
+def get_fxa_config(request):
+    return settings.FXA_CONFIG[get_fxa_config_name(request)]
+
+
+def redirect_for_login(request, *, config=None, next_path=None):
+    if config is None:
+        config = get_fxa_config(request)
+    if next_path is None:
+        next_path = path_with_query(request)
     request.session.setdefault('fxa_state', generate_fxa_state())
+    # Previous page in session might have required 2FA, but this page doesn't.
+    # We override it in case the user didn't complete the flow for the previous
+    # page they were on.
+    request.session['enforce_2fa'] = False
     url = fxa_login_url(
-        config=settings.FXA_CONFIG['default'],
+        config=config,
         state=request.session['fxa_state'],
-        next_path=path_with_query(request),
-        action='signin',
+        next_path=next_path,
+    )
+    return HttpResponseRedirect(url)
+
+
+def redirect_for_login_with_2fa_enforced(
+    request, *, config=None, next_path=None, id_token_hint=None, login_hint=None
+):
+    if config is None:
+        config = get_fxa_config(request)
+    if next_path is None:
+        next_path = path_with_query(request)
+    request.session.setdefault('fxa_state', generate_fxa_state())
+    request.session['enforce_2fa'] = True
+    url = fxa_login_url(
+        config=config,
+        state=request.session['fxa_state'],
+        next_path=next_path,
+        enforce_2fa=True,
+        id_token_hint=id_token_hint,
+        login_hint=login_hint,
+        request=request,
     )
     return HttpResponseRedirect(url)
 

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -73,7 +73,12 @@ from .serializers import (
     UserProfileSerializer,
 )
 from .tasks import clear_sessions_event, delete_user_event, primary_email_change_event
-from .utils import fxa_login_url, generate_fxa_state
+from .utils import (
+    get_fxa_config,
+    get_fxa_config_name,
+    redirect_for_login,
+    redirect_for_login_with_2fa_enforced,
+)
 
 
 log = olympia.core.logger.getLogger('accounts')
@@ -83,17 +88,20 @@ ERROR_NO_CODE = 'no-code'
 ERROR_NO_PROFILE = 'no-profile'
 ERROR_NO_USER = 'no-user'
 ERROR_STATE_MISMATCH = 'state-mismatch'
+ERROR_FXA_ERROR = 'error-fxa'
 ERROR_STATUSES = {
     ERROR_AUTHENTICATED: 400,
     ERROR_NO_CODE: 422,
     ERROR_NO_PROFILE: 401,
     ERROR_STATE_MISMATCH: 400,
+    ERROR_FXA_ERROR: 400,
 }
 LOGIN_ERROR_MESSAGES = {
     ERROR_AUTHENTICATED: _('You are already logged in.'),
     ERROR_NO_CODE: _('Your login attempt could not be parsed. Please try again.'),
     ERROR_NO_PROFILE: _('Your Firefox Account could not be found. Please try again.'),
     ERROR_STATE_MISMATCH: _('You could not be logged in. Please try again.'),
+    ERROR_FXA_ERROR: _('You could not be logged in. Please try again.'),
 }
 
 
@@ -176,6 +184,9 @@ def login_user(sender, request, user, identity, token_data=None):
     update_user(user, identity)
     log.info('Logging in user %s from FxA', user)
     login(request, user)
+    request.session['has_two_factor_authentication'] = identity.get(
+        'twoFactorAuthentication'
+    )
     if token_data:
         request.session['fxa_access_token_expiry'] = token_data['access_token_expiry']
         request.session['fxa_refresh_token'] = token_data['refresh_token']
@@ -216,30 +227,48 @@ def with_user(f):
     @functools.wraps(f)
     @use_primary_db
     def inner(self, request):
-        fxa_config = self.get_fxa_config(request)
+        # If we get an error, we want a new session without the 2FA enforcement
+        # requirement active and with a fresh state for future authentication
+        # attempts, so pop them.
+        enforce_2fa_for_this_session = request.session.pop('enforce_2fa', False)
+        fxa_state_session = request.session.pop('fxa_state', None)
+
+        fxa_config = get_fxa_config(request)
         if request.method == 'GET':
             data = request.query_params
         else:
             data = request.data
-
         state_parts = data.get('state', '').split(':', 1)
         state = state_parts[0]
         next_path = parse_next_path(state_parts, request)
-        if not data.get('code'):
-            log.info('No code provided.')
-            return safe_redirect(request, next_path, ERROR_NO_CODE)
-        elif (
-            not request.session.get('fxa_state')
-            or request.session['fxa_state'] != state
-        ):
+
+        if not fxa_state_session or fxa_state_session != state:
             log.info(
-                'State mismatch. URL: {url} Session: {session}'.format(
-                    url=data.get('state'),
-                    session=request.session.get('fxa_state'),
+                'FxA Auth State mismatch: {state} Session: {fxa_state_session}'.format(
+                    state=data.get('state'),
+                    fxa_state_session=fxa_state_session,
                 )
             )
-            return safe_redirect(request, next_path, ERROR_STATE_MISMATCH)
-        elif request.user.is_authenticated:
+            # Redirect to / as the state mismatch indicates the next path might
+            # not be reliable.
+            return safe_redirect(request, '/', ERROR_STATE_MISMATCH)
+        elif data.get('error'):
+            if enforce_2fa_for_this_session:
+                # If we're trying to enforce 2FA, we should try again without
+                # prompt=none (and a new state), maybe there is a mismatch
+                # between what user we currently have logged in and what
+                # Firefox Account the browser is logged into.
+                return redirect_for_login_with_2fa_enforced(
+                    request,
+                    config=fxa_config,
+                    next_path=next_path,
+                )
+            else:
+                return safe_redirect(request, next_path, ERROR_FXA_ERROR)
+        elif not data.get('code'):
+            log.info('No code provided.')
+            return safe_redirect(request, next_path, ERROR_NO_CODE)
+        elif request.user.is_authenticated and not enforce_2fa_for_this_session:
             return safe_redirect(request, next_path, ERROR_AUTHENTICATED)
         try:
             if use_fake_fxa() and 'fake_fxa_email' in data:
@@ -249,13 +278,16 @@ def with_user(f):
                     'email': data['fake_fxa_email'],
                     'uid': 'fake_fxa_id-%s'
                     % force_str(binascii.b2a_hex(os.urandom(16))),
+                    'twoFactorAuthentication': data.get(
+                        'fake_two_factor_authentication'
+                    ),
                 }
                 id_token, token_data = identity['email'], {}
             else:
                 identity, token_data = verify.fxa_identify(
                     data['code'], config=fxa_config
                 )
-                token_data['config_name'] = self.get_config_name(request)
+                token_data['config_name'] = get_fxa_config_name(request)
                 id_token = token_data.get('id_token')
         except verify.IdentificationError:
             log.info('Profile not found. Code: {}'.format(data['code']))
@@ -271,39 +303,42 @@ def with_user(f):
             # We can't use waffle.flag_is_active() wrapper, because
             # request.user isn't populated at this point (and we don't want
             # it to be).
-            flag = waffle.get_waffle_flag_model().get(
+            enforce_2fa_flag = waffle.get_waffle_flag_model().get(
                 '2fa-enforcement-for-developers-and-special-users'
             )
-            enforce_2fa_for_developers_and_special_users = flag.is_active(request) or (
-                flag.pk and flag.is_active_for_user(user)
+            enforce_2fa_flag_is_active = enforce_2fa_flag.is_active(request) or (
+                enforce_2fa_flag.pk and enforce_2fa_flag.is_active_for_user(user)
             )
             if (
                 user
                 and not identity.get('twoFactorAuthentication')
-                and enforce_2fa_for_developers_and_special_users
-                and (user.is_addon_developer or user.groups_list)
+                and enforce_2fa_flag_is_active
+                and (
+                    user.is_addon_developer
+                    or user.groups_list
+                    or enforce_2fa_for_this_session
+                )
             ):
                 # https://github.com/mozilla/addons/issues/732
-                # The user is an add-on developer (with other types of
-                # add-ons than just themes) or part of any group (so they
-                # are special in some way, may be an admin or a reviewer),
-                # but hasn't logged in with a second factor. Immediately
-                # redirect them to start the FxA flow again, this time
-                # requesting 2FA to be present - they should be
-                # automatically logged in FxA with the existing token, and
-                # should be prompted to create the second factor before
-                # coming back to AMO.
+                # https://github.com/mozilla/addons-server/issues/20943
+                # The user is an add-on developer (with other types of add-ons
+                # than just themes) or part of any group (so they are special
+                # in some way, may be an admin or a reviewer), or trying to
+                # access a page restricted to users with 2FA and they have
+                # successfully logged in from FxA, but without a second factor.
+                # Immediately redirect them to start the FxA flow again, this
+                # time requesting 2FA to be present:
+                # They should be automatically logged in FxA with the existing
+                # id_token, and should be prompted to create the second factor
+                # before coming back to AMO.
                 log.info('Redirecting user %s to enforce 2FA', user)
-                return HttpResponseRedirect(
-                    fxa_login_url(
-                        config=fxa_config,
-                        state=request.session['fxa_state'],
-                        next_path=next_path,
-                        action='signin',
-                        force_two_factor=True,
-                        request=request,
-                        id_token=id_token,
-                    )
+                # There wasn't any error, we can keep the original state.
+                request.session['fxa_state'] = fxa_state_session
+                return redirect_for_login_with_2fa_enforced(
+                    request,
+                    config=fxa_config,
+                    next_path=next_path,
+                    id_token_hint=id_token,
                 )
             return f(
                 self,
@@ -317,35 +352,13 @@ def with_user(f):
     return inner
 
 
-class FxAConfigMixin:
-    def get_config_name(self, request):
-        config_name = request.GET.get('config')
-        if config_name not in settings.FXA_CONFIG:
-            if config_name:
-                log.info(f'Using default FxA config instead of {config_name}')
-            config_name = settings.DEFAULT_FXA_CONFIG_NAME
-        return config_name
-
-    def get_fxa_config(self, request):
-        return settings.FXA_CONFIG[self.get_config_name(request)]
-
-
-class LoginStartView(FxAConfigMixin, APIView):
+class LoginStartView(APIView):
     @method_decorator(never_cache)
     def get(self, request):
-        request.session.setdefault('fxa_state', generate_fxa_state())
-        return HttpResponseRedirect(
-            fxa_login_url(
-                config=self.get_fxa_config(request),
-                state=request.session['fxa_state'],
-                next_path=request.GET.get('to'),
-                action=request.GET.get('action', 'signin'),
-                request=request,
-            )
-        )
+        return redirect_for_login(request, next_path=request.GET.get('to', ''))
 
 
-class AuthenticateView(FxAConfigMixin, APIView):
+class AuthenticateView(APIView):
     authentication_classes = (SessionAuthentication,)
 
     @method_decorator(never_cache)
@@ -735,7 +748,7 @@ class AccountNotificationUnsubscribeView(AccountNotificationMixin, GenericAPIVie
         return Response(serializer.data)
 
 
-class FxaNotificationView(FxAConfigMixin, APIView):
+class FxaNotificationView(APIView):
     authentication_classes = []
     permission_classes = []
 
@@ -767,7 +780,7 @@ class FxaNotificationView(FxAConfigMixin, APIView):
         return cls.fxa_verifying_keys
 
     def get_jwt_payload(self, request):
-        client_id = self.get_fxa_config(request)['client_id']
+        client_id = get_fxa_config(request)['client_id']
         authenticated_jwt = None
 
         auth_header_split = request.headers.get('Authorization', '').split('Bearer ')

--- a/src/olympia/amo/templates/amo/fake_fxa_authorization.html
+++ b/src/olympia/amo/templates/amo/fake_fxa_authorization.html
@@ -11,6 +11,7 @@
     {% endfor %}
     <input type="hidden" name="code" value="fakecode" />
     <label for="id_email">{{ _('Email:') }}</label> <input type="email" name="fake_fxa_email" id="id_email" />
+    <label><input type="checkbox" name="fake_two_factor_authentication" value="true" />{{ _('Two-step authentication') }}</label>
     <input type="submit" value="{{ _('OK') }}" />
 
     {% if interesting_accounts %}

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -285,6 +285,17 @@ class TestClient(Client):
         else:
             raise AttributeError
 
+    def force_login_with_2fa(self, user, backend=None):
+        self.force_login(user, backend=backend)
+        # https://docs.djangoproject.com/en/dev/topics/testing/tools/
+        # #django.test.Client.session
+        # To modify the session and then save it, it must be stored in a
+        # variable first (because a new SessionStore is created every time this
+        # property is accessed)
+        session = self.session
+        session['has_two_factor_authentication'] = True
+        session.save()
+
 
 class APITestClientSessionID(APIClient):
     def create_session(self, user, **overrides):
@@ -393,7 +404,6 @@ def fxa_login_link(response=None, to=None, request=None):
         config=settings.FXA_CONFIG['default'],
         state=state,
         next_path=to,
-        action='signin',
     )
 
 

--- a/src/olympia/amo/tests/test_middleware.py
+++ b/src/olympia/amo/tests/test_middleware.py
@@ -352,7 +352,6 @@ class TestTokenValidMiddleware(TestCase):
             config=settings.FXA_CONFIG['default'],
             state=request.session['fxa_state'],
             next_path=path_with_query(request),
-            action='signin',
         )
 
     def test_anonymous_user(self):


### PR DESCRIPTION
Pre-requisite for https://github.com/mozilla/addons-server/issues/20943
Fixes https://github.com/mozilla/addons-server/issues/21002

Refactors away some obsolete code in accounts and adds basic handling for FxA errors