### PR TITLE
CI: Only run push locales on push events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,9 @@ jobs:
           run: make extract_locales
 
       - name: Push Locales
-        if:  github.event_name == 'push'
+        if:  |
+          github.event_name == 'push' ||
+          github.event_name == 'pull_request'
         shell: bash
         run: |
           is_fork="${{ needs.context.outputs.is_fork }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,11 +193,11 @@ jobs:
           run: make extract_locales
 
       - name: Push Locales
+        if:  github.event_name == 'push'
         shell: bash
         run: |
           is_fork="${{ needs.context.outputs.is_fork }}"
           is_default_branch="${{ needs.context.outputs.is_default_branch }}"
-          is_push="${{ github.event_name == 'push' }}"
 
           if [[ "$is_fork" == 'true' ]]; then
             cat <<'EOF'
@@ -206,7 +206,7 @@ jobs:
               Please submit a PR from the base repository if you are modifying l10n extraction scripts.
           EOF
           else
-            if [[ "$is_default_branch" == 'true' && "$is_push" == 'true' ]]; then
+            if [[ "$is_default_branch" == 'true' ]]; then
               args=""
             else
               args="--dry-run"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,7 @@ jobs:
         run: |
           is_fork="${{ needs.context.outputs.is_fork }}"
           is_default_branch="${{ needs.context.outputs.is_default_branch }}"
+          is_push="${{ github.event_name == 'push' }}"
 
           if [[ "$is_fork" == 'true' ]]; then
             cat <<'EOF'
@@ -208,7 +209,7 @@ jobs:
               Please submit a PR from the base repository if you are modifying l10n extraction scripts.
           EOF
           else
-            if [[ "$is_default_branch" == 'true' ]]; then
+            if [[ "$is_default_branch" == 'true' && "$is_push" == 'true' ]]; then
               args=""
             else
               args="--dry-run"


### PR DESCRIPTION
Follow up of failled deployment: https://github.com/mozilla/addons-server/actions/runs/10505053101

### Context

Currently our CI runs a locales job that extracts locales and runs the push locales command. On non master push it was running in dry mode and for any tag based from master this would be fine as it would include the automatically extracted locale strings.

But.... if you cherry pick a commit without cherry picking the extracted locales... then they are missing and locale job tries to push new strings.

This fails because we are on a detached head. There is no reason to run the push job at all on any event other than push so we can just avoid this class of bugs entirely.

We did NOT see this before because we didn't run any CI on tags before deploying them previously.

### Checklist

- [ ] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
