### PR TITLE
Add some reserved guids

### DIFF
--- a/src/olympia/access/tests.py
+++ b/src/olympia/access/tests.py
@@ -299,6 +299,8 @@ system_guids = pytest.mark.parametrize(
         'flop@search.mozilla.org',
         'user@mozillaonline.com',
         'tester@MoZiLlAoNlInE.CoM',
+        'foo@siteperms.mozilla.org',
+        'bar@modelhub.mozilla.org',
     ],
 )
 

--- a/src/olympia/constants/base.py
+++ b/src/olympia/constants/base.py
@@ -392,6 +392,9 @@ RESERVED_ADDON_GUIDS = (
     '@temporary-addon',
     # Android Components/Fenix built-in extensions.
     '@mozac.org',
+    # Internal IDs used by Firefox
+    '@modelhub.mozilla.org',
+    '@siteperms.mozilla.org',
     # Test privileged add-ons for mozilla-central.
     '@tests.mozilla.org',
 )


### PR DESCRIPTION
Fixes: mozilla/addons#15423
Fixes: mozilla/addons#15424

There was some pushback against having a wildcard in there during triage meeting so I didn't go that far.