### PR TITLE
add logging for changed slug on devhub

### DIFF
--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -953,6 +953,12 @@ class CLEAR_ADMIN_REVIEW_THEME(_LOG):
     reviewer_review_action = True
     admin_event = True
 
+class ADDON_SLUG_CHANGED(_LOG):
+    id = 182
+    format = _('Addon {addon} slug changed from {old} to {new}.')
+    short = _('Addon slug changed')
+    keep = True
+    show_user_to_developer = True
 
 LOGS = [x for x in vars().values() if isclass(x) and issubclass(x, _LOG) and x != _LOG]
 # Make sure there's no duplicate IDs.

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -137,6 +137,11 @@ class BaseTestEditDescribe(BaseTestEdit):
         doc = pq(response.content)
         assert doc('form').attr('action') != old_edit
 
+        activity_log = ActivityLog.objects.latest('pk')
+        assert activity_log.action == amo.LOG.ADDON_SLUG_CHANGED.id
+        assert activity_log.user == self.user
+        assert activity_log.arguments == [self.addon, self.addon.slug, 'valid']
+
     def test_edit_as_developer(self):
         self.client.force_login(UserProfile.objects.get(email='regular@mozilla.com'))
         data = self.get_dict()

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -906,7 +906,10 @@ def addons_section(request, addon_id, addon, section, editable=False):
                 else:
                     ActivityLog.create(amo.LOG.EDIT_PROPERTIES, addon)
 
+                if valid_slug != addon.slug:
+                    ActivityLog.create(amo.LOG.ADDON_SLUG_CHANGED, addon, valid_slug, addon.slug)
                 valid_slug = addon.slug
+
             if cat_form:
                 if cat_form.is_valid():
                     cat_form.save()


### PR DESCRIPTION
Fixes #21174 

When the slug in devhub is changed, create an activity log.
