### PR TITLE
Run CI on push to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
 on:
+  push:
+    branches:
+      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build Docker image
+        if: ${{ github.event.pull_request.head.repo.fork == false }}
         id: build
         uses: ./.github/actions/build-docker
         with:


### PR DESCRIPTION
Follow up to https://github.com/mozilla/addons-server/pull/22306 enabling CI on push to master