### PR TITLE
Use proper css syntax for table styles on verify-email page

### DIFF
--- a/static/css/zamboni/developers.css
+++ b/static/css/zamboni/developers.css
@@ -1514,20 +1514,23 @@ form.select-review .errorlist {
 .verify-email-table {
     margin: 20px 0;
     width: 100%;
+}
 
-    table {
-        border-collapse: collapse;
-        border: 1px solid;
-    }
-    tr {
-        border: solid;
-        border-width: 1px 0;
-    }
-    td {
-        padding: 5px;
-        border: solid;
-        border-width: 0 1px;
-    }
+.verify-email-table table {
+    border-collapse: collapse;
+    border: 1px solid;
+    width: 100%;
+}
+
+.verify-email-table tr {
+    border: solid;
+    border-width: 1px 0;
+}
+
+.verify-email-table td {
+    padding: 5px;
+    border: solid;
+    border-width: 0 1px;
 }
 
 button.search-button {


### PR DESCRIPTION
Fixes: #22045

### Description

Use css syntax for table styling

### Context

the styles applied in developers.css were using less syntax. the table { nesting applied the style to all table elements causing the style to pollute the whole app.

It was not caught because it worked as expected on /verify-email and caused no build error.

It wasn't checked on other pages before merging also.

### Testing

Pages specified in the ticket should not have the table styles applied.