### PR TITLE
Switch remote settings URL to new GCP-specific endpoint on stage & prod

### DIFF
--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -68,7 +68,9 @@ EXTENSION_WORKSHOP_URL = env(
 )
 
 REMOTE_SETTINGS_API_URL = 'https://firefox.settings.services.mozilla.com/v1/'
-REMOTE_SETTINGS_WRITER_URL = 'https://remote-settings.mozilla.org/v1/'
+REMOTE_SETTINGS_WRITER_URL = env(
+    'REMOTE_SETTINGS_WRITER_URL', default='https://remote-settings.mozilla.org/v1/'
+)
 REMOTE_SETTINGS_WRITER_BUCKET = 'staging'
 
 # See: https://bugzilla.mozilla.org/show_bug.cgi?id=1633746

--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -68,7 +68,7 @@ EXTENSION_WORKSHOP_URL = env(
 )
 
 REMOTE_SETTINGS_API_URL = 'https://firefox.settings.services.mozilla.com/v1/'
-REMOTE_SETTINGS_WRITER_URL = 'https://settings-writer.prod.mozaws.net/v1/'
+REMOTE_SETTINGS_WRITER_URL = 'https://remote-settings.mozilla.org/v1/'
 REMOTE_SETTINGS_WRITER_BUCKET = 'staging'
 
 # See: https://bugzilla.mozilla.org/show_bug.cgi?id=1633746

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -74,5 +74,5 @@ EXTENSION_WORKSHOP_URL = env(
 )
 
 REMOTE_SETTINGS_API_URL = 'https://firefox.settings.services.allizom.org/v1/'
-REMOTE_SETTINGS_WRITER_URL = 'https://settings-writer.stage.mozaws.net/v1/'
+REMOTE_SETTINGS_WRITER_URL = 'https://remote-settings.allizom.org/v1/'
 REMOTE_SETTINGS_WRITER_BUCKET = 'staging'

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -74,5 +74,7 @@ EXTENSION_WORKSHOP_URL = env(
 )
 
 REMOTE_SETTINGS_API_URL = 'https://firefox.settings.services.allizom.org/v1/'
-REMOTE_SETTINGS_WRITER_URL = 'https://remote-settings.allizom.org/v1/'
+REMOTE_SETTINGS_WRITER_URL = env(
+    'REMOTE_SETTINGS_WRITER_URL', default='https://remote-settings.allizom.org/v1/'
+)
 REMOTE_SETTINGS_WRITER_BUCKET = 'staging'


### PR DESCRIPTION
Reverts mozilla/addons-server#20729