### PR TITLE
Add feedback_spam as one of the possible reasons for user reports

### DIFF
--- a/docs/topics/api/abuse.rst
+++ b/docs/topics/api/abuse.rst
@@ -271,6 +271,7 @@ so reports can be responded to if necessary.
  ===========================  ================================================================
    hateful_violent_deceptive  Hateful, violent, deceptive, or other inappropriate content
                      illegal  Violates the law or contains content that violates the law
+               feedback_spam  Spam
                        other  Something else
  ===========================  ================================================================
 

--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -121,8 +121,10 @@ class AbuseReport(ModelBase):
         ),
         ('OTHER', 127, 'Other'),
     )
+    # Base reasons shared by all on-AMO content using AMO Feedback flow.
     REASONS.add_subset(
-        'CONTENT_REASONS', ('HATEFUL_VIOLENT_DECEPTIVE', 'ILLEGAL', 'OTHER')
+        'CONTENT_REASONS',
+        ('HATEFUL_VIOLENT_DECEPTIVE', 'ILLEGAL', 'FEEDBACK_SPAM', 'OTHER'),
     )
     # Those reasons will be reported to Cinder.
     REASONS.add_subset(


### PR DESCRIPTION
(Technically allows it for ratings too, but unused/undocumented at
 the moment as the plan is to use the old flagging system for those)

Follow-up for https://github.com/mozilla/addons-server/issues/21386