### PR TITLE
Listen to all release events

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,18 +2,6 @@ name: Release
 
 on:
   release:
-    types: [
-      # Deploy staging
-      created,
-      edited,
-      prereleased,
-      # Deploy rollback
-      deleted,
-      unpublished,
-      # Deploy prodcution
-      published
-    ]
-  # Deploy dev
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
Following https://github.com/mozilla/addons-server/pull/22359

For some reason, release events are not triggering the workflow, so to simplify I am removing all filters and just triggering on any release event. We can figure out how to narrow down later.