### PR TITLE
Skip reindex on normal make up where index alias exists

### DIFF
--- a/src/olympia/amo/management/commands/initialize.py
+++ b/src/olympia/amo/management/commands/initialize.py
@@ -62,4 +62,6 @@ class Command(BaseDataCommand):
         # We should reindex even if no data is loaded/modified
         # because we might have a fresh instance of elasticsearch
         else:
-            call_command('reindex', '--wipe', '--force', '--noinput')
+            call_command(
+                'reindex', '--wipe', '--force', '--noinput', '--skip-if-exists'
+            )

--- a/src/olympia/amo/tests/test_commands.py
+++ b/src/olympia/amo/tests/test_commands.py
@@ -156,7 +156,10 @@ class BaseTestDataCommand(TestCase):
         migrate = mock.call('migrate', '--noinput')
         data_seed = mock.call('data_seed')
 
-        reindex = mock.call('reindex', '--wipe', '--force', '--noinput')
+        reindex_force_wipe = mock.call('reindex', '--wipe', '--force', '--noinput')
+        reindex_skip_if_exists = mock.call(
+            'reindex', '--wipe', '--force', '--noinput', '--skip-if-exists'
+        )
         load_initial_data = mock.call('loaddata', 'initial.json')
         import_prod_versions = mock.call('import_prod_versions')
         createsuperuser = mock.call(
@@ -314,7 +317,7 @@ class TestInitializeDataCommand(BaseTestDataCommand):
             self.mocks['mock_call_command'],
             [
                 self.mock_commands.migrate,
-                self.mock_commands.reindex,
+                self.mock_commands.reindex_skip_if_exists,
             ],
         )
 
@@ -570,7 +573,7 @@ class TestLoadDataCommand(BaseTestDataCommand):
             [
                 self.mock_commands.db_restore(db_path),
                 self.mock_commands.media_restore(storage_path),
-                self.mock_commands.reindex,
+                self.mock_commands.reindex_force_wipe,
             ],
         )
 

--- a/src/olympia/search/management/commands/reindex.py
+++ b/src/olympia/search/management/commands/reindex.py
@@ -117,6 +117,12 @@ class Command(BaseCommand):
             help=('Do not ask for confirmation before wiping. Default: False'),
             default=False,
         )
+        parser.add_argument(
+            '--skip-if-exists',
+            action='store_true',
+            help=('Skip the reindex if the index already exists.'),
+            default=False,
+        )
 
     def accepted_keys(self):
         return ', '.join(settings.ES_INDEXES.keys())
@@ -140,6 +146,9 @@ class Command(BaseCommand):
                 % (self.accepted_keys())
             )
         self.stdout.write('Starting the reindexation for %s.' % alias)
+        if kwargs['skip_if_exists'] and ES.indices.exists_alias(name=alias):
+            self.stdout.write('Index %s already exists. Skipping reindex.' % alias)
+            return
 
         if kwargs['wipe']:
             skip_confirmation = kwargs['noinput']

--- a/src/olympia/search/management/commands/reindex.py
+++ b/src/olympia/search/management/commands/reindex.py
@@ -120,7 +120,7 @@ class Command(BaseCommand):
         parser.add_argument(
             '--skip-if-exists',
             action='store_true',
-            help=('Skip the reindex if the index already exists.'),
+            help=('Skip the reindex if the alias already exists.'),
             default=False,
         )
 

--- a/src/olympia/search/management/commands/reindex.py
+++ b/src/olympia/search/management/commands/reindex.py
@@ -147,7 +147,7 @@ class Command(BaseCommand):
             )
         self.stdout.write('Starting the reindexation for %s.' % alias)
         if kwargs['skip_if_exists'] and ES.indices.exists_alias(name=alias):
-            self.stdout.write('Index %s already exists. Skipping reindex.' % alias)
+            self.stdout.write('Alias %s already exists. Skipping reindex.' % alias)
             return
 
         if kwargs['wipe']:

--- a/src/olympia/search/tests/test_commands.py
+++ b/src/olympia/search/tests/test_commands.py
@@ -113,7 +113,10 @@ class TestIndexCommand(ESTestCaseMixin, PatchMixin, TransactionTestCase):
                 # alias in setUpClass.
                 time.sleep(1)
                 management.call_command(
-                    'reindex', wipe=wipe, noinput=True, stdout=self.stdout
+                    'reindex',
+                    wipe=wipe,
+                    noinput=True,
+                    stdout=self.stdout,
                 )
 
         t = ReindexThread()
@@ -229,3 +232,20 @@ class TestIndexCommand(ESTestCaseMixin, PatchMixin, TransactionTestCase):
         for addons.
         """
         self._test_workflow('default')
+
+    @mock.patch(
+        'olympia.search.management.commands.reindex.ES.indices.exists_alias',
+        return_value=True,
+    )
+    @mock.patch('olympia.search.management.commands.reindex.Command.create_workflow')
+    def test_reindex_skip_if_exists(self, mock_create_workflow, mock_exists_alias):
+        """
+        Test reindex command with skip_if_exists option when index already exists.
+        """
+        management.call_command(
+            'reindex',
+            skip_if_exists=True,
+            noinput=True,
+        )
+        assert mock_exists_alias.call_count == 1
+        assert mock_create_workflow.call_count == 0

--- a/src/olympia/search/tests/test_commands.py
+++ b/src/olympia/search/tests/test_commands.py
@@ -240,7 +240,7 @@ class TestIndexCommand(ESTestCaseMixin, PatchMixin, TransactionTestCase):
     @mock.patch('olympia.search.management.commands.reindex.Command.create_workflow')
     def test_reindex_skip_if_exists(self, mock_create_workflow, mock_exists_alias):
         """
-        Test reindex command with skip_if_exists option when index already exists.
+        Test reindex command with skip_if_exists option when alias already exists.
         """
         management.call_command(
             'reindex',


### PR DESCRIPTION
Follow up: https://github.com/mozilla/addons-server/pull/22805

### Description

When running make up, if we are not explicitly cleaning and reseting the database and we have a non-empty database it is fair to assume that indexing may have already happened and we can safely skip reindex if the es index is already aliased

### Context

See: LINK TO COMMENT for explanation

### Testing

Run `make up` after running `make down` and you should expect ES indexing to happen. Then run `make up` again and expect it not to happen. Adding `INIT_CEAN=True` or wiping the database should also cause reindexing.

### Checklist


- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
