### PR TITLE
don't set forwarded to legal job as resolvable_in_reviewer_tools

### DIFF
--- a/src/olympia/abuse/actions.py
+++ b/src/olympia/abuse/actions.py
@@ -344,7 +344,9 @@ class ContentActionForwardToLegal(ContentAction):
         job_id = entity_helper.workflow_recreate(notes=self.decision.notes, job=old_job)
 
         if old_job:
-            old_job.handle_job_recreated(new_job_id=job_id)
+            old_job.handle_job_recreated(
+                new_job_id=job_id, resolvable_in_reviewer_tools=False
+            )
         else:
             CinderJob.objects.update_or_create(
                 job_id=job_id,

--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -255,13 +255,13 @@ class CinderJob(ModelBase):
             reporter_abuse_reports=appellants, is_appeal=True
         )
 
-    def handle_job_recreated(self, new_job_id):
+    def handle_job_recreated(self, *, new_job_id, resolvable_in_reviewer_tools):
         from olympia.reviewers.models import NeedsHumanReview
 
         new_job, created = CinderJob.objects.update_or_create(
             job_id=new_job_id,
             defaults={
-                'resolvable_in_reviewer_tools': True,
+                'resolvable_in_reviewer_tools': resolvable_in_reviewer_tools,
                 'target_addon': self.target_addon,
             },
         )

--- a/src/olympia/abuse/tasks.py
+++ b/src/olympia/abuse/tasks.py
@@ -243,4 +243,4 @@ def handle_escalate_action(*, job_pk):
     )
     job_id = entity_helper.workflow_recreate(notes=old_job.decision.notes, job=old_job)
 
-    old_job.handle_job_recreated(new_job_id=job_id)
+    old_job.handle_job_recreated(new_job_id=job_id, resolvable_in_reviewer_tools=True)

--- a/src/olympia/abuse/tests/test_actions.py
+++ b/src/olympia/abuse/tests/test_actions.py
@@ -838,7 +838,7 @@ class TestContentActionAddon(BaseTestContentAction, TestCase):
             'cinder_action': DECISION_ACTIONS.AMO_DISABLE_ADDON,
         }
 
-    def test_forward_to_reviewers_no_job(self):
+    def test_forward_from_reviewers_no_job(self):
         self.decision.update(action=DECISION_ACTIONS.AMO_LEGAL_FORWARD)
         self.decision.cinder_job.update(decision=None)
         action = ContentActionForwardToLegal(self.decision)
@@ -856,7 +856,7 @@ class TestContentActionAddon(BaseTestContentAction, TestCase):
         assert request_body['reasoning'] == self.decision.notes
         assert request_body['queue_slug'] == 'legal-escalations'
 
-    def test_forward_to_reviewers_with_job(self):
+    def test_forward_from_reviewers_with_job(self):
         self.decision.update(action=DECISION_ACTIONS.AMO_LEGAL_FORWARD)
         action = ContentActionForwardToLegal(self.decision)
         responses.add_callback(
@@ -884,6 +884,7 @@ class TestContentActionAddon(BaseTestContentAction, TestCase):
         request_body = json.loads(responses.calls[0].request.body)
         assert request_body['reasoning'] == self.decision.notes
         assert request_body['queue_slug'] == 'legal-escalations'
+        assert not new_cinder_job.resolvable_in_reviewer_tools
 
 
 class TestContentActionCollection(BaseTestContentAction, TestCase):


### PR DESCRIPTION
Fixes: mozilla/addons#15255 and fixes mozilla/addons#15259

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Sets `resolvable_in_reviewer_tools` to False for jobs (re)created when a job/add-on is forwarded to legal in Cinder.

### Context

When `resolvable_in_reviewer_tools` is True we ignore the actions (15255) and also don't clear the NHRs (15259).

### Testing

- forward a job from the reviewer tools and see that the NHR that lead to the add-on being in the review queue is cleared
  - the edge case here is a job that was itself forwarded from Cinder - that should also lose it's NHR
- check the new CinderJob (use django shell to find it) is `resolvable_in_reviewer_tools=False`

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
