### PR TITLE
Skip push locales CI check on PRs from forks.

### DIFF
--- a/.github/workflows/extract-locales.yml
+++ b/.github/workflows/extract-locales.yml
@@ -38,6 +38,16 @@ jobs:
         if: github.event_name == 'pull_request'
         shell: bash
         run: |
+          if [[ ${{ github.event.pull_request.head.repo.fork}} == 'true' ]]; then
+            echo """
+            Github actions are not authorized to push from workflows triggered by forks.
+            We cannot verify if the l10n extraction push will work or not.
+            Please submit a PR from the base repository if you are modifying l10n extraction scripts.
+            """
+
+            exit 0
+          fi
+
           make push_locales ARGS="--dry-run"
 
       - name: Push Locales


### PR DESCRIPTION
Fixes: #22067

### Context

The github token for forks only has read access. This makes any git push command fail, even if run in dry run mode. It is actually great that we get this error because it means dry mode is working as expected, showing the error you would have gotten had you tried to push.

I've tried several approaches to modify permissions or otherwise change the configuration and none seem to reliably work. Read [docs for more info](https://docs.github.com/en/actions/security-guides/automatic-token-authentication)

### Change

This change adds a check on PRs, if the pr is from a fork of the repo, we skip the push step and add a log warning the user if they are changing the push logic, it will not be tested.

### Testing

This PR tests, itself by being from a fork. The extract locales job is passing, whereas previous PRs (links in issue) have failed.
