### PR TITLE
Run github action (run-docker) action using docker compose

### DIFF
--- a/.github/actions/run-docker/action.yml
+++ b/.github/actions/run-docker/action.yml
@@ -1,55 +1,52 @@
 name: 'Docker Run Action'
 description: 'Run a command in a new container'
 inputs:
-  image:
-    description: "The Docker image to run"
+  version:
+    description: 'The version of the image to run'
     required: true
-  options:
-    description: 'Options'
-    required: false
+    default: 'local'
   run:
     description: 'Run command in container'
     required: true
+  services:
+    description: 'List of services to start'
+    required: false
+    default: 'web'
+  compose_file:
+    description: 'The docker-compose file to use'
+    required: false
+    default: 'docker-compose.yml'
 runs:
   using: 'composite'
   steps:
-    - name: Run Docker Container
+    - id: id
       shell: bash
       run: |
-        # Export .env file with host user info
-        make -f Makefile-os create_env_file
+        echo "id=$(id -u)" >> $GITHUB_OUTPUT
 
-        cat <<EOF > exec.sh
-        #!/bin/bash
-        whoami
-        ${{ inputs.run }}
+    - name: Run Docker Container
+      shell: bash
+      env:
+        DOCKER_VERSION: ${{ inputs.version }}
+        COMPOSE_FILE: ${{ inputs.compose_file }}
+        DOCKER_SERVICES: ${{ inputs.services }}
+        HOST_UID: ${{ steps.id.outputs.id }}
+      run: |
+        if [[ -z "${{ inputs.run }}" ]]; then
+          echo "run input is required"
+          exit 1
+        fi
+
+        # Start the specified services
+        make up
+
+        # Exec the run command in the container
+        # quoted 'EOF' to prevent variable expansion
+        cat <<'EOF' | docker compose exec --user olympia web sh
+          ${{ inputs.run }}
         EOF
 
-        cat <<EOF > root.sh
-        #!/bin/bash
-        whoami
-        ./docker/entrypoint.sh
-        su -s /bin/bash -c './exec.sh' olympia
-        EOF
-
-        # Make both files executable
-        chmod +x exec.sh
-        chmod +x root.sh
-
-        # Debug info
-        echo "############"
-        cat root.sh
-        echo "############"
-        echo "############"
-        cat exec.sh
-        echo "############"
-
-        # Execute inside docker container
-        cat root.sh | docker run ${{ inputs.options }} \
-          --env-file .env \
-          -i --rm -u 0 \
-          -v $(pwd):/data/olympia \
-          -v ./deps:/deps \
-          -v ./package.json:/deps/package.json \
-          -v ./package-lock.json:/deps/package-lock.json \
-          ${{ inputs.image }} bash
+    - name: Logs
+      shell: bash
+      if: failure()
+      run: docker compose logs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,10 +25,8 @@ jobs:
       - name: Build Docs
         uses: ./.github/actions/run-docker
         with:
-          image: ${{ steps.build.outputs.tags }}
-          options:
+          version: ${{ steps.build.outputs.version }}
           run: |
-            make update_deps
             make docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/extract-locales.yml
+++ b/.github/workflows/extract-locales.yml
@@ -22,16 +22,12 @@ jobs:
       - name: Build Docker image
         id: build
         uses: ./.github/actions/build-docker
-        with:
-          load: true
 
       - name: Extract Locales
         uses: ./.github/actions/run-docker
         with:
-          image: ${{ steps.build.outputs.tags }}
-          options:
+          version: ${{ steps.build.outputs.version }}
           run: |
-            make update_deps
             make extract_locales
 
       - name: Push Locales (dry-run)

--- a/.github/workflows/verify-docker-image.yml
+++ b/.github/workflows/verify-docker-image.yml
@@ -35,7 +35,7 @@ jobs:
         id: failure
         uses: ./.github/actions/run-docker
         with:
-          image: ${{ steps.build.outputs.tags }}
+          version: ${{ steps.build.outputs.version }}
           run: |
             exit 1
         continue-on-error: true
@@ -50,7 +50,7 @@ jobs:
       - name: Check (special characters in command)
         uses: ./.github/actions/run-docker
         with:
-          image: ${{ steps.build.outputs.tags }}
+          version: ${{ steps.build.outputs.version }}
           run: |
             echo 'this is a question?'
             echo 'a * is born'
@@ -59,8 +59,6 @@ jobs:
       - name: Manage py check
         uses: ./.github/actions/run-docker
         with:
-          image: ${{ steps.build.outputs.tags }}
-          options:
+          version: ${{ steps.build.outputs.version }}
           run: |
-            make update_deps
             make check


### PR DESCRIPTION
Fixes: https://github.com/mozilla/addons/issues/14792

### Description

Convert our reusable action run-docker to use docker compose exec instead of simply running the single container via docker run.

### Context

Enabling run-docker to use compose means we run our containers the same way in local and ci environments. This makes the flow much simpler and the fidelity between running a single command in local or ci much higher.

Furthermore, running via docker compose allows us to reuse existing compose definitions for other services that are required for some CI jobs.

### Testing

CI