### PR TITLE
Make signing API create versions compatible with Firefox only (not Android)

### DIFF
--- a/src/olympia/devhub/tests/test_utils.py
+++ b/src/olympia/devhub/tests/test_utils.py
@@ -586,7 +586,7 @@ class TestCreateVersionForUpload(UploadMixin, TestCase):
             newer_upload,
             self.addon,
             amo.CHANNEL_LISTED,
-            selected_apps=[amo.FIREFOX.id, amo.ANDROID.id],
+            selected_apps=[amo.FIREFOX.id],
             parsed_data=self.mocks['parse_addon'].return_value,
         )
 
@@ -636,7 +636,7 @@ class TestCreateVersionForUpload(UploadMixin, TestCase):
             upload,
             self.addon,
             amo.CHANNEL_LISTED,
-            selected_apps=[amo.FIREFOX.id, amo.ANDROID.id],
+            selected_apps=[amo.FIREFOX.id],
             parsed_data=self.mocks['parse_addon'].return_value,
         )
 
@@ -651,7 +651,7 @@ class TestCreateVersionForUpload(UploadMixin, TestCase):
             upload,
             self.addon,
             amo.CHANNEL_LISTED,
-            selected_apps=[amo.FIREFOX.id, amo.ANDROID.id],
+            selected_apps=[amo.FIREFOX.id],
             parsed_data=self.mocks['parse_addon'].return_value,
         )
 
@@ -666,7 +666,7 @@ class TestCreateVersionForUpload(UploadMixin, TestCase):
             upload,
             self.addon,
             amo.CHANNEL_LISTED,
-            selected_apps=[amo.FIREFOX.id, amo.ANDROID.id],
+            selected_apps=[amo.FIREFOX.id],
             parsed_data=self.mocks['parse_addon'].return_value,
         )
 
@@ -684,6 +684,6 @@ class TestCreateVersionForUpload(UploadMixin, TestCase):
             upload,
             self.addon,
             amo.CHANNEL_LISTED,
-            selected_apps=[amo.FIREFOX.id, amo.ANDROID.id],
+            selected_apps=[amo.FIREFOX.id],
             parsed_data=parsed_data,
         )

--- a/src/olympia/devhub/utils.py
+++ b/src/olympia/devhub/utils.py
@@ -354,7 +354,7 @@ def create_version_for_upload(addon, upload, channel, parsed_data=None):
             upload,
             addon,
             channel,
-            selected_apps=[x[0] for x in amo.APPS_CHOICES],
+            selected_apps=[amo.FIREFOX.id],
             parsed_data=parsed_data,
         )
         channel_name = amo.CHANNEL_CHOICES_API[channel]

--- a/src/olympia/versions/management/commands/drop_android_compatibility.py
+++ b/src/olympia/versions/management/commands/drop_android_compatibility.py
@@ -1,0 +1,47 @@
+import csv
+
+from django.core.management.base import BaseCommand
+
+import olympia.core.logger
+from olympia import amo
+from olympia.addons.tasks import index_addons
+from olympia.versions.models import ApplicationsVersions
+
+
+log = olympia.core.logger.getLogger('z.versions.drop_android_compatibility')
+
+
+class Command(BaseCommand):
+    """
+    Drop Firefox for Android compatibility on *all* versions of the add-ons in
+    the provided csv.
+
+    The caller should make sure the csv contains all the add-ons we want to
+    drop compatibility for.
+    """
+
+    help = 'Drop compatibility with Firefox for Android on specified add-ons'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'CSVFILE',
+            help='Path to CSV file containing add-on ids.',
+        )
+
+    def read_csv(self, path):
+        with open(path) as file_:
+            csv_reader = csv.reader(file_)
+            # Format should be a single column with the add-on id.
+            # Ignore non-decimal to avoid the column header.
+            return [
+                int(row[0])
+                for row in csv_reader
+                if row[0] and row[0].strip().isdecimal()
+            ]
+
+    def handle(self, *args, **kwargs):
+        addon_ids = self.read_csv(kwargs['CSVFILE'])
+        ApplicationsVersions.objects.filter(
+            version__addon__id__in=addon_ids, application=amo.ANDROID.id
+        ).delete()
+        index_addons.delay(addon_ids)


### PR DESCRIPTION
Versions created with the signing API should only be compatible with Firefox for Android if the manifest contains `browser_specific_settings.gecko_android` key.

Also add a command to clean up any recently affected add-ons (using a csv).

Fixes #21229