### PR TITLE
Make assets step in Dockerfile depend on locales, for jsi18n files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -64,7 +64,6 @@ tmp/*
 docs
 private
 storage
-tests
 docker-bake.hcl
 docker-compose*.yml
 Dockerfile*

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -48,7 +48,7 @@ jobs:
           -
             name: Static Assets
             services: ''
-            compose_file: docker-compose.yml
+            compose_file: docker-compose.yml:docker-compose.ci.yml
             run: make test_static_assets
           -
             name: Internal Routes

--- a/Dockerfile
+++ b/Dockerfile
@@ -128,7 +128,7 @@ ${PIP_COMMAND} install --progress-bar=off --no-deps --exists-action=w -r require
 npm install ${NPM_ARGS} --no-save
 EOF
 
-FROM pip_production AS locales
+FROM base AS locales
 ARG LOCALE_DIR=${HOME}/locale
 # Compile locales
 # Copy the locale files from the host so it is writable by the olympia user
@@ -142,10 +142,12 @@ RUN \
 
 # More efficient caching by mounting the exact files we need
 # and copying only the static/ & locale/ directory.
-FROM locales AS assets
+FROM pip_production AS assets
 
+# In order to create js i18n files with all of our strings, we need to include
+# the compiled locale files
+COPY --from=locales --chown=olympia:olympia ${HOME}/locale/ ${HOME}/locale/
 # TODO: only copy the files we need for compiling assets
-COPY --chown=olympia:olympia locale/ ${HOME}/locale/
 COPY --chown=olympia:olympia static/ ${HOME}/static/
 
 # Finalize the build

--- a/Dockerfile
+++ b/Dockerfile
@@ -128,7 +128,7 @@ ${PIP_COMMAND} install --progress-bar=off --no-deps --exists-action=w -r require
 npm install ${NPM_ARGS} --no-save
 EOF
 
-FROM base AS locales
+FROM pip_production AS locales
 ARG LOCALE_DIR=${HOME}/locale
 # Compile locales
 # Copy the locale files from the host so it is writable by the olympia user
@@ -141,10 +141,11 @@ RUN \
     make -f Makefile-docker compile_locales
 
 # More efficient caching by mounting the exact files we need
-# and copying only the static/ directory.
-FROM pip_production AS assets
+# and copying only the static/ & locale/ directory.
+FROM locales AS assets
 
 # TODO: only copy the files we need for compiling assets
+COPY --chown=olympia:olympia locale/ ${HOME}/locale/
 COPY --chown=olympia:olympia static/ ${HOME}/static/
 
 # Finalize the build

--- a/tests/js/zamboni/i18n.spec.js
+++ b/tests/js/zamboni/i18n.spec.js
@@ -1,0 +1,14 @@
+describe(__filename, () => {
+  it('has translations in french', () => {
+    // We require the output from generate_jsi18n_files (which should live in
+    // static-build/ before getting picked up by collectstatic). It should
+    // contain not only gettext() function definition, some translations from
+    // django, but also our own, if it was called by the docker build process
+    // in the right order, after locales have been built.
+    const i18n_fr = require('../../../static-build/js/i18n/fr.js');
+    expect(i18n_fr.django.gettext).toBeInstanceOf(Function);
+    expect(
+      i18n_fr.django.catalog['There was an error uploading your file.'],
+    ).toEqual('Une erreur est survenue pendant l’envoi de votre fichier.');
+  });
+});

--- a/tests/js/zamboni/i18n.spec.js
+++ b/tests/js/zamboni/i18n.spec.js
@@ -1,11 +1,13 @@
 describe(__filename, () => {
-  it('has translations in french', () => {
-    // We require the output from generate_jsi18n_files (which should live in
-    // static-build/ before getting picked up by collectstatic). It should
-    // contain not only gettext() function definition, some translations from
-    // django, but also our own, if it was called by the docker build process
-    // in the right order, after locales have been built.
-    const i18n_fr = require('../../../static-build/js/i18n/fr.js');
+  it('has gettext() function in static-build/ for local development', () => {
+    const i18n_fr = require('../../../site-static/js/i18n/fr.js');
+    expect(i18n_fr.django.gettext).toBeInstanceOf(Function);
+  });
+
+  it('has gettext() function and translations in site-static/ for production', () => {
+    // Note: the actual path required in prod is not `fr.js`, but rather
+    // fr.<hash>.js. But we don't know the hash without requiring some python.
+    const i18n_fr = require('../../../site-static/js/i18n/fr.js');
     expect(i18n_fr.django.gettext).toBeInstanceOf(Function);
     expect(
       i18n_fr.django.catalog['There was an error uploading your file.'],

--- a/tests/js/zamboni/i18n.spec.js
+++ b/tests/js/zamboni/i18n.spec.js
@@ -1,6 +1,6 @@
 describe(__filename, () => {
   it('has gettext() function in static-build/ for local development', () => {
-    const i18n_fr = require('../../../site-static/js/i18n/fr.js');
+    const i18n_fr = require('../../../static-build/js/i18n/fr.js');
     expect(i18n_fr.django.gettext).toBeInstanceOf(Function);
   });
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/15048

### Description

This fixes missing translations from our jsi18n files in our production images, which was happening because locales and assets were built in parallel.

### Context

We pregenerate [jsi18n](https://docs.djangoproject.com/en/5.1/topics/i18n/translation/#module-django.views.i18n) like regular static assets for performance reasons. That means the following needs to happen, for each locale:
- Our own `djangojs.mo` must be generated
- Then `manage.py generate_jsi18n_files` must be called
- Then `collectstatic` must be called

If one step is not done in this order, then the file will either be missing completely or missing our translations (only including django's, which are shipped out of the box).

There is a better way to fix this by completely moving all the bits `jsi18n` generation to its own step, and calling `collectstatic` at the end of the build, but that's a larger refactor and we need to fix this bug now.


### Testing

There was already an automated test about this, `test_generate_jsi18n_files`, but unfortunately it's passing because we aren't running tests against production images. And it's calling the command explicitly anyway, so it would hide the bug.

I've added a js test ran through `make test_static_assets`. The `Static Assets` job should not force a recompilation of assets or locales and still pass. Note that this test depends on `site-static/`, so if you're running with a local environment where `collecstatic` has not ran, it will fail.

To test manually, you need to inspect the `site-static/` and `static-build/` directories of a production image made from this branch. You can do it manually by running the image yourself, or use our abstractions meant for development, with some caveats:

- Run `make up DOCKER_TARGET=production COMPOSE_FILE=docker-compose.yml:docker-compose.ci.yml` with this branch. `web` and `worker` container will fail to go up because of https://github.com/mozilla/addons/issues/15058, ignore that by `Ctrl+C`ing the `make up` once it's reached the part where it's waiting for the containers to be healthy.
- Run `make shell` and verify that the `static-build/js/i18n/fr.js` and `site-static/js/i18n/fr.js` files contain one of our translations in French, such as `"Your add-on was validated with no errors or warnings"`. You can also check that a `site-static/js/i18n/fr.{hash}.js` file exist and is also up to date.
- Do not forget to reset your `.env` to drop the `DOCKER_TARGET` and `COMPOSE_FILE` before switching to something else. It's likely you don't want to stay in production mode.