### PR TITLE
stop activity emails to reviewers

### DIFF
--- a/src/olympia/activity/tests/test_utils.py
+++ b/src/olympia/activity/tests/test_utils.py
@@ -13,7 +13,7 @@ import pytest
 from waffle.testutils import override_switch
 
 from olympia import amo
-from olympia.access.models import Group, GroupUser
+from olympia.access.models import Group
 from olympia.activity.models import MAX_TOKEN_USE_COUNT, ActivityLog, ActivityLogToken
 from olympia.activity.utils import (
     ACTIVITY_MAIL_GROUP,
@@ -351,13 +351,12 @@ class TestLogAndNotify(TestCase):
         assert len(logs) == 2  # We added one above.
         assert logs[0].details['comments'] == 'Thïs is á reply'
 
-        assert send_mail_mock.call_count == 2  # One author, one reviewer.
+        assert send_mail_mock.call_count == 1  # One author.
         sender = formataddr((self.developer.name, NOTIFICATIONS_FROM_EMAIL))
         assert sender == send_mail_mock.call_args_list[0][1]['from_email']
         recipients = self._recipients(send_mail_mock)
-        assert len(recipients) == 2
-        assert self.reviewer.email in recipients
-        assert self.developer2.email in recipients
+        assert len(recipients) == 1
+        assert [self.developer2.email] == recipients
         # The developer who sent it doesn't get their email back.
         assert self.developer.email not in recipients
 
@@ -365,21 +364,6 @@ class TestLogAndNotify(TestCase):
             send_mail_mock.call_args_list[0],
             absolutify(self.addon.get_dev_url('versions')),
             'you are listed as an author of this add-on.',
-            author=self.developer,
-            is_from_developer=True,
-            is_to_developer=True,
-        )
-        review_url = absolutify(
-            reverse(
-                'reviewers.review',
-                kwargs={'addon_id': self.version.addon.pk, 'channel': 'listed'},
-                add_prefix=False,
-            )
-        )
-        self._check_email(
-            send_mail_mock.call_args_list[1],
-            review_url,
-            'you reviewed this add-on.',
             author=self.developer,
             is_from_developer=True,
             is_to_developer=True,
@@ -406,8 +390,6 @@ class TestLogAndNotify(TestCase):
         assert len(recipients) == 2
         assert self.developer.email in recipients
         assert self.developer2.email in recipients
-        # The reviewer who sent it doesn't get their email back.
-        assert self.reviewer.email not in recipients
 
         self._check_email(
             send_mail_mock.call_args_list[0],
@@ -442,16 +424,14 @@ class TestLogAndNotify(TestCase):
         assert len(logs) == 1
         assert not logs[0].details  # No details json because no comment.
 
-        assert send_mail_mock.call_count == 2  # One author, one reviewer.
+        assert send_mail_mock.call_count == 1  # One author.
         sender = formataddr((self.developer.name, NOTIFICATIONS_FROM_EMAIL))
         assert sender == send_mail_mock.call_args_list[0][1]['from_email']
         recipients = self._recipients(send_mail_mock)
-        assert len(recipients) == 2
-        assert self.reviewer.email in recipients
-        assert self.developer2.email in recipients
+        assert len(recipients) == 1
+        assert [self.developer2.email] == recipients
 
         assert 'Approval notes changed' in (send_mail_mock.call_args_list[0][0][1])
-        assert 'Approval notes changed' in (send_mail_mock.call_args_list[1][0][1])
 
     def test_staff_cc_group_is_empty_no_failure(self):
         Group.objects.create(name=ACTIVITY_MAIL_GROUP, rules='None:None')
@@ -471,7 +451,7 @@ class TestLogAndNotify(TestCase):
         sender = formataddr((self.developer.name, NOTIFICATIONS_FROM_EMAIL))
         assert sender == send_mail_mock.call_args_list[0][1]['from_email']
         assert len(recipients) == 2
-        # self.reviewers wasn't on the thread, but gets an email anyway.
+        # self.reviewer wasn't on the thread, but gets an email anyway.
         assert self.reviewer.email in recipients
         assert self.developer2.email in recipients
         review_url = absolutify(
@@ -507,27 +487,6 @@ class TestLogAndNotify(TestCase):
         assert self.task_user.email not in recipients
 
     @mock.patch('olympia.activity.utils.send_mail')
-    def test_ex_reviewer_doesnt_get_mail(self, send_mail_mock):
-        """If a reviewer has now left the team don't email them."""
-        self._create(amo.LOG.REJECT_VERSION, self.reviewer)
-        # Take his joob!
-        GroupUser.objects.get(
-            group=Group.objects.get(name='Addon Reviewers'), user=self.reviewer
-        ).delete()
-
-        action = amo.LOG.DEVELOPER_REPLY_VERSION
-        comments = 'Thïs is á reply'
-        log_and_notify(action, comments, self.developer, self.version)
-
-        logs = ActivityLog.objects.filter(action=action.id)
-        assert len(logs) == 1
-
-        recipients = self._recipients(send_mail_mock)
-        assert len(recipients) == 1
-        assert self.developer2.email in recipients
-        assert self.reviewer.email not in recipients
-
-    @mock.patch('olympia.activity.utils.send_mail')
     def test_review_url_listed(self, send_mail_mock):
         # One from the reviewer.
         self._create(amo.LOG.REJECT_VERSION, self.reviewer)
@@ -541,11 +500,10 @@ class TestLogAndNotify(TestCase):
         assert len(logs) == 2  # We added one above.
         assert logs[0].details['comments'] == 'Thïs is á reply'
 
-        assert send_mail_mock.call_count == 2  # One author, one reviewer.
+        assert send_mail_mock.call_count == 1  # One author
         recipients = self._recipients(send_mail_mock)
-        assert len(recipients) == 2
-        assert self.reviewer.email in recipients
-        assert self.developer2.email in recipients
+        assert len(recipients) == 1
+        assert [self.developer2.email] == recipients
         # The developer who sent it doesn't get their email back.
         assert self.developer.email not in recipients
 
@@ -553,19 +511,6 @@ class TestLogAndNotify(TestCase):
             send_mail_mock.call_args_list[0],
             absolutify(self.addon.get_dev_url('versions')),
             'you are listed as an author of this add-on.',
-            author=self.developer,
-        )
-        review_url = absolutify(
-            reverse(
-                'reviewers.review',
-                add_prefix=False,
-                kwargs={'channel': 'listed', 'addon_id': self.addon.pk},
-            )
-        )
-        self._check_email(
-            send_mail_mock.call_args_list[1],
-            review_url,
-            'you reviewed this add-on.',
             author=self.developer,
         )
 
@@ -586,12 +531,11 @@ class TestLogAndNotify(TestCase):
         assert len(logs) == 2  # We added one above.
         assert logs[0].details['comments'] == 'Thïs is á reply'
 
-        assert send_mail_mock.call_count == 2  # One author, one reviewer.
+        assert send_mail_mock.call_count == 1  # One author
         recipients = self._recipients(send_mail_mock)
 
-        assert len(recipients) == 2
-        assert self.reviewer.email in recipients
-        assert self.developer2.email in recipients
+        assert len(recipients) == 1
+        assert [self.developer2.email] == recipients
         # The developer who sent it doesn't get their email back.
         assert self.developer.email not in recipients
 
@@ -599,19 +543,6 @@ class TestLogAndNotify(TestCase):
             send_mail_mock.call_args_list[0],
             absolutify(self.addon.get_dev_url('versions')),
             'you are listed as an author of this add-on.',
-            author=self.developer,
-        )
-        review_url = absolutify(
-            reverse(
-                'reviewers.review',
-                add_prefix=False,
-                kwargs={'channel': 'unlisted', 'addon_id': self.addon.pk},
-            )
-        )
-        self._check_email(
-            send_mail_mock.call_args_list[1],
-            review_url,
-            'you reviewed this add-on.',
             author=self.developer,
         )
 

--- a/src/olympia/activity/utils.py
+++ b/src/olympia/activity/utils.py
@@ -256,7 +256,7 @@ def log_and_notify(
 
 
 def notify_about_activity_log(
-    addon, version, note, perm_setting=None, send_to_reviewers=True, send_to_staff=True
+    addon, version, note, perm_setting=None, send_to_staff=True
 ):
     """Notify relevant users about an ActivityLog note."""
     comments = (note.details or {}).get('comments')
@@ -309,7 +309,7 @@ def notify_about_activity_log(
         perm_setting,
     )
 
-    if send_to_reviewers or send_to_staff:
+    if send_to_staff:
         # If task_user doesn't exist that's no big issue (i.e. in tests)
         try:
             task_user = {get_task_user()}
@@ -318,19 +318,14 @@ def notify_about_activity_log(
         # Update the author and from_email to use the real name because it will
         # be used in emails to reviewers and staff, and not add-on developers.
         from_email = formataddr((note.user.name, NOTIFICATIONS_FROM_EMAIL))
-        reviewer_context_dict = author_context_dict.copy()
-        reviewer_context_dict['author'] = note.user.name
 
-    if send_to_reviewers:
-        # Collect reviewers on the thread (excl. the email sender and task user
-        # for automated messages) and send them their copy.
-        log_users = {
-            alog.user
-            for alog in ActivityLog.objects.for_versions(version)
-            if acl.is_user_any_kind_of_reviewer(alog.user)
-        }
-        reviewers = log_users - addon_authors - task_user - {note.user}
-        reviewer_context_dict['url'] = absolutify(
+        # Collect staff that want a copy of the email, build the context for
+        # them and send them their copy.
+        staff = set(UserProfile.objects.filter(groups__name=ACTIVITY_MAIL_GROUP))
+        staff_cc = staff - addon_authors - task_user - {note.user}
+        staff_cc_context_dict = author_context_dict.copy()
+        staff_cc_context_dict['author'] = note.user.name
+        staff_cc_context_dict['url'] = absolutify(
             reverse(
                 'reviewers.review',
                 kwargs={
@@ -340,23 +335,6 @@ def notify_about_activity_log(
                 add_prefix=False,
             )
         )
-        reviewer_context_dict['email_reason'] = 'you reviewed this add-on'
-        send_activity_mail(
-            reviewer_subject,
-            template.render(reviewer_context_dict),
-            version,
-            reviewers,
-            from_email,
-            note.id,
-            perm_setting,
-        )
-
-    if send_to_staff:
-        # Collect staff that want a copy of the email, build the context for
-        # them and send them their copy.
-        staff = set(UserProfile.objects.filter(groups__name=ACTIVITY_MAIL_GROUP))
-        staff_cc = staff - reviewers - addon_authors - task_user - {note.user}
-        staff_cc_context_dict = reviewer_context_dict.copy()
         staff_cc_context_dict[
             'email_reason'
         ] = 'you are member of the activity email cc group'

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -1032,15 +1032,14 @@ class TestVersionEditDetails(TestVersionEditBase):
         self.test_should_accept_zip_source_file()
 
         # Check that an email has been sent to relevant people.
-        assert len(mail.outbox) == 3
+        assert len(mail.outbox) == 2
         for message in mail.outbox:
             assert message.subject == ('Mozilla Add-ons: Delicious Bookmarks 2.1.072')
             assert 'Source code uploaded' in message.body
 
         # Check each message was sent separately to who we are meant to notify.
-        assert mail.outbox[0].to != mail.outbox[1].to != mail.outbox[2].to
-        assert set(mail.outbox[0].to + mail.outbox[1].to + mail.outbox[2].to) == {
-            reviewer.email,
+        assert mail.outbox[0].to != mail.outbox[1].to
+        assert set(mail.outbox[0].to + mail.outbox[1].to) == {
             extra_author.email,
             staff_user.email,
         }


### PR DESCRIPTION
fixes #21101 (I guess I could have just defaulted the `send_to_reviewers` kwarg to `False`, but leaving around unused code isn't ideal)