### PR TITLE
Group celery and google packages together in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,15 @@ updates:
   directory: "/requirements"
   schedule:
     interval: daily
+  groups:
+      google:
+        patterns:
+          - "google-*"
+      celery:
+        patterns:
+          - celery
+          - billiard
+          - kombu
   open-pull-requests-limit: 99
   ignore:
   - dependency-name: django


### PR DESCRIPTION
Fixes: mozilla/addons#15304