### PR TITLE
Add warning message for when unreviewed versions are in another queue

### DIFF
--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -111,6 +111,13 @@
       {% include "reviewers/includes/paginator_history.html" %}
     </div>
   </div>
+  <div id="unreviewed-other-queue">
+    {% if has_versions_with_due_date_in_other_queue %}
+      <p class="unreviewed-versions-warning" style="color: red;">
+        This add-on has 1 or more versions with a due date in other pages.
+      </p>
+    {% endif %}
+  </div>
   <div id="versions-history" class="results">
     <div class="results-inner">
       <table class="review-files item-history">

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -112,9 +112,9 @@
     </div>
   </div>
   <div id="unreviewed-other-queue">
-    {% if has_versions_with_due_date_in_other_queue %}
+    {% if has_versions_with_due_date_in_other_channel %}
       <p class="unreviewed-versions-warning" style="color: red;">
-        This add-on has 1 or more versions with a due date in other pages.
+        This add-on has 1 or more versions with a due date in another channel.
       </p>
     {% endif %}
   </div>

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -2776,7 +2776,7 @@ class TestReview(ReviewBase):
         assert response.status_code == 200
         doc = pq(response.content)
         assert not doc('#unreviewed-other-queue .unreviewed-versions-warning')
-    
+
         version_factory(
             addon=self.addon,
             channel=amo.CHANNEL_UNLISTED,
@@ -2790,8 +2790,9 @@ class TestReview(ReviewBase):
         doc = pq(response.content)
         assert doc('#unreviewed-other-queue .unreviewed-versions-warning')
         assert doc('#unreviewed-other-queue .unreviewed-versions-warning').text() == (
-            'This add-on has 1 or more versions with a due date in other pages.')
-        
+            'This add-on has 1 or more versions with a due date in other pages.'
+        )
+
     def test_item_history_unreviewed_version_in_listed_queue(self):
         self.addon.versions.update(channel=amo.CHANNEL_UNLISTED)
         self.addon.update_version()
@@ -2818,8 +2819,8 @@ class TestReview(ReviewBase):
         doc = pq(response.content)
         assert doc('#unreviewed-other-queue .unreviewed-versions-warning')
         assert doc('#unreviewed-other-queue .unreviewed-versions-warning').text() == (
-            'This add-on has 1 or more versions with a due date in other pages.')
-        
+            'This add-on has 1 or more versions with a due date in other pages.'
+        )
 
     def test_item_history_notes(self):
         version = self.addon.versions.all()[0]

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -2782,6 +2782,7 @@ class TestReview(ReviewBase):
             addon=self.addon,
             channel=amo.CHANNEL_UNLISTED,
             file_kw={'status': amo.STATUS_AWAITING_REVIEW},
+            due_date=datetime.now() + timedelta(hours=1, minutes=1),
         )
         self.addon.update_version()
         assert self.addon.versions.filter(channel=amo.CHANNEL_UNLISTED).count() == 1
@@ -2811,6 +2812,7 @@ class TestReview(ReviewBase):
             addon=self.addon,
             channel=amo.CHANNEL_LISTED,
             file_kw={'status': amo.STATUS_AWAITING_REVIEW},
+            due_date=datetime.now() + timedelta(hours=1, minutes=1),
         )
         self.addon.update_version()
         assert self.addon.versions.filter(channel=amo.CHANNEL_LISTED).count() == 1

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -2792,7 +2792,7 @@ class TestReview(ReviewBase):
         doc = pq(response.content)
         assert doc('#unreviewed-other-queue .unreviewed-versions-warning')
         assert doc('#unreviewed-other-queue .unreviewed-versions-warning').text() == (
-            'This add-on has 1 or more versions with a due date in other pages.'
+            'This add-on has 1 or more versions with a due date in another channel.'
         )
 
     def test_item_history_unreviewed_version_in_listed_queue(self):
@@ -2822,7 +2822,7 @@ class TestReview(ReviewBase):
         doc = pq(response.content)
         assert doc('#unreviewed-other-queue .unreviewed-versions-warning')
         assert doc('#unreviewed-other-queue .unreviewed-versions-warning').text() == (
-            'This add-on has 1 or more versions with a due date in other pages.'
+            'This add-on has 1 or more versions with a due date in another channel.'
         )
 
     def test_item_history_notes(self):

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -2677,6 +2677,7 @@ class TestReview(ReviewBase):
             # 50. select all versions in channel for versions dropdown widget
             # 51. reviewer reasons for the reason dropdown
             # 52. select users by role for this add-on (?)
+            # 53. unreviewed versions in other channel
             response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
@@ -5318,7 +5319,7 @@ class TestReview(ReviewBase):
                     results={'matchedRules': [customs_rule.name]},
                 )
 
-        with self.assertNumQueries(53):
+        with self.assertNumQueries(54):
             # See test_item_history_pagination() for more details about the
             # queries count. What's important here is that the extra versions
             # and scanner results don't cause extra queries.

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -2616,7 +2616,7 @@ class TestReview(ReviewBase):
             str(author.get_role_display()),
             self.addon,
         )
-        with self.assertNumQueries(52):
+        with self.assertNumQueries(53):
             # FIXME: obviously too high, but it's a starting point.
             # Potential further optimizations:
             # - Remove trivial... and not so trivial duplicates

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -725,12 +725,11 @@ def review(request, addon, channel=None):
         flags=flags,
         form=form,
         format_matched_rules=formatted_matched_rules_with_files_and_data,
-        has_versions_with_due_date_in_other_queue=addon.versions.exclude(
-            channel=channel
+        has_versions_with_due_date_in_other_channel=addon.versions(
+            managers='unfiltered_for_relations'
         )
-        .filter(
-            due_date__isnull=False,
-        )
+        .exclude(channel=channel)
+        .filter(due_date__isnull=False)
         .exists(),
         important_changes_log=important_changes_log,
         is_admin=is_admin,

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -726,7 +726,7 @@ def review(request, addon, channel=None):
         form=form,
         format_matched_rules=formatted_matched_rules_with_files_and_data,
         has_versions_with_due_date_in_other_channel=addon.versions(
-            managers='unfiltered_for_relations'
+            manager='unfiltered_for_relations'
         )
         .exclude(channel=channel)
         .filter(due_date__isnull=False)

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -442,13 +442,14 @@ def determine_channel(channel_as_text):
 def other_queue_has_unreviewed_versions(addon, channel):
     """Return True if the addon has unreviewed versions in another queue."""
     versions = addon.versions.filter(
-        channel=amo.CHANNEL_LISTED if channel == amo.CHANNEL_UNLISTED else amo.CHANNEL_UNLISTED,
+        channel=amo.CHANNEL_LISTED
+        if channel == amo.CHANNEL_UNLISTED
+        else amo.CHANNEL_UNLISTED,
     )
     for version in versions:
         if version.is_unreviewed:
             return True
     return False
-
 
 
 @login_required
@@ -737,7 +738,9 @@ def review(request, addon, channel=None):
         flags=flags,
         form=form,
         format_matched_rules=formatted_matched_rules_with_files_and_data,
-        has_versions_with_due_date_in_other_queue=other_queue_has_unreviewed_versions(addon, channel),
+        has_versions_with_due_date_in_other_queue=other_queue_has_unreviewed_versions(
+            addon, channel
+        ),
         important_changes_log=important_changes_log,
         is_admin=is_admin,
         language_dict=dict(settings.LANGUAGES),

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -725,7 +725,7 @@ def review(request, addon, channel=None):
         flags=flags,
         form=form,
         format_matched_rules=formatted_matched_rules_with_files_and_data,
-        has_versions_with_due_date_in_other_queue=not addon.versions.exclude(
+        has_versions_with_due_date_in_other_queue=addon.versions.exclude(
             channel=channel
         )
         .filter(

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -439,6 +439,18 @@ def determine_channel(channel_as_text):
     return channel, content_review
 
 
+def other_queue_has_unreviewed_versions(addon, channel):
+    """Return True if the addon has unreviewed versions in another queue."""
+    versions = addon.versions.filter(
+        channel=amo.CHANNEL_LISTED if channel == amo.CHANNEL_UNLISTED else amo.CHANNEL_UNLISTED,
+    )
+    for version in versions:
+        if version.is_unreviewed:
+            return True
+    return False
+
+
+
 @login_required
 @any_reviewer_required  # Additional permission checks are done inside.
 @reviewer_addon_view_factory
@@ -725,6 +737,7 @@ def review(request, addon, channel=None):
         flags=flags,
         form=form,
         format_matched_rules=formatted_matched_rules_with_files_and_data,
+        has_versions_with_due_date_in_other_queue=other_queue_has_unreviewed_versions(addon, channel),
         important_changes_log=important_changes_log,
         is_admin=is_admin,
         language_dict=dict(settings.LANGUAGES),


### PR DESCRIPTION
Fixes #20855 

<img width="506" alt="Screenshot 2023-11-21 at 12 25 48 AM" src="https://github.com/mozilla/addons-server/assets/63402349/128dd62e-44c5-4890-b242-bf1a08027cdc">


This adds a simple red message stating that there are versions with a due date in another queue if there are any.