### PR TITLE
Add action to (mass-) delete restrictions in admin

### DIFF
--- a/src/olympia/users/admin.py
+++ b/src/olympia/users/admin.py
@@ -567,6 +567,7 @@ class DeniedNameAdmin(AMOModelAdmin):
 
 @admin.register(IPNetworkUserRestriction)
 class IPNetworkUserRestrictionAdmin(AMOModelAdmin):
+    actions = ['delete_selected']
     list_display = ('network', 'restriction_type', 'reason')
     list_filter = ('restriction_type',)
     search_fields = ('=network',)
@@ -578,6 +579,7 @@ class IPNetworkUserRestrictionAdmin(AMOModelAdmin):
 
 @admin.register(EmailUserRestriction)
 class EmailUserRestrictionAdmin(AMOModelAdmin):
+    actions = ['delete_selected']
     list_display = ('email_pattern', 'restriction_type', 'reason')
     list_filter = ('restriction_type',)
     search_fields = ('^email_pattern',)
@@ -588,6 +590,7 @@ class EmailUserRestrictionAdmin(AMOModelAdmin):
 
 @admin.register(DisposableEmailDomainRestriction)
 class DisposableEmailDomainRestrictionAdmin(AMOModelAdmin):
+    actions = ['delete_selected']
     list_display = ('domain', 'restriction_type', 'reason')
     list_filter = ('restriction_type',)
     search_fields = ('^domain',)


### PR DESCRIPTION
Helps https://mozilla-hub.atlassian.net/browse/ADDONSOPS-1175
Pre-requisite for https://github.com/mozilla/addons-server/pull/23753 (will help get rid of duplicates before adding a constraint)

### Context

We disable Django's `delete_selected` default action in our base admin, but we want it here so that Operations can quickly change multiple restrictions at once.

### Testing

- In admin, add a few email/network/disposable email restrictions
- Select multiple rows to delete multiple restrictions at once

### Screenshots
#### Before
<img width="3412" height="800" alt="Screenshot 2025-07-30 at 17-25-38 Select email user restriction to change Django site admin" src="https://github.com/user-attachments/assets/44979892-f327-4462-a0d3-121879c66270" />

#### After
<img width="3412" height="800" alt="Screenshot 2025-07-30 at 17-25-02 Select email user restriction to change Django site admin" src="https://github.com/user-attachments/assets/e3665e44-190d-4824-a0c9-36db0fefbdf1" />
