### PR TITLE
Limit height of notes for reviewers and replies in review page, add scroll

### DIFF
--- a/static/css/zamboni/reviewers.less
+++ b/static/css/zamboni/reviewers.less
@@ -1142,14 +1142,6 @@ pre.history-comment {
         linear-gradient(rgba(255,255,255,0), white 70%) 0 100%,
 
         /* Shadows */
-        radial-gradient(50% 0, farthest-side, rgba(0,0,0,.2), rgba(0,0,0,0)),
-        radial-gradient(50% 100%,farthest-side, rgba(0,0,0,.2), rgba(0,0,0,0)) 0 100%;
-    background:
-        /* Shadow covers */
-        linear-gradient(white 30%, rgba(255,255,255,0)),
-        linear-gradient(rgba(255,255,255,0), white 70%) 0 100%,
-
-        /* Shadows */
         radial-gradient(farthest-side at 50% 0, rgba(0,0,0,.2), rgba(0,0,0,0)),
         radial-gradient(farthest-side at 50% 100%, rgba(0,0,0,.2), rgba(0,0,0,0)) 0 100%;
     background-repeat: no-repeat;

--- a/static/css/zamboni/reviewers.less
+++ b/static/css/zamboni/reviewers.less
@@ -1129,9 +1129,33 @@ pre.history-comment {
     font-style: italic;
 }
 
-.history-notes {
-    max-width: 370px;
+.history-notes, .history-comment {
     overflow: auto;
+    max-height: 50em;
+    /* hack to show gradients indicating that there is some scrolling to do,
+       in case the browser would decide to hide it despite overflow-y: scroll;
+       See https://lea.verou.me/blog/2012/04/background-attachment-local/
+    */
+    background:
+        /* Shadow covers */
+        linear-gradient(white 30%, rgba(255,255,255,0)),
+        linear-gradient(rgba(255,255,255,0), white 70%) 0 100%,
+
+        /* Shadows */
+        radial-gradient(50% 0, farthest-side, rgba(0,0,0,.2), rgba(0,0,0,0)),
+        radial-gradient(50% 100%,farthest-side, rgba(0,0,0,.2), rgba(0,0,0,0)) 0 100%;
+    background:
+        /* Shadow covers */
+        linear-gradient(white 30%, rgba(255,255,255,0)),
+        linear-gradient(rgba(255,255,255,0), white 70%) 0 100%,
+
+        /* Shadows */
+        radial-gradient(farthest-side at 50% 0, rgba(0,0,0,.2), rgba(0,0,0,0)),
+        radial-gradient(farthest-side at 50% 100%, rgba(0,0,0,.2), rgba(0,0,0,0)) 0 100%;
+    background-repeat: no-repeat;
+    background-color: white;
+    background-size: 100% 40px, 100% 40px, 100% 14px, 100% 14px;
+    background-attachment: local, local, scroll, scroll;
 }
 
 .review-paging {


### PR DESCRIPTION
Fixes: mozilla/addons#15502

### Testing:

- As a developer, change "Notes for reviewers" for a version to something super long
- As a reviewer, open the review page for that add-on

The height of the text in the version history should have a limit, with a scrollbar available to see the rest. If there is some text to show after the scrollbar at the bottom (or at the top if you started scrolling) a subtle background gradient should show up to indicate that.

Repeat for developers and reviewer replies.

### Screenshot

![Screenshot 2025-04-03 at 14-45-39 seafowala-chanter-girroach – Add-ons for Firefox](https://github.com/user-attachments/assets/da787a51-c6a7-4c5f-8e06-60097d1811b0)
