### PR TITLE
Update Elasticsearch local image to 8.x, enable compatibility mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ ENV NPM_DEPS_DIR=${HOME}/node_modules
 ENV VITE_MANIFEST_FILE_NAME=manifest.json
 ENV STATIC_URL_PREFIX=/static-server/
 ENV MEDIA_URL_PREFIX=/user-media/
+ENV ELASTIC_CLIENT_APIVERSIONING=1
 RUN <<EOF
 groupadd -g ${OLYMPIA_UID} olympia
 useradd -u ${OLYMPIA_UID} -g ${OLYMPIA_UID} -s /sbin/nologin -d ${HOME} olympia

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ x-env-mapping: &env
     - CELERY_RESULT_BACKEND=redis://redis:6379/1
     - DATABASES_DEFAULT_URL=mysql://root:@mysqld/olympia
     - ELASTICSEARCH_LOCATION=elasticsearch:9200
+    - ELASTIC_CLIENT_APIVERSIONING=1
     - MEMCACHE_LOCATION=memcached:11211
     - MYSQL_DATABASE=olympia
     - MYSQL_ROOT_PASSWORD=docker
@@ -139,14 +140,13 @@ services:
       retries: 3
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.27@sha256:e3db87aef5d115408b36e3d5bbd309629100597462910d6b5efec70fcfead22a
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.17.4@sha256:413d8df69823e9f41f6008f025fcbaf31a5849ab9c74894731d7ded65543cd56
     environment:
       # Disable all xpack related features to avoid unrelated logging
       # in docker logs. https://github.com/mozilla/addons-server/issues/8887
       # This also avoids us to require authentication for local development
       # which simplifies the setup.
       - xpack.security.enabled=false
-      - xpack.monitoring.enabled=false
       - xpack.graph.enabled=false
       - xpack.watcher.enabled=false
       - "discovery.type=single-node"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ x-env-mapping: &env
     - CELERY_RESULT_BACKEND=redis://redis:6379/1
     - DATABASES_DEFAULT_URL=mysql://root:@mysqld/olympia
     - ELASTICSEARCH_LOCATION=elasticsearch:9200
-    - ELASTIC_CLIENT_APIVERSIONING=1
     - MEMCACHE_LOCATION=memcached:11211
     - MYSQL_DATABASE=olympia
     - MYSQL_ROOT_PASSWORD=docker

--- a/src/olympia/search/tests/test_search_ranking.py
+++ b/src/olympia/search/tests/test_search_ranking.py
@@ -803,7 +803,7 @@ class TestRankingScenarios(ESTestCase):
         # Doesn't find "RapidShare DownloadHelper" anymore
         # since we now query by "MegaUpload AND DownloadHelper"
         self._check_scenario(
-            'MegaUpload DownloadHelper', (['MegaUpload DownloadHelper', 5241],)
+            'MegaUpload DownloadHelper', (['MegaUpload DownloadHelper', 4772],)
         )
 
     def test_scenario_downloadhelper(self):


### PR DESCRIPTION
ELASTIC_CLIENT_APIVERSIONING=1 forces our client libraries to send headers requesting compatibility with 7.x requests/responses, so we don't have to upgrade them yet and can wait for dev/stage/prod to be switched over.

Fixes https://github.com/mozilla/addons/issues/15351

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Testing

Should be transparent, although the first `make up` might take longer (or even initially fail until re-triggered, because the cluster takes too long to come online initially) to update the cluster.

You can do a few searches, make some updates to add-ons and see the updates being reflected in search results (excluding API caching).