### PR TITLE
Optimize number of queries made by devhub version list view & display block status

### DIFF
--- a/src/olympia/blocklist/models.py
+++ b/src/olympia/blocklist/models.py
@@ -15,6 +15,7 @@ from olympia.addons.models import Addon
 from olympia.amo.models import BaseQuerySet, ManagerBase, ModelBase
 from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.amo.utils import chunked
+from olympia.constants.blocklist import BLOCK_TYPE_END_USERS_CHOICES
 from olympia.users.models import UserProfile
 from olympia.versions.models import Version
 
@@ -170,6 +171,10 @@ class BlockVersion(ModelBase):
             f'Block.id={self.block_id} ({self.get_soft_display()}) '
             f'-> Version.id={self.version_id}'
         )
+
+    def get_user_facing_block_type_display(self):
+        """Like get_soft_display(), but using strings meant for end-users."""
+        return BLOCK_TYPE_END_USERS_CHOICES.for_value(int(self.soft)).display
 
 
 class BlocklistSubmissionQuerySet(BaseQuerySet):

--- a/src/olympia/constants/blocklist.py
+++ b/src/olympia/constants/blocklist.py
@@ -1,3 +1,8 @@
+from django.utils.translation import gettext_lazy as _
+
+from extended_choices import Choices
+
+
 # How many guids should there be in the stashes before we make a new base.
 BASE_REPLACE_THRESHOLD = 5_000
 
@@ -6,3 +11,10 @@ MLBF_TIME_CONFIG_KEY = 'blocklist_mlbf_generation_time'
 MLBF_BASE_ID_CONFIG_KEY = 'blocklist_mlbf_base_id'
 
 REMOTE_SETTINGS_COLLECTION_MLBF = 'addons-bloomfilters'
+
+
+# As BlockVersion.BLOCK_TYPE_CHOICES except meant to be exposed to end-users.
+BLOCK_TYPE_END_USERS_CHOICES = Choices(
+    ('BLOCKED', 0, _('Blocked')),
+    ('SOFT_BLOCKED', 1, _('Restricted')),
+)

--- a/src/olympia/devhub/templates/devhub/versions/list.html
+++ b/src/olympia/devhub/templates/devhub/versions/list.html
@@ -46,7 +46,17 @@
     </td>
     <td class="file-status">
       <div>
-        {{ distro_tag(version.channel)}} {{ version.file.get_status_display() }}
+        {{ distro_tag(version.channel)}}
+        <span class="file-status-text">
+          {% if version.file.status == amo.STATUS_DISABLED and version.is_blocked %}
+            {# Slight optimization: don't try getting blocked status for
+               non-disabled versions - this avoids checking if for latest/current
+               versions, which are fetched without a select_related('blockversion') #}
+            {{ version.blockversion.get_user_facing_block_type_display() }}
+          {% else %}
+            {{ version.file.get_status_display() }}
+          {% endif %}
+        </span>
       </div>
       {% if version.is_user_disabled %}
         <div>
@@ -87,7 +97,7 @@
          data-is-current="{{ (version == addon.current_version)|int }}">x</a>
     </td>
   </tr>
-  {% if full_info and version.channel == amo.CHANNEL_LISTED and (can_request_review or can_cancel) and check_addon_ownership(request.user, addon, allow_developer=True) %}
+  {% if full_info and version.channel == amo.CHANNEL_LISTED and (can_request_review or can_cancel) %}
     <tr>
       <td colspan="0" class="version-status-actions item-actions">
         {% if can_request_review %}
@@ -148,9 +158,8 @@
     <h3>{{ distro_tag(amo.CHANNEL_LISTED)}} {{ _('Listing visibility') }}</h3>
     <div class="item" id="addon-current-state">
       <div class="item_wrapper">
-        {% set owner = check_addon_ownership(request.user, addon, allow_developer=True) %}
         <label><input name="addon-state" value="listed" type="radio"
-                    {% if not owner or addon.status == amo.STATUS_DISABLED %}disabled="disabled"{% endif %}
+                    {% if addon.status == amo.STATUS_DISABLED %}disabled="disabled"{% endif %}
                     {% if not addon.is_disabled %}checked="checked"{% endif %}
                     data-url="{{ addon.get_dev_url('enable') }}"
                     class="enable-addon">
@@ -159,7 +168,7 @@
              label_open='<strong>'|safe, label_close='</strong>'|safe, site_url=settings.SITE_URL)|safe }}</label>
         <br>
         <label><input name="addon-state" value="hidden" type="radio"
-                    {% if not owner %}disabled="disabled"{% endif %}
+                    {% if addon.status == amo.STATUS_DISABLED %}disabled="disabled"{% endif %}
                     {% if addon.is_disabled %}checked="checked"{% endif %}
                     class="disable-addon">
         {{ _("{label_open}Invisible:{label_close} Won't be included in search results, and its product page will "
@@ -212,7 +221,7 @@
   <div class="item" id="version-list"
        data-stats="{{ url('devhub.versions.stats', addon.slug) }}">
     <div class="item_wrapper">
-      {% if check_addon_ownership(request.user, addon, allow_developer=True) and addon.status != amo.STATUS_DISABLED %}{# i.e. Admin disabled #}
+      {% if can_submit %}
       <div>
         {% set version_upload_url = url('devhub.submit.version', addon.slug) %}
         <a href="{{ version_upload_url }}" class="button version-upload">{{ _('Upload a New Version') }}</a>
@@ -239,7 +248,7 @@
       </div>
     {% endif %}
   </div>
-  {% if check_addon_ownership(request.user, addon) and addon.can_be_deleted() %}
+  {% if addon.can_be_deleted() %}
   <h3>{{ _('Delete Add-on') }}</h3>
   <div class="item" id="addon-delete-listing">
     <div class="item_wrapper">

--- a/src/olympia/devhub/templates/devhub/versions/list.html
+++ b/src/olympia/devhub/templates/devhub/versions/list.html
@@ -248,7 +248,8 @@
       </div>
     {% endif %}
   </div>
-  {% if addon.can_be_deleted() %}
+  {# Checks for an actual owner, not just a developer #}
+  {% if check_addon_ownership(request.user, addon) and addon.can_be_deleted() %}
   <h3>{{ _('Delete Add-on') }}</h3>
   <div class="item" id="addon-delete-listing">
     <div class="item_wrapper">

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -702,7 +702,7 @@ class TestVersion(TestCase):
             amo.LOG.REVIEWER_REPLY_VERSION, v2.addon, v2, user=self.user
         )
 
-        with self.assertNumQueries(36):
+        with self.assertNumQueries(37):
             # 1. SAVEPOINT
             # 2. the add-on
             # 3. translations for that add-on (default transformer)
@@ -736,10 +736,11 @@ class TestVersion(TestCase):
             # 30. latest non-disabled version
             # 31. translations for that version
             # 32. are there versions in unlisted channel
-            # 33. versions in unlisted channel
-            # 34. translations for those versions
-            # 35. latest non-disabled version in unlisted channel
-            # 36. check on user being an author (dupe)
+            # 33. check on user being an owner
+            # 34. versions in unlisted channel
+            # 35. translations for those versions
+            # 36. latest non-disabled version in unlisted channel
+            # 37. check on user being an author (dupe)
             response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -3,6 +3,7 @@ import zipfile
 from datetime import datetime, timedelta
 from unittest import mock
 
+from django.conf import settings
 from django.core import mail
 from django.core.files import temp
 from django.core.files.base import File as DjangoFile
@@ -17,6 +18,7 @@ from olympia.addons.models import Addon
 from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.amo.tests import (
     TestCase,
+    block_factory,
     create_default_webext_appversion,
     formset,
     initial,
@@ -75,6 +77,34 @@ class TestVersion(TestCase):
         self.addon.update(status=amo.STATUS_APPROVED, disabled_by_user=True)
         doc = self.get_doc()
         assert doc('.addon-status .status-disabled').text() == ('Invisible')
+
+    def test_blocked_version(self):
+        task_user = UserProfile.objects.get(pk=settings.TASK_USER_ID)
+        v3 = version_factory(addon=self.addon, version='3.0')
+        v4 = version_factory(addon=self.addon, version='4.0.1')
+        block_factory(version_ids=[v3.pk, v4.pk], updated_by=task_user)
+        for version in (v3, v4):
+            version.file.update(status=amo.STATUS_DISABLED)
+        doc = self.get_doc()
+        assert (
+            doc('#version-list .file-status-text')[0].text_content().strip()
+            == 'Blocked'
+        )
+        assert (
+            doc('#version-list .file-status-text')[1].text_content().strip()
+            == 'Blocked'
+        )
+
+        v4.blockversion.update(soft=True)
+        doc = self.get_doc()
+        assert (
+            doc('#version-list .file-status-text')[0].text_content().strip()
+            == 'Restricted'
+        )
+        assert (
+            doc('#version-list .file-status-text')[1].text_content().strip()
+            == 'Blocked'
+        )
 
     def test_label_open_marked_safe(self):
         doc = self.get_doc()
@@ -672,9 +702,7 @@ class TestVersion(TestCase):
             amo.LOG.REVIEWER_REPLY_VERSION, v2.addon, v2, user=self.user
         )
 
-        with self.assertNumQueries(43):
-            # FIXME: lots of optimizations left to do. That count shouldn't go
-            # higher.
+        with self.assertNumQueries(36):
             # 1. SAVEPOINT
             # 2. the add-on
             # 3. translations for that add-on (default transformer)
@@ -689,35 +717,29 @@ class TestVersion(TestCase):
             # 12. check on user being an author
             # 13. count versions for the add-on for pagination
             # 14. RELEASE SAVEPOINT
-            # 15. Add-ons for that user
-            # 16. Latest version in listed channel
-            # 17. Translations for that version
-            # 18. Latest version in unlisted channel
-            # 19. Latest public version in listed channel
+            # 15. add-ons for that user
+            # 16. latest version in listed channel
+            # 17. translations for that version
+            # 18. latest version in unlisted channel
+            # 19. latest public version in listed channel
             # 20. Translations for that version
             # 21. check on user being an author (dupe)
             # 22. site notice
             # 23. suppressed email waffle switch check
             # 24. 8 latest add-ons from that user for the menu
             # 25. translations for those add-ons
-            # 26. authors for those add-ons
-            # 27. count of pending activities on latest version
-            # 28. file validation for that latest version
-            # 29. is add-on promoted (for deletion warning)
-            # 30. check on user being an author (dupe)
-            # 31. versions being displayed w/ pending activities count and file attached
-            # 32. translations for those versions
-            # 33. applications versions for those versions
-            # 34. file validation
-            # 35. file validation (other version)
+            # 26. count of pending activities on latest version
+            # 27. file validation for that latest version
+            # 28. is add-on promoted (for deletion warning)
+            # 29. versions being displayed w/ pending activities count and
+            #     file/validation/blockversion attached
+            # 30. latest non-disabled version
+            # 31. translations for that version
+            # 32. are there versions in unlisted channel
+            # 33. versions in unlisted channel
+            # 34. translations for those versions
+            # 35. latest non-disabled version in unlisted channel
             # 36. check on user being an author (dupe)
-            # 37. latest non-disabled version
-            # 38. translations for that version
-            # 39. are there versions in unlisted channel
-            # 40. versions in unlisted channel
-            # 41. translations for those versions
-            # 42. latest non-disabled version in unlisted channel
-            # 43. check on user being an author (dupe)
             response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)


### PR DESCRIPTION
Fixes mozilla/addons#15037
Fixes mozilla/addons#15017

### Description

This replaces "Disabled by Mozilla" by "Blocked"/"Restricted" in devhub versions list, and optimizes queries made by that view as a drive-by (I was already in the neighborhood and was changing the test anyway...)

### Testing

Unit test, or play with blocks on versions that you have locally. Note that technically one can force a block without having the version disabled, but I figured this was an edge case not worth worrying about, that saves us a couple database queries that way because we are re-using the macro for various versions that are fetched without fetching the blockversion as well.