### PR TITLE
Remove email reply for account deletion notification emails

### DIFF
--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -648,7 +648,6 @@ class UserProfile(OnChangeMixin, ModelBase, AbstractBaseUser):
             'subject': f'Your account on {site_url} has been deleted',
             'message': email_msg,
             'recipient_list': [str(self.email)],
-            'reply_to': ['amo-admins+deleted@mozilla.com'],
         }
 
     def should_send_delete_email(self):

--- a/src/olympia/users/templates/users/emails/user_deleted.ltxt
+++ b/src/olympia/users/templates/users/emails/user_deleted.ltxt
@@ -2,8 +2,6 @@
 
 You’re receiving this message because your user account {{ name }} on {{ site_url }} has been deleted. This could have been done automatically if you recently deleted your Mozilla account.
 
-If you didn’t do this or believe an unauthorized person has accessed your account, please reply to this email. Otherwise, there’s no further action to take.
-
 Regards,
 
 Mozilla Add-ons Team{% endblocktrans %}


### PR DESCRIPTION
Fixes: mozilla/addons#15723

### Description

This removes the call to action to reply to the account deletion notification emails.

### Context

there is nothing we can do when someone does reply. We cannot verify of falsify claims either way, and we also cannot reinstate the account.

### Testing

1. Delete an account.
2. Observe the email you receive.

### Checklist

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
