### PR TITLE
don't try to resolve an already closed job in cinder

### DIFF
--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -1114,7 +1114,9 @@ class CinderDecision(ModelBase):
                 'reasoning': self.notes,
                 'policy_uuids': [policy.uuid for policy in policies],
             }
-            if cinder_job := getattr(self, 'cinder_job', None):
+            if not overriden_action and (
+                cinder_job := getattr(self, 'cinder_job', None)
+            ):
                 decision_cinder_id = entity_helper.create_job_decision(
                     job_id=cinder_job.job_id, **create_decision_kw
                 )


### PR DESCRIPTION
Fixes: mozilla/addons#14906 ...?

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

We've not gotten an answer from the cinder developers why we're getting a 500 error with their product, but we can assume from the STR it's related to resolving a job that cinder regards as already resolved (in the issue, resolved as "escalated to AMO").  So this patch works around that (assumed) problem by calling a different endpoint, to make a decision on the entity (Addon) instead.

### Context

Previously we only had the /create_decision endpoint, but on our request a /jobs/xxx/decision endpoint was added, which allows a job to be closed with a decision (like the cinder web UI allows).  If there is a limitation with using this endpoint, it's not documented, and not handled (e.g. with a 400) but to prevent this issue from being a blocker to re-enabling moderation we have to work around it on our side.

### Testing

This is difficult to fully test because it relies on an escalation from cinder to a webhook, but you can fake it by:
- report an abuse report that would be handled in cinder (legal, etc)
- resolve it with an escalation to AMO in cinder
- use django shell to create a CinderDecision attached to the CinderJob with the action of AMO_ESCALATE (missing a lot of complexity and tinkering here)
- then open up the review page for that addon in the reviewer tools (the NHR won't be there if you manually create the CinderDecision)
- and make a decision on the CinderJob in the reviewer tools.
- See the email went out to the developer, and the job is now not showing in the reviewer tools.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [ ] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
