### PR TITLE
Support long locale in dynamic served js catalog

### DIFF
--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -7968,3 +7968,10 @@ class TestJavascriptCatalog(TestCase):
             '"Une erreur est survenue pendant l\\u2019envoi de votre fichier."'
             in content
         )
+
+    @pytest.mark.needs_locales_compilation
+    def test_long_locales(self):
+        for locale in ['en-US', 'sr-Latn', 'cak']:
+            url = reverse('javascript-catalog', kwargs={'locale': locale})
+            content = self.client.get(url).content.decode('utf-8')
+            assert 'There was an error uploading your file.' in content

--- a/src/olympia/urls.py
+++ b/src/olympia/urls.py
@@ -140,7 +140,7 @@ if settings.SERVE_STATIC_FILES:
             ),
             # Serve javascript catalog locales bundle directly from django
             re_path(
-                r'^static/js/i18n/(?P<locale>\w+)\.js$',
+                r'^static/js/i18n/(?P<locale>\w{2,3}(?:-\w{2,6})?)\.js$',
                 serve_javascript_catalog,
                 name='javascript-catalog',
             ),


### PR DESCRIPTION
Fixes: mozilla/addons#15297

### Description

Support long locale for serving dynamic i18n bundles

### Context

This problem was pre-existing and only short locales were covered with tests.

It surfaced when we landed PR that redireected short locale to long locale default.

### Testing

- clean the ./static and ./site-static directories to ensure no compiled locales exist.

- run dev mode "make up"

Ensure devhub loads and the locale file en-US.js is loaded 200.

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
