### PR TITLE
fix Expression injection in Actions

### DIFF
--- a/.github/actions/context/action.yml
+++ b/.github/actions/context/action.yml
@@ -65,6 +65,9 @@ runs:
       env:
         # The default branch of the repository, in this case "master"
         default_branch: ${{ github.event.repository.default_branch }}
+        GITHUB_REF_NAME: ${{ github.ref_name }}
+        HEAD_REF: ${{ github.head_ref }}
+        RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
       shell: bash
       run: |
         event_name="${{ github.event_name }}"
@@ -74,10 +77,10 @@ runs:
         # https://stackoverflow.com/questions/64781462/github-actions-default-branch-variable
         is_default_branch="${{ format('refs/heads/{0}', env.default_branch) == github.ref }}"
 
-        # In most events, the epository refers to the head which would be the fork
+        # In most events, the repository refers to the head which would be the fork
         is_fork="${{ github.event.repository.fork }}"
         # Default version is the branch name
-        docker_version="${{ github.ref_name }}"
+        docker_version="$GITHUB_REF_NAME"
 
         # This is different in a pull_request where we need to check the head explicitly
         if [[ "${{ github.event_name }}" == 'pull_request' ]]; then
@@ -87,7 +90,7 @@ runs:
           is_dependabot="${{ github.actor == 'dependabot[bot]' }}"
 
           # For PRs we need to reference the head branch
-          docker_version="${{ github.head_ref }}"
+          docker_version="$HEAD_REF"
 
           # If the head repository is a fork or if the PR is opened by dependabot
           # we consider the run to be a fork. Dependabot and proper forks are treated
@@ -115,7 +118,7 @@ runs:
             is_release_tag="true"
 
             # If we are releasing a tag, we tag the docker version as the git tag
-            docker_version="${{ github.event.release.tag_name }}"
+            docker_version="$RELEASE_TAG_NAME"
           fi
         fi
 


### PR DESCRIPTION
https://github.com/mozilla/addons-server/blob/c9a6ce1ff19a3a86834d5f194dc910d091c6c03b/.github/actions/context/action.yml#L69-L129

fix the issue will follow the recommended best practice of assigning the untrusted input (`${{ github.head_ref }}`) to an environment variable and referencing it using shell syntax (`$VAR`). This approach ensures that the input is treated as a literal string by the shell, mitigating the risk of command injection.

Specifically:
1. Replace the direct use of `${{ github.head_ref }}` in the script with an environment variable (e.g., `HEAD_REF`).
2. Reference the environment variable using `$HEAD_REF` in the script.

Using user-controlled input in GitHub Actions may lead to code injection in contexts like run: or script:. Code injection in GitHub Actions may allow an attacker to exfiltrate any secrets used in the workflow and the temporary GitHub repository authorization token. The token might have write access to the repository, allowing an attacker to use the token to make changes to the repository.

The following lets a user inject an arbitrary shell command:
```
on: issue_comment

jobs:
  echo-body:
    runs-on: ubuntu-latest
    steps:
    - run: |
        echo '${{ github.event.comment.body }}'
```
The following uses an environment variable, but still allows the injection because of the use of expression syntax:
```
on: issue_comment

jobs:
  echo-body:
    runs-on: ubuntu-latest
    steps:
    -  env:
        BODY: ${{ github.event.issue.body }}
      run: |
        echo '${{ env.BODY }}'
```
The following uses shell syntax to read the environment variable and will prevent the attack:
```
on: issue_comment

jobs:
  echo-body:
    runs-on: ubuntu-latest
    steps:
    - env:
        BODY: ${{ github.event.issue.body }}
      run: |
        echo "$BODY"
```
## References
[Keeping your GitHub Actions and workflows secure: Untrusted input](https://securitylab.github.com/research/github-actions-untrusted-input)
[Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
[Permissions for the GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
[CWE-94](https://cwe.mitre.org/data/definitions/94.html)

- [ ] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [x] Add or update relevant [docs](../docs/) reflecting the changes made.
