### PR TITLE
Allow regular reviewers to delay-reject again without changing the date

### DIFF
--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -19,6 +19,7 @@ import markupsafe
 import olympia.core.logger
 from olympia import amo, ratings
 from olympia.abuse.models import CinderJob, CinderPolicy
+from olympia.access import acl
 from olympia.amo.forms import AMOModelForm
 from olympia.constants.reviewers import REVIEWER_DELAYED_REJECTION_PERIOD_DAYS_DEFAULT
 from olympia.files.utils import SafeZip
@@ -573,17 +574,29 @@ class ReviewForm(forms.Form):
         self.helper = kw.pop('helper')
         super().__init__(*args, **kw)
         if any(action.get('delayable') for action in self.helper.actions.values()):
-            # Minimum delayed rejection date should be in the future.
-            self.min_rejection_date = datetime.now() + timedelta(days=1)
-            self.fields['delayed_rejection_date'].widget.attrs['min'] = (
-                self.min_rejection_date.isoformat()[:16]
-            )
             # Default delayed rejection date should be
             # REVIEWER_DELAYED_REJECTION_PERIOD_DAYS_DEFAULT days in the
             # future plus one hour to account for the time it's taking the
             # reviewer to actually perform the review.
-            self.fields['delayed_rejection_date'].initial = datetime.now() + timedelta(
+            now = datetime.now()
+            self.fields['delayed_rejection_date'].initial = now + timedelta(
                 days=REVIEWER_DELAYED_REJECTION_PERIOD_DAYS_DEFAULT, hours=1
+            )
+            delayed_rejection_date_widget_attrs = {}
+            if acl.action_allowed_for(self.helper.handler.user, amo.permissions.REVIEWS_ADMIN):
+                # If the reviewer is an admin, they can customize the date, we
+                # enforce reasonable min & max values on the widget.
+                self.min_rejection_date = now + timedelta(days=1)
+                self.max_rejection_date = now + timedelta(days=365)
+            else:
+                # Otherwise the widget should be readonly.
+                self.min_rejection_date = self.fields['delayed_rejection_date'].initial
+                self.max_rejection_date = self.fields['delayed_rejection_date'].initial
+                delayed_rejection_date_widget_attrs['readonly'] = 'readonly'
+            delayed_rejection_date_widget_attrs['min'] = self.min_rejection_date.isoformat()[:16]
+            delayed_rejection_date_widget_attrs['max'] = self.max_rejection_date.isoformat()[:16]
+            self.fields['delayed_rejection_date'].widget.attrs.update(
+                delayed_rejection_date_widget_attrs
             )
         else:
             # No delayable action available, remove the fields entirely.

--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -582,25 +582,16 @@ class ReviewForm(forms.Form):
             self.fields['delayed_rejection_date'].initial = now + timedelta(
                 days=REVIEWER_DELAYED_REJECTION_PERIOD_DAYS_DEFAULT, hours=1
             )
-            delayed_rejection_date_widget_attrs = {}
-            if acl.action_allowed_for(
+            # We enforce a reasonable min value on the widget.
+            self.min_rejection_date = now + timedelta(days=1)
+            delayed_rejection_date_widget_attrs = {
+                'min': self.min_rejection_date.isoformat()[:16],
+            }
+            if not acl.action_allowed_for(
                 self.helper.handler.user, amo.permissions.REVIEWS_ADMIN
             ):
-                # If the reviewer is an admin, they can customize the date, we
-                # enforce reasonable min & max values on the widget.
-                self.min_rejection_date = now + timedelta(days=1)
-                self.max_rejection_date = now + timedelta(days=365)
-            else:
-                # Otherwise the widget should be readonly.
-                self.min_rejection_date = self.fields['delayed_rejection_date'].initial
-                self.max_rejection_date = self.fields['delayed_rejection_date'].initial
+                # Non-admin reviewers can't customize the date.
                 delayed_rejection_date_widget_attrs['readonly'] = 'readonly'
-            delayed_rejection_date_widget_attrs['min'] = (
-                self.min_rejection_date.isoformat()[:16]
-            )
-            delayed_rejection_date_widget_attrs['max'] = (
-                self.max_rejection_date.isoformat()[:16]
-            )
             self.fields['delayed_rejection_date'].widget.attrs.update(
                 delayed_rejection_date_widget_attrs
             )

--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -583,7 +583,9 @@ class ReviewForm(forms.Form):
                 days=REVIEWER_DELAYED_REJECTION_PERIOD_DAYS_DEFAULT, hours=1
             )
             delayed_rejection_date_widget_attrs = {}
-            if acl.action_allowed_for(self.helper.handler.user, amo.permissions.REVIEWS_ADMIN):
+            if acl.action_allowed_for(
+                self.helper.handler.user, amo.permissions.REVIEWS_ADMIN
+            ):
                 # If the reviewer is an admin, they can customize the date, we
                 # enforce reasonable min & max values on the widget.
                 self.min_rejection_date = now + timedelta(days=1)
@@ -593,8 +595,12 @@ class ReviewForm(forms.Form):
                 self.min_rejection_date = self.fields['delayed_rejection_date'].initial
                 self.max_rejection_date = self.fields['delayed_rejection_date'].initial
                 delayed_rejection_date_widget_attrs['readonly'] = 'readonly'
-            delayed_rejection_date_widget_attrs['min'] = self.min_rejection_date.isoformat()[:16]
-            delayed_rejection_date_widget_attrs['max'] = self.max_rejection_date.isoformat()[:16]
+            delayed_rejection_date_widget_attrs['min'] = (
+                self.min_rejection_date.isoformat()[:16]
+            )
+            delayed_rejection_date_widget_attrs['max'] = (
+                self.max_rejection_date.isoformat()[:16]
+            )
             self.fields['delayed_rejection_date'].widget.attrs.update(
                 delayed_rejection_date_widget_attrs
             )

--- a/src/olympia/reviewers/tests/test_forms.py
+++ b/src/olympia/reviewers/tests/test_forms.py
@@ -1018,8 +1018,7 @@ class TestReviewForm(TestCase):
         assert 'delayed_rejection_date' in form.fields
         assert 'delayed_rejection' in form.fields
         assert form.fields['delayed_rejection_date'].widget.attrs == {
-            'min': '2025-02-24T13:09',
-            'max': '2025-02-24T13:09',
+            'min': '2025-02-11T12:09',
             'readonly': 'readonly',
         }
         assert form.fields['delayed_rejection_date'].initial == datetime(
@@ -1056,7 +1055,6 @@ class TestReviewForm(TestCase):
         assert 'delayed_rejection' in form.fields
         assert form.fields['delayed_rejection_date'].widget.attrs == {
             'min': '2025-01-24T12:52',
-            'max': '2026-01-23T12:52',
         }
         assert form.fields['delayed_rejection_date'].initial == datetime(
             2025, 2, 6, 13, 52

--- a/src/olympia/reviewers/tests/test_forms.py
+++ b/src/olympia/reviewers/tests/test_forms.py
@@ -355,6 +355,7 @@ class TestReviewForm(TestCase):
                 'action': 'reject_multiple_versions',
                 'comments': 'lol',
                 'versions': self.addon.versions.all(),
+                'delayed_rejection': 'False',
             }
         )
         assert form.is_bound
@@ -1001,6 +1002,7 @@ class TestReviewForm(TestCase):
                         canned_response='reason 1',
                     )
                 ],
+                'delayed_rejection': 'False',
             }
         )
         form.helper.actions['reject_multiple_versions']['versions'] = True
@@ -1008,13 +1010,41 @@ class TestReviewForm(TestCase):
         assert not form.is_valid()
         assert form.errors == {'versions': ['This field is required.']}
 
-    def test_delayed_rejection_days_doesnt_show_up_for_regular_reviewers(self):
-        # Regular reviewers can't customize the delayed rejection period so
-        # the field is removed at init for them.
+    @freeze_time('2025-02-10 12:09')
+    def test_delayed_rejection_date_is_readonly_for_regular_reviewers(self):
+        # Regular reviewers can't customize the delayed rejection period.
         self.grant_permission(self.request.user, 'Addons:Review')
         form = self.get_form()
-        assert 'delayed_rejection_date' not in form.fields
-        assert 'delayed_rejection' not in form.fields
+        assert 'delayed_rejection_date' in form.fields
+        assert 'delayed_rejection' in form.fields
+        assert form.fields['delayed_rejection_date'].widget.attrs == {
+            'min': '2025-02-24T13:09',
+            'max': '2025-02-24T13:09',
+            'readonly': 'readonly',
+        }
+        assert form.fields['delayed_rejection_date'].initial == datetime(
+            2025, 2, 24, 13, 9
+        )
+        content = str(form['delayed_rejection'])
+        doc = pq(content)
+        inputs = doc('input[type=radio]')
+        assert (
+            inputs[0].label.text_content().strip()
+            == 'Delay rejection, requiring developer to correct before…'
+        )
+        assert inputs[0].attrib['value'] == 'True'
+        assert inputs[1].label.text_content().strip() == 'Reject immediately.'
+        assert inputs[1].attrib['value'] == 'False'
+        assert inputs[1].attrib['checked'] == 'checked'
+        assert inputs[1].attrib['class'] == 'data-toggle'
+        assert inputs[1].attrib['data-value'] == 'reject_multiple_versions'
+        assert inputs[2].label.text_content().strip() == 'Clear pending rejection.'
+        assert inputs[2].attrib['value'] == ''
+        assert inputs[2].attrib['class'] == 'data-toggle'
+        assert (
+            inputs[2].attrib['data-value']
+            == 'change_or_clear_pending_rejection_multiple_versions'
+        )
 
     @freeze_time('2025-01-23 12:52')
     def test_delayed_rejection_days_shows_up_for_admin_reviewers(self):
@@ -1025,7 +1055,8 @@ class TestReviewForm(TestCase):
         assert 'delayed_rejection_date' in form.fields
         assert 'delayed_rejection' in form.fields
         assert form.fields['delayed_rejection_date'].widget.attrs == {
-            'min': '2025-01-24T12:52'
+            'min': '2025-01-24T12:52',
+            'max': '2026-01-23T12:52',
         }
         assert form.fields['delayed_rejection_date'].initial == datetime(
             2025, 2, 6, 13, 52

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -5241,7 +5241,6 @@ class TestReview(ReviewBase):
         assert doc('.data-toggle.review-files')[0].attrib['data-value'] == ''
         assert doc('.data-toggle.review-tested')[0].attrib['data-value'] == ''
 
-
     def test_test_data_value_attributes_admin(self):
         AutoApprovalSummary.objects.create(
             verdict=amo.AUTO_APPROVED, version=self.version

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -4541,6 +4541,7 @@ class TestReview(ReviewBase):
                 'comments': 'multireject!',
                 'reasons': [reason.id],
                 'versions': [old_version.pk, self.version.pk],
+                'delayed_rejection': 'False',
             },
         )
 
@@ -5229,12 +5230,17 @@ class TestReview(ReviewBase):
             ' '
         ) == ['reject_multiple_versions', 'reply']
 
+        assert doc('.data-toggle.review-delayed-rejection')[0].attrib[
+            'data-value'
+        ].split(' ') == [
+            'reject_multiple_versions',
+        ]
+
         # We don't have approve/reject actions so these have an empty
         # data-value.
         assert doc('.data-toggle.review-files')[0].attrib['data-value'] == ''
         assert doc('.data-toggle.review-tested')[0].attrib['data-value'] == ''
-        # Regular reviewer won't see delayed rejection inputs, need an admin.
-        assert not doc('.data-toggle.review-delayed-rejection')
+
 
     def test_test_data_value_attributes_admin(self):
         AutoApprovalSummary.objects.create(
@@ -5300,7 +5306,6 @@ class TestReview(ReviewBase):
         assert (
             doc('.data-toggle.review-tested')[0].attrib['data-value'] == 'disable_addon'
         )
-        # Admins can use delayed rejections
         assert doc('.data-toggle.review-delayed-rejection')[0].attrib[
             'data-value'
         ].split(' ') == [
@@ -5365,8 +5370,11 @@ class TestReview(ReviewBase):
         assert doc('.data-toggle.review-files')[0].attrib['data-value'] == ''
         assert doc('.data-toggle.review-tested')[0].attrib['data-value'] == ''
 
-        # Regular reviewer won't see delayed rejection inputs, need an admin.
-        assert not doc('.data-toggle.review-delayed-rejection')
+        assert doc('.data-toggle.review-delayed-rejection')[0].attrib[
+            'data-value'
+        ].split(' ') == [
+            'reject_multiple_versions',
+        ]
 
     def test_no_data_value_attributes_unlisted_for_viewer(self):
         self.version.update(channel=amo.CHANNEL_UNLISTED)
@@ -5390,7 +5398,7 @@ class TestReview(ReviewBase):
         assert doc('.data-toggle.review-files')[0].attrib['data-value'] == ''
         assert doc('.data-toggle.review-tested')[0].attrib['data-value'] == ''
 
-        # Regular reviewer won't see delayed rejection inputs, need an admin.
+        # Viewer won't see delayed rejection inputs, need a reviewer.
         assert not doc('.data-toggle.review-delayed-rejection')
 
     def test_data_value_attributes_unreviewed(self):

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -620,13 +620,13 @@ class ReviewHelper:
             'method': self.handler.reject_multiple_versions,
             'label': 'Reject Multiple Versions',
             'minimal': True,
-            'delayable': is_appropriate_admin_reviewer,
+            'delayable': True,
             'multiple_versions': True,
             'details': (
                 'This will reject the selected versions. '
                 'The comments will be sent to the developer.'
             ),
-            'available': (can_reject_multiple),
+            'available': can_reject_multiple,
             'allows_reasons': True,
             'resolves_cinder_jobs': True,
             'requires_reasons': not is_static_theme,


### PR DESCRIPTION
They should be able to see the widget, just not customize the value.

Fixes mozilla/addons#15336

Same testing instructions as https://github.com/mozilla/addons-server/pull/23001 except if you use an account with only `Addons:Review` permission (not a superuser, not someone with `Reviews:Admin`) they should be able to delay reject, but they shouldn't be able to customize the date, it should be the default +14 days (+1 hour).