### PR TITLE
drop minimal-profile-has-all-fields-shim from api/v5

### DIFF
--- a/src/olympia/accounts/serializers.py
+++ b/src/olympia/accounts/serializers.py
@@ -90,7 +90,7 @@ class MinimalUserProfileSerializer(FullUserProfileSerializer):
         request = self.context.get('request', None)
 
         # Once we drop this api gate we can drop this class and use BaseUserSerializer
-        if request and is_gate_active(request, 'mimimal-profile-has-all-fields-shim'):
+        if request and is_gate_active(request, 'minimal-profile-has-all-fields-shim'):
             data.update({field: None for field in self.nullable_fields})
         else:
             data = {

--- a/src/olympia/accounts/tests/test_serializers.py
+++ b/src/olympia/accounts/tests/test_serializers.py
@@ -118,7 +118,7 @@ class TestFullUserProfileSerializer(TestCase):
 
 class TestMinimalUserProfileSerializer(TestFullUserProfileSerializer):
     serializer = MinimalUserProfileSerializer
-    gates = {None: ('mimimal-profile-has-all-fields-shim',)}
+    gates = {None: ('minimal-profile-has-all-fields-shim',)}
 
     def test_picture(self):
         self.user.update(picture_type='image/jpeg')

--- a/src/olympia/accounts/tests/test_views.py
+++ b/src/olympia/accounts/tests/test_views.py
@@ -1269,8 +1269,10 @@ class TestAccountViewSet(TestCase):
         assert response.status_code == 404
 
     def test_is_not_full_public_profile_because_not_developer_but_fields_present(self):
-        # TODO: when mimimal-profile-has-all-fields-shim is removed for v5, we should
-        # change self.url to use v4 or v3
+        # v3 and v4 have `minimal-profile-has-all-fields-shim`
+        self.url = reverse_ns(
+            'account-detail', api_version='v4', kwargs={'pk': self.user.pk}
+        )
         assert not self.user.has_full_profile
         response = self.client.get(self.url)  # No auth.
         assert response.data['name'] == self.user.name
@@ -1286,10 +1288,7 @@ class TestAccountViewSet(TestCase):
         assert 'email' not in response.data
         assert response.data['url'] == absolutify(self.user.get_url_path())
 
-    @override_settings(DRF_API_GATES={'v5': ()})
     def test_is_not_full_public_profile_because_not_developer_no_fields(self):
-        # TODO: when mimimal-profile-has-all-fields-shim is removed for v5, we won't
-        # need the override_settings
         assert not self.user.has_full_profile
         response = self.client.get(self.url)  # No auth.
         assert response.data['name'] == self.user.name

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1299,7 +1299,7 @@ DRF_API_GATES = {
         'block-min-max-versions-shim',
         'block-versions-list-shim',
         'promoted-groups-shim',
-        'mimimal-profile-has-all-fields-shim',
+        'minimal-profile-has-all-fields-shim',
     ),
     'v5': (
         'addons-search-_score-field',
@@ -1308,7 +1308,6 @@ DRF_API_GATES = {
         'addon-submission-api',
         'promoted-verified-sponsored',
         'block-versions-list-shim',
-        'mimimal-profile-has-all-fields-shim',
     ),
 }
 


### PR DESCRIPTION
Fixes: mozilla/addons#15490

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

<!--
Your PR will be squashed when merged so the 1st commit must contain a descriptive and concise summary of the change.
Additional details should be added in the description. If your change is simple enough to summarize in the commit, or
if it is not relevant for your PR, remove this section.
-->

### Context

<!--
Often a pull request contains changes that are not fully self explanatory. Maybe this PR is a part of a series,
or maybe it is a partial change now with a more ambitious plan for the future. Add this additional context here.
If it is not relevant for your PR, remove this section.
-->

### Testing

- set up a user who has a some combination of non-empty biography, occupation, location, or homepage (but isn't an author of any publicly listed add-ons).
- access that user's profile with /api/v5/accounts/account/(int:user_id)/
- see the user is returned, but biography (etc) are absent from the response - only name, url, id, username should be returned in the api response.
-repeat with /v4/ and see the extra fields are present but empty values.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
