### PR TITLE
Ensure TESTING_ENV is defined in all environments correctly

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -194,6 +194,3 @@ SWAGGER_SETTINGS = {
     },
     'PERSIST_AUTH': True,
 }
-
-# This is not a testing environment
-TESTING_ENV = False

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1606,3 +1606,7 @@ CINDER_QUEUE_PREFIX = 'amo-dev-'
 SOCKET_LABS_HOST = env('SOCKET_LABS_HOST', default='https://api.socketlabs.com/v2/')
 SOCKET_LABS_TOKEN = env('SOCKET_LABS_TOKEN', default=None)
 SOCKET_LABS_SERVER_ID = env('SOCKET_LABS_SERVER_ID', default=None)
+
+# Set to True in settings_test.py
+# This controls the behavior of migrations
+TESTING_ENV = False


### PR DESCRIPTION
Fixes: mozilla/addons#15185

### Description

Quick fix for the bug by defining the value to False in settings_base we ensure it can be referenced in any environment

### Context

We could consider wrapping this access in a util function that can be tested and guaranteed to never raise.. I think it might be overkill though.


### Testing

You have to run make up on a fresh environment:

```bash
make down
make docker_mysqld_volume_remove
make up
```

The migration should not raise.


### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
