### PR TITLE
Remove obsolete `docs` job from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -567,13 +567,6 @@ jobs:
       - run:
           command: pytest -n 2 -m 'not es_tests and not needs_locales_compilation and not static_assets' -v src/olympia/devhub/
 
-  docs:
-    <<: *defaults
-    steps:
-      - setup_container:
-          wait_services: false
-      - run: make docs
-
   main:
     <<: *defaults-with-services
     steps:
@@ -656,7 +649,6 @@ workflows:
       - assets
       - codestyle
       - devhub
-      - docs
       - main
       # Uncomment if you want to test the docker build
       # - build-image


### PR DESCRIPTION
docs are built (and deployed, for commits from `master`) as a GitHub action now.

Fixes #22093