### PR TITLE
seperate forwards from 2nd level approval queue NHRs

### DIFF
--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -370,6 +370,7 @@ class CinderJob(ModelBase):
             reasons = {
                 NeedsHumanReview.REASONS.CINDER_ESCALATION,
                 NeedsHumanReview.REASONS.CINDER_APPEAL_ESCALATION,
+                NeedsHumanReview.REASONS.AMO_2ND_LEVEL_ESCALATION,
             }
         elif self.queue_moves.exists():
             has_unresolved_jobs_with_similar_reason = base_unresolved_jobs_qs.filter(

--- a/src/olympia/abuse/tasks.py
+++ b/src/olympia/abuse/tasks.py
@@ -227,12 +227,14 @@ def sync_cinder_policies():
 
 @task
 @use_primary_db
-def handle_escalate_action(*, job_pk):
+def handle_escalate_action(*, job_pk, from_2nd_level=False):
     old_job = CinderJob.objects.get(id=job_pk)
     entity_helper = CinderJob.get_entity_helper(
         old_job.target, resolved_in_reviewer_tools=True
     )
-    job_id = entity_helper.workflow_recreate(notes=old_job.decision.notes, job=old_job)
+    job_id = entity_helper.workflow_recreate(
+        notes=old_job.decision.notes, job=old_job, from_2nd_level=from_2nd_level
+    )
 
     old_job.handle_job_recreated(new_job_id=job_id, resolvable_in_reviewer_tools=True)
 

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -1447,12 +1447,17 @@ class TestCinderJob(TestCase):
             version=addon.current_version,
             reason=NeedsHumanReview.REASONS.ADDON_REVIEW_APPEAL,
         )
+        NeedsHumanReview.objects.create(
+            version=addon.current_version,
+            reason=NeedsHumanReview.REASONS.AMO_2ND_LEVEL_ESCALATION,
+        )
 
         # for a non-forwarded or appealed job, this should clear the abuse NHR only
         job.clear_needs_human_review_flags()
         assert not nhr_exists(NeedsHumanReview.REASONS.ABUSE_ADDON_VIOLATION)
         assert nhr_exists(NeedsHumanReview.REASONS.CINDER_ESCALATION)
         assert nhr_exists(NeedsHumanReview.REASONS.ADDON_REVIEW_APPEAL)
+        assert nhr_exists(NeedsHumanReview.REASONS.AMO_2ND_LEVEL_ESCALATION)
 
         NeedsHumanReview.objects.create(
             version=addon.current_version,
@@ -1472,6 +1477,7 @@ class TestCinderJob(TestCase):
         assert nhr_exists(NeedsHumanReview.REASONS.ABUSE_ADDON_VIOLATION)
         assert nhr_exists(NeedsHumanReview.REASONS.CINDER_ESCALATION)
         assert nhr_exists(NeedsHumanReview.REASONS.ADDON_REVIEW_APPEAL)
+        assert nhr_exists(NeedsHumanReview.REASONS.AMO_2ND_LEVEL_ESCALATION)
 
         # unless the other job is closed too
         other_forward.update(
@@ -1483,10 +1489,15 @@ class TestCinderJob(TestCase):
         assert nhr_exists(NeedsHumanReview.REASONS.ABUSE_ADDON_VIOLATION)
         assert not nhr_exists(NeedsHumanReview.REASONS.CINDER_ESCALATION)
         assert nhr_exists(NeedsHumanReview.REASONS.ADDON_REVIEW_APPEAL)
+        assert not nhr_exists(NeedsHumanReview.REASONS.AMO_2ND_LEVEL_ESCALATION)
 
         NeedsHumanReview.objects.create(
             version=addon.current_version,
             reason=NeedsHumanReview.REASONS.CINDER_ESCALATION,
+        )
+        NeedsHumanReview.objects.create(
+            version=addon.current_version,
+            reason=NeedsHumanReview.REASONS.AMO_2ND_LEVEL_ESCALATION,
         )
         # similarly if the job is an appeal we make sure that there are no other appeals
         CinderJob.objects.create(
@@ -1515,6 +1526,7 @@ class TestCinderJob(TestCase):
         assert nhr_exists(NeedsHumanReview.REASONS.ABUSE_ADDON_VIOLATION)
         assert nhr_exists(NeedsHumanReview.REASONS.CINDER_ESCALATION)
         assert nhr_exists(NeedsHumanReview.REASONS.ADDON_REVIEW_APPEAL)
+        assert nhr_exists(NeedsHumanReview.REASONS.AMO_2ND_LEVEL_ESCALATION)
 
         # unless the other job is closed too
         other_appeal.update(
@@ -1526,6 +1538,7 @@ class TestCinderJob(TestCase):
         assert nhr_exists(NeedsHumanReview.REASONS.ABUSE_ADDON_VIOLATION)
         assert nhr_exists(NeedsHumanReview.REASONS.CINDER_ESCALATION)
         assert not nhr_exists(NeedsHumanReview.REASONS.ADDON_REVIEW_APPEAL)
+        assert nhr_exists(NeedsHumanReview.REASONS.AMO_2ND_LEVEL_ESCALATION)
 
 
 class TestContentDecisionCanBeAppealed(TestCase):

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -3659,6 +3659,12 @@ class TestExtensionsQueues(TestCase):
             'needs_human_review_from_cinder_forwarded_appeal',
         )
 
+    def test_pending_queue_needs_human_review_from_2nd_level_approval(self):
+        self._test_pending_queue_needs_human_review_from(
+            NeedsHumanReview.REASONS.AMO_2ND_LEVEL_ESCALATION,
+            'needs_human_review_from_2nd_level_approval',
+        )
+
     def test_pending_queue_needs_human_review_other(self):
         self._test_pending_queue_needs_human_review_from(
             NeedsHumanReview.REASONS.SCANNER_ACTION, 'needs_human_review_other'

--- a/src/olympia/reviewers/models.py
+++ b/src/olympia/reviewers/models.py
@@ -86,6 +86,10 @@ VIEW_QUEUE_FLAGS = (
         'Appeal forwarded from Cinder',
     ),
     (
+        'needs_human_review_from_2nd_level_approval',
+        'Abuse or appeal forwarded from 2nd Level Approval',
+    ),
+    (
         'is_from_theme_awaiting_review',
         'Theme version',
     ),
@@ -895,6 +899,11 @@ class NeedsHumanReview(ModelBase):
         ('AUTO_APPROVAL_DISABLED', 13, 'Has auto-approval disabled'),
         ('BELONGS_TO_PROMOTED_GROUP', 14, 'Belongs to a promoted group'),
         ('CINDER_APPEAL_ESCALATION', 15, 'Escalated appeal via cinder'),
+        (
+            'AMO_2ND_LEVEL_ESCALATION',
+            16,
+            'Forwarded from 2nd level approval to reviewers',
+        ),
     )
     REASONS.add_subset(
         'ABUSE_OR_APPEAL_RELATED',
@@ -903,6 +912,7 @@ class NeedsHumanReview(ModelBase):
             'ABUSE_ADDON_VIOLATION',
             'ADDON_REVIEW_APPEAL',
             'CINDER_APPEAL_ESCALATION',
+            'AMO_2ND_LEVEL_ESCALATION',
         ),
     )
 

--- a/src/olympia/reviewers/tests/test_models.py
+++ b/src/olympia/reviewers/tests/test_models.py
@@ -1791,6 +1791,7 @@ class TestGetFlags(TestCase):
             self.addon.needs_human_review_from_abuse = False
             self.addon.needs_human_review_from_cinder_forwarded_abuse = False
             self.addon.needs_human_review_from_cinder_forwarded_appeal = False
+            self.addon.needs_human_review_from_2nd_level_approval = False
             self.addon.needs_human_review_from_appeal = False
             self.addon.is_from_theme_awaiting_review = False
             self.addon.needs_human_review_promoted = False
@@ -1809,6 +1810,10 @@ class TestGetFlags(TestCase):
             (
                 'needs_human_review_from_cinder_forwarded_appeal',
                 'Appeal forwarded from Cinder',
+            ),
+            (
+                'needs_human_review_from_2nd_level_approval',
+                'Abuse or appeal forwarded from 2nd Level Approval',
             ),
             ('needs_human_review_from_abuse', 'Abuse report to AMO'),
             ('needs_human_review_from_appeal', 'Appeal on decision from AMO'),

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -7595,6 +7595,11 @@ class TestHeldDecisionReview(ReviewerTest):
         assert new_job
         assert new_job.resolvable_in_reviewer_tools
         self.assertCloseToNow(self.decision.reload().action_date)
+        assert NeedsHumanReview.objects.filter(
+            reason=NeedsHumanReview.REASONS.AMO_2ND_LEVEL_ESCALATION,
+            is_active=True,
+            version=addon.current_version,
+        ).exists()
 
     def test_release_user_ban_hold(self):
         self.decision.update(

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -1279,7 +1279,7 @@ def decision_review(request, decision_id):
                 # execution flow.
                 decision.update(action_date=datetime.now())
                 for job in form.cinder_jobs_qs:
-                    handle_escalate_action.delay(job_pk=job.id)
+                    handle_escalate_action.delay(job_pk=job.id, from_2nd_level=True)
         return redirect('reviewers.queue_decisions')
     return TemplateResponse(
         request,

--- a/src/olympia/signing/tests/test_views.py
+++ b/src/olympia/signing/tests/test_views.py
@@ -1502,9 +1502,12 @@ class TestSignedFile(SigningAPITestMixin, TestCase):
         assert response.status_code == 401
 
     def test_api_relies_on_version_downloader(self):
+        url = (
+            self.url()
+        )  # Resolve the URL before mocking to not mess up URL resolving cache
         with mock.patch('olympia.versions.views.download_file') as df:
             df.return_value = Response({})
-            self.get(self.url())
+            self.get(url)
         assert df.called is True
         assert df.call_args[0][0].user == self.user
         assert df.call_args[0][1] == str(self.file_.pk)

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -249,13 +249,15 @@ class VersionManager(ManagerBase):
             'is_from_theme_awaiting_review': is_from_theme_awaiting_review,
             'needs_human_review_from_cinder_forwarded_abuse': Q(
                 needshumanreview__is_active=True,
-                needshumanreview__reason__in={
-                    NeedsHumanReview.REASONS.CINDER_ESCALATION,
-                },
+                needshumanreview__reason=NeedsHumanReview.REASONS.CINDER_ESCALATION,
             ),
             'needs_human_review_from_cinder_forwarded_appeal': Q(
                 needshumanreview__is_active=True,
                 needshumanreview__reason=NeedsHumanReview.REASONS.CINDER_APPEAL_ESCALATION,
+            ),
+            'needs_human_review_from_2nd_level_approval': Q(
+                needshumanreview__is_active=True,
+                needshumanreview__reason=NeedsHumanReview.REASONS.AMO_2ND_LEVEL_ESCALATION,
             ),
             'needs_human_review_other': Q(
                 is_other_needs_human_review,
@@ -264,6 +266,7 @@ class VersionManager(ManagerBase):
                         NeedsHumanReview.REASONS.ABUSE_ADDON_VIOLATION.value,
                         NeedsHumanReview.REASONS.CINDER_ESCALATION.value,
                         NeedsHumanReview.REASONS.CINDER_APPEAL_ESCALATION.value,
+                        NeedsHumanReview.REASONS.AMO_2ND_LEVEL_ESCALATION.value,
                         NeedsHumanReview.REASONS.ADDON_REVIEW_APPEAL.value,
                         NeedsHumanReview.REASONS.BELONGS_TO_PROMOTED_GROUP.value,
                         NeedsHumanReview.REASONS.ADDED_TO_PROMOTED_GROUP.value,

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -1223,6 +1223,7 @@ class TestVersion(AMOPaths, TestCase):
             NeedsHumanReview.REASONS.CINDER_ESCALATION,
             NeedsHumanReview.REASONS.CINDER_APPEAL_ESCALATION,
             NeedsHumanReview.REASONS.ADDON_REVIEW_APPEAL,
+            NeedsHumanReview.REASONS.AMO_2ND_LEVEL_ESCALATION,
         ]:
             # Every other reason shouldn't result in a due date since the
             # version is disabled and not signed at this point.

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -469,6 +469,12 @@ class TestVersionManager(TestCase):
             reason=NeedsHumanReview.REASONS.CINDER_APPEAL_ESCALATION,
         )
 
+        forwarded_2nd_level_abuse = addon_factory(**addon_kws).current_version
+        NeedsHumanReview.objects.create(
+            version=forwarded_2nd_level_abuse,
+            reason=NeedsHumanReview.REASONS.AMO_2ND_LEVEL_ESCALATION,
+        )
+
         qs = Version.objects.should_have_due_date().order_by('id')
         assert list(qs) == [
             # absent addon with nothing special set
@@ -481,6 +487,7 @@ class TestVersionManager(TestCase):
             multiple,
             escalated_abuse,
             escalated_appeal,
+            forwarded_2nd_level_abuse,
         ]
 
     def test_get_due_date_reason_q_objects(self):
@@ -499,6 +506,7 @@ class TestVersionManager(TestCase):
             multiple,
             escalated_abuse,
             escalated_appeal,
+            forwarded_2nd_level_abuse,
         ) = list(qs)
 
         q_objects = Version.objects.get_due_date_reason_q_objects()
@@ -516,6 +524,10 @@ class TestVersionManager(TestCase):
         ) == [
             escalated_appeal,
         ]
+
+        assert list(
+            method(q_objects['needs_human_review_from_2nd_level_approval'])
+        ) == [forwarded_2nd_level_abuse]
 
         assert list(method(q_objects['needs_human_review_from_abuse'])) == [abuse_nhr]
 


### PR DESCRIPTION
Fixes: mozilla/addons#15413

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Separates forwards from 2nd level approval queue from other types of forward all the way down

### Testing

- Set up a decision on a job that requires 2nd level approval (e.g. report a recommended add-on for a policy violation in the add-on; then reject a version, resolving that job.)
- In the second level approval queue forward that decision back to the reviewer tools
- in reviewer tools manual review queue see toggle for "Abuse or appeal forwarded from 2nd Level Approval"
  - verify that the toggle works
- in the review page for the add-on see the NHR reason in the review history "Forwarded from 2nd level approval to reviewers"

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
