### PR TITLE
Split CI dependencies and add ./deps:/deps mount.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,7 +28,7 @@
 backups
 build*.py
 buildx-bake-metadata.json
-deps
+deps/*
 docker*.yml
 docker/artifacts/*
 docs/_build

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -10,9 +10,6 @@ inputs:
   version:
     required: true
     description: The image version to tag with
-  target:
-    required: true
-    description: The stage to target in the build
   push:
     required: false
     description: Push the image?
@@ -57,7 +54,8 @@ runs:
     - name: Create .env and version.json files
       shell: bash
       run: |
-        echo "DOCKER_TARGET=${{ inputs.target }}" >> $GITHUB_ENV
+        # We only build the production image in CI
+        echo "DOCKER_TARGET=production" >> $GITHUB_ENV
         echo "DOCKER_VERSION=${{ steps.meta.outputs.version }}" >> $GITHUB_ENV
         echo "DOCKER_COMMIT=${{ steps.context.outputs.git_sha }}" >> $GITHUB_ENV
         echo "DOCKER_BUILD=${{ steps.context.outputs.git_build_url }}" >> $GITHUB_ENV

--- a/.github/actions/run-docker/action.yml
+++ b/.github/actions/run-docker/action.yml
@@ -20,7 +20,11 @@ inputs:
     required: false
     default: 'true'
   mount:
-    description: 'Mount olympia files from host'
+    description: 'Mount host files at runtime? (development|production)'
+    required: false
+    default: 'production'
+  deps:
+    description: 'Which dependencies to install at runtime? (development|production)'
     required: false
     default: 'production'
 
@@ -36,6 +40,7 @@ runs:
           DOCKER_DIGEST="${{ inputs.digest }}" \
           OLYMPIA_UID="$(id -u)" \
           OLYMPIA_MOUNT="${{ inputs.mount }}" \
+          OLYMPIA_DEPS="${{ inputs.deps }}" \
           DATA_BACKUP_SKIP="${{ inputs.data_backup_skip }}" \
           DOCKER_WAIT="true"
 
@@ -47,6 +52,6 @@ runs:
         EOF
 
     - name: Logs
-      shell: bash
       if: ${{ inputs.logs }}
+      shell: bash
       run: docker compose logs

--- a/.github/actions/run-docker/action.yml
+++ b/.github/actions/run-docker/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: 'Skip data backup'
     required: false
     default: 'true'
+  target:
+    description: 'Docker target to run (development|production)'
+    required: false
+    default: 'production'
   mount:
     description: 'Mount host files at runtime? (development|production)'
     required: false
@@ -38,6 +42,7 @@ runs:
         make up \
           DOCKER_VERSION="${{ inputs.version }}" \
           DOCKER_DIGEST="${{ inputs.digest }}" \
+          DOCKER_TARGET="${{ inputs.target }}" \
           OLYMPIA_UID="$(id -u)" \
           OLYMPIA_MOUNT="${{ inputs.mount }}" \
           OLYMPIA_DEPS="${{ inputs.deps }}" \

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -68,4 +68,5 @@ jobs:
           version: ${{ inputs.version }}
           digest: ${{ inputs.digest }}
           services: ${{ matrix.services }}
+          deps: development
           run: ${{ matrix.run }}

--- a/.github/workflows/_test_check.yml
+++ b/.github/workflows/_test_check.yml
@@ -45,7 +45,8 @@ jobs:
     runs-on: ubuntu-latest
     name: |
       version: '${{ matrix.version }}' |
-      mount: '${{ matrix.mount }}'
+      target: '${{ matrix.target }}' |
+      mount: '${{ matrix.mount }}' |
       deps: '${{ matrix.deps }}'
     strategy:
       fail-fast: false
@@ -53,6 +54,9 @@ jobs:
         version:
           - local
           - ${{ inputs.version }}
+        target:
+          - development
+          - production
         mount:
           - development
           - production
@@ -67,6 +71,7 @@ jobs:
           cat <<EOF
             Values passed to the action:
             version: ${{ matrix.version }}
+            target: ${{ matrix.target }}
             mount: ${{ matrix.mount }}
             deps: ${{ matrix.deps }}
           EOF
@@ -78,6 +83,7 @@ jobs:
           DOCKER_VERSION: 'not-expected'
         with:
           version: ${{ matrix.version }}
+          target: ${{ matrix.target }}
           mount: ${{ matrix.mount }}
           deps: ${{ matrix.deps }}
           run: make check
@@ -86,6 +92,7 @@ jobs:
         if: ${{ matrix.version == 'local' }}
         with:
           version: ${{ matrix.version }}
+          target: ${{ matrix.target }}
           mount: ${{ matrix.mount }}
           deps: ${{ matrix.deps }}
           run: echo true

--- a/.github/workflows/_test_check.yml
+++ b/.github/workflows/_test_check.yml
@@ -46,6 +46,7 @@ jobs:
     name: |
       version: '${{ matrix.version }}' |
       mount: '${{ matrix.mount }}'
+      deps: '${{ matrix.deps }}'
     strategy:
       fail-fast: false
       matrix:
@@ -53,6 +54,9 @@ jobs:
           - local
           - ${{ inputs.version }}
         mount:
+          - development
+          - production
+        deps:
           - development
           - production
     steps:
@@ -64,6 +68,7 @@ jobs:
             Values passed to the action:
             version: ${{ matrix.version }}
             mount: ${{ matrix.mount }}
+            deps: ${{ matrix.deps }}
           EOF
       - name: ${{ matrix.version == 'local' && 'Uncached Build' || 'Pull' }} Check
         uses: ./.github/actions/run-docker
@@ -74,6 +79,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           mount: ${{ matrix.mount }}
+          deps: ${{ matrix.deps }}
           run: make check
       - name: Cached Build Check
         uses: ./.github/actions/run-docker
@@ -81,6 +87,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           mount: ${{ matrix.mount }}
+          deps: ${{ matrix.deps }}
           run: echo true
 
   test_make_docker_configuration:
@@ -102,10 +109,11 @@ jobs:
         with:
           digest: ${{ inputs.digest }}
           version: ${{ inputs.version }}
+          deps: development
           run: |
             pytest tests/make/
 
-  test_run_docker_action:
+  test_verify_failure:
     runs-on: ubuntu-latest
     needs: context
 
@@ -131,6 +139,10 @@ jobs:
             exit 1
           fi
 
+  test_special_characters:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
       - name: Check (special characters in command)
         uses: ./.github/actions/run-docker
         with:

--- a/.github/workflows/_test_main.yml
+++ b/.github/workflows/_test_main.yml
@@ -89,6 +89,7 @@ jobs:
           digest: ${{ inputs.digest }}
           version: ${{ inputs.version }}
           mount: development
+          deps: development
           run: |
             split="--splits ${{ needs.test_config.outputs.splits }}"
             group="--group ${{ matrix.group }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,6 @@ jobs:
           registry: ${{ steps.docker_hub.outputs.registry }}
           image: ${{ steps.docker_hub.outputs.image }}
           version: ci-${{ needs.context.outputs.docker_version }}
-          target: development
           push: true
 
   docs_build:
@@ -90,6 +89,7 @@ jobs:
           version: ${{ needs.build.outputs.version }}
           mount: development
           deps: development
+          target: development
           run: |
             make docs
 
@@ -215,7 +215,6 @@ jobs:
           registry: ${{ steps.docker_hub.outputs.registry }}
           image: ${{ steps.docker_hub.outputs.image }}
           version: ${{ needs.context.outputs.docker_version }}
-          target: production
           push: true
 
   push_gar:
@@ -247,5 +246,4 @@ jobs:
           registry: ${{ steps.docker_gar.outputs.registry }}
           image: ${{ steps.docker_gar.outputs.image }}
           version: ${{ needs.context.outputs.docker_version }}
-          target: production
           push: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
           digest: ${{ needs.build.outputs.digest }}
           version: ${{ needs.build.outputs.version }}
           mount: development
+          deps: development
           run: |
             make docs
 
@@ -140,6 +141,7 @@ jobs:
           digest: ${{ needs.build.outputs.digest }}
           version: ${{ needs.build.outputs.version }}
           mount: development
+          deps: development
           run: make extract_locales
 
       - name: Push Locales

--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@
 backups
 build*.py
 buildx-bake-metadata.json
-deps
+deps/*
 docker*.yml
 docker/artifacts/*
 docs/_build
@@ -56,3 +56,4 @@ tmp/*
 !docker-compose.private.yml
 !private/README.md
 !storage/.gitignore
+!deps/.gitkeep

--- a/Makefile-docker
+++ b/Makefile-docker
@@ -18,6 +18,13 @@ REQUIRED_FILES := \
 	/deps/package-lock.json \
 	/addons-server-docker-container \
 
+# Build list of dependencies to install
+DEPS = pip prod
+# If we're running a development image, then we should install the development dependencies
+ifeq ($(OLYMPIA_DEPS), development)
+DEPS += dev
+endif
+
 .PHONY: help_redirect
 help_redirect:
 	@$(MAKE) help --no-print-directory
@@ -28,12 +35,9 @@ check_debian_packages: ## check the existence of multiple debian packages
 
 .PHONY: check_pip_packages
 check_pip_packages: ## check the existence of multiple python packages
-	@ ./scripts/check_pip_packages.sh prod.txt
-# "production" corresponds to the "propduction" DOCKER_TARGET defined in the Dockerfile
-# When the target is "production" it means we cannot expect dev.txt dependencies to be installed.
-	@if [ "$(DOCKER_TARGET)" != "production" ]; then \
-		./scripts/check_pip_packages.sh dev.txt; \
-	fi
+	@for dep in $(DEPS); do \
+		./scripts/check_pip_packages.sh $$dep.txt; \
+	done
 
 .PHONY: check_files
 check_files: ## check the existence of multiple files
@@ -76,6 +80,10 @@ update_assets:
 	# Collect static files: This MUST be run last or files will be missing
 	$(PYTHON_COMMAND) manage.py collectstatic --noinput
 
+
+.PHONY: update_deps
+update_deps: ## Update the dependencies
+	$(HOME)/scripts/install_deps.py $(DEPS)
 
 # TOOD: remove this after we migrate addons-frontned to not depend on it.
 .PHONY: setup-ui-tests

--- a/Makefile-os
+++ b/Makefile-os
@@ -58,7 +58,6 @@ CLEAN_PATHS := \
 	version.json \
 	logs \
 	buildx-bake-metadata.json \
-	deps \
 
 .PHONY: help_redirect
 help_redirect:
@@ -154,8 +153,17 @@ docker_clean_build_cache: ## Remove buildx build cache
 .PHONY: clean_docker
 clean_docker: docker_compose_down docker_mysqld_volume_remove docker_clean_images docker_clean_volumes docker_clean_build_cache ## Remove all docker resources taking space on the host machine
 
+.PHONY: docker_update_deps
+docker_update_deps: docker_mysqld_volume_create ## Update the dependencies in the container based on the docker tag and target
+	docker compose run \
+		--rm \
+		--no-deps \
+		$(DOCKER_RUN_ARGS) \
+		web \
+		make update_deps
+
 .PHONY: up_pre
-up_pre: setup docker_pull_or_build ## Pre-up the environment, setup files, volumes and host state
+up_pre: setup docker_pull_or_build docker_update_deps ## Pre-up the environment, setup files, volumes and host state
 
 .PHONY: up_start
 up_start: docker_mysqld_volume_create ## Start the docker containers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
     volumes:
       # used by: web, worker, nginx
       - ${HOST_MOUNT_SOURCE:?}:/data/olympia
+      - ${HOST_MOUNT_SOURCE:?}deps:/deps
       - data_site_static:/data/olympia/site-static
       - ${HOST_MOUNT_SOURCE:?}storage:/data/olympia/storage
   worker:
@@ -63,6 +64,7 @@ services:
     ]
     volumes:
       - ${HOST_MOUNT_SOURCE:?}:/data/olympia
+      - ${HOST_MOUNT_SOURCE:?}deps:/deps
       - ${HOST_MOUNT_SOURCE:?}storage:/data/olympia/storage
     extra_hosts:
      - "olympia.test:127.0.0.1"
@@ -215,6 +217,7 @@ volumes:
   # it will map to the current directory ./<name>
   # (data_olympia_)<name>:/<path>
   data_olympia_:
+  data_olympia_deps:
   data_olympia_storage:
   # Volume for rabbitmq/redis to avoid anonymous volumes
   data_rabbitmq:

--- a/scripts/install_deps.py
+++ b/scripts/install_deps.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+import os
+import shutil
+import subprocess
+import sys
+
+
+def copy_package_json():
+    """Copy package.json files to deps directory if they exist."""
+    try:
+        shutil.copy('/data/olympia/package.json', '/deps')
+        shutil.copy('/data/olympia/package-lock.json', '/deps')
+    except (IOError, OSError):
+        pass  # Ignore if files don't exist or can't be copied
+
+
+def main(targets):
+    # Constants
+    ALLOWED_NPM_TARGETS = set(['prod', 'dev'])
+    DOCKER_TAG = os.environ.get('DOCKER_TAG', 'local')
+    DOCKER_TARGET = os.environ.get('DOCKER_TARGET', '')
+    OLYMPIA_DEPS = os.environ.get('OLYMPIA_DEPS', '')
+
+    if not targets:
+        raise ValueError('No targets specified')
+
+    print(
+        'Updating deps... \n',
+        f'targets: {", ".join(targets)} \n',
+        f'DOCKER_TAG: {DOCKER_TAG} \n',
+        f'DOCKER_TARGET: {DOCKER_TARGET} \n',
+        f'OLYMPIA_DEPS: {OLYMPIA_DEPS} \n',
+    )
+
+    # If we are installing production dependencies or on a non local image
+    # we always remove existing deps as we don't know what was previously
+    # installed or in the host ./deps directory before running this script
+    if 'local' not in DOCKER_TAG or OLYMPIA_DEPS == 'production':
+        print('Removing existing deps')
+        for item in os.listdir('/deps'):
+            item_path = os.path.join('/deps', item)
+            if os.path.isdir(item_path) and item != 'cache':
+                shutil.rmtree(item_path)
+    else:
+        print('Updating existing deps')
+
+    # Copy package.json files
+    copy_package_json()
+
+    # Prepare the includes lists
+    pip_includes = []
+    npm_includes = []
+
+    # PIP_COMMAND is set by the Dockerfile
+    pip_command = os.environ['PIP_COMMAND']
+    pip_args = pip_command.split() + [
+        'install',
+        '--progress-bar=off',
+        '--no-deps',
+        '--exists-action=w',
+    ]
+
+    # NPM_ARGS is set by the Dockerfile
+    npm_args_env = os.environ['NPM_ARGS']
+    npm_args = [
+        'npm',
+        'install',
+        '--no-save',
+        '--no-audit',
+        '--no-fund',
+    ] + npm_args_env.split()
+
+    # Add the relevant targets to the includes lists
+    for target in targets:
+        pip_includes.append(target)
+        pip_args.extend(['-r', f'requirements/{target}.txt'])
+        if target in ALLOWED_NPM_TARGETS:
+            npm_includes.append(target)
+            npm_args.extend(['--include', target])
+
+    if pip_includes:
+        # Install pip dependencies
+        print(f"Installing pip dependencies: {', '.join(pip_includes)} \n")
+        subprocess.run(pip_args, check=True)
+
+    if npm_includes:
+        # Install npm dependencies
+        print(f"Installing npm dependencies: {', '.join(npm_includes)} \n")
+        subprocess.run(npm_args, check=True)
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -118,10 +118,11 @@ def main():
     olympia_uid = os.getuid()
     olympia_mount, olympia_mount_source = get_olympia_mount(docker_target)
 
-    # DEBUG is special, as we should allow the user to override it
+    # These variables are special, as we should allow the user to override them
     # but we should not set a default to the previously set value but instead
-    # to the most sensible default.
+    # use a value derived from other stable values.
     debug = os.environ.get('DEBUG', str(False if is_production else True))
+    olympia_deps = os.environ.get('OLYMPIA_DEPS', docker_target)
 
     set_env_file(
         {
@@ -138,6 +139,7 @@ def main():
             # to use as the source of the /data/olympia volume
             'HOST_MOUNT_SOURCE': olympia_mount_source,
             'DEBUG': debug,
+            'OLYMPIA_DEPS': olympia_deps,
         }
     )
 

--- a/settings.py
+++ b/settings.py
@@ -62,7 +62,8 @@ def insert_debug_toolbar_middleware(middlewares):
     return tuple(ret_middleware)
 
 
-if DEV_MODE:
+# We can only add these dependencies if we have development dependencies
+if os.environ.get('OLYMPIA_DEPS', '') == 'development':
     INSTALLED_APPS += (
         'debug_toolbar',
         'dbbackup',

--- a/src/olympia/amo/monitors.py
+++ b/src/olympia/amo/monitors.py
@@ -134,6 +134,7 @@ def elastic():
             status = 'ES is red'
         elastic_results = health
     except Exception:
+        status = 'Failed to connect to Elasticsearch'
         elastic_results = {'exception': traceback.format_exc()}
 
     return status, elastic_results

--- a/src/olympia/core/apps.py
+++ b/src/olympia/core/apps.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import warnings
 from io import StringIO
+from pwd import getpwnam
 
 from django.apps import AppConfig
 from django.conf import settings
@@ -48,7 +49,8 @@ def host_check(app_configs, **kwargs):
     # set the expected uid to 9500, otherwise we expect the uid
     # passed to the environment to be the expected uid.
     expected_uid = 9500 if settings.HOST_UID is None else int(settings.HOST_UID)
-    actual_uid = os.getuid()
+    # Get the actual uid from the olympia user
+    actual_uid = getpwnam('olympia').pw_uid
 
     if actual_uid != expected_uid:
         return [

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,6 @@
+import os
+from unittest import mock
+
+
+def override_env(**kwargs):
+    return mock.patch.dict(os.environ, kwargs, clear=True)

--- a/tests/make/test_install_deps.py
+++ b/tests/make/test_install_deps.py
@@ -1,0 +1,181 @@
+import unittest
+from unittest import mock
+
+from scripts.install_deps import copy_package_json, main
+from tests import override_env
+
+
+@mock.patch('scripts.install_deps.shutil.copy')
+class TestCopyPackageJson(unittest.TestCase):
+    def test_copy_package_json(self, mock_shutil):
+        copy_package_json()
+        assert mock_shutil.call_args_list == [
+            mock.call('/data/olympia/package.json', '/deps'),
+            mock.call('/data/olympia/package-lock.json', '/deps'),
+        ]
+
+    def test_copy_package_json_no_files(self, mock_shutil):
+        mock_shutil.side_effect = IOError
+        copy_package_json()
+        assert mock_shutil.call_args_list == [
+            mock.call('/data/olympia/package.json', '/deps'),
+        ]
+
+
+class TestInstallDeps(unittest.TestCase):
+    def setUp(self):
+        mocks = ['shutil.rmtree', 'os.listdir', 'subprocess.run', 'copy_package_json']
+        self.mocks = {}
+        for mock_name in mocks:
+            patch = mock.patch(
+                f'scripts.install_deps.{mock_name}',
+            )
+            self.mocks[mock_name] = patch.start()
+            self.addCleanup(patch.stop)
+
+    def test_raises_no_targets(self):
+        """
+        Test that the function raises a ValueError if
+        no or invalid targets are specified
+        """
+        for argument in [None, '', []]:
+            with self.assertRaises(ValueError):
+                main(argument)
+
+    def _test_remove_existing_deps(self, args, expect_remove=False):
+        self.mocks['os.listdir'].return_value = [
+            'cache',
+            'lib',
+            'node_modules',
+            'package.json',
+            'package-lock.json',
+        ]
+        with override_env(
+            **{
+                'PIP_COMMAND': 'pip-test',
+                'NPM_ARGS': 'npm-test',
+                **args,
+            }
+        ):
+            main(['prod'])
+
+        if expect_remove:
+            assert self.mocks['os.listdir'].called
+            assert self.mocks['shutil.rmtree'].call_args_list == [
+                mock.call('/deps/lib'),
+                mock.call('/deps/node_modules'),
+            ]
+        else:
+            assert not self.mocks['os.listdir'].called
+            assert not self.mocks['shutil.rmtree'].called
+
+    def test_keep_deps_for_local_mixed_env(self):
+        """Test that dependencies are kept when running
+        locally with development deps in production"""
+        args = {
+            'DOCKER_TAG': 'local',
+            'OLYMPIA_DEPS': 'development',
+            'DOCKER_TARGET': 'production',
+        }
+        self._test_remove_existing_deps(args, expect_remove=False)
+
+    def test_keep_deps_for_local_default(self):
+        """Test that dependencies are kept when running locally with default settings"""
+        args = {'DOCKER_TAG': 'local', 'OLYMPIA_DEPS': 'development'}
+        self._test_remove_existing_deps(args, expect_remove=False)
+
+    def test_remove_deps_for_non_local(self):
+        """Test that dependencies are removed when running in production environment"""
+        args = {'DOCKER_TAG': 'prod'}
+        self._test_remove_existing_deps(args, expect_remove=True)
+
+    def test_remove_deps_for_prod_deps_in_dev(self):
+        """Test that dependencies are removed when
+        installing production deps in development"""
+        args = {
+            'DOCKER_TAG': 'local',
+            'OLYMPIA_DEPS': 'production',
+            'DOCKER_TARGET': 'development',
+        }
+        self._test_remove_existing_deps(args, expect_remove=True)
+
+    def test_remove_deps_for_prod_deps_in_prod(self):
+        """Test that dependencies are removed when
+        installing production deps in production"""
+        args = {
+            'DOCKER_TAG': 'local',
+            'OLYMPIA_DEPS': 'production',
+            'DOCKER_TARGET': 'production',
+        }
+        self._test_remove_existing_deps(args, expect_remove=True)
+
+    def test_copy_package_json_called(self):
+        """Test that copy_package_json is called"""
+        main(['prod'])
+        assert self.mocks['copy_package_json'].called
+
+    @override_env(PIP_COMMAND='pip-test', NPM_ARGS='npm-test')
+    def test_pip_command_set_on_environment(self):
+        main(['prod'])
+        assert self.mocks['subprocess.run'].call_args_list[0][0][0][0] == 'pip-test'
+
+    @override_env()
+    def test_pip_command_not_set_on_environment(self):
+        self.assertRaises(KeyError, main, ['prod'])
+
+    @override_env(NPM_ARGS='npm-test', PIP_COMMAND='pip-test')
+    def test_npm_command_set_on_environment(self):
+        main(['prod'])
+        assert 'npm-test' in self.mocks['subprocess.run'].call_args_list[1][0][0]
+
+    @override_env()
+    def test_npm_command_not_set_on_environment(self):
+        self.assertRaises(KeyError, main, ['prod'])
+
+    def test_correct_args_passed_to_subprocesses(self):
+        """
+        Test that the correct arguments are passed to the subprocesses
+        """
+        main(['pip', 'prod', 'dev'])
+
+        assert self.mocks['subprocess.run'].call_args_list == [
+            mock.call(
+                [
+                    'python3',
+                    '-m',
+                    'pip',
+                    'install',
+                    '--progress-bar=off',
+                    '--no-deps',
+                    '--exists-action=w',
+                    '-r',
+                    'requirements/pip.txt',
+                    '-r',
+                    'requirements/prod.txt',
+                    '-r',
+                    'requirements/dev.txt',
+                ],
+                check=True,
+            ),
+            # NPM excludes the pip target
+            mock.call(
+                [
+                    'npm',
+                    'install',
+                    '--no-save',
+                    '--no-audit',
+                    '--no-fund',
+                    '--prefix',
+                    '/deps/',
+                    '--cache',
+                    '/deps/cache/npm',
+                    '--loglevel',
+                    'verbose',
+                    '--include',
+                    'prod',
+                    '--include',
+                    'dev',
+                ],
+                check=True,
+            ),
+        ]


### PR DESCRIPTION
Fixes: mozilla/addons#15234
Fixes: mozilla/addons#15034

### Description

- Introduced a new script `install_deps.py` to streamline the installation of pip and npm dependencies based on specified targets.
- Updated `docker-compose.yml` to include a new volume for dependencies and adjusted service configurations accordingly.
- Modified `Makefile-docker` to incorporate checks for CI dependencies and streamline the update process.

### Context

Adds a dependency mount to load dependencies from the host. Additionally optimizes the logic for installing dependencies in one batch.

Which dependencies to run is set during make up and not "mutable" because we pass it to the container via the .env file. to change it, re-run make up with a different value.

> [!NOTE]
> You can cheat and install development depenednecies in a production running container is you run the command inside the container shell, where make will accept your OLYMPIA_DEPS=development argument

### Testing

The value of `OLYMPIA_DEPS` defaults to the value of `DOCKER_TARGET` but can be overriden so there are 4 different scenarios.

### Standard development mode

```bash
make up DOCKER_TARGET=development
```

Expect:
- volume called `data_deps` is created
- it is synced to your ./deps folder.
- containers start up and install prod/dev dependencies.
- Theoretically this should re-enable tracking in IDE
- running `make check` in the container should pass

### Dev mode with Prod dependencies

```bash
make up DOCKER_TARGET=development OLYMPIA_DEPS=production
```

Expect:
- everything from above, but missing development dependencies.
- pytest will not work

> [!IMPORTANT]
> You will see in the logs during make up that the ./deps directory is cleaned. That is because we are running a development image but specifying we want production dependencies. To ensure we don't end up with stale dependencies we have to clean up the directory and freshly install, otherwise some dev dependencies could be left behind. we DON'T do this on local images that are installing development dependencies as we should not need any removed

### Prod mode

This should happen if the `DOCKER_TARGET` is `production`

```bash
make up DOCKER_TARGET=production
```

Expect:
- Everything from above AND
- ./deps directory is cleared and dependencies are freshly installed
- expect only prod dependencies to be installed
- verify this with `make check` and (for example) that debug toolbar is missing on the web
- no pytest or ruff
- verify with `make check`

### Prod mode with Dev dependencies

This does not currently work on a running container We set the OLYMPIA_DEPS variable during startup and make does not support passing arguments from the host makefile, into the container, and into the host again, at least not easily.

So to run prod mode with testing, run a production build with dev dependencies.

```bash
make up DOCKER_TARGET=production OLYMPIA_DEPS=development
```

This will build the production image and install the development dependencies at runtime.

Expect:
- Everything from above AND
- now you should be able to run pytest and ruff

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
