### PR TITLE
Use relative path resolution and manually include static assets in vite's module graph.

### DIFF
--- a/Makefile-os
+++ b/Makefile-os
@@ -19,7 +19,8 @@ override DOCKER_MYSQLD_VOLUME = addons-server_data_mysqld
 
 export FXA_CLIENT_ID ?=
 export FXA_CLIENT_SECRET ?=
-
+export STATIC_URL_PREFIX ?= /static-server/
+export MEDIA_URL_PREFIX ?= /user-media/
 INITIALIZE_ARGS ?=
 INIT_CLEAN ?=
 INIT_LOAD ?=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ x-env-mapping: &env
     - MEMCACHE_LOCATION=memcached:11211
     - MYSQL_DATABASE=olympia
     - MYSQL_ROOT_PASSWORD=docker
-    - OLYMPIA_SITE_URL=http://olympia.test
+    - SITE_URL=http://olympia.test
     - PYTHONDONTWRITEBYTECODE=1
     - PYTHONUNBUFFERED=1
     - PYTHONBREAKPOINT=ipdb.set_trace
@@ -25,6 +25,8 @@ x-env-mapping: &env
     - SKIP_DATA_SEED
     - FXA_CLIENT_ID
     - FXA_CLIENT_SECRET
+    - STATIC_URL_PREFIX
+    - MEDIA_URL_PREFIX
 
 x-olympia: &olympia
   <<: *env
@@ -94,8 +96,9 @@ services:
 
   nginx:
     image: nginx
+    <<: *env
     volumes:
-      - data_nginx:/etc/nginx/conf.d
+      - data_nginx:/etc/nginx/templates
       - ./:/srv
     ports:
       - "80:80"

--- a/docker/nginx/addons.conf.template
+++ b/docker/nginx/addons.conf.template
@@ -10,7 +10,7 @@ server {
         alias /srv/storage/;
     }
 
-    location ^~ /static/bundle/ {
+    location ^~ ${STATIC_URL_PREFIX}bundle/ {
         proxy_pass http://static;
 
         proxy_set_header Upgrade $http_upgrade;
@@ -25,7 +25,7 @@ server {
         add_header X-Served-By "vite" always;
     }
 
-    location ~ ^/static/(.*)$ {
+    location ~ ^${STATIC_URL_PREFIX}(.*)$ {
         add_header X-Served-By "nginx" always;
 
         # "root /srv" as we mount all files in this directory
@@ -36,7 +36,7 @@ server {
         try_files /site-static/$1 /static/$1 @olympia;
     }
 
-    location /user-media/ {
+    location ${MEDIA_URL_PREFIX} {
         alias /srv/storage/shared_storage/uploads/;
         add_header X-Served-By "nginx" always;
     }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "type": "module",
   "scripts": {
-    "dev": "vite -d --strictPort --clearScreen",
+    "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run",

--- a/settings.py
+++ b/settings.py
@@ -85,14 +85,15 @@ CELERY_TASK_ALWAYS_EAGER = False
 # replicas to zero.
 ES_DEFAULT_NUM_REPLICAS = 0
 
-SITE_URL = os.environ.get('OLYMPIA_SITE_URL') or 'http://localhost:8000'
+SITE_URL = env('SITE_URL')
+
 DOMAIN = SERVICES_DOMAIN = urlparse(SITE_URL).netloc
 ADDONS_FRONTEND_PROXY_PORT = '7000'
 SERVICES_URL = SITE_URL
 INTERNAL_SITE_URL = 'http://nginx'
 EXTERNAL_SITE_URL = SITE_URL
-STATIC_URL = '%s/static/' % EXTERNAL_SITE_URL
-MEDIA_URL = '%s/user-media/' % EXTERNAL_SITE_URL
+STATIC_URL = EXTERNAL_SITE_URL + STATIC_URL_PREFIX
+MEDIA_URL = EXTERNAL_SITE_URL + MEDIA_URL_PREFIX
 
 ALLOWED_HOSTS = ALLOWED_HOSTS + [SERVICES_DOMAIN, 'nginx', '127.0.0.1']
 
@@ -158,6 +159,7 @@ RECAPTCHA_PRIVATE_KEY = '6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe'
 ADDONS_SERVER_DOCS_URL = 'https://addons-server.readthedocs.io/en/latest'
 
 ENABLE_ADMIN_MLBF_UPLOAD = True
+
 
 # Use dev mode if we are on a non production imqage and debug is enabled.
 if get_version_json().get('target') != 'production' and DEBUG:

--- a/src/olympia/core/apps.py
+++ b/src/olympia/core/apps.py
@@ -162,16 +162,17 @@ def nginx_check(app_configs, **kwargs):
         return []
 
     configs = [
-        (settings.MEDIA_ROOT, 'http://nginx/user-media'),
-        (settings.STATIC_FILES_PATH, 'http://nginx/static'),
-        (settings.STATIC_ROOT, 'http://nginx/static'),
+        (settings.MEDIA_ROOT, settings.MEDIA_URL_PREFIX),
+        (settings.STATIC_FILES_PATH, settings.STATIC_URL_PREFIX),
+        (settings.STATIC_ROOT, settings.STATIC_URL_PREFIX),
     ]
 
     files_to_remove = []
 
-    for dir, base_url in configs:
+    for dir, prefix in configs:
+        base_url = f'{settings.INTERNAL_SITE_URL}{prefix}'
         file_path = os.path.join(dir, 'test.txt')
-        file_url = f'{base_url}/test.txt'
+        file_url = f'{base_url}test.txt'
 
         if not os.path.exists(dir):
             errors.append(Error(f'{dir} does not exist', id='setup.E007'))

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -245,7 +245,7 @@ PROD_MEDIA_URL = 'https://addons.mozilla.org/user-media/'
 
 # Static
 STATIC_ROOT = path('site-static')
-# Allow overriding static/mdeia url path prefix
+# Allow overriding static/media url path prefix
 STATIC_URL_PREFIX = env('STATIC_URL_PREFIX', default='/static-server/')
 MEDIA_URL_PREFIX = env('MEDIA_URL_PREFIX', default='/user-media/')
 # URL that handles the media served from MEDIA_ROOT. Make sure to use a

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -243,6 +243,20 @@ SERVICES_URL = 'http://%s' % SERVICES_DOMAIN
 PROD_STATIC_URL = 'https://addons.mozilla.org/static-server/'
 PROD_MEDIA_URL = 'https://addons.mozilla.org/user-media/'
 
+# Static
+STATIC_ROOT = path('site-static')
+# Allow overriding static/mdeia url path prefix
+STATIC_URL_PREFIX = env('STATIC_URL_PREFIX', default='/static-server/')
+MEDIA_URL_PREFIX = env('MEDIA_URL_PREFIX', default='/user-media/')
+# URL that handles the media served from MEDIA_ROOT. Make sure to use a
+# trailing slash if there is a path component (optional in other cases).
+# Examples: "http://media.lawrence.com", "http://example.com/media/"
+MEDIA_URL = MEDIA_URL_PREFIX
+# URL that handles the static files served from STATIC_ROOT. Make sure to use a
+# trailing slash if there is a path component (optional in other cases).
+# Examples: "http://media.lawrence.com", "http://example.com/static/"
+STATIC_URL = STATIC_URL_PREFIX
+
 # Filter IP addresses of allowed clients that can post email through the API.
 ALLOWED_CLIENTS_EMAIL_API = env.list('ALLOWED_CLIENTS_EMAIL_API', default=[])
 # Auth token required to authorize inbound email.
@@ -251,11 +265,6 @@ INBOUND_EMAIL_SECRET_KEY = env('INBOUND_EMAIL_SECRET_KEY', default='')
 INBOUND_EMAIL_VALIDATION_KEY = env('INBOUND_EMAIL_VALIDATION_KEY', default='')
 # Domain emails should be sent to.
 INBOUND_EMAIL_DOMAIN = env('INBOUND_EMAIL_DOMAIN', default=DOMAIN)
-
-# URL that handles the media served from MEDIA_ROOT. Make sure to use a
-# trailing slash if there is a path component (optional in other cases).
-# Examples: "http://media.lawrence.com", "http://example.com/media/"
-MEDIA_URL = '/user-media/'
 
 # Tarballs in DUMPED_APPS_PATH deleted 30 days after they have been written.
 DUMPED_APPS_DAYS_DELETE = 3600 * 24 * 30
@@ -288,7 +297,7 @@ SUPPORTED_NONAPPS = (
     'statistics',
     'services',
     'sitemap.xml',
-    'static',
+    STATIC_URL_PREFIX.strip('/'),
     'update',
     'user-media',
     '__heartbeat__',
@@ -309,7 +318,7 @@ SUPPORTED_NONLOCALES = (
     'services',
     'sitemap.xml',
     'downloads',
-    'static',
+    STATIC_URL_PREFIX.strip('/'),
     'update',
     'user-media',
     '__heartbeat__',
@@ -1176,9 +1185,6 @@ HIVE_CONNECTION = {
     'auth_mechanism': 'PLAIN',
 }
 
-# Static
-STATIC_ROOT = path('site-static')
-STATIC_URL = '/static/'
 
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',

--- a/src/olympia/urls.py
+++ b/src/olympia/urls.py
@@ -132,6 +132,8 @@ if settings.SERVE_STATIC_FILES:
     # Remove leading and trailing slashes so the regex matches.
     media_url = settings.MEDIA_URL.lstrip('/').rstrip('/')
 
+    static_url_prefix = settings.STATIC_URL_PREFIX.lstrip('/').rstrip('/')
+
     urlpatterns.extend(
         [
             re_path(
@@ -141,19 +143,22 @@ if settings.SERVE_STATIC_FILES:
             ),
             # Serve javascript catalog locales bundle directly from django
             re_path(
-                r'^static/js/i18n/(?P<locale>\w{2,3}(?:-\w{2,6})?)\.js$',
+                (
+                    r'^%s/js/i18n/(?P<locale>\w{2,3}(?:-\w{2,6})?)\.js$'
+                    % static_url_prefix
+                ),
                 serve_javascript_catalog,
                 name='javascript-catalog',
             ),
             # Serve swagger UI JS directly from django
             re_path(
-                r'^static/js/swagger/(?P<version>[^/]+)\.js$',
+                r'^%s/js/swagger/(?P<version>[^/]+)\.js$' % static_url_prefix,
                 serve_swagger_ui_js,
             ),
             # fallback for static files that are not available directly over nginx.
             # Mostly vendor files from python or npm dependencies that are not available
             # in the static files directory.
-            re_path(r'^static/(?P<path>.*)$', serve_static_files),
+            re_path(r'^%s/(?P<path>.*)$' % static_url_prefix, serve_static_files),
         ]
     )
 

--- a/tests/make/make.spec.js
+++ b/tests/make/make.spec.js
@@ -150,7 +150,7 @@ describe('docker-compose.yml', () => {
           // mapping for nginx conf.d adding addon-server routing
           expect.objectContaining({
             source: 'data_nginx',
-            target: '/etc/nginx/conf.d',
+            target: '/etc/nginx/templates',
           }),
           // mapping for /data/olympia/ directory to /srv
           expect.objectContaining({

--- a/vite.config.js
+++ b/vite.config.js
@@ -66,6 +66,11 @@ export default defineConfig(({ command }) => {
       }),
     ],
     build: {
+      // Disable inline assets. For performance reasons we want to server
+      // all static assets from dedicated URLs which in production will
+      // be cached in our CDN. The incremental build size is worse than
+      // the increase in number of requests.
+      assetsInlineLimit: 0,
       // This value should be kept in sync with settings_base.py
       // which determines where to read static file paths
       // for production URL resolution

--- a/vite.config.js
+++ b/vite.config.js
@@ -27,13 +27,8 @@ const jqueryGlobals = {
   jQuery: 'jquery',
 };
 
-const env = (name) => {
-  const value = process.env[name];
-  if (!value) {
-    throw new Error(`${name} is not defined`);
-  }
-  return value;
-};
+const env = (name, defaultValue) =>
+  process.env[name] || defaultValue || new Error(`${name} is not defined`);
 
 export default defineConfig(({ command }) => {
   const isLocal = env('ENV') === 'local';
@@ -47,6 +42,7 @@ export default defineConfig(({ command }) => {
     assetsInclude: `${INPUT_DIR}/*`,
     strict: true,
     root: resolve(INPUT_DIR),
+    debug: env('DEBUG', false),
     // In dev mode, prefix 'bundle' to static file URLs
     // so that nginx knows to forward the request to the vite
     // dev server instead of serving from static files or olympia
@@ -133,12 +129,15 @@ export default defineConfig(({ command }) => {
   if (isDev) {
     // In dev mode, add the bundle path to direct
     // static requests to the vite dev server via nginx
-    baseConfig.base += 'bundle/';
+    baseConfig.base = `${env('STATIC_URL_PREFIX')}bundle/`;
     // Configure the dev server in dev mode
     baseConfig.server = {
       host: true,
       port: 5173,
       allowedHosts: true,
+      origin: env('SITE_URL'),
+      strictPort: true,
+      clearScreen: true,
     };
   }
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -66,7 +66,7 @@ export default defineConfig(({ command }) => {
       }),
     ],
     build: {
-      // Disable inline assets. For performance reasons we want to server
+      // Disable inline assets. For performance reasons we want to serve
       // all static assets from dedicated URLs which in production will
       // be cached in our CDN. The incremental build size is worse than
       // the increase in number of requests.

--- a/vite.config.js
+++ b/vite.config.js
@@ -40,12 +40,20 @@ export default defineConfig(({ command }) => {
   const isDev = command === 'serve';
 
   const baseConfig = {
+    // Ensure all static assets are treated as
+    // 'in-scope' assets that can be tracked by vite
+    // this ensures any imported static assets are correctly
+    // mapped across file transformations.
+    assetsInclude: `${INPUT_DIR}/*`,
     strict: true,
     root: resolve(INPUT_DIR),
     // In dev mode, prefix 'bundle' to static file URLs
     // so that nginx knows to forward the request to the vite
     // dev server instead of serving from static files or olympia
-    base: '/static/',
+    // Use a relative path during the build
+    // this ensures that import paths can be transformed
+    // independently of where the importing file ends up in the bundle
+    base: './',
     resolve: {
       alias: {
         // Alias 'highcharts' to our local vendored copy
@@ -106,7 +114,6 @@ export default defineConfig(({ command }) => {
       preprocessorOptions: {
         less: {
           math: 'always',
-          // relativeUrls: true,
           javascriptEnabled: true,
         },
       },


### PR DESCRIPTION
Fixes: mozilla/addons#15486

### Description

- Use relative paths for production URLs
- include static assets (png|svg) manually in vite

### Context

The path where we serve static assets impacts several parts of the codebase:
- the nginx path we route requests to static asset servers
- settings which exempt static urls from having a lang/app prefix
- settings which are used to produce static urls in html
- settings in vite itself to determine how to transform URLs during dev/build

Since all of these have to be syncronized it makes sense to extract the part of the URL which defines the "root" or "prefix" of the url to its own environment variable setting.

By default, the values in `base_settings.py` will be the same, and these values are explicitly overriden in all production like environments. But in local environments this allows one to configure the path where static files are served from and linked to from a single place.

## Testing

### clean project

```bash
make down \
  && rm -rf ./static-build ./site-static \
  && git clean -xdf ./static \
  && echo "finished!"
```

### Dev mode

```bash
make up DOCKER_TARGET=development
```

Navigate the site, ensuring that static images, css files and js files are resolving correctly.

- /developers*
- /reviewers*

There are 141 URL imports in our css files, spread across virtually every page. It should be easy to find non-resolving URLs but make sure to be thorough and follow all links across devhub/reviewer tools

### Prod mode


```bash
make down && make up DOCKER_TARGET=production
```

Expect the same as in dev mode. URLs should resolve correctly, though the css files will be bundled and minified.

### Build

Verify the build is resolving correctly

```bash
make update_assets
```

Now inspect `./site-static/assets/css`, find a css file that imports files `devhub.css` for example (note: it will have a hash postfix). Check for refrences to `url(` and expect all references should use relative paths pointing to `../<path>`. This path should match a file existing at the expected path (in the parent).

> [!NOTE]
> Because vite transforms the file paths, nested files are collapsed so any file in source will point to `../<name>.<ext>` in the build. All css file as in `<static>/css` and all images are in `<static>/<name>.<ext>`  so all css files will point to the parent directory when referencing static images.

### Dynamic STATIC_URL

Re-run the development build setting a value for the `STATIC_URL_PREFIX`

```bash
make up STATIC_URL_PREFIX=/static-server/
```

> [!IMPORTANT]
> Make sure to include the `/` trailing slash. 

This will modify the path we expect to serve static files from for `nginx`, `web` and `static` (vite)

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
