### PR TITLE
Bump rabbitmq to 3.12 on local envs.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
     image: redis:6.2
 
   rabbitmq:
-    image: rabbitmq:3.8
+    image: rabbitmq:3.12
     hostname: olympia
     expose:
       - "5672"


### PR DESCRIPTION
Note: you _need_ to run `docker compose down rabbitmq` at some point to start fresh: https://www.rabbitmq.com/blog/2022/07/20/required-feature-flags-in-rabbitmq-3.11

Fixes mozilla/addons#2014