### PR TITLE
Add workflow to log context on release events

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   # Release events should trigger this workflow to
-  # autp deploy: published
+  # auto deploy: published
   # rollback: unpublished, deleted (when latest)
   # manually deploy: workflow_dispatch
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  # Release events should trigger this workflow to
+  # autp deploy: published
+  # rollback: unpublished, deleted (when latest)
+  # manually deploy: workflow_dispatch
+  release:
+    types: [deleted, unpublished, published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "The docker image version to release, defaults to latest"
+        required: true
+        default: "latest"
+
+jobs:
+  context:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Log (github)
+        shell: bash
+        run: |
+          cat <<EOF
+          ${{toJson(github)}}
+      - name: Log (inputs)
+        shell: bash
+        run: |
+          cat <<EOF
+          ${{toJson(inputs)}}


### PR DESCRIPTION
Relates to: 
- https://mozilla-hub.atlassian.net/browse/AMOENG-616
- https://mozilla-hub.atlassian.net/browse/AMOENG-812

### Description

This PR introduces a release.yml workflow that will be triggered on release events and should be a part of how we deploy addons-server

### Context

Currently the workflow is relatively empty. It is just logging the relevent information from the webhook payload so we can plan how best to integrate the release events to the actual deployment pipeline.

We will need to find
- tag related to a release
- time a release was created/published/unpublished
etc.

How does this relate to AMOENG-812? Currently deploying requires webhook events to tell deploy-amo when to actually deploy and what to deploy. Te push event by itself will not suffice for this because no image has been created at that point. So we will need to either listen for a specific job (say the build job in the ciyml) workflow, or a job in this workflow if we aim to use a relase entity to manage deployment, we should already check the feasability of this event.

We should merge this to be able to play around with the release feature and see how it works, but right now it does not and will not do anything important.
