### PR TITLE
Remove unecessary files from the Docker image during production build

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -41,3 +41,4 @@ Please delete anything that isn't relevant to your patch.
 - [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
 - [ ] Add before and after screenshots (Only for changes that impact the UI).
 - [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
+- [ ] I have added any new files that are not required for production to the Docker build production stage remove list in the Dockerfile

--- a/docs/topics/development/building_and_running_services.md
+++ b/docs/topics/development/building_and_running_services.md
@@ -49,6 +49,12 @@ make build_docker_image
 
 This command leverages BuildKit and Bake to efficiently build the required images.
 
+### Adding files to the image
+
+In order to prevent bloat in our production image there is a RUN command to remove files and directories that are not required for production.
+
+When developing please consider if the file is required for production. If it is not, please add it to the remove list in the [Dockerfile](../../../Dockerfile).
+
 ### Clearing Cache
 
 To clear the custom builder cache used for buildkit mount caching:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ exclude = [
     "static",
     ".git",
     "*/migrations/*.py",
-    "build.py",
 ]
 line-length = 88
 


### PR DESCRIPTION
Relates to: mozilla/addons#14972

### Description

Adds logic to remove files not strictly needed for the production container. This reduces the overall size of the production image without removing files during development.

### Context

A lot of files are not needed in our production docker image. By reducing the amount of content in the build we can slim down the image to 1) increase push/pull performance 2) increase build speed

### Testing

Make up and all commands and tests should work. Specifically consider files that are included in the remove list. Are they required anywhere in the running container in production?

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [X] Add or update relevant [docs](../docs/) reflecting the changes made.
