### PR TITLE
Ignore webhook decisions for reviewer tools resolved jobs

### DIFF
--- a/src/olympia/abuse/tests/test_utils.py
+++ b/src/olympia/abuse/tests/test_utils.py
@@ -708,7 +708,9 @@ class TestCinderActionAddon(BaseTestCinderAction, TestCase):
     def _test_reject_version(self):
         self.decision.update(action=DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON)
         action = CinderActionRejectVersion(self.decision)
-        # note: process_action isn't implemented for this action currently.
+        # process_action isn't implemented for this action currently.
+        with self.assertRaises(NotImplementedError):
+            action.process_action()
 
         subject = f'Mozilla Add-ons: {self.addon.name}'
 

--- a/src/olympia/abuse/tests/test_views.py
+++ b/src/olympia/abuse/tests/test_views.py
@@ -1190,6 +1190,22 @@ class TestCinderWebhook(TestCase):
             }
         }
 
+    def test_reviewer_tools_resolved_cinder_job(self):
+        report = self._setup_reports()
+        report.cinder_job.update(resolvable_in_reviewer_tools=True)
+        req = self.get_request()
+        with mock.patch.object(CinderJob, 'process_decision') as process_mock:
+            response = cinder_webhook(req)
+            process_mock.assert_not_called()
+        assert response.status_code == 200
+        assert response.data == {
+            'amo': {
+                'received': True,
+                'handled': False,
+                'not_handled_reason': 'Decision already handled via reviewer tools',
+            }
+        }
+
     def test_invalid_decision_action(self):
         abuse_report = self._setup_reports()
         addon_factory(guid=abuse_report.guid)

--- a/src/olympia/abuse/utils.py
+++ b/src/olympia/abuse/utils.py
@@ -52,11 +52,12 @@ class CinderAction:
             )
 
     def process_action(self):
-        """This method should an activity log instance for the action, if available."""
+        """This method should return an activity log instance for the action,
+        if available."""
         raise NotImplementedError
 
     def get_owners(self):
-        """No owner emails will be sent.  Override to send owner emails"""
+        """No owner emails will be sent. Override to send owner emails"""
         return ()
 
     def get_target_name(self):
@@ -256,7 +257,7 @@ class CinderActionDisableAddon(CinderAction):
 class CinderActionRejectVersion(CinderActionDisableAddon):
     description = 'Add-on version(s) have been rejected'
 
-    def process(self):
+    def process_action(self):
         # This action should only be used by reviewer tools, not cinder webhook
         raise NotImplementedError
 

--- a/src/olympia/abuse/views.py
+++ b/src/olympia/abuse/views.py
@@ -229,6 +229,10 @@ def cinder_webhook(request):
             log.debug('CinderJob instance not found for job id %s', job_id)
             raise ValidationError('No matching job id found')
 
+        if cinder_job.resolvable_in_reviewer_tools:
+            log.debug('Cinder webhook decision for reviewer resolvable job skipped.')
+            raise ValidationError('Decision already handled via reviewer tools')
+
         enforcement_actions = filter_enforcement_actions(
             payload.get('enforcement_actions') or [],
             cinder_job,


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/14800 by 
a) properly overriding `process_action` in `CinderActionRejectVersion` and
b) skipping reviewer tools resolved cinder jobs in the webhook

Because of b), a) isn't testable any longer.  You can test b) by following the STR in the issue and also seeing in the webhook log in cinder's admin that the request wasn't processed.