### PR TITLE
Improve Cinder Policy / Review Action Reasons admin

### DIFF
--- a/src/olympia/abuse/admin.py
+++ b/src/olympia/abuse/admin.py
@@ -353,17 +353,32 @@ class AbuseReportAdmin(AMOModelAdmin):
 
 class CinderPolicyAdmin(AMOModelAdmin):
     fields = (
+        'id',
         'created',
         'uuid',
+        'parent',
         'name',
         'text',
     )
     list_display = (
+        'id',
         'uuid',
+        'parent',
         'name',
+        'text',
     )
-    readonly_fields = ('created',)
+    ordering = ('parent__name', 'name')
+    list_select_related = ('parent',)
     view_on_site = False
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
 
 
 admin.site.register(AbuseReport, AbuseReportAdmin)

--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -873,10 +873,10 @@ class CinderPolicy(ModelBase):
     objects = CinderPolicyQuerySet.as_manager()
 
     def __str__(self):
-        return self.name
+        return self.full_text('')
 
     def full_text(self, canned_response_text=None):
-        if not canned_response_text:
+        if canned_response_text is None:
             canned_response_text = self.text
         parts = []
         if self.parent:

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -1264,6 +1264,21 @@ class TestCinderPolicy(TestCase):
                 uuid=existing_policy.uuid,
             )
 
+    def test_str(self):
+        parent_policy = CinderPolicy.objects.create(
+            name='Parent Policy',
+            text='Parent Policy Description',
+            uuid='parent-uuid',
+        )
+        child_policy = CinderPolicy.objects.create(
+            name='Child Policy',
+            text='Child Policy Description',
+            uuid='child-uuid',
+            parent=parent_policy,
+        )
+        assert str(parent_policy) == 'Parent Policy'
+        assert str(child_policy) == 'Parent Policy, specifically Child Policy'
+
     def test_full_text(self):
         parent_policy = CinderPolicy.objects.create(
             name='Parent Policy',
@@ -1276,11 +1291,13 @@ class TestCinderPolicy(TestCase):
             uuid='child-uuid',
             parent=parent_policy,
         )
+        assert parent_policy.full_text('') == 'Parent Policy'
         assert parent_policy.full_text() == 'Parent Policy: Parent Policy Description'
         assert (
             parent_policy.full_text('Some Canned Response')
             == 'Parent Policy: Some Canned Response'
         )
+        assert child_policy.full_text('') == 'Parent Policy, specifically Child Policy'
         assert (
             child_policy.full_text()
             == 'Parent Policy, specifically Child Policy: Child Policy Description'

--- a/src/olympia/reviewers/admin.py
+++ b/src/olympia/reviewers/admin.py
@@ -11,6 +11,15 @@ class ReviewActionReasonAdmin(AMOModelAdmin):
         'addon_type',
         'is_active',
     )
+    fields = (
+        'name',
+        'is_active',
+        'canned_response',
+        'canned_block_reason',
+        'addon_type',
+        'cinder_policy',
+    )
+    raw_id_fields = ('cinder_policy',)
     view_on_site = False
 
 


### PR DESCRIPTION
- Make more fields visible to distinguish between the policies
- Use raw id field for Cinder policy in Review Action Reason admin to allow for a more efficient lookup + easy copy/paste of data

Fixes #21855