### PR TITLE
Read full input ref from json to enforce data type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,4 +271,4 @@ jobs:
       digest: ${{ needs.build.outputs.digest }}
       # If running from a manual workflow_dispatch event, use the provided input
       # If no input is given or running on pull_request event, use the default value of 14
-      splits: ${{ inputs.splits || 14 }}
+      splits: ${{ fromJson(github.event.inputs.splits) || 14 }}


### PR DESCRIPTION
Fixes: mozilla/addons#14904


### Description

<!--
Your PR will be squashed when merged so the 1st commit must contain a descriptive and concise summary of the change.
Additional details should be added in the description. If your change is simple enough to summarize in the commit, or
if it is not relevant for your PR, remove this section.
-->

### Context

Looks like github actions enforce data types on triggering a workflow, so you cannot input `banana` in the manual workflow dispatch. However, they cast all inputs to strings so even if you input `14` you end up with `'14'` and because workflows validate on trigger, triggering a workflow via `workflow_call` reads this as an invalid value.

This is kind of wacky but seems to be something that is known and should be looked into by github. For now we can workaround by reading in the value fromJson which converts it back to a number.

### Testing

This can be tested by running the workflow manually via

```bash
gh workflow run ci.yml --ref fix-inputs  
```

> NOTE: make sure to reference the branch of the PR to run the workflow from this branch

Before: https://github.com/mozilla/addons-server/actions/runs/9836302086/job/27151708455
After: https://github.com/mozilla/addons-server/actions/runs/9836394504/job/27152015889

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
