### PR TITLE
More efficient diff function removing quadratic iterable

### DIFF
--- a/src/olympia/blocklist/mlbf.py
+++ b/src/olympia/blocklist/mlbf.py
@@ -23,9 +23,11 @@ log = olympia.core.logger.getLogger('z.amo.blocklist')
 def ordered_diff_lists(
     previous: List[str], current: List[str]
 ) -> Tuple[List[str], List[str], int]:
+    current_set = set(current)
+    previous_set = set(previous)
     # Use lists instead of sets to maintain order
-    extras = [x for x in current if x not in previous]
-    deletes = [x for x in previous if x not in current]
+    extras = [x for x in current if x not in previous_set]
+    deletes = [x for x in previous if x not in current_set]
     changed_count = len(extras) + len(deletes)
     return extras, deletes, changed_count
 

--- a/src/olympia/blocklist/tests/test_mlbf.py
+++ b/src/olympia/blocklist/tests/test_mlbf.py
@@ -48,7 +48,7 @@ class _MLBFBase(TestCase):
         )
 
 
-class TestOrderedDiffLists(_MLBFBase):
+class TestOrderedDiffLists(TestCase):
     def test_return_added(self):
         assert ordered_diff_lists(['a', 'b'], ['a', 'b', 'c']) == (['c'], [], 1)
 
@@ -62,7 +62,12 @@ class TestOrderedDiffLists(_MLBFBase):
         size = 2_000_000
         even_items = [i for i in range(size) if i % 2 == 0]
         odd_items = [i for i in range(size) if i % 2 == 1]
-        assert ordered_diff_lists(even_items, odd_items) == (odd_items, even_items, size)
+        assert ordered_diff_lists(even_items, odd_items) == (
+            odd_items,
+            even_items,
+            size,
+        )
+
 
 class TestBaseMLBFLoader(_MLBFBase):
     class TestStaticLoader(BaseMLBFLoader):

--- a/src/olympia/blocklist/tests/test_mlbf.py
+++ b/src/olympia/blocklist/tests/test_mlbf.py
@@ -21,6 +21,7 @@ from ..mlbf import (
     MLBFDataBaseLoader,
     MLBFDataType,
     MLBFStorageLoader,
+    ordered_diff_lists,
 )
 
 
@@ -46,6 +47,22 @@ class _MLBFBase(TestCase):
             block_type=block_type,
         )
 
+
+class TestOrderedDiffLists(_MLBFBase):
+    def test_return_added(self):
+        assert ordered_diff_lists(['a', 'b'], ['a', 'b', 'c']) == (['c'], [], 1)
+
+    def test_return_removed(self):
+        assert ordered_diff_lists(['a', 'b', 'c'], ['a', 'b']) == ([], ['c'], 1)
+
+    def test_return_added_and_removed(self):
+        assert ordered_diff_lists(['a', 'b', 'c'], ['b', 'c', 'd']) == (['d'], ['a'], 2)
+
+    def test_large_diff(self):
+        size = 2_000_000
+        even_items = [i for i in range(size) if i % 2 == 0]
+        odd_items = [i for i in range(size) if i % 2 == 1]
+        assert ordered_diff_lists(even_items, odd_items) == (odd_items, even_items, size)
 
 class TestBaseMLBFLoader(_MLBFBase):
     class TestStaticLoader(BaseMLBFLoader):


### PR DESCRIPTION
Fixes: mozilla/addons#15170

### Testing

Automated test should cover it.. the test without sets hangs forever

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
