### PR TITLE
Clear NeedsHumanReview selectively depending on job being resolved

### DIFF
--- a/src/olympia/abuse/cinder.py
+++ b/src/olympia/abuse/cinder.py
@@ -517,12 +517,11 @@ class CinderAddonHandledByReviewers(CinderAddon):
             )
 
     def post_report(self, job):
-        if not (job.is_appeal and job.is_unresolved):
+        if not job.is_appeal:
             self.flag_for_human_review(appeal=False)
-        # If our report was added to an unresolved appeal job (i.e. an appeal
-        # was ongoing, and a report was made against the add-on), don't flag
-        # the add-on for human review again : we should already have one
-        # because of the appeal.
+        # If our report was added to an appeal job (i.e. an appeal was ongoing,
+        # and a report was made against the add-on), don't flag the add-on for
+        # human review again: we should already have one because of the appeal.
 
     def appeal(self, *args, **kwargs):
         self.flag_for_human_review(appeal=True)

--- a/src/olympia/abuse/cinder.py
+++ b/src/olympia/abuse/cinder.py
@@ -517,11 +517,11 @@ class CinderAddonHandledByReviewers(CinderAddon):
             )
 
     def post_report(self, job):
-        if not job.is_appeal:
+        if not (job.is_appeal and job.is_unresolved):
             self.flag_for_human_review(appeal=False)
-        # If our report was added to an appeal job (i.e. an appeal was ongoing,
-        # not yet resolved, and a report was made against the add-on), don't
-        # flag the add-on for human review again : we should already have one
+        # If our report was added to an unresolved appeal job (i.e. an appeal
+        # was ongoing, and a report was made against the add-on), don't flag
+        # the add-on for human review again : we should already have one
         # because of the appeal.
 
     def appeal(self, *args, **kwargs):

--- a/src/olympia/abuse/cinder.py
+++ b/src/olympia/abuse/cinder.py
@@ -40,9 +40,12 @@ class CinderEntity:
         return str(field_content or '').strip()
 
     def get_attributes(self):
+        """Return dict of attributes for this entity, to be sent to Cinder."""
         raise NotImplementedError
 
     def get_context_generator(self):
+        """Return a context generator containing dict of relationships for this
+        entity, to be sent to Cinder separately from the main attributes."""
         raise NotImplementedError
 
     def get_empty_context(self):
@@ -61,10 +64,12 @@ class CinderEntity:
         }
 
     def get_extended_attributes(self):
-        # Extended attributes are only returned with reports (not as part of
-        # relationships or reporter data for instance) as they require as they
-        # are more expensive to compute. Media that we need to make a copy of
-        # are typically returned there instead of in get_attributes().
+        """Return dict of attributes only sent with reports, not as part of
+        relationships or reporter data.
+
+        Those are typically more expensive to compute. Media that we need to
+        make a copy of are typically returned there instead of in
+        get_attributes()."""
         return {}
 
     def get_cinder_http_headers(self):
@@ -104,6 +109,10 @@ class CinderEntity:
         }
 
     def report(self, *, report, reporter):
+        """Build the payload and send the report to Cinder API.
+
+        Return a job_id that can be used by CinderJob.report() to either get an
+        existing CinderJob to attach this report to, or create a new one."""
         if self.type is None:
             # type needs to be defined by subclasses
             raise NotImplementedError
@@ -116,6 +125,8 @@ class CinderEntity:
             raise ConnectionError(response.content)
 
     def report_additional_context(self):
+        """Report to Cinder API additional context for an entity. Uses
+        get_context_generator() to send that additional context in chunks."""
         context_generator = self.get_context_generator()
         # This is a new generator, so advance it once to avoid re-sending the
         # context already sent as part of the report.
@@ -132,6 +143,9 @@ class CinderEntity:
                 raise ConnectionError(response.content)
 
     def appeal(self, *, decision_cinder_id, appeal_text, appealer):
+        """File an appeal with the Cinder API. Return a job_id for the appeal
+        job that can be used by CinderJob.appeal() to either get an existing
+        CinderJob or create a new one."""
         if self.type is None:
             # type needs to be defined by subclasses
             raise NotImplementedError
@@ -185,6 +199,12 @@ class CinderEntity:
             return response.json().get('external_id')
         else:
             raise ConnectionError(response.content)
+
+    def post_report(self, *, job):
+        """Callback triggered after a report has been posted to Cinder API and
+        a job has been created or fetched for that report. The job is passed as
+        a keyword argument."""
+        pass
 
 
 class CinderUser(CinderEntity):
@@ -496,9 +516,13 @@ class CinderAddonHandledByReviewers(CinderAddon):
                 user=core.get_user() or get_task_user(),
             )
 
-    def report(self, *args, **kwargs):
-        self.flag_for_human_review(appeal=False)
-        return super().report(*args, **kwargs)
+    def post_report(self, job):
+        if not job.is_appeal:
+            self.flag_for_human_review(appeal=False)
+        # If our report was added to an appeal job (i.e. an appeal was ongoing,
+        # not yet resolved, and a report was made against the add-on), don't
+        # flag the add-on for human review again : we should already have one
+        # because of the appeal.
 
     def appeal(self, *args, **kwargs):
         self.flag_for_human_review(appeal=True)

--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -188,6 +188,8 @@ class CinderJob(ModelBase):
                 reporter_abuse_reports=[abuse_report], is_appeal=False
             )
 
+        entity_helper.post_report(job=cinder_job)
+
     def notify_reporters(self, action_helper):
         action_helper.notify_reporters(
             reporter_abuse_reports=self.abusereport_set.all(),

--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -314,7 +314,8 @@ class CinderJob(ModelBase):
                     ).exists()
                 )
                 reason = NeedsHumanReview.REASONS.ADDON_REVIEW_APPEAL
-            elif self.abusereport_set.exists():
+            else:
+                has_unresolved_jobs_with_similar_reason = self.abusereport_set.exists()
                 reason = NeedsHumanReview.REASONS.ABUSE_ADDON_VIOLATION
             if not has_unresolved_jobs_with_similar_reason:
                 NeedsHumanReview.objects.filter(

--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -120,13 +120,6 @@ class CinderJob(ModelBase):
     def is_appeal(self):
         return bool(self.appealed_decisions.exists())
 
-    @property
-    def is_unresolved(self):
-        return (
-            not self.decision
-            or self.decision.action in DECISION_ACTIONS.UNRESOLVED.values
-        )
-
     @classmethod
     def get_entity_helper(
         cls, target, *, resolved_in_reviewer_tools, addon_version_string=None

--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -120,6 +120,13 @@ class CinderJob(ModelBase):
     def is_appeal(self):
         return bool(self.appealed_decisions.exists())
 
+    @property
+    def is_unresolved(self):
+        return (
+            not self.decision
+            or self.decision.action in DECISION_ACTIONS.UNRESOLVED.values
+        )
+
     @classmethod
     def get_entity_helper(
         cls, target, *, resolved_in_reviewer_tools, addon_version_string=None
@@ -317,7 +324,9 @@ class CinderJob(ModelBase):
                 )
                 reason = NeedsHumanReview.REASONS.ADDON_REVIEW_APPEAL
             else:
-                has_unresolved_jobs_with_similar_reason = self.abusereport_set.exists()
+                # If the job we're resolving was not an appeal or escalation
+                # then all abuse reports are considered dealt with.
+                has_unresolved_jobs_with_similar_reason = None
                 reason = NeedsHumanReview.REASONS.ABUSE_ADDON_VIOLATION
             if not has_unresolved_jobs_with_similar_reason:
                 NeedsHumanReview.objects.filter(

--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -294,9 +294,7 @@ class CinderJob(ModelBase):
             # We don't want to clear a NeedsHumanReview caused by a job that
             # isn't resolved yet, but there is no link between NHR and jobs.
             # So for each possible reason, we look if there are unresolved jobs
-            # and either clear them all, or none. It essentially means that for
-            # a given reason we only clear NHR when the last job of that reason
-            # is resolved.
+            # and only clear NHR for that reason if there aren't any jobs left.
             base_unresolved_jobs_qs = (
                 self.__class__.objects.for_addon(cinder_decision.addon)
                 .unresolved()

--- a/src/olympia/abuse/tests/test_cinder.py
+++ b/src/olympia/abuse/tests/test_cinder.py
@@ -10,7 +10,7 @@ import waffle
 from waffle.testutils import override_switch
 
 from olympia import amo, core
-from olympia.abuse.models import AbuseReport, CinderJob
+from olympia.abuse.models import AbuseReport, CinderDecision, CinderJob
 from olympia.activity.models import ActivityLog
 from olympia.addons.models import Addon, Preview
 from olympia.amo.tests import (
@@ -1053,24 +1053,10 @@ class TestCinderAddon(BaseTestCinderCase, TestCase):
 @override_switch('dsa-appeals-review', active=True)
 class TestCinderAddonHandledByReviewers(TestCinderAddon):
     cinder_class = CinderAddonHandledByReviewers
-    # Expected queries is a bit larger here because of activity log and
-    # needs human review checks + insertion.
-    # - 1 Fetch Version
-    # - 2 Fetch Translations for that Version
-    # - 3 Fetch NeedsHumanReview
-    # - 4 Create NeedsHumanReview
-    # - 5 Fetch NeedsHumanReview
-    # - 6 Update due date on Versions
-    # - 7 Fetch Latest signed Version
-    # - 8 Fetch task user
-    # - 9 Create ActivityLog
-    # - 10 Create ActivityLogComment
-    # - 11 Update ActivityLogComment
-    # - 12 Create VersionLog
-    # The last 2 are for rendering the payload to Cinder like CinderAddon:
-    # - 13 Fetch Addon authors
-    # - 14 Fetch Promoted Addon
-    expected_queries_for_report = 14
+    # For rendering the payload to Cinder like CinderAddon:
+    # - 1 Fetch Addon authors
+    # - 2 Fetch Promoted Addon
+    expected_queries_for_report = 2
     expected_queue_suffix = 'addon-infringement'
 
     def test_queue(self):
@@ -1103,6 +1089,25 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
         # count more predictable.
         waffle.switch_is_active('dsa-abuse-reports-review')
         self._test_report(addon)
+        # Adding the NHR is done by post_report().
+        assert addon.current_version.needshumanreview_set.count() == 0
+        job = CinderJob.objects.create(job_id='1234-xyz')
+        cinder_instance = self.cinder_class(addon)
+        with self.assertNumQueries(13):
+            # - 1 Fetch Cinder Decision
+            # - 2 Fetch Version
+            # - 3 Fetch Translations for that Version
+            # - 4 Fetch NeedsHumanReview
+            # - 5 Create NeedsHumanReview
+            # - 6 Fetch NeedsHumanReview
+            # - 7 Update due date on Versions
+            # - 8 Fetch Latest signed Version
+            # - 9 Fetch task user
+            # - 10 Create ActivityLog
+            # - 11 Create ActivityLogComment
+            # - 12 Update ActivityLogComment
+            # - 13 Create VersionLog
+            cinder_instance.post_report(job)
         assert (
             addon.current_version.needshumanreview_set.get().reason
             == NeedsHumanReview.REASONS.ABUSE_ADDON_VIOLATION
@@ -1144,9 +1149,12 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
         report = CinderReport(abuse_report)
         cinder_instance = self.cinder_class(addon, other_version)
         assert cinder_instance.report(report=report, reporter=None)
-        assert cinder_instance.report(report=report, reporter=None)
+        job = CinderJob.objects.create(job_id='1234-xyz')
         assert not addon.current_version.needshumanreview_set.exists()
-        # We called report() multiple times but there should be only one
+        cinder_instance.post_report(job)
+        cinder_instance.post_report(job)
+        cinder_instance.post_report(job)
+        # We called post_report() multiple times but there should be only one
         # needs human review instance.
         assert (
             other_version.needshumanreview_set.get().reason
@@ -1183,6 +1191,89 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
         self.expected_queries_for_report = TestCinderAddon.expected_queries_for_report
         self._test_appeal(CinderUser(user_factory()), self.cinder_class(addon))
         assert addon.current_version.needshumanreview_set.count() == 0
+
+    def test_report_with_ongoing_appeal(self):
+        addon = self._create_dummy_target()
+        addon.current_version.file.update(is_signed=True)
+        job = CinderJob.objects.create(job_id='1234-xyz')
+        job.appealed_decisions.add(
+            CinderDecision.objects.create(
+                addon=addon,
+                cinder_id='1234-decision',
+                action=DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON,
+            )
+        )
+        # Trigger switch_is_active to ensure it's cached to make db query
+        # count more predictable.
+        waffle.switch_is_active('dsa-abuse-reports-review')
+        self._test_report(addon)
+        cinder_instance = self.cinder_class(addon)
+        cinder_instance.post_report(job)
+        # The add-on does not get flagged again while the appeal is ongoing.
+        assert addon.current_version.needshumanreview_set.count() == 0
+
+    def test_report_with_ongoing_escalated_appeal(self):
+        addon = self._create_dummy_target()
+        addon.current_version.file.update(is_signed=True)
+        job = CinderJob.objects.create(job_id='1234-xyz')
+        job.appealed_decisions.add(
+            CinderDecision.objects.create(
+                addon=addon,
+                cinder_id='1234-decision',
+                action=DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON,
+            )
+        )
+        # Job we're attaching the report does have a decision but it's an
+        # escalation so it's still considered ongoing/open.
+        job.update(
+            decision=CinderDecision.objects.create(
+                addon=addon,
+                cinder_id='1234-escalation',
+                action=DECISION_ACTIONS.AMO_ESCALATE_ADDON,
+            )
+        )
+        # Trigger switch_is_active to ensure it's cached to make db query
+        # count more predictable.
+        waffle.switch_is_active('dsa-abuse-reports-review')
+        self._test_report(addon)
+        cinder_instance = self.cinder_class(addon)
+        cinder_instance.post_report(job)
+        # The add-on does not get flagged again while the appeal is ongoing.
+        assert addon.current_version.needshumanreview_set.count() == 0
+
+    def test_report_with_resolved_appeal(self):
+        # It doesn't make much sense for a new report to get attached to a
+        # job for which we already made a decision, but if that happens, even
+        # if it was an appeal, flag the add-on again.
+        addon = self._create_dummy_target()
+        addon.current_version.file.update(is_signed=True)
+        job = CinderJob.objects.create(job_id='1234-xyz')
+        job.appealed_decisions.add(
+            CinderDecision.objects.create(
+                addon=addon,
+                cinder_id='1234-decision',
+                action=DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON,
+            )
+        )
+        # Appeal job was closed with a decision.
+        job.update(
+            decision=CinderDecision.objects.create(
+                addon=addon,
+                cinder_id='1234-escalation',
+                action=DECISION_ACTIONS.AMO_APPROVE,
+            )
+        )
+        # Trigger switch_is_active to ensure it's cached to make db query
+        # count more predictable.
+        waffle.switch_is_active('dsa-abuse-reports-review')
+        self._test_report(addon)
+        cinder_instance = self.cinder_class(addon)
+        cinder_instance.post_report(job)
+        # The add-on does get flagged again.
+        assert (
+            addon.current_version.needshumanreview_set.get().reason
+            == NeedsHumanReview.REASONS.ABUSE_ADDON_VIOLATION
+        )
 
     def test_create_decision(self):
         target = self._create_dummy_target()

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -503,24 +503,6 @@ class TestCinderJob(TestCase):
         )
         assert abuse_report.target == abuse_report.cinder_job.target == addon
 
-    def test_is_unresolved(self):
-        cinder_job = CinderJob.objects.create(job_id='1234')
-        assert cinder_job.is_unresolved
-
-        cinder_job.decision = CinderDecision.objects.create(
-            addon=addon_factory(),
-            cinder_id='1234-escalation',
-            action=DECISION_ACTIONS.AMO_IGNORE,
-        )
-        for action in (
-            DECISION_ACTIONS.values.keys() - DECISION_ACTIONS.UNRESOLVED.values.keys()
-        ):
-            cinder_job.decision.update(action=action)
-            assert not cinder_job.is_unresolved
-        for action in DECISION_ACTIONS.UNRESOLVED.values:
-            cinder_job.decision.update(action=action)
-            assert cinder_job.is_unresolved
-
     def test_get_entity_helper(self):
         addon = addon_factory()
         user = user_factory()

--- a/src/olympia/abuse/tests/test_utils.py
+++ b/src/olympia/abuse/tests/test_utils.py
@@ -404,6 +404,7 @@ class TestCinderActionUser(BaseTestCinderAction, TestCase):
 
 
 @override_switch('dsa-cinder-escalations-review', active=True)
+@override_switch('dsa-appeals-review', active=True)
 class TestCinderActionAddon(BaseTestCinderAction, TestCase):
     ActionClass = CinderActionDisableAddon
 

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -963,7 +963,9 @@ class ReviewBase:
         are supposed to automatically get the update to that version, so we
         don't need to care about older ones anymore.
         """
-        # Do a mass UPDATE.
+        # Do a mass UPDATE. The NeedsHumanReview coming from
+        # abuse/appeal/escalations are only cleared in CinderJob.resolve_job()
+        # if the reviewer has selected to resolve all jobs of that type though.
         NeedsHumanReview.objects.filter(
             version__addon=self.addon,
             version__channel=self.version.channel,


### PR DESCRIPTION
Fixes: mozilla/addons#14872

### Description

If there are multiple jobs for a given add-on, when resolving a job we only want to clear the `NeedsHumanReview` flag if the job we're resolving is the last one of its kind: the add-on should stay in the queue until all jobs are resolved.

With that logic in place, because reports can be added to an ongoing appeal job, we need to also prevent NHR from being added following a report attached to an appeal job (otherwise we can't determine what NHR to clear). It's redundant anyway, there will already have a NHR for the appeal and that's enough.
