### PR TITLE
Relax parsing of IP networks coming from the database

### DIFF
--- a/src/olympia/amo/fields.py
+++ b/src/olympia/amo/fields.py
@@ -120,7 +120,11 @@ class CIDRField(models.Field):
         value = value.strip()
 
         try:
-            return ipaddress.ip_network(value)
+            # We pass strict=False to allow networks with host bits from the
+            # database to avoid generating an exception even though they should
+            # not have passed validation in case they were added by automation.
+            # It should still represent the correct network anyway.
+            return ipaddress.ip_network(value, strict=False)
         except Exception as exc:
             raise exceptions.ValidationError(exc) from exc
 

--- a/src/olympia/amo/tests/test_fields.py
+++ b/src/olympia/amo/tests/test_fields.py
@@ -123,6 +123,12 @@ class TestCIDRField(TestCase):
 
         self.field.clean('127.0.0.0/28')
 
+    def test_to_python(self):
+        # Technically invalid because it has the same bits set as the netmask
+        # but we want to be able to load those from the db.
+        assert self.field.to_python('127.0.0.1/28')
+        assert self.field.to_python('::1/28')
+
 
 class TestIPAddressBinaryField(TestCase):
     def test_from_db_value(self):


### PR DESCRIPTION
Even if technically the bits corresponding to the netmask should be set to 0, in practice it's fine to accept that they are not, it will result in the same network.

Fixes https://github.com/mozilla/addons/issues/15116