### PR TITLE
Add button to Cinder Policy Admin to trigger a sync from Cinder

### DIFF
--- a/src/olympia/abuse/templates/admin/abuse/cinderpolicy/change_list_object_tools.html
+++ b/src/olympia/abuse/templates/admin/abuse/cinderpolicy/change_list_object_tools.html
@@ -1,0 +1,9 @@
+{% extends "admin/change_list_object_tools.html" %}
+
+{% block object-tools-items %}
+<form>
+    {% csrf_token %}
+    {{ block.super }}
+    <li><input id="abuse_sync_cinder_policies" type="submit" formmethod="post" formaction="{% url 'admin:abuse_sync_cinder_policies' %}" value="Sync from Cinder" /></li>
+</form>
+{% endblock %}


### PR DESCRIPTION
Fixes #21896

The button should appear on the cinder policy changelist page in the admin (`/admin/models/abuse/cinderpolicy/`) and trigger the sync when used, if the user has `Admin:Advanced` permission (or `*:*`)