### PR TITLE
Enforce 2FA at upload time

### DIFF
--- a/src/olympia/accounts/decorators.py
+++ b/src/olympia/accounts/decorators.py
@@ -1,0 +1,24 @@
+import functools
+
+import olympia.core.logger
+from olympia.accounts.utils import redirect_for_login_with_2fa_enforced
+
+
+# Needs to match accounts/views.py
+log = olympia.core.logger.getLogger('accounts')
+
+
+def two_factor_auth_required(f):
+    """Require the user to be authenticated and have 2FA enabled."""
+
+    @functools.wraps(f)
+    def wrapper(request, *args, **kw):
+        if not request.session.get('has_two_factor_authentication'):
+            # Note: Technically the user might not be logged in or not, it does
+            # not matter, if they are they need to go through FxA again anyway.
+            login_hint = request.user.email if request.user.is_authenticated else None
+            log.info('Redirecting user %s to enforce 2FA', request.user)
+            return redirect_for_login_with_2fa_enforced(request, login_hint=login_hint)
+        return f(request, *args, **kw)
+
+    return wrapper

--- a/src/olympia/accounts/tests/test_decorators.py
+++ b/src/olympia/accounts/tests/test_decorators.py
@@ -1,0 +1,45 @@
+from unittest import mock
+
+from django.contrib.auth.models import AnonymousUser
+from django.test.client import RequestFactory
+
+from olympia.accounts.decorators import two_factor_auth_required
+from olympia.accounts.utils import redirect_for_login_with_2fa_enforced
+from olympia.amo.tests import TestCase, user_factory
+
+
+class TestTwoFactorAuthRequired(TestCase):
+    def setUp(self):
+        self.user = user_factory()
+        self.f = mock.Mock()
+        self.f.__name__ = 'function'
+        self.f.return_value = 'FakeResponse'
+        self.request = RequestFactory().get('/')
+        self.request.session = {}
+        self.request.user = AnonymousUser()
+
+    def test_has_two_factor_auth(self):
+        self.request.session['has_two_factor_authentication'] = True
+        func = two_factor_auth_required(self.f)
+        response = func(self.request)
+        assert self.f.call_count == 1
+        assert response == 'FakeResponse'
+
+    def test_does_not_have_two_factor_auth_yet(self):
+        self.request.user = self.user
+        func = two_factor_auth_required(self.f)
+        response = func(self.request)
+        assert self.f.call_count == 0
+        expected_redirect_url = redirect_for_login_with_2fa_enforced(
+            self.request, login_hint=self.user.email
+        )['location']
+        self.assert3xx(response, expected_redirect_url)
+
+    def test_does_not_have_two_factor_auth_yet_anonymous(self):
+        func = two_factor_auth_required(self.f)
+        response = func(self.request)
+        assert self.f.call_count == 0
+        expected_redirect_url = redirect_for_login_with_2fa_enforced(self.request)[
+            'location'
+        ]
+        self.assert3xx(response, expected_redirect_url)

--- a/src/olympia/devhub/decorators.py
+++ b/src/olympia/devhub/decorators.py
@@ -18,7 +18,7 @@ def dev_required(
     submitting=False,
     qs=Addon.objects.all,
 ):
-    """Requires user to be add-on owner or admin.
+    """Require user to be add-on owner or admin.
 
     When owner_for_post is True, only owners can make a POST request. That
     argument can also be a callable.
@@ -100,7 +100,7 @@ def dev_required(
 
 
 def no_admin_disabled(f):
-    """Requires the addon not be STATUS_DISABLED (mozilla admin disabled)."""
+    """Require the addon not be STATUS_DISABLED (mozilla admin disabled)."""
 
     @functools.wraps(f)
     def wrapper(*args, **kw):

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -1100,6 +1100,7 @@ class TestAPIKeyPage(TestCase):
             state=self.client.session['fxa_state'],
             next_path=self.url,
             enforce_2fa=True,
+            login_hint=self.user.email,
         )
         self.assert3xx(response, expected_location)
 

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -18,6 +18,7 @@ from pyquery import PyQuery as pq
 from waffle.testutils import override_switch
 
 from olympia import amo, core
+from olympia.accounts.utils import fxa_login_url
 from olympia.activity.models import GENERIC_USER_NAME, ActivityLog
 from olympia.addons.models import Addon, AddonCategory, AddonReviewerFlags, AddonUser
 from olympia.amo.templatetags.jinja_helpers import (
@@ -37,6 +38,7 @@ from olympia.applications.models import AppVersion
 from olympia.constants.promoted import RECOMMENDED
 from olympia.devhub.decorators import dev_required
 from olympia.devhub.models import BlogPost
+from olympia.devhub.tasks import validate
 from olympia.devhub.views import get_next_version_number
 from olympia.files.models import FileUpload
 from olympia.files.tests.test_models import UploadMixin
@@ -840,7 +842,7 @@ class TestAPIKeyPage(TestCase):
     def setUp(self):
         super().setUp()
         self.url = reverse('devhub.api_key')
-        self.client.force_login(UserProfile.objects.get(email='del@icio.us'))
+        self.client.force_login_with_2fa(UserProfile.objects.get(email='del@icio.us'))
         self.user = UserProfile.objects.get(email='del@icio.us')
         self.user.update(last_login_ip='192.168.1.1')
 
@@ -1089,13 +1091,26 @@ class TestAPIKeyPage(TestCase):
         assert len(mail.outbox) == 1
         assert 'revoked' in mail.outbox[0].body
 
+    def test_enforce_2fa(self):
+        self.client.logout()
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        expected_location = fxa_login_url(
+            config=settings.FXA_CONFIG['default'],
+            state=self.client.session['fxa_state'],
+            next_path=self.url,
+            enforce_2fa=True,
+        )
+        self.assert3xx(response, expected_location)
+
 
 class TestUpload(UploadMixin, TestCase):
     fixtures = ['base/users']
 
     def setUp(self):
         super().setUp()
-        self.client.force_login(UserProfile.objects.get(email='regular@mozilla.com'))
+        self.user = UserProfile.objects.get(email='regular@mozilla.com')
+        self.client.force_login(self.user)
         self.url = reverse('devhub.upload')
         self.xpi_path = self.file_path('webextension_no_id.xpi')
 
@@ -1112,6 +1127,7 @@ class TestUpload(UploadMixin, TestCase):
         assert response.status_code == 302
 
     def test_create_fileupload(self):
+        self.client.force_login_with_2fa(self.user)
         self.post()
 
         upload = FileUpload.objects.filter().order_by('-created').first()
@@ -1128,15 +1144,16 @@ class TestUpload(UploadMixin, TestCase):
         assert manifest_data == original_manifest_data
 
     def test_fileupload_metadata(self):
-        user = UserProfile.objects.get(email='regular@mozilla.com')
-        self.client.force_login(user)
+        self.client.force_login_with_2fa(self.user)
+        self.client.force_login(self.user)
         self.post(REMOTE_ADDR='4.8.15.16.23.42')
         upload = FileUpload.objects.get()
-        assert upload.user == user
+        assert upload.user == self.user
         assert upload.source == amo.UPLOAD_SOURCE_DEVHUB
         assert upload.ip_address == '4.8.15.16.23.42'
 
     def test_fileupload_validation_not_a_xpi_file(self):
+        self.client.force_login_with_2fa(self.user)
         self.xpi_path = get_image_path('animated.png')  # not a xpi file.
         self.post()
         upload = FileUpload.objects.filter().order_by('-created').first()
@@ -1157,6 +1174,7 @@ class TestUpload(UploadMixin, TestCase):
         assert not msg['description']
 
     def test_redirect(self):
+        self.client.force_login_with_2fa(self.user)
         response = self.post()
         upload = FileUpload.objects.get()
         assert upload.channel == amo.CHANNEL_LISTED
@@ -1171,6 +1189,7 @@ class TestUpload(UploadMixin, TestCase):
     @mock.patch('olympia.devhub.tasks.validate')
     def test_upload_unlisted_addon(self, validate_mock):
         """Unlisted addons are validated as "self hosted" addons."""
+        self.client.force_login_with_2fa(self.user)
         validate_mock.return_value = json.dumps(amo.VALIDATOR_SKELETON_RESULTS)
         self.url = reverse('devhub.upload_unlisted')
         response = self.post()
@@ -1211,6 +1230,67 @@ class TestUpload(UploadMixin, TestCase):
             }
         }
 
+    def test_upload_extension_without_2fa(self):
+        self.url = reverse('devhub.upload')
+        from olympia.accounts.utils import fxa_login_url
+        from olympia.amo.templatetags.jinja_helpers import absolutify
+
+        response = self.post()
+        expected_url = absolutify(
+            fxa_login_url(
+                config=settings.FXA_CONFIG['default'],
+                state=self.client.session['fxa_state'],
+                next_path=reverse('devhub.submit.upload', args=['listed']),
+                enforce_2fa=True,
+            )
+        )
+        assert response.status_code == 400
+        assert response.json() == {
+            'validation': {
+                'errors': 1,
+                'warnings': 0,
+                'notices': 0,
+                'success': False,
+                'compatibility_summary': {'notices': 0, 'errors': 0, 'warnings': 0},
+                'metadata': {'listed': True},
+                'messages': [
+                    {
+                        'tier': 1,
+                        'type': 'error',
+                        'id': ['validation', 'messages', ''],
+                        'message': (
+                            f'<a href="{expected_url}">'
+                            'Please add two-factor authentication to your account '
+                            'to submit extensions.</a>'
+                        ),
+                        'description': [],
+                        'compatibility_type': None,
+                        'extra': True,
+                    }
+                ],
+                'message_tree': {},
+                'ending_tier': 5,
+            }
+        }
+
+    def test_upload_theme_without_2fa(self):
+        self.xpi_path = os.path.join(
+            settings.ROOT, 'src/olympia/devhub/tests/addons/static_theme.zip'
+        )
+        response = self.post(theme_specific=True)
+        upload = FileUpload.objects.get()
+        assert upload.channel == amo.CHANNEL_LISTED
+        url = reverse('devhub.upload_detail', args=[upload.uuid.hex, 'json'])
+        self.assert3xx(response, url)
+
+    def test_upload_for_standalone_validation_without_2fa(self):
+        self.url = reverse('devhub.standalone_upload')
+        response = self.post()
+        upload = FileUpload.objects.get()
+        assert upload.channel == amo.CHANNEL_LISTED
+        url = reverse('devhub.standalone_upload_detail', args=[upload.uuid.hex])
+        self.assert3xx(response, url)
+
 
 class TestUploadDetail(UploadMixin, TestCase):
     fixtures = ['base/appversion', 'base/users']
@@ -1229,18 +1309,14 @@ class TestUploadDetail(UploadMixin, TestCase):
 
     def setUp(self):
         super().setUp()
-        self.client.force_login(UserProfile.objects.get(email='regular@mozilla.com'))
+        self.user = UserProfile.objects.get(email='regular@mozilla.com')
+        self.client.force_login(self.user)
 
     @classmethod
     def create_appversion(cls, application_name, version):
         return AppVersion.objects.create(
             application=amo.APPS[application_name].id, version=version
         )
-
-    def post(self):
-        # Has to be a binary, non xpi file.
-        data = open(get_image_path('animated.png'), 'rb')
-        return self.client.post(reverse('devhub.upload'), {'upload': data})
 
     def validation_ok(self):
         return {
@@ -1254,16 +1330,31 @@ class TestUploadDetail(UploadMixin, TestCase):
             'metadata': {},
         }
 
-    def upload_file(self, file, url='devhub.upload'):
-        addon = os.path.join(
-            settings.ROOT, 'src', 'olympia', 'devhub', 'tests', 'addons', file
+    def upload_dummy_file(self):
+        return self.upload_file(get_image_path('animated.png'))
+
+    def upload_file(self, filename):
+        path = (
+            os.path.join(
+                settings.ROOT, 'src', 'olympia', 'devhub', 'tests', 'addons', filename
+            )
+            if not filename.startswith('/')
+            else filename
         )
-        with open(addon, 'rb') as f:
-            response = self.client.post(reverse(url), {'upload': f})
-        assert response.status_code == 302
+        with open(path, 'rb') as f:
+            data = f.read()
+        upload = FileUpload.from_post(
+            [data],
+            filename=os.path.basename(filename),
+            size=42,
+            user=self.user,
+            source=amo.UPLOAD_SOURCE_DEVHUB,
+            channel=amo.CHANNEL_LISTED,
+        )
+        validate(upload)
 
     def test_detail_json(self):
-        self.post()
+        self.upload_dummy_file()
 
         upload = FileUpload.objects.get()
         response = self.client.get(
@@ -1289,7 +1380,7 @@ class TestUploadDetail(UploadMixin, TestCase):
         user = UserProfile.objects.get(email='regular@mozilla.com')
         addon = addon_factory()
         addon.addonuser_set.create(user=user)
-        self.post()
+        self.upload_dummy_file()
 
         upload = FileUpload.objects.get()
         response = self.client.get(
@@ -1311,7 +1402,7 @@ class TestUploadDetail(UploadMixin, TestCase):
         user = UserProfile.objects.get(email='regular@mozilla.com')
         addon = addon_factory()
         addon.addonuser_set.create(user=user)
-        self.post()
+        self.upload_dummy_file()
         upload = FileUpload.objects.get()
         self.client.force_login(user_factory())
 
@@ -1326,7 +1417,7 @@ class TestUploadDetail(UploadMixin, TestCase):
         user = UserProfile.objects.get(email='regular@mozilla.com')
         addon = addon_factory(version_kw={'channel': amo.CHANNEL_UNLISTED})
         addon.addonuser_set.create(user=user)
-        self.post()
+        self.upload_dummy_file()
 
         upload = FileUpload.objects.get()
         response = self.client.get(
@@ -1341,7 +1432,7 @@ class TestUploadDetail(UploadMixin, TestCase):
         addon = addon_factory()
         addon.addonuser_set.create(user=user)
         addon.delete()
-        self.post()
+        self.upload_dummy_file()
 
         upload = FileUpload.objects.get()
         response = self.client.get(
@@ -1352,7 +1443,7 @@ class TestUploadDetail(UploadMixin, TestCase):
         assert response.status_code == 404
 
     def test_detail_view(self):
-        self.post()
+        self.upload_dummy_file()
         upload = FileUpload.objects.filter().order_by('-created').first()
         response = self.client.get(
             reverse('devhub.upload_detail', args=[upload.uuid.hex])
@@ -1372,7 +1463,7 @@ class TestUploadDetail(UploadMixin, TestCase):
         assert response.status_code == 404
 
     def test_wrong_user(self):
-        self.post()
+        self.upload_dummy_file()
         upload = FileUpload.objects.filter().order_by('-created').first()
         self.client.force_login(user_factory())
         response = self.client.get(
@@ -1491,11 +1582,9 @@ class TestUploadDetail(UploadMixin, TestCase):
 
     @mock.patch('olympia.devhub.tasks.run_addons_linter')
     def test_restricted_guid_addon_allowed(self, run_addons_linter_mock):
-        user = user_factory()
-        self.grant_permission(user, 'SystemAddon:Submit')
-        self.client.force_login(user)
+        self.grant_permission(self.user, 'SystemAddon:Submit')
         run_addons_linter_mock.return_value = self.validation_ok()
-        self.upload_file('../../../files/fixtures/files/mozilla_guid.xpi')
+        self.upload_file(self.file_fixture_path('mozilla_guid.xpi'))
         upload = FileUpload.objects.get()
         response = self.client.get(
             reverse('devhub.upload_detail', args=[upload.uuid.hex, 'json'])
@@ -1505,10 +1594,8 @@ class TestUploadDetail(UploadMixin, TestCase):
 
     @mock.patch('olympia.devhub.tasks.run_addons_linter')
     def test_restricted_guid_addon_not_allowed(self, run_addons_linter_mock):
-        user = user_factory()
-        self.client.force_login(user)
         run_addons_linter_mock.return_value = self.validation_ok()
-        self.upload_file('../../../files/fixtures/files/mozilla_guid.xpi')
+        self.upload_file(self.file_fixture_path('mozilla_guid.xpi'))
         upload = FileUpload.objects.get()
         response = self.client.get(
             reverse('devhub.upload_detail', args=[upload.uuid.hex, 'json'])
@@ -1528,14 +1615,10 @@ class TestUploadDetail(UploadMixin, TestCase):
     @mock.patch('olympia.devhub.tasks.run_addons_linter')
     @mock.patch('olympia.files.utils.get_signer_organizational_unit_name')
     def test_mozilla_signed_allowed(self, get_signer_mock, run_addons_linter_mock):
-        user = user_factory()
-        self.client.force_login(user)
-        self.grant_permission(user, 'SystemAddon:Submit')
+        self.grant_permission(self.user, 'SystemAddon:Submit')
         run_addons_linter_mock.return_value = self.validation_ok()
         get_signer_mock.return_value = 'Mozilla Extensions'
-        self.upload_file(
-            '../../../files/fixtures/files/webextension_signed_already.xpi'
-        )
+        self.upload_file(self.file_fixture_path('webextension_signed_already.xpi'))
         upload = FileUpload.objects.get()
         response = self.client.get(
             reverse('devhub.upload_detail', args=[upload.uuid.hex, 'json'])
@@ -1545,12 +1628,8 @@ class TestUploadDetail(UploadMixin, TestCase):
 
     @mock.patch('olympia.files.utils.get_signer_organizational_unit_name')
     def test_mozilla_signed_not_allowed_not_allowed(self, get_signer_mock):
-        user_factory(email='redpanda@mozilla.com')
-        self.client.force_login(UserProfile.objects.get(email='redpanda@mozilla.com'))
         get_signer_mock.return_value = 'Mozilla Extensions'
-        self.upload_file(
-            '../../../files/fixtures/files/webextension_signed_already.xpi'
-        )
+        self.upload_file(self.file_fixture_path('webextension_signed_already.xpi'))
         upload = FileUpload.objects.get()
         response = self.client.get(
             reverse('devhub.upload_detail', args=[upload.uuid.hex, 'json'])
@@ -1570,12 +1649,10 @@ class TestUploadDetail(UploadMixin, TestCase):
     @mock.patch('olympia.devhub.tasks.run_addons_linter')
     def test_system_addon_update_allowed(self, run_addons_linter_mock):
         """Updates to system addons are allowed from anyone."""
-        user = user_factory(email='pinkpanda@notzilla.com')
         addon = addon_factory(guid='systemaddon@mozilla.org')
-        AddonUser.objects.create(addon=addon, user=user)
-        self.client.force_login(UserProfile.objects.get(email='pinkpanda@notzilla.com'))
+        AddonUser.objects.create(addon=addon, user=self.user)
         run_addons_linter_mock.return_value = self.validation_ok()
-        self.upload_file('../../../files/fixtures/files/mozilla_guid.xpi')
+        self.upload_file(self.file_fixture_path('mozilla_guid.xpi'))
         upload = FileUpload.objects.get()
         response = self.client.get(
             reverse(
@@ -1586,11 +1663,10 @@ class TestUploadDetail(UploadMixin, TestCase):
         assert data['validation']['messages'] == []
 
     def test_no_redirect_for_metadata(self):
-        user = UserProfile.objects.get(email='regular@mozilla.com')
         addon = addon_factory(status=amo.STATUS_NULL)
         AddonCategory.objects.filter(addon=addon).delete()
-        addon.addonuser_set.create(user=user)
-        self.post()
+        addon.addonuser_set.create(user=self.user)
+        self.upload_dummy_file()
 
         upload = FileUpload.objects.get()
         response = self.client.get(

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -386,6 +386,7 @@ class TestAddonSubmitAgreement(TestSubmitBase):
             state=self.client.session['fxa_state'],
             next_path=self.url,
             enforce_2fa=True,
+            login_hint=self.user.email,
         )
         self.assert3xx(response, expected_location)
 
@@ -494,6 +495,7 @@ class TestAddonSubmitDistribution(TestCase):
             state=self.client.session['fxa_state'],
             next_path=self.url,
             enforce_2fa=True,
+            login_hint=self.user.email,
         )
         self.assert3xx(response, expected_location)
 
@@ -838,6 +840,7 @@ class TestAddonSubmitUpload(UploadMixin, TestCase):
             state=self.client.session['fxa_state'],
             next_path=self.url,
             enforce_2fa=True,
+            login_hint=self.user.email,
         )
         self.assert3xx(response, expected_location)
 
@@ -848,6 +851,7 @@ class TestAddonSubmitUpload(UploadMixin, TestCase):
             state=self.client.session['fxa_state'],
             next_path=self.url,
             enforce_2fa=True,
+            login_hint=self.user.email,
         )
         self.assert3xx(response, expected_location)
 
@@ -1983,6 +1987,7 @@ class TestVersionSubmitDistribution(TestSubmitBase):
             state=self.client.session['fxa_state'],
             next_path=self.url,
             enforce_2fa=True,
+            login_hint=self.user.email,
         )
         self.assert3xx(response, expected_location)
 
@@ -2350,6 +2355,7 @@ class VersionSubmitUploadMixin:
             state=self.client.session['fxa_state'],
             next_path=self.url,
             enforce_2fa=True,
+            login_hint=self.user.email,
         )
         self.assert3xx(response, expected_location)
 

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -20,6 +20,7 @@ from pyquery import PyQuery as pq
 from waffle.testutils import override_switch
 
 from olympia import amo
+from olympia.accounts.utils import fxa_login_url
 from olympia.activity.models import ActivityLog
 from olympia.addons.models import Addon, AddonCategory, AddonReviewerFlags
 from olympia.amo.tests import (
@@ -62,8 +63,8 @@ class TestSubmitBase(TestCase):
     def setUp(self):
         super().setUp()
         self.user = UserProfile.objects.get(email='del@icio.us')
-        self.client.force_login(self.user)
-        self.user.update(last_login_ip='192.168.1.1')
+        self.client.force_login_with_2fa(self.user)
+        self.user.update(last_login_ip='192.0.2.1')
         self.addon = self.get_addon()
 
     def get_addon(self):
@@ -104,29 +105,38 @@ class TestSubmitBase(TestCase):
 
 
 class TestAddonSubmitAgreement(TestSubmitBase):
+    def setUp(self):
+        self.url = reverse('devhub.submit.agreement')
+        self.next_url = reverse('devhub.submit.distribution')
+        super().setUp()
+
     def test_set_read_dev_agreement(self):
         response = self.client.post(
-            reverse('devhub.submit.agreement'),
+            self.url,
             {
                 'distribution_agreement': 'on',
                 'review_policy': 'on',
             },
         )
-        assert response.status_code == 302
-        self.assert3xx(response, reverse('devhub.submit.distribution'))
+        self.assert3xx(response, self.next_url)
         self.user.reload()
         self.assertCloseToNow(self.user.read_dev_agreement)
 
     def test_set_read_dev_agreement_theme(self):
+        self.client.logout()  # Shouldn't need 2FA.
+        self.client.force_login(self.user)
+        # Make sure we still have a last login ip though.
+        self.user.update(last_login_ip='192.0.2.1')
+        self.url = reverse('devhub.submit.theme.agreement')
+        self.next_url = reverse('devhub.submit.theme.distribution')
         response = self.client.post(
-            reverse('devhub.submit.theme.agreement'),
+            self.url,
             {
                 'distribution_agreement': 'on',
                 'review_policy': 'on',
             },
         )
-        assert response.status_code == 302
-        self.assert3xx(response, reverse('devhub.submit.theme.distribution'))
+        self.assert3xx(response, self.next_url)
         self.user.reload()
         self.assertCloseToNow(self.user.read_dev_agreement)
 
@@ -134,7 +144,7 @@ class TestAddonSubmitAgreement(TestSubmitBase):
         set_config('last_dev_agreement_change_date', '2019-06-10 00:00')
         before_agreement_last_changed = datetime(2019, 6, 10) - timedelta(days=1)
         self.user.update(read_dev_agreement=before_agreement_last_changed)
-        response = self.client.post(reverse('devhub.submit.agreement'))
+        response = self.client.post(self.url)
         assert response.status_code == 200
         assert 'agreement_form' in response.context
         form = response.context['agreement_form']
@@ -152,21 +162,21 @@ class TestAddonSubmitAgreement(TestSubmitBase):
         set_config('last_dev_agreement_change_date', '2019-06-10 00:00')
         after_agreement_last_changed = datetime(2019, 6, 10) + timedelta(days=1)
         self.user.update(read_dev_agreement=after_agreement_last_changed)
-        response = self.client.get(reverse('devhub.submit.agreement'))
-        self.assert3xx(response, reverse('devhub.submit.distribution'))
+        response = self.client.get(self.url)
+        self.assert3xx(response, self.next_url)
 
     @override_settings(DEV_AGREEMENT_CHANGE_FALLBACK=datetime(2019, 6, 10, 12, 00))
     def test_read_dev_agreement_fallback_with_config_set_to_future(self):
         set_config('last_dev_agreement_change_date', '2099-12-31 00:00')
         read_dev_date = datetime(2019, 6, 11)
         self.user.update(read_dev_agreement=read_dev_date)
-        response = self.client.get(reverse('devhub.submit.agreement'))
-        self.assert3xx(response, reverse('devhub.submit.distribution'))
+        response = self.client.get(self.url)
+        self.assert3xx(response, self.next_url)
 
     def test_read_dev_agreement_fallback_with_conf_future_and_not_agreed(self):
         set_config('last_dev_agreement_change_date', '2099-12-31 00:00')
         self.user.update(read_dev_agreement=None)
-        response = self.client.get(reverse('devhub.submit.agreement'))
+        response = self.client.get(self.url)
         assert response.status_code == 200
         assert 'agreement_form' in response.context
 
@@ -175,30 +185,30 @@ class TestAddonSubmitAgreement(TestSubmitBase):
         set_config('last_dev_agreement_change_date', '2099-25-75 00:00')
         read_dev_date = datetime(2019, 6, 11)
         self.user.update(read_dev_agreement=read_dev_date)
-        response = self.client.get(reverse('devhub.submit.agreement'))
-        self.assert3xx(response, reverse('devhub.submit.distribution'))
+        response = self.client.get(self.url)
+        self.assert3xx(response, self.next_url)
 
     def test_read_dev_agreement_invalid_date_not_agreed_post_fallback(self):
         set_config('last_dev_agreement_change_date', '2099,31,12,0,0')
         self.user.update(read_dev_agreement=None)
-        response = self.client.get(reverse('devhub.submit.agreement'))
+        response = self.client.get(self.url)
         self.assertRaises(ValueError)
         assert response.status_code == 200
         assert 'agreement_form' in response.context
 
     def test_read_dev_agreement_no_date_configured_agreed_post_fallback(self):
-        response = self.client.get(reverse('devhub.submit.agreement'))
-        self.assert3xx(response, reverse('devhub.submit.distribution'))
+        response = self.client.get(self.url)
+        self.assert3xx(response, self.next_url)
 
     def test_read_dev_agreement_no_date_configured_not_agreed_post_fallb(self):
         self.user.update(read_dev_agreement=None)
-        response = self.client.get(reverse('devhub.submit.agreement'))
+        response = self.client.get(self.url)
         assert response.status_code == 200
         assert 'agreement_form' in response.context
 
     def test_read_dev_agreement_captcha_inactive(self):
         self.user.update(read_dev_agreement=None)
-        response = self.client.get(reverse('devhub.submit.agreement'))
+        response = self.client.get(self.url)
         assert response.status_code == 200
         form = response.context['agreement_form']
         assert 'recaptcha' not in form.fields
@@ -209,12 +219,12 @@ class TestAddonSubmitAgreement(TestSubmitBase):
     @override_switch('developer-agreement-captcha', active=True)
     def test_read_dev_agreement_captcha_active_error(self):
         self.user.update(read_dev_agreement=None)
-        response = self.client.get(reverse('devhub.submit.agreement'))
+        response = self.client.get(self.url)
         assert response.status_code == 200
         form = response.context['agreement_form']
         assert 'recaptcha' in form.fields
 
-        response = self.client.post(reverse('devhub.submit.agreement'))
+        response = self.client.post(self.url)
 
         # Captcha is properly rendered
         doc = pq(response.content)
@@ -225,7 +235,7 @@ class TestAddonSubmitAgreement(TestSubmitBase):
     @override_switch('developer-agreement-captcha', active=True)
     def test_read_dev_agreement_captcha_active_success(self):
         self.user.update(read_dev_agreement=None)
-        response = self.client.get(reverse('devhub.submit.agreement'))
+        response = self.client.get(self.url)
         assert response.status_code == 200
         form = response.context['agreement_form']
         assert 'recaptcha' in form.fields
@@ -248,22 +258,20 @@ class TestAddonSubmitAgreement(TestSubmitBase):
         )
 
         response = self.client.post(
-            reverse('devhub.submit.agreement'),
+            self.url,
             data={
                 'g-recaptcha-response': 'test',
                 'distribution_agreement': 'on',
                 'review_policy': 'on',
             },
         )
-
-        assert response.status_code == 302
-        assert response['Location'] == reverse('devhub.submit.distribution')
+        self.assert3xx(response, self.next_url)
 
     def test_cant_submit_agreement_if_restricted_functional(self):
         IPNetworkUserRestriction.objects.create(network='127.0.0.1/32')
         self.user.update(read_dev_agreement=None)
         response = self.client.post(
-            reverse('devhub.submit.agreement'),
+            self.url,
             data={
                 'distribution_agreement': 'on',
                 'review_policy': 'on',
@@ -284,23 +292,23 @@ class TestAddonSubmitAgreement(TestSubmitBase):
 
     def test_display_name_already_set_not_asked_again(self):
         self.user.update(read_dev_agreement=None, display_name='Foo')
-        response = self.client.get(reverse('devhub.submit.agreement'))
+        response = self.client.get(self.url)
         assert response.status_code == 200
         form = response.context['agreement_form']
         assert 'display_name' not in form.fields
         response = self.client.post(
-            reverse('devhub.submit.agreement'),
+            self.url,
             data={
                 'distribution_agreement': 'on',
                 'review_policy': 'on',
             },
         )
-        assert response.status_code == 302
+        self.assert3xx(response, self.next_url)
         assert self.user.reload().read_dev_agreement
 
     def test_display_name_required(self):
         self.user.update(read_dev_agreement=None, display_name='')
-        response = self.client.get(reverse('devhub.submit.agreement'))
+        response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
         form = response.context['agreement_form']
@@ -310,7 +318,7 @@ class TestAddonSubmitAgreement(TestSubmitBase):
             in doc('.addon-submission-process').text()
         )
         response = self.client.post(
-            reverse('devhub.submit.agreement'),
+            self.url,
             data={
                 'distribution_agreement': 'on',
                 'review_policy': 'on',
@@ -328,7 +336,7 @@ class TestAddonSubmitAgreement(TestSubmitBase):
     def test_display_name_submission(self):
         self.user.update(read_dev_agreement=None, display_name='')
         response = self.client.post(
-            reverse('devhub.submit.agreement'),
+            self.url,
             data={
                 'distribution_agreement': 'on',
                 'review_policy': 'on',
@@ -342,7 +350,7 @@ class TestAddonSubmitAgreement(TestSubmitBase):
         }
 
         response = self.client.post(
-            reverse('devhub.submit.agreement'),
+            self.url,
             data={
                 'distribution_agreement': 'on',
                 'review_policy': 'on',
@@ -356,17 +364,30 @@ class TestAddonSubmitAgreement(TestSubmitBase):
         }
 
         response = self.client.post(
-            reverse('devhub.submit.agreement'),
+            self.url,
             data={
                 'distribution_agreement': 'on',
                 'review_policy': 'on',
                 'display_name': 'Fôä',
             },
         )
-        assert response.status_code == 302
+        self.assert3xx(response, self.next_url)
         self.user.reload()
         self.assertCloseToNow(self.user.read_dev_agreement)
         assert self.user.display_name == 'Fôä'
+
+    def test_enforce_2fa(self):
+        self.user.update(read_dev_agreement=None)
+        self.client.logout()
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        expected_location = fxa_login_url(
+            config=settings.FXA_CONFIG['default'],
+            state=self.client.session['fxa_state'],
+            next_path=self.url,
+            enforce_2fa=True,
+        )
+        self.assert3xx(response, expected_location)
 
 
 class TestAddonSubmitDistribution(TestCase):
@@ -374,14 +395,17 @@ class TestAddonSubmitDistribution(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.client.force_login(UserProfile.objects.get(email='regular@mozilla.com'))
+        self.client.force_login_with_2fa(
+            UserProfile.objects.get(email='regular@mozilla.com')
+        )
         self.user = UserProfile.objects.get(email='regular@mozilla.com')
-        self.user.update(last_login_ip='192.168.1.1')
+        self.user.update(last_login_ip='192.0.2.1')
+        self.url = reverse('devhub.submit.distribution')
 
     def test_check_agreement_okay(self):
         response = self.client.post(reverse('devhub.submit.agreement'))
-        self.assert3xx(response, reverse('devhub.submit.distribution'))
-        response = self.client.get(reverse('devhub.submit.distribution'))
+        self.assert3xx(response, self.url)
+        response = self.client.get(self.url)
         assert response.status_code == 200
         # No error shown for a redirect from previous step.
         assert b'This field is required' not in response.content
@@ -391,7 +415,7 @@ class TestAddonSubmitDistribution(TestCase):
             key='submit_notification_warning',
             value='Text with <a href="http://example.com">a link</a>.',
         )
-        response = self.client.get(reverse('devhub.submit.distribution'))
+        response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
         assert doc('.notification-box.warning').html().strip() == config.value
@@ -399,7 +423,7 @@ class TestAddonSubmitDistribution(TestCase):
     def test_redirect_back_to_agreement(self):
         self.user.update(read_dev_agreement=None)
 
-        response = self.client.get(reverse('devhub.submit.distribution'), follow=True)
+        response = self.client.get(self.url, follow=True)
         self.assert3xx(response, reverse('devhub.submit.agreement'))
 
         # read_dev_agreement needs to be a more recent date than
@@ -407,7 +431,7 @@ class TestAddonSubmitDistribution(TestCase):
         set_config('last_dev_agreement_change_date', '2019-06-10 00:00')
         before_agreement_last_changed = datetime(2019, 6, 10) - timedelta(days=1)
         self.user.update(read_dev_agreement=before_agreement_last_changed)
-        response = self.client.get(reverse('devhub.submit.distribution'), follow=True)
+        response = self.client.get(self.url, follow=True)
         self.assert3xx(response, reverse('devhub.submit.agreement'))
 
     def test_redirect_back_to_agreement_theme(self):
@@ -430,19 +454,15 @@ class TestAddonSubmitDistribution(TestCase):
 
     def test_redirect_back_to_agreement_if_restricted(self):
         IPNetworkUserRestriction.objects.create(network='127.0.0.1/32')
-        response = self.client.get(reverse('devhub.submit.distribution'), follow=True)
+        response = self.client.get(self.url, follow=True)
         self.assert3xx(response, reverse('devhub.submit.agreement'))
 
     def test_listed_redirects_to_next_step(self):
-        response = self.client.post(
-            reverse('devhub.submit.distribution'), {'channel': 'listed'}
-        )
+        response = self.client.post(self.url, {'channel': 'listed'})
         self.assert3xx(response, reverse('devhub.submit.upload', args=['listed']))
 
     def test_unlisted_redirects_to_next_step(self):
-        response = self.client.post(
-            reverse('devhub.submit.distribution'), {'channel': 'unlisted'}
-        )
+        response = self.client.post(self.url, {'channel': 'unlisted'})
         self.assert3xx(response, reverse('devhub.submit.upload', args=['unlisted']))
 
     def test_listed_redirects_to_next_step_theme(self):
@@ -452,7 +472,7 @@ class TestAddonSubmitDistribution(TestCase):
         self.assert3xx(response, reverse('devhub.submit.theme.upload', args=['listed']))
 
     def test_channel_selection_error_shown(self):
-        url = reverse('devhub.submit.distribution')
+        url = self.url
         # First load should have no error
         assert b'This field is required' not in self.client.get(url).content
 
@@ -465,6 +485,18 @@ class TestAddonSubmitDistribution(TestCase):
         # A post submission without channel selection should be an error
         assert b'This field is required' in self.client.post(url).content
 
+    def test_enforce_2fa(self):
+        self.client.logout()
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        expected_location = fxa_login_url(
+            config=settings.FXA_CONFIG['default'],
+            state=self.client.session['fxa_state'],
+            next_path=self.url,
+            enforce_2fa=True,
+        )
+        self.assert3xx(response, expected_location)
+
 
 @override_settings(REPUTATION_SERVICE_URL=None)
 class TestAddonSubmitUpload(UploadMixin, TestCase):
@@ -476,9 +508,11 @@ class TestAddonSubmitUpload(UploadMixin, TestCase):
 
     def setUp(self):
         super().setUp()
-        self.client.force_login(UserProfile.objects.get(email='regular@mozilla.com'))
+        self.client.force_login_with_2fa(
+            UserProfile.objects.get(email='regular@mozilla.com')
+        )
         self.user = UserProfile.objects.get(email='regular@mozilla.com')
-        self.user.update(last_login_ip='192.168.1.1')
+        self.user.update(last_login_ip='192.0.2.1')
         self.upload = self.get_upload('webextension_no_id.xpi', user=self.user)
         self.statsd_incr_mock = self.patch('olympia.devhub.views.statsd.incr')
 
@@ -657,6 +691,10 @@ class TestAddonSubmitUpload(UploadMixin, TestCase):
         )
 
     def test_theme_variant_has_theme_stuff_visible(self):
+        self.client.logout()  # Shouldn't need 2FA.
+        self.client.force_login(self.user)
+        # Make sure we still have a last login ip though.
+        self.user.update(last_login_ip='192.0.2.1')
         response = self.client.get(
             reverse('devhub.submit.theme.upload', args=['listed']), follow=True
         )
@@ -789,6 +827,29 @@ class TestAddonSubmitUpload(UploadMixin, TestCase):
         assert addon.type == amo.ADDON_STATICTHEME
         # Only listed submissions need a preview generated.
         assert latest_version.previews.all().count() == 0
+
+    def test_enforce_2fa(self):
+        self.client.logout()
+        self.client.force_login(self.user)
+        self.url = reverse('devhub.submit.upload', args=['listed'])
+        response = self.client.get(self.url)
+        expected_location = fxa_login_url(
+            config=settings.FXA_CONFIG['default'],
+            state=self.client.session['fxa_state'],
+            next_path=self.url,
+            enforce_2fa=True,
+        )
+        self.assert3xx(response, expected_location)
+
+        self.url = reverse('devhub.submit.upload', args=['unlisted'])
+        response = self.client.get(self.url)
+        expected_location = fxa_login_url(
+            config=settings.FXA_CONFIG['default'],
+            state=self.client.session['fxa_state'],
+            next_path=self.url,
+            enforce_2fa=True,
+        )
+        self.assert3xx(response, expected_location)
 
 
 class TestAddonSubmitSource(TestSubmitBase):
@@ -1579,6 +1640,9 @@ class TestAddonSubmitDetails(DetailsPageMixin, TestSubmitBase):
 class TestStaticThemeSubmitDetails(DetailsPageMixin, TestSubmitBase):
     def setUp(self):
         super().setUp()
+        self.client.logout()
+        self.client.force_login(self.user)
+        self.user.update(last_login_ip='192.0.2.0.1')
         self.url = reverse('devhub.submit.details', args=['a3615'])
 
         addon = self.get_addon()
@@ -1910,6 +1974,18 @@ class TestVersionSubmitDistribution(TestSubmitBase):
             response, reverse('devhub.submit.version.agreement', args=[self.addon.slug])
         )
 
+    def test_enforce_2fa(self):
+        self.client.logout()
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        expected_location = fxa_login_url(
+            config=settings.FXA_CONFIG['default'],
+            state=self.client.session['fxa_state'],
+            next_path=self.url,
+            enforce_2fa=True,
+        )
+        self.assert3xx(response, expected_location)
+
 
 class TestVersionSubmitAutoChannel(TestSubmitBase):
     """Just check we chose the right upload channel.  The upload tests
@@ -1973,8 +2049,8 @@ class VersionSubmitUploadMixin:
         self.version = self.addon.current_version
         self.addon.update(guid='@webextension-guid')
         self.user = UserProfile.objects.get(email='del@icio.us')
-        self.client.force_login(self.user)
-        self.user.update(last_login_ip='192.168.1.1')
+        self.client.force_login_with_2fa(self.user)
+        self.user.update(last_login_ip='192.0.2.1')
         self.addon.versions.update(channel=self.channel, version='0.0.0.99')
         channel = 'listed' if self.channel == amo.CHANNEL_LISTED else 'unlisted'
         self.url = reverse(
@@ -2264,6 +2340,18 @@ class VersionSubmitUploadMixin:
         doc = pq(response.content)
         assert doc('.notification-box.warning')
         assert doc('.notification-box.warning').html().strip() == config.value
+
+    def test_enforce_2fa(self):
+        self.client.logout()
+        self.client.force_login(self.user)
+        response = self.client.get(self.url)
+        expected_location = fxa_login_url(
+            config=settings.FXA_CONFIG['default'],
+            state=self.client.session['fxa_state'],
+            next_path=self.url,
+            enforce_2fa=True,
+        )
+        self.assert3xx(response, expected_location)
 
 
 class TestVersionSubmitUploadListed(VersionSubmitUploadMixin, UploadMixin, TestCase):

--- a/src/olympia/devhub/tests/test_views_validation.py
+++ b/src/olympia/devhub/tests/test_views_validation.py
@@ -26,7 +26,7 @@ class TestUploadValidation(ValidatorTestCase, UploadMixin, TestCase):
     def setUp(self):
         super().setUp()
         self.user = UserProfile.objects.get(email='regular@mozilla.com')
-        self.client.force_login(self.user)
+        self.client.force_login_with_2fa(self.user)
         self.validation = {
             'errors': 1,
             'detected_type': 'extension',
@@ -400,7 +400,9 @@ class TestValidateAddon(TestCase):
 
     def setUp(self):
         super().setUp()
-        self.client.force_login(UserProfile.objects.get(email='regular@mozilla.com'))
+        self.client.force_login_with_2fa(
+            UserProfile.objects.get(email='regular@mozilla.com')
+        )
 
     def test_login_required(self):
         self.client.logout()
@@ -484,7 +486,9 @@ class TestUploadURLs(TestCase):
     def setUp(self):
         super().setUp()
         user = UserProfile.objects.get(email='regular@mozilla.com')
-        self.client.force_login(UserProfile.objects.get(email='regular@mozilla.com'))
+        self.client.force_login_with_2fa(
+            UserProfile.objects.get(email='regular@mozilla.com')
+        )
 
         self.addon = Addon.objects.create(
             guid='thing@stuff', slug='thing-stuff', status=amo.STATUS_APPROVED

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -27,7 +27,11 @@ from django_statsd.clients import statsd
 import olympia.core.logger
 from olympia import amo
 from olympia.access import acl
-from olympia.accounts.utils import redirect_for_login
+from olympia.accounts.decorators import two_factor_auth_required
+from olympia.accounts.utils import (
+    redirect_for_login,
+    redirect_for_login_with_2fa_enforced,
+)
 from olympia.accounts.views import logout_user
 from olympia.activity.models import ActivityLog, CommentLog
 from olympia.addons.models import (
@@ -584,11 +588,40 @@ def handle_upload(
 @login_required
 @post_required
 def upload(request, channel='listed', addon=None, is_standalone=False):
+    channel_as_text = channel
     channel = amo.CHANNEL_CHOICES_LOOKUP[channel]
     filedata = request.FILES['upload']
     theme_specific = django_forms.BooleanField().to_python(
         request.POST.get('theme_specific')
     )
+    if (
+        not theme_specific
+        and not is_standalone
+        and not request.session.get('has_two_factor_authentication')
+    ):
+        # This shouldn't happen: it means the user attempted to use the add-on
+        # submission flow that is behind @two_factor_auth_required decorator
+        # but didn't log in with 2FA. Because this view is used to serve an XHR
+        # we return a fake validation error suggesting to enable 2FA instead of
+        # redirecting.
+        next_path = (
+            reverse('devhub.submit.version.upload', args=[addon.slug, channel_as_text])
+            if addon
+            else reverse('devhub.submit.upload', args=[channel_as_text])
+        )
+        url = redirect_for_login_with_2fa_enforced(request, next_path=next_path)[
+            'location'
+        ]
+        results = deepcopy(amo.VALIDATOR_SKELETON_RESULTS)
+        insert_validation_message(
+            results,
+            message=_(
+                '<a href="{link}">Please add two-factor authentication to your account '
+                'to submit extensions.</a>'
+            ).format(link=absolutify(url)),
+        )
+        return JsonResponse({'validation': results}, status=400)
+
     try:
         upload = handle_upload(
             filedata=filedata,
@@ -1244,6 +1277,7 @@ def version_stats(request, addon_id, addon):
     return data
 
 
+@two_factor_auth_required
 @login_required
 def submit_addon(request):
     return render_agreement(
@@ -1262,6 +1296,7 @@ def submit_theme(request):
     )
 
 
+@two_factor_auth_required
 @dev_required
 def submit_version_agreement(request, addon_id, addon):
     return render_agreement(
@@ -1301,6 +1336,7 @@ def _submit_distribution(request, addon, next_view):
     )
 
 
+@two_factor_auth_required
 @login_required
 def submit_addon_distribution(request):
     if not RestrictionChecker(request=request).is_submission_allowed():
@@ -1315,6 +1351,7 @@ def submit_theme_distribution(request):
     return _submit_distribution(request, None, 'devhub.submit.theme.upload')
 
 
+@two_factor_auth_required
 @dev_required(submitting=True)
 def submit_version_distribution(request, addon_id, addon):
     if not RestrictionChecker(request=request).is_submission_allowed():
@@ -1504,6 +1541,7 @@ def _submit_upload(
     )
 
 
+@two_factor_auth_required
 @login_required
 def submit_addon_upload(request, channel):
     if not RestrictionChecker(request=request).is_submission_allowed():
@@ -1522,6 +1560,7 @@ def submit_theme_upload(request, channel):
     )
 
 
+@two_factor_auth_required
 @dev_required(submitting=True)
 @no_admin_disabled
 def submit_version_upload(request, addon_id, addon, channel):
@@ -1531,6 +1570,7 @@ def submit_version_upload(request, addon_id, addon, channel):
     return _submit_upload(request, addon, channel_id, 'devhub.submit.version.source')
 
 
+@two_factor_auth_required
 @dev_required(submitting=True)
 @no_admin_disabled
 def submit_version_auto(request, addon_id, addon):
@@ -1892,6 +1932,7 @@ def render_agreement(request, template, next_step, **extra_context):
         return response
 
 
+@two_factor_auth_required
 @login_required
 @transaction.atomic
 def api_key(request):


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/20943

Note: when trying this, make sure `2fa-enforcement-for-developers-and-special-users` flag is active (and note that it's a flag, not a switch - to activate it, enable it for `everyone`). This should work both with fake and actual FxA implementations.