### PR TITLE
Fix bump_min_android_compatibility command (constant not a setting)

### DIFF
--- a/src/olympia/versions/management/commands/bump_min_android_compatibility.py
+++ b/src/olympia/versions/management/commands/bump_min_android_compatibility.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.core.management.base import BaseCommand
 
 import olympia.core.logger
@@ -24,7 +23,7 @@ class Command(BaseCommand):
     def handle(self, **kwargs):
         new_minimum = AppVersion.objects.get(
             application=amo.ANDROID.id,
-            version=settings.MIN_VERSION_FENIX_GENERAL_AVAILABILITY,
+            version=amo.MIN_VERSION_FENIX_GENERAL_AVAILABILITY,
         )
         qs = ApplicationsVersions.objects.filter(
             application=amo.ANDROID.id,

--- a/src/olympia/versions/tests/test_commands.py
+++ b/src/olympia/versions/tests/test_commands.py
@@ -1,11 +1,10 @@
 import csv
 import os
 import tempfile
+from unittest import mock
 
-from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import CommandError
-from django.test.utils import override_settings
 
 from olympia import amo
 from olympia.amo.tests import TestCase, addon_factory, version_factory
@@ -436,11 +435,11 @@ class TestBumpMinAndroidCompatibility(TestCase):
     # Force MIN_VERSION_FENIX_GENERAL_AVAILABILITY to 119.0a1 so that we can
     # set the ApplicationsVersions to that value in the test data we're
     # creating. It's overridden below when triggering call_command().
-    @override_settings(MIN_VERSION_FENIX_GENERAL_AVAILABILITY='119.0a1')
+    @mock.patch.object(amo, 'MIN_VERSION_FENIX_GENERAL_AVAILABILITY', '119.0a1')
     def test_basic(self):
         AppVersion.objects.get_or_create(
             application=amo.ANDROID.id,
-            version=settings.MIN_VERSION_FENIX_GENERAL_AVAILABILITY,
+            version=amo.MIN_VERSION_FENIX_GENERAL_AVAILABILITY,
         )
         new_min_android_ga_version = '120.0a1'
         AppVersion.objects.get_or_create(
@@ -491,8 +490,8 @@ class TestBumpMinAndroidCompatibility(TestCase):
             ),
         ]
 
-        with override_settings(
-            MIN_VERSION_FENIX_GENERAL_AVAILABILITY=new_min_android_ga_version
+        with mock.patch.object(
+            amo, 'MIN_VERSION_FENIX_GENERAL_AVAILABILITY', new_min_android_ga_version
         ):
             call_command('bump_min_android_compatibility')
 


### PR DESCRIPTION
Follow-up fix for https://github.com/mozilla/addons-server/issues/21293