### PR TITLE
Add support for soft/hard block in upload_to_mllf_to_remote_settings cron

### DIFF
--- a/src/olympia/blocklist/cron.py
+++ b/src/olympia/blocklist/cron.py
@@ -116,13 +116,6 @@ def _upload_mlbf_to_remote_settings(*, force_base=False):
         len(mlbf.data.not_blocked_items),
     )
 
-    # Until we are ready to enable soft blocking, it should not be possible
-    # to create a stash and a filter at the same iteration
-    # This should never happen, but we'll raise an exception just in case.
-    assert not (create_stash and len(base_filters_to_update) > 0), (
-        'Cannot upload stash and filter without implementing soft blocking'
-    )
-
     if create_stash:
         mlbf.generate_and_write_stash(previous_filter)
 

--- a/src/olympia/blocklist/cron.py
+++ b/src/olympia/blocklist/cron.py
@@ -77,9 +77,9 @@ def _upload_mlbf_to_remote_settings(*, force_base=False):
     create_stash = False
 
     # Determine which base filters need to be re uploaded
-    # and whether a new stash needs to be created
+    # and whether a new stash needs to be created.
     for block_type in BlockType:
-        # This prevents us from updating a stash or filter based on new soft blocks
+        # This prevents us from updating a stash or filter based on new soft blocks.
         if block_type == BlockType.SOFT_BLOCKED:
             log.info(
                 'Skipping soft-blocks because enable-soft-blocking switch is inactive'
@@ -88,22 +88,22 @@ def _upload_mlbf_to_remote_settings(*, force_base=False):
 
         base_filter = MLBF.load_from_storage(get_base_generation_time(block_type))
 
-        # add this block type to the list of filters to be re-uploaded
+        # Add this block type to the list of filters to be re-uploaded.
         if (
             force_base
             or base_filter is None
             or mlbf.should_upload_filter(block_type, base_filter)
         ):
             base_filters_to_update.append(block_type)
-        # only update the stash if we should AND if
-        # we aren't already reuploading the filter for this block type
+        # Only update the stash if we should AND if we aren't already 
+        # re-uploading the filter for this block type.
         elif mlbf.should_upload_stash(block_type, previous_filter or base_filter):
             create_stash = True
 
     skip_update = len(base_filters_to_update) == 0 and not create_stash
     if skip_update:
         log.info('No new/modified/deleted Blocks in database; skipping MLBF generation')
-        # Delete the locally generated MLBF directory and files as they are not needed
+        # Delete the locally generated MLBF directory and files as they are not needed.
         mlbf.delete()
         return
 

--- a/src/olympia/blocklist/cron.py
+++ b/src/olympia/blocklist/cron.py
@@ -119,10 +119,9 @@ def _upload_mlbf_to_remote_settings(*, force_base=False):
     # Until we are ready to enable soft blocking, it should not be possible
     # to create a stash and a filter at the same iteration
     # This should never happen, but we'll raise an exception just in case.
-    if create_stash and len(base_filters_to_update) > 0:
-        raise Exception(
-            'Cannot upload stash and filter without implementing soft blocking'
-        )
+    assert not (create_stash and len(base_filters_to_update) > 0), (
+        'Cannot upload stash and filter without implementing soft blocking'
+    )
 
     if create_stash:
         mlbf.generate_and_write_stash(previous_filter)

--- a/src/olympia/blocklist/cron.py
+++ b/src/olympia/blocklist/cron.py
@@ -95,7 +95,7 @@ def _upload_mlbf_to_remote_settings(*, force_base=False):
             or mlbf.should_upload_filter(block_type, base_filter)
         ):
             base_filters_to_update.append(block_type)
-        # Only update the stash if we should AND if we aren't already 
+        # Only update the stash if we should AND if we aren't already
         # re-uploading the filter for this block type.
         elif mlbf.should_upload_stash(block_type, previous_filter or base_filter):
             create_stash = True
@@ -118,6 +118,7 @@ def _upload_mlbf_to_remote_settings(*, force_base=False):
 
     # Until we are ready to enable soft blocking, it should not be possible
     # to create a stash and a filter at the same iteration
+    # This should never happen, but we'll raise an exception just in case.
     if create_stash and len(base_filters_to_update) > 0:
         raise Exception(
             'Cannot upload stash and filter without implementing soft blocking'

--- a/src/olympia/blocklist/tests/test_commands.py
+++ b/src/olympia/blocklist/tests/test_commands.py
@@ -9,6 +9,7 @@ from olympia.amo.tests import (
     version_factory,
 )
 from olympia.blocklist.mlbf import MLBF
+from olympia.blocklist.models import BlockType
 
 
 class TestExportBlocklist(TestCase):
@@ -38,4 +39,4 @@ class TestExportBlocklist(TestCase):
 
         call_command('export_blocklist', '1')
         mlbf = MLBF.load_from_storage(1)
-        assert mlbf.storage.exists(mlbf.filter_path())
+        assert mlbf.storage.exists(mlbf.filter_path(BlockType.BLOCKED))

--- a/src/olympia/blocklist/tests/test_cron.py
+++ b/src/olympia/blocklist/tests/test_cron.py
@@ -617,7 +617,7 @@ class TestUploadToRemoteSettings(TestCase):
         upload_mlbf_to_remote_settings(force_base=False)
         assert not self.mocks['olympia.blocklist.cron.upload_filter.delay'].called
 
-        # delete the last filter, now the base filter will be used to compare
+        # Delete the last filter, now the base filter will be used to compare
         MLBF.load_from_storage(self.last_time).delete()
         upload_mlbf_to_remote_settings(force_base=False)
         # We expect to not upload anything as soft blocking is disabled
@@ -698,8 +698,8 @@ class TestTimeMethods(TestCase):
     def test_get_base_generation_time(self):
         for block_type in BlockType:
             assert get_base_generation_time(block_type) is None
-            set_config(MLBF_BASE_ID_CONFIG_KEY(block_type, compat=True), 1)
-            assert get_base_generation_time(block_type) == 1
+            set_config(MLBF_BASE_ID_CONFIG_KEY(block_type, compat=True), 123)
+            assert get_base_generation_time(block_type) == 123
 
 
 @pytest.mark.django_db

--- a/src/olympia/blocklist/tests/test_cron.py
+++ b/src/olympia/blocklist/tests/test_cron.py
@@ -580,7 +580,6 @@ class TestUploadToRemoteSettings(TestCase):
                 create_stash=False,
             )
             mlbf = MLBF.load_from_storage(self.current_time)
-            mlbf = MLBF.load_from_storage(self.current_time)
             assert mlbf.storage.exists(mlbf.filter_path(BlockType.BLOCKED))
             assert not mlbf.storage.exists(mlbf.stash_path)
 

--- a/src/olympia/blocklist/tests/test_cron.py
+++ b/src/olympia/blocklist/tests/test_cron.py
@@ -503,7 +503,6 @@ class TestUploadToRemoteSettings(TestCase):
                 )
             ) in self.mocks['olympia.blocklist.cron.upload_filter.delay'].call_args_list
 
-    # TODO: add test for soft blocks and ensure stash/filter compatibility
     @mock.patch('olympia.blocklist.mlbf.BASE_REPLACE_THRESHOLD', 1)
     @override_switch('enable-soft-blocking', active=True)
     def test_upload_stash_unless_enough_changes(self):

--- a/src/olympia/blocklist/tests/test_mlbf.py
+++ b/src/olympia/blocklist/tests/test_mlbf.py
@@ -262,6 +262,18 @@ class TestMLBFDataBaseLoader(_MLBFBase):
 
 
 class TestMLBF(_MLBFBase):
+    def test_filter_path(self):
+        mlbf = MLBF.generate_from_db('test')
+        assert mlbf.filter_path(BlockType.BLOCKED, compat=True).endswith('filter')
+        assert mlbf.filter_path(BlockType.BLOCKED).endswith('filter-blocked')
+        assert mlbf.filter_path(BlockType.SOFT_BLOCKED).endswith('filter-soft_blocked')
+
+    def test_save_filter_writes_to_both_file_names(self):
+        mlbf = MLBF.generate_from_db('test')
+        mlbf.generate_and_write_filter(BlockType.BLOCKED)
+        assert mlbf.storage.exists('filter')
+        assert mlbf.storage.exists('filter-blocked')
+
     def test_get_data_from_db(self):
         self._blocked_addon()
         mlbf = MLBF.generate_from_db('test')

--- a/src/olympia/blocklist/tests/test_tasks.py
+++ b/src/olympia/blocklist/tests/test_tasks.py
@@ -284,6 +284,7 @@ class TestUploadMLBFToRemoteSettings(TestCase):
     def test_cleanup_records_with_matching_attachment(self):
         mlbf = MLBF.generate_from_db(self.generation_time)
         mlbf.generate_and_write_filter(BlockType.BLOCKED)
+        mlbf.generate_and_write_filter(BlockType.SOFT_BLOCKED)
 
         self.mocks['records'].return_value = [
             self._attachment(0, 'bloomfilter-base', self.generation_time - 1),


### PR DESCRIPTION
Relates to: https://github.com/mozilla/addons/issues/15014

### Description

- adds support to process fort blocks in the cron
- does not actually support soft blocks, we skip them always
- adds test proving we always skip them

### Context

This commit makes actually adding them more clear and easier to grok

### Testing

Test exactly the same as <https://github.com/mozilla/addons-server/pull/22828>

Adding hard or soft blocks should produce only hard block filter/stash regardless of the soft block change count or the `enable-soft-blocking` waffle_switch.

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
