### PR TITLE
Add Slack notification to healthcheck

### DIFF
--- a/.github/workflows/health_check.yml
+++ b/.github/workflows/health_check.yml
@@ -9,6 +9,10 @@ on:
     # Every 5 minutes
     - cron: '*/5 * * * *'
 
+env:
+  health_check_file: health_check.json
+  health_check_blocks_file: health_check_blocks.json
+
 jobs:
   health_check:
     runs-on: ubuntu-latest
@@ -20,11 +24,45 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: ./.github/actions/run-docker
+      - name: Run health check
+        id: health_check
+        continue-on-error: true
+        uses: ./.github/actions/run-docker
         with:
           target: development
           version: local
-          run: ./scripts/health_check.py --env ${{ matrix.environment }} --verbose
+          run: |
+            ./scripts/health_check.py \
+            --env ${{ matrix.environment }} \
+            --verbose \
+            --output ${{ env.health_check_file }}
 
+      - name: Set message blocks
+        id: blocks
+        if: steps.health_check.outcome == 'failure'
+        shell: bash
+        run: |
+          # Create the message blocks file
+          ./scripts/health_check_blocks.py \
+          --input ${{ env.health_check_file }} \
+          --output ${{ env.health_check_blocks_file }}
+          # Multiline output needs to use a delimiter to be passed to
+          # the GITHUB_OUTPUT file.
+          blocks=$(cat ${{ env.health_check_blocks_file }})
+          echo "blocks<<EOF"$'\n'$blocks$'\n'EOF >> $GITHUB_OUTPUT
+          cat $GITHUB_OUTPUT
 
+      - uses: mozilla/addons/.github/actions/slack@main
+        if: steps.health_check.outcome == 'failure'
+        with:
+          slack_token: ${{ secrets.SLACK_TOKEN }}
+          payload: |
+            {
+              "channel": "${{ secrets.SLACK_ADDONS_PRODUCTION_CHANNEL }}",
+              "blocks": ${{ toJson(steps.blocks.outputs.blocks) }},
+              "text": "Health check failed",
+              # Don't unfurl links or media
+              "unfurl_links": false,
+              "unfurl_media": false,
+            }
 

--- a/.github/workflows/health_check.yml
+++ b/.github/workflows/health_check.yml
@@ -53,7 +53,9 @@ jobs:
           cat $GITHUB_OUTPUT
 
       - uses: mozilla/addons/.github/actions/slack@main
-        if: steps.health_check.outcome == 'failure'
+        if: |
+          github.event_name == 'scheduled' &&
+          steps.health_check.outcome == 'failure'
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
           payload: |

--- a/.github/workflows/health_check_completed.yml
+++ b/.github/workflows/health_check_completed.yml
@@ -1,0 +1,33 @@
+name: Health Check Completed
+
+on:
+  workflow_run:
+    workflows: Health Check
+    types: [completed]
+
+jobs:
+  health_check_failure_notification:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Context
+        id: context
+        uses: ./.github/actions/context
+
+      - uses: mozilla/addons/.github/actions/slack-workflow-notification@main
+        with:
+          slack_token: ${{ secrets.SLACK_TOKEN }}
+          slack_channel: ${{ secrets.SLACK_ADDONS_PRODUCTION_CHANNEL }}
+          emoji: ':x:'
+          actor: ${{ vars.slack_actor }}
+          conclusion: ${{ github.event.workflow_run.conclusion }}
+          workflow_id: ${{ github.event.workflow_run.id }}
+          workflow_url: ${{ github.event.workflow_run.url }}
+          event: ${{ github.event.workflow_run.event }}
+          env: ci
+          ref: ''
+          ref_link: ''
+
+

--- a/.github/workflows/health_check_completed.yml
+++ b/.github/workflows/health_check_completed.yml
@@ -6,7 +6,19 @@ on:
     types: [completed]
 
 jobs:
+  context:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Context
+        id: context
+        uses: ./.github/actions/context
+
   health_check_failure_notification:
+    if: |
+      github.event.workflow_run.event == 'scheduled' &&
+      github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-latest
 
     steps:

--- a/scripts/health_check_blocks.py
+++ b/scripts/health_check_blocks.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+
+
+def format_monitors(data: dict, source: str):
+    monitors = data['data']
+    failures = []
+
+    for name, monitor in monitors.items():
+        if not monitor['state']:
+            failures.append(
+                {
+                    'type': 'rich_text_section',
+                    'elements': [
+                        {
+                            'type': 'text',
+                            'text': f'{name}: ',
+                            'style': {
+                                'bold': True,
+                            },
+                        },
+                        {
+                            'type': 'text',
+                            'text': f'{monitor["status"]}',
+                        },
+                    ],
+                }
+            )
+
+    if failures:
+        return {
+            'type': 'rich_text',
+            'elements': [
+                {
+                    'type': 'rich_text_section',
+                    'elements': [
+                        {
+                            'type': 'text',
+                            'text': f'{source.capitalize()}:',
+                            'style': {
+                                'bold': True,
+                            },
+                        }
+                    ],
+                },
+                {
+                    'type': 'rich_text_list',
+                    'elements': failures,
+                    'style': 'bullet',
+                    'indent': 0,
+                    'border': 1,
+                },
+            ],
+        }
+
+
+def format_context(data: dict):
+    version_data = data.get('version', {}).get('data', {})
+    version_elements = [
+        {'type': 'mrkdwn', 'text': f'{key.capitalize()}: {value} |'}
+        for key, value in version_data.items()
+        if value and key in ['version', 'commit', 'build']
+    ]
+    url_elements = [
+        {'type': 'mrkdwn', 'text': f'<{data["url"]}|{name.capitalize()}> |'}
+        for name, data in data.items()
+    ]
+    return {'type': 'context', 'elements': version_elements + url_elements}
+
+
+def format_header(emoji: str, text: setattr):
+    return {
+        'type': 'rich_text',
+        'elements': [
+            {
+                'type': 'rich_text_section',
+                'elements': [
+                    {
+                        'type': 'emoji',
+                        'name': emoji,
+                    },
+                    {
+                        'type': 'text',
+                        'text': 'Health Check Alert: ',
+                        'style': {'bold': True},
+                    },
+                    {
+                        'type': 'text',
+                        'text': text,
+                    },
+                ],
+            }
+        ],
+    }
+
+
+def create_blocks(health_data: dict):
+    """Create a Slack message from health check data."""
+    failing_monitors = []
+
+    for name, data in health_data.items():
+        if name in ['monitors', 'heartbeat']:
+            if monitors := format_monitors(data, name):
+                failing_monitors.append(monitors)
+
+    if not failing_monitors:
+        return []
+
+    return [
+        format_header('x', 'Issues Detected'),
+        *failing_monitors,
+        format_context(health_data),
+    ]
+
+
+def main():
+    args = argparse.ArgumentParser()
+    args.add_argument('--input', type=str, required=True)
+    args.add_argument('--output', type=str, required=True)
+    args.add_argument('--verbose', action='store_true')
+
+    args = args.parse_args()
+
+    with open(args.input) as f:
+        health_data = json.load(f)
+
+    if args.verbose:
+        print(f'Health data loaded from {args.input}')
+
+    blocks = create_blocks(health_data)
+    with open(args.output, 'w') as f:
+        json.dump(blocks, f)
+
+    if args.verbose:
+        print(f'Blocks saved to {args.output}')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/make/test_health_check_blocks.py
+++ b/tests/make/test_health_check_blocks.py
@@ -1,0 +1,377 @@
+from unittest import TestCase
+
+from scripts.health_check_blocks import create_blocks
+
+
+class TestHealthCheckBlocks(TestCase):
+    def setUp(self):
+        self.base_data = {
+            'version': {
+                'data': {'version': '1.0.0'},
+                'url': 'http://nginx/__version__',
+            },
+            'heartbeat': {
+                'data': {'heartbeat': {'state': True, 'status': ''}},
+                'url': 'http://nginx/__heartbeat__',
+            },
+            'monitors': {
+                'data': {'memcache': {'state': True, 'status': ''}},
+                'url': 'http://nginx/services/__heartbeat__',
+            },
+        }
+
+    def _monitor(self, name: str, state: bool, status: str):
+        return {name: {'state': state, 'status': status}}
+
+    def test_no_failing_monitors(self):
+        self.assertEqual(
+            create_blocks(self.base_data),
+            [],
+        )
+
+    def test_one_failing_monitor(self):
+        data = dict(self.base_data)
+        data.update(
+            {
+                'monitors': {
+                    'data': self._monitor('memcache', False, 'Service is down'),
+                    'url': 'http://nginx/services/__heartbeat__',
+                },
+            }
+        )
+        self.assertEqual(
+            create_blocks(data),
+            [
+                {
+                    'type': 'rich_text',
+                    'elements': [
+                        {
+                            'type': 'rich_text_section',
+                            'elements': [
+                                {
+                                    'type': 'emoji',
+                                    'name': 'x',
+                                },
+                                {
+                                    'type': 'text',
+                                    'text': 'Health Check Alert: ',
+                                    'style': {'bold': True},
+                                },
+                                {
+                                    'type': 'text',
+                                    'text': 'Issues Detected',
+                                },
+                            ],
+                        }
+                    ],
+                },
+                {
+                    'type': 'rich_text',
+                    'elements': [
+                        {
+                            'type': 'rich_text_section',
+                            'elements': [
+                                {
+                                    'type': 'text',
+                                    'text': 'Monitors:',
+                                    'style': {
+                                        'bold': True,
+                                    },
+                                }
+                            ],
+                        },
+                        {
+                            'type': 'rich_text_list',
+                            'elements': [
+                                {
+                                    'type': 'rich_text_section',
+                                    'elements': [
+                                        {
+                                            'type': 'text',
+                                            'text': 'memcache: ',
+                                            'style': {
+                                                'bold': True,
+                                            },
+                                        },
+                                        {
+                                            'type': 'text',
+                                            'text': 'Service is down',
+                                        },
+                                    ],
+                                }
+                            ],
+                            'style': 'bullet',
+                            'indent': 0,
+                            'border': 1,
+                        },
+                    ],
+                },
+                {
+                    'type': 'context',
+                    'elements': [
+                        {'type': 'mrkdwn', 'text': 'Version: 1.0.0 |'},
+                        {
+                            'type': 'mrkdwn',
+                            'text': '<http://nginx/__version__|Version> |',
+                        },
+                        {
+                            'type': 'mrkdwn',
+                            'text': '<http://nginx/__heartbeat__|Heartbeat> |',
+                        },
+                        {
+                            'type': 'mrkdwn',
+                            'text': '<http://nginx/services/__heartbeat__|Monitors> |',
+                        },
+                    ],
+                },
+            ],
+        )
+
+    def test_multiple_failing_monitors(self):
+        data = dict(self.base_data)
+        data.update(
+            {
+                'heartbeat': {
+                    'data': self._monitor('cinder', False, 'cinder is down'),
+                    'url': 'http://nginx/__heartbeat__',
+                },
+                'monitors': {
+                    'data': self._monitor('memcache', False, 'Service is down'),
+                    'url': 'http://nginx/services/__heartbeat__',
+                },
+            }
+        )
+        self.assertEqual(
+            create_blocks(data),
+            [
+                {
+                    'type': 'rich_text',
+                    'elements': [
+                        {
+                            'type': 'rich_text_section',
+                            'elements': [
+                                {
+                                    'type': 'emoji',
+                                    'name': 'x',
+                                },
+                                {
+                                    'type': 'text',
+                                    'text': 'Health Check Alert: ',
+                                    'style': {'bold': True},
+                                },
+                                {
+                                    'type': 'text',
+                                    'text': 'Issues Detected',
+                                },
+                            ],
+                        }
+                    ],
+                },
+                {
+                    'type': 'rich_text',
+                    'elements': [
+                        {
+                            'type': 'rich_text_section',
+                            'elements': [
+                                {
+                                    'type': 'text',
+                                    'text': 'Heartbeat:',
+                                    'style': {
+                                        'bold': True,
+                                    },
+                                }
+                            ],
+                        },
+                        {
+                            'type': 'rich_text_list',
+                            'elements': [
+                                {
+                                    'type': 'rich_text_section',
+                                    'elements': [
+                                        {
+                                            'type': 'text',
+                                            'text': 'cinder: ',
+                                            'style': {
+                                                'bold': True,
+                                            },
+                                        },
+                                        {
+                                            'type': 'text',
+                                            'text': 'cinder is down',
+                                        },
+                                    ],
+                                }
+                            ],
+                            'style': 'bullet',
+                            'indent': 0,
+                            'border': 1,
+                        },
+                    ],
+                },
+                {
+                    'type': 'rich_text',
+                    'elements': [
+                        {
+                            'type': 'rich_text_section',
+                            'elements': [
+                                {
+                                    'type': 'text',
+                                    'text': 'Monitors:',
+                                    'style': {
+                                        'bold': True,
+                                    },
+                                }
+                            ],
+                        },
+                        {
+                            'type': 'rich_text_list',
+                            'elements': [
+                                {
+                                    'type': 'rich_text_section',
+                                    'elements': [
+                                        {
+                                            'type': 'text',
+                                            'text': 'memcache: ',
+                                            'style': {
+                                                'bold': True,
+                                            },
+                                        },
+                                        {
+                                            'type': 'text',
+                                            'text': 'Service is down',
+                                        },
+                                    ],
+                                }
+                            ],
+                            'style': 'bullet',
+                            'indent': 0,
+                            'border': 1,
+                        },
+                    ],
+                },
+                {
+                    'type': 'context',
+                    'elements': [
+                        {'type': 'mrkdwn', 'text': 'Version: 1.0.0 |'},
+                        {
+                            'type': 'mrkdwn',
+                            'text': '<http://nginx/__version__|Version> |',
+                        },
+                        {
+                            'type': 'mrkdwn',
+                            'text': '<http://nginx/__heartbeat__|Heartbeat> |',
+                        },
+                        {
+                            'type': 'mrkdwn',
+                            'text': '<http://nginx/services/__heartbeat__|Monitors> |',
+                        },
+                    ],
+                },
+            ],
+        )
+
+    def test_version_with_empty_values(self):
+        data = dict(self.base_data)
+        data['version'] = {
+            'data': {'version': '1.0.0', 'build': '', 'commit': None},
+            'url': 'http://nginx/__version__',
+        }
+        data['monitors'] = {
+            'data': self._monitor('memcache', False, 'Service is down'),
+            'url': 'http://nginx/services/__heartbeat__',
+        }
+        self.assertEqual(
+            create_blocks(data),
+            [
+                {
+                    'type': 'rich_text',
+                    'elements': [
+                        {
+                            'type': 'rich_text_section',
+                            'elements': [
+                                {
+                                    'type': 'emoji',
+                                    'name': 'x',
+                                },
+                                {
+                                    'type': 'text',
+                                    'text': 'Health Check Alert: ',
+                                    'style': {'bold': True},
+                                },
+                                {
+                                    'type': 'text',
+                                    'text': 'Issues Detected',
+                                },
+                            ],
+                        }
+                    ],
+                },
+                {
+                    'type': 'rich_text',
+                    'elements': [
+                        {
+                            'type': 'rich_text_section',
+                            'elements': [
+                                {
+                                    'type': 'text',
+                                    'text': 'Monitors:',
+                                    'style': {
+                                        'bold': True,
+                                    },
+                                }
+                            ],
+                        },
+                        {
+                            'type': 'rich_text_list',
+                            'elements': [
+                                {
+                                    'type': 'rich_text_section',
+                                    'elements': [
+                                        {
+                                            'type': 'text',
+                                            'text': 'memcache: ',
+                                            'style': {
+                                                'bold': True,
+                                            },
+                                        },
+                                        {
+                                            'type': 'text',
+                                            'text': 'Service is down',
+                                        },
+                                    ],
+                                }
+                            ],
+                            'style': 'bullet',
+                            'indent': 0,
+                            'border': 1,
+                        },
+                    ],
+                },
+                {
+                    'type': 'context',
+                    'elements': [
+                        {'type': 'mrkdwn', 'text': 'Version: 1.0.0 |'},
+                        {
+                            'type': 'mrkdwn',
+                            'text': '<http://nginx/__version__|Version> |',
+                        },
+                        {
+                            'type': 'mrkdwn',
+                            'text': '<http://nginx/__heartbeat__|Heartbeat> |',
+                        },
+                        {
+                            'type': 'mrkdwn',
+                            'text': '<http://nginx/services/__heartbeat__|Monitors> |',
+                        },
+                    ],
+                },
+            ],
+        )
+
+    def test_no_version_data(self):
+        data = dict(self.base_data)
+        data['version'] = {}
+        self.assertEqual(
+            create_blocks(data),
+            [],
+        )


### PR DESCRIPTION
Fixes: mozilla/addons#15440

### Description

- Updated the health check workflow to generate health check output and message JSON files.
- Introduced a new script, `health_check_blocks.py`, to format health check data for Slack notifications.
- Modified `health_check.py` to support output file generation and improved error handling.
- Added tests for the new health check block formatting functionality.
- Updated the workflow to send notifications to Slack with health check results, excluding local environment notifications.

### Context

This enahnces the healthcheck to add slack notifications when there are failures and a notification if the workflow fails for any reason.

<img width="684" alt="image" src="https://github.com/user-attachments/assets/f4670efe-540f-48e8-81bb-9f5108fce7c6" />


### Testing

You can run the healtcheck locally, modifying monitors to get different results. set an `--output` property to save the file.

```bash
health_check_file="health_check.json"
health_check_blocks_file="health_check_blocks.json"
env="local"
./scripts/health_check.py --env $env --output $health_check_file --retries 0
./scripts/health_check_blocks.py --input $health_check_file --out $health_check_blocks_file
```

Then you can execute the bash script line by line to se what the final payload to slack would look like..

Finallly you can execute the healthcheck via github actions on this branch

```bash
gh workflow run health_check.yml --ref kevinmind/addons/15440
```

This PR introduces a temp failing monitor that should trigger a notifaction to the channel.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
