### PR TITLE
Fix urlparams() when a query has multiple values for a given key

### DIFF
--- a/src/olympia/amo/tests/test_helpers.py
+++ b/src/olympia/amo/tests/test_helpers.py
@@ -202,6 +202,22 @@ def test_urlparams():
     assert s == url
 
 
+def test_urlparams_multiple_values():
+    url = 'https://example.com/?foo=one&foo=two'
+    assert (
+        utils.urlparams(url, bar='extra')
+        == 'https://example.com/?foo=one&foo=two&bar=extra'
+    )
+
+    # Replacing value for existing param with multiple values
+    url = 'https://example.com/?foo=one&foo=two'
+    assert utils.urlparams(url, foo='newvalue') == 'https://example.com/?foo=newvalue'
+
+    # Removing existing param with multiple values
+    url = 'https://example.com/?foo=one&foo=two'
+    assert utils.urlparams(url, foo=None) == 'https://example.com/'
+
+
 def test_urlparams_unicode():
     url = '/xx?evil=reco\ufffd\ufffd\ufffd\u02f5'
     utils.urlparams(url)
@@ -226,8 +242,8 @@ def test_urlparams_returns_safe_string():
     s = render('{{ "https://foo.com/"|urlparams(param="a%20b") }}', {})
     assert s == 'https://foo.com/?param=a+b'
 
-    s = render('{{ "https://foo.com/"|urlparams(param="%AAA") }}', {})
-    assert s == 'https://foo.com/?param=%AAA'
+    s = render('{{ "https://foo.com/"|urlparams(param="%40something") }}', {})
+    assert s == 'https://foo.com/?param=%40something'
 
     string = render(
         '{{ unsafe_url|urlparams }}',


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/15532

### Description

This fixes review queue filter breakage caused by pagination or sorting as those filters work by adding values to the same `due_date_reasons` key.

### Context

We use `urlparams()` in a bunch of places to add params to an URL to do pagination and things like that - it's very old code that was introduced 15 years ago and has been patched a couple times since. Because it was using a `dict` internally it didn't support keys with multiple values, which is a valid scenario that can happen when dealing with URLs created from forms with `<select multiple>` or `<input type=checkbox>`.

### Testing

I've added a couple unit tests demonstrating the following works:
```python
>>> urlparams('https://example.com/?foo=one&foo=two', bar='extra')
'https://example.com/?foo=one&foo=two&bar=extra'
```
To test that in the real world, you can:
- Make sure you have some add-ons in the review queue
- Visit the manual review queue
- Click link to uncheck all filters
- Check a few checkboxes (that match reasons shown for add-ons already in the queue)
- Submit
- If you have multiple results (lucky you, you have lots of add-ons waiting to be reviewed) and pagination is shown, click on page 2. Alternatively, sort by due date in reverse order.
- Make sure the same filters you selected before are still active on that new page
