### PR TITLE
chore(swagger): add session auth settings for authenticated requests in swagger ui

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -151,7 +151,33 @@ SITEMAP_DEBUG_AVAILABLE = True
 RECAPTCHA_PUBLIC_KEY = '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI'
 RECAPTCHA_PRIVATE_KEY = '6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe'
 
+ADDONS_SERVER_DOCS_URL = 'https://addons-server.readthedocs.io/en/latest'
+
+
 SWAGGER_SETTINGS = {
     'USE_SESSION_AUTH': False,
     'DEEP_LINKING': True,
+    'SECURITY_DEFINITIONS': {
+        'Session ID': {
+            'type': 'apiKey',
+            'name': 'Authorization',
+            'in': 'header',
+            'description': (
+                'Use your session ID found in the sessionid cookie. See the '
+                f'[docs]({ADDONS_SERVER_DOCS_URL}/topics/api/auth_internal.html). \n'
+                'Format as `Session <sessionid>`'
+            ),
+        },
+        'JWT': {
+            'type': 'apiKey',
+            'name': 'Authorization',
+            'in': 'header',
+            'description': (
+                'Use JWT token. see the '
+                f'[docs]({ADDONS_SERVER_DOCS_URL}/topics/api/auth.html). \n'
+                'Format as `JWT <token>`'
+            ),
+        },
+    },
+    'PERSIST_AUTH': True,
 }


### PR DESCRIPTION
Fixes: #21613

Quick fix for swagger UI to allow setting "Authorization": "Session <session-id>" headers to make authenticated requests from the UI.

https://github.com/mozilla/addons-server/assets/19595165/448c7436-3b36-4039-891b-045cae1b1956

## Testing

Follow the video more or less

1. open http://olympia.test/api/v5/swagger/#/accounts/accounts_account_read
2. click "try it out"
3. type a valid account ID (1 is probably a safe bet)
4. should get 404 and no authorization header
5. now click on the little lock
<img width="289" alt="image" src="https://github.com/mozilla/addons-server/assets/19595165/88bf809f-a9b1-4637-bb33-24fac8ea095e">
6. copy your sessionId from cookies and paste it (include the "Session" prefix)
7. now try to execute the api again.
8. you should now get back your user account in the swagger UI response box.

