### PR TITLE
feat(): add api to check suppressed email

### DIFF
--- a/docs/topics/api/index.rst
+++ b/docs/topics/api/index.rst
@@ -47,4 +47,5 @@ using the API.
    reviewers
    scanners
    shelves
+   suppressed_emails
    tags

--- a/docs/topics/api/suppressed_emails.md
+++ b/docs/topics/api/suppressed_emails.md
@@ -1,0 +1,10 @@
+# Suppressed Emails
+
+This API is used to surface emails that we have detected are
+unable to recieve critical emails from our operations team.
+
+## Check Suppressed Email
+
+`/suppressed_emails/?email={email}`
+
+You can use this endpoint to check if an email is currently suppressed.

--- a/src/olympia/users/serializers.py
+++ b/src/olympia/users/serializers.py
@@ -1,0 +1,9 @@
+from rest_framework import serializers
+
+from .models import SuppressedEmail
+
+
+class SuppressedEmailSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SuppressedEmail
+        fields = '__all__'

--- a/src/olympia/users/urls.py
+++ b/src/olympia/users/urls.py
@@ -2,6 +2,8 @@ from django.urls import include, re_path
 
 from olympia.amo.views import frontend_view
 
+from . import views
+
 
 USER_ID = r"""(?P<user_id>[^/<>"']+)"""
 
@@ -21,8 +23,18 @@ users_patterns = [
     ),
 ]
 
+email_suppression_patterns = [
+    re_path(
+        r'^$',
+        views.SuppressedEmailDetailView.as_view(),
+        name='users.suppressedemails',
+    ),
+]
+
 urlpatterns = [
     # URLs for a single user.
     re_path(r'^user/%s/' % USER_ID, include(detail_patterns)),
     re_path(r'^users/', include(users_patterns)),
+    # URLs for email suppression.
+    re_path(r'^suppressed_emails/', include(email_suppression_patterns)),
 ]

--- a/src/olympia/users/views.py
+++ b/src/olympia/users/views.py
@@ -1,0 +1,19 @@
+from django.shortcuts import get_object_or_404
+
+from rest_framework.exceptions import ValidationError
+from rest_framework.generics import RetrieveAPIView
+
+from .models import SuppressedEmail
+from .serializers import SuppressedEmailSerializer
+
+
+class SuppressedEmailDetailView(RetrieveAPIView):
+    serializer_class = SuppressedEmailSerializer
+
+    def get_object(self):
+        email = self.request.query_params.get('email', None)
+        if email is not None:
+            print('email: ', email)
+            return get_object_or_404(SuppressedEmail, email__iexact=email)
+
+        raise ValidationError('email is required')


### PR DESCRIPTION
Related: #21578 

1/2 introduces an api for checking the if a given email address is suppressed.

```[tasklist]
### Tasks
- [x] add the api view and serializer
- [x] add tests
- [x] add documentation
```
