### PR TITLE
Change growth threshold algorithm do use percentage points increase

### DIFF
--- a/src/olympia/addons/tests/test_tasks.py
+++ b/src/olympia/addons/tests/test_tasks.py
@@ -256,7 +256,7 @@ def test_flag_high_hotness_according_to_review_tier():
         name='D tier (below minimum usage for hotness)',
         lower_adu_threshold=0,
         upper_adu_threshold=100,
-        growth_threshold_before_flagging=0.1,
+        growth_threshold_before_flagging=1,
     )
     UsageTier.objects.create(
         name='C tier (no growth threshold)',
@@ -267,13 +267,13 @@ def test_flag_high_hotness_according_to_review_tier():
         name='B tier',
         lower_adu_threshold=200,
         upper_adu_threshold=250,
-        growth_threshold_before_flagging=35,
+        growth_threshold_before_flagging=11,
     )
     UsageTier.objects.create(
         name='A tier',
         lower_adu_threshold=250,
         upper_adu_threshold=1000,
-        growth_threshold_before_flagging=20,
+        growth_threshold_before_flagging=7,
     )
     UsageTier.objects.create(
         name='S tier (no upper threshold)',
@@ -332,14 +332,14 @@ def test_flag_high_hotness_according_to_review_tier():
     )
 
     flagged = [
-        # B tier average hotness should be 0.325, with a threshold of 35, so
-        # Add-ons with a hotness over 0.43875000000000003 should be flagged.
+        # B tier average hotness should be 0.32, with a threshold of 11, so
+        # Add-ons with a hotness over 0.43 should be flagged.
         addon_factory(name='B tier', average_daily_users=200, hotness=0.44),
-        # A tier average hotness should be 0.375, with a threshold of 20, so
-        # Add-ons with a hotness over 0.44999999999999996 should be flagged.
-        addon_factory(name='A tier', average_daily_users=250, hotness=0.45),
+        # A tier average hotness should be 0.3755, with a threshold of 7, so
+        # Add-ons with a hotness over 0.4455 should be flagged.
+        addon_factory(name='A tier', average_daily_users=250, hotness=0.451),
         addon_factory(
-            name='A tier with inactive flags', average_daily_users=250, hotness=0.45
+            name='A tier with inactive flags', average_daily_users=250, hotness=0.451
         ),
     ]
 
@@ -401,7 +401,7 @@ def test_flag_high_hotness_according_to_review_tier_threshold_check():
     )
     # Average hotness should be 0.5666666666666667,
     # growth_threshold_before_flagging for that tier is 10 so we should flag
-    # add-ons with hotness above 0.6233333333333334, meaning no add-ons should
+    # add-ons with hotness above 0.6666666666666667, meaning no add-ons should
     # be flagged.
     addon_factory(average_daily_users=251, hotness=0.55)
     addon_factory(average_daily_users=251, hotness=0.55)
@@ -412,11 +412,10 @@ def test_flag_high_hotness_according_to_review_tier_threshold_check():
 
     assert NeedsHumanReview.objects.count() == 0
 
-    # Average hotness should now be 0.6,
-    # growth_threshold_before_flagging for that tier is 10 so we should flag
-    # add-ons with hotness above 0.66, meaning that add-on should
-    # be flagged.
-    addon.update(hotness=0.7)
+    # Average hotness should now be 0.65, growth_threshold_before_flagging for
+    # that tier is 10 so we should flag add-ons with hotness above 0.75,
+    # meaning that this add-on should be flagged.
+    addon.update(hotness=0.85)
     flag_high_hotness_according_to_review_tier()
 
     assert NeedsHumanReview.objects.count() == 1

--- a/src/olympia/reviewers/templates/reviewers/addon_details_box.html
+++ b/src/olympia/reviewers/templates/reviewers/addon_details_box.html
@@ -131,7 +131,7 @@
               <th>Average Daily Users</th>
               <td>
                 <strong class="downloads">{{
-                  addon.average_daily_users|numberfmt }}</strong>
+                  addon.average_daily_users|numberfmt }}</strong> ({% if addon.hotness >= 0 %}+{% endif %}{{ addon.hotness * 100}}% from last week)
               </td>
             </tr>
           {% endif %}

--- a/src/olympia/reviewers/tests/test_models.py
+++ b/src/olympia/reviewers/tests/test_models.py
@@ -12,7 +12,12 @@ from olympia import amo, core
 from olympia.abuse.models import AbuseReport
 from olympia.access.models import Group, GroupUser
 from olympia.activity.models import ActivityLog
-from olympia.addons.models import AddonApprovalsCounter, AddonReviewerFlags, AddonUser
+from olympia.addons.models import (
+    Addon,
+    AddonApprovalsCounter,
+    AddonReviewerFlags,
+    AddonUser,
+)
 from olympia.amo.tests import (
     TestCase,
     addon_factory,
@@ -38,6 +43,7 @@ from olympia.reviewers.models import (
     NeedsHumanReview,
     ReviewActionReason,
     ReviewerSubscription,
+    UsageTier,
     get_flags,
     send_notifications,
     set_reviewing_cache,
@@ -1860,3 +1866,63 @@ class TestNeedsHumanReview(TestCase):
         flagged.reason = NeedsHumanReview.REASONS.DEVELOPER_REPLY
         flagged.save()
         assert ActivityLog.objects.count() == 0
+
+
+class UsageTierTests(TestCase):
+    def setUp(self):
+        self.tier = UsageTier.objects.create(
+            lower_adu_threshold=100,
+            upper_adu_threshold=1000,
+            growth_threshold_before_flagging=50,
+        )
+
+    def test_get_base_addons(self):
+        addon_factory(status=amo.STATUS_DISABLED)
+        addon_factory(type=amo.ADDON_STATICTHEME)
+        expected = {addon_factory()}
+        assert set(self.tier.get_base_addons()) == expected
+
+    def test_get_tier_boundaries(self):
+        assert self.tier.get_tier_boundaries() == {
+            'average_daily_users__gte': 100,
+            'average_daily_users__lt': 1000,
+        }
+
+    def test_average_growth(self):
+        addon_factory(hotness=0.5, average_daily_users=1000)  # Different tier
+        addon_factory(
+            hotness=0.5, average_daily_users=999, status=amo.STATUS_DISABLED
+        )  # Right tier but disabled
+        addon_factory(
+            hotness=0.5, average_daily_users=999, type=amo.ADDON_STATICTHEME
+        )  # Right tier but not an extension
+        addon_factory(hotness=0.1, average_daily_users=100)
+        addon_factory(hotness=0.2, average_daily_users=999)
+        assert round(self.tier.average_growth, ndigits=2) == 0.15
+
+        # Value is cached on the instance
+        addon_factory(hotness=0.3, average_daily_users=500)
+        assert round(self.tier.average_growth, ndigits=2) == 0.15
+        del self.tier.average_growth
+        assert round(self.tier.average_growth, ndigits=2) == 0.2
+
+    def test_get_growth_threshold(self):
+        assert round(self.tier.get_growth_threshold(), ndigits=2) == 0.5
+        addon_factory(hotness=0.01, average_daily_users=100)
+        addon_factory(hotness=0.01, average_daily_users=999)
+        del self.tier.average_growth
+        assert round(self.tier.get_growth_threshold(), ndigits=2) == 0.51
+
+        addon_factory(hotness=0.78, average_daily_users=999)
+        del self.tier.average_growth
+        assert round(self.tier.get_growth_threshold(), ndigits=2) == 0.77
+
+    def test_get_growth_threshold_q_object(self):
+        addon_factory(hotness=0.01, average_daily_users=100)
+        addon_factory(hotness=0.01, average_daily_users=999)
+        expected = [addon_factory(hotness=0.78, average_daily_users=999)]
+
+        assert (
+            list(Addon.objects.filter(self.tier.get_growth_threshold_q_object()))
+            == expected
+        )


### PR DESCRIPTION
Also contains a refactor to make the code easier to test, as well as admin & reviewer tools tweaks to make the consequences of changing that threshold more obvious.

If the average hotness in a tier is 0.1, and the growth threshold is set to 50, we used to flag add-ons in that tier with hotness over 0.15 (percentage increase) now we'll flag over 0.51 (percentage points increase).

Fixes mozilla/addons#15178

### Screenshots

New admin features:
![Screenshot 2024-11-21 at 14-45-47 low Change usage tier Django site admin](https://github.com/user-attachments/assets/5d8696e4-e008-4436-b4dd-673f74f6e51d)

### Testing

You can add addons with various `hotness` and `average_daily_users` values to your local environment to test and trigger `flag_high_hotness_according_to_review_tier` task (if the add-on is flagged, it should get a `NeedsHumanReview` instance with `HOTNESS_THRESHOLD` reason attached to the latest signed version in each channel that hasn't already been explicitly reviewed by a human), or trust the unit tests that do that.
