### PR TITLE
reset File.original_status when rejected

### DIFF
--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -865,6 +865,8 @@ class ReviewBase:
         if status == amo.STATUS_APPROVED:
             file.approval_date = datetime.now()
         file.status = status
+        if status == amo.STATUS_DISABLED:
+            file.original_status = amo.STATUS_NULL
         file.save()
 
     def set_promoted(self, versions=None):


### PR DESCRIPTION
Fixes: mozilla/addons#15023

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

resets File.original_status to STATUS_NULL when rejecting versions

### Context

The issue scenario was only possible with unlisted versions (i.e. reject_multiple_versions) because the listed reject_version action works on current_version, and a disabled version (even if disabled by the developer) can't be current_version.

### Testing
(you can probably do 1-3 in django admin/shell, to skip the full STR)
1) have an unlisted version that's approved
2) delay reject that version in reviewer tools
3) developer disable that version in devhub
4) change the pending rejection date/time in django admin to a date/time in the past in `/admin/models/versions/version/<version-id>/change/`, "Version reviewer flags" section.
5) run `./manage.py cron auto_reject`
6) see in devhub you can't re-enable that version
7) (double check `original status` is 0 (STATUS_NULL) in django admin/shell)

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
