### PR TITLE
add linter for workflows

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -40,21 +40,17 @@ jobs:
         include:
           -
             name: Needs Locale Compilation
-            services: ''
             run: |
               make compile_locales
               make test_needs_locales_compilation
           -
             name: Internal Routes
-            services: ''
             run: make test_internal_routes_allowed
           -
             name: Elastic Search
-            services: ''
             run: make test_es_tests
           -
             name: Codestyle
-            services: web
             run: make lint-codestyle
     steps:
       - uses: actions/checkout@v4
@@ -63,6 +59,5 @@ jobs:
         with:
           version: ${{ inputs.version }}
           digest: ${{ inputs.digest }}
-          services: ${{ matrix.services }}
           deps: development
           run: ${{ matrix.run }}

--- a/.github/workflows/_test_main.yml
+++ b/.github/workflows/_test_main.yml
@@ -61,15 +61,22 @@ jobs:
         id: result
         shell: bash
         run: |
-          splits="${{ inputs.splits }}"
-          echo "splits: $splits"
-          echo "splits=$splits" >> "$GITHUB_OUTPUT"
-
           # Construct the matrix input for test_main using the groups count
-          # the matrix.group should be an array of numbers from 1 to $splits
-          matrix=$(seq -s, 1 "$splits")
-          echo "matrix: $matrix"
+          # the matrix.group should be an array of numbers from 0 to ${{ inputs.splits }}
+          splits="${{ inputs.splits }}"
+          # the matrix group should be indexed from 1 to splits + 1
+          n=$((splits + 1))
+          matrix=$(jq -n -c --arg n "$n" '[range(1;($n|tonumber))]')
+
+          # validate that matrix is an array of numbers from 1 to splits + 1
+          if ! echo "$matrix" | jq empty; then
+            echo "matrix is not an array of numbers from 1 to splits + 1"
+            exit 1
+          fi
+
+          echo "splits=$splits" >> "$GITHUB_OUTPUT"
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"
 
   test_main:
     runs-on: ubuntu-latest

--- a/.github/workflows/_test_main.yml
+++ b/.github/workflows/_test_main.yml
@@ -61,15 +61,15 @@ jobs:
         id: result
         shell: bash
         run: |
-          splits=${{ inputs.splits }}
+          splits="${{ inputs.splits }}"
           echo "splits: $splits"
-          echo "splits=$splits" >> $GITHUB_OUTPUT
+          echo "splits=$splits" >> "$GITHUB_OUTPUT"
 
           # Construct the matrix input for test_main using the groups count
           # the matrix.group should be an array of numbers from 1 to $splits
-          matrix=[$(seq -s, 1 $splits)]
+          matrix=$(seq -s, 1 "$splits")
           echo "matrix: $matrix"
-          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
   test_main:
     runs-on: ubuntu-latest
@@ -85,7 +85,6 @@ jobs:
       - name: Test (test_matrix)
         uses: ./.github/actions/run-docker
         with:
-          services: ''
           digest: ${{ inputs.digest }}
           version: ${{ inputs.version }}
           deps: development
@@ -118,14 +117,14 @@ jobs:
       - name: Cat logs
         shell: bash
         run: |
-          for dir in $(ls -d ${{ env.log_artifact }}* | sort -V); do
+          for dir in $(find . -maxdepth 1 -name "${{ env.log_artifact }}*" -type d | sort -V); do
             job=$(basename "$dir")
             file="${dir}/${{ env.log_file }}"
             if [ -f "$file" ]; then
-              cat "$file" | jq \
+              jq \
                 -r \
                 --arg job "$job" \
-                'select(has("when") and .when == "teardown") | "[\($job)] \(.outcome) \(.nodeid)"'
+                'select(has("when") and .when == "teardown") | "[\($job)] \(.outcome) \(.nodeid)"' < "$file"
             else
               echo "$file: No such file or directory"
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
     outputs:
       is_fork: ${{ steps.context.outputs.is_fork }}
       is_release_master: ${{ steps.context.outputs.is_release_master }}
-      is_dependabot: ${{ steps.context.outputs.is_dependabot }}
       is_default_branch: ${{ steps.context.outputs.is_default_branch }}
       is_release_tag: ${{ steps.context.outputs.is_release_tag }}
       docker_version: ${{ steps.context.outputs.docker_version }}
@@ -51,8 +50,8 @@ jobs:
         run: |
           docker run \
             --rm \
-            -v $(pwd):/workdir \
-            -w /workdir \
+            -v "$(pwd):/workdir" \
+            -w "/workdir" \
             rhysd/actionlint:latest \
             -verbose
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,17 +43,13 @@ jobs:
         uses: ./.github/actions/context
 
   actionlint:
+    permissions:
+      contents: 'read'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Run actionlint
-        run: |
-          docker run \
-            --rm \
-            -v "$(pwd):/workdir" \
-            -w "/workdir" \
-            rhysd/actionlint:latest \
-            -verbose
+        run: make actionlint
 
   build:
     name: ${{ needs.context.outputs.is_fork == 'true' && 'Skip' || 'Build' }}  CI Image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,19 @@ jobs:
         id: context
         uses: ./.github/actions/context
 
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run actionlint
+        run: |
+          docker run \
+            --rm \
+            -v $(pwd):/workdir \
+            -w /workdir \
+            rhysd/actionlint:latest \
+            -verbose
+
   build:
     name: ${{ needs.context.outputs.is_fork == 'true' && 'Skip' || 'Build' }}  CI Image
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_completed.yml
+++ b/.github/workflows/ci_completed.yml
@@ -52,11 +52,13 @@ jobs:
             emoji=":x:"
           fi
 
-          echo "sha=$sha" >> $GITHUB_OUTPUT
-          echo "conclusion=$conclusion" >> $GITHUB_OUTPUT
-          echo "commit_short=$commit_short" >> $GITHUB_OUTPUT
-          echo "emoji=$emoji" >> $GITHUB_OUTPUT
-          cat $GITHUB_OUTPUT
+          {
+            echo "sha=$sha"
+            echo "conclusion=$conclusion"
+            echo "commit_short=$commit_short"
+            echo "emoji=$emoji"
+          } >> "$GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"
 
   slack_notification_master_push:
     needs: context

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -49,7 +49,7 @@ jobs:
           fi
 
           # Verify that a release with this tag does not already exist
-          if gh release view $tag &> /dev/null; then
+          if gh release view "$tag" &> /dev/null; then
             echo "Release $tag-next already exists"
             exit 1
           fi
@@ -62,8 +62,8 @@ jobs:
             /repos/mozilla/addons-server/releases/latest
           )
 
-          previous_tag=$(echo $previous_release | jq -r '.tag_name')
-          previous_release_url=$(echo $previous_release | jq -r '.html_url')
+          previous_tag=$(echo "$previous_release" | jq -r '.tag_name')
+          previous_release_url=$(echo "$previous_release" | jq -r '.html_url')
 
           cat <<EOF
           $previous_release
@@ -81,8 +81,8 @@ jobs:
           # Replace {{PREVIOUS_RELEASE_URL}} in template with $previous_release_url
           template=${template//\{\{PREVIOUS_RELEASE_URL\}\}/$previous_release_url}
 
-          gh release create $tag \
-            --title $tag \
+          gh release create "$tag" \
+            --title "$tag" \
             --target master \
             --notes "$template" \
             --draft

--- a/.github/workflows/health_check.yml
+++ b/.github/workflows/health_check.yml
@@ -56,13 +56,13 @@ jobs:
 
           # Create the message blocks file
           ./scripts/health_check_blocks.py \
-          --input ${{ env.health_check_file }} \
-          --output ${{ env.health_check_blocks_file }}
+          --input "${{ env.health_check_file }}" \
+          --output "${{ env.health_check_blocks_file }}"
           # Multiline output needs to use a delimiter to be passed to
           # the GITHUB_OUTPUT file.
-          blocks=$(cat ${{ env.health_check_blocks_file }})
-          echo "blocks<<EOF"$'\n'$blocks$'\n'EOF >> $GITHUB_OUTPUT
-          cat $GITHUB_OUTPUT
+          blocks=$(cat "${{ env.health_check_blocks_file }}")
+          echo "blocks<<EOF"$'\n'"$blocks"$'\n'EOF >> "$GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"
 
       - uses: mozilla/addons/.github/actions/slack@main
         if: |

--- a/Makefile-os
+++ b/Makefile-os
@@ -87,8 +87,7 @@ actionlint: ## lint github action workflows
 		--rm \
 		-v "$(PWD):/workdir" \
 		-w "/workdir" \
-		rhysd/actionlint@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9 \
-		-verbose
+		rhysd/actionlint@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9
 
 .PHONY: test_setup
 test_setup:

--- a/Makefile-os
+++ b/Makefile-os
@@ -81,6 +81,15 @@ help_submake:
 	@echo "\nAll other commands will be passed through to the docker 'web' container make:"
 	@make -f Makefile-docker help_submake
 
+.PHONY: actionlint
+actionlint: ## lint github action workflows
+	docker run \
+		--rm \
+		-v "$(PWD):/workdir" \
+		-w "/workdir" \
+		rhysd/actionlint@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9 \
+		-verbose
+
 .PHONY: test_setup
 test_setup:
 	npm run test tests/make


### PR DESCRIPTION
Fixes: mozilla/addons#15481

### Description

Use [actionlint](https://github.com/rhysd/actionlint/) to lint our github workflow files.

### Testing

Before: **failing** <https://github.com/mozilla/addons-server/actions/runs/13952752375/job/39056293411?pr=23193>
After:  **passing** <https://github.com/mozilla/addons-server/actions/runs/13952805622/job/39056471261?pr=23193>

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
