### PR TITLE
Avoid extra queries around banned user content in user admin

### DIFF
--- a/src/olympia/users/admin.py
+++ b/src/olympia/users/admin.py
@@ -49,6 +49,7 @@ from .models import (
 class GroupUserInline(admin.TabularInline):
     model = GroupUser
     raw_id_fields = ('user',)
+    extra = 0
 
 
 class BannedUserContentInline(admin.TabularInline):
@@ -70,10 +71,21 @@ class BannedUserContentInline(admin.TabularInline):
         'picture_link',
     )
     can_delete = False
+    extra = 0
+
+    def has_add_permission(self, request, obj):
+        # Instances of this model shouldn't be added through the admin.
+        # The combination of this and extra = 0 means Django won't try to
+        # pre-populate empty instances, which in turns avoids useless queries
+        # that would be caused by banned_content_link().
+        return False
 
     def banned_content_link(self, obj, related_class):
         return related_content_link(
-            obj, related_class, 'bannedusercontent', related_manager='unfiltered'
+            obj,
+            related_class,
+            'bannedusercontent',
+            related_manager='unfiltered',
         )
 
     def collections_link(self, obj):


### PR DESCRIPTION
Before this change these queries would happen all the time: we display counts of disabled content on ban for each type, that's 4 queries, and for every user, even not banned, Django would execute them once to display the hidden instance used to create additional instances when the user adds one, and another time for the existing default instance displayed because of the `extra` bit.

Because those queries do JOINs _and_ there isn't even an actual banned_user_content row to find, there were extra slow on top of being useless.

Preventing adds (it's an internal model anyway that admins should look at, but not manually add) and removing the extra default instance fixes the problem.

Fixes: https://github.com/mozilla/addons/issues/2011

### Testing

This wasn't really noticeable locally (the queries would be fast enough on most environments that don't have a lot of data), but the unit test included demonstrate the extra queries.
