### PR TITLE
Filter reused guid:version strings from not blocked items in mlbf

### DIFF
--- a/src/olympia/blocklist/mlbf.py
+++ b/src/olympia/blocklist/mlbf.py
@@ -150,12 +150,13 @@ class MLBFDataBaseLoader(BaseMLBFLoader):
     def not_blocked_items(self) -> List[str]:
         # see blocked_items - we need self._version_excludes populated
         blocked_items = self.blocked_items
+        not_blocked_items = MLBF.hash_filter_inputs(
+            fetch_all_versions_from_db(self._version_excludes)
+        )
         # even though we exclude all the version ids in the query there's an
         # edge case where the version string occurs twice for an addon so we
         # ensure not_blocked_items doesn't contain any blocked_items.
-        return MLBF.hash_filter_inputs(
-            fetch_all_versions_from_db(self._version_excludes) - set(blocked_items)
-        )
+        return list(set(not_blocked_items) - set(blocked_items))
 
 
 class MLBF:


### PR DESCRIPTION
Fixes: mozilla/addons#15132

### Description

Ensure filtering of duplicate guid:version strings from not_blocked_items

### Context

After merging [commit](https://github.com/mozilla/addons-server/commit/97f3dbdbc230cd2ff346b521aa571852fd056458#diff-9d78bf2fa1a0d5d8446a4506e00278a05b8713e6bac8d430913150be293f43b5L240) it became clear in stage that we have duplicate hashed version strings in the mlbf data set.

### Testing

unit tested to cover the edge case

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
