### PR TITLE
Raise error when specifying compatibility inside forbidden Android range in the API

### DIFF
--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -3157,10 +3157,9 @@ class VersionViewSetCreateUpdateMixin(RequestMixin):
             ]
         }
 
+        # Recommended add-ons for Android don't have that restriction.
         self.make_addon_promoted(self.addon, RECOMMENDED, approve_version=True)
-        response = self.request(
-            compatibility={'android': {'min': '119.0a1', 'max': '*'}}
-        )
+        response = self.request(compatibility={'android': {'min': '48.0', 'max': '*'}})
         assert response.status_code == self.SUCCESS_STATUS_CODE, response.content
 
     def test_compatibility_forbidden_range_android_only_min_specified(self):
@@ -3174,10 +3173,9 @@ class VersionViewSetCreateUpdateMixin(RequestMixin):
             ]
         }
 
+        # Recommended add-ons for Android don't have that restriction.
         self.make_addon_promoted(self.addon, RECOMMENDED, approve_version=True)
-        response = self.request(
-            compatibility={'android': {'min': '48.0', 'max': '61.0'}}
-        )
+        response = self.request(compatibility={'android': {'min': '48.0'}})
         assert response.status_code == self.SUCCESS_STATUS_CODE, response.content
 
     @staticmethod

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -3146,6 +3146,21 @@ class VersionViewSetCreateUpdateMixin(RequestMixin):
         assert response.status_code == 400, response.content
         assert response.data == {'compatibility': ['Unknown min app version specified']}
 
+    def test_compatibility_forbidden_range_android(self):
+        response = self.request(compatibility={'android': {'min': '48.0', 'max': '*'}})
+        assert response.status_code == 400, response.content
+        assert response.data == {
+            'compatibility': [
+                'Invalid version range. For Firefox for Android, you may only pick a '
+                'range that starts with version 119.0a1 or higher, or ends with lower '
+                'than version 79.0a1.'
+            ]
+        }
+
+        self.make_addon_promoted(self.addon, RECOMMENDED, approve_version=True)
+        response = self.request(compatibility={'android': {'min': '48.0', 'max': '*'}})
+        assert response.status_code == self.SUCCESS_STATUS_CODE, response.content
+
     @staticmethod
     def _parse_xpi_mock(pkg, addon, minimal, user):
         return {**parse_xpi(pkg, addon, minimal, user), 'type': addon.type}

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -3158,7 +3158,26 @@ class VersionViewSetCreateUpdateMixin(RequestMixin):
         }
 
         self.make_addon_promoted(self.addon, RECOMMENDED, approve_version=True)
-        response = self.request(compatibility={'android': {'min': '48.0', 'max': '*'}})
+        response = self.request(
+            compatibility={'android': {'min': '119.0a1', 'max': '*'}}
+        )
+        assert response.status_code == self.SUCCESS_STATUS_CODE, response.content
+
+    def test_compatibility_forbidden_range_android_only_min_specified(self):
+        response = self.request(compatibility={'android': {'min': '48.0'}})
+        assert response.status_code == 400, response.content
+        assert response.data == {
+            'compatibility': [
+                'Invalid version range. For Firefox for Android, you may only pick a '
+                'range that starts with version 119.0a1 or higher, or ends with lower '
+                'than version 79.0a1.'
+            ]
+        }
+
+        self.make_addon_promoted(self.addon, RECOMMENDED, approve_version=True)
+        response = self.request(
+            compatibility={'android': {'min': '48.0', 'max': '61.0'}}
+        )
         assert response.status_code == self.SUCCESS_STATUS_CODE, response.content
 
     @staticmethod
@@ -4281,7 +4300,7 @@ class TestVersionViewSetUpdate(UploadMixin, VersionViewSetCreateUpdateMixin, Tes
         response = self.request(
             compatibility={
                 'firefox': {'min': amo.DEFAULT_WEBEXT_MIN_VERSION},
-                'android': {'min': amo.DEFAULT_WEBEXT_MIN_VERSION_GECKO_ANDROID},
+                'android': {'min': amo.MIN_VERSION_FENIX_GENERAL_AVAILABILITY},
             }
         )
         assert response.status_code == 400, response.content

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -1482,8 +1482,8 @@ class ApplicationsVersions(models.Model):
         # completing later. Use default values in that case (increases the
         # chance that the range would be considered forbbiden, forcing caller
         # to provide a complete instance).
-        min_ = getattr(self, 'min', self.get_default_minimum_appversion())
-        max_ = getattr(self, 'max', self.get_default_maximum_appversion())
+        min_ = getattr(self, 'min', None) or self.get_default_minimum_appversion()
+        max_ = getattr(self, 'max', None) or self.get_default_maximum_appversion()
 
         return (
             min_.version_int < limited_range_end

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -3052,6 +3052,57 @@ class TestApplicationsVersionsVersionRangeContainsForbiddenCompatibility(TestCas
         self.assert_min_and_max_are_set_to_fenix_ga_on_save(avs)
         assert not avs.version.file.reload().strict_compatibility
 
+    def test_get_default_minimum_appversion(self):
+        assert ApplicationsVersions(
+            application=amo.FIREFOX.id
+        ).get_default_minimum_appversion() == AppVersion.objects.get(
+            application=amo.FIREFOX.id,
+            version=amo.DEFAULT_WEBEXT_MIN_VERSIONS[amo.FIREFOX],
+        )
+
+        assert ApplicationsVersions(
+            application=amo.ANDROID.id
+        ).get_default_minimum_appversion() == AppVersion.objects.get(
+            application=amo.ANDROID.id,
+            version=amo.DEFAULT_WEBEXT_MIN_VERSIONS[amo.ANDROID],
+        )
+
+    def get_default_maximum_appversion(self):
+        self.star_firefox_appversion = AppVersion.objects.filter(
+            application=amo.FIREFOX.id, version=amo.DEFAULT_WEBEXT_MAX_VERSION
+        )
+        assert (
+            ApplicationsVersions(
+                application=amo.FIREFOX.id
+            ).get_default_maximum_appversion()
+            == self.star_firefox_appversion
+        )
+
+        assert (
+            ApplicationsVersions(
+                application=amo.ANDROID.id
+            ).get_default_maximum_appversion()
+            == self.star_android_appversion
+        )
+
+    def test_min_not_set_fallback_to_default(self):
+        addon = addon_factory()
+        avs = ApplicationsVersions(
+            application=amo.ANDROID.id,
+            version=addon.current_version,
+            max=self.fenix_appversion_star,
+        )
+        assert avs.version_range_contains_forbidden_compatibility()
+
+    def test_max_not_set_fallback_to_default(self):
+        addon = addon_factory()
+        avs = ApplicationsVersions(
+            application=amo.ANDROID.id,
+            version=addon.current_version,
+            min=self.fennec_appversion,
+        )
+        assert avs.version_range_contains_forbidden_compatibility()
+
 
 class TestVersionPreview(BasePreviewMixin, TestCase):
     def get_object(self):


### PR DESCRIPTION
Only do it when the full compatibility object is specified, we silently rewrite invalid ranges anyway.

Fixes #21195