### PR TITLE
Expose the policy text for decisions in version|important-changes history

### DIFF
--- a/src/olympia/reviewers/templates/reviewers/includes/history.html
+++ b/src/olympia/reviewers/templates/reviewers/includes/history.html
@@ -22,6 +22,11 @@
               </details>
             {% endif %}
           {% endif %}
+          <ul>
+          {% for policy_text in record.details.policy_texts %}
+            <li class="light history-comment">{{ policy_text }}</li>
+          {% endfor %}
+          </ul>
           {# <pre> rather than <div> so that white space is preserved on copy #}
           <pre class="light history-comment">{{ record.details.comments }}</pre>
           {% if record.details.reason %}


### PR DESCRIPTION
Fixes: mozilla/addons#15503

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Simple fix to expose `policy_texts` alongside review comments where they're shown.  If it's too much or too ugly can be iterated on.

![Screenshot 2025-05-01 161253](https://github.com/user-attachments/assets/9b91ec59-c87e-4850-9976-c9f0f6cfad42)

![Screenshot 2025-05-01 151937](https://github.com/user-attachments/assets/51012631-c4b2-442a-93a5-17ea1112b495)

### Context

`policy_text` is only be added to `details` for Cinder originated decisions while the reviewer tools is including all the policy text in the comments.  https://github.com/mozilla/addons/issues/15513 will address that.

The subtle different in formatting between the Hold and the actual Force Disable (I disabled a recommended add-on, so it was held for 2nd level approval) is because I resync'd the policies in the meantime and the policy text had been updated with some extra line breaks.  What's displayed is always the policy text at the time the activity log was created, so we have a immutable record of it.

### Testing

- report an add-on for abuse for something Cinder handled (e.g. legal)
- in Cinder resolve that job with some policies that disable the add-on.  Add some manual reasoning if you like.
- replay the webhook payload for that decision into your local web container with curl
- in reviewer tools navigate to the review page for that add-on and see the policy text shown for those decisions along side any manual reasoning as comments.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
