### PR TITLE
Ensure we clear stashes when uploading new blocklist filters

### DIFF
--- a/src/olympia/blocklist/cron.py
+++ b/src/olympia/blocklist/cron.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import List
 
 import waffle
 from django_statsd.clients import statsd
@@ -8,6 +7,7 @@ import olympia.core.logger
 from olympia.constants.blocklist import (
     MLBF_BASE_ID_CONFIG_KEY,
     MLBF_TIME_CONFIG_KEY,
+    BlockListAction,
 )
 from olympia.zadmin.models import get_config
 
@@ -74,8 +74,9 @@ def _upload_mlbf_to_remote_settings(*, force_base=False):
     )
 
     base_filters: dict[BlockType, MLBF | None] = {key: None for key in BlockType}
-    base_filters_to_update: List[BlockType] = []
-    create_stash = False
+
+    upload_filters = False
+    upload_stash = False
 
     # Determine which base filters need to be re uploaded
     # and whether a new stash needs to be created.
@@ -93,20 +94,26 @@ def _upload_mlbf_to_remote_settings(*, force_base=False):
         base_filter = MLBF.load_from_storage(get_base_generation_time(block_type))
         base_filters[block_type] = base_filter
 
-        # Add this block type to the list of filters to be re-uploaded.
+        # For now we upload both filters together when either exceeds
+        # the change threshold. Additionally we brute force clear all stashes
+        # when uploading filters. This is the easiest way to ensure that stashes
+        # are always newer than any existing filters, a requirement of the way
+        # FX is reading the blocklist stash and filter sets.
+        # We may attempt handling block types separately in the future as a
+        # performance optimization https://github.com/mozilla/addons/issues/15217.
         if (
             force_base
             or base_filter is None
             or mlbf.should_upload_filter(block_type, base_filter)
         ):
-            base_filters_to_update.append(block_type)
+            upload_filters = True
+            upload_stash = False
         # Only update the stash if we should AND if we aren't already
-        # re-uploading the filter for this block type.
+        # re-uploading the filters.
         elif mlbf.should_upload_stash(block_type, previous_filter or base_filter):
-            create_stash = True
+            upload_stash = True
 
-    skip_update = len(base_filters_to_update) == 0 and not create_stash
-    if skip_update:
+    if not upload_filters and not upload_stash:
         log.info('No new/modified/deleted Blocks in database; skipping MLBF generation')
         # Delete the locally generated MLBF directory and files as they are not needed.
         mlbf.delete()
@@ -125,7 +132,19 @@ def _upload_mlbf_to_remote_settings(*, force_base=False):
         len(mlbf.data.not_blocked_items),
     )
 
-    if create_stash:
+    if upload_filters:
+        for block_type in BlockType:
+            mlbf.generate_and_write_filter(block_type)
+
+        # Upload both filters and clear the stash to keep
+        # all of the records in sync with the expectations of FX.
+        actions = [
+            BlockListAction.UPLOAD_BLOCKED_FILTER,
+            BlockListAction.UPLOAD_SOFT_BLOCKED_FILTER,
+            BlockListAction.CLEAR_STASH,
+        ]
+
+    elif upload_stash:
         # We generate unified stashes, which means they can contain data
         # for both soft and hard blocks. We need the base filters of each
         # block type to determine what goes in a stash.
@@ -134,15 +153,12 @@ def _upload_mlbf_to_remote_settings(*, force_base=False):
             blocked_base_filter=base_filters[BlockType.BLOCKED],
             soft_blocked_base_filter=base_filters[BlockType.SOFT_BLOCKED],
         )
+        actions = [
+            BlockListAction.UPLOAD_STASH,
+        ]
 
-    for block_type in base_filters_to_update:
-        mlbf.generate_and_write_filter(block_type)
-
-    upload_filter.delay(
-        mlbf.created_at,
-        filter_list=[key.name for key in base_filters_to_update],
-        create_stash=create_stash,
-    )
+    # Serialize the actions to strings because celery doesn't support enums.
+    upload_filter.delay(mlbf.created_at, actions=[action.name for action in actions])
 
 
 def process_blocklistsubmissions():

--- a/src/olympia/blocklist/cron.py
+++ b/src/olympia/blocklist/cron.py
@@ -81,16 +81,6 @@ def _upload_mlbf_to_remote_settings(*, force_base=False):
     # Determine which base filters need to be re uploaded
     # and whether a new stash needs to be created.
     for block_type in BlockType:
-        # This prevents us from updating a stash or filter based on new soft blocks
-        # until we are ready to enable soft blocking.
-        if block_type == BlockType.SOFT_BLOCKED and not waffle.switch_is_active(
-            'enable-soft-blocking'
-        ):
-            log.info(
-                'Skipping soft-blocks because enable-soft-blocking switch is inactive'
-            )
-            continue
-
         base_filter = MLBF.load_from_storage(get_base_generation_time(block_type))
         base_filters[block_type] = base_filter
 

--- a/src/olympia/blocklist/mlbf.py
+++ b/src/olympia/blocklist/mlbf.py
@@ -7,7 +7,6 @@ from typing import Dict, List, Optional, Tuple
 
 from django.utils.functional import cached_property
 
-import waffle
 from filtercascade import FilterCascade
 from filtercascade.fileformats import HashAlgorithm
 
@@ -352,14 +351,13 @@ class MLBF:
             stash_json[STASH_KEYS[BlockType.BLOCKED]] = blocked_added
             stash_json[UNBLOCKED_STASH_KEY] = blocked_removed
 
-        if waffle.switch_is_active('enable-soft-blocking'):
-            soft_blocked_added, soft_blocked_removed, _ = diffs[BlockType.SOFT_BLOCKED]
-            added_items.update(soft_blocked_added)
-            if not self.should_upload_filter(
-                BlockType.SOFT_BLOCKED, soft_blocked_base_filter
-            ):
-                stash_json[STASH_KEYS[BlockType.SOFT_BLOCKED]] = soft_blocked_added
-                stash_json[UNBLOCKED_STASH_KEY].extend(soft_blocked_removed)
+        soft_blocked_added, soft_blocked_removed, _ = diffs[BlockType.SOFT_BLOCKED]
+        added_items.update(soft_blocked_added)
+        if not self.should_upload_filter(
+            BlockType.SOFT_BLOCKED, soft_blocked_base_filter
+        ):
+            stash_json[STASH_KEYS[BlockType.SOFT_BLOCKED]] = soft_blocked_added
+            stash_json[UNBLOCKED_STASH_KEY].extend(soft_blocked_removed)
 
         # Remove any items that were added to a block type.
         stash_json[UNBLOCKED_STASH_KEY] = [

--- a/src/olympia/constants/blocklist.py
+++ b/src/olympia/constants/blocklist.py
@@ -1,4 +1,6 @@
 # How many guids should there be in the stashes before we make a new base.
+from enum import Enum
+
 from olympia.blocklist.models import BlockType
 
 
@@ -20,3 +22,14 @@ def MLBF_BASE_ID_CONFIG_KEY(block_type: BlockType, compat: bool = False):
 
 
 REMOTE_SETTINGS_COLLECTION_MLBF = 'addons-bloomfilters'
+
+
+class BlockListAction(Enum):
+    # Re-upload the Blocked filter
+    UPLOAD_BLOCKED_FILTER = 'upload_blocked_filter'
+    # Re-upload the Soft Blocked filter
+    UPLOAD_SOFT_BLOCKED_FILTER = 'upload_soft_blocked_filter'
+    # Upload a new stash entry
+    UPLOAD_STASH = 'upload_stash'
+    # Clear the Stash (clear all stashes)
+    CLEAR_STASH = 'clear_stash'


### PR DESCRIPTION
Fixes: mozilla/addons#15294

### Description

- Adding a new `BlockListAction` enum to define specific upload actions
- Refactoring "upload_filter" to accept a programmable set of "actions" simplifying the underlying logic and making future modifications to how and what we upload easier to control from the cron
- Change business logic in "upload_mlbf_to_remote_settings" to upload either both filters if either filter exceeds the replace threshold, simplifying the cleanup logic for stashes in "upload_filter"

### Context

Why add `actions`. The reason two fold. 1) This is very readable and makes it clear what we expect `upload_filter` to do. 2) In a future where we want a more granular or sophisticated set of actions to perform, we can add them without greatly interrupting the existing set of code. This will make further improvements simpler and easier to review.

### Testing

In a nutshell, use all of [these scenarios](https://github.com/mozilla/addons/issues/15014) excepting:
- for any case where we would have uploaded a filter and a stash, now we upload 2 filters.
- when we upload a filter, we expect both filters to be uploaded and for all previous records to be removed from remote settings

You can follow setup instructions [here](https://github.com/mozilla/addons-server/pull/22828)

> [!NOTE]
> You won't need to set `enable-soft-blocking` any more as that switch is removed in this patch 

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
