### PR TITLE
Disable build-image in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -665,7 +665,7 @@ workflows:
       - devhub
       - main
       # Uncomment if you want to test the docker build
-      - build-image
+      # - build-image
       - reviewers-and-zadmin
       - es-tests
       - localization


### PR DESCRIPTION
Follow up to: https://github.com/mozilla/addons-server/pull/22260

Build should not be running all the time.