### PR TITLE
"Fix makefile env variables definition"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -667,7 +667,7 @@ workflows:
       - devhub
       - main
       # Uncomment if you want to test the docker build
-      - build-image
+      # - build-image
       - reviewers-and-zadmin
       - es-tests
       - localization

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,6 +369,12 @@ commands:
             echo 'export DOCKER_PUSH=<< parameters.push >>' >> $BASH_ENV
             echo 'export DOCKER_OUTPUT=<< parameters.output_file >>' >> $BASH_ENV
       - run:
+          name: Create .env file
+          command: |
+            # We must defined a .env file for the docker-compose config
+            # The values will be inferred by what is set in the bash env above.
+            make create_env_file
+      - run:
           name: Docker build config
           command: |
             make docker_compose_config
@@ -661,7 +667,7 @@ workflows:
       - devhub
       - main
       # Uncomment if you want to test the docker build
-      # - build-image
+      - build-image
       - reviewers-and-zadmin
       - es-tests
       - localization

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -73,13 +73,21 @@ runs:
           # The production build
           # type=raw,value=latest,enable={{is_default_branch}}
 
+    - name: Define environment variables
+      shell: bash
+      run: |
+        echo "DOCKER_VERSION=${{ steps.meta.outputs.version }}" >> $GITHUB_ENV
+        echo "DOCKER_COMMIT=${{ github.sha }}" >> $GITHUB_ENV
+        echo "VERSION_BUILD_URL=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_ENV
+
+    - name: Create .env file
+      shell: bash
+      run: make create_env_file
+
     - name: Create version
       shell: bash
       run: |
-        make version \
-          DOCKER_VERSION="${{ steps.meta.outputs.version }}" \
-          DOCKER_COMMIT="${{ github.sha }}" \
-          VERSION_BUILD_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        make version
 
     - name: Build Image
       uses: docker/bake-action@v4
@@ -87,5 +95,3 @@ runs:
         targets: web
         push: ${{ inputs.push }}
         load: ${{ inputs.push == 'false' }}
-      env:
-        DOCKER_VERSION: ${{ steps.meta.outputs.version }}

--- a/.github/workflows/verify-docker-image.yml
+++ b/.github/workflows/verify-docker-image.yml
@@ -11,42 +11,80 @@ jobs:
     strategy:
       matrix:
         include:
-          - expected: { version: local, push: false }
-            input: { version: '', push: '' }
-          - expected: { version: version, push: true }
-            input: { version: version, push: true }
+          - expected: { version: 'local', push: false, uid: ''}
+            input: { version: '', push: '', uid: '' }
+          - expected: { version: version, push: true, uid: '1' }
+            input: { version: version, push: true, uid: '1' }
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Check Docker Compose (default)
         id: default
-        env:
-          DOCKER_VERSION: ${{ matrix.input.version }}
-          DOCKER_PUSH: ${{ matrix.input.push }}
         shell: bash
         run: |
-          set -xue
-          config=$(make docker_compose_config)
+          set -ue
 
-          # Expect image tag is correct
-          echo $config | grep -q "image: mozilla/addons-server:${{ matrix.expected.version }}"
+          export SUPERUSER_EMAIL="email"
+          export SUPERUSER_USERNAME="username"
 
-          # Expect docker push args are correct
-          if [[ ${{ matrix.expected.push }} == "true" ]]; then
-            echo $config | grep -q -- "--push"
-            echo $config | grep -v -q -- "--load"
-          else
-            echo $config | grep -v -q -- "--push"
-            echo $config | grep -q -- "--load"
+          if [ -n "${{ matrix.input.version }}" ]; then
+            export DOCKER_VERSION="${{ matrix.expected.version }}"
           fi
 
-          # Expect docker platform is correct
-          echo $config | grep -q -- "platform: linux/amd64"
-          echo $config | grep -q -- "\"platforms\": \[
-            \"linux/amd64\"
-          \]"
+          if [ -n "${{ matrix.input.push }}" ]; then
+            export DOCKER_PUSH="${{ matrix.expected.push }}"
+          fi
 
+          if [ -n "${{ matrix.input.uid }}" ]; then
+            export HOST_UID="${{ matrix.expected.uid }}"
+          fi
+
+          function test_assert() {
+            echo "Expected: $1"
+            echo "Actual: $2"
+            if [ -n "${3:-}" ]; then echo "Message: $3"; fi
+            if [[ "$1" != "$2" ]]; then exit 1; fi
+          }
+
+          function test_compose() {
+            test_assert "$(make docker_compose_config | yq e $1 -)" "$2" "$1"
+          }
+
+          function test_bake() {
+            test_assert "$(make docker_build_config | jq -r $1)" "$2" "$1"
+          }
+
+          test_compose '.services.web.image' "mozilla/addons-server:${{ matrix.expected.version }}"
+
+          expected_id=$(id -u)
+          if [ -n "${{ matrix.input.uid }}" ]; then expected_id="${{ matrix.expected.uid }}"; fi
+          test_compose '.services.web.environment.HOST_UID' "$expected_id"
+
+          test_compose '.services.web.environment.SUPERUSER_EMAIL' "$SUPERUSER_EMAIL"
+          test_compose '.services.web.environment.SUPERUSER_USERNAME' "$SUPERUSER_USERNAME"
+
+          # Expect docker push args are correct
+          builder="test_builder"
+          progress="test_progress"
+          actual_build_args=$(
+            make docker_build_args \
+              DOCKER_PROGRESS=$progress \
+              DOCKER_BUILDER=$builder
+          )
+          expected_build_args="docker buildx bake web --progress=$progress --builder=$builder"
+
+          if [[ ${{ matrix.expected.push }} == "true" ]]; then
+            expected_build_args="$expected_build_args --push"
+          else
+            expected_build_args="$expected_build_args --load"
+          fi
+
+          test_assert "$actual_build_args" "$expected_build_args"
+
+          # Expect docker platform is correct
+          test_compose '.services.web.platform' 'linux/amd64'
+          test_bake '.target.web.platforms[0]' 'linux/amd64'
 
   verify_docker_image:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify-docker-image.yml
+++ b/.github/workflows/verify-docker-image.yml
@@ -8,83 +8,18 @@ on:
 jobs:
   docker_config_check:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - expected: { version: 'local', push: false, uid: ''}
-            input: { version: '', push: '', uid: '' }
-          - expected: { version: version, push: true, uid: '1' }
-            input: { version: version, push: true, uid: '1' }
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Check Docker Compose (default)
-        id: default
+      - uses: actions/setup-node@v2
+      - name: Install dependencies
+        shell: bash
+        run: npm ci
+      - name: Check make/docker configuration
         shell: bash
         run: |
-          set -ue
-
-          export SUPERUSER_EMAIL="email"
-          export SUPERUSER_USERNAME="username"
-
-          if [ -n "${{ matrix.input.version }}" ]; then
-            export DOCKER_VERSION="${{ matrix.expected.version }}"
-          fi
-
-          if [ -n "${{ matrix.input.push }}" ]; then
-            export DOCKER_PUSH="${{ matrix.expected.push }}"
-          fi
-
-          if [ -n "${{ matrix.input.uid }}" ]; then
-            export HOST_UID="${{ matrix.expected.uid }}"
-          fi
-
-          function test_assert() {
-            echo "Expected: $1"
-            echo "Actual: $2"
-            if [ -n "${3:-}" ]; then echo "Message: $3"; fi
-            if [[ "$1" != "$2" ]]; then exit 1; fi
-          }
-
-          function test_compose() {
-            test_assert "$(make docker_compose_config | yq e $1 -)" "$2" "$1"
-          }
-
-          function test_bake() {
-            test_assert "$(make docker_build_config | jq -r $1)" "$2" "$1"
-          }
-
-          test_compose '.services.web.image' "mozilla/addons-server:${{ matrix.expected.version }}"
-
-          expected_id=$(id -u)
-          if [ -n "${{ matrix.input.uid }}" ]; then expected_id="${{ matrix.expected.uid }}"; fi
-          test_compose '.services.web.environment.HOST_UID' "$expected_id"
-
-          test_compose '.services.web.environment.SUPERUSER_EMAIL' "$SUPERUSER_EMAIL"
-          test_compose '.services.web.environment.SUPERUSER_USERNAME' "$SUPERUSER_USERNAME"
-
-          # Expect docker push args are correct
-          builder="test_builder"
-          progress="test_progress"
-          actual_build_args=$(
-            make docker_build_args \
-              DOCKER_PROGRESS=$progress \
-              DOCKER_BUILDER=$builder
-          )
-          expected_build_args="docker buildx bake web --progress=$progress --builder=$builder"
-
-          if [[ ${{ matrix.expected.push }} == "true" ]]; then
-            expected_build_args="$expected_build_args --push"
-          else
-            expected_build_args="$expected_build_args --load"
-          fi
-
-          test_assert "$actual_build_args" "$expected_build_args"
-
-          # Expect docker platform is correct
-          test_compose '.services.web.platform' 'linux/amd64'
-          test_bake '.target.web.platforms[0]' 'linux/amd64'
+          docker compose version
+          npm exec jest -- ./tests/make --runInBand
 
   verify_docker_image:
     runs-on: ubuntu-latest

--- a/Makefile-docker
+++ b/Makefile-docker
@@ -263,7 +263,7 @@ test_failed: ## rerun the failed tests from the previous run
 
 .PHONY: run_js_tests
 run_js_tests: ## Run the JavaScript test suite (requires compiled/compressed assets).
-	NODE_PATH=$(NODE_MODULES) npm exec $(NPM_ARGS) -- jest
+	NODE_PATH=$(NODE_MODULES) npm exec $(NPM_ARGS) -- jest tests/js
 
 .PHONY: watch_js_tests
 watch_js_tests: ## Run+watch the JavaScript test suite (requires compiled/compressed assets).

--- a/Makefile-os
+++ b/Makefile-os
@@ -7,6 +7,7 @@ DOCKER_PUSH ?= false
 DOCKER_OUTPUT ?=
 DOCKER_COMMIT ?= $(shell git rev-parse HEAD || echo "commit")
 VERSION_BUILD_URL ?= build
+BUILDX_BAKE_COMMAND := docker buildx bake web
 export DOCKER_MYSQLD_VOLUME = addons-server_data_mysqld
 
 BACKUPS_DIR = $(shell pwd)/backups
@@ -79,18 +80,18 @@ create_docker_builder: ## Create a custom builder for buildkit to efficiently bu
 		--name $(DOCKER_BUILDER) \
 		--driver=docker-container
 
-DOCKER_BUILD_ARGS := \
+BUILDX_BAKE_COMMAND += \
 --progress=$(DOCKER_PROGRESS) \
 --builder=$(DOCKER_BUILDER) \
 
 ifeq ($(DOCKER_PUSH), true)
-	DOCKER_BUILD_ARGS += --push
+	BUILDX_BAKE_COMMAND += --push
 else
-	DOCKER_BUILD_ARGS += --load
+	BUILDX_BAKE_COMMAND += --load
 endif
 
 ifneq ($(DOCKER_OUTPUT),)
-	DOCKER_BUILD_ARGS += --metadata-file=$(DOCKER_OUTPUT)
+	BUILDX_BAKE_COMMAND += --metadata-file=$(DOCKER_OUTPUT)
 endif
 
 .PHONY: version
@@ -99,15 +100,19 @@ version: ## create version.json file
 
 .PHONY: docker_compose_config
 docker_compose_config: ## Show the docker compose configuration
-	@echo "version: $(DOCKER_VERSION)"
-	@echo "push: $(DOCKER_PUSH)"
-	docker compose config web
-	docker buildx bake web --print
-	echo $(DOCKER_BUILD_ARGS)
+	@docker compose config $(DOCKER_SERVICES)
+
+.PHONY: docker_build_args
+docker_build_args: ## Show the docker build configuration
+	@echo $(BUILDX_BAKE_COMMAND)
+
+.PHONY: docker_build_config
+docker_build_config:
+	@$(BUILDX_BAKE_COMMAND) --print
 
 .PHONY: build_docker_image
 build_docker_image: create_docker_builder version ## Build the docker image
-	docker buildx bake web $(DOCKER_BUILD_ARGS)
+	$(BUILDX_BAKE_COMMAND)
 
 .PHONY: docker_mysqld_volume_create
 docker_mysqld_volume_create: ## Create the mysqld volume

--- a/Makefile-os
+++ b/Makefile-os
@@ -1,25 +1,33 @@
-export HOST_UID := $(shell id -u)
+####################################################################################################
+# Our makefile makes use of docker compose commands. Our config files rely on environment variables
+# both for passing configuration to the containers as well as configuring the compose file itself.
+# Variables referenced in docker-compose*.yml should be read from .env, exported and saved in .env
 
-export DOCKER_BUILDER=container
+define ENV_VAR
+export $(1) ?= $(or $(shell test -f .env && grep -w $(1) .env | cut -d '=' -f2), $(2))
+endef
 
+# This value can be hardcoded, but should still be synced to the .env file
+override DOCKER_MYSQLD_VOLUME = addons-server_data_mysqld
+$(eval $(call ENV_VAR,DOCKER_VERSION,$(shell echo local)))
+$(eval $(call ENV_VAR,HOST_UID,$(shell id -u)))
+$(eval $(call ENV_VAR,SUPERUSER_EMAIL,$(shell git config user.email || echo admin@mozilla.com)))
+$(eval $(call ENV_VAR,SUPERUSER_USERNAME,$(shell git config user.name || echo admin)))
+
+####################################################################################################
+
+DOCKER_BUILDER ?= container
 DOCKER_PROGRESS ?= auto
 DOCKER_PUSH ?= false
 DOCKER_OUTPUT ?=
 DOCKER_COMMIT ?= $(shell git rev-parse HEAD || echo "commit")
 VERSION_BUILD_URL ?= build
 BUILDX_BAKE_COMMAND := docker buildx bake web
-export DOCKER_MYSQLD_VOLUME = addons-server_data_mysqld
 
-BACKUPS_DIR = $(shell pwd)/backups
-EXPORT_DIR = $(BACKUPS_DIR)/$(shell date +%Y%m%d%H%M%S)
+override BACKUPS_DIR = $(shell pwd)/backups
+override EXPORT_DIR = $(BACKUPS_DIR)/$(shell date +%Y%m%d%H%M%S)
 RESTORE_DIR ?= $(BACKUPS_DIR)/$(shell ls -1 backups | sort -r | head -n 1)
 
-# Exporting these variables make them default values for docker-compose*.yml files
-export DOCKER_VERSION ?= local
-
-# define the username and email for the superuser in the container
-SUPERUSER_EMAIL=$(shell git config user.email)
-SUPERUSER_USERNAME=$(shell git config user.name)
 
 .PHONY: help_redirect
 help_redirect:
@@ -31,6 +39,15 @@ help_submake:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' Makefile-os | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 	@echo "\nAll other commands will be passed through to the docker 'web' container make:"
 	@make -f Makefile-docker help_submake
+
+.PHONY: create_env_file
+create_env_file:
+	@ rm -f .env
+	echo "DOCKER_VERSION=${DOCKER_VERSION}" >> .env
+	echo "HOST_UID=${HOST_UID}" >> .env
+	echo "SUPERUSER_EMAIL=${SUPERUSER_EMAIL}" >> .env
+	echo "SUPERUSER_USERNAME=${SUPERUSER_USERNAME}" >> .env
+	echo "DOCKER_MYSQLD_VOLUME=${DOCKER_MYSQLD_VOLUME}" >> .env
 
 .PHONY: push_locales
 push_locales: ## extracts and merges translation strings
@@ -46,13 +63,6 @@ shell: ## connect to a running addons-server docker shell
 .PHONY: rootshell
 rootshell: ## connect to a running addons-server docker shell with root user
 	docker compose exec --user root web bash
-
-.PHONY: create_env_file
-create_env_file:
-	@ rm -f .env
-	echo "HOST_UID=${HOST_UID}" >> .env
-	echo "SUPERUSER_EMAIL=${SUPERUSER_EMAIL}" >> .env
-	echo "SUPERUSER_USERNAME=${SUPERUSER_USERNAME}" >> .env
 
 .PHONY: data_export
 data_export:
@@ -100,7 +110,7 @@ version: ## create version.json file
 
 .PHONY: docker_compose_config
 docker_compose_config: ## Show the docker compose configuration
-	@docker compose config $(DOCKER_SERVICES)
+	@docker compose config web --format json
 
 .PHONY: docker_build_args
 docker_build_args: ## Show the docker build configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,7 @@
 x-env-mapping: &env
+  # https://docs.docker.com/compose/environment-variables/envvars-precedence/
+  env_file:
+    - .env
   environment:
     - CELERY_BROKER_URL=amqp://olympia:olympia@rabbitmq/olympia
     - CELERY_RESULT_BACKEND=redis://redis:6379/1
@@ -12,23 +15,19 @@ x-env-mapping: &env
     - PYTHONUNBUFFERED=1
     - PYTHONBREAKPOINT=ipdb.set_trace
     - TERM=xterm-256color
-    - CIRCLECI=${CIRCLECI}
     - HISTFILE=/data/olympia/docker/artifacts/bash_history
     - HISTSIZE=50000
     - HISTIGNORE=ls:exit:"cd .."
     - HISTCONTROL=erasedups
-    # Note: docker compose uses the values exported from .env for HOST_UID if
-    # it exists. ./docker/entrypoint.sh uses this variable to fix
-    # the uid of the olympia user to match the host user id if necessary.
-    - HOST_UID=${HOST_UID:-}
-    # This is the email address of the superuser created when initializing the db
-    - SUPERUSER_EMAIL=${SUPERUSER_EMAIL:-admin@mozilla.com}
-    - SUPERUSER_USERNAME=${SUPERUSER_USERNAME:-admin}
+    - CIRCLECI
+    - HOST_UID
+    - SUPERUSER_EMAIL
+    - SUPERUSER_USERNAME
 
 services:
   worker: &worker
     <<: *env
-    image: mozilla/addons-server:${DOCKER_VERSION:-local}
+    image: mozilla/addons-server:${DOCKER_VERSION:-}
     build:
       context: .
       dockerfile: Dockerfile
@@ -169,4 +168,4 @@ volumes:
     driver_opts:
       type: none
       o: bind
-      device: ${PWD}/storage
+      device: ./storage

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,6 @@
 // https://jestjs.io/docs/en/configuration.html
 module.exports = {
   setupFiles: ['<rootDir>/tests/js/setup.js'],
-  testMatch: ['<rootDir>/tests/js/**/*.spec.js'],
+  testMatch: ['<rootDir>/tests/**/*.spec.js'],
   testEnvironment: 'jsdom',
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "underscore": "1.13.6"
       },
       "devDependencies": {
+        "dotenv": "^16.4.5",
         "jest": "^29.7.0",
         "jest-date-mock": "^1.0.10",
         "jest-environment-jsdom": "^29.7.0",
@@ -2700,6 +2701,18 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/eastasianwidth": {
@@ -8734,6 +8747,12 @@
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.1"
       }
+    },
+    "dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "dev": true
     },
     "eastasianwidth": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "underscore": "1.13.6"
   },
   "devDependencies": {
+    "dotenv": "^16.4.5",
     "jest": "^29.7.0",
     "jest-date-mock": "^1.0.10",
     "jest-environment-jsdom": "^29.7.0",

--- a/tests/make/make.spec.js
+++ b/tests/make/make.spec.js
@@ -1,0 +1,223 @@
+const { spawnSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const { globSync } = require('glob');
+
+const rootPath = path.join(__dirname, '..', '..');
+const envPath = path.join(rootPath, '.env');
+
+const options = [false, true];
+const frozenKeys = ['DOCKER_MYSQLD_VOLUME'];
+const configurableKeys = [
+  'DOCKER_VERSION',
+  'HOST_UID',
+  'SUPERUSER_EMAIL',
+  'SUPERUSER_USERNAME',
+];
+const keys = [...frozenKeys, ...configurableKeys];
+
+const product = (...arrays) =>
+  arrays.reduce((a, b) => a.flatMap((d) => b.map((e) => [d, e].flat())));
+
+const runCommand = (args, env = {}) => {
+  const result = spawnSync('make', ['-f', 'Makefile-os', ...args], {
+    env: {
+      ...process.env,
+      ...env,
+    },
+    encoding: 'utf-8',
+  });
+  if (result.status !== 0) throw new Error(result.stderr);
+  return result;
+};
+
+const readEnv = () => {
+  const exists = fs.existsSync(envPath);
+  if (exists) {
+    return require('dotenv').parse(
+      fs.readFileSync(envPath, { encoding: 'utf-8' }),
+    );
+  }
+  return require('dotenv').parse('');
+};
+
+const cleanEnv = () => {
+  if (fs.existsSync(envPath)) fs.rmSync(envPath);
+  const env = readEnv();
+
+  for (const key of keys) {
+    delete env[key];
+  }
+
+  return env;
+};
+
+const runMakeCreateEnvFile = (
+  name,
+  useFile = false,
+  useEnv = false,
+  useArgs = false,
+) => {
+  const env = cleanEnv();
+
+  const args = ['create_env_file'];
+
+  if (useFile) {
+    fs.writeFileSync(envPath, `${name}=file`);
+  }
+  if (useEnv) {
+    env[name] = 'env';
+  }
+  if (useArgs) {
+    args.push(`${name}=args`);
+  }
+
+  runCommand(args, env);
+  const result = readEnv()[name];
+
+  console.debug(`
+    name: ${name}
+    args: ${JSON.stringify({ useFile, useEnv, useArgs }, null, 2)}
+    command: make ${args.join(' ')}
+    env: ${env[name] || 'undefined'}
+    envFile: ${readEnv()[name] || 'undefined'}
+    result: ${result}
+  `);
+
+  cleanEnv();
+  return result;
+};
+
+const defaultValues = keys.reduce((acc, key) => {
+  acc[key] = runMakeCreateEnvFile(key);
+  return acc;
+}, {});
+
+describe('environment based configurations', () => {
+  beforeEach(cleanEnv);
+
+  describe.each(product(options, options, options, options, options))(
+    'test_docker_compose_config',
+    (useVersion, usePush, useUid, useEmail, useName) => {
+      it(`
+      test_version:${useVersion}_push:${usePush}_uid:${useUid}_email:${useEmail}_name:${useName}
+    `, () => {
+        const version = useVersion ? 'version' : defaultValues.DOCKER_VERSION;
+        const uid = useUid ? '1000' : defaultValues.HOST_UID;
+        const email = useEmail ? 'email' : defaultValues.SUPERUSER_EMAIL;
+        const userName = useName ? 'name' : defaultValues.SUPERUSER_USERNAME;
+
+        const env = {};
+
+        const args = ['docker_compose_config'];
+
+        if (useVersion) args.push(`DOCKER_VERSION=${version}`);
+        if (useUid) args.push(`HOST_UID=${uid}`);
+        if (useEmail) args.push(`SUPERUSER_EMAIL=${email}`);
+        if (useName) args.push(`SUPERUSER_USERNAME=${userName}`);
+
+        runCommand(['create_env_file'], env);
+
+        const result = runCommand(args);
+
+        const {
+          services: { web },
+        } = JSON.parse(result.stdout);
+
+        expect(web.image).toStrictEqual(`mozilla/addons-server:${version}`);
+        expect(web.platform).toStrictEqual('linux/amd64');
+
+        expect(web.environment.HOST_UID).toStrictEqual(uid);
+        expect(web.environment.SUPERUSER_EMAIL).toStrictEqual(email);
+        expect(web.environment.SUPERUSER_USERNAME).toStrictEqual(userName);
+
+        const builder = 'test_builder';
+        const progress = 'test_progress';
+        const push = usePush ? '--push' : '--load';
+        const expectedBuildargs = `docker buildx bake web --progress=${progress} --builder=${builder} ${push}`;
+
+        const { stdout: actualBuildArgs } = runCommand(['docker_build_args'], {
+          DOCKER_PROGRESS: progress,
+          DOCKER_BUILDER: builder,
+          DOCKER_PUSH: usePush ? 'true' : 'false',
+        });
+
+        expect(actualBuildArgs.trim()).toStrictEqual(expectedBuildargs);
+
+        const { stdout: bakeConfigOutput } = runCommand([
+          'docker_build_config',
+        ]);
+
+        const bakeConfig = JSON.parse(bakeConfigOutput);
+
+        expect(bakeConfig.target.web.platforms).toStrictEqual(['linux/amd64']);
+      });
+    },
+  );
+
+  test('docker compose substitution', () => {
+    expect(new Set(Object.keys(defaultValues))).toStrictEqual(new Set(keys));
+
+    const composeFiles = globSync('docker-compose*.yml', { cwd: rootPath });
+    const variableDefinitions = [];
+
+    for (let file of composeFiles) {
+      const fileContent = fs.readFileSync(path.join(rootPath, file), {
+        encoding: 'utf-8',
+      });
+
+      for (let line of fileContent.split('\n')) {
+        const regex = /\${(.*?)(?::-.*)?}/g;
+        let match;
+        while ((match = regex.exec(line)) !== null) {
+          const variable = match[1];
+          variableDefinitions.push(variable);
+        }
+      }
+    }
+
+    for (let variable of variableDefinitions) {
+      expect(keys).toContain(variable);
+    }
+  });
+
+  describe.each(product(configurableKeys, options, options, options))(
+    'test_configurable_keys',
+    (name, useFile, useEnv, useArgs) => {
+      it(`test_${name}_file:${useFile}_env:${useEnv}_args:${useArgs}`, () => {
+        let expectedValue = defaultValues[name];
+
+        if (!expectedValue) throw new Error(`expected value for ${name}.`);
+
+        if (useFile) expectedValue = 'file';
+        if (useEnv) expectedValue = 'env';
+        if (useArgs) expectedValue = 'args';
+
+        const actualValue = runMakeCreateEnvFile(
+          name,
+          useFile,
+          useEnv,
+          useArgs,
+        );
+
+        expect(actualValue).toStrictEqual(expectedValue);
+      });
+    },
+  );
+
+  describe.each(product(frozenKeys, options, options, options))(
+    'test_frozen_keys',
+    (name, useFile, useEnv, useArgs) => {
+      it(`test_${name}_file:${useFile}_env:${useEnv}_args:${useArgs}`, () => {
+        const expectedValue = defaultValues[name];
+        const actualValue = runMakeCreateEnvFile(
+          name,
+          useFile,
+          useEnv,
+          useArgs,
+        );
+        expect(actualValue).toStrictEqual(expectedValue);
+      });
+    },
+  );
+});


### PR DESCRIPTION
Fixes: https://github.com/mozilla/addons/issues/14787

### Description

The makefile env variables were not defined correctly, causing issues with the configuration of the containers. This pull request fixes the definition of the makefile env variables to ensure proper configuration.

### Context

We have 4 possible values of critical environment variables.

1. the default value define in the makefile
2. the value specified in the .env file
3. the value on the shell running the make command
4. the argument passed to the make command.

Critical environment variables are exactly those which might produce different behavior if running a command via a make target, or directly.

E.g. we have variables defined in our compose files which should be define on the environment. If docker compose <whatever> is run via make, values will be managed appropriately, but unless the value is in the .env or specified in the environment running docker compose directly will use a different or no value.

### Testing

I've added a CI job to verify that the make create_env_file will produce expected results given all 8 possible combinations of the 4 possible sources

You can also manually test 

1. default value.

Remove .env file

run 

```bash
make create_env_file
```

Expect all values to be the value defined in the default parameter via make file.

2. ..env file

Modify one of the values in the produced in the .env and rerun the command.

Expect the value is persisted from the .env

3. env on the shell

Keep the .env file,  and set the value in the shell before running the command. Re-run and expect the env to take priority.

```bash
HOST_UID=env make create_env_file
```

4. args on the command

Now adding to this, if you further specify an argument and expect it to take precedence over all values, regardless of if env/file/default are specified.

```bash
HOST_UID=env make create_env_file HOST_UID=arg
```

Expect value to be arg now.

The CI check runs through effectively this set of steps for every variable that is in this critical list.
