### PR TITLE
Cinder sends a 200 for a successfull decision override, not 201

### DIFF
--- a/src/olympia/abuse/cinder.py
+++ b/src/olympia/abuse/cinder.py
@@ -168,7 +168,9 @@ class CinderEntity:
         else:
             raise ConnectionError(response.content)
 
-    def _send_create_decision(self, url, data, action, reasoning, policy_uuids):
+    def _send_create_decision(
+        self, url, data, action, reasoning, policy_uuids, *, success_code=201
+    ):
         data = {
             **data,
             'reasoning': self.get_str(reasoning),
@@ -183,7 +185,7 @@ class CinderEntity:
             ),
         }
         response = requests.post(url, json=data, headers=self.get_cinder_http_headers())
-        if response.status_code == 201:
+        if response.status_code == success_code:
             return response.json().get('uuid')
         else:
             raise ConnectionError(response.content)
@@ -208,7 +210,9 @@ class CinderEntity:
         # TODO: send action too once
         # https://lindie.app/share/6a21d831b39351d7c6fe898f6d22619af62dde98/PLAT-1834
         # implements the same parameters for overrides
-        return self._send_create_decision(url, {}, None, reasoning, policy_uuids)
+        return self._send_create_decision(
+            url, {}, None, reasoning, policy_uuids, success_code=200
+        )
 
     def close_job(self, *, job_id):
         url = f'{settings.CINDER_SERVER_URL}jobs/{job_id}/cancel'

--- a/src/olympia/abuse/tests/test_cinder.py
+++ b/src/olympia/abuse/tests/test_cinder.py
@@ -1446,7 +1446,7 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
             responses.POST,
             f'{settings.CINDER_SERVER_URL}decisions/{overridden_decision_id}/override/',
             json={'uuid': cinder_id},
-            status=201,
+            status=200,
         )
         responses.add(
             responses.POST,

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -2688,7 +2688,7 @@ class TestContentDecision(TestCase):
             responses.POST,
             f'{settings.CINDER_SERVER_URL}decisions/{overridden_id}/override/',
             json={'uuid': uuid.uuid4().hex},
-            status=201,
+            status=200,
         )
         decision.policies.add(
             CinderPolicy.objects.create(name='policy', uuid='12345678')

--- a/src/olympia/reviewers/tests/test_commands.py
+++ b/src/olympia/reviewers/tests/test_commands.py
@@ -1464,7 +1464,7 @@ class TestAutoReject(AutoRejectTestsMixin, TestCase):
             responses.POST,
             f'{settings.CINDER_SERVER_URL}decisions/13579/override/',
             json={'uuid': uuid.uuid4().hex},
-            status=201,
+            status=200,
         )
         policies = [CinderPolicy.objects.create(name='policy', uuid='12345678')]
         review_action_reason = ReviewActionReason.objects.create(
@@ -1509,7 +1509,7 @@ class TestAutoReject(AutoRejectTestsMixin, TestCase):
             responses.POST,
             f'{settings.CINDER_SERVER_URL}decisions/13579/override/',
             json={'uuid': uuid.uuid4().hex},
-            status=201,
+            status=200,
         )
         policies = [CinderPolicy.objects.create(name='policy', uuid='12345678')]
         review_action_reason = ReviewActionReason.objects.create(
@@ -1554,7 +1554,7 @@ class TestAutoReject(AutoRejectTestsMixin, TestCase):
             responses.POST,
             f'{settings.CINDER_SERVER_URL}decisions/13579/override/',
             json={'uuid': uuid.uuid4().hex},
-            status=201,
+            status=200,
         )
         policies = [CinderPolicy.objects.create(name='policy', uuid='12345678')]
         review_action_reason = ReviewActionReason.objects.create(

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -7556,7 +7556,7 @@ class TestHeldDecisionReview(ReviewerTest):
             responses.POST,
             f'{settings.CINDER_SERVER_URL}decisions/{self.decision.cinder_id}/override/',
             json={'uuid': '5678'},
-            status=201,
+            status=200,
         )
 
         response = self.client.post(self.url, {'choice': 'no'})


### PR DESCRIPTION
Fixes: mozilla/addons#15383

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

We were expecting a 201, but Cinder is sending a 200

### Testing

- report a recommend, notable, etc add-on for abuse
- disable the add-on via Cinder review page
- see the decision in 2nd level approval queue
- deny the decision, and approve the add-on
- check the email to the reporter, denying their abuse report, has been sent (in django admin fake mail)

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
