### PR TITLE
Add a filter to the review queue for due date reasons

### DIFF
--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -596,8 +596,7 @@ class ReviewQueueFilter(forms.Form):
 
     def __init__(self, data, *args, **kw):
         due_date_reasons = list(Version.objects.get_due_date_reason_q_objects().keys())
-        data = data.copy()
-        data.setlistdefault('due_date_reasons', due_date_reasons)
+        kw['initial'] = {'due_date_reasons': due_date_reasons}
         super().__init__(data, *args, **kw)
         labels = {reason: label for reason, label in VIEW_QUEUE_FLAGS}
         self.fields['due_date_reasons'].choices = [

--- a/src/olympia/reviewers/models.py
+++ b/src/olympia/reviewers/models.py
@@ -69,23 +69,23 @@ VIEW_QUEUE_FLAGS = (
     # See VersionManager.get_due_date_reason_q_objects for the names
     (
         'needs_human_review_from_cinder',
-        'Abuse report forwarded from Cinder present',
+        'Abuse report forwarded from Cinder',
     ),
     (
         'needs_human_review_from_abuse',
-        'Abuse report present',
+        'Abuse report',
     ),
     (
         'needs_human_review_from_appeal',
-        'Appeal on decision present',
+        'Appeal on decision',
     ),
     (
         'needs_human_review_other',
-        'Other NeedsHumanReview flag set',
+        'Other NeedsHumanReview flag',
     ),
     (
         'is_pre_review_version',
-        'Version(s) awaiting pre-approval review',
+        'Version awaiting pre-approval review',
     ),
     (
         'has_developer_reply',

--- a/src/olympia/reviewers/templates/reviewers/queue.html
+++ b/src/olympia/reviewers/templates/reviewers/queue.html
@@ -78,6 +78,13 @@
         </form>
       </div>
     {% else %}
+      <div id="addon-queue-filter-form">
+        <button class="show-hide-toggle">Show/Hide Filter Selections</button>
+        <form action="" method="get">
+          {{ filter_form }}
+          <input type="submit" value="Update Filters">
+        </form>
+      </div>
       <table id="addon-queue" class="data-grid" data-url="{{ url('reviewers.queue_viewing') }}">
         <thead>
           <tr class="listing-header">

--- a/src/olympia/reviewers/tests/test_models.py
+++ b/src/olympia/reviewers/tests/test_models.py
@@ -1717,12 +1717,12 @@ class TestGetFlags(TestCase):
         for attribute, title in (
             (
                 'needs_human_review_from_cinder',
-                'Abuse report forwarded from Cinder present',
+                'Abuse report forwarded from Cinder',
             ),
-            ('needs_human_review_from_abuse', 'Abuse report present'),
-            ('needs_human_review_from_appeal', 'Appeal on decision present'),
-            ('needs_human_review_other', 'Other NeedsHumanReview flag set'),
-            ('is_pre_review_version', 'Version(s) awaiting pre-approval review'),
+            ('needs_human_review_from_abuse', 'Abuse report'),
+            ('needs_human_review_from_appeal', 'Appeal on decision'),
+            ('needs_human_review_other', 'Other NeedsHumanReview flag'),
+            ('is_pre_review_version', 'Version awaiting pre-approval review'),
             ('has_developer_reply', 'Outstanding developer reply'),
         ):
             self.addon.needs_human_review_from_abuse = False

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -83,6 +83,7 @@ from olympia.users.models import UserProfile
 from olympia.versions.models import (
     ApplicationsVersions,
     AppVersion,
+    VersionManager,
     VersionReviewerFlags,
 )
 from olympia.versions.utils import get_review_due_date
@@ -1721,6 +1722,53 @@ class TestExtensionQueue(QueueTest):
             self.addons['Pending Two'],
         ]
         self.expected_versions = self.get_expected_versions(self.expected_addons)
+        self._test_results()
+
+    def test_due_date_reason_filter_form(self):
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        # the form is present
+        assert doc('#addon-queue-filter-form').length
+        # and all the checkboxes are checked by default if there are not GET params
+        assert doc(
+            '#addon-queue-filter-form input[type="checkbox"]:checked'
+        ).length == len(VersionManager.get_due_date_reason_q_objects())
+
+    def test_due_date_reason_filtering(self):
+        self.url += '?due_date_reasons=needs_human_review_from_abuse'
+        self.expected_addons = self.get_expected_addons_by_names(
+            ['Pending One', 'Nominated Two'],
+            auto_approve_disabled=True,
+        )
+        self.expected_versions = self.get_expected_versions(self.expected_addons)
+        for _, version in self.expected_versions.items():
+            NeedsHumanReview.objects.create(
+                version=version, reason=NeedsHumanReview.REASONS.ABUSE_ADDON_VIOLATION
+            )
+        self._test_results()
+
+    def test_due_date_reason_with_two_filters(self):
+        # test with two filters applied
+        self.url += (
+            '?due_date_reasons=needs_human_review_from_abuse'
+            '&due_date_reasons=has_developer_reply'
+        )
+        self.expected_addons = self.get_expected_addons_by_names(
+            ['Pending One', 'Nominated One', 'Nominated Two'],
+            auto_approve_disabled=True,
+        )
+        self.expected_versions = self.get_expected_versions(self.expected_addons)
+        # pending one and nominated one have a report
+        for _, version in list(self.expected_versions.items())[0:2]:
+            NeedsHumanReview.objects.create(
+                version=version, reason=NeedsHumanReview.REASONS.ABUSE_ADDON_VIOLATION
+            )
+        # and nominated one and nominated two have a developer reply
+        for _, version in list(self.expected_versions.items())[1:]:
+            NeedsHumanReview.objects.create(
+                version=version, reason=NeedsHumanReview.REASONS.DEVELOPER_REPLY
+            )
         self._test_results()
 
 

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -330,8 +330,12 @@ def queue(request, tab):
             order_by = TableObj.default_order_by()
         if order_by is not None:
             params['order_by'] = order_by
-        filter_form = ReviewQueueFilter(request.GET)
-        if due_date_reasons := request.GET.getlist('due_date_reasons'):
+        filter_form = ReviewQueueFilter(
+            request.GET if 'due_date_reasons' in request.GET else None
+        )
+        if filter_form.is_valid() and (
+            due_date_reasons := filter_form.cleaned_data['due_date_reasons']
+        ):
             filters = [Q(**{reason: True}) for reason in due_date_reasons]
             qs = qs.filter(functools.reduce(operator.or_, filters))
         table = TableObj(data=qs, **params)

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -1,3 +1,5 @@
+import functools
+import operator
 from collections import OrderedDict
 from datetime import date, datetime
 from urllib.parse import quote
@@ -76,6 +78,7 @@ from olympia.reviewers.forms import (
     RatingModerationLogForm,
     ReviewForm,
     ReviewLogForm,
+    ReviewQueueFilter,
     WhiteboardForm,
 )
 from olympia.reviewers.models import (
@@ -327,6 +330,10 @@ def queue(request, tab):
             order_by = TableObj.default_order_by()
         if order_by is not None:
             params['order_by'] = order_by
+        filter_form = ReviewQueueFilter(request.GET)
+        if due_date_reasons := request.GET.getlist('due_date_reasons'):
+            filters = [Q(**{reason: True}) for reason in due_date_reasons]
+            qs = qs.filter(functools.reduce(operator.or_, filters))
         table = TableObj(data=qs, **params)
         per_page = request.GET.get('per_page', REVIEWS_PER_PAGE)
         try:
@@ -342,11 +349,12 @@ def queue(request, tab):
             request,
             'reviewers/queue.html',
             context=context(
-                table=table,
                 page=page,
-                tab=tab,
-                title=TableObj.title,
                 registry=reviewer_tables_registry,
+                filter_form=filter_form,
+                tab=tab,
+                table=table,
+                title=TableObj.title,
             ),
         )
 

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -189,6 +189,7 @@ class VersionManager(ManagerBase):
             .distinct()
         )
 
+    @classmethod
     def get_due_date_reason_q_objects(cls):
         """Class method that returns a dict with all the Q objects needed to determine
         if a version should_have_due_date is true as values, and the annotation names

--- a/static/css/zamboni/reviewers.less
+++ b/static/css/zamboni/reviewers.less
@@ -1378,3 +1378,17 @@ table.abuse_reports {
         border-left: 0;
     }
 }
+
+#addon-queue-filter-form {
+    margin: 1em;
+    padding: 1em;
+    background-color: #ecf5fe;
+
+    #id_due_date_reasons {
+        column-count: 3;
+    }
+
+    form {
+        margin-bottom: 0;
+    }
+}

--- a/static/js/zamboni/reviewers.js
+++ b/static/js/zamboni/reviewers.js
@@ -56,6 +56,24 @@ $(document).ready(function () {
       window.location.hash = 'id=' + $('#addon, #persona').attr('data-id');
     });
   }
+
+  if ($('#addon-queue-filter-form').length) {
+    let filter_form = $('#addon-queue-filter-form form')[0];
+
+    $('#addon-queue-filter-form button').click(function () {
+      if (filter_form.hidden) {
+        filter_form.hidden = false;
+      } else {
+        filter_form.hidden = true;
+      }
+    });
+    if (
+      $('#addon-queue-filter-form input[type="checkbox"]').length ==
+      $('#addon-queue-filter-form input[type="checkbox"]:checked').length
+    ) {
+      filter_form.hidden = true;
+    }
+  }
 });
 
 function initReviewActions() {


### PR DESCRIPTION
Fixes: mozilla/addons#14921

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Adds a form to the top of the manual review queue where the reasons the add-on is in the queue can be filtered.

![Screenshot 2024-08-07 134444](https://github.com/user-attachments/assets/e499899c-7538-4181-8158-4da1e40fda0c)


### Context

The filtering relies on annotations added to the queryset results that were added in #22530.

### Testing

If you don't have any add-ons in your local review queue, add some.  For example:
- An add-on that would be there for manual review could be in the Recommended promoted group
- An add-on can be reported for abuse inside the add-on, for a policy violation (needs cinder api integration)
- Reply to a review in developer hub, as the developer, so the add-on has an outstanding developer reply
- Any add-on can be manually given a needs human review in the reviewer tools

Then go to the review queue.  
- See all add-ons are present initially (with no GET params).  
- Show the form; see all the checkboxes are checked; submit the form; 
- See all the add-ons are still present.  
- Deselect some checkboxes and submit to see fewer add-ons
- (No checkboxes checked is treated as all checked)

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [x] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
