### PR TITLE
Remove 3rd party dependencies from health_check

### DIFF
--- a/.github/workflows/health_check.yml
+++ b/.github/workflows/health_check.yml
@@ -14,34 +14,58 @@ env:
   health_check_blocks_file: health_check_blocks.json
 
 jobs:
+  context:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.context.outputs.matrix }}
+    steps:
+      - name: Set Context
+        id: context
+        shell: bash
+        run: |
+          is_test="${{ github.event_name == 'push' }}"
+          if [[ "${is_test}" == "true" ]]; then
+            matrix='["host"]'
+          else
+            matrix='["dev","stage","prod"]'
+          fi
+
+          echo "is_test=${is_test}" >> "$GITHUB_OUTPUT"
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"
+
   health_check:
+    needs: context
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        environment: ${{fromJson(github.event_name == 'push' && '["local"]' || '["dev","stage","prod"]')}}
+        environment: ${{ fromJson(needs.context.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Run health check
-        id: health_check
-        continue-on-error: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Set waffle switch dummy-monitor-fails to true
+        if: matrix.environment == 'host'
         uses: ./.github/actions/run-docker
         with:
           version: local
           run: |
-            # On local, we want to ensure there are failures to test
-            # the later steps with so set the waffle switch to on.
-            if [ "${{ matrix.environment }}" = "local" ]; then
-              echo "Set waffle switch dummy-monitor-fails to true"
-              ./manage.py waffle_switch dummy-monitor-fails on
-            fi
+            ./manage.py waffle_switch dummy-monitor-fails on
 
-            ./scripts/health_check.py \
-            --env ${{ matrix.environment }} \
-            --verbose \
-            --output ${{ env.health_check_file }}
+      - name: Run health check
+        continue-on-error: true
+        id: health_check
+        shell: bash
+        run: |
+          ./scripts/health_check.py \
+          --env ${{ matrix.environment }} \
+          --verbose \
+          --output ${{ env.health_check_file }}
 
       - name: Set message blocks
         id: blocks


### PR DESCRIPTION
Fixes: mozilla/addons#15523


### Description

health check should not require make up except on push events.

### Context

make up running every 5 minutes is flaky because our setup relies too much on internet connectivity and not strong enough caching.

Until we fix that, we cannot reliably run the healthcheck in our own containers and should run it in the top level action container.

### Testing

Run locally on your host, it should not require any pip dependencies.. if you want to be super careful you can run in a virtual environment or an empty python docker container.

I set the push event to use prod environment [here](https://github.com/mozilla/addons-server/actions/runs/14386059632/job/40341673428?pr=23300) and you can see it skipped make up and ran in 30 seconds.

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
