### PR TITLE
Allow enable addon and unreject version(s) to resolve jobs

### DIFF
--- a/src/olympia/abuse/tasks.py
+++ b/src/olympia/abuse/tasks.py
@@ -109,11 +109,11 @@ def appeal_to_cinder(
 
 @task
 @use_primary_db
-def resolve_job_in_cinder(*, cinder_job_id, decision, log_entry_id):
+def resolve_job_in_cinder(*, cinder_job_id, log_entry_id):
     try:
         cinder_job = CinderJob.objects.get(id=cinder_job_id)
         log_entry = ActivityLog.objects.get(id=log_entry_id)
-        cinder_job.resolve_job(decision=decision, log_entry=log_entry)
+        cinder_job.resolve_job(log_entry=log_entry)
     except Exception:
         statsd.incr('abuse.tasks.resolve_job_in_cinder.failure')
         raise

--- a/src/olympia/abuse/tests/test_tasks.py
+++ b/src/olympia/abuse/tests/test_tasks.py
@@ -622,7 +622,6 @@ def test_resolve_job_in_cinder(statsd_incr_mock):
 
     resolve_job_in_cinder.delay(
         cinder_job_id=cinder_job.id,
-        decision=CinderJob.DECISION_ACTIONS.AMO_DISABLE_ADDON,
         log_entry_id=log_entry.id,
     )
 
@@ -671,7 +670,6 @@ def test_resolve_job_in_cinder_exception(statsd_incr_mock):
     with pytest.raises(ConnectionError):
         resolve_job_in_cinder.delay(
             cinder_job_id=cinder_job.id,
-            decision=CinderJob.DECISION_ACTIONS.AMO_DISABLE_ADDON,
             log_entry_id=log_entry.id,
         )
 

--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -146,6 +146,7 @@ class APPROVE_VERSION(_LOG):
     review_email_user = True
     review_queue = True
     reviewer_review_action = True
+    cinder_action = 'amo_approve'
 
 
 class PRELIMINARY_VERSION(_LOG):
@@ -169,6 +170,7 @@ class REJECT_VERSION(_LOG):
     review_email_user = True
     review_queue = True
     reviewer_review_action = True
+    cinder_action = 'amo_reject_version_addon'
 
 
 class RETAIN_VERSION(_LOG):
@@ -622,6 +624,7 @@ class CONFIRM_AUTO_APPROVED(_LOG):
     reviewer_review_action = True
     review_queue = True
     hide_developer = True
+    cinder_action = 'amo_approve'
 
 
 class ENABLE_VERSION(_LOG):
@@ -655,6 +658,7 @@ class REJECT_CONTENT(_LOG):
     review_email_user = True
     review_queue = True
     reviewer_review_action = True
+    cinder_action = 'amo-reject-version-addon'
 
 
 class ADMIN_ALTER_INFO_REQUEST(_LOG):
@@ -789,6 +793,7 @@ class REJECT_CONTENT_DELAYED(_LOG):
     review_email_user = True
     review_queue = True
     reviewer_review_action = True
+    cinder_action = 'amo-reject-version-addon'
 
 
 class REJECT_VERSION_DELAYED(_LOG):
@@ -801,6 +806,7 @@ class REJECT_VERSION_DELAYED(_LOG):
     review_email_user = True
     review_queue = True
     reviewer_review_action = True
+    cinder_action = 'amo-reject-version-addon'
 
 
 class VERSION_RESIGNED(_LOG):
@@ -819,6 +825,7 @@ class FORCE_DISABLE(_LOG):
     reviewer_format = '{addon} force-disabled by {user_responsible}.'
     admin_format = reviewer_format
     short = 'Force disabled'
+    cinder_action = 'amo_disable_addon'
 
 
 class FORCE_ENABLE(_LOG):
@@ -878,6 +885,7 @@ class CLEAR_NEEDS_HUMAN_REVIEWS_LEGACY(_LOG):
     admin_event = True
     review_queue = True
     reviewer_review_action = True
+    cinder_action = 'amo_approve'
 
 
 class NEEDS_HUMAN_REVIEW_AUTOMATIC(_LOG):

--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -836,6 +836,7 @@ class FORCE_ENABLE(_LOG):
     reviewer_format = '{addon} force-enabled by {user_responsible}.'
     admin_format = reviewer_format
     short = 'Force enabled'
+    cinder_action = 'amo_approve'
 
 
 class LOG_IN(_LOG):
@@ -865,6 +866,7 @@ class UNREJECT_VERSION(_LOG):
     keep = True
     review_queue = True
     reviewer_review_action = True
+    cinder_action = 'amo_approve'
 
 
 class LOG_IN_API_TOKEN(_LOG):

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -1030,20 +1030,16 @@ class TestReviewHelper(TestReviewHelperBase):
             {**self.get_data(), 'resolve_cinder_jobs': [cinder_job1, cinder_job2]}
         )
 
-        self.helper.handler.resolve_abuse_reports(
-            CinderJob.DECISION_ACTIONS.AMO_APPROVE
-        )
+        self.helper.handler.resolve_abuse_reports()
 
         mock_resolve_task.assert_has_calls(
             [
                 call(
                     cinder_job_id=cinder_job1.id,
-                    decision=CinderJob.DECISION_ACTIONS.AMO_APPROVE,
                     log_entry_id=log_entry.id,
                 ),
                 call(
                     cinder_job_id=cinder_job2.id,
-                    decision=CinderJob.DECISION_ACTIONS.AMO_APPROVE,
                     log_entry_id=log_entry.id,
                 ),
             ]
@@ -3181,7 +3177,7 @@ class TestReviewHelper(TestReviewHelperBase):
 
     def _resolve_abuse_reports_called_everywhere_checkbox_shown(self, channel, actions):
         # these two functions are to verify we call log_action before it's accessed
-        def log_check(decision):
+        def log_check():
             assert self.helper.handler.log_entry
 
         def log_action(*args, **kwargs):

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -5594,7 +5594,6 @@ class TestReview(ReviewBase):
         log_entry = ActivityLog.objects.get(action=amo.LOG.FORCE_DISABLE.id)
         mock_resolve_task.assert_called_once_with(
             cinder_job_id=cinder_job.id,
-            decision=CinderJob.DECISION_ACTIONS.AMO_DISABLE_ADDON,
             log_entry_id=log_entry.id,
         )
 
@@ -5642,7 +5641,6 @@ class TestReview(ReviewBase):
         log_entry = ActivityLog.objects.get(action=amo.LOG.APPROVE_VERSION.id)
         mock_resolve_task.assert_called_once_with(
             cinder_job_id=cinder_job.id,
-            decision=CinderJob.DECISION_ACTIONS.AMO_APPROVE,
             log_entry_id=log_entry.id,
         )
 

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -679,7 +679,7 @@ class ReviewHelper:
             'minimal': True,
             'details': (
                 'This will un-reject the latest version without notifying the '
-                'developer.'
+                'developer. If resolving an appeal job the developer will be notified.'
             ),
             'comments': False,
             'available': (
@@ -688,6 +688,7 @@ class ReviewHelper:
                 and version_was_rejected
                 and is_appropriate_admin_reviewer
             ),
+            'resolves_abuse_reports': True,
         }
         actions['unreject_multiple_versions'] = {
             'method': self.handler.unreject_multiple_versions,
@@ -696,7 +697,7 @@ class ReviewHelper:
             'multiple_versions': True,
             'details': (
                 'This will un-reject the selected versions without notifying the '
-                'developer.'
+                'developer. If resolving an appeal job the developer will be notified.'
             ),
             'comments': False,
             'available': (
@@ -704,6 +705,7 @@ class ReviewHelper:
                 and addon_is_not_disabled_or_deleted
                 and is_appropriate_admin_reviewer
             ),
+            'resolves_abuse_reports': True,
         }
         actions['block_multiple_versions'] = {
             'method': self.handler.block_multiple_versions,
@@ -812,7 +814,8 @@ class ReviewHelper:
             'label': 'Force enable',
             'details': (
                 'This will force enable this add-on, but not the versions. '
-                'The developer will not be notified.'
+                'The developer will not be notified. '
+                'If resolving an appeal job the developer will be notified.'
             ),
             'minimal': True,
             'available': (
@@ -820,6 +823,7 @@ class ReviewHelper:
                 and not addon_is_not_disabled
                 and is_appropriate_admin_reviewer
             ),
+            'resolves_abuse_reports': True,
         }
         actions['disable_addon'] = {
             'method': self.handler.disable_addon,
@@ -1427,6 +1431,7 @@ class ReviewBase:
         self.set_file(amo.STATUS_AWAITING_REVIEW, self.version.file)
         self.log_action(amo.LOG.UNREJECT_VERSION)
         self.addon.update_status(self.user)
+        self.resolve_abuse_reports()
 
     def confirm_multiple_versions(self):
         raise NotImplementedError  # only implemented for unlisted below.
@@ -1489,6 +1494,7 @@ class ReviewBase:
         self.version = None
         self.addon.force_enable(skip_activity_log=True)
         self.log_action(amo.LOG.FORCE_ENABLE)
+        self.resolve_abuse_reports()
 
     def disable_addon(self):
         """Force disable the add-on and all versions."""
@@ -1697,3 +1703,4 @@ class ReviewUnlisted(ReviewBase):
         if self.data['versions']:
             # if these are listed versions then the addon status may need updating
             self.addon.update_status(self.user)
+        self.resolve_abuse_reports()


### PR DESCRIPTION
fixes #21879  (pulls part of https://github.com/mozilla/addons-server/pull/21858 along, so the cinder decision action doesn't have to be defined in the reviewer tools)