### PR TITLE
Make build-docker locally debuggable

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -37,6 +37,7 @@ runs:
 
         echo "git_build_url=$git_repo_url/actions/runs/${{ github.run_id }}" >> $GITHUB_OUTPUT
         echo "git_sha=${{ github.sha }}" >> $GITHUB_OUTPUT
+        echo "metadata_file=buildx-bake-metadata.json" >> $GITHUB_OUTPUT
 
         cat $GITHUB_OUTPUT
 
@@ -51,33 +52,28 @@ runs:
           # and to prevent multiple tags from being associated with a build
           type=raw,value=${{ inputs.version }}
 
-    - name: Create .env and version.json files
-      shell: bash
-      run: |
-        # We only build the production image in CI
-        echo "DOCKER_TARGET=production" >> $GITHUB_ENV
-        echo "DOCKER_VERSION=${{ steps.meta.outputs.version }}" >> $GITHUB_ENV
-        echo "DOCKER_COMMIT=${{ steps.context.outputs.git_sha }}" >> $GITHUB_ENV
-        echo "DOCKER_BUILD=${{ steps.context.outputs.git_build_url }}" >> $GITHUB_ENV
-        echo "TAGS_FILE=${{ steps.meta.outputs.bake-file-tags }}" >> $GITHUB_ENV
-        echo "ANNOTATIONS_FILE=${{ steps.meta.outputs.bake-file-annotations }}" >> $GITHUB_ENV
-        echo "DOCKER_METADATA_FILE=buildx-bake-metadata.json" >> $GITHUB_ENV
-
-        make setup
-
     - name: Build Image
       id: build
       shell: bash
+      env:
+        DOCKER_TAGS_FILE: ${{ steps.meta.outputs.bake-file-tags }}
+        DOCKER_ANNOTATIONS_FILE: ${{ steps.meta.outputs.bake-file-annotations }}
+        DOCKER_METADATA_FILE: ${{ steps.context.outputs.metadata_file }}
+        DOCKER_PUSH: ${{ inputs.push }}
       run: |
+        make setup \
+          DOCKER_TARGET="production" \
+          DOCKER_VERSION="${{ steps.meta.outputs.version }}"
+
         make docker_build_web \
-          ARGS="--file ${{ env.TAGS_FILE }} --file ${{ env.ANNOTATIONS_FILE }}" \
-          DOCKER_PUSH=${{ inputs.push }}
+          DOCKER_COMMIT="${{ steps.context.outputs.git_sha }}" \
+          DOCKER_BUILD="${{ steps.context.outputs.git_build_url }}"
 
     - name: Get image digest
       id: build_meta
       shell: bash
       run: |
-        metadata=$(cat $DOCKER_METADATA_FILE)
+        metadata=$(cat ${{ steps.context.outputs.metadata_file }})
         echo "digest=$(echo $metadata | jq -r '.web."containerimage.digest"')" >> $GITHUB_OUTPUT
         echo "tag=$(echo $metadata | jq -r '.web."image.name"')" >> $GITHUB_OUTPUT
 

--- a/Makefile-os
+++ b/Makefile-os
@@ -39,6 +39,14 @@ ifeq ($(DOCKER_PUSH), true)
 	DOCKER_BAKE_ARGS += --push
 endif
 
+ifneq ($(DOCKER_ANNOTATIONS_FILE),)
+	DOCKER_BAKE_ARGS += --file $(DOCKER_ANNOTATIONS_FILE)
+endif
+
+ifneq ($(DOCKER_TAGS_FILE),)
+	DOCKER_BAKE_ARGS += --file $(DOCKER_TAGS_FILE)
+endif
+
 DOCKER_COMPOSE_ARGS := \
 	-d \
 	--remove-orphans \


### PR DESCRIPTION
Relates to: mozilla/addons#15066


### Description

the build command run in the github action should be debuggable, as in, you can copy paste the command as is locally and it will:
- just work
- reproduce the same image (given same code)

### Context

This is achieved by adding the arguments which are critical for the build to bash args passed directly to the make command. The arguments which are either not needed or wouldn't be possible to include locally are moved to environment variables in the step so they are still picked up by make.

### Testing

You can verify in the CI job that all the arguments are passed to make, but the command printed in the logs can be copy/pasted and run (as is) locally

(args passed directly only include what is critical for the build)

<img width="721" alt="image" src="https://github.com/user-attachments/assets/b133cc33-f06f-472a-9836-9d5ad2683a9a" />

(buildx still gets the file references passed to include additional metadata from those files)

<img width="1350" alt="image" src="https://github.com/user-attachments/assets/cbb49a29-1e47-4de9-ae0f-59a1e02647b2" />




### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
