### PR TITLE
Fix typos in docs

### DIFF
--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -93,10 +93,10 @@ constants are as follows:
     ============================  =====================================================
 
 
-.. _api-overview-maintainance:
+.. _api-overview-maintenance:
 
 ~~~~~~~~~~~~~~~~~
-Maintainance Mode
+Maintenance Mode
 ~~~~~~~~~~~~~~~~~
 
 When returning ``HTTP 503 Service Unavailable`` responses the API may be in
@@ -244,7 +244,7 @@ original url (``url``), and wrapped through ``outgoing.prod.mozaws.net`` (``outg
 
 Note, if the field is also a translated field then the ``url`` and ``outgoing``
 values could be an object rather than a string
-(See :ref:`translated fields <api-overview-translations>` for translated field represenations).
+(See :ref:`translated fields <api-overview-translations>` for translated field representations).
 
 Fields supporting some HTML, such as add-on ``description`` or ``summary``,
 always wrap any links directly inside the content (the original url is not available).
@@ -271,7 +271,7 @@ Site Status
 .. _`api-site-status`:
 
 This special endpoint returns if the site is in read only mode, and if there is a site notice currently in effect.
-See :ref:`maintainance mode <api-overview-maintainance>` for more details of when the site is read only and how requests are affected.
+See :ref:`maintenance mode <api-overview-maintenance>` for more details of when the site is read only and how requests are affected.
 
 
 .. http:get:: /api/v5/site/
@@ -335,7 +335,7 @@ v4 API changelog
 * 2018-08-16: added ``is_developer_reply`` property to ratings. This changed was also backported to the `v3` API. https://github.com/mozilla/addons-server/issues/8993
 * 2018-09-13: added ``name`` and ``icon_url`` properties to the ``addon`` object in ratings. This changed was also backported to the `v3` API. https://github.com/mozilla/addons-server/issues/9357
 * 2018-09-27: backed out "localised field values are always returned as objects" change from 2018-07-19 from `v4` API.  This is intended to be temporary change while addons-frontend upgrades.
-  On addons-dev and addons stage enviroments the previous behavior is available as `api/v4dev`. The `v4dev` api is not available on AMO production server.
+  On addons-dev and addons stage environments the previous behavior is available as `api/v4dev`. The `v4dev` api is not available on AMO production server.
   https://github.com/mozilla/addons-server/issues/9467
 * 2018-10-04: added ``is_strict_compatibility_enabled`` to discovery API ``addons.current_version`` object. This change was also backported to the `v3` API. https://github.com/mozilla/addons-server/issues/9520
 * 2018-10-04: added ``is_deleted`` to the ratings API. This change was also backported to the `v3` API. https://github.com/mozilla/addons-server/issues/9371
@@ -396,7 +396,7 @@ v4 API changelog
 * 2020-11-05: added endpoint to receive Stripe events. https://github.com/mozilla/addons-server/issues/15879
 * 2021-01-14: as addons-frontend now uses /v5/, v5 becomes the stable default; v4 becomes frozen; v3 is deprecated
 * 2021-02-12: added ``versions_url`` to addon detail endpoint. https://github.com/mozilla/addons-server/issues/16534
-* 2021-02-25: ``platform`` filtering was remoed from add-on search and autocomplete endpoints. https://github.com/mozilla/addons-server/issues/16463
+* 2021-02-25: ``platform`` filtering was removed from add-on search and autocomplete endpoints. https://github.com/mozilla/addons-server/issues/16463
 
 ----------------
 v5 API changelog
@@ -422,7 +422,7 @@ These are `v5` specific changes - `v4` changes apply also.
 * 2021-02-18: made ``description``, ``headline``, and ``cta.text`` in shelves/hero endpoint translated fields in the response. (They were always localized, we just didn't return them as such). https://github.com/mozilla/addons-server/issues/16515
 * 2021-02-18: added ``versions_url`` to addon detail endpoint. https://github.com/mozilla/addons-server/issues/16534
 * 2021-02-25: made ``headline`` and ``footer_text`` in shelves endpoint translated fields. Also added shelves/editorial endpoint for the localization process. https://github.com/mozilla/addons-server/issues/16514
-* 2021-02-25: ``platform`` filtering was remoed from add-on search and autocomplete endpoints. https://github.com/mozilla/addons-server/issues/16463
+* 2021-02-25: ``platform`` filtering was removed from add-on search and autocomplete endpoints. https://github.com/mozilla/addons-server/issues/16463
 * 2021-03-04: replaced ``footer_pathname`` and ``footer_text`` with ``footer`` object in shelves api response.  https://github.com/mozilla/addons-server/issues/16575
 * 2021-03-18: removed ``platform`` from file objects (it was always ``all``) in all endpoints. https://github.com/mozilla/addons-server/issues/16466
 * 2021-05-20: removed ``text`` from license objects in versions list endpoint. https://github.com/mozilla/addons-server/issues/17163
@@ -456,7 +456,7 @@ These are `v5` specific changes - `v4` changes apply also.
 * 2023-02-23: removed ``canned-response`` from the /draft_comments/ endpoint. https://github.com/mozilla/addons-server/issues/20353
 * 2023-03-02: added specific HTTP 409 status code for add-on/version submissions that already exist
 * 2023-03-02: added support for calling the version detail endpoint using a version number instead of an ``id``.
-* 2023-03-09: added ``is_disabled`` to version detail and update endpoints, for authenticated developers and revieweers. https://github.com/mozilla/addons-server/issues/20142
+* 2023-03-09: added ``is_disabled`` to version detail and update endpoints, for authenticated developers and reviewers. https://github.com/mozilla/addons-server/issues/20142
 * 2023-03-08: restricted ``lang`` parameter to only alphanumeric, ``_``, ``-``. https://github.com/mozilla/addons-server/issues/20452
 * 2023-03-09: added ``host_permissions`` to the response of the version detail endpoint. https://github.com/mozilla/addons-server/issues/20418
 * 2023-04-13: removed signing api from api/v5+ in favor of addon submission api. https://github.com/mozilla/addons-server/issues/20560

--- a/docs/topics/api/shelves.rst
+++ b/docs/topics/api/shelves.rst
@@ -15,7 +15,7 @@ Combined Hero Shelves
 
 .. _hero-shelves:
 
-This convienence endpoint serves a single, randomly selected, primary hero shelf,
+This convenience endpoint serves a single, randomly selected, primary hero shelf,
 and a single, randomly selected secondary hero shelf.
 
 

--- a/docs/topics/api/v3_legacy/abuse.rst
+++ b/docs/topics/api/v3_legacy/abuse.rst
@@ -6,7 +6,7 @@ Abuse Reports
 
     These v3 APIs are now deprecated and you should switch to a newer version before
     it is removed. See :ref:`the API versions available<api-versions-list>` for details
-    of the different API versions available and the deprection timeline.
+    of the different API versions available and the deprecation timeline.
 
 The following API endpoint covers abuse reporting
 
@@ -19,7 +19,7 @@ Submitting an add-on abuse report
 The following API endpoint allows an abuse report to be submitted for an Add-on,
 either listed on https://addons.mozilla.org or not.
 Authentication is not required, but is recommended so reports can be responded
-to if nessecary.
+to if necessary.
 
 .. http:post:: /api/v3/abuse/report/addon/
 
@@ -47,7 +47,7 @@ Submitting a user abuse report
 
 The following API endpoint allows an abuse report to be submitted for a user account
 on https://addons.mozilla.org.  Authentication is not required, but is recommended
-so reports can be responded to if nessecary.
+so reports can be responded to if necessary.
 
 .. http:post:: /api/v3/abuse/report/user/
 

--- a/docs/topics/api/v3_legacy/accounts.rst
+++ b/docs/topics/api/v3_legacy/accounts.rst
@@ -6,7 +6,7 @@ Accounts
 
     These v3 APIs are now deprecated and you should switch to a newer version before
     it is removed. See :ref:`the API versions available<api-versions-list>` for details
-    of the different API versions available and the deprection timeline.
+    of the different API versions available and the deprecation timeline.
 
 The following API endpoints cover a users account.
 
@@ -181,7 +181,7 @@ Delete
 
 .. note::
     Accounts of users who are authors of Add-ons can't be deleted.
-    All Add-ons (and Themes) must be deleted or transfered to other users first.
+    All Add-ons (and Themes) must be deleted or transferred to other users first.
 
 This endpoint allows the account to be deleted. The reviews and ratings
 created by the user will not be deleted; but all the user's details are

--- a/docs/topics/api/v3_legacy/activity.rst
+++ b/docs/topics/api/v3_legacy/activity.rst
@@ -6,7 +6,7 @@ Activity
 
     These v3 APIs are now deprecated and you should switch to a newer version before
     it is removed. See :ref:`the API versions available<api-versions-list>` for details
-    of the different API versions available and the deprection timeline.
+    of the different API versions available and the deprecation timeline.
 
 .. note::
     The only authentication method available at

--- a/docs/topics/api/v3_legacy/addons.rst
+++ b/docs/topics/api/v3_legacy/addons.rst
@@ -6,7 +6,7 @@ Add-ons
 
     These v3 APIs are now deprecated and you should switch to a newer version before
     it is removed. See :ref:`the API versions available<api-versions-list>` for details
-    of the different API versions available and the deprection timeline.
+    of the different API versions available and the deprecation timeline.
 
 .. note::
     The only authentication method available at
@@ -477,7 +477,7 @@ Compat Override
 .. _v3-addon-compat-override:
 
 This endpoint allows compatibility overrides specified by AMO admins to be searched.
-Compatibilty overrides are used within Firefox i(and other toolkit applications e.g. Thunderbird) to change compatibility of installed add-ons where they have stopped working correctly in new release of Firefox, etc.
+Compatibility overrides are used within Firefox i(and other toolkit applications e.g. Thunderbird) to change compatibility of installed add-ons where they have stopped working correctly in new release of Firefox, etc.
 
 .. http:get:: /api/v3/addons/compat-override/
 

--- a/docs/topics/api/v3_legacy/auth.rst
+++ b/docs/topics/api/v3_legacy/auth.rst
@@ -8,7 +8,7 @@ Authentication (External)
 
     These v3 APIs are now deprecated and you should switch to a newer version before
     it is removed. See :ref:`the API versions available<api-versions-list>` for details
-    of the different API versions available and the deprection timeline.
+    of the different API versions available and the deprecation timeline.
 
 To access the API as an external consumer, you need to include a
 `JSON Web Token (JWT)`_ in the ``Authorization`` header for every request.

--- a/docs/topics/api/v3_legacy/auth_internal.rst
+++ b/docs/topics/api/v3_legacy/auth_internal.rst
@@ -8,7 +8,7 @@ Authentication (internal)
 
     These v3 APIs are now deprecated and you should switch to a newer version before
     it is removed. See :ref:`the API versions available<api-versions-list>` for details
-    of the different API versions available and the deprection timeline.
+    of the different API versions available and the deprecation timeline.
 
 
 This documents how to use authentication in your API requests when you are

--- a/docs/topics/api/v3_legacy/categories.rst
+++ b/docs/topics/api/v3_legacy/categories.rst
@@ -6,7 +6,7 @@ Categories
 
     These v3 APIs are now deprecated and you should switch to a newer version before
     it is removed. See :ref:`the API versions available<api-versions-list>` for details
-    of the different API versions available and the deprection timeline.
+    of the different API versions available and the deprecation timeline.
 
 -------------
 Category List

--- a/docs/topics/api/v3_legacy/collections.rst
+++ b/docs/topics/api/v3_legacy/collections.rst
@@ -6,7 +6,7 @@ Collections
 
     These v3 APIs are now deprecated and you should switch to a newer version before
     it is removed. See :ref:`the API versions available<api-versions-list>` for details
-    of the different API versions available and the deprection timeline.
+    of the different API versions available and the deprecation timeline.
 
 The following API endpoints cover user created collections.
 

--- a/docs/topics/api/v3_legacy/discovery.rst
+++ b/docs/topics/api/v3_legacy/discovery.rst
@@ -6,7 +6,7 @@ Discovery
 
     These v3 APIs are now deprecated and you should switch to a newer version before
     it is removed. See :ref:`the API versions available<api-versions-list>` for details
-    of the different API versions available and the deprection timeline.
+    of the different API versions available and the deprecation timeline.
 
 -----------------
 Discovery Content
@@ -39,7 +39,7 @@ If a telemetry client id is passed as a parameter to the discovery pane api
 endpoint then static curated content is amended with recommendations from the
 `recommendation service <https://github.com/mozilla/taar>`_.  The same number
 of results will be returned as a standard discovery response and only extensions
-(not themes) are recommeded.  Only valid, publicly available addons are shown.
+(not themes) are recommended.  Only valid, publicly available addons are shown.
 
 E.g. a standard discovery pane will display 7 items, 4 extensions and 3 themes.
 Up to 4 extensions will be replaced with recommendations; the 3 themes will not

--- a/docs/topics/api/v3_legacy/index.rst
+++ b/docs/topics/api/v3_legacy/index.rst
@@ -7,7 +7,7 @@ External API (V3 - Deprecated)
 .. warning::
     These v3 APIs are now deprecated and you should switch to a newer version before
     it is removed. See :ref:`the API versions available<api-versions-list>` for details
-    of the different API versions available and the deprection timeline.
+    of the different API versions available and the deprecation timeline.
 
 This shows you how to use the `addons.mozilla.org <https://addons.mozilla.org/en-US/firefox/>`_
 API at ``/api/v3/`` which is hosted at the following URLs:

--- a/docs/topics/api/v3_legacy/overview.rst
+++ b/docs/topics/api/v3_legacy/overview.rst
@@ -8,7 +8,7 @@ Overview
 
     These v3 APIs are now deprecated and you should switch to a newer version before
     it is removed. See :ref:`the API versions available<api-versions-list>` for details
-    of the different API versions available and the deprection timeline.
+    of the different API versions available and the deprecation timeline.
 
 This describes the details of the requests and responses you can expect from
 the `addons.mozilla.org <https://addons.mozilla.org/en-US/firefox/>`_ API.

--- a/docs/topics/api/v3_legacy/reviewers.rst
+++ b/docs/topics/api/v3_legacy/reviewers.rst
@@ -8,7 +8,7 @@ Reviewers
 
     These v3 APIs are now deprecated and you should switch to a newer version before
     it is removed. See :ref:`the API versions available<api-versions-list>` for details
-    of the different API versions available and the deprection timeline.
+    of the different API versions available and the deprecation timeline.
 
 .. note::
     The only authentication method available at

--- a/docs/topics/api/v3_legacy/reviews.rst
+++ b/docs/topics/api/v3_legacy/reviews.rst
@@ -6,7 +6,7 @@ Reviews
 
     These v3 APIs are now deprecated and you should switch to a newer version before
     it is removed. See :ref:`the API versions available<api-versions-list>` for details
-    of the different API versions available and the deprection timeline.
+    of the different API versions available and the deprecation timeline.
 
 .. note::
     The only authentication method available at

--- a/docs/topics/api/v3_legacy/signing.rst
+++ b/docs/topics/api/v3_legacy/signing.rst
@@ -6,7 +6,7 @@ Signing
 
     These v3 APIs are now deprecated and you should switch to a newer version before
     it is removed. See :ref:`the API versions available<api-versions-list>` for details
-    of the different API versions available and the deprection timeline.
+    of the different API versions available and the deprecation timeline.
 
 .. note::
     This API requires :doc:`authentication <auth>`.
@@ -22,7 +22,7 @@ Client Libraries
 
 The following libraries will make it easier to use the signing API:
 
-* `sign-addon <https://github.com/mozilla/sign-addon/>`_, for general programattic use in
+* `sign-addon <https://github.com/mozilla/sign-addon/>`_, for general programmatic use in
   `NodeJS <https://nodejs.org/>`_
 * `web-ext sign <https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Getting_started_with_web-ext#Signing_your_extension_for_distribution>`_,
   for developing `Web Extensions <https://developer.mozilla.org/en-US/Add-ons/WebExtensions>`_

--- a/docs/topics/api/v4_frozen/discovery.rst
+++ b/docs/topics/api/v4_frozen/discovery.rst
@@ -25,7 +25,7 @@ Firefox (about:addons).
     endpoint then static curated content is amended with recommendations from the
     `recommendation service <https://github.com/mozilla/taar>`_.  The same number
     of results will be returned as a standard discovery response and only extensions
-    (not themes) are recommeded.  Only valid, publicly available addons are shown.
+    (not themes) are recommended.  Only valid, publicly available addons are shown.
 
     E.g. a standard discovery pane will display 7 items, 4 extensions and 3 themes.
     Up to 4 extensions will be replaced with recommendations; the 3 themes will not

--- a/docs/topics/api/v4_frozen/overview.rst
+++ b/docs/topics/api/v4_frozen/overview.rst
@@ -90,10 +90,10 @@ constants are as follows:
     ========================  =========================================================
 
 
-.. _v4-api-overview-maintainance:
+.. _v4-api-overview-maintenance:
 
 ~~~~~~~~~~~~~~~~~
-Maintainance Mode
+Maintenance Mode
 ~~~~~~~~~~~~~~~~~
 
 When returning ``HTTP 503 Service Unavailable`` responses the API may be in
@@ -224,7 +224,7 @@ original url (``url``), and wrapped through ``outgoing.prod.mozaws.net`` (``outg
 
 Note, if the field is also a translated field then the ``url`` and ``outgoing``
 values could be an object rather than a string
-(See `translated fields <v4-api-overview-translations>` for translated field represenations).
+(See `translated fields <v4-api-overview-translations>` for translated field representations).
 
 Fields supporting some HTML, such as add-on ``description`` or ``summary``,
 always wrap any links directly inside the content (the original url is not available).
@@ -248,7 +248,7 @@ Site Status
 .. _v4-api-site-status:
 
 This special endpoint returns if the site is in read only mode, and if there is a site notice currently in effect.
-See :ref:`maintainance mode <v4-api-overview-maintainance>` for more details of when the site is read only and how requests are affected.
+See :ref:`maintenance mode <v4-api-overview-maintenance>` for more details of when the site is read only and how requests are affected.
 
 
 .. http:get:: /api/v4/site/
@@ -275,7 +275,7 @@ v4 API changelog
 * 2018-08-16: added ``is_developer_reply`` property to ratings. This changed was also backported to the `v3` API. https://github.com/mozilla/addons-server/issues/8993
 * 2018-09-13: added ``name`` and ``icon_url`` properties to the ``addon`` object in ratings. This changed was also backported to the `v3` API. https://github.com/mozilla/addons-server/issues/9357
 * 2018-09-27: backed out "localised field values are always returned as objects" change from 2018-07-19 from `v4` API.  This is intended to be temporary change while addons-frontend upgrades.
-  On addons-dev and addons stage enviroments the previous behavior is available as `api/v4dev`. The `v4dev` api is not available on AMO production server.
+  On addons-dev and addons stage environments the previous behavior is available as `api/v4dev`. The `v4dev` api is not available on AMO production server.
   https://github.com/mozilla/addons-server/issues/9467
 * 2018-10-04: added ``is_strict_compatibility_enabled`` to discovery API ``addons.current_version`` object. This change was also backported to the `v3` API. https://github.com/mozilla/addons-server/issues/9520
 * 2018-10-04: added ``is_deleted`` to the ratings API. This change was also backported to the `v3` API. https://github.com/mozilla/addons-server/issues/9371

--- a/docs/topics/api/v4_frozen/shelves.rst
+++ b/docs/topics/api/v4_frozen/shelves.rst
@@ -15,7 +15,7 @@ Combined Hero Shelves
 
 .. _v4-hero-shelves:
 
-This convienence endpoint serves a single, randomly selected, primary hero shelf,
+This convenience endpoint serves a single, randomly selected, primary hero shelf,
 and a single, randomly selected secondary hero shelf.
 
 

--- a/docs/topics/api/v4_frozen/signing.rst
+++ b/docs/topics/api/v4_frozen/signing.rst
@@ -19,7 +19,7 @@ Client Libraries
 
 The following libraries will make it easier to use the signing API:
 
-* `sign-addon <https://github.com/mozilla/sign-addon/>`_, for general programattic use in
+* `sign-addon <https://github.com/mozilla/sign-addon/>`_, for general programmatic use in
   `NodeJS <https://nodejs.org/>`_
 * `web-ext sign <https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Getting_started_with_web-ext#Signing_your_extension_for_distribution>`_,
   for developing `Web Extensions <https://developer.mozilla.org/en-US/Add-ons/WebExtensions>`_

--- a/docs/topics/install/deprecated/elasticsearch.rst
+++ b/docs/topics/install/deprecated/elasticsearch.rst
@@ -43,7 +43,7 @@ Olympia has commands that sets up mappings and indexes objects such as add-ons
 and apps for you. Setting up the mappings is analogous to defining the
 structure of a table, indexing is analogous to storing rows.
 
-For AMO, this will set up all indexes and start the indexing processeses::
+For AMO, this will set up all indexes and start the indexing processes::
 
     ./manage.py reindex
 


### PR DESCRIPTION
This PR fixes a few minor typos in the docs.

I noticed a typo while reading the documentation, and added a few more fixes at the same time when I went to fix it.
I have not touched any words with different US vs UK spelling.
All changes are under `docs/`.