### PR TITLE
Implement APIKey as django form + recaptcha field

### DIFF
--- a/src/olympia/devhub/forms.py
+++ b/src/olympia/devhub/forms.py
@@ -1512,8 +1512,8 @@ class APIKeyForm(forms.Form):
             ):
                 help_text = _(
                     'Please click the confirm button below to generate '
-                    'API credentials for user <strong>{user}</strong>.'
-                ).format(user=self.request.user.name)
+                    'API credentials for user <strong>{name}</strong>.'
+                ).format(name=self.request.user.name)
                 self.available_actions.append(self.ACTION_CHOICES.generate)
             else:
                 help_text = _(

--- a/src/olympia/devhub/templates/devhub/api/key.html
+++ b/src/olympia/devhub/templates/devhub/api/key.html
@@ -9,84 +9,44 @@
 
 <section class="primary full">
   <div class="island prettyform row">
-    <form method="post" class="item api-credentials">
+    <form method="post" class="item api-credentials" name="api-credentials-form">
       {% csrf_token %}
+      {% if '__all__' in form.errors %}
+        <div class="text-danger">
+          {{ form.errors.__all__ }}
+        </div>
+      {% endif %}
       <fieldset>
         <legend>
           {{ _('API Credentials') }}
         </legend>
-        {% if credentials %}
-          <p>
-          {% trans
-              docs_url='https://addons-server.readthedocs.io/en/latest/topics/api/index.html' %}
-            For detailed instructions, consult the <a href="{{ docs_url }}">API documentation</a>.
-          {% endtrans %}
-          </p>
-          <p class="notification-box error">
-            {{ _('Keep your API keys secret and <strong>never share them with anyone</strong>, including Mozilla contributors.') }}
-          </p>
-          <ul class="api-credentials">
-            <li class="row api-input key-input">
-              <label for="jwtkey" class="row">{{ _('JWT issuer') }}</label>
-              <input type="text" name="jwtkey" value="{{ credentials.key }}" readonly/>
-            </li>
-            <li class="row api-input">
-              <label for="jwtsecret" class="row">{{ _('JWT secret') }}</label>
-              <input type="text" name="jwtsecret" value="{{ credentials.secret }}" readonly/>
-            </li>
-          </ul>
-          <p>
-          {% trans
-              docs_url='https://addons-server.readthedocs.io/en/latest/topics/api/auth.html',
-              jwt_url='https://self-issued.info/docs/draft-ietf-oauth-json-web-token.html' %}
-            To make API requests, send a <a href="{{ jwt_url }}">JSON Web Token (JWT)</a> as the authorization header.
-            You'll need to generate a JWT for every request as explained in the
-            <a href="{{ docs_url }}">API documentation</a>.
-          {% endtrans %}
-          </p>
-        {% elif confirmation and not confirmation.confirmed_once %}
-          {% if token %}
-            <p>
-              {% trans name=request.user.name %}
-                Please click the confirm button below to generate API credentials for user <strong>{{ name }}</strong>.
-              {% endtrans %}
-              <input type="hidden" name="confirmation_token" value="{{ token }}" />
-            </p>
-          {% else %}
-            <p>
-              {% trans %}
-                A confirmation link will be sent to your email address. After confirmation you will find your API keys on this page.
-              {% endtrans %}
-            </p>
-          {% endif %}
-        {% else %}
-          <p>
-          {% trans %}
-            You don't have any API credentials.
-          {% endtrans %}
-          </p>
-        {% endif %}
+        {% for field in form %}
+          <div class="row api-input key-input">
+              {% if field.help_text %}
+              <div>{{ field.help_text|format_html }}</div>
+              {% endif %}
+              <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+              {{ field }}
+              {% if field.errors %}
+                  <div class="text-danger">
+                      {{ field.errors }}
+                  </div>
+              {% endif %}
+          </div>
+        {% endfor %}
       </fieldset>
       <div class="listing-footer">
         <p class="footer-submit">
-          {% if credentials %}
-            <button id="revoke-key" class="button prominent" type="submit" name="action" value="revoke">
-              {{ _('Revoke') }}
+          {% for action in form.available_actions %}
+            <button
+              class="button prominent"
+              type="submit"
+              name="action"
+              value="{{ action }}"
+            >
+              {{ form.ACTION_CHOICES.for_value(action).display }}
             </button>
-            <button id="generate-key" class="button prominent" type="submit" name="action" value="generate">
-              {{ _('Revoke and regenerate credentials') }}
-            </button>
-          {% elif confirmation and not confirmation.confirmed_once %}
-            {% if token %}
-              <button id="generate-key" class="button prominent" type="submit" name="action" value="generate">
-                {{ _('Confirm and generate new credentials') }}
-              </button>
-            {% endif %}
-          {% else %}
-            <button id="generate-key" class="button prominent" type="submit" name="action" value="generate">
-              {{ _('Generate new credentials') }}
-            </button>
-          {% endif %}
+          {% endfor %}
         </p>
       </div>
     </form>

--- a/src/olympia/devhub/tests/test_forms.py
+++ b/src/olympia/devhub/tests/test_forms.py
@@ -25,6 +25,7 @@ from olympia.amo.tests import (
 )
 from olympia.amo.tests.test_helpers import get_image_path
 from olympia.amo.utils import rm_local_tmp_dir
+from olympia.api.models import APIKey, APIKeyConfirmation
 from olympia.applications.models import AppVersion
 from olympia.constants.promoted import RECOMMENDED
 from olympia.devhub import forms
@@ -1281,3 +1282,166 @@ class TestAddonFormTechnical(TestCase):
                 'Ensure this value has at most 3000 characters (it has 3001).'
             ]
         }
+
+
+class TestAPIKeyForm(TestCase):
+    def setUp(self):
+        self.user = user_factory()
+
+    def _request(self, action=None, token=None, data=None):
+        url = '/' if token is None else f'/?token={token}'
+        data = {} if data is None else data
+        if action is not None:
+            data['action'] = action
+        return req_factory_factory(url, post=True, user=self.user, data=data)
+
+    def test_fields_without_credentials_or_confirmation(self):
+        request = self._request(action=forms.APIKeyForm.ACTION_CHOICES.confirm)
+        form = forms.APIKeyForm(request.POST, request=request)
+        assert form.available_actions == [
+            forms.APIKeyForm.ACTION_CHOICES.confirm,
+        ]
+        assert form.is_valid()
+        assert 'credentials_key' not in form.fields
+        assert 'credentials_secret' not in form.fields
+        assert 'confirmation_token' not in form.fields
+        assert 'recaptcha' not in form.fields
+
+        with override_switch('developer-submit-addon-captcha', active=True):
+            form = forms.APIKeyForm(request.POST, request=request)
+            recaptcha = form.fields['recaptcha']
+            self.assertEqual(recaptcha.label, '')
+            self.assertEqual(recaptcha.help_text, "You don't have any API credentials.")
+            self.assertEqual(recaptcha.required, True)
+            assert not form.is_valid()
+            assert form.errors['recaptcha'] == ['This field is required.']
+
+            request = self._request(
+                action=forms.APIKeyForm.ACTION_CHOICES.confirm,
+                data={'g-recaptcha-response': 'test'},
+            )
+            form = forms.APIKeyForm(request.POST, request=request)
+            assert form.is_valid()
+
+    def test_fields_with_credentials(self):
+        APIKey.new_jwt_credentials(self.user)
+        credentials = APIKey.get_jwt_key(user=self.user)
+        request = self._request(action=forms.APIKeyForm.ACTION_CHOICES.revoke)
+        form = forms.APIKeyForm(request.POST, request=request)
+        assert 'confirmation_token' not in form.fields
+        assert 'recaptcha' not in form.fields
+
+        key = form.fields['credentials_key']
+        self.assertEqual(key.label, 'JWT issuer')
+        self.assertEqual(key.disabled, True)
+        self.assertEqual(key.widget.attrs['readonly'], True)
+        self.assertEqual(key.required, True)
+        self.assertEqual(key.initial, credentials.key)
+        assert 'To make API requests' in key.help_text
+
+        secret = form.fields['credentials_secret']
+        self.assertEqual(secret.label, 'JWT secret')
+        self.assertEqual(secret.disabled, True)
+        self.assertEqual(secret.widget.attrs['readonly'], True)
+        self.assertEqual(secret.required, True)
+        self.assertEqual(secret.initial, credentials.secret)
+
+        assert form.is_valid()
+        assert form.available_actions == [
+            forms.APIKeyForm.ACTION_CHOICES.revoke,
+        ]
+
+    def test_fields_with_confirmation(self):
+        confirmation = APIKeyConfirmation.objects.create(user=self.user, token='test')
+        request = self._request(action=forms.APIKeyForm.ACTION_CHOICES.generate)
+        form = forms.APIKeyForm(request.POST, request=request)
+        assert 'credentials_key' not in form.fields
+        assert 'credentials_secret' not in form.fields
+        assert 'recaptcha' not in form.fields
+
+        confirmation_token = form.fields['confirmation_token']
+        self.assertEqual(confirmation_token.label, '')
+        self.assertEqual(confirmation_token.max_length, 20)
+        self.assertEqual(confirmation_token.required, False)
+
+        form = forms.APIKeyForm(request.POST, request=request)
+        assert not form.is_valid()
+        assert form.available_actions == []
+
+        request = self._request(
+            action=forms.APIKeyForm.ACTION_CHOICES.generate,
+            token=confirmation.token,
+        )
+        form = forms.APIKeyForm(request.POST, request=request)
+        assert form.is_valid()
+        assert form.available_actions == [
+            forms.APIKeyForm.ACTION_CHOICES.generate,
+        ]
+
+        confirmation.update(confirmed_once=True)
+        request = self._request(
+            action=forms.APIKeyForm.ACTION_CHOICES.generate,
+            token=None,
+        )
+        form = forms.APIKeyForm(request.POST, request=request)
+        assert form.is_valid()
+        assert form.available_actions == [
+            forms.APIKeyForm.ACTION_CHOICES.generate,
+        ]
+
+    def test_fields_with_credentials_and_confirmation(self):
+        APIKey.new_jwt_credentials(self.user)
+        confirmation = APIKeyConfirmation.objects.create(
+            user=self.user, token='test', confirmed_once=True
+        )
+        request = self._request(action=forms.APIKeyForm.ACTION_CHOICES.revoke)
+        form = forms.APIKeyForm(request.POST, request=request)
+        assert 'recaptcha' not in form.fields
+        assert 'confirmation_token' not in form.fields
+        assert 'credentials_key' in form.fields
+        assert 'credentials_secret' in form.fields
+        assert form.is_valid()
+        assert form.available_actions == [
+            forms.APIKeyForm.ACTION_CHOICES.revoke,
+            forms.APIKeyForm.ACTION_CHOICES.regenerate,
+        ]
+
+        confirmation.update(confirmed_once=False)
+        form = forms.APIKeyForm(request.POST, request=request)
+        assert form.is_valid()
+        assert form.available_actions == [
+            forms.APIKeyForm.ACTION_CHOICES.revoke,
+        ]
+
+    def test_revoke_credentials(self):
+        APIKey.new_jwt_credentials(self.user)
+        credentials = APIKey.get_jwt_key(user=self.user)
+        assert credentials.is_active is True
+        request = self._request(action=forms.APIKeyForm.ACTION_CHOICES.revoke)
+        form = forms.APIKeyForm(request.POST, request=request)
+        assert form.is_valid()
+        form.save()
+        assert credentials.reload().is_active is None
+
+    def test_generate_credentials(self):
+        APIKeyConfirmation.objects.create(user=self.user, token='test')
+        confirmation = APIKeyConfirmation.objects.get(user=self.user)
+        assert confirmation.confirmed_once is False
+        request = self._request(
+            action=forms.APIKeyForm.ACTION_CHOICES.generate, token=confirmation.token
+        )
+        form = forms.APIKeyForm(request.POST, request=request)
+        assert form.is_valid()
+        form.save()
+        assert confirmation.reload().confirmed_once is True
+        assert form.credentials == APIKey.get_jwt_key(user=self.user)
+
+    def test_send_confirmation(self):
+        request = self._request(action=forms.APIKeyForm.ACTION_CHOICES.confirm)
+        form = forms.APIKeyForm(request.POST, request=request)
+        assert form.confirmation is None
+        assert form.is_valid()
+        form.save()
+        confirmation = APIKeyConfirmation.objects.get(user=self.user)
+        assert confirmation.token is not None
+        assert confirmation.user == self.user


### PR DESCRIPTION
Fixes: mozilla/addons#15083

### Description

This PR refactors the `APIKeyPage` view to utilize a django form, both to support using the recaptcha field as part of the flow, and to make the form logic more consolidated and easier to test/grok.

### Context

Previously, the logic for managing the API key page was kind of murky and spread/duplicated between the view and the template layer.

Now, there is a Django form `APIKeyForm` that is managing the state machine of which actions a developer has available, what is the current state of the relevant entities (confirmation + credentials) and which fields + validations should be in scope.

This is a dynamic form that can model the full state of the API key lifecycle from requesting a confirmation, confirming + generating, revoking, and regenerating credentials.

The underlying logic is largely the same as before, but to support the re-captcha a few key changes have been made.

1) the re-captcha field is now included in the "confirm" stage, when a user does not have a confirmation or credentials.

2) if a user has credentials but no confirmation, they are shown the credentials view with ONLY the revoke action. Previously we handled creating the confirmation to allow them to regenerate but now, we don't know if they have re-captcha complete and it is simpler to remove that action and force the developer to reenter the flow from the beginning.

3) We use GET parameters to prefill the confirmation code, but the API is exposed as a post endpoint so it is (unlikely but) possible to submit both a POST and GET token. this is explicitly handled to prefer the POST over the get and covered with a test.

### Testing

I'm going to document the entire flow in the issue since there are really a lot of edge cases with this form.

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [X] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
