### PR TITLE
Bump check locales completion rate to 70%

### DIFF
--- a/src/olympia/amo/management/commands/check_locales_completion_rate.py
+++ b/src/olympia/amo/management/commands/check_locales_completion_rate.py
@@ -46,10 +46,8 @@ class Command(BaseCommand):
     # query above. AMO locales are split into 2 projects, our query reflects
     # that by querying amo and amoFrontend.
     PONTOON_PROJECTS = 2
-    # 40% completion is the first step of the project. Then we'll move it up to
-    # 80% for a limited period, and eventually it will be set to 70% to account
-    # for new strings being added over time.
-    COMPLETION_THRESHOLD = 40
+    # Threshold to enable/disable locales.
+    COMPLETION_THRESHOLD = 70
     # Arbitrary list of locales we always want to keep, either because they
     # receive the most traffic/affect the most users, or because they are RTL
     # and we want to keep at least one of those to ensure AMO works in RTL.

--- a/src/olympia/amo/tests/test_commands.py
+++ b/src/olympia/amo/tests/test_commands.py
@@ -781,12 +781,19 @@ class TestCheckLocalesCompletionRate(TestCase):
 
     def _test_full_run_typical_response(self):
         expected_below = (
-            'The following locales are below threshold of 40% or completely '
+            'The following locales are below threshold of 70% or completely '
             'absent in one of our projects in Pontoon:\n- '
             + '\n- '.join(
                 (
+                    'Bulgarian [bg]',
+                    'Danish [da]',
+                    'Finnish [fi]',
+                    'Kaqchikel [cak]',
+                    'Malay [ms]',
+                    'Norwegian (Bokmål) [nb-NO]',
                     'Portuguese (Brazilian) [pt-BR]',
                     'Sinhala [si]',
+                    'Telugu [te]',
                 )
             )
         )
@@ -838,7 +845,7 @@ class TestCheckLocalesCompletionRate(TestCase):
     def _test_full_run_empty_response(self):
         # Everything should be missing since the response is an empty object.
         expected_below = (
-            'The following locales are below threshold of 40% or completely '
+            'The following locales are below threshold of 70% or completely '
             'absent in one of our projects in Pontoon:\n- '
             + '\n- '.join(
                 sorted(


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/15441

### Testing

We're only changing the threshold value, so not much to verify. You can run the command locally and check the logs and `FakeEmail` to see if we correctly considered locales below/above the threshold, but unit tests already do that.