### PR TITLE
Allow arguments to be passed to update_and_clean_categories command

### DIFF
--- a/src/olympia/addons/management/commands/update_and_clean_categories.py
+++ b/src/olympia/addons/management/commands/update_and_clean_categories.py
@@ -75,6 +75,6 @@ class Command(BaseCommand):
             count += loop_count
         log.info('Done deleting %d obsolete categories', count)
 
-    def handle(self):
+    def handle(self, *args, **kwargs):
         self.add_new_categories_for_old_android_categories()
         self.delete_old_categories()


### PR DESCRIPTION
Follow-up for #5989 - `handle()` always need this to allow for `verbosity` to be passed.