### PR TITLE
Set ipdb as the breakpoint callback

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ x-env-mapping: &env
     - OLYMPIA_SITE_URL=http://olympia.test
     - PYTHONDONTWRITEBYTECODE=1
     - PYTHONUNBUFFERED=1
+    - PYTHONBREAKPOINT=ipdb.set_trace
     - TERM=xterm-256color
     - CIRCLECI=${CIRCLECI}
     - HISTFILE=/data/olympia/docker/artifacts/bash_history


### PR DESCRIPTION
[`breakpoint()`](https://docs.python.org/3/library/functions.html#breakpoint) is a built-in python function that drops a debugger where you put it in the code, like `debugger;` in JavaScript, which is very useful to quickly debug an issue, since from there you can navigate up and down the stack, inspect locals etc. While our current local environments setup doesn't allow this to work with uwsgi/celery, because there is no terminal to attach to, it works great in tests.

This PR makes python use `ipdb` instead of `pdb` as the debugger callback for `breakpoint()`, which is a lot nicer: it has tab-completion, syntax highlighting, etc. We already have `ipdb` in our requirements because of how useful it is, this makes it easier to call (no longer have to drop `import ipdb; ipdb.set_trace()` in the code, you can just use `breakpoint()`)
