### PR TITLE
Use correct name for softblack waffle switch

### DIFF
--- a/src/olympia/blocklist/cron.py
+++ b/src/olympia/blocklist/cron.py
@@ -40,13 +40,13 @@ def get_blocklist_last_modified_time():
 def upload_mlbf_to_remote_settings(*, bypass_switch=False, force_base=False):
     """Creates a bloomfilter, and possibly a stash json blob, and uploads to
     remote-settings.
-    bypass_switch=<Truthy value> will bypass the "blocklist_mlbf_submit" switch
+    bypass_switch=<Truthy value> will bypass the "enable-soft-blocking" switch
     for manual use/testing.
     force_base=<Truthy value> will force a new base MLBF and a reset of the
     collection.
     """
     bypass_switch = bool(bypass_switch)
-    if not (bypass_switch or waffle.switch_is_active('blocklist_mlbf_submit')):
+    if not (bypass_switch or waffle.switch_is_active('enable-soft-blocking')):
         log.info('Upload MLBF to remote settings cron job disabled.')
         return
     with statsd.timer('blocklist.cron.upload_mlbf_to_remote_settings'):

--- a/src/olympia/blocklist/tests/test_cron.py
+++ b/src/olympia/blocklist/tests/test_cron.py
@@ -35,7 +35,7 @@ STATSD_PREFIX = 'blocklist.cron.upload_mlbf_to_remote_settings.'
 
 
 @freeze_time('2020-01-01 12:34:56')
-@override_switch('blocklist_mlbf_submit', active=True)
+@override_switch('enable-soft-blocking', active=True)
 class TestUploadToRemoteSettings(TestCase):
     def setUp(self):
         self.user = user_factory()
@@ -199,7 +199,7 @@ class TestUploadToRemoteSettings(TestCase):
             in statsd_calls
         )
 
-    @override_switch('blocklist_mlbf_submit', active=False)
+    @override_switch('enable-soft-blocking', active=False)
     def test_skip_upload_if_switch_is_disabled(self):
         upload_mlbf_to_remote_settings()
         assert not self.mocks['olympia.blocklist.cron.statsd.incr'].called


### PR DESCRIPTION
Fixes: mozilla/addons#15166


### Description

Use correct name for waffle switch

### Checklist


- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
