### PR TITLE
Remove all time inefficient loops from mlbf

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -61,6 +61,11 @@ jobs:
             compose_file: docker-compose.yml:docker-compose.ci.yml
             run: make test_es_tests
           -
+            name: MLBF
+            services: ''
+            compose_file: docker-compose.yml:docker-compose.ci.yml
+            run: make test_mlbf
+          -
             name: Codestyle
             services: web
             compose_file: docker-compose.yml:docker-compose.ci.yml

--- a/Makefile-docker
+++ b/Makefile-docker
@@ -163,6 +163,13 @@ test_es: ## run the ES tests
 		-m es_tests \
 		$(ARGS)
 
+.PHONY: test_mlbf
+test_mlbf: ## run the MLBF tests
+	pytest \
+		$(PYTEST_SRC) \
+		-m mlbf_tests \
+		$(ARGS)
+
 .PHONY: test_no_es
 test_no_es: ## run all but the ES tests
 	pytest \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,9 @@ norecursedirs = [
   "venv",
   "__pycache__",
 ]
+# Disables the timeout globally. We can investigate
+# setting a SLA for tests in the future.
+timeout = 0
 DJANGO_SETTINGS_MODULE = "settings_test"
 # Ignoring csp deprecation warnings, we have control over the module and
 # currently it warns for child-src which is deprecated in CSPv3 but we're still

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -311,3 +311,6 @@ pytest-reportlog==0.4.0 \
 django-dbbackup==4.2.1 \
     --hash=sha256:157a2ec10d482345cd75092e510ac40d6e2ee6084604a1d17abe178c2f06bc69 \
     --hash=sha256:b23265600ead0780ca781b1b4b594949aaa8a20d74f08701f91ee9d7eb1f08cd
+pytest-timeout==2.3.1 \
+    --hash=sha256:12397729125c6ecbdaca01035b9e5239d4db97352320af155b3f5de1ba5165d9 \
+    --hash=sha256:68188cb703edfc6a18fad98dc25a3c61e9f24d644b0b70f33af545219fc7813e

--- a/src/olympia/blocklist/tests/test_tasks.py
+++ b/src/olympia/blocklist/tests/test_tasks.py
@@ -124,6 +124,7 @@ class TestProcessBlocklistSubmission(TransactionTestCase):
 
 
 @pytest.mark.django_db
+@pytest.mark.mlbf_tests
 class TestUploadMLBFToRemoteSettings(TestCase):
     def setUp(self):
         self.user = user_factory()


### PR DESCRIPTION
Fixes: mozilla/addons#15170

### Description

- extract the database querying logic from `MLBFDatabaseLoader` to module scope functions for easier mocking
- reduce number of loops required to build initial dataset in `MLBFDatabaseLoader` to 1
- filter `not_blocked_items` with an O(1) set instead of list
- refactor `generate_diffs` to accept a block_type and only diff one set of data at a time.
- add an lru_cache to `generate_diffs` to ensure computation is executed only one time per instance + block_type + previous_mlbf
- collect all mlbf tests under `test_mlbf` mark 

### Context

This patch includes logic that should reduce the number of long loops required to process our mlbf data sets and determine the cache and diff of blocks across different scenarios.

### Testing

### Run the mlbf suite

```bash
make test_mlbf
```

This will run all of the mlbf related tests. Expect everything passes

### Test the timeout for the slow test

1. modify the `pytest.mark.timeout(120)` reducing the time to 3 (or some low number
2. run the test

```bash
pytest ./src/olympia/blocklist/tests/test_cron.py::TestUploadToRemoteSettings::test_large_data_set
```

3. expect the test to fail due to timeout

```bash
FAILED src/olympia/blocklist/tests/test_cron.py::TestUploadToRemoteSettings::test_large_data_set - Failed: Timeout >10.0s
```

### Test in local environment

IF you want to test with a real data set you will have to create a large amount of blocks and execute the cron

[Code snippet](https://github.com/mozilla/addons/issues/15171#issuecomment-2479388403)

Execute this code. You will need to execute many time or bump `1_000 up to between 1 and 2 million.. grab a coffee this will take a while.

After that is finished, execute `./manage.py cron upload_mlbf_to_remote_settings` and expect it to take up to 2 minutes to complete.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
