### PR TITLE
refactor get_action_helper to close appeal email loopholes

### DIFF
--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -1032,9 +1032,6 @@ class CinderDecision(ModelBase):
         action_helper = self.get_action_helper(
             overriden_action=overriden_action, appealed_action=appealed_action
         )
-        action_helper = self.get_action_helper(
-            overriden_action=overriden_action, appealed_action=appealed_action
-        )
         action_helper.notify_reporters(
             reporter_abuse_reports=reporter_abuse_reports,
             is_appeal=bool(appealed_action),

--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -198,11 +198,10 @@ class CinderJob(ModelBase):
         decision_action,
         decision_notes,
         policy_ids,
-        override=False,
     ):
         """This is called for cinder originated decisions.
         See resolve_job for reviewer tools originated decisions."""
-        prior_decision = self.appealed_decisions.first() or self.decision
+        overriden_action = getattr(self.decision, 'action', None)
         # We need either an AbuseReport or CinderDecision for the target props
         abuse_report_or_decision = (
             self.appealed_decisions.first() or self.abusereport_set.first()
@@ -236,22 +235,15 @@ class CinderJob(ModelBase):
         ).without_parents_if_their_children_are_present()
         self.decision.policies.add(*policies)
         action_helper = self.decision.get_action_helper(
-            prior_decision and prior_decision.action, override=override
+            overriden_action=overriden_action,
+            appealed_action=getattr(self.appealed_decisions.first(), 'action', None),
         )
-        action_occured, log_entry = action_helper.process_action()
-        if (
-            not prior_decision
-            or prior_decision.action != self.decision.action
-            or self.decision.action == DECISION_ACTIONS.AMO_APPROVE
-        ):
-            action_helper.notify_reporters(
-                reporter_abuse_reports=self.get_reporter_abuse_reports(),
-                is_appeal=self.is_appeal,
-            )
-        if action_occured:
-            action_helper.notify_owners(
-                log_entry_id=(log_entry.id if log_entry else None)
-            )
+        log_entry = action_helper.process_action()
+        action_helper.notify_reporters(
+            reporter_abuse_reports=self.get_reporter_abuse_reports(),
+            is_appeal=self.is_appeal,
+        )
+        action_helper.notify_owners(log_entry_id=getattr(log_entry, 'id', None))
 
     def resolve_job(self, *, log_entry):
         """This is called for reviewer tools originated decisions.
@@ -278,9 +270,7 @@ class CinderJob(ModelBase):
             log_entry=log_entry,
             entity_helper=entity_helper,
             reporter_abuse_reports=self.get_reporter_abuse_reports(),
-            appealed_decision_action=getattr(
-                self.appealed_decisions.first(), 'action', None
-            ),
+            appealed_action=getattr(self.appealed_decisions.first(), 'action', None),
         )
         self.update(decision=cinder_decision)
         if self.decision.is_delayed:
@@ -856,31 +846,36 @@ class CinderDecision(ModelBase):
             DECISION_ACTIONS.AMO_APPROVE: CinderActionApproveInitialDecision,
         }.get(decision_action, CinderActionNotImplemented)
 
-    def get_action_helper(self, existing_decision=None, *, override=False):
-        # Base case
+    def get_action_helper(self, *, overriden_action=None, appealed_action=None):
+        # Base case when it's a new decision, that wasn't an appeal
         CinderActionClass = self.get_action_helper_class(self.action)
-        # But we use more specific actions for certain cases:
-        # Where there was an appeal/override from a remove action to approve
-        if self.action == DECISION_ACTIONS.AMO_APPROVE and (
-            existing_decision in DECISION_ACTIONS.REMOVING
-        ):
-            CinderActionClass = (
-                CinderActionOverrideApprove
-                if override
-                else CinderActionTargetAppealApprove
-            )
+        skip_reporter_notify = False
 
-        # Where there was an appeal/override which didn't change from a remove action
-        elif self.action == existing_decision and (
-            self.action in DECISION_ACTIONS.REMOVING
-        ):
-            CinderActionClass = (
-                CinderActionNotImplemented
-                if override
-                else CinderActionTargetAppealRemovalAffirmation
-            )
+        if appealed_action:
+            # target appeal
+            if appealed_action in DECISION_ACTIONS.REMOVING:
+                if self.action == DECISION_ACTIONS.AMO_APPROVE:
+                    # i.e. we've reversed our target takedown
+                    CinderActionClass = CinderActionTargetAppealApprove
+                elif self.action == appealed_action:
+                    # i.e. we've not reversed our target takedown
+                    CinderActionClass = CinderActionTargetAppealRemovalAffirmation
+            # (a reporter appeal doesn't need any alternate CinderAction class)
 
-        return CinderActionClass(decision=self)
+        elif overriden_action in DECISION_ACTIONS.REMOVING:
+            # override on a decision that was a takedown before, and wasn't an appeal
+            if self.action == DECISION_ACTIONS.AMO_APPROVE:
+                CinderActionClass = CinderActionOverrideApprove
+            if self.action == overriden_action:
+                # For an override that is still a takedown we can send the same emails
+                # to the target; but we don't want to notify the reporter again.
+                skip_reporter_notify = True
+
+        cinder_action = CinderActionClass(decision=self)
+        if skip_reporter_notify:
+            cinder_action.reporter_template_path = None
+            cinder_action.reporter_appeal_template_path = None
+        return cinder_action
 
     def can_be_appealed(self, *, is_reporter, abuse_report=None):
         """
@@ -1002,7 +997,7 @@ class CinderDecision(ModelBase):
         log_entry,
         entity_helper,
         reporter_abuse_reports=(),
-        appealed_decision_action=None,
+        appealed_action=None,
     ):
         """Calling this method calls cinder to create a decision, or notfies the content
         owner/reporter by email, or both.
@@ -1015,7 +1010,7 @@ class CinderDecision(ModelBase):
                 'Missing or invalid cinder_action for activity log entry passed to '
                 'notify_reviewer_decision'
             )
-        prior_decision_action = appealed_decision_action or self.action
+        overriden_action = self.action
         self.action = log_entry.log.cinder_action.value
 
         if self.action != DECISION_ACTIONS.AMO_APPROVE or hasattr(self, 'cinder_job'):
@@ -1034,12 +1029,16 @@ class CinderDecision(ModelBase):
                 self.save()
                 self.policies.set(policies)
 
-        action_helper = self.get_action_helper(prior_decision_action)
-        if reporter_abuse_reports:
-            action_helper.notify_reporters(
-                reporter_abuse_reports=reporter_abuse_reports,
-                is_appeal=bool(appealed_decision_action),
-            )
+        action_helper = self.get_action_helper(
+            overriden_action=overriden_action, appealed_action=appealed_action
+        )
+        action_helper = self.get_action_helper(
+            overriden_action=overriden_action, appealed_action=appealed_action
+        )
+        action_helper.notify_reporters(
+            reporter_abuse_reports=reporter_abuse_reports,
+            is_appeal=bool(appealed_action),
+        )
         if not getattr(log_entry.log, 'hide_developer', False):
             version_list = ', '.join(
                 log_entry.versionlog_set.values_list('version__version', flat=True)

--- a/src/olympia/abuse/tests/assets/cinder_webhook_appeal_confirm_disable.json
+++ b/src/olympia/abuse/tests/assets/cinder_webhook_appeal_confirm_disable.json
@@ -1,0 +1,157 @@
+{
+    "event": "decision.created",
+    "payload": {
+      "notes": "still disable it",
+      "appeal": {
+        "appealed_decision": {
+          "id": "d1f01fae-3bce-41d5-af8a-e0b4b5ceaaed",
+          "type": "queue_review",
+          "user": {
+            "name": "Ioana rusiczki",
+            "email": "irusiczki@mozilla.com",
+            "groups": [
+              {
+                "name": "API Manager"
+              },
+              {
+                "name": "Base User"
+              },
+              {
+                "name": "Everyone"
+              },
+              {
+                "name": "QA"
+              },
+              {
+                "name": "TaskUs moderators"
+              }
+            ]
+          },
+          "notes": "still disable it",
+          "policies": [
+            {
+              "id": "0d9df565-f249-40f8-8954-e73e65932ca2",
+              "name": "Acceptable Use",
+              "is_illegal": false,
+              "enforcement_actions": []
+            },
+            {
+              "id": "a9935672-c8ad-41fa-b4de-84be084ec5d5",
+              "name": "Deceptive or misleading",
+              "parent_id": "0d9df565-f249-40f8-8954-e73e65932ca2",
+              "is_illegal": false,
+              "enforcement_actions": [
+                "amo-ban-user",
+                "amo-delete-collection",
+                "amo-delete-rating",
+                "amo-disable-addon"
+              ]
+            }
+          ],
+          "policies_removed": [],
+          "enforcement_actions": [
+            "amo-ban-user",
+            "amo-delete-collection",
+            "amo-delete-rating",
+            "amo-disable-addon"
+          ],
+          "enforcement_actions_removed": []
+        }
+      },
+      "entity": {
+        "attributes": {
+          "id": "568327",
+          "body": "not yet not yet",
+          "score": 5,
+          "created": "2024-02-28T14:54:06.080905"
+        },
+        "entity_schema": "amo_rating"
+      },
+      "source": {
+        "job": {
+          "id": "5ab7cb33-a5ab-4dfa-9d72-4c2061ffeb08",
+          "queue": {
+            "slug": "amo-content-infringement",
+            "is_multi_review": false
+          },
+          "reports": [],
+          "created_at": "2024-02-28T14:55:44.964825+00:00"
+        },
+        "user": {
+          "name": "Ioana rusiczki",
+          "email": "irusiczki@mozilla.com",
+          "groups": [
+            {
+              "name": "API Manager"
+            },
+            {
+              "name": "Base User"
+            },
+            {
+              "name": "Everyone"
+            },
+            {
+              "name": "QA"
+            },
+            {
+              "name": "TaskUs moderators"
+            }
+          ]
+        },
+        "decision": {
+          "id": "4f18b22c-6078-4934-b395-6a2e01cadf63",
+          "type": "override",
+          "metadata": {}
+        }
+      },
+      "policies": [
+        {
+          "id": "7ea512a2-39a6-4cb6-91a0-2ed162192f7f",
+          "name": "Content",
+          "is_illegal": false,
+          "enforcement_actions": []
+        },
+        {
+          "id": "a5c96c92-2373-4d11-b573-61b0de00d8e0",
+          "name": "Spam",
+          "parent_id": "7ea512a2-39a6-4cb6-91a0-2ed162192f7f",
+          "is_illegal": false,
+          "enforcement_actions": [
+            "amo-ban-user",
+            "amo-delete-collection",
+            "amo-delete-rating",
+            "amo-disable-addon"
+          ]
+        }
+      ],
+      "timestamp": "2024-01-12T14:53:23.438634+00:00",
+      "point_updates": [],
+      "policies_removed": [
+        {
+          "id": "0d9df565-f249-40f8-8954-e73e65932ca2",
+          "name": "Acceptable Use",
+          "is_illegal": false,
+          "enforcement_actions": []
+        },
+        {
+          "id": "a9935672-c8ad-41fa-b4de-84be084ec5d5",
+          "name": "Deceptive or misleading",
+          "parent_id": "0d9df565-f249-40f8-8954-e73e65932ca2",
+          "is_illegal": false,
+          "enforcement_actions": [
+            "amo-ban-user",
+            "amo-delete-collection",
+            "amo-delete-rating",
+            "amo-disable-addon"
+          ]
+        }
+      ],
+      "enforcement_actions": [
+        "amo-ban-user",
+        "amo-delete-collection",
+        "amo-delete-rating",
+        "amo-disable-addon"
+      ],
+      "enforcement_actions_removed": []
+    }
+  }

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -42,8 +42,9 @@ from ..utils import (
     CinderActionDeleteRating,
     CinderActionDisableAddon,
     CinderActionEscalateAddon,
-    CinderActionNotImplemented,
     CinderActionOverrideApprove,
+    CinderActionRejectVersion,
+    CinderActionRejectVersionDelayed,
     CinderActionTargetAppealApprove,
     CinderActionTargetAppealRemovalAffirmation,
 )
@@ -1493,53 +1494,100 @@ class TestCinderDecision(TestCase):
         assert current_decision.is_third_party_initiated
 
     def test_get_action_helper(self):
+        addon = addon_factory()
         decision = CinderDecision.objects.create(
-            action=DECISION_ACTIONS.AMO_DISABLE_ADDON, addon=addon_factory()
+            action=DECISION_ACTIONS.AMO_DISABLE_ADDON, addon=addon
         )
-        action_to_class = (
-            (DECISION_ACTIONS.AMO_BAN_USER, CinderActionBanUser),
-            (DECISION_ACTIONS.AMO_DISABLE_ADDON, CinderActionDisableAddon),
-            (DECISION_ACTIONS.AMO_ESCALATE_ADDON, CinderActionEscalateAddon),
-            (DECISION_ACTIONS.AMO_DELETE_COLLECTION, CinderActionDeleteCollection),
-            (DECISION_ACTIONS.AMO_DELETE_RATING, CinderActionDeleteRating),
-            (DECISION_ACTIONS.AMO_APPROVE, CinderActionApproveInitialDecision),
-        )
-        action_existing_to_class = {
-            (new_action, existing_action): ActionClass
-            for new_action, ActionClass in action_to_class
-            for existing_action in DECISION_ACTIONS.values
+        targets = {
+            CinderActionBanUser: {'user': user_factory()},
+            CinderActionDisableAddon: {'addon': addon},
+            CinderActionRejectVersion: {'addon': addon},
+            CinderActionRejectVersionDelayed: {'addon': addon},
+            CinderActionEscalateAddon: {'addon': addon},
+            CinderActionDeleteCollection: {'collection': collection_factory()},
+            CinderActionDeleteRating: {
+                'rating': Rating.objects.create(addon=addon, user=user_factory())
+            },
+            CinderActionApproveInitialDecision: {'addon': addon},
+            CinderActionOverrideApprove: {'addon': addon},
+            CinderActionTargetAppealApprove: {'addon': addon},
+            CinderActionTargetAppealRemovalAffirmation: {'addon': addon},
         }
+        action_to_class = [
+            (decision_action, CinderDecision.get_action_helper_class(decision_action))
+            for decision_action in DECISION_ACTIONS.values
+        ]
+        # base cases, where it's a decision without an override or appeal involved
+        action_existing_to_class = {
+            (new_action, None, None): ActionClass
+            for new_action, ActionClass in action_to_class
+        }
+
         for action in DECISION_ACTIONS.REMOVING.values:
-            action_existing_to_class[(DECISION_ACTIONS.AMO_APPROVE, action)] = (
+            # add appeal success cases
+            action_existing_to_class[(DECISION_ACTIONS.AMO_APPROVE, None, action)] = (
                 CinderActionTargetAppealApprove
             )
-            action_existing_to_class[(action, action)] = (
+            # add appeal denial cases
+            action_existing_to_class[(action, None, action)] = (
                 CinderActionTargetAppealRemovalAffirmation
             )
-
-        for (
-            new_action,
-            existing_action,
-        ), ActionClass in action_existing_to_class.items():
-            decision.update(action=new_action)
-            helper = decision.get_action_helper(existing_action)
-            assert helper.__class__ == ActionClass
-            assert helper.decision == decision
-
-        # and repeat for the override edge case
-        for action in DECISION_ACTIONS.REMOVING.values:
-            action_existing_to_class[(DECISION_ACTIONS.AMO_APPROVE, action)] = (
+            # add override from takedown to approve cases
+            action_existing_to_class[(DECISION_ACTIONS.AMO_APPROVE, action, None)] = (
                 CinderActionOverrideApprove
             )
-            action_existing_to_class[(action, action)] = CinderActionNotImplemented
 
         for (
             new_action,
-            existing_action,
+            overridden_action,
+            appealed_action,
         ), ActionClass in action_existing_to_class.items():
-            decision.update(action=new_action)
-            helper = decision.get_action_helper(existing_action, override=True)
+            decision.update(
+                **{
+                    'action': new_action,
+                    'addon': None,
+                    'rating': None,
+                    'collection': None,
+                    'user': None,
+                    **targets[ActionClass],
+                }
+            )
+            helper = decision.get_action_helper(
+                appealed_action=appealed_action, overriden_action=overridden_action
+            )
             assert helper.__class__ == ActionClass
+            assert helper.decision == decision
+            assert helper.reporter_template_path == ActionClass.reporter_template_path
+            assert (
+                helper.reporter_appeal_template_path
+                == ActionClass.reporter_appeal_template_path
+            )
+
+        action_existing_to_class_no_reporter_emails = {
+            (action, action): CinderDecision.get_action_helper_class(action)
+            for action in DECISION_ACTIONS.REMOVING.values
+        }
+        for (
+            new_action,
+            overridden_action,
+        ), ActionClass in action_existing_to_class_no_reporter_emails.items():
+            decision.update(
+                **{
+                    'action': new_action,
+                    'addon': None,
+                    'rating': None,
+                    'collection': None,
+                    'user': None,
+                    **targets[ActionClass],
+                }
+            )
+            helper = decision.get_action_helper(
+                appealed_action=None, overriden_action=overridden_action
+            )
+            assert helper.reporter_template_path is None
+            assert helper.reporter_appeal_template_path is None
+            assert ActionClass.reporter_template_path is not None
+            assert ActionClass.reporter_appeal_template_path is not None
 
     @override_switch('enable-cinder-reviewer-tools-integration', active=True)
     def _test_appeal_as_target(self, *, resolvable_in_reviewer_tools):

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -37,6 +37,7 @@ from ..cinder import (
 from ..models import AbuseReport, CinderDecision, CinderJob, CinderPolicy
 from ..utils import (
     CinderActionApproveInitialDecision,
+    CinderActionApproveNoAction,
     CinderActionBanUser,
     CinderActionDeleteCollection,
     CinderActionDeleteRating,
@@ -1509,6 +1510,7 @@ class TestCinderDecision(TestCase):
                 'rating': Rating.objects.create(addon=addon, user=user_factory())
             },
             CinderActionApproveInitialDecision: {'addon': addon},
+            CinderActionApproveNoAction: {'addon': addon},
             CinderActionOverrideApprove: {'addon': addon},
             CinderActionTargetAppealApprove: {'addon': addon},
             CinderActionTargetAppealRemovalAffirmation: {'addon': addon},
@@ -1528,6 +1530,9 @@ class TestCinderDecision(TestCase):
             action_existing_to_class[(DECISION_ACTIONS.AMO_APPROVE, None, action)] = (
                 CinderActionTargetAppealApprove
             )
+            action_existing_to_class[
+                (DECISION_ACTIONS.AMO_APPROVE_VERSION, None, action)
+            ] = CinderActionTargetAppealApprove
             # add appeal denial cases
             action_existing_to_class[(action, None, action)] = (
                 CinderActionTargetAppealRemovalAffirmation
@@ -1536,6 +1541,9 @@ class TestCinderDecision(TestCase):
             action_existing_to_class[(DECISION_ACTIONS.AMO_APPROVE, action, None)] = (
                 CinderActionOverrideApprove
             )
+            action_existing_to_class[
+                (DECISION_ACTIONS.AMO_APPROVE_VERSION, action, None)
+            ] = CinderActionOverrideApprove
 
         for (
             new_action,
@@ -2015,8 +2023,9 @@ class TestCinderDecision(TestCase):
         self._test_notify_reviewer_decision(
             decision,
             amo.LOG.APPROVE_VERSION,
-            DECISION_ACTIONS.AMO_APPROVE,
+            DECISION_ACTIONS.AMO_APPROVE_VERSION,
             expect_create_decision_call=False,
+            expect_email=True,
         )
 
     def test_notify_reviewer_decision_no_cinder_action_in_activity_log(self):

--- a/src/olympia/abuse/tests/test_utils.py
+++ b/src/olympia/abuse/tests/test_utils.py
@@ -281,7 +281,7 @@ class TestCinderActionUser(BaseTestCinderAction, TestCase):
     def _test_ban_user(self):
         self.decision.update(action=DECISION_ACTIONS.AMO_BAN_USER)
         action = self.ActionClass(self.decision)
-        assert action.process_action() == (True, None)
+        assert action.process_action() is None
 
         self.user.reload()
         self.assertCloseToNow(self.user.banned)
@@ -324,7 +324,7 @@ class TestCinderActionUser(BaseTestCinderAction, TestCase):
     def _test_reporter_ignore_initial_or_appeal(self, *, send_owner_email=None):
         self.decision.update(action=DECISION_ACTIONS.AMO_APPROVE)
         action = CinderActionApproveInitialDecision(self.decision)
-        assert action.process_action() == (False, None)
+        assert action.process_action() is None
 
         self.user.reload()
         assert not self.user.banned
@@ -342,7 +342,7 @@ class TestCinderActionUser(BaseTestCinderAction, TestCase):
         self.decision.update(action=DECISION_ACTIONS.AMO_APPROVE)
         self.user.update(banned=self.days_ago(1), deleted=True)
         action = CinderActionClass(self.decision)
-        assert action.process_action() == (True, None)
+        assert action.process_action() is None
 
         self.user.reload()
         assert not self.user.banned
@@ -362,7 +362,7 @@ class TestCinderActionUser(BaseTestCinderAction, TestCase):
     def test_target_appeal_decline(self):
         self.user.update(banned=self.days_ago(1), deleted=True)
         action = CinderActionTargetAppealRemovalAffirmation(self.decision)
-        assert action.process_action() == (True, None)
+        assert action.process_action() is None
 
         self.user.reload()
         assert self.user.banned
@@ -392,8 +392,7 @@ class TestCinderActionAddon(BaseTestCinderAction, TestCase):
     def _test_disable_addon(self):
         self.decision.update(action=DECISION_ACTIONS.AMO_DISABLE_ADDON)
         action = self.ActionClass(self.decision)
-        outcome, activity = action.process_action()
-        assert outcome is True
+        activity = action.process_action()
         assert activity
         assert activity.log == amo.LOG.FORCE_DISABLE
         assert self.addon.reload().status == amo.STATUS_DISABLED
@@ -437,7 +436,7 @@ class TestCinderActionAddon(BaseTestCinderAction, TestCase):
         self.addon.update(status=amo.STATUS_DISABLED)
         ActivityLog.objects.all().delete()
         action = CinderActionClass(self.decision)
-        assert action.process_action() == (True, None)
+        assert action.process_action() is None
 
         assert self.addon.reload().status == amo.STATUS_APPROVED
         assert ActivityLog.objects.count() == 1
@@ -456,7 +455,7 @@ class TestCinderActionAddon(BaseTestCinderAction, TestCase):
     def _test_reporter_ignore_initial_or_appeal(self, *, send_owner_email=None):
         self.decision.update(action=DECISION_ACTIONS.AMO_APPROVE)
         action = CinderActionApproveInitialDecision(self.decision)
-        assert action.process_action() == (False, None)
+        assert action.process_action() is None
 
         assert self.addon.reload().status == amo.STATUS_APPROVED
         assert ActivityLog.objects.count() == 0
@@ -477,7 +476,7 @@ class TestCinderActionAddon(BaseTestCinderAction, TestCase):
         )
         ActivityLog.objects.all().delete()
         action = CinderActionEscalateAddon(self.decision)
-        assert action.process_action() == (False, None)
+        assert action.process_action() is None
 
         assert self.addon.reload().status == amo.STATUS_APPROVED
         assert (
@@ -503,7 +502,7 @@ class TestCinderActionAddon(BaseTestCinderAction, TestCase):
         assert not other_version.due_date
         ActivityLog.objects.all().delete()
         self.cinder_job.abusereport_set.update(addon_version=other_version.version)
-        assert action.process_action() == (False, None)
+        assert action.process_action() is None
         assert not listed_version.reload().needshumanreview_set.exists()
         assert not unlisted_version.reload().needshumanreview_set.exists()
         other_version.reload()
@@ -538,7 +537,7 @@ class TestCinderActionAddon(BaseTestCinderAction, TestCase):
         ActivityLog.objects.all().delete()
 
         action = CinderActionEscalateAddon(self.decision)
-        assert action.process_action() == (False, None)
+        assert action.process_action() is None
         assert NeedsHumanReview.objects.count() == 2
         assert ActivityLog.objects.count() == 0
         assert len(mail.outbox) == 0
@@ -554,7 +553,7 @@ class TestCinderActionAddon(BaseTestCinderAction, TestCase):
         )
         ActivityLog.objects.all().delete()
         action = CinderActionEscalateAddon(self.decision)
-        assert action.process_action() == (False, None)
+        assert action.process_action() is None
 
         assert self.addon.reload().status == amo.STATUS_APPROVED
         assert not listed_version.reload().needshumanreview_set.exists()
@@ -569,7 +568,7 @@ class TestCinderActionAddon(BaseTestCinderAction, TestCase):
         assert not other_version.due_date
         ActivityLog.objects.all().delete()
         self.cinder_job.abusereport_set.update(addon_version=other_version.version)
-        assert action.process_action() == (False, None)
+        assert action.process_action() is None
         assert not listed_version.reload().needshumanreview_set.exists()
         assert not unlisted_version.reload().needshumanreview_set.exists()
         other_version.reload()
@@ -581,7 +580,7 @@ class TestCinderActionAddon(BaseTestCinderAction, TestCase):
         self.addon.update(status=amo.STATUS_DISABLED)
         ActivityLog.objects.all().delete()
         action = CinderActionTargetAppealRemovalAffirmation(self.decision)
-        assert action.process_action() == (True, None)
+        assert action.process_action() is None
 
         self.addon.reload()
         assert self.addon.status == amo.STATUS_DISABLED
@@ -600,7 +599,7 @@ class TestCinderActionAddon(BaseTestCinderAction, TestCase):
         ActivityLog.objects.all().delete()
         self.decision.update(notes='')
         action = CinderActionTargetAppealRemovalAffirmation(self.decision)
-        assert action.process_action() == (True, None)
+        assert action.process_action() is None
 
         self.addon.reload()
         assert self.addon.status == amo.STATUS_DISABLED
@@ -817,8 +816,7 @@ class TestCinderActionCollection(BaseTestCinderAction, TestCase):
     def _test_delete_collection(self):
         self.decision.update(action=DECISION_ACTIONS.AMO_DELETE_COLLECTION)
         action = self.ActionClass(self.decision)
-        action_taken, log_entry = action.process_action()
-        assert action_taken
+        log_entry = action.process_action()
 
         assert self.collection.reload()
         assert self.collection.deleted
@@ -863,7 +861,7 @@ class TestCinderActionCollection(BaseTestCinderAction, TestCase):
     def _test_reporter_ignore_initial_or_appeal(self, *, send_owner_email=None):
         self.decision.update(action=DECISION_ACTIONS.AMO_APPROVE)
         action = CinderActionApproveInitialDecision(self.decision)
-        assert action.process_action() == (False, None)
+        assert action.process_action() is None
 
         assert self.collection.reload()
         assert not self.collection.deleted
@@ -881,7 +879,7 @@ class TestCinderActionCollection(BaseTestCinderAction, TestCase):
     def _test_approve_appeal_or_override(self, CinderActionClass):
         self.collection.update(deleted=True)
         action = CinderActionClass(self.decision)
-        assert action.process_action() == (True, None)
+        assert action.process_action() is None
 
         assert self.collection.reload()
         assert not self.collection.deleted
@@ -901,7 +899,7 @@ class TestCinderActionCollection(BaseTestCinderAction, TestCase):
     def test_target_appeal_decline(self):
         self.collection.update(deleted=True)
         action = CinderActionTargetAppealRemovalAffirmation(self.decision)
-        assert action.process_action() == (True, None)
+        assert action.process_action() is None
 
         self.collection.reload()
         assert self.collection.deleted
@@ -932,7 +930,7 @@ class TestCinderActionRating(BaseTestCinderAction, TestCase):
     def _test_delete_rating(self):
         self.decision.update(action=DECISION_ACTIONS.AMO_DELETE_RATING)
         action = self.ActionClass(self.decision)
-        assert action.process_action() == (True, None)
+        assert action.process_action() is None
 
         assert self.rating.reload().deleted
         assert ActivityLog.objects.count() == 1
@@ -974,7 +972,7 @@ class TestCinderActionRating(BaseTestCinderAction, TestCase):
     def _test_reporter_ignore_initial_or_appeal(self, *, send_owner_email=None):
         self.decision.update(action=DECISION_ACTIONS.AMO_APPROVE)
         action = CinderActionApproveInitialDecision(self.decision)
-        assert action.process_action() == (False, None)
+        assert action.process_action() is None
 
         assert not self.rating.reload().deleted
         assert ActivityLog.objects.count() == 0
@@ -992,7 +990,7 @@ class TestCinderActionRating(BaseTestCinderAction, TestCase):
         self.rating.delete()
         ActivityLog.objects.all().delete()
         action = CinderActionClass(self.decision)
-        assert action.process_action() == (True, None)
+        assert action.process_action() is None
 
         assert not self.rating.reload().deleted
         assert ActivityLog.objects.count() == 1
@@ -1014,7 +1012,7 @@ class TestCinderActionRating(BaseTestCinderAction, TestCase):
         self.rating.delete()
         ActivityLog.objects.all().delete()
         action = CinderActionTargetAppealRemovalAffirmation(self.decision)
-        assert action.process_action() == (True, None)
+        assert action.process_action() is None
 
         self.rating.reload()
         assert self.rating.deleted

--- a/src/olympia/abuse/utils.py
+++ b/src/olympia/abuse/utils.py
@@ -389,9 +389,24 @@ class CinderActionOverrideApprove(CinderActionTargetAppealApprove):
     description = 'Reported content is within policy, after override'
 
 
+class CinderActionApproveNoAction(CinderAction):
+    valid_targets = (Addon, UserProfile, Collection, Rating)
+    description = 'Reported content is within policy, initial decision, so no action'
+    reporter_template_path = 'abuse/emails/reporter_ignore.txt'
+    reporter_appeal_template_path = 'abuse/emails/reporter_appeal_ignore.txt'
+
+    def process_action(self):
+        return None
+
+    def get_owners(self):
+        return ()
+
+
 class CinderActionApproveInitialDecision(CinderAction):
     valid_targets = (Addon, UserProfile, Collection, Rating)
-    description = 'Reported content is within policy, initial decision'
+    description = (
+        'Reported content is within policy, initial decision, approving versions'
+    )
     reporter_template_path = 'abuse/emails/reporter_ignore.txt'
     reporter_appeal_template_path = 'abuse/emails/reporter_appeal_ignore.txt'
 

--- a/src/olympia/abuse/views.py
+++ b/src/olympia/abuse/views.py
@@ -266,7 +266,6 @@ def cinder_webhook(request):
             decision_action=enforcement_actions[0],
             decision_notes=payload.get('notes') or '',
             policy_ids=policy_ids,
-            override=source.get('decision', {}).get('type') == 'override',
         )
 
     except ValidationError as exc:

--- a/src/olympia/constants/abuse.py
+++ b/src/olympia/constants/abuse.py
@@ -17,6 +17,8 @@ DECISION_ACTIONS = APIChoicesWithDash(
     # It should not be sent by the cinder webhook, & does not have an action defined
     ('AMO_REJECT_VERSION_ADDON', 8, 'Add-on version reject'),
     ('AMO_REJECT_VERSION_WARNING_ADDON', 9, 'Add-on version delayed reject warning'),
+    # Approving new versions is not an available action for moderators in cinder
+    ('AMO_APPROVE_VERSION', 10, 'Approved (new version approval)'),
 )
 DECISION_ACTIONS.add_subset(
     'APPEALABLE_BY_AUTHOR',
@@ -30,7 +32,7 @@ DECISION_ACTIONS.add_subset(
 )
 DECISION_ACTIONS.add_subset(
     'APPEALABLE_BY_REPORTER',
-    ('AMO_APPROVE',),
+    ('AMO_APPROVE', 'AMO_APPROVE_VERSION'),
 )
 DECISION_ACTIONS.add_subset(
     'UNRESOLVED',
@@ -45,4 +47,8 @@ DECISION_ACTIONS.add_subset(
         'AMO_DELETE_COLLECTION',
         'AMO_REJECT_VERSION_ADDON',
     ),
+)
+DECISION_ACTIONS.add_subset(
+    'APPROVING',
+    ('AMO_APPROVE', 'AMO_APPROVE_VERSION'),
 )

--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -148,7 +148,7 @@ class APPROVE_VERSION(_LOG):
     review_email_user = True
     review_queue = True
     reviewer_review_action = True
-    cinder_action = DECISION_ACTIONS.AMO_APPROVE
+    cinder_action = DECISION_ACTIONS.AMO_APPROVE_VERSION
 
 
 class PRELIMINARY_VERSION(_LOG):
@@ -838,7 +838,7 @@ class FORCE_ENABLE(_LOG):
     reviewer_format = '{addon} force-enabled by {user_responsible}.'
     admin_format = reviewer_format
     short = 'Force enabled'
-    cinder_action = DECISION_ACTIONS.AMO_APPROVE
+    cinder_action = DECISION_ACTIONS.AMO_APPROVE_VERSION
 
 
 class LOG_IN(_LOG):
@@ -888,7 +888,6 @@ class CLEAR_NEEDS_HUMAN_REVIEWS_LEGACY(_LOG):
     admin_event = True
     review_queue = True
     reviewer_review_action = True
-    cinder_action = DECISION_ACTIONS.AMO_APPROVE
 
 
 class NEEDS_HUMAN_REVIEW_AUTOMATIC(_LOG):


### PR DESCRIPTION
hopefully:
fixes #21948 + fixes mozilla/addons#1729 + fixes #21928 + fixes #22011 + at least helps with #21986

The significant changes are:
-  `get_action_helper` refactored to explicitly pass existing decision actions, and/or appealed decision actions (rather than guessing)
- always send emails when an action has been taken - don't rely on `process_action` returning True/False
- change the check about the correct content class for the CinderAction to instead raise in the class init, rather than silently ignore and and not send an email about it.
- have a separate `AMO_APPROVE_VERSION` action and CinderAction class for reviewer approve actions that notify the developer to silent actions, so we don't have extra logic to decide whether to notify them or not.