### PR TITLE
chore(docker): Add port mapping for MySQL container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,8 @@ services:
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
       - MYSQL_DATABASE=olympia
+    ports:
+    - "3306:3306"
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.17.3


### PR DESCRIPTION
FIxes: #21559 

Add mysql port to docker compose config to allow host to connect to mysql during local development.

## Test

To test this, you need to "up" the docker.

```bash
docker-compose up
```

Then connect to mysql

```bash
 mysql -u root -h localhost olympia --protocol tcp
```
Note: assuming you have mysql CLI installed.











