### PR TITLE
Change NARC scanner to run on versions rather than uploads

### DIFF
--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -1344,16 +1344,6 @@ class AddonSerializer(AMOModelSerializer):
         addon.version = self.fields['version'].create(
             {**validated_data.get('version', {}), 'addon': addon}
         )
-        # We scan uploads, but narc cares about add-on translations too, and
-        # the developer might have provided some that were not in the upload,
-        # so we have to trigger it again. This only matters if the initial
-        # version is listed, since that's when those translations matter.
-        if (
-            waffle.switch_is_active('enable-narc')
-            and 'name' in validated_data
-            and addon.version.channel == amo.CHANNEL_LISTED
-        ):
-            run_narc_on_version.delay(addon.version.pk)
         # When creating, always return the version we just created in the
         # representation. It uses <instance>.version.
         self.fields['version'].write_only = False

--- a/src/olympia/devhub/utils.py
+++ b/src/olympia/devhub/utils.py
@@ -17,7 +17,7 @@ from olympia.amo.urlresolvers import linkify_and_clean
 from olympia.files.models import File, FileUpload
 from olympia.files.tasks import repack_fileupload
 from olympia.files.utils import parse_addon, parse_xpi
-from olympia.scanners.tasks import call_mad_api, run_customs, run_narc, run_yara
+from olympia.scanners.tasks import call_mad_api, run_customs, run_yara
 from olympia.versions.models import Version
 from olympia.versions.utils import process_color_value
 
@@ -272,9 +272,6 @@ class Validator:
 
         if waffle.switch_is_active('enable-customs'):
             tasks_in_parallel.append(run_customs.s(upload_pk))
-
-        if waffle.switch_is_active('enable-narc'):
-            tasks_in_parallel.append(run_narc.s(upload_pk))
 
         return [
             tasks.create_initial_validation_results.si(),

--- a/src/olympia/scanners/tests/test_tasks.py
+++ b/src/olympia/scanners/tests/test_tasks.py
@@ -40,7 +40,6 @@ from olympia.scanners.tasks import (
     call_mad_api,
     mark_yara_query_rule_as_completed_or_aborted,
     run_customs,
-    run_narc,
     run_narc_on_version,
     run_scanner,
     run_yara,
@@ -252,34 +251,58 @@ class TestRunCustoms(TestCase):
 class TestRunNarc(UploadMixin, TestCase):
     def setUp(self):
         super().setUp()
-        self.upload = self.get_upload('webextension.xpi')
-        self.upload.user.update(display_name='Fôo')
-        self.results = {
-            **amo.VALIDATOR_SKELETON_RESULTS,
-        }
+        self.user = user_factory(display_name='Fôo')
+        self.addon = addon_factory(
+            guid='@webextension-guid',
+            name='My Fancy WebExtension Addon',
+            users=[self.user],
+        )
+        upload = self.get_upload('webextension.xpi', user=self.user)
+        parsed_data = parse_addon(upload, addon=self.addon, user=self.user)
+        self.version = Version.from_upload(
+            upload,
+            self.addon,
+            amo.CHANNEL_LISTED,
+            selected_apps=[amo.FIREFOX.id],
+            parsed_data=parsed_data,
+        )
         assert len(ScannerResult.objects.all()) == 0
 
     @mock.patch('olympia.scanners.tasks.statsd.incr')
     def test_run(self, incr_mock):
-        # This rule will match all strings, we have a user and an xpi so there
-        # should be 2 matches.
+        # This rule will match all strings, we have a user, an xpi and strings
+        # in db matching so there should be 3 matches.
         rule = ScannerRule.objects.create(
             name='always_match_rule',
             scanner=NARC,
             definition='.*',
         )
 
-        received_results = run_narc(self.results, self.upload.pk)
+        run_narc_on_version(self.version.pk)
 
         scanner_results = ScannerResult.objects.all()
         assert len(scanner_results) == 1
         narc_result = scanner_results[0]
         assert narc_result.scanner == NARC
-        assert narc_result.upload == self.upload
+        assert narc_result.upload is None
+        assert narc_result.version == self.version
         assert narc_result.has_matches
         assert list(narc_result.matched_rules.all()) == [rule]
-        assert len(narc_result.results) == 2
+        assert len(narc_result.results) == 3
         assert narc_result.results == [
+            {
+                'meta': {
+                    'locale': 'en-us',
+                    'pattern': '.*',
+                    'source': 'db_addon',
+                    'span': [
+                        0,
+                        27,
+                    ],
+                    'string': 'My Fancy WebExtension Addon',
+                },
+                'rule': 'always_match_rule',
+            },
             {
                 'meta': {
                     'span': [0, 3],
@@ -310,18 +333,15 @@ class TestRunNarc(UploadMixin, TestCase):
                 mock.call('devhub.narc.success'),
             ]
         )
-        assert received_results == self.results
 
     @mock.patch('olympia.scanners.tasks.statsd.incr')
     def test_run_db_translation_match_only(self, incr_mock):
-        addon = addon_factory(guid='@webextension-guid')  # Has to match xpi.
-        addon.name = {
+        self.addon.name = {
             'fr': 'Päin au chocolat',
             'de': 'German päin',
             'en-US': 'Chocolatine',
         }
-        addon.save()
-        self.upload.update(addon=addon)
+        self.addon.save()
         rule = ScannerRule.objects.create(
             name='match_the_pain',
             scanner=NARC,
@@ -329,13 +349,14 @@ class TestRunNarc(UploadMixin, TestCase):
         )
         incr_mock.reset_mock()
 
-        received_results = run_narc(self.results, self.upload.pk)
+        run_narc_on_version(self.version.pk)
 
         scanner_results = ScannerResult.objects.all()
         assert len(scanner_results) == 1
         narc_result = scanner_results[0]
         assert narc_result.scanner == NARC
-        assert narc_result.upload == self.upload
+        assert narc_result.upload is None
+        assert narc_result.version == self.version
         assert narc_result.has_matches
         assert list(narc_result.matched_rules.all()) == [rule]
         assert len(narc_result.results) == 2
@@ -370,7 +391,6 @@ class TestRunNarc(UploadMixin, TestCase):
                 mock.call('devhub.narc.success'),
             ]
         )
-        assert received_results == self.results
 
     @mock.patch('olympia.scanners.tasks.statsd.incr')
     def test_run_xpi_match_only(self, incr_mock):
@@ -380,13 +400,14 @@ class TestRunNarc(UploadMixin, TestCase):
             definition='^My WebExtension.*$',
         )
 
-        received_results = run_narc(self.results, self.upload.pk)
+        run_narc_on_version(self.version.pk)
 
         scanner_results = ScannerResult.objects.all()
         assert len(scanner_results) == 1
         narc_result = scanner_results[0]
         assert narc_result.scanner == NARC
-        assert narc_result.upload == self.upload
+        assert narc_result.upload is None
+        assert narc_result.version == self.version
         assert narc_result.has_matches
         assert list(narc_result.matched_rules.all()) == [rule]
         assert len(narc_result.results) == 1
@@ -411,19 +432,16 @@ class TestRunNarc(UploadMixin, TestCase):
                 mock.call('devhub.narc.success'),
             ]
         )
-        assert received_results == self.results
         return narc_result
 
     @mock.patch('olympia.scanners.tasks.statsd.incr')
     def test_run_multiple_authors_match(self, incr_mock):
-        addon = addon_factory(guid='@webextension-guid')  # Has to match xpi.
         user1 = user_factory(display_name='Foo')
         user2 = user_factory(display_name='FooBar')
         user3 = user_factory(display_name='Alice Foo')
-        addon.authors.add(user1)
-        addon.authors.add(user2)
-        addon.authors.add(user3)
-        self.upload.update(addon=addon)
+        self.addon.authors.add(user1)
+        self.addon.authors.add(user2)
+        self.addon.authors.add(user3)
         rule = ScannerRule.objects.create(
             name='match_the_fool',
             scanner=NARC,
@@ -431,13 +449,14 @@ class TestRunNarc(UploadMixin, TestCase):
         )
         incr_mock.reset_mock()
 
-        received_results = run_narc(self.results, self.upload.pk)
+        run_narc_on_version(self.version.pk)
 
         scanner_results = ScannerResult.objects.all()
         assert len(scanner_results) == 1
         narc_result = scanner_results[0]
         assert narc_result.scanner == NARC
-        assert narc_result.upload == self.upload
+        assert narc_result.upload is None
+        assert narc_result.version == self.version
         assert narc_result.has_matches
         assert list(narc_result.matched_rules.all()) == [rule]
         assert len(narc_result.results) == 2
@@ -475,49 +494,6 @@ class TestRunNarc(UploadMixin, TestCase):
                 mock.call('devhub.narc.success'),
             ]
         )
-        assert received_results == self.results
-
-    @mock.patch('olympia.scanners.tasks.statsd.incr')
-    def test_run_uploader_match(self, incr_mock):
-        self.upload.user.update(display_name='Fool')
-        rule = ScannerRule.objects.create(
-            name='match_the_fool',
-            scanner=NARC,
-            definition=r'^Foo.*',
-        )
-
-        received_results = run_narc(self.results, self.upload.pk)
-
-        scanner_results = ScannerResult.objects.all()
-        assert len(scanner_results) == 1
-        narc_result = scanner_results[0]
-        assert narc_result.scanner == NARC
-        assert narc_result.upload == self.upload
-        assert narc_result.has_matches
-        assert list(narc_result.matched_rules.all()) == [rule]
-        assert len(narc_result.results) == 1
-        assert narc_result.results == [
-            {
-                'meta': {
-                    'span': [0, 4],
-                    'locale': None,
-                    'source': 'author',
-                    'string': 'Fool',
-                    'pattern': '^Foo.*',
-                },
-                'rule': 'match_the_fool',
-            },
-        ]
-        assert incr_mock.called
-        assert incr_mock.call_count == 3
-        incr_mock.assert_has_calls(
-            [
-                mock.call('devhub.narc.has_matches'),
-                mock.call(f'devhub.narc.rule.{rule.id}.match'),
-                mock.call('devhub.narc.success'),
-            ]
-        )
-        assert received_results == self.results
 
     @mock.patch('olympia.scanners.tasks.statsd.incr')
     def test_run_multiple_matching_rules(self, incr_mock):
@@ -532,17 +508,44 @@ class TestRunNarc(UploadMixin, TestCase):
             definition=r'WebExtension Addon$',
         )
 
-        received_results = run_narc(self.results, self.upload.pk)
+        run_narc_on_version(self.version.pk)
 
         scanner_results = ScannerResult.objects.all()
         assert len(scanner_results) == 1
         narc_result = scanner_results[0]
         assert narc_result.scanner == NARC
-        assert narc_result.upload == self.upload
+        assert narc_result.upload is None
+        assert narc_result.version == self.version
         assert narc_result.has_matches
         assert list(narc_result.matched_rules.all()) == [rule1, rule2]
-        assert len(narc_result.results) == 2
+        assert len(narc_result.results) == 4
         assert narc_result.results == [
+            {
+                'meta': {
+                    'locale': 'en-us',
+                    'pattern': 'WebExtension Addon$',
+                    'source': 'db_addon',
+                    'span': [
+                        9,
+                        27,
+                    ],
+                    'string': 'My Fancy WebExtension Addon',
+                },
+                'rule': 'match_the_end',
+            },
+            {
+                'meta': {
+                    'locale': 'en-us',
+                    'pattern': '^My.*',
+                    'source': 'db_addon',
+                    'span': [
+                        0,
+                        27,
+                    ],
+                    'string': 'My Fancy WebExtension Addon',
+                },
+                'rule': 'match_the_beginning',
+            },
             {
                 'meta': {
                     'span': [3, 21],
@@ -574,16 +577,16 @@ class TestRunNarc(UploadMixin, TestCase):
                 mock.call('devhub.narc.success'),
             ]
         )
-        assert received_results == self.results
         return narc_result
 
     @mock.patch('olympia.scanners.tasks.statsd.incr')
     def test_run_no_rule(self, incr_mock):
-        received_results = run_narc(self.results, self.upload.pk)
+        run_narc_on_version(self.version.pk)
         scanner_results = ScannerResult.objects.all()
         narc_result = scanner_results[0]
         assert narc_result.scanner == NARC
-        assert narc_result.upload == self.upload
+        assert narc_result.upload is None
+        assert narc_result.version == self.version
         assert len(narc_result.results) == 0
         assert not narc_result.has_matches
         assert list(narc_result.matched_rules.all()) == []
@@ -594,7 +597,6 @@ class TestRunNarc(UploadMixin, TestCase):
                 mock.call('devhub.narc.success'),
             ]
         )
-        assert received_results == self.results
 
     @mock.patch('olympia.scanners.tasks.statsd.incr')
     def test_run_inactive_rule_ignored(self, incr_mock):
@@ -607,27 +609,28 @@ class TestRunNarc(UploadMixin, TestCase):
         rule2 = ScannerRule.objects.create(
             name='match_the_end',
             scanner=NARC,
-            definition=r'WebExtension Addon$',
+            definition=r'(?<!fancy) WebExtension Addon$',
         )
 
-        received_results = run_narc(self.results, self.upload.pk)
+        run_narc_on_version(self.version.pk)
 
         scanner_results = ScannerResult.objects.all()
         assert len(scanner_results) == 1
         narc_result = scanner_results[0]
         assert narc_result.scanner == NARC
-        assert narc_result.upload == self.upload
+        assert narc_result.upload is None
+        assert narc_result.version == self.version
         assert narc_result.has_matches
         assert list(narc_result.matched_rules.all()) == [rule2]
         assert len(narc_result.results) == 1
         assert narc_result.results == [
             {
                 'meta': {
-                    'span': [3, 21],
+                    'span': [2, 21],
                     'locale': None,
                     'source': 'xpi',
                     'string': 'My WebExtension Addon',
-                    'pattern': 'WebExtension Addon$',
+                    'pattern': '(?<!fancy) WebExtension Addon$',
                 },
                 'rule': 'match_the_end',
             },
@@ -641,7 +644,6 @@ class TestRunNarc(UploadMixin, TestCase):
                 mock.call('devhub.narc.success'),
             ]
         )
-        assert received_results == self.results
 
     @mock.patch('olympia.scanners.tasks.statsd.incr')
     def test_run_no_match(self, incr_mock):
@@ -651,13 +653,14 @@ class TestRunNarc(UploadMixin, TestCase):
             definition=r'^something*',
         )
 
-        received_results = run_narc(self.results, self.upload.pk)
+        run_narc_on_version(self.version.pk)
 
         scanner_results = ScannerResult.objects.all()
         assert len(scanner_results) == 1
         narc_result = scanner_results[0]
         assert narc_result.scanner == NARC
-        assert narc_result.upload == self.upload
+        assert narc_result.upload is None
+        assert narc_result.version == self.version
         assert len(narc_result.results) == 0
         assert not narc_result.has_matches
         assert list(narc_result.matched_rules.all()) == []
@@ -668,133 +671,52 @@ class TestRunNarc(UploadMixin, TestCase):
                 mock.call('devhub.narc.success'),
             ]
         )
-        assert received_results == self.results
-
-    @mock.patch('olympia.scanners.tasks._run_narc')
-    @mock.patch('olympia.scanners.tasks.statsd.incr')
-    def test_run_does_not_raise_with_waffle(self, incr_mock, _run_narc_mock):
-        self.create_switch('ignore-exceptions-in-scanner-tasks', active=True)
-        _run_narc_mock.side_effect = RuntimeError()
-        received_results = run_narc(self.results, self.upload.pk)
-
-        assert incr_mock.called
-        assert incr_mock.call_count == 1
-        incr_mock.assert_called_with('devhub.narc.failure')
-        assert received_results == self.results
-
-    @mock.patch('olympia.scanners.tasks._run_narc')
-    @mock.patch('olympia.scanners.tasks.statsd.incr')
-    def test_throws_errors(self, incr_mock, _run_narc_mock):
-        _run_narc_mock.side_effect = RuntimeError()
-        # task is decorated with `@validation_task`, which gracefully handles
-        # exceptions, but without the waffle switch to ignore exceptions in
-        # scanner tasks we should fail validation.
-        received_results = run_narc(self.results, self.upload.pk)
-
-        assert incr_mock.called
-        assert incr_mock.call_count == 1
-        incr_mock.assert_called_with('devhub.narc.failure')
-        # We have affected validation results.
-        assert received_results != self.results
-        assert received_results['errors'] == 1
-        assert received_results['success'] is False
-
-    @mock.patch('olympia.scanners.tasks.statsd.incr')
-    def test_does_not_run_when_validation_results_contain_errors(self, incr_mock):
-        # run_narc is a validation task and therefore shouldn't run if the
-        # validation results contain some errors.
-        self.results.update({'errors': 1})
-        ScannerRule.objects.create(
-            name='always_match_rule',
-            scanner=NARC,
-            definition=r'.*',
-        )
-
-        run_narc(self.results, self.upload.pk)
-
-        assert not ScannerResult.objects.exists()
-        assert not incr_mock.called
-
-    @mock.patch('olympia.scanners.tasks.statsd.incr')
-    def test_run_ignores_guid_conflict(self, incr_mock):
-        # Create an add-on with the same guid as what's in the manifest of the
-        # xpi we're uploading: that should raise a DuplicateAddonID during
-        # validation, but narc should not trigger that and scan normally.
-        addon_factory(guid='@webextension-guid')
-        rule = ScannerRule.objects.create(
-            name='match_the_beginning',
-            scanner=NARC,
-            definition=r'^My.*$',
-        )
-        incr_mock.reset_mock()
-
-        received_results = run_narc(self.results, self.upload.pk)
-
-        scanner_results = ScannerResult.objects.all()
-        assert len(scanner_results) == 1
-        narc_result = scanner_results[0]
-        assert narc_result.scanner == NARC
-        assert narc_result.upload == self.upload
-        assert narc_result.has_matches
-        assert list(narc_result.matched_rules.all()) == [rule]
-        assert len(narc_result.results) == 1
-        assert narc_result.results == [
-            {
-                'meta': {
-                    'span': [0, 21],
-                    'locale': None,
-                    'source': 'xpi',
-                    'string': 'My WebExtension Addon',
-                    'pattern': '^My.*$',
-                },
-                'rule': 'match_the_beginning',
-            },
-        ]
-        assert incr_mock.called
-        assert incr_mock.call_count == 3
-        incr_mock.assert_has_calls(
-            [
-                mock.call('devhub.narc.has_matches'),
-                mock.call(f'devhub.narc.rule.{rule.id}.match'),
-                mock.call('devhub.narc.success'),
-            ]
-        )
-        assert received_results == self.results
 
     @mock.patch('olympia.scanners.tasks.statsd.incr')
     @mock.patch.object(ScannerResult, 'run_action')
-    def test_run_on_version(self, run_action_mock, incr_mock):
-        # Validate an upload first, make it match multiple rules.
+    def test_re_run_on_version(self, run_action_mock, incr_mock):
+        # Scan a version first, make it match multiple rules.
         narc_result = self.test_run_multiple_matching_rules()
-        assert len(narc_result.results) == 2
+        assert len(narc_result.results) == 4
         rules = list(narc_result.matched_rules.all())
 
-        addon = addon_factory(
-            guid='@webextension-guid', name='My Fancy WebExtension Addon'
-        )
-        fake_user = user_factory()
-        parsed_data = parse_addon(self.upload, addon=addon, user=fake_user)
-        version = Version.from_upload(
-            self.upload,
-            addon,
-            amo.CHANNEL_LISTED,
-            selected_apps=[amo.FIREFOX.id],
-            parsed_data=parsed_data,
-        )
-        narc_result.update(version=version)
+        # Add more matches through the add-on name.
+        self.addon.name = {
+            'fr': 'My Foolish Addon',
+            'en-US': 'Another WebExtension Addon',
+        }
+        self.addon.save()
+
         incr_mock.reset_mock()
         run_action_mock.reset_mock()
 
-        run_narc_on_version(version.pk)
+        run_narc_on_version(self.version.pk)
 
         scanner_results = ScannerResult.objects.all()
         assert len(scanner_results) == 1
         narc_result = scanner_results[0]
         assert narc_result.scanner == NARC
-        assert narc_result.upload == self.upload
-        assert narc_result.version == version
-        assert len(narc_result.results) == 4
+        assert narc_result.upload is None
+        assert narc_result.version == self.version
+        # New matches are added, they don't overwrite the existing ones, so we
+        # should have 2 new matches.
+        assert len(narc_result.results) == 6
         assert narc_result.results == [
+            {
+                'meta': {
+                    'locale': 'en-us',
+                    'pattern': 'WebExtension Addon$',
+                    'source': 'db_addon',
+                    'span': [
+                        8,
+                        26,
+                    ],
+                    'string': 'Another WebExtension Addon',
+                },
+                'rule': 'match_the_end',
+            },
+            # This second hit is from the initial run, that string is no longer
+            # present, but we are preserving the old results.
             {
                 'meta': {
                     'locale': 'en-us',
@@ -808,6 +730,7 @@ class TestRunNarc(UploadMixin, TestCase):
                 },
                 'rule': 'match_the_end',
             },
+            # Same as above.
             {
                 'meta': {
                     'locale': 'en-us',
@@ -818,6 +741,19 @@ class TestRunNarc(UploadMixin, TestCase):
                         27,
                     ],
                     'string': 'My Fancy WebExtension Addon',
+                },
+                'rule': 'match_the_beginning',
+            },
+            {
+                'meta': {
+                    'locale': 'fr',
+                    'pattern': '^My.*',
+                    'source': 'db_addon',
+                    'span': [
+                        0,
+                        16,
+                    ],
+                    'string': 'My Foolish Addon',
                 },
                 'rule': 'match_the_beginning',
             },
@@ -864,87 +800,30 @@ class TestRunNarc(UploadMixin, TestCase):
 
         # We re-triggered the run action.
         assert run_action_mock.call_count == 1
-        assert run_action_mock.call_args[0] == (version,)
+        assert run_action_mock.call_args[0] == (self.version,)
         assert run_action_mock.call_args[1] == {'check_mad_results': False}
 
     @mock.patch('olympia.scanners.tasks.statsd.incr')
-    def test_run_on_version_xpi_does_not_exist(self, incr_mock):
-        rule = ScannerRule.objects.create(
-            name='always_match_rule',
-            scanner=NARC,
-            definition=r'.*',
-        )
+    @mock.patch.object(ScannerResult, 'run_action')
+    def test_run_on_version_no_new_result(self, run_action_mock, incr_mock):
+        # Scan a version first, make it one rule.
+        narc_result = self.test_run_xpi_match_only()
+        assert len(narc_result.results) == 1
+        rules = list(narc_result.matched_rules.all())
 
-        version = addon_factory(name='My Fancy WebExtension Addon').current_version
         incr_mock.reset_mock()
+        run_action_mock.reset_mock()
 
-        run_narc_on_version(version.pk)
+        # Re-run on the version.
+        run_narc_on_version(self.version.pk)
 
         scanner_results = ScannerResult.objects.all()
         assert len(scanner_results) == 1
         narc_result = scanner_results[0]
         assert narc_result.scanner == NARC
         assert narc_result.upload is None
-        assert narc_result.version == version
-        assert len(narc_result.results) == 1
-        assert narc_result.results == [
-            {
-                'meta': {
-                    'locale': 'en-us',
-                    'pattern': '.*',
-                    'source': 'db_addon',
-                    'span': [
-                        0,
-                        27,
-                    ],
-                    'string': 'My Fancy WebExtension Addon',
-                },
-                'rule': 'always_match_rule',
-            },
-        ]
-        assert narc_result.has_matches
-        assert list(narc_result.matched_rules.all()) == [rule]
-        assert incr_mock.called
-        assert incr_mock.call_count == 4
-        incr_mock.assert_has_calls(
-            [
-                mock.call('devhub.narc.has_matches'),
-                mock.call(f'devhub.narc.rule.{rule.id}.match'),
-                mock.call('devhub.narc.results_differ'),
-                mock.call('devhub.narc.success'),
-            ]
-        )
-
-    @mock.patch('olympia.scanners.tasks.statsd.incr')
-    @mock.patch.object(ScannerResult, 'run_action')
-    def test_run_on_version_no_new_result(self, run_action_mock, incr_mock):
-        # Validate an upload first
-        narc_result = self.test_run_xpi_match_only()
-        assert len(narc_result.results) == 1
-        addon = addon_factory(
-            guid='@webextension-guid', name='Name that does not cause an extra match'
-        )
-        fake_user = user_factory()
-        parsed_data = parse_addon(self.upload, addon=addon, user=fake_user)
-        version = Version.from_upload(
-            self.upload,
-            addon,
-            amo.CHANNEL_LISTED,
-            selected_apps=[amo.FIREFOX.id],
-            parsed_data=parsed_data,
-        )
-        narc_result.update(version=version)
-        incr_mock.reset_mock()
-        run_action_mock.reset_mock()
-
-        run_narc_on_version(version.pk)
-
-        scanner_results = ScannerResult.objects.all()
-        assert len(scanner_results) == 1
-        narc_result = scanner_results[0]
-        assert narc_result.scanner == NARC
-        assert narc_result.upload == self.upload
-        assert narc_result.version == version
+        assert narc_result.version == self.version
+        # Extra run shouldn't have caused duplicates.
         assert len(narc_result.results) == 1
         assert narc_result.has_matches
         rule = narc_result.matched_rules.all()[0]


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/15780

### Description

This means triggering the scanner synchronously in auto_approve, but solves various edge cases as we're guaranteed to have an addon and translations attached at that point.

### Context

Scanners typically run on `FileUpload`s during validation but NARC needs more than just the XPI, it checks translations linked to the `Addon`, and unfortunately in the API `FileUploads` are not attached to an `Addon` during validation.

We already were running scanner _actions_ in `auto_approve`, this makes us run `narc` specifically with a similar logic (only running once, when an `AutoApprovalSummary` doesn't exist yet).

We still re-run the scan on name changes as before.