### PR TITLE
Increase default caching duration of API endpoints to 360 seconds

### DIFF
--- a/src/olympia/amo/tests/test_middleware.py
+++ b/src/olympia/amo/tests/test_middleware.py
@@ -334,7 +334,7 @@ class TestCacheControlMiddleware(TestCase):
             response = CacheControlMiddleware(
                 lambda x, status=status_code: HttpResponse(status=status)
             )(request)
-            assert response['Cache-Control'] == 'max-age=180'
+            assert response['Cache-Control'] == 'max-age=360'
 
     def test_services_amo_should_cache_for_one_hour(self):
         request = self.request_factory.get('/api/v5/foo')
@@ -350,7 +350,7 @@ class TestCacheControlMiddleware(TestCase):
         response = self.client.get(reverse_ns('amo-site-status'))
         assert response.status_code == 200
         assert 'Cache-Control' in response
-        assert response['Cache-Control'] == 'max-age=180'
+        assert response['Cache-Control'] == 'max-age=360'
 
     def test_functional_should_not_cache(self):
         response = self.client.get(

--- a/src/olympia/bandwagon/tests/test_views.py
+++ b/src/olympia/bandwagon/tests/test_views.py
@@ -1087,7 +1087,7 @@ class TestCollectionAddonViewSetList(CollectionAddonViewSetMixin, TestCase):
 
     def test_no_caching_anonymous_not_mozilla_collection(self):
         # We get the Cache-Control set from middleware (not the view).
-        self._test_response(expected_max_age=180)
+        self._test_response(expected_max_age=360)
 
     def test_no_caching_anonymous_but_not_mozilla_collection_by_username(self):
         self.user.update(username='notmozilla')
@@ -1098,7 +1098,7 @@ class TestCollectionAddonViewSetList(CollectionAddonViewSetMixin, TestCase):
                 'collection_slug': self.collection.slug,
             },
         )
-        self._test_response(expected_max_age=180)
+        self._test_response(expected_max_age=360)
 
     def test_caching_anonymous(self):
         self.user = user_factory(id=settings.TASK_USER_ID)

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1319,7 +1319,7 @@ MAX_APIKEY_JWT_AUTH_TOKEN_LIFETIME = 5 * 60
 API_KEY_CONFIRMATION_DELAY = None
 
 # Default cache duration for the API, in seconds.
-API_CACHE_DURATION = 3 * 60
+API_CACHE_DURATION = 6 * 60
 
 # Default cache duration for the API on services.a.m.o., in seconds.
 API_CACHE_DURATION_SERVICES = 60 * 60


### PR DESCRIPTION
See mozilla/addons#14798 (fixes the API part)

You can try it locally by observing non-authenticated HTTP responses for API endpoints that don't provide a custom caching duration (like `/api/v5/addons/search/` or many others) are served with `cache-control: max-age=360` instead of `cache-control: max-age=180`.