### PR TITLE
Allow autograph to pull config in prod mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,9 +146,9 @@ services:
   autograph:
     image: mozilla/autograph:3.3.2
     platform: linux/amd64
-    command: /go/bin/autograph -c /data/olympia/scripts/autograph_localdev_config.yaml
+    command: /go/bin/autograph -c /autograph_localdev_config.yaml
     volumes:
-      - data_olympia:/data/olympia
+      - ./scripts/autograph_localdev_config.yaml:/autograph_localdev_config.yaml
 
   addons-frontend:
     <<: *env


### PR DESCRIPTION
Fixes: mozilla/addons#15043

### Description

Autograph depends on a single config file and we can afford to use an anonymous volume for that.

### Context

We use a named volume for mounting the local git repo files into containers. In prod mode we want to prevent host files from entering the web container so we wipe it's contents. This caused the unexpected side effect of wiping autograph as well since the web/autograph containers depend on the same volume.

### Testing

Run prod mode from a clean environment

```sh
make clean_docker && make up COMPOSE_FILE=docker-compose.yml:docker-compose.ci.yml
```

> NOTE: this will wipe your local database so make a backup first!

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
