### PR TITLE
Modify Button Behaviour When enable-submissions Flag is Disabled

### DIFF
--- a/src/olympia/devhub/templates/devhub/addons/submit/upload.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/upload.html
@@ -94,19 +94,19 @@
     </p>
     {% endif %}
 
-    <div class="submission-buttons addon-submission-field">
+    <div id="submissions" class="submission-buttons addon-submission-field" data-submissions-enabled="{{ submissions_enabled|json }}">
       <button class="addon-upload-dependant" id="submit-upload-file-finish" disabled=disabled type="submit">
         {{ _('Continue') }}
       </button>
+      {% if not submissions_enabled %}
+          <div class="submissions-disabled-error">
+            Add-on uploads are temporarily unavailable.
+            {% if reason %}
+            <span class="tip tooltip" title="{{ reason }}">?</span>
+            {% endif %}
+          </div>
+      {% endif %}
     </div>
   </section>
 </form>
-<span
-  class="hidden"
-  id="submissions"
-  data-submissions-enabled="{{ submissions_enabled|json }}"
-  {% if reason %}
-    data-disabled-reason="{{ reason }}"
-  {% endif %}>
-</span>
 {% endblock primary %}

--- a/src/olympia/devhub/templates/devhub/addons/submit/upload.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/upload.html
@@ -37,10 +37,6 @@
   </p>
   <section
   id="upload-file"
-  data-submissions-enabled="{{ submissions_enabled|json }}"
-  {% if reason %}
-    data-disabled-reason="{{ reason }}"
-  {% endif %}
   >
 
   <div class="hidden">
@@ -107,4 +103,11 @@
     </div>
   </section>
 </form>
+<span
+id="submissions"
+class="hidden"
+data-submissions-enabled="{{ submissions_enabled|json }}"
+{% if reason %}
+  data-disabled-reason="{{ reason }}"
+{% endif %}></span>
 {% endblock primary %}

--- a/src/olympia/devhub/templates/devhub/addons/submit/upload.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/upload.html
@@ -35,7 +35,13 @@
   The maximum file size accepted is {{ max_size }}. If your add-on is larger than {{ max_size }}, it will fail validation.
   {% endtrans %}
   </p>
-  <section id="upload-file">
+  <section
+  id="upload-file"
+  data-submissions-enabled="{{ submissions_enabled|json }}"
+  {% if reason %}
+    data-disabled-reason="{{ reason }}"
+  {% endif %}
+  >
 
   <div class="hidden">
     {{ new_addon_form.upload }}
@@ -51,7 +57,6 @@
     {% endif %}
   {% endif %}
   data-max-upload-size="{{ max_upload_size }}"
-  data-submissions-enabled="{{ submissions_enabled|json }}"
   >
   {{ new_addon_form.theme_specific }}
   {{ new_addon_form.non_field_errors() }}

--- a/src/olympia/devhub/templates/devhub/addons/submit/upload.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/upload.html
@@ -94,7 +94,7 @@
     </p>
     {% endif %}
 
-    <div id="submissions" class="submission-buttons addon-submission-field" data-submissions-enabled="{{ submissions_enabled|json }}">
+    <div id="submission-field" class="submission-buttons addon-submission-field" data-submissions-enabled="{{ submissions_enabled|json }}">
       <button class="addon-upload-dependant" id="submit-upload-file-finish" disabled=disabled type="submit">
         {{ _('Continue') }}
       </button>

--- a/src/olympia/devhub/templates/devhub/addons/submit/upload.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/upload.html
@@ -31,11 +31,12 @@
     Use the fields below to upload your add-on package. After upload, a series
     of automated validation tests will be run on your file.
   {% endtrans %}
-  {% trans max_size=max_upload_size|filesizeformat %}
+  {% trans max_size=mzax_upload_size|filesizeformat %}
   The maximum file size accepted is {{ max_size }}. If your add-on is larger than {{ max_size }}, it will fail validation.
   {% endtrans %}
   </p>
   <section id="upload-file">
+
   <div class="hidden">
     {{ new_addon_form.upload }}
   </div>

--- a/src/olympia/devhub/templates/devhub/addons/submit/upload.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/upload.html
@@ -35,10 +35,7 @@
   The maximum file size accepted is {{ max_size }}. If your add-on is larger than {{ max_size }}, it will fail validation.
   {% endtrans %}
   </p>
-  <section
-  id="upload-file"
-  >
-
+  <section id="upload-file">
   <div class="hidden">
     {{ new_addon_form.upload }}
   </div>
@@ -104,10 +101,11 @@
   </section>
 </form>
 <span
-id="submissions"
-class="hidden"
-data-submissions-enabled="{{ submissions_enabled|json }}"
-{% if reason %}
-  data-disabled-reason="{{ reason }}"
-{% endif %}></span>
+  class="hidden"
+  id="submissions"
+  data-submissions-enabled="{{ submissions_enabled|json }}"
+  {% if reason %}
+    data-disabled-reason="{{ reason }}"
+  {% endif %}>
+</span>
 {% endblock primary %}

--- a/src/olympia/devhub/templates/devhub/addons/submit/upload.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/upload.html
@@ -31,7 +31,7 @@
     Use the fields below to upload your add-on package. After upload, a series
     of automated validation tests will be run on your file.
   {% endtrans %}
-  {% trans max_size=mzax_upload_size|filesizeformat %}
+  {% trans max_size=max_upload_size|filesizeformat %}
   The maximum file size accepted is {{ max_size }}. If your add-on is larger than {{ max_size }}, it will fail validation.
   {% endtrans %}
   </p>

--- a/src/olympia/devhub/templates/devhub/addons/submit/upload.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/upload.html
@@ -98,14 +98,6 @@
       <button class="addon-upload-dependant" id="submit-upload-file-finish" disabled=disabled type="submit">
         {{ _('Continue') }}
       </button>
-      {% if not submissions_enabled %}
-          <div class="submissions-disabled-error">
-            Add-on uploads are temporarily unavailable.
-            {% if reason %}
-            <span class="tip tooltip" title="{{ reason }}">?</span>
-            {% endif %}
-          </div>
-      {% endif %}
     </div>
   </section>
 </form>

--- a/src/olympia/devhub/templates/devhub/addons/submit/wizard.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/wizard.html
@@ -115,14 +115,6 @@
             {% endif %}
             >{{ _('Back') }}
         </button>
-        {% if not submissions_enabled %}
-          <div class="submissions-disabled-error">
-            Add-on uploads are temporarily unavailable.
-            {% if reason %}
-              <span class="tip tooltip" title="{{ reason }}">?</span>
-            {% endif %}
-          </div>
-        {% endif %}
       </div>
     </form>
   </div>

--- a/src/olympia/devhub/templates/devhub/addons/submit/wizard.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/wizard.html
@@ -8,7 +8,12 @@
 
 {% block primary %}
   <h3>{{ _('Theme generator') }}</h3>
-  <div id="theme-wizard" data-version="{{ version_number }}">
+  <div id="theme-wizard" data-version="{{ version_number }}"
+  data-submissions-enabled="{{ submissions_enabled|json }}"
+  {% if reason %}
+    data-disabled-reason="{{ reason }}"
+  {% endif %}
+  >
     {% if unsupported_properties %}
       <div class="notification-box error">
           {{ _('Warning: the following manifest properties that your most recent version '

--- a/src/olympia/devhub/templates/devhub/addons/submit/wizard.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/wizard.html
@@ -96,7 +96,7 @@
       {{ new_addon_form.compatible_apps.errors }}
       {{ new_addon_form.upload.errors }}
       {{ new_addon_form.non_field_errors() }}
-      <div class="submission-buttons addon-submission-field">
+      <div id="submissions" class="submission-buttons addon-submission-field" data-submissions-enabled="{{ submissions_enabled|json }}">
         <button class="button upload"
             {% if addon %}
                 formaction="{{ url('devhub.upload_for_version', addon.slug, channel_param) }}"
@@ -115,15 +115,15 @@
             {% endif %}
             >{{ _('Back') }}
         </button>
+        {% if not submissions_enabled %}
+          <div class="submissions-disabled-error">
+            Add-on uploads are temporarily unavailable.
+            {% if reason %}
+              <span class="tip tooltip" title="{{ reason }}">?</span>
+            {% endif %}
+          </div>
+        {% endif %}
       </div>
     </form>
   </div>
-  <span
-    class="hidden"
-    id="submissions"
-    data-submissions-enabled="{{ submissions_enabled|json }}"
-    {% if reason %}
-      data-disabled-reason="{{ reason }}"
-    {% endif %}>
-  </span>
 {% endblock %}

--- a/src/olympia/devhub/templates/devhub/addons/submit/wizard.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/wizard.html
@@ -9,10 +9,6 @@
 {% block primary %}
   <h3>{{ _('Theme generator') }}</h3>
   <div id="theme-wizard" data-version="{{ version_number }}"
-  data-submissions-enabled="{{ submissions_enabled|json }}"
-  {% if reason %}
-    data-disabled-reason="{{ reason }}"
-  {% endif %}
   >
     {% if unsupported_properties %}
       <div class="notification-box error">
@@ -123,4 +119,11 @@
       </div>
     </form>
   </div>
+  <span
+  id="submissions"
+  class="hidden"
+  data-submissions-enabled="{{ submissions_enabled|json }}"
+  {% if reason %}
+    data-disabled-reason="{{ reason }}"
+  {% endif %}></span>
 {% endblock %}

--- a/src/olympia/devhub/templates/devhub/addons/submit/wizard.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/wizard.html
@@ -96,7 +96,7 @@
       {{ new_addon_form.compatible_apps.errors }}
       {{ new_addon_form.upload.errors }}
       {{ new_addon_form.non_field_errors() }}
-      <div id="submissions" class="submission-buttons addon-submission-field" data-submissions-enabled="{{ submissions_enabled|json }}">
+      <div id="submission-field" class="submission-buttons addon-submission-field" data-submissions-enabled="{{ submissions_enabled|json }}">
         <button class="button upload"
             {% if addon %}
                 formaction="{{ url('devhub.upload_for_version', addon.slug, channel_param) }}"

--- a/src/olympia/devhub/templates/devhub/addons/submit/wizard.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/wizard.html
@@ -8,8 +8,7 @@
 
 {% block primary %}
   <h3>{{ _('Theme generator') }}</h3>
-  <div id="theme-wizard" data-version="{{ version_number }}"
-  >
+  <div id="theme-wizard" data-version="{{ version_number }}">
     {% if unsupported_properties %}
       <div class="notification-box error">
           {{ _('Warning: the following manifest properties that your most recent version '
@@ -120,10 +119,11 @@
     </form>
   </div>
   <span
-  id="submissions"
-  class="hidden"
-  data-submissions-enabled="{{ submissions_enabled|json }}"
-  {% if reason %}
-    data-disabled-reason="{{ reason }}"
-  {% endif %}></span>
+    class="hidden"
+    id="submissions"
+    data-submissions-enabled="{{ submissions_enabled|json }}"
+    {% if reason %}
+      data-disabled-reason="{{ reason }}"
+    {% endif %}>
+  </span>
 {% endblock %}

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -3021,8 +3021,8 @@ class TestSubmissionsDisabledView(TestSubmitBase):
         self.create_flag('enable-submissions', note=':-(', everyone=False)
         url = reverse(viewname, args=args)
         response = self.client.post(url)
-        if assert_status:  
-            assert response.status_code == 503  
+        if assert_status:
+            assert response.status_code == 503
         doc = pq(response.content)
         assert 'Add-on uploads are temporarily unavailable' in doc.text()
         assert ':-(' in doc.html()
@@ -3031,12 +3031,12 @@ class TestSubmissionsDisabledView(TestSubmitBase):
         self, viewname, assert_status=True, args=None
     ):
         args = args or []
-        self._test_submissions_disabled(  
-            viewname, assert_status=assert_status, args=args + ['listed']  
-        )  
-        self._test_submissions_disabled(  
-            viewname, assert_status=assert_status, args=args + ['unlisted']  
-        )  
+        self._test_submissions_disabled(
+            viewname, assert_status=assert_status, args=args + ['listed']
+        )
+        self._test_submissions_disabled(
+            viewname, assert_status=assert_status, args=args + ['unlisted']
+        )
 
     def test_submissions_disabled_submit_details(self):
         self._test_submissions_disabled('devhub.submit.details', args=['a3615'])

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -3016,6 +3016,21 @@ class TestSubmissionsDisabledView(TestSubmitBase):
         addon = self.get_addon()
         self.version = version_factory(addon=addon)
 
+    def _test_submissions_disabled_variables(self, viewname, args=None):
+        args = args or []
+        self.create_flag('enable-submissions', note=':-(', everyone=False)
+        url = reverse(viewname, args=args)
+        response = self.client.post(url)
+        submissionsField = pq(response.content)('#submissions')
+        assert submissionsField
+        assert submissionsField.attr('data-submissions-enabled') == 'false'
+        assert submissionsField.attr('data-disabled-reason') == ':-('
+
+    def _test_submissions_disabled_variables_by_list_type(self, viewname, args=None):
+        args = args or []
+        self._test_submissions_disabled_variables(viewname, args + ['listed'])
+        self._test_submissions_disabled_variables(viewname, args + ['unlisted'])
+
     def _test_submissions_disabled(self, viewname, args=None):
         args = args or []
         self.create_flag('enable-submissions', note=':-(', everyone=False)
@@ -3028,8 +3043,8 @@ class TestSubmissionsDisabledView(TestSubmitBase):
 
     def _test_submissions_disabled_by_list_type(self, viewname, args=None):
         args = args or []
-        self._test_submissions_disabled(viewname, args=args + ['listed'])
-        self._test_submissions_disabled(viewname, args=args + ['unlisted'])
+        self._test_submissions_disabled(viewname, args + ['listed'])
+        self._test_submissions_disabled(viewname, args + ['unlisted'])
 
     def test_submissions_disabled_submit_details(self):
         self._test_submissions_disabled('devhub.submit.details', args=['a3615'])
@@ -3046,3 +3061,9 @@ class TestSubmissionsDisabledView(TestSubmitBase):
         self._test_submissions_disabled(
             'devhub.submit.version.finish', args=[self.addon.slug, self.version.pk]
         )
+
+    def test_submissions_disabled_upload(self):
+        self._test_submissions_disabled_variables_by_list_type('devhub.submit.upload')
+
+    def test_submissions_disabled_wizard(self):
+        self._test_submissions_disabled_variables_by_list_type('devhub.submit.wizard')

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -3043,8 +3043,8 @@ class TestSubmissionsDisabledView(TestSubmitBase):
 
     def _test_submissions_disabled_by_list_type(self, viewname, args=None):
         args = args or []
-        self._test_submissions_disabled(viewname, args + ['listed'])
-        self._test_submissions_disabled(viewname, args + ['unlisted'])
+        self._test_submissions_disabled(viewname, args=args + ['listed'])
+        self._test_submissions_disabled(viewname, args=args + ['unlisted'])
 
     def test_submissions_disabled_submit_details(self):
         self._test_submissions_disabled('devhub.submit.details', args=['a3615'])

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -3016,24 +3016,27 @@ class TestSubmissionsDisabledView(TestSubmitBase):
         addon = self.get_addon()
         self.version = version_factory(addon=addon)
 
-    def _test_submissions_disabled(self, viewname, assertStatus=True, args=None):
+    def _test_submissions_disabled(self, viewname, *, assert_status=True, args=None):
         args = args or []
         self.create_flag('enable-submissions', note=':-(', everyone=False)
         url = reverse(viewname, args=args)
         response = self.client.post(url)
-        assert not assertStatus or response.status_code == 503
+        if assert_status:  
+            assert response.status_code == 503  
         doc = pq(response.content)
-        assert 'Add-on uploads are temporarily unavailable.' in doc.text()
+        assert 'Add-on uploads are temporarily unavailable' in doc.text()
         assert ':-(' in doc.html()
 
     def _test_submissions_disabled_by_list_type(
-        self, viewname, assertStatus=True, args=None
+        self, viewname, assert_status=True, args=None
     ):
         args = args or []
-        self._test_submissions_disabled(viewname, assertStatus, args=args + ['listed'])
-        self._test_submissions_disabled(
-            viewname, assertStatus, args=args + ['unlisted']
-        )
+        self._test_submissions_disabled(  
+            viewname, assert_status=assert_status, args=args + ['listed']  
+        )  
+        self._test_submissions_disabled(  
+            viewname, assert_status=assert_status, args=args + ['unlisted']  
+        )  
 
     def test_submissions_disabled_submit_details(self):
         self._test_submissions_disabled('devhub.submit.details', args=['a3615'])
@@ -3053,10 +3056,10 @@ class TestSubmissionsDisabledView(TestSubmitBase):
 
     def test_submissions_disabled_upload(self):
         self._test_submissions_disabled_by_list_type(
-            'devhub.submit.upload', assertStatus=False
+            'devhub.submit.upload', assert_status=False
         )
 
     def test_submissions_disabled_wizard(self):
         self._test_submissions_disabled_by_list_type(
-            'devhub.submit.wizard', assertStatus=False
+            'devhub.submit.wizard', assert_status=False
         )

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -3018,14 +3018,23 @@ class TestSubmissionsDisabledView(TestSubmitBase):
 
     def _test_submissions_disabled(self, viewname, *, assert_status=True, args=None):
         args = args or []
-        self.create_flag('enable-submissions', note=':-(', everyone=False)
         url = reverse(viewname, args=args)
+
+        self.create_flag('enable-submissions', note=':-(', everyone=False)
         response = self.client.post(url)
         if assert_status:
             assert response.status_code == 503
         doc = pq(response.content)
         assert 'Add-on uploads are temporarily unavailable' in doc.text()
         assert ':-(' in doc.html()
+
+        self.create_flag('enable-submissions', note='', everyone=False)
+        response = self.client.post(url)
+        if assert_status:
+            assert response.status_code == 503
+        doc = pq(response.content)
+        assert 'Add-on uploads are temporarily unavailable.' in doc.text()
+        assert ':-(' not in doc.html()
 
     def _test_submissions_disabled_by_list_type(
         self, viewname, assert_status=True, args=None

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -3026,10 +3026,14 @@ class TestSubmissionsDisabledView(TestSubmitBase):
         assert 'Add-on uploads are temporarily unavailable.' in doc.text()
         assert ':-(' in doc.html()
 
-    def _test_submissions_disabled_by_list_type(self, viewname, assertStatus=True, args=None):
+    def _test_submissions_disabled_by_list_type(
+        self, viewname, assertStatus=True, args=None
+    ):
         args = args or []
         self._test_submissions_disabled(viewname, assertStatus, args=args + ['listed'])
-        self._test_submissions_disabled(viewname, assertStatus, args=args + ['unlisted'])
+        self._test_submissions_disabled(
+            viewname, assertStatus, args=args + ['unlisted']
+        )
 
     def test_submissions_disabled_submit_details(self):
         self._test_submissions_disabled('devhub.submit.details', args=['a3615'])
@@ -3048,7 +3052,11 @@ class TestSubmissionsDisabledView(TestSubmitBase):
         )
 
     def test_submissions_disabled_upload(self):
-        self._test_submissions_disabled_by_list_type('devhub.submit.upload', assertStatus=False)
+        self._test_submissions_disabled_by_list_type(
+            'devhub.submit.upload', assertStatus=False
+        )
 
     def test_submissions_disabled_wizard(self):
-        self._test_submissions_disabled_by_list_type('devhub.submit.wizard', assertStatus=False)
+        self._test_submissions_disabled_by_list_type(
+            'devhub.submit.wizard', assertStatus=False
+        )

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -1614,7 +1614,7 @@ def _submit_upload(
             'wizard_url': wizard_url,
             'max_upload_size': settings.MAX_UPLOAD_SIZE,
             'submissions_enabled': flag.is_active(request),
-            'reason': flag.note if hasattr(flag, 'note') else None
+            'reason': flag.note if hasattr(flag, 'note') else None,
         },
     )
 

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -1574,7 +1574,19 @@ def _submit_upload(
         if existing_properties
         else []
     )
-    submit_notification_warning = get_config('submit_notification_warning')
+
+    flag = waffle.get_waffle_flag_model().get('enable-submissions')
+    warning = (
+        'Add-on uploads are temporarily unavailable' + ': ' + flag.note
+        if hasattr(flag, 'note')
+        else '.'
+    )
+
+    submit_notification_warning = (
+        warning
+        if not flag.is_active(request)
+        else get_config('submit_notification_warning')
+    )
     if not submit_notification_warning and addon:
         # If we're not showing the generic submit notification warning, show
         # one specific to pre review if the developer would be affected because
@@ -1594,7 +1606,7 @@ def _submit_upload(
         wizard_url = reverse('devhub.submit.wizard', args=[channel_text])
     else:
         wizard_url = None
-    flag = waffle.get_waffle_flag_model().get('enable-submissions')
+
     return TemplateResponse(
         request,
         template,
@@ -1614,7 +1626,6 @@ def _submit_upload(
             'wizard_url': wizard_url,
             'max_upload_size': settings.MAX_UPLOAD_SIZE,
             'submissions_enabled': flag.is_active(request),
-            'reason': flag.note if hasattr(flag, 'note') else None,
         },
     )
 

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -1574,14 +1574,12 @@ def _submit_upload(
         if existing_properties
         else []
     )
-
     flag = waffle.get_waffle_flag_model().get('enable-submissions')
     warning = (
         'Add-on uploads are temporarily unavailable' + ': ' + flag.note
         if hasattr(flag, 'note')
         else '.'
     )
-
     submit_notification_warning = (
         warning
         if not flag.is_active(request)
@@ -1606,7 +1604,6 @@ def _submit_upload(
         wizard_url = reverse('devhub.submit.wizard', args=[channel_text])
     else:
         wizard_url = None
-
     return TemplateResponse(
         request,
         template,

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -1575,10 +1575,8 @@ def _submit_upload(
         else []
     )
     flag = waffle.get_waffle_flag_model().get('enable-submissions')
-    warning = (
-        'Add-on uploads are temporarily unavailable' + ': ' + flag.note
-        if hasattr(flag, 'note')
-        else '.'
+    warning = gettext('Add-on uploads are temporarily unavailable') + (
+        ': ' + flag.note if getattr(flag, 'note', None) else '.'
     )
     submit_notification_warning = (
         warning

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -1594,6 +1594,7 @@ def _submit_upload(
         wizard_url = reverse('devhub.submit.wizard', args=[channel_text])
     else:
         wizard_url = None
+    flag = waffle.get_waffle_flag_model().get('enable-submissions')
     return TemplateResponse(
         request,
         template,
@@ -1612,7 +1613,8 @@ def _submit_upload(
             'version_number': get_next_version_number(addon) if wizard else None,
             'wizard_url': wizard_url,
             'max_upload_size': settings.MAX_UPLOAD_SIZE,
-            'submissions_enabled': waffle.flag_is_active(request, 'enable-submissions'),
+            'submissions_enabled': flag.is_active(request),
+            'reason': flag.note if hasattr(flag, 'note') else None
         },
     )
 

--- a/static/css/zamboni/developers.css
+++ b/static/css/zamboni/developers.css
@@ -427,10 +427,6 @@ form .char-count b {
     margin-bottom: 1em;
 }
 
-div.addon-submission-field .submissions-disabled-error {
-    padding: 1em 0em;
-}
-
 .clear-info-request label {
     font-weight: normal;
 }

--- a/static/css/zamboni/developers.css
+++ b/static/css/zamboni/developers.css
@@ -425,6 +425,10 @@ form .char-count b {
 
 .addon-submission-process form div.addon-submission-field {
     margin-bottom: 1em;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1em;
 }
 
 .clear-info-request label {

--- a/static/css/zamboni/developers.css
+++ b/static/css/zamboni/developers.css
@@ -425,10 +425,10 @@ form .char-count b {
 
 .addon-submission-process form div.addon-submission-field {
     margin-bottom: 1em;
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 1em;
+}
+
+div.addon-submission-field .submissions-disabled-error {
+    padding: 1em 0em;
 }
 
 .clear-info-request label {

--- a/static/js/common/upload-addon.js
+++ b/static/js/common/upload-addon.js
@@ -80,8 +80,8 @@
           text: gettext('Your add-on should end with .zip, .xpi or .crx'),
         });
 
-      ui_link.toggleClass('disabled', submissionsDisabled);
-      $upload_field.prop('disabled', submissionsDisabled);
+      ui_link.toggleClass('disabled', settings.submissionsDisabled);
+      $upload_field.prop('disabled', settings.submissionsDisabled);
 
       $upload_field.wrap(ui_parent);
       $upload_field.before(ui_link);

--- a/static/js/common/upload-addon.js
+++ b/static/js/common/upload-addon.js
@@ -36,6 +36,7 @@
       getErrors: getErrors,
       cancel: $(),
       maxSize: null, // Dynamically set by devhub.js
+      submissionsDisabled: false,
     };
 
     if (options) {
@@ -79,16 +80,8 @@
           text: gettext('Your add-on should end with .zip, .xpi or .crx'),
         });
 
-      const submissionsDisabled = !$(this).data('submissions-enabled');
       ui_link.toggleClass('disabled', submissionsDisabled);
       $upload_field.prop('disabled', submissionsDisabled);
-
-      $upload_field.attr(
-        'title',
-        submissionsDisabled
-          ? gettext('Add-on uploads are temporarily unavailable.')
-          : $upload_field.attr('title'),
-      );
 
       $upload_field.wrap(ui_parent);
       $upload_field.before(ui_link);

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -48,7 +48,7 @@ $(document).ready(function () {
   });
 
   // disable buttons if submission is disabled
-  const submissionField = $('#submissions');
+  const submissionField = $('#submission-field');
   const submissionsDisabled =
     submissionField && !submissionField.data('submissions-enabled');
   $('.submission-buttons .button').toggleClass('disabled', submissionsDisabled);

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -48,14 +48,23 @@ $(document).ready(function () {
   });
 
   // disable buttons if submission is disabled
-  const submissionsDisabled = !$('#upload-file').data('submissions-enabled');
-  const reason = $('#upload-file').data('disabled-reason');
-  
+
+  // if upload-file exists
+
+  const submissionField = $('#submissions');
+  const submissionsDisabled =
+    submissionField && !submissionField.data('submissions-enabled');
+  const reason = submissionField.data('disabled-reason');
+
   $('.submission-buttons .button').toggleClass('disabled', submissionsDisabled);
-  const error = $('<div>').text(gettext('Add-on uploads are temporarily unavailable.'))
-  const tooltip = $('<span>?</span>').addClass('tip tooltip').attr('title', reason);
+  const error = $('<div>')
+    .addClass('submissions-disabled-error')
+    .text(gettext('Add-on uploads are temporarily unavailable.'));
+  const tooltip = $('<span>?</span>')
+    .addClass('tip tooltip')
+    .attr('title', reason);
   reason && error.append(tooltip);
-  submissionsDisabled && $('.addon-submission-field').append(error)
+  submissionsDisabled && $('.addon-submission-field').append(error);
 
   // Add-on uploader
   var $uploadAddon = $('#upload-addon');
@@ -63,7 +72,7 @@ $(document).ready(function () {
     var opt = {
       cancel: $('.upload-file-cancel'),
       maxSize: $uploadAddon.data('max-upload-size'),
-      submissionsDisabled
+      submissionsDisabled,
     };
     opt.appendFormData = function (formData) {
       if ($('#addon-compat-upload').length) {

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -48,9 +48,6 @@ $(document).ready(function () {
   });
 
   // disable buttons if submission is disabled
-
-  // if upload-file exists
-
   const submissionField = $('#submissions');
   const submissionsDisabled =
     submissionField && !submissionField.data('submissions-enabled');

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -47,12 +47,23 @@ $(document).ready(function () {
     initUploadPreview();
   });
 
+  // disable buttons if submission is disabled
+  const submissionsDisabled = !$('#upload-file').data('submissions-enabled');
+  const reason = $('#upload-file').data('disabled-reason');
+  
+  $('.submission-buttons .button').toggleClass('disabled', submissionsDisabled);
+  const error = $('<div>').text(gettext('Add-on uploads are temporarily unavailable.'))
+  const tooltip = $('<span>?</span>').addClass('tip tooltip').attr('title', reason);
+  reason && error.append(tooltip);
+  submissionsDisabled && $('.addon-submission-field').append(error)
+
   // Add-on uploader
   var $uploadAddon = $('#upload-addon');
   if ($('#upload-addon').length) {
     var opt = {
       cancel: $('.upload-file-cancel'),
       maxSize: $uploadAddon.data('max-upload-size'),
+      submissionsDisabled
     };
     opt.appendFormData = function (formData) {
       if ($('#addon-compat-upload').length) {

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -51,17 +51,8 @@ $(document).ready(function () {
   const submissionField = $('#submissions');
   const submissionsDisabled =
     submissionField && !submissionField.data('submissions-enabled');
-  const reason = submissionField.data('disabled-reason');
 
-  $('.submission-buttons .button').toggleClass('disabled', submissionsDisabled);
-  const error = $('<div>')
-    .addClass('submissions-disabled-error')
-    .text(gettext('Add-on uploads are temporarily unavailable.'));
-  const tooltip = $('<span>?</span>')
-    .addClass('tip tooltip')
-    .attr('title', reason);
-  reason && error.append(tooltip);
-  submissionsDisabled && $('.addon-submission-field').append(error);
+  // $('.submission-buttons .button').toggleClass('disabled', submissionsDisabled);
 
   // Add-on uploader
   var $uploadAddon = $('#upload-addon');

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -51,8 +51,7 @@ $(document).ready(function () {
   const submissionField = $('#submissions');
   const submissionsDisabled =
     submissionField && !submissionField.data('submissions-enabled');
-
-  // $('.submission-buttons .button').toggleClass('disabled', submissionsDisabled);
+  $('.submission-buttons .button').toggleClass('disabled', submissionsDisabled);
 
   // Add-on uploader
   var $uploadAddon = $('#upload-addon');


### PR DESCRIPTION
Fixes: mozilla/addons#15090

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description
when `enable-submissions` is disabled, now:
1. Disables the 'create a theme' button 
2. Addon submission buttons are disabled and a warning is displayed banner style with the flag note (if any).


![image](https://github.com/user-attachments/assets/c01c7f46-621b-4ac1-8bfb-fdc725f93661)

![image](https://github.com/user-attachments/assets/3c0fe129-7be9-4ad2-915f-cdb11c127823)

<!--
Your PR will be squashed when merged so the 1st commit must contain a descriptive and concise summary of the change.
Additional details should be added in the description. If your change is simple enough to summarize in the commit, or
if it is not relevant for your PR, remove this section.
-->

### Testing
1. Deactivate the `enable-submissions` waffle flag (everyone should be = `True` by default).
2. User should be unable to make new submissions and warned via the disabled button.


### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
