### PR TITLE
github action to efficiently build docker image on PRs to verify build

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -60,7 +60,7 @@ runs:
         buildkitd-flags: --debug
 
     # Login to a registry to push the image
-    - name: Login to GitHub Container Registry
+    - name: Login to Container Registry
       # Only login if we are pushing the image
       if: ${{ inputs.push == 'true' }}
       uses: docker/login-action@v3

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -1,0 +1,106 @@
+name: 'Docker Build'
+description: 'Builds `addons-server` docker image'
+inputs:
+  load:
+    required: false
+    description: "Build and load image to local docker daemon. (cannot be used together with push)"
+    default: "false"
+  no_cache:
+    required: false
+    description: "Build fresh image without cache"
+    default: "false"
+  password:
+    required: false
+    description: "Docker registry password"
+    default: "invalid"
+  pull:
+    required: false
+    description: "Pull all referenced images before building"
+    default: "false"
+  push:
+    required: false
+    description: "Build and push image to registry (cannot be used together with load)"
+    default: "false"
+  python_version:
+    required: false
+    description: "Python version"
+    default: "3.10"
+  username:
+    required: false
+    description: "Docker registry username"
+    default: "invalid"
+
+outputs:
+  tags:
+    description: "The Docker tags for the image"
+    value: ${{ steps.meta.outputs.tags }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate inputs
+      shell: bash
+      run: |
+        if [[ ${{ inputs.load == 'true' }} == ${{ inputs.push == 'true' }} ]]; then
+          echo "Cannot use load and push together. Must choose only one of them."
+          exit 1
+        fi
+
+        if [[ "${{ inputs.push  }}" == "true" && "${{ github.ref }}" == "refs/heads/master" ]]; then
+          echo "Cannot push to registry from master branch unless we migrate our master build job to GHA."
+          exit 1
+        fi
+    # Setup docker to build for multiple architectures
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+      with:
+        version: latest
+        buildkitd-flags: --debug
+
+    # Login to a registry to push the image
+    - name: Login to GitHub Container Registry
+      # Only login if we are pushing the image
+      if: ${{ inputs.push == 'true' }}
+      uses: docker/login-action@v3
+      with:
+        username: ${{ inputs.username }}
+        password: ${{ inputs.password }}
+
+    - name: Set commit sha
+      id: sha
+      shell: bash
+      run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+    # Determine the tags for the image
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        # Hard coding our dockerhub imnage name
+        images: mozilla/addons-server
+        tags: |
+          type=schedule
+          type=ref,event=tag
+          type=ref,event=branch,suffix=-${{ steps.sha.outputs.sha_short }}
+          type=ref,event=pr,suffix=-${{ steps.sha.outputs.sha_short }}
+          # set latest tag for default branch
+          # Disabled for now as we do not use this action for
+          # The production build
+          # type=raw,value=latest,enable={{is_default_branch}}
+
+    - name: Build Image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        platforms: linux/amd64
+        pull: ${{ inputs.pull }}
+        push: ${{ inputs.push }}
+        load: ${{ inputs.load }}
+        no-cache: ${{ inputs.no_cache }}
+        tags: ${{ steps.meta.outputs.tags }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        build-args: |
+            PYTHON_VERSION=${{ inputs.python_version }}

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  bulid_docker_image:
+  build_docker_image:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,35 @@
+name: Build Docker image
+
+on:
+  workflow_dispatch:
+    inputs:
+      push:
+        description: 'Push the image to registry?'
+        default: "false"
+        required: false
+      ref:
+        description: 'Branch, PR, tag or commit to build'
+        default: "master"
+        required: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.ref }}-${{ github.event.inputs.push }}
+  cancel-in-progress: true
+
+jobs:
+  bulid_docker_image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref }}
+          fetch-depth: 1
+
+      - name: Build container
+        id: build_container
+        uses: ./.github/actions/build-docker
+        with:
+          push: ${{ github.event.inputs.push }}
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}

--- a/.github/workflows/verify-docker-image.yml
+++ b/.github/workflows/verify-docker-image.yml
@@ -1,0 +1,32 @@
+name: Verify Docker Image
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  verify_docker_image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build container
+        id: build_container
+        uses: ./.github/actions/build-docker
+        with:
+          load: true
+
+      - name: List images
+        shell: bash
+        run: |
+          docker images
+          echo "target: ${{ steps.build_container.outputs.tags }}"
+
+      - name: Smoke test
+        shell: bash
+        run: |
+          docker run ${{ steps.build_container.outputs.tags }} sh -c \
+            "echo 'from olympia.lib.settings_base import *' > settings_local.py && \
+            DJANGO_SETTINGS_MODULE='settings_local' python3 ./manage.py check"


### PR DESCRIPTION
Relates to: #21888 

### Description

This PR introduces a github composite action that can build and (optionally) push a docker image to a registry. There are also two workflows:

- `verify-docker-image` that runs on PRs and builds (without pushing).
- `build-docker-image` the runs on workflow dispatch and can arbitrarily build and or push an image to the registry.

This ensures PRs do not merge code which results in an unbuildable docker image (as has happened recently) Also allows sharing built images.

### Context

Why build a composite action instead of only a workflow? The docker build involves several steps and can be reused across any number of workflows, from actually pushing production images, testing PRs with a real container, to deploying on temporary environments or sharing containers over a registry for testing. 

I already have several such use-cases prototyped but did not want to make this PR to big, but at the same time it is fine to implement the composite action that is already clearly useful.

Prior art: Examples of repos pushing images in CI, majority pushing, majority using dockerhub.

- https://github.com/mozilla/neqo/blob/main/.github/workflows/qns.yml
- https://github.com/mozilla/neqo/blob/7f6fc8bdf60d026c87980c9fe6974166fc2455c5/.github/workflows/qns.yml#L51
- https://github.com/mozilla/hubs-ops/blob/53b43ea7326499d324707a08159d77323f9b8dfa/.github/workflows/turkeyGitops.yml#L85
- https://github.com/mozilla/jira-bugzilla-integration/blob/c6cb0b70aad5f6207bea6f7f729e251379d29383/.github/workflows/build-publish.yaml#L53
- https://github.com/mozilla/classify-client/blob/a7bd632a63e5bcf4c6eb090a2618f1f57aa52d85/.github/workflows/publish.yml#L56
- https://github.com/mozilla/remote-settings/blob/6169a51ec1b9ec04ead5198cdcfb9dc7b9cafb53/.github/workflows/publish.yaml#L44
- https://github.com/mozilla/remote-settings/blob/6169a51ec1b9ec04ead5198cdcfb9dc7b9cafb53/.github/workflows/ci.yaml#L124
- https://github.com/mozilla/mentoring/blob/345a8bd2a66e4456c2c0338ccbc5e4e483fe8e5f/.github/workflows/docker.yaml#L33
- https://github.com/mozilla/ssh_scan/blob/f3256f29e1a8e596f37824ae063c1f05e00fc32f/.github/workflows/docker-deploy.yml#L23
- https://github.com/mozilla/ssh_scan/blob/f3256f29e1a8e596f37824ae063c1f05e00fc32f/.github/workflows/docker-test.yml#L20

### Testing

You can test the workflow on this PR or by branching and adding commits. Keep in mind, there will not be very efficient caching on the build until https://github.com/mozilla/addons-server/pull/21914 is merged, but actually, this PR is a great way to test that one so we should merge it first and make sure we don't break the build.
