### PR TITLE
Make reviewer pending rejection input a datetime widget and allow changing it through an action

### DIFF
--- a/src/olympia/abuse/actions.py
+++ b/src/olympia/abuse/actions.py
@@ -447,6 +447,14 @@ class ContentActionForwardToLegal(ContentAction):
         return self.log_action(amo.LOG.REQUEST_LEGAL)
 
 
+class ContentActionChangePendingRejectionDate(ContentAction):
+    description = 'Add-on pending rejection date has changed'
+    valid_targets = (Addon,)
+
+    def get_owners(self):
+        return self.target.authors.all()
+
+
 class ContentActionDeleteCollection(ContentAction):
     valid_targets = (Collection,)
     description = 'Collection has been deleted'

--- a/src/olympia/abuse/actions.py
+++ b/src/olympia/abuse/actions.py
@@ -383,9 +383,15 @@ class ContentActionRejectVersionDelayed(ContentActionRejectVersion):
 
     def __init__(self, decision):
         super().__init__(decision)
-        self.delayed_rejection_date = datetime.fromisoformat(
-            self.decision.metadata.get('delayed_rejection_date')
-        )
+        if 'delayed_rejection_date' in self.decision.metadata:
+            self.delayed_rejection_date = datetime.fromisoformat(
+                self.decision.metadata.get('delayed_rejection_date')
+            )
+        else:
+            # Will fail later if we try to use it to log/process the action,
+            # but allows us to at least instantiate the class and use other
+            # methods.
+            self.delayed_rejection_date = None
 
     def log_action(self, activity_log_action, *extra_args, extra_details=None):
         extra_details = {

--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -31,6 +31,7 @@ from .actions import (
     ContentActionApproveInitialDecision,
     ContentActionApproveNoAction,
     ContentActionBanUser,
+    ContentActionChangePendingRejectionDate,
     ContentActionDeleteCollection,
     ContentActionDeleteRating,
     ContentActionDisableAddon,
@@ -1070,6 +1071,9 @@ class ContentDecision(ModelBase):
             DECISION_ACTIONS.AMO_IGNORE: ContentActionIgnore,
             DECISION_ACTIONS.AMO_CLOSED_NO_ACTION: ContentActionAlreadyRemoved,
             DECISION_ACTIONS.AMO_LEGAL_FORWARD: ContentActionForwardToLegal,
+            DECISION_ACTIONS.AMO_CHANGE_PENDING_REJECTION_DATE: (
+                ContentActionChangePendingRejectionDate
+            ),
         }.get(decision_action, ContentActionNotImplemented)
 
     def get_action_helper(self):
@@ -1314,6 +1318,7 @@ class ContentDecision(ModelBase):
             extra_context = {
                 'auto_approval': is_auto_approval,
                 'delayed_rejection_days': details.get('delayed_rejection_days'),
+                'details': details,
                 'is_addon_being_blocked': details.get('is_addon_being_blocked'),
                 'is_addon_disabled': details.get('is_addon_being_disabled')
                 or getattr(self.target, 'is_disabled', False),

--- a/src/olympia/abuse/templates/abuse/emails/ContentActionChangePendingRejectionDate.txt
+++ b/src/olympia/abuse/templates/abuse/emails/ContentActionChangePendingRejectionDate.txt
@@ -1,0 +1,6 @@
+{% extends "abuse/emails/base.txt" %}{% block content %}
+
+As you are aware, your {{ type }} {{ name }} was manually reviewed by the Mozilla Add-ons team, at which point we found a violation of one or more Mozilla add-on policies.
+
+Our previous correspondence indicated that you would be required to correct the violation(s) by {{ details.old_deadline }}. However, after further assessing the circumstances - including the violation itself, the risks it presents, and the steps required to resolve it - we have determined that an alternative timeline is appropriate. Based on that determination, we have updated the deadline, and will now require you to correct your add-on violations no later than {{ details.new_deadline }}.
+{% endblock %}

--- a/src/olympia/abuse/tests/test_actions.py
+++ b/src/olympia/abuse/tests/test_actions.py
@@ -782,12 +782,11 @@ class TestContentActionAddon(BaseTestContentAction, TestCase):
         self._test_reporter_appeal_takedown_email(subject)
 
     def _test_reject_version_delayed(self, *, content_review):
+        in_the_future = datetime.now() + timedelta(days=14, hours=1)
         self.decision.update(
             action=DECISION_ACTIONS.AMO_REJECT_VERSION_WARNING_ADDON,
             metadata={
-                'delayed_rejection_date': (
-                    datetime.now() + timedelta(days=14, minutes=1)
-                ).isoformat(),
+                'delayed_rejection_date': in_the_future.isoformat(),
                 'content_review': content_review,
             },
         )
@@ -809,9 +808,7 @@ class TestContentActionAddon(BaseTestContentAction, TestCase):
         assert self.addon.reload().status == amo.STATUS_APPROVED
         assert self.version.file.status == amo.STATUS_APPROVED
         version_flags = VersionReviewerFlags.objects.filter(version=self.version).get()
-        self.assertCloseToNow(
-            version_flags.pending_rejection, now=datetime.now() + timedelta(14)
-        )
+        self.assertCloseToNow(version_flags.pending_rejection, now=in_the_future)
         assert version_flags.pending_rejection_by == reviewer
         assert version_flags.pending_content_rejection == content_review
         assert ActivityLog.objects.count() == 1

--- a/src/olympia/abuse/tests/test_actions.py
+++ b/src/olympia/abuse/tests/test_actions.py
@@ -784,7 +784,12 @@ class TestContentActionAddon(BaseTestContentAction, TestCase):
     def _test_reject_version_delayed(self, *, content_review):
         self.decision.update(
             action=DECISION_ACTIONS.AMO_REJECT_VERSION_WARNING_ADDON,
-            metadata={'delayed_rejection_days': 14, 'content_review': content_review},
+            metadata={
+                'delayed_rejection_date': (
+                    datetime.now() + timedelta(days=14, minutes=1)
+                ).isoformat(),
+                'content_review': content_review,
+            },
         )
         action = ContentActionRejectVersionDelayed(self.decision)
         # process_action is only available for reviewer tools decisions.

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -2835,7 +2835,11 @@ class TestContentDecision(TestCase):
             action=DECISION_ACTIONS.AMO_REJECT_VERSION_WARNING_ADDON,
             notes='some review text',
             reviewer_user=self.reviewer_user,
-            metadata={'delayed_rejection_days': 14},
+            metadata={
+                'delayed_rejection_date': (
+                    datetime.now() + timedelta(days=14, minutes=1)
+                ).isoformat()
+            },
         )
         decision.target_versions.set([addon.current_version])
         NeedsHumanReview.objects.create(
@@ -2870,7 +2874,11 @@ class TestContentDecision(TestCase):
             action=DECISION_ACTIONS.AMO_REJECT_VERSION_WARNING_ADDON,
             notes='some review text',
             reviewer_user=self.reviewer_user,
-            metadata={'delayed_rejection_days': 14},
+            metadata={
+                'delayed_rejection_date': (
+                    datetime.now() + timedelta(days=14, minutes=1)
+                ).isoformat()
+            },
         )
         decision.target_versions.set([version])
         assert decision.action_date is None

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -2887,7 +2887,7 @@ class TestContentDecision(TestCase):
         decision.execute_action(release_hold=True)
         self._test_execute_action_reject_version_delayed_outcome(decision)
 
-    def test_execute_action_change_pending_rejection_date(self):
+    def test_send_notifications_change_pending_rejection_date(self):
         addon = addon_factory(users=[user_factory(email='author@example.com')])
         old_pending_rejection = self.days_ago(1)
         new_pending_rejection = datetime.now() + timedelta(days=1)
@@ -2913,7 +2913,7 @@ class TestContentDecision(TestCase):
             },
             user=user_factory(),
         )
-        decision.execute_action_and_notify()
+        decision.send_notifications()
         assert (
             'previous correspondence indicated that you would be required '
             f'to correct the violation(s) by {old_pending_rejection}'

--- a/src/olympia/constants/abuse.py
+++ b/src/olympia/constants/abuse.py
@@ -23,6 +23,9 @@ DECISION_ACTIONS = APIChoicesWithDash(
     ('AMO_IGNORE', 11, 'Invalid report, so ignored'),
     ('AMO_CLOSED_NO_ACTION', 12, 'Content already removed (no action)'),
     ('AMO_LEGAL_FORWARD', 13, 'Forward add-on to legal'),
+    # Changing pending rejection date is not an available action for moderators
+    # in cinder - it is only performed by AMO Reviewers.
+    ('AMO_CHANGE_PENDING_REJECTION_DATE', 14, 'Pending rejection date changed'),
 )
 DECISION_ACTIONS.add_subset(
     'APPEALABLE_BY_AUTHOR',
@@ -51,7 +54,13 @@ DECISION_ACTIONS.add_subset(
     'NON_OFFENDING', ('AMO_APPROVE', 'AMO_APPROVE_VERSION', 'AMO_IGNORE')
 )
 DECISION_ACTIONS.add_subset(
-    'SKIP_DECISION', ('AMO_APPROVE', 'AMO_APPROVE_VERSION', 'AMO_LEGAL_FORWARD')
+    'SKIP_DECISION',
+    (
+        'AMO_APPROVE',
+        'AMO_APPROVE_VERSION',
+        'AMO_LEGAL_FORWARD',
+        'AMO_CHANGE_PENDING_REJECTION_DATE',
+    ),
 )
 
 # Illegal categories, only used when the reason is `illegal`. The constants
@@ -115,12 +124,12 @@ ILLEGAL_SUBCATEGORIES = APIChoicesWithNone(
     (
         'HIDDEN_ADVERTISEMENT',
         4,
-        'Hidden advertisement or commercial communication, including by ' 'influencers',
+        'Hidden advertisement or commercial communication, including by influencers',
     ),
     (
         'MISLEADING_INFO_GOODS_SERVICES',
         5,
-        'Misleading information about the characteristics of the goods and ' 'services',
+        'Misleading information about the characteristics of the goods and services',
     ),
     (
         'MISLEADING_INFO_CONSUMER_RIGHTS',

--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -1163,6 +1163,16 @@ class HELD_ACTION_REJECT_CONTENT_DELAYED(_LOG):
     admin_event = True
 
 
+class CHANGE_PENDING_REJECTION(_LOG):
+    id = 203
+    format = _('{addon} {version} pending rejection changed.')
+    short = _('Pending rejection changed')
+    keep = True
+    review_queue = True
+    reviewer_review_action = True
+    # Not hidden to developers.
+
+
 LOGS = [x for x in vars().values() if isclass(x) and issubclass(x, _LOG) and x != _LOG]
 # Make sure there's no duplicate IDs.
 assert len(LOGS) == len({log.id for log in LOGS})

--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -1170,6 +1170,7 @@ class CHANGE_PENDING_REJECTION(_LOG):
     keep = True
     review_queue = True
     reviewer_review_action = True
+    cinder_action = DECISION_ACTIONS.AMO_CHANGE_PENDING_REJECTION_DATE
     # Not hidden to developers.
 
 

--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -327,8 +327,9 @@ def validate_review_attachment(value):
             valid_extensions_string = '(%s)' % ', '.join(VALID_ATTACHMENT_EXTENSIONS)
             raise forms.ValidationError(
                 gettext(
-                    'Unsupported file type, please upload a '
-                    'file {extensions}.'.format(extensions=valid_extensions_string)
+                    'Unsupported file type, please upload a file {extensions}.'.format(
+                        extensions=valid_extensions_string
+                    )
                 )
             )
         if value.size >= settings.MAX_UPLOAD_SIZE:
@@ -522,6 +523,10 @@ class ReviewForm(forms.Form):
                     'delayed_rejection_date',
                     forms.ValidationError('This field is required.'),
                 )
+
+            # FIXME: if they chose to change a pending rejection date we need
+            # to check all versions had the same one or raise an error.
+            # FIXME: and versions is required in that case
 
         return self.cleaned_data
 

--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -516,10 +516,12 @@ class ReviewForm(forms.Form):
                 )
 
         if self.helper.actions.get(selected_action, {}).get('delayable'):
+            # Extra required checks are added here because the NullBooleanField
+            # otherwise accepts missing data as `None`.
             if 'delayed_rejection' not in self.data:
                 self.add_error(
                     'delayed_rejection',
-                    forms.ValidationError('This field is required.'),
+                    self.fields['delayed_rejection'].error_messages['required'],
                 )
             elif self.cleaned_data.get('delayed_rejection') and not self.data.get(
                 'delayed_rejection_date'
@@ -528,7 +530,7 @@ class ReviewForm(forms.Form):
                 # somehow cleared the date widget, raise an error.
                 self.add_error(
                     'delayed_rejection_date',
-                    forms.ValidationError('This field is required.'),
+                    self.fields['delayed_rejection'].error_messages['required'],
                 )
             elif (
                 selected_action == 'change_pending_rejection_multiple_versions'

--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -174,7 +174,7 @@ class VersionsChoiceWidget(forms.SelectMultiple):
                 # fine though.
                 actions.remove('unreject_multiple_versions')
             if obj.pending_rejection:
-                actions.append('change_pending_rejection_multiple_versions')
+                actions.append('change_or_clear_pending_rejection_multiple_versions')
             if needs_human_review:
                 actions.append('clear_needs_human_review_multiple_versions')
             # Setting needs human review is available if the version is not
@@ -353,7 +353,7 @@ class DelayedRejectionWidget(forms.RadioSelect):
                 option['attrs']['data-value'] = 'reject_multiple_versions'
             else:  # Empty value is reserved for clearing pending rejection.
                 option['attrs']['data-value'] = (
-                    'change_pending_rejection_multiple_versions'
+                    'change_or_clear_pending_rejection_multiple_versions'
                 )
         return option
 
@@ -533,7 +533,7 @@ class ReviewForm(forms.Form):
                     self.fields['delayed_rejection'].error_messages['required'],
                 )
             elif (
-                selected_action == 'change_pending_rejection_multiple_versions'
+                selected_action == 'change_or_clear_pending_rejection_multiple_versions'
                 and delayed_rejection
                 and delayed_rejection_date
                 and self.cleaned_data.get('versions')

--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -361,6 +361,7 @@ class DelayedRejectionWidget(forms.RadioSelect):
 class DelayedRejectionDateWidget(forms.DateTimeInput):
     input_type = 'datetime-local'
 
+    # Force the format to prevent seconds from showing up.
     def __init__(self, attrs=None, format='%Y-%m-%dT%H:%M'):
         super().__init__(attrs, format)
 
@@ -538,7 +539,6 @@ class ReviewForm(forms.Form):
 
     def clean_delayed_rejection_date(self):
         if self.cleaned_data.get('delayed_rejection_date'):
-            now = datetime.now()
             if self.cleaned_data['delayed_rejection_date'] < self.min_rejection_date:
                 raise ValidationError(
                     'Delayed rejection date should be at least one day in the future'

--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -516,6 +516,8 @@ class ReviewForm(forms.Form):
                 )
 
         if self.helper.actions.get(selected_action, {}).get('delayable'):
+            delayed_rejection = self.cleaned_data.get('delayed_rejection')
+            delayed_rejection_date = self.cleaned_data.get('delayed_rejection_date')
             # Extra required checks are added here because the NullBooleanField
             # otherwise accepts missing data as `None`.
             if 'delayed_rejection' not in self.data:
@@ -523,9 +525,7 @@ class ReviewForm(forms.Form):
                     'delayed_rejection',
                     self.fields['delayed_rejection'].error_messages['required'],
                 )
-            elif self.cleaned_data.get('delayed_rejection') and not self.data.get(
-                'delayed_rejection_date'
-            ):
+            elif delayed_rejection and not self.data.get('delayed_rejection_date'):
                 # In case reviewer selected delayed rejection option and
                 # somehow cleared the date widget, raise an error.
                 self.add_error(
@@ -534,8 +534,8 @@ class ReviewForm(forms.Form):
                 )
             elif (
                 selected_action == 'change_pending_rejection_multiple_versions'
-                and self.cleaned_data.get('delayed_rejection')
-                and self.cleaned_data.get('delayed_rejection_date')
+                and delayed_rejection
+                and delayed_rejection_date
                 and self.cleaned_data.get('versions')
             ):
                 distinct_pending_rejection_dates = (

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -250,15 +250,11 @@
            data-value="{{ actions_delayable|join(' ') }}">
         <div class="review-delayed-rejection-inner">
           {{ form.delayed_rejection }}
-          {{ form.delayed_rejection.errors }}
-
           <div class="review-delayed-rejection-deadline">
-            {{ form.delayed_rejection_days }}
-            <label for="{{ form.delayed_rejection_days.auto_id }}">
-              {{ form.delayed_rejection_days.label }}
-            </label>
-            {{ form.delayed_rejection_days.errors }}
+            {{ form.delayed_rejection_date }}
+            {{ form.delayed_rejection_date.errors }}
           </div>
+          {{ form.delayed_rejection.errors }}
         </div>
       </div>
       {% if switch_is_active('enable-activity-log-attachments') %}

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -246,17 +246,19 @@
         {{ form.operating_systems.errors }}
         {{ form.applications.errors }}
       </div>
-      <div class="review-actions-section data-toggle review-delayed-rejection"
-           data-value="{{ actions_delayable|join(' ') }}">
-        <div class="review-delayed-rejection-inner">
-          {{ form.delayed_rejection }}
-          <div class="review-delayed-rejection-deadline">
-            {{ form.delayed_rejection_date }}
-            {{ form.delayed_rejection_date.errors }}
+      {% if form.delayed_rejection and form.delayed_rejection_date %}
+        <div class="review-actions-section data-toggle review-delayed-rejection"
+             data-value="{{ actions_delayable|join(' ') }}">
+          <div class="review-delayed-rejection-inner">
+            {{ form.delayed_rejection }}
+            <div class="review-delayed-rejection-deadline">
+              {{ form.delayed_rejection_date }} UTC
+              {{ form.delayed_rejection_date.errors }}
+            </div>
+            {{ form.delayed_rejection.errors }}
           </div>
-          {{ form.delayed_rejection.errors }}
         </div>
-      </div>
+      {% endif %}
       {% if switch_is_active('enable-activity-log-attachments') %}
         <div class="review-actions-section data-toggle review-actions-attachment-reply"
         data-value="{{ actions_attachments|join(' ') }}"

--- a/src/olympia/reviewers/tests/test_forms.py
+++ b/src/olympia/reviewers/tests/test_forms.py
@@ -1092,9 +1092,7 @@ class TestReviewForm(TestCase):
         }
         form = self.get_form(data=data)
         assert not form.is_valid()
-        assert form.errors['delayed_rejection'] == [
-            'This field is required.'
-        ]
+        assert form.errors['delayed_rejection'] == ['This field is required.']
 
         # 'False' or '' works, we just want to ensure the field was submitted.
         form = self.get_form(data=data)
@@ -1109,9 +1107,7 @@ class TestReviewForm(TestCase):
         data['delayed_rejection_date'] = ''
         form = self.get_form(data=data)
         assert not form.is_valid()
-        assert form.errors['delayed_rejection_date'] == [
-            'This field is required.'
-        ]
+        assert form.errors['delayed_rejection_date'] == ['This field is required.']
 
     def test_version_pk(self):
         self.grant_permission(self.request.user, 'Addons:Review')

--- a/src/olympia/reviewers/tests/test_forms.py
+++ b/src/olympia/reviewers/tests/test_forms.py
@@ -95,7 +95,7 @@ class TestReviewForm(TestCase):
         actions = self.get_form().helper.get_actions()
         assert list(actions.keys()) == [
             'unreject_latest_version',
-            'change_pending_rejection_multiple_versions',
+            'change_or_clear_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
             'reply',
@@ -134,7 +134,7 @@ class TestReviewForm(TestCase):
             'unreject_multiple_versions',
             'block_multiple_versions',
             'confirm_multiple_versions',
-            'change_pending_rejection_multiple_versions',
+            'change_or_clear_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
             'reply',
@@ -163,7 +163,7 @@ class TestReviewForm(TestCase):
             addon_status=amo.STATUS_DELETED, file_status=amo.STATUS_DISABLED
         )
         assert list(actions.keys()) == [
-            'change_pending_rejection_multiple_versions',
+            'change_or_clear_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
             'reply',
@@ -193,7 +193,7 @@ class TestReviewForm(TestCase):
         )
         assert list(actions.keys()) == [
             'reject_multiple_versions',
-            'change_pending_rejection_multiple_versions',
+            'change_or_clear_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
             'reply',
@@ -208,7 +208,7 @@ class TestReviewForm(TestCase):
             addon_status=amo.STATUS_DISABLED, file_status=amo.STATUS_DISABLED
         )
         assert list(actions.keys()) == [
-            'change_pending_rejection_multiple_versions',
+            'change_or_clear_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'reply',
             'enable_addon',
@@ -754,7 +754,7 @@ class TestReviewForm(TestCase):
         self.test_versions_queryset_contains_pending_files_for_listed(
             expected_select_data_value=[
                 'reject_multiple_versions',
-                'change_pending_rejection_multiple_versions',
+                'change_or_clear_pending_rejection_multiple_versions',
                 'clear_needs_human_review_multiple_versions',
                 'set_needs_human_review_multiple_versions',
                 'reply',
@@ -977,7 +977,7 @@ class TestReviewForm(TestCase):
                 'unreject_multiple_versions',
                 'block_multiple_versions',
                 'confirm_multiple_versions',
-                'change_pending_rejection_multiple_versions',
+                'change_or_clear_pending_rejection_multiple_versions',
                 'clear_needs_human_review_multiple_versions',
                 'set_needs_human_review_multiple_versions',
             ]
@@ -1048,7 +1048,7 @@ class TestReviewForm(TestCase):
         assert inputs[2].attrib['class'] == 'data-toggle'
         assert (
             inputs[2].attrib['data-value']
-            == 'change_pending_rejection_multiple_versions'
+            == 'change_or_clear_pending_rejection_multiple_versions'
         )
 
     @freeze_time('2025-01-23 12:52')
@@ -1128,7 +1128,7 @@ class TestReviewForm(TestCase):
         )
 
         data = {
-            'action': 'change_pending_rejection_multiple_versions',
+            'action': 'change_or_clear_pending_rejection_multiple_versions',
             'delayed_rejection': 'True',
             'delayed_rejection_date': in_the_future.isoformat()[:16],
             'versions': [self.version.pk, new_version.pk],

--- a/src/olympia/reviewers/tests/test_forms.py
+++ b/src/olympia/reviewers/tests/test_forms.py
@@ -95,7 +95,7 @@ class TestReviewForm(TestCase):
         actions = self.get_form().helper.get_actions()
         assert list(actions.keys()) == [
             'unreject_latest_version',
-            'clear_pending_rejection_multiple_versions',
+            'change_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
             'reply',
@@ -134,7 +134,7 @@ class TestReviewForm(TestCase):
             'unreject_multiple_versions',
             'block_multiple_versions',
             'confirm_multiple_versions',
-            'clear_pending_rejection_multiple_versions',
+            'change_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
             'reply',
@@ -163,7 +163,7 @@ class TestReviewForm(TestCase):
             addon_status=amo.STATUS_DELETED, file_status=amo.STATUS_DISABLED
         )
         assert list(actions.keys()) == [
-            'clear_pending_rejection_multiple_versions',
+            'change_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
             'reply',
@@ -193,7 +193,7 @@ class TestReviewForm(TestCase):
         )
         assert list(actions.keys()) == [
             'reject_multiple_versions',
-            'clear_pending_rejection_multiple_versions',
+            'change_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
             'reply',
@@ -208,7 +208,7 @@ class TestReviewForm(TestCase):
             addon_status=amo.STATUS_DISABLED, file_status=amo.STATUS_DISABLED
         )
         assert list(actions.keys()) == [
-            'clear_pending_rejection_multiple_versions',
+            'change_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'reply',
             'enable_addon',
@@ -754,7 +754,7 @@ class TestReviewForm(TestCase):
         self.test_versions_queryset_contains_pending_files_for_listed(
             expected_select_data_value=[
                 'reject_multiple_versions',
-                'clear_pending_rejection_multiple_versions',
+                'change_pending_rejection_multiple_versions',
                 'clear_needs_human_review_multiple_versions',
                 'set_needs_human_review_multiple_versions',
                 'reply',
@@ -977,7 +977,7 @@ class TestReviewForm(TestCase):
                 'unreject_multiple_versions',
                 'block_multiple_versions',
                 'confirm_multiple_versions',
-                'clear_pending_rejection_multiple_versions',
+                'change_pending_rejection_multiple_versions',
                 'clear_needs_human_review_multiple_versions',
                 'set_needs_human_review_multiple_versions',
             ]

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -3469,7 +3469,7 @@ class TestReviewHelper(TestReviewHelperBase):
         )
         data['action'] = 'change_pending_rejection_multiple_versions'
         data['delayed_rejection'] = 'True'
-        data['delayed_rejection_date'] = in_the_future.isoformat()[:16]
+        data['delayed_rejection_date'] = in_the_future
         self.helper.set_data(data)
         self.helper.process()
 

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -584,7 +584,7 @@ class TestReviewHelper(TestReviewHelperBase):
             'public',
             'reject',
             'reject_multiple_versions',
-            'change_pending_rejection_multiple_versions',
+            'change_or_clear_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
             'reply',
@@ -659,7 +659,7 @@ class TestReviewHelper(TestReviewHelperBase):
             'unreject_multiple_versions',
             'block_multiple_versions',
             'confirm_multiple_versions',
-            'change_pending_rejection_multiple_versions',
+            'change_or_clear_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
             'reply',
@@ -800,7 +800,7 @@ class TestReviewHelper(TestReviewHelperBase):
         expected = [
             'confirm_auto_approved',
             'reject_multiple_versions',
-            'change_pending_rejection_multiple_versions',
+            'change_or_clear_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
             'reply',
@@ -827,7 +827,7 @@ class TestReviewHelper(TestReviewHelperBase):
             'reject',
             'confirm_auto_approved',
             'reject_multiple_versions',
-            'change_pending_rejection_multiple_versions',
+            'change_or_clear_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
             'reply',
@@ -864,7 +864,7 @@ class TestReviewHelper(TestReviewHelperBase):
 
         self.grant_permission(self.user, 'Reviews:Admin')
         expected = [
-            'change_pending_rejection_multiple_versions',
+            'change_or_clear_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'reply',
             'enable_addon',
@@ -896,7 +896,7 @@ class TestReviewHelper(TestReviewHelperBase):
         self.grant_permission(self.user, 'Reviews:Admin')
         expected = [
             'unreject_latest_version',
-            'change_pending_rejection_multiple_versions',
+            'change_or_clear_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
             'reply',
@@ -958,7 +958,7 @@ class TestReviewHelper(TestReviewHelperBase):
 
         self.grant_permission(self.user, 'Reviews:Admin')
         expected = [
-            'change_pending_rejection_multiple_versions',
+            'change_or_clear_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
             'reply',
@@ -3395,7 +3395,7 @@ class TestReviewHelper(TestReviewHelperBase):
             .exclude(pk=unselected.pk)
             .order_by('pk')
         )
-        data['action'] = 'change_pending_rejection_multiple_versions'
+        data['action'] = 'change_or_clear_pending_rejection_multiple_versions'
         self.helper.set_data(data)
         self.helper.process()
 
@@ -3467,7 +3467,7 @@ class TestReviewHelper(TestReviewHelperBase):
             .exclude(pk=unselected.pk)
             .order_by('pk')
         )
-        data['action'] = 'change_pending_rejection_multiple_versions'
+        data['action'] = 'change_or_clear_pending_rejection_multiple_versions'
         data['delayed_rejection'] = 'True'
         data['delayed_rejection_date'] = in_the_future
         self.helper.set_data(data)

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -2445,7 +2445,7 @@ class TestReviewHelper(TestReviewHelperBase):
         )
         self.setup_data(amo.STATUS_APPROVED, file_status=amo.STATUS_APPROVED)
 
-        in_the_future = datetime.now() + timedelta(days=14)
+        in_the_future = datetime.now() + timedelta(days=14, hours=1)
 
         # Safeguards.
         assert isinstance(self.helper.handler, ReviewFiles)
@@ -2457,7 +2457,7 @@ class TestReviewHelper(TestReviewHelperBase):
             **self.get_data(),
             'versions': self.addon.versions.all(),
             'delayed_rejection': True,
-            'delayed_rejection_days': 14,
+            'delayed_rejection_date': in_the_future,
             **extra_data,
         }
         self.helper.set_data(data)
@@ -2673,7 +2673,7 @@ class TestReviewHelper(TestReviewHelperBase):
             amo.STATUS_APPROVED, file_status=amo.STATUS_APPROVED, content_review=True
         )
 
-        in_the_future = datetime.now() + timedelta(days=14)
+        in_the_future = datetime.now() + timedelta(days=14, hours=1)
 
         # Safeguards.
         assert isinstance(self.helper.handler, ReviewFiles)
@@ -2686,7 +2686,7 @@ class TestReviewHelper(TestReviewHelperBase):
             {
                 'versions': self.addon.versions.all(),
                 'delayed_rejection': True,
-                'delayed_rejection_days': 14,
+                'delayed_rejection_date': in_the_future,
             }
         )
         self.helper.set_data(data)
@@ -2952,12 +2952,14 @@ class TestReviewHelper(TestReviewHelperBase):
 
         assert self.addon.status == amo.STATUS_APPROVED
 
+        in_the_future = datetime.now() + timedelta(days=14, hours=1)
+
         data = self.get_data().copy()
         data.update(
             {
                 'versions': self.addon.versions.all(),
                 'delayed_rejection': True,
-                'delayed_rejection_days': 14,
+                'delayed_rejection_date': in_the_future,
             }
         )
         self.helper.set_data(data)

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -584,7 +584,7 @@ class TestReviewHelper(TestReviewHelperBase):
             'public',
             'reject',
             'reject_multiple_versions',
-            'clear_pending_rejection_multiple_versions',
+            'change_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
             'reply',
@@ -659,7 +659,7 @@ class TestReviewHelper(TestReviewHelperBase):
             'unreject_multiple_versions',
             'block_multiple_versions',
             'confirm_multiple_versions',
-            'clear_pending_rejection_multiple_versions',
+            'change_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
             'reply',
@@ -800,7 +800,7 @@ class TestReviewHelper(TestReviewHelperBase):
         expected = [
             'confirm_auto_approved',
             'reject_multiple_versions',
-            'clear_pending_rejection_multiple_versions',
+            'change_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
             'reply',
@@ -827,7 +827,7 @@ class TestReviewHelper(TestReviewHelperBase):
             'reject',
             'confirm_auto_approved',
             'reject_multiple_versions',
-            'clear_pending_rejection_multiple_versions',
+            'change_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
             'reply',
@@ -864,7 +864,7 @@ class TestReviewHelper(TestReviewHelperBase):
 
         self.grant_permission(self.user, 'Reviews:Admin')
         expected = [
-            'clear_pending_rejection_multiple_versions',
+            'change_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'reply',
             'enable_addon',
@@ -896,7 +896,7 @@ class TestReviewHelper(TestReviewHelperBase):
         self.grant_permission(self.user, 'Reviews:Admin')
         expected = [
             'unreject_latest_version',
-            'clear_pending_rejection_multiple_versions',
+            'change_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
             'reply',
@@ -958,7 +958,7 @@ class TestReviewHelper(TestReviewHelperBase):
 
         self.grant_permission(self.user, 'Reviews:Admin')
         expected = [
-            'clear_pending_rejection_multiple_versions',
+            'change_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
             'reply',
@@ -3364,7 +3364,7 @@ class TestReviewHelper(TestReviewHelperBase):
         assert not unselected.needshumanreview_set.filter(is_active=True).exists()
         assert not unselected.due_date
 
-    def test_clear_pending_rejection_multiple_versions(self):
+    def test_change_pending_rejection_multiple_versions(self):
         self.grant_permission(self.user, 'Addons:Review')
         self.grant_permission(self.user, 'Reviews:Admin')
         self.setup_data(amo.STATUS_APPROVED, file_status=amo.STATUS_APPROVED)
@@ -3395,7 +3395,7 @@ class TestReviewHelper(TestReviewHelperBase):
             .exclude(pk=unselected.pk)
             .order_by('pk')
         )
-        data['action'] = 'clear_pending_rejection_multiple_versions'
+        data['action'] = 'change_pending_rejection_multiple_versions'
         self.helper.set_data(data)
         self.helper.process()
 

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -2391,7 +2391,6 @@ class TestReviewHelper(TestReviewHelperBase):
             ]
             assert decision.metadata == {
                 'content_review': False,
-                'delayed_rejection_days': None,
             }
 
             # listed auto approvals should be disabled until the next manual
@@ -2499,7 +2498,7 @@ class TestReviewHelper(TestReviewHelperBase):
         assert log.arguments == [self.addon, decision, self.review_version, old_version]
         assert decision.metadata == {
             'content_review': False,
-            'delayed_rejection_days': 14,
+            'delayed_rejection_date': in_the_future.isoformat(),
         }
 
         # The flag to prevent the authors from being notified several times
@@ -2662,7 +2661,6 @@ class TestReviewHelper(TestReviewHelperBase):
 
         assert ContentDecision.objects.get().metadata == {
             'content_review': True,
-            'delayed_rejection_days': None,
         }
 
     def test_reject_multiple_versions_content_review_with_delay(self):
@@ -2728,7 +2726,7 @@ class TestReviewHelper(TestReviewHelperBase):
         assert log.arguments == [self.addon, decision, self.review_version, old_version]
         assert decision.metadata == {
             'content_review': True,
-            'delayed_rejection_days': 14,
+            'delayed_rejection_date': in_the_future.isoformat(),
         }
 
     def test_unreject_latest_version_approved_addon(self):

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -5301,10 +5301,12 @@ class TestReview(ReviewBase):
             doc('.data-toggle.review-tested')[0].attrib['data-value'] == 'disable_addon'
         )
         # Admins can use delayed rejections
-        assert (
-            doc('.data-toggle.review-delayed-rejection')[0].attrib['data-value']
-            == 'reject_multiple_versions change_or_clear_pending_rejection_multiple_versions'
-        )
+        assert doc('.data-toggle.review-delayed-rejection')[0].attrib[
+            'data-value'
+        ].split(' ') == [
+            'reject_multiple_versions',
+            'change_or_clear_pending_rejection_multiple_versions',
+        ]
 
     def test_data_value_attributes_unlisted(self):
         self.version.update(channel=amo.CHANNEL_UNLISTED)

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -81,7 +81,6 @@ from olympia.versions.models import (
     ApplicationsVersions,
     AppVersion,
     VersionManager,
-    VersionReviewerFlags,
 )
 from olympia.versions.utils import get_review_due_date
 from olympia.zadmin.models import get_config

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -2449,7 +2449,7 @@ class TestReview(ReviewBase):
             'public',
             'reject',
             'reject_multiple_versions',
-            'clear_pending_rejection_multiple_versions',
+            'change_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
             'reply',

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -4613,8 +4613,7 @@ class TestReview(ReviewBase):
         self.grant_permission(self.reviewer, 'Addons:Review,Reviews:Admin')
 
         in_the_future = datetime.now() + timedelta(
-            days=REVIEWER_DELAYED_REJECTION_PERIOD_DAYS_DEFAULT,
-            hours=1
+            days=REVIEWER_DELAYED_REJECTION_PERIOD_DAYS_DEFAULT, hours=1
         )
 
         response = self.client.post(
@@ -5252,12 +5251,23 @@ class TestReview(ReviewBase):
 
         assert doc('.data-toggle.review-actions-reasons')[0].attrib['data-value'].split(
             ' '
-        ) == ['reject_multiple_versions', 'reply', 'disable_addon',]
+        ) == [
+            'reject_multiple_versions',
+            'reply',
+            'disable_addon',
+        ]
 
-        assert doc('.data-toggle.review-files')[0].attrib['data-value'] == 'disable_addon'
-        assert doc('.data-toggle.review-tested')[0].attrib['data-value'] == 'disable_addon'
+        assert (
+            doc('.data-toggle.review-files')[0].attrib['data-value'] == 'disable_addon'
+        )
+        assert (
+            doc('.data-toggle.review-tested')[0].attrib['data-value'] == 'disable_addon'
+        )
         # Admins can use delayed rejections
-        assert doc('.data-toggle.review-delayed-rejection')[0].attrib['data-value'] == 'reject_multiple_versions change_pending_rejection_multiple_versions'
+        assert (
+            doc('.data-toggle.review-delayed-rejection')[0].attrib['data-value']
+            == 'reject_multiple_versions change_pending_rejection_multiple_versions'
+        )
 
     def test_data_value_attributes_unlisted(self):
         self.version.update(channel=amo.CHANNEL_UNLISTED)

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -2449,7 +2449,7 @@ class TestReview(ReviewBase):
             'public',
             'reject',
             'reject_multiple_versions',
-            'change_pending_rejection_multiple_versions',
+            'change_or_clear_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
             'reply',
@@ -4658,7 +4658,7 @@ class TestReview(ReviewBase):
         response = self.client.post(
             self.url,
             {
-                'action': 'change_pending_rejection_multiple_versions',
+                'action': 'change_or_clear_pending_rejection_multiple_versions',
                 'versions': [old_version.pk, self.version.pk],
                 'delayed_rejection': 'True',
                 'delayed_rejection_date': in_the_future2.isoformat()[:16],
@@ -5248,7 +5248,7 @@ class TestReview(ReviewBase):
         expected_actions_values = [
             'confirm_auto_approved',
             'reject_multiple_versions',
-            'change_pending_rejection_multiple_versions',
+            'change_or_clear_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
             'reply',
@@ -5264,7 +5264,7 @@ class TestReview(ReviewBase):
             ' '
         ) == [
             'reject_multiple_versions',
-            'change_pending_rejection_multiple_versions',
+            'change_or_clear_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
             'reply',
@@ -5303,7 +5303,7 @@ class TestReview(ReviewBase):
         # Admins can use delayed rejections
         assert (
             doc('.data-toggle.review-delayed-rejection')[0].attrib['data-value']
-            == 'reject_multiple_versions change_pending_rejection_multiple_versions'
+            == 'reject_multiple_versions change_or_clear_pending_rejection_multiple_versions'
         )
 
     def test_data_value_attributes_unlisted(self):

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -694,12 +694,14 @@ class ReviewHelper:
             ),
             'resolves_cinder_jobs': True,
         }
-        actions['change_pending_rejection_multiple_versions'] = {
-            'method': self.handler.change_pending_rejection_multiple_versions,
+        actions['change_or_clear_pending_rejection_multiple_versions'] = {
+            'method': self.handler.change_or_clear_pending_rejection_multiple_versions,
             'label': 'Change pending rejection',
             'details': (
-                'Change pending rejection from selected versions, but '
-                "otherwise don't change the version(s) or add-on statuses."
+                'Change or clear pending rejection from selected versions, '
+                "but otherwise don't change the version(s) or add-on "
+                'statuses. Developer will be notified of the new pending '
+                'rejection date unless the action clears it.'
             ),
             'delayable': True,
             'multiple_versions': True,
@@ -1605,8 +1607,8 @@ class ReviewBase:
             versions=self.data['versions'],
         )
 
-    def change_pending_rejection_multiple_versions(self):
-        """Change pending rejection on selected versions."""
+    def change_or_clear_pending_rejection_multiple_versions(self):
+        """Change/clear pending rejection on selected versions."""
         self.file = None
         self.version = None
         extra_details = {}

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -1614,14 +1614,16 @@ class ReviewBase:
             'delayed_rejection_date'
         ):
             pending_rejection_deadline = self.data['delayed_rejection_date']
-            extra_details['new_deadline'] = str(pending_rejection_deadline)
+            extra_details['new_deadline'] = pending_rejection_deadline
         else:
             pending_rejection_deadline = None
 
         for version in self.data['versions']:
             # Do it one by one to trigger the post_save() for each version.
             if version.pending_rejection:
-                extra_details['old_deadline'] = str(version.pending_rejection)
+                extra_details['old_deadline'] = version.pending_rejection.isoformat()[
+                    :16
+                ]
                 kwargs = {
                     'pending_rejection': pending_rejection_deadline,
                 }

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -620,7 +620,7 @@ class ReviewHelper:
             'method': self.handler.reject_multiple_versions,
             'label': 'Reject Multiple Versions',
             'minimal': True,
-            'delayable': True,
+            'delayable': is_appropriate_admin_reviewer,
             'multiple_versions': True,
             'details': (
                 'This will reject the selected versions. '

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -1614,7 +1614,7 @@ class ReviewBase:
             'delayed_rejection_date'
         ):
             pending_rejection_deadline = self.data['delayed_rejection_date']
-            extra_details['new_deadline'] = pending_rejection_deadline
+            extra_details['new_deadline'] = pending_rejection_deadline.isoformat()[:16]
         else:
             pending_rejection_deadline = None
 

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -68,7 +68,7 @@ from olympia.stats.utils import (
     get_average_daily_users_per_version_from_bigquery,
 )
 from olympia.users.models import UserProfile
-from olympia.versions.models import Version, VersionReviewerFlags
+from olympia.versions.models import Version
 from olympia.zadmin.models import get_config, set_config
 
 from .decorators import (
@@ -1112,21 +1112,6 @@ class AddonReviewerViewSet(GenericViewSet):
             addon.allow_resubmission()
         except RuntimeError:
             status_code = status.HTTP_409_CONFLICT
-        return Response(status=status_code)
-
-    @drf_action(
-        detail=True,
-        methods=['post'],
-        permission_classes=[GroupPermission(amo.permissions.REVIEWS_ADMIN)],
-    )
-    def clear_pending_rejections(self, request, **kwargs):
-        addon = get_object_or_404(Addon, pk=kwargs['pk'])
-        status_code = status.HTTP_202_ACCEPTED
-        VersionReviewerFlags.objects.filter(version__addon=addon).update(
-            pending_rejection=None,
-            pending_rejection_by=None,
-            pending_content_rejection=None,
-        )
         return Response(status=status_code)
 
     @drf_action(

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -1195,7 +1195,7 @@ class Version(OnChangeMixin, ModelBase):
         if (reviewer_flags := getattr(self, 'reviewerflags', None)) and (
             rejection_date := reviewer_flags.pending_rejection
         ):
-            status = gettext('Delay-rejected, scheduled for %s') % rejection_date.date()
+            status = gettext('Delay-rejected, scheduled for %s') % rejection_date
         elif self.file.status == amo.STATUS_APPROVED:
             summary = getattr(self, 'autoapprovalsummary', None)
             if summary and summary.verdict == amo.AUTO_APPROVED:

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -1659,19 +1659,19 @@ def test_unreviewed_files(db, addon_status, file_status, is_unreviewed):
     (
         (
             amo.STATUS_AWAITING_REVIEW,
-            datetime(2022, 7, 7, 7, 7, 7),
+            datetime(2025, 1, 22, 8, 9, 10),
             True,
             amo.AUTO_APPROVED,
             False,
-            'Delay-rejected, scheduled for 2022-07-07',
+            'Delay-rejected, scheduled for 2025-01-22 08:09:10',
         ),
         (
             amo.STATUS_APPROVED,
-            datetime(2022, 8, 8, 8, 8, 8),
+            datetime(2025, 1, 23, 10, 11, 12),
             True,
             amo.AUTO_APPROVED,
             False,
-            'Delay-rejected, scheduled for 2022-08-08',
+            'Delay-rejected, scheduled for 2025-01-23 10:11:12',
         ),
         (
             amo.STATUS_APPROVED,

--- a/static/css/zamboni/reviewers.less
+++ b/static/css/zamboni/reviewers.less
@@ -1088,10 +1088,6 @@ form.review-form .data-toggle {
         "c c";
     grid-template-columns: max-content 1fr;
 
-    input[type="number"] {
-        width: 2.5em;
-    }
-
     .review-delayed-rejection-deadline {
         grid-area: b;
     }
@@ -1102,15 +1098,6 @@ form.review-form .data-toggle {
 
     li {
         list-style-type: none
-    }
-
-    li:nth-child(1) {
-        grid-area: a;
-    }
-
-    li:nth-child(2) {
-        grid-column-start: 1;
-        grid-column-end: 3;
     }
 }
 

--- a/static/js/zamboni/reviewers.js
+++ b/static/js/zamboni/reviewers.js
@@ -104,12 +104,16 @@ function initReviewActions() {
     }
 
     // Hide everything, then show the ones containing the value we're interested in.
-    $data_toggle.hide();
-    $data_toggle.filter('[data-value~="' + value + '"]').show();
+    $data_toggle.hide().prop('disabled', true)
+    $data_toggle.parent('label').hide()
+    $data_toggle.filter('[data-value~="' + value + '"]').show().prop('disabled', false);
+    $data_toggle.filter('[data-value~="' + value + '"]').parent('label').show();
     // For data_toggle_hide, the opposite - show everything, then hide the ones containing
     // the value we're interested in.
-    $data_toggle_hide.show();
-    $data_toggle_hide.filter('[data-value~="' + value + '"]').hide();
+    $data_toggle_hide.show().prop('disabled', false);
+    $data_toggle_hide.parent('label').show();
+    $data_toggle_hide.filter('[data-value~="' + value + '"]').hide().prop('disabled', true);
+    $data_toggle_hide.filter('[data-value~="' + value + '"]').parent('label').hide();
   }
 
   $('#review-actions .action_nav #id_action > *:not(.disabled)').click(

--- a/static/js/zamboni/reviewers.js
+++ b/static/js/zamboni/reviewers.js
@@ -126,7 +126,22 @@ function initReviewActions() {
       .filter('[data-value~="' + value + '"]')
       .parent('label')
       .hide();
+
+    showHideDelayedRejectionDateWidget();
   }
+
+  function showHideDelayedRejectionDateWidget() {
+    var delayed_rejection_input = $('#id_delayed_rejection input[name=delayed_rejection]:checked');
+    console.log(delayed_rejection_input);
+    var delayed_rejection_date_widget = $('#id_delayed_rejection_date');
+    if (delayed_rejection_input.prop('value') == 'True') {
+      delayed_rejection_date_widget.prop('disabled', false);
+    } else {
+      delayed_rejection_date_widget.prop('disabled', true);
+    }
+  }
+
+  $('#id_delayed_rejection input[name=delayed_rejection]').change(showHideDelayedRejectionDateWidget);
 
   $('#review-actions .action_nav #id_action > *:not(.disabled)').click(
     function () {

--- a/static/js/zamboni/reviewers.js
+++ b/static/js/zamboni/reviewers.js
@@ -131,7 +131,9 @@ function initReviewActions() {
   }
 
   function showHideDelayedRejectionDateWidget() {
-    var delayed_rejection_input = $('#id_delayed_rejection input[name=delayed_rejection]:checked');
+    var delayed_rejection_input = $(
+      '#id_delayed_rejection input[name=delayed_rejection]:checked',
+    );
     console.log(delayed_rejection_input);
     var delayed_rejection_date_widget = $('#id_delayed_rejection_date');
     if (delayed_rejection_input.prop('value') == 'True') {
@@ -141,7 +143,9 @@ function initReviewActions() {
     }
   }
 
-  $('#id_delayed_rejection input[name=delayed_rejection]').change(showHideDelayedRejectionDateWidget);
+  $('#id_delayed_rejection input[name=delayed_rejection]').change(
+    showHideDelayedRejectionDateWidget,
+  );
 
   $('#review-actions .action_nav #id_action > *:not(.disabled)').click(
     function () {

--- a/static/js/zamboni/reviewers.js
+++ b/static/js/zamboni/reviewers.js
@@ -104,16 +104,28 @@ function initReviewActions() {
     }
 
     // Hide everything, then show the ones containing the value we're interested in.
-    $data_toggle.hide().prop('disabled', true)
-    $data_toggle.parent('label').hide()
-    $data_toggle.filter('[data-value~="' + value + '"]').show().prop('disabled', false);
-    $data_toggle.filter('[data-value~="' + value + '"]').parent('label').show();
+    $data_toggle.hide().prop('disabled', true);
+    $data_toggle.parent('label').hide();
+    $data_toggle
+      .filter('[data-value~="' + value + '"]')
+      .show()
+      .prop('disabled', false);
+    $data_toggle
+      .filter('[data-value~="' + value + '"]')
+      .parent('label')
+      .show();
     // For data_toggle_hide, the opposite - show everything, then hide the ones containing
     // the value we're interested in.
     $data_toggle_hide.show().prop('disabled', false);
     $data_toggle_hide.parent('label').show();
-    $data_toggle_hide.filter('[data-value~="' + value + '"]').hide().prop('disabled', true);
-    $data_toggle_hide.filter('[data-value~="' + value + '"]').parent('label').hide();
+    $data_toggle_hide
+      .filter('[data-value~="' + value + '"]')
+      .hide()
+      .prop('disabled', true);
+    $data_toggle_hide
+      .filter('[data-value~="' + value + '"]')
+      .parent('label')
+      .hide();
   }
 
   $('#review-actions .action_nav #id_action > *:not(.disabled)').click(


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/14920

### Description

This allows reviewers to change the pending rejection date of versions pending rejection through a widget where they can select the date and time.

Because the actions menu is already pretty large, the clear pending rejection date action is reused, with an option to change or clear ; to tie everything together and make the UI more consistent, the rejection action use the same widgets, making the date choice absolute rather than relative.

### Screenshots

#### New reject multiple versions UI
![Screenshot 2025-01-03 at 17-17-44 Ui-Addon-Install – Add-ons for Firefox](https://github.com/user-attachments/assets/3539f065-b883-4605-aea1-b23d4bb2a1b5)

#### Modified Clear pending rejection action (now Change pending rejection) UI
![Screenshot 2025-01-03 at 17-18-37 Ui-Addon-Install – Add-ons for Firefox](https://github.com/user-attachments/assets/7348ea6f-d9ab-485f-94e0-1daf660c382d)

## Testing

See tests. Non-exhaustive list of scenarios, after submitting an add-on and going to its review page:
- Use the reject multiple versions action with immediate effect
- Use the reject multiple versions action with a delay, and then...
  - Use the change pending rejection action to clear the delay
  - Use the change pending rejection action to change the delay to a date in the future

Changing the delay (not clearing it) should send an email to the developer following copy that can be found as a comment in the issue.

Changing a delay should require the new date to be at least one extra day in the future compared to now. Changing the delay of multiple versions at once is possible, but the existing pending rejection date should all be the same.