### PR TITLE
Link Extension Workshop for Markdown Field Syntax

### DIFF
--- a/src/olympia/devhub/templates/devhub/addons/edit/describe.html
+++ b/src/olympia/devhub/templates/devhub/addons/edit/describe.html
@@ -1,4 +1,4 @@
-{% from "devhub/includes/macros.html" import tip, empty_unless, flags, select_cats, supported_syntax_tip, trans_readonly %}
+{% from "devhub/includes/macros.html" import tip, empty_unless, flags, select_cats, supported_syntax_link, trans_readonly %}
 
 <form method="post" action="{{ url('devhub.addons.section', valid_slug, 'describe', 'edit') }}"
       id="addon-edit-describe"
@@ -141,7 +141,7 @@
                 <div class="char-count"
                      data-for-startswith="{{ main_form.description.auto_id }}_"
                      data-minlength="{{ main_form.description.field.min_length }}"></div>
-                {{ supported_syntax_tip(allowed_markdown) }}
+                {{ supported_syntax_link(settings) }}
               {% else %}
                 {% call empty_unless(addon.description) %}
                   <div id="addon-description" class="prose">

--- a/src/olympia/devhub/templates/devhub/addons/edit/technical.html
+++ b/src/olympia/devhub/templates/devhub/addons/edit/technical.html
@@ -1,4 +1,4 @@
-{% from "devhub/includes/macros.html" import tip, supported_syntax_tip, empty_unless, flags %}
+{% from "devhub/includes/macros.html" import tip, supported_syntax_link, empty_unless, flags %}
 
 <form method="post"
       action="{{ url('devhub.addons.section', addon.slug, 'technical', 'edit') }}">
@@ -32,7 +32,7 @@
               {% if editable %}
                 {{ main_form.developer_comments }}
                 {{ main_form.developer_comments.errors }}
-                {{ supported_syntax_tip(allowed_markdown) }}
+                {{ supported_syntax_link(settings) }}
               {% else %}
                 {% call empty_unless(addon.developer_comments) %}
                   <div id="developer_comments">{{ addon|all_locales('developer_comments', nl2br=True) }}</div>

--- a/src/olympia/devhub/templates/devhub/addons/submit/describe.html
+++ b/src/olympia/devhub/templates/devhub/addons/submit/describe.html
@@ -1,4 +1,4 @@
-{% from "devhub/includes/macros.html" import supported_syntax_tip, select_cats %}
+{% from "devhub/includes/macros.html" import supported_syntax_link, select_cats %}
 {% from "includes/forms.html" import tip %}
 {% extends "devhub/addons/submit/base.html" %}
 
@@ -113,7 +113,7 @@
              data-for-startswith="{{ describe_form.description.auto_id }}_"
              data-minlength="{{ describe_form.description.field.min_length }}"></div>
       </div>
-      {{ supported_syntax_tip(allowed_markdown) }}
+      {{ supported_syntax_link(settings) }}
     </div>
     {% endif %}
     {% if addon.type != amo.ADDON_STATICTHEME %}
@@ -180,7 +180,7 @@
             {{ license_form.text.errors }}
             {{ license_form.text.label_tag() }}
             {{ license_form.text }}
-            {{ supported_syntax_tip(allowed_markdown) }}
+            {{ supported_syntax_link(settings) }}
           </div>
       </div>
     {% endif %}

--- a/src/olympia/devhub/templates/devhub/includes/macros.html
+++ b/src/olympia/devhub/templates/devhub/includes/macros.html
@@ -1,11 +1,8 @@
 {% extends "includes/forms.html" %}
 
-{% macro supported_syntax_tip(allowed_markdown, title=None) %}
+{% macro supported_syntax_link(settings) %}
 <p class="syntax-support">
-{# L10n: %s is a list of markdown syntax. #}
-<span class="tooltip" title="{% if title %}{{ title }}{% else %}{{
-      _('Allowed Markdown: %(allowed_markdown)s', allowed_markdown=allowed_markdown)
-    }}{% endif %}">{{ _('Some Markdown supported.') }}</span>
+  <a href="{{ settings.EXTENSION_WORKSHOP_URL }}/documentation/develop/create-an-appealing-listing/#make-use-of-markdown" target="_blank" rel="noopener noreferrer">{{ _('Some Markdown supported.') }}</a>
 </p>
 {% endmacro %}
 

--- a/src/olympia/devhub/templates/devhub/includes/policy_form.html
+++ b/src/olympia/devhub/templates/devhub/includes/policy_form.html
@@ -1,4 +1,4 @@
-{% from "devhub/includes/macros.html" import tip, supported_syntax_tip %}
+{% from "devhub/includes/macros.html" import tip, supported_syntax_link %}
 <tr>
   <th>{{ tip(_('End-User License Agreement'),
              _('Please note that a EULA is not '
@@ -13,7 +13,7 @@
         {{ policy_form.eula.label }}
       </label>
       {{ policy_form.eula }}
-      {{ supported_syntax_tip(allowed_markdown) }}
+      {{ supported_syntax_link(settings) }}
     </div>
   </td>
 </tr>
@@ -31,7 +31,7 @@
         {{ policy_form.privacy_policy.label }}
       </label>
       {{ policy_form.privacy_policy }}
-      {{ supported_syntax_tip(allowed_markdown) }}
+      {{ supported_syntax_link(settings) }}
     </div>
   </td>
 </tr>

--- a/src/olympia/devhub/templates/devhub/versions/edit.html
+++ b/src/olympia/devhub/templates/devhub/versions/edit.html
@@ -1,6 +1,6 @@
 {% extends "devhub/base.html" %}
 
-{% from "devhub/includes/macros.html" import tip, supported_syntax_tip, empty_unless, compat %}
+{% from "devhub/includes/macros.html" import tip, supported_syntax_link, empty_unless, compat %}
 
 {% set title = _('Manage Version {0}')|format_html(version.version) %}
 
@@ -73,7 +73,7 @@
             <td>
               {{ field.errors }}
               {{ field }}
-              {{ supported_syntax_tip(allowed_markdown) }}
+              {{ supported_syntax_link(settings) }}
             </td>
           {% endwith %}
           </tr>

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -71,7 +71,6 @@ from olympia.files.utils import parse_addon
 from olympia.reviewers.forms import PublicWhiteboardForm
 from olympia.reviewers.models import Whiteboard
 from olympia.reviewers.utils import ReviewHelper
-from olympia.translations.models import PurifiedTranslation
 from olympia.users.models import (
     DeveloperAgreementRestriction,
     SuppressedEmailVerification,
@@ -962,7 +961,6 @@ def addons_section(request, addon_id, addon, section, editable=False):
         'whiteboard_form': whiteboard_form,
         'valid_slug': valid_slug,
         'supported_image_types': amo.SUPPORTED_IMAGE_TYPES,
-        'allowed_markdown': PurifiedTranslation.get_allowed_tags(),
     }
 
     return TemplateResponse(
@@ -1176,7 +1174,6 @@ def version_edit(request, addon_id, addon, version_id):
             'is_admin': is_admin,
             'choices': File.STATUS_CHOICES,
             'files': (version.file,),
-            'allowed_markdown': PurifiedTranslation.get_allowed_tags(),
         }
     )
 
@@ -1813,7 +1810,6 @@ def _submit_details(request, addon, version):
         'version': version,
         'sources_provided': latest_version.sources_provided,
         'submit_page': 'version' if version else 'addon',
-        'allowed_markdown': PurifiedTranslation.get_allowed_tags(),
     }
 
     post_data = request.POST if request.method == 'POST' else None

--- a/src/olympia/translations/models.py
+++ b/src/olympia/translations/models.py
@@ -240,10 +240,6 @@ class PurifiedTranslation(PureTranslation):
 
         return cleaner.clean(str(self.localized_string))
 
-    @classmethod
-    def get_allowed_tags(cls):
-        return ', '.join(cls.allowed_tags)
-
 
 class PurifiedMarkdownTranslation(PurifiedTranslation):
     class Meta:


### PR DESCRIPTION
Fixes: mozilla/addons#15392

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

<!--
Your PR will be squashed when merged so the 1st commit must contain a descriptive and concise summary of the change.
Additional details should be added in the description. If your change is simple enough to summarize in the commit, or
if it is not relevant for your PR, remove this section.
-->

"Some Markdown Supported" links the Extension Workshop Markdown section instead of using the tooltip to explain markdown syntax.

![image](https://github.com/user-attachments/assets/c4710f22-1c8c-466c-b247-49aadc3c2453)

### Testing

Affects the following inputs:
- Edit Product Page > Describe Add-on Section > Description
- Edit Product Page > Technical Details Section > Developer Comments
- Manage Authors & License > EULA, Privacy Policy
- Manage Status & Versions > Specific Version > Version Notes
- Submit a New Add-on > Description, Other License

<!--
Your change must be related to an existing, open issue. This issue should contain testing instructions.
Often, the testing info in the issue is higher level, geared towards a user or QA experience.
Here you can provide information for a developer verifying this PR. Get technical.
If it is not relevant to your PR, remove this section.
-->

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] Add before and after screenshots (Only for changes that impact the UI).
