### PR TITLE
Add npm dependencies in the production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -198,5 +198,7 @@ COPY --from=assets --chown=olympia:olympia ${HOME}/static-build ${HOME}/static-b
 COPY --from=info ${BUILD_INFO} ${BUILD_INFO}
 # Copy compiled locales from builder
 COPY --from=locales --chown=olympia:olympia ${HOME}/locale ${HOME}/locale
-# Copy dependencies from `pip_production`
+# Copy pip dependencies from `pip_production`
 COPY --from=pip_production --chown=olympia:olympia ${DEPS_DIR} ${DEPS_DIR}
+# Copy npm dependencies from `pip_production`
+COPY --from=pip_production --chown=olympia:olympia ${NPM_DEPS_DIR} ${NPM_DEPS_DIR}


### PR DESCRIPTION
Fixes: mozilla/addons#15314
Fixes: https://github.com/mozilla/addons/issues/15315

### Description

This stops the bleeding but we will need a better test for the production image that does not rely on mounted data.

### Context

After moving node_modules to no longer be a dependency of /deps we need to explcitly copy both directories to the final production stage.

This was not caught so far because our CI checks are using make up which re-runs the build steps ensuring those files exist in the mount. We should run without a mount the same checks to verify the pure production image.

https://mozilla.sentry.io/issues/6254859352/?project=6224627&referrer=slack

### Testing

You can run the build locally and inspect the files.. you cannot use make up for this because it mounts the files.

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
