### PR TITLE
update CINDER_SERVER_URL to saas cinder

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -178,3 +178,5 @@ GOOGLE_APPLICATION_CREDENTIALS_BIGQUERY = env(
     # Set default path to the path explicitly gitignored.
     default=path('private/google-application-credentials.json'),
 )
+
+CINDER_SERVER_URL = 'https://mozilla-staging.cinderapp.com/api/v1/'

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1473,8 +1473,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 SITEMAP_DEBUG_AVAILABLE = False
 
 CINDER_SERVER_URL = env(
-    'CINDER_SERVER_URL',
-    default='https://stage.cinder.nonprod.webservices.mozgcp.net/api/v1/',
+    'CINDER_SERVER_URL', default='https://mozilla-staging.cinderapp.com/api/v1/'
 )
 CINDER_API_TOKEN = env('CINDER_API_TOKEN', default=None)
 CINDER_WEBHOOK_TOKEN = env('CINDER_WEBHOOK_TOKEN', default=None)

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1472,9 +1472,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 SITEMAP_DEBUG_AVAILABLE = False
 
-CINDER_SERVER_URL = env(
-    'CINDER_SERVER_URL', default='https://mozilla-staging.cinderapp.com/api/v1/'
-)
+CINDER_SERVER_URL = env('CINDER_SERVER_URL', default=None)
 CINDER_API_TOKEN = env('CINDER_API_TOKEN', default=None)
 CINDER_WEBHOOK_TOKEN = env('CINDER_WEBHOOK_TOKEN', default=None)
 CINDER_QUEUE_PREFIX = 'amo-dev-'


### PR DESCRIPTION
Fixes: mozilla/addons#15735

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

As issue, just updates the setting default

### Testing

Do something that communicates with Cinder, e.g. reject a version of an add-on.  You'll need an api key defined in settings

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
