### PR TITLE
Fix error when users.table does not exist yet during initialize

### DIFF
--- a/src/olympia/amo/management/commands/initialize.py
+++ b/src/olympia/amo/management/commands/initialize.py
@@ -3,6 +3,8 @@ import logging
 from django.conf import settings
 from django.core.management import call_command
 
+from olympia.users.models import UserProfile
+
 from .. import BaseDataCommand
 
 
@@ -25,9 +27,11 @@ class Command(BaseDataCommand):
         )
 
     def local_admin_exists(self):
-        from olympia.users.models import UserProfile
-
-        return UserProfile.objects.filter(email=settings.LOCAL_ADMIN_EMAIL).exists()
+        try:
+            return UserProfile.objects.filter(email=settings.LOCAL_ADMIN_EMAIL).exists()
+        except Exception as e:
+            logging.error(f'Error checking if local admin exists: {e}')
+            return False
 
     def handle(self, *args, **options):
         """

--- a/src/olympia/amo/tests/test_commands.py
+++ b/src/olympia/amo/tests/test_commands.py
@@ -350,6 +350,16 @@ class TestInitializeDataCommand(BaseTestDataCommand):
             ],
         )
 
+    @mock.patch('olympia.amo.management.commands.initialize.UserProfile.objects.filter')
+    def test_handle_mysql_exception(self, mock_filter):
+        mock_filter.return_value.exists.side_effect = Exception('test')
+
+        call_command('initialize')
+        self._assert_commands_called_in_order(
+            self.mocks['mock_call_command'],
+            [self.mock_commands.data_seed],
+        )
+
 
 class TestBaseDataCommand(BaseTestDataCommand):
     def setUp(self):


### PR DESCRIPTION
Fixes: mozilla/addons#15196

Follow up: https://github.com/mozilla/addons-server/pull/22860

### Description

Add error handling to check_users in the initialize script

### Context

When running `initialize` we check if there are any users in the user table.. however if you run this command before the database has been migrated, it will raise a mysql error.

We should handle that such that if the query errors, we assume no users and return false

### Testing

```bash
make down
make docker_mysqld_volume_remove
make up
```

Should not error

### Checklist


- [ ] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
