### PR TITLE
Implement basic view logic for displaying email suppression state

### DIFF
--- a/src/olympia/devhub/templates/devhub/nav.html
+++ b/src/olympia/devhub/templates/devhub/nav.html
@@ -6,6 +6,7 @@
     {% endtrans %}
   </a>
 </h1>
+{% include 'devhub/suppressed_email.html' %}
 <nav id="site-nav" class="menu-nav no-img c">
   <ul>
     {% if request.user.is_authenticated and request.user.is_developer %}

--- a/src/olympia/devhub/templates/devhub/new-landing/components/navigation.html
+++ b/src/olympia/devhub/templates/devhub/new-landing/components/navigation.html
@@ -1,3 +1,4 @@
+{% include 'devhub/suppressed_email.html' %}
 <nav id="nav-menu" class="DevHub-Navigation content scheme-light">
   <div class="DevHub-Navigation-list-wrapper">
     <ul>

--- a/src/olympia/devhub/templates/devhub/suppressed_email.html
+++ b/src/olympia/devhub/templates/devhub/suppressed_email.html
@@ -1,0 +1,9 @@
+{% if waffle.switch("suppressed-email") and request.user.is_authenticated and request.user.suppressed_email %}
+<div class="notification-box warning" id="suppressed-email">
+    <p>
+        {% trans email=request.user.email %}
+            We have discovered that your email "{{ email }}" is unable to receive emails from us. Please update your email address to one that can receive emails from us.
+        {% endtrans %}
+    </p>
+</div>
+{% endif %}

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -683,6 +683,10 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
         )
         activity.log_create(action, user=user)
 
+    @property
+    def suppressed_email(self):
+        return SuppressedEmail.objects.filter(email=self.email).first()
+
 
 class UserNotification(ModelBase):
     user = models.ForeignKey(

--- a/src/olympia/users/tests/test_models.py
+++ b/src/olympia/users/tests/test_models.py
@@ -912,6 +912,14 @@ class TestUserProfile(TestCase):
         lookup_field_random_string = UserProfile.get_lookup_field('my@mail.co')
         assert lookup_field_random_string == 'email'
 
+    def test_suppressed_email(self):
+        user = user_factory()
+        assert not user.suppressed_email
+
+        suppressed_email = SuppressedEmail.objects.create(email=user.email)
+
+        assert user.reload().suppressed_email == suppressed_email
+
 
 class TestDeniedName(TestCase):
     fixtures = ['users/test_backends']

--- a/static/css/devhub/new-landing/base.less
+++ b/static/css/devhub/new-landing/base.less
@@ -192,6 +192,7 @@ h4 {
 @import 'button';
 @import 'logo';
 @import 'navigation';
+@import 'notifications';
 
 // Content sections
 @import 'sections/overview';

--- a/static/css/devhub/new-landing/notifications.less
+++ b/static/css/devhub/new-landing/notifications.less
@@ -1,0 +1,47 @@
+
+/** Notifications **/
+.notification-box {
+  padding: 13px 13px 13px 58px;
+  font-family: "helvetica neue", arial, helvetica, sans-serif;
+  font-size: 13px;
+  position: relative;
+  background-color: #FFCD34;
+  color: #444;
+  display: flex;
+  align-items: center;
+  justify-self: space-around;
+}
+
+.notification-box p {
+   margin: 0 20px;
+}
+
+.notification-box button {
+  border: none;
+  padding: 5px 15px;
+}
+
+.notification-box:before {
+  content: "\00a0";
+  width: 32px;
+  height: 32px;
+  display: block;
+  left: 10px;
+  top: 50%;
+  margin-top: -16px;
+  position: absolute;
+  background-image:url(../../../img/zamboni/notifications.png);
+  background-position: 0 -225px;
+}
+
+.html-rtl .notification-box:before {
+  background-position: 0 -225px;
+  right: 10px;
+  left: auto;
+}
+
+
+.html-rtl .notification-box {
+  padding: 13px 58px 13px 13px;
+}
+


### PR DESCRIPTION
This pull request implements the basic view logic for displaying the email suppression state. It includes changes to the navigation menu, site title, and site navigation. Additionally, a new notification box is added to inform users about their suppressed email status. The `suppressed_email` decorator is also introduced to inject the request context with a boolean value indicating whether the user's email is suppressed. This PR sets the foundation for further email suppression functionality.

## UX

New landing page:

<img width="1440" alt="image" src="https://github.com/mozilla/addons-server/assets/19595165/1d158c5e-be41-44e7-ad02-4b782eae868a">

Dashboard:

<img width="1440" alt="image" src="https://github.com/mozilla/addons-server/assets/19595165/c5ff255d-5946-4736-870f-b08630224815">


## Testing

PR depends on waffle flag "suppressed-email". 

Toggle the feature via the docker container shell

```bash
make shell
```

Enable "suppressed-email" switch following this [guide](https://waffle.readthedocs.io/en/stable/usage/cli.html#switches).

### Test logged out

- any view in devhub available without auth should not display email suppression information, and should not error

### Test logged in (switch disabled)

- navigate to an auth protected page
- no email suppression information should be displayed as the feature is disabled

### Test logged in (switch enabled)
- navigate to an auth protected page
- notification banner should be present above the navigation bar indicating the the current user email is suppressed.
- NOTE: no CTA yet, this feature depends on unfinished APIs for managing email verification. That will come in a future PR.

Fixes #21578