### PR TITLE
Tweak file upload limits: bump max uncompressed size, round down max upload size

### DIFF
--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1131,10 +1131,12 @@ MAX_IMAGE_UPLOAD_SIZE = 4 * 1024 * 1024
 MAX_ICON_UPLOAD_SIZE = MAX_IMAGE_UPLOAD_SIZE
 MAX_PHOTO_UPLOAD_SIZE = MAX_IMAGE_UPLOAD_SIZE
 MAX_STATICTHEME_SIZE = 7 * 1024 * 1024
-MAX_ZIP_UNCOMPRESSED_SIZE = 200 * 1024 * 1024
+MAX_ZIP_UNCOMPRESSED_SIZE = 250 * 1024 * 1024
 # Not a Django setting -- needs to be implemented by relevant forms
-# See: validate_review_attachment()
-MAX_UPLOAD_SIZE = 200 * 1024 * 1024
+# See SourceForm, _submit_upload(), validate_review_attachment(), etc. Since it
+# is displayed to users with filesizeformat it should be using powers of 1000
+# to be displayed correctly.
+MAX_UPLOAD_SIZE = 200 * 1000 * 1000
 
 # File uploads should have -rw-r--r-- permissions in order to be served by
 # nginx later one. The 0o prefix is intentional, this is an octal value.


### PR DESCRIPTION
Fixes: mozilla/addons#15093