### PR TITLE
Add vscode urls to the review page

### DIFF
--- a/src/olympia/reviewers/templates/reviewers/includes/files_view.html
+++ b/src/olympia/reviewers/templates/reviewers/includes/files_view.html
@@ -4,19 +4,19 @@
   &middot;
   <a href="{{ url('devhub.file_validation', addon.slug, file.id) }}">Validation results</a>
   &middot;
+  <a 
+    class="assay"
+    href="vscode://mozilla.assay/review/{{addon.guid}}/{{version}}"
+    title="Download this version in the VS Code addon reviewer"
+    >
+      Open in VSC
+  </a>
+  &middot;
   <a
     href="{{ code_manager_url('browse', addon.pk, version.pk) }}"
     title="Browse all files in this version"
     >
       Browse contents
-  </a>
-  &middot;
-  <a 
-    class="assay"
-    href="vscode://mozilla.assay/review/{{addon.guid}}/{{version}}"
-    title="Download this version in the Assay addon reviewer"
-    >
-      Open in Assay
   </a>
   {% if base_version_pk and version == latest_not_disabled_version %}
   &middot;

--- a/src/olympia/reviewers/templates/reviewers/includes/files_view.html
+++ b/src/olympia/reviewers/templates/reviewers/includes/files_view.html
@@ -7,7 +7,7 @@
   <a 
     class="assay"
     href="vscode://mozilla.assay/review/{{addon.guid}}/{{version}}"
-    title="Download this version in the VS Code addon reviewer"
+    title="Open this version in Visual Studio Code"
     >
       Open in VSC
   </a>

--- a/src/olympia/reviewers/templates/reviewers/includes/files_view.html
+++ b/src/olympia/reviewers/templates/reviewers/includes/files_view.html
@@ -10,6 +10,12 @@
     >
       Browse contents
   </a>
+  &middot;
+  <a 
+    href="vscode://mozilla.assay/review/{{addon.guid}}/{{version}}"
+    title="Download this version in the Assay addon reviewer">
+    Open in Assay
+  </a>
   {% if base_version_pk and version == latest_not_disabled_version %}
   &middot;
   <a

--- a/src/olympia/reviewers/templates/reviewers/includes/files_view.html
+++ b/src/olympia/reviewers/templates/reviewers/includes/files_view.html
@@ -12,9 +12,11 @@
   </a>
   &middot;
   <a 
+    class="assay"
     href="vscode://mozilla.assay/review/{{addon.guid}}/{{version}}"
-    title="Download this version in the Assay addon reviewer">
-    Open in Assay
+    title="Download this version in the Assay addon reviewer"
+    >
+      Open in Assay
   </a>
   {% if base_version_pk and version == latest_not_disabled_version %}
   &middot;

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -3837,9 +3837,12 @@ class TestReview(ReviewBase):
         assert response.status_code == 200
         doc = pq(response.content)
         assay_info = doc('#versions-history .file-info .assay')
-        assert assay_info[0].text.strip() == "Open in Assay"
-        assert assay_info.attr['href'] == f'vscode://mozilla.assay/review/{self.addon.guid}/{self.addon.current_version.version}'
-    
+        assert assay_info[0].text.strip() == 'Open in VSC'
+        assert (
+            assay_info.attr['href']
+            == f'vscode://mozilla.assay/review/{self.addon.guid}/{self.addon.current_version.version}'
+        )
+
     def test_compare_link(self):
         first_file = self.addon.current_version.file
         first_file.update(status=amo.STATUS_APPROVED)

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -3516,9 +3516,10 @@ class TestReview(ReviewBase):
 
         validation = doc.find('.files')
         assert validation.find('a').eq(1).text() == 'Validation results'
-        assert validation.find('a').eq(2).text() == 'Browse contents'
+        assert validation.find('a').eq(2).text() == 'Open in VSC'
+        assert validation.find('a').eq(3).text() == 'Browse contents'
 
-        assert validation.find('a').length == 3
+        assert validation.find('a').length == 4
 
     def test_version_deletion(self):
         """

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -2542,6 +2542,7 @@ class TestReview(ReviewBase):
                 'Validation results',
                 reverse('devhub.file_validation', args=[self.addon.slug, file_.id]),
             ),
+            ('Open in VSC', None),
             ('Browse contents', None),
         ]
         check_links(expected, items.find('a'), verify=False)

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -3831,6 +3831,15 @@ class TestReview(ReviewBase):
         assert info.find('a')[0].text == 'Download'
         assert b'Compatibility' not in response.content
 
+    def test_assay_link(self):
+        self.addon.current_version.update()
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        assay_info = doc('#versions-history .file-info .assay')
+        assert assay_info[0].text.strip() == "Open in Assay"
+        assert assay_info.attr['href'] == f'vscode://mozilla.assay/review/{self.addon.guid}/{self.addon.current_version.version}'
+    
     def test_compare_link(self):
         first_file = self.addon.current_version.file
         first_file.update(status=amo.STATUS_APPROVED)


### PR DESCRIPTION
Fixes #21403 

<img width="336" alt="Screenshot 2023-11-07 at 7 45 43 PM" src="https://github.com/mozilla/addons-server/assets/63402349/988a211f-c7fc-471b-837b-6a1d84e79ca5">

Adds in this link that opens vscode to download the addon.