### PR TITLE
load stats_overview before stats_stats

### DIFF
--- a/static/js/stats.js
+++ b/static/js/stats.js
@@ -11,5 +11,5 @@ import { stats_stats } from './stats/stats';
 import { capabilities } from './zamboni/capabilities';
 
 // Initialize the stats module.
-stats_stats(window.sessionStorage, capabilities);
 stats_overview();
+stats_stats(window.sessionStorage, capabilities);

--- a/static/js/stats/topchart.js
+++ b/static/js/stats/topchart.js
@@ -42,6 +42,7 @@ var baseConfig = {
 };
 
 $.fn.topChart = function (cfg) {
+  console.debug('topchart:init');
   $(this).each(function () {
     var $self = $(this),
       $win = $(window),


### PR DESCRIPTION
Fixes: mozilla/addons#15515

### Description

Ensure we load stats overview before triggering the changeview event which stats over view dependson.

### Context

Various places rely on $().on('changeview') to update the chart UI client side (reactive programming eh)

The problem here is we rely on a single trigger of that event in the `stats_sats` function. This ensures all the event listeners are called at least once with the initial state to render the correct stuff. That trigger was happening before we setup the topChart listener so the top chart is not rendered initially but is rendered on subsequent events.

### Testing

TBD

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
