### PR TITLE
Prevent Review Page Activity From Cutting Off

### DIFF
--- a/src/olympia/reviewers/templates/reviewers/includes/history.html
+++ b/src/olympia/reviewers/templates/reviewers/includes/history.html
@@ -2,27 +2,28 @@
   <th>
     {{ record.log.short|default }}
   </th>
-  <td>
-    {% trans user = record.user|user_link, date = record.created|datetime %}
-      <div>By {{ user }} on {{ date }}</div>
-    {% endtrans %}
-    {% if record.details %}
-      {# <pre> rather than <div> so that white space is preserved on copy #}
-      <pre class="light history-comment">{{ record.details.comments }}</pre>
-      {% if record.details.reason %}
-        <pre class="light history-comment">Reason: {{ record.details.reason }}</pre>
+  <td class="record-container">
+      <div>
+        {% trans user = record.user|user_link, date = record.created|datetime %}
+          <div>By {{ user }} on {{ date }}</div>
+        {% endtrans %}
+        {% if record.details %}
+          {# <pre> rather than <div> so that white space is preserved on copy #}
+          <pre class="light history-comment">{{ record.details.comments }}</pre>
+          {% if record.details.reason %}
+            <pre class="light history-comment">Reason: {{ record.details.reason }}</pre>
+          {% endif %}
+        {% endif %}
+      </div>
+      {% if switch_is_active('enable-activity-log-attachments') %}
+          {% if record.attachmentlog %}
+            {% with attachment=record.attachmentlog.file %}
+            <div>
+              <a class="download-reply-attachment" href="{{ url('activity.attachment', record.pk) }}" download>Download Attachment</a> ({{attachment.size|filesizeformat}})
+            </div>
+            {% endwith %}
+          {% endif %}
       {% endif %}
-    {% endif %}
   </td>
-  {% if switch_is_active('enable-activity-log-attachments') %}
-    <td>
-      {% if record.attachmentlog %}
-        {% with attachment=record.attachmentlog.file %}
-        <div>
-          <a class="download-reply-attachment" href="{{ url('activity.attachment', record.pk) }}" download>Download Attachment</a> ({{attachment.size|filesizeformat}})
-        </div>
-        {% endwith %}
-      {% endif %}
-    </td>
-  {% endif %}
+  
 </tr>

--- a/static/css/zamboni/zamboni.css
+++ b/static/css/zamboni/zamboni.css
@@ -724,6 +724,12 @@ th, td {
     padding: 0.308em 0.537em 0.214em 0.231em; /* 4px 7px 3px 7px */
 }
 
+.record-container {
+    display: flex;
+    justify-content: space-between;
+    gap: 2em;
+}
+
 div:has(> .download-reply-attachment) {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Fixes: mozilla/addons#15198
### Description

Moves the 'download attachment' section to the 2nd column rather than its own column to prevent inconsistent column numbers and the activity logs from clipping through.

**Before:**
![image](https://github.com/user-attachments/assets/b54aff43-1ee8-4710-bd13-1172af86d273)

**After:**
![image](https://github.com/user-attachments/assets/2f1db2b5-eacb-4982-853f-04977e19047f)


Attachments are otherwise unaffected.
![image](https://github.com/user-attachments/assets/65f6b88c-2472-4c77-9c72-3d2a8484e082)

### Testing

From the original issue --
1. Enable `enable-activity-log-attachments` switch
2. Submit an unlisted add-on (single version)
3. Get it auto-approved
4. Soft-Block it
5. Harden the block
The logs should not clip through the border of the cell.
6. Add an action with an attachment
'Download attachment' section should display as expected.

<!--
Your change must be related to an existing, open issue. This issue should contain testing instructions.
Often, the testing info in the issue is higher level, geared towards a user or QA experience.
Here you can provide information for a developer verifying this PR. Get technical.
If it is not relevant to your PR, remove this section.
-->

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] Add before and after screenshots (Only for changes that impact the UI).
