### PR TITLE
Reset user sessions when users are banned

### DIFF
--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -232,10 +232,11 @@ class UserQuerySet(BaseQuerySet):
             )
             user.banned = user.modified = datetime.now()
             user.deleted = True
+            user.auth_id = None  # Reset user sessions
             # To delete their photo, avoid delete_picture() that updates
             # picture_type immediately.
             delete_photo.delay(user.pk, banned=user.banned)
-        return self.bulk_update(users, fields=('banned', 'deleted', 'modified'))
+        return self.bulk_update(users, fields=('auth_id', 'banned', 'deleted', 'modified'))
 
     def unban_and_reenable_related_content(self, *, skip_activity_log=False):
         """Admin method to unban users and restore their content that was

--- a/src/olympia/users/tests/test_models.py
+++ b/src/olympia/users/tests/test_models.py
@@ -834,6 +834,9 @@ class TestUserProfile(TestCase):
         hash2 = user.get_session_auth_hash()
         assert hash1 != hash2
 
+        user.update(deleted=True)
+        assert user.get_session_auth_hash() is None
+
     def test_has_read_developer_agreement(self):
         set_config('last_dev_agreement_change_date', '2019-06-12 00:00')
         after_change = datetime(2019, 6, 12) + timedelta(days=1)

--- a/src/olympia/users/tests/test_models.py
+++ b/src/olympia/users/tests/test_models.py
@@ -201,6 +201,7 @@ class TestUserProfile(TestCase):
             lambda local_path, content_type: os.path.basename(local_path)
         )
         user_sole = user_factory(
+            auth_id=123456789,
             email='sole@foo.baa',
             fxa_id='13579',
             last_login_ip='127.0.0.1',
@@ -215,6 +216,7 @@ class TestUserProfile(TestCase):
         addon_sole_file = addon_sole.current_version.file
         self.setup_user_to_be_have_content_disabled(user_sole)
         user_multi = user_factory(
+            auth_id=987654321,
             email='multi@foo.baa',
             fxa_id='24680',
             last_login_ip='127.0.0.2',
@@ -329,7 +331,7 @@ class TestUserProfile(TestCase):
         self.assertCloseToNow(user_sole.banned)
         self.assertCloseToNow(user_sole.modified)
         assert user_sole.email == 'sole@foo.baa'
-        assert user_sole.auth_id
+        assert user_sole.auth_id is None
         assert user_sole.fxa_id == '13579'
         assert user_sole.last_login_ip == '127.0.0.1'
         assert user_sole.averagerating == 4.4
@@ -343,7 +345,7 @@ class TestUserProfile(TestCase):
         self.assertCloseToNow(user_multi.banned)
         self.assertCloseToNow(user_multi.modified)
         assert user_multi.email == 'multi@foo.baa'
-        assert user_multi.auth_id
+        assert user_multi.auth_id is None
         assert user_multi.fxa_id == '24680'
         assert user_multi.last_login_ip == '127.0.0.2'
         assert user_multi.averagerating == 2.2
@@ -354,6 +356,8 @@ class TestUserProfile(TestCase):
         assert user_multi.read_dev_agreement
 
         assert not user_innocent.deleted
+        assert not user_innocent.banned
+        assert user_innocent.auth_id
         assert user_innocent.ratings.exists()
 
         return {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/15649

### Context

`auth_id` is used by `get_session_auth_hash()` to invalidate sessions. If set to any value different to the one the session had, the session won't be valid.

### Description

This patches ensures we clear `auth_id` on banning, but also, just in case, makes `get_session_auth_hash()` return `None` for any deleted user, no matter what `auth_id` value is. Since `auth_id` defaults to a non-null value, this effectively ensures past sessions are never valid for deleted users (which banned users are a subset of)

### Testing

See STR in the issue:
- Create a user
- In a [private window, other browser, other container] log in as an admin and ban that user
- Go back to the original user, refresh, you should have been logged out