### PR TITLE
Include policy text in stakeholder email (if reviewer tools uses policies)

### DIFF
--- a/src/olympia/abuse/actions.py
+++ b/src/olympia/abuse/actions.py
@@ -438,6 +438,7 @@ class ContentActionRejectVersion(ContentActionDisableAddon):
             )
             context_dict = {
                 'new_current_version': new_current_version,
+                'policy_texts': self.decision.get_policy_texts(),
                 'private_notes': self.decision.private_notes,
                 'reasoning': self.decision.reasoning,
                 'rejection_type': rejection_type,

--- a/src/olympia/abuse/templates/abuse/emails/stakeholder_notification.txt
+++ b/src/olympia/abuse/templates/abuse/emails/stakeholder_notification.txt
@@ -2,6 +2,14 @@
 [Listed] {{ version_list_listed }}
 [Unlisted] {{ version_list_unlisted }}
 
+{% if policy_texts %}
+Policies:
+{% for policytext in policy_texts %}
+    {# Policies text may contain HTML entities, this is a text email so we consider that safe #}
+    - {{ policytext|safe }}
+{% endfor %}
+{% endif %}
+
 Reasoning:
 {{ reasoning }}
 


### PR DESCRIPTION
Fixes: mozilla/addons#15645

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Include policy texts in stakeholder email, when the content isn't in ContentDecision.reasoning.

### Context

When the waffle switch for https://github.com/mozilla/addons/issues/15513 is enabled CinderPolicies are directly selected, and the comments field is just for additional reasoning.  This means the stakeholder email might not contain any reasoning text, because in the normal case the policy text is supposed to contain all the reasoning for the rejection.

### Testing

- if necessary see https://github.com/mozilla/addons-server/pull/23437 for how to set up CinderPolicy selection in reviewer tools.  tl;dr is:
    - enable `cinder_policy_review_reasons_enabled` waffle switch
    - sync policies from Cinder in django admin
    - edit one of more policies in django admin to make them available for selection in the reviewer tools
- see https://github.com/mozilla/addons-server/pull/23270 for how to set up stakeholder emails, and an appropriate version. tl;dr is:
    - add your userprofile to Stakeholder-Rejection-Notifications
    - make an add-on promoted
    - make the latest version have `is_signed=True` for the File.
- reject the latest version, choosing one or more policies (one with placeholder fields if you like, but optional)
- look in django admin fakemail and see the stakeholder email, with the policy texts for the policies you chose in the email.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
