### PR TITLE
Fix ActivityLog recording when flagging a version because of an abuse report

### DIFF
--- a/src/olympia/abuse/cinder.py
+++ b/src/olympia/abuse/cinder.py
@@ -8,13 +8,14 @@ import requests
 import waffle
 
 import olympia
-from olympia import activity, amo
+from olympia import activity, amo, core
 from olympia.amo.utils import (
     backup_storage_enabled,
     chunked,
     copy_file_to_backup_storage,
     create_signed_url_for_file_backup,
 )
+from olympia.users.utils import get_task_user
 
 
 log = olympia.core.logger.getLogger('z.abuse')
@@ -492,6 +493,7 @@ class CinderAddonHandledByReviewers(CinderAddon):
                 amo.LOG.NEEDS_HUMAN_REVIEW_CINDER,
                 *versions_to_log,
                 details={'comments': nhr_object.get_reason_display()},
+                user=core.get_user() or get_task_user(),
             )
 
     def report(self, *args, **kwargs):

--- a/src/olympia/abuse/tests/test_cinder.py
+++ b/src/olympia/abuse/tests/test_cinder.py
@@ -1062,14 +1062,15 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
     # - 5 Fetch NeedsHumanReview
     # - 6 Update due date on Versions
     # - 7 Fetch Latest signed Version
-    # - 8 Create ActivityLog
-    # - 9 Create ActivityLogComment
-    # - 10 Update ActivityLogComment
-    # - 11 Create VersionLog
+    # - 8 Fetch task user
+    # - 9 Create ActivityLog
+    # - 10 Create ActivityLogComment
+    # - 11 Update ActivityLogComment
+    # - 12 Create VersionLog
     # The last 2 are for rendering the payload to Cinder like CinderAddon:
-    # - 12 Fetch Addon authors
-    # - 13 Fetch Promoted Addon
-    expected_queries_for_report = 13
+    # - 13 Fetch Addon authors
+    # - 14 Fetch Promoted Addon
+    expected_queries_for_report = 14
     expected_queue_suffix = 'addon-infringement'
 
     def test_queue(self):
@@ -1090,10 +1091,13 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
         )
 
     def setUp(self):
-        core.set_user(user_factory(id=settings.TASK_USER_ID))
+        user_factory(id=settings.TASK_USER_ID)
 
     def test_report(self):
         addon = self._create_dummy_target()
+        # Make sure this is testing the case where no user is set (we fall back
+        # to the task user).
+        assert core.get_user() is None
         addon.current_version.file.update(is_signed=True)
         # Trigger switch_is_active to ensure it's cached to make db query
         # count more predictable.


### PR DESCRIPTION
When we're manually creating the `ActivityLog`, we need to pass a user for the `ActivityLog` to be saved. This code could be called from somewhere where there is no user in the thread, so explicitly fall back on the task user when that's happening.

Fixes mozilla/addons#2010