### PR TITLE
disable auto-approval when setting needs human review in a content review

### DIFF
--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -243,14 +243,14 @@ class TestReviewHelper(TestReviewHelperBase):
             'reply',
             'comment',
         ]
+        actions = self.get_review_actions(
+            addon_status=amo.STATUS_NOMINATED,
+            file_status=amo.STATUS_AWAITING_REVIEW,
+        )
+        assert list(actions.keys()) == expected
         assert (
-            list(
-                self.get_review_actions(
-                    addon_status=amo.STATUS_NOMINATED,
-                    file_status=amo.STATUS_AWAITING_REVIEW,
-                ).keys()
-            )
-            == expected
+            'Will also disable auto-approval'
+            not in actions['set_needs_human_review_multiple_versions']['details']
         )
 
     def test_actions_full_update(self):
@@ -263,14 +263,14 @@ class TestReviewHelper(TestReviewHelperBase):
             'reply',
             'comment',
         ]
+        actions = self.get_review_actions(
+            addon_status=amo.STATUS_APPROVED,
+            file_status=amo.STATUS_AWAITING_REVIEW,
+        )
+        assert list(actions.keys()) == expected
         assert (
-            list(
-                self.get_review_actions(
-                    addon_status=amo.STATUS_APPROVED,
-                    file_status=amo.STATUS_AWAITING_REVIEW,
-                ).keys()
-            )
-            == expected
+            'Will also disable auto-approval'
+            not in actions['set_needs_human_review_multiple_versions']['details']
         )
 
     def test_actions_full_nonpending(self):
@@ -283,13 +283,13 @@ class TestReviewHelper(TestReviewHelperBase):
         ]
         f_statuses = [amo.STATUS_APPROVED, amo.STATUS_DISABLED]
         for file_status in f_statuses:
+            actions = self.get_review_actions(
+                addon_status=amo.STATUS_APPROVED, file_status=file_status
+            )
+            assert list(actions.keys()) == expected
             assert (
-                list(
-                    self.get_review_actions(
-                        addon_status=amo.STATUS_APPROVED, file_status=file_status
-                    ).keys()
-                )
-                == expected
+                'Will also disable auto-approval'
+                not in actions['set_needs_human_review_multiple_versions']['details']
             )
 
     def test_actions_public_post_review(self):
@@ -352,15 +352,15 @@ class TestReviewHelper(TestReviewHelperBase):
             'reply',
             'comment',
         ]
+        actions = self.get_review_actions(
+            addon_status=amo.STATUS_APPROVED,
+            file_status=amo.STATUS_APPROVED,
+            content_review=True,
+        )
+        assert list(actions.keys()) == expected
         assert (
-            list(
-                self.get_review_actions(
-                    addon_status=amo.STATUS_APPROVED,
-                    file_status=amo.STATUS_APPROVED,
-                    content_review=True,
-                ).keys()
-            )
-            == expected
+            'Will also disable auto-approval'
+            in actions['set_needs_human_review_multiple_versions']['details']
         )
 
     def test_actions_content_review_non_approved_addon(self):
@@ -374,15 +374,15 @@ class TestReviewHelper(TestReviewHelperBase):
             'reply',
             'comment',
         ]
+        actions = self.get_review_actions(
+            addon_status=amo.STATUS_NOMINATED,
+            file_status=amo.STATUS_AWAITING_REVIEW,
+            content_review=True,
+        )
+        assert list(actions.keys()) == expected
         assert (
-            list(
-                self.get_review_actions(
-                    addon_status=amo.STATUS_NOMINATED,
-                    file_status=amo.STATUS_AWAITING_REVIEW,
-                    content_review=True,
-                ).keys()
-            )
-            == expected
+            'Will also disable auto-approval'
+            in actions['set_needs_human_review_multiple_versions']['details']
         )
 
     def test_actions_public_static_theme(self):
@@ -3211,7 +3211,7 @@ class TestReviewHelper(TestReviewHelperBase):
         )
         assert self.review_version.due_date
 
-    def _set_needs_human_review_multiple_versions_test(self, content_review):
+    def _check_set_needs_human_review_multiple_versions(self, content_review):
         self.setup_data(
             amo.STATUS_APPROVED,
             file_status=amo.STATUS_APPROVED,
@@ -3256,11 +3256,11 @@ class TestReviewHelper(TestReviewHelperBase):
         assert not unselected.due_date
 
     def test_set_needs_human_review_multiple_versions_code_review(self):
-        self._set_needs_human_review_multiple_versions_test(content_review=False)
+        self._check_set_needs_human_review_multiple_versions(content_review=False)
         assert not self.addon.auto_approval_disabled_until_next_approval
 
     def test_set_needs_human_review_multiple_versions_content_review(self):
-        self._set_needs_human_review_multiple_versions_test(content_review=True)
+        self._check_set_needs_human_review_multiple_versions(content_review=True)
         assert self.addon.auto_approval_disabled_until_next_approval
 
     def test_clear_pending_rejection_multiple_versions(self):

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -3211,8 +3211,12 @@ class TestReviewHelper(TestReviewHelperBase):
         )
         assert self.review_version.due_date
 
-    def test_set_needs_human_review_multiple_versions(self):
-        self.setup_data(amo.STATUS_APPROVED, file_status=amo.STATUS_APPROVED)
+    def _set_needs_human_review_multiple_versions_test(self, content_review):
+        self.setup_data(
+            amo.STATUS_APPROVED,
+            file_status=amo.STATUS_APPROVED,
+            content_review=content_review,
+        )
         selected = version_factory(addon=self.review_version.addon)
         unselected = version_factory(addon=self.review_version.addon)
         data = self.get_data().copy()
@@ -3250,6 +3254,14 @@ class TestReviewHelper(TestReviewHelperBase):
         assert not selected.human_review_date
         assert not unselected.needshumanreview_set.filter(is_active=True).exists()
         assert not unselected.due_date
+
+    def test_set_needs_human_review_multiple_versions_code_review(self):
+        self._set_needs_human_review_multiple_versions_test(content_review=False)
+        assert not self.addon.auto_approval_disabled_until_next_approval
+
+    def test_set_needs_human_review_multiple_versions_content_review(self):
+        self._set_needs_human_review_multiple_versions_test(content_review=True)
+        assert self.addon.auto_approval_disabled_until_next_approval
 
     def test_clear_pending_rejection_multiple_versions(self):
         self.grant_permission(self.user, 'Addons:Review')

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -771,6 +771,11 @@ class ReviewHelper:
             'details': (
                 'Set needs human review flag from selected versions, but '
                 "otherwise don't change the version(s) or add-on statuses."
+                + (
+                    ' Will also disable auto-approval until the next human approval.'
+                    if self.content_review
+                    else ''
+                )
             ),
             'multiple_versions': True,
             'minimal': True,

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -1486,6 +1486,13 @@ class ReviewBase:
                 version=version,
                 reason=NeedsHumanReview.REASONS.MANUALLY_SET_BY_REVIEWER,
             ).save(_no_automatic_activity_log=True)
+
+        if version and version.channel == amo.CHANNEL_LISTED and self.content_review:
+            AddonReviewerFlags.objects.update_or_create(
+                addon=self.addon,
+                defaults={'auto_approval_disabled_until_next_approval': True},
+            )
+
         # Record a single activity log.
         self.log_action(
             amo.LOG.NEEDS_HUMAN_REVIEW,


### PR DESCRIPTION
Fixes: mozilla/addons#14889

### Description

Pretty simple change as per the title.  The PR adds an extra sentence for content reviews for the set needs human review action; and sets a reviewer flag for content reviews.  (content reviews are only for listed versions)

### Testing

- open any review page for an add-on in the content review queue
- choose "set needs human review" action, choose a version, and submit with a comment
- navigate to the admin for that add-on (link in the right hand column) and scroll down to the add-on reviewer flags section to see `Auto approval disabled until next approval` set to yes

(screenshots below)
### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
