### PR TITLE
Introduce new CinderReport entity, attach reason and reporter to it

### DIFF
--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -18,6 +18,7 @@ from .cinder import (
     CinderAddonHandledByReviewers,
     CinderCollection,
     CinderRating,
+    CinderReport,
     CinderUnauthenticatedReporter,
     CinderUser,
 )
@@ -125,14 +126,14 @@ class CinderJob(ModelBase):
         return reporter
 
     @classmethod
-    def report(cls, abuse):
-        reporter = cls.get_cinder_reporter(abuse)
-        reason = AbuseReport.REASONS.for_value(abuse.reason)
-        job_id = cls.get_entity_helper(abuse).report(
-            report_text=abuse.message, category=reason.api_value, reporter=reporter
+    def report(cls, abuse_report):
+        report_entity = CinderReport(abuse_report)
+        reporter_entity = cls.get_cinder_reporter(abuse_report)
+        job_id = cls.get_entity_helper(abuse_report).report(
+            report=report_entity, reporter=reporter_entity
         )
         cinder_job, _ = cls.objects.get_or_create(job_id=job_id)
-        abuse.update(cinder_job=cinder_job)
+        abuse_report.update(cinder_job=cinder_job)
 
     def process_decision(
         self, *, decision_id, decision_date, decision_action, policy_ids

--- a/src/olympia/abuse/tests/test_tasks.py
+++ b/src/olympia/abuse/tests/test_tasks.py
@@ -207,7 +207,30 @@ def test_addon_report_to_cinder():
     request = responses.calls[0].request
     assert request.headers['authorization'] == 'Bearer fake-test-token'
     assert json.loads(request.body) == {
-        'context': {'entities': [], 'relationships': []},
+        'context': {
+            'entities': [
+                {
+                    'attributes': {
+                        'id': str(abuse_report.pk),
+                        'locale': None,
+                        'message': 'This is bad',
+                        'reason': 'DSA: It violates the law '
+                        'or contains content that '
+                        'violates the law',
+                    },
+                    'entity_type': 'amo_report',
+                }
+            ],
+            'relationships': [
+                {
+                    'relationship_type': 'amo_report_of',
+                    'source_id': str(abuse_report.pk),
+                    'source_type': 'amo_report',
+                    'target_id': str(addon.pk),
+                    'target_type': 'amo_addon',
+                }
+            ],
+        },
         'entity': {
             'id': str(addon.id),
             'average_daily_users': addon.average_daily_users,


### PR DESCRIPTION
This replaces the relationship between a reported entity and a reporter by two relationships: one between the reported entity and a new report entity, and one between that new report entity and the reporter.

Fixes #21571 