### PR TITLE
Handle TypeError in abuse report serializer for non-string values

### DIFF
--- a/src/olympia/abuse/serializers.py
+++ b/src/olympia/abuse/serializers.py
@@ -143,9 +143,9 @@ class AddonAbuseReportSerializer(BaseAbuseReportSerializer):
                 field_name,
                 str(data[field_name])[:255],
             )
-            raise serializers.ValidationError({
-                field_name: _('Invalid type for value submitted.')
-            })
+            raise serializers.ValidationError(
+                {field_name: _('Invalid type for value submitted.')}
+            )
 
         if is_value_unknown:
             log.warning(

--- a/src/olympia/abuse/serializers.py
+++ b/src/olympia/abuse/serializers.py
@@ -143,9 +143,7 @@ class AddonAbuseReportSerializer(BaseAbuseReportSerializer):
                 field_name,
                 str(data[field_name])[:255],
             )
-            raise serializers.ValidationError(
-                {field_name: _('Invalid value')}
-            )
+            raise serializers.ValidationError({field_name: _('Invalid value')})
 
         if is_value_unknown:
             log.warning(

--- a/src/olympia/abuse/serializers.py
+++ b/src/olympia/abuse/serializers.py
@@ -133,7 +133,21 @@ class AddonAbuseReportSerializer(BaseAbuseReportSerializer):
     def handle_unknown_install_method_or_source(self, data, field_name):
         reversed_choices = self.fields[field_name].reversed_choices
         value = data[field_name]
-        if value not in reversed_choices:
+
+        try:
+            is_value_unknown = value not in reversed_choices
+        except TypeError:
+            # Log the invalid type and raise a validation error.
+            log.warning(
+                'Invalid type for abuse report %s value submitted: %s',
+                field_name,
+                str(data[field_name])[:255],
+            )
+            raise serializers.ValidationError({
+                field_name: _('Invalid type for value submitted.')
+            })
+
+        if is_value_unknown:
             log.warning(
                 'Unknown abuse report %s value submitted: %s',
                 field_name,

--- a/src/olympia/abuse/serializers.py
+++ b/src/olympia/abuse/serializers.py
@@ -144,7 +144,7 @@ class AddonAbuseReportSerializer(BaseAbuseReportSerializer):
                 str(data[field_name])[:255],
             )
             raise serializers.ValidationError(
-                {field_name: _('Invalid type for value submitted.')}
+                {field_name: _('Invalid value')}
             )
 
         if is_value_unknown:

--- a/src/olympia/abuse/tests/test_views.py
+++ b/src/olympia/abuse/tests/test_views.py
@@ -402,6 +402,22 @@ class AddonAbuseViewSetTestBase:
         self.check_report(report, 'Abuse Report for Addon %s' % addon.guid)
         assert report.country_code == 'YY'
 
+    def test_abuse_report_with_invalid_data(self):
+        addon = addon_factory()
+        # Prepare data with invalid field values
+        data = {
+            'addon': addon.pk,
+            'addon_install_method': {'dictionary_key': 'dictionary_val'},
+            'addon_install_source': {'dictionary_key': 'dictionary_val'},
+            'message': 'abuse!',
+        }
+
+        response = self.client.post(self.url, data=data)
+        assert response.status_code == 400
+        assert json.loads(response.content) == {
+            "addon_install_method": "Invalid type for value submitted."
+        }
+
 
 class TestAddonAbuseViewSetLoggedOut(AddonAbuseViewSetTestBase, TestCase):
     def check_reporter(self, report):

--- a/src/olympia/abuse/tests/test_views.py
+++ b/src/olympia/abuse/tests/test_views.py
@@ -415,7 +415,7 @@ class AddonAbuseViewSetTestBase:
         response = self.client.post(self.url, data=data)
         assert response.status_code == 400
         assert json.loads(response.content) == {
-            "addon_install_method": "Invalid type for value submitted."
+            'addon_install_method': 'Invalid type for value submitted.'
         }
 
 

--- a/src/olympia/abuse/tests/test_views.py
+++ b/src/olympia/abuse/tests/test_views.py
@@ -414,9 +414,7 @@ class AddonAbuseViewSetTestBase:
 
         response = self.client.post(self.url, data=data)
         assert response.status_code == 400
-        assert json.loads(response.content) == {
-            'addon_install_method': 'Invalid type for value submitted.'
-        }
+        assert json.loads(response.content) == {'addon_install_method': 'Invalid value'}
 
 
 class TestAddonAbuseViewSetLoggedOut(AddonAbuseViewSetTestBase, TestCase):


### PR DESCRIPTION
Fixes #19286

This PR addresses an issue where the abuse report API would throw a TypeError when certain fields received unexpected data types. The solution involves wrapping the problematic code block with a try-except to handle the TypeError and raising a more specific ValidationError. Tests will be pushed in a subsequent commit.

The change has been successfully run and tested (on existing tests) locally.
