### PR TITLE
send different wording in approval email for an auto approval

### DIFF
--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -1044,10 +1044,15 @@ class CinderDecision(ModelBase):
             version_list = ', '.join(
                 log_entry.versionlog_set.values_list('version__version', flat=True)
             )
+            is_auto_approval = (
+                self.action == DECISION_ACTIONS.AMO_APPROVE
+                and not log_entry.details.get('human_review', True)
+            )
             action_helper.notify_owners(
                 log_entry_id=log_entry.id,
                 policy_text=log_entry.details.get('comments'),
                 extra_context={
+                    'auto_approval': is_auto_approval,
                     'delayed_rejection_days': log_entry.details.get(
                         'delayed_rejection_days'
                     ),

--- a/src/olympia/abuse/templates/abuse/emails/CinderActionApproveInitialDecision.txt
+++ b/src/olympia/abuse/templates/abuse/emails/CinderActionApproveInitialDecision.txt
@@ -1,7 +1,12 @@
 Hello,
 
+{% if not auto_approval %}
 Your {{ type }} has been approved on Mozilla Add-ons and it is now available at {{ target_url }}.
+{% else %}
+Your {{ type }} has been automatically screened and tentatively approved. It is now available at {{ target_url }}.
 
+Your add-on can be subject to human review at any time. Reviewers may determine that it requires changes or should be removed. If that occurs, you will receive a separate notification with details and next steps.
+{% endif %}
 Approved versions: {{ version_list }}
 
 Thank you.

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -1867,6 +1867,7 @@ class TestCinderDecision(TestCase):
         *,
         expect_email=True,
         expect_create_decision_call=True,
+        extra_log_details=None,
     ):
         create_decision_response = responses.add(
             responses.POST,
@@ -1886,7 +1887,7 @@ class TestCinderDecision(TestCase):
             decision.addon,
             decision.addon.current_version,
             review_action_reason,
-            details={'comments': 'some review text'},
+            details={'comments': 'some review text', **(extra_log_details or {})},
             user=user_factory(),
         )
 
@@ -1975,6 +1976,34 @@ class TestCinderDecision(TestCase):
             DECISION_ACTIONS.AMO_APPROVE,
             expect_create_decision_call=False,
         )
+
+    def test_notify_reviewer_decision_auto_approve_email_for_non_human_review(self):
+        addon_developer = user_factory()
+        addon = addon_factory(users=[addon_developer])
+        decision = CinderDecision(addon=addon)
+        self._test_notify_reviewer_decision(
+            decision,
+            amo.LOG.APPROVE_VERSION,
+            DECISION_ACTIONS.AMO_APPROVE,
+            expect_email=True,
+            expect_create_decision_call=False,
+            extra_log_details={'human_review': False},
+        )
+        assert 'automatically screened and tentatively approved' in mail.outbox[0].body
+
+    def test_notify_reviewer_decision_auto_approve_email_for_human_review(self):
+        addon_developer = user_factory()
+        addon = addon_factory(users=[addon_developer])
+        decision = CinderDecision(addon=addon)
+        self._test_notify_reviewer_decision(
+            decision,
+            amo.LOG.APPROVE_VERSION,
+            DECISION_ACTIONS.AMO_APPROVE,
+            expect_email=True,
+            expect_create_decision_call=False,
+            extra_log_details={'human_review': True},
+        )
+        assert 'has been approved' in mail.outbox[0].body
 
     def test_notify_reviewer_decision_no_cinder_action_in_activity_log(self):
         addon = addon_factory()

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -978,6 +978,7 @@ class ReviewBase:
         details = {
             'comments': self.data.get('comments', ''),
             'reviewtype': self.review_type.split('_')[1],
+            'human_review': self.human_review,
             **(extra_details or {}),
         }
         if version is None and self.version:


### PR DESCRIPTION
fixes #22125 by storing if the approval was completed by a human in the activity log (usual to know anyway, I would have thought), and having the approval template include different wording in that case.