### PR TITLE
Fix broken statistics dashboard. (Enable no-undef and no-reassign-const eslint rules)

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -85,11 +85,9 @@ const config = defineConfig([
       // Disable rules causing errors
       'simple-import-sort/imports': 'off',
       'no-unused-vars': 'off',
-      'no-undef': 'off',
       'no-var': 'off',
       'prettier/prettier': 'off',
       'no-prototype-builtins': 'off',
-      'no-const-assign': 'off',
       'no-dupe-keys': 'off',
     },
   },

--- a/static/js/stats/chart.js
+++ b/static/js/stats/chart.js
@@ -229,7 +229,7 @@ const dayMsecs = 24 * 3600 * 1000;
     }
 
     // Transform xAxis based on time grouping (day, week, month) and range.
-    let pointInterval = (dayMsecs = 1 * 24 * 3600 * 1000);
+    let pointInterval = dayMsecs;
     let dateRangeDays = (end - start) / dayMsecs;
     baseConfig.xAxis.min = start - dayMsecs; // Fix chart truncation.
     baseConfig.xAxis.max = end;

--- a/static/js/stats/stats.js
+++ b/static/js/stats/stats.js
@@ -8,8 +8,8 @@ function updateQueryParams(view) {
   let queryParams = {};
 
   if (view.range) {
-    if (typeof range == 'string') {
-      queryParams.last = range.split(/\s+/)[0];
+    if (typeof view.range == 'string') {
+      queryParams.last = view.range.split(/\s+/)[0];
     }
   }
 

--- a/static/js/zamboni/reviewers.js
+++ b/static/js/zamboni/reviewers.js
@@ -86,14 +86,14 @@ $(document).ready(function () {
 
     $('#addon-queue-filter-form .select-all').click(function (e) {
       e.preventDefault();
-      jQuery('#addon-queue-filter-form input[type="checkbox"]').prop(
+      $('#addon-queue-filter-form input[type="checkbox"]').prop(
         'checked',
         true,
       );
     });
     $('#addon-queue-filter-form .select-none').click(function (e) {
       e.preventDefault();
-      jQuery('#addon-queue-filter-form input[type="checkbox"]').prop(
+      $('#addon-queue-filter-form input[type="checkbox"]').prop(
         'checked',
         false,
       );


### PR DESCRIPTION
Fixes: mozilla/addons#15515

### Description

Enable eslint rules preventing:
- re-defining constants
- using undefined values

### Context

The statistics dashbaord was broken due to 2 lines of code violating these rules. It led to blank pages without any error validation.

Should we consider adding additional validation when there is a critical error?

### Testing

1. setup dev credentials for bigquery.
2. set the guid for one of your addons to a dev enabled stats guid
3. open the statistics page for that addon

Expect:
- the default view to load.
- changing the date range should work and update the chart, including custom date range


### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [x] Add or update relevant [docs](../docs/) reflecting the changes made.
