### PR TITLE
Switch ubuntu image to 2004:current (ubuntu-2004:202201-02 is deprecated)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -343,7 +343,7 @@ references:
 
   defaults-release: &defaults-release
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2004:current
     working_directory: &working-directory
 
 commands:


### PR DESCRIPTION
Relates to mozilla/addons#1565