### PR TITLE
Re-run scanner actions if results changed when running narc scanner on version

### DIFF
--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -1344,6 +1344,16 @@ class AddonSerializer(AMOModelSerializer):
         addon.version = self.fields['version'].create(
             {**validated_data.get('version', {}), 'addon': addon}
         )
+        # We scan uploads, but narc cares about add-on translations too, and
+        # the developer might have provided some that were not in the upload,
+        # so we have to trigger it again. This only matters if the initial
+        # version is listed, since that's when those translations matter.
+        if (
+            waffle.switch_is_active('enable-narc')
+            and 'name' in validated_data
+            and addon.version.channel == amo.CHANNEL_LISTED
+        ):
+            run_narc_on_version.delay(addon.version.pk)
         # When creating, always return the version we just created in the
         # representation. It uses <instance>.version.
         self.fields['version'].write_only = False

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -1840,7 +1840,6 @@ class TestAddonViewSetCreate(UploadMixin, AddonViewSetCreateUpdateMixin, TestCas
         }
         response = self.request(**data)
         assert response.status_code == 201, response.content
-        version = Addon.objects.get().versions.get()
         assert run_narc_on_version_mock.delay.call_count == 0
 
     @mock.patch('olympia.addons.serializers.run_narc_on_version')
@@ -1883,7 +1882,6 @@ class TestAddonViewSetCreate(UploadMixin, AddonViewSetCreateUpdateMixin, TestCas
         }
         response = self.request(**data)
         assert response.status_code == 201, response.content
-        version = Addon.objects.get().versions.get()
         assert run_narc_on_version_mock.delay.call_count == 0
 
 

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -1802,6 +1802,90 @@ class TestAddonViewSetCreate(UploadMixin, AddonViewSetCreateUpdateMixin, TestCas
         response = self.request(data=request_data)
         assert response.status_code == 201, response.content
 
+    @mock.patch('olympia.addons.serializers.run_narc_on_version')
+    def test_run_narc_on_version_at_creation_if_name_provided_and_listed(
+        self, run_narc_on_version_mock
+    ):
+        self.create_switch('enable-narc', active=True)
+        self.upload.update(channel=amo.CHANNEL_LISTED)
+        data = {
+            'categories': ['bookmarks'],
+            'description': {'en-US': 'new description'},
+            'name': {'en-US': 'new name'},
+            'version': {
+                'upload': self.upload.uuid,
+                'license': self.license.slug,
+            },
+        }
+        response = self.request(**data)
+        assert response.status_code == 201, response.content
+        version = Addon.objects.get().versions.get()
+        assert run_narc_on_version_mock.delay.call_count == 1
+        assert run_narc_on_version_mock.delay.call_args[0] == (version.pk,)
+
+    @mock.patch('olympia.addons.serializers.run_narc_on_version')
+    def test_dont_run_narc_on_version_at_creation_if_waffle_is_off(
+        self, run_narc_on_version_mock
+    ):
+        self.create_switch('enable-narc', active=False)
+        self.upload.update(channel=amo.CHANNEL_LISTED)
+        data = {
+            'categories': ['bookmarks'],
+            'description': {'en-US': 'new description'},
+            'name': {'en-US': 'new name'},
+            'version': {
+                'upload': self.upload.uuid,
+                'license': self.license.slug,
+            },
+        }
+        response = self.request(**data)
+        assert response.status_code == 201, response.content
+        version = Addon.objects.get().versions.get()
+        assert run_narc_on_version_mock.delay.call_count == 0
+
+    @mock.patch('olympia.addons.serializers.run_narc_on_version')
+    def test_dont_run_narc_on_version_at_creation_if_name_provided_and_unlisted(
+        self, run_narc_on_version_mock
+    ):
+        # If channel is unlisted, the scanning we will have done on the upload
+        # is enough - we'll scan the name translation later if another upload
+        # comes through before the add-on listing becomes available on AMO.
+        self.create_switch('enable-narc', active=True)
+        assert self.upload.channel == amo.CHANNEL_UNLISTED
+        data = {
+            'description': {'en-US': 'new description'},
+            'name': {'en-US': 'new name'},
+            'version': {
+                'upload': self.upload.uuid,
+            },
+        }
+        response = self.request(**data)
+        assert response.status_code == 201, response.content
+        version = Addon.objects.get().versions.get()
+        assert version.channel == amo.CHANNEL_UNLISTED
+        assert run_narc_on_version_mock.delay.call_count == 0
+
+    @mock.patch('olympia.addons.serializers.run_narc_on_version')
+    def test_dont_run_narc_on_version_at_creation_if_name_not_provided(
+        self, run_narc_on_version_mock
+    ):
+        # If name is not provided, the scanning we will have done on the upload
+        # is enough.
+        self.create_switch('enable-narc', active=True)
+        self.upload.update(channel=amo.CHANNEL_LISTED)
+        data = {
+            'categories': ['bookmarks'],
+            'description': {'en-US': 'new description'},
+            'version': {
+                'upload': self.upload.uuid,
+                'license': self.license.slug,
+            },
+        }
+        response = self.request(**data)
+        assert response.status_code == 201, response.content
+        version = Addon.objects.get().versions.get()
+        assert run_narc_on_version_mock.delay.call_count == 0
+
 
 class TestAddonViewSetCreatePut(TestAddonViewSetCreate):
     client_request_verb = 'put'

--- a/src/olympia/scanners/tasks.py
+++ b/src/olympia/scanners/tasks.py
@@ -247,10 +247,8 @@ def _run_narc(*, upload, version):
     # Find all translations from the XPI - if we get a string, that means there
     # were no translations to find, build a simple dict for ease of use later.
     if xpi := upload or version.file.file:
-        xpi_info = parse_xpi(xpi, addon=addon, bypass_trademark_checks=True)
-        values_from_xpi = Addon.resolve_webext_translations(xpi_info, xpi).get(
-            'name', {}
-        )
+        data = parse_xpi(xpi, addon=addon, minimal=True, bypass_trademark_checks=True)
+        values_from_xpi = Addon.resolve_webext_translations(data, xpi).get('name', {})
         if isinstance(values_from_xpi, str):
             values_from_xpi = {None: values_from_xpi}
 

--- a/src/olympia/scanners/tests/test_tasks.py
+++ b/src/olympia/scanners/tests/test_tasks.py
@@ -412,6 +412,7 @@ class TestRunNarc(UploadMixin, TestCase):
             ]
         )
         assert received_results == self.results
+        return narc_result
 
     @mock.patch('olympia.scanners.tasks.statsd.incr')
     def test_run_multiple_authors_match(self, incr_mock):
@@ -716,7 +717,8 @@ class TestRunNarc(UploadMixin, TestCase):
         assert received_results == self.results
 
     @mock.patch('olympia.scanners.tasks.statsd.incr')
-    def test_run_on_version(self, incr_mock):
+    @mock.patch.object(ScannerResult, 'run_action')
+    def test_run_on_version(self, run_action_mock, incr_mock):
         # Validate an upload first, make it match multiple rules.
         narc_result = self.test_run_multiple_matching_rules()
         assert len(narc_result.results) == 2
@@ -736,6 +738,7 @@ class TestRunNarc(UploadMixin, TestCase):
         )
         narc_result.update(version=version)
         incr_mock.reset_mock()
+        run_action_mock.reset_mock()
 
         run_narc_on_version(version.pk)
 
@@ -803,15 +806,21 @@ class TestRunNarc(UploadMixin, TestCase):
         assert narc_result.has_matches
         assert set(narc_result.matched_rules.all()) == set(rules)
         assert incr_mock.called
-        assert incr_mock.call_count == 4
+        assert incr_mock.call_count == 5
         incr_mock.assert_has_calls(
             [
                 mock.call('devhub.narc.has_matches'),
                 mock.call(f'devhub.narc.rule.{rules[0].id}.match'),
                 mock.call(f'devhub.narc.rule.{rules[1].id}.match'),
+                mock.call('devhub.narc.results_differ'),
                 mock.call('devhub.narc.success'),
             ]
         )
+
+        # We re-triggered the run action.
+        assert run_action_mock.call_count == 1
+        assert run_action_mock.call_args[0] == (version,)
+        assert run_action_mock.call_args[1] == {'check_mad_results': False}
 
     @mock.patch('olympia.scanners.tasks.statsd.incr')
     def test_run_on_version_xpi_does_not_exist(self, incr_mock):
@@ -851,6 +860,50 @@ class TestRunNarc(UploadMixin, TestCase):
         assert narc_result.has_matches
         assert list(narc_result.matched_rules.all()) == [rule]
         assert incr_mock.called
+        assert incr_mock.call_count == 4
+        incr_mock.assert_has_calls(
+            [
+                mock.call('devhub.narc.has_matches'),
+                mock.call(f'devhub.narc.rule.{rule.id}.match'),
+                mock.call('devhub.narc.results_differ'),
+                mock.call('devhub.narc.success'),
+            ]
+        )
+
+    @mock.patch('olympia.scanners.tasks.statsd.incr')
+    @mock.patch.object(ScannerResult, 'run_action')
+    def test_run_on_version_no_new_result(self, run_action_mock, incr_mock):
+        # Validate an upload first
+        narc_result = self.test_run_xpi_match_only()
+        assert len(narc_result.results) == 1
+        addon = addon_factory(
+            guid='@webextension-guid', name='Name that does not cause an extra match'
+        )
+        fake_user = user_factory()
+        parsed_data = parse_addon(self.upload, addon=addon, user=fake_user)
+        version = Version.from_upload(
+            self.upload,
+            addon,
+            amo.CHANNEL_LISTED,
+            selected_apps=[amo.FIREFOX.id],
+            parsed_data=parsed_data,
+        )
+        narc_result.update(version=version)
+        incr_mock.reset_mock()
+        run_action_mock.reset_mock()
+
+        run_narc_on_version(version.pk)
+
+        scanner_results = ScannerResult.objects.all()
+        assert len(scanner_results) == 1
+        narc_result = scanner_results[0]
+        assert narc_result.scanner == NARC
+        assert narc_result.upload == self.upload
+        assert narc_result.version == version
+        assert len(narc_result.results) == 1
+        assert narc_result.has_matches
+        rule = narc_result.matched_rules.all()[0]
+        assert incr_mock.called
         assert incr_mock.call_count == 3
         incr_mock.assert_has_calls(
             [
@@ -859,6 +912,9 @@ class TestRunNarc(UploadMixin, TestCase):
                 mock.call('devhub.narc.success'),
             ]
         )
+
+        # We didn't retrigger the action since the first run (no new matches).
+        assert run_action_mock.call_count == 0
 
 
 class TestRunYara(UploadMixin, TestCase):

--- a/src/olympia/scanners/tests/test_tasks.py
+++ b/src/olympia/scanners/tests/test_tasks.py
@@ -710,7 +710,7 @@ class TestRunNarc(UploadMixin, TestCase):
             definition=r'.*',
         )
 
-        received_results = run_narc(self.results, self.upload.pk)
+        run_narc(self.results, self.upload.pk)
 
         assert not ScannerResult.objects.exists()
         assert not incr_mock.called


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/15765
(Also addresses follow-ups for https://github.com/mozilla/addons/issues/15763)

### Description

Initial implementation of https://github.com/mozilla/addons/issues/15763 already triggered a new scan when developer or add-on name changes outside of the XPI, but we didn't re-trigger the scanner actions. This does.

### Context

To handle the case where a scanner action is run multiple times (something that is specific to `NARC`, doesn't happen for other scanners), the actions now check for a `NeedsHumanReview` corresponding to a scanner action before doing anything: if there weren't any scanner action NHR, or if one or more active scanner action NHR exist, we proceed with the action, but otherwise we abort (reviewer has acknowledged the NHR and the scanner shouldn't override what the reviewer has done)

### Testing

#### Initial setup
- Add a Scanner rule in the admin for the narc scanner with whatever regexp you want in the definition of the rule. Make the rule active and associate an action with it, for instance flag for human review.
- Enable enable-narc waffle switch
- Enable run-action-in-auto-approve waffle switch

#### API submission while providing a different name
- Craft an add-on XPI that would *not* match the rule created above.
- Submit that XPI as a new listed add-on with the add-on API while passing a `name` through the parameters that would match the rule above
- Your rule action should be triggered on that add-on

#### Changing the name afterwards
- Craft an add-on XPI that would *not* match the rule created above.
- Submit that XPI
- Change the add-on name with devhub or the API with a name that matches the rule above
- Your rule action should be triggered on that add-on

#### Changing the name afterwards but the add-on was reviewed
- Craft an add-on XPI that *would* match the rule created above.
- Submit that XPI
- Your rule action should be triggered on that add-on
- As a reviewer, clear the NHR in some way, like approving/confirming auto-approval.
- As the developer, change your display name to a name that matches the rule above (this doesn't re-trigger the rule yet, but will be taken into consideration when re-scanning in the next step)
- As the developer, change the add-on name with devhub or the API to a different name that matches the rule above
- Your rule action should *not* be triggered on that add-on (a reviewer approved the code already)