### PR TITLE
Rename docker.md in comment in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ##### Important information for maintaining this Dockerfile ########################################
-# Read the docs/topics/development/docker.md file for more information about this Dockerfile.
+# Read docs/topics/development/building_and_running_services.md for more info about this Dockerfile.
 ####################################################################################################
 
 FROM python:3.12-slim-bookworm AS olympia


### PR DESCRIPTION
Dockerfile mentions docker.md that was introduced by https://github.com/mozilla/addons-server/pull/21914

docker.md was however removed by https://github.com/mozilla/addons-server/pull/22313

This patch updates the docker.md reference to its new location and rephrases the existing sentence to stay within 100 characters.

As this is a comment-only fix, I have not filed an issue in the mozilla/addons/ repo associated with it.