### PR TITLE
Fix extract locales split dry/wet runs to separate steps.

### DIFF
--- a/.github/workflows/extract-locales.yml
+++ b/.github/workflows/extract-locales.yml
@@ -29,11 +29,15 @@ jobs:
           run: |
             make update_deps
             make extract_locales
-      - name: Push Locales
+
+      - name: Push Lcoales (dry-run)
+        if: github.event_name == 'pull_request'
         shell: bash
         run: |
-          ARGS="--dry-run"
-          if [[ ${{ github.event_name }} == 'push' && ${{ github.ref }} == 'refs/head/master' ]]; then
-            ARGS=""
-          fi
-          make push_locales ARGS="$ARGS"
+          make push_locales ARGS="--dry-run"
+
+      - name: Push Locales
+        if: github.event_name == 'push'
+        shell: bash
+        run: |
+          make push_locales


### PR DESCRIPTION
Follow up of: https://github.com/mozilla/addons-server/pull/21966

The action was incorrectly configured inspecting github.event which is "Object" instead of "github.event_name" which is a string that can match "push" on push to master.

Causes the push to always run as "dry-run"

https://github.com/mozilla/addons-server/actions/runs/8326351811/job/22781858480