### PR TITLE
clear REASONS.ABUSE_ADDON_VIOLATION if a forwarded job is combined

### DIFF
--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -1065,6 +1065,10 @@ class TestCinderJob(TestCase):
             version=addon.current_version,
             reason=NeedsHumanReview.REASONS.ABUSE_ADDON_VIOLATION,
         )
+        NeedsHumanReview.objects.create(
+            version=addon.current_version,
+            reason=NeedsHumanReview.REASONS.CINDER_ESCALATION,
+        )
 
         old_job.handle_job_recreated(new_job_id='5678')
 
@@ -1078,8 +1082,11 @@ class TestCinderJob(TestCase):
         assert list(exisiting_escalation_job.abusereport_set.all()) == [report]
         assert report.reload().cinder_job == exisiting_escalation_job
         assert NeedsHumanReview.objects.filter(
-            is_active=True
+            is_active=True, reason=NeedsHumanReview.REASONS.ABUSE_ADDON_VIOLATION
         ).exists()  # it's not cleared
+        assert NeedsHumanReview.objects.filter(
+            is_active=True, reason=NeedsHumanReview.REASONS.CINDER_ESCALATION
+        ).exists()  # and neither is the CINDER_ESCALATION NHR
 
     def test_handle_job_recreated_existing_report_job(self):
         addon = addon_factory()
@@ -1101,6 +1108,10 @@ class TestCinderJob(TestCase):
             version=addon.current_version,
             reason=NeedsHumanReview.REASONS.ABUSE_ADDON_VIOLATION,
         )
+        NeedsHumanReview.objects.create(
+            version=addon.current_version,
+            reason=NeedsHumanReview.REASONS.CINDER_ESCALATION,
+        )
 
         old_job.handle_job_recreated(new_job_id='5678')
 
@@ -1114,8 +1125,13 @@ class TestCinderJob(TestCase):
         ]
         assert report.reload().cinder_job == exisiting_report_job
         assert not NeedsHumanReview.objects.filter(
-            is_active=True
+            is_active=True,
+            reason=NeedsHumanReview.REASONS.ABUSE_ADDON_VIOLATION,
         ).exists()  # it's cleared
+        assert NeedsHumanReview.objects.filter(
+            is_active=True,
+            reason=NeedsHumanReview.REASONS.CINDER_ESCALATION,
+        ).exists()  # the CINDER_ESCALATION NHR isn't though
 
     def test_handle_job_recreated_appeal(self):
         addon = addon_factory()


### PR DESCRIPTION
Fixes: mozilla/addons#15001

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Clears NHR for an abuse report if a forwarded job is combined into it.

### Context

Cinder combines reports for the same queue together into single jobs.  So if a job existed in the content infringement queue for abuse report(s) then that would have a `ABUSE_ADDON_VIOLATION` NHR; if a job is forwarded and we recreate it in that infringement queue then it'll be combined into a single job (this is all fine).  But now we have a job that, effectively, has two NHR for it - one of the abuse report, one for the forward.  

I tried adjusting `CinderJob.clear_needs_human_review_flags` to clear both when the job was resolved but it turned out to be difficult, so this patch clears the unnecessary NHR just after the job has been recreated.

Ultimately this may all be code that is removed once AMO forwards are reimplemented using Cinder's new multi-queue escalations.

### Testing

Follow the STR in the issue - it's tricky to do though because it needs cinder api integration set up, and for the webhook responses to be applied locally.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
