### PR TITLE
Don't show duplicate flags for NeedsHumanReview reasons already flagged explicitly

### DIFF
--- a/static/css/zamboni/reviewers.less
+++ b/static/css/zamboni/reviewers.less
@@ -56,6 +56,11 @@
 .ed-sprite-needs-human-review-from-abuse { background-position: 0 -468px; }
 .ed-sprite-needs-human-review-from-cinder { background-position: 0 -484px; }
 .ed-sprite-needs-human-review-from-appeal { background-position: 0 -500px; }
+/* Those NeedsHumanReview reasons are already handled through separate, more
+   precise flags, so hide them */
+.ed-sprite-needs-human-review-promoted { display: none; }
+.ed-sprite-needs-human-review-auto-approval-disabled { display: none; }
+.ed-sprite-is-from-theme-awaiting-review { display: none; }
 
 .ed-sprite-action-target-Extension { background-position: 0 -532px; }
 .ed-sprite-action-target-Theme { background-position: 0 -564px; }


### PR DESCRIPTION
Those new `NeedsHumanReview` reasons get a flag because they are in `VIEW_QUEUE_FLAGS`. That is useful for the form to filter the queue for those reasons, but they don't need to show the corresponding sprite icon, because we also already display one by checking `AddonReviewerFlags`/`PromotedAddon` state.

Fixes: mozilla/addons#15072 (see screenshots posted by QA)
