### PR TITLE
Add Forward to Legal to important changes history in review page

### DIFF
--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -55,6 +55,7 @@ class ADD_USER_WITH_ROLE(_LOG):
     action_class = 'add'
     # L10n: {0} is the user role.
     format = _('{user} ({0}) added to {addon}.')
+    short = 'Author added'
     keep = True
     show_user_to_developer = True
 
@@ -64,6 +65,7 @@ class REMOVE_USER_WITH_ROLE(_LOG):
     action_class = 'delete'
     # L10n: {0} is the user role.
     format = _('{user} ({0}) removed from {addon}.')
+    short = 'Author removed'
     keep = True
     show_user_to_developer = True
 
@@ -324,6 +326,7 @@ class CHANGE_USER_WITH_ROLE(_LOG):
     id = 36
     # L10n: {0} is the user role
     format = _('{user} role changed to {0} for {addon}.')
+    short = 'Author role changed'
     keep = True
     show_user_to_developer = True
 

--- a/src/olympia/reviewers/templates/reviewers/includes/history.html
+++ b/src/olympia/reviewers/templates/reviewers/includes/history.html
@@ -4,15 +4,15 @@
   </th>
   <td class="record-container">
       <div>
-        {% trans user = record.user|user_link, date = record.created|datetime %}
-          <div>By {{ user }} on {{ date }}</div>
-        {% endtrans %}
+        <div>By {{ record.user|user_link }} on {{ record.created|datetime }}</div>
         {% if record.details %}
           {# <pre> rather than <div> so that white space is preserved on copy #}
           <pre class="light history-comment">{{ record.details.comments }}</pre>
           {% if record.details.reason %}
             <pre class="light history-comment">Reason: {{ record.details.reason }}</pre>
           {% endif %}
+        {% elif show_long_format_fallback %}
+          <pre class="light history-comment">{{ record.to_string('reviewer') }}</pre>
         {% endif %}
       </div>
       {% if switch_is_active('enable-activity-log-attachments') %}

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -60,16 +60,13 @@
   <h3>
     Add-on important changes history
   </h3>
-  <ul>
-    {% for activity in important_changes_log %}
-      <li {% if activity.log.reviewer_review_action %}class="reviewer-review-action"{% endif %}>
-        <p>{{ activity.created|datetime }}: {{ activity.to_string('reviewer') }}</p>
-        {% if activity.details.comments %}
-          <p>{{ activity.details.comments }}</p>
-        {% endif %}
-      </li>
+  <table class="activity">
+    {% for record in important_changes_log %}
+      {% with show_long_format_fallback=True %}
+        {% include 'reviewers/includes/history.html' %}
+      {% endwith %}
     {% endfor %}
-  </ul>
+  </table>
 </div>
 {% endif %}
 

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -674,19 +674,23 @@ def review(request, addon, channel=None):
     wb_form_cls = PublicWhiteboardForm if is_static_theme else WhiteboardForm
     whiteboard_form = wb_form_cls(instance=whiteboard, prefix='whiteboard')
 
-    user_changes_actions = (
+    # Actions that are not tied to a specific version that we want to highlight
+    # in the "Add-on important changes history" section.
+    addon_important_changes_actions = (
+        # These are from developers themselves
         amo.LOG.ADD_USER_WITH_ROLE.id,
         amo.LOG.CHANGE_USER_WITH_ROLE.id,
         amo.LOG.REMOVE_USER_WITH_ROLE.id,
-    )
-    admin_changes_actions = (
+        # These are from admins or reviewers
         amo.LOG.FORCE_DISABLE.id,
+        amo.LOG.HELD_ACTION_FORCE_DISABLE.id,
         amo.LOG.FORCE_ENABLE.id,
         amo.LOG.REQUEST_ADMIN_REVIEW_THEME.id,
         amo.LOG.CLEAR_ADMIN_REVIEW_THEME.id,
+        amo.LOG.REQUEST_LEGAL.id,
     )
     important_changes_log = ActivityLog.objects.filter(
-        action__in=(user_changes_actions + admin_changes_actions),
+        action__in=addon_important_changes_actions,
         addonlog__addon=addon,
     ).order_by('id')
 

--- a/static/css/zamboni/reviewers.less
+++ b/static/css/zamboni/reviewers.less
@@ -758,18 +758,18 @@ div.reviewer-stats-table > div.reviewer-stats-dark {
     top: -20px;
     width: auto;
 }
-.review-files table.activity {
+table.activity {
     margin: 0;
     width: 100%;
 }
-.review-files table.activity th {
+table.activity th {
     width: 25%;
     padding-right: 1em;
 }
-.review-files table.activity tr {
+table.activity tr {
     border-top: 1px dotted #ccc;
 }
-.review-files table.activity tr:first-child {
+table.activity tr:first-child {
     border-top: 0 none;
 }
 .review-files .listing-header span.light {


### PR DESCRIPTION
Also make that history look more version activity to reduce custom formatting logic.

Fixes mozilla/addons#15327

### Context

"Forward to legal" is one of those actions that is not tied to a version, so in order to show it to reviewers, we add it to the "Important add-on changes history".

### Screenshots
#### With the new action
![Screenshot 2025-02-14 at 13-17-01 New Tasty Salad 6 – Add-ons for Firefox](https://github.com/user-attachments/assets/d0a7f382-5ae1-4509-be1e-fea538efa1cd)
#### Some old actions in the new format
![Screenshot 2025-02-14 at 13-16-51 New Exquisite Sandwich 90 – Add-ons for Firefox](https://github.com/user-attachments/assets/e6fd4391-31d4-42dc-a265-ce7a337d0578)


### Testing

- Review an add-on as an admin, and select the action to forward it to legal
- "Important add-on changes history" should now be shown on review page for that add-on and should include the forward to legal action, with the comment that was made at the time

You can verify that other actions we're supposed to show there (force enable, force disable, author add, author remove, author role change, etc) still show up, but the unit test does that already.