### PR TITLE
Remove time inefficient loop in not_blocked_items

### DIFF
--- a/src/olympia/blocklist/mlbf.py
+++ b/src/olympia/blocklist/mlbf.py
@@ -175,14 +175,11 @@ class MLBFDataBaseLoader(BaseMLBFLoader):
             .order_by('id')
             .values_list('addon__addonguid__guid', 'version')
         )
+        blocked_items = set(self.blocked_items + self.soft_blocked_items)
         # even though we exclude all the version ids in the query there's an
         # edge case where the version string occurs twice for an addon so we
         # ensure not_blocked_items contain no blocked_items or soft_blocked_items.
-        return [
-            item
-            for item in not_blocked_items
-            if item not in self.blocked_items + self.soft_blocked_items
-        ]
+        return [item for item in not_blocked_items if item not in blocked_items]
 
 
 class MLBF:


### PR DESCRIPTION
Relates to: mozilla/addons#15170

### Description

Removes time inefficient loop in get_not_blocked_items by filtering from a once created set instead of an inlined list

### Context

This patch adds a slow test 20 seconds that can be isolated from the rest of our tests in a follow up PR

### Testing

CI passes, this PR will be verified on staging as well.

### Checklist


- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
