### PR TITLE
Improve logging for suppressed email confirmation task + fix relative URL in verification email

### DIFF
--- a/src/olympia/devhub/templates/devhub/emails/verify-email-requested.ltxt
+++ b/src/olympia/devhub/templates/devhub/emails/verify-email-requested.ltxt
@@ -3,7 +3,7 @@
 You're receiving this message because you requested to verify your email.
 To finish this process, please click on the link below:
 
-{{ confirmation_link }}
+{{ settings.SITE_URL }}{{ confirmation_link }}
 
 If you didn't request this, please notify amo-admins@mozilla.com.
 

--- a/src/olympia/devhub/templates/devhub/emails/verify-email-requested.ltxt
+++ b/src/olympia/devhub/templates/devhub/emails/verify-email-requested.ltxt
@@ -3,7 +3,7 @@
 You're receiving this message because you requested to verify your email.
 To finish this process, please click on the link below:
 
-{{ settings.SITE_URL }}{{ confirmation_link }}
+{{ confirmation_link }}
 
 If you didn't request this, please notify amo-admins@mozilla.com.
 

--- a/src/olympia/users/tasks.py
+++ b/src/olympia/users/tasks.py
@@ -15,6 +15,7 @@ from requests.exceptions import HTTPError, Timeout
 import olympia.core.logger
 from olympia.amo.celery import task
 from olympia.amo.decorators import set_modified_on, use_primary_db
+from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.amo.utils import (
     SafeStorage,
     backup_storage_enabled,
@@ -189,7 +190,7 @@ def send_suppressed_email_confirmation(suppressed_email_verification_id):
 
     verification.status = SuppressedEmailVerification.STATUS_CHOICES.Pending
 
-    confirmation_link = (
+    confirmation_link = absolutify(
         reverse('devhub.email_verification')
         + '?code='
         + str(verification.confirmation_code)

--- a/src/olympia/users/tasks.py
+++ b/src/olympia/users/tasks.py
@@ -280,6 +280,13 @@ def check_suppressed_email_confirmation(suppressed_email_verification_id, page_s
 
         if is_first_page:
             total = json['total']
+
+            if total == 0:
+                raise Retry(
+                    f'No emails found for email {email}.'
+                    'retrying as email could not be queued yet'
+                )
+
             is_first_page = False
 
         data = json['data']
@@ -297,12 +304,14 @@ def check_suppressed_email_confirmation(suppressed_email_verification_id, page_s
                         f'expected {", ".join(options)}'
                     )
 
+                task_log.info(f'Found matching email {item}')
+
                 verification.update(
                     status=SuppressedEmailVerification.STATUS_CHOICES[item['status']]
                 )
                 return
 
     raise Retry(
-        f'failed to find {code_snippet} in {total} emails.'
+        f'failed to find email for code: {code_snippet} in {total} emails.'
         'retrying as email could not be queued yet'
     )

--- a/src/olympia/users/tests/test_tasks.py
+++ b/src/olympia/users/tests/test_tasks.py
@@ -18,6 +18,7 @@ from freezegun import freeze_time
 from PIL import Image
 from requests.exceptions import Timeout
 
+from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.amo.tests import TestCase, user_factory
 from olympia.amo.tests.test_helpers import get_image_path
 from olympia.amo.utils import SafeStorage
@@ -392,7 +393,7 @@ class TestSendSuppressedEmailConfirmation(TestCase):
 
         assert len(mail.outbox) == 1
 
-        expected_confirmation_link = (
+        expected_confirmation_link = absolutify(
             reverse('devhub.email_verification')
             + '?code='
             + str(verification.confirmation_code)


### PR DESCRIPTION
FIxes: #21687

## Description

This pull request improves the logging for the suppressed email confirmation task. It adds the site URL to the verify email template and updates the check_suppressed_email_confirmation function to provide more detailed error messages.

## Context

In testing this feature on dev, it is sometimes difficult to understand the reason why `check_suppressed_email_confirmation` is retrying. It could be because of bad network response, or that the response returned no results, or that the response returned results and non matched our target email. This PR should make distinguishing those cases easier.

## Testing

Test in dev following the linked issue.