### PR TITLE
Fix build docker image action

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -1,22 +1,10 @@
 name: 'Docker Build'
 description: 'Builds `addons-server` docker image'
 inputs:
-  load:
-    required: false
-    description: "Build and load image to local docker daemon. (cannot be used together with push)"
-    default: "false"
-  no_cache:
-    required: false
-    description: "Build fresh image without cache"
-    default: "false"
   password:
     required: false
     description: "Docker registry password"
     default: "invalid"
-  pull:
-    required: false
-    description: "Pull all referenced images before building"
-    default: "false"
   push:
     required: false
     description: "Build and push image to registry (cannot be used together with load)"
@@ -41,11 +29,6 @@ runs:
     - name: Validate inputs
       shell: bash
       run: |
-        if [[ ${{ inputs.load == 'true' }} == ${{ inputs.push == 'true' }} ]]; then
-          echo "Cannot use load and push together. Must choose only one of them."
-          exit 1
-        fi
-
         if [[ "${{ inputs.push  }}" == "true" && "${{ github.ref }}" == "refs/heads/master" ]]; then
           echo "Cannot push to registry from master branch unless we migrate our master build job to GHA."
           exit 1
@@ -95,10 +78,9 @@ runs:
       with:
         context: .
         platforms: linux/amd64
-        pull: ${{ inputs.pull }}
+        pull: true
         push: ${{ inputs.push }}
-        load: ${{ inputs.load }}
-        no-cache: ${{ inputs.no_cache }}
+        load: ${{ inputs.push == 'false' }}
         tags: ${{ steps.meta.outputs.tags }}
         cache-from: type=gha
         cache-to: type=gha,mode=max

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -51,11 +51,6 @@ runs:
         username: ${{ inputs.username }}
         password: ${{ inputs.password }}
 
-    - name: Set commit sha
-      id: sha
-      shell: bash
-      run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-
     # Determine the tags for the image
     - name: Docker meta
       id: meta
@@ -66,8 +61,8 @@ runs:
         tags: |
           type=schedule
           type=ref,event=tag
-          type=ref,event=branch,suffix=-${{ steps.sha.outputs.sha_short }}
-          type=ref,event=pr,suffix=-${{ steps.sha.outputs.sha_short }}
+          type=ref,event=branch
+          type=ref,event=pr
           # set latest tag for default branch
           # Disabled for now as we do not use this action for
           # The production build

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -7,13 +7,9 @@ on:
         description: 'Push the image to registry?'
         default: "false"
         required: false
-      ref:
-        description: 'Branch, PR, tag or commit to build'
-        default: "master"
-        required: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.inputs.ref }}-${{ github.event.inputs.push }}
+  group: ${{ github.workflow }}-${{ github.event.inputs.push }}
   cancel-in-progress: true
 
 jobs:
@@ -22,14 +18,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.ref }}
-          fetch-depth: 1
 
       - name: Build container
         id: build_container
         uses: ./.github/actions/build-docker
         with:
-          push: ${{ github.event.inputs.push }}
+          push: ${{ inputs.push }}
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}

--- a/.github/workflows/verify-docker-image.yml
+++ b/.github/workflows/verify-docker-image.yml
@@ -15,8 +15,6 @@ jobs:
       - name: Build container
         id: build_container
         uses: ./.github/actions/build-docker
-        with:
-          load: true
 
       - name: List images
         shell: bash


### PR DESCRIPTION
Fixes: #22018

### Description

PR fixes the build docker image workflow that errors unless you push the image. Should be able to trigger a build without pushing.

### Context

I've simplified the input parameters for the build workflow and the build action. Several were there from the beginning but are not used and others add complexity which is not worth it.

Important changes:
- now push/load are inversions of each other. You specify `push` and if you don't push, you automatically load.
- pull by default cache by default. No need to omit these ever. Just changes the output of the build for no real benefit. They were there mostly for testing of the original action
- no need to specify `ref` as GHA let you specify which branch to run the action on already.
- simplified the tagging behavior for branch/PR so we update tags instead of creating a new tag per commit. That's just too many tags.

### Testing

You can run the action from this branch via the CLI to ispect the behavior and compare to master.

```bash
gh workflow run --ref ADDSRV-762
```

Set push to false and it should build. On master this will error.