### PR TITLE
Support Markdown in Add-on Listing Fields

### DIFF
--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -162,7 +162,7 @@ This endpoint allows you to fetch a specific add-on by id, slug or guid.
     :>json string created: The date the add-on was created.
     :>json object current_version: Object holding the current :ref:`version <version-detail-object>` of the add-on. For performance reasons the ``license`` field omits the ``text`` property from both the search and detail endpoints.
     :>json string default_locale: The add-on default locale for translations.
-    :>json object|null description: The add-on description (See :ref:`translated fields <api-overview-translations>`). This field might contain some HTML tags.
+    :>json object|null description: The add-on description (See :ref:`translated fields <api-overview-translations>`). This field might contain markdown.
     :>json object|null developer_comments: Additional information about the add-on provided by the developer. (See :ref:`translated fields <api-overview-translations>`).
     :>json string edit_url: The URL to the developer edit page for the add-on.
     :>json string guid: The add-on `extension identifier <https://developer.mozilla.org/en-US/Add-ons/Install_Manifests#id>`_.
@@ -203,7 +203,7 @@ This endpoint allows you to fetch a specific add-on by id, slug or guid.
     :>json string review_url: The URL to the reviewer review page for the add-on.
     :>json string slug: The add-on slug.
     :>json string status: The :ref:`add-on status <addon-detail-status>`.
-    :>json object|null summary: The add-on summary (See :ref:`translated fields <api-overview-translations>`). This field supports "linkification" and therefore might contain HTML hyperlinks.
+    :>json object|null summary: The add-on summary (See :ref:`translated fields <api-overview-translations>`). This field supports "linkification" and therefore might contain Markdown hyperlinks.
     :>json object|null support_email: The add-on support email (See :ref:`translated fields <api-overview-translations>`).
     :>json object|null support_url: The add-on support URL (See :ref:`translated fields <api-overview-translations>` and :ref:`Outgoing Links <api-overview-outgoing>`).
     :>json array tags: List containing the tag names set on the add-on.
@@ -311,7 +311,7 @@ is compatible with.
     :<json array categories[app_name]: Array holding the :ref:`category slugs <category-list>` the add-on belongs to for a given :ref:`add-on application <addon-detail-application>`.
     :<json string contributions_url: URL to the (external) webpage where the addon's authors collect monetary contributions.  Only a limited number of services are `supported <https://github.com/mozilla/addons-server/blob/0b5db7d544a21f6b887e8e8032496778234ade33/src/olympia/constants/base.py#L214:L226>`_.
     :<json string default_locale: The fallback locale for translated fields for this add-on. Note this only applies to the fields here - the default locale for :ref:`version release notes <version-create-request>` and custom license text is fixed to `en-US`.
-    :<json object|null description: The add-on description (See :ref:`translated fields <api-overview-translations>`). This field can contain some HTML tags.
+    :<json object|null description: The add-on description (See :ref:`translated fields <api-overview-translations>`). This field can contain some Markdown.
     :<json object|null developer_comments: Additional information about the add-on. (See :ref:`translated fields <api-overview-translations>`).
     :<json object|null homepage: The add-on homepage (See :ref:`translated fields <api-overview-translations>` and :ref:`Outgoing Links <api-overview-outgoing>`).
     :<json boolean is_disabled: Whether the add-on is disabled or not.
@@ -347,7 +347,7 @@ This endpoint allows an add-on's AMO metadata to be edited.
     :<json array categories[app_name]: Array holding the :ref:`category slugs <category-list>` the add-on belongs to for a given :ref:`add-on application <addon-detail-application>`.
     :<json string contributions_url: URL to the (external) webpage where the addon's authors collect monetary contributions.  Only a limited number of services are `supported <https://github.com/mozilla/addons-server/blob/0b5db7d544a21f6b887e8e8032496778234ade33/src/olympia/constants/base.py#L214:L226>`_.
     :<json string default_locale: The fallback locale for translated fields for this add-on. Note this only applies to the fields here - the default locale for :ref:`version release notes <version-create-request>` and custom license text is fixed to `en-US`.
-    :<json object|null description: The add-on description (See :ref:`translated fields <api-overview-translations>`). This field can contain some HTML tags.
+    :<json object|null description: The add-on description (See :ref:`translated fields <api-overview-translations>`). This field can contain some Markdown.
     :<json object|null developer_comments: Additional information about the add-on. (See :ref:`translated fields <api-overview-translations>`).
     :<json object|null homepage: The add-on homepage (See :ref:`translated fields <api-overview-translations>` and :ref:`Outgoing Links <api-overview-outgoing>`).
     :<json null icon: To clear the icon, i.e. revert to the default add-on icon, send ``null``.  See :ref:`addon icon <addon-icon>` to upload a new icon.

--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -246,7 +246,7 @@ Note, if the field is also a translated field then the ``url`` and ``outgoing``
 values could be an object rather than a string
 (See :ref:`translated fields <api-overview-translations>` for translated field representations).
 
-Fields supporting some HTML, such as add-on ``description`` or ``summary``,
+Fields supporting some HTML or Markdown, such as add-on ``description`` or ``summary``,
 always wrap any links directly inside the content (the original url is not available).
 
 

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1208,3 +1208,6 @@ watchdog[watchmedo]==3.0.0 \
 django-node-assets==0.9.14 \
     --hash=sha256:80cbe3d10521808309712b2aa5ef6d69799bbcafef844cf7f223d3c93f405768 \
     --hash=sha256:d5b5c472136084d533268f52ab77897327863a102e25c81f484aae85eb806987
+Markdown==3.7 \
+    --hash=sha256:2ae2471477cfd02dbbf038d5d9bc226d40def84b4fe2986e49b59b6b472bbed2 \
+    --hash=sha256:7eb6df5690b81a1d7942992c97fad2938e956e79df20cbc6186e9c3a77b1c803

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -65,7 +65,7 @@ from olympia.ratings.models import Rating
 from olympia.tags.models import Tag
 from olympia.translations.fields import (
     NoURLsField,
-    PurifiedField,
+    PurifiedMarkdownField,
     TranslatedField,
     save_signal,
 )
@@ -501,12 +501,14 @@ class Addon(OnChangeMixin, ModelBase):
     homepage = TranslatedField(max_length=255)
     support_email = TranslatedField(db_column='supportemail', max_length=100)
     support_url = TranslatedField(db_column='supporturl', max_length=255)
-    description = PurifiedField(short=False, max_length=15000)
+    description = PurifiedMarkdownField(short=False, max_length=15000)
 
     summary = NoURLsField(max_length=250)
-    developer_comments = PurifiedField(db_column='developercomments', max_length=3000)
-    eula = PurifiedField(max_length=350000)
-    privacy_policy = PurifiedField(db_column='privacypolicy', max_length=150000)
+    developer_comments = PurifiedMarkdownField(
+        db_column='developercomments', max_length=3000
+    )
+    eula = PurifiedMarkdownField(max_length=350000)
+    privacy_policy = PurifiedMarkdownField(db_column='privacypolicy', max_length=150000)
 
     average_rating = models.FloatField(
         max_length=255, default=0, null=True, db_column='averagerating'

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -964,6 +964,9 @@ class TestAddonModels(TestCase):
         addon.save()
         return addon.privacy_policy.localized_string_clean
 
+    def replace_helper(self, string_before):
+        return string_before.replace('<', '&lt;').replace('>', '&gt;')
+
     def test_newlines_normal(self):
         before = (
             'Paragraph one.\n'
@@ -973,7 +976,14 @@ class TestAddonModels(TestCase):
             "Should be four nl's before this line."
         )
 
-        after = before  # Nothing special; this shouldn't change.
+        # Markdown.
+        after = (
+            'Paragraph one.\n'
+            'This should be on the very next line.\n\n'
+            "Should be two nl's before this line.\n\n"
+            "Should be three nl's before this line.\n\n"
+            "Should be four nl's before this line."
+        )
 
         assert self.newlines_helper(before) == after
 
@@ -986,13 +996,7 @@ class TestAddonModels(TestCase):
             '</ul>'
         )
 
-        after = (
-            '<ul>'
-            "<li>No nl's between the ul and the li.</li>"
-            "<li>No nl's between li's.\n\n"
-            'But there should be two before this line.</li>'
-            '</ul>'
-        )
+        after = self.replace_helper(before)
 
         assert self.newlines_helper(before) == after
 
@@ -1003,11 +1007,7 @@ class TestAddonModels(TestCase):
             "There should be no nl's above this line."
         )
 
-        after = (
-            'There should be one nl between this and the ul.\n'
-            '<ul><li>test</li><li>test</li></ul>'
-            "There should be no nl's above this line."
-        )
+        after = self.replace_helper(before)
 
         assert self.newlines_helper(before) == after
 
@@ -1018,11 +1018,7 @@ class TestAddonModels(TestCase):
             'There should be one nl above this line.'
         )
 
-        after = (
-            "There should be two nl's between this and the ul.\n\n"
-            '<ul><li>test</li><li>test</li></ul>\n'
-            'There should be one nl above this line.'
-        )
+        after = self.replace_helper(before)
 
         assert self.newlines_helper(before) == after
 
@@ -1033,11 +1029,7 @@ class TestAddonModels(TestCase):
             "There should be no nl's above this."
         )
 
-        after = (
-            'There should be one nl below this.\n'
-            '<blockquote>Hi</blockquote>'
-            "There should be no nl's above this."
-        )
+        after = self.replace_helper(before)
 
         assert self.newlines_helper(before) == after
 
@@ -1048,11 +1040,7 @@ class TestAddonModels(TestCase):
             'There should be one nl above this.'
         )
 
-        after = (
-            'There should be two nls below this.\n\n'
-            '<blockquote>Hi</blockquote>\n'
-            'There should be one nl above this.'
-        )
+        after = self.replace_helper(before)
 
         assert self.newlines_helper(before) == after
 
@@ -1062,56 +1050,56 @@ class TestAddonModels(TestCase):
             '<b>The newlines</b> should be kept'
         )
 
-        after = before  # Should stay the same
+        after = self.replace_helper(before)
 
         assert self.newlines_helper(before) == after
 
     def test_newlines_code_inline(self):
         before = "Code tags aren't blocks.\n\n" '<code>alert(test);</code>\n\nSee?'
 
-        after = before  # Should stay the same
+        after = self.replace_helper(before)
 
         assert self.newlines_helper(before) == after
 
     def test_newlines_li_newlines(self):
         before = '<ul><li>\nxx</li></ul>'
-        after = '<ul><li>xx</li></ul>'
+        after = self.replace_helper(before)
         assert self.newlines_helper(before) == after
 
         before = '<ul><li>xx\n</li></ul>'
-        after = '<ul><li>xx</li></ul>'
+        after = self.replace_helper(before)
         assert self.newlines_helper(before) == after
 
         before = '<ul><li>xx\nxx</li></ul>'
-        after = '<ul><li>xx\nxx</li></ul>'
+        after = self.replace_helper(before)
         assert self.newlines_helper(before) == after
 
         before = '<ul><li></li></ul>'
-        after = '<ul><li></li></ul>'
+        after = self.replace_helper(before)
         assert self.newlines_helper(before) == after
 
         # All together now
         before = '<ul><li>\nxx</li> <li>xx\n</li> <li>xx\nxx</li> <li></li>\n</ul>'
 
-        after = '<ul><li>xx</li> <li>xx</li> <li>xx\nxx</li> <li></li></ul>'
+        after = self.replace_helper(before)
 
         assert self.newlines_helper(before) == after
 
     def test_newlines_empty_tag(self):
         before = 'This is a <b></b> test!'
-        after = before
+        after = self.replace_helper(before)
 
         assert self.newlines_helper(before) == after
 
     def test_newlines_empty_tag_nested(self):
         before = 'This is a <b><i></i></b> test!'
-        after = before
+        after = self.replace_helper(before)
 
         assert self.newlines_helper(before) == after
 
     def test_newlines_empty_tag_block_nested(self):
         b = 'Test.\n\n<blockquote><ul><li></li></ul></blockquote>\ntest.'
-        a = 'Test.\n\n<blockquote><ul><li></li></ul></blockquote>test.'
+        a = self.replace_helper(b)
 
         assert self.newlines_helper(b) == a
 
@@ -1120,7 +1108,7 @@ class TestAddonModels(TestCase):
             'Test.\n\n<blockquote>\n\n<ul>\n\n<li>'
             '</li>\n\n</ul>\n\n</blockquote>\ntest.'
         )
-        after = 'Test.\n\n<blockquote><ul><li></li></ul></blockquote>test.'
+        after = self.replace_helper(before)
 
         assert self.newlines_helper(before) == after
 
@@ -1130,10 +1118,7 @@ class TestAddonModels(TestCase):
             '<li>Test <b>test</b> test.</li></ul>'
         )
 
-        after = (
-            '<ul><li><b>test\ntest\n\ntest</b></li>'
-            '<li>Test <b>test</b> test.</li></ul>'
-        )
+        after = self.replace_helper(before)
 
         assert self.newlines_helper(before) == after
 
@@ -1143,7 +1128,7 @@ class TestAddonModels(TestCase):
             'stuff</code> to see what happens.'
         )
 
-        after = before  # Should stay the same
+        after = self.replace_helper(before)
 
         assert self.newlines_helper(before) == after
 
@@ -1152,31 +1137,31 @@ class TestAddonModels(TestCase):
             '<blockquote>\n\n<ul>\n\n<li>\n\ntest\n\n</li>\n\n</ul>\n\n</blockquote>'
         )
 
-        after = '<blockquote><ul><li>test</li></ul></blockquote>'
+        after = self.replace_helper(before)
 
         assert self.newlines_helper(before) == after
 
     def test_newlines_spaced_inline(self):
         before = "Line.\n\n<b>\nThis line is bold.\n</b>\n\nThis isn't."
-        after = before
+        after = self.replace_helper(before)
 
         assert self.newlines_helper(before) == after
 
     def test_newlines_nested_inline(self):
         before = '<b>\nThis line is bold.\n\n<i>This is also italic</i></b>'
-        after = before
+        after = self.replace_helper(before)
 
         assert self.newlines_helper(before) == after
 
     def test_newlines_xss_script(self):
         before = "<script>\n\nalert('test');\n</script>"
-        after = "&lt;script&gt;\n\nalert('test');\n&lt;/script&gt;"
+        after = self.replace_helper(before)
 
         assert self.newlines_helper(before) == after
 
     def test_newlines_xss_inline(self):
         before = '<b onclick="alert(\'test\');">test</b>'
-        after = '<b>test</b>'
+        after = self.replace_helper(before)
 
         assert self.newlines_helper(before) == after
 
@@ -1191,61 +1176,61 @@ class TestAddonModels(TestCase):
 
     def test_newlines_attribute_singlequote(self):
         before = "<abbr title='laugh out loud'>lol</abbr>"
-        after = '<abbr title="laugh out loud">lol</abbr>'
+        after = self.replace_helper(before)
 
         assert self.newlines_helper(before) == after
 
     def test_newlines_attribute_doublequote(self):
         before = '<abbr title="laugh out loud">lol</abbr>'
-        after = before
+        after = self.replace_helper(before)
 
         assert self.newlines_helper(before) == after
 
     def test_newlines_attribute_nestedquotes_doublesingle(self):
         before = '<abbr title="laugh \'out\' loud">lol</abbr>'
-        after = before
+        after = self.replace_helper(before)
 
         assert self.newlines_helper(before) == after
 
     def test_newlines_attribute_nestedquotes_singledouble(self):
         before = '<abbr title=\'laugh "out" loud\'>lol</abbr>'
-        after = before
+        after = self.replace_helper(before)
 
         assert self.newlines_helper(before) == after
 
     def test_newlines_unclosed_b(self):
         before = '<b>test'
-        after = '<b>test</b>'
+        after = self.replace_helper(before)
 
         assert self.newlines_helper(before) == after
 
     def test_newlines_unclosed_b_wrapped(self):
         before = 'This is a <b>test'
-        after = 'This is a <b>test</b>'
+        after = self.replace_helper(before)
 
         assert self.newlines_helper(before) == after
 
     def test_newlines_unclosed_li(self):
         before = '<ul><li>test</ul>'
-        after = '<ul><li>test</li></ul>'
+        after = self.replace_helper(before)
 
         assert self.newlines_helper(before) == after
 
     def test_newlines_malformed_faketag(self):
         before = '<madonna'
-        after = '&lt;madonna'
+        after = self.replace_helper(before)
 
         assert self.newlines_helper(before) == after
 
     def test_newlines_correct_faketag(self):
         before = '<madonna>'
-        after = '&lt;madonna&gt;'
+        after = self.replace_helper(before)
 
         assert self.newlines_helper(before) == after
 
     def test_newlines_malformed_tag(self):
         before = '<strong'
-        after = '&lt;strong'
+        after = self.replace_helper(before)
 
         assert self.newlines_helper(before) == after
 
@@ -1261,13 +1246,13 @@ class TestAddonModels(TestCase):
 
     def test_newlines_less_than(self):
         before = '3 < 5'
-        after = '3 &lt; 5'
+        after = self.replace_helper(before)
 
         assert self.newlines_helper(before) == after
 
     def test_newlines_less_than_tight(self):
         before = 'abc 3<5 def'
-        after = 'abc 3&lt;5 def'
+        after = self.replace_helper(before)
 
         assert self.newlines_helper(before) == after
 

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -989,14 +989,15 @@ class TestAddonModels(TestCase):
         mock_get_outgoing_url.return_value = 'https://www.mozilla.org'
         before = 'Heres a link [to here!](https://www.mozilla.org "Click me!")'
 
-        after = ('Heres a link '
-        '<a href="https://www.mozilla.org" '
-        'title="Click me!" rel="nofollow">'
-        'to here!'
-        '</a>')
+        after = (
+            'Heres a link '
+            '<a href="https://www.mozilla.org" '
+            'title="Click me!" rel="nofollow">'
+            'to here!'
+            '</a>'
+        )
 
         assert self.newlines_helper(before) == after
-
 
     def test_abbr_markdown(self):
         before = (
@@ -1013,16 +1014,22 @@ class TestAddonModels(TestCase):
 
     def test_bold_markdown(self):
         before = "Line.\n\n__This line is bold.__\n\n**So is this.**\n\nThis isn't."
-        after = "Line.\n\n<strong>This line is bold.</strong>\n\n<strong>So is this.</strong>\n\nThis isn't."
+        after = (
+            'Line.\n\n<strong>This line is bold.</strong>\n\n'
+            "<strong>So is this.</strong>\n\nThis isn't."
+        )
 
         assert self.newlines_helper(before) == after
 
     def test_italics_markdown(self):
         before = "Line.\n\n_This line is emphasized._\n\n*So is this.*\n\nThis isn't."
-        after = "Line.\n\n<em>This line is emphasized.</em>\n\n<em>So is this.</em>\n\nThis isn't."
+        after = (
+            'Line.\n\n<em>This line is emphasized.</em>\n\n'
+            "<em>So is this.</em>\n\nThis isn't."
+        )
 
         assert self.newlines_helper(before) == after
-    
+
     def test_empty_markdown(self):
         before = 'This is a **** test!'
         after = before
@@ -1044,21 +1051,19 @@ class TestAddonModels(TestCase):
             '    System.out.println("Hello Again!")'
         )
 
-        after =  '<code>System.out.println("Hello, World!")</code>\n\n<code>System.out.println("Hello Again!")\n</code>'
+        after = (
+            '<code>System.out.println("Hello, World!")</code>\n\n'
+            '<code>System.out.println("Hello Again!")\n</code>'
+        )
 
         assert self.newlines_helper(before) == after
-    
+
     def test_blockquote_markdown(self):
-        before = (
-            'Test.\n\n'
-            '> \n'
-            '> -  \n'
-            '\ntest.'
-        )
+        before = 'Test.\n\n' '> \n' '> -  \n' '\ntest.'
         after = 'Test.\n<blockquote><ul><li></li></ul></blockquote>\ntest.'
 
         assert self.newlines_helper(before) == after
-    
+
     def test_ul_markdown(self):
         before = '* \nxx'
         after = '<ul><li>xx</li></ul>'
@@ -1073,16 +1078,11 @@ class TestAddonModels(TestCase):
         assert self.newlines_helper(before) == after
 
         before = '*'
-        after = before # Doesn't do anything on its own
+        after = before  # Doesn't do anything on its own
         assert self.newlines_helper(before) == after
 
         # All together now
-        before = (
-            '* \nxx\n'
-            '* xx\n'
-            '* \n'
-            '* xx\nxx\n'
-        )
+        before = '* \nxx\n' '* xx\n' '* \n' '* xx\nxx\n'
 
         after = '<ul><li>xx</li><li>xx</li><li></li><li>xx\nxx</li></ul>'
         assert self.newlines_helper(before) == after
@@ -1101,16 +1101,11 @@ class TestAddonModels(TestCase):
         assert self.newlines_helper(before) == after
 
         before = '1.'
-        after = before # Doesn't do anything on its own
+        after = before  # Doesn't do anything on its own
         assert self.newlines_helper(before) == after
 
         # All together now
-        before = (
-            '1. \nxx\n'
-            '2. xx\n'
-            '3. \n'
-            '4. xx\nxx\n'
-        )
+        before = '1. \nxx\n' '2. xx\n' '3. \n' '4. xx\nxx\n'
 
         after = '<ol><li>xx</li><li>xx</li><li></li><li>xx\nxx</li></ol>'
         assert self.newlines_helper(before) == after

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -964,204 +964,166 @@ class TestAddonModels(TestCase):
         addon.save()
         return addon.privacy_policy.localized_string_clean
 
-    def replace_helper(self, string_before):
-        return string_before.replace('<', '&lt;').replace('>', '&gt;')
-
-    def test_newlines_normal(self):
+    def test_newlines(self):
         before = (
             'Paragraph one.\n'
             'This should be on the very next line.\n\n'
             "Should be two nl's before this line.\n\n\n"
-            "Should be three nl's before this line.\n\n\n\n"
-            "Should be four nl's before this line."
+            "Should be two nl's before this line.\n\n\n\n"
+            "Should be two nl's before this line."
         )
 
-        # Markdown.
+        # Markdown treats multiple blank lines as one.
         after = (
             'Paragraph one.\n'
             'This should be on the very next line.\n\n'
             "Should be two nl's before this line.\n\n"
-            "Should be three nl's before this line.\n\n"
-            "Should be four nl's before this line."
+            "Should be two nl's before this line.\n\n"
+            "Should be two nl's before this line."
         )
 
         assert self.newlines_helper(before) == after
 
-    def test_newlines_ul(self):
+    @patch('olympia.amo.templatetags.jinja_helpers.urlresolvers.get_outgoing_url')
+    def test_link_markdown(self, mock_get_outgoing_url):
+        mock_get_outgoing_url.return_value = 'https://www.mozilla.org'
+        before = 'Heres a link [to here!](https://www.mozilla.org "Click me!")'
+
+        after = ('Heres a link '
+        '<a href="https://www.mozilla.org" '
+        'title="Click me!" rel="nofollow">'
+        'to here!'
+        '</a>')
+
+        assert self.newlines_helper(before) == after
+
+
+    def test_abbr_markdown(self):
         before = (
-            '<ul>\n\n'
-            "<li>No nl's between the ul and the li.</li>\n\n"
-            "<li>No nl's between li's.\n\n"
-            'But there should be two before this line.</li>\n\n'
-            '</ul>'
+            'TGIF ROFL\n\n'
+            '*[TGIF]:i stand for this\n\n'
+            '*[ROFL]: i stand for that\n\n'
         )
-
-        after = self.replace_helper(before)
+        after = (
+            '<abbr title="i stand for this">TGIF</abbr> '
+            '<abbr title="i stand for that">ROFL</abbr>'
+        )
 
         assert self.newlines_helper(before) == after
 
-    def test_newlines_ul_tight(self):
+    def test_bold_markdown(self):
+        before = "Line.\n\n__This line is bold.__\n\n**So is this.**\n\nThis isn't."
+        after = "Line.\n\n<strong>This line is bold.</strong>\n\n<strong>So is this.</strong>\n\nThis isn't."
+
+        assert self.newlines_helper(before) == after
+
+    def test_italics_markdown(self):
+        before = "Line.\n\n_This line is emphasized._\n\n*So is this.*\n\nThis isn't."
+        after = "Line.\n\n<em>This line is emphasized.</em>\n\n<em>So is this.</em>\n\nThis isn't."
+
+        assert self.newlines_helper(before) == after
+    
+    def test_empty_markdown(self):
+        before = 'This is a **** test!'
+        after = before
+
+        assert self.newlines_helper(before) == after
+
+    def test_nested_newline(self):
+        # Nested newlines escape the markdown.
+        before = '**\nThis line is not bold.\n\n*This is italic***'
+        after = '**\nThis line is not bold.\n\n<em>This is italic</em>**'
+
+        assert self.newlines_helper(before) == after
+
+    def test_code_markdown(self):
         before = (
-            'There should be one nl between this and the ul.\n'
-            '<ul><li>test</li><li>test</li></ul>\n'
-            "There should be no nl's above this line."
+            '````'
+            'System.out.println("Hello, World!")'
+            '````\n\n'
+            '    System.out.println("Hello Again!")'
         )
 
-        after = self.replace_helper(before)
+        after =  '<code>System.out.println("Hello, World!")</code>\n\n<code>System.out.println("Hello Again!")\n</code>'
 
         assert self.newlines_helper(before) == after
-
-    def test_newlines_ul_loose(self):
+    
+    def test_blockquote_markdown(self):
         before = (
-            "There should be two nl's between this and the ul.\n\n"
-            '<ul><li>test</li><li>test</li></ul>\n\n'
-            'There should be one nl above this line.'
+            'Test.\n\n'
+            '> \n'
+            '> -  \n'
+            '\ntest.'
         )
-
-        after = self.replace_helper(before)
-
-        assert self.newlines_helper(before) == after
-
-    def test_newlines_blockquote_tight(self):
-        before = (
-            'There should be one nl below this.\n'
-            '<blockquote>Hi</blockquote>\n'
-            "There should be no nl's above this."
-        )
-
-        after = self.replace_helper(before)
+        after = 'Test.\n<blockquote><ul><li></li></ul></blockquote>\ntest.'
 
         assert self.newlines_helper(before) == after
-
-    def test_newlines_blockquote_loose(self):
-        before = (
-            'There should be two nls below this.\n\n'
-            '<blockquote>Hi</blockquote>\n\n'
-            'There should be one nl above this.'
-        )
-
-        after = self.replace_helper(before)
-
+    
+    def test_ul_markdown(self):
+        before = '* \nxx'
+        after = '<ul><li>xx</li></ul>'
         assert self.newlines_helper(before) == after
 
-    def test_newlines_inline(self):
-        before = (
-            'If we end a paragraph w/ a <b>non-block-level tag</b>\n\n'
-            '<b>The newlines</b> should be kept'
-        )
-
-        after = self.replace_helper(before)
-
+        before = '* xx'
+        after = '<ul><li>xx</li></ul>'
         assert self.newlines_helper(before) == after
 
-    def test_newlines_code_inline(self):
-        before = "Code tags aren't blocks.\n\n" '<code>alert(test);</code>\n\nSee?'
-
-        after = self.replace_helper(before)
-
+        before = '* xx\nxx'
+        after = '<ul><li>xx\nxx</li></ul>'
         assert self.newlines_helper(before) == after
 
-    def test_newlines_li_newlines(self):
-        before = '<ul><li>\nxx</li></ul>'
-        after = self.replace_helper(before)
-        assert self.newlines_helper(before) == after
-
-        before = '<ul><li>xx\n</li></ul>'
-        after = self.replace_helper(before)
-        assert self.newlines_helper(before) == after
-
-        before = '<ul><li>xx\nxx</li></ul>'
-        after = self.replace_helper(before)
-        assert self.newlines_helper(before) == after
-
-        before = '<ul><li></li></ul>'
-        after = self.replace_helper(before)
+        before = '*'
+        after = before # Doesn't do anything on its own
         assert self.newlines_helper(before) == after
 
         # All together now
-        before = '<ul><li>\nxx</li> <li>xx\n</li> <li>xx\nxx</li> <li></li>\n</ul>'
-
-        after = self.replace_helper(before)
-
-        assert self.newlines_helper(before) == after
-
-    def test_newlines_empty_tag(self):
-        before = 'This is a <b></b> test!'
-        after = self.replace_helper(before)
-
-        assert self.newlines_helper(before) == after
-
-    def test_newlines_empty_tag_nested(self):
-        before = 'This is a <b><i></i></b> test!'
-        after = self.replace_helper(before)
-
-        assert self.newlines_helper(before) == after
-
-    def test_newlines_empty_tag_block_nested(self):
-        b = 'Test.\n\n<blockquote><ul><li></li></ul></blockquote>\ntest.'
-        a = self.replace_helper(b)
-
-        assert self.newlines_helper(b) == a
-
-    def test_newlines_empty_tag_block_nested_spaced(self):
         before = (
-            'Test.\n\n<blockquote>\n\n<ul>\n\n<li>'
-            '</li>\n\n</ul>\n\n</blockquote>\ntest.'
-        )
-        after = self.replace_helper(before)
-
-        assert self.newlines_helper(before) == after
-
-    def test_newlines_li_newlines_inline(self):
-        before = (
-            '<ul><li>\n<b>test\ntest\n\ntest</b>\n</li>'
-            '<li>Test <b>test</b> test.</li></ul>'
+            '* \nxx\n'
+            '* xx\n'
+            '* \n'
+            '* xx\nxx\n'
         )
 
-        after = self.replace_helper(before)
-
+        after = '<ul><li>xx</li><li>xx</li><li></li><li>xx\nxx</li></ul>'
         assert self.newlines_helper(before) == after
 
-    def test_newlines_li_all_inline(self):
+    def test_ol_markdown(self):
+        before = '1. \nxx'
+        after = '<ol><li>xx</li></ol>'
+        assert self.newlines_helper(before) == after
+
+        before = '1. xx'
+        after = '<ol><li>xx</li></ol>'
+        assert self.newlines_helper(before) == after
+
+        before = '1. xx\nxx'
+        after = '<ol><li>xx\nxx</li></ol>'
+        assert self.newlines_helper(before) == after
+
+        before = '1.'
+        after = before # Doesn't do anything on its own
+        assert self.newlines_helper(before) == after
+
+        # All together now
         before = (
-            'Test with <b>no newlines</b> and <code>block level '
-            'stuff</code> to see what happens.'
+            '1. \nxx\n'
+            '2. xx\n'
+            '3. \n'
+            '4. xx\nxx\n'
         )
 
-        after = self.replace_helper(before)
-
-        assert self.newlines_helper(before) == after
-
-    def test_newlines_spaced_blocks(self):
-        before = (
-            '<blockquote>\n\n<ul>\n\n<li>\n\ntest\n\n</li>\n\n</ul>\n\n</blockquote>'
-        )
-
-        after = self.replace_helper(before)
-
-        assert self.newlines_helper(before) == after
-
-    def test_newlines_spaced_inline(self):
-        before = "Line.\n\n<b>\nThis line is bold.\n</b>\n\nThis isn't."
-        after = self.replace_helper(before)
-
-        assert self.newlines_helper(before) == after
-
-    def test_newlines_nested_inline(self):
-        before = '<b>\nThis line is bold.\n\n<i>This is also italic</i></b>'
-        after = self.replace_helper(before)
-
+        after = '<ol><li>xx</li><li>xx</li><li></li><li>xx\nxx</li></ol>'
         assert self.newlines_helper(before) == after
 
     def test_newlines_xss_script(self):
         before = "<script>\n\nalert('test');\n</script>"
-        after = self.replace_helper(before)
+        after = "&lt;script&gt;\n\nalert('test');\n&lt;/script&gt;"
 
         assert self.newlines_helper(before) == after
 
     def test_newlines_xss_inline(self):
         before = '<b onclick="alert(\'test\');">test</b>'
-        after = self.replace_helper(before)
+        after = '&lt;b onclick="alert(\'test\');"&gt;test&lt;/b&gt;'
 
         assert self.newlines_helper(before) == after
 
@@ -1174,63 +1136,35 @@ class TestAddonModels(TestCase):
 
         assert 'rel="nofollow"' in parsed
 
-    def test_newlines_attribute_singlequote(self):
-        before = "<abbr title='laugh out loud'>lol</abbr>"
-        after = self.replace_helper(before)
+    def test_newlines_tag(self):
+        # user-inputted HTML is cleaned and ignored in favour of markdown.
+        # Disallowed markdown is stripped from the final result.
+        before = 'This is a <b>bold</b> **test!** \n\n --- \n\n'
+        after = 'This is a &lt;b&gt;bold&lt;/b&gt; <strong>test!</strong>'
 
         assert self.newlines_helper(before) == after
 
-    def test_newlines_attribute_doublequote(self):
-        before = '<abbr title="laugh out loud">lol</abbr>'
-        after = self.replace_helper(before)
-
-        assert self.newlines_helper(before) == after
-
-    def test_newlines_attribute_nestedquotes_doublesingle(self):
-        before = '<abbr title="laugh \'out\' loud">lol</abbr>'
-        after = self.replace_helper(before)
-
-        assert self.newlines_helper(before) == after
-
-    def test_newlines_attribute_nestedquotes_singledouble(self):
-        before = '<abbr title=\'laugh "out" loud\'>lol</abbr>'
-        after = self.replace_helper(before)
-
-        assert self.newlines_helper(before) == after
-
-    def test_newlines_unclosed_b(self):
+    def test_newlines_unclosed_tag(self):
         before = '<b>test'
-        after = self.replace_helper(before)
-
-        assert self.newlines_helper(before) == after
-
-    def test_newlines_unclosed_b_wrapped(self):
-        before = 'This is a <b>test'
-        after = self.replace_helper(before)
-
-        assert self.newlines_helper(before) == after
-
-    def test_newlines_unclosed_li(self):
-        before = '<ul><li>test</ul>'
-        after = self.replace_helper(before)
+        after = '&lt;b&gt;test'
 
         assert self.newlines_helper(before) == after
 
     def test_newlines_malformed_faketag(self):
         before = '<madonna'
-        after = self.replace_helper(before)
+        after = '&lt;madonna'
 
         assert self.newlines_helper(before) == after
 
     def test_newlines_correct_faketag(self):
         before = '<madonna>'
-        after = self.replace_helper(before)
+        after = '&lt;madonna&gt;'
 
         assert self.newlines_helper(before) == after
 
     def test_newlines_malformed_tag(self):
         before = '<strong'
-        after = self.replace_helper(before)
+        after = '&lt;strong'
 
         assert self.newlines_helper(before) == after
 
@@ -1246,13 +1180,13 @@ class TestAddonModels(TestCase):
 
     def test_newlines_less_than(self):
         before = '3 < 5'
-        after = self.replace_helper(before)
+        after = '3 &lt; 5'
 
         assert self.newlines_helper(before) == after
 
     def test_newlines_less_than_tight(self):
         before = 'abc 3<5 def'
-        after = self.replace_helper(before)
+        after = 'abc 3&lt;5 def'
 
         assert self.newlines_helper(before) == after
 

--- a/src/olympia/devhub/templates/devhub/addons/edit/additional_details.html
+++ b/src/olympia/devhub/templates/devhub/addons/edit/additional_details.html
@@ -1,4 +1,4 @@
-{% from "devhub/includes/macros.html" import tip, some_html_tip, empty_unless %}
+{% from "devhub/includes/macros.html" import tip, empty_unless %}
 
 <form method="post" action="{{ url('devhub.addons.section', addon.slug, 'additional_details', 'edit') }}">
   <h3>

--- a/src/olympia/devhub/templates/devhub/addons/edit/describe.html
+++ b/src/olympia/devhub/templates/devhub/addons/edit/describe.html
@@ -1,4 +1,4 @@
-{% from "devhub/includes/macros.html" import tip, empty_unless, flags, select_cats, markdown_tip, trans_readonly %}
+{% from "devhub/includes/macros.html" import tip, empty_unless, flags, select_cats, supported_syntax_tip, trans_readonly %}
 
 <form method="post" action="{{ url('devhub.addons.section', valid_slug, 'describe', 'edit') }}"
       id="addon-edit-describe"
@@ -141,7 +141,7 @@
                 <div class="char-count"
                      data-for-startswith="{{ main_form.description.auto_id }}_"
                      data-minlength="{{ main_form.description.field.min_length }}"></div>
-                {{ markdown_tip() }}
+                {{ supported_syntax_tip() }}
               {% else %}
                 {% call empty_unless(addon.description) %}
                   <div id="addon-description" class="prose">

--- a/src/olympia/devhub/templates/devhub/addons/edit/describe.html
+++ b/src/olympia/devhub/templates/devhub/addons/edit/describe.html
@@ -141,7 +141,7 @@
                 <div class="char-count"
                      data-for-startswith="{{ main_form.description.auto_id }}_"
                      data-minlength="{{ main_form.description.field.min_length }}"></div>
-                {{ supported_syntax_tip() }}
+                {{ supported_syntax_tip(allowed_markdown) }}
               {% else %}
                 {% call empty_unless(addon.description) %}
                   <div id="addon-description" class="prose">

--- a/src/olympia/devhub/templates/devhub/addons/edit/describe.html
+++ b/src/olympia/devhub/templates/devhub/addons/edit/describe.html
@@ -1,4 +1,4 @@
-{% from "devhub/includes/macros.html" import tip, empty_unless, flags, select_cats, some_html_tip, trans_readonly %}
+{% from "devhub/includes/macros.html" import tip, empty_unless, flags, select_cats, markdown_tip, trans_readonly %}
 
 <form method="post" action="{{ url('devhub.addons.section', valid_slug, 'describe', 'edit') }}"
       id="addon-edit-describe"
@@ -141,7 +141,7 @@
                 <div class="char-count"
                      data-for-startswith="{{ main_form.description.auto_id }}_"
                      data-minlength="{{ main_form.description.field.min_length }}"></div>
-                {{ some_html_tip() }}
+                {{ markdown_tip() }}
               {% else %}
                 {% call empty_unless(addon.description) %}
                   <div id="addon-description" class="prose">

--- a/src/olympia/devhub/templates/devhub/addons/edit/technical.html
+++ b/src/olympia/devhub/templates/devhub/addons/edit/technical.html
@@ -1,4 +1,4 @@
-{% from "devhub/includes/macros.html" import tip, some_html_tip, empty_unless, flags %}
+{% from "devhub/includes/macros.html" import tip, markdown_tip, empty_unless, flags %}
 
 <form method="post"
       action="{{ url('devhub.addons.section', addon.slug, 'technical', 'edit') }}">
@@ -32,7 +32,7 @@
               {% if editable %}
                 {{ main_form.developer_comments }}
                 {{ main_form.developer_comments.errors }}
-                {{ some_html_tip() }}
+                {{ markdown_tip() }}
               {% else %}
                 {% call empty_unless(addon.developer_comments) %}
                   <div id="developer_comments">{{ addon|all_locales('developer_comments') }}</div>

--- a/src/olympia/devhub/templates/devhub/addons/edit/technical.html
+++ b/src/olympia/devhub/templates/devhub/addons/edit/technical.html
@@ -32,7 +32,7 @@
               {% if editable %}
                 {{ main_form.developer_comments }}
                 {{ main_form.developer_comments.errors }}
-                {{ supported_syntax_tip() }}
+                {{ supported_syntax_tip(allowed_markdown) }}
               {% else %}
                 {% call empty_unless(addon.developer_comments) %}
                   <div id="developer_comments">{{ addon|all_locales('developer_comments', nl2br=True) }}</div>

--- a/src/olympia/devhub/templates/devhub/addons/edit/technical.html
+++ b/src/olympia/devhub/templates/devhub/addons/edit/technical.html
@@ -1,4 +1,4 @@
-{% from "devhub/includes/macros.html" import tip, markdown_tip, empty_unless, flags %}
+{% from "devhub/includes/macros.html" import tip, supported_syntax_tip, empty_unless, flags %}
 
 <form method="post"
       action="{{ url('devhub.addons.section', addon.slug, 'technical', 'edit') }}">
@@ -32,7 +32,7 @@
               {% if editable %}
                 {{ main_form.developer_comments }}
                 {{ main_form.developer_comments.errors }}
-                {{ markdown_tip() }}
+                {{ supported_syntax_tip() }}
               {% else %}
                 {% call empty_unless(addon.developer_comments) %}
                   <div id="developer_comments">{{ addon|all_locales('developer_comments', nl2br=True) }}</div>

--- a/src/olympia/devhub/templates/devhub/addons/edit/technical.html
+++ b/src/olympia/devhub/templates/devhub/addons/edit/technical.html
@@ -35,7 +35,7 @@
                 {{ markdown_tip() }}
               {% else %}
                 {% call empty_unless(addon.developer_comments) %}
-                  <div id="developer_comments">{{ addon|all_locales('developer_comments') }}</div>
+                  <div id="developer_comments">{{ addon|all_locales('developer_comments', nl2br=True) }}</div>
                 {% endcall %}
               {% endif %}
             </td>

--- a/src/olympia/devhub/templates/devhub/addons/owner.html
+++ b/src/olympia/devhub/templates/devhub/addons/owner.html
@@ -1,6 +1,6 @@
 {% extends "devhub/base.html" %}
 
-{% from "devhub/includes/macros.html" import tip, some_html_tip %}
+{% from "devhub/includes/macros.html" import tip %}
 
 {% set title = _('Manage Authors & License') %}
 

--- a/src/olympia/devhub/templates/devhub/addons/submit/describe.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/describe.html
@@ -113,7 +113,7 @@
              data-for-startswith="{{ describe_form.description.auto_id }}_"
              data-minlength="{{ describe_form.description.field.min_length }}"></div>
       </div>
-      {{ supported_syntax_tip() }}
+      {{ supported_syntax_tip(allowed_markdown) }}
     </div>
     {% endif %}
     {% if addon.type != amo.ADDON_STATICTHEME %}
@@ -180,7 +180,7 @@
             {{ license_form.text.errors }}
             {{ license_form.text.label_tag() }}
             {{ license_form.text }}
-            {{ supported_syntax_tip() }}
+            {{ supported_syntax_tip(allowed_markdown) }}
           </div>
       </div>
     {% endif %}

--- a/src/olympia/devhub/templates/devhub/addons/submit/describe.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/describe.html
@@ -1,4 +1,4 @@
-{% from "devhub/includes/macros.html" import some_html_tip, select_cats %}
+{% from "devhub/includes/macros.html" import markdown_tip, select_cats %}
 {% from "includes/forms.html" import tip %}
 {% extends "devhub/addons/submit/base.html" %}
 
@@ -113,7 +113,7 @@
              data-for-startswith="{{ describe_form.description.auto_id }}_"
              data-minlength="{{ describe_form.description.field.min_length }}"></div>
       </div>
-      {{ some_html_tip() }}
+      {{ markdown_tip() }}
     </div>
     {% endif %}
     {% if addon.type != amo.ADDON_STATICTHEME %}
@@ -180,7 +180,7 @@
             {{ license_form.text.errors }}
             {{ license_form.text.label_tag() }}
             {{ license_form.text }}
-            {{ some_html_tip() }}
+            {{ markdown_tip() }}
           </div>
       </div>
     {% endif %}

--- a/src/olympia/devhub/templates/devhub/addons/submit/describe.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/describe.html
@@ -1,4 +1,4 @@
-{% from "devhub/includes/macros.html" import markdown_tip, select_cats %}
+{% from "devhub/includes/macros.html" import supported_syntax_tip, select_cats %}
 {% from "includes/forms.html" import tip %}
 {% extends "devhub/addons/submit/base.html" %}
 
@@ -113,7 +113,7 @@
              data-for-startswith="{{ describe_form.description.auto_id }}_"
              data-minlength="{{ describe_form.description.field.min_length }}"></div>
       </div>
-      {{ markdown_tip() }}
+      {{ supported_syntax_tip() }}
     </div>
     {% endif %}
     {% if addon.type != amo.ADDON_STATICTHEME %}
@@ -180,7 +180,7 @@
             {{ license_form.text.errors }}
             {{ license_form.text.label_tag() }}
             {{ license_form.text }}
-            {{ markdown_tip() }}
+            {{ supported_syntax_tip() }}
           </div>
       </div>
     {% endif %}

--- a/src/olympia/devhub/templates/devhub/addons/submit/describe_minimal.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/describe_minimal.html
@@ -1,4 +1,3 @@
-{% from "devhub/includes/macros.html" import some_html_tip %}
 {% extends "devhub/addons/submit/base.html" %}
 
 {% block title %}{{ dev_page_title(_('Describe Add-on'), addon) }}{% endblock %}

--- a/src/olympia/devhub/templates/devhub/includes/macros.html
+++ b/src/olympia/devhub/templates/devhub/includes/macros.html
@@ -10,7 +10,7 @@
 </p>
 {% endmacro %}
 
-{% macro markdown_tip(title=None) %}
+{% macro supported_syntax_tip(title=None) %}
 <p class="syntax-support">
 {# L10n: %s is a list of markdown syntax. #}
 <span class="tooltip" title="{% if title %}{{ title }}{% else %}{{

--- a/src/olympia/devhub/templates/devhub/includes/macros.html
+++ b/src/olympia/devhub/templates/devhub/includes/macros.html
@@ -10,6 +10,17 @@
 </p>
 {% endmacro %}
 
+{% macro markdown_tip(title=None) %}
+<p class="html-support">
+{# L10n: %s is a list of HTML tags. #}
+<span class="tooltip" title="{% if title %}{{ title }}{% else %}{{
+      _('Allowed HTML: %(allowed_html)s', allowed_html='<a href title> <abbr title> <acronym title> <b>
+                             <blockquote> <code> <em> <i> <li> <ol> <strong> <ul>')|safe
+    }}{% endif %}">{{ _('Some Markdown supported.') }}</span>
+</p>
+{% endmacro %}
+
+
 {% macro empty_unless(truthy) %}
   {% if truthy %}
     {{ caller() }}

--- a/src/olympia/devhub/templates/devhub/includes/macros.html
+++ b/src/olympia/devhub/templates/devhub/includes/macros.html
@@ -1,7 +1,7 @@
 {% extends "includes/forms.html" %}
 
 {% macro some_html_tip(title=None) %}
-<p class="html-support">
+<p class="syntax-support">
 {# L10n: %s is a list of HTML tags. #}
 <span class="tooltip" title="{% if title %}{{ title }}{% else %}{{
       _('Allowed HTML: %(allowed_html)s', allowed_html='<a href title> <abbr title> <acronym title> <b>
@@ -11,11 +11,10 @@
 {% endmacro %}
 
 {% macro markdown_tip(title=None) %}
-<p class="html-support">
-{# L10n: %s is a list of HTML tags. #}
+<p class="syntax-support">
+{# L10n: %s is a list of markdown syntax. #}
 <span class="tooltip" title="{% if title %}{{ title }}{% else %}{{
-      _('Allowed HTML: %(allowed_html)s', allowed_html='<a href title> <abbr title> <acronym title> <b>
-                             <blockquote> <code> <em> <i> <li> <ol> <strong> <ul>')|safe
+      _('Allowed Markdown: %(allowed_markdown)s', allowed_markdown='links, abbr,  bold, italics, blockquote, code, ol, ul')
     }}{% endif %}">{{ _('Some Markdown supported.') }}</span>
 </p>
 {% endmacro %}

--- a/src/olympia/devhub/templates/devhub/includes/macros.html
+++ b/src/olympia/devhub/templates/devhub/includes/macros.html
@@ -1,15 +1,5 @@
 {% extends "includes/forms.html" %}
 
-{% macro some_html_tip(title=None) %}
-<p class="syntax-support">
-{# L10n: %s is a list of HTML tags. #}
-<span class="tooltip" title="{% if title %}{{ title }}{% else %}{{
-      _('Allowed HTML: %(allowed_html)s', allowed_html='<a href title> <abbr title> <acronym title> <b>
-                             <blockquote> <code> <em> <i> <li> <ol> <strong> <ul>')|safe
-    }}{% endif %}">{{ _('Some HTML supported.') }}</span>
-</p>
-{% endmacro %}
-
 {% macro supported_syntax_tip(allowed_markdown, title=None) %}
 <p class="syntax-support">
 {# L10n: %s is a list of markdown syntax. #}

--- a/src/olympia/devhub/templates/devhub/includes/macros.html
+++ b/src/olympia/devhub/templates/devhub/includes/macros.html
@@ -10,11 +10,11 @@
 </p>
 {% endmacro %}
 
-{% macro supported_syntax_tip(title=None) %}
+{% macro supported_syntax_tip(allowed_markdown, title=None) %}
 <p class="syntax-support">
 {# L10n: %s is a list of markdown syntax. #}
 <span class="tooltip" title="{% if title %}{{ title }}{% else %}{{
-      _('Allowed Markdown: %(allowed_markdown)s', allowed_markdown='links, abbr,  bold, italics, blockquote, code, ol, ul')
+      _('Allowed Markdown: %(allowed_markdown)s', allowed_markdown=allowed_markdown)
     }}{% endif %}">{{ _('Some Markdown supported.') }}</span>
 </p>
 {% endmacro %}

--- a/src/olympia/devhub/templates/devhub/includes/policy_form.html
+++ b/src/olympia/devhub/templates/devhub/includes/policy_form.html
@@ -1,4 +1,4 @@
-{% from "devhub/includes/macros.html" import tip, markdown_tip %}
+{% from "devhub/includes/macros.html" import tip, supported_syntax_tip %}
 <tr>
   <th>{{ tip(_('End-User License Agreement'),
              _('Please note that a EULA is not '
@@ -13,7 +13,7 @@
         {{ policy_form.eula.label }}
       </label>
       {{ policy_form.eula }}
-      {{ markdown_tip() }}
+      {{ supported_syntax_tip() }}
     </div>
   </td>
 </tr>
@@ -31,7 +31,7 @@
         {{ policy_form.privacy_policy.label }}
       </label>
       {{ policy_form.privacy_policy }}
-      {{ markdown_tip() }}
+      {{ supported_syntax_tip() }}
     </div>
   </td>
 </tr>

--- a/src/olympia/devhub/templates/devhub/includes/policy_form.html
+++ b/src/olympia/devhub/templates/devhub/includes/policy_form.html
@@ -1,4 +1,4 @@
-{% from "devhub/includes/macros.html" import tip, some_html_tip %}
+{% from "devhub/includes/macros.html" import tip, markdown_tip %}
 <tr>
   <th>{{ tip(_('End-User License Agreement'),
              _('Please note that a EULA is not '
@@ -13,7 +13,7 @@
         {{ policy_form.eula.label }}
       </label>
       {{ policy_form.eula }}
-      {{ some_html_tip() }}
+      {{ markdown_tip() }}
     </div>
   </td>
 </tr>
@@ -31,7 +31,7 @@
         {{ policy_form.privacy_policy.label }}
       </label>
       {{ policy_form.privacy_policy }}
-      {{ some_html_tip() }}
+      {{ markdown_tip() }}
     </div>
   </td>
 </tr>

--- a/src/olympia/devhub/templates/devhub/includes/policy_form.html
+++ b/src/olympia/devhub/templates/devhub/includes/policy_form.html
@@ -13,7 +13,7 @@
         {{ policy_form.eula.label }}
       </label>
       {{ policy_form.eula }}
-      {{ supported_syntax_tip() }}
+      {{ supported_syntax_tip(allowed_markdown) }}
     </div>
   </td>
 </tr>
@@ -31,7 +31,7 @@
         {{ policy_form.privacy_policy.label }}
       </label>
       {{ policy_form.privacy_policy }}
-      {{ supported_syntax_tip() }}
+      {{ supported_syntax_tip(allowed_markdown) }}
     </div>
   </td>
 </tr>

--- a/src/olympia/devhub/templates/devhub/versions/edit.html
+++ b/src/olympia/devhub/templates/devhub/versions/edit.html
@@ -1,6 +1,6 @@
 {% extends "devhub/base.html" %}
 
-{% from "devhub/includes/macros.html" import tip, some_html_tip, empty_unless, compat %}
+{% from "devhub/includes/macros.html" import tip, supported_syntax_tip, empty_unless, compat %}
 
 {% set title = _('Manage Version {0}')|format_html(version.version) %}
 
@@ -73,7 +73,7 @@
             <td>
               {{ field.errors }}
               {{ field }}
-              {{ some_html_tip() }}
+              {{ supported_syntax_tip(allowed_markdown) }}
             </td>
           {% endwith %}
           </tr>

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -353,14 +353,14 @@ class BaseTestEditDescribe(BaseTestEdit):
         Let's try to put xss in our description, and safe html, and verify
         that we are playing safe.
         """
-        self.addon.description = 'This\n<b>IS</b>' "<script>alert('awesome')</script>"
+        self.addon.description = 'This\n**IS**' "<script>alert('awesome')</script>"
         self.addon.save()
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
 
         assert doc('#addon-description span[lang]').html() == (
-            "This<br/><b>IS</b>&lt;script&gt;alert('awesome')&lt;/script&gt;"
+            "This<br/><strong>IS</strong>&lt;script&gt;alert('awesome')&lt;/script&gt;"
         )
 
         response = self.client.get(self.describe_edit_url)
@@ -368,7 +368,7 @@ class BaseTestEditDescribe(BaseTestEdit):
 
         assert b'<script>' not in response.content
         assert (
-            f'This\n&lt;b&gt;IS&lt;/b&gt;&lt;script&gt;alert({SQUOTE_ESCAPED}awesome'
+            f'This\n**IS**&lt;script&gt;alert({SQUOTE_ESCAPED}awesome'
             f'{SQUOTE_ESCAPED})&lt;/script&gt;</textarea>'
         ) in response.content.decode('utf-8')
 

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -1175,6 +1175,7 @@ def version_edit(request, addon_id, addon, version_id):
             'is_admin': is_admin,
             'choices': File.STATUS_CHOICES,
             'files': (version.file,),
+            'allowed_markdown': PurifiedTranslation.get_allowed_tags(),
         }
     )
 

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -20,7 +20,6 @@ from django.utils.translation import gettext, gettext_lazy as _
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt
 
-from olympia.translations.models import PurifiedTranslation
 import waffle
 from csp.decorators import csp_update
 from django_statsd.clients import statsd
@@ -71,6 +70,7 @@ from olympia.files.utils import parse_addon
 from olympia.reviewers.forms import PublicWhiteboardForm
 from olympia.reviewers.models import Whiteboard
 from olympia.reviewers.utils import ReviewHelper
+from olympia.translations.models import PurifiedTranslation
 from olympia.users.models import (
     DeveloperAgreementRestriction,
     SuppressedEmailVerification,

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -358,7 +358,6 @@ def edit(request, addon_id, addon):
         'previews': previews,
         'header_preview': header_preview,
         'supported_image_types': amo.SUPPORTED_IMAGE_TYPES,
-        'allowed_markdown': PurifiedTranslation.get_allowed_tags(),
     }
 
     return TemplateResponse(request, 'devhub/addons/edit.html', context=data)
@@ -487,7 +486,6 @@ def ownership(request, addon_id, addon):
         'editable_body_class': 'no-edit'
         if not acl.check_addon_ownership(request.user, addon)
         else '',
-        'allowed_markdown': PurifiedTranslation.get_allowed_tags(),
     }
     post_data = request.POST if request.method == 'POST' else None
     # Authors.
@@ -963,6 +961,7 @@ def addons_section(request, addon_id, addon, section, editable=False):
         'whiteboard_form': whiteboard_form,
         'valid_slug': valid_slug,
         'supported_image_types': amo.SUPPORTED_IMAGE_TYPES,
+        'allowed_markdown': PurifiedTranslation.get_allowed_tags(),
     }
 
     return TemplateResponse(

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -20,6 +20,7 @@ from django.utils.translation import gettext, gettext_lazy as _
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt
 
+from olympia.translations.models import PurifiedTranslation
 import waffle
 from csp.decorators import csp_update
 from django_statsd.clients import statsd
@@ -357,6 +358,7 @@ def edit(request, addon_id, addon):
         'previews': previews,
         'header_preview': header_preview,
         'supported_image_types': amo.SUPPORTED_IMAGE_TYPES,
+        'allowed_markdown': PurifiedTranslation.get_allowed_tags(),
     }
 
     return TemplateResponse(request, 'devhub/addons/edit.html', context=data)
@@ -485,6 +487,7 @@ def ownership(request, addon_id, addon):
         'editable_body_class': 'no-edit'
         if not acl.check_addon_ownership(request.user, addon)
         else '',
+        'allowed_markdown': PurifiedTranslation.get_allowed_tags(),
     }
     post_data = request.POST if request.method == 'POST' else None
     # Authors.
@@ -1808,6 +1811,7 @@ def _submit_details(request, addon, version):
         'version': version,
         'sources_provided': latest_version.sources_provided,
         'submit_page': 'version' if version else 'addon',
+        'allowed_markdown': PurifiedTranslation.get_allowed_tags(),
     }
 
     post_data = request.POST if request.method == 'POST' else None

--- a/src/olympia/translations/fields.py
+++ b/src/olympia/translations/fields.py
@@ -196,6 +196,10 @@ class PurifiedField(TranslatedField):
     to = 'translations.PurifiedTranslation'
 
 
+class PurifiedMarkdownField(TranslatedField):
+    to = 'translations.PurifiedMarkdownTranslation'
+
+
 class LinkifiedField(TranslatedField):
     to = 'translations.LinkifiedTranslation'
 

--- a/src/olympia/translations/models.py
+++ b/src/olympia/translations/models.py
@@ -232,9 +232,15 @@ class PurifiedMarkdownTranslation(PurifiedTranslation):
 
     def clean_localized_string(self):
         # bleach user-inputted html
-        cleaned = bleach.clean(self.localized_string, tags=[], attributes={})
+        cleaned = (
+            bleach.clean(self.localized_string, tags=[], attributes={})
+            if self.localized_string
+            else ''
+        )
         # hack; cleaning breaks blockquotes
-        markdown = md.markdown(cleaned.replace('&gt;', '>'), extensions=['abbr'])
+        markdown = md.markdown(
+            cleaned.replace('&gt;', '>'), extensions=['abbr', 'nl2br']
+        )
 
         # Keep only the allowed tags and attributes, strip the rest.
         cleaner = bleach.Cleaner(

--- a/src/olympia/translations/models.py
+++ b/src/olympia/translations/models.py
@@ -238,9 +238,8 @@ class PurifiedMarkdownTranslation(PurifiedTranslation):
             else ''
         )
         # hack; cleaning breaks blockquotes
-        markdown = md.markdown(
-            cleaned.replace('&gt;', '>'), extensions=['abbr', 'nl2br']
-        )
+        text_with_brs = cleaned.replace('&gt;', '>')
+        markdown = md.markdown(text_with_brs, extensions=['abbr', 'fenced_code'])
 
         # Keep only the allowed tags and attributes, strip the rest.
         cleaner = bleach.Cleaner(

--- a/src/olympia/translations/models.py
+++ b/src/olympia/translations/models.py
@@ -234,7 +234,7 @@ class PurifiedMarkdownTranslation(PurifiedTranslation):
         # bleach user-inputted html
         cleaned = bleach.clean(self.localized_string, tags=[], attributes={})
         # hack; cleaning breaks blockquotes
-        markdown = md.markdown(cleaned.replace('&gt;', '>'))
+        markdown = md.markdown(cleaned.replace('&gt;', '>'), extensions=['abbr'])
 
         # Keep only the allowed tags and attributes, strip the rest.
         cleaner = bleach.Cleaner(

--- a/src/olympia/translations/models.py
+++ b/src/olympia/translations/models.py
@@ -239,8 +239,8 @@ class PurifiedMarkdownTranslation(PurifiedTranslation):
         )
         # hack; cleaning breaks blockquotes
         text_with_brs = cleaned.replace('&gt;', '>')
-        # the base syntax of markdown library does not provide abbreviations or fenced code.
-        # see https://python-markdown.github.io/extensions/
+        # the base syntax of markdown library does not provide abbreviations or fenced
+        # code. see https://python-markdown.github.io/extensions/
         markdown = md.markdown(text_with_brs, extensions=['abbr', 'fenced_code'])
 
         # Keep only the allowed tags and attributes, strip the rest.

--- a/src/olympia/translations/models.py
+++ b/src/olympia/translations/models.py
@@ -225,6 +225,10 @@ class PurifiedTranslation(Translation):
 
         return cleaner.clean(str(self.localized_string))
 
+    @classmethod
+    def get_allowed_tags(cls):
+        return ', '.join(cls.allowed_tags)
+
 
 class PurifiedMarkdownTranslation(PurifiedTranslation):
     class Meta:

--- a/src/olympia/translations/models.py
+++ b/src/olympia/translations/models.py
@@ -239,6 +239,8 @@ class PurifiedMarkdownTranslation(PurifiedTranslation):
         )
         # hack; cleaning breaks blockquotes
         text_with_brs = cleaned.replace('&gt;', '>')
+        # the base syntax of markdown library does not provide abbreviations or fenced code.
+        # see https://python-markdown.github.io/extensions/
         markdown = md.markdown(text_with_brs, extensions=['abbr', 'fenced_code'])
 
         # Keep only the allowed tags and attributes, strip the rest.

--- a/src/olympia/translations/tests/test_models.py
+++ b/src/olympia/translations/tests/test_models.py
@@ -712,9 +712,12 @@ class PurifiedMarkdownTranslationTest(TestCase):
         assert x.__html__() == 'This is some text'
 
     def test_markdown(self):
-        s = '__bold text__ or _italics_ <b>not bold</b>'
+        s = '__bold text__ or _italics_<b>not bold</b>'
         x = PurifiedMarkdownTranslation(localized_string=s)
-        assert x.__html__() == '<strong>bold text</strong> or <em>italics</em> &lt;b&gt;not bold&lt;/b&gt;'
+        assert x.__html__() == (
+            '<strong>bold text</strong> or <em>italics</em>'
+            '&lt;b&gt;not bold&lt;/b&gt;'
+        )
 
     def test_html(self):
         s = '<script>some naughty xss</script>'
@@ -748,6 +751,7 @@ class PurifiedMarkdownTranslationTest(TestCase):
         links = doc('a[href="http://external.url"][rel="nofollow"]')
         assert links[0].text == 'http://example.com'
         assert doc('strong')[0].text == 'markup'
+
 
 class LinkifiedTranslationTest(TestCase):
     @patch('olympia.amo.urlresolvers.get_outgoing_url')

--- a/src/olympia/translations/tests/test_models.py
+++ b/src/olympia/translations/tests/test_models.py
@@ -711,7 +711,7 @@ class TestPurifiedMarkdownTranslation(TestCase):
         x = PurifiedMarkdownTranslation(localized_string=s)
         assert x.__html__() == 'This is some text'
 
-    def test_markdown(self):
+    def test_mixed_markdown_html(self):
         s = '__bold text__ or _italics_<b>not bold</b>'
         x = PurifiedMarkdownTranslation(localized_string=s)
         assert x.__html__() == (

--- a/src/olympia/translations/tests/test_models.py
+++ b/src/olympia/translations/tests/test_models.py
@@ -19,6 +19,7 @@ from olympia.translations.hold import translation_saved
 from olympia.translations.models import (
     LinkifiedTranslation,
     NoURLsTranslation,
+    PurifiedMarkdownTranslation,
     PurifiedTranslation,
     Translation,
     TranslationSequence,
@@ -700,6 +701,53 @@ class PurifiedTranslationTest(TestCase):
         assert links[0].text == 'http://example.com'
         assert doc('b')[0].text == 'markup'
 
+
+class PurifiedMarkdownTranslationTest(TestCase):
+    def test_output(self):
+        assert isinstance(PurifiedMarkdownTranslation().__html__(), str)
+
+    def test_raw_text(self):
+        s = '   This is some text   '
+        x = PurifiedMarkdownTranslation(localized_string=s)
+        assert x.__html__() == 'This is some text'
+
+    def test_markdown(self):
+        s = '__bold text__ or _italics_ <b>not bold</b>'
+        x = PurifiedMarkdownTranslation(localized_string=s)
+        assert x.__html__() == '<strong>bold text</strong> or <em>italics</em> &lt;b&gt;not bold&lt;/b&gt;'
+
+    def test_html(self):
+        s = '<script>some naughty xss</script>'
+        x = PurifiedMarkdownTranslation(localized_string=s)
+        assert x.__html__() == '&lt;script&gt;some naughty xss&lt;/script&gt;'
+
+    def test_internal_link(self):
+        s = '**markup** [bar](http://addons.mozilla.org/foo)'
+        x = PurifiedMarkdownTranslation(localized_string=s)
+        doc = pq(x.__html__())
+        links = doc('a[href="http://addons.mozilla.org/foo"][rel="nofollow"]')
+        assert links[0].text == 'bar'
+        assert doc('strong')[0].text == 'markup'
+
+    @patch('olympia.amo.urlresolvers.get_outgoing_url')
+    def test_external_link(self, get_outgoing_url_mock):
+        get_outgoing_url_mock.return_value = 'http://external.url'
+        s = '**markup** [bar](http://example.com)'
+        x = PurifiedMarkdownTranslation(localized_string=s)
+        doc = pq(x.__html__())
+        links = doc('a[href="http://external.url"][rel="nofollow"]')
+        assert links[0].text == 'bar'
+        assert doc('strong')[0].text == 'markup'
+
+    @patch('olympia.amo.urlresolvers.get_outgoing_url')
+    def test_external_text_link(self, get_outgoing_url_mock):
+        get_outgoing_url_mock.return_value = 'http://external.url'
+        s = '**markup** http://example.com'
+        x = PurifiedMarkdownTranslation(localized_string=s)
+        doc = pq(x.__html__())
+        links = doc('a[href="http://external.url"][rel="nofollow"]')
+        assert links[0].text == 'http://example.com'
+        assert doc('strong')[0].text == 'markup'
 
 class LinkifiedTranslationTest(TestCase):
     @patch('olympia.amo.urlresolvers.get_outgoing_url')

--- a/src/olympia/translations/tests/test_models.py
+++ b/src/olympia/translations/tests/test_models.py
@@ -702,7 +702,7 @@ class PurifiedTranslationTest(TestCase):
         assert doc('b')[0].text == 'markup'
 
 
-class PurifiedMarkdownTranslationTest(TestCase):
+class TestPurifiedMarkdownTranslation(TestCase):
     def test_output(self):
         assert isinstance(PurifiedMarkdownTranslation().__html__(), str)
 

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -52,7 +52,7 @@ from olympia.files.models import File, cleanup_file
 from olympia.scanners.models import ScannerResult
 from olympia.translations.fields import (
     LinkifiedField,
-    PurifiedField,
+    PurifiedMarkdownField,
     TranslatedField,
     save_signal,
 )
@@ -315,7 +315,7 @@ class Version(OnChangeMixin, ModelBase):
     license = models.ForeignKey(
         'License', null=True, blank=True, on_delete=models.SET_NULL
     )
-    release_notes = PurifiedField(
+    release_notes = PurifiedMarkdownField(
         db_column='releasenotes', short=False, max_length=3000
     )
     # Note that max_length isn't enforced at the database level for TextFields,

--- a/static/css/zamboni/developers.css
+++ b/static/css/zamboni/developers.css
@@ -147,7 +147,7 @@ form .char-count {
     font-size: 0.9em;
 }
 form .edit-addon-details .char-count,
-form .edit-addon-details .html-support {
+form .edit-addon-details .syntax-support {
     font-size: 1em;
 }
 

--- a/static/css/zamboni/zamboni.css
+++ b/static/css/zamboni/zamboni.css
@@ -3197,18 +3197,18 @@ input.ui-autocomplete-loading {
 }
 /* end l10n */
 
-/** "Some HTML Allowed" text/popup **/
-.html-support {
+/** "Some HTML/Markdown Allowed" text/popup **/
+.syntax-support {
     font-size: .9em;
     color: #003595;
     float: right;
 }
 
-.html-rtl .html-support {
+.html-rtl .syntax-support {
     float: left;
 }
 
-.html-support:hover {
+.syntax-support:hover {
     color: #000;
     cursor: help;
 }


### PR DESCRIPTION
Fixes: mozilla/addons#15145

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Replaces HTML syntax support with Markdown support in the `description`, `developer_comments`, `eula`, and `privacy_policy` fields of `Addon`. Existing HTML in those fields will remain functional until the field is edited. No new HTML will be functional.

Only the markdown-equivalent of [currently allowed HTML attributes](https://github.com/mozilla/addons-server/blob/ffd993045cef73fb7635e4a94ac95e1a3a9073ec/src/olympia/devhub/templates/devhub/includes/macros.html#L6) are allowed. `abbr` uses the [PHP Markdown Extra syntax](https://python-markdown.github.io/extensions/abbreviations/).


#### DevHub:

![image](https://github.com/user-attachments/assets/363bb5f1-2389-447f-80c0-48355b012484)
![image](https://github.com/user-attachments/assets/ec0971a6-3947-423d-a1a5-2995fe667849)
![image](https://github.com/user-attachments/assets/4c519b4d-980a-4753-95c0-e510dd410653)

#### Frontend:

![image](https://github.com/user-attachments/assets/a829c3a6-8da0-4637-b21b-273885724400)
![image](https://github.com/user-attachments/assets/34096916-19f9-46df-9a37-e5f8052dd431)
![image](https://github.com/user-attachments/assets/6c8767cb-b2e3-4da5-b51a-19ed40f77b84)




<!--
Your PR will be squashed when merged so the 1st commit must contain a descriptive and concise summary of the change.
Additional details should be added in the description. If your change is simple enough to summarize in the commit, or
if it is not relevant for your PR, remove this section.
-->

### Testing

**New Add-ons**
1. Create a listed add-on.
2. Under 'submit/details', description should have the tooltip and support markdown.

**Existing Add-ons**
1. Navigate to an add-on that already has HTML in its description. The HTML should still be functional. The HTML is still rendered on the frontend listing.
3. Under the 'edit' page, the description and developer comments should support markdown syntax.*
4. Under the 'Manage Authors & License' page, the EULA and Privacy Policy fields should support markdown syntax.*

\* Any user-inputted HTML saved at this point is rendered as plaintext. Any allowed markdown in the field is rendered as expected in the frontend. Disallowed markdown is stripped from the result and not visible at all (this is to avoid showing the user the markdown formatted into HTML).


<!--
Your change must be related to an existing, open issue. This issue should contain testing instructions.
Often, the testing info in the issue is higher level, geared towards a user or QA experience.
Here you can provide information for a developer verifying this PR. Get technical.
If it is not relevant to your PR, remove this section.
-->

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [x] Add before and after screenshots (Only for changes that impact the UI).
- [x] Add or update relevant [docs](../docs/) reflecting the changes made.
