### PR TITLE
Ignore all decisions that originated from the api

### DIFF
--- a/src/olympia/abuse/tests/assets/cinder_webhook_payloads/proactive_decision_from_amo.json
+++ b/src/olympia/abuse/tests/assets/cinder_webhook_payloads/proactive_decision_from_amo.json
@@ -1,0 +1,69 @@
+{
+    "event": "decision.created",
+    "payload": {
+      "appeals_resolved": [],
+      "enforcement_actions": [
+        "amo-reject-version-addon"
+      ],
+      "enforcement_actions_removed": [],
+      "entity": {
+        "attributes": {
+          "average_daily_users": 216747,
+          "created": "2011-07-12T02:00:33",
+          "description": "Donate to Anonymously &amp; further tweaks!",
+          "guid": "2oniejfef@sdswwf",
+          "homepage": "http://www.343ff3f.net/en",
+          "id": "43434",
+          "last_updated": "2011-07-12T02:00:33",
+          "name": "jijef",
+          "slug": "jijef",
+          "summary": "Easy",
+          "version": "4.7.1"
+        },
+        "entity_schema": "amo_addon"
+      },
+      "notes": "- Security, specifically Unsanitized DOM injection: This add-on is creating DOM nodes from HTML strings containing potentially unsanitized data, by assigning to innerHTML, jQuery.html, or through similar means. Aside from being inefficient, this is a major security risk. For more information, see https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Safely_inserting_external_content_into_a_page . Here are some examples that were discovered:\r\n-> contentscript\\advertising.js - line 211\r\n\r\n- Monetization, specifically Advertising not identified: Advertising injected into web page content must clearly be identified as originating from the add-on.\r\n-> events\\tabs.js - line 216",
+      "point_updates": [],
+      "policies": [
+        {
+          "enforcement_actions": [],
+          "id": "2d5203ad-3363-46cd-869f-b1949ca503a0",
+          "is_illegal": false,
+          "is_non_violating": false,
+          "name": "Advertising not identified",
+          "parent_id": "0483f465-bcd6-436e-9291-016df5654dd0"
+        },
+        {
+          "enforcement_actions": [],
+          "id": "0483f465-bcd6-436e-9291-016df5654dd0",
+          "is_illegal": false,
+          "is_non_violating": false,
+          "name": "Monetization"
+        },
+        {
+          "enforcement_actions": [],
+          "id": "421fcb71-caa1-48e0-84f9-94d9f5685cf5",
+          "is_illegal": false,
+          "is_non_violating": false,
+          "name": "Security"
+        },
+        {
+          "enforcement_actions": [],
+          "id": "fc75822a-5968-4c71-b0fa-70c9b73023da",
+          "is_illegal": false,
+          "is_non_violating": false,
+          "name": "Unsanitized DOM injection",
+          "parent_id": "421fcb71-caa1-48e0-84f9-94d9f5685cf5"
+        }
+      ],
+      "policies_removed": [],
+      "source": {
+        "decision": {
+          "id": "3953172e-d0b6-4416-b1c8-799da1614f05",
+          "metadata": {},
+          "type": "api_decision"
+        }
+      },
+      "timestamp": "2025-04-30T08:59:00.866971+00:00"
+    }
+  }

--- a/src/olympia/abuse/views.py
+++ b/src/olympia/abuse/views.py
@@ -208,25 +208,23 @@ def filter_enforcement_actions(enforcement_actions, cinder_job):
 def process_webhook_payload_decision(payload):
     source = payload.get('source', {})
     log.info('Valid Payload from AMO queue: %s', payload)
-    if source.get('decision').get('type') == 'api_decision':
+    if source.get('decision', {}).get('type') == 'api_decision':
         log.debug('Cinder webhook decision for api decision skipped.')
         raise CinderWebhookIgnoredError('Decision already handled via reviewer tools')
-    elif 'job' in source:
-        job_id = source.get('job', {}).get('id', '')
-
+    elif job_id := source.get('job', {}).get('id'):
         try:
             cinder_job = CinderJob.objects.get(job_id=job_id)
         except CinderJob.DoesNotExist as exc:
             log.debug('CinderJob instance not found for job id %s', job_id)
             raise CinderWebhookMissingIdError('No matching job id found') from exc
-    elif prev_decision_id := payload.get('previous_decision', {}).get('id', ''):
+    elif prev_decision_id := payload.get('previous_decision', {}).get('id'):
         try:
-            decision = ContentDecision.objects.get(cinder_id=prev_decision_id)
+            prev_decision = ContentDecision.objects.get(cinder_id=prev_decision_id)
         except ContentDecision.DoesNotExist as exc:
             log.debug('ContentDecision instance not found for id %s', prev_decision_id)
             raise CinderWebhookMissingIdError('No matching decision id found') from exc
 
-        cinder_job = decision.cinder_job
+        cinder_job = prev_decision.cinder_job
         if not cinder_job:
             log.debug('No job for ContentDecision with id %s', prev_decision_id)
             raise CinderWebhookMissingIdError('No matching job found for decision id')

--- a/src/olympia/abuse/views.py
+++ b/src/olympia/abuse/views.py
@@ -208,7 +208,10 @@ def filter_enforcement_actions(enforcement_actions, cinder_job):
 def process_webhook_payload_decision(payload):
     source = payload.get('source', {})
     log.info('Valid Payload from AMO queue: %s', payload)
-    if 'job' in source:
+    if source.get('type') == 'api_decision':
+        log.debug('Cinder webhook decision for api decision skipped.')
+        raise CinderWebhookIgnoredError('Decision already handled via reviewer tools')
+    elif 'job' in source:
         job_id = source.get('job', {}).get('id', '')
 
         try:
@@ -216,23 +219,21 @@ def process_webhook_payload_decision(payload):
         except CinderJob.DoesNotExist as exc:
             log.debug('CinderJob instance not found for job id %s', job_id)
             raise CinderWebhookMissingIdError('No matching job id found') from exc
-    else:
-        decision_id = payload.get('previous_decision', {}).get('id', '')
-
+    elif prev_decision_id := payload.get('previous_decision', {}).get('id', ''):
         try:
-            decision = ContentDecision.objects.get(cinder_id=decision_id)
+            decision = ContentDecision.objects.get(cinder_id=prev_decision_id)
         except ContentDecision.DoesNotExist as exc:
-            log.debug('ContentDecision instance not found for id %s', decision_id)
+            log.debug('ContentDecision instance not found for id %s', prev_decision_id)
             raise CinderWebhookMissingIdError('No matching decision id found') from exc
 
         cinder_job = decision.cinder_job
         if not cinder_job:
-            log.debug('No job for ContentDecision with id %s', decision_id)
+            log.debug('No job for ContentDecision with id %s', prev_decision_id)
             raise CinderWebhookMissingIdError('No matching job found for decision id')
-
-    if cinder_job.resolvable_in_reviewer_tools:
-        log.debug('Cinder webhook decision for reviewer resolvable job skipped.')
-        raise CinderWebhookIgnoredError('Decision already handled via reviewer tools')
+    else:
+        # We may support this one day, but we currently don't support this
+        log.debug('Cinder webhook decision for cinder proactive decision skipped.')
+        raise CinderWebhookError('Unsupported Manual decision')
 
     enforcement_actions = filter_enforcement_actions(
         payload.get('enforcement_actions') or [],

--- a/src/olympia/abuse/views.py
+++ b/src/olympia/abuse/views.py
@@ -208,7 +208,7 @@ def filter_enforcement_actions(enforcement_actions, cinder_job):
 def process_webhook_payload_decision(payload):
     source = payload.get('source', {})
     log.info('Valid Payload from AMO queue: %s', payload)
-    if source.get('type') == 'api_decision':
+    if source.get('decision').get('type') == 'api_decision':
         log.debug('Cinder webhook decision for api decision skipped.')
         raise CinderWebhookIgnoredError('Decision already handled via reviewer tools')
     elif 'job' in source:


### PR DESCRIPTION
Fixes: mozilla/addons#15525

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

refactors `process_webhook_payload_decision` so we filter out all api originated decisions with a 200, and raise a different 400 error if we get a proactive decision _not_ from the api.

### Context

`process_webhook_payload_decision` was previously checking `job.resolvable_in_reviewer_tools` to filter out api_decisions, but only for jobs - not proactive decisions.  Instead we were treating all non-job decisions as overrides and then raising when the decision id didn't exist (which didn't exist for a new, non override, decision).  

There's a bonus performance win in that we won't try to query any CinderJobs or ContentDecisions for any api originated decision now - we previously queried all decisions to find a job, to then check if was `resolvable_in_reviewer_tools==True`.

### Testing

As always, annoying to test locally because you have to replay webhook payloads from Cinder.

To test proactive reviewer decisions are ignored:
1) Reject or disable any addon/version in the reviewer tools, with Cinder API integration set up
2) See the decision in `/dashboards/decisions-created` in Cinder
3) replay the webhook payload from `/settings/webhooks` with curl
4) get a 200 with "Decision already handled via reviewer tools" in the response

To test proactive cinder decisions are ignored:
1) identify any add-on in investigate (e.g. investigate/amo_addon/616992)
2) take a manual action (right hand 3 dot menu) with a supported enforcement action (e.g. AMO_DISABLE_ADDON)
3) replay the webhook payload from `/settings/webhooks` with curl
4) get a 400 with "Unsupported Manual decision" in the response

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
