### PR TITLE
still have a link in the queue for addons that have an empty name

### DIFF
--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -1526,6 +1526,25 @@ class TestExtensionQueue(QueueTest):
             '🛠️ Manual Review', tab_position=0, total_addons=4, total_queues=2
         )
 
+    def test_empty_name(self):
+        self.get_expected_addons_by_names(
+            ['Nominated One'],
+            auto_approve_disabled=True,
+        )
+        addon = self.addons['Nominated One']
+        addon.name = '  '
+        addon.save()
+
+        response = self.client.get(self.url)
+
+        url = reverse('reviewers.review', args=[addon.pk])
+        doc = pq(response.content)
+        links = doc('#addon-queue tr.addon-row td a:not(.app-icon)')
+        a_href = links.eq(0)
+
+        assert a_href.text() == f'[{addon.id}] 0.1'
+        assert a_href.attr('href') == url
+
     def test_webextension_with_auto_approval_disabled_false_filtered_out(self):
         self.generate_files(auto_approve_disabled=True)
         self.addons['Pending Two'].reviewerflags.update(auto_approval_disabled=False)

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -41,7 +41,9 @@ def is_admin_reviewer(user):
 
 
 class AddonQueueTable(tables.Table):
-    addon_name = tables.Column(verbose_name='Add-on', accessor='name', orderable=False)
+    addon_name = tables.Column(
+        verbose_name='Add-on', accessor='name', orderable=False, empty_values=()
+    )
     # Override empty_values for flags so that they can be displayed even if the
     # model does not have a flags attribute.
     flags = tables.Column(verbose_name='Flags', empty_values=(), orderable=False)
@@ -106,13 +108,10 @@ class AddonQueueTable(tables.Table):
 
     def render_addon_name(self, record):
         url = self._get_addon_name_url(record)
+        name = markupsafe.escape(str(record.name or '').strip() or f'[{record.id}]')
         return markupsafe.Markup(
             '<a href="%s">%s <em>%s</em></a>'
-            % (
-                url,
-                markupsafe.escape(record.name),
-                markupsafe.escape(self.get_version(record).version),
-            )
+            % (url, name, markupsafe.escape(self.get_version(record).version))
         )
 
     def render_last_human_review(self, value):


### PR DESCRIPTION
This was quite an investigation to find out where the em-dash was coming from, but it seems, basically, that an empty string triggered a default value that _didn't_ call the render function for the add-on name.

fixes #20785 - it display the add-on id instead for the link text when the name is empty
![Screenshot 2023-09-07 18 11 45](https://github.com/mozilla/addons-server/assets/768592/ac84bdfb-5191-4235-ac41-1b82223be7c6)
