### PR TITLE
Compile locales independently of prod.txt pip install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -534,7 +534,7 @@ jobs:
       # overhead to CLIs like `dennis-cmd`. By updating the path below, we
       # should use `dennis-cmd` directly instead of the pyenv shim.
       - run: echo "export PATH=\"$(pyenv prefix)/bin:$PATH\"" >> $BASH_ENV
-      - run: bash ./locale/compile-mo.sh ./locale/
+      - run: make compile_locales
       - run:
           command: pytest -n 2 -m 'needs_locales_compilation' -v src/olympia/
 

--- a/Makefile-docker
+++ b/Makefile-docker
@@ -236,6 +236,11 @@ format: ## Autoformat our codebase.
 extract_locales: ## extracts and merges translation strings
 	./scripts/run_l10n_extraction.sh
 
+.PHONE: compile_locales
+compile_locales: ## compiles translation strings
+	$(PIP_COMMAND) install --progress-bar=off --no-deps --exists-action=w -r requirements/locale.txt
+	./locale/compile-mo.sh ./locale/
+
 .PHONY: help_submake
 help_submake:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' Makefile-docker | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/locale/compile-mo.sh
+++ b/locale/compile-mo.sh
@@ -3,7 +3,7 @@
 # compile-mo.sh locale-dir/
 
 # Make this script fail if any command exits wit exit code != 0
-set -e
+set -ue
 
 function process_po_file() {
     pofile=$1
@@ -11,7 +11,7 @@ function process_po_file() {
     lang=$(echo "$pofile" | cut -d "/" -f2)
     stem=$(basename "$pofile" .po)
     touch "${dir}/${stem}.mo"
-    dennis-cmd lint --errorsonly "$pofile" && msgfmt -o "${dir}/${stem}.mo" "$pofile"
+    dennis-cmd lint --quiet --errorsonly "$pofile" && msgfmt -o "${dir}/${stem}.mo" "$pofile"
 }
 
 # We are spawning sub processes with `xargs`

--- a/locale/compile-mo.sh
+++ b/locale/compile-mo.sh
@@ -11,7 +11,7 @@ function process_po_file() {
     lang=$(echo "$pofile" | cut -d "/" -f2)
     stem=$(basename "$pofile" .po)
     touch "${dir}/${stem}.mo"
-    dennis-cmd lint --quiet --errorsonly "$pofile" && msgfmt -o "${dir}/${stem}.mo" "$pofile"
+    dennis-cmd lint --errorsonly "$pofile" && msgfmt -o "${dir}/${stem}.mo" "$pofile"
 }
 
 # We are spawning sub processes with `xargs`

--- a/requirements/locale.txt
+++ b/requirements/locale.txt
@@ -1,0 +1,10 @@
+dennis==1.1.0 \
+    --hash=sha256:305ec6531b49edaf0434cb19b5498b7d66870e229234672cfad6a95811b9d66c \
+    --hash=sha256:8cfa89acbee5acd3e70714fbc45d9dc23446a2418624c17b1dcfdf0bdd33bbe0
+# polib is required by dennis
+polib==1.2.0 \
+    --hash=sha256:1c77ee1b81feb31df9bca258cbc58db1bbb32d10214b173882452c73af06d62d \
+    --hash=sha256:f3ef94aefed6e183e342a8a269ae1fc4742ba193186ad76f175938621dbfc26b
+click==8.1.7 \
+    --hash=sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28 \
+    --hash=sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -511,7 +511,7 @@ charset-normalizer==3.3.2 \
     --hash=sha256:fb69256e180cb6c8a894fee62b3afebae785babc1ee98b81cdf68bbca1987f33 \
     --hash=sha256:fd1abc0d89e30cc4e02e4064dc67fcc51bd941eb395c502aac3ec19fab46b519 \
     --hash=sha256:ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561
-# click is required by dennis, celery
+# click is required by celery
 click==8.1.7 \
     --hash=sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28 \
     --hash=sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de
@@ -527,9 +527,6 @@ click-plugins==1.1.1 \
 colorgram.py==1.2.0 \
     --hash=sha256:e990769fa6df7261a450c7d5bef3a1a062f09ba1214bff67b4d6f02970a1a27b \
     --hash=sha256:e77766a5f9de7207bdef8f1c22a702cbf09630eae3bc46a450b9d9f12a7bfdbf
-dennis==1.1.0 \
-    --hash=sha256:305ec6531b49edaf0434cb19b5498b7d66870e229234672cfad6a95811b9d66c \
-    --hash=sha256:8cfa89acbee5acd3e70714fbc45d9dc23446a2418624c17b1dcfdf0bdd33bbe0
 Deprecated==1.2.14 \
     --hash=sha256:6fac8b097794a90302bdbb17b9b815e732d3c4720583ff1b198499d78470466c \
     --hash=sha256:e5323eb936458dccc2582dc6f9c322c852a775a27065ff2b0c4970b9d53d01b3
@@ -699,10 +696,6 @@ mmh3==4.1.0 \
 pymemcache==4.0.0 \
     --hash=sha256:27bf9bd1bbc1e20f83633208620d56de50f14185055e49504f4f5e94e94aff94 \
     --hash=sha256:f507bc20e0dc8d562f8df9d872107a278df049fa496805c1431b926f3ddd0eab
-# polib is required by dennis
-polib==1.2.0 \
-    --hash=sha256:1c77ee1b81feb31df9bca258cbc58db1bbb32d10214b173882452c73af06d62d \
-    --hash=sha256:f3ef94aefed6e183e342a8a269ae1fc4742ba193186ad76f175938621dbfc26b
 prompt_toolkit==3.0.43 \
     --hash=sha256:3527b7af26106cbc65a040bcc84839a3566ec1b051bb0bfe953631e704b0ff7d \
     --hash=sha256:a11a29cb3bf0a28a387fe5122cdb649816a957cd9261dcedf8c9f1fef33eacf6


### PR DESCRIPTION
Relates to: Relates to: https://mozilla-hub.atlassian.net/browse/ADDSRV-720

### Description

This pull request updates the Dockerfile to compile locales independently of the prod.txt pip install. It introduces a new make target `compile_locales` that installs the necessary dependencies and runs the `compile-mo.sh` script to compile the translation strings. This change improves the build process and allows locale compilation to occur in parallel with the pip install step.

### Testing

1. clean your repo.

```bash
make clean_docker
```

Recommended (git clean)

```bash
git clean -xdf
```

2. Build the image.

```
make build_docker_image
```

3. Inspect the container to ensure there are locale .mo files

```bash
docker run --rm -it --platform linux/amd64 mozilla/addons-server:local ls -lan /data/olympia/locale/af/LC_MESSAGES
```

There should be .mo files in there.

4. Run locale tests in the container (docker compose up first)

```bash
pytest -n 2 -m 'needs_locales_compilation' -v src/olympia/
```


