### PR TITLE
Update 0044_auto_20240409_1358.py

### DIFF
--- a/src/olympia/versions/migrations/0044_auto_20240409_1358.py
+++ b/src/olympia/versions/migrations/0044_auto_20240409_1358.py
@@ -4,14 +4,6 @@ from django.db import migrations
 
 from olympia import amo
 
-
-def clear_due_dates_from_old_disabled_addons(apps, schema_editor):
-    Version = apps.get_model('versions', 'Version')
-    Version.unfiltered.filter(
-        addon__status=amo.STATUS_DISABLED, due_date__isnull=False
-    ).update(due_date=None)
-
-
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -19,5 +11,4 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(clear_due_dates_from_old_disabled_addons)
     ]


### PR DESCRIPTION
Follow-up for https://github.com/mozilla/addons-server/pull/22123 - @wagnerand decided we don't want to clear the due_dates in a migration - he will manually clear them as appropriate.