### PR TITLE
Only disable auto approval until next manual one on human rejections, not automatic

### DIFF
--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -1086,6 +1086,13 @@ class Version(OnChangeMixin, ModelBase):
             return None
 
     @property
+    def pending_content_rejection(self):
+        try:
+            return self.reviewerflags.pending_content_rejection
+        except VersionReviewerFlags.DoesNotExist:
+            return None
+
+    @property
     def pending_rejection_by(self):
         try:
             return self.reviewerflags.pending_rejection_by

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -1330,6 +1330,26 @@ class TestVersion(AMOPaths, TestCase):
             pending_content_rejection=False,
         )
         assert version.pending_rejection == in_the_past
+        assert not version.pending_content_rejection
+
+    def test_pending_content_rejection_property(self):
+        addon = Addon.objects.get(id=3615)
+        version = addon.current_version
+        # No flags: None
+        assert version.pending_content_rejection is None
+        # Flag present, value is None (default): None.
+        flags = version_review_flags_factory(version=version)
+        assert flags.pending_content_rejection is None
+        assert version.pending_content_rejection is None
+        # Flag present, value is a date.
+        in_the_past = self.days_ago(1)
+        flags.update(
+            pending_rejection=in_the_past,
+            pending_rejection_by=user_factory(),
+            pending_content_rejection=True,
+        )
+        assert version.pending_rejection == in_the_past
+        assert version.pending_content_rejection
 
     def test_pending_rejection_by_property(self):
         addon = Addon.objects.get(id=3615)


### PR DESCRIPTION
Fixes mozilla/addons#14836

### Context

We go through the same `reject_multiple_versions()` method for human rejections and automatic ones after a delay. In the non-human case, `human_review` will be `False` and we can use that to avoid disabling future auto-approvals like asked in the ticket.

### Testing

The issue contains some STR but it should be straightforward enough to just rely on the tests.