### PR TITLE
Allow Zip Files to be Uploaded as Attachment

### DIFF
--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1129,7 +1129,8 @@ MAX_ICON_UPLOAD_SIZE = MAX_IMAGE_UPLOAD_SIZE
 MAX_PHOTO_UPLOAD_SIZE = MAX_IMAGE_UPLOAD_SIZE
 MAX_STATICTHEME_SIZE = 7 * 1024 * 1024
 MAX_ZIP_UNCOMPRESSED_SIZE = 200 * 1024 * 1024
-# Not a Django setting -- needs to be implemented by relevant forms -- see: validate_review_attachment()
+# Not a Django setting -- needs to be implemented by relevant forms
+# See: validate_review_attachment()
 MAX_UPLOAD_SIZE = 200 * 1024 * 1024
 
 # File uploads should have -rw-r--r-- permissions in order to be served by

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1129,6 +1129,8 @@ MAX_ICON_UPLOAD_SIZE = MAX_IMAGE_UPLOAD_SIZE
 MAX_PHOTO_UPLOAD_SIZE = MAX_IMAGE_UPLOAD_SIZE
 MAX_STATICTHEME_SIZE = 7 * 1024 * 1024
 MAX_ZIP_UNCOMPRESSED_SIZE = 200 * 1024 * 1024
+# Not a Django setting -- needs to be implemented by relevant forms -- see: validate_review_attachment()
+MAX_UPLOAD_SIZE = 200 * 1024 * 1024
 
 # File uploads should have -rw-r--r-- permissions in order to be served by
 # nginx later one. The 0o prefix is intentional, this is an octal value.

--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -316,9 +316,7 @@ def validate_review_attachment(value):
                 )
             )
         if value.size >= settings.MAX_UPLOAD_SIZE:
-            raise forms.ValidationError(
-                gettext('File too large.')
-            )
+            raise forms.ValidationError(gettext('File too large.'))
         try:
             if value.name.endswith('.zip'):
                 # See clean_source() in WithSourceMixin
@@ -395,8 +393,11 @@ class ReviewForm(forms.Form):
         widget=ReasonsChoiceWidget,
     )
     attachment_file = forms.FileField(
-        required=False, validators=[validate_review_attachment],
-        widget=forms.ClearableFileInput(attrs={'max_upload_size': settings.MAX_UPLOAD_SIZE})
+        required=False,
+        validators=[validate_review_attachment],
+        widget=forms.ClearableFileInput(
+            attrs={'max_upload_size': settings.MAX_UPLOAD_SIZE}
+        ),
     )
     attachment_input = forms.CharField(required=False, widget=forms.Textarea())
 
@@ -406,7 +407,6 @@ class ReviewForm(forms.Form):
         required=False,
         queryset=CinderJob.objects.none(),
         widget=CinderJobsWidget(attrs={'class': 'data-toggle-hide'}),
-        
     )
 
     cinder_policies = forms.ModelMultipleChoiceField(

--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -315,9 +315,9 @@ def validate_review_attachment(value):
                     'file {extensions}.'.format(extensions=valid_extensions_string)
                 )
             )
-        if value.size >= settings.MAX_ZIP_UNCOMPRESSED_SIZE:
+        if value.size >= settings.MAX_UPLOAD_SIZE:
             raise forms.ValidationError(
-                gettext('File too large; the maximum file size is 200MB.')
+                gettext('File too large.')
             )
         try:
             if value.name.endswith('.zip'):
@@ -395,7 +395,8 @@ class ReviewForm(forms.Form):
         widget=ReasonsChoiceWidget,
     )
     attachment_file = forms.FileField(
-        required=False, validators=[validate_review_attachment]
+        required=False, validators=[validate_review_attachment],
+        widget=forms.ClearableFileInput(attrs={'max_upload_size': settings.MAX_UPLOAD_SIZE})
     )
     attachment_input = forms.CharField(required=False, widget=forms.Textarea())
 
@@ -405,6 +406,7 @@ class ReviewForm(forms.Form):
         required=False,
         queryset=CinderJob.objects.none(),
         widget=CinderJobsWidget(attrs={'class': 'data-toggle-hide'}),
+        
     )
 
     cinder_policies = forms.ModelMultipleChoiceField(

--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -396,7 +396,7 @@ class ReviewForm(forms.Form):
         required=False,
         validators=[validate_review_attachment],
         widget=forms.ClearableFileInput(
-            attrs={'max_upload_size': settings.MAX_UPLOAD_SIZE}
+            attrs={'data-max-upload-size': settings.MAX_UPLOAD_SIZE}
         ),
     )
     attachment_input = forms.CharField(required=False, widget=forms.Textarea())

--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -1,7 +1,8 @@
-from datetime import timedelta
 import zipfile
+from datetime import timedelta
 
 from django import forms
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db.models import Exists, OuterRef
 from django.forms import widgets
@@ -15,7 +16,6 @@ from django.utils.translation import gettext
 
 import markupsafe
 
-from django.conf import settings
 import olympia.core.logger
 from olympia import amo, ratings
 from olympia.abuse.models import CinderJob, CinderPolicy
@@ -316,7 +316,9 @@ def validate_review_attachment(value):
                 )
             )
         if value.size >= settings.MAX_ZIP_UNCOMPRESSED_SIZE:
-            raise forms.ValidationError(gettext('File too large; the maximum file size is 200MB.'))
+            raise forms.ValidationError(
+                gettext('File too large; the maximum file size is 200MB.')
+            )
         try:
             if value.name.endswith('.zip'):
                 # See clean_source() in WithSourceMixin

--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -325,8 +325,8 @@ def validate_review_attachment(value):
                 zip_file = SafeZip(value)
                 if zip_file.zip_file.testzip() is not None:
                     raise zipfile.BadZipFile()
-        except (zipfile.BadZipFile, OSError, EOFError):
-            raise forms.ValidationError(gettext('Invalid or broken archive.'))
+        except (zipfile.BadZipFile, OSError, EOFError) as err:
+            raise forms.ValidationError(gettext('Invalid or broken archive.')) from err
     return value
 
 

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -274,8 +274,10 @@
           <div id="attachment_file_wrapper" class="hidden">
               {{ form.attachment_file }}
           </div>
-          {{ form.attachment_input.errors }}
-          {{ form.attachment_file.errors }}
+          <div id="attachment_errors">
+            {{ form.attachment_input.errors }}
+            {{ form.attachment_file.errors }}
+          </div>
         </div>
       {% endif %}
       <div class="review-actions-section review-actions-save">

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -7,11 +7,10 @@ from collections import OrderedDict
 from datetime import datetime, timedelta
 from unittest import mock
 
-from django.core.files import File
 from django.conf import settings
 from django.core import mail
 from django.core.cache import cache
-from django.core.files import temp
+from django.core.files import File, temp
 from django.core.files.base import ContentFile, File as DjangoFile
 from django.db import connection, reset_queries
 from django.template import defaultfilters
@@ -2691,7 +2690,7 @@ class TestReview(ReviewBase):
             'Invalid or broken archive.',
             response.content.decode('utf-8'),
         )
-    
+
     @override_switch('enable-activity-log-attachments', active=True)
     def test_attachment_large_upload(self):
         # Any file greater than 200mb should be rejected.

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -3066,9 +3066,9 @@ class TestReview(ReviewBase):
                 'attachment_input': 'build log',
             },
         )
-
         response = self.client.get(self.url)
         assert response.status_code == 200
+        assert pq(response.content)('#id_attachment_file').attr('data-max-upload-size')
         doc = pq(response.content)('#versions-history .review-files')
         assert doc('th').eq(1).text() == 'Commented'
         assert doc('.history-comment').eq(0).text() == 'hello sailor'

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -2693,11 +2693,10 @@ class TestReview(ReviewBase):
 
     @override_switch('enable-activity-log-attachments', active=True)
     def test_attachment_large_upload(self):
-        # Any file greater than 200mb should be rejected.
+        # Any file greater than the limit should be rejected.
         assert AttachmentLog.objects.count() == 0
-        file_buffer = io.BytesIO(b'0' * (settings.MAX_ZIP_UNCOMPRESSED_SIZE + 1))
+        file_buffer = io.BytesIO(b'0' * (settings.MAX_UPLOAD_SIZE + 1))
         attachment = File(file_buffer, name='im_too_big.txt')
-
         response = self.client.post(
             self.url,
             {
@@ -2709,7 +2708,7 @@ class TestReview(ReviewBase):
         assert response.status_code != 302
         assert AttachmentLog.objects.count() == 0
         self.assertIn(
-            'File too large; the maximum file size is',
+            'File too large.',
             response.content.decode('utf-8'),
         )
 

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -2666,10 +2666,11 @@ class TestReview(ReviewBase):
         assert response.status_code != 302
         assert AttachmentLog.objects.count() == 0
         self.assertIn(
-            'Unsupported file type, please upload a file (.txt, .zip))',
+            'Unsupported file type, please upload a file (.txt, .zip)',
             response.content.decode('utf-8'),
         )
 
+    @override_switch('enable-activity-log-attachments', active=True)
     def test_attachment_invalid_zip_upload(self):
         # A file disguised to be a .zip should fail.
         assert AttachmentLog.objects.count() == 0

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -2696,7 +2696,7 @@ class TestReview(ReviewBase):
     def test_attachment_large_upload(self):
         # Any file greater than 200mb should be rejected.
         assert AttachmentLog.objects.count() == 0
-        file_buffer = io.BytesIO(b'0' * (201 * 1024 * 1024))
+        file_buffer = io.BytesIO(b'0' * (settings.MAX_ZIP_UNCOMPRESSED_SIZE + 1))
         attachment = File(file_buffer, name='im_too_big.txt')
 
         response = self.client.post(
@@ -2710,7 +2710,7 @@ class TestReview(ReviewBase):
         assert response.status_code != 302
         assert AttachmentLog.objects.count() == 0
         self.assertIn(
-            'File too large; the maximum file size is 200MB.',
+            'File too large; the maximum file size is',
             response.content.decode('utf-8'),
         )
 

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -2669,7 +2669,7 @@ class TestReview(ReviewBase):
             'Unsupported file type, please upload a file (.txt, .zip))',
             response.content.decode('utf-8'),
         )
-    
+
     def test_attachment_invalid_zip_upload(self):
         # A file disguised to be a .zip should fail.
         assert AttachmentLog.objects.count() == 0

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -2666,7 +2666,26 @@ class TestReview(ReviewBase):
         assert response.status_code != 302
         assert AttachmentLog.objects.count() == 0
         self.assertIn(
-            'Unsupported file type, please upload a file (.txt)',
+            'Unsupported file type, please upload a file (.txt, .zip))',
+            response.content.decode('utf-8'),
+        )
+    
+    def test_attachment_invalid_zip_upload(self):
+        # A file disguised to be a .zip should fail.
+        assert AttachmentLog.objects.count() == 0
+        attachment = ContentFile("I'm an evil text file", name='attachment.zip')
+        response = self.client.post(
+            self.url,
+            {
+                'action': 'reply',
+                'comments': 'hello sailor',
+                'attachment_file': attachment,
+            },
+        )
+        assert response.status_code != 302
+        assert AttachmentLog.objects.count() == 0
+        self.assertIn(
+            'Invalid or broken archive.',
             response.content.decode('utf-8'),
         )
 

--- a/static/js/zamboni/reviewers.js
+++ b/static/js/zamboni/reviewers.js
@@ -247,16 +247,19 @@ $('#id_attachment_file').on('change', function () {
   const file = this.files[0];
   const max_upload_size = $(this).attr('max_upload_size');
   if (file) {
-      if (file.size > max_upload_size) {
-          error = $('<ul>').attr('class', 'errorlist').append(
-            $('<li>').append(
-              format(gettext('Your file exceeds the maximum size of {0}.'), 
-              ['200MB'])
-          )
-          )
-          $('#attachment_errors').append(error);
-          $(this).val('');
-      }
+    if (file.size > max_upload_size) {
+      error = $('<ul>')
+        .attr('class', 'errorlist')
+        .append(
+          $('<li>').append(
+            format(gettext('Your file exceeds the maximum size of {0}.'), [
+              '200MB',
+            ]),
+          ),
+        );
+      $('#attachment_errors').append(error);
+      $(this).val('');
+    }
   }
 });
 

--- a/static/js/zamboni/reviewers.js
+++ b/static/js/zamboni/reviewers.js
@@ -253,7 +253,12 @@ $('#id_attachment_file').on('change', function () {
         .append(
           $('<li>').append(
             format(gettext('Your file exceeds the maximum size of {0}.'), [
-              '200MB',
+              Intl.NumberFormat(document.documentElement.lang, {
+                notation: 'compact',
+                style: 'unit',
+                unit: 'byte',
+                unitDisplay: 'narrow',
+              }).format(max_upload_size),
             ]),
           ),
         );

--- a/static/js/zamboni/reviewers.js
+++ b/static/js/zamboni/reviewers.js
@@ -242,6 +242,24 @@ function callReviewersAPI(apiUrl, method, data, successCallback) {
   });
 }
 
+$('#id_attachment_file').on('change', function () {
+  $('#attachment_errors').empty();
+  const file = this.files[0];
+  const max_upload_size = $(this).attr('max_upload_size');
+  if (file) {
+      if (file.size > max_upload_size) {
+          error = $('<ul>').attr('class', 'errorlist').append(
+            $('<li>').append(
+              format(gettext('Your file exceeds the maximum size of {0}.'), 
+              ['200MB'])
+          )
+          )
+          $('#attachment_errors').append(error);
+          $(this).val('');
+      }
+  }
+});
+
 function initExtraReviewActions() {
   /* Inline actions that should trigger a XHR and modify the form element
    * accordingly.

--- a/static/js/zamboni/reviewers.js
+++ b/static/js/zamboni/reviewers.js
@@ -245,7 +245,7 @@ function callReviewersAPI(apiUrl, method, data, successCallback) {
 $('#id_attachment_file').on('change', function () {
   $('#attachment_errors').empty();
   const file = this.files[0];
-  const max_upload_size = $(this).attr('max_upload_size');
+  const max_upload_size = $(this).data('max-upload-size');
   if (file) {
     if (file.size > max_upload_size) {
       error = $('<ul>')


### PR DESCRIPTION
Fixes: mozilla/addons#14999

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Builds on #22640 to allow .zip files to be uploaded as attachment.

![image](https://github.com/user-attachments/assets/466ad7b9-5f73-4b37-9301-6a4bbef11515)

**Note**: The local nginx configuration fails for large files. There's an issue filed for this [here](https://github.com/mozilla/addons/issues/15029). To test this feature locally, two lines in `addons.conf` need to be changed --
1. `try_files $uri @frontendamo;` -> `try_files $uri @olympia;`
2. `client_max_body_size 50m;`-> `client_max_body_size 500m;` (or anything else bigger than 200mb)


### Testing

<!--
Your change must be related to an existing, open issue. This issue should contain testing instructions.
Often, the testing info in the issue is higher level, geared towards a user or QA experience.
Here you can provide information for a developer verifying this PR. Get technical.
If it is not relevant to your PR, remove this section.
-->

1. Enable the `enable-activity-log-attachments` waffle switch.
3. Log in with local_admin@mozilla.com (for ease of navigation).
4. Submit a new add-on.
5. Make a reviewer reply (or any other action) from the review action section and include a zip attachment.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
