### PR TITLE
Fix overrides of negative reviewer/moderator actions for add-ons

### DIFF
--- a/src/olympia/abuse/actions.py
+++ b/src/olympia/abuse/actions.py
@@ -761,7 +761,7 @@ class ContentActionTargetAppealApprove(
             elif self.previous_decisions.filter(
                 action=DECISION_ACTIONS.AMO_REJECT_VERSION_WARNING_ADDON
             ).exists():
-                for version in self.data['versions']:
+                for version in target_versions:
                     VersionReviewerFlags.objects.update_or_create(
                         version=version,
                         defaults={

--- a/src/olympia/abuse/actions.py
+++ b/src/olympia/abuse/actions.py
@@ -813,14 +813,10 @@ class ContentActionOverrideApprove(ContentActionTargetAppealApprove):
     @property
     def previous_decisions(self):
         """Queryset with previous decisions made that this action would revert."""
-        # We want a queryset to be able to filter later, so create one from the
-        # overriden instance, or just return an empty one.
-        qs = self.decision.__class__.objects.all()
-        return (
-            qs.filter(pk=self.decision.override_of.pk)
-            if self.decision.override_of
-            else qs.none()
-        )
+        # If there is no overriden decision this will be an impossible query
+        # returning nothing, which is what we want here since this class is
+        # specific to overrides actions.
+        return self.decision.__class__.objects.filter(pk=self.decision.override_of_id)
 
 
 class ContentActionApproveNoAction(AnyTargetMixin, NoActionMixin, ContentAction):

--- a/src/olympia/abuse/tests/test_actions.py
+++ b/src/olympia/abuse/tests/test_actions.py
@@ -57,6 +57,12 @@ from ..models import AbuseReport, CinderAppeal, CinderJob, CinderPolicy, Content
 class BaseTestContentAction:
     def setUp(self):
         addon = addon_factory()
+        self.past_negative_decision = ContentDecision.objects.create(
+            cinder_id='4815162342',
+            action=DECISION_ACTIONS.AMO_DISABLE_ADDON,
+            addon=addon,
+            action_date=datetime.now(),
+        )
         self.decision = ContentDecision.objects.create(
             cinder_id='ab89',
             action=DECISION_ACTIONS.AMO_APPROVE,
@@ -255,13 +261,17 @@ class BaseTestContentAction:
         assert self.decision.private_notes not in mail_item.body
 
     def _test_approve_appeal_or_override(ContentActionClass):
+        # Common things that we expect to happen after a successful appeal or
+        # override of a negative action.
         raise NotImplementedError
 
     def test_approve_appeal_success(self):
+        self.past_negative_decision.update(appeal_job=self.cinder_job)
         self._test_approve_appeal_or_override(ContentActionTargetAppealApprove)
         assert 'After reviewing your appeal' in mail.outbox[0].body
 
     def test_approve_override(self):
+        self.decision.update(override_of=self.past_negative_decision)
         self._test_approve_appeal_or_override(ContentActionOverrideApprove)
         assert 'After reviewing your appeal' not in mail.outbox[0].body
 
@@ -425,6 +435,9 @@ class TestContentActionUser(BaseTestContentAction, TestCase):
         self.user = user_factory(display_name='<b>Bad Hørse</b>')
         self.cinder_job.abusereport_set.update(user=self.user, guid=None)
         self.decision.update(addon=None, user=self.user)
+        self.past_negative_decision.update(
+            addon=None, user=self.user, action=DECISION_ACTIONS.AMO_BAN_USER
+        )
 
     def _test_ban_user(self):
         self.decision.update(action=DECISION_ACTIONS.AMO_BAN_USER)
@@ -614,6 +627,12 @@ class TestContentActionDisableAddon(BaseTestContentAction, TestCase):
         self.cinder_job.abusereport_set.update(guid=self.addon.guid)
         self.decision.update(addon=self.addon)
         self.decision.target_versions.set((self.version, self.old_version))
+        self.past_negative_decision.update(
+            addon=self.addon, action=self.takedown_decision_action
+        )
+        self.past_negative_decision.target_versions.set(
+            (self.version, self.old_version)
+        )
 
     def test_addon_version_has_target_versions(self):
         # if the decision has target_versions, then the most recent target
@@ -714,12 +733,6 @@ class TestContentActionDisableAddon(BaseTestContentAction, TestCase):
     def _test_approve_appeal_or_override(self, ContentActionClass):
         self.addon.update(status=amo.STATUS_DISABLED)
         ActivityLog.objects.all().delete()
-        ContentDecision.objects.create(
-            appeal_job=self.cinder_job,
-            action=DECISION_ACTIONS.AMO_DISABLE_ADDON,
-            action_date=datetime.now(),
-            addon=self.addon,
-        ).target_versions.set(self.decision.target_versions.all())
         action = ContentActionClass(self.decision)
         activity = action.process_action()
 
@@ -1049,7 +1062,7 @@ class TestContentActionRejectVersion(TestContentActionDisableAddon):
     ActionClass = ContentActionRejectVersion
     activity_log_action = amo.LOG.REJECT_VERSION
     disable_snippet = 'versions of your Extension have been disabled'
-    takedown_decision_action = DECISION_ACTIONS.AMO_DISABLE_ADDON
+    takedown_decision_action = DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON
 
     def setUp(self):
         super().setUp()
@@ -1132,12 +1145,6 @@ class TestContentActionRejectVersion(TestContentActionDisableAddon):
         )
         # set-up where version.file doesn't have an original_status for some reason
         self.version.file.update(status=amo.STATUS_DISABLED)
-        ContentDecision.objects.create(
-            appeal_job=self.cinder_job,
-            action=DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON,
-            action_date=datetime.now(),
-            addon=self.addon,
-        ).target_versions.set(self.decision.target_versions.all())
         ActivityLog.objects.all().delete()
         action = ContentActionClass(self.decision)
         activity = action.process_action()
@@ -1739,6 +1746,11 @@ class TestContentActionCollection(BaseTestContentAction, TestCase):
         )
         self.cinder_job.abusereport_set.update(collection=self.collection, guid=None)
         self.decision.update(addon=None, collection=self.collection)
+        self.past_negative_decision.update(
+            addon=None,
+            collection=self.collection,
+            action=DECISION_ACTIONS.AMO_DELETE_COLLECTION,
+        )
 
     def _test_delete_collection(self):
         self.decision.update(action=DECISION_ACTIONS.AMO_DELETE_COLLECTION)
@@ -1903,6 +1915,9 @@ class TestContentActionRating(BaseTestContentAction, TestCase):
         )
         self.cinder_job.abusereport_set.update(rating=self.rating, guid=None)
         self.decision.update(addon=None, rating=self.rating)
+        self.past_negative_decision.update(
+            addon=None, rating=self.rating, action=DECISION_ACTIONS.AMO_DELETE_RATING
+        )
         ActivityLog.objects.all().delete()
 
     def _test_delete_rating(self):

--- a/src/olympia/constants/reviewers.py
+++ b/src/olympia/constants/reviewers.py
@@ -1,5 +1,7 @@
 from django.utils.translation import gettext_lazy as _
 
+from extended_choices import Choices
+
 from .base import ADDON_ANY, ADDON_EXTENSION, ADDON_STATICTHEME
 
 
@@ -67,3 +69,11 @@ REASON_ADDON_TYPE_CHOICES = {
     ADDON_EXTENSION: _('Extension'),
     ADDON_STATICTHEME: _('Theme'),
 }
+
+HELD_DECISION_CHOICES = Choices(
+    ('YES', 'yes', 'Proceed with action'),
+    ('NO', 'no', 'Approve content instead'),
+    ('CANCEL', 'cancel', 'Cancel and enqueue in Reviewer Tools'),
+)
+HELD_DECISION_CHOICES.add_subset('ADDON', ('YES', 'CANCEL'))
+HELD_DECISION_CHOICES.add_subset('OTHER', ('YES', 'NO'))

--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -27,7 +27,10 @@ from olympia.addons.models import Addon
 from olympia.amo.forms import AMOModelForm
 from olympia.amo.templatetags.jinja_helpers import format_datetime
 from olympia.constants.abuse import DECISION_ACTIONS
-from olympia.constants.reviewers import HELD_DECISION_CHOICES, REVIEWER_DELAYED_REJECTION_PERIOD_DAYS_DEFAULT
+from olympia.constants.reviewers import (
+    HELD_DECISION_CHOICES,
+    REVIEWER_DELAYED_REJECTION_PERIOD_DAYS_DEFAULT,
+)
 from olympia.files.utils import SafeZip
 from olympia.ratings.models import Rating
 from olympia.ratings.permissions import user_can_delete_rating

--- a/src/olympia/reviewers/forms.py
+++ b/src/olympia/reviewers/forms.py
@@ -27,7 +27,7 @@ from olympia.addons.models import Addon
 from olympia.amo.forms import AMOModelForm
 from olympia.amo.templatetags.jinja_helpers import format_datetime
 from olympia.constants.abuse import DECISION_ACTIONS
-from olympia.constants.reviewers import REVIEWER_DELAYED_REJECTION_PERIOD_DAYS_DEFAULT
+from olympia.constants.reviewers import HELD_DECISION_CHOICES, REVIEWER_DELAYED_REJECTION_PERIOD_DAYS_DEFAULT
 from olympia.files.utils import SafeZip
 from olympia.ratings.models import Rating
 from olympia.ratings.permissions import user_can_delete_rating
@@ -893,10 +893,7 @@ class HeldDecisionReviewForm(forms.Form):
         widget=CinderJobsWidget(),
         disabled=True,
     )
-    choice = forms.ChoiceField(
-        choices=(('yes', 'Proceed with action'), ('no', 'Approve content instead')),
-        widget=forms.RadioSelect,
-    )
+    choice = forms.ChoiceField(widget=forms.RadioSelect)
     comments = forms.CharField(required=False)
 
     def __init__(self, *args, **kw):
@@ -909,9 +906,9 @@ class HeldDecisionReviewForm(forms.Form):
             self.fields['cinder_job'].queryset = self.cinder_jobs_qs
             self.fields['cinder_job'].initial = [job.id for job in self.cinder_jobs_qs]
         if self.decision.addon:
-            self.fields['choice'].choices += (
-                ('cancel', 'Cancel and enqueue in Reviewer Tools'),
-            )
+            self.fields['choice'].choices = HELD_DECISION_CHOICES.ADDON
+        else:
+            self.fields['choice'].choices = HELD_DECISION_CHOICES.OTHER
 
     def clean(self):
         super().clean()

--- a/src/olympia/reviewers/tests/test_forms.py
+++ b/src/olympia/reviewers/tests/test_forms.py
@@ -1577,7 +1577,7 @@ class TestHeldDecisionReviewForm(TestCase):
         form = HeldDecisionReviewForm(decision=decision)
         assert form.fields['choice'].choices == [
             ('yes', 'Proceed with action'),
-            ('cancel', 'Cancel and enqueue in Reviewer Tools')
+            ('cancel', 'Cancel and enqueue in Reviewer Tools'),
         ]
 
     def test_choices_user(self):
@@ -1589,7 +1589,7 @@ class TestHeldDecisionReviewForm(TestCase):
         form = HeldDecisionReviewForm(decision=decision)
         assert form.fields['choice'].choices == [
             ('yes', 'Proceed with action'),
-            ('no', 'Approve content instead')
+            ('no', 'Approve content instead'),
         ]
 
     def test_choices_rating(self):
@@ -1601,19 +1601,19 @@ class TestHeldDecisionReviewForm(TestCase):
         form = HeldDecisionReviewForm(decision=decision)
         assert form.fields['choice'].choices == [
             ('yes', 'Proceed with action'),
-            ('no', 'Approve content instead')
+            ('no', 'Approve content instead'),
         ]
 
-    def test_choices_user(self):
+    def test_choices_collection(self):
         decision = ContentDecision.objects.create(
             collection=Collection.objects.create(),
-            action=DECISION_ACTIONS.AMO_BAN_USER,
+            action=DECISION_ACTIONS.AMO_DELETE_COLLECTION,
             action_date=None,
         )
         form = HeldDecisionReviewForm(decision=decision)
         assert form.fields['choice'].choices == [
             ('yes', 'Proceed with action'),
-            ('no', 'Approve content instead')
+            ('no', 'Approve content instead'),
         ]
 
 

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -8012,7 +8012,9 @@ class TestHeldDecisionReview(ReviewerTest):
         assert 'Add-on disable' in doc('tr.decision-action td').html()
         assert 'Bad Things' in doc('tr.decision-policies td').html()
         assert 'Proceed with action' == doc('[for="id_choice_0"]').text()
-        assert 'Cancel and enqueue in Reviewer Tools' == doc('[for="id_choice_1"]').text()
+        assert (
+            'Cancel and enqueue in Reviewer Tools' == doc('[for="id_choice_1"]').text()
+        )
         assert 'Affected versions' in doc.text()
         assert self.version.version in doc.text()
         return doc
@@ -8060,7 +8062,7 @@ class TestHeldDecisionReview(ReviewerTest):
         response = self.client.get(self.url)
         assert response.context_data['form'].fields['choice'].choices == [
             ('yes', 'Proceed with action'),
-            ('cancel', 'Cancel and enqueue in Reviewer Tools')
+            ('cancel', 'Cancel and enqueue in Reviewer Tools'),
         ]
 
     def test_cancel_addon_with_job(self):

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -52,6 +52,7 @@ from olympia.api.permissions import (
 )
 from olympia.constants.abuse import DECISION_ACTIONS
 from olympia.constants.reviewers import (
+    HELD_DECISION_CHOICES,
     MAX_VERSIONS_SHOWN_INLINE,
     REVIEWS_PER_PAGE,
     REVIEWS_PER_PAGE_MAX,
@@ -1278,10 +1279,10 @@ def decision_review(request, decision_id):
     if form.is_valid():
         data = form.cleaned_data
         match data.get('choice'):
-            case 'yes':
+            case HELD_DECISION_CHOICES.YES:
                 decision.execute_action(release_hold=True)
                 decision.send_notifications()
-            case 'no':
+            case HELD_DECISION_CHOICES.NO:
                 new_decision = ContentDecision.objects.create(
                     addon=decision.addon,
                     rating=decision.rating,
@@ -1300,7 +1301,7 @@ def decision_review(request, decision_id):
                 new_decision.execute_action(release_hold=True)
                 new_decision.target_versions.set(decision.target_versions.all())
                 report_decision_to_cinder_and_notify.delay(decision_id=new_decision.id)
-            case 'cancel':
+            case HELD_DECISION_CHOICES.CANCEL:
                 decision.requeue_held_action(
                     user=request.user, notes=data.get('comments', '')
                 )


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/15653

This fixes overrides of negative actions but also remove the ability to override a decision about an add-on in second level approval (they remain available for other kind of content) - you have to use the review page (or Cinder) to make a new decision about add-ons.

### Testing

This is the full testing QA should do. I don't expect a reviewer to do all of that.

#### Overrides in general
- Report an [add-on, collection, user, rating] publicly available on AMO frontend for a reason like hateful content. Avoid content that would trigger 2nd level approval. For add-ons, specify that the location is on the page and not inside the add-on and don't pick a promoted one. For users/collections/ratings, pick content not tied to staff/developers of promoted add-ons.
- Find the report in Cinder, then disable the content
- Make sure the content has been disabled
- Using decisions tab or investigate feature in Cinder to find that decision, override it and approve it instead
- Make sure the content is back up

#### Second level approval of non add-ons
- Report a [collection, user, rating] publicly available on AMO frontend for a reason like hateful content. We want to trigger 2nd level approval, so when picking/creating the relevant content, the collection should be owned by the TASK_USER_ID user, the user should be a staff user or someone who is an author of add-ons belonging to a high-profile promoted group, the rating should be a developer reply on an add-ons belonging to a high-profile promoted group.
- Find the report in Cinder, then disable the content
- Make sure the decision is held for 2nd level approval
- In second level approval, find that decision and note that you can either approve the content instead of proceeding with the decision
- Test that both options work

#### Second level approval of add-ons
- Report an add-on publicly available on AMO for violating policies in the add-on. Pick an add-on that would trigger 2nd level approval, such as a recommended add-on.
- In reviewer tools, disable the add-on, or reject its versions
- Make sure that decision is held for 2nd level approval
- In second level approval, find that decision and note that you can no longer approve the content instead, but only proceed with the decision or enqueue the add-on back in reviewer tools.
- Test that both options work
