### PR TITLE
create override decision for denied 2nd level approvals

### DIFF
--- a/src/olympia/abuse/cinder.py
+++ b/src/olympia/abuse/cinder.py
@@ -173,8 +173,14 @@ class CinderEntity:
             **data,
             'reasoning': self.get_str(reasoning),
             'policy_uuids': policy_uuids,
-            'enforcement_actions_slugs': [action],
-            'enforcement_actions_update_strategy': 'set',
+            **(
+                {
+                    'enforcement_actions_slugs': [action],
+                    'enforcement_actions_update_strategy': 'set',
+                }
+                if action is not None
+                else {}
+            ),
         }
         response = requests.post(url, json=data, headers=self.get_cinder_http_headers())
         if response.status_code == 201:
@@ -196,6 +202,13 @@ class CinderEntity:
     def create_job_decision(self, *, action, reasoning, policy_uuids, job_id):
         url = f'{settings.CINDER_SERVER_URL}jobs/{job_id}/decision'
         return self._send_create_decision(url, {}, action, reasoning, policy_uuids)
+
+    def create_override_decision(self, *, action, reasoning, policy_uuids, decision_id):
+        url = f'{settings.CINDER_SERVER_URL}decisions/{decision_id}/override/'
+        # TODO: send action too once
+        # https://lindie.app/share/6a21d831b39351d7c6fe898f6d22619af62dde98/PLAT-1834
+        # implements the same parameters for overrides
+        return self._send_create_decision(url, {}, None, reasoning, policy_uuids)
 
     def close_job(self, *, job_id):
         url = f'{settings.CINDER_SERVER_URL}jobs/{job_id}/cancel'

--- a/src/olympia/abuse/views.py
+++ b/src/olympia/abuse/views.py
@@ -431,7 +431,7 @@ def appeal(request, *, abuse_report_id, decision_cinder_id, **kwargs):
                 # error message in this case.
                 context_data['appealed_decision_already_made'] = True
                 context_data['appealed_decision_affirmed'] = (
-                    cinder_decision.appeal_job.final_decision.action
+                    cinder_decision.appeal_job.decision.final.action
                     == cinder_decision.action
                 )
 

--- a/src/olympia/reviewers/management/commands/send_pending_rejection_last_warning_notifications.py
+++ b/src/olympia/reviewers/management/commands/send_pending_rejection_last_warning_notifications.py
@@ -92,8 +92,8 @@ class Command(BaseCommand):
         )
         # We just need the decision to send an accurate email
         decision = (
-            cinder_job.final_decision
-            if cinder_job
+            cinder_job.decision.final
+            if cinder_job and cinder_job.decision
             # Fake a decision if there isn't a job
             else ContentDecision(
                 addon=addon,

--- a/src/olympia/reviewers/tests/test_commands.py
+++ b/src/olympia/reviewers/tests/test_commands.py
@@ -1462,8 +1462,8 @@ class TestAutoReject(AutoRejectTestsMixin, TestCase):
         AbuseReport.objects.create(guid=self.addon.guid, cinder_job=cinder_job)
         responses.add(
             responses.POST,
-            f'{settings.CINDER_SERVER_URL}jobs/1/decision',
-            json={'uuid': cinder_job.job_id},
+            f'{settings.CINDER_SERVER_URL}decisions/13579/override/',
+            json={'uuid': uuid.uuid4().hex},
             status=201,
         )
         policies = [CinderPolicy.objects.create(name='policy', uuid='12345678')]
@@ -1507,7 +1507,7 @@ class TestAutoReject(AutoRejectTestsMixin, TestCase):
         )
         responses.add(
             responses.POST,
-            f'{settings.CINDER_SERVER_URL}jobs/2/decision',
+            f'{settings.CINDER_SERVER_URL}decisions/13579/override/',
             json={'uuid': uuid.uuid4().hex},
             status=201,
         )
@@ -1552,7 +1552,7 @@ class TestAutoReject(AutoRejectTestsMixin, TestCase):
         )
         responses.add(
             responses.POST,
-            f'{settings.CINDER_SERVER_URL}jobs/2/decision',
+            f'{settings.CINDER_SERVER_URL}decisions/13579/override/',
             json={'uuid': uuid.uuid4().hex},
             status=201,
         )

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -7453,6 +7453,18 @@ class TestHeldDecisionQueue(ReviewerTest):
         )
         assert doc('tr.held-item td').eq(2).text() == 'Add-on disable'
 
+        # But overridden decisions should not be present, even if not actioned
+        ContentDecision.objects.create(
+            action=DECISION_ACTIONS.AMO_APPROVE,
+            addon=self.addon_decision.addon,
+            action_date=datetime.now(),
+            override_of=self.addon_decision,
+        )
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)('#held-decision-queue')
+        assert doc('tr.held-item').length == 3
+
     def test_non_admin_cannot_access(self):
         self.login_as_reviewer()
         response = self.client.get(self.url)
@@ -7545,13 +7557,24 @@ class TestHeldDecisionReview(ReviewerTest):
     def test_approve_addon_instead(self):
         addon = self.decision.addon
         assert addon.status == amo.STATUS_APPROVED
+        responses.add(
+            responses.POST,
+            f'{settings.CINDER_SERVER_URL}decisions/{self.decision.cinder_id}/override/',
+            json={'uuid': '5678'},
+            status=201,
+        )
 
         response = self.client.post(self.url, {'choice': 'no'})
 
         assert response.status_code == 302
         assert addon.reload().status == amo.STATUS_APPROVED
-        assert self.decision.reload().action == DECISION_ACTIONS.AMO_APPROVE
-        self.assertCloseToNow(self.decision.action_date)
+        assert self.decision.reload().action == DECISION_ACTIONS.AMO_DISABLE_ADDON
+        assert self.decision.action_date is None
+
+        override = ContentDecision.objects.get(cinder_id='5678')
+        assert override.action == DECISION_ACTIONS.AMO_APPROVE
+        self.assertCloseToNow(override.action_date)
+        assert override.override_of == self.decision
 
     def test_escalate_addon_instead(self):
         addon = self.decision.addon

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -319,7 +319,9 @@ class HeldDecisionQueueTable:
 
     @classmethod
     def get_queryset(cls, request, **kwargs):
-        return ContentDecision.objects.filter(action_date=None).order_by('created')
+        return ContentDecision.objects.filter(
+            action_date=None, overridden_by=None
+        ).order_by('created')
 
 
 class ReviewHelper:

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -319,9 +319,7 @@ class HeldDecisionQueueTable:
 
     @classmethod
     def get_queryset(cls, request, **kwargs):
-        return ContentDecision.objects.filter(
-            action_date=None, overridden_by=None
-        ).order_by('created')
+        return ContentDecision.objects.awaiting_action().order_by('created')
 
 
 class ReviewHelper:


### PR DESCRIPTION
Fixes: mozilla/addons#15094
### Description

Creates an override decision if a 2nd level approval action is to decline the negative action, and approve the content instead.

### Context

We've only recently been able to create override decisions via the API, so previously we just didn't notify Cinder if the 2nd level hold was denied instead of proceeded with.  The second commit is because we previously assumed that a decision could only be overridden once, which is now not a given (though is still the likely case).

Ideally, I'd like to have a decision return an iterator that would allow overridden decisions to be iterated through to the start (or end), rather than having to do a recursive look through `override_of` in 3 different places ( `originating_job`, and in `get_action_helper` and `report_to_cinder`; and `final` goes to the other end) but it'll take some playing around. It could be done as a follow-up.

### Testing

- Set-up a decision that is held for a 2nd level approval:
  -  i.e. reject or disable an add-on in a high impact group (notable, recommended, etc).  Either in reviewer tools or Cinder - though reviewer tools is easier because you don't have to replay the webhook payload
- deny the second level approval - i.e. don't reject/disable, mark the add-on as okay instead
- as before, the developer should not be emailed, because the rejection/disable didn't take place; if the rejection/disable was linked to a 3rd party job (i.e. from an abuse report), then the reporter should get an email saying we didn't take down the content, etc.
- in Cinder there should be a record of both the original decision to reject/disable _and_ the 2nd level decision to approve - with the latter decision as an override of the first.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
