### PR TITLE
Include needed requirements files for read the docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,6 +9,11 @@ build:
   os: ubuntu-20.04
   tools:
     python: "3.10"
+    nodejs: "18"
+  jobs:
+    post_install:
+      - make -f Makefile-docker update_deps
+
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -16,4 +21,4 @@ sphinx:
 
 python:
    install:
-   - requirements: requirements/docs.txt
+   - requirements: requirements/pip.txt


### PR DESCRIPTION
Fixes: #21932

### Description

In #21837 we merged our requirements.txt files but forgot to update the readthedocs config. Because this build doesn't run on PRs it was not caught before merging.

Use our needed req files in readthedocs build.

### Context

This is a bit of a hack, but rtd has strong opinions about how they want to install pip dependencies and only let us specify files to include. This breaks the build because our .txt files include loose versions, which they don't allow.

The solution, to keep it simple is to just install pip.txt which gives us the correct pip version, and then install via our make command. This gives us total control over the installation flow and ensures compatibility with the Makefile.

FWIW this patch will likely be made redundant by https://github.com/mozilla/addons-server/pull/21937 which entirely replaces rtd with github pages.

### Testing

You can enable rtd deployments on PRs and I did enable it to verify this fixes the build.
