### PR TITLE
When resolving multiple jobs in a reviewer action, record activity & notify owners once

### DIFF
--- a/src/olympia/abuse/actions.py
+++ b/src/olympia/abuse/actions.py
@@ -438,9 +438,15 @@ class ContentActionRejectVersion(ContentActionDisableAddon):
         if not self.decision.reviewer_user:
             # This action should only be used by reviewer tools, not cinder webhook
             raise NotImplementedError
+        if not self.target_versions.exclude(
+            file__status=amo.STATUS_DISABLED, file__original_status=amo.STATUS_NULL
+        ).exists():
+            return None
+
         for version in self.target_versions:
+            now = datetime.now()
             version.file.update(
-                datestatuschanged=datetime.now(),
+                datestatuschanged=now,
                 status=amo.STATUS_DISABLED,
                 original_status=amo.STATUS_NULL,
                 status_disabled_reason=File.STATUS_DISABLED_REASONS.NONE,
@@ -504,6 +510,12 @@ class ContentActionRejectVersionDelayed(ContentActionRejectVersion):
         if not self.decision.reviewer_user:
             # This action should only be used by reviewer tools, not cinder webhook
             raise NotImplementedError
+
+        if not self.target_versions.exclude(
+            reviewerflags__pending_rejection=self.delayed_rejection_date,
+            reviewerflags__pending_content_rejection=self.content_review,
+        ).exists():
+            return None
 
         for version in self.target_versions:
             # (Re)set pending_rejection.

--- a/src/olympia/abuse/actions.py
+++ b/src/olympia/abuse/actions.py
@@ -511,10 +511,16 @@ class ContentActionRejectVersionDelayed(ContentActionRejectVersion):
             # This action should only be used by reviewer tools, not cinder webhook
             raise NotImplementedError
 
-        if not self.target_versions.exclude(
-            reviewerflags__pending_rejection=self.delayed_rejection_date,
-            reviewerflags__pending_content_rejection=self.content_review,
-        ).exists():
+        if (
+            not self.target_versions.exclude(
+                reviewerflags__pending_rejection=self.delayed_rejection_date,
+                reviewerflags__pending_content_rejection=self.content_review,
+            )
+            .exclude(
+                file__status=amo.STATUS_DISABLED, file__original_status=amo.STATUS_NULL
+            )
+            .exists()
+        ):
             return None
 
         for version in self.target_versions:

--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -1331,7 +1331,7 @@ class ContentDecision(ModelBase):
             second_level=True,
         )
 
-    def send_notifications(self):
+    def send_notifications(self, *, notify_owners=True):
         from olympia.activity.models import AttachmentLog
 
         if not self.action_date:
@@ -1381,9 +1381,10 @@ class ContentDecision(ModelBase):
         else:
             extra_context = {}
 
-        action_helper.notify_owners(
-            log_entry_id=getattr(log_entry, 'id', None), extra_context=extra_context
-        )
+        if notify_owners:
+            action_helper.notify_owners(
+                log_entry_id=getattr(log_entry, 'id', None), extra_context=extra_context
+            )
 
     def get_target_review_url(self):
         return reverse('reviewers.decision_review', kwargs={'decision_id': self.id})

--- a/src/olympia/abuse/tasks.py
+++ b/src/olympia/abuse/tasks.py
@@ -120,7 +120,7 @@ def appeal_to_cinder(
 
 @retryable_task
 @use_primary_db
-def report_decision_to_cinder_and_notify(*, decision_id):
+def report_decision_to_cinder_and_notify(*, decision_id, notify_owners=True):
     decision = ContentDecision.objects.get(id=decision_id)
     entity_helper = CinderJob.get_entity_helper(
         decision.target,
@@ -128,7 +128,7 @@ def report_decision_to_cinder_and_notify(*, decision_id):
     )
     decision.report_to_cinder(entity_helper)
     # We've already executed the action in the reviewer tools
-    decision.send_notifications()
+    decision.send_notifications(notify_owners=notify_owners)
 
 
 @retryable_task

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -7,8 +7,8 @@ from django.conf import settings
 from django.core import mail
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage as storage
-from django.test.utils import override_settings
 from django.db import transaction
+from django.test.utils import override_settings
 from django.urls import reverse
 
 import pytest

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -17,7 +17,6 @@ from waffle.testutils import override_switch
 
 from olympia import amo
 from olympia.abuse.models import AbuseReport, CinderJob, CinderPolicy, ContentDecision
-from olympia.abuse.tasks import report_decision_to_cinder_and_notify
 from olympia.activity import log_create
 from olympia.activity.models import (
     ActivityLog,
@@ -3985,7 +3984,7 @@ class TestReviewHelper(TestReviewHelperBase):
                 assert job.decision == decision
 
                 reviewer_log_mock.reset_mock()
-                content_action_log_mock.reset_mock()
+                content_action_log_spy.reset_mock()
                 self.helper.handler.version = self.review_version
 
                 # Clean up any changes to start next iteration fresh.

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -2689,7 +2689,9 @@ class TestReview(ReviewBase):
         )
         assert activity_log_qs.count() == 1
         decision = ContentDecision.objects.get()
-        resolve_mock.assert_called_once_with(decision_id=decision.id)
+        resolve_mock.assert_called_once_with(
+            decision_id=decision.id, notify_owners=True
+        )
         assert decision.activities.all().get() == activity_log_qs.get()
         assert decision.action == DECISION_ACTIONS.AMO_IGNORE
         self.assertCloseToNow(decision.action_date)
@@ -2779,7 +2781,7 @@ class TestReview(ReviewBase):
         activity_log_qs = ActivityLog.objects.filter(action=amo.LOG.REQUEST_LEGAL.id)
         assert activity_log_qs.count() == 1
         decision = ContentDecision.objects.last()
-        report_mock.assert_called_once_with(decision_id=decision.id)
+        report_mock.assert_called_once_with(decision_id=decision.id, notify_owners=True)
         assert decision.activities.all().get() == activity_log_qs.get()
         assert decision.action == DECISION_ACTIONS.AMO_LEGAL_FORWARD
         self.assertCloseToNow(decision.action_date)
@@ -6244,7 +6246,9 @@ class TestReview(ReviewBase):
         assert self.get_addon().status == amo.STATUS_DISABLED
         log_entry = ActivityLog.objects.get(action=amo.LOG.FORCE_DISABLE.id)
         decision = ContentDecision.objects.get()
-        mock_resolve_task.assert_called_once_with(decision_id=decision.id)
+        mock_resolve_task.assert_called_once_with(
+            decision_id=decision.id, notify_owners=True
+        )
         assert decision.activities.all().get() == log_entry
         assert decision.action == DECISION_ACTIONS.AMO_DISABLE_ADDON
         self.assertCloseToNow(decision.action_date)
@@ -6283,7 +6287,9 @@ class TestReview(ReviewBase):
 
         log_entry = ActivityLog.objects.get(action=amo.LOG.APPROVE_VERSION.id)
         decision = ContentDecision.objects.get()
-        mock_resolve_task.assert_called_once_with(decision_id=decision.id)
+        mock_resolve_task.assert_called_once_with(
+            decision_id=decision.id, notify_owners=True
+        )
         assert decision.activities.all().get() == log_entry
         assert decision.action == DECISION_ACTIONS.AMO_APPROVE_VERSION
         self.assertCloseToNow(decision.action_date)

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -1142,7 +1142,12 @@ class ReviewBase:
                 # already carried out, we are just resolving multiple jobs with
                 # the same action. We need to attach the extra "no-op"
                 # decisions to the log_entry to have proper records.
+                log_entry.set_arguments(
+                    [log_entry.arguments[0], decision, *log_entry.arguments[1:]]
+                )
+                del log_entry.arguments
                 log_entry.contentdecision_set.add(decision)
+                log_entry.save()
             report_decision_to_cinder_and_notify.delay(
                 decision_id=decision.id, notify_owners=notify_owners
             )

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -1117,17 +1117,35 @@ class ReviewBase:
             )
             if update_queue_history:
                 self.update_queue_history(log_entry)
+
         for decision in decisions:
-            log_entry = decision.execute_action()
-            if not action_completed:
-                ReviewActionReasonLog.objects.bulk_create(
-                    ReviewActionReasonLog(reason=reason, activity_log=log_entry)
-                    for reason in reasons
-                )
-                self.log_attachment(log_entry)
-                if update_queue_history:
-                    self.update_queue_history(log_entry)
-            report_decision_to_cinder_and_notify.delay(decision_id=decision.id)
+            # Since we're executing multiple times the same decision, only one
+            # should be executed completely and log an activity, the rest are
+            # no-op that we just need for record-keeping purposes. We will only
+            # notify the owners for that "complete" one.
+            notify_owners = False
+            log_entry_for_decision = decision.execute_action()
+            if log_entry_for_decision:
+                notify_owners = True
+                log_entry = log_entry_for_decision
+                if not action_completed:
+                    ReviewActionReasonLog.objects.bulk_create(
+                        ReviewActionReasonLog(reason=reason, activity_log=log_entry)
+                        for reason in reasons
+                    )
+                    self.log_attachment(log_entry)
+                    if update_queue_history:
+                        self.update_queue_history(log_entry)
+            elif log_entry:
+                # decision.execute_action() explicitly returned None but we
+                # already have a log_entry: that means this decision was
+                # already carried out, we are just resolving multiple jobs with
+                # the same action. We need to attach the extra "no-op"
+                # decisions to the log_entry to have proper records.
+                log_entry.contentdecision_set.add(decision)
+            report_decision_to_cinder_and_notify.delay(
+                decision_id=decision.id, notify_owners=notify_owners
+            )
 
     def clear_all_needs_human_review_flags_in_channel(self, mad_too=True):
         """Clear needs_human_review flags on all versions in the same channel.

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -1119,11 +1119,11 @@ class ReviewBase:
                 self.update_queue_history(log_entry)
 
         for decision in decisions:
-            # Since we're executing multiple times the same decision, only one
-            # should be executed completely and log an activity, the rest are
-            # no-op that we just need for record-keeping purposes. We will only
-            # notify the owners for that "complete" one.
-            notify_owners = False
+            # If there are multiple decisions, only one should really be
+            # executed completely and log an activity, the rest are no-op that
+            # we just need for record-keeping purposes. We will only notify the
+            # owners for that "complete" one.
+            notify_owners = action_completed
             log_entry_for_decision = decision.execute_action()
             if log_entry_for_decision:
                 notify_owners = True

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -1119,10 +1119,10 @@ class ReviewBase:
                 self.update_queue_history(log_entry)
 
         for decision in decisions:
-            # If there are multiple decisions, only one should really be
-            # executed completely and log an activity, the rest are no-op that
-            # we just need for record-keeping purposes. We will only notify the
-            # owners for that "complete" one.
+            # If there are multiple decisions, in theory only one should really
+            # be executed completely and log an activity, the rest should be
+            # no-op that we just need for record-keeping purposes. We will only
+            # notify the owners for that "complete" one.
             notify_owners = action_completed
             log_entry_for_decision = decision.execute_action()
             if log_entry_for_decision:


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/15495

### Context

While Cinder consolidates multiple reports into the same job, we can still have multiple jobs for a given add-on because of escalations. When that happens, reviewers can resolve them all at the same time, but we don't want to duplicate activities or emails.

### Testing

- Report an add-on for policy violation on the website (leave your email as the reporter)
- In Cinder, escalate that to reviewers
- Report an add-on for policy violation on the website again (leave a different email as the reporter)
- In Cinder, escalate that to reviewers again
- In the review page, that add-on should now have 2 jobs to resolve when selecting an action
- Disable the add-on while checking the checkboxes to resolve those 2 jobs
- The developer should get a single email, each reporter should get one too. A single activity log should have been recorded and made visible in the review page

Repeat with a different add-on, this time rejecting multiple versions instead of disabling the add-on.