### PR TITLE
Add event/workflow context to concurrency for all workflows

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -47,7 +47,7 @@ on:
         description: The GCP workload to use for identity management
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.inputs.push }}
+  group: ${{ github.workflow }}-${{ github.event_name}}-${{ github.ref}}-${{ toJson(inputs) }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -28,7 +28,7 @@ on:
         required: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name}}-${{ github.ref}}-${{ toJSON(inputs) }}
+  group: ${{ github.workflow }}-${{ github.event_name}}-${{ github.ref}}-${{ toJson(inputs) }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/_test_main.yml
+++ b/.github/workflows/_test_main.yml
@@ -39,7 +39,7 @@ on:
         default: 14
 
 concurrency:
-  group: ${{ github.event_name}}-${{ github.ref}}-${{ toJSON(inputs) }}
+  group: ${{ github.workflow }}-${{ github.event_name}}-${{ github.ref}}-${{ toJson(inputs) }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ on:
     types: [published]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name}}-${{ github.ref}}
+  group: ${{ github.workflow }}-${{ github.event_name}}-${{ github.ref}}-${{ toJson(inputs) }}
   cancel-in-progress: true
 
 env:

--- a/docs/topics/development/github_actions.md
+++ b/docs/topics/development/github_actions.md
@@ -45,7 +45,7 @@ on:
     - master
 
 concurrency:
-  group: <some group>
+  group: ${{ github.workflow }}-${{ github.event_name}}-${{ github.ref}}-${{ toJson(inputs) }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Follow up to: https://github.com/mozilla/addons-server/pull/22455

### Description

Reusable workflows need to account for the workflow/event they are being triggered by when determining concrurrency.

### Context

Without this, if two workflow triggers a reusable workflow, one could interupt the other.

E.G: https://github.com/mozilla/addons-server/actions/runs/9860932753

### Testing

When pushing this PR, I also trigger CI via workflow dispatch, these two workflows should run in parallel. Screenshot proves this is true.

We have a `pull_request` and a `workflow_dispatch` running on the same ref.

<img width="1330" alt="Screenshot 2024-07-09 at 18 54 57" src="https://github.com/mozilla/addons-server/assets/19595165/9d172513-ec93-490e-8efe-f90caa3beeb9">

Pushing the PR again, cancels the `pull_request` run but not the `workflow_dispatch` run, proving the concurrency model works.

<img width="1349" alt="Screenshot 2024-07-09 at 18 55 35" src="https://github.com/mozilla/addons-server/assets/19595165/430d1379-fcbb-48e2-a8f2-b95d955783bf">

Additionally, opening another PR with the same commit runs concurrently.

<img width="1347" alt="Screenshot 2024-07-09 at 18 59 05" src="https://github.com/mozilla/addons-server/assets/19595165/f546c788-782a-481f-b3cf-537691cfa1b8">

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [X] Add before and after screenshots (Only for changes that impact the UI).
- [X] Add or update relevant [docs](../docs/) reflecting the changes made.
