### PR TITLE
Update task that resigns add-ons without a COSE signature

### DIFF
--- a/src/olympia/addons/management/commands/process_addons.py
+++ b/src/olympia/addons/management/commands/process_addons.py
@@ -83,7 +83,6 @@ class Command(ProcessObjectsCommand):
                         disabled_by_user=False,
                         type__in=(
                             amo.ADDON_EXTENSION,
-                            amo.ADDON_LPAPP,
                             amo.ADDON_STATICTHEME,
                         ),
                     )

--- a/src/olympia/addons/management/commands/process_addons.py
+++ b/src/olympia/addons/management/commands/process_addons.py
@@ -20,7 +20,7 @@ from olympia.constants.base import (
     _ADDON_WEBAPP,
 )
 from olympia.devhub.tasks import get_preview_sizes, recreate_previews
-from olympia.lib.crypto.tasks import sign_addons
+from olympia.lib.crypto.tasks import bump_and_resign_addons
 from olympia.ratings.tasks import addon_rating_aggregates
 from olympia.reviewers.tasks import recalculate_post_review_weight
 from olympia.versions.tasks import delete_list_theme_previews
@@ -72,8 +72,8 @@ class Command(ProcessObjectsCommand):
                 'task': recalculate_post_review_weight,
                 'queryset_filters': get_recalc_needed_filters(),
             },
-            'resign_addons_for_cose': {
-                'task': sign_addons,
+            'bump_and_resign_addons': {
+                'task': bump_and_resign_addons,
                 'queryset_filters': [
                     # Only resign public add-ons where the latest version has been
                     # created before the 5th of April

--- a/src/olympia/addons/management/commands/process_addons.py
+++ b/src/olympia/addons/management/commands/process_addons.py
@@ -80,6 +80,12 @@ class Command(ProcessObjectsCommand):
                     Q(
                         status=amo.STATUS_APPROVED,
                         _current_version__created__lt=datetime(2019, 4, 5),
+                        disabled_by_user=False,
+                        type__in=(
+                            amo.ADDON_EXTENSION,
+                            amo.ADDON_LPAPP,
+                            amo.ADDON_STATICTHEME,
+                        ),
                     )
                 ],
             },

--- a/src/olympia/addons/tests/test_commands.py
+++ b/src/olympia/addons/tests/test_commands.py
@@ -69,13 +69,13 @@ def test_process_addons_limit_addons():
     addon_ids = [addon_factory(status=amo.STATUS_APPROVED).id for _ in range(5)]
     assert Addon.objects.count() == 5
 
-    with count_subtask_calls(process_addons.sign_addons) as calls:
-        call_command('process_addons', task='resign_addons_for_cose')
+    with count_subtask_calls(process_addons.bump_and_resign_addons) as calls:
+        call_command('process_addons', task='bump_and_resign_addons')
         assert len(calls) == 1
         assert calls[0]['kwargs']['args'] == [addon_ids]
 
-    with count_subtask_calls(process_addons.sign_addons) as calls:
-        call_command('process_addons', task='resign_addons_for_cose', limit=2)
+    with count_subtask_calls(process_addons.bump_and_resign_addons) as calls:
+        call_command('process_addons', task='bump_and_resign_addons', limit=2)
         assert len(calls) == 1
         assert calls[0]['kwargs']['args'] == [addon_ids[:2]]
 

--- a/src/olympia/addons/tests/test_commands.py
+++ b/src/olympia/addons/tests/test_commands.py
@@ -380,10 +380,9 @@ class TestBumpAndResignAddons(TestCase):
 
             another_extension = addon_factory(file_kw=file_kw)
             a_theme = addon_factory(type=amo.ADDON_STATICTHEME, file_kw=file_kw)
-            a_langpack = addon_factory(type=amo.ADDON_LPAPP, file_kw=file_kw)
 
-            # Dictionaries won't get re-signed, same with deleted and disabled
-            # versions. Also, only public addons are being resigned
+            # Dictionaries, langpacks and non-public add-ons won't be bumped.
+            addon_factory(type=amo.ADDON_LPAPP, file_kw=file_kw)
             addon_factory(type=amo.ADDON_DICT, file_kw=file_kw)
             addon_factory(status=amo.STATUS_DISABLED, file_kw=file_kw)
             addon_factory(status=amo.STATUS_AWAITING_REVIEW, file_kw=file_kw)
@@ -397,11 +396,10 @@ class TestBumpAndResignAddons(TestCase):
 
         call_command('process_addons', task='bump_and_resign_addons')
 
-        assert bump_addon_version_mock.call_count == 4
+        assert bump_addon_version_mock.call_count == 3
         assert {call[0][0] for call in bump_addon_version_mock.call_args_list} == {
             addon_with_history.current_version,
             another_extension.current_version,
-            a_langpack.current_version,
             a_theme.current_version,
         }
 

--- a/src/olympia/addons/tests/test_commands.py
+++ b/src/olympia/addons/tests/test_commands.py
@@ -373,25 +373,26 @@ class TestResignAddonsForCose(TestCase):
             version_factory(addon=addon_with_history, file_kw=file_kw)
             version_factory(addon=addon_with_history, file_kw=file_kw)
 
-            addon_factory(file_kw=file_kw)
-            addon_factory(type=amo.ADDON_STATICTHEME, file_kw=file_kw)
-            addon_factory(type=amo.ADDON_LPAPP, file_kw=file_kw)
+            another_addon = addon_factory(file_kw=file_kw)
+            a_theme = addon_factory(type=amo.ADDON_STATICTHEME, file_kw=file_kw)
+            a_langpack = addon_factory(type=amo.ADDON_LPAPP, file_kw=file_kw)
+
+            # Dictionaries won't get re-signed, same with deleted and disabled
+            # versions. Also, only public addons are being resigned
             addon_factory(type=amo.ADDON_DICT, file_kw=file_kw)
+            addon_factory(status=amo.STATUS_DISABLED, file_kw=file_kw)
+            addon_factory(status=amo.STATUS_AWAITING_REVIEW, file_kw=file_kw)
+            addon_factory(status=amo.STATUS_NULL, file_kw=file_kw)
+            addon_factory(disabled_by_user=True, file_kw=file_kw)
 
         # Don't resign add-ons created after April 4th 2019
         with freeze_time('2019-05-01'):
             addon_factory(file_kw=file_kw)
             addon_factory(type=amo.ADDON_STATICTHEME, file_kw=file_kw)
 
-        # Search add-ons won't get re-signed, same with deleted and disabled
-        # versions. Also, only public addons are being resigned
-        addon_factory(status=amo.STATUS_DISABLED, file_kw=file_kw)
-        addon_factory(status=amo.STATUS_AWAITING_REVIEW, file_kw=file_kw)
-        addon_factory(status=amo.STATUS_NULL, file_kw=file_kw)
-
         call_command('process_addons', task='resign_addons_for_cose')
 
-        assert sign_file_mock.call_count == 5
+        assert sign_file_mock.call_count == 4
 
 
 class TestDeleteObsoleteAddons(TestCase):

--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -814,7 +814,7 @@ class REJECT_VERSION_DELAYED(_LOG):
 class VERSION_RESIGNED(_LOG):
     # takes add-on, version, VersionString
     id = 166
-    format = _('{addon} {version} re-signed (previously {0}).')
+    format = _('{addon} {version} automatically created and signed from {0}.')
     short = _('Version re-signed')
     review_queue = True
 

--- a/src/olympia/files/tests/test_utils.py
+++ b/src/olympia/files/tests/test_utils.py
@@ -1232,28 +1232,6 @@ def test_extract_extension_to_dest_invalid_archive():
 
 
 @pytestmark
-def test_bump_version_in_manifest_json():
-    AppVersion.objects.create(
-        application=amo.FIREFOX.id, version=amo.DEFAULT_WEBEXT_MIN_VERSION
-    )
-    AppVersion.objects.create(
-        application=amo.FIREFOX.id, version=amo.DEFAULT_WEBEXT_MAX_VERSION
-    )
-    AppVersion.objects.create(
-        application=amo.ANDROID.id, version=amo.DEFAULT_WEBEXT_MIN_VERSION_ANDROID
-    )
-    AppVersion.objects.create(
-        application=amo.ANDROID.id, version=amo.DEFAULT_WEBEXT_MAX_VERSION
-    )
-    file_obj = amo.tests.addon_factory(
-        file_kw={'filename': 'webextension.xpi'}
-    ).current_version.file
-    utils.update_version_number(file_obj, '0.0.1.1-signed')
-    parsed = utils.parse_xpi(file_obj.file.path)
-    assert parsed['version'] == '0.0.1.1-signed'
-
-
-@pytestmark
 def test_extract_translations_simple():
     file_obj = amo.tests.addon_factory(
         file_kw={'filename': 'notify-link-clicks-i18n.xpi'}

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -1041,14 +1041,6 @@ def get_sha256(file_obj):
     return hash_.hexdigest()
 
 
-def update_version_number_in_place(file_path, new_version_number):
-    """Update the manifest of an xpi file path to have the new version number."""
-    with zipfile.ZipFile(file_path, 'rw') as file_:
-        content = file_.read('manifest.json')
-        content = _update_version_in_json_manifest(content, new_version_number)
-        file_.writestr(file_, content)
-
-
 class InvalidOrUnsupportedCrx(Exception):
     pass
 
@@ -1112,14 +1104,6 @@ def write_crx_as_xpi(chunks, target):
                 data = tmp.read(65536)
 
     return hash_value
-
-
-def _update_version_in_json_manifest(content, new_version_number):
-    """Change the version number in the json manifest file provided."""
-    updated = json.loads(content)
-    if 'version' in updated:
-        updated['version'] = new_version_number
-    return json.dumps(updated)
 
 
 def extract_translations(file_obj):

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -1041,23 +1041,12 @@ def get_sha256(file_obj):
     return hash_.hexdigest()
 
 
-def update_version_number(file_obj, new_version_number):
-    """Update the manifest to have the new version number."""
-    # Create a new xpi with the updated version.
-    updated = f'{file_obj.file.path}.updated_version_number'
-    # Copy the original XPI, with the updated manifest.json.
-    with zipfile.ZipFile(file_obj.file.path, 'r') as source:
-        file_list = source.infolist()
-        with zipfile.ZipFile(updated, 'w', zipfile.ZIP_DEFLATED) as dest:
-            for file_ in file_list:
-                content = source.read(file_.filename)
-                if file_.filename == 'manifest.json':
-                    content = _update_version_in_json_manifest(
-                        content, new_version_number
-                    )
-                dest.writestr(file_, content)
-    # Move the updated file to the original file.
-    os.replace(updated, file_obj.file.path)
+def update_version_number_in_place(file_path, new_version_number):
+    """Update the manifest of an xpi file path to have the new version number."""
+    with zipfile.ZipFile(file_path, 'rw') as file_:
+        content = file_.read('manifest.json')
+        content = _update_version_in_json_manifest(content, new_version_number)
+        file_.writestr(file_, content)
 
 
 class InvalidOrUnsupportedCrx(Exception):

--- a/src/olympia/lib/crypto/tasks.py
+++ b/src/olympia/lib/crypto/tasks.py
@@ -20,38 +20,24 @@ from olympia.versions.models import Version
 log = olympia.core.logger.getLogger('z.task')
 
 
-MAIL_COSE_SUBJECT = (
-    'Your Firefox extension has been re-signed with a stronger signature'
-)
+MAIL_COSE_SUBJECT = 'Your Firefox add-on has been re-signed'
 
 MAIL_COSE_MESSAGE = """
-Hello,
+Greetings from the Firefox Add-ons team!
 
-Mozilla has recently upgraded the signing [1] for Firefox extensions, themes,
-dictionaries, and langpacks to provide a stronger signature. All add-on
-versions uploaded to addons.mozilla.org after April 5, 2019 have this
-signature. We plan to stop accepting the old signature with Firefox 70 [2].
+Per our previous communication, this email is to confirm that the most recent
+publicly available version of your add-on has now been re-signed with a
+stronger signature for a more secure add-ons ecosystem. It will remain
+backwards compatible with previous versions of Firefox.
 
-The current version of your add-on, {addon}, listed on addons.mozilla.org has
-been automatically re-signed with the stronger signature. Your add-on will
-remain backwards compatible with previous versions of Firefox, including ESR 68
-[3], and will continue working when your users upgrade to Firefox 70.
+Please be aware that to re-sign add-ons automatically we had to clone the
+latest public version of your add-on, bump the version number and then re-sign,
+so don’t be alarmed if you see that your add-on’s version number has increased.
 
-You do not need to take any action at this time.
+Please feel free to reply to this email if you have any questions.
 
 Regards,
-
-The Add-ons Team
-
----
-[1] https://extensionworkshop.com/documentation/publish/signing-and-distribution-overview/
-[2] https://wiki.mozilla.org/Release_Management/Calendar
-[3] https://www.mozilla.org/firefox/enterprise/
---
-
-You have received this email because you are a registered developer of a
-Firefox add-on. If you do not want to receive these updates regarding your
-add-on, please sign in to addons.mozilla.org and delete your add-on(s).
+Firefox Add-ons team
 """  # noqa: E501
 
 

--- a/src/olympia/lib/crypto/tasks.py
+++ b/src/olympia/lib/crypto/tasks.py
@@ -2,7 +2,9 @@ import json
 import os
 import zipfile
 
+from django.conf import settings
 from django.db import transaction
+from django.utils import translation
 
 import olympia.core.logger
 from olympia import amo
@@ -20,14 +22,14 @@ from olympia.versions.models import Version
 log = olympia.core.logger.getLogger('z.task')
 
 
-MAIL_COSE_SUBJECT = 'Your Firefox add-on has been re-signed'
+MAIL_COSE_SUBJECT = 'Your Firefox add-on {addon} has been re-signed'
 
 MAIL_COSE_MESSAGE = """
 Greetings from the Firefox Add-ons team!
 
 Per our previous communication, this email is to confirm that the most recent
-publicly available version of your add-on has now been re-signed with a
-stronger signature for a more secure add-ons ecosystem. It will remain
+publicly available version of your add-on, {addon}, has now been re-signed with
+a stronger signature for a more secure add-ons ecosystem. It will remain
 backwards compatible with previous versions of Firefox.
 
 Please be aware that to re-sign add-ons automatically we had to clone the
@@ -71,7 +73,7 @@ def copy_bumping_version_number(src, dst, new_version_number):
     # the old zip file and modifying it, we open the old one, copy the contents
     # of each file it contains to the new one, altering the manifest.json when
     # we run into it.
-    os.makedirs(os.path.dirname(dst))
+    os.makedirs(os.path.dirname(dst), exist_ok=True)
     with zipfile.ZipFile(src, 'r') as source:
         file_list = source.infolist()
         with zipfile.ZipFile(dst, 'w', zipfile.ZIP_DEFLATED) as dest:
@@ -85,133 +87,132 @@ def copy_bumping_version_number(src, dst, new_version_number):
 
 
 @task
-def sign_addons(addon_ids):
-    """Used to sign all the versions of an addon.
+def bump_and_resign_addons(addon_ids):
+    """Used to bump and resign the current version of specified add-ons..
 
-    This is used in the 'process_addons --task resign_addons_for_cose'
+    This is used in the 'process_addons --task bump_and_resign_addons'
     management command.
 
-    This is also used to resign some promoted addons after they've been added
-    to a group (or paid).
-
-    It also bumps the version number of the file and the Version, so the
-    Firefox extension update mechanism picks this new signed version and
-    installs it.
+    It creates a new version from the current version, bumping the version
+    number inside the manifest and on the version instance, and that new
+    version replaces the current version, so the Firefox extension update
+    mechanism will pick this new signed version up and will install it.
     """
     log.info(f'[{len(addon_ids)}] Signing addons.')
-
-    mail_subject, mail_message = MAIL_COSE_SUBJECT, MAIL_COSE_MESSAGE
 
     current_versions = Addon.objects.filter(id__in=addon_ids).values_list(
         '_current_version', flat=True
     )
     qs = Version.objects.filter(id__in=current_versions)
 
+    with translation.override(settings.LANGUAGE_CODE):
+        for old_version in qs:
+            bump_addon_version(old_version)
+
+
+def bump_addon_version(old_version):
+    mail_subject, mail_message = MAIL_COSE_SUBJECT, MAIL_COSE_MESSAGE
     task_user = get_task_user()
-
-    for old_version in qs:
-        addon = old_version.addon
-        old_file_obj = old_version.file
-        # We only sign files that have been reviewed
-        if old_file_obj.status not in amo.APPROVED_STATUSES:
-            log.info(
-                'Not signing addon {}, version {} (no files)'.format(
-                    old_version.addon, old_version
-                )
+    addon = old_version.addon
+    old_file_obj = old_version.file
+    # We only sign files that have been reviewed
+    if old_file_obj.status not in amo.APPROVED_STATUSES:
+        log.info(
+            'Not signing addon {}, version {} (no files)'.format(
+                old_version.addon, old_version
             )
-            continue
+        )
+        return
 
-        log.info(f'Bumping addon {old_version.addon}, version {old_version}')
-        bumped_version_number = get_new_version_number(old_version.version)
-        did_sign = False  # Did we sign at the file?
+    log.info(f'Bumping addon {old_version.addon}, version {old_version}')
+    bumped_version_number = get_new_version_number(old_version.version)
 
-        if not old_file_obj.file or not os.path.isfile(old_file_obj.file.path):
-            log.info(f'File {old_file_obj.pk} does not exist, skip')
-            continue
+    if not old_file_obj.file or not os.path.isfile(old_file_obj.file.path):
+        log.info(f'File {old_file_obj.pk} does not exist, skip')
+        return
 
-        old_validation = (
-            old_file_obj.validation.validation
-            if old_file_obj.has_been_validated
-            else None
+    old_validation = (
+        old_file_obj.validation.validation if old_file_obj.has_been_validated else None
+    )
+
+    try:
+        # Copy the original file to a new FileUpload.
+        task_user = get_task_user()
+        # last login ip should already be set in the database even on the
+        # task user, but in case it's not, like in tests/local envs, set it
+        # on the instance, forcing it to be localhost, that should be
+        # enough for our needs.
+        task_user.last_login_ip = '127.0.0.1'
+        original_author = addon.authors.first()
+        upload = FileUpload.objects.create(
+            addon=addon,
+            version=bumped_version_number,
+            user=task_user,
+            channel=amo.CHANNEL_LISTED,
+            source=amo.UPLOAD_SOURCE_GENERATED,
+            ip_address=task_user.last_login_ip,
+            validation=old_validation,
+        )
+        upload.name = f'{upload.uuid.hex}_{bumped_version_number}.zip'
+        upload.path = upload.generate_path('.zip')
+        upload.valid = True
+        upload.save()
+
+        # Create the xpi with the bumped version number.
+        copy_bumping_version_number(
+            old_file_obj.file.path, upload.file_path, bumped_version_number
         )
 
-        try:
-            # Copy the original file to a new FileUpload.
-            task_user = get_task_user()
-            # last login ip should already be set in the database even on the
-            # task user, but in case it's not, like in tests/local envs, set it
-            # on the instance, forcing it to be localhost, that should be
-            # enough for our needs.
-            task_user.last_login_ip = '127.0.0.1'
-            original_author = addon.authors.first()
-            upload = FileUpload.objects.create(
-                addon=addon,
-                version=bumped_version_number,
-                user=task_user,
+        # Parse the add-on. We use the original author of the add-on, not
+        # the task user, in case they have special permissions allowing
+        # the original version to be submitted.
+        parsed_data = parse_addon(upload, addon=addon, user=original_author)
+        parsed_data['approval_notes'] = old_version.approval_notes
+
+        with transaction.atomic():
+            # Create a version object out of the FileUpload + parsed data.
+            new_version = Version.from_upload(
+                upload,
+                old_version.addon,
+                compatibility=old_version.compatible_apps,
                 channel=amo.CHANNEL_LISTED,
-                source=amo.UPLOAD_SOURCE_GENERATED,
-                ip_address=task_user.last_login_ip,
-                validation=old_validation,
-            )
-            upload.name = f'{upload.uuid.hex}_{bumped_version_number}.zip'
-            upload.path = upload.generate_path('.zip')
-            upload.valid = True
-            upload.save()
-
-            # Create the xpi with the bumped version number.
-            copy_bumping_version_number(
-                old_file_obj.file.path, upload.file_path, bumped_version_number
+                parsed_data=parsed_data,
             )
 
-            # Parse the add-on. We use the original author of the add-on, not
-            # the task user, in case they have special permissions allowing
-            # the original version to be submitted.
-            parsed_data = parse_addon(upload, addon=addon, user=original_author)
-            parsed_data['approval_notes'] = old_version.approval_notes
+            # Sign it (may raise SigningError).
+            sign_file(new_version.file)
 
-            with transaction.atomic():
-                # Create a version object out of the FileUpload + parsed data.
-                new_version = Version.from_upload(
-                    upload,
-                    old_version.addon,
-                    compatibility=old_version.compatible_apps,
-                    channel=amo.CHANNEL_LISTED,
-                    parsed_data=parsed_data,
-                )
-
-                # Sign it (may raise SigningError).
-                sign_file(new_version.file)
-
-                # Approve it.
-                new_version.file.update(
-                    approval_date=new_version.file.created,
-                    datestatuschanged=new_version.file.created,
-                    status=amo.STATUS_APPROVED,
-                )
-
-        except Exception:
-            log.exception(f'Failed re-signing file {old_file_obj.pk}', exc_info=True)
-
-        # Now update the Version model, if we signed at least one file.
-        if did_sign:
-            ActivityLog.objects.create(
-                amo.LOG.VERSION_RESIGNED,
-                addon,
-                new_version,
-                str(old_version.version),
-                user=task_user,
+            # Approve it.
+            new_version.file.update(
+                approval_date=new_version.file.created,
+                datestatuschanged=new_version.file.created,
+                status=amo.STATUS_APPROVED,
             )
-            # Send a mail to the owners warning them we've automatically
-            # created and signed a new version of their addon.
-            qs = AddonUser.objects.filter(
-                role=amo.AUTHOR_ROLE_OWNER, addon=addon
-            ).exclude(user__email__isnull=True)
-            emails = qs.values_list('user__email', flat=True)
-            subject = mail_subject
-            message = mail_message.format(addon=addon.name)
-            amo.utils.send_mail(
-                subject,
-                message,
-                recipient_list=emails,
-                headers={'Reply-To': 'amo-admins@mozilla.com'},
-            )
+
+    except Exception:
+        log.exception(f'Failed re-signing file {old_file_obj.pk}', exc_info=True)
+        return
+
+    # Now notify the developers of that add-on. Any exception should have
+    # caused an early return before reaching this point.
+    ActivityLog.objects.create(
+        amo.LOG.VERSION_RESIGNED,
+        addon,
+        new_version,
+        str(old_version.version),
+        user=task_user,
+    )
+    # Send a mail to the owners warning them we've automatically created and
+    # signed a new version of their addon.
+    qs = AddonUser.objects.filter(role=amo.AUTHOR_ROLE_OWNER, addon=addon).exclude(
+        user__email__isnull=True
+    )
+    emails = qs.values_list('user__email', flat=True)
+    subject = mail_subject.format(addon=addon.name)
+    message = mail_message.format(addon=addon.name)
+    amo.utils.send_mail(
+        subject,
+        message,
+        recipient_list=emails,
+        headers={'Reply-To': 'amo-admins@mozilla.com'},
+    )

--- a/src/olympia/lib/crypto/tasks.py
+++ b/src/olympia/lib/crypto/tasks.py
@@ -56,6 +56,7 @@ def get_new_version_number(version):
     # there).
     parts[-1].b = 'resigned'
     parts[-1].c = 1
+    parts[-1].d = ''
     return VersionString('.'.join(str(part) for part in parts))
 
 

--- a/src/olympia/lib/crypto/tasks.py
+++ b/src/olympia/lib/crypto/tasks.py
@@ -97,7 +97,7 @@ def copy_bumping_version_number(src, dst, new_version_number):
 
 
 @task
-def sign_addons(addon_ids, force=False, send_emails=True, **kw):
+def sign_addons(addon_ids):
     """Used to sign all the versions of an addon.
 
     This is used in the 'process_addons --task resign_addons_for_cose'
@@ -212,18 +212,17 @@ def sign_addons(addon_ids, force=False, send_emails=True, **kw):
                 str(old_version.version),
                 user=task_user,
             )
-            if send_emails:
-                # Send a mail to the owners warning them we've automatically
-                # created and signed a new version of their addon.
-                qs = AddonUser.objects.filter(
-                    role=amo.AUTHOR_ROLE_OWNER, addon=addon
-                ).exclude(user__email__isnull=True)
-                emails = qs.values_list('user__email', flat=True)
-                subject = mail_subject
-                message = mail_message.format(addon=addon.name)
-                amo.utils.send_mail(
-                    subject,
-                    message,
-                    recipient_list=emails,
-                    headers={'Reply-To': 'amo-admins@mozilla.com'},
-                )
+            # Send a mail to the owners warning them we've automatically
+            # created and signed a new version of their addon.
+            qs = AddonUser.objects.filter(
+                role=amo.AUTHOR_ROLE_OWNER, addon=addon
+            ).exclude(user__email__isnull=True)
+            emails = qs.values_list('user__email', flat=True)
+            subject = mail_subject
+            message = mail_message.format(addon=addon.name)
+            amo.utils.send_mail(
+                subject,
+                message,
+                recipient_list=emails,
+                headers={'Reply-To': 'amo-admins@mozilla.com'},
+            )

--- a/src/olympia/lib/crypto/tasks.py
+++ b/src/olympia/lib/crypto/tasks.py
@@ -54,14 +54,17 @@ add-on, please sign in to addons.mozilla.org and delete your add-on(s).
 def get_new_version_number(version):
     # Parse existing version number, increment the last part, and replace
     # the suffix with "resigned1", in order to get a new version number that
-    # would force existing users to upgrade.
-    # Example: '1.0' would return '1.1resigned1'.
+    # would force existing users to upgrade while making it explicit this is
+    # an automatic re-sign. For example, '1.0' would return '1.1resigned1'.
     vs = VersionString(version)
     parts = vs.vparts
+    # We're always incrementing the last "number".
     parts[-1].a += 1
+    # The "suffix" is always "resigned1" (potentially overriding whatever was
+    # there).
     parts[-1].b = 'resigned'
     parts[-1].c = 1
-    return str(VersionString.from_vparts(parts))
+    return VersionString('.'.join(str(part) for part in parts))
 
 
 @task

--- a/src/olympia/lib/crypto/tasks.py
+++ b/src/olympia/lib/crypto/tasks.py
@@ -25,7 +25,7 @@ log = olympia.core.logger.getLogger('z.task')
 MAIL_COSE_SUBJECT = 'Your Firefox add-on {addon} has been re-signed'
 
 MAIL_COSE_MESSAGE = """
-Greetings from the Firefox Add-ons team!
+Greetings from the Mozilla Add-ons Team!
 
 Per our previous communication, this email is to confirm that the most recent
 publicly available version of your add-on, {addon}, has now been re-signed with
@@ -34,12 +34,12 @@ backwards compatible with previous versions of Firefox.
 
 Please be aware that to re-sign add-ons automatically we had to clone the
 latest public version of your add-on, bump the version number and then re-sign,
-so don’t be alarmed if you see that your add-on’s version number has increased.
+so don't be alarmed if you see that your add-on's version number has increased.
 
 Please feel free to reply to this email if you have any questions.
 
 Regards,
-Firefox Add-ons team
+Mozilla Add-ons Team
 """  # noqa: E501
 
 
@@ -62,8 +62,7 @@ def get_new_version_number(version):
 def update_version_in_json_manifest(content, new_version_number):
     """Change the version number in the json manifest file provided."""
     updated = json.loads(content)
-    if 'version' in updated:
-        updated['version'] = new_version_number
+    updated['version'] = new_version_number
     return json.dumps(updated)
 
 

--- a/src/olympia/lib/crypto/tests/test_signing.py
+++ b/src/olympia/lib/crypto/tests/test_signing.py
@@ -22,7 +22,6 @@ from waffle.testutils import override_switch
 
 from olympia import amo
 from olympia.activity.models import ActivityLog
-from olympia.addons.models import AddonUser
 from olympia.amo.tests import (
     TestCase,
     addon_factory,
@@ -614,7 +613,6 @@ class TestTasks(TestCase):
 
         # Make sure we haven't touched the existing version and its file.
         self.assert_existing_version_was_untouched()
-        
 
     @mock.patch('olympia.lib.crypto.tasks.sign_file')
     def test_sign_bump_non_ascii_filename(self, mock_sign_file):

--- a/src/olympia/lib/crypto/tests/test_signing.py
+++ b/src/olympia/lib/crypto/tests/test_signing.py
@@ -25,7 +25,7 @@ from olympia.addons.models import AddonUser
 from olympia.amo.tests import TestCase, addon_factory, version_factory
 from olympia.constants.promoted import LINE, RECOMMENDED, SPOTLIGHT
 from olympia.lib.crypto import signing, tasks
-from olympia.versions.compare import version_int
+from olympia.versions.compare import VersionString, version_int
 
 
 def _get_signature_details(path):
@@ -735,17 +735,27 @@ class TestTasks(TestCase):
 
 
 @pytest.mark.parametrize(
-    ('old', 'new'),
+    ('old_version', 'expected_version'),
     [
-        ('1.1', '1.1.1-signed'),
-        ('1.1.1-signed.1', '1.1.1-signed.1.1-signed'),
-        ('1.1.1-signed', '1.1.1-signed-2'),
-        ('1.1.1-signed-3', '1.1.1-signed-4'),
-        ('1.1.1-signed.1-signed-16', '1.1.1-signed.1-signed-17'),
+        ('1.1', '1.2resigned1'),
+        ('1.2.3resigned1', '1.2.4resigned1'),
+        ('1.1.1b', '1.1.2resigned1'),
+        ('1.1.1b3', '1.1.2resigned1'),
+        ('1.1.1b.1c-16', '1.1.1b.2resigned1'),
+        ('1.2.3.4', '1.2.3.5resigned1'),
+        ('2.0a1', '2.1resigned1'),
+        ('0.2.0b1', '0.2.1resigned1'),
+        ('40007.2024.3.42c', '40007.2024.3.43resigned1'),
+        ('1.01b.78', '1.1b.79resigned1'),
+        ('1.2.5_5', '1.2.6resigned1'),
+        ('714.16G', '714.17resigned1'),
+        ('999999999999999999999999999999', '1000000000000000000000000000000resigned1'),
     ],
 )
-def test_get_new_version_number(old, new):
-    assert tasks.get_new_version_number(old) == new
+def test_get_new_version_number(old_version, expected_version):
+    new_version = tasks.get_new_version_number(old_version)
+    assert new_version == VersionString(expected_version)
+    assert str(new_version) == expected_version
 
 
 class TestSignatureInfo:

--- a/src/olympia/lib/crypto/tests/test_signing.py
+++ b/src/olympia/lib/crypto/tests/test_signing.py
@@ -569,7 +569,7 @@ class TestTasks(TestCase):
         # rewritten by update_version_number() in sign_addons().
         assert mock_sign_file.call_count == 1
         self.version.reload()
-        assert self.version.version == '0.0.1.1-signed'
+        assert self.version.version == '0.0.2resigned1'
         self.file_.reload()  # Otherwise self.file_.file doesn't get re-opened
         assert file_hash != self.file_.generate_hash()
         self.assert_backup()
@@ -602,21 +602,7 @@ class TestTasks(TestCase):
         tasks.sign_addons([self.addon.pk])
         assert mock_sign_file.called
         self.version.reload()
-        assert self.version.version == '0.0.1.1-signed'
-        self.file_.reload()  # Otherwise self.file_.file doesn't get re-opened
-        assert file_hash != self.file_.generate_hash()
-        self.assert_backup()
-
-    @mock.patch('olympia.lib.crypto.tasks.sign_file')
-    def test_sign_bump_non_ascii_version(self, mock_sign_file):
-        """Sign versions which have non-ascii version numbers."""
-        self.version.update(version='é0.0.1')
-        file_hash = self.file_.generate_hash()
-        assert self.version.version == 'é0.0.1'
-        tasks.sign_addons([self.addon.pk])
-        assert mock_sign_file.called
-        self.version.reload()
-        assert self.version.version == 'é0.0.1.1-signed'
+        assert self.version.version == '0.0.2resigned1'
         self.file_.reload()  # Otherwise self.file_.file doesn't get re-opened
         assert file_hash != self.file_.generate_hash()
         self.assert_backup()
@@ -630,7 +616,7 @@ class TestTasks(TestCase):
         tasks.sign_addons([self.addon.pk])
         assert mock_sign_file.called
         self.version.reload()
-        assert self.version.version == '0.0.1.1-signed'
+        assert self.version.version == '0.0.2resigned1'
         self.file_.reload()  # Otherwise self.file_.file doesn't get re-opened
         assert file_hash != self.file_.generate_hash()
         self.assert_backup()
@@ -645,7 +631,7 @@ class TestTasks(TestCase):
             tasks.sign_addons([self.addon.pk])
             assert mock_sign_file.called
             self.version.reload()
-            assert self.version.version == '0.0.1.1-signed'
+            assert self.version.version == '0.0.2resigned1'
             self.file_.reload()  # Otherwise self.file_.file doesn't get re-opened
             assert file_hash != self.file_.generate_hash()
             self.assert_backup()
@@ -705,7 +691,7 @@ class TestTasks(TestCase):
         assert mock_sign_file.call_count == 1
 
         new_current_version.reload()
-        assert new_current_version.version == '0.0.2.1-signed'
+        assert new_current_version.version == '0.0.3resigned1'
         new_file.reload()  # Otherwise new_file.file doesn't get re-opened
         assert new_file_hash != new_file.generate_hash()
 

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -843,6 +843,7 @@ CELERY_TASK_ROUTES = {
     'olympia.versions.tasks.hard_delete_versions': {'queue': 'adhoc'},
     'olympia.activity.tasks.create_ratinglog': {'queue': 'adhoc'},
     'olympia.files.tasks.extract_host_permissions': {'queue': 'adhoc'},
+    'olympia.lib.crypto.tasks.bump_and_resign_addons': {'queue': 'adhoc'},
     # Misc AMO tasks.
     'olympia.blocklist.tasks.monitor_remote_settings': {'queue': 'amo'},
     'olympia.abuse.tasks.appeal_to_cinder': {'queue': 'amo'},
@@ -921,11 +922,10 @@ CELERY_TASK_ROUTES = {
     'olympia.addons.tasks.flag_high_hotness_according_to_review_tier': {
         'queue': 'cron'
     },
-    'olympia.reviewers.tasks.recalculate_post_review_weight': {'queue': 'cron'},
     'olympia.users.tasks.sync_suppressed_emails_task': {'queue': 'cron'},
     'olympia.users.tasks.send_suppressed_email_confirmation': {'queue': 'devhub'},
     # Reviewers.
-    'olympia.lib.crypto.tasks.sign_addons': {'queue': 'reviewers'},
+    'olympia.reviewers.tasks.recalculate_post_review_weight': {'queue': 'reviewers'},
     # Admin.
     'olympia.scanners.tasks.mark_yara_query_rule_as_completed_or_aborted': {
         'queue': 'zadmin'

--- a/src/olympia/promoted/models.py
+++ b/src/olympia/promoted/models.py
@@ -96,26 +96,11 @@ class PromotedAddon(ModelBase):
     def approve_for_addon(self):
         """This sets up the addon as approved for the current promoted group.
 
-        The current version will be signed for approval, and if there's special
-        signing needed for that group the version will be resigned."""
-        from olympia.lib.crypto.tasks import sign_addons
+        The current version will be signed for approval."""
 
         if not self.addon.current_version:
             return
         self.approve_for_version(self.addon.current_version)
-        if self.group.autograph_signing_states:
-            sign_addons([self.addon.id], send_emails=False)
-
-    def get_resigned_version_number(self):
-        """Returns what the new version number would be if approved_for_addon
-        was called.  If no version would be signed return None."""
-        from olympia.lib.crypto.tasks import get_new_version_number
-
-        version = self.addon.current_version
-        if version and not version.is_unreviewed:
-            return get_new_version_number(version.version)
-        else:
-            return None
 
     def save(self, *args, **kwargs):
         due_date = kwargs.pop('_due_date', None)

--- a/src/olympia/promoted/tests/test_models.py
+++ b/src/olympia/promoted/tests/test_models.py
@@ -1,10 +1,8 @@
 from datetime import datetime
-from unittest import mock
 
 from django.conf import settings
 
 from olympia import amo, core
-from olympia.activity.models import ActivityLog
 from olympia.addons.models import AddonReviewerFlags
 from olympia.amo.tests import TestCase, addon_factory, user_factory, version_factory
 from olympia.constants import applications, promoted
@@ -275,8 +273,7 @@ class TestPromotedAddon(TestCase):
         assert listed_ver.reload().due_date == specified_due_date
         assert unlisted_ver.reload().due_date == specified_due_date
 
-    @mock.patch('olympia.lib.crypto.tasks.sign_file')
-    def test_approve_for_addon(self, mock_sign_file):
+    def test_approve_for_addon(self):
         core.set_user(user_factory())
         promo = PromotedAddon.objects.create(
             addon=addon_factory(
@@ -285,54 +282,11 @@ class TestPromotedAddon(TestCase):
             ),
             group_id=promoted.SPOTLIGHT.id,
         )
-        file_ = promo.addon.current_version.file
         # SPOTLIGHT doesnt have special signing states so won't be resigned
         # approve_for_addon is called automatically - SPOTLIGHT has immediate_approval
         promo.addon.reload()
         assert promo.addon.promoted_group() == promoted.SPOTLIGHT
         assert promo.addon.current_version.version == '0.123a'
-        mock_sign_file.assert_not_called()
-
-        # VERIFIED does though.
-        promo.update(group_id=promoted.VERIFIED.id)
-        promo.addon.reload()
-        assert promo.addon.promoted_group() == promoted.NOT_PROMOTED
-        promo.approve_for_addon()
-        promo.addon.reload()
-        assert promo.addon.promoted_group() == promoted.VERIFIED
-        assert promo.addon.current_version.version == '0.123a.1-signed'
-        mock_sign_file.assert_called_with(file_)
-        assert (
-            ActivityLog.objects.for_addons((promo.addon,))
-            .filter(action=amo.LOG.VERSION_RESIGNED.id)
-            .exists()
-        )
-        alog = ActivityLog.objects.filter(action=amo.LOG.VERSION_RESIGNED.id).get()
-        assert alog.user == self.task_user
-        assert '0.123a.1-signed</a> re-signed (previously 0.123a)' in (str(alog))
-
-    def test_get_resigned_version_number(self):
-        addon = addon_factory(
-            version_kw={'version': '0.123a'},
-            file_kw={'status': amo.STATUS_AWAITING_REVIEW},
-        )
-        promo = PromotedAddon.objects.create(addon=addon, group_id=promoted.VERIFIED.id)
-        assert addon.current_version is not None
-        assert promo.get_resigned_version_number() is None
-
-        addon.current_version.file.update(status=amo.STATUS_APPROVED)
-        assert promo.get_resigned_version_number() == '0.123a.1-signed'
-
-        addon.current_version.update(version='123.4.1-signed')
-        assert promo.get_resigned_version_number() == '123.4.1-signed-2'
-
-        addon.current_version.update(version='123.4.1-signed-2')
-        assert promo.get_resigned_version_number() == '123.4.1-signed-3'
-
-        addon.current_version.delete()
-        addon.reload()
-        assert addon.current_version is None
-        assert promo.get_resigned_version_number() is None
 
     def test_signal(self):
         addon = addon_factory(file_kw={'status': amo.STATUS_AWAITING_REVIEW})

--- a/src/olympia/versions/compare.py
+++ b/src/olympia/versions/compare.py
@@ -137,17 +137,11 @@ class VersionString(str):
             return f'{self.asdict()}'
 
         def __str__(self):
-            return f'{self.a}{self.b}{self.c}{self.d}'
+            return f'{self.a}{self.b}{(self.c or "")}{self.d}'
 
     @cached_property
     def vparts(self):
         return tuple(self.Part(vpart) for vpart in self.split('.'))
-
-    @classmethod
-    def from_vparts(cls, vparts):
-        return cls(
-            '.'.join(f'{part.a}{part.b}{(part.c or "")}{part.d}' for part in vparts)
-        )
 
     def __eq__(self, other):
         if other is None or (bool(self) ^ bool(other)):

--- a/src/olympia/versions/compare.py
+++ b/src/olympia/versions/compare.py
@@ -136,9 +136,18 @@ class VersionString(str):
         def __repr__(self):
             return f'{self.asdict()}'
 
+        def __str__(self):
+            return f'{self.a}{self.b}{self.c}{self.d}'
+
     @cached_property
     def vparts(self):
         return tuple(self.Part(vpart) for vpart in self.split('.'))
+
+    @classmethod
+    def from_vparts(cls, vparts):
+        return cls(
+            '.'.join(f'{part.a}{part.b}{(part.c or "")}{part.d}' for part in vparts)
+        )
 
     def __eq__(self, other):
         if other is None or (bool(self) ^ bool(other)):

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -509,6 +509,7 @@ class Version(OnChangeMixin, ModelBase):
                 if avs.max_id is None:
                     avs.max = avs_from_parsed_data.max
                     avs.originated_from = amo.APPVERSIONS_ORIGINATED_FROM_DEVELOPER
+            avs.pk = None  # Make sure to create new ApplicationsVersions in any case.
             avs.version = version
             avs.save()
             compatible_apps[application] = avs

--- a/src/olympia/versions/tests/test_compare.py
+++ b/src/olympia/versions/tests/test_compare.py
@@ -1,3 +1,5 @@
+import pytest
+
 from olympia.versions.compare import (
     APP_MAJOR_VERSION_PART_MAX,
     VersionString,
@@ -224,6 +226,26 @@ class TestVersionStringPart:
         assert VersionString.Part('6a1a') > VersionString.Part('5b2')
         assert VersionString.Part('6a1a') > VersionString.Part('5b')
         assert VersionString.Part('6a1a') > VersionString.Part('5')
+
+
+@pytest.mark.parametrize(
+    'version',
+    (
+        '1.0',
+        '1.2.3.4',
+        '2.0a1',
+        '0.2.0b1',
+        '40007.2024.3.42c',
+        '1.01b.78',
+        '1.2.5_5',
+        '714.16G',
+        '999999999999999999999999999999',
+    ),
+)
+def test_version_string_back_to_str(version):
+    vs = VersionString(version)
+    assert vs == VersionString('.'.join(str(part) for part in vs.vparts))
+    assert str(vs) == version
 
 
 def test_version_dict():


### PR DESCRIPTION
### Context

This is the main task we are going to use to resign add-ons without a COSE signature, to prepare for SHA-1 deprecation.

When ran, it will:
- Pick up publicly available add-ons for which the latest listed version (`current_version` internally) was created before the threshold date, then for each of them:
  - Clone this version into an entirely new one with a new version number considered higher than the existing one
  - Approve and sign that cloned version, replacing the existing one as the latest public listed version for each add-on
  - Notify affected developers

### Testing

The unit tests should cover a bunch of different scenarios. If you want to test it manually:

- Create some add-ons and versions depending on what you want to test. The script should only care about the `current_version` of public, non-invisible add-ons (`disabled_by_user=False`, `status=amo.STATUS_APPROVED`), if that version `created` date is from before 2019-04-05 and the add-on is not a dictionary.
- Run `manage.py --task=bump_and_resign_addons` (this will return and leave the celery workers to do the work when the tasks have been created, check your celery logs to see when it's finished)
- For add-ons matching the criteria described above, they should get a new `current_version` replacing the previous one. It should have a new version number higher than the one it's replacing (and with a `resigned1` suffix to distinguish from version numbers used by the developers), including in the manifest, and be signed.
- If there are developers/owners attached to the affected add-ons they should receive an email (locally, a `FakeEmail`).

Fixes #21996