### PR TITLE
Prevent automatic actions from being recorded in review queue history table

### DIFF
--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -4128,7 +4128,11 @@ class TestReviewHelper(TestReviewHelperBase):
             )
 
     def test_non_human_approval_does_not_affect_queue_history(self):
-        self.setup_data(amo.STATUS_APPROVED, file_status=amo.STATUS_AWAITING_REVIEW, human_review=False)
+        self.setup_data(
+            amo.STATUS_APPROVED,
+            file_status=amo.STATUS_AWAITING_REVIEW,
+            human_review=False,
+        )
         self.review_version.needshumanreview_set.all().delete()
         self.review_version.reviewqueuehistory_set.all().delete()
         self.review_version.needshumanreview_set.create()

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -933,7 +933,13 @@ class ReviewBase:
                 self.addon.promotedaddon.approve_for_version(version)
 
     def update_queue_history(self, log_entry):
-        if log_entry:
+        """Update ReviewQueueHistory so that the first action (log_entry) made
+        by a reviewer for each version is recorded.
+
+        Does nothing if log_entry is somehow falsy, or the action wasn't
+        performed by a human, or there was already a record for a given version
+        (only the first human "review" counts)."""
+        if log_entry and self.human_review:
             # Each entry in the ReviewQueueHistory corresponding to a version
             # we are affecting and that doesn't already have a review decision
             # log should get one. The exit_date will be cleared separately in


### PR DESCRIPTION
Fixes: mozilla/addons#15276

See issue for STR, or unit test for testing.