### PR TITLE
Additional case handling for color parameter in search API

### DIFF
--- a/src/olympia/search/filters.py
+++ b/src/olympia/search/filters.py
@@ -442,12 +442,12 @@ class AddonColorQueryParam(AddonQueryParam):
         try:
             rgb = tuple(bytearray.fromhex(hexvalue))
         except ValueError:
-            rgb = (0, 0, 0)
+            raise ValueError(gettext('Expected a hex string color code.'))
         return colorgram.colorgram.hsl(*rgb)
 
     def get_value(self):
         color = self.query_data.get(self.query_param, '')
-        return self.convert_to_hsl(color.upper().lstrip('#'))
+        return self.convert_to_hsl(color.upper().lstrip('#')[:6]) if color else None
 
     def get_es_query(self):
         # Thresholds for saturation & luminosity that dictate which query to
@@ -457,6 +457,9 @@ class AddonColorQueryParam(AddonQueryParam):
         HIGH_LUMINOSITY = 255 * 98 / 100.0
 
         hsl = self.get_value()
+        if not hsl:
+            return []
+
         if hsl[1] <= LOW_SATURATION:
             # If we're given a color with a very low saturation, the user is
             # searching for a black/white/grey and we need to take saturation

--- a/src/olympia/search/filters.py
+++ b/src/olympia/search/filters.py
@@ -442,7 +442,7 @@ class AddonColorQueryParam(AddonQueryParam):
         try:
             rgb = tuple(bytearray.fromhex(hexvalue))
         except ValueError as err:
-            raise ValueError(gettext('Expected a hex string color code.')) from err
+            raise ValueError(gettext('Invalid "%s" parameter.' % self.query_param)) from err
         return colorgram.colorgram.hsl(*rgb)
 
     def get_value(self):

--- a/src/olympia/search/filters.py
+++ b/src/olympia/search/filters.py
@@ -441,8 +441,8 @@ class AddonColorQueryParam(AddonQueryParam):
             hexvalue = ''.join(2 * c for c in hexvalue)
         try:
             rgb = tuple(bytearray.fromhex(hexvalue))
-        except ValueError:
-            raise ValueError(gettext('Expected a hex string color code.'))
+        except ValueError as err:
+            raise ValueError(gettext('Expected a hex string color code.')) from err
         return colorgram.colorgram.hsl(*rgb)
 
     def get_value(self):

--- a/src/olympia/search/filters.py
+++ b/src/olympia/search/filters.py
@@ -442,7 +442,9 @@ class AddonColorQueryParam(AddonQueryParam):
         try:
             rgb = tuple(bytearray.fromhex(hexvalue))
         except ValueError as err:
-            raise ValueError(gettext('Invalid "%s" parameter.' % self.query_param)) from err
+            raise ValueError(
+                gettext('Invalid "%s" parameter.' % self.query_param)
+            ) from err
         return colorgram.colorgram.hsl(*rgb)
 
     def get_value(self):

--- a/src/olympia/search/tests/test_filters.py
+++ b/src/olympia/search/tests/test_filters.py
@@ -1061,7 +1061,6 @@ class TestSearchParameterFilter(FilterTestsBase):
         ]
 
         qs = self._filter(data={'color': '333'})
-        assert not qs
         filter_ = qs['query']['bool']['filter']
         assert len(filter_) == 1
         inner = filter_[0]['nested']['query']['bool']['filter']

--- a/src/olympia/search/tests/test_filters.py
+++ b/src/olympia/search/tests/test_filters.py
@@ -1036,6 +1036,18 @@ class TestSearchParameterFilter(FilterTestsBase):
             {'range': {'colors.ratio': {'gte': 0.25}}},
         ]
 
+        qs = self._filter(data={'color': '#00ffffalotofjunk'})
+        filter_ = qs['query']['bool']['filter']
+        assert len(filter_) == 1
+        inner = filter_[0]['nested']['query']['bool']['filter']
+        assert len(inner) == 4
+        assert inner == [
+            {'range': {'colors.s': {'gt': 6.375}}},
+            {'range': {'colors.l': {'gt': 12.75, 'lt': 249.9}}},
+            {'range': {'colors.h': {'gte': 101, 'lte': 153}}},
+            {'range': {'colors.ratio': {'gte': 0.25}}},
+        ]
+
     def test_search_by_color_grey(self):
         qs = self._filter(data={'color': '#f6f6f6'})
         filter_ = qs['query']['bool']['filter']
@@ -1049,6 +1061,7 @@ class TestSearchParameterFilter(FilterTestsBase):
         ]
 
         qs = self._filter(data={'color': '333'})
+        assert not qs
         filter_ = qs['query']['bool']['filter']
         assert len(filter_) == 1
         inner = filter_[0]['nested']['query']['bool']['filter']
@@ -1058,6 +1071,11 @@ class TestSearchParameterFilter(FilterTestsBase):
             {'range': {'colors.l': {'gte': 0, 'lte': 115}}},
             {'range': {'colors.ratio': {'gte': 0.25}}},
         ]
+
+    def test_search_by_color_invalid(self):
+        with self.assertRaises(serializers.ValidationError) as context:
+            self._filter(data={'color': '#gggggg'})
+        assert context.exception.detail == ['Expected a hex string color code.']
 
     def test_search_by_color_luminosity_extremes(self):
         qs = self._filter(data={'color': '080603'})

--- a/src/olympia/search/tests/test_filters.py
+++ b/src/olympia/search/tests/test_filters.py
@@ -1071,10 +1071,15 @@ class TestSearchParameterFilter(FilterTestsBase):
             {'range': {'colors.ratio': {'gte': 0.25}}},
         ]
 
+    def test_search_by_color_empty(self):
+        qs = self._filter(data={'color': ''})
+        # No filtering to apply.
+        assert not qs
+
     def test_search_by_color_invalid(self):
         with self.assertRaises(serializers.ValidationError) as context:
             self._filter(data={'color': '#gggggg'})
-        assert context.exception.detail == ['Expected a hex string color code.']
+        assert context.exception.detail == ['Invalid "color" parameter.']
 
     def test_search_by_color_luminosity_extremes(self):
         qs = self._filter(data={'color': '080603'})


### PR DESCRIPTION
Fixes: mozilla/addons#15022

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Handles cases as follows -- 
1. The empty color parameter is ignored. 
2. Otherwise, take the first 6 characters of the color parameter (after removing the #, if any). 3-character hex codes (ex. `#aaa`) still pass.
3. Throw ValueError if the value is still unparseable as a hex code.

<!--
Your PR will be squashed when merged so the 1st commit must contain a descriptive and concise summary of the change.
Additional details should be added in the description. If your change is simple enough to summarize in the commit, or
if it is not relevant for your PR, remove this section.
-->

### Testing

Directly use the search function for static themes, or to the API directly, ex.
`http://olympia.test/api/v5/addons/search/?type=statictheme&color=336699aa`

<!--
Your change must be related to an existing, open issue. This issue should contain testing instructions.
Often, the testing info in the issue is higher level, geared towards a user or QA experience.
Here you can provide information for a developer verifying this PR. Get technical.
If it is not relevant to your PR, remove this section.
-->

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
