### PR TITLE
prevent unreject reviewer actions from resolving cinderjobs

### DIFF
--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -868,7 +868,6 @@ class UNREJECT_VERSION(_LOG):
     keep = True
     review_queue = True
     reviewer_review_action = True
-    cinder_action = DECISION_ACTIONS.AMO_APPROVE
 
 
 class LOG_IN_API_TOKEN(_LOG):

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -3268,7 +3268,6 @@ class TestReviewHelper(TestReviewHelperBase):
             [
                 ('confirm_auto_approved', False),
                 ('reject_multiple_versions', True),
-                ('unreject_latest_version', True),
                 ('clear_needs_human_review_multiple_versions', False),
                 ('disable_addon', True),
             ]
@@ -3295,7 +3294,6 @@ class TestReviewHelper(TestReviewHelperBase):
                 ('public', True),
                 ('approve_multiple_versions', True),
                 ('reject_multiple_versions', True),
-                ('unreject_multiple_versions', True),
                 ('confirm_multiple_versions', False),
                 ('clear_needs_human_review_multiple_versions', False),
                 ('disable_addon', True),

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -679,7 +679,7 @@ class ReviewHelper:
             'minimal': True,
             'details': (
                 'This will un-reject the latest version without notifying the '
-                'developer. If resolving an appeal job the developer will be notified.'
+                'developer.'
             ),
             'comments': False,
             'available': (
@@ -688,7 +688,6 @@ class ReviewHelper:
                 and version_was_rejected
                 and is_appropriate_admin_reviewer
             ),
-            'resolves_abuse_reports': True,
         }
         actions['unreject_multiple_versions'] = {
             'method': self.handler.unreject_multiple_versions,
@@ -697,7 +696,7 @@ class ReviewHelper:
             'multiple_versions': True,
             'details': (
                 'This will un-reject the selected versions without notifying the '
-                'developer. If resolving an appeal job the developer will be notified.'
+                'developer.'
             ),
             'comments': False,
             'available': (
@@ -705,7 +704,6 @@ class ReviewHelper:
                 and addon_is_not_disabled_or_deleted
                 and is_appropriate_admin_reviewer
             ),
-            'resolves_abuse_reports': True,
         }
         actions['block_multiple_versions'] = {
             'method': self.handler.block_multiple_versions,
@@ -1441,7 +1439,6 @@ class ReviewBase:
         self.set_file(amo.STATUS_AWAITING_REVIEW, self.version.file)
         self.log_action(amo.LOG.UNREJECT_VERSION)
         self.addon.update_status(self.user)
-        self.resolve_abuse_reports()
 
     def confirm_multiple_versions(self):
         raise NotImplementedError  # only implemented for unlisted below.
@@ -1713,4 +1710,3 @@ class ReviewUnlisted(ReviewBase):
         if self.data['versions']:
             # if these are listed versions then the addon status may need updating
             self.addon.update_status(self.user)
-        self.resolve_abuse_reports()


### PR DESCRIPTION
fixes #21987 by removing the ability to resolve cinderjobs/abusereports with the un-reject action in reviewer tools. It's a partial reversion of https://github.com/mozilla/addons-server/pull/21963 where I added the functionality to resolve cinderjobs with enable add-on and un-reject version - it works fine with enable add-on because that action is able to restore the version statuses; it doesn't work with un-reject version where the statuses are not restored.  The reviewers will instead un-reject version silently, and resolve the cinderjob with the subsequent approval of the version.

You can test this locally by having an add-on with the latest version rejected (or any rejected version for unlisted channel) and a cinderjob pending for the add-on. Previously the UI to resolve a cinderjob was available with the Unreject Versions actions; now it's not.  

After the version has been unrejected it should be possible to resolve the cinderjob with one of the approve actions instead (clear needs human review; approve version; confirm auto approved)