### PR TITLE
move ActivityLog.create to ActivityLogManager

### DIFF
--- a/src/olympia/accounts/tasks.py
+++ b/src/olympia/accounts/tasks.py
@@ -55,7 +55,7 @@ def primary_email_change_event(user, event_date, email):
 def delete_user_event(user, event_date):
     """Process the delete user event."""
     if switch_is_active('fxa-account-delete'):
-        ActivityLog.create(amo.LOG.USER_AUTO_DELETED, user, user=user)
+        ActivityLog.objects.create(amo.LOG.USER_AUTO_DELETED, user, user=user)
         user.delete(addon_msg='Deleted via FxA account deletion')
         log.info(f'Account pk [{user.id}] deleted from FxA on {event_date}')
     else:

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -518,7 +518,7 @@ class AccountViewSet(
 
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()
-        ActivityLog.create(amo.LOG.USER_DELETED, instance)
+        ActivityLog.objects.create(amo.LOG.USER_DELETED, instance)
         self.perform_destroy(instance)
         response = Response(status=HTTP_204_NO_CONTENT)
         if instance == request.user:

--- a/src/olympia/activity/__init__.py
+++ b/src/olympia/activity/__init__.py
@@ -2,4 +2,4 @@ def log_create(action, *args, **kw):
     """Use this if importing ActivityLog causes a circular import."""
     from olympia.activity.models import ActivityLog
 
-    return ActivityLog.create(action, *args, **kw)
+    return ActivityLog.objects.create(action, *args, **kw)

--- a/src/olympia/activity/tests/test_admin.py
+++ b/src/olympia/activity/tests/test_admin.py
@@ -56,15 +56,15 @@ class TestActivityLogAdmin(TestCase):
         with core.override_remote_addr('127.0.0.2'):
             user2.update(email='foo@bar.com')
             # That will make user2 match our query.
-            ActivityLog.create(amo.LOG.LOG_IN, user=user2)
+            ActivityLog.objects.create(amo.LOG.LOG_IN, user=user2)
         with core.override_remote_addr('127.0.0.2'):
             # That will make user3 match our query.
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.ADD_VERSION, addon.current_version, addon, user=user3
             )
         with core.override_remote_addr('127.0.0.1'):
             extra_user = user_factory()  # Extra user that shouldn't match
-            ActivityLog.create(amo.LOG.LOG_IN, user=extra_user)
+            ActivityLog.objects.create(amo.LOG.LOG_IN, user=extra_user)
         with self.assertNumQueries(11):
             # - 2 savepoints/release
             # - 2 user and groups

--- a/src/olympia/activity/tests/test_commands.py
+++ b/src/olympia/activity/tests/test_commands.py
@@ -75,20 +75,22 @@ def test_backfill_ratinglog_command():
     user = user_factory()
     addon = addon_factory()
 
-    no_rating_in_args_log = ActivityLog.create(amo.LOG.ADD_RATING, user=user)
+    no_rating_in_args_log = ActivityLog.objects.create(amo.LOG.ADD_RATING, user=user)
     assert no_rating_in_args_log.arguments == []
 
     missing = Rating.objects.create(addon=addon, user=user)
-    missing_log = ActivityLog.create(amo.LOG.ADD_RATING, user=user)
+    missing_log = ActivityLog.objects.create(amo.LOG.ADD_RATING, user=user)
     missing_log.set_arguments((missing,))
     missing_log.save()
 
     has_rating = Rating.objects.create(addon=addon, user=user)
-    has_rating_log = ActivityLog.create(amo.LOG.ADD_RATING, has_rating, user=user)
+    has_rating_log = ActivityLog.objects.create(
+        amo.LOG.ADD_RATING, has_rating, user=user
+    )
     assert has_rating_log.arguments == [has_rating]
 
     has_rating_not_no_ratinglog_yet = Rating.objects.create(addon=addon, user=user)
-    has_rating_not_no_ratinglog_yet_log = ActivityLog.create(
+    has_rating_not_no_ratinglog_yet_log = ActivityLog.objects.create(
         amo.LOG.ADD_RATING, has_rating_not_no_ratinglog_yet, user=user
     )
     assert has_rating_not_no_ratinglog_yet_log.arguments == [
@@ -98,7 +100,9 @@ def test_backfill_ratinglog_command():
     has_rating_log.ratinglog_set.all().delete()
 
     other_action = Rating.objects.create(addon=addon, user=user)
-    other_action_log = ActivityLog.create(amo.LOG.CHANGE_STATUS, addon, user=user)
+    other_action_log = ActivityLog.objects.create(
+        amo.LOG.CHANGE_STATUS, addon, user=user
+    )
     assert other_action_log.arguments == [addon]
     other_action_log.set_arguments((addon, other_action))
     other_action_log.save()

--- a/src/olympia/activity/tests/test_log.py
+++ b/src/olympia/activity/tests/test_log.py
@@ -19,7 +19,7 @@ class LogTest(TestCase):
         """
         addon = addon_factory(name='kümar is awesome')
         magic = {'title': 'nô', 'body': 'wày!'}
-        al = ActivityLog.create(amo.LOG.DELETE_RATING, 1, addon, details=magic)
+        al = ActivityLog.objects.create(amo.LOG.DELETE_RATING, 1, addon, details=magic)
 
         assert al.details == magic
         assert al._details == json.dumps(magic)

--- a/src/olympia/activity/tests/test_models.py
+++ b/src/olympia/activity/tests/test_models.py
@@ -111,7 +111,7 @@ class TestActivityLog(TestCase):
 
     def test_basic(self):
         addon = Addon.objects.get()
-        ActivityLog.create(amo.LOG.CREATE_ADDON, addon)
+        ActivityLog.objects.create(amo.LOG.CREATE_ADDON, addon)
         entries = ActivityLog.objects.for_addons(addon)
         assert len(entries) == 1
         assert entries[0].arguments[0] == addon
@@ -121,7 +121,7 @@ class TestActivityLog(TestCase):
     def test_no_user(self):
         core.set_user(None)
         count = ActivityLog.objects.count()
-        ActivityLog.create(amo.LOG.CUSTOM_TEXT, 'hi')
+        ActivityLog.objects.create(amo.LOG.CUSTOM_TEXT, 'hi')
         assert count == ActivityLog.objects.count()
 
     def test_pseudo_objects(self):
@@ -138,12 +138,12 @@ class TestActivityLog(TestCase):
         If we are given (Addon, 3615) it should log in the AddonLog as well.
         """
         addon = Addon.objects.get()
-        ActivityLog.create(amo.LOG.CREATE_ADDON, (Addon, addon.id))
+        ActivityLog.objects.create(amo.LOG.CREATE_ADDON, (Addon, addon.id))
         assert AddonLog.objects.count() == 1
 
     def test_addon_log(self):
         addon = Addon.objects.get()
-        ActivityLog.create(amo.LOG.CREATE_ADDON, (Addon, addon.id))
+        ActivityLog.objects.create(amo.LOG.CREATE_ADDON, (Addon, addon.id))
         entries = ActivityLog.objects.for_addons(addon)
         assert len(entries) == 1
         assert addon.get_url_path() in str(entries[0])
@@ -155,7 +155,7 @@ class TestActivityLog(TestCase):
         self.make_addon_unlisted(addon)
         # Delete the status change log entry from making versions unlisted.
         ActivityLog.objects.for_addons(addon).delete()
-        ActivityLog.create(amo.LOG.CREATE_ADDON, (Addon, addon.id))
+        ActivityLog.objects.create(amo.LOG.CREATE_ADDON, (Addon, addon.id))
         entries = ActivityLog.objects.for_addons(addon)
         assert len(entries) == 1
         assert url_path not in str(entries[0])
@@ -181,7 +181,7 @@ class TestActivityLog(TestCase):
 
     def test_json_failboat(self):
         addon = Addon.objects.get()
-        ActivityLog.create(amo.LOG.CREATE_ADDON, addon)
+        ActivityLog.objects.create(amo.LOG.CREATE_ADDON, addon)
         entry = ActivityLog.objects.get()
         entry._arguments = 'failboat?'
         entry.save()
@@ -235,12 +235,12 @@ class TestActivityLog(TestCase):
             )
 
     def test_no_arguments(self):
-        ActivityLog.create(amo.LOG.CUSTOM_HTML)
+        ActivityLog.objects.create(amo.LOG.CUSTOM_HTML)
         entry = ActivityLog.objects.get()
         assert entry.arguments == []
 
     def test_output(self):
-        ActivityLog.create(amo.LOG.CUSTOM_TEXT, 'hi there')
+        ActivityLog.objects.create(amo.LOG.CUSTOM_TEXT, 'hi there')
         entry = ActivityLog.objects.get()
         assert str(entry) == 'hi there'
 
@@ -248,13 +248,13 @@ class TestActivityLog(TestCase):
         addon = Addon.objects.get()
         addon2 = addon_factory()
         with core.override_remote_addr('1.1.1.1'):
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.ADD_VERSION,
                 addon,
                 addon.current_version,
                 user=self.request.user,
             )
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.ADD_VERSION,
                 addon2,
                 addon2.current_version,
@@ -284,7 +284,7 @@ class TestActivityLog(TestCase):
         action = amo.LOG.REJECT_VERSION
         assert not getattr(action, 'store_ip', False)
         with core.override_remote_addr('127.0.4.8'):
-            activity = ActivityLog.create(
+            activity = ActivityLog.objects.create(
                 action,
                 addon,
                 addon.current_version,
@@ -296,7 +296,7 @@ class TestActivityLog(TestCase):
         action = amo.LOG.ADD_VERSION
         assert getattr(action, 'store_ip', False)
         with core.override_remote_addr('15.16.23.42'):
-            activity = ActivityLog.create(
+            activity = ActivityLog.objects.create(
                 action,
                 addon,
                 addon.current_version,
@@ -314,7 +314,7 @@ class TestActivityLog(TestCase):
         # Creating an activity log without any `reason` arguments doesn't
         # create a ReviewActionReasonLog.
         action = amo.LOG.REJECT_VERSION
-        ActivityLog.create(
+        ActivityLog.objects.create(
             action,
             addon,
             addon.current_version,
@@ -331,7 +331,7 @@ class TestActivityLog(TestCase):
             name='reason 2',
             is_active=True,
         )
-        ActivityLog.create(
+        ActivityLog.objects.create(
             action,
             addon,
             addon.current_version,
@@ -347,7 +347,7 @@ class TestActivityLog(TestCase):
 
     def test_version_log(self):
         version = Version.objects.all()[0]
-        ActivityLog.create(
+        ActivityLog.objects.create(
             amo.LOG.REJECT_VERSION, version.addon, version, user=self.request.user
         )
         entries = ActivityLog.objects.for_versions(version)
@@ -359,7 +359,7 @@ class TestActivityLog(TestCase):
         version = version_factory(addon=addon)
         addon_factory()  # To create an extra unrelated version
         for version in Version.objects.all():
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.REJECT_VERSION, version.addon, version, user=self.request.user
             )
         entries = ActivityLog.objects.for_versions(addon.versions.all())
@@ -370,7 +370,7 @@ class TestActivityLog(TestCase):
         # Get the url before the addon is changed to unlisted.
         url_path = version.get_url_path()
         self.make_addon_unlisted(version.addon)
-        ActivityLog.create(
+        ActivityLog.objects.create(
             amo.LOG.REJECT_VERSION, version.addon, version, user=self.request.user
         )
         entries = ActivityLog.objects.for_versions(version)
@@ -380,7 +380,7 @@ class TestActivityLog(TestCase):
     def test_version_log_transformer(self):
         addon = Addon.objects.get()
         version = addon.current_version
-        ActivityLog.create(
+        ActivityLog.objects.create(
             amo.LOG.REJECT_VERSION, addon, version, user=self.request.user
         )
 
@@ -388,7 +388,7 @@ class TestActivityLog(TestCase):
             addon=addon, license=version.license, version='1.2.3'
         )
 
-        ActivityLog.create(
+        ActivityLog.objects.create(
             amo.LOG.REJECT_VERSION, addon, version_two, user=self.request.user
         )
 
@@ -404,9 +404,9 @@ class TestActivityLog(TestCase):
     def test_anonymize_user_for_developer_transformer(self):
         addon = Addon.objects.get()
         # This action's user can be shown.
-        ActivityLog.create(amo.LOG.CREATE_ADDON, addon, user=self.request.user)
+        ActivityLog.objects.create(amo.LOG.CREATE_ADDON, addon, user=self.request.user)
         # This action's user should not be shown.
-        ActivityLog.create(amo.LOG.FORCE_DISABLE, addon, user=self.request.user)
+        ActivityLog.objects.create(amo.LOG.FORCE_DISABLE, addon, user=self.request.user)
 
         logs = ActivityLog.objects.all().transform(
             ActivityLog.transformer_anonymize_user_for_developer
@@ -424,7 +424,7 @@ class TestActivityLog(TestCase):
         addon.save()
         addon = addon.reload()
         au = AddonUser(addon=addon, user=self.user)
-        ActivityLog.create(
+        ActivityLog.objects.create(
             amo.LOG.CHANGE_USER_WITH_ROLE, au.user, str(au.get_role_display()), addon
         )
         log = ActivityLog.objects.get()
@@ -443,7 +443,7 @@ class TestActivityLog(TestCase):
     def test_tag_no_match(self):
         addon = Addon.objects.get()
         tag = Tag.objects.create(tag_text='http://foo.com')
-        ActivityLog.create(amo.LOG.ADD_TAG, addon, tag)
+        ActivityLog.objects.create(amo.LOG.ADD_TAG, addon, tag)
         log = ActivityLog.objects.get()
         text = amo.utils.from_string('<p>{{ log }}</p>').render({'log': log})
         # There should only be one a, the link to the addon, but no tag link.
@@ -451,7 +451,9 @@ class TestActivityLog(TestCase):
 
     def test_change_status(self):
         addon = Addon.objects.get()
-        log = ActivityLog.create(amo.LOG.CHANGE_STATUS, addon, amo.STATUS_APPROVED)
+        log = ActivityLog.objects.create(
+            amo.LOG.CHANGE_STATUS, addon, amo.STATUS_APPROVED
+        )
         expected = (
             '<a href="http://testserver/en-US/firefox/addon/a3615/">'
             'Delicious Bookmarks</a> status changed to Approved.'
@@ -489,7 +491,9 @@ class TestActivityLog(TestCase):
 
     def test_str_activity_file(self):
         addon = Addon.objects.get()
-        log = ActivityLog.create(amo.LOG.UNLISTED_SIGNED, addon.current_version.file)
+        log = ActivityLog.objects.create(
+            amo.LOG.UNLISTED_SIGNED, addon.current_version.file
+        )
         assert str(log) == (
             '<a href="http://testserver/firefox/downloads/file/67442/'
             'delicious_bookmarks-2.1.072.xpi">'

--- a/src/olympia/activity/tests/test_models.py
+++ b/src/olympia/activity/tests/test_models.py
@@ -501,6 +501,14 @@ class TestActivityLog(TestCase):
             ' (validation ignored) was signed.'
         )
 
+    def test_create_action_arg_or_kwarg(self):
+        assert ActivityLog.objects.create(amo.LOG.ADD_TAG).log == amo.LOG.ADD_TAG
+        assert ActivityLog.objects.create(action=amo.LOG.ADD_TAG).log == amo.LOG.ADD_TAG
+        assert ActivityLog.objects.create(amo.LOG.ADD_TAG.id).log == amo.LOG.ADD_TAG
+        assert (
+            ActivityLog.objects.create(action=amo.LOG.ADD_TAG.id).log == amo.LOG.ADD_TAG
+        )
+
 
 class TestDraftComment(TestCase):
     def test_default_requirements(self):

--- a/src/olympia/activity/tests/test_serializers.py
+++ b/src/olympia/activity/tests/test_serializers.py
@@ -11,7 +11,7 @@ class LogMixin:
         version = self.addon.find_latest_version(channel=amo.CHANNEL_LISTED)
         details = {'comments': comments, 'version': version.version}
         kwargs = {'user': self.user, 'details': details}
-        al = ActivityLog.create(action, self.addon, version, **kwargs)
+        al = ActivityLog.objects.create(action, self.addon, version, **kwargs)
         if created:
             al.update(created=created)
         return al
@@ -89,7 +89,7 @@ class TestReviewNotesSerializerOutput(TestCase, LogMixin):
 
     def test_log_entry_without_details(self):
         # Create a log but without a details property.
-        self.entry = ActivityLog.create(
+        self.entry = ActivityLog.objects.create(
             amo.LOG.APPROVAL_NOTES_CHANGED,
             self.addon,
             self.addon.find_latest_version(channel=amo.CHANNEL_LISTED),

--- a/src/olympia/activity/tests/test_utils.py
+++ b/src/olympia/activity/tests/test_utils.py
@@ -96,7 +96,7 @@ class TestEmailBouncing(TestCase):
         )
         self.email_text = sample_message_content['Message']
 
-    @mock.patch('olympia.activity.utils.ActivityLog.create')
+    @mock.patch('olympia.activity.utils.ActivityLog.objects.create')
     def test_no_note_logged(self, log_mock):
         # First set everything up so it's working
         addon = addon_factory()
@@ -321,7 +321,7 @@ class TestLogAndNotify(TestCase):
             'comments': 'I spy, with my líttle €ye...',
             'version': self.version.version,
         }
-        activity = ActivityLog.create(
+        activity = ActivityLog.objects.create(
             action, self.addon, self.version, user=author, details=details
         )
         activity.update(created=self.days_ago(1))
@@ -645,7 +645,7 @@ def test_send_activity_mail():
         user,
     ]
     from_email = 'bob@bob.bob'
-    action = ActivityLog.create(amo.LOG.DEVELOPER_REPLY_VERSION, user=user)
+    action = ActivityLog.objects.create(amo.LOG.DEVELOPER_REPLY_VERSION, user=user)
     send_activity_mail(
         subject, message, latest_version, recipients, from_email, action.id
     )

--- a/src/olympia/activity/utils.py
+++ b/src/olympia/activity/utils.py
@@ -260,7 +260,7 @@ def log_and_notify(
                 due_date=get_review_due_date(default_days=REVIEWER_STANDARD_REPLY_TIME)
             )
 
-    note = ActivityLog.create(action, version.addon, version, **log_kwargs)
+    note = ActivityLog.objects.create(action, version.addon, version, **log_kwargs)
     if not note:
         return
 

--- a/src/olympia/addons/admin.py
+++ b/src/olympia/addons/admin.py
@@ -505,7 +505,9 @@ class AddonAdmin(AMOModelAdmin):
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)
         if 'status' in form.changed_data:
-            ActivityLog.create(amo.LOG.CHANGE_STATUS, obj, form.cleaned_data['status'])
+            ActivityLog.objects.create(
+                amo.LOG.CHANGE_STATUS, obj, form.cleaned_data['status']
+            )
             log.info(
                 'Addon "%s" status changed to: %s'
                 % (obj.slug, form.cleaned_data['status'])

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -240,7 +240,7 @@ class PreviewSerializer(AMOModelSerializer):
 
     def save(self, *args, **kwargs):
         instance = super().save(*args, **kwargs)
-        ActivityLog.create(
+        ActivityLog.objects.create(
             amo.LOG.CHANGE_MEDIA, instance.addon, user=self.context['request'].user
         )
         return instance
@@ -701,7 +701,7 @@ class DeveloperVersionSerializer(VersionSerializer):
                 if appver and (
                     app not in existing_maxs or existing_maxs[app] != appver.max
                 ):
-                    ActivityLog.create(
+                    ActivityLog.objects.create(
                         amo.LOG.MAX_APPVERSION_UPDATED,
                         instance.addon,
                         instance,
@@ -718,7 +718,7 @@ class DeveloperVersionSerializer(VersionSerializer):
             else:
                 instance.update(license=custom_license_field.create(custom_license))
         if custom_license or 'license' in validated_data:
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.CHANGE_LICENSE, instance.license, instance.addon, user=user
             )
         if 'source' in validated_data:
@@ -1240,14 +1240,14 @@ class AddonSerializer(AMOModelSerializer):
 
         if 'disabled_by_user' in validated_data:
             is_disabled = validated_data.pop('disabled_by_user')
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.USER_DISABLE if is_disabled else amo.LOG.USER_ENABLE,
                 instance,
                 user=user,
             )
         if 'icon' in validated_data:
             validated_data.pop('icon')
-            ActivityLog.create(amo.LOG.CHANGE_MEDIA, instance, user=user)
+            ActivityLog.objects.create(amo.LOG.CHANGE_MEDIA, instance, user=user)
         if 'tag_list' in validated_data:
             # Tag.add_tag and Tag.remove_tag have their own logging so don't repeat it.
             validated_data.pop('tag_list')
@@ -1256,7 +1256,7 @@ class AddonSerializer(AMOModelSerializer):
             validated_data.pop('version')
 
         if validated_data:
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.EDIT_PROPERTIES,
                 instance,
                 details=list(validated_data.keys()),
@@ -1318,7 +1318,7 @@ class AddonSerializer(AMOModelSerializer):
             # representation if there was one.
             self.fields['version'].write_only = False
         if 'slug' in validated_data:
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.ADDON_SLUG_CHANGED, instance, old_slug, instance.slug
             )
 

--- a/src/olympia/addons/tests/test_admin.py
+++ b/src/olympia/addons/tests/test_admin.py
@@ -266,17 +266,17 @@ class TestAddonAdmin(TestCase):
 
         addon = addon_factory(guid='@foo')
         with core.override_remote_addr('4.8.15.16'):
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.ADD_VERSION, addon.current_version, addon, user=user
             )
         version_factory(addon=addon)
         with core.override_remote_addr('4.8.15.16'):
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.ADD_VERSION, addon.current_version, addon, user=user
             )
         second_addon = addon_factory(guid='@bar')
         with core.override_remote_addr('4.8.15.16'):
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.ADD_VERSION,
                 second_addon.current_version,
                 second_addon,
@@ -284,7 +284,7 @@ class TestAddonAdmin(TestCase):
             )
         third_addon = addon_factory(guid='@xyz')
         with core.override_remote_addr('127.0.0.1'):
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.ADD_VERSION,
                 third_addon.current_version,
                 third_addon,
@@ -846,13 +846,13 @@ class TestAddonAdmin(TestCase):
         core.set_user(user_factory())
 
         addon = addon_factory()
-        ActivityLog.create(amo.LOG.CREATE_ADDON, addon)
-        ActivityLog.create(amo.LOG.EDIT_PROPERTIES, addon)
-        ActivityLog.create(amo.LOG.DELETE_ADDON, addon)
+        ActivityLog.objects.create(amo.LOG.CREATE_ADDON, addon)
+        ActivityLog.objects.create(amo.LOG.EDIT_PROPERTIES, addon)
+        ActivityLog.objects.create(amo.LOG.DELETE_ADDON, addon)
 
         # Create another activity attached to a different add-on.
         unrelated_addon = addon_factory()
-        ActivityLog.create(amo.LOG.EDIT_PROPERTIES, unrelated_addon)
+        ActivityLog.objects.create(amo.LOG.EDIT_PROPERTIES, unrelated_addon)
 
         admin_page = AddonAdmin(Addon, admin.site).activity(addon)
         link = pq(admin_page)('a')[0]

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -2294,7 +2294,7 @@ class TestAddonDelete(TestCase):
         AddonLog.objects.create(
             addon=addon,
             activity_log=ActivityLog.objects.create(
-                action=0, user=UserProfile.objects.create()
+                action=1, user=UserProfile.objects.create()
             ),
         )
         RssKey.objects.create(addon=addon)

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -756,7 +756,9 @@ class AddonPreviewViewSet(
 
     def perform_destroy(self, instance):
         super().perform_destroy(instance)
-        ActivityLog.create(amo.LOG.CHANGE_MEDIA, instance.addon, user=self.request.user)
+        ActivityLog.objects.create(
+            amo.LOG.CHANGE_MEDIA, instance.addon, user=self.request.user
+        )
 
 
 class AddonAuthorViewSet(

--- a/src/olympia/api/throttling.py
+++ b/src/olympia/api/throttling.py
@@ -52,7 +52,7 @@ class GranularUserRateThrottle(UserRateThrottle):
             request_allowed = super().allow_request(request, view)
             if not request_allowed and user and user.is_authenticated:
                 log.info('User %s throttled for scope %s', user, self.scope)
-                ActivityLog.create(amo.LOG.THROTTLED, self.scope, user=user)
+                ActivityLog.objects.create(amo.LOG.THROTTLED, self.scope, user=user)
 
             return request_allowed
         else:

--- a/src/olympia/devhub/forms.py
+++ b/src/olympia/devhub/forms.py
@@ -649,7 +649,7 @@ class LicenseForm(AMOModelForm):
             if (changed and is_other) or license != self.version.license:
                 self.version.update(license=license)
                 if log:
-                    ActivityLog.create(
+                    ActivityLog.objects.create(
                         amo.LOG.CHANGE_LICENSE, license, self.version.addon
                     )
         return license
@@ -701,7 +701,7 @@ class PolicyForm(TranslationFormMixin, AMOModelForm):
                 delete_translation(self.instance, field)
 
         if 'privacy_policy' in self.changed_data:
-            ActivityLog.create(amo.LOG.CHANGE_POLICY, self.addon, self.instance)
+            ActivityLog.objects.create(amo.LOG.CHANGE_POLICY, self.addon, self.instance)
 
         return ob
 

--- a/src/olympia/devhub/tests/test_feeds.py
+++ b/src/olympia/devhub/tests/test_feeds.py
@@ -32,33 +32,35 @@ class TestActivity(HubTest):
         if not addon:
             addon = self.addon
         for _i in range(num):
-            ActivityLog.create(amo.LOG.CREATE_ADDON, addon)
+            ActivityLog.objects.create(amo.LOG.CREATE_ADDON, addon)
 
     def log_updates(self, num, version_string='1'):
         version = Version.objects.create(version=version_string, addon=self.addon)
 
         for _i in range(num):
             with core.override_remote_addr('127.0.0.1'):
-                ActivityLog.create(amo.LOG.ADD_VERSION, self.addon, version)
+                ActivityLog.objects.create(amo.LOG.ADD_VERSION, self.addon, version)
 
     def log_status(self, num):
         for _i in range(num):
-            ActivityLog.create(amo.LOG.USER_DISABLE, self.addon)
+            ActivityLog.objects.create(amo.LOG.USER_DISABLE, self.addon)
 
     def log_collection(self, num, prefix='foo'):
         for i in range(num):
             collection = Collection.objects.create(name='%s %d' % (prefix, i))
-            ActivityLog.create(amo.LOG.ADD_TO_COLLECTION, self.addon, collection)
+            ActivityLog.objects.create(
+                amo.LOG.ADD_TO_COLLECTION, self.addon, collection
+            )
 
     def log_tag(self, num, prefix='foo'):
         for i in range(num):
             tag = Tag.objects.create(tag_text='%s %d' % (prefix, i))
-            ActivityLog.create(amo.LOG.ADD_TAG, self.addon, tag)
+            ActivityLog.objects.create(amo.LOG.ADD_TAG, self.addon, tag)
 
     def log_rating(self, num):
         rating = Rating(addon=self.addon)
         for _i in range(num):
-            ActivityLog.create(amo.LOG.ADD_RATING, self.addon, rating)
+            ActivityLog.objects.create(amo.LOG.ADD_RATING, self.addon, rating)
 
     def get_response(self, **kwargs):
         follow = kwargs.pop('follow', True)
@@ -290,7 +292,7 @@ class TestActivity(HubTest):
 
     def test_hidden(self):
         version = Version.objects.create(addon=self.addon)
-        ActivityLog.create(amo.LOG.COMMENT_VERSION, self.addon, version)
+        ActivityLog.objects.create(amo.LOG.COMMENT_VERSION, self.addon, version)
         res = self.get_response(addon=self.addon.id)
         key = RssKey.objects.get()
         res = self.get_response(privaterss=key.key)

--- a/src/olympia/devhub/tests/test_helpers.py
+++ b/src/olympia/devhub/tests/test_helpers.py
@@ -110,9 +110,15 @@ def test_pending_activity_log_count_for_developer(
     user = user_factory()
     addon = addon_factory()
     version = addon.current_version
-    ActivityLog.create(action1, addon, version, user=user).update(created=days_ago(2))
-    ActivityLog.create(action2, addon, version, user=user).update(created=days_ago(1))
-    ActivityLog.create(action3, addon, version, user=user).update(created=days_ago(0))
+    ActivityLog.objects.create(action1, addon, version, user=user).update(
+        created=days_ago(2)
+    )
+    ActivityLog.objects.create(action2, addon, version, user=user).update(
+        created=days_ago(1)
+    )
+    ActivityLog.objects.create(action3, addon, version, user=user).update(
+        created=days_ago(0)
+    )
 
     count = jinja_helpers.pending_activity_log_count_for_developer(version)
     assert count == expected_count

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -589,7 +589,7 @@ class TestActivityFeed(TestCase):
 
     def add_log(self, action=amo.LOG.ADD_RATING):
         core.set_user(self.action_user)
-        ActivityLog.create(action, self.addon, self.version)
+        ActivityLog.objects.create(action, self.addon, self.version)
 
     def add_hidden_log(self, action=amo.LOG.COMMENT_VERSION):
         self.add_log(action=action)

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -658,8 +658,12 @@ class TestVersion(TestCase):
     def test_pending_activity_count(self):
         v2, _ = self._extra_version_and_file(amo.STATUS_AWAITING_REVIEW)
         # Add some activity log messages
-        ActivityLog.create(amo.LOG.REVIEWER_REPLY_VERSION, v2.addon, v2, user=self.user)
-        ActivityLog.create(amo.LOG.REVIEWER_REPLY_VERSION, v2.addon, v2, user=self.user)
+        ActivityLog.objects.create(
+            amo.LOG.REVIEWER_REPLY_VERSION, v2.addon, v2, user=self.user
+        )
+        ActivityLog.objects.create(
+            amo.LOG.REVIEWER_REPLY_VERSION, v2.addon, v2, user=self.user
+        )
 
         response = self.client.get(self.url)
         assert response.status_code == 200
@@ -1018,7 +1022,7 @@ class TestVersionEditDetails(TestVersionEditBase):
         # Have a reviewer review a version.
         reviewer = user_factory()
         self.grant_permission(reviewer, 'Addons:Review')
-        ActivityLog.create(
+        ActivityLog.objects.create(
             amo.LOG.REJECT_VERSION_DELAYED, self.addon, self.version, user=reviewer
         )
 

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -386,7 +386,7 @@ def delete(request, addon_id, addon):
 @post_required
 def enable(request, addon_id, addon):
     addon.update(disabled_by_user=False)
-    ActivityLog.create(amo.LOG.USER_ENABLE, addon)
+    ActivityLog.objects.create(amo.LOG.USER_ENABLE, addon)
     return redirect(addon.get_dev_url('versions'))
 
 
@@ -406,7 +406,7 @@ def cancel(request, addon_id, addon, channel):
 @post_required
 def disable(request, addon_id, addon):
     addon.update(disabled_by_user=True)
-    ActivityLog.create(amo.LOG.USER_DISABLE, addon)
+    ActivityLog.objects.create(amo.LOG.USER_DISABLE, addon)
     return redirect(addon.get_dev_url('versions'))
 
 
@@ -905,12 +905,12 @@ def addons_section(request, addon_id, addon, section, editable=False):
 
                 editable = False
                 if section == 'media':
-                    ActivityLog.create(amo.LOG.CHANGE_MEDIA, addon)
+                    ActivityLog.objects.create(amo.LOG.CHANGE_MEDIA, addon)
                 else:
-                    ActivityLog.create(amo.LOG.EDIT_PROPERTIES, addon)
+                    ActivityLog.objects.create(amo.LOG.EDIT_PROPERTIES, addon)
 
                 if valid_slug != addon.slug:
-                    ActivityLog.create(
+                    ActivityLog.objects.create(
                         amo.LOG.ADDON_SLUG_CHANGED, addon, valid_slug, addon.slug
                     )
                 valid_slug = addon.slug
@@ -1132,7 +1132,7 @@ def version_edit(request, addon_id, addon, version_id):
                 timer.log_interval('3.form_saved')
 
             if 'approval_notes' in version_form.changed_data:
-                ActivityLog.create(
+                ActivityLog.objects.create(
                     amo.LOG.APPROVAL_NOTES_CHANGED, addon, version, request.user
                 )
 
@@ -1182,7 +1182,9 @@ def _log_max_version_change(addon, version, appversion):
         'target': appversion.version.version,
         'application': appversion.application,
     }
-    ActivityLog.create(amo.LOG.MAX_APPVERSION_UPDATED, addon, version, details=details)
+    ActivityLog.objects.create(
+        amo.LOG.MAX_APPVERSION_UPDATED, addon, version, details=details
+    )
 
 
 @dev_required
@@ -1867,7 +1869,7 @@ def request_review(request, addon_id, addon):
         messages.success(request, gettext('Review requested.'))
     else:
         messages.success(request, _('You must provide further details to proceed.'))
-    ActivityLog.create(amo.LOG.CHANGE_STATUS, addon, addon.status)
+    ActivityLog.objects.create(amo.LOG.CHANGE_STATUS, addon, addon.status)
     return redirect(addon.get_dev_url('versions'))
 
 

--- a/src/olympia/lib/crypto/tasks.py
+++ b/src/olympia/lib/crypto/tasks.py
@@ -134,7 +134,7 @@ def sign_addons(addon_ids, force=False, send_emails=True, **kw):
             previous_version_str = str(version.version)
             version.update(version=bumped_version_number)
             addon = version.addon
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.VERSION_RESIGNED,
                 addon,
                 version,

--- a/src/olympia/reviewers/tests/test_commands.py
+++ b/src/olympia/reviewers/tests/test_commands.py
@@ -680,7 +680,7 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
         version_factory(addon=addon)
         for version in addon.versions.all():
             # Add some activity logs, but no pending_rejection flag.
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.REJECT_VERSION_DELAYED,
                 addon,
                 version,
@@ -698,7 +698,7 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
             version_review_flags_factory(
                 version=version, pending_rejection=datetime.now() + timedelta(days=2)
             )
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.REJECT_VERSION_DELAYED,
                 addon,
                 version,
@@ -716,7 +716,7 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
             version_review_flags_factory(
                 version=version, pending_rejection=datetime.now() + timedelta(hours=23)
             )
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.REJECT_VERSION_DELAYED,
                 addon,
                 version,
@@ -746,7 +746,7 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
             version_review_flags_factory(
                 version=version, pending_rejection=datetime.now() + timedelta(hours=23)
             )
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.REJECT_VERSION_DELAYED,
                 addon,
                 version,
@@ -767,7 +767,7 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
             version_review_flags_factory(
                 version=version, pending_rejection=datetime.now() + timedelta(hours=23)
             )
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.REJECT_VERSION_DELAYED,
                 addon,
                 version,
@@ -788,7 +788,7 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
             version_review_flags_factory(
                 version=version, pending_rejection=datetime.now() + timedelta(hours=23)
             )
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.REJECT_VERSION_DELAYED,
                 addon,
                 version,
@@ -814,7 +814,7 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
             version_review_flags_factory(
                 version=version, pending_rejection=datetime.now() + timedelta(hours=23)
             )
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.REJECT_VERSION_DELAYED,
                 addon,
                 version,
@@ -832,7 +832,7 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
             version_review_flags_factory(
                 version=version, pending_rejection=datetime.now() + timedelta(hours=23)
             )
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.REJECT_VERSION_DELAYED,
                 addon,
                 version,
@@ -863,7 +863,7 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
             version_review_flags_factory(
                 version=version, pending_rejection=datetime.now() + timedelta(hours=23)
             )
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.REJECT_VERSION_DELAYED,
                 addon,
                 version,
@@ -888,7 +888,7 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
             version_review_flags_factory(
                 version=version, pending_rejection=datetime.now() + timedelta(hours=23)
             )
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.REJECT_VERSION_DELAYED,
                 addon,
                 version,
@@ -917,7 +917,7 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
             version_review_flags_factory(
                 version=version, pending_rejection=datetime.now() + timedelta(hours=23)
             )
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.REJECT_VERSION_DELAYED,
                 addon,
                 version,
@@ -945,7 +945,7 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
             version_review_flags_factory(
                 version=version, pending_rejection=datetime.now() + timedelta(hours=23)
             )
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.REJECT_VERSION_DELAYED,
                 addon,
                 version,
@@ -980,7 +980,7 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
             version_review_flags_factory(
                 version=version, pending_rejection=datetime.now() + timedelta(hours=23)
             )
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.REJECT_CONTENT_DELAYED,
                 version.addon,
                 version,
@@ -1016,7 +1016,7 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
             )
             # The ActivityLog doesn't match a pending rejection, so we should
             # not send the notification here.
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.REJECT_VERSION,
                 addon,
                 version,
@@ -1036,7 +1036,7 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
             )
             # The ActivityLog doesn't have details, so we should
             # not send the notification here.
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.REJECT_VERSION_DELAYED, addon, version, user=self.user
             )
         call_command('send_pending_rejection_last_warning_notifications')
@@ -1052,7 +1052,7 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
             )
             # The ActivityLog doesn't have comments, so we should
             # not send the notification here.
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.REJECT_VERSION_DELAYED,
                 addon,
                 version,
@@ -1071,7 +1071,7 @@ class TestSendPendingRejectionLastWarningNotification(TestCase):
             version_review_flags_factory(
                 version=version, pending_rejection=datetime.now() + timedelta(hours=23)
             )
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.REJECT_VERSION_DELAYED,
                 addon,
                 version,

--- a/src/olympia/reviewers/tests/test_review_reports.py
+++ b/src/olympia/reviewers/tests/test_review_reports.py
@@ -45,7 +45,7 @@ class TestReviewReports:
         action = (
             amo.LOG.APPROVE_VERSION if not content_review else amo.LOG.APPROVE_CONTENT
         )
-        ActivityLog.create(action, addon, addon.versions.all()[0], user=user)
+        ActivityLog.objects.create(action, addon, addon.versions.all()[0], user=user)
 
     def generate_review_data(self):
         with freeze_time(self.last_week_begin) as frozen_time:
@@ -122,7 +122,7 @@ class TestReviewReports:
             # Search plugin (submitted before auto-approval was implemented)
             search_plugin = addon_factory(type=4)
             frozen_time.tick()
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.APPROVE_CONTENT,
                 search_plugin,
                 search_plugin.versions.all()[0],
@@ -132,7 +132,7 @@ class TestReviewReports:
             # Dictionary (submitted before auto-approval was implemented)
             dictionary = addon_factory(type=amo.ADDON_DICT)
             frozen_time.tick()
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.APPROVE_CONTENT,
                 dictionary,
                 dictionary.versions.all()[0],
@@ -142,13 +142,13 @@ class TestReviewReports:
             # Theme (should be filtered out of the reports)
             theme = addon_factory(type=amo.ADDON_STATICTHEME)
             frozen_time.tick()
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.APPROVE_VERSION,
                 theme,
                 theme.versions.all()[0],
                 user=self.reviewer2,
             )
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.APPROVE_CONTENT,
                 theme,
                 theme.versions.all()[0],
@@ -329,28 +329,28 @@ class TestReviewReports:
         self.reviewer1 = user_factory(display_name='Volunteer A')
 
         with freeze_time(self.last_week_begin) as frozen_time:
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.APPROVE_VERSION,
                 (addon := addon_factory()),
                 addon.versions.all()[0],
                 user=self.reviewer1,
             )
             frozen_time.tick()
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.CONFIRM_AUTO_APPROVED,
                 (addon := addon_factory()),
                 addon.versions.all()[0],
                 user=self.reviewer1,
             )
             frozen_time.tick()
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.APPROVE_VERSION,
                 (addon := addon_factory()),
                 addon.versions.all()[0],
                 user=self.reviewer1,
             )
             frozen_time.tick()
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.REJECT_VERSION_DELAYED,
                 (addon := addon_factory()),
                 addon.versions.all()[0],
@@ -364,12 +364,12 @@ class TestReviewReports:
             frozen_time.tick()
             # As these are logged at the exact same time, only 1 should be counted
             for i in range(3):
-                ActivityLog.create(
+                ActivityLog.objects.create(
                     amo.LOG.REJECT_VERSION, addon, all_versions[i], user=self.reviewer1
                 )
             # This should be ignored because it's an auto-rejection
             frozen_time.tick()
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.REJECT_VERSION,
                 (addon := addon_factory()),
                 addon.versions.all()[0],
@@ -404,21 +404,21 @@ class TestReviewReports:
         with freeze_time(self.last_week_begin) as frozen_time:
             for _i in range(3):
                 frozen_time.tick()
-                ActivityLog.create(
+                ActivityLog.objects.create(
                     amo.LOG.APPROVE_CONTENT,
                     (addon := addon_factory()),
                     addon.versions.all()[0],
                     user=self.reviewer1,
                 )
                 frozen_time.tick()
-                ActivityLog.create(
+                ActivityLog.objects.create(
                     amo.LOG.REJECT_CONTENT,
                     (addon := addon_factory()),
                     addon.versions.all()[0],
                     user=self.reviewer1,
                 )
                 frozen_time.tick()
-                ActivityLog.create(
+                ActivityLog.objects.create(
                     amo.LOG.REJECT_CONTENT_DELAYED,
                     (addon := addon_factory()),
                     addon.versions.all()[0],
@@ -432,12 +432,12 @@ class TestReviewReports:
             frozen_time.tick()
             # As these are logged at the exact same time, only 1 should be counted
             for i in range(3):
-                ActivityLog.create(
+                ActivityLog.objects.create(
                     amo.LOG.REJECT_CONTENT, addon, all_versions[i], user=self.reviewer1
                 )
             # This should be ignored because it's an auto-rejection
             frozen_time.tick()
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.REJECT_CONTENT,
                 (addon := addon_factory()),
                 addon.versions.all()[0],

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -144,7 +144,7 @@ class TestRatingsModerationLog(ReviewerTest):
         1/1/2011.  To not do as such would be dishonorable.
         """
         review = self.make_review(username='b')
-        ActivityLog.create(amo.LOG.APPROVE_RATING, review, review.addon).update(
+        ActivityLog.objects.create(amo.LOG.APPROVE_RATING, review, review.addon).update(
             created=datetime(2011, 1, 1)
         )
 
@@ -161,8 +161,8 @@ class TestRatingsModerationLog(ReviewerTest):
         """
         review = self.make_review()
         for _i in range(2):
-            ActivityLog.create(amo.LOG.APPROVE_RATING, review, review.addon)
-            ActivityLog.create(amo.LOG.DELETE_RATING, review.id, review.addon)
+            ActivityLog.objects.create(amo.LOG.APPROVE_RATING, review, review.addon)
+            ActivityLog.objects.create(amo.LOG.DELETE_RATING, review.id, review.addon)
         response = self.client.get(self.url, {'filter': 'deleted'})
         assert response.status_code == 200
         assert pq(response.content)('tbody tr').length == 2
@@ -174,7 +174,7 @@ class TestRatingsModerationLog(ReviewerTest):
 
     def test_moderation_log_detail(self):
         review = self.make_review()
-        ActivityLog.create(amo.LOG.APPROVE_RATING, review, review.addon)
+        ActivityLog.objects.create(amo.LOG.APPROVE_RATING, review, review.addon)
         id_ = ActivityLog.objects.moderation_events()[0].id
         response = self.client.get(
             reverse('reviewers.ratings_moderation_log.detail', args=[id_])
@@ -196,7 +196,7 @@ class TestReviewLog(ReviewerTest):
 
     def make_approvals(self):
         for addon in Addon.objects.all():
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.REJECT_VERSION,
                 addon,
                 addon.current_version,
@@ -211,7 +211,7 @@ class TestReviewLog(ReviewerTest):
             user = self.get_user()
         if not addon:
             addon = Addon.objects.all()[0]
-        ActivityLog.create(
+        ActivityLog.objects.create(
             action,
             addon,
             addon.current_version,
@@ -273,7 +273,7 @@ class TestReviewLog(ReviewerTest):
         a = Addon.objects.all()[0]
         a.name = '<script>alert("xss")</script>'
         a.save()
-        ActivityLog.create(
+        ActivityLog.objects.create(
             amo.LOG.REJECT_VERSION,
             a,
             a.current_version,
@@ -333,7 +333,7 @@ class TestReviewLog(ReviewerTest):
         with freeze_time('2017-08-01 10:00'):
             addon = Addon.objects.first()
 
-            ActivityLog.create(
+            ActivityLog.objects.create(
                 amo.LOG.REJECT_VERSION,
                 addon,
                 addon.current_version,
@@ -472,7 +472,7 @@ class TestReviewLog(ReviewerTest):
         self.make_addon_unlisted(addon)
         self.grant_permission(self.user, 'Addons:ReviewUnlisted')
         version_factory(addon=addon, channel=amo.CHANNEL_UNLISTED, version='3.0')
-        ActivityLog.create(
+        ActivityLog.objects.create(
             amo.LOG.CONFIRM_AUTO_APPROVED,
             addon,
             *list(addon.versions.all()),
@@ -489,7 +489,7 @@ class TestReviewLog(ReviewerTest):
     def test_rejection_multiple_versions(self):
         addon = Addon.objects.get(pk=3615)
         version_factory(addon=addon, version='3.2.1')
-        ActivityLog.create(
+        ActivityLog.objects.create(
             amo.LOG.REJECT_VERSION,
             addon,
             *list(addon.versions.all()),
@@ -518,7 +518,7 @@ class TestReviewLog(ReviewerTest):
         addon = addon_factory()
         unlisted_version = version_factory(addon=addon, channel=amo.CHANNEL_UNLISTED)
 
-        ActivityLog.create(
+        ActivityLog.objects.create(
             amo.LOG.APPROVE_VERSION,
             addon,
             addon.current_version,
@@ -532,7 +532,7 @@ class TestReviewLog(ReviewerTest):
         link = pq(response.content)('#log-listing tbody tr[data-addonid] a').eq(0)
         assert link.attr('href') == url
 
-        entry = ActivityLog.create(
+        entry = ActivityLog.objects.create(
             amo.LOG.APPROVE_VERSION,
             addon,
             unlisted_version,
@@ -552,7 +552,7 @@ class TestReviewLog(ReviewerTest):
         self.login_as_reviewer()
         addon = addon_factory()
 
-        ActivityLog.create(
+        ActivityLog.objects.create(
             amo.LOG.FORCE_DISABLE,
             addon,
             user=self.get_user(),
@@ -2610,7 +2610,7 @@ class TestReview(ReviewBase):
         # be displayed in the "important changes" log.
         author = self.addon.addonuser_set.get()
         core.set_user(author.user)
-        ActivityLog.create(
+        ActivityLog.objects.create(
             amo.LOG.ADD_USER_WITH_ROLE,
             author.user,
             str(author.get_role_display()),
@@ -4553,26 +4553,26 @@ class TestReview(ReviewBase):
         # change and deletion.
         author = self.addon.addonuser_set.get()
         core.set_user(author.user)
-        activity0 = ActivityLog.create(
+        activity0 = ActivityLog.objects.create(
             amo.LOG.ADD_USER_WITH_ROLE,
             author.user,
             str(author.get_role_display()),
             self.addon,
         )
-        activity1 = ActivityLog.create(
+        activity1 = ActivityLog.objects.create(
             amo.LOG.CHANGE_USER_WITH_ROLE,
             author.user,
             str(author.get_role_display()),
             self.addon,
         )
-        activity2 = ActivityLog.create(
+        activity2 = ActivityLog.objects.create(
             amo.LOG.REMOVE_USER_WITH_ROLE,
             author.user,
             str(author.get_role_display()),
             self.addon,
         )
-        activity3 = ActivityLog.create(amo.LOG.FORCE_DISABLE, self.addon)
-        activity4 = ActivityLog.create(
+        activity3 = ActivityLog.objects.create(amo.LOG.FORCE_DISABLE, self.addon)
+        activity4 = ActivityLog.objects.create(
             amo.LOG.FORCE_ENABLE,
             self.addon,
         )

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -990,7 +990,7 @@ class ReviewBase:
 
         args = (*args, *self.data.get('reasons', []))
         kwargs = {'user': user or self.user, 'created': timestamp, 'details': details}
-        self.log_entry = ActivityLog.create(action, *args, **kwargs)
+        self.log_entry = ActivityLog.objects.create(action, *args, **kwargs)
 
     def notify_email(
         self, template, subject, perm_setting='reviewer_reviewed', version=None
@@ -1074,7 +1074,9 @@ class ReviewBase:
         assert not (self.version and self.version.is_blocked)
         if self.file:
             if self.file.is_experiment:
-                ActivityLog.create(amo.LOG.EXPERIMENT_SIGNED, self.file, user=self.user)
+                ActivityLog.objects.create(
+                    amo.LOG.EXPERIMENT_SIGNED, self.file, user=self.user
+                )
             sign_file(self.file)
 
     def process_comment(self):
@@ -1515,7 +1517,9 @@ class ReviewUnlisted(ReviewBase):
         # Sign addon.
         self.sign_file()
         if self.file:
-            ActivityLog.create(amo.LOG.UNLISTED_SIGNED, self.file, user=self.user)
+            ActivityLog.objects.create(
+                amo.LOG.UNLISTED_SIGNED, self.file, user=self.user
+            )
 
         self.set_file(amo.STATUS_APPROVED, self.file)
 
@@ -1612,7 +1616,9 @@ class ReviewUnlisted(ReviewBase):
             assert not version.is_blocked
             if version.file.status == amo.STATUS_AWAITING_REVIEW:
                 sign_file(version.file)
-            ActivityLog.create(amo.LOG.UNLISTED_SIGNED, version.file, user=self.user)
+            ActivityLog.objects.create(
+                amo.LOG.UNLISTED_SIGNED, version.file, user=self.user
+            )
             self.set_file(amo.STATUS_APPROVED, version.file)
             if self.human_review:
                 self.clear_specific_needs_human_review_flags(version)

--- a/src/olympia/scanners/tests/test_views.py
+++ b/src/olympia/scanners/tests/test_views.py
@@ -73,29 +73,33 @@ class TestScannerResultViewInternal(TestCase):
         good_result_1 = ScannerResult.objects.create(
             scanner=CUSTOMS, version=good_version_1
         )
-        ActivityLog.create(amo.LOG.APPROVE_VERSION, good_version_1, user=self.user)
+        ActivityLog.objects.create(
+            amo.LOG.APPROVE_VERSION, good_version_1, user=self.user
+        )
         # result labelled as "good" because auto-approve has been confirmed
         good_version_2 = version_factory(addon=addon_factory())
         good_result_2 = ScannerResult.objects.create(
             scanner=CUSTOMS, version=good_version_2
         )
-        ActivityLog.create(amo.LOG.APPROVE_VERSION, good_version_2, user=task_user)
-        ActivityLog.create(
+        ActivityLog.objects.create(
+            amo.LOG.APPROVE_VERSION, good_version_2, user=task_user
+        )
+        ActivityLog.objects.create(
             amo.LOG.CONFIRM_AUTO_APPROVED, good_version_2, user=self.user
         )
         # Simulate a reviewer who has confirmed auto-approval a second time. We
         # should not return duplicate results.
-        ActivityLog.create(
+        ActivityLog.objects.create(
             amo.LOG.CONFIRM_AUTO_APPROVED, good_version_2, user=self.user
         )
         # result NOT labelled as "good" because action is not correct.
         version_3 = version_factory(addon=addon_factory())
         ScannerResult.objects.create(scanner=YARA, version=version_3)
-        ActivityLog.create(amo.LOG.REJECT_VERSION, version_3, user=self.user)
+        ActivityLog.objects.create(amo.LOG.REJECT_VERSION, version_3, user=self.user)
         # result NOT labelled as "good" because user is TASK_USER_ID
         version_4 = version_factory(addon=addon_factory())
         ScannerResult.objects.create(scanner=YARA, version=version_4)
-        ActivityLog.create(amo.LOG.APPROVE_VERSION, version_4, user=task_user)
+        ActivityLog.objects.create(amo.LOG.APPROVE_VERSION, version_4, user=task_user)
 
         with override_settings(TASK_USER_ID=task_user.pk):
             response = self.client.get(self.url)
@@ -159,7 +163,7 @@ class TestScannerResultViewInternal(TestCase):
         good_version = version_factory(addon=addon_factory())
         ScannerResult.objects.create(scanner=CUSTOMS, version=good_version)
         VersionLog.objects.create(
-            activity_log=ActivityLog.create(
+            activity_log=ActivityLog.objects.create(
                 action=amo.LOG.APPROVE_VERSION,
                 version=good_version,
                 user=self.user,
@@ -198,7 +202,7 @@ class TestScannerResultViewInternal(TestCase):
         good_version = version_factory(addon=addon_factory())
         ScannerResult.objects.create(scanner=CUSTOMS, version=good_version)
         VersionLog.objects.create(
-            activity_log=ActivityLog.create(
+            activity_log=ActivityLog.objects.create(
                 action=amo.LOG.APPROVE_VERSION,
                 version=good_version,
                 user=self.user,
@@ -265,7 +269,7 @@ class TestScannerResultViewInternal(TestCase):
         # Result labelled as "good" because auto-approve has been confirmed.
         version_1 = version_factory(addon=addon_factory())
         result_1 = ScannerResult.objects.create(scanner=CUSTOMS, version=version_1)
-        ActivityLog.create(amo.LOG.APPROVE_VERSION, version_1, user=self.user)
+        ActivityLog.objects.create(amo.LOG.APPROVE_VERSION, version_1, user=self.user)
         # Oh noes! The version has been blocked.
         block_1 = block_factory(guid=version_1.addon.guid, updated_by=self.user)
         block_activity_log_save(block_1, change=False)
@@ -278,12 +282,20 @@ class TestScannerResultViewInternal(TestCase):
     def test_get_unique_bad_results(self):
         version_1 = version_factory(addon=addon_factory(), version='1.0')
         ScannerResult.objects.create(scanner=MAD, version=version_1)
-        ActivityLog.create(amo.LOG.BLOCKLIST_BLOCK_ADDED, version_1, user=self.user)
-        ActivityLog.create(amo.LOG.BLOCKLIST_BLOCK_EDITED, version_1, user=self.user)
+        ActivityLog.objects.create(
+            amo.LOG.BLOCKLIST_BLOCK_ADDED, version_1, user=self.user
+        )
+        ActivityLog.objects.create(
+            amo.LOG.BLOCKLIST_BLOCK_EDITED, version_1, user=self.user
+        )
         version_2 = version_factory(addon=addon_factory(), version='2.0')
         ScannerResult.objects.create(scanner=MAD, version=version_2)
-        ActivityLog.create(amo.LOG.BLOCKLIST_BLOCK_ADDED, version_2, user=self.user)
-        ActivityLog.create(amo.LOG.BLOCKLIST_BLOCK_EDITED, version_2, user=self.user)
+        ActivityLog.objects.create(
+            amo.LOG.BLOCKLIST_BLOCK_ADDED, version_2, user=self.user
+        )
+        ActivityLog.objects.create(
+            amo.LOG.BLOCKLIST_BLOCK_EDITED, version_2, user=self.user
+        )
 
         response = self.client.get(f'{self.url}?label=bad')
         results = self.assert_json_results(response, expected_results=2)
@@ -292,14 +304,22 @@ class TestScannerResultViewInternal(TestCase):
     def test_get_unique_good_results(self):
         version_1 = version_factory(addon=addon_factory(), version='1.0')
         ScannerResult.objects.create(scanner=MAD, version=version_1)
-        ActivityLog.create(amo.LOG.APPROVE_VERSION, version_1, user=self.user)
-        ActivityLog.create(amo.LOG.CONFIRM_AUTO_APPROVED, version_1, user=self.user)
-        ActivityLog.create(amo.LOG.CONFIRM_AUTO_APPROVED, version_1, user=self.user)
+        ActivityLog.objects.create(amo.LOG.APPROVE_VERSION, version_1, user=self.user)
+        ActivityLog.objects.create(
+            amo.LOG.CONFIRM_AUTO_APPROVED, version_1, user=self.user
+        )
+        ActivityLog.objects.create(
+            amo.LOG.CONFIRM_AUTO_APPROVED, version_1, user=self.user
+        )
         version_2 = version_factory(addon=addon_factory(), version='2.0')
         ScannerResult.objects.create(scanner=MAD, version=version_2)
-        ActivityLog.create(amo.LOG.APPROVE_VERSION, version_2, user=self.user)
-        ActivityLog.create(amo.LOG.CONFIRM_AUTO_APPROVED, version_2, user=self.user)
-        ActivityLog.create(amo.LOG.CONFIRM_AUTO_APPROVED, version_2, user=self.user)
+        ActivityLog.objects.create(amo.LOG.APPROVE_VERSION, version_2, user=self.user)
+        ActivityLog.objects.create(
+            amo.LOG.CONFIRM_AUTO_APPROVED, version_2, user=self.user
+        )
+        ActivityLog.objects.create(
+            amo.LOG.CONFIRM_AUTO_APPROVED, version_2, user=self.user
+        )
 
         response = self.client.get(f'{self.url}?label=good')
         results = self.assert_json_results(response, expected_results=2)

--- a/src/olympia/users/admin.py
+++ b/src/olympia/users/admin.py
@@ -282,8 +282,7 @@ class UserAdmin(AMOModelAdmin):
         if not acl.action_allowed_for(request.user, amo.permissions.USERS_EDIT):
             return HttpResponseForbidden()
 
-        ActivityLog.objects.create(amo.LOG.ADMIN_USER_BANNED, obj)
-        UserProfile.ban_and_disable_related_content_bulk([obj], move_files=True)
+        self.model.objects.filter(pk=obj.pk).ban_and_disable_related_content()
         kw = {'user': force_str(obj)}
         self.message_user(request, 'The user "%(user)s" has been banned.' % kw)
         return HttpResponseRedirect(

--- a/src/olympia/users/tests/test_admin.py
+++ b/src/olympia/users/tests/test_admin.py
@@ -163,10 +163,10 @@ class TestUserAdmin(TestCase):
         with core.override_remote_addr('127.0.0.2'):
             self.user.update(email='foo@bar.com')
             # That will make self.user match our query.
-            ActivityLog.create(amo.LOG.LOG_IN, user=self.user)
+            ActivityLog.objects.create(amo.LOG.LOG_IN, user=self.user)
         with core.override_remote_addr('127.0.0.1'):
             extra_user = user_factory()  # Extra user that shouldn't match
-            ActivityLog.create(amo.LOG.LOG_IN, user=extra_user)
+            ActivityLog.objects.create(amo.LOG.LOG_IN, user=extra_user)
         with self.assertNumQueries(6):
             # - 2 savepoint/release
             # - 2 logged in user & groups
@@ -188,17 +188,17 @@ class TestUserAdmin(TestCase):
         with core.override_remote_addr('127.0.0.2'):
             self.user.update(email='foo@bar.com')
             # That will make self.user match our query.
-            ActivityLog.create(amo.LOG.LOG_IN, user=self.user)
+            ActivityLog.objects.create(amo.LOG.LOG_IN, user=self.user)
         # 127.0.0.44 packed is b'\x7f\x00\x00,' - it's useful to test since it
         # contains a comma character, which would trip the split(',') we do on
         # the result of the GROUP_CONCAT if the binary value wasn't translated
         # to an IP address string representation before being grouped.
         with core.override_remote_addr('127.0.0.44'):
             # Add another login from a different IP to make sure we show it.
-            ActivityLog.create(amo.LOG.LOG_IN, user=self.user)
+            ActivityLog.objects.create(amo.LOG.LOG_IN, user=self.user)
         with core.override_remote_addr('127.0.0.1'):
             extra_user = user_factory()  # Extra user that shouldn't match
-            ActivityLog.create(amo.LOG.LOG_IN, user=extra_user)
+            ActivityLog.objects.create(amo.LOG.LOG_IN, user=extra_user)
         with self.assertNumQueries(6):
             # - 2 savepoint/release
             # - 2 logged in user & groups
@@ -221,16 +221,16 @@ class TestUserAdmin(TestCase):
         # Extra user that will match but not thanks to their last login ip...
         with core.override_remote_addr('127.0.0.1'):
             extra_user = user_factory(email='extra@bar.com')
-            ActivityLog.create(amo.LOG.LOG_IN, user=extra_user)
+            ActivityLog.objects.create(amo.LOG.LOG_IN, user=extra_user)
         with core.override_remote_addr('127.0.0.2'):
-            ActivityLog.create(amo.LOG.RESTRICTED, user=extra_user)
+            ActivityLog.objects.create(amo.LOG.RESTRICTED, user=extra_user)
         # Another one that will match through their activity
         extra_extra_user = user_factory(email='extra_extra@bar.com')
         with core.override_remote_addr('127.0.0.2'):
-            ActivityLog.create(amo.LOG.RESTRICTED, user=extra_extra_user)
+            ActivityLog.objects.create(amo.LOG.RESTRICTED, user=extra_extra_user)
         # And finally self.user that will also match
         with core.override_remote_addr('127.0.0.2'):
-            ActivityLog.create(amo.LOG.ADD_RATING, user=self.user)
+            ActivityLog.objects.create(amo.LOG.ADD_RATING, user=self.user)
         self.user.update(email='foo@bar.com')
         with self.assertNumQueries(6):
             # - 2 savepoint/release
@@ -261,7 +261,7 @@ class TestUserAdmin(TestCase):
         self.grant_permission(user, 'Users:Edit')
         self.client.force_login(user)
         with core.override_remote_addr('127.0.0.2'):
-            ActivityLog.create(amo.LOG.ADD_RATING, user=self.user)
+            ActivityLog.objects.create(amo.LOG.ADD_RATING, user=self.user)
         self.user.update(email='foo@bar.com')
         with self.assertNumQueries(6):
             # - 2 savepoint/release
@@ -283,7 +283,7 @@ class TestUserAdmin(TestCase):
         self.grant_permission(user, 'Users:Edit')
         self.client.force_login(user)
         with core.override_remote_addr('127.0.0.2'):
-            ActivityLog.create(amo.LOG.ADD_RATING, user=self.user)
+            ActivityLog.objects.create(amo.LOG.ADD_RATING, user=self.user)
         self.user.update(email='foo@bar.com')
         with self.assertNumQueries(6):
             # - 2 savepoint/release
@@ -305,7 +305,7 @@ class TestUserAdmin(TestCase):
         self.grant_permission(user, 'Users:Edit')
         self.client.force_login(user)
         with core.override_remote_addr('127.0.0.2'):
-            ActivityLog.create(amo.LOG.ADD_RATING, user=self.user)
+            ActivityLog.objects.create(amo.LOG.ADD_RATING, user=self.user)
         self.user.update(email='foo@bar.com')
         with self.assertNumQueries(6):
             # - 2 savepoint/release
@@ -327,7 +327,7 @@ class TestUserAdmin(TestCase):
         self.grant_permission(user, 'Users:Edit')
         self.client.force_login(user)
         with core.override_remote_addr('127.0.0.2'):
-            ActivityLog.create(amo.LOG.ADD_RATING, user=self.user)
+            ActivityLog.objects.create(amo.LOG.ADD_RATING, user=self.user)
         self.user.update(email='foo@bar.com')
         with self.assertNumQueries(6):
             # - 2 savepoint/release
@@ -350,21 +350,21 @@ class TestUserAdmin(TestCase):
         self.client.force_login(user)
         # Will match once with the last_login
         with core.override_remote_addr('127.0.0.3'):
-            ActivityLog.create(amo.LOG.LOG_IN, user=self.user)
+            ActivityLog.objects.create(amo.LOG.LOG_IN, user=self.user)
         self.user.update(email='foo@bar.com')
         # Will match twice, will only show up once since it's the same user.
         extra_user = user_factory(email='extra@bar.com')
         with core.override_remote_addr('127.0.0.2'):
-            ActivityLog.create(amo.LOG.LOG_IN, user=extra_user)
-            ActivityLog.create(amo.LOG.LOG_IN, user=extra_user)
+            ActivityLog.objects.create(amo.LOG.LOG_IN, user=extra_user)
+            ActivityLog.objects.create(amo.LOG.LOG_IN, user=extra_user)
         # Will match 4 times, will only show up once since it's the same user.
         extra_extra_user = user_factory(email='extra_extra@bar.com')
         with core.override_remote_addr('127.0.0.3'):
-            ActivityLog.create(amo.LOG.LOG_IN, user=extra_extra_user)
+            ActivityLog.objects.create(amo.LOG.LOG_IN, user=extra_extra_user)
         with core.override_remote_addr('127.0.0.2'):
-            ActivityLog.create(amo.LOG.RESTRICTED, user=extra_extra_user)
-            ActivityLog.create(amo.LOG.ADD_RATING, user=extra_extra_user)
-            ActivityLog.create(amo.LOG.ADD_VERSION, user=extra_extra_user)
+            ActivityLog.objects.create(amo.LOG.RESTRICTED, user=extra_extra_user)
+            ActivityLog.objects.create(amo.LOG.ADD_RATING, user=extra_extra_user)
+            ActivityLog.objects.create(amo.LOG.ADD_VERSION, user=extra_extra_user)
         with self.assertNumQueries(6):
             # - 2 savepoint/release
             # - 2 logged in user & groups
@@ -395,21 +395,21 @@ class TestUserAdmin(TestCase):
         self.client.force_login(user)
         # Will match once with the last_login
         with core.override_remote_addr('127.0.0.3'):
-            ActivityLog.create(amo.LOG.LOG_IN, user=self.user)
+            ActivityLog.objects.create(amo.LOG.LOG_IN, user=self.user)
         self.user.update(email='foo@bar.com')
         # Will match twice, will only show up once since it's the same user.
         extra_user = user_factory(email='extra@bar.com')
         with core.override_remote_addr('127.0.0.2'):
-            ActivityLog.create(amo.LOG.LOG_IN, user=extra_user)
-            ActivityLog.create(amo.LOG.LOG_IN, user=extra_user)
+            ActivityLog.objects.create(amo.LOG.LOG_IN, user=extra_user)
+            ActivityLog.objects.create(amo.LOG.LOG_IN, user=extra_user)
         # Will match 4 times, will only show up once since it's the same user.
         extra_extra_user = user_factory(email='extra_extra@bar.com')
         with core.override_remote_addr('127.0.0.3'):
-            ActivityLog.create(amo.LOG.LOG_IN, user=extra_extra_user)
+            ActivityLog.objects.create(amo.LOG.LOG_IN, user=extra_extra_user)
         with core.override_remote_addr('127.0.0.2'):
-            ActivityLog.create(amo.LOG.RESTRICTED, user=extra_extra_user)
-            ActivityLog.create(amo.LOG.ADD_RATING, user=extra_extra_user)
-            ActivityLog.create(amo.LOG.ADD_VERSION, user=extra_extra_user)
+            ActivityLog.objects.create(amo.LOG.RESTRICTED, user=extra_extra_user)
+            ActivityLog.objects.create(amo.LOG.ADD_RATING, user=extra_extra_user)
+            ActivityLog.objects.create(amo.LOG.ADD_VERSION, user=extra_extra_user)
         with self.assertNumQueries(6):
             # - 2 savepoint/release
             # - 2 logged in user & groups
@@ -529,7 +529,7 @@ class TestUserAdmin(TestCase):
         relations_that_should_survive = [
             AbuseReport.objects.create(reporter=self.user, guid='@foo'),
             AbuseReport.objects.create(user=self.user),
-            ActivityLog.create(user=self.user, action=amo.LOG.USER_EDITED),
+            ActivityLog.objects.create(user=self.user, action=amo.LOG.USER_EDITED),
             addon_with_other_authors,  # Has other authors, should be kept.
             # Bit of a weird case, but because the user was the only author of
             # this add-on, the addonuser relation is kept, and both the add-on
@@ -924,7 +924,7 @@ class TestUserAdmin(TestCase):
             Rating.objects.create(addon=dummy_addon, user=another_user)
         core.set_user(self.user)
         with core.override_remote_addr('127.1.2.3'):
-            ActivityLog.create(amo.LOG.LOG_IN, user=self.user)
+            ActivityLog.objects.create(amo.LOG.LOG_IN, user=self.user)
         with core.override_remote_addr('129.1.2.4'):
             Rating.objects.create(addon=addon_factory(), user=self.user)
         with core.override_remote_addr('128.1.2.3'):
@@ -944,11 +944,11 @@ class TestUserAdmin(TestCase):
         with core.override_remote_addr('130.1.2.4'):
             Rating.objects.create(addon=addon_factory(), user=self.user)
         with core.override_remote_addr('15.16.23.42'):
-            ActivityLog.create(amo.LOG.ADD_VERSION, dummy_addon, user=self.user)
+            ActivityLog.objects.create(amo.LOG.ADD_VERSION, dummy_addon, user=self.user)
         with core.override_remote_addr('4.8.15.16'):
-            ActivityLog.create(amo.LOG.RESTRICTED, user=self.user)
+            ActivityLog.objects.create(amo.LOG.RESTRICTED, user=self.user)
         with core.override_remote_addr('172.0.0.2'):
-            ActivityLog.create(amo.LOG.RESTRICTED, user=self.user)
+            ActivityLog.objects.create(amo.LOG.RESTRICTED, user=self.user)
         model_admin = UserAdmin(UserProfile, admin.site)
         doc = pq(model_admin.known_ip_adresses(self.user))
         result = doc('ul li').text().split()
@@ -971,11 +971,11 @@ class TestUserAdmin(TestCase):
                 user=self.user,
             )
         with core.override_remote_addr('172.0.0.2'):
-            ActivityLog.create(amo.LOG.ADD_VERSION, dummy_addon, user=self.user)
+            ActivityLog.objects.create(amo.LOG.ADD_VERSION, dummy_addon, user=self.user)
         with core.override_remote_addr('15.16.23.42'):
-            ActivityLog.create(amo.LOG.RESTRICTED, user=self.user)
+            ActivityLog.objects.create(amo.LOG.RESTRICTED, user=self.user)
         with core.override_remote_addr('4.8.15.16'):
-            ActivityLog.create(amo.LOG.RESTRICTED, user=self.user)
+            ActivityLog.objects.create(amo.LOG.RESTRICTED, user=self.user)
         doc = pq(model_admin.known_ip_adresses(self.user))
         result = doc('ul li').text().split()
         assert set(result) == {
@@ -1000,17 +1000,17 @@ class TestUserAdmin(TestCase):
         # set in the thread global at the time, so set that in advance.
         core.set_user(self.user)
         expected_date = self.days_ago(1)
-        activity = ActivityLog.create(amo.LOG.CREATE_ADDON, addon)
+        activity = ActivityLog.objects.create(amo.LOG.CREATE_ADDON, addon)
         activity.update(created=self.days_ago(2))
 
-        activity = ActivityLog.create(amo.LOG.EDIT_PROPERTIES, addon)
+        activity = ActivityLog.objects.create(amo.LOG.EDIT_PROPERTIES, addon)
         activity.update(created=expected_date)
 
         assert activity.reload().created == expected_date
 
         # Create another activity, more recent, attached to a different user.
         core.set_user(someone_else)
-        activity = ActivityLog.create(amo.LOG.EDIT_PROPERTIES, addon)
+        activity = ActivityLog.objects.create(amo.LOG.EDIT_PROPERTIES, addon)
 
         expected_result = localize(expected_date)
 
@@ -1079,13 +1079,13 @@ class TestUserAdmin(TestCase):
     def test_activity(self):
         addon = addon_factory()
         core.set_user(self.user)
-        ActivityLog.create(amo.LOG.CREATE_ADDON, addon)
-        ActivityLog.create(amo.LOG.EDIT_PROPERTIES, addon)
+        ActivityLog.objects.create(amo.LOG.CREATE_ADDON, addon)
+        ActivityLog.objects.create(amo.LOG.EDIT_PROPERTIES, addon)
 
         # Create another activity attached to a different user.
         someone_else = user_factory()
         core.set_user(someone_else)
-        ActivityLog.create(amo.LOG.EDIT_PROPERTIES, addon)
+        ActivityLog.objects.create(amo.LOG.EDIT_PROPERTIES, addon)
         url, text = self._call_related_content_method('activity')
         expected_url = (
             reverse('admin:activity_activitylog_changelist') + '?user=%d' % self.user.pk

--- a/src/olympia/users/tests/test_commands.py
+++ b/src/olympia/users/tests/test_commands.py
@@ -86,7 +86,7 @@ class TestClearOldUserData(TestCase):
         # deletion - so even if we change our minds about storing ips for
         # a given action after a while, we'll still correctly clear the old
         # data when it's time to do so.
-        activity = ActivityLog.create(amo.LOG.CUSTOM_TEXT, 'hi', user=user)
+        activity = ActivityLog.objects.create(amo.LOG.CUSTOM_TEXT, 'hi', user=user)
         IPLog.objects.create(activity_log=activity, ip_address_binary='127.0.0.56')
 
     def test_no_addons(self):


### PR DESCRIPTION
fixes #21471 - a lot of change here but the only changes of note are in ActivityLog and ActivityLogManager - and there it's largely just a straight move.  

I didn't move the associated object creation into a post_save or similar as it'd be the same code in a different place, pretty much, but I could?