### PR TITLE
Fix inconsistent padding on review history

### DIFF
--- a/static/css/zamboni/reviewers.less
+++ b/static/css/zamboni/reviewers.less
@@ -727,6 +727,11 @@ div.reviewer-stats-table > div.reviewer-stats-dark {
     width: 42%;
     padding: 15px;
 }
+
+.listing-body > td {
+    padding: 15px;
+}
+
 .review-files .files .file-permissions {
     max-height: 25.5em;
     overflow: auto;

--- a/static/css/zamboni/reviewers.less
+++ b/static/css/zamboni/reviewers.less
@@ -759,6 +759,7 @@ div.reviewer-stats-table > div.reviewer-stats-dark {
     width: auto;
 }
 .review-files table.activity {
+    margin: 0;
     width: 100%;
 }
 .review-files table.activity th {

--- a/static/css/zamboni/reviewers.less
+++ b/static/css/zamboni/reviewers.less
@@ -759,7 +759,6 @@ div.reviewer-stats-table > div.reviewer-stats-dark {
     width: auto;
 }
 .review-files table.activity {
-    margin: 0 10px;
     width: 100%;
 }
 .review-files table.activity th {


### PR DESCRIPTION
Fixes: mozilla/addons#15198

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Inconsistent padding in review history pushes the activity table out of the main table, causing overflow.

Before:
![image](https://github.com/user-attachments/assets/0d9f05f1-f438-4425-a0da-6a6ac531a988)
After:
![image](https://github.com/user-attachments/assets/8e40af99-edd0-4cfe-8dda-ace7b5c261b7)

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] Add before and after screenshots (Only for changes that impact the UI).
