### PR TITLE
Add recaptcha for new addon submission upload

### DIFF
--- a/src/olympia/devhub/forms.py
+++ b/src/olympia/devhub/forms.py
@@ -1056,11 +1056,17 @@ class NewUploadForm(CheckThrottlesFormMixin, forms.Form):
         'Please try again after some time.'
     )
     throttle_classes = addon_submission_throttles
+    recaptcha = ReCaptchaField(label='')
 
     def __init__(self, *args, **kw):
         self.request = kw.pop('request')
         self.addon = kw.pop('addon', None)
+        self.include_recaptcha = kw.pop('include_recaptcha', False)
         super().__init__(*args, **kw)
+
+        recaptcha_enabled = waffle.switch_is_active('developer-submit-addon-captcha')
+        if not recaptcha_enabled or not self.include_recaptcha:
+            del self.fields['recaptcha']
 
         # Preselect compatible apps based on the current version
         if self.addon and self.addon.current_version:

--- a/src/olympia/devhub/templates/devhub/addons/submit/upload.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/upload.html
@@ -87,6 +87,13 @@
     </div>
     {% endif %}
 
+    {% if 'recaptcha' in new_addon_form.fields %}
+    <p>
+      {{ new_addon_form.recaptcha }}
+      {{ new_addon_form.recaptcha.errors }}
+    </p>
+    {% endif %}
+
     <div class="submission-buttons addon-submission-field">
       <button class="addon-upload-dependant" id="submit-upload-file-finish" disabled=disabled type="submit">
         {{ _('Continue') }}

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -904,6 +904,13 @@ class TestAddonSubmitUpload(UploadMixin, TestCase):
         form = response.context['new_addon_form']
         assert 'recaptcha' not in form.fields
 
+    @override_switch('developer-submit-addon-captcha', active=False)
+    def test_recaptcha_skipped_theme_upload(self):
+        url = reverse('devhub.submit.theme.upload', args=['listed'])
+        response = self.client.get(url)
+        form = response.context['new_addon_form']
+        assert 'recaptcha' not in form.fields
+
     @override_switch('developer-submit-addon-captcha', active=True)
     def test_recaptcha_enabled_success(self):
         url = reverse('devhub.submit.upload', args=['listed'])
@@ -2171,6 +2178,11 @@ class TestVersionSubmitAutoChannel(TestSubmitBase):
         super().setUp()
         self.url = reverse('devhub.submit.version', args=[self.addon.slug])
 
+    @override_switch('developer-submit-addon-captcha', active=True)
+    def test_recaptcha_not_included(self):
+        response = self.client.get(self.url)
+        assert 'recaptcha' not in response.context['new_addon_form'].fields
+
     @mock.patch('olympia.devhub.views._submit_upload', side_effect=views._submit_upload)
     def test_listed_last_uses_listed_upload(self, _submit_upload_mock):
         version_factory(addon=self.addon, channel=amo.CHANNEL_LISTED)
@@ -2545,6 +2557,11 @@ class VersionSubmitUploadMixin:
 class TestVersionSubmitUploadListed(VersionSubmitUploadMixin, UploadMixin, TestCase):
     channel = amo.CHANNEL_LISTED
 
+    @override_switch('developer-submit-addon-captcha', active=True)
+    def test_recaptcha_not_included(self):
+        response = self.client.get(self.url)
+        assert 'recaptcha' not in response.context['new_addon_form'].fields
+
     def test_success(self):
         response = self.post()
         version = self.addon.find_latest_version(channel=amo.CHANNEL_LISTED)
@@ -2724,6 +2741,11 @@ class TestVersionSubmitUploadListed(VersionSubmitUploadMixin, UploadMixin, TestC
 
 class TestVersionSubmitUploadUnlisted(VersionSubmitUploadMixin, UploadMixin, TestCase):
     channel = amo.CHANNEL_UNLISTED
+
+    @override_switch('developer-submit-addon-captcha', active=True)
+    def test_recaptcha_not_included(self):
+        response = self.client.get(self.url)
+        assert 'recaptcha' not in response.context['new_addon_form'].fields
 
     def test_success(self):
         # No validation errors or warning.

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -930,21 +930,29 @@ class TestAddonSubmitUpload(UploadMixin, TestCase):
             json={'error-codes': [], 'success': True},
         )
 
-        post_response = self.client.post(url, {
-            'g-recaptcha-response': 'test',
-            'upload': self.upload.uuid.hex,
-            'compatible_apps': [amo.FIREFOX.id],
-        })
+        post_response = self.client.post(
+            url,
+            {
+                'g-recaptcha-response': 'test',
+                'upload': self.upload.uuid.hex,
+                'compatible_apps': [amo.FIREFOX.id],
+            },
+        )
         addon = Addon.unfiltered.get()
-        self.assert3xx(post_response, reverse('devhub.submit.source', args=[addon.slug, 'listed']))
+        self.assert3xx(
+            post_response, reverse('devhub.submit.source', args=[addon.slug, 'listed'])
+        )
 
     @override_switch('developer-submit-addon-captcha', active=True)
     def test_recaptcha_enabled_failed(self):
         url = reverse('devhub.submit.upload', args=['listed'])
-        response = self.client.post(url, {
-            'upload': self.upload.uuid.hex,
-            'compatible_apps': [amo.FIREFOX.id],
-        })
+        response = self.client.post(
+            url,
+            {
+                'upload': self.upload.uuid.hex,
+                'compatible_apps': [amo.FIREFOX.id],
+            },
+        )
 
         # Captcha is properly rendered
         doc = pq(response.content)

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -1486,7 +1486,13 @@ WIZARD_COLOR_FIELDS = [
 
 @transaction.atomic
 def _submit_upload(
-    request, addon, channel, next_view, wizard=False, theme_specific=False
+    request,
+    addon,
+    channel,
+    next_view,
+    wizard=False,
+    theme_specific=False,
+    include_recaptcha=False,
 ):
     """If this is a new addon upload `addon` will be None.
 
@@ -1497,7 +1503,11 @@ def _submit_upload(
         # "invisible" (disabled_by_user).
         return redirect('devhub.submit.version.distribution', addon.slug)
     form = forms.NewUploadForm(
-        request.POST or None, request.FILES or None, addon=addon, request=request
+        request.POST or None,
+        request.FILES or None,
+        addon=addon,
+        request=request,
+        include_recaptcha=include_recaptcha,
     )
     if wizard or (addon and addon.type == amo.ADDON_STATICTHEME):
         # If using the wizard or submitting a new version of a theme, we can
@@ -1611,7 +1621,9 @@ def submit_addon_upload(request, channel):
     if not RestrictionChecker(request=request).is_submission_allowed():
         return redirect('devhub.submit.agreement')
     channel_id = amo.CHANNEL_CHOICES_LOOKUP[channel]
-    return _submit_upload(request, None, channel_id, 'devhub.submit.source')
+    return _submit_upload(
+        request, None, channel_id, 'devhub.submit.source', include_recaptcha=True
+    )
 
 
 @login_required


### PR DESCRIPTION
Fixes: mozilla/addons#15076


### Description

Adds recaptcha for new addon submissions, behind a waffle switch.

### Context

In order to combat spam uploads, we will enable the google recaptcha field on all new addon upload submissions.

This should NOT lead to a recaptcha being seen on each submission, but will include the field to decide if and when to display.

### Testing

You can enable seeing the recaptcha by flipping `developer-submit-addon-captcha` on

1. navigate to the new submission [page](http://olympia.test/en-US/developers/addon/submit/distribution)
2. choose "listed" or "unlisted" (You should test both)
3. click continue
4. Expect to see the captcha above the continue button.
5. upload a valid xpi
6. If you do not submit the recaptcha, expect the page to reload with an error that the field is required, otherwise you will continue.

Note: if the waffle flag is "disabled" expect 4 to not display the captcha and thus 6 will always let you continue (assuming other fields are valid)

### Checklist


- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
