### PR TITLE
Fix email verification bug(s)

### DIFF
--- a/src/olympia/devhub/templates/devhub/verify_email.html
+++ b/src/olympia/devhub/templates/devhub/verify_email.html
@@ -39,13 +39,16 @@
   {% trans %}
   This is taking longer than expected. Try again.
   {% endtrans %}
-{% elif state == "confirmation_pending" %}
+{% elif state == "verification_delivered" %}
   {% trans email=request.user.email %}
   An email with a confirmation link has been sent to your email address: {{ email }}. Please click the link to confirm your email address. If you did not receive the email, please check your spam folder.
   {% endtrans %}
-{% elif state == "confirmation_unauthorized" %}
+{% elif state == "confirmation_invalid" %}
   {% trans email=request.user.email %}
-  The provided code is associated with another user's email. Please use the link in the email sent to your email address {{ email }}.
+  The provided code is invalid. Please use the link in the email sent to your email address {{ email }}.
+  - could be unauthorized
+  - could be expired
+  - could be a mistake
   {% endtrans %}
 {% endif %}
 {% if render_button %}


### PR DESCRIPTION
Fixes: #21943

### Description

- handle case where valid code is given for non-expired verification but we have not recieved confirmation from socketlabs for X reason
- extract method to resolve email verification state from the view
- add additional edge case testing
- merge invalid code and unauthorized code error states

### Context

This PR is technically a bug fix and a refactor, but I realized while fixing the code that the bug was hidden in the complexity of the code, so, yeah. 

Happy to split this into 2 PRs if its felt this would be better but I believe the code is much easier to grok now and should be clear where the bug is fixed.

### Testing

In the ticket.

