### PR TITLE
Close reports for already removed content

### DIFF
--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -174,7 +174,7 @@ class CinderJob(ModelBase):
             addon_version_string=abuse_report.addon_version,
             resolved_in_reviewer_tools=False,
         )
-        decision.id = entity_helper.create_decision(
+        decision.cinder_id = entity_helper.create_decision(
             action=decision.action.api_value,
             reasoning='',
             policy_uuids=(),

--- a/src/olympia/abuse/templates/abuse/emails/reporter_disabled_ignore.txt
+++ b/src/olympia/abuse/templates/abuse/emails/reporter_disabled_ignore.txt
@@ -1,0 +1,9 @@
+Hello,
+
+Thank you for your report about {{ name }}, at {{ target_url }} that appeared to violate our policies..
+
+As this content has already been removed before your report was reviewed, your report will not be processed.
+[{{ reference_id }}]
+--
+Mozilla Add-ons Team
+{{ SITE_URL }}

--- a/src/olympia/abuse/tests/test_cinder.py
+++ b/src/olympia/abuse/tests/test_cinder.py
@@ -1271,10 +1271,11 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
     def test_create_decision(self):
         target = self._create_dummy_target()
 
+        cinder_id = uuid.uuid4().hex
         responses.add(
             responses.POST,
             f'{settings.CINDER_SERVER_URL}create_decision',
-            json={'uuid': uuid.uuid4().hex},
+            json={'uuid': cinder_id},
             status=201,
         )
         responses.add(
@@ -1290,7 +1291,7 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
                 reasoning='some review text',
                 policy_uuids=['12345678'],
             )
-            == '123'
+            == cinder_id
         )
         request = responses.calls[0].request
         request_body = json.loads(request.body)
@@ -1311,11 +1312,12 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
     def test_create_job_decision(self):
         target = self._create_dummy_target()
         job = CinderJob.objects.create(job_id='1234')
+        cinder_id = uuid.uuid4().hex
 
         responses.add(
             responses.POST,
             f'{settings.CINDER_SERVER_URL}jobs/{job.job_id}/decision',
-            json={'uuid': uuid.uuid4().hex},
+            json={'uuid': cinder_id},
             status=201,
         )
         responses.add(
@@ -1332,7 +1334,7 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
                 reasoning='some review text',
                 policy_uuids=['12345678'],
             )
-            == '123'
+            == cinder_id
         )
         request = responses.calls[0].request
         request_body = json.loads(request.body)
@@ -1353,7 +1355,7 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
 
     def test_close_job(self):
         target = self._create_dummy_target()
-        job_id = '123'
+        job_id = uuid.uuid4().hex
         responses.add(
             responses.POST,
             f'{settings.CINDER_SERVER_URL}jobs/{job_id}/cancel',

--- a/src/olympia/abuse/tests/test_cinder.py
+++ b/src/olympia/abuse/tests/test_cinder.py
@@ -1,6 +1,7 @@
 import json
 import os.path
 import random
+import uuid
 from unittest import mock
 
 from django.conf import settings
@@ -1273,7 +1274,7 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
         responses.add(
             responses.POST,
             f'{settings.CINDER_SERVER_URL}create_decision',
-            json={'uuid': '123'},
+            json={'uuid': uuid.uuid4().hex},
             status=201,
         )
         responses.add(
@@ -1314,7 +1315,7 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
         responses.add(
             responses.POST,
             f'{settings.CINDER_SERVER_URL}jobs/{job.job_id}/decision',
-            json={'uuid': '123'},
+            json={'uuid': uuid.uuid4().hex},
             status=201,
         )
         responses.add(

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 from datetime import datetime
 from unittest import mock
 from urllib import parse
@@ -798,7 +799,7 @@ class TestCinderJob(TestCase):
         responses.add(
             responses.POST,
             f'{settings.CINDER_SERVER_URL}create_decision',
-            json={'uuid': '123'},
+            json={'uuid': uuid.uuid4().hex},
             status=201,
         )
         CinderJob.report(abuse_report)
@@ -1024,7 +1025,7 @@ class TestCinderJob(TestCase):
         responses.add(
             responses.POST,
             f'{settings.CINDER_SERVER_URL}jobs/{cinder_job.job_id}/decision',
-            json={'uuid': '123'},
+            json={'uuid': uuid.uuid4().hex},
             status=201,
         )
         policies = [CinderPolicy.objects.create(name='policy', uuid='12345678')]
@@ -1097,7 +1098,7 @@ class TestCinderJob(TestCase):
         responses.add(
             responses.POST,
             f'{settings.CINDER_SERVER_URL}jobs/{cinder_job.job_id}/decision',
-            json={'uuid': '123'},
+            json={'uuid': uuid.uuid4().hex},
             status=201,
         )
         log_entry = ActivityLog.objects.create(
@@ -1170,7 +1171,7 @@ class TestCinderJob(TestCase):
         responses.add(
             responses.POST,
             f'{settings.CINDER_SERVER_URL}jobs/{appeal_job.job_id}/decision',
-            json={'uuid': '123'},
+            json={'uuid': uuid.uuid4().hex},
             status=201,
         )
         policies = [CinderPolicy.objects.create(name='policy', uuid='12345678')]
@@ -1240,7 +1241,7 @@ class TestCinderJob(TestCase):
         responses.add(
             responses.POST,
             f'{settings.CINDER_SERVER_URL}jobs/{appeal_job.job_id}/decision',
-            json={'uuid': '123'},
+            json={'uuid': uuid.uuid4().hex},
             status=201,
         )
         policies = [CinderPolicy.objects.create(name='policy', uuid='12345678')]
@@ -1306,7 +1307,7 @@ class TestCinderJob(TestCase):
         responses.add(
             responses.POST,
             f'{settings.CINDER_SERVER_URL}jobs/{cinder_job.job_id}/decision',
-            json={'uuid': '123'},
+            json={'uuid': uuid.uuid4().hex},
             status=201,
         )
         policies = [CinderPolicy.objects.create(name='policy', uuid='12345678')]
@@ -1824,7 +1825,9 @@ class TestCinderDecision(TestCase):
         )
         assert not current_decision.is_third_party_initiated
 
-        current_job = CinderJob.objects.create(decision=current_decision, job_id='123')
+        current_job = CinderJob.objects.create(
+            decision=current_decision, job_id=uuid.uuid4().hex
+        )
         current_decision.refresh_from_db()
         assert not current_decision.is_third_party_initiated
 
@@ -1838,7 +1841,9 @@ class TestCinderDecision(TestCase):
             action=DECISION_ACTIONS.AMO_DISABLE_ADDON,
             addon=addon,
         )
-        current_job = CinderJob.objects.create(decision=current_decision, job_id='123')
+        current_job = CinderJob.objects.create(
+            decision=current_decision, job_id=uuid.uuid4().hex
+        )
         original_job = CinderJob.objects.create(
             job_id='456',
             decision=CinderDecision.objects.create(
@@ -2304,14 +2309,14 @@ class TestCinderDecision(TestCase):
         create_decision_response = responses.add(
             responses.POST,
             f'{settings.CINDER_SERVER_URL}create_decision',
-            json={'uuid': '123'},
+            json={'uuid': uuid.uuid4().hex},
             status=201,
         )
         cinder_job_id = (job := getattr(decision, 'cinder_job', None)) and job.job_id
         create_job_decision_response = responses.add(
             responses.POST,
             f'{settings.CINDER_SERVER_URL}jobs/{cinder_job_id}/decision',
-            json={'uuid': '123'},
+            json={'uuid': uuid.uuid4().hex},
             status=201,
         )
         policies = [

--- a/src/olympia/abuse/tests/test_tasks.py
+++ b/src/olympia/abuse/tests/test_tasks.py
@@ -623,7 +623,7 @@ def test_resolve_job_in_cinder(statsd_incr_mock):
     responses.add(
         responses.POST,
         f'{settings.CINDER_SERVER_URL}jobs/{cinder_job.job_id}/decision',
-        json={'uuid': '123'},
+        json={'uuid': uuid.uuid4().hex},
         status=201,
     )
     statsd_incr_mock.reset_mock()
@@ -668,7 +668,7 @@ def test_resolve_job_in_cinder_exception(statsd_incr_mock):
     responses.add(
         responses.POST,
         f'{settings.CINDER_SERVER_URL}jobs/999/decision',
-        json={'uuid': '123'},
+        json={'uuid': uuid.uuid4().hex},
         status=500,
     )
     log_entry = ActivityLog.objects.create(
@@ -699,7 +699,7 @@ def test_notify_addon_decision_to_cinder(statsd_incr_mock):
     responses.add(
         responses.POST,
         f'{settings.CINDER_SERVER_URL}create_decision',
-        json={'uuid': '123'},
+        json={'uuid': uuid.uuid4().hex},
         status=201,
     )
     addon = addon_factory()
@@ -739,7 +739,7 @@ def test_notify_addon_decision_to_cinder_exception(statsd_incr_mock):
     responses.add(
         responses.POST,
         f'{settings.CINDER_SERVER_URL}create_decision',
-        json={'uuid': '123'},
+        json={'uuid': uuid.uuid4().hex},
         status=500,
     )
     log_entry = ActivityLog.objects.create(

--- a/src/olympia/abuse/utils.py
+++ b/src/olympia/abuse/utils.py
@@ -434,5 +434,11 @@ class CinderActionIgnore(AnyTargetMixin, NoActionMixin, CinderAction):
     # no appeal template because no appeals possible
 
 
+class CinderActionAlreadyRemoved(AnyTargetMixin, NoActionMixin, CinderAction):
+    description = 'Content is already disabled or deleted, so no action'
+    reporter_template_path = 'abuse/emails/reporter_disabled_ignore.txt'
+    # no appeal template because no appeals possible
+
+
 class CinderActionNotImplemented(NoActionMixin, CinderAction):
     pass

--- a/src/olympia/constants/abuse.py
+++ b/src/olympia/constants/abuse.py
@@ -20,6 +20,7 @@ DECISION_ACTIONS = APIChoicesWithDash(
     # Approving new versions is not an available action for moderators in cinder
     ('AMO_APPROVE_VERSION', 10, 'Approved (new version approval)'),
     ('AMO_IGNORE', 11, 'Invalid report, so ignored'),
+    ('AMO_CLOSED_NO_ACTION', 12, 'Content already removed (no action)'),
 )
 DECISION_ACTIONS.add_subset(
     'APPEALABLE_BY_AUTHOR',

--- a/src/olympia/reviewers/tests/test_commands.py
+++ b/src/olympia/reviewers/tests/test_commands.py
@@ -1427,7 +1427,7 @@ class TestAutoReject(AutoRejectTestsMixin, TestCase):
         responses.add(
             responses.POST,
             f'{settings.CINDER_SERVER_URL}jobs/2/decision',
-            json={'uuid': '123'},
+            json={'uuid': uuid.uuid4().hex},
             status=201,
         )
         policies = [CinderPolicy.objects.create(name='policy', uuid='12345678')]
@@ -1472,7 +1472,7 @@ class TestAutoReject(AutoRejectTestsMixin, TestCase):
         responses.add(
             responses.POST,
             f'{settings.CINDER_SERVER_URL}jobs/2/decision',
-            json={'uuid': '123'},
+            json={'uuid': uuid.uuid4().hex},
             status=201,
         )
         policies = [CinderPolicy.objects.create(name='policy', uuid='12345678')]

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -1,6 +1,7 @@
 import json
 import os
 import time
+import uuid
 from collections import OrderedDict
 from datetime import datetime, timedelta
 from unittest import mock
@@ -4439,7 +4440,7 @@ class TestReview(ReviewBase):
         responses.add(
             responses.POST,
             f'{settings.CINDER_SERVER_URL}create_decision',
-            json={'uuid': '123'},
+            json={'uuid': uuid.uuid4().hex},
             status=201,
         )
         reason = ReviewActionReason.objects.create(
@@ -4476,7 +4477,7 @@ class TestReview(ReviewBase):
         responses.add(
             responses.POST,
             f'{settings.CINDER_SERVER_URL}create_decision',
-            json={'uuid': '123'},
+            json={'uuid': uuid.uuid4().hex},
             status=201,
         )
         reason = ReviewActionReason.objects.create(
@@ -4517,7 +4518,7 @@ class TestReview(ReviewBase):
         responses.add(
             responses.POST,
             f'{settings.CINDER_SERVER_URL}create_decision',
-            json={'uuid': '123'},
+            json={'uuid': uuid.uuid4().hex},
             status=201,
         )
         reason = ReviewActionReason.objects.create(


### PR DESCRIPTION
Fixes: mozilla/addons#14928

### Description

If the content is already removed (either by us, or by the author) when a report is received auto-handle it.

### Context

It's possible to report abuse for content that is already disabled, deleted, or banned on AMO (maybe using an old link; maybe because it's an add-on they have installed before it was disabled), but we then have no other action we can take - it's already gone - so rather than wasting the effort of reviewing the report, we will instead auto-"close" it.  Not actually close the report - because we don't close abuse reports - but not opening a job, and instead sending an email immediately and log a decision for record keeping.

### Testing

- Remove some content
  - for an add-on, either set to status disabled, or delete it
  - for a user, ban or delete it
  - for a collection or rating delete it.
- Report that content via frontend
- See you get an email immediately saying we didn't process the report because it was already removed (look in fakemail)
- See a decision is sent to cinder as `amo-closed-no-action` (needs cinder API integration set up)

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
