### PR TITLE
Remove race conditions in docker volumes during build/runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,7 +119,7 @@ ${PIP_COMMAND} install --progress-bar=off --no-deps --exists-action=w -r require
 npm ci ${NPM_ARGS} --include=prod
 EOF
 
-FROM base AS pip_development
+FROM pip_production AS pip_development
 
 RUN \
     # Files required to install pip dependencies

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,5 +1,5 @@
 services:
-  olympia:
+  volumes:
     environment:
       - HOST_UID=9500
     volumes:
@@ -8,9 +8,9 @@ services:
 
   worker:
     extends:
-      service: olympia
+      service: volumes
     depends_on:
-      - olympia
+      - volumes
   web:
     extends:
       service: worker
@@ -19,7 +19,7 @@ services:
     volumes:
       - storage:/srv/storage
     depends_on:
-      - olympia
+      - volumes
 
 volumes:
   storage:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,5 +1,5 @@
 services:
-  volumes:
+  olympia_volumes:
     environment:
       - HOST_UID=9500
     volumes:
@@ -8,9 +8,9 @@ services:
 
   worker:
     extends:
-      service: volumes
+      service: olympia_volumes
     depends_on:
-      - volumes
+      - olympia_volumes
   web:
     extends:
       service: worker
@@ -19,7 +19,7 @@ services:
     volumes:
       - storage:/srv/storage
     depends_on:
-      - volumes
+      - olympia_volumes
 
 volumes:
   storage:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,19 +1,25 @@
 services:
-  worker:
+  olympia:
     environment:
       - HOST_UID=9500
     volumes:
+      - storage:/data/olympia/storage
       - /data/olympia
 
+  worker:
+    extends:
+      service: olympia
+    depends_on:
+      - olympia
   web:
     extends:
       service: worker
-    volumes:
-      - storage:/data/olympia/storage
 
   nginx:
     volumes:
       - storage:/srv/storage
+    depends_on:
+      - olympia
 
 volumes:
   storage:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ x-olympia: &olympia
   entrypoint: ["/data/olympia/docker/entrypoint.sh"]
 
 services:
-  volumes:
+  olympia_volumes:
     <<: *olympia
     # We could let this container exit 0, but docker compose --wait
     # interprets this as a failure, even with a passing healtcheck.
@@ -107,7 +107,7 @@ services:
       - ./package.json:/deps/package.json
       - ./package-lock.json:/deps/package-lock.json
     depends_on:
-      - volumes
+      - olympia_volumes
 
   nginx:
     image: nginx
@@ -122,7 +122,7 @@ services:
         aliases:
           - olympia.test
     depends_on:
-      - volumes
+      - olympia_volumes
 
   memcached:
     image: memcached:1.4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,9 @@ x-env-mapping: &env
     - DEBUG
     - DATA_BACKUP_SKIP
 
+x-site-static-mount: &site-static-mount
+  data_site_static:/data/olympia/site-static
+
 x-olympia: &olympia
   <<: *env
   image: ${DOCKER_TAG:-}
@@ -39,6 +42,14 @@ x-olympia: &olympia
   entrypoint: ["/data/olympia/docker/entrypoint.sh"]
 
 services:
+  olympia:
+    <<: *olympia
+    # We could let this container exit 0, but docker compose --wait
+    # interprets this as a failure, even with a passing healtcheck.
+    # so we just sleep indefinitely instead.
+    command: ["sleep", "infinity"]
+    volumes:
+      - *site-static-mount
   worker:
     <<: *olympia
     command: [
@@ -53,12 +64,7 @@ services:
     ]
     volumes:
       - .:/data/olympia
-      # Don't mount generated files. They only exist in the container
-      # and would otherwiser be deleted by mounting the cwd volume above
-      - /data/olympia/static-build
-      - /data/olympia/site-static
-      - ./package.json:/deps/package.json
-      - ./package-lock.json:/deps/package-lock.json
+
     extra_hosts:
      - "olympia.test:127.0.0.1"
     restart: on-failure:5
@@ -93,12 +99,22 @@ services:
       start_period: 120s
     command:
       - uwsgi --ini /data/olympia/docker/uwsgi.ini
+    volumes:
+      # Don't mount generated files. They only exist in the container
+      # and would otherwiser be deleted by mounting the cwd volume above
+      - /data/olympia/static-build
+      - *site-static-mount
+      - ./package.json:/deps/package.json
+      - ./package-lock.json:/deps/package-lock.json
+    depends_on:
+      - olympia
 
   nginx:
     image: nginx
     volumes:
       - ./docker/nginx/addons.conf:/etc/nginx/conf.d/addons.conf
       - .:/srv
+      - *site-static-mount
     ports:
       - "80:80"
     networks:
@@ -106,8 +122,7 @@ services:
         aliases:
           - olympia.test
     depends_on:
-      - web
-      - addons-frontend
+      - olympia
 
   memcached:
     image: memcached:1.4
@@ -183,6 +198,9 @@ networks:
   default:
 
 volumes:
+  # Volumes for static files that should not be
+  # mounted from the host.
+  data_site_static:
   data_mysqld:
     # Keep this value in sync with Makefile-os
     # External volumes must be manually created/destroyed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ x-olympia: &olympia
   entrypoint: ["/data/olympia/docker/entrypoint.sh"]
 
 services:
-  olympia:
+  volumes:
     <<: *olympia
     # We could let this container exit 0, but docker compose --wait
     # interprets this as a failure, even with a passing healtcheck.
@@ -107,7 +107,7 @@ services:
       - ./package.json:/deps/package.json
       - ./package-lock.json:/deps/package-lock.json
     depends_on:
-      - olympia
+      - volumes
 
   nginx:
     image: nginx
@@ -122,7 +122,7 @@ services:
         aliases:
           - olympia.test
     depends_on:
-      - olympia
+      - volumes
 
   memcached:
     image: memcached:1.4


### PR DESCRIPTION
Fixes: mozilla/addons#15046

### Description

- creates base "olympia" service responsible for mounting shared docker volumes between services
- adds olympia as a dependency to any service using a shared volume.

### Context

It is not feasible to test a race condition like this, so instead the configuration and runtime checks are setup in a way to virtually guarantee:
- no volume used by more than one container can be created by any container other than "olympia"
- the correct volumes are used based on the given input parameters
- the compose project and make up can run in any of the given configurations and pass the basic "check" command

This comes [here](https://github.com/mozilla/addons-server/pull/22928) where tests are currently failing due to missing this patch.

### Testing

There isn't really a good way to test this PR outside of adding the commit from the other patch, and then running the `test_setup` tests to verify statically the configuration is valid.

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [x] Add or update relevant [docs](../docs/) reflecting the changes made.
