### PR TITLE
Add localization job to CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -493,7 +493,6 @@ commands:
       - run:
           name: Set environment variables
           command: |
-            echo export PYTHONPATH=src >> $BASH_ENV
             echo export CPUCOUNT=2 >> $BASH_ENV
             echo export NPM_CONFIG_PREFIX=/deps/ >> $BASH_ENV
             echo export CC=\"`python -c 'import sysconfig; print(sysconfig.get_config_var("CC"))'`\" >> $BASH_ENV
@@ -574,6 +573,17 @@ jobs:
       - run: make install_python_codestyle_dependencies
       - run: pyenv rehash
       - run: make lint-codestyle
+
+  localization:
+    <<: *defaults
+    steps:
+      - setup_container:
+          wait_services: false
+          install_node_dependencies: true
+          install_python_dev_dependencies: true
+      - run : make extract_locales
+      - run: git diff
+
 
   devhub:
     <<: *defaults-with-services
@@ -666,6 +676,7 @@ workflows:
       - main
       - reviewers-and-zadmin
       - es-tests
+      - localization
       - release-master:
           filters:
             branches:

--- a/Makefile-docker
+++ b/Makefile-docker
@@ -80,12 +80,17 @@ cleanup_python_build_dir:
 	# Work arounds "Multiple .dist-info directories" issue.
 	rm -rf /deps/build/*
 
+.PHONY: install_python_olympia_module
+install_python_olympia_module:
+	# pep 517 mode (the default) breaks editable install in our project. https://github.com/mozilla/addons-server/issues/16144
+	$(PIP_COMMAND) install --no-use-pep517 -e .
+
 .PHONY: install_python_codestyle_dependencies
 install_python_codestyle_dependencies:
 	$(PIP_COMMAND) install --progress-bar=off --no-deps --exists-action=w -r requirements/codestyle.txt
 
 .PHONY: install_python_test_dependencies
-install_python_test_dependencies:
+install_python_test_dependencies: install_python_olympia_module
 	$(PIP_COMMAND) install --progress-bar=off --no-deps --exists-action=w -r requirements/system.txt
 	$(PIP_COMMAND) install --progress-bar=off --no-deps --exists-action=w -r requirements/prod.txt
 	$(PIP_COMMAND) install --progress-bar=off --no-deps --exists-action=w -r requirements/tests.txt
@@ -94,8 +99,6 @@ install_python_test_dependencies:
 install_python_dev_dependencies: install_python_test_dependencies install_python_codestyle_dependencies
 	$(PIP_COMMAND) install --progress-bar=off --no-deps --exists-action=w -r requirements/dev.txt
 	$(PIP_COMMAND) install --progress-bar=off --no-deps --exists-action=w -r requirements/docs.txt
-	# pep 517 mode (the default) breaks editable install in our project. https://github.com/mozilla/addons-server/issues/16144
-	$(PIP_COMMAND) install --no-use-pep517 -e .
 
 .PHONY: install_node_dependencies
 install_node_dependencies: install_node_js copy_node_js
@@ -234,6 +237,10 @@ format: ## Autoformat our codebase.
 	NODE_PATH=$(NODE_MODULES) npm exec $(NPM_ARGS) -- prettier --write '**'
 	ruff check --fix-only .
 	ruff format .
+
+.PHONY: extract_locales
+extract_locales: ## extracts and merges translation strings
+	./scripts/run_l10n_extraction.sh
 
 .PHONY: help_submake
 help_submake:

--- a/scripts/run_l10n_extraction.sh
+++ b/scripts/run_l10n_extraction.sh
@@ -1,0 +1,67 @@
+#! /bin/bash
+
+# Exit immediately when a command fails.
+set -e
+
+# Make sure exit code are respected in a pipeline.
+set -o pipefail
+
+# Treat unset variables as an error an exit immediately.
+set -u
+
+# Extraction needs our django settings for jinja, so we need a django settings
+# module set. Since this command is meant to be run in local envs, we use
+# "settings".
+DJANGO_SETTINGS_MODULE=settings
+
+# gettext flags
+CLEAN_FLAGS="--no-obsolete --width=200 --no-location"
+MERGE_FLAGS="--update --width=200 --backup=none --no-fuzzy-matching"
+UNIQ_FLAGS="--width=200"
+
+info() {
+  local message="$1"
+
+  echo ""
+  echo "INFO: $message"
+  echo ""
+}
+
+info "Extracting content strings..."
+python3 manage.py extract_content_strings
+
+info "Extracting strings from python..."
+# We must set PYTHONPATH here because pybabel needs to be able to import our settings file from the root
+PYTHONPATH=. DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE} pybabel extract -F babel.cfg -o locale/templates/LC_MESSAGES/django.pot -c 'L10n:' -w 80 --version=1.0 --project=addons-server --copyright-holder=Mozilla .
+info "Extracting strings from javascript..."
+PYTHONPATH=. DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE} pybabel extract -F babeljs.cfg -o locale/templates/LC_MESSAGES/djangojs.pot -c 'L10n:' -w 80 --version=1.0 --project=addons-server --copyright-holder=Mozilla .
+
+pushd locale > /dev/null
+
+info "Merging any new keys from templates/LC_MESSAGES/django.pot"
+for i in `find . -name "django.po" | grep -v "en_US"`; do
+    msguniq $UNIQ_FLAGS -o "$i" "$i"
+    msgmerge $MERGE_FLAGS "$i" "templates/LC_MESSAGES/django.pot"
+done
+msgen templates/LC_MESSAGES/django.pot | msgmerge $MERGE_FLAGS en_US/LC_MESSAGES/django.po -
+
+info "Merging any new keys from templates/LC_MESSAGES/djangojs.pot"
+for i in `find . -name "djangojs.po" | grep -v "en_US"`; do
+    msguniq $UNIQ_FLAGS -o "$i" "$i"
+    msgmerge $MERGE_FLAGS "$i" "templates/LC_MESSAGES/djangojs.pot"
+done
+msgen templates/LC_MESSAGES/djangojs.pot | msgmerge $MERGE_FLAGS en_US/LC_MESSAGES/djangojs.po -
+
+info "Cleaning out obsolete messages..."
+for i in `find . -name "django.po"`; do
+    msgattrib $CLEAN_FLAGS --output-file=$i $i
+done
+for i in `find . -name "djangojs.po"`; do
+    msgattrib $CLEAN_FLAGS --output-file=$i $i
+done
+
+msgfilter -i sr/LC_MESSAGES/django.po -o sr_Latn/LC_MESSAGES/django.po recode-sr-latin
+
+popd > /dev/null
+
+info "Done extracting."


### PR DESCRIPTION
Relates to #9112 

### Description

This PR "extracts" the logic for extracting and merging l10n strings to an executable script that can be run in CI. 

### Context:

Previously the script was designed to run locally and did more than extract, this script just extracts and can be a part of a job that synchronizes our l10n automatically.

This PR does not implement the automation, but just the extraction. A follow up PR will include automatically committing the updated locales once we have proven it works as expected.

In the future, we can consider executing pybabel via [setup.py](https://babel.pocoo.org/en/stable/setup.html) or directly [calling the functions](https://babel.pocoo.org/en/latest/api/messages/extract.html#babel.messages.extract.extract_from_dir) in a django command, but implementing this was not straight forward and thus outside of scope.

### Testing:

You can test this script in CI by checking the "localization" job. You can also run the script locally running:

```bash
make extract_locales
```
