### PR TITLE
Support uploading stash/filter from multiple block types

### DIFF
--- a/src/olympia/blocklist/cron.py
+++ b/src/olympia/blocklist/cron.py
@@ -29,7 +29,9 @@ def get_last_generation_time():
 
 
 def get_base_generation_time():
-    return get_config(MLBF_BASE_ID_CONFIG_KEY, None, json_value=True)
+    return get_config(
+        MLBF_BASE_ID_CONFIG_KEY(BlockType.BLOCKED, compat=True), None, json_value=True
+    )
 
 
 def get_blocklist_last_modified_time():
@@ -130,7 +132,11 @@ def _upload_mlbf_to_remote_settings(*, force_base=False):
     else:
         mlbf.generate_and_write_stash(previous_filter)
 
-    upload_filter.delay(generation_time, is_base=make_base_filter)
+    upload_filter.delay(
+        generation_time,
+        filter_list=[BlockType.BLOCKED.name] if make_base_filter else [],
+        create_stash=not make_base_filter,
+    )
 
     if base_filter:
         cleanup_old_files.delay(base_filter_id=base_filter.created_at)

--- a/src/olympia/blocklist/mlbf.py
+++ b/src/olympia/blocklist/mlbf.py
@@ -207,15 +207,14 @@ class MLBF:
             for (guid, version) in input_list
         ]
 
-    @property
-    def filter_path(self):
+    def filter_path(self, _block_type: BlockType = BlockType.BLOCKED):
         return self.storage.path('filter')
 
     @property
     def stash_path(self):
         return self.storage.path('stash.json')
 
-    def generate_and_write_filter(self):
+    def generate_and_write_filter(self, block_type: BlockType = BlockType.BLOCKED):
         stats = {}
 
         bloomfilter = generate_mlbf(
@@ -225,7 +224,7 @@ class MLBF:
         )
 
         # write bloomfilter
-        mlbf_path = self.filter_path
+        mlbf_path = self.filter_path(block_type)
         with self.storage.open(mlbf_path, 'wb') as filter_file:
             log.info(f'Writing to file {mlbf_path}')
             bloomfilter.tofile(filter_file)

--- a/src/olympia/blocklist/tasks.py
+++ b/src/olympia/blocklist/tasks.py
@@ -112,15 +112,15 @@ def upload_filter(generation_time, filter_list=None, create_stash=False):
     attachment_types_to_delete = []
 
     for block_type in BlockType:
-        # Skip soft blocked filters if the switch is not active
+        # Skip soft blocked filters if the switch is not active.
         if block_type == BlockType.SOFT_BLOCKED and not waffle.switch_is_active(
             'enable-soft-blocking'
         ):
             continue
 
-        # Only upload filters that are in the filter_list arg
+        # Only upload filters that are in the filter_list arg.
         # We cannot send enum values to tasks so we serialize
-        # them in the filter_list arg as the name of the enum
+        # them in the filter_list arg as the name of the enum.
         if filter_list and block_type.name in filter_list:
             filters_to_upload.append(block_type)
 
@@ -130,7 +130,7 @@ def upload_filter(generation_time, filter_list=None, create_stash=False):
         )
 
         # If there is an existing base filter id, we need to keep track of it
-        # so we can potentially delete stashes older than this timestamp
+        # so we can potentially delete stashes older than this timestamp.
         if base_filter_id is not None:
             base_filter_ids[block_type] = base_filter_id
 
@@ -151,7 +151,7 @@ def upload_filter(generation_time, filter_list=None, create_stash=False):
 
         statsd.incr('blocklist.tasks.upload_filter.upload_mlbf.base')
         # Update the base filter id for this block type to the generation time
-        # so we can delete stashes older than this new filter
+        # so we can delete stashes older than this new filter.
         base_filter_ids[block_type] = generation_time
 
     # It is possible to upload a stash and a filter in the same task.
@@ -168,14 +168,14 @@ def upload_filter(generation_time, filter_list=None, create_stash=False):
             statsd.incr('blocklist.tasks.upload_filter.upload_stash')
 
     # Get the oldest base filter id so we can delete only stashes
-    # that are definitely not needed anymore
+    # that are definitely not needed anymore.
     oldest_base_filter_id = min(base_filter_ids.values()) if base_filter_ids else None
 
     for record in old_records:
         # Delete attachment records that match the
-        # attachment types of filters we just uplaoded
-        # this ensures we only have one filter attachment
-        # per block_type
+        # attachment types of filters we just uploaded.
+        # This ensures we only have one filter attachment
+        # per block_type.
         if 'attachment' in record:
             attachment_type = record['attachment_type']
             if attachment_type in attachment_types_to_delete:
@@ -183,13 +183,13 @@ def upload_filter(generation_time, filter_list=None, create_stash=False):
 
         # Delete stash records that are older than the oldest
         # pre-existing filter attachment records. These records
-        # cannot apply to any existing filter since we uploaded
+        # cannot apply to any existing filter since we uploaded.
         elif 'stash' in record and oldest_base_filter_id is not None:
             record_time = record['stash_time']
             if record_time < oldest_base_filter_id:
                 server.delete_record(record['id'])
 
-    # Commit the changes to remote settings for review.
+    # Commit the changes to remote settings for review + signing.
     # Only after any changes to records (attachments and stashes)
     # and including deletions can we commit the session and update
     # the config with the new timestamps.

--- a/src/olympia/blocklist/tests/test_commands.py
+++ b/src/olympia/blocklist/tests/test_commands.py
@@ -38,4 +38,4 @@ class TestExportBlocklist(TestCase):
 
         call_command('export_blocklist', '1')
         mlbf = MLBF.load_from_storage(1)
-        assert mlbf.storage.exists(mlbf.filter_path)
+        assert mlbf.storage.exists(mlbf.filter_path())

--- a/src/olympia/blocklist/tests/test_cron.py
+++ b/src/olympia/blocklist/tests/test_cron.py
@@ -220,8 +220,8 @@ class TestUploadToRemoteSettings(TestCase):
         ].call_args_list == [
             mock.call(
                 self.current_time,
-                filter_list=[BlockType.BLOCKED.name] if force_base else [],
-                create_stash=not force_base,
+                filter_list=[],
+                create_stash=True,
             )
         ]
         mlbf = MLBF.load_from_storage(self.current_time)

--- a/src/olympia/blocklist/tests/test_cron.py
+++ b/src/olympia/blocklist/tests/test_cron.py
@@ -100,7 +100,7 @@ class TestUploadToRemoteSettings(TestCase):
 
         # Check that a filter was created on the second attempt
         mlbf = MLBF.load_from_storage(self.current_time)
-        assert mlbf.storage.exists(mlbf.filter_path)
+        assert mlbf.storage.exists(mlbf.filter_path())
         assert not mlbf.storage.exists(mlbf.stash_path)
 
     def test_skip_update_unless_no_base_mlbf(self):
@@ -220,11 +220,12 @@ class TestUploadToRemoteSettings(TestCase):
         ].call_args_list == [
             mock.call(
                 self.current_time,
-                is_base=force_base,
+                filter_list=[BlockType.BLOCKED.name] if force_base else [],
+                create_stash=not force_base,
             )
         ]
         mlbf = MLBF.load_from_storage(self.current_time)
-        assert mlbf.storage.exists(mlbf.filter_path) == force_base
+        assert mlbf.storage.exists(mlbf.filter_path()) == force_base
         assert mlbf.storage.exists(mlbf.stash_path) != force_base
 
     def test_upload_stash_unless_missing_base_filter(self):
@@ -238,11 +239,12 @@ class TestUploadToRemoteSettings(TestCase):
         ].call_args_list == [
             mock.call(
                 self.current_time,
-                is_base=False,
+                filter_list=[],
+                create_stash=True,
             )
         ]
         mlbf = MLBF.load_from_storage(self.current_time)
-        assert not mlbf.storage.exists(mlbf.filter_path)
+        assert not mlbf.storage.exists(mlbf.filter_path())
         assert mlbf.storage.exists(mlbf.stash_path)
 
         self.mocks[
@@ -252,11 +254,12 @@ class TestUploadToRemoteSettings(TestCase):
         assert (
             mock.call(
                 self.current_time,
-                is_base=True,
+                filter_list=[BlockType.BLOCKED.name],
+                create_stash=False,
             )
             in self.mocks['olympia.blocklist.cron.upload_filter.delay'].call_args_list
         )
-        assert mlbf.storage.exists(mlbf.filter_path)
+        assert mlbf.storage.exists(mlbf.filter_path())
 
     @mock.patch('olympia.blocklist.cron.BASE_REPLACE_THRESHOLD', 1)
     def test_upload_stash_unless_enough_changes(self):
@@ -271,11 +274,12 @@ class TestUploadToRemoteSettings(TestCase):
         ].call_args_list == [
             mock.call(
                 self.current_time,
-                is_base=False,
+                filter_list=[],
+                create_stash=True,
             )
         ]
         mlbf = MLBF.load_from_storage(self.current_time)
-        assert not mlbf.storage.exists(mlbf.filter_path)
+        assert not mlbf.storage.exists(mlbf.filter_path())
         assert mlbf.storage.exists(mlbf.stash_path)
 
         self._block_version(is_signed=True)
@@ -288,12 +292,13 @@ class TestUploadToRemoteSettings(TestCase):
         assert (
             mock.call(
                 self.current_time,
-                is_base=True,
+                filter_list=[BlockType.BLOCKED.name],
+                create_stash=False,
             )
             in self.mocks['olympia.blocklist.cron.upload_filter.delay'].call_args_list
         )
         new_mlbf = MLBF.load_from_storage(self.current_time)
-        assert new_mlbf.storage.exists(new_mlbf.filter_path)
+        assert new_mlbf.storage.exists(new_mlbf.filter_path())
         assert not new_mlbf.storage.exists(new_mlbf.stash_path)
 
     def test_cleanup_old_files(self):
@@ -374,7 +379,8 @@ class TestUploadToRemoteSettings(TestCase):
         assert (
             mock.call(
                 self.current_time,
-                is_base=False,
+                filter_list=[],
+                create_stash=True,
             )
             in self.mocks['olympia.blocklist.cron.upload_filter.delay'].call_args_list
         )
@@ -393,7 +399,7 @@ class TestTimeMethods(TestCase):
 
     def test_get_base_generation_time(self):
         assert get_base_generation_time() is None
-        set_config(MLBF_BASE_ID_CONFIG_KEY, 1)
+        set_config(MLBF_BASE_ID_CONFIG_KEY(BlockType.BLOCKED, compat=True), 1)
         assert get_base_generation_time() == 1
 
 

--- a/src/olympia/blocklist/tests/test_tasks.py
+++ b/src/olympia/blocklist/tests/test_tasks.py
@@ -298,8 +298,8 @@ class TestUploadMLBFToRemoteSettings(TestCase):
 
     def test_cleanup_old_records(self):
         """
-        Clean up 0 because its the only record matching the uplaoded filters
-        attachment_type or is older than genreation_time
+        Clean up 0 because it's the only record matching the uploaded filters
+        attachment_type or is older than generation_time.
         """
         self._test_cleanup_old_records(
             filter_list={
@@ -317,7 +317,7 @@ class TestUploadMLBFToRemoteSettings(TestCase):
 
     def test_cleanup_oldest_stash_records(self):
         """
-        The oldest base id time is (self.generation_time -3)
+        The oldest base id time is (self.generation_time - 3)
         Delete 0 as matching attachment
         Delete 1 as older than base id
         """

--- a/src/olympia/blocklist/tests/test_tasks.py
+++ b/src/olympia/blocklist/tests/test_tasks.py
@@ -1,7 +1,6 @@
 import json
 import os
 from datetime import datetime, timedelta
-from typing import Dict, List
 from unittest import TestCase, mock
 
 from django.conf import settings
@@ -267,7 +266,9 @@ class TestUploadMLBFToRemoteSettings(TestCase):
 
         upload_filter(self.generation_time, filter_list=[])
 
-        assert get_config(MLBF_BASE_ID_CONFIG_KEY(BlockType.BLOCKED, compat=True)) == None
+        assert (
+            get_config(MLBF_BASE_ID_CONFIG_KEY(BlockType.BLOCKED, compat=True)) is None
+        )
         assert not self.mocks['delete_record'].called
 
         set_config(
@@ -335,9 +336,11 @@ class TestUploadMLBFToRemoteSettings(TestCase):
             json_value=True,
         )
         upload_filter(self.generation_time, filter_list=[])
-        assert self.mocks['delete_record'].call_args_list == [mock.call(0), mock.call(1)]
+        assert self.mocks['delete_record'].call_args_list == [
+            mock.call(0),
+            mock.call(1),
+        ]
         self.mocks['delete_record'].reset_mock()
-
 
         # Delete all records older than the new active filter
         # which is t3
@@ -384,7 +387,8 @@ class TestUploadMLBFToRemoteSettings(TestCase):
         mlbf = MLBF.generate_from_db(t2)
         mlbf.generate_and_write_filter(BlockType.BLOCKED)
 
-        # Remote settings returns the old filter and a stash created before the new filter
+        # Remote settings returns the old filter
+        # and a stash created before the new filter
         # this stash should also be deleted
         self.mocks['records'].return_value = [
             self._attachment(0, 'bloomfilter-base', t0),
@@ -419,9 +423,7 @@ class TestUploadMLBFToRemoteSettings(TestCase):
             self._stash(1, t0),
         ]
 
-        upload_filter(
-            self.generation_time, filter_list=[BlockType.SOFT_BLOCKED.name]
-        )
+        upload_filter(self.generation_time, filter_list=[BlockType.SOFT_BLOCKED.name])
 
         assert not self.mocks['delete_record'].called
 
@@ -469,9 +471,7 @@ class TestUploadMLBFToRemoteSettings(TestCase):
 
     def test_raises_when_no_filter_exists(self):
         with self.assertRaises(FileNotFoundError):
-            upload_filter(
-                self.generation_time, filter_list=[BlockType.BLOCKED.name]
-            )
+            upload_filter(self.generation_time, filter_list=[BlockType.BLOCKED.name])
 
     def test_raises_when_no_stash_exists(self):
         with self.assertRaises(FileNotFoundError):

--- a/src/olympia/constants/blocklist.py
+++ b/src/olympia/constants/blocklist.py
@@ -1,8 +1,22 @@
 # How many guids should there be in the stashes before we make a new base.
+from olympia.blocklist.models import BlockType
+
+
 BASE_REPLACE_THRESHOLD = 5_000
 
 # Config keys used to track recent mlbf ids
 MLBF_TIME_CONFIG_KEY = 'blocklist_mlbf_generation_time'
-MLBF_BASE_ID_CONFIG_KEY = 'blocklist_mlbf_base_id'
+
+
+def MLBF_BASE_ID_CONFIG_KEY(block_type: BlockType, compat: bool = False):
+    """
+    We use compat to return the old singular config key for hard blocks.
+    This allows us to migrate writes to the new plural key right now without
+    losing access to the old existing key when deploying this patch.
+    """
+    if compat and block_type == BlockType.BLOCKED:
+        return 'blocklist_mlbf_base_id'
+    return f'blocklist_mlbf_base_id_{block_type.name.lower()}'
+
 
 REMOTE_SETTINGS_COLLECTION_MLBF = 'addons-bloomfilters'

--- a/src/olympia/lib/tests/test_remote_settings.py
+++ b/src/olympia/lib/tests/test_remote_settings.py
@@ -21,6 +21,22 @@ class TestRemoteSettings(TestCase):
         server = RemoteSettings('foo', 'baa')
         assert server.bucket == 'foo'
 
+    def test_records(self):
+        server = RemoteSettings('foo', 'baa')
+
+        for data in [{'id': 'an-id'}], []:
+            responses.add(
+                responses.GET,
+                settings.REMOTE_SETTINGS_WRITER_URL
+                + 'buckets/foo/collections/baa/records',
+                content_type='application/json',
+                json={'data': data},
+            )
+            assert server.records() == data
+            # Reset the responses so that the next test
+            # doesn't get the responses from the previous test.
+            responses.reset()
+
     def test_publish_record(self):
         server = RemoteSettings('foo', 'baa')
         server._setup_done = True


### PR DESCRIPTION
Relates to: mozilla/addons#15014

### Description

Adds support for uploading filters and stashes simultaneously as well as supporting soft/hard filters.

### Context

Supporting https://github.com/mozilla/addons-server/pull/22828

### Testing

### Setup

- Setup a local remote server [here](https://gist.github.com/willdurand/f2fcc937a00050aa80a16807d550abf3)
- Set the base replace threshold to a low number (so you can trigger re-uploading of filters without creating a bunch of blocks)
- enable `enable-soft-blocking` and `blocklist_mlbf_submit` waffle switch

`src/olympia/constants/blocklist.py`

```python
BASE_REPLACE_THRESHOLD = 2
```

See the [test scenarios](https://github.com/mozilla/addons-server/pull/22828#issuecomment-2489370673)

```python
from olympia.blocklist.models import BlockType
from olympia.amo.tests import addon_factory, block_factory, version_factory

def _blocked_addon(block_type=BlockType.BLOCKED, **kwargs):
    addon = addon_factory(**kwargs)
    block = block_factory(
        guid=addon.guid, updated_by=user, block_type=block_type
    )
    return addon, block

user = UserProfile.objects.first()
```

Now you can call the `_blocked_addon` method to create an addon with block/version of the specified type.

Ex:

```python
_blocked_addon(block_type=BlockType.BLOCKED)
_blocked_addon(block_type=BlockType.BLOCKED)
_blocked_addon(block_type=BlockType.SOFT_BLOCKED)
```

This PR will not change any of the existing behavior so you expect to see a new stash record if >0<Replace threshold changes or a new filter if >Replace threshold changes, also if new filter expect previous stashes to be deleted.

> Important @willdurand you need to remove the soft block config key from admin or the deletion will depend on arbitrary soft block times which are probably wrong

### Force recreate

First force recreate the filter

```bash
./manage.py cron upload_mlbf_to_remote_settings force_base=True
```

Expect only an attachment record, regardless of what was there before.

### Create a stash

Create one new block

```python
_blocked_addon(block_type=BlockType.BLOCKED file_kw={'is_signed': True})
```

```bash
./manage.py cron upload_mlbf_to_remote_settings
```

Expect a stash record uploaded

Repeat, expect another stash record

Repeat, now expect a new filter and all stashes deleted.

You can create as many soft blocks at any point in this flow and it should have zero impact.

### Checklist

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
