### PR TITLE
Fix review queue flag icon for cinder forwarded jobs

### DIFF
--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -1302,6 +1302,56 @@ class TestQueueBasics(QueueTest):
         assert rows.find('td').eq(1).text() == 'Firefox Fún 1.1'
         assert rows.find('.ed-sprite-promoted-line').length == 1
 
+    def test_flags_abuse_report_forwarded_from_cinder(self):
+        addon = addon_factory(name='Firefox Fún')
+        version = version_factory(
+            addon=addon,
+            version='1.1',
+            file_kw={'status': amo.STATUS_APPROVED},
+            due_date=datetime.now() + timedelta(hours=24),
+        )
+        NeedsHumanReview.objects.create(
+            reason=NeedsHumanReview.REASONS.CINDER_ESCALATION, version=version
+        )
+
+        r = self.client.get(reverse('reviewers.queue_extension'))
+
+        rows = pq(r.content)('#addon-queue tr.addon-row')
+        assert rows.length == 1
+        assert rows.attr('data-addon') == str(addon.id)
+        assert rows.find('td').eq(1).text() == 'Firefox Fún 1.1'
+        assert (
+            rows.find(
+                '.ed-sprite-needs-human-review-from-cinder-forwarded-abuse'
+            ).length
+            == 1
+        )
+
+    def test_flags_appeal_forwarded_from_cinder(self):
+        addon = addon_factory(name='Firefox Fún')
+        version = version_factory(
+            addon=addon,
+            version='1.1',
+            file_kw={'status': amo.STATUS_APPROVED},
+            due_date=datetime.now() + timedelta(hours=24),
+        )
+        NeedsHumanReview.objects.create(
+            reason=NeedsHumanReview.REASONS.CINDER_APPEAL_ESCALATION, version=version
+        )
+
+        r = self.client.get(reverse('reviewers.queue_extension'))
+
+        rows = pq(r.content)('#addon-queue tr.addon-row')
+        assert rows.length == 1
+        assert rows.attr('data-addon') == str(addon.id)
+        assert rows.find('td').eq(1).text() == 'Firefox Fún 1.1'
+        assert (
+            rows.find(
+                '.ed-sprite-needs-human-review-from-cinder-forwarded-appeal'
+            ).length
+            == 1
+        )
+
     def test_tabnav_permissions(self):
         response = self.client.get(self.url)
         assert response.status_code == 200

--- a/static/css/zamboni/reviewers.less
+++ b/static/css/zamboni/reviewers.less
@@ -54,8 +54,9 @@
 .ed-sprite-auto-approval-disabled { background-position: 0 -434px }
 .ed-sprite-auto-approval-disabled-unlisted { background-position: 0 -450px }
 .ed-sprite-needs-human-review-from-abuse { background-position: 0 -468px; }
-.ed-sprite-needs-human-review-from-cinder { background-position: 0 -484px; }
 .ed-sprite-needs-human-review-from-appeal { background-position: 0 -500px; }
+.ed-sprite-needs-human-review-from-cinder-forwarded-abuse { background-position: 0 -484px; }
+.ed-sprite-needs-human-review-from-cinder-forwarded-appeal { background-position: 0 -484px; }
 /* Those NeedsHumanReview reasons are already handled through separate, more
    precise flags, so hide them */
 .ed-sprite-needs-human-review-promoted { display: none; }


### PR DESCRIPTION
Fixes: mozilla/addons#15414 (followup, for main patch see https://github.com/mozilla/addons-server/pull/23122)

### Description

This followup fixes the review queue flag icons for forwarded jobs.

### Context

See main patch.

### Testing

See main patch.

I tested the icons locally by creating `NeedsHumanReview` objects with `REASON`s
* `CINDER_APPEAL_ESCALATION`
* `CINDER_ESCALATION`

The screenshot here shows both flags added:

<img width="1221" alt="Screenshot 2025-03-04 at 14 41 46" src="https://github.com/user-attachments/assets/0a7f5dfa-9fd0-47b6-9313-1999977c2422" />



### Checklist

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [x] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
