### PR TITLE
Add require_submissions_enabled decorator to FileUploadViewSet Create

### DIFF
--- a/src/olympia/files/tests/test_views.py
+++ b/src/olympia/files/tests/test_views.py
@@ -120,11 +120,11 @@ class TestFileUploadViewSet(TestCase):
                 HTTP_X_FORWARDED_FOR=f'{ip}, {get_random_ip()}',
             )
         return response
-    
+
     def test_submissions_disabled(self):
         self.create_flag('enable-submissions', note=':-(', everyone=False)
         expected = {
-            'error': 'Submissions are not currently available.',
+            'error': 'Add-on uploads are temporarily unavailable.',
             'reason': ':-(',
         }
         response = self._create_post()

--- a/src/olympia/files/tests/test_views.py
+++ b/src/olympia/files/tests/test_views.py
@@ -120,6 +120,16 @@ class TestFileUploadViewSet(TestCase):
                 HTTP_X_FORWARDED_FOR=f'{ip}, {get_random_ip()}',
             )
         return response
+    
+    def test_submissions_disabled(self):
+        self.create_flag('enable-submissions', note=':-(', everyone=False)
+        expected = {
+            'error': 'Submissions are not currently available.',
+            'reason': ':-(',
+        }
+        response = self._create_post()
+        assert response.status_code == 503
+        assert response.json() == expected
 
     def test_not_authenticated(self):
         self.client.logout_api()

--- a/src/olympia/files/views.py
+++ b/src/olympia/files/views.py
@@ -3,7 +3,6 @@ from django.core.exceptions import PermissionDenied
 from django.utils.crypto import constant_time_compare
 from django.utils.translation import gettext
 
-from olympia.addons.decorators import require_submissions_enabled
 from rest_framework import exceptions, status
 from rest_framework.mixins import CreateModelMixin
 from rest_framework.response import Response
@@ -11,6 +10,7 @@ from rest_framework.viewsets import ReadOnlyModelViewSet
 
 import olympia.core.logger
 from olympia import amo
+from olympia.addons.decorators import require_submissions_enabled
 from olympia.amo.decorators import use_primary_db
 from olympia.amo.utils import HttpResponseXSendFile
 from olympia.api.authentication import (

--- a/src/olympia/files/views.py
+++ b/src/olympia/files/views.py
@@ -3,6 +3,7 @@ from django.core.exceptions import PermissionDenied
 from django.utils.crypto import constant_time_compare
 from django.utils.translation import gettext
 
+from olympia.addons.decorators import require_submissions_enabled
 from rest_framework import exceptions, status
 from rest_framework.mixins import CreateModelMixin
 from rest_framework.response import Response
@@ -72,6 +73,7 @@ class FileUploadViewSet(CreateModelMixin, ReadOnlyModelViewSet):
     def get_queryset(self):
         return super().get_queryset().filter(user=self.request.user)
 
+    @require_submissions_enabled
     def create(self, request):
         if 'upload' in request.FILES:
             filedata = request.FILES['upload']


### PR DESCRIPTION
Fixes: mozilla/addons#1830

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

<!--
Your PR will be squashed when merged so the 1st commit must contain a descriptive and concise summary of the change.
Additional details should be added in the description. If your change is simple enough to summarize in the commit, or
if it is not relevant for your PR, remove this section.
-->

Adds `require_submissions_enabled` decorator to POST `/api/v5/addons/upload`.

### Testing


1. Deactivate the enable-submissions waffle flag (everyone should be = True by default).
3. POST API requests to `/api/v5/addons/upload`. should return a 503.


<!--
Your change must be related to an existing, open issue. This issue should contain testing instructions.
Often, the testing info in the issue is higher level, geared towards a user or QA experience.
Here you can provide information for a developer verifying this PR. Get technical.
If it is not relevant to your PR, remove this section.
-->

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.