### PR TITLE
Add command to give "By Firefox" badge to themes with "Firefox" as author

### DIFF
--- a/src/olympia/promoted/management/commands/promote_by_firefox_themes.py
+++ b/src/olympia/promoted/management/commands/promote_by_firefox_themes.py
@@ -3,7 +3,7 @@ from django.core.management.base import BaseCommand
 
 from olympia import amo
 from olympia.addons.models import Addon
-from olympia.constants.promoted import LINE
+from olympia.constants.promoted import PROMOTED_GROUP_CHOICES
 from olympia.promoted.models import (
     PromotedAddon,
 )
@@ -24,6 +24,9 @@ class Command(BaseCommand):
             self.stdout.write(f'Promoting {addon.slug}')
             promotion, created = PromotedAddon.objects.get_or_create(
                 addon=addon,
-                defaults={'application_id': amo.FIREFOX.id, 'group_id': LINE.id},
+                defaults={
+                    'application_id': amo.FIREFOX.id,
+                    'group_id': PROMOTED_GROUP_CHOICES.LINE,
+                },
             )
             promotion.approve_for_addon()

--- a/src/olympia/promoted/management/commands/promote_by_firefox_themes.py
+++ b/src/olympia/promoted/management/commands/promote_by_firefox_themes.py
@@ -1,0 +1,30 @@
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from olympia import amo
+from olympia.addons.models import Addon
+from olympia.constants.promoted import LINE
+from olympia.promoted.models import (
+    PromotedAddon,
+    PromotedApproval,
+)
+from olympia.users.models import UserProfile
+
+
+class Command(BaseCommand):
+    help = 'Give themes with Firefox as author the "By Firefox" badge'
+
+    def handle(self, *args, **options):
+        firefox_user = UserProfile.objects.get(pk=settings.TASK_USER_ID)
+        addons = (
+            Addon.objects.public()
+            .filter(type=amo.ADDON_STATICTHEME, authors=firefox_user)
+            .no_transforms()
+        )
+        for addon in addons:
+            self.stdout.write(f'Promoting {addon.slug}')
+            promotion, created = PromotedAddon.objects.get_or_create(
+                addon=addon,
+                defaults={'application_id': amo.FIREFOX.id, 'group_id': LINE.id},
+            )
+            promotion.approve_for_addon()

--- a/src/olympia/promoted/management/commands/promote_by_firefox_themes.py
+++ b/src/olympia/promoted/management/commands/promote_by_firefox_themes.py
@@ -6,7 +6,6 @@ from olympia.addons.models import Addon
 from olympia.constants.promoted import LINE
 from olympia.promoted.models import (
     PromotedAddon,
-    PromotedApproval,
 )
 from olympia.users.models import UserProfile
 

--- a/src/olympia/promoted/tests/test_commands.py
+++ b/src/olympia/promoted/tests/test_commands.py
@@ -6,7 +6,7 @@ from django.db.models.signals import post_save
 
 from olympia import amo
 from olympia.amo.tests import TestCase, addon_factory, user_factory
-from olympia.constants.promoted import LINE, PROMOTED_GROUP_CHOICES
+from olympia.constants.promoted import PROMOTED_GROUP_CHOICES
 from olympia.discovery.admin import PromotedAddon as PromotedAddonProxy
 from olympia.promoted.models import (
     PromotedAddon,
@@ -416,34 +416,47 @@ class TestSyncPromotedDiscoveryProxy(TestSyncPromotedMixin):
 
 class TestPromoteByFirefoxThemesCommand(TestCase):
     def test_basic(self):
-        user = user_factory(pk=settings.TASK_USER_ID)
+        other_user = user_factory()
+        firefox_user = user_factory(pk=settings.TASK_USER_ID)
         non_affected = [
             # Not By Firefox user.
-            addon_factory(type=amo.ADDON_STATICTHEME),
+            addon_factory(type=amo.ADDON_STATICTHEME, users=[other_user]),
             # Not a theme.
-            addon_factory(users=[user]),
+            addon_factory(type=amo.ADDON_EXTENSION, users=[firefox_user]),
             # Not public.
             addon_factory(
-                type=amo.ADDON_STATICTHEME, status=amo.STATUS_DISABLED, users=[user]
+                type=amo.ADDON_STATICTHEME,
+                status=amo.STATUS_DISABLED,
+                users=[firefox_user],
             ),
         ]
         # Already promoted, should not cause an error.
-        addon_factory(type=amo.ADDON_STATICTHEME, users=[user], promoted_id=LINE.id)
+        already_promoted = addon_factory(
+            type=amo.ADDON_STATICTHEME,
+            users=[firefox_user],
+            promoted_id=PROMOTED_GROUP_CHOICES.LINE,
+        )
 
-        expected_affected = addon_factory(type=amo.ADDON_STATICTHEME, users=[user])
+        expected_affected = addon_factory(
+            type=amo.ADDON_STATICTHEME, users=[firefox_user]
+        )
 
         call_command('promote_by_firefox_themes')
 
         for addon in non_affected:
-            assert not PromotedAddon.objects.filter(addon=addon).exists()
-            assert not PromotedApproval.objects.filter(version__addon=addon).exists()
+            assert not PromotedAddonPromotion.objects.filter(addon=addon).exists()
+            assert not PromotedAddonVersion.objects.filter(
+                version__addon=addon
+            ).exists()
 
-        assert expected_affected.promotedaddon
-        assert (
-            expected_affected.current_version.promoted_approvals.all()
-            .filter(application_id=amo.FIREFOX.id)
-            .exists()
-        )
-        assert list(expected_affected.promoted_groups()) == [
-            PromotedGroup.objects.get(group_id=LINE.id)
-        ]
+        for addon in (already_promoted, expected_affected):
+            assert addon.promotedaddon
+            assert (
+                addon.current_version.promoted_approvals.all()
+                .filter(application_id=amo.FIREFOX.id)
+                .exists()
+            )
+
+            assert list(addon.promoted_groups()) == [
+                PromotedGroup.objects.get(group_id=PROMOTED_GROUP_CHOICES.LINE)
+            ]


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/14947

### Context

Prod has some themes that were added to the "Firefox" user (they were initially built for Firefox and later released on AMO), and for consistency we want all of them to have the "By Firefox" badge.

### Testing

See unit test. Can also do locally:

- Make your "Firefox" user (`UserProfile` with id `settings.TASK_USER_ID`) an author on a public theme
- Run `manage.py promote_by_firefox_themes` command
- Your theme should now have a "By Firefox" badge.