### PR TITLE
Configurable docker build

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -48,6 +48,8 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - shell: bash
+      run: git reset --hard
     - id: input_meta
       shell: bash
       run: |

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -69,7 +69,7 @@ runs:
         echo "cache_from=$cache_from" >> $GITHUB_OUTPUT
 
         if [[ "$target" != 'development' && "$target" != 'production' ]]; then
-          echo "invalid target $target. Expected `production` or `development`"
+          echo "invalid target $target. Expected 'production' or 'development'"
           exit 1
         else
           echo "target=$target" >> $GITHUB_OUTPUT

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -1,18 +1,38 @@
 name: 'Docker Build'
 description: 'Builds `addons-server` docker image'
 inputs:
-  password:
-    required: false
-    description: "Docker registry password"
-    default: "invalid"
-  push:
-    required: false
-    description: "Build and push image to registry (cannot be used together with load)"
-    default: "false"
-  username:
-    required: false
-    description: "Docker registry username"
-    default: "invalid"
+    # Required Inputs
+    registry:
+      required: true
+      description: docker registry to publish to
+    image:
+      required: true
+      description: docker image to tag the image
+    version:
+      required: true
+      description: docker image version to tag the image
+    target:
+      required: true
+      description: docker image target to build to
+    # Optional Inputs
+    username:
+      required: false
+      description: the username to login with
+      default: ''
+    password:
+      required: false
+      description: the password to login with
+      default: ''
+    push:
+      required: false
+      description: should the image be pushed to the specified registry
+      default: 'false'
+    cache_to:
+      required: false
+      description: Cache the docker image layers to a remote store
+    cache_from:
+      required: false
+      description: Cache to pull before building the image
 
 outputs:
   digest:
@@ -20,14 +40,67 @@ outputs:
     value: ${{ steps.digest.outputs.digest }}
   version:
     description: "The Docker version for the image"
-    value: ${{ steps.meta.outputs.version }}
+    value: ${{ steps.docker_meta.outputs.version }}
   tags:
     description: "The Docker tags for the image"
-    value: ${{ steps.meta.outputs.tags }}
+    value: ${{ steps.docker_meta.outputs.tags }}
 
 runs:
   using: "composite"
   steps:
+    - id: input_meta
+      shell: bash
+      run: |
+        registry="${{ inputs.registry }}"
+        image="${{ inputs.image }}"
+        version="${{ inputs.version }}"
+        target="${{ inputs.target }}"
+        username="${{ inputs.username }}"
+        password="${{ inputs.password }}"
+        push="${{ inputs.push }}"
+        cache_to="${{ inputs.cache_to }}"
+        cache_from="${{ inputs.cache_from }}"
+
+        echo "registry=$registry" >> $GITHUB_OUTPUT
+        echo "image_file=image.tar" >> $GITHUB_OUTPUT
+        echo "version=$version" >> $GITHUB_OUTPUT
+        echo "target=$target" >> $GITHUB_OUTPUT
+        echo "cache_to=$cache_to" >> $GITHUB_OUTPUT
+        echo "cache_from=$cache_from" >> $GITHUB_OUTPUT
+
+        if [[ "$target" != 'development' && "$target" != 'production' ]]; then
+          echo "invalid target $target. Expected `production` or `development`"
+          exit 1
+        else
+          echo "target=$target" >> $GITHUB_OUTPUT
+        fi
+
+        base_image="$registry/$image"
+        echo "base_image=$base_image" >> $GITHUB_OUTPUT
+
+        if [[ "$push" == 'true' ]]; then
+          if [[ "$username" == '' ||  "$password" == '' ]]; then
+            echo "username and password are required when pushing an image"
+            exit 1
+          fi
+        fi
+        echo "push=$push" >> $GITHUB_OUTPUT
+
+        cat $GITHUB_OUTPUT
+
+    - name: Docker meta
+      id: docker_meta
+      env:
+        version: ${{ steps.input_meta.outputs.version }}
+        suffix: -next
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ steps.input_meta.outputs.base_image }}
+        tags: |
+            # use raw tag to allow the calling workflow to define the version of the image
+            # and to prevent multiple tags from being associated with a build
+            type=raw,value=${{ env.version }},suffix=${{ env.suffix }}
+
     # Setup docker to build for multiple architectures
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
@@ -37,72 +110,37 @@ runs:
         version: latest
         buildkitd-flags: --debug
 
-    # Login to a registry to push the image
-    - name: Login to Container Registry
-      # Only login if we are pushing the image
-      if: ${{ inputs.push == 'true' }}
+    - name: Login
+      id: login
+      if: ${{ steps.input_meta.outputs.push == 'true' }}
       uses: docker/login-action@v3
       with:
+        registry: ${{ steps.input_meta.outputs.registry }}
+        # Read username and password directly from inputs as they are likely secrets
+        # and cannot be passed around between step outputs
         username: ${{ inputs.username }}
         password: ${{ inputs.password }}
 
-
-    - name: Suffix for local builds
-      id: suffix
-      shell: bash
-      # The suffix is unique to a branch and commit
-      run: |
-        if [[ "${{ inputs.push }}" == "false" ]]; then
-          echo "suffix=${{ github.ref }}-${{ github.sha }}" >> $GITHUB_OUTPUT
-        else
-          echo "suffix=ci" >> $GITHUB_OUTPUT
-        fi
-
-    # Determine the tags for the image
-    # We need to support custom explicit tags allowing CI to build unique images
-    # that won't be pushed to the registry.
-    - name: Docker meta
-      id: meta
-      uses: docker/metadata-action@v5
-      with:
-        # Hard coding our dockerhub image name
-        images: mozilla/addons-server
-        flavor: |
-          suffix=-${{ steps.suffix.outputs.suffix }}
-        tags: |
-          type=schedule
-          type=ref,event=tag
-          type=ref,event=branch
-          type=ref,event=pr
-          # set latest tag for default branch
-          # Disabled for now as we do not use this action for
-          # The production build
-          # type=raw,value=latest,enable={{is_default_branch}}
-
-    - name: Create .env and version.json files
+    - name: Local Environment Setup
       shell: bash
       env:
-        DOCKER_VERSION: ${{ steps.meta.outputs.version }}
+        DOCKER_VERSION: ${{ steps.docker_meta.outputs.version }}
+        DOCKER_TARGET: ${{ steps.input_meta.outputs.target }}
         DOCKER_COMMIT: ${{ github.sha }}
         VERSION_BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-      run: make setup
-
-    - name: Set Docker Variables
-      id: cache
-      shell: bash
       run: |
-        echo "tag=mozilla/addons-server:${{ steps.meta.outputs.version }}-cache" >> $GITHUB_OUTPUT
+        make setup
 
     - name: Build Image
       id: build
       uses: docker/bake-action@v4
       with:
         targets: web
-        push: ${{ inputs.push }}
-        load: ${{ inputs.push == 'false' }}
+        load: true
+        push: ${{ steps.login.outcome == 'success' && steps.input_meta.outputs.push == 'true' }}
         set: |
-          *.cache-from=type=registry,ref=${{ steps.cache.outputs.tag }}
-          *.cache-to=type=registry,ref=${{ steps.cache.outputs.tag }},mode=max,compression-level=9,force-compression=true,ignore-error=true
+          *.cache-from=${{ steps.input_meta.outputs.cache_from }}
+          *.cache-to=${{ steps.input_meta.outputs.cache_to }}
 
     - name: Get image digest
       id: digest

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -125,7 +125,6 @@ runs:
       shell: bash
       env:
         DOCKER_VERSION: ${{ steps.docker_meta.outputs.version }}
-        DOCKER_TARGET: ${{ steps.input_meta.outputs.target }}
         DOCKER_COMMIT: ${{ github.sha }}
         VERSION_BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       run: |

--- a/.github/actions/context/action.yml
+++ b/.github/actions/context/action.yml
@@ -1,0 +1,114 @@
+name: 'Dump Context'
+description: 'Display context for action run'
+
+outputs:
+  # All github action outputs are strings, even if set to "true"
+  # so when using these values always assert against strings or convert from json
+  # \$\{{ needs.context.outputs.is_fork == 'true' }} // true
+  # \$\{{ fromJson(needs.context.outputs.is_fork) == false }} // true
+  # \$\{{ needs.context.outputs.is_fork == true }} // false
+  # \$\{{ needs.context.outputs.is_fork }} // false
+  is_fork:
+    description: ""
+    value: ${{ steps.context.outputs.is_fork }}
+  is_default_branch:
+    description: ""
+    value: ${{ steps.context.outputs.is_default_branch }}
+  is_release_master:
+    description: ""
+    value: ${{ steps.context.outputs.is_release_master }}
+  is_release_tag:
+    description: ""
+    value: ${{ steps.context.outputs.is_release_tag }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Dump GitHub context
+      shell: bash
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
+    - name: Dump job context
+      shell: bash
+      env:
+        JOB_CONTEXT: ${{ toJson(job) }}
+      run: echo "$JOB_CONTEXT"
+    - name: Dump steps context
+      shell: bash
+      env:
+        STEPS_CONTEXT: ${{ toJson(steps) }}
+      run: echo "$STEPS_CONTEXT"
+    - name: Dump runner context
+      shell: bash
+      env:
+        RUNNER_CONTEXT: ${{ toJson(runner) }}
+      run: echo "$RUNNER_CONTEXT"
+    - name: Dump env context
+      shell: bash
+      env:
+        ENV_CONTEXT: ${{ toJson(env) }}
+      run: |
+        echo "$ENV_CONTEXT"
+    - name: Dump inputs context
+      shell: bash
+      env:
+        INPUTS_CONTEXT: ${{ toJson(inputs) }}
+      run: |
+        echo "$INPUTS_CONTEXT"
+
+    - name: Set context
+      id: context
+      env:
+        # The default branch of the repository, in this case "master"
+        default_branch: ${{ github.event.repository.default_branch }}
+      shell: bash
+      run: |
+        event_name="${{ github.event_name }}"
+        event_action="${{ github.event.action }}"
+
+        # Stable check for if the workflow is running on the default branch
+        # https://stackoverflow.com/questions/64781462/github-actions-default-branch-variable
+        is_default_branch="${{ format('refs/heads/{0}', env.default_branch) == github.ref }}"
+
+        # In most events, the epository refers to the head which would be the fork
+        is_fork="${{ github.event.repository.fork }}"
+
+        # This is different in a pull_request where we need to check the head explicitly
+        if [[ "${{ github.event_name }}" == 'pull_request' ]]; then
+          # repository on a pull request refers to the base which is always mozilla/addons-server
+          is_head_fork="${{ github.event.pull_request.head.repo.fork }}"
+          # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
+          is_dependabot="${{ github.actor == 'dependabot[bot]' }}"
+
+          # If the head repository is a fork or if the PR is opened by dependabot
+          # we consider the run to be a fork. Dependabot and proper forks are treated
+          # the same in terms of limited read only github token scope
+          if [[ "$is_head_fork" == 'true' || "$is_dependabot" == 'true' ]]; then
+            is_fork="true"
+          fi
+        fi
+
+        is_release_master="false"
+        is_release_tag="false"
+
+        # Releases can only happen if we are NOT on a fork
+        if [[ "$is_fork" == 'false' ]]; then
+          # A master release occurs on a push to the default branch of the origin repository
+          if [[ "$event_name" == 'push' && "$is_default_branch" == 'true' ]]; then
+            is_release_master="true"
+          fi
+
+          # A tag release occurs when a release is published
+          if [[ "$event_name" == 'release' && "$event_action" == 'publish' ]]; then
+            is_release_tag="true"
+          fi
+        fi
+
+        echo "is_default_branch=$is_default_branch" >> $GITHUB_OUTPUT
+        echo "is_fork=$is_fork" >> $GITHUB_OUTPUT
+        echo "is_release_master=$is_release_master" >> $GITHUB_OUTPUT
+        echo "is_release_tag=$is_release_tag" >> $GITHUB_OUTPUT
+
+        echo "event_name: $event_name"
+        cat $GITHUB_OUTPUT

--- a/.github/actions/run-docker/action.yml
+++ b/.github/actions/run-docker/action.yml
@@ -20,6 +20,7 @@ inputs:
     description: 'The docker-compose file to use'
     required: false
     default: 'docker-compose.yml:docker-compose.ci.yml'
+
 runs:
   using: 'composite'
   steps:

--- a/.github/actions/run-docker/action.yml
+++ b/.github/actions/run-docker/action.yml
@@ -1,12 +1,25 @@
 name: 'Docker Run Action'
 description: 'Run a command in a new container'
 inputs:
-  version:
-    description: 'The version of the image to run. '
+  # Required Inputs
+  registry:
     required: true
-    default: 'local'
+    description: docker registry to publish to
+  image:
+    required: true
+    description: docker image to tag the image
+  version:
+    required: true
+    description: docker image version to tag the image
+  target:
+    required: true
+    description: docker image target to build to
+  cache_from:
+    required: false
+    description: Cache to pull before building the image
+
   digest:
-    description: 'The build digest of the image to run. Overrides version.'
+    description: A build digest to verify the image against
     required: true
     default: ''
   run:
@@ -24,6 +37,27 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Build Docker image
+      id: build
+      uses: ./.github/actions/build-docker
+      with:
+        registry: ${{ inputs.registry }}
+        image: ${{ inputs.image }}
+        version: ${{ inputs.version }}
+        cache_from: ${{ inputs.cache_from }}
+        target: ${{ inputs.target }}
+
+    - name: Verify image
+      shell: bash
+      run: |
+        input_digest="${{ inputs.digest }}"
+        build_digest="${{ steps.build.outputs.digest }}"
+
+        if [[ "$input_digest" != "$build_digest" ]]; then
+          echo "Invalid digest, something went wrong in the build"
+          exit 1
+        fi
+
     - id: id
       shell: bash
       run: |
@@ -32,8 +66,7 @@ runs:
     - name: Run Docker Container
       shell: bash
       env:
-        DOCKER_VERSION: ${{ inputs.version }}
-        DOCKER_DIGEST: ${{ inputs.digest }}
+        DOCKER_VERSION: ${{ steps.build.outputs.version }}
         COMPOSE_FILE: ${{ inputs.compose_file }}
         DOCKER_SERVICES: ${{ inputs.services }}
         HOST_UID: ${{ steps.id.outputs.id }}

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -4,12 +4,20 @@ on:
   workflow_dispatch:
     inputs:
       push:
-        description: 'Push the image to registry?'
-        default: "false"
-        required: false
+        required: true
+        description: Push the image to dockerhub?
+        type: boolean
+        default: false
+      target:
+        required: true
+        description: The docker stage to target
+        type: choice
+        options:
+          - development
+          - production
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.inputs.push }}
+  group: ${{ github.workflow }}-${{ inputs.target }}-${{ inputs.push }}
   cancel-in-progress: true
 
 jobs:
@@ -23,6 +31,11 @@ jobs:
         id: build_container
         uses: ./.github/actions/build-docker
         with:
-          push: ${{ inputs.push }}
+          registry: docker.io
+          image: ${{ github.repository }}
+          # Prefix version for this workflow to prevent tag collission
+          version: build-${{ github.ref_name }}
+          target: ${{ inputs.target }}
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
+          push: ${{ inputs.push }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,34 +139,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build Docker image
-        id: build
-        uses: ./.github/actions/build-docker
+      - name: Create failure
+        id: failure
+        uses: ./.github/actions/run-docker
         with:
           registry: ${{ needs.context.outputs.registry }}
           image: ${{ needs.context.outputs.image }}
           version: ${{ needs.context.outputs.version }}
           cache_from: ${{ needs.context.outputs.cache_from }}
-          cache_to: ${{ needs.context.outputs.cache_to }}
-          target: development
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASS }}
-
-      - name: Verify Digest
-        shell: bash
-        run: |
-          build_digest="${{ needs.build.outputs.digest }}"
-          run_digest="${{ steps.build.outputs.digest }}"
-
-          echo "build: $build_digest"
-          echo "run: $run_digest"
-
-      - name: Create failure
-        id: failure
-        uses: ./.github/actions/run-docker
-        with:
-          digest: ${{ steps.build.outputs.digest }}
-          version: ${{ steps.build.outputs.version }}
+          digest: ${{ needs.build.outputs.digest }}
           run: |
             exit 1
         continue-on-error: true
@@ -182,8 +163,11 @@ jobs:
       - name: Check (special characters in command)
         uses: ./.github/actions/run-docker
         with:
+          registry: ${{ needs.context.outputs.registry }}
+          image: ${{ needs.context.outputs.image }}
+          version: ${{ needs.context.outputs.version }}
+          cache_from: ${{ needs.context.outputs.cache_from }}
           digest: ${{ needs.build.outputs.digest }}
-          version: ${{ needs.build.outputs.version }}
           run: |
             echo 'this is a question?'
             echo 'a * is born'
@@ -192,22 +176,28 @@ jobs:
       - name: Manage py check
         uses: ./.github/actions/run-docker
         with:
+          registry: ${{ needs.context.outputs.registry }}
+          image: ${{ needs.context.outputs.image }}
+          version: ${{ needs.context.outputs.version }}
+          cache_from: ${{ needs.context.outputs.cache_from }}
           digest: ${{ needs.build.outputs.digest }}
-          version: ${{ needs.build.outputs.version }}
           run: |
             make check
 
       - name: Codestyle
         uses: ./.github/actions/run-docker
         with:
+          registry: ${{ needs.context.outputs.registry }}
+          image: ${{ needs.context.outputs.image }}
+          version: ${{ needs.context.outputs.version }}
+          cache_from: ${{ needs.context.outputs.cache_from }}
           digest: ${{ needs.build.outputs.digest }}
-          version: ${{ needs.build.outputs.version }}
           run: |
             make lint-codestyle
 
   docs_build:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, context]
 
     steps:
       - uses: actions/checkout@v4
@@ -216,8 +206,11 @@ jobs:
       - name: Build Docs
         uses: ./.github/actions/run-docker
         with:
+          registry: ${{ needs.context.outputs.registry }}
+          image: ${{ needs.context.outputs.image }}
+          version: ${{ needs.context.outputs.version }}
+          cache_from: ${{ needs.context.outputs.cache_from }}
           digest: ${{ needs.build.outputs.digest }}
-          version: ${{ needs.build.outputs.version }}
           compose_file: docker-compose.yml
           run: |
             make docs
@@ -267,8 +260,11 @@ jobs:
       - name: Extract Locales
         uses: ./.github/actions/run-docker
         with:
+          registry: ${{ needs.context.outputs.registry }}
+          image: ${{ needs.context.outputs.image }}
+          version: ${{ needs.context.outputs.version }}
+          cache_from: ${{ needs.context.outputs.cache_from }}
           digest: ${{ needs.build.outputs.digest }}
-          version: ${{ needs.build.outputs.version }}
           compose_file: docker-compose.yml
           run: make extract_locales
 
@@ -296,7 +292,7 @@ jobs:
 
   test_needs_locales_compilation:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, context]
 
     steps:
       - uses: actions/checkout@v4
@@ -304,15 +300,18 @@ jobs:
       - name: Test (test_needs_locales_compilation)
         uses: ./.github/actions/run-docker
         with:
+          registry: ${{ needs.context.outputs.registry }}
+          image: ${{ needs.context.outputs.image }}
+          version: ${{ needs.context.outputs.version }}
+          cache_from: ${{ needs.context.outputs.cache_from }}
           services: ''
           digest: ${{ needs.build.outputs.digest }}
-          version: ${{ needs.build.outputs.version }}
           run: |
             make test_needs_locales_compilation
 
   test_static_assets:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, context]
 
     steps:
       - uses: actions/checkout@v4
@@ -320,9 +319,12 @@ jobs:
       - name: Test (test_static_assets)
         uses: ./.github/actions/run-docker
         with:
+          registry: ${{ needs.context.outputs.registry }}
+          image: ${{ needs.context.outputs.image }}
+          version: ${{ needs.context.outputs.version }}
+          cache_from: ${{ needs.context.outputs.cache_from }}
           services: ''
           digest: ${{ needs.build.outputs.digest }}
-          version: ${{ needs.build.outputs.version }}
           # TODO: we should remove this once we
           # a) update the asset tests to look in the static-assets folder
           # b) copy the static file into the container also.
@@ -332,7 +334,7 @@ jobs:
 
   test_internal_routes_allowed:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, context]
 
     steps:
       - uses: actions/checkout@v4
@@ -340,15 +342,18 @@ jobs:
       - name: Test (test_internal_routes_allowed)
         uses: ./.github/actions/run-docker
         with:
+          registry: ${{ needs.context.outputs.registry }}
+          image: ${{ needs.context.outputs.image }}
+          version: ${{ needs.context.outputs.version }}
+          cache_from: ${{ needs.context.outputs.cache_from }}
           services: ''
           digest: ${{ needs.build.outputs.digest }}
-          version: ${{ needs.build.outputs.version }}
           run: |
             make test_internal_routes_allowed
 
   test_es_tests:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, context]
 
     steps:
       - uses: actions/checkout@v4
@@ -356,9 +361,12 @@ jobs:
       - name: Test (test_es_tests)
         uses: ./.github/actions/run-docker
         with:
+          registry: ${{ needs.context.outputs.registry }}
+          image: ${{ needs.context.outputs.image }}
+          version: ${{ needs.context.outputs.version }}
+          cache_from: ${{ needs.context.outputs.cache_from }}
           services: ''
           digest: ${{ needs.build.outputs.digest }}
-          version: ${{ needs.build.outputs.version }}
           run: |
             make test_es_tests
 
@@ -388,7 +396,7 @@ jobs:
 
   test_main:
     runs-on: ubuntu-latest
-    needs: [build, test_config]
+    needs: [build, test_config, context]
     strategy:
       fail-fast: false
       matrix:
@@ -400,9 +408,12 @@ jobs:
       - name: Test (test_matrix)
         uses: ./.github/actions/run-docker
         with:
+          registry: ${{ needs.context.outputs.registry }}
+          image: ${{ needs.context.outputs.image }}
+          version: ${{ needs.context.outputs.version }}
+          cache_from: ${{ needs.context.outputs.cache_from }}
           services: ''
           digest: ${{ needs.build.outputs.digest }}
-          version: ${{ needs.build.outputs.version }}
           compose_file: docker-compose.yml
           run: |
             split="--splits ${{ needs.test_config.outputs.splits }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
       registry: ${{ steps.build_context.outputs.registry }}
       image: ${{ steps.build_context.outputs.image }}
       version: ${{ steps.build_context.outputs.version }}
+      target: ${{ steps.build_context.outputs.target }}
       cache_from: ${{ steps.build_context.outputs.cache_from }}
       cache_to: ${{ steps.build_context.outputs.cache_to }}
 
@@ -73,6 +74,7 @@ jobs:
           registry="docker.io"
           image="${{ github.repository }}"
           version="${{ github.ref_name }}"
+          target="development"
 
           if [[ "$is_fork" == 'true' ]]; then
             cache_from='type=gha'
@@ -85,9 +87,11 @@ jobs:
             cache_to="$cache_from,$cache_to_options"
           fi
 
+
           echo "registry=$registry" >> $GITHUB_OUTPUT
           echo "image=$image" >> $GITHUB_OUTPUT
           echo "version=$version" >> $GITHUB_OUTPUT
+          echo "target=$target" >> $GITHUB_OUTPUT
           echo "cache_from=$cache_from" >> $GITHUB_OUTPUT
           echo "cache_to=$cache_to" >> $GITHUB_OUTPUT
 
@@ -111,9 +115,9 @@ jobs:
           registry: ${{ needs.context.outputs.registry }}
           image: ${{ needs.context.outputs.image }}
           version: ${{ needs.context.outputs.version }}
+          target: ${{ needs.context.outputs.target }}
           cache_from: ${{ needs.context.outputs.cache_from }}
           cache_to: ${{ needs.context.outputs.cache_to }}
-          target: development
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
 
@@ -146,6 +150,7 @@ jobs:
           registry: ${{ needs.context.outputs.registry }}
           image: ${{ needs.context.outputs.image }}
           version: ${{ needs.context.outputs.version }}
+          target: ${{ needs.context.outputs.target }}
           cache_from: ${{ needs.context.outputs.cache_from }}
           digest: ${{ needs.build.outputs.digest }}
           run: |
@@ -166,6 +171,7 @@ jobs:
           registry: ${{ needs.context.outputs.registry }}
           image: ${{ needs.context.outputs.image }}
           version: ${{ needs.context.outputs.version }}
+          target: ${{ needs.context.outputs.target }}
           cache_from: ${{ needs.context.outputs.cache_from }}
           digest: ${{ needs.build.outputs.digest }}
           run: |
@@ -179,6 +185,7 @@ jobs:
           registry: ${{ needs.context.outputs.registry }}
           image: ${{ needs.context.outputs.image }}
           version: ${{ needs.context.outputs.version }}
+          target: ${{ needs.context.outputs.target }}
           cache_from: ${{ needs.context.outputs.cache_from }}
           digest: ${{ needs.build.outputs.digest }}
           run: |
@@ -209,6 +216,7 @@ jobs:
           registry: ${{ needs.context.outputs.registry }}
           image: ${{ needs.context.outputs.image }}
           version: ${{ needs.context.outputs.version }}
+          target: ${{ needs.context.outputs.target }}
           cache_from: ${{ needs.context.outputs.cache_from }}
           digest: ${{ needs.build.outputs.digest }}
           compose_file: docker-compose.yml
@@ -263,6 +271,7 @@ jobs:
           registry: ${{ needs.context.outputs.registry }}
           image: ${{ needs.context.outputs.image }}
           version: ${{ needs.context.outputs.version }}
+          target: ${{ needs.context.outputs.target }}
           cache_from: ${{ needs.context.outputs.cache_from }}
           digest: ${{ needs.build.outputs.digest }}
           compose_file: docker-compose.yml
@@ -303,6 +312,7 @@ jobs:
           registry: ${{ needs.context.outputs.registry }}
           image: ${{ needs.context.outputs.image }}
           version: ${{ needs.context.outputs.version }}
+          target: ${{ needs.context.outputs.target }}
           cache_from: ${{ needs.context.outputs.cache_from }}
           services: ''
           digest: ${{ needs.build.outputs.digest }}
@@ -322,6 +332,7 @@ jobs:
           registry: ${{ needs.context.outputs.registry }}
           image: ${{ needs.context.outputs.image }}
           version: ${{ needs.context.outputs.version }}
+          target: ${{ needs.context.outputs.target }}
           cache_from: ${{ needs.context.outputs.cache_from }}
           services: ''
           digest: ${{ needs.build.outputs.digest }}
@@ -345,6 +356,7 @@ jobs:
           registry: ${{ needs.context.outputs.registry }}
           image: ${{ needs.context.outputs.image }}
           version: ${{ needs.context.outputs.version }}
+          target: ${{ needs.context.outputs.target }}
           cache_from: ${{ needs.context.outputs.cache_from }}
           services: ''
           digest: ${{ needs.build.outputs.digest }}
@@ -364,6 +376,7 @@ jobs:
           registry: ${{ needs.context.outputs.registry }}
           image: ${{ needs.context.outputs.image }}
           version: ${{ needs.context.outputs.version }}
+          target: ${{ needs.context.outputs.target }}
           cache_from: ${{ needs.context.outputs.cache_from }}
           services: ''
           digest: ${{ needs.build.outputs.digest }}
@@ -411,6 +424,7 @@ jobs:
           registry: ${{ needs.context.outputs.registry }}
           image: ${{ needs.context.outputs.image }}
           version: ${{ needs.context.outputs.version }}
+          target: ${{ needs.context.outputs.target }}
           cache_from: ${{ needs.context.outputs.cache_from }}
           services: ''
           digest: ${{ needs.build.outputs.digest }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,42 +51,46 @@ jobs:
       is_dependabot: ${{ steps.context.outputs.is_dependabot }}
       is_default_branch: ${{ steps.context.outputs.is_default_branch }}
 
+      registry: ${{ steps.build_context.outputs.registry }}
+      image: ${{ steps.build_context.outputs.image }}
+      version: ${{ steps.build_context.outputs.version }}
+      cache_from: ${{ steps.build_context.outputs.cache_from }}
+      cache_to: ${{ steps.build_context.outputs.cache_to }}
+
     steps:
-      - name: Log context
-        shell: bash
-        run: |
-          cat <<'EOF'
-          ${{ toJSON(github) }}
-          EOF
+      - uses: actions/checkout@v4
+
       - name: Set context
         id: context
-        env:
-          # The default branch of the repository, in this case "master"
-          default_branch: ${{ github.event.repository.default_branch }}
+        uses: ./.github/actions/context
+
+      - name: Build context
+        id: build_context
         shell: bash
         run: |
-          # Stable check for if the workflow is running on the default branch
-          # https://stackoverflow.com/questions/64781462/github-actions-default-branch-variable
-          is_default_branch="${{ format('refs/heads/{0}', env.default_branch) == github.ref }}"
+          is_fork="${{ steps.context.outputs.is_fork }}"
 
-          # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
-          is_dependabot="${{ github.actor == 'dependabot[bot]' }}"
+          registry="docker.io"
+          image="${{ github.repository }}"
+          version="${{ github.ref_name }}"
 
-
-          if [[ "${{ github.event_name }}" == 'pull_request' ]]; then
-            # repository on a pull request refers to the base which is always mozilla/addons-server
-            is_fork=${{ github.event.pull_request.head.repo.fork }}
+          if [[ "$is_fork" == 'true' ]]; then
+            cache_from='type=gha'
+            cache_to='type=gha,mode=max'
           else
-            # In most events, the epository refers to the head which would be the fork
-            # This is different in a pullrequest where we need to check the head explicitly
-            is_fork="${{ github.event.repository.fork }}"
+            cache_ref="$registry/$image:$version-cache"
+            cache_from="type=registry,ref=$cache_ref"
+
+            cache_to_options='mode=max,compression-level=9,force-compression=true,ignore-error=true'
+            cache_to="$cache_from,$cache_to_options"
           fi
 
-          echo "is_default_branch=$is_default_branch" >> $GITHUB_OUTPUT
-          echo "is_fork=$is_fork" >> $GITHUB_OUTPUT
-          echo "is_dependabot=$is_dependabot" >> $GITHUB_OUTPUT
+          echo "registry=$registry" >> $GITHUB_OUTPUT
+          echo "image=$image" >> $GITHUB_OUTPUT
+          echo "version=$version" >> $GITHUB_OUTPUT
+          echo "cache_from=$cache_from" >> $GITHUB_OUTPUT
+          echo "cache_to=$cache_to" >> $GITHUB_OUTPUT
 
-          echo "event_name: ${{ github.event_name }}"
           cat $GITHUB_OUTPUT
 
   build:
@@ -97,64 +101,21 @@ jobs:
       digest: ${{ steps.build.outputs.digest }}
       version: ${{ steps.build.outputs.version }}
 
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-
     steps:
       - uses: actions/checkout@v4
 
-      - name: Determine if build is allowed
-        id: should_build
-        shell: bash
-        run: |
-          is_fork="${{ needs.context.outputs.is_fork }}"
-          is_dependabot="${{ needs.context.outputs.is_dependabot }}"
-
-          # Default behaviour is to build images for any CI.yml run
-          should_build="true"
-
-          # Never run the build on a fork. Forks lack sufficient permissions
-          # to access secrets or push artifacts
-          if [[ "$is_fork" == 'true' ]]; then
-            should_build="false"
-          fi
-
-          # Dependabot PRs are treated as if they are from forks (see above)
-          if [[ "$is_dependabot" == 'true' && "${{ github.event_name }}" == 'pull_request' ]]; then
-            should_build="false"
-          fi
-
-          echo "result=$should_build" >> $GITHUB_OUTPUT
-
-
       - name: Build Docker image
-        if: ${{ steps.should_build.outputs.result == 'true' }}
         id: build
         uses: ./.github/actions/build-docker
         with:
+          registry: ${{ needs.context.outputs.registry }}
+          image: ${{ needs.context.outputs.image }}
+          version: ${{ needs.context.outputs.version }}
+          cache_from: ${{ needs.context.outputs.cache_from }}
+          cache_to: ${{ needs.context.outputs.cache_to }}
+          target: development
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
-          push: true
-
-      # Only continue if we are releasing
-      # Login to GAR to publish production image
-      - name: get the GCP auth token
-        if: ${{ steps.should_build.outputs.result == 'true' }}
-        id: gcp-auth
-        uses: google-github-actions/auth@v2
-        with:
-          token_format: access_token
-          service_account: ${{ secrets.GAR_PUSHER_SERVICE_ACCOUNT_EMAIL }}
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-
-      - name: login to GAR
-        if: ${{ steps.should_build.outputs.result == 'true' }}
-        uses: docker/login-action@v3
-        with:
-          registry: us-docker.pkg.dev
-          username: oauth2accesstoken
-          password: ${{ steps.gcp-auth.outputs.access_token }}
 
   test_make_docker_configuration:
     runs-on: ubuntu-latest
@@ -173,17 +134,39 @@ jobs:
 
   check:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [context, build]
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        id: build
+        uses: ./.github/actions/build-docker
+        with:
+          registry: ${{ needs.context.outputs.registry }}
+          image: ${{ needs.context.outputs.image }}
+          version: ${{ needs.context.outputs.version }}
+          cache_from: ${{ needs.context.outputs.cache_from }}
+          cache_to: ${{ needs.context.outputs.cache_to }}
+          target: development
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASS }}
+
+      - name: Verify Digest
+        shell: bash
+        run: |
+          build_digest="${{ needs.build.outputs.digest }}"
+          run_digest="${{ steps.build.outputs.digest }}"
+
+          echo "build: $build_digest"
+          echo "run: $run_digest"
 
       - name: Create failure
         id: failure
         uses: ./.github/actions/run-docker
         with:
-          digest: ${{ needs.build.outputs.digest }}
-          version: ${{ needs.build.outputs.version }}
+          digest: ${{ steps.build.outputs.digest }}
+          version: ${{ steps.build.outputs.version }}
           run: |
             exit 1
         continue-on-error: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,6 @@ services:
   worker: &worker
     <<: *env
     image: ${DOCKER_TAG:-}
-    # Ignore any linting saying we have an invalid value.
-    pull_policy: ${DOCKER_PULL_POLICY:-}
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
Relates to: mozilla/addons#14283


### Description

- specify registry/image/version from calling workflow
- upload image to artifact allowing forks to push images
- configurable cache parameters
- explicit version from caling workflow to limit variability of tags

### Context

This PR enables building/running our`addons-server` docker image via github action artifacts. In additon to pushing to a registry (when desired and possible) we upload the image to an artifact, allowing subsequent jobs to pull the image without needing authenticated access to any docker regsitry. This allows Forks and PRs to the main repo to behave the same way.

### Testing

TBD

### Checklist


- [ ] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
