### PR TITLE
Create github action to generate a tag/release from master

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,6 @@
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+changelog:
+  categories:
+    - title: 🏕 Features
+      labels:
+        - '*'

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,109 @@
+name: Tag Repository for Release to Staging
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag (YYYY.MM.DD) to push. Defaults to current day"
+        required: false
+      push:
+        description: "Should the tag be pushed to github. (false means dry run)"
+        required: false
+        default: 'false'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          #always tag from master
+          ref: 'master'
+          # get whole history (not great but we need tags)
+          fetch-depth: '0'
+          # get tags so we can diff latest
+          fetch-tags: 'true'
+          # show progress for debugging
+          show-progress: true
+      - name: Get and validate date
+        id: date
+        shell: bash
+        run: |
+          CURRENT_DATE=$(date '+%Y.%m.%d')
+          DATE=$CURRENT_DATE
+
+          if [[ -n "${{ inputs.tag }}" ]]; then
+            DATE="${{ inputs.tag }}"
+
+            regex='^([0-9]{4})\.(0[1-9]|1[0-2])\.(0[1-9]|[12][0-9]|3[01])$'
+
+            if [[ $DATE =~ $regex ]]; then
+                input_date="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
+                if [[ $DATE < $CURRENT_DATE ]]; then
+                    echo "Error: Input date: \"$DATE\" is earlier than current date: \"$CURRENT_DATE\""
+                    exit 1
+                fi
+            else
+                echo "Error: Input date: \"$DATE\" does not match the format YYYY.MM.DD"
+                exit 1
+            fi
+          fi
+
+          echo "date=$DATE" >> $GITHUB_OUTPUT
+
+      - name: Get latest tag
+        id: from_tag
+        shell: bash
+        run: |
+          echo "tag=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
+
+      - name: Get next tag
+        id: to_tag
+        shell: bash
+        run: |
+          from_tag="${{ steps.from_tag.outputs.tag }}"
+          to_tag="${{ steps.date.outputs.date }}"
+
+          revision=""
+          is_cherry_picked=false
+
+          if [[ $from_tag == "$to_tag" ]]; then
+              revision=1
+          elif [[ $from_tag == "${to_tag}-"* ]]; then
+              is_cherry_picked=true
+              if [[ $from_tag =~ -([0-9]+)$ ]]; then
+                  current_revision="${BASH_REMATCH[1]}"
+                  ((revision = current_revision + 1))
+              fi
+          fi
+
+          tag=$to_tag
+
+          if [[ -n "$revision" ]]; then
+              tag="${tag}-${revision}"
+          fi
+
+          echo "tag=$tag" >> $GITHUB_OUTPUT
+
+      - name: Tag Branch
+        shell: bash
+        run: |
+          from_tag="${{ steps.from_tag.outputs.tag }}"
+          to_tag="${{ steps.to_tag.outputs.tag }}"
+
+          echo "tagging from \"$from_tag\" to \"$to_tag\""
+          git tag ${{ steps.to_tag.outputs.tag }}
+
+          # Construct the GitHub diff URL
+          diff_url="${{ github.server_url }}/${{ github.repository }}/compare/$from_tag...$to_tag"
+
+          echo "Diff URL: $diff_url"
+
+      - name: Push Tag
+        if: ${{ inputs.push == 'true' }}
+        shell: bash
+        run: git push origin ${{ steps.to_tag.outputs.tag }}

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -10,6 +10,10 @@ on:
         description: "Should the tag be pushed to github. (false means dry run)"
         required: false
         default: 'false'
+      release:
+        description: "Should a draft release be created in gitub."
+        required: false
+        default: 'false'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.ref }}
@@ -107,3 +111,12 @@ jobs:
         if: ${{ inputs.push == 'true' }}
         shell: bash
         run: git push origin ${{ steps.to_tag.outputs.tag }}
+
+      - name: Create Release
+        if: ${{ inputs.release == 'true'}}
+        shell: bash
+        run: |
+          PRE_FORMATTED_DATE=$(echo "${{ steps.to_tag.outputs.tag }}" | sed 's/\./-/g')
+          FORMATTED_DATE=$(date -d "$PRE_FORMATTED_DATE" +"%A %e %B %Y")
+          TITLE="AMO Release $FORMATTED_DATE"
+          gh release create --draft --generate-notes --verify-tag --title "$TITLE" ${{ steps.to_tag.outputs.tag }}

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -5,14 +5,14 @@ on:
     inputs:
       tag:
         description: "Tag (YYYY.MM.DD) to push. Defaults to current day"
-        required: false
+        required: true
       push:
         description: "Should the tag be pushed to github. (false means dry run)"
-        required: false
+        required: true
         default: 'false'
       release:
         description: "Should a draft release be created in gitub."
-        required: false
+        required: true
         default: 'false'
 
 concurrency:
@@ -23,6 +23,37 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     steps:
+      - name: Validate Inputs
+        shell: bash
+        run: |
+          ##### validate boolean inputs #####
+
+          function true_or_false() {
+            local value="$1"
+            if [[ "$value" != "true" && "$value" != "false" ]]; then
+                echo "The value: \"$value\" is neither either true nor false."
+                exit 1
+            fi
+          }
+
+          true_or_false "${{ inputs.push }}"
+          true_or_false "${{ inputs.release }}"
+
+          ##### validate tag input #####
+
+          DATE="${{ inputs.tag }}"
+          regex='^([0-9]{4})\.(0[1-9]|1[0-2])\.(0[1-9]|[12][0-9]|3[01])$'
+
+          if [[ $DATE =~ $regex ]]; then
+              if [[ $DATE < $CURRENT_DATE ]]; then
+                  echo "Error: Input date: \"$DATE\" is earlier than current date: \"$CURRENT_DATE\""
+                  exit 1
+              fi
+          else
+              echo "Error: Input date: \"$DATE\" does not match the format YYYY.MM.DD"
+              exit 1
+          fi
+
       - uses: actions/checkout@v4
         with:
           #always tag from master
@@ -33,90 +64,49 @@ jobs:
           fetch-tags: 'true'
           # show progress for debugging
           show-progress: true
-      - name: Get and validate date
-        id: date
+
+      - name: Create the tag
+        id: tags
         shell: bash
         run: |
-          CURRENT_DATE=$(date '+%Y.%m.%d')
-          DATE=$CURRENT_DATE
-
-          if [[ -n "${{ inputs.tag }}" ]]; then
-            DATE="${{ inputs.tag }}"
-
-            regex='^([0-9]{4})\.(0[1-9]|1[0-2])\.(0[1-9]|[12][0-9]|3[01])$'
-
-            if [[ $DATE =~ $regex ]]; then
-                input_date="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
-                if [[ $DATE < $CURRENT_DATE ]]; then
-                    echo "Error: Input date: \"$DATE\" is earlier than current date: \"$CURRENT_DATE\""
-                    exit 1
-                fi
-            else
-                echo "Error: Input date: \"$DATE\" does not match the format YYYY.MM.DD"
-                exit 1
-            fi
-          fi
-
-          echo "date=$DATE" >> $GITHUB_OUTPUT
-
-      - name: Get latest tag
-        id: from_tag
-        shell: bash
-        run: |
-          echo "tag=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
-
-      - name: Get next tag
-        id: to_tag
-        shell: bash
-        run: |
-          from_tag="${{ steps.from_tag.outputs.tag }}"
-          to_tag="${{ steps.date.outputs.date }}"
+          from_tag=$(git describe --tags --abbrev=0)
+          to_tag="${{ inputs.tag }}"
 
           revision=""
-          is_cherry_picked=false
 
           if [[ $from_tag == "$to_tag" ]]; then
               revision=1
           elif [[ $from_tag == "${to_tag}-"* ]]; then
-              is_cherry_picked=true
               if [[ $from_tag =~ -([0-9]+)$ ]]; then
                   current_revision="${BASH_REMATCH[1]}"
                   ((revision = current_revision + 1))
               fi
           fi
 
-          tag=$to_tag
-
           if [[ -n "$revision" ]]; then
-              tag="${tag}-${revision}"
+            to_tag="${to_tag}-${revision}"
           fi
 
-          echo "tag=$tag" >> $GITHUB_OUTPUT
-
-      - name: Tag Branch
-        shell: bash
-        run: |
-          from_tag="${{ steps.from_tag.outputs.tag }}"
-          to_tag="${{ steps.to_tag.outputs.tag }}"
-
           echo "tagging from \"$from_tag\" to \"$to_tag\""
-          git tag ${{ steps.to_tag.outputs.tag }}
+          git tag $to_tag
 
-          # Construct the GitHub diff URL
-          diff_url="${{ github.server_url }}/${{ github.repository }}/compare/$from_tag...$to_tag"
-
-          echo "Diff URL: $diff_url"
+          echo "to_tag=$to_tag" >> $GITHUB_OUTPUT
+          echo "from_tag=$from_tag" >> $GITHUB_OUTPUT
 
       - name: Push Tag
         if: ${{ inputs.push == 'true' }}
         shell: bash
-        run: git push origin ${{ steps.to_tag.outputs.tag }}
+        run: |
+          git push origin ${{ steps.tags.outputs.to_tag }}
+
+          diff_url="${{ github.server_url }}/${{ github.repository }}/compare/${{ steps.tags.outputs.from_tag }}...${{ steps.tags.outputs.to_tag }}"
+          echo "Diff URL: $diff_url"
 
       - name: Create Release
         if: ${{ inputs.release == 'true'}}
         shell: bash
         run: |
-          PRE_FORMATTED_DATE=$(echo "${{ steps.to_tag.outputs.tag }}" | sed 's/\./-/g')
+          PRE_FORMATTED_DATE=$(echo "${{ steps.tags.outputs.to_tag }}" | sed 's/\./-/g')
           FORMATTED_DATE=$(date -d "$PRE_FORMATTED_DATE" +"%A %e %B %Y")
           TITLE="AMO Release $FORMATTED_DATE"
-          gh release create --draft --generate-notes --verify-tag --title "$TITLE" ${{ steps.to_tag.outputs.tag }}
+          gh release create --draft --generate-notes --verify-tag --title "$TITLE" ${{ steps.tags.outputs.to_tag }}


### PR DESCRIPTION
Fixes: Manual release process

### Description

Github action to create tags for release. You can dispatch via the action web interface or via cli. One day, maybe we will create a tag on every push to master, who knows...

### Context

This is a good first step in automating the deployment phase of our release process. We already deploy to stage when a tag is pushed and this automates the generation of the tag, meaning you can deploy to stage via a button 💯 

### Testing

You can run this action via the github cli

```bash
gh workflow run --ref auto-tag
```

Then select the appropriate workflow

```bash
> Tag Repository for Release to Staging (tag-release.yml)
```

And select your options for `push` and `tag`

Test cases

#### Invalid tag

1. pass "banana" as tag
2. expect error "does not match the format YYYY.MM.DD"

1. pass "2024-03-12"
2. expect same error as above.

#### Invalid date

1. Pass "1999.12.31"
2. expect error "is earlier than current date"

You must provide a valid date string which is greater or equal to today's date.