### PR TITLE
Add py-call-uwsgi-fork-hooks to local development uwsgi config

### DIFF
--- a/docker/uwsgi.ini
+++ b/docker/uwsgi.ini
@@ -18,13 +18,14 @@ uid             = $(id -u olympia)
 gid             = $(id -g olympia)
 memory-report   = true
 enable-threads  = true
+py-call-uwsgi-fork-hooks = true
 
+# Enable lazy-apps and autoreload to get clean autoreload for development
+# https://uwsgi-docs.readthedocs.io/en/latest/articles/TheArtOfGracefulReloading.html
 py-autoreload=1
+lazy-apps = true
 
 max-requests = 5000
-
-# Load apps in workers and not only in master
-lazy-apps = true
 
 # Set default settings as originally done by manage.py
 env = DJANGO_SETTINGS_MODULE=settings


### PR DESCRIPTION
This shouldn't have any impact, just making things more consistent as [we are going to want that enabled in dev/stage/prod](https://mozilla-hub.atlassian.net/browse/SVCSE-2554).

Helps mozilla/addons#1994

Recent versions of sentry sdk will warn if this is not set, it resolves some uwsgi workers dying with those versions of the sentry sdk.