### PR TITLE
Split test jobs to callable workflows

### DIFF
--- a/.github/actions/context/action.yml
+++ b/.github/actions/context/action.yml
@@ -1,0 +1,114 @@
+name: 'Dump Context'
+description: 'Display context for action run'
+
+outputs:
+  # All github action outputs are strings, even if set to "true"
+  # so when using these values always assert against strings or convert from json
+  # \$\{{ needs.context.outputs.is_fork == 'true' }} // true
+  # \$\{{ fromJson(needs.context.outputs.is_fork) == false }} // true
+  # \$\{{ needs.context.outputs.is_fork == true }} // false
+  # \$\{{ needs.context.outputs.is_fork }} // false
+  is_fork:
+    description: ""
+    value: ${{ steps.context.outputs.is_fork }}
+  is_default_branch:
+    description: ""
+    value: ${{ steps.context.outputs.is_default_branch }}
+  is_release_master:
+    description: ""
+    value: ${{ steps.context.outputs.is_release_master }}
+  is_release_tag:
+    description: ""
+    value: ${{ steps.context.outputs.is_release_tag }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Dump GitHub context
+      shell: bash
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
+    - name: Dump job context
+      shell: bash
+      env:
+        JOB_CONTEXT: ${{ toJson(job) }}
+      run: echo "$JOB_CONTEXT"
+    - name: Dump steps context
+      shell: bash
+      env:
+        STEPS_CONTEXT: ${{ toJson(steps) }}
+      run: echo "$STEPS_CONTEXT"
+    - name: Dump runner context
+      shell: bash
+      env:
+        RUNNER_CONTEXT: ${{ toJson(runner) }}
+      run: echo "$RUNNER_CONTEXT"
+    - name: Dump env context
+      shell: bash
+      env:
+        ENV_CONTEXT: ${{ toJson(env) }}
+      run: |
+        echo "$ENV_CONTEXT"
+    - name: Dump inputs context
+      shell: bash
+      env:
+        INPUTS_CONTEXT: ${{ toJson(inputs) }}
+      run: |
+        echo "$INPUTS_CONTEXT"
+
+    - name: Set context
+      id: context
+      env:
+        # The default branch of the repository, in this case "master"
+        default_branch: ${{ github.event.repository.default_branch }}
+      shell: bash
+      run: |
+        event_name="${{ github.event_name }}"
+        event_action="${{ github.event.action }}"
+
+        # Stable check for if the workflow is running on the default branch
+        # https://stackoverflow.com/questions/64781462/github-actions-default-branch-variable
+        is_default_branch="${{ format('refs/heads/{0}', env.default_branch) == github.ref }}"
+
+        # In most events, the epository refers to the head which would be the fork
+        is_fork="${{ github.event.repository.fork }}"
+
+        # This is different in a pull_request where we need to check the head explicitly
+        if [[ "${{ github.event_name }}" == 'pull_request' ]]; then
+          # repository on a pull request refers to the base which is always mozilla/addons-server
+          is_head_fork="${{ github.event.pull_request.head.repo.fork }}"
+          # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
+          is_dependabot="${{ github.actor == 'dependabot[bot]' }}"
+
+          # If the head repository is a fork or if the PR is opened by dependabot
+          # we consider the run to be a fork. Dependabot and proper forks are treated
+          # the same in terms of limited read only github token scope
+          if [[ "$is_head_fork" == 'true' || "$is_dependabot" == 'true' ]]; then
+            is_fork="true"
+          fi
+        fi
+
+        is_release_master="false"
+        is_release_tag="false"
+
+        # Releases can only happen if we are NOT on a fork
+        if [[ "$is_fork" == 'false' ]]; then
+          # A master release occurs on a push to the default branch of the origin repository
+          if [[ "$event_name" == 'push' && "$is_default_branch" == 'true' ]]; then
+            is_release_master="true"
+          fi
+
+          # A tag release occurs when a release is published
+          if [[ "$event_name" == 'release' && "$event_action" == 'publish' ]]; then
+            is_release_tag="true"
+          fi
+        fi
+
+        echo "is_default_branch=$is_default_branch" >> $GITHUB_OUTPUT
+        echo "is_fork=$is_fork" >> $GITHUB_OUTPUT
+        echo "is_release_master=$is_release_master" >> $GITHUB_OUTPUT
+        echo "is_release_tag=$is_release_tag" >> $GITHUB_OUTPUT
+
+        echo "event_name: $event_name"
+        cat $GITHUB_OUTPUT

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -1,0 +1,133 @@
+name: Test Docker Image
+
+run-name: |
+  Test ${{ github.workflow }} \
+  version: ${{ inputs.version }} \
+  digest: ${{ inputs.digest }}
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: The version of the image to run
+        type: string
+        required: true
+      digest:
+        description: The build digest of the image to run
+        type: string
+        required: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create failure
+        id: failure
+        uses: ./.github/actions/run-docker
+        with:
+          digest: ${{ inputs.digest }}
+          version: ${{ inputs.version }}
+          run: |
+            exit 1
+        continue-on-error: true
+
+      - name: Verify failure
+        if: always()
+        run: |
+          if [[ "${{ steps.failure.outcome }}" != "failure" ]]; then
+            echo "Expected failure"
+            exit 1
+          fi
+
+      - name: Check (special characters in command)
+        uses: ./.github/actions/run-docker
+        with:
+          digest: ${{ inputs.digest }}
+          version: ${{ inputs.version }}
+          run: |
+            echo 'this is a question?'
+            echo 'a * is born'
+            echo 'wow an array []'
+
+      - name: Manage py check
+        uses: ./.github/actions/run-docker
+        with:
+          digest: ${{ inputs.digest }}
+          version: ${{ inputs.version }}
+          run: |
+            make check
+
+      - name: Codestyle
+        uses: ./.github/actions/run-docker
+        with:
+          digest: ${{ inputs.digest }}
+          version: ${{ inputs.version }}
+          run: |
+            make lint-codestyle
+
+  test_needs_locales_compilation:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test (test_needs_locales_compilation)
+        uses: ./.github/actions/run-docker
+        with:
+          services: ''
+          digest: ${{ inputs.digest }}
+          version: ${{ inputs.version }}
+          run: |
+            make test_needs_locales_compilation
+
+  test_static_assets:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test (test_static_assets)
+        uses: ./.github/actions/run-docker
+        with:
+          services: ''
+          digest: ${{ inputs.digest }}
+          version: ${{ inputs.version }}
+          # TODO: we should remove this once we
+          # a) update the asset tests to look in the static-assets folder
+          # b) copy the static file into the container also.
+          run: |
+            make update_assets
+            make test_static_assets
+
+  test_internal_routes_allowed:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test (test_internal_routes_allowed)
+        uses: ./.github/actions/run-docker
+        with:
+          services: ''
+          digest: ${{ inputs.digest }}
+          version: ${{ inputs.version }}
+          run: |
+            make test_internal_routes_allowed
+
+  test_es_tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test (test_es_tests)
+        uses: ./.github/actions/run-docker
+        with:
+          services: ''
+          digest: ${{ inputs.digest }}
+          version: ${{ inputs.version }}
+          run: |
+            make test_es_tests

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -18,116 +18,47 @@ on:
         required: true
 
 jobs:
-  check:
+  test:
     runs-on: ubuntu-latest
-
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          -
+            name: Needs Locale Compilation
+            services: ''
+            run: make test_needs_locales_compilation
+          -
+            name: Static Assets
+            services: ''
+            # TODO: we should remove this once we
+            # a) update the asset tests to look in the static-assets folder
+            # b) copy the static file into the container also.
+            run: |
+              make update_assets
+              make test_static_assets
+          -
+            name: Internal Routes
+            services: ''
+            run: make test_internal_routes_allowed
+          -
+            name: Elastic Search
+            services: ''
+            run: make test_es_tests
+          -
+            name: Codestyle
+            services: web
+            run: make lint-codestyle
+          -
+            name: Manage Check
+            services: web
+            run: make check
     steps:
       - uses: actions/checkout@v4
-
-      - name: Create failure
-        id: failure
+      - name: Test (${{ matrix.name }})
         uses: ./.github/actions/run-docker
         with:
-          digest: ${{ inputs.digest }}
           version: ${{ inputs.version }}
-          run: |
-            exit 1
-        continue-on-error: true
-
-      - name: Verify failure
-        if: always()
-        run: |
-          if [[ "${{ steps.failure.outcome }}" != "failure" ]]; then
-            echo "Expected failure"
-            exit 1
-          fi
-
-      - name: Check (special characters in command)
-        uses: ./.github/actions/run-docker
-        with:
           digest: ${{ inputs.digest }}
-          version: ${{ inputs.version }}
-          run: |
-            echo 'this is a question?'
-            echo 'a * is born'
-            echo 'wow an array []'
-
-      - name: Manage py check
-        uses: ./.github/actions/run-docker
-        with:
-          digest: ${{ inputs.digest }}
-          version: ${{ inputs.version }}
-          run: |
-            make check
-
-      - name: Codestyle
-        uses: ./.github/actions/run-docker
-        with:
-          digest: ${{ inputs.digest }}
-          version: ${{ inputs.version }}
-          run: |
-            make lint-codestyle
-
-  test_needs_locales_compilation:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Test (test_needs_locales_compilation)
-        uses: ./.github/actions/run-docker
-        with:
-          services: ''
-          digest: ${{ inputs.digest }}
-          version: ${{ inputs.version }}
-          run: |
-            make test_needs_locales_compilation
-
-  test_static_assets:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Test (test_static_assets)
-        uses: ./.github/actions/run-docker
-        with:
-          services: ''
-          digest: ${{ inputs.digest }}
-          version: ${{ inputs.version }}
-          # TODO: we should remove this once we
-          # a) update the asset tests to look in the static-assets folder
-          # b) copy the static file into the container also.
-          run: |
-            make update_assets
-            make test_static_assets
-
-  test_internal_routes_allowed:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Test (test_internal_routes_allowed)
-        uses: ./.github/actions/run-docker
-        with:
-          services: ''
-          digest: ${{ inputs.digest }}
-          version: ${{ inputs.version }}
-          run: |
-            make test_internal_routes_allowed
-
-  test_es_tests:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Test (test_es_tests)
-        uses: ./.github/actions/run-docker
-        with:
-          services: ''
-          digest: ${{ inputs.digest }}
-          version: ${{ inputs.version }}
-          run: |
-            make test_es_tests
+          services: ${{ matrix.services }}
+          run: ${{ matrix.run }}

--- a/.github/workflows/_test_main.yml
+++ b/.github/workflows/_test_main.yml
@@ -1,0 +1,113 @@
+name: Test Docker Image (test_main only)
+
+run-name: |
+  Test (main) ${{ github.workflow }} \
+  version: ${{ inputs.version }} \
+  digest: ${{ inputs.digest }} \
+  splits: ${{ inputs.splits }}
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: The version of the image to run
+        type: string
+        required: true
+      digest:
+        description: The build digest of the image to run
+        type: string
+        required: true
+      splits:
+        description: How many splits for test_main
+        type: number
+        required: false
+        default: 14
+
+env:
+  log_artifact: test_main_logs
+  log_file: report.json
+
+jobs:
+  test_config:
+    runs-on: ubuntu-latest
+
+    outputs:
+      matrix: ${{ steps.result.outputs.matrix }}
+      splits: ${{ steps.result.outputs.splits }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Calculate splits
+        id: result
+        shell: bash
+        run: |
+          splits=${{ inputs.splits }}
+          echo "splits: $splits"
+          echo "splits=$splits" >> $GITHUB_OUTPUT
+
+          # Construct the matrix input for test_main using the groups count
+          # the matrix.group should be an array of numbers from 1 to $splits
+          matrix=[$(seq -s, 1 $splits)]
+          echo "matrix: $matrix"
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+
+  test_main:
+    runs-on: ubuntu-latest
+    needs: [test_config]
+    strategy:
+      fail-fast: false
+      matrix:
+        group: ${{fromJson(needs.test_config.outputs.matrix)}}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test (test_matrix)
+        uses: ./.github/actions/run-docker
+        with:
+          services: ''
+          digest: ${{ inputs.digest }}
+          version: ${{ inputs.version }}
+          compose_file: docker-compose.yml
+          run: |
+            split="--splits ${{ needs.test_config.outputs.splits }}"
+            group="--group ${{ matrix.group }}"
+            report="--report-log ${{ env.log_file}}"
+            make test_main ARGS="${split} ${group} ${report}"
+
+      - name: Upload logs
+        uses: actions/upload-artifact@v4
+        with:
+          path: ${{ env.log_file }}
+          name: ${{ env.log_artifact }}-${{ matrix.group }}
+          retention-days: 1
+          overwrite: true
+
+  test_log:
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [test_config, test_main]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: ${{ env.log_artifact }}*
+
+      - name: Cat logs
+        shell: bash
+        run: |
+          for dir in $(ls -d ${{ env.log_artifact }}* | sort -V); do
+            job=$(basename "$dir")
+            file="${dir}/${{ env.log_file }}"
+            if [ -f "$file" ]; then
+              cat "$file" | jq \
+                -r \
+                --arg job "$job" \
+                'select(has("when") and .when == "teardown") | "[\($job)] \(.outcome) \(.nodeid)"'
+            else
+              echo "$file: No such file or directory"
+            fi
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,8 @@ on:
       splits:
         description: 'The number of splits for test_main'
         required: true
-        default: '14'
+        type: number
+        default: 14
   # Runs when a release is published
   # Pushes a tagged image
   # That is deployed to the "staging/production" environments
@@ -32,8 +33,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  log_artifact: test_main_logs
-  log_file: report.json
   docs_artifact: docs
 
 jobs:
@@ -41,53 +40,15 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      # All github action outputs are strings, even if set to "true"
-      # so when using these values always assert against strings or convert from json
-      # \$\{{ needs.context.outputs.is_fork == 'true' }} // true
-      # \$\{{ fromJson(needs.context.outputs.is_fork) == false }} // true
-      # \$\{{ needs.context.outputs.is_fork == true }} // false
-      # \$\{{ needs.context.outputs.is_fork }} // false
       is_fork: ${{ steps.context.outputs.is_fork }}
       is_dependabot: ${{ steps.context.outputs.is_dependabot }}
       is_default_branch: ${{ steps.context.outputs.is_default_branch }}
 
     steps:
-      - name: Log context
-        shell: bash
-        run: |
-          cat <<'EOF'
-          ${{ toJSON(github) }}
-          EOF
+      - uses: actions/checkout@v4
       - name: Set context
         id: context
-        env:
-          # The default branch of the repository, in this case "master"
-          default_branch: ${{ github.event.repository.default_branch }}
-        shell: bash
-        run: |
-          # Stable check for if the workflow is running on the default branch
-          # https://stackoverflow.com/questions/64781462/github-actions-default-branch-variable
-          is_default_branch="${{ format('refs/heads/{0}', env.default_branch) == github.ref }}"
-
-          # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
-          is_dependabot="${{ github.actor == 'dependabot[bot]' }}"
-
-
-          if [[ "${{ github.event_name }}" == 'pull_request' ]]; then
-            # repository on a pull request refers to the base which is always mozilla/addons-server
-            is_fork=${{ github.event.pull_request.head.repo.fork }}
-          else
-            # In most events, the epository refers to the head which would be the fork
-            # This is different in a pullrequest where we need to check the head explicitly
-            is_fork="${{ github.event.repository.fork }}"
-          fi
-
-          echo "is_default_branch=$is_default_branch" >> $GITHUB_OUTPUT
-          echo "is_fork=$is_fork" >> $GITHUB_OUTPUT
-          echo "is_dependabot=$is_dependabot" >> $GITHUB_OUTPUT
-
-          echo "event_name: ${{ github.event_name }}"
-          cat $GITHUB_OUTPUT
+        uses: ./.github/actions/context
 
   build:
     runs-on: ubuntu-latest
@@ -171,7 +132,7 @@ jobs:
           docker compose version
           npm exec jest -- ./tests/make --runInBand
 
-  check:
+  test_run_docker_action:
     runs-on: ubuntu-latest
     needs: build
 
@@ -180,13 +141,13 @@ jobs:
 
       - name: Create failure
         id: failure
+        continue-on-error: true
         uses: ./.github/actions/run-docker
         with:
           digest: ${{ needs.build.outputs.digest }}
           version: ${{ needs.build.outputs.version }}
           run: |
             exit 1
-        continue-on-error: true
 
       - name: Verify failure
         if: always()
@@ -205,22 +166,6 @@ jobs:
             echo 'this is a question?'
             echo 'a * is born'
             echo 'wow an array []'
-
-      - name: Manage py check
-        uses: ./.github/actions/run-docker
-        with:
-          digest: ${{ needs.build.outputs.digest }}
-          version: ${{ needs.build.outputs.version }}
-          run: |
-            make check
-
-      - name: Codestyle
-        uses: ./.github/actions/run-docker
-        with:
-          digest: ${{ needs.build.outputs.digest }}
-          version: ${{ needs.build.outputs.version }}
-          run: |
-            make lint-codestyle
 
   docs_build:
     runs-on: ubuntu-latest
@@ -311,155 +256,19 @@ jobs:
             make push_locales ARGS="${args}"
           fi
 
-  test_needs_locales_compilation:
-    runs-on: ubuntu-latest
+  test:
     needs: build
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Test (test_needs_locales_compilation)
-        uses: ./.github/actions/run-docker
-        with:
-          services: ''
-          digest: ${{ needs.build.outputs.digest }}
-          version: ${{ needs.build.outputs.version }}
-          run: |
-            make test_needs_locales_compilation
-
-  test_static_assets:
-    runs-on: ubuntu-latest
-    needs: build
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Test (test_static_assets)
-        uses: ./.github/actions/run-docker
-        with:
-          services: ''
-          digest: ${{ needs.build.outputs.digest }}
-          version: ${{ needs.build.outputs.version }}
-          # TODO: we should remove this once we
-          # a) update the asset tests to look in the static-assets folder
-          # b) copy the static file into the container also.
-          run: |
-            make update_assets
-            make test_static_assets
-
-  test_internal_routes_allowed:
-    runs-on: ubuntu-latest
-    needs: build
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Test (test_internal_routes_allowed)
-        uses: ./.github/actions/run-docker
-        with:
-          services: ''
-          digest: ${{ needs.build.outputs.digest }}
-          version: ${{ needs.build.outputs.version }}
-          run: |
-            make test_internal_routes_allowed
-
-  test_es_tests:
-    runs-on: ubuntu-latest
-    needs: build
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Test (test_es_tests)
-        uses: ./.github/actions/run-docker
-        with:
-          services: ''
-          digest: ${{ needs.build.outputs.digest }}
-          version: ${{ needs.build.outputs.version }}
-          run: |
-            make test_es_tests
-
-  test_config:
-    runs-on: ubuntu-latest
-
-    outputs:
-      matrix: ${{ steps.result.outputs.matrix }}
-      splits: ${{ steps.result.outputs.splits }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Calculate splits
-        id: result
-        shell: bash
-        run: |
-          splits=${{ inputs.splits || 14 }}
-          echo "splits: $splits"
-          echo "splits=$splits" >> $GITHUB_OUTPUT
-
-          # Construct the matrix input for test_main using the groups count
-          # the matrix.group should be an array of numbers from 1 to $splits
-          matrix=[$(seq -s, 1 $splits)]
-          echo "matrix: $matrix"
-          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+    uses: ./.github/workflows/_test.yml
+    with:
+      version: ${{ needs.build.outputs.version }}
+      digest: ${{ needs.build.outputs.digest }}
 
   test_main:
-    runs-on: ubuntu-latest
-    needs: [build, test_config]
-    strategy:
-      fail-fast: false
-      matrix:
-        group: ${{fromJson(needs.test_config.outputs.matrix)}}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Test (test_matrix)
-        uses: ./.github/actions/run-docker
-        with:
-          services: ''
-          digest: ${{ needs.build.outputs.digest }}
-          version: ${{ needs.build.outputs.version }}
-          compose_file: docker-compose.yml
-          run: |
-            split="--splits ${{ needs.test_config.outputs.splits }}"
-            group="--group ${{ matrix.group }}"
-            report="--report-log ${{ env.log_file}}"
-            make test_main ARGS="${split} ${group} ${report}"
-
-      - name: Upload logs
-        uses: actions/upload-artifact@v4
-        with:
-          path: ${{ env.log_file }}
-          name: ${{ env.log_artifact }}-${{ matrix.group }}
-          retention-days: 1
-          overwrite: true
-
-  test_log:
-    runs-on: ubuntu-latest
-    if: always()
-    needs: [build, test_config, test_main]
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/download-artifact@v4
-        with:
-          pattern: ${{ env.log_artifact }}*
-
-      - name: Cat logs
-        shell: bash
-        run: |
-          for dir in $(ls -d ${{ env.log_artifact }}* | sort -V); do
-            job=$(basename "$dir")
-            file="${dir}/${{ env.log_file }}"
-            if [ -f "$file" ]; then
-              cat "$file" | jq \
-                -r \
-                --arg job "$job" \
-                'select(has("when") and .when == "teardown") | "[\($job)] \(.outcome) \(.nodeid)"'
-            else
-              echo "$file: No such file or directory"
-            fi
-          done
-
+    needs: [context, build]
+    uses: ./.github/workflows/_test_main.yml
+    with:
+      version: ${{ needs.build.outputs.version }}
+      digest: ${{ needs.build.outputs.digest }}
+      # If running from a manual workflow_dispatch event, use the provided input
+      # If no input is given or running on pull_request event, use the default value of 14
+      splits: ${{ inputs.splits || 14 }}


### PR DESCRIPTION
Relates to: mozilla/addons#14823


### Description

Split some of our test jobs from ci.yml to callable workflows. Re-organize the _test.yml workflow to use a matrix strategy for simpler definition.

### Context

We have a lot of jobs in our CI. Previously each was defined independently in the ci.yml file. This PR splits the test jobs out into 2 separately callable workflows that are then called by the CI workflow.

Using `workflow_call` events allow workflows to be called from other workflows (see [docs](https://docs.github.com/en/actions/using-workflows/reusing-workflows)). This gives 2 tangible benefits.

1. Callable workflows can keep CI jobs DRY by allowing you to define a set of jobs that should be executed by multiple workflows. This will be useful to us shortly when we introduce release workflows for master and tags that also want to run tests.

2. Jobs executed in a called workflow are collapsible in the jobs list view in the action run details page. This allows better organization in the view and cleaning up the UI by collapsing is just nice.

After / Before

<img width="1999" alt="image" src="https://github.com/mozilla/addons-server/assets/19595165/04eba14f-3932-4b8c-8ba8-f2d2729d88c7">

Collapsed View:

<img width="362" alt="image" src="https://github.com/mozilla/addons-server/assets/19595165/cf15641a-0ffe-4842-8566-0eae68d6e63f">


### Testing

CI should pass and run essentially the same jobs as before.

### Checklist


- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [X] Add before and after screenshots (Only for changes that impact the UI).
- [X] Add or update relevant [docs](../docs/) reflecting the changes made.
