### PR TITLE
monitor cinder's /health endpoint in our services monitor

### DIFF
--- a/src/olympia/amo/monitors.py
+++ b/src/olympia/amo/monitors.py
@@ -2,6 +2,7 @@ import io
 import os
 import socket
 import traceback
+from urllib.parse import urljoin
 
 from django.conf import settings
 
@@ -224,3 +225,31 @@ def remotesettings():
         status = f'Failed to execute task in time: {e}'
         monitor_log.critical(status)
     return status, None
+
+
+def cinder():
+    # check cinder connectivity
+    signer_results = None
+    status = ''
+
+    cinder_api_url = settings.CINDER_SERVER_URL
+    if cinder_api_url:
+        try:
+            health_url = urljoin(cinder_api_url, '/health', allow_fragments=False)
+            response = requests.get(health_url, timeout=5)
+            if response.status_code != 200:
+                status = 'Failed to chat with cinder. Invalid HTTP response code.'
+                monitor_log.critical(status)
+                signer_results = False
+            else:
+                signer_results = True
+        except Exception as exc:
+            status = 'Failed to chat with cinder: %s' % exc
+            monitor_log.critical(status)
+            signer_results = False
+    else:
+        status = 'CINDER_SERVER_URL is not set'
+        monitor_log.critical(status)
+        signer_results = False
+
+    return status, signer_results

--- a/src/olympia/amo/monitors.py
+++ b/src/olympia/amo/monitors.py
@@ -237,16 +237,13 @@ def cinder():
         try:
             health_url = urljoin(cinder_api_url, '/health', allow_fragments=False)
             response = requests.get(health_url, timeout=5)
-            if response.status_code != 200:
-                status = 'Failed to chat with cinder. Invalid HTTP response code.'
-                monitor_log.critical(status)
-                signer_results = False
-            else:
-                signer_results = True
+            response.raise_for_status()
         except Exception as exc:
             status = 'Failed to chat with cinder: %s' % exc
             monitor_log.critical(status)
             signer_results = False
+        else:
+            signer_results = True
     else:
         status = 'CINDER_SERVER_URL is not set'
         monitor_log.critical(status)

--- a/src/olympia/amo/tests/test_monitor.py
+++ b/src/olympia/amo/tests/test_monitor.py
@@ -128,25 +128,16 @@ class TestMonitor(TestCase):
         assert '503 Server Error: Service Unavailable' in obtained
 
     def test_cinder_success(self):
-        responses.add(
-            responses.GET,
-            'https://stage.cinder.nonprod.webservices.mozgcp.net/health',
-            status=200,
-            body=json.dumps({'http': True}),
-        )
+        url = settings.CINDER_SERVER_URL.replace('/api/v1/', '/health')
+        responses.add(responses.GET, url, status=200, body=json.dumps({'http': True}))
 
         status, signer_result = monitors.cinder()
         assert signer_result is True
         assert status == ''
 
     def test_cinder_fail(self):
-        url = 'https://stage.cinder.nonprod.webservices.mozgcp.net/health'
-        responses.add(
-            responses.GET,
-            url,
-            status=500,
-            body=json.dumps({'http': False}),
-        )
+        url = settings.CINDER_SERVER_URL.replace('/api/v1/', '/health')
+        responses.add(responses.GET, url, status=500, body=json.dumps({'http': False}))
 
         status, signer_result = monitors.cinder()
         assert signer_result is False

--- a/src/olympia/amo/tests/test_monitor.py
+++ b/src/olympia/amo/tests/test_monitor.py
@@ -140,13 +140,17 @@ class TestMonitor(TestCase):
         assert status == ''
 
     def test_cinder_fail(self):
+        url = 'https://stage.cinder.nonprod.webservices.mozgcp.net/health'
         responses.add(
             responses.GET,
-            'https://stage.cinder.nonprod.webservices.mozgcp.net/health',
+            url,
             status=500,
             body=json.dumps({'http': False}),
         )
 
         status, signer_result = monitors.cinder()
         assert signer_result is False
-        assert status == 'Failed to chat with cinder. Invalid HTTP response code.'
+        assert status == (
+            'Failed to chat with cinder: '
+            f'500 Server Error: Internal Server Error for url: {url}'
+        )

--- a/src/olympia/amo/tests/test_monitor.py
+++ b/src/olympia/amo/tests/test_monitor.py
@@ -126,3 +126,27 @@ class TestMonitor(TestCase):
         )
         obtained, _ = monitors.remotesettings()
         assert '503 Server Error: Service Unavailable' in obtained
+
+    def test_cinder_success(self):
+        responses.add(
+            responses.GET,
+            'https://stage.cinder.nonprod.webservices.mozgcp.net/health',
+            status=200,
+            body=json.dumps({'http': True}),
+        )
+
+        status, signer_result = monitors.cinder()
+        assert signer_result is True
+        assert status == ''
+
+    def test_cinder_fail(self):
+        responses.add(
+            responses.GET,
+            'https://stage.cinder.nonprod.webservices.mozgcp.net/health',
+            status=500,
+            body=json.dumps({'http': False}),
+        )
+
+        status, signer_result = monitors.cinder()
+        assert signer_result is False
+        assert status == 'Failed to chat with cinder. Invalid HTTP response code.'

--- a/src/olympia/amo/tests/test_views.py
+++ b/src/olympia/amo/tests/test_views.py
@@ -382,6 +382,7 @@ class TestHeartbeat(TestCase):
             'rabbitmq',
             'signer',
             'remotesettings',
+            'cinder',
         ]:
             patcher = mock.patch(f'olympia.amo.monitors.{check}')
             self.mocks[check] = patcher.start()

--- a/src/olympia/amo/views.py
+++ b/src/olympia/amo/views.py
@@ -57,6 +57,7 @@ def services_heartbeat(request):
             'rabbitmq',
             'signer',
             'remotesettings',
+            'cinder',
         ]
     )
     # If anything broke, send HTTP 500.


### PR DESCRIPTION
fixes #21931 - the /health endpoint is available without auth

If you want to test this locally you can load `http://olympia.test/services/monitor.json` (some of the other services might fail depending on your local settings)