### PR TITLE
Bump mozilla/addons/.github actions

### DIFF
--- a/.github/workflows/_health_check.yml
+++ b/.github/workflows/_health_check.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Notify Failure
         if: steps.blocks.outcome == 'success'
-        uses: mozilla/addons/.github/actions/slack@0e9caffce5be5662446a83a878e1d7812af3b618
+        uses: mozilla/addons/.github/actions/slack@2406c44b0b624bcf6b9b2a8a6368c32ada25af66
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
           payload: |

--- a/.github/workflows/_test_check.yml
+++ b/.github/workflows/_test_check.yml
@@ -40,7 +40,7 @@ jobs:
       is_fork: ${{ steps.context.outputs.is_fork }}
     steps:
       - id: context
-        uses: mozilla/addons/.github/actions/context@0e9caffce5be5662446a83a878e1d7812af3b618
+        uses: mozilla/addons/.github/actions/context@2406c44b0b624bcf6b9b2a8a6368c32ada25af66
 
   test_check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - name: Set context
         id: context
-        uses: mozilla/addons/.github/actions/context@0e9caffce5be5662446a83a878e1d7812af3b618
+        uses: mozilla/addons/.github/actions/context@2406c44b0b624bcf6b9b2a8a6368c32ada25af66
 
       - name: Git Reference
         id: git
@@ -116,7 +116,7 @@ jobs:
       - name: Login to Dockerhub
         if: needs.context.outputs.is_fork == 'false'
         id: docker_hub
-        uses: mozilla/addons/.github/actions/login-docker@0e9caffce5be5662446a83a878e1d7812af3b618
+        uses: mozilla/addons/.github/actions/login-docker@2406c44b0b624bcf6b9b2a8a6368c32ada25af66
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
@@ -271,7 +271,7 @@ jobs:
 
       - name: Login to Dockerhub
         id: docker_hub
-        uses: mozilla/addons/.github/actions/login-docker@0e9caffce5be5662446a83a878e1d7812af3b618
+        uses: mozilla/addons/.github/actions/login-docker@2406c44b0b624bcf6b9b2a8a6368c32ada25af66
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
@@ -308,7 +308,7 @@ jobs:
 
       - name: Login to GAR
         id: docker_gar
-        uses: mozilla/addons/.github/actions/login-gar@0e9caffce5be5662446a83a878e1d7812af3b618
+        uses: mozilla/addons/.github/actions/login-gar@2406c44b0b624bcf6b9b2a8a6368c32ada25af66
         with:
           registry: ${{ env.registry }}
           service_account: ${{ secrets.GAR_PUSHER_SERVICE_ACCOUNT_EMAIL }}
@@ -342,7 +342,7 @@ jobs:
     steps:
 
     - name: Slack Notification
-      uses: mozilla/addons/.github/actions/slack-workflow-notification@0e9caffce5be5662446a83a878e1d7812af3b618
+      uses: mozilla/addons/.github/actions/slack-workflow-notification@2406c44b0b624bcf6b9b2a8a6368c32ada25af66
       with:
         slack_token: ${{ secrets.SLACK_TOKEN }}
         slack_channel: ${{ vars.SLACK_ADDONS_PRODUCTION_CHANNEL }}

--- a/.github/workflows/health_check.yml
+++ b/.github/workflows/health_check.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Context
         id: context
-        uses: mozilla/addons/.github/actions/context@0e9caffce5be5662446a83a878e1d7812af3b618
+        uses: mozilla/addons/.github/actions/context@2406c44b0b624bcf6b9b2a8a6368c32ada25af66
 
   health_check:
     strategy:
@@ -65,7 +65,7 @@ jobs:
           gh workflow run health_check.yml --ref "${ref}"
 
       - name: Notify Recovery
-        uses: mozilla/addons/.github/actions/slack@0e9caffce5be5662446a83a878e1d7812af3b618
+        uses: mozilla/addons/.github/actions/slack@2406c44b0b624bcf6b9b2a8a6368c32ada25af66
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
           payload: |
@@ -76,9 +76,7 @@ jobs:
           dry_run: ${{ !(needs.health_check.result == 'success' && github.event_name == 'workflow_dispatch') }}
 
       - name: Notify Failure
-        uses: mozilla/addons/.github/actions/slack-workflow-notification@0e9caffce5be5662446a83a878e1d7812af3b618
-        env:
-          dry_run: ${{ !(github.event_name == 'schedule' && needs.health_check.result == 'failure') }}
+        uses: mozilla/addons/.github/actions/slack-workflow-notification@2406c44b0b624bcf6b9b2a8a6368c32ada25af66
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
           slack_channel: ${{ vars.SLACK_ADDONS_PRODUCTION_CHANNEL }}
@@ -95,7 +93,7 @@ jobs:
               "${{ github.run_id }}": "${{ format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}",
               "${{ github.repository }}": "${{ github.server_url }}/${{ github.repository }}"
             }
-          dry_run: ${{ env.DRY_RUN }}
+          dry_run: ${{ !(github.event_name == 'schedule' && needs.health_check.result == 'failure') }}
 
 
 


### PR DESCRIPTION
Fixes: mozilla/addons#15628

### Description

Follow up to https://github.com/mozilla/addons-server/pull/23696

### Context

The `mozilla/addons/slack` action is looking at an input value `dry_run` to determine whether to actually send a slack notification or to just print what it would have sent. this was previously checking `${{ inputs.dry_run != 'true' }}`.

Unfortunately if you call the action

```yaml
with:
  dry_run: true
```
or more realistically

```yaml
with:
  dry_run: ${{ some expression }}
```

The data type is a boolean which does not equal the literal string "true" and so passes the condition and causes notifications to be sent even in dry run mode.

This is more or less the result

<img width="569" height="624" alt="image" src="https://github.com/user-attachments/assets/318aeec3-cf6d-46a5-8c6c-72e4692a4c41" />

### Testing

I tested running the health check job against this branch. we got the notification but no call to the actual slack action so 🤷 should work.

<img width="612" height="448" alt="image" src="https://github.com/user-attachments/assets/fcceee13-27cb-4420-8b9d-ddafa3b7ab71" />

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
