### PR TITLE
ADDSRV-735-github-pages

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -1,0 +1,18 @@
+name: 'Setup Environment'
+description: 'Install dependencies and setup environment for actions that do not require docker'
+inputs:
+  python_version:
+    required: false
+    description: "Python version"
+    default: "3.10"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python_version }}
+        cache: 'pip'
+
+    - run: make -f Makefile-docker update_deps
+      shell: bash

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,57 @@
+name: Docs
+
+on:
+  # Build docs on pull request to verify changes
+  pull_request:
+    branches:
+      - master
+  # Deploy to production on master
+  push:
+    branches:
+      - master
+  # Deploy `master` on workflow dispatch.
+  workflow_dispatch:
+
+jobs:
+  build_docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Build Docs
+        shell: bash
+        run: |
+          make -f Makefile-docker docs
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'docs/_build/html'
+          name: "docs"
+
+  deploy_docs:
+    # only deploy on push to the master branch
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    # Only deploy the latest build artifact to GitHub Pages
+    concurrency:
+      group: "pages"
+      cancel-in-progress: true
+    needs: build_docs
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+        with:
+          artifact_name: "docs"

--- a/Makefile-docker
+++ b/Makefile-docker
@@ -79,10 +79,10 @@ populate_data: ## populate a new database
 update_deps_base: ## update the python and node dependencies
 	# Work arounds "Multiple .dist-info directories" issue.
 	rm -rf /deps/build/*
-	# pep 517 mode (the default) breaks editable install in our project. https://github.com/mozilla/addons-server/issues/16144
-	$(PIP_COMMAND) install --no-use-pep517 -e .
 	$(PIP_COMMAND) install --progress-bar=off --no-deps --exists-action=w -r requirements/pip.txt
 	$(PIP_COMMAND) install --progress-bar=off --no-deps --exists-action=w -r requirements/prod.txt
+	# pep 517 mode (the default) breaks editable install in our project. https://github.com/mozilla/addons-server/issues/16144
+	$(PIP_COMMAND) install --no-use-pep517 -e .
 
 	npm install $(NPM_ARGS)
 	for dest in $(NODE_LIBS_CSS) ; do cp $(NODE_MODULES)$$dest $(STATIC_CSS) ; done


### PR DESCRIPTION
Fixes: #21932

### Description

Adds a github action workflow for deploying our docs site to github pages. Effectively replacing readthedocs as a hosting provider.

### Context

This PR introduces a composite action setup-local to enable running CI commands in a github runner without needing to use the docker container. This can be faster and is more lightweight for actions that dont' explicitly need the full container running

In order for this change to work we have to enable redirects on readthedocs to maintain the domain name we currently have. These are already implemented and seem to be working.

### Testing

You can deploy this action by pushing to the branch or triggering the workflow via the gh cli.

