### PR TITLE
Show Pastebin Attachment if File/Input Already Uploaded

### DIFF
--- a/static/js/zamboni/reviewers.js
+++ b/static/js/zamboni/reviewers.js
@@ -308,18 +308,18 @@ function initExtraReviewActions() {
     $('#attachment-type-toggle').addClass('hidden');
     $('#attachment_input_wrapper').addClass('hidden');
     $('#attachment_file_wrapper').removeClass('hidden');
-  }
+  };
   const showInputWrapper = (e) => {
     e?.preventDefault();
     $('#attachment-type-toggle').addClass('hidden');
     $('#attachment_file_wrapper').addClass('hidden');
     $('#attachment_input_wrapper').removeClass('hidden');
-  }
+  };
 
-  if($('#id_attachment_file').prop('files').length){
+  if ($('#id_attachment_file').prop('files').length) {
     showFileWrapper();
   }
-  if($('#id_attachment_input').val()){
+  if ($('#id_attachment_input').val()) {
     showInputWrapper();
   }
 

--- a/static/js/zamboni/reviewers.js
+++ b/static/js/zamboni/reviewers.js
@@ -303,19 +303,28 @@ function initExtraReviewActions() {
     }),
   );
 
-  $('#toggle_attachment_file').on('click', function (e) {
-    e.preventDefault();
+  const showFileWrapper = (e) => {
+    e?.preventDefault();
     $('#attachment-type-toggle').addClass('hidden');
     $('#attachment_input_wrapper').addClass('hidden');
     $('#attachment_file_wrapper').removeClass('hidden');
-  });
-
-  $('#toggle_attachment_input').on('click', function (e) {
-    e.preventDefault();
+  }
+  const showInputWrapper = (e) => {
+    e?.preventDefault();
     $('#attachment-type-toggle').addClass('hidden');
     $('#attachment_file_wrapper').addClass('hidden');
     $('#attachment_input_wrapper').removeClass('hidden');
-  });
+  }
+
+  if($('#id_attachment_file').prop('files').length){
+    showFileWrapper();
+  }
+  if($('#id_attachment_input').val()){
+    showInputWrapper();
+  }
+
+  $('#toggle_attachment_file').on('click', showFileWrapper);
+  $('#toggle_attachment_input').on('click', showInputWrapper);
 
   // One-off-style buttons.
   $('.more-actions button.oneoff[data-api-url]').click(

--- a/static/js/zamboni/reviewers.js
+++ b/static/js/zamboni/reviewers.js
@@ -305,23 +305,17 @@ function initExtraReviewActions() {
 
   const showFileWrapper = (e) => {
     e?.preventDefault();
-    $('#attachment-type-toggle').addClass('hidden');
-    $('#attachment_input_wrapper').addClass('hidden');
+    $('#attachment-type-toggle, #attachment_input_wrapper').addClass('hidden');
     $('#attachment_file_wrapper').removeClass('hidden');
   };
   const showInputWrapper = (e) => {
     e?.preventDefault();
-    $('#attachment-type-toggle').addClass('hidden');
-    $('#attachment_file_wrapper').addClass('hidden');
+    $('#attachment-type-toggle, #attachment_file_wrapper').addClass('hidden');
     $('#attachment_input_wrapper').removeClass('hidden');
   };
 
-  if ($('#id_attachment_file').prop('files').length) {
-    showFileWrapper();
-  }
-  if ($('#id_attachment_input').val()) {
-    showInputWrapper();
-  }
+  $('#id_attachment_file').prop('files').length && showFileWrapper();
+  $('#id_attachment_input').val() && showInputWrapper();
 
   $('#toggle_attachment_file').on('click', showFileWrapper);
   $('#toggle_attachment_input').on('click', showInputWrapper);


### PR DESCRIPTION
Fixes: mozilla/addons#15105

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Makes it clearer that a file or text is still attached to an action and prevent defaulting to the initial menu.

### Testing

1. Enable waffle flag `enable-activity-log-attachments`
2. Upload a file or input text as attachment from reviewer actions
3. Refreshes that contain the cached input will continue to show that input. Hard refreshes will reset.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.