### PR TITLE
Expose target affected versions for decision on held review page

### DIFF
--- a/src/olympia/reviewers/templates/reviewers/decision_review.html
+++ b/src/olympia/reviewers/templates/reviewers/decision_review.html
@@ -40,6 +40,14 @@
         <strong>{{ decision.get_action_display() }}</strong>
       </td>
     </tr>
+    {% if decision.addon %}
+    <tr class="decision-affected-versions">
+      <th>Affected versions</th>
+      <td>
+        {{ decision.target_versions.all()|join(', ') }}
+      </td>
+    </tr>
+    {% endif %}
     <tr class="decision-policies">
       <th>Policies</th>
       <td>

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -7483,6 +7483,8 @@ class TestHeldDecisionReview(ReviewerTest):
             addon=addon_factory(),
             cinder_id='1234',
         )
+        self.version = self.decision.addon.current_version
+        self.decision.target_versions.set([self.version])
         self.decision.policies.add(
             CinderPolicy.objects.create(uuid='1', name='Bad Things')
         )
@@ -7507,6 +7509,8 @@ class TestHeldDecisionReview(ReviewerTest):
         assert 'Bad Things' in doc('tr.decision-policies td').html()
         assert 'Proceed with action' == doc('[for="id_choice_0"]').text()
         assert 'Approve content instead' == doc('[for="id_choice_1"]').text()
+        assert 'Affected versions' in doc.text()
+        assert self.version.version in doc.text()
         return doc
 
     def test_review_page_addon_with_job(self):
@@ -7538,6 +7542,7 @@ class TestHeldDecisionReview(ReviewerTest):
         assert 'Proceed with action' == doc('[for="id_choice_0"]').text()
         assert 'Approve content instead' == doc('[for="id_choice_1"]').text()
         assert 'Forward to Reviewer Tools' not in doc.text()
+        assert 'Affected versions' not in doc.text()
 
     def test_release_addon_disable_hold(self):
         addon = self.decision.addon


### PR DESCRIPTION
Fixes: mozilla/addons#15370

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Exposes target versions (affected versions) for a decision on the 2nd level review page for held decisions.

### Testing

- Trigger a decision that would be held for 2nd level approval (rejecting a version for a notable, recommended, etc add-on)
- load the 2nd level review page; see the affected version(s) listed.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
