### PR TITLE
Fixed submission-field Button Disabling

### DIFF
--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -47,10 +47,11 @@ $(document).ready(function () {
     initUploadPreview();
   });
 
-  // disable buttons if submission is disabled
+  // disable buttons if submission is explicitly disabled
   const submissionField = $('#submission-field');
   const submissionsDisabled =
-    submissionField && !submissionField.data('submissions-enabled');
+    submissionField && submissionField.data('submissions-enabled') == false;
+
   $('.submission-buttons .button').toggleClass('disabled', submissionsDisabled);
 
   // Add-on uploader

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -50,7 +50,7 @@ $(document).ready(function () {
   // disable buttons if submission is explicitly disabled
   const submissionField = $('#submission-field');
   const submissionsDisabled =
-    submissionField && submissionField.data('submissions-enabled') == false;
+    submissionField && submissionField.data('submissions-enabled') === false;
 
   $('.submission-buttons .button').toggleClass('disabled', submissionsDisabled);
 


### PR DESCRIPTION
Fixes: mozilla/addons#15138

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Fixed `submission-field` buttons from disabling as part of the submissions disabling process when `submission-field` exists but does not have `data-submissions-enabled`.

`/en-US/developers/addon/submit/theme/upload-listed` and `/en-US/developers/addon/submit/wizard-listed` buttons are still disabled as expected when `submissions-enabled` is `False`.

![image](https://github.com/user-attachments/assets/94a4abad-ebd3-4a76-9c47-bb81d8b3cc63)
![image](https://github.com/user-attachments/assets/88c08541-0bc3-4211-a40f-73fbf0f6365e)

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] Add before and after screenshots (Only for changes that impact the UI).
