### PR TITLE
Add bulk add functionality for disposable email domains

### DIFF
--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -825,6 +825,7 @@ CELERY_TASK_ROUTES = {
     },
     'olympia.users.tasks.sync_suppressed_emails_task': {'queue': 'cron'},
     'olympia.users.tasks.send_suppressed_email_confirmation': {'queue': 'devhub'},
+    'olympia.users.tasks.bulk_add_disposable_email_domains': {'queue': 'devhub'},
     # Reviewers.
     'olympia.reviewers.tasks.recalculate_post_review_weight': {'queue': 'reviewers'},
     # Admin.

--- a/src/olympia/users/management/commands/bulk_add_disposable_domains.py
+++ b/src/olympia/users/management/commands/bulk_add_disposable_domains.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
             for row in reader:
                 if len(row) >= 2:
                     domain, provider = row[0], row[1]
-                    records.append((domain, provider))
+                    records.append((domain.strip(), provider.strip()))
 
         result = bulk_add_disposable_email_domains.apply(args=[records])
         logger.info(result)

--- a/src/olympia/users/management/commands/bulk_add_disposable_domains.py
+++ b/src/olympia/users/management/commands/bulk_add_disposable_domains.py
@@ -11,7 +11,7 @@ logger = logger.getLogger('z.users')
 
 
 class Command(BaseCommand):
-    help = 'Bulk add disposable email domains (no-op)'
+    help = 'Bulk add disposable email domains'
 
     def add_arguments(self, parser):
         parser.add_argument('file', type=str)

--- a/src/olympia/users/management/commands/bulk_add_disposable_domains.py
+++ b/src/olympia/users/management/commands/bulk_add_disposable_domains.py
@@ -1,0 +1,34 @@
+import csv
+from pathlib import Path
+
+from django.core.management.base import BaseCommand, CommandError
+
+from olympia.core import logger
+from olympia.users.tasks import bulk_add_disposable_email_domains
+
+
+logger = logger.getLogger('z.users')
+
+
+class Command(BaseCommand):
+    help = 'Bulk add disposable email domains (no-op)'
+
+    def add_arguments(self, parser):
+        parser.add_argument('file', type=str)
+
+    def handle(self, *args, **options):
+        file_path = Path(options['file'])
+        if not file_path.exists():
+            raise CommandError(f'File {file_path} does not exist')
+
+        records = []
+        with file_path.open(newline='') as f:
+            reader = csv.reader(f)
+            next(reader, None)  # skip header row
+            for row in reader:
+                if len(row) >= 2:
+                    domain, provider = row[0], row[1]
+                    records.append((domain, provider))
+
+        result = bulk_add_disposable_email_domains.apply(args=[records])
+        logger.info(result)

--- a/src/olympia/users/tasks.py
+++ b/src/olympia/users/tasks.py
@@ -4,6 +4,8 @@ import tempfile
 import urllib.parse
 
 from django.conf import settings
+from django.core.exceptions import ValidationError
+from django.db.utils import InterfaceError, OperationalError
 from django.urls import reverse
 from django.utils.translation import gettext
 
@@ -24,6 +26,7 @@ from olympia.amo.utils import (
 
 from .models import (
     BannedUserContent,
+    DisposableEmailDomainRestriction,
     SuppressedEmail,
     SuppressedEmailVerification,
     UserProfile,
@@ -196,3 +199,53 @@ def send_suppressed_email_confirmation(suppressed_email_verification_id):
     )
 
     verification.save()
+
+
+@task(
+    autoretry_for=(OperationalError, InterfaceError), max_retries=5, retry_backoff=True
+)
+def bulk_add_disposable_email_domains(entries: list[tuple[str, str]], batch_size=1000):
+    task_log.info(f'Adding {len(entries)} disposable email domains')
+
+    records = []
+    errors = []
+
+    for entry in entries:
+        [domain, provider] = entry
+        record = DisposableEmailDomainRestriction(
+            domain=domain,
+            reason=f'Disposable email domain of {provider}',
+        )
+
+        try:
+            record.full_clean()
+            records.append(record)
+        except ValidationError as e:
+            errors.append(e)
+
+    if not records:
+        task_log.info('No valid entries provided')
+        return
+
+    processed_domains = []
+    records_iter = iter(records)
+
+    if not isinstance(batch_size, int) or batch_size <= 0:
+        raise ValueError('batch_size must be a positive integer')
+
+    while batch := list(itertools.islice(records_iter, batch_size)):
+        created_objects = DisposableEmailDomainRestriction.objects.bulk_create(
+            batch,
+            batch_size,
+            ignore_conflicts=True,
+        )
+        processed_domains.extend(created_objects)
+        task_log.info(
+            f'Successfully processed {len(created_objects)} '
+            f'of {len(batch)} domains in this batch'
+        )
+
+    task_log.info(
+        f'Processed {len(processed_domains)} domains: '
+        f'{[obj.domain for obj in processed_domains]}'
+    )

--- a/src/olympia/users/tasks.py
+++ b/src/olympia/users/tasks.py
@@ -205,6 +205,9 @@ def send_suppressed_email_confirmation(suppressed_email_verification_id):
     autoretry_for=(OperationalError, InterfaceError), max_retries=5, retry_backoff=True
 )
 def bulk_add_disposable_email_domains(entries: list[tuple[str, str]], batch_size=1000):
+    if not isinstance(batch_size, int) or batch_size <= 0:
+        raise ValueError('batch_size must be a positive integer')
+
     task_log.info(f'Adding {len(entries)} disposable email domains')
 
     records = []
@@ -228,9 +231,9 @@ def bulk_add_disposable_email_domains(entries: list[tuple[str, str]], batch_size
         return
 
     processed_domains = []
-    records_iter = iter(records)
 
-    while batch := list(itertools.islice(records_iter, batch_size)):
+    for i in range(0, len(records), batch_size):
+        batch = records[i : i + batch_size]
         created_objects = DisposableEmailDomainRestriction.objects.bulk_create(
             batch,
             batch_size,

--- a/src/olympia/users/tasks.py
+++ b/src/olympia/users/tasks.py
@@ -230,9 +230,6 @@ def bulk_add_disposable_email_domains(entries: list[tuple[str, str]], batch_size
     processed_domains = []
     records_iter = iter(records)
 
-    if not isinstance(batch_size, int) or batch_size <= 0:
-        raise ValueError('batch_size must be a positive integer')
-
     while batch := list(itertools.islice(records_iter, batch_size)):
         created_objects = DisposableEmailDomainRestriction.objects.bulk_create(
             batch,

--- a/src/olympia/users/tests/test_commands.py
+++ b/src/olympia/users/tests/test_commands.py
@@ -513,9 +513,9 @@ class TestBulkAddDisposableEmailDomains(TestCase):
             tmp.flush()
             tmp_path = tmp.name
 
-        assert DisposableEmailDomainRestriction.objects.count() == 0
+            assert DisposableEmailDomainRestriction.objects.count() == 0
 
-        call_command('bulk_add_disposable_domains', tmp_path)
+            call_command('bulk_add_disposable_domains', tmp_path)
 
         expected = [
             ('mailfast.pro', 'incognitomail.co'),
@@ -528,8 +528,6 @@ class TestBulkAddDisposableEmailDomains(TestCase):
             ).exists()
 
         assert DisposableEmailDomainRestriction.objects.count() == len(expected)
-
-        os.remove(tmp_path)
 
     def test_file_with_missing_columns(self):
         """Test that rows with missing columns are ignored or handled gracefully."""
@@ -545,9 +543,9 @@ class TestBulkAddDisposableEmailDomains(TestCase):
             tmp.flush()
             tmp_path = tmp.name
 
-        assert DisposableEmailDomainRestriction.objects.count() == 0
+            assert DisposableEmailDomainRestriction.objects.count() == 0
 
-        call_command('bulk_add_disposable_domains', tmp_path)
+            call_command('bulk_add_disposable_domains', tmp_path)
 
         expected = [
             ('mailfast.pro', 'incognitomail.co'),
@@ -561,8 +559,6 @@ class TestBulkAddDisposableEmailDomains(TestCase):
         assert not DisposableEmailDomainRestriction.objects.filter(domain='').exists()
         assert DisposableEmailDomainRestriction.objects.count() == len(expected)
 
-        os.remove(tmp_path)
-
     def test_file_with_header_only(self):
         """Test that a file with only a header row does not trigger any additions."""
         csv_content = 'Domain,Provider\n'
@@ -572,11 +568,8 @@ class TestBulkAddDisposableEmailDomains(TestCase):
             tmp.flush()
             tmp_path = tmp.name
 
-        call_command('bulk_add_disposable_domains', tmp_path)
-
-        assert DisposableEmailDomainRestriction.objects.count() == 0
-
-        os.remove(tmp_path)
+            call_command('bulk_add_disposable_domains', tmp_path)
+            assert DisposableEmailDomainRestriction.objects.count() == 0
 
     @patch('olympia.users.management.commands.bulk_add_disposable_domains.logger')
     @patch(
@@ -598,8 +591,5 @@ class TestBulkAddDisposableEmailDomains(TestCase):
             tmp.flush()
             tmp_path = tmp.name
 
-        try:
             call_command('bulk_add_disposable_domains', tmp_path)
             mock_logger.info.assert_called_with(fake_result)
-        finally:
-            os.remove(tmp_path)

--- a/src/olympia/users/tests/test_commands.py
+++ b/src/olympia/users/tests/test_commands.py
@@ -615,7 +615,6 @@ class TestBulkAddDisposableEmailDomains(TestCase):
             ('foo.com', 'mail.tm'),
             ('mailpro.live', 'incognitomail.co'),
         ]
-        breakpoint()
         for domain, provider in expected:
             assert DisposableEmailDomainRestriction.objects.filter(
                 domain=domain, reason=f'Disposable email domain of {provider}'

--- a/src/olympia/users/tests/test_commands.py
+++ b/src/olympia/users/tests/test_commands.py
@@ -6,11 +6,11 @@ import tempfile
 import uuid
 from ipaddress import IPv4Address
 from unittest.mock import ANY, patch
-from celery.result import EagerResult
 
 from django.core.files.base import ContentFile
 from django.core.management import CommandError, call_command
 
+from celery.result import EagerResult
 from waffle.testutils import override_switch
 
 from olympia import amo
@@ -575,7 +575,6 @@ class TestBulkAddDisposableEmailDomains(TestCase):
     @patch('olympia.users.management.commands.bulk_add_disposable_domains.logger')
     def test_bulk_add_result_is_printed(self, mock_logger):
         """result of bulk_add_disposable_email_domains task logged."""
-        fake_result = 'Task completed successfully'
 
         csv_content = (
             'Domain,Provider\n'

--- a/src/olympia/users/tests/test_tasks.py
+++ b/src/olympia/users/tests/test_tasks.py
@@ -430,35 +430,29 @@ class TestBulkAddDisposableEmailDomains(TestCase):
         # Ensure that the task runs with 2 batches by default
         self.batch_size = len(self.entries) // 2
 
-    def _assert_count(self, count):
-        assert DisposableEmailDomainRestriction.objects.count() == count
-
-    def _assert_result(self, result, outcome):
-        assert result.status == outcome
-
     def test_bulk_add_disposable_email_domains_success(self):
-        self._assert_count(0)
+        assert DisposableEmailDomainRestriction.objects.count() == 0
 
         result = bulk_add_disposable_email_domains.apply(
             args=[self.entries, self.batch_size]
         )
 
-        self._assert_result(result, 'SUCCESS')
-        self._assert_count(len(self.entries))
+        assert result.status == 'SUCCESS'
+        assert DisposableEmailDomainRestriction.objects.count() == len(self.entries)
 
     def test_bulk_add_disposable_email_domains_skips_duplicate_entries(self):
         [domain, provider] = self.entries[0]
         DisposableEmailDomainRestriction.objects.create(
             domain=domain, reason=f'Disposable email domain of {provider}'
         )
-        self._assert_count(1)
+        assert DisposableEmailDomainRestriction.objects.count() == 1
 
         result = bulk_add_disposable_email_domains.apply(
             args=[self.entries, self.batch_size]
         )
 
-        self._assert_result(result, 'SUCCESS')
-        self._assert_count(len(self.entries))
+        assert result.status == 'SUCCESS'
+        assert DisposableEmailDomainRestriction.objects.count() == len(self.entries)
 
     def test_zero_batch_size_raises_error(self):
         with pytest.raises(ValueError):

--- a/src/olympia/users/tests/test_tasks.py
+++ b/src/olympia/users/tests/test_tasks.py
@@ -7,6 +7,7 @@ from unittest import mock
 
 from django.conf import settings
 from django.core import mail
+from django.db.utils import OperationalError
 from django.urls import reverse
 
 import pytest
@@ -21,10 +22,12 @@ from olympia.amo.tests.test_helpers import get_image_path
 from olympia.amo.utils import SafeStorage
 from olympia.users.models import (
     BannedUserContent,
+    DisposableEmailDomainRestriction,
     SuppressedEmail,
     SuppressedEmailVerification,
 )
 from olympia.users.tasks import (
+    bulk_add_disposable_email_domains,
     delete_photo,
     resize_photo,
     send_suppressed_email_confirmation,
@@ -414,3 +417,62 @@ class TestSendSuppressedEmailConfirmation(TestCase):
             verification.reload().status
             == SuppressedEmailVerification.STATUS_CHOICES.Pending
         )
+
+
+class TestBulkAddDisposableEmailDomains(TestCase):
+    def setUp(self):
+        self.user_profile = user_factory()
+        self.entries = [
+            (f'test-{i}-{j}.com', f'provider-{i}')
+            for i in range(10)
+            for j in range(100)
+        ]
+        # Ensure that the task runs with 2 batches by default
+        self.batch_size = len(self.entries) // 2
+
+    def _assert_count(self, count):
+        assert DisposableEmailDomainRestriction.objects.count() == count
+
+    def _assert_result(self, result, outcome):
+        assert result.status == outcome
+
+    def test_bulk_add_disposable_email_domains_success(self):
+        self._assert_count(0)
+
+        result = bulk_add_disposable_email_domains.apply(
+            args=[self.entries, self.batch_size]
+        )
+
+        self._assert_result(result, 'SUCCESS')
+        self._assert_count(len(self.entries))
+
+    def test_bulk_add_disposable_email_domains_skips_duplicate_entries(self):
+        [domain, provider] = self.entries[0]
+        DisposableEmailDomainRestriction.objects.create(
+            domain=domain, reason=f'Disposable email domain of {provider}'
+        )
+        self._assert_count(1)
+
+        result = bulk_add_disposable_email_domains.apply(
+            args=[self.entries, self.batch_size]
+        )
+
+        self._assert_result(result, 'SUCCESS')
+        self._assert_count(len(self.entries))
+
+    def test_zero_batch_size_raises_error(self):
+        with pytest.raises(ValueError):
+            bulk_add_disposable_email_domains.apply(args=[self.entries, 0])
+
+    def test_retries_on_db_timeout(self):
+        def always_raise_operational_error(*args, **kwargs):
+            raise OperationalError()
+
+        with mock.patch(
+            'olympia.users.tasks.DisposableEmailDomainRestriction.objects.bulk_create',
+            side_effect=always_raise_operational_error,
+        ):
+            with pytest.raises(Retry):
+                bulk_add_disposable_email_domains.apply(
+                    args=[self.entries, self.batch_size]
+                ).get()


### PR DESCRIPTION
- Introduced a new CSV file containing disposable email domains.
- Implemented the `bulk_add_disposable_email_domains` task to handle the addition of these domains.
- Added a management command to facilitate bulk addition from a CSV file.
- Created unit tests to ensure the functionality works as expected, including handling of duplicate entries.

## Description

Add a task + command to execute the task, taking a csv file (via the command) path, extracting the (domain, provider) values and passing them to the task.

The task bulk adds the records in batches to handle gracefully large payloads. Currently, it logs errors that fail django model validation, removes the m from the list of domains to add and continues.

## Context

We want an easy way to process large numbers of domain block requests.

## Testing

TBD: see the automated tests, we should be covering the following edge cases:

### Task level:
- duplicate same domain and provider
- duplicate same domain different provider
- existing model validation for `DisposableEmailRestriction`

To run the task, from a django shell run something like

```python
from olympia.users.tasks import bulk_add_disposable_domains 

entries = [
('foo.com', 'fooprovider')
]

result = bulk_add_disposable_domains.apply(args=[entries])
```

You can inspect result and check the `result.status` to see if it was ran successfully, you can verify the records exist in the database.

### Command level:

- Invalid or missing file provided.

To execute the command run from a shell

```python
./manage.py bulk_add_disposable_domains disposable_domains_2025-07-22.csv
```

- invalid file (remove the file path before checking this) should be a required argument
- missing file (delete the file but pass the path) should raise command error that the file must exist.

### Checklist

- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
