### PR TITLE
send cinder emails to targets from reviewer tools

### DIFF
--- a/src/olympia/abuse/tasks.py
+++ b/src/olympia/abuse/tasks.py
@@ -8,6 +8,7 @@ import requests
 from django_statsd.clients import statsd
 
 from olympia import amo
+from olympia.activity.models import ActivityLog
 from olympia.addons.models import Addon
 from olympia.amo.celery import task
 from olympia.amo.decorators import use_primary_db
@@ -108,17 +109,16 @@ def appeal_to_cinder(
 
 @task
 @use_primary_db
-def resolve_job_in_cinder(*, cinder_job_id, reasoning, decision, policy_ids):
+def resolve_job_in_cinder(*, cinder_job_id, decision, log_entry_id):
     try:
         cinder_job = CinderJob.objects.get(id=cinder_job_id)
-        policies = CinderPolicy.objects.filter(id__in=policy_ids)
-        cinder_job.resolve_job(reasoning, decision, policies)
+        log_entry = ActivityLog.objects.get(id=log_entry_id)
+        cinder_job.resolve_job(decision=decision, log_entry=log_entry)
     except Exception:
         statsd.incr('abuse.tasks.resolve_job_in_cinder.failure')
         raise
     else:
         statsd.incr('abuse.tasks.resolve_job_in_cinder.success')
-
 
 @task
 @use_primary_db

--- a/src/olympia/abuse/tasks.py
+++ b/src/olympia/abuse/tasks.py
@@ -120,6 +120,7 @@ def resolve_job_in_cinder(*, cinder_job_id, decision, log_entry_id):
     else:
         statsd.incr('abuse.tasks.resolve_job_in_cinder.success')
 
+
 @task
 @use_primary_db
 def sync_cinder_policies():

--- a/src/olympia/abuse/tests/test_tasks.py
+++ b/src/olympia/abuse/tests/test_tasks.py
@@ -11,10 +11,11 @@ from freezegun import freeze_time
 
 from olympia import amo
 from olympia.abuse.tasks import flag_high_abuse_reports_addons_according_to_review_tier
+from olympia.activity.models import ActivityLog
 from olympia.amo.tests import TestCase, addon_factory, days_ago, user_factory
 from olympia.constants.reviewers import EXTRA_REVIEW_TARGET_PER_DAY_CONFIG_KEY
 from olympia.files.models import File
-from olympia.reviewers.models import NeedsHumanReview, UsageTier
+from olympia.reviewers.models import NeedsHumanReview, ReviewActionReason, UsageTier
 from olympia.versions.models import Version
 from olympia.zadmin.models import set_config
 
@@ -600,20 +601,29 @@ def test_resolve_job_in_cinder(statsd_incr_mock):
         json={'external_id': cinder_job.job_id},
         status=200,
     )
-    policy = CinderPolicy.objects.create(name='policy', uuid='12345678')
     statsd_incr_mock.reset_mock()
+    review_action_reason = ReviewActionReason.objects.create(
+        cinder_policy=CinderPolicy.objects.create(name='policy', uuid='12345678')
+    )
+    log_entry = ActivityLog.objects.create(
+        amo.LOG.FORCE_DISABLE,
+        abuse_report.target,
+        abuse_report.target.current_version,
+        review_action_reason,
+        details={'comments': 'some review text'},
+        user=user_factory(),
+    )
 
     resolve_job_in_cinder.delay(
         cinder_job_id=cinder_job.id,
-        reasoning='some text',
         decision=CinderJob.DECISION_ACTIONS.AMO_DISABLE_ADDON,
-        policy_ids=[policy.id],
+        log_entry_id=log_entry.id,
     )
 
     request = responses.calls[0].request
     request_body = json.loads(request.body)
     assert request_body['policy_uuids'] == ['12345678']
-    assert request_body['reasoning'] == 'some text'
+    assert request_body['reasoning'] == 'some review text'
     assert request_body['entity']['id'] == str(abuse_report.target.id)
     cinder_job.reload()
     assert cinder_job.decision_action == CinderJob.DECISION_ACTIONS.AMO_DISABLE_ADDON

--- a/src/olympia/abuse/utils.py
+++ b/src/olympia/abuse/utils.py
@@ -27,7 +27,16 @@ class CinderAction:
         self.target = self.cinder_job.target
         self.is_third_party_initiated = True  # will not always be true in the future
 
-    def process(self):
+        if isinstance(self.target, Addon):
+            self.addon_version = (
+                self.target.current_version
+                or self.target.find_latest_version(channel=None, exclude=())
+            )
+
+    def process_action(self):
+        raise NotImplementedError
+
+    def process_notifications(self, *, policy_text=None):
         raise NotImplementedError
 
     def get_target_name(self):
@@ -54,7 +63,7 @@ class CinderAction:
     def owner_template_path(self):
         return f'abuse/emails/{self.__class__.__name__}.txt'
 
-    def notify_owners(self, owners, *, policy_text=None):
+    def notify_owners(self, owners, *, policy_text):
         name = self.get_target_name()
         reference_id = f'ref:{self.cinder_job.decision_id}'
         context_dict = {
@@ -67,7 +76,9 @@ class CinderAction:
             'target_url': absolutify(self.target.get_url_path()),
             'type': self.get_target_type(),
             'SITE_URL': settings.SITE_URL,
-            'version_list': ', '.join(getattr(self, 'addon_rejected_versions', ())),
+            'version_list': ', '.join(
+                version.version for version in getattr(self, 'affected_versions', ())
+            ),
         }
         if policy_text is not None:
             context_dict['manual_policy_text'] = policy_text
@@ -154,13 +165,16 @@ class CinderActionBanUser(CinderAction):
     reporter_template_path = 'abuse/emails/reporter_takedown_user.txt'
     reporter_appeal_template_path = 'abuse/emails/reporter_appeal_takedown.txt'
 
-    def process(self):
+    def process_action(self):
         if isinstance(self.target, UserProfile) and not self.target.banned:
             UserProfile.objects.filter(
                 pk=self.target.pk
             ).ban_and_disable_related_content()
-            self.notify_reporters()
-            self.notify_owners([self.target])
+            return True
+
+    def process_notifications(self, *, policy_text=None):
+        self.notify_reporters()
+        self.notify_owners([self.target], policy_text=policy_text)
 
 
 class CinderActionDisableAddon(CinderAction):
@@ -169,16 +183,17 @@ class CinderActionDisableAddon(CinderAction):
     reporter_template_path = 'abuse/emails/reporter_takedown_addon.txt'
     reporter_appeal_template_path = 'abuse/emails/reporter_appeal_takedown.txt'
 
-    def process(self):
+    def process_action(self):
         if isinstance(self.target, Addon) and self.target.status != amo.STATUS_DISABLED:
-            self.addon_version = (
-                self.target.current_version
-                or self.target.find_latest_version(channel=None, exclude=())
-            )
             self.target.force_disable(skip_activity_log=True)
-            self.log_entry = log_create(amo.LOG.FORCE_DISABLE, self.target)
-            self.notify_reporters()
-            self.notify_owners(self.target.authors.all())
+            self.log_entry_id = (
+                log_entry := log_create(amo.LOG.FORCE_DISABLE, self.target)
+            ) and log_entry.id
+            return True
+
+    def process_notifications(self, *, policy_text=None):
+        self.notify_reporters()
+        self.notify_owners(self.target.authors.all(), policy_text=policy_text)
 
     def send_mail(self, subject, message, recipients):
         from olympia.activity.utils import send_activity_mail
@@ -186,9 +201,7 @@ class CinderActionDisableAddon(CinderAction):
         """We send addon related via activity mail instead for the integration"""
 
         if version := getattr(self, 'addon_version', None):
-            unique_id = (
-                self.log_entry.id if self.log_entry else random.randrange(100000)
-            )
+            unique_id = getattr(self, 'log_entry_id', None) or random.randrange(100000)
             send_activity_mail(
                 subject, message, version, recipients, settings.ADDONS_EMAIL, unique_id
             )
@@ -208,7 +221,7 @@ class CinderActionRejectVersion(CinderActionDisableAddon):
 class CinderActionEscalateAddon(CinderAction):
     valid_targets = [Addon]
 
-    def process(self):
+    def process_action(self):
         from olympia.reviewers.models import NeedsHumanReview
 
         if isinstance(self.target, Addon):
@@ -240,6 +253,11 @@ class CinderActionEscalateAddon(CinderAction):
                 self.target.set_needs_human_review_on_latest_versions(
                     reason=reason, ignore_reviewed=False, unique_reason=True
                 )
+            return True
+
+    def process_notifications(self, *, policy_text=None):
+        # we don't send any emails for escalations
+        pass
 
 
 class CinderActionDeleteCollection(CinderAction):
@@ -248,12 +266,15 @@ class CinderActionDeleteCollection(CinderAction):
     reporter_template_path = 'abuse/emails/reporter_takedown_collection.txt'
     reporter_appeal_template_path = 'abuse/emails/reporter_appeal_takedown.txt'
 
-    def process(self):
+    def process_action(self):
         if isinstance(self.target, Collection) and not self.target.deleted:
             log_create(amo.LOG.COLLECTION_DELETED, self.target)
             self.target.delete(clear_slug=False)
-            self.notify_reporters()
-            self.notify_owners([self.target.author])
+            return True
+
+    def process_notifications(self, *, policy_text=None):
+        self.notify_reporters()
+        self.notify_owners([self.target.author], policy_text=policy_text)
 
 
 class CinderActionDeleteRating(CinderAction):
@@ -262,37 +283,51 @@ class CinderActionDeleteRating(CinderAction):
     reporter_template_path = 'abuse/emails/reporter_takedown_rating.txt'
     reporter_appeal_template_path = 'abuse/emails/reporter_appeal_takedown.txt'
 
-    def process(self):
+    def process_action(self):
         if isinstance(self.target, Rating) and not self.target.deleted:
             self.target.delete(clear_flags=False)
-            self.notify_reporters()
-            self.notify_owners([self.target.user])
+            return True
+
+    def process_notifications(self, *, policy_text=None):
+        self.notify_reporters()
+        self.notify_owners([self.target.user], policy_text=policy_text)
 
 
 class CinderActionTargetAppealApprove(CinderAction):
     valid_targets = [Addon, UserProfile, Collection, Rating]
     description = 'Reported content is within policy, after appeal'
 
-    def process(self):
+    def process_action(self):
         target = self.target
         if isinstance(target, Addon) and target.status == amo.STATUS_DISABLED:
             target.force_enable()
-            self.notify_owners(target.authors.all())
+            return True
 
         elif isinstance(target, UserProfile) and target.banned:
             UserProfile.objects.filter(
                 pk=target.pk
             ).unban_and_reenable_related_content()
-            self.notify_owners([target])
+            return True
 
         elif isinstance(target, Collection) and target.deleted:
             target.undelete()
             log_create(amo.LOG.COLLECTION_UNDELETED, target)
-            self.notify_owners([target.author])
+            return True
 
         elif isinstance(target, Rating) and target.deleted:
             target.undelete()
-            self.notify_owners([target.user])
+            return True
+
+    def process_notifications(self, *, policy_text=None):
+        target = self.target
+        if isinstance(target, Addon):
+            self.notify_owners(target.authors.all(), policy_text=policy_text)
+        elif isinstance(target, UserProfile):
+            self.notify_owners([target], policy_text=policy_text)
+        elif isinstance(target, Collection):
+            self.notify_owners([target.author], policy_text=policy_text)
+        elif isinstance(target, Rating):
+            self.notify_owners([target.user], policy_text=policy_text)
 
 
 class CinderActionOverrideApprove(CinderActionTargetAppealApprove):
@@ -305,27 +340,36 @@ class CinderActionApproveInitialDecision(CinderAction):
     reporter_template_path = 'abuse/emails/reporter_ignore.txt'
     reporter_appeal_template_path = 'abuse/emails/reporter_appeal_ignore.txt'
 
-    def process(self):
-        self.notify_reporters()
+    def process_action(self):
+        return True
         # If it's an initial decision approve there is nothing else to do
+
+    def process_notifications(self, *, policy_text=None):
+        self.notify_reporters()
 
 
 class CinderActionTargetAppealRemovalAffirmation(CinderAction):
     valid_targets = [Addon, UserProfile, Collection, Rating]
     description = 'Reported content is still offending, after appeal.'
 
-    def process(self):
+    def process_action(self):
+        return True
+
+    def process_notifications(self, *, policy_text=None):
         target = self.target
         if isinstance(target, Addon):
-            self.notify_owners(target.authors.all())
+            self.notify_owners(target.authors.all(), policy_text=policy_text)
         elif isinstance(target, UserProfile):
-            self.notify_owners([target])
+            self.notify_owners([target], policy_text=policy_text)
         elif isinstance(target, Collection):
-            self.notify_owners([target.author])
+            self.notify_owners([target.author], policy_text=policy_text)
         elif isinstance(target, Rating):
-            self.notify_owners([target.user])
+            self.notify_owners([target.user], policy_text=policy_text)
 
 
 class CinderActionNotImplemented(CinderAction):
-    def process(self):
+    def process_action(self):
+        return True
+
+    def process_notifications(self, *, policy_text=None):
         pass

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 from django.conf import settings
 from django.core import mail
@@ -12,6 +12,7 @@ import pytest
 import responses
 
 from olympia import amo
+from olympia.abuse.models import AbuseReport, CinderJob
 from olympia.activity.models import ActivityLog, ActivityLogToken, ReviewActionReasonLog
 from olympia.addons.models import Addon, AddonApprovalsCounter, AddonReviewerFlags
 from olympia.amo.templatetags.jinja_helpers import absolutify
@@ -1017,8 +1018,36 @@ class TestReviewHelper(TestReviewHelperBase):
         assert base_fragment not in message.body
         assert message.reply_to == [reply_email]
 
-    def test_resolve_abuse_reports(self):
-        pass
+    @patch('olympia.reviewers.utils.resolve_job_in_cinder.delay')
+    def test_resolve_abuse_reports(self, mock_resolve_task):
+        log_entry = ActivityLog.objects.create(
+            action=amo.LOG.APPROVE_VERSION.id, user=user_factory()
+        )
+        self.helper.handler.log_entry = log_entry
+        cinder_job1 = CinderJob.objects.create(job_id='1')
+        cinder_job2 = CinderJob.objects.create(job_id='2')
+        self.helper.set_data(
+            {**self.get_data(), 'resolve_cinder_jobs': [cinder_job1, cinder_job2]}
+        )
+
+        self.helper.handler.resolve_abuse_reports(
+            CinderJob.DECISION_ACTIONS.AMO_APPROVE
+        )
+
+        mock_resolve_task.assert_has_calls(
+            [
+                call(
+                    cinder_job_id=cinder_job1.id,
+                    decision=CinderJob.DECISION_ACTIONS.AMO_APPROVE,
+                    log_entry_id=log_entry.id,
+                ),
+                call(
+                    cinder_job_id=cinder_job2.id,
+                    decision=CinderJob.DECISION_ACTIONS.AMO_APPROVE,
+                    log_entry_id=log_entry.id,
+                ),
+            ]
+        )
 
     def test_email_links(self):
         expected = {
@@ -2082,7 +2111,7 @@ class TestReviewHelper(TestReviewHelperBase):
         self.addon.update(status=amo.STATUS_NOMINATED)
         assert self.get_helper()
 
-    def test_reject_multiple_versions(self):
+    def _test_reject_multiple_versions(self, extra_data):
         old_version = self.review_version
         self.review_version = version_factory(addon=self.addon, version='3.0')
         AutoApprovalSummary.objects.create(
@@ -2096,9 +2125,9 @@ class TestReviewHelper(TestReviewHelperBase):
         assert self.file.status == amo.STATUS_APPROVED
         assert self.addon.current_version.is_public()
 
-        data = self.get_data().copy()
-        data['versions'] = self.addon.versions.all()
-        self.helper.set_data(data)
+        self.helper.set_data(
+            {**self.get_data(), 'versions': self.addon.versions.all(), **extra_data}
+        )
         self.helper.handler.reject_multiple_versions()
 
         self.addon.reload()
@@ -2118,11 +2147,6 @@ class TestReviewHelper(TestReviewHelperBase):
         assert len(mail.outbox) == 1
         message = mail.outbox[0]
         assert message.to == [self.addon.authors.all()[0].email]
-        assert message.subject == (
-            'Mozilla Add-ons: Delicious Bookmarks has been disabled on '
-            'addons.mozilla.org'
-        )
-        assert 'your add-on Delicious Bookmarks has been disabled' in message.body
         log_token = ActivityLogToken.objects.get()
         assert log_token.uuid.hex in message.reply_to[0]
 
@@ -2141,6 +2165,30 @@ class TestReviewHelper(TestReviewHelperBase):
         flags.reload()
         assert not flags.auto_approval_disabled_until_next_approval_unlisted
         assert flags.auto_approval_disabled_until_next_approval
+
+    def test_reject_multiple_versions(self):
+        self._test_reject_multiple_versions({})
+        message = mail.outbox[0]
+        assert message.subject == (
+            'Mozilla Add-ons: Delicious Bookmarks has been disabled on '
+            'addons.mozilla.org'
+        )
+        assert 'your add-on Delicious Bookmarks has been disabled' in message.body
+
+    def test_reject_multiple_versions_resolving_abuse_report(self):
+        responses.add(
+            responses.POST,
+            f'{settings.CINDER_SERVER_URL}create_decision',
+            json={'uuid': '12345'},
+            status=201,
+        )
+        cinder_job = CinderJob.objects.create(job_id='1')
+        AbuseReport.objects.create(guid=self.addon.guid, cinder_job=cinder_job)
+        self._test_reject_multiple_versions({'resolve_cinder_jobs': [cinder_job]})
+        message = mail.outbox[0]
+        assert message.subject == ('Mozilla Add-ons: Delicious Bookmarks [ref:12345]')
+        assert 'Extension Delicious Bookmarks was manually reviewed' in message.body
+        assert 'those versions of your Extension have been disabled' in message.body
 
     def test_reject_multiple_versions_with_delay(self):
         old_version = self.review_version

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -1017,6 +1017,9 @@ class TestReviewHelper(TestReviewHelperBase):
         assert base_fragment not in message.body
         assert message.reply_to == [reply_email]
 
+    def test_resolve_abuse_reports(self):
+        pass
+
     def test_email_links(self):
         expected = {
             'extension_nominated_to_approved': 'addon_url',

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -5583,11 +5583,11 @@ class TestReview(ReviewBase):
             ),
         )
         assert self.get_addon().status == amo.STATUS_DISABLED
+        log_entry = ActivityLog.objects.get(action=amo.LOG.FORCE_DISABLE.id)
         mock_resolve_task.assert_called_once_with(
             cinder_job_id=cinder_job.id,
-            reasoning='something',
             decision=CinderJob.DECISION_ACTIONS.AMO_DISABLE_ADDON,
-            policy_ids=[reason.cinder_policy.id],
+            log_entry_id=log_entry.id,
         )
 
     @override_switch('enable-cinder-reporting', active=True)
@@ -5628,11 +5628,11 @@ class TestReview(ReviewBase):
             ),
         )
 
+        log_entry = ActivityLog.objects.get(action=amo.LOG.APPROVE_VERSION.id)
         mock_resolve_task.assert_called_once_with(
             cinder_job_id=cinder_job.id,
-            reasoning='something',
             decision=CinderJob.DECISION_ACTIONS.AMO_APPROVE,
-            policy_ids=[reason.cinder_policy.id],
+            log_entry_id=log_entry.id,
         )
 
 


### PR DESCRIPTION
fixes #21705

We are able to get most of the data we need to send out the emails from the activity log so rather than passing an increasing number of parameters to the task we're just passing that the id for the activity log entry.