### PR TITLE
Redirect incoming URLs with short languages to the long-language variant

### DIFF
--- a/src/olympia/amo/tests/test_url_prefix.py
+++ b/src/olympia/amo/tests/test_url_prefix.py
@@ -38,6 +38,11 @@ class MiddlewareTest(TestCase):
             '/es-PE/firefox/addon/1': '/es/firefox/addon/1',
             # /developers doesn't get an app.
             '/developers': '/en-US/developers',
+            # Shorter locales redirects to long form
+            '/pt/developers': '/pt-PT/developers',
+            '/pt/firefox': '/pt-PT/firefox/',
+            '/pt/firefox/addon/1': '/pt-PT/firefox/addon/1',
+            '/pt/addon/1': '/pt-PT/firefox/addon/1',
             # Check basic use-cases with a 'lang' GET parameter:
             '/?lang=fr': '/fr/firefox/',
             '/addon/1/?lang=fr': '/fr/firefox/addon/1/',

--- a/src/olympia/amo/urlresolvers.py
+++ b/src/olympia/amo/urlresolvers.py
@@ -36,8 +36,15 @@ class Prefixer:
         first_lower = first.lower()
         lang, dash, territory = first_lower.partition('-')
 
-        # Check language-territory first.
-        if first_lower in settings.LANGUAGE_URL_MAP:
+        # First test shorter languages shortcuts.
+        if not dash and first in settings.SHORTER_LANGUAGES:
+            first = settings.SHORTER_LANGUAGES[first]
+            if second in amo.APPS:
+                return first, second, rest
+            else:
+                return first, '', first_rest
+        # Then check language-territory.
+        elif first_lower in settings.LANGUAGE_URL_MAP:
             if second in amo.APPS:
                 return first, second, rest
             else:

--- a/src/olympia/amo/urlresolvers.py
+++ b/src/olympia/amo/urlresolvers.py
@@ -38,11 +38,11 @@ class Prefixer:
 
         # First test shorter languages shortcuts.
         if not dash and first in settings.SHORTER_LANGUAGES:
-            first = settings.SHORTER_LANGUAGES[first]
+            first_short = settings.SHORTER_LANGUAGES[first]
             if second in amo.APPS:
-                return first, second, rest
+                return first_short, second, rest
             else:
-                return first, '', first_rest
+                return first_short, '', first_rest
         # Then check language-territory.
         elif first_lower in settings.LANGUAGE_URL_MAP:
             if second in amo.APPS:


### PR DESCRIPTION
Pre-requisite for https://github.com/mozilla/addons/issues/15232

### Context

That was previously only done for Accept-Language HTTP header in addons-server, not in URLs, despite being supported on addons-frontend.

### Testing

See unit test, you can try those URLs/redirects locally too.