### PR TITLE
Use primary db in promote_by_firefox_themes and promoted models sync in general

### DIFF
--- a/src/olympia/promoted/management/commands/promote_by_firefox_themes.py
+++ b/src/olympia/promoted/management/commands/promote_by_firefox_themes.py
@@ -4,6 +4,7 @@ from django.core.management.base import BaseCommand
 from olympia import amo
 from olympia.addons.models import Addon
 from olympia.constants.promoted import PROMOTED_GROUP_CHOICES
+from olympia.amo.decorators import use_primary_db
 from olympia.promoted.models import (
     PromotedAddon,
 )
@@ -13,6 +14,7 @@ from olympia.users.models import UserProfile
 class Command(BaseCommand):
     help = 'Give themes with Firefox as author the "By Firefox" badge'
 
+    @use_primary_db
     def handle(self, *args, **options):
         firefox_user = UserProfile.objects.get(pk=settings.TASK_USER_ID)
         addons = (

--- a/src/olympia/promoted/management/commands/promote_by_firefox_themes.py
+++ b/src/olympia/promoted/management/commands/promote_by_firefox_themes.py
@@ -3,8 +3,8 @@ from django.core.management.base import BaseCommand
 
 from olympia import amo
 from olympia.addons.models import Addon
-from olympia.constants.promoted import PROMOTED_GROUP_CHOICES
 from olympia.amo.decorators import use_primary_db
+from olympia.constants.promoted import PROMOTED_GROUP_CHOICES
 from olympia.promoted.models import (
     PromotedAddon,
 )

--- a/src/olympia/promoted/signals.py
+++ b/src/olympia/promoted/signals.py
@@ -2,6 +2,7 @@ from django.db import models, transaction
 from django.db.models.signals import ModelSignal
 
 from olympia.constants.promoted import PROMOTED_GROUP_CHOICES
+from olympia.amo.decorators import use_primary_db
 
 from .models import (
     PromotedAddon,
@@ -12,6 +13,7 @@ from .models import (
 )
 
 
+@use_primary_db
 def promoted_addon_to_promoted_addon_promotion(
     signal: ModelSignal, instance: PromotedAddon
 ):
@@ -63,6 +65,7 @@ def promoted_addon_to_promoted_addon_promotion(
         ).delete()
 
 
+@use_primary_db
 def promoted_approval_to_promoted_addon_version(
     signal: ModelSignal,
     instance: PromotedApproval,

--- a/src/olympia/promoted/signals.py
+++ b/src/olympia/promoted/signals.py
@@ -1,8 +1,8 @@
 from django.db import models, transaction
 from django.db.models.signals import ModelSignal
 
-from olympia.constants.promoted import PROMOTED_GROUP_CHOICES
 from olympia.amo.decorators import use_primary_db
+from olympia.constants.promoted import PROMOTED_GROUP_CHOICES
 
 from .models import (
     PromotedAddon,


### PR DESCRIPTION
Follow-up fix (hopefully) for https://github.com/mozilla/addons/issues/14947

(We ran the command on dev and it created incomplete models, likely because some reads where happening on the replica)