### PR TITLE
Print docker image digest as a part of the CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -356,6 +356,9 @@ commands:
       image_tag:
         type: string
         default: "latest"
+      output_file:
+        type: string
+        default: "bake-result.json"
     steps:
       - run:
           name: Set environment variables
@@ -364,12 +367,17 @@ commands:
             echo 'export DOCKER_COMMIT=$CIRCLE_SHA1' >> $BASH_ENV
             echo 'export VERSION_BUILD_URL=$CIRCLE_BUILD_URL' >> $BASH_ENV
             echo 'export DOCKER_PUSH=<< parameters.push >>' >> $BASH_ENV
+            echo 'export DOCKER_OUTPUT=<< parameters.output_file >>' >> $BASH_ENV
       - run:
           name: Build docker image and push to repo
           command: |
             docker version
             docker login -u "${DOCKERHUB_USER}" -p "${DOCKERHUB_PASS}"
             make build_docker_image
+      - run:
+          name: Print Digest
+          command: |
+            cat << parameters.output_file >> | jq -r '.web."containerimage.digest"'
 
   better_checkout:
     description: circle ci checkout step on steroids
@@ -649,7 +657,7 @@ workflows:
       - devhub
       - main
       # Uncomment if you want to test the docker build
-      # - build-image
+      - build-image
       - reviewers-and-zadmin
       - es-tests
       - localization

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -657,7 +657,7 @@ workflows:
       - devhub
       - main
       # Uncomment if you want to test the docker build
-      - build-image
+      # - build-image
       - reviewers-and-zadmin
       - es-tests
       - localization

--- a/Makefile-os
+++ b/Makefile-os
@@ -4,6 +4,7 @@ export DOCKER_BUILDER=container
 
 DOCKER_PROGRESS ?= auto
 DOCKER_PUSH ?= false
+DOCKER_OUTPUT ?=
 DOCKER_COMMIT ?= $(shell git rev-parse HEAD || echo "commit")
 VERSION_BUILD_URL ?= build
 # Exporting these variables make them default values for docker-compose*.yml files
@@ -57,6 +58,10 @@ ifeq ($(DOCKER_PUSH), true)
 	DOCKER_BUILD_ARGS += --push
 else
 	DOCKER_BUILD_ARGS += --load
+endif
+
+ifneq ($(DOCKER_OUTPUT),)
+	DOCKER_BUILD_ARGS += --metadata-file=$(DOCKER_OUTPUT)
 endif
 
 .PHONY: version


### PR DESCRIPTION
Fixes: TBD

### Description

This pull request adds a temporary print statement to display the digest and tags after the build process. This is useful for debugging and verifying the build output.

### Context

Our deployment jobs are expecting to be able to read the digest of our tagged image as a part of the deployment flow. This is so we can verify the tag has not been updated during the build/deploy workflow. (I am kind of assuming here)

### Testing

This [step](https://circleci.com/api/v1.1/project/github/mozilla/addons-server/211685/output/104/0?file=true&allocation-id=66431b1f1039d4309c1e7b46-0-build%2FABCDEFGH) prints literally the digest only from the build.