### PR TITLE
Install python/npm dependencies in repostiroy root. (WIP/POC)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,9 +105,7 @@ WORKDIR ${HOME}
 # Build locales, assets, build id.
 RUN echo "from olympia.lib.settings_base import *\n" \
 > settings_local.py && DJANGO_SETTINGS_MODULE='settings_local' locale/compile-mo.sh locale \
-    && DJANGO_SETTINGS_MODULE='settings_local' python manage.py compress_assets \
-    && DJANGO_SETTINGS_MODULE='settings_local' python manage.py generate_jsi18n_files \
-    && DJANGO_SETTINGS_MODULE='settings_local' python manage.py collectstatic --noinput \
+    && make update_assets \
     && npm prune --production \
     && ./scripts/generate_build.py > build.py \
     && rm -f settings_local.py settings_local.pyc

--- a/Makefile-docker
+++ b/Makefile-docker
@@ -11,13 +11,8 @@ APP=src/olympia/
 NUM_ADDONS=10
 NUM_THEMES=$(NUM_ADDONS)
 
-NPM_ARGS :=
+NODE_MODULES := $(shell pwd)/node_modules/
 
-ifneq ($(NPM_CONFIG_PREFIX),)
-	NPM_ARGS := --prefix $(NPM_CONFIG_PREFIX)
-endif
-
-NODE_MODULES := $(NPM_CONFIG_PREFIX)node_modules/
 STATIC_CSS := static/css/node_lib/
 STATIC_JS := static/js/node_lib/
 STATIC_JQUERY_UI := static/js/node_lib/ui/
@@ -78,37 +73,31 @@ populate_data: ## populate a new database
 .PHONY: cleanup_python_build_dir
 cleanup_python_build_dir:
 	# Work arounds "Multiple .dist-info directories" issue.
-	rm -rf /deps/build/*
+	rm -rf ./deps/build/*
 
 .PHONY: install_python_olympia_module
 install_python_olympia_module:
 	# pep 517 mode (the default) breaks editable install in our project. https://github.com/mozilla/addons-server/issues/16144
-	$(PIP_COMMAND) install --no-use-pep517 -e .
+	$(PIP_COMMAND) install --user --no-use-pep517 -e .
 
 .PHONY: install_python_codestyle_dependencies
 install_python_codestyle_dependencies:
-	$(PIP_COMMAND) install --progress-bar=off --no-deps --exists-action=w -r requirements/codestyle.txt
+	$(PIP_COMMAND) install --user --progress-bar=off --no-deps --exists-action=w -r requirements/codestyle.txt
 
 .PHONY: install_python_test_dependencies
 install_python_test_dependencies: install_python_olympia_module
-	$(PIP_COMMAND) install --progress-bar=off --no-deps --exists-action=w -r requirements/system.txt
-	$(PIP_COMMAND) install --progress-bar=off --no-deps --exists-action=w -r requirements/prod.txt
-	$(PIP_COMMAND) install --progress-bar=off --no-deps --exists-action=w -r requirements/tests.txt
+	$(PIP_COMMAND) install --user --progress-bar=off --no-deps --exists-action=w -r requirements/system.txt
+	$(PIP_COMMAND) install --user --progress-bar=off --no-deps --exists-action=w -r requirements/prod.txt
+	$(PIP_COMMAND) install --user --progress-bar=off --no-deps --exists-action=w -r requirements/tests.txt
 
 .PHONY: install_python_dev_dependencies
 install_python_dev_dependencies: install_python_test_dependencies install_python_codestyle_dependencies
-	$(PIP_COMMAND) install --progress-bar=off --no-deps --exists-action=w -r requirements/dev.txt
-	$(PIP_COMMAND) install --progress-bar=off --no-deps --exists-action=w -r requirements/docs.txt
+	$(PIP_COMMAND) install --user --progress-bar=off --no-deps --exists-action=w -r requirements/dev.txt
+	$(PIP_COMMAND) install --user --progress-bar=off --no-deps --exists-action=w -r requirements/docs.txt
 
 .PHONY: install_node_dependencies
-install_node_dependencies: install_node_js copy_node_js
-
-.PHONY: install_node_js
-install_node_js:
-	npm install $(NPM_ARGS)
-
-.PHONY: copy_node_js
-copy_node_js:
+install_node_dependencies:
+	npm install
 	for dest in $(NODE_LIBS_CSS) ; do cp $(NODE_MODULES)$$dest $(STATIC_CSS) ; done
 	for dest in $(NODE_LIBS_JS) ; do cp $(NODE_MODULES)$$dest $(STATIC_JS) ; done
 	for dest in $(NODE_LIBS_JQUERY_UI) ; do cp $(NODE_MODULES)$$dest $(STATIC_JQUERY_UI) ; done

--- a/Makefile-docker
+++ b/Makefile-docker
@@ -13,33 +13,6 @@ NUM_THEMES=$(NUM_ADDONS)
 
 NODE_MODULES := $(shell pwd)/node_modules/
 
-STATIC_CSS := static/css/node_lib/
-STATIC_JS := static/js/node_lib/
-STATIC_JQUERY_UI := static/js/node_lib/ui/
-
-NODE_LIBS_CSS := \
-@claviska/jquery-minicolors/jquery.minicolors.css \
-@claviska/jquery-minicolors/jquery.minicolors.png \
-
-# NODE_LIBS_JS and NODE_LIBS_JQUERY_UI are referenced in settings.MINIFY_BUNDLES - keep both lists in sync
-NODE_LIBS_JS := \
-less/dist/less.js \
-jquery/dist/jquery.js \
-jquery.browser/dist/jquery.browser.js \
-jquery.cookie/jquery.cookie.js \
-@claviska/jquery-minicolors/jquery.minicolors.js \
-jszip/dist/jszip.js \
-timeago/jquery.timeago.js \
-underscore/underscore.js \
-netmask/lib/netmask.js \
-
-NODE_LIBS_JQUERY_UI := \
-jquery-ui/ui/data.js \
-jquery-ui/ui/scroll-parent.js \
-jquery-ui/ui/widget.js \
-jquery-ui/ui/widgets/mouse.js \
-jquery-ui/ui/widgets/sortable.js
-
 .PHONY: help_redirect
 help_redirect:
 	@$(MAKE) help --no-print-directory
@@ -98,9 +71,6 @@ install_python_dev_dependencies: install_python_test_dependencies install_python
 .PHONY: install_node_dependencies
 install_node_dependencies:
 	npm install
-	for dest in $(NODE_LIBS_CSS) ; do cp $(NODE_MODULES)$$dest $(STATIC_CSS) ; done
-	for dest in $(NODE_LIBS_JS) ; do cp $(NODE_MODULES)$$dest $(STATIC_JS) ; done
-	for dest in $(NODE_LIBS_JQUERY_UI) ; do cp $(NODE_MODULES)$$dest $(STATIC_JQUERY_UI) ; done
 
 .PHONY: update_deps
 update_deps: cleanup_python_build_dir install_python_dev_dependencies install_node_dependencies ## update the python and node dependencies
@@ -112,7 +82,7 @@ update_db: ## run the database migrations
 .PHONY: update_assets
 update_assets:
 	# If changing this here, make sure to adapt tests in amo/test_commands.py
-	$(PYTHON_COMMAND) manage.py compress_assets
+	$(PYTHON_COMMAND) manage.py compress_assets --settings settings_assets
 	$(PYTHON_COMMAND) manage.py collectstatic --noinput
 	$(PYTHON_COMMAND) manage.py generate_jsi18n_files
 

--- a/Makefile-os
+++ b/Makefile-os
@@ -16,14 +16,14 @@ help_submake:
 
 .PHONY: update_docker
 update_docker: ## update all the docker images
-	docker compose exec --user olympia worker make update_deps
-	docker compose exec --user olympia web make update
+	docker compose exec  worker make update_deps
+	docker compose exec  web make update
 	docker compose restart web
 	docker compose restart worker
 
 .PHONY: shell
 shell: ## connect to a running addons-server docker shell
-	docker compose exec --user olympia web bash
+	docker compose exec  web bash
 
 .PHONY: rootshell
 rootshell: ## connect to a running addons-server docker shell with root user
@@ -35,25 +35,11 @@ create_env_file:
 
 .PHONY: initialize_docker
 initialize_docker: create_env_file
-# Run a fresh container from the base image to install deps. Since /deps is
-# shared via a volume in docker-compose.yml, this installs deps for both web
-# and worker containers, and does so without requiring the containers to be up.
-# We just create dummy empty package.json and package-lock.json in deps/ so
-# that docker compose doesn't create dummy ones itself, as they would be owned
-# by root. They don't matter: the ones at the root directory are mounted
-# instead.
-	touch deps/package.json
-	touch deps/package-lock.json
-# Note that this is running with --user ${UID}:${GID} because the user olympia
-# would be uid 9500 regardless of host at this point (this is only fixed when
-# the container is up, through the command defined in docker-compose.yml),
-# which is wrong for local development.
-	docker compose run --rm --user ${UID}:${GID} web make update_deps
-	docker compose up -d
-	docker compose exec --user olympia web make initialize
+	docker compose up -d --build
+	docker compose exec  web make initialize
 
 %: ## This directs any other recipe (command) to the web container's make.
-	docker compose exec --user olympia web make $(MAKECMDGOALS) ARGS=$(ARGS)
+	docker compose exec  web make $(MAKECMDGOALS) ARGS=$(ARGS)
 
 # You probably want to put new commands in Makefile-docker, unless they operate
 # on multiple containers or are host-os specific.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,8 +36,6 @@ services:
     volumes:
       - .:/data/olympia
       - ./deps:/deps
-      - ./package.json:/deps/package.json
-      - ./package-lock.json:/deps/package-lock.json
     extra_hosts:
      - "olympia.test:127.0.0.1"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,26 +18,20 @@ x-env-mapping: &env
     - HISTSIZE=50000
     - HISTIGNORE=ls:exit:"cd .."
     - HISTCONTROL=erasedups
-    # Note: docker compose uses the values exported from .env for GID/UID if
-    # they exist. ./docker/fix_olympia_user.sh uses those variables to fix
-    # the uid/gid of the user to match the host if necessary.
-    - UID=${UID:-9500}
-    - GID=${UID:-9500}
 
 services:
   worker: &worker
     <<: *env
-    image: mozilla/addons-server:latest
-    # We drop down to a different user through supervisord, but starting as
-    # root allows us to fix the ownership of files generated at image build
-    # time through the ./docker/fix_olympia_user.sh script.
-    user: root
+    build:
+      context: .
+      args:
+        - UID=${UID:-9500}
+        - GID=${GID:-9500}
     platform: linux/amd64
     command:
       - /bin/sh
       - -c
       - |
-        ./docker/fix_olympia_user.sh
         supervisord -n -c /data/olympia/docker/supervisor-celery.conf
     volumes:
       - .:/data/olympia
@@ -54,7 +48,6 @@ services:
       - /bin/sh
       - -c
       - |
-        ./docker/fix_olympia_user.sh
         supervisord -n -c /data/olympia/docker/supervisor.conf
 
   nginx:

--- a/docker/fix_olympia_user.sh
+++ b/docker/fix_olympia_user.sh
@@ -1,3 +1,48 @@
-# Alter the uid/gid of the olympia user/group to match the host
-usermod -u ${UID} olympia
-groupmod -g ${GID} olympia
+
+# This script is run during a docker build, with the goal of ensuring that given the UID/GID of the `host` user running the containr, the `olympia` user inside the container has the same UID/GID. This is necessary to ensure that the files created by the `olympia` user inside the container are owned by the `host` user running the container.
+
+echo "gid: $GID"
+echo "uid: $UID"
+
+function error() { echo "Error: $1"; exit 1; }
+
+# Verify GID and UID are set in the environment.
+if [ -z "$GID" ]; then error "GID not set."; fi
+if [ -z "$UID" ]; then error "UID not set."; fi
+
+# There are several scenarios to consider.
+# Is there a group with matching GID? If so, is the group name "olympia"?
+# Is there a user with matching UID? If so, is the username "olympia"?
+# Is the user olympia a member of the group olympia?
+
+# Check if there is a group with the name olympia
+if getent group olympia >/dev/null; then
+    # Change the GID of the group to the desired GID
+    groupmod -g ${GID} olympia
+else
+    # Create a group with name olympia and GID as the id
+    groupadd -g ${GID} olympia
+fi
+
+# Check if there is a user with UID as the id
+if getent passwd ${UID} >/dev/null; then
+    # Check if the username is not olympia
+    if [ "$(getent passwd ${UID} | cut -d: -f1)" != "olympia" ]; then
+        # Change the username to olympia
+        usermod -l olympia $(getent passwd ${UID} | cut -d: -f1)
+    fi
+else
+    if getent psswd olympia >/dev/null; then
+        # We should not change the UID of an existing user,
+        # But a user exists with our name olympia.
+        error "User with name `olympia` already exists in the container. This should not happen"
+    else
+    # Create a user with name olympia and UID as the id, and add it to the olympia group
+    useradd -u ${UID} -g olympia olympia
+fi
+
+# Check if user olympia is not a member of the group olympia
+if ! getent group olympia | grep -q "\bolympia\b"; then
+    # Add user olympia to the group olympia
+    usermod -a -G olympia olympia
+fi

--- a/docker/uwsgi.ini
+++ b/docker/uwsgi.ini
@@ -10,8 +10,6 @@ master          = true
 processes       = 4
 vaccum          = true
 socket          = :8001
-uid             = $(UID)
-gid             = $(GID)
 memory-report   = true
 enable-threads  = true
 

--- a/docs/topics/install/docker.rst
+++ b/docs/topics/install/docker.rst
@@ -8,7 +8,7 @@ Want the easiest way to start contributing to AMO? Try our Docker-based
 development environment.
 
 First you'll need to install Docker_. Please read their docs for
-the installation steps specific to your operating system. 
+the installation steps specific to your operating system.
 
 .. note::
     If you're running Linux, make sure the ``compose`` package is installed.
@@ -71,9 +71,9 @@ on your host machine::
     docker compose pull  # Can take a while depending on your internet bandwidth.
     make initialize_docker  # Answer yes, and create your superuser when asked.
     # On Windows you can substitute `make initialize_docker` by the following commands:
-    docker compose run --rm --user olympia web make update_deps
+    docker compose run --rm  web make update_deps
     docker compose up -d
-    docker compose exec --user olympia web make initialize
+    docker compose exec  web make initialize
 
 .. note::
 
@@ -121,13 +121,13 @@ Run the tests using ``make``, *outside* of the Docker container::
 
     make test
     # or
-    docker compose exec --user olympia web pytest src/olympia/
+    docker compose exec  web pytest src/olympia/
 
 You can run commands inside the Docker container by ``ssh``\ing into it using::
 
     make shell
     # or
-    docker compose exec --user olympia web bash
+    docker compose exec  web bash
 
 Then to run the tests inside the Docker container you can run::
 
@@ -158,8 +158,8 @@ migrations::
     docker compose up -d
     make update_docker  # Runs database migrations and rebuilds assets.
     # On Windows you can substitute `make update_docker` for the following commands:
-    docker compose exec --user olympia worker make update_deps
-    docker compose exec --user olympia web make update
+    docker compose exec  worker make update_deps
+    docker compose exec  web make update
     docker compose restart web
     docker compose restart worker
 

--- a/settings_assets.py
+++ b/settings_assets.py
@@ -1,0 +1,3 @@
+from olympia.lib.settings_base import *
+
+STATICFILES_DIRS += (path('node_modules'),)

--- a/src/olympia/amo/admin.py
+++ b/src/olympia/amo/admin.py
@@ -183,7 +183,9 @@ class AMOModelAdmin(admin.ModelAdmin):
         js = (
             'js/admin/ip_address_search.js',
             'js/exports.js',
-            'js/node_lib/netmask.js',
+            # requiring the compiled js file directly
+            # because we don't have access to the jinja js() method
+            'js/admin-min.js',
         )
         css = {'all': ('css/admin/amoadmin.css',)}
 

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -76,15 +76,15 @@ SILENCED_SYSTEM_CHECKS = (
 # LESS CSS OPTIONS (Debug only).
 LESS_PREPROCESS = True  # Compile LESS with Node, rather than client-side JS?
 LESS_LIVE_REFRESH = False  # Refresh the CSS on save?
-LESS_BIN = env('LESS_BIN', default='/deps/node_modules/less/bin/lessc')
+LESS_BIN = env('LESS_BIN', default=path('node_modules/less/bin/lessc'))
 
 # Path to cleancss (our CSS minifier).
 CLEANCSS_BIN = env(
-    'CLEANCSS_BIN', default='/deps/node_modules/clean-css-cli/bin/cleancss'
+    'CLEANCSS_BIN', default=path('node_modules/clean-css-cli/bin/cleancss')
 )
 
 # Path to our JS minifier.
-JS_MINIFIER_BIN = env('JS_MINIFIER_BIN', default='/deps/node_modules/terser/bin/terser')
+JS_MINIFIER_BIN = env('JS_MINIFIER_BIN', default=path('node_modules/terser/bin/terser'))
 
 # rsvg-convert is used to save our svg static theme previews to png
 RSVG_CONVERT_BIN = env('RSVG_CONVERT_BIN', default='rsvg-convert')
@@ -94,7 +94,7 @@ PNGCRUSH_BIN = env('PNGCRUSH_BIN', default='pngcrush')
 
 # Path to our addons-linter binary
 ADDONS_LINTER_BIN = env(
-    'ADDONS_LINTER_BIN', default='/deps/node_modules/addons-linter/bin/addons-linter'
+    'ADDONS_LINTER_BIN', default=path('node_modules/addons-linter/bin/addons-linter')
 )
 # --enable-background-service-worker linter flag value
 ADDONS_LINTER_ENABLE_SERVICE_WORKER = False

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -608,7 +608,7 @@ MINIFY_BUNDLES = {
             'css/devhub/buttons.less',
             'css/devhub/in-app-config.less',
             'css/devhub/static-theme.less',
-            'css/node_lib/jquery.minicolors.css',
+            '@claviska/jquery-minicolors/jquery.minicolors.css',
             'css/impala/devhub-api.less',
             'css/devhub/dashboard.less',
         ),
@@ -626,11 +626,11 @@ MINIFY_BUNDLES = {
         # JS files common to the entire site, apart from dev-landing.
         # js/node_lib/* files are copied in Makefile-docker - keep both lists in sync
         'common': (
-            'js/node_lib/underscore.js',
+            'underscore/underscore.js',
             'js/zamboni/init.js',
             'js/zamboni/capabilities.js',
             'js/lib/format.js',
-            'js/node_lib/jquery.cookie.js',
+            'jquery.cookie/jquery.cookie.js',
             'js/zamboni/storage.js',
             'js/common/keys.js',
             'js/zamboni/helpers.js',
@@ -644,8 +644,8 @@ MINIFY_BUNDLES = {
         ),
         # Things to be loaded at the top of the page
         'preload': (
-            'js/node_lib/jquery.js',
-            'js/node_lib/jquery.browser.js',
+            'jquery/dist/jquery.js',
+            'jquery.browser/dist/jquery.browser.js',
             'js/zamboni/analytics.js',
         ),
         'zamboni/devhub': (
@@ -656,16 +656,16 @@ MINIFY_BUNDLES = {
             'js/common/upload-image.js',
             'js/zamboni/devhub.js',
             'js/zamboni/validator.js',
-            'js/node_lib/jquery.timeago.js',
+            'timeago/jquery.timeago.js',
             'js/zamboni/static_theme.js',
-            'js/node_lib/jquery.minicolors.js',
-            'js/node_lib/jszip.js',
+            '@claviska/jquery-minicolors/jquery.minicolors.js',
+            'jszip/dist/jszip.js',
             # jQuery UI for sortable
-            'js/node_lib/ui/data.js',
-            'js/node_lib/ui/scroll-parent.js',
-            'js/node_lib/ui/widget.js',
-            'js/node_lib/ui/mouse.js',
-            'js/node_lib/ui/sortable.js',
+            'jquery-ui/ui/data.js',
+            'jquery-ui/ui/scroll-parent.js',
+            'jquery-ui/ui/widget.js',
+            'jquery-ui/ui/widgets/mouse.js',
+            'jquery-ui/ui/widgets/sortable.js',
         ),
         'devhub/new-landing/js': (
             # Note that new-landing (devhub/index.html) doesn't include
@@ -697,8 +697,11 @@ MINIFY_BUNDLES = {
         # This is included when DEBUG is True.  Bundle in <head>.
         'debug': (
             'js/debug/less_setup.js',
-            'js/node_lib/less.js',
+            'less/dist/less.js',
             'js/debug/less_live.js',
+        ),
+        'amo': (
+            'netmask/lib/netmask.js',
         ),
     },
 }

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,13 @@
+
+FROM docker:dind
+
+# Install system deps
+RUN apk update && \
+    apk add --no-cache git nodejs npm make sudo nano curl docker-compose && \
+    rm -rf /var/cache/apk/*
+
+COPY ./setup_docker.sh /setup_docker.sh
+RUN /setup_docker.sh
+
+CMD dockerd &> docker.log & tail -f docker.log
+

--- a/tests/setup_docker.sh
+++ b/tests/setup_docker.sh
@@ -1,0 +1,28 @@
+# Extract code block into a function
+get_next_uid() {
+  local uid=$(awk -F: '{print $3}' /etc/passwd | sort -n | tail -1)
+  echo $((uid + 1))
+}
+
+# Extract code block into a function
+get_next_gid() {
+  local gid=$(awk -F: '{print $3}' /etc/group | sort -n | tail -1)
+  echo $((gid + 1))
+}
+
+NONROOT="nonroot"
+DOCKER="docker"
+
+# Create non-root user and group
+addgroup -g $(get_next_gid) $NONROOT
+adduser -u $(get_next_uid) -G $NONROOT -D -s /bin/sh $NONROOT
+
+
+# Check if group docker exists
+if ! getent group docker > /dev/null; then
+  addgroup -g $(get_next_gid) $DOCKER
+fi
+
+# allow nonroot to use docker daemon
+adduser $NONROOT $DOCKER
+


### PR DESCRIPTION
## Description

This PR has 2 commits. The aim is to simplify some of our build logic, specifically with how we handle node_modules. The first commit moves our node_modules back to the repo root in /data/olympia. The second uses django staticfiles to source files we need to include in our css/js bundles, removing the need for manually copying and maintaining those files.

## Context

Based on the comments so far, seems like we have had premission issues between the container and host.

## Tests

Check in the comments but you can test this on a non-linux host using docker in docker.

```docker
FROM docker:19.03.12-dind

RUN apk add git nodejs npm make sudo

RUN git clone https://github.com/mozilla/addons-server.git

RUN addgroup -g 12345 nonroot \
    && adduser -u 12345 -G nonroot -S nonroot -s /bin/sh \
    && addgroup nonroot docker \
    && chown -R nonroot:nonroot /addons-server

WORKDIR /addons-server

ENV UID=12345
ENV GID=12345
USER nonroot

CMD ["docker", "compose", "pull"]
```
