### PR TITLE
Add MLBF validation logic and corresponding management command

### DIFF
--- a/src/olympia/blocklist/management/commands/validate_mlbf.py
+++ b/src/olympia/blocklist/management/commands/validate_mlbf.py
@@ -12,9 +12,19 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         """Handle command arguments."""
-        parser.add_argument('storage_id', help='The storage ID of the MLBF', metavar=('ID'))
+        parser.add_argument(
+            'storage_id', help='The storage ID of the MLBF', metavar=('ID')
+        )
+        parser.add_argument(
+            '--fail-fast',
+            action='store_true',
+            help='Fail fast if an error is found',
+            default=False,
+        )
 
     def handle(self, *args, **options):
         storage_id = options['storage_id']
-        mlbf = MLBF.load_from_storage(storage_id)
-        mlbf.validate()
+        fail_fast = options['fail_fast']
+        log.info(f'Validating MLBF {storage_id} with fail_fast={fail_fast}')
+        mlbf = MLBF.load_from_storage(storage_id, error_on_missing=True)
+        mlbf.validate(fail_fast=fail_fast)

--- a/src/olympia/blocklist/management/commands/validate_mlbf.py
+++ b/src/olympia/blocklist/management/commands/validate_mlbf.py
@@ -1,0 +1,28 @@
+import json
+import os
+
+from django.core.management.base import BaseCommand
+from django.conf import settings
+
+import olympia.core.logger
+from olympia.blocklist.mlbf import MLBF
+
+
+log = olympia.core.logger.getLogger('z.amo.blocklist')
+
+
+class Command(BaseCommand):
+    help = 'Validates a given MLBF directory'
+
+    def add_arguments(self, parser):
+        """Handle command arguments."""
+        parser.add_argument('storage_id', help='The storage ID of the MLBF', metavar=('ID'))
+
+    def load_json(self, json_path):
+        with open(json_path, 'r') as json_file:
+            return json.load(json_file)
+
+    def handle(self, *args, **options):
+        storage_id = options['storage_id']
+        mlbf = MLBF.load_from_storage(storage_id)
+        mlbf.validate()

--- a/src/olympia/blocklist/management/commands/validate_mlbf.py
+++ b/src/olympia/blocklist/management/commands/validate_mlbf.py
@@ -8,7 +8,7 @@ log = olympia.core.logger.getLogger('z.amo.blocklist')
 
 
 class Command(BaseCommand):
-    help = 'Validates a given MLBF directory'
+    help = 'Validates a given MLBF does not contain duplicate items'
 
     def add_arguments(self, parser):
         """Handle command arguments."""

--- a/src/olympia/blocklist/management/commands/validate_mlbf.py
+++ b/src/olympia/blocklist/management/commands/validate_mlbf.py
@@ -1,8 +1,4 @@
-import json
-import os
-
 from django.core.management.base import BaseCommand
-from django.conf import settings
 
 import olympia.core.logger
 from olympia.blocklist.mlbf import MLBF
@@ -17,10 +13,6 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         """Handle command arguments."""
         parser.add_argument('storage_id', help='The storage ID of the MLBF', metavar=('ID'))
-
-    def load_json(self, json_path):
-        with open(json_path, 'r') as json_file:
-            return json.load(json_file)
 
     def handle(self, *args, **options):
         storage_id = options['storage_id']

--- a/src/olympia/blocklist/management/commands/validate_mlbf.py
+++ b/src/olympia/blocklist/management/commands/validate_mlbf.py
@@ -15,16 +15,9 @@ class Command(BaseCommand):
         parser.add_argument(
             'storage_id', help='The storage ID of the MLBF', metavar=('ID')
         )
-        parser.add_argument(
-            '--fail-fast',
-            action='store_true',
-            help='Fail fast if an error is found',
-            default=False,
-        )
 
     def handle(self, *args, **options):
         storage_id = options['storage_id']
-        fail_fast = options['fail_fast']
-        log.info(f'Validating MLBF {storage_id} with fail_fast={fail_fast}')
+        log.info(f'Validating MLBF {storage_id}')
         mlbf = MLBF.load_from_storage(storage_id, error_on_missing=True)
-        mlbf.validate(fail_fast=fail_fast)
+        mlbf.validate()

--- a/src/olympia/blocklist/mlbf.py
+++ b/src/olympia/blocklist/mlbf.py
@@ -384,15 +384,8 @@ class MLBF:
             > 0
         )
 
-    def validate(self, fail_fast: bool = False):
-        errors = []
+    def validate(self):
         store: Dict[str, Dict[MLBFDataType, int]] = {}
-
-        def add_error(error: str):
-            if fail_fast:
-                raise ValueError(error)
-            log.error(error)
-            errors.append(error)
 
         # Create a map of each guid:version string in the cache.json
         # and the set of data types that contain it and the count of
@@ -412,19 +405,16 @@ class MLBF:
             # We expect each item to only occur in one data type
             if len(data_types) > 1:
                 formatted_data_types = ', '.join(key.name for key in data_types.keys())
-                add_error(
+                raise ValueError(
                     f'Item {item} found in multiple data types: '
                     f'{formatted_data_types}'
                 )
             # We expect each item to occur only one time in a given data type
             for dtype, count in data_types.items():
                 if count > 1:
-                    add_error(
+                    raise ValueError(
                         f'Item {item} found {count} times in data type ' f'{dtype.name}'
                     )
-
-        if errors:
-            raise ValueError(f'Invalid cache.json: {errors}')
 
     @classmethod
     def load_from_storage(

--- a/src/olympia/blocklist/mlbf.py
+++ b/src/olympia/blocklist/mlbf.py
@@ -1,6 +1,7 @@
 import json
 import os
 import secrets
+from collections import defaultdict
 from enum import Enum
 from typing import Dict, List, Optional, Tuple
 
@@ -399,20 +400,14 @@ class MLBF:
         )
 
     def validate(self):
-        store: Dict[str, Dict[MLBFDataType, int]] = {}
+        store = defaultdict(lambda: defaultdict(int))
 
         # Create a map of each guid:version string in the cache.json
         # and the set of data types that contain it and the count of
         # how many times it occurs in each data type.
         for key in MLBFDataType:
             for item in self.data[key]:
-                if item in store:
-                    if key in store[item]:
-                        store[item][key] = store[item][key] + 1
-                    else:
-                        store[item][key] = 1
-                else:
-                    store[item] = {key: 1}
+                store[item][key] += 1
 
         # Verify that each item occurs only one time and in only one data type
         for item, data_types in store.items():
@@ -420,8 +415,7 @@ class MLBF:
             if len(data_types) > 1:
                 formatted_data_types = ', '.join(key.name for key in data_types.keys())
                 raise ValueError(
-                    f'Item {item} found in multiple data types: '
-                    f'{formatted_data_types}'
+                    f'Item {item} found in multiple data types: {formatted_data_types}'
                 )
             # We expect each item to occur only one time in a given data type
             for dtype, count in data_types.items():

--- a/src/olympia/blocklist/mlbf.py
+++ b/src/olympia/blocklist/mlbf.py
@@ -2,7 +2,7 @@ import json
 import os
 import secrets
 from enum import Enum
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 from django.utils.functional import cached_property
 
@@ -383,6 +383,35 @@ class MLBF:
             )
             > 0
         )
+
+    def validate(self):
+        errors = []
+        store: Dict[str, Dict[MLBFDataType, int]] = {}
+
+        # Create a map of each guid:version string in the cache.json
+        # and the set of data types that contain it and the count of
+        # how many times it occurs in each data type.
+        for key in MLBFDataType:
+            for item in self.data[key]:
+                if item in store:
+                    if key in store[item]:
+                        store[item][key] = store[item][key] + 1
+                    else:
+                        store[item][key] = 1
+                else:
+                    store[item] = {key: 1}
+
+        # Verify that each item occurs only one time and in only one data type
+        for item, data_types in store.items():
+            # We expect each item to only occur in one data type
+            if len(data_types) > 1:
+                errors.append(f'Item {item} found in multiple data types: {data_types}')
+            # We expect each item to occur only one time in a given data type
+            if data_types[0] != 1:
+                errors.append(f'Item {item} found in multiple data types: {data_types}')
+
+        if errors:
+            raise ValueError(f'Invalid cache.json: {errors}')
 
     @classmethod
     def load_from_storage(

--- a/src/olympia/blocklist/mlbf.py
+++ b/src/olympia/blocklist/mlbf.py
@@ -77,7 +77,7 @@ def generate_mlbf(stats, include, exclude):
 # Extends the BlockType enum to include versions that have no block of any type
 MLBFDataType = Enum(
     'MLBFDataType',
-    [block_type.name for block_type in BlockType] + ['NOT_BLOCKED', 'not_blocked'],
+    [block_type.name for block_type in BlockType] + ['NOT_BLOCKED'],
     start=0,
 )
 

--- a/src/olympia/blocklist/tests/test_mlbf.py
+++ b/src/olympia/blocklist/tests/test_mlbf.py
@@ -1121,10 +1121,17 @@ class TestMLBF(_MLBFBase):
         then the cache.json fails validation.
         """
         mlbf = MLBF.generate_from_db('test')
-        mlbf.data[MLBFDataType.BLOCKED] = [
-            'guid:version',
-            'guid:version',
-        ]
+
+        with open(mlbf.data._cache_path, 'w') as f:
+            json.dump({
+                'blocked': ['guid:version', 'guid:version'],
+                'soft_blocked': [],
+                'not_blocked': [],
+            }, f)
+
+        # Reload the mlbf with the faked cache.json
+        mlbf = MLBF.load_from_storage(mlbf.created_at)
+
         with self.assertRaises(ValueError):
             mlbf.validate()
 
@@ -1133,7 +1140,16 @@ class TestMLBF(_MLBFBase):
         Test that if an item is found in multiple data types, it is not valid
         """
         mlbf = MLBF.generate_from_db('test')
-        mlbf.data[MLBFDataType.BLOCKED] = ['guid:version']
-        mlbf.data[MLBFDataType.SOFT_BLOCKED] = ['guid:version']
+
+        with open(mlbf.data._cache_path, 'w') as f:
+            json.dump({
+                'blocked': ['guid:version'],
+                'soft_blocked': ['guid:version'],
+                'not_blocked': [],
+            }, f)
+
+        # Reload the mlbf with the faked cache.json
+        mlbf = MLBF.load_from_storage(mlbf.created_at)
+
         with self.assertRaises(ValueError):
             mlbf.validate()

--- a/src/olympia/blocklist/tests/test_mlbf.py
+++ b/src/olympia/blocklist/tests/test_mlbf.py
@@ -1163,26 +1163,3 @@ class TestMLBF(_MLBFBase):
             'Item guid:version found in multiple data types: '
             f'{MLBFDataType.BLOCKED.name}, {MLBFDataType.SOFT_BLOCKED.name}'
         ) in str(e.exception)
-
-    def test_validate_multiple_errors_fail_fast(self):
-        mlbf = MLBF.generate_from_db('test')
-        with open(mlbf.data._cache_path, 'w') as f:
-            json.dump(
-                {
-                    'blocked': ['guid:version', 'guid:version'],
-                    'soft_blocked': ['guid:version'],
-                    'not_blocked': [],
-                },
-                f,
-            )
-        mlbf = MLBF.load_from_storage(mlbf.created_at, error_on_missing=True)
-
-        with self.assertRaises(ValueError) as e:
-            mlbf.validate(fail_fast=True)
-
-        # We check for existence in multiple data types before we check for
-        # duplicate items within a single data type.
-        assert (
-            'Item guid:version found in multiple data types: '
-            f'{MLBFDataType.BLOCKED.name}, {MLBFDataType.SOFT_BLOCKED.name}'
-        ) in str(e.exception)

--- a/src/olympia/blocklist/tests/test_mlbf.py
+++ b/src/olympia/blocklist/tests/test_mlbf.py
@@ -69,7 +69,6 @@ class TestOrderedDiffLists(TestCase):
             size,
         )
 
-
 class TestBaseMLBFLoader(_MLBFBase):
     class TestStaticLoader(BaseMLBFLoader):
         @cached_property
@@ -137,6 +136,13 @@ class TestBaseMLBFLoader(_MLBFBase):
         loader.blocked_items = []
         assert loader[MLBFDataType.BLOCKED] == []
 
+    def test_contains_only_valid_keys(self):
+        loader = self.TestStaticLoader(self.storage)
+
+        loader_keys = list(loader._raw.keys())
+        data_type_keys = [BaseMLBFLoader.data_type_key(key) for key in MLBFDataType]
+
+        assert sorted(loader_keys) == sorted(data_type_keys)
 
 class TestMLBFStorageLoader(_MLBFBase):
     def setUp(self):

--- a/src/olympia/blocklist/tests/test_mlbf.py
+++ b/src/olympia/blocklist/tests/test_mlbf.py
@@ -1114,3 +1114,26 @@ class TestMLBF(_MLBFBase):
             == 0
         )
         assert mlbf.data.blocked_items == []
+
+    def test_validate_duplicate_item_in_single_data_type(self):
+        """
+        Test that if an item is found more than once in a single data type
+        then the cache.json fails validation.
+        """
+        mlbf = MLBF.generate_from_db('test')
+        mlbf.data[MLBFDataType.BLOCKED] = [
+            'guid:version',
+            'guid:version',
+        ]
+        with self.assertRaises(ValueError):
+            mlbf.validate()
+
+    def test_validate_duplicate_item_in_multiple_data_types(self):
+        """
+        Test that if an item is found in multiple data types, it is not valid
+        """
+        mlbf = MLBF.generate_from_db('test')
+        mlbf.data[MLBFDataType.BLOCKED] = ['guid:version']
+        mlbf.data[MLBFDataType.SOFT_BLOCKED] = ['guid:version']
+        with self.assertRaises(ValueError):
+            mlbf.validate()


### PR DESCRIPTION
Fixes: mozilla/addons#15281

### Description

- Implemented a `validate` method in the `MLBF` class to check for duplicate items in the cache.json, ensuring each item occurs only once and in a single data type.
- Added a new management command `validate_mlbf` to facilitate validation of MLBF directories from the command line.
- Created unit tests to verify the validation logic, ensuring it raises errors for duplicate items within a single data type and across multiple data types.

### Context

We have discovered that MLBFs created since November 2024 are larger than expected. This validation is one step to ensure we do not see unchecked growth in the mlbf by verifying the underlying data set used to produce the filter.

### Testing

- Download the cache.json from the (privately) linked g-drive URL
- move the `mlbf` directory into your "storage" directory in the repository
- Run the below command to validate the data

```bash
./manage.py validate_mlbf.py <id>
```

Where `id` is the timestamp directory name `./mlbf/<id>/`.

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
