### PR TITLE
allow unsigned versions to be flagged for NHR

### DIFF
--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -1172,7 +1172,9 @@ class ContentDecision(ModelBase):
             raise CantBeAppealed
 
         entity_helper = CinderJob.get_entity_helper(
-            self.target, resolved_in_reviewer_tools=resolvable_in_reviewer_tools
+            self.target,
+            resolved_in_reviewer_tools=resolvable_in_reviewer_tools,
+            addon_version_string=getattr(abuse_report, 'addon_version', None),
         )
         appeal_id = entity_helper.appeal(
             decision_cinder_id=self.cinder_id,
@@ -1201,8 +1203,8 @@ class ContentDecision(ModelBase):
         entity_helper,
         appealed_action=None,
     ):
-        """Calling this method calls cinder to create a decision, or notfies the content
-        owner/reporter by email, or both.
+        """Calling this method calls Cinder to create a decision, or notifies the
+        content owner/reporter by email, or both.
 
         If a decision is created in cinder the instance will be saved, along with
         relevant policies; if a cinder decision isn't need the instance won't be saved.

--- a/src/olympia/abuse/tests/test_tasks.py
+++ b/src/olympia/abuse/tests/test_tasks.py
@@ -591,6 +591,7 @@ def test_addon_appeal_to_cinder_authenticated_reporter():
 @pytest.mark.django_db
 def test_addon_appeal_to_cinder_authenticated_author():
     user = user_factory(fxa_id='fake-fxa-id')
+    user_factory(pk=settings.TASK_USER_ID)
     addon = addon_factory(users=[user])
     decision = ContentDecision.objects.create(
         cinder_id='4815162342-abc',

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -239,7 +239,7 @@ class VersionManager(ManagerBase):
         # Versions that haven't been disabled or have ever been signed and have
         # the explicit needs human review flag should have a due date (it gets
         # dropped on various reviewer actions).
-        is_needs_human_review = Q(
+        is_other_needs_human_review = Q(
             ~Q(file__status=amo.STATUS_DISABLED) | Q(file__is_signed=True),
             needshumanreview__is_active=True,
         )
@@ -251,19 +251,19 @@ class VersionManager(ManagerBase):
         )
         return {
             'needs_human_review_from_cinder': Q(
-                is_needs_human_review,
+                needshumanreview__is_active=True,
                 needshumanreview__reason=NeedsHumanReview.REASONS.CINDER_ESCALATION,
             ),
             'needs_human_review_from_abuse': Q(
-                is_needs_human_review,
+                needshumanreview__is_active=True,
                 needshumanreview__reason=NeedsHumanReview.REASONS.ABUSE_ADDON_VIOLATION,
             ),
             'needs_human_review_from_appeal': Q(
-                is_needs_human_review,
+                needshumanreview__is_active=True,
                 needshumanreview__reason=NeedsHumanReview.REASONS.ADDON_REVIEW_APPEAL,
             ),
             'needs_human_review_other': Q(
-                is_needs_human_review,
+                is_other_needs_human_review,
                 ~Q(
                     needshumanreview__reason__in=(
                         NeedsHumanReview.REASONS.ABUSE_ADDON_VIOLATION.value,


### PR DESCRIPTION
Fixes: mozilla/addons#15114 and because I rewrote how we create the NHR, fixes mozilla/addons#15010 too

### Description

Makes changes to include unsigned versions when considering which is the latest version to flag for NHR, and to flag an unsigned version if it was specified - particularly useful for appeals on pre-review versions, but also fixes edge case with abuse reports on unsigned versions. 

Additionally we now pass along the appealed version for reporter appeals so it's slightly more accurate (but not entirely - we will need a resolution on https://mozilla-hub.atlassian.net/browse/AMOENG-1230 to get more accurate)

### Context

See the issue for the problem - we excluded unsigned versions from being considered for the latest version for a NHR, and then excluded unsigned disabled versions from getting a due_date.  

### Testing
- (Make sure you have the all the DSA related waffle switches enabled and cinder API key in your settings)
- Upload a new add-on, or a new version of an existing add-on
- With the reviewer tools reject that version (i.e. before it was approved and signed)
- with the appeal link in the rejection email (See fakemail in django admin) submit an appeal to that rejection
- See the add-on in the manual review queue because the appeal has created a NHR, with a due date, for that rejected version.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
