### PR TITLE
Use MinimalUserProfileSerializer for AccountViewSet for non-developers

### DIFF
--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -1268,7 +1268,28 @@ class TestAccountViewSet(TestCase):
         response = self.client.get(self.url)
         assert response.status_code == 404
 
-    def test_is_not_full_public_profile_because_not_developer(self):
+    def test_is_not_full_public_profile_because_not_developer_but_fields_present(self):
+        # TODO: when mimimal-profile-has-all-fields-shim is removed for v5, we should
+        # change self.url to use v4 or v3
+        assert not self.user.has_full_profile
+        response = self.client.get(self.url)  # No auth.
+        assert response.data['name'] == self.user.name
+        assert response.data['biography'] is None
+        assert 'email' not in response.data
+        assert response.data['url'] == absolutify(self.user.get_url_path())
+
+        # Login as a random user and check it's still not visible.
+        self.client.login_api(user_factory())
+        response = self.client.get(self.url)
+        assert response.data['name'] == self.user.name
+        assert response.data['biography'] is None
+        assert 'email' not in response.data
+        assert response.data['url'] == absolutify(self.user.get_url_path())
+
+    @override_settings(DRF_API_GATES={'v5': ()})
+    def test_is_not_full_public_profile_because_not_developer_no_fields(self):
+        # TODO: when mimimal-profile-has-all-fields-shim is removed for v5, we won't
+        # need the override_settings
         assert not self.user.has_full_profile
         response = self.client.get(self.url)  # No auth.
         assert response.data['name'] == self.user.name

--- a/src/olympia/accounts/views.py
+++ b/src/olympia/accounts/views.py
@@ -68,8 +68,8 @@ from olympia.users.notifications import (
 from . import verify
 from .serializers import (
     AccountSuperCreateSerializer,
-    BaseUserSerializer,
     FullUserProfileSerializer,
+    MinimalUserProfileSerializer,
     SelfUserProfileSerializer,
     UserNotificationSerializer,
 )
@@ -506,7 +506,7 @@ class AccountViewSet(
         elif self.get_object().has_full_profile:
             return FullUserProfileSerializer
         else:
-            return BaseUserSerializer
+            return MinimalUserProfileSerializer
 
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()


### PR DESCRIPTION
Fixes: mozilla/addons#15479 - follow up for mozilla/addons#15402, fixing a bug in https://github.com/mozilla/addons-server/pull/23154

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

See issue.  We were using the wrong serializer that didn't have the API_GATE integration to shim the fields.

### Context

<!--
Often a pull request contains changes that are not fully self explanatory. Maybe this PR is a part of a series,
or maybe it is a partial change now with a more ambitious plan for the future. Add this additional context here.
If it is not relevant for your PR, remove this section.
-->

### Testing

access any `/api/v[3|4|5]/accounts/account/(int:user_id)/` url without auth; see all the fields present, but with biography, etc (see original issue and pr) shim'd as `null` rather than omitted.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
