### PR TITLE
Revert ./stats/js/stats files closer to original state before vite migration

### DIFF
--- a/static/js/stats.js
+++ b/static/js/stats.js
@@ -3,8 +3,13 @@ import './stats/helpers';
 import './stats/dateutils';
 import './stats/manager';
 import './stats/controls';
-import './stats/overview';
+import { stats_overview } from './stats/overview';
 import './stats/topchart';
 import './stats/chart';
 import './stats/table';
-import './stats/stats';
+import { stats_stats } from './stats/stats';
+import { capabilities } from './zamboni/capabilities';
+
+// Initialize the stats module.
+stats_stats(window.sessionStorage, capabilities);
+stats_overview();

--- a/static/js/stats/chart.js
+++ b/static/js/stats/chart.js
@@ -10,7 +10,7 @@ import { StatsManager } from './manager';
 const dayMsecs = 24 * 3600 * 1000;
 
 (function () {
-  let $win = $(window),
+  var $win = $(window),
     $chart = $('#head-chart'),
     $btnZoom = $('#chart-zoomout'),
     baseConfig = {
@@ -83,9 +83,9 @@ const dayMsecs = 24 * 3600 * 1000;
       },
     };
   Highcharts.setOptions({ lang: { resetZoom: '' } });
-  let chart;
+  var chart;
   // which unit do we use for a given metric?
-  let metricTypes = {
+  var metricTypes = {
     usage: 'users',
     apps: 'users',
     locales: 'users',
@@ -114,7 +114,7 @@ const dayMsecs = 24 * 3600 * 1000;
     campaigns: 'downloads',
   };
 
-  let acceptedGroups = {
+  var acceptedGroups = {
     day: true,
     week: true,
     month: true,
@@ -133,7 +133,7 @@ const dayMsecs = 24 * 3600 * 1000;
   });
 
   $win.on('dataready', function (e, obj) {
-    let view = obj.view,
+    var view = obj.view,
       metric = view.metric,
       group = view.group,
       data = obj.data,
@@ -187,7 +187,7 @@ const dayMsecs = 24 * 3600 * 1000;
 
     // Transmute the data into something Highcharts understands.
     start = Date.iso(data.firstIndex);
-    let step = '1 ' + group,
+    var step = '1 ' + group,
       point,
       dataSum = 0;
 
@@ -209,9 +209,9 @@ const dayMsecs = 24 * 3600 * 1000;
 
     // Display marker if only one data point.
     baseConfig.plotOptions.line.marker.radius = 3;
-    let count = 0,
+    var count = 0,
       dateRegex = /\d{4}-\d{2}-\d{2}/;
-    for (let key in data) {
+    for (var key in data) {
       if (dateRegex.exec(key) && data.hasOwnProperty(key)) {
         count++;
       }
@@ -229,8 +229,8 @@ const dayMsecs = 24 * 3600 * 1000;
     }
 
     // Transform xAxis based on time grouping (day, week, month) and range.
-    let pointInterval = dayMsecs;
-    let dateRangeDays = (end - start) / dayMsecs;
+    var pointInterval = dayMsecs;
+    var dateRangeDays = (end - start) / dayMsecs;
     baseConfig.xAxis.min = start - dayMsecs; // Fix chart truncation.
     baseConfig.xAxis.max = end;
     baseConfig.xAxis.tickInterval = null;
@@ -251,10 +251,10 @@ const dayMsecs = 24 * 3600 * 1000;
     }
 
     // Set minimum max value for yAxis to prevent duplicate yAxis values.
-    let max = 0;
-    for (let key in data) {
-      if (data[key].count > max) {
-        max = data[key].count;
+    var max = 0;
+    for (var _key in data) {
+      if (data[_key].count > max) {
+        max = data[_key].count;
       }
     }
     // Chart has minimum 5 ticks so set max to 5 to avoid pigeonholing.
@@ -269,7 +269,7 @@ const dayMsecs = 24 * 3600 * 1000;
     start = date.getTime() - date.getTimezoneOffset() * 60000;
 
     // Populate the chart config object.
-    let chartData = [],
+    var chartData = [],
       id;
     for (i = 0; i < fields.length; i++) {
       field = fields[i];
@@ -288,8 +288,8 @@ const dayMsecs = 24 * 3600 * 1000;
 
     // Generate the tooltip function for this chart.
     // both x and y axis can be displayed differently.
-    let tooltipFormatter = (function () {
-      let xFormatter, yFormatter;
+    var tooltipFormatter = (function () {
+      var xFormatter, yFormatter;
       function dayFormatter(d) {
         return Highcharts.dateFormat('%a, %b %e, %Y', new Date(d));
       }
@@ -354,7 +354,7 @@ const dayMsecs = 24 * 3600 * 1000;
         );
       }
       function addEventData(s, date) {
-        let e = events[date];
+        var e = events[date];
         if (e) {
           s += format('<br><br><b>{type_pretty}</b>', e);
         }
@@ -372,9 +372,9 @@ const dayMsecs = 24 * 3600 * 1000;
 
       if (is_overview) {
         return function () {
-          let ret = '<b>' + xFormatter(this.x) + '</b>',
+          var ret = '<b>' + xFormatter(this.x) + '</b>',
             p;
-          for (let i = 0; i < this.points.length; i++) {
+          for (var i = 0; i < this.points.length; i++) {
             p = this.points[i];
             ret += '<br>' + p.series.name + ': ';
             ret += Highcharts.numberFormat(p.y, 0);
@@ -383,9 +383,9 @@ const dayMsecs = 24 * 3600 * 1000;
         };
       } else if (metric == 'contributions') {
         return function () {
-          let ret = '<b>' + xFormatter(this.x) + '</b>',
+          var ret = '<b>' + xFormatter(this.x) + '</b>',
             p;
-          for (let i = 0; i < this.points.length; i++) {
+          for (var i = 0; i < this.points.length; i++) {
             p = this.points[i];
             ret += '<br>' + p.series.name + ': ';
             if (p.series.options.yAxis > 0) {
@@ -429,7 +429,7 @@ const dayMsecs = 24 * 3600 * 1000;
             break;
         }
         return function () {
-          let ret =
+          var ret =
             '<b>' +
             this.series.name +
             '</b><br>' +
@@ -442,7 +442,7 @@ const dayMsecs = 24 * 3600 * 1000;
     })();
 
     // Set up the new chart's configuration.
-    let newConfig = $.extend(baseConfig, { series: chartData });
+    var newConfig = $.extend(baseConfig, { series: chartData });
     // set up dual-axes for the overview chart.
     if (is_overview && newConfig.series.length) {
       _.extend(newConfig, {
@@ -530,7 +530,7 @@ const dayMsecs = 24 * 3600 * 1000;
 
     function makeSiteEventHandler(e) {
       return function () {
-        let s = format('<h3>{type_pretty}</h3><p>{description}</p>', e);
+        var s = format('<h3>{type_pretty}</h3><p>{description}</p>', e);
         if (e.url) {
           s += format('<p><a href="{0}">{1}</a></p>', [
             e.url,
@@ -549,7 +549,7 @@ const dayMsecs = 24 * 3600 * 1000;
       };
     }
 
-    let pb = [],
+    var pb = [],
       pl = [];
     const eventColors = ['#DDD', '#DDD', '#FDFFD0', '#D0FFD8'];
     _.forEach(events, function (e) {
@@ -570,9 +570,9 @@ const dayMsecs = 24 * 3600 * 1000;
     }
 
     // Generate a pretty title for the chart.
-    let title;
+    var title;
     if (typeof obj.view.range == 'string') {
-      let numDays = parseInt(obj.view.range, 10);
+      var numDays = parseInt(obj.view.range, 10);
       title = format(csv_keys.chartTitle[metric][0], numDays);
     } else {
       // This is a custom range so display a range shorter by one day.

--- a/static/js/stats/controls.js
+++ b/static/js/stats/controls.js
@@ -3,20 +3,20 @@ import _ from 'underscore';
 import { _pd } from '../lib/prevent-default';
 import { normalizeRange } from './dateutils';
 
-let $rangeSelector = $('.criteria.range ul'),
+var $rangeSelector = $('.criteria.range ul'),
   $customRangeForm = $('div.custom.criteria'),
   $groupSelector = $('.criteria.group ul'),
   minDate = Date.iso($('.primary').attr('data-min-date')),
   msDay = 24 * 60 * 60 * 1000; // One day in milliseconds.
 
-let $customModal = $('#custom-criteria').modal('#custom-date-range', {
+var $customModal = $('#custom-criteria').modal('#custom-date-range', {
   width: 520,
   hideme: true,
 });
 
 $rangeSelector.click(function (e) {
-  let $target = $(e.target).parent();
-  let newRange = $target.attr('data-range');
+  var $target = $(e.target).parent();
+  var newRange = $target.attr('data-range');
   if (newRange && newRange != 'custom') {
     $target.trigger('changeview', { range: newRange });
   }
@@ -24,7 +24,7 @@ $rangeSelector.click(function (e) {
 });
 
 $groupSelector.on('click', 'a', function (e) {
-  let $target = $(this).parent(),
+  var $target = $(this).parent(),
     newGroup = $target.attr('data-group');
 
   $(this).trigger('changeview', { group: newGroup });
@@ -33,9 +33,10 @@ $groupSelector.on('click', 'a', function (e) {
 
 // set controls when `changeview` is detected.
 $(window).on('changeview', function (e, newState) {
+  console.debug('controls:window:changeview', newState);
   if (!newState) return;
   function populateCustomRange() {
-    let nRange = normalizeRange(newState.range),
+    var nRange = normalizeRange(newState.range),
       startStr = nRange.start.iso(),
       endStr = nRange.end.iso();
 
@@ -50,7 +51,7 @@ $(window).on('changeview', function (e, newState) {
   }
   if (newState.range) {
     if (!newState.range.custom) {
-      let newRange = newState.range,
+      var newRange = newState.range,
         $rangeEl = $('li[data-range="' + _.escape(newRange) + '"]');
       if ($rangeEl.length) {
         $rangeSelector.children('li.selected').removeClass('selected');
@@ -75,7 +76,7 @@ $('#chart-zoomout').click(_pd);
 
 $('#date-range-form').submit(
   _pd(function (e) {
-    let start = Date.iso($('#date-range-start').val()),
+    var start = Date.iso($('#date-range-start').val()),
       end = Date.iso($('#date-range-end').val()),
       newRange = {
         custom: true,

--- a/static/js/stats/dateutils.js
+++ b/static/js/stats/dateutils.js
@@ -4,17 +4,17 @@ import _ from 'underscore';
 
 // utility
 function pad2(n) {
-  let str = n.toString();
+  var str = n.toString();
   return ('0' + str).substr(-2);
 }
-let intervalRegex = /(-?\d+)\s*(\w)/,
+var intervalRegex = /(-?\d+)\s*(\w)/,
   // ISO date format is used for internal representations.
   dateRegex = /(\d{4})[^\d]?(\d{2})[^\d]?(\d{2})/;
 
 _.extend(Date.prototype, {
   forward: function (by, unit) {
     if (typeof by == 'string') {
-      let match = intervalRegex.exec(by);
+      var match = intervalRegex.exec(by);
       by = +match[1];
       unit = match[2];
     }
@@ -40,7 +40,7 @@ _.extend(Date.prototype, {
   },
   backward: function (by, unit) {
     if (typeof by == 'string') {
-      let match = intervalRegex.exec(by);
+      var match = intervalRegex.exec(by);
       by = +match[1];
       unit = match[2];
     }
@@ -79,7 +79,7 @@ _.extend(Date, {
   },
   iso: function (s) {
     if (s instanceof Date) return s;
-    let d = dateRegex.exec(s);
+    var d = dateRegex.exec(s);
     if (d) {
       return new Date(d[1], d[2] - 1, d[3]);
     }
@@ -95,15 +95,15 @@ _.extend(String, {
 });
 
 export function forEachISODate(range, step, data, iterator, context) {
-  let d = range.start.clone();
+  var d = range.start.clone();
   for (d; d.isBefore(range.end); d.forward(step)) {
-    let ds = d.iso();
+    var ds = d.iso();
     iterator.call(context, data[ds], d, ds);
   }
 }
 
 export function normalizeRange(range) {
-  let ret = {};
+  var ret = {};
   if (typeof range == 'string') {
     ret.start = Date.ago(range);
     ret.end = new Date();

--- a/static/js/stats/helpers.js
+++ b/static/js/stats/helpers.js
@@ -1,7 +1,7 @@
 // Web Worker Pool
 // size is the max number of arguments
 function WorkerPool(size) {
-  let workers = 0,
+  var workers = 0,
     jobs = [];
 
   // url: the url of the worker's js
@@ -10,7 +10,7 @@ function WorkerPool(size) {
   //      return true from cb to dismiss the worker and advance the queue.
   // ctx: the context for cb.apply
   this.queueJob = function (url, msg, cb, ctx) {
-    let job = {
+    var job = {
       url: url,
       msg: msg,
       cb: cb,
@@ -23,7 +23,7 @@ function WorkerPool(size) {
   function nextJob() {
     if (jobs.length) {
       (function () {
-        let job = jobs.shift(),
+        var job = jobs.shift(),
           worker = new Worker(job.url);
         workers++;
         worker.addEventListener(
@@ -53,7 +53,7 @@ function WorkerPool(size) {
 //       Takes one parameter:
 //       * key
 function AsyncCache(miss, hash) {
-  let cache = {},
+  var cache = {},
     self = this;
 
   hash =
@@ -68,7 +68,7 @@ function AsyncCache(miss, hash) {
   //      val: the value in the cache for key
   // ctx: context for cb.call
   this.get = function (key, cb, ctx) {
-    let k = hash(key);
+    var k = hash(key);
     if (k in cache) {
       cb.call(ctx, cache[k]);
     } else {
@@ -86,8 +86,8 @@ function AsyncCache(miss, hash) {
 }
 
 function hashObj(o) {
-  let hash = [];
-  for (let i in o) {
+  var hash = [];
+  for (var i in o) {
     if (o.hasOwnProperty(i)) {
       hash.push(o[i].toString());
     }
@@ -105,12 +105,12 @@ function hashObj(o) {
  * ctx: context from which to run all functions
  */
 function chunkfor(cfg) {
-  let position = cfg.start;
+  var position = cfg.start;
 
   function nextchunk() {
     if (position < cfg.end) {
       for (
-        let iterator = position;
+        var iterator = position;
         iterator < position + cfg.chunk_size * cfg.step && iterator < cfg.end;
         iterator += cfg.step
       ) {

--- a/static/js/stats/manager.js
+++ b/static/js/stats/manager.js
@@ -8,12 +8,12 @@ import { Storage, SessionStorage } from '../zamboni/storage';
 function getStatsManager() {
   // The version of the stats localStorage we are using.
   // If you increment this number, you cache-bust everyone!
-  let STATS_VERSION = '2020-10-08';
-  let PRECISION = 2;
+  var STATS_VERSION = '2020-10-08';
+  var PRECISION = 2;
 
-  let $primary = $('.primary');
+  var $primary = $('.primary');
 
-  let storage = Storage('stats'),
+  var storage = Storage('stats'),
     storageCache = SessionStorage('statscache'),
     dataStore = {},
     currentView = {},
@@ -31,7 +31,7 @@ function getStatsManager() {
 
   // It's a bummer, but we need to know which metrics have breakdown fields.
   // check by saying `if (metric in breakdownMetrics)`
-  let breakdownMetrics = {
+  var breakdownMetrics = {
     apps: true,
     locales: true,
     os: true,
@@ -47,7 +47,7 @@ function getStatsManager() {
   };
 
   // is a metric an average or a sum?
-  let metricTypes = {
+  var metricTypes = {
     usage: 'mean',
     apps: 'mean',
     locales: 'mean',
@@ -66,7 +66,7 @@ function getStatsManager() {
   // Initialize from localStorage when dom is ready.
   function init() {
     if (verifyLocalStorage()) {
-      let cacheObject = storageCache.get(addonId);
+      var cacheObject = storageCache.get(addonId);
       if (cacheObject) {
         cacheObject = JSON.parse(cacheObject);
         if (cacheObject) {
@@ -106,6 +106,7 @@ function getStatsManager() {
 
   // Runs when 'changeview' event is detected.
   function processView(e, newView) {
+    console.debug('manager:window:changeview', newView);
     // Update our internal view state.
     currentView = $.extend(currentView, newView);
 
@@ -128,7 +129,7 @@ function getStatsManager() {
   $(window).on('changeview', processView);
 
   function annotateData(data, events) {
-    let i, ev, sd, ed;
+    var i, ev, sd, ed;
     for (i = 0; i < events.length; i++) {
       ev = events[i];
       if (ev.end) {
@@ -150,7 +151,7 @@ function getStatsManager() {
 
   // Returns a list of field names for a given data set.
   function getAvailableFields(view) {
-    let metric = view.metric,
+    var metric = view.metric,
       range = normalizeRange(view.range),
       start = range.start,
       end = range.end,
@@ -204,14 +205,14 @@ function getStatsManager() {
   // the range currently stored locally. Once all server requests return,
   // we move on.
   function getDataRange(view) {
-    let range = normalizeRange(view.range),
+    var range = normalizeRange(view.range),
       metric = view.metric,
       ds = dataStore[metric],
       reqs = [],
       $def = $.Deferred();
 
     function finished() {
-      let ds = dataStore[metric],
+      var ds = dataStore[metric],
         ret = {},
         row,
         firstIndex;
@@ -221,7 +222,7 @@ function getStatsManager() {
           '1 day',
           ds,
           function (row, date) {
-            let d = date.iso();
+            var d = date.iso();
             if (row) {
               if (!firstIndex) {
                 firstIndex = range.start;
@@ -267,14 +268,14 @@ function getStatsManager() {
 
   // Aggregate data based on view's `group` setting.
   function groupData(data, view) {
-    let metric = view.metric,
+    var metric = view.metric,
       range = normalizeRange(view.range),
       group = view.group || 'day',
       groupedData = {};
 
     // If grouping doesn't fit into custom date range, force group to day.
-    let dayMsecs = 24 * 3600 * 1000;
-    let date_range_days =
+    var dayMsecs = 24 * 3600 * 1000;
+    var date_range_days =
       (range.end.getTime() - range.start.getTime()) / dayMsecs;
     if (
       (group == 'week' && date_range_days <= 8) ||
@@ -286,7 +287,7 @@ function getStatsManager() {
 
     // if grouping is by day, do nothing.
     if (group == 'day') return data;
-    let groupKey = false,
+    var groupKey = false,
       groupVal = false,
       groupCount = 0,
       d,
@@ -394,11 +395,11 @@ function getStatsManager() {
 
   // The beef. Negotiates with the server for data.
   function fetchData(metric, start, end) {
-    let seriesStart = start,
+    var seriesStart = start,
       seriesEnd = end,
       $def = $.Deferred();
 
-    let seriesURLStart = Highcharts.dateFormat('%Y%m%d', seriesStart),
+    var seriesURLStart = Highcharts.dateFormat('%Y%m%d', seriesStart),
       seriesURLEnd = Highcharts.dateFormat('%Y%m%d', seriesEnd),
       seriesURL =
         baseURL +
@@ -424,7 +425,7 @@ function getStatsManager() {
     }
 
     function fetchHandler(raw_data, status, xhr) {
-      let maxdate = '1970-01-01',
+      var maxdate = '1970-01-01',
         mindate = new Date().iso();
 
       if ([200, 503].includes(xhr.status)) {
@@ -435,10 +436,10 @@ function getStatsManager() {
           };
         }
 
-        let ds = dataStore[metric],
+        var ds = dataStore[metric],
           data = JSON.parse(raw_data);
 
-        let i, datekey;
+        var i, datekey;
         for (i = 0; i < data.length; i++) {
           datekey = data[i].date;
           maxdate = String.max(datekey, maxdate);
@@ -453,7 +454,7 @@ function getStatsManager() {
       } else if (xhr.status == 202) {
         //Handle a successful fetch but with no response
 
-        let retry_delay = 30000;
+        var retry_delay = 30000;
 
         if (xhr.getResponseHeader('Retry-After')) {
           retry_delay =
@@ -469,7 +470,7 @@ function getStatsManager() {
   }
 
   function collapseSources(row) {
-    let out = {
+    var out = {
         count: row.count,
         date: row.date,
         end: row.end,
@@ -495,7 +496,7 @@ function getStatsManager() {
   // Rounds application version strings to a given precision.
   // Passing `0` will truncate versions entirely.
   function collapseVersions(row, precision) {
-    let out = {
+    var out = {
         count: row.count,
         date: row.date,
         end: row.end,
@@ -519,14 +520,14 @@ function getStatsManager() {
 
   // Takes a data row and a field identifier and returns the value.
   function getField(row, field) {
-    let parts = field.split('|'),
+    var parts = field.split('|'),
       val = row;
 
     // give up if the row is falsy.
     if (!val) return null;
     // drill into the row object for a nested key.
     // `data|api` means row['data']['api']
-    for (let i = 0; i < parts.length; i++) {
+    for (var i = 0; i < parts.length; i++) {
       val = val[parts[i]];
       if (!_.isNumber(val) && !_.isObject(val)) {
         return null;
@@ -536,7 +537,7 @@ function getStatsManager() {
   }
 
   function getPrettyName(metric, field) {
-    let parts = field.split('_'),
+    var parts = field.split('_'),
       key = parts[0];
     parts = parts.slice(1);
 

--- a/static/js/stats/overview.js
+++ b/static/js/stats/overview.js
@@ -9,7 +9,7 @@ import { StatsManager } from './manager';
 
 // This function is called once we have stats data and we get aggregates for
 // daily users and weekly downloads.
-export function stats_overview_make_handler({ view }) {
+export const stats_overview_make_handler = function ({ view }) {
   const range = normalizeRange(view.range);
 
   return function (data) {
@@ -19,7 +19,7 @@ export function stats_overview_make_handler({ view }) {
       );
     } else {
       // make all that data pretty.
-      let aggregateRow = data[data.firstIndex].data,
+      var aggregateRow = data[data.firstIndex].data,
         totalDownloads = Highcharts.numberFormat(aggregateRow.downloads, 0),
         totalUsers = Highcharts.numberFormat(aggregateRow.updates, 0),
         startString = range.start.iso(),
@@ -55,14 +55,20 @@ export function stats_overview_make_handler({ view }) {
     }
     $('.two-up').removeClass('loading');
   };
-}
+};
 
 // `$` is passed by jQuery itself when calling `jQuery(stats_overview)`.
-if ($('.primary').attr('data-report') === 'overview') {
+export const stats_overview = function () {
+  console.debug('overview:stats_overview:init');
+  if ($('.primary').attr('data-report') != 'overview') {
+    return;
+  }
+
   // set up topcharts (defined in topchart.js)
   $('.toplist').topChart();
 
   $(window).on('changeview', function (e, view) {
+    console.debug('overview:window:changeview', view);
     $('.two-up').addClass('loading');
   });
 
@@ -75,4 +81,4 @@ if ($('.primary').attr('data-report') === 'overview') {
       stats_overview_make_handler({ view }),
     );
   });
-}
+};

--- a/static/js/stats/table.js
+++ b/static/js/stats/table.js
@@ -7,7 +7,7 @@ import { StatsManager } from './manager';
 
 $.fn.csvTable = function (cfg) {
   $(this).each(function () {
-    let $self = $(this),
+    var $self = $(this),
       $table = $self.find('table'),
       $thead = $self.find('thead'),
       $paginator = $self.find('.paginator'),
@@ -56,7 +56,7 @@ $.fn.csvTable = function (cfg) {
     }
 
     function showPage(page) {
-      let p = pages[page];
+      var p = pages[page];
       if (p) {
         $table.find('tbody').hide();
         p.el.show();
@@ -67,7 +67,7 @@ $.fn.csvTable = function (cfg) {
 
     function getPage(page) {
       if (pages[page] || page < 0) return;
-      let $def = $.Deferred(),
+      var $def = $.Deferred(),
         range = {
           end: Date.ago(pageSize * page + 'days'),
           start: Date.ago(pageSize * page + pageSize + 'days'),
@@ -78,14 +78,14 @@ $.fn.csvTable = function (cfg) {
           range: range,
         };
       $.when(StatsManager.getDataRange(view)).then(function (data) {
-        let fields = StatsManager.getAvailableFields(view),
+        var fields = StatsManager.getAvailableFields(view),
           newBody = '<tbody>',
           newPage = {},
           newHead = '<tr><th>' + gettext('Date') + '</th>',
           row;
 
         _.each(fields, function (f) {
-          let id = f.split('|').pop(),
+          var id = f.split('|').pop(),
             prettyName = _.escape(StatsManager.getPrettyName(metric, id)),
             trimmedPrettyName =
               prettyName.length > 32
@@ -96,7 +96,7 @@ $.fn.csvTable = function (cfg) {
           newHead += '</th>';
         });
 
-        let d = range.end.clone().backward('1 day'),
+        var d = range.end.clone().backward('1 day'),
           lastRowDate = range.start.clone().backward('1 day');
         for (; lastRowDate.isBefore(d); d.backward('1 day')) {
           row = data[d.iso()] || {};
@@ -109,7 +109,8 @@ $.fn.csvTable = function (cfg) {
             newBody += '<td>';
             if (metric == 'contributions' && f != 'count') {
               newBody +=
-                '$' + Highcharts.numberFormat(StatsManager.getField(row, f), 2);
+                '$' +
+                Highcharts.numberFormat(StatsManager.getField(row, f), 2);
             } else {
               newBody += Highcharts.numberFormat(
                 StatsManager.getField(row, f),

--- a/static/js/stats/topchart.js
+++ b/static/js/stats/topchart.js
@@ -5,7 +5,7 @@ import { normalizeRange } from './dateutils';
 import { template } from '../lib/format';
 import { StatsManager } from './manager';
 
-let baseConfig = {
+var baseConfig = {
   chart: {
     backgroundColor: null,
   },
@@ -43,7 +43,7 @@ let baseConfig = {
 
 $.fn.topChart = function (cfg) {
   $(this).each(function () {
-    let $self = $(this),
+    var $self = $(this),
       $win = $(window),
       $chart = $self.find('.piechart'),
       hChart,
@@ -56,6 +56,7 @@ $.fn.topChart = function (cfg) {
 
     // reload the data when the view's range is modified.
     $win.on('changeview', function (e, newView) {
+      console.debug('topchart:window:changeview', newView);
       // we only want to respond to changes in range.
       if (!newView.range) return;
       $self.addClass('loading');
@@ -75,7 +76,7 @@ $.fn.topChart = function (cfg) {
         $table.html('');
         return;
       }
-      let totalValue = 0,
+      var totalValue = 0,
         otherValue = 0;
       data = data[data.firstIndex].data;
       if (_.isEmpty(data)) return;
@@ -84,8 +85,8 @@ $.fn.topChart = function (cfg) {
         totalValue += val;
       });
       // Convert all fields to percentages and prettify names.
-      let rankedList = _.map(data, function (val, key) {
-        let field = key.split('|').slice(-1)[0];
+      var rankedList = _.map(data, function (val, key) {
+        var field = key.split('|').slice(-1)[0];
         return [
           StatsManager.getPrettyName(metric, field),
           val,
@@ -97,7 +98,7 @@ $.fn.topChart = function (cfg) {
         return -a[1];
       });
       // Calculate the 'Other' percentage
-      for (let i = 5; i < rankedList.length; i++) {
+      for (var i = 5; i < rankedList.length; i++) {
         otherValue += rankedList[i][1];
       }
       // Take the top 5 values and append an 'Other' row.
@@ -111,17 +112,20 @@ $.fn.topChart = function (cfg) {
       done(rankedList);
     }
 
-    let tableRow = template(
+    var tableRow = template(
       '<tr><td>{0}</td><td title="{3}">{1}</td><td>({2}%)</td></tr>',
     );
 
     function render(data) {
-      let newBody = '<tbody>';
+      var newBody = '<tbody>';
       _.each(data, function (row) {
-        let title = row[0];
-        let raw_value = row[1];
-        let value = Highcharts.numberFormat(raw_value, raw_value < 10 ? 1 : 0);
-        let percent = Highcharts.numberFormat(row[2], 0);
+        var title = row[0];
+        var raw_value = row[1];
+        var value = Highcharts.numberFormat(
+          raw_value,
+          raw_value < 10 ? 1 : 0,
+        );
+        var percent = Highcharts.numberFormat(row[2], 0);
 
         if (percent < 1) {
           percent = '<1';
@@ -133,7 +137,7 @@ $.fn.topChart = function (cfg) {
       $table.html(newBody);
 
       // set up chart.
-      let newConfig = _.clone(baseConfig),
+      var newConfig = _.clone(baseConfig),
         row;
       newConfig.chart.renderTo = $chart[0];
       newConfig.series[0].data = _.map(data, function (r) {
@@ -141,7 +145,7 @@ $.fn.topChart = function (cfg) {
       });
       hChart = new Highcharts.Chart(newConfig);
       for (let i = 0; i < data.length; i++) {
-        row = $table.find('tr').eq(i);
+        const row = $table.find('tr').eq(i);
         row
           .children()
           .eq(0)


### PR DESCRIPTION
Fixes: mozilla/addons#15515

### Description

This does 4 things:
- revert the files in `./static/js/stats` to https://github.com/mozilla/addons-server/tree/bdbcbcdd635a106d25cb65c42897b3fbc814ce9d/static/js/stats
- reapply surgical updates to make module graph work with vite and maintain removal of "z." state etc.
- add logs to all `changeview` events to debug on dev. (will be reverted before pushing)
- replace `typeof module === 'undefined'` calling of top level functions to direct calls in our bundle entrypoint

### Context

The statistics dashboard is broken and this is the fastest way to get the code back to its original state

### Testing

Follow these steps

https://github.com/mozilla/addons-server/pull/23274

You can verify that using `typeof module === 'undefined'` checks are not valid in vite bundles.

```javascript
console.log('module', typeof module);
```

This will return 'object' in production and 'undefined' in development. That is because in development we are loading modules with native ESM and in production we are using rollup bundled es modules. Rollup defines module but vite does not.

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
