### PR TITLE
add cinder actoin for CLEAR_NEEDS_HUMAN_REVIEW activity

### DIFF
--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -914,6 +914,7 @@ class CLEAR_NEEDS_HUMAN_REVIEW(_LOG):
     review_queue = True
     reviewer_review_action = True
     hide_developer = True
+    cinder_action = 'amo_approve'
 
 
 class CLEAR_PENDING_REJECTION(_LOG):

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -3205,10 +3205,13 @@ class TestReviewHelper(TestReviewHelperBase):
                 action['method']()
                 resolve_mock.assert_called_once()
                 resolve_mock.reset_mock()
+                log_entry = log_action_mock.call_args.args[0]
                 assert (
-                    getattr(log_action_mock.call_args.args[0], 'hide_developer', False)
+                    getattr(log_entry, 'hide_developer', False)
                     != should_email[action_name]
                 )
+                assert hasattr(log_entry, 'cinder_action')
+                assert CinderJob.DECISION_ACTIONS.has_api_value(log_entry.cinder_action)
                 log_action_mock.assert_called_once()
                 log_action_mock.reset_mock()
                 self.helper.handler.log_entry = None


### PR DESCRIPTION
fixes #21963 - it's a regression from https://github.com/mozilla/addons-server/issues/21879

The patch is a little longer than 1 line because I added more tests and a runtime exception to make sure this doesn't happen again