### PR TITLE
always detect if there is an attachment for a decision

### DIFF
--- a/src/olympia/abuse/actions.py
+++ b/src/olympia/abuse/actions.py
@@ -314,7 +314,7 @@ class ContentActionDisableAddon(ContentAction):
             activity_log__contentdecision__id=self.decision.id
         ).first():
             attachment.update(activity_log=activity_log)
-            activity_log.attacmentlog = attachment  # update fk
+            activity_log.attachmentlog = attachment  # update fk
         return activity_log
 
     def process_action(self):

--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -1335,12 +1335,17 @@ class ContentDecision(ModelBase):
         return log_entry
 
     def send_notifications(self):
+        from olympia.activity.models import AttachmentLog
+
         if not self.action_date:
             return
 
         action_helper = self.get_action_helper()
         cinder_job = self.originating_job
         log_entry = self.activities.last()
+        has_attachment = AttachmentLog.objects.filter(
+            activity_log__contentdecisionlog__decision=self
+        ).exists()
 
         if cinder_job:
             cinder_job.notify_reporters(action_helper)
@@ -1366,7 +1371,7 @@ class ContentDecision(ModelBase):
                 'is_addon_disabled': details.get('is_addon_being_disabled')
                 or getattr(self.target, 'is_disabled', False),
                 'version_list': ', '.join(ver_str for ver_str in version_numbers),
-                'has_attachment': hasattr(log_entry, 'attachmentlog'),
+                'has_attachment': has_attachment,
                 'dev_url': absolutify(self.target.get_dev_url('versions'))
                 if self.addon_id
                 else None,

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -2886,23 +2886,6 @@ class TestContentDecision(TestCase):
             expect_create_override_call=True,
         )
 
-    def _check_notify_emails(self, decision, log_entry):
-        assert len(mail.outbox) == 1
-        assert mail.outbox[0].to == [decision.addon.authors.first().email]
-        assert str(log_entry.id) in mail.outbox[0].extra_headers['Message-ID']
-        assert 'days' not in mail.outbox[0].body
-        assert 'some review text' in mail.outbox[0].body
-        assert 'some policy text' not in mail.outbox[0].body
-        AttachmentLog.objects.create(
-            activity_log=log_entry,
-            file=ContentFile('Pseudo File', name='attachment.txt'),
-        )
-        decision.send_notifications()
-        assert 'An attachment was provided.' not in mail.outbox[0].body
-        assert 'To respond or view the file,' not in mail.outbox[0].body
-        assert 'An attachment was provided.' in mail.outbox[1].body
-        assert 'To respond or view the file,' in mail.outbox[1].body
-
     def _test_execute_action_ban_user_outcome(self, decision):
         self.assertCloseToNow(decision.action_date)
         self.assertCloseToNow(decision.user.reload().banned)
@@ -2970,12 +2953,19 @@ class TestContentDecision(TestCase):
         alog = ActivityLog.objects.filter(
             action=amo.LOG.HELD_ACTION_FORCE_DISABLE.id
         ).get()
+        # attachment is linked to the original decision activity log
+        AttachmentLog.objects.create(
+            activity_log=alog,
+            file=ContentFile('Pseudo File', name='attachment.txt'),
+        )
         assert alog.contentdecisionlog_set.get().decision == decision
         decision.send_notifications()
         assert len(mail.outbox) == 0
 
         decision.execute_action(release_hold=True)
         self._test_execute_action_disable_addon_outcome(decision)
+        assert 'An attachment was provided.' in mail.outbox[0].body
+        assert 'To respond or view the file,' in mail.outbox[0].body
 
     def test_execute_action_disable_addon(self):
         addon = addon_factory(users=[user_factory()])
@@ -2988,6 +2978,8 @@ class TestContentDecision(TestCase):
         decision.execute_action()
         self._test_execute_action_disable_addon_outcome(decision)
         assert '14 day(s)' not in mail.outbox[0].body
+        assert 'An attachment was provided.' not in mail.outbox[0].body
+        assert 'To respond or view the file,' not in mail.outbox[0].body
 
     def _test_execute_action_reject_version_outcome(self, decision):
         decision.send_notifications()
@@ -3024,12 +3016,19 @@ class TestContentDecision(TestCase):
             action=amo.LOG.HELD_ACTION_REJECT_VERSIONS.id
         ).get()
         assert alog.contentdecisionlog_set.get().decision == decision
+        # attachment is linked to the original decision activity log
+        AttachmentLog.objects.create(
+            activity_log=alog,
+            file=ContentFile('Pseudo File', name='attachment.txt'),
+        )
         decision.send_notifications()
         assert len(mail.outbox) == 0
         assert not version.needshumanreview_set.filter(is_active=True).exists()
 
         decision.execute_action(release_hold=True)
         self._test_execute_action_reject_version_outcome(decision)
+        assert 'An attachment was provided.' in mail.outbox[0].body
+        assert 'To respond or view the file,' in mail.outbox[0].body
 
     def test_execute_action_reject_version(self):
         addon = addon_factory(users=[user_factory()])
@@ -3061,6 +3060,8 @@ class TestContentDecision(TestCase):
         self._test_execute_action_reject_version_outcome(decision)
         assert '14 day(s)' not in mail.outbox[0].body
         assert not version.needshumanreview_set.filter(is_active=True).exists()
+        assert 'An attachment was provided.' not in mail.outbox[0].body
+        assert 'To respond or view the file,' not in mail.outbox[0].body
 
     def _test_execute_action_reject_version_delayed_outcome(self, decision):
         decision.send_notifications()
@@ -3405,7 +3406,21 @@ class TestContentDecision(TestCase):
             process_mock.assert_not_called()
             hold_mock.assert_not_called()
         decision.send_notifications()
-        self._check_notify_emails(decision, log_entry)
+        assert len(mail.outbox) == 1
+        assert mail.outbox[0].to == [decision.addon.authors.first().email]
+        assert str(log_entry.id) in mail.outbox[0].extra_headers['Message-ID']
+        assert 'days' not in mail.outbox[0].body
+        assert 'some review text' in mail.outbox[0].body
+        assert 'some policy text' not in mail.outbox[0].body
+        AttachmentLog.objects.create(
+            activity_log=log_entry,
+            file=ContentFile('Pseudo File', name='attachment.txt'),
+        )
+        decision.send_notifications()
+        assert 'An attachment was provided.' not in mail.outbox[0].body
+        assert 'To respond or view the file,' not in mail.outbox[0].body
+        assert 'An attachment was provided.' in mail.outbox[1].body
+        assert 'To respond or view the file,' in mail.outbox[1].body
 
     def test_get_target_review_url(self):
         addon = addon_factory()


### PR DESCRIPTION
follow-up fix for: mozilla/addons#15412

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

changes how we detect if there is an attachment for a decision, to correctly include the template snippet about it.

### Context

It appears while fixing #15412 I fixed the attachment being available for download in developer hub, but inadvertently stopped the existence of the attachment being exposed in the email.
The more complete fix would be to refactor how `send_notifications` selects the appropriate activity log but to limit the scope of this pr, which is expected to be cherry-picked, I instead changed how `has_attachment` was determined.

### Testing

Follow the testing steps from https://github.com/mozilla/addons-server/pull/23121

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
