### PR TITLE
add GCP token file to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -64,3 +64,6 @@ Makefile-os
 
 # Do not copy .git directory to docker images
 .git
+
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json


### PR DESCRIPTION
reference bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1959182