### PR TITLE
send enforcement action to cinder & use jobs decision endpoint

### DIFF
--- a/src/olympia/abuse/cinder.py
+++ b/src/olympia/abuse/cinder.py
@@ -148,7 +148,7 @@ class CinderEntity:
         else:
             raise ConnectionError(response.content)
 
-    def create_decision(self, *, reasoning, policy_uuids):
+    def create_decision(self, *, action, reasoning, policy_uuids):
         if self.type is None:
             # type needs to be defined by subclasses
             raise NotImplementedError
@@ -159,6 +159,8 @@ class CinderEntity:
             'entity': self.get_attributes(),
             'reasoning': self.get_str(reasoning),
             'policy_uuids': policy_uuids,
+            'enforcement_actions_slugs': [action],
+            'enforcement_actions_update_strategy': 'set',
         }
         response = requests.post(url, json=data, headers=self.get_cinder_http_headers())
         if response.status_code == 201:

--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -1027,6 +1027,7 @@ class CinderDecision(ModelBase):
                 .values_list('reason__cinder_policy', flat=True)
             ).without_parents_if_their_children_are_present()
             decision_cinder_id = entity_helper.create_decision(
+                action=self.action.api_value,
                 reasoning=log_entry.details.get('comments', ''),
                 policy_uuids=[policy.uuid for policy in policies],
             )

--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -285,9 +285,6 @@ class CinderJob(ModelBase):
         else:
             self.pending_rejections.clear()
 
-        if self.resolvable_in_reviewer_tools:
-            entity_helper.close_job(job_id=self.job_id)
-
 
 class AbuseReportQuerySet(BaseQuerySet):
     def for_addon(self, addon):
@@ -1026,11 +1023,17 @@ class CinderDecision(ModelBase):
                 .filter(reason__cinder_policy__isnull=False)
                 .values_list('reason__cinder_policy', flat=True)
             ).without_parents_if_their_children_are_present()
-            decision_cinder_id = entity_helper.create_decision(
-                action=self.action.api_value,
-                reasoning=log_entry.details.get('comments', ''),
-                policy_uuids=[policy.uuid for policy in policies],
-            )
+            create_decision_kw = {
+                'action': self.action.api_value,
+                'reasoning': log_entry.details.get('comments', ''),
+                'policy_uuids': [policy.uuid for policy in policies],
+            }
+            if cinder_job := getattr(self, 'cinder_job', None):
+                decision_cinder_id = entity_helper.create_job_decision(
+                    job_id=cinder_job.job_id, **create_decision_kw
+                )
+            else:
+                decision_cinder_id = entity_helper.create_decision(**create_decision_kw)
             with atomic():
                 self.cinder_id = decision_cinder_id
                 self.save()

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -1960,6 +1960,9 @@ class TestCinderDecision(TestCase):
             assert request_body['policy_uuids'] == ['12345678']
             assert request_body['reasoning'] == 'some review text'
             assert request_body['entity']['id'] == str(decision.addon.id)
+            assert request_body['enforcement_actions_slugs'] == [
+                cinder_action.api_value
+            ]
             self.assertCloseToNow(decision.date)
             assert list(decision.policies.all()) == policies
             assert CinderDecision.objects.count() == 1

--- a/src/olympia/abuse/tests/test_tasks.py
+++ b/src/olympia/abuse/tests/test_tasks.py
@@ -597,15 +597,9 @@ def test_resolve_job_in_cinder(statsd_incr_mock):
     )
     responses.add(
         responses.POST,
-        f'{settings.CINDER_SERVER_URL}create_decision',
+        f'{settings.CINDER_SERVER_URL}jobs/{cinder_job.job_id}/decision',
         json={'uuid': '123'},
         status=201,
-    )
-    responses.add(
-        responses.POST,
-        f'{settings.CINDER_SERVER_URL}jobs/{cinder_job.job_id}/cancel',
-        json={'external_id': cinder_job.job_id},
-        status=200,
     )
     statsd_incr_mock.reset_mock()
     review_action_reason = ReviewActionReason.objects.create(
@@ -629,7 +623,6 @@ def test_resolve_job_in_cinder(statsd_incr_mock):
     request_body = json.loads(request.body)
     assert request_body['policy_uuids'] == ['12345678']
     assert request_body['reasoning'] == 'some review text'
-    assert request_body['entity']['id'] == str(abuse_report.target.id)
     cinder_job.reload()
     assert cinder_job.decision.action == DECISION_ACTIONS.AMO_DISABLE_ADDON
 
@@ -651,7 +644,7 @@ def test_resolve_job_in_cinder_exception(statsd_incr_mock):
     )
     responses.add(
         responses.POST,
-        f'{settings.CINDER_SERVER_URL}create_decision',
+        f'{settings.CINDER_SERVER_URL}jobs/999/decision',
         json={'uuid': '123'},
         status=500,
     )

--- a/src/olympia/api/utils.py
+++ b/src/olympia/api/utils.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 
 from extended_choices import Choices
-from extended_choices.helpers import ChoiceEntry
+from extended_choices.helpers import ChoiceAttributeMixin, ChoiceEntry
 
 
 def is_gate_active(request, name):
@@ -41,8 +41,17 @@ class UnderscoreSeperatorConvertor:
         return slug.upper() if slug else slug
 
 
+class APIChoiceAttributeMixin(ChoiceAttributeMixin):
+    @property
+    def api_value(self):
+        """Property that returns the ``api_value`` attribute of the attached
+        ``APIChoiceEntry``."""
+        return self.choice_entry.api_value
+
+
 class APIChoiceEntry(ChoiceEntry):
     convertor = UnderscoreSeperatorConvertor
+    ChoiceAttributeMixin = APIChoiceAttributeMixin
 
     @property
     def api_value(self):

--- a/src/olympia/reviewers/tests/test_commands.py
+++ b/src/olympia/reviewers/tests/test_commands.py
@@ -1341,9 +1341,9 @@ class TestAutoReject(TestCase):
         AbuseReport.objects.create(guid=self.addon.guid, cinder_job=cinder_job)
         responses.add(
             responses.POST,
-            f'{settings.CINDER_SERVER_URL}jobs/{cinder_job.job_id}/cancel',
-            json={'external_id': cinder_job.job_id},
-            status=200,
+            f'{settings.CINDER_SERVER_URL}jobs/1/decision',
+            json={'uuid': cinder_job.job_id},
+            status=201,
         )
         policies = [CinderPolicy.objects.create(name='policy', uuid='12345678')]
         review_action_reason = ReviewActionReason.objects.create(
@@ -1386,15 +1386,9 @@ class TestAutoReject(TestCase):
         )
         responses.add(
             responses.POST,
-            f'{settings.CINDER_SERVER_URL}create_decision',
+            f'{settings.CINDER_SERVER_URL}jobs/2/decision',
             json={'uuid': '123'},
             status=201,
-        )
-        responses.add(
-            responses.POST,
-            f'{settings.CINDER_SERVER_URL}jobs/{cinder_job.job_id}/cancel',
-            json={'external_id': cinder_job.job_id},
-            status=200,
         )
         policies = [CinderPolicy.objects.create(name='policy', uuid='12345678')]
         review_action_reason = ReviewActionReason.objects.create(

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -2127,6 +2127,11 @@ class TestReviewHelper(TestReviewHelperBase):
     def test_reject_multiple_versions_resolving_abuse_report(self):
         cinder_job = CinderJob.objects.create(job_id='1')
         AbuseReport.objects.create(guid=self.addon.guid, cinder_job=cinder_job)
+        responses.add_callback(
+            responses.POST,
+            f'{settings.CINDER_SERVER_URL}jobs/1/decision',
+            callback=lambda r: (201, {}, json.dumps({'uuid': uuid.uuid4().hex})),
+        )
         self._test_reject_multiple_versions({'resolve_cinder_jobs': [cinder_job]})
         message = mail.outbox[0]
         self.check_subject(message)
@@ -2212,6 +2217,11 @@ class TestReviewHelper(TestReviewHelperBase):
     def test_reject_multiple_versions_with_delay_resolving_abuse_reports(self):
         cinder_job = CinderJob.objects.create(job_id='1')
         AbuseReport.objects.create(guid=self.addon.guid, cinder_job=cinder_job)
+        responses.add_callback(
+            responses.POST,
+            f'{settings.CINDER_SERVER_URL}jobs/1/decision',
+            callback=lambda r: (201, {}, json.dumps({'uuid': uuid.uuid4().hex})),
+        )
         self._test_reject_multiple_versions_with_delay(
             {'resolve_cinder_jobs': [cinder_job]}
         )


### PR DESCRIPTION
fixes mozilla/addons#14778 and fixes mozilla/addons#xxx

Fixed these two issues together as they touched the same code (but as two commits).  Now we send the enforcement action in addition to the policies a decision was made under, and if there's a job we use the new job specific endpoint for creating the decision (also means we don't need to close the job manually afterwards)