### PR TITLE
Display block type in reviewer tools & Use specific activity log for soft-blocking versions

### DIFF
--- a/src/olympia/blocklist/admin.py
+++ b/src/olympia/blocklist/admin.py
@@ -17,7 +17,7 @@ from .forms import (
     MultiAddForm,
     MultiDeleteForm,
 )
-from .models import Block, BlocklistSubmission, BlockVersion
+from .models import Block, BlocklistSubmission, BlockType, BlockVersion
 from .tasks import process_blocklistsubmission
 from .utils import splitlines
 
@@ -540,7 +540,9 @@ class BlocklistSubmissionAdmin(AMOModelAdmin):
             .filter(action__in=Block.ACTIVITY_IDS)
             .order_by('created')
         )
-        return render_to_string('admin/blocklist/includes/logs.html', {'logs': logs})
+        return render_to_string(
+            'admin/blocklist/includes/logs.html', {'BlockType': BlockType, 'logs': logs}
+        )
 
 
 @admin.register(Block)
@@ -597,6 +599,7 @@ class BlockAdmin(BlockAdminAddMixin, AMOModelAdmin):
         return render_to_string(
             'admin/blocklist/includes/logs.html',
             {
+                'BlockType': BlockType,
                 'logs': logs,
                 'blocklistsubmission': submission,
                 'blocklistsubmission_changes': submission.get_changes_from_block(obj)

--- a/src/olympia/blocklist/templates/admin/blocklist/includes/logs.html
+++ b/src/olympia/blocklist/templates/admin/blocklist/includes/logs.html
@@ -10,7 +10,8 @@
         {% if log.details %}{{ log.details.guid }}{% else %}{{ log.arguments.1 }}{% endif %}{% if 'min_version' in log.details %}
             , versions {{ log.details.min_version }} - {{ log.details.max_version }}.
         {% elif 'added_versions' in log.details %}
-        , versions {% if log.details.soft %}soft-{% else %}hard-{% endif %}blocked [{{ log.details.added_versions|join:', ' }}].
+          {# log.details.block_type was added for soft-blocks, if absent the block is a hard one #}
+        , versions {% if log.details.block_type == BlockType.SOFT_BLOCKED %}soft-{% else %}hard-{% endif %}blocked [{{ log.details.added_versions|join:', ' }}].
         {% elif 'removed_versions' in log.details %}
         , versions unblocked [{{ log.details.removed_versions|join:', ' }}].
         {% else %}.

--- a/src/olympia/blocklist/tests/test_admin.py
+++ b/src/olympia/blocklist/tests/test_admin.py
@@ -635,7 +635,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
         assert block_log.details['blocked_versions'] == changed_version_strs
         assert block_log.details['added_versions'] == changed_version_strs
         assert block_log.details['reason'] == 'some reason'
-        assert not block_log.details['soft']
+        assert block_log.details['block_type'] == BlockType.BLOCKED
         assert block_log == (
             ActivityLog.objects.for_block(block).filter(action=block_log.action).get()
         )

--- a/src/olympia/blocklist/tests/test_utils.py
+++ b/src/olympia/blocklist/tests/test_utils.py
@@ -102,7 +102,7 @@ class TestSaveVersionsToBlocks(TestCase):
             'guid': f'{addon.guid}',
             'reason': 'some reason',
             'signoff_state': 'Published',
-            'soft': False,
+            'block_type': BlockType.BLOCKED,
             'url': '',
         }
 
@@ -159,7 +159,7 @@ class TestSaveVersionsToBlocks(TestCase):
             'guid': f'{addon.guid}',
             'reason': 'some reason',
             'signoff_state': 'Published',
-            'soft': True,
+            'block_type': BlockType.SOFT_BLOCKED,
             'url': '',
         }
 

--- a/src/olympia/blocklist/utils.py
+++ b/src/olympia/blocklist/utils.py
@@ -45,7 +45,7 @@ def block_activity_log_save(
         ).display
         if submission_obj.signoff_by:
             details['signoff_by'] = submission_obj.signoff_by.id
-        details['soft'] = submission_obj.block_type == BlockType.SOFT_BLOCKED
+        details['block_type'] = submission_obj.block_type
         if submission_obj.block_type == BlockType.SOFT_BLOCKED:
             action_version = amo.LOG.BLOCKLIST_VERSION_SOFT_BLOCKED
 

--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -1092,6 +1092,15 @@ class HELD_ACTION_FORCE_DISABLE(_LOG):
     admin_event = True
 
 
+class BLOCKLIST_VERSION_SOFT_BLOCKED(_LOG):
+    id = 197
+    keep = True
+    action_class = 'add'
+    hide_developer = True
+    format = '{version} added to Soft Blocklist.'
+    short = 'Version Soft Blocked'
+
+
 LOGS = [x for x in vars().values() if isclass(x) and issubclass(x, _LOG) and x != _LOG]
 # Make sure there's no duplicate IDs.
 assert len(LOGS) == len({log.id for log in LOGS})

--- a/src/olympia/reviewers/templates/reviewers/includes/version.html
+++ b/src/olympia/reviewers/templates/reviewers/includes/version.html
@@ -21,7 +21,7 @@
     {% endif %}
 
     {% if version.is_blocked %}
-    <span class="blocked-version">Blocked</span>
+    <span class="blocked-version">{{ version.blockversion.get_block_type_display() }}</span>
     {% endif %}
   </th>
   <td class="due_date">

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -57,7 +57,7 @@ from olympia.amo.tests import (
     version_factory,
     version_review_flags_factory,
 )
-from olympia.blocklist.models import Block, BlocklistSubmission, BlockVersion
+from olympia.blocklist.models import Block, BlocklistSubmission, BlockType, BlockVersion
 from olympia.blocklist.utils import block_activity_log_save
 from olympia.constants.abuse import DECISION_ACTIONS
 from olympia.constants.promoted import LINE, NOTABLE, RECOMMENDED, SPOTLIGHT, STRATEGIC
@@ -5561,15 +5561,17 @@ class TestReview(ReviewBase):
         response = self.client.get(self.url)
         assert b'Blocked' in response.content
         span = pq(response.content)('#versions-history .blocked-version')
-        assert span.text() == 'Blocked'
+        assert span.text() == '🛑 Hard-Blocked'
         assert span.length == 1  # addon only has 1 version
 
         blockversion = BlockVersion.objects.create(
-            block=block, version=version_factory(addon=self.addon, version='99')
+            block=block,
+            version=version_factory(addon=self.addon, version='99'),
+            block_type=BlockType.SOFT_BLOCKED,
         )
         response = self.client.get(self.url)
         span = pq(response.content)('#versions-history .blocked-version')
-        assert span.text() == 'Blocked Blocked'
+        assert span.text() == '🛑 Hard-Blocked ⚠️ Soft-Blocked'
         assert span.length == 2  # a new version is blocked too
 
         block_reason = 'Very bad addon!'
@@ -5578,7 +5580,7 @@ class TestReview(ReviewBase):
         block_activity_log_save(obj=block, change=False)
         response = self.client.get(self.url)
         span = pq(response.content)('#versions-history .blocked-version')
-        assert span.text() == 'Blocked'
+        assert span.text() == '🛑 Hard-Blocked'
         assert span.length == 1
         assert 'Version Blocked' in (
             pq(response.content)('#versions-history .activity').text()


### PR DESCRIPTION
Fixes: mozilla/addons#15125

### Testing

Add some hard and soft-blocks / harden some soft-blocks / soften some hard-blocks: this should be reflected in reviewer tools review page next to the corresponding version in the history. (For accurate soft-block info, the block need to have been created as soft or softened after applying this patch)

### Screenshots

Version soft-blocked:
![Screenshot 2024-11-25 at 13-55-45 rabbil-rabugong-narkato – Add-ons for Firefox](https://github.com/user-attachments/assets/5a239f3e-4d79-48cd-90db-a4b5770da4fb)

Version soft-blocked then hardened:
![Screenshot 2024-11-25 at 14-23-01 rabbil-rabugong-narkato – Add-ons for Firefox](https://github.com/user-attachments/assets/8081b114-05be-45ff-b0ee-1b09875f5140)

