### PR TITLE
chore(ci): add mysql-apt-config public key in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -464,7 +464,7 @@ commands:
       - run:
           name: Initial setup
           command: |
-            curl -sL https://repo.mysql.com/mysql-apt-config_0.8.24-1_all.deb --output mysql-apt-config.deb
+            curl -sL https://repo.mysql.com/mysql-apt-config_0.8.29-1_all.deb --output mysql-apt-config.deb
             sudo dpkg -i mysql-apt-config.deb
             sudo apt-get update -q
             sudo apt-get install -y gettext pngcrush librsvg2-bin libmysqlclient-dev


### PR DESCRIPTION
Relates to: #21629

CI was failing ([example](https://app.circleci.com/pipelines/github/mozilla/addons-server/28149/workflows/c7356664-e865-4ddd-9bb6-ae4092de582f/jobs/181122)) due to missing public key for mysql.

This PR adds the (deprecated) but fast way to fix this issue by adding the key with apt-key. We will need to replace this fix with the non-deprecated approach but I'm not confident enough with linux to attempt that solution now.

```
Err:3 http://repo.mysql.com/apt/ubuntu jammy InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY B7B3B788A8D3785C
```