### PR TITLE
Add configurable COMPOSE_FILE to setup flow.

### DIFF
--- a/.github/actions/run-docker/action.yml
+++ b/.github/actions/run-docker/action.yml
@@ -19,7 +19,7 @@ inputs:
   compose_file:
     description: 'The docker-compose file to use'
     required: false
-    default: 'docker-compose.yml'
+    default: 'docker-compose.yml:docker-compose.ci.yml'
 runs:
   using: 'composite'
   steps:

--- a/.github/workflows/extract-locales.yml
+++ b/.github/workflows/extract-locales.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Extract Locales
         uses: ./.github/actions/run-docker
         with:
+          compose_file: docker-compose.yml
           run: |
             make extract_locales
 

--- a/.github/workflows/verify-docker-image.yml
+++ b/.github/workflows/verify-docker-image.yml
@@ -82,6 +82,7 @@ jobs:
         uses: ./.github/actions/run-docker
         with:
           version: ${{ steps.build.outputs.version }}
+          compose_file: docker-compose.yml
           run: |
             make docs
 
@@ -112,6 +113,7 @@ jobs:
         uses: ./.github/actions/run-docker
         with:
           version: ${{ steps.build.outputs.version }}
+          compose_file: docker-compose.yml
           run: make extract_locales
 
       - name: Push Locales (dry-run)

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ deps/*
 private/
 
 # do not ignore the following files
+!docker-compose.ci.yml
 !docker-compose.private.yml
 !private/README.md
 !deps/.keep

--- a/Makefile-os
+++ b/Makefile-os
@@ -138,7 +138,7 @@ docker_extract_deps: ## Extract dependencies from the docker image to a local vo
 	touch deps/package-lock.json
 	# mounting ./deps:/deps effectively removes dependencies from the /deps directory in the container
 	# running `update_deps` will install the dependencies in the /deps directory before running
-	docker compose run --rm web make update_deps
+	docker compose -f docker-compose.yml run --rm web make update_deps
 
 .PHONY: up
 up: setup docker_mysqld_volume_create docker_extract_deps docker_compose_up ## Create and start docker compose

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,9 @@
+services:
+  web: &web
+      environment:
+        - HOST_UID=9500
+      volumes:
+      - /data/olympia
+
+  worker:
+    <<: *web

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -96,6 +96,7 @@ docker_tag, docker_version, docker_digest = get_docker_tag()
 
 set_env_file(
     {
+        'COMPOSE_FILE': get_value('COMPOSE_FILE', ('docker-compose.yml')),
         'DOCKER_TAG': docker_tag,
         'HOST_UID': get_value('HOST_UID', os.getuid()),
         'SUPERUSER_EMAIL': get_value(

--- a/tests/make/make.spec.js
+++ b/tests/make/make.spec.js
@@ -168,6 +168,7 @@ const testCases = [
   ...standardPermutations('HOST_UID', process.getuid().toString()),
   ...standardPermutations('SUPERUSER_EMAIL', gitConfigUserEmail()),
   ...standardPermutations('SUPERUSER_USERNAME', gitConfigUserName()),
+  ...standardPermutations('COMPOSE_FILE', 'docker-compose.yml'),
 ];
 
 describe.each(testCases)('.env file', ({ name, file, env, expected }) => {


### PR DESCRIPTION
Relates to: [AMOENG-599](https://mozilla-hub.atlassian.net/browse/AMOENG-599)

### Description

This PR adds COMPOSE_FILE to the .env setup flow for running the project. This allows users to configure how the project runs in a predictable way.

### Context

You could already use COMPOSE_FILE (built in feature of docker compose) but our `make setup` flow doesn't consider this variable when managing the .env file and so it could be removed. adding it explicitly to the flow ensures a sensible default is maintained and that any user overrides are not erased unintentionally.

### Testing

This PR enables several new features locally.

1. Run web/worker containers without mounting local files. This is useful if you want to test a remote image and not mount your local file system.

```bash
DOCKER_DIGEST=<valid digest> COMPOSE_FILE=docker-compose.yml:docker-compose.ci.yml make up
```

This is the "default" behavior for CI preventing any host files in the runner from influencing the tests.

This will run the digest you pass and not mount local files. You can verify this by creatin a new file on the host, and checking it does NOT exist in the container.

2. Add additional override/private compose file.

Similarly to the above you can specify a COMPOSE_FILE environment variable either in the cli or in the .env file itself to specify additional compose files to add to your configuration. This is useful for those wanting to run `docker-compose.private.yml` @wagnerand CC please verify this works as expected.
