### PR TITLE
Don't enforce 2FA in upload callback if the waffle flag is off

### DIFF
--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -1276,6 +1276,17 @@ class TestUpload(UploadMixin, TestCase):
             }
         }
 
+    def test_upload_extension_without_2fa_waffle_is_off(self):
+        self.create_flag(
+            '2fa-enforcement-for-developers-and-special-users', everyone=False
+        )
+        self.url = reverse('devhub.upload')
+        response = self.post()
+        upload = FileUpload.objects.get()
+        assert upload.channel == amo.CHANNEL_LISTED
+        url = reverse('devhub.upload_detail', args=[upload.uuid.hex, 'json'])
+        self.assert3xx(response, url)
+
     def test_upload_theme_without_2fa(self):
         self.xpi_path = os.path.join(
             settings.ROOT, 'src/olympia/devhub/tests/addons/static_theme.zip'

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -598,6 +598,9 @@ def upload(request, channel='listed', addon=None, is_standalone=False):
         not theme_specific
         and not is_standalone
         and not request.session.get('has_two_factor_authentication')
+        and waffle.flag_is_active(
+            request, '2fa-enforcement-for-developers-and-special-users'
+        )
     ):
         # This shouldn't happen: it means the user attempted to use the add-on
         # submission flow that is behind @two_factor_auth_required decorator


### PR DESCRIPTION
Avoids showing the 'Please add two-factor authentication' message if we're not supposed to enforce 2FA for developers.

Fixes #20943