### PR TITLE
Escape json blob in context job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Log context
         shell: bash
         run: |
-          cat <<EOF
+          cat <<'EOF'
           ${{ toJSON(github) }}
           EOF
       - name: Set context

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - id: context
         shell: bash
         run: |
-          cat <<EOF
+          cat <<'EOF'
           ${{toJson(github)}}
           EOF
 


### PR DESCRIPTION
Fixes: mozilla/addons/issues/14857

### Description

cat <<EOF is to "" 

as 

cat <<'EOF' is  to ''

We want to prevent any interpolation of the values inside the github context blob as these can cause arbitrary execution errors in what should just be a plain log statement.



