### PR TITLE
split appeal job action from abuse job action

### DIFF
--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -1041,8 +1041,18 @@ class AUTO_REJECT_CONTENT_AFTER_DELAY_EXPIRED(_LOG):
 
 class RESOLVE_CINDER_JOB_WITH_NO_ACTION(_LOG):
     id = 191
-    format = '{addon} cinder job resolved with no action .'
-    short = _('Job Resolved as Ignore/Approve')
+    format = '{addon} abuse report job resolved with no action.'
+    short = _('Reports resolved as Ignore/Approve')
+    keep = True
+    review_queue = True
+    hide_developer = True
+    reviewer_review_action = True
+
+
+class DENY_APPEAL_JOB(_LOG):
+    id = 192
+    format = '{addon} appeal job denied.'
+    short = _('Appeal denied')
     keep = True
     review_queue = True
     hide_developer = True

--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -1042,7 +1042,7 @@ class AUTO_REJECT_CONTENT_AFTER_DELAY_EXPIRED(_LOG):
 class RESOLVE_CINDER_JOB_WITH_NO_ACTION(_LOG):
     id = 191
     format = '{addon} abuse report job resolved with no action.'
-    short = _('Reports resolved as Ignore/Approve')
+    short = 'Reports resolved as Ignore/Approve'
     keep = True
     review_queue = True
     hide_developer = True
@@ -1052,7 +1052,7 @@ class RESOLVE_CINDER_JOB_WITH_NO_ACTION(_LOG):
 class DENY_APPEAL_JOB(_LOG):
     id = 192
     format = '{addon} appeal job denied.'
-    short = _('Appeal denied')
+    short = 'Appeal denied'
     keep = True
     review_queue = True
     hide_developer = True

--- a/src/olympia/reviewers/management/commands/auto_reject.py
+++ b/src/olympia/reviewers/management/commands/auto_reject.py
@@ -92,7 +92,7 @@ class Command(BaseCommand):
         ).distinct()
         helper.handler.data = {
             'comments': log_details.get('comments', ''),
-            'resolve_cinder_jobs': cinder_jobs,
+            'cinder_jobs_to_resolve': cinder_jobs,
             'versions': versions,
         }
         helper.handler.reject_multiple_versions()

--- a/src/olympia/reviewers/templates/reviewers/includes/input_option_with_label_attrs.html
+++ b/src/olympia/reviewers/templates/reviewers/includes/input_option_with_label_attrs.html
@@ -1,0 +1,1 @@
+<label{% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %} {% include "django/forms/widgets/attrs.html" %}>{% include "django/forms/widgets/input.html" %} {{ widget.label }}</label>

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -180,28 +180,38 @@
             <div class="review-actions-reasons-select">
               {{ form.reasons }}
             </div>
-            <div class="review-actions-reasons-error">
-              {{ form.reasons.errors }}
-            </div>
+            {% if form.reasons.errors %}
+              <div class="review-actions-reasons-error">{{ form.reasons.errors }}</div>
+            {% endif %}
           </div>
           <div class="data-toggle review-actions-policies"
-           data-value="{{ actions_policies|join(' ') }}">
-          <label for="id_cinder_policies">{{ form.cinder_policies.label }}</label>
-          <div class="review-actions-policies-select">
-            {{ form.cinder_policies }}
+               data-value="{{ actions_policies|join(' ') }}">
+            <label for="id_cinder_policies">{{ form.cinder_policies.label }}</label>
+            <div class="review-actions-policies-select">
+              {{ form.cinder_policies }}
+            </div>
+            <div>
+              {{ form.cinder_policies.errors }}
+            </div>
           </div>
-          <div>
-            {{ form.cinder_policies.errors }}
+          <div class="data-toggle"
+               data-value="resolve_appeal_job">
+            <label for="id_appeal_action">{{ form.appeal_action.label }}</label>
+            <div class="review-actions-policies-select">
+              {{ form.appeal_action }}
+            </div>
+            <div>
+              {{ form.appeal_action.errors }}
+            </div>
           </div>
-      </div>
         </div>
       </div>
 
       <div class="review-actions-section data-toggle review-resolve-abuse-reports"
            data-value="{{ actions_resolves_abuse_reports|join(' ') }}">
-          <strong><label for="id_resolve_cinder_jobs">{{ form.resolve_cinder_jobs.label }}</label></strong>
-          {{ form.resolve_cinder_jobs }}
-          {{ form.resolve_cinder_jobs.errors }}
+          <strong><label for="id_cinder_jobs_to_resolve">{{ form.cinder_jobs_to_resolve.label }}</label></strong>
+          {{ form.cinder_jobs_to_resolve }}
+          {{ form.cinder_jobs_to_resolve.errors }}
       </div>
 
       <div class="review-actions-section review-actions-files data-toggle review-files"

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -949,16 +949,34 @@ class TestReviewHelper(TestReviewHelperBase):
         )
         assert expected == actions
 
-    def test_actions_resolve_cinder_jobs(self):
+    def test_actions_cinder_jobs_to_resolve(self):
         self.grant_permission(self.user, 'Addons:Review')
-        CinderJob.objects.create(
+        job = CinderJob.objects.create(
             target_addon=self.addon, resolvable_in_reviewer_tools=True
         )
         expected = [
             'reject_multiple_versions',
             'set_needs_human_review_multiple_versions',
             'reply',
-            'resolve_job',
+            'resolve_reports_job',
+            'comment',
+        ]
+        actions = list(
+            self.get_review_actions(
+                addon_status=amo.STATUS_APPROVED,
+                file_status=amo.STATUS_APPROVED,
+            ).keys()
+        )
+        assert expected == actions
+
+        CinderDecision.objects.create(
+            action=DECISION_ACTIONS.AMO_DISABLE_ADDON, addon=self.addon, appeal_job=job
+        )
+        expected = [
+            'reject_multiple_versions',
+            'set_needs_human_review_multiple_versions',
+            'reply',
+            'resolve_appeal_job',
             'comment',
         ]
         actions = list(
@@ -1049,10 +1067,12 @@ class TestReviewHelper(TestReviewHelperBase):
                     uuid='z', default_cinder_action=DECISION_ACTIONS.AMO_IGNORE
                 ),
             ],
-            'resolve_cinder_jobs': [cinder_job],
+            'cinder_jobs_to_resolve': [cinder_job],
         }
         self.helper.set_data(data)
-        self.helper.handler.review_action = self.helper.actions.get('resolve_job')
+        self.helper.handler.review_action = self.helper.actions.get(
+            'resolve_reports_job'
+        )
         self.helper.handler.log_action(amo.LOG.RESOLVE_CINDER_JOB_WITH_NO_ACTION)
         assert ReviewActionReasonLog.objects.count() == 0
         assert CinderPolicyLog.objects.count() == 2
@@ -1061,6 +1081,71 @@ class TestReviewHelper(TestReviewHelperBase):
                 action=amo.LOG.RESOLVE_CINDER_JOB_WITH_NO_ACTION.id
             ).details['cinder_action']
             == 'AMO_IGNORE'
+        )
+
+    def test_log_action_override_policies(self):
+        self.grant_permission(self.user, 'Addons:Review')
+        cinder_job = CinderJob.objects.create(
+            target_addon=self.addon, resolvable_in_reviewer_tools=True
+        )
+        other_policy = CinderPolicy.objects.create(
+            uuid='y', default_cinder_action=DECISION_ACTIONS.AMO_DISABLE_ADDON
+        )
+        self.helper = self.get_helper()
+        data = {
+            'cinder_policies': [
+                CinderPolicy.objects.create(
+                    uuid='z', default_cinder_action=DECISION_ACTIONS.AMO_IGNORE
+                ),
+            ],
+            'cinder_jobs_to_resolve': [cinder_job],
+        }
+        self.helper.set_data(data)
+        self.helper.handler.review_action = self.helper.actions.get(
+            'resolve_reports_job'
+        )
+        self.helper.handler.log_action(
+            amo.LOG.RESOLVE_CINDER_JOB_WITH_NO_ACTION, policies=[other_policy]
+        )
+        assert ReviewActionReasonLog.objects.count() == 0
+        assert CinderPolicyLog.objects.count() == 1
+        assert CinderPolicyLog.objects.first().cinder_policy == other_policy
+        assert (
+            ActivityLog.objects.get(
+                action=amo.LOG.RESOLVE_CINDER_JOB_WITH_NO_ACTION.id
+            ).details['cinder_action']
+            == 'AMO_DISABLE_ADDON'  # from other_policy
+        )
+
+    def test_log_action_override_action(self):
+        self.grant_permission(self.user, 'Addons:Review')
+        cinder_job = CinderJob.objects.create(
+            target_addon=self.addon, resolvable_in_reviewer_tools=True
+        )
+        self.helper = self.get_helper()
+        data = {
+            'cinder_policies': [
+                CinderPolicy.objects.create(
+                    uuid='z', default_cinder_action=DECISION_ACTIONS.AMO_IGNORE
+                ),
+            ],
+            'cinder_jobs_to_resolve': [cinder_job],
+        }
+        self.helper.set_data(data)
+        self.helper.handler.review_action = self.helper.actions.get(
+            'resolve_reports_job'
+        )
+        self.helper.handler.log_action(
+            amo.LOG.RESOLVE_CINDER_JOB_WITH_NO_ACTION,
+            cinder_action=DECISION_ACTIONS.AMO_DISABLE_ADDON,
+        )
+        assert ReviewActionReasonLog.objects.count() == 0
+        assert CinderPolicyLog.objects.count() == 1
+        assert (
+            ActivityLog.objects.get(
+                action=amo.LOG.RESOLVE_CINDER_JOB_WITH_NO_ACTION.id
+            ).details['cinder_action']
+            == 'AMO_DISABLE_ADDON'
         )
 
     def test_log_action_override_user(self):
@@ -1089,16 +1174,16 @@ class TestReviewHelper(TestReviewHelperBase):
         cinder_job1 = CinderJob.objects.create(job_id='1')
         cinder_job2 = CinderJob.objects.create(job_id='2')
 
-        # without 'resolve_cinder_jobs', notify_addon_decision_to_cinder is called
+        # without 'cinder_jobs_to_resolve', notify_addon_decision_to_cinder is called
         self.helper.set_data(self.get_data())
         self.helper.handler.notify_decision()
         mock_report.assert_called_once_with(
             addon_id=self.addon.id, log_entry_id=log_entry.id
         )
 
-        # with 'resolve_cinder_jobs', resolve_job_in_cinder is called instead
+        # with 'cinder_jobs_to_resolve', resolve_job_in_cinder is called instead
         self.helper.set_data(
-            {**self.get_data(), 'resolve_cinder_jobs': [cinder_job1, cinder_job2]}
+            {**self.get_data(), 'cinder_jobs_to_resolve': [cinder_job1, cinder_job2]}
         )
         self.helper.handler.notify_decision()
 
@@ -2231,7 +2316,7 @@ class TestReviewHelper(TestReviewHelperBase):
             f'{settings.CINDER_SERVER_URL}jobs/1/decision',
             callback=lambda r: (201, {}, json.dumps({'uuid': uuid.uuid4().hex})),
         )
-        self._test_reject_multiple_versions({'resolve_cinder_jobs': [cinder_job]})
+        self._test_reject_multiple_versions({'cinder_jobs_to_resolve': [cinder_job]})
         message = mail.outbox[0]
         self.check_subject(message)
         assert 'Extension Delicious Bookmarks was manually reviewed' in message.body
@@ -2327,7 +2412,7 @@ class TestReviewHelper(TestReviewHelperBase):
             callback=lambda r: (201, {}, json.dumps({'uuid': uuid.uuid4().hex})),
         )
         self._test_reject_multiple_versions_with_delay(
-            {'resolve_cinder_jobs': [cinder_job]}
+            {'cinder_jobs_to_resolve': [cinder_job]}
         )
         message = mail.outbox[0]
         self.check_subject(message)
@@ -3279,7 +3364,7 @@ class TestReviewHelper(TestReviewHelperBase):
 
         self.helper.handler.data = {
             'versions': [self.review_version],
-            'resolve_cinder_jobs': [CinderJob()],
+            'cinder_jobs_to_resolve': [CinderJob()],
         }
         resolves_actions = {
             key: action
@@ -3346,7 +3431,7 @@ class TestReviewHelper(TestReviewHelperBase):
                     'should_email': True,
                     'cinder_action': DECISION_ACTIONS.AMO_DISABLE_ADDON,
                 },
-                'resolve_job': {'should_email': False, 'cinder_action': None},
+                'resolve_reports_job': {'should_email': False, 'cinder_action': None},
             }
         )
         self.setup_data(amo.STATUS_APPROVED, file_status=amo.STATUS_DISABLED)
@@ -3365,7 +3450,7 @@ class TestReviewHelper(TestReviewHelperBase):
                     'should_email': True,
                     'cinder_action': DECISION_ACTIONS.AMO_DISABLE_ADDON,
                 },
-                'resolve_job': {'should_email': False, 'cinder_action': None},
+                'resolve_reports_job': {'should_email': False, 'cinder_action': None},
             }
         )
         self.setup_data(amo.STATUS_DISABLED, file_status=amo.STATUS_DISABLED)
@@ -3379,7 +3464,7 @@ class TestReviewHelper(TestReviewHelperBase):
                     'should_email': True,
                     'cinder_action': DECISION_ACTIONS.AMO_APPROVE_VERSION,
                 },
-                'resolve_job': {'should_email': False, 'cinder_action': None},
+                'resolve_reports_job': {'should_email': False, 'cinder_action': None},
             }
         )
 
@@ -3416,7 +3501,7 @@ class TestReviewHelper(TestReviewHelperBase):
                     'should_email': True,
                     'cinder_action': DECISION_ACTIONS.AMO_DISABLE_ADDON,
                 },
-                'resolve_job': {'should_email': False, 'cinder_action': None},
+                'resolve_reports_job': {'should_email': False, 'cinder_action': None},
             }
         )
         self.setup_data(amo.STATUS_DISABLED, file_status=amo.STATUS_DISABLED)
@@ -3438,9 +3523,73 @@ class TestReviewHelper(TestReviewHelperBase):
                     'should_email': True,
                     'cinder_action': DECISION_ACTIONS.AMO_APPROVE_VERSION,
                 },
-                'resolve_job': {'should_email': False, 'cinder_action': None},
+                'resolve_reports_job': {'should_email': False, 'cinder_action': None},
             }
         )
+
+    def test_resolve_appeal_job(self):
+        policy_a = CinderPolicy.objects.create(uuid='a')
+        policy_b = CinderPolicy.objects.create(uuid='b')
+        policy_c = CinderPolicy.objects.create(uuid='c')
+        policy_d = CinderPolicy.objects.create(uuid='d')
+
+        appeal_job1 = CinderJob.objects.create(
+            job_id='1', resolvable_in_reviewer_tools=True, target_addon=self.addon
+        )
+        CinderDecision.objects.create(
+            appeal_job=appeal_job1,
+            action=DECISION_ACTIONS.AMO_DISABLE_ADDON,
+            addon=self.addon,
+        ).policies.add(policy_a, policy_b)
+        CinderDecision.objects.create(
+            appeal_job=appeal_job1,
+            action=DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON,
+            addon=self.addon,
+        ).policies.add(policy_a, policy_c)
+        responses.add_callback(
+            responses.POST,
+            f'{settings.CINDER_SERVER_URL}jobs/{appeal_job1.job_id}/decision',
+            callback=lambda r: (201, {}, json.dumps({'uuid': uuid.uuid4().hex})),
+        )
+
+        appeal_job2 = CinderJob.objects.create(
+            job_id='2', resolvable_in_reviewer_tools=True, target_addon=self.addon
+        )
+        CinderDecision.objects.create(
+            appeal_job=appeal_job2,
+            action=DECISION_ACTIONS.AMO_APPROVE,
+            addon=self.addon,
+        ).policies.add(policy_d)
+        responses.add_callback(
+            responses.POST,
+            f'{settings.CINDER_SERVER_URL}jobs/{appeal_job2.job_id}/decision',
+            callback=lambda r: (201, {}, json.dumps({'uuid': uuid.uuid4().hex})),
+        )
+
+        self.grant_permission(self.user, 'Addons:Review')
+        self.file.update(status=amo.STATUS_AWAITING_REVIEW)
+        self.helper = self.get_helper()
+        data = {
+            'comments': 'Nope',
+            'cinder_jobs_to_resolve': [appeal_job1, appeal_job2],
+            'appeal_action': ['deny'],
+        }
+        self.helper.set_data(data)
+
+        self.helper.handler.resolve_appeal_job()
+
+        assert CinderPolicyLog.objects.count() == 4
+        activity_log_qs = ActivityLog.objects.filter(action=amo.LOG.DENY_APPEAL_JOB.id)
+        assert activity_log_qs.count() == 2
+        log2, log1 = list(activity_log_qs.all())
+        assert log1.details['cinder_action'] == 'AMO_DISABLE_ADDON'
+        assert log2.details['cinder_action'] == 'AMO_APPROVE'
+        assert set(appeal_job1.reload().decision.policies.all()) == {
+            policy_a,
+            policy_b,
+            policy_c,
+        }
+        assert set(appeal_job2.reload().decision.policies.all()) == {policy_d}
 
 
 @override_settings(ENABLE_ADDON_SIGNING=True)

--- a/static/css/zamboni/reviewers.less
+++ b/static/css/zamboni/reviewers.less
@@ -1050,7 +1050,7 @@ form.review-form .data-toggle {
     list-style: none;
 }
 
-.review-actions-section #id_resolve_cinder_jobs {
+.review-actions-section #id_cinder_jobs_to_resolve {
     details {
         margin-left: 2em;
     }

--- a/static/js/zamboni/reviewers.js
+++ b/static/js/zamboni/reviewers.js
@@ -63,6 +63,7 @@ function initReviewActions() {
     var $element = $(element),
       value = $element.find('input').val(),
       $data_toggle = $('form.review-form').find('.data-toggle'),
+      $data_toggle_hide = $('form.review-form').find('.data-toggle-hide'),
       $comments = $('#id_comments'),
       boilerplate_text = $element.find('input').attr('data-value');
 
@@ -87,6 +88,10 @@ function initReviewActions() {
     // Hide everything, then show the ones containing the value we're interested in.
     $data_toggle.hide();
     $data_toggle.filter('[data-value~="' + value + '"]').show();
+    // For data_toggle_hide, the opposite - show everything, then hide the ones containing
+    // the value we're interested in.
+    $data_toggle_hide.show();
+    $data_toggle_hide.filter('[data-value~="' + value + '"]').hide();
   }
 
   $('#review-actions .action_nav #id_action > *:not(.disabled)').click(


### PR DESCRIPTION
Fixes: mozilla/addons#1760
<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Adds a Resolve Appeals reviewer tools action that allows appeals to be denied.  Also changes Resolve Reports to exclude appeals.

### Context

The appeal handling process in the reviewer tools is built on top of the existing reviewer action functionality - you can decide to accept an appeal by carrying out the action that was opposite to the decision that was appealled - for example, if the decision was to disable the addon, and the was appealed, then to accept the appeal the add-on is enabled, and the appeal job selected to be resolved. But for denying an appeal there wasn't always a way to do this - you couldn't disable an add-on twice, for example of a developer appeal.  And for a reporter appeal, even though you _could_ choose the Approve policy again, it wasn't an obvious choice (you had to "deny" the appeal by selecting "approve").  So this new action is specific to denying appeals; while preventing appeal jobs from appearing in Resolve Reports so there aren't counter-intuitive options.

### Testing

- set up an appeal job (by reporting an add-on; taking an action on the report; then appealing the decision.  E.g. resolve report with Approve; appeal as reporter). The report must be resolvable in the reviewer tools - choose inside the Add-on, and policy violation reason.
- Also set-up a non-appeal job (report the add-on).  Cinder would usually combine the appeal and report together so don't have it resolvable in the reviewer tools and escalate it from Cinder instead.
- In the reviewer tools look in one of the other actions with cinder jobs visible (e.g. Approve) and see both jobs
- look in Resolve Reports and see only one job - the escalation, with the policy selection as before.
- look in Resolve Appeals and see the appeal job only, with a similar selection of "policies", but with only one, "Deny Appeal"
- Deny the appeal by selecting Deny Appeal, with some comments.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [x] Add before and after screenshots (Only for changes that impact the UI).

![Screenshot 2024-06-21 190101](https://github.com/mozilla/addons-server/assets/768592/9480642c-e3a5-4117-90b5-af8ed8323d7b)
![Screenshot 2024-06-21 190114](https://github.com/mozilla/addons-server/assets/768592/5835d238-d8f6-4e3a-a514-0bbf94a9dffb)
