### PR TITLE
Respond to cinder moving a job into the amo handled queue

### DIFF
--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -7,6 +7,7 @@ from django.db.models import Exists, OuterRef, Q
 from django.db.transaction import atomic
 from django.utils.functional import cached_property
 
+import olympia.core.logger
 from olympia import amo
 from olympia.addons.models import Addon
 from olympia.amo.models import BaseQuerySet, ManagerBase, ModelBase
@@ -49,6 +50,9 @@ from .utils import (
     CinderActionTargetAppealApprove,
     CinderActionTargetAppealRemovalAffirmation,
 )
+
+
+log = olympia.core.logger.getLogger('z.abuse')
 
 
 class CinderJobQuerySet(BaseQuerySet):
@@ -312,6 +316,28 @@ class CinderJob(ModelBase):
         ).without_parents_if_their_children_are_present()
         cinder_decision.policies.add(*policies)
         cinder_decision.process_action(overridden_action)
+
+    def process_queue_move(self, *, new_queue):
+        if new_queue == CinderAddonHandledByReviewers.queue:
+            # now escalated
+            entity_helper = CinderJob.get_entity_helper(
+                self.target,
+                addon_version_string=None,
+                resolved_in_reviewer_tools=True,
+            )
+            entity_helper.workflow_move(job=self)
+            self.update(resolvable_in_reviewer_tools=True)
+        elif self.resolvable_in_reviewer_tools:
+            # now not escalated
+            log.debug(
+                'Job %s has moved out of AMO handled queue, but this is not yet '
+                'supported',
+                self.id,
+            )
+        else:
+            log.debug(
+                'Job %s has moved, but not in or out of AMO handled queue', self.id
+            )
 
     def resolve_job(self, *, log_entry):
         """This is called for reviewer tools originated decisions.

--- a/src/olympia/abuse/tests/assets/cinder_webhook_payloads/job_actioned_move_to_dev_infringement.json
+++ b/src/olympia/abuse/tests/assets/cinder_webhook_payloads/job_actioned_move_to_dev_infringement.json
@@ -1,0 +1,53 @@
+{
+    "event": "job.actioned",
+    "payload": {
+      "action": "escalated",
+      "action_made_by": {
+        "user": {
+          "email": "awilliamson@test.com",
+          "groups": [
+            {
+              "name": "Admin"
+            },
+            {
+              "name": "Everyone"
+            }
+          ],
+          "name": "Andrew Williamson"
+        }
+      },
+      "job": {
+        "entity": {
+          "attributes": {
+            "average_daily_users": 0,
+            "created": "2022-05-04T07:28:32.414515",
+            "description": "",
+            "guid": "arabicoffeetest222@dictionaries.addons.mozilla.org",
+            "id": "621524",
+            "last_updated": "2022-05-04T07:28:32.414515",
+            "name": "Dictionary",
+            "privacy_policy": "",
+            "promoted": "",
+            "promoted_badge": "",
+            "release_notes": "null",
+            "slug": "dictionary",
+            "summary": "Dictionary",
+            "version": "3.2.2012034.4webext"
+          },
+          "entity_schema": "amo_addon"
+        },
+        "id": "d16e1ebc-b6df-4742-83c1-61f5ed3bd644",
+        "job_category": "appeal",
+        "num_reports": 0,
+        "priority": 0,
+        "queue": {
+          "is_multi_review": false,
+          "slug": "amo-env-addon-infringement"
+        },
+        "status": "open"
+      },
+      "notes": "no",
+      "source": "manual",
+      "timestamp": "2024-10-01T13:19:49.546547+00:00"
+    }
+  }

--- a/src/olympia/abuse/tests/test_cinder.py
+++ b/src/olympia/abuse/tests/test_cinder.py
@@ -1364,7 +1364,7 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
         cinder_instance = self.CinderClass(target)
         assert cinder_instance.close_job(job_id=job_id) == job_id
 
-    def test_workflow_recreate(self):
+    def _setup_workflow_move_test(self):
         addon = self._create_dummy_target()
         listed_version = addon.current_version
         listed_version.file.update(is_signed=True)
@@ -1386,16 +1386,10 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
             cinder_job=cinder_job,
             reporter=user_factory(),
         )
-        responses.add(
-            responses.POST,
-            f'{settings.CINDER_SERVER_URL}create_report',
-            json={'job_id': '2'},
-            status=201,
-        )
+        return cinder_instance, cinder_job, listed_version, unlisted_version
 
-        assert cinder_instance.workflow_recreate(job=cinder_job) == '2'
-
-        assert addon.reload().status == amo.STATUS_APPROVED
+    def _check_workflow_move_test(self, listed_version, unlisted_version):
+        assert listed_version.addon.reload().status == amo.STATUS_APPROVED
         assert (
             listed_version.reload().needshumanreview_set.get().reason
             == NeedsHumanReview.REASONS.CINDER_ESCALATION
@@ -1411,15 +1405,30 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
         assert activity.arguments == [listed_version, unlisted_version]
         assert activity.user == self.task_user
 
+    def test_workflow_move(self):
+        cinder_instance, cinder_job, listed_version, unlisted_version = (
+            self._setup_workflow_move_test()
+        )
+
+        cinder_instance.workflow_move(job=cinder_job)
+
+        self._check_workflow_move_test(listed_version, unlisted_version)
+
+    def test_workflow_move_specific_version(self):
         # but if we have a version specified, we flag that version
-        NeedsHumanReview.objects.all().delete()
+        cinder_instance, cinder_job, listed_version, unlisted_version = (
+            self._setup_workflow_move_test()
+        )
         other_version = version_factory(
-            addon=addon, file_kw={'status': amo.STATUS_DISABLED, 'is_signed': True}
+            addon=listed_version.addon,
+            file_kw={'status': amo.STATUS_DISABLED, 'is_signed': True},
         )
         assert not other_version.due_date
-        ActivityLog.objects.all().delete()
         cinder_job.abusereport_set.update(addon_version=other_version.version)
-        cinder_instance.workflow_recreate(job=cinder_job)
+        ActivityLog.objects.all().delete()
+
+        cinder_instance.workflow_move(job=cinder_job)
+
         assert not listed_version.reload().needshumanreview_set.exists()
         assert not unlisted_version.reload().needshumanreview_set.exists()
         other_version.reload()
@@ -1433,12 +1442,41 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
         assert activity.arguments == [other_version]
         assert activity.user == self.task_user
 
+    def test_workflow_recreate(self):
+        cinder_instance, cinder_job, listed_version, unlisted_version = (
+            self._setup_workflow_move_test()
+        )
+        responses.add(
+            responses.POST,
+            f'{settings.CINDER_SERVER_URL}create_report',
+            json={'job_id': '2'},
+            status=201,
+        )
+
+        assert cinder_instance.workflow_recreate(job=cinder_job) == '2'
+
+        self._check_workflow_move_test(listed_version, unlisted_version)
+
+    def test_workflow_move_no_versions_to_flag(self):
+        cinder_instance, cinder_job, listed_version, unlisted_version = (
+            self._setup_workflow_move_test()
+        )
+        NeedsHumanReview.objects.create(
+            reason=NeedsHumanReview.REASONS.CINDER_ESCALATION, version=listed_version
+        )
+        NeedsHumanReview.objects.create(
+            reason=NeedsHumanReview.REASONS.CINDER_ESCALATION, version=unlisted_version
+        )
+        assert NeedsHumanReview.objects.count() == 2
+        ActivityLog.objects.all().delete()
+
+        cinder_instance.workflow_move(job=cinder_job)
+        assert NeedsHumanReview.objects.count() == 2
+        assert ActivityLog.objects.count() == 0
+
     def test_workflow_recreate_no_versions_to_flag(self):
-        addon = self._create_dummy_target()
-        listed_version = addon.current_version
-        listed_version.file.update(is_signed=True)
-        unlisted_version = version_factory(
-            addon=addon, channel=amo.CHANNEL_UNLISTED, file_kw={'is_signed': True}
+        cinder_instance, cinder_job, listed_version, unlisted_version = (
+            self._setup_workflow_move_test()
         )
         NeedsHumanReview.objects.create(
             reason=NeedsHumanReview.REASONS.CINDER_ESCALATION, version=listed_version
@@ -1454,49 +1492,21 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
             json={'job_id': '2'},
             status=201,
         )
-
-        cinder_instance = self.CinderClass(addon)
-        cinder_job = CinderJob.objects.create(target_addon=addon, job_id='1')
-
         assert cinder_instance.workflow_recreate(job=cinder_job) == '2'
         assert NeedsHumanReview.objects.count() == 2
         assert ActivityLog.objects.count() == 0
 
     @override_switch('dsa-cinder-forwarded-review', active=False)
-    def test_workflow_recreate_waffle_switch_off(self):
+    def test_workflow_move_waffle_switch_off(self):
         # Escalation when the waffle switch is off is essentially a no-op on
         # AMO side.
-        addon = self._create_dummy_target()
-        listed_version = addon.current_version
-        listed_version.file.update(is_signed=True)
-        unlisted_version = version_factory(
-            addon=addon, channel=amo.CHANNEL_UNLISTED, file_kw={'is_signed': True}
-        )
-        ActivityLog.objects.all().delete()
-        cinder_instance = self.CinderClass(addon)
-        cinder_job = CinderJob.objects.create(target_addon=addon)
-        AbuseReport.objects.create(
-            reason=AbuseReport.REASONS.HATEFUL_VIOLENT_DECEPTIVE,
-            guid=addon.guid,
-            cinder_job=cinder_job,
-            reporter_email='email@domain.com',
-        )
-        AbuseReport.objects.create(
-            reason=AbuseReport.REASONS.HATEFUL_VIOLENT_DECEPTIVE,
-            guid=addon.guid,
-            cinder_job=cinder_job,
-            reporter=user_factory(),
-        )
-        responses.add(
-            responses.POST,
-            f'{settings.CINDER_SERVER_URL}create_report',
-            json={'job_id': '2'},
-            status=201,
+        cinder_instance, cinder_job, listed_version, unlisted_version = (
+            self._setup_workflow_move_test()
         )
 
-        assert cinder_instance.workflow_recreate(job=cinder_job) == '2'
+        cinder_instance.workflow_move(job=cinder_job)
 
-        assert addon.reload().status == amo.STATUS_APPROVED
+        assert listed_version.addon.reload().status == amo.STATUS_APPROVED
         assert not listed_version.reload().needshumanreview_set.exists()
         assert not listed_version.due_date
         assert not unlisted_version.reload().needshumanreview_set.exists()
@@ -1504,18 +1514,39 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
         assert ActivityLog.objects.count() == 0
 
         other_version = version_factory(
-            addon=addon, file_kw={'status': amo.STATUS_DISABLED, 'is_signed': True}
+            addon=listed_version.addon,
+            file_kw={'status': amo.STATUS_DISABLED, 'is_signed': True},
         )
         assert not other_version.due_date
         ActivityLog.objects.all().delete()
         cinder_job.abusereport_set.update(addon_version=other_version.version)
-        cinder_instance.workflow_recreate(job=cinder_job)
+        cinder_instance.workflow_move(job=cinder_job)
         assert not listed_version.reload().needshumanreview_set.exists()
         assert not unlisted_version.reload().needshumanreview_set.exists()
         other_version.reload()
         assert not other_version.due_date
         assert not listed_version.reload().needshumanreview_set.exists()
         assert not unlisted_version.reload().needshumanreview_set.exists()
+
+    @override_switch('dsa-cinder-forwarded-review', active=False)
+    def test_workflow_recreate_waffle_switch_off(self):
+        cinder_instance, cinder_job, listed_version, unlisted_version = (
+            self._setup_workflow_move_test()
+        )
+        responses.add(
+            responses.POST,
+            f'{settings.CINDER_SERVER_URL}create_report',
+            json={'job_id': '2'},
+            status=201,
+        )
+        assert cinder_instance.workflow_recreate(job=cinder_job) == '2'
+
+        assert listed_version.addon.reload().status == amo.STATUS_APPROVED
+        assert not listed_version.reload().needshumanreview_set.exists()
+        assert not listed_version.due_date
+        assert not unlisted_version.reload().needshumanreview_set.exists()
+        assert not unlisted_version.due_date
+        assert ActivityLog.objects.count() == 0
 
 
 class TestCinderUser(BaseTestCinderCase, TestCase):

--- a/src/olympia/abuse/tests/test_views.py
+++ b/src/olympia/abuse/tests/test_views.py
@@ -1509,6 +1509,30 @@ class TestCinderWebhook(TestCase):
             }
         }
 
+    def test_missing_payload(self):
+        expected = {
+            'amo': {
+                'received': True,
+                'handled': False,
+                'not_handled_reason': 'No payload dict',
+            }
+        }
+
+        def check(response):
+            process_mock.assert_not_called()
+            assert response.status_code == 200
+            assert response.data == expected
+
+        self._setup_reports()
+        data = self.get_data()
+        with mock.patch.object(CinderJob, 'process_decision') as process_mock:
+            del data['payload']
+            check(cinder_webhook(self.get_request(data=data)))
+            data['payload'] = 'string'
+            check(cinder_webhook(self.get_request(data=data)))
+            data['payload'] = {}
+            check(cinder_webhook(self.get_request(data=data)))
+
     def test_no_cinder_report(self):
         req = self.get_request()
         with mock.patch.object(CinderJob, 'process_decision') as process_mock:

--- a/src/olympia/abuse/views.py
+++ b/src/olympia/abuse/views.py
@@ -261,9 +261,13 @@ def cinder_webhook(request):
     set_user(UserProfile.objects.get(pk=settings.TASK_USER_ID))
 
     try:
-        if not (payload := request.data.get('payload', {})):
-            log.info('No payload received: %s', str(request.data)[:255])
-            raise ValidationError('No payload')
+        if (
+            not (payload := request.data.get('payload', {}))
+            or not isinstance(payload, dict)
+            or not payload
+        ):
+            log.info('No payload dict received: %s', str(request.data)[:255])
+            raise ValidationError('No payload dict')
         match event := request.data.get('event'):
             case 'decision.created':
                 process_webhook_payload_decision(payload)


### PR DESCRIPTION
Fixes: mozilla/addons#15035

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Allowing monitoring of job.action webhook - if a job is moved into the AMO reviewer handled queue, treat it as a forward.

### Context

It's a small amount of extra code, but unlocks removing a lot of complexity in our Cinder related models (and somewhat in Cinder too). Currently, with AMO_ESCALATE, a decision is made to escalate, which closes the job.  We then have to a) create a new job in Cinder, and b) link up the new and old jobs in a our models via forwarded_job.  We can remove all that.

### Testing

As always we webhook integration, it's involved...
- Report an extension to be handled in Cinder (e.g. other reason).
- In Cinder, find the job in [AMO Dev Listings](https://stage.cinder.nonprod.webservices.mozgcp.net/queues/UXVldWVUeXBlOjM5/details/jobs?filters=%7B%7D) on cinder stage
- Escalate that job (under More Actions) to "AMO Dev Add-on Infringement"
- (The Escalate policies have been removed from that queue)
- see the job is now in the "[AMO Dev Add-on Infringement](https://stage.cinder.nonprod.webservices.mozgcp.net/queues/UXVldWVUeXBlOjI1/details/jobs?filters=%7B%7D)" queue in Cinder
- go into [webhooks in admin](https://stage.cinder.nonprod.webservices.mozgcp.net/settings/webhooks) and copy the job action webhook request; replay it via curl, etc, into your local AMO.  (as usual, probably easier if you comment out the auth)
- The job should now be escalated in AMO - i.e. it's got a NHR which causes it to show up in the manual review queue; and the job is shown as available to be resolved on the review page.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
