### PR TITLE
add decision origination copy to BAN_USER email template too

### DIFF
--- a/src/olympia/abuse/templates/abuse/emails/CinderActionBanUser.txt
+++ b/src/olympia/abuse/templates/abuse/emails/CinderActionBanUser.txt
@@ -1,6 +1,6 @@
 {% extends "abuse/emails/base.txt" %}{% block content %}
 
-Your account on {{ SITE_URL }} has been banned.
+Your account on {{ SITE_URL }} has been banned, after we reviewed the content in response to a report by a third party, and found that it violated our Terms of Service.
 You will not be able to log in, and any content you submitted has been removed.
 
 {% endblock %}


### PR DESCRIPTION
fixes #21551 - there's an expectation these email templates will be revised before launch anyway (https://mozilla-hub.atlassian.net/browse/AMO-143) but this at least makes the copy consistent right now.