### PR TITLE
expose addon_version in details of cinder jobs being resolved

### DIFF
--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -214,14 +214,20 @@ class CinderJobChoiceField(ModelMultipleChoiceField):
         reasons_set = {
             (report.REASONS.for_value(report.reason).display,) for report in reports
         }
-        messages_gen = ((report.message,) for report in reports)
+        messages_gen = (
+            (
+                (f'v[{report.addon_version}]: ' if report.addon_version else ''),
+                report.message,
+            )
+            for report in reports
+        )
         return format_html(
             '{}{}{}<details><summary>Show {} reports</summary><ul>{}</ul></details>',
             '[Appeal] ' if obj.is_appeal else '',
             '[Escalation] ' if is_escalation else '',
             format_html_join(', ', '"{}"', reasons_set),
             len(reports),
-            format_html_join('', '<li>{}</li>', messages_gen),
+            format_html_join('', '<li>{}{}</li>', messages_gen),
         )
 
 

--- a/src/olympia/reviewers/tests/test_forms.py
+++ b/src/olympia/reviewers/tests/test_forms.py
@@ -781,7 +781,10 @@ class TestReviewForm(TestCase):
             decision_action=CinderJob.DECISION_ACTIONS.AMO_DISABLE_ADDON,
         )
         AbuseReport.objects.create(
-            **abuse_kw, cinder_job=cinder_job_appealed, message='ccc'
+            **abuse_kw,
+            cinder_job=cinder_job_appealed,
+            message='ccc',
+            addon_version='1.2',
         )
         cinder_job_appeal = CinderJob.objects.create(job_id='appeal')
         cinder_job_appealed.update(appeal_job=cinder_job_appeal)
@@ -793,6 +796,7 @@ class TestReviewForm(TestCase):
             **{**abuse_kw, 'location': AbuseReport.LOCATION.AMO},
             message='ddd',
             cinder_job=cinder_job_escalated,
+            addon_version='<script>alert()</script>',
         )
 
         AbuseReport.objects.create(
@@ -822,14 +826,17 @@ class TestReviewForm(TestCase):
             cinder_job_2_reports,
         ]
 
-        doc = pq(str(form['resolve_cinder_jobs']))
+        content = str(form['resolve_cinder_jobs'])
+        doc = pq(content)
         assert doc('label[for="id_resolve_cinder_jobs_0"]').text() == (
             '[Escalation] "DSA: It violates Mozilla\'s Add-on Policies"'
-            '\nShow 1 reports\nddd'
+            '\nShow 1 reports\nv[<script>alert()</script>]: ddd'
         )
+        assert '<script>alert()</script>' not in content  # should be escaped
+        assert '&lt;script&gt;alert()&lt;/script&gt' in content  # should be escaped
         assert doc('label[for="id_resolve_cinder_jobs_1"]').text() == (
             '[Appeal] "DSA: It violates Mozilla\'s Add-on Policies"'
-            '\nShow 1 reports\nccc'
+            '\nShow 1 reports\nv[1.2]: ccc'
         )
         assert doc('label[for="id_resolve_cinder_jobs_2"]').text() == (
             '"DSA: It violates Mozilla\'s Add-on Policies"\nShow 2 reports\naaa\nbbb'


### PR DESCRIPTION
fixes #21797 in a very (very) minimal way - just changes it to be "v[version_number]: abuse.message" e.g. "v[1.23]: This add-on does bad thing" if there is an `addon_version` in the AbuseReport instance; keeps it to just the abuse message otherwise.