### PR TITLE
Fix broken settings import in review_reports command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ select = [
     "I",  # isort
     "Q",  # flake8-quotes
     "W",  # pycodestyle warnings
+    "TID251",  # banned imports
 ]
 
 [tool.ruff.lint.flake8-quotes]
@@ -56,6 +57,9 @@ lines-after-imports = 2
 section-order = ["future", "standard-library", "django", "third-party", "first-party", "local-folder"]
 [tool.ruff.lint.isort.sections]
 "django" = ["django"]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"settings".msg = "`settings` is a module at the root of the project. Did you mean from `django.conf import settings` instead?"
 
 [tool.ruff.format]
 quote-style = "single"

--- a/src/olympia/reviewers/management/commands/review_reports.py
+++ b/src/olympia/reviewers/management/commands/review_reports.py
@@ -1,12 +1,12 @@
 import os
 from datetime import date, timedelta
 
+from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.db import connection
 from django.utils.encoding import force_str
 
 import olympia.core.logger
-import settings
 from olympia import amo
 from olympia.amo.utils import send_mail
 from olympia.constants.reviewers import (


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/15543

### Testing

This is annoying to test locally or in CI: It fails in dev/stage/prod prod because `import settings` actually imports `./settings.py`, which in turn fails when we try to evaluate `SITE_URL` since it's set to `env('SITE_URL')` and there is no such environment variable on dev/stage/prod. Locally and in CI that variable _is_ set through `docker-compose.yml`.

I triggered the command on dev, it failed, then applied this patch, it worked.