### PR TITLE
Assay Links Added for Yara and Customs, opens the flagged add-on version & specific file.  Links to code.AMO should direct to the corresponding file and line in VS Code

### DIFF
--- a/src/olympia/reviewers/templates/reviewers/includes/files_view.html
+++ b/src/olympia/reviewers/templates/reviewers/includes/files_view.html
@@ -6,7 +6,7 @@
   &middot;
   <a 
     class="assay"
-    href="vscode://mozilla.assay/review/{{addon.guid}}/{{version}}"
+    href="{{ assay_url(addon.guid, version) }}"
     title="Open this version in Visual Studio Code"
     >
       Open in VSC

--- a/src/olympia/reviewers/templatetags/assay.py
+++ b/src/olympia/reviewers/templatetags/assay.py
@@ -1,0 +1,10 @@
+from django import template
+
+register = template.Library()
+
+@register.simple_tag
+def assay_url(addon_guid, version, file=None):
+    url = f'vscode://mozilla.assay/review/{addon_guid}/{version}'
+    if file:
+        url = f'{url}?path={file}'
+    return url

--- a/src/olympia/reviewers/templatetags/jinja_helpers.py
+++ b/src/olympia/reviewers/templatetags/jinja_helpers.py
@@ -7,6 +7,8 @@ from olympia.access import acl
 from olympia.amo.templatetags.jinja_helpers import new_context
 from olympia.ratings.permissions import user_can_delete_rating
 from olympia.reviewers.templatetags import code_manager
+from olympia.reviewers.templatetags import assay
+
 
 
 @library.global_function
@@ -65,6 +67,11 @@ def file_view(context, version):
 @jinja2.pass_context
 def is_expired_lock(context, lock):
     return lock.expiry < datetime.datetime.now()
+
+
+@library.global_function
+def assay_url(addon_guid, version, file=None):
+    return assay.assay_url(addon_guid, version, file)
 
 
 @library.global_function

--- a/src/olympia/reviewers/tests/test_assay_tags.py
+++ b/src/olympia/reviewers/tests/test_assay_tags.py
@@ -4,7 +4,7 @@ from olympia.amo.tests import TestCase
 from olympia.reviewers.templatetags import assay
 
 
-class TestCodeManagerUrl(TestCase):
+class TestAssayUrl(TestCase):
     def setUp(self):
         super().setUp()
         self.assay_url = 'vscode://mozilla.assay/review'

--- a/src/olympia/reviewers/tests/test_assay_tags.py
+++ b/src/olympia/reviewers/tests/test_assay_tags.py
@@ -1,0 +1,31 @@
+from django.test.utils import override_settings
+
+from olympia.amo.tests import TestCase
+from olympia.reviewers.templatetags import assay
+
+
+class TestCodeManagerUrl(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.assay_url = 'vscode://mozilla.assay/review'
+        self.addon_guid = 1
+        self.version = 3
+        self.file = 'somefile.js'
+
+    def test_create_an_assay_url(self):
+        assert assay.assay_url(
+            self.assay_url, self.addon_guid, self.version
+        ) == (
+            '{}/{}/{}'.format(
+                self.assay_url, self.addon_guid, self.version
+            )
+        )
+
+    def test_create_an_assay_url_with_file(self):
+        assert assay.assay_url(
+            self.assay_url, self.addon_guid, self.version, self.file
+        ) == (
+            '{}/{}/{}?path={}'.format(
+                self.assay_url, self.addon_guid, self.version, self.file
+            )
+        )

--- a/src/olympia/reviewers/tests/test_jinja_helpers.py
+++ b/src/olympia/reviewers/tests/test_jinja_helpers.py
@@ -5,6 +5,13 @@ from olympia.reviewers.templatetags import code_manager, jinja_helpers
 
 pytestmark = pytest.mark.django_db
 
+def test_create_an_assay_url():
+    assert jinja_helpers.assay_url(
+        addon_guid="{guid}", version="version", file="file.js"
+    ) == code_manager.assay_url(
+        addon_guid="{guid}", version="version", file="file.js"
+    )
+
 
 def test_create_a_code_manager_url():
     assert jinja_helpers.code_manager_url(

--- a/src/olympia/scanners/admin.py
+++ b/src/olympia/scanners/admin.py
@@ -84,6 +84,8 @@ def formatted_matched_rules_with_files_and_data(
             ],
             'addon_id': obj.version.addon.pk if obj.version else None,
             'version_id': obj.version.pk if obj.version else None,
+            'addon_guid': obj.version.addon.guid if obj.version else None,
+            'addon_version': obj.version if obj.version else None
         },
     )
 

--- a/src/olympia/scanners/templates/admin/scanners/scannerresult/formatted_matched_rules_with_files.html
+++ b/src/olympia/scanners/templates/admin/scanners/scannerresult/formatted_matched_rules_with_files.html
@@ -1,5 +1,6 @@
 {% load admin_urls %}
 {% load code_manager %}
+{% load assay %}
 {% load scanners %}
 
 {# This template can be used for scanner results and scanner query results, #}
@@ -28,9 +29,14 @@
       {% for item in rule.files_and_data %}
         <li>
         {% if file_id and item.filename %}
+        <span>
           <a href="{% code_manager_url 'browse' addon_id version_id file=item.filename %}">
             {{ item.filename }}
           </a>
+          <a href="{% assay_url addon_guid addon_version file=item.filename %}">
+            (Assay)
+          </a>
+        </span>
         {% else %}
           {{ item.filename }}
         {% endif %}


### PR DESCRIPTION
This PR is to create the links next to the existing code-manager ones for proof-of-concept purposes. These links should eventually fully replace code-manager. 

**Changes**
- Added Assay link to Yara results
- Modified existing Assay link to use helper.

<img width="363" alt="image" src="https://github.com/mozilla/addons-server/assets/44586776/36f18ce9-03d2-4d03-8750-eda63ca1a778">