### PR TITLE
create specific activity for version flagged by cinder activty

### DIFF
--- a/src/olympia/abuse/tests/test_utils.py
+++ b/src/olympia/abuse/tests/test_utils.py
@@ -439,16 +439,11 @@ class TestCinderActionAddon(BaseTestCinderAction, TestCase):
             unlisted_version.reload().needshumanreview_set.get().reason
             == NeedsHumanReview.REASON_CINDER_ESCALATION
         )
-        assert ActivityLog.objects.count() == 2
+        assert ActivityLog.objects.count() == 1
         activity = ActivityLog.objects.filter(
-            action=amo.LOG.NEEDS_HUMAN_REVIEW_AUTOMATIC.id
-        ).order_by('pk')[0]
-        assert activity.arguments == [listed_version]
-        assert activity.user == self.task_user
-        activity = ActivityLog.objects.filter(
-            action=amo.LOG.NEEDS_HUMAN_REVIEW_AUTOMATIC.id
-        ).order_by('pk')[1]
-        assert activity.arguments == [unlisted_version]
+            action=amo.LOG.NEEDS_HUMAN_REVIEW_CINDER.id
+        ).get()
+        assert activity.arguments == [listed_version, unlisted_version]
         assert activity.user == self.task_user
 
         # but if we have a version specified, we flag that version
@@ -469,9 +464,7 @@ class TestCinderActionAddon(BaseTestCinderAction, TestCase):
             == NeedsHumanReview.REASON_CINDER_ESCALATION
         )
         assert ActivityLog.objects.count() == 1
-        activity = ActivityLog.objects.get(
-            action=amo.LOG.NEEDS_HUMAN_REVIEW_AUTOMATIC.id
-        )
+        activity = ActivityLog.objects.get(action=amo.LOG.NEEDS_HUMAN_REVIEW_CINDER.id)
         assert activity.arguments == [other_version]
         assert activity.user == self.task_user
         action.notify_reporters()

--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -1012,6 +1012,11 @@ class ADMIN_USER_UNBAN(_LOG):
     admin_event = True
 
 
+class NEEDS_HUMAN_REVIEW_CINDER(NEEDS_HUMAN_REVIEW_AUTOMATIC):
+    id = 188
+    review_queue = True
+
+
 LOGS = [x for x in vars().values() if isclass(x) and issubclass(x, _LOG) and x != _LOG]
 # Make sure there's no duplicate IDs.
 assert len(LOGS) == len({log.id for log in LOGS})

--- a/src/olympia/reviewers/models.py
+++ b/src/olympia/reviewers/models.py
@@ -836,7 +836,7 @@ class NeedsHumanReview(ModelBase):
         used_generator_last_iteration = None
         due_date = None
         for addon in addons:
-            if used_generator_last_iteration is not False:
+            if used_generator_last_iteration != []:
                 # Only advance the generator if we used the previous due date or
                 # it's the first iteration.
                 due_date = next(due_date_generator)


### PR DESCRIPTION
fixes #21871 by using `_no_automatic_activity_log` and manually creating the ActivityLog with a specific type ourselves.  Manually creating the ActivityLog means we can associate a single log entry with multiple versions for db efficiency too.