### PR TITLE
Bump minimum version for Android general availability to 120.0a1

### DIFF
--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -1717,7 +1717,7 @@ class TestAddonViewSetCreate(UploadMixin, AddonViewSetCreateUpdateMixin, TestCas
         assert response.data['version'] == {
             'compatibility': [
                 'Invalid version range. For Firefox for Android, you may only pick a '
-                'range that starts with version 119.0a1 or higher, or ends with lower '
+                'range that starts with version 120.0a1 or higher, or ends with lower '
                 'than version 79.0a1.'
             ]
         }
@@ -1726,7 +1726,7 @@ class TestAddonViewSetCreate(UploadMixin, AddonViewSetCreateUpdateMixin, TestCas
         request_data = {
             'version': {
                 'upload': self.upload.uuid,
-                'compatibility': {'android': {'min': '119.0a1', 'max': '*'}},
+                'compatibility': {'android': {'min': '120.0a1', 'max': '*'}},
             }
         }
         response = self.request(data=request_data)
@@ -3290,7 +3290,7 @@ class VersionViewSetCreateUpdateMixin(RequestMixin):
         assert response.data == {
             'compatibility': [
                 'Invalid version range. For Firefox for Android, you may only pick a '
-                'range that starts with version 119.0a1 or higher, or ends with lower '
+                'range that starts with version 120.0a1 or higher, or ends with lower '
                 'than version 79.0a1.'
             ]
         }
@@ -3306,7 +3306,7 @@ class VersionViewSetCreateUpdateMixin(RequestMixin):
         assert response.data == {
             'compatibility': [
                 'Invalid version range. For Firefox for Android, you may only pick a '
-                'range that starts with version 119.0a1 or higher, or ends with lower '
+                'range that starts with version 120.0a1 or higher, or ends with lower '
                 'than version 79.0a1.'
             ]
         }

--- a/src/olympia/constants/base.py
+++ b/src/olympia/constants/base.py
@@ -365,7 +365,7 @@ MAX_VERSION_FENNEC = '68.*'
 
 # The minimum version of Fenix where extensions are all available. Expect this
 # to be bumped to 120.0 later.
-MIN_VERSION_FENIX_GENERAL_AVAILABILITY = '119.0a1'
+MIN_VERSION_FENIX_GENERAL_AVAILABILITY = '120.0a1'
 
 ADDON_GUID_PATTERN = re.compile(
     # Match {uuid} or something@host.tld ("something" being optional)

--- a/src/olympia/devhub/tests/test_forms.py
+++ b/src/olympia/devhub/tests/test_forms.py
@@ -294,8 +294,8 @@ class TestCompatForm(TestCase):
             '79.0',
             '79.*',
             '113.0',
-            '119.0a1',
-            '119.0',
+            '120.0a1',
+            '120.0',
             '*',
         ):
             AppVersion.objects.get_or_create(
@@ -416,7 +416,7 @@ class TestCompatForm(TestCase):
                 version='48.0'
             ),
             'form-1-max': AppVersion.objects.filter(application=amo.ANDROID.id).get(
-                version='119.0a1'
+                version='120.0a1'
             ),
             'form-1-application': amo.ANDROID.id,
             'form-1-id': '',
@@ -432,7 +432,7 @@ class TestCompatForm(TestCase):
             {
                 '__all__': [
                     'Invalid version range. For Firefox for Android, you may only pick '
-                    'a range that starts with version 119.0a1 or higher, or ends with '
+                    'a range that starts with version 120.0a1 or higher, or ends with '
                     'lower than version 79.0a1.'
                 ]
             },
@@ -448,7 +448,7 @@ class TestCompatForm(TestCase):
 
         # That range is valid because it's entirely above Fenix GA
         data['form-1-min'] = AppVersion.objects.get(
-            application=amo.ANDROID.id, version='119.0a1'
+            application=amo.ANDROID.id, version='120.0a1'
         )
         data['form-1-max'] = AppVersion.objects.get(
             application=amo.ANDROID.id, version='*'
@@ -493,7 +493,7 @@ class TestCompatForm(TestCase):
                 version='48.0'
             ),
             'form-1-max': AppVersion.objects.filter(application=amo.ANDROID.id).get(
-                version='119.0a1'
+                version='120.0a1'
             ),
             'form-1-application': amo.ANDROID.id,
             'form-1-id': '',

--- a/src/olympia/versions/management/commands/bump_min_android_compatibility.py
+++ b/src/olympia/versions/management/commands/bump_min_android_compatibility.py
@@ -1,0 +1,36 @@
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+import olympia.core.logger
+from olympia import amo
+from olympia.applications.models import AppVersion
+from olympia.versions.compare import version_int
+from olympia.versions.models import ApplicationsVersions
+
+
+log = olympia.core.logger.getLogger('z.versions.bump_min_android_compatibility')
+
+
+class Command(BaseCommand):
+    """
+    Bump minimum Firefox for Android compatibility to
+    <MIN_VERSION_FENIX_GENERAL_AVAILABILITY>.
+
+    This command should be reused everytime we change the value of
+    MIN_VERSION_FENIX_GENERAL_AVAILABILITY (in either direction, as long as
+    it's higher than 119.0a1).
+    """
+
+    def handle(self, **kwargs):
+        new_minimum = AppVersion.objects.get(
+            application=amo.ANDROID.id,
+            version=settings.MIN_VERSION_FENIX_GENERAL_AVAILABILITY,
+        )
+        qs = ApplicationsVersions.objects.filter(
+            application=amo.ANDROID.id,
+            # 119.0a1 is the first version we started to set as the minimum, so
+            # that's the first version we'll need to start bumping from, and
+            # will remain true in the future, it can be hardcoded.
+            min__version_int__gte=version_int('119.0a1'),
+        )
+        qs.update(min=new_minimum)

--- a/src/olympia/versions/management/commands/force_max_android_compatibility.py
+++ b/src/olympia/versions/management/commands/force_max_android_compatibility.py
@@ -55,8 +55,8 @@ class Command(BaseCommand):
                     version__addon__promotedaddon__application_id=amo.FIREFOX.id
                 )  # Promoted, but for Firefox only (not Android / not both)
             )
-            # If they are already marked as compatible with 119.0a1, we don't
-            # care.
+            # If they are already marked as compatible with GA version, we
+            # don't care.
             .filter(min__version_int__lt=min_version_fenix.version_int)
         )
         # If the min is also over 68.* then it means the developer marked it


### PR DESCRIPTION
Includes command to migrate existing compatibility

Fixes #21293