### PR TITLE
Don't inherit due date and/or NeedsHumanReview for ABUSE_ADDON_VIOLATION/CINDER_ESCALATION

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -307,6 +307,7 @@ class AddonManager(ManagerBase):
         theme_review=False,
         show_temporarily_delayed=True,
         show_only_upcoming=False,
+        due_date_reasons_choices=None,
     ):
         filters = {
             'type__in': amo.GROUP_TYPE_THEME if theme_review else amo.GROUP_TYPE_ADDON,
@@ -359,13 +360,29 @@ class AddonManager(ManagerBase):
                     & ~Q(**{listed_delay_flag_field: datetime.max})
                 )
             )
+        version_subqs = versions_due_qs.all()
+        if due_date_reasons_choices:
+            versions_filter = Q(
+                versions__needshumanreview__reason__in=due_date_reasons_choices.values
+            )
+            version_subqs = version_subqs.filter(
+                needshumanreview__reason__in=due_date_reasons_choices.values
+            )
+        else:
+            versions_filter = None
         qs = (
             qs.filter(**filters)
             .annotate(
-                first_version_due_date=Min('versions__due_date'),
-                first_version_id=Subquery(
-                    versions_due_qs.filter(addon=OuterRef('pk')).values('pk')[:1]
+                # We need both first_version_due_date and first_version_id to
+                # be set and have the same behavior. The former is used for
+                # grouping (hence the Min()) and provides a way for callers to
+                # sort this queryset by due date, the latter to filter add-ons
+                # matching the reasons we care about and to instantiate the
+                # right Version in first_pending_version_transformer().
+                first_version_due_date=Min(
+                    'versions__due_date', filter=versions_filter
                 ),
+                first_version_id=Subquery(version_subqs.values('pk')[:1]),
                 **{
                     name: Exists(versions_due_qs.filter(q))
                     for name, q in (

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -768,6 +768,21 @@ class Addon(OnChangeMixin, ModelBase):
             version.reset_due_date(due_date)
         return version
 
+    def versions_triggering_needs_human_review_inheritance(self, channel):
+        """Return queryset of Versions belonging to this addon in the specified
+        channel that should be considered for due date and NeedsHumanReview
+        inheritance."""
+        from olympia.reviewers.models import NeedsHumanReview
+
+        reasons_triggering_inheritance = set(
+            NeedsHumanReview.REASONS.values.keys()
+        ) - set(NeedsHumanReview.REASONS.NO_DUE_DATE_INHERITANCE.values.keys())
+        return self.versions(manager='unfiltered_for_relations').filter(
+            channel=channel,
+            needshumanreview__is_active=True,
+            needshumanreview__reason__in=reasons_triggering_inheritance,
+        )
+
     @property
     def is_guid_denied(self):
         return DeniedGuid.objects.filter(guid=self.guid).exists()

--- a/src/olympia/reviewers/models.py
+++ b/src/olympia/reviewers/models.py
@@ -933,6 +933,13 @@ class NeedsHumanReview(ModelBase):
             'SECOND_LEVEL_REQUEUE',
         ),
     )
+    REASONS.add_subset(
+        'NO_DUE_DATE_INHERITANCE',
+        (
+            'ABUSE_ADDON_VIOLATION',
+            'CINDER_ESCALATION',
+        ),
+    )
 
     reason = models.SmallIntegerField(
         default=0, choices=REASONS.choices, editable=False

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -115,7 +115,14 @@ class PendingManualApprovalQueueTable(AddonQueueTable):
         orderable = True
 
     @classmethod
-    def get_queryset(cls, request, *, upcoming_due_date_focus=False, **kwargs):
+    def get_queryset(
+        cls,
+        request,
+        *,
+        upcoming_due_date_focus=False,
+        due_date_reasons_choices=None,
+        **kwargs,
+    ):
         if request is None:
             admin_reviewer = True
             show_temporarily_delayed = True
@@ -132,6 +139,7 @@ class PendingManualApprovalQueueTable(AddonQueueTable):
             admin_reviewer=admin_reviewer,
             show_temporarily_delayed=show_temporarily_delayed,
             show_only_upcoming=show_only_upcoming,
+            due_date_reasons_choices=due_date_reasons_choices,
         )
 
     def get_version(self, record):
@@ -172,10 +180,12 @@ class ThemesQueueTable(PendingManualApprovalQueueTable):
         )
 
     @classmethod
-    def get_queryset(cls, request, **kwargs):
+    def get_queryset(cls, request, due_date_reasons_choices=None, **kwargs):
         admin_reviewer = is_admin_reviewer(request.user) if request else True
         return Addon.objects.get_queryset_for_pending_queues(
-            admin_reviewer=admin_reviewer, theme_review=True
+            admin_reviewer=admin_reviewer,
+            theme_review=True,
+            due_date_reasons_choices=due_date_reasons_choices,
         )
 
 


### PR DESCRIPTION
*Only* for those reasons: as soon as a version has more reasons for needing human review its due date (and NHR itself) can be inherited from again.

Fixes https://github.com/mozilla/addons/issues/15535

### Testing

Scenario 1:
- Pick a recommended add-on with a listed version already public
- Report that add-on for policy violation inside the add-on. That should trigger a Needs Human Review for the current version of the add-on, for `ABUSE_ADDON_VIOLATION` reason. You should see the add-on in the manual review queue with a due date.
- Submit a new version for that add-on. Run `auto_approve` command, and you should see that the version is not auto-approved (because the add-on is recommended).
- If you refresh the manual review queue and filter out `Reported for abuse within the add-on` you should still see the add-on, now that it has a new version. Its due date should not be the same as the one it had before.
- You can check the review page for the add-on, and both versions should have a different due date.

Scenario 2:
- Pick a non promoted add-on with a listed version already public
- Report that add-on for policy violation inside the add-on. That should trigger a Needs Human Review for the current version of the add-on, for `ABUSE_ADDON_VIOLATION` reason. You should see the add-on in the manual review queue with a due date.
- Submit a new version for that add-on. Run `auto_approve` command, and you should see that the version is auto-approved.
- If you refresh the manual review queue and filter out `Reported for abuse within the add-on` you should not see the add-on. If you check that filter you should see it.
- You can check the review page for the add-on, and only the old version should have a due date.

Scenario 3 (unchanged from before):
- Pick a non promoted add-on with a listed version already public
- In review page for this add-on, set Needs Human Review for the latest version of that add-on. The version should get a due date.
- Submit a new version for that add-on. Run `auto_approve` command, and you should see that the version is auto-approved.
- You can check the review page for the add-on, and both versions should have a due date. The new version should have been flagged for `Previous version in channel had needs human review set`