### PR TITLE
Notify Developer if an Attachment is Included in a Reviewer Action

### DIFF
--- a/src/olympia/activity/templates/activity/emails/from_reviewer.txt
+++ b/src/olympia/activity/templates/activity/emails/from_reviewer.txt
@@ -6,9 +6,11 @@ A reviewer at addons.mozilla.org is contacting you regarding version {{ number }
 
 {{ comments|safe }}
 
-
+{% if has_attachment %}
+An attachment was provided. To respond or view the file, visit {{ url }}.
+{% else %}
 To respond, please reply to this email or visit {{ url }}.
-
+{% endif %}
 
 Thank you for your attention.
 

--- a/src/olympia/activity/utils.py
+++ b/src/olympia/activity/utils.py
@@ -284,6 +284,7 @@ def notify_about_activity_log(
         'number': version.version,
         'author': sender_name,
         'comments': comments,
+        'has_attachment': hasattr(note, 'attachmentlog'),
         'url': absolutify(addon.get_dev_url('versions')),
         'SITE_URL': settings.SITE_URL,
         'email_reason': 'you are listed as an author of this add-on',


### PR DESCRIPTION
Fixes: mozilla/addons#15018

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Modifies the email template to indicate that an attachment was included in a reviewer's action.

<!--
Your PR will be squashed when merged so the 1st commit must contain a descriptive and concise summary of the change.
Additional details should be added in the description. If your change is simple enough to summarize in the commit, or
if it is not relevant for your PR, remove this section.
-->

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
