### PR TITLE
stop requiring reason for positive reviewer action resolving jobs

### DIFF
--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -422,7 +422,7 @@ class ReviewForm(forms.Form):
     cinder_policies = forms.ModelMultipleChoiceField(
         # queryset is set later in __init__
         queryset=CinderPolicy.objects.none(),
-        required=False,
+        required=True,
         label='Choose one or more policies:',
         widget=widgets.CheckboxSelectMultiple,
     )
@@ -444,12 +444,12 @@ class ReviewForm(forms.Form):
                 self.fields['versions'].required = True
             if not action.get('requires_reasons', False):
                 self.fields['reasons'].required = False
+            if not action.get('requires_policies'):
+                self.fields['cinder_policies'].required = False
             if self.data.get('cinder_jobs_to_resolve'):
-                # if a cinder job is being resolved we need a review reason or policy
-                if action.get('allows_reasons'):
+                # if a cinder job is being resolved we need a review reason
+                if action.get('requires_reasons_for_cinder_jobs'):
                     self.fields['reasons'].required = True
-                if action.get('allows_policies'):
-                    self.fields['cinder_policies'].required = True
             if selected_action == 'resolve_appeal_job':
                 self.fields['appeal_action'].required = True
         result = super().is_valid()

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -213,7 +213,7 @@
       </div>
 
       <div class="review-actions-section data-toggle review-resolve-abuse-reports"
-           data-value="{{ actions_resolves_abuse_reports|join(' ') }}">
+           data-value="{{ actions_resolves_cinder_jobs|join(' ') }}">
           <strong><label for="id_cinder_jobs_to_resolve">{{ form.cinder_jobs_to_resolve.label }}</label></strong>
           {{ form.cinder_jobs_to_resolve }}
           {{ form.cinder_jobs_to_resolve.errors }}

--- a/src/olympia/reviewers/tests/test_forms.py
+++ b/src/olympia/reviewers/tests/test_forms.py
@@ -377,7 +377,7 @@ class TestReviewForm(TestCase):
         reason = ReviewActionReason.objects.create(name='A reason', canned_response='a')
         form = self.get_form()
         assert not form.is_bound
-        data = {'action': 'public', 'comments': 'lol', 'cinder_jobs_to_resolve': [job]}
+        data = {'action': 'reject', 'comments': 'lol', 'cinder_jobs_to_resolve': [job]}
         form = self.get_form(data=data)
         assert form.is_bound
         assert not form.is_valid()
@@ -388,6 +388,11 @@ class TestReviewForm(TestCase):
         assert form.is_bound
         assert form.is_valid()
         assert not form.errors
+
+    def test_reasons_required_with_cinder_jobs_theme_too(self):
+        self.grant_permission(self.request.user, 'Addons:ThemeReview')
+        self.addon.update(type=amo.ADDON_STATICTHEME)
+        self.test_reasons_required_with_cinder_jobs()
 
     def test_policies_required_with_cinder_jobs(self):
         self.grant_permission(self.request.user, 'Addons:Review')
@@ -578,6 +583,13 @@ class TestReviewForm(TestCase):
                         name='reason 1',
                         is_active=True,
                         canned_response='reason 1',
+                    )
+                ],
+                'cinder_policies': [
+                    CinderPolicy.objects.create(
+                        uuid='1',
+                        name='policy 1',
+                        expose_in_reviewer_tools=True,
                     )
                 ],
             }

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -3450,7 +3450,7 @@ class TestReviewHelper(TestReviewHelperBase):
         resolves_actions = {
             key: action
             for key, action in self.helper.actions.items()
-            if action.get('resolves_abuse_reports', False)
+            if action.get('resolves_cinder_jobs', False)
         }
         assert list(resolves_actions) == list(actions)
 

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -5865,12 +5865,6 @@ class TestReview(ReviewBase):
             addon=self.addon, file_kw={'status': amo.STATUS_AWAITING_REVIEW}
         )
         self.grant_permission(self.reviewer, 'Reviews:Admin')
-        reason = ReviewActionReason.objects.create(
-            name='reason 1',
-            is_active=True,
-            canned_response='reason',
-            cinder_policy=CinderPolicy.objects.create(),
-        )
         cinder_job = CinderJob.objects.create(
             job_id='123', target_addon=self.addon, resolvable_in_reviewer_tools=True
         )
@@ -5890,7 +5884,6 @@ class TestReview(ReviewBase):
             self.url,
             self.get_dict(
                 action='public',
-                reasons=[reason.id],
                 cinder_jobs_to_resolve=[cinder_job.id],
             ),
         )

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -513,8 +513,9 @@ class ReviewHelper:
                 and not version_is_blocked
             ),
             'allows_reasons': not is_static_theme,
-            'resolves_abuse_reports': True,
+            'resolves_cinder_jobs': True,
             'requires_reasons': False,
+            'requires_reasons_for_cinder_jobs': False,
             'boilerplate_text': 'Thank you for your contribution.',
             'can_attach': True,
         }
@@ -537,8 +538,9 @@ class ReviewHelper:
                 and is_appropriate_reviewer
             ),
             'allows_reasons': True,
-            'resolves_abuse_reports': True,
+            'resolves_cinder_jobs': True,
             'requires_reasons': not is_static_theme,
+            'requires_reasons_for_cinder_jobs': True,
         }
         actions['approve_content'] = {
             'method': self.handler.approve_content,
@@ -572,7 +574,7 @@ class ReviewHelper:
                 and current_or_latest_listed_version_was_auto_approved
                 and is_appropriate_reviewer_post_review
             ),
-            'resolves_abuse_reports': True,
+            'resolves_cinder_jobs': True,
         }
         actions['approve_multiple_versions'] = {
             'method': self.handler.approve_multiple_versions,
@@ -585,8 +587,9 @@ class ReviewHelper:
             ),
             'available': (can_approve_multiple),
             'allows_reasons': not is_static_theme,
+            'resolves_cinder_jobs': True,
             'requires_reasons': False,
-            'resolves_abuse_reports': True,
+            'requires_reasons_for_cinder_jobs': False,
         }
         actions['reject_multiple_versions'] = {
             'method': self.handler.reject_multiple_versions,
@@ -600,8 +603,9 @@ class ReviewHelper:
             ),
             'available': (can_reject_multiple),
             'allows_reasons': True,
-            'resolves_abuse_reports': True,
+            'resolves_cinder_jobs': True,
             'requires_reasons': not is_static_theme,
+            'requires_reasons_for_cinder_jobs': True,
         }
         actions['unreject_latest_version'] = {
             'method': self.handler.unreject_latest_version,
@@ -663,7 +667,7 @@ class ReviewHelper:
             'available': (
                 not is_static_theme and version_is_unlisted and is_appropriate_reviewer
             ),
-            'resolves_abuse_reports': True,
+            'resolves_cinder_jobs': True,
         }
         actions['clear_pending_rejection_multiple_versions'] = {
             'method': self.handler.clear_pending_rejection_multiple_versions,
@@ -751,7 +755,7 @@ class ReviewHelper:
                 and not addon_is_not_disabled
                 and is_appropriate_admin_reviewer
             ),
-            'resolves_abuse_reports': True,
+            'resolves_cinder_jobs': True,
             'can_attach': False,
         }
         actions['disable_addon'] = {
@@ -766,8 +770,9 @@ class ReviewHelper:
                 addon_is_not_disabled_or_deleted and is_appropriate_admin_reviewer
             ),
             'allows_reasons': True,
+            'resolves_cinder_jobs': True,
             'requires_reasons': not is_static_theme,
-            'resolves_abuse_reports': True,
+            'requires_reasons_for_cinder_jobs': True,
             'can_attach': False,
         }
         actions['resolve_reports_job'] = {
@@ -780,8 +785,8 @@ class ReviewHelper:
             'minimal': True,
             'available': is_reviewer and has_unresolved_abuse_report_jobs,
             'comments': False,
-            'resolves_abuse_reports': True,
-            'allows_policies': True,
+            'resolves_cinder_jobs': True,
+            'requires_policies': True,
         }
         actions['resolve_appeal_job'] = {
             'method': self.handler.resolve_appeal_job,
@@ -793,7 +798,7 @@ class ReviewHelper:
             'minimal': True,
             'available': is_reviewer and has_unresolved_appeal_jobs,
             'comments': True,
-            'resolves_abuse_reports': True,
+            'resolves_cinder_jobs': True,
         }
         actions['comment'] = {
             'method': self.handler.process_comment,
@@ -982,7 +987,7 @@ class ReviewBase:
                 for reason in reasons
                 if getattr(reason, 'cinder_policy', None)
             ]
-            if self.review_action and self.review_action.get('allows_policies'):
+            if self.review_action and self.review_action.get('requires_policies'):
                 policies.extend(self.data.get('cinder_policies', []))
 
         cinder_action = cinder_action or getattr(action, 'cinder_action', None)

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -605,7 +605,7 @@ def review(request, addon, channel=None):
     # The actions for which we should display the reason select field.
     actions_reasons = []
     # The actions for which we should display the resolve abuse reports checkbox
-    actions_resolves_abuse_reports = []
+    actions_resolves_cinder_jobs = []
     # The actions for which we should display the cinder policy select field.
     actions_policies = []
     # The actions for which to allow attachments.
@@ -620,10 +620,10 @@ def review(request, addon, channel=None):
             actions_delayable.append(key)
         if action.get('allows_reasons', False):
             actions_reasons.append(key)
-        if action.get('allows_policies', False):
+        if action.get('requires_policies', False):
             actions_policies.append(key)
-        if action.get('resolves_abuse_reports', False):
-            actions_resolves_abuse_reports.append(key)
+        if action.get('resolves_cinder_jobs', False):
+            actions_resolves_cinder_jobs.append(key)
         if action.get('can_attach', True):
             actions_attachments.append(key)
 
@@ -741,7 +741,7 @@ def review(request, addon, channel=None):
         actions_policies=actions_policies,
         actions_reasons=actions_reasons,
         actions_attachments=actions_attachments,
-        actions_resolves_abuse_reports=actions_resolves_abuse_reports,
+        actions_resolves_cinder_jobs=actions_resolves_cinder_jobs,
         addon=addon,
         addons_sharing_same_guid=addons_sharing_same_guid,
         approvals_info=approvals_info,


### PR DESCRIPTION
Fixes: mozilla/addons#15091

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Adjust Approve (and Approve multiple) reviewer tools actions to not require reasons, even when resolving a cinder job.

### Context

I probably spent more time trying to work out why I implemented it this way earlier this year than the actual fix - I think it was just because I couldn't rely on `requires_reasons` - which was already `True` for the actions we'd want reasons for - because it wasn't hard-coded to `True`, it was instead `not is_static_theme`, leaving an edge case of a static theme review that resolved a job not requiring  a reason (if that was ever to happen in the first place), so worked around it by overriding `requires_reasons` when resolving a job - leading to this issue.
Anyway, I fixed it now by adding an explicit  `requires_reasons_for_cinder_job` to the actions - that is False for the approve actions.

### Testing

After setting up your env with an abuse report job that's reported to Cinder (with that integration enabled), and resolvable in the reviewer tools (e.g. policy violation, located in the Addon), try to resolve the job in the reviewer tools.  Reject, etc, should require a reason; Approve should not require a reason.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
