### PR TITLE
Set a higher DATA_UPLOAD_MAX_NUMBER_FIELDS on amo-internal-web instances

### DIFF
--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -39,6 +39,11 @@ ALLOWED_HOSTS = [
 # This variable should only be set to `True` for local env and internal hosts.
 INTERNAL_ROUTES_ALLOWED = env('INTERNAL_ROUTES_ALLOWED', default=False)
 
+if os.environ.get('ADDONS_SERVER_COMPONENT') == 'amo-internal-web':
+    # Allow (much) higher number of fields to be submitted to internal web, it
+    # serves the admin which can potentially have huge forms for the blocklist.
+    DATA_UPLOAD_MAX_NUMBER_FIELDS = 100000
+
 try:
     # If we have a build id (it should be generated when building the image),
     # we'll grab it here and add it to our CACHE_KEY_PREFIX. This will let us


### PR DESCRIPTION
Workaround for mozilla/addons#1953

### Context

The blocklist submission admin displays one checkbox for each version. Each checkbox that is submitted results in one parameter in the body of the request upon submission. `DATA_UPLOAD_MAX_NUMBER_FIELDS` defaults to 1000 to circumvent DOS attacks through memory consumption, preventing us from using the blocklist admin when add-ons have too many versions to block.

We don't want to change the limit on the main website, and we still want _a_ limit just in case (the admin is only accessible through VPN so it's harder to exploit, but not impossible), hence this compromise.

### Testing

Settings are evaluated too early to unit test this. You can pass the `ADDONS_SERVER_COMPONENT` env variable to your `web` docker container locally by adding that to `docker-compose.yml` if you want to check that it works, or modify the condition to use a different variable.

I've verified that this is the right value to use by looking at the `webservices-infra` repos and also logging in to the dev bastion: inside the `addons-server-v1-deploy-uwsgi-amo-internal-web-xxxxxxx` pod that is serving the admin, `os.environ.get('ADDONS_SERVER_COMPONENT')` returns `"amo-internal-web"`, and something else outside.