### PR TITLE
Remove obsolete `version` in docker compose files

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,5 +1,3 @@
-version: "2.4"
-
 services:
   nginx:
     ports:

--- a/docker-compose.private.yml
+++ b/docker-compose.private.yml
@@ -1,5 +1,3 @@
-version: "2.4"
-
 services:
   worker:
     depends_on:


### PR DESCRIPTION
This removes the warning

```
`version` is obsolete
```

when running `make up`.
