### PR TITLE
Clear pending rejections & set human review date in `approve_multiple_versions()`

### DIFF
--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -2879,7 +2879,9 @@ class TestReviewHelper(TestReviewHelperBase):
         # This version wasn't part of the version we're approving so it should
         # not have changed status, and shouldn't get a human review date.
         assert wont_be_approved_version.reload().human_review_date is None
-        assert wont_be_approved_version.file.reload().status == amo.STATUS_AWAITING_REVIEW
+        assert (
+            wont_be_approved_version.file.reload().status == amo.STATUS_AWAITING_REVIEW
+        )
 
     def test_approve_multiple_versions_unlisted(self):
         expected_versions = self._approve_multiple_versions_unlisted()

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -2821,15 +2821,37 @@ class TestReviewHelper(TestReviewHelperBase):
         assert self.check_log_count(amo.LOG.UNREJECT_VERSION.id) == 1
 
     def test_approve_multiple_versions_unlisted(self):
-        old_version = self.review_version
         self.make_addon_unlisted(self.addon)
+        old_version = self.review_version.reload()
+        extra_version = version_factory(
+            addon=self.addon,
+            version='1.987',
+            channel=amo.CHANNEL_UNLISTED,
+            file_kw={'status': amo.STATUS_AWAITING_REVIEW},
+        )
+        version_pending_rejection = version_factory(
+            addon=self.addon,
+            version='2.99',
+            channel=amo.CHANNEL_UNLISTED,
+            file_kw={'status': amo.STATUS_AWAITING_REVIEW},
+        )
+        VersionReviewerFlags.objects.create(
+            version=version_pending_rejection,
+            pending_rejection=datetime.now() + timedelta(days=1),
+            pending_rejection_by=self.user,
+            pending_content_rejection=False,
+        )
         self.review_version = version_factory(
             addon=self.addon,
             version='3.0',
             channel=amo.CHANNEL_UNLISTED,
             file_kw={'status': amo.STATUS_AWAITING_REVIEW},
         )
-        self.setup_data(amo.STATUS_NULL, file_status=amo.STATUS_AWAITING_REVIEW)
+        self.setup_data(
+            amo.STATUS_NULL,
+            file_status=amo.STATUS_AWAITING_REVIEW,
+            channel=amo.CHANNEL_UNLISTED,
+        )
         AddonReviewerFlags.objects.create(
             addon=self.addon,
             auto_approval_disabled_until_next_approval=True,
@@ -2841,8 +2863,13 @@ class TestReviewHelper(TestReviewHelperBase):
         assert self.addon.status == amo.STATUS_NULL
         assert self.file.status == amo.STATUS_AWAITING_REVIEW
 
+        expected_versions = [
+            self.review_version,
+            version_pending_rejection,
+            old_version,
+        ]
         data = self.get_data().copy()
-        data['versions'] = self.addon.versions.all()
+        data['versions'] = expected_versions
         self.helper.set_data(data)
         self.helper.handler.approve_multiple_versions()
 
@@ -2850,8 +2877,19 @@ class TestReviewHelper(TestReviewHelperBase):
         self.file.reload()
         assert self.addon.status == amo.STATUS_NULL
         assert self.addon.current_version is None
-        assert list(self.addon.versions.all()) == [self.review_version, old_version]
         assert self.file.status == amo.STATUS_APPROVED
+        for version in expected_versions:
+            version.reload()
+            version.file.reload()
+            try:
+                version.reviewerflags.reload()
+            except VersionReviewerFlags.DoesNotExist:
+                pass
+            assert version.file.status == amo.STATUS_APPROVED
+            self.assertCloseToNow(version.human_review_date)
+            assert version.pending_rejection is None
+            assert version.pending_content_rejection is None
+            assert version.pending_rejection_by is None
 
         # unlisted auto approvals should be enabled again
         flags = self.addon.reviewerflags
@@ -2876,7 +2914,13 @@ class TestReviewHelper(TestReviewHelperBase):
             .get()
         )
         decision = ContentDecision.objects.get()
-        assert log.arguments == [self.addon, self.review_version, old_version, decision]
+        assert log.arguments == [
+            self.addon,
+            self.review_version,
+            version_pending_rejection,
+            old_version,
+            decision,
+        ]
 
     def test_reject_multiple_versions_unlisted(self):
         old_version = self.review_version

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -2891,6 +2891,9 @@ class TestReviewHelper(TestReviewHelperBase):
             assert version.pending_content_rejection is None
             assert version.pending_rejection_by is None
 
+        assert extra_version.reload().human_review_date is None
+        assert extra_version.file.reload().status == amo.STATUS_AWAITING_REVIEW
+
         # unlisted auto approvals should be enabled again
         flags = self.addon.reviewerflags
         flags.reload()

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -1700,36 +1700,43 @@ class ReviewFiles(ReviewBase):
 
 
 class ReviewUnlisted(ReviewBase):
-    def approve_latest_version(self):
-        """Set an unlisted addon version files to public."""
-        assert self.version.channel == amo.CHANNEL_UNLISTED
-
-        # Sign addon.
-        self.sign_file()
-        if self.file:
+    def _approve_version(self, version):
+        assert version.channel == amo.CHANNEL_UNLISTED
+        assert not version.is_blocked
+        if version.file and version.file.status == amo.STATUS_AWAITING_REVIEW:
+            sign_file(version.file)
             ActivityLog.objects.create(
-                amo.LOG.UNLISTED_SIGNED, self.file, user=self.user
+                amo.LOG.UNLISTED_SIGNED, version.file, user=self.user
             )
-
-        self.set_file(amo.STATUS_APPROVED, self.file)
+            self.set_file(amo.STATUS_APPROVED, version.file)
 
         if self.human_review:
-            self.set_promoted()
-            self.clear_specific_needs_human_review_flags(self.version)
+            self.clear_specific_needs_human_review_flags(version)
 
             # Clear pending rejection since we approved that version.
-            VersionReviewerFlags.objects.filter(version=self.version).update(
+            VersionReviewerFlags.objects.filter(version=version).update(
                 pending_rejection=None,
                 pending_rejection_by=None,
                 pending_content_rejection=None,
             )
+
+            self.set_human_review_date(version)
+
+    def approve_latest_version(self):
+        """Set an unlisted addon version files to public."""
+        assert self.version.channel == amo.CHANNEL_UNLISTED
+
+        # Do all main approval bits.
+        self._approve_version(self.version)
+
+        if self.human_review:
+            self.set_promoted()
 
             # An approval took place so we can reset this.
             AddonReviewerFlags.objects.update_or_create(
                 addon=self.addon,
                 defaults={'auto_approval_disabled_until_next_approval_unlisted': False},
             )
-            self.set_human_review_date()
         elif (
             not self.version.needshumanreview_set.filter(is_active=True)
             and (delay := self.addon.auto_approval_delayed_until_unlisted)
@@ -1795,16 +1802,7 @@ class ReviewUnlisted(ReviewBase):
             return
 
         for version in versions:
-            # Sign addon.
-            assert not version.is_blocked
-            if version.file.status == amo.STATUS_AWAITING_REVIEW:
-                sign_file(version.file)
-            ActivityLog.objects.create(
-                amo.LOG.UNLISTED_SIGNED, version.file, user=self.user
-            )
-            self.set_file(amo.STATUS_APPROVED, version.file)
-            if self.human_review:
-                self.clear_specific_needs_human_review_flags(version)
+            self._approve_version(version)
             log.info('Making %s files %s public' % (self.addon, version.file.file.name))
 
         if self.human_review:


### PR DESCRIPTION
Reduce duplication between `approve_latest_version()` and `approve_multiple_versions()` to hopefully reduce the chance of similar discrepancies happening in the future - Only the latter was affected by this bug.

Fixes mozilla/addons/issues/15097

### Testing

- As a developer, submit an initial version of an add-on choosing "On your own" as the distribution method (unlisted).
- As a reviewer, delay reject that version
- As a developer, submit another version of that same add-on, still unlisted
- As a reviewer, select approve multiple versions and approve both versions (including the one currently being pending rejection)

It should approve both versions, clear reviewer flag preventing future auto-approvals, and more importantly, clear the pending rejection on the initial version.