### PR TITLE
create activity log when eula or privacy policy is updated

### DIFF
--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -839,6 +839,18 @@ class AddonEulaPolicySerializer(AMOModelSerializer):
             'privacy_policy',
         )
 
+    def update(self, instance, validated_data):
+        instance = super().update(instance, validated_data)
+
+        if validated_data:
+            ActivityLog.objects.create(
+                amo.LOG.EDIT_PROPERTIES,
+                instance,
+                details=list(validated_data.keys()),
+                user=self.context['request'].user,
+            )
+        return instance
+
 
 class UserSerializerWithPictureUrl(BaseUserSerializer):
     picture_url = serializers.SerializerMethodField()

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -5139,6 +5139,9 @@ class TestAddonViewSetEulaPolicy(TestCase):
         user = UserProfile.objects.create(username='user')
         AddonUser.objects.create(user=user, addon=self.addon)
         self.client.login_api(user)
+        assert not ActivityLog.objects.filter(
+            action=amo.LOG.EDIT_PROPERTIES.id
+        ).exists()
         response = self.client.patch(
             self.url,
             {
@@ -5168,6 +5171,11 @@ class TestAddonViewSetEulaPolicy(TestCase):
             self.addon = Addon.objects.get(pk=self.addon.pk)
             assert str(self.addon.eula) == 'Mes Conditions générales d’utilisation'
             assert str(self.addon.privacy_policy) == 'My privacy policy'
+
+        assert ActivityLog.objects.filter(action=amo.LOG.EDIT_PROPERTIES.id).exists()
+        assert ActivityLog.objects.filter(action=amo.LOG.EDIT_PROPERTIES.id)[
+            0
+        ].details == ['eula', 'privacy_policy']
 
     def test_update_put(self):
         user = UserProfile.objects.create(username='user')

--- a/src/olympia/devhub/forms.py
+++ b/src/olympia/devhub/forms.py
@@ -692,12 +692,9 @@ class PolicyForm(TranslationFormMixin, AMOModelForm):
 
     def save(self, commit=True):
         ob = super().save(commit)
-        for k, field in (('has_eula', 'eula'), ('has_priv', 'privacy_policy')):
-            if not self.cleaned_data[k]:
+        for has, field in (('has_eula', 'eula'), ('has_priv', 'privacy_policy')):
+            if not self.cleaned_data[has]:
                 delete_translation(self.instance, field)
-
-        if 'privacy_policy' in self.changed_data:
-            ActivityLog.objects.create(amo.LOG.CHANGE_POLICY, self.addon, self.instance)
 
         return ob
 

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -546,6 +546,7 @@ def ownership(request, addon_id, addon):
             license_form.save()
         if policy_form and policy_form in fs:
             policy_form.save()
+            ActivityLog.objects.create(amo.LOG.EDIT_PROPERTIES, addon)
         messages.success(request, gettext('Changes successfully saved.'))
 
         existing_authors_emails = list(addon.authors.values_list('email', flat=True))


### PR DESCRIPTION
Fixes: mozilla/addons#14940

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Adds the standard add-on metadata logging for changes made via `AddonEulaPolicySerializer`.  Also replaces the (broken attempt at) logging in `PolicyForm`, in favour of the `ownership` view, to be consistent with how other devhub views log changes to add-on metadata.

### Context

`AMOModelForm.changed_data` appears to broken.  There is some code we added that attempts to fix upstream `changed_data` to handle Translated field data _not_ changing, but at some point `ModelForm.changed_data` altered it's behaviour and now the translated fields aren't included in `changed_data` at all.  We would have discovered this when it happened but there are no tests that directly test our patch to `ModelForm.changed_data`, indirectly we only use `changed_data` in a few other places - but not for translation fields - and we didn't test the logging worked in the tests for the view or form (or that changing the privacy policy worked either).  I did make some attempts to fix `changed_data` but with no success, and didn't see the value in investing more time.

### Testing

Devhub:
- make a change to either eula or privacy policy page in the "Manage Authors & License" in devhub for an add-on
- look in "View Recent Changes" page in devhub for an add-on and see the activity
  - (because the logging is naive just saving the form will result in an activity log - even if no changes were made to the eula or privacy policy - similar to the other devhub forms.)

API:
- make a PATCH request to the [policy endpoint](https://mozilla.github.io/addons-server/topics/api/addons.html#eula-and-privacy-policy-edit) changing the policy or eula for an add-on you own
- look in django admin for the activity.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
