### PR TITLE
Normalize how we expose reviewer comments in emails

### DIFF
--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -1079,15 +1079,14 @@ class CinderDecision(ModelBase):
         self.action = DECISION_ACTIONS.for_constant(
             log_entry.details['cinder_action']
         ).value
+        self.notes = log_entry.details.get('comments', '')
+        policies = {cpl.cinder_policy for cpl in log_entry.cinderpolicylog_set.all()}
 
         if self.action not in DECISION_ACTIONS.APPROVING or hasattr(self, 'cinder_job'):
             # we don't create cinder decisions for approvals that aren't resolving a job
-            policies = {
-                cpl.cinder_policy for cpl in log_entry.cinderpolicylog_set.all()
-            }
             create_decision_kw = {
                 'action': self.action.api_value,
-                'reasoning': log_entry.details.get('comments', ''),
+                'reasoning': self.notes,
                 'policy_uuids': [policy.uuid for policy in policies],
             }
             if cinder_job := getattr(self, 'cinder_job', None):
@@ -1125,7 +1124,6 @@ class CinderDecision(ModelBase):
         )
         action_helper.notify_owners(
             log_entry_id=log_entry.id,
-            policy_text=log_entry.details.get('comments'),
             extra_context={
                 'auto_approval': is_auto_approval,
                 'delayed_rejection_days': log_entry.details.get(
@@ -1136,6 +1134,9 @@ class CinderDecision(ModelBase):
                 ),
                 'is_addon_disabled': log_entry.details.get('is_addon_being_disabled')
                 or self.target.is_disabled,
+                # Because we expand the reason/policy text into notes in the reviewer
+                # tools, we don't want to duplicate it as policies too.
+                'policies': policies if not self.notes else (),
                 'version_list': ', '.join(ver_str for ver_str, _ in versions_data),
                 **target_url_override,
             },

--- a/src/olympia/abuse/templates/abuse/emails/CinderActionApproveInitialDecision.txt
+++ b/src/olympia/abuse/templates/abuse/emails/CinderActionApproveInitialDecision.txt
@@ -9,6 +9,8 @@ Your add-on can be subject to human review at any time. Reviewers may determine 
 {% endif %}
 Approved versions: {{ version_list }}
 
+{% if manual_reasoning_text %}Comments: {{ manual_reasoning_text }}.{% endif %}
+
 Thank you.
 
 More information about Mozilla's add-on policies can be found at {{ policy_document_url }}.

--- a/src/olympia/abuse/templates/abuse/emails/CinderActionTargetAppealApprove.txt
+++ b/src/olympia/abuse/templates/abuse/emails/CinderActionTargetAppealApprove.txt
@@ -3,6 +3,7 @@ Hello,
 Previously, your {{ type }} was suspended/removed from Mozilla Add-ons, based on a finding that you had violated Mozilla's policies.
 
 {% if not is_override %}After reviewing your appeal, we{% else %}We have now{% endif %} determined that the previous decision was incorrect, and based on that determination, we have restored your {{ type }}. It is now available at {{ target_url }}.
+{% if manual_reasoning_text %}{{ manual_reasoning_text }}. {% endif %}
 
 Thank you.
 

--- a/src/olympia/abuse/templates/abuse/emails/CinderActionTargetAppealRemovalAffirmation.txt
+++ b/src/olympia/abuse/templates/abuse/emails/CinderActionTargetAppealRemovalAffirmation.txt
@@ -2,7 +2,7 @@ Hello,
 
 Previously, your {{ type }} was suspended/removed from Mozilla Add-ons, based on a finding that you had violated Mozilla's policies.
 
-After reviewing your appeal, we determined that the previous decision, that your {{ type }} violates Mozilla's policies, was correct.{% if additional_reasoning %} {{ additional_reasoning }}.{% endif %} Based on that determination, we have denied your appeal, and will not reinstate your {{ type }}.
+After reviewing your appeal, we determined that the previous decision, that your {{ type }} violates Mozilla's policies, was correct. {% if manual_reasoning_text %}{{ manual_reasoning_text }}. {% endif %}Based on that determination, we have denied your appeal, and will not reinstate your {{ type }}.
 
 More information about Mozilla's add-on policies can be found at {{ policy_document_url }}.
 

--- a/src/olympia/abuse/templates/abuse/emails/includes/policies.txt
+++ b/src/olympia/abuse/templates/abuse/emails/includes/policies.txt
@@ -1,8 +1,5 @@
-{% if manual_policy_text %}
-    {{ manual_policy_text }}
-{% else %}
-    {% for policy in policies %}
-        {# Policies text may contain HTML entities, this is a text email so we consider that safe #}
-        - {{ policy.full_text|safe }}
-    {% endfor %}
-{% endif %}
+{% for policy in policies %}
+    {# Policies text may contain HTML entities, this is a text email so we consider that safe #}
+    - {{ policy.full_text|safe }}
+{% endfor %}
+{% if manual_reasoning_text %}{{ manual_reasoning_text|safe }}. {% endif %}

--- a/src/olympia/abuse/templates/abuse/emails/reporter_appeal_approve.txt
+++ b/src/olympia/abuse/templates/abuse/emails/reporter_appeal_approve.txt
@@ -2,6 +2,7 @@
 Thank you for your report about {{ name }} on Mozilla Add-ons, and for providing more information about your concerns.
 
 After reviewing your appeal, we determined that the previous decision, that this content does not violate Mozilla’s policies ({{ policy_document_url }}), was correct. Based on that determination, we have denied your appeal, and will not take any action against the account or the content.
+{{ manual_reasoning_text }}.
 
 Thank you for your attention.
 {% endblocktranslate %}{% endblock %}

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -2229,7 +2229,11 @@ class TestCinderDecision(TestCase):
             json={'uuid': '123'},
             status=201,
         )
-        policies = [CinderPolicy.objects.create(name='policy', uuid='12345678')]
+        policies = [
+            CinderPolicy.objects.create(
+                name='policy', uuid='12345678', text='some policy text'
+            )
+        ]
         entity_helper = CinderJob.get_entity_helper(
             decision.addon, resolved_in_reviewer_tools=True
         )
@@ -2253,6 +2257,7 @@ class TestCinderDecision(TestCase):
         )
 
         assert decision.action == cinder_action
+        assert decision.notes == 'some review text'
         if expect_create_decision_call:
             assert create_decision_response.call_count == 1
             assert create_job_decision_response.call_count == 0
@@ -2294,6 +2299,8 @@ class TestCinderDecision(TestCase):
             assert str(log_entry.id) in mail.outbox[0].extra_headers['Message-ID']
             assert str(addon_version) in mail.outbox[0].body
             assert 'days' not in mail.outbox[0].body
+            assert 'some review text' in mail.outbox[0].body
+            assert 'some policy text' not in mail.outbox[0].body
         else:
             assert len(mail.outbox) == 0
 

--- a/src/olympia/reviewers/management/commands/send_pending_rejection_last_warning_notifications.py
+++ b/src/olympia/reviewers/management/commands/send_pending_rejection_last_warning_notifications.py
@@ -85,7 +85,6 @@ class Command(BaseCommand):
             )
             return
         log.info('Sending email for %s' % addon)
-        log_details = getattr(relevant_activity_log, 'details', {})
         cinder_job = (
             CinderJob.objects.filter(pending_rejections__version__in=versions)
             .distinct()
@@ -104,7 +103,6 @@ class Command(BaseCommand):
         action_helper = CinderActionRejectVersionDelayed(decision)
         action_helper.notify_owners(
             log_entry_id=relevant_activity_log.id,
-            policy_text=log_details.get('comments', ''),
             extra_context={
                 'delayed_rejection_days': self.EXPIRING_PERIOD_DAYS,
                 'version_list': ', '.join(str(v.version) for v in versions),


### PR DESCRIPTION
Fixes: mozilla/addons#14878

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Make sure we include reviewer/moderator comments if available.

### Context

Previously we had logic that included comments from cinder as a special field, but only for certain types of emails, and then either included policies or comments in the place of the policies.  The logic was confusing, meaning some emails were missing comments entirely because they were an approve email, where we wouldn't expect policy text.  Now it's more straightforward - every email includes comments.

### Testing

Resolve some appeals with comments and see them in the emails.  (The only type of appeal email that _doesn't_ get the reviewer comments, is a successful reporter appeal, because that would be an action that takes down content and we'd send the comments to the developer instead)

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [ ] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
