### PR TITLE
cinder returns 201 for override decision

### DIFF
--- a/src/olympia/abuse/cinder.py
+++ b/src/olympia/abuse/cinder.py
@@ -169,9 +169,7 @@ class CinderEntity:
         else:
             raise HTTPError(response.content)
 
-    def _send_create_decision(
-        self, url, data, action, reasoning, policy_uuids, *, success_code=201
-    ):
+    def _send_create_decision(self, url, data, action, reasoning, policy_uuids):
         data = {
             **data,
             'reasoning': self.get_str(reasoning),
@@ -186,7 +184,7 @@ class CinderEntity:
             ),
         }
         response = requests.post(url, json=data, headers=self.get_cinder_http_headers())
-        if response.status_code == success_code:
+        if response.status_code == 201:
             return response.json().get('uuid')
         else:
             raise HTTPError(response.content)
@@ -212,7 +210,7 @@ class CinderEntity:
         # https://lindie.app/share/6a21d831b39351d7c6fe898f6d22619af62dde98/PLAT-1834
         # implements the same parameters for overrides
         return self._send_create_decision(
-            url, {}, None, reasoning, policy_uuids, success_code=200
+            url, {}, None, reasoning, policy_uuids
         )
 
     def close_job(self, *, job_id):

--- a/src/olympia/abuse/cinder.py
+++ b/src/olympia/abuse/cinder.py
@@ -184,10 +184,8 @@ class CinderEntity:
             ),
         }
         response = requests.post(url, json=data, headers=self.get_cinder_http_headers())
-        if response.status_code == 201:
-            return response.json().get('uuid')
-        else:
-            raise HTTPError(response.content)
+        response.raise_for_status()
+        return response.json().get('uuid')
 
     def create_decision(self, *, action, reasoning, policy_uuids):
         if self.type is None:
@@ -209,9 +207,7 @@ class CinderEntity:
         # TODO: send action too once
         # https://lindie.app/share/6a21d831b39351d7c6fe898f6d22619af62dde98/PLAT-1834
         # implements the same parameters for overrides
-        return self._send_create_decision(
-            url, {}, None, reasoning, policy_uuids
-        )
+        return self._send_create_decision(url, {}, None, reasoning, policy_uuids)
 
     def close_job(self, *, job_id):
         url = f'{settings.CINDER_SERVER_URL}jobs/{job_id}/cancel'

--- a/src/olympia/abuse/tests/test_cinder.py
+++ b/src/olympia/abuse/tests/test_cinder.py
@@ -1408,7 +1408,7 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
             responses.POST,
             f'{settings.CINDER_SERVER_URL}decisions/{overridden_decision_id}/override/',
             json={'uuid': cinder_id},
-            status=200,
+            status=201,
         )
         responses.add(
             responses.POST,

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -2986,7 +2986,7 @@ class TestContentDecision(TestCase):
             responses.POST,
             f'{settings.CINDER_SERVER_URL}decisions/{overridden_id}/override/',
             json={'uuid': uuid.uuid4().hex},
-            status=200,
+            status=201,
         )
         decision.policies.add(
             CinderPolicy.objects.create(name='policy', uuid='12345678')

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -2986,7 +2986,7 @@ class TestContentDecision(TestCase):
             responses.POST,
             f'{settings.CINDER_SERVER_URL}decisions/{overridden_id}/override/',
             json={'uuid': uuid.uuid4().hex},
-            status=201,
+            status=200,
         )
         decision.policies.add(
             CinderPolicy.objects.create(name='policy', uuid='12345678')

--- a/src/olympia/reviewers/tests/test_commands.py
+++ b/src/olympia/reviewers/tests/test_commands.py
@@ -1496,7 +1496,7 @@ class TestAutoReject(AutoRejectTestsMixin, TestCase):
             responses.POST,
             f'{settings.CINDER_SERVER_URL}decisions/13579/override/',
             json={'uuid': uuid.uuid4().hex},
-            status=200,
+            status=201,
         )
         policies = [CinderPolicy.objects.create(name='policy', uuid='12345678')]
         review_action_reason = ReviewActionReason.objects.create(
@@ -1543,7 +1543,7 @@ class TestAutoReject(AutoRejectTestsMixin, TestCase):
             responses.POST,
             f'{settings.CINDER_SERVER_URL}decisions/13579/override/',
             json={'uuid': uuid.uuid4().hex},
-            status=200,
+            status=201,
         )
         policies = [CinderPolicy.objects.create(name='policy', uuid='12345678')]
         review_action_reason = ReviewActionReason.objects.create(
@@ -1590,7 +1590,7 @@ class TestAutoReject(AutoRejectTestsMixin, TestCase):
             responses.POST,
             f'{settings.CINDER_SERVER_URL}decisions/13579/override/',
             json={'uuid': uuid.uuid4().hex},
-            status=200,
+            status=201,
         )
         policies = [
             CinderPolicy.objects.create(name='policy', uuid='12345678'),

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -7998,7 +7998,7 @@ class TestHeldDecisionReview(ReviewerTest):
             responses.POST,
             f'{settings.CINDER_SERVER_URL}decisions/{self.decision.cinder_id}/override/',
             json={'uuid': '5678'},
-            status=200,
+            status=201,
         )
 
         response = self.client.post(self.url, {'choice': 'no'})


### PR DESCRIPTION
Fixes: mozilla/addons#15734

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Relaxes the status code enforcement we have for a decision request to Cinder, to only raise for >=400 error codes.

### Context

See issue.  Cinder originally implemented the override decision endpoint to return a 200, rather than a 201 for the other decision endpoints.  Now it's returning a 201.

### Testing

It's such a trivial change it doesn't really need testing, but if you want to:
- set your setting CINDER_SERVER_URL to `https://mozilla-staging.cinderapp.com/api/v1/`
- in reviewer tools force disable a recommended add-on
- in 2nd level approval queue in reviewer tools, requeue the add-on in the reviewer tools
- back in reviewer tools, force disable it again, but this time resolve the (newly created, from requeue) job at the same time
- in 2nd level approval queue in reviewer tools, proceed with the disable
- check in fake mail for the email to the developer about the disable
- check in Cinder that both decisions were recorded - and the second is override of the first

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
