### PR TITLE
use primary_db with duplicate_addon_version_for_rollback task

### DIFF
--- a/src/olympia/versions/tasks.py
+++ b/src/olympia/versions/tasks.py
@@ -281,6 +281,7 @@ def hard_delete_versions(version_ids, **kw):
 
 
 @task
+@use_primary_db
 def duplicate_addon_version_for_rollback(*, version_pk, new_version_number, user_pk):
     task_user = get_task_user()
     new_version_number = VersionString(new_version_number)


### PR DESCRIPTION
Fixes: mozilla/addons#15767

### Description

I think this is all we need?

### Testing

Can't be tested locally.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
