### PR TITLE
Remove obsolete section about volunteer reviewers in devhub footer

### DIFF
--- a/src/olympia/devhub/templates/devhub/new-landing/components/dev_footer.html
+++ b/src/olympia/devhub/templates/devhub/new-landing/components/dev_footer.html
@@ -34,17 +34,6 @@
 
     <div class="DevHub-Footer-sections">
       <section class="DevHub-Footer-section">
-        <h4>{{ _('Review Add-ons') }}</h4>
-        <p>
-          {% trans %}
-          Volunteer reviewers help keep add-ons safe and
-          reliable to use. They enjoy great perks too!
-          {% endtrans %}
-        </p>
-        <a href="https://wiki.mozilla.org/Add-ons/Reviewers">{{ _('Join us!') }}</a>
-      </section>
-
-      <section class="DevHub-Footer-section">
         <h4>{{ _('Write Some Code') }}</h4>
         <p>
           {% trans %}


### PR DESCRIPTION
Fixes mozilla/addons#14806

Screenshot:
![Screenshot 2024-05-27 at 17-51-02 Developer Hub Add-ons for Firefox](https://github.com/mozilla/addons-server/assets/187006/33f51424-068b-40ac-a58f-d9a6b1215e3a)
