### PR TITLE
Fix Docker build and add concurrency limit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,7 +367,6 @@ commands:
             echo 'export DOCKER_COMMIT=$CIRCLE_SHA1' >> $BASH_ENV
             echo 'export VERSION_BUILD_URL=$CIRCLE_BUILD_URL' >> $BASH_ENV
             echo 'export DOCKER_PUSH=<< parameters.push >>' >> $BASH_ENV
-            echo 'export DOCKER_OUTPUT=<< parameters.output_file >>' >> $BASH_ENV
       - run:
           name: Create .env and version.json files
           command: |
@@ -379,15 +378,23 @@ commands:
           command: |
             make docker_compose_config
       - run:
-          name: Build docker image and push to repo
+          name: Build docker image (push = << parameters.push >>)
+          environment:
+            # Pass these evnrionment variables directly as they are not saved to .env
+            # but used directly in the make target
+            DOCKER_PROGRESS: plain
+            DOCKER_PUSH: << parameters.push >>
           command: |
             docker version
             docker login -u "${DOCKERHUB_USER}" -p "${DOCKERHUB_PASS}"
             make build_docker_image
-      - run:
-          name: Print Digest
-          command: |
-            cat << parameters.output_file >> | jq -r '.web."containerimage.digest"'
+      - when:
+          condition: << parameters.push >>
+          steps:
+            - run:
+                name: Print Digest
+                command: |
+                  make docker_image_digest
 
   better_checkout:
     description: circle ci checkout step on steroids

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -356,9 +356,6 @@ commands:
       image_tag:
         type: string
         default: "latest"
-      output_file:
-        type: string
-        default: "bake-result.json"
     steps:
       - run:
           name: Set environment variables
@@ -366,7 +363,7 @@ commands:
             echo 'export DOCKER_VERSION=<< parameters.image_tag >>' >> $BASH_ENV
             echo 'export DOCKER_COMMIT=$CIRCLE_SHA1' >> $BASH_ENV
             echo 'export VERSION_BUILD_URL=$CIRCLE_BUILD_URL' >> $BASH_ENV
-            echo 'export DOCKER_PUSH=<< parameters.push >>' >> $BASH_ENV
+            echo 'export BUILDX_BAKE_METADATA_FILE=metadata.json' >> $BASH_ENV
       - run:
           name: Create .env and version.json files
           command: |
@@ -394,7 +391,7 @@ commands:
             - run:
                 name: Print Digest
                 command: |
-                  make docker_image_digest
+                  cat ${BUILDX_BAKE_METADATA_FILE} | jq -r '.web."containerimage.digest"'
 
   better_checkout:
     description: circle ci checkout step on steroids
@@ -643,7 +640,7 @@ jobs:
       - make_release:
           image_tag: circle-${CIRCLE_BRANCH}
           # explicitly don't push
-          push: false
+          push: true
 
   release-master:
     <<: *defaults-release
@@ -672,7 +669,7 @@ workflows:
       - devhub
       - main
       # Uncomment if you want to test the docker build
-      # - build-image
+      - build-image
       - reviewers-and-zadmin
       - es-tests
       - localization

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,7 +377,7 @@ commands:
       - run:
           name: Build docker image (push = << parameters.push >>)
           environment:
-            # Pass these evnrionment variables directly as they are not saved to .env
+            # Pass these environment variables directly as they are not saved to .env
             # but used directly in the make target
             DOCKER_PROGRESS: plain
             DOCKER_PUSH: << parameters.push >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -640,7 +640,7 @@ jobs:
       - make_release:
           image_tag: circle-${CIRCLE_BRANCH}
           # explicitly don't push
-          push: true
+          push: false
 
   release-master:
     <<: *defaults-release
@@ -669,7 +669,7 @@ workflows:
       - devhub
       - main
       # Uncomment if you want to test the docker build
-      - build-image
+      # - build-image
       - reviewers-and-zadmin
       - es-tests
       - localization

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -53,7 +53,21 @@ runs:
         username: ${{ inputs.username }}
         password: ${{ inputs.password }}
 
+
+    - name: Suffix for local builds
+      id: suffix
+      shell: bash
+      # The suffix is unique to a branch and commit
+      run: |
+        if [[ "${{ inputs.push }}" == "false" ]]; then
+          echo "suffix=${{ github.ref }}-${{ github.sha }}" >> $GITHUB_OUTPUT
+        else
+          echo "suffix=ci" >> $GITHUB_OUTPUT
+        fi
+
     # Determine the tags for the image
+    # We need to support custom explicit tags allowing CI to build unique images
+    # that won't be pushed to the registry.
     - name: Docker meta
       id: meta
       uses: docker/metadata-action@v5
@@ -61,7 +75,7 @@ runs:
         # Hard coding our dockerhub imnage name
         images: mozilla/addons-server
         flavor: |
-          prefix=ci-,onlatest=false
+          suffix=-${{ steps.suffix.outputs.suffix }},onlatest=false
         tags: |
           type=schedule
           type=ref,event=tag
@@ -72,15 +86,12 @@ runs:
           # The production build
           # type=raw,value=latest,enable={{is_default_branch}}
 
-    - name: Define environment variables
-      shell: bash
-      run: |
-        echo "DOCKER_VERSION=${{ steps.meta.outputs.version }}" >> $GITHUB_ENV
-        echo "DOCKER_COMMIT=${{ github.sha }}" >> $GITHUB_ENV
-        echo "VERSION_BUILD_URL=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_ENV
-
     - name: Create .env and version.json files
       shell: bash
+      env:
+        DOCKER_VERSION: ${{ steps.meta.outputs.version }}
+        DOCKER_COMMIT: ${{ github.sha }}
+        VERSION_BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       run: make setup
 
     - name: Build Image
@@ -94,6 +105,8 @@ runs:
     - name: Get image digest
       id: digest
       shell: bash
+      env:
+        BUILDX_BAKE_METADATA_FILE: metadata.json
       run: |
-        echo '${{ steps.build.outputs.metadata }}' > metadata.json
-        echo "digest=$(jq -r '.web."containerimage.digest"' metadata.json )" >> $GITHUB_OUTPUT
+        echo '${{ steps.build.outputs.metadata }}' > $BUILDX_BAKE_METADATA_FILE
+        echo "digest=$(make docker_image_digest)" >> $GITHUB_OUTPUT

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -108,5 +108,5 @@ runs:
       env:
         BUILDX_BAKE_METADATA_FILE: metadata.json
       run: |
-        echo '${{ steps.build.outputs.metadata }}' > $BUILDX_BAKE_METADATA_FILE
-        echo "digest=$(make docker_image_digest)" >> $GITHUB_OUTPUT
+        echo '${{ steps.build.outputs.metadata }}' > metadata.json
+        echo "digest=$(cat metadata.json | jq -r '.web."containerimage.digest"')" >> $GITHUB_OUTPUT

--- a/.github/actions/run-docker/action.yml
+++ b/.github/actions/run-docker/action.yml
@@ -2,9 +2,13 @@ name: 'Docker Run Action'
 description: 'Run a command in a new container'
 inputs:
   version:
-    description: 'The version of the image to run. Supports tag or digest'
+    description: 'The version of the image to run. '
     required: true
     default: 'local'
+  digest:
+    description: 'The build digest of the image to run. Overrides version.'
+    required: true
+    default: ''
   run:
     description: 'Run command in container'
     required: true
@@ -28,6 +32,7 @@ runs:
       shell: bash
       env:
         DOCKER_VERSION: ${{ inputs.version }}
+        DOCKER_DIGEST: ${{ inputs.digest }}
         COMPOSE_FILE: ${{ inputs.compose_file }}
         DOCKER_SERVICES: ${{ inputs.services }}
         HOST_UID: ${{ steps.id.outputs.id }}
@@ -36,9 +41,6 @@ runs:
           echo "run input is required"
           exit 1
         fi
-
-        # Setup host
-        make setup
 
         # Start the specified services
         make up

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,10 +1,6 @@
 name: Docs
 
 on:
-  # Build docs on pull request to verify changes
-  pull_request:
-    branches:
-      - master
   # Deploy to production on master
   push:
     branches:
@@ -12,41 +8,18 @@ on:
   # Deploy `master` on workflow dispatch.
   workflow_dispatch:
 
-jobs:
-  build_docs:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - id: build
-        uses: ./.github/actions/build-docker
-      - name: Setup Pages
-        uses: actions/configure-pages@v4
-      - name: Build Docs
-        uses: ./.github/actions/run-docker
-        with:
-          version: ${{ steps.build.outputs.digest }}
-          run: |
-            make docs
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: 'docs/_build/html'
-          name: "docs"
+# Only deploy the latest build artifact to GitHub Pages
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
 
+jobs:
   deploy_docs:
-    # only deploy on push to the master branch
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
     permissions:
       contents: read
       pages: write
       id-token: write
-    # Only deploy the latest build artifact to GitHub Pages
-    concurrency:
-      group: "pages"
-      cancel-in-progress: true
-    needs: build_docs
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -56,4 +29,5 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v4
         with:
-          artifact_name: "docs"
+          # Keep this in sync with `build_docs` where we upload the artifact
+          artifact_name: ${{ secrets.DOCS_ARTIFACT_NAME}}

--- a/.github/workflows/extract-locales.yml
+++ b/.github/workflows/extract-locales.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
 
 jobs:
   extract_locales:
@@ -14,10 +11,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Build Docker image
         id: build
@@ -26,25 +19,8 @@ jobs:
       - name: Extract Locales
         uses: ./.github/actions/run-docker
         with:
-          version: ${{ steps.build.outputs.digest }}
           run: |
             make extract_locales
-
-      - name: Push Locales (dry-run)
-        if: github.event_name == 'pull_request'
-        shell: bash
-        run: |
-          if [[ ${{ github.event.pull_request.head.repo.fork}} == 'true' ]]; then
-            echo """
-            Github actions are not authorized to push from workflows triggered by forks.
-            We cannot verify if the l10n extraction push will work or not.
-            Please submit a PR from the base repository if you are modifying l10n extraction scripts.
-            """
-
-            exit 0
-          fi
-
-          make push_locales ARGS="--dry-run"
 
       - name: Push Locales
         if: github.event_name == 'push'

--- a/.github/workflows/verify-docker-image.yml
+++ b/.github/workflows/verify-docker-image.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: verify-docker-image
+  cancel-in-progress: true
+
 jobs:
   docker_config_check:
     runs-on: ubuntu-latest
@@ -35,7 +39,7 @@ jobs:
         id: failure
         uses: ./.github/actions/run-docker
         with:
-          version: ${{ steps.build.outputs.digest }}
+          version: ${{ steps.build.outputs.version }}
           run: |
             exit 1
         continue-on-error: true
@@ -50,7 +54,7 @@ jobs:
       - name: Check (special characters in command)
         uses: ./.github/actions/run-docker
         with:
-          version: ${{ steps.build.outputs.digest }}
+          version: ${{ steps.build.outputs.version }}
           run: |
             echo 'this is a question?'
             echo 'a * is born'
@@ -59,6 +63,68 @@ jobs:
       - name: Manage py check
         uses: ./.github/actions/run-docker
         with:
-          version: ${{ steps.build.outputs.digest }}
+          version: ${{ steps.build.outputs.version }}
           run: |
             make check
+
+  build_docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v4
+
+      - name: Build Docker image
+        id: build
+        uses: ./.github/actions/build-docker
+
+      - name: Build Docs
+        uses: ./.github/actions/run-docker
+        with:
+          version: ${{ steps.build.outputs.version }}
+          run: |
+            make docs
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'docs/_build/html'
+          # Keep this in sync with `deploy_dos`
+          # where we uploaded artifact is deployed to github pages
+          name: ${{ secrets.DOCS_ARTIFACT_NAME}}
+
+  extract_locales:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Check out on the fork if applicable
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+
+      - name: Build Docker image
+        id: build
+        uses: ./.github/actions/build-docker
+
+      - name: Extract Locales
+        uses: ./.github/actions/run-docker
+        with:
+          version: ${{ steps.build.outputs.version }}
+          run: make extract_locales
+
+      - name: Push Locales (dry-run)
+        shell: bash
+        run: |
+          if [[ ${{ github.event.pull_request.head.repo.fork}} == 'true' ]]; then
+            echo """
+            Github actions are not authorized to push from workflows triggered by forks.
+            We cannot verify if the l10n extraction push will work or not.
+            Please submit a PR from the base repository if you are modifying l10n extraction scripts.
+            """
+
+            exit 0
+          fi
+
+          make push_locales ARGS="--dry-run"

--- a/.gitignore
+++ b/.gitignore
@@ -60,9 +60,8 @@ private/
 !private/README.md
 !deps/.keep
 
-# Local cache directory for docker layer/build cache
-docker-cache/
-docker-cache-new/
+# Ignore buildx bake output files
+buildx-bake-metadata.json
 
 # Ignore the version.json as this should be created during the build
 version.json

--- a/Makefile-os
+++ b/Makefile-os
@@ -7,7 +7,7 @@
 DOCKER_BUILDER ?= container
 DOCKER_PROGRESS ?= auto
 DOCKER_PUSH ?= false
-BUILDX_BAKE_METADATA_FILE ?= buildx-bake-metadata.json
+BUILDX_BAKE_METADATA_FILE ?=
 DOCKER_COMMIT ?= $(shell git rev-parse HEAD || echo "commit")
 VERSION_BUILD_URL ?= build
 BUILDX_BAKE_COMMAND := docker buildx bake web
@@ -111,10 +111,6 @@ docker_mysqld_volume_create: ## Create the mysqld volume
 .PHONY: docker_mysqld_volume_remove
 docker_mysqld_volume_remove: ## Remove the mysqld volume
 	docker volume rm $(DOCKER_MYSQLD_VOLUME)
-
-.PHONY: docker_image_digest
-docker_image_digest: ## get the digest of the built image
-	@cat $(BUILDX_BAKE_METADATA_FILE) | jq -r '.web."containerimage.digest"'
 
 .PHONY: docker_compose_down
 docker_compose_down: ## Stop the docker containers

--- a/Makefile-os
+++ b/Makefile-os
@@ -7,7 +7,7 @@
 DOCKER_BUILDER ?= container
 DOCKER_PROGRESS ?= auto
 DOCKER_PUSH ?= false
-DOCKER_OUTPUT ?=
+BUILDX_BAKE_METADATA_FILE ?= buildx-bake-metadata.json
 DOCKER_COMMIT ?= $(shell git rev-parse HEAD || echo "commit")
 VERSION_BUILD_URL ?= build
 BUILDX_BAKE_COMMAND := docker buildx bake web
@@ -84,8 +84,8 @@ else
 	BUILDX_BAKE_COMMAND += --load
 endif
 
-ifneq ($(DOCKER_OUTPUT),)
-	BUILDX_BAKE_COMMAND += --metadata-file=$(DOCKER_OUTPUT)
+ifneq ($(BUILDX_BAKE_METADATA_FILE),)
+	BUILDX_BAKE_COMMAND += --metadata-file=$(BUILDX_BAKE_METADATA_FILE)
 endif
 
 .PHONY: docker_compose_config
@@ -111,6 +111,10 @@ docker_mysqld_volume_create: ## Create the mysqld volume
 .PHONY: docker_mysqld_volume_remove
 docker_mysqld_volume_remove: ## Remove the mysqld volume
 	docker volume rm $(DOCKER_MYSQLD_VOLUME)
+
+.PHONY: docker_image_digest
+docker_image_digest: ## get the digest of the built image
+	@cat $(BUILDX_BAKE_METADATA_FILE) | jq -r '.web."containerimage.digest"'
 
 .PHONY: docker_compose_down
 docker_compose_down: ## Stop the docker containers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ x-env-mapping: &env
 services:
   worker: &worker
     <<: *env
-    image: mozilla/addons-server${DOCKER_VERSION:-}
+    image: ${DOCKER_TAG:-}
     build:
       context: .
       dockerfile: Dockerfile

--- a/tests/make/make.spec.js
+++ b/tests/make/make.spec.js
@@ -112,57 +112,59 @@ function standardPermutations(name, defaultValue) {
   ];
 }
 
+describe.each([
+  {
+    version: undefined,
+    digest: undefined,
+    tag: undefined,
+    expected: 'mozilla/addons-server:local',
+  },
+  {
+    version: 'version',
+    digest: undefined,
+    tag: undefined,
+    expected: 'mozilla/addons-server:version',
+  },
+  {
+    version: undefined,
+    digest: 'sha256:digest',
+    tag: undefined,
+    expected: 'mozilla/addons-server@sha256:digest',
+  },
+  {
+    version: 'version',
+    digest: 'sha256:digest',
+    tag: undefined,
+    expected: 'mozilla/addons-server@sha256:digest',
+  },
+  {
+    version: 'version',
+    digest: 'sha256:digest',
+    tag: 'previous',
+    expected: 'mozilla/addons-server@sha256:digest',
+  },
+  {
+    version: undefined,
+    digest: undefined,
+    tag: 'previous',
+    expected: 'previous',
+  },
+])('DOCKER_TAG', ({ version, digest, tag, expected }) => {
+  it(`version:${version}_digest:${digest}_tag:${tag}`, () => {
+    fs.writeFileSync(envPath, '');
+    runSetup({
+      DOCKER_VERSION: version,
+      DOCKER_DIGEST: digest,
+      DOCKER_TAG: tag,
+    });
+
+    const actual = readEnvFile('DOCKER_TAG');
+    expect(actual).toStrictEqual(expected);
+  });
+});
+
 const testCases = [
-  {
-    name: 'DOCKER_VERSION',
-    file: undefined,
-    env: undefined,
-    expected: ':local',
-  },
-  {
-    name: 'DOCKER_VERSION',
-    file: 'file',
-    env: undefined,
-    expected: ':file',
-  },
-  {
-    name: 'DOCKER_VERSION',
-    file: undefined,
-    env: 'env',
-    expected: ':env',
-  },
-  {
-    name: 'DOCKER_VERSION',
-    file: 'file',
-    env: 'env',
-    expected: ':env',
-  },
-  // Test that if the prefix already exists, it is not duplicated
-  {
-    name: 'DOCKER_VERSION',
-    file: ':local',
-    env: undefined,
-    expected: ':local',
-  },
-  // Test that if the prefix already exists, it is not duplicated
-  {
-    name: 'DOCKER_VERSION',
-    file: '@sha256:local',
-    env: undefined,
-    expected: '@sha256:local',
-  },
-  {
-    name: 'DOCKER_VERSION',
-    file: 'sha256:local',
-    env: undefined,
-    expected: '@sha256:local',
-  },
-  {
-    name: 'DOCKER_VERSION',
-    file: undefined,
-    env: '@sha256:local',
-    expected: '@sha256:local',
-  },
+  ...standardPermutations('DOCKER_TAG', 'mozilla/addons-server:local'),
   ...standardPermutations('HOST_UID', process.getuid().toString()),
   ...standardPermutations('SUPERUSER_EMAIL', gitConfigUserEmail()),
   ...standardPermutations('SUPERUSER_USERNAME', gitConfigUserName()),
@@ -171,7 +173,6 @@ const testCases = [
 describe.each(testCases)('.env file', ({ name, file, env, expected }) => {
   it(`name:${name}_file:${file}_env:${env}`, () => {
     fs.writeFileSync(envPath, file ? `${name}=${file}` : '');
-    process.env[name] = env;
 
     runSetup({ [name]: env });
 


### PR DESCRIPTION
fixes: mozilla/addons#14802

### Description

Fix the computed image tag in our docker compose file causing tags to be invalid and therrefore failing to push

### Context

We added (here) support for running our container via a tag or a digest, but the logic had a bug that meant if you defined DOCKER_VERSION in the shell environment, it would override the formattted value produced by calling make setup.

Essentially, the value in the .env is updated but not in the shel environment.

Fun facts: There is a different between an image Id, and image digest and an image configuration digest.

| Field                | Description                                                                                                                                                                                                                                                                                                                                                                               |
|----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| **id**               | Image ID is a unique identifier for a Docker image that is different on every build, even if the contents are the same.                                                                                                                                                                                                                                                                   |
| **digest**           | A hash of the image layer content digests. A hash of hashes that is produced only when an image is pushed to a Docker registry. (To further confuse, it is also produced when building with buildkit, which is kind of like a pseudo-registry because it's running on its own Docker container that exports to the local daemon)                                                          |
| **configuration digest** | This is a hash of the image configuration object which is what you get when you inspect an image. It is not 1:1 with a digest because it doesn't (necessarily) take into account changes in the contents of the image, but in its configuration. For example, you could have a change in a RUN step that produces no change in the content of the layer, but it is still a change. Kind of confusing. |

### Testing

There are several flows to test.

First and formost. remove your .env file and create a new one!

`rm -f .env && make setup`

Not doing this likely won't cause any problems but better consistent than sorry.

#### Run with digest

1. Grab a digest from a built image in CI. This will NOT work with locally built images.
2. set the digest and up the environment `DOCKER_DIGEST=<value> make up`

This should run the container exactly from the build.

#### Run with tag

1. set the tag to latest `DOCKER_VERSION=latest make up`
2. This should run the latest tag from dockerhub.

#### Test concurrency.

If you have an open PR from this branch, with jobs in progress. Pushing a new commit should queue a new workflow run and cancel the previous one. There should only be one running at a time. This will save a huge amount of resources as the number of jobs per workflow increases.