### PR TITLE
Embed build info into the docker image instead of relying on runtime variables.

### DIFF
--- a/Makefile-os
+++ b/Makefile-os
@@ -7,6 +7,9 @@
 DOCKER_PROGRESS ?= auto
 DOCKER_METADATA_FILE ?= buildx-bake-metadata.json
 DOCKER_PUSH ?=
+# Not in dot env saved,
+# Docker needs these values set,
+# Static, cache preserved.
 export DOCKER_COMMIT ?=
 export DOCKER_BUILD ?=
 export DOCKER_VERSION ?=

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -15,10 +15,11 @@ target "web" {
   tags = ["${DOCKER_TAG}"]
   platforms = ["linux/amd64"]
   args = {
-	DOCKER_COMMIT = "${DOCKER_COMMIT}"
-	DOCKER_VERSION = "${DOCKER_VERSION}"
-	DOCKER_BUILD = "${DOCKER_BUILD}"
-  DOCKER_TARGET = "${DOCKER_TARGET}"
+    DOCKER_COMMIT = "${DOCKER_COMMIT}"
+    DOCKER_VERSION = "${DOCKER_VERSION}"
+    DOCKER_BUILD = "${DOCKER_BUILD}"
+    DOCKER_TARGET = "${DOCKER_TARGET}"
+    DOCKER_SOURCE = "https://github.com/mozilla/addons-server"
   }
   pull = true
 

--- a/src/olympia/core/tests/test_apps.py
+++ b/src/olympia/core/tests/test_apps.py
@@ -3,36 +3,26 @@ from unittest import mock
 from django.core.management import call_command
 from django.core.management.base import SystemCheckError
 from django.test import TestCase
-from django.test.utils import override_settings
+
+from olympia.core.utils import REQUIRED_VERSION_KEYS
 
 
 class SystemCheckIntegrationTest(TestCase):
-    @mock.patch('olympia.core.apps.os.getuid')
-    def test_illegal_override_uid_check(self, mock_getuid):
-        """
-        If the HOST_UID is not set or if it is not set to the
-        olympia user actual uid, then file ownership is probably
-        incorrect and we should fail the check.
-        """
-        dummy_uid = '1000'
-        olympia_uid = '9500'
-        for host_uid in [None, olympia_uid]:
-            with override_settings(HOST_UID=host_uid):
-                with self.subTest(host_uid=host_uid):
-                    mock_getuid.return_value = int(dummy_uid)
-                    with self.assertRaisesMessage(
-                        SystemCheckError,
-                        f'Expected user uid to be {olympia_uid}, received {dummy_uid}',
-                    ):
-                        call_command('check')
-
-        with override_settings(HOST_UID=dummy_uid):
-            mock_getuid.return_value = int(olympia_uid)
-            with self.assertRaisesMessage(
-                SystemCheckError,
-                f'Expected user uid to be {dummy_uid}, received {olympia_uid}',
-            ):
-                call_command('check')
+    def setUp(self):
+        self.default_version_json = {
+            'tag': 'mozilla/addons-server:1.0',
+            'target': 'production',
+            'commit': 'abc',
+            'version': '1.0',
+            'build': 'http://example.com/build',
+            'source': 'https://github.com/mozilla/addons-server',
+        }
+        patch = mock.patch(
+            'olympia.core.apps.get_version_json',
+            return_value=self.default_version_json,
+        )
+        self.mock_get_version_json = patch.start()
+        self.addCleanup(patch.stop)
 
     @mock.patch('olympia.core.apps.connection.cursor')
     def test_db_charset_check(self, mock_cursor):
@@ -56,29 +46,15 @@ class SystemCheckIntegrationTest(TestCase):
             ):
                 call_command('check')
 
-    def test_version_missing_key(self):
-        call_command('check')
-
-        with mock.patch('olympia.core.apps.get_version_json') as get_version_json:
-            keys = ['version', 'build', 'commit', 'source']
-            version_mock = {key: 'test' for key in keys}
-
-            for key in keys:
-                version = version_mock.copy()
-                version.pop(key)
-                get_version_json.return_value = version
-
+    def test_missing_version_keys_check(self):
+        """
+        We expect all required version keys to be set during the docker build.
+        """
+        for broken_key in REQUIRED_VERSION_KEYS:
+            with self.subTest(broken_key=broken_key):
+                del self.mock_get_version_json.return_value[broken_key]
                 with self.assertRaisesMessage(
-                    SystemCheckError, f'{key} is missing from version.json'
+                    SystemCheckError,
+                    f'{broken_key} is missing from version.json',
                 ):
                     call_command('check')
-
-    def test_version_missing_multiple_keys(self):
-        call_command('check')
-
-        with mock.patch('olympia.core.apps.get_version_json') as get_version_json:
-            get_version_json.return_value = {'version': 'test', 'build': 'test'}
-            with self.assertRaisesMessage(
-                SystemCheckError, 'commit, source is missing from version.json'
-            ):
-                call_command('check')


### PR DESCRIPTION
Fixes: mozilla/addons#15230

### Description

- Modified `Dockerfile` to expose build arguments and create a static build info file, ensuring that build variables are hard-coded and not overridden at runtime.
- Refactored `get_version_json` function in `utils.py` to read build information from the newly created static file, ensuring required keys are validated.
- Updated tests in `test_apps.py` and `test_utils.py` to check for required version keys and validate the build info retrieval process.

### Context

Previously relying on runtime environment variables led to less consistent checks because runtime variables can change, where the underlying image cannot. Since we are mostly checking the underlying image, we should not rely on the runtime variables but instead the image itself.

### Testing

1. verify the image contains the /build-info file with the correct information. Set values for all the variables to verify they can be configured appropriately
2. Modifying one of the variables after the build should not invalidate most caches.

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
