### PR TITLE
Bypass trademark checks when bumping add-ons for sha-1

### DIFF
--- a/src/olympia/files/tests/test_utils.py
+++ b/src/olympia/files/tests/test_utils.py
@@ -579,6 +579,20 @@ class TestManifestJSONExtractor(AppVersionsMixin, TestCase):
             )
 
     @mock.patch('olympia.addons.models.resolve_i18n_message')
+    def test_bypass_trademark_checks(self, resolve_message):
+        resolve_message.return_value = 'Notify Mozilla'
+
+        addon = amo.tests.addon_factory(
+            file_kw={'filename': 'notify-link-clicks-i18n.xpi'}
+        )
+        file_obj = addon.current_version.file
+
+        assert utils.parse_xpi(file_obj.file.path, bypass_trademark_checks=True)
+        assert utils.parse_addon(
+            file_obj.file.path, user=user_factory(), bypass_trademark_checks=True
+        )
+
+    @mock.patch('olympia.addons.models.resolve_i18n_message')
     def test_mozilla_trademark_for_prefix_allowed(self, resolve_message):
         resolve_message.return_value = 'Notify for Mozilla'
 
@@ -587,7 +601,7 @@ class TestManifestJSONExtractor(AppVersionsMixin, TestCase):
         )
         file_obj = addon.current_version.file
 
-        utils.parse_xpi(file_obj.file.path)
+        assert utils.parse_xpi(file_obj.file.path)
 
     def test_apps_use_default_versions_if_applications_is_omitted(self):
         """

--- a/src/olympia/lib/crypto/tasks.py
+++ b/src/olympia/lib/crypto/tasks.py
@@ -181,7 +181,9 @@ def bump_addon_version(old_version):
         # Parse the add-on. We use the original author of the add-on, not
         # the task user, in case they have special permissions allowing
         # the original version to be submitted.
-        parsed_data = parse_addon(upload, addon=addon, user=original_author)
+        parsed_data = parse_addon(
+            upload, addon=addon, user=original_author, bypass_trademark_checks=True
+        )
         parsed_data['approval_notes'] = old_version.approval_notes
 
         # Discard any existing celery tasks that may have been queued before:

--- a/src/olympia/lib/crypto/tests/test_signing.py
+++ b/src/olympia/lib/crypto/tests/test_signing.py
@@ -682,6 +682,16 @@ class TestTasks(TestCase):
         new_current_version = self.addon.reload().current_version
         assert new_current_version.version == '0.0.3resigned1'
 
+    @mock.patch('olympia.lib.crypto.tasks.sign_file')
+    @mock.patch('olympia.addons.models.Addon.resolve_webext_translations')
+    def test_resign_bypass_trademark_checks(self, mock_resolve_message, mock_sign_file):
+        # Would violate trademark rule, as it contains "Firefox" but doesn't
+        # end with "for Firefox", and the author doesn't have special
+        # permissions.
+        mock_resolve_message.return_value = {'name': 'My Firefox Add-on'}
+
+        self.test_sign_bump()
+
     def test_resign_carry_over_promotion(self):
         self.make_addon_promoted(self.addon, RECOMMENDED, approve_version=True)
         assert self.addon.promoted


### PR DESCRIPTION
(Also gives us the possibility to do it when calling parse_addon()
 in general - it has come up once or twice before)

Follow-up for #21996