### PR TITLE
Collect static files after generating all static files

### DIFF
--- a/Makefile-docker
+++ b/Makefile-docker
@@ -113,8 +113,9 @@ update_assets:
 	for dest in $(NODE_LIBS_JQUERY_UI) ; do cp $(NODE_MODULES)$$dest $(STATIC_JQUERY_UI) ; done
 	# If changing this here, make sure to adapt tests in amo/test_commands.py
 	$(PYTHON_COMMAND) manage.py compress_assets
-	$(PYTHON_COMMAND) manage.py collectstatic --noinput
 	$(PYTHON_COMMAND) manage.py generate_jsi18n_files
+	# Collect static files: This MUST be run last or files will be missing
+	$(PYTHON_COMMAND) manage.py collectstatic --noinput
 
 .PHONY: update
 update: update_deps update_db update_assets ## update the dependencies, the database, and assets


### PR DESCRIPTION
Fixes: #21976

### Description

This pull request ensures that static files are collected after generating all static files. This prevents missing files and ensures that the process is executed in the correct order.

### Context

The commands for updating static assets were split between the makefile and the dockerfile before, and in the dockerfile the order was correct.

IN https://github.com/mozilla/addons-server/pull/21914 that entire operation was moved to the makefile and the ordering was included incorrectly.

### Testing

This bug can only be reproduced at runtime so we would need to include build time checks to inspect static assets are present to verify this. We should do this eventually.