### PR TITLE
Simplify socketlabs check for status and messaging when something goes wrong.

### DIFF
--- a/src/olympia/devhub/templates/devhub/verify_email.html
+++ b/src/olympia/devhub/templates/devhub/verify_email.html
@@ -20,21 +20,28 @@
   Could not verify email address. The verification link has expired.
   {% endtrans %}
 {% elif state == "verification_pending" %}
-  {% trans %}
-  Working... Please be patient.
-  {% endtrans %}
   <div class="loader"></div>
-{% elif state == "verification_failed" %}
-  {% trans %}
-  Failed to send confirmation email. Please try again.
-  If you no longer have access to your email address, please update your mozilla account email address.
-  <a
-    href="https://support.mozilla.org/en-US/kb/change-primary-email-address-firefox-accounts"
-    target="_blank"
-  >
-    Change email address
-  </a>
-  {% endtrans %}
+  {% if found_emails|length > 0 %}
+    <p>
+      {% trans %}
+      We have attempted to send your verification email but ran into an issue.
+      Below are the records we found and the associated delivery status.
+      This page will refresh automatically in 10 seconds to check again.
+      You can click 'try again' to attempt sending another email.
+      {% endtrans %}
+    </p>
+    <ul>
+    {% for email in found_emails %}
+      <li>
+        Subject: {{ email.subject }} ({{ email.status}})
+      </li>
+    {% endfor %}
+    </ul>
+  {% else %}
+    {% trans %}
+    Working... Please be patient.
+    {% endtrans %}
+  {% endif %}
 {% elif state == "verification_timedout" %}
   {% trans %}
   This is taking longer than expected. Try again.

--- a/src/olympia/devhub/templates/devhub/verify_email.html
+++ b/src/olympia/devhub/templates/devhub/verify_email.html
@@ -35,7 +35,7 @@
   {% endtrans %}
 {% elif state == "confirmation_invalid" %}
   {% trans email=request.user.email %}
-  The provided code is invalid, unauthorized, expired or incomplete. Please use the link in the email sent to your email address {{ email }}. If the code is still not working please request a new email.
+  The provided code is invalid, unauthorized, expired or incomplete. Please use the link in the email sent to your email address {{ email }}. If the code is still not working, please request a new email.
 
 
   {% endtrans %}

--- a/src/olympia/devhub/templates/devhub/verify_email.html
+++ b/src/olympia/devhub/templates/devhub/verify_email.html
@@ -7,6 +7,7 @@
 {% block content %}
 <h1>{{ title }}</h1>
 <div id="{{ state }}">
+<div class="verify-email-text">
 {% if state == "email_verified" %}
   {% trans %}
   Your email address is verified.
@@ -21,27 +22,9 @@
   {% endtrans %}
 {% elif state == "verification_pending" %}
   <div class="loader"></div>
-  {% if found_emails|length > 0 %}
-    <p>
-      {% trans %}
-      We have attempted to send your verification email but ran into an issue.
-      Below are the records we found and the associated delivery status.
-      This page will refresh automatically in 10 seconds to check again.
-      You can click 'try again' to attempt sending another email.
-      {% endtrans %}
-    </p>
-    <ul>
-    {% for email in found_emails %}
-      <li>
-        Subject: {{ email.subject }} ({{ email.status}})
-      </li>
-    {% endfor %}
-    </ul>
-  {% else %}
     {% trans %}
     Working... Please be patient.
     {% endtrans %}
-  {% endif %}
 {% elif state == "verification_timedout" %}
   {% trans %}
   This is taking longer than expected. Try again.
@@ -57,6 +40,49 @@
     - could be expired
     - could be a mistake
   {% endtrans %}
+{% endif %}
+</div>
+{% if found_emails|length > 0 %}
+<div class="verify-email-table">
+  <p>
+    {% trans %}
+      We have attempted to send your verification email.
+      Below are the confirmation records we found and their associated delivery statuses.
+    {% endtrans %}
+  </p>
+  <table border=1 frame=void rules=rows>
+    <thead>
+      <tr>
+        <th>{{ _('Date') }}</th>
+        <th>{{ _('From') }}</th>
+        <th>{{ _('To') }}</th>
+        <th>{{ _('Subject') }}</th>
+        <th>{{ _('Status') }}</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for email in found_emails %}
+      <tr>
+        <td>
+          {{ email.statusDate }}
+        </td>
+        <td>
+          {{ email.from }}
+        </td>
+        <td>
+          {{ email.to }}
+        </td>
+        <td>
+          {{ email.subject }}
+        </td>
+        <td>
+          {{ email.status }}
+        </td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
 {% endif %}
 {% if render_button %}
   {% with submit_text=button_text %}

--- a/src/olympia/devhub/templates/devhub/verify_email.html
+++ b/src/olympia/devhub/templates/devhub/verify_email.html
@@ -23,11 +23,11 @@
 {% elif state == "verification_pending" %}
   <div class="loader"></div>
     {% trans %}
-    Working... Please be patient.
+    We are sending an email to you, this might take a minute. The page will automatically refresh.
     {% endtrans %}
 {% elif state == "verification_timedout" %}
   {% trans %}
-  This is taking longer than expected. Try again.
+  It is taking longer than expected to confirm delivery of your verification email. Please try again.
   {% endtrans %}
 {% elif state == "confirmation_pending" %}
   {% trans email=request.user.email %}
@@ -35,10 +35,9 @@
   {% endtrans %}
 {% elif state == "confirmation_invalid" %}
   {% trans email=request.user.email %}
-    The provided code is invalid. Please use the link in the email sent to your email address {{ email }}.
-    - could be unauthorized
-    - could be expired
-    - could be a mistake
+  The provided code is invalid, unauthorized, expired or incomplete. Please use the link in the email sent to your email address {{ email }}. If the code is still not working please request a new email.
+
+
   {% endtrans %}
 {% endif %}
 </div>

--- a/src/olympia/devhub/templates/devhub/verify_email_form.html
+++ b/src/olympia/devhub/templates/devhub/verify_email_form.html
@@ -1,6 +1,6 @@
 <form action="{{ url('devhub.email_verification') }}" method="post">
   {% csrf_token %}
-  <button class="Button" type="submit">
+  <button class="Button verify-email-button" type="submit">
     {{ submit_text | default('Verify email address') }}
   </button>
 </form>

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -2255,7 +2255,9 @@ class TestVerifyEmail(TestCase):
         doc = pq(response.content)
         assert doc('#suppressed-email').length == 0
 
-    def test_get_confirmation_complete(self):
+    @mock.patch('olympia.devhub.views.check_suppressed_email_confirmation')
+    def test_get_confirmation_complete(self, mock_check_emails):
+        mock_check_emails.return_value = []
         self.with_email_verification()
         code = self.email_verification.confirmation_code
         url = f'{self.url}?code={code}'
@@ -2268,7 +2270,9 @@ class TestVerifyEmail(TestCase):
         assert 'Your email was successfully verified.' in mail.outbox[0].body
         self.assert3xx(response, reverse('devhub.email_verification'))
 
-    def test_get_confirmation_complete_with_timeout(self):
+    @mock.patch('olympia.devhub.views.check_suppressed_email_confirmation')
+    def test_get_confirmation_complete_with_timeout(self, mock_check_emails):
+        mock_check_emails.return_value = []
         self.with_email_verification()
         code = self.email_verification.confirmation_code
         url = f'{self.url}?code={code}'
@@ -2296,8 +2300,11 @@ class TestVerifyEmail(TestCase):
         doc = pq(response.content)
 
         assert 'Please verify your email' in doc.text()
+        assert 'Verify email' in doc.text()
 
-    def test_get_verification_expired(self):
+    @mock.patch('olympia.devhub.views.check_suppressed_email_confirmation')
+    def test_get_verification_expired(self, mock_check_emails):
+        mock_check_emails.return_value = []
         self.with_email_verification()
 
         with freezegun.freeze_time(self.email_verification.created) as frozen_time:
@@ -2307,6 +2314,7 @@ class TestVerifyEmail(TestCase):
             doc = pq(response.content)
 
             assert 'Could not verify email address.' in doc.text()
+            assert 'Send another email' in doc.text()
 
     @mock.patch('olympia.devhub.views.check_suppressed_email_confirmation')
     def test_get_verification_pending_without_emails(self, mock_check_emails):
@@ -2316,10 +2324,13 @@ class TestVerifyEmail(TestCase):
         doc = pq(response.content)
 
         assert 'Working... Please be patient.' in doc.text()
+        assert 'Send another email' in doc.text()
 
     @mock.patch('olympia.devhub.views.check_suppressed_email_confirmation')
     def test_get_verification_pending_with_emails(self, mock_check_emails):
-        mock_check_emails.return_value = [{'status': 'Delivered', 'subject': 'subject'}]
+        mock_check_emails.return_value = [
+            {'status': 'Delivered', 'subject': 'subject', 'from': 'from', 'to': 'to'}
+        ]
         self.with_email_verification()
         response = self.client.get(self.url)
         doc = pq(response.content)
@@ -2327,8 +2338,13 @@ class TestVerifyEmail(TestCase):
         assert 'We have attempted to send your verification' in doc.text()
         assert 'Delivered' in doc.text()
         assert 'subject' in doc.text()
+        assert 'from' in doc.text()
+        assert 'to' in doc.text()
+        assert 'Send another email' in doc.text()
 
-    def test_get_verification_timedout(self):
+    @mock.patch('olympia.devhub.views.check_suppressed_email_confirmation')
+    def test_get_verification_timedout(self, mock_check_emails):
+        mock_check_emails.return_value = []
         self.with_email_verification()
 
         with freezegun.freeze_time(self.email_verification.created) as frozen_time:
@@ -2340,6 +2356,7 @@ class TestVerifyEmail(TestCase):
             doc = pq(response.content)
 
             assert 'This is taking longer than expected.' in doc.text()
+            assert 'Send another email' in doc.text()
 
     @mock.patch('olympia.devhub.views.check_suppressed_email_confirmation')
     def test_get_verification_delivered(self, mock_check_suppressed):
@@ -2354,7 +2371,9 @@ class TestVerifyEmail(TestCase):
 
         assert 'An email with a confirmation link has been sent' in doc.text()
 
-    def test_get_confirmation_invalid(self):
+    @mock.patch('olympia.devhub.views.check_suppressed_email_confirmation')
+    def test_get_confirmation_invalid(self, mock_check_emails):
+        mock_check_emails.return_value = []
         self.with_email_verification()
         code = 'invalid'
         url = f'{self.url}?code={code}'
@@ -2362,3 +2381,4 @@ class TestVerifyEmail(TestCase):
         doc = pq(response.content)
 
         assert 'The provided code is invalid.' in doc.text()
+        assert 'Send another email' in doc.text()

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -2323,7 +2323,7 @@ class TestVerifyEmail(TestCase):
         response = self.client.get(self.url)
         doc = pq(response.content)
 
-        assert 'Working... Please be patient.' in doc.text()
+        assert 'We are sending an email to you' in doc.text()
         assert 'Send another email' in doc.text()
 
     @mock.patch('olympia.devhub.views.check_suppressed_email_confirmation')
@@ -2355,7 +2355,7 @@ class TestVerifyEmail(TestCase):
             response = self.client.get(self.url)
             doc = pq(response.content)
 
-            assert 'This is taking longer than expected.' in doc.text()
+            assert 'It is taking longer than expected' in doc.text()
             assert 'Send another email' in doc.text()
 
     @mock.patch('olympia.devhub.views.check_suppressed_email_confirmation')
@@ -2380,5 +2380,8 @@ class TestVerifyEmail(TestCase):
         response = self.client.get(url)
         doc = pq(response.content)
 
-        assert 'The provided code is invalid.' in doc.text()
+        assert (
+            'The provided code is invalid, unauthorized, expired or incomplete.'
+            in doc.text()
+        )
         assert 'Send another email' in doc.text()

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -2105,7 +2105,7 @@ def get_button_text(state):
     if state == VERIFY_EMAIL_STATE['email_suppressed']:
         return gettext('Verify email')
 
-    return gettext('Try again')
+    return gettext('Send another email')
 
 
 @login_required
@@ -2130,6 +2130,7 @@ def email_verification(request):
         return redirect('devhub.email_verification')
 
     if email_verification:
+        data['found_emails'] = check_suppressed_email_confirmation(email_verification)
         if email_verification.is_expired:
             data['state'] = VERIFY_EMAIL_STATE['verification_expired']
         elif code := request.GET.get('code'):
@@ -2147,8 +2148,6 @@ def email_verification(request):
         elif email_verification.is_timedout:
             data['state'] = VERIFY_EMAIL_STATE['verification_timedout']
         else:
-            found_emails = check_suppressed_email_confirmation(email_verification)
-
             if (
                 email_verification.reload().status
                 == SuppressedEmailVerification.STATUS_CHOICES.Delivered
@@ -2156,7 +2155,6 @@ def email_verification(request):
                 data['state'] = VERIFY_EMAIL_STATE['confirmation_pending']
             else:
                 data['state'] = VERIFY_EMAIL_STATE['verification_pending']
-                data['found_emails'] = found_emails
 
     elif suppressed_email:
         data['state'] = VERIFY_EMAIL_STATE['email_suppressed']

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -78,6 +78,7 @@ from olympia.users.models import (
 from olympia.users.tasks import send_suppressed_email_confirmation
 from olympia.users.utils import (
     RestrictionChecker,
+    check_suppressed_email_confirmation,
     send_addon_author_add_mail,
     send_addon_author_change_mail,
     send_addon_author_remove_mail,
@@ -2086,7 +2087,6 @@ VERIFY_EMAIL_STATE = {
     'email_suppressed': 'email_suppressed',
     'verification_expired': 'verification_expired',
     'verification_pending': 'verification_pending',
-    'verification_failed': 'verification_failed',
     'verification_timedout': 'verification_timedout',
     'confirmation_pending': 'confirmation_pending',
     'confirmation_invalid': 'confirmation_invalid',
@@ -2095,7 +2095,7 @@ VERIFY_EMAIL_STATE = {
 RENDER_BUTTON_STATES = [
     VERIFY_EMAIL_STATE['email_suppressed'],
     VERIFY_EMAIL_STATE['verification_expired'],
-    VERIFY_EMAIL_STATE['verification_failed'],
+    VERIFY_EMAIL_STATE['verification_pending'],
     VERIFY_EMAIL_STATE['verification_timedout'],
     VERIFY_EMAIL_STATE['confirmation_invalid'],
 ]
@@ -2144,24 +2144,19 @@ def email_verification(request):
                 return redirect('devhub.email_verification')
             else:
                 data['state'] = VERIFY_EMAIL_STATE['confirmation_invalid']
-        elif (
-            email_verification.status
-            == SuppressedEmailVerification.STATUS_CHOICES.Pending
-        ):
-            if email_verification.is_timedout:
-                data['state'] = VERIFY_EMAIL_STATE['verification_timedout']
+        elif email_verification.is_timedout:
+            data['state'] = VERIFY_EMAIL_STATE['verification_timedout']
+        else:
+            found_emails = check_suppressed_email_confirmation(email_verification)
+
+            if (
+                email_verification.reload().status
+                == SuppressedEmailVerification.STATUS_CHOICES.Delivered
+            ):
+                data['state'] = VERIFY_EMAIL_STATE['confirmation_pending']
             else:
                 data['state'] = VERIFY_EMAIL_STATE['verification_pending']
-        elif (
-            email_verification.status
-            == SuppressedEmailVerification.STATUS_CHOICES.Failed
-        ):
-            data['state'] = VERIFY_EMAIL_STATE['verification_failed']
-        elif (
-            email_verification.status
-            == SuppressedEmailVerification.STATUS_CHOICES.Delivered
-        ):
-            data['state'] = VERIFY_EMAIL_STATE['confirmation_pending']
+                data['found_emails'] = found_emails
 
     elif suppressed_email:
         data['state'] = VERIFY_EMAIL_STATE['email_suppressed']

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -924,7 +924,6 @@ CELERY_TASK_ROUTES = {
     'olympia.reviewers.tasks.recalculate_post_review_weight': {'queue': 'cron'},
     'olympia.users.tasks.sync_suppressed_emails_task': {'queue': 'cron'},
     'olympia.users.tasks.send_suppressed_email_confirmation': {'queue': 'devhub'},
-    'olympia.users.tasks.check_suppressed_email_confirmation': {'queue': 'devhub'},
     # Reviewers.
     'olympia.lib.crypto.tasks.sign_addons': {'queue': 'reviewers'},
     # Admin.

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -1386,3 +1386,7 @@ class SuppressedEmailVerification(ModelBase):
     @property
     def is_timedout(self):
         return self.created + timedelta(seconds=30) < datetime.now()
+
+    def mark_as_delivered(self):
+        self.update(status=SuppressedEmailVerification.STATUS_CHOICES.Delivered)
+        self.save()

--- a/src/olympia/users/tests/test_user_utils.py
+++ b/src/olympia/users/tests/test_user_utils.py
@@ -338,7 +338,7 @@ class TestCheckSuppressedEmailConfirmation(TestCase):
     def test_no_verification(self):
         assert not self.user_profile.suppressed_email
 
-        with pytest.raises(Exception, match='Verification is not defined'):
+        with pytest.raises(AssertionError):
             check_suppressed_email_confirmation(self.verification)
 
     def test_socket_labs_returns_5xx(self):

--- a/src/olympia/users/tests/test_user_utils.py
+++ b/src/olympia/users/tests/test_user_utils.py
@@ -1,11 +1,16 @@
+import json
 from contextlib import ExitStack
 from ipaddress import IPv4Address
 from unittest import mock
+from urllib.parse import parse_qs, urlparse
 
+from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.test.client import RequestFactory
 
 import pytest
+import responses
+from freezegun import freeze_time
 
 from olympia import amo, core
 from olympia.activity.models import ActivityLog
@@ -16,9 +21,15 @@ from ..models import (
     RESTRICTION_TYPES,
     EmailUserRestriction,
     IPNetworkUserRestriction,
+    SuppressedEmail,
+    SuppressedEmailVerification,
     UserRestrictionHistory,
 )
-from ..utils import RestrictionChecker, UnsubscribeCode
+from ..utils import (
+    RestrictionChecker,
+    UnsubscribeCode,
+    check_suppressed_email_confirmation,
+)
 
 
 def test_email_unsubscribe_code_parse():
@@ -298,3 +309,305 @@ class TestRestrictionChecker(TestCase):
             assert restriction_mock.call_count == 0
         for restriction_mock in allow_auto_approval_mocks:
             assert restriction_mock.call_count == 1
+
+
+class TestCheckSuppressedEmailConfirmation(TestCase):
+    def setUp(self):
+        self.verification = None
+        self.user_profile = user_factory()
+
+    def with_verification(self):
+        self.verification = SuppressedEmailVerification.objects.create(
+            suppressed_email=SuppressedEmail.objects.create(
+                email=self.user_profile.email
+            )
+        )
+
+    def test_fails_missing_settings(self):
+        self.with_verification()
+        for setting in (
+            'SOCKET_LABS_TOKEN',
+            'SOCKET_LABS_HOST',
+            'SOCKET_LABS_SERVER_ID',
+        ):
+            with pytest.raises(Exception) as exc:
+                setattr(settings, setting, None)
+                check_suppressed_email_confirmation(self.verification)
+                assert exc.match(f'{setting} is not defined')
+
+    def test_no_verification(self):
+        assert not self.user_profile.suppressed_email
+
+        with pytest.raises(Exception, match='Verification is not defined'):
+            check_suppressed_email_confirmation(self.verification)
+
+    def test_socket_labs_returns_5xx(self):
+        self.with_verification()
+
+        responses.add(
+            responses.GET,
+            (
+                f'{settings.SOCKET_LABS_HOST}servers/{settings.SOCKET_LABS_SERVER_ID}/'
+                f'reports/recipient-search/'
+            ),
+            status=500,
+        )
+
+        with pytest.raises(Exception):  # noqa: B017
+            check_suppressed_email_confirmation(self.verification)
+
+    def test_socket_labs_returns_empty(self):
+        self.with_verification()
+
+        responses.add(
+            responses.GET,
+            (
+                f'{settings.SOCKET_LABS_HOST}servers/{settings.SOCKET_LABS_SERVER_ID}/'
+                f'reports/recipient-search/'
+            ),
+            status=200,
+            body=json.dumps(
+                {
+                    'data': [],
+                    'total': 0,
+                }
+            ),
+            content_type='application/json',
+        )
+
+        assert len(check_suppressed_email_confirmation(self.verification)) == 0
+
+    def test_auth_header_present(self):
+        self.with_verification()
+
+        responses.add(
+            responses.GET,
+            (
+                f'{settings.SOCKET_LABS_HOST}servers/{settings.SOCKET_LABS_SERVER_ID}/'
+                f'reports/recipient-search/'
+            ),
+            status=200,
+            body=json.dumps(
+                {
+                    'data': [],
+                    'total': 0,
+                }
+            ),
+            content_type='application/json',
+        )
+
+        check_suppressed_email_confirmation(self.verification)
+
+        assert (
+            settings.SOCKET_LABS_TOKEN
+            in responses.calls[0].request.headers['authorization']
+        )
+
+    @freeze_time('2023-06-26 11:00')
+    def test_format_date_params(self):
+        self.with_verification()
+
+        responses.add(
+            responses.GET,
+            (
+                f'{settings.SOCKET_LABS_HOST}servers/{settings.SOCKET_LABS_SERVER_ID}/'
+                f'reports/recipient-search/'
+            ),
+            status=200,
+            body=json.dumps(
+                {
+                    'data': [],
+                    'total': 0,
+                }
+            ),
+            content_type='application/json',
+        )
+
+        check_suppressed_email_confirmation(self.verification)
+
+        parsed_url = urlparse(responses.calls[0].request.url)
+        search_params = parse_qs(parsed_url.query)
+
+        assert search_params['startDate'][0] == '2023-06-25'
+        assert search_params['endDate'][0] == '2023-06-27'
+
+    def test_pagination(self):
+        self.with_verification()
+
+        response_size = 5
+
+        body = [
+            {'subject': 'test', 'status': 'Delivered'} for _ in range(response_size)
+        ]
+
+        url = (
+            f'{settings.SOCKET_LABS_HOST}servers/{settings.SOCKET_LABS_SERVER_ID}/'
+            f'reports/recipient-search/'
+        )
+
+        responses.add(
+            responses.GET,
+            url,
+            status=200,
+            body=json.dumps(
+                {
+                    'data': body,
+                    'total': response_size + 1,
+                }
+            ),
+            content_type='application/json',
+        )
+        code_snippet = str(self.verification.confirmation_code)[-5:]
+        responses.add(
+            responses.GET,
+            url,
+            status=200,
+            body=json.dumps(
+                {
+                    'data': [
+                        {
+                            'subject': f'test {code_snippet}',
+                            'status': 'Delivered',
+                        }
+                    ],
+                    'total': response_size + 1,
+                }
+            ),
+            content_type='application/json',
+        )
+
+        check_suppressed_email_confirmation(self.verification, response_size)
+
+        assert len(responses.calls) == 2
+
+    def test_found_email(self):
+        self.with_verification()
+
+        response_size = 5
+
+        body = [
+            {'subject': 'test', 'status': 'Delivered'} for _ in range(response_size)
+        ]
+
+        url = (
+            f'{settings.SOCKET_LABS_HOST}servers/{settings.SOCKET_LABS_SERVER_ID}/'
+            f'reports/recipient-search/'
+        )
+
+        responses.add(
+            responses.GET,
+            url,
+            status=200,
+            body=json.dumps(
+                {
+                    'data': body,
+                    'total': response_size + 1,
+                }
+            ),
+            content_type='application/json',
+        )
+        code_snippet = str(self.verification.confirmation_code)[-5:]
+        responses.add(
+            responses.GET,
+            url,
+            status=200,
+            body=json.dumps(
+                {
+                    'data': [
+                        {
+                            'subject': f'test {code_snippet}',
+                            'status': 'Delivered',
+                        }
+                    ],
+                    'total': response_size + 1,
+                }
+            ),
+            content_type='application/json',
+        )
+
+        check_suppressed_email_confirmation(self.verification, response_size)
+
+        assert (
+            self.verification.reload().status
+            == SuppressedEmailVerification.STATUS_CHOICES.Delivered
+        )
+
+    def test_not_delivered_status(self):
+        self.with_verification()
+
+        response_size = 5
+
+        body = [
+            {'subject': 'test', 'status': 'Suppressed'} for _ in range(response_size)
+        ]
+
+        url = (
+            f'{settings.SOCKET_LABS_HOST}servers/{settings.SOCKET_LABS_SERVER_ID}/'
+            f'reports/recipient-search/'
+        )
+
+        responses.add(
+            responses.GET,
+            url,
+            status=200,
+            body=json.dumps(
+                {
+                    'data': body,
+                    'total': response_size + 1,
+                }
+            ),
+            content_type='application/json',
+        )
+        code_snippet = str(self.verification.confirmation_code)[-5:]
+        responses.add(
+            responses.GET,
+            url,
+            status=200,
+            body=json.dumps(
+                {
+                    'data': [
+                        {
+                            'subject': f'test {code_snippet}',
+                            'status': 'InvalidStatus',
+                        }
+                    ],
+                    'total': response_size + 1,
+                }
+            ),
+            content_type='application/json',
+        )
+
+        result = check_suppressed_email_confirmation(self.verification, response_size)
+
+        assert len(result) == 1
+
+        assert result[0]['status'] == 'InvalidStatus'
+
+    def test_rsponse_does_not_contain_suppressed_email(self):
+        self.with_verification()
+
+        response_size = 5
+
+        body = [{'subject': 'test'} for _ in range(response_size)]
+
+        url = (
+            f'{settings.SOCKET_LABS_HOST}servers/{settings.SOCKET_LABS_SERVER_ID}/'
+            f'reports/recipient-search/'
+        )
+
+        responses.add(
+            responses.GET,
+            url,
+            status=200,
+            body=json.dumps(
+                {
+                    'data': body,
+                    'total': response_size,
+                }
+            ),
+            content_type='application/json',
+        )
+
+        result = check_suppressed_email_confirmation(self.verification, response_size)
+
+        assert len(result) == 0

--- a/src/olympia/users/utils.py
+++ b/src/olympia/users/utils.py
@@ -385,8 +385,11 @@ def check_suppressed_email_confirmation(verification, page_size=5):
             if code_snippet in item['subject']:
                 found_emails.append(
                     {
+                        'from': item['from'],
+                        'to': item['to'],
                         'subject': item['subject'],
                         'status': item['status'],
+                        'statusDate': item['statusDate'],
                     }
                 )
 

--- a/src/olympia/users/utils.py
+++ b/src/olympia/users/utils.py
@@ -304,11 +304,12 @@ def assert_socket_labs_settings_defined():
 utils_log = olympia.core.logger.getLogger('z.users')
 
 
-def check_suppressed_email_confirmation(verification=None, page_size=5):
+def check_suppressed_email_confirmation(verification, page_size=5):
+    from olympia.users.models import SuppressedEmailVerification
+
     assert_socket_labs_settings_defined()
 
-    if not verification:
-        raise Exception('Verification is not defined')
+    assert isinstance(verification, SuppressedEmailVerification)
 
     email = verification.suppressed_email.email
 
@@ -362,19 +363,19 @@ def check_suppressed_email_confirmation(verification=None, page_size=5):
 
         response = requests.get(url, headers=headers)
         response.raise_for_status()
-        json = response.json()
+        json_data = response.json()
 
-        utils_log.info(f'recieved data {json} for {code_snippet}')
+        utils_log.info(f'recieved data {json_data} for {code_snippet}')
 
         if is_first_page:
-            total = json['total']
+            total = json_data['total']
 
             if total == 0:
                 return found_emails
 
             is_first_page = False
 
-        data = json['data']
+        data = json_data['data']
         current_count += len(data)
 
         utils_log.info(f'found emails {data} for {code_snippet}')

--- a/static/css/zamboni/developers.css
+++ b/static/css/zamboni/developers.css
@@ -1507,6 +1507,29 @@ form.select-review .errorlist {
     margin-bottom: 10px;
 }
 
+.verify-email-button {
+    margin-top: 10px;
+}
+
+.verify-email-table {
+    margin: 20px 0;
+    width: 100%;
+
+    table {
+        border-collapse: collapse;
+        border: 1px solid;
+    }
+    tr {
+        border: solid;
+        border-width: 1px 0;
+    }
+    td {
+        padding: 5px;
+        border: solid;
+        border-width: 0 1px;
+    }
+}
+
 button.search-button {
   background: #84c63c url("../../img/icons/go-arrow.png") center no-repeat;
   background-image: url("../../img/icons/go-arrow.png"), linear-gradient(#84c63c, #489615);


### PR DESCRIPTION
Relates to: https://github.com/mozilla/addons-server/issues/21687

### Description

This PR simplifies the existing logic for checking the socketlabs recipient search API for delivery status of email verification sent via AMO. Instead of checking for specific statuses, we check for "Delivered" or anything else. 

If we find at least one email that is "Delivered" we mark the verification as sent, otherwise we return a list of all emails we found and their associated meta data to display to the user to help them debug why they didn't receive the email.

Finally, there are some additional copy changes that are included in this PR.

### Context

We need to review this UX change with @wagnerand but I believe this is a better UX and also simpler code without totally removing the feature.

### Testing

You can follow the flow in the attached videos that display a successful and an unsuccessful delivery. 

### Standard attempt

This example demonstrates a successful attempt where an email is sent and found to be delivered shortly after refreshing the screen.

https://github.com/mozilla/addons-server/assets/19595165/55d5b628-3429-4f84-96ba-22a2fb24358e

#### Failed attempts

This example demonstrates the UX if an email is sent but not "delivered", in this case "suppressed".
It also demonstrates the UX of using an invalid code with the new UX (already merged a while ago but just to demonstrate)

https://github.com/mozilla/addons-server/assets/19595165/35ea08c0-12b9-431e-b282-ae2524cbd793

> NOTE: UI for non delivered emails is now a table

<img width="1232" alt="Screenshot 2024-03-19 at 08 53 35" src="https://github.com/mozilla/addons-server/assets/19595165/0abe875b-a6ba-4f6e-8ca5-c2eb4e246969">



