### PR TITLE
Remove CTA to email amo-admins

### DIFF
--- a/src/olympia/devhub/templates/devhub/emails/api_key_confirmation.ltxt
+++ b/src/olympia/devhub/templates/devhub/emails/api_key_confirmation.ltxt
@@ -5,8 +5,6 @@ You're receiving this message because you requested new developer API keys for
 
 {{ api_key_confirmation_link }}
 
-If you didn't request this, please notify amo-admins@mozilla.com.
-
 Regards,
 
 The Mozilla Add-ons Team{% endblocktrans %}

--- a/src/olympia/devhub/templates/devhub/emails/verify-email-requested.ltxt
+++ b/src/olympia/devhub/templates/devhub/emails/verify-email-requested.ltxt
@@ -5,8 +5,6 @@ To finish this process, please click on the link below:
 
 {{ confirmation_link }}
 
-If you didn't request this, please notify amo-admins@mozilla.com.
-
 Regards,
 
 The Mozilla Add-ons Team{% endblocktrans %}

--- a/src/olympia/users/templates/users/emails/author_added_confirmation.ltxt
+++ b/src/olympia/users/templates/users/emails/author_added_confirmation.ltxt
@@ -6,7 +6,5 @@ Click on the link below to respond if you want to be added as an author for {{ a
 
 {{ author_confirmation_link }}
 
-If you didn't expect to receive this invitation, please send an email to amo-admins@mozilla.com.
-
 Kind regards,
 The Mozilla Add-ons Team{% endblocktrans %}


### PR DESCRIPTION
Fixes: mozilla/addons#15725

### Description

This removes inactionable CTA to email amo-
* When they request a new API
* When they request their email to be verified
* When they have been invited to become an author of an add-on.


### Context

It's not clear what amo-admins would do in case we receive such an email. We don't have enough data or insight to verify or falsify any claims.

### Testing

Execute the actions above and observe the email content. It should not include a reference to amo-admins.

### Checklist

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
