### PR TITLE
Fix git commit error missing committer identity

### DIFF
--- a/.github/workflows/extract-locales.yml
+++ b/.github/workflows/extract-locales.yml
@@ -14,6 +14,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Build Docker image
         id: build

--- a/scripts/push_l10n_extraction.sh
+++ b/scripts/push_l10n_extraction.sh
@@ -9,38 +9,52 @@ set -o pipefail
 # Treat unset variables as an error an exit immediately.
 set -u
 
+set -x
+
+info() {
+  local message="$1"
+
+  echo ""
+  echo "INFO: $message"
+  echo ""
+}
+
 ROBOT_EMAIL="addons-dev-automation+github@mozilla.com"
 ROBOT_NAME="Mozilla Add-ons Robot"
+
+# Set git committer/author to the robot.
+export GIT_AUTHOR_NAME="$ROBOT_NAME"
+export GIT_AUTHOR_EMAIL="$ROBOT_EMAIL"
+export GIT_COMMITTER_NAME="$ROBOT_NAME"
+export GIT_COMMITTER_EMAIL="$ROBOT_EMAIL"
 
 DATE=$(date -u +%Y-%m-%d)
 REV=$(git rev-parse --short HEAD)
 MESSAGE="Extracted l10n messages from $DATE at $REV"
 DIFF_WITH_ONE_LINE_CHANGE="2 files changed, 2 insertions(+), 2 deletions(-)"
 
-DRY_RUN=true
-
-if [[ "${1:-}" != "--dry-run" ]]; then
-  DRY_RUN=false
-fi
-
 git_diff_stat=$(git diff --shortstat locale/templates/LC_MESSAGES)
 
-echo "git_diff_stat: $git_diff_stat"
+info "git_diff_stat: $git_diff_stat"
 
 # IF there are no uncommitted local changes, exit early.
 if [[ -z "$git_diff_stat" ]] || [[ "$git_diff_stat" == *"$DIFF_WITH_ONE_LINE_CHANGE"* ]]; then
-  echo """
+  info """
     No substantial changes to l10n strings found. Exiting the process.
   """
   exit 0
 fi
 
-if [[ $DRY_RUN == true ]]; then
-  echo "Dry running..."
-  echo "git commit --author=\"$ROBOT_NAME <$ROBOT_EMAIL>\" -a -m \"$MESSAGE\""
-  echo "git push"
-else
-  # Commit the changes and push them to the repository.
-  git commit --author="$ROBOT_NAME <$ROBOT_EMAIL>" -a -m "$MESSAGE"
-  git push
-fi
+info """
+GIT_AUTHOR_NAME: $GIT_AUTHOR_NAME
+GIT_AUTHOR_EMAIL: $GIT_AUTHOR_EMAIL
+GIT_COMMITTER_NAME: $GIT_COMMITTER_NAME
+GIT_COMMITTER_EMAIL: $GIT_COMMITTER_EMAIL
+
+This script passes arguments directly to Git commands. We can pass --dry-mode to test this script
+Without actually committing or pushing. Make sure to only pass arguments supported on both commit and push..
+ARGS: $@
+"""
+
+git commit -am "$MESSAGE" "$@"
+git push "$@"


### PR DESCRIPTION
Fixes: #22058

### Description

Adds a function robot_commit that runs git commands as the robot user using environment variables.

Also cleans up some logging and exposes commands executed for better debugging.

IMPORTANT: this PR modifies how the script accepts and interprets arguments. Instead of implementing our own --dry-mode flag, i've exposed the script to accept any arguments and pass them to the git comands. git already supports --dry-mode both for commit and push so this should allow the same (and more) flexibility with less code.

### Context

The trick here is to get the commit to work in CI without potentially changing git config information if run locally.

### Testing

You have to modify some strings and commit them. Then run

```bash
make extract_locales
```

and try 

```bash
make push_locales ARGS="--dry-run"
```

To test the output.
