### PR TITLE
Trigger change event to reset custom validity when Firefox for Android is checked

### DIFF
--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -1372,6 +1372,7 @@ function initSubmitModals() {
             // in a setTimeout() to force it to wait for the event to be
             // processed.
             $input.prop('checked', !$input.prop('checked'));
+            $input.trigger('change');
           }, 0);
         }
         return !confirmedOnce;
@@ -1383,6 +1384,7 @@ function initSubmitModals() {
       .on('submit', function onSubmit(e) {
         e.preventDefault();
         $input.prop('checked', true);
+        $input.trigger('change');
         $modalAndroidConfirm.trigger('close');
         confirmedOnce = true;
       });


### PR DESCRIPTION
The modal calls `e.preventsDefault()`, so the click never goes through, preventing change event from firing normally, which in turn leaves our custom validity enabled and triggers a validation error on submit. Manually triggering change works around this

Fixes #21294