### PR TITLE
define Config keys in constants, with safeguards

### DIFF
--- a/src/olympia/abuse/tests/test_tasks.py
+++ b/src/olympia/abuse/tests/test_tasks.py
@@ -18,7 +18,6 @@ from olympia.constants.abuse import (
     ILLEGAL_CATEGORIES,
     ILLEGAL_SUBCATEGORIES,
 )
-from olympia.constants.reviewers import EXTRA_REVIEW_TARGET_PER_DAY_CONFIG_KEY
 from olympia.files.models import File
 from olympia.reviewers.models import NeedsHumanReview, ReviewActionReason, UsageTier
 from olympia.versions.models import Version
@@ -47,7 +46,7 @@ def addon_factory_with_abuse_reports(*, abuse_reports_count, **kwargs):
 @pytest.mark.django_db
 def test_flag_high_abuse_reports_addons_according_to_review_tier():
     user_factory(pk=settings.TASK_USER_ID)
-    set_config(EXTRA_REVIEW_TARGET_PER_DAY_CONFIG_KEY, '1')
+    set_config(amo.config_keys.EXTRA_REVIEW_TARGET_PER_DAY, '1')
     # Create some usage tiers and add add-ons in them for the task to do
     # something. The ones missing a lower, upper, or abuse report threshold
     # don't do anything for this test.
@@ -209,7 +208,7 @@ def test_flag_high_abuse_reports_addons_according_to_review_tier():
             == 1
         ), f'Addon {addon} should have been flagged'
 
-    # We've set EXTRA_REVIEW_TARGET_PER_DAY_CONFIG_KEY so that there would be
+    # We've set amo.config_keys.EXTRA_REVIEW_TARGET_PER_DAY so that there would be
     # one review per day after . Since we've frozen time on a Wednesday,
     # we should get: Friday, Monday (skipping week-end), Tuesday.
     due_dates = (

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -92,8 +92,6 @@ log = olympia.core.logger.getLogger('z.addons')
 MAX_SLUG_INCREMENT = 999
 SLUG_INCREMENT_SUFFIXES = set(range(1, MAX_SLUG_INCREMENT + 1))
 GUID_REUSE_FORMAT = 'guid-reused-by-pk-{}'
-UPCOMING_DUE_DATE_CUT_OFF_DAYS_CONFIG_KEY = 'upcoming-due-date-cut-off-days'
-UPCOMING_DUE_DATE_CUT_OFF_DAYS_CONFIG_DEFAULT = 2
 
 
 class GuidAlreadyDeniedError(RuntimeError):
@@ -326,15 +324,7 @@ class AddonManager(ManagerBase):
             .order_by('due_date')
         )
         if show_only_upcoming:
-            try:
-                days = int(
-                    get_config(
-                        UPCOMING_DUE_DATE_CUT_OFF_DAYS_CONFIG_KEY,
-                        UPCOMING_DUE_DATE_CUT_OFF_DAYS_CONFIG_DEFAULT,
-                    )
-                )
-            except (ValueError, TypeError):
-                days = UPCOMING_DUE_DATE_CUT_OFF_DAYS_CONFIG_DEFAULT
+            days = get_config(amo.config_keys.UPCOMING_DUE_DATE_CUT_OFF_DAYS)
             upcoming_cutoff_date = get_review_due_date(default_days=days)
             versions_due_qs = versions_due_qs.filter(due_date__lte=upcoming_cutoff_date)
         if not show_temporarily_delayed:

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -15,7 +15,6 @@ from olympia import amo, core
 from olympia.activity.models import ActivityLog, AddonLog
 from olympia.addons import models as addons_models
 from olympia.addons.models import (
-    UPCOMING_DUE_DATE_CUT_OFF_DAYS_CONFIG_KEY,
     Addon,
     AddonApprovalsCounter,
     AddonCategory,
@@ -3764,13 +3763,13 @@ class TestExtensionsQueues(TestCase):
         }
         assert set(addons) == due_dates_within_2_days
         # the upcoming days config can be overriden
-        set_config(UPCOMING_DUE_DATE_CUT_OFF_DAYS_CONFIG_KEY, '10')
+        set_config(amo.config_keys.UPCOMING_DUE_DATE_CUT_OFF_DAYS, '10')
         addons = Addon.unfiltered.get_queryset_for_pending_queues(
             admin_reviewer=True, show_only_upcoming=True
         )
         assert set(addons) == set(expected_addons)
         # an invalid config value will default back to 2 again
-        set_config(UPCOMING_DUE_DATE_CUT_OFF_DAYS_CONFIG_KEY, '10.')
+        set_config(amo.config_keys.UPCOMING_DUE_DATE_CUT_OFF_DAYS, '10.')
         addons = Addon.unfiltered.get_queryset_for_pending_queues(
             admin_reviewer=True, show_only_upcoming=True
         )

--- a/src/olympia/addons/tests/test_tasks.py
+++ b/src/olympia/addons/tests/test_tasks.py
@@ -18,7 +18,6 @@ from olympia.addons.models import DeletedPreviewFile, DisabledAddonContent
 from olympia.amo.tests import TestCase, addon_factory, user_factory
 from olympia.amo.tests.test_helpers import get_image_path
 from olympia.amo.utils import image_size
-from olympia.constants.reviewers import EXTRA_REVIEW_TARGET_PER_DAY_CONFIG_KEY
 from olympia.files.models import File
 from olympia.reviewers.models import NeedsHumanReview, UsageTier
 from olympia.users.models import UserProfile
@@ -258,7 +257,7 @@ def test_update_addon_hotness():
 @pytest.mark.django_db
 def test_flag_high_hotness_according_to_review_tier():
     user_factory(pk=settings.TASK_USER_ID)
-    set_config(EXTRA_REVIEW_TARGET_PER_DAY_CONFIG_KEY, '1')
+    set_config(amo.config_keys.EXTRA_REVIEW_TARGET_PER_DAY, '1')
     # Create some usage tiers and add add-ons in them for the task to do
     # something. The ones missing a lower, upper, or growth threshold don't
     # do anything. Also, tiers need to have a lower adu threshold above
@@ -383,7 +382,7 @@ def test_flag_high_hotness_according_to_review_tier():
             == 1
         )
 
-    # We've set EXTRA_REVIEW_TARGET_PER_DAY_CONFIG_KEY so that there would be
+    # We've set amo.config_keys.EXTRA_REVIEW_TARGET_PER_DAY so that there would be
     # one review per day after . Since we've frozen time on a Wednesday,
     # we should get: Friday, Monday (skipping week-end), Tuesday.
     due_dates = (

--- a/src/olympia/amo/__init__.py
+++ b/src/olympia/amo/__init__.py
@@ -2,6 +2,7 @@
 Miscellaneous helpers that make Django compatible with AMO.
 """
 
+from olympia.constants import config_keys  # noqa
 from olympia.constants import permissions  # noqa
 from olympia.constants import promoted  # noqa
 from olympia.constants.activity import (  # noqa

--- a/src/olympia/api/serializers.py
+++ b/src/olympia/api/serializers.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from elasticsearch_dsl.response.hit import Hit
 from rest_framework import serializers
 
+from olympia import amo
 from olympia.amo.utils import BaseModelSerializerAndFormMixin
 from olympia.zadmin.models import get_config
 
@@ -91,5 +92,5 @@ class SiteStatusSerializer(serializers.BaseSerializer):
     def to_representation(self, obj):
         return {
             'read_only': settings.READ_ONLY,
-            'notice': get_config('site_notice'),
+            'notice': get_config(amo.config_keys.SITE_NOTICE),
         }

--- a/src/olympia/blocklist/cron.py
+++ b/src/olympia/blocklist/cron.py
@@ -4,17 +4,14 @@ import waffle
 from django_statsd.clients import statsd
 
 import olympia.core.logger
-from olympia.constants.blocklist import (
-    MLBF_BASE_ID_CONFIG_KEY,
-    MLBF_TIME_CONFIG_KEY,
-    BlockListAction,
-)
+from olympia import amo
+from olympia.constants.blocklist import BlockListAction
 from olympia.zadmin.models import get_config
 
 from .mlbf import MLBF
 from .models import Block, BlocklistSubmission, BlockType
 from .tasks import process_blocklistsubmission, upload_filter
-from .utils import datetime_to_ts
+from .utils import datetime_to_ts, get_mlbf_base_id_config_key
 
 
 log = olympia.core.logger.getLogger('z.cron')
@@ -25,13 +22,11 @@ def get_generation_time():
 
 
 def get_last_generation_time():
-    return get_config(MLBF_TIME_CONFIG_KEY, None, json_value=True)
+    return get_config(amo.config_keys.BLOCKLIST_MLBF_TIME)
 
 
 def get_base_generation_time(block_type: BlockType):
-    return get_config(
-        MLBF_BASE_ID_CONFIG_KEY(block_type, compat=True), None, json_value=True
-    )
+    return get_config(get_mlbf_base_id_config_key(block_type, compat=True))
 
 
 def get_blocklist_last_modified_time():

--- a/src/olympia/blocklist/mlbf.py
+++ b/src/olympia/blocklist/mlbf.py
@@ -11,10 +11,10 @@ from filtercascade import FilterCascade
 from filtercascade.fileformats import HashAlgorithm
 
 import olympia.core.logger
+from olympia import amo
 from olympia.amo.utils import SafeStorage
 from olympia.blocklist.models import BlockType, BlockVersion
 from olympia.blocklist.utils import datetime_to_ts
-from olympia.constants.blocklist import BASE_REPLACE_THRESHOLD_KEY
 from olympia.versions.models import Version
 from olympia.zadmin.models import get_config
 
@@ -23,7 +23,7 @@ log = olympia.core.logger.getLogger('z.amo.blocklist')
 
 
 def get_base_replace_threshold():
-    return get_config(BASE_REPLACE_THRESHOLD_KEY, int_value=True, default=5_000)
+    return get_config(amo.config_keys.BLOCKLIST_BASE_REPLACE_THRESHOLD)
 
 
 def ordered_diff_lists(

--- a/src/olympia/blocklist/tests/test_cron.py
+++ b/src/olympia/blocklist/tests/test_cron.py
@@ -11,6 +11,7 @@ import responses
 from freezegun import freeze_time
 from waffle.testutils import override_switch
 
+from olympia import amo
 from olympia.amo.tests import (
     TestCase,
     addon_factory,
@@ -28,13 +29,8 @@ from olympia.blocklist.cron import (
 from olympia.blocklist.mlbf import MLBF
 from olympia.blocklist.models import Block, BlocklistSubmission, BlockType, BlockVersion
 from olympia.blocklist.tasks import upload_filter
-from olympia.blocklist.utils import datetime_to_ts
-from olympia.constants.blocklist import (
-    BASE_REPLACE_THRESHOLD_KEY,
-    MLBF_BASE_ID_CONFIG_KEY,
-    MLBF_TIME_CONFIG_KEY,
-    BlockListAction,
-)
+from olympia.blocklist.utils import datetime_to_ts, get_mlbf_base_id_config_key
+from olympia.constants.blocklist import BlockListAction
 from olympia.zadmin.models import set_config
 
 
@@ -321,7 +317,7 @@ class TestUploadToRemoteSettings(TestCase):
         self,
         expected_actions: List[BlockListAction],
     ):
-        set_config(BASE_REPLACE_THRESHOLD_KEY, 1)
+        set_config(amo.config_keys.BLOCKLIST_BASE_REPLACE_THRESHOLD, 1)
         upload_mlbf_to_remote_settings()
 
         # Generation time is set to current time so we can load the MLBF.
@@ -576,13 +572,13 @@ class TestTimeMethods(TestCase):
 
     def test_get_last_generation_time(self):
         assert get_last_generation_time() is None
-        set_config(MLBF_TIME_CONFIG_KEY, 1)
+        set_config(amo.config_keys.BLOCKLIST_MLBF_TIME, 1)
         assert get_last_generation_time() == 1
 
     def test_get_base_generation_time(self):
         for block_type in BlockType:
             assert get_base_generation_time(block_type) is None
-            set_config(MLBF_BASE_ID_CONFIG_KEY(block_type, compat=True), 123)
+            set_config(get_mlbf_base_id_config_key(block_type, compat=True), 123)
             assert get_base_generation_time(block_type) == 123
 
 

--- a/src/olympia/blocklist/utils.py
+++ b/src/olympia/blocklist/utils.py
@@ -289,3 +289,16 @@ def delete_versions_from_blocks(guids, submission):
             block.delete()
 
     return blocks
+
+
+def get_mlbf_base_id_config_key(block_type, compat: bool = False):
+    """
+    We use compat to return the old singular config key for hard blocks.
+    This allows us to migrate writes to the new plural key right now without
+    losing access to the old existing key when deploying this patch.
+    """
+    from olympia.blocklist.models import BlockType
+
+    if compat and block_type == BlockType.BLOCKED:
+        return amo.config_keys.BLOCKLIST_MLBF_BASE_ID
+    return getattr(amo.config_keys, f'BLOCKLIST_MLBF_BASE_ID_{block_type.name.upper()}')

--- a/src/olympia/constants/blocklist.py
+++ b/src/olympia/constants/blocklist.py
@@ -1,25 +1,6 @@
 # How many guids should there be in the stashes before we make a new base.
 from enum import Enum
 
-from olympia.blocklist.models import BlockType
-
-
-BASE_REPLACE_THRESHOLD_KEY = 'blocklist_base_replace_threshold'
-
-# Config keys used to track recent mlbf ids
-MLBF_TIME_CONFIG_KEY = 'blocklist_mlbf_generation_time'
-
-
-def MLBF_BASE_ID_CONFIG_KEY(block_type: BlockType, compat: bool = False):
-    """
-    We use compat to return the old singular config key for hard blocks.
-    This allows us to migrate writes to the new plural key right now without
-    losing access to the old existing key when deploying this patch.
-    """
-    if compat and block_type == BlockType.BLOCKED:
-        return 'blocklist_mlbf_base_id'
-    return f'blocklist_mlbf_base_id_{block_type.name.lower()}'
-
 
 REMOTE_SETTINGS_COLLECTION_MLBF = 'addons-bloomfilters'
 

--- a/src/olympia/constants/config_keys.py
+++ b/src/olympia/constants/config_keys.py
@@ -1,0 +1,49 @@
+import json
+
+
+"""
+Keys are define either as a tuple of (str, value-type, default) or a str.
+`value-type` currently supported in get_config are int, json, and str (the default).
+The default `default` is None.
+"""
+
+BLOCKLIST_BASE_REPLACE_THRESHOLD = 'blocklist_base_replace_threshold', int, 5_000
+
+BLOCKLIST_MLBF_BASE_ID = 'blocklist_mlbf_base_id', json, None
+
+BLOCKLIST_MLBF_BASE_ID_SOFT_BLOCKED = 'blocklist_mlbf_base_id_soft_blocked', json, None
+
+BLOCKLIST_MLBF_BASE_ID_BLOCKED = 'blocklist_mlbf_base_id_blocked', json, None
+
+# Used to track recent mlbf ids
+BLOCKLIST_MLBF_TIME = 'blocklist_mlbf_generation_time', json, None
+
+# Target number of reviews each task that adds extra versions to the review
+# queue will add per day.
+EXTRA_REVIEW_TARGET_PER_DAY = 'extra-review-target-per-day', int, 8
+
+INITIAL_AUTO_APPROVAL_DELAY_FOR_LISTED = (
+    'INITIAL_AUTO_APPROVAL_DELAY_FOR_LISTED',
+    int,
+    24 * 60 * 60,
+)
+
+INITIAL_DELAY_FOR_UNLISTED = 'INITIAL_DELAY_FOR_UNLISTED', int, 0
+
+LAST_DEV_AGREEMENT_CHANGE_DATE = 'last_dev_agreement_change_date'
+
+REVIEWERS_MOTD = 'reviewers_review_motd'
+
+SITE_NOTICE = 'site_notice'
+
+SUBMIT_NOTIFICATION_WARNING = 'submit_notification_warning'
+
+SUBMIT_NOTIFICATION_WARNING_PRE_REVIEW = 'submit_notification_warning_pre_review'
+
+UPCOMING_DUE_DATE_CUT_OFF_DAYS = 'upcoming-due-date-cut-off-days', int, 2
+
+KEYS = [
+    val[0] if isinstance(val, tuple) else val
+    for val in vars().values()
+    if isinstance(val, (str, tuple))
+]

--- a/src/olympia/constants/config_keys.py
+++ b/src/olympia/constants/config_keys.py
@@ -1,49 +1,73 @@
 import json
+from dataclasses import dataclass
 
 
-"""
-Keys are define either as a tuple of (str, value-type, default) or a str.
-`value-type` currently supported in get_config are int, json, and str (the default).
-The default `default` is None.
-"""
+@dataclass
+class ConfigKey:
+    key: str
+    default: str | None = None
+    type_ = str
 
-BLOCKLIST_BASE_REPLACE_THRESHOLD = 'blocklist_base_replace_threshold', int, 5_000
+    def load(self, value):
+        return self.type_(value)
 
-BLOCKLIST_MLBF_BASE_ID = 'blocklist_mlbf_base_id', json, None
+    def dump(self, value):
+        return str(value)
 
-BLOCKLIST_MLBF_BASE_ID_SOFT_BLOCKED = 'blocklist_mlbf_base_id_soft_blocked', json, None
 
-BLOCKLIST_MLBF_BASE_ID_BLOCKED = 'blocklist_mlbf_base_id_blocked', json, None
+class IntConfigKey(ConfigKey):
+    default: int | None = None
+    type_ = int
+
+
+class JsonConfigKey(ConfigKey):
+    default: dict | list | None = None
+    type_ = None
+
+    def load(self, value):
+        return json.loads(value)
+
+    def dump(self, value):
+        return json.dumps(value)
+
+
+BLOCKLIST_BASE_REPLACE_THRESHOLD = IntConfigKey(
+    'blocklist_base_replace_threshold', 5_000
+)
+
+BLOCKLIST_MLBF_BASE_ID = JsonConfigKey('blocklist_mlbf_base_id')
+
+BLOCKLIST_MLBF_BASE_ID_SOFT_BLOCKED = JsonConfigKey(
+    'blocklist_mlbf_base_id_soft_blocked'
+)
+
+BLOCKLIST_MLBF_BASE_ID_BLOCKED = JsonConfigKey('blocklist_mlbf_base_id_blocked')
 
 # Used to track recent mlbf ids
-BLOCKLIST_MLBF_TIME = 'blocklist_mlbf_generation_time', json, None
+BLOCKLIST_MLBF_TIME = JsonConfigKey('blocklist_mlbf_generation_time')
 
 # Target number of reviews each task that adds extra versions to the review
 # queue will add per day.
-EXTRA_REVIEW_TARGET_PER_DAY = 'extra-review-target-per-day', int, 8
+EXTRA_REVIEW_TARGET_PER_DAY = IntConfigKey('extra-review-target-per-day', 8)
 
-INITIAL_AUTO_APPROVAL_DELAY_FOR_LISTED = (
-    'INITIAL_AUTO_APPROVAL_DELAY_FOR_LISTED',
-    int,
-    24 * 60 * 60,
+INITIAL_AUTO_APPROVAL_DELAY_FOR_LISTED = IntConfigKey(
+    'INITIAL_AUTO_APPROVAL_DELAY_FOR_LISTED', 24 * 60 * 60
 )
 
-INITIAL_DELAY_FOR_UNLISTED = 'INITIAL_DELAY_FOR_UNLISTED', int, 0
+INITIAL_DELAY_FOR_UNLISTED = IntConfigKey('INITIAL_DELAY_FOR_UNLISTED', 0)
 
-LAST_DEV_AGREEMENT_CHANGE_DATE = 'last_dev_agreement_change_date'
+LAST_DEV_AGREEMENT_CHANGE_DATE = ConfigKey('last_dev_agreement_change_date')
 
-REVIEWERS_MOTD = 'reviewers_review_motd'
+REVIEWERS_MOTD = ConfigKey('reviewers_review_motd')
 
-SITE_NOTICE = 'site_notice'
+SITE_NOTICE = ConfigKey('site_notice')
 
-SUBMIT_NOTIFICATION_WARNING = 'submit_notification_warning'
+SUBMIT_NOTIFICATION_WARNING = ConfigKey('submit_notification_warning')
 
-SUBMIT_NOTIFICATION_WARNING_PRE_REVIEW = 'submit_notification_warning_pre_review'
+SUBMIT_NOTIFICATION_WARNING_PRE_REVIEW = ConfigKey(
+    'submit_notification_warning_pre_review'
+)
 
-UPCOMING_DUE_DATE_CUT_OFF_DAYS = 'upcoming-due-date-cut-off-days', int, 2
+UPCOMING_DUE_DATE_CUT_OFF_DAYS = IntConfigKey('upcoming-due-date-cut-off-days', 2)
 
-KEYS = [
-    val[0] if isinstance(val, tuple) else val
-    for val in vars().values()
-    if isinstance(val, (str, tuple))
-]
+KEYS = [val.key for val in vars().values() if isinstance(val, ConfigKey)]

--- a/src/olympia/constants/reviewers.py
+++ b/src/olympia/constants/reviewers.py
@@ -70,11 +70,6 @@ REASON_ADDON_TYPE_CHOICES = {
     ADDON_STATICTHEME: _('Theme'),
 }
 
-
-# Target number of reviews each task that adds extra versions to the review
-# queue will add per day.
-EXTRA_REVIEW_TARGET_PER_DAY_CONFIG_KEY = 'extra-review-target-per-day'
-
 POLICY_VALUE_PATTERN = 'policy-value-{id}-{placeholder}'
 POLICY_VALUE_PATTERN_REGEX = re.compile(
     POLICY_VALUE_PATTERN.format(id=r'(?P<id>\d+)', placeholder=r'(?P<placeholder>.+)')

--- a/src/olympia/devhub/templates/devhub/index.html
+++ b/src/olympia/devhub/templates/devhub/index.html
@@ -46,7 +46,7 @@
         {% block bodyattrs %}{% endblock %}>
 
     {% block site_notice %}
-      {% set admin_message = get_config('site_notice') %}
+      {% set admin_message = get_config(amo.config_keys.SITE_NOTICE) %}
       {% if admin_message or settings.READ_ONLY %}
         <div id="site-notice">
           {% if admin_message %}

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -1384,7 +1384,9 @@ def _submit_distribution(request, addon, next_view):
         context={
             'addon': addon,
             'distribution_form': form,
-            'submit_notification_warning': get_config('submit_notification_warning'),
+            'submit_notification_warning': get_config(
+                amo.config_keys.SUBMIT_NOTIFICATION_WARNING
+            ),
             'submit_page': 'version' if addon else 'addon',
         },
     )
@@ -1579,7 +1581,7 @@ def _submit_upload(
     submit_notification_warning = (
         warning
         if not flag.is_active(request)
-        else get_config('submit_notification_warning')
+        else get_config(amo.config_keys.SUBMIT_NOTIFICATION_WARNING)
     )
     if not submit_notification_warning and addon:
         # If we're not showing the generic submit notification warning, show
@@ -1592,7 +1594,7 @@ def _submit_upload(
             channel == amo.CHANNEL_UNLISTED and any(promoted_group.unlisted_pre_review)
         ):
             submit_notification_warning = get_config(
-                'submit_notification_warning_pre_review'
+                amo.config_keys.SUBMIT_NOTIFICATION_WARNING_PRE_REVIEW
             )
     if addon and addon.type == amo.ADDON_STATICTHEME:
         wizard_url = reverse(

--- a/src/olympia/promoted/tests/test_tasks.py
+++ b/src/olympia/promoted/tests/test_tasks.py
@@ -20,7 +20,7 @@ from ..tasks import NOTABLE_TIER_SLUG, add_high_adu_extensions_to_notable
 @pytest.mark.django_db
 def test_add_high_adu_extensions_to_notable_tier_absent_or_no_threshold():
     user_factory(pk=settings.TASK_USER_ID)
-    set_config(amo.EXTRA_REVIEW_TARGET_PER_DAY_CONFIG_KEY, 999)
+    set_config(amo.config_keys.EXTRA_REVIEW_TARGET_PER_DAY, 999)
 
     extension_with_high_adu = addon_factory(
         average_daily_users=42, file_kw={'is_signed': True}
@@ -55,7 +55,7 @@ def test_add_high_adu_extensions_to_notable():
     )
     # arbitrary target per day
     target_per_day = 12
-    set_config(amo.EXTRA_REVIEW_TARGET_PER_DAY_CONFIG_KEY, target_per_day)
+    set_config(amo.config_keys.EXTRA_REVIEW_TARGET_PER_DAY, target_per_day)
 
     extension_with_low_adu = addon_factory(
         average_daily_users=lower_adu_threshold - 1, file_kw={'is_signed': True}

--- a/src/olympia/reviewers/models.py
+++ b/src/olympia/reviewers/models.py
@@ -637,9 +637,7 @@ class AutoApprovalSummary(ModelBase):
         except AddonApprovalsCounter.DoesNotExist:
             content_review = None
         INITIAL_AUTO_APPROVAL_DELAY_FOR_LISTED = get_config(
-            'INITIAL_AUTO_APPROVAL_DELAY_FOR_LISTED',
-            default=24 * 60 * 60,
-            int_value=True,
+            amo.config_keys.INITIAL_AUTO_APPROVAL_DELAY_FOR_LISTED
         )
         return (
             not is_langpack

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -1687,17 +1687,17 @@ class TestExtensionQueue(QueueTest):
                 self.addons[addon].current_version.needshumanreview_set.create(
                     reason=NeedsHumanReview.REASONS.AUTO_APPROVAL_DISABLED
                 )
-        _, _, due_date_cut_off_default = amo.config_keys.UPCOMING_DUE_DATE_CUT_OFF_DAYS
+        due_date_cutoff_default = amo.config_keys.UPCOMING_DUE_DATE_CUT_OFF_DAYS.default
         self.addons['Nominated One'].current_version.update(
             due_date=get_review_due_date(
                 starting=datetime.now()
-                + timedelta(days=due_date_cut_off_default, seconds=1)
+                + timedelta(days=due_date_cutoff_default, seconds=1)
             )
         )
         self.addons['Pending Two'].current_version.update(
             due_date=get_review_due_date(
                 starting=datetime.now()
-                + timedelta(days=due_date_cut_off_default, seconds=2)
+                + timedelta(days=due_date_cutoff_default, seconds=2)
             )
         )
 

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -31,7 +31,6 @@ from olympia.access import acl
 from olympia.access.models import Group, GroupUser
 from olympia.activity.models import ActivityLog, AttachmentLog
 from olympia.addons.models import (
-    UPCOMING_DUE_DATE_CUT_OFF_DAYS_CONFIG_DEFAULT,
     Addon,
     AddonApprovalsCounter,
     AddonReviewerFlags,
@@ -1688,20 +1687,17 @@ class TestExtensionQueue(QueueTest):
                 self.addons[addon].current_version.needshumanreview_set.create(
                     reason=NeedsHumanReview.REASONS.AUTO_APPROVAL_DISABLED
                 )
+        _, _, due_date_cut_off_default = amo.config_keys.UPCOMING_DUE_DATE_CUT_OFF_DAYS
         self.addons['Nominated One'].current_version.update(
             due_date=get_review_due_date(
                 starting=datetime.now()
-                + timedelta(
-                    days=UPCOMING_DUE_DATE_CUT_OFF_DAYS_CONFIG_DEFAULT, seconds=1
-                )
+                + timedelta(days=due_date_cut_off_default, seconds=1)
             )
         )
         self.addons['Pending Two'].current_version.update(
             due_date=get_review_due_date(
                 starting=datetime.now()
-                + timedelta(
-                    days=UPCOMING_DUE_DATE_CUT_OFF_DAYS_CONFIG_DEFAULT, seconds=2
-                )
+                + timedelta(days=due_date_cut_off_default, seconds=2)
             )
         )
 
@@ -6609,7 +6605,7 @@ class TestReviewerMOTD(ReviewerTest):
             reverse('reviewers.save_motd'), {'motd': 'I am the keymaster.'}
         )
         assert response.status_code == 302
-        assert get_config('reviewers_review_motd') == 'I am the keymaster.'
+        assert get_config(amo.config_keys.REVIEWERS_MOTD) == 'I am the keymaster.'
 
     def test_form_errors(self):
         self.login_as_admin()

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -115,7 +115,7 @@ from .utils import (
 
 
 def context(**kw):
-    ctx = {'motd': get_config('reviewers_review_motd')}
+    ctx = {'motd': get_config(amo.config_keys.REVIEWERS_MOTD)}
     ctx.update(kw)
     return ctx
 
@@ -293,7 +293,7 @@ def dashboard(request):
 @permission_required(amo.permissions.ADDON_REVIEWER_MOTD_EDIT)
 def motd(request):
     form = None
-    form = MOTDForm(initial={'motd': get_config('reviewers_review_motd')})
+    form = MOTDForm(initial={'motd': get_config(amo.config_keys.REVIEWERS_MOTD)})
     data = context(form=form)
     return TemplateResponse(request, 'reviewers/motd.html', context=data)
 

--- a/src/olympia/templates/base.html
+++ b/src/olympia/templates/base.html
@@ -52,9 +52,9 @@
         data-readonly="{{ settings.READ_ONLY|json }}"
         {% block bodyattrs %}{% endblock %}>
 
-    <div id="main-wrapper"> 
+    <div id="main-wrapper">
       {% block site_notice %}
-        {% set admin_message = get_config('site_notice') %}
+        {% set admin_message = get_config(amo.config_keys.SITE_NOTICE) %}
         {% if admin_message or settings.READ_ONLY %}
           <div id="site-notice">
             {% if admin_message %}

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -437,7 +437,9 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
             return False
         last_agreement_change_config = None
         try:
-            last_agreement_change_config = get_config('last_dev_agreement_change_date')
+            last_agreement_change_config = get_config(
+                amo.config_keys.LAST_DEV_AGREEMENT_CHANGE_DATE
+            )
             change_config_date = datetime.strptime(
                 last_agreement_change_config, '%Y-%m-%d %H:%M'
             )

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -593,14 +593,9 @@ class Version(OnChangeMixin, ModelBase):
             .exclude(pk=version.pk)
             .exists()
         ):
-            try:
-                INITIAL_DELAY_FOR_UNLISTED = int(
-                    get_config('INITIAL_DELAY_FOR_UNLISTED')
-                )
-            except (ValueError, TypeError):
-                INITIAL_DELAY_FOR_UNLISTED = 0
+            initial_delay = get_config(amo.config_keys.INITIAL_DELAY_FOR_UNLISTED)
             auto_approval_delay_for_unlisted = addon.created + timedelta(
-                seconds=INITIAL_DELAY_FOR_UNLISTED
+                seconds=initial_delay
             )
             if datetime.now() < auto_approval_delay_for_unlisted:
                 addon.set_auto_approval_delay_if_higher_than_existing(

--- a/src/olympia/versions/tests/test_utils.py
+++ b/src/olympia/versions/tests/test_utils.py
@@ -15,7 +15,7 @@ from PIL import Image, ImageChops
 
 from olympia import amo
 from olympia.amo.tests import root_storage
-from olympia.zadmin.models import Config
+from olympia.zadmin.models import set_config
 
 from ..utils import (
     AdditionalBackground,
@@ -275,8 +275,7 @@ def test_get_staggered_review_due_date_generator_default_initial_starting_date()
 @freeze_time('2023-05-16 11:00')
 @pytest.mark.django_db
 def test_get_staggered_review_due_date_generator_custom_config():
-    key, _, _ = amo.config_keys.EXTRA_REVIEW_TARGET_PER_DAY
-    Config.objects.create(key=key, value='4')
+    set_config(amo.config_keys.EXTRA_REVIEW_TARGET_PER_DAY.key, 4)
     generator = get_staggered_review_due_date_generator()
     due = next(generator)
     assert due == datetime(2023, 5, 19, 11, 0)
@@ -292,8 +291,7 @@ def test_get_staggered_review_due_date_generator_custom_config():
 @freeze_time('2023-05-16 11:00')
 @pytest.mark.django_db
 def test_get_staggered_review_due_date_generator_garbage_config(log_mock):
-    key, _, _ = amo.config_keys.EXTRA_REVIEW_TARGET_PER_DAY
-    Config.objects.create(key=key, value='lolweird')
+    set_config(amo.config_keys.EXTRA_REVIEW_TARGET_PER_DAY, 'lolweird')
     generator = get_staggered_review_due_date_generator()
 
     # Falls back on arbitrary default (8), logging an error. So next due date

--- a/src/olympia/versions/tests/test_utils.py
+++ b/src/olympia/versions/tests/test_utils.py
@@ -15,7 +15,6 @@ from PIL import Image, ImageChops
 
 from olympia import amo
 from olympia.amo.tests import root_storage
-from olympia.constants.reviewers import EXTRA_REVIEW_TARGET_PER_DAY_CONFIG_KEY
 from olympia.zadmin.models import Config
 
 from ..utils import (
@@ -276,7 +275,8 @@ def test_get_staggered_review_due_date_generator_default_initial_starting_date()
 @freeze_time('2023-05-16 11:00')
 @pytest.mark.django_db
 def test_get_staggered_review_due_date_generator_custom_config():
-    Config.objects.create(key=EXTRA_REVIEW_TARGET_PER_DAY_CONFIG_KEY, value='4')
+    key, _, _ = amo.config_keys.EXTRA_REVIEW_TARGET_PER_DAY
+    Config.objects.create(key=key, value='4')
     generator = get_staggered_review_due_date_generator()
     due = next(generator)
     assert due == datetime(2023, 5, 19, 11, 0)
@@ -292,7 +292,8 @@ def test_get_staggered_review_due_date_generator_custom_config():
 @freeze_time('2023-05-16 11:00')
 @pytest.mark.django_db
 def test_get_staggered_review_due_date_generator_garbage_config(log_mock):
-    Config.objects.create(key=EXTRA_REVIEW_TARGET_PER_DAY_CONFIG_KEY, value='lolweird')
+    key, _, _ = amo.config_keys.EXTRA_REVIEW_TARGET_PER_DAY
+    Config.objects.create(key=key, value='lolweird')
     generator = get_staggered_review_due_date_generator()
 
     # Falls back on arbitrary default (8), logging an error. So next due date

--- a/src/olympia/versions/utils.py
+++ b/src/olympia/versions/utils.py
@@ -10,9 +10,9 @@ from django.utils.encoding import force_str
 
 from PIL import Image
 
+from olympia import amo
 from olympia.amo.utils import convert_svg_to_png
 from olympia.constants.reviewers import (
-    EXTRA_REVIEW_TARGET_PER_DAY_CONFIG_KEY,
     REVIEWER_STANDARD_REVIEW_TIME,
 )
 from olympia.core import logger
@@ -168,9 +168,7 @@ def get_staggered_review_due_date_generator(
     due_date = starting + timedelta(days=initial_days_delay)
 
     if target_per_day is None:
-        target_per_day = get_config(
-            EXTRA_REVIEW_TARGET_PER_DAY_CONFIG_KEY, int_value=True, default=8
-        )
+        target_per_day = get_config(amo.config_keys.EXTRA_REVIEW_TARGET_PER_DAY)
     stagger = 24 / target_per_day
 
     while True:

--- a/src/olympia/zadmin/tests/test_models.py
+++ b/src/olympia/zadmin/tests/test_models.py
@@ -1,26 +1,52 @@
+import json
 from unittest import mock
 
 import pytest
 
-from olympia.zadmin.models import Config, get_config, set_config
+from olympia.zadmin.models import Config, amo, get_config, set_config
 
 
+@mock.patch.object(amo, 'config_keys')
 @pytest.mark.django_db
-def test_set_config():
+def test_set_config(keys_mock):
+    keys_mock.KEYS = ['foo']
+
     assert Config.objects.filter(key='foo').count() == 0
     set_config('foo', 'bar')
     assert Config.objects.get(key='foo').value == 'bar'
 
+    # missing key should error
+    with pytest.raises(AssertionError):
+        set_config('key', 'value 0')
+
+    keys_mock.KEYS = ['foo', 'key']
     # Overwrites existing values
     set_config('key', 'value 1')
     set_config('key', 'value 2')
-
     assert Config.objects.get(key='key').value == 'value 2'
 
+    # with a json value
+    keys_mock.KEY = 'key', json, int
+    set_config(keys_mock.KEY, ['value 1', 'value 2'])
 
+    assert Config.objects.get(key='key').value == '["value 1", "value 2"]'
+
+
+@mock.patch('olympia.zadmin.models.amo.config_keys')
 @mock.patch('olympia.zadmin.models.log')
 @pytest.mark.django_db
-def test_get_config(log_mock):
+def test_get_config(log_mock, keys_mock):
+    # a missing key should raise
+    with pytest.raises(AssertionError):
+        get_config('key')
+    assert log_mock.error.call_count == 0
+
+    # if the key exists, it should work and return None
+    keys_mock.KEYS = ['key']
+    assert get_config('key') is None
+    assert log_mock.error.call_count == 0
+
+    # and if it has a value, that value
     Config.objects.create(key='key', value='value')
     assert get_config('key') == 'value'
     assert log_mock.error.call_count == 0
@@ -29,21 +55,27 @@ def test_get_config(log_mock):
     assert get_config('key') == 'value 2'
     assert log_mock.error.call_count == 0
 
-    assert get_config('absent') is None
-    # Absence is not an error, just triggers the default.
-    assert log_mock.error.call_count == 0
-
-    assert get_config('absent', default='oops') == 'oops'
-    assert log_mock.error.call_count == 0
-
+    # and with other types of values
     Config.objects.filter(key='key').update(value='{"foo": "bar"}')
-    assert get_config('key', json_value=True) == {'foo': 'bar'}
+    assert get_config(('key', json, None)) == {'foo': 'bar'}
 
     Config.objects.filter(key='key').update(value='56786798')
-    assert get_config('key', int_value=True) == 56786798
+    assert get_config(('key', int, 1)) == 56786798
 
+    # similarly if the key is defined with a default
+    keys_mock.KEYS = ['key', 'absent']
+    assert get_config(('absent', str, 'oops')) == 'oops'
+    assert log_mock.error.call_count == 0
+
+    assert get_config(('absent', int, 42)) == 42
+    assert log_mock.error.call_count == 0
+
+    assert get_config(('absent', json, {})) == {}
+    assert log_mock.error.call_count == 0
+
+    # if the instance value is malformed, we return the default though
     Config.objects.filter(key='key').update(value='not a number')
-    assert get_config('key', int_value=True, default=1) == 1
+    assert get_config(('key', int, 1)) == 1
     assert log_mock.error.call_count == 1
     assert log_mock.error.call_args[0] == (
         '[%s] config key appears to not be set correctly (%s)',
@@ -53,7 +85,7 @@ def test_get_config(log_mock):
     log_mock.error.reset_mock()
 
     Config.objects.filter(key='key').update(value=',,,')
-    assert get_config('key', json_value=True, default={}) == {}
+    assert get_config(('key', json, {})) == {}
     assert log_mock.error.call_count == 1
     assert log_mock.error.call_args[0] == (
         '[%s] config key appears to not be set correctly (%s)',
@@ -61,27 +93,3 @@ def test_get_config(log_mock):
         ',,,',
     )
     log_mock.error.reset_mock()
-
-    assert get_config('absent', default=42, int_value=True) == 42
-    assert log_mock.error.call_count == 0
-    assert get_config('absent', default='{}', json_value=True) == {}
-    assert log_mock.error.call_count == 0
-
-    # It's the caller responsibility to provide a sensible default value
-    log_mock.error.reset_mock()
-    assert get_config('absent', default='oops', int_value=True) == 'oops'
-    assert log_mock.error.call_count == 1
-    assert log_mock.error.call_args[0] == (
-        '[%s] config key appears to not be set correctly (%s)',
-        'absent',
-        'oops',
-    )
-
-    log_mock.error.reset_mock()
-    assert get_config('absent', default='oops', json_value=True) == 'oops'
-    assert log_mock.error.call_count == 1
-    assert log_mock.error.call_args[0] == (
-        '[%s] config key appears to not be set correctly (%s)',
-        'absent',
-        'oops',
-    )


### PR DESCRIPTION
Fixes: mozilla/addons#1932

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description
Replace our config keys (and defaults, and types) with constants.  A call to `get_config` or `set_config` must use a valid config name from the constants; but because the constants are tuples it's still possible to override `get_config` to provide an arbitrary default (or type) - though we don't currently.

### Context

This... was supposed to be a quick and easy fix of an old code quality issue and ended up more complicated than it would have seemed - mainly because, to me, it didn't make sense to centralize the config _names_ while leaving defaults defined somewhere else, and the type of the config unenforced, and needing to specify it each time you get or set it. wdyt?  (directly requesting review as the code is all very inside baseball 😬)

### Testing

- test somewhere we set or get config, I guess? reviewer MOTD is an easy candidate; the blocklist code is a more complicated test.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
