### PR TITLE
Prevent creation of PromotedAddonVersion for PromotedApproval with null application_id; added corresponding test case.

### DIFF
--- a/src/olympia/promoted/models.py
+++ b/src/olympia/promoted/models.py
@@ -481,16 +481,6 @@ def promoted_addon_to_promoted_addon_promotion(sender, instance, signal, **kw):
     promoted_addon_to_promoted_addon_promotion(signal=signal, instance=instance)
 
 
-@receiver([models.signals.pre_save], sender=PromotedApproval)
-def pre_save_promoted_approval(sender, instance, **kw):
-    # Store original values if it's an update so in the case
-    # where both application_id and group_id are None, we can
-    # delete the relevant PromotedAddonVersion instances.
-    if instance.pk:
-        original = sender.objects.get(pk=instance.pk)
-        instance._state.original_group_id = original.group_id
-        instance._state.original_application_id = original.application_id
-
 @receiver(
     [models.signals.post_save, models.signals.post_delete],
     sender=PromotedApproval,

--- a/src/olympia/promoted/models.py
+++ b/src/olympia/promoted/models.py
@@ -481,6 +481,16 @@ def promoted_addon_to_promoted_addon_promotion(sender, instance, signal, **kw):
     promoted_addon_to_promoted_addon_promotion(signal=signal, instance=instance)
 
 
+@receiver([models.signals.pre_save], sender=PromotedApproval)
+def pre_save_promoted_approval(sender, instance, **kw):
+    # Store original values if it's an update so in the case
+    # where both application_id and group_id are None, we can
+    # delete the relevant PromotedAddonVersion instances.
+    if instance.pk:
+        original = sender.objects.get(pk=instance.pk)
+        instance._state.original_group_id = original.group_id
+        instance._state.original_application_id = original.application_id
+
 @receiver(
     [models.signals.post_save, models.signals.post_delete],
     sender=PromotedApproval,


### PR DESCRIPTION
Fixes: mozilla/addons#15488

### Testing

1. create a PromotedApproval from any version with a null application_id
2. run sync_promoted_addons command
3. expect command to pass and not create any new PromotedAddonVersion instances.

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
