### PR TITLE
l10n - add Saraiki (skr) to languages.py

### DIFF
--- a/src/olympia/core/languages.py
+++ b/src/olympia/core/languages.py
@@ -214,6 +214,7 @@ ADDITIONAL_PRODUCT_LANGUAGES = {
         'native': '\u1c65\u1c5f\u1c71\u1c5b\u1c5f\u1c72\u1c64',
     },
     'si': {'english': 'Sinhala', 'native': '\u0dc3\u0dd2\u0d82\u0dc4\u0dbd'},
+    'skr': {'english': 'Saraiki', 'native': '\u0633\u0631\u0627\u0626\u06cc\u06a9\u06cc'},
     'son': {'english': 'Songhai', 'native': 'So\u014bay'},
     'sr': {'english': 'Serbian', 'native': '\u0421\u0440\u043f\u0441\u043a\u0438'},
     'sr-Cyrl': {'english': 'Serbian', 'native': '\u0421\u0440\u043f\u0441\u043a\u0438'},

--- a/src/olympia/core/languages.py
+++ b/src/olympia/core/languages.py
@@ -214,7 +214,10 @@ ADDITIONAL_PRODUCT_LANGUAGES = {
         'native': '\u1c65\u1c5f\u1c71\u1c5b\u1c5f\u1c72\u1c64',
     },
     'si': {'english': 'Sinhala', 'native': '\u0dc3\u0dd2\u0d82\u0dc4\u0dbd'},
-    'skr': {'english': 'Saraiki', 'native': '\u0633\u0631\u0627\u0626\u06cc\u06a9\u06cc'},
+    'skr': {
+        'english': 'Saraiki',
+        'native': '\u0633\u0631\u0627\u0626\u06cc\u06a9\u06cc',
+    },
     'son': {'english': 'Songhai', 'native': 'So\u014bay'},
     'sr': {'english': 'Serbian', 'native': '\u0421\u0440\u043f\u0441\u043a\u0438'},
     'sr-Cyrl': {'english': 'Serbian', 'native': '\u0421\u0440\u043f\u0441\u043a\u0438'},


### PR DESCRIPTION
Saraiki locale was added to Firefox starting from 128. This change is to ensure backend languages file matches the frontend changes being added in [this PR](https://github.com/mozilla/addons-frontend/pull/13189).

This adds the following:
Locale: skr
English: Saraiki
Native: سرائیکی