### PR TITLE
Show comments in addon important changes history section

### DIFF
--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -62,7 +62,12 @@
   </h3>
   <ul>
     {% for activity in important_changes_log %}
-      <li {% if activity.log.reviewer_review_action %}class="reviewer-review-action"{% endif %}>{{ activity.created|datetime }}: {{ activity.to_string('reviewer') }}</li>
+      <li {% if activity.log.reviewer_review_action %}class="reviewer-review-action"{% endif %}>
+        <p>{{ activity.created|datetime }}: {{ activity.to_string('reviewer') }}</p>
+        {% if activity.details.comments %}
+          <p>{{ activity.details.comments }}</p>
+        {% endif %}
+      </li>
     {% endfor %}
   </ul>
 </div>

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -4735,9 +4735,11 @@ class TestReview(ReviewBase):
             self.addon,
         )
         activity3 = ActivityLog.objects.create(amo.LOG.FORCE_DISABLE, self.addon)
+        comment = 'Test comment'
         activity4 = ActivityLog.objects.create(
             amo.LOG.FORCE_ENABLE,
             self.addon,
+            details={'comments': comment}
         )
 
         response = self.client.get(self.url)
@@ -4757,31 +4759,32 @@ class TestReview(ReviewBase):
         # Make sure the logs are displayed in the page.
         important_changes = doc('#important-changes-history li')
         assert len(important_changes) == 5
-        assert important_changes[0].text_content() == (
+        assert (
             f'{format_datetime(activity0.created)}: {activity1.user.name} '
             '(Owner) added to Public.'
-        )
+        ) in important_changes[0].text_content()
         assert 'class' not in important_changes[0].attrib
-        assert important_changes[1].text_content() == (
+        assert (
             f'{format_datetime(activity1.created)}: {activity1.user.name} '
             'role changed to Owner for Public.'
-        )
+        ) in important_changes[1].text_content()
         assert 'class' not in important_changes[1].attrib
-        assert important_changes[2].text_content() == (
+        assert (
             f'{format_datetime(activity2.created)}: {activity1.user.name} '
             '(Owner) removed from Public.'
-        )
+        ) in important_changes[2].text_content()
         assert 'class' not in important_changes[2].attrib
-        assert important_changes[3].text_content() == (
+        assert (
             f'{format_datetime(activity3.created)}: Public force-disabled by '
             f'{activity1.user.name}.'
-        )
+        ) in important_changes[3].text_content()
         assert important_changes[3].attrib['class'] == 'reviewer-review-action'
-        assert important_changes[4].text_content() == (
+        assert (
             f'{format_datetime(activity4.created)}: Public force-enabled by '
             f'{activity1.user.name}.'
-        )
+        ) in important_changes[4].text_content()
         assert important_changes[4].attrib['class'] == 'reviewer-review-action'
+        assert comment in important_changes[4].text_content()
 
     @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
     @mock.patch('olympia.devhub.tasks.validate')

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -4737,9 +4737,7 @@ class TestReview(ReviewBase):
         activity3 = ActivityLog.objects.create(amo.LOG.FORCE_DISABLE, self.addon)
         comment = 'Test comment'
         activity4 = ActivityLog.objects.create(
-            amo.LOG.FORCE_ENABLE,
-            self.addon,
-            details={'comments': comment}
+            amo.LOG.FORCE_ENABLE, self.addon, details={'comments': comment}
         )
 
         response = self.client.get(self.url)


### PR DESCRIPTION
Fixes: mozilla/addons#14956


### Description

Split content of important changes section to 2 part containing the relevant metadata + time stamp and additionally the "comments" associated with the action.

### Context

We already have the full activity log so it seemed relatively simple to conditionally render the comments field from the activity log details property.


### Testing

- Open any addon in reviewer tools.
- Force disable the addon if it is not disabled. 
- Force enable the addon (make sure to add a comment)
- Check the important changes history to ensure the comments for both enabling/disabling are present under the action timestamp

<img width="681" alt="image" src="https://github.com/user-attachments/assets/61478c70-5ed2-4efd-ae78-92e9c30c7d47">

### Checklist


- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [X] Add before and after screenshots (Only for changes that impact the UI).
