### PR TITLE
Revert "disable auto-approval when setting needs human review in a content review"

### DIFF
--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -775,11 +775,6 @@ class ReviewHelper:
             'details': (
                 'Set needs human review flag from selected versions, but '
                 "otherwise don't change the version(s) or add-on statuses."
-                + (
-                    ' Will also disable auto-approval until the next human approval.'
-                    if self.content_review
-                    else ''
-                )
             ),
             'multiple_versions': True,
             'minimal': True,
@@ -1495,13 +1490,6 @@ class ReviewBase:
                 version=version,
                 reason=NeedsHumanReview.REASONS.MANUALLY_SET_BY_REVIEWER,
             ).save(_no_automatic_activity_log=True)
-
-        if version and version.channel == amo.CHANNEL_LISTED and self.content_review:
-            AddonReviewerFlags.objects.update_or_create(
-                addon=self.addon,
-                defaults={'auto_approval_disabled_until_next_approval': True},
-            )
-
         # Record a single activity log.
         self.log_action(
             amo.LOG.NEEDS_HUMAN_REVIEW,


### PR DESCRIPTION
This completely reverts commit 15e4bd0b8ee64da8384a5f15b281aa1af734e12c (#22443), which was the fix for mozilla/addons#14889