### PR TITLE
consistently use devhub url as the target_url if no public listing

### DIFF
--- a/src/olympia/abuse/templates/abuse/emails/CinderActionApproveInitialDecision.txt
+++ b/src/olympia/abuse/templates/abuse/emails/CinderActionApproveInitialDecision.txt
@@ -7,8 +7,8 @@ Your {{ type }} has been automatically screened and tentatively approved. It is 
 
 Your add-on can be subject to human review at any time. Reviewers may determine that it requires changes or should be removed. If that occurs, you will receive a separate notification with details and next steps.
 {% endif %}
-Approved versions: {{ version_list }}
-
+{% if version_list %}Approved versions: {{ version_list }}
+{% endif %}
 {% if manual_reasoning_text %}Comments: {{ manual_reasoning_text }}.{% endif %}
 
 Thank you.

--- a/src/olympia/abuse/templates/abuse/emails/CinderActionDisableAddon.txt
+++ b/src/olympia/abuse/templates/abuse/emails/CinderActionDisableAddon.txt
@@ -4,5 +4,5 @@ Your {{ type }} {{ name }} was manually reviewed by the Mozilla Add-ons team {% 
 Our review found that your content violates the following Mozilla policy or policies:
 {% include 'abuse/emails/includes/policies.txt' %}
 
-Based on that finding, your {{ type }} has been permanently disabled on {{ target_url }} and is no longer available for download from Mozilla Add-ons, anywhere in the world. Users who have previously installed your add-on will be able to continue using it.
+Based on that finding, your {{ type }} has been permanently disabled on {{ target_url }} and is no longer available for download from Mozilla Add-ons, anywhere in the world. {% if is_addon_being_blocked %}In addition, users who have previously installed the add-on won't be able to continue using it.{% else %}Users who have previously installed your add-on will be able to continue using it.{% endif %}
 {% endblock %}

--- a/src/olympia/abuse/templates/abuse/emails/CinderActionRejectVersion.txt
+++ b/src/olympia/abuse/templates/abuse/emails/CinderActionRejectVersion.txt
@@ -6,7 +6,7 @@ Our review found that your content violates the following Mozilla policy or poli
 
 Affected versions: {{ version_list }}
 
-Based on that finding, those versions of your {{ type }} have been disabled on {{ target_url }} and are no longer available for download from Mozilla Add-ons, anywhere in the world. {% if is_addon_being_blocked %}In addition, users who have previously installed those versions won’t be able to continue using them.{% else %}Users who have previously installed those versions will be able to continue using them.{% endif %}
+Based on that finding, those versions of your {{ type }} have been disabled on {{ target_url }} and are no longer available for download from Mozilla Add-ons, anywhere in the world. {% if is_addon_being_blocked %}In addition, users who have previously installed those versions won't be able to continue using them.{% else %}Users who have previously installed those versions will be able to continue using them.{% endif %}
 
 {% if not is_addon_disabled %}You may upload a new version which addresses the policy violation(s).{% endif %}
 {% endblock %}

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -2490,7 +2490,7 @@ class TestCinderDecision(TestCase):
             not in mail.outbox[0].body
         )
         assert (
-            'users who have previously installed those versions won’t be able to'
+            "users who have previously installed those versions won't be able to"
             in mail.outbox[0].body
         )
         assert (
@@ -2516,7 +2516,7 @@ class TestCinderDecision(TestCase):
             not in mail.outbox[0].body
         )
         assert (
-            'users who have previously installed those versions won’t be able to'
+            "users who have previously installed those versions won't be able to"
             in mail.outbox[0].body
         )
         assert (
@@ -2538,7 +2538,7 @@ class TestCinderDecision(TestCase):
             in mail.outbox[0].body
         )
         assert (
-            'users who have previously installed those versions won’t be able to'
+            "users who have previously installed those versions won't be able to"
             not in mail.outbox[0].body
         )
         assert (

--- a/src/olympia/abuse/utils.py
+++ b/src/olympia/abuse/utils.py
@@ -93,6 +93,13 @@ class CinderAction:
         template = loader.get_template(self.owner_template_path)
         target_name = self.get_target_name()
         reference_id = f'ref:{self.decision.get_reference_id()}'
+        # override target_url to devhub if there is no public listing
+        target_url = (
+            self.target.get_absolute_url()
+            if not isinstance(self.target, Addon) or self.target.get_url_path()
+            else absolutify(reverse('devhub.addons.versions', args=[self.target.id]))
+        )
+
         context_dict = {
             'is_third_party_initiated': self.decision.is_third_party_initiated,
             # It's a plain-text email so we're safe to include comments without escaping
@@ -103,7 +110,7 @@ class CinderAction:
             'policy_document_url': POLICY_DOCUMENT_URL,
             'reference_id': reference_id,
             'target': self.target,
-            'target_url': absolutify(self.target.get_url_path()),
+            'target_url': target_url,
             'type': self.get_target_type(),
             'SITE_URL': settings.SITE_URL,
             **(extra_context or {}),


### PR DESCRIPTION
Fixes: mozilla/addons#1765 and fixes mozilla/addons#1766

### Description

Anytime that `Addon.get_url_path()` returns an empty string, indicating the listing url is non-public, switch it out for the relevant devhub url so the developer can unambiguously see what add-on we're referencing to, and potentially take some action.  Plus some drive-by template fixes.

### Context

We were previously just considering unlisted, when we swapped out the public url for devhub, but add-ons that are disabled, or otherwise have no publicly available version, also need to use the devhub url instead.

### Testing

- reject an unlisted version and see the devhub url in the email (and no public url)
- disable an add-on with listed versions and see the devhub url in the email (and no public url)
- re-enable an add-on with a listed version and see the public listing url in the email (and no devhub url)

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
