### PR TITLE
flag correct versions for a developer appeal

### DIFF
--- a/src/olympia/abuse/tests/test_cinder.py
+++ b/src/olympia/abuse/tests/test_cinder.py
@@ -1230,7 +1230,10 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
         assert addon.current_version.reload().due_date
 
     def test_appeal_specific_version_from_report(self):
-        # version_string is set for reporter appeals on reports that specified a version
+        """For an appeal from a reporter, version_string is set on the CinderClass
+        instance, from AbuseReport.addon_version_string. If version_string is defined,
+        and the version exists, we should flag that version rather than current_version.
+        """
         addon = self._create_dummy_target()
         other_version = version_factory(
             addon=addon,
@@ -1252,7 +1255,9 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
         assert other_version.reload().due_date
 
     def test_appeal_specific_version_from_action(self):
-        # for developer appeals we should use the versions that were affected
+        """For an appeal from a developer, version_string will be None on the
+        CinderClass instance. If version_string is falsely we collect and flag the addon
+        versions from the appealled decision rather the current_version."""
         addon = self._create_dummy_target()
         other_version = version_factory(
             addon=addon,

--- a/src/olympia/abuse/tests/test_cinder.py
+++ b/src/olympia/abuse/tests/test_cinder.py
@@ -136,9 +136,14 @@ class BaseTestCinderCase:
     def test_report(self):
         self._test_report(self._create_dummy_target())
 
-    def _test_appeal(self, appealer, cinder_instance=None):
-        fake_decision_id = 'decision-id-to-appeal-666'
-        cinder_instance = cinder_instance or self.CinderClass(
+    def _test_appeal(
+        self,
+        appealer,
+        *,
+        cinder_entity_instance=None,
+        appealed_decision_id='decision-id-to-appeal-666',
+    ):
+        cinder_entity_instance = cinder_entity_instance or self.CinderClass(
             self._create_dummy_target()
         )
 
@@ -149,8 +154,8 @@ class BaseTestCinderCase:
             status=201,
         )
         assert (
-            cinder_instance.appeal(
-                decision_cinder_id=fake_decision_id,
+            cinder_entity_instance.appeal(
+                decision_cinder_id=appealed_decision_id,
                 appeal_text='reason',
                 appealer=appealer,
             )
@@ -163,8 +168,8 @@ class BaseTestCinderCase:
             status=400,
         )
         with self.assertRaises(ConnectionError):
-            cinder_instance.appeal(
-                decision_cinder_id=fake_decision_id,
+            cinder_entity_instance.appeal(
+                decision_cinder_id=appealed_decision_id,
                 appeal_text='reason',
                 appealer=appealer,
             )
@@ -1204,7 +1209,8 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
     def test_appeal_anonymous(self):
         addon = self._create_dummy_target()
         self._test_appeal(
-            CinderUnauthenticatedReporter('itsme', 'm@r.io'), self.CinderClass(addon)
+            CinderUnauthenticatedReporter('itsme', 'm@r.io'),
+            cinder_entity_instance=self.CinderClass(addon),
         )
         assert (
             addon.current_version.needshumanreview_set.get().reason
@@ -1214,14 +1220,17 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
 
     def test_appeal_logged_in(self):
         addon = self._create_dummy_target()
-        self._test_appeal(CinderUser(user_factory()), self.CinderClass(addon))
+        self._test_appeal(
+            CinderUser(user_factory()), cinder_entity_instance=self.CinderClass(addon)
+        )
         assert (
             addon.current_version.needshumanreview_set.get().reason
             == NeedsHumanReview.REASONS.ADDON_REVIEW_APPEAL
         )
         assert addon.current_version.reload().due_date
 
-    def test_appeal_specific_version(self):
+    def test_appeal_specific_version_from_report(self):
+        # version_string is set for reporter appeals on reports that specified a version
         addon = self._create_dummy_target()
         other_version = version_factory(
             addon=addon,
@@ -1230,7 +1239,36 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
         )
         self._test_appeal(
             CinderUser(user_factory()),
-            self.CinderClass(addon, version_string=other_version.version),
+            cinder_entity_instance=self.CinderClass(
+                addon, version_string=other_version.version
+            ),
+        )
+        assert not addon.current_version.needshumanreview_set.exists()
+        assert (
+            other_version.needshumanreview_set.get().reason
+            == NeedsHumanReview.REASONS.ADDON_REVIEW_APPEAL
+        )
+        assert not addon.current_version.reload().due_date
+        assert other_version.reload().due_date
+
+    def test_appeal_specific_version_from_action(self):
+        # for developer appeals we should use the versions that were affected
+        addon = self._create_dummy_target()
+        other_version = version_factory(
+            addon=addon,
+            channel=amo.CHANNEL_UNLISTED,
+            file_kw={'status': amo.STATUS_AWAITING_REVIEW},
+        )
+        decision = ContentDecision.objects.create(
+            action=DECISION_ACTIONS.AMO_DISABLE_ADDON, cinder_id='some_id', addon=addon
+        )
+        ActivityLog.objects.create(
+            amo.LOG.FORCE_DISABLE, addon, other_version, decision, user=user_factory()
+        )
+        self._test_appeal(
+            CinderUser(user_factory()),
+            cinder_entity_instance=self.CinderClass(addon, version_string=None),
+            appealed_decision_id=decision.cinder_id,
         )
         assert not addon.current_version.needshumanreview_set.exists()
         assert (
@@ -1248,7 +1286,7 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
         assert not addon.current_version
         self._test_appeal(
             CinderUser(user_factory()),
-            self.CinderClass(addon),
+            cinder_entity_instance=self.CinderClass(addon),
         )
         assert (
             version.needshumanreview_set.get().reason
@@ -1263,7 +1301,9 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
         # etc since the waffle switch is off. So we're back to the same number of
         # queries made by the reports that go to Cinder.
         self.expected_queries_for_report = TestCinderAddon.expected_queries_for_report
-        self._test_appeal(CinderUser(user_factory()), self.CinderClass(addon))
+        self._test_appeal(
+            CinderUser(user_factory()), cinder_entity_instance=self.CinderClass(addon)
+        )
         assert addon.current_version.needshumanreview_set.count() == 0
 
     def test_report_with_ongoing_appeal(self):


### PR DESCRIPTION
Fixes: mozilla/addons#15182 and fixes mozilla/addons#15247

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Flag the versions that were affected by a version rejection if the developer appeals.

### Context

Until recently there was no easy way to reference the versions rejected by the ContentDecision, so we could only flag the current version if the developer appealed the rejection. 

### Testing

- enable all the DSA related waffle switches and have a Cinder API key in your settings
- Reject a version of an add-on in the reviewer tools - either an unlisted version or a non-latest version - i.e. a version that wouldn't be the addon's current_version (unlisted is better, because that's the use-case the issue was filed for)
- appeal that decision with the appeal link in the email
- go back to the reviewer tools and see that the appealed version is flagged for NHR

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
