### PR TITLE
Load service data via portable and persistent data volumes 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,6 +369,10 @@ commands:
             echo 'export DOCKER_PUSH=<< parameters.push >>' >> $BASH_ENV
             echo 'export DOCKER_OUTPUT=<< parameters.output_file >>' >> $BASH_ENV
       - run:
+          name: Docker build config
+          command: |
+            make docker_compose_config
+      - run:
           name: Build docker image and push to repo
           command: |
             docker version

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ private/
 
 # do not ignore the following files
 !docker-compose.private.yml
+!docker-compose.data.yml
 !private/README.md
 !deps/.keep
 
@@ -66,3 +67,6 @@ docker-cache-new/
 
 # Ignore the version.json as this should be created during the build
 version.json
+
+# Ignore db backup files
+backups

--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,6 @@ private/
 
 # do not ignore the following files
 !docker-compose.private.yml
-!docker-compose.data.yml
 !private/README.md
 !deps/.keep
 

--- a/Makefile-docker
+++ b/Makefile-docker
@@ -96,7 +96,10 @@ initialize_db: ## create a new database
 	$(PYTHON_COMMAND) manage.py migrate --noinput
 	$(PYTHON_COMMAND) manage.py loaddata initial.json
 	$(PYTHON_COMMAND) manage.py import_prod_versions
-	$(PYTHON_COMMAND) manage.py createsuperuser
+	$(PYTHON_COMMAND) manage.py createsuperuser \
+		--no-input \
+		--username "$(SUPERUSER_USERNAME)" \
+		--email $(SUPERUSER_EMAIL)
 	$(PYTHON_COMMAND) manage.py loaddata zadmin/users
 
 .PHONY: populate_data

--- a/Makefile-docker
+++ b/Makefile-docker
@@ -102,6 +102,10 @@ initialize_db: ## create a new database
 		--email $(SUPERUSER_EMAIL)
 	$(PYTHON_COMMAND) manage.py loaddata zadmin/users
 
+.PHONY: reindex_data
+reindex_data: ## reindex the data in elasticsearch
+	$(PYTHON_COMMAND) manage.py reindex --force --noinput
+
 .PHONY: populate_data
 populate_data: ## populate a new database
 	# reindex --wipe will force the ES mapping to be re-installed. Useful to
@@ -114,9 +118,6 @@ populate_data: ## populate a new database
 	# homepage. You may have to re-run this, in case the data there
 	# changes.
 	$(PYTHON_COMMAND) manage.py generate_default_addons_for_frontend
-
-	# Now that addons have been generated, reindex.
-	$(PYTHON_COMMAND) manage.py reindex --force --noinput
 
 .PHONY: update_deps_pip
 update_deps_pip: ## Install pip
@@ -228,7 +229,7 @@ dbshell: ## connect to a database shell
 	$(PYTHON_COMMAND) ./manage.py dbshell
 
 .PHONY: initialize
-initialize: update_deps initialize_db update_assets populate_data ## init the dependencies, the database, and assets
+initialize: update_deps initialize_db update_assets populate_data reindex_data ## init the dependencies, the database, and assets
 
 .PHONY: reload
 reload: ## force django code reload

--- a/Makefile-os
+++ b/Makefile-os
@@ -53,10 +53,6 @@ create_env_file:
 	echo "SUPERUSER_EMAIL=${SUPERUSER_EMAIL}" >> .env
 	echo "SUPERUSER_USERNAME=${SUPERUSER_USERNAME}" >> .env
 
-SERVICES_PATHS := \
-    "elasticsearch:/usr/share/elasticsearch/data" \
-    "rabbitmq:/var/lib/rabbitmq"
-
 .PHONY: data_export
 data_export:
 	@ mkdir -p $(EXPORT_DIR)

--- a/Makefile-os
+++ b/Makefile-os
@@ -10,6 +10,10 @@ VERSION_BUILD_URL ?= build
 # Exporting these variables make them default values for docker-compose*.yml files
 export DOCKER_VERSION ?= local
 
+# define the username and email for the superuser in the container
+SUPERUSER_EMAIL=$(shell git config user.email)
+SUPERUSER_USERNAME=$(shell git config user.name)
+
 .PHONY: help_redirect
 help_redirect:
 	@$(MAKE) help --no-print-directory
@@ -42,7 +46,10 @@ rootshell: ## connect to a running addons-server docker shell with root user
 
 .PHONY: create_env_file
 create_env_file:
-	echo "HOST_UID=${HOST_UID}" > .env
+	@ rm -f .env
+	echo "HOST_UID=${HOST_UID}" >> .env
+	echo "SUPERUSER_EMAIL=${SUPERUSER_EMAIL}" >> .env
+	echo "SUPERUSER_USERNAME=${SUPERUSER_USERNAME}" >> .env
 
 .PHONY: create_docker_builder
 create_docker_builder: ## Create a custom builder for buildkit to efficiently build local images

--- a/Makefile-os
+++ b/Makefile-os
@@ -64,6 +64,10 @@ data_export:
 data_restore:
 	@[ -d $(RESTORE_DIR) ] || (echo "Directory $(RESTORE_DIR) does not exist" && exit 1)
 
+	# Wait for MySQL server to be ready
+	docker compose exec mysqld bash \
+	-c 'while ! mysqladmin ping --silent; do echo "waiting"; sleep 1; done'
+
 	# Restoring mysql database
 	docker compose exec -T mysqld /usr/bin/mysql olympia < $(RESTORE_DIR)/data_mysqld.sql
 

--- a/Makefile-os
+++ b/Makefile-os
@@ -7,6 +7,7 @@ DOCKER_PUSH ?= false
 DOCKER_OUTPUT ?=
 DOCKER_COMMIT ?= $(shell git rev-parse HEAD || echo "commit")
 VERSION_BUILD_URL ?= build
+export DOCKER_MYSQLD_VOLUME = addons-server_data_mysqld
 
 BACKUPS_DIR = $(shell pwd)/backups
 EXPORT_DIR = $(BACKUPS_DIR)/$(shell date +%Y%m%d%H%M%S)
@@ -108,18 +109,25 @@ docker_compose_config: ## Show the docker compose configuration
 build_docker_image: create_docker_builder version ## Build the docker image
 	docker buildx bake web $(DOCKER_BUILD_ARGS)
 
+.PHONY: docker_mysqld_volume_create
+docker_mysqld_volume_create: ## Create the mysqld volume
+	docker volume create $(DOCKER_MYSQLD_VOLUME)
+
+.PHONY: docker_mysqld_volume_remove
+docker_mysqld_volume_remove: ## Remove the mysqld volume
+	docker volume rm $(DOCKER_MYSQLD_VOLUME)
+
 .PHONY: docker_compose_down
 docker_compose_down: ## Stop the docker containers
-	docker compose down --rmi local --remove-orphans
+	docker compose down --rmi local --remove-orphans --volumes
 
 .PHONY: clean_docker
-clean_docker: docker_compose_down ## Clean up docker containers, images, caches, volumes and local cache directories. Use with caution. To restart the app run make initialize_docker after this command.
-	docker compose down --volumes
+clean_docker: docker_compose_down docker_mysqld_volume_remove ## Clean up docker containers, images, caches, volumes and local cache directories. Use with caution. To restart the app run make initialize_docker after this command.
 	docker buildx prune -af
 	rm -rf ./deps/**
 
 .PHONY: docker_compose_up
-docker_compose_up: ## Start the docker containers
+docker_compose_up: docker_mysqld_volume_create ## Start the docker containers
 	docker compose up $(DOCKER_SERVICES) -d --wait --remove-orphans --force-recreate --quiet-pull $(ARGS)
 
 .PHONY: docker_extract_deps
@@ -138,7 +146,7 @@ docker_extract_deps: ## Extract dependencies from the docker image to a local vo
 	docker compose run --rm web make update_deps
 
 .PHONY: up
-up: create_env_file version docker_extract_deps docker_compose_up ## Create and start docker compose
+up: create_env_file version docker_mysqld_volume_create docker_extract_deps docker_compose_up ## Create and start docker compose
 
 .PHONY: down
 down: docker_compose_down ## Stop the docker containers

--- a/Makefile-os
+++ b/Makefile-os
@@ -7,6 +7,11 @@ DOCKER_PUSH ?= false
 DOCKER_OUTPUT ?=
 DOCKER_COMMIT ?= $(shell git rev-parse HEAD || echo "commit")
 VERSION_BUILD_URL ?= build
+
+BACKUPS_DIR = $(shell pwd)/backups
+EXPORT_DIR = $(BACKUPS_DIR)/$(shell date +%Y%m%d%H%M%S)
+RESTORE_DIR ?= $(BACKUPS_DIR)/$(shell ls -1 backups | sort -r | head -n 1)
+
 # Exporting these variables make them default values for docker-compose*.yml files
 export DOCKER_VERSION ?= local
 
@@ -30,11 +35,7 @@ push_locales: ## extracts and merges translation strings
 	bash ./scripts/push_l10n_extraction.sh $(ARGS)
 
 .PHONY: update_docker
-update_docker: ## update all the docker images
-	docker compose exec --user olympia worker make update_deps
-	docker compose exec --user olympia web make update
-	docker compose restart web
-	docker compose restart worker
+update_docker: data_export up data_restore ## update all the docker images
 
 .PHONY: shell
 shell: ## connect to a running addons-server docker shell
@@ -50,6 +51,26 @@ create_env_file:
 	echo "HOST_UID=${HOST_UID}" >> .env
 	echo "SUPERUSER_EMAIL=${SUPERUSER_EMAIL}" >> .env
 	echo "SUPERUSER_USERNAME=${SUPERUSER_USERNAME}" >> .env
+
+SERVICES_PATHS := \
+    "elasticsearch:/usr/share/elasticsearch/data" \
+    "rabbitmq:/var/lib/rabbitmq"
+
+.PHONY: data_export
+data_export:
+	@ mkdir -p $(EXPORT_DIR)
+
+	# Extracting mysql database
+	docker compose exec mysqld /usr/bin/mysqldump olympia > $(EXPORT_DIR)/data_mysqld.sql
+
+.PHONY: data_restore
+data_restore:
+	@[ -d $(RESTORE_DIR) ] || (echo "Directory $(RESTORE_DIR) does not exist" && exit 1)
+
+	# Restoring mysql database
+	docker compose exec -T mysqld /usr/bin/mysql olympia < $(RESTORE_DIR)/data_mysqld.sql
+
+	$(MAKE) reindex_data
 
 .PHONY: create_docker_builder
 create_docker_builder: ## Create a custom builder for buildkit to efficiently build local images
@@ -84,18 +105,25 @@ docker_compose_config: ## Show the docker compose configuration
 	echo $(DOCKER_BUILD_ARGS)
 
 .PHONY: build_docker_image
-build_docker_image: create_docker_builder version docker_compose_config ## Build the docker image
-	docker buildx bake web $(DOCKER_BUILD_ARGS) --print
+build_docker_image: create_docker_builder version ## Build the docker image
 	docker buildx bake web $(DOCKER_BUILD_ARGS)
 
+.PHONY: docker_compose_down
+docker_compose_down: ## Stop the docker containers
+	docker compose down --rmi local --remove-orphans
+
 .PHONY: clean_docker
-clean_docker: ## Clean up docker containers, images, caches, volumes and local cache directories. Use with caution. To restart the app run make initialize_docker after this commandUse with caution.
-	docker compose down --rmi local --volumes --remove-orphans
+clean_docker: docker_compose_down ## Clean up docker containers, images, caches, volumes and local cache directories. Use with caution. To restart the app run make initialize_docker after this command.
+	docker compose down --volumes
 	docker buildx prune -af
 	rm -rf ./deps/**
 
-.PHONY: initialize_docker
-initialize_docker: create_env_file build_docker_image
+.PHONY: docker_compose_up
+docker_compose_up: ## Start the docker containers
+	docker compose up $(DOCKER_SERVICES) -d --wait --remove-orphans --force-recreate --quiet-pull $(ARGS)
+
+.PHONY: docker_extract_deps
+docker_extract_deps: ## Extract dependencies from the docker image to a local volume mount
 # Run a fresh container from the base image to install deps. Since /deps is
 # shared via a volume in docker-compose.yml, this installs deps for both web
 # and worker containers, and does so without requiring the containers to be up.
@@ -108,7 +136,15 @@ initialize_docker: create_env_file build_docker_image
 	# mounting ./deps:/deps effectively removes dependencies from the /deps directory in the container
 	# running `update_deps` will install the dependencies in the /deps directory before running
 	docker compose run --rm web make update_deps
-	docker compose up -d
+
+.PHONY: up
+up: create_env_file version docker_extract_deps docker_compose_up ## Create and start docker compose
+
+.PHONY: down
+down: docker_compose_down ## Stop the docker containers
+
+.PHONY: initialize_docker
+initialize_docker: up
 	docker compose exec --user olympia web make initialize
 
 %: ## This directs any other recipe (command) to the web container's make.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,7 @@ services:
       - supervisord -n -c /data/olympia/docker/supervisor-celery.conf
     volumes:
       - .:/data/olympia
+      - storage:/data/olympia/storage
       - ./deps:/deps
       - ./package.json:/deps/package.json
       - ./package-lock.json:/deps/package-lock.json
@@ -66,10 +67,10 @@ services:
       - ./docker/nginx/addons.conf:/etc/nginx/conf.d/addons.conf
       - ./static:/srv/static
       - ./site-static:/srv/site-static
-      - ./storage/shared_storage/uploads:/srv/user-media
-      - ./storage/files:/srv/user-media/addons
-      - ./storage/guarded-addons:/srv/user-media/guarded-addons
-      - ./storage/sitemaps:/srv/user-media/sitemaps
+      - storage:/shared_storage/uploads:/srv/user-media
+      - storage:/files:/srv/user-media/addons
+      - storage:/guarded-addons:/srv/user-media/guarded-addons
+      - storage:/sitemaps:/srv/user-media/sitemaps
     ports:
       - "80:80"
     networks:
@@ -92,6 +93,8 @@ services:
       - MYSQL_DATABASE=olympia
     ports:
     - "3306:3306"
+    volumes:
+      - data_mysqld:/var/lib/mysql
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.17.3
@@ -107,6 +110,8 @@ services:
       - "discovery.type=single-node"
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     mem_limit: 2g
+    volumes:
+      - data_elasticsearch:/usr/share/elasticsearch/data
 
   redis:
     image: redis:6.2
@@ -120,6 +125,8 @@ services:
       - RABBITMQ_DEFAULT_USER=olympia
       - RABBITMQ_DEFAULT_PASS=olympia
       - RABBITMQ_DEFAULT_VHOST=olympia
+    volumes:
+      - data_rabbitmq:/var/lib/rabbitmq
 
   autograph:
     image: mozilla/autograph:3.3.2
@@ -147,3 +154,14 @@ services:
 
 networks:
   default:
+
+volumes:
+  data_elasticsearch:
+  data_mysqld:
+  data_rabbitmq:
+  storage:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: ${PWD}/storage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,9 @@ x-env-mapping: &env
     # it exists. ./docker/entrypoint.sh uses this variable to fix
     # the uid of the olympia user to match the host user id if necessary.
     - HOST_UID=${HOST_UID:-}
+    # This is the email address of the superuser created when initializing the db
+    - SUPERUSER_EMAIL=${SUPERUSER_EMAIL:-admin@mozilla.com}
+    - SUPERUSER_USERNAME=${SUPERUSER_USERNAME:-admin}
 
 services:
   worker: &worker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -161,6 +161,8 @@ volumes:
   data_redis:
   data_elasticsearch:
   data_mysqld:
+    name: ${DOCKER_MYSQLD_VOLUME:-}
+    external: true
   data_rabbitmq:
   storage:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,6 +115,8 @@ services:
 
   redis:
     image: redis:6.2
+    volumes:
+      - data_redis:/data
 
   rabbitmq:
     image: rabbitmq:3.12
@@ -156,6 +158,7 @@ networks:
   default:
 
 volumes:
+  data_redis:
   data_elasticsearch:
   data_mysqld:
   data_rabbitmq:


### PR DESCRIPTION
### Description

Relates to: https://github.com/mozilla/addons/issues/14784

Load data in `mysqld`, `elasticsearch`, `rabbitmq` services via persistent data volumes. Also load the `storage` data via a persistent volume.

Some of these volumes are exportable and importable via make commands which allows an environment to be "saved" at a particular point in time and then "resumed" with that exact set of data across the relevant containers.

Persistence:

- Mysql: exportable/importable persistent volume
- Storage: persistent volume mounted on host (already exported)
- Rabbitmq: persistent not re-storeable (is there a need?)
- Elasticsearch: persistent not re-storeable (can be reindexed instead)
- Redis: persistent not re-storeable (no need for in memory)

### Context

By moving our data to data volumes, we decouple the lifecycle of a compose project and it's containers from the data in the containers.

This means you can restart, recreate or totally reinstantiate your entire environment without destryoing any historical data you may have.

Additionally, this opens the possibility to load a snapshot of the database from one environment in another. There are a multitude of use cases for this such as testing or supporting multiple profiles of initial data.

### Testing

#### Export data

First make a snapshot by running. It's important you do this first.

```bash
make data_export
```

This will create a directory `backups/<timestamp>` that will contain a tar file for each volume. this tar file contains the extracted data the container had at the moment of extraction. We do this first just to make sure we keep a snapshot of the original data.

#### Data persisting across containers

Now, try totally recreating your environment to see that the volume data is persisted. Note, we are not using the snapshot yet, we are just recreating the containers.

```bash
make down
make up
```

This creates a totally fresh environment by building the docker image and re-creating all containers, wiping any local state they may have. You will still have all of your data though because the data itself is located in the still running volumes.

You should run make down the first time, to decouple any links to anonymous volumes `make down` and `make up` but running make up will recreate containers even if they are already running in the future.

Now you can test that the app is running, but there should basically be no database.. the volumes are empty.

You should get an error like this on /login

<img width="1812" alt="image" src="https://github.com/mozilla/addons-server/assets/19595165/e423ca35-be88-4559-8fe7-855572ab63b8">

And like this on the home page.

<img width="1542" alt="image" src="https://github.com/mozilla/addons-server/assets/19595165/1e581848-d5d3-4719-92d6-00192eea4fa3">

That is where our snapshot comes in.

#### Restore from the base snapshot.

Run `make data_restore` and you should have a restored environment.

#### Data persist from snapshot

Now, change something in the environment. Maybe change your admin user name, or update an addon, anything to change the state from the first snapshot.

Create a new snapshot, again `make data_export`

Now you can restore the first snapshot and see the data snap back.

```bash
make data_restore RESTORE_DIR=/Users/kmeinhardt/src/mozilla/addons-server/backups/<timestamp>
```

Make sure to include the full absolute path, and also include the timestamp from the FIRST snapshot.

Now you can check that the data has been restored to before you made the change. You can restore the change by running again `make data_restore` and pass the path to the newer snapshot, or pass no arguments. By default the command will restore the latest snapshot.
