### PR TITLE
Correct PromotedGroup Approvals

### DIFF
--- a/src/olympia/devhub/tests/test_views_versions.py
+++ b/src/olympia/devhub/tests/test_views_versions.py
@@ -711,7 +711,7 @@ class TestVersion(TestCase):
             amo.LOG.REVIEWER_REPLY_VERSION, v2.addon, v2, user=self.user
         )
 
-        with self.assertNumQueries(42):
+        with self.assertNumQueries(40):
             # 1. SAVEPOINT
             # 2. the add-on
             # 3. translations for that add-on (default transformer)
@@ -750,7 +750,7 @@ class TestVersion(TestCase):
             # 35. latest non-disabled version in unlisted channel
             # 36. check on user being an author (dupe)
             # 38. waffle switch
-            # 39-42. promotion group queries
+            # 39-40. promotion group queries
             response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)

--- a/src/olympia/lib/crypto/tasks.py
+++ b/src/olympia/lib/crypto/tasks.py
@@ -123,6 +123,7 @@ def bump_addon_version(old_version):
     addon = old_version.addon
     old_file_obj = old_version.file
     promoted_group = addon.promoted_groups(currently_approved=True)
+    carryover = promoted_group and any(promoted_group.listed_pre_review)
     # We only sign files that have been reviewed
     if old_file_obj.status not in amo.APPROVED_STATUSES:
         log.info(
@@ -201,7 +202,7 @@ def bump_addon_version(old_version):
 
             # Carry over promotion if necessary.
             # TODO: promotedaddon; approve_for_version refactor (Write PR)
-            if promoted_group and any(promoted_group.listed_pre_review):
+            if carryover:
                 addon.promotedaddon.approve_for_version(new_version)
 
     except Exception:

--- a/src/olympia/promoted/models.py
+++ b/src/olympia/promoted/models.py
@@ -40,12 +40,12 @@ class PromotedGroupManager(ManagerBase):
             return self.none()
 
         # An addon is approved for a promoted group if:
-        # 1. For each PromotedAddonVersion A, there exists a
-        #    PromotedAddonPromotion B (an approval) such that
+        # 1. For each PromotedAddonPromotion A, there exists a
+        #    PromotedAddonVersion B (an approval) such that
         #       i. Are the same group,
         #       ii. Are the same application,
-        #       iii. A.version = B.addon.current_version
-        # OR, 2. is a promoted group that does not require prereview.
+        #       iii. A.addon.current_version = B.version, OR
+        # 2. is a promoted group that does not require prereview.
 
         approved_promotions = PromotedAddonPromotion.objects.filter(
             models.Exists(

--- a/src/olympia/promoted/models.py
+++ b/src/olympia/promoted/models.py
@@ -38,36 +38,30 @@ class PromotedGroupManager(ManagerBase):
     def approved_for(self, addon):
         if not addon.current_version:
             return self.none()
-        # For each PromotedGroup, the group should have an
-        # associated promoted_version version that is:
-        # 1. The addon's current version
-        # 2. The same promoted group
-        # 3. The group has approved_applications for the current version
-        # OR is not prereviewed for all apps
-        groups = (
-            self.all_for(addon=addon)
-            .filter(
-                Q(
-                    promoted_versions__version=addon.current_version,
-                    promotedaddonpromotion__promoted_group=models.F('id'),
-                )
-                | Q(
-                    promotedaddonpromotion__promoted_group__listed_pre_review=False,
-                    promotedaddonpromotion__promoted_group__unlisted_pre_review=False,
+
+        # An addon is approved for a promoted group if:
+        # 1. For each PromotedAddonVersion A, there exists a
+        #    PromotedAddonPromotion B (an approval) such that
+        #       i. Are the same group,
+        #       ii. Are the same application,
+        #       iii. A.version = B.addon.current_version
+        # OR, 2. is a promoted group that does not require prereview.
+
+        approved_promotions = PromotedAddonPromotion.objects.filter(
+            models.Exists(
+                PromotedAddonVersion.objects.filter(
+                    promoted_group=models.OuterRef('promoted_group'),
+                    application_id=models.OuterRef('application_id'),
+                    version=models.OuterRef('addon___current_version'),
                 )
             )
-            .distinct()
-        )
-        valid_groups = [
-            group.id
-            for group in groups
-            if addon.approved_applications_for(promoted_group=group)
-            or (
-                not (group.listed_pre_review and group.unlisted_pre_review)
-                and all(app in addon.all_applications for app in APP_USAGE)
+            | Q(
+                promoted_group__listed_pre_review=False,
+                promoted_group__unlisted_pre_review=False,
             )
-        ]
-        return groups.filter(id__in=valid_groups)
+        ).values_list('promoted_group__group_id', flat=True)
+
+        return self.all_for(addon=addon).filter(group_id__in=approved_promotions)
 
 
 class PromotedGroup(models.Model):

--- a/src/olympia/versions/tests/test_models.py
+++ b/src/olympia/versions/tests/test_models.py
@@ -1401,11 +1401,11 @@ class TestVersion(AMOPaths, TestCase):
             addon, PROMOTED_GROUP_CHOICES.RECOMMENDED, approve_version=True
         )
         addon.reload()
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(4):
             # 1. query for the addon's promoted groups
             # 2. check if the addon is badged
             # 3. check if the addon is listed_pre_review
-            # 4-8. promoted group queries
+            # 4. promoted group queries
             assert not addon.current_version.can_be_disabled_and_deleted()
 
     def test_is_blocked(self):


### PR DESCRIPTION
Fixes: mozilla/addons#15487

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Fixes the logic relating to retrieving approved promotions for an add-on.

### Testing

**Note**: Expected promotions are in the promotedaddon admin.
1. Run `/manage.py sync_promoted_addons`.
2. All promotions in search view, when filtered by 'Recommended' or by 'For Firefox', are listed as expected.
4. Recommended badges appear on the listing page for individual Recommended add-ons.
5. 'For Firefox' badges appear on the listing page for individual Line add-ons.
6. The reviewer tools page correctly shows any promotion on the banner.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.