### PR TITLE
Add script to transfer GitHub issues

### DIFF
--- a/scripts/transfer-issues.sh
+++ b/scripts/transfer-issues.sh
@@ -2,11 +2,31 @@
 
 COUNT=1
 
-gh issue list \
+FROM_REPO="https://github.com/mozilla/addons-server"
+TO_REPO="https://github.com/mozilla/addons"
+
+gh label clone $FROM_REPO -R $TO_REPO --force
+
+ISSUE_NUMBERS=$(gh issue list \
+  -R $FROM_REPO \
   -s all \
   -L $COUNT \
   --json number \
   --search sort:created-asc \
-  --jq '.[] | .number' | \
-  xargs -I% gh issue transfer % https://github.com/mozilla/addons
+  --jq '.[] | .number'
+)
 
+transfer_issue() {
+  issue_number=$1
+  to_repo=$2
+  result=$(gh issue transfer "$issue_number" "$to_repo")
+
+  echo $result
+}
+
+export -f transfer_issue
+
+echo "Transferring issues from \"$FROM_REPO\" to \"$TO_REPO\""
+echo "Issues: $ISSUE_NUMBERS"
+
+echo "$ISSUE_NUMBERS" | xargs -P 4 -I % sh -c -e 'transfer_issue % '"$TO_REPO"

--- a/scripts/transfer-issues.sh
+++ b/scripts/transfer-issues.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+COUNT=1
+
+gh issue list \
+  -s all \
+  -L $COUNT \
+  --json number \
+  --search sort:created-asc \
+  --jq '.[] | .number' | \
+  xargs -I% gh issue transfer % https://github.com/mozilla/addons
+

--- a/scripts/transfer-issues.sh
+++ b/scripts/transfer-issues.sh
@@ -1,32 +1,43 @@
 #! /bin/bash
 
+set -x
+
 COUNT=1
 
-FROM_REPO="https://github.com/mozilla/addons-server"
-TO_REPO="https://github.com/mozilla/addons"
+GITHUB_URL="https://github.com"
+GITHUB_ORG="mozilla"
+
+FROM_NAME="addons-server"
+TO_NAME="addons"
+
+FROM_REPO="$GITHUB_URL/$GITHUB_ORG/$FROM_NAME"
+TO_REPO="$GITHUB_URL/$GITHUB_ORG/$TO_NAME"
+
+REPO_LABEL="repository:$FROM_NAME"
 
 gh label clone $FROM_REPO -R $TO_REPO --force
 
-ISSUE_NUMBERS=$(gh issue list \
-  -R $FROM_REPO \
-  -s all \
-  -L $COUNT \
-  --json number \
-  --search sort:created-asc \
-  --jq '.[] | .number'
-)
+gh label create $REPO_LABEL
 
 transfer_issue() {
   issue_number=$1
-  to_repo=$2
+  from_repo=$2
+  to_repo=$3
+  repo_label=$4
+
+  echo "$from_repo/issues/$issue_number" >> old-issues.txt
+
   result=$(gh issue transfer "$issue_number" "$to_repo")
 
-  echo $result
+  echo "$result" >> new-issues.txt
+
+  echo "Transferred issue $issue_number to $result"
+
+  gh issue -R $to_repo edit $result --add-label $repo_label
 }
 
 export -f transfer_issue
 
 echo "Transferring issues from \"$FROM_REPO\" to \"$TO_REPO\""
-echo "Issues: $ISSUE_NUMBERS"
 
-echo "$ISSUE_NUMBERS" | xargs -P 4 -I % sh -c -e 'transfer_issue % '"$TO_REPO"
+gh issue list -R "$FROM_REPO" -s all -L $COUNT --json number --search sort:created-asc --jq '.[] | .number' | xargs -P 4 -I % bash -c -e 'transfer_issue % '"$FROM_REPO $TO_REPO $REPO_LABEL" 2>&1


### PR DESCRIPTION
Relates to: https://mozilla-hub.atlassian.net/browse/AMO-212

### Description
This pull request adds a bash script that can be used to transfer GitHub issues from one repository to another. The script uses the GitHub CLI tool to list all issues, sort them by creation date, and transfer them to a specified repository. This script can be useful when migrating repositories or consolidating multiple repositories into one.

### Context
We don't have to merge this PR. just review and execute for all the issues.

### Testing
You can run this script in parts to verify it works, but running it will actually transfer an issue so be careful.