### PR TITLE
dont report abuse reports for unlisted versions to cinder

### DIFF
--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -794,11 +794,14 @@ class AbuseReport(ModelBase):
                 not self.guid
                 or (
                     Addon.unfiltered.filter(guid=self.guid).exists()
-                    and not Version.unfiltered.filter(
-                        addon__guid=self.guid,
-                        version=self.addon_version,
-                        channel=amo.CHANNEL_UNLISTED,
-                    ).exists()
+                    and (
+                        not self.addon_version
+                        or Version.unfiltered.filter(
+                            addon__guid=self.guid,
+                            version=self.addon_version,
+                            channel=amo.CHANNEL_LISTED,
+                        ).exists()
+                    )
                 )
             )
         )

--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -455,7 +455,7 @@ class AbuseReport(ModelBase):
     )
     # Those reasons will be reported to Cinder.
     REASONS.add_subset(
-        'REPORTABLE_REASONS',
+        'INDIVIDUALLY_ACTIONABLE_REASONS',
         ('HATEFUL_VIOLENT_DECEPTIVE', 'ILLEGAL', 'POLICY_VIOLATION', 'SOMETHING_ELSE'),
     )
     # Abuse in these locations are handled by reviewers
@@ -786,10 +786,10 @@ class AbuseReport(ModelBase):
             return self.addon
 
     @property
-    def is_reportable(self):
+    def is_individually_actionable(self):
         """Is this abuse report reportable under DSA, so should be sent to Cinder"""
         return bool(
-            self.reason in AbuseReport.REASONS.REPORTABLE_REASONS
+            self.reason in AbuseReport.REASONS.INDIVIDUALLY_ACTIONABLE_REASONS
             and (
                 not self.guid
                 or (

--- a/src/olympia/abuse/serializers.py
+++ b/src/olympia/abuse/serializers.py
@@ -155,7 +155,7 @@ class BaseAbuseReportSerializer(AMOModelSerializer):
         instance = super().create(validated_data)
         if (
             waffle.switch_is_active('dsa-job-technical-processing')
-            and validated_data.get('reason') in AbuseReport.REASONS.REPORTABLE_REASONS
+            and instance.is_reportable
         ):
             # call task to fire off cinder report
             report_to_cinder.delay(instance.id)

--- a/src/olympia/abuse/serializers.py
+++ b/src/olympia/abuse/serializers.py
@@ -155,7 +155,7 @@ class BaseAbuseReportSerializer(AMOModelSerializer):
         instance = super().create(validated_data)
         if (
             waffle.switch_is_active('dsa-job-technical-processing')
-            and instance.is_reportable
+            and instance.is_individually_actionable
         ):
             # call task to fire off cinder report
             report_to_cinder.delay(instance.id)

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -482,11 +482,11 @@ class TestAbuseReport(TestCase):
         report.update(rating=None, collection=collection)
         assert report.target == collection
 
-    def test_is_reportable(self):
+    def test_is_individually_actionable(self):
         report = AbuseReport.objects.create(
             guid='@lol', reason=AbuseReport.REASONS.HATEFUL_VIOLENT_DECEPTIVE
         )
-        assert report.is_reportable is False
+        assert report.is_individually_actionable is False
         addon = addon_factory(guid='@lol')
         user = user_factory()
         for target in (
@@ -505,9 +505,9 @@ class TestAbuseReport(TestCase):
                     **target,
                 },
             )
-            assert report.is_reportable is False
+            assert report.is_individually_actionable is False
             report.update(reason=AbuseReport.REASONS.HATEFUL_VIOLENT_DECEPTIVE)
-            assert report.is_reportable is True
+            assert report.is_individually_actionable is True
 
         report.update(
             guid=addon.guid,
@@ -516,16 +516,16 @@ class TestAbuseReport(TestCase):
             collection=None,
             addon_version=addon.current_version.version,
         )
-        assert report.is_reportable is True
+        assert report.is_individually_actionable is True
 
         self.make_addon_unlisted(addon)
-        assert report.is_reportable is False
+        assert report.is_individually_actionable is False
 
         Version.objects.get(version=report.addon_version).delete()
-        assert report.is_reportable is False
+        assert report.is_individually_actionable is False
 
         Version.unfiltered.get(version=report.addon_version).delete(hard=True)
-        assert report.is_reportable is True
+        assert report.is_individually_actionable is True
 
     def test_is_handled_by_reviewers(self):
         addon = addon_factory()

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -522,6 +522,9 @@ class TestAbuseReport(TestCase):
         assert report.is_reportable is False
 
         Version.objects.get(version=report.addon_version).delete()
+        assert report.is_reportable is False
+
+        Version.unfiltered.get(version=report.addon_version).delete(hard=True)
         assert report.is_reportable is True
 
     def test_is_handled_by_reviewers(self):

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -521,11 +521,12 @@ class TestAbuseReport(TestCase):
         self.make_addon_unlisted(addon)
         assert report.is_individually_actionable is False
 
+        self.make_addon_listed(addon)
         Version.objects.get(version=report.addon_version).delete()
-        assert report.is_individually_actionable is False
+        assert report.is_individually_actionable is True
 
         Version.unfiltered.get(version=report.addon_version).delete(hard=True)
-        assert report.is_individually_actionable is True
+        assert report.is_individually_actionable is False
 
     def test_is_handled_by_reviewers(self):
         addon = addon_factory()

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -31,7 +31,7 @@ from olympia.constants.abuse import (
 )
 from olympia.ratings.models import Rating
 from olympia.reviewers.models import NeedsHumanReview
-from olympia.versions.models import VersionReviewerFlags
+from olympia.versions.models import Version, VersionReviewerFlags
 
 from ..cinder import (
     CinderAddon,
@@ -66,7 +66,7 @@ from ..utils import (
 )
 
 
-class TestAbuse(TestCase):
+class TestAbuseReport(TestCase):
     fixtures = ['base/addon_3615', 'base/user_999']
 
     def test_choices(self):
@@ -481,6 +481,48 @@ class TestAbuse(TestCase):
         collection = collection_factory()
         report.update(rating=None, collection=collection)
         assert report.target == collection
+
+    def test_is_reportable(self):
+        report = AbuseReport.objects.create(
+            guid='@lol', reason=AbuseReport.REASONS.HATEFUL_VIOLENT_DECEPTIVE
+        )
+        assert report.is_reportable is False
+        addon = addon_factory(guid='@lol')
+        user = user_factory()
+        for target in (
+            {'guid': addon.guid},
+            {'user': user},
+            {'rating': Rating.objects.create(user=user, addon=addon, rating=5)},
+            {'collection': collection_factory()},
+        ):
+            report.update(
+                reason=AbuseReport.REASONS.FEEDBACK_SPAM,
+                **{
+                    'guid': None,
+                    'user': None,
+                    'rating': None,
+                    'collection': None,
+                    **target,
+                },
+            )
+            assert report.is_reportable is False
+            report.update(reason=AbuseReport.REASONS.HATEFUL_VIOLENT_DECEPTIVE)
+            assert report.is_reportable is True
+
+        report.update(
+            guid=addon.guid,
+            user=None,
+            rating=None,
+            collection=None,
+            addon_version=addon.current_version.version,
+        )
+        assert report.is_reportable is True
+
+        self.make_addon_unlisted(addon)
+        assert report.is_reportable is False
+
+        Version.objects.get(version=report.addon_version).delete()
+        assert report.is_reportable is True
 
     def test_is_handled_by_reviewers(self):
         addon = addon_factory()


### PR DESCRIPTION
Fixes: mozilla/addons#14985

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

The check for whether an abuse report should be reported to cinder has been extracted out to a function so we can test it more thoroughly.

### Context

There may also be future work to reduce the reports we are submitting, so having the logic for that in a contained place that can be tested is helpful for that also.  I additionally added a query on `guid`, because previously we would create a task for guids that are unknown to AMO, even though there wasn't anything we could possibly review from an unknown guid.

### Testing

- prerequisites
  -  `CINDER_API_TOKEN` set to a valid API token
  - waffle switch `dsa-job-technical-processing` enabled
- install an unlisted version of an add-on
  - either sign the unlisted version locally, and install that xpi (takes some setup in Firefox to be able to install them); or update a local Addon instance to have a matching guid, and a version with a matching version number (that is unlisted channel, and `is_signed=True`)
- report that add-on for abuse
- see the abuse report exists but no `CinderJob` instance (or errors raised in logs)
- repeat with a url pointing to guid that doesn't exist locally (same - AbuseReport instance, but no CinderJob)
- check the default case is still working - report for an abuse an add-on you _do_ have in your local database, and see there _is_ a CinderJob created, with a cinder_id set.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
