### PR TITLE
Update appeal flag description in reviewer tools

### DIFF
--- a/src/olympia/reviewers/models.py
+++ b/src/olympia/reviewers/models.py
@@ -802,7 +802,7 @@ class NeedsHumanReview(ModelBase):
             ),
             (
                 REASON_ABUSE_ADDON_VIOLATION_APPEAL,
-                'Appeal against a reviewer decision about a policy violation',
+                "Appeal of a reviewer's decision about a policy violation",
             ),
         ),
         editable=False,

--- a/src/olympia/reviewers/models.py
+++ b/src/olympia/reviewers/models.py
@@ -802,7 +802,7 @@ class NeedsHumanReview(ModelBase):
             ),
             (
                 REASON_ABUSE_ADDON_VIOLATION_APPEAL,
-                'Appeal about a decision on abuse reported within the add-on',
+                'Appeal against a reviewer decision about a policy violation',
             ),
         ),
         editable=False,


### PR DESCRIPTION
This is just changing an inaccurate string displayed to add-on reviewers as the reason for when an add-on is enqueued due to a developer appeal.