### PR TITLE
Use specific, non-admin permission for 2nd level approval queue

### DIFF
--- a/src/olympia/constants/permissions.py
+++ b/src/olympia/constants/permissions.py
@@ -49,6 +49,8 @@ ADDONS_RECOMMENDED_REVIEW = AclPermission('Addons', 'RecommendedReview')
 ADDONS_TRIAGE_DELAYED = AclPermission('Addons', 'TriageDelayed')
 # Can see add-ons with all due dates in the queue, rather than just upcoming ones
 ADDONS_ALL_DUE_DATES = AclPermission('Addons', 'AllDueDates')
+# Can view/make choices in 2nd level approval queue
+ADDONS_HIGH_IMPACT_APPROVE = AclPermission('Addons', 'HighImpactApprove')
 
 # Can edit all collections.
 COLLECTIONS_EDIT = AclPermission('Collections', 'Edit')

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -7957,9 +7957,10 @@ class TestHeldDecisionReview(ReviewerTest):
             name='Approve',
             enforcement_actions=[DECISION_ACTIONS.AMO_APPROVE.api_value],
         )
-        # CinderJob.objects.create(cinder)
         self.url = reverse('reviewers.decision_review', args=(self.decision.id,))
-        self.login_as_admin()
+        self.user = user_factory()
+        self.grant_permission(self.user, 'Addons:HighImpactApprove')
+        self.client.force_login(self.user)
 
     def _test_review_page_addon(self):
         response = self.client.get(self.url)
@@ -8123,7 +8124,7 @@ class TestHeldDecisionReview(ReviewerTest):
         self.assertCloseToNow(override.action_date)
         assert override.override_of == self.decision
 
-    def test_non_admin_cannot_access(self):
+    def test_non_second_level_approver_cannot_access(self):
         self.login_as_reviewer()
         response = self.client.get(self.url)
         assert response.status_code == 403

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -621,7 +621,7 @@ class TestDashboard(TestCase):
         response = self.client.get(self.url)
         assert response.status_code == 403
 
-    def test_admin_all_permissions(self):
+    def test_super_admin_all_permissions(self):
         # Create a lot of add-ons to test the queue counts.
         user_factory(pk=settings.TASK_USER_ID)
         # Recommended extensions
@@ -679,8 +679,6 @@ class TestDashboard(TestCase):
         AutoApprovalSummary.objects.create(
             version=addon1.current_version, verdict=amo.AUTO_APPROVED
         )
-        admins_group = Group.objects.create(name='Admins', rules='*:*')
-        GroupUser.objects.create(user=self.user, group=admins_group)
 
         # Pending addon
         addon_factory(name='Pending Addön', status=amo.STATUS_NOMINATED)
@@ -725,10 +723,13 @@ class TestDashboard(TestCase):
             action=DECISION_ACTIONS.AMO_DISABLE_ADDON, addon=addon1
         )
 
+        admins_group = Group.objects.create(name='Admins', rules='*:*')
+        GroupUser.objects.create(user=self.user, group=admins_group)
+
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
-        assert len(doc('.dashboard h3')) == 7  # All sections are present.
+        assert len(doc('.dashboard h3')) == 8  # All sections are present.
         expected_links = [
             reverse('reviewers.queue_extension'),
             reverse('reviewers.reviewlog'),
@@ -766,7 +767,7 @@ class TestDashboard(TestCase):
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)
-        assert len(doc('.dashboard h3')) == 7  # All sections are present.
+        assert len(doc('.dashboard h3')) == 8  # All sections are present.
         expected_links = [
             reverse('reviewers.queue_extension'),
             reverse('reviewers.reviewlog'),

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -1265,7 +1265,7 @@ def queue_decisions(request, tab):
     )
 
 
-@permission_or_tools_listed_view_required(amo.permissions.REVIEWS_ADMIN)
+@permission_or_tools_listed_view_required(amo.permissions.ADDONS_HIGH_IMPACT_APPROVE)
 def decision_review(request, decision_id):
     decision = get_object_or_404(ContentDecision, pk=decision_id)
     form = HeldDecisionReviewForm(

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -272,7 +272,9 @@ def dashboard(request):
                 reverse('reviewers.queue_pending_rejection'),
             ),
         ]
-    if view_all or acl.action_allowed_for(request.user, amo.permissions.ADDONS_HIGH_IMPACT_APPROVE):
+    if view_all or acl.action_allowed_for(
+        request.user, amo.permissions.ADDONS_HIGH_IMPACT_APPROVE
+    ):
         sections['2nd Level Approval'] = [
             (
                 'Held Decisions for 2nd Level Approval ({0})'.format(

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -271,6 +271,9 @@ def dashboard(request):
                 ),
                 reverse('reviewers.queue_pending_rejection'),
             ),
+        ]
+    if view_all or acl.action_allowed_for(request.user, amo.permissions.ADDONS_HIGH_IMPACT_APPROVE):
+        sections['2nd Level Approval'] = [
             (
                 'Held Decisions for 2nd Level Approval ({0})'.format(
                     queue_counts['queue_decisions']


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/15601

### Testing

See issue: accessing or making decisions in 2nd level approval queue need a new permission, `Addons:HighImpactApprove`.

You can try this by doing the following:
- Pick a recommended add-on
- As a reviewer, force disable it in review page
- Create a Group with `Addons:HighImpactApprove,ReviewerTools:View` `rules` through the django admin or in a shell
- Add a user that isn't part of any other group to that group
- Log in with that user, and check that you can access the second level approval queue in reviewer tools. You should see that add-on you force-disabled.
- Proceed with the action, make sure the decision goes through and the add-on is force-disabled.