### PR TITLE
Replace email link with EW page for suppressed email troubleshooting

### DIFF
--- a/src/olympia/devhub/templates/devhub/verify_email.html
+++ b/src/olympia/devhub/templates/devhub/verify_email.html
@@ -98,8 +98,8 @@
 {% with submit_text=button_text %}
   {% include 'devhub/verify_email_form.html' %}
 {% endwith %}
-{% trans %}
-  Having trouble? Please <a href="mailto:{{ support_email }}?subject={{ support_subject }}&body={{ support_body }}">contact AMO Admins</a> if you need help.
+{% trans a_attrs='target="_blank" rel="noopener noreferrer" href="%s/documentation/publish/developer-accounts/#email-issues?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=devhub"'|format(settings.EXTENSION_WORKSHOP_URL)|safe%}
+  If you encounter issues, please see our <a {{ a_attrs }}>troubleshooting suggestions</a> on Firefox Extension Workshop.
 {% endtrans %}
 </div>
 {% endif %}

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -2361,6 +2361,12 @@ class TestVerifyEmail(TestCase):
             assert 'Send another email' in doc.text()
 
             assert 'If you encounter issues' in doc.text()
+            support_link = doc('a:contains("troubleshooting suggestions")')
+            assert (
+                '/documentation/publish/developer-accounts/#email-issues'
+                '?utm_source=addons.mozilla.org&utm_medium=referral'
+                '&utm_content=devhub' in support_link.attr('href')
+            )
 
     @mock.patch('olympia.devhub.views.check_suppressed_email_confirmation')
     def test_get_verification_delivered(self, mock_check_suppressed):

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -2360,12 +2360,7 @@ class TestVerifyEmail(TestCase):
             assert 'It is taking longer than expected' in doc.text()
             assert 'Send another email' in doc.text()
 
-            assert 'Having trouble?' in doc.text()
-            support_link = doc('a:contains("contact AMO Admins")')
-            assert f'mailto:{settings.SUPPORT_EMAIL}' in support_link.attr('href')
-            assert '?subject=Suppressed Email verification' in support_link.attr('href')
-            assert 'I have a suppressed email' in support_link.attr('href')
-            assert self.user_profile.email in support_link.attr('href')
+            assert 'If you encounter issues' in doc.text()
 
     @mock.patch('olympia.devhub.views.check_suppressed_email_confirmation')
     def test_get_verification_delivered(self, mock_check_suppressed):

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -2179,12 +2179,6 @@ def email_verification(request):
         raise Exception('Invalid view must result in assigned state')
 
     if data['state'] in RENDER_BUTTON_STATES:
-        data['support_email'] = settings.SUPPORT_EMAIL
-        data['support_subject'] = 'Suppressed Email verification'
-        data['support_body'] = (
-            'I have a suppressed email and I need help verifying it. '
-            f'email: {request.user.email}.'
-        )
         data['render_button'] = True
         data['button_text'] = get_button_text(data['state'])
 

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1553,5 +1553,3 @@ CINDER_QUEUE_PREFIX = 'amo-dev-'
 SOCKET_LABS_HOST = env('SOCKET_LABS_HOST', default='https://api.socketlabs.com/v2/')
 SOCKET_LABS_TOKEN = env('SOCKET_LABS_TOKEN', default=None)
 SOCKET_LABS_SERVER_ID = env('SOCKET_LABS_SERVER_ID', default=None)
-
-SUPPORT_EMAIL = 'amo-admins+amo_devhub@mozilla.org'


### PR DESCRIPTION
Fix https://github.com/mozilla/addons/issues/14786 by replacing email link with link to EW page.
