### PR TITLE
prevent .git directory from being copied into docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -61,3 +61,6 @@ docker-bake.hcl
 docker-compose*.yml
 Dockerfile*
 Makefile-os
+
+# Do not copy .git directory to docker images
+.git


### PR DESCRIPTION
Fixes:
https://bugzilla.mozilla.org/show_bug.cgi?id=1950939

