### PR TITLE
Remove reference to amo-admins in force-disabled tooltip

### DIFF
--- a/src/olympia/devhub/templates/devhub/includes/addon_details.html
+++ b/src/olympia/devhub/templates/devhub/includes/addon_details.html
@@ -28,8 +28,7 @@
     amo.STATUS_APPROVED: _("Your add-on is displayed in our gallery and users are "
                          "receiving automatic updates."),
     amo.STATUS_DISABLED: _("Your add-on was disabled by a site administrator and is no "
-                           "longer shown in our gallery. If you have any questions, "
-                           "please email amo-admins@mozilla.com."),
+                           "longer shown in our gallery."),
     amo.STATUS_DELETED: '',
     'invisible': _("Your add-on won't be included in search results, and its "
                    "listing page will indicate you disabled it. New version "


### PR DESCRIPTION
Fixes: mozilla/addons#15722

### Description

This commit removes the reference to amo-admins in the developer hub status tooltip for a force-disabled add-on.

### Context

With DSA, developers should use the appeal functionality when objecting to their add-on being force-disabled by Mozilla.

### Testing

1. Have a force disabled add-on
2. On the developer hub page for that add-on, (`developers/addon/<slug>/edit`), above the left-hand navigation there is a box showing "Last Updated" and "Status". However over the "?" for the status description. The tooltip should not mention to email amo-admins.

### Checklist

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
