### PR TITLE
Check If Promoted Is Array in AddonSerializers

### DIFF
--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -1144,9 +1144,7 @@ class AddonSerializer(AMOModelSerializer):
             data.pop('is_featured', None)
         if request and is_gate_active(request, 'promoted-groups-shim'):
             promoted = data.pop('promoted', None)
-            data['promoted'] = (
-                promoted[0] if promoted else None
-            )
+            data['promoted'] = promoted[0] if promoted else None
         return data
 
     def get_promoted(self, obj):

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -1145,7 +1145,7 @@ class AddonSerializer(AMOModelSerializer):
         if request and is_gate_active(request, 'promoted-groups-shim'):
             promoted = data.pop('promoted', None)
             data['promoted'] = (
-                promoted[0] if promoted and isinstance(promoted, list) else promoted
+                promoted[0] if promoted else None
             )
         return data
 


### PR DESCRIPTION
Fixes: mozilla/addons#15478

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Corrects ESAddonSerializer assumption of a list (and makes it compatible with multiple promotions in the meantime, instead of maintaining the assumption of a single promotion)

<!--
Your PR will be squashed when merged so the 1st commit must contain a descriptive and concise summary of the change.
Additional details should be added in the description. If your change is simple enough to summarize in the commit, or
if it is not relevant for your PR, remove this section.
-->

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
