### PR TITLE
Lock down github action permissions

### DIFF
--- a/.github/workflows/_health_check.yml
+++ b/.github/workflows/_health_check.yml
@@ -4,6 +4,8 @@ run-name: |
   ref: ${{ github.ref_name }} |
   environment: ${{ inputs.environment }} |
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -5,6 +5,8 @@ run-name: |
   version: ${{ inputs.version }} |
   digest: ${{ inputs.digest }} |
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/_test_check.yml
+++ b/.github/workflows/_test_check.yml
@@ -5,6 +5,8 @@ run-name: |
   version: ${{ inputs.version }} |
   digest: ${{ inputs.digest }} |
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/_test_main.yml
+++ b/.github/workflows/_test_main.yml
@@ -6,6 +6,8 @@ run-name: |
   digest: ${{ inputs.digest }} |
   splits: ${{ inputs.splits }} |
 
+permissions: {}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name}}-${{ github.ref}}
   cancel-in-progress: true
 
+permissions: {}
+
 env:
   docs_artifact: docs
 

--- a/.github/workflows/ci_completed.yml
+++ b/.github/workflows/ci_completed.yml
@@ -2,8 +2,11 @@ name: CI Completed
 
 on:
   workflow_run:
-    workflows: CI
+    workflows:
+      - CI
     types: [completed]
+
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name}}-${{ github.ref}}

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -15,6 +15,8 @@ on:
         description: 'Release date YYYY.MM.DD Also used to generate the tag name.'
         required: true
 
+permissions: {}
+
 jobs:
   draft_release:
     runs-on: ubuntu-latest

--- a/.github/workflows/health_check.yml
+++ b/.github/workflows/health_check.yml
@@ -7,6 +7,8 @@ on:
     # Every 5 minutes
     - cron: '*/5 * * * *'
 
+permissions: {}
+
 env:
   health_check_file: health_check.json
   health_check_blocks_file: health_check_blocks.json

--- a/.github/workflows/health_check_completed.yml
+++ b/.github/workflows/health_check_completed.yml
@@ -2,8 +2,11 @@ name: Health Check Completed
 
 on:
   workflow_run:
-    workflows: Health Check
+    workflows:
+      - Health Check
     types: [completed]
+
+permissions: {}
 
 jobs:
   context:


### PR DESCRIPTION
Fixes: mozilla/addons#15312

### Description

- [ ] Lock down top level workflow permissions to {} (empty)
- [ ] Add permissions back until all jobs pass
- [ ] Add linting for security holes in GHA workflows

### Context

By locking down default permissions and adding them back on a job or even step level gives us the most granular and limited by default security model for GHA.

Ensuring a step/job/workflow can only do what it intends and should be allowed to do.

### Testing

Tests Green

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
