### PR TITLE
Don't attempt to push an image if actor is dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build Docker image
-        if: ${{ github.event.pull_request.head.repo.fork == false }}
+        if: ${{ github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]' }}
         id: build
         uses: ./.github/actions/build-docker
         with:


### PR DESCRIPTION
Dependabot doesn't (and shouldn't) have access to secrets, so it can't push the temporary image built for its PR. This changes prevents GitHub actions from attempting to push that image (overall job will be slower but should succeed).

Follow-up for https://github.com/mozilla/addons/issues/14821