### PR TITLE
update abuse api to support reporter name&email and report to cinder

### DIFF
--- a/docs/topics/api/abuse.rst
+++ b/docs/topics/api/abuse.rst
@@ -58,6 +58,8 @@ to if necessary.
     :>json string reporter.name: The name of the user who submitted the report.
     :>json string reporter.username: The username of the user who submitted the report.
     :>json string reporter.url: The link to the profile page for of the user who submitted the report.
+    :>json string|null reporter_name: The provided name of the reporter, if not authenticated.
+    :>json string|null reporter_email: The provided email of the reporter, if not authenticated.
     :>json object addon: The add-on reported for abuse.
     :>json string addon.guid: The add-on `extension identifier <https://developer.mozilla.org/en-US/Add-ons/Install_Manifests#id>`_.
     :>json int|null addon.id: The add-on id on AMO, or ``null`` if the ``addon`` submitted was a guid.
@@ -227,6 +229,8 @@ so reports can be responded to if necessary.
     :>json string reporter.name: The name of the user who submitted the report.
     :>json string reporter.url: The link to the profile page for of the user who submitted the report.
     :>json string reporter.username: The username of the user who submitted the report.
+    :>json string|null reporter_name: The provided name of the reporter, if not authenticated.
+    :>json string|null reporter_email: The provided email of the reporter, if not authenticated.
     :>json object user: The user reported for abuse.
     :>json int user.id: The id of the user reported.
     :>json string user.name: The name of the user reported.

--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -464,6 +464,7 @@ These are `v5` specific changes - `v4` changes apply also.
 * 2023-06-06: added the /addons/browser-mappings/ endpoint. https://github.com/mozilla/addons-server/issues/20798
 * 2023-06-22: added ``versions`` to blocklist block endpoint. https://github.com/mozilla/addons-server/issues/20748
 * 2023-07-06: added ``is_all_versions`` to blocklist block endpoint. https://github.com/mozilla/addons-server/issues/20857
+* 2023-10-12: added ``reporter_name`` and ``reporter_email`` as two optional alternatives to an authenticated reporer in the abuse api. https://github.com/mozilla/addons-server/issues/21268
 
 .. _`#11380`: https://github.com/mozilla/addons-server/issues/11380/
 .. _`#11379`: https://github.com/mozilla/addons-server/issues/11379/

--- a/src/olympia/abuse/cinder.py
+++ b/src/olympia/abuse/cinder.py
@@ -46,15 +46,10 @@ class Cinder:
             'context': context,
         }
 
-    def report(self, reason, reporter_user):
+    def report(self, reason, reporter):
         if self.type is None:
             # type needs to be defined by subclasses
             raise NotImplementedError
-        reporter = (
-            reporter_user
-            and not reporter_user.is_anonymous()
-            and CinderUser(reporter_user)
-        )
         url = f'{settings.CINDER_SERVER_URL}create_report'
         headers = {
             'accept': 'application/json',
@@ -62,7 +57,6 @@ class Cinder:
             'authorization': f'Bearer {settings.CINDER_API_TOKEN}',
         }
         data = self.build_report_payload(reason, reporter)
-        print(data)
         response = requests.post(url, json=data, headers=headers)
         if response.status_code == 201:
             return response.json().get('job_id')
@@ -96,6 +90,28 @@ class CinderUser(Cinder):
                 self.get_relationship_data(addon, 'amo_author_of') for addon in addons
             ],
         }
+
+
+class CinderNonFxaUser(Cinder):
+    type = 'amo_unauthenticated_reporter'
+
+    def __init__(self, name, email):
+        self.name = name
+        self.email = email
+
+    def get_attributes(self):
+        return {
+            'id': f'{self.name} : {self.email}',
+            'name': self.name,
+            'email': self.email,
+        }
+
+    def get_context(self):
+        return {}
+
+    def report(self, reason, reporter):
+        # It doesn't make sense to report a non fxa user
+        raise NotImplementedError
 
 
 class CinderAddon(Cinder):

--- a/src/olympia/abuse/serializers.py
+++ b/src/olympia/abuse/serializers.py
@@ -5,10 +5,12 @@ from rest_framework import serializers
 
 import olympia.core.logger
 from olympia import amo
-from olympia.abuse.models import AbuseReport
 from olympia.accounts.serializers import BaseUserSerializer
 from olympia.api.fields import ReverseChoiceField
 from olympia.api.serializers import AMOModelSerializer
+
+from .models import AbuseReport
+from .tasks import report_to_cinder
 
 
 log = olympia.core.logger.getLogger('z.abuse')
@@ -16,10 +18,11 @@ log = olympia.core.logger.getLogger('z.abuse')
 
 class BaseAbuseReportSerializer(AMOModelSerializer):
     reporter = BaseUserSerializer(read_only=True)
+    reporter_email = serializers.EmailField(required=False)
 
     class Meta:
         model = AbuseReport
-        fields = ('message', 'reporter')
+        fields = ('message', 'reporter', 'reporter_name', 'reporter_email')
 
     def validate_target(self, data, target_name):
         if target_name not in data:
@@ -193,6 +196,13 @@ class AddonAbuseReportSerializer(BaseAbuseReportSerializer):
                 # want to reveal the slug or id of those add-ons.
                 pass
         return output
+
+    def create(self, validated_data):
+        instance = super().create(validated_data)
+        if validated_data.get('reason') in AbuseReport.REPORTABLE_REASONS:
+            # call task to fire off cinder report
+            report_to_cinder.delay(instance.id)
+        return instance
 
 
 class UserAbuseReportSerializer(BaseAbuseReportSerializer):

--- a/src/olympia/abuse/tests/test_cinder.py
+++ b/src/olympia/abuse/tests/test_cinder.py
@@ -1,9 +1,54 @@
+from django.conf import settings
+
+import responses
+
 from olympia.amo.tests import TestCase, addon_factory, user_factory
 
-from ..cinder import CinderAddon, CinderUser
+from ..cinder import CinderAddon, CinderNonFxaUser, CinderUser
 
 
-class TestCinderAddon(TestCase):
+class BaseTestCinderCase:
+    def _test_report(self, cinder_class):
+        responses.add(
+            responses.POST,
+            f'{settings.CINDER_SERVER_URL}create_report',
+            json={'job_id': '1234-xyz'},
+            status=201,
+        )
+        responses.add(
+            responses.POST,
+            f'{settings.CINDER_SERVER_URL}create_report',
+            json={'job_id': '1234-xyz'},
+            status=201,
+        )
+        responses.add(
+            responses.POST,
+            f'{settings.CINDER_SERVER_URL}create_report',
+            json={'job_id': '1234-xyz'},
+            status=201,
+        )
+        responses.add(
+            responses.POST,
+            f'{settings.CINDER_SERVER_URL}create_report',
+            json={'job_id': '1234-xyz'},
+            status=400,
+        )
+        assert cinder_class.report('reason', None) == '1234-xyz'
+        assert cinder_class.report('reason', CinderUser(user_factory())) == '1234-xyz'
+        assert (
+            cinder_class.report(
+                'reason', CinderNonFxaUser(name='name', email='e@ma.il')
+            )
+            == '1234-xyz'
+        )
+        with self.assertRaises(ConnectionError):
+            cinder_class.report('reason', None)
+
+    def test_report(self):
+        raise NotImplementedError
+
+
+class TestCinderAddon(BaseTestCinderCase, TestCase):
     def test_build_report_payload(self):
         addon = addon_factory()
         reason = 'bad addon!'
@@ -23,7 +68,33 @@ class TestCinderAddon(TestCase):
             'context': {'entities': [], 'relationships': []},
         }
 
-        # and if the reporter isn't anonymous
+        # if we have an email or name
+        name = 'Foxy McFox'
+        email = 'foxy@mozilla'
+        data = cinder_addon.build_report_payload(reason, CinderNonFxaUser(name, email))
+        assert data['context'] == {
+            'entities': [
+                {
+                    'entity_type': 'amo_unauthenticated_reporter',
+                    'attributes': {
+                        'id': f'{name} : {email}',
+                        'name': name,
+                        'email': email,
+                    },
+                }
+            ],
+            'relationships': [
+                {
+                    'source_id': f'{name} : {email}',
+                    'source_type': 'amo_unauthenticated_reporter',
+                    'target_id': str(addon.id),
+                    'target_type': 'amo_addon',
+                    'relationship_type': 'amo_reporter_of',
+                }
+            ],
+        }
+
+        # and if the reporter is authenticated
         reporter_user = user_factory()
         data = cinder_addon.build_report_payload(reason, CinderUser(reporter_user))
         assert data['context'] == {
@@ -79,7 +150,7 @@ class TestCinderAddon(TestCase):
             ],
         }
 
-        # and if the reporter isn't anonymous
+        # and if the reporter is authenticated
         reporter_user = user_factory()
         data = cinder_addon.build_report_payload(reason, CinderUser(reporter_user))
         assert data['context'] == {
@@ -121,8 +192,11 @@ class TestCinderAddon(TestCase):
             ],
         }
 
+    def test_report(self):
+        self._test_report(CinderAddon(addon_factory()))
 
-class TestCinderUser(TestCase):
+
+class TestCinderUser(BaseTestCinderCase, TestCase):
     def test_build_report_payload(self):
         user = user_factory()
         reason = 'bad person!'
@@ -141,7 +215,34 @@ class TestCinderUser(TestCase):
             'reasoning': reason,
             'context': {'entities': [], 'relationships': []},
         }
-        # and if the reporter isn't anonymous
+
+        # if we have an email or name
+        name = 'Foxy McFox'
+        email = 'foxy@mozilla'
+        data = cinder_user.build_report_payload(reason, CinderNonFxaUser(name, email))
+        assert data['context'] == {
+            'entities': [
+                {
+                    'entity_type': 'amo_unauthenticated_reporter',
+                    'attributes': {
+                        'id': f'{name} : {email}',
+                        'name': name,
+                        'email': email,
+                    },
+                }
+            ],
+            'relationships': [
+                {
+                    'source_id': f'{name} : {email}',
+                    'source_type': 'amo_unauthenticated_reporter',
+                    'target_id': str(user.id),
+                    'target_type': 'amo_user',
+                    'relationship_type': 'amo_reporter_of',
+                }
+            ],
+        }
+
+        # and if the reporter is authenticated
         reporter_user = user_factory()
         data = cinder_user.build_report_payload(reason, CinderUser(reporter_user))
         assert data['context'] == {
@@ -197,7 +298,7 @@ class TestCinderUser(TestCase):
             ],
         }
 
-        # and if the reporter isn't anonymous
+        # and if the reporter is authenticated
         reporter_user = user_factory()
         data = cinder_user.build_report_payload(reason, CinderUser(reporter_user))
         assert data['context'] == {
@@ -238,3 +339,6 @@ class TestCinderUser(TestCase):
                 },
             ],
         }
+
+    def test_report(self):
+        self._test_report(CinderUser(user_factory()))

--- a/src/olympia/abuse/tests/test_serializers.py
+++ b/src/olympia/abuse/tests/test_serializers.py
@@ -36,6 +36,8 @@ class TestAddonAbuseReportSerializer(TestCase):
         serialized = self.serialize(report, context=context)
         assert serialized == {
             'reporter': None,
+            'reporter_email': None,
+            'reporter_name': None,
             'addon': {'guid': addon.guid, 'id': addon.pk, 'slug': addon.slug},
             'message': 'bad stuff',
             'addon_install_method': None,
@@ -63,6 +65,8 @@ class TestAddonAbuseReportSerializer(TestCase):
         serialized = self.serialize(report)
         assert serialized == {
             'reporter': None,
+            'reporter_email': None,
+            'reporter_name': None,
             'addon': {'guid': addon.guid, 'id': None, 'slug': None},
             'message': 'bad stuff',
             'addon_install_method': None,
@@ -89,6 +93,8 @@ class TestAddonAbuseReportSerializer(TestCase):
         serialized = self.serialize(report)
         assert serialized == {
             'reporter': None,
+            'reporter_email': None,
+            'reporter_name': None,
             'addon': {'guid': '@guid', 'id': None, 'slug': None},
             'message': 'bad stuff',
             'addon_install_method': None,
@@ -252,6 +258,8 @@ class TestUserAbuseReportSerializer(TestCase):
         serialized_user = BaseUserSerializer(user).data
         assert serialized == {
             'reporter': None,
+            'reporter_email': None,
+            'reporter_name': None,
             'user': serialized_user,
             'message': 'bad stuff',
         }

--- a/src/olympia/api/utils.py
+++ b/src/olympia/api/utils.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 
 from extended_choices import Choices
+from extended_choices.helpers import ChoiceEntry
 
 
 def is_gate_active(request, name):
@@ -16,10 +17,18 @@ def is_gate_active(request, name):
     return name in gates
 
 
+class APIChoiceEntry(ChoiceEntry):
+    @property
+    def api_value(self):
+        return str(self.value).lower() if self.value else self.value
+
+
 class APIChoices(Choices):
     """Like a regular extended_choices.Choices class, with an extra api_choices
     property that exposes constants in lower-case, meant to be used as choices
     in an API."""
+
+    ChoiceEntryClass = APIChoiceEntry
 
     @property
     def api_choices(self):

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -840,6 +840,7 @@ CELERY_TASK_ROUTES = {
     'olympia.files.tasks.extract_host_permissions': {'queue': 'adhoc'},
     # Misc AMO tasks.
     'olympia.blocklist.tasks.monitor_remote_settings': {'queue': 'amo'},
+    'olympia.abuse.tasks.report_to_cinder': {'queue': 'amo'},
     'olympia.accounts.tasks.clear_sessions_event': {'queue': 'amo'},
     'olympia.accounts.tasks.delete_user_event': {'queue': 'amo'},
     'olympia.accounts.tasks.primary_email_change_event': {'queue': 'amo'},


### PR DESCRIPTION
fixes #21268 - and some changes to cinder.py too to handle non-authenticated users providing name and email instead.   