### PR TITLE
Add distinct to search by promoted in discovery addons

### DIFF
--- a/src/olympia/discovery/admin.py
+++ b/src/olympia/discovery/admin.py
@@ -202,7 +202,7 @@ class AddonPromotionFilter(admin.SimpleListFilter):
     def queryset(self, request, queryset):
         is_null = self.value() != 'promoted'
         if self.value():
-            return queryset.filter(promotedaddon__isnull=is_null)
+            return queryset.filter(promotedaddon__isnull=is_null).distinct()
 
 
 class AddonPromotedGroupFilter(ExclusiveMultiSelectFieldListFilter):


### PR DESCRIPTION
Fixes: mozilla/addons#15569

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Adds `distinct()` to promoted search to prevent duplicate 'None' values in search.

![image](https://github.com/user-attachments/assets/c4873b8b-e811-4f29-a375-61e5426b5e4c)
![image](https://github.com/user-attachments/assets/828fe3a3-b8cc-4026-b4e7-0809431c263e)

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] Add before and after screenshots (Only for changes that impact the UI).
