### PR TITLE
Add playwright to make sure that pixels are not smorgulated when we burf the flapitulator

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -50,6 +50,8 @@ static/css/node_lib/*
 static/js/node_lib/*
 storage
 tmp/*
+tests/visual/**/*.ts-snapshots/*
+test-results/*
 
 # Additionally ignore these files from the docker build that are not in .gitignore
 

--- a/.github/actions/run-docker/action.yml
+++ b/.github/actions/run-docker/action.yml
@@ -44,7 +44,8 @@ runs:
           OLYMPIA_UID="$(id -u)" \
           OLYMPIA_DEPS="${{ inputs.deps }}" \
           SKIP_DATA_SEED="${{ inputs.skip_data_seed }}" \
-          DOCKER_WAIT="true"
+          DOCKER_WAIT="true" \
+          DEBUG="False"
 
 
         # Exec the run command in the container

--- a/.github/workflows/visual_tests.yml
+++ b/.github/workflows/visual_tests.yml
@@ -1,0 +1,97 @@
+name: Visual Regression Tests
+
+on:
+  # Run on pull requests
+  pull_request:
+    branches:
+      - main
+  # Allow manual triggering
+  workflow_dispatch:
+    inputs:
+      target_url:
+        description: 'Custom target URL to test against'
+        required: false
+        default: ''
+      environment:
+        description: 'Environment to test against (local, dev, staging)'
+        required: false
+        default: 'local'
+      update_snapshots:
+        description: 'Update snapshots instead of comparing'
+        required: false
+        default: false
+        type: boolean
+
+# Cancel in-progress runs for the same branch to avoid wasting resources
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  visual-tests:
+    name: Visual Regression Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Install dependencies
+        run: |
+          npm ci
+          npm run test:visual:install
+
+      - name: Determine test mode and targets
+        id: test_config
+        shell: bash
+        run: |
+          update_snapshots="${{ github.event.inputs.update_snapshots }}"
+          base_url="${{ github.event.inputs.target_url || '' }}"
+          env_name="${{ github.event.inputs.environment || 'local' }}"
+
+          # Use custom URL if provided or use environment
+          if [[ -n "${base_url}" ]]; then
+            env_name="custom"
+          fi
+
+          {
+            echo "update_snapshots=${update_snapshots}"
+            echo "env_name=${env_name}"
+            echo "base_url=${base_url}"
+          } >> "$GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"
+
+      - name: Run addons-server
+        uses: ./.github/actions/run-docker
+        with:
+          version: local
+          run: echo "running..."
+
+      # Running tests with the determined configuration
+      - name: Run visual tests
+        env:
+          ENV_NAME: ${{ steps.test_config.outputs.env_name }}
+          BASE_URL: ${{ steps.test_config.outputs.base_url }}
+        run: |
+          npm run test:visual${{ steps.test_config.outputs.update_snapshots && ':update' || '' }}
+
+      # Upload test results and artifacts
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
+
+      # Upload snapshots if they were updated
+      - name: Upload updated snapshots
+        if: steps.test_config.outputs.update_snapshots == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: updated-snapshots
+          path: tests/visual/**/*-snapshots/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ local_settings.py
 MANIFEST
 node_modules
 pip-log.txt
+playwright-report
 private/
 .ruff_cache
 settings_local.py*
@@ -49,6 +50,8 @@ static/css/node_lib/*
 static/js/node_lib/*
 storage/*
 tmp/*
+tests/visual/**/*.ts-snapshots/*
+test-results/*
 
 # End of .gitignore. Please keep this in sync with the top section of .dockerignore
 

--- a/Makefile-os
+++ b/Makefile-os
@@ -21,6 +21,10 @@ export FXA_CLIENT_ID ?=
 export FXA_CLIENT_SECRET ?=
 export STATIC_URL_PREFIX ?= /static-server/
 export MEDIA_URL_PREFIX ?= /user-media/
+
+SHELL_USER ?= olympia
+SHELL_ARGS ?= bash
+
 INITIALIZE_ARGS ?=
 INIT_CLEAN ?=
 INIT_LOAD ?=
@@ -108,11 +112,11 @@ update_docker: data_export up data_restore ## update all the docker images
 
 .PHONY: shell
 shell: ## connect to a running addons-server docker shell
-	docker compose exec --user olympia web bash
+	@docker compose exec --user $(SHELL_USER) web $(SHELL_ARGS)
 
 .PHONY: rootshell
 rootshell: ## connect to a running addons-server docker shell with root user
-	docker compose exec --user root web bash
+	$(MAKE) shell SHELL_USER=root SHELL_ARGS="$(SHELL_ARGS)"
 
 .PHONY: docker_compose_config
 docker_compose_config: ## Show the docker compose configuration

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
       },
       "devDependencies": {
         "@babel/preset-env": "^7.26.9",
+        "@playwright/test": "^1.51.1",
         "@rollup/plugin-babel": "^6.0.4",
         "@rollup/plugin-inject": "^5.0.5",
         "dotenv": "^16.4.7",
@@ -2458,6 +2459,21 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.51.1.tgz",
+      "integrity": "sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.51.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -5314,6 +5330,50 @@
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
       "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="
     },
+    "node_modules/playwright": {
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.1.tgz",
+      "integrity": "sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.51.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.1.tgz",
+      "integrity": "sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.3",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
@@ -8121,6 +8181,15 @@
       "dev": true,
       "optional": true
     },
+    "@playwright/test": {
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.51.1.tgz",
+      "integrity": "sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q==",
+      "dev": true,
+      "requires": {
+        "playwright": "1.51.1"
+      }
+    },
     "@rollup/plugin-babel": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-6.0.4.tgz",
@@ -10085,6 +10154,31 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
       "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="
+    },
+    "playwright": {
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.1.tgz",
+      "integrity": "sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==",
+      "dev": true,
+      "requires": {
+        "fsevents": "2.3.2",
+        "playwright-core": "1.51.1"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "playwright-core": {
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.1.tgz",
+      "integrity": "sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==",
+      "dev": true
     },
     "postcss": {
       "version": "8.5.3",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:watch": "vitest watch"
+    "test:watch": "vitest watch",
+    "test:visual": "playwright test",
+    "test:visual:update": "playwright test --update-snapshots",
+    "test:visual:install": "playwright install --with-deps"
   },
   "dependencies": {
     "@claviska/jquery-minicolors": "2.3.6",
@@ -30,6 +33,7 @@
   "devDependencies": {
     "@babel/preset-env": "^7.26.9",
     "@rollup/plugin-babel": "^6.0.4",
+    "@playwright/test": "^1.51.1",
     "@rollup/plugin-inject": "^5.0.5",
     "dotenv": "^16.4.7",
     "glob": "^11.0.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from '@playwright/test';
+
+import { base } from './tests/visual/config';
+
+export default defineConfig({
+  testDir: './tests/visual',
+  timeout: 30000,
+  expect: {
+    timeout: 5000,
+    toHaveScreenshot: { maxDiffPixels: 200 },
+  },
+  fullyParallel: !process.env.CI,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : 2,
+  reporter: [
+    ['list'],
+    ['html', { open: 'never' }]
+  ],
+  use: {
+    baseURL: base.baseURL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    viewport: { width: 1200, height: 800 },
+  },
+  projects: [700, 960, 1200].map((width) => {
+    return {
+      name: `firefox-${width}`,
+      use: {
+        ...devices['Desktop Firefox'],
+        // Target the width 1 pixel less than the breakpoint
+        viewport: { width: width - 1, height: 800 },
+      },
+    };
+  }, []),
+});

--- a/tests/visual/config.ts
+++ b/tests/visual/config.ts
@@ -1,0 +1,53 @@
+export interface PageConfig {
+  path: string;
+  requiresAuth: boolean;
+  threshold: number;
+}
+
+export const pages: PageConfig[] = [
+  {
+    path: '/developers',
+    requiresAuth: false,
+    threshold: 0
+  },
+  {
+    path: '/developers/addons',
+    requiresAuth: true,
+    threshold: 0
+  },
+  {
+    path: '/developers/themes',
+    requiresAuth: true,
+    threshold: 0
+  },
+  {
+    path: '/developers/addon/{guid}/edit',
+    requiresAuth: true,
+    threshold: 0
+  },
+  {
+    path: '/developers/addon/{guid}/ownership',
+    requiresAuth: true,
+    threshold: 0
+  },
+  {
+    path: '/developers/addon/{guid}/versions',
+    requiresAuth: true,
+    threshold: 0
+  },
+  {
+    path: '/developers/addon/{guid}/versions/{version}',
+    requiresAuth: true,
+    threshold: 0
+  },
+  {
+    path: '/reviewers/review/{version}',
+    requiresAuth: true,
+    threshold: 0
+  }
+];
+
+export const base = {
+  baseURL: process.env.BASE_URL || 'http://olympia.test',
+  authEmail: process.env.AUTH_EMAIL || 'local_admin@mozilla.com',
+}

--- a/tests/visual/helpers/auth.ts
+++ b/tests/visual/helpers/auth.ts
@@ -1,0 +1,18 @@
+import { Page } from '@playwright/test';
+
+export async function authenticate(page: Page, email: string, redirectTo: string) {
+  // Navigate to the login page
+  await page.goto(`/api/v5/accounts/login/start?to=${encodeURIComponent(redirectTo)}`);
+  // Fill and submit the login form
+  const form = page.locator('form#fake_fxa_authorization');
+  await form.getByLabel('Email').fill(email);
+  await form.getByRole('button').click();
+  // Wait for the redirect to complete
+  await page.waitForURL(new RegExp(`${redirectTo}$`));
+}
+
+export async function logout(page: Page, redirectTo: string) {
+  const encodedRedirect = encodeURIComponent(redirectTo);
+  await page.goto(`/developers/logout?to=${encodedRedirect}`);
+  await page.waitForURL(redirectTo);
+}

--- a/tests/visual/regression/visual.spec.ts
+++ b/tests/visual/regression/visual.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+import { pages, base } from '../config';
+import { authenticate } from '../helpers/auth';
+
+test.describe('Snapshot', () => {
+  for (const pageConfig of pages) {
+    test(`${pageConfig.path}`, async ({ page }) => {
+      if (pageConfig.requiresAuth) {
+        await authenticate(page, base.authEmail, pageConfig.path);
+      } else {
+        await page.goto(pageConfig.path);
+      }
+      await expect(page).toHaveScreenshot({
+        animations: 'disabled',
+        maxDiffPixelRatio: pageConfig.threshold,
+        fullPage: true,
+      });
+    });
+  }
+});


### PR DESCRIPTION
Fixes: mozilla/addons#ISSUENUM

### Description

Add playwright to get snapshots of all our pages to make sure we don't break any big things along the way with future planned updates to revtools and devhub

### Context

### Testing

TBD

### Checklist

- [ ] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
