### PR TITLE
Add retry mechanism to health check and notification of recovery

### DIFF
--- a/.github/workflows/_health_check.yml
+++ b/.github/workflows/_health_check.yml
@@ -1,0 +1,131 @@
+name: Health check
+
+run-name: |
+  ref: ${{ github.ref_name }} |
+  environment: ${{ inputs.environment }} |
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: The environment to run the health check in
+        type: string
+        required: false
+      notify:
+        description: Whether to notify the user of the health check outcome
+        type: boolean
+        required: false
+    outputs:
+      outcome:
+        description: The outcome of the health check
+        value: ${{ jobs.health_check.outputs.outcome}}
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: The environment to run the health check in
+        type: choice
+        required: true
+        options:
+          - production
+          - staging
+          - development
+          - host
+      notify:
+        description: Whether to notify the user of the health check outcome
+        type: boolean
+        required: false
+
+env:
+  health_check_file: health_check.json
+  health_check_blocks_file: health_check_blocks.json
+
+jobs:
+  health_check:
+    runs-on: ubuntu-latest
+
+    outputs:
+      outcome: ${{ steps.health_check.outcome }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Set waffle switch dummy-monitor-fails to true
+        if: inputs.environment == 'host'
+        uses: ./.github/actions/run-docker
+        with:
+          version: local
+          run: |
+            ./manage.py waffle_switch dummy-monitor-fails on
+
+      - name: Run health check
+        continue-on-error: true
+        id: health_check
+        shell: bash
+        run: |
+          ./scripts/health_check.py \
+          --env ${{ inputs.environment }} \
+          --verbose \
+          --output ${{ env.health_check_file }}
+
+
+      - name: Should notify?
+        id: should_notify
+        shell: bash
+        run: |
+          outcome="${{ steps.health_check.outcome }}"
+          notify="${{ inputs.notify }}"
+          environment="${{ inputs.environment }}"
+          result=false
+
+          if [[ "$outcome" == 'failure' && "$notify" == 'true' && "$environment" != 'host' ]]; then
+            result=true
+          fi
+
+          echo "result=$result" >> "$GITHUB_OUTPUT"
+
+      - name: Set message blocks
+        id: blocks
+        if: steps.should_notify.outputs.result == 'true'
+        shell: bash
+        run: |
+          if [ ! -f "${{ env.health_check_file }}" ]; then
+            echo "Health check file not found"
+            exit 1
+          fi
+
+          # Create the message blocks file
+          ./scripts/health_check_blocks.py \
+          --input "${{ env.health_check_file }}" \
+          --output "${{ env.health_check_blocks_file }}"
+
+          # Multiline output needs to use a delimiter to be passed to
+          # the GITHUB_OUTPUT file.
+          blocks=$(cat "${{ env.health_check_blocks_file }}")
+          echo "blocks<<EOF"$'\n'"$blocks"$'\n'EOF >> "$GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"
+
+      - name: Notify Failure
+        if: steps.should_notify.outputs.result == 'true'
+        uses: mozilla/addons/.github/actions/slack@main
+        with:
+          slack_token: ${{ secrets.SLACK_TOKEN }}
+          payload: |
+            {
+              "channel": "${{ secrets.SLACK_ADDONS_PRODUCTION_CHANNEL }}",
+              "blocks": ${{ toJson(steps.blocks.outputs.blocks) }},
+              "text": "[${{ inputs.environment }}] Health check ${{ steps.health_check.outcome }}",
+              # Don't unfurl links or media
+              "unfurl_links": false,
+              "unfurl_media": false,
+            }
+
+      - name: Exit with outcome
+        shell: bash
+        run: |
+          if [[ "${{ steps.health_check.outcome }}" == 'failure' ]]; then
+            exit 1
+          fi

--- a/.github/workflows/_health_check.yml
+++ b/.github/workflows/_health_check.yml
@@ -120,6 +120,15 @@ jobs:
       - name: Exit with outcome
         shell: bash
         run: |
-          if [[ "${{ steps.health_check.outcome }}" == 'failure' ]]; then
+          environment="${{ inputs.environment }}"
+          outcome="${{ steps.health_check.outcome }}"
+
+          if [[ "$environment" == 'host' && "$outcome" != "failure" ]]; then
+            echo "Health check should fail on host environment to simulate a real failure"
+            exit 1
+          fi
+
+          if [[ "$environment" != 'host' && "$outcome" == "failure" ]]; then
+            echo "Health check should not fail on a live environment, that is a real failure!"
             exit 1
           fi

--- a/.github/workflows/_health_check.yml
+++ b/.github/workflows/_health_check.yml
@@ -15,10 +15,7 @@ on:
         description: Whether to notify the user of the health check outcome
         type: boolean
         required: false
-    outputs:
-      outcome:
-        description: The outcome of the health check
-        value: ${{ jobs.health_check.outputs.outcome}}
+
   workflow_dispatch:
     inputs:
       environment:
@@ -42,9 +39,6 @@ env:
 jobs:
   health_check:
     runs-on: ubuntu-latest
-
-    outputs:
-      outcome: ${{ steps.health_check.outcome }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,12 @@ jobs:
             make push_locales ARGS="${args}"
           fi
 
+  health_check:
+    needs: context
+    uses: ./.github/workflows/_health_check.yml
+    with:
+      environment: host
+
   test:
     needs: build
     uses: ./.github/workflows/_test.yml

--- a/.github/workflows/health_check.yml
+++ b/.github/workflows/health_check.yml
@@ -52,7 +52,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           sleep 10
-          gh workflow --ref ${{ github.ref }} run health_check.yml
+          gh workflow run health_check.yml --ref ${{ github.ref }}
 
       - name: Notify Recovery
         if: needs.health_check.result == 'success' && github.event_name == 'workflow_dispatch'

--- a/.github/workflows/health_check.yml
+++ b/.github/workflows/health_check.yml
@@ -1,9 +1,7 @@
 name: Health Check
 
 on:
-  # Run the workflow test on push events
-  push:
-  # Run the main workflow on workflow_dispatch or schedule
+  repository_dispatch:
   workflow_dispatch:
   schedule:
     # Every 5 minutes
@@ -13,93 +11,58 @@ env:
   health_check_file: health_check.json
   health_check_blocks_file: health_check_blocks.json
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   context:
     runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.context.outputs.matrix }}
     steps:
-      - name: Set Context
-        id: context
-        shell: bash
-        run: |
-          is_test="${{ github.event_name == 'push' }}"
-          if [[ "${is_test}" == "true" ]]; then
-            matrix='["host"]'
-          else
-            matrix='["dev","stage","prod"]'
-          fi
-
-          echo "is_test=${is_test}" >> "$GITHUB_OUTPUT"
-          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
-          cat "$GITHUB_OUTPUT"
+      - uses: actions/checkout@v4
+      - id: context
+        uses: ./.github/actions/context
 
   health_check:
-    needs: context
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        environment: ${{ fromJson(needs.context.outputs.matrix) }}
+        environment:
+          - dev
+          - stage
+          - prod
 
+    uses: ./.github/workflows/_health_check.yml
+    secrets: inherit
+    with:
+      environment: ${{ matrix.environment }}
+      notify: ${{ github.event_name == 'schedule' }}
+
+  post_health_check:
+    if: always()
+    needs: health_check
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.12
-
-      - name: Set waffle switch dummy-monitor-fails to true
-        if: matrix.environment == 'host'
-        uses: ./.github/actions/run-docker
-        with:
-          version: local
-          run: |
-            ./manage.py waffle_switch dummy-monitor-fails on
-
-      - name: Run health check
-        continue-on-error: true
-        id: health_check
+      - name: Retry Health Check
+        if: needs.health_check.result == 'failure'
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          ./scripts/health_check.py \
-          --env ${{ matrix.environment }} \
-          --verbose \
-          --output ${{ env.health_check_file }}
+          sleep 10
+          gh workflow --ref ${{ github.ref }} run health_check.yml
 
-      - name: Set message blocks
-        id: blocks
-        if: steps.health_check.outcome == 'failure'
-        shell: bash
-        run: |
-          if [ ! -f ${{ env.health_check_file }} ]; then
-            echo "Health check file is missing from previous step"
-            exit 1
-          fi
-
-          # Create the message blocks file
-          ./scripts/health_check_blocks.py \
-          --input "${{ env.health_check_file }}" \
-          --output "${{ env.health_check_blocks_file }}"
-          # Multiline output needs to use a delimiter to be passed to
-          # the GITHUB_OUTPUT file.
-          blocks=$(cat "${{ env.health_check_blocks_file }}")
-          echo "blocks<<EOF"$'\n'"$blocks"$'\n'EOF >> "$GITHUB_OUTPUT"
-          cat "$GITHUB_OUTPUT"
-
-      - uses: mozilla/addons/.github/actions/slack@main
-        if: |
-          github.event_name == 'schedule' &&
-          steps.health_check.outcome == 'failure'
+      - name: Notify Recovery
+        if: needs.health_check.result == 'success' && github.event_name == 'workflow_dispatch'
+        uses: mozilla/addons/.github/actions/slack@main
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
           payload: |
             {
               "channel": "${{ secrets.SLACK_ADDONS_PRODUCTION_CHANNEL }}",
-              "blocks": ${{ toJson(steps.blocks.outputs.blocks) }},
-              "text": "Health check failed",
-              # Don't unfurl links or media
-              "unfurl_links": false,
-              "unfurl_media": false,
+              "text": ":white_check_mark: Health check has recovered",
             }
+
 

--- a/.github/workflows/health_check_completed.yml
+++ b/.github/workflows/health_check_completed.yml
@@ -28,12 +28,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Context
-        id: context
-        uses: ./.github/actions/context
-
       - uses: mozilla/addons/.github/actions/slack-workflow-notification@main
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}


### PR DESCRIPTION
Fixes: mozilla/addons#15451

### Description

Adds a retry mechanism to health check to notify of a recovery.

### Context

When health_check runs, it executes the check on all environments and:
- if any environment fails, it will:
  - notify in slack (only the first one that is `scheduled`)
  - retrigger the workflow via `workflow_dispatch`
- if all environments pass, AND the workflow was triggered by a previous workflow (not scheduled):
   - notify recovery

### Testing

<img width="685" alt="image" src="https://github.com/user-attachments/assets/27723fc8-0a57-44a1-b776-fa05c132db04" />

If you enable the `[dummy-monitor-fails](https://addons-internal.dev.mozaws.net/en-US/admin/models/waffle/switch/129/change/)` on dev and trigger a deploy of this workflow, you'll see it fail and retrigger the job until it gets a successful response.

```bash
gh workflow run health_checky.yml --ref kevinmind/addons/15451
```

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [X] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
