### PR TITLE
Expose reviewers validation result API through JWT auth and document it

### DIFF
--- a/docs/topics/api/reviewers.rst
+++ b/docs/topics/api/reviewers.rst
@@ -9,9 +9,11 @@ Reviewers
     These APIs are not frozen and can change at any time without warning.
     See :ref:`the API versions available<api-versions-list>` for alternatives
     if you need stability.
-    The only authentication method available at
-    the moment is :ref:`the internal one<api-auth-internal>`, except for
-    :ref:`validation results<reviewers-validation>`.
+
+    The only authentication method available for these APIs is
+    :ref:`the internal one<api-auth-internal>`, except for the
+    :ref:`validation results<reviewers-validation>` endpoint, which allows both
+    internal and :ref:`external auth<api-auth>`.
 
 ---------
 Subscribe

--- a/docs/topics/api/reviewers.rst
+++ b/docs/topics/api/reviewers.rst
@@ -10,7 +10,8 @@ Reviewers
     See :ref:`the API versions available<api-versions-list>` for alternatives
     if you need stability.
     The only authentication method available at
-    the moment is :ref:`the internal one<api-auth-internal>`.
+    the moment is :ref:`the internal one<api-auth-internal>`, except for
+    :ref:`validation results<reviewers-validation>`.
 
 ---------
 Subscribe
@@ -49,6 +50,23 @@ sent when a new version is submitted on a particular add-on.
 .. http:post:: /api/v5/reviewers/addon/(int:addon_id)/unsubscribe_listed/
 .. http:post:: /api/v5/reviewers/addon/(int:addon_id)/unsubscribe_unlisted/
 
+
+---------------
+File Validation
+---------------
+
+.. _reviewers-validation:
+
+This endpoint allows you to view the validation results of a given file
+belonging to an add-on.
+
+    .. note::
+        Requires authentication and the current user to have any
+        reviewer-related permission.
+
+.. http:post:: /api/v5/reviewers/addon/(int: addon_id)/file/(int: file_id)/validation/
+
+    :>json object validation: the validation results
 
 -----
 Flags

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -50,6 +50,10 @@ from olympia.amo.decorators import (
 )
 from olympia.amo.templatetags.jinja_helpers import numberfmt
 from olympia.amo.utils import paginate
+from olympia.api.authentication import (
+    JWTKeyAuthentication,
+    SessionIDAuthentication,
+)
 from olympia.api.permissions import (
     AllowAnyKindOfReviewer,
     AllowListedViewerOrReviewer,
@@ -1197,6 +1201,10 @@ class AddonReviewerViewSet(GenericViewSet):
         detail=True,
         methods=['get'],
         permission_classes=[AllowAnyKindOfReviewer],
+        authentication_classes=[
+            JWTKeyAuthentication,
+            SessionIDAuthentication,
+        ],
         url_path=r'file/(?P<file_id>[^/]+)/validation',
     )
     def json_file_validation(self, request, **kwargs):


### PR DESCRIPTION
Fixes mozilla/addons#14833

## Context

That endpoint existed already but wasn't documented and was only available through the SessionID auth, which is the default, and not through JWT auth. That's because it was only needed for code-manager until now, which uses session auth. It's now needed for [Assay](https://github.com/mozilla/assay) which uses JWT so I've added the relevant authentication classes.

## Testing

See unit tests, we have used a similar method of duplicating the class and changing the `client_class` for other API tests, makes things easier even it's a little wasteful.

It's painful to test locally and I would just trust the unit tests, but for anyone adventurous, you'd need to:
- Upload an add-on, then grab the add-on and file id (from a shell is easier, i.e. `Addon.objects.latest('pk').pk` and `File.objects.latest('pk').pk`)
- Log in as a reviewer, generate API keys in devhub (need to look up fake emails to grab the confirmation link)
- Using those API keys to generate a JWT-authenticated request against `http://olympia.test/api/v5/reviewers/addon/{addon_id}/file/{file_id}/validation/` following our API docs