### PR TITLE
Fix small bugs in the docker build that are not obvious most of the time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -138,6 +138,6 @@ COPY --chown=olympia:olympia . ${HOME}
 # This will shave nearly 1 minute off the best case build time
 RUN echo "from olympia.lib.settings_base import *" > settings_local.py \
     && DJANGO_SETTINGS_MODULE="settings_local" make update_assets \
-    && npm prune --production \
+    && make prune_deps \
     && ./scripts/generate_build.py > build.py \
     && rm -f settings_local.py settings_local.pyc

--- a/Makefile-docker
+++ b/Makefile-docker
@@ -100,6 +100,10 @@ update_deps: update_deps_base ## update the python and node dependencies for dev
 update_deps_prod: update_deps_base ## update the python and node dependencies for production
 	npm ci $(NPM_ARGS)
 
+.PHONY: prune_deps
+prune_deps: ## remove unused dependencies
+	npm prune $(NPM_ARGS) --production
+
 .PHONY: update_db
 update_db: ## run the database migrations
 	$(PYTHON_COMMAND) manage.py migrate --noinput

--- a/locale/compile-mo.sh
+++ b/locale/compile-mo.sh
@@ -27,7 +27,8 @@ function usage() {
 # check if file and dir are there
 if [[ ($# -ne 1) || (! -d "$1") ]]; then usage; fi
 
-hash dennis-cmd 2>/dev/null || source $VENV/bin/activate
+# Ensure dennis-cmd cli is available in the environment
+hash dennis-cmd
 
 echo "compiling django.po..."
 find $1 -type f -name "django.po" -print0 | xargs -0 -n1 -P4 bash -c 'process_po_file "$@"' _


### PR DESCRIPTION
Fixes: #21981

### Description

2 changes to scripts executed during our docker build

- add the npm prefix flag to `prun` to ensure we prune the correct directory and not the default ./node_modules which is already empty

- hard failure on the compile locales script when `dennis-cmd` is not installed. Removing the venv fallback

### Context

These issues can cause failure in certain contexts, or not result in failure in other contexts. This PR ensures we have consistent and correct behavior.

### Testing

You can run a build and inspect the image before and after and see the pruned /deps/node_modules directory.