### PR TITLE
Add logs to sync_cinder_policies + trigger sync in management command

### DIFF
--- a/src/olympia/abuse/management/commands/sync_cinder_policies.py
+++ b/src/olympia/abuse/management/commands/sync_cinder_policies.py
@@ -8,6 +8,4 @@ class Command(BaseCommand):
     log = olympia.core.logger.getLogger('z.abuse')
 
     def handle(self, *args, **options):
-        sync_cinder_policies.apply_async()
-
-        self.log.info('Triggered policy sync task.')
+        sync_cinder_policies.apply()

--- a/src/olympia/abuse/tests/test_tasks.py
+++ b/src/olympia/abuse/tests/test_tasks.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from unittest import mock
 
 from django.conf import settings
+from celery.exceptions import Retry
 
 import pytest
 import requests
@@ -703,7 +704,7 @@ class TestSyncCinderPolicies(TestCase):
 
     def test_sync_cinder_policies_raises_for_non_200(self):
         responses.add(responses.GET, self.url, json=[], status=500)
-        with pytest.raises(requests.HTTPError):
+        with pytest.raises(Retry):
             sync_cinder_policies()
 
     def test_sync_cinder_policies_creates_new_record(self):


### PR DESCRIPTION
Fixes: #21850

This pull request adds logs to the `sync_cinder_policies` function and triggers the sync in the management command.