### PR TITLE
Remove docker context switcher

### DIFF
--- a/Makefile-os
+++ b/Makefile-os
@@ -4,7 +4,6 @@
 # Variables referenced in docker-compose*.yml should be read from .env, exported and saved in .env
 ####################################################################################################
 
-DOCKER_BUILDER ?= default
 DOCKER_PROGRESS ?= auto
 DOCKER_METADATA_FILE ?= buildx-bake-metadata.json
 DOCKER_PUSH ?=
@@ -96,16 +95,12 @@ data_restore:
 
 	$(MAKE) reindex_data
 
-	.PHONY: docker_use_builder
-docker_use_builder: ## Specify a docker builder to use. defaults to "default"
-	docker buildx use $(DOCKER_BUILDER)
-
 .PHONY: docker_compose_config
 docker_compose_config: ## Show the docker compose configuration
 	@docker compose config web --format json
 
 .PHONY: docker_build_web
-docker_build_web: docker_use_builder ## Build the docker images using buildx bake
+docker_build_web: ## Build the docker images using buildx bake
 	docker buildx bake $(DOCKER_BAKE_ARGS) $(ARGS)
 
 .PHONY: docker_pull_web

--- a/docs/topics/development/setup_and_configuration.md
+++ b/docs/topics/development/setup_and_configuration.md
@@ -349,3 +349,40 @@ validating /Users/user/mozilla/addons-server/docker-compose.yml: services.worker
 ```
 
 To fix this error, run `make setup` to ensure you have an up-to-date .env file locally.
+
+### Invalid docker context
+
+We have in the past used custom docker build contexts to build and run addons-server.
+We currently use the `default` builder context so if you get this error running make up:
+
+```bash
+ERROR: run `docker context use default` to switch to default context
+18306 v0.16.1-desktop.1 /Users/awagner/.docker/cli-plugins/docker-buildx buildx use default
+github.com/docker/buildx/commands.runUse
+	github.com/docker/buildx/commands/use.go:31
+github.com/docker/buildx/commands.useCmd.func1
+	github.com/docker/buildx/commands/use.go:73
+github.com/docker/cli/cli-plugins/plugin.RunPlugin.func1.1.2
+	github.com/docker/cli@v27.0.3+incompatible/cli-plugins/plugin/plugin.go:64
+github.com/spf13/cobra.(*Command).execute
+	github.com/spf13/cobra@v1.8.1/command.go:985
+github.com/spf13/cobra.(*Command).ExecuteC
+	github.com/spf13/cobra@v1.8.1/command.go:1117
+github.com/spf13/cobra.(*Command).Execute
+	github.com/spf13/cobra@v1.8.1/command.go:1041
+github.com/docker/cli/cli-plugins/plugin.RunPlugin
+	github.com/docker/cli@v27.0.3+incompatible/cli-plugins/plugin/plugin.go:79
+main.runPlugin
+	github.com/docker/buildx/cmd/buildx/main.go:67
+main.main
+	github.com/docker/buildx/cmd/buildx/main.go:84
+runtime.main
+	runtime/proc.go:271
+runtime.goexit
+	runtime/asm_arm64.s:1222
+
+make[1]: *** [docker_use_builder] Error 1
+make: *** [docker_pull_or_build] Error 2
+```
+
+To fix this error, run `docker context use default` to switch to the default builder context.


### PR DESCRIPTION
Fixes: mozilla/addons#15027

### Description

We do not need to explicitly set context. It shoud be set for most active developers and new devs will not need to switch as default should be... default.

### Context

We used to have a custom builder for docker images. We now use the default daemon owned context "default"

The switched caused this bug where docker sometimes did not like how we speecify the default context... we don't really need to do this anymore and can just remove the code and add a gotcha if anyone sees this again.

### Testing

```bash
make up DOCKER_VERSION=local
```

Should work.

### Checklist


- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [X] Add or update relevant [docs](../docs/) reflecting the changes made.
