### PR TITLE
Ditch the /deps volume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ private/
 
 # do not ignore the following files
 !docker-compose.ci.yml
+!docker-compose.deps.yml
 !docker-compose.private.yml
 !private/README.md
 !deps/.keep

--- a/Makefile-os
+++ b/Makefile-os
@@ -141,7 +141,7 @@ docker_extract_deps: ## Extract dependencies from the docker image to a local vo
 	docker compose run --rm --quiet-pull web make update_deps
 
 .PHONY: up
-up: setup docker_mysqld_volume_create docker_extract_deps docker_compose_up ## Create and start docker compose
+up: setup docker_mysqld_volume_create docker_compose_up ## Create and start docker compose
 
 .PHONY: down
 down: docker_compose_down ## Stop the docker containers

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -4,7 +4,6 @@ services:
         - HOST_UID=9500
       volumes:
       - /data/olympia
-      - /deps
 
   worker:
     <<: *web

--- a/docker-compose.deps.yml
+++ b/docker-compose.deps.yml
@@ -1,0 +1,9 @@
+services:
+  web: &web
+      volumes:
+      - ./deps:/deps
+      - ./package.json:/deps/package.json
+      - ./package-lock.json:/deps/package-lock.json
+
+  worker:
+    <<: *web

--- a/docker-compose.deps.yml
+++ b/docker-compose.deps.yml
@@ -1,3 +1,6 @@
+# Using this file enables a mount of ./deps to /deps in the web/worker containers.
+# This allows the /deps folder to be exposed on the host machine enabling editing of those files
+# from the host. It is disabled by default.
 services:
   web: &web
       volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       - supervisord -n -c /data/olympia/docker/supervisor-celery.conf
     volumes:
       - .:/data/olympia
+      - /data/olympia/src/olympia.egg-info
       - storage:/data/olympia/storage
     extra_hosts:
      - "olympia.test:127.0.0.1"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,12 +44,20 @@ services:
     volumes:
       - .:/data/olympia
       - storage:/data/olympia/storage
-      - ./deps:/deps
-      - ./package.json:/deps/package.json
-      - ./package-lock.json:/deps/package-lock.json
     extra_hosts:
      - "olympia.test:127.0.0.1"
     restart: on-failure:5
+    # entrypoint.sh takes some time
+    # we can wait for supervisor to start
+    # indicating the service is ready
+    healthcheck:
+      test: [
+        "CMD-SHELL",
+        "if [ -f /data/olympia/supervisord.pid ]; then echo 'File exists'; else echo 'File not found'; exit 1; fi"
+      ]
+      interval: 5s
+      timeout: 10s
+      retries: 30
 
   web:
     <<: *worker

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -15,16 +15,19 @@ fi
 
 OLYMPIA_USER="olympia"
 
+function get_olympia_uid() { echo "$(id -u "$OLYMPIA_USER")"; }
+function get_olympia_gid() { echo "$(id -g "$OLYMPIA_USER")"; }
+
 if [[ -n "${HOST_UID:-}" ]]; then
   usermod -u ${HOST_UID} ${OLYMPIA_USER}
   echo "${OLYMPIA_USER} UID: ${OLYMPIA_UID} -> ${HOST_UID}"
+
+  # Ensure the olympia user has access to the /deps directory
+  time chown -R "$(get_olympia_uid):$(get_olympia_gid)" /deps
 fi
 
-uid=$(id -u $OLYMPIA_USER)
-gid=$(id -g $OLYMPIA_USER)
-
 cat <<EOF | su -s /bin/bash $OLYMPIA_USER
-  echo "Running command as ${OLYMPIA_USER} ${uid}:${gid}"
+  echo "Running command as ${OLYMPIA_USER} $(get_olympia_uid):$(get_olympia_gid)"
   set -xue
   $@
 EOF


### PR DESCRIPTION
Follow up of: https://github.com/mozilla/addons/issues/14821

### Description

Remove the ./deps:/deps volume as an unnecessary artifact of the previous build architecture. Currently dependencies are packaged with the docker image and mounting from the host is both unnecessary and complex to maintain.

Inspecting files using the local ./deps can have some limited benefits in some cases so a `docker-compose.deps.yml` file is retained to do so if a developer wants to, but it is no longer the default behavior to mount the ./deps directory.

### Testing

No changes to existing environments, once rebased any files in the ./deps directory will be ignored and should be cleaned up by developers on their machines.

#### Running with ./deps mount

To mount with deps run

```bash
make up COMPOSE_FILE=docker-compose.yml:docker-compose.deps.yml
```

Expect mounting from ./deps to occur.
