### PR TITLE
Remove duplicate entry for github-actions in .dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,10 +20,6 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 99
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: daily
 - package-ecosystem: pip
   directory: "/requirements"
   schedule:


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/15550