### PR TITLE
Use separate activity log action for automated rejections after delay expiry

### DIFF
--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -1015,6 +1015,31 @@ class NEEDS_HUMAN_REVIEW_CINDER(NEEDS_HUMAN_REVIEW_AUTOMATIC):
     review_queue = True
 
 
+class AUTO_REJECT_VERSION_AFTER_DELAY_EXPIRED(_LOG):
+    # takes add-on, version, reviewtype
+    id = 189
+    action_class = 'reject'
+    format = _('{addon} {version} rejected automatically after delay expired.')
+    short = _('Rejected automatically after delay expired')
+    keep = True
+    review_email_user = True
+    review_queue = True
+    reviewer_review_action = True
+    cinder_action = DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON
+
+
+class AUTO_REJECT_CONTENT_AFTER_DELAY_EXPIRED(_LOG):
+    id = 190
+    action_class = 'reject'
+    format = _('{addon} {version} content rejected automatically after delay expired.')
+    short = _('Content rejected automatically after delay expired')
+    keep = True
+    review_email_user = True
+    review_queue = True
+    reviewer_review_action = True
+    cinder_action = DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON
+
+
 LOGS = [x for x in vars().values() if isclass(x) and issubclass(x, _LOG) and x != _LOG]
 # Make sure there's no duplicate IDs.
 assert len(LOGS) == len({log.id for log in LOGS})

--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -1015,12 +1015,12 @@ class NEEDS_HUMAN_REVIEW_CINDER(NEEDS_HUMAN_REVIEW_AUTOMATIC):
     review_queue = True
 
 
-class AUTO_REJECT_VERSION_AFTER_DELAY_EXPIRED(_LOG):
+class AUTO_REJECT_VERSION_DUE(_LOG):
     # takes add-on, version, reviewtype
     id = 189
     action_class = 'reject'
-    format = _('{addon} {version} rejected automatically after delay expired.')
-    short = _('Rejected automatically after delay expired')
+    format = _('{addon} {version} scheduled rejection is due.')
+    short = _('Scheduled rejection due')
     keep = True
     review_email_user = True
     review_queue = True
@@ -1028,11 +1028,11 @@ class AUTO_REJECT_VERSION_AFTER_DELAY_EXPIRED(_LOG):
     cinder_action = DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON
 
 
-class AUTO_REJECT_CONTENT_AFTER_DELAY_EXPIRED(_LOG):
+class AUTO_REJECT_CONTENT_DUE(_LOG):
     id = 190
     action_class = 'reject'
-    format = _('{addon} {version} content rejected automatically after delay expired.')
-    short = _('Content rejected automatically after delay expired')
+    format = _('{addon} {version} scheduled content rejection is due.')
+    short = _('Scheduled content rejection due')
     keep = True
     review_email_user = True
     review_queue = True

--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -1015,12 +1015,12 @@ class NEEDS_HUMAN_REVIEW_CINDER(NEEDS_HUMAN_REVIEW_AUTOMATIC):
     review_queue = True
 
 
-class AUTO_REJECT_VERSION_DUE(_LOG):
+class AUTO_REJECT_VERSION_AFTER_DELAY_EXPIRED(_LOG):
     # takes add-on, version, reviewtype
     id = 189
     action_class = 'reject'
-    format = _('{addon} {version} scheduled rejection is due.')
-    short = _('Scheduled rejection due')
+    format = _('{addon} {version} rejected automatically after delay expired.')
+    short = _('Rejected automatically after delay expired')
     keep = True
     review_email_user = True
     review_queue = True
@@ -1028,11 +1028,11 @@ class AUTO_REJECT_VERSION_DUE(_LOG):
     cinder_action = DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON
 
 
-class AUTO_REJECT_CONTENT_DUE(_LOG):
+class AUTO_REJECT_CONTENT_AFTER_DELAY_EXPIRED(_LOG):
     id = 190
     action_class = 'reject'
-    format = _('{addon} {version} scheduled content rejection is due.')
-    short = _('Scheduled content rejection due')
+    format = _('{addon} {version} content rejected automatically after delay expired.')
+    short = _('Content rejected automatically after delay expired')
     keep = True
     review_email_user = True
     review_queue = True

--- a/src/olympia/reviewers/tests/test_commands.py
+++ b/src/olympia/reviewers/tests/test_commands.py
@@ -1309,7 +1309,7 @@ class TestAutoReject(TestCase):
         assert logs[0].action == amo.LOG.CHANGE_STATUS.id
         assert logs[0].arguments == [self.addon, amo.STATUS_NULL]
         assert logs[0].user == self.task_user
-        assert logs[1].action == amo.LOG.AUTO_REJECT_CONTENT_AFTER_DELAY_EXPIRED.id
+        assert logs[1].action == amo.LOG.AUTO_REJECT_CONTENT_DUE.id
         assert logs[1].arguments == [
             self.addon,
             self.version,
@@ -1512,13 +1512,13 @@ class TestAutoReject(TestCase):
         assert logs[0].action == amo.LOG.CHANGE_STATUS.id
         assert logs[0].arguments == [self.addon, amo.STATUS_NULL]
         assert logs[0].user == self.task_user
-        assert logs[1].action == amo.LOG.AUTO_REJECT_CONTENT_AFTER_DELAY_EXPIRED.id
+        assert logs[1].action == amo.LOG.AUTO_REJECT_CONTENT_DUE.id
         assert logs[1].arguments == [
             self.addon,
             self.version,
         ]
         assert logs[1].user == self.user
-        assert logs[2].action == amo.LOG.AUTO_REJECT_CONTENT_AFTER_DELAY_EXPIRED.id
+        assert logs[2].action == amo.LOG.AUTO_REJECT_CONTENT_DUE.id
         assert logs[2].arguments == [
             self.addon,
             another_pending_rejection,
@@ -1577,13 +1577,13 @@ class TestAutoReject(TestCase):
         assert logs[0].action == amo.LOG.CHANGE_STATUS.id
         assert logs[0].arguments == [self.addon, amo.STATUS_NULL]
         assert logs[0].user == self.task_user
-        assert logs[1].action == amo.LOG.AUTO_REJECT_CONTENT_AFTER_DELAY_EXPIRED.id
+        assert logs[1].action == amo.LOG.AUTO_REJECT_CONTENT_DUE.id
         assert logs[1].arguments == [
             self.addon,
             self.version,
         ]
         assert logs[1].user == self.user
-        assert logs[2].action == amo.LOG.AUTO_REJECT_VERSION_AFTER_DELAY_EXPIRED.id
+        assert logs[2].action == amo.LOG.AUTO_REJECT_VERSION_DUE.id
         assert logs[2].arguments == [
             self.addon,
             another_pending_rejection,

--- a/src/olympia/reviewers/tests/test_commands.py
+++ b/src/olympia/reviewers/tests/test_commands.py
@@ -1309,7 +1309,7 @@ class TestAutoReject(TestCase):
         assert logs[0].action == amo.LOG.CHANGE_STATUS.id
         assert logs[0].arguments == [self.addon, amo.STATUS_NULL]
         assert logs[0].user == self.task_user
-        assert logs[1].action == amo.LOG.AUTO_REJECT_CONTENT_DUE.id
+        assert logs[1].action == amo.LOG.AUTO_REJECT_CONTENT_AFTER_DELAY_EXPIRED.id
         assert logs[1].arguments == [
             self.addon,
             self.version,
@@ -1512,13 +1512,13 @@ class TestAutoReject(TestCase):
         assert logs[0].action == amo.LOG.CHANGE_STATUS.id
         assert logs[0].arguments == [self.addon, amo.STATUS_NULL]
         assert logs[0].user == self.task_user
-        assert logs[1].action == amo.LOG.AUTO_REJECT_CONTENT_DUE.id
+        assert logs[1].action == amo.LOG.AUTO_REJECT_CONTENT_AFTER_DELAY_EXPIRED.id
         assert logs[1].arguments == [
             self.addon,
             self.version,
         ]
         assert logs[1].user == self.user
-        assert logs[2].action == amo.LOG.AUTO_REJECT_CONTENT_DUE.id
+        assert logs[2].action == amo.LOG.AUTO_REJECT_CONTENT_AFTER_DELAY_EXPIRED.id
         assert logs[2].arguments == [
             self.addon,
             another_pending_rejection,
@@ -1577,13 +1577,13 @@ class TestAutoReject(TestCase):
         assert logs[0].action == amo.LOG.CHANGE_STATUS.id
         assert logs[0].arguments == [self.addon, amo.STATUS_NULL]
         assert logs[0].user == self.task_user
-        assert logs[1].action == amo.LOG.AUTO_REJECT_CONTENT_DUE.id
+        assert logs[1].action == amo.LOG.AUTO_REJECT_CONTENT_AFTER_DELAY_EXPIRED.id
         assert logs[1].arguments == [
             self.addon,
             self.version,
         ]
         assert logs[1].user == self.user
-        assert logs[2].action == amo.LOG.AUTO_REJECT_VERSION_DUE.id
+        assert logs[2].action == amo.LOG.AUTO_REJECT_VERSION_AFTER_DELAY_EXPIRED.id
         assert logs[2].arguments == [
             self.addon,
             another_pending_rejection,

--- a/src/olympia/reviewers/tests/test_commands.py
+++ b/src/olympia/reviewers/tests/test_commands.py
@@ -1309,7 +1309,7 @@ class TestAutoReject(TestCase):
         assert logs[0].action == amo.LOG.CHANGE_STATUS.id
         assert logs[0].arguments == [self.addon, amo.STATUS_NULL]
         assert logs[0].user == self.task_user
-        assert logs[1].action == amo.LOG.REJECT_CONTENT.id
+        assert logs[1].action == amo.LOG.AUTO_REJECT_CONTENT_AFTER_DELAY_EXPIRED.id
         assert logs[1].arguments == [
             self.addon,
             self.version,
@@ -1512,13 +1512,13 @@ class TestAutoReject(TestCase):
         assert logs[0].action == amo.LOG.CHANGE_STATUS.id
         assert logs[0].arguments == [self.addon, amo.STATUS_NULL]
         assert logs[0].user == self.task_user
-        assert logs[1].action == amo.LOG.REJECT_CONTENT.id
+        assert logs[1].action == amo.LOG.AUTO_REJECT_CONTENT_AFTER_DELAY_EXPIRED.id
         assert logs[1].arguments == [
             self.addon,
             self.version,
         ]
         assert logs[1].user == self.user
-        assert logs[2].action == amo.LOG.REJECT_CONTENT.id
+        assert logs[2].action == amo.LOG.AUTO_REJECT_CONTENT_AFTER_DELAY_EXPIRED.id
         assert logs[2].arguments == [
             self.addon,
             another_pending_rejection,
@@ -1577,13 +1577,13 @@ class TestAutoReject(TestCase):
         assert logs[0].action == amo.LOG.CHANGE_STATUS.id
         assert logs[0].arguments == [self.addon, amo.STATUS_NULL]
         assert logs[0].user == self.task_user
-        assert logs[1].action == amo.LOG.REJECT_CONTENT.id
+        assert logs[1].action == amo.LOG.AUTO_REJECT_CONTENT_AFTER_DELAY_EXPIRED.id
         assert logs[1].arguments == [
             self.addon,
             self.version,
         ]
         assert logs[1].user == self.user
-        assert logs[2].action == amo.LOG.REJECT_VERSION.id
+        assert logs[2].action == amo.LOG.AUTO_REJECT_VERSION_AFTER_DELAY_EXPIRED.id
         assert logs[2].arguments == [
             self.addon,
             another_pending_rejection,

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -2685,9 +2685,9 @@ class TestReviewHelper(TestReviewHelperBase):
         assert self.addon.status == amo.STATUS_NULL
 
         action = (
-            amo.LOG.AUTO_REJECT_VERSION_AFTER_DELAY_EXPIRED
+            amo.LOG.AUTO_REJECT_VERSION_DUE
             if not content_review
-            else amo.LOG.AUTO_REJECT_CONTENT_AFTER_DELAY_EXPIRED
+            else amo.LOG.AUTO_REJECT_CONTENT_DUE
         )
         # The request user is recorded as scheduling the rejection.
         assert self.check_log_count(action.id, original_user) == 1

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -2685,7 +2685,9 @@ class TestReviewHelper(TestReviewHelperBase):
         assert self.addon.status == amo.STATUS_NULL
 
         action = (
-            amo.LOG.REJECT_VERSION if not content_review else amo.LOG.REJECT_CONTENT
+            amo.LOG.AUTO_REJECT_VERSION_AFTER_DELAY_EXPIRED
+            if not content_review
+            else amo.LOG.AUTO_REJECT_CONTENT_AFTER_DELAY_EXPIRED
         )
         # The request user is recorded as scheduling the rejection.
         assert self.check_log_count(action.id, original_user) == 1

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -2685,9 +2685,9 @@ class TestReviewHelper(TestReviewHelperBase):
         assert self.addon.status == amo.STATUS_NULL
 
         action = (
-            amo.LOG.AUTO_REJECT_VERSION_DUE
+            amo.LOG.AUTO_REJECT_VERSION_AFTER_DELAY_EXPIRED
             if not content_review
-            else amo.LOG.AUTO_REJECT_CONTENT_DUE
+            else amo.LOG.AUTO_REJECT_CONTENT_AFTER_DELAY_EXPIRED
         )
         # The request user is recorded as scheduling the rejection.
         assert self.check_log_count(action.id, original_user) == 1

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -1244,9 +1244,9 @@ class ReviewBase:
                 and flags.pending_rejection
             ):
                 action_id = (
-                    amo.LOG.AUTO_REJECT_CONTENT_AFTER_DELAY_EXPIRED
+                    amo.LOG.AUTO_REJECT_CONTENT_DUE
                     if flags.pending_content_rejection
-                    else amo.LOG.AUTO_REJECT_VERSION_AFTER_DELAY_EXPIRED
+                    else amo.LOG.AUTO_REJECT_VERSION_DUE
                 )
             if self.human_review:
                 # Clear needs human review flags on rejected versions, we

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -1244,9 +1244,9 @@ class ReviewBase:
                 and flags.pending_rejection
             ):
                 action_id = (
-                    amo.LOG.REJECT_CONTENT
+                    amo.LOG.AUTO_REJECT_CONTENT_AFTER_DELAY_EXPIRED
                     if flags.pending_content_rejection
-                    else amo.LOG.REJECT_VERSION
+                    else amo.LOG.AUTO_REJECT_VERSION_AFTER_DELAY_EXPIRED
                 )
             if self.human_review:
                 # Clear needs human review flags on rejected versions, we

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -1244,9 +1244,9 @@ class ReviewBase:
                 and flags.pending_rejection
             ):
                 action_id = (
-                    amo.LOG.AUTO_REJECT_CONTENT_DUE
+                    amo.LOG.AUTO_REJECT_CONTENT_AFTER_DELAY_EXPIRED
                     if flags.pending_content_rejection
-                    else amo.LOG.AUTO_REJECT_VERSION_DUE
+                    else amo.LOG.AUTO_REJECT_VERSION_AFTER_DELAY_EXPIRED
                 )
             if self.human_review:
                 # Clear needs human review flags on rejected versions, we


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/14810

This PR introduces separate activity log actions for automated rejections after the delay expired, in order to distinguish them from instant rejections.

# How to test
1. Submit a new add-on.
2. Delay reject it in the reviewer tools (you need a `ReviewReason` and a `CinderPolicy` to exist for this).
   * Cinder policies can be synced from cinder stage (stick `CINDER_SERVER_URL='https://stage.cinder.nonprod.webservices.mozgcp.net/api/v1/'` and `CINDER_API_TOKEN='<whateverthatis>'` in your local settings, then sync them on `/admin/models/abuse/cinderpolicy/`)
   * If needed, create a new `ReviewReason` (`/admin/models/reviewers/reviewactionreason/`, reference an existing `CinderPolicy`)
3. Update the delay expiry to be in the past, so you don't have to wait: Run `make dbshell`, then something like the following. Note this will update all rows in the table, add a condition if you don't want that.
   ```
   UPDATE versions_versionreviewerflags set pending_rejection = "2024-05-25 00:00:00";
   ```
4. Close the review page and wait a few minutes for the reviewer lock to expire.
5. Run `make shell`, then `./manage.py auto_reject`
6. Reopen the review page, you should see something like this:
<img width="1467" alt="Screenshot 2024-05-28 at 14 13 20" src="https://github.com/mozilla/addons-server/assets/873258/0613180c-a3f5-4920-b2db-51ac96b2ed9c">

