### PR TITLE
aggregate abuse triggers exclude dsa handled reports

### DIFF
--- a/src/olympia/abuse/tasks.py
+++ b/src/olympia/abuse/tasks.py
@@ -16,7 +16,13 @@ from olympia.amo.utils import to_language
 from olympia.reviewers.models import NeedsHumanReview, UsageTier
 from olympia.users.models import UserProfile
 
-from .models import AbuseReport, CinderDecision, CinderJob, CinderPolicy
+from .models import (
+    AbuseReport,
+    AbuseReportManager,
+    CinderDecision,
+    CinderJob,
+    CinderPolicy,
+)
 
 
 @task
@@ -43,7 +49,11 @@ def flag_high_abuse_reports_addons_according_to_review_tier():
 
     abuse_reports_count_qs = (
         AbuseReport.objects.values('guid')
-        .filter(guid=OuterRef('guid'), created__gte=datetime.now() - timedelta(days=14))
+        .filter(
+            ~AbuseReportManager.is_individually_actionable_q(assume_guid_exists=True),
+            guid=OuterRef('guid'),
+            created__gte=datetime.now() - timedelta(days=14),
+        )
         .annotate(guid_abuse_reports_count=Count('*'))
         .values('guid_abuse_reports_count')
         .order_by()

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -21,6 +21,7 @@ from olympia.amo.tests import (
     addon_factory,
     collection_factory,
     user_factory,
+    version_factory,
     version_review_flags_factory,
 )
 from olympia.constants.abuse import (
@@ -587,7 +588,7 @@ class TestAbuseReport(TestCase):
         assert not report.illegal_subcategory_cinder_value
 
 
-class TestAbuseManager(TestCase):
+class TestAbuseReportManager(TestCase):
     def test_for_addon_finds_by_author(self):
         addon = addon_factory(users=[user_factory()])
         report = AbuseReport.objects.create(user=addon.listed_authors[0])
@@ -603,6 +604,75 @@ class TestAbuseManager(TestCase):
         addon.update(guid='guid-reused-by-pk-42')
         report = AbuseReport.objects.create(guid='foo@bar')
         assert list(AbuseReport.objects.for_addon(addon)) == [report]
+
+    def test_is_individually_actionable(self):
+        user = user_factory()
+        addon = addon_factory(guid='@lol')
+        addon_report = AbuseReport.objects.create(
+            guid=addon.guid, reason=AbuseReport.REASONS.HATEFUL_VIOLENT_DECEPTIVE
+        )
+        user_report = AbuseReport.objects.create(
+            user=user, reason=AbuseReport.REASONS.HATEFUL_VIOLENT_DECEPTIVE
+        )
+        collection_report = AbuseReport.objects.create(
+            collection=collection_factory(),
+            reason=AbuseReport.REASONS.HATEFUL_VIOLENT_DECEPTIVE,
+        )
+        rating_report = AbuseReport.objects.create(
+            rating=Rating.objects.create(user=user, addon=addon, rating=5),
+            reason=AbuseReport.REASONS.HATEFUL_VIOLENT_DECEPTIVE,
+        )
+        listed_version_report = AbuseReport.objects.create(
+            guid=addon.guid,
+            addon_version=addon.current_version.version,
+            reason=AbuseReport.REASONS.HATEFUL_VIOLENT_DECEPTIVE,
+        )
+        listed_deleted_version_report = AbuseReport.objects.create(
+            guid=addon.guid,
+            addon_version=version_factory(addon=addon, deleted=True).version,
+            reason=AbuseReport.REASONS.HATEFUL_VIOLENT_DECEPTIVE,
+        )
+
+        # some reports that aren't individually actionable:
+        # non-actionable reason
+        AbuseReport.objects.create(
+            guid=addon.guid, reason=AbuseReport.REASONS.FEEDBACK_SPAM
+        )
+        AbuseReport.objects.create(user=user, reason=AbuseReport.REASONS.FEEDBACK_SPAM)
+        AbuseReport.objects.create(
+            collection=collection_factory(), reason=AbuseReport.REASONS.FEEDBACK_SPAM
+        )
+        AbuseReport.objects.create(
+            rating=Rating.objects.create(user=user, addon=addon, rating=5),
+            reason=AbuseReport.REASONS.FEEDBACK_SPAM,
+        )
+        # guid doesn't exist
+        AbuseReport.objects.create(
+            guid='dfdf', reason=AbuseReport.REASONS.HATEFUL_VIOLENT_DECEPTIVE
+        )
+        # unlisted version
+        AbuseReport.objects.create(
+            guid=addon.guid,
+            addon_version=version_factory(
+                addon=addon, channel=amo.CHANNEL_UNLISTED
+            ).version,
+            reason=AbuseReport.REASONS.HATEFUL_VIOLENT_DECEPTIVE,
+        )
+        # invalid version
+        AbuseReport.objects.create(
+            guid=addon.guid,
+            addon_version='123456',
+            reason=AbuseReport.REASONS.HATEFUL_VIOLENT_DECEPTIVE,
+        )
+
+        assert set(AbuseReport.objects.all().is_individually_actionable()) == {
+            addon_report,
+            collection_report,
+            user_report,
+            rating_report,
+            listed_version_report,
+            listed_deleted_version_report,
+        }
 
 
 class TestCinderJobManager(TestCase):


### PR DESCRIPTION
Fixes: mozilla/addons#14993

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Filters out `AbuseReport`s that have been (or will be) reviewed individually, because they fall under DSA regulations.  Because all of those will result in the add-on being reviewed by a human it is redundant to consider if we need to flag the add-on separately for needs human review based on thresholds

### Context

This builds on the changes in mozilla/addons#14985 / #22625: first refactoring into a queryset method; before abstracting the logic into a `Q` instance that can be easily negated; then adding to the query in `flag_high_abuse_reports_addons_according_to_review_tier`

### Testing
- create a bunch of abuse reports for an add-on; some that would go to cinder (DSA related reasons like illegality); some that wouldn't (like SPAM)
- create a UsageTier instance in django admin that is lower than than the total number of reports, but higher than the DSA related ones - e.g set at 3 abuse reports, and you created 4, but two of them had a DSA related reason
- (Other extended testing - because the code is refactored - the same as for https://github.com/mozilla/addons/issues/14985)

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [ ] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
