### PR TITLE
Update mozilla/addons github actions after security patches

### DIFF
--- a/.github/workflows/_health_check.yml
+++ b/.github/workflows/_health_check.yml
@@ -139,7 +139,7 @@ jobs:
 
       - name: Notify Failure
         if: steps.blocks.outcome == 'success' && needs.context.outputs.slack_channel != ''
-        uses: mozilla/addons/.github/actions/slack@aa3c320008a837a8faa40badb88006421f63efdb
+        uses: mozilla/addons/.github/actions/slack@f748fdc2c8057ad7b574521a60c182939f2ee687
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
           payload: |

--- a/.github/workflows/_test_check.yml
+++ b/.github/workflows/_test_check.yml
@@ -40,7 +40,7 @@ jobs:
       is_fork: ${{ steps.context.outputs.is_fork }}
     steps:
       - id: context
-        uses: mozilla/addons/.github/actions/context@aa3c320008a837a8faa40badb88006421f63efdb
+        uses: mozilla/addons/.github/actions/context@f748fdc2c8057ad7b574521a60c182939f2ee687
 
   test_check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - name: Set context
         id: context
-        uses: mozilla/addons/.github/actions/context@aa3c320008a837a8faa40badb88006421f63efdb
+        uses: mozilla/addons/.github/actions/context@f748fdc2c8057ad7b574521a60c182939f2ee687
 
       - name: Git Reference
         id: git
@@ -116,7 +116,7 @@ jobs:
       - name: Login to Dockerhub
         if: needs.context.outputs.is_fork == 'false'
         id: docker_hub
-        uses: mozilla/addons/.github/actions/login-docker@aa3c320008a837a8faa40badb88006421f63efdb
+        uses: mozilla/addons/.github/actions/login-docker@f748fdc2c8057ad7b574521a60c182939f2ee687
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
@@ -272,7 +272,7 @@ jobs:
 
       - name: Login to Dockerhub
         id: docker_hub
-        uses: mozilla/addons/.github/actions/login-docker@aa3c320008a837a8faa40badb88006421f63efdb
+        uses: mozilla/addons/.github/actions/login-docker@f748fdc2c8057ad7b574521a60c182939f2ee687
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASS }}
@@ -309,7 +309,7 @@ jobs:
 
       - name: Login to GAR
         id: docker_gar
-        uses: mozilla/addons/.github/actions/login-gar@aa3c320008a837a8faa40badb88006421f63efdb
+        uses: mozilla/addons/.github/actions/login-gar@f748fdc2c8057ad7b574521a60c182939f2ee687
         with:
           registry: ${{ env.registry }}
           service_account: ${{ secrets.GAR_PUSHER_SERVICE_ACCOUNT_EMAIL }}
@@ -342,7 +342,7 @@ jobs:
     steps:
 
     - name: Slack Notification
-      uses: mozilla/addons/.github/actions/slack-workflow-notification@aa3c320008a837a8faa40badb88006421f63efdb
+      uses: mozilla/addons/.github/actions/slack-workflow-notification@f748fdc2c8057ad7b574521a60c182939f2ee687
       with:
         slack_token: ${{ secrets.SLACK_TOKEN }}
         slack_channel: ${{ vars.SLACK_ADDONS_PRODUCTION_CHANNEL }}

--- a/.github/workflows/health_check.yml
+++ b/.github/workflows/health_check.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Context
         id: context
-        uses: mozilla/addons/.github/actions/context@aa3c320008a837a8faa40badb88006421f63efdb
+        uses: mozilla/addons/.github/actions/context@f748fdc2c8057ad7b574521a60c182939f2ee687
 
   health_check:
     strategy:
@@ -66,7 +66,7 @@ jobs:
           gh workflow run health_check.yml --ref "${ref}"
 
       - name: Notify Recovery
-        uses: mozilla/addons/.github/actions/slack@aa3c320008a837a8faa40badb88006421f63efdb
+        uses: mozilla/addons/.github/actions/slack@
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
           payload: |
@@ -77,7 +77,7 @@ jobs:
           dry_run: ${{ !(needs.health_check.result == 'success' && github.event_name == 'workflow_dispatch') }}
 
       - name: Notify Failure
-        uses: mozilla/addons/.github/actions/slack-workflow-notification@aa3c320008a837a8faa40badb88006421f63efdb
+        uses: mozilla/addons/.github/actions/slack-workflow-notification@
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
           slack_channel: ${{ vars.SLACK_ADDONS_PRODUCTION_CHANNEL }}

--- a/.github/workflows/health_check.yml
+++ b/.github/workflows/health_check.yml
@@ -66,7 +66,7 @@ jobs:
           gh workflow run health_check.yml --ref "${ref}"
 
       - name: Notify Recovery
-        uses: mozilla/addons/.github/actions/slack@
+        uses: mozilla/addons/.github/actions/slack@f748fdc2c8057ad7b574521a60c182939f2ee687
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
           payload: |
@@ -77,7 +77,7 @@ jobs:
           dry_run: ${{ !(needs.health_check.result == 'success' && github.event_name == 'workflow_dispatch') }}
 
       - name: Notify Failure
-        uses: mozilla/addons/.github/actions/slack-workflow-notification@
+        uses: mozilla/addons/.github/actions/slack-workflow-notification@f748fdc2c8057ad7b574521a60c182939f2ee687
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
           slack_channel: ${{ vars.SLACK_ADDONS_PRODUCTION_CHANNEL }}


### PR DESCRIPTION
Fixes: mozilla/addons#15744

### Description

After https://github.com/mozilla/addons/pull/15751 landed we now need to update addons-server to use the new patched version of github actions.

### Context

The update upstream added security patches for various vulnerabilities.

### Testing

CI is green.

### Checklist


- [X] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [X] Successfully verified the change locally.
- [X] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
