### PR TITLE
wrap backfill_cinder_decisions_from_cinder_jobs in @use_master

### DIFF
--- a/src/olympia/abuse/migrations/0028_cinderdecision_backfill.py
+++ b/src/olympia/abuse/migrations/0028_cinderdecision_backfill.py
@@ -2,6 +2,9 @@
 
 from django.db import migrations
 
+from olympia import amo
+
+@amo.decorators.use_primary_db
 def backfill_cinder_decisions_from_cinder_jobs(apps, schema_editor):
     CinderJob = apps.get_model('abuse', 'CinderJob')
     CinderDecision = apps.get_model('abuse', 'CinderDecision')


### PR DESCRIPTION
follow-up to the pr for #21990 - #22023 that runs fine locally... but on dev only updates the last CinderDecision.  Our speculation is this may be database replica related so forcing the master database may fix it 🤞 