### PR TITLE
Sign user deleted email as Mozilla Add-ons Team

### DIFF
--- a/src/olympia/users/templates/users/emails/user_deleted.ltxt
+++ b/src/olympia/users/templates/users/emails/user_deleted.ltxt
@@ -6,4 +6,4 @@ If you didn’t do this or believe an unauthorized person has accessed your acco
 
 Regards,
 
-The Firefox Add-ons Team{% endblocktrans %}
+Mozilla Add-ons Team{% endblocktrans %}


### PR DESCRIPTION
fixes #21712 