### PR TITLE
Add PromotedGroupAdmin

### DIFF
--- a/src/olympia/constants/permissions.py
+++ b/src/olympia/constants/permissions.py
@@ -177,6 +177,7 @@ DJANGO_PERMISSIONS_MAPPING.update(
         'discovery.add_discoveryaddon': DISCOVERY_EDIT,
         'discovery.change_discoveryaddon': DISCOVERY_EDIT,
         'discovery.delete_discoveryaddon': DISCOVERY_EDIT,
+        'discovery.view_discoverypromotedgroup': DISCOVERY_EDIT,
         'files.change_file': ADMIN_ADVANCED,
         'files.change_webextpermission': ADMIN_ADVANCED,
         'files.change_filevalidation': ADMIN_ADVANCED,

--- a/src/olympia/discovery/admin.py
+++ b/src/olympia/discovery/admin.py
@@ -24,7 +24,9 @@ from olympia.hero.models import PrimaryHeroImage, SecondaryHero
 from olympia.promoted.admin import (
     PromotedAddonPromotionAdminInline,
     PromotedAddonVersionInline,
+    PromotedGroupAdmin,
 )
+from olympia.promoted.models import PromotedGroup
 from olympia.shelves.admin import ShelfAdmin
 from olympia.shelves.models import Shelf
 
@@ -203,6 +205,11 @@ class DiscoveryAddon(Addon):
         proxy = True
 
 
+class DiscoveryPromotedGroup(PromotedGroup):
+    class Meta:
+        proxy = True
+
+
 DISCOVERY_ADDON_FIELDS = ['__str__', 'addon', 'guid', 'has_promotions']
 
 
@@ -244,6 +251,7 @@ class DiscoveryAddonAdmin(AMOModelAdmin):
 
 
 admin.site.register(DiscoveryAddon, DiscoveryAddonAdmin)
+admin.site.register(DiscoveryPromotedGroup, PromotedGroupAdmin)
 admin.site.register(DiscoveryItem, DiscoveryItemAdmin)
 admin.site.register(PrimaryHeroImageUpload, PrimaryHeroImageAdmin)
 admin.site.register(SecondaryHeroShelf, SecondaryHeroAdmin)

--- a/src/olympia/promoted/admin.py
+++ b/src/olympia/promoted/admin.py
@@ -120,26 +120,23 @@ class PromotedAddonPromotionAdminInline(admin.TabularInline):
         return super().has_delete_permission(request=request, obj=obj)
 
 
-PROMOTED_GROUP_FIELDS = [
-    'name',
-    'listed_pre_review',
-    'unlisted_pre_review',
-    'admin_review',
-    'badged',
-    'can_primary_hero',
-    'flag_for_human_review',
-    'can_be_compatible_with_all_fenix_versions',
-    'high_profile',
-    'high_profile_rating',
-    'search_ranking_bump',
-    'active',
-]
-
-
 class PromotedGroupAdmin(AMOModelAdmin):
     model = PromotedGroup
-    list_display = PROMOTED_GROUP_FIELDS
-    list_filter = PROMOTED_GROUP_FIELDS
+    list_display = [
+        'name',
+        'listed_pre_review',
+        'unlisted_pre_review',
+        'admin_review',
+        'badged',
+        'can_primary_hero',
+        'flag_for_human_review',
+        'can_be_compatible_with_all_fenix_versions',
+        'high_profile',
+        'high_profile_rating',
+        'search_ranking_bump',
+        'active',
+    ]
+    list_filter = list_display
     search_fields = ('name',)
 
     def has_add_permission(self, request, obj=None):

--- a/src/olympia/promoted/admin.py
+++ b/src/olympia/promoted/admin.py
@@ -3,6 +3,7 @@ from django.db.models import Prefetch, Q
 from django.forms.models import modelformset_factory
 
 from olympia.addons.models import Addon
+from olympia.amo.admin import AMOModelAdmin
 from olympia.constants.promoted import PROMOTED_GROUP_CHOICES
 from olympia.hero.models import PrimaryHero
 from olympia.versions.models import Version
@@ -117,3 +118,35 @@ class PromotedAddonPromotionAdminInline(admin.TabularInline):
         if shelf and shelf.enabled and qs.count() == 1:
             return False
         return super().has_delete_permission(request=request, obj=obj)
+
+
+PROMOTED_GROUP_FIELDS = [
+    'name',
+    'listed_pre_review',
+    'unlisted_pre_review',
+    'admin_review',
+    'badged',
+    'can_primary_hero',
+    'flag_for_human_review',
+    'can_be_compatible_with_all_fenix_versions',
+    'high_profile',
+    'high_profile_rating',
+    'search_ranking_bump',
+    'active',
+]
+
+
+class PromotedGroupAdmin(AMOModelAdmin):
+    model = PromotedGroup
+    list_display = PROMOTED_GROUP_FIELDS
+    list_filter = PROMOTED_GROUP_FIELDS
+    search_fields = ('name',)
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False


### PR DESCRIPTION
Fixes: mozilla/addons#15526

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Adds a PromotedGroupAdmin under Discovery to view promoted groups.

![image](https://github.com/user-attachments/assets/a4b49187-13b9-4f6a-8508-4b4695738ca1)

<!--
Your PR will be squashed when merged so the 1st commit must contain a descriptive and concise summary of the change.
Additional details should be added in the description. If your change is simple enough to summarize in the commit, or
if it is not relevant for your PR, remove this section.
-->

### Testing

1. Navigate to the admin.
2. Under the Discovery section, navigate to 'Discovery Promoted Groups.'
3. Promoted groups should be visible. New ones cannot be created. Existing ones cannot be deleted or edited.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [x] Add before and after screenshots (Only for changes that impact the UI).
