### PR TITLE
Use specific emoji for cancelled workflows

### DIFF
--- a/.github/workflows/ci_completed.yml
+++ b/.github/workflows/ci_completed.yml
@@ -44,6 +44,8 @@ jobs:
 
           if [[ "$conclusion" == "success" ]]; then
             emoji=":white_check_mark:"
+          elif [[ "$conclussion" == "cancelled" ]]; then
+            emoji=":github-actions-cancelled:"
           else
             emoji=":x:"
           fi


### PR DESCRIPTION
Follow up of: https://github.com/mozilla/addons-server/pull/23080

### Description

Cancelled workflows shouldn't look like failed ones.

### Context

<img width="785" alt="image" src="https://github.com/user-attachments/assets/f58f397f-1552-41ed-886e-8ca415fda2e9" />

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
