### PR TITLE
Allow developers to download file attachments

### DIFF
--- a/src/olympia/activity/views.py
+++ b/src/olympia/activity/views.py
@@ -176,7 +176,6 @@ def inbound_email(request):
     return Response(data=validation_response, status=status.HTTP_201_CREATED)
 
 
-
 @non_atomic_requests
 def download_attachment(request, log_id):
     """
@@ -188,10 +187,10 @@ def download_attachment(request, log_id):
 
     is_reviewer = acl.action_allowed_for(request.user, amo.permissions.ADDONS_REVIEW)
     is_developer = acl.check_addon_ownership(
-                request.user,
-                addon,
-                allow_developer=True,
-            )
+        request.user,
+        addon,
+        allow_developer=True,
+    )
 
     if not (is_reviewer or is_developer):
         raise http.Http404()

--- a/src/olympia/activity/views.py
+++ b/src/olympia/activity/views.py
@@ -176,6 +176,7 @@ def inbound_email(request):
     return Response(data=validation_response, status=status.HTTP_201_CREATED)
 
 
+
 @non_atomic_requests
 def download_attachment(request, log_id):
     """
@@ -185,7 +186,7 @@ def download_attachment(request, log_id):
     attachmentlog = log.attachmentlog
 
     is_reviewer = acl.action_allowed_for(request.user, amo.permissions.ADDONS_REVIEW)
-    if not is_reviewer:
+    if not (is_reviewer or request.user.is_developer):
         raise http.Http404()
 
     response = HttpResponseXSendFile(request, attachmentlog.file.path)

--- a/src/olympia/activity/views.py
+++ b/src/olympia/activity/views.py
@@ -185,7 +185,7 @@ def download_attachment(request, log_id):
     addon = get_object_or_404(AddonLog, activity_log=log).addon
     attachmentlog = log.attachmentlog
 
-    is_reviewer = acl.action_allowed_for(request.user, amo.permissions.ADDONS_REVIEW)
+    is_reviewer = acl.is_user_any_kind_of_reviewer(request.user, allow_viewers=True)
     is_developer = acl.check_addon_ownership(
         request.user,
         addon,


### PR DESCRIPTION
Fixes: mozilla/addons#15062

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Allows developers to download file attachments.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
