### PR TITLE
only sync AMO policies (+ delete unused)

### DIFF
--- a/src/olympia/abuse/tasks.py
+++ b/src/olympia/abuse/tasks.py
@@ -148,12 +148,18 @@ def sync_cinder_policies():
 
     def sync_policies(policies, parent_id=None):
         for policy in policies:
+            if (labels := [label['name'] for label in policy.get('labels', [])]) and (
+                'AMO' not in labels
+            ):
+                # If the policy is labelled, but not for AMO, skip it
+                continue
             cinder_policy, _ = CinderPolicy.objects.update_or_create(
                 uuid=policy['uuid'],
                 defaults={
                     'name': policy['name'][:max_length],
                     'text': policy['description'],
                     'parent_id': parent_id,
+                    'modified': datetime.now(),
                 },
             )
 
@@ -172,6 +178,11 @@ def sync_cinder_policies():
         response.raise_for_status()
         data = response.json()
         sync_policies(data)
+        CinderPolicy.objects.exclude(
+            Q(cinderdecision__id__gte=0)
+            | Q(reviewactionreason__id__gte=0)
+            | Q(modified__date__gte=datetime.today())
+        ).delete()
     except Exception:
         statsd.incr('abuse.tasks.sync_cinder_policies.failure')
         raise

--- a/src/olympia/abuse/tasks.py
+++ b/src/olympia/abuse/tasks.py
@@ -167,6 +167,7 @@ def sync_cinder_policies():
                 sync_policies(nested, cinder_policy.id)
 
     try:
+        now = datetime.now()
         url = f'{settings.CINDER_SERVER_URL}policies'
         headers = {
             'accept': 'application/json',
@@ -181,7 +182,7 @@ def sync_cinder_policies():
         CinderPolicy.objects.exclude(
             Q(cinderdecision__id__gte=0)
             | Q(reviewactionreason__id__gte=0)
-            | Q(modified__date__gte=datetime.today())
+            | Q(modified__gte=now)
         ).delete()
     except Exception:
         statsd.incr('abuse.tasks.sync_cinder_policies.failure')


### PR DESCRIPTION
fixes mozilla/addons#14791 (I thought I'd need this for mozilla/addons#14777 but probably not now)

Now policy labels are exposed they are taken into account, and only policies with, or nested under, the AMO label, or no label (mainly for sub-policies, but requirements were ambiguous) are added.  Because there'll be a lot of existing CinderPolicy instances I added a clean-up too, that deletes policies that weren't present in the recent sync (assuming we've not fk'd them to anything)

Can be tested by pressing the sync button in django admin and seeing only AMO labelled policies synced.  Clean-up can be tested by having CinderPolicies that won't be in the recent sync (they need to have a modified date of yesterday or prior)