### PR TITLE
Add retry to some abuse tasks

### DIFF
--- a/src/olympia/abuse/cinder.py
+++ b/src/olympia/abuse/cinder.py
@@ -5,6 +5,7 @@ from django.core.files.storage import default_storage as storage
 
 import requests
 import waffle
+from requests import HTTPError
 
 import olympia
 from olympia import activity, amo, core
@@ -127,7 +128,7 @@ class CinderEntity:
         if response.status_code == 201:
             return response.json().get('job_id')
         else:
-            raise ConnectionError(response.content)
+            raise HTTPError(response.content)
 
     def report_additional_context(self):
         """Report to Cinder API additional context for an entity. Uses
@@ -145,7 +146,7 @@ class CinderEntity:
                 url, json=data, headers=self.get_cinder_http_headers()
             )
             if response.status_code != 202:
-                raise ConnectionError(response.content)
+                raise HTTPError(response.content)
 
     def appeal(self, *, decision_cinder_id, appeal_text, appealer):
         """File an appeal with the Cinder API. Return a job_id for the appeal
@@ -166,7 +167,7 @@ class CinderEntity:
         if response.status_code == 201:
             return response.json().get('external_id')
         else:
-            raise ConnectionError(response.content)
+            raise HTTPError(response.content)
 
     def _send_create_decision(
         self, url, data, action, reasoning, policy_uuids, *, success_code=201
@@ -188,7 +189,7 @@ class CinderEntity:
         if response.status_code == success_code:
             return response.json().get('uuid')
         else:
-            raise ConnectionError(response.content)
+            raise HTTPError(response.content)
 
     def create_decision(self, *, action, reasoning, policy_uuids):
         if self.type is None:
@@ -220,7 +221,7 @@ class CinderEntity:
         if response.status_code == 200:
             return response.json().get('external_id')
         else:
-            raise ConnectionError(response.content)
+            raise HTTPError(response.content)
 
     def post_report(self, *, job):
         """Callback triggered after a report has been posted to Cinder API and

--- a/src/olympia/abuse/tasks.py
+++ b/src/olympia/abuse/tasks.py
@@ -1,3 +1,4 @@
+import functools
 from datetime import datetime, timedelta
 
 from django.conf import settings
@@ -27,14 +28,6 @@ from .models import (
 
 
 log = olympia.core.logger.getLogger('z.abuse')
-
-
-task_retry_kw = {
-    'autoretry_for': (requests.RequestException,),
-    'retry_backoff': 30,  # start backoff at 30 seconds
-    'retry_backoff_max': 60 * 60,  # Max out at 1 hour between retries
-    'retry_kwargs': {'max_retries': 79},  # this works out about 72 hours
-}
 
 
 @task
@@ -81,75 +74,80 @@ def flag_high_abuse_reports_addons_according_to_review_tier():
     )
 
 
-@task(**task_retry_kw)
-@use_primary_db
+def retryable_task(f):
+    retryable_exceptions = (requests.RequestException,)
+
+    @task(
+        autoretry_for=retryable_exceptions,
+        retry_backoff=30,  # start backoff at 30 seconds
+        retry_backoff_max=60 * 60,  # Max out at 1 hour between retries
+        retry_kwargs={'max_retries': 79},  # this works out about 72 hours
+    )
+    @functools.wraps(f)
+    def wrapper(*args, **kw):
+        function_name = f.__name__
+        try:
+            with amo.models.use_primary_db():
+                f(*args, **kw)
+        except Exception as exc:
+            retry_count = globals()[function_name].request.retries
+            statsd.incr(f'abuse.tasks.{function_name}.failure')
+            if isinstance(exc, retryable_exceptions) and retry_count == 0:
+                log.exception('Retrying Celery Task', exc_info=exc)
+            raise
+        else:
+            statsd.incr(f'abuse.tasks.{function_name}.success')
+
+    return wrapper
+
+
+@retryable_task
 def report_to_cinder(abuse_report_id):
-    try:
-        abuse_report = AbuseReport.objects.get(pk=abuse_report_id)
-        with translation.override(
-            to_language(abuse_report.application_locale or settings.LANGUAGE_CODE)
-        ):
-            CinderJob.report(abuse_report)
-    except Exception:
-        statsd.incr('abuse.tasks.report_to_cinder.failure')
-        raise
-    else:
-        statsd.incr('abuse.tasks.report_to_cinder.success')
+    abuse_report = AbuseReport.objects.get(pk=abuse_report_id)
+    with translation.override(
+        to_language(abuse_report.application_locale or settings.LANGUAGE_CODE)
+    ):
+        CinderJob.report(abuse_report)
 
 
-@task(**task_retry_kw)
-@use_primary_db
+@retryable_task
 def appeal_to_cinder(
     *, decision_cinder_id, abuse_report_id, appeal_text, user_id, is_reporter
 ):
-    try:
-        decision = ContentDecision.objects.get(cinder_id=decision_cinder_id)
-        if abuse_report_id:
-            abuse_report = AbuseReport.objects.get(id=abuse_report_id)
-        else:
-            abuse_report = None
-        if user_id:
-            user = UserProfile.objects.get(pk=user_id)
-        else:
-            # If no user is passed then they were anonymous, caller should have
-            # verified appeal was allowed, so the appeal is coming from the
-            # anonymous reporter and we have their name/email in the abuse report
-            # already.
-            user = None
-        decision.appeal(
-            abuse_report=abuse_report,
-            appeal_text=appeal_text,
-            user=user,
-            is_reporter=is_reporter,
-        )
-    except Exception:
-        statsd.incr('abuse.tasks.appeal_to_cinder.failure')
-        raise
+    decision = ContentDecision.objects.get(cinder_id=decision_cinder_id)
+    if abuse_report_id:
+        abuse_report = AbuseReport.objects.get(id=abuse_report_id)
     else:
-        statsd.incr('abuse.tasks.appeal_to_cinder.success')
+        abuse_report = None
+    if user_id:
+        user = UserProfile.objects.get(pk=user_id)
+    else:
+        # If no user is passed then they were anonymous, caller should have
+        # verified appeal was allowed, so the appeal is coming from the
+        # anonymous reporter and we have their name/email in the abuse report
+        # already.
+        user = None
+    decision.appeal(
+        abuse_report=abuse_report,
+        appeal_text=appeal_text,
+        user=user,
+        is_reporter=is_reporter,
+    )
 
 
-@task(**task_retry_kw)
-@use_primary_db
+@retryable_task
 def report_decision_to_cinder_and_notify(*, decision_id):
-    try:
-        decision = ContentDecision.objects.get(id=decision_id)
-        entity_helper = CinderJob.get_entity_helper(
-            decision.target,
-            resolved_in_reviewer_tools=True,
-        )
-        decision.report_to_cinder(entity_helper)
-        # We've already executed the action in the reviewer tools
-        decision.send_notifications()
-    except Exception:
-        statsd.incr('abuse.tasks.report_decision_to_cinder_and_notify.failure')
-        raise
-    else:
-        statsd.incr('abuse.tasks.report_decision_to_cinder_and_notify.success')
+    decision = ContentDecision.objects.get(id=decision_id)
+    entity_helper = CinderJob.get_entity_helper(
+        decision.target,
+        resolved_in_reviewer_tools=True,
+    )
+    decision.report_to_cinder(entity_helper)
+    # We've already executed the action in the reviewer tools
+    decision.send_notifications()
 
 
-@task(**task_retry_kw)
-@use_primary_db
+@retryable_task
 def sync_cinder_policies():
     max_length = CinderPolicy._meta.get_field('name').max_length
     policies_in_use_q = (
@@ -206,25 +204,19 @@ def sync_cinder_policies():
             )
             qs.update(present_in_cinder=False)
 
-    try:
-        url = f'{settings.CINDER_SERVER_URL}policies'
-        headers = {
-            'accept': 'application/json',
-            'content-type': 'application/json',
-            'authorization': f'Bearer {settings.CINDER_API_TOKEN}',
-        }
+    url = f'{settings.CINDER_SERVER_URL}policies'
+    headers = {
+        'accept': 'application/json',
+        'content-type': 'application/json',
+        'authorization': f'Bearer {settings.CINDER_API_TOKEN}',
+    }
 
-        response = requests.get(url, headers=headers)
-        response.raise_for_status()
-        data = response.json()
-        policies_in_cinder = sync_policies(data)
-        delete_unused_orphaned_policies(policies_in_cinder)
-        mark_used_orphaned_policies(policies_in_cinder)
-    except Exception:
-        statsd.incr('abuse.tasks.sync_cinder_policies.failure')
-        raise
-    else:
-        statsd.incr('abuse.tasks.sync_cinder_policies.success')
+    response = requests.get(url, headers=headers)
+    response.raise_for_status()
+    data = response.json()
+    policies_in_cinder = sync_policies(data)
+    delete_unused_orphaned_policies(policies_in_cinder)
+    mark_used_orphaned_policies(policies_in_cinder)
 
 
 @task

--- a/src/olympia/abuse/tests/test_cinder.py
+++ b/src/olympia/abuse/tests/test_cinder.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 from django.conf import settings
 
+import requests
 import responses
 import waffle
 from waffle.testutils import override_switch
@@ -127,7 +128,7 @@ class BaseTestCinderCase:
             == '1234-xyz'
         )
         # Last response is a 400, we raise for that.
-        with self.assertRaises(ConnectionError):
+        with self.assertRaises(requests.HTTPError):
             cinder_instance.report(report=report, reporter=None)
 
     def test_build_report_payload(self):
@@ -167,7 +168,7 @@ class BaseTestCinderCase:
             json={'external_id': '67890-abc'},
             status=400,
         )
-        with self.assertRaises(ConnectionError):
+        with self.assertRaises(requests.HTTPError):
             cinder_entity_instance.appeal(
                 decision_cinder_id=appealed_decision_id,
                 appeal_text='reason',
@@ -1091,7 +1092,7 @@ class TestCinderAddon(BaseTestCinderCase, TestCase):
             status=400,
         )
 
-        with self.assertRaises(ConnectionError):
+        with self.assertRaises(requests.HTTPError):
             cinder_addon.report_additional_context()
 
 
@@ -1386,7 +1387,7 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
         assert request_body['entity']['id'] == str(target.id)
 
         # Last response is a 400, we raise for that.
-        with self.assertRaises(ConnectionError):
+        with self.assertRaises(requests.HTTPError):
             cinder_instance.create_decision(
                 action='something',
                 reasoning='some review text',
@@ -1429,7 +1430,7 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
         assert 'entity' not in request_body
 
         # Last response is a 400, we raise for that.
-        with self.assertRaises(ConnectionError):
+        with self.assertRaises(requests.HTTPError):
             cinder_instance.create_job_decision(
                 job_id=job.job_id,
                 action='something',
@@ -1473,7 +1474,7 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
         assert 'entity' not in request_body
 
         # Last response is a 400, we raise for that.
-        with self.assertRaises(ConnectionError):
+        with self.assertRaises(requests.HTTPError):
             cinder_instance.create_override_decision(
                 decision_id=overridden_decision_id,
                 action='something',
@@ -2430,7 +2431,7 @@ class TestCinderUser(BaseTestCinderCase, TestCase):
             status=400,
         )
 
-        with self.assertRaises(ConnectionError):
+        with self.assertRaises(requests.HTTPError):
             cinder_user.report_additional_context()
 
 

--- a/src/olympia/abuse/tests/test_tasks.py
+++ b/src/olympia/abuse/tests/test_tasks.py
@@ -6,12 +6,11 @@ from unittest import mock
 from django.conf import settings
 
 import pytest
-import requests
 import responses
+from celery.exceptions import Retry
 from freezegun import freeze_time
 
 from olympia import amo
-from olympia.abuse.tasks import flag_high_abuse_reports_addons_according_to_review_tier
 from olympia.activity.models import ActivityLog
 from olympia.amo.tests import TestCase, addon_factory, days_ago, user_factory
 from olympia.constants.abuse import (
@@ -25,9 +24,11 @@ from olympia.reviewers.models import NeedsHumanReview, ReviewActionReason, Usage
 from olympia.versions.models import Version
 from olympia.zadmin.models import set_config
 
+from ..cinder import CinderAddon
 from ..models import AbuseReport, CinderJob, CinderPolicy, ContentDecision
 from ..tasks import (
     appeal_to_cinder,
+    flag_high_abuse_reports_addons_according_to_review_tier,
     handle_escalate_action,
     report_decision_to_cinder_and_notify,
     report_to_cinder,
@@ -330,8 +331,10 @@ def test_addon_report_to_cinder_exception(statsd_incr_mock):
     )
     statsd_incr_mock.reset_mock()
 
-    with pytest.raises(ConnectionError):
+    with pytest.raises(Retry) as exc_info:
         report_to_cinder.delay(abuse_report.id)
+    assert exc_info.value.when > 0
+    assert exc_info.value.when <= 30
 
     assert CinderJob.objects.count() == 0
 
@@ -425,6 +428,44 @@ def test_addon_report_to_cinder_different_locale():
 
 
 @pytest.mark.django_db
+@mock.patch.object(CinderAddon, 'RELATIONSHIPS_BATCH_SIZE', 1)
+@mock.patch('olympia.amo.tasks.statsd.incr')
+def test_addon_report_with_additional_context_no_retry(statsd_incr_mock):
+    addon = addon_factory()
+    addon.authors.add(user_factory())
+    addon.authors.add(user_factory())
+
+    abuse_report = AbuseReport.objects.create(
+        guid=addon.guid,
+        reason=AbuseReport.REASONS.ILLEGAL,
+        message='This is bad',
+        illegal_category=ILLEGAL_CATEGORIES.OTHER,
+        illegal_subcategory=ILLEGAL_SUBCATEGORIES.OTHER,
+    )
+    responses.add(
+        responses.POST,
+        f'{settings.CINDER_SERVER_URL}create_report',
+        json={'job_id': '1234-xyz'},
+        status=201,
+    )
+    additional = responses.add(
+        responses.POST,
+        f'{settings.CINDER_SERVER_URL}graph/',
+        status=400,
+    )
+    statsd_incr_mock.reset_mock()
+
+    # An exception in the additional context shouldn't trigger a Retry
+    with pytest.raises(ConnectionError):
+        report_to_cinder.delay(abuse_report.id)
+
+    assert len(responses.calls) == 2
+    assert statsd_incr_mock.call_count == 1
+    assert statsd_incr_mock.call_args[0] == ('abuse.tasks.report_to_cinder.failure',)
+    assert additional.call_count == 1
+
+
+@pytest.mark.django_db
 @mock.patch('olympia.abuse.tasks.statsd.incr')
 def test_addon_appeal_to_cinder_reporter(statsd_incr_mock):
     addon = addon_factory()
@@ -515,7 +556,7 @@ def test_addon_appeal_to_cinder_reporter_exception(statsd_incr_mock):
     )
     statsd_incr_mock.reset_mock()
 
-    with pytest.raises(ConnectionError):
+    with pytest.raises(Retry) as exc_info:
         appeal_to_cinder.delay(
             decision_cinder_id=cinder_job.decision.cinder_id,
             abuse_report_id=abuse_report.id,
@@ -523,6 +564,8 @@ def test_addon_appeal_to_cinder_reporter_exception(statsd_incr_mock):
             user_id=None,
             is_reporter=True,
         )
+    assert exc_info.value.when > 0
+    assert exc_info.value.when <= 30
 
     assert statsd_incr_mock.call_count == 1
     assert statsd_incr_mock.call_args[0] == ('abuse.tasks.appeal_to_cinder.failure',)
@@ -743,8 +786,10 @@ def test_report_decision_to_cinder_and_notify_exception(statsd_incr_mock):
     )
     statsd_incr_mock.reset_mock()
 
-    with pytest.raises(ConnectionError):
+    with pytest.raises(Retry) as exc_info:
         report_decision_to_cinder_and_notify.delay(decision_id=decision.id)
+    assert exc_info.value.when > 0
+    assert exc_info.value.when <= 30
 
     assert statsd_incr_mock.call_count == 1
     assert statsd_incr_mock.call_args[0] == (
@@ -764,7 +809,7 @@ class TestSyncCinderPolicies(TestCase):
 
     def test_sync_cinder_policies_headers(self):
         responses.add(responses.GET, self.url, json=[], status=200)
-        sync_cinder_policies()
+        sync_cinder_policies.delay()
         assert 'Authorization' in responses.calls[0].request.headers
         assert (
             responses.calls[0].request.headers['Authorization']
@@ -773,12 +818,14 @@ class TestSyncCinderPolicies(TestCase):
 
     def test_sync_cinder_policies_raises_for_non_200(self):
         responses.add(responses.GET, self.url, json=[], status=500)
-        with pytest.raises(requests.HTTPError):
-            sync_cinder_policies()
+        with pytest.raises(Retry) as exc_info:
+            sync_cinder_policies.delay()
+        assert exc_info.value.when > 0
+        assert exc_info.value.when <= 30
 
     def test_sync_cinder_policies_creates_new_record(self):
         responses.add(responses.GET, self.url, json=[self.policy], status=200)
-        sync_cinder_policies()
+        sync_cinder_policies.delay()
         assert CinderPolicy.objects.filter(uuid='test-uuid').exists()
 
     def test_sync_cinder_policies_updates_existing_record(self):
@@ -796,7 +843,7 @@ class TestSyncCinderPolicies(TestCase):
         }
         responses.add(responses.GET, self.url, json=[changed_policy], status=200)
 
-        sync_cinder_policies()
+        sync_cinder_policies.delay()
 
         updated_policy = CinderPolicy.objects.get(uuid='test-uuid')
         assert updated_policy.name == changed_policy['name']
@@ -805,7 +852,7 @@ class TestSyncCinderPolicies(TestCase):
     def test_sync_cinder_policies_maps_fields_correctly(self):
         responses.add(responses.GET, self.url, json=[self.policy], status=200)
 
-        sync_cinder_policies()
+        sync_cinder_policies.delay()
 
         created_policy = CinderPolicy.objects.get(uuid=self.policy['uuid'])
         assert created_policy.name == self.policy['name']
@@ -816,7 +863,7 @@ class TestSyncCinderPolicies(TestCase):
         self.policy['nested_policies'] = [nested_policy]
         responses.add(responses.GET, self.url, json=[self.policy], status=200)
 
-        sync_cinder_policies()
+        sync_cinder_policies.delay()
 
         nested_policy = CinderPolicy.objects.get(uuid=nested_policy['uuid'])
         assert (
@@ -841,7 +888,7 @@ class TestSyncCinderPolicies(TestCase):
         ]
         responses.add(responses.GET, self.url, json=policies, status=200)
 
-        sync_cinder_policies()
+        sync_cinder_policies.delay()
 
         new_policy = CinderPolicy.objects.get(uuid='some-uuid')
         assert new_policy.name == 'a' * 255  # Truncated.
@@ -891,7 +938,7 @@ class TestSyncCinderPolicies(TestCase):
         )
         responses.add(responses.GET, self.url, json=[self.policy], status=200)
 
-        sync_cinder_policies()
+        sync_cinder_policies.delay()
         assert CinderPolicy.objects.filter(uuid='test-uuid').exists()
         assert updated_policy.reload().present_in_cinder is True
 
@@ -927,7 +974,7 @@ class TestSyncCinderPolicies(TestCase):
         )
         responses.add(responses.GET, self.url, json=[self.policy], status=200)
 
-        sync_cinder_policies()
+        sync_cinder_policies.delay()
         assert CinderPolicy.objects.filter(uuid='test-uuid-nested').exists()
         assert updated_nested_policy.reload().present_in_cinder is True
 
@@ -1011,7 +1058,7 @@ class TestSyncCinderPolicies(TestCase):
         ]
         responses.add(responses.GET, self.url, json=data, status=200)
 
-        sync_cinder_policies()
+        sync_cinder_policies.delay()
         assert CinderPolicy.objects.count() == 6
         assert CinderPolicy.objects.filter(text='ADDED').count() == 6
 

--- a/src/olympia/abuse/tests/test_tasks.py
+++ b/src/olympia/abuse/tests/test_tasks.py
@@ -340,7 +340,7 @@ def test_addon_report_to_cinder_exception(log_exception_mock, statsd_incr_mock):
     assert log_exception_mock.call_count == 1
     assert log_exception_mock.call_args_list == [
         (
-            ('Retrying Celery Task',),
+            ('Retrying Celery Task report_to_cinder',),
             {'exc_info': exception.exc},
         ),
     ]
@@ -582,7 +582,7 @@ def test_addon_appeal_to_cinder_reporter_exception(
     assert log_exception_mock.call_count == 1
     assert log_exception_mock.call_args_list == [
         (
-            ('Retrying Celery Task',),
+            ('Retrying Celery Task appeal_to_cinder',),
             {'exc_info': exception.exc},
         ),
     ]
@@ -817,7 +817,7 @@ def test_report_decision_to_cinder_and_notify_exception(
     assert log_exception_mock.call_count == 1
     assert log_exception_mock.call_args_list == [
         (
-            ('Retrying Celery Task',),
+            ('Retrying Celery Task report_decision_to_cinder_and_notify',),
             {'exc_info': exception.exc},
         ),
     ]
@@ -858,7 +858,7 @@ class TestSyncCinderPolicies(TestCase):
         assert log_exception_mock.call_count == 1
         assert log_exception_mock.call_args_list == [
             (
-                ('Retrying Celery Task',),
+                ('Retrying Celery Task sync_cinder_policies',),
                 {'exc_info': exception.exc},
             ),
         ]

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -494,23 +494,22 @@ class TestCase(PatchMixin, InitializeSessionMixin, test.TestCase):
         kwargs.setdefault('fetch_redirect_response', False)
         return self.assertRedirects(*args, **kwargs)
 
-    def assertCloseToNow(self, dt, *, now=None, delta=None):
+    def assertCloseToNow(self, dt, now=None):
         """
         Make sure the datetime is within a minute from `now`.
         """
         if not dt or not isinstance(dt, datetime):
             raise AssertionError('Expected datetime; got %s' % dt)
-        delta = delta or timedelta(minutes=1)
 
-        dt_later_ts = time.mktime((dt + delta).timetuple())
-        dt_earlier_ts = time.mktime((dt - delta).timetuple())
+        dt_later_ts = time.mktime((dt + timedelta(minutes=1)).timetuple())
+        dt_earlier_ts = time.mktime((dt - timedelta(minutes=1)).timetuple())
         if not now:
             now = datetime.now()
         now_ts = time.mktime(now.timetuple())
 
         assert (
             dt_earlier_ts < now_ts < dt_later_ts
-        ), f'Expected datetime to be {delta!r} of {now}. Got {dt!r}.'
+        ), f'Expected datetime to be within a minute of {now}. Got {dt!r}.'
 
     def assertQuerySetContentsEqual(self, qs1, qs2):
         """

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -494,22 +494,23 @@ class TestCase(PatchMixin, InitializeSessionMixin, test.TestCase):
         kwargs.setdefault('fetch_redirect_response', False)
         return self.assertRedirects(*args, **kwargs)
 
-    def assertCloseToNow(self, dt, now=None):
+    def assertCloseToNow(self, dt, *, now=None, delta=None):
         """
         Make sure the datetime is within a minute from `now`.
         """
         if not dt or not isinstance(dt, datetime):
             raise AssertionError('Expected datetime; got %s' % dt)
+        delta = delta or timedelta(minutes=1)
 
-        dt_later_ts = time.mktime((dt + timedelta(minutes=1)).timetuple())
-        dt_earlier_ts = time.mktime((dt - timedelta(minutes=1)).timetuple())
+        dt_later_ts = time.mktime((dt + delta).timetuple())
+        dt_earlier_ts = time.mktime((dt - delta).timetuple())
         if not now:
             now = datetime.now()
         now_ts = time.mktime(now.timetuple())
 
         assert (
             dt_earlier_ts < now_ts < dt_later_ts
-        ), f'Expected datetime to be within a minute of {now}. Got {dt!r}.'
+        ), f'Expected datetime to be {delta!r} of {now}. Got {dt!r}.'
 
     def assertQuerySetContentsEqual(self, qs1, qs2):
         """


### PR DESCRIPTION
Fixes: mozilla/addons#15359

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Adds retry to some tasks (as specified in the issue). Currently the settings are:
-  [`retry_jitter`](https://docs.celeryq.dev/en/latest/userguide/tasks.html#Task.retry_jitter)`: True` (by default) - all retry delays are variable, with the exact delay between 0 seconds and whatever the retry delay was calculated as.
- `retry_backoff: 30` - the first retry will be (a maximum of) 30 seconds after; the retry after that (a maximum of) 60 seconds, then 120, and so on.
- `retry_backoff_max: 60*60` - the maximum delay between retries will be 1 hour
- `max_retries: 79` - I calculated this with a spreadsheet, to see how many retries would be needed to retry for 72 hours.  Though with retry_jitter it will be always less than 72 hours... so could need increasing.

A report of an entity with many relationships can lead to multiple requests - the patch currently excludes those failures from retry as there's no easy way to retry part of a task.

### Testing
- Prevent cinder from being accessible from your local addons-server instance somehow (turn off your wifi?)
- Take an action that would normally communicate with Cinder, e.g. submitting an abuse report
- see in logs from `addons-server-worker` container that the task failed with a request exception
- wait 30 seconds
- see another request exception from celery
- reconnect your connection to Cinder
- after some amount of time (the 1st retry would be up to 30 seconds after the original attempt; the second up to 60 seconds after the first) the task should succeed
- verify the abuse report was submitted and we updated the AbuseReport with an fk to a CinderJob (there may not have been a new CinderJob created if that add-on was reported for abuse previously).

<!--
Your change must be related to an existing, open issue. This issue should contain testing instructions.
Often, the testing info in the issue is higher level, geared towards a user or QA experience.
Here you can provide information for a developer verifying this PR. Get technical.
If it is not relevant to your PR, remove this section.
-->

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
