### PR TITLE
update ContentActionTargetAppealRemovalAffirmation template

### DIFF
--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -1359,13 +1359,15 @@ class ContentDecision(ModelBase):
                 if log_entry
                 else []
             )
+            is_addon_enabled = self.addon and not (
+                details.get('is_addon_being_disabled') or self.addon.is_disabled
+            )
             extra_context = {
                 'auto_approval': is_auto_approval,
                 'delayed_rejection_days': details.get('delayed_rejection_days'),
                 'details': details,
                 'is_addon_being_blocked': details.get('is_addon_being_blocked'),
-                'is_addon_disabled': details.get('is_addon_being_disabled')
-                or getattr(self.target, 'is_disabled', False),
+                'is_addon_enabled': is_addon_enabled,
                 'version_list': ', '.join(ver_str for ver_str in version_numbers),
                 'has_attachment': has_attachment,
                 'dev_url': absolutify(self.target.get_dev_url('versions'))

--- a/src/olympia/abuse/templates/abuse/emails/ContentActionRejectVersion.txt
+++ b/src/olympia/abuse/templates/abuse/emails/ContentActionRejectVersion.txt
@@ -8,5 +8,5 @@ Affected versions: {{ version_list }}
 
 Based on that finding, those versions of your {{ type }} have been disabled on {{ target_url }} and are no longer available for download from Mozilla Add-ons, anywhere in the world. {% if is_addon_being_blocked %}In addition, in some cases, users who have previously installed those versions won't be able to continue using them.{% else %}Users who have previously installed those versions will be able to continue using them.{% endif %}
 
-{% if not is_addon_disabled %}You may upload a new version which addresses the policy violation(s).{% endif %}
+{% if is_addon_enabled %}You may upload a new version which addresses the policy violation(s).{% endif %}
 {% endblock %}

--- a/src/olympia/abuse/templates/abuse/emails/ContentActionTargetAppealRemovalAffirmation.txt
+++ b/src/olympia/abuse/templates/abuse/emails/ContentActionTargetAppealRemovalAffirmation.txt
@@ -2,7 +2,8 @@ Hello,
 
 Previously, your {{ type }} was suspended/removed from Mozilla Add-ons, based on a finding that you had violated Mozilla's policies.
 
-After reviewing your appeal, we determined that the previous decision, that your {{ type }} violates Mozilla's policies, was correct. {% if manual_reasoning_text %}{{ manual_reasoning_text }}. {% endif %}Based on that determination, we have denied your appeal, and will not reinstate your {{ type }}.
+After reviewing your appeal, we determined that it did not provide sufficient basis to overturn our earlier finding that your {{ type }} violates Mozilla's policies. {% if manual_reasoning_text %}{{ manual_reasoning_text }}. {% endif %}Based on that determination, we have denied your appeal, and will not reinstate your {{ type }}.
+{% if is_addon_enabled %}If you submit a new version of this add-on (or have already done so), that version will be evaluated separately.{% endif %}
 
 {% if has_attachment %}
 An attachment was provided. {% if dev_url %}To respond or view the file, visit {{ dev_url }}.{% endif %}
@@ -16,3 +17,6 @@ Thank you.
 --
 Mozilla Add-ons Team
 {{ SITE_URL }}
+
+
+

--- a/src/olympia/abuse/templates/abuse/emails/ContentActionTargetAppealRemovalAffirmation.txt
+++ b/src/olympia/abuse/templates/abuse/emails/ContentActionTargetAppealRemovalAffirmation.txt
@@ -17,6 +17,3 @@ Thank you.
 --
 Mozilla Add-ons Team
 {{ SITE_URL }}
-
-
-


### PR DESCRIPTION
Fixes: mozilla/addons#15598

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Updates template as per Lindsay's issue.

### Testing

It's a pretty minor change so CI should be sufficient, but to test manually if you want:
- report an addon via local frontend - choose policy violation in the add-on to be able to resolve via the reviewer tools
- resolve the report job by rejecting a version in the reviewer tools
- appeal that decision (via the appeal link in the email)
- in the reviewer tools deny that appeal
- see the new text in the email, and a reference to being able to upload a new version

When the content isn't an enabled add-on (e.g. a user profile, or a disabled addon) it's the same email, but without the blurb about uploading a new version.  

To test with disable addon:
- report an addon via local frontend - choose policy violation in the add-on to be able to resolve via the reviewer tools
- resolve the report job by force disabling the addon in the reviewer tools
- appeal that decision (via the appeal link in the email)
- in the reviewer tools deny that appeal
- see the new text in the email, with no reference to being able to upload a new version

Alternatively to test with a user ban:
- report an user profile via local frontend
- resolve the report job in Cinder with a policy that would ban the user (all of them, except the Approve and Ignore policies)
- copy and replay the webhook for the decision locally
- appeal that decision (via the appeal link in the email)
- in Cinder deny that appeal
- copy and replay the webhook for the appeall decision locally
- see the new text in the email, with no reference to being able to upload a new version

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
