### PR TITLE
Handle average_daily_users of 0 in UsageTier threshold-based rules

### DIFF
--- a/src/olympia/abuse/tests/test_tasks.py
+++ b/src/olympia/abuse/tests/test_tasks.py
@@ -49,6 +49,11 @@ def _high_abuse_reports_setup(field):
     # don't do anything for this test.
     UsageTier.objects.create(name='Not a tier with usage values')
     UsageTier.objects.create(
+        name='D tier (no lower threshold)',
+        upper_adu_threshold=100,
+        **{field: 200},
+    )
+    UsageTier.objects.create(
         name='C tier (no abuse threshold)',
         lower_adu_threshold=100,
         upper_adu_threshold=200,
@@ -73,7 +78,15 @@ def _high_abuse_reports_setup(field):
     )
 
     not_flagged = [
-        # Belongs to C tier, which doesn't have a growth threshold set.
+        # Belongs to D tier, below threshold since it has 0 reports/users.
+        addon_factory(name='D tier empty addon', average_daily_users=0),
+        # Belongs to D tier, below threshold since it has 1 report and 0 users.
+        addon_factory_with_abuse_reports(
+            name='D tier addon below threshold',
+            average_daily_users=0,
+            abuse_reports_count=1,
+        ),
+        # Belongs to C tier, which doesn't have an abuse report threshold set.
         addon_factory_with_abuse_reports(
             name='C tier addon', average_daily_users=100, abuse_reports_count=2
         ),
@@ -150,6 +163,11 @@ def _high_abuse_reports_setup(field):
     )
 
     flagged = [
+        addon_factory_with_abuse_reports(
+            name='D tier addon with reports',
+            average_daily_users=0,
+            abuse_reports_count=2,
+        ),
         addon_factory_with_abuse_reports(
             name='B tier', average_daily_users=200, abuse_reports_count=2
         ),
@@ -231,6 +249,7 @@ def test_flag_high_abuse_reports_addons_according_to_review_tier():
         datetime(2023, 6, 30, 11, 0),
         datetime(2023, 7, 3, 11, 0),
         datetime(2023, 7, 4, 11, 0),
+        datetime(2023, 7, 5, 11, 0),
     ]
 
 

--- a/src/olympia/ratings/tasks.py
+++ b/src/olympia/ratings/tasks.py
@@ -173,6 +173,7 @@ def flag_high_rating_addons_according_to_review_tier():
     flagging_tier_filters = Q()
     for usage_tier in flagging_tiers:
         flagging_tier_filters |= usage_tier.get_rating_threshold_q_object(block=False)
+
     if flagging_tier_filters:
         NeedsHumanReview.set_on_addons_latest_signed_versions(
             addons_qs.filter(flagging_tier_filters),

--- a/src/olympia/ratings/tests/test_tasks.py
+++ b/src/olympia/ratings/tests/test_tasks.py
@@ -130,6 +130,11 @@ def _high_ratings_setup(threshold_field):
     # don't do anything for this test.
     UsageTier.objects.create(name='Not a tier with usage values')
     UsageTier.objects.create(
+        name='D tier (no lower threshold)',
+        upper_adu_threshold=100,
+        **{threshold_field: 200},
+    )
+    UsageTier.objects.create(
         name='C tier (no rating threshold)',
         lower_adu_threshold=100,
         upper_adu_threshold=200,
@@ -154,7 +159,13 @@ def _high_ratings_setup(threshold_field):
     )
 
     not_flagged = [
-        # Belongs to C tier, which doesn't have a growth threshold set.
+        # Belongs to D tier, below threshold since it has 0 ratings/users.
+        addon_factory(name='D tier empty addon', average_daily_users=0),
+        # Belongs to D tier, below threshold since it has 1 rating and 0 users.
+        addon_factory_with_ratings(
+            name='D tier addon below threshold', average_daily_users=0, ratings_count=1
+        ),
+        # Belongs to C tier, which doesn't have a ratings threshold set.
         addon_factory_with_ratings(
             name='C tier addon', average_daily_users=100, ratings_count=2
         ),
@@ -199,6 +210,9 @@ def _high_ratings_setup(threshold_field):
     ]
 
     flagged = [
+        addon_factory_with_ratings(
+            name='D tier addon with ratings', average_daily_users=0, ratings_count=2
+        ),
         addon_factory_with_ratings(
             name='B tier', average_daily_users=200, ratings_count=2
         ),
@@ -280,6 +294,7 @@ def test_flag_high_rating_addons_according_to_review_tier():
         datetime(2023, 6, 30, 11, 0),
         datetime(2023, 7, 3, 11, 0),
         datetime(2023, 7, 4, 11, 0),
+        datetime(2023, 7, 5, 11, 0),
     ]
 
 

--- a/src/olympia/reviewers/models.py
+++ b/src/olympia/reviewers/models.py
@@ -4,7 +4,8 @@ from datetime import datetime, timedelta
 from django.conf import settings
 from django.core.cache import cache
 from django.db import models
-from django.db.models import Avg, Count, F, OuterRef, Q
+from django.db.models import Avg, Count, OuterRef, Q
+from django.db.models.functions import Greatest
 from django.dispatch import receiver
 from django.template import loader
 from django.urls import reverse
@@ -876,7 +877,9 @@ class UsageTier(ModelBase):
             else self.abuse_reports_ratio_threshold_before_blocking
         ) or 0
         return Q(
-            abuse_reports_count__gte=F('average_daily_users') * threshold / 100,
+            abuse_reports_count__gte=Greatest('average_daily_users', 1)
+            * threshold
+            / 100,
             **self.get_tier_boundaries(),
         )
 
@@ -912,7 +915,7 @@ class UsageTier(ModelBase):
             else self.ratings_ratio_threshold_before_blocking
         ) or 0
         return Q(
-            ratings_count__gte=F('average_daily_users') * threshold / 100,
+            ratings_count__gte=Greatest('average_daily_users', 1) * threshold / 100,
             **self.get_tier_boundaries(),
         )
 


### PR DESCRIPTION
If a UsageTier includes 0 as the lower bound (or has no lower bound) we still want the ratings/abuse reports thresholds to make sense, so we fall back to 1 when computing the ratios.

Fixes https://github.com/mozilla/addons/issues/15785