### PR TITLE
Use more explicit syntax in push locales conditional expression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,8 @@ jobs:
         id: should_build
         shell: bash
         run: |
-          is_fork="${{ needs.context.outputs.is_fork == 'true' }}"
-          is_dependabot="${{ needs.context.outputs.is_dependabot == 'true' }}"
+          is_fork="${{ needs.context.outputs.is_fork }}"
+          is_dependabot="${{ needs.context.outputs.is_dependabot }}"
 
           # Default behaviour is to build images for any CI.yml run
           should_build="true"
@@ -267,17 +267,24 @@ jobs:
           run: make extract_locales
 
       - name: Push Locales
-        if: github.event_name == 'push'
         shell: bash
         run: |
-          if [[ "${{ needs.context.outputs.is_fork == 'true' }}" == 'true' ]]; then
-            echo """
+          is_fork="${{ needs.context.outputs.is_fork }}"
+          is_default_branch="${{ needs.context.outputs.is_default_branch }}"
+          is_push="${{ github.event_name == 'push' }}"
+
+          if [[ "$is_fork" == 'true' ]]; then
+            cat <<'EOF'
               Github actions are not authorized to push from workflows triggered by forks.
               We cannot verify if the l10n extraction push will work or not.
               Please submit a PR from the base repository if you are modifying l10n extraction scripts.
-            """
+          EOF
           else
-            args="${{ needs.context.outputs.is_default_branch == 'true' && '' || '--dry-run' }}"
+            if [[ "$is_default_branch" == 'true' && "$is_push" == 'true' ]]; then
+              args=""
+            else
+              args="--dry-run"
+            fi
             make push_locales ARGS="${args}"
           fi
 


### PR DESCRIPTION
Relates to: <https://github.com/mozilla/addons/14869>

### Context

The ternary logic makes the evaluation of the github expression less explicit. We just see what ARGS="<expression>" evaluates to.

Using this more explicit syntax should either solve the problem or make it more clear how to solve

### Testing

Removing the if condition on the step, we can now execute this step via workflow dispatch and ensure we only push when running on the default branch.

Fork: works as expected ([job](https://github.com/mozilla/addons-server/actions/runs/9594926061/job/26458550825?pr=22387))

### Checklist


- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.

