### PR TITLE
Refactor email sending logic to use a group for QA email recipients

### DIFF
--- a/src/olympia/access/migrations/0003_add_force_send_mail_group.py
+++ b/src/olympia/access/migrations/0003_add_force_send_mail_group.py
@@ -1,0 +1,29 @@
+from django.db import migrations
+
+from olympia.amo.mail import DevEmailBackend
+
+def create_group(apps, schema_editor):
+    Group = apps.get_model('access', 'Group')
+
+    Group.objects.create(
+        name=DevEmailBackend.force_send_mail_group,
+        notes=(
+            'UserProfiles belonging to this group will have real emails sent'
+            ' to them in dev/stage environments. This is useful for testing email flows.'
+        )
+    )
+
+def delete_group(apps, schema_editor):
+    Group = apps.get_model('access', 'Group')
+
+    Group.objects.filter(name=DevEmailBackend.force_send_mail_group).delete()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('access', '0002_give_api_bypass_throttling_permission'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_group, delete_group)
+    ]

--- a/src/olympia/amo/tests/test_fields.py
+++ b/src/olympia/amo/tests/test_fields.py
@@ -96,6 +96,7 @@ class TestPositiveAutoField(TestCase):
             assert extra == 'auto_increment'
 
     def test_unsigned_int_limits(self):
+        self.ClassUsingPositiveAutoField.objects.all().delete()
         self.ClassUsingPositiveAutoField.objects.create(id=1)
         mysql_max_signed_int = 2147483647
         self.ClassUsingPositiveAutoField.objects.create(id=mysql_max_signed_int + 10)

--- a/src/olympia/amo/tests/test_pytest_fixtures.py
+++ b/src/olympia/amo/tests/test_pytest_fixtures.py
@@ -8,8 +8,7 @@ from olympia.access.models import Group
 
 
 def test_admin_group(admin_group):
-    assert Group.objects.count() == 1
-    admin_group = Group.objects.get()
+    admin_group = Group.objects.get(name='Admins')
     assert admin_group.name == 'Admins'
     assert admin_group.rules == '*:*'
 

--- a/src/olympia/landfill/serializers.py
+++ b/src/olympia/landfill/serializers.py
@@ -321,7 +321,9 @@ class GenerateAddonsSerializer(serializers.Serializer):
         # Groups should have been created by loaddata initial.json at this
         # point, we need our user to be part of a group allowed to submit
         # extensions signed by Mozilla. Let's use Admins (pk=1) as a shortcut.
-        GroupUser.objects.get_or_create(user=user, group=Group.objects.get(pk=1))
+        GroupUser.objects.get_or_create(
+            user=user, group=Group.objects.get(name='Admins')
+        )
 
         # generate a proper uploaded file that simulates what django requires
         # as request.POST

--- a/src/olympia/landfill/tests/test_serializers.py
+++ b/src/olympia/landfill/tests/test_serializers.py
@@ -7,7 +7,7 @@ from olympia.landfill.serializers import GenerateAddonsSerializer
 
 class TestGenerateAddonsSerializer(TestCase):
     def test_create_installable_addon(self):
-        Group.objects.get_or_create(pk=1, defaults={'name': 'Admins', 'rules': '*:*'})
+        Group.objects.create(name='Admins', rules='*:*')
         AppVersion.objects.create(application=amo.FIREFOX.id, version='42.0')
         AppVersion.objects.create(application=amo.FIREFOX.id, version='*')
         AppVersion.objects.create(application=amo.ANDROID.id, version='48.0')

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -752,8 +752,6 @@ DEFAULT_FROM_EMAIL = ADDONS_EMAIL
 # Email goes to the console by default.  s/console/smtp/ for regular delivery
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
-# Please use all lowercase for the QA allow list.
-EMAIL_QA_ALLOW_LIST = env.list('EMAIL_QA_ALLOW_LIST', default=())
 # Please use all lowercase for the deny_list.
 EMAIL_DENY_LIST = env.list('EMAIL_DENY_LIST', default=('nobody@mozilla.org',))
 


### PR DESCRIPTION
Fixes: #21790

## Description

This pull request refactors the email sending logic to use a group for QA email recipients instead of a static list. This allows for easier management of QA email addresses and improves code maintainability.

## Context

The name is maybe up for debate but it shouold be relatively clear what the group is for.

What is unclear right now, how to manage this group? Do we have a migration that creates it and adds users? Do we have a management command to add/remove users?

## Testing

Run the migrations to create the group and add users, try to send mail with other settings disabled and you should see it send an email, an actual email.