### PR TITLE
add statsd ping specifically for rollback success (or failure)

### DIFF
--- a/src/olympia/versions/tasks.py
+++ b/src/olympia/versions/tasks.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.db import transaction
 from django.template import loader
 
+from django_statsd.clients import statsd
 from PIL import Image
 
 import olympia.core.logger
@@ -305,6 +306,7 @@ def duplicate_addon_version_for_rollback(*, version_pk, new_version_number, user
             },
         )
         version = old_version
+        statsd.incr('versions.tasks.rollback.failure')
     else:
         version.update(human_review_date=old_version.human_review_date)
 
@@ -339,6 +341,7 @@ def duplicate_addon_version_for_rollback(*, version_pk, new_version_number, user
             },
         )
         VersionLog.objects.create(activity_log=log_entry, version=old_version)
+        statsd.incr('versions.tasks.rollback.success')
 
     notify_about_activity_log(
         version.addon, version, log_entry, perm_setting='individual_contact'


### PR DESCRIPTION
Fixes: mozilla/addons#15664

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Add a statsd ping specifically for version rollback success or failure

### Context

This was deemed sufficient for the issue - the activity log could also be queried against in redash if we wanted to get data grouped by add-on or user, etc.

### Testing

I'm not sure its possible to test statsd pings locally?  You could trigger the task and make sure it still works, but even that's probably redundant with the tests.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.