### PR TITLE
Only include locale stage in production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -172,8 +172,6 @@ ENV DOCKER_VERSION=${DOCKER_VERSION}
 COPY docker/etc/mime.types /etc/mime.types
 # Copy the rest of the source files from the host
 COPY --chown=olympia:olympia . ${HOME}
-# Copy compiled locales from builder
-COPY --from=locales --chown=olympia:olympia ${HOME}/locale ${HOME}/locale
 # Copy assets from assets
 COPY --from=assets --chown=olympia:olympia ${HOME}/site-static ${HOME}/site-static
 COPY --from=assets --chown=olympia:olympia ${HOME}/static-build ${HOME}/static-build
@@ -188,6 +186,8 @@ COPY --from=pip_development --chown=olympia:olympia /deps /deps
 
 FROM sources AS production
 
+# Copy compiled locales from builder
+COPY --from=locales --chown=olympia:olympia ${HOME}/locale ${HOME}/locale
 # Copy dependencies from `pip_production`
 COPY --from=pip_production --chown=olympia:olympia /deps /deps
 


### PR DESCRIPTION
fixes: https://github.com/mozilla/addons/issues/15055

### Description

Skip locale compilation outside of the production image build.
This is a difficult to cache operation that is not necessary for development

### Context

In order to speed up our local make up flow there are stages we can optimize and others we can totally skip. This is a low hanging fruit as we don't need compiled .mo files for dev at all.

### Testing

1. make up should work and skip the locale stage if `DOCKER_TARGET=development`
2. make up should work and include the locale stage if `DOCKER_TARGET=production`
3. in a production image you should see the .mo files in the container, in development not.
4. running `make test_needs_locale_compilation` will fail on development images if you don't first run the compilation step.

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
