### PR TITLE
Make enable/disable auto-approval an action in review page

### DIFF
--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -1218,6 +1218,26 @@ class VERSION_ROLLBACK_FAILED(_LOG):
     review_queue = True
 
 
+class ENABLE_AUTO_APPROVAL(_LOG):
+    id = 206
+    format = '{addon} auto-approval enabled.'
+    short = 'Auto-Approval enabled'
+    keep = True
+    reviewer_review_action = True
+    review_queue = True
+    hide_developer = True
+
+
+class DISABLE_AUTO_APPROVAL(_LOG):
+    id = 207
+    format = '{addon} auto-approval disabled.'
+    short = 'Auto-Approval disabled'
+    keep = True
+    reviewer_review_action = True
+    review_queue = True
+    hide_developer = True
+
+
 LOGS = [x for x in vars().values() if isclass(x) and issubclass(x, _LOG) and x != _LOG]
 # Make sure there's no duplicate IDs.
 assert len(LOGS) == len({log.id for log in LOGS})

--- a/src/olympia/reviewers/management/commands/auto_approve.py
+++ b/src/olympia/reviewers/management/commands/auto_approve.py
@@ -179,6 +179,7 @@ class Command(BaseCommand):
             addon=version.addon,
             version=version,
             human_review=False,
+            channel=version.channel,
         )
         approve_action = helper.actions.get('public')
         if not approve_action:

--- a/src/olympia/reviewers/management/commands/auto_reject.py
+++ b/src/olympia/reviewers/management/commands/auto_reject.py
@@ -68,7 +68,9 @@ class Command(BaseCommand):
                 addon,
             )
             return
-        helper = ReviewHelper(addon=addon, version=latest_version, human_review=False)
+        helper = ReviewHelper(
+            addon=addon, version=latest_version, human_review=False, channel=None
+        )
         relevant_activity_logs = ActivityLog.objects.for_versions(versions).filter(
             action__in=(
                 amo.LOG.REJECT_CONTENT_DELAYED.id,

--- a/src/olympia/reviewers/templates/reviewers/includes/history.html
+++ b/src/olympia/reviewers/templates/reviewers/includes/history.html
@@ -1,6 +1,9 @@
 <tr>
   <th>
     {{ record.log.short|default }}
+    {% if record.details and record.details.channel %}
+      ({{ amo.CHANNEL_CHOICES.get(record.details.channel) }})
+    {% endif %}
   </th>
   <td class="record-container">
       <div>

--- a/src/olympia/reviewers/templates/reviewers/review.html
+++ b/src/olympia/reviewers/templates/reviewers/review.html
@@ -139,7 +139,9 @@
     </p>
   {% endif %}
 
-  <input type="hidden" name="version_pk" value="{{ version.pk }}"/>
+  {% if version %}
+    <input type="hidden" name="version_pk" value="{{ version.pk }}"/>
+  {% endif %}
   {{ form.version_pk.errors }}
   {% if form.errors.__all__ %}
     {{ form.errors.__all__ }}
@@ -373,25 +375,11 @@
         </li>
       {% else %}
         {% if addon.type in (amo.ADDON_EXTENSION, amo.ADDON_LPAPP, amo.ADDON_DICT) %}
-          {% if channel == amo.CHANNEL_LISTED and addon.promoted_groups(currently_approved=False).listed_pre_review|python_any %}
+          {% if channel == amo.CHANNEL_LISTED and promoted_groups.listed_pre_review|python_any %}
           <li>
             <button id="auto_approval_disabled" class="disabled" disabled type="button">Listed Auto-Approval Disabled by Promoted group</button>
           </li>
           {% elif channel == amo.CHANNEL_LISTED %}
-          <li {% if addon.auto_approval_disabled %}class="hidden"{% endif %}>
-            <button data-api-url="{{ drf_url('reviewers-addon-flags', addon.pk) }}"
-                    data-api-method="patch"
-                    data-api-data="{&quot;auto_approval_disabled&quot;: true}"
-                    data-toggle-button-selector="#enable_auto_approval"
-                    id="disable_auto_approval" class="toggle" type="button">Disable Listed Auto-Approval</button>
-          </li>
-          <li {% if not addon.auto_approval_disabled %}class="hidden"{% endif %}>
-            <button data-api-url="{{ drf_url('reviewers-addon-flags', addon.pk) }}"
-                    data-api-method="patch"
-                    data-api-data="{&quot;auto_approval_disabled&quot;: false}"
-                    data-toggle-button-selector="#disable_auto_approval"
-                    id="enable_auto_approval" class="toggle" type="button">Enable Listed Auto-Approval</button>
-          </li>
           <li {% if addon.auto_approval_disabled_until_next_approval %}class="hidden"{% endif %}>
             <button data-api-url="{{ drf_url('reviewers-addon-flags', addon.pk) }}"
                     data-api-method="patch"
@@ -406,25 +394,11 @@
                     data-toggle-button-selector="#disable_auto_approval_until_next_approval"
                     id="enable_auto_approval_until_next_approval" class="toggle" type="button">Enable Listed Auto-Approval Before Next Manual Approval</button>
           </li>
-          {% elif channel == amo.CHANNEL_UNLISTED and addon.promoted_groups(currently_approved=False).unlisted_pre_review|python_any %}
+          {% elif channel == amo.CHANNEL_UNLISTED and promoted_groups.unlisted_pre_review|python_any %}
           <li>
             <button id="auto_approval_disabled_unlisted" class="disabled" disabled type="button">Unlisted Auto-Approval Disabled by Promoted group</button>
           </li>
           {% elif channel == amo.CHANNEL_UNLISTED %}
-          <li {% if addon.auto_approval_disabled_unlisted %}class="hidden"{% endif %}>
-            <button data-api-url="{{ drf_url('reviewers-addon-flags', addon.pk) }}"
-                    data-api-method="patch"
-                    data-api-data="{&quot;auto_approval_disabled_unlisted&quot;: true}"
-                    data-toggle-button-selector="#enable_auto_approval_unlisted"
-                    id="disable_auto_approval_unlisted" class="toggle" type="button">Disable Unlisted Auto-Approval</button>
-          </li>
-          <li {% if not addon.auto_approval_disabled_unlisted %}class="hidden"{% endif %}>
-            <button data-api-url="{{ drf_url('reviewers-addon-flags', addon.pk) }}"
-                    data-api-method="patch"
-                    data-api-data="{&quot;auto_approval_disabled_unlisted&quot;: false}"
-                    data-toggle-button-selector="#disable_auto_approval_unlisted"
-                    id="enable_auto_approval_unlisted" class="toggle" type="button">Enable Unlisted Auto-Approval</button>
-          </li>
           <li {% if addon.auto_approval_disabled_until_next_approval_unlisted %}class="hidden"{% endif %}>
             <button data-api-url="{{ drf_url('reviewers-addon-flags', addon.pk) }}"
                     data-api-method="patch"

--- a/src/olympia/reviewers/tests/test_commands.py
+++ b/src/olympia/reviewers/tests/test_commands.py
@@ -312,7 +312,12 @@ class TestAutoApproveCommand(AutoApproveTestsMixin, TestCase):
         assert review_helper_mock.call_count == 1
         assert review_helper_mock.call_args == (
             (),
-            {'addon': self.addon, 'version': self.version, 'human_review': False},
+            {
+                'addon': self.addon,
+                'version': self.version,
+                'human_review': False,
+                'channel': self.version.channel,
+            },
         )
         assert review_helper_mock().actions['public']['method'].call_count == 1
         assert statsd_incr_mock.call_count == 1

--- a/src/olympia/reviewers/tests/test_forms.py
+++ b/src/olympia/reviewers/tests/test_forms.py
@@ -60,7 +60,10 @@ class TestReviewForm(TestCase):
             data=data,
             files=files,
             helper=ReviewHelper(
-                addon=self.addon, version=self.version, user=self.request.user
+                addon=self.addon,
+                version=self.version,
+                user=self.request.user,
+                channel=self.version.channel,
             ),
         )
 
@@ -103,6 +106,7 @@ class TestReviewForm(TestCase):
             'change_or_clear_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
+            'disable_auto_approval',
             'reply',
             'disable_addon',
             'request_legal_review',
@@ -142,6 +146,7 @@ class TestReviewForm(TestCase):
             'change_or_clear_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
+            'disable_auto_approval',
             'reply',
             'disable_addon',
             'request_legal_review',
@@ -171,6 +176,7 @@ class TestReviewForm(TestCase):
             'change_or_clear_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
+            'disable_auto_approval',
             'reply',
             'request_legal_review',
             'comment',
@@ -201,6 +207,7 @@ class TestReviewForm(TestCase):
             'change_or_clear_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
+            'disable_auto_approval',
             'reply',
             'disable_addon',
             'request_legal_review',
@@ -215,6 +222,7 @@ class TestReviewForm(TestCase):
         assert list(actions.keys()) == [
             'change_or_clear_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
+            'disable_auto_approval',
             'reply',
             'enable_addon',
             'request_legal_review',

--- a/src/olympia/reviewers/tests/test_review_scenarios.py
+++ b/src/olympia/reviewers/tests/test_review_scenarios.py
@@ -85,7 +85,9 @@ def test_review_scenario(
     )
     version = addon.versions.get()
     # Get the review helper.
-    helper = ReviewHelper(addon=addon, version=version, user=user_factory())
+    helper = ReviewHelper(
+        addon=addon, version=version, user=user_factory(), channel=amo.CHANNEL_LISTED
+    )
     assert isinstance(helper.handler, review_class)
     helper.set_data({'comments': 'testing review scenarios'})
     # Run the action (approve_latest_version, reject_latest_version).

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -147,6 +147,7 @@ class TestReviewHelperBase(TestCase):
             user=self.user,
             human_review=human_review,
             content_review=content_review,
+            channel=getattr(self.review_version, 'channel', amo.CHANNEL_LISTED),
         )
 
     def check_log_count(self, id, user=None):
@@ -585,7 +586,9 @@ class TestReviewHelper(TestReviewHelperBase):
             == expected
         )
 
-        # you need admin review permission
+        # You need admin review permission. Also because it's a promoted add-on
+        # despite being admin you don't get the enable/disable auto-approval
+        # action.
         self.grant_permission(self.user, 'Reviews:Admin')
         expected = [
             'public',
@@ -669,6 +672,7 @@ class TestReviewHelper(TestReviewHelperBase):
             'change_or_clear_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
+            'disable_auto_approval',
             'reply',
             'disable_addon',
             'request_legal_review',
@@ -810,6 +814,7 @@ class TestReviewHelper(TestReviewHelperBase):
             'change_or_clear_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
+            'disable_auto_approval',
             'reply',
             'disable_addon',
             'request_legal_review',
@@ -837,6 +842,7 @@ class TestReviewHelper(TestReviewHelperBase):
             'change_or_clear_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
+            'disable_auto_approval',
             'reply',
             'disable_addon',
             'request_legal_review',
@@ -873,6 +879,7 @@ class TestReviewHelper(TestReviewHelperBase):
         expected = [
             'change_or_clear_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
+            'disable_auto_approval',
             'reply',
             'enable_addon',
             'request_legal_review',
@@ -906,6 +913,7 @@ class TestReviewHelper(TestReviewHelperBase):
             'change_or_clear_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
+            'disable_auto_approval',
             'reply',
             'disable_addon',
             'request_legal_review',
@@ -968,6 +976,7 @@ class TestReviewHelper(TestReviewHelperBase):
             'change_or_clear_pending_rejection_multiple_versions',
             'clear_needs_human_review_multiple_versions',
             'set_needs_human_review_multiple_versions',
+            'disable_auto_approval',
             'reply',
             'request_legal_review',
             'comment',

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -365,6 +365,11 @@ class ReviewHelper:
         user=None,
         content_review=False,
         human_review=True,
+        # channel corresponds to the channel the reviewer is looking at in the
+        # case of a human review, and it then determines which handler class to
+        # use and which actions are available, even if there are no versions in
+        # that channel. Callers that do not care about that can pass
+        # channel=None.
         channel,
     ):
         self.handler = None

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -516,6 +516,7 @@ def review(request, addon, channel=None):
         user=request.user,
         content_review=content_review,
         human_review=True,
+        channel=channel,
     )
     form = ReviewForm(
         request.POST if request.method == 'POST' else None,
@@ -715,6 +716,8 @@ def review(request, addon, channel=None):
         amo.LOG.REQUEST_ADMIN_REVIEW_THEME.id,
         amo.LOG.CLEAR_ADMIN_REVIEW_THEME.id,
         amo.LOG.REQUEST_LEGAL.id,
+        amo.LOG.ENABLE_AUTO_APPROVAL.id,
+        amo.LOG.DISABLE_AUTO_APPROVAL.id,
     )
     important_changes_log = ActivityLog.objects.filter(
         action__in=addon_important_changes_actions,


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/15646

### Testing

In the (listed) review page for an add-on, users with `Reviews:Admin` should now see a new action to Enable or Disable auto-approval depending on the state of that reviewer flag. Hitting the action should flip that flag, and log an activity recording that action took place, shown in "Important Changes" section.

### Screenshots

#### Example of a listed review page before the changes

The actions don't have enable/disable auto-approval and we have a button in the bottom right corner that does it.

![Screenshot 2025-07-01 at 14-14-58 seafowala-chanter-girroach – Add-ons for Firefox](https://github.com/user-attachments/assets/fb054841-1b4e-416e-8a7c-ab2ac5156cf6)

#### Example of a review page after the changes

(due date field is missing and remaining button is different color because I changed channel in the meantime)

##### When auto-approval is still enabled in channel
![Screenshot 2025-07-04 at 12-04-15 seafowala-chanter-girroach – Add-ons for Firefox](https://github.com/user-attachments/assets/84a958dc-6d0c-4157-b934-ed1eb20afa77)

##### When auto-approval is disabled in channel
![Screenshot 2025-07-04 at 15-26-07 seafowala-chanter-girroach – Add-ons for Firefox](https://github.com/user-attachments/assets/b6bd6a27-8bb0-4ac8-898e-385913a9b793)

##### Add-on important changes history section showing the new activities
![Screenshot 2025-07-04 at 12-04-24 seafowala-chanter-girroach – Add-ons for Firefox](https://github.com/user-attachments/assets/a8aeb346-56d2-4101-8a79-fda37b62504f)

