### PR TITLE
Improvements to Discovery Addon Admin

### DIFF
--- a/src/olympia/addons/admin.py
+++ b/src/olympia/addons/admin.py
@@ -19,6 +19,7 @@ from olympia.amo.admin import AMOModelAdmin, DateRangeFilter
 from olympia.amo.forms import AMOModelForm
 from olympia.amo.templatetags.jinja_helpers import vite_asset
 from olympia.amo.utils import send_mail
+from olympia.discovery.admin import DiscoveryAddon
 from olympia.files.models import File
 from olympia.ratings.models import Rating
 from olympia.reviewers.models import NeedsHumanReview
@@ -249,6 +250,7 @@ class AddonAdmin(AMOModelAdmin):
         'id',
         'created',
         'activity',
+        'discovery_addon',
         'average_rating',
         'bayesian_rating',
         'guid',
@@ -273,6 +275,7 @@ class AddonAdmin(AMOModelAdmin):
                     'type',
                     'status',
                     'activity',
+                    'discovery_addon',
                 ),
             },
         ),
@@ -514,6 +517,16 @@ class AddonAdmin(AMOModelAdmin):
                 )
         except AddonReviewerFlags.DoesNotExist:
             pass
+
+    @admin.display(description='Discovery Addon')
+    def discovery_addon(self, obj):
+        url = reverse(
+            'admin:{}_{}_change'.format(
+                DiscoveryAddon._meta.app_label, DiscoveryAddon._meta.model_name
+            ),
+            args=[obj.pk],
+        )
+        return format_html('<a href="{}">Discovery Addon</a>', url)
 
 
 class FrozenAddonAdmin(AMOModelAdmin):

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1623,7 +1623,7 @@ class Addon(OnChangeMixin, ModelBase):
         return []
 
     @cached_property
-    def has_promotions(self):
+    def is_promoted(self):
         return bool(self.promoted_groups(currently_approved=False))
 
     @property

--- a/src/olympia/promoted/tests/test_admin.py
+++ b/src/olympia/promoted/tests/test_admin.py
@@ -132,7 +132,7 @@ class TestDiscoveryAddonAdmin(TestCase):
         self.grant_permission(user, 'Discovery:Edit')
         self.client.force_login(user)
 
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(10):
             # 1. select current user
             # 2. savepoint (because we're in tests)
             # 3. select groups
@@ -142,6 +142,7 @@ class TestDiscoveryAddonAdmin(TestCase):
             # 6. prefetch add-ons
             # 7. select translations for add-ons from 7.
             # 8. check if addon has promoted groups
+            # 9/10. fetch promoted groups
             response = self.client.get(self.list_url, follow=True)
 
         assert response.status_code == 200
@@ -151,7 +152,7 @@ class TestDiscoveryAddonAdmin(TestCase):
         addon_factory(name='FooBâr')
         # throw in a promoted addon that doesn't have a current_version
         addon_factory(name='FooBâr', version_kw={'channel': amo.CHANNEL_UNLISTED})
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(12):
             self.client.get(self.list_url, follow=True)
 
     def test_can_edit_with_discovery_edit_permission(self):


### PR DESCRIPTION
Fixes: mozilla/addons#15569

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

**Addon Admin**
- Adds link to associated discovery addon on change page.
![image](https://github.com/user-attachments/assets/6aa0a937-bd88-4267-9bee-ab337cd39a4f)

**Discovery Addon Admin**
- Changes search to allow partial searches by both slug and guid.
- Adds filters to filter by: promoted/not promoted, add-on type, and application.
- Adds multi-select filters for promoted groups and promoted approvals -- an add-on must be part of all selected groups to be returned.
![image](https://github.com/user-attachments/assets/c47143df-b450-4971-b047-d0bfed972678)
![image](https://github.com/user-attachments/assets/6b4fb6bb-4be8-4e29-805f-646ac068f3fd)
![image](https://github.com/user-attachments/assets/9da10478-aaf4-4f00-b8a5-38da34dd19cc)
![image](https://github.com/user-attachments/assets/15eb8436-3fdb-48dd-a12d-9e49d59d0315)
![image](https://github.com/user-attachments/assets/c0ce69e6-3b55-4db3-8f6b-d35addb4961b)

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] Add before and after screenshots (Only for changes that impact the UI).
