### PR TITLE
Don't require 2FA for theme developers versions

### DIFF
--- a/src/olympia/constants/base.py
+++ b/src/olympia/constants/base.py
@@ -134,7 +134,7 @@ ADDON_TYPE = {
     _ADDON_LPADDON: _('Deprecated Language Pack (Add-on)'),
     _ADDON_PLUGIN: _('Deprecated Plugin'),
     _ADDON_PERSONA: _('Deprecated LWT'),
-    ADDON_STATICTHEME: _('Theme (Static)'),
+    ADDON_STATICTHEME: _('Theme'),
     _ADDON_SITE_PERMISSION: _('Deprecated Site Permission'),
 }
 
@@ -148,7 +148,7 @@ ADDON_TYPES = {
     _ADDON_LPADDON: _('Deprecated Language Packs (Add-on)'),
     _ADDON_PLUGIN: _('Deprecated Plugins'),
     _ADDON_PERSONA: _('Deprecated LWTs'),
-    ADDON_STATICTHEME: _('Themes (Static)'),
+    ADDON_STATICTHEME: _('Themes'),
     _ADDON_SITE_PERMISSION: _('Deprecated Site Permissions'),
 }
 

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -2005,6 +2005,8 @@ class TestVersionSubmitDistribution(TestSubmitBase):
         self.user.update(last_login_ip='192.168.48.50')
         response = self.client.get(self.url)
         assert response.status_code == 200
+        doc = pq(response.content)
+        assert doc('#id_theme_specific').attr('value') == 'True'
 
 
 class TestVersionSubmitAutoChannel(TestSubmitBase):

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -2005,8 +2005,6 @@ class TestVersionSubmitDistribution(TestSubmitBase):
         self.user.update(last_login_ip='192.168.48.50')
         response = self.client.get(self.url)
         assert response.status_code == 200
-        doc = pq(response.content)
-        assert doc('#id_theme_specific').attr('value') == 'True'
 
 
 class TestVersionSubmitAutoChannel(TestSubmitBase):
@@ -2384,6 +2382,8 @@ class VersionSubmitUploadMixin:
         self.user.update(last_login_ip='192.168.48.50')
         response = self.client.get(self.url)
         assert response.status_code == 200
+        doc = pq(response.content)
+        assert doc('#id_theme_specific').attr('value') == 'True'
 
 
 class TestVersionSubmitUploadListed(VersionSubmitUploadMixin, UploadMixin, TestCase):

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -1467,6 +1467,12 @@ def _submit_upload(
     form = forms.NewUploadForm(
         request.POST or None, request.FILES or None, addon=addon, request=request
     )
+    if wizard or (addon and addon.type == amo.ADDON_STATICTHEME):
+        # If using the wizard or submitting a new version of a theme, we can
+        # force theme_specific to be True. If somehow the developer is not
+        # uploading a theme, validation will reject it just like if they had
+        # tried to use the theme submission flow for an entirely new add-on.
+        theme_specific = True
     form.fields['theme_specific'].initial = theme_specific
     channel_text = amo.CHANNEL_CHOICES_API[channel]
     if request.method == 'POST' and form.is_valid():

--- a/src/olympia/files/tests/test_models.py
+++ b/src/olympia/files/tests/test_models.py
@@ -611,17 +611,19 @@ class TestParseXpi(amo.tests.AMOPaths, TestCase):
         # really matter what we set here, we allow updates to an add-on
         # with a XPI that has no id.
         addon = Addon.objects.create(
-            guid='e2c45b71-6cbb-452c-97a5-7e8039cc6535', type=1
+            guid='e2c45b71-6cbb-452c-97a5-7e8039cc6535', type=amo.ADDON_EXTENSION
         )
         info = self.parse(addon, filename='webextension_no_id.xpi')
         assert info['guid'] == addon.guid
 
     def test_match_type(self):
-        addon = Addon.objects.create(guid='@webextension-guid', type=4)
+        addon = Addon.objects.create(
+            guid='@webextension-guid', type=amo.ADDON_STATICTHEME
+        )
         with self.assertRaises(forms.ValidationError) as e:
             self.parse(addon)
         assert e.exception.messages[0] == (
-            'The type (1) does not match the type of your add-on on AMO (4)'
+            'The type (Extension) does not match the type of your add-on on AMO (Theme)'
         )
 
     def test_match_type_extension_for_webextension_experiments(self):

--- a/src/olympia/files/utils.py
+++ b/src/olympia/files/utils.py
@@ -1043,7 +1043,13 @@ def parse_addon(
             msg = gettext(
                 'The type (%s) does not match the type of your add-on on AMO (%s)'
             )
-            raise forms.ValidationError(msg % (parsed['type'], addon.type))
+            raise forms.ValidationError(
+                msg
+                % (
+                    amo.ADDON_TYPE.get(parsed['type'], gettext('Unknown')),
+                    addon.get_type_display(),
+                )
+            )
     return parsed
 
 


### PR DESCRIPTION
This is achieved by overriding `theme_specific` in `_submit_upload()` if an add-on is passed (or if we're using the theme wizard). That variable is passed down to the upload flow (and checked against the xpi being uploaded later) to bypass the 2FA requirement.

### Context

We enforce 2FA at submission time if the `2fa-enforcement-for-developers-and-special-users` flag is active for the user, but we want that for extensions (and langpacks/dicts, technically), not themes. The bug was that we accidentally required it for all new versions of existing add-ons, even themes.

### Testing

Automated tests should cover this but if you want to try locally you can follow the STR in the issue. You can use the theme wizard to create the initial theme, and then take the zip and bump the version number. 

Note that you need to create the waffle flag (not a switch! it can be potentially active for a limited set of users) with: `manage.py waffle_flag 2fa-enforcement-for-developers-and-special-users --everyone`. Then, when logging in with the fake auth, check or uncheck the "two-factor authentication" checkbox before logging in depending on what you want to test.

Fixes https://github.com/mozilla/addons/issues/1956