### PR TITLE
Remove extra docker volumes and extra associated configurations

### DIFF
--- a/.github/actions/run-docker/action.yml
+++ b/.github/actions/run-docker/action.yml
@@ -23,10 +23,6 @@ inputs:
     description: 'Docker target to run (development|production)'
     required: false
     default: 'production'
-  mount:
-    description: 'Mount host files at runtime? (development|production)'
-    required: false
-    default: 'production'
   deps:
     description: 'Which dependencies to install at runtime? (development|production)'
     required: false
@@ -44,7 +40,6 @@ runs:
           DOCKER_DIGEST="${{ inputs.digest }}" \
           DOCKER_TARGET="${{ inputs.target }}" \
           OLYMPIA_UID="$(id -u)" \
-          OLYMPIA_MOUNT="${{ inputs.mount }}" \
           OLYMPIA_DEPS="${{ inputs.deps }}" \
           DATA_BACKUP_SKIP="${{ inputs.data_backup_skip }}" \
           DOCKER_WAIT="true"

--- a/.github/workflows/_test_check.yml
+++ b/.github/workflows/_test_check.yml
@@ -46,7 +46,6 @@ jobs:
     name: |
       version: '${{ matrix.version }}' |
       target: '${{ matrix.target }}' |
-      mount: '${{ matrix.mount }}' |
       deps: '${{ matrix.deps }}'
     strategy:
       fail-fast: false
@@ -55,9 +54,6 @@ jobs:
           - local
           - ${{ inputs.version }}
         target:
-          - development
-          - production
-        mount:
           - development
           - production
         deps:
@@ -72,7 +68,6 @@ jobs:
             Values passed to the action:
             version: ${{ matrix.version }}
             target: ${{ matrix.target }}
-            mount: ${{ matrix.mount }}
             deps: ${{ matrix.deps }}
           EOF
       - name: ${{ matrix.version == 'local' && 'Uncached Build' || 'Pull' }} Check
@@ -84,7 +79,6 @@ jobs:
         with:
           version: ${{ matrix.version }}
           target: ${{ matrix.target }}
-          mount: ${{ matrix.mount }}
           deps: ${{ matrix.deps }}
           run: make check
       - name: Cached Build Check
@@ -93,7 +87,6 @@ jobs:
         with:
           version: ${{ matrix.version }}
           target: ${{ matrix.target }}
-          mount: ${{ matrix.mount }}
           deps: ${{ matrix.deps }}
           run: echo true
 

--- a/.github/workflows/_test_main.yml
+++ b/.github/workflows/_test_main.yml
@@ -88,7 +88,6 @@ jobs:
           services: ''
           digest: ${{ inputs.digest }}
           version: ${{ inputs.version }}
-          mount: development
           deps: development
           run: |
             split="--splits ${{ needs.test_config.outputs.splits }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,6 @@ jobs:
         with:
           digest: ${{ needs.build.outputs.digest }}
           version: ${{ needs.build.outputs.version }}
-          mount: development
           deps: development
           target: development
           run: |
@@ -140,7 +139,6 @@ jobs:
         with:
           digest: ${{ needs.build.outputs.digest }}
           version: ${{ needs.build.outputs.version }}
-          mount: development
           deps: development
           run: make extract_locales
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,18 +37,6 @@ x-olympia: &olympia
   entrypoint: ["/data/olympia/docker/entrypoint.sh"]
 
 services:
-  olympia_volumes:
-    <<: *olympia
-    # We could let this container exit 0, but docker compose --wait
-    # interprets this as a failure, even with a passing healtcheck.
-    # so we just sleep indefinitely instead.
-    command: ["sleep", "infinity"]
-    volumes:
-      # used by: web, worker, nginx
-      - ${HOST_MOUNT_SOURCE:?}:/data/olympia
-      - ./deps:/data/olympia/deps
-      - ./site-static:/data/olympia/site-static
-      - ./storage:/data/olympia/storage
   worker:
     <<: *olympia
     command: [
@@ -63,9 +51,7 @@ services:
       "celery -A olympia.amo.celery:app worker -E -c 2 --loglevel=INFO",
     ]
     volumes:
-      - ${HOST_MOUNT_SOURCE:?}:/data/olympia
-      - ./deps:/data/olympia/deps
-      - ./storage:/data/olympia/storage
+      - ./:/data/olympia
     extra_hosts:
      - "olympia.test:127.0.0.1"
     restart: on-failure:5
@@ -75,7 +61,6 @@ services:
       retries: 3
       start_interval: 1s
     depends_on:
-      - olympia_volumes
       - mysqld
       - elasticsearch
       - redis
@@ -93,17 +78,12 @@ services:
       interval: 30s
       retries: 3
       start_interval: 1s
-    volumes:
-      - ./static-build:/data/olympia/static-build
-      - ./site-static:/data/olympia/site-static
 
   nginx:
     image: nginx
     volumes:
       - data_nginx:/etc/nginx/conf.d
-      - ${HOST_MOUNT_SOURCE:?}:/srv
-      - ./site-static:/srv/site-static
-      - ./storage:/srv/storage
+      - ./:/srv
     ports:
       - "80:80"
     networks:
@@ -111,7 +91,7 @@ services:
         aliases:
           - olympia.test
     depends_on:
-      - olympia_volumes
+      - web
 
   memcached:
     image: memcached:1.4
@@ -161,6 +141,8 @@ services:
 
   redis:
     image: redis:6.2
+    volumes:
+      - data_redis:/data
 
   rabbitmq:
     image: rabbitmq:3.12
@@ -171,6 +153,8 @@ services:
       - RABBITMQ_DEFAULT_USER=olympia
       - RABBITMQ_DEFAULT_PASS=olympia
       - RABBITMQ_DEFAULT_VHOST=olympia
+    volumes:
+      - data_rabbitmq:/var/lib/rabbitmq
 
   autograph:
     image: mozilla/autograph:3.3.2
@@ -202,16 +186,6 @@ networks:
     enable_ipv6: false
 
 volumes:
-  # Volumes for the production olympia mounts
-  # allowing to conditionally mount directories
-  # from the host or from the image to <path>
-  # in the running docker container.
-  # If OLYMPIA_MOUNT_SOURCE matches (data_olympia_)
-  # then we use the production volume mounts. Otherwise
-  # it will map to the current directory ./<name>
-  # (data_olympia_)<name>:/<path>
-  data_olympia_:
-  data_olympia_deps:
   # Volume for rabbitmq/redis to avoid anonymous volumes
   data_rabbitmq:
   data_redis:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -30,12 +30,6 @@ fi
 NEW_HOST_UID=$(get_olympia_uid)
 OLYMPIA_ID_STRING="${NEW_HOST_UID}:$(get_olympia_gid)"
 
-# If we are on production mode, update the ownership of /data/olympia to match the new id
-if [[ "${HOST_MOUNT}" == "production" ]]; then
-  echo "Updating ownership of /data/olympia to ${OLYMPIA_ID_STRING}"
-  chown -R ${OLYMPIA_ID_STRING} /data/olympia
-fi
-
 cat <<EOF | su -s /bin/bash $OLYMPIA_USER
   echo "Running command as ${OLYMPIA_USER} ${OLYMPIA_ID_STRING}"
   set -xue

--- a/settings.py
+++ b/settings.py
@@ -19,7 +19,6 @@ from olympia.lib.settings_base import *  # noqa
 DEV_MODE = DOCKER_TARGET != 'production'
 
 HOST_UID = os.environ.get('HOST_UID')
-HOST_MOUNT = os.environ.get('HOST_MOUNT')
 
 WSGI_APPLICATION = 'olympia.wsgi.application'
 

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -73,7 +73,6 @@ DEV_MODE = False
 
 # Host info that is hard coded for production images.
 HOST_UID = None
-HOST_MOUNT = None
 
 # Used to determine if django should serve static files.
 # For local deployments we want nginx to proxy static file requests to the

--- a/tests/make/make.spec.js
+++ b/tests/make/make.spec.js
@@ -34,7 +34,10 @@ function getConfig(env = {}) {
   );
   try {
     if (rawError) throw new Error(rawError);
-    return JSON.parse(rawConfig);
+    return {
+      config: JSON.parse(rawConfig),
+      env: rawEnv,
+    };
   } catch (error) {
     throw new Error(
       JSON.stringify({ error, rawConfig, rawError, rawEnv }, null, 2),
@@ -42,36 +45,45 @@ function getConfig(env = {}) {
   }
 }
 
+function permutations(configObj) {
+  return Object.entries(configObj).reduce((acc, [key, values]) => {
+    if (!acc.length) return values.map((value) => ({ [key]: value }));
+    return acc.flatMap((obj) =>
+      values.map((value) => ({ ...obj, [key]: value })),
+    );
+  }, []);
+}
+
 describe('docker-compose.yml', () => {
   afterAll(() => {
     clearEnv();
   });
 
-  describe.each([
-    ['development', 'development'],
-    ['development', 'production'],
-    ['production', 'development'],
-    ['production', 'production'],
-  ])('DOCKER_TARGET=%s, OLYMPIA_MOUNT=%s', (DOCKER_TARGET, OLYMPIA_MOUNT) => {
-    const isProdTarget = DOCKER_TARGET === 'production';
-    const isProdMount = OLYMPIA_MOUNT === 'production';
-    const isProdMountTarget = isProdMount && isProdTarget;
+  describe.each(
+    permutations({
+      DOCKER_TARGET: ['development', 'production'],
+      DOCKER_VERSION: ['local', 'latest'],
+    }),
+  )('\n%s\n', (config) => {
+    const { DOCKER_TARGET, DOCKER_VERSION } = config;
 
     const inputValues = {
       DOCKER_TARGET,
-      OLYMPIA_MOUNT,
-      DOCKER_TAG: 'mozilla/addons-server:tag',
+      DOCKER_VERSION,
       DEBUG: 'debug',
       DATA_BACKUP_SKIP: 'skip',
     };
 
     it('.services.(web|worker) should have the correct configuration', () => {
       const {
-        services: { web, worker },
+        config: {
+          services: { web, worker },
+        },
+        env: { DOCKER_TAG },
       } = getConfig(inputValues);
 
       for (let service of [web, worker]) {
-        expect(service.image).toStrictEqual(inputValues.DOCKER_TAG);
+        expect(service.image).toStrictEqual(DOCKER_TAG);
         expect(service.pull_policy).toStrictEqual('never');
         expect(service.user).toStrictEqual('root');
         expect(service.platform).toStrictEqual('linux/amd64');
@@ -101,16 +113,13 @@ describe('docker-compose.yml', () => {
         expect(service.volumes).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              source: isProdMountTarget ? 'data_olympia_' : expect.any(String),
-              target: '/data/olympia',
-            }),
-            expect.objectContaining({
               source: expect.any(String),
-              target: '/data/olympia/storage',
+              target: '/data/olympia',
             }),
           ]),
         );
-        const { OLYMPIA_MOUNT, ...environmentOutput } = inputValues;
+        const { DOCKER_VERSION, DOCKER_TARGET, ...environmentOutput } =
+          inputValues;
         expect(service.environment).toEqual(
           expect.objectContaining({
             ...environmentOutput,
@@ -119,24 +128,13 @@ describe('docker-compose.yml', () => {
         // We excpect not to pass the input values to the container
         expect(service.environment).not.toHaveProperty('OLYMPIA_UID');
       }
-
-      expect(web.volumes).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            source: expect.any(String),
-            target: '/data/olympia/static-build',
-          }),
-          expect.objectContaining({
-            source: expect.any(String),
-            target: '/data/olympia/site-static',
-          }),
-        ]),
-      );
     });
 
     it('.services.nginx should have the correct configuration', () => {
       const {
-        services: { nginx },
+        config: {
+          services: { nginx },
+        },
       } = getConfig(inputValues);
       // nginx is mapped from http://olympia.test to port 80 in /etc/hosts on the host
       expect(nginx.ports).toStrictEqual([
@@ -154,72 +152,19 @@ describe('docker-compose.yml', () => {
             source: 'data_nginx',
             target: '/etc/nginx/conf.d',
           }),
-          // mapping for local host directory to /data/olympia
+          // mapping for /data/olympia/ directory to /srv
           expect.objectContaining({
-            source: isProdMountTarget ? 'data_olympia_' : expect.any(String),
+            source: expect.any(String),
             target: '/srv',
-          }),
-          expect.objectContaining({
-            source: expect.any(String),
-            target: '/srv/site-static',
-          }),
-          // mapping for local host directory to /data/olympia/storage
-          expect.objectContaining({
-            source: expect.any(String),
-            target: '/srv/storage',
           }),
         ]),
       );
     });
 
-    it('.services.*.volumes duplicate volumes should be defined on services.olympia_volumes.volumes', () => {
-      const key = 'olympia_volumes';
-      const { services } = getConfig(inputValues);
-      // all volumes defined on any service other than olympia
-      const volumesMap = new Map();
-      // volumes defined on the olympia service, any dupes in other services should be here also
-      const olympiaVolumes = new Set();
-
-      for (let [name, config] of Object.entries(services)) {
-        for (let volume of config.volumes ?? []) {
-          if (volume.bind) continue;
-          const source = volume.source || volume.target;
-
-          if (name === key) {
-            olympiaVolumes.add(source);
-          } else {
-            const set = volumesMap.get(source) ?? new Set();
-            volumesMap.set(source, set.add(name));
-          }
-        }
-      }
-
-      // duplicate volumes should be defined on the olympia service
-      // to ensure that the volume is mounted by docker before any
-      // other service tries to use it.
-      for (let [source, services] of volumesMap) {
-        if (services.size > 1 && !olympiaVolumes.has(source)) {
-          const serviceNames = [...services].join(', ');
-          throw new Error(
-            `.services.${key}.volumes missing '${source}' used by '${serviceNames}'`,
-          );
-        }
-      }
-
-      // any service that depends on a duplicate volume must also depend on olympia
-      for (let source of olympiaVolumes) {
-        for (let name of volumesMap.get(source) ?? []) {
-          if (!services[name]?.depends_on?.[key]) {
-            throw new Error(
-              `'.services.${name}.depends_on' missing '${key}' for shared volume '${source}'`,
-            );
-          }
-        }
-      }
-    });
-
     it('.services.*.volumes does not contain anonymous or unnamed volumes', () => {
-      const { services } = getConfig(inputValues);
+      const {
+        config: { services },
+      } = getConfig(inputValues);
       for (let [name, config] of Object.entries(services)) {
         for (let volume of config.volumes ?? []) {
           if (!volume.bind && !volume.source) {
@@ -238,7 +183,9 @@ describe('docker-compose.yml', () => {
     // and should not be able to deviate from the state at build time.
     it('.services.(web|worker).environment excludes build info variables', () => {
       const {
-        services: { web, worker },
+        config: {
+          services: { web, worker },
+        },
       } = getConfig({
         ...inputValues,
         ...Object.fromEntries(EXCLUDED_KEYS.map((key) => [key, 'filtered'])),
@@ -255,16 +202,12 @@ describe('docker-compose.yml', () => {
   const failKeys = [
     // Invalid docker tag leads to docker not parsing the image
     'DOCKER_TAG',
-    // Value is read directly as the volume source for /data/olympia and must be valid
-    'HOST_MOUNT_SOURCE',
   ];
   const ignoreKeys = [
     // Ignored because these values are explicitly mapped to the host_* values
     'OLYMPIA_UID',
-    'OLYMPIA_MOUNT',
     // Ignored because the HOST_UID is always set to the host user's UID
     'HOST_UID',
-    'HOST_MOUNT',
   ];
   const defaultEnv = runSetup();
   const customValue = 'custom';
@@ -281,7 +224,9 @@ describe('docker-compose.yml', () => {
       } else if (ignoreKeys.includes(key)) {
         it('variable should be ignored', () => {
           const {
-            services: { web, worker },
+            config: {
+              services: { web, worker },
+            },
           } = getConfig({ ...defaultEnv, [key]: customValue });
           for (let service of [web, worker]) {
             expect(service.environment).not.toEqual(
@@ -294,7 +239,9 @@ describe('docker-compose.yml', () => {
       } else {
         it('variable should be overriden based on the input', () => {
           const {
-            services: { web, worker },
+            config: {
+              services: { web, worker },
+            },
           } = getConfig({ ...defaultEnv, [key]: customValue });
           for (let service of [web, worker]) {
             expect(service.environment).toEqual(

--- a/tests/make/test_setup.py
+++ b/tests/make/test_setup.py
@@ -2,7 +2,7 @@ import os
 import unittest
 from unittest import mock
 
-from scripts.setup import get_docker_tag, main
+from scripts.setup import get_docker_image_meta, main
 from tests import override_env
 
 
@@ -10,8 +10,6 @@ keys = [
     'DOCKER_TAG',
     'DOCKER_TARGET',
     'HOST_UID',
-    'HOST_MOUNT',
-    'HOST_MOUNT_SOURCE',
     'OLYMPIA_DEPS',
     'DEBUG',
 ]
@@ -35,83 +33,103 @@ class BaseTestClass(unittest.TestCase):
 @override_env()
 class TestGetDockerTag(BaseTestClass):
     def test_default_value_is_local(self):
-        tag, version, digest = get_docker_tag()
+        tag, target, version, digest = get_docker_image_meta()
         self.assertEqual(tag, 'mozilla/addons-server:local')
+        self.assertEqual(target, 'development')
         self.assertEqual(version, 'local')
         self.assertEqual(digest, None)
 
+        with override_env(DOCKER_TARGET='production'):
+            _, target, _, _ = get_docker_image_meta()
+            self.assertEqual(target, 'production')
+
     @override_env(DOCKER_VERSION='test')
     def test_version_overrides_default(self):
-        tag, version, digest = get_docker_tag()
+        tag, target, version, digest = get_docker_image_meta()
         self.assertEqual(tag, 'mozilla/addons-server:test')
+        self.assertEqual(target, 'production')
         self.assertEqual(version, 'test')
         self.assertEqual(digest, None)
 
     @override_env(DOCKER_DIGEST='sha256:123')
     def test_digest_overrides_version_and_default(self):
-        tag, version, digest = get_docker_tag()
+        tag, target, version, digest = get_docker_image_meta()
         self.assertEqual(tag, 'mozilla/addons-server@sha256:123')
+        self.assertEqual(target, 'production')
         self.assertEqual(version, None)
         self.assertEqual(digest, 'sha256:123')
 
         with override_env(DOCKER_VERSION='test', DOCKER_DIGEST='sha256:123'):
-            tag, version, digest = get_docker_tag()
+            tag, target, version, digest = get_docker_image_meta()
             self.assertEqual(tag, 'mozilla/addons-server@sha256:123')
+            self.assertEqual(target, 'production')
             self.assertEqual(version, None)
             self.assertEqual(digest, 'sha256:123')
 
     @override_env(DOCKER_TAG='image:latest')
     def test_tag_overrides_default_version(self):
-        tag, version, digest = get_docker_tag()
+        tag, target, version, digest = get_docker_image_meta()
         self.assertEqual(tag, 'image:latest')
+        self.assertEqual(target, 'production')
         self.assertEqual(version, 'latest')
         self.assertEqual(digest, None)
 
         with override_env(DOCKER_TAG='image:latest', DOCKER_VERSION='test'):
-            tag, version, digest = get_docker_tag()
+            tag, target, version, digest = get_docker_image_meta()
             self.assertEqual(tag, 'image:test')
+            self.assertEqual(target, 'production')
             self.assertEqual(version, 'test')
             self.assertEqual(digest, None)
 
     @override_env(DOCKER_TAG='image@sha256:123')
     def test_tag_overrides_default_digest(self):
-        tag, version, digest = get_docker_tag()
+        tag, target, version, digest = get_docker_image_meta()
         self.assertEqual(tag, 'image@sha256:123')
+        self.assertEqual(target, 'production')
         self.assertEqual(version, None)
         self.assertEqual(digest, 'sha256:123')
 
         with mock.patch.dict(os.environ, {'DOCKER_DIGEST': 'test'}):
-            tag, version, digest = get_docker_tag()
+            tag, target, version, digest = get_docker_image_meta()
             self.assertEqual(tag, 'image@test')
+            self.assertEqual(target, 'production')
             self.assertEqual(version, None)
             self.assertEqual(digest, 'test')
 
     def test_version_from_env_file(self):
         self.mock_get_env_file.return_value = {'DOCKER_TAG': 'image:latest'}
-        tag, version, digest = get_docker_tag()
+        tag, target, version, digest = get_docker_image_meta()
         self.assertEqual(tag, 'image:latest')
+        self.assertEqual(target, 'production')
         self.assertEqual(version, 'latest')
         self.assertEqual(digest, None)
 
     def test_digest_from_env_file(self):
         self.mock_get_env_file.return_value = {'DOCKER_TAG': 'image@sha256:123'}
-        tag, version, digest = get_docker_tag()
+        tag, target, version, digest = get_docker_image_meta()
         self.assertEqual(tag, 'image@sha256:123')
+        self.assertEqual(target, 'production')
         self.assertEqual(version, None)
         self.assertEqual(digest, 'sha256:123')
 
     @override_env(DOCKER_VERSION='')
     def test_default_when_version_is_empty(self):
-        tag, version, digest = get_docker_tag()
+        tag, target, version, digest = get_docker_image_meta()
         self.assertEqual(tag, 'mozilla/addons-server:local')
+        self.assertEqual(target, 'development')
         self.assertEqual(version, 'local')
         self.assertEqual(digest, None)
+
+        with override_env(DOCKER_VERSION='', DOCKER_TARGET='production'):
+            _, target, _, _ = get_docker_image_meta()
+            self.assertEqual(target, 'production')
 
     @override_env(DOCKER_DIGEST='', DOCKER_TAG='image@sha256:123')
     def test_default_when_digest_is_empty(self):
         self.mock_get_env_file.return_value = {'DOCKER_TAG': 'image@sha256:123'}
-        tag, version, digest = get_docker_tag()
+        tag, target, version, digest = get_docker_image_meta()
         self.assertEqual(tag, 'image@sha256:123')
+        self.assertEqual(target, 'production')
         self.assertEqual(version, None)
         self.assertEqual(digest, 'sha256:123')
 
@@ -162,44 +180,6 @@ class TestDebug(BaseTestClass):
     def test_debug_override(self):
         main()
         self.assert_set_env_file_called_with(DEBUG='test')
-
-
-@override_env()
-class TestHostMount(BaseTestClass):
-    def test_default_host_mount(self):
-        main()
-        self.assert_set_env_file_called_with(
-            HOST_MOUNT='development', HOST_MOUNT_SOURCE='./'
-        )
-
-    @override_env(DOCKER_TARGET='production')
-    def test_host_mount_set_by_docker_target(self):
-        main()
-        self.assert_set_env_file_called_with(
-            HOST_MOUNT='production', HOST_MOUNT_SOURCE='data_olympia_'
-        )
-
-    @override_env(DOCKER_TARGET='production', OLYMPIA_MOUNT='test')
-    def test_invalid_host_mount_set_by_env_ignored(self):
-        main()
-        self.assert_set_env_file_called_with(
-            HOST_MOUNT='production', HOST_MOUNT_SOURCE='data_olympia_'
-        )
-
-    @override_env(DOCKER_TARGET='development', OLYMPIA_MOUNT='production')
-    def test_host_mount_overriden_by_development_target(self):
-        main()
-        self.assert_set_env_file_called_with(
-            HOST_MOUNT='development', HOST_MOUNT_SOURCE='./'
-        )
-
-    @override_env(DOCKER_TARGET='production')
-    def test_host_mount_from_file_ignored(self):
-        self.mock_get_env_file.return_value = {'HOST_MOUNT': 'development'}
-        main()
-        self.assert_set_env_file_called_with(
-            HOST_MOUNT='production', HOST_MOUNT_SOURCE='data_olympia_'
-        )
 
 
 @override_env()


### PR DESCRIPTION
Fixes: https://github.com/mozilla/addons/issues/15066

### Description

- Updated docker-compose.yml to simplify volume mounts by using the current directory for all services.
- Removed HOST_MOUNT and HOST_MOUNT_SOURCE environment variables from settings and entrypoint scripts, streamlining the configuration for local and production environments.
- Refactored setup.py to eliminate the get_olympia_mount function, replacing it with a more straightforward approach to determine the Docker target.
- Adjusted GitHub Actions workflows to remove references to the obsolete mount input, ensuring cleaner CI/CD processes.
- Enhanced test cases to reflect changes in Docker configuration and environment variable handling.

### Context

This patch drastically simplifies how we mount files into docker containers:
- there is a single bind mount from the root repo into any and all containers that need files.
- every container expects to find files at /data/olympia/**
- the mount is always on, we preemptively configure the host file system to reflect the desired container state so we can straight mount the files when running the containers

> [!WARNING]
> This means that the state of your host and the state of containers is 100% matching. so running remote built production containers require first checking out the commit that image was built on. This can be done manually right now and could be automated in the future. 

### Testing

Running make up in prod or dev mode will result in the exact same state where the root repo directory is mounted into /data/olympia no matter what.

### Checklist

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
