### PR TITLE
Deactivate jitter for Cinder tasks we're retrying

### DIFF
--- a/src/olympia/abuse/tasks.py
+++ b/src/olympia/abuse/tasks.py
@@ -80,12 +80,11 @@ def retryable_task(f):
 
     @task(
         autoretry_for=retryable_exceptions,
-        retry_backoff=30,  # start backoff at 30 seconds
-        retry_backoff_max=2 * 60 * 60,  # Max out at 2 hours between retries
-        # With jitter we don't know the total time period for retries, but we're aiming
-        # for ~72 hours
-        retry_kwargs={'max_retries': 60},
-        bind=True,
+        retry_backoff=30,  # Start backoff at 30 seconds.
+        retry_backoff_max=2 * 60 * 60,  # Max out at 2 hours between retries.
+        retry_jitter=False,  # Delay can be 0 with jitter, which we don't want.
+        retry_kwargs={'max_retries': 60},  # Aiming for ~72 hours retry period.
+        bind=True,  # Gives access to task retries count inside the function.
     )
     @functools.wraps(f)
     def wrapper(task, *args, **kw):


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/15447

### Context

As mentioned in the issue, with `retry_jitter` enabled the delay is too unpredictable, could potentially be `0` which is not ideal. Let's stick to regular exponential backoff delay.

### Testing

See https://github.com/mozilla/addons-server/pull/23098, except the delay between each retry should always increase due to exponential backoff.