### PR TITLE
Log image digest in docker build

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -80,4 +80,5 @@ runs:
         metadata=$(cat $DOCKER_METADATA_FILE)
         echo "digest=$(echo $metadata | jq -r '.web."containerimage.digest"')" >> $GITHUB_OUTPUT
         echo "tag=$(echo $metadata | jq -r '.web."image.name"')" >> $GITHUB_OUTPUT
+        echo $GITHUB_OUTPUT
 

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -80,5 +80,5 @@ runs:
         metadata=$(cat $DOCKER_METADATA_FILE)
         echo "digest=$(echo $metadata | jq -r '.web."containerimage.digest"')" >> $GITHUB_OUTPUT
         echo "tag=$(echo $metadata | jq -r '.web."image.name"')" >> $GITHUB_OUTPUT
-        echo $GITHUB_OUTPUT
+        cat $GITHUB_OUTPUT
 


### PR DESCRIPTION
Fixes: mozilla/addons#15298

### Description

Log the build 

### Testing

Works on CI

<img width="713" alt="image" src="https://github.com/user-attachments/assets/f4556410-a39e-4ba3-a3df-5e1540ffaadc" />

you should be able to copy the digest and run 

```bash
make up DOCKER_DIGEST=<digest>
```

And it will pull the image built from that job.

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
