### PR TITLE
ADDSRV-720-no-host-install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -495,7 +495,6 @@ commands:
           name: Set environment variables
           command: |
             echo export CPUCOUNT=2 >> $BASH_ENV
-            echo export NPM_CONFIG_PREFIX=/deps/ >> $BASH_ENV
             echo export CC=\"`python -c 'import sysconfig; print(sysconfig.get_config_var("CC"))'`\" >> $BASH_ENV
             cat $BASH_ENV
       - run:
@@ -504,8 +503,6 @@ commands:
               sudo mkdir /deps
               sudo chown circleci /deps
               ACTUAL_CIRCLE_WORKING_DIRECTORY="${CIRCLE_WORKING_DIRECTORY/#\~/$HOME}"
-              ln -s ${ACTUAL_CIRCLE_WORKING_DIRECTORY}/package.json /deps/package.json
-              ln -s ${ACTUAL_CIRCLE_WORKING_DIRECTORY}/package-lock.json /deps/package-lock.json
               make update_deps
       # should be executed after all python install commands
       - run: pyenv rehash

--- a/.github/actions/run-docker/action.yml
+++ b/.github/actions/run-docker/action.yml
@@ -50,6 +50,5 @@ runs:
           -i --rm -u 0 \
           -v $(pwd):/data/olympia \
           -v ./deps:/deps \
-          -v ./package.json:/deps/package.json \
-          -v ./package-lock.json:/deps/package-lock.json \
+          -v ./node_modules:/data/olympia/node_modules \
           ${{ inputs.image }} bash

--- a/.github/actions/run-docker/action.yml
+++ b/.github/actions/run-docker/action.yml
@@ -22,6 +22,7 @@ runs:
         cat <<EOF > exec.sh
         #!/bin/bash
         whoami
+        set -x
         ${{ inputs.run }}
         EOF
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,14 +18,24 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup Environment
-        uses: ./.github/actions/setup-environment
+      - name: Build Docker image
+        id: build
+        uses: ./.github/actions/build-docker
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Build Docs
+        uses: ./.github/actions/run-docker
+        with:
+          image: ${{ steps.build.outputs.tags }}
+          options:
+          run: |
+            make update_deps
+            make docs
+      - name: Verify output
         shell: bash
         run: |
-          make -f Makefile-docker docs
+            ls -la docs/_build/
+            ls -la docs/_build/html
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/verify-docker-image.yml
+++ b/.github/workflows/verify-docker-image.yml
@@ -22,7 +22,15 @@ jobs:
           image: ${{ steps.build.outputs.tags }}
           options:
           run: |
+            ls -la node_modules
             make update_deps
+            ls -la node_modules
             echo 'from olympia.lib.settings_base import *' > settings_local.py
             DJANGO_SETTINGS_MODULE='settings_local' python3 ./manage.py check
+            make run_js_tests
+            make lint
+            ls -la node_modules/@claviska
+            ls -la node_modules/@claviska/jquery-minicolors
+            ls -la node_modules/@claviska/jquery-minicolors/jquery.minicolors.css
+            make update_assets
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,8 @@ ENV PATH $PYTHONUSERBASE/bin:$PATH
 ENV NPM_DEBUG=true
 
 RUN \
+    # Script to verify running in docker
+    --mount=type=bind,source=./scripts/fail-outside-docker.sh,target=${HOME}/scripts/fail-outside-docker.sh \
     # Files needed to run the make command
     --mount=type=bind,source=Makefile,target=${HOME}/Makefile \
     --mount=type=bind,source=Makefile-docker,target=${HOME}/Makefile-docker \

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,6 @@ ENV PIP_CACHE_DIR=/deps/cache/
 ENV PIP_SRC=/deps/src/
 ENV PYTHONUSERBASE=/deps
 ENV PATH $PYTHONUSERBASE/bin:$PATH
-ENV NPM_DEBUG=true
 
 RUN \
     # Script to verify running in docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,8 +93,6 @@ ENV PIP_CACHE_DIR=/deps/cache/
 ENV PIP_SRC=/deps/src/
 ENV PYTHONUSERBASE=/deps
 ENV PATH $PYTHONUSERBASE/bin:$PATH
-ENV NPM_CONFIG_PREFIX=/deps/
-ENV NPM_CACHE_DIR=/deps/cache/npm
 ENV NPM_DEBUG=true
 
 RUN \
@@ -109,11 +107,9 @@ RUN \
     --mount=type=bind,source=package-lock.json,target=${HOME}/package-lock.json \
     # Mounts for caching dependencies
     --mount=type=cache,target=${PIP_CACHE_DIR},uid=${OLYMPIA_UID},gid=${OLYMPIA_GID} \
-    --mount=type=cache,target=${NPM_CACHE_DIR},uid=${OLYMPIA_UID},gid=${OLYMPIA_GID} \
+    --mount=type=cache,target=${HOME}/.npm,uid=${OLYMPIA_UID},gid=${OLYMPIA_GID} \
     # Command to install dependencies
-    ln -s ${HOME}/package.json /deps/package.json \
-    && ln -s ${HOME}/package-lock.json /deps/package-lock.json \
-    && make update_deps_prod
+    make update_deps_prod
 
 FROM base as builder
 ARG LOCALE_DIR=${HOME}/locale

--- a/Makefile-docker
+++ b/Makefile-docker
@@ -206,7 +206,7 @@ test_failed: ## rerun the failed tests from the previous run
 
 .PHONY: run_js_tests
 run_js_tests: ## Run the JavaScript test suite (requires compiled/compressed assets).
-	num run test
+	npm run test
 
 .PHONY: watch_js_tests
 watch_js_tests: ## Run+watch the JavaScript test suite (requires compiled/compressed assets).

--- a/Makefile-docker
+++ b/Makefile-docker
@@ -13,19 +13,11 @@ NUM_THEMES=$(NUM_ADDONS)
 
 NPM_ARGS :=
 
-ifneq ($(NPM_CONFIG_PREFIX),)
-	NPM_ARGS := --prefix $(NPM_CONFIG_PREFIX)
-endif
-
-ifneq ($(NPM_CACHE_DIR),)
-	NPM_ARGS := $(NPM_ARGS) --cache $(NPM_CACHE_DIR)
-endif
-
 ifneq ($(NPM_DEBUG),)
 	NPM_ARGS := $(NPM_ARGS) --loglevel verbose
 endif
 
-NODE_MODULES := $(NPM_CONFIG_PREFIX)node_modules/
+NODE_MODULES := node_modules/
 STATIC_CSS := static/css/node_lib/
 STATIC_JS := static/js/node_lib/
 STATIC_JQUERY_UI := static/js/node_lib/ui/

--- a/Makefile-docker
+++ b/Makefile-docker
@@ -11,12 +11,6 @@ APP=src/olympia/
 NUM_ADDONS=10
 NUM_THEMES=$(NUM_ADDONS)
 
-NPM_ARGS :=
-
-ifneq ($(NPM_DEBUG),)
-	NPM_ARGS := $(NPM_ARGS) --loglevel verbose
-endif
-
 NODE_MODULES := node_modules/
 STATIC_CSS := static/css/node_lib/
 STATIC_JS := static/js/node_lib/
@@ -86,15 +80,15 @@ update_deps_base: ## update the python and node dependencies
 .PHONY: update_deps
 update_deps: update_deps_base ## update the python and node dependencies for development
 	$(PIP_COMMAND) install --progress-bar=off --no-deps --exists-action=w -r requirements/dev.txt
-	npm install $(NPM_ARGS) --no-save
+	npm install --loglevel verbose --no-save
 
 .PHONY: update_deps_prod
 update_deps_prod: update_deps_base ## update the python and node dependencies for production
-	npm ci $(NPM_ARGS)
+	npm ci --loglevel verbose
 
 .PHONY: prune_deps
 prune_deps: ## remove unused dependencies
-	npm prune $(NPM_ARGS) --production
+	npm prune --loglevel verbose --production
 
 .PHONY: update_db
 update_db: ## run the database migrations
@@ -156,7 +150,7 @@ perf-tests: setup-ui-tests
 lint: ## lint the code
 	ruff check .
 	ruff format --check .
-	NODE_PATH=$(NODE_MODULES) npm exec $(NPM_ARGS) -- prettier --check '**'
+	npm run lint
 	curlylint src/
 
 lint-codestyle: lint
@@ -212,15 +206,15 @@ test_failed: ## rerun the failed tests from the previous run
 
 .PHONY: run_js_tests
 run_js_tests: ## Run the JavaScript test suite (requires compiled/compressed assets).
-	NODE_PATH=$(NODE_MODULES) npm exec $(NPM_ARGS) -- jest
+	num run test
 
 .PHONY: watch_js_tests
 watch_js_tests: ## Run+watch the JavaScript test suite (requires compiled/compressed assets).
-	NODE_PATH=$(NODE_MODULES) npm exec $(NPM_ARGS) -- jest --watch
+	npm run test:watch
 
 .PHONY: format
 format: ## Autoformat our codebase.
-	NODE_PATH=$(NODE_MODULES) npm exec $(NPM_ARGS) -- prettier --write '**'
+	npm run format
 	ruff check --fix-only .
 	ruff format .
 

--- a/Makefile-os
+++ b/Makefile-os
@@ -80,15 +80,6 @@ clean_docker: ## Clean up docker containers, images, caches, volumes and local c
 
 .PHONY: initialize_docker
 initialize_docker: create_env_file
-# Run a fresh container from the base image to install deps. Since /deps is
-# shared via a volume in docker-compose.yml, this installs deps for both web
-# and worker containers, and does so without requiring the containers to be up.
-# We just create dummy empty package.json and package-lock.json in deps/ so
-# that docker compose doesn't create dummy ones itself, as they would be owned
-# by root. They don't matter: the ones at the root directory are mounted
-# instead.
-	touch deps/package.json
-	touch deps/package-lock.json
 # Note that this is running with --user ${UID}:${GID} because the user olympia
 # would be uid 9500 regardless of host at this point (this is only fixed when
 # the container is up, through the command defined in docker-compose.yml),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,8 +42,7 @@ services:
     volumes:
       - .:/data/olympia
       - ./deps:/deps
-      - ./package.json:/deps/package.json
-      - ./package-lock.json:/deps/package-lock.json
+      - ./node_modules:/data/olympia/node_modules
     extra_hosts:
      - "olympia.test:127.0.0.1"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "addons-server",
       "version": "0.0.17",
+      "hasInstallScript": true,
       "dependencies": {
         "@claviska/jquery-minicolors": "2.3.6",
         "addons-linter": "6.24.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
     "node": ">= 18.18"
   },
   "scripts": {
-    "preinstall": "./scripts/fail-outside-docker.sh"
+    "preinstall": "./scripts/fail-outside-docker.sh",
+    "test": "jest",
+    "test:watch": "npm run test --watch",
+    "lint": "prettier --check '**'",
+    "format": "prettier --write '**'"
   },
   "dependencies": {
     "@claviska/jquery-minicolors": "2.3.6",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "engines": {
     "node": ">= 18.18"
   },
+  "scripts": {
+    "preinstall": "if [ ! -f /addons-server-docker-container ]; then echo 'Cannot install on host. run in docker';exit 1; fi"
+  },
   "dependencies": {
     "@claviska/jquery-minicolors": "2.3.6",
     "addons-linter": "6.24.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": ">= 18.18"
   },
   "scripts": {
-    "preinstall": "if [ ! -f /addons-server-docker-container ]; then echo 'Cannot install on host. run in docker';exit 1; fi"
+    "preinstall": "./scripts/fail-outside-docker.sh"
   },
   "dependencies": {
     "@claviska/jquery-minicolors": "2.3.6",

--- a/scripts/fail-outside-docker.sh
+++ b/scripts/fail-outside-docker.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [[ ! -f '/addons-server-docker-container' ]]; then
+  echo """
+  ERROR: This script must be run inside the docker container.
+
+  Try running your command via a make target, e.g.:
+
+  $(make)
+
+  """
+  exit 1
+fi

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -76,15 +76,13 @@ SILENCED_SYSTEM_CHECKS = (
 # LESS CSS OPTIONS (Debug only).
 LESS_PREPROCESS = True  # Compile LESS with Node, rather than client-side JS?
 LESS_LIVE_REFRESH = False  # Refresh the CSS on save?
-LESS_BIN = env('LESS_BIN', default='/deps/node_modules/less/bin/lessc')
+LESS_BIN = env('LESS_BIN', default='node_modules/less/bin/lessc')
 
 # Path to cleancss (our CSS minifier).
-CLEANCSS_BIN = env(
-    'CLEANCSS_BIN', default='/deps/node_modules/clean-css-cli/bin/cleancss'
-)
+CLEANCSS_BIN = env('CLEANCSS_BIN', default='node_modules/clean-css-cli/bin/cleancss')
 
 # Path to our JS minifier.
-JS_MINIFIER_BIN = env('JS_MINIFIER_BIN', default='/deps/node_modules/terser/bin/terser')
+JS_MINIFIER_BIN = env('JS_MINIFIER_BIN', default='node_modules/terser/bin/terser')
 
 # rsvg-convert is used to save our svg static theme previews to png
 RSVG_CONVERT_BIN = env('RSVG_CONVERT_BIN', default='rsvg-convert')
@@ -94,7 +92,7 @@ PNGCRUSH_BIN = env('PNGCRUSH_BIN', default='pngcrush')
 
 # Path to our addons-linter binary
 ADDONS_LINTER_BIN = env(
-    'ADDONS_LINTER_BIN', default='/deps/node_modules/addons-linter/bin/addons-linter'
+    'ADDONS_LINTER_BIN', default='node_modules/addons-linter/bin/addons-linter'
 )
 # --enable-background-service-worker linter flag value
 ADDONS_LINTER_ENABLE_SERVICE_WORKER = False


### PR DESCRIPTION
Relates to: ADDSRV-720

### Description

This PR adds a `preinstall` script that ensures npm install is only run inside a docker container.

Additionally this PR moves the path for node_modules to the repository root in the docker container `/data/olympia/node_modules` and mounts this as a volume in the host repostory root.

### Context

This prevents users from accidentally installing npm modules via the host which could lead to platform incompatibility errors.

when you run `npm i` on the host you'll get an error. If you run it in the docker container, it will install where the docker container expects.

### Testing