### PR TITLE
Allow API authentication for source package downloads

### DIFF
--- a/src/olympia/versions/tests/test_views.py
+++ b/src/olympia/versions/tests/test_views.py
@@ -848,6 +848,13 @@ class TestDownloadSource(TestCase):
         xsendfile_header = decode_http_header_value(response[settings.XSENDFILE_HEADER])
         assert xsendfile_header == expected_path
 
+    def test_no_source_with_permission_should_go_in_404(self):
+        self.client.force_login(self.user)
+        self.version.source = None
+        self.version.save()
+        response = self.client.get(self.url)
+        assert response.status_code == 404
+
     def test_no_source_should_go_in_404(self):
         self.version.source = None
         self.version.save()

--- a/src/olympia/versions/tests/test_views.py
+++ b/src/olympia/versions/tests/test_views.py
@@ -810,8 +810,11 @@ class TestDownloadSource(TestCase):
         )
         self.url = reverse('downloads.source', args=(self.version.pk,))
 
+    def login(self, user):
+        return self.client.force_login(user)
+
     def test_owner_should_be_allowed(self):
-        self.client.force_login(self.user)
+        self.login(self.user)
         response = self.client.get(self.url)
         assert response.status_code == 200
         assert response[settings.XSENDFILE_HEADER]
@@ -830,13 +833,13 @@ class TestDownloadSource(TestCase):
     def test_deleted_version(self):
         self.version.delete()
         GroupUser.objects.create(user=self.user, group=self.group)
-        self.client.force_login(self.user)
+        self.login(self.user)
         response = self.client.get(self.url)
         assert response.status_code == 404
 
     def test_group_binarysource_should_be_allowed(self):
         GroupUser.objects.create(user=self.user, group=self.group)
-        self.client.force_login(self.user)
+        self.login(self.user)
         response = self.client.get(self.url)
         assert response.status_code == 200
         assert response[settings.XSENDFILE_HEADER]
@@ -849,7 +852,7 @@ class TestDownloadSource(TestCase):
         assert xsendfile_header == expected_path
 
     def test_no_source_with_permission_should_go_in_404(self):
-        self.client.force_login(self.user)
+        self.login(self.user)
         self.version.source = None
         self.version.save()
         response = self.client.get(self.url)
@@ -901,7 +904,7 @@ class TestDownloadSource(TestCase):
         """File downloading is allowed for admins."""
         self.grant_permission(self.user, 'Reviews:Admin')
         self.addon.authors.clear()
-        self.client.force_login(self.user)
+        self.login(self.user)
         assert self.client.get(self.url).status_code == 200
 
         # Even unlisted.
@@ -923,3 +926,9 @@ class TestDownloadSource(TestCase):
         # Even deleted!
         self.addon.delete()
         assert self.client.get(self.url).status_code == 200
+
+class TestDownloadSourceSessionAPIAuth(TestDownloadSource, APILoginMixin):
+    client_class = APITestClientSessionID
+
+class TestDownloadSourceJWTAPIAuth(TestDownloadSource, APILoginMixin):
+    client_class = APITestClientJWT

--- a/src/olympia/versions/tests/test_views.py
+++ b/src/olympia/versions/tests/test_views.py
@@ -927,8 +927,10 @@ class TestDownloadSource(TestCase):
         self.addon.delete()
         assert self.client.get(self.url).status_code == 200
 
+
 class TestDownloadSourceSessionAPIAuth(TestDownloadSource, APILoginMixin):
     client_class = APITestClientSessionID
+
 
 class TestDownloadSourceJWTAPIAuth(TestDownloadSource, APILoginMixin):
     client_class = APITestClientJWT

--- a/src/olympia/versions/tests/test_views.py
+++ b/src/olympia/versions/tests/test_views.py
@@ -928,9 +928,9 @@ class TestDownloadSource(TestCase):
         assert self.client.get(self.url).status_code == 200
 
 
-class TestDownloadSourceSessionAPIAuth(TestDownloadSource, APILoginMixin):
+class TestDownloadSourceSessionAPIAuth(APILoginMixin, TestDownloadSource):
     client_class = APITestClientSessionID
 
 
-class TestDownloadSourceJWTAPIAuth(TestDownloadSource, APILoginMixin):
+class TestDownloadSourceJWTAPIAuth(APILoginMixin, TestDownloadSource):
     client_class = APITestClientJWT

--- a/src/olympia/versions/views.py
+++ b/src/olympia/versions/views.py
@@ -183,6 +183,7 @@ def download_latest(request, addon, download_type=None, **kwargs):
 
 
 @non_atomic_requests
+@api_authentication
 def download_source(request, version_id):
     """
     Download source code for a given version_id.

--- a/src/olympia/versions/views.py
+++ b/src/olympia/versions/views.py
@@ -215,7 +215,7 @@ def download_source(request, version_id):
             allow_addons_edit_permission=False,
             allow_developer=True,
         )
-    if not has_permission:
+    if not (has_permission and getattr(version, 'source', None)):
         raise http.Http404()
 
     response = HttpResponseXSendFile(request, version.source.path)


### PR DESCRIPTION
Relates to https://github.com/mozilla/assay/issues/59

### Description

Enables Assay to access & install source code packages for review.

### Testing

<!--
Your change must be related to an existing, open issue. This issue should contain testing instructions.
Often, the testing info in the issue is higher level, geared towards a user or QA experience.
Here you can provide information for a developer verifying this PR. Get technical.
If it is not relevant to your PR, remove this section.
-->

- `GETs` to `/firefox/downloads/source/<version_id>` should return the source code if the file exists. 404 otherwise.
- Source code is only available to admin reviewers or developers of the add-on.
- A 404 is returned if there is no version source code, but the user had the right permissions.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
