### PR TITLE
Center the site notice text in devhub new landing

### DIFF
--- a/static/css/devhub/new-landing/common.less
+++ b/static/css/devhub/new-landing/common.less
@@ -179,3 +179,7 @@
 .flex-grow {
   flex-grow: 1;
 }
+
+#site-notice {
+  text-align: center;
+}


### PR DESCRIPTION
Something that was never tested with the new landing it seems...

Before:
![Screenshot 2023-09-15 at 14-23-30 Developer Hub Add-ons for Firefox](https://github.com/mozilla/addons-server/assets/187006/6e11f452-bfd5-49e0-8d36-c17886b825f4)

After:
![Screenshot 2023-09-15 at 14-24-08 Developer Hub Add-ons for Firefox](https://github.com/mozilla/addons-server/assets/187006/2baf036b-b8bd-4dcd-be2d-18f3a107c923)
