### PR TITLE
Hide attachment upload on force disable/enable

### DIFF
--- a/static/js/zamboni/reviewers.js
+++ b/static/js/zamboni/reviewers.js
@@ -1,3 +1,5 @@
+NO_ATTACHMENT_ACTIONS = ['disable_addon', 'enable_addon'];
+
 $(document).ready(function () {
   if ($('.daily-message').length) {
     initDailyMessage();
@@ -110,6 +112,11 @@ function initReviewActions() {
     // the value we're interested in.
     $data_toggle_hide.show();
     $data_toggle_hide.filter('[data-value~="' + value + '"]').hide();
+
+    $('.review-actions-attachment-reply').toggleClass(
+      'hidden',
+      NO_ATTACHMENT_ACTIONS.includes(value),
+    );
   }
 
   $('#review-actions .action_nav #id_action > *:not(.disabled)').click(


### PR DESCRIPTION
Fixes: mozilla/addons#15063

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Removes the option to upload attachments for force disable/enable add-ons.

![image](https://github.com/user-attachments/assets/c8bda4de-5b4e-40b6-b1a1-a9133d520e60)
![image](https://github.com/user-attachments/assets/b693fd86-bd8e-4526-a0a5-b3395b613323)

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
