### PR TITLE
Fix placeholder processing in `resolve_i18n_message` function

### DIFF
--- a/src/olympia/files/tests/test_utils.py
+++ b/src/olympia/files/tests/test_utils.py
@@ -1470,6 +1470,50 @@ class TestResolvei18nMessage:
         result = utils.resolve_i18n_message('__MSG_app_desc__', messages, 'en')
         assert result == 'Test Placeholder is replaced!'
 
+    def test_app_without_content(self):
+        """Test message with a placeholder but no content."""
+        app_without_content_message = {
+            'message': 'This $placeholder$ should not be replaced.',
+            'placeholders': {'placeholder': {}},
+        }
+        messages = {'en-US': {'app_without_content': app_without_content_message}}
+
+        result = utils.resolve_i18n_message(
+            '__MSG_app_without_content__', messages, 'en-US'
+        )
+        assert result == 'This $placeholder$ should not be replaced.'
+
+    def test_app_without_placeholder(self):
+        """Test message without any placeholders."""
+        app_without_placeholder_message = {
+            'message': 'This message has no placeholders.',
+        }
+        messages = {
+            'en-US': {'app_without_placeholder': app_without_placeholder_message}
+        }
+
+        result = utils.resolve_i18n_message(
+            '__MSG_app_without_placeholder__', messages, 'en-US'
+        )
+        assert result == 'This message has no placeholders.'
+
+    def test_app_with_invalid_placeholder(self):
+        """Test message with invalid placeholder format."""
+        app_with_invalid_placeholder_message = {
+            'message': 'This $placeholder$ might cause issues.',
+            'placeholders': 'Invalid format',
+        }
+        messages = {
+            'en-US': {
+                'app_with_invalid_placeholder': app_with_invalid_placeholder_message
+            }
+        }
+
+        result = utils.resolve_i18n_message(
+            '__MSG_app_with_invalid_placeholder__', messages, 'en-US'
+        )
+        assert result == 'This $placeholder$ might cause issues.'
+
 
 class TestGetBackgroundImages(TestCase):
     file_obj = os.path.join(

--- a/src/olympia/files/tests/test_utils.py
+++ b/src/olympia/files/tests/test_utils.py
@@ -1461,22 +1461,14 @@ class TestResolvei18nMessage:
 
     def test_resolve_placeholders_in_message(self):
         """Test that placeholders in the message string are correctly replaced."""
-        messages = {
-            'en-US': {
-                'app_desc': {
-                    'message': '$test_placeholder$ tests whether placeholder is correctly replaced.',
-                    'placeholders': {
-                        'test_placeholder': {'content': 'Test Placeholder'}
-                    },
-                }
-            }
+        app_desc_message = {
+            'message': '$test_placeholder$ is replaced!',
+            'placeholders': {'test_placeholder': {'content': 'Test Placeholder'}},
         }
+        messages = {'en-US': {'app_desc': app_desc_message}}
 
         result = utils.resolve_i18n_message('__MSG_app_desc__', messages, 'en')
-        assert (
-            result
-            == 'Test Placeholder tests whether placeholder is correctly replaced.'
-        )
+        assert result == 'Test Placeholder is replaced!'
 
 
 class TestGetBackgroundImages(TestCase):

--- a/src/olympia/files/tests/test_utils.py
+++ b/src/olympia/files/tests/test_utils.py
@@ -1459,6 +1459,25 @@ class TestResolvei18nMessage:
         result = utils.resolve_i18n_message('__MSG_foo__', messages, 'en')
         assert result is None
 
+    def test_resolve_placeholders_in_message(self):
+        """Test that placeholders in the message string are correctly replaced."""
+        messages = {
+            'en-US': {
+                'app_desc': {
+                    'message': '$test_placeholder$ tests whether placeholder is correctly replaced.',
+                    'placeholders': {
+                        'test_placeholder': {'content': 'Test Placeholder'}
+                    },
+                }
+            }
+        }
+
+        result = utils.resolve_i18n_message('__MSG_app_desc__', messages, 'en')
+        assert (
+            result
+            == 'Test Placeholder tests whether placeholder is correctly replaced.'
+        )
+
 
 class TestGetBackgroundImages(TestCase):
     file_obj = os.path.join(

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -1219,15 +1219,19 @@ def resolve_i18n_message(message, messages, locale, default_locale=None):
 
     resolved_message = message['message']
     # Check if the message has placeholders
-    if 'placeholders' in message:
-        for placeholder, content in message['placeholders'].items():
-            # Replace the placeholder with its content
-            resolved_message = re.sub(
-                f'\\${placeholder}\\$',
-                content['content'],
-                resolved_message,
-                flags=re.IGNORECASE,
-            )
+    try:
+        if 'placeholders' in message and isinstance(message['placeholders'], dict):
+            for placeholder, content in message['placeholders'].items():
+                if 'content' in content:
+                    # Replace the placeholder with its content
+                    resolved_message = re.sub(
+                        f'\\${placeholder}\\$',
+                        content['content'],
+                        resolved_message,
+                        flags=re.IGNORECASE,
+                    )
+    except (AttributeError, KeyError):
+        pass
 
     return resolved_message
 

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -1222,10 +1222,14 @@ def resolve_i18n_message(message, messages, locale, default_locale=None):
     if 'placeholders' in message:
         for placeholder, content in message['placeholders'].items():
             # Replace the placeholder with its content
-            resolved_message = re.sub(f'\\${placeholder}\\$', content['content'], resolved_message, flags=re.IGNORECASE)
+            resolved_message = re.sub(
+                f'\\${placeholder}\\$',
+                content['content'],
+                resolved_message,
+                flags=re.IGNORECASE,
+            )
 
     return resolved_message
-
 
 
 def get_background_images(file_obj, theme_data, header_only=False):

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -1217,7 +1217,15 @@ def resolve_i18n_message(message, messages, locale, default_locale=None):
         # See https://github.com/mozilla/addons-server/issues/3485
         return default['message']
 
-    return message['message']
+    resolved_message = message['message']
+    # Check if the message has placeholders
+    if 'placeholders' in message:
+        for placeholder, content in message['placeholders'].items():
+            # Replace the placeholder with its content
+            resolved_message = re.sub(f'\\${placeholder}\\$', content['content'], resolved_message, flags=re.IGNORECASE)
+
+    return resolved_message
+
 
 
 def get_background_images(file_obj, theme_data, header_only=False):


### PR DESCRIPTION
Fixes #20562 

Resolved an issue in the `resolve_i18n_message` function where placeholders in the message string were not being correctly replaced based on the `placeholders` section of the `messages.json` file. The function now correctly processes and replaces placeholders.

The change has been tested locally by hard-coding the `messages.json` file based on the provided documentation.

I will push tests in a future commit.