### PR TITLE
Stop using our remote settings "test server mode" for dev, it's broken

### DIFF
--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -74,6 +74,6 @@ FXA_CONTENT_HOST = 'https://accounts.stage.mozaws.net'
 FXA_OAUTH_HOST = 'https://oauth.stage.mozaws.net/v1'
 FXA_PROFILE_HOST = 'https://profile.stage.mozaws.net/v1'
 
-REMOTE_SETTINGS_IS_TEST_SERVER = True
+REMOTE_SETTINGS_WRITER_BUCKET = 'staging'
 
 SITEMAP_DEBUG_AVAILABLE = True


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/1939

### Context

`REMOTE_SETTINGS_IS_TEST_SERVER` is a special mode designed to work around the fact that the Kinto server was being regularly wiped out, so we had this special user that created the actual user and collection dynamically, and then used its own special bucket. But nowadays we can just use the same user/bucket/collection everywhere, as the remote settings server has the same config everywhere.

### Testing

This is difficult to test without the credentials, but you can check that this is consistent with stage. I manually logged in to dev and used our `RemoteSettings` class, bypassing `REMOTE_SETTINGS_IS_TEST_SERVER` to ensure it works. This resulted in https://remote-settings-dev.allizom.org/v1/buckets/blocklists/collections/addons-bloomfilters/records (which was empty before, and has been for the past few years...)