### PR TITLE
Add validation for DOCKER_* variables:

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -56,16 +56,15 @@ runs:
       id: build
       shell: bash
       env:
+        # These values are irrelevant for local builds, so don't include them
+        # in the make command directly but set them on the environment to be picked up.
         DOCKER_TAGS_FILE: ${{ steps.meta.outputs.bake-file-tags }}
         DOCKER_ANNOTATIONS_FILE: ${{ steps.meta.outputs.bake-file-annotations }}
         DOCKER_METADATA_FILE: ${{ steps.context.outputs.metadata_file }}
         DOCKER_PUSH: ${{ inputs.push }}
       run: |
-        make setup \
-          DOCKER_TARGET="production" \
-          DOCKER_VERSION="${{ steps.meta.outputs.version }}"
-
-        make docker_build_web \
+        make build \
+          DOCKER_VERSION="${{ steps.meta.outputs.version }}" \
           DOCKER_COMMIT="${{ steps.context.outputs.git_sha }}" \
           DOCKER_BUILD="${{ steps.context.outputs.git_build_url }}"
 

--- a/.github/workflows/_test_check.yml
+++ b/.github/workflows/_test_check.yml
@@ -61,16 +61,9 @@ jobs:
           - production
     steps:
       - uses: actions/checkout@v4
-      - shell: bash
-        continue-on-error: true
-        run: |
-          cat <<EOF
-            Values passed to the action:
-            version: ${{ matrix.version }}
-            target: ${{ matrix.target }}
-            deps: ${{ matrix.deps }}
-          EOF
       - name: ${{ matrix.version == 'local' && 'Uncached Build' || 'Pull' }} Check
+        id: build
+        continue-on-error: true
         uses: ./.github/actions/run-docker
         # Set environment variables that are expected to be ignored
         env:
@@ -81,9 +74,22 @@ jobs:
           target: ${{ matrix.target }}
           deps: ${{ matrix.deps }}
           run: make check
+
+      - name: Verify build
+        id: verify
+        shell: bash
+        run: |
+          version="${{ matrix.version }}"
+          target="${{ matrix.target }}"
+          outcome="${{ steps.build.outcome }}"
+          if [[ "$version" != "local" && "$target" == "development" && "$outcome" == "success" ]]; then
+            echo "Non local images must run in production mode"
+            exit 1
+          fi
+
       - name: Cached Build Check
         uses: ./.github/actions/run-docker
-        if: ${{ matrix.version == 'local' }}
+        if: matrix.version == 'local' && steps.verify.outcome == 'success'
         with:
           version: ${{ matrix.version }}
           target: ${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,6 @@ jobs:
           digest: ${{ needs.build.outputs.digest }}
           version: ${{ needs.build.outputs.version }}
           deps: development
-          target: development
           run: |
             make docs
 

--- a/.github/workflows/health_check.yml
+++ b/.github/workflows/health_check.yml
@@ -29,7 +29,6 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/run-docker
         with:
-          target: development
           version: local
           run: |
             # On local, we want to ensure there are failures to test

--- a/Makefile-os
+++ b/Makefile-os
@@ -97,7 +97,12 @@ test_setup:
 .PHONY: setup
 setup: ## create configuration files version.json and .env required to run this project
 	for path in $(CLEAN_PATHS); do rm -rf "$(PWD)/$$path" && echo "$$path removed"; done
-	./scripts/setup.py
+	./scripts/setup.py $(SETUP_ARGS)
+
+.PHONY: build
+build: ## build the docker image
+	$(MAKE) setup SETUP_ARGS="--build"
+	$(MAKE) docker_build_web
 
 .PHONY: push_locales
 push_locales: ## extracts and merges translation strings

--- a/tests/make/test_setup.py
+++ b/tests/make/test_setup.py
@@ -6,19 +6,11 @@ from scripts.setup import get_docker_image_meta, main
 from tests import override_env
 
 
-keys = [
-    'DOCKER_TAG',
-    'DOCKER_TARGET',
-    'HOST_UID',
-    'OLYMPIA_DEPS',
-    'DEBUG',
-]
-
-
 class BaseTestClass(unittest.TestCase):
     def assert_set_env_file_called_with(self, **kwargs):
-        expected = {key: kwargs.get(key, mock.ANY) for key in keys}
-        assert mock.call(expected) in self.mock_set_env_file.call_args_list
+        result = self.mock_set_env_file.call_args_list[0][0][0]
+        for key, value in kwargs.items():
+            assert result[key] == value
 
     def setUp(self):
         patch = mock.patch('scripts.setup.set_env_file')
@@ -33,105 +25,130 @@ class BaseTestClass(unittest.TestCase):
 @override_env()
 class TestGetDockerTag(BaseTestClass):
     def test_default_value_is_local(self):
-        tag, target, version, digest = get_docker_image_meta()
-        self.assertEqual(tag, 'mozilla/addons-server:local')
-        self.assertEqual(target, 'development')
-        self.assertEqual(version, 'local')
-        self.assertEqual(digest, None)
+        meta = get_docker_image_meta()
+        self.assertEqual(meta['DOCKER_TAG'], 'mozilla/addons-server:local')
+        self.assertEqual(meta['DOCKER_TARGET'], 'development')
+        self.assertEqual(meta['DOCKER_VERSION'], 'local')
+        assert 'DOCKER_DIGEST' not in meta
 
         with override_env(DOCKER_TARGET='production'):
-            _, target, _, _ = get_docker_image_meta()
-            self.assertEqual(target, 'production')
+            meta = get_docker_image_meta()
+            self.assertEqual(meta['DOCKER_TARGET'], 'production')
 
     @override_env(DOCKER_VERSION='test')
     def test_version_overrides_default(self):
-        tag, target, version, digest = get_docker_image_meta()
-        self.assertEqual(tag, 'mozilla/addons-server:test')
-        self.assertEqual(target, 'production')
-        self.assertEqual(version, 'test')
-        self.assertEqual(digest, None)
+        meta = get_docker_image_meta()
+        self.assertEqual(meta['DOCKER_TAG'], 'mozilla/addons-server:test')
+        self.assertEqual(meta['DOCKER_TARGET'], 'production')
+        self.assertEqual(meta['DOCKER_VERSION'], 'test')
+        assert 'DOCKER_DIGEST' not in meta
 
     @override_env(DOCKER_DIGEST='sha256:123')
     def test_digest_overrides_version_and_default(self):
-        tag, target, version, digest = get_docker_image_meta()
-        self.assertEqual(tag, 'mozilla/addons-server@sha256:123')
-        self.assertEqual(target, 'production')
-        self.assertEqual(version, None)
-        self.assertEqual(digest, 'sha256:123')
+        meta = get_docker_image_meta()
+        self.assertEqual(meta['DOCKER_TAG'], 'mozilla/addons-server@sha256:123')
+        self.assertEqual(meta['DOCKER_TARGET'], 'production')
+        assert 'DOCKER_VERSION' not in meta
+        self.assertEqual(meta['DOCKER_DIGEST'], 'sha256:123')
 
-        with override_env(DOCKER_VERSION='test', DOCKER_DIGEST='sha256:123'):
-            tag, target, version, digest = get_docker_image_meta()
-            self.assertEqual(tag, 'mozilla/addons-server@sha256:123')
-            self.assertEqual(target, 'production')
-            self.assertEqual(version, None)
-            self.assertEqual(digest, 'sha256:123')
+        with override_env(
+            DOCKER_VERSION='test',
+            DOCKER_DIGEST='sha256:123',
+        ):
+            meta = get_docker_image_meta()
+            self.assertEqual(meta['DOCKER_TAG'], 'mozilla/addons-server@sha256:123')
+            self.assertEqual(meta['DOCKER_TARGET'], 'production')
+            assert 'DOCKER_VERSION' not in meta
+            self.assertEqual(meta['DOCKER_DIGEST'], 'sha256:123')
 
     @override_env(DOCKER_TAG='image:latest')
     def test_tag_overrides_default_version(self):
-        tag, target, version, digest = get_docker_image_meta()
-        self.assertEqual(tag, 'image:latest')
-        self.assertEqual(target, 'production')
-        self.assertEqual(version, 'latest')
-        self.assertEqual(digest, None)
+        meta = get_docker_image_meta()
+        self.assertEqual(meta['DOCKER_TAG'], 'image:latest')
+        self.assertEqual(meta['DOCKER_TARGET'], 'production')
+        self.assertEqual(meta['DOCKER_VERSION'], 'latest')
+        assert 'DOCKER_DIGEST' not in meta
 
-        with override_env(DOCKER_TAG='image:latest', DOCKER_VERSION='test'):
-            tag, target, version, digest = get_docker_image_meta()
-            self.assertEqual(tag, 'image:test')
-            self.assertEqual(target, 'production')
-            self.assertEqual(version, 'test')
-            self.assertEqual(digest, None)
+        with override_env(
+            DOCKER_TAG='image:latest',
+            DOCKER_VERSION='test',
+        ):
+            meta = get_docker_image_meta()
+            self.assertEqual(meta['DOCKER_TAG'], 'image:test')
+            self.assertEqual(meta['DOCKER_TARGET'], 'production')
+            self.assertEqual(meta['DOCKER_VERSION'], 'test')
+            assert 'DOCKER_DIGEST' not in meta
 
     @override_env(DOCKER_TAG='image@sha256:123')
     def test_tag_overrides_default_digest(self):
-        tag, target, version, digest = get_docker_image_meta()
-        self.assertEqual(tag, 'image@sha256:123')
-        self.assertEqual(target, 'production')
-        self.assertEqual(version, None)
-        self.assertEqual(digest, 'sha256:123')
+        meta = get_docker_image_meta()
+        self.assertEqual(meta['DOCKER_TAG'], 'image@sha256:123')
+        self.assertEqual(meta['DOCKER_TARGET'], 'production')
+        assert 'DOCKER_VERSION' not in meta
+        self.assertEqual(meta['DOCKER_DIGEST'], 'sha256:123')
 
         with mock.patch.dict(os.environ, {'DOCKER_DIGEST': 'test'}):
-            tag, target, version, digest = get_docker_image_meta()
-            self.assertEqual(tag, 'image@test')
-            self.assertEqual(target, 'production')
-            self.assertEqual(version, None)
-            self.assertEqual(digest, 'test')
+            meta = get_docker_image_meta()
+            self.assertEqual(meta['DOCKER_TAG'], 'image@test')
+            self.assertEqual(meta['DOCKER_TARGET'], 'production')
+            assert 'DOCKER_VERSION' not in meta
+            self.assertEqual(meta['DOCKER_DIGEST'], 'test')
 
+    @override_env(DOCKER_TAG='image:latest')
     def test_version_from_env_file(self):
         self.mock_get_env_file.return_value = {'DOCKER_TAG': 'image:latest'}
-        tag, target, version, digest = get_docker_image_meta()
-        self.assertEqual(tag, 'image:latest')
-        self.assertEqual(target, 'production')
-        self.assertEqual(version, 'latest')
-        self.assertEqual(digest, None)
+        meta = get_docker_image_meta()
+        self.assertEqual(meta['DOCKER_TAG'], 'image:latest')
+        self.assertEqual(meta['DOCKER_TARGET'], 'production')
+        self.assertEqual(meta['DOCKER_VERSION'], 'latest')
+        assert 'DOCKER_DIGEST' not in meta
 
     def test_digest_from_env_file(self):
         self.mock_get_env_file.return_value = {'DOCKER_TAG': 'image@sha256:123'}
-        tag, target, version, digest = get_docker_image_meta()
-        self.assertEqual(tag, 'image@sha256:123')
-        self.assertEqual(target, 'production')
-        self.assertEqual(version, None)
-        self.assertEqual(digest, 'sha256:123')
+        meta = get_docker_image_meta()
+        self.assertEqual(meta['DOCKER_TAG'], 'image@sha256:123')
+        self.assertEqual(meta['DOCKER_TARGET'], 'production')
+        assert 'DOCKER_VERSION' not in meta
+        self.assertEqual(meta['DOCKER_DIGEST'], 'sha256:123')
 
     @override_env(DOCKER_VERSION='')
     def test_default_when_version_is_empty(self):
-        tag, target, version, digest = get_docker_image_meta()
-        self.assertEqual(tag, 'mozilla/addons-server:local')
-        self.assertEqual(target, 'development')
-        self.assertEqual(version, 'local')
-        self.assertEqual(digest, None)
+        meta = get_docker_image_meta()
+        self.assertEqual(meta['DOCKER_TAG'], 'mozilla/addons-server:local')
+        self.assertEqual(meta['DOCKER_TARGET'], 'development')
+        self.assertEqual(meta['DOCKER_VERSION'], 'local')
+        assert 'DOCKER_DIGEST' not in meta
 
         with override_env(DOCKER_VERSION='', DOCKER_TARGET='production'):
-            _, target, _, _ = get_docker_image_meta()
-            self.assertEqual(target, 'production')
+            meta = get_docker_image_meta()
+            self.assertEqual(meta['DOCKER_TARGET'], 'production')
 
-    @override_env(DOCKER_DIGEST='', DOCKER_TAG='image@sha256:123')
+    @override_env(
+        DOCKER_DIGEST='',
+        DOCKER_TAG='image@sha256:123',
+    )
     def test_default_when_digest_is_empty(self):
         self.mock_get_env_file.return_value = {'DOCKER_TAG': 'image@sha256:123'}
-        tag, target, version, digest = get_docker_image_meta()
-        self.assertEqual(tag, 'image@sha256:123')
-        self.assertEqual(target, 'production')
-        self.assertEqual(version, None)
-        self.assertEqual(digest, 'sha256:123')
+        meta = get_docker_image_meta()
+        self.assertEqual(meta['DOCKER_TAG'], 'image@sha256:123')
+        self.assertEqual(meta['DOCKER_TARGET'], 'production')
+        assert 'DOCKER_VERSION' not in meta
+        self.assertEqual(meta['DOCKER_DIGEST'], 'sha256:123')
+
+    def test_version_on_env_file_ignored(self):
+        self.mock_get_env_file.return_value = {'DOCKER_VERSION': 'latest'}
+        meta = get_docker_image_meta()
+        self.assertEqual(meta['DOCKER_VERSION'], 'local')
+
+    def test_commit_on_env_file_ignored(self):
+        self.mock_get_env_file.return_value = {'DOCKER_COMMIT': 'commit'}
+        meta = get_docker_image_meta()
+        assert 'DOCKER_COMMIT' not in meta
+
+    def test_build_on_env_file_ignored(self):
+        self.mock_get_env_file.return_value = {'DOCKER_BUILD': 'build'}
+        meta = get_docker_image_meta()
+        assert 'DOCKER_BUILD' not in meta
 
 
 @override_env()
@@ -145,12 +162,103 @@ class TestDockerTarget(BaseTestClass):
         main()
         self.assert_set_env_file_called_with(DOCKER_TARGET='production')
 
+    @override_env()
     def test_default_env_file(self):
         self.mock_get_env_file.return_value = {
             'DOCKER_TAG': 'mozilla/addons-server:test'
         }
         main()
         self.assert_set_env_file_called_with(DOCKER_TARGET='production')
+
+    @override_env(DOCKER_VERSION='latest', DOCKER_COMMIT='abc', DOCKER_BUILD='build')
+    def test_env_file_is_ignored_when_building_remote_image(self):
+        self.mock_get_env_file.return_value = {
+            'DOCKER_TARGET': 'development',
+        }
+        main(build=True)
+        self.assert_set_env_file_called_with(DOCKER_TARGET='production')
+
+    @override_env(DOCKER_VERSION='latest', DOCKER_TARGET='development')
+    def test_invalid_remote_development_image(self):
+        with self.assertRaises(ValueError):
+            main()
+
+    @override_env(DOCKER_TARGET='development')
+    def test_invalid_building_development_image(self):
+        for version in ['local', 'latest']:
+            with self.subTest(version=version):
+                with override_env(DOCKER_VERSION=version):
+                    with self.assertRaises(ValueError):
+                        main(build=True)
+
+
+@override_env()
+class DockerCommitAndBuildMixin:
+    @override_env(
+        DOCKER_TARGET='production',
+        DOCKER_VERSION='local',
+    )
+    def test_env_file_is_ignored(self):
+        """
+        The previous commit on a .env file is ignored and so will never be used
+        in subsequent runs of make setup.
+        """
+        self.mock_get_env_file.return_value = {self.key: 'c'}
+        main()
+        self.assert_set_env_file_called_with(
+            DOCKER_TARGET='production',
+            DOCKER_VERSION='local',
+        )
+
+    def test_forbidden_when_running_remote_image(self):
+        with (
+            override_env(
+                DOCKER_TARGET='production',
+                DOCKER_VERSION='latest',
+                **{self.key: 'c'},
+            ),
+            self.assertRaises(ValueError),
+        ):
+            main()
+
+    def test_required_when_building_remote_image(self):
+        for target in ['production', 'development']:
+            with self.subTest(target=target):
+                with (
+                    override_env(
+                        DOCKER_TARGET=target,
+                        DOCKER_VERSION='latest',
+                        **{self.key: ''},
+                    ),
+                    self.assertRaises(ValueError),
+                ):
+                    main(build=True)
+
+    def test_irrelevant_when_local_image(self):
+        for target in ['production', 'development']:
+            for build in [True, False]:
+                with self.subTest(target=target, build=build):
+                    with (
+                        override_env(
+                            DOCKER_TARGET=target,
+                            DOCKER_VERSION='local',
+                            **{self.key: ''},
+                        ),
+                    ):
+                        # We cannot build a development image
+                        # so this will fail for a different reason
+                        if build and target == 'development':
+                            continue
+                        else:
+                            main(build=build)
+
+
+class TestDockerCommit(BaseTestClass, DockerCommitAndBuildMixin):
+    key = 'DOCKER_COMMIT'
+
+
+class TestDockerBuild(BaseTestClass, DockerCommitAndBuildMixin):
+    key = 'DOCKER_BUILD'
 
 
 @override_env()
@@ -212,12 +320,13 @@ class TestOlympiaDeps(BaseTestClass):
 
 
 @override_env()
-@mock.patch('scripts.setup.os.makedirs')
-def test_make_dirs(mock_makedirs):
-    from scripts.setup import root
+class TestMakeDirs(BaseTestClass):
+    @mock.patch('scripts.setup.os.makedirs')
+    def test_make_dirs(self, mock_makedirs):
+        from scripts.setup import root
 
-    main()
-    assert mock_makedirs.call_args_list == [
-        mock.call(os.path.join(root, dir), exist_ok=True)
-        for dir in ['deps', 'site-static', 'static-build', 'storage']
-    ]
+        main()
+        assert mock_makedirs.call_args_list == [
+            mock.call(os.path.join(root, dir), exist_ok=True)
+            for dir in ['deps', 'site-static', 'static-build', 'storage']
+        ]


### PR DESCRIPTION
Fixes: mozilla/addons#15504

## Description

- add explicit make build command
- Refactored setup.py to improve metadata handling for Docker images, including validation of environment variables.

## Context

This PR solves the issue found in the bug in 2 separate and compatiible ways.

###  combined `build` command

Before we had to call `make setup` before calling `make docker_build_web` that is because the build command relied on values set in the .env file, but did not actually create the .env so it would either a) not exist or b) be whatever it happened to be before.

That could lead to very bizzare and unexpected results (like this bug) where we passed a value that is **relevant** for the build but not saved in the .env and therefore not available to the build command context.

A dedicated `make build` command that depends on setup will bass whatever environment variables and arguments you pass to both setup and docker build commands.

### validate setup .env results

We have always had implicit validation of the values created by setup.py but that is not really good enough as this bug was allowed to exist. In some cases we would (silently) override values passed to the command. That's not great because it might fix the issue but doesn't give the user feedback In other cases we just let invalid values go unnoticed.

Now we have explicit validation of every value set in the .env file ensuring it is impossible to run the project with an invalid setup config.

## Testing

### 1) Run make setup

```bash
make setup
```

Here are some sample test scenarios, all covered by automated testing.

> [!NOTE]
> It is assumed that you `rm .env` in between each invocation. Some values are preserved and re-read from the .env file DOCKER_TARGET and DOCKER_TAG 

```
make setup DOCKER_TAG='' -> works because tag can be inferred from default version
make setup DOCKER_TAG='' DOCKER_VERSION='' -> still works because version defaults to local
make setup DOCKER_VERSION='' DOCKER_DIGEST='' -> surprisingly still works because version defaults to local
make setup DOCKER_VERSION='local' DOCKER_DIGEST='abc' -> also works.. expect digest to take precedence

make setup DOCKER_TARGET=development -> works because the default verssion is local
make setup DOCKER_TARGET=development DOCKER_VERSION=latest -> fails because remote images are always production
make setup DOCKER_TARGET=production DOCKER_VERSION=latest -> works because we use production for remote image
make setup DOCKER_TARGET=production DOCKER_DIGEST=abc -> works because we use production for remote image
make setup DOCKER_TARGET=production DOCKER_DIGEST=abc DOCKER_VERSION=local -> works because we use production for remote image and digest takes precedence

make setup DOCKER_TARGET=production DOCKER_COMMIT=abc -> works because we do not care about commit on local images and the default version is local
make setup DOCKER_TARGET=production DOCKER_BUILD=abc -> works because we do not care about build on local images and the default version is local

make setup DOCKER_TARGET=production DOCKER_COMMIT=abc DOCKER_VERSION=latest -> fails because we cannot override commit when running production images
make setup DOCKER_TARGET=production DOCKER_BUILD=abc DOCKER_VERSION=latest -> fails because we cannot override build when running production images

make setup DOCKER_TARGET=development DOCKER_COMMIT=abc -> works because we dont care about commit on local images
make setup DOCKER_TARGET=development DOCKER_BUILD=abc -> works because we dont care about build on local images

make setup SETUP_ARGS="--build" DOCKER_TARGET=production DOCKER_COMMIT="" -> works because we do not care about commit on local images
make setup SETUP_ARGS="--build" DOCKER_TARGET=production DOCKER_VERSION=latest DOCKER_COMMIT="abc" -> fails because we must set a build when building remote images
make setup SETUP_ARGS="--build" DOCKER_TARGET=production DOCKER_VERSION=latest DOCKER_COMMIT="abc" -> fails because we must set a build when building remote images
make setup SETUP_ARGS="--build" DOCKER_TARGET=production DOCKER_VERSION=latest DOCKER_COMMIT="abc" DOCKER_BUILD="build" -> works because we set a build and commit when building a remote image

make setup SETUP_ARGS="--build" DOCKER_TARGET=production DOCKER_VERSION=latest DOCKER_COMMIT="abc" DOCKER_BUILD="build"

make setup SETUP_ARGS="--build" DOCKER_TARGET=development -> fails because we cannot build a development image
```

### 2) Run make build

```bash
make build
```

Check the endpoint

```bash
curl http://olympia.test/__version__
```
Should contain content matching the `/build-info.json` file. Run make up with different values and it should reflect the updates

Will run `setup` first so same rules apply and then will run the build.

## Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [x] Add or update relevant [docs](../docs/) reflecting the changes made.
