### PR TITLE
flag current version for NHR if available

### DIFF
--- a/src/olympia/abuse/tasks.py
+++ b/src/olympia/abuse/tasks.py
@@ -50,7 +50,7 @@ def flag_high_abuse_reports_addons_according_to_review_tier():
     abuse_reports_count_qs = (
         AbuseReport.objects.values('guid')
         .filter(
-            ~AbuseReportManager.is_individually_actionable_q(assume_guid_exists=True),
+            ~AbuseReportManager.is_individually_actionable_q(),
             guid=OuterRef('guid'),
             created__gte=datetime.now() - timedelta(days=14),
         )


### PR DESCRIPTION
Fixes: mozilla/addons#1988

### Description

Tighten the definition of a report that is individually reviewed, and align how we flag for needs human review with that.

### Context

There are a bunch of issues logged (mainly unlisted related) that I duped to mozilla/addons#15179 and this tries to address them all - but mainly by avoiding cases where we were pushing unlisted only add-ons through cinder in the first place.  

Appeals on unlisted are covered by https://github.com/mozilla/addons/issues/15182 and this doesn't try to address that issue - only not regress the listed version case.  

### Testing
- enable all DSA/abuse related waffle switches
- report an unlisted only add-on for abuse, without any version of it installed in Firefox; 
- see no job in Cinder in any of the queues.  (and nothing in the logs indicating an exception was raised)
- report an add-on that has at least one approved or awaiting_review versions locally, without any version of it installed in Firefox, for policy violation in the add-on; 
- see the add-on in the manual review queue in reviewer tools, with the current version (the most recent approved version; or the awaiting review version if none are approved) flagged for human review.
- reject that version
- appeal the rejection (email with the link will be in django email fakemail)
- see the add-on in the manual review queue in reviewer tools, with the most recent listed version flagged for human review.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [ ] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
