### PR TITLE
Better pruning of docker volumes during make up/down

### DIFF
--- a/Makefile-os
+++ b/Makefile-os
@@ -130,8 +130,11 @@ docker_compose_down: ## Stop the docker containers
 	docker compose down --rmi local --remove-orphans --volumes
 
 .PHONY: docker_clean_volumes
-docker_clean_volumes: ## Remove dangling volumes
-	docker volume prune --force
+docker_clean_volumes: ## Remove dangling volumes, skipping the mysqld volume
+	docker volume prune \
+		--filter label=com.docker.compose.project=addons-server \
+		--all \
+		--force
 
 .PHONY: docker_clean_images
 docker_clean_images: ## Remove dangling images

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -9,5 +9,3 @@ services:
     extends:
       service: worker
 
-volumes:
-  data_olympia:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,12 +52,11 @@ services:
       "celery -A olympia.amo.celery:app worker -E -c 2 --loglevel=INFO",
     ]
     volumes:
-      - data_olympia:/data/olympia
+      - .:/data/olympia
       # Don't mount generated files. They only exist in the container
-      # and would otherwiser be deleted by mounbting data_olympia
+      # and would otherwiser be deleted by mounting the cwd volume above
       - /data/olympia/static-build
       - /data/olympia/site-static
-      - storage:/data/olympia/storage
       - ./package.json:/deps/package.json
       - ./package-lock.json:/deps/package-lock.json
     extra_hosts:
@@ -99,8 +98,7 @@ services:
     image: nginx
     volumes:
       - ./docker/nginx/addons.conf:/etc/nginx/conf.d/addons.conf
-      - ./static:/srv/static
-      - storage:/srv/user-media
+      - .:/srv
     ports:
       - "80:80"
     networks:
@@ -143,13 +141,9 @@ services:
       - "discovery.type=single-node"
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     mem_limit: 2g
-    volumes:
-      - data_elasticsearch:/usr/share/elasticsearch/data
 
   redis:
     image: redis:6.2
-    volumes:
-      - data_redis:/data
 
   rabbitmq:
     image: rabbitmq:3.12
@@ -160,8 +154,6 @@ services:
       - RABBITMQ_DEFAULT_USER=olympia
       - RABBITMQ_DEFAULT_PASS=olympia
       - RABBITMQ_DEFAULT_VHOST=olympia
-    volumes:
-      - data_rabbitmq:/var/lib/rabbitmq
 
   autograph:
     image: mozilla/autograph:3.3.2
@@ -191,23 +183,8 @@ networks:
   default:
 
 volumes:
-  data_redis:
-  data_elasticsearch:
   data_mysqld:
     # Keep this value in sync with Makefile-os
     # External volumes must be manually created/destroyed
     name: addons-server_data_mysqld
     external: true
-  data_rabbitmq:
-  data_olympia:
-    driver: local
-    driver_opts:
-      type: none
-      o: bind
-      device: ${PWD}
-  storage:
-    driver: local
-    driver_opts:
-      type: none
-      o: bind
-      device: ./storage

--- a/docker/nginx/addons.conf
+++ b/docker/nginx/addons.conf
@@ -20,7 +20,7 @@ server {
     }
 
     location /user-media/ {
-        alias /srv/user-media/shared_storage/uploads/;
+        alias /srv/storage/shared_storage/uploads/;
     }
 
     location ~ ^/api/ {


### PR DESCRIPTION
Relates to: mozilla/addons#15119
Relates to: mozilla/addons#15046

### Description

Remove many totally unnecessary docker volumes and simplifies the management of others.

### Context

There is a recently squashed upstream bug in docker where (supposed to be) anonymous volumes are not labelled correctly, causing our various docker commands to leave behind anonymous looking volumes. Over time these volumes pile up and result in out of storage errors and general slowness of docker.

This PR originally tried to address that issue but instead simply addresses the volume mount concurrency problem and reduces the surface area of the space problem by reducing the number of volumes our project depends on.

### Testing

### Make UP

Create an anonyomous dangling volumne

```bash
docker volume create
```

> Note the hash name of the volume

Now run `make up` to ensure your containers and non dangling volumes are running.

```bash
make docker_clean_volumes
```

Expect that the volume you created is not destroyed, neither are any of the running container volumes

```bash
make down
```

This should remove anonymous volumes that were created when running make up, but should not remove the volume you created initially.

Bonus: Rerunning `make docker_clean_volumes` after running make down should either do nothing (if all volumes were cleaned up already) or remove any project associated anonymous volumes. Again, you original volume from the top should still be there.

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
