### PR TITLE
Update ci_completed.yml

### DIFF
--- a/.github/workflows/ci_completed.yml
+++ b/.github/workflows/ci_completed.yml
@@ -7,7 +7,8 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name}}-${{ github.ref}}
-  cancel-in-progress: true
+  # Don't cancel concurrent runs. Every run should notify.
+  cancel-in-progress: false
 
 jobs:
   context:


### PR DESCRIPTION
Follow up: https://github.com/mozilla/addons-server/pull/23080

### Description

We don't want to cancel concurrent workflows for `ci_completed.yml` each and every commit should update the status even if the triggering job was cancelled.

### Context

This workflow was cancelled because another ci_completed workflow was triggered. This workflow should have waited and then ran, but instead it was cancelled so we are missing a notification.

https://github.com/mozilla/addons-server/actions/runs/13854810472

### Testing

Very difficult to test but we should be able to see in the ci_completed queue that jobs are waiting and running 1 at a time, but are not cancelling. Only visible after merging.

### Checklist

- [ ] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
