### PR TITLE
all appeals back to their original queues

### DIFF
--- a/src/olympia/abuse/cinder.py
+++ b/src/olympia/abuse/cinder.py
@@ -338,14 +338,6 @@ class CinderAddon(CinderEntity):
     def queue_suffix(self):
         return 'themes' if self.addon.type == amo.ADDON_STATICTHEME else 'listings'
 
-    @property
-    def queue_appeal(self):
-        return (
-            self.queue
-            if self.addon.type == amo.ADDON_STATICTHEME
-            else 'amo-escalations'
-        )
-
     def get_attributes(self):
         # We look at the promoted group to tell whether or not the add-on is
         # promoted in any way, but we don't care about the promotion being
@@ -520,11 +512,6 @@ class CinderAddonHandledByReviewers(CinderAddon):
         super().__init__(addon)
         self.version_string = version_string
 
-    @property
-    def queue_appeal(self):
-        # No special appeal queue for reviewer handled jobs
-        return self.queue
-
     def flag_for_human_review(
         self, *, related_versions, appeal=False, forwarded=False, second_level=False
     ):
@@ -654,7 +641,6 @@ class CinderAddonHandledByReviewers(CinderAddon):
 
 class CinderAddonHandledByLegal(CinderAddon):
     queue = 'legal-escalations'
-    queue_appeal = 'legal-escalations'
 
 
 class CinderReport(CinderEntity):

--- a/src/olympia/abuse/tests/test_cinder.py
+++ b/src/olympia/abuse/tests/test_cinder.py
@@ -210,14 +210,6 @@ class TestCinderAddon(BaseTestCinderCase, TestCase):
             == f'{settings.CINDER_QUEUE_PREFIX}{cinder_entity.queue_suffix}'
         )
 
-    def test_queue_appeal(self):
-        extension = self._create_dummy_target()
-        assert self.CinderClass(extension).queue_appeal == 'amo-escalations'
-
-        theme = self._create_dummy_target(type=amo.ADDON_STATICTHEME)
-        # we only have a special queue for extensions
-        assert self.CinderClass(theme).queue == f'{settings.CINDER_QUEUE_PREFIX}themes'
-
     def test_build_report_payload(self):
         addon = self._create_dummy_target(
             homepage='https://home.example.com',
@@ -1118,11 +1110,6 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
             cinder_entity.queue
             == f'{settings.CINDER_QUEUE_PREFIX}{cinder_entity.queue_suffix}'
         )
-
-    def test_queue_appeal(self):
-        # Contrary to reports handled by Cinder moderators, for reports handled
-        # by AMO reviewers there is no special queue.
-        BaseTestCinderCase.test_queue_appeal(self)
 
     def setUp(self):
         self.task_user = user_factory(id=settings.TASK_USER_ID)

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -2371,7 +2371,7 @@ class TestContentDecision(TestCase):
 
     def test_appeal_as_target_from_resolved_in_cinder(self):
         appeal_job = self._test_appeal_as_target(
-            resolvable_in_reviewer_tools=False, expected_queue='amo-escalations'
+            resolvable_in_reviewer_tools=False, expected_queue='amo-env-listings'
         )
         assert not appeal_job.resolvable_in_reviewer_tools
         assert not (
@@ -2569,7 +2569,7 @@ class TestContentDecision(TestCase):
         assert request_body['decision_to_appeal_id'] == str(
             abuse_report.cinder_job.decision.cinder_id
         )
-        assert request_body['queue_slug'] == 'amo-escalations'
+        assert request_body['queue_slug'] == 'amo-env-listings'
 
     def test_appeal_as_reporter_already_appealed(self):
         addon = addon_factory()

--- a/src/olympia/abuse/tests/test_tasks.py
+++ b/src/olympia/abuse/tests/test_tasks.py
@@ -522,7 +522,7 @@ def test_addon_appeal_to_cinder_reporter(statsd_incr_mock):
         },
         'appealer_entity_type': 'amo_unauthenticated_reporter',
         'decision_to_appeal_id': '4815162342-abc',
-        'queue_slug': 'amo-escalations',
+        'queue_slug': 'amo-env-listings',
         'reasoning': 'I appeal',
     }
 
@@ -639,7 +639,7 @@ def test_addon_appeal_to_cinder_authenticated_reporter():
         },
         'appealer_entity_type': 'amo_user',
         'decision_to_appeal_id': '4815162342-abc',
-        'queue_slug': 'amo-escalations',
+        'queue_slug': 'amo-env-listings',
         'reasoning': 'I appeal',
     }
 


### PR DESCRIPTION
Fixes: mozilla/addons#15439

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Removes the special handling for extension appeals, so rather than going into the `escalations` queue directly, they go back into the original queue for that entity (amo_listings) - which is how extension appeals originally worked, and non-extension appeals continued to work.

### Context

I didn't entirely revert https://github.com/mozilla/addons-server/pull/22851 because there was some useful refactoring in there, and I wanted to leave open the possibility that we may want to target different queues for appeals again in the future.

### Testing

- (you need your Cinder API key defined)
- report an extension for abuse (anything but policy violation in the addon/both)
- make a decision on the extension in Cinder (amo dev listings)
- play back the payload locally, so you have the ContentDecision instance and the email in django admin fake mail
- use the appeal link in the fake mail to appeal
- see the appeal job is in the amo dev listings queue, rather than escalations

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
