### PR TITLE
Remove obsolete validator caching

### DIFF
--- a/src/olympia/devhub/tests/test_utils.py
+++ b/src/olympia/devhub/tests/test_utils.py
@@ -127,27 +127,6 @@ class TestAddonsLinterListed(UploadMixin, TestCase):
         assert isinstance(tasks.validate(self.file_upload), AsyncResult)
         assert get_task_mock.return_value.delay.call_count == 1
 
-    def test_cache_key(self):
-        """Tests that the correct cache key is generated for a given object."""
-
-        assert (
-            utils.Validator(self.file).cache_key
-            == f'validation-task:files.File:{self.file.pk}:2'
-        )
-
-        assert utils.Validator(
-            self.file_upload
-        ).cache_key == 'validation-task:files.FileUpload:{}:2'.format(
-            self.file_upload.pk
-        )
-
-        self.file_upload.update(channel=amo.CHANNEL_UNLISTED)
-        assert utils.Validator(
-            self.file_upload
-        ).cache_key == 'validation-task:files.FileUpload:{}:1'.format(
-            self.file_upload.pk
-        )
-
 
 class TestLimitAddonsLinterResults(TestCase):
     """Test that higher priority messages are truncated last."""

--- a/src/olympia/devhub/tests/test_utils.py
+++ b/src/olympia/devhub/tests/test_utils.py
@@ -8,7 +8,6 @@ from django.test.utils import override_settings
 
 import pytest
 from celery import chord
-from celery.result import AsyncResult
 
 from olympia import amo
 from olympia.addons.models import Addon
@@ -99,33 +98,6 @@ class TestAddonsLinterListed(UploadMixin, TestCase):
             utils.Validator(self.file_upload, theme_specific=True)
         assert not repack_fileupload.called
         assert not validate_upload.called
-
-    @mock.patch.object(utils.Validator, 'get_task')
-    def test_run_once_per_file(self, get_task_mock):
-        """Tests that only a single validation task is run for a given file."""
-        get_task_mock.return_value.freeze.return_value = mock.Mock(id='42')
-
-        assert isinstance(tasks.validate(self.file), mock.Mock)
-        assert get_task_mock.return_value.delay.call_count == 1
-
-        assert isinstance(tasks.validate(self.file), AsyncResult)
-        assert get_task_mock.return_value.delay.call_count == 1
-
-        new_version = version_factory(addon=self.addon, version='0.0.2')
-        assert isinstance(tasks.validate(new_version.file), mock.Mock)
-        assert get_task_mock.return_value.delay.call_count == 2
-
-    @mock.patch.object(utils.Validator, 'get_task')
-    def test_run_once_file_upload(self, get_task_mock):
-        """Tests that only a single validation task is run for a given file
-        upload."""
-        get_task_mock.return_value.freeze.return_value = mock.Mock(id='42')
-
-        assert isinstance(tasks.validate(self.file_upload), mock.Mock)
-        assert get_task_mock.return_value.delay.call_count == 1
-
-        assert isinstance(tasks.validate(self.file_upload), AsyncResult)
-        assert get_task_mock.return_value.delay.call_count == 1
 
 
 class TestLimitAddonsLinterResults(TestCase):

--- a/src/olympia/devhub/utils.py
+++ b/src/olympia/devhub/utils.py
@@ -255,13 +255,6 @@ class Validator:
 
         self.task = chain(*validation_tasks)
 
-        # Create a cache key for the task, so multiple requests to validate the
-        # same object do not result in duplicate tasks.
-        opts = file_._meta
-        self.cache_key = 'validation-task:{}.{}:{}:{}'.format(
-            opts.app_label, opts.object_name, file_.pk, channel
-        )
-
     def get_task(self):
         """Return task chain to execute to trigger validation."""
         return self.task


### PR DESCRIPTION
This was only really relevant when validation could be triggered arbitrarily by reviewers for an existing File(Upload) that was laying around unvalidated.

That confusing and dangerous functionality no longer exists, FileUpload validation is always done once at upload and can't be triggered later.

When we still had post-request-task, that caching was broken for years and nobody noticed because the code path where we pulled the task id from the cache was never used.

Fixes mozilla/addons#14995