### PR TITLE
Update .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -59,7 +59,6 @@ tmp/*
 # Additionally ignore these files from the docker build that are not in .gitignore
 
 .dockerignore
-.gitignore
 .github
 docs
 private


### PR DESCRIPTION
Fixes: mozilla/addons#15071

### Description

Remove .gitignore from .dockerignore

We should include this file in the build as other tools use it to determine their behaviour. Relying on lower level ignore of files by ruff that would have been ignored via the gitignore is cumbersome and error prone and adding it as a mount in docker compose will create a regression between production and dev always.

It is not expensive to include this file so we should just include it.

### Context

The dockerignore file ignored some files not in the gitignore including the gitignore itself. This 

### Testing

Pull or rebase https://github.com/mozilla/addons-server/pull/22744 onto the branch and run 

```
make up COMPOSE_FILE=docker-compose.yml:docker-compose.ci.yml
```

running `make lint` should pass

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
