### PR TITLE
Add AMO_REJECT_VERSION_ADDON to CinderJob.DECISION_ACTIONS

### DIFF
--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -45,6 +45,7 @@ class CinderJob(ModelBase):
         ('AMO_DELETE_RATING', 5, 'Rating delete'),
         ('AMO_DELETE_COLLECTION', 6, 'Collection delete'),
         ('AMO_APPROVE', 7, 'Approved (no action)'),
+        ('AMO_REJECT_VERSION_ADDON', 8, 'Add-on version reject'),
     )
     DECISION_ACTIONS.add_subset(
         'APPEALABLE_BY_AUTHOR',
@@ -53,6 +54,7 @@ class CinderJob(ModelBase):
             'AMO_DISABLE_ADDON',
             'AMO_DELETE_RATING',
             'AMO_DELETE_COLLECTION',
+            'AMO_REJECT_VERSION_ADDON',
         ),
     )
     DECISION_ACTIONS.add_subset(

--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -45,6 +45,9 @@ class CinderJob(ModelBase):
         ('AMO_DELETE_RATING', 5, 'Rating delete'),
         ('AMO_DELETE_COLLECTION', 6, 'Collection delete'),
         ('AMO_APPROVE', 7, 'Approved (no action)'),
+        # Rejecting versions is not an available action for moderators in cinder
+        # - it is only handled by the reviewer tools by AMO Reviewers.
+        # It should not be sent by the cinder webhook, & does not have an action defined
         ('AMO_REJECT_VERSION_ADDON', 8, 'Add-on version reject'),
     )
     DECISION_ACTIONS.add_subset(

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -3156,7 +3156,9 @@ class TestReviewHelper(TestReviewHelperBase):
             amo.CHANNEL_LISTED,
             [
                 'public',
+                'reject',
                 'confirm_auto_approved',
+                'reject_multiple_versions',
                 'clear_needs_human_review_multiple_versions',
                 'disable_addon',
             ],
@@ -3168,6 +3170,7 @@ class TestReviewHelper(TestReviewHelperBase):
             [
                 'public',
                 'approve_multiple_versions',
+                'reject_multiple_versions',
                 'confirm_multiple_versions',
                 'clear_needs_human_review_multiple_versions',
                 'disable_addon',

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -613,6 +613,7 @@ class ReviewHelper:
                 and is_appropriate_reviewer
             ),
             'allows_reasons': True,
+            'resolves_abuse_reports': True,
             'requires_reasons': not is_static_theme,
             'boilerplate_text': boilerplate_for_reject,
         }
@@ -681,6 +682,7 @@ class ReviewHelper:
             ),
             'available': (can_reject_multiple),
             'allows_reasons': True,
+            'resolves_abuse_reports': True,
             'requires_reasons': not is_static_theme,
             'boilerplate_text': boilerplate_for_reject,
         }
@@ -1205,6 +1207,9 @@ class ReviewBase:
             # at.
             self.clear_specific_needs_human_review_flags(self.version)
             self.set_human_review_date()
+            self.resolve_abuse_reports(
+                CinderJob.DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON
+            )
 
         self.log_action(amo.LOG.REJECT_VERSION)
         template = '%s_to_rejected' % self.review_type
@@ -1415,7 +1420,6 @@ class ReviewBase:
         # don't need to notify the developer (we should already have done that
         # before) and don't need to award points.
         if self.human_review:
-            channel = latest_version.channel
             # Send the email to the developer. We need to pass the latest
             # version of the add-on instead of one of the versions we rejected,
             # it will be used to generate a token allowing the developer to
@@ -1438,6 +1442,9 @@ class ReviewBase:
                 template = 'reject_multiple_versions'
                 subject = 'Mozilla Add-ons: Versions disabled for %s%s'
             log.info('Sending email for %s' % (self.addon))
+            self.resolve_abuse_reports(
+                CinderJob.DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON
+            )
             self.notify_email(template, subject, version=latest_version)
 
     def unreject_latest_version(self):


### PR DESCRIPTION
fixes #21671 - though there will be more changes once [emails are aligned](https://github.com/mozilla/addons-server/issues/21705).