### PR TITLE
Serve django locale bundles from django as a fallback in local dev

### DIFF
--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -7954,3 +7954,17 @@ class TestBrowserMapping(TestCase):
             'extension_id': extension_id_2,
             'addon_guid': addon_2.guid,
         }
+
+
+class TestJavascriptCatalog(TestCase):
+    @pytest.mark.needs_locales_compilation
+    def test_get_correct_catalog(self):
+        url = reverse('javascript-catalog', kwargs={'locale': 'fr'})
+        content = self.client.get(url).content.decode('utf-8')
+        # Check the key is present
+        assert 'There was an error uploading your file.' in content
+        # Check the translation is in the correct locale
+        assert (
+            '"Une erreur est survenue pendant l\\u2019envoi de votre fichier."'
+            in content
+        )

--- a/src/olympia/urls.py
+++ b/src/olympia/urls.py
@@ -2,8 +2,9 @@ from django.conf import settings
 from django.contrib import admin
 from django.shortcuts import redirect
 from django.urls import include, re_path, reverse
-from django.views.static import serve as serve_static
+from django.utils import translation
 from django.views.i18n import JavaScriptCatalog
+from django.views.static import serve as serve_static
 
 from olympia.amo.utils import urlparams
 from olympia.amo.views import frontend_view
@@ -123,6 +124,10 @@ if settings.SERVE_STATIC_FILES:
                 request, path, document_root=settings.STATIC_ROOT, **kwargs
             )
 
+    def serve_javascript_catalog(request, locale, **kwargs):
+        with translation.override(locale):
+            return JavaScriptCatalog.as_view()(request, locale, **kwargs)
+
     # Remove leading and trailing slashes so the regex matches.
     media_url = settings.MEDIA_URL.lstrip('/').rstrip('/')
 
@@ -135,8 +140,8 @@ if settings.SERVE_STATIC_FILES:
             ),
             # Serve javascript catalog locales bundle directly from django
             re_path(
-                r'^static/js/i18n/(?P<path>.*)$',
-                JavaScriptCatalog.as_view(),
+                r'^static/js/i18n/(?P<locale>\w+)\.js$',
+                serve_javascript_catalog,
                 name='javascript-catalog',
             ),
             # fallback for static files that are not available directly over nginx.

--- a/src/olympia/urls.py
+++ b/src/olympia/urls.py
@@ -3,6 +3,7 @@ from django.contrib import admin
 from django.shortcuts import redirect
 from django.urls import include, re_path, reverse
 from django.views.static import serve as serve_static
+from django.views.i18n import JavaScriptCatalog
 
 from olympia.amo.utils import urlparams
 from olympia.amo.views import frontend_view
@@ -131,6 +132,12 @@ if settings.SERVE_STATIC_FILES:
                 r'^%s/(?P<path>.*)$' % media_url,
                 serve_static,
                 {'document_root': settings.MEDIA_ROOT},
+            ),
+            # Serve javascript catalog locales bundle directly from django
+            re_path(
+                r'^static/js/i18n/(?P<path>.*)$',
+                JavaScriptCatalog.as_view(),
+                name='javascript-catalog',
             ),
             # fallback for static files that are not available directly over nginx.
             # Mostly vendor files from python or npm dependencies that are not available


### PR DESCRIPTION
Fixes: mozilla/addons#15272

### Context

We typically serve these files directly from nginx, but in dev mode you may or may not have them defined, so we should serve them from django as a fallback

### Testing

1. create an empty site static dir `mkdir -p ./site-static` (make sure it is empty)
2. run `make up DOCKER_TARGET=development`
3. verify there are no files in nginx `docker compose exec nginx ls /srv/site-static/js/i18n`
4. load dev hub `http://olympia.test/developers` (open the network tab)
5. Verify the `/static/js/i18n/en.js` file loads 200 with the javascript.

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
