### PR TITLE
Allow EULA/Privacy policy to be edited through the API

### DIFF
--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -894,6 +894,23 @@ This endpoint allows you to fetch an add-on EULA and privacy policy.
     :>json object|null privacy_policy: The text of the Privacy Policy, if present (See :ref:`translated fields <api-overview-translations>`).
 
 
+----------------------------
+EULA and Privacy Policy Edit
+----------------------------
+
+.. _addon-eula-policy-edit:
+
+This endpoint allows an add-on's EULA and privacy policy to be edited.
+
+    .. note::
+        This API requires :doc:`authentication <auth>`, and for the user to be an author of the add-on.
+
+.. http:patch:: /api/v5/addons/addon/(int:id|string:slug|string:guid)/eula_policy/
+
+    :<json object|null eula: The EULA text (See :ref:`translated fields <api-overview-translations>`).
+    :<json object|null privacy_policy: The privacy policy text (See :ref:`translated fields <api-overview-translations>`).
+
+
 --------------
 Language Tools
 --------------

--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -471,6 +471,7 @@ These are `v5` specific changes - `v4` changes apply also.
 * 2023-12-07: added ``lang`` parameter to all /abuse/report/ endpoints. https://github.com/mozilla/addons-server/issues/21529
 * 2024-06-20: added ``illegal_category`` parameter to all /abuse/report/ endpoints. https://github.com/mozilla/addons/issues/14870
 * 2024-06-20: added ``illegal_subcategory`` parameter to all /abuse/report/ endpoints. https://github.com/mozilla/addons/issues/14875
+* 2024-08-08: added support for writing to add-on eula_policy endpoint. https://github.com/mozilla/addons/issues/14927
 
 .. _`#11380`: https://github.com/mozilla/addons-server/issues/11380/
 .. _`#11379`: https://github.com/mozilla/addons-server/issues/11379/

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -5104,7 +5104,7 @@ class TestAddonViewSetEulaPolicy(TestCase):
                 },
             },
         )
-        assert response.status_code == 403
+        assert response.status_code == 405
 
     def test_update_anonymous(self):
         response = self.client.patch(
@@ -5185,23 +5185,7 @@ class TestAddonViewSetEulaPolicy(TestCase):
                 },
             },
         )
-        assert response.status_code == 200
-        data = json.loads(force_str(response.content))
-        assert list(data.keys()) == ['eula', 'privacy_policy']
-        assert data['eula'] == {
-            'en-US': 'My Updated Add-on EULA in English',
-            'fr': 'Mes Conditions générales d’utilisation',
-        }
-        assert data['privacy_policy'] == {
-            'en-US': 'My privacy policy',
-        }
-        self.addon.reload()
-        assert str(self.addon.eula) == 'My Updated Add-on EULA in English'
-        assert str(self.addon.privacy_policy) == 'My privacy policy'
-        with self.activate('fr'):
-            self.addon = Addon.objects.get(pk=self.addon.pk)
-            assert str(self.addon.eula) == 'Mes Conditions générales d’utilisation'
-            assert str(self.addon.privacy_policy) == 'My privacy policy'
+        assert response.status_code == 405
 
     def test_update_something_else(self):
         assert self.addon.summary

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -346,22 +346,19 @@ class AddonViewSet(
 
     @action(
         detail=True,
-        methods=['get', 'patch', 'put'],
+        methods=['get', 'patch'],
         serializer_class=AddonEulaPolicySerializer,
+        # For this action, developers use the same serializer - it only
+        # contains eula/privacy policy.
+        serializer_class_for_developers=AddonEulaPolicySerializer,
     )
     def eula_policy(self, request, pk=None):
         kwargs = {}
         if request.method in SAFE_METHODS:
             method = self.retrieve
         else:
-            kwargs['partial'] = request.method == 'PATCH'
-            # For writes, use DRF's base update method - not our own overridden
-            # below, as it handles some specifics about add-on creation via PUT
-            # that we don't care about here.
-            method = super().update
-            # For this action, developers use the same serializer - it only
-            # contains eula/privacy policy.
-            self.serializer_class_for_developers = self.serializer_class
+            kwargs['partial'] = True
+            method = self.update
         return method(request, **kwargs)
 
     @action(detail=True)


### PR DESCRIPTION
Fixes mozilla/addons#14927

### Context

We have a separate endpoint for EULA/Privacy policy but it didn't allow writing, this change fixes that.

### Testing

Unit tests should be enough but you can also call the endpoint by following the updated docs in this change.