### PR TITLE
absolutify devhub urls in the dsa emails

### DIFF
--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -11,6 +11,7 @@ from django.utils.functional import cached_property
 from olympia import amo
 from olympia.addons.models import Addon
 from olympia.amo.models import BaseQuerySet, ManagerBase, ModelBase
+from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.api.utils import APIChoicesWithNone
 from olympia.bandwagon.models import Collection
 from olympia.constants.abuse import APPEAL_EXPIRATION_DAYS, DECISION_ACTIONS
@@ -1044,7 +1045,11 @@ class CinderDecision(ModelBase):
         )
         # override target_url if this decision related to unlisted versions
         target_url_override = (
-            {'target_url': reverse('devhub.addons.versions', args=[self.target.id])}
+            {
+                'target_url': absolutify(
+                    reverse('devhub.addons.versions', args=[self.target.id])
+                )
+            }
             if versions_data and versions_data[0][1] == amo.CHANNEL_UNLISTED
             else {}
         )

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -2009,7 +2009,10 @@ class TestCinderDecision(TestCase):
             decision, amo.LOG.REJECT_VERSION, DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON
         )
         assert '/firefox/' not in mail.outbox[0].body
-        assert f'/developers/addon/{addon.id}/' in mail.outbox[0].body
+        assert (
+            f'{settings.SITE_URL}/en-US/developers/addon/{addon.id}/'
+            in mail.outbox[0].body
+        )
 
     def test_notify_reviewer_decision_new_decision_no_email_to_owner(self):
         addon_developer = user_factory()


### PR DESCRIPTION
fixes mozilla/addons#1764 - I forgot to absolutify the url

STR:
- reject/approve an unlisted version in the reviewer tools
  - if you don't have an unlisted version locally you'll need to upload one (api or devhub)
- look at the email and see the developer hub url in the email is an absolute one.
  - emails can be viewed in django admin FakeEmail or a django shell