### PR TITLE
Update second_level_notification.txt

### DIFF
--- a/src/olympia/abuse/templates/abuse/emails/second_level_notification.txt
+++ b/src/olympia/abuse/templates/abuse/emails/second_level_notification.txt
@@ -1,3 +1,1 @@
-Lo and behold! A fresh contender has triumphantly emerged and now awaits its fate in the hallowed halls of Second-Level Approval, where only the wisest of stewards may pass judgment. The scrolls declare that you, brave soul, must now render thine decision and seal its fate!
-
 {{ approval_url }}


### PR DESCRIPTION
Fixes: mozilla/addons#15728
<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Drops the extra text in the second level queue notification email, leaving just the link

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
