### PR TITLE
Add `build-action` steps to build job in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,9 @@ jobs:
       # \$\{{ needs.context.outputs.is_fork == true }} // false
       # \$\{{ needs.context.outputs.is_fork }} // false
       is_fork: ${{ steps.context.outputs.is_fork }}
-      is_dependabot: ${{ steps.context.outputs.is_dependabot }}
       is_default_branch: ${{ steps.context.outputs.is_default_branch }}
+      is_release_master: ${{ steps.context.outputs.is_release_master }}
+      is_release_tag: ${{ steps.context.outputs.is_release_tag }}
 
     steps:
       - name: Log context
@@ -65,28 +66,53 @@ jobs:
           default_branch: ${{ github.event.repository.default_branch }}
         shell: bash
         run: |
+          event_name="${{ github.event_name }}"
+          event_action="${{ github.event.action }}"
+
           # Stable check for if the workflow is running on the default branch
           # https://stackoverflow.com/questions/64781462/github-actions-default-branch-variable
           is_default_branch="${{ format('refs/heads/{0}', env.default_branch) == github.ref }}"
 
-          # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
-          is_dependabot="${{ github.actor == 'dependabot[bot]' }}"
+          # In most events, the epository refers to the head which would be the fork
+          is_fork="${{ github.event.repository.fork }}"
 
-
+          # This is different in a pull_request where we need to check the head explicitly
           if [[ "${{ github.event_name }}" == 'pull_request' ]]; then
             # repository on a pull request refers to the base which is always mozilla/addons-server
-            is_fork=${{ github.event.pull_request.head.repo.fork }}
-          else
-            # In most events, the epository refers to the head which would be the fork
-            # This is different in a pullrequest where we need to check the head explicitly
-            is_fork="${{ github.event.repository.fork }}"
+            is_head_fork="${{ github.event.pull_request.head.repo.fork }}"
+            # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
+            is_dependabot="${{ github.actor == 'dependabot[bot]' }}"
+
+            # If the head repository is a fork or if the PR is opened by dependabot
+            # we consider the run to be a fork. Dependabot and proper forks are treated
+            # the same in terms of limited read only github token scope
+            if [[ "$is_head_fork" == 'true' || "$is_dependabot" == 'true' ]]; then
+              is_fork="true"
+            fi
+          fi
+
+          is_release_master="false"
+          is_release_tag="false"
+
+          # Releases can only happen if we are NOT on a fork
+          if [[ "$is_fork" == 'false' ]]; then
+            # A master release occurs on a push to the default branch of the origin repository
+            if [[ "$event_name" == 'push' && "$is_default_branch" == 'true' ]]; then
+              is_release_master="true"
+            fi
+
+            # A tag release occurs when a release is published
+            if [[ "$event_name" == 'release' && "$event_action" == 'publish' ]]; then
+              is_release_tag="true"
+            fi
           fi
 
           echo "is_default_branch=$is_default_branch" >> $GITHUB_OUTPUT
           echo "is_fork=$is_fork" >> $GITHUB_OUTPUT
-          echo "is_dependabot=$is_dependabot" >> $GITHUB_OUTPUT
+          echo "is_release_master=$is_release_master" >> $GITHUB_OUTPUT
+          echo "is_release_tag=$is_release_tag" >> $GITHUB_OUTPUT
 
-          echo "event_name: ${{ github.event_name }}"
+          echo "event_name: $event_name"
           cat $GITHUB_OUTPUT
 
   build:
@@ -104,32 +130,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Determine if build is allowed
-        id: should_build
-        shell: bash
-        run: |
-          is_fork="${{ needs.context.outputs.is_fork }}"
-          is_dependabot="${{ needs.context.outputs.is_dependabot }}"
-
-          # Default behaviour is to build images for any CI.yml run
-          should_build="true"
-
-          # Never run the build on a fork. Forks lack sufficient permissions
-          # to access secrets or push artifacts
-          if [[ "$is_fork" == 'true' ]]; then
-            should_build="false"
-          fi
-
-          # Dependabot PRs are treated as if they are from forks (see above)
-          if [[ "$is_dependabot" == 'true' && "${{ github.event_name }}" == 'pull_request' ]]; then
-            should_build="false"
-          fi
-
-          echo "result=$should_build" >> $GITHUB_OUTPUT
-
-
       - name: Build Docker image
-        if: ${{ steps.should_build.outputs.result == 'true' }}
+        if: ${{ needs.context.outputs.is_fork == 'false' }}
         id: build
         uses: ./.github/actions/build-docker
         with:
@@ -140,7 +142,7 @@ jobs:
       # Only continue if we are releasing
       # Login to GAR to publish production image
       - name: get the GCP auth token
-        if: ${{ steps.should_build.outputs.result == 'true' }}
+        if: ${{ needs.context.outputs.is_fork == 'false' }}
         id: gcp-auth
         uses: google-github-actions/auth@v2
         with:
@@ -149,7 +151,7 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
 
       - name: login to GAR
-        if: ${{ steps.should_build.outputs.result == 'true' }}
+        if: ${{ needs.context.outputs.is_fork == 'false' }}
         uses: docker/login-action@v3
         with:
           registry: us-docker.pkg.dev
@@ -247,13 +249,7 @@ jobs:
 
   docs_deploy:
     needs: [context, docs_build]
-    # Only deploy docs on a push event
-    # to the default branch
-    # that is not running on a fork
-    if: |
-      github.event_name == 'push' &&
-      needs.context.outputs.is_default_branch == 'true' &&
-      needs.context.outputs.is_fork == 'false'
+    if: needs.context.outputs.is_release_master == 'true'
     permissions:
       contents: read
       pages: write
@@ -293,8 +289,7 @@ jobs:
         shell: bash
         run: |
           is_fork="${{ needs.context.outputs.is_fork }}"
-          is_default_branch="${{ needs.context.outputs.is_default_branch }}"
-          is_push="${{ github.event_name == 'push' }}"
+          is_release_master="${{ needs.context.outputs.is_release_master }}"
 
           if [[ "$is_fork" == 'true' ]]; then
             cat <<'EOF'
@@ -303,7 +298,7 @@ jobs:
               Please submit a PR from the base repository if you are modifying l10n extraction scripts.
           EOF
           else
-            if [[ "$is_default_branch" == 'true' && "$is_push" == 'true' ]]; then
+            if [[ "$is_release_master" == 'true' ]]; then
               args=""
             else
               args="--dry-run"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
       is_default_branch: ${{ steps.context.outputs.is_default_branch }}
       is_release_master: ${{ steps.context.outputs.is_release_master }}
       is_release_tag: ${{ steps.context.outputs.is_release_tag }}
+      # Hardcode image name
+      image_name: mozilla/addons-server
 
     steps:
       - name: Log context
@@ -129,6 +131,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ needs.context.outputs.image_name }}
+          flavor: |
+            suffix=-next,onlatest=true
+            latest=${{ needs.context.outputs.is_release_master == 'true' }}
+          tags: |
+            # Only use `tag` version on published release
+            type=ref,event=tag,enabled=${{ needs.context.outputs.is_release_tag == 'true' }}
+            type=ref,event=branch
+            type=ref,event=pr
 
       - name: Build Docker image
         if: ${{ needs.context.outputs.is_fork == 'false' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Setup docker to build for multiple architectures
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+          buildkitd-flags: --debug
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5


### PR DESCRIPTION
Relates to: mozilla/addons#14823

### Description

Extract metadata step from build-docker action so we can independently tweak for production image push

### Context

Since we are already using the `build-docker` action and it is unclear how useful it will be moving forward I'd like to get the metadata independently so we can tweak and make sure in all the different events we have the right tag.

### Testing

We have to check each type of event that would result in a build and verify the tag is correct the various combinations result in a matrix like

It will be MUCH easier to tesst this after it is merged, and right now it does nothing so it is safe to merge.

| Event             | Fork | Ref       | Job |
|--------------|------|--------|-----|
| push               | true  | master | url  |
| push               | false | master | url |
| push               | true | branch | url  |
| push               | false | branch | url  |
| pull_request  | false | branch | url  |
| pull_request  | true | branch | url   |
| release           | true | tag      | url   |
| release           | false | tag     | url   |


### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
