### PR TITLE
Expose data collection permissions in API

### DIFF
--- a/docs/topics/api/addons.rst
+++ b/docs/topics/api/addons.rst
@@ -543,6 +543,8 @@ This endpoint allows you to fetch a single version belonging to a specific add-o
     :>json array file.optional_permissions[]: Array of the optional webextension permissions for this File, as strings. Empty for non-webextensions.
     :>json array file.host_permissions[]: Array of the host permissions for this File, as strings. Empty for non-webextensions.
     :>json array file.permissions[]: Array of the webextension permissions for this File, as strings. Empty for non-webextensions.
+    :>json array file.data_collection_permissions[]: Array of the data collection permissions for this File, as strings. Empty for non-webextensions.
+    :>json array file.optional_data_collection_permissions[]: Array of the optional data collection permissions for this File, as strings. Empty for non-webextensions.
     :>json int file.size: The size for the file, in bytes.
     :>json int file.status: The :ref:`status <version-detail-status>` for the file.
     :>json string file.url: The (absolute) URL to download the file.

--- a/docs/topics/api/overview.rst
+++ b/docs/topics/api/overview.rst
@@ -476,6 +476,7 @@ These are `v5` specific changes - `v4` changes apply also.
 * 2024-08-08: added support for writing to add-on eula_policy endpoint. https://github.com/mozilla/addons/issues/14927
 * 2024-08-22: restricted add-on eula_policy endpoint to non-themes only. https://github.com/mozilla/addons/issues/14937
 * 2024-10-17: replaced ``versions`` with ``blocked`` and ``soft_blocked`` in blocklist api; dropped unused ``min_version`` and ``max_version``. https://github.com/mozilla/addons/issues/15015
+* 2025-06-26: added ``data_collection_permissions`` and ``optional_data_collection_permissions`` to the version detail endpoint (and therefore addons/search as well). https://github.com/mozilla/addons/issues/15620
 
 .. _`#11380`: https://github.com/mozilla/addons-server/issues/11380/
 .. _`#11379`: https://github.com/mozilla/addons-server/issues/11379/

--- a/src/olympia/addons/indexers.py
+++ b/src/olympia/addons/indexers.py
@@ -390,6 +390,14 @@ class AddonIndexer:
                         'permissions': {'type': 'keyword', 'index': False},
                         'optional_permissions': {'type': 'keyword', 'index': False},
                         'host_permissions': {'type': 'keyword', 'index': False},
+                        'data_collection_permissions': {
+                            'type': 'keyword',
+                            'index': False,
+                        },
+                        'optional_data_collection_permissions': {
+                            'type': 'keyword',
+                            'index': False,
+                        },
                     },
                 },
                 'license': {
@@ -549,6 +557,12 @@ class AddonIndexer:
                         'permissions': version_obj.file.permissions,
                         'optional_permissions': version_obj.file.optional_permissions,
                         'host_permissions': version_obj.file.host_permissions,
+                        'data_collection_permissions': (
+                            version_obj.file.data_collection_permissions
+                        ),
+                        'optional_data_collection_permissions': (
+                            version_obj.file.optional_data_collection_permissions
+                        ),
                     }
                 ],
                 'reviewed': (

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -103,6 +103,10 @@ class FileSerializer(AMOModelSerializer):
     permissions = serializers.ListField(child=serializers.CharField())
     optional_permissions = serializers.ListField(child=serializers.CharField())
     host_permissions = serializers.ListField(child=serializers.CharField())
+    data_collection_permissions = serializers.ListField(child=serializers.CharField())
+    optional_data_collection_permissions = serializers.ListField(
+        child=serializers.CharField()
+    )
     is_restart_required = serializers.SerializerMethodField()
     is_webextension = serializers.SerializerMethodField()
 
@@ -122,6 +126,8 @@ class FileSerializer(AMOModelSerializer):
             'permissions',
             'optional_permissions',
             'host_permissions',
+            'data_collection_permissions',
+            'optional_data_collection_permissions',
         )
 
     def get_url(self, obj):
@@ -158,6 +164,8 @@ class LanguageToolFileSerializer(FileSerializer):
     permissions = serializers.SerializerMethodField()
     optional_permissions = serializers.SerializerMethodField()
     host_permissions = serializers.SerializerMethodField()
+    data_collection_permissions = serializers.SerializerMethodField()
+    optional_data_collection_permissions = serializers.SerializerMethodField()
 
     def get_permissions(self, obj):
         # Language tools are not "real" webextensions, they don't have
@@ -172,6 +180,16 @@ class LanguageToolFileSerializer(FileSerializer):
     def get_host_permissions(self, obj):
         # Language tools are not "real" webextensions, they don't have
         # host permissions.
+        return []
+
+    def get_data_collection_permissions(self, obj):
+        # Language tools are not "real" webextensions, they don't have
+        # data collection permissions.
+        return []
+
+    def get_optional_data_collection_permissions(self, obj):
+        # Language tools are not "real" webextensions, they don't have
+        # optional data collection permissions.
         return []
 
 
@@ -1450,11 +1468,16 @@ class ESAddonSerializer(BaseESSerializer, AddonSerializer):
             strict_compatibility=data.get('strict_compatibility', False),
             version=obj,
         )
+        # Set cached properties for permissions (can't be set in __init__).
         file_.permissions = data.get(
             'permissions', data.get('webext_permissions_list', [])
         )
         file_.optional_permissions = data.get('optional_permissions', [])
         file_.host_permissions = data.get('host_permissions', [])
+        file_.data_collection_permissions = data.get('data_collection_permissions', [])
+        file_.optional_data_collection_permissions = data.get(
+            'optional_data_collection_permissions', []
+        )
         return file_
 
     def fake_version_object(self, obj, data, channel):

--- a/src/olympia/addons/tests/test_indexers.py
+++ b/src/olympia/addons/tests/test_indexers.py
@@ -176,6 +176,8 @@ class TestAddonIndexer(TestCase):
             'permissions',
             'optional_permissions',
             'host_permissions',
+            'data_collection_permissions',
+            'optional_data_collection_permissions',
         )
         assert set(files_mapping.keys()) == set(expected_file_keys)
 
@@ -268,6 +270,10 @@ class TestAddonIndexer(TestCase):
         permissions = ['bookmarks', 'random permission']
         optional_permissions = ['cookies', 'optional permission']
         host_permissions = ['https://example.com', 'https://mozilla.com']
+        data_collection_permissions = ['none']
+        optional_data_collection_permissions = [
+            'technicalAndInteraction',
+        ]
         version = self.addon.current_version
         # Add a bunch of things to it to test different scenarios.
         version.license = License.objects.create(name='My licensé', builtin=3)
@@ -277,6 +283,10 @@ class TestAddonIndexer(TestCase):
                 permissions=permissions,
                 optional_permissions=optional_permissions,
                 host_permissions=host_permissions,
+                data_collection_permissions=data_collection_permissions,
+                optional_data_collection_permissions=(
+                    optional_data_collection_permissions
+                ),
             )
         ]
         version.save()
@@ -324,6 +334,13 @@ class TestAddonIndexer(TestCase):
         assert extracted_file['permissions'] == permissions
         assert extracted_file['optional_permissions'] == optional_permissions
         assert extracted_file['host_permissions'] == host_permissions
+        assert (
+            extracted_file['data_collection_permissions'] == data_collection_permissions
+        )
+        assert (
+            extracted_file['optional_data_collection_permissions']
+            == optional_data_collection_permissions
+        )
 
     def test_version_compatibility_with_strict_compatibility_enabled(self):
         version = self.addon.current_version

--- a/src/olympia/files/tests/test_models.py
+++ b/src/olympia/files/tests/test_models.py
@@ -398,6 +398,57 @@ class TestFile(TestCase, amo.tests.AMOPaths):
             'laststring!',
         ]
 
+    def test_data_collection_permissions(self):
+        file_ = File.objects.get(pk=67442)
+        data_collection_permissions = [
+            'iamstring',
+            'iamnutherstring',
+            {'iamadict': 'hmm'},
+            ['iamalistinalist', 'indeedy'],
+            13,
+            'laststring!',
+            'iamstring',
+            'iamnutherstring',
+            'laststring!',
+            None,
+        ]
+        WebextPermission.objects.create(
+            data_collection_permissions=data_collection_permissions, file=file_
+        )
+
+        # Strings only please.No duplicates.
+        assert file_.data_collection_permissions == [
+            'iamstring',
+            'iamnutherstring',
+            'laststring!',
+        ]
+
+    def test_optional_data_collection_permissions(self):
+        file_ = File.objects.get(pk=67442)
+        optional_data_collection_permissions = [
+            'iamstring',
+            'iamnutherstring',
+            {'iamadict': 'hmm'},
+            ['iamalistinalist', 'indeedy'],
+            13,
+            'laststring!',
+            'iamstring',
+            'iamnutherstring',
+            'laststring!',
+            None,
+        ]
+        WebextPermission.objects.create(
+            optional_data_collection_permissions=optional_data_collection_permissions,
+            file=file_,
+        )
+
+        # Strings only please.No duplicates.
+        assert file_.optional_data_collection_permissions == [
+            'iamstring',
+            'iamnutherstring',
+            'laststring!',
+        ]
+
     def test_has_been_validated_returns_false_when_no_validation(self):
         file = File()
         assert not file.has_been_validated


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/15620

### Testing

- Follow instructions in https://github.com/mozilla/addons-server/pull/23545 to upload an add-on with data collection permissions, but make sure to submit it as listed
- Approve that add-on
- Look at its detail API (`http://olympia.test/api/v5/addons/addon/<pk_or_slug_or_guid>/`) and search API (`http://olympia.test/api/v5/addons/search/?guid=<guid>`) and check `data_collection_permissions` and `optional_data_collection_permissions` are there and correct

Bonus:
- Check search API still works for other add-ons you already had (the 2 data collection properties should be an empty array)
