### PR TITLE
create approve 2nd level decision with non-addon entities too

### DIFF
--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -1261,6 +1261,9 @@ def decision_review(request, decision_id):
             case 'no':
                 new_decision = ContentDecision.objects.create(
                     addon=decision.addon,
+                    rating=decision.rating,
+                    collection=decision.collection,
+                    user=decision.user,
                     action=DECISION_ACTIONS.AMO_APPROVE,
                     reviewer_user=request.user,
                     override_of=decision,


### PR DESCRIPTION
Fixes: mozilla/addons#15382

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Correctly creates ContentDecision with all possible entities, not just `addon`.

### Testing

- set up a non-addon decision to require 2nd level approval - e.g. a delete collection owned by TaskUser, by reporting it; choosing to delete the collection in cinder; then replaying the webhook locally
  - or fake it by creating a `ContentDecision` without an `action_date` set
- navigate to the review page for the 2nd level approval via the reviewer tools
- choose to approve (i.e. deny the delete action)
- see: no 500 error; content remains non-deleted; record of Approve decision in Cinder

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
