### PR TITLE
Log when an admin deletes/undeletes a collection through the admin

### DIFF
--- a/src/olympia/bandwagon/admin.py
+++ b/src/olympia/bandwagon/admin.py
@@ -62,7 +62,7 @@ class CollectionAdmin(AMOModelAdmin):
         # something not yet deleted the admin should use the regular button
         # instead of the checkbox.
         if obj and obj.deleted:
-            return fields + ('deleted', )
+            return fields + ('deleted',)
         return fields
 
     # Permission checks:
@@ -95,7 +95,6 @@ class CollectionAdmin(AMOModelAdmin):
         return acl.action_allowed_for(
             request.user, amo.permissions.ADMIN_CURATION
         ) or super().has_add_permission(request)
-
 
     def delete_model(self, request, obj):
         ActivityLog.objects.create(amo.LOG.COLLECTION_DELETED, obj)

--- a/src/olympia/bandwagon/admin.py
+++ b/src/olympia/bandwagon/admin.py
@@ -99,7 +99,7 @@ class CollectionAdmin(AMOModelAdmin):
 
     def delete_model(self, request, obj):
         ActivityLog.objects.create(amo.LOG.COLLECTION_DELETED, obj)
-        obj.delete()
+        obj.delete(clear_slug=False)
 
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)

--- a/src/olympia/bandwagon/admin.py
+++ b/src/olympia/bandwagon/admin.py
@@ -3,6 +3,7 @@ from django.contrib import admin
 
 from olympia import amo
 from olympia.access import acl
+from olympia.activity.models import ActivityLog
 from olympia.amo.admin import AMOModelAdmin
 
 from .models import Collection, CollectionAddon
@@ -48,13 +49,21 @@ class CollectionAdmin(AMOModelAdmin):
         'description',
         'uuid',
         'listed',
-        'deleted',
         'default_locale',
         'author',
     )
     raw_id_fields = ('author',)
     readonly_fields = ('uuid',)
     inlines = (CollectionAddonInline,)
+
+    def get_fields(self, request, obj=None):
+        fields = super().get_fields(request, obj=obj)
+        # Only add "deleted" to the fields for something already deleted, for
+        # something not yet deleted the admin should use the regular button
+        # instead of the checkbox.
+        if obj and obj.deleted:
+            return fields + ('deleted', )
+        return fields
 
     # Permission checks:
     # A big part of the curation job for the homepage etc is done through
@@ -86,6 +95,16 @@ class CollectionAdmin(AMOModelAdmin):
         return acl.action_allowed_for(
             request.user, amo.permissions.ADMIN_CURATION
         ) or super().has_add_permission(request)
+
+
+    def delete_model(self, request, obj):
+        ActivityLog.objects.create(amo.LOG.COLLECTION_DELETED, obj)
+        obj.delete()
+
+    def save_model(self, request, obj, form, change):
+        super().save_model(request, obj, form, change)
+        if change and 'deleted' in form.changed_data and not obj.deleted:
+            ActivityLog.objects.create(amo.LOG.COLLECTION_UNDELETED, obj)
 
 
 admin.site.register(Collection, CollectionAdmin)

--- a/src/olympia/bandwagon/tests/test_admin.py
+++ b/src/olympia/bandwagon/tests/test_admin.py
@@ -4,8 +4,8 @@ from django.urls import reverse
 from pyquery import PyQuery as pq
 
 from olympia import amo
-from olympia.amo.tests import TestCase, addon_factory, formset, user_factory
 from olympia.activity.models import ActivityLog
+from olympia.amo.tests import TestCase, addon_factory, formset, user_factory
 from olympia.bandwagon.models import Collection, CollectionAddon
 
 
@@ -117,7 +117,9 @@ class TestCollectionAdmin(TestCase):
         assert collection_addon.collection == collection
         assert CollectionAddon.objects.count() == 1
         # Editing normally shouldn't have triggered the undeletion log.
-        assert not ActivityLog.objects.filter(action=amo.LOG.COLLECTION_UNDELETED.id).exists()
+        assert not ActivityLog.objects.filter(
+            action=amo.LOG.COLLECTION_UNDELETED.id
+        ).exists()
 
     def test_can_not_list_without_collections_edit_permission(self):
         collection = Collection.objects.create(slug='floob')
@@ -342,15 +344,21 @@ class TestCollectionAdmin(TestCase):
         assert collection.slug  # Slug was kept
         assert not Collection.objects.filter(pk=collection.pk).exists()
         assert Collection.unfiltered.filter(pk=collection.pk).exists()  # Soft-deleted.
-        assert not ActivityLog.objects.filter(action=amo.LOG.COLLECTION_UNDELETED.id).exists()
+        assert not ActivityLog.objects.filter(
+            action=amo.LOG.COLLECTION_UNDELETED.id
+        ).exists()
         assert ActivityLog.objects.filter(action=amo.LOG.COLLECTION_DELETED.id).exists()
-        activity = ActivityLog.objects.filter(action=amo.LOG.COLLECTION_DELETED.id).get()
+        activity = ActivityLog.objects.filter(
+            action=amo.LOG.COLLECTION_DELETED.id
+        ).get()
         assert activity.arguments == [collection]
         assert activity.user == user
 
     def test_can_undelete_with_admin_collection_edit_permission(self):
         someone = user_factory()
-        collection = Collection.objects.create(slug='floob', deleted=True, author=someone)
+        collection = Collection.objects.create(
+            slug='floob', deleted=True, author=someone
+        )
         collection.delete(clear_slug=False)
         self.change_url = reverse(
             'admin:bandwagon_collection_change', args=(collection.pk,)
@@ -371,7 +379,11 @@ class TestCollectionAdmin(TestCase):
         response = self.client.post(self.change_url, data=post_data, follow=True)
         assert response.status_code == 200
         assert Collection.objects.filter(pk=collection.pk).exists()
-        assert ActivityLog.objects.filter(action=amo.LOG.COLLECTION_UNDELETED.id).exists()
-        activity = ActivityLog.objects.filter(action=amo.LOG.COLLECTION_UNDELETED.id).get()
+        assert ActivityLog.objects.filter(
+            action=amo.LOG.COLLECTION_UNDELETED.id
+        ).exists()
+        activity = ActivityLog.objects.filter(
+            action=amo.LOG.COLLECTION_UNDELETED.id
+        ).get()
         assert activity.arguments == [collection]
         assert activity.user == user

--- a/src/olympia/bandwagon/tests/test_admin.py
+++ b/src/olympia/bandwagon/tests/test_admin.py
@@ -338,6 +338,8 @@ class TestCollectionAdmin(TestCase):
         self.client.force_login(user)
         response = self.client.post(self.delete_url, data={'post': 'yes'}, follow=True)
         assert response.status_code == 200
+        assert collection.reload().deleted
+        assert collection.slug  # Slug was kept
         assert not Collection.objects.filter(pk=collection.pk).exists()
         assert Collection.unfiltered.filter(pk=collection.pk).exists()  # Soft-deleted.
         assert not ActivityLog.objects.filter(action=amo.LOG.COLLECTION_UNDELETED.id).exists()


### PR DESCRIPTION
Also avoid showing `deleted` field if the collection isn't already deleted - that's pointless and confusing, admins should use the regular delete action if they want to delete something.

Fixes https://github.com/mozilla/addons/issues/15394

### Testing
- As an admin (needs `Collections:Edit` permission + access to the admin, or just `*:*`) look at a non-deleted collection detail page in the admin
- `Deleted` field should be absent
- Delete that collection through the button
- Collection should now be deleted - can't see it in frontend
- An `ActivityLog` with `COLLECTION_DELETED` action and the collection as argument should have been recorded in the database
- Go back to that collection admin detail page
- `Slug` field should not have changed (it would if the user would have deleted the collection themselves through the frontend)
- `Deleted` field should be present and ticked
- Untick `Deleted` field and hit save
- An `ActivityLog` with `COLLECTION_UNDELETED` action and the collection as argument should have been recorded in the database
- Collection should now be undeleted - can see it in frontend