### PR TITLE
reset file.status_disabled_reason when rejecting too

### DIFF
--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -3675,7 +3675,9 @@ class TestReviewHelper(TestReviewHelperBase):
     def test_reject_multiple_versions_resets_original_status_too(self):
         old_version = self.review_version
         old_version.file.update(
-            status=amo.STATUS_DISABLED, original_status=amo.STATUS_APPROVED
+            status=amo.STATUS_DISABLED,
+            original_status=amo.STATUS_APPROVED,
+            status_disabled_reason=File.STATUS_DISABLED_REASONS.DEVELOPER,
         )
         self.review_version = version_factory(
             addon=self.addon,
@@ -3683,6 +3685,7 @@ class TestReviewHelper(TestReviewHelperBase):
             file_kw={
                 'status': amo.STATUS_DISABLED,
                 'original_status': amo.STATUS_AWAITING_REVIEW,
+                'status_disabled_reason': File.STATUS_DISABLED_REASONS.DEVELOPER,
             },
         )
         self.file = self.review_version.file
@@ -3698,6 +3701,10 @@ class TestReviewHelper(TestReviewHelperBase):
         assert self.review_version.file.reload().status == amo.STATUS_DISABLED
         assert old_version.file.original_status == amo.STATUS_NULL
         assert self.review_version.file.original_status == amo.STATUS_NULL
+        assert old_version.file.original_status == File.STATUS_DISABLED_REASONS.NONE
+        assert self.review_version.file.original_status == (
+            File.STATUS_DISABLED_REASONS.NONE
+        )
 
 
 @override_settings(ENABLE_ADDON_SIGNING=True)

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -21,6 +21,7 @@ from olympia.activity.utils import notify_about_activity_log
 from olympia.addons.models import Addon, AddonApprovalsCounter, AddonReviewerFlags
 from olympia.constants.abuse import DECISION_ACTIONS
 from olympia.constants.promoted import RECOMMENDED
+from olympia.files.models import File
 from olympia.lib.crypto.signing import sign_file
 from olympia.reviewers.models import (
     AutoApprovalSummary,
@@ -867,6 +868,7 @@ class ReviewBase:
         file.status = status
         if status == amo.STATUS_DISABLED:
             file.original_status = amo.STATUS_NULL
+            file.status_disabled_reason = File.STATUS_DISABLED_REASONS.NONE
         file.save()
 
     def set_promoted(self, versions=None):


### PR DESCRIPTION
Fixes: mozilla/addons#15023 (again)

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description
Resets `File.status_disabled_reason` to `File.STATUS_DISABLED_REASONS.NONE` in the reviewer tools when a file/version is rejected.

### Context

https://github.com/mozilla/addons-server/pull/22705 only reset `File.original_status` and I forgot that when `File.status_disabled_reason` was added (by me 😬) `Version.is_user_disabled` was changed to rely on it, so it also needs resetting to a null state.

### Testing

the testing steps from https://github.com/mozilla/addons-server/pull/22705 ... but I guess something was missing from it because the version should still have been possible to un-disable. in devhub - and then doing that would have set the File status to 0 (as visible in the reviewer tools).  So check that doesn't happen.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
