### PR TITLE
Force collation when comparing Denied Names to avoid unwanted collisions

### DIFF
--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -17,6 +17,7 @@ from django.core import validators
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db import models
 from django.db.models import F, Value
+from django.db.models.functions import Collate
 from django.template import loader
 from django.templatetags.static import static
 from django.urls import reverse
@@ -739,7 +740,9 @@ class DeniedName(ModelBase):
         """
         return (
             DeniedName.objects.annotate(
-                query_field=Value(value, output_field=models.CharField())
+                query_field=Collate(
+                    Value(value, output_field=models.CharField()), 'utf8mb4_0900_ai_ci'
+                )
             )
             .filter(query_field__icontains=F('name'))
             .exists()

--- a/src/olympia/users/tests/test_models.py
+++ b/src/olympia/users/tests/test_models.py
@@ -922,6 +922,14 @@ class TestDeniedName(TestCase):
         assert not DeniedName.blocked('IE6')
         assert not DeniedName.blocked('testo')
 
+    def test_blocked_emoji(self):
+        assert not DeniedName.blocked('Test 🎧')
+        assert not DeniedName.blocked('Test 🌠')
+
+        DeniedName.objects.create(name='🌠')
+        assert not DeniedName.blocked('Test 🎧')
+        assert DeniedName.blocked('Test 🌠')
+
 
 class TestIPNetworkUserRestriction(TestCase):
     def test_str(self):

--- a/src/olympia/users/tests/test_models.py
+++ b/src/olympia/users/tests/test_models.py
@@ -926,9 +926,13 @@ class TestDeniedName(TestCase):
         assert not DeniedName.blocked('Test 🎧')
         assert not DeniedName.blocked('Test 🌠')
 
-        DeniedName.objects.create(name='🌠')
+        denied = DeniedName.objects.create(name='🌠')
         assert not DeniedName.blocked('Test 🎧')
         assert DeniedName.blocked('Test 🌠')
+
+        denied.update(name='🎧')
+        assert DeniedName.blocked('Test 🎧')
+        assert not DeniedName.blocked('Test 🌠')
 
 
 class TestIPNetworkUserRestriction(TestCase):


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/15032

### Context

We are using a default collation of `utf8mb4_general_ci` in tests and in dev/stage/prod (not locally, but that's a different issue... https://github.com/mozilla/addons/issues/1832). With that collation some emojis are considered equal when they shouldn't - QA found 🎧 and 🌠.

We'll want to do a big migration to switch every table and database to `utf8mb4_0900_ai_ci` but in the meantime we force the comparison for denied names (which are a list of admin-set words that are not allowed to be present in collections & user names) to be correct.

### Testing

See unit test. 

If you don't trust the test... you can see the issue for STRs, but since by default we don't specify anything, our local envs already have `utf8mb4_0900_ai_ci` as the default collation when the database and tables are created, so reproducing this bug in a local env is annoying, you need to `ALTER` your database/table to set `utf8mb4_general_ci` instead... Once you do that, you can add the 🎧 emoji to the `DeniedName`s using the admin and try to create a user or collection with a name containing 🌠, it should work (and with 🎧 it should show the denied error message).