### PR TITLE
Use commit sha as ref because commit message is too unpredictable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,8 @@ jobs:
   locales:
     runs-on: ubuntu-latest
     needs: [build, context]
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,26 @@ jobs:
       is_release_tag: ${{ steps.context.outputs.is_release_tag }}
       docker_version: ${{ steps.context.outputs.docker_version }}
 
+      short_sha: ${{ steps.git.outputs.short_sha }}
+      short_message: ${{ steps.git.outputs.short_message }}
+
     steps:
       - name: Set context
         id: context
         uses: mozilla/addons/.github/actions/context@f1d4daa008d908d52815aa41257db39b8cdef958
+
+      - name: Git
+        id: git
+        env:
+          sha: ${{ github.sha }}
+          message: ${{ github.event.head_commit.message}}
+        run: |
+          short_sha=$(echo "${sha}" | cut -c1-7)
+          short_message=$(echo "${message}" | tr -d '\n' | tr -dc '[:print:]' | cut -c1-140)
+
+          echo "short_sha=${short_sha}" >> "$GITHUB_OUTPUT"
+          echo "short_message=${short_message}" >> "$GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"
 
   test_actions:
     permissions:
@@ -296,8 +312,8 @@ jobs:
           -
             name: Push Dockerhub
             result: ${{ needs.push_dockerhub.result }}
-            ref: ${{ github.event.head_commit.message }}
-            ref_link: ${{ github.event.head_commit.url }}
+            ref: ${{ format('{0} {1}', needs.context.outputs.short_sha, needs.context.outputs.short_message) }}
+            ref_link: ${{ github.event.compare }}
           -
             name: Push GAR
             result: ${{ needs.push_gar.result }}
@@ -318,12 +334,15 @@ jobs:
         env:
           result: ${{ matrix.result }}
         run: |
-          dry_run="${{ contains(needs.*.result, 'skipped') }}"
+          dry_run=false
+          emoji=":x:"
 
           if [[ "$result" == "success" ]]; then
             emoji=":white_check_mark:"
           elif [[ "$result" == "cancelled" ]]; then
             emoji=":github-actions-cancelled:"
+          elif [[ "$result" == "skipped" ]]; then
+            dry_run=true
           else
             emoji=":x:"
           fi


### PR DESCRIPTION
Fixes: mozilla/addons#15312

## Description

Follow up to https://github.com/mozilla/addons-server/pull/23566

### Clip commit message and add sha

The commit message could be multi-line and contain characters that are difficult to serialize in bash scripts. So we can shorten the message/sha to make it more readable and bash compliant

### Give locales job permission to write contents

add the correct permissions for locales job to push locales

### Fix condition for dry run

We want to be more explicit how we determine if a notification is `dry_run` by only looking at the specific result and not all dependent jobs. some jobs could be skipped or cancelled and this should not indicate a dry run but only if the specific job we care about was skipped.

## Context

<img width="530" alt="image" src="https://github.com/user-attachments/assets/bad43e00-e788-4ab2-ac7f-d11cfbe4757d" />

## Testing

### Checklist

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
