### PR TITLE
Bring back max-width on review page history comments/notes to prevent text overflow

### DIFF
--- a/static/css/zamboni/reviewers.less
+++ b/static/css/zamboni/reviewers.less
@@ -1132,6 +1132,7 @@ pre.history-comment {
 .history-notes, .history-comment {
     overflow: auto;
     max-height: 50em;
+    max-width: 510px;
     /* hack to show gradients indicating that there is some scrolling to do,
        in case the browser would decide to hide it despite overflow-y: scroll;
        See https://lea.verou.me/blog/2012/04/background-attachment-local/


### PR DESCRIPTION
Follow-up for https://github.com/mozilla/addons/issues/15502

In 037133186eda8c7ae6f987e3e66185c1ae599885 I removed the `max-width` because from my testing it caused version approval notes and release notes box to be inconsistent with activity logs, which was very noticeable with the scrollbars. But it was actually useful to have this `max-width`, because while activity comments are wrapped in a `<pre>` with specific wrapping set, approval/release notes aren't...

This adds back a `max-width`, but applied to both kinds of content, fixing the inconsistency issue.