### PR TITLE
Build docker image with buildx to support new Dockerfile syntax

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,6 +350,9 @@ commands:
   make_release:
     description: "Builds and pushes a Docker image"
     parameters:
+      push:
+        type: boolean
+        default: false
       image_tag:
         type: string
         default: "latest"
@@ -367,9 +370,16 @@ commands:
           command: |
             docker version
             docker login -u "${DOCKERHUB_USER}" -p "${DOCKERHUB_PASS}"
-            docker build -t app:build --label git.commit="$CIRCLE_SHA1" .
-            docker tag app:build "${DOCKERHUB_REPO}":<< parameters.image_tag >>
-            docker push "${DOCKERHUB_REPO}":<< parameters.image_tag >>
+            make build_docker_image DOCKER_TAG="app:build" DOCKER_COMMIT="$CIRCLE_SHA1"
+            docker images
+      - when:
+          condition: << parameters.push >>
+          steps:
+            - run:
+                name: Wait for services to be ready
+                command: |
+                  docker tag app:build "${DOCKERHUB_REPO}":<< parameters.image_tag >>
+                  docker push "${DOCKERHUB_REPO}":<< parameters.image_tag >>
 
   better_checkout:
     description: circle ci checkout step on steroids
@@ -610,12 +620,24 @@ jobs:
       - run:
           command: pytest -m "es_tests and not needs_locales_compilation and not static_assets" -v src/olympia/
 
+  # Add to a workflow, if you want to test the docker build in circleci
+  build-image:
+    <<: *defaults-release
+    steps:
+      - checkout
+      - make_release:
+          # use invalid tag
+          image_tag: test
+          # explicitly don't push
+          push: false
+
   release-master:
     <<: *defaults-release
     steps:
       - checkout
       - make_release:
           image_tag: latest
+          push: true
 
   release-tag:
     <<: *defaults-release
@@ -623,6 +645,7 @@ jobs:
       - checkout
       - make_release:
           image_tag: "${CIRCLE_TAG}"
+          push: true
 
 workflows:
   version: 2
@@ -635,6 +658,8 @@ workflows:
       - devhub
       - docs
       - main
+      # Uncomment if you want to test the docker build
+      # - build-image
       - reviewers-and-zadmin
       - es-tests
       - localization

--- a/Makefile-os
+++ b/Makefile-os
@@ -5,9 +5,10 @@ export GID
 
 export DOCKER_BUILDER=container
 
-TAG := addons-server-test
-PLATFORM := linux/amd64
-PROGRESS := auto
+DOCKER_TAG := addons-server-test
+DOCKER_PLATFORM := linux/amd64
+DOCKER_PROGRESS := auto
+DOCKER_COMMIT := $(shell git rev-parse HEAD)
 DOCKER_CACHE_DIR := docker-cache
 
 .PHONY: help_redirect
@@ -48,14 +49,16 @@ create_docker_builder: ## Create a custom builder for buildkit to efficiently bu
 
 .PHONY: build_docker_image
 build_docker_image: create_docker_builder ## Build the docker image
-	DOCKER_BUILDKIT=1 docker build \
-		-t $(TAG) \
+	DOCKER_BUILDKIT=1 docker buildx build \
+		-t $(DOCKER_TAG) \
 		--load \
-		--platform $(PLATFORM) \
-		--progress=$(PROGRESS) \
+		--platform $(DOCKER_PLATFORM) \
+		--progress=$(DOCKER_PROGRESS) \
 		--cache-to=type=local,dest=$(DOCKER_CACHE_DIR)-new \
 		--cache-from=type=local,src=$(DOCKER_CACHE_DIR),mode=max \
-		--builder=$(DOCKER_BUILDER) .
+		--builder=$(DOCKER_BUILDER) \
+		--label git.commit=$(DOCKER_COMMIT) \
+		.
 	rm -rf $(DOCKER_CACHE_DIR)
 	mv $(DOCKER_CACHE_DIR)-new $(DOCKER_CACHE_DIR)
 


### PR DESCRIPTION
Fixes: #21959

### Description

Explicitly use `docker buildx build` to ensure buildkit flags and syntax are available during local/ci builds. We run the make command in CI to ensure the same command is executed in both environments. This is also _essentially_ compatible with that is executed in the github action build.

### Context

#21914 broke the docker build in circleci, this went unnoticed because the build only runs on master and the command was simple and using the same docker build as we have in the locale make command `build_docker_image`. There were differences in arguments, but it was assumed that docker build would support buildx context... that was wrong.

### Testing

You can test by adding the `-build-image` job to a workflow. It is enabled in this commit: [d8a8420731e2b4ca7d83fbb98befc8f8817e5478](https://github.com/mozilla/addons-server/pull/21960/commits/d8a8420731e2b4ca7d83fbb98befc8f8817e5478)

Which will be removed before merging.