### PR TITLE
Use setCustomValidity for File Uploads

### DIFF
--- a/src/olympia/devhub/forms.py
+++ b/src/olympia/devhub/forms.py
@@ -1137,7 +1137,12 @@ class NewUploadForm(CheckThrottlesFormMixin, forms.Form):
 
 
 class SourceForm(WithSourceMixin, AMOModelForm):
-    source = forms.FileField(required=False, widget=SourceFileInput)
+    source = forms.FileField(
+        required=False,
+        widget=SourceFileInput(
+            attrs={'data-max-upload-size': settings.MAX_UPLOAD_SIZE}
+        ),
+    )
     has_source = forms.ChoiceField(
         choices=(('yes', _('Yes')), ('no', _('No'))), required=True, widget=RadioSelect
     )

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -1330,6 +1330,26 @@ function initSourceSubmitOutcomes() {
       }
     });
   });
+
+  $('#id_source').on('change', function () {
+    const maxSize = $(this).data('max-upload-size');
+    const file = this.files[0];
+    input = $(this).get(0);
+    if (file.size > maxSize) {
+      input.setCustomValidity(
+        format(gettext('Your file exceeds the maximum size of {0}.'), [
+          Intl.NumberFormat(document.documentElement.lang, {
+            notation: 'compact',
+            style: 'unit',
+            unit: 'byte',
+            unitDisplay: 'narrow',
+          }).format(maxSize),
+        ]),
+      );
+    } else {
+      input.setCustomValidity('');
+    }
+  });
 }
 
 function initSubmitModals() {

--- a/static/js/zamboni/reviewers.js
+++ b/static/js/zamboni/reviewers.js
@@ -243,28 +243,22 @@ function callReviewersAPI(apiUrl, method, data, successCallback) {
 }
 
 $('#id_attachment_file').on('change', function () {
-  $('#attachment_errors').empty();
+  const maxSize = $(this).data('max-upload-size');
   const file = this.files[0];
-  const max_upload_size = $(this).data('max-upload-size');
-  if (file) {
-    if (file.size > max_upload_size) {
-      error = $('<ul>')
-        .attr('class', 'errorlist')
-        .append(
-          $('<li>').append(
-            format(gettext('Your file exceeds the maximum size of {0}.'), [
-              Intl.NumberFormat(document.documentElement.lang, {
-                notation: 'compact',
-                style: 'unit',
-                unit: 'byte',
-                unitDisplay: 'narrow',
-              }).format(max_upload_size),
-            ]),
-          ),
-        );
-      $('#attachment_errors').append(error);
-      $(this).val('');
-    }
+  input = $(this).get(0);
+  if (file.size > maxSize) {
+    input.setCustomValidity(
+      format(gettext('Your file exceeds the maximum size of {0}.'), [
+        Intl.NumberFormat(document.documentElement.lang, {
+          notation: 'compact',
+          style: 'unit',
+          unit: 'byte',
+          unitDisplay: 'narrow',
+        }).format(maxSize),
+      ]),
+    );
+  } else {
+    input.setCustomValidity('');
   }
 });
 


### PR DESCRIPTION
Fixes: mozilla/addons#15039

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Modifies FileFields to use setCustomValidity to check the max file size.

![image](https://github.com/user-attachments/assets/9d891f0d-95d3-4898-8766-9bd1cdfe6c50)


### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [x] Add before and after screenshots (Only for changes that impact the UI).
