### PR TITLE
fix test_escalate_addon_no_versions_to_flag

### DIFF
--- a/src/olympia/abuse/tests/test_utils.py
+++ b/src/olympia/abuse/tests/test_utils.py
@@ -4,7 +4,7 @@ from django.urls import reverse
 
 from waffle.testutils import override_switch
 
-from olympia import amoth
+from olympia import amo
 from olympia.activity.models import ActivityLog
 from olympia.amo.tests import (
     TestCase,

--- a/src/olympia/abuse/tests/test_utils.py
+++ b/src/olympia/abuse/tests/test_utils.py
@@ -4,7 +4,7 @@ from django.urls import reverse
 
 from waffle.testutils import override_switch
 
-from olympia import amo
+from olympia import amoth
 from olympia.activity.models import ActivityLog
 from olympia.amo.tests import (
     TestCase,
@@ -532,7 +532,7 @@ class TestCinderActionAddon(BaseTestCinderAction, TestCase):
         assert NeedsHumanReview.objects.count() == 2
         ActivityLog.objects.all().delete()
 
-        action = CinderActionEscalateAddon(self.cinder_job)
+        action = CinderActionEscalateAddon(self.decision)
         assert action.process_action() == (False, None)
         assert NeedsHumanReview.objects.count() == 2
         assert ActivityLog.objects.count() == 0


### PR DESCRIPTION
https://github.com/mozilla/addons-server/pull/22052 broke a test because of a bad-ish merge (CinderAction classes changed to be created with a CinderDecision rather than a CinderJob instance, but in the meantime a different PR added `test_escalate_addon_no_versions_to_flag` that still used a CinderJob)

- https://github.com/mozilla/addons-server/commit/e2e90aed8c9123fb637b2e78d6b9ea4a07f70f37 added test_escalate_addon_no_versions_to_flag
- https://github.com/mozilla/addons-server/pull/22052 changed the classes from CinderJob to CinderDecision
- https://github.com/mozilla/addons-server/commit/c1b35673acb4860d4e1e25d0950cca1a9fe373cf was the merge commit of #22052

