### PR TITLE
Display banned column in user admin changelist page

### DIFF
--- a/src/olympia/users/admin.py
+++ b/src/olympia/users/admin.py
@@ -106,7 +106,14 @@ class BannedUserContentInline(admin.TabularInline):
 
 @admin.register(UserProfile)
 class UserAdmin(AMOModelAdmin):
-    list_display = ('__str__', 'email', 'last_login', 'has_full_profile', 'deleted')
+    list_display = (
+        '__str__',
+        'email',
+        'last_login',
+        'has_full_profile',
+        'deleted',
+        'banned',
+    )
     # pk and IP address search are supported without needing to specify them in
     # search_fields (see `AMOModelAdmin`)
     search_fields = ('email__like',)


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/15581