### PR TITLE
Replace post-request-task with transaction.on_commit on every delay/apply_async

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -557,9 +557,6 @@ django-extensions==3.2.3 \
 django-multidb-router==0.10 \
     --hash=sha256:6802bbfce3a0dac343f93a290df12a9979aed99b350bc0148a7430353efae8b6 \
     --hash=sha256:a10bf4b664465090a5f2e8543dd1491eaf8dde7c551270e546324454e7280964
-django-post-request-task==0.5 \
-    --hash=sha256:26c03b5d06eb1705b2438bb719575fac4aae7f34c32837480202acad556edb3c \
-    --hash=sha256:91df3893c9551851cd10568ef3b2cf358bd87e8c65dce728c37196a8de34247c
 django-recaptcha==4.0.0 \
     --hash=sha256:0d912d5c7c009df4e47accd25029133d47a74342dbd2a8edc2877b6bffa971a3 \
     --hash=sha256:5316438f97700c431d65351470d1255047e3f2cd9af0f2f13592b637dad9213e

--- a/settings_test.py
+++ b/settings_test.py
@@ -81,6 +81,7 @@ CELERY_TASK_ALWAYS_EAGER = True
 CELERY_IMPORTS += (
     'olympia.amo.tests.test_celery',
     'olympia.search.tests.test_commands',
+    'olympia.devhub.tests.test_tasks',
 )
 
 CELERY_TASK_ROUTES.update(

--- a/src/olympia/amo/celery.py
+++ b/src/olympia/amo/celery.py
@@ -8,14 +8,16 @@ is directly being run/imported by Celery)
 """
 
 import datetime
+import functools
 
 from django.core.cache import cache
+from django.db import transaction
 
 from celery import Celery, group
+from celery.app.task import Task
 from celery.signals import task_failure, task_postrun, task_prerun
 from django_statsd.clients import statsd
 from kombu import serialization
-from post_request_task.task import PostRequestTask
 
 import olympia.core.logger
 
@@ -23,10 +25,11 @@ import olympia.core.logger
 log = olympia.core.logger.getLogger('z.task')
 
 
-class AMOTask(PostRequestTask):
-    """A custom celery Task base class that inherits from `PostRequestTask`
-    to delay tasks and adds a special hack to still perform a serialization
-    roundtrip in eager mode, to mimic what happens in production in tests.
+class AMOTask(Task):
+    """A custom celery Task base class to always trigger tasks after the
+    current transaction has been committed, and also adds a special hack to
+    still perform a serialization roundtrip in eager mode, to mimic what
+    happens in production in tests.
 
     The serialization is applied both to apply_async() and apply() to work
     around the fact that celery groups have their own apply_async() method that
@@ -50,13 +53,21 @@ class AMOTask(PostRequestTask):
             args, kwargs = serialization.loads(data, content_type, content_encoding)
         return args, kwargs
 
+    def original_apply_async(self, args=None, kwargs=None, **extrakw):
+        return super().apply_async(args=args, kwargs=kwargs, **extrakw)
+
+    def delay(self, *args, **kwargs) -> None:
+        transaction.on_commit(functools.partial(super().delay, *args, **kwargs))
+
     def apply_async(self, args=None, kwargs=None, **options):
         if app.conf.task_always_eager:
             args, kwargs = self._serialize_args_and_kwargs_for_eager_mode(
                 args=args, kwargs=kwargs, **options
             )
 
-        return super().apply_async(args=args, kwargs=kwargs, **options)
+        transaction.on_commit(
+            functools.partial(self.original_apply_async, *args, **kwargs)
+        )
 
     def apply(self, args=None, kwargs=None, **options):
         if app.conf.task_always_eager:

--- a/src/olympia/amo/celery.py
+++ b/src/olympia/amo/celery.py
@@ -53,8 +53,8 @@ class AMOTask(Task):
             args, kwargs = serialization.loads(data, content_type, content_encoding)
         return args, kwargs
 
-    def original_apply_async(self, args=None, kwargs=None, **extrakw):
-        return super().apply_async(args=args, kwargs=kwargs, **extrakw)
+    def original_apply_async(self, *args, **kwargs):
+        return super().apply_async(*args, **kwargs)
 
     def apply_async(self, args=None, kwargs=None, **options):
         if app.conf.task_always_eager:
@@ -69,7 +69,9 @@ class AMOTask(Task):
             # In normal mode, wait until the current transaction is committed
             # to actually send the task.
             transaction.on_commit(
-                functools.partial(self.original_apply_async, *args, **kwargs)
+                functools.partial(
+                    self.original_apply_async, args=args, kwargs=kwargs, **options
+                )
             )
             return None  # Can't return anything meaningful in this case.
 

--- a/src/olympia/amo/celery.py
+++ b/src/olympia/amo/celery.py
@@ -54,6 +54,9 @@ class AMOTask(Task):
         return args, kwargs
 
     def original_apply_async(self, *args, **kwargs):
+        """Alias for celery's original apply_async() method, allowing us to
+        trigger a task without waiting without waiting for the current
+        transaction to be committed. Use with caution."""
         return super().apply_async(*args, **kwargs)
 
     def apply_async(self, args=None, kwargs=None, **options):

--- a/src/olympia/amo/celery.py
+++ b/src/olympia/amo/celery.py
@@ -67,7 +67,7 @@ class AMOTask(Task):
             # In eager mode, immediately call original apply async as we are
             # using eager mode for tests, where no transaction is ever actually
             # committed so transaction.on_commit() is never called.
-            return self.original_apply_async(args=args, kwargs=kwargs, **options)
+            self.original_apply_async(args=args, kwargs=kwargs, **options)
         else:
             # In normal mode, wait until the current transaction is committed
             # to actually send the task.
@@ -76,7 +76,9 @@ class AMOTask(Task):
                     self.original_apply_async, args=args, kwargs=kwargs, **options
                 )
             )
-            return None  # Can't return anything meaningful in this case.
+        # We can't return anything meaningful if we're going through the
+        # on_commit path, so for consistency return None in all cases.
+        return None
 
     def apply(self, args=None, kwargs=None, **options):
         if app.conf.task_always_eager:

--- a/src/olympia/amo/monitors.py
+++ b/src/olympia/amo/monitors.py
@@ -217,7 +217,9 @@ def remotesettings():
     # a worker, and since workers have different network
     # configuration than the Web head, we use a task to check
     # the connectivity to the Remote Settings server.
-    # Since we want the result immediately, bypass django-post-request-task.
+    # Since we want the result immediately, use original_apply_async() to avoid
+    # waiting for the transaction django creates for the request like we
+    # usually do.
     result = monitor_remote_settings.original_apply_async()
     try:
         status = result.get(timeout=settings.REMOTE_SETTINGS_CHECK_TIMEOUT_SECONDS)

--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -253,7 +253,8 @@ def send_mail(
         kwargs.update(options)
         # Email subject *must not* contain newlines
         args = (list(recipients), ' '.join(subject.splitlines()), message)
-        return send_email.delay(*args, **kwargs)
+        send_email.delay(*args, **kwargs)
+        return True
 
     if white_list:
         if perm_setting:

--- a/src/olympia/core/apps.py
+++ b/src/olympia/core/apps.py
@@ -72,10 +72,3 @@ class CoreConfig(AppConfig):
         # Ignore Python warnings unless we're running in debug mode.
         if not settings.DEBUG:
             warnings.simplefilter('ignore')
-
-        self.enable_post_request_task()
-
-    def enable_post_request_task(self):
-        """Import post_request_task so that it can listen to `request_started`
-        signal before the first request is handled."""
-        import post_request_task.task  # noqa

--- a/src/olympia/devhub/tasks.py
+++ b/src/olympia/devhub/tasks.py
@@ -74,7 +74,7 @@ def validate(file_, *, final_task=None, theme_specific=False):
         return AsyncResult(task_id)
     else:
         task = validator.get_task()
-        task_id = task.freeze()
+        task_id = task.freeze().id
         cache.set(validator.cache_key, task_id, 5 * 60)
         return task.delay()
 

--- a/src/olympia/devhub/tasks.py
+++ b/src/olympia/devhub/tasks.py
@@ -73,6 +73,7 @@ def validate(file_, *, final_task=None, theme_specific=False):
     if task_id:
         return AsyncResult(task_id)
     else:
+        breakpoint()
         result = validator.get_task().delay()
         cache.set(validator.cache_key, result.task_id, 5 * 60)
         return result

--- a/src/olympia/devhub/tasks.py
+++ b/src/olympia/devhub/tasks.py
@@ -73,10 +73,10 @@ def validate(file_, *, final_task=None, theme_specific=False):
     if task_id:
         return AsyncResult(task_id)
     else:
-        breakpoint()
-        result = validator.get_task().delay()
-        cache.set(validator.cache_key, result.task_id, 5 * 60)
-        return result
+        task = validator.get_task()
+        task_id = task.freeze()
+        cache.set(validator.cache_key, task_id, 5 * 60)
+        return task.delay()
 
 
 def validate_and_submit(*, addon, upload, client_info, theme_specific=False):

--- a/src/olympia/devhub/tests/test_utils.py
+++ b/src/olympia/devhub/tests/test_utils.py
@@ -119,7 +119,7 @@ class TestAddonsLinterListed(UploadMixin, TestCase):
     def test_run_once_file_upload(self, get_task_mock):
         """Tests that only a single validation task is run for a given file
         upload."""
-        get_task_mock.return_value.delay.return_value = mock.Mock(task_id='42')
+        get_task_mock.return_value.freeze.return_value = mock.Mock(id='42')
 
         assert isinstance(tasks.validate(self.file_upload), mock.Mock)
         assert get_task_mock.return_value.delay.call_count == 1

--- a/src/olympia/devhub/tests/test_utils.py
+++ b/src/olympia/devhub/tests/test_utils.py
@@ -103,7 +103,7 @@ class TestAddonsLinterListed(UploadMixin, TestCase):
     @mock.patch.object(utils.Validator, 'get_task')
     def test_run_once_per_file(self, get_task_mock):
         """Tests that only a single validation task is run for a given file."""
-        get_task_mock.return_value.delay.return_value = mock.Mock(task_id='42')
+        get_task_mock.return_value.freeze.return_value = mock.Mock(id='42')
 
         assert isinstance(tasks.validate(self.file), mock.Mock)
         assert get_task_mock.return_value.delay.call_count == 1

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1013,12 +1013,6 @@ LOGGING = {
             'propagate': False,
         },
         'parso': {'handlers': ['null'], 'level': logging.INFO, 'propagate': False},
-        'post_request_task': {
-            'handlers': ['mozlog'],
-            # Ignore INFO or DEBUG from post-request-task, it logs too much.
-            'level': logging.WARNING,
-            'propagate': False,
-        },
         'sentry_sdk': {
             'handlers': ['mozlog'],
             'level': logging.WARNING,


### PR DESCRIPTION
## Description

According to [Django docs](https://docs.djangoproject.com/en/5.0/topics/db/transactions/#performing-actions-after-commit), `transaction.on_commit` should:
- only be called once the outer `transaction.atomic()` has been executed, guaranteeing that it works even if there are savepoints.
- be discarded on rollback

So it should be a drop-in replacement with the added benefit that it handles tasks and commands doing transactions outside of the request-response cycle.

This is the same approach celery has introduced in 5.4 with its [DjangoTask](https://docs.celeryq.dev/en/stable/reference/celery.contrib.django.task.html#celery.contrib.django.task.DjangoTask) except we keep our own class and apply that waiting for the transaction commit behavior to all tasks by default.

### Context

post-request-task is an app we wrote years ago to delay sending the tasks to celery broker until the current request sends the `request_finished` signal. The idea is that we're using django's `ATOMIC_REQUESTS` so that each request is wrapped in a transaction (unless it's specifically disabled for that view), so by waiting for that signal, we know the task we want to trigger is safe to execute, any database changes it's relying on will have been committed.

This works fine for requests, but doesn't do anything for management commands or tasks. Historically this hasn't been much of an issue, because we didn't trigger that many tasks from those, but lately it's become apparent we need to address that.

### Testing

Unit tests passing are not enough to prove this change works, because of 2 reasons:
- Our tests often expect tasks to be executed synchronously for convenience, so we use celery eager mode
- Django's `TestCase` wraps tests in its own transaction that is never committed and simply rolled back at the end of each test

Local testing should be done by looking at worker logs (`logs/docker-celery.log`) for the following scenarios to make sure the corresponding task(s) have been executed:
- Triggering `manage.py generate_error --celery --atomic`. You can repeat with or without `--atomic` and it shouldn't make a difference.
- Submitting a new add-on. This triggers a chord with our validation-related tasks, and should succeed and let you continue with your submission.
- Triggering `manage.py auto_approve` with some unreviewed versions. This should approve them, provided you don't have their review page opened in a tab and that the versions can be auto-approved (submitting a new unlisted one is the fastest way to do that)
- Replying as a reviewer in review page for an add-on. This should send a fake email. Note that you can also resolve cinder jobs if you have that set up.
- Making changes to an add-on name or description. That should trigger a reindex, which you can check by then searching for that change using the API or frontend.

Fixes mozilla/addons#14842