### PR TITLE
override target_url if the decision related to unlisted versions

### DIFF
--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -4,6 +4,7 @@ from itertools import chain
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.db.transaction import atomic
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
 
@@ -1038,8 +1039,14 @@ class CinderDecision(ModelBase):
             reporter_abuse_reports=reporter_abuse_reports,
             is_appeal=bool(appealed_action),
         )
-        version_list = ', '.join(
-            log_entry.versionlog_set.values_list('version__version', flat=True)
+        versions_data = log_entry.versionlog_set.values_list(
+            'version__version', 'version__channel'
+        )
+        # override target_url if this decision related to unlisted versions
+        target_url_override = (
+            {'target_url': reverse('devhub.addons.versions', args=[self.target.id])}
+            if versions_data and versions_data[0][1] == amo.CHANNEL_UNLISTED
+            else {}
         )
         action_helper.notify_owners(
             log_entry_id=log_entry.id,
@@ -1048,6 +1055,7 @@ class CinderDecision(ModelBase):
                 'delayed_rejection_days': log_entry.details.get(
                     'delayed_rejection_days'
                 ),
-                'version_list': version_list,
+                'version_list': ', '.join(ver_str for ver_str, _ in versions_data),
+                **target_url_override,
             },
         )

--- a/src/olympia/abuse/templates/abuse/emails/CinderActionRejectVersion.txt
+++ b/src/olympia/abuse/templates/abuse/emails/CinderActionRejectVersion.txt
@@ -6,7 +6,7 @@ Our review found that your content violates the following Mozilla policy or poli
 
 Affected versions: {{ version_list }}
 
-Based on that finding, those versions of your {{ type }} have been disabled on {{ target_url }} and is no longer available for download from Mozilla Add-ons, anywhere in the world. Users who have previously installed those versions will be able to continue using them.
+Based on that finding, those versions of your {{ type }} have been disabled on {{ target_url }} and are no longer available for download from Mozilla Add-ons, anywhere in the world. Users who have previously installed those versions will be able to continue using them.
 
 You may upload a new version which addresses the policy violation(s).
 {% endblock %}

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime
 from unittest import mock
+from urllib import parse
 
 from django.conf import settings
 from django.core import mail
@@ -1937,10 +1938,11 @@ class TestCinderDecision(TestCase):
         entity_helper = CinderJob.get_entity_helper(
             decision.addon, resolved_in_reviewer_tools=True
         )
+        addon_version = decision.addon.versions.all()[0]
         log_entry = ActivityLog.objects.create(
             activity_action,
             decision.addon,
-            decision.addon.current_version,
+            addon_version,
             review_action_reason,
             details={'comments': 'some review text'},
             user=user_factory(),
@@ -1971,7 +1973,7 @@ class TestCinderDecision(TestCase):
             assert len(mail.outbox) == 1
             assert mail.outbox[0].to == [decision.addon.authors.first().email]
             assert str(log_entry.id) in mail.outbox[0].extra_headers['Message-ID']
-            assert str(decision.addon.current_version.version) in mail.outbox[0].body
+            assert str(addon_version) in mail.outbox[0].body
             assert 'days' not in mail.outbox[0].body
         else:
             assert len(mail.outbox) == 0
@@ -1983,6 +1985,8 @@ class TestCinderDecision(TestCase):
         self._test_notify_reviewer_decision(
             decision, amo.LOG.REJECT_VERSION, DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON
         )
+        assert parse.quote(f'/firefox/addon/{addon.slug}/') in mail.outbox[0].body
+        assert '/developers/' not in mail.outbox[0].body
 
     def test_notify_reviewer_decision_updated_decision(self):
         addon_developer = user_factory()
@@ -1993,6 +1997,20 @@ class TestCinderDecision(TestCase):
         self._test_notify_reviewer_decision(
             decision, amo.LOG.REJECT_VERSION, DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON
         )
+        assert parse.quote(f'/firefox/addon/{addon.slug}/') in mail.outbox[0].body
+        assert '/developers/' not in mail.outbox[0].body
+
+    def test_notify_reviewer_decision_unlisted_version(self):
+        addon_developer = user_factory()
+        addon = addon_factory(
+            users=[addon_developer], version_kw={'channel': amo.CHANNEL_UNLISTED}
+        )
+        decision = CinderDecision(addon=addon)
+        self._test_notify_reviewer_decision(
+            decision, amo.LOG.REJECT_VERSION, DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON
+        )
+        assert '/firefox/' not in mail.outbox[0].body
+        assert f'/developers/addon/{addon.id}/' in mail.outbox[0].body
 
     def test_notify_reviewer_decision_new_decision_no_email_to_owner(self):
         addon_developer = user_factory()


### PR DESCRIPTION
fixes mozilla/addons#1739 by overriding the target_url with a devhub link if the versions linked in the activity log were unlisted