### PR TITLE
Also bump and resign dictionaries in process_addons --task=bump_and_resign_addons

### DIFF
--- a/src/olympia/addons/management/commands/process_addons.py
+++ b/src/olympia/addons/management/commands/process_addons.py
@@ -84,6 +84,7 @@ class Command(ProcessObjectsCommand):
                         type__in=(
                             amo.ADDON_EXTENSION,
                             amo.ADDON_STATICTHEME,
+                            amo.ADDON_DICT,
                         ),
                     )
                 ],

--- a/src/olympia/addons/tests/test_commands.py
+++ b/src/olympia/addons/tests/test_commands.py
@@ -380,10 +380,10 @@ class TestBumpAndResignAddons(TestCase):
 
             another_extension = addon_factory(file_kw=file_kw)
             a_theme = addon_factory(type=amo.ADDON_STATICTHEME, file_kw=file_kw)
+            a_dict = addon_factory(type=amo.ADDON_DICT, file_kw=file_kw)
 
-            # Dictionaries, langpacks and non-public add-ons won't be bumped.
+            # Mangpacks and non-public add-ons won't be bumped.
             addon_factory(type=amo.ADDON_LPAPP, file_kw=file_kw)
-            addon_factory(type=amo.ADDON_DICT, file_kw=file_kw)
             addon_factory(status=amo.STATUS_DISABLED, file_kw=file_kw)
             addon_factory(status=amo.STATUS_AWAITING_REVIEW, file_kw=file_kw)
             addon_factory(status=amo.STATUS_NULL, file_kw=file_kw)
@@ -396,11 +396,12 @@ class TestBumpAndResignAddons(TestCase):
 
         call_command('process_addons', task='bump_and_resign_addons')
 
-        assert bump_addon_version_mock.call_count == 3
+        assert bump_addon_version_mock.call_count == 4
         assert {call[0][0] for call in bump_addon_version_mock.call_args_list} == {
             addon_with_history.current_version,
             another_extension.current_version,
             a_theme.current_version,
+            a_dict.current_version,
         }
 
 

--- a/src/olympia/addons/tests/test_commands.py
+++ b/src/olympia/addons/tests/test_commands.py
@@ -382,7 +382,7 @@ class TestBumpAndResignAddons(TestCase):
             a_theme = addon_factory(type=amo.ADDON_STATICTHEME, file_kw=file_kw)
             a_dict = addon_factory(type=amo.ADDON_DICT, file_kw=file_kw)
 
-            # Mangpacks and non-public add-ons won't be bumped.
+            # Langpacks and non-public add-ons won't be bumped.
             addon_factory(type=amo.ADDON_LPAPP, file_kw=file_kw)
             addon_factory(status=amo.STATUS_DISABLED, file_kw=file_kw)
             addon_factory(status=amo.STATUS_AWAITING_REVIEW, file_kw=file_kw)


### PR DESCRIPTION
Their signature is currently ignored by Firefox, but might as well bump them anyway.

Fixes #21996