### PR TITLE
Fix build image CircleCI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -651,7 +651,7 @@ jobs:
       - make_release:
           image_tag: circle-${CIRCLE_BRANCH}
           # explicitly don't push
-          push:
+          push: false
 
   release-master:
     <<: *defaults-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,19 +360,25 @@ commands:
       - run:
           name: Set environment variables
           command: |
-            echo "DOCKER_PUSH: << parameters.push >>"
-            echo "Configured: << parameters.push ? "true" : "" >>"
-            DOCKER_PUSH="<< parameters.push ? "true" : "" >>"
-            echo "var: $DOCKER_PUSH"
             echo 'export DOCKER_VERSION=<< parameters.image_tag >>' >> $BASH_ENV
             echo 'export DOCKER_COMMIT=$CIRCLE_SHA1' >> $BASH_ENV
             echo 'export VERSION_BUILD_URL=$CIRCLE_BUILD_URL' >> $BASH_ENV
             echo 'export BUILDX_BAKE_METADATA_FILE=metadata.json' >> $BASH_ENV
-            # CircleCI casts boolean paramters as binary 0/1 integers.
-            # Our Makefile is expecting any non-empty value to indicate a push.
-            # So we must explicitly set to an empty string if the parameter is false.
-            echo 'export DOCKER_PUSH=\<< parameters.push ? "true" : "" >>' >> $BASH_ENV
             echo 'export DOCKER_PROGRESS=plain' >> $BASH_ENV
+      - when:
+          condition: << parameters.push >>
+          steps:
+            - run:
+                name: Push mode activated
+                command: |
+                  # CircleCI casts boolean paramters as binary 0/1 integers
+                  # when they are passed via environment: variables.
+                  # CircleCI will not reasonably work with conditional expressions
+
+                  # Our Makefile is expecting any non-empty value to indicate a push.
+                  # So we must explicitly set the value
+                  # only if the "condition" passes at the configuration level
+                  echo 'export DOCKER_PUSH=true' >> $BASH_ENV
       - run:
           name: Create .env and version.json files
           command: |
@@ -383,6 +389,7 @@ commands:
           name: Docker build config
           command: |
             make docker_compose_config
+            echo $BASH_ENV
       - run:
           name: Build docker image (push = << parameters.push >>)
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,7 +352,6 @@ commands:
     parameters:
       push:
         type: boolean
-        default: false
       image_tag:
         type: string
         default: "latest"
@@ -376,15 +375,12 @@ commands:
             make docker_compose_config
       - run:
           name: Build docker image (push = << parameters.push >>)
-          environment:
-            # Pass these environment variables directly as they are not saved to .env
-            # but used directly in the make target
-            DOCKER_PROGRESS: plain
-            DOCKER_PUSH: << parameters.push >>
           command: |
             docker version
             docker login -u "${DOCKERHUB_USER}" -p "${DOCKERHUB_PASS}"
-            make build_docker_image
+            make -f Makefile-os build_docker_image \
+              DOCKER_PROGRESS="plain" \
+              DOCKER_PUSH="<< parameters.push >>"
       - when:
           condition: << parameters.push >>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -389,7 +389,7 @@ commands:
           name: Docker build config
           command: |
             make docker_compose_config
-            echo $BASH_ENV
+            cat $BASH_ENV
       - run:
           name: Build docker image (push = << parameters.push >>)
           command: |
@@ -651,7 +651,7 @@ jobs:
       - make_release:
           image_tag: circle-${CIRCLE_BRANCH}
           # explicitly don't push
-          push: false
+          push: true
 
   release-master:
     <<: *defaults-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -665,7 +665,7 @@ workflows:
       - devhub
       - main
       # Uncomment if you want to test the docker build
-      # - build-image
+      - build-image
       - reviewers-and-zadmin
       - es-tests
       - localization

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,6 +352,7 @@ commands:
     parameters:
       push:
         type: boolean
+        default: false
       image_tag:
         type: string
         default: "latest"
@@ -363,6 +364,8 @@ commands:
             echo 'export DOCKER_COMMIT=$CIRCLE_SHA1' >> $BASH_ENV
             echo 'export VERSION_BUILD_URL=$CIRCLE_BUILD_URL' >> $BASH_ENV
             echo 'export BUILDX_BAKE_METADATA_FILE=metadata.json' >> $BASH_ENV
+            echo 'export DOCKER_PUSH=\<< parameters.push ? "true" : "" >>' >> $BASH_ENV
+            echo 'export DOCKER_PROGRESS=plain' >> $BASH_ENV
       - run:
           name: Create .env and version.json files
           command: |
@@ -378,10 +381,7 @@ commands:
           command: |
             docker version
             docker login -u "${DOCKERHUB_USER}" -p "${DOCKERHUB_PASS}"
-            echo "push: << parameters.push >>"
-            make -f Makefile-os build_docker_image \
-              DOCKER_PROGRESS="plain" \
-              DOCKER_PUSH: "<< parameters.push ? '' : 'true' >>"
+            make -f Makefile-os build_docker_image
       - when:
           condition: << parameters.push >>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,6 +360,10 @@ commands:
       - run:
           name: Set environment variables
           command: |
+            echo "DOCKER_PUSH: << parameters.push >>"
+            echo "Configured: \<< parameters.push ? "true" : "" >>"
+            DOCKER_PUSH="\<< parameters.push ? "true" : "" >>"
+            echo "var: $DOCKER_PUSH"
             echo 'export DOCKER_VERSION=<< parameters.image_tag >>' >> $BASH_ENV
             echo 'export DOCKER_COMMIT=$CIRCLE_SHA1' >> $BASH_ENV
             echo 'export VERSION_BUILD_URL=$CIRCLE_BUILD_URL' >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -651,7 +651,7 @@ jobs:
       - make_release:
           image_tag: circle-${CIRCLE_BRANCH}
           # explicitly don't push
-          push: 1
+          push:
 
   release-master:
     <<: *defaults-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -651,7 +651,7 @@ jobs:
       - make_release:
           image_tag: circle-${CIRCLE_BRANCH}
           # explicitly don't push
-          push: true
+          push: false
 
   release-master:
     <<: *defaults-release
@@ -680,7 +680,7 @@ workflows:
       - devhub
       - main
       # Uncomment if you want to test the docker build
-      - build-image
+      # - build-image
       - reviewers-and-zadmin
       - es-tests
       - localization

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -364,6 +364,9 @@ commands:
             echo 'export DOCKER_COMMIT=$CIRCLE_SHA1' >> $BASH_ENV
             echo 'export VERSION_BUILD_URL=$CIRCLE_BUILD_URL' >> $BASH_ENV
             echo 'export BUILDX_BAKE_METADATA_FILE=metadata.json' >> $BASH_ENV
+            # CircleCI casts boolean paramters as binary 0/1 integers.
+            # Our Makefile is expecting any non-empty value to indicate a push.
+            # So we must explicitly set to an empty string if the parameter is false.
             echo 'export DOCKER_PUSH=\<< parameters.push ? "true" : "" >>' >> $BASH_ENV
             echo 'export DOCKER_PROGRESS=plain' >> $BASH_ENV
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -361,8 +361,8 @@ commands:
           name: Set environment variables
           command: |
             echo "DOCKER_PUSH: << parameters.push >>"
-            echo "Configured: \<< parameters.push ? "true" : "" >>"
-            DOCKER_PUSH="\<< parameters.push ? "true" : "" >>"
+            echo "Configured: << parameters.push ? "true" : "" >>"
+            DOCKER_PUSH="<< parameters.push ? "true" : "" >>"
             echo "var: $DOCKER_PUSH"
             echo 'export DOCKER_VERSION=<< parameters.image_tag >>' >> $BASH_ENV
             echo 'export DOCKER_COMMIT=$CIRCLE_SHA1' >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,9 +378,10 @@ commands:
           command: |
             docker version
             docker login -u "${DOCKERHUB_USER}" -p "${DOCKERHUB_PASS}"
+            echo "push: << parameters.push >>"
             make -f Makefile-os build_docker_image \
               DOCKER_PROGRESS="plain" \
-              DOCKER_PUSH="<< parameters.push >>"
+              DOCKER_PUSH: "<< parameters.push ? '' : 'true' >>"
       - when:
           condition: << parameters.push >>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -651,7 +651,7 @@ jobs:
       - make_release:
           image_tag: circle-${CIRCLE_BRANCH}
           # explicitly don't push
-          push: false
+          push: 1
 
   release-master:
     <<: *defaults-release

--- a/Makefile-os
+++ b/Makefile-os
@@ -6,7 +6,7 @@
 
 DOCKER_BUILDER ?= container
 DOCKER_PROGRESS ?= auto
-DOCKER_PUSH ?= false
+DOCKER_PUSH ?=
 BUILDX_BAKE_METADATA_FILE ?=
 DOCKER_COMMIT ?= $(shell git rev-parse HEAD || echo "commit")
 VERSION_BUILD_URL ?= build
@@ -78,7 +78,7 @@ BUILDX_BAKE_COMMAND += \
 --progress=$(DOCKER_PROGRESS) \
 --builder=$(DOCKER_BUILDER) \
 
-ifeq ($(DOCKER_PUSH), true)
+ifneq ($(DOCKER_PUSH),)
 	BUILDX_BAKE_COMMAND += --push
 else
 	BUILDX_BAKE_COMMAND += --load


### PR DESCRIPTION
### Testing

Pushing: (true) is interpreted as a push event and sets --push on the make command.

Not pushing: (false, "") [false](https://app.circleci.com/pipelines/github/mozilla/addons-server/31701/workflows/ec39c261-eef5-4325-8048-76084f465a0c/jobs/215642) is interpreted correctly and [empty](https://app.circleci.com/pipelines/github/mozilla/addons-server/31700/workflows/df7107f6-a531-43ef-88a9-ddfc0227256b/jobs/215635) defaults to false.

Invalid: (1) Non-boolean values trigger configuration validation errors reducing the possible values passable to "true" and "false" literally.