### PR TITLE
Update serializers.py

### DIFF
--- a/src/olympia/abuse/serializers.py
+++ b/src/olympia/abuse/serializers.py
@@ -19,7 +19,7 @@ log = olympia.core.logger.getLogger('z.abuse')
 
 class BaseAbuseReportSerializer(AMOModelSerializer):
     reporter = BaseUserSerializer(read_only=True)
-    reporter_email = serializers.EmailField(required=False)
+    reporter_email = serializers.EmailField(required=False, allow_null=True)
 
     class Meta:
         model = AbuseReport


### PR DESCRIPTION
Needed fix for the frontend patch (it was an advertent change when I specified `EmailField` for `reporter_email` - when the field was generated from the model it would have allowed null because the underlying model field does)