### PR TITLE
Fix stats menu items indentation

### DIFF
--- a/src/olympia/stats/templates/stats/addon_report_menu.html
+++ b/src/olympia/stats/templates/stats/addon_report_menu.html
@@ -6,41 +6,41 @@
     {% if has_listed_versions %}
     <li data-report="downloads">
       <a href="{{ url('stats.downloads', slug_or_id) }}">{{ _('Downloads') }}</a>
+      <ul>
+        <li data-report="sources">
+          <a href="{{ url('stats.sources', slug_or_id) }}">{{ _('by Source') }}</a>
+        </li>
+        <li data-report="mediums">
+          <a href="{{ url('stats.mediums', slug_or_id) }}">{{ _('by Medium') }}</a>
+        </li>
+        <li data-report="contents">
+          <a href="{{ url('stats.contents', slug_or_id) }}">{{ _('by Content') }}</a>
+        </li>
+        <li data-report="campaigns">
+          <a href="{{ url('stats.campaigns', slug_or_id) }}">{{ _('by Campaign') }}</a>
+        </li>
+      </ul>
     </li>
-    <ul>
-      <li data-report="sources">
-        <a href="{{ url('stats.sources', slug_or_id) }}">{{ _('by Source') }}</a>
-      </li>
-      <li data-report="mediums">
-        <a href="{{ url('stats.mediums', slug_or_id) }}">{{ _('by Medium') }}</a>
-      </li>
-      <li data-report="contents">
-        <a href="{{ url('stats.contents', slug_or_id) }}">{{ _('by Content') }}</a>
-      </li>
-      <li data-report="campaigns">
-        <a href="{{ url('stats.campaigns', slug_or_id) }}">{{ _('by Campaign') }}</a>
-      </li>
-    </ul>
     {% endif %}
     <li data-report="usage">
       <a href="{{ url('stats.usage', slug_or_id) }}">{{ _('Daily Users') }}</a>
+      <ul>
+        <li data-report="versions">
+          <a href="{{ url('stats.versions', slug_or_id) }}">{{ _('by Add-on Version') }}</a>
+        </li>
+        <li data-report="apps">
+          <a href="{{ url('stats.apps', slug_or_id) }}">{{ _('by Application') }}</a>
+        </li>
+        <li data-report="locales">
+          <a href="{{ url('stats.locales', slug_or_id) }}">{{ _('by Language') }}</a>
+        </li>
+        <li data-report="os">
+          <a href="{{ url('stats.os', slug_or_id) }}">{{ _('by Platform') }}</a>
+        </li>
+        <li data-report="countries">
+          <a href="{{ url('stats.countries', slug_or_id) }}">{{ _('by Country') }}</a>
+        </li>
+      </ul>
     </li>
-    <ul>
-      <li data-report="versions">
-        <a href="{{ url('stats.versions', slug_or_id) }}">{{ _('by Add-on Version') }}</a>
-      </li>
-      <li data-report="apps">
-        <a href="{{ url('stats.apps', slug_or_id) }}">{{ _('by Application') }}</a>
-      </li>
-      <li data-report="locales">
-        <a href="{{ url('stats.locales', slug_or_id) }}">{{ _('by Language') }}</a>
-      </li>
-      <li data-report="os">
-        <a href="{{ url('stats.os', slug_or_id) }}">{{ _('by Platform') }}</a>
-      </li>
-      <li data-report="countries">
-        <a href="{{ url('stats.countries', slug_or_id) }}">{{ _('by Country') }}</a>
-      </li>
-    </ul>
   </ul>
 </nav>

--- a/static/css/zamboni/stats.less
+++ b/static/css/zamboni/stats.less
@@ -532,6 +532,10 @@ table.stats-aggregate tbody span.change.minus {
     }
 }
 
+#side-nav ul ul {
+    margin-left: 1em;
+}
+
 #popup-staging {
     display: none;
 }


### PR DESCRIPTION
Fixes #21418

![Screenshot 2023-11-09 at 17-56-33 eagpil-anter-seaverk Statistics Dashboard Add-ons for Firefox](https://github.com/mozilla/addons-server/assets/187006/0befb45f-82c1-4a81-8f12-c6ef8e396a1a)
