### PR TITLE
process jobs from legal escalations with no abuse reports

### DIFF
--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -312,9 +312,9 @@ class CinderJob(ModelBase):
                 if self.target_addon_id
                 else abuse_report_or_decision.addon
             ),
-            rating=abuse_report_or_decision.rating,
-            collection=abuse_report_or_decision.collection,
-            user=abuse_report_or_decision.user,
+            rating=getattr(abuse_report_or_decision, 'rating', None),
+            collection=getattr(abuse_report_or_decision, 'collection', None),
+            user=getattr(abuse_report_or_decision, 'user', None),
             cinder_id=decision_cinder_id,
             action=decision_action,
             notes=decision_notes[: ContentDecision._meta.get_field('notes').max_length],

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -1260,6 +1260,8 @@ class TestCinderJob(TestCase):
         cinder_job = CinderJob.objects.create(job_id='1234', target_addon=target)
         policy_a = CinderPolicy.objects.create(uuid='123-45', name='aaa', text='AAA')
         policy_b = CinderPolicy.objects.create(uuid='678-90', name='bbb', text='BBB')
+        assert AbuseReport.objects.filter(cinder_job=cinder_job).count() == 0
+        assert ContentDecision.objects.filter(appeal_job=cinder_job).count() == 0
 
         with mock.patch.object(
             ContentActionDisableAddon, 'process_action'

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -3741,6 +3741,7 @@ class TestReviewHelper(TestReviewHelperBase):
         NeedsHumanReview.objects.create(
             version=self.addon.current_version,
             reason=NeedsHumanReview.REASONS.AUTO_APPROVAL_DISABLED,
+            is_active=True,
         )
         self.helper.handler.request_legal_review()
 
@@ -3753,10 +3754,21 @@ class TestReviewHelper(TestReviewHelperBase):
             if data
             else self.get_data()['comments']
         )
-        assert not NeedsHumanReview.objects.filter(is_active=True).exists()
+        assert not NeedsHumanReview.objects.filter(
+            reason=NeedsHumanReview.REASONS.AUTO_APPROVAL_DISABLED, is_active=True
+        ).exists()
 
     def test_request_legal_review_no_job(self):
+        NeedsHumanReview.objects.create(
+            version=self.addon.current_version,
+            reason=NeedsHumanReview.REASONS.ABUSE_ADDON_VIOLATION,
+        )
         self._test_request_legal_review()
+
+        # is not cleared
+        assert NeedsHumanReview.objects.filter(
+            reason=NeedsHumanReview.REASONS.ABUSE_ADDON_VIOLATION, is_active=True
+        ).exists()
 
     def test_request_legal_review_resolve_job(self):
         # Set up a typical job that would be handled in the reviewer tools
@@ -3778,6 +3790,11 @@ class TestReviewHelper(TestReviewHelperBase):
         # And check that the job was resolved in the way we expected
         assert job.reload().decision.action == DECISION_ACTIONS.AMO_LEGAL_FORWARD
         assert job.forwarded_to_job == CinderJob.objects.get(job_id='5678')
+
+        # is cleared
+        assert not NeedsHumanReview.objects.filter(
+            reason=NeedsHumanReview.REASONS.ABUSE_ADDON_VIOLATION, is_active=True
+        ).exists()
 
     def _test_single_action_remove_from_queue_history(
         self, action, channel=amo.CHANNEL_LISTED

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -1571,6 +1571,7 @@ class ReviewBase:
     def request_legal_review(self):
         """Forward add-on and/or job to legal via Cinder."""
         log.info('Forwarding %s for legal review' % (self.addon))
+        self.clear_all_needs_human_review_flags_in_channel()
         self.record_decision(amo.LOG.REQUEST_LEGAL, action_completed=False)
 
 


### PR DESCRIPTION
Fixes: mozilla/addons#15278

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Handles jobs from Cinder that have no abuse report attached.  Also correctly clears NHR from the add-on when the legal escalation is made (the other problem noted in the issue)

### Context

CinderJobs in general don't have any target information directly fk'd to them - the information is on the AbuseReport, or appealed decision, that led to the job being created.  A legal forward doesn't (necessarily) have any appeals or abuse reports associated with it.  But for add-on, we do set `target_addon`, so we can use that instead (which we did already as an optimization, but then failed because there was no abuse report or appeal to reference `.rating`, etc , which would always have been `None` for an addon abuse report/appeal anyway).

### Testing

- Forward an add-on with some NHRs (manually create them in django shell if it's easier)
- see them cleared with the "review" (i.e. the add-on is no longer in the manual review queue)
- see the job in Cinder legal escalations queue
- resolve the job in Cinder with an action that would disable the add-on (AUP, etc)
- playback the webhook response locally
- see the add-on is disabled

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
