### PR TITLE
Clarify URL handling for extension fields.

### DIFF
--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -246,8 +246,9 @@ Note, if the field is also a translated field then the ``url`` and ``outgoing``
 values could be an object rather than a string
 (See :ref:`translated fields <api-overview-translations>` for translated field representations).
 
-Fields supporting some HTML or Markdown, such as add-on ``description`` or ``summary``,
-always wrap any links directly inside the content (the original url is not available).
+Fields supporting some Markdown, such as add-on ``description`` or ``license``,
+always wrap any links directly inside the content (the original url is not
+available).
 
 
 ~~~~~~~~~~~~


### PR DESCRIPTION
Fixes: mozilla/addons#15393

### Description

The original text suggested that it was possible to use HTML or Markdown in an extension's `summary` field. Rephrase to remove the reference to HTML and to use another field (`license` where Markdown is valid.

### Context

N/A

### Testing

N/A. I was not able to get docs to build locally.

### Checklist

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [x] Add or update relevant [docs](../docs/) reflecting the changes made.
