### PR TITLE
Expose new current_version after rejection in stakeholder email

### DIFF
--- a/src/olympia/abuse/templates/abuse/emails/stakeholder_notification.txt
+++ b/src/olympia/abuse/templates/abuse/emails/stakeholder_notification.txt
@@ -1,5 +1,6 @@
 {{ rejection_type }} for versions:
-{{ version_list }}
+[Listed] {{ version_list_listed }}
+[Unlisted] {{ version_list_unlisted }}
 
 Reasoning:
 {{ reasoning }}
@@ -7,6 +8,14 @@ Reasoning:
 {% if private_notes %}
 Private notes:
 {{ private_notes }}
+{% endif %}
+
+{% if version_list_listed %}
+  {% if new_current_version %}
+  {{ new_current_version.version }} will be the new current version of the {{ type }}; first approved {{ new_current_version.file.approval_date|date:"Y-m-d" }}.
+  {% else %}
+  The add-on will no longer be publicly viewable on AMO.
+  {% endif %}
 {% endif %}
 
 {{ review_urls }}


### PR DESCRIPTION
Fixes: mozilla/addons#15597

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Updates the email to specify the version that would become the current version after the versions were rejected.

### Context

Also changes the version list to be per channel, to make it more obvious (i.e. unlisted versions aren't going to affect what's publicly accessible)

### Testing

testing as #23270, pretty much:

- add yourself (or another account) to the "Stakeholder-Rejection-Notifications" access group.
- make an add-on promoted in the Strategic group
- check it either has a currently approved version, or upload / enable one
  - if it has an existing approved version, check `Version.File.approval_date` is set (it may not be for landfill add-ons)
- upload and approve a version of the add-on in the reviewer tools (so xpi is signed, and it's approved for that promoted group)
- reject that version
- see you've got a notification email in django admin fakemail, in addition to the usual email to the developer, etc.
- look in the email and see it mentions the older version of now being the current version, and the approval date.

bonus testing:
- repeat with delayed rejections - it should be as above - we're doing a Version query and excluding target_versions, so it shouldn't make a difference that the target versions are not yet rejected.
- repeat with unlisted versions - there shouldn't be any mention of new current versions, because listed versions aren't affected
- repeat when there isn't another approved version - the email should say the add-on won't be public

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
