### PR TITLE
Allow selecting "AMO_CLOSED_NO_ACTION" policies when resolving jobs in reviewer tools

### DIFF
--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -485,14 +485,14 @@ class ReviewForm(forms.Form):
 
     def clean(self):
         super().clean()
-        # If the user select a different type of job before changing actions there could
-        # be non-appeal jobs selected as cinder_jobs_to_resolve under resolve_appeal_job
-        # action, or appeal jobs under resolve_reports_job action. So filter them out.
         if self.cleaned_data.get('attachment_input') and self.cleaned_data.get(
             'attachment_file'
         ):
-            raise ValidationError('Cannot upload both a file and input.')
+            self.add_error('attachment_input', 'Cannot upload both a file and input.')
         selected_action = self.cleaned_data.get('action')
+        # If the user select a different type of job before changing actions there could
+        # be non-appeal jobs selected as cinder_jobs_to_resolve under resolve_appeal_job
+        # action, or appeal jobs under resolve_reports_job action. So filter them out.
         if selected_action == 'resolve_appeal_job':
             self.cleaned_data['cinder_jobs_to_resolve'] = [
                 job
@@ -512,12 +512,14 @@ class ReviewForm(forms.Form):
                 self.cleaned_data.get('cinder_policies')
             )
             if len(actions) == 0:
-                raise ValidationError(
-                    'No policies selected with an associated cinder action.'
+                self.add_error(
+                    'cinder_policies',
+                    'No policies selected with an associated cinder action.',
                 )
             elif len(actions) > 1:
-                raise ValidationError(
-                    'Multiple policies selected with different cinder actions.'
+                self.add_error(
+                    'cinder_policies',
+                    'Multiple policies selected with different cinder actions.',
                 )
 
         if self.helper.actions.get(selected_action, {}).get('delayable'):

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -102,9 +102,6 @@
 <form method="POST" enctype="multipart/form-data" action="#review-actions" class="review-form">
   {% csrf_token %}
 
-  <input type="hidden" name="version_pk" value="{{ version.pk }}"/>
-  {{ form.version_pk.errors }}
-
   <div id="review-files-header">
     <h3 id="history">
       Add-on History
@@ -140,6 +137,12 @@
         You don't have permission to review it.
       {% endif %}
     </p>
+  {% endif %}
+
+  <input type="hidden" name="version_pk" value="{{ version.pk }}"/>
+  {{ form.version_pk.errors }}
+  {% if form.errors.__all__ %}
+    {{ form.errors.__all__ }}
   {% endif %}
 
   <div id="review-actions" class="review-actions">

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -1110,7 +1110,11 @@ class ReviewBase:
         return [
             action
             for action in actions
-            if action in (DECISION_ACTIONS.AMO_APPROVE, DECISION_ACTIONS.AMO_IGNORE)
+            if action
+            in (
+                *DECISION_ACTIONS.NON_OFFENDING.values,
+                DECISION_ACTIONS.AMO_CLOSED_NO_ACTION,
+            )
         ]
 
     def log_action(


### PR DESCRIPTION
Also make error handling for the review form a little more explicit to make debugging such issues easier in the future.

Fixes https://github.com/mozilla/addons/issues/15574

### Context

We have a policy in prod that is configured to trigger `AMO_CLOSED_NO_ACTION` decision action, which should be used to close jobs that were created for content that has since already been moderated. It has been enabled for reviewers, but using it doesn't work because we have a specific allow-list on our side (that is a temporary safeguard that will eventually be removed, but it's still here at the moment).

On top of that, the error was hidden because we didn't show global form errors, making the issue very confusing for reviewers.

### Testing

- Enable all cinder-related waffle switches
- In the admin ensure you have a Cinder Policy with `"amo-closed-no-action"` as the only `enforcement_actions`, and make that policy exposed in Reviewer Tools by flipping the checkbox. (If you trigger a sync with dev right now, `Ignore, specifically Content already moderated` should be configured with that enforcement action already, you just need to enable it in reviewer tools)
- Report an add-on for policy violation inside the add-on
- Go to that add-on review page
- Select "Resolve reports", picking the job for that report you just made
- Select the Policy mentioned above
- Submit

Expected result:
- Job should be closed, action recorded in activity log