### PR TITLE
Improve usability of verify email page when verification is pending or timedout

### DIFF
--- a/src/olympia/devhub/templates/devhub/verify_email.html
+++ b/src/olympia/devhub/templates/devhub/verify_email.html
@@ -6,28 +6,29 @@
 
 {% block content %}
 <h1>{{ title }}</h1>
-<div id="{{ state }}">
-<div class="verify-email-text">
+<div class="verify-email" id="{{ state }}">
+<strong>Status:</strong>
 {% if state == "email_verified" %}
   {% trans %}
   Your email address is verified.
   {% endtrans %}
 {% elif state == "email_suppressed" %}
   {% trans %}
-  Please verify your email by clicking "Verify email" above.
+  Please verify your email.
   {% endtrans %}
 {% elif state == "verification_expired" %}
   {% trans %}
   Could not verify email address. The verification link has expired.
   {% endtrans %}
 {% elif state == "verification_pending" %}
-  <div class="loader"></div>
     {% trans %}
-    We are sending an email to you, this might take a minute. The page will automatically refresh.
+    We are sending an email to you, please be patient...
+    <div class="loader"></div>
+    The page will automatically refresh.
     {% endtrans %}
 {% elif state == "verification_timedout" %}
   {% trans %}
-  It is taking longer than expected to confirm delivery of your verification email. Please try again.
+  It is taking longer than expected to confirm delivery of your verification email. Please try again later.
   {% endtrans %}
 {% elif state == "confirmation_pending" %}
   {% trans email=request.user.email %}
@@ -36,57 +37,74 @@
 {% elif state == "confirmation_invalid" %}
   {% trans email=request.user.email %}
   The provided code is invalid, unauthorized, expired or incomplete. Please use the link in the email sent to your email address {{ email }}. If the code is still not working, please request a new email.
-
-
   {% endtrans %}
 {% endif %}
 </div>
-{% if found_emails|length > 0 %}
+
+
+{% if render_table %}
 <div class="verify-email-table">
   <p>
     {% trans %}
-      We have attempted to send your verification email.
-      Below are the confirmation records we found and their associated delivery statuses.
+      <strong>Email history:</strong> The table below shows all emails we have attempted to send to you in the last 2 days.
     {% endtrans %}
   </p>
   <table border=1 frame=void rules=rows>
-    <thead>
-      <tr>
-        <th>{{ _('Date') }}</th>
-        <th>{{ _('From') }}</th>
-        <th>{{ _('To') }}</th>
-        <th>{{ _('Subject') }}</th>
-        <th>{{ _('Status') }}</th>
-      </tr>
-    </thead>
-    <tbody>
-    {% for email in found_emails %}
-      <tr>
-        <td>
-          {{ email.statusDate }}
-        </td>
-        <td>
-          {{ email.from }}
-        </td>
-        <td>
-          {{ email.to }}
-        </td>
-        <td>
-          {{ email.subject }}
-        </td>
-        <td>
-          {{ email.status }}
-        </td>
-      </tr>
-    {% endfor %}
-    </tbody>
+    {% if found_emails|length > 0 %}
+      <thead>
+        <tr>
+          <th>{{ _('Date') }}</th>
+          <th>{{ _('From') }}</th>
+          <th>{{ _('To') }}</th>
+          <th>{{ _('Subject') }}</th>
+          <th>{{ _('Status') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+      {% for email in found_emails %}
+        <tr>
+          <td>
+            {{ email.statusDate }}
+          </td>
+          <td>
+            {{ email.from }}
+          </td>
+          <td>
+            {{ email.to }}
+          </td>
+          <td>
+            {{ email.subject }}
+          </td>
+          <td>
+            {{ email.status }}
+          </td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    {% else %}
+      {% trans %}
+        <tbody>
+          <td>We have not found any email records for you in the last 2 days.</td>
+        </tbody>
+      {% endtrans %}
+    {% endif %}
   </table>
+  <a href="{{ request.get_full_path() }}">Refresh results</a>
 </div>
 {% endif %}
+
+
 {% if render_button %}
-  {% with submit_text=button_text %}
-    {% include 'devhub/verify_email_form.html' %}
-  {% endwith %}
-{% endif %}
+<div class="verify-email-actions">
+{% with submit_text=button_text %}
+  {% include 'devhub/verify_email_form.html' %}
+{% endwith %}
+{% trans %}
+  Having trouble? Please contact AMO Admins if you need help.
+<a href="mailto:{{ support_email }}?subject={{ support_subject }}&body={{ support_body }}">
+  email support
+</a>.
+{% endtrans %}
 </div>
+{% endif %}
 {% endblock %}

--- a/src/olympia/devhub/templates/devhub/verify_email.html
+++ b/src/olympia/devhub/templates/devhub/verify_email.html
@@ -82,11 +82,9 @@
       {% endfor %}
       </tbody>
     {% else %}
-      {% trans %}
-        <tbody>
-          <td>We have not found any email records for you in the last 2 days.</td>
-        </tbody>
-      {% endtrans %}
+      <tbody>
+        <td>{{ _('We have not found any email records for you in the last 2 days.') }}</td>
+      </tbody>
     {% endif %}
   </table>
   <a href="{{ request.get_full_path() }}">Refresh results</a>

--- a/src/olympia/devhub/templates/devhub/verify_email.html
+++ b/src/olympia/devhub/templates/devhub/verify_email.html
@@ -100,10 +100,7 @@
   {% include 'devhub/verify_email_form.html' %}
 {% endwith %}
 {% trans %}
-  Having trouble? Please contact AMO Admins if you need help.
-<a href="mailto:{{ support_email }}?subject={{ support_subject }}&body={{ support_body }}">
-  email support
-</a>.
+  Having trouble? Please <a href="mailto:{{ support_email }}?subject={{ support_subject }}&body={{ support_body }}">contact AMO Admins</a> if you need help.
 {% endtrans %}
 </div>
 {% endif %}

--- a/src/olympia/devhub/templates/devhub/verify_email.html
+++ b/src/olympia/devhub/templates/devhub/verify_email.html
@@ -31,6 +31,7 @@
   It is taking longer than expected to confirm delivery of your verification email. Please try again later.
   {% endtrans %}
 {% elif state == "confirmation_pending" %}
+  <h3>{{ _('Success!') }}</h3>
   {% trans email=request.user.email %}
   An email with a confirmation link has been sent to your email address: {{ email }}. Please click the link to confirm your email address. If you did not receive the email, please check your spam folder.
   {% endtrans %}

--- a/src/olympia/devhub/templates/devhub/verify_email.html
+++ b/src/olympia/devhub/templates/devhub/verify_email.html
@@ -87,7 +87,7 @@
       </tbody>
     {% endif %}
   </table>
-  <a href="{{ request.get_full_path() }}">Refresh results</a>
+  <a href="{{ request.get_full_path() }}">{{ _('Refresh results') }}</a>
 </div>
 {% endif %}
 

--- a/src/olympia/devhub/templates/devhub/verify_email.html
+++ b/src/olympia/devhub/templates/devhub/verify_email.html
@@ -7,7 +7,7 @@
 {% block content %}
 <h1>{{ title }}</h1>
 <div class="verify-email" id="{{ state }}">
-<strong>Status:</strong>
+<strong>{{ _('Status:') }}</strong>
 {% if state == "email_verified" %}
   {% trans %}
   Your email address is verified.

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -2281,7 +2281,7 @@ class TestVerifyEmail(TestCase):
         assert not self.email_verification.is_timedout
 
         with freezegun.freeze_time(self.email_verification.created) as frozen_time:
-            frozen_time.tick(timedelta(seconds=31))
+            frozen_time.tick(timedelta(minutes=10, seconds=1))
             response = self.client.get(url)
 
             assert len(mail.outbox) == 1
@@ -2350,7 +2350,7 @@ class TestVerifyEmail(TestCase):
         self.with_email_verification()
 
         with freezegun.freeze_time(self.email_verification.created) as frozen_time:
-            frozen_time.tick(timedelta(minutes=1, seconds=31))
+            frozen_time.tick(timedelta(minutes=10, seconds=31))
 
             assert self.email_verification.is_timedout
 

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -2361,8 +2361,7 @@ class TestVerifyEmail(TestCase):
             assert 'Send another email' in doc.text()
 
             assert 'Having trouble?' in doc.text()
-            support_link = doc('a:contains("email support")')
-            assert 'email support' in support_link.text()
+            support_link = doc('a:contains("contact AMO Admins")')
             assert f'mailto:{settings.SUPPORT_EMAIL}' in support_link.attr('href')
             assert '?subject=Suppressed Email verification' in support_link.attr('href')
             assert 'I have a suppressed email' in support_link.attr('href')

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -2379,6 +2379,7 @@ class TestVerifyEmail(TestCase):
         doc = pq(response.content)
 
         assert 'An email with a confirmation link has been sent' in doc.text()
+        assert 'The table below shows all emails ' not in doc.text()
 
     @mock.patch('olympia.devhub.views.check_suppressed_email_confirmation')
     def test_get_confirmation_invalid(self, mock_check_emails):

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -2324,7 +2324,7 @@ class TestVerifyEmail(TestCase):
         doc = pq(response.content)
 
         assert 'We are sending an email to you' in doc.text()
-        assert 'Send another email' in doc.text()
+        assert 'Refresh results' in doc.text()
 
     @mock.patch('olympia.devhub.views.check_suppressed_email_confirmation')
     def test_get_verification_pending_with_emails(self, mock_check_emails):
@@ -2335,12 +2335,14 @@ class TestVerifyEmail(TestCase):
         response = self.client.get(self.url)
         doc = pq(response.content)
 
-        assert 'We have attempted to send your verification' in doc.text()
+        assert (
+            'The table below shows all emails we have attempted to send to you'
+        ) in doc.text()
         assert 'Delivered' in doc.text()
         assert 'subject' in doc.text()
         assert 'from' in doc.text()
         assert 'to' in doc.text()
-        assert 'Send another email' in doc.text()
+        assert 'Refresh results' in doc.text()
 
     @mock.patch('olympia.devhub.views.check_suppressed_email_confirmation')
     def test_get_verification_timedout(self, mock_check_emails):
@@ -2357,6 +2359,14 @@ class TestVerifyEmail(TestCase):
 
             assert 'It is taking longer than expected' in doc.text()
             assert 'Send another email' in doc.text()
+
+            assert 'Having trouble?' in doc.text()
+            support_link = doc('a:contains("email support")')
+            assert 'email support' in support_link.text()
+            assert f'mailto:{settings.SUPPORT_EMAIL}' in support_link.attr('href')
+            assert '?subject=Suppressed Email verification' in support_link.attr('href')
+            assert 'I have a suppressed email' in support_link.attr('href')
+            assert self.user_profile.email in support_link.attr('href')
 
     @mock.patch('olympia.devhub.views.check_suppressed_email_confirmation')
     def test_get_verification_delivered(self, mock_check_suppressed):

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -2350,7 +2350,7 @@ class TestVerifyEmail(TestCase):
         self.with_email_verification()
 
         with freezegun.freeze_time(self.email_verification.created) as frozen_time:
-            frozen_time.tick(timedelta(seconds=31))
+            frozen_time.tick(timedelta(minutes=1, seconds=31))
 
             assert self.email_verification.is_timedout
 

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -2095,7 +2095,6 @@ VERIFY_EMAIL_STATE = {
 RENDER_BUTTON_STATES = [
     VERIFY_EMAIL_STATE['email_suppressed'],
     VERIFY_EMAIL_STATE['verification_expired'],
-    VERIFY_EMAIL_STATE['verification_pending'],
     VERIFY_EMAIL_STATE['verification_timedout'],
     VERIFY_EMAIL_STATE['confirmation_invalid'],
 ]
@@ -2130,6 +2129,7 @@ def email_verification(request):
         return redirect('devhub.email_verification')
 
     if email_verification:
+        data['render_table'] = True
         data['found_emails'] = check_suppressed_email_confirmation(email_verification)
         if email_verification.is_expired:
             data['state'] = VERIFY_EMAIL_STATE['verification_expired']
@@ -2165,6 +2165,12 @@ def email_verification(request):
         raise Exception('Invalid view must result in assigned state')
 
     if data['state'] in RENDER_BUTTON_STATES:
+        data['support_email'] = settings.SUPPORT_EMAIL
+        data['support_subject'] = 'Suppressed Email verification'
+        data['support_body'] = (
+            'I have a suppressed email and I need help verifying it. '
+            f'email: {request.user.email}.'
+        )
         data['render_button'] = True
         data['button_text'] = get_button_text(data['state'])
 

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -2153,6 +2153,7 @@ def email_verification(request):
                 == SuppressedEmailVerification.STATUS_CHOICES.Delivered
             ):
                 data['state'] = VERIFY_EMAIL_STATE['confirmation_pending']
+                data['render_table'] = False
             else:
                 data['state'] = VERIFY_EMAIL_STATE['verification_pending']
 

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1553,4 +1553,4 @@ SOCKET_LABS_HOST = env('SOCKET_LABS_HOST', default='https://api.socketlabs.com/v
 SOCKET_LABS_TOKEN = env('SOCKET_LABS_TOKEN', default=None)
 SOCKET_LABS_SERVER_ID = env('SOCKET_LABS_SERVER_ID', default=None)
 
-SUPPORT_EMAIL = 'amo-admins@mozilla.org'
+SUPPORT_EMAIL = 'amo-admins+amo_devhub@mozilla.org'

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1552,3 +1552,5 @@ CINDER_QUEUE_PREFIX = 'amo-dev-'
 SOCKET_LABS_HOST = env('SOCKET_LABS_HOST', default='https://api.socketlabs.com/v2/')
 SOCKET_LABS_TOKEN = env('SOCKET_LABS_TOKEN', default=None)
 SOCKET_LABS_SERVER_ID = env('SOCKET_LABS_SERVER_ID', default=None)
+
+SUPPORT_EMAIL = 'amo-admins@mozilla.org'

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -1385,7 +1385,7 @@ class SuppressedEmailVerification(ModelBase):
 
     @property
     def is_timedout(self):
-        return self.created + timedelta(seconds=30) < datetime.now()
+        return self.created + timedelta(minutes=1) < datetime.now()
 
     def mark_as_delivered(self):
         self.update(status=SuppressedEmailVerification.STATUS_CHOICES.Delivered)

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -1385,7 +1385,7 @@ class SuppressedEmailVerification(ModelBase):
 
     @property
     def is_timedout(self):
-        return self.created + timedelta(minutes=1) < datetime.now()
+        return self.created + timedelta(minutes=10) < datetime.now()
 
     def mark_as_delivered(self):
         self.update(status=SuppressedEmailVerification.STATUS_CHOICES.Delivered)

--- a/src/olympia/users/tests/test_models.py
+++ b/src/olympia/users/tests/test_models.py
@@ -1568,5 +1568,5 @@ class TestSuppressedEmailVerification(TestCase):
         )
         assert not email_verification.is_timedout
 
-        with freeze_time(email_verification.created + timedelta(minutes=1, seconds=1)):
+        with freeze_time(email_verification.created + timedelta(minutes=10, seconds=1)):
             assert email_verification.is_timedout

--- a/src/olympia/users/tests/test_models.py
+++ b/src/olympia/users/tests/test_models.py
@@ -1568,5 +1568,5 @@ class TestSuppressedEmailVerification(TestCase):
         )
         assert not email_verification.is_timedout
 
-        with freeze_time(email_verification.created + timedelta(seconds=31)):
+        with freeze_time(email_verification.created + timedelta(minutes=1, seconds=1)):
             assert email_verification.is_timedout

--- a/src/olympia/users/utils.py
+++ b/src/olympia/users/utils.py
@@ -382,18 +382,17 @@ def check_suppressed_email_confirmation(verification, page_size=5):
 
         ## TODO: check if we can set `customMessageId` to replace code snippet
         for item in data:
-            if code_snippet in item['subject']:
-                found_emails.append(
-                    {
-                        'from': item['from'],
-                        'to': item['to'],
-                        'subject': item['subject'],
-                        'status': item['status'],
-                        'statusDate': item['statusDate'],
-                    }
-                )
+            found_emails.append(
+                {
+                    'from': item['from'],
+                    'to': item['to'],
+                    'subject': item['subject'],
+                    'status': item['status'],
+                    'statusDate': item['statusDate'],
+                }
+            )
 
-                if item['status'] == 'Delivered':
-                    verification.mark_as_delivered()
+            if code_snippet in item['subject'] and item['status'] == 'Delivered':
+                verification.mark_as_delivered()
 
     return found_emails

--- a/static/css/zamboni/developers.css
+++ b/static/css/zamboni/developers.css
@@ -1507,6 +1507,10 @@ form.select-review .errorlist {
     margin-bottom: 10px;
 }
 
+.verify-email-actions {
+    margin-top: 10px;
+}
+
 .verify-email-button {
     margin-top: 10px;
 }

--- a/static/css/zamboni/developers.css
+++ b/static/css/zamboni/developers.css
@@ -1535,6 +1535,9 @@ form.select-review .errorlist {
     padding: 5px;
     border: solid;
     border-width: 0 1px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 button.search-button {

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -9,7 +9,7 @@ $(document).ready(function () {
   $('.verify-email#verification_pending').exists(function () {
     setTimeout(function () {
       window.location.reload();
-    }, 10_000);
+    }, 30_000);
   });
 
   //Ownership

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -6,7 +6,7 @@ $(document).ready(function () {
   $('#edit-addon').exists(initEditAddon);
 
   // Poll for suppressed email removal updates.
-  $('#verification_pending').exists(function () {
+  $('.verify-email#verification_pending').exists(function () {
     setTimeout(function () {
       window.location.reload();
     }, 10_000);


### PR DESCRIPTION
Fixes: mozilla/addons/issues/1734

### Description

This PR introduces usability improvements for users trying to verify their email that are not recieving the email or have not yet recieved the email.

### Context

Socketlabs uses queues to process email requests and so we cannot know if socketlabs will have sent the email within a reasonable window for the user.

If the user decides to request another email during a verification, a new code will be created and so the filter we use for socketlabs should be wider and include potentially failed emails and previous verification attempts.