### PR TITLE
Add duplicate_addon_version_for_rollback task

### DIFF
--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -1202,6 +1202,22 @@ class CHANGE_PENDING_REJECTION(_LOG):
     # Not hidden to developers.
 
 
+class VERSION_ROLLBACK(_LOG):
+    # takes add-on, version, VersionString
+    id = 204
+    format = _('{addon} {version} created, to rollback from {0}.')
+    short = _('Version rollback')
+    review_queue = True
+
+
+class VERSION_ROLLBACK_FAILED(_LOG):
+    # takes add-on, version
+    id = 205
+    format = _('{addon} rollback from {version} failed.')
+    short = _('Version rollback failure')
+    review_queue = True
+
+
 LOGS = [x for x in vars().values() if isclass(x) and issubclass(x, _LOG) and x != _LOG]
 # Make sure there's no duplicate IDs.
 assert len(LOGS) == len({log.id for log in LOGS})

--- a/src/olympia/lib/crypto/tests/test_signing.py
+++ b/src/olympia/lib/crypto/tests/test_signing.py
@@ -542,7 +542,7 @@ class TestTasks(TestCase):
         new_file = new_version.file
         assert new_version.version == '0.0.2resigned1'
         # We mocked sign_file(), but the new file on disk should have been
-        # written by copy_bumping_version_number() in sign_addons().
+        # written by copy_xpi_with_new_version_number() in sign_addons().
         assert new_file.file.path
         assert os.path.exists(new_file.file.path)
         with zipfile.ZipFile(new_file.file.path) as zipf:

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -782,6 +782,7 @@ CELERY_TASK_ROUTES = {
     'olympia.users.tasks.resize_photo': {'queue': 'amo'},
     'olympia.users.tasks.update_user_ratings_task': {'queue': 'amo'},
     'olympia.versions.tasks.delete_preview_files': {'queue': 'amo'},
+    'olympia.versions.tasks.duplicate_addon_version_for_rollback': {'queue': 'amo'},
     # 'Default' queue. In theory shouldn't be used, it's mostly a fallback.
     'celery.accumulate': {'queue': 'default'},
     'celery.backend_cleanup': {'queue': 'default'},

--- a/src/olympia/versions/tasks.py
+++ b/src/olympia/versions/tasks.py
@@ -286,7 +286,9 @@ def duplicate_addon_version_for_rollback(*, version_pk, new_version_number, user
     old_version = Version.unfiltered.get(id=version_pk)
     user = UserProfile.objects.get(id=user_pk)
 
-    text = f'Rolling back addon {old_version.addon}, to version {old_version.version}'
+    text = (
+        f'Rolling back add-on "{old_version.addon}", to version "{old_version.version}"'
+    )
     log.info(f'Starting: {text}')
     version = duplicate_addon_version(old_version, new_version_number, user)
     if not version:
@@ -329,7 +331,7 @@ def duplicate_addon_version_for_rollback(*, version_pk, new_version_number, user
             details={
                 # The comment is not translated on purpose, to behave like regular human
                 # approval does.
-                'comments': f'{text} by re-publishing as {new_version_number}, '
+                'comments': f'{text} by re-publishing as "{new_version_number}", '
                 'successfull!\n'
                 'Keep in mind that, like any submission, reviewers may look into this '
                 'version in the future and determine that it requires changes or '

--- a/src/olympia/versions/tests/test_tasks.py
+++ b/src/olympia/versions/tests/test_tasks.py
@@ -699,8 +699,8 @@ class TestDuplicateAddonVersionForRollback(TestCase):
         assert mail.outbox[0].to == [self.user.email]
         assert mail.outbox[0].subject == f'Mozilla Add-ons: Rændom add-on {new.version}'
         assert (
-            f'Rolling back addon {new.addon_id}: Rændom add-on, to version 0.0.1 '
-            f'by re-publishing as {new.version}, successfull' in mail.outbox[0].body
+            f'Rolling back add-on "{new.addon_id}: Rændom add-on", to version "0.0.1" '
+            f'by re-publishing as "{new.version}", successfull' in mail.outbox[0].body
         )
 
     @mock.patch('olympia.lib.crypto.tasks.sign_file')
@@ -758,6 +758,6 @@ class TestDuplicateAddonVersionForRollback(TestCase):
         assert mail.outbox[0].to == [self.user.email]
         assert mail.outbox[0].subject == 'Mozilla Add-ons: Rændom add-on 0.0.1'
         assert (
-            f'Rolling back addon {self.rollback_version.addon_id}: Rændom add-on, to '
-            f'version 0.0.1 failed.' in mail.outbox[0].body
+            f'Rolling back add-on "{self.rollback_version.addon_id}: Rændom add-on", '
+            f'to version "0.0.1" failed.' in mail.outbox[0].body
         )

--- a/src/olympia/versions/tests/test_tasks.py
+++ b/src/olympia/versions/tests/test_tasks.py
@@ -1,17 +1,33 @@
+import json
 import os
+import zipfile
 from base64 import b64encode
+from datetime import datetime
 from unittest import mock
 
 from django.conf import settings
+from django.core import mail
+from django.core.files import temp
+from django.core.files.base import File as DjangoFile
 from django.utils.encoding import force_str
 
 import pytest
 
 from olympia import amo
-from olympia.amo.tests import addon_factory, root_storage, version_factory
-from olympia.versions.models import Version, VersionPreview
-from olympia.versions.tasks import (
+from olympia.activity.models import ActivityLog
+from olympia.amo.tests import (
+    TestCase,
+    addon_factory,
+    create_default_webext_appversion,
+    root_storage,
+    user_factory,
+    version_factory,
+)
+
+from ..models import Version, VersionPreview
+from ..tasks import (
     UI_FIELDS,
+    duplicate_addon_version_for_rollback,
     generate_static_theme_preview,
     hard_delete_versions,
 )
@@ -611,3 +627,137 @@ def test_hard_delete_task():
     assert Version.unfiltered.count() == 2
     hard_delete_versions.delay([version1.pk, version2.pk])
     assert Version.unfiltered.count() == 0
+
+
+class TestDuplicateAddonVersionForRollback(TestCase):
+    def setUp(self):
+        create_default_webext_appversion()
+        user_factory(id=settings.TASK_USER_ID)
+        self.user = user_factory()
+        addon = addon_factory(
+            name='Rændom add-on',
+            guid='@webextension-guid',
+            version_kw={
+                'version': '0.0.1',
+                'created': datetime(2019, 4, 1),
+                'min_app_version': '48.0',
+                'max_app_version': '*',
+                'approval_notes': 'Hey reviewers, this is for you',
+                'human_review_date': datetime(2025, 1, 1),
+            },
+            file_kw={'filename': 'webextension.xpi'},
+            users=[self.user],
+        )
+        self.rollback_version = addon.current_version
+        self.setup_source()
+
+        version_factory(addon=addon)
+        assert Version.unfiltered.count() == 2
+
+    def setup_source(self):
+        self.source_content = ('foo', 'a' * (2**21))
+        with temp.NamedTemporaryFile(
+            suffix='.zip', dir=temp.gettempdir()
+        ) as source_file:
+            with zipfile.ZipFile(source_file, 'w') as zip_file:
+                zip_file.writestr(*self.source_content)
+            source_file.seek(0)
+            self.rollback_version.source.save(
+                os.path.basename(source_file.name), DjangoFile(source_file)
+            )
+            self.rollback_version.save()
+        assert self.rollback_version.source
+
+    def check_activity(self, new):
+        al = ActivityLog.objects.get(action=amo.LOG.VERSION_ROLLBACK.id)
+        assert set(al.versionlog_set.values_list('version', flat=True)) == {
+            new.id,
+            self.rollback_version.id,
+        }
+
+    def check_compatiblity(self, new):
+        assert new.apps.get().min.version == '48.0'
+        assert new.apps.get().max.version == '*'
+
+    def check_source(self, new):
+        assert new.source
+        with zipfile.ZipFile(new.source) as source:
+            content = source.read(self.source_content[0])
+            assert content == self.source_content[1].encode()
+
+    def check_version_fields(self, new):
+        assert new.approval_notes == 'Hey reviewers, this is for you'
+        assert new.human_review_date == self.rollback_version.human_review_date
+        self.assertCloseToNow(new.created)
+
+    def check_new_xpi(self, new):
+        with zipfile.ZipFile(new.file.file.path) as zipf:
+            assert json.loads(zipf.read('manifest.json'))['version'] == new.version
+
+    def check_email(self, new):
+        assert len(mail.outbox) == 1
+        assert mail.outbox[0].to == [self.user.email]
+        assert mail.outbox[0].subject == f'Mozilla Add-ons: Rændom add-on {new.version}'
+        assert (
+            f'Rolling back addon {new.addon_id}: Rændom add-on, to version 0.0.1 '
+            f'by re-publishing as {new.version}, successfull' in mail.outbox[0].body
+        )
+
+    @mock.patch('olympia.lib.crypto.tasks.sign_file')
+    def _test_rollback_success(self, sign_file_mock):
+        new_version_number = '123'
+
+        duplicate_addon_version_for_rollback.delay(
+            version_pk=self.rollback_version.pk,
+            new_version_number=new_version_number,
+            user_pk=self.user.pk,
+        )
+
+        assert self.rollback_version.addon.versions.count() == 3
+        new_version = Version.objects.first()
+        if self.rollback_version.channel == amo.CHANNEL_LISTED:
+            assert self.rollback_version.addon.reload().current_version == new_version
+        assert new_version.version == new_version_number
+        sign_file_mock.assert_called_once()
+
+        self.check_activity(new_version)
+        self.check_compatiblity(new_version)
+        self.check_source(new_version)
+        self.check_version_fields(new_version)
+        self.check_new_xpi(new_version)
+        self.check_email(new_version)
+        return new_version
+
+    def test_listed(self):
+        self._test_rollback_success()
+
+    def test_unlisted(self):
+        self.rollback_version.update(channel=amo.CHANNEL_UNLISTED)
+        new_version = self._test_rollback_success()
+        assert new_version.channel == amo.CHANNEL_UNLISTED
+
+    @mock.patch('olympia.lib.crypto.tasks.sign_file')
+    def test_missing_file(self, sign_file_mock):
+        new_version_number = '123'
+        self.rollback_version.file.update(file='')
+
+        duplicate_addon_version_for_rollback.delay(
+            version_pk=self.rollback_version.pk,
+            new_version_number=new_version_number,
+            user_pk=self.user.pk,
+        )
+
+        assert self.rollback_version.addon.versions.count() == 2
+        sign_file_mock.assert_not_called()
+
+        al = ActivityLog.objects.get(action=amo.LOG.VERSION_ROLLBACK_FAILED.id)
+        assert set(al.versionlog_set.values_list('version', flat=True)) == {
+            self.rollback_version.id,
+        }
+        assert len(mail.outbox) == 1
+        assert mail.outbox[0].to == [self.user.email]
+        assert mail.outbox[0].subject == 'Mozilla Add-ons: Rændom add-on 0.0.1'
+        assert (
+            f'Rolling back addon {self.rollback_version.addon_id}: Rændom add-on, to '
+            f'version 0.0.1 failed.' in mail.outbox[0].body
+        )


### PR DESCRIPTION
Fixes: mozilla/addons#15658 and fixes mozilla/addons#15659 (more or less)

### Description

Adds a task that can be triggered to duplicate an existing version.  Note this is the first step so can only be triggered in a django console.

(We probably wouldn't allow a developer to "rollback" to the current version, but as a proof of concept, and showing what it would look like in reviewer tools)
![Screenshot 2025-06-30 150718](https://github.com/user-attachments/assets/0e0d7dac-46ff-45d2-b1b1-47bc29f3e8bb)


### Context

I started writing this from scratch but realized the existing resigning task was almost what we need, so refactored that code, so we can reuse it (mostly). This first step differs a little than the spec in that: it talks about linking the review history in the UI (this links using `VersionLog`, so it shows up in both places); and doesn't trigger the validator and ignore any errors, it just copies the old results. If we want to follow the spec in these cases, we can address in follow-ups (I think these changes are preferable anyway)

### Testing

- Identify a version of an add-on to rollback.  Ideally (to test everything) it would:
    - have a source zip upload
    - be signed 
    - have been superseded by a newer approved version 
    - have been human reviewed (either manual approval, or confirmed after auto approval)
- in a django shell import `olympia.versions.tasks.duplicate_addon_version_for_rollback` and run `duplicate_addon_version_for_rollback.delay(version_pk=<the version to rollback>, new_version_number=<new version number>, user_pk=<an author*>)`
    -  i.e. `from olympia.versions.tasks import duplicate_addon_version_for_rollback`
    - ~note the~ new version number ~is expected to have been validated before the task is called (so the error can be fed back) so~ will accept anything.
    -  *an author of the add-on, or any user with sufficient perms to upload new version
- See the task has succeeded because the version you specified has been recreated with the new version you specified
- The reviewer tools page for the add-on will look similar to the screenshot - i.e. both versions will have the activity log, and the new version will have the history for old version.
  - if you specified a source file, that should be duplicated in the new version
  - if you chose a human reviewed version, the new version will be human reviewed
- in fake mail there should be an email to all authors of the add-on telling them of the success 

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [x] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
