### PR TITLE
restrict /policy PATCH to non-themes

### DIFF
--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -905,6 +905,9 @@ This endpoint allows an add-on's EULA and privacy policy to be edited.
     .. note::
         This API requires :doc:`authentication <auth>`, and for the user to be an author of the add-on.
 
+    .. note::
+        This API is not valid for themes - themes do not have EULA or privacy policies.
+
 .. http:patch:: /api/v5/addons/addon/(int:id|string:slug|string:guid)/eula_policy/
 
     :<json object|null eula: The EULA text (See :ref:`translated fields <api-overview-translations>`).

--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -472,6 +472,7 @@ These are `v5` specific changes - `v4` changes apply also.
 * 2024-06-20: added ``illegal_category`` parameter to all /abuse/report/ endpoints. https://github.com/mozilla/addons/issues/14870
 * 2024-06-20: added ``illegal_subcategory`` parameter to all /abuse/report/ endpoints. https://github.com/mozilla/addons/issues/14875
 * 2024-08-08: added support for writing to add-on eula_policy endpoint. https://github.com/mozilla/addons/issues/14927
+* 2024-08-22: restricted add-on eula_policy endpoint to non-themes only. https://github.com/mozilla/addons/issues/14937
 
 .. _`#11380`: https://github.com/mozilla/addons-server/issues/11380/
 .. _`#11379`: https://github.com/mozilla/addons-server/issues/11379/

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -84,6 +84,7 @@ from .validators import (
     CanSetCompatibilityValidator,
     MatchingGuidValidator,
     NoFallbackDefaultLocaleValidator,
+    NoThemesValidator,
     ReviewedSourceFileValidator,
     VerifyMozillaTrademark,
     VersionAddonMetadataValidator,
@@ -200,6 +201,7 @@ class PreviewSerializer(AMOModelSerializer):
             'thumbnail_size',
             'thumbnail_url',
         )
+        validators = (NoThemesValidator(),)
 
     def get_image_url(self, obj):
         return absolutify(obj.image_url)
@@ -212,13 +214,6 @@ class PreviewSerializer(AMOModelSerializer):
         request = self.context.get('request', None)
         if request and is_gate_active(request, 'del-preview-position'):
             data.pop('position', None)
-        return data
-
-    def validate(self, data):
-        if self.context['view'].get_addon_object().type == amo.ADDON_STATICTHEME:
-            raise exceptions.ValidationError(
-                gettext('Previews cannot be created for themes.')
-            )
         return data
 
     def create(self, validated_data):
@@ -838,6 +833,7 @@ class AddonEulaPolicySerializer(AMOModelSerializer):
             'eula',
             'privacy_policy',
         )
+        validators = (NoThemesValidator(),)
 
     def update(self, instance, validated_data):
         instance = super().update(instance, validated_data)

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -5211,6 +5211,28 @@ class TestAddonViewSetEulaPolicy(TestCase):
         self.addon.reload()
         assert self.addon.summary == original_summary
 
+    def test_update_on_theme(self):
+        user = UserProfile.objects.create(username='user')
+        self.addon.update(type=amo.ADDON_STATICTHEME)
+        AddonUser.objects.create(user=user, addon=self.addon)
+        self.client.login_api(user)
+        response = self.client.patch(
+            self.url,
+            {
+                'eula': {
+                    'en-US': 'My Updated Add-on EULA in English',
+                    'fr': 'Mes Conditions générales d’utilisation',
+                },
+                'privacy_policy': {
+                    'en-US': 'My privacy policy',
+                },
+            },
+        )
+        assert response.status_code == 400
+        assert response.json() == {
+            'non_field_errors': ['This endpoint is not valid for Themes.']
+        }
+
 
 class TestAddonSearchView(ESTestCase):
     client_class = APITestClientSessionID
@@ -7239,7 +7261,7 @@ class TestAddonPreviewViewSet(TestCase):
         )
         assert response.status_code == 400, response.content
         assert response.data == {
-            'non_field_errors': ['Previews cannot be created for themes.']
+            'non_field_errors': ['This endpoint is not valid for Themes.']
         }
 
         self.addon.reload()

--- a/src/olympia/addons/validators.py
+++ b/src/olympia/addons/validators.py
@@ -316,3 +316,18 @@ class CanSetCompatibilityValidator:
                     )
                 }
             )
+
+
+class NoThemesValidator:
+    requires_context = True
+
+    def __call__(self, data, serializer):
+        addon = (
+            serializer.instance
+            if isinstance(serializer.instance, Addon)
+            else serializer.context['view'].get_addon_object()
+        )
+        if addon.type == amo.ADDON_STATICTHEME:
+            raise exceptions.ValidationError(
+                gettext('This endpoint is not valid for Themes.')
+            )


### PR DESCRIPTION
Fixes: mozilla/addons#14937

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Themes can't have EULA or privacy policies, so restrict the endpoint to non-themes, like devhub does.

### Context

PATCH for /policy was added recently.

### Testing

- Try to patch a theme's eula or privacy via https://mozilla.github.io/addons-server/topics/api/addons.html#eula-and-privacy-policy-edit (and get a 400)
- Try to patch a non-theme with the same API and succeed

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
