### PR TITLE
Remove pull_request event from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,10 @@
 name: CI
 
 on:
-  # Runs when there is a push to the default branch
-  # This triggers tests and a pushed "latest" image
+  # Runs when there is a push to any branch
+  # This triggers tests and (if "master") pushes "latest" image
   # That is deployed to the "dev" environment
   push:
-    branches:
-      - master
-  # Runs on pull requests to verify changes and push
-  # PR image for local testing
-  pull_request:
   # Manually dispatch to update cache or to push an image
   # From any ref
   workflow_dispatch:
@@ -48,7 +43,6 @@ jobs:
       # \$\{{ needs.context.outputs.is_fork == true }} // false
       # \$\{{ needs.context.outputs.is_fork }} // false
       is_fork: ${{ steps.context.outputs.is_fork }}
-      is_dependabot: ${{ steps.context.outputs.is_dependabot }}
       is_default_branch: ${{ steps.context.outputs.is_default_branch }}
 
     steps:
@@ -69,22 +63,11 @@ jobs:
           # https://stackoverflow.com/questions/64781462/github-actions-default-branch-variable
           is_default_branch="${{ format('refs/heads/{0}', env.default_branch) == github.ref }}"
 
-          # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
-          is_dependabot="${{ github.actor == 'dependabot[bot]' }}"
-
-
-          if [[ "${{ github.event_name }}" == 'pull_request' ]]; then
-            # repository on a pull request refers to the base which is always mozilla/addons-server
-            is_fork=${{ github.event.pull_request.head.repo.fork }}
-          else
-            # In most events, the epository refers to the head which would be the fork
-            # This is different in a pullrequest where we need to check the head explicitly
-            is_fork="${{ github.event.repository.fork }}"
-          fi
+          # Pushes to forked branches have limited permissions
+          is_fork="${{ github.event.repository.fork }}"
 
           echo "is_default_branch=$is_default_branch" >> $GITHUB_OUTPUT
           echo "is_fork=$is_fork" >> $GITHUB_OUTPUT
-          echo "is_dependabot=$is_dependabot" >> $GITHUB_OUTPUT
 
           echo "event_name: ${{ github.event_name }}"
           cat $GITHUB_OUTPUT
@@ -100,32 +83,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Determine if build is allowed
-        id: should_build
-        shell: bash
-        run: |
-          is_fork="${{ needs.context.outputs.is_fork }}"
-          is_dependabot="${{ needs.context.outputs.is_dependabot }}"
-
-          # Default behaviour is to build images for any CI.yml run
-          should_build="true"
-
-          # Never run the build on a fork. Forks lack sufficient permissions
-          # to access secrets or push artifacts
-          if [[ "$is_fork" == 'true' ]]; then
-            should_build="false"
-          fi
-
-          # Dependabot PRs are treated as if they are from forks (see above)
-          if [[ "$is_dependabot" == 'true' && "${{ github.event_name }}" == 'pull_request' ]]; then
-            should_build="false"
-          fi
-
-          echo "result=$should_build" >> $GITHUB_OUTPUT
-
-
       - name: Build Docker image
-        if: ${{ steps.should_build.outputs.result == 'true' }}
+        # Don't build forks
+        if: needs.context.outputs.is_fork == 'false'
         id: build
         uses: ./.github/actions/build-docker
         with:
@@ -253,10 +213,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Extract Locales
         uses: ./.github/actions/run-docker


### PR DESCRIPTION
Relates to: <https://github.com/mozilla/addons/issues/14823>

### Description

Simplify CI by no longer relying on the pull request event and instead on the push event.
### Context

This reduces complexity in defining context, resolves several permission issus with forks and will eventually simplify how we determine the docker tag version to set when pushing images to production GAR registry.


### Testing

CI should work for normal PR, push to branch without PR, push to fork and dependabot PR/push

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
