### PR TITLE
exclude 2nd level approval requeued jobs from being auto resolved

### DIFF
--- a/src/olympia/abuse/management/commands/auto_resolve_reports.py
+++ b/src/olympia/abuse/management/commands/auto_resolve_reports.py
@@ -10,7 +10,9 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         job_ids = (
-            CinderJob.objects.unresolved().resolvable_in_reviewer_tools()
+            CinderJob.objects.filter(
+                decisions__isnull=True
+            ).resolvable_in_reviewer_tools()
         ).values_list('id', flat=True)
         self.stdout.write(f'{len(job_ids)} unresolved CinderJobs in reviewer tools')
 

--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -216,6 +216,7 @@ class CinderJob(ModelBase):
             action_date=datetime.now(),
             reviewer_user_id=settings.TASK_USER_ID,
             cinder_job=self,
+            override_of=self.final_decision,
         )
         decision.policies.set(
             CinderPolicy.objects.filter(


### PR DESCRIPTION
Fixes: mozilla/addons#15671

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Changes filtering in command to only process jobs that have no decisions (meaning we won't try to process any jobs that have had a decision that was subsequently held or overridden)

### Testing

A little tricky to set up, because we're testing for a situation that wouldn't occur (the relevant jobs would already have been closed).
- select an add-on that has a public listing - the current version should **not** have a human review date, but **should** be `is_signed=True`
  - use django admin to tinker with the version/file
- make the add-on promoted in django admin
- report an add-on for abuse for in the add-on, for a policy violation.
- check the job is open and the add-on is flagged for review in the review tools
- reject all the versions of the add-on while resolving the open job
  - it should be held for 2nd level approval as it's promoted; a signed version is being rejected; and the add-on will no longer be public.
- run `auto_resolve_reports` command - the job shouldn't be closed

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
