### PR TITLE
Bypass checks about remaining listed/owner authors in pending authors…

### DIFF
--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -904,6 +904,18 @@ class AddonPendingAuthorSerializer(AddonAuthorSerializer):
         writeable_fields = ('addon', 'user_id', 'listed', 'role')
         read_only_fields = tuple(set(fields) - set(writeable_fields))
 
+    def validate_role(self, value):
+        # We inherit from AddonAuthorSerializer but the check it does to ensure
+        # a owner is left doesn't make sense here - we are only inviting
+        # someone new.
+        return value
+
+    def validate_listed(self, value):
+        # We inherit from AddonAuthorSerializer but the check it does to ensure
+        # a owner is left doesn't make sense here - we are only inviting
+        # someone new.
+        return value
+
     def validate_user_id(self, value):
         try:
             user = UserProfile.objects.get(id=value)


### PR DESCRIPTION
… API

This fixes an intermittent test error, because the methods we're overriding check AddonUser against the instance id, but the instance id in that case is not an AddonUser, it's an AddonUserPendingConfirmation.

Fixes: mozilla/addons#14933

Example of the test failing in CI without that change https://github.com/mozilla/addons-server/actions/runs/10162196826/job/28104173268?pr=22522