### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/_health_check.yml
+++ b/.github/workflows/_health_check.yml
@@ -105,10 +105,7 @@ jobs:
 
       - name: Set message blocks
         id: blocks
-        if: |
-          steps.health_check.outcome == 'failure' &&
-          needs.context.outputs.notify == 'true' &&
-          needs.context.outputs.environment != 'host'
+        if: steps.health_check.outcome == 'failure'
         shell: bash
         run: |
           if [ ! -f "$health_check_file" ]; then
@@ -129,7 +126,7 @@ jobs:
 
       - name: Notify Failure
         if: steps.blocks.outcome == 'success'
-        uses: mozilla/addons/.github/actions/slack@f1d4daa008d908d52815aa41257db39b8cdef958
+        uses: mozilla/addons/.github/actions/slack@0e9caffce5be5662446a83a878e1d7812af3b618
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
           payload: |
@@ -141,6 +138,7 @@ jobs:
               "unfurl_links": false,
               "unfurl_media": false,
             }
+          dry_run: ${{ !(needs.context.outputs.environment != 'host' && needs.context.outputs.notify == 'true') }}
 
       - name: Exit with outcome
         shell: bash

--- a/.github/workflows/_test_check.yml
+++ b/.github/workflows/_test_check.yml
@@ -40,7 +40,7 @@ jobs:
       is_fork: ${{ steps.context.outputs.is_fork }}
     steps:
       - id: context
-        uses: mozilla/addons/.github/actions/context@f1d4daa008d908d52815aa41257db39b8cdef958
+        uses: mozilla/addons/.github/actions/context@0e9caffce5be5662446a83a878e1d7812af3b618
 
   test_check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - name: Set context
         id: context
-        uses: mozilla/addons/.github/actions/context@f1d4daa008d908d52815aa41257db39b8cdef958
+        uses: mozilla/addons/.github/actions/context@0e9caffce5be5662446a83a878e1d7812af3b618
 
       - name: Git Reference
         id: git
@@ -116,7 +116,7 @@ jobs:
       - name: Login to Dockerhub
         if: needs.context.outputs.is_fork == 'false'
         id: docker_hub
-        uses: mozilla/addons/.github/actions/login-docker@f1d4daa008d908d52815aa41257db39b8cdef958
+        uses: mozilla/addons/.github/actions/login-docker@0e9caffce5be5662446a83a878e1d7812af3b618
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
@@ -271,7 +271,7 @@ jobs:
 
       - name: Login to Dockerhub
         id: docker_hub
-        uses: mozilla/addons/.github/actions/login-docker@f1d4daa008d908d52815aa41257db39b8cdef958
+        uses: mozilla/addons/.github/actions/login-docker@0e9caffce5be5662446a83a878e1d7812af3b618
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
@@ -308,7 +308,7 @@ jobs:
 
       - name: Login to GAR
         id: docker_gar
-        uses: mozilla/addons/.github/actions/login-gar@f1d4daa008d908d52815aa41257db39b8cdef958
+        uses: mozilla/addons/.github/actions/login-gar@0e9caffce5be5662446a83a878e1d7812af3b618
         with:
           registry: ${{ env.registry }}
           service_account: ${{ secrets.GAR_PUSHER_SERVICE_ACCOUNT_EMAIL }}
@@ -342,7 +342,7 @@ jobs:
     steps:
 
     - name: Slack Notification
-      uses: mozilla/addons/.github/actions/slack-workflow-notification@d29de6a2f1890252d787932c3600966fa5f22f66
+      uses: mozilla/addons/.github/actions/slack-workflow-notification@0e9caffce5be5662446a83a878e1d7812af3b618
       with:
         slack_token: ${{ secrets.SLACK_TOKEN }}
         slack_channel: ${{ vars.SLACK_ADDONS_PRODUCTION_CHANNEL }}

--- a/.github/workflows/health_check.yml
+++ b/.github/workflows/health_check.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Context
         id: context
-        uses: mozilla/addons/.github/actions/context@f1d4daa008d908d52815aa41257db39b8cdef958
+        uses: mozilla/addons/.github/actions/context@0e9caffce5be5662446a83a878e1d7812af3b618
 
   health_check:
     strategy:
@@ -65,8 +65,7 @@ jobs:
           gh workflow run health_check.yml --ref "${ref}"
 
       - name: Notify Recovery
-        if: needs.health_check.result == 'success' && github.event_name == 'workflow_dispatch'
-        uses: mozilla/addons/.github/actions/slack@f1d4daa008d908d52815aa41257db39b8cdef958
+        uses: mozilla/addons/.github/actions/slack@0e9caffce5be5662446a83a878e1d7812af3b618
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
           payload: |
@@ -74,24 +73,29 @@ jobs:
               "channel": "${{ vars.SLACK_ADDONS_PRODUCTION_CHANNEL }}",
               "text": ":white_check_mark: Health check has recovered",
             }
+          dry_run: ${{ !(needs.health_check.result == 'success' && github.event_name == 'workflow_dispatch') }}
 
       - name: Notify Failure
-        if: |
-          needs.context.outputs.is_fork == 'false' &&
-          github.event_name == 'schedule' &&
-          needs.health_check.result == 'failure'
-        uses: mozilla/addons/.github/actions/slack-workflow-notification@f1d4daa008d908d52815aa41257db39b8cdef958
+        uses: mozilla/addons/.github/actions/slack-workflow-notification@0e9caffce5be5662446a83a878e1d7812af3b618
+        env:
+          dry_run: ${{ !(github.event_name == 'schedule' && needs.health_check.result == 'failure') }}
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
           slack_channel: ${{ vars.SLACK_ADDONS_PRODUCTION_CHANNEL }}
-          emoji: ':x:'
-          actor: ${{ vars.SLACK_ACTOR }}
-          conclusion: ${{ needs.health_check.result }}
-          workflow_id: ${{ github.run_id }}
-          workflow_url: ${{ format('{0}/actions/runs/{1}', github.event.repository.html_url, github.run_id) }}
-          event: ${{ github.event_name }}
-          env: ci
-          ref: ${{ github.ref }}
-          ref_link: ${{ github.event.repository.html_url }}
+          conclusion: "failure"
+          text: ${{ github.ref }}
+          text_link: ${{ github.event.repository.html_url }}
+          context: |
+            {
+              "channel": "${{ vars.SLACK_ADDONS_PRODUCTION_CHANNEL }}",
+              "text": ":x: Health check has failed"
+            }
+          links: |
+            {
+              "${{ github.run_id }}": "${{ format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}",
+              "${{ github.repository }}": "${{ github.server_url }}/${{ github.repository }}"
+            }
+          dry_run: ${{ env.DRY_RUN }}
+
 
 


### PR DESCRIPTION
Fixes: mozilla/addons#15628

### Description

After merging https://github.com/mozilla/addons/commit/3f3a868413c48ebd766c7c896ac57928be2ef825 we need to update the hash for github actions coming from mozilla/addons.

In one place the API of the action changed so needed to be updated as well.

### Context

Even after merging the original PR, one of the mozill/addons actions was calling another mozilla/addons action (using the old branch). This [commit](https://github.com/mozilla/addons/commit/0e9caffce5be5662446a83a878e1d7812af3b618) fixes that internally.

### Testing

You can test locally by running the linter for github actions.

```bash
make actionlint
```

and also another linter

```bash
make zizmor
```

This will verify that the actions are pointing to resolvable commit hashes.

You can test the health check by running it [manually](https://github.com/mozilla/addons-server/actions/workflows/health_check.yml) on this branch.

Example run: https://github.com/mozilla/addons-server/actions/runs/16298389273/job/46026224820

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
