### PR TITLE
Relax idna requirement (only used by requests, which allows 3.x)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,7 +34,7 @@ updates:
     - ">= 6"
   - dependency-name: idna
     versions:
-    - ">= 3"
+    - ">= 4"
   - dependency-name: amqp
     versions:
     - ">= 6"


### PR DESCRIPTION
Fixes #22146