### PR TITLE
CI tests for make check to prevent breakage to our local dev:

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -65,12 +65,6 @@ jobs:
             services: web
             compose_file: docker-compose.yml:docker-compose.ci.yml
             run: make lint-codestyle
-          -
-            name: Manage Check
-            services: web nginx
-            compose_file: docker-compose.yml:docker-compose.ci.yml
-            run: make check
-            data_backup_skip: true
     steps:
       - uses: actions/checkout@v4
       - name: Test (${{ matrix.name }})
@@ -81,4 +75,3 @@ jobs:
           services: ${{ matrix.services }}
           compose_file: ${{ matrix.compose_file }}
           run: ${{ matrix.run }}
-          data_backup_skip: ${{ matrix.data_backup_skip || 'true' }}

--- a/.github/workflows/_test_check.yml
+++ b/.github/workflows/_test_check.yml
@@ -1,0 +1,144 @@
+name: Test make up and check the local dev setup
+
+run-name: |
+  ref: ${{ github.ref_name }} |
+  version: ${{ inputs.version }} |
+  digest: ${{ inputs.digest }} |
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: The version of the image to run
+        type: string
+        required: true
+      digest:
+        description: The build digest of the image to run. Overrides version.
+        type: string
+        required: false
+  workflow_dispatch:
+    inputs:
+      version:
+        description: The version of the image to run
+        type: string
+        required: true
+      digest:
+        description: The build digest of the image to run. Overrides version.
+        type: string
+        required: false
+
+concurrency:
+  group: test_check-${{ github.workflow }}-${{ github.event_name}}-${{ github.ref}}-${{ toJson(inputs) }}
+  cancel-in-progress: true
+
+jobs:
+  context:
+    runs-on: ubuntu-latest
+    outputs:
+      is_fork: ${{ steps.context.outputs.is_fork }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: context
+        uses: ./.github/actions/context
+
+  test_check:
+    runs-on: ubuntu-latest
+    name: |
+      version: '${{ matrix.version }}' |
+      compose_file: '${{ matrix.compose_file }}'
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - local
+          - ${{ inputs.version }}
+        compose_file:
+          - docker-compose.yml
+          - docker-compose.yml:docker-compose.ci.yml
+    steps:
+      - uses: actions/checkout@v4
+      - shell: bash
+        continue-on-error: true
+        run: |
+          cat <<EOF
+            Values passed to the action:
+            version: ${{ matrix.version }}
+            compose_file: ${{ matrix.compose_file }}
+          EOF
+      - uses: ./.github/actions/run-docker
+        # Set environment variables that are expected to be ignored
+        env:
+          DOCKER_COMMIT: 'not-expected'
+          DOCKER_VERSION: 'not-expected'
+        with:
+          version: ${{ matrix.version }}
+          compose_file: ${{ matrix.compose_file }}
+          run: make check
+
+  test_make_docker_configuration:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v2
+      - name: Install dependencies
+        shell: bash
+        run: npm ci
+      - name: Check make/docker configuration
+        shell: bash
+        run: |
+          docker compose version
+          make test_setup
+      - name: Test setup
+        uses: ./.github/actions/run-docker
+        with:
+          digest: ${{ inputs.digest }}
+          version: ${{ inputs.version }}
+          run: |
+            pytest tests/make/
+
+  test_run_docker_action:
+    runs-on: ubuntu-latest
+    needs: context
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create failure
+        id: failure
+        continue-on-error: true
+        uses: ./.github/actions/run-docker
+        with:
+          digest: ${{ inputs.digest }}
+          version: ${{ inputs.version }}
+          logs: true
+          run: |
+            exit 1
+
+      - name: Verify failure
+        if: always()
+        run: |
+          if [[ "${{ steps.failure.outcome }}" != "failure" ]]; then
+            echo "Expected failure"
+            exit 1
+          fi
+
+      - name: Check (special characters in command)
+        uses: ./.github/actions/run-docker
+        with:
+          digest: ${{ inputs.digest }}
+          version: ${{ inputs.version }}
+          run: |
+            echo 'this is a question?'
+            echo 'a * is born'
+            echo 'wow an array []'
+
+  test_migrations:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/run-docker
+        with:
+          version: ${{ inputs.version }}
+          data_backup_skip: false
+          run: echo true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,97 +75,6 @@ jobs:
           target: development
           push: true
 
-  test_make_docker_configuration:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v2
-      - name: Install dependencies
-        shell: bash
-        run: npm ci
-      - name: Check make/docker configuration
-        shell: bash
-        run: |
-          docker compose version
-          make test_setup
-
-  test_run_docker_action:
-    runs-on: ubuntu-latest
-    needs: [build, context]
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Create failure
-        id: failure
-        continue-on-error: true
-        uses: ./.github/actions/run-docker
-        with:
-          digest: ${{ needs.build.outputs.digest }}
-          version: ${{ needs.build.outputs.version }}
-          run: |
-            exit 1
-
-      - name: Verify failure
-        if: always()
-        run: |
-          if [[ "${{ steps.failure.outcome }}" != "failure" ]]; then
-            echo "Expected failure"
-            exit 1
-          fi
-
-      - name: Check (special characters in command)
-        uses: ./.github/actions/run-docker
-        with:
-          digest: ${{ needs.build.outputs.digest }}
-          version: ${{ needs.build.outputs.version }}
-          run: |
-            echo 'this is a question?'
-            echo 'a * is born'
-            echo 'wow an array []'
-
-      - name: Verify Build Metadata
-        uses: ./.github/actions/run-docker
-        if: needs.context.outputs.is_fork == 'false'
-        with:
-          digest: ${{ needs.build.outputs.digest }}
-          version: ${{ needs.build.outputs.version }}
-          run: |
-            expected_version="${{ needs.build.outputs.version }}"
-            expected_commit="${{ github.sha }}"
-
-            if [ "$DOCKER_COMMIT" != "$expected_commit" ]; then
-              echo "DOCKER_COMMIT: '$DOCKER_COMMIT' is not equal to '$expected_commit'"
-              exit 1
-            fi
-
-            if [ "$DOCKER_VERSION" != "$expected_version" ]; then
-              echo "DOCKER_VERSION: '$DOCKER_VERSION' is not equal to '$expected_version'"
-              exit 1
-            fi
-
-      - name: Check ignored files
-        uses: ./.github/actions/run-docker
-        with:
-          digest: ${{ needs.build.outputs.digest }}
-          version: ${{ needs.build.outputs.version }}
-          run: |
-            # Verify that .dockerignore is working and the
-            # Makefile-os is not in the production container
-            if [ -f Makefile-os ]; then
-              echo "Makefile-os exists"
-              exit 1
-            fi
-
-      - name: Test setup
-        uses: ./.github/actions/run-docker
-        with:
-          digest: ${{ needs.build.outputs.digest }}
-          version: ${{ needs.build.outputs.version }}
-          run: |
-            pytest tests/make/
-
   docs_build:
     runs-on: ubuntu-latest
     needs: build
@@ -268,6 +177,13 @@ jobs:
   test_main:
     needs: [context, build]
     uses: ./.github/workflows/_test_main.yml
+    with:
+      version: ${{ needs.build.outputs.version }}
+      digest: ${{ needs.build.outputs.digest }}
+
+  test_check:
+    needs: [context, build]
+    uses: ./.github/workflows/_test_check.yml
     with:
       version: ${{ needs.build.outputs.version }}
       digest: ${{ needs.build.outputs.digest }}

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,6 @@ tmp/*
 # End of .gitignore. Please keep this in sync with the top section of .dockerignore
 
 # do not ignore the following files
-!docker-compose.development.yml
+!docker-compose.ci.yml
 !docker-compose.private.yml
 !private/README.md

--- a/Makefile-docker
+++ b/Makefile-docker
@@ -47,9 +47,7 @@ check_olympia_user: ## check if the olympia user exists and is current user
 
 .PHONY: check_django
 check_django: ## check if the django app is configured properly
-	echo 'from olympia.lib.settings_base import *' > settings_local.py
-	DJANGO_SETTINGS_MODULE='settings_local' python3 ./manage.py check
-	rm settings_local.py
+	./manage.py check
 
 .PHONY: check_nginx
 check_nginx:  ## check if the nginx config for local development is configured properly

--- a/settings.py
+++ b/settings.py
@@ -18,6 +18,8 @@ from olympia.lib.settings_base import *  # noqa
 # So if the value is anything other than "production" we are in development mode.
 DEV_MODE = DOCKER_TARGET != 'production'
 
+HOST_UID = os.environ.get('HOST_UID')
+
 WSGI_APPLICATION = 'olympia.wsgi.application'
 
 INTERNAL_ROUTES_ALLOWED = True

--- a/src/olympia/core/apps.py
+++ b/src/olympia/core/apps.py
@@ -40,6 +40,28 @@ def uwsgi_check(app_configs, **kwargs):
 
 
 @register(CustomTags.custom_setup)
+def host_check(app_configs, **kwargs):
+    """Check that the host settings are valid."""
+    errors = []
+
+    # In production, we expect settings.HOST_UID to be None and so
+    # set the expected uid to 9500, otherwise we expect the uid
+    # passed to the environment to be the expected uid.
+    expected_uid = 9500 if settings.HOST_UID is None else int(settings.HOST_UID)
+    actual_uid = os.getuid()
+
+    if actual_uid != expected_uid:
+        return [
+            Error(
+                f'Expected user uid to be {expected_uid}, received {actual_uid}',
+                id='setup.E002',
+            )
+        ]
+
+    return errors
+
+
+@register(CustomTags.custom_setup)
 def version_check(app_configs, **kwargs):
     """Check the (virtual) version.json file exists and has the correct keys."""
     required_keys = ['version', 'build', 'commit', 'source']

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -71,6 +71,9 @@ DOCKER_TARGET = env('DOCKER_TARGET')
 
 DEV_MODE = False
 
+# Host info that is hard coded for production images.
+HOST_UID = None
+
 # Used to determine if django should serve static files.
 # For local deployments we want nginx to proxy static file requests to the
 # uwsgi server and not try to serve them locally.

--- a/tests/make/make.spec.js
+++ b/tests/make/make.spec.js
@@ -1,45 +1,283 @@
 const { spawnSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
-const { globSync } = require('glob');
 const { parse } = require('dotenv');
 
 const rootPath = path.join(__dirname, '..', '..');
 const envPath = path.join(rootPath, '.env');
 
+function clearEnv() {
+  fs.rmSync(envPath, { force: true });
+}
+
 function runSetup(env) {
-  fs.writeFileSync(envPath, '');
-  spawnSync('make', ['setup'], {
+  clearEnv();
+  const result = spawnSync('make', ['setup'], {
     env: { ...process.env, ...env },
     encoding: 'utf-8',
   });
+  if (result.stderr) {
+    throw new Error(result.stderr);
+  }
   return parse(fs.readFileSync(envPath, { encoding: 'utf-8' }));
 }
 
-test('map docker compose config', () => {
-  values = runSetup({
-    DOCKER_VERSION: 'version',
-    HOST_UID: 'uid',
-  });
-
-  const { stdout: rawConfig } = spawnSync(
+function getConfig(env = {}) {
+  runSetup(env);
+  const { stdout: rawConfig, stderr: rawError } = spawnSync(
     'docker',
     ['compose', 'config', '--format', 'json'],
-    { encoding: 'utf-8' },
+    {
+      encoding: 'utf-8',
+      env: { ...process.env, ...env },
+    },
   );
+  try {
+    if (rawError) throw new Error(rawError);
+    return JSON.parse(rawConfig);
+  } catch (error) {
+    throw new Error(JSON.stringify({ error, rawConfig, rawError }, null, 2));
+  }
+}
 
-  const config = JSON.parse(rawConfig);
-  const { web } = config.services;
+describe('docker-compose.yml', () => {
+  afterAll(() => {
+    clearEnv();
+  });
 
-  expect(web.image).toStrictEqual(`mozilla/addons-server:version`);
-  expect(web.platform).toStrictEqual('linux/amd64');
-  expect(web.environment.HOST_UID).toStrictEqual('9500');
-  expect(config.volumes.data_mysqld.name).toStrictEqual(
-    'addons-server_data_mysqld',
+  describe.each([
+    'docker-compose.yml',
+    'docker-compose.yml:docker-compose.ci.yml',
+  ])('COMPOSE_FILE=%s', (COMPOSE_FILE) => {
+    const isProd = COMPOSE_FILE.includes('docker-compose.ci.yml');
+    it('.services.(web|worker) should have the correct configuration', () => {
+      const values = {
+        COMPOSE_FILE,
+        DOCKER_TAG: 'mozilla/addons-server:tag',
+        // set docker target to production to ensure we are allowed
+        // to override the olympia mount
+        DOCKER_TARGET: 'production',
+        DEBUG: 'debug',
+        OLYMPIA_UID: '1',
+        DATA_BACKUP_SKIP: 'skip',
+      };
+      const {
+        services: { web, worker },
+      } = getConfig(values);
+
+      for (let service of [web, worker]) {
+        expect(service.image).toStrictEqual(values.DOCKER_TAG);
+        expect(service.pull_policy).toStrictEqual('never');
+        expect(service.user).toStrictEqual('root');
+        expect(service.platform).toStrictEqual('linux/amd64');
+        expect(service.entrypoint).toStrictEqual([
+          '/data/olympia/docker/entrypoint.sh',
+        ]);
+        expect(service.extra_hosts).toStrictEqual(['olympia.test=127.0.0.1']);
+        expect(service.restart).toStrictEqual('on-failure:5');
+        // Each service should have a healthcheck
+        expect(service.healthcheck.test).not.toBeUndefined();
+        expect(service.healthcheck.interval).toStrictEqual('1m30s');
+        expect(service.healthcheck.retries).toStrictEqual(3);
+        expect(service.healthcheck.start_interval).toStrictEqual('1s');
+        expect(service.healthcheck.start_period).toStrictEqual('2m0s');
+        // each service should have a command
+        expect(service.command).not.toBeUndefined();
+        // each service should have the same dependencies
+        expect(service.depends_on).toEqual(
+          expect.objectContaining({
+            autograph: expect.any(Object),
+            elasticsearch: expect.any(Object),
+            memcached: expect.any(Object),
+            mysqld: expect.any(Object),
+            rabbitmq: expect.any(Object),
+            redis: expect.any(Object),
+          }),
+        );
+        expect(service.volumes).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              ...(isProd ? {} : { source: expect.any(String) }),
+              target: '/data/olympia',
+            }),
+            expect.objectContaining(
+              isProd
+                ? {
+                    source: 'storage',
+                    target: '/data/olympia/storage',
+                  }
+                : {},
+            ),
+          ]),
+        );
+        expect(service.environment).toEqual(
+          expect.objectContaining({
+            COMPOSE_FILE: values.COMPOSE_FILE,
+            DEBUG: values.DEBUG,
+            // Should be set to the UID of the host user
+            HOST_UID: expect.any(String),
+            DATA_BACKUP_SKIP: values.DATA_BACKUP_SKIP,
+          }),
+        );
+      }
+
+      expect(web.volumes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'volume',
+            target: '/data/olympia/static-build',
+          }),
+          expect.objectContaining({
+            type: 'volume',
+            target: '/data/olympia/site-static',
+          }),
+        ]),
+      );
+    });
+
+    it('.services.nginx should have the correct configuration', () => {
+      const {
+        services: { nginx },
+      } = getConfig({
+        COMPOSE_FILE,
+      });
+      // nginx is mapped from http://olympia.test to port 80 in /etc/hosts on the host
+      expect(nginx.ports).toStrictEqual([
+        expect.objectContaining({
+          mode: 'ingress',
+          protocol: 'tcp',
+          published: '80',
+          target: 80,
+        }),
+      ]);
+      expect(nginx.volumes).toEqual(
+        expect.arrayContaining([
+          // mapping for nginx conf.d adding addon-server routing
+          expect.objectContaining({
+            source: expect.any(String),
+            target: '/etc/nginx/conf.d/addons.conf',
+          }),
+          // mapping for local host directory to /data/olympia
+          expect.objectContaining({
+            source: expect.any(String),
+            target: '/srv',
+          }),
+          // mapping for local host directory to /data/olympia/storage
+          expect.objectContaining(
+            isProd
+              ? {
+                  source: 'storage',
+                  target: '/srv/storage',
+                }
+              : {},
+          ),
+        ]),
+      );
+    });
+
+    it('.services.*.volumes duplicate volumes should be defined on services.olympia_volumes.volumes', () => {
+      const key = 'olympia_volumes';
+      const { services } = getConfig({ COMPOSE_FILE });
+      // all volumes defined on any service other than olympia
+      const volumesMap = new Map();
+      // volumes defined on the olympia service, any dupes in other services should be here also
+      const olympiaVolumes = new Set();
+
+      for (let [name, config] of Object.entries(services)) {
+        for (let volume of config.volumes ?? []) {
+          if (volume.bind) continue;
+          const source = volume.source || volume.target;
+
+          if (name === key) {
+            olympiaVolumes.add(source);
+          } else {
+            const set = volumesMap.get(source) ?? new Set();
+            volumesMap.set(source, set.add(name));
+          }
+        }
+      }
+
+      // duplicate volumes should be defined on the olympia service
+      // to ensure that the volume is mounted by docker before any
+      // other service tries to use it.
+      for (let [source, services] of volumesMap) {
+        if (services.size > 1 && !olympiaVolumes.has(source)) {
+          const serviceNames = [...services].join(', ');
+          throw new Error(
+            `.services.${key}.volumes missing '${source}' used by '${serviceNames}'`,
+          );
+        }
+      }
+
+      // any service that depends on a duplicate volume must also depend on olympia
+      for (let source of olympiaVolumes) {
+        for (let name of volumesMap.get(source) ?? []) {
+          if (!services[name]?.depends_on?.[key]) {
+            throw new Error(
+              `'.services.${name}.depends_on' missing '${key}' for shared volume '${source}'`,
+            );
+          }
+        }
+      }
+    });
+  });
+
+  // these keys require special handling to prevent runtime errors in make setup
+  const failKeys = [
+    // Invalid docker tag leads to docker not parsing the image
+    'DOCKER_TAG',
+    // Invalid compose file leads to inability to create a compose config
+    'COMPOSE_FILE',
+  ];
+  const ignoreKeys = [];
+  const defaultEnv = runSetup();
+  const customValue = 'custom';
+
+  describe.each(Array.from(new Set([...Object.keys(defaultEnv), ...failKeys])))(
+    `custom value for environment variable %s=${customValue}`,
+    (key) => {
+      if (failKeys.includes(key)) {
+        it('config should fail if set to an arbitrary custom value', () => {
+          expect(() =>
+            getConfig({ DOCKER_TARGET: 'production', [key]: customValue }),
+          ).toThrow();
+        });
+      } else if (ignoreKeys.includes(key)) {
+        it('variable should be ignored', () => {
+          const {
+            services: { web, worker },
+          } = getConfig({ ...defaultEnv, [key]: customValue });
+          for (let service of [web, worker]) {
+            expect(service.environment).not.toEqual(
+              expect.objectContaining({
+                [key]: customValue,
+              }),
+            );
+          }
+        });
+      } else {
+        it('variable should be overriden based on the input', () => {
+          const {
+            services: { web, worker },
+          } = getConfig({ ...defaultEnv, [key]: customValue });
+          for (let service of [web, worker]) {
+            expect(service.environment).toEqual(
+              expect.objectContaining({
+                [key]: customValue,
+              }),
+            );
+          }
+        });
+      }
+    },
   );
 });
 
 describe('docker-bake.hcl', () => {
+  afterAll(() => {
+    clearEnv();
+  });
+
   function getBakeConfig(env = {}) {
     runSetup(env);
     const { stdout: output } = spawnSync(


### PR DESCRIPTION
Fixes: mozilla/addons#15229

### Description

Adds additional test coverage for local dev setup via a new workflow `test_check` which runs make up and make check on a variety of configurations.

Additionally, this adds more tests to apps.py to cover various assertions about our dev container.

### Context

This test ensures future regressions are caught by running our local dev setup in a number of different configurations and asserting the containers are up and running smoothely.

### Testing

You can test the configuration is solid by installing npm depenencies on the host (to run the test command)

```bash
npm i
```

Then run the test command

```bash
make test_setup
```

### shared volume missing from '.services.olympia_volumes.volumes'
- remove "olympia_volumes" from the "depends_on" prop of any combination of web, worker, and or nginx
- run the test command

<img width="1109" alt="image" src="https://github.com/user-attachments/assets/8d11e30c-22da-4a31-bc00-c891d9016bdf">

### 'olympia_volumes' missing from dependency list of service using shared volume
- remove "site-static-mount" (in docker-compose.yml) or "storage-mount" (docker-compose.ci.yml) from "olympia_volumes" volumes list
- run the test command

<img width="1254" alt="image" src="https://github.com/user-attachments/assets/4ea2609c-35fa-49f2-bd73-5b3f27cc2d84">

### (optional) Duplicate bind mount does not raise
- add a shared bind mount `.:/data/olympia` to multiple services.
- run the test command

Expect the tests to pass as bind mounts can be freely shared without causing race conditions

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
