### PR TITLE
Use nobody@mozilla.org as the `From` for all emails, even activity ones

### DIFF
--- a/src/olympia/abuse/utils.py
+++ b/src/olympia/abuse/utils.py
@@ -137,7 +137,12 @@ class CinderAction:
         if version := getattr(self, 'addon_version', None):
             unique_id = log_entry_id or random.randrange(100000)
             send_activity_mail(
-                subject, message, version, owners, settings.ADDONS_EMAIL, unique_id
+                subject,
+                message,
+                version,
+                owners,
+                settings.DEFAULT_FROM_EMAIL,
+                unique_id,
             )
         else:
             # we didn't manage to find a version to associate with, we have to fall back

--- a/src/olympia/amo/tests/test_send_mail.py
+++ b/src/olympia/amo/tests/test_send_mail.py
@@ -228,7 +228,6 @@ class TestSendMail(TestCase):
             text_template,
             context={},
             recipient_list=emails,
-            from_email=settings.ADDONS_EMAIL,
             use_deny_list=False,
             perm_setting='individual_contact',
         )
@@ -238,7 +237,7 @@ class TestSendMail(TestCase):
 
         assert msg.to == emails
         assert msg.subject == subject
-        assert msg.from_email == settings.ADDONS_EMAIL
+        assert msg.from_email == settings.DEFAULT_FROM_EMAIL
 
         assert message.is_multipart()
         assert message.get_content_type() == 'multipart/alternative'

--- a/src/olympia/devhub/tasks.py
+++ b/src/olympia/devhub/tasks.py
@@ -644,7 +644,6 @@ def send_initial_submission_acknowledgement_email(addon_pk, channel, email, **kw
             text_template,
             context,
             recipient_list=[email],
-            from_email=settings.ADDONS_EMAIL,
             use_deny_list=False,
             perm_setting='individual_contact',
         )
@@ -660,7 +659,6 @@ def send_api_key_revocation_email(emails):
     send_mail(
         subject,
         template.render(context),
-        from_email=settings.ADDONS_EMAIL,
         recipient_list=emails,
         use_deny_list=False,
         perm_setting='individual_contact',

--- a/src/olympia/devhub/tests/test_tasks.py
+++ b/src/olympia/devhub/tests/test_tasks.py
@@ -6,7 +6,6 @@ from datetime import datetime, timedelta
 from decimal import Decimal
 from unittest import mock
 
-from django.conf import settings
 from django.core import mail
 from django.core.files.storage import default_storage as storage
 from django.test.utils import override_settings
@@ -570,7 +569,6 @@ class TestInitialSubmissionAcknoledgementEmail(TestCase):
                 'detail_url': absolutify(addon.get_url_path()),
             },
             recipient_list=['del@icio.us'],
-            from_email=settings.ADDONS_EMAIL,
             use_deny_list=False,
             perm_setting='individual_contact',
         )

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -746,8 +746,8 @@ LOGOUT_REDIRECT_URL = '/'
 MAX_GEN_USERNAME_TRIES = 50
 
 # Email settings
-ADDONS_EMAIL = 'Mozilla Add-ons <nobody@mozilla.org>'
-DEFAULT_FROM_EMAIL = ADDONS_EMAIL
+ADDONS_EMAIL = 'nobody@mozilla.org'
+DEFAULT_FROM_EMAIL = f'Mozilla Add-ons <{ADDONS_EMAIL}>'
 
 # Email goes to the console by default.  s/console/smtp/ for regular delivery
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'

--- a/src/olympia/reviewers/models.py
+++ b/src/olympia/reviewers/models.py
@@ -169,7 +169,6 @@ class ReviewerSubscription(ModelBase):
             subject,
             template.render(context),
             recipient_list=[self.user.email],
-            from_email=settings.ADDONS_EMAIL,
             use_deny_list=False,
         )
 

--- a/src/olympia/reviewers/tests/test_commands.py
+++ b/src/olympia/reviewers/tests/test_commands.py
@@ -652,7 +652,7 @@ class TestAutoApproveCommandTransactions(AutoApproveTestsMixin, TransactionTestC
         assert len(mail.outbox) == 1
         msg = mail.outbox[0]
         assert msg.to == [self.addons[1].authors.all()[0].email]
-        assert msg.from_email == settings.ADDONS_EMAIL
+        assert msg.from_email == settings.DEFAULT_FROM_EMAIL
         assert self.versions[1].version in msg.body
 
         assert get_reviewing_cache(self.addons[0].pk) is None


### PR DESCRIPTION
Keep setting notifications@addons.mozilla.org as the `Reply-To` email (with logic to dispatch the replies to the correct activity according to prefix) but stop using that address as the `From`, as it will fail DMARC.

Fixes mozilla/addons#14944