### PR TITLE
Create release with template and release notes

### DIFF
--- a/.github/release-template.md
+++ b/.github/release-template.md
@@ -1,0 +1,18 @@
+This week's push hero is @{{GITHUB_USER}}
+
+Latest Release: [{{LATEST_TAG}}]({{LAST_RELEASE_URL}})
+
+## Blockers:
+
+## Cherry-picks:
+
+<!-- Link to the actual commits, NOT merge commits. The commits need to appear
+in chronological order so that `git cherry-pick` will apply them correctly. -->
+
+## Before we push:
+
+## Before we start:
+
+## Before we promote:
+
+## After we're done:

--- a/.github/release-template.md
+++ b/.github/release-template.md
@@ -1,6 +1,6 @@
 This week's push hero is @{{GITHUB_USER}}
 
-Latest Release: [{{LATEST_TAG}}]({{LAST_RELEASE_URL}})
+Previous Release: [{{PREVIOUS_TAG}}]({{PREVIOUS_RELEASE_URL}})
 
 ## Blockers:
 

--- a/.github/release-template.md
+++ b/.github/release-template.md
@@ -16,3 +16,13 @@ in chronological order so that `git cherry-pick` will apply them correctly. -->
 ## Before we promote:
 
 ## After we're done:
+
+## Addons-Frontend Changelog:
+
+<!-- Link to the tag comparison of the target tag and the previous tag for addons-frontend
+https://github.com/mozilla/addons-frontend/compare/<PREVIOUS_TAG...<CURRENT_TAG>
+-->
+
+## Addons Server Changelog:
+
+<!-- This section will be automatically populated once the release notes are auto generated -->

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,11 @@
+changelog:
+  categories:
+    - title: Notable things shipping
+      labels:
+        - '*'
+      exclude:
+        labels:
+          - dependencies
+    - title: Dependendabots
+      labels:
+        - dependencies

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -41,8 +41,8 @@ jobs:
             tag="${{ github.event.inputs.tag }}"
           fi
 
-          #Validate the tag is formatted correctly YYYY.MM.DD or YYYY.MM.DD-rcX
-          # where rcX is a whole number greater than zero
+          # Validate the tag is formatted correctly YYYY.MM.DD or YYYY.MM.DD-X
+          # where X is a whole number greater than zero
           if [[ ! $tag =~ ^[0-9]{4}\.[0-9]{2}\.[0-9]{2}(-[0-9]+)?$ ]]; then
             echo "Invalid tag format. Must be YYYY.MM.DD or YYYY.MM.DD-X"
             exit 1

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -1,0 +1,72 @@
+name: Draft Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release date YYYY.MM.DD Also used to generate the tag name.'
+        required: true
+
+jobs:
+  draft_release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Create Release Draft
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          # Format current date as YYYY.MM.DD
+
+          if [[ "${{ github.event_name}}" == 'workflow_dispatch' ]]; then
+            tag="${{ github.event.inputs.tag }}"
+          else
+            tag=$(date +'%Y.%m.%d')
+          fi
+
+          #Validate the tag is formatted correctly YYYY.MM.DD or YYYY.MM.DD-rcX
+          # where rcX is a whole number greater than zero
+          if [[ ! $tag =~ ^[0-9]{4}\.[0-9]{2}\.[0-9]{2}(-rc[0-9]+)?$ ]]; then
+            echo "Invalid tag format. Must be YYYY.MM.DD or YYYY.MM.DD-rcX"
+            exit 1
+          fi
+
+          # Verify that a release with this tag does not already exist
+          if gh release view $tag &> /dev/null; then
+            echo "Release $tag-next already exists"
+            exit 1
+          fi
+
+          # Get the latest release tag
+          latest_release=$(
+            gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/mozilla/addons-server/releases/latest
+          )
+
+          latest_tag=$(echo $latest_release | jq -r '.tag_name')
+          latest_release_url=$(echo $latest_release | jq -r '.html_url')
+
+          cat <<EOF
+          $latest_release
+          EOF
+
+          # Cat the file ../release-template.md
+          template=$(cat .github/release-template.md)
+
+          # Replace {{GITHUB_USER}} in template with ${{ github.actor }}
+          template=${template//\{\{GITHUB_USER\}\}/${{ github.actor }}}
+
+          # Replace {{LATEST_TAG}} in template with $latest_tag
+          template=${template//\{\{LATEST_TAG\}\}/$latest_tag}
+
+          # Replace {{LAST_RELEASE_URL}} in template with $latest_release_url
+          template=${template//\{\{LAST_RELEASE_URL\}\}/$latest_release_url}
+
+          gh release create $tag \
+            --title $tag \
+            --target master \
+            --notes "$template" \
+            --draft

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -3,6 +3,14 @@ name: Draft Release
 on:
   workflow_dispatch:
     inputs:
+      push_hero:
+        description: The person responsible for facilitating the release.
+        required: true
+        type: choice
+        options:
+          - kevinmind
+          - diox
+          - eviljeff
       tag:
         description: 'Release date YYYY.MM.DD Also used to generate the tag name.'
         required: true
@@ -17,18 +25,26 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
+          if [ -z "${{ github.event.inputs.tag }}" ]; then
+            echo "Tag is required"
+            exit 1
+          fi
+
+          if [ -z "${{ github.event.inputs.push_hero }}" ]; then
+            echo "Push hero is required"
+            exit 1
+          fi
+
           # Format current date as YYYY.MM.DD
 
           if [[ "${{ github.event_name}}" == 'workflow_dispatch' ]]; then
             tag="${{ github.event.inputs.tag }}"
-          else
-            tag=$(date +'%Y.%m.%d')
           fi
 
           #Validate the tag is formatted correctly YYYY.MM.DD or YYYY.MM.DD-rcX
           # where rcX is a whole number greater than zero
-          if [[ ! $tag =~ ^[0-9]{4}\.[0-9]{2}\.[0-9]{2}(-rc[0-9]+)?$ ]]; then
-            echo "Invalid tag format. Must be YYYY.MM.DD or YYYY.MM.DD-rcX"
+          if [[ ! $tag =~ ^[0-9]{4}\.[0-9]{2}\.[0-9]{2}(-[0-9]+)?$ ]]; then
+            echo "Invalid tag format. Must be YYYY.MM.DD or YYYY.MM.DD-X"
             exit 1
           fi
 

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -55,18 +55,18 @@ jobs:
           fi
 
           # Get the latest release tag
-          latest_release=$(
+          previous_release=$(
             gh api \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/mozilla/addons-server/releases/latest
           )
 
-          latest_tag=$(echo $latest_release | jq -r '.tag_name')
-          latest_release_url=$(echo $latest_release | jq -r '.html_url')
+          previous_tag=$(echo $previous_release | jq -r '.tag_name')
+          previous_release_url=$(echo $previous_release | jq -r '.html_url')
 
           cat <<EOF
-          $latest_release
+          $previous_release
           EOF
 
           # Cat the file ../release-template.md
@@ -75,11 +75,11 @@ jobs:
           # Replace {{GITHUB_USER}} in template with ${{ github.event.inputs.push_hero }}
           template=${template//\{\{GITHUB_USER\}\}/${{ github.event.inputs.push_hero }}}
 
-          # Replace {{LATEST_TAG}} in template with $latest_tag
-          template=${template//\{\{LATEST_TAG\}\}/$latest_tag}
+          # Replace {{PREVIOUS_TAG}} in template with $previous_tag
+          template=${template//\{\{PREVIOUS_TAG\}\}/$previous_tag}
 
-          # Replace {{LAST_RELEASE_URL}} in template with $latest_release_url
-          template=${template//\{\{LAST_RELEASE_URL\}\}/$latest_release_url}
+          # Replace {{PREVIOUS_RELEASE_URL}} in template with $previous_release_url
+          template=${template//\{\{PREVIOUS_RELEASE_URL\}\}/$previous_release_url}
 
           gh release create $tag \
             --title $tag \

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -72,8 +72,8 @@ jobs:
           # Cat the file ../release-template.md
           template=$(cat .github/release-template.md)
 
-          # Replace {{GITHUB_USER}} in template with ${{ github.actor }}
-          template=${template//\{\{GITHUB_USER\}\}/${{ github.actor }}}
+          # Replace {{GITHUB_USER}} in template with ${{ github.event.inputs.push_hero }}
+          template=${template//\{\{GITHUB_USER\}\}/${{ github.event.inputs.push_hero }}}
 
           # Replace {{LATEST_TAG}} in template with $latest_tag
           template=${template//\{\{LATEST_TAG\}\}/$latest_tag}


### PR DESCRIPTION
Fixes: <https://mozilla-hub.atlassian.net/browse/AMOENG-616>

### Description

Adds a workflow to trigger the creation of a draft release. This allows us to have a standardized template for the information in our releases.

### Context

Previously we created release documentation manually and updated with commit diffs of tags and info related to a given release. Now that we can release via github releases we should automate creation of release docs in the same way.

### Testing

The criteria for the release is:
- the release hero is set to the current actor. It can be updated post release but typically the release hero will trigger this workflow 
- the tag is based on an input parameter which is validated:
- date YYYY.MM.DD with or without the -X suffix indicating a cherry-pick release.
- The tag is validated to not match the tag of an existing release. Cannot release the same tag twice (you can deploy the same tag twice, but that is different)
- Link to the latest published release is included.

> NOTE: Release notes with commits and diffs are only created when we click the "generate notes" button. we should only do that when we actually roll out to stage.

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.

