### PR TITLE
add retry_unreported_abuse_reports command to retry AbuseReports

### DIFF
--- a/src/olympia/abuse/management/commands/retry_unreported_abuse_reports.py
+++ b/src/olympia/abuse/management/commands/retry_unreported_abuse_reports.py
@@ -1,0 +1,20 @@
+from django.core.management.base import BaseCommand
+
+import olympia.core.logger
+from olympia.abuse.models import AbuseReport, AbuseReportManager
+from olympia.abuse.tasks import report_to_cinder
+
+
+class Command(BaseCommand):
+    log = olympia.core.logger.getLogger('z.abuse')
+
+    def handle(self, *args, **options):
+        qs = AbuseReport.objects.filter(
+            AbuseReportManager.is_individually_actionable_q(), cinder_job__isnull=True
+        )
+        self.stdout.write(f'{len(qs)} AbuseReports to report to Cinder')
+
+        for report in qs:
+            # call task to fire off cinder report
+            self.log.info('Created task for %s.', report)
+            report_to_cinder.delay(report.id)

--- a/src/olympia/abuse/tests/test_commands.py
+++ b/src/olympia/abuse/tests/test_commands.py
@@ -78,3 +78,34 @@ def test_backfill_cinder_escalations():
     assert new_appeal_job
     assert new_appeal_job.resolvable_in_reviewer_tools is True
     assert appealled_decision.reload().appeal_job == new_appeal_job
+
+
+@pytest.mark.django_db
+def test_retry_unreported_abuse_reports():
+    addon = addon_factory()
+    reported_job = CinderJob.objects.create()
+    reported = AbuseReport.objects.create(
+        guid=addon.guid,
+        reason=AbuseReport.REASONS.HATEFUL_VIOLENT_DECEPTIVE,
+        cinder_job=reported_job,
+    )
+    unreported = AbuseReport.objects.create(
+        guid=addon.guid, reason=AbuseReport.REASONS.HATEFUL_VIOLENT_DECEPTIVE
+    )
+    notactionable = AbuseReport.objects.create(
+        guid=addon.guid, reason=AbuseReport.REASONS.FEEDBACK_SPAM
+    )
+    responses.add(
+        responses.POST,
+        f'{settings.CINDER_SERVER_URL}create_report',
+        json={'job_id': '1234-xyz'},
+        status=201,
+    )
+
+    call_command('retry_unreported_abuse_reports')
+
+    assert reported.reload().cinder_job == reported_job  # not changed
+    assert unreported.reload().cinder_job is not None
+    assert unreported.cinder_job.job_id == '1234-xyz'
+    assert notactionable.reload().cinder_job is None
+    assert len(responses.calls) == 1


### PR DESCRIPTION
Fixes: mozilla/addons#15376
<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Fires the `report_to_cinder` celery task for any AbuseReports that should have been reported to Cinder but don't have an associated `CinderJob` (e.g. the reporting to Cinder failed; or the waffle switch was disabled at the time)

### Context

Doesn't depend on https://github.com/mozilla/addons/issues/15359 but makes more sense after it's merged

### Testing

- toggle `dsa-job-technical-processing` waffle switch off
- submit an abuse report for an addon/collection, etc
- check AbuseRepot is created in database but it has no associated CinderJob
- execute `./manage.py retry_unreported_abuse_reports` 
- see AbuseReport now has an associated `.cinder_job` fk
- (re-enable `dsa-job-technical-processing` before you forget 😉)

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
