### PR TITLE
move DECISION_ACTIONS to constants

### DIFF
--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -8,9 +8,9 @@ from django.db.transaction import atomic
 from olympia import amo
 from olympia.addons.models import Addon
 from olympia.amo.models import BaseQuerySet, ManagerBase, ModelBase
-from olympia.api.utils import APIChoicesWithDash, APIChoicesWithNone
+from olympia.api.utils import APIChoicesWithNone
 from olympia.bandwagon.models import Collection
-from olympia.constants.abuse import APPEAL_EXPIRATION_DAYS
+from olympia.constants.abuse import APPEAL_EXPIRATION_DAYS, DECISION_ACTIONS
 from olympia.ratings.models import Rating
 from olympia.users.models import UserProfile
 
@@ -44,7 +44,7 @@ class CinderJobQuerySet(BaseQuerySet):
 
     def unresolved(self):
         return self.filter(
-            decision_action__in=tuple(CinderJob.DECISION_ACTIONS.UNRESOLVED.values)
+            decision_action__in=tuple(DECISION_ACTIONS.UNRESOLVED.values)
         )
 
     def resolvable_in_reviewer_tools(self):
@@ -65,47 +65,6 @@ class CinderJobManager(ManagerBase):
 
 
 class CinderJob(ModelBase):
-    DECISION_ACTIONS = APIChoicesWithDash(
-        ('NO_DECISION', 0, 'No decision'),
-        ('AMO_BAN_USER', 1, 'User ban'),
-        ('AMO_DISABLE_ADDON', 2, 'Add-on disable'),
-        ('AMO_ESCALATE_ADDON', 3, 'Escalate add-on to reviewers'),
-        # 4 is unused
-        ('AMO_DELETE_RATING', 5, 'Rating delete'),
-        ('AMO_DELETE_COLLECTION', 6, 'Collection delete'),
-        ('AMO_APPROVE', 7, 'Approved (no action)'),
-        # Rejecting versions is not an available action for moderators in cinder
-        # - it is only handled by the reviewer tools by AMO Reviewers.
-        # It should not be sent by the cinder webhook, & does not have an action defined
-        ('AMO_REJECT_VERSION_ADDON', 8, 'Add-on version reject'),
-    )
-    DECISION_ACTIONS.add_subset(
-        'APPEALABLE_BY_AUTHOR',
-        (
-            'AMO_BAN_USER',
-            'AMO_DISABLE_ADDON',
-            'AMO_DELETE_RATING',
-            'AMO_DELETE_COLLECTION',
-            'AMO_REJECT_VERSION_ADDON',
-        ),
-    )
-    DECISION_ACTIONS.add_subset(
-        'APPEALABLE_BY_REPORTER',
-        ('AMO_APPROVE',),
-    )
-    DECISION_ACTIONS.add_subset(
-        'UNRESOLVED',
-        ('NO_DECISION', 'AMO_ESCALATE_ADDON'),
-    )
-    DECISION_ACTIONS.add_subset(
-        'REMOVING',
-        (
-            'AMO_BAN_USER',
-            'AMO_DISABLE_ADDON',
-            'AMO_DELETE_RATING',
-            'AMO_DELETE_COLLECTION',
-        ),
-    )
     job_id = models.CharField(max_length=36, unique=True)
     decision_action = models.PositiveSmallIntegerField(
         default=DECISION_ACTIONS.NO_DECISION, choices=DECISION_ACTIONS.choices
@@ -186,7 +145,7 @@ class CinderJob(ModelBase):
                 and abuse_report
                 and abuse_report.cinder_job == self
                 and not abuse_report.appellant_job
-                and self.decision_action in self.DECISION_ACTIONS.APPEALABLE_BY_REPORTER
+                and self.decision_action in DECISION_ACTIONS.APPEALABLE_BY_REPORTER
                 and not self.appealed_jobs.exists()
             )
             or
@@ -199,7 +158,7 @@ class CinderJob(ModelBase):
             (
                 not is_reporter
                 and not self.appeal_job
-                and self.decision_action in self.DECISION_ACTIONS.APPEALABLE_BY_AUTHOR
+                and self.decision_action in DECISION_ACTIONS.APPEALABLE_BY_AUTHOR
             )
         )
         return base_criteria and user_criteria
@@ -236,13 +195,13 @@ class CinderJob(ModelBase):
     @classmethod
     def get_action_helper_class(cls, decision_action):
         return {
-            cls.DECISION_ACTIONS.AMO_BAN_USER: CinderActionBanUser,
-            cls.DECISION_ACTIONS.AMO_DISABLE_ADDON: CinderActionDisableAddon,
-            cls.DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON: CinderActionRejectVersion,
-            cls.DECISION_ACTIONS.AMO_ESCALATE_ADDON: CinderActionEscalateAddon,
-            cls.DECISION_ACTIONS.AMO_DELETE_COLLECTION: CinderActionDeleteCollection,
-            cls.DECISION_ACTIONS.AMO_DELETE_RATING: CinderActionDeleteRating,
-            cls.DECISION_ACTIONS.AMO_APPROVE: CinderActionApproveInitialDecision,
+            DECISION_ACTIONS.AMO_BAN_USER: CinderActionBanUser,
+            DECISION_ACTIONS.AMO_DISABLE_ADDON: CinderActionDisableAddon,
+            DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON: CinderActionRejectVersion,
+            DECISION_ACTIONS.AMO_ESCALATE_ADDON: CinderActionEscalateAddon,
+            DECISION_ACTIONS.AMO_DELETE_COLLECTION: CinderActionDeleteCollection,
+            DECISION_ACTIONS.AMO_DELETE_RATING: CinderActionDeleteRating,
+            DECISION_ACTIONS.AMO_APPROVE: CinderActionApproveInitialDecision,
         }.get(decision_action, CinderActionNotImplemented)
 
     def get_action_helper(
@@ -253,8 +212,8 @@ class CinderJob(ModelBase):
 
         # But we use more specific actions for certain cases:
         # Where there was an appeal/override from a remove action to approve
-        if self.decision_action == self.DECISION_ACTIONS.AMO_APPROVE and (
-            existing_decision in self.DECISION_ACTIONS.REMOVING
+        if self.decision_action == DECISION_ACTIONS.AMO_APPROVE and (
+            existing_decision in DECISION_ACTIONS.REMOVING
         ):
             CinderActionClass = (
                 CinderActionOverrideApprove
@@ -264,7 +223,7 @@ class CinderJob(ModelBase):
 
         # Where there was an appeal/override which didn't change from a remove action
         elif self.decision_action == existing_decision and (
-            self.decision_action in self.DECISION_ACTIONS.REMOVING
+            self.decision_action in DECISION_ACTIONS.REMOVING
         ):
             CinderActionClass = (
                 CinderActionNotImplemented
@@ -327,7 +286,7 @@ class CinderJob(ModelBase):
                 : self._meta.get_field('decision_notes').max_length
             ],
             resolvable_in_reviewer_tools=self.resolvable_in_reviewer_tools
-            or decision_action == self.DECISION_ACTIONS.AMO_ESCALATE_ADDON,
+            or decision_action == DECISION_ACTIONS.AMO_ESCALATE_ADDON,
         )
         policies = CinderPolicy.objects.filter(
             uuid__in=policy_ids
@@ -337,7 +296,7 @@ class CinderJob(ModelBase):
         action_occured = action_helper.process_action()
         if (
             existing_decision != decision_action
-            or decision_action == self.DECISION_ACTIONS.AMO_APPROVE
+            or decision_action == DECISION_ACTIONS.AMO_APPROVE
         ):
             action_helper.notify_reporters()
         if action_occured:
@@ -395,14 +354,12 @@ class CinderJob(ModelBase):
     def resolve_job(self, *, log_entry):
         """This is called for reviewer tools originated decisions.
         See process_decision for cinder originated decisions."""
-        if not self.DECISION_ACTIONS.has_api_value(
-            cinder_action_slug := getattr(log_entry.log, 'cinder_action', None)
-        ):
+        if not hasattr(log_entry.log, 'cinder_action'):
             raise ImproperlyConfigured(
                 'Missing or invalid cinder_action for activity log entry passed to '
                 'resolve_job'
             )
-        decision_action = self.DECISION_ACTIONS.for_api_value(cinder_action_slug).value
+        decision_action = log_entry.log.cinder_action.value
         entity_helper = self.get_entity_helper(self.abuse_reports[0])
         policies = CinderPolicy.objects.filter(
             pk__in=log_entry.reviewactionreasonlog_set.all()

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -13,7 +13,7 @@ import responses
 from olympia import amo
 from olympia.activity.models import ActivityLog
 from olympia.amo.tests import TestCase, addon_factory, collection_factory, user_factory
-from olympia.constants.abuse import APPEAL_EXPIRATION_DAYS
+from olympia.constants.abuse import APPEAL_EXPIRATION_DAYS, DECISION_ACTIONS
 from olympia.ratings.models import Rating
 from olympia.reviewers.models import ReviewActionReason
 
@@ -386,7 +386,7 @@ class TestCinderJobManager(TestCase):
         AbuseReport.objects.create(
             guid='5678',
             cinder_job=CinderJob.objects.create(
-                job_id='2', decision_action=CinderJob.DECISION_ACTIONS.AMO_DISABLE_ADDON
+                job_id='2', decision_action=DECISION_ACTIONS.AMO_DISABLE_ADDON
             ),
         )
         qs = CinderJob.objects.unresolved()
@@ -427,7 +427,7 @@ class TestCinderJobManager(TestCase):
         assert list(qs) == [job, appeal_job]
 
         not_policy_report.cinder_job.update(
-            decision_action=CinderJob.DECISION_ACTIONS.AMO_ESCALATE_ADDON,
+            decision_action=DECISION_ACTIONS.AMO_ESCALATE_ADDON,
             resolvable_in_reviewer_tools=True,
         )
         qs = CinderJob.objects.resolvable_in_reviewer_tools()
@@ -633,7 +633,6 @@ class TestCinderJob(TestCase):
         assert cinder_job.resolvable_in_reviewer_tools
 
     def test_get_action_helper(self):
-        DECISION_ACTIONS = CinderJob.DECISION_ACTIONS
         cinder_job = CinderJob.objects.create(job_id='1234')
         helper = cinder_job.get_action_helper()
         assert helper.cinder_job == cinder_job
@@ -699,13 +698,13 @@ class TestCinderJob(TestCase):
             cinder_job.process_decision(
                 decision_id='12345',
                 decision_date=new_date,
-                decision_action=CinderJob.DECISION_ACTIONS.AMO_BAN_USER.value,
+                decision_action=DECISION_ACTIONS.AMO_BAN_USER.value,
                 decision_notes='teh notes',
                 policy_ids=['123-45', '678-90'],
             )
         assert cinder_job.decision_id == '12345'
         assert cinder_job.decision_date == new_date
-        assert cinder_job.decision_action == CinderJob.DECISION_ACTIONS.AMO_BAN_USER
+        assert cinder_job.decision_action == DECISION_ACTIONS.AMO_BAN_USER
         assert cinder_job.decision_notes == 'teh notes'
         assert action_mock.call_count == 1
         assert notify_mock.call_count == 1
@@ -730,13 +729,13 @@ class TestCinderJob(TestCase):
             cinder_job.process_decision(
                 decision_id='12345',
                 decision_date=new_date,
-                decision_action=CinderJob.DECISION_ACTIONS.AMO_BAN_USER.value,
+                decision_action=DECISION_ACTIONS.AMO_BAN_USER.value,
                 decision_notes='teh notes',
                 policy_ids=['123-45', '678-90'],
             )
         assert cinder_job.decision_id == '12345'
         assert cinder_job.decision_date == new_date
-        assert cinder_job.decision_action == CinderJob.DECISION_ACTIONS.AMO_BAN_USER
+        assert cinder_job.decision_action == DECISION_ACTIONS.AMO_BAN_USER
         assert cinder_job.decision_notes == 'teh notes'
         assert action_mock.call_count == 1
         assert notify_mock.call_count == 1
@@ -750,15 +749,13 @@ class TestCinderJob(TestCase):
         cinder_job.process_decision(
             decision_id='12345',
             decision_date=new_date,
-            decision_action=CinderJob.DECISION_ACTIONS.AMO_ESCALATE_ADDON,
+            decision_action=DECISION_ACTIONS.AMO_ESCALATE_ADDON,
             decision_notes='blah',
             policy_ids=[],
         )
         assert cinder_job.decision_id == '12345'
         assert cinder_job.decision_date == new_date
-        assert (
-            cinder_job.decision_action == CinderJob.DECISION_ACTIONS.AMO_ESCALATE_ADDON
-        )
+        assert cinder_job.decision_action == DECISION_ACTIONS.AMO_ESCALATE_ADDON
         assert cinder_job.decision_notes == 'blah'
         assert cinder_job.resolvable_in_reviewer_tools
         assert cinder_job.target_addon == addon
@@ -772,7 +769,7 @@ class TestCinderJob(TestCase):
             cinder_job=CinderJob.objects.create(
                 decision_id='4815162342-lost',
                 decision_date=self.days_ago(179),
-                decision_action=CinderJob.DECISION_ACTIONS.AMO_DISABLE_ADDON,
+                decision_action=DECISION_ACTIONS.AMO_DISABLE_ADDON,
                 target_addon=addon,
             ),
         )
@@ -810,7 +807,7 @@ class TestCinderJob(TestCase):
             cinder_job=CinderJob.objects.create(
                 decision_id='4815162342-lost',
                 decision_date=self.days_ago(179),
-                decision_action=CinderJob.DECISION_ACTIONS.AMO_APPROVE,
+                decision_action=DECISION_ACTIONS.AMO_APPROVE,
                 target_addon=addon,
             )
         )
@@ -848,7 +845,7 @@ class TestCinderJob(TestCase):
             cinder_job=CinderJob.objects.create(
                 decision_id='4815162342-lost',
                 decision_date=self.days_ago(179),
-                decision_action=CinderJob.DECISION_ACTIONS.AMO_APPROVE,
+                decision_action=DECISION_ACTIONS.AMO_APPROVE,
                 target_addon=addon,
             )
         )
@@ -891,7 +888,7 @@ class TestCinderJob(TestCase):
         cinder_job = CinderJob.objects.create(
             decision_id='4815162342-lost',
             decision_date=self.days_ago(179),
-            decision_action=CinderJob.DECISION_ACTIONS.AMO_APPROVE,
+            decision_action=DECISION_ACTIONS.AMO_APPROVE,
         )
         with self.assertRaises(ImproperlyConfigured):
             cinder_job.appeal(
@@ -910,7 +907,7 @@ class TestCinderJob(TestCase):
         cinder_job = CinderJob.objects.create(
             decision_id='4815162342-lost',
             decision_date=self.days_ago(179),
-            decision_action=CinderJob.DECISION_ACTIONS.AMO_APPROVE,
+            decision_action=DECISION_ACTIONS.AMO_APPROVE,
         )
         with self.assertRaises(ImproperlyConfigured):
             cinder_job.appeal(
@@ -980,14 +977,14 @@ class TestCinderJob(TestCase):
     def test_resolve_job_notify_owner(self):
         self._test_resolve_job(
             amo.LOG.REJECT_VERSION,
-            CinderJob.DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON,
+            DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON,
             expect_target_email=True,
         )
 
     def test_resolve_job_no_email_to_owner(self):
         self._test_resolve_job(
             amo.LOG.CONFIRM_AUTO_APPROVED,
-            CinderJob.DECISION_ACTIONS.AMO_APPROVE,
+            DECISION_ACTIONS.AMO_APPROVE,
             expect_target_email=False,
         )
 
@@ -1042,9 +1039,7 @@ class TestCinderJob(TestCase):
         assert request_body['reasoning'] == 'some review text'
         assert request_body['entity']['id'] == str(abuse_report.target.id)
         cinder_job.reload()
-        assert cinder_job.decision_action == (
-            CinderJob.DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON
-        )
+        assert cinder_job.decision_action == (DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON)
         self.assertCloseToNow(cinder_job.decision_date)
         # Parent policy was a duplicate since we already have its child, and
         # has been ignored.
@@ -1126,7 +1121,7 @@ class TestCinderJobCanBeAppealed(TestCase):
         self.initial_job.update(
             decision_date=datetime.now(),
             decision_id='fake_decision_id',
-            decision_action=CinderJob.DECISION_ACTIONS.AMO_APPROVE,
+            decision_action=DECISION_ACTIONS.AMO_APPROVE,
         )
         assert not self.initial_job.appealed_decision_already_made()
 
@@ -1143,7 +1138,7 @@ class TestCinderJobCanBeAppealed(TestCase):
         self.initial_job.update(
             decision_date=datetime.now(),
             decision_id='fake_decision_id',
-            decision_action=CinderJob.DECISION_ACTIONS.AMO_APPROVE,
+            decision_action=DECISION_ACTIONS.AMO_APPROVE,
         )
         assert self.initial_job.can_be_appealed(
             is_reporter=True, abuse_report=self.initial_report
@@ -1153,18 +1148,18 @@ class TestCinderJobCanBeAppealed(TestCase):
         self.initial_job.update(
             decision_date=datetime.now(),
             decision_id='fake_decision_id',
-            decision_action=CinderJob.DECISION_ACTIONS.AMO_APPROVE,
+            decision_action=DECISION_ACTIONS.AMO_APPROVE,
         )
         assert not self.initial_job.can_be_appealed(is_reporter=True)
 
     def test_reporter_cant_appeal_non_approve_decision(self):
         for decision_action in (
-            CinderJob.DECISION_ACTIONS.NO_DECISION,
-            CinderJob.DECISION_ACTIONS.AMO_ESCALATE_ADDON,
-            CinderJob.DECISION_ACTIONS.AMO_BAN_USER,
-            CinderJob.DECISION_ACTIONS.AMO_DISABLE_ADDON,
-            CinderJob.DECISION_ACTIONS.AMO_DELETE_RATING,
-            CinderJob.DECISION_ACTIONS.AMO_DELETE_COLLECTION,
+            DECISION_ACTIONS.NO_DECISION,
+            DECISION_ACTIONS.AMO_ESCALATE_ADDON,
+            DECISION_ACTIONS.AMO_BAN_USER,
+            DECISION_ACTIONS.AMO_DISABLE_ADDON,
+            DECISION_ACTIONS.AMO_DELETE_RATING,
+            DECISION_ACTIONS.AMO_DELETE_COLLECTION,
         ):
             self.initial_job.update(
                 decision_date=datetime.now(),
@@ -1179,7 +1174,7 @@ class TestCinderJobCanBeAppealed(TestCase):
         self.initial_job.update(
             decision_date=datetime.now(),
             decision_id='fake_decision_id',
-            decision_action=CinderJob.DECISION_ACTIONS.AMO_APPROVE,
+            decision_action=DECISION_ACTIONS.AMO_APPROVE,
         )
         appeal_job = CinderJob.objects.create(
             job_id='fake_appeal_job_id',
@@ -1196,7 +1191,7 @@ class TestCinderJobCanBeAppealed(TestCase):
         self.initial_job.update(
             decision_date=datetime.now(),
             decision_id='fake_decision_id',
-            decision_action=CinderJob.DECISION_ACTIONS.AMO_APPROVE,
+            decision_action=DECISION_ACTIONS.AMO_APPROVE,
         )
         appeal_job = CinderJob.objects.create(
             job_id='fake_appeal_job_id',
@@ -1218,13 +1213,13 @@ class TestCinderJobCanBeAppealed(TestCase):
         self.initial_job.update(
             decision_date=datetime.now(),
             decision_id='fake_decision_id',
-            decision_action=CinderJob.DECISION_ACTIONS.AMO_APPROVE,
+            decision_action=DECISION_ACTIONS.AMO_APPROVE,
         )
         appeal_job = CinderJob.objects.create(
             job_id='fake_appeal_job_id',
             decision_date=datetime.now(),
             decision_id='fake_appeal_decision_id',
-            decision_action=CinderJob.DECISION_ACTIONS.AMO_APPROVE,
+            decision_action=DECISION_ACTIONS.AMO_APPROVE,
         )
         self.initial_job.update(appeal_job=appeal_job)
         AbuseReport.objects.create(
@@ -1243,13 +1238,13 @@ class TestCinderJobCanBeAppealed(TestCase):
         self.initial_job.update(
             decision_date=datetime.now(),
             decision_id='fake_decision_id',
-            decision_action=CinderJob.DECISION_ACTIONS.AMO_APPROVE,
+            decision_action=DECISION_ACTIONS.AMO_APPROVE,
         )
         appeal_job = CinderJob.objects.create(
             job_id='fake_appeal_job_id',
             decision_date=datetime.now(),
             decision_id='fake_appeal_decision_id',
-            decision_action=CinderJob.DECISION_ACTIONS.AMO_APPROVE,
+            decision_action=DECISION_ACTIONS.AMO_APPROVE,
         )
         self.initial_job.update(appeal_job=appeal_job)
         self.initial_report.update(
@@ -1271,7 +1266,7 @@ class TestCinderJobCanBeAppealed(TestCase):
         self.initial_job.update(
             decision_date=self.days_ago(APPEAL_EXPIRATION_DAYS + 1),
             decision_id='fake_decision_id',
-            decision_action=CinderJob.DECISION_ACTIONS.AMO_APPROVE,
+            decision_action=DECISION_ACTIONS.AMO_APPROVE,
         )
         assert not self.initial_job.can_be_appealed(
             is_reporter=True, abuse_report=self.initial_report
@@ -1281,7 +1276,7 @@ class TestCinderJobCanBeAppealed(TestCase):
         self.initial_job.update(
             decision_date=datetime.now(),
             decision_id='fake_decision_id',
-            decision_action=CinderJob.DECISION_ACTIONS.AMO_DISABLE_ADDON,
+            decision_action=DECISION_ACTIONS.AMO_DISABLE_ADDON,
         )
         assert self.initial_job.can_be_appealed(is_reporter=False)
 
@@ -1294,7 +1289,7 @@ class TestCinderJobCanBeAppealed(TestCase):
         self.initial_job.update(
             decision_date=datetime.now(),
             decision_id='fake_decision_id',
-            decision_action=CinderJob.DECISION_ACTIONS.AMO_DELETE_RATING,
+            decision_action=DECISION_ACTIONS.AMO_DELETE_RATING,
         )
         self.initial_job.can_be_appealed(is_reporter=False)
 
@@ -1305,7 +1300,7 @@ class TestCinderJobCanBeAppealed(TestCase):
         self.initial_job.update(
             decision_date=datetime.now(),
             decision_id='fake_decision_id',
-            decision_action=CinderJob.DECISION_ACTIONS.AMO_DELETE_COLLECTION,
+            decision_action=DECISION_ACTIONS.AMO_DELETE_COLLECTION,
         )
         self.initial_job.can_be_appealed(is_reporter=False)
 
@@ -1315,15 +1310,15 @@ class TestCinderJobCanBeAppealed(TestCase):
         self.initial_job.update(
             decision_date=datetime.now(),
             decision_id='fake_decision_id',
-            decision_action=CinderJob.DECISION_ACTIONS.AMO_BAN_USER,
+            decision_action=DECISION_ACTIONS.AMO_BAN_USER,
         )
         self.initial_job.can_be_appealed(is_reporter=False)
 
     def test_author_cant_appeal_approve_or_escalation_decision(self):
         for decision_action in (
-            CinderJob.DECISION_ACTIONS.NO_DECISION,
-            CinderJob.DECISION_ACTIONS.AMO_ESCALATE_ADDON,
-            CinderJob.DECISION_ACTIONS.AMO_APPROVE,
+            DECISION_ACTIONS.NO_DECISION,
+            DECISION_ACTIONS.AMO_ESCALATE_ADDON,
+            DECISION_ACTIONS.AMO_APPROVE,
         ):
             self.initial_job.update(
                 decision_date=datetime.now(),
@@ -1336,7 +1331,7 @@ class TestCinderJobCanBeAppealed(TestCase):
         self.initial_job.update(
             decision_date=datetime.now(),
             decision_id='fake_decision_id',
-            decision_action=CinderJob.DECISION_ACTIONS.AMO_DISABLE_ADDON,
+            decision_action=DECISION_ACTIONS.AMO_DISABLE_ADDON,
         )
         appeal_job = CinderJob.objects.create(
             job_id='fake_appeal_job_id',
@@ -1348,13 +1343,13 @@ class TestCinderJobCanBeAppealed(TestCase):
         self.initial_job.update(
             decision_date=datetime.now(),
             decision_id='fake_decision_id',
-            decision_action=CinderJob.DECISION_ACTIONS.AMO_APPROVE,
+            decision_action=DECISION_ACTIONS.AMO_APPROVE,
         )
         appeal_job = CinderJob.objects.create(
             job_id='fake_appeal_job_id',
             decision_date=datetime.now(),
             decision_id='fake_appeal_decision_id',
-            decision_action=CinderJob.DECISION_ACTIONS.AMO_DISABLE_ADDON,
+            decision_action=DECISION_ACTIONS.AMO_DISABLE_ADDON,
         )
         self.initial_job.update(appeal_job=appeal_job)
         assert appeal_job.can_be_appealed(is_reporter=False)

--- a/src/olympia/abuse/tests/test_tasks.py
+++ b/src/olympia/abuse/tests/test_tasks.py
@@ -13,6 +13,7 @@ from olympia import amo
 from olympia.abuse.tasks import flag_high_abuse_reports_addons_according_to_review_tier
 from olympia.activity.models import ActivityLog
 from olympia.amo.tests import TestCase, addon_factory, days_ago, user_factory
+from olympia.constants.abuse import DECISION_ACTIONS
 from olympia.constants.reviewers import EXTRA_REVIEW_TARGET_PER_DAY_CONFIG_KEY
 from olympia.files.models import File
 from olympia.reviewers.models import NeedsHumanReview, ReviewActionReason, UsageTier
@@ -388,7 +389,7 @@ def test_addon_appeal_to_cinder_reporter(statsd_incr_mock):
     cinder_job = CinderJob.objects.create(
         decision_id='4815162342-abc',
         decision_date=datetime.now(),
-        decision_action=CinderJob.DECISION_ACTIONS.AMO_APPROVE,
+        decision_action=DECISION_ACTIONS.AMO_APPROVE,
     )
     abuse_report = AbuseReport.objects.create(
         guid=addon.guid,
@@ -446,7 +447,7 @@ def test_addon_appeal_to_cinder_reporter_exception(statsd_incr_mock):
     cinder_job = CinderJob.objects.create(
         decision_id='4815162342-abc',
         decision_date=datetime.now(),
-        decision_action=CinderJob.DECISION_ACTIONS.AMO_APPROVE,
+        decision_action=DECISION_ACTIONS.AMO_APPROVE,
     )
     abuse_report = AbuseReport.objects.create(
         guid=addon.guid,
@@ -483,7 +484,7 @@ def test_addon_appeal_to_cinder_authenticated_reporter():
     cinder_job = CinderJob.objects.create(
         decision_id='4815162342-abc',
         decision_date=datetime.now(),
-        decision_action=CinderJob.DECISION_ACTIONS.AMO_APPROVE,
+        decision_action=DECISION_ACTIONS.AMO_APPROVE,
     )
     abuse_report = AbuseReport.objects.create(
         guid=addon.guid,
@@ -538,7 +539,7 @@ def test_addon_appeal_to_cinder_authenticated_author():
     cinder_job = CinderJob.objects.create(
         decision_id='4815162342-abc',
         decision_date=datetime.now(),
-        decision_action=CinderJob.DECISION_ACTIONS.AMO_DISABLE_ADDON,
+        decision_action=DECISION_ACTIONS.AMO_DISABLE_ADDON,
     )
     abuse_report = AbuseReport.objects.create(
         guid=addon.guid,
@@ -631,7 +632,7 @@ def test_resolve_job_in_cinder(statsd_incr_mock):
     assert request_body['reasoning'] == 'some review text'
     assert request_body['entity']['id'] == str(abuse_report.target.id)
     cinder_job.reload()
-    assert cinder_job.decision_action == CinderJob.DECISION_ACTIONS.AMO_DISABLE_ADDON
+    assert cinder_job.decision_action == DECISION_ACTIONS.AMO_DISABLE_ADDON
 
     assert statsd_incr_mock.call_count == 1
     assert statsd_incr_mock.call_args[0] == (

--- a/src/olympia/abuse/tests/test_utils.py
+++ b/src/olympia/abuse/tests/test_utils.py
@@ -15,6 +15,7 @@ from olympia.amo.tests import (
     user_factory,
     version_factory,
 )
+from olympia.constants.abuse import DECISION_ACTIONS
 from olympia.core import set_user
 from olympia.ratings.models import Rating
 from olympia.reviewers.models import NeedsHumanReview
@@ -249,7 +250,7 @@ class TestCinderActionUser(BaseTestCinderAction, TestCase):
         self.cinder_job.abusereport_set.update(user=self.user, guid=None)
 
     def _test_ban_user(self):
-        self.cinder_job.update(decision_action=CinderJob.DECISION_ACTIONS.AMO_BAN_USER)
+        self.cinder_job.update(decision_action=DECISION_ACTIONS.AMO_BAN_USER)
         action = self.ActionClass(self.cinder_job)
         assert action.process_action()
 
@@ -284,7 +285,7 @@ class TestCinderActionUser(BaseTestCinderAction, TestCase):
         self._test_reporter_appeal_takedown_email(subject)
 
     def _test_reporter_ignore_initial_or_appeal(self, *, send_owner_email=None):
-        self.cinder_job.update(decision_action=CinderJob.DECISION_ACTIONS.AMO_APPROVE)
+        self.cinder_job.update(decision_action=DECISION_ACTIONS.AMO_APPROVE)
         action = CinderActionApproveInitialDecision(self.cinder_job)
         assert action.process_action() is None
 
@@ -298,7 +299,7 @@ class TestCinderActionUser(BaseTestCinderAction, TestCase):
         return f'Mozilla Add-ons: {self.user.name}'
 
     def _test_approve_appeal_or_override(self, CinderActionClass):
-        self.cinder_job.update(decision_action=CinderJob.DECISION_ACTIONS.AMO_APPROVE)
+        self.cinder_job.update(decision_action=DECISION_ACTIONS.AMO_APPROVE)
         self.user.update(banned=self.days_ago(1), deleted=True)
         action = CinderActionClass(self.cinder_job)
         assert action.process_action()
@@ -342,9 +343,7 @@ class TestCinderActionAddon(BaseTestCinderAction, TestCase):
         self.cinder_job.abusereport_set.update(guid=self.addon.guid)
 
     def _test_disable_addon(self):
-        self.cinder_job.update(
-            decision_action=CinderJob.DECISION_ACTIONS.AMO_DISABLE_ADDON
-        )
+        self.cinder_job.update(decision_action=DECISION_ACTIONS.AMO_DISABLE_ADDON)
         action = self.ActionClass(self.cinder_job)
         assert action.process_action()
 
@@ -396,7 +395,7 @@ class TestCinderActionAddon(BaseTestCinderAction, TestCase):
         self._test_owner_restore_email(f'Mozilla Add-ons: {self.addon.name}')
 
     def _test_reporter_ignore_initial_or_appeal(self, *, send_owner_email=None):
-        self.cinder_job.update(decision_action=CinderJob.DECISION_ACTIONS.AMO_APPROVE)
+        self.cinder_job.update(decision_action=DECISION_ACTIONS.AMO_APPROVE)
         action = CinderActionApproveInitialDecision(self.cinder_job)
         assert action.process_action() is None
 
@@ -533,9 +532,7 @@ class TestCinderActionAddon(BaseTestCinderAction, TestCase):
         )
 
     def test_notify_owners_with_manual_policy_block(self):
-        self.cinder_job.update(
-            decision_action=CinderJob.DECISION_ACTIONS.AMO_DISABLE_ADDON
-        )
+        self.cinder_job.update(decision_action=DECISION_ACTIONS.AMO_DISABLE_ADDON)
         self.ActionClass(self.cinder_job).notify_owners(
             policy_text='some other policy justification'
         )
@@ -558,7 +555,7 @@ class TestCinderActionAddon(BaseTestCinderAction, TestCase):
 
     def _test_reject_version(self):
         self.cinder_job.update(
-            decision_action=CinderJob.DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON
+            decision_action=DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON
         )
         action = CinderActionRejectVersion(self.cinder_job)
         action.affected_versions = [
@@ -621,9 +618,7 @@ class TestCinderActionCollection(BaseTestCinderAction, TestCase):
         self.cinder_job.abusereport_set.update(collection=self.collection, guid=None)
 
     def _test_delete_collection(self):
-        self.cinder_job.update(
-            decision_action=CinderJob.DECISION_ACTIONS.AMO_DELETE_COLLECTION
-        )
+        self.cinder_job.update(decision_action=DECISION_ACTIONS.AMO_DELETE_COLLECTION)
         action = self.ActionClass(self.cinder_job)
         assert action.process_action()
 
@@ -659,7 +654,7 @@ class TestCinderActionCollection(BaseTestCinderAction, TestCase):
         self._test_reporter_appeal_takedown_email(subject)
 
     def _test_reporter_ignore_initial_or_appeal(self, *, send_owner_email=None):
-        self.cinder_job.update(decision_action=CinderJob.DECISION_ACTIONS.AMO_APPROVE)
+        self.cinder_job.update(decision_action=DECISION_ACTIONS.AMO_APPROVE)
         action = CinderActionApproveInitialDecision(self.cinder_job)
         assert action.process_action() is None
 
@@ -718,9 +713,7 @@ class TestCinderActionRating(BaseTestCinderAction, TestCase):
         ActivityLog.objects.all().delete()
 
     def _test_delete_rating(self):
-        self.cinder_job.update(
-            decision_action=CinderJob.DECISION_ACTIONS.AMO_DELETE_RATING
-        )
+        self.cinder_job.update(decision_action=DECISION_ACTIONS.AMO_DELETE_RATING)
         action = self.ActionClass(self.cinder_job)
         assert action.process_action()
 
@@ -754,7 +747,7 @@ class TestCinderActionRating(BaseTestCinderAction, TestCase):
         self._test_reporter_appeal_takedown_email(subject)
 
     def _test_reporter_ignore_initial_or_appeal(self, *, send_owner_email=None):
-        self.cinder_job.update(decision_action=CinderJob.DECISION_ACTIONS.AMO_APPROVE)
+        self.cinder_job.update(decision_action=DECISION_ACTIONS.AMO_APPROVE)
         action = CinderActionApproveInitialDecision(self.cinder_job)
         assert action.process_action() is None
 

--- a/src/olympia/constants/abuse.py
+++ b/src/olympia/constants/abuse.py
@@ -1,2 +1,47 @@
+from olympia.api.utils import APIChoicesWithDash
+
+
 APPEAL_EXPIRATION_DAYS = 184
 REPORTED_MEDIA_BACKUP_EXPIRATION_DAYS = 31 + APPEAL_EXPIRATION_DAYS
+
+DECISION_ACTIONS = APIChoicesWithDash(
+    ('NO_DECISION', 0, 'No decision'),
+    ('AMO_BAN_USER', 1, 'User ban'),
+    ('AMO_DISABLE_ADDON', 2, 'Add-on disable'),
+    ('AMO_ESCALATE_ADDON', 3, 'Escalate add-on to reviewers'),
+    # 4 is unused
+    ('AMO_DELETE_RATING', 5, 'Rating delete'),
+    ('AMO_DELETE_COLLECTION', 6, 'Collection delete'),
+    ('AMO_APPROVE', 7, 'Approved (no action)'),
+    # Rejecting versions is not an available action for moderators in cinder
+    # - it is only handled by the reviewer tools by AMO Reviewers.
+    # It should not be sent by the cinder webhook, & does not have an action defined
+    ('AMO_REJECT_VERSION_ADDON', 8, 'Add-on version reject'),
+)
+DECISION_ACTIONS.add_subset(
+    'APPEALABLE_BY_AUTHOR',
+    (
+        'AMO_BAN_USER',
+        'AMO_DISABLE_ADDON',
+        'AMO_DELETE_RATING',
+        'AMO_DELETE_COLLECTION',
+        'AMO_REJECT_VERSION_ADDON',
+    ),
+)
+DECISION_ACTIONS.add_subset(
+    'APPEALABLE_BY_REPORTER',
+    ('AMO_APPROVE',),
+)
+DECISION_ACTIONS.add_subset(
+    'UNRESOLVED',
+    ('NO_DECISION', 'AMO_ESCALATE_ADDON'),
+)
+DECISION_ACTIONS.add_subset(
+    'REMOVING',
+    (
+        'AMO_BAN_USER',
+        'AMO_DISABLE_ADDON',
+        'AMO_DELETE_RATING',
+        'AMO_DELETE_COLLECTION',
+    ),
+)

--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -3,6 +3,8 @@ from inspect import isclass
 
 from django.utils.translation import gettext_lazy as _
 
+from .abuse import DECISION_ACTIONS
+
 
 RETENTION_DAYS = 365
 
@@ -146,7 +148,7 @@ class APPROVE_VERSION(_LOG):
     review_email_user = True
     review_queue = True
     reviewer_review_action = True
-    cinder_action = 'amo_approve'
+    cinder_action = DECISION_ACTIONS.AMO_APPROVE
 
 
 class PRELIMINARY_VERSION(_LOG):
@@ -170,7 +172,7 @@ class REJECT_VERSION(_LOG):
     review_email_user = True
     review_queue = True
     reviewer_review_action = True
-    cinder_action = 'amo_reject_version_addon'
+    cinder_action = DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON
 
 
 class RETAIN_VERSION(_LOG):
@@ -624,7 +626,7 @@ class CONFIRM_AUTO_APPROVED(_LOG):
     reviewer_review_action = True
     review_queue = True
     hide_developer = True
-    cinder_action = 'amo_approve'
+    cinder_action = DECISION_ACTIONS.AMO_APPROVE
 
 
 class ENABLE_VERSION(_LOG):
@@ -658,7 +660,7 @@ class REJECT_CONTENT(_LOG):
     review_email_user = True
     review_queue = True
     reviewer_review_action = True
-    cinder_action = 'amo-reject-version-addon'
+    cinder_action = DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON
 
 
 class ADMIN_ALTER_INFO_REQUEST(_LOG):
@@ -793,7 +795,7 @@ class REJECT_CONTENT_DELAYED(_LOG):
     review_email_user = True
     review_queue = True
     reviewer_review_action = True
-    cinder_action = 'amo-reject-version-addon'
+    cinder_action = DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON
 
 
 class REJECT_VERSION_DELAYED(_LOG):
@@ -806,7 +808,7 @@ class REJECT_VERSION_DELAYED(_LOG):
     review_email_user = True
     review_queue = True
     reviewer_review_action = True
-    cinder_action = 'amo-reject-version-addon'
+    cinder_action = DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON
 
 
 class VERSION_RESIGNED(_LOG):
@@ -825,7 +827,7 @@ class FORCE_DISABLE(_LOG):
     reviewer_format = '{addon} force-disabled by {user_responsible}.'
     admin_format = reviewer_format
     short = 'Force disabled'
-    cinder_action = 'amo_disable_addon'
+    cinder_action = DECISION_ACTIONS.AMO_DISABLE_ADDON
 
 
 class FORCE_ENABLE(_LOG):
@@ -836,7 +838,7 @@ class FORCE_ENABLE(_LOG):
     reviewer_format = '{addon} force-enabled by {user_responsible}.'
     admin_format = reviewer_format
     short = 'Force enabled'
-    cinder_action = 'amo_approve'
+    cinder_action = DECISION_ACTIONS.AMO_APPROVE
 
 
 class LOG_IN(_LOG):
@@ -866,7 +868,7 @@ class UNREJECT_VERSION(_LOG):
     keep = True
     review_queue = True
     reviewer_review_action = True
-    cinder_action = 'amo_approve'
+    cinder_action = DECISION_ACTIONS.AMO_APPROVE
 
 
 class LOG_IN_API_TOKEN(_LOG):
@@ -887,7 +889,7 @@ class CLEAR_NEEDS_HUMAN_REVIEWS_LEGACY(_LOG):
     admin_event = True
     review_queue = True
     reviewer_review_action = True
-    cinder_action = 'amo_approve'
+    cinder_action = DECISION_ACTIONS.AMO_APPROVE
 
 
 class NEEDS_HUMAN_REVIEW_AUTOMATIC(_LOG):
@@ -914,7 +916,7 @@ class CLEAR_NEEDS_HUMAN_REVIEW(_LOG):
     review_queue = True
     reviewer_review_action = True
     hide_developer = True
-    cinder_action = 'amo_approve'
+    cinder_action = DECISION_ACTIONS.AMO_APPROVE
 
 
 class CLEAR_PENDING_REJECTION(_LOG):

--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -19,6 +19,7 @@ from olympia import amo, ratings
 from olympia.abuse.models import CinderJob
 from olympia.access import acl
 from olympia.amo.forms import AMOModelForm
+from olympia.constants.abuse import DECISION_ACTIONS
 from olympia.constants.reviewers import REVIEWER_DELAYED_REJECTION_PERIOD_DAYS_DEFAULT
 from olympia.ratings.models import Rating
 from olympia.ratings.permissions import user_can_delete_rating
@@ -212,9 +213,7 @@ class ReasonsChoiceWidget(forms.CheckboxSelectMultiple):
 
 class CinderJobChoiceField(ModelMultipleChoiceField):
     def label_from_instance(self, obj):
-        is_escalation = (
-            obj.decision_action == CinderJob.DECISION_ACTIONS.AMO_ESCALATE_ADDON
-        )
+        is_escalation = obj.decision_action == DECISION_ACTIONS.AMO_ESCALATE_ADDON
         reports = obj.abuse_reports
         reasons_set = {
             (report.REASONS.for_value(report.reason).display,) for report in reports

--- a/src/olympia/reviewers/tests/test_forms.py
+++ b/src/olympia/reviewers/tests/test_forms.py
@@ -16,6 +16,7 @@ from olympia.amo.tests import (
     user_factory,
     version_factory,
 )
+from olympia.constants.abuse import DECISION_ACTIONS
 from olympia.constants.reviewers import REVIEWER_DELAYED_REJECTION_PERIOD_DAYS_DEFAULT
 from olympia.files.models import File
 from olympia.reviewers.forms import ReviewForm
@@ -811,7 +812,7 @@ class TestReviewForm(TestCase):
         )
         cinder_job_appealed = CinderJob.objects.create(
             job_id='appealed',
-            decision_action=CinderJob.DECISION_ACTIONS.AMO_DISABLE_ADDON,
+            decision_action=DECISION_ACTIONS.AMO_DISABLE_ADDON,
             resolvable_in_reviewer_tools=True,
             target_addon=self.addon,
         )
@@ -829,7 +830,7 @@ class TestReviewForm(TestCase):
         cinder_job_appealed.update(appeal_job=cinder_job_appeal)
         cinder_job_escalated = CinderJob.objects.create(
             job_id='escalated',
-            decision_action=CinderJob.DECISION_ACTIONS.AMO_ESCALATE_ADDON,
+            decision_action=DECISION_ACTIONS.AMO_ESCALATE_ADDON,
             decision_notes='Why o why',
             resolvable_in_reviewer_tools=True,
             target_addon=self.addon,
@@ -855,7 +856,7 @@ class TestReviewForm(TestCase):
             message='fff',
             cinder_job=CinderJob.objects.create(
                 job_id='already resovled',
-                decision_action=CinderJob.DECISION_ACTIONS.AMO_DISABLE_ADDON,
+                decision_action=DECISION_ACTIONS.AMO_DISABLE_ADDON,
                 resolvable_in_reviewer_tools=True,
             ),
         )

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -3211,7 +3211,6 @@ class TestReviewHelper(TestReviewHelperBase):
                     != should_email[action_name]
                 )
                 assert hasattr(log_entry, 'cinder_action')
-                assert CinderJob.DECISION_ACTIONS.has_api_value(log_entry.cinder_action)
                 log_action_mock.assert_called_once()
                 log_action_mock.reset_mock()
                 self.helper.handler.log_entry = None


### PR DESCRIPTION
fixes #21954 - just a refactoring.  Other than constants moving from the class to file, the only other significant change is that the activity classes now directly reference the decision actions, rather than just the slug string.