### PR TITLE
Do not include current extension in 'Other popular extensions'

### DIFF
--- a/src/olympia/addons/tests/test_utils_.py
+++ b/src/olympia/addons/tests/test_utils_.py
@@ -148,15 +148,19 @@ class TestGetAddonRecommendations(TestCase):
         assert reason == TAAR_LITE_FALLBACK_REASON_INVALID
         assert incr_mock.call_count == 0
         # Fallback filters out the current guid if it exists in TAAR_LITE_FALLBACKS
-        recommendations, _, _ = get_addon_recommendations_invalid(TAAR_LITE_FALLBACKS[0])
+        recommendations, _, _ = get_addon_recommendations_invalid(
+            TAAR_LITE_FALLBACKS[0]
+        )
         assert recommendations == TAAR_LITE_FALLBACKS[1:]
-    
+
     def test_get_filtered_fallbacks(self, _):
         # Fallback filters out the current guid if it exists in TAAR_LITE_FALLBACKS
         recommendations = get_filtered_fallbacks(TAAR_LITE_FALLBACKS[2])
         assert recommendations == TAAR_LITE_FALLBACKS[:2] + TAAR_LITE_FALLBACKS[3:]
         # Fallback returns the first four if it does not.
-        recommendations, outcome, reason = get_addon_recommendations_invalid('random-guid')
+        recommendations, outcome, reason = get_addon_recommendations_invalid(
+            'random-guid'
+        )
         assert recommendations == TAAR_LITE_FALLBACKS[:4]
 
     def test_is_outcome_recommended(self, incr_mock):

--- a/src/olympia/addons/tests/test_utils_.py
+++ b/src/olympia/addons/tests/test_utils_.py
@@ -104,6 +104,7 @@ class TestGetAddonRecommendations(TestCase):
     def test_recommended_no_results(self, incr_mock):
         self.recommendation_server_mock.return_value = []
         recommendations, outcome, reason = get_addon_recommendations('a@b', True)
+        # If there's no results, it takes the first four fallback recommendations
         assert recommendations == TAAR_LITE_FALLBACKS[:4]
         assert outcome == TAAR_LITE_OUTCOME_REAL_FAIL
         assert reason is TAAR_LITE_FALLBACK_REASON_EMPTY

--- a/src/olympia/addons/tests/test_utils_.py
+++ b/src/olympia/addons/tests/test_utils_.py
@@ -139,10 +139,22 @@ class TestGetAddonRecommendations(TestCase):
     def test_invalid_fallback(self, incr_mock):
         recommendations, outcome, reason = get_addon_recommendations_invalid()
         assert not self.recommendation_server_mock.called
-        assert recommendations == TAAR_LITE_FALLBACKS
+        assert recommendations == TAAR_LITE_FALLBACKS[:4]
         assert outcome == TAAR_LITE_OUTCOME_REAL_FAIL
         assert reason == TAAR_LITE_FALLBACK_REASON_INVALID
         assert incr_mock.call_count == 0
+    
+    def test_invalid_fallback_filtered(self, _):
+        # Fallback filters out the current guid if it exists in TAAR_LITE_FALLBACKS
+        recommendations, outcome, reason = get_addon_recommendations_invalid(TAAR_LITE_FALLBACKS[0])
+        assert recommendations == TAAR_LITE_FALLBACKS[1:]
+        assert outcome == TAAR_LITE_OUTCOME_REAL_FAIL
+        assert reason == TAAR_LITE_FALLBACK_REASON_INVALID
+        # Fallback returns the first four if it does not.
+        recommendations, outcome, reason = get_addon_recommendations_invalid('random-guid')
+        assert recommendations == TAAR_LITE_FALLBACKS[:4]
+        assert outcome == TAAR_LITE_OUTCOME_REAL_FAIL
+        assert reason == TAAR_LITE_FALLBACK_REASON_INVALID
 
     def test_is_outcome_recommended(self, incr_mock):
         assert is_outcome_recommended(TAAR_LITE_OUTCOME_REAL_SUCCESS)

--- a/src/olympia/addons/tests/test_utils_.py
+++ b/src/olympia/addons/tests/test_utils_.py
@@ -22,6 +22,7 @@ from ..utils import (
     DeleteTokenSigner,
     get_addon_recommendations,
     get_addon_recommendations_invalid,
+    get_filtered_fallbacks,
     is_outcome_recommended,
     validate_version_number_is_gt_latest_signed_listed_version,
     verify_mozilla_trademark,
@@ -103,7 +104,7 @@ class TestGetAddonRecommendations(TestCase):
     def test_recommended_no_results(self, incr_mock):
         self.recommendation_server_mock.return_value = []
         recommendations, outcome, reason = get_addon_recommendations('a@b', True)
-        assert recommendations == TAAR_LITE_FALLBACKS
+        assert recommendations == TAAR_LITE_FALLBACKS[:4]
         assert outcome == TAAR_LITE_OUTCOME_REAL_FAIL
         assert reason is TAAR_LITE_FALLBACK_REASON_EMPTY
         self.recommendation_server_mock.assert_called_with(
@@ -113,11 +114,14 @@ class TestGetAddonRecommendations(TestCase):
         assert incr_mock.call_args_list[0][0] == (
             f'services.addon_recommendations.{TAAR_LITE_FALLBACK_REASON_EMPTY}',
         )
+        # Fallback filters out the current guid if it exists in TAAR_LITE_FALLBACKS
+        recommendations, _, _ = get_addon_recommendations(TAAR_LITE_FALLBACKS[0], True)
+        assert recommendations == TAAR_LITE_FALLBACKS[1:]
 
     def test_recommended_timeout(self, incr_mock):
         self.recommendation_server_mock.return_value = None
         recommendations, outcome, reason = get_addon_recommendations('a@b', True)
-        assert recommendations == TAAR_LITE_FALLBACKS
+        assert recommendations == TAAR_LITE_FALLBACKS[:4]
         assert outcome == TAAR_LITE_OUTCOME_REAL_FAIL
         assert reason is TAAR_LITE_FALLBACK_REASON_TIMEOUT
         self.recommendation_server_mock.assert_called_with(
@@ -131,7 +135,7 @@ class TestGetAddonRecommendations(TestCase):
     def test_not_recommended(self, incr_mock):
         recommendations, outcome, reason = get_addon_recommendations('a@b', False)
         assert not self.recommendation_server_mock.called
-        assert recommendations == TAAR_LITE_FALLBACKS
+        assert recommendations == TAAR_LITE_FALLBACKS[:4]
         assert outcome == TAAR_LITE_OUTCOME_CURATED
         assert reason is None
         assert incr_mock.call_count == 0
@@ -143,18 +147,17 @@ class TestGetAddonRecommendations(TestCase):
         assert outcome == TAAR_LITE_OUTCOME_REAL_FAIL
         assert reason == TAAR_LITE_FALLBACK_REASON_INVALID
         assert incr_mock.call_count == 0
-    
-    def test_invalid_fallback_filtered(self, _):
         # Fallback filters out the current guid if it exists in TAAR_LITE_FALLBACKS
-        recommendations, outcome, reason = get_addon_recommendations_invalid(TAAR_LITE_FALLBACKS[0])
+        recommendations, _, _ = get_addon_recommendations_invalid(TAAR_LITE_FALLBACKS[0])
         assert recommendations == TAAR_LITE_FALLBACKS[1:]
-        assert outcome == TAAR_LITE_OUTCOME_REAL_FAIL
-        assert reason == TAAR_LITE_FALLBACK_REASON_INVALID
+    
+    def test_get_filtered_fallbacks(self, _):
+        # Fallback filters out the current guid if it exists in TAAR_LITE_FALLBACKS
+        recommendations = get_filtered_fallbacks(TAAR_LITE_FALLBACKS[2])
+        assert recommendations == TAAR_LITE_FALLBACKS[:2] + TAAR_LITE_FALLBACKS[3:]
         # Fallback returns the first four if it does not.
         recommendations, outcome, reason = get_addon_recommendations_invalid('random-guid')
         assert recommendations == TAAR_LITE_FALLBACKS[:4]
-        assert outcome == TAAR_LITE_OUTCOME_REAL_FAIL
-        assert reason == TAAR_LITE_FALLBACK_REASON_INVALID
 
     def test_is_outcome_recommended(self, incr_mock):
         assert is_outcome_recommended(TAAR_LITE_OUTCOME_REAL_SUCCESS)

--- a/src/olympia/addons/tests/test_utils_.py
+++ b/src/olympia/addons/tests/test_utils_.py
@@ -117,11 +117,12 @@ class TestGetAddonRecommendations(TestCase):
         )
         # Fallback filters out the current guid if it exists in TAAR_LITE_FALLBACKS
         recommendations, _, _ = get_addon_recommendations(TAAR_LITE_FALLBACKS[0], True)
-        assert recommendations == TAAR_LITE_FALLBACKS[1:]
+        assert TAAR_LITE_FALLBACKS[0] not in recommendations
 
     def test_recommended_timeout(self, incr_mock):
         self.recommendation_server_mock.return_value = None
         recommendations, outcome, reason = get_addon_recommendations('a@b', True)
+        # If there's no results, it takes the first four fallback recommendations
         assert recommendations == TAAR_LITE_FALLBACKS[:4]
         assert outcome == TAAR_LITE_OUTCOME_REAL_FAIL
         assert reason is TAAR_LITE_FALLBACK_REASON_TIMEOUT
@@ -136,6 +137,7 @@ class TestGetAddonRecommendations(TestCase):
     def test_not_recommended(self, incr_mock):
         recommendations, outcome, reason = get_addon_recommendations('a@b', False)
         assert not self.recommendation_server_mock.called
+        # If there's no results, it takes the first four fallback recommendations
         assert recommendations == TAAR_LITE_FALLBACKS[:4]
         assert outcome == TAAR_LITE_OUTCOME_CURATED
         assert reason is None
@@ -144,6 +146,7 @@ class TestGetAddonRecommendations(TestCase):
     def test_invalid_fallback(self, incr_mock):
         recommendations, outcome, reason = get_addon_recommendations_invalid()
         assert not self.recommendation_server_mock.called
+        # If there's no results, it takes the first four fallback recommendations
         assert recommendations == TAAR_LITE_FALLBACKS[:4]
         assert outcome == TAAR_LITE_OUTCOME_REAL_FAIL
         assert reason == TAAR_LITE_FALLBACK_REASON_INVALID
@@ -152,16 +155,17 @@ class TestGetAddonRecommendations(TestCase):
         recommendations, _, _ = get_addon_recommendations_invalid(
             TAAR_LITE_FALLBACKS[0]
         )
-        assert recommendations == TAAR_LITE_FALLBACKS[1:]
+        assert TAAR_LITE_FALLBACKS[0] not in recommendations
 
     def test_get_filtered_fallbacks(self, _):
         # Fallback filters out the current guid if it exists in TAAR_LITE_FALLBACKS
         recommendations = get_filtered_fallbacks(TAAR_LITE_FALLBACKS[2])
-        assert recommendations == TAAR_LITE_FALLBACKS[:2] + TAAR_LITE_FALLBACKS[3:]
+        assert TAAR_LITE_FALLBACKS[2] not in recommendations
         # Fallback returns the first four if it does not.
         recommendations, outcome, reason = get_addon_recommendations_invalid(
             'random-guid'
         )
+        # If there's no results, it takes the first four fallback recommendations
         assert recommendations == TAAR_LITE_FALLBACKS[:4]
 
     def test_is_outcome_recommended(self, incr_mock):

--- a/src/olympia/addons/utils.py
+++ b/src/olympia/addons/utils.py
@@ -91,7 +91,7 @@ def get_addon_recommendations(guid_param, taar_enable):
     else:
         outcome = TAAR_LITE_OUTCOME_CURATED
     if not guids:
-        guids = TAAR_LITE_FALLBACKS
+        guids = get_filtered_fallbacks(guid_param)
     return guids, outcome, fail_reason
 
 
@@ -101,11 +101,14 @@ def is_outcome_recommended(outcome):
 
 def get_addon_recommendations_invalid(current_guid=None):
     return (
-        # Filter out the current_guid from TAAR_LITE_FALLBACKS
-        [guid for guid in TAAR_LITE_FALLBACKS if guid != current_guid][:4],
+        get_filtered_fallbacks(current_guid),
         TAAR_LITE_OUTCOME_REAL_FAIL,
         TAAR_LITE_FALLBACK_REASON_INVALID,
     )
+
+def get_filtered_fallbacks(current_guid=None):
+    # Filter out the current_guid from TAAR_LITE_FALLBACKS
+    return [guid for guid in TAAR_LITE_FALLBACKS if guid != current_guid][:4]
 
 
 def compute_last_updated(addon):

--- a/src/olympia/addons/utils.py
+++ b/src/olympia/addons/utils.py
@@ -58,6 +58,7 @@ TAAR_LITE_FALLBACKS = [
     'treestyletab@piro.sakura.ne.jp',  # Tree Style Tab
     'languagetool-webextension@languagetool.org',  # LanguageTool
     '{2e5ff8c8-32fe-46d0-9fc8-6b8986621f3c}',  # Search by Image
+    'simple-tab-groups@drive4ik' # Simple Tab Groups
 ]
 
 TAAR_LITE_OUTCOME_REAL_SUCCESS = 'recommended'
@@ -98,9 +99,10 @@ def is_outcome_recommended(outcome):
     return outcome == TAAR_LITE_OUTCOME_REAL_SUCCESS
 
 
-def get_addon_recommendations_invalid():
+def get_addon_recommendations_invalid(current_guid=None):
     return (
-        TAAR_LITE_FALLBACKS,
+        # Filter out the current_guid from TAAR_LITE_FALLBACKS
+        [guid for guid in TAAR_LITE_FALLBACKS if guid != current_guid][:4],
         TAAR_LITE_OUTCOME_REAL_FAIL,
         TAAR_LITE_FALLBACK_REASON_INVALID,
     )

--- a/src/olympia/addons/utils.py
+++ b/src/olympia/addons/utils.py
@@ -108,7 +108,9 @@ def get_addon_recommendations_invalid(current_guid=None):
 
 
 def get_filtered_fallbacks(current_guid=None):
-    # Filter out the current_guid from TAAR_LITE_FALLBACKS
+    # Filter out the current_guid from TAAR_LITE_FALLBACKS.
+    # A maximum of 4 should be returned at a time.
+    # See https://mozilla.github.io/addons-server/topics/api/addons.html#recommendations
     return [guid for guid in TAAR_LITE_FALLBACKS if guid != current_guid][:4]
 
 

--- a/src/olympia/addons/utils.py
+++ b/src/olympia/addons/utils.py
@@ -58,7 +58,7 @@ TAAR_LITE_FALLBACKS = [
     'treestyletab@piro.sakura.ne.jp',  # Tree Style Tab
     'languagetool-webextension@languagetool.org',  # LanguageTool
     '{2e5ff8c8-32fe-46d0-9fc8-6b8986621f3c}',  # Search by Image
-    'simple-tab-groups@drive4ik' # Simple Tab Groups
+    'simple-tab-groups@drive4ik',  # Simple Tab Groups
 ]
 
 TAAR_LITE_OUTCOME_REAL_SUCCESS = 'recommended'
@@ -105,6 +105,7 @@ def get_addon_recommendations_invalid(current_guid=None):
         TAAR_LITE_OUTCOME_REAL_FAIL,
         TAAR_LITE_FALLBACK_REASON_INVALID,
     )
+
 
 def get_filtered_fallbacks(current_guid=None):
     # Filter out the current_guid from TAAR_LITE_FALLBACKS

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -1272,7 +1272,7 @@ class AddonRecommendationView(AddonSearchView):
                 guids,
                 self.ab_outcome,
                 self.fallback_reason,
-            ) = get_addon_recommendations_invalid()
+            ) = get_addon_recommendations_invalid(guid_param)
             return qs.query(query.Bool(must=[Q('terms', guid=guids)]))
         return results
 


### PR DESCRIPTION
Fixes: mozilla/addons#1569

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Filters out the current extension from 'other popular extensions' when using the fallback extensions.
![image](https://github.com/user-attachments/assets/a53e3b71-d60e-4cd3-85c0-ae700400c623)
![image](https://github.com/user-attachments/assets/bc426421-9ad4-4217-b646-0e76bc36cc12)

### Testing

`TAAR_LITE_FALLBACKS` uses GUIDs from production, so I'm actually unsure what the proper way of testing this should be. You can mimick the behaviour locally by replacing the GUIDs in `TAAR_LITE_FALLBACKS` with local ones (similar to the screenshot)

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [x] Add before and after screenshots (Only for changes that impact the UI).
