### PR TITLE
Add management command for sync suppressed emails

### DIFF
--- a/src/olympia/users/management/commands/sync_suppressed_emails.py
+++ b/src/olympia/users/management/commands/sync_suppressed_emails.py
@@ -1,0 +1,10 @@
+from django.core.management.base import BaseCommand
+
+from olympia.users.tasks import sync_blocked_emails
+
+
+class Command(BaseCommand):
+    """Sync Socket labs suppression list to database."""
+
+    def handle(self, *args, **options):
+        sync_blocked_emails.apply()


### PR DESCRIPTION
relates to: #21687

## Description

This pull request adds a new management command for syncing suppressed emails from Socket Labs to the database. The command fetches the suppression list from Socket Labs, downloads it, and then bulk creates the suppressed emails in the database. The pull request also includes a task for sending suppressed email confirmations.

## Context

This PR exposes the [sync_blocked_emails](https://github.com/mozilla/addons-server/blob/2f89e2033f47131676e60720ecef6b4a0faab40a/src/olympia/users/tasks.py#L105) task via a management command. 

This can be useful for a few reasons:
- testing the email suppression feature will likely require manually adding emails to the suppression list and then syncing them to our DB so we can run through the verification steps to unsuppress the email.
- in general if we need, for operational reasons, to resync the suppression list we can do so via an easy to execute command.

In general the sync_blocked_emails task will be run periodically. This is not in production yet as we have only just recently been given the necessary credentials to communicate with socketlabs via API and having that job executing until now would have simply erred indefinitely.