### PR TITLE
only git status on push command

### DIFF
--- a/.github/workflows/extract-locales.yml
+++ b/.github/workflows/extract-locales.yml
@@ -30,7 +30,7 @@ jobs:
             make update_deps
             make extract_locales
 
-      - name: Push Lcoales (dry-run)
+      - name: Push Locales (dry-run)
         if: github.event_name == 'pull_request'
         shell: bash
         run: |

--- a/scripts/push_l10n_extraction.sh
+++ b/scripts/push_l10n_extraction.sh
@@ -9,8 +9,6 @@ set -o pipefail
 # Treat unset variables as an error an exit immediately.
 set -u
 
-CURRENT_EMAIL=$(git config --get user.email)
-CURRENT_USER=$(git config --get user.name)
 ROBOT_EMAIL="addons-dev-automation+github@mozilla.com"
 ROBOT_NAME="Mozilla Add-ons Robot"
 
@@ -39,19 +37,10 @@ fi
 
 if [[ $DRY_RUN == true ]]; then
   echo "Dry running..."
-  echo "git config --global user.name \"$ROBOT_NAME\""
-  echo "git config --global user.email \"$ROBOT_EMAIL\""
-  echo "git commit -a -m \"$MESSAGE\""
+  echo "git commit --author=\"$ROBOT_NAME <$ROBOT_EMAIL>\" -a -m \"$MESSAGE\""
   echo "git push"
-  echo "git config --global user.name \"$CURRENT_USER\""
-  echo "git config --global user.email \"$CURRENT_EMAIL\""
 else
   # Commit the changes and push them to the repository.
-  git config --global user.name "$ROBOT_NAME"
-  git config --global user.email "$ROBOT_EMAIL"
-  git commit -a -m "$MESSAGE"
+  git commit --author="$ROBOT_NAME <$ROBOT_EMAIL>" -a -m "$MESSAGE"
   git push
-  # Reset the user name and email to the original values.
-  git config --global user.name "$CURRENT_USER"
-  git config --global user.email "$CURRENT_EMAIL"
 fi

--- a/scripts/push_l10n_extraction.sh
+++ b/scripts/push_l10n_extraction.sh
@@ -9,12 +9,15 @@ set -o pipefail
 # Treat unset variables as an error an exit immediately.
 set -u
 
+CURRENT_EMAIL=$(git config --get user.email)
+CURRENT_USER=$(git config --get user.name)
 ROBOT_EMAIL="addons-dev-automation+github@mozilla.com"
 ROBOT_NAME="Mozilla Add-ons Robot"
 
 DATE=$(date -u +%Y-%m-%d)
 REV=$(git rev-parse --short HEAD)
 MESSAGE="Extracted l10n messages from $DATE at $REV"
+DIFF_WITH_ONE_LINE_CHANGE="2 files changed, 2 insertions(+), 2 deletions(-)"
 
 DRY_RUN=true
 
@@ -22,11 +25,14 @@ if [[ "${1:-}" != "--dry-run" ]]; then
   DRY_RUN=false
 fi
 
+git_diff_stat=$(git diff --shortstat locale/templates/LC_MESSAGES)
+
+echo "git_diff_stat: $git_diff_stat"
+
 # IF there are no uncommitted local changes, exit early.
-if [[ -z "$(git status --porcelain)" ]]; then
+if [[ -z "$git_diff_stat" ]] || [[ "$git_diff_stat" == *"$DIFF_WITH_ONE_LINE_CHANGE"* ]]; then
   echo """
-    There are no uncommited changes in the working directory.
-    Run make extract_locales to extract the locales first.
+    No substantial changes to l10n strings found. Exiting the process.
   """
   exit 0
 fi
@@ -37,9 +43,15 @@ if [[ $DRY_RUN == true ]]; then
   echo "git config --global user.email \"$ROBOT_EMAIL\""
   echo "git commit -a -m \"$MESSAGE\""
   echo "git push"
+  echo "git config --global user.name \"$CURRENT_USER\""
+  echo "git config --global user.email \"$CURRENT_EMAIL\""
 else
+  # Commit the changes and push them to the repository.
   git config --global user.name "$ROBOT_NAME"
   git config --global user.email "$ROBOT_EMAIL"
   git commit -a -m "$MESSAGE"
   git push
+  # Reset the user name and email to the original values.
+  git config --global user.name "$CURRENT_USER"
+  git config --global user.email "$CURRENT_EMAIL"
 fi

--- a/scripts/run_l10n_extraction.sh
+++ b/scripts/run_l10n_extraction.sh
@@ -18,7 +18,6 @@ DJANGO_SETTINGS_MODULE=settings
 CLEAN_FLAGS="--no-obsolete --width=200 --no-location"
 MERGE_FLAGS="--update --width=200 --backup=none --no-fuzzy-matching"
 UNIQ_FLAGS="--width=200"
-DIFF_WITH_ONE_LINE_CHANGE="2 files changed, 2 insertions(+), 2 deletions(-)"
 LOCALE_TEMPLATE_DIR="locale/templates/LC_MESSAGES"
 
 info() {
@@ -40,16 +39,6 @@ PYTHONPATH=. DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE} pybabel extract -F
 
 pushd locale > /dev/null
 
-git_diff_stat=$(git diff --shortstat)
-
-echo "git_diff_stat: $git_diff_stat"
-
-# IF there are no uncommitted local changes, exit early.
-if [[ -z "$git_diff_stat" ]] || [[ "$git_diff_stat" == *"$DIFF_WITH_ONE_LINE_CHANGE"* ]]; then
-  info "No changes to template files. Exitting early."
-  git reset --hard
-  exit 0
-fi
 
 info "Merging any new keys from templates/LC_MESSAGES/django.pot"
 for i in `find . -name "django.po" | grep -v "en_US"`; do


### PR DESCRIPTION
FIxes: #22039

### Description

This PR moves all of the git operations to the push extraction script which runs on a stable host environment where secure git ownership should be reliably known.

It also changes the way we specify the author using the `--author` flag instead of setting global config. This prevents overwriting the host committer on local environments.

### Context

The previous attempt at this fix missed the fact that there are 2 extraction commands, running in different environments.

1: extract runs in the container and has a dubious user
2. push runs on the host and should have the user who authoered the PR

There's no guarantee these are the same user and running git reset in the container could make weird things happen on the host.

It seems like running git status --porcelain on the host after running git reset --hard on the container resulted in changes detected, but then when we tried to commit, no changes were found because no files actually remained changed.

### Testing

I'm not sure why I wasn't able to encounter the issue that is now found in CI locally when running the previous PR, but by moving all of the git commands to the host, it should prevent that class of errors entirely.

We will just have to run this on master and see I think...

