### PR TITLE
Fix storage volume config for the nginx service

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -185,7 +185,6 @@ def test_pre_setup(request, tmpdir, settings):
     settings.SHARED_STORAGE = shared_storage = _path(storage_root, 'shared_storage')
 
     settings.ADDONS_PATH = _path(storage_root, 'files')
-    settings.GUARDED_ADDONS_PATH = _path(storage_root, 'guarded-addons')
     settings.GIT_FILE_STORAGE_PATH = _path(storage_root, 'git-storage')
     settings.MLBF_STORAGE_PATH = _path(storage_root, 'mlbf')
     settings.MEDIA_ROOT = _path(shared_storage, 'uploads')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,10 +74,7 @@ services:
       - ./docker/nginx/addons.conf:/etc/nginx/conf.d/addons.conf
       - ./static:/srv/static
       - ./site-static:/srv/site-static
-      - storage:/shared_storage/uploads:/srv/user-media
-      - storage:/files:/srv/user-media/addons
-      - storage:/guarded-addons:/srv/user-media/guarded-addons
-      - storage:/sitemaps:/srv/user-media/sitemaps
+      - storage:/srv/user-media
     ports:
       - "80:80"
     networks:

--- a/docker/nginx/addons.conf
+++ b/docker/nginx/addons.conf
@@ -5,25 +5,9 @@ merge_slashes off;
 server {
     listen  80 default;
 
-    location /data/olympia/storage/files/ {
+    location /data/olympia/storage/ {
         internal;
-        # This matches where addons-server `docker-compose.yml` mounts
-        # `./storage/addons/` - as `/srv/user-media/addons/`
-        alias /srv/user-media/addons/;
-    }
-
-    location /data/olympia/storage/guarded-addons/ {
-        internal;
-        # This matches where addons-server `docker-compose.yml` mounts
-        # `./storage/guarded-addons/` - as `/srv/user-media/guarded-addons/`
-        alias /srv/user-media/guarded-addons/;
-    }
-
-    location /data/olympia/storage/sitemaps/ {
-        internal;
-        # This matches where addons-server `docker-compose.yml` mounts
-        # `./storage/sitemaps/` - as `/srv/user-media/sitemaps/`
-        alias /srv/user-media/sitemaps/;
+        alias /srv/user-media/;
     }
 
     location /static/ {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/14882

---

I tested locally and it worked for me but not sure if I didn't break anything else...


## Testing

This is _a_ scenario:

1. Upload an add-on locally
2. Get it signed (likely needs to be approved manually in reviewer tools because it will be a _new_ add-on + signed via `./manage.py auto_approve`)
3. Navigate to the detail page of this add-on (frontend)
4. Try to download the XPI