### PR TITLE
Make growth threshold before flagging relative instead of absolute

### DIFF
--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -4,7 +4,7 @@ import os
 
 from django.core.files.storage import default_storage as storage
 from django.db import transaction
-from django.db.models import Q, Value
+from django.db.models import Avg, Q, Value
 from django.db.models.functions import Collate
 
 from elasticsearch_dsl import Search
@@ -535,20 +535,31 @@ def flag_high_hotness_according_to_review_tier():
         # Need a hotness threshold to be set for the tier.
         growth_threshold_before_flagging__isnull=False,
     )
-    tier_filters = Q()
-    for usage_tier in usage_tiers:
-        tier_filters |= Q(
-            average_daily_users__gte=usage_tier.lower_adu_threshold,
-            average_daily_users__lt=usage_tier.upper_adu_threshold,
-            hotness__gte=usage_tier.growth_threshold_before_flagging / 100,
-        )
-    if not tier_filters:
-        return
-    qs = (
-        Addon.unfiltered.exclude(status=amo.STATUS_DISABLED)
-        .filter(type=amo.ADDON_EXTENSION)
-        .filter(tier_filters)
+    base_qs = Addon.unfiltered.exclude(status=amo.STATUS_DISABLED).filter(
+        type=amo.ADDON_EXTENSION
     )
+    hotness_per_tier_filters = Q()
+    for usage_tier in usage_tiers:
+        tier_filters = {
+            'average_daily_users__gte': usage_tier.lower_adu_threshold,
+            'average_daily_users__lt': usage_tier.upper_adu_threshold,
+        }
+        mean_hotness_in_tier = (
+            base_qs.filter(**tier_filters)
+            .aggregate(Avg('hotness', default=0))
+            .get('hotness__avg')
+        )
+        if not mean_hotness_in_tier:
+            continue
+        hotness_ceiling_before_flagging = mean_hotness_in_tier * (
+            1 + usage_tier.growth_threshold_before_flagging / 100
+        )
+        hotness_per_tier_filters |= Q(
+            hotness__gt=hotness_ceiling_before_flagging, **tier_filters
+        )
+    if not hotness_per_tier_filters:
+        return
+    qs = base_qs.filter(hotness_per_tier_filters)
     NeedsHumanReview.set_on_addons_latest_signed_versions(
         qs, NeedsHumanReview.REASONS.HOTNESS_THRESHOLD
     )

--- a/src/olympia/addons/tests/test_tasks.py
+++ b/src/olympia/addons/tests/test_tasks.py
@@ -267,13 +267,13 @@ def test_flag_high_hotness_according_to_review_tier():
         name='B tier',
         lower_adu_threshold=200,
         upper_adu_threshold=250,
-        growth_threshold_before_flagging=20,
+        growth_threshold_before_flagging=35,
     )
     UsageTier.objects.create(
         name='A tier',
         lower_adu_threshold=250,
         upper_adu_threshold=1000,
-        growth_threshold_before_flagging=30,
+        growth_threshold_before_flagging=20,
     )
     UsageTier.objects.create(
         name='S tier (no upper threshold)',
@@ -300,9 +300,9 @@ def test_flag_high_hotness_according_to_review_tier():
             average_daily_users=200,
             hotness=0.3,
         ),
-        # Belongs to A tier but below the growth threshold.
+        # Belongs to A tier but hotness below the average + threshold.
         addon_factory(
-            name='A tier below threshold', average_daily_users=250, hotness=0.2
+            name='A tier below threshold', average_daily_users=250, hotness=0.3
         ),
         # Belongs to S tier, which doesn't have an upper threshold. (like
         # notable, subject to human review anyway)
@@ -324,7 +324,7 @@ def test_flag_high_hotness_according_to_review_tier():
         # Belongs to B tier but already flagged for human review for growth
         # (see below).
         addon_factory(
-            name='B tier already flagged', average_daily_users=200, hotness=0.3
+            name='B tier already flagged', average_daily_users=200, hotness=0.2
         ),
     ]
     NeedsHumanReview.objects.create(
@@ -332,10 +332,14 @@ def test_flag_high_hotness_according_to_review_tier():
     )
 
     flagged = [
-        addon_factory(name='B tier', average_daily_users=200, hotness=0.3),
-        addon_factory(name='A tier', average_daily_users=250, hotness=0.3),
+        # B tier average hotness should be 0.325, with a threshold of 35, so
+        # Add-ons with a hotness over 0.43875000000000003 should be flagged.
+        addon_factory(name='B tier', average_daily_users=200, hotness=0.44),
+        # A tier average hotness should be 0.375, with a threshold of 20, so
+        # Add-ons with a hotness over 0.44999999999999996 should be flagged.
+        addon_factory(name='A tier', average_daily_users=250, hotness=0.45),
         addon_factory(
-            name='A tier with inactive flags', average_daily_users=250, hotness=0.3
+            name='A tier with inactive flags', average_daily_users=250, hotness=0.45
         ),
     ]
 


### PR DESCRIPTION
`growth_threshold_before_flagging` for a given `UsageTier` is now relative to the average growth of all non-disabled add-ons in that usage tier.

Fixes mozilla/addons#15049

### Testing

Play around with the unit test or locally. As you can see in the patch `UsageTier` has `lower_adu_threshold` and `upper_adu_threshold` fields governing which add-ons it targets, and then `growth_threshold_before_flagging` is now relative to the average `hotness` of all extensions in that tier. `growth_threshold_before_flagging` is still a percentage though, and needs to be converted back to a float when comparing.

So, a simplistic case is to have `Addon(average_daily_users=102, hotness=0.3)`, `Addon(average_daily_users=102, hotness=0.2)`, `UsageTier(lower_adu_threshold=100, upper_adu_threshold=1000, growth_threshold_before_flagging=1)`: Before the changes, this would have flagged both add-ons for having their `hotness` over `0.01` (`1/100`). Now, it should only flag the first one for being over `0.26` (`(0.3+0.2)/2 + 1/100`).

Flagging will result in an `active` `NeedsHumanReview` instance on the add-on latest versions in both channels with `REASONS.HOTNESS_THRESHOLD` reason.