### PR TITLE
Only run verify build metadata on upstream PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
 
   test_run_docker_action:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, context]
 
     steps:
       - uses: actions/checkout@v4
@@ -127,8 +127,7 @@ jobs:
 
       - name: Verify Build Metadata
         uses: ./.github/actions/run-docker
-        env:
-          DOCKER_COMMIT: should_not_be_this
+        if: needs.context.outputs.is_fork == 'false'
         with:
           digest: ${{ needs.build.outputs.digest }}
           version: ${{ needs.build.outputs.version }}


### PR DESCRIPTION
Folluw up: [PR](https://github.com/mozilla/addons-server/pull/22611)


### Description

Forks build the docker image without setting the DOCKER_COMMIT/BUILD_URL resulting in a ci test expecting them to be set to fail.

### Context

We cannot set the DOCKER_COMMIT in the run-docker action as it would cause the tests to only pass as the value is set at runtime.

We don't execute build-docker on forks so we cannot run this test. It's okay

### Testing

CI passing on upstream and fork PR.

upstream: [link](https://github.com/mozilla/addons-server/actions/runs/10697406014/job/29654619080?pr=22634)
fork: [link](https://github.com/mozilla/addons-server/actions/runs/10697353786/job/29654377161?pr=22633)

### Checklist

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
