### PR TITLE
report appeals for extensions to a different queue

### DIFF
--- a/src/olympia/abuse/tasks.py
+++ b/src/olympia/abuse/tasks.py
@@ -206,9 +206,7 @@ def sync_cinder_policies():
 def handle_escalate_action(*, job_pk):
     old_job = CinderJob.objects.get(id=job_pk)
     entity_helper = CinderJob.get_entity_helper(
-        old_job.target,
-        addon_version_string=None,
-        resolved_in_reviewer_tools=True,
+        old_job.target, resolved_in_reviewer_tools=True
     )
     job_id = entity_helper.workflow_recreate(job=old_job)
 

--- a/src/olympia/abuse/tests/test_tasks.py
+++ b/src/olympia/abuse/tests/test_tasks.py
@@ -472,7 +472,7 @@ def test_addon_appeal_to_cinder_reporter(statsd_incr_mock):
         },
         'appealer_entity_type': 'amo_unauthenticated_reporter',
         'decision_to_appeal_id': '4815162342-abc',
-        'queue_slug': 'amo-env-listings',
+        'queue_slug': 'amo-escalations',
         'reasoning': 'I appeal',
     }
 
@@ -576,7 +576,7 @@ def test_addon_appeal_to_cinder_authenticated_reporter():
         },
         'appealer_entity_type': 'amo_user',
         'decision_to_appeal_id': '4815162342-abc',
-        'queue_slug': 'amo-env-listings',
+        'queue_slug': 'amo-escalations',
         'reasoning': 'I appeal',
     }
 

--- a/src/olympia/abuse/tests/test_views.py
+++ b/src/olympia/abuse/tests/test_views.py
@@ -1498,24 +1498,6 @@ class TestCinderWebhook(TestCase):
         data['payload']['source']['job']['queue']['slug'] = 'amo-another-queue'
         return self.test_process_decision_called(data)
 
-    def test_queue_handled_reviewer_queue_ignored(self):
-        data = self.get_data()
-        data['payload']['source']['job']['queue']['slug'] = 'amo-addon-infringement'
-        abuse_report = self._setup_reports()
-        addon_factory(guid=abuse_report.guid)
-        req = self.get_request(data=data)
-        with mock.patch.object(CinderJob, 'process_decision') as process_mock:
-            response = cinder_webhook(req)
-            process_mock.assert_not_called()
-        assert response.status_code == 200
-        assert response.data == {
-            'amo': {
-                'received': True,
-                'handled': False,
-                'not_handled_reason': 'Queue handled by AMO reviewers',
-            }
-        }
-
     def test_unknown_event(self):
         self._setup_reports()
         data = self.get_data()

--- a/src/olympia/abuse/views.py
+++ b/src/olympia/abuse/views.py
@@ -20,7 +20,6 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 import olympia.core.logger
-from olympia.abuse.cinder import CinderAddonHandledByReviewers
 from olympia.abuse.tasks import appeal_to_cinder
 from olympia.accounts.utils import redirect_for_login
 from olympia.accounts.views import AccountViewSet
@@ -185,16 +184,9 @@ def filter_enforcement_actions(enforcement_actions, cinder_job):
 
 def process_webhook_payload_decision(payload):
     source = payload.get('source', {})
+    log.info('Valid Payload from AMO queue: %s', payload)
     if 'job' in source:
-        job = source.get('job', {})
-        if (
-            queue_name := job.get('queue', {}).get('slug')
-        ) == CinderAddonHandledByReviewers.queue:
-            log.info('Payload from queue handled by reviewers: %s', queue_name)
-            raise ValidationError('Queue handled by AMO reviewers')
-
-        log.info('Valid Payload from AMO queue: %s', payload)
-        job_id = job.get('id', '')
+        job_id = source.get('job', {}).get('id', '')
 
         try:
             cinder_job = CinderJob.objects.get(job_id=job_id)


### PR DESCRIPTION
Fixes: mozilla/addons#15161

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Route appeals for decisions on extensions (that were made in Cinder) to T&S's escalation queue, rather than the original `listings` queue.

### Context

There's some strictly unnecessary refactoring of `get_entity_helper` and `CinderAddon` from an earlier version of the patch when I went a different direction but I've kept it because it's pretty small and I like it better.

### Testing

Like most cinder related patches, it's a bit of pain to set up fully.  To get to the state where you can test this you need: 
- to have an abuse report reported to Cinder; 
- then a decision made on the job for that abuse report in Cinder; 
- and replay the webhook request from the decision locally with curl, etc.
  - (It _is_ possible to fake the webhook response by manually creating the `ContentDecision`, or updating another `ContentDecision` instance, but it's out of scope for this testing detail to explain exactly how 😛)

To test the patch itself:
- Once you have a decision from Cinder locally, check the email in fakemail for the appeal link (or compose the url yourself if you know how).  
- Submit the appeal.  
- See in Cinder the appeal is in the `amo-escalations` ("T&S Escalations") queue, rather than in the AMO dev Listings queue.

Bonus testing would be to repeat all of this with a theme and a non-add-on content type (e.g. collection) to check those go into their original queues in Cinder; plus appeals on reviewer tools decisions also go to their original (amo dev addon infringement) queue.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
