### PR TITLE
Fix permission for 2nd level approval queue

### DIFF
--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -7787,11 +7787,12 @@ class TestHeldDecisionQueue(ReviewerTest):
             action=DECISION_ACTIONS.AMO_DELETE_RATING,
             rating=Rating.objects.create(addon=addon_factory(), user=user_factory()),
         )
-        self.user = user_factory()
-        self.grant_permission(self.user, 'Addons:HighImpactApprove')
-        self.client.force_login(self.user)
 
     def test_results(self):
+        user = user_factory()
+        self.grant_permission(user, 'Addons:HighImpactApprove')
+        self.client.force_login(user)
+
         response = self.client.get(self.url)
         assert response.status_code == 200
         doc = pq(response.content)('#held-decision-queue')

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -7787,9 +7787,9 @@ class TestHeldDecisionQueue(ReviewerTest):
             action=DECISION_ACTIONS.AMO_DELETE_RATING,
             rating=Rating.objects.create(addon=addon_factory(), user=user_factory()),
         )
-        user = user_factory()
-        self.grant_permission(user, 'Addons:HighImpactApprove')
-        self.client.force_login(user)
+        self.user = user_factory()
+        self.grant_permission(self.user, 'Addons:HighImpactApprove')
+        self.client.force_login(self.user)
 
     def test_results(self):
         response = self.client.get(self.url)

--- a/src/olympia/reviewers/tests/test_views.py
+++ b/src/olympia/reviewers/tests/test_views.py
@@ -1380,12 +1380,15 @@ class TestQueueBasics(QueueTest):
         assert response.status_code == 200
         doc = pq(response.content)
         links = doc('.tabnav li a').map(lambda i, e: e.attrib['href'])
-        expected.extend(
-            [
-                reverse('reviewers.queue_pending_rejection'),
-                reverse('reviewers.queue_decisions'),
-            ]
-        )
+        expected.append(reverse('reviewers.queue_pending_rejection'))
+        assert links == expected
+
+        self.grant_permission(self.user, 'Addons:HighImpactApprove')
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        doc = pq(response.content)
+        links = doc('.tabnav li a').map(lambda i, e: e.attrib['href'])
+        expected.append(reverse('reviewers.queue_decisions'))
         assert links == expected
 
     @override_settings(DEBUG=True)
@@ -7784,7 +7787,9 @@ class TestHeldDecisionQueue(ReviewerTest):
             action=DECISION_ACTIONS.AMO_DELETE_RATING,
             rating=Rating.objects.create(addon=addon_factory(), user=user_factory()),
         )
-        self.login_as_admin()
+        user = user_factory()
+        self.grant_permission(user, 'Addons:HighImpactApprove')
+        self.client.force_login(user)
 
     def test_results(self):
         response = self.client.get(self.url)

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -342,7 +342,7 @@ class HeldDecisionQueueTable:
     title = 'Held Decisions for 2nd Level Approval'
     name = 'queue_decisions'
     url_suffix = r'^held_decisions$'
-    permission = amo.permissions.REVIEWS_ADMIN
+    permission = amo.permissions.ADDONS_HIGH_IMPACT_APPROVE
     show_count_in_dashboard = True
     view_name = 'queue_decisions'
 

--- a/src/olympia/reviewers/views.py
+++ b/src/olympia/reviewers/views.py
@@ -1255,7 +1255,7 @@ def review_version_redirect(request, addon, version):
     return redirect(url + page_param + f'#version-{to_dom_id(version)}')
 
 
-@permission_or_tools_listed_view_required(amo.permissions.REVIEWS_ADMIN)
+@permission_or_tools_listed_view_required(amo.permissions.ADDONS_HIGH_IMPACT_APPROVE)
 def queue_decisions(request, tab):
     TableObj = reviewer_tables_registry[tab]
     qs = TableObj.get_queryset(request)


### PR DESCRIPTION
Fixes: https://github.com/mozilla/addons/issues/15775

### Description

This patch fixes the permissions required to see the Held Decisions for 2nd Level Approval queue page.
### Context

Permissions for 2nd level approval were updated in https://github.com/mozilla/addons-server/pull/23538 but I believe we missed this one.

### Testing

1. Assign a user the `Addons:HighImpactApprove` permission.
2. Access `/reviewers/queue/held_decisions`

### Checklist

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
