### PR TITLE
Record version rejections triggered by a block as a human review

### DIFF
--- a/src/olympia/blocklist/tests/test_utils.py
+++ b/src/olympia/blocklist/tests/test_utils.py
@@ -11,7 +11,7 @@ from olympia import amo
 from olympia.activity.models import ActivityLog
 from olympia.amo.tests import TestCase, addon_factory, block_factory, user_factory
 
-from ..models import Block, BlocklistSubmission, BlockType, BlockVersion
+from ..models import Block, BlocklistSubmission, BlockType
 from ..utils import datetime_to_ts, disable_versions_for_block, save_versions_to_blocks
 
 
@@ -226,7 +226,7 @@ class TestSaveVersionsToBlocks(TestCase):
             url=None,
             updated_by=user,
             disable_addon=True,
-            block_type=BlockVersion.BLOCK_TYPE_CHOICES.BLOCKED,
+            block_type=BlockType.BLOCKED,
             changed_version_ids=[addon.current_version.pk],
             signoff_state=BlocklistSubmission.SIGNOFF_PUBLISHED,
         )
@@ -252,7 +252,7 @@ class TestSaveVersionsToBlocks(TestCase):
             url=None,
             updated_by=self.task_user,
             disable_addon=True,
-            block_type=BlockVersion.BLOCK_TYPE_CHOICES.BLOCKED,
+            block_type=BlockType.BLOCKED,
             changed_version_ids=[addon.current_version.pk],
             signoff_state=BlocklistSubmission.SIGNOFF_PUBLISHED,
         )
@@ -282,7 +282,7 @@ class TestSaveVersionsToBlocks(TestCase):
             url=None,
             updated_by=self.task_user,
             disable_addon=True,
-            block_type=BlockVersion.BLOCK_TYPE_CHOICES.BLOCKED,
+            block_type=BlockType.BLOCKED,
             changed_version_ids=[addon.current_version.pk],
             signoff_state=BlocklistSubmission.SIGNOFF_PUBLISHED,
         )

--- a/src/olympia/blocklist/tests/test_utils.py
+++ b/src/olympia/blocklist/tests/test_utils.py
@@ -21,7 +21,7 @@ def test_datetime_to_ts():
 
 class TestSaveVersionsToBlocks(TestCase):
     def setUp(self):
-        self.task_user = user_factory(pk=settings.TASK_USER_ID)
+        self.task_user = user_factory(pk=settings.TASK_USER_ID, display_name='Mozilla')
         responses.add_callback(
             responses.POST,
             f'{settings.CINDER_SERVER_URL}create_decision',
@@ -75,7 +75,7 @@ class TestSaveVersionsToBlocks(TestCase):
 
         activity = ActivityLog.objects.latest('pk')
         assert activity.action == amo.LOG.REJECT_VERSION.id
-        assert activity.user == self.task_user
+        assert activity.user == user_new
         assert activity.details['comments'] == 'some reason'
         assert activity.details['is_addon_being_blocked']
         assert activity.details['is_addon_being_disabled']
@@ -130,7 +130,7 @@ class TestSaveVersionsToBlocks(TestCase):
 
         activity = ActivityLog.objects.latest('pk')
         assert activity.action == amo.LOG.REJECT_VERSION.id
-        assert activity.user == self.task_user
+        assert activity.user == user_new
         assert activity.details['comments'] == 'some reason'
         assert activity.details['is_addon_being_blocked']
         assert activity.details['is_addon_being_disabled']

--- a/src/olympia/blocklist/utils.py
+++ b/src/olympia/blocklist/utils.py
@@ -147,12 +147,15 @@ def disable_versions_for_block(block, submission):
     """Disable appropriate addon versions that are affected by the Block."""
     from olympia.reviewers.utils import ReviewBase
 
+    task_user = get_task_user()
+    activity_user = block.updated_by or get_task_user()
+    human_review = activity_user != task_user
     review = ReviewBase(
         addon=block.addon,
         version=None,
-        user=get_task_user(),
+        user=activity_user,
         review_type='pending',
-        human_review=False,
+        human_review=human_review,
     )
     versions_to_reject = [
         ver


### PR DESCRIPTION
The user that last updated the block should be the user set on the corresponding activity.

Fixes: mozilla/addons#15104

### Context

We want `human_review_date` to be set on versions we reject as part of a block, because that makes us consider the person that made the block as having performed a review of the version, which allows reviewers to unreject that version (on the listed channel, reviewers can only unreject versions that a human reviewer rejected in the first place). It's also more consistent in general - the person who made the block should have performed a review of the affected versions, so we should record that.

### Testing

Block a listed version from the admin: it should set a `human_review_date` on the `Version`, and the reject activity log should be coming from the user that recorded the block, not the task user.

This can then allow unrejecting the version in reviewer tools (assuming the add-on is re-enabled first if it was disabled).