### PR TITLE
Migrate all admin js/css to vite compilation

### DIFF
--- a/src/olympia/abuse/admin.py
+++ b/src/olympia/abuse/admin.py
@@ -16,6 +16,7 @@ from olympia import amo
 from olympia.access import acl
 from olympia.addons.models import Addon, AddonApprovalsCounter
 from olympia.amo.admin import AMOModelAdmin, DateRangeFilter, FakeChoicesMixin
+from olympia.amo.templatetags.jinja_helpers import vite_asset
 from olympia.ratings.models import Rating
 from olympia.translations.utils import truncate_text
 
@@ -91,13 +92,8 @@ class MinimumReportsCountFilter(FakeChoicesMixin, admin.SimpleListFilter):
 
 
 class AbuseReportAdmin(AMOModelAdmin):
-    class Media(AMOModelAdmin.Media):
-        css = {
-            'all': (
-                'css/admin/amoadmin.css',
-                'css/admin/abuse_reports.css',
-            )
-        }
+    class Media:
+        css = {'all': (vite_asset('css/admin-abuse-report.less'),)}
 
     date_hierarchy = 'modified'
     list_display = (

--- a/src/olympia/addons/admin.py
+++ b/src/olympia/addons/admin.py
@@ -176,12 +176,9 @@ class FileInline(admin.TabularInline):
 
 
 class AddonAdmin(AMOModelAdmin):
-    class Media(AMOModelAdmin.Media):
-        css = {
-            'all': AMOModelAdmin.Media.css['all']
-            + (vite_asset('css/admin-addon.less'),)
-        }
-        js = AMOModelAdmin.Media.js + (
+    class Media:
+        css = {'all': (vite_asset('css/admin-addon.less'),)}
+        js = (
             # TODO: This is probably a redundant dependency
             'admin/js/jquery.init.js',
             vite_asset('js/admin-addon.js'),

--- a/src/olympia/amo/admin.py
+++ b/src/olympia/amo/admin.py
@@ -4,7 +4,6 @@ import operator
 from collections import OrderedDict
 
 from django import forms
-from django.conf import settings
 from django.contrib import admin
 from django.contrib.admin.options import IncorrectLookupParameters
 from django.contrib.admin.views.main import (
@@ -26,6 +25,7 @@ from rangefilter.filters import DateRangeFilter as DateRangeFilterBase
 
 from olympia.activity.models import IPLog
 from olympia.amo.models import GroupConcat, Inet6Ntoa
+from olympia.amo.templatetags.jinja_helpers import vite_asset
 from olympia.constants.activity import LOG_BY_ID
 
 from .models import FakeEmail
@@ -182,12 +182,8 @@ class AMOModelAdminChangeList(ChangeList):
 
 class AMOModelAdmin(admin.ModelAdmin):
     class Media:
-        js = ((vite_hmr_client(),) if settings.DEV_MODE else ()) + (
-            'js/admin/ip_address_search.js',
-            'js/exports.js',
-            'netmask/lib/netmask.js',
-        )
-        css = {'all': ('css/admin/amoadmin.css',)}
+        js = (vite_hmr_client(), vite_asset('js/admin.js'))
+        css = {'all': (vite_asset('css/admin.less'),)}
 
     # Classes that want to implement search by ip can override these if needed.
     search_by_ip_actions = ()  # Deactivated by default.

--- a/src/olympia/blocklist/admin.py
+++ b/src/olympia/blocklist/admin.py
@@ -14,6 +14,7 @@ import waffle
 from olympia.activity.models import ActivityLog
 from olympia.addons.models import Addon
 from olympia.amo.admin import AMOModelAdmin
+from olympia.amo.templatetags.jinja_helpers import vite_asset
 from olympia.amo.utils import HttpResponseTemporaryRedirect
 
 from .forms import (
@@ -191,7 +192,7 @@ class BlocklistSubmissionAdmin(AMOModelAdmin):
     form = BlocklistSubmissionForm
 
     class Media:
-        css = {'all': ('css/admin/blocklist_blocklistsubmission.css',)}
+        css = {'all': (vite_asset('css/admin-blocklist_blocklistsubmission.less'),)}
         js = ('js/i18n/en-US.js',)
 
     def state(self, obj):
@@ -595,7 +596,7 @@ class BlockAdmin(BlockAdminAddMixin, AMOModelAdmin):
     change_form_template = 'admin/blocklist/block_change_form.html'
 
     class Media:
-        css = {'all': ('css/admin/blocklist_block.css',)}
+        css = {'all': (vite_asset('css/admin-blocklist_block.less'),)}
         js = ('js/i18n/en-US.js',)
 
     def addon_guid(self, obj):

--- a/src/olympia/discovery/admin.py
+++ b/src/olympia/discovery/admin.py
@@ -12,6 +12,7 @@ from django.utils.translation import gettext
 from olympia import promoted
 from olympia.addons.models import Addon
 from olympia.amo.admin import AMOModelAdmin
+from olympia.amo.templatetags.jinja_helpers import vite_asset
 from olympia.discovery.models import DiscoveryItem
 from olympia.hero.admin import PrimaryHeroImageAdmin, SecondaryHeroAdmin
 from olympia.hero.models import PrimaryHeroImage, SecondaryHero
@@ -80,7 +81,7 @@ class PositionChinaFilter(PositionFilter):
 
 class DiscoveryItemAdmin(AMOModelAdmin):
     class Media:
-        css = {'all': ('css/admin/discovery.css',)}
+        css = {'all': (vite_asset('css/admin-discovery.less'),)}
 
     list_display = (
         '__str__',

--- a/src/olympia/hero/admin.py
+++ b/src/olympia/hero/admin.py
@@ -9,6 +9,7 @@ from django.forms import BaseInlineFormSet
 from django.utils.safestring import mark_safe
 
 from olympia.amo.admin import AMOModelAdmin
+from olympia.amo.templatetags.jinja_helpers import vite_asset
 from olympia.amo.utils import resize_image
 
 from .models import PrimaryHero, PrimaryHeroImage, SecondaryHeroModule
@@ -23,7 +24,7 @@ class ImageChoiceField(forms.ModelChoiceField):
 
 class PrimaryHeroInline(admin.StackedInline):
     class Media:
-        css = {'all': ('css/admin/discovery.css',)}
+        css = {'all': (vite_asset('css/admin-discovery.less'),)}
 
     model = PrimaryHero
     fields = (
@@ -57,7 +58,7 @@ class PrimaryHeroInline(admin.StackedInline):
 
 class PrimaryHeroImageAdmin(AMOModelAdmin):
     class Media:
-        css = {'all': ('css/admin/discovery.css',)}
+        css = {'all': (vite_asset('css/admin-discovery.less'),)}
 
     list_display = ('preview_image', 'custom_image')
     actions = ['delete_selected']
@@ -100,7 +101,7 @@ class SecondaryHeroModuleInline(admin.StackedInline):
 
 class SecondaryHeroAdmin(AMOModelAdmin):
     class Media:
-        css = {'all': ('css/admin/discovery.css',)}
+        css = {'all': (vite_asset('css/admin-discovery.less'),)}
 
     list_display = ('headline', 'description', 'enabled')
     inlines = [SecondaryHeroModuleInline]

--- a/src/olympia/scanners/admin.py
+++ b/src/olympia/scanners/admin.py
@@ -15,6 +15,7 @@ from olympia import amo
 from olympia.access import acl
 from olympia.addons.models import Addon
 from olympia.amo.admin import AMOModelAdmin, MultipleRelatedListFilter
+from olympia.amo.templatetags.jinja_helpers import vite_asset
 from olympia.amo.utils import is_safe_url
 from olympia.constants import scanners
 from olympia.constants.scanners import (
@@ -249,12 +250,7 @@ class AbstractScannerResultAdminMixin:
     ordering = ('-pk',)
 
     class Media(AMOModelAdmin.Media):
-        css = {
-            'all': (
-                'css/admin/amoadmin.css',
-                'css/admin/scannerresult.css',
-            )
-        }
+        css = {'all': (vite_asset('css/admin-scanner-results.less'),)}
 
     def get_queryset(self, request):
         # We already set list_select_related() so we don't need to repeat that.
@@ -457,12 +453,7 @@ class AbstractScannerRuleAdminMixin:
         return super().formfield_for_choice_field(db_field, request, **kwargs)
 
     class Media(AMOModelAdmin.Media):
-        css = {
-            'all': (
-                'css/admin/amoadmin.css',
-                'css/admin/scannerrule.css',
-            )
-        }
+        css = {'all': (vite_asset('css/admin-scanner-rule.less'),)}
 
     def get_fields(self, request, obj=None):
         fields = super().get_fields(request, obj)
@@ -759,7 +750,7 @@ class ScannerQueryResultAdmin(AbstractScannerResultAdminMixin, AMOModelAdmin):
     ordering = ('version__addon_id', 'version__channel', 'version__created')
 
     class Media(AbstractScannerResultAdminMixin.Media):
-        js = ('js/admin/scannerqueryresult.js',)
+        js = (vite_asset('js/admin-scanner-query-result.js'),)
 
     def addon_name(self, obj):
         # Custom, simpler implementation to go with add-on grouping: the

--- a/src/olympia/versions/admin.py
+++ b/src/olympia/versions/admin.py
@@ -4,6 +4,7 @@ from django.db.models import Prefetch
 
 from olympia.addons.models import Addon
 from olympia.amo.admin import AMOModelAdmin
+from olympia.amo.templatetags.jinja_helpers import vite_asset
 from olympia.reviewers.models import NeedsHumanReview
 
 from .models import (
@@ -75,8 +76,8 @@ class LicenseAdmin(AMOModelAdmin):
 
 class VersionAdmin(AMOModelAdmin):
     class Media:
-        css = {'all': ('css/admin/l10n.css',)}
-        js = ('js/admin/l10n.js',)
+        css = {'all': (vite_asset('css/admin-versions.less'),)}
+        js = (vite_asset('js/admin-versions.js'),)
 
     view_on_site = False
     readonly_fields = ('id', 'created', 'version', 'channel')

--- a/static/css/admin-abuse-report.less
+++ b/static/css/admin-abuse-report.less
@@ -1,0 +1,1 @@
+@import url('./admin/abuse_reports.css');

--- a/static/css/admin-blocklist_block.less
+++ b/static/css/admin-blocklist_block.less
@@ -1,0 +1,1 @@
+@import url('./admin/blocklist_block.css');

--- a/static/css/admin-blocklist_blocklistsubmission.less
+++ b/static/css/admin-blocklist_blocklistsubmission.less
@@ -1,0 +1,1 @@
+@import url('./admin/blocklist_blocklistsubmission.css');

--- a/static/css/admin-discovery.less
+++ b/static/css/admin-discovery.less
@@ -1,0 +1,1 @@
+@import url('./admin/discovery.css');

--- a/static/css/admin-scanner-results.less
+++ b/static/css/admin-scanner-results.less
@@ -1,0 +1,1 @@
+@import url('./admin/scannerresult.css');

--- a/static/css/admin-scanner-rule.less
+++ b/static/css/admin-scanner-rule.less
@@ -1,0 +1,1 @@
+@import url('./admin/scannerrule.css');

--- a/static/css/admin-versions.less
+++ b/static/css/admin-versions.less
@@ -1,0 +1,1 @@
+@import url('./admin/l10n.css');

--- a/static/css/admin.less
+++ b/static/css/admin.less
@@ -1,0 +1,1 @@
+@import url('./admin/amoadmin.css');

--- a/static/css/admin/discovery.css
+++ b/static/css/admin/discovery.css
@@ -11,7 +11,7 @@
     background: none;
     color: #444;
     font-size: 14px;
-    font-weight: medium;
+    font-weight: 500;
     line-height: 1.2;
     margin: 0.75em 0 0 0;
     padding: 0;

--- a/static/js/admin-scanner-query-result.js
+++ b/static/js/admin-scanner-query-result.js
@@ -1,0 +1,1 @@
+import './admin/scannerqueryresult';

--- a/static/js/admin-versions.js
+++ b/static/js/admin-versions.js
@@ -1,0 +1,1 @@
+import './admin/l10n.js';

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -1,0 +1,2 @@
+import './admin/ip_address_search.js';
+import './exports.js';

--- a/static/js/admin/ip_address_search.js
+++ b/static/js/admin/ip_address_search.js
@@ -1,13 +1,32 @@
-document.addEventListener('DOMContentLoaded', () => {
-  'use strict';
+import { Netmask } from 'netmask';
 
+document.addEventListener('DOMContentLoaded', () => {
   /* Those variables are used in the functions below, and initialized a bit
      later if we're on a userprofile changelist page */
-  var search_bar;
-  var original_search_terms;
-  var ip_fields;
+  const search_bar = document.querySelector('#searchbar');
 
-  const Netmask = exports.Netmask;
+  function get_search_bar_terms() {
+    /**
+     * Return a Set of all search terms in the search bar.
+     */
+    if (!search_bar) {
+      return new Set();
+    }
+
+    const search_term = search_bar.value.trim();
+    return new Set(
+      search_term
+        ? search_term.split(',').map(function (x) {
+            return x.trim();
+          })
+        : [],
+    );
+  }
+
+  const original_search_terms = get_search_bar_terms();
+  const ip_fields = document.querySelectorAll(
+    '.change-list .field-known_ip_adresses li',
+  );
 
   function are_set_equal(a, b) {
     /** Return whether or not two sets contains the same values. */
@@ -20,20 +39,6 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     }
     return true;
-  }
-
-  function get_search_bar_terms() {
-    /**
-     * Return a Set of all search terms in the search bar.
-     */
-    const search_term = search_bar.value.trim();
-    return new Set(
-      search_term
-        ? search_term.split(',').map(function (x) {
-            return x.trim();
-          })
-        : [],
-    );
   }
 
   function highlight_ips_not_in(values) {
@@ -67,6 +72,10 @@ document.addEventListener('DOMContentLoaded', () => {
       } else {
         field.classList.remove('notinsearch');
       }
+    }
+
+    if (!search_bar) {
+      return;
     }
 
     if (!are_set_equal(original_search_terms, values)) {
@@ -106,14 +115,11 @@ document.addEventListener('DOMContentLoaded', () => {
     return;
   }
 
-  search_bar = document.querySelector('#searchbar');
-  original_search_terms = get_search_bar_terms();
-  ip_fields = document.querySelectorAll(
-    '.change-list .field-known_ip_adresses li',
-  );
   add_add_remove_links();
   const values = get_search_bar_terms();
-  search_bar.value = [...values].join(', ');
+  if (search_bar) {
+    search_bar.value = [...values].join(', ');
+  }
   highlight_ips_not_in(values);
 
   document.querySelector('#result_list').addEventListener('click', (e) => {
@@ -128,7 +134,9 @@ document.addEventListener('DOMContentLoaded', () => {
       } else if (target.classList.contains('deletelink')) {
         values.delete(new_value);
       }
-      search_bar.value = [...values].join(', ');
+      if (search_bar) {
+        search_bar.value = [...values].join(', ');
+      }
       highlight_ips_not_in(values);
     }
   });

--- a/static/js/admin/scannerqueryresult.js
+++ b/static/js/admin/scannerqueryresult.js
@@ -1,6 +1,4 @@
 document.addEventListener('DOMContentLoaded', () => {
-  'use strict';
-
   const result_list = document.querySelector(
     'body.change-list.model-scannerqueryresult #result_list',
   );


### PR DESCRIPTION
Fixes: mozilla/addons#15432

## Description

Migrate remaining admin pages to use vite for asset compilation

## Context

Removed redundant `AMOModelAdmin.Media.css['all']` and `AMOModelAdmin.Media.js` inclusions as django admin automatically merges `Media` class js/css properties.

## Testing

Run the following tests in prod/dev modes

```
make up DOCKER_TARGET=<production|development>
``` 

For each of these admin pages:
- verify there are no 404/500 type responses for all js/css assets
- verify there are no critical js console errors
- verify any additional requirements on the specific page

> [!NOTE]
> there are a few expected errors you can ignore CSP google analytics errors 

### [AbuseReportAdmin](http://olympia.test/en-US/admin/models/abuse/abusereport/)
### [BlocklistSubmissionAdmin](http://olympia.test/en-US/admin/models/blocklist/blocklistsubmission/1/change/))

> [!NOTE]
> Assuming you have a blocklist submission

Expect the "add or change blocks" section has styled content, namely the border on the addon guid input box

<img width="885" alt="image" src="https://github.com/user-attachments/assets/116ad6c4-1cc7-4476-9afc-143003f374ad" />

### [DiscoveryItemAdmin](http://olympia.test/en-US/admin/models/discovery/discoveryitem/1/change/)

> [!NOTE]
> There should be at least one discovery item created, if not create one. 

Expect the preview text to be formatted correctly

> [!NOTE]
> I discovered an invalid css property "font-weight: medium" which has been replaced with the valid equivalent "500" to indicate a "light" boldness. 

<img width="867" alt="image" src="https://github.com/user-attachments/assets/f5a83818-1f91-43be-be94-41b9e797e32c" />

### [PromotedAddon](http://olympia.test/en-US/admin/models/discovery/promotedaddon/)

> [!NOTE]
> Select a promoted addon, and on the hero section verify the below 

Expect the color gradient selection tool is styled correctly

<img width="882" alt="image" src="https://github.com/user-attachments/assets/52711964-06f9-406b-a91d-38a5b4fbb483" />

> [!NOTE]
> expect some hero images to be uploaded [here](http://olympia.test/en-US/admin/models/discovery/primaryheroimageupload/)

Verify that the select image options are styled correctly

<img width="693" alt="image" src="https://github.com/user-attachments/assets/f7f54d4f-73a3-4fe6-aabf-e59d07c9c98e" />

### [ScannerQueryResult](http://olympia.test/en-US/admin/models/scanners/scannerqueryresult/)

It's not totally clear to me how exactly to reproduce the conditions for the scanner results admin sections.

There is js and css that adds and styles custom classes depending on some logic... TBD

<img width="645" alt="image" src="https://github.com/user-attachments/assets/7f8489e4-0445-48ab-bc80-7196a376264a" />

### [VersionAdmin](http://olympia.test/en-US/admin/models/versions/version/)

> [!NOTE]
> Make sure you have a version with a release note or other translated field

Verify that the translated fields (those that have .trans class) have the locale string prefix.

TBD add the screenshot

### [ActivityLog](http://olympia.test/en-US/admin/models/activity/activitylog/)

Verify that you can add/remove IP addresses via the search results page. Follow this video for details.

https://github.com/user-attachments/assets/3568a345-7120-4749-bf25-88e4f33548f0

## Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [X] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
