### PR TITLE
Add "build" to version.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -500,7 +500,8 @@ commands:
               # We can use a hardcoded tag here because we're not pushing
               # an image but just testing the build
               DOCKER_VERSION="branch" \
-              DOCKER_COMMIT="$CIRCLE_SHA1"
+              DOCKER_COMMIT="$CIRCLE_SHA1" \
+              VERSION_BUILD_URL="$CIRCLE_BUILD_URL"
       - run:
             name: Install Python and Node dependencies
             command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,7 +365,8 @@ commands:
             make build_docker_image \
               DOCKER_TAG="app:build" \
               DOCKER_VERSION=<< parameters.image_tag >> \
-              DOCKER_COMMIT="$CIRCLE_SHA1"
+              DOCKER_COMMIT="$CIRCLE_SHA1" \
+              VERSION_BUILD_URL="$CIRCLE_BUILD_URL"
             docker images
       - when:
           condition: << parameters.push >>

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -19,6 +19,9 @@ inputs:
     default: "invalid"
 
 outputs:
+  version:
+    description: "The Docker version for the image"
+    value: ${{ steps.meta.outputs.version }}
   tags:
     description: "The Docker tags for the image"
     value: ${{ steps.meta.outputs.tags }}

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -75,7 +75,8 @@ runs:
       run: |
         make version \
           DOCKER_VERSION="${{ steps.meta.outputs.version }}" \
-          DOCKER_COMMIT=${{ github.sha }}
+          DOCKER_COMMIT="${{ github.sha }}" \
+          VERSION_BUILD_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
     - name: Build Image
       uses: docker/build-push-action@v5

--- a/.github/workflows/verify-docker-image.yml
+++ b/.github/workflows/verify-docker-image.yml
@@ -26,3 +26,26 @@ jobs:
             echo 'from olympia.lib.settings_base import *' > settings_local.py
             DJANGO_SETTINGS_MODULE='settings_local' python3 ./manage.py check
 
+      - id: version
+        shell: bash
+        run: |
+          # Create the version JSON we expect
+          make version \
+            DOCKER_VERSION="${{ steps.build.outputs.version }}" \
+            DOCKER_COMMIT="${{ github.sha }}" \
+            VERSION_BUILD_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          # Extract the version JSON from the image
+          touch version-container.json
+          docker run \
+            -v $(pwd)/version-container.json:/data/olympia/version-container.json \
+            --rm -u 0 ${{ steps.build.outputs.tags }} \
+            cp version.json version-container.json
+
+          # expect them to be the same
+          if [[ "$(cat version.json)" != "$(cat version-container.json)" ]]; then
+            echo "version.json is incorrect"
+            exit 1
+          else
+            echo "version.json is correct"
+          fi

--- a/Makefile-os
+++ b/Makefile-os
@@ -13,6 +13,7 @@ DOCKER_CACHE_DIR := docker-cache
 
 export DOCKER_VERSION ?= local
 export DOCKER_COMMIT ?= $(shell git rev-parse --short HEAD)
+export VERSION_BUILD_URL ?= local
 
 .PHONY: help_redirect
 help_redirect:
@@ -70,7 +71,7 @@ endif
 
 .PHONY: version
 version: ## create version.json file
-	./scripts/version.sh $(DOCKER_VERSION) $(DOCKER_COMMIT)
+	./scripts/version.sh $(DOCKER_VERSION) $(DOCKER_COMMIT) $(VERSION_BUILD_URL)
 
 .PHONY: build_docker_image
 build_docker_image: create_docker_builder version ## Build the docker image
@@ -86,7 +87,7 @@ clean_docker: ## Clean up docker containers, images, caches, volumes and local c
 	rm -rf ./deps/**
 
 .PHONY: initialize_docker
-initialize_docker: create_env_file
+initialize_docker: create_env_file build_docker_image
 # Run a fresh container from the base image to install deps. Since /deps is
 # shared via a volume in docker-compose.yml, this installs deps for both web
 # and worker containers, and does so without requiring the containers to be up.

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -7,11 +7,14 @@ set -xue
 version=$1
 # we use the current HEAD as commit
 commit=$2
+# link to the job which produced the image
+build=$3
 
 cat <<EOF > version.json
 {
   "commit": "$commit",
   "version": "$version",
+  "build": "$build",
   "source": "https://github.com/mozilla/addons-server"
 }
 EOF


### PR DESCRIPTION
Fixes: https://github.com/mozilla/addons/issues/1785

### Description

Adds "build" prop to version.json with a test to verify it exists in the container on CI.

### Context

we don't rely on this property locally, but our deployment jobs expect this value to contain a link to the job which produced the image to be deployed

### Testing

You can build the container locally

```bash
make build_docker_image
```

and then inspect the file


```bash
docker run --rm -it --platform linux/amd64 <image> cat version.json
```

You can run the test locally by copying the bash script from the verify workflow. This essentially creates a new version.json with a different file, mounts it, and compares the container and host versions.



