### PR TITLE
remove mv3 compatibility warning from devhub

### DIFF
--- a/src/olympia/devhub/tasks.py
+++ b/src/olympia/devhub/tasks.py
@@ -248,9 +248,7 @@ def validate_file_path(path, channel):
 
     log.info('Running linter on %s', path)
     results = run_addons_linter(path, channel=channel)
-    annotations.annotate_validation_results(
-        results=results, parsed_data=parsed_data, channel=channel
-    )
+    annotations.annotate_validation_results(results=results, parsed_data=parsed_data)
     return json.dumps(results)
 
 

--- a/src/olympia/devhub/tests/test_file_validation_annotations.py
+++ b/src/olympia/devhub/tests/test_file_validation_annotations.py
@@ -16,9 +16,7 @@ class TestDeniedOrigins(TestCase):
         DeniedInstallOrigin.objects.create(hostname_pattern='foo.com')
         results = deepcopy(VALIDATOR_SKELETON_RESULTS)
         data = {'install_origins': ['https://foo.com']}
-        return_value = annotate_validation_results(
-            results=results, parsed_data=data, channel=amo.CHANNEL_UNLISTED
-        )
+        return_value = annotate_validation_results(results=results, parsed_data=data)
         assert return_value == results
         assert results['errors'] == 0
         assert len(results['messages']) == 0
@@ -27,9 +25,7 @@ class TestDeniedOrigins(TestCase):
         DeniedInstallOrigin.objects.create(hostname_pattern='foo.com')
         results = deepcopy(VALIDATOR_SKELETON_RESULTS)
         data = {'install_origins': ['https://bar.com']}
-        return_value = annotate_validation_results(
-            results=results, parsed_data=data, channel=amo.CHANNEL_UNLISTED
-        )
+        return_value = annotate_validation_results(results=results, parsed_data=data)
         assert return_value == results
         assert results['errors'] == 0
         assert len(results['messages']) == 0
@@ -38,9 +34,7 @@ class TestDeniedOrigins(TestCase):
         DeniedInstallOrigin.objects.create(hostname_pattern='foo.com')
         results = deepcopy(VALIDATOR_SKELETON_RESULTS)
         data = {'install_origins': ['https://bar.com', 'https://example.com']}
-        return_value = annotate_validation_results(
-            results=results, parsed_data=data, channel=amo.CHANNEL_UNLISTED
-        )
+        return_value = annotate_validation_results(results=results, parsed_data=data)
         assert return_value == results
         assert results['errors'] == 0
         assert len(results['messages']) == 0
@@ -49,9 +43,7 @@ class TestDeniedOrigins(TestCase):
         DeniedInstallOrigin.objects.create(hostname_pattern='foo.com')
         results = deepcopy(VALIDATOR_SKELETON_RESULTS)
         data = {'install_origins': ['https://bar.com', 'https://foo.com']}
-        return_value = annotate_validation_results(
-            results=results, parsed_data=data, channel=amo.CHANNEL_UNLISTED
-        )
+        return_value = annotate_validation_results(results=results, parsed_data=data)
         assert return_value == results
         assert results['errors'] == 1
         assert results['messages'][0] == {
@@ -69,9 +61,7 @@ class TestDeniedOrigins(TestCase):
         DeniedInstallOrigin.objects.create(hostname_pattern='foo.*')
         results = deepcopy(VALIDATOR_SKELETON_RESULTS)
         data = {'install_origins': ['https://bar.com', 'https://foo.com']}
-        return_value = annotate_validation_results(
-            results=results, parsed_data=data, channel=amo.CHANNEL_UNLISTED
-        )
+        return_value = annotate_validation_results(results=results, parsed_data=data)
         assert return_value == results
         assert results['errors'] == 1
         assert results['messages'][0] == {
@@ -95,9 +85,7 @@ class TestDeniedOrigins(TestCase):
                 'https://foo.com',
             ]
         }
-        return_value = annotate_validation_results(
-            results=results, parsed_data=data, channel=amo.CHANNEL_UNLISTED
-        )
+        return_value = annotate_validation_results(results=results, parsed_data=data)
         assert return_value == results
         assert results['errors'] == 2
         assert results['messages'][0] == {
@@ -124,9 +112,7 @@ class TestDeniedOrigins(TestCase):
         DeniedInstallOrigin.objects.create(hostname_pattern='foo.*')
         results = deepcopy(VALIDATOR_SKELETON_RESULTS)
         data = {'install_origins': ['https://bar.com', 'https://foo.com']}
-        return_value = annotate_validation_results(
-            results=results, parsed_data=data, channel=amo.CHANNEL_UNLISTED
-        )
+        return_value = annotate_validation_results(results=results, parsed_data=data)
         assert return_value == results
         assert results['errors'] == 2
         assert results['messages'][0] == {
@@ -152,9 +138,7 @@ class TestDeniedOrigins(TestCase):
         DeniedInstallOrigin.objects.create(hostname_pattern='foo.com')
         results = deepcopy(VALIDATOR_SKELETON_RESULTS)
         data = {}
-        return_value = annotate_validation_results(
-            results=results, parsed_data=data, channel=amo.CHANNEL_UNLISTED
-        )
+        return_value = annotate_validation_results(results=results, parsed_data=data)
         assert return_value == results
         assert results['errors'] == 0
         assert len(results['messages']) == 0
@@ -166,9 +150,7 @@ class TestAddManifestVersionMessages(TestCase):
         results['messages'] = []
         results['metadata']['manifestVersion'] = 3
         data = {}
-        annotate_validation_results(
-            results=results, parsed_data=data, channel=amo.CHANNEL_UNLISTED
-        )
+        annotate_validation_results(results=results, parsed_data=data)
         # mv3 submission switch is off so we should have added the message even
         # for an unlisted submission.
         assert len(results['messages']) == 1
@@ -183,9 +165,7 @@ class TestAddManifestVersionMessages(TestCase):
         results['messages'] = []
         results['metadata']['manifestVersion'] = 2
         data = {}
-        annotate_validation_results(
-            results=results, parsed_data=data, channel=amo.CHANNEL_LISTED
-        )
+        annotate_validation_results(results=results, parsed_data=data)
         assert results['messages'] == []
 
     def test_add_manifest_version_message_switch_enabled(self):
@@ -194,27 +174,8 @@ class TestAddManifestVersionMessages(TestCase):
         results['metadata']['manifestVersion'] = 3
         data = {}
         with override_switch('enable-mv3-submissions', active=True):
-            annotate_validation_results(
-                results=results, parsed_data=data, channel=amo.CHANNEL_UNLISTED
-            )
+            annotate_validation_results(results=results, parsed_data=data)
             assert results['messages'] == []
-
-            # For listed mv3, we want our message suggesting to use unlisted for
-            # the time being.
-            annotate_validation_results(
-                results=results, parsed_data=data, channel=amo.CHANNEL_LISTED
-            )
-            assert len(results['messages']) == 1
-            assert (
-                results['messages'][0]['message'] == 'Manifest V3 compatibility warning'
-            )
-            assert (
-                'https://mzl.la/3hIwQXX'
-                in (
-                    # description is a list of strings, the link is in the second one.
-                    results['messages'][0]['description'][1]
-                )
-            )
 
     def test_add_manifest_version_message(self):
         results = deepcopy(amo.VALIDATOR_SKELETON_EXCEPTION_WEBEXT)
@@ -225,9 +186,7 @@ class TestAddManifestVersionMessages(TestCase):
         # The manifest_version error isn't in VALIDATOR_SKELETON_EXCEPTION_WEBEXT.
         results['metadata']['manifestVersion'] = 3
         data = {}
-        annotate_validation_results(
-            results=results, parsed_data=data, channel=amo.CHANNEL_LISTED
-        )
+        annotate_validation_results(results=results, parsed_data=data)
         assert len(results['messages']) == 2  # we added it
         # It should be inserted at the top.
         assert (
@@ -249,9 +208,7 @@ class TestAddManifestVersionMessages(TestCase):
         ]
         results['metadata']['manifestVersion'] = 3
         data = {}
-        annotate_validation_results(
-            results=results, parsed_data=data, channel=amo.CHANNEL_LISTED
-        )
+        annotate_validation_results(results=results, parsed_data=data)
         assert len(results['messages']) == 1  # we replaced it and not added it.
         assert (
             'https://blog.mozilla.org/addons/2021/05/27/manifest-v3-update/'

--- a/src/olympia/devhub/tests/test_tasks.py
+++ b/src/olympia/devhub/tests/test_tasks.py
@@ -547,7 +547,6 @@ class TestValidateFilePath(ValidatorTestCase):
         annotate_validation_results_mock.assert_called_with(
             results=run_addons_linter_mock.return_value,
             parsed_data=parse_addon_mock.return_value,
-            channel=amo.CHANNEL_UNLISTED,
         )
 
 

--- a/static/js/common/upload-addon.js
+++ b/static/js/common/upload-addon.js
@@ -608,9 +608,7 @@
               'UNSAFE_VAR_ASSIGNMENT',
               'MANIFEST_CSP',
             ],
-            mv3NoticeId = '_MV3_COMPATIBILITY',
             checklistMessages = [],
-            mv3CompatibilityMessage,
             // this.id is in the form ["abc_def_ghi', 'foo_bar', 'something'],
             // we usually only match one of the elements.
             matchId = function (id) {
@@ -638,21 +636,6 @@
                   1,
                 );
                 if (!checklistWarningsIds.length) break;
-              }
-
-              // Manifest v3 warning is a custom one added by addons-server
-              // that should be added once, regardless of whether or not we're
-              // displaying the submission warning box.
-              if (_.find([mv3NoticeId], matchId, current)) {
-                let mv3CompatibilityBox = $('<div>')
-                  .attr('class', 'submission-warning')
-                  .appendTo(upload_results);
-                $('<h5>').text(current.message).appendTo(mv3CompatibilityBox);
-                // That description is split into several paragraphs and can
-                // contain HTML for links.
-                current.description.forEach(function (item) {
-                  $('<p>').html(item).appendTo(mv3CompatibilityBox);
-                });
               }
             }
           }


### PR DESCRIPTION
Fixes: mozilla/addons#15341

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

As issue

### Testing

- with `enable-mv3-submissions` enabled try to submit an mv3 extension.  Observe no warning (it was previously on the listed channel)

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
