### PR TITLE
tmp: wip download csv

### DIFF
--- a/src/olympia/users/tasks.py
+++ b/src/olympia/users/tasks.py
@@ -1,3 +1,6 @@
+import requests
+from requests.exceptions import HTTPError, RequestException
+
 import olympia.core.logger
 from olympia.amo.celery import task
 from olympia.amo.decorators import set_modified_on, use_primary_db
@@ -65,3 +68,28 @@ def update_user_ratings_task(data, **kw):
     )
     for pk, rating in data:
         UserProfile.objects.filter(pk=pk).update(averagerating=round(float(rating), 2))
+
+SOCKET_LABS_SERVER = "13776"
+SOCKET_LABS_API_KEY = "SgxdyqBI725lo6QBKpgp.U8jWGW9hgnFyYSocTSkBFvZdPIzO1NoOE6Aw8IcC"
+
+SOCKET_LABS_URL = f"https://api.socketlabs.com/v2/server/{SOCKET_LABS_SERVER}/suppressions/search?pageSize=5&pageNumber=0&sortField=emailAddress&sortDirection=dsc"
+
+@task(autoretry_for=(HTTPError,), max_retries=5, retry_backoff=True)
+def download_suppressed_emails_csv():
+    print("Start")
+    url = SOCKET_LABS_URL
+
+    headers = {
+    'Authorization': f"Bearer {SOCKET_LABS_API_KEY}"
+    }
+
+    response = requests.get(url, headers=headers)
+    # response.raise_for_status()
+
+    print("End")
+    print(response.text)
+    ## Make an API call to socketlabs
+
+    ## Save the response to a local file with a timestamp
+
+    ## Trigger a celery task to process suppressed emails

--- a/src/olympia/users/tests/test_tasks.py
+++ b/src/olympia/users/tests/test_tasks.py
@@ -172,3 +172,17 @@ def test_resize_photo_poorly():
     # assert nothing happened
     src_image = Image.open(src.name)
     assert src_image.size == (339, 128)
+
+def test_download_suppressed_emails_csv_retriable_error():
+    # Make an API call to socketlabs that fails, but is retriable.
+    pass
+
+def test_download_suppressed_emails_csv_non_retriable_error():
+    # Make an API call to socketlabs that fails, and is not retriable.
+    pass
+
+def test_download_suppressed_emails_csv_success():
+    # Make an API call to socketlabs that succeeds.
+
+    # Save the response to a local file with a timestamp
+    pass


### PR DESCRIPTION
Fixes #21535

WIP for downloading the CSV file.. seems to not be working so well the API is returning 404s... status page is not down. Our suppression list is currently 21mb so maybe it is too big?
