### PR TITLE
remove NOT_PROMOTED group as a concept.

### DIFF
--- a/src/olympia/amo/tests/__init__.py
+++ b/src/olympia/amo/tests/__init__.py
@@ -55,7 +55,6 @@ from olympia.applications.models import AppVersion
 from olympia.bandwagon.models import Collection
 from olympia.blocklist.models import Block, BlockType, BlockVersion
 from olympia.constants.categories import CATEGORIES
-from olympia.constants.promoted import PROMOTED_GROUP_CHOICES
 from olympia.files.models import File
 from olympia.promoted.models import (
     PromotedAddon,
@@ -589,8 +588,6 @@ class TestCase(PatchMixin, InitializeSessionMixin, test.TestCase):
         """
         Promotes the addon for the group in the given apps, or all if none are given.
         """
-        if group_id == PROMOTED_GROUP_CHOICES.NOT_PROMOTED:
-            return
 
         promoted_group = PromotedGroup.objects.get(group_id=group_id)
 
@@ -738,7 +735,7 @@ def addon_factory(status=amo.STATUS_APPROVED, version_kw=None, file_kw=None, **k
         addon = Addon.objects.create(type=type_, **kwargs)
 
     # Save 2.
-    if promoted_group_id and promoted_group_id != PROMOTED_GROUP_CHOICES.NOT_PROMOTED:
+    if promoted_group_id:
         group = PromotedGroup.objects.get(group_id=promoted_group_id)
         for app in amo.APP_USAGE:
             PromotedAddon.objects.create(

--- a/src/olympia/constants/promoted.py
+++ b/src/olympia/constants/promoted.py
@@ -7,7 +7,6 @@ from olympia.constants import applications
 
 
 PROMOTED_GROUP_CHOICES = APIChoices(
-    ('NOT_PROMOTED', 0, 'Not Promoted'),
     ('RECOMMENDED', 1, 'Recommended'),
     ('LINE', 4, 'By Firefox'),
     ('SPOTLIGHT', 5, 'Spotlight'),
@@ -69,13 +68,6 @@ class PromotedClass(_PromotedSuperClass):
     def __bool__(self):
         return bool(self.id)
 
-
-# Obsolete with transition to DB-Based PromotedGroups.
-NOT_PROMOTED = PromotedClass(
-    id=PROMOTED_GROUP_CHOICES.NOT_PROMOTED,
-    name=_('Not Promoted'),
-    api_name=PROMOTED_GROUP_CHOICES.NOT_PROMOTED.api_value,
-)
 
 RECOMMENDED = PromotedClass(
     id=PROMOTED_GROUP_CHOICES.RECOMMENDED,
@@ -170,7 +162,6 @@ PARTNER = PromotedClass(
 # If this list changes, we should update the relevant PromotedGroup instances
 # via a data migration to add/remove the "active" field.
 PROMOTED_GROUPS = [
-    NOT_PROMOTED,
     RECOMMENDED,
     LINE,
     SPOTLIGHT,

--- a/src/olympia/hero/migrations/0014_auto_20200717_1120.py
+++ b/src/olympia/hero/migrations/0014_auto_20200717_1120.py
@@ -11,17 +11,14 @@ def add_promoted_for_each_recommended(apps, schema_editor):
     DiscoveryItem = apps.get_model('discovery', 'DiscoveryItem')
     PromotedAddon = apps.get_model('promoted', 'PromotedAddon')
     for disco in DiscoveryItem.objects.all():
-        group_id = (
-            PROMOTED_GROUP_CHOICES.RECOMMENDED
-            if disco.recommendable
-            else PROMOTED_GROUP_CHOICES.NOT_PROMOTED
-        )
-        promoted, _ = PromotedAddon.objects.get_or_create(
-            addon=disco.addon, group_id=group_id
-        )
-        if hasattr(disco, 'primaryhero'):
-            disco.primaryhero.promoted_addon = promoted
-            disco.primaryhero.save()
+        if disco.recommendable:
+            group_id = PROMOTED_GROUP_CHOICES.RECOMMENDED
+            promoted, _ = PromotedAddon.objects.get_or_create(
+                addon=disco.addon, group_id=group_id
+            )
+            if hasattr(disco, 'primaryhero'):
+                disco.primaryhero.promoted_addon = promoted
+                disco.primaryhero.save()
 
 
 class Migration(migrations.Migration):

--- a/src/olympia/promoted/admin.py
+++ b/src/olympia/promoted/admin.py
@@ -1,10 +1,9 @@
 from django.contrib import admin
-from django.db.models import Prefetch, Q
+from django.db.models import Prefetch
 from django.forms.models import modelformset_factory
 
 from olympia.addons.models import Addon
 from olympia.amo.admin import AMOModelAdmin
-from olympia.constants.promoted import PROMOTED_GROUP_CHOICES
 from olympia.hero.models import PrimaryHero
 from olympia.versions.models import Version
 
@@ -106,9 +105,7 @@ class PromotedAddonAdminInline(admin.TabularInline):
             kwargs['help_text'] = db_field.help_text
             return SlugOrPkChoiceField(**kwargs)
         if db_field.name == 'promoted_group':
-            kwargs['queryset'] = PromotedGroup.objects.filter(
-                ~Q(group_id=PROMOTED_GROUP_CHOICES.NOT_PROMOTED)
-            )
+            kwargs['queryset'] = PromotedGroup.objects.all()
         return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
     def has_delete_permission(self, request, obj=None):

--- a/src/olympia/promoted/migrations/0021_auto_20240919_0952.py
+++ b/src/olympia/promoted/migrations/0021_auto_20240919_0952.py
@@ -11,7 +11,7 @@ def delete_verified_sponsored_promoted_usage(apps, schema_editor):
             PROMOTED_GROUP_CHOICES.VERIFIED,
             PROMOTED_GROUP_CHOICES.SPONSORED,
         )
-    ).update(group_id=PROMOTED_GROUP_CHOICES.NOT_PROMOTED)
+    ).delete()
     PromotedApproval.objects.filter(group_id__in=(
             PROMOTED_GROUP_CHOICES.VERIFIED,
             PROMOTED_GROUP_CHOICES.SPONSORED,

--- a/src/olympia/promoted/models.py
+++ b/src/olympia/promoted/models.py
@@ -116,15 +116,6 @@ class PromotedGroup(models.Model):
     )
     objects = PromotedGroupManager()
 
-    def __bool__(self):
-        """
-        When we use a PromotedGroup in a boolean context, we should treat NOT_PROMOTED
-        as falsey. This is how the rest of the code base expects it. Eventually,
-        we should consider deprectaing the NOT_PROMOTED group which could yield
-        the same result via a database query simply not returning a promoted group.
-        """
-        return bool(self.group_id != PROMOTED_GROUP_CHOICES.NOT_PROMOTED)
-
     def save(self, *args, **kwargs):
         # Obsolete, never used in production, only there to prevent us from re-using
         # the ids. Both these classes used to have specific properties set that were

--- a/src/olympia/promoted/tests/test_models.py
+++ b/src/olympia/promoted/tests/test_models.py
@@ -126,22 +126,12 @@ class TestPromotedGroup(TestCase):
 
     def test_str_method(self):
         # Ensure the __str__ method returns the name
-        for const_group in PROMOTED_GROUPS_BY_ID.values():
-            pg = PromotedGroup.objects.get(group_id=const_group.id)
-            self.assertEqual(str(pg), const_group.name)
-
-    def test_boolean_representation(self):
-        promoted_group = PromotedGroup.objects.create(
-            group_id=PROMOTED_GROUP_CHOICES.NOT_PROMOTED,
-            name='Test',
-            api_name='test',
-        )
-        assert str(promoted_group) == 'Test'
-        assert bool(promoted_group) is False
+        for pg in PromotedGroup.objects.all():
+            self.assertEqual(str(pg), pg.name)
 
     def test_get_active_or_badged_promoted_groups(self):
         active_groups = PromotedGroup.active_groups()
-        assert len(active_groups) == 7
+        assert len(active_groups) == 6
         badged_groups = PromotedGroup.badged_groups()
         assert len(badged_groups) == 2
 

--- a/src/olympia/reviewers/cron.py
+++ b/src/olympia/reviewers/cron.py
@@ -1,7 +1,6 @@
 from datetime import date
 
 from olympia.constants.promoted import (
-    PROMOTED_GROUP_CHOICES,
     PROMOTED_GROUPS,
 )
 from olympia.reviewers.models import QueueCount
@@ -19,12 +18,11 @@ def record_reviewer_queues_counts():
     # Also drill down manual review queue by promoted class (there is no real
     # queue for each, but we still want that data).
     for group in PROMOTED_GROUPS:
-        if group.id != PROMOTED_GROUP_CHOICES.NOT_PROMOTED:
-            querysets[f'{PendingManualApprovalQueueTable.name}/{group.api_name}'] = (
-                PendingManualApprovalQueueTable.get_queryset(None).filter(
-                    promotedaddon__promoted_group__group_id=group.id
-                )
+        querysets[f'{PendingManualApprovalQueueTable.name}/{group.api_name}'] = (
+            PendingManualApprovalQueueTable.get_queryset(None).filter(
+                promotedaddon__promoted_group__group_id=group.id
             )
+        )
 
     # Execute a count for each queryset and record a QueueCount instance for it
     for key, qs in querysets.items():

--- a/src/olympia/reviewers/tests/test_cron.py
+++ b/src/olympia/reviewers/tests/test_cron.py
@@ -20,9 +20,8 @@ class TestQueueCount(TestCase):
         user_factory(pk=settings.TASK_USER_ID)
 
     def _test_expected_count(self, date):
-        # We are recording every queue, plus drilling down in every promoted
-        # group, minus the special not promoted group.
-        expected_count = len(reviewer_tables_registry) + len(PROMOTED_GROUPS) - 1
+        # We are recording every queue, plus drilling down in every promoted group
+        expected_count = len(reviewer_tables_registry) + len(PROMOTED_GROUPS)
         assert QueueCount.objects.filter(date=date).count() == expected_count
 
     def test_empty(self):


### PR DESCRIPTION
Fixes: mozilla/addons#15616

### Description

Remove the `NOT_PROMOTED` group as we rely now on non-existence to represent the NOT_PROMOTED group.

### Context

The codebase was already prepped to handle this flow during the migration to multiple promoted groups, but we did not remove the NOT_PROMOTED group as this is a clean up task. Now that multi-promoted-groups is in prod and stable we can remove this.

### Testing

CI should be enough, but you could try to execute the code paths which are touched with:
- a promoted addon
- a not promoted addon

1. Specifically check that the discovery addon promoted addon inline table still works. Should be able to view and update promoted groups for addons.
2. Run `record_reviewer_queues_counts` should work no errors.

No errors and beavhior should be as expected.

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
