### PR TITLE
Implement throttling on abuse appeal form

### DIFF
--- a/src/olympia/abuse/forms.py
+++ b/src/olympia/abuse/forms.py
@@ -34,11 +34,6 @@ class AbuseAppealEmailForm(CheckThrottlesFormMixin, forms.Form):
     # reporter, or from the target of a ban (who can no longer log in).
     email = forms.EmailField(label=_('Email address'))
 
-    throttled_error_message = _(
-        'You have submitted this form too many times recently. '
-        'Please try again after some time.'
-    )
-
     throttle_classes = (
         HourlyAbuseAppealIPThrottle,
         AbuseAppealIPThrottle,
@@ -60,11 +55,6 @@ class AbuseAppealEmailForm(CheckThrottlesFormMixin, forms.Form):
 
 
 class AbuseAppealForm(CheckThrottlesFormMixin, forms.Form):
-    throttled_error_message = _(
-        'You have submitted this form too many times recently. '
-        'Please try again after some time.'
-    )
-
     throttle_classes = (
         HourlyAbuseAppealIPThrottle,
         AbuseAppealIPThrottle,

--- a/src/olympia/abuse/forms.py
+++ b/src/olympia/abuse/forms.py
@@ -1,13 +1,50 @@
 from django import forms
 from django.utils.translation import gettext_lazy as _
 
+from olympia.api.throttling import (
+    CheckThrottlesFormMixin,
+    GranularIPRateThrottle,
+    GranularUserRateThrottle,
+)
 
-class AbuseAppealEmailForm(forms.Form):
+
+class HourlyAbuseAppealUserThrottle(GranularUserRateThrottle):
+    rate = '6/hour'
+    scope = 'hourly_user_abuse_appeal'
+
+
+class HourlyAbuseAppealIPThrottle(GranularIPRateThrottle):
+    rate = '6/hour'
+    scope = 'hourly_ip_abuse_appeal'
+
+
+class AbuseAppealUserThrottle(GranularUserRateThrottle):
+    rate = '20/day'
+    scope = 'daily_user_abuse_appeal'
+
+
+class AbuseAppealIPThrottle(GranularIPRateThrottle):
+    rate = '20/day'
+    scope = 'daily_ip_abuse_appeal'
+
+
+class AbuseAppealEmailForm(CheckThrottlesFormMixin, forms.Form):
     # Note: the label is generic on purpose. It could be an appeal from the
     # reporter, or from the target of a ban (who can no longer log in).
     email = forms.EmailField(label=_('Email address'))
 
+    throttled_error_message = _(
+        'You have submitted this form too many times recently. '
+        'Please try again after some time.'
+    )
+
+    throttle_classes = (
+        HourlyAbuseAppealIPThrottle,
+        AbuseAppealIPThrottle,
+    )
+
     def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop('request')
         self.expected_email = kwargs.pop('expected_email')
         return super().__init__(*args, **kwargs)
 
@@ -17,7 +54,23 @@ class AbuseAppealEmailForm(forms.Form):
         return email
 
 
-class AbuseAppealForm(forms.Form):
+class AbuseAppealForm(CheckThrottlesFormMixin, forms.Form):
+    error_message = _(
+        'You have submitted this form too many times recently. '
+        'Please try again after some time.'
+    )
+
+    throttle_classes = (
+        HourlyAbuseAppealIPThrottle,
+        AbuseAppealIPThrottle,
+        HourlyAbuseAppealIPThrottle,
+        AbuseAppealUserThrottle,
+    )
+
+    def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop('request')
+        return super().__init__(*args, **kwargs)
+
     reason = forms.CharField(
         widget=forms.Textarea(),
         label=_('Reason for appeal'),

--- a/src/olympia/abuse/forms.py
+++ b/src/olympia/abuse/forms.py
@@ -45,17 +45,20 @@ class AbuseAppealEmailForm(CheckThrottlesFormMixin, forms.Form):
 
     def __init__(self, *args, **kwargs):
         self.request = kwargs.pop('request')
-        self.expected_email = kwargs.pop('expected_email')
+        self.expected_email = kwargs.pop('expected_email', None)
         return super().__init__(*args, **kwargs)
 
     def clean_email(self):
-        if (email := self.cleaned_data['email']) != self.expected_email:
+        if (
+            self.expected_email is None
+            or (email := self.cleaned_data['email']) != self.expected_email
+        ):
             raise forms.ValidationError(_('Invalid email provided.'))
         return email
 
 
 class AbuseAppealForm(CheckThrottlesFormMixin, forms.Form):
-    error_message = _(
+    throttled_error_message = _(
         'You have submitted this form too many times recently. '
         'Please try again after some time.'
     )

--- a/src/olympia/abuse/tests/test_forms.py
+++ b/src/olympia/abuse/tests/test_forms.py
@@ -1,0 +1,28 @@
+from django.core.exceptions import ImproperlyConfigured
+from django.test.client import RequestFactory
+
+import pytest
+
+from olympia.abuse.forms import AbuseAppealEmailForm, AbuseAppealForm
+
+
+def test_abuse_appeal_email_form_no_request_or_expected_email_raises():
+    with pytest.raises(KeyError):
+        AbuseAppealEmailForm()
+
+    request = RequestFactory().get('/')
+    with pytest.raises(KeyError):
+        AbuseAppealEmailForm(request=request)
+
+    with pytest.raises(ImproperlyConfigured):
+        AbuseAppealEmailForm(request=request, expected_email=None)
+
+    AbuseAppealEmailForm(request=request, expected_email='foo@example.com')
+
+
+def test_abuse_appeal_email_form_no_request_raises():
+    with pytest.raises(KeyError):
+        AbuseAppealForm()
+
+    request = RequestFactory().get('/')
+    AbuseAppealForm(request=request)

--- a/src/olympia/abuse/tests/test_views.py
+++ b/src/olympia/abuse/tests/test_views.py
@@ -1938,6 +1938,7 @@ class TestAppeal(TestCase):
             for _x in range(0, 6):
                 self._add_fake_throttling_action(
                     view_class=AbuseAppealEmailForm,
+                    view_kwargs={'expected_email': 'doesntmatter@example.com'},
                     url=self.author_appeal_url,
                     remote_addr='5.6.7.8',
                 )
@@ -1972,6 +1973,7 @@ class TestAppeal(TestCase):
             for _x in range(0, 15):
                 self._add_fake_throttling_action(
                     view_class=AbuseAppealEmailForm,
+                    view_kwargs={'expected_email': 'doesntmatter@example.com'},
                     url=self.author_appeal_url,
                     remote_addr='5.6.7.8',
                 )
@@ -2017,6 +2019,7 @@ class TestAppeal(TestCase):
             for _x in range(0, 6):
                 self._add_fake_throttling_action(
                     view_class=AbuseAppealEmailForm,
+                    view_kwargs={'expected_email': 'doesntmatter@example.com'},
                     url=self.author_appeal_url,
                     remote_addr='5.6.7.8',
                 )
@@ -2049,6 +2052,7 @@ class TestAppeal(TestCase):
             for _x in range(0, 6):
                 self._add_fake_throttling_action(
                     view_class=AbuseAppealEmailForm,
+                    view_kwargs={'expected_email': 'doesntmatter@example.com'},
                     url=self.author_appeal_url,
                     remote_addr='5.6.7.8',
                     user=user,
@@ -2083,6 +2087,7 @@ class TestAppeal(TestCase):
             for _x in range(0, 15):
                 self._add_fake_throttling_action(
                     view_class=AbuseAppealEmailForm,
+                    view_kwargs={'expected_email': 'doesntmatter@example.com'},
                     url=self.author_appeal_url,
                     remote_addr='5.6.7.8',
                     user=user,

--- a/src/olympia/abuse/tests/test_views.py
+++ b/src/olympia/abuse/tests/test_views.py
@@ -2,7 +2,7 @@ import hashlib
 import hmac
 import json
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest import mock
 
 from django.conf import settings
@@ -10,11 +10,13 @@ from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils.encoding import force_bytes
 
+from freezegun import freeze_time
 from pyquery import PyQuery as pq
 from rest_framework.test import APIRequestFactory
 from waffle.testutils import override_switch
 
 from olympia import amo
+from olympia.abuse.forms import AbuseAppealEmailForm
 from olympia.addons.models import AddonRegionalRestrictions
 from olympia.amo.tests import (
     APITestClientSessionID,
@@ -1924,3 +1926,193 @@ class TestAppeal(TestCase):
         assert not doc('#appeal-thank-you')
         assert doc('#appeal-submit')
         assert self.appeal_mock.call_count == 0
+
+    def test_throttling_initial_email_form(self):
+        expected_error_message = (
+            'You have submitted this form too many times recently. '
+            'Please try again after some time.'
+        )
+        self.cinder_job.update(decision_action=CinderJob.DECISION_ACTIONS.AMO_BAN_USER)
+        self.abuse_report.update(guid=None, user=user_factory())
+        with freeze_time() as frozen_time:
+            for _x in range(0, 6):
+                self._add_fake_throttling_action(
+                    view_class=AbuseAppealEmailForm,
+                    url=self.author_appeal_url,
+                    remote_addr='5.6.7.8',
+                )
+            response = self.client.post(
+                self.author_appeal_url,
+                {'email': self.abuse_report.user.email},
+                REMOTE_ADDR='5.6.7.8',
+            )
+            assert (
+                expected_error_message
+                in response.context_data['appeal_email_form'].non_field_errors()
+            )
+            doc = pq(response.content)
+            assert doc('ul.errorlist').text() == expected_error_message
+
+            # Advance one hour to be able to submit again with the same IP.
+            frozen_time.tick(delta=timedelta(hours=1, seconds=1))
+            response = self.client.post(
+                self.author_appeal_url,
+                {'email': self.abuse_report.user.email},
+                REMOTE_ADDR='5.6.7.8',
+            )
+            assert (
+                expected_error_message
+                not in response.context_data['appeal_email_form'].non_field_errors()
+            )
+            doc = pq(response.content)
+            assert doc('#id_reason')
+            assert not doc('#appeal-thank-you')
+            assert doc('#appeal-submit')
+
+            for _x in range(0, 15):
+                self._add_fake_throttling_action(
+                    view_class=AbuseAppealEmailForm,
+                    url=self.author_appeal_url,
+                    remote_addr='5.6.7.8',
+                )
+            # This time advancing one hour isn't enough, we're blocked for the
+            # day.
+            frozen_time.tick(delta=timedelta(hours=1, seconds=1))
+            response = self.client.post(
+                self.author_appeal_url,
+                {'email': self.abuse_report.user.email},
+                REMOTE_ADDR='5.6.7.8',
+            )
+            assert (
+                expected_error_message
+                in response.context_data['appeal_email_form'].non_field_errors()
+            )
+            doc = pq(response.content)
+            assert doc('ul.errorlist').text() == expected_error_message
+
+            # Advance one day to be able to submit again with the same IP.
+            frozen_time.tick(delta=timedelta(hours=24, seconds=1))
+            response = self.client.post(
+                self.author_appeal_url,
+                {'email': self.abuse_report.user.email},
+                REMOTE_ADDR='5.6.7.8',
+            )
+            assert (
+                expected_error_message
+                not in response.context_data['appeal_email_form'].non_field_errors()
+            )
+            doc = pq(response.content)
+            assert doc('#id_reason')
+            assert not doc('#appeal-thank-you')
+            assert doc('#appeal-submit')
+
+    def test_throttling_doesnt_reveal_validation_state_fields(self):
+        expected_error_message = (
+            'You have submitted this form too many times recently. '
+            'Please try again after some time.'
+        )
+        self.cinder_job.update(decision_action=CinderJob.DECISION_ACTIONS.AMO_BAN_USER)
+        self.abuse_report.update(guid=None, user=user_factory())
+        with freeze_time():
+            for _x in range(0, 6):
+                self._add_fake_throttling_action(
+                    view_class=AbuseAppealEmailForm,
+                    url=self.author_appeal_url,
+                    remote_addr='5.6.7.8',
+                )
+            response = self.client.post(
+                self.author_appeal_url,
+                # Email won't be validated because throttling will fail first.
+                {'email': 'garbage@example.com'},
+                REMOTE_ADDR='5.6.7.8',
+            )
+            assert (
+                expected_error_message
+                in response.context_data['appeal_email_form'].non_field_errors()
+            )
+            assert 'email' not in response.context_data['appeal_email_form'].errors
+            doc = pq(response.content)
+            assert doc('ul.errorlist').text() == expected_error_message
+
+    def test_throttling_appeal_form(self):
+        expected_error_message = (
+            'You have submitted this form too many times recently. '
+            'Please try again after some time.'
+        )
+        self.cinder_job.update(
+            decision_action=CinderJob.DECISION_ACTIONS.AMO_DISABLE_ADDON
+        )
+        user = user_factory()
+        self.addon.authors.add(user)
+        self.client.force_login(user)
+        with freeze_time() as frozen_time:
+            for _x in range(0, 6):
+                self._add_fake_throttling_action(
+                    view_class=AbuseAppealEmailForm,
+                    url=self.author_appeal_url,
+                    remote_addr='5.6.7.8',
+                    user=user,
+                )
+            response = self.client.post(
+                self.author_appeal_url,
+                {'reason': 'I dont like this'},
+                REMOTE_ADDR='5.6.7.8',
+            )
+            assert (
+                expected_error_message
+                in response.context_data['appeal_form'].non_field_errors()
+            )
+            doc = pq(response.content)
+            assert doc('ul.errorlist').text() == expected_error_message
+            assert not doc('#appeal-thank-you')
+
+            # Advance one hour to be able to submit again with the same IP.
+            frozen_time.tick(delta=timedelta(hours=1, seconds=1))
+            response = self.client.post(
+                self.author_appeal_url,
+                {'reason': 'I dont like this'},
+                REMOTE_ADDR='5.6.7.8',
+            )
+            assert (
+                expected_error_message
+                not in response.context_data['appeal_form'].non_field_errors()
+            )
+            doc = pq(response.content)
+            assert doc('#appeal-thank-you')
+
+            for _x in range(0, 15):
+                self._add_fake_throttling_action(
+                    view_class=AbuseAppealEmailForm,
+                    url=self.author_appeal_url,
+                    remote_addr='5.6.7.8',
+                    user=user,
+                )
+            # This time advancing one hour isn't enough, we're blocked for the
+            # day.
+            frozen_time.tick(delta=timedelta(hours=1, seconds=1))
+            response = self.client.post(
+                self.author_appeal_url,
+                {'reason': 'I dont like this'},
+                REMOTE_ADDR='5.6.7.8',
+            )
+            assert (
+                expected_error_message
+                in response.context_data['appeal_form'].non_field_errors()
+            )
+            doc = pq(response.content)
+            assert doc('ul.errorlist').text() == expected_error_message
+            assert not doc('#appeal-thank-you')
+
+            # Advance one day to be able to submit again with the same IP.
+            frozen_time.tick(delta=timedelta(hours=24, seconds=1))
+            response = self.client.post(
+                self.author_appeal_url,
+                {'reason': 'I dont like this'},
+                REMOTE_ADDR='5.6.7.8',
+            )
+            assert (
+                expected_error_message
+                not in response.context_data['appeal_form'].non_field_errors()
+            )
+            doc = pq(response.content)
+            assert doc('#appeal-thank-you')

--- a/src/olympia/abuse/views.py
+++ b/src/olympia/abuse/views.py
@@ -343,7 +343,7 @@ def appeal(request, *, abuse_report_id, decision_id, **kwargs):
                 else abuse_report.reporter_email
             )
             appeal_email_form = AbuseAppealEmailForm(
-                post_data, expected_email=expected_email
+                post_data, expected_email=expected_email, request=request
             )
             if appeal_email_form.is_bound and appeal_email_form.is_valid():
                 valid_user_or_email_provided = True
@@ -384,7 +384,7 @@ def appeal(request, *, abuse_report_id, decision_id, **kwargs):
         if cinder_job.can_be_appealed(
             is_reporter=is_reporter, abuse_report=abuse_report
         ):
-            appeal_form = AbuseAppealForm(post_data)
+            appeal_form = AbuseAppealForm(post_data, request=request)
             if appeal_form.is_bound and appeal_form.is_valid():
                 appeal_to_cinder.delay(
                     decision_id=cinder_job.decision_id,

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -597,7 +597,14 @@ class TestCase(PatchMixin, InitializeSessionMixin, test.TestCase):
         return obj
 
     def _add_fake_throttling_action(
-        self, view_class, verb='post', url=None, user=None, remote_addr=None
+        self,
+        *,
+        view_class,
+        view_kwargs=None,
+        verb='post',
+        url=None,
+        user=None,
+        remote_addr=None,
     ):
         """Trigger the throttling classes on the API view passed in argument
         just like an action happened.
@@ -608,6 +615,8 @@ class TestCase(PatchMixin, InitializeSessionMixin, test.TestCase):
         # Create the fake request, make sure to use an 'unsafe' method by
         # default otherwise we'd be allowed without any checks whatsoever in
         # some of our views.
+        if view_kwargs is None:
+            view_kwargs = {}
         path = urlparse(url).path
         factory = APIRequestFactory()
         fake_request = getattr(factory, verb)(path)
@@ -624,7 +633,7 @@ class TestCase(PatchMixin, InitializeSessionMixin, test.TestCase):
             # set that in the cache. If it failed, we force a success anyway
             # to make sure our number of actions target is reached artifically.
             if not throttle.allow_request(
-                fake_request, view_class(request=fake_request)
+                fake_request, view_class(request=fake_request, **view_kwargs)
             ):
                 throttle.throttle_success()
 

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -623,7 +623,9 @@ class TestCase(PatchMixin, InitializeSessionMixin, test.TestCase):
             # and if it's a success it will add the request to the history and
             # set that in the cache. If it failed, we force a success anyway
             # to make sure our number of actions target is reached artifically.
-            if not throttle.allow_request(fake_request, view_class()):
+            if not throttle.allow_request(
+                fake_request, view_class(request=fake_request)
+            ):
                 throttle.throttle_success()
 
 

--- a/src/olympia/api/throttling.py
+++ b/src/olympia/api/throttling.py
@@ -110,7 +110,7 @@ class CheckThrottlesFormMixin:
     """
 
     throttled_error_message = _(
-        'You have submitted too many uploads recently. '
+        'You have submitted this form too many times recently. '
         'Please try again after some time.'
     )
 

--- a/src/olympia/devhub/forms.py
+++ b/src/olympia/devhub/forms.py
@@ -1036,6 +1036,11 @@ class NewUploadForm(CheckThrottlesFormMixin, forms.Form):
         error_messages={'required': _('Need to select at least one application.')},
     )
     theme_specific = forms.BooleanField(required=False, widget=forms.HiddenInput)
+
+    throttled_error_message = _(
+        'You have submitted too many uploads recently. '
+        'Please try again after some time.'
+    )
     throttle_classes = addon_submission_throttles
 
     def __init__(self, *args, **kw):

--- a/src/olympia/devhub/tests/test_forms.py
+++ b/src/olympia/devhub/tests/test_forms.py
@@ -256,7 +256,7 @@ class TestNewUploadForm(TestCase):
         """
         user = user_factory()
         manifest_extractor_parse.parse.return_value = None
-        mock_check_xpi_info.return_value = {'name': 'foo', 'type': 2}
+        mock_check_xpi_info.return_value = {'name': 'foo', 'type': amo.ADDON_EXTENSION}
         upload = FileUpload.objects.create(
             valid=True,
             name='foo.xpi',
@@ -265,12 +265,12 @@ class TestNewUploadForm(TestCase):
             ip_address='127.0.0.64',
             channel=amo.CHANNEL_LISTED,
         )
-        addon = Addon.objects.create()
+        addon = Addon.objects.create(type=amo.ADDON_EXTENSION)
         data = {'upload': upload.uuid, 'compatible_apps': [amo.FIREFOX.id]}
         request = req_factory_factory('/', post=True, data=data)
         request.user = user
         form = forms.NewUploadForm(data, addon=addon, request=request)
-        form.clean()
+        assert form.is_valid(), form.errors
         assert mock_check_xpi_info.called
 
 


### PR DESCRIPTION
This reuses the existing implementation that we have in the `NewUploadForm`, refactoring it in a generic mixin that no longer depends on the viewset being passed, we pass the list of throttle classes instead.

It purposefully changes the existing behavior to prevent further validation from taking place, to avoid potential credentials stuffing : we don't want to validate data (which, in the case of appeals, could be the email of a reporter) when rate-limiting the user. It shouldn't have an impact for `NewUploadForm` though.

Fixes #21302