### PR TITLE
handle a category ID from ES index not existing in constants

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1361,6 +1361,8 @@ class Addon(OnChangeMixin, ModelBase):
         qs = AddonCategory.objects.filter(addon__in=addon_dict.values()).values_list(
             'addon_id', 'category_id'
         )
+        for addon_id in addon_dict:
+            addon_dict[addon_id].all_categories = []
 
         for addon_id, cats_iter in itertools.groupby(qs, key=lambda x: x[0]):
             # The second value of each tuple in cats_iter are the category ids
@@ -1592,7 +1594,8 @@ class Addon(OnChangeMixin, ModelBase):
 
     @cached_property
     def all_categories(self):
-        return [addoncat.category for addoncat in self.addoncategory_set.all()]
+        self.attach_static_categories([self], {self.id: self})
+        return self.all_categories
 
     def set_categories(self, categories):
         # Add new categories.

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -1410,7 +1410,9 @@ class ESAddonSerializer(BaseESSerializer, AddonSerializer):
         # Attach attributes that do not have the same name/format in ES.
         obj.tag_list = data.get('tags', [])
         obj.all_categories = [
-            CATEGORIES_BY_ID[cat_id] for cat_id in data.get('category', [])
+            CATEGORIES_BY_ID[cat_id]
+            for cat_id in data.get('category', [])
+            if cat_id in CATEGORIES_BY_ID
         ]
 
         # Not entirely accurate, but enough in the context of the search API.

--- a/src/olympia/addons/tests/test_serializers.py
+++ b/src/olympia/addons/tests/test_serializers.py
@@ -1,3 +1,4 @@
+import copy
 from contextlib import ExitStack
 from unittest import mock
 
@@ -1120,6 +1121,22 @@ class TestESAddonSerializerOutput(AddonSerializerOutputTestMixin, ESTestCase):
     def test_static_theme_preview_no_current_version(self):
         # add-ons with no current version aren't in the ES index, so won't be serialized
         pass
+
+    @mock.patch('olympia.addons.models.Addon.attach_static_categories')
+    def test_category_not_in_constants(self, attach_static_categories_mock):
+        def side_effect(addons, addon_dict: None):
+            addons[0].all_categories = [category, old_category]
+
+        category_name = 'music'
+        category = CATEGORIES[amo.FIREFOX.id][amo.ADDON_STATICTHEME][category_name]
+        old_category = copy.copy(category)
+        object.__setattr__(old_category, 'id', 666666)
+        object.__setattr__(old_category, 'application', amo.ANDROID.id)
+        attach_static_categories_mock.side_effect = side_effect
+
+        self.addon = addon_factory(type=amo.ADDON_STATICTHEME, category=category)
+        result = self.serialize()
+        assert result['categories'] == {amo.FIREFOX.short: [category_name]}
 
 
 class TestVersionSerializerOutput(TestCase):


### PR DESCRIPTION
fixes #21176

