### PR TITLE
Update reviewer tools rejection action explanation label

### DIFF
--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -382,8 +382,7 @@ class ReviewForm(forms.Form):
                 ),
                 (
                     False,
-                    'Reject immediately. Only use in case of serious '
-                    'security issues.',
+                    'Reject immediately.',
                 ),
             )
         ),


### PR DESCRIPTION
Fixes: mozilla/addons#1915

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

<!--
Your PR will be squashed when merged so the 1st commit must contain a descriptive and concise summary of the change.
Additional details should be added in the description. If your change is simple enough to summarize in the commit, or
if it is not relevant for your PR, remove this section.
-->

THis updates the rejection action explanation label, removing 'Only use in case of serious security issues.' to improve accuracy for content-rejections.

### Context

<!--
Often a pull request contains changes that are not fully self explanatory. Maybe this PR is a part of a series,
or maybe it is a partial change now with a more ambitious plan for the future. Add this additional context here.
If it is not relevant for your PR, remove this section.
-->

### Testing

<!--
Your change must be related to an existing, open issue. This issue should contain testing instructions.
Often, the testing info in the issue is higher level, geared towards a user or QA experience.
Here you can provide information for a developer verifying this PR. Get technical.
If it is not relevant to your PR, remove this section.
-->

On a review page, select the "Reject" or "Reject multiple versions" action. Below the comments box, there is a list of two radio buttons. The second  one should say "Reject immediately."

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [X] Add before and after screenshots (Only for changes that impact the UI).
- [X] Add or update relevant [docs](../docs/) reflecting the changes made.
