### PR TITLE
Don't send auto-approval email for langpacks

### DIFF
--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -1469,19 +1469,13 @@ class TestReviewHelper(TestReviewHelperBase):
         )
         assert activity.details['human_review'] is True
 
-    def test_nomination_to_public_not_human(self):
+    def _test_nomination_to_public_not_human(self):
         self.sign_file_mock.reset()
-        self.setup_data(amo.STATUS_NOMINATED, human_review=False)
 
         self.helper.handler.approve_latest_version()
 
         assert self.addon.status == amo.STATUS_APPROVED
         assert self.addon.versions.all()[0].file.status == (amo.STATUS_APPROVED)
-
-        assert len(mail.outbox) == 1
-        message = mail.outbox[0]
-        self.check_subject(message)
-        assert 'been automatically screened and tentatively approved' in message.body
 
         # AddonApprovalsCounter counter is now at 0 for this addon since there
         # was an automatic approval.
@@ -1503,6 +1497,19 @@ class TestReviewHelper(TestReviewHelperBase):
             .get()
         )
         assert activity.details['human_review'] is False
+
+    def test_nomination_to_public_not_human(self):
+        self.setup_data(amo.STATUS_NOMINATED, human_review=False)
+        self._test_nomination_to_public_not_human()
+        assert len(mail.outbox) == 1
+        message = mail.outbox[0]
+        self.check_subject(message)
+        assert 'been automatically screened and tentatively approved' in message.body
+
+    def test_nomination_to_public_not_human_langpack(self):
+        self.setup_data(amo.STATUS_NOMINATED, human_review=False, type=amo.ADDON_LPAPP)
+        self._test_nomination_to_public_not_human()
+        assert len(mail.outbox) == 0
 
     def test_public_addon_with_version_awaiting_review_to_public(self):
         self.sign_file_mock.reset()

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -1114,8 +1114,10 @@ class ReviewBase:
             AddonApprovalsCounter.reset_for_addon(addon=self.addon)
 
         self.log_action(amo.LOG.APPROVE_VERSION)
-        log.info('Sending email for %s' % (self.addon))
-        self.notify_decision()
+        if self.human_review or self.addon.type != amo.ADDON_LPAPP:
+            # Don't notify decisions (to cinder or owners) for auto-approved langpacks
+            log.info('Sending email for %s' % (self.addon))
+            self.notify_decision()
         self.log_public_message()
 
     def reject_latest_version(self):


### PR DESCRIPTION
Fixes: mozilla/addons#1968
<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Don't trigger the task which would email the developers of langpacks for auto-approvals

### Context

All langpacks are from Mozilla releng these days and they don't need the emails.  The logic is in the reviewer tools because further along, for example in CinderDecision.notify_reviewer_decision, nothing else other than emailing the developers of the add-on happens anyway - for approvals without attached jobs: we don't create a CinderDecision instance; we don't notify Cinder; there are no cinder jobs that could be resolved; and there can't be any reporters to be emailed.

### Testing

- Submit a langpack (this will probably be easier if it's a new version of an existing langpack, so you don't hit any other restrictions/delays on new submissions)
- manually run `manage.py cron autoapprove`
- see no approval email in django admin
- (repeat with some other type of add-on that would be auto approved and see the email)

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
