### PR TITLE
Update local dev docker images for autograph, elasticsearch, memcached

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,9 +104,7 @@ services:
       - web
 
   memcached:
-    image: memcached:1.4
-    # Remove this once we upgrade to a version that provides multi-platform images
-    platform: linux/amd64
+    image: memcached:1.5.16
 
   mysqld:
     image: mysql:8.0
@@ -135,7 +133,7 @@ services:
       retries: 3
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.3
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.27
     environment:
       # Disable all xpack related features to avoid unrelated logging
       # in docker logs. https://github.com/mozilla/addons-server/issues/8887
@@ -167,8 +165,7 @@ services:
       - data_rabbitmq:/var/lib/rabbitmq
 
   autograph:
-    image: mozilla/autograph:3.3.2
-    platform: linux/amd64
+    image: mozilla/autograph:7.3.3
     command: /go/bin/autograph -c /data/autograph/autograph_localdev_config.yaml
     volumes:
       - data_autograph:/data/autograph

--- a/docker/autograph/autograph_localdev_config.yaml
+++ b/docker/autograph/autograph_localdev_config.yaml
@@ -251,3 +251,7 @@ authorizations:
       key: 9vh6bhlc10y63ow2k4zke7k0c3l9hpr8mo96p92jmbfqngs9e7d
       signers:
           - webextensions-rsa-with-recommendation
+
+heartbeat:
+    hsmchecktimeout: 100ms
+    dbchecktimeout: 150ms


### PR DESCRIPTION
Fixes: https://github.com/mozilla/addons/issues/15381
Fixes: https://github.com/mozilla/addons/issues/15379

### Description

This updates the local development docker images to match what we are currently using in production.

### Context

As an added benefit, some images are now multi-platform, which is mostly relevant for developers on Apple Silicon or other non-amd64 platforms.
Updating to a more recent autograph version also required some heartbeat parameters to be added to the config, I took those from https://github.com/mozilla-services/autograph/blob/master/autograph.yaml as per https://github.com/mozilla/addons-server/blob/1f3e27cc2bf6a64b64c4e75525df1d7bd05e183a/docker/autograph/autograph_localdev_config.yaml#L2

### Testing

Make sure the containers all start without an error, and perhaps you can reach the website. Not sure what else to test. Perhaps a quick look at the container log files might be useful to see if there are any errors.

### Checklist

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
