### PR TITLE
Soft-block-tests

### DIFF
--- a/src/olympia/blocklist/cron.py
+++ b/src/olympia/blocklist/cron.py
@@ -81,7 +81,7 @@ def _upload_mlbf_to_remote_settings(*, force_base=False):
         # and that timestamp is not the same as the base_filter
         MLBF.load_from_storage(last_generation_time)
         if last_generation_time is not None
-        and (base_filter is None or base_filter.id != last_generation_time)
+        and (base_filter is None or base_filter.created_at != last_generation_time)
         else base_filter
     )
 
@@ -94,7 +94,7 @@ def _upload_mlbf_to_remote_settings(*, force_base=False):
         or base_filter is None
         or (
             previous_filter is not None
-            and previous_filter.id < get_blocklist_last_modified_time()
+            and previous_filter.created_at < get_blocklist_last_modified_time()
         )
         or changes_count > 0
     )

--- a/src/olympia/blocklist/cron.py
+++ b/src/olympia/blocklist/cron.py
@@ -4,7 +4,7 @@ import waffle
 from django_statsd.clients import statsd
 
 import olympia.core.logger
-from olympia.constants.blocklist import MLBF_BASE_ID_CONFIG_KEY, MLBF_TIME_CONFIG_KEY
+from olympia.constants.blocklist import BASE_REPLACE_THRESHOLD, MLBF_BASE_ID_CONFIG_KEY, MLBF_TIME_CONFIG_KEY
 from olympia.zadmin.models import get_config
 
 from .mlbf import MLBF
@@ -21,11 +21,11 @@ def get_generation_time():
 
 
 def get_last_generation_time():
-    return get_config(MLBF_TIME_CONFIG_KEY, 0, json_value=True)
+    return get_config(MLBF_TIME_CONFIG_KEY, None, json_value=True)
 
 
 def get_base_generation_time():
-    return get_config(MLBF_BASE_ID_CONFIG_KEY, 0, json_value=True)
+    return get_config(MLBF_BASE_ID_CONFIG_KEY, None, json_value=True)
 
 
 def get_blocklist_last_modified_time():
@@ -69,7 +69,21 @@ def _upload_mlbf_to_remote_settings(*, force_base=False):
     base_generation_time = get_base_generation_time()
 
     mlbf = MLBF.generate_from_db(generation_time)
-    previous_filter = MLBF.load_from_storage(last_generation_time)
+
+    base_filter = (
+        MLBF.load_from_storage(base_generation_time)
+        if base_generation_time is not None
+        else None
+    )
+
+    previous_filter = (
+        # Only load previoous filter if there is a timestamp to use
+        # and that timestamp is not the same as the base_filter
+        MLBF.load_from_storage(last_generation_time)
+        if last_generation_time is not None
+        and (base_filter is None or base_filter.id != last_generation_time)
+        else base_filter
+    )
 
     changes_count = mlbf.blocks_changed_since_previous(previous_filter)
     statsd.incr(
@@ -77,8 +91,12 @@ def _upload_mlbf_to_remote_settings(*, force_base=False):
     )
     need_update = (
         force_base
-        or last_generation_time < get_blocklist_last_modified_time()
-        or changes_count
+        or base_filter is None
+        or (
+            previous_filter is not None
+            and previous_filter.id < get_blocklist_last_modified_time()
+        )
+        or changes_count > 0
     )
     if not need_update:
         log.info('No new/modified/deleted Blocks in database; skipping MLBF generation')
@@ -93,21 +111,13 @@ def _upload_mlbf_to_remote_settings(*, force_base=False):
         len(mlbf.not_blocked_items),
     )
 
-    # optimize for when the base_filter was the previous generation so
-    # we don't have to load the blocked JSON file twice.
-    base_filter = (
-        MLBF.load_from_storage(base_generation_time)
-        if last_generation_time != base_generation_time
-        else previous_filter
-    )
-
     make_base_filter = (
         force_base
         or not base_generation_time
-        or mlbf.should_reset_base_filter(base_filter)
+        or mlbf.blocks_changed_since_previous(base_filter) > BASE_REPLACE_THRESHOLD
     )
 
-    if last_generation_time and not make_base_filter:
+    if previous_filter and not make_base_filter:
         try:
             mlbf.generate_and_write_stash(previous_filter)
         except FileNotFoundError:

--- a/src/olympia/blocklist/cron.py
+++ b/src/olympia/blocklist/cron.py
@@ -15,6 +15,7 @@ from .utils import datetime_to_ts
 
 log = olympia.core.logger.getLogger('z.cron')
 
+
 def get_generation_time():
     return datetime_to_ts()
 
@@ -101,7 +102,9 @@ def _upload_mlbf_to_remote_settings(*, force_base=False):
     )
 
     make_base_filter = (
-        force_base or not base_generation_time or mlbf.should_reset_base_filter(base_filter)
+        force_base
+        or not base_generation_time
+        or mlbf.should_reset_base_filter(base_filter)
     )
 
     if last_generation_time and not make_base_filter:

--- a/src/olympia/blocklist/cron.py
+++ b/src/olympia/blocklist/cron.py
@@ -4,7 +4,11 @@ import waffle
 from django_statsd.clients import statsd
 
 import olympia.core.logger
-from olympia.constants.blocklist import BASE_REPLACE_THRESHOLD, MLBF_BASE_ID_CONFIG_KEY, MLBF_TIME_CONFIG_KEY
+from olympia.constants.blocklist import (
+    BASE_REPLACE_THRESHOLD,
+    MLBF_BASE_ID_CONFIG_KEY,
+    MLBF_TIME_CONFIG_KEY,
+)
 from olympia.zadmin.models import get_config
 
 from .mlbf import MLBF

--- a/src/olympia/blocklist/cron.py
+++ b/src/olympia/blocklist/cron.py
@@ -15,6 +15,17 @@ from .utils import datetime_to_ts
 
 log = olympia.core.logger.getLogger('z.cron')
 
+def get_generation_time():
+    return datetime_to_ts()
+
+
+def get_last_generation_time():
+    return get_config(MLBF_TIME_CONFIG_KEY, 0, json_value=True)
+
+
+def get_base_generation_time():
+    return get_config(MLBF_BASE_ID_CONFIG_KEY, 0, json_value=True)
+
 
 def get_blocklist_last_modified_time():
     latest_block = Block.objects.order_by('-modified').first()
@@ -39,8 +50,6 @@ def upload_mlbf_to_remote_settings(*, bypass_switch=False, force_base=False):
 
 
 def _upload_mlbf_to_remote_settings(*, force_base=False):
-    last_generation_time = get_config(MLBF_TIME_CONFIG_KEY, 0, json_value=True)
-
     log.info('Starting Upload MLBF to remote settings cron job.')
 
     # This timestamp represents the point in time when all previous addon
@@ -50,7 +59,14 @@ def _upload_mlbf_to_remote_settings(*, force_base=False):
     # An add-on version/file from after this time can't be reliably asserted -
     # there may be false positives or false negatives.
     # https://github.com/mozilla/addons-server/issues/13695
-    generation_time = datetime_to_ts()
+    generation_time = get_generation_time()
+    # This timestamp represents the last time the MLBF was generated and uploaded.
+    # It could have been a base filter or a stash.
+    last_generation_time = get_last_generation_time()
+    # This timestamp represents the point in time when
+    # the base filter was generated and uploaded.
+    base_generation_time = get_base_generation_time()
+
     mlbf = MLBF.generate_from_db(generation_time)
     previous_filter = MLBF.load_from_storage(last_generation_time)
 
@@ -76,17 +92,16 @@ def _upload_mlbf_to_remote_settings(*, force_base=False):
         len(mlbf.not_blocked_items),
     )
 
-    base_filter_id = get_config(MLBF_BASE_ID_CONFIG_KEY, 0, json_value=True)
     # optimize for when the base_filter was the previous generation so
     # we don't have to load the blocked JSON file twice.
     base_filter = (
-        MLBF.load_from_storage(base_filter_id)
-        if last_generation_time != base_filter_id
+        MLBF.load_from_storage(base_generation_time)
+        if last_generation_time != base_generation_time
         else previous_filter
     )
 
     make_base_filter = (
-        force_base or not base_filter_id or mlbf.should_reset_base_filter(base_filter)
+        force_base or not base_generation_time or mlbf.should_reset_base_filter(base_filter)
     )
 
     if last_generation_time and not make_base_filter:
@@ -101,8 +116,8 @@ def _upload_mlbf_to_remote_settings(*, force_base=False):
 
     upload_filter.delay(generation_time, is_base=make_base_filter)
 
-    if base_filter_id:
-        cleanup_old_files.delay(base_filter_id=base_filter_id)
+    if base_generation_time:
+        cleanup_old_files.delay(base_filter_id=base_generation_time)
 
 
 def process_blocklistsubmissions():

--- a/src/olympia/blocklist/mlbf.py
+++ b/src/olympia/blocklist/mlbf.py
@@ -24,10 +24,15 @@ def generate_mlbf(stats, blocked, not_blocked):
         salt=secrets.token_bytes(16),
     )
 
-    error_rates = sorted((len(blocked), len(not_blocked)))
-    cascade.set_crlite_error_rates(
-        include_len=error_rates[0], exclude_len=error_rates[1]
-    )
+    len_blocked = len(blocked)
+    len_unblocked = len(not_blocked)
+
+    # We can only set error rates if both blocked and unblocked are non-empty
+    if len_blocked > 0 and len_unblocked > 0:
+        error_rates = sorted((len_blocked, len_unblocked))
+        cascade.set_crlite_error_rates(
+            include_len=error_rates[0], exclude_len=error_rates[1]
+        )
 
     stats['mlbf_blocked_count'] = len(blocked)
     stats['mlbf_notblocked_count'] = len(not_blocked)

--- a/src/olympia/blocklist/mlbf.py
+++ b/src/olympia/blocklist/mlbf.py
@@ -2,7 +2,6 @@ import json
 import os
 import secrets
 
-from django.conf import settings
 from django.utils.functional import cached_property
 
 from filtercascade import FilterCascade

--- a/src/olympia/blocklist/mlbf.py
+++ b/src/olympia/blocklist/mlbf.py
@@ -120,13 +120,8 @@ class MLBF:
         return os.path.join(settings.MLBF_STORAGE_PATH, self.id, 'filter')
 
     @property
-    def _stash_path(self):
+    def stash_path(self):
         return os.path.join(settings.MLBF_STORAGE_PATH, self.id, 'stash.json')
-
-    @cached_property
-    def stash_json(self):
-        with self.storage.open(self._stash_path, 'r') as json_file:
-            return json.load(json_file)
 
     def generate_and_write_filter(self):
         stats = {}
@@ -163,15 +158,15 @@ class MLBF:
         extras, deletes = self.generate_diffs(
             previous_mlbf.blocked_items, self.blocked_items
         )
-        self.stash_json = {
+        stash_json = {
             'blocked': list(extras),
             'unblocked': list(deletes),
         }
         # write stash
-        stash_path = self._stash_path
+        stash_path = self.stash_path
         with self.storage.open(stash_path, 'w') as json_file:
             log.info(f'Writing to file {stash_path}')
-            json.dump(self.stash_json, json_file)
+            json.dump(stash_json, json_file)
 
     def should_reset_base_filter(self, previous_bloom_filter):
         try:

--- a/src/olympia/blocklist/mlbf.py
+++ b/src/olympia/blocklist/mlbf.py
@@ -79,10 +79,12 @@ def fetch_all_versions_from_db(excluding_version_ids=None):
 class MLBF:
     KEY_FORMAT = '{guid}:{version}'
 
-    def __init__(self, id_):
-        # simplify later code by assuming always a string
-        self.id = str(id_)
-        self.storage = SafeStorage(root_setting='MLBF_STORAGE_PATH')
+    def __init__(self, created_at):
+        self.created_at = created_at
+        self.storage = SafeStorage(
+            root_setting='MLBF_STORAGE_PATH',
+            rel_location=str(self.created_at),
+        )
 
     @classmethod
     def hash_filter_inputs(cls, input_list):
@@ -94,7 +96,7 @@ class MLBF:
 
     @property
     def _blocked_path(self):
-        return os.path.join(settings.MLBF_STORAGE_PATH, self.id, 'blocked.json')
+        return self.storage.path('blocked.json')
 
     @cached_property
     def blocked_items(self):
@@ -102,7 +104,7 @@ class MLBF:
 
     @property
     def _not_blocked_path(self):
-        return os.path.join(settings.MLBF_STORAGE_PATH, self.id, 'notblocked.json')
+        return self.storage.path('notblocked.json')
 
     @cached_property
     def not_blocked_items(self):
@@ -110,11 +112,11 @@ class MLBF:
 
     @property
     def filter_path(self):
-        return os.path.join(settings.MLBF_STORAGE_PATH, self.id, 'filter')
+        return self.storage.path('filter')
 
     @property
     def stash_path(self):
-        return os.path.join(settings.MLBF_STORAGE_PATH, self.id, 'stash.json')
+        return self.storage.path('stash.json')
 
     def generate_and_write_filter(self):
         stats = {}

--- a/src/olympia/blocklist/tasks.py
+++ b/src/olympia/blocklist/tasks.py
@@ -113,12 +113,12 @@ def upload_filter(generation_time, is_base=True):
         with mlbf.storage.open(mlbf.stash_path, 'r') as stash_file:
             stash_data = json.load(stash_file)
             # If we have a stash, write that
-            stash_data = {
+            stash_upload_data = {
                 'key_format': MLBF.KEY_FORMAT,
                 'stash_time': generation_time,
                 'stash': stash_data,
             }
-            server.publish_record(stash_data)
+            server.publish_record(stash_upload_data)
             statsd.incr('blocklist.tasks.upload_filter.upload_stash')
 
     server.complete_session()

--- a/src/olympia/blocklist/tests/test_commands.py
+++ b/src/olympia/blocklist/tests/test_commands.py
@@ -1,6 +1,3 @@
-import os
-
-from django.conf import settings
 from django.core.management import call_command
 
 from olympia import amo
@@ -11,6 +8,7 @@ from olympia.amo.tests import (
     user_factory,
     version_factory,
 )
+from olympia.blocklist.mlbf import MLBF
 
 
 class TestExportBlocklist(TestCase):
@@ -39,5 +37,5 @@ class TestExportBlocklist(TestCase):
         )
 
         call_command('export_blocklist', '1')
-        out_path = os.path.join(settings.MLBF_STORAGE_PATH, '1', 'filter')
-        assert os.path.exists(out_path)
+        mlbf = MLBF.load_from_storage(1)
+        assert mlbf.storage.exists(mlbf.filter_path)

--- a/src/olympia/blocklist/tests/test_cron.py
+++ b/src/olympia/blocklist/tests/test_cron.py
@@ -321,12 +321,12 @@ class TestTimeMethods(TestCase):
         assert isinstance(get_generation_time(), int)
 
     def test_get_last_generation_time(self):
-        assert get_last_generation_time() == None
+        assert get_last_generation_time() is None
         set_config(MLBF_TIME_CONFIG_KEY, 1)
         assert get_last_generation_time() == 1
 
     def test_get_base_generation_time(self):
-        assert get_base_generation_time() == None
+        assert get_base_generation_time() is None
         set_config(MLBF_BASE_ID_CONFIG_KEY, 1)
         assert get_base_generation_time() == 1
 

--- a/src/olympia/blocklist/tests/test_cron.py
+++ b/src/olympia/blocklist/tests/test_cron.py
@@ -24,7 +24,7 @@ from olympia.blocklist.cron import (
     process_blocklistsubmissions,
     upload_mlbf_to_remote_settings,
 )
-from olympia.blocklist.mlbf import MLBF, MLBFDataType
+from olympia.blocklist.mlbf import MLBF
 from olympia.blocklist.models import Block, BlocklistSubmission, BlockVersion
 from olympia.blocklist.utils import datetime_to_ts
 from olympia.constants.blocklist import MLBF_BASE_ID_CONFIG_KEY, MLBF_TIME_CONFIG_KEY
@@ -204,7 +204,6 @@ class TestUploadToRemoteSettings(TestCase):
             mock.call(
                 self.current_time,
                 is_base=force_base,
-                block_type_constant=MLBFDataType.BLOCKED.name,
             )
         ]
         mlbf = MLBF.load_from_storage(self.current_time)
@@ -223,7 +222,6 @@ class TestUploadToRemoteSettings(TestCase):
             mock.call(
                 self.current_time,
                 is_base=False,
-                block_type_constant=MLBFDataType.BLOCKED.name,
             )
         ]
         mlbf = MLBF.load_from_storage(self.current_time)
@@ -238,7 +236,6 @@ class TestUploadToRemoteSettings(TestCase):
             mock.call(
                 self.current_time,
                 is_base=True,
-                block_type_constant=MLBFDataType.BLOCKED.name,
             )
             in self.mocks['olympia.blocklist.cron.upload_filter.delay'].call_args_list
         )
@@ -258,7 +255,6 @@ class TestUploadToRemoteSettings(TestCase):
             mock.call(
                 self.current_time,
                 is_base=False,
-                block_type_constant=MLBFDataType.BLOCKED.name,
             )
         ]
         mlbf = MLBF.load_from_storage(self.current_time)
@@ -276,7 +272,6 @@ class TestUploadToRemoteSettings(TestCase):
             mock.call(
                 self.current_time,
                 is_base=True,
-                block_type_constant=MLBFDataType.BLOCKED.name,
             )
             in self.mocks['olympia.blocklist.cron.upload_filter.delay'].call_args_list
         )

--- a/src/olympia/blocklist/tests/test_cron.py
+++ b/src/olympia/blocklist/tests/test_cron.py
@@ -1,11 +1,9 @@
 import json
-import os
 import uuid
 from datetime import datetime, timedelta
 from unittest import mock
 
 from django.conf import settings
-from django.core.files.storage import default_storage as storage
 
 import pytest
 import responses
@@ -20,15 +18,17 @@ from olympia.amo.tests import (
     version_factory,
 )
 from olympia.blocklist.cron import (
-    get_blocklist_last_modified_time,
+    get_base_generation_time,
+    get_generation_time,
+    get_last_generation_time,
     process_blocklistsubmissions,
     upload_mlbf_to_remote_settings,
 )
-from olympia.blocklist.mlbf import MLBF
-from olympia.blocklist.models import Block, BlocklistSubmission
+from olympia.blocklist.mlbf import MLBF, MLBFDataType
+from olympia.blocklist.models import Block, BlocklistSubmission, BlockVersion
+from olympia.blocklist.utils import datetime_to_ts
 from olympia.constants.blocklist import MLBF_BASE_ID_CONFIG_KEY, MLBF_TIME_CONFIG_KEY
-from olympia.lib.remote_settings import RemoteSettings
-from olympia.zadmin.models import get_config, set_config
+from olympia.zadmin.models import set_config
 
 
 STATSD_PREFIX = 'blocklist.cron.upload_mlbf_to_remote_settings.'
@@ -38,342 +38,302 @@ STATSD_PREFIX = 'blocklist.cron.upload_mlbf_to_remote_settings.'
 @override_switch('blocklist_mlbf_submit', active=True)
 class TestUploadToRemoteSettings(TestCase):
     def setUp(self):
-        addon = addon_factory()
-        version_factory(addon=addon)
-        version_factory(addon=addon)
-        self.block = block_factory(
-            addon=addon_factory(
-                version_kw={'version': '1.2b3'},
-                file_kw={'is_signed': True},
-            ),
-            updated_by=user_factory(),
+        self.user = user_factory()
+        self.addon = addon_factory()
+        self.block = block_factory(guid=self.addon.guid, updated_by=self.user)
+
+        self.mocks: dict[str, mock.Mock] = {}
+        for mock_name in (
+            'olympia.blocklist.cron.statsd.incr',
+            'olympia.blocklist.cron.cleanup_old_files.delay',
+            'olympia.blocklist.cron.upload_filter.delay',
+            'olympia.blocklist.cron.get_generation_time',
+            'olympia.blocklist.cron.get_last_generation_time',
+            'olympia.blocklist.cron.get_base_generation_time',
+        ):
+            patcher = mock.patch(mock_name)
+            self.addCleanup(patcher.stop)
+            self.mocks[mock_name] = patcher.start()
+
+        self.base_time = datetime_to_ts(self.block.modified)
+        self.last_time = datetime_to_ts(self.block.modified + timedelta(seconds=1))
+        self.current_time = datetime_to_ts(self.block.modified + timedelta(seconds=2))
+        self.mocks[
+            'olympia.blocklist.cron.get_base_generation_time'
+        ].return_value = self.base_time
+        self.mocks[
+            'olympia.blocklist.cron.get_last_generation_time'
+        ].return_value = self.last_time
+        self.mocks[
+            'olympia.blocklist.cron.get_generation_time'
+        ].return_value = self.current_time
+
+        # Create the base/last filters by default so each test starts with a happy path
+        # where there is a base/last filter with correct times that we skip the update.
+        MLBF.generate_from_db(self.base_time)
+        MLBF.generate_from_db(self.last_time)
+
+    def _block_version(self, block=None, version=None, soft=False, is_signed=True):
+        block = block or self.block
+        version = version or version_factory(
+            addon=self.addon, file_kw={'is_signed': is_signed}
         )
-        delete_patcher = mock.patch.object(RemoteSettings, 'delete_all_records')
-        attach_patcher = mock.patch.object(RemoteSettings, 'publish_attachment')
-        record_patcher = mock.patch.object(RemoteSettings, 'publish_record')
-        statsd_incr_patcher = mock.patch('olympia.blocklist.cron.statsd.incr')
-        cleanup_files_patcher = mock.patch(
-            'olympia.blocklist.cron.cleanup_old_files.delay'
-        )
-        self.addCleanup(delete_patcher.stop)
-        self.addCleanup(attach_patcher.stop)
-        self.addCleanup(record_patcher.stop)
-        self.addCleanup(statsd_incr_patcher.stop)
-        self.addCleanup(cleanup_files_patcher.stop)
-        self.delete_mock = delete_patcher.start()
-        self.publish_attachment_mock = attach_patcher.start()
-        self.publish_record_mock = record_patcher.start()
-        self.statsd_incr_mock = statsd_incr_patcher.start()
-        self.cleanup_files_mock = cleanup_files_patcher.start()
+        return BlockVersion.objects.create(block=block, version=version, soft=soft)
 
-    def test_no_previous_mlbf(self):
-        with self.assertNumQueries(16):
-            # Mainly config gets/saves and savepoints; regression check.
-            upload_mlbf_to_remote_settings()
+    def test_skip_update_unless_force_base(self):
+        """
+        skip update unless force_base is true
+        """
+        upload_mlbf_to_remote_settings(force_base=False)
 
-        generation_time = int(datetime(2020, 1, 1, 12, 34, 56).timestamp() * 1000)
-        self.publish_attachment_mock.assert_called_with(
-            {
-                'key_format': MLBF.KEY_FORMAT,
-                'generation_time': generation_time,
-                'attachment_type': 'bloomfilter-base',
-            },
-            ('filter.bin', mock.ANY, 'application/octet-stream'),
-        )
-        assert get_config(MLBF_TIME_CONFIG_KEY, json_value=True) == generation_time
-        assert get_config(MLBF_BASE_ID_CONFIG_KEY, json_value=True) == generation_time
-        self.publish_record_mock.assert_not_called()
-        self.delete_mock.assert_called_once()
+        # We skip update at this point because there is no reason to update.
+        assert not self.mocks['olympia.blocklist.cron.upload_filter.delay'].called
 
-        gen_path = os.path.join(settings.MLBF_STORAGE_PATH, str(generation_time))
-        assert os.path.getsize(os.path.join(gen_path, 'filter'))
-        assert os.path.getsize(os.path.join(gen_path, 'blocked.json'))
-        assert os.path.getsize(os.path.join(gen_path, 'notblocked.json'))
-        # no stash because no previous mlbf
-        assert not os.path.exists(os.path.join(gen_path, 'stash.json'))
-
-        self.statsd_incr_mock.assert_has_calls(
-            [
-                mock.call(f'{STATSD_PREFIX}blocked_changed', 1),
-                mock.call(f'{STATSD_PREFIX}blocked_count', 1),
-                mock.call(f'{STATSD_PREFIX}not_blocked_count', 3),
-                mock.call('blocklist.tasks.upload_filter.reset_collection'),
-                mock.call('blocklist.tasks.upload_filter.upload_mlbf'),
-                mock.call('blocklist.tasks.upload_filter.upload_mlbf.base'),
-                mock.call(f'{STATSD_PREFIX}success'),
-            ]
-        )
-        self.cleanup_files_mock.assert_not_called()
-
-    def test_stash_because_previous_mlbf(self):
-        set_config(MLBF_TIME_CONFIG_KEY, 123456, json_value=True)
-        set_config(MLBF_BASE_ID_CONFIG_KEY, 123456, json_value=True)
-        prev_blocked_path = os.path.join(
-            settings.MLBF_STORAGE_PATH, '123456', 'blocked.json'
-        )
-        with storage.open(prev_blocked_path, 'w') as blocked_file:
-            json.dump(['madeup@guid:123'], blocked_file)
-
-        with self.assertNumQueries(8):
-            # Mainly config gets/saves and savepoints; regression check.
-            upload_mlbf_to_remote_settings()
-
-        generation_time = int(datetime(2020, 1, 1, 12, 34, 56).timestamp() * 1000)
-
-        self.publish_attachment_mock.assert_not_called()
-        self.publish_record_mock.assert_called_with(
-            {
-                'key_format': MLBF.KEY_FORMAT,
-                'stash_time': generation_time,
-                'stash': {
-                    'blocked': [
-                        f'{self.block.guid}:'
-                        f'{self.block.addon.current_version.version}'
-                    ],
-                    'unblocked': ['madeup@guid:123'],
-                },
-            }
-        )
-        self.delete_mock.assert_not_called()
-        assert get_config(MLBF_TIME_CONFIG_KEY, json_value=True) == generation_time
-        assert get_config(MLBF_BASE_ID_CONFIG_KEY, json_value=True) == 123456
-
-        self.statsd_incr_mock.assert_has_calls(
-            [
-                mock.call(f'{STATSD_PREFIX}blocked_changed', 2),
-                mock.call(f'{STATSD_PREFIX}blocked_count', 1),
-                mock.call(f'{STATSD_PREFIX}not_blocked_count', 3),
-                mock.call('blocklist.tasks.upload_filter.upload_stash'),
-                mock.call(f'{STATSD_PREFIX}success'),
-            ]
-        )
-        self.cleanup_files_mock.assert_called_with(base_filter_id=123456)
-
-    def test_stash_because_many_mlbf(self):
-        set_config(MLBF_TIME_CONFIG_KEY, 123456, json_value=True)
-        set_config(MLBF_BASE_ID_CONFIG_KEY, 987654, json_value=True)
-        prev_blocked_path = os.path.join(
-            settings.MLBF_STORAGE_PATH, '123456', 'blocked.json'
-        )
-        with storage.open(prev_blocked_path, 'w') as blocked_file:
-            json.dump(['madeup@guid:12345'], blocked_file)
-        base_blocked_path = os.path.join(
-            settings.MLBF_STORAGE_PATH, '987654', 'blocked.json'
-        )
-        with storage.open(base_blocked_path, 'w') as blocked_file:
-            json.dump([], blocked_file)
-
-        upload_mlbf_to_remote_settings()
-
-        generation_time = int(datetime(2020, 1, 1, 12, 34, 56).timestamp() * 1000)
-
-        self.publish_attachment_mock.assert_not_called()
-        self.publish_record_mock.assert_called_with(
-            {
-                'key_format': MLBF.KEY_FORMAT,
-                'stash_time': generation_time,
-                'stash': {
-                    'blocked': [
-                        f'{self.block.guid}:'
-                        f'{self.block.addon.current_version.version}'
-                    ],
-                    'unblocked': ['madeup@guid:12345'],
-                },
-            }
-        )
-        self.delete_mock.assert_not_called()
-        assert get_config(MLBF_TIME_CONFIG_KEY, json_value=True) == generation_time
-        assert get_config(MLBF_BASE_ID_CONFIG_KEY, json_value=True) == 987654
-
-        self.statsd_incr_mock.assert_has_calls(
-            [
-                mock.call(f'{STATSD_PREFIX}blocked_changed', 2),
-                mock.call(f'{STATSD_PREFIX}blocked_count', 1),
-                mock.call(f'{STATSD_PREFIX}not_blocked_count', 3),
-                mock.call('blocklist.tasks.upload_filter.upload_stash'),
-                mock.call(f'{STATSD_PREFIX}success'),
-            ]
-        )
-        self.cleanup_files_mock.assert_called_with(base_filter_id=987654)
-
-    @mock.patch.object(MLBF, 'should_reset_base_filter')
-    def test_reset_base_because_over_reset_threshold(self, should_reset_mock):
-        should_reset_mock.return_value = True
-        set_config(MLBF_TIME_CONFIG_KEY, 123456, json_value=True)
-        set_config(MLBF_BASE_ID_CONFIG_KEY, 987654, json_value=True)
-        prev_blocked_path = os.path.join(
-            settings.MLBF_STORAGE_PATH, '123456', 'blocked.json'
-        )
-        with storage.open(prev_blocked_path, 'w') as blocked_file:
-            json.dump(['madeup@guid:12345'], blocked_file)
-        base_blocked_path = os.path.join(
-            settings.MLBF_STORAGE_PATH, '987654', 'blocked.json'
-        )
-        with storage.open(base_blocked_path, 'w') as blocked_file:
-            json.dump([], blocked_file)
-
-        with self.assertNumQueries(10):
-            # Mainly config gets/saves and savepoints; regression check.
-            upload_mlbf_to_remote_settings()
-
-        generation_time = int(datetime(2020, 1, 1, 12, 34, 56).timestamp() * 1000)
-
-        self.publish_attachment_mock.assert_called_with(
-            {
-                'key_format': MLBF.KEY_FORMAT,
-                'generation_time': generation_time,
-                'attachment_type': 'bloomfilter-base',
-            },
-            ('filter.bin', mock.ANY, 'application/octet-stream'),
-        )
-        self.publish_record_mock.assert_not_called()
-        self.delete_mock.assert_called_once()
-        assert get_config(MLBF_TIME_CONFIG_KEY, json_value=True) == generation_time
-        assert get_config(MLBF_BASE_ID_CONFIG_KEY, json_value=True) == generation_time
-
-        gen_path = os.path.join(settings.MLBF_STORAGE_PATH, str(generation_time))
-        # no stash because we're starting with a new base mlbf
-        assert not os.path.exists(os.path.join(gen_path, 'stash.json'))
-
-        self.statsd_incr_mock.assert_has_calls(
-            [
-                mock.call(f'{STATSD_PREFIX}blocked_changed', 2),
-                mock.call(f'{STATSD_PREFIX}blocked_count', 1),
-                mock.call(f'{STATSD_PREFIX}not_blocked_count', 3),
-                mock.call('blocklist.tasks.upload_filter.reset_collection'),
-                mock.call('blocklist.tasks.upload_filter.upload_mlbf'),
-                mock.call('blocklist.tasks.upload_filter.upload_mlbf.base'),
-                mock.call(f'{STATSD_PREFIX}success'),
-            ]
-        )
-
-    @override_switch('blocklist_mlbf_submit', active=True)
-    @mock.patch.object(MLBF, 'should_reset_base_filter')
-    def test_force_base_option(self, should_reset_mock):
-        should_reset_mock.return_value = False
-
-        # set the times to now
-        now = datetime.now()
-        now_timestamp = now.timestamp() * 1000
-        set_config(MLBF_TIME_CONFIG_KEY, now_timestamp, json_value=True)
-        self.block.update(modified=now)
-        prev_blocked_path = os.path.join(
-            settings.MLBF_STORAGE_PATH, str(now_timestamp), 'blocked.json'
-        )
-        with storage.open(prev_blocked_path, 'w') as blocked_file:
-            json.dump([f'{self.block.guid}:1.2b3'], blocked_file)
-        # without force_base nothing happens
-        upload_mlbf_to_remote_settings()
-        self.publish_attachment_mock.assert_not_called()
-        self.publish_record_mock.assert_not_called()
-
-        # but with force_base=True we generate a filter
+        # But if we force the base filter, we update.
         upload_mlbf_to_remote_settings(force_base=True)
-        self.publish_attachment_mock.assert_called_once()  # the mlbf
-        self.publish_record_mock.assert_not_called()  # no stash
-        self.delete_mock.assert_called()  # the collection was cleared
 
-        # doublecheck no stash
-        gen_path = os.path.join(
-            settings.MLBF_STORAGE_PATH,
-            str(get_config(MLBF_TIME_CONFIG_KEY, json_value=True)),
+        assert self.mocks['olympia.blocklist.cron.upload_filter.delay'].called
+
+        # Check that a filter was created on the second attempt
+        mlbf = MLBF.load_from_storage(self.current_time)
+        assert mlbf.storage.exists(mlbf.filter_path)
+        assert not mlbf.storage.exists(mlbf.stash_path)
+
+    def test_skip_update_unless_no_base_mlbf(self):
+        """
+        skip update unless there is no base mlbf
+        """
+        # We skip update at this point because there is a base filter.
+        upload_mlbf_to_remote_settings(force_base=False)
+        assert not self.mocks['olympia.blocklist.cron.upload_filter.delay'].called
+
+        self.mocks[
+            'olympia.blocklist.cron.get_base_generation_time'
+        ].return_value = None
+        upload_mlbf_to_remote_settings(force_base=False)
+
+        assert self.mocks['olympia.blocklist.cron.upload_filter.delay'].called
+
+    def test_missing_last_filter_uses_base_filter(self):
+        """
+        When there is a base filter and no last filter,
+        fallback to using the base filter
+        """
+        self._block_version(is_signed=True)
+        # Re-created the last filter created after the new block
+        MLBF.generate_from_db(self.last_time)
+
+        # We skip the update at this point because the new last filter already
+        # accounted for the new block.
+        upload_mlbf_to_remote_settings(force_base=False)
+        assert not self.mocks['olympia.blocklist.cron.upload_filter.delay'].called
+
+        # We don't skip because the base filter is now used to compare against
+        # and it has not accounted for the new block.
+        self.mocks[
+            'olympia.blocklist.cron.get_last_generation_time'
+        ].return_value = None
+        upload_mlbf_to_remote_settings(force_base=False)
+        assert self.mocks['olympia.blocklist.cron.upload_filter.delay'].called
+        assert (
+            mock.call(
+                'blocklist.cron.upload_mlbf_to_remote_settings.blocked_changed', 1
+            )
+            in self.mocks['olympia.blocklist.cron.statsd.incr'].call_args_list
         )
-        # no stash because we're starting with a new base mlbf
-        assert not os.path.exists(os.path.join(gen_path, 'stash.json'))
 
-        self.statsd_incr_mock.assert_has_calls(
-            [
-                mock.call(f'{STATSD_PREFIX}blocked_changed', 0),
-                mock.call(f'{STATSD_PREFIX}success'),
-                # 2nd execution
-                mock.call(f'{STATSD_PREFIX}blocked_changed', 0),
-                mock.call(f'{STATSD_PREFIX}blocked_count', 1),
-                mock.call(f'{STATSD_PREFIX}not_blocked_count', 3),
-                mock.call('blocklist.tasks.upload_filter.reset_collection'),
-                mock.call('blocklist.tasks.upload_filter.upload_mlbf'),
-                mock.call('blocklist.tasks.upload_filter.upload_mlbf.base'),
-                mock.call(f'{STATSD_PREFIX}success'),
-            ]
-        )
+    def test_skip_update_unless_recent_modified_blocks(self):
+        """
+        skip update unless there are recent modified blocks
+        """
+        upload_mlbf_to_remote_settings(force_base=False)
+        assert not self.mocks['olympia.blocklist.cron.upload_filter.delay'].called
 
-    @override_switch('blocklist_mlbf_submit', active=False)
-    def test_waffle_off_disables_publishing(self):
+        # Now the last filter is older than the most recently modified block.
+        older_last_time = datetime_to_ts(self.block.modified - timedelta(seconds=1))
+        self.mocks[
+            'olympia.blocklist.cron.get_last_generation_time'
+        ].return_value = older_last_time
+        MLBF.generate_from_db(older_last_time)
+
+        upload_mlbf_to_remote_settings(force_base=False)
+        assert self.mocks['olympia.blocklist.cron.upload_filter.delay'].called
+
+    def test_skip_update_unless_new_blocks(self):
+        """
+        skip update unless there are new blocks
+        """
+        upload_mlbf_to_remote_settings(force_base=False)
+        assert not self.mocks['olympia.blocklist.cron.upload_filter.delay'].called
+
+        # Now there is a new blocked version
+        self._block_version(is_signed=True)
+        upload_mlbf_to_remote_settings(force_base=False)
+        assert self.mocks['olympia.blocklist.cron.upload_filter.delay'].called
+
+    def test_send_statsd_counts(self):
+        """
+        Send statsd counts for the number of blocked and not blocked items.
+        """
+        self._block_version(is_signed=True)
         upload_mlbf_to_remote_settings()
 
-        self.publish_attachment_mock.assert_not_called()
-        self.publish_record_mock.assert_not_called()
-        assert not get_config(MLBF_TIME_CONFIG_KEY)
-
-        # except when 'bypass_switch' kwarg is passed
-        upload_mlbf_to_remote_settings(bypass_switch=True)
-        self.publish_attachment_mock.assert_called()
-        assert get_config(MLBF_TIME_CONFIG_KEY)
-
-    @freeze_time('2020-01-01 12:34:56', as_arg=True)
-    def test_no_block_changes(frozen_time, self):
-        # This was the last time the mlbf was generated
-        last_time = int((frozen_time() - timedelta(seconds=1)).timestamp() * 1000)
-        # And the Block was modified just that before so would be included
-        self.block.update(modified=(frozen_time() - timedelta(seconds=2)))
-        set_config(MLBF_TIME_CONFIG_KEY, last_time, json_value=True)
-        set_config(MLBF_BASE_ID_CONFIG_KEY, last_time, json_value=True)
-        prev_blocked_path = os.path.join(
-            settings.MLBF_STORAGE_PATH, str(last_time), 'blocked.json'
+        assert (
+            mock.call('blocklist.cron.upload_mlbf_to_remote_settings.blocked_count', 1)
+            in self.mocks['olympia.blocklist.cron.statsd.incr'].call_args_list
         )
-        with storage.open(prev_blocked_path, 'w') as blocked_file:
-            json.dump([f'{self.block.guid}:1.2b3'], blocked_file)
+        assert (
+            mock.call(
+                'blocklist.cron.upload_mlbf_to_remote_settings.not_blocked_count', 1
+            )
+            in self.mocks['olympia.blocklist.cron.statsd.incr'].call_args_list
+        )
 
+    def test_upload_stash_unless_force_base(self):
+        """
+        Upload a stash unless force_base is true. When there is a new block,
+        We expect to upload a stash, unless the force_base is true, in which case
+        we upload a new filter.
+        """
+        force_base = False
+        self._block_version(is_signed=True)
+        upload_mlbf_to_remote_settings(force_base=force_base)
+        assert self.mocks[
+            'olympia.blocklist.cron.upload_filter.delay'
+        ].call_args_list == [
+            mock.call(
+                self.current_time,
+                is_base=force_base,
+                block_type_constant=MLBFDataType.BLOCKED.name,
+            )
+        ]
+        mlbf = MLBF.load_from_storage(self.current_time)
+        assert mlbf.storage.exists(mlbf.filter_path) == force_base
+        assert mlbf.storage.exists(mlbf.stash_path) != force_base
+
+    def test_upload_stash_unless_missing_base_filter(self):
+        """
+        Upload a stash unless there is no base filter.
+        """
+        self._block_version(is_signed=True)
         upload_mlbf_to_remote_settings()
-        # So no need for a new bloomfilter
-        self.publish_attachment_mock.assert_not_called()
-        self.publish_record_mock.assert_not_called()
-        self.cleanup_files_mock.assert_not_called()
+        assert self.mocks[
+            'olympia.blocklist.cron.upload_filter.delay'
+        ].call_args_list == [
+            mock.call(
+                self.current_time,
+                is_base=False,
+                block_type_constant=MLBFDataType.BLOCKED.name,
+            )
+        ]
+        mlbf = MLBF.load_from_storage(self.current_time)
+        assert not mlbf.storage.exists(mlbf.filter_path)
+        assert mlbf.storage.exists(mlbf.stash_path)
 
-        # But if we add a new Block a new filter is needed
-        block_factory(
-            addon=addon_factory(file_kw={'is_signed': True}),
-            updated_by=user_factory(),
-        )
+        self.mocks[
+            'olympia.blocklist.cron.get_base_generation_time'
+        ].return_value = None
         upload_mlbf_to_remote_settings()
-        self.publish_attachment_mock.assert_not_called()
-        self.publish_record_mock.assert_called_once()
-        self.cleanup_files_mock.assert_called_once()
-        assert get_config(MLBF_TIME_CONFIG_KEY, json_value=True) == int(
-            datetime(2020, 1, 1, 12, 34, 56).timestamp() * 1000
+        assert (
+            mock.call(
+                self.current_time,
+                is_base=True,
+                block_type_constant=MLBFDataType.BLOCKED.name,
+            )
+            in self.mocks['olympia.blocklist.cron.upload_filter.delay'].call_args_list
         )
-        self.statsd_incr_mock.reset_mock()
+        assert mlbf.storage.exists(mlbf.filter_path)
 
-        frozen_time.tick()
-        # If the first block is deleted the last_modified date won't have
-        # changed, but the number of blocks will, so trigger a new filter.
-        last_modified = get_blocklist_last_modified_time()
-        self.block.delete()
-        assert last_modified == get_blocklist_last_modified_time()
+    @mock.patch('olympia.blocklist.cron.BASE_REPLACE_THRESHOLD', 1)
+    def test_upload_stash_unless_enough_changes(self):
+        """
+        When there are new blocks, upload either a stash or a filter depending on
+        whether we have surpased the BASE_REPLACE_THRESHOLD amount.
+        """
+        self._block_version(is_signed=True)
         upload_mlbf_to_remote_settings()
-        self.publish_attachment_mock.assert_not_called()
-        assert self.publish_record_mock.call_count == 2
-        assert self.cleanup_files_mock.call_count == 2
+        assert self.mocks[
+            'olympia.blocklist.cron.upload_filter.delay'
+        ].call_args_list == [
+            mock.call(
+                self.current_time,
+                is_base=False,
+                block_type_constant=MLBFDataType.BLOCKED.name,
+            )
+        ]
+        mlbf = MLBF.load_from_storage(self.current_time)
+        assert not mlbf.storage.exists(mlbf.filter_path)
+        assert mlbf.storage.exists(mlbf.stash_path)
 
-        self.statsd_incr_mock.assert_has_calls(
-            [
-                mock.call(f'{STATSD_PREFIX}blocked_changed', 1),
-                mock.call(f'{STATSD_PREFIX}blocked_count', 1),
-                mock.call(f'{STATSD_PREFIX}not_blocked_count', 4),
-                mock.call('blocklist.tasks.upload_filter.upload_stash'),
-                mock.call(f'{STATSD_PREFIX}success'),
-            ]
+        self._block_version(is_signed=True)
+        # Create a new current time so we can test that the stash is not created
+        self.current_time = datetime_to_ts(self.block.modified + timedelta(seconds=4))
+        self.mocks[
+            'olympia.blocklist.cron.get_generation_time'
+        ].return_value = self.current_time
+        upload_mlbf_to_remote_settings()
+        assert (
+            mock.call(
+                self.current_time,
+                is_base=True,
+                block_type_constant=MLBFDataType.BLOCKED.name,
+            )
+            in self.mocks['olympia.blocklist.cron.upload_filter.delay'].call_args_list
         )
-        self.cleanup_files_mock.assert_called_with(base_filter_id=last_time)
+        new_mlbf = MLBF.load_from_storage(self.current_time)
+        assert new_mlbf.storage.exists(new_mlbf.filter_path)
+        assert not new_mlbf.storage.exists(new_mlbf.stash_path)
 
-    @mock.patch('olympia.blocklist.cron._upload_mlbf_to_remote_settings')
-    def test_no_statsd_ping_when_switch_off(self, inner_mock):
-        with override_switch('blocklist_mlbf_submit', active=False):
-            upload_mlbf_to_remote_settings()
-            self.statsd_incr_mock.assert_not_called()
+    def test_cleanup_old_files(self):
+        """
+        Cleanup old files only if a base filter already exists.
+        """
+        upload_mlbf_to_remote_settings(force_base=True)
+        assert self.mocks[
+            'olympia.blocklist.cron.cleanup_old_files.delay'
+        ].call_args_list == [mock.call(base_generation_time=self.base_time)]
 
-        with override_switch('blocklist_mlbf_submit', active=True):
-            upload_mlbf_to_remote_settings()
-            self.statsd_incr_mock.assert_called()
+        self.mocks[
+            'olympia.blocklist.cron.get_base_generation_time'
+        ].return_value = None
+        upload_mlbf_to_remote_settings(force_base=True)
+        assert (
+            self.mocks['olympia.blocklist.cron.cleanup_old_files.delay'].call_count == 1
+        )
+
+    def test_raises_if_base_generation_time_invalid(self):
+        """
+        When a base_generation_time is provided, but no filter exists for it,
+        raise no filter found.
+        """
+        self.mocks['olympia.blocklist.cron.get_base_generation_time'].return_value = 1
+        with pytest.raises(FileNotFoundError):
+            upload_mlbf_to_remote_settings(force_base=True)
+
+    def test_raises_if_last_generation_time_invalid(self):
+        """
+        When a last_generation_time is provided, but no filter exists for it,
+        raise no filter found.
+        """
+        self.mocks['olympia.blocklist.cron.get_last_generation_time'].return_value = 1
+        with pytest.raises(FileNotFoundError):
+            upload_mlbf_to_remote_settings(force_base=True)
+
+
+class TestTimeMethods(TestCase):
+    def test_get_generation_time(self):
+        assert get_generation_time() == datetime_to_ts()
+        assert isinstance(get_generation_time(), int)
+
+    def test_get_last_generation_time(self):
+        assert get_last_generation_time() == 0
+        set_config(MLBF_TIME_CONFIG_KEY, 1)
+        assert get_last_generation_time() == 1
+
+    def test_get_base_generation_time(self):
+        assert get_base_generation_time() == 0
+        set_config(MLBF_BASE_ID_CONFIG_KEY, 1)
+        assert get_base_generation_time() == 1
 
 
 @pytest.mark.django_db

--- a/src/olympia/blocklist/tests/test_cron.py
+++ b/src/olympia/blocklist/tests/test_cron.py
@@ -316,6 +316,7 @@ class TestUploadToRemoteSettings(TestCase):
 
 
 class TestTimeMethods(TestCase):
+    @freeze_time('2024-10-10 12:34:56')
     def test_get_generation_time(self):
         assert get_generation_time() == datetime_to_ts()
         assert isinstance(get_generation_time(), int)

--- a/src/olympia/blocklist/tests/test_cron.py
+++ b/src/olympia/blocklist/tests/test_cron.py
@@ -286,7 +286,7 @@ class TestUploadToRemoteSettings(TestCase):
         upload_mlbf_to_remote_settings(force_base=True)
         assert self.mocks[
             'olympia.blocklist.cron.cleanup_old_files.delay'
-        ].call_args_list == [mock.call(base_generation_time=self.base_time)]
+        ].call_args_list == [mock.call(base_filter_id=self.base_time)]
 
         self.mocks[
             'olympia.blocklist.cron.get_base_generation_time'
@@ -321,12 +321,12 @@ class TestTimeMethods(TestCase):
         assert isinstance(get_generation_time(), int)
 
     def test_get_last_generation_time(self):
-        assert get_last_generation_time() == 0
+        assert get_last_generation_time() == None
         set_config(MLBF_TIME_CONFIG_KEY, 1)
         assert get_last_generation_time() == 1
 
     def test_get_base_generation_time(self):
-        assert get_base_generation_time() == 0
+        assert get_base_generation_time() == None
         set_config(MLBF_BASE_ID_CONFIG_KEY, 1)
         assert get_base_generation_time() == 1
 

--- a/src/olympia/blocklist/tests/test_mlbf.py
+++ b/src/olympia/blocklist/tests/test_mlbf.py
@@ -1,12 +1,6 @@
 import json
-import os
-import tempfile
-from unittest import mock
+from functools import cached_property
 
-from filtercascade import FilterCascade
-
-from olympia import amo
-from olympia.addons.models import GUID_REUSE_FORMAT
 from olympia.amo.tests import (
     TestCase,
     addon_factory,
@@ -14,436 +8,390 @@ from olympia.amo.tests import (
     user_factory,
     version_factory,
 )
-from olympia.files.models import File
+from olympia.amo.utils import SafeStorage
+from olympia.blocklist.models import BlockVersion
 
 from ..mlbf import (
     MLBF,
-    fetch_all_versions_from_db,
-    fetch_blocked_from_db,
-    generate_mlbf,
+    BaseMLBFLoader,
+    MLBFDataBaseLoader,
+    MLBFDataType,
+    MLBFStorageLoader,
 )
 
 
-class TestMLBF(TestCase):
-    def setup_data(self):
-        user = user_factory()
-        for _idx in range(0, 5):
-            addon_factory()
-        # one version, listed (twice)
-        block_factory(
-            addon=addon_factory(file_kw={'is_signed': True}),
-            updated_by=user,
-        )
-        block_factory(
-            addon=addon_factory(file_kw={'is_signed': True}),
-            updated_by=user,
-        )
-        # one version, unlisted
-        block_factory(
-            addon=addon_factory(
-                version_kw={'channel': amo.CHANNEL_UNLISTED},
-                file_kw={'is_signed': True},
-            ),
-            updated_by=user,
-        )
-        # five versions, but only two within block (123.40, 123.5)
-        five_ver_block_addon = addon_factory(
-            version_kw={'version': '123.40'},
-            file_kw={'is_signed': True},
-        )
-        self.five_ver_123_40 = five_ver_block_addon.current_version
-        self.five_ver_123_5 = version_factory(
-            addon=five_ver_block_addon,
-            version='123.5',
-            deleted=True,
-            file_kw={'is_signed': True},
-        )
-        self.five_ver_123_45_1 = version_factory(
-            addon=five_ver_block_addon,
-            version='123.45.1',
-            file_kw={'is_signed': True},
-        )
-        # these two would be included if they were signed
-        self.not_signed_version = version_factory(
-            addon=five_ver_block_addon,
-            version='123.5.1',
-            file_kw={'is_signed': False},
-        )
-        self.not_signed_version2 = version_factory(
-            addon=five_ver_block_addon,
-            version='123.5.2',
-            file_kw={'is_signed': False},
-        )
-        self.five_ver_block = block_factory(
-            addon=five_ver_block_addon,
-            updated_by=user,
-            version_ids=[
-                self.five_ver_123_40.id,
-                self.five_ver_123_5.id,
-                self.not_signed_version.id,
-                self.not_signed_version2.id,
-            ],
+class _MLBFBase(TestCase):
+    def setUp(self):
+        self.storage = SafeStorage()
+        self.cache_path = self.storage.path('mlbf_test.json')
+        self.user = user_factory()
+
+    def _blocked_addon(self, **kwargs):
+        addon = addon_factory(**kwargs)
+        block = block_factory(guid=addon.guid, updated_by=self.user)
+        return addon, block
+
+    def _version(self, addon, is_signed=True):
+        return version_factory(addon=addon, file_kw={'is_signed': is_signed})
+
+    def _block_version(self, block, version, soft=False):
+        return BlockVersion.objects.create(
+            block=block,
+            version=version,
+            soft=soft,
         )
 
-        # no matching versions (edge cases)
-        self.no_versions = block_factory(
-            addon=addon_factory(
-                version_kw={'version': '0.1'},
-                file_kw={'is_signed': True},
-            ),
-            updated_by=user,
-            version_ids=[],
-        )
-        self.no_versions2 = block_factory(
-            addon=addon_factory(
-                version_kw={'version': '0.1'},
-                file_kw={'is_signed': True},
-            ),
-            updated_by=user,
-            version_ids=[],
-        )
 
-        # A blocked addon has been uploaded and deleted before
-        reused_2_1_addon = addon_factory(
-            # this a previous, superceeded, addon that should be included
-            status=amo.STATUS_DELETED,  # they should all be deleted
-            version_kw={'version': '2.1'},
-            file_kw={'is_signed': True},
-        )
-        self.addon_deleted_before_2_1_ver = reused_2_1_addon.versions.all()[0]
-        reused_2_5_addon = addon_factory(
-            # And this is an earlier addon that should also be included
-            status=amo.STATUS_DELETED,  # they should all be deleted
-            version_kw={'version': '2.5'},
-            file_kw={'is_signed': True},
-        )
-        self.addon_deleted_before_2_5_ver = reused_2_5_addon.versions.all()[0]
-        current_addon = addon_factory(
-            version_kw={'version': '2'},
-            file_kw={'is_signed': True},
-        )
-        self.addon_deleted_before_unblocked_ver = current_addon.current_version
-        self.addon_deleted_before_unsigned_ver = version_factory(
-            addon=current_addon,
-            version='2.1',
-            # not signed, but shouldn't override the signed 2.1 version
-            file_kw={'is_signed': False},
-        )
-        self.addon_deleted_before_3_0_ver = version_factory(
-            addon=current_addon,
-            version='3.0',
-            file_kw={'is_signed': True},
-        )
-        reused_2_1_addon.update(guid=GUID_REUSE_FORMAT.format(current_addon.id))
-        reused_2_5_addon.update(guid=GUID_REUSE_FORMAT.format(reused_2_1_addon.id))
-        reused_2_1_addon.addonguid.update(guid=current_addon.guid)
-        reused_2_5_addon.addonguid.update(guid=current_addon.guid)
-        self.addon_deleted_before_block = block_factory(
-            guid=current_addon.guid,
-            updated_by=user,
-            version_ids=[
-                self.addon_deleted_before_2_1_ver.id,
-                self.addon_deleted_before_2_5_ver.id,
-                self.addon_deleted_before_unsigned_ver.id,
-                self.addon_deleted_before_3_0_ver.id,
-            ],
-        )
+class TestBaseMLBFLoader(_MLBFBase):
+    class TestStaticLoader(BaseMLBFLoader):
+        @cached_property
+        def blocked_items(self):
+            return ['blocked:version']
 
-    def test_fetch_all_versions_from_db(self):
-        self.setup_data()
-        with self.assertNumQueries(1):
-            all_versions = fetch_all_versions_from_db()
-        assert len(all_versions) == File.objects.count() == 5 + 10 + 5
-        assert (self.five_ver_block.guid, '123.40') in all_versions
-        assert (self.five_ver_block.guid, '123.5') in all_versions
-        assert (self.five_ver_block.guid, '123.45.1') in all_versions
-        assert (self.five_ver_block.guid, '123.5.1') in all_versions
-        assert (self.five_ver_block.guid, '123.5.2') in all_versions
-        no_versions_tuple = (
-            self.no_versions.guid,
-            self.no_versions.addon.current_version.version,
-        )
-        assert no_versions_tuple in all_versions
-        no_versions2_tuple = (
-            self.no_versions2.guid,
-            self.no_versions2.addon.current_version.version,
-        )
-        assert no_versions2_tuple in all_versions
+        @cached_property
+        def not_blocked_items(self):
+            return ['notblocked:version']
 
-        assert (self.addon_deleted_before_block.guid, '2') in all_versions
-        # this is fine; test_hash_filter_inputs removes duplicates.
-        assert all_versions.count((self.addon_deleted_before_block.guid, '2.1')) == 2
-        assert (self.addon_deleted_before_block.guid, '2.5') in all_versions
-        assert (self.addon_deleted_before_block.guid, '3.0') in all_versions
+    def test_missing_methods_raises(self):
+        with self.assertRaises(NotImplementedError):
+            _ = BaseMLBFLoader(self.storage, self.cache_path)._raw
 
-        # repeat, but with excluded version ids
-        excludes = [self.five_ver_123_40.id, self.five_ver_123_5.id]
-        all_versions = fetch_all_versions_from_db(excludes)
-        assert len(all_versions) == 18
-        assert (self.five_ver_block.guid, '123.40') not in all_versions
-        assert (self.five_ver_block.guid, '123.5') not in all_versions
-        assert (self.five_ver_block.guid, '123.45.1') in all_versions
-        assert (self.five_ver_block.guid, '123.5.1') in all_versions
-        assert (self.five_ver_block.guid, '123.5.2') in all_versions
-        no_versions_tuple = (
-            self.no_versions.guid,
-            self.no_versions.addon.current_version.version,
-        )
-        assert no_versions_tuple in all_versions
-        no_versions2_tuple = (
-            self.no_versions2.guid,
-            self.no_versions2.addon.current_version.version,
-        )
-        assert no_versions2_tuple in all_versions
+        class TestMissingNotBlocked(BaseMLBFLoader):
+            @cached_property
+            def blocked_items(self):
+                return []
 
-    def test_fetch_blocked_from_db(self):
-        self.setup_data()
-        with self.assertNumQueries(1):
-            blocked_versions = fetch_blocked_from_db()
+        with self.assertRaises(NotImplementedError):
+            _ = TestMissingNotBlocked(self.storage, self.cache_path).not_blocked_items
 
-        # check the values - the tuples used to generate the mlbf
-        blocked_guids = blocked_versions.values()
-        assert len(blocked_guids) == 8, blocked_guids
-        assert (self.five_ver_block.guid, '123.40') in blocked_guids
-        assert (self.five_ver_block.guid, '123.5') in blocked_guids
-        assert (self.five_ver_block.guid, '123.45.1') not in blocked_guids
-        assert (self.five_ver_block.guid, '123.5.1') not in blocked_guids
-        assert (self.five_ver_block.guid, '123.5.2') not in blocked_guids
-        no_versions_tuple = (
-            self.no_versions.guid,
-            self.no_versions.addon.current_version.version,
-        )
-        assert no_versions_tuple not in blocked_guids
-        no_versions2_tuple = (
-            self.no_versions2.guid,
-            self.no_versions2.addon.current_version.version,
-        )
-        assert no_versions2_tuple not in blocked_guids
-        assert (self.addon_deleted_before_block.guid, '2.1') in blocked_guids
-        assert (self.addon_deleted_before_block.guid, '2.5') in blocked_guids
-        assert (self.addon_deleted_before_block.guid, '3.0') in blocked_guids
-        assert (self.addon_deleted_before_block.guid, '2.0') not in blocked_guids
+        class TestMissingBlocked(BaseMLBFLoader):
+            @cached_property
+            def notblocked_items(self):
+                return []
 
-        # And check the keys, the ids used to filter out the versions
-        assert self.five_ver_123_40.id in blocked_versions
-        assert self.five_ver_123_5.id in blocked_versions
-        assert self.five_ver_123_45_1.id not in blocked_versions
-        assert self.not_signed_version.id not in blocked_versions
-        assert self.not_signed_version2.id not in blocked_versions
-        assert self.no_versions.addon.current_version.id not in blocked_versions
-        assert self.no_versions2.addon.current_version.id not in blocked_versions
+        with self.assertRaises(NotImplementedError):
+            _ = TestMissingBlocked(self.storage, self.cache_path).blocked_items
 
-        assert self.addon_deleted_before_unblocked_ver.id not in (blocked_versions)
-        assert self.addon_deleted_before_unsigned_ver.id not in (blocked_versions)
-        assert self.addon_deleted_before_block.addon.current_version.id in (
-            blocked_versions
-        )
-        assert self.addon_deleted_before_2_1_ver.id in (blocked_versions)
-        assert self.addon_deleted_before_2_5_ver.id in (blocked_versions)
-
-        # doublecheck if the versions were signed & webextensions they'd be in.
-        self.not_signed_version.file.update(is_signed=True)
-        self.not_signed_version2.file.update(is_signed=True)
-        assert len(fetch_blocked_from_db()) == 10
-
-    def test_hash_filter_inputs(self):
-        data = [
-            ('guid@', '1.0'),
-            ('foo@baa', '999.223a'),
-        ]
-        assert sorted(MLBF.hash_filter_inputs(data)) == [
-            'foo@baa:999.223a',
-            'guid@:1.0',
-        ]
-        # check dupes are stripped out too
-        data.append(('guid@', '1.0'))
-        assert sorted(MLBF.hash_filter_inputs(data)) == [
-            'foo@baa:999.223a',
-            'guid@:1.0',
-        ]
-
-    def test_generate_mlbf(self):
-        stats = {}
-        key_format = MLBF.KEY_FORMAT
-        blocked = [
-            ('guid1@', '1.0'),
-            ('@guid2', '1.0'),
-            ('@guid2', '1.1'),
-            ('guid3@', '0.01b1'),
-            # throw in a dupe at the end - should be removed along the way
-            ('guid3@', '0.01b1'),
-        ]
-        not_blocked = [
-            ('guid10@', '1.0'),
-            ('@guid20', '1.0'),
-            ('@guid20', '1.1'),
-            ('guid30@', '0.01b1'),
-            ('guid100@', '1.0'),
-            ('@guid200', '1.0'),
-            ('@guid200', '1.1'),
-            ('guid300@', '0.01b1'),
-        ]
-        bfilter = generate_mlbf(
-            stats,
-            blocked=MLBF.hash_filter_inputs(blocked),
-            not_blocked=MLBF.hash_filter_inputs(not_blocked),
-        )
-        for entry in blocked:
-            key = key_format.format(guid=entry[0], version=entry[1])
-            assert key in bfilter
-        for entry in not_blocked:
-            key = key_format.format(guid=entry[0], version=entry[1])
-            assert key not in bfilter
-        assert stats['mlbf_version'] == 2
-        assert stats['mlbf_layers'] == 1
-        assert stats['mlbf_bits'] == 2160
-        with tempfile.NamedTemporaryFile() as out:
-            bfilter.tofile(out)
-            assert os.stat(out.name).st_size == 300
-
-    def test_generate_mlbf_with_more_blocked_than_not_blocked(self):
-        key_format = MLBF.KEY_FORMAT
-        blocked = [('guid1@', '1.0'), ('@guid2', '1.0')]
-        not_blocked = [('guid10@', '1.0')]
-        bfilter = generate_mlbf(
-            {},
-            blocked=MLBF.hash_filter_inputs(blocked),
-            not_blocked=MLBF.hash_filter_inputs(not_blocked),
-        )
-        for entry in blocked:
-            key = key_format.format(guid=entry[0], version=entry[1])
-            assert key in bfilter
-        for entry in not_blocked:
-            key = key_format.format(guid=entry[0], version=entry[1])
-            assert key not in bfilter
-
-    def test_generate_and_write_filter(self):
-        self.setup_data()
-        with self.assertNumQueries(2):
-            mlbf = MLBF.generate_from_db(123456)
-            mlbf.generate_and_write_filter()
-
-        with open(mlbf.filter_path, 'rb') as filter_file:
-            buffer = filter_file.read()
-            bfilter = FilterCascade.from_buf(buffer)
-
-        blocked_versions = fetch_blocked_from_db()
-        blocked_guids = blocked_versions.values()
-        for guid, version_str in blocked_guids:
-            key = MLBF.KEY_FORMAT.format(guid=guid, version=version_str)
-            assert key in bfilter
-
-        all_addons = fetch_all_versions_from_db(blocked_versions.keys())
-        for guid, version_str in all_addons:
-            # edge case where a version_str exists in both
-            if (guid, version_str) in blocked_guids:
-                continue
-            key = MLBF.KEY_FORMAT.format(guid=guid, version=version_str)
-            assert key not in bfilter
-
-        # Occasionally a combination of salt generated with secrets.token_bytes
-        # and the version str generated in version_factory results in a
-        # collision in layer 1 of the bloomfilter, leading to a second layer
-        # being generated.  When this happens the bitCount and size is larger.
-        expected_size, expected_bit_count = (
-            (203, 1384) if bfilter.layerCount() == 1 else (393, 2824)
-        )
-        assert os.stat(mlbf.filter_path).st_size == expected_size, (
-            blocked_guids,
-            all_addons,
-        )
-        assert bfilter.bitCount() == expected_bit_count, (blocked_guids, all_addons)
-
-    def test_generate_diffs(self):
-        old_versions = [
-            ('guid1@', '1.0'),
-            ('@guid2', '1.0'),
-            ('@guid2', '1.1'),
-            ('guid3@', '0.01b1'),
-        ]
-        new_versions = [
-            ('guid1@', '1.0'),
-            ('guid3@', '0.01b1'),
-            ('@guid2', '1.1'),
-            ('new_guid@', '0.01b1'),
-            ('new_guid@', '24'),
-        ]
-        extras, deletes = MLBF.generate_diffs(old_versions, new_versions)
-        assert extras == {('new_guid@', '0.01b1'), ('new_guid@', '24')}
-        assert deletes == {('@guid2', '1.0')}
-
-    def test_write_stash(self):
-        self.setup_data()
-        old_mlbf = MLBF.generate_from_db('old')
-        old_mlbf.generate_and_write_filter()
-        new_mlbf = MLBF.generate_from_db('new_no_change')
-        new_mlbf.generate_and_write_filter()
-        new_mlbf.generate_and_write_stash(old_mlbf)
-        empty_stash = {'blocked': [], 'unblocked': []}
-        with open(new_mlbf._stash_path) as stash_file:
-            assert json.load(stash_file) == empty_stash
-        assert new_mlbf.stash_json == empty_stash
-        # add a new Block and delete one
-        block_factory(
-            addon=addon_factory(
-                guid='fooo@baaaa',
-                version_kw={'version': '999'},
-                file_kw={'is_signed': True},
-            ),
-            updated_by=user_factory(),
-        )
-        self.five_ver_123_5.delete(hard=True)
-        newer_mlbf = MLBF.generate_from_db('new_one_change')
-        newer_mlbf.generate_and_write_filter()
-        newer_mlbf.generate_and_write_stash(new_mlbf)
-        full_stash = {
-            'blocked': ['fooo@baaaa:999'],
-            'unblocked': [f'{self.five_ver_block.guid}:123.5'],
+    def test_raw_contains_correct_data(self):
+        loader = self.TestStaticLoader(self.storage, self.cache_path)
+        assert loader._raw == {
+            'blocked': ['blocked:version'],
+            'not_blocked': ['notblocked:version'],
         }
-        with open(newer_mlbf._stash_path) as stash_file:
-            assert json.load(stash_file) == full_stash
-        assert newer_mlbf.stash_json == full_stash
 
-    def test_should_reset_base_filter_and_blocks_changed_since_previous(self):
-        self.setup_data()
+    def test_invalid_key_access_raises(self):
+        loader = self.TestStaticLoader(self.storage, self.cache_path)
+
+        with self.assertRaises(AttributeError):
+            loader['invalid']
+        with self.assertRaises(AttributeError):
+            loader[BlockVersion.BLOCK_TYPE_CHOICES.BLOCKED]
+
+    def test_valid_key_access_returns_expected_data(self):
+        loader = self.TestStaticLoader(self.storage, self.cache_path)
+        assert loader[MLBFDataType.BLOCKED] == ['blocked:version']
+        assert loader[MLBFDataType.NOT_BLOCKED] == ['notblocked:version']
+
+    def test_cache_raw_data(self):
+        loader = self.TestStaticLoader(self.storage, self.cache_path)
+
+        for data_type in MLBFDataType:
+            assert loader[data_type] == loader._raw[data_type.value]
+
+        # The source of truth should ultimately be the named cached properties
+        # Even though _raw is cached, it should still return
+        # the reference to the named property
+        loader.blocked_items = []
+        assert loader[MLBFDataType.BLOCKED] == []
+
+
+class TestMLBFStorageLoader(_MLBFBase):
+    def setUp(self):
+        super().setUp()
+        self._data = {
+            'blocked': ['blocked:version'],
+            'not_blocked': ['notblocked:version'],
+        }
+
+    def test_raises_missing_file(self):
+        with self.assertRaises(FileNotFoundError):
+            _ = MLBFStorageLoader(self.storage, self.cache_path)._raw
+
+    def test_loads_data_from_file(self):
+        with self.storage.open(self.cache_path, 'w') as f:
+            json.dump(self._data, f)
+
+        loader = MLBFStorageLoader(self.storage, self.cache_path)
+        assert loader._raw == self._data
+
+
+class TestMLBFDataBaseLoader(_MLBFBase):
+    def test_load_returns_expected_data(self):
+        """
+        Test that the class returns a dictionary mapping the
+        expected TestMLBFDataBaseLoader keys to the blocked and notblocked item lists.
+        """
+        addon, block = self._blocked_addon()
+
+        notblocked_version = addon.current_version
+        block_version = self._block_version(block, self._version(addon), soft=False)
+
+        mlbf_data = MLBFDataBaseLoader(self.storage, self.cache_path)
+        assert mlbf_data[MLBFDataType.BLOCKED] == MLBF.hash_filter_inputs(
+            [(block_version.block.guid, block_version.version.version)]
+        )
+        assert mlbf_data[MLBFDataType.NOT_BLOCKED] == MLBF.hash_filter_inputs(
+            [(notblocked_version.addon.guid, notblocked_version.version)]
+        )
+
+    def test_blocked_items_caches_excluded_version_ids(self):
+        """
+        Test that accessing the blocked_items property caches the version IDs
+        to exclude in the notblocked_items property.
+        """
+        addon, block = self._blocked_addon()
+        block_version = self._block_version(block, self._version(addon), soft=False)
+        with self.assertNumQueries(2):
+            mlbf_data = MLBFDataBaseLoader(self.storage, self.cache_path)
+        assert mlbf_data._version_excludes == [block_version.version.id]
+
+    def test_hash_filter_inputs_returns_set_of_hashed_strings(self):
+        """
+        Test that the hash_filter_inputs class method returns a set of
+        hashed guid:version strings given an input list of (guid, version)
+        tuples.
+        """
+        default = MLBF.hash_filter_inputs(
+            [
+                ('guid', 'version'),
+            ]
+        )
+        assert default == ['guid:version']
+
+
+class TestMLBF(_MLBFBase):
+    def test_get_data_from_db(self):
+        self._blocked_addon()
+        mlbf = MLBF.generate_from_db('test')
+        assert isinstance(mlbf.data, MLBFDataBaseLoader)
+        mlbf_data = MLBFDataBaseLoader(mlbf.storage, mlbf.cache_path)
+        assert mlbf.data._raw == mlbf_data._raw
+
+    def test_get_data_from_storage(self):
+        self._blocked_addon()
+        mlbf = MLBF.generate_from_db('test')
+        cached_mlbf = MLBF.load_from_storage('test')
+        assert isinstance(cached_mlbf.data, MLBFStorageLoader)
+        assert mlbf.data._raw == cached_mlbf.data._raw
+
+    def test_diff_returns_stateless_without_previous(self):
+        """
+        Starting with an initially blocked addon, diff after removing the block
+        depends on whether a previous mlbf is provided and if that previous mlbf
+        has the unblocked addon already
+        """
+        addon, _ = self._blocked_addon()
         base_mlbf = MLBF.generate_from_db('base')
-        # should handle the files not existing
-        assert base_mlbf.should_reset_base_filter(MLBF.load_from_storage('no_files'))
-        assert base_mlbf.blocks_changed_since_previous(
-            MLBF.load_from_storage('no_files')
-        )
-        base_mlbf.generate_and_write_filter()
 
-        no_change_mlbf = MLBF.generate_from_db('no_change')
-        no_change_mlbf.generate_and_write_filter()
-        assert not no_change_mlbf.should_reset_base_filter(base_mlbf)
-        assert not no_change_mlbf.blocks_changed_since_previous(base_mlbf)
-
-        # make some changes
-        block_factory(
-            addon=addon_factory(
-                guid='fooo@baaaa',
-                version_kw={'version': '999'},
-                file_kw={'is_signed': True},
+        assert base_mlbf.generate_diffs(data_type=MLBFDataType.NOT_BLOCKED) == (
+            set(
+                MLBF.hash_filter_inputs(
+                    [(addon.block.guid, addon.current_version.version)]
+                )
             ),
-            updated_by=user_factory(),
+            set(),
+            1,
         )
-        self.five_ver_123_5.delete(hard=True)
-        small_change_mlbf = MLBF.generate_from_db('small_change')
-        small_change_mlbf.generate_and_write_filter()
-        # but the changes were small (less than threshold) so no need for new
-        # base filter
-        assert not small_change_mlbf.should_reset_base_filter(base_mlbf)
-        # there _were_ changes though
-        assert small_change_mlbf.blocks_changed_since_previous(base_mlbf)
-        # double check what the differences were
-        diffs = MLBF.generate_diffs(
-            previous=base_mlbf.blocked_items, current=small_change_mlbf.blocked_items
-        )
-        assert diffs == ({'fooo@baaaa:999'}, {f'{self.five_ver_block.guid}:123.5'})
 
-        # so lower the threshold
-        to_patch = 'olympia.blocklist.mlbf.BASE_REPLACE_THRESHOLD'
-        with mock.patch(to_patch, 1):
-            assert small_change_mlbf.should_reset_base_filter(base_mlbf)
-            assert small_change_mlbf.blocks_changed_since_previous(base_mlbf)
+        next_mlbf = MLBF.generate_from_db('next')
+        # If we don't include the base_mlbf, unblocked version will still be in the diff
+        assert next_mlbf.generate_diffs(data_type=MLBFDataType.NOT_BLOCKED) == (
+            set(
+                MLBF.hash_filter_inputs(
+                    [(addon.block.guid, addon.current_version.version)]
+                )
+            ),
+            set(),
+            1,
+        )
+        # Providing a previous mlbf with the unblocked version already included
+        # removes it from the diff
+        assert next_mlbf.generate_diffs(
+            data_type=MLBFDataType.NOT_BLOCKED, previous_mlbf=base_mlbf
+        ) == (set(), set(), 0)
+
+    def test_diff_no_changes(self):
+        addon, block = self._blocked_addon()
+        self._block_version(block, self._version(addon), soft=False)
+        base_mlbf = MLBF.generate_from_db('test')
+        next_mlbf = MLBF.generate_from_db('test_two')
+
+        assert next_mlbf.generate_diffs(
+            data_type=MLBFDataType.BLOCKED, previous_mlbf=base_mlbf
+        ) == (set(), set(), 0)
+        assert next_mlbf.generate_diffs(
+            data_type=MLBFDataType.NOT_BLOCKED, previous_mlbf=base_mlbf
+        ) == (set(), set(), 0)
+
+    def test_diff_block_added(self):
+        addon, block = self._blocked_addon()
+        base_mlbf = MLBF.generate_from_db('test')
+
+        new_block = self._block_version(block, self._version(addon), soft=False)
+
+        next_mlbf = MLBF.generate_from_db('test_two')
+
+        assert next_mlbf.generate_diffs(
+            previous_mlbf=base_mlbf, data_type=MLBFDataType.BLOCKED
+        ) == (
+            set(
+                MLBF.hash_filter_inputs(
+                    [(new_block.block.guid, new_block.version.version)]
+                )
+            ),
+            set(),
+            1,
+        )
+        assert next_mlbf.generate_diffs(
+            previous_mlbf=base_mlbf, data_type=MLBFDataType.NOT_BLOCKED
+        ) == (set(), set(), 0)
+
+    def test_diff_block_removed(self):
+        addon, block = self._blocked_addon()
+        block_version = self._block_version(block, self._version(addon), soft=False)
+        base_mlbf = MLBF.generate_from_db('test')
+        block_version.delete()
+        next_mlbf = MLBF.generate_from_db('test_two')
+
+        assert next_mlbf.generate_diffs(
+            data_type=MLBFDataType.BLOCKED, previous_mlbf=base_mlbf
+        ) == (
+            set(),
+            set(
+                MLBF.hash_filter_inputs(
+                    [(block_version.block.guid, block_version.version.version)]
+                )
+            ),
+            1,
+        )
+        assert next_mlbf.generate_diffs(
+            data_type=MLBFDataType.NOT_BLOCKED, previous_mlbf=base_mlbf
+        ) == (
+            set(
+                MLBF.hash_filter_inputs(
+                    [(block_version.block.guid, block_version.version.version)]
+                )
+            ),
+            set(),
+            1,
+        )
+
+    def test_diff_block_added_and_removed(self):
+        addon, block = self._blocked_addon()
+        block_version = self._block_version(block, self._version(addon), soft=False)
+        base_mlbf = MLBF.generate_from_db('test')
+
+        new_block = self._block_version(block, self._version(addon), soft=False)
+        block_version.delete()
+
+        next_mlbf = MLBF.generate_from_db('test_two')
+
+        assert next_mlbf.generate_diffs(
+            data_type=MLBFDataType.BLOCKED, previous_mlbf=base_mlbf
+        ) == (
+            set(
+                MLBF.hash_filter_inputs(
+                    [(new_block.block.guid, new_block.version.version)]
+                )
+            ),
+            set(
+                MLBF.hash_filter_inputs(
+                    [(block_version.block.guid, block_version.version.version)]
+                )
+            ),
+            2,
+        )
+
+        assert next_mlbf.generate_diffs(
+            data_type=MLBFDataType.NOT_BLOCKED, previous_mlbf=base_mlbf
+        ) == (
+            set(
+                MLBF.hash_filter_inputs(
+                    [(block_version.block.guid, block_version.version.version)]
+                )
+            ),
+            set(),
+            1,
+        )
+
+    def test_generate_stash_returns_expected_stash(self):
+        addon, block = self._blocked_addon()
+        block_version = self._block_version(block, self._version(addon), soft=False)
+        mlbf = MLBF.generate_from_db('test')
+        mlbf.generate_and_write_stash(MLBFDataType.BLOCKED)
+
+        with mlbf.storage.open(mlbf.stash_path(MLBFDataType.BLOCKED), 'r') as f:
+            assert json.load(f) == {
+                'blocked': MLBF.hash_filter_inputs(
+                    [(block_version.block.guid, block_version.version.version)]
+                ),
+                'unblocked': [],
+            }
+        block_version.delete()
+
+        next_mlbf = MLBF.generate_from_db('test_two')
+        next_mlbf.generate_and_write_stash(
+            data_type=MLBFDataType.BLOCKED, previous_mlbf=mlbf
+        )
+        with next_mlbf.storage.open(
+            next_mlbf.stash_path(MLBFDataType.BLOCKED), 'r'
+        ) as f:
+            assert json.load(f) == {
+                'blocked': [],
+                'unblocked': MLBF.hash_filter_inputs(
+                    [(block_version.block.guid, block_version.version.version)]
+                ),
+            }
+
+    def test_changed_count_returns_expected_count(self):
+        addon, block = self._blocked_addon()
+        self._block_version(block, self._version(addon), soft=False)
+        first_mlbf = MLBF.generate_from_db('first')
+        # Include the new blocked version
+        assert first_mlbf.blocks_changed_since_previous(MLBFDataType.BLOCKED) == 1
+        self._block_version(block, self._version(addon), soft=False)
+        # The count should not change because the data is already calculated
+        assert first_mlbf.blocks_changed_since_previous(MLBFDataType.BLOCKED) == 1
+        next_mlbf = MLBF.generate_from_db('next')
+        # The count should include both blocked versions since we are not comparing
+        assert next_mlbf.blocks_changed_since_previous(MLBFDataType.BLOCKED) == 2
+        # When comparing to the first mlbf,
+        # the count should only include the second block
+        assert (
+            next_mlbf.blocks_changed_since_previous(
+                MLBFDataType.BLOCKED, previous_mlbf=first_mlbf
+            )
+            == 1
+        )
+
+    def test_generate_filter_not_raises_if_all_versions_unblocked(self):
+        """
+        When we create a bloom filter where all versions fall into
+        the "not filtered" category This can create invalid error rates
+        because the error rate depends on these numbers being non-zero.
+        """
+        mlbf = MLBF.generate_from_db('test')
+        self._blocked_addon(file_kw={'is_signed': True})
+        assert mlbf.data.blocked_items == []
+        mlbf.generate_and_write_filter(MLBFDataType.BLOCKED)
+
+    def test_generate_filter_not_raises_if_all_versions_blocked(self):
+        """
+        When we create a bloom filter where all versions fall into
+        the "not filtered" category This can create invalid error rates
+        because the error rate depends on these numbers being non-zero.
+        """
+        mlbf = MLBF.generate_from_db('test')
+        self._blocked_addon(file_kw={'is_signed': False})
+        assert mlbf.data.not_blocked_items == []
+        mlbf.generate_and_write_filter(MLBFDataType.BLOCKED)

--- a/src/olympia/blocklist/tests/test_mlbf.py
+++ b/src/olympia/blocklist/tests/test_mlbf.py
@@ -2,6 +2,7 @@ import json
 import os
 import tempfile
 from unittest import mock
+
 from django.test.utils import override_settings
 
 from filtercascade import FilterCascade
@@ -469,11 +470,13 @@ class TestMLBF(TestCase):
         addon = addon_factory(file_kw={'is_signed': True})
         mlbf = MLBF.generate_from_db('test')
         assert mlbf.blocked_items == []
-        assert mlbf.not_blocked_items == list(MLBF.hash_filter_inputs(
-            [
-                (addon.guid, addon.current_version.version),
-            ]
-        ))
+        assert mlbf.not_blocked_items == list(
+            MLBF.hash_filter_inputs(
+                [
+                    (addon.guid, addon.current_version.version),
+                ]
+            )
+        )
         mlbf.generate_and_write_filter()
 
     def test_generate_filter_not_raises_if_all_versions_blocked(self):
@@ -486,11 +489,13 @@ class TestMLBF(TestCase):
         mlbf = MLBF.generate_from_db('test')
 
         assert mlbf.not_blocked_items == []
-        assert mlbf.blocked_items == list(MLBF.hash_filter_inputs(
-            [
-                (addon.guid, addon.current_version.version),
-            ]
-        ))
+        assert mlbf.blocked_items == list(
+            MLBF.hash_filter_inputs(
+                [
+                    (addon.guid, addon.current_version.version),
+                ]
+            )
+        )
         mlbf.generate_and_write_filter()
 
     @override_settings(MLBF_STORAGE_PATH='test_storage_path')

--- a/src/olympia/blocklist/tests/test_mlbf.py
+++ b/src/olympia/blocklist/tests/test_mlbf.py
@@ -1,6 +1,12 @@
 import json
-from functools import cached_property
+import os
+import tempfile
+from unittest import mock
 
+from filtercascade import FilterCascade
+
+from olympia import amo
+from olympia.addons.models import GUID_REUSE_FORMAT
 from olympia.amo.tests import (
     TestCase,
     addon_factory,
@@ -8,390 +14,434 @@ from olympia.amo.tests import (
     user_factory,
     version_factory,
 )
-from olympia.amo.utils import SafeStorage
-from olympia.blocklist.models import BlockVersion
+from olympia.files.models import File
 
 from ..mlbf import (
     MLBF,
-    BaseMLBFLoader,
-    MLBFDataBaseLoader,
-    MLBFDataType,
-    MLBFStorageLoader,
+    fetch_all_versions_from_db,
+    fetch_blocked_from_db,
+    generate_mlbf,
 )
 
 
-class _MLBFBase(TestCase):
-    def setUp(self):
-        self.storage = SafeStorage()
-        self.cache_path = self.storage.path('mlbf_test.json')
-        self.user = user_factory()
-
-    def _blocked_addon(self, **kwargs):
-        addon = addon_factory(**kwargs)
-        block = block_factory(guid=addon.guid, updated_by=self.user)
-        return addon, block
-
-    def _version(self, addon, is_signed=True):
-        return version_factory(addon=addon, file_kw={'is_signed': is_signed})
-
-    def _block_version(self, block, version, soft=False):
-        return BlockVersion.objects.create(
-            block=block,
-            version=version,
-            soft=soft,
+class TestMLBF(TestCase):
+    def setup_data(self):
+        user = user_factory()
+        for _idx in range(0, 5):
+            addon_factory()
+        # one version, listed (twice)
+        block_factory(
+            addon=addon_factory(file_kw={'is_signed': True}),
+            updated_by=user,
+        )
+        block_factory(
+            addon=addon_factory(file_kw={'is_signed': True}),
+            updated_by=user,
+        )
+        # one version, unlisted
+        block_factory(
+            addon=addon_factory(
+                version_kw={'channel': amo.CHANNEL_UNLISTED},
+                file_kw={'is_signed': True},
+            ),
+            updated_by=user,
+        )
+        # five versions, but only two within block (123.40, 123.5)
+        five_ver_block_addon = addon_factory(
+            version_kw={'version': '123.40'},
+            file_kw={'is_signed': True},
+        )
+        self.five_ver_123_40 = five_ver_block_addon.current_version
+        self.five_ver_123_5 = version_factory(
+            addon=five_ver_block_addon,
+            version='123.5',
+            deleted=True,
+            file_kw={'is_signed': True},
+        )
+        self.five_ver_123_45_1 = version_factory(
+            addon=five_ver_block_addon,
+            version='123.45.1',
+            file_kw={'is_signed': True},
+        )
+        # these two would be included if they were signed
+        self.not_signed_version = version_factory(
+            addon=five_ver_block_addon,
+            version='123.5.1',
+            file_kw={'is_signed': False},
+        )
+        self.not_signed_version2 = version_factory(
+            addon=five_ver_block_addon,
+            version='123.5.2',
+            file_kw={'is_signed': False},
+        )
+        self.five_ver_block = block_factory(
+            addon=five_ver_block_addon,
+            updated_by=user,
+            version_ids=[
+                self.five_ver_123_40.id,
+                self.five_ver_123_5.id,
+                self.not_signed_version.id,
+                self.not_signed_version2.id,
+            ],
         )
 
-
-class TestBaseMLBFLoader(_MLBFBase):
-    class TestStaticLoader(BaseMLBFLoader):
-        @cached_property
-        def blocked_items(self):
-            return ['blocked:version']
-
-        @cached_property
-        def not_blocked_items(self):
-            return ['notblocked:version']
-
-    def test_missing_methods_raises(self):
-        with self.assertRaises(NotImplementedError):
-            _ = BaseMLBFLoader(self.storage, self.cache_path)._raw
-
-        class TestMissingNotBlocked(BaseMLBFLoader):
-            @cached_property
-            def blocked_items(self):
-                return []
-
-        with self.assertRaises(NotImplementedError):
-            _ = TestMissingNotBlocked(self.storage, self.cache_path).not_blocked_items
-
-        class TestMissingBlocked(BaseMLBFLoader):
-            @cached_property
-            def notblocked_items(self):
-                return []
-
-        with self.assertRaises(NotImplementedError):
-            _ = TestMissingBlocked(self.storage, self.cache_path).blocked_items
-
-    def test_raw_contains_correct_data(self):
-        loader = self.TestStaticLoader(self.storage, self.cache_path)
-        assert loader._raw == {
-            'blocked': ['blocked:version'],
-            'not_blocked': ['notblocked:version'],
-        }
-
-    def test_invalid_key_access_raises(self):
-        loader = self.TestStaticLoader(self.storage, self.cache_path)
-
-        with self.assertRaises(AttributeError):
-            loader['invalid']
-        with self.assertRaises(AttributeError):
-            loader[BlockVersion.BLOCK_TYPE_CHOICES.BLOCKED]
-
-    def test_valid_key_access_returns_expected_data(self):
-        loader = self.TestStaticLoader(self.storage, self.cache_path)
-        assert loader[MLBFDataType.BLOCKED] == ['blocked:version']
-        assert loader[MLBFDataType.NOT_BLOCKED] == ['notblocked:version']
-
-    def test_cache_raw_data(self):
-        loader = self.TestStaticLoader(self.storage, self.cache_path)
-
-        for data_type in MLBFDataType:
-            assert loader[data_type] == loader._raw[data_type.value]
-
-        # The source of truth should ultimately be the named cached properties
-        # Even though _raw is cached, it should still return
-        # the reference to the named property
-        loader.blocked_items = []
-        assert loader[MLBFDataType.BLOCKED] == []
-
-
-class TestMLBFStorageLoader(_MLBFBase):
-    def setUp(self):
-        super().setUp()
-        self._data = {
-            'blocked': ['blocked:version'],
-            'not_blocked': ['notblocked:version'],
-        }
-
-    def test_raises_missing_file(self):
-        with self.assertRaises(FileNotFoundError):
-            _ = MLBFStorageLoader(self.storage, self.cache_path)._raw
-
-    def test_loads_data_from_file(self):
-        with self.storage.open(self.cache_path, 'w') as f:
-            json.dump(self._data, f)
-
-        loader = MLBFStorageLoader(self.storage, self.cache_path)
-        assert loader._raw == self._data
-
-
-class TestMLBFDataBaseLoader(_MLBFBase):
-    def test_load_returns_expected_data(self):
-        """
-        Test that the class returns a dictionary mapping the
-        expected TestMLBFDataBaseLoader keys to the blocked and notblocked item lists.
-        """
-        addon, block = self._blocked_addon()
-
-        notblocked_version = addon.current_version
-        block_version = self._block_version(block, self._version(addon), soft=False)
-
-        mlbf_data = MLBFDataBaseLoader(self.storage, self.cache_path)
-        assert mlbf_data[MLBFDataType.BLOCKED] == MLBF.hash_filter_inputs(
-            [(block_version.block.guid, block_version.version.version)]
+        # no matching versions (edge cases)
+        self.no_versions = block_factory(
+            addon=addon_factory(
+                version_kw={'version': '0.1'},
+                file_kw={'is_signed': True},
+            ),
+            updated_by=user,
+            version_ids=[],
         )
-        assert mlbf_data[MLBFDataType.NOT_BLOCKED] == MLBF.hash_filter_inputs(
-            [(notblocked_version.addon.guid, notblocked_version.version)]
+        self.no_versions2 = block_factory(
+            addon=addon_factory(
+                version_kw={'version': '0.1'},
+                file_kw={'is_signed': True},
+            ),
+            updated_by=user,
+            version_ids=[],
         )
 
-    def test_blocked_items_caches_excluded_version_ids(self):
-        """
-        Test that accessing the blocked_items property caches the version IDs
-        to exclude in the notblocked_items property.
-        """
-        addon, block = self._blocked_addon()
-        block_version = self._block_version(block, self._version(addon), soft=False)
+        # A blocked addon has been uploaded and deleted before
+        reused_2_1_addon = addon_factory(
+            # this a previous, superceeded, addon that should be included
+            status=amo.STATUS_DELETED,  # they should all be deleted
+            version_kw={'version': '2.1'},
+            file_kw={'is_signed': True},
+        )
+        self.addon_deleted_before_2_1_ver = reused_2_1_addon.versions.all()[0]
+        reused_2_5_addon = addon_factory(
+            # And this is an earlier addon that should also be included
+            status=amo.STATUS_DELETED,  # they should all be deleted
+            version_kw={'version': '2.5'},
+            file_kw={'is_signed': True},
+        )
+        self.addon_deleted_before_2_5_ver = reused_2_5_addon.versions.all()[0]
+        current_addon = addon_factory(
+            version_kw={'version': '2'},
+            file_kw={'is_signed': True},
+        )
+        self.addon_deleted_before_unblocked_ver = current_addon.current_version
+        self.addon_deleted_before_unsigned_ver = version_factory(
+            addon=current_addon,
+            version='2.1',
+            # not signed, but shouldn't override the signed 2.1 version
+            file_kw={'is_signed': False},
+        )
+        self.addon_deleted_before_3_0_ver = version_factory(
+            addon=current_addon,
+            version='3.0',
+            file_kw={'is_signed': True},
+        )
+        reused_2_1_addon.update(guid=GUID_REUSE_FORMAT.format(current_addon.id))
+        reused_2_5_addon.update(guid=GUID_REUSE_FORMAT.format(reused_2_1_addon.id))
+        reused_2_1_addon.addonguid.update(guid=current_addon.guid)
+        reused_2_5_addon.addonguid.update(guid=current_addon.guid)
+        self.addon_deleted_before_block = block_factory(
+            guid=current_addon.guid,
+            updated_by=user,
+            version_ids=[
+                self.addon_deleted_before_2_1_ver.id,
+                self.addon_deleted_before_2_5_ver.id,
+                self.addon_deleted_before_unsigned_ver.id,
+                self.addon_deleted_before_3_0_ver.id,
+            ],
+        )
+
+    def test_fetch_all_versions_from_db(self):
+        self.setup_data()
+        with self.assertNumQueries(1):
+            all_versions = fetch_all_versions_from_db()
+        assert len(all_versions) == File.objects.count() == 5 + 10 + 5
+        assert (self.five_ver_block.guid, '123.40') in all_versions
+        assert (self.five_ver_block.guid, '123.5') in all_versions
+        assert (self.five_ver_block.guid, '123.45.1') in all_versions
+        assert (self.five_ver_block.guid, '123.5.1') in all_versions
+        assert (self.five_ver_block.guid, '123.5.2') in all_versions
+        no_versions_tuple = (
+            self.no_versions.guid,
+            self.no_versions.addon.current_version.version,
+        )
+        assert no_versions_tuple in all_versions
+        no_versions2_tuple = (
+            self.no_versions2.guid,
+            self.no_versions2.addon.current_version.version,
+        )
+        assert no_versions2_tuple in all_versions
+
+        assert (self.addon_deleted_before_block.guid, '2') in all_versions
+        # this is fine; test_hash_filter_inputs removes duplicates.
+        assert all_versions.count((self.addon_deleted_before_block.guid, '2.1')) == 2
+        assert (self.addon_deleted_before_block.guid, '2.5') in all_versions
+        assert (self.addon_deleted_before_block.guid, '3.0') in all_versions
+
+        # repeat, but with excluded version ids
+        excludes = [self.five_ver_123_40.id, self.five_ver_123_5.id]
+        all_versions = fetch_all_versions_from_db(excludes)
+        assert len(all_versions) == 18
+        assert (self.five_ver_block.guid, '123.40') not in all_versions
+        assert (self.five_ver_block.guid, '123.5') not in all_versions
+        assert (self.five_ver_block.guid, '123.45.1') in all_versions
+        assert (self.five_ver_block.guid, '123.5.1') in all_versions
+        assert (self.five_ver_block.guid, '123.5.2') in all_versions
+        no_versions_tuple = (
+            self.no_versions.guid,
+            self.no_versions.addon.current_version.version,
+        )
+        assert no_versions_tuple in all_versions
+        no_versions2_tuple = (
+            self.no_versions2.guid,
+            self.no_versions2.addon.current_version.version,
+        )
+        assert no_versions2_tuple in all_versions
+
+    def test_fetch_blocked_from_db(self):
+        self.setup_data()
+        with self.assertNumQueries(1):
+            blocked_versions = fetch_blocked_from_db()
+
+        # check the values - the tuples used to generate the mlbf
+        blocked_guids = blocked_versions.values()
+        assert len(blocked_guids) == 8, blocked_guids
+        assert (self.five_ver_block.guid, '123.40') in blocked_guids
+        assert (self.five_ver_block.guid, '123.5') in blocked_guids
+        assert (self.five_ver_block.guid, '123.45.1') not in blocked_guids
+        assert (self.five_ver_block.guid, '123.5.1') not in blocked_guids
+        assert (self.five_ver_block.guid, '123.5.2') not in blocked_guids
+        no_versions_tuple = (
+            self.no_versions.guid,
+            self.no_versions.addon.current_version.version,
+        )
+        assert no_versions_tuple not in blocked_guids
+        no_versions2_tuple = (
+            self.no_versions2.guid,
+            self.no_versions2.addon.current_version.version,
+        )
+        assert no_versions2_tuple not in blocked_guids
+        assert (self.addon_deleted_before_block.guid, '2.1') in blocked_guids
+        assert (self.addon_deleted_before_block.guid, '2.5') in blocked_guids
+        assert (self.addon_deleted_before_block.guid, '3.0') in blocked_guids
+        assert (self.addon_deleted_before_block.guid, '2.0') not in blocked_guids
+
+        # And check the keys, the ids used to filter out the versions
+        assert self.five_ver_123_40.id in blocked_versions
+        assert self.five_ver_123_5.id in blocked_versions
+        assert self.five_ver_123_45_1.id not in blocked_versions
+        assert self.not_signed_version.id not in blocked_versions
+        assert self.not_signed_version2.id not in blocked_versions
+        assert self.no_versions.addon.current_version.id not in blocked_versions
+        assert self.no_versions2.addon.current_version.id not in blocked_versions
+
+        assert self.addon_deleted_before_unblocked_ver.id not in (blocked_versions)
+        assert self.addon_deleted_before_unsigned_ver.id not in (blocked_versions)
+        assert self.addon_deleted_before_block.addon.current_version.id in (
+            blocked_versions
+        )
+        assert self.addon_deleted_before_2_1_ver.id in (blocked_versions)
+        assert self.addon_deleted_before_2_5_ver.id in (blocked_versions)
+
+        # doublecheck if the versions were signed & webextensions they'd be in.
+        self.not_signed_version.file.update(is_signed=True)
+        self.not_signed_version2.file.update(is_signed=True)
+        assert len(fetch_blocked_from_db()) == 10
+
+    def test_hash_filter_inputs(self):
+        data = [
+            ('guid@', '1.0'),
+            ('foo@baa', '999.223a'),
+        ]
+        assert sorted(MLBF.hash_filter_inputs(data)) == [
+            'foo@baa:999.223a',
+            'guid@:1.0',
+        ]
+        # check dupes are stripped out too
+        data.append(('guid@', '1.0'))
+        assert sorted(MLBF.hash_filter_inputs(data)) == [
+            'foo@baa:999.223a',
+            'guid@:1.0',
+        ]
+
+    def test_generate_mlbf(self):
+        stats = {}
+        key_format = MLBF.KEY_FORMAT
+        blocked = [
+            ('guid1@', '1.0'),
+            ('@guid2', '1.0'),
+            ('@guid2', '1.1'),
+            ('guid3@', '0.01b1'),
+            # throw in a dupe at the end - should be removed along the way
+            ('guid3@', '0.01b1'),
+        ]
+        not_blocked = [
+            ('guid10@', '1.0'),
+            ('@guid20', '1.0'),
+            ('@guid20', '1.1'),
+            ('guid30@', '0.01b1'),
+            ('guid100@', '1.0'),
+            ('@guid200', '1.0'),
+            ('@guid200', '1.1'),
+            ('guid300@', '0.01b1'),
+        ]
+        bfilter = generate_mlbf(
+            stats,
+            blocked=MLBF.hash_filter_inputs(blocked),
+            not_blocked=MLBF.hash_filter_inputs(not_blocked),
+        )
+        for entry in blocked:
+            key = key_format.format(guid=entry[0], version=entry[1])
+            assert key in bfilter
+        for entry in not_blocked:
+            key = key_format.format(guid=entry[0], version=entry[1])
+            assert key not in bfilter
+        assert stats['mlbf_version'] == 2
+        assert stats['mlbf_layers'] == 1
+        assert stats['mlbf_bits'] == 2160
+        with tempfile.NamedTemporaryFile() as out:
+            bfilter.tofile(out)
+            assert os.stat(out.name).st_size == 300
+
+    def test_generate_mlbf_with_more_blocked_than_not_blocked(self):
+        key_format = MLBF.KEY_FORMAT
+        blocked = [('guid1@', '1.0'), ('@guid2', '1.0')]
+        not_blocked = [('guid10@', '1.0')]
+        bfilter = generate_mlbf(
+            {},
+            blocked=MLBF.hash_filter_inputs(blocked),
+            not_blocked=MLBF.hash_filter_inputs(not_blocked),
+        )
+        for entry in blocked:
+            key = key_format.format(guid=entry[0], version=entry[1])
+            assert key in bfilter
+        for entry in not_blocked:
+            key = key_format.format(guid=entry[0], version=entry[1])
+            assert key not in bfilter
+
+    def test_generate_and_write_filter(self):
+        self.setup_data()
         with self.assertNumQueries(2):
-            mlbf_data = MLBFDataBaseLoader(self.storage, self.cache_path)
-        assert mlbf_data._version_excludes == [block_version.version.id]
+            mlbf = MLBF.generate_from_db(123456)
+            mlbf.generate_and_write_filter()
 
-    def test_hash_filter_inputs_returns_set_of_hashed_strings(self):
-        """
-        Test that the hash_filter_inputs class method returns a set of
-        hashed guid:version strings given an input list of (guid, version)
-        tuples.
-        """
-        default = MLBF.hash_filter_inputs(
-            [
-                ('guid', 'version'),
-            ]
+        with open(mlbf.filter_path, 'rb') as filter_file:
+            buffer = filter_file.read()
+            bfilter = FilterCascade.from_buf(buffer)
+
+        blocked_versions = fetch_blocked_from_db()
+        blocked_guids = blocked_versions.values()
+        for guid, version_str in blocked_guids:
+            key = MLBF.KEY_FORMAT.format(guid=guid, version=version_str)
+            assert key in bfilter
+
+        all_addons = fetch_all_versions_from_db(blocked_versions.keys())
+        for guid, version_str in all_addons:
+            # edge case where a version_str exists in both
+            if (guid, version_str) in blocked_guids:
+                continue
+            key = MLBF.KEY_FORMAT.format(guid=guid, version=version_str)
+            assert key not in bfilter
+
+        # Occasionally a combination of salt generated with secrets.token_bytes
+        # and the version str generated in version_factory results in a
+        # collision in layer 1 of the bloomfilter, leading to a second layer
+        # being generated.  When this happens the bitCount and size is larger.
+        expected_size, expected_bit_count = (
+            (203, 1384) if bfilter.layerCount() == 1 else (393, 2824)
         )
-        assert default == ['guid:version']
+        assert os.stat(mlbf.filter_path).st_size == expected_size, (
+            blocked_guids,
+            all_addons,
+        )
+        assert bfilter.bitCount() == expected_bit_count, (blocked_guids, all_addons)
 
+    def test_generate_diffs(self):
+        old_versions = [
+            ('guid1@', '1.0'),
+            ('@guid2', '1.0'),
+            ('@guid2', '1.1'),
+            ('guid3@', '0.01b1'),
+        ]
+        new_versions = [
+            ('guid1@', '1.0'),
+            ('guid3@', '0.01b1'),
+            ('@guid2', '1.1'),
+            ('new_guid@', '0.01b1'),
+            ('new_guid@', '24'),
+        ]
+        extras, deletes = MLBF.generate_diffs(old_versions, new_versions)
+        assert extras == {('new_guid@', '0.01b1'), ('new_guid@', '24')}
+        assert deletes == {('@guid2', '1.0')}
 
-class TestMLBF(_MLBFBase):
-    def test_get_data_from_db(self):
-        self._blocked_addon()
-        mlbf = MLBF.generate_from_db('test')
-        assert isinstance(mlbf.data, MLBFDataBaseLoader)
-        mlbf_data = MLBFDataBaseLoader(mlbf.storage, mlbf.cache_path)
-        assert mlbf.data._raw == mlbf_data._raw
+    def test_write_stash(self):
+        self.setup_data()
+        old_mlbf = MLBF.generate_from_db('old')
+        old_mlbf.generate_and_write_filter()
+        new_mlbf = MLBF.generate_from_db('new_no_change')
+        new_mlbf.generate_and_write_filter()
+        new_mlbf.generate_and_write_stash(old_mlbf)
+        empty_stash = {'blocked': [], 'unblocked': []}
+        with open(new_mlbf.stash_path) as stash_file:
+            assert json.load(stash_file) == empty_stash
+        # add a new Block and delete one
+        block_factory(
+            addon=addon_factory(
+                guid='fooo@baaaa',
+                version_kw={'version': '999'},
+                file_kw={'is_signed': True},
+            ),
+            updated_by=user_factory(),
+        )
+        self.five_ver_123_5.delete(hard=True)
+        newer_mlbf = MLBF.generate_from_db('new_one_change')
+        newer_mlbf.generate_and_write_filter()
+        newer_mlbf.generate_and_write_stash(new_mlbf)
+        full_stash = {
+            'blocked': ['fooo@baaaa:999'],
+            'unblocked': [f'{self.five_ver_block.guid}:123.5'],
+        }
+        with open(newer_mlbf.stash_path) as stash_file:
+            assert json.load(stash_file) == full_stash
 
-    def test_get_data_from_storage(self):
-        self._blocked_addon()
-        mlbf = MLBF.generate_from_db('test')
-        cached_mlbf = MLBF.load_from_storage('test')
-        assert isinstance(cached_mlbf.data, MLBFStorageLoader)
-        assert mlbf.data._raw == cached_mlbf.data._raw
-
-    def test_diff_returns_stateless_without_previous(self):
-        """
-        Starting with an initially blocked addon, diff after removing the block
-        depends on whether a previous mlbf is provided and if that previous mlbf
-        has the unblocked addon already
-        """
-        addon, _ = self._blocked_addon()
+    def test_should_reset_base_filter_and_blocks_changed_since_previous(self):
+        self.setup_data()
         base_mlbf = MLBF.generate_from_db('base')
+        # should handle the files not existing
+        assert base_mlbf.should_reset_base_filter(MLBF.load_from_storage('no_files'))
+        assert base_mlbf.blocks_changed_since_previous(
+            MLBF.load_from_storage('no_files')
+        )
+        base_mlbf.generate_and_write_filter()
 
-        assert base_mlbf.generate_diffs(data_type=MLBFDataType.NOT_BLOCKED) == (
-            set(
-                MLBF.hash_filter_inputs(
-                    [(addon.block.guid, addon.current_version.version)]
-                )
+        no_change_mlbf = MLBF.generate_from_db('no_change')
+        no_change_mlbf.generate_and_write_filter()
+        assert not no_change_mlbf.should_reset_base_filter(base_mlbf)
+        assert not no_change_mlbf.blocks_changed_since_previous(base_mlbf)
+
+        # make some changes
+        block_factory(
+            addon=addon_factory(
+                guid='fooo@baaaa',
+                version_kw={'version': '999'},
+                file_kw={'is_signed': True},
             ),
-            set(),
-            1,
+            updated_by=user_factory(),
         )
-
-        next_mlbf = MLBF.generate_from_db('next')
-        # If we don't include the base_mlbf, unblocked version will still be in the diff
-        assert next_mlbf.generate_diffs(data_type=MLBFDataType.NOT_BLOCKED) == (
-            set(
-                MLBF.hash_filter_inputs(
-                    [(addon.block.guid, addon.current_version.version)]
-                )
-            ),
-            set(),
-            1,
+        self.five_ver_123_5.delete(hard=True)
+        small_change_mlbf = MLBF.generate_from_db('small_change')
+        small_change_mlbf.generate_and_write_filter()
+        # but the changes were small (less than threshold) so no need for new
+        # base filter
+        assert not small_change_mlbf.should_reset_base_filter(base_mlbf)
+        # there _were_ changes though
+        assert small_change_mlbf.blocks_changed_since_previous(base_mlbf)
+        # double check what the differences were
+        diffs = MLBF.generate_diffs(
+            previous=base_mlbf.blocked_items, current=small_change_mlbf.blocked_items
         )
-        # Providing a previous mlbf with the unblocked version already included
-        # removes it from the diff
-        assert next_mlbf.generate_diffs(
-            data_type=MLBFDataType.NOT_BLOCKED, previous_mlbf=base_mlbf
-        ) == (set(), set(), 0)
+        assert diffs == ({'fooo@baaaa:999'}, {f'{self.five_ver_block.guid}:123.5'})
 
-    def test_diff_no_changes(self):
-        addon, block = self._blocked_addon()
-        self._block_version(block, self._version(addon), soft=False)
-        base_mlbf = MLBF.generate_from_db('test')
-        next_mlbf = MLBF.generate_from_db('test_two')
-
-        assert next_mlbf.generate_diffs(
-            data_type=MLBFDataType.BLOCKED, previous_mlbf=base_mlbf
-        ) == (set(), set(), 0)
-        assert next_mlbf.generate_diffs(
-            data_type=MLBFDataType.NOT_BLOCKED, previous_mlbf=base_mlbf
-        ) == (set(), set(), 0)
-
-    def test_diff_block_added(self):
-        addon, block = self._blocked_addon()
-        base_mlbf = MLBF.generate_from_db('test')
-
-        new_block = self._block_version(block, self._version(addon), soft=False)
-
-        next_mlbf = MLBF.generate_from_db('test_two')
-
-        assert next_mlbf.generate_diffs(
-            previous_mlbf=base_mlbf, data_type=MLBFDataType.BLOCKED
-        ) == (
-            set(
-                MLBF.hash_filter_inputs(
-                    [(new_block.block.guid, new_block.version.version)]
-                )
-            ),
-            set(),
-            1,
-        )
-        assert next_mlbf.generate_diffs(
-            previous_mlbf=base_mlbf, data_type=MLBFDataType.NOT_BLOCKED
-        ) == (set(), set(), 0)
-
-    def test_diff_block_removed(self):
-        addon, block = self._blocked_addon()
-        block_version = self._block_version(block, self._version(addon), soft=False)
-        base_mlbf = MLBF.generate_from_db('test')
-        block_version.delete()
-        next_mlbf = MLBF.generate_from_db('test_two')
-
-        assert next_mlbf.generate_diffs(
-            data_type=MLBFDataType.BLOCKED, previous_mlbf=base_mlbf
-        ) == (
-            set(),
-            set(
-                MLBF.hash_filter_inputs(
-                    [(block_version.block.guid, block_version.version.version)]
-                )
-            ),
-            1,
-        )
-        assert next_mlbf.generate_diffs(
-            data_type=MLBFDataType.NOT_BLOCKED, previous_mlbf=base_mlbf
-        ) == (
-            set(
-                MLBF.hash_filter_inputs(
-                    [(block_version.block.guid, block_version.version.version)]
-                )
-            ),
-            set(),
-            1,
-        )
-
-    def test_diff_block_added_and_removed(self):
-        addon, block = self._blocked_addon()
-        block_version = self._block_version(block, self._version(addon), soft=False)
-        base_mlbf = MLBF.generate_from_db('test')
-
-        new_block = self._block_version(block, self._version(addon), soft=False)
-        block_version.delete()
-
-        next_mlbf = MLBF.generate_from_db('test_two')
-
-        assert next_mlbf.generate_diffs(
-            data_type=MLBFDataType.BLOCKED, previous_mlbf=base_mlbf
-        ) == (
-            set(
-                MLBF.hash_filter_inputs(
-                    [(new_block.block.guid, new_block.version.version)]
-                )
-            ),
-            set(
-                MLBF.hash_filter_inputs(
-                    [(block_version.block.guid, block_version.version.version)]
-                )
-            ),
-            2,
-        )
-
-        assert next_mlbf.generate_diffs(
-            data_type=MLBFDataType.NOT_BLOCKED, previous_mlbf=base_mlbf
-        ) == (
-            set(
-                MLBF.hash_filter_inputs(
-                    [(block_version.block.guid, block_version.version.version)]
-                )
-            ),
-            set(),
-            1,
-        )
-
-    def test_generate_stash_returns_expected_stash(self):
-        addon, block = self._blocked_addon()
-        block_version = self._block_version(block, self._version(addon), soft=False)
-        mlbf = MLBF.generate_from_db('test')
-        mlbf.generate_and_write_stash(MLBFDataType.BLOCKED)
-
-        with mlbf.storage.open(mlbf.stash_path(MLBFDataType.BLOCKED), 'r') as f:
-            assert json.load(f) == {
-                'blocked': MLBF.hash_filter_inputs(
-                    [(block_version.block.guid, block_version.version.version)]
-                ),
-                'unblocked': [],
-            }
-        block_version.delete()
-
-        next_mlbf = MLBF.generate_from_db('test_two')
-        next_mlbf.generate_and_write_stash(
-            data_type=MLBFDataType.BLOCKED, previous_mlbf=mlbf
-        )
-        with next_mlbf.storage.open(
-            next_mlbf.stash_path(MLBFDataType.BLOCKED), 'r'
-        ) as f:
-            assert json.load(f) == {
-                'blocked': [],
-                'unblocked': MLBF.hash_filter_inputs(
-                    [(block_version.block.guid, block_version.version.version)]
-                ),
-            }
-
-    def test_changed_count_returns_expected_count(self):
-        addon, block = self._blocked_addon()
-        self._block_version(block, self._version(addon), soft=False)
-        first_mlbf = MLBF.generate_from_db('first')
-        # Include the new blocked version
-        assert first_mlbf.blocks_changed_since_previous(MLBFDataType.BLOCKED) == 1
-        self._block_version(block, self._version(addon), soft=False)
-        # The count should not change because the data is already calculated
-        assert first_mlbf.blocks_changed_since_previous(MLBFDataType.BLOCKED) == 1
-        next_mlbf = MLBF.generate_from_db('next')
-        # The count should include both blocked versions since we are not comparing
-        assert next_mlbf.blocks_changed_since_previous(MLBFDataType.BLOCKED) == 2
-        # When comparing to the first mlbf,
-        # the count should only include the second block
-        assert (
-            next_mlbf.blocks_changed_since_previous(
-                MLBFDataType.BLOCKED, previous_mlbf=first_mlbf
-            )
-            == 1
-        )
-
-    def test_generate_filter_not_raises_if_all_versions_unblocked(self):
-        """
-        When we create a bloom filter where all versions fall into
-        the "not filtered" category This can create invalid error rates
-        because the error rate depends on these numbers being non-zero.
-        """
-        mlbf = MLBF.generate_from_db('test')
-        self._blocked_addon(file_kw={'is_signed': True})
-        assert mlbf.data.blocked_items == []
-        mlbf.generate_and_write_filter(MLBFDataType.BLOCKED)
-
-    def test_generate_filter_not_raises_if_all_versions_blocked(self):
-        """
-        When we create a bloom filter where all versions fall into
-        the "not filtered" category This can create invalid error rates
-        because the error rate depends on these numbers being non-zero.
-        """
-        mlbf = MLBF.generate_from_db('test')
-        self._blocked_addon(file_kw={'is_signed': False})
-        assert mlbf.data.not_blocked_items == []
-        mlbf.generate_and_write_filter(MLBFDataType.BLOCKED)
+        # so lower the threshold
+        to_patch = 'olympia.blocklist.mlbf.BASE_REPLACE_THRESHOLD'
+        with mock.patch(to_patch, 1):
+            assert small_change_mlbf.should_reset_base_filter(base_mlbf)
+            assert small_change_mlbf.blocks_changed_since_previous(base_mlbf)

--- a/src/olympia/blocklist/tests/test_tasks.py
+++ b/src/olympia/blocklist/tests/test_tasks.py
@@ -1,16 +1,31 @@
+import json
 import os
 from datetime import datetime, timedelta
-from unittest import mock
+from unittest import TestCase, mock
 
 from django.conf import settings
 from django.contrib.admin.models import LogEntry
 from django.core.exceptions import SuspiciousOperation
 from django.test.testcases import TransactionTestCase
 
-from olympia.amo.tests import addon_factory, user_factory
+import pytest
 
-from ..models import BlocklistSubmission
-from ..tasks import cleanup_old_files, process_blocklistsubmission
+from olympia.amo.tests import (
+    addon_factory,
+    block_factory,
+    user_factory,
+    version_factory,
+)
+from olympia.blocklist.mlbf import MLBF
+from olympia.constants.blocklist import MLBF_BASE_ID_CONFIG_KEY, MLBF_TIME_CONFIG_KEY
+
+from ..models import BlocklistSubmission, BlockVersion
+from ..tasks import (
+    BLOCKLIST_RECORD_MLBF_BASE,
+    cleanup_old_files,
+    process_blocklistsubmission,
+    upload_filter,
+)
 from ..utils import datetime_to_ts
 
 
@@ -78,3 +93,116 @@ class TestProcessBlocklistSubmission(TransactionTestCase):
         log_entry = LogEntry.objects.get()
         assert log_entry.user.id == settings.TASK_USER_ID
         assert log_entry.change_message == 'Exception in task: Something happened!'
+
+
+@pytest.mark.django_db
+class TestUploadMLBFToRemoteSettings(TestCase):
+    def setUp(self):
+        self.user = user_factory()
+        self.addon = addon_factory()
+        self.block = block_factory(guid=self.addon.guid, updated_by=self.user)
+
+        prefix = 'olympia.blocklist.tasks.'
+        self.mocks = {
+            'delete_all_records': f'{prefix}RemoteSettings.delete_all_records',
+            'publish_attachment': f'{prefix}RemoteSettings.publish_attachment',
+            'publish_record': f'{prefix}RemoteSettings.publish_record',
+            'complete_session': f'{prefix}RemoteSettings.complete_session',
+            'set_config': f'{prefix}set_config',
+            'statsd.incr': f'{prefix}statsd.incr',
+        }
+        for mock_name, mock_path in self.mocks.items():
+            patcher = mock.patch(mock_path)
+            self.addCleanup(patcher.stop)
+            self.mocks[mock_name] = patcher.start()
+
+        self.generation_time = datetime_to_ts(datetime.now())
+
+    def _block_version(self, block=None, version=None, soft=False, is_signed=True):
+        block = block or self.block
+        version = version or version_factory(
+            addon=self.addon, file_kw={'is_signed': is_signed}
+        )
+        return BlockVersion.objects.create(block=block, version=version, soft=soft)
+
+    def test_upload_base_filter(self):
+        self._block_version(is_signed=True)
+        mlbf = MLBF.generate_from_db(self.generation_time)
+        mlbf.generate_and_write_filter()
+
+        upload_filter.delay(self.generation_time, is_base=True)
+
+        assert self.mocks['delete_all_records'].called
+        with mlbf.storage.open(mlbf.filter_path, 'rb') as filter_file:
+            actual_data, actual_attchment = self.mocks[
+                'publish_attachment'
+            ].call_args_list[0][0]
+
+            assert actual_data == {
+                'key_format': MLBF.KEY_FORMAT,
+                'generation_time': self.generation_time,
+                'attachment_type': BLOCKLIST_RECORD_MLBF_BASE,
+            }
+            name, file, content_type = actual_attchment
+            assert name == 'filter.bin'
+            assert file.name == filter_file.name
+            assert content_type == 'application/octet-stream'
+
+        assert self.mocks['statsd.incr'].call_args_list == [
+            mock.call('blocklist.tasks.upload_filter.reset_collection'),
+            mock.call('blocklist.tasks.upload_filter.upload_mlbf.base'),
+            mock.call('blocklist.tasks.upload_filter.upload_mlbf'),
+        ]
+
+        assert self.mocks['complete_session'].called
+        assert self.mocks['set_config'].call_args_list == [
+            mock.call(MLBF_TIME_CONFIG_KEY, self.generation_time, json_value=True),
+            mock.call(MLBF_BASE_ID_CONFIG_KEY, self.generation_time, json_value=True),
+        ]
+
+    def test_upload_stashed_filter(self):
+        old_mlbf = MLBF.generate_from_db(self.generation_time - 1)
+        blocked_version = self._block_version(is_signed=True)
+        mlbf = MLBF.generate_from_db(self.generation_time)
+        mlbf.generate_and_write_stash(old_mlbf)
+
+        upload_filter.delay(self.generation_time, is_base=False)
+
+        assert not self.mocks['delete_all_records'].called
+        with mlbf.storage.open(mlbf.stash_path, 'rb') as stash_file:
+            actual_stash = self.mocks['publish_record'].call_args_list[0][0][0]
+            stash_data = json.load(stash_file)
+
+            assert actual_stash == {
+                'key_format': MLBF.KEY_FORMAT,
+                'stash_time': self.generation_time,
+                'stash': stash_data,
+            }
+
+            assert actual_stash['stash']['blocked'] == list(
+                MLBF.hash_filter_inputs(
+                    [(blocked_version.block.guid, blocked_version.version.version)]
+                )
+            )
+
+        assert self.mocks['statsd.incr'].call_args_list == [
+            mock.call('blocklist.tasks.upload_filter.upload_stash'),
+        ]
+
+        assert self.mocks['complete_session'].called
+        assert self.mocks['set_config'].call_args_list == [
+            mock.call(MLBF_TIME_CONFIG_KEY, self.generation_time, json_value=True),
+        ]
+
+    def test_raises_when_no_filter_exists(self):
+        with self.assertRaises(FileNotFoundError):
+            upload_filter.delay(self.generation_time)
+
+    def test_raises_when_no_stash_exists(self):
+        with self.assertRaises(FileNotFoundError):
+            upload_filter.delay(self.generation_time, is_base=False)
+
+    def test_default_is_base_is_true(self):
+        MLBF.generate_from_db(self.generation_time).generate_and_write_filter()
+        upload_filter.delay(self.generation_time)
+        assert self.mocks['delete_all_records'].called

--- a/src/olympia/blocklist/tests/test_tasks.py
+++ b/src/olympia/blocklist/tests/test_tasks.py
@@ -148,11 +148,14 @@ class TestUploadMLBFToRemoteSettings(TestCase):
             assert file.name == filter_file.name
             assert content_type == 'application/octet-stream'
 
-        assert self.mocks['statsd.incr'].call_args_list == [
-            mock.call('blocklist.tasks.upload_filter.reset_collection'),
-            mock.call('blocklist.tasks.upload_filter.upload_mlbf.base'),
-            mock.call('blocklist.tasks.upload_filter.upload_mlbf'),
-        ]
+        assert all(
+            call in self.mocks['statsd.incr'].call_args_list
+            for call in [
+                mock.call('blocklist.tasks.upload_filter.reset_collection'),
+                mock.call('blocklist.tasks.upload_filter.upload_mlbf.base'),
+                mock.call('blocklist.tasks.upload_filter.upload_mlbf'),
+            ]
+        )
 
         assert self.mocks['complete_session'].called
         assert self.mocks['set_config'].call_args_list == [
@@ -185,14 +188,16 @@ class TestUploadMLBFToRemoteSettings(TestCase):
                 )
             )
 
-        assert self.mocks['statsd.incr'].call_args_list == [
-            mock.call('blocklist.tasks.upload_filter.upload_stash'),
-        ]
+        assert (
+            mock.call('blocklist.tasks.upload_filter.upload_stash')
+            in self.mocks['statsd.incr'].call_args_list
+        )
 
         assert self.mocks['complete_session'].called
-        assert self.mocks['set_config'].call_args_list == [
-            mock.call(MLBF_TIME_CONFIG_KEY, self.generation_time, json_value=True),
-        ]
+        assert (
+            mock.call(MLBF_TIME_CONFIG_KEY, self.generation_time, json_value=True)
+            in self.mocks['set_config'].call_args_list
+        )
 
     def test_raises_when_no_filter_exists(self):
         with self.assertRaises(FileNotFoundError):


### PR DESCRIPTION
Relates to: https://github.com/mozilla/addons/issues/15014

### Description

- Refactors the test_cron tests to match ([new code](https://github.com/mozilla/addons-server/pull/22718))) with minimal reverting to work with the existing code base (e.g existing MLBF/cron has no concept of a block_type)
- Refactors the existing code (minimally) to pass the new tests. The new tests were more aggressive and exposed a few edge cases that can be solved within the existing code base before adding the block_type functionality

### Context

This PR is an attempt to a) decouple https://github.com/mozilla/addons-server/pull/22718 by splitting the patch and b) ensure backwards compatibility with the existing codebase.

I would have ideally liked to change **literally** nothing ([first commit](https://github.com/mozilla/addons-server/pull/22738/commits/072bd011b1fe391b7a4b174405675a2a317f62b0)) but the tests, but as mentioned above, there are some bugs in the code that I've found through the new feature and it doesn't make sense to make the tests _not catch_ those bugs. Specifically:

- bloom filter fails if either `blocked` or `not_blocked` lists are empty. This is rare but found in testing and easy to cover by not adding error rates in those cases.
- the Store bloom filter does not check whether the stored files exist on initialization. This was techincally covered in the cron job, but should actually fail on initialization of the `MLBF` class as it is catastrophic
- the DataBase bloom filter does not store the json until you call either "write" stash or filter methods. This can lead to bugs where the data is queried by the class, but not stored, making it possible for subsequent Store filters to fail due to missing files. There is no reason not to store immediately. Additionally if you call both filter and stash methods, you would overwrite the files, which could lead to a filter with a given time stamp to have different data (especially since we can freely modify the underlying data store)
- remove the stash_json property and instead read the file where we need to (like we do with the filter) This guarantees the data comes from the stash file and not some arbitrary set of that property. Also fails if the file doesn't exist meaning we don't need to check in the cron job.

Small refactors that do not change underlying loogic:
- reverse the ordering of defining `base_filter` and `last_filter` (IMO this is just easier to reason about)
- encapsulate the timestamp getters to named methods (this is in fact mostly to make testing easier by mocking those methods)
- use existing `rel_location` and storage.path methods to derive paths instead of direct os.path methods
- rename self.id to self.created_at (that is what it is and it is important that we understand you should be able to do math with the value)

### Testing

Check the tests, this is the heart and soul of the PR. I've made the mocks for test_cron much more composable so it should be easier to understand what specific data is used in each test as well as what critical values cause the test to pass or fail.

You should be able to run the cron function or `./manage.py export_blocklist 1`

You should additionally be able to create and manipulate `MLBF` in the djshell.

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
