### PR TITLE
send email notification to abuse reporter on decision

### DIFF
--- a/src/olympia/abuse/templates/abuse/emails/base_reporter.txt
+++ b/src/olympia/abuse/templates/abuse/emails/base_reporter.txt
@@ -1,0 +1,10 @@
+{% load i18n %}{% blocktranslate %}Hello,{% endblocktranslate %}
+
+{% block content %}{% endblock %}
+{# L10n: This is an email. Whitespace matters #}{% blocktranslate %}
+To learn more about our policies, please visit: https://extensionworkshop.com/documentation/publish/add-on-policies/ 
+and https://www.mozilla.org/about/legal/terms/mozilla/
+
+-- 
+Mozilla Add-ons Team
+{% endblocktranslate %}{{ SITE_URL }}

--- a/src/olympia/abuse/templates/abuse/emails/reporter_ignore.txt
+++ b/src/olympia/abuse/templates/abuse/emails/reporter_ignore.txt
@@ -1,0 +1,5 @@
+{% extends "abuse/emails/base_reporter.txt" %}{% load i18n %}{% block content %}{# L10n: This is an email. Whitespace matters #}{% blocktranslate %}
+Thank you for your report about {{ name }}, at {{ target_url }}. After review, it has been determined that the content does not violate any policy and will remain visible.
+
+You have the right to appeal this decision within 6 months. See {{ appeal_url }} for details on the appeal process.
+{% endblocktranslate %}{% endblock %}

--- a/src/olympia/abuse/templates/abuse/emails/reporter_restore.txt
+++ b/src/olympia/abuse/templates/abuse/emails/reporter_restore.txt
@@ -1,0 +1,5 @@
+{% extends "abuse/emails/base_reporter.txt" %}{% load i18n %}{% block content %}{# L10n: This is an email. Whitespace matters #}{% blocktranslate %}
+Thank you for your report about {{ name }}, at {{ target_url }}. Following further investigation we have decided to restore the content.
+
+You have the right to appeal this decision within 6 months. See {{ appeal_url }} for details on the appeal process.
+{% endblocktranslate %}{% endblock %}

--- a/src/olympia/abuse/templates/abuse/emails/reporter_takedown.txt
+++ b/src/olympia/abuse/templates/abuse/emails/reporter_takedown.txt
@@ -1,0 +1,3 @@
+{% extends "abuse/emails/base_reporter.txt" %}{% load i18n %}{% block content %}{# L10n: This is an email. Whitespace matters #}{% blocktranslate %}
+Thank you for your report about {{ name }}, at {{ target_url }}. We have taken action to remove the content.
+{% endblocktranslate %}{% endblock %}


### PR DESCRIPTION
fixes #21486 (+ driveby fix because I noticed we weren't absolutifying the appeal/content urls in the owner emails either)

