### PR TITLE
chore(github): update PR template.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,6 @@
+<!-- 
 Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
+-->
 
 <!-- REQUIRED  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
 Fixes: `<issue-number>`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,48 @@
 Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
 
-Please delete anything that isn't relevant to your patch.
+<!-- REQUIRED  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
+Fixes: `<issue-number>`
 
-* [ ] This PR relates to an existing open issue and there are no existing
-      PRs open for the same issue.
-* [ ] Add `Fixes #ISSUENUM` at the top of your PR.
-* [ ] Add a description of the changes introduced in this PR.
-* [ ] The change has been successfully run locally.
-* [ ] Add tests to cover the changes added in this PR.
-* [ ] Add before and after screenshots (Only for changes that impact the UI).
+## How did you solve the problem?
 
-Once you have met the above requirements please replace this section with
-a `Fixes #ISSUENUM` linking to the issue fixed by this PR along with an
-explanation of the changes. Thanks for your contribution!
+<!-- REQUIRED
+
+Short description of the changes you made and how they address the linked issue.
+This should be written directly in the PR so reviewers and testers understand a basic overview of the change.
+It also ensures this PR is self documenting to viewers from the future.
+
+-->
+
+## What should the reviewer focus on?
+
+<!-- OPTIONAL
+
+Help the reviewer by pointing to parts of the PR that might need special attention or where you would like explicit feedback.
+
+-->
+
+## How to test this PR?
+
+<!-- REQUIRED
+
+Include explicit steps to test this PR. Valid answers include:
+- filling the task list below with steps to execute the code and expected outcomes.
+- tested in CI, no explicit testing needed (for PRs where this is true)
+- link to test scenarios in the issue or some other document. No need to repeat yourself
+
+-->
+
+### Test template (replace with a block for each scenario)
+
+1. Open http://olympia.test
+2. Navigate to X
+3. Click Button
+
+**expected**: You see a notification telling you the current time.
+
+## Check list
+
+- [ ] This PR relates to an existing open issue and there are no existing PRs open for the same issue.
+- [ ] The change has been successfully run locally.
+- [ ] Add tests to cover the changes added in this PR.
+- [ ] Add before and after screenshots (Only for changes that impact the UI).


### PR DESCRIPTION
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.

<!-- REQUIRED  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Fixes: N/A

## How did you solve the problem?

I updated the github PR template to include specific sections for required information and clear descriptions. Each section includes examples and links to help the PR author and specifies which sections are required.

## What should the reviewer focus on?

If we want to maintain a separate pull request template for community PRs, that is also [possible](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository). We can create a directory of PR templates and open them with query parameters or selecting in the Web UI.

If we want to extend this template to other addon repositories, we [could](https://www.rhysmills.com/post/2021/09/07/set-a-default-pr-template-for-a-github-organisation.html) do so, but would require moving the addon repos to a separate org. Probably not worth it.

## How to test this PR?

No testing required.
