### PR TITLE
Use the latest delayed-rejection comments when auto-rejecting, not the first

### DIFF
--- a/src/olympia/reviewers/management/commands/auto_reject.py
+++ b/src/olympia/reviewers/management/commands/auto_reject.py
@@ -77,6 +77,7 @@ class Command(BaseCommand):
                     amo.LOG.REJECT_VERSION_DELAYED.id,
                 )
             )
+            .order_by('created')
             .last()
         )
         log_details = getattr(relevant_activity_log, 'details', {})


### PR DESCRIPTION
Fixes mozilla/addons#14793