### PR TITLE
Show outstanding reports per cinderjob

### DIFF
--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -37,6 +37,52 @@ from .utils import (
 )
 
 
+class CinderJobQuerySet(BaseQuerySet):
+    def for_addon(self, addon):
+        return (
+            self.filter(
+                Q(abusereport__guid=addon.addonguid_guid)
+                | Q(appealed_jobs__abusereport__guid=addon.addonguid_guid)
+            )
+            .order_by('-created')
+            .distinct()
+        )
+
+    def unresolved(self):
+        return self.filter(
+            decision_action__in=tuple(CinderJob.DECISION_ACTIONS.UNRESOLVED.values)
+        )
+
+    def reviewer_handled(self):
+        # Note this isn't as comprehensive as AbuseReport.reviewer_handled - it doesn't
+        # verify the guids are valid add-ons.
+        filter_fields = dict(
+            abusereport__reason__in=tuple(AbuseReport.REASONS.REVIEWER_HANDLED.values),
+            abusereport__location__in=tuple(
+                AbuseReport.LOCATION.REVIEWER_HANDLED.values
+            ),
+        )
+        return self.exclude(
+            abusereport__guid=None, appealed_jobs__abusereport__guid=None
+        ).filter(
+            Q(**filter_fields)
+            | Q(**{'appealed_jobs__' + key: val for key, val in filter_fields.items()})
+        )
+
+
+class CinderJobManager(ManagerBase):
+    _queryset_class = CinderJobQuerySet
+
+    def for_addon(self, addon):
+        return self.get_queryset().for_addon(addon)
+
+    def unresolved(self):
+        return self.get_queryset().unresolved()
+
+    def reviewer_handled(self):
+        return self.get_queryset().reviewer_handled()
+
+
 class CinderJob(ModelBase):
     DECISION_ACTIONS = APIChoicesWithDash(
         ('NO_DECISION', 0, 'No decision'),
@@ -89,6 +135,8 @@ class CinderJob(ModelBase):
         # appeal for multiple previous decisions (jobs).
         related_name='appealed_jobs',
     )
+
+    objects = CinderJobManager()
 
     @property
     def target(self):
@@ -300,36 +348,12 @@ class AbuseReportQuerySet(BaseQuerySet):
             .order_by('-created')
         )
 
-    def unresolved(self):
-        return self.filter(
-            Q(
-                cinder_job__decision_action__in=tuple(
-                    CinderJob.DECISION_ACTIONS.UNRESOLVED.values
-                )
-            )
-            | Q(cinder_job__isnull=True)
-        )
-
-    def reviewer_handled(self):
-        # Note this isn't as comprehensive as AbuseReport.reviewer_handled - it doesn't
-        # verify the guids are valid add-ons.
-        return self.exclude(guid=None).filter(
-            reason__in=tuple(AbuseReport.REASONS.REVIEWER_HANDLED.values),
-            location__in=tuple(AbuseReport.LOCATION.REVIEWER_HANDLED.values),
-        )
-
 
 class AbuseReportManager(ManagerBase):
     _queryset_class = AbuseReportQuerySet
 
     def for_addon(self, addon):
         return self.get_queryset().for_addon(addon)
-
-    def unresolved(self):
-        return self.get_queryset().unresolved()
-
-    def reviewer_handled(self):
-        return self.get_queryset().reviewer_handled()
 
 
 class AbuseReport(ModelBase):

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -188,26 +188,11 @@
         </div>
       </div>
 
-      <div class="review-actions-section review-resolve-abuse-reports"
+      <div class="review-actions-section data-toggle review-resolve-abuse-reports"
            data-value="{{ actions_resolves_abuse_reports|join(' ') }}">
-          <label><strong>Outstanding abuse reports:</strong></label>
-          {% if unresolved_abuse_reports|length > 0 %}
-            {{ form.resolve_abuse_reports }}
-            {{ form.resolve_abuse_reports.errors }}
-            <label for="id_resolve_abuse_reports">{{ form.resolve_abuse_reports.label|format(unresolved_abuse_reports|length) }}</label>
-            <details>
-              <summary>
-                Show reports
-              </summary>
-              <ul>
-              {% for report in unresolved_abuse_reports %}
-                <li>{{ report.message }}</li>
-              {% endfor %}
-              </ul>
-            </details>
-          {% else %}
-            No reports to resolve
-          {% endif %}
+          <strong><label for="id_resolve_cinder_jobs">{{ form.resolve_cinder_jobs.label }}</label></strong>
+          {{ form.resolve_cinder_jobs }}
+          {{ form.resolve_cinder_jobs.errors }}
       </div>
 
       <div class="review-actions-section review-actions-files data-toggle review-files"

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -5540,13 +5540,11 @@ class TestReview(ReviewBase):
             message='Its baaaad',
         )
         response = self.client.get(self.url)
-        self.assertContains(response, 'No reports to resolve')
-        self.assertNotContains(response, 'DSA related reports?')
+        self.assertNotContains(response, 'Show 1 reports')
 
         with override_switch('enable-cinder-reporting', active=True):
             response = self.client.get(self.url)
-            self.assertNotContains(response, 'No reports to resolve')
-            self.assertContains(response, 'Resolve 1 DSA related reports?')
+            self.assertContains(response, 'Show 1 reports')
             self.assertContains(response, 'Its baaaad')
 
     @override_switch('enable-cinder-reporting', active=True)
@@ -5581,7 +5579,7 @@ class TestReview(ReviewBase):
             self.get_dict(
                 action='disable_addon',
                 reasons=[reason.id],
-                resolve_abuse_reports=True,
+                resolve_cinder_jobs=[cinder_job.id],
             ),
         )
         assert self.get_addon().status == amo.STATUS_DISABLED
@@ -5624,7 +5622,9 @@ class TestReview(ReviewBase):
         self.client.post(
             self.url,
             self.get_dict(
-                action='public', reasons=[reason.id], resolve_abuse_reports=True
+                action='public',
+                reasons=[reason.id],
+                resolve_cinder_jobs=[cinder_job.id],
             ),
         )
 


### PR DESCRIPTION
fixes #21670 - the UI isn't great, and possibly other information needs to be shown about the abuse reports, but it minimally allows _some_ sets of abuse reports to be resolved without all of them needing to be.

![Screenshot 2024-01-17 133659](https://github.com/mozilla/addons-server/assets/768592/629b8f25-90ab-4c94-aeb2-4d853cce01ba)
