### PR TITLE
expose blocked version as blocked and soft_blocked in the API

### DIFF
--- a/docs/topics/api/blocklist.rst
+++ b/docs/topics/api/blocklist.rst
@@ -26,9 +26,8 @@ This endpoint returns an add-on Block from the blocklist, specified by guid or i
     :>json string modified: The date the block was last updated.
     :>json object|null addon_name: The add-on name, if we have details of an add-on matching that guid (See :ref:`translated fields <api-overview-translations>`).
     :>json string guid: The guid of the add-on being blocked.
-    :>json string min_version: The minimum version of the add-on that will be blocked.  "0" is the lowest version, meaning all versions up to max_version will be blocked.  ("0" - "*" would be all versions).
-    :>json string max_version: The maximum version of the add-on that will be blocked.  "*" is the highest version, meaning all versions from min_version will be blocked.  ("0" - "*" would be all versions).
     :>json string|null reason: Why the add-on needed to be blocked.
     :>json object|null url: A url to the report/request that detailed why the add-on should potentially be blocked.  Typically a bug report on bugzilla.mozilla.org.  (See :ref:`Outgoing Links <api-overview-outgoing>`)
-    :>json string versions[]: The versions of this add-on that are blocked.
+    :>json string blocked[]: The versions of this add-on that are (hard) blocked.
+    :>json string soft_blocked[]: The versions of this add-on that are soft blocked (can be optionally re-enabled by existing users).
     :>json boolean is_all_versions: Are all versions of this add-on blocked. If ``False``, some versions are not blocked.

--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -473,6 +473,7 @@ These are `v5` specific changes - `v4` changes apply also.
 * 2024-06-20: added ``illegal_subcategory`` parameter to all /abuse/report/ endpoints. https://github.com/mozilla/addons/issues/14875
 * 2024-08-08: added support for writing to add-on eula_policy endpoint. https://github.com/mozilla/addons/issues/14927
 * 2024-08-22: restricted add-on eula_policy endpoint to non-themes only. https://github.com/mozilla/addons/issues/14937
+* 2024-10-17: replaced ``versions`` with ``blocked`` and ``soft_blocked`` in blocklist api; dropped unused ``min_version`` and ``max_version``. https://github.com/mozilla/addons/issues/15015
 
 .. _`#11380`: https://github.com/mozilla/addons-server/issues/11380/
 .. _`#11379`: https://github.com/mozilla/addons-server/issues/11379/

--- a/src/olympia/blocklist/tests/test_serializers.py
+++ b/src/olympia/blocklist/tests/test_serializers.py
@@ -1,3 +1,7 @@
+from django.test.utils import override_settings
+
+from rest_framework.test import APIRequestFactory
+
 from olympia import amo
 from olympia.amo.tests import TestCase, addon_factory, user_factory, version_factory
 from olympia.amo.urlresolvers import get_outgoing_url
@@ -8,6 +12,7 @@ from ..serializers import BlockSerializer
 
 class TestBlockSerializer(TestCase):
     def setUp(self):
+        self.request = APIRequestFactory().get('/')
         self.block = Block.objects.create(
             guid='foo@baa',
             reason='something happened',
@@ -16,23 +21,30 @@ class TestBlockSerializer(TestCase):
         )
 
     def test_basic_no_addon(self):
-        serializer = BlockSerializer(instance=self.block)
-        assert serializer.data == {
+        expected = {
             'id': self.block.id,
             'addon_name': None,
             'guid': 'foo@baa',
-            'min_version': '',
-            'max_version': '',
             'reason': 'something happened',
+            'blocked': [],
+            'soft_blocked': [],
             'url': {
                 'url': 'https://goo.gol',
                 'outgoing': get_outgoing_url('https://goo.gol'),
             },
-            'versions': [],
             'is_all_versions': True,
             'created': self.block.created.isoformat()[:-7] + 'Z',
             'modified': self.block.modified.isoformat()[:-7] + 'Z',
         }
+        serializer = BlockSerializer(context={'request': self.request})
+        assert serializer.to_representation(self.block) == expected
+
+        with override_settings(DRF_API_GATES={None: ('block-min-max-versions-shim',)}):
+            assert serializer.to_representation(self.block) == {
+                **expected,
+                'min_version': '0',
+                'max_version': '*',
+            }
 
     def test_with_addon(self):
         addon = addon_factory(
@@ -45,26 +57,40 @@ class TestBlockSerializer(TestCase):
         )
         version_4 = version_factory(addon=addon, version='4')
         _version_3 = version_factory(addon=addon, version='3b1')
+        version_6 = version_factory(addon=addon, version='123456')
         BlockVersion.objects.create(block=self.block, version=version_2)
         BlockVersion.objects.create(block=self.block, version=version_4)
+        BlockVersion.objects.create(block=self.block, version=version_6, soft=True)
 
-        serializer = BlockSerializer(instance=self.block)
-        assert serializer.data == {
+        expected = {
             'id': self.block.id,
             'addon_name': {'en-US': 'Addón náme'},
             'guid': 'foo@baa',
-            'min_version': version_2.version,
-            'max_version': version_4.version,
             'reason': 'something happened',
             'url': {
                 'url': 'https://goo.gol',
                 'outgoing': get_outgoing_url('https://goo.gol'),
             },
-            'versions': [version_2.version, version_4.version],
+            'blocked': [version_2.version, version_4.version],
+            'soft_blocked': [version_6.version],
             'is_all_versions': False,
             'created': self.block.created.isoformat()[:-7] + 'Z',
             'modified': self.block.modified.isoformat()[:-7] + 'Z',
         }
+        serializer = BlockSerializer(context={'request': self.request})
+        assert serializer.to_representation(self.block) == expected
+
+        with override_settings(DRF_API_GATES={None: ('block-min-max-versions-shim',)}):
+            assert serializer.to_representation(self.block) == {
+                **expected,
+                'min_version': version_2.version,
+                'max_version': version_4.version,
+            }
+        with override_settings(DRF_API_GATES={None: ('block-versions-list-shim',)}):
+            assert serializer.to_representation(self.block) == {
+                **expected,
+                'versions': expected['blocked'],
+            }
 
     def test_is_all_versions(self):
         # no add-on so True
@@ -73,11 +99,16 @@ class TestBlockSerializer(TestCase):
         addon = addon_factory(
             guid=self.block.guid, name='Addón náme', file_kw={'is_signed': True}
         )
-        BlockVersion.objects.create(block=self.block, version=addon.current_version)
+        BlockVersion.objects.create(
+            block=self.block, version=addon.current_version, soft=False
+        )
+        BlockVersion.objects.create(
+            block=self.block, version=version_factory(addon=addon), soft=True
+        )
         version_factory(addon=addon, file_kw={'is_signed': False})  # not signed
         self.block.refresh_from_db()
         del self.block.addon
-        # add-on with only one signed version - so all blocked - but not disabled
+        # add-on with only two signed versions - so all blocked - but not disabled
         assert BlockSerializer(instance=self.block).data['is_all_versions'] is False
 
         addon.update(status=amo.STATUS_DISABLED)

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1406,6 +1406,8 @@ DRF_API_GATES = {
         'del-preview-position',
         'categories-application',
         'promoted-verified-sponsored',
+        'block-min-max-versions-shim',
+        'block-versions-list-shim',
     ),
     'v5': (
         'addons-search-_score-field',
@@ -1413,6 +1415,7 @@ DRF_API_GATES = {
         'ratings-score-filter',
         'addon-submission-api',
         'promoted-verified-sponsored',
+        'block-versions-list-shim',
     ),
 }
 


### PR DESCRIPTION
Fixes: mozilla/addons#15015

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Renames `versions` to `blocked`, adds `soft_blocked`, and drops unused `max_version` and `min_version`.  Adds shims for v4 so functionality is as now.

### Context

Frontend consumes this API to display details of blocks, and in particular for this change, the versions that are blocked, to end-users.  Until deploy+1 after frontend is updated to consume `blocked` rather than `versions` we'll keep the shim `block-versions-list-shim` enabled for v5 too so it continues to work during the deploy, etc.  `min_version` and `max_version` have been unused for a long time on frontend - since we stopped implementing blocked versions as a range - but we overlooked removing and shim'ing them.

### Testing
- Add some blocked (signed) versions that are a mixture of hard and soft blocks, and see `/api/v5/blocked/<guid>/` lists them as `blocked` and `soft_blocked` respectively.
- See hard blocked are still there as `versions` as before
- check /v4/ and see `min_version` and `max_version` are still there, and are the max and min hard blocked versions.
- `is_all_versions` should be true if all signed versions are either hard or soft blocked AND the add-on is disabled to prevent further versions.

<!--
Your change must be related to an existing, open issue. This issue should contain testing instructions.
Often, the testing info in the issue is higher level, geared towards a user or QA experience.
Here you can provide information for a developer verifying this PR. Get technical.
If it is not relevant to your PR, remove this section.
-->

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
