### PR TITLE
Duplicate services/ URLs under /api/v5/services/

### DIFF
--- a/docs/topics/api/index.rst
+++ b/docs/topics/api/index.rst
@@ -45,6 +45,7 @@ using the API.
    licenses
    ratings
    reviewers
+   services
    scanners
    shelves
    tags

--- a/docs/topics/api/services.rst
+++ b/docs/topics/api/services.rst
@@ -1,0 +1,72 @@
+========
+Services
+========
+
+.. note::
+  
+      These APIs are not frozen and can change at any time without warning.
+      See :ref:`the API versions available<api-versions-list>` for alternatives
+      if you need stability.
+
+
+These special endpoints are meant for internal debugging, not for general use.
+
+-----------
+Client Info
+-----------
+
+.. _`api-client_info`:
+
+This endpoints returns basic information about the request environement. It is
+useful to test what the application sees behind the CDN and Load Balancers, as
+both will alter some of the HTTP headers / WSGI variables.
+
+Because it can return IP addresses, it only works in the ``addons-dev.allizom.org``
+environment.
+
+.. http:get:: /api/v5/services/client_info/
+
+    :>json string HTTP_USER_AGENT: The User-Agent HTTP header.
+    :>json string HTTP_X_COUNTRY_CODE: The ISO 3166-1 alpha-2 country code corresponding to the IP that made the request.
+    :>json string HTTP_X_FORWARDED_FOR: The X-Forwarded-For HTTP header.
+    :>json string REMOTE_ADDR: The IP address of the client.
+    :>json object POST: POST data of the request.
+    :>json object GET: GET data of the request.
+
+---
+403
+---
+
+.. _`api-403`:
+
+This endpoint returns a basic 403 error response.
+
+.. http:get:: /api/v5/services/403/
+
+    :>json string detail: Message explaining the error.
+
+---
+404
+---
+
+.. _`api-404`:
+
+This endpoint returns a basic 404 error response.
+
+.. http:get:: /api/v5/services/404/
+
+    :>json string detail: Message explaining the error.
+
+---
+500
+---
+
+.. _`api-500`:
+
+This endpoint returns a basic 500 error response. The ``traceback`` property in
+the response is only present on local environments, when ``DEBUG`` is ``True``.
+
+.. http:get:: /api/v5/services/500/
+
+    :>json string detail: Message explaining the error.
+    :>json string traceback: Traceback of the error.

--- a/src/olympia/amo/tests/test_views.py
+++ b/src/olympia/amo/tests/test_views.py
@@ -60,6 +60,12 @@ class Test403(TestCase):
         assert response.status_code == 403
         self.assertTemplateUsed(response, 'amo/403.html')
 
+    def test_403_api_services_api(self):
+        response = self.client.get('/api/v5/services/403')
+        assert response.status_code == 403
+        data = json.loads(response.content)
+        assert data['detail'] == 'You do not have permission to perform this action.'
+
 
 class Test404(TestCase):
     def test_404_no_app(self):
@@ -85,6 +91,12 @@ class Test404(TestCase):
 
     def test_404_api_v4(self):
         response = self.client.get('/api/v4/lol')
+        assert response.status_code == 404
+        data = json.loads(response.content)
+        assert data['detail'] == 'Not found.'
+
+    def test_404_api_services_api(self):
+        response = self.client.get('/api/v5/services/404')
         assert response.status_code == 404
         data = json.loads(response.content)
         assert data['detail'] == 'Not found.'
@@ -122,6 +134,13 @@ class Test500(TestCase):
         request = RequestFactory().get('/api/v4/addons/addon/lol/')
         APIRequestMiddleware(lambda: None).process_exception(request, Exception())
         response = handler500(request)
+        assert response.status_code == 500
+        assert response['Content-Type'] == 'application/json'
+        data = json.loads(response.content)
+        assert data['detail'] == 'Internal Server Error'
+
+    def test_500_api_services_api(self):
+        response = self.client.get('/api/v5/services/500')
         assert response.status_code == 500
         assert response['Content-Type'] == 'application/json'
         data = json.loads(response.content)

--- a/src/olympia/amo/tests/test_views.py
+++ b/src/olympia/amo/tests/test_views.py
@@ -637,6 +637,7 @@ def test_client_info():
             'HTTP_X_COUNTRY_CODE': None,
             'HTTP_X_FORWARDED_FOR': None,
             'REMOTE_ADDR': '127.0.0.1',
+            'SERVER_NAME': 'testserver',
             'GET': {},
             'POST': {},
         }
@@ -654,6 +655,7 @@ def test_client_info():
             'HTTP_X_COUNTRY_CODE': 'FR',
             'HTTP_X_FORWARDED_FOR': '192.0.0.2,193.0.0.1',
             'REMOTE_ADDR': '127.0.0.1',
+            'SERVER_NAME': 'testserver',
             'GET': {'foo': 'bar'},
             'POST': {},
         }
@@ -671,9 +673,22 @@ def test_client_info():
             'HTTP_X_COUNTRY_CODE': 'FR',
             'HTTP_X_FORWARDED_FOR': '192.0.0.2,193.0.0.1',
             'REMOTE_ADDR': '127.0.0.1',
+            'SERVER_NAME': 'testserver',
             'GET': {},
             'POST': {'foo': 'bar'},
         }
+
+
+@pytest.mark.django_db
+def test_api_services():
+    client = Client()
+
+    response = client.get(reverse('v5:amo.client_info'))
+    assert response.status_code == 403
+
+    with override_settings(ENV='dev'):
+        response = client.get(reverse('v5:amo.client_info'))
+    assert response.status_code == 200
 
 
 TEST_SITEMAPS_DIR = os.path.join(

--- a/src/olympia/amo/urls.py
+++ b/src/olympia/amo/urls.py
@@ -9,6 +9,13 @@ services_patterns = [
         r'^__heartbeat__$', views.services_heartbeat, name='amo.services_heartbeat'
     ),
     re_path(r'^monitor\.json$', views.services_heartbeat, name='amo.services_monitor'),
+]
+
+shared_services_api_patterns = [
+    # These patterns are duplicated under /services/ and /api/v5/services/,
+    # which is useful to reach those services from an API request, to make them
+    # work with services.a.m.o. or test their behavior with request.is_api
+    # being True.
     re_path(r'^client_info', views.client_info, name='amo.client_info'),
     re_path(r'^403', views.handler403),
     re_path(r'^404', views.handler404),
@@ -17,17 +24,14 @@ services_patterns = [
 
 api_patterns = [
     re_path(r'^site/$', views.SiteStatusView.as_view(), name='amo-site-status'),
-    # This duplicates services patterns under /api/vX/services/, which is
-    # useful to reach those services from an API request, to make them work
-    # with services.a.m.o. or test their behavior with request.is_api being
-    # True.
-    re_path(r'^services/', include(services_patterns)),
+    re_path(r'^services/', include(shared_services_api_patterns)),
 ]
 
 urlpatterns = [
     re_path(r'^robots\.txt$', views.robots, name='robots.txt'),
     re_path(r'^contribute\.json$', views.contribute, name='contribute.json'),
     re_path(r'^services/', include(services_patterns)),
+    re_path(r'^services/', include(shared_services_api_patterns)),
     re_path(r'^__version__$', views.version, name='version.json'),
     re_path(r'^__heartbeat__$', views.front_heartbeat, name='amo.front_heartbeat'),
     re_path(

--- a/src/olympia/amo/urls.py
+++ b/src/olympia/amo/urls.py
@@ -17,6 +17,11 @@ services_patterns = [
 
 api_patterns = [
     re_path(r'^site/$', views.SiteStatusView.as_view(), name='amo-site-status'),
+    # This duplicates services patterns under /api/vX/services/, which is
+    # useful to reach those services from an API request, to make them work
+    # with services.a.m.o. or test their behavior with request.is_api being
+    # True.
+    re_path(r'^services/', include(services_patterns)),
 ]
 
 urlpatterns = [

--- a/src/olympia/amo/views.py
+++ b/src/olympia/amo/views.py
@@ -15,7 +15,7 @@ from django.template.response import TemplateResponse
 from django.utils.cache import patch_cache_control
 from django.views.decorators.cache import never_cache
 
-from rest_framework.exceptions import NotFound
+from rest_framework import exceptions as drf_exceptions
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -110,6 +110,10 @@ def contribute(request):
 
 @non_atomic_requests
 def handler403(request, exception=None, **kwargs):
+    if getattr(request, 'is_api', False):
+        return JsonResponse(
+            {'detail': str(drf_exceptions.PermissionDenied.default_detail)}, status=403
+        )
     return TemplateResponse(request, 'amo/403.html', status=403)
 
 
@@ -117,7 +121,9 @@ def handler403(request, exception=None, **kwargs):
 def handler404(request, exception=None, **kwargs):
     if getattr(request, 'is_api', False):
         # It's a v3+ api request (/api/vX/ or /api/auth/)
-        return JsonResponse({'detail': str(NotFound.default_detail)}, status=404)
+        return JsonResponse(
+            {'detail': str(drf_exceptions.NotFound.default_detail)}, status=404
+        )
     elif re.match(r'^/api/\d\.\d/', getattr(request, 'path_info', '')):
         # It's a legacy API request in the form of /api/X.Y/. We use path_info,
         # which is set in LocaleAndAppURLMiddleware, because there might be a
@@ -140,9 +146,7 @@ def handler500(request, **kwargs):
         # custom_exception_handler function in olympia.api.exceptions, but in
         # the rare case where the exception is caused by a middleware or django
         # itself, it might not, so we need to handle it here.
-        return HttpResponse(
-            json.dumps(base_500_data()), content_type='application/json', status=500
-        )
+        return JsonResponse(base_500_data(), status=500)
     return TemplateResponse(request, 'amo/500.html', status=500)
 
 

--- a/src/olympia/amo/views.py
+++ b/src/olympia/amo/views.py
@@ -75,6 +75,7 @@ def client_info(request):
         'HTTP_X_COUNTRY_CODE',
         'HTTP_X_FORWARDED_FOR',
         'REMOTE_ADDR',
+        'SERVER_NAME',
     )
     data = {key: request.META.get(key) for key in keys}
     data['POST'] = request.POST


### PR DESCRIPTION
This makes it easier to reach those views for testing purposes, enabling us to reach `client_info/` from `services.a.m.o.` domain (which only accepts specific URL patterns like `/api/`) or test the various 40x/500 handlers from an API perspective.

Supports https://github.com/mozilla/addons-server/issues/21628 (will help test that my implementation for it is correct)

This enables:
- http://olympia.test/api/v5/services/500
- http://olympia.test/api/v5/services/404
- http://olympia.test/api/v5/services/403
- http://olympia.test/api/v5/services/client_info (if `settings.ENV` is `dev`)