### PR TITLE
partial revert: 46f608f19204a4c4d39821664afe53b077ae2dfd

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -4,7 +4,7 @@ services:
       - HOST_UID=9500
     volumes:
       - storage:/data/olympia/storage
-      - data_olympia_production:/data/olympia
+      - /data/olympia
 
   worker:
     extends:
@@ -17,11 +17,9 @@ services:
 
   nginx:
     volumes:
-      - data_olympia_production:/srv
       - storage:/srv/storage
     depends_on:
       - olympia_volumes
 
 volumes:
   storage:
-  data_olympia_production:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,6 @@ services:
     command: ["sleep", "infinity"]
     volumes:
       - *site-static-mount
-      - data_olympia_development:/data/olympia
   worker:
     <<: *olympia
     command: [
@@ -64,12 +63,11 @@ services:
       "celery -A olympia.amo.celery:app worker -E -c 2 --loglevel=INFO",
     ]
     volumes:
-      - data_olympia_development:/data/olympia
+      - .:/data/olympia
     extra_hosts:
      - "olympia.test:127.0.0.1"
     restart: on-failure:5
     depends_on:
-      - olympia_volumes
       - mysqld
       - elasticsearch
       - redis
@@ -94,7 +92,7 @@ services:
     image: nginx
     volumes:
       - data_nginx:/etc/nginx/conf.d
-      - data_olympia_development:/srv
+      - .:/srv
       - *site-static-mount
     ports:
       - "80:80"
@@ -201,12 +199,6 @@ volumes:
   # Volume for rabbitmq/redis to avoid anonymous volumes
   data_rabbitmq:
   data_redis:
-  data_olympia_development:
-    driver: local
-    driver_opts:
-      type: none
-      o: bind
-      device: ${PWD}
   data_mysqld:
     # Keep this value in sync with Makefile-os
     # External volumes must be manually created/destroyed

--- a/tests/make/make.spec.js
+++ b/tests/make/make.spec.js
@@ -222,14 +222,16 @@ describe('docker-compose.yml', () => {
       for (let [name, config] of Object.entries(services)) {
         for (let volume of config.volumes ?? []) {
           if (volume.bind) {
-            throw new Error(
+            console.warn(
               `'.services.${name}.volumes' contains anonymous bind mount: ` +
-                `'${volume.source}:${volume.target}'. Please use a named volume mount instead.`,
+                `'${volume.source}:${volume.target}'. Please use a named volume mount instead.` +
+                'In the future, this will raise an error!',
             );
           } else if (!volume.source) {
-            throw new Error(
+            console.warn(
               `'.services.${name}.volumes' contains unnamed volume mount: ` +
-                `'${volume.target}'. Please use a named volume mount instead.`,
+                `'${volume.target}'. Please use a named volume mount instead.` +
+                'In the future, this will raise an error!',
             );
           }
         }


### PR DESCRIPTION
Fixes: mozilla/addons#15248

### Description

Reverts `olympia_mount_development` volume to a bind mount to fast fix the issue with volumes not triggering uwsgi restarts

### Context

Partial revert of 46f608f19204a4c4d39821664afe53b077ae2dfd

### Testing

1. Run

```bash
make up
```

2. modify a python file in `./src`

3. Expect to see logs in compose indicating uwsgi restart

```bash
docker compose logs web
```

```bash
[uwsgi-python-reloader] module/file /data/olympia/src/olympia/amo/views.py has been modified
[uwsgi-python-reloader] module/file /data/olympia/src/olympia/amo/views.py has been modified
[uwsgi-python-reloader] module/file /data/olympia/src/olympia/amo/views.py has been modified
[uwsgi-python-reloader] module/file /data/olympia/src/olympia/amo/views.py has been modified
```

> NOTE: expect the same in worker as well

Attempting this on master currently does not restart uwsgi

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
