### PR TITLE
Add clean_docker command and fix local build_docker_image when run with empty cache

### DIFF
--- a/Makefile-os
+++ b/Makefile-os
@@ -71,6 +71,13 @@ build_docker_image: create_docker_builder ## Build the docker image
 	rm -rf $(DOCKER_CACHE_DIR)
 	mv $(DOCKER_CACHE_DIR)-new $(DOCKER_CACHE_DIR)
 
+.PHONY: clean_docker
+clean_docker: ## Clean up docker containers, images, caches, volumes and local cache directories. Use with caution. To restart the app run make initialize_docker after this commandUse with caution.
+	docker compose down --rmi all --volumes
+	docker rmi $(DOCKER_TAG) || true
+	rm -rf $(DOCKER_CACHE_DIR)
+	rm -rf ./deps/**
+
 .PHONY: initialize_docker
 initialize_docker: create_env_file
 # Run a fresh container from the base image to install deps. Since /deps is

--- a/Makefile-os
+++ b/Makefile-os
@@ -51,18 +51,23 @@ create_docker_builder: ## Create a custom builder for buildkit to efficiently bu
 		--name $(DOCKER_BUILDER) \
 		--driver=docker-container
 
+DOCKER_BUILD_ARGS := -t $(DOCKER_TAG) \
+--load \
+--platform $(DOCKER_PLATFORM) \
+--progress=$(DOCKER_PROGRESS) \
+--builder=$(DOCKER_BUILDER) \
+--label git.commit=$(DOCKER_COMMIT) \
+--cache-to=type=local,dest=$(DOCKER_CACHE_DIR)-new \
+
+DOCKER_CACHE_INDEX = $(wildcard $(DOCKER_CACHE_DIR)/index.json)
+
+ifneq ($(DOCKER_CACHE_INDEX),)
+	DOCKER_BUILD_ARGS += --cache-from=type=local,src=$(DOCKER_CACHE_DIR),mode=max
+endif
+
 .PHONY: build_docker_image
 build_docker_image: create_docker_builder ## Build the docker image
-	DOCKER_BUILDKIT=1 docker buildx build \
-		-t $(DOCKER_TAG) \
-		--load \
-		--platform $(DOCKER_PLATFORM) \
-		--progress=$(DOCKER_PROGRESS) \
-		--cache-to=type=local,dest=$(DOCKER_CACHE_DIR)-new \
-		--cache-from=type=local,src=$(DOCKER_CACHE_DIR),mode=max \
-		--builder=$(DOCKER_BUILDER) \
-		--label git.commit=$(DOCKER_COMMIT) \
-		.
+	DOCKER_BUILDKIT=1 docker buildx build $(DOCKER_BUILD_ARGS) .
 	rm -rf $(DOCKER_CACHE_DIR)
 	mv $(DOCKER_CACHE_DIR)-new $(DOCKER_CACHE_DIR)
 


### PR DESCRIPTION
Relates to: #21888, PR https://github.com/mozilla/addons-server/pull/22044

### Description

This PR achieves 2 aims.

1) Add a `clean_docker` command to enable pristine builds by removing local cache directories that can be "incorrectly" mounted to the build context causing unexpected issues. (see linked PR)

2) fix local docker build errors when there is no cache directory present. (first build or pristine build)

Fix local `build_docker_image` command when there is a purged cache.

Only include the `---cache-from` argument to `docker build` when the index.json for a previous docker build cache exists. if it doesn't exist and you pull as a cache it can lead to docker build errors.