### PR TITLE
Dev-mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,11 @@ rm -rf /deps/build/*
 ${PIP_COMMAND} install --progress-bar=off --no-deps --exists-action=w -r requirements/pip.txt
 EOF
 
+# Expose the DOCKER_TARGET variable to all subsequent stages
+# This value is used to determine if we are building for production or development
+ARG DOCKER_TARGET
+ENV DOCKER_TARGET=${DOCKER_TARGET}
+
 # Define production dependencies as a single layer
 # let's the rest of the stages inherit prod dependencies
 # and makes copying the /deps dir to the final layer easy.

--- a/Makefile-docker
+++ b/Makefile-docker
@@ -28,7 +28,12 @@ check_debian_packages: ## check the existence of multiple debian packages
 
 .PHONY: check_pip_packages
 check_pip_packages: ## check the existence of multiple python packages
-	./scripts/check_pip_packages.sh prod.txt dev.txt
+	@ ./scripts/check_pip_packages.sh prod.txt
+# "production" corresponds to the "propduction" DOCKER_TARGET defined in the Dockerfile
+# When the target is "production" it means we cannot expect dev.txt dependencies to be installed.
+	@if [ "$(DOCKER_TARGET)" != "production" ]; then \
+		./scripts/check_pip_packages.sh dev.txt; \
+	fi
 
 .PHONY: check_files
 check_files: ## check the existence of multiple files

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -18,6 +18,7 @@ target "web" {
 	DOCKER_COMMIT = "${DOCKER_COMMIT}"
 	DOCKER_VERSION = "${DOCKER_VERSION}"
 	DOCKER_BUILD = "${DOCKER_BUILD}"
+  DOCKER_TARGET = "${DOCKER_TARGET}"
   }
   pull = true
 

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -2,20 +2,12 @@ services:
   worker:
     environment:
       - HOST_UID=9500
-      - DEBUG=
     volumes:
       - /data/olympia
 
   web:
     extends:
       service: worker
-    volumes:
-      - data_site_static:/data/olympia/site-static
-
-  nginx:
-    volumes:
-      - data_site_static:/srv/site-static
 
 volumes:
   data_olympia:
-  data_site_static:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ x-olympia: &olympia
   entrypoint: ["/data/olympia/docker/entrypoint.sh"]
 
 services:
-  worker: &worker
+  worker:
     <<: *olympia
     command: [
       "DJANGO_SETTINGS_MODULE=settings",
@@ -84,7 +84,8 @@ services:
       - autograph
 
   web:
-    <<: *worker
+    extends:
+      service: worker
     healthcheck:
       test: ["CMD-SHELL", "curl --fail --show-error --include --location http://127.0.0.1:8002/__version__"]
       retries: 3
@@ -98,7 +99,7 @@ services:
     image: nginx
     volumes:
       - ./docker/nginx/addons.conf:/etc/nginx/conf.d/addons.conf
-      - ./static:/srv/site-static
+      - ./static:/srv/static
       - storage:/srv/user-media
     ports:
       - "80:80"

--- a/docker/nginx/addons.conf
+++ b/docker/nginx/addons.conf
@@ -11,7 +11,7 @@ server {
     }
 
     location /static/ {
-         alias /srv/site-static/;
+         alias /srv/static/;
 
          # Fallback to the uwsgi server if the file is not found in the static files directory.
          # This will happen for vendor files from pytnon or npm dependencies that won't be available

--- a/docs/topics/development/troubleshooting_and_debugging.md
+++ b/docs/topics/development/troubleshooting_and_debugging.md
@@ -2,6 +2,22 @@
 
 Effective troubleshooting and debugging practices are essential for maintaining and improving the **addons-server** project. This section covers common issues, their solutions, and tools for effective debugging.
 
+## DEV_MODE vs DEBUG
+
+In our project, `DEV_MODE` and `DEBUG` serve distinct but complementary purposes.
+`DEV_MODE` is directly tied to the `DOCKER_TARGET` environment variable and is used to enable or disable behaviors
+based on whether we are running a production image or not.
+
+For instance, production images always disables certain features like using fake fxa authentication. Additionally,
+certain dependencies are only installed in [dev.txt](../../../requirements/dev.txt) and so must be disabled in production.
+
+Conversely, `DEBUG` controls the activation of debugging tools and utilities, such as the debug_toolbar,
+which are useful for troubleshooting. Unlike DEV_MODE, DEBUG is independent
+and can be toggled in both development and production environments as needed.
+
+This separation ensures that essential behaviors are managed according to the deployment target (DEV_MODE),
+while allowing flexibility to enable or disable debugging features (DEBUG) in production or development images.
+
 ## Common Issues and Solutions
 
 1. **Containers Not Starting**:

--- a/settings.py
+++ b/settings.py
@@ -12,6 +12,12 @@ from urllib.parse import urlparse
 from olympia.lib.settings_base import *  # noqa
 
 
+# "production" is a named docker stage corresponding to the production image.
+# when we build the production image, the stage to use is determined
+# via the "DOCKER_TARGET" variable which is also passed into the image.
+# So if the value is anything other than "production" we are in development mode.
+DEV_MODE = DOCKER_TARGET != 'production'
+
 WSGI_APPLICATION = 'olympia.wsgi.application'
 
 INTERNAL_ROUTES_ALLOWED = True

--- a/settings.py
+++ b/settings.py
@@ -16,11 +16,11 @@ WSGI_APPLICATION = 'olympia.wsgi.application'
 
 INTERNAL_ROUTES_ALLOWED = True
 
+# Always
+SERVE_STATIC_FILES = True
+
 # These apps are great during development.
-INSTALLED_APPS += (
-    'olympia.landfill',
-    'dbbackup',
-)
+INSTALLED_APPS += ('olympia.landfill',)
 
 DBBACKUP_STORAGE = 'django.core.files.storage.FileSystemStorage'
 
@@ -53,8 +53,11 @@ def insert_debug_toolbar_middleware(middlewares):
     return tuple(ret_middleware)
 
 
-if DEBUG:
-    INSTALLED_APPS += ('debug_toolbar',)
+if DEV_MODE:
+    INSTALLED_APPS += (
+        'debug_toolbar',
+        'dbbackup',
+    )
     MIDDLEWARE = insert_debug_toolbar_middleware(MIDDLEWARE)
 
 DEBUG_TOOLBAR_CONFIG = {
@@ -107,7 +110,7 @@ FXA_CONTENT_HOST = 'https://accounts.stage.mozaws.net'
 FXA_OAUTH_HOST = 'https://oauth.stage.mozaws.net/v1'
 FXA_PROFILE_HOST = 'https://profile.stage.mozaws.net/v1'
 
-# When USE_FAKE_FXA_AUTH and settings.DEBUG are both True, we serve a fake
+# When USE_FAKE_FXA_AUTH and settings.DEV_MODE are both True, we serve a fake
 # authentication page, bypassing FxA. To disable this behavior, set
 # USE_FAKE_FXA = False in your local settings.
 # You will also need to specify `client_id` and `client_secret` in your

--- a/settings_test.py
+++ b/settings_test.py
@@ -23,7 +23,7 @@ INTERNAL_ROUTES_ALLOWED = env('INTERNAL_ROUTES_ALLOWED', default=False)
 IN_TEST_SUITE = True
 
 DEBUG = False
-# We should default to production mode unless otherwiser specified
+# We should default to production mode unless otherwise specified
 DEV_MODE = False
 
 # We won't actually send an email.

--- a/settings_test.py
+++ b/settings_test.py
@@ -23,6 +23,8 @@ INTERNAL_ROUTES_ALLOWED = env('INTERNAL_ROUTES_ALLOWED', default=False)
 IN_TEST_SUITE = True
 
 DEBUG = False
+# We should default to production mode unless otherwiser specified
+DEV_MODE = False
 
 # We won't actually send an email.
 SEND_REAL_EMAIL = True

--- a/src/olympia/accounts/tests/test_utils.py
+++ b/src/olympia/accounts/tests/test_utils.py
@@ -292,7 +292,7 @@ def test_redirect_for_login_with_2fa_enforced_and_config():
     assert request.session['enforce_2fa'] is True
 
 
-@override_settings(DEBUG=True, USE_FAKE_FXA_AUTH=True)
+@override_settings(DEV_MODE=True, USE_FAKE_FXA_AUTH=True)
 def test_fxa_login_url_when_faking_fxa_auth():
     path = '/en-US/addons/abp/?source=ddg'
     request = RequestFactory().get(path)

--- a/src/olympia/accounts/tests/test_verify.py
+++ b/src/olympia/accounts/tests/test_verify.py
@@ -234,7 +234,7 @@ class TestIdentify(TestCase):
         self.get_profile.assert_called_with('cafe')
 
 
-@override_settings(USE_FAKE_FXA_AUTH=False, DEBUG=True, VERIFY_FXA_ACCESS_TOKEN=True)
+@override_settings(USE_FAKE_FXA_AUTH=False, DEV_MODE=True, VERIFY_FXA_ACCESS_TOKEN=True)
 class TestCheckAndUpdateFxaAccessToken(TestCase):
     def setUp(self):
         super().setUp()

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -172,7 +172,7 @@ def has_cors_headers(response, origin='https://addons-frontend'):
 
 
 class TestLoginStartView(TestCase):
-    @override_settings(DEBUG=True, USE_FAKE_FXA_AUTH=True)
+    @override_settings(DEV_MODE=True, USE_FAKE_FXA_AUTH=True)
     def test_redirect_url_fake_fxa_auth(self):
         response = self.client.get(reverse_ns('accounts.login_start'))
         assert response.status_code == 302
@@ -700,7 +700,7 @@ class TestWithUser(TestCase):
         self.request.session['enforce_2fa'] = True
         self._test_should_continue_without_redirect_for_two_factor_auth()
 
-    @override_settings(DEBUG=True, USE_FAKE_FXA_AUTH=True)
+    @override_settings(DEV_MODE=True, USE_FAKE_FXA_AUTH=True)
     def test_fake_fxa_auth(self):
         self.user = user_factory()
         self.find_user.return_value = self.user
@@ -721,7 +721,7 @@ class TestWithUser(TestCase):
         assert kwargs['next_path'] == '/a/path/?'
         assert self.fxa_identify.call_count == 0
 
-    @override_settings(DEBUG=True, USE_FAKE_FXA_AUTH=True)
+    @override_settings(DEV_MODE=True, USE_FAKE_FXA_AUTH=True)
     def test_fake_fxa_auth_with_2fa(self):
         self.user = user_factory()
         self.find_user.return_value = self.user

--- a/src/olympia/amo/tests/test_views.py
+++ b/src/olympia/amo/tests/test_views.py
@@ -510,7 +510,7 @@ class TestRobots(TestCase):
 
 @pytest.mark.django_db
 def test_fake_fxa_authorization_correct_values_passed():
-    with override_settings(DEBUG=True):  # USE_FAKE_FXA_AUTH is already True
+    with override_settings(DEV_MODE=True):  # USE_FAKE_FXA_AUTH is already True
         url = reverse('fake-fxa-authorization')
         response = test.Client().get(url, {'state': 'foobar'})
         assert response.status_code == 200
@@ -528,15 +528,15 @@ def test_fake_fxa_authorization_correct_values_passed():
 @pytest.mark.django_db
 def test_fake_fxa_authorization_deactivated():
     url = reverse('fake-fxa-authorization')
-    with override_settings(DEBUG=False, USE_FAKE_FXA_AUTH=False):
+    with override_settings(DEV_MODE=False, USE_FAKE_FXA_AUTH=False):
         response = test.Client().get(url)
     assert response.status_code == 404
 
-    with override_settings(DEBUG=False, USE_FAKE_FXA_AUTH=True):
+    with override_settings(DEV_MODE=False, USE_FAKE_FXA_AUTH=True):
         response = test.Client().get(url)
     assert response.status_code == 404
 
-    with override_settings(DEBUG=True, USE_FAKE_FXA_AUTH=False):
+    with override_settings(DEV_MODE=True, USE_FAKE_FXA_AUTH=False):
         response = test.Client().get(url)
     assert response.status_code == 404
 

--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -1165,7 +1165,7 @@ def extract_colors_from_image(path):
 def use_fake_fxa():
     """Return whether or not to use a fake FxA server for authentication.
     Should always return False in production"""
-    return settings.DEBUG and settings.USE_FAKE_FXA_AUTH
+    return settings.DEV_MODE and settings.USE_FAKE_FXA_AUTH
 
 
 class AMOJSONEncoder(JSONEncoder):

--- a/src/olympia/api/urls.py
+++ b/src/olympia/api/urls.py
@@ -27,7 +27,7 @@ def get_versioned_api_routes(version, url_patterns):
     routes = url_patterns
 
     # For now, this feature is only enabled in dev mode
-    if settings.DEBUG:
+    if settings.DEV_MODE:
         routes.extend(
             [
                 re_path(

--- a/src/olympia/core/apps.py
+++ b/src/olympia/core/apps.py
@@ -63,6 +63,9 @@ def static_check(app_configs, **kwargs):
     errors = []
     output = StringIO()
 
+    if settings.DEV_MODE:
+        return []
+
     try:
         call_command('compress_assets', dry_run=True, stdout=output)
         file_paths = output.getvalue().strip().split('\n')

--- a/src/olympia/devhub/templates/devhub/index.html
+++ b/src/olympia/devhub/templates/devhub/index.html
@@ -34,7 +34,7 @@
       <meta name="csrf" content="{{ csrf_token }}">
     {% endif %}
 
-    {% if settings.DEBUG %}
+    {% if settings.DEV_MODE %}
       {% if settings.LESS_LIVE_REFRESH %}
         <meta id="live_refresh" name="live_refresh" value="1">
       {% endif %}

--- a/src/olympia/landfill/management/commands/fetch_prod_addons.py
+++ b/src/olympia/landfill/management/commands/fetch_prod_addons.py
@@ -43,9 +43,9 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        if not settings.DEBUG:
+        if not settings.DEV_MODE:
             raise CommandError(
-                'As a safety precaution this command only works if DEBUG=True.'
+                'As a safety precaution this command only works in DEV_MODE.'
             )
         self.fetch_addon_data(options)
 

--- a/src/olympia/landfill/management/commands/fetch_prod_versions.py
+++ b/src/olympia/landfill/management/commands/fetch_prod_versions.py
@@ -28,9 +28,9 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        if not settings.DEBUG:
+        if not settings.DEV_MODE:
             raise CommandError(
-                'As a safety precaution this command only works if DEBUG=True.'
+                'As a safety precaution this command only works in DEV_MODE.'
             )
         self.options = options
         self.fetch_versions_data()

--- a/src/olympia/landfill/management/commands/generate_addons.py
+++ b/src/olympia/landfill/management/commands/generate_addons.py
@@ -46,10 +46,8 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **kwargs):
-        if not settings.DEBUG:
-            raise CommandError(
-                'You can only run this command with your DEBUG setting set to True.'
-            )
+        if not settings.DEV_MODE:
+            raise CommandError('You can only run this command in DEV_MODE.')
 
         num = int(kwargs.get('num'))
         email = kwargs.get('email')

--- a/src/olympia/landfill/management/commands/generate_themes.py
+++ b/src/olympia/landfill/management/commands/generate_themes.py
@@ -37,10 +37,8 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **kwargs):
-        if not settings.DEBUG:
-            raise CommandError(
-                'You can only run this command with your DEBUG setting set to True.'
-            )
+        if not settings.DEV_MODE:
+            raise CommandError('You can only run this command in DEV_MODE.')
         num = int(kwargs.get('num'))
         email = kwargs.get('email')
 

--- a/src/olympia/lib/jingo_minify_helpers.py
+++ b/src/olympia/lib/jingo_minify_helpers.py
@@ -38,10 +38,7 @@ def get_js_urls(bundle, debug=None):
         If True, return URLs for individual files instead of the minified
         bundle.
     """
-    if debug is None:
-        debug = settings.DEBUG
-
-    if debug:
+    if debug or settings.DEBUG or settings.DEV_MODE:
         return [static(item) for item in settings.MINIFY_BUNDLES['js'][bundle]]
     else:
         return [static(f'js/{bundle}-min.js')]
@@ -58,10 +55,7 @@ def get_css_urls(bundle, debug=None):
         If True, return URLs for individual files instead of the minified
         bundle.
     """
-    if debug is None:
-        debug = settings.DEBUG
-
-    if debug:
+    if debug or settings.DEBUG or settings.DEV_MODE:
         items = []
         for item in settings.MINIFY_BUNDLES['css'][bundle]:
             should_compile = item.endswith('.less') and getattr(

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -59,6 +59,23 @@ def path(*folders):
 
 DEBUG = env('DEBUG', default=False)
 
+# Do NOT provide a default value, this should be explicitly
+# set during the docker image build. If it is not set,
+# we want to raise an error.
+DOCKER_TARGET = env('DOCKER_TARGET')
+
+# "production" is a named docker stage corresponding to the production image.
+# when we build the production image, the stage to use is determined
+# via the "DOCKER_TARGET" variable which is also passed into the image.
+# So if the value is anything other than "production" we are in development mode.
+DEV_MODE = DOCKER_TARGET != 'production'
+
+# Used to determine if django should serve static files.
+# For local deployments we want nginx to proxy static file requests to the
+# uwsgi server and not try to serve them locally.
+# In production, nginx serves these files from a CDN.
+SERVE_STATIC_FILES = False
+
 DEBUG_TOOLBAR_CONFIG = {
     # Deactivate django debug toolbar by default.
     'SHOW_TOOLBAR_CALLBACK': lambda request: DEBUG,
@@ -699,7 +716,7 @@ MINIFY_BUNDLES = {
             'js/stats/table.js',
             'js/stats/stats.js',
         ),
-        # This is included when DEBUG is True.  Bundle in <head>.
+        # This is included when DEV_MODE is True.  Bundle in <head>.
         'debug': (
             'js/debug/less_setup.js',
             'less/dist/less.js',
@@ -1316,7 +1333,7 @@ STATICFILES_DIRS = (
     STATIC_BUILD_PATH,
 )
 
-STATICFILES_STORAGE = 'olympia.lib.storage.ManifestStaticFilesStorageNotMaps'
+STATICFILES_STORAGE = 'olympia.lib.storage.OlympiaStaticFilesStorage'
 
 # Path related settings. In dev/stage/prod `NETAPP_STORAGE_ROOT` environment
 # variable will be set and point to our NFS/EFS storage

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -64,11 +64,7 @@ DEBUG = env('DEBUG', default=False)
 # we want to raise an error.
 DOCKER_TARGET = env('DOCKER_TARGET')
 
-# "production" is a named docker stage corresponding to the production image.
-# when we build the production image, the stage to use is determined
-# via the "DOCKER_TARGET" variable which is also passed into the image.
-# So if the value is anything other than "production" we are in development mode.
-DEV_MODE = DOCKER_TARGET != 'production'
+DEV_MODE = False
 
 # Used to determine if django should serve static files.
 # For local deployments we want nginx to proxy static file requests to the

--- a/src/olympia/lib/storage.py
+++ b/src/olympia/lib/storage.py
@@ -1,4 +1,8 @@
-from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
+from django.conf import settings
+from django.contrib.staticfiles.storage import (
+    ManifestStaticFilesStorage,
+    StaticFilesStorage,
+)
 
 
 class ManifestStaticFilesStorageNotMaps(ManifestStaticFilesStorage):
@@ -17,3 +21,8 @@ class ManifestStaticFilesStorageNotMaps(ManifestStaticFilesStorage):
             ),
         ),
     )
+
+
+OlympiaStaticFilesStorage = (
+    StaticFilesStorage if settings.DEV_MODE else ManifestStaticFilesStorageNotMaps
+)

--- a/src/olympia/templates/base.html
+++ b/src/olympia/templates/base.html
@@ -32,7 +32,7 @@
 
     <noscript><link rel="stylesheet" href="{{ static('css/legacy/nojs.css') }}"></noscript>
 
-    {% if settings.DEBUG %}
+    {% if settings.DEV_MODE %}
       {% if settings.LESS_LIVE_REFRESH %}
         <meta id="live_refresh" name="live_refresh" value="1">
       {% endif %}

--- a/src/olympia/urls.py
+++ b/src/olympia/urls.py
@@ -109,11 +109,18 @@ urlpatterns = [
     ),
 ]
 
-if settings.DEBUG:
+if settings.SERVE_STATIC_FILES:
     from django.contrib.staticfiles.views import serve as static_serve
 
     def serve_static_files(request, path, **kwargs):
-        return static_serve(request, path, insecure=True, **kwargs)
+        if settings.DEV_MODE:
+            return static_serve(
+                request, path, insecure=True, show_indexes=True, **kwargs
+            )
+        else:
+            return serve_static(
+                request, path, document_root=settings.STATIC_ROOT, **kwargs
+            )
 
     # Remove leading and trailing slashes so the regex matches.
     media_url = settings.MEDIA_URL.lstrip('/').rstrip('/')


### PR DESCRIPTION
Relates to: mozilla/addons#15066
Relates to: mozilla/addons#15046 (removes one of the mounts that could cause race conditions)
Fixes: mozilla/addons#15058

### Description

Adds a `DEV_MODE` boolean setting based on the value of `DOCKER_TARGET` being not equal to `production`. This value is then used in the places that previously relied on `DEBUG` bu that should instead rely specifically on if we are using a production image or not.

### Context

`DEBUG` has largley been used to determine if we are in "dev" or "prod" mode. But we have a better value set during the docker build `DOCKER_TARGET` that actually controls which set of dependencies we have and how we setup our docker compose configuration and this value is much more suited to the task of making such a determination.

This split also means you can now run prod mode in debug mode, great for debugging a production like environment.s

To put into context 

### Testing

There are 4 combinations of make up to run `DEBUG=True/False` and `DOCKER_TARGET=development/production`

#### Dev Mode

First run dev mode without debugging

```bash
make up DEBUG= DOCKER_TARGET=development
```

This is running the development image, with debug false. You should expect to have development dependencies installed, but running the app will not load django debug toolbar.

Now rerun the same command but change `DEBUG=True` (it actually can be any value, just not literally empty)

```bash
make up DEBUG=True DOCKER_TARGET=development
```

### Prod Mode

Very much like above, except we are targeting the production image

```bash
make up DEBUG= DOCKER_TARGET=production
```

Now expect dev dependencies to NOT be installed. You can test by running `pip show <dependency` for a dep in the dev.txt file.

Rerun with debugging

```bash
make up DEBUG=True DOCKER_TARGET=production
```

Expect now to have debugging enabled. You are still running production mode, but debugging is now enabled.

### Expectations

All four should work as expected.
- containers running and healthy
- endpoints serving correctly app rendering
- `make check` works.
- if debug is true, expect debug toolbar
- if dev mode expect development dependencies.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
