### PR TITLE
return 200 for an unhandled webhook decison, with the reason

### DIFF
--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timedelta
 
-from django.core.exceptions import ValidationError
 from django.db import models
 
 from extended_choices import Choices
@@ -475,19 +474,11 @@ class CinderReport(ModelBase):
         )
         self.update(job_id=job_id)
 
-    def process_decision(self, *, decision_id, decision_date, decision_actions):
-        if (
-            not decision_actions
-            or len(decision_actions) > 1
-            or not self.DECISION_ACTIONS.has_api_value(decision_actions[0])
-        ):
-            raise ValidationError('decision_actions malformed')
+    def process_decision(self, *, decision_id, decision_date, decision_action):
         self.update(
             decision_id=decision_id,
             decision_date=decision_date,
-            decision_action=self.DECISION_ACTIONS.for_api_value(
-                decision_actions[0]
-            ).value,
+            decision_action=decision_action,
         )
         self.get_action_helper().process()
 

--- a/src/olympia/abuse/tests/assets/cinder_webhook.json
+++ b/src/olympia/abuse/tests/assets/cinder_webhook.json
@@ -4,16 +4,14 @@
         "appeal": {
             "appealed_decision": {
                 "enforcement_actions": [
-                    "delete-status",
-                    "freeze-account"
+                    "amo_disable_addon"
                 ],
                 "id": "ae106e36-700c-4668-9618-851451dc5c2c",
                 "notes": "",
                 "policies": [
                     {
                         "enforcement_actions": [
-                            "delete-status",
-                            "freeze-account"
+                            "amo_disable_addon"
                         ],
                         "id": "f73ad527-54ed-430c-86ff-80e15e2a352b",
                         "is_illegal": false,
@@ -36,8 +34,7 @@
             }
         },
         "enforcement_actions": [
-            "delete-status",
-            "freeze-account"
+            "amo_disable_addon"
         ],
         "entity": {
             "attributes": {
@@ -52,8 +49,7 @@
         "policies": [
             {
                 "enforcement_actions": [
-                    "delete-status",
-                    "freeze-account"
+                    "amo_disable_addon"
                 ],
                 "id": "f73ad527-54ed-430c-86ff-80e15e2a352b",
                 "is_illegal": false,

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -451,7 +451,7 @@ class TestCinderReport(TestCase):
             cinder_report.process_decision(
                 decision_id='12345',
                 decision_date=new_date,
-                decision_actions=['amo_approve'],
+                decision_action=CinderReport.DECISION_ACTIONS.AMO_APPROVE.value,
             )
         assert cinder_report.decision_id == '12345'
         assert cinder_report.decision_date == new_date
@@ -459,36 +459,6 @@ class TestCinderReport(TestCase):
             CinderReport.DECISION_ACTIONS.AMO_APPROVE
         )
         assert cinder_action_mock.call_count == 1
-
-    def test_process_decision_invalid_actions(self):
-        cinder_report = CinderReport.objects.create(
-            abuse_report=AbuseReport.objects.create(
-                guid=addon_factory().guid, reason=AbuseReport.REASONS.ILLEGAL
-            )
-        )
-        with self.assertRaises(ValidationError):
-            # no decision actions
-            cinder_report.process_decision(
-                decision_id='12345',
-                decision_date=datetime(2023, 1, 1),
-                decision_actions=[],
-            )
-        with self.assertRaises(ValidationError):
-            # more than one decision action
-            cinder_report.process_decision(
-                decision_id='12345',
-                decision_date=datetime(2023, 1, 1),
-                decision_actions=[
-                    'amo_approve',
-                    'amo_disable_addon',
-                ],
-            )
-        with self.assertRaises(ValidationError):
-            cinder_report.process_decision(
-                decision_id='12345',
-                decision_date=datetime(2023, 1, 1),
-                decision_actions=['some_other_action'],
-            )
 
     def test_can_be_appealed(self):
         cinder_report = CinderReport.objects.create(

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -451,7 +451,7 @@ class TestCinderReport(TestCase):
             cinder_report.process_decision(
                 decision_id='12345',
                 decision_date=new_date,
-                decision_actions=[CinderReport.DECISION_ACTIONS.AMO_APPROVE],
+                decision_actions=['amo_approve'],
             )
         assert cinder_report.decision_id == '12345'
         assert cinder_report.decision_date == new_date
@@ -459,6 +459,36 @@ class TestCinderReport(TestCase):
             CinderReport.DECISION_ACTIONS.AMO_APPROVE
         )
         assert cinder_action_mock.call_count == 1
+
+    def test_process_decision_invalid_actions(self):
+        cinder_report = CinderReport.objects.create(
+            abuse_report=AbuseReport.objects.create(
+                guid=addon_factory().guid, reason=AbuseReport.REASONS.ILLEGAL
+            )
+        )
+        with self.assertRaises(ValidationError):
+            # no decision actions
+            cinder_report.process_decision(
+                decision_id='12345',
+                decision_date=datetime(2023, 1, 1),
+                decision_actions=[],
+            )
+        with self.assertRaises(ValidationError):
+            # more than one decision action
+            cinder_report.process_decision(
+                decision_id='12345',
+                decision_date=datetime(2023, 1, 1),
+                decision_actions=[
+                    'amo_approve',
+                    'amo_disable_addon',
+                ],
+            )
+        with self.assertRaises(ValidationError):
+            cinder_report.process_decision(
+                decision_id='12345',
+                decision_date=datetime(2023, 1, 1),
+                decision_actions=['some_other_action'],
+            )
 
     def test_can_be_appealed(self):
         cinder_report = CinderReport.objects.create(

--- a/src/olympia/abuse/tests/test_views.py
+++ b/src/olympia/abuse/tests/test_views.py
@@ -2,7 +2,7 @@ import hashlib
 import hmac
 import json
 import os
-from datetime import datetime, timezone
+from datetime import datetime
 from unittest import mock
 
 from django.test.utils import override_settings
@@ -823,10 +823,8 @@ class TestCinderWebhook(TestCase):
             process_mock.assert_called()
             process_mock.assert_called_with(
                 decision_id='d1f01fae-3bce-41d5-af8a-e0b4b5ceaaed',
-                decision_date=datetime(
-                    2023, 10, 12, 9, 8, 37, 4789, tzinfo=timezone.utc
-                ),
-                decision_actions=['delete-status', 'freeze-account'],
+                decision_date=datetime(2023, 10, 12, 9, 8, 37, 4789),
+                decision_action=CinderReport.DECISION_ACTIONS.AMO_DISABLE_ADDON.value,
             )
         assert response.status_code == 201
         assert response.data == {'amo': {'received': True, 'handled': True}}
@@ -883,14 +881,14 @@ class TestCinderWebhook(TestCase):
         self._setup_report()
         data = self.get_data()
         data['payload']['enforcement_actions'] = []
-        req = self.get_request()
+        req = self.get_request(data=data)
         response = cinder_webhook(req)
         assert response.status_code == 200
         assert response.data == {
             'amo': {
                 'received': True,
                 'handled': False,
-                'not_handled_reason': "Payload invalid: ['decision_actions malformed']",
+                'not_handled_reason': 'Payload invalid: "decision_actions" malformed',
             }
         }
 

--- a/src/olympia/abuse/views.py
+++ b/src/olympia/abuse/views.py
@@ -221,6 +221,8 @@ def cinder_webhook(request):
                     'not_handled_reason': exc.message,
                 }
             },
+            # cinder will retry indefinately on 4xx or 5xx so we return 200 even when
+            # it's an error
             status=status.HTTP_200_OK,
         )
     return Response(

--- a/src/olympia/abuse/views.py
+++ b/src/olympia/abuse/views.py
@@ -1,6 +1,6 @@
 import hashlib
 import hmac
-from datetime import datetime
+from datetime import datetime, timezone
 
 from django import forms
 from django.conf import settings
@@ -157,7 +157,11 @@ class CinderInboundPermission:
 
 def process_datestamp(date_string):
     try:
-        return datetime.fromisoformat(date_string.replace(' ', ''))
+        return (
+            datetime.fromisoformat(date_string.replace(' ', ''))
+            .astimezone(timezone.utc)
+            .replace(tzinfo=None)
+        )
     except ValueError:
         log.warn('Invalid timestamp from cinder webhook %s', date_string)
         return datetime.now()
@@ -167,55 +171,61 @@ def process_datestamp(date_string):
 @authentication_classes(())
 @permission_classes((CinderInboundPermission,))
 def cinder_webhook(request):
-    not_handled_reason = None
-    if request.data.get('event') == 'decision.created' and (
-        payload := request.data.get('payload', {})
-    ):
+    try:
+        if request.data.get('event') != 'decision.created':
+            log.info('Non-decision payload received: %s', str(request.data)[:255])
+            raise ValidationError('Not a decision')
+
+        if not (payload := request.data.get('payload', {})):
+            log.info('No payload received: %s', str(request.data)[:255])
+            raise ValidationError('No payload')
+
         source = payload.get('source', {})
         job = source.get('job', {})
-        if (queue_name := job.get('queue', {}).get('slug')) == CinderEntity.queue:
-            log.info('Valid Payload from AMO queue: %s', payload)
-            job_id = job.get('id', '')
-            decision_id = source.get('decision', {}).get('id')
-            actions = payload.get('enforcement_actions')
-            try:
-                cinder_report = CinderReport.objects.get(job_id=job_id)
-                cinder_report.process_decision(
-                    decision_id=decision_id,
-                    decision_date=process_datestamp(payload.get('timestamp')),
-                    decision_actions=actions,
-                )
-            except CinderReport.DoesNotExist:
-                log.debug('CinderReport instance not found for job id %s', job_id)
-                not_handled_reason = 'No matching job id found'
-            except ValidationError as exc:
-                log.exception(
-                    'Cinder webhook request failed process_decision', exc_info=exc
-                )
-                not_handled_reason = f'Payload invalid: {exc}'
-        else:
+        if (queue_name := job.get('queue', {}).get('slug')) != CinderEntity.queue:
             log.info('Payload from other queue: %s', queue_name)
-            not_handled_reason = 'Not from a queue we process'
-    else:
-        log.info(
-            'Non-decision payload received: %s',
-            str(request.data)[:255],
-        )
-        not_handled_reason = 'Not a decision'
+            raise ValidationError('Not from a queue we process')
 
+        if (
+            not (actions := payload.get('enforcement_actions'))
+            or len(actions) > 1
+            or not CinderReport.DECISION_ACTIONS.has_api_value(actions[0])
+        ):
+            log.exception(
+                'Cinder webhook request failed: bad enforcement_actions [%s]', actions
+            )
+            raise ValidationError('Payload invalid: "decision_actions" malformed')
+
+        log.info('Valid Payload from AMO queue: %s', payload)
+        job_id = job.get('id', '')
+        try:
+            cinder_report = CinderReport.objects.get(job_id=job_id)
+        except CinderReport.DoesNotExist:
+            log.debug('CinderReport instance not found for job id %s', job_id)
+            raise ValidationError('No matching job id found')
+
+        cinder_report.process_decision(
+            decision_id=source.get('decision', {}).get('id'),
+            decision_date=process_datestamp(payload.get('timestamp')),
+            decision_action=CinderReport.DECISION_ACTIONS.for_api_value(
+                actions[0]
+            ).value,
+        )
+
+    except ValidationError as exc:
+        return Response(
+            data={
+                'amo': {
+                    'received': True,
+                    'handled': False,
+                    'not_handled_reason': exc.message,
+                }
+            },
+            status=status.HTTP_200_OK,
+        )
     return Response(
-        data={
-            'amo': {
-                'received': True,
-                'handled': not bool(not_handled_reason),
-                **(
-                    {'not_handled_reason': not_handled_reason}
-                    if not_handled_reason
-                    else {}
-                ),
-            }
-        },
-        status=status.HTTP_200_OK if not_handled_reason else status.HTTP_201_CREATED,
+        data={'amo': {'received': True, 'handled': True}},
+        status=status.HTTP_201_CREATED,
     )
 
 

--- a/src/olympia/api/utils.py
+++ b/src/olympia/api/utils.py
@@ -34,6 +34,12 @@ class APIChoices(Choices):
     def api_choices(self):
         return tuple((entry[1], entry[0].lower()) for entry in self.entries)
 
+    def has_api_value(self, value):
+        return self.has_constant(value.upper() if value else value)
+
+    def for_api_value(self, value):
+        return self.for_constant(value.upper() if value else value)
+
 
 class APIChoicesWithNone(APIChoices):
     """Like APIChoices, but also returns 'None' as a valid choice for `choices`


### PR DESCRIPTION
fixes #21402 and notably also fixes a bug in #21376 - it wasn't being converted from the api value to the int value, and tests didn't pick it up because the calls were mocked 😐 