### PR TITLE
Move email address for regional restriction notifications

### DIFF
--- a/src/olympia/addons/admin.py
+++ b/src/olympia/addons/admin.py
@@ -616,7 +616,7 @@ class AddonRegionalRestrictionsAdmin(AMOModelAdmin):
         send_mail(
             f'Regional Restriction {action} for Add-on',
             message,
-            recipient_list=('amo-admins@mozilla.com',),
+            recipient_list=('amo-notifications+regionrestrict@mozilla.com',),
         )
 
     def delete_model(self, request, obj):

--- a/src/olympia/addons/tests/test_admin.py
+++ b/src/olympia/addons/tests/test_admin.py
@@ -1005,7 +1005,7 @@ class TestAddonRegionalRestrictionsAdmin(TestCase):
             f'Regional restriction for addon "Thíng" '
             f"[{restriction.addon.id}] added: ['DE', 'BR']"
         )
-        assert mail.outbox[0].to == ['amo-admins@mozilla.com']
+        assert mail.outbox[0].to == ['amo-notifications+regionrestrict@mozilla.com']
 
     def test_can_edit(self):
         addon = addon_factory(name='Thíng')
@@ -1039,7 +1039,7 @@ class TestAddonRegionalRestrictionsAdmin(TestCase):
             f'Regional restriction for addon "Thíng" '
             f"[{restriction.addon.id}] changed: ['DE', 'BR']"
         )
-        assert mail.outbox[0].to == ['amo-admins@mozilla.com']
+        assert mail.outbox[0].to == ['amo-notifications+regionrestrict@mozilla.com']
 
     def test_can_delete(self):
         restriction = AddonRegionalRestrictions.objects.create(
@@ -1059,7 +1059,7 @@ class TestAddonRegionalRestrictionsAdmin(TestCase):
             f'Regional restriction for addon "Thíng" '
             f"[{restriction.addon.id}] deleted: ['FR']"
         )
-        assert mail.outbox[0].to == ['amo-admins@mozilla.com']
+        assert mail.outbox[0].to == ['amo-notifications+regionrestrict@mozilla.com']
 
 
 class TestAddonBrowserMappingAdmin(TestCase):


### PR DESCRIPTION
Fixes: mozilla/addons#15727

### Description

This changes the email address for regional restriction change notifications from amo-admins to amo-notifications.

### Context

Moving notifications to where they belong.

### Testing

1. Add, change or delete a regional restriction for an add-on.
2. Observe the recipient address of the outgoing email.

### Checklist

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
