### PR TITLE
Fix error on devhub pages when debug toolbar is enabled

### DIFF
--- a/src/olympia/devhub/templates/devhub/base.html
+++ b/src/olympia/devhub/templates/devhub/base.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% if addon %}
-  {% set default_body_class = "no-edit" if not check_addon_ownership(request.user, addon, allow_developer=True) %}
+  {% set default_body_class = "no-edit" if not check_addon_ownership(request.user, addon, allow_developer=True) else "" %}
 {% endif %}
 {% block bodyclass %}developer-hub {{ editable_body_class|default(default_body_class) }}{% endblock %}
 


### PR DESCRIPTION
Normally, doing an inline if with no else in Jinja raises the special undefined error similar to what happens with missing variables etc, and that error just prints an empty string, completely ignoring it.

In django-debug-toolbar 4.3.0 however, in some specific cases (seemingly only when the inline if contains a function call, but there may be more cases), with the templates panel enabled, that causes a hard exception to be thrown instead. This changes works around that problem by simply providing an else clause.

Fixes #22053