### PR TITLE
migrate PrimaryHero model to use addon instead of promoted_addon in a migration safe way

### DIFF
--- a/src/olympia/hero/migrations/0020_primaryhero_addon.py
+++ b/src/olympia/hero/migrations/0020_primaryhero_addon.py
@@ -36,12 +36,4 @@ class Migration(migrations.Migration):
             name='addon',
             field=models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, to='addons.addon', null=True),
         ),
-        # Migrate promoted_addon to addon
-        migrations.RunPython(primary_hero_addon_up, primary_hero_addon_down),
-        # Make the addon field non-nullable after populating the existing data
-        migrations.AlterField(
-            model_name='primaryhero',
-            name='addon',
-            field=models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, to='addons.addon', null=False),
-        ),
     ]

--- a/src/olympia/hero/models.py
+++ b/src/olympia/hero/models.py
@@ -179,7 +179,7 @@ class PrimaryHero(ModelBase):
     promoted_addon = models.OneToOneField(
         PromotedAddon, on_delete=models.CASCADE, null=True
     )
-    addon = models.OneToOneField(Addon, on_delete=models.CASCADE, null=False)
+    addon = models.OneToOneField(Addon, on_delete=models.CASCADE, null=True)
 
     is_external = models.BooleanField(default=False)
 

--- a/src/olympia/hero/tasks.py
+++ b/src/olympia/hero/tasks.py
@@ -1,0 +1,20 @@
+from olympia.hero.models import PrimaryHero
+from olympia.amo.celery import task
+from olympia.amo.decorators import use_primary_db
+
+@task()
+@use_primary_db
+def sync_primary_hero_addon():
+    invalid_heroes = []
+    for hero in PrimaryHero.objects.filter(addon__isnull=True):
+        promoted_addon = hero.promoted_addon
+
+        if promoted_addon is None:
+            invalid_heroes.append(hero)
+        else:
+            hero.addon = promoted_addon.addon
+            hero.save()
+
+    if len(invalid_heroes) > 0:
+        raise ValueError(f'{invalid_heroes} heroes have no addon or legacy promoted addon')
+

--- a/src/olympia/hero/tasks.py
+++ b/src/olympia/hero/tasks.py
@@ -1,8 +1,13 @@
-from olympia.hero.models import PrimaryHero
+import olympia.core.logger
 from olympia.amo.celery import task
 from olympia.amo.decorators import use_primary_db
+from olympia.hero.models import PrimaryHero
 
-@task()
+
+log = olympia.core.logger.getLogger('z.hero')
+
+
+@task
 @use_primary_db
 def sync_primary_hero_addon():
     invalid_heroes = []
@@ -12,9 +17,9 @@ def sync_primary_hero_addon():
         if promoted_addon is None:
             invalid_heroes.append(hero)
         else:
+            log.info(f'Syncing hero {hero} with promoted addon {hero.promoted_addon}')
             hero.addon = promoted_addon.addon
             hero.save()
 
     if len(invalid_heroes) > 0:
-        raise ValueError(f'{invalid_heroes} heroes have no addon or legacy promoted addon')
-
+        log.error(f'Invalid PrimaryHero records: {invalid_heroes}')

--- a/src/olympia/hero/tests/test_tasks.py
+++ b/src/olympia/hero/tests/test_tasks.py
@@ -36,14 +36,9 @@ class TestSyncPrimaryHeroAddon(TestCase):
         or a promoted addon. This should not happen, but we should handle the edge case
         until we have removed the legacy promoted_addon field.
         """
-        addon_factory()
-        hero = PrimaryHero.objects.create()
+        PrimaryHero.objects.create()
 
-        with self.assertRaises(
-            ValueError,
-            msg=f'{hero} heroes have no addon or legacy promoted addon'
-        ):
+        with self.assertLogs(logger='z.hero', level='ERROR') as cm:
             sync_primary_hero_addon.apply()
 
-
-
+        assert 'Invalid PrimaryHero records' in cm.output[0]

--- a/src/olympia/hero/tests/test_tasks.py
+++ b/src/olympia/hero/tests/test_tasks.py
@@ -1,0 +1,49 @@
+from olympia.amo.tests import TestCase, addon_factory
+from olympia.hero.models import PrimaryHero
+from olympia.hero.tasks import sync_primary_hero_addon
+from olympia.promoted.models import PromotedAddon
+
+
+class TestSyncPrimaryHeroAddon(TestCase):
+    def test_no_heros(self):
+        assert PrimaryHero.objects.count() == 0
+        sync_primary_hero_addon.apply()
+        assert PrimaryHero.objects.count() == 0
+
+    def test_with_legacy_promoted_addon(self):
+        addon = addon_factory()
+        # Create legacy promoted_addon
+        promoted_addon = PromotedAddon.objects.create(addon=addon)
+        # Also make the addon promoted with the new promoted addon model
+        self.make_addon_promoted(addon, 1)
+        hero = PrimaryHero.objects.create(promoted_addon=promoted_addon)
+        sync_primary_hero_addon.apply()
+        hero.reload()
+        assert hero.addon == addon
+
+    def test_with_new_promoted_addon(self):
+        addon = addon_factory()
+        self.make_addon_promoted(addon, 1)
+        hero = PrimaryHero.objects.create(addon=addon)
+        sync_primary_hero_addon.apply()
+        hero.reload()
+        assert hero.addon == addon
+
+    def test_with_no_addon_or_legacy_promoted_addon_should_raise(self):
+        """
+        During the transition to using `addon` instead of `promoted_addon`,
+        It is possible that there are some heroes that have neither an addon
+        or a promoted addon. This should not happen, but we should handle the edge case
+        until we have removed the legacy promoted_addon field.
+        """
+        addon_factory()
+        hero = PrimaryHero.objects.create()
+
+        with self.assertRaises(
+            ValueError,
+            msg=f'{hero} heroes have no addon or legacy promoted addon'
+        ):
+            sync_primary_hero_addon.apply()
+
+
+

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -779,6 +779,7 @@ CELERY_TASK_ROUTES = {
     'olympia.users.tasks.resize_photo': {'queue': 'amo'},
     'olympia.users.tasks.update_user_ratings_task': {'queue': 'amo'},
     'olympia.versions.tasks.delete_preview_files': {'queue': 'amo'},
+    'olympia.hero.tasks.sync_primary_hero_addon': {'queue': 'amo'},
     # 'Default' queue. In theory shouldn't be used, it's mostly a fallback.
     'celery.accumulate': {'queue': 'default'},
     'celery.backend_cleanup': {'queue': 'default'},

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -743,6 +743,7 @@ CELERY_TASK_ROUTES = {
     'olympia.files.tasks.backfill_file_manifest': {'queue': 'adhoc'},
     'olympia.files.tasks.extract_host_permissions': {'queue': 'adhoc'},
     'olympia.lib.crypto.tasks.bump_and_resign_addons': {'queue': 'adhoc'},
+    'olympia.hero.tasks.sync_primary_hero_addon': {'queue': 'adhoc'},
     # Misc AMO tasks.
     'olympia.blocklist.tasks.monitor_remote_settings': {'queue': 'amo'},
     'olympia.abuse.tasks.appeal_to_cinder': {'queue': 'amo'},
@@ -779,7 +780,6 @@ CELERY_TASK_ROUTES = {
     'olympia.users.tasks.resize_photo': {'queue': 'amo'},
     'olympia.users.tasks.update_user_ratings_task': {'queue': 'amo'},
     'olympia.versions.tasks.delete_preview_files': {'queue': 'amo'},
-    'olympia.hero.tasks.sync_primary_hero_addon': {'queue': 'amo'},
     # 'Default' queue. In theory shouldn't be used, it's mostly a fallback.
     'celery.accumulate': {'queue': 'default'},
     'celery.backend_cleanup': {'queue': 'default'},


### PR DESCRIPTION
Fixes: mozilla/addons#15557

### Description

- Changed the `addon` field in the `PrimaryHero` model to be nullable to be able to continue querying before the migration is complete
- Introduced a new task `sync_primary_hero_addon` to synchronize the `addon` field with the `promoted_addon` where applicable.

### Context

We tried running the migraiton via a single migration script. This can fail if the RunPython script executes before the database commits the new field.

Additionally, if there are a lot of PrimaryHero records the script can take an arbitrarily long time to run. Safer to use a task.

That means we need to revert the null constraint on addon until after this commit lands and the task is run. That is fine for now since all records will still have the promoted_addon field.

### Testing

Look at the unit tests. There are 2 scenarios:

- hero with promoted_addon without addon (the standard before case)
- hero with promoted_addon and addon (the standard after case)
- hero with addon and no promoted addon (non-standard but okay since we only care about addon from now on)
- hero with neither (non standard edge case that should never happen

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
