### PR TITLE
Expose when jobs were created / forwarded / requeued in review page

### DIFF
--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -276,11 +276,7 @@ class CinderJobsWidget(forms.CheckboxSelectMultiple):
             *(decision.private_notes for decision in requeued_decisions),
         ]
         internal_notes = (
-            (
-                (
-                    f'Reasoning: {"; ".join(notes for notes in forwarded_or_requeued_notes)}',
-                ),
-            )
+            ((f'Reasoning: {"; ".join(forwarded_or_requeued_notes)}',),)
             if forwarded_or_requeued_notes
             else ()
         )

--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -21,6 +21,7 @@ from olympia import amo, ratings
 from olympia.abuse.models import CinderJob, CinderPolicy, ContentDecision
 from olympia.access import acl
 from olympia.amo.forms import AMOModelForm
+from olympia.amo.templatetags.jinja_helpers import format_datetime
 from olympia.constants.abuse import DECISION_ACTIONS
 from olympia.constants.reviewers import REVIEWER_DELAYED_REJECTION_PERIOD_DAYS_DEFAULT
 from olympia.files.utils import SafeZip
@@ -250,13 +251,15 @@ class CinderJobsWidget(forms.CheckboxSelectMultiple):
         # label_from_instance() on WidgetRenderedModelMultipleChoiceField returns the
         # full object, not a label, this is what makes this work.
         obj = label
-        forwarded_notes = [
-            *obj.queue_moves.values_list('notes', flat=True),
-            *obj.decisions.filter(action=DECISION_ACTIONS.AMO_REQUEUE).values_list(
-                'private_notes', flat=True
-            ),
-        ]
         is_appeal = obj.is_appeal
+        queue_moves = list(obj.queue_moves.order_by('-created'))
+        requeued_decisions = list(
+            obj.decisions.filter(action=DECISION_ACTIONS.AMO_REQUEUE).order_by(
+                '-created'
+            )
+        )
+        forwarded = queue_moves[0].created if queue_moves else None
+        requeued = requeued_decisions[0].created if requeued_decisions else None
         reports = obj.all_abuse_reports
         reasons_set = {
             (report.REASONS.for_value(report.reason).display,) for report in reports
@@ -268,18 +271,26 @@ class CinderJobsWidget(forms.CheckboxSelectMultiple):
             )
             for report in reports
         )
-        forwarded = (
-            ((f'Reasoning: {"; ".join(notes for notes in forwarded_notes)}',),)
-            if forwarded_notes
+        forwarded_or_requeued_notes = [
+            *(move.notes for move in queue_moves),
+            *(decision.private_notes for decision in requeued_decisions),
+        ]
+        internal_notes = (
+            (
+                (
+                    f'Reasoning: {"; ".join(notes for notes in forwarded_or_requeued_notes)}',
+                ),
+            )
+            if forwarded_or_requeued_notes
             else ()
         )
         appeals = (
-            (appeal_text_obj.text, appeal_text_obj.reporter_report is not None)
+            (appeal_obj.text, appeal_obj.reporter_report is not None)
             for appealed_decision in obj.appealed_decisions.all()
-            for appeal_text_obj in appealed_decision.appeals.all()
+            for appeal_obj in appealed_decision.appeals.all()
         )
         subtexts_gen = [
-            *forwarded,
+            *internal_notes,
             *(
                 (f'{"Reporter" if is_reporter else "Developer"} Appeal: {text}',)
                 for text, is_reporter in appeals
@@ -287,11 +298,17 @@ class CinderJobsWidget(forms.CheckboxSelectMultiple):
         ]
 
         label = format_html(
-            '{}{}{}<br/><span>{}</span>'
+            '(Created on {}) {}{}{}{}<br/><span>{}</span>'
             '<details><summary>Show detail on {} reports</summary><ul>{}</ul>'
             '</details>',
+            format_datetime(obj.created),
             '[Appeal] ' if is_appeal else '',
-            '[Forwarded] ' if forwarded else '',
+            format_html('[Forwarded on {}] ', format_datetime(forwarded))
+            if forwarded
+            else '',
+            format_html('[Requeued on {}] ', format_datetime(requeued))
+            if requeued
+            else '',
             format_html_join(', ', '"{}"', reasons_set),
             format_html_join('', '{}<br/>', subtexts_gen),
             len(reports),

--- a/src/olympia/reviewers/tests/test_forms.py
+++ b/src/olympia/reviewers/tests/test_forms.py
@@ -1211,6 +1211,7 @@ class TestReviewForm(TestCase):
             'reason': AbuseReport.REASONS.POLICY_VIOLATION,
         }
         cinder_job_2_reports = CinderJob.objects.create(
+            created=datetime(2025, 5, 22, 11, 27, 42, 123456),
             job_id='2 reports',
             resolvable_in_reviewer_tools=True,
             target_addon=self.addon,
@@ -1239,6 +1240,7 @@ class TestReviewForm(TestCase):
             addon_version='1.2',
         )
         cinder_job_appeal = CinderJob.objects.create(
+            created=datetime(2025, 5, 6, 1, 24, 2, 194875),
             job_id='appeal',
             resolvable_in_reviewer_tools=True,
             target_addon=self.addon,
@@ -1257,17 +1259,20 @@ class TestReviewForm(TestCase):
         )
 
         cinder_job_forwarded = CinderJob.objects.create(
+            created=datetime(2025, 4, 8, 15, 16, 3, 550090),
             job_id='forwarded',
             resolvable_in_reviewer_tools=True,
             target_addon=self.addon,
         )
         ContentDecision.objects.create(
+            created=datetime(2025, 5, 23, 22, 54, 4, 270060),
             action=DECISION_ACTIONS.AMO_REQUEUE,
             private_notes='Why o why',
             addon=self.addon,
             cinder_job=cinder_job_forwarded,
         )
         CinderQueueMove.objects.create(
+            created=datetime(2025, 5, 22, 11, 42, 5, 541216),
             cinder_job=cinder_job_forwarded,
             notes='Zee de zee',
             to_queue='amo-env-content-infringment',
@@ -1315,7 +1320,10 @@ class TestReviewForm(TestCase):
         doc = pq(content)
         label_0 = doc('label[for="id_cinder_jobs_to_resolve_0"]')
         assert label_0.text() == (
-            '[Forwarded] "DSA: It violates Mozilla\'s Add-on Policies"\n'
+            '(Created on April 8, 2025, 3:16 p.m.) '
+            '[Forwarded on May 22, 2025, 11:42 a.m.] '
+            '[Requeued on May 23, 2025, 10:54 p.m.] '
+            '"DSA: It violates Mozilla\'s Add-on Policies"\n'
             'Reasoning: Zee de zee; Why o why\n\n'
             'Show detail on 1 reports\n'
             'v[<script>alert()</script>]: ddd'
@@ -1324,6 +1332,7 @@ class TestReviewForm(TestCase):
         assert '&lt;script&gt;alert()&lt;/script&gt' in content  # should be escaped
         label_1 = doc('label[for="id_cinder_jobs_to_resolve_1"]')
         assert label_1.text() == (
+            '(Created on May 6, 2025, 1:24 a.m.) '
             '[Appeal] "DSA: It violates Mozilla\'s Add-on Policies"\n'
             'Developer Appeal: some justification\n'
             'Reporter Appeal: some other justification\n\n'
@@ -1332,6 +1341,7 @@ class TestReviewForm(TestCase):
         )
         label_2 = doc('label[for="id_cinder_jobs_to_resolve_2"]')
         assert label_2.text() == (
+            '(Created on May 22, 2025, 11:27 a.m.) '
             '"DSA: It violates Mozilla\'s Add-on Policies"\n\n'
             'Show detail on 2 reports\n<no message>\nbbb'
         )


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/15575

### Testing

The unit test change should cover it, but a full test would look something like:

- Create a listed add-on, content-approve it, then run auto-approve to get it fully approved (*)
- Make a report against a signed version of that add-on for policy violations inside the add-on
- In the review page for that add-on, select an action that can resolve jobs (reject, resolve reports, disable add-on...)
- See the creation date for the cinder job being displayed
- Make another report for the same add-on for policy violations inside the add-on again
- In the review page, see the creation date hasn't changed since that new report it should be attached to the same job
- Make another report for the same add-on for hateful content in the add-on page itself
- In Cinder, find that job in the add-on listings queue, assign it to yourself and escalate that to reviewers
- (locally, grab the webhook request corresponding to that escalation and replay it locally)
- In the review page, notice you should have a second job displayed when selecting an action that resolves jobs, and both the creation and forward date are displayed
- Add the add-on to a high profile promoted group (don't manually approve the version)
- Reject the add-on while resolving the jobs
- See the add-on in second level approval queue
- In second level approval queue, requeue the add-on
- In the review page, see the requeue date in the jobs that can be resolved

(*) auto-approving vs manual approving doesn't change anything at the moment but it would matter [when auto-resolving reports against reviewed content](https://github.com/mozilla/addons-server/pull/23465) is merged.