### PR TITLE
Log name|summary changes in more detail

### DIFF
--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -1,4 +1,5 @@
 import copy
+import json
 import re
 
 from django.core.exceptions import ValidationError as DjangoValidationError
@@ -1320,12 +1321,12 @@ class AddonSerializer(AMOModelSerializer):
             # version is always a new object, and not a property either
             validated_data.pop('version')
 
-        for field in changes:
+        for field, addedremoved in changes.items():
             ActivityLog.objects.create(
                 amo.LOG.EDIT_ADDON_PROPERTY,
                 instance,
                 field,
-                details={**changes.get(field, {})},
+                json.dumps(addedremoved),
                 user=user,
             )
             validated_data.pop(field)

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -1961,6 +1961,7 @@ class TestAddonViewSetUpdate(AddonViewSetCreateUpdateMixin, TestCase):
         self.statsd_incr_mock = self.patch('olympia.addons.serializers.statsd.incr')
 
     def test_basic(self):
+        original_summary = str(self.addon.summary)
         response = self.request(data={'summary': {'en-US': 'summary update!'}})
         self.addon.reload()
         assert response.status_code == 200, response.content
@@ -1990,8 +1991,12 @@ class TestAddonViewSetUpdate(AddonViewSetCreateUpdateMixin, TestCase):
             )
         ).get()
         assert alog.user == self.user
-        assert alog.action == amo.LOG.EDIT_PROPERTIES.id
-        assert alog.details == ['summary']
+        assert alog.action == amo.LOG.EDIT_ADDON_PROPERTY.id
+        assert alog.arguments == [self.addon, 'summary']
+        assert alog.details == {
+            'removed': [original_summary],
+            'added': ['summary update!'],
+        }
         return data
 
     @override_settings(API_THROTTLING=False)
@@ -2212,6 +2217,10 @@ class TestAddonViewSetUpdate(AddonViewSetCreateUpdateMixin, TestCase):
     def test_set_extra_data(self):
         self.addon.description = 'Existing description'
         self.addon.save()
+        original_data = {
+            'name': str(self.addon.name),
+            'summary': str(self.addon.summary),
+        }
         patch_data = {
             'developer_comments': {'en-US': 'comments'},
             'homepage': {'en-US': 'https://my.home.page/'},
@@ -2251,17 +2260,35 @@ class TestAddonViewSetUpdate(AddonViewSetCreateUpdateMixin, TestCase):
         assert addon.support_email == 'email@me.me'
         assert data['support_url']['url'] == {'en-US': 'https://my.home.page/support/'}
         assert addon.support_url == 'https://my.home.page/support/'
+
+        summ_log, name_log = list(
+            ActivityLog.objects.filter(action=amo.LOG.EDIT_ADDON_PROPERTY.id)
+        )
+        assert name_log.arguments == [self.addon, 'name']
+        assert name_log.details == {
+            'added': [patch_data['name']['en-US']],
+            'removed': [original_data['name']],
+        }
+        assert summ_log.arguments == [self.addon, 'summary']
+        assert summ_log.details == {
+            'added': [patch_data['summary']['en-US']],
+            'removed': [original_data['summary']],
+        }
+
         alog = ActivityLog.objects.exclude(
             action__in=(
                 amo.LOG.ADD_VERSION.id,
                 amo.LOG.LOG_IN.id,
                 amo.LOG.LOG_IN_API_TOKEN.id,
                 amo.LOG.ADDON_SLUG_CHANGED.id,
+                amo.LOG.EDIT_ADDON_PROPERTY.id,
             )
         ).get()
         assert alog.user == self.user
         assert alog.action == amo.LOG.EDIT_PROPERTIES.id
-        assert alog.details == list(patch_data.keys())
+        assert alog.details == [
+            prop for prop in patch_data if prop not in ('name', 'summary')
+        ]
 
     def test_set_disabled(self):
         response = self.request(
@@ -2500,7 +2527,7 @@ class TestAddonViewSetUpdate(AddonViewSetCreateUpdateMixin, TestCase):
 
     def _test_metadata_content_review(self):
         response = self.request(
-            data={'name': {'en-US': 'new name'}, 'summary': {'en-US': 'new summary'}},
+            data={'name': {'en-US': 'new name'}, 'summary': {'fr': 'summary nouveau'}},
         )
         assert response.status_code == 200
 
@@ -2526,6 +2553,7 @@ class TestAddonViewSetUpdate(AddonViewSetCreateUpdateMixin, TestCase):
         )
 
     def test_metadata_change_triggers_content_review(self):
+        old_name = self.addon.name
         AddonApprovalsCounter.approve_content_for_addon(addon=self.addon)
         assert AddonApprovalsCounter.objects.get(addon=self.addon).last_content_review
 
@@ -2539,6 +2567,17 @@ class TestAddonViewSetUpdate(AddonViewSetCreateUpdateMixin, TestCase):
         self.statsd_incr_mock.assert_any_call(
             'addons.submission.metadata_content_review_triggered'
         )
+        assert (
+            ActivityLog.objects.filter(action=amo.LOG.EDIT_ADDON_PROPERTY.id).count()
+            == 2
+        )
+        summ_log, name_log = list(
+            ActivityLog.objects.filter(action=amo.LOG.EDIT_ADDON_PROPERTY.id)
+        )
+        assert name_log.arguments == [self.addon, 'name']
+        assert name_log.details == {'added': ['new name'], 'removed': [old_name]}
+        assert summ_log.arguments == [self.addon, 'summary']
+        assert summ_log.details == {'added': ['summary nouveau'], 'removed': []}
 
     def test_metadata_change_same_content(self):
         AddonApprovalsCounter.approve_content_for_addon(addon=self.addon)
@@ -2547,7 +2586,7 @@ class TestAddonViewSetUpdate(AddonViewSetCreateUpdateMixin, TestCase):
         ).last_content_review
         assert old_content_review
         self.addon.name = {'en-US': 'new name'}
-        self.addon.summary = {'en-US': 'new summary'}
+        self.addon.summary = {'en-US': str(self.addon.summary), 'fr': 'summary nouveau'}
         self.addon.save()
 
         self._test_metadata_content_review()

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -2264,6 +2264,9 @@ class TestAddonViewSetUpdate(AddonViewSetCreateUpdateMixin, TestCase):
         summ_log, name_log = list(
             ActivityLog.objects.filter(action=amo.LOG.EDIT_ADDON_PROPERTY.id)
         )
+        if name_log.arguments[1] != 'name':
+            # The order isn't deterministic, it doesn't matter, so just switch em.
+            name_log, summ_log = summ_log, name_log
         assert name_log.arguments == [self.addon, 'name']
         assert name_log.details == {
             'added': [patch_data['name']['en-US']],
@@ -2574,6 +2577,9 @@ class TestAddonViewSetUpdate(AddonViewSetCreateUpdateMixin, TestCase):
         summ_log, name_log = list(
             ActivityLog.objects.filter(action=amo.LOG.EDIT_ADDON_PROPERTY.id)
         )
+        if name_log.arguments[1] != 'name':
+            # The order isn't deterministic, it doesn't matter, so just switch em.
+            name_log, summ_log = summ_log, name_log
         assert name_log.arguments == [self.addon, 'name']
         assert name_log.details == {'added': ['new name'], 'removed': [old_name]}
         assert summ_log.arguments == [self.addon, 'summary']

--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -1239,7 +1239,7 @@ class DISABLE_AUTO_APPROVAL(_LOG):
 
 
 class EDIT_ADDON_PROPERTY(_LOG):
-    """Expects: addon, field"""
+    """Expects: addon, field. 3rd arg is a json blob."""
 
     id = 208
     action_class = 'edit'

--- a/src/olympia/constants/activity.py
+++ b/src/olympia/constants/activity.py
@@ -28,7 +28,7 @@ class CREATE_ADDON(_LOG):
 
 
 class EDIT_PROPERTIES(_LOG):
-    """Expects: addon"""
+    """Expects: addon. Consider using EDIT_ADDON_PROPERTY instead"""
 
     id = 2
     action_class = 'edit'
@@ -1236,6 +1236,15 @@ class DISABLE_AUTO_APPROVAL(_LOG):
     reviewer_review_action = True
     review_queue = True
     hide_developer = True
+
+
+class EDIT_ADDON_PROPERTY(_LOG):
+    """Expects: addon, field"""
+
+    id = 208
+    action_class = 'edit'
+    format = _('{addon} {0} property edited.')
+    show_user_to_developer = True
 
 
 LOGS = [x for x in vars().values() if isclass(x) and issubclass(x, _LOG) and x != _LOG]

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -331,16 +331,21 @@ class BaseTestEditDescribe(BaseTestEdit):
             if name_log.arguments[1] != 'name':
                 # The order isn't deterministic, it doesn't matter, so just switch em.
                 name_log, summ_log = summ_log, name_log
-            assert name_log.arguments == [self.addon, 'name']
-            assert name_log.details == {
-                'added': ['new name'],
-                'removed': ['Delicious Bookmarks'],
-            }
-            assert summ_log.arguments == [self.addon, 'summary']
-            assert summ_log.details == {
-                'added': ['new summary'],
-                'removed': ['Delicious Bookmarks is the official'],
-            }
+            assert name_log.arguments == [
+                self.addon,
+                'name',
+                json.dumps({'removed': ['Delicious Bookmarks'], 'added': ['new name']}),
+            ]
+            assert summ_log.arguments == [
+                self.addon,
+                'summary',
+                json.dumps(
+                    {
+                        'removed': ['Delicious Bookmarks is the official'],
+                        'added': ['new summary'],
+                    }
+                ),
+            ]
         else:
             alogs = ActivityLog.objects.filter(action=amo.LOG.EDIT_PROPERTIES.id)
             assert alogs.count() == 1

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -321,22 +321,29 @@ class BaseTestEditDescribe(BaseTestEdit):
         assert str(addon.name) == data['name']
         assert str(addon.summary) == data['summary']
 
-        # check we logged the changes
-        alogs = ActivityLog.objects.filter(action=amo.LOG.EDIT_ADDON_PROPERTY.id)
-        assert alogs.count() == 2
-        name_log, summ_log = list(
-            ActivityLog.objects.filter(action=amo.LOG.EDIT_ADDON_PROPERTY.id)
-        )
-        assert name_log.arguments == [self.addon, 'name']
-        assert name_log.details == {
-            'added': ['new name'],
-            'removed': ['Delicious Bookmarks'],
-        }
-        assert summ_log.arguments == [self.addon, 'summary']
-        assert summ_log.details == {
-            'added': ['new summary'],
-            'removed': ['Delicious Bookmarks is the official'],
-        }
+        if self.listed:
+            # check we logged the changes
+            alogs = ActivityLog.objects.filter(action=amo.LOG.EDIT_ADDON_PROPERTY.id)
+            assert alogs.count() == 2
+            name_log, summ_log = list(
+                ActivityLog.objects.filter(action=amo.LOG.EDIT_ADDON_PROPERTY.id)
+            )
+            if name_log.arguments[1] != 'name':
+                # The order isn't deterministic, it doesn't matter, so just switch em.
+                name_log, summ_log = summ_log, name_log
+            assert name_log.arguments == [self.addon, 'name']
+            assert name_log.details == {
+                'added': ['new name'],
+                'removed': ['Delicious Bookmarks'],
+            }
+            assert summ_log.arguments == [self.addon, 'summary']
+            assert summ_log.details == {
+                'added': ['new summary'],
+                'removed': ['Delicious Bookmarks is the official'],
+            }
+        else:
+            alogs = ActivityLog.objects.filter(action=amo.LOG.EDIT_PROPERTIES.id)
+            assert alogs.count() == 1
 
         # Now repeat, but we won't be changing either name or summary
         alogs.delete()

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -919,6 +919,15 @@ def addons_section(request, addon_id, addon, section, editable=False):
                 if section == 'media':
                     ActivityLog.objects.create(amo.LOG.CHANGE_MEDIA, addon)
                 else:
+                    metadata_changes = getattr(main_form, 'metadata_changes', {})
+                    for field in metadata_changes:
+                        ActivityLog.objects.create(
+                            amo.LOG.EDIT_ADDON_PROPERTY,
+                            addon,
+                            field,
+                            details=metadata_changes.get(field, {}),
+                        )
+
                     ActivityLog.objects.create(amo.LOG.EDIT_PROPERTIES, addon)
 
                 if valid_slug != addon.slug:

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import os
 import time
 from copy import deepcopy
@@ -920,12 +921,12 @@ def addons_section(request, addon_id, addon, section, editable=False):
                     ActivityLog.objects.create(amo.LOG.CHANGE_MEDIA, addon)
                 else:
                     metadata_changes = getattr(main_form, 'metadata_changes', {})
-                    for field in metadata_changes:
+                    for field, addedremoved in metadata_changes.items():
                         ActivityLog.objects.create(
                             amo.LOG.EDIT_ADDON_PROPERTY,
                             addon,
                             field,
-                            details=metadata_changes.get(field, {}),
+                            json.dumps(addedremoved),
                         )
 
                     ActivityLog.objects.create(amo.LOG.EDIT_PROPERTIES, addon)


### PR DESCRIPTION
Fixes: mozilla/addons#15742

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Name and summary addon metadata changes create `EDIT_ADDON_PROPERTY` activity logs, with the added and removed localized strings in a json blob in the arguments (not displayed).  

A simple name change from `en-US`: `good add-on` to `en-US`: `bad add-on` would result in the following activity log record:

action =  `amo.LOG.EDIT_ADDON_PROPERTY.id`
arguments = `[<Addon: id>, 'name',  '{"added": ["bad add-on"], "removed": ["good add-on"]}']`

or in the database:
action = `208`
arguments =  `'[{"addons.addon": 1}, {"str": "name"}, {"str": "{\\"added\\": [\\"bad add-on\\"], \\"removed\\": [\\"good add-on\\"]}"}]`

Added and removed are de-duplicated lists, and if a localized string hasn't changed it won't be included.

### Context

I originally intended to replace `EDIT_PROPERTIES` everywhere, and create seperate `EDIT_ADDON_PROPERTY` logs for each property change but ran into some difficulties with the devhub form (localized fields weren't being returned in changed_fields property) so, given the priority on the issue, limited the change to `name` and `summary` - and added the same limitation to `AddonSerializer` for consistency.

### Testing

- In devhub, edit the name (or summary) of an add-on with listed versions in en-US locale and save the form
- check:
  - the name (or summary) has changed
  - there is an activity log in the developer's activity log view for "{addon} name property edited."
  - in a django shell (or dbshell) check the `details` json blob contains the old and new names (or summaries) for the `EDIT_ADDON_PROPERTY` activity
- repeat via the API, by submitting a PATCH to [the addon endpoint](https://mozilla.github.io/addons-server/topics/api/addons.html#patch--api-v5-addons-addon-(int-id|string-slug|string-guid)-), changing the name (or summary)
- repeat the checks:
  - the name (or summary) has changed
  - there is an activity log in the developer's activity log view for "{addon} name property edited."
  - in a django shell (or dbshell) check the `details` json blob contains the old and new names (or summaries)

- Optional further testing:
  - add and/or delete name/summary in multiple, other locales
  - duplicate some strings (name is commonly duplicated because it's often a brand name)
  - change other properties at the same time and see the older `EDIT_PROPERTIES` is used for other properties, and name/summary in add-ons without listed versions.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
