### PR TITLE
Make "Cancel and Disable Version" behave like Disable Version ; remove "Cancel Review Request"

### DIFF
--- a/src/olympia/devhub/templates/devhub/versions/list.html
+++ b/src/olympia/devhub/templates/devhub/versions/list.html
@@ -97,7 +97,7 @@
          data-is-current="{{ (version == addon.current_version)|int }}">x</a>
     </td>
   </tr>
-  {% if full_info and version.channel == amo.CHANNEL_LISTED and (can_request_review or can_cancel) %}
+  {% if full_info and version.channel == amo.CHANNEL_LISTED and can_request_review %}
     <tr>
       <td colspan="0" class="version-status-actions item-actions">
         {% if can_request_review %}
@@ -106,9 +106,6 @@
             {% csrf_token %}
             <button class="link" type="submit">{{ _('Request Review') }}</button> &middot;
           </form>
-        {% endif %}
-        {% if can_cancel %}
-          <a href="#" id="cancel-review">{{ _('Cancel Review Request') }}</a>
         {% endif %}
       </td>
     </tr>
@@ -339,35 +336,6 @@
         </button>
         {{ _('or') }} <a href="#" class="close">{{ _('Cancel') }}</a>
       </p>
-    </form>
-  </div>
-  {% endif %}
-
-  {% if not addon.is_disabled and addon.status == amo.STATUS_NOMINATED %}
-  {# Note: devhub.addons.cancel will cancel the latest version in the specified channel.
-   # This particular modal is only shown for listed versions though, so we can safely
-   # hardcode the channel parameter. #}
-  <div id="modal-cancel" class="modal">
-    <form method="post" action="{{ url('devhub.addons.cancel', addon.slug, 'listed') }}">
-      <h3>{{ _('Cancel Review Request') }}</h3>
-      <p>
-        {% trans %}
-            Canceling your review request will mark your add-on incomplete,
-            and any versions awaiting review will be disabled.
-        {% endtrans %}
-      </p>
-      <p>
-        {% trans %}
-          Are you sure you wish to cancel your review request?
-        {% endtrans %}
-      </p>
-      {% csrf_token %}
-      <input type="hidden" name="addon_id" class="addon_id" value="{{ addon.id }}">
-      <p>
-        <button type="submit">{{ _('Cancel Review Request') }}</button>
-        {{ _('or') }} <a href="#" class="cancel close">{{ _('Close') }}</a>
-      </p>
-      <a href="#" class="close">{{ _('Close') }}</a>
     </form>
   </div>
   {% endif %}

--- a/src/olympia/devhub/tests/test_views_submit.py
+++ b/src/olympia/devhub/tests/test_views_submit.py
@@ -1364,20 +1364,6 @@ class DetailsPageMixin:
         response = self.client.get(self.url)
         self.assert3xx(response, self.next_step)
 
-    def test_can_cancel_review(self):
-        addon = self.get_addon()
-        addon.versions.latest().file.update(status=amo.STATUS_AWAITING_REVIEW)
-
-        cancel_url = reverse('devhub.addons.cancel', args=['a3615', 'listed'])
-        versions_url = reverse('devhub.addons.versions', args=['a3615'])
-        response = self.client.post(cancel_url)
-        self.assert3xx(response, versions_url)
-
-        addon = self.get_addon()
-        assert addon.status == amo.STATUS_NULL
-        version = addon.versions.latest()
-        assert version.file.status == amo.STATUS_DISABLED
-
     @override_switch('content-optimization', active=False)
     def test_name_summary_lengths_short(self):
         # check the separate name and summary labels, etc are served
@@ -2867,21 +2853,6 @@ class TestVersionSubmitDetails(TestSubmitBase):
                 'devhub.submit.version.finish', args=[self.addon.slug, self.version.pk]
             ),
         )
-
-    def test_can_cancel_review(self):
-        addon = self.get_addon()
-        addon_status = addon.status
-        addon.versions.latest().file.update(status=amo.STATUS_AWAITING_REVIEW)
-
-        cancel_url = reverse('devhub.addons.cancel', args=['a3615', 'listed'])
-        versions_url = reverse('devhub.addons.versions', args=['a3615'])
-        response = self.client.post(cancel_url)
-        self.assert3xx(response, versions_url)
-
-        addon = self.get_addon()
-        assert addon.status == addon_status  # No change.
-        version = addon.versions.latest()
-        assert version.file.status == amo.STATUS_DISABLED
 
     def test_public_addon_stays_public_even_if_had_missing_metadata(self):
         """Posting details for a new version for a public add-on that somehow

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -573,28 +573,6 @@ class TestVersion(TestCase):
         assert response.status_code == 302
         assert Addon.objects.get(id=3615).status == amo.STATUS_APPROVED
 
-    def test_cancel_button(self):
-        for status in Addon.STATUS_CHOICES:
-            if status != amo.STATUS_NOMINATED:
-                continue
-
-            self.addon.update(status=status)
-            response = self.client.get(self.url)
-            doc = pq(response.content)
-            assert doc('#cancel-review')
-            assert doc('#modal-cancel')
-
-    def test_not_cancel_button(self):
-        for status in Addon.STATUS_CHOICES:
-            if status == amo.STATUS_NOMINATED:
-                continue
-
-            self.addon.update(status=status)
-            response = self.client.get(self.url)
-            doc = pq(response.content)
-            assert not doc('#cancel-review'), status
-            assert not doc('#modal-cancel'), status
-
     def test_incomplete_request_review(self):
         self.addon.update(status=amo.STATUS_NULL)
         doc = pq(self.client.get(self.url).content)

--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -524,8 +524,22 @@ class TestVersion(TestCase):
     def test_cancel(self):
         cancel_url = reverse('devhub.addons.cancel', args=['a3615', 'listed'])
         self.addon.current_version.file.update(status=amo.STATUS_AWAITING_REVIEW)
+        latest_version = self.addon.current_version
+        assert not latest_version.is_user_disabled
+        assert (
+            ActivityLog.objects.filter(action=amo.LOG.DISABLE_VERSION.id).count() == 0
+        )
         self.client.post(cancel_url)
         assert Addon.objects.get(id=3615).status == amo.STATUS_NULL
+        assert (
+            ActivityLog.objects.filter(action=amo.LOG.DISABLE_VERSION.id).count() == 1
+        )
+        assert ActivityLog.objects.filter(
+            action=amo.LOG.DISABLE_VERSION.id
+        ).get().arguments == [self.addon, latest_version]
+        latest_version.file.reload()
+        assert latest_version.is_user_disabled
+        assert latest_version.file.status == amo.STATUS_DISABLED
 
     def test_cancel_obey_channel_listed(self):
         addon = Addon.objects.get(id=3615)
@@ -540,10 +554,18 @@ class TestVersion(TestCase):
         self.client.post(cancel_url)
         file_.reload()
         assert file_.status == amo.STATUS_DISABLED
+        assert file_.version.is_user_disabled
         unlisted_file.reload()
+        assert not unlisted_file.version.is_user_disabled
         assert unlisted_file.status == amo.STATUS_AWAITING_REVIEW
         addon.reload()
         assert addon.status == amo.STATUS_NULL
+        assert (
+            ActivityLog.objects.filter(action=amo.LOG.DISABLE_VERSION.id).count() == 1
+        )
+        assert ActivityLog.objects.filter(
+            action=amo.LOG.DISABLE_VERSION.id
+        ).get().arguments == [addon, file_.version]
 
     def test_cancel_obey_channel_unlisted(self):
         addon = Addon.objects.get(id=3615)
@@ -560,10 +582,18 @@ class TestVersion(TestCase):
         self.client.post(cancel_url)
         file_.reload()
         assert file_.status == amo.STATUS_DISABLED
+        assert file_.version.is_user_disabled
         listed_file.reload()
+        assert not listed_file.version.is_user_disabled
         assert listed_file.status == amo.STATUS_AWAITING_REVIEW
         addon.reload()
         assert addon.status == amo.STATUS_NOMINATED
+        assert (
+            ActivityLog.objects.filter(action=amo.LOG.DISABLE_VERSION.id).count() == 1
+        )
+        assert ActivityLog.objects.filter(
+            action=amo.LOG.DISABLE_VERSION.id
+        ).get().arguments == [addon, file_.version]
 
     def test_not_cancel(self):
         self.client.logout()

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -408,7 +408,7 @@ def cancel(request, addon_id, addon, channel):
     latest_version = addon.find_latest_version(channel=channel)
     if latest_version:
         if latest_version.file.status == amo.STATUS_AWAITING_REVIEW:
-            latest_version.file.update(status=amo.STATUS_DISABLED)
+            latest_version.is_user_disabled = True  # Will update the files/activity log
         addon.update_status()
     return redirect(addon.get_dev_url('versions'))
 
@@ -1300,7 +1300,6 @@ def version_list(request, addon_id, addon):
     data = {
         'addon': addon,
         'can_request_review': addon.can_request_review(),
-        'can_cancel': not addon.is_disabled and addon.status == amo.STATUS_NOMINATED,
         'comments_maxlength': CommentLog._meta.get_field('comments').max_length,
         'is_admin': is_admin,
         'can_submit': not addon.is_disabled,

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -108,7 +108,6 @@ $(document).ready(function () {
   });
 
   // hook up various links related to current version status
-  $('#modal-cancel').modal('#cancel-review', { width: 400 });
   if ($('#modal-delete').length) {
     $modalDelete = $('#modal-delete').modal('.delete-addon', {
       width: 400,


### PR DESCRIPTION
### Context

"Cancel Review Request" is a relic from before auto-approval. Developers can just disable the version instead.

"Cancel and Disable Version", in the submission flow, is potentially useful but should behave like Disable Version instead, which is reversible and logs the activity.

### Testing

- Submit an add-on, choosing "On this site" as the distribution method. After uploading, during the submission process, hit "Cancel and Disable Version". 

Expected results:
- This should take you to the add-on version list page
- There should have been an activity log recorded (visible from "Recent changes" in the sidebar) for the version being disabled.
- The add-on should be shown as "Incomplete", it should not be public (`status` should be `0`).
- The version should have been disabled.
- Re-enabling the version should work, and let you resume the submission process, filling out details for the listing.
- Once you do the version should be awaiting review, and one approved the add-on should be public.

- You can repeat for an unlisted submission or a new version, everything should work in the same way except of course you won't have to fill out missing details for the listing and the add-on itself won't become public.


Fixes: mozilla/addons#15395