### PR TITLE
Don't add NHR for a version we couldn't auto-approve if it's waiting for 2nd level approval

### DIFF
--- a/src/olympia/reviewers/management/commands/auto_approve.py
+++ b/src/olympia/reviewers/management/commands/auto_approve.py
@@ -218,11 +218,15 @@ class Command(BaseCommand):
         # could leave the review queue and re-enter it multiple times.
         for key in verdicts_to_reasons:
             reason = verdicts_to_reasons[key]
-            if not version.pending_rejection and (
-                getattr(version.autoapprovalsummary, key)
-                and not version.needshumanreview_set.filter(
-                    reason=reason, is_active=True
-                ).exists()
+            if (
+                not version.pending_rejection
+                and not version.contentdecision_set.awaiting_action().exists()
+                and (
+                    getattr(version.autoapprovalsummary, key)
+                    and not version.needshumanreview_set.filter(
+                        reason=reason, is_active=True
+                    ).exists()
+                )
             ):
                 NeedsHumanReview.objects.create(version=version, reason=reason)
 

--- a/src/olympia/reviewers/management/commands/auto_approve.py
+++ b/src/olympia/reviewers/management/commands/auto_approve.py
@@ -218,15 +218,20 @@ class Command(BaseCommand):
         # could leave the review queue and re-enter it multiple times.
         for key in verdicts_to_reasons:
             reason = verdicts_to_reasons[key]
+            was_not_auto_approved_because_of_that_reason = getattr(
+                version.autoapprovalsummary, key
+            )
+            has_decision_waiting_for_2nd_level_approval = (
+                version.contentdecision_set.awaiting_action().exists()
+            )
+            already_has_same_active_nhr = version.needshumanreview_set.filter(
+                reason=reason, is_active=True
+            ).exists()
             if (
-                not version.pending_rejection
-                and not version.contentdecision_set.awaiting_action().exists()
-                and (
-                    getattr(version.autoapprovalsummary, key)
-                    and not version.needshumanreview_set.filter(
-                        reason=reason, is_active=True
-                    ).exists()
-                )
+                was_not_auto_approved_because_of_that_reason
+                and not version.pending_rejection
+                and not has_decision_waiting_for_2nd_level_approval
+                and not already_has_same_active_nhr
             ):
                 NeedsHumanReview.objects.create(version=version, reason=reason)
 


### PR DESCRIPTION
Fixes mozilla/addons#15618

### Context

Before this patch, each time `auto_approve` is attempted for an add-on with auto-approval disabled or belonging to a promoted group that should prevent auto-approval, if the version was not pending rejection we'd add a NHR, unless there was already one. That in turn is what causes such add-ons to land in the manual review queue.

### Description

With that change, we also look if the version has a decision waiting for second level approval as well before attempting to add the NHR. If the version in the second level approval queue, that means someone already looked at it, we don't need to add it to the manual review queue again.

### Testing

- Submit a new version of a recommended or notable add-on with a listed version
- Run `auto_approve`, that version should get a new active NHR
- Go to the review page for that add-on and reject all versions, including that new one awaiting review. Note that the new version was marked as needing human review (orange background, has a due date)
- Since the add-on is part of a high-profile promoted group, that decision should be held for second level approval
- Leave the review page and run `auto_approve` again

Expected results:
- The add-on shouldn't get a new NHR