### PR TITLE
send enforcement action for override decisions

### DIFF
--- a/src/olympia/abuse/cinder.py
+++ b/src/olympia/abuse/cinder.py
@@ -174,14 +174,8 @@ class CinderEntity:
             **data,
             'reasoning': self.get_str(reasoning),
             'policy_uuids': policy_uuids,
-            **(
-                {
-                    'enforcement_actions_slugs': [action],
-                    'enforcement_actions_update_strategy': 'set',
-                }
-                if action is not None
-                else {}
-            ),
+            'enforcement_actions_slugs': [action],
+            'enforcement_actions_update_strategy': 'set',
         }
         response = requests.post(url, json=data, headers=self.get_cinder_http_headers())
         response.raise_for_status()
@@ -204,10 +198,7 @@ class CinderEntity:
 
     def create_override_decision(self, *, action, reasoning, policy_uuids, decision_id):
         url = f'{settings.CINDER_SERVER_URL}decisions/{decision_id}/override/'
-        # TODO: send action too once
-        # https://lindie.app/share/6a21d831b39351d7c6fe898f6d22619af62dde98/PLAT-1834
-        # implements the same parameters for overrides
-        return self._send_create_decision(url, {}, None, reasoning, policy_uuids)
+        return self._send_create_decision(url, {}, action, reasoning, policy_uuids)
 
     def close_job(self, *, job_id):
         url = f'{settings.CINDER_SERVER_URL}jobs/{job_id}/cancel'

--- a/src/olympia/abuse/tests/test_cinder.py
+++ b/src/olympia/abuse/tests/test_cinder.py
@@ -1428,8 +1428,8 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
         )
         request = responses.calls[0].request
         request_body = json.loads(request.body)
-        assert b'enforcement_actions_slugs' not in request.body
-        assert b'enforcement_actions_update_strategy' not in request.body
+        assert request_body['enforcement_actions_slugs'] == ['amo-reject-version-addon']
+        assert request_body['enforcement_actions_update_strategy'] == 'set'
         assert request_body['policy_uuids'] == ['12345678']
         assert request_body['reasoning'] == 'some review text'
         assert 'entity' not in request_body

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -3034,7 +3034,9 @@ class TestContentDecision(TestCase):
             assert request_body['policy_uuids'] == ['12345678']
             assert request_body['reasoning'] == 'some review text'
             assert 'entity' not in request_body
-            assert 'enforcement_actions_slugs' not in request_body
+            assert request_body['enforcement_actions_slugs'] == [
+                decision.action.api_value
+            ]
         else:
             assert create_decision_response.call_count == 0
             assert create_job_decision_response.call_count == 0


### PR DESCRIPTION
Fixes: mozilla/addons#15371

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Trivial change to now send enforcement action too for an override decision, with some clean-up because now all decision endpoints accept the same action and policies fields.

### Testing

Pretty trivial change, but to test:
- in reviewer tools force disable a recommended add-on
- in 2nd level approval queue in reviewer tools, requeue the add-on in the reviewer tools
- back in reviewer tools, resolve the (newly created, from requeue) job, but this time reject the a version instead of disable
- check in fake mail for the email to the developer about the rejection
- check in Cinder that the override decision has the enforcement action of amo-reject-version-addon rather than amo-disable-addon.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
