### PR TITLE
prevent 2nd level approval form from being submitted if not pending

### DIFF
--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -7618,3 +7618,18 @@ class TestHeldDecisionReview(ReviewerTest):
         assert response.status_code == 403
         assert self.decision.addon.reload().status == amo.STATUS_APPROVED
         assert self.decision.reload().action_date is None
+
+    def test_cant_submit_a_resolved_decision(self):
+        self.decision.update(action_date=datetime.now())
+        addon = self.decision.addon
+
+        response = self.client.post(self.url, {'choice': 'yes'})
+
+        assert response.status_code == 200
+        assert addon.reload().status == amo.STATUS_APPROVED
+        self.assertFormError(
+            response,
+            form='form',
+            field=None,
+            errors=['Not currently held for 2nd level approval'],
+        )


### PR DESCRIPTION
Fixes: mozilla/addons#15389

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

adds a form validation check that the decision is awaiting a 2nd level approval (the decision is in the queue) so decisions that have already been processed so have an action date - or are overridden with a new decision - can't be processed again.

### Testing

- set up a decision that is held for second level approval (e.g. a reject on a recommended add-on)
- either proceed with, or deny, that decision in the held decisions queue
- navigate back to the review page and try to do it again
- (optionally):
  - repeat with the other actions
  - attempt with a decision that wasn't held in the first place. 

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
