### PR TITLE
Unify themes reviewers queue into a single queue

### DIFF
--- a/src/olympia/reviewers/templatetags/jinja_helpers.py
+++ b/src/olympia/reviewers/templatetags/jinja_helpers.py
@@ -22,8 +22,7 @@ def queue_tabnav(context, reviewer_tables_registry):
     for queue in (
         'extension',
         'mad',
-        'theme_nominated',
-        'theme_pending',
+        'theme',
         'moderated',
         'content_review',
         'pending_rejection',

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -1759,6 +1759,18 @@ class TestThemeQueue(QueueTest):
         self.grant_permission(self.user, 'Addons:Review')
         self._test_results()
 
+    def test_redirects_old_urls(self):
+        self.assertRedirects(
+            self.client.get('/en-US/reviewers/queue/theme_new'),
+            self.url,
+            status_code=301,
+        )
+        self.assertRedirects(
+            self.client.get('/en-US/reviewers/queue/theme_updates'),
+            self.url,
+            status_code=301,
+        )
+
 
 class TestModeratedQueue(QueueTest):
     fixtures = ['base/users', 'ratings/dev-reply']

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -923,7 +923,7 @@ class TestDashboard(TestCase):
         ]
         links = [link.attrib['href'] for link in doc('.dashboard a')]
         assert links == expected_links
-        assert doc('.dashboard a')[0].text == 'Manual Review (3)'
+        assert doc('.dashboard a')[0].text == 'Awaiting Review (3)'
 
     def test_legacy_reviewer_and_ratings_moderator(self):
         # Grant user the permission to see both the legacy add-ons and the

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -735,7 +735,7 @@ class TestDashboard(TestCase):
         # content review
         assert doc('.dashboard a')[4].text == 'Content Review (7)'
         # themes
-        assert doc('.dashboard a')[5].text == 'Manual Review (2)'
+        assert doc('.dashboard a')[5].text == 'Awaiting Review (2)'
         # user ratings moderation
         assert doc('.dashboard a')[8].text == 'Ratings Awaiting Moderation (1)'
         # admin tools

--- a/src/olympia/reviewers/urls.py
+++ b/src/olympia/reviewers/urls.py
@@ -26,10 +26,12 @@ urlpatterns = (
     ),
     re_path(r'^queue/', include(queue_urls())),
     re_path(
-        r'^queue/theme_new$', lambda request: redirect('reviewers.queue_theme', permanent=True)
+        r'^queue/theme_new$',
+        lambda request: redirect('reviewers.queue_theme', permanent=True),
     ),
     re_path(
-        r'^queue/theme_updates$', lambda request: redirect('reviewers.queue_theme', permanent=True)
+        r'^queue/theme_updates$',
+        lambda request: redirect('reviewers.queue_theme', permanent=True),
     ),
     re_path(
         r'^moderationlog$',

--- a/src/olympia/reviewers/urls.py
+++ b/src/olympia/reviewers/urls.py
@@ -26,6 +26,12 @@ urlpatterns = (
     ),
     re_path(r'^queue/', include(queue_urls())),
     re_path(
+        r'^queue/theme_new$', lambda request: redirect('reviewers.queue_theme', permanent=True)
+    ),
+    re_path(
+        r'^queue/theme_updates$', lambda request: redirect('reviewers.queue_theme', permanent=True)
+    ),
+    re_path(
         r'^moderationlog$',
         views.ratings_moderation_log,
         name='reviewers.ratings_moderation_log',

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -193,7 +193,7 @@ class PendingManualApprovalQueueTable(AddonQueueTable):
 
 class ThemesQueueTable(PendingManualApprovalQueueTable):
     title = '🎨 Themes'
-    urlname = 'queue_themes'
+    urlname = 'queue_theme'
     url = r'^theme$'
     permission = amo.permissions.STATIC_THEMES_REVIEW
     due_date = tables.Column(

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -191,11 +191,14 @@ class PendingManualApprovalQueueTable(AddonQueueTable):
         return 'due_date'
 
 
-class NewThemesQueueTable(PendingManualApprovalQueueTable):
-    title = '🎨 New'
-    urlname = 'queue_theme_nominated'
-    url = r'^theme_new$'
+class ThemesQueueTable(PendingManualApprovalQueueTable):
+    title = '🎨 Themes'
+    urlname = 'queue_themes'
+    url = r'^theme$'
     permission = amo.permissions.STATIC_THEMES_REVIEW
+    due_date = tables.Column(
+        verbose_name='Target Date', accessor='first_version_due_date'
+    )
 
     class Meta(AddonQueueTable.Meta):
         exclude = (
@@ -211,19 +214,7 @@ class NewThemesQueueTable(PendingManualApprovalQueueTable):
     def get_queryset(cls, request, **kw):
         return Addon.objects.get_queryset_for_pending_queues(
             admin_reviewer=is_admin_reviewer(request.user), theme_review=True
-        ).filter(status__in=(amo.STATUS_NOMINATED,))
-
-
-class UpdatedThemesQueueTable(NewThemesQueueTable):
-    title = '🎨 Updates'
-    urlname = 'queue_theme_pending'
-    url = r'^theme_updates$'
-
-    @classmethod
-    def get_queryset(cls, request, **kw):
-        return Addon.objects.get_queryset_for_pending_queues(
-            admin_reviewer=is_admin_reviewer(request.user), theme_review=True
-        ).exclude(status=amo.STATUS_NOMINATED)
+        )
 
 
 class PendingRejectionTable(AddonQueueTable):

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -232,7 +232,7 @@ def dashboard(request):
     ):
         sections['Themes'] = [
             (
-                'Manual Review ({0})'.format(queue_counts['theme']),
+                'Awaiting Review ({0})'.format(queue_counts['theme']),
                 reverse('reviewers.queue_theme'),
             ),
             (

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -233,7 +233,7 @@ def dashboard(request):
         sections['Themes'] = [
             (
                 'Manual Review ({0})'.format(queue_counts['theme']),
-                reverse('reviewers.queue_themes'),
+                reverse('reviewers.queue_theme'),
             ),
             (
                 'Review Log',
@@ -528,7 +528,7 @@ def review(request, addon, channel=None):
         5,
     ).page(1)
     if channel == amo.CHANNEL_LISTED and is_static_theme:
-        redirect_url = reverse(f'reviewers.queue_{form.helper.handler.review_type}')
+        redirect_url = reverse('reviewers.queue_theme')
     else:
         channel_arg = (
             amo.CHANNEL_CHOICES_API.get(channel) if not content_review else 'content'

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -103,11 +103,10 @@ from olympia.reviewers.utils import (
     ContentReviewTable,
     MadReviewTable,
     ModerationQueueTable,
-    NewThemesQueueTable,
     PendingManualApprovalQueueTable,
     PendingRejectionTable,
     ReviewHelper,
-    UpdatedThemesQueueTable,
+    ThemesQueueTable,
 )
 from olympia.scanners.admin import formatted_matched_rules_with_files_and_data
 from olympia.stats.decorators import bigquery_api_view
@@ -233,12 +232,8 @@ def dashboard(request):
     ):
         sections['Themes'] = [
             (
-                'New ({0})'.format(queue_counts['theme_nominated']),
-                reverse('reviewers.queue_theme_nominated'),
-            ),
-            (
-                'Updates ({0})'.format(queue_counts['theme_pending']),
-                reverse('reviewers.queue_theme_pending'),
+                'Manual Review ({0})'.format(queue_counts['theme']),
+                reverse('reviewers.queue_themes'),
             ),
             (
                 'Review Log',
@@ -419,8 +414,7 @@ def queue_moderated(request, tab):
 
 reviewer_tables_registry = {
     'extension': PendingManualApprovalQueueTable,
-    'theme_pending': UpdatedThemesQueueTable,
-    'theme_nominated': NewThemesQueueTable,
+    'theme': ThemesQueueTable,
     'content_review': ContentReviewTable,
     'mad': MadReviewTable,
     'pending_rejection': PendingRejectionTable,


### PR DESCRIPTION
Fixes: https://github.com/mozilla/addons/issues/14935

### Testing

- Submit a new theme (using the theme creation wizard or not), find it in reviewer tools new "Themes" queue, approve it, submit a new version of the theme after that
- Submit another new theme
- You should see both themes in the reviewer tools themes queue
