### PR TITLE
split resolving jobs functionality into seperate action from comment

### DIFF
--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -1039,6 +1039,16 @@ class AUTO_REJECT_CONTENT_AFTER_DELAY_EXPIRED(_LOG):
     cinder_action = DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON
 
 
+class RESOLVE_CINDER_JOB_WITH_NO_ACTION(_LOG):
+    id = 191
+    format = '{addon} cinder job resolved with no action .'
+    short = _('Job Resolved as Ignore/Approve')
+    keep = True
+    review_queue = True
+    hide_developer = True
+    reviewer_review_action = True
+
+
 LOGS = [x for x in vars().values() if isclass(x) and issubclass(x, _LOG) and x != _LOG]
 # Make sure there's no duplicate IDs.
 assert len(LOGS) == len({log.id for log in LOGS})

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -167,10 +167,9 @@
       {{ form.versions }}
       {{ form.versions.errors }}
 
-      <div class="review-actions-section data-toggle review-comments"
-           data-value="{{ actions_comments|join(' ') }}">
+      <div class="review-actions-section">
         <div class="review-actions-comments-reasons">
-          <div class="review-actions-comments">
+          <div class="review-actions-comments data-toggle review-comments" data-value="{{ actions_comments|join(' ') }}">
             <label for="id_comments">{{ form.comments.label }}</label>
             {{ form.comments }}
             {{ form.comments.errors }}

--- a/src/olympia/reviewers/tests/test_forms.py
+++ b/src/olympia/reviewers/tests/test_forms.py
@@ -383,7 +383,11 @@ class TestReviewForm(TestCase):
         )
         form = self.get_form()
         assert not form.is_bound
-        data = {'action': 'comment', 'comments': 'lol', 'resolve_cinder_jobs': [job.id]}
+        data = {
+            'action': 'resolve_job',
+            'comments': 'lol',
+            'resolve_cinder_jobs': [job.id],
+        }
         form = self.get_form(data=data)
         assert form.is_bound
         assert not form.is_valid()
@@ -426,7 +430,7 @@ class TestReviewForm(TestCase):
         form = self.get_form()
         assert not form.is_bound
         data = {
-            'action': 'comment',
+            'action': 'resolve_job',
             'comments': 'lol',
             'resolve_cinder_jobs': [job.id],
             'cinder_policies': [no_action_policy.id],

--- a/static/css/zamboni/reviewers.less
+++ b/static/css/zamboni/reviewers.less
@@ -1042,6 +1042,10 @@ form.review-form .data-toggle {
     width: 100%;
 }
 
+.review-actions-policies-select {
+    height: 100px;
+}
+
 .review-actions-reasons-select ul {
     list-style: none;
 }


### PR DESCRIPTION
fixes mozilla/addons#14845

![image(1)](https://github.com/mozilla/addons-server/assets/768592/d18ff3b8-820a-488a-a7ac-5c19ccf5bc0c)

Note: there is further work which will build on this to specifically handle appeals.