### PR TITLE
Upgrade base image to Debian bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN touch /addons-server-docker-container \
         # Git, because we're using git-checkout dependencies
         git \
         # Dependencies for mysql-python (from mysql apt repo, not debian)
+        pkg-config \
         mysql-client \
         libmysqlclient-dev \
         swig \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Read the docs/topics/development/docker.md file for more information about this Dockerfile.
 ####################################################################################################
 
-FROM python:3.10-slim-buster as base
+FROM python:3.10-slim-bookworm as base
 
 # Should change it to use ARG instead of ENV for OLYMPIA_UID/OLYMPIA_GID
 # once the jenkins server is upgraded to support docker >= v1.9.0

--- a/docker/mysql.list
+++ b/docker/mysql.list
@@ -1,1 +1,1 @@
-deb http://repo.mysql.com/apt/debian/ buster mysql-8.0
+deb http://repo.mysql.com/apt/debian/ bookworm mysql-8.0

--- a/src/olympia/core/apps.py
+++ b/src/olympia/core/apps.py
@@ -1,12 +1,33 @@
 import logging
+import subprocess
 import warnings
 
 from django.apps import AppConfig
 from django.conf import settings
+from django.core.checks import Error, Tags, register
 from django.utils.translation import gettext_lazy as _
 
 
 log = logging.getLogger('z.startup')
+
+
+class CustomTags(Tags):
+    custom_setup = 'setup'
+
+
+@register(CustomTags.custom_setup)
+def uwsgi_check(app_configs, **kwargs):
+    errors = []
+    command = ['uwsgi', '--version']
+    result = subprocess.run(command, capture_output=True)
+    if result.returncode != 0:
+        errors.append(
+            Error(
+                f'{" ".join(command)} returned a non-zero value',
+                id='setup.E001',
+            )
+        )
+    return errors
 
 
 class CoreConfig(AppConfig):

--- a/src/olympia/core/apps.py
+++ b/src/olympia/core/apps.py
@@ -17,6 +17,8 @@ class CustomTags(Tags):
 
 @register(CustomTags.custom_setup)
 def uwsgi_check(app_configs, **kwargs):
+    """Custom check triggered when ./manage.py check is ran (should be done
+    as part of verifying the docker image in CI)."""
     errors = []
     command = ['uwsgi', '--version']
     result = subprocess.run(command, capture_output=True)

--- a/src/olympia/core/tests/test_apps.py
+++ b/src/olympia/core/tests/test_apps.py
@@ -1,0 +1,17 @@
+from unittest import mock
+
+from django.core.management import call_command
+from django.core.management.base import SystemCheckError
+from django.test import SimpleTestCase
+
+
+class SystemCheckIntegrationTest(SimpleTestCase):
+    def test_uwsgi_check(self):
+        call_command('check')
+
+        with mock.patch('olympia.core.apps.subprocess') as subprocess:
+            subprocess.run.return_value.returncode = 127
+            with self.assertRaisesMessage(
+                SystemCheckError, 'uwsgi --version returned a non-zero value'
+            ):
+                call_command('check')


### PR DESCRIPTION
Fixes #22041

### Description

This PR updates the base docker image addons-server from Debian buster to bookworm

 ### Context

Debian buster is in long-term support mode, but that will end soon. On top of this, the python docker images for buster are not longer receiving updates. We could switch to bullseye but bookworm is the current stable version and will be supported for longer

### Testing

- Run `make clean_docker` or equivalent to make sure you're rebuilding your deps
- Build the image with `make build_docker_image`
- If it builds correctly:
  - Stop your containers
  - Tag the newly built image to replace `mozilla/addons-server`
  - Restart the containers to pick it up
- Test your env by clicking around, running tests etc. 
- `make shell` followed by `cat /etc/debian_version` should return `12.5`