### PR TITLE
Create empty local_settings.py when none exists to avoid erronious "missing local_settings" warning

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -137,8 +137,7 @@ local_settings_path = path('local_settings.py')
 if not os.path.exists(local_settings_path):
     with open(local_settings_path, 'w') as file:
         file.write(
-            '# If you have settings you want to overload,'
-            'put them in a local_settings.py.\n'
+            '# Put settings you want to overload in this file.\n'
         )
 
 from local_settings import *  # noqa

--- a/settings.py
+++ b/settings.py
@@ -136,9 +136,7 @@ local_settings_path = path('local_settings.py')
 
 if not os.path.exists(local_settings_path):
     with open(local_settings_path, 'w') as file:
-        file.write(
-            '# Put settings you want to overload in this file.\n'
-        )
+        file.write('# Put settings you want to overload in this file.\n')
 
 from local_settings import *  # noqa
 

--- a/settings.py
+++ b/settings.py
@@ -132,17 +132,16 @@ CUSTOMS_API_KEY = 'customssecret'
 
 REMOTE_SETTINGS_IS_TEST_SERVER = True
 
-# If you have settings you want to overload, put them in a local_settings.py.
-try:
-    from local_settings import *  # noqa
-except ImportError:
-    import traceback
-    import warnings
+local_settings_path = path('local_settings.py')
 
-    warnings.warn(
-        'Could not import local_settings module. {}'.format(traceback.format_exc()),
-        stacklevel=1,
-    )
+if not os.path.exists(local_settings_path):
+    with open(local_settings_path, 'w') as file:
+        file.write(
+            '# If you have settings you want to overload,'
+            'put them in a local_settings.py.\n'
+        )
+
+from local_settings import *  # noqa
 
 SITEMAP_DEBUG_AVAILABLE = True
 


### PR DESCRIPTION
Relates to: #21888

### Description

modify settings.py to create a local_settings.py with base_settings import if none exists. This ensures the git ignored local_settings file is always present without polutting it with any contents.

### Context

If you don't have a local_settings.py file, any command that relies on settings.py (almost anything) will print a warning that it could not find the file.

### Testing

You will need to build the container locally and shell into it. I was able to do this with 


```bash
docker build -t test_locale .   
```

Our image doesn't have a command or entry point so you need to define one when running it.

```bash
docker run -d --name test_locale_container test_locale tail -f /dev/null
```

ANd finally shell

```
docker exec -it test_locale_container bash 
```

NOTE: There is no volume, so if you change the code on your machine, it will not be reflected in the container

Now you can run any command that uses the settings.py file

```bash
make update_assets
```

You should not see any warnings about missing local settings file, even if you delete the file and rerun. If you have a local_settings file with a setting, it should not update it.
