### PR TITLE
Expose private notes and/or reasoning from reviewer

### DIFF
--- a/src/olympia/reviewers/templates/reviewers/decision_review.html
+++ b/src/olympia/reviewers/templates/reviewers/decision_review.html
@@ -52,7 +52,7 @@
       <th>Policies</th>
       <td>
         <ul>
-          {% for policy in decision.policies.all() %}
+          {% for policy in decision.get_policy_texts() %}
             <li>{{ policy }}</li>
           {% endfor %}
         </ul>
@@ -61,7 +61,10 @@
     <tr class="decision-notes">
       <th>Notes from moderator/reviewer</th>
       <td>
-        {{ decision.notes }}
+        {{ decision.reasoning }}
+      </td>
+      <td>
+        {{ decision.private_notes }}
       </td>
     </tr>
   </table>


### PR DESCRIPTION
Fixes: mozilla/addons#15668

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Shows reasoning and/or private notes on the 2nd level held review page, as it used to before.  Also fix the policy rendering to expose the text with placeholder values

### Testing

- set up a 2nd level approval as per https://mozilla.github.io/addons-server/topics/runbooks/localdev/test_2nd_level_approvals.html
- see the notes from the review, along with any policies selected, on the held review page
- to test private notes from Cinder reviewers:
    - use django shell to `.update` the ContentDecision instance to set `private_notes` (and clear `reasoning` if you like)
    - go back to the held review page and see the private notes exposed

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
