### PR TITLE
Add add-on created datetime as a column to the content review queue

### DIFF
--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -206,16 +206,17 @@ class PendingRejectionTable(AddonQueueTable):
 
 class ContentReviewTable(AddonQueueTable):
     last_updated = tables.DateTimeColumn(verbose_name='Last Updated')
+    created = tables.DateTimeColumn(verbose_name='Created')
     title = 'Content Review'
     urlname = 'queue_content_review'
     url = r'^content_review$'
     permission = amo.permissions.ADDONS_CONTENT_REVIEW
 
     class Meta(AddonQueueTable.Meta):
-        fields = ('addon_name', 'flags', 'last_updated')
+        fields = ('addon_name', 'flags', 'created', 'last_updated')
         # Exclude base fields AddonQueueTable has that we don't want.
         exclude = ('last_human_review',)
-        orderable = False
+        orderable = True
 
     @classmethod
     def get_queryset(cls, request, **kw):
@@ -224,6 +225,9 @@ class ContentReviewTable(AddonQueueTable):
         )
 
     def render_last_updated(self, value):
+        return naturaltime(value) if value else ''
+
+    def render_created(self, value):
         return naturaltime(value) if value else ''
 
     def _get_addon_name_url(self, record):


### PR DESCRIPTION
Fixes: mozilla/addons#15077

### Description

This PR adds the creation date time to the content-review queue and make orderable this and the last-updated column.
It does not remove the 'flag' column because this seems a task for a separate bug.

### Testing

No extra tests added. I did not find tests for the columns in that queue. If there are, ping me and I'm happy to write a test.

### Checklist

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [x] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.

Before:
![image](https://github.com/user-attachments/assets/ef818c45-f738-4cbd-974f-6a59d758afbe)

After:
![image](https://github.com/user-attachments/assets/c5f2620b-aa17-42cd-8072-c6a9d9e15c2e)

