### PR TITLE
Split diff by block type

### DIFF
--- a/src/olympia/blocklist/cron.py
+++ b/src/olympia/blocklist/cron.py
@@ -12,7 +12,7 @@ from olympia.constants.blocklist import (
 from olympia.zadmin.models import get_config
 
 from .mlbf import MLBF
-from .models import Block, BlocklistSubmission
+from .models import Block, BlocklistSubmission, BlockType
 from .tasks import cleanup_old_files, process_blocklistsubmission, upload_filter
 from .utils import datetime_to_ts
 
@@ -89,7 +89,9 @@ def _upload_mlbf_to_remote_settings(*, force_base=False):
         else base_filter
     )
 
-    changes_count = mlbf.blocks_changed_since_previous(previous_filter)
+    changes_count = mlbf.blocks_changed_since_previous(
+        BlockType.BLOCKED, previous_filter
+    )
     statsd.incr(
         'blocklist.cron.upload_mlbf_to_remote_settings.blocked_changed', changes_count
     )
@@ -119,7 +121,8 @@ def _upload_mlbf_to_remote_settings(*, force_base=False):
         force_base
         or base_filter is None
         or previous_filter is None
-        or mlbf.blocks_changed_since_previous(base_filter) > BASE_REPLACE_THRESHOLD
+        or mlbf.blocks_changed_since_previous(BlockType.BLOCKED, base_filter)
+        > BASE_REPLACE_THRESHOLD
     )
 
     if make_base_filter:

--- a/src/olympia/blocklist/mlbf.py
+++ b/src/olympia/blocklist/mlbf.py
@@ -135,6 +135,7 @@ class MLBFDataBaseLoader(BaseMLBFLoader):
     def _all_blocks(self):
         return (
             BlockVersion.objects.filter(version__file__is_signed=True)
+            .distinct()
             .order_by('id')
             .values_list(
                 'block__guid',
@@ -167,6 +168,7 @@ class MLBFDataBaseLoader(BaseMLBFLoader):
         all_blocks_ids = [version.version_id for version in self._all_blocks]
         not_blocked_items = MLBF.hash_filter_inputs(
             Version.unfiltered.exclude(id__in=all_blocks_ids or ())
+            .distinct()
             .order_by('id')
             .values_list('addon__addonguid__guid', 'version')
         )
@@ -258,7 +260,8 @@ class MLBF:
     def blocks_changed_since_previous(
         self, block_type: BlockType = BlockType.BLOCKED, previous_mlbf: 'MLBF' = None
     ):
-        return self.generate_diffs(previous_mlbf)[block_type][2]
+        _, _, changed_count = self.generate_diffs(previous_mlbf)[block_type]
+        return changed_count
 
     @classmethod
     def load_from_storage(

--- a/src/olympia/blocklist/mlbf.py
+++ b/src/olympia/blocklist/mlbf.py
@@ -24,7 +24,7 @@ def diff_lists(
 ) -> Tuple[Set[str], Set[str], int]:
     extras = set(current) - set(previous)
     deletes = set(previous) - set(current)
-    changed_count = len(extras) + len(deletes) if len(previous) > 0 else len(current)
+    changed_count = len(extras) + len(deletes)
     return extras, deletes, changed_count
 
 

--- a/src/olympia/blocklist/tests/test_mlbf.py
+++ b/src/olympia/blocklist/tests/test_mlbf.py
@@ -503,7 +503,7 @@ class TestMLBF(_MLBFBase):
             == 1
         )
         final_mlbf = MLBF.generate_from_db('final')
-        # The soft blocked version is no logner a change comparing to the previous mlbf
+        # The soft blocked version is no longer a change comparing to the previous mlbf
         # but is still a change to the original mlbf from before it was created
         assert (
             final_mlbf.blocks_changed_since_previous(


### PR DESCRIPTION
Relates to: https://github.com/mozilla/addons-server/pull/22826
Relates to: https://github.com/mozilla/addons-server/pull/22828
Fixes: mozilla/addons#15147

### Description

Split `generate_diffs` to include diffs for both hard and soft blocks. This is required for both stashing and filter updates.

### Context

This patch is required by both of the linked PRs and to keep them independent we should land this (trivial) change first and rebase the other two.

### Testing

This is a backaward compatible patch so automated testing is fine.

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
