### PR TITLE
Return minimal user profile for non-developer users.

### DIFF
--- a/src/olympia/accounts/tests/test_serializers.py
+++ b/src/olympia/accounts/tests/test_serializers.py
@@ -148,13 +148,20 @@ class TestMinimalUserProfileSerializer(TestFullUserProfileSerializer):
             for field in MinimalUserProfileSerializer.nullable_fields:
                 assert data[field] is None
 
+    def test_addons(self):
+        with override_settings(DRF_API_GATES=self.gates):
+            super().test_addons()
+        data = self.serialize()
+        assert 'num_addons_listed' not in data
+        assert 'average_addon_rating' not in data
+
     def test_anonymous_username_display_name(self):
+        with override_settings(DRF_API_GATES=self.gates):
+            super().test_anonymous_username_display_name()
+
         data = self.serialize()
         assert 'has_anonymous_username' not in data
         assert 'has_anonymous_display_name' not in data
-
-        with override_settings(DRF_API_GATES=self.gates):
-            super().test_anonymous_username_display_name()
 
 
 class PermissionsTestMixin:

--- a/src/olympia/addons/indexers.py
+++ b/src/olympia/addons/indexers.py
@@ -443,7 +443,6 @@ class AddonIndexer:
                         'id': {'type': 'long'},
                         'name': {'type': 'text'},
                         'username': {'type': 'keyword'},
-                        'has_full_profile': {'type': 'boolean', 'index': False},
                     },
                 },
                 'modified': {'type': 'date', 'index': False},
@@ -650,12 +649,7 @@ class AddonIndexer:
         data['category'] = [cat.id for cat in obj.all_categories]
         data['current_version'] = cls.extract_version(obj, obj.current_version)
         data['listed_authors'] = [
-            {
-                'name': a.name,
-                'id': a.id,
-                'username': a.username,
-                'has_full_profile': a.has_full_profile,
-            }
+            {'name': a.name, 'id': a.id, 'username': a.username}
             for a in obj.listed_authors
         ]
 

--- a/src/olympia/addons/indexers.py
+++ b/src/olympia/addons/indexers.py
@@ -443,7 +443,7 @@ class AddonIndexer:
                         'id': {'type': 'long'},
                         'name': {'type': 'text'},
                         'username': {'type': 'keyword'},
-                        'is_public': {'type': 'boolean', 'index': False},
+                        'has_full_profile': {'type': 'boolean', 'index': False},
                     },
                 },
                 'modified': {'type': 'date', 'index': False},
@@ -654,7 +654,7 @@ class AddonIndexer:
                 'name': a.name,
                 'id': a.id,
                 'username': a.username,
-                'is_public': a.is_public,
+                'has_full_profile': a.has_full_profile,
             }
             for a in obj.listed_authors
         ]

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1943,7 +1943,7 @@ def watch_status(old_attr=None, new_attr=None, instance=None, sender=None, **kwa
 
     # Update the author's account profile visibility
     if new_status != old_status:
-        [author.update_is_public() for author in instance.authors.all()]
+        [author.update_has_full_profile() for author in instance.authors.all()]
 
     if new_status not in amo.VALID_ADDON_STATUSES or not (
         latest_version := instance.find_latest_version(channel=amo.CHANNEL_LISTED)
@@ -2181,7 +2181,7 @@ class AddonUser(OnChangeMixin, SaveUpdateMixin, models.Model):
 def watch_addon_user(
     old_attr=None, new_attr=None, instance=None, sender=None, **kwargs
 ):
-    instance.user.update_is_public()
+    instance.user.update_has_full_profile()
     # Update ES because authors is included.
     update_search_index(sender=sender, instance=instance.addon, **kwargs)
 

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -1547,7 +1547,6 @@ class ESAddonSerializer(BaseESSerializer, AddonSerializer):
                 created=None,
                 display_name=data_author['name'],
                 username=data_author['username'],
-                has_full_profile=data_author.get('has_full_profile', False),
             )
             for data_author in data_authors
         ]

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -1547,7 +1547,7 @@ class ESAddonSerializer(BaseESSerializer, AddonSerializer):
                 created=None,
                 display_name=data_author['name'],
                 username=data_author['username'],
-                is_public=data_author.get('is_public', False),
+                has_full_profile=data_author.get('has_full_profile', False),
             )
             for data_author in data_authors
         ]

--- a/src/olympia/addons/tests/test_indexers.py
+++ b/src/olympia/addons/tests/test_indexers.py
@@ -230,12 +230,7 @@ class TestAddonIndexer(TestCase):
         assert extracted['category'] == [1, 22, 71]  # From fixture.
         assert extracted['current_version']
         assert extracted['listed_authors'] == [
-            {
-                'name': '55021 التطب',
-                'id': 55021,
-                'username': '55021',
-                'has_full_profile': True,
-            }
+            {'name': '55021 التطب', 'id': 55021, 'username': '55021'}
         ]
         assert extracted['ratings'] == {
             'average': self.addon.average_rating,

--- a/src/olympia/addons/tests/test_indexers.py
+++ b/src/olympia/addons/tests/test_indexers.py
@@ -234,7 +234,7 @@ class TestAddonIndexer(TestCase):
                 'name': '55021 التطب',
                 'id': 55021,
                 'username': '55021',
-                'is_public': True,
+                'has_full_profile': True,
             }
         ]
         assert extracted['ratings'] == {

--- a/src/olympia/amo/fixtures/base/addon_3615.json
+++ b/src/olympia/amo/fixtures/base/addon_3615.json
@@ -223,7 +223,7 @@
             "biography": null,
             "deleted": false,
             "username": "55021",
-            "is_public": true,
+            "has_full_profile": true,
             "display_name": "55021 \u0627\u0644\u062a\u0637\u0628",
             "created": "2007-03-05 13:09:56",
             "notes": null,

--- a/src/olympia/amo/sitemap.py
+++ b/src/olympia/amo/sitemap.py
@@ -308,7 +308,7 @@ class AccountSitemap(Sitemap):
             addon_q = addon_q & Q(addons__id__in=promoted_addon_ids)
 
         users = (
-            UserProfile.objects.filter(is_public=True, deleted=False)
+            UserProfile.objects.filter(has_full_profile=True, deleted=False)
             .annotate(
                 theme_count=Count(
                     'addons', filter=Q(addon_q, addons__type=amo.ADDON_STATICTHEME)

--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -796,8 +796,8 @@ def addon_factory(status=amo.STATUS_APPROVED, version_kw=None, file_kw=None, **k
     if addon.guid:
         AddonGUID.objects.create(addon=addon, guid=addon.guid)
 
-    # Potentially update is_public on authors
-    [user.update_is_public() for user in users]
+    # Potentially update has_full_profile on authors
+    [user.update_has_full_profile() for user in users]
 
     if 'due_date' in version_kw:
         # If a due date was set on the version, then it might have been

--- a/src/olympia/amo/tests/test_sitemap.py
+++ b/src/olympia/amo/tests/test_sitemap.py
@@ -251,7 +251,7 @@ class TestAccountSitemap(TestCase):
         user_with_themes = user_factory()
         user_with_extensions = user_factory()
         user_with_both = user_factory()
-        user_factory(is_public=True)  # marked as public, but no addons.
+        user_factory(has_full_profile=True)  # marked as developer, but no addons.
         extension = addon_factory(users=(user_with_extensions, user_with_both))
         theme = addon_factory(
             type=amo.ADDON_STATICTHEME, users=(user_with_themes, user_with_both)
@@ -285,7 +285,7 @@ class TestAccountSitemap(TestCase):
         user_with_themes = user_factory()
         user_with_extensions = user_factory()
         user_with_both = user_factory()
-        user_factory(is_public=True)  # marked as public, but no addons.
+        user_factory(has_full_profile=True)  # marked as developer, but no addons.
         addon_factory(users=(user_with_extensions, user_with_both))
         addon_factory(
             type=amo.ADDON_STATICTHEME, users=(user_with_themes, user_with_both)
@@ -482,7 +482,7 @@ class TestAccountSitemap(TestCase):
         user_with_themes = user_factory()
         user_with_extensions = user_factory()
         user_with_both = user_factory()
-        user_factory(is_public=True)  # marked as public, but no addons.
+        user_factory(has_full_profile=True)  # marked as developer, but no addons.
         extension = addon_factory(
             users=(user_with_extensions, user_with_both),
             version_kw={'application': amo.ANDROID.id},

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1424,6 +1424,7 @@ DRF_API_GATES = {
         'del-preview-position',
         'categories-application',
         'promoted-verified-sponsored',
+        'mimimal-profile-has-all-fields-shim',
     ),
     'v4': (
         'l10n_flat_input_output',
@@ -1442,6 +1443,7 @@ DRF_API_GATES = {
         'promoted-verified-sponsored',
         'block-min-max-versions-shim',
         'block-versions-list-shim',
+        'mimimal-profile-has-all-fields-shim',
     ),
     'v5': (
         'addons-search-_score-field',
@@ -1450,6 +1452,7 @@ DRF_API_GATES = {
         'addon-submission-api',
         'promoted-verified-sponsored',
         'block-versions-list-shim',
+        'mimimal-profile-has-all-fields-shim',
     ),
 }
 

--- a/src/olympia/ratings/tests/test_serializers.py
+++ b/src/olympia/ratings/tests/test_serializers.py
@@ -60,7 +60,7 @@ class TestBaseRatingSerializer(TestCase):
         assert result['user'] == {
             'id': self.user.pk,
             'name': str(self.user.name),
-            'url': None,
+            'url': absolutify(self.user.get_url_path()),
             'username': self.user.username,
         }
         assert result['version'] == {
@@ -113,7 +113,7 @@ class TestBaseRatingSerializer(TestCase):
         assert result['user'] == {
             'id': self.user.pk,
             'name': str(self.user.name),
-            'url': None,
+            'url': absolutify(self.user.get_url_path()),
             'username': self.user.username,
         }
         assert result['version'] == {

--- a/src/olympia/users/admin.py
+++ b/src/olympia/users/admin.py
@@ -106,7 +106,7 @@ class BannedUserContentInline(admin.TabularInline):
 
 @admin.register(UserProfile)
 class UserAdmin(AMOModelAdmin):
-    list_display = ('__str__', 'email', 'last_login', 'is_public', 'deleted')
+    list_display = ('__str__', 'email', 'last_login', 'has_full_profile', 'deleted')
     # pk and IP address search are supported without needing to specify them in
     # search_fields (see `AMOModelAdmin`)
     search_fields = ('email__like',)
@@ -131,7 +131,7 @@ class UserAdmin(AMOModelAdmin):
         'has_active_api_key',
         'history_for_this_user',
         'id',
-        'is_public',
+        'has_full_profile',
         'known_ip_adresses',
         'last_known_activity_time',
         'last_login',
@@ -165,7 +165,7 @@ class UserAdmin(AMOModelAdmin):
         (
             'Flags',
             {
-                'fields': ('deleted', 'is_public'),
+                'fields': ('deleted', 'has_full_profile'),
             },
         ),
         (

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -296,7 +296,7 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
         'bypass_upload_restrictions',
         'display_name',
         'homepage',
-        'is_public',
+        'has_full_profile',
         'location',
         'occupation',
         'picture_type',
@@ -338,8 +338,8 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
     email_changed = models.DateTimeField(null=True, editable=False)
     banned = models.DateTimeField(null=True, editable=False)
 
-    # Is the profile page for this account publicly viewable?
-    is_public = models.BooleanField(default=False, db_column='public')
+    # Is the profile page for this account a full profile?
+    has_full_profile = models.BooleanField(default=False, db_column='public')
 
     fxa_id = models.CharField(blank=True, null=True, max_length=128)
 
@@ -555,18 +555,23 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
         return self.cached_developer_status['is_theme_developer']
 
     @use_primary_db
-    def update_is_public(self):
-        pre = self.is_public
-        is_public = self.addonuser_set.filter(
+    def update_has_full_profile(self):
+        pre = self.has_full_profile
+        has_full_profile = self.addonuser_set.filter(
             role__in=[amo.AUTHOR_ROLE_OWNER, amo.AUTHOR_ROLE_DEV],
             listed=True,
             addon__status=amo.STATUS_APPROVED,
         ).exists()
-        if is_public != pre:
-            log.info('Updating %s.is_public from %s to %s', self.pk, pre, is_public)
-            self.update(is_public=is_public)
+        if has_full_profile != pre:
+            log.info(
+                'Updating %s.has_full_profile from %s to %s',
+                self.pk,
+                pre,
+                has_full_profile,
+            )
+            self.update(has_full_profile=has_full_profile)
         else:
-            log.info('Not changing %s.is_public from %s', self.pk, pre)
+            log.info('Not changing %s.has_full_profile from %s', self.pk, pre)
 
     @property
     def name(self):

--- a/src/olympia/users/tests/test_models.py
+++ b/src/olympia/users/tests/test_models.py
@@ -849,39 +849,39 @@ class TestUserProfile(TestCase):
             username='d', read_dev_agreement=after_change
         ).has_read_developer_agreement()
 
-    def test_is_public(self):
+    def test_has_full_profile(self):
         user = UserProfile.objects.get(id=4043307)
         assert not user.addonuser_set.exists()
-        assert not user.is_public
+        assert not user.has_full_profile
 
         addon = Addon.objects.get(pk=3615)
         addon_user = addon.addonuser_set.create(user=user)
-        assert user.is_public
+        assert user.has_full_profile
 
-        # Only developer and owner roles make a profile public.
+        # Only developer and owner roles make a developer profile.
         addon_user.update(role=amo.AUTHOR_ROLE_DEV)
-        assert user.is_public
+        assert user.has_full_profile
         addon_user.update(role=amo.AUTHOR_ROLE_OWNER)
-        assert user.is_public
+        assert user.has_full_profile
         # But only if they're listed
         addon_user.update(role=amo.AUTHOR_ROLE_OWNER, listed=False)
-        assert not user.is_public
+        assert not user.has_full_profile
         addon_user.update(listed=True)
-        assert user.is_public
+        assert user.has_full_profile
         addon_user.update(role=amo.AUTHOR_ROLE_DEV, listed=False)
-        assert not user.is_public
+        assert not user.has_full_profile
         addon_user.update(listed=True)
-        assert user.is_public
+        assert user.has_full_profile
 
         # The add-on needs to be public.
         self.make_addon_unlisted(addon)  # Easy way to toggle status
-        assert not user.reload().is_public
+        assert not user.reload().has_full_profile
         self.make_addon_listed(addon)
         addon.update(status=amo.STATUS_APPROVED)
-        assert user.reload().is_public
+        assert user.reload().has_full_profile
 
         addon.delete()
-        assert not user.reload().is_public
+        assert not user.reload().has_full_profile
 
     def test_get_lookup_field(self):
         user = UserProfile.objects.get(id=55021)


### PR DESCRIPTION
Fixes: mozilla/addons#15402

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Changes accounts API endpoint to return a response for all users, but with less fields for a non-developer.  API shims are in-place so any consumer that expects the payload to either be a 404, or to contain all the data, don't fail - we're returning `null` values for the missing fields. 

### Context

Frontend is initially a consumer that will (likely?) fail if presented with a user profile response with most of the fields missing, so the API_GATE is enabled for v5 too.  Once frontend is patched we can drop the api_gate for v5.  Some fields aren't nullified because the api contract defines them as boolean, etc, with no valid null or empty values, so they're returned (though are going to empty/useless in all non-edge-cases anyway) - `created` is probably the only field that has a value we can't sanitise easily, so I just left it in.

~After writing this patch I'm pretty sure we no longer need to store the `has_full_profile` in the ES index - I could drop it here or in a follow-up?~ (dropped in this patch)  

And the need for a `has_full_profile` denormalized field on the model isn't particularly clear either these days - we access it in 2 places after this patch - to determine what serializer to use for the accounts response, and whether we want the url in the sitemap - both of those could be (likely) replaced with calculations based on preloaded values from the model instance, really.  That would certainly be a follow-up issue though.

### Testing

- set up a user who has a some combination of non-empty biography, occupation, location, or homepage (but isn't an author of any publicly listed add-ons).
- access that user's profile with `/api/v5/accounts/account/(int:user_id)/`
- see the user is returned, but biography (etc) returned as null values.
- also access that user's profile via frontend `/firefox/user/(int:user_id)/`
- repeat while authenticated and see the values returned on the profile page (because you're an admin)
  - you can go through the api authentication too, but it's a bit of a pain, and the local frontend should be sufficient.
- make a rating with some text on a random add-on, and see the url to their profile is linked on the ratings page for that add-on.
- to test the case without the API_GATE shim you have to change the `DRF_API_GATES` setting for `v5` to not have the gate enabled.
- then repeat above for a non-authenticated user and see the extra fields are absent entirely from the response - only `name`, `url`, `id`, `username` should be returned in the api response.
- make that user an author of a publicly listed add-on and the response should be as now - full fields with url, etc.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
