### PR TITLE
Show "pending" activity in devhub for all versions and not just the latest one

### DIFF
--- a/src/olympia/activity/models.py
+++ b/src/olympia/activity/models.py
@@ -3,7 +3,7 @@ import os
 import uuid
 from collections import defaultdict
 from copy import copy
-from datetime import datetime
+from datetime import date, datetime
 from inspect import isclass
 
 from django.apps import apps
@@ -40,6 +40,18 @@ log = olympia.core.logger.getLogger('z.amo.activity')
 MAX_TOKEN_USE_COUNT = 100
 
 GENERIC_USER_NAME = gettext('Add-ons Review Team')
+
+# Activity ids that are not considered as needing a reply from developers, so
+# they are never considered "pending".
+NOT_PENDING_IDS = (
+    amo.LOG.DEVELOPER_REPLY_VERSION.id,
+    amo.LOG.APPROVE_VERSION.id,
+    amo.LOG.REJECT_VERSION.id,
+    amo.LOG.PRELIMINARY_VERSION.id,
+    amo.LOG.PRELIMINARY_ADDON_MIGRATED.id,
+    amo.LOG.NOTES_FOR_REVIEWERS_CHANGED.id,
+    amo.LOG.SOURCE_CODE_UPLOADED.id,
+)
 
 
 def attachment_upload_path(instance, filename):
@@ -312,6 +324,23 @@ class DraftComment(ModelBase):
 class ActivityLogQuerySet(BaseQuerySet):
     def default_transformer(self, logs):
         ActivityLog.arguments_builder(logs)
+
+    def pending_for_developer(self):
+        latest_reply_date = models.functions.Coalesce(
+            models.Subquery(
+                self.filter(
+                    action__in=NOT_PENDING_IDS,
+                    versionlog__version_id=models.OuterRef('versionlog__version_id'),
+                )
+                .values('created')
+                .order_by('-created')[:1]
+            ),
+            date.min,
+        )
+        return self.filter(
+            action__in=amo.LOG_REVIEW_QUEUE_DEVELOPER,
+            created__gt=latest_reply_date,
+        )
 
 
 class ActivityLogManager(ManagerBase):

--- a/src/olympia/activity/models.py
+++ b/src/olympia/activity/models.py
@@ -347,8 +347,11 @@ class ActivityLogQuerySet(BaseQuerySet):
             date.min,
         )
         return (
-            # The subquery needs to appear after having already filtered by
-            # action.
+            # The subquery needs to run on the already filterd activities we
+            # care about (it uses `self`, i.e. the current state of the
+            # queryset), so we need to filter by action first, then trigger the
+            # subquery, then filter by the result, we can't group all of that
+            # in a single filter() call.
             self.filter(action__in=amo.LOG_REVIEW_QUEUE_DEVELOPER)
             .annotate(latest_reply_date=latest_reply_date)
             .filter(created__gt=models.F('latest_reply_date'))

--- a/src/olympia/activity/models.py
+++ b/src/olympia/activity/models.py
@@ -326,6 +326,13 @@ class ActivityLogQuerySet(BaseQuerySet):
         ActivityLog.arguments_builder(logs)
 
     def pending_for_developer(self, for_version=None):
+        """Return ActivityLog that are considered "pending" for developers.
+
+        An Activity will be considered "pending" if it's a review queue
+        activity not hidden to developers that is more recent that the latest
+        activity created by a developer/reviewer. Said differently: if a
+        developer doesn't do something after a reviewer action, that reviewer
+        action will be considered pending."""
         if for_version is None:
             for_version = models.OuterRef('versionlog__version_id')
         latest_reply_date = models.functions.Coalesce(

--- a/src/olympia/activity/tests/test_views.py
+++ b/src/olympia/activity/tests/test_views.py
@@ -302,7 +302,7 @@ class TestReviewNotesViewSetList(ReviewNotesViewSetDetailMixin, TestCase):
             'fiiiine', amo.LOG.REVIEWER_REPLY_VERSION, self.days_ago(0)
         )
         self._login_developer()
-        with self.assertNumQueries(17):
+        with self.assertNumQueries(16):
             # - 2 savepoints because of tests
             # - 2 user and groups
             # - 2 addon and its translations
@@ -315,8 +315,7 @@ class TestReviewNotesViewSetList(ReviewNotesViewSetDetailMixin, TestCase):
             #   enough yet to pass that to the activity log queryset, it's
             #   difficult since it's not a FK)
             # - 2 version and its translations (same issue)
-            # - 2 for highlighting (repeats the query to fetch the activity log
-            #   per version)
+            # - 1 for highlighting "pending" activities
             response = self.client.get(self.url)
             assert response.status_code == 200
 

--- a/src/olympia/activity/utils.py
+++ b/src/olympia/activity/utils.py
@@ -394,28 +394,6 @@ def send_activity_mail(
         )
 
 
-NOT_PENDING_IDS = (
-    amo.LOG.DEVELOPER_REPLY_VERSION.id,
-    amo.LOG.APPROVE_VERSION.id,
-    amo.LOG.REJECT_VERSION.id,
-    amo.LOG.PRELIMINARY_VERSION.id,
-    amo.LOG.PRELIMINARY_ADDON_MIGRATED.id,
-    amo.LOG.NOTES_FOR_REVIEWERS_CHANGED.id,
-    amo.LOG.SOURCE_CODE_UPLOADED.id,
-)
-
-
-def filter_queryset_to_pending_replies(queryset, log_type_ids=NOT_PENDING_IDS):
-    latest_reply_date = (
-        queryset.filter(action__in=log_type_ids)
-        .values_list('created', flat=True)
-        .first()
-    )
-    if not latest_reply_date:
-        return queryset
-    return queryset.filter(created__gt=latest_reply_date)
-
-
 def bounce_mail(message, reason):
     recipient_header = (
         None

--- a/src/olympia/activity/views.py
+++ b/src/olympia/activity/views.py
@@ -27,7 +27,6 @@ from olympia.activity.serializers import (
 from olympia.activity.tasks import process_email
 from olympia.activity.utils import (
     action_from_user,
-    filter_queryset_to_pending_replies,
     log_and_notify,
 )
 from olympia.addons.views import AddonChildMixin
@@ -96,9 +95,7 @@ class VersionReviewNotesViewSet(
     def get_serializer_context(self):
         ctx = super().get_serializer_context()
         ctx['to_highlight'] = list(
-            filter_queryset_to_pending_replies(self.get_queryset()).values_list(
-                'pk', flat=True
-            )
+            self.get_queryset().pending_for_developer().values_list('pk', flat=True)
         )
         return ctx
 

--- a/src/olympia/devhub/templates/devhub/versions/list.html
+++ b/src/olympia/devhub/templates/devhub/versions/list.html
@@ -62,8 +62,9 @@
           <a href="#" class="review-history-show" data-div="#{{ version.id }}-review-history"
             id="review-history-show-{{ version.id }}" data-version="{{ version.id }}">{{ _('Review History') }}</a>
           <a href="#" class="review-history-hide hidden">{{ _('Close Review History') }}</a>
-            {% if version.unread_count > 0 %}
-                <b class="review-history-pending-count">{{ version.unread_count }}</b>
+            {% set pending_count = pending_activity_log_count_for_developer(version) %}
+            {% if pending_count > 0 %}
+                <b class="review-history-pending-count">{{ pending_count }}</b>
             {% endif %}
       </div>
     </td>

--- a/src/olympia/devhub/templates/devhub/versions/list.html
+++ b/src/olympia/devhub/templates/devhub/versions/list.html
@@ -62,9 +62,8 @@
           <a href="#" class="review-history-show" data-div="#{{ version.id }}-review-history"
             id="review-history-show-{{ version.id }}" data-version="{{ version.id }}">{{ _('Review History') }}</a>
           <a href="#" class="review-history-hide hidden">{{ _('Close Review History') }}</a>
-            {% set pending_count = pending_activity_log_count_for_developer(version) %}
-            {% if pending_count > 0 %}
-                <b class="review-history-pending-count">{{ pending_count }}</b>
+            {% if version.unread_count > 0 %}
+                <b class="review-history-pending-count">{{ version.unread_count }}</b>
             {% endif %}
       </div>
     </td>

--- a/src/olympia/devhub/templates/devhub/versions/list.html
+++ b/src/olympia/devhub/templates/devhub/versions/list.html
@@ -62,12 +62,10 @@
           <a href="#" class="review-history-show" data-div="#{{ version.id }}-review-history"
             id="review-history-show-{{ version.id }}" data-version="{{ version.id }}">{{ _('Review History') }}</a>
           <a href="#" class="review-history-hide hidden">{{ _('Close Review History') }}</a>
-          {% if latest_version_in_channel_including_disabled == version %}
-              {% set pending_count = pending_activity_log_count_for_developer(version) %}
-              {% if pending_count > 0 %}
-                  <b class="review-history-pending-count">{{ pending_count }}</b>
-              {% endif %}
-          {% endif %}
+            {% set pending_count = pending_activity_log_count_for_developer(version) %}
+            {% if pending_count > 0 %}
+                <b class="review-history-pending-count">{{ pending_count }}</b>
+            {% endif %}
       </div>
     </td>
     <td class="file-validation">

--- a/src/olympia/devhub/templatetags/jinja_helpers.py
+++ b/src/olympia/devhub/templatetags/jinja_helpers.py
@@ -6,7 +6,6 @@ from django_jinja import library
 from olympia import amo
 from olympia.access import acl
 from olympia.activity.models import ActivityLog
-from olympia.activity.utils import filter_queryset_to_pending_replies
 from olympia.amo.templatetags.jinja_helpers import format_date, new_context, page_title
 from olympia.files.models import File
 
@@ -88,10 +87,8 @@ def summarize_validation(validation):
 
 @library.global_function
 def pending_activity_log_count_for_developer(version):
-    alog = ActivityLog.objects.for_versions(version).filter(
-        action__in=amo.LOG_REVIEW_QUEUE_DEVELOPER
-    )
-    return filter_queryset_to_pending_replies(alog).count()
+    alog = ActivityLog.objects.for_versions(version).pending_for_developer()
+    return alog.count()
 
 
 @library.global_function

--- a/src/olympia/devhub/templatetags/jinja_helpers.py
+++ b/src/olympia/devhub/templatetags/jinja_helpers.py
@@ -87,8 +87,12 @@ def summarize_validation(validation):
 
 @library.global_function
 def pending_activity_log_count_for_developer(version):
-    alog = ActivityLog.objects.for_versions(version).pending_for_developer()
-    return alog.count()
+    # unread_count is an annotation set by version_list() view to do this once
+    # for all versions in the list. We use it if it's present, otherwise fall
+    # back to the per-version computation.
+    if hasattr(version, 'unread_count'):
+        return version.unread_count
+    return ActivityLog.objects.for_versions(version).pending_for_developer().count()
 
 
 @library.global_function

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.core.files.storage import default_storage as storage
 from django.db import transaction
-from django.db.models import Count
+from django.db.models import Count, F, Func, OuterRef, Subquery
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.template import loader
@@ -1267,7 +1267,19 @@ def check_validation_override(request, form, addon, version):
 
 @dev_required
 def version_list(request, addon_id, addon):
-    qs = addon.versions.order_by('-created')
+    unread_count = (
+        (
+            ActivityLog.objects.all()
+            .pending_for_developer(for_version=OuterRef(OuterRef('id')))
+            .filter(versionlog__version=OuterRef('id'))
+            .values('id')
+        )
+        .annotate(count=Func(F('id'), function='COUNT'))
+        .values('count')
+    )
+    qs = addon.versions.annotate(unread_count=Subquery(unread_count)).order_by(
+        '-created'
+    )
     versions = amo_utils.paginate(request, qs)
     is_admin = acl.action_allowed_for(request.user, amo.permissions.REVIEWS_ADMIN)
 


### PR DESCRIPTION
Fixes: mozilla/addons#15024

## Context

See the issue - without this change, for a given add-on in devhub, only the last version in each channel shows the "pending" activity count. This makes it shown on all versions, while not increasing the query count (plenty more to optimize there though, but out of scope)

## Testing

See the issue but also the added tests of the model method + test around the view that were added.