### PR TITLE
Fix SERVICES_DOMAIN to be correct on dev/stage/prod

### DIFF
--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -17,11 +17,12 @@ RAISE_ON_SIGNAL_ERROR = True
 API_THROTTLING = True
 
 DOMAIN = env('DOMAIN', default='addons-dev.allizom.org')
+SERVICES_DOMAIN = env('SERVICES_DOMAIN', default='services.addons-dev.allizom.org')
 SERVER_EMAIL = 'zdev@addons.mozilla.org'
 SITE_URL = 'https://' + DOMAIN
 INTERNAL_SITE_URL = env('INTERNAL_SITE_URL', default='https://addons-dev.allizom.org')
 EXTERNAL_SITE_URL = env('EXTERNAL_SITE_URL', default='https://addons-dev.allizom.org')
-SERVICES_URL = env('SERVICES_URL', default='https://services.addons-dev.allizom.org')
+SERVICES_URL = 'https://' + SERVICES_DOMAIN
 CODE_MANAGER_URL = env(
     'CODE_MANAGER_URL', default='https://code.addons-dev.allizom.org'
 )

--- a/src/olympia/conf/prod/settings.py
+++ b/src/olympia/conf/prod/settings.py
@@ -26,10 +26,11 @@ API_THROTTLING = True
 
 DOMAIN = env('DOMAIN', default='addons.mozilla.org')
 SERVER_EMAIL = 'zprod@addons.mozilla.org'
+SERVICES_DOMAIN = env('SERVICES_DOMAIN', default='services.addons.mozilla.org')
 SITE_URL = 'https://' + DOMAIN
 INTERNAL_SITE_URL = env('INTERNAL_SITE_URL', default='https://addons.mozilla.org')
 EXTERNAL_SITE_URL = env('EXTERNAL_SITE_URL', default='https://addons.mozilla.org')
-SERVICES_URL = env('SERVICES_URL', default='https://services.addons.mozilla.org')
+SERVICES_URL = 'https://' + SERVICES_DOMAIN
 CODE_MANAGER_URL = env('CODE_MANAGER_URL', default='https://code.addons.mozilla.org')
 STATIC_URL = PROD_STATIC_URL
 MEDIA_URL = PROD_MEDIA_URL

--- a/src/olympia/conf/stage/settings.py
+++ b/src/olympia/conf/stage/settings.py
@@ -16,11 +16,12 @@ ENV = env('ENV')
 API_THROTTLING = True
 
 DOMAIN = env('DOMAIN', default='addons.allizom.org')
+SERVICES_DOMAIN = env('SERVICES_DOMAIN', default='services.addons.allizom.org')
 SERVER_EMAIL = 'zstage@addons.mozilla.org'
 SITE_URL = 'https://' + DOMAIN
 INTERNAL_SITE_URL = env('INTERNAL_SITE_URL', default='https://addons.allizom.org')
 EXTERNAL_SITE_URL = env('EXTERNAL_SITE_URL', default='https://addons.allizom.org')
-SERVICES_URL = env('SERVICES_URL', default='https://services.addons.allizom.org')
+SERVICES_URL = 'https://' + SERVICES_DOMAIN
 CODE_MANAGER_URL = env('CODE_MANAGER_URL', default='https://code.addons.allizom.org')
 STATIC_URL = '%s/static-server/' % EXTERNAL_SITE_URL
 MEDIA_URL = '%s/user-media/' % EXTERNAL_SITE_URL


### PR DESCRIPTION
Fixes #21628

`SERVICES_DOMAIN` was only set in `olympia/lib/settings_base.py`, so it was evaluated early, end up with the domain set by:
https://github.com/mozilla/addons-server/blob/6c4fc0d2fc4198f154f538f950fa7f86ea37a41f/src/olympia/lib/settings_base.py#L197-L204

Which means that on dev for instance, it was `services.addons-server-v1-deploy-uwsgi-amo-web-<id>`, which obviously is completely wrong. `SERVICES_URL` _was_ overridden in the relevant settings files and so was correct.

This doesn't impact production code (both settings are mostly unused - there is one check in `robots` function that was broken, but it's unreachable as nginx doesn't route `robots.txt` for the services domain, and the other use is what I want to fix here, [the recent introduction of a specific caching duration for the services domain](https://github.com/mozilla/addons-server/issues/21628) which isn't in prod yet).