### PR TITLE
mark decision notes as safe so jinja doesn't escape them

### DIFF
--- a/src/olympia/abuse/tests/test_utils.py
+++ b/src/olympia/abuse/tests/test_utils.py
@@ -43,7 +43,7 @@ class BaseTestCinderAction:
         self.decision = CinderDecision.objects.create(
             cinder_id='ab89',
             action=DECISION_ACTIONS.AMO_APPROVE,
-            notes='extra notes',
+            notes="extra note's",
             addon=addon,
         )
         self.cinder_job = CinderJob.objects.create(
@@ -167,6 +167,7 @@ class BaseTestCinderAction:
         assert f'[ref:ab89/{self.abuse_report_auth.id}]' in mail.outbox[0].body
         assert '&quot;' not in mail.outbox[0].body
         assert '&lt;b&gt;' not in mail.outbox[0].body
+        assert '&#x27;' not in mail.outbox[0].body
         assert self.decision.notes in mail.outbox[0].body
 
     def _check_owner_email(self, mail_item, subject, snippet):
@@ -177,6 +178,7 @@ class BaseTestCinderAction:
         assert '[ref:ab89]' in mail_item.body
         assert '&quot;' not in mail_item.body
         assert '&lt;b&gt;' not in mail_item.body
+        assert '&#x27;' not in mail_item.body
         assert self.decision.notes in mail_item.body
 
     def _test_owner_takedown_email(self, subject, snippet):
@@ -198,6 +200,7 @@ class BaseTestCinderAction:
         )
         assert '&quot;' not in mail_item.body
         assert '&lt;b&gt;' not in mail_item.body
+        assert '&#x27;' not in mail_item.body
         assert self.decision.notes in mail_item.body
 
     def _test_owner_affirmation_email(self, subject):
@@ -206,6 +209,7 @@ class BaseTestCinderAction:
         assert 'right to appeal' not in mail_item.body
         notes = f'{self.decision.notes}. ' if self.decision.notes else ''
         assert f' was correct. {notes}Based on that determination' in (mail_item.body)
+        assert '&#x27;' not in mail_item.body
         if isinstance(self.decision.target, Addon):
             # Verify we used activity mail for Addon related target emails
             log_token = ActivityLogToken.objects.get()
@@ -216,6 +220,7 @@ class BaseTestCinderAction:
         assert len(mail.outbox) == 1
         self._check_owner_email(mail_item, subject, 'we have restored')
         assert 'right to appeal' not in mail_item.body
+        assert '&#x27;' not in mail_item.body
         assert self.decision.notes in mail_item.body
 
     def _test_approve_appeal_or_override(CinderActionClass):

--- a/src/olympia/abuse/tests/test_utils.py
+++ b/src/olympia/abuse/tests/test_utils.py
@@ -312,6 +312,20 @@ class BaseTestCinderAction:
             assert 'Bad policy' not in mail.outbox[idx].body  # policy name
             assert 'Parent' not in mail.outbox[idx].body  # parent policy text
 
+    def test_email_content_not_escaped(self):
+        unsafe_str = '<script>jar=window.triggerExploit();"</script>'
+        self.decision.update(notes=unsafe_str)
+        action = self.ActionClass(self.decision)
+        action.notify_owners()
+        assert unsafe_str in mail.outbox[0].body
+
+        action = CinderActionApproveNoAction(self.decision)
+        mail.outbox.clear()
+        action.notify_reporters(
+            reporter_abuse_reports=[self.abuse_report_auth], is_appeal=True
+        )
+        assert unsafe_str in mail.outbox[0].body
+
 
 class TestCinderActionUser(BaseTestCinderAction, TestCase):
     ActionClass = CinderActionBanUser

--- a/src/olympia/abuse/utils.py
+++ b/src/olympia/abuse/utils.py
@@ -183,7 +183,7 @@ class CinderAction:
                     'type': self.get_target_type(),
                     'SITE_URL': settings.SITE_URL,
                 }
-                if self.decision.cinder_job.is_appeal:
+                if is_appeal:
                     # it's a plain-text email, and text from our own reveiewers, so
                     # we're safe - and we don't want ' or other charactors rendered with
                     # html escaping.

--- a/src/olympia/abuse/utils.py
+++ b/src/olympia/abuse/utils.py
@@ -96,7 +96,9 @@ class CinderAction:
         reference_id = f'ref:{self.decision.get_reference_id()}'
         context_dict = {
             'is_third_party_initiated': self.decision.is_third_party_initiated,
-            'manual_reasoning_text': self.decision.notes or '',
+            # it's a plain-text email, and text from our own reveiewers, so we're safe
+            # - and we don't want ' or other charactors rendered with html escaping.
+            'manual_reasoning_text': mark_safe(self.decision.notes or ''),
             # Auto-escaping is already disabled above as we're dealing with an
             # email but the target name could have triggered lazy escaping when
             # it was generated so it needs special treatment to avoid it.
@@ -182,7 +184,12 @@ class CinderAction:
                     'SITE_URL': settings.SITE_URL,
                 }
                 if self.decision.cinder_job.is_appeal:
-                    context_dict['manual_reasoning_text'] = self.decision.notes or ''
+                    # it's a plain-text email, and text from our own reveiewers, so
+                    # we're safe - and we don't want ' or other charactors rendered with
+                    # html escaping.
+                    context_dict['manual_reasoning_text'] = mark_safe(
+                        self.decision.notes or ''
+                    )
                 if self.decision.can_be_appealed(
                     is_reporter=True, abuse_report=abuse_report
                 ):


### PR DESCRIPTION
Fixes: mozilla/addons#14901

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Context

See issue; QA identified that `'` (and other characters) from the decision text are escaped with html entity codes in the emails.  It's rendered into a plain text email so it doesn't make sense to do that.  (And even if it wasn't, the content comes from ~inside the building~ our own reviewers and moderators, so should be regarded as safe anyway)

### Testing

Take any reviewer action in the reviewer tools and include a comment with it that has `'`.  (essentially every reviewer tools action with the comment box, apart from Comment, which doesn't send anything out).  Then check the email in fake mail in django admin.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.