### PR TITLE
Make DOCKER_TARGET a buid time argument only.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,10 +119,6 @@ RUN \
 ${HOME}/scripts/install_deps.py pip
 EOF
 
-# TODO: we should remove dependency on the environment variable
-# and instead read from the /build-info file
-ARG DOCKER_TARGET
-ENV DOCKER_TARGET=${DOCKER_TARGET}
 
 # Add our custom mime types (required for for ts/json/md files)
 COPY docker/etc/mime.types /etc/mime.types

--- a/docs/topics/development/troubleshooting_and_debugging.md
+++ b/docs/topics/development/troubleshooting_and_debugging.md
@@ -5,7 +5,7 @@ Effective troubleshooting and debugging practices are essential for maintaining 
 ## DEV_MODE vs DEBUG
 
 In our project, `DEV_MODE` and `DEBUG` serve distinct but complementary purposes.
-`DEV_MODE` is directly tied to the `DOCKER_TARGET` environment variable and is used to enable or disable behaviors
+`DEV_MODE` is directly tied to the `DOCKER_TARGET` build argument and is used to enable or disable behaviors
 based on whether we are running a production image or not.
 
 For instance, production images always disables certain features like using fake fxa authentication. Additionally,

--- a/scripts/install_deps.py
+++ b/scripts/install_deps.py
@@ -20,7 +20,6 @@ def main(targets):
     # Constants
     ALLOWED_NPM_TARGETS = set(['prod', 'dev'])
     DOCKER_TAG = os.environ.get('DOCKER_TAG', 'local')
-    DOCKER_TARGET = os.environ.get('DOCKER_TARGET', '')
     OLYMPIA_DEPS = os.environ.get('OLYMPIA_DEPS', '')
     DEPS_DIR = os.environ.get('DEPS_DIR')
     NPM_DEPS_DIR = os.environ.get('NPM_DEPS_DIR')
@@ -32,7 +31,6 @@ def main(targets):
         'Updating deps... \n',
         f'targets: {", ".join(targets)} \n',
         f'DOCKER_TAG: {DOCKER_TAG} \n',
-        f'DOCKER_TARGET: {DOCKER_TARGET} \n',
         f'OLYMPIA_DEPS: {OLYMPIA_DEPS} \n',
         f'DEPS_DIR: {DEPS_DIR} \n',
         f'NPM_DEPS_DIR: {NPM_DEPS_DIR} \n',

--- a/settings.py
+++ b/settings.py
@@ -13,11 +13,8 @@ from olympia.core.utils import get_version_json
 from olympia.lib.settings_base import *  # noqa
 
 
-# "production" is a named docker stage corresponding to the production image.
-# when we build the production image, the stage to use is determined
-# via the "DOCKER_TARGET" variable which is also passed into the image.
-# So if the value is anything other than "production" we are in development mode.
-DEV_MODE = DOCKER_TARGET != 'production'
+# Any target other than "production" is considered a development target.
+DEV_MODE = TARGET != 'production'
 
 HOST_UID = os.environ.get('HOST_UID')
 

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -15,6 +15,7 @@ from sentry_sdk.integrations.logging import ignore_logger
 
 import olympia.core.logger
 import olympia.core.sentry
+from olympia.core.utils import get_version_json
 
 
 env = environ.Env()
@@ -64,10 +65,8 @@ def path(*folders):
 
 DEBUG = env('DEBUG', default=False)
 
-# Do NOT provide a default value, this should be explicitly
-# set during the docker image build. If it is not set,
-# we want to raise an error.
-DOCKER_TARGET = env('DOCKER_TARGET')
+# Target is the target the current container image was built for.
+TARGET = get_version_json().get('target')
 
 DEV_MODE = False
 

--- a/tests/make/test_install_deps.py
+++ b/tests/make/test_install_deps.py
@@ -55,11 +55,10 @@ class TestInstallDeps(unittest.TestCase):
 
     def test_keep_deps_for_local_mixed_env(self):
         """Test that dependencies are kept when running
-        locally with development deps in production"""
+        locally with development deps"""
         args = {
             'DOCKER_TAG': 'local',
             'OLYMPIA_DEPS': 'development',
-            'DOCKER_TARGET': 'production',
         }
         self._test_remove_existing_deps(args, expect_remove=False)
 
@@ -75,21 +74,10 @@ class TestInstallDeps(unittest.TestCase):
 
     def test_remove_deps_for_prod_deps_in_dev(self):
         """Test that dependencies are removed when
-        installing production deps in development"""
+        installing production deps"""
         args = {
             'DOCKER_TAG': 'local',
             'OLYMPIA_DEPS': 'production',
-            'DOCKER_TARGET': 'development',
-        }
-        self._test_remove_existing_deps(args, expect_remove=True)
-
-    def test_remove_deps_for_prod_deps_in_prod(self):
-        """Test that dependencies are removed when
-        installing production deps in production"""
-        args = {
-            'DOCKER_TAG': 'local',
-            'OLYMPIA_DEPS': 'production',
-            'DOCKER_TARGET': 'production',
         }
         self._test_remove_existing_deps(args, expect_remove=True)
 


### PR DESCRIPTION
Fixes: mozilla/addons#15361


### Description

Define `TARGET` setting reading the docker target from build info.

### Context

It is very subtle, but extremely problematic to rely on an environmnet variable for `DOCKER_TARGET`. This value is mostly relevant during build time, it literally determines which stage of the docker image to build to. The actual state cannot be changed, but environment variables can be freely changed whenever you want.

Since we are relying on this value to know what kind of checks to run or what features might be enabled we must use a value that is hard coded during the build. that is what the build-info.json is meant for.

### Testing

Make up with a given target "production" or "development"

```bash
make up DOCKER_TARGET=<target>
```

Shell into the container

```bash
make shell
```

Print the environmnet

> Expect DOCKER_TARGET is *not* defined

```bash
printenv
```

Django shell it up

```bash
make djshell
```

Get that TARGET setting

```bash
settings.TARGET
```

> Expect to match `<target>`


### Checklist


- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
