### PR TITLE
Efficiently cache docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,7 @@ deps/
 node_modules/
 storage/
 logs/*
+
+# Don't include the docker cache in the build context or you will get memory leaks
+docker-cache/
+docker-cache-new/

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ private/
 !docker-compose.private.yml
 !private/README.md
 !deps/.keep
+
+# Local cache directory for docker layer/build cache
+docker-cache/
+docker-cache-new/

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,24 @@ ENV PIP_SRC=/deps/src/
 ENV PYTHONUSERBASE=/deps
 ENV PATH $PYTHONUSERBASE/bin:$PATH
 ENV NPM_CONFIG_PREFIX=/deps/
-RUN ln -s ${HOME}/package.json /deps/package.json \
+ENV NPM_CACHE_DIR=/deps/cache/npm
+ENV NPM_DEBUG=true
+
+RUN \
+    # Files needed to run the make command
+    --mount=type=bind,source=Makefile,target=${HOME}/Makefile \
+    --mount=type=bind,source=Makefile-docker,target=${HOME}/Makefile-docker \
+    # Files required to install pip dependencies
+    --mount=type=bind,source=setup.py,target=${HOME}/setup.py \
+    --mount=type=bind,source=./requirements,target=${HOME}/requirements \
+    # Files required to install npm dependencies
+    --mount=type=bind,source=package.json,target=${HOME}/package.json \
+    --mount=type=bind,source=package-lock.json,target=${HOME}/package-lock.json \
+    # Mounts for caching dependencies
+    --mount=type=cache,target=${PIP_CACHE_DIR},uid=${OLYMPIA_UID},gid=${OLYMPIA_GID} \
+    --mount=type=cache,target=${NPM_CACHE_DIR},uid=${OLYMPIA_UID},gid=${OLYMPIA_GID} \
+    # Command to install dependencies
+    ln -s ${HOME}/package.json /deps/package.json \
     && ln -s ${HOME}/package-lock.json /deps/package-lock.json \
     && make update_deps_prod
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+##### Important information for maintaining this Dockerfile ########################################
+# Read the docs/topics/development/docker.md file for more information about this Dockerfile.
+####################################################################################################
+
 FROM python:3.10-slim-buster as base
 
 # Should change it to use ARG instead of ENV for OLYMPIA_UID/OLYMPIA_GID

--- a/Makefile-docker
+++ b/Makefile-docker
@@ -17,6 +17,14 @@ ifneq ($(NPM_CONFIG_PREFIX),)
 	NPM_ARGS := --prefix $(NPM_CONFIG_PREFIX)
 endif
 
+ifneq ($(NPM_CACHE_DIR),)
+	NPM_ARGS := $(NPM_ARGS) --cache $(NPM_CACHE_DIR)
+endif
+
+ifneq ($(NPM_DEBUG),)
+	NPM_ARGS := $(NPM_ARGS) --loglevel verbose
+endif
+
 NODE_MODULES := $(NPM_CONFIG_PREFIX)node_modules/
 STATIC_CSS := static/css/node_lib/
 STATIC_JS := static/js/node_lib/
@@ -75,7 +83,6 @@ populate_data: ## populate a new database
 	# Now that addons have been generated, reindex.
 	$(PYTHON_COMMAND) manage.py reindex --force --noinput
 
-.PHONY: update_deps_base
 update_deps_base: ## update the python and node dependencies
 	# Work arounds "Multiple .dist-info directories" issue.
 	rm -rf /deps/build/*
@@ -84,18 +91,14 @@ update_deps_base: ## update the python and node dependencies
 	# pep 517 mode (the default) breaks editable install in our project. https://github.com/mozilla/addons-server/issues/16144
 	$(PIP_COMMAND) install --no-use-pep517 -e .
 
-	npm install $(NPM_ARGS)
-	for dest in $(NODE_LIBS_CSS) ; do cp $(NODE_MODULES)$$dest $(STATIC_CSS) ; done
-	for dest in $(NODE_LIBS_JS) ; do cp $(NODE_MODULES)$$dest $(STATIC_JS) ; done
-	for dest in $(NODE_LIBS_JQUERY_UI) ; do cp $(NODE_MODULES)$$dest $(STATIC_JQUERY_UI) ; done
-
 .PHONY: update_deps
 update_deps: update_deps_base ## update the python and node dependencies for development
 	$(PIP_COMMAND) install --progress-bar=off --no-deps --exists-action=w -r requirements/dev.txt
+	npm install $(NPM_ARGS)
 
 .PHONY: update_deps_prod
 update_deps_prod: update_deps_base ## update the python and node dependencies for production
-	npm prune --omit=dev
+	npm ci $(NPM_ARGS)
 
 .PHONY: update_db
 update_db: ## run the database migrations
@@ -103,6 +106,11 @@ update_db: ## run the database migrations
 
 .PHONY: update_assets
 update_assets:
+	# Copy files required in compress_assets to the static folder
+	mkdir -p $(STATIC_CSS) $(STATIC_JS) $(STATIC_JQUERY_UI)
+	for dest in $(NODE_LIBS_CSS) ; do cp $(NODE_MODULES)$$dest $(STATIC_CSS) ; done
+	for dest in $(NODE_LIBS_JS) ; do cp $(NODE_MODULES)$$dest $(STATIC_JS) ; done
+	for dest in $(NODE_LIBS_JQUERY_UI) ; do cp $(NODE_MODULES)$$dest $(STATIC_JQUERY_UI) ; done
 	# If changing this here, make sure to adapt tests in amo/test_commands.py
 	$(PYTHON_COMMAND) manage.py compress_assets
 	$(PYTHON_COMMAND) manage.py collectstatic --noinput

--- a/Makefile-os
+++ b/Makefile-os
@@ -3,6 +3,13 @@ GID := $(shell id -g)
 export UID
 export GID
 
+export DOCKER_BUILDER=container
+
+TAG := addons-server-test
+PLATFORM := linux/amd64
+PROGRESS := auto
+DOCKER_CACHE_DIR := docker-cache
+
 .PHONY: help_redirect
 help_redirect:
 	@$(MAKE) help --no-print-directory
@@ -32,6 +39,25 @@ rootshell: ## connect to a running addons-server docker shell with root user
 .PHONY: create_env_file
 create_env_file:
 	echo "UID=${UID}\nGID=${GID}" > .env
+
+.PHONY: create_docker_builder
+create_docker_builder: ## Create a custom builder for buildkit to efficiently build local images
+	docker buildx use $(DOCKER_BUILDER) 2>/dev/null || docker buildx create \
+		--name $(DOCKER_BUILDER) \
+		--driver=docker-container
+
+.PHONY: build_docker_image
+build_docker_image: create_docker_builder ## Build the docker image
+	DOCKER_BUILDKIT=1 docker build \
+		-t $(TAG) \
+		--load \
+		--platform $(PLATFORM) \
+		--progress=$(PROGRESS) \
+		--cache-to=type=local,dest=$(DOCKER_CACHE_DIR)-new \
+		--cache-from=type=local,src=$(DOCKER_CACHE_DIR),mode=max \
+		--builder=$(DOCKER_BUILDER) .
+	rm -rf $(DOCKER_CACHE_DIR)
+	mv $(DOCKER_CACHE_DIR)-new $(DOCKER_CACHE_DIR)
 
 .PHONY: initialize_docker
 initialize_docker: create_env_file

--- a/docs/topics/development/dependencies.md
+++ b/docs/topics/development/dependencies.md
@@ -61,3 +61,9 @@ make -f Makefile-docker update_deps
 ```
 
 This is used in github actions for example that do not need a full container to run.
+
+> Note: If you are adding a new dependency, make sure to update static assets imported from the new versions.
+
+```bash
+make update_assets
+```

--- a/docs/topics/development/docker.md
+++ b/docs/topics/development/docker.md
@@ -1,0 +1,56 @@
+# Docker
+
+## The Dockerfile
+
+Our Dockerfile is used in both production and development environments, however it is not always and not entirely used in CI (for now at least).
+
+The Dockerfile builds addons-server and runs using docker-compose by specifying the latest image pushed to dockerhub. Keep in mind during local development you are likely not running the current image in your git repository but the latest push to master in github.
+
+### Best Practices for the Dockerfile
+
+- Use as few instructions as possible
+- Split long running tasks into distinct stages to improve caching/concurrency
+- Prefer --mount=type=bind over COPY for files that are needed for a single command
+
+  > bind mounts files as root/docker user, so run the stage from base and chown them to olympia.
+  > bind mounts do not persist data, so if you modify any files, they will **not** be in the final layer.
+
+- If you do use COPY for files that are executed, prefer copying individual files over directories.
+
+  > The larger the directory, the more likely it is to have false cache hits.
+  > Link: <https://github.com/moby/moby/issues/33107>
+
+- Use --mount=type=cache for caching caches npm/pip etc.
+
+  > cache mounts are not persisted in CI due to an existing bug in buildkit. Link: <https://github.com/moby/buildkit/issues/1512>
+
+- Delay copying source files until the end of the Dockerfile to imrove cache validity
+
+## Building locally
+
+To build the Dockerfile locally, run the following command:
+
+```bash
+make build_docker_image
+```
+
+This will build the Dockerfile locally with buildkit and tag it as `addons-server-test` by default. You can control several parameters including the tag and platform. This can be very useful if you are testing a new image or want to test a new platform.
+
+We utilize buildkit layer and mount caching to build extremely efficiently. There are more improvements we can make.
+
+## Clearing cache
+
+Because we use a custom builder to take full advantage of buildkit mount caching clearing your cache means clearing
+the specific builder cache we use, not the docker cache.
+
+Do:
+
+```bash
+docker builder prune
+```
+
+Don't do:
+
+```bash
+docker system prune
+```

--- a/docs/topics/development/index.rst
+++ b/docs/topics/development/index.rst
@@ -8,6 +8,7 @@ Development
    tests
    debugging
    dependencies
+   docker
    error_pages
    testing
    style


### PR DESCRIPTION
relates to : #21888

### Description

Using more efficient caching within our docker build to speed up successive builds.

### Context

This opens up faster build times both locally and in CI and makes the idea of building images more frequently a lot more palletable.

### Testing

This PR adds a make command to build a local docker image

```bash
make build_docker_image
```

This will build an image. If you want to really see the cache benefit, then first prune your local layer cache

```bash
docker system prune -a --volumes
```

If you have already run `make build_docker_image` you should prune the builder cache as well 

```bash
docker buildx prune --all
```

This is like runnig for the first time. It will take a while.

Then modify the package.json or one of the requirements files.

Run the build again.

You will see that pip is using "cached" versions of dependencies which have already been installed. That is the more aggressive layer caching kicking in.

You'll also see that if you change other files in the code base, it won't necessarily reinstall dependencies. You can compare that behavior to running the same commands on master.