### PR TITLE
relax hold criteria, to promoted add-ons in groups but not approved yet

### DIFF
--- a/src/olympia/abuse/actions.py
+++ b/src/olympia/abuse/actions.py
@@ -250,7 +250,7 @@ class ContentActionBanUser(ContentAction):
                 or self.target.groups_list  # has any permissions
                 # owns a high profile add-on
                 or any(
-                    addon.promoted_group().high_profile
+                    addon.promoted_group(currently_approved=False).high_profile
                     for addon in self.target.addons.all()
                 )
             )
@@ -281,7 +281,7 @@ class ContentActionDisableAddon(ContentAction):
         return bool(
             self.target.status != amo.STATUS_DISABLED
             # is a high profile add-on
-            and self.target.promoted_group().high_profile
+            and self.target.promoted_group(currently_approved=False).high_profile
         )
 
     def process_action(self):
@@ -392,7 +392,9 @@ class ContentActionDeleteRating(ContentAction):
         return bool(
             not self.target.deleted
             and self.target.reply_to
-            and self.target.addon.promoted_group().high_profile_rating
+            and self.target.addon.promoted_group(
+                currently_approved=False
+            ).high_profile_rating
         )
 
     def process_action(self):

--- a/src/olympia/abuse/tests/test_actions.py
+++ b/src/olympia/abuse/tests/test_actions.py
@@ -449,7 +449,7 @@ class TestContentActionUser(BaseTestContentAction, TestCase):
         assert action.should_hold_action() is False
         addon = addon_factory(users=[self.user])
         assert action.should_hold_action() is False
-        self.make_addon_promoted(addon, RECOMMENDED, approve_version=True)
+        self.make_addon_promoted(addon, RECOMMENDED)
         assert action.should_hold_action() is True
 
         self.user.banned = datetime.now()
@@ -815,7 +815,7 @@ class TestContentActionAddon(BaseTestContentAction, TestCase):
         action = self.ActionClass(self.decision)
         assert action.should_hold_action() is False
 
-        self.make_addon_promoted(self.addon, RECOMMENDED, approve_version=True)
+        self.make_addon_promoted(self.addon, RECOMMENDED)
         assert action.should_hold_action() is True
 
         self.addon.status = amo.STATUS_DISABLED
@@ -1136,7 +1136,7 @@ class TestContentActionRating(BaseTestContentAction, TestCase):
 
         AddonUser.objects.create(addon=self.rating.addon, user=self.rating.user)
         assert action.should_hold_action() is False
-        self.make_addon_promoted(self.rating.addon, RECOMMENDED, approve_version=True)
+        self.make_addon_promoted(self.rating.addon, RECOMMENDED)
         assert action.should_hold_action() is False
         self.rating.update(
             reply_to=Rating.objects.create(


### PR DESCRIPTION
Fixes: mozilla/addons#15244

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Changes `should_hold_action` criteria in actions to include promoted groups where the add-on is not yet approved for that promotional group

### Testing

A pain to fully test, but:
- add an add-on to a promoted* group locally, but *don't* approve the add-on for that promoted group.  (can be verified with an api response - the promoted group shouldn't be included; or listing page on frontend shouldn't badge the group)
- report add-on to Cinder
- process that report in Cinder with a policy that would disable the add-on
- replay the webhook response locally
- see the add-on isn't disabled
- see the add-on in the 2nd level approvals queue in reviewer tools
- (optionally repeat with a Rating developer reply on a promoted** add-on, or a user profile that's an owner of a promoted** add-on)


*recommended, line, spotlight notable
**recommended, line
### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
