### PR TITLE
Docker compose: Add 'start_period' to healthcheck for web and worker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,7 @@ services:
       interval: 30s
       retries: 3
       start_interval: 1s
+      start_period: 10s
     depends_on:
       - mysqld
       - elasticsearch
@@ -93,6 +94,7 @@ services:
       interval: 30s
       retries: 3
       start_interval: 1s
+      start_period: 10s
 
   nginx:
     image: nginx:1.27-bookworm@sha256:5ed8fcc66f4ed123c1b2560ed708dc148755b6e4cbd8b943fab094f2c6bfa91e


### PR DESCRIPTION
Fixes: mozilla/addons#15624

### Description

@KevinMind helped me figure this out, apparently `start_period` is required now.

### Context

Not much context, other than my local containers won't start without this.

### Testing

I have tested this manually. With these additions, the containers start successfully.

### Checklist

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
