### PR TITLE
Update admin.py

### DIFF
--- a/src/olympia/amo/admin.py
+++ b/src/olympia/amo/admin.py
@@ -183,7 +183,7 @@ class AMOModelAdmin(admin.ModelAdmin):
         js = (
             'js/admin/ip_address_search.js',
             'js/exports.js',
-            'js/node_lib/netmask.js',
+            'netmask/lib/netmask.js',
         )
         css = {'all': ('css/admin/amoadmin.css',)}
 


### PR DESCRIPTION
Fixes: mozilla/addons#15007

### Description

When updating the static paths for npm module static assets, I forgot to update this asset in admin, causing 500 for missing file.

### Context

This didn't trigger a build failure because we do not compress this asset, but just collect it. I'm also somewhat surprised collectstatic would allow a nonexistent file to quietly pass through.

### Testing

Make up and navigate to any admin page. should load

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
