### PR TITLE
Use `integer` to index ratings counts, there might be more than what fits in a `short`

### DIFF
--- a/src/olympia/addons/indexers.py
+++ b/src/olympia/addons/indexers.py
@@ -489,7 +489,8 @@ class AddonIndexer:
                 'ratings': {
                     'type': 'object',
                     'properties': {
-                        'count': {'type': 'short', 'index': False},
+                        'count': {'type': 'integer', 'index': False},
+                        'text_count': {'type': 'integer', 'index': False},
                         'average': {'type': 'float'},
                     },
                 },

--- a/src/olympia/amo/fixtures/base/addon_3615.json
+++ b/src/olympia/amo/fixtures/base/addon_3615.json
@@ -168,7 +168,7 @@
             "icon_type": "image/png",
             "modified": "2010-05-28 09:01:57",
             "summary": 15004,
-            "total_ratings": 413
+            "total_ratings": 32768
         }
     },
     {


### PR DESCRIPTION
Fixes mozilla/addons#15240

### Testing

Force an add-on to have over 32767 in `ratings_count` in a shell, run `index_addons([addon.id])`, it should work. Or run `src/olympia/addons/tests/test_indexers.pyTestAddonIndexerWithES.test_mapping` which does that with the add-on whose fixture I modified to trigger that (it fails without that change).

I also included `text_count` mapping because we do extract that as well. I'll file a follow-up to add a better test around mapping issues as the fact that this mapping was missing should have been caught before.