### PR TITLE
Handle manifest parsing errors caused by narc in auto_approve

### DIFF
--- a/src/olympia/reviewers/management/commands/auto_approve.py
+++ b/src/olympia/reviewers/management/commands/auto_approve.py
@@ -3,6 +3,7 @@ from collections import Counter
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.db import transaction
+from django.forms import ValidationError
 
 import waffle
 from django_statsd.clients import statsd
@@ -173,6 +174,10 @@ class Command(BaseCommand):
                 'Version %s was skipped because approval action was not available',
                 version,
             )
+            self.stats['error'] += 1
+        except ValidationError:
+            statsd.incr('reviewers.auto_approve.approve.failure')
+            log.info('Version %s was skipped because of a validation error', version)
             self.stats['error'] += 1
         except SigningError:
             statsd.incr('reviewers.auto_approve.approve.failure')

--- a/src/olympia/reviewers/tests/test_commands.py
+++ b/src/olympia/reviewers/tests/test_commands.py
@@ -737,6 +737,16 @@ class TestAutoApproveCommand(AutoApproveTestsMixin, TestCase):
         call_command('auto_approve')  # Shouldn't matter if it's called twice.
         check_assertions()
 
+    @mock.patch('olympia.reviewers.utils.sign_file')
+    def test_run_narc_causes_broken_manifest_addon_to_be_ignored(self, sign_file_mock):
+        # Functional test making sure that an error when scanning does not
+        # break auto-approval entirely, instead the broken add-on is ignored.
+        # We're not providing a real XPI so this should raise when parsing.
+        self.create_switch('enable-narc', active=True)
+        call_command('auto_approve')
+        assert not sign_file_mock.called
+        self._check_stats({'total': 1, 'error': 1})
+
     def test_run_action_delay_approval_unlisted(self):
         self.version.update(channel=amo.CHANNEL_UNLISTED)
         self.test_run_action_delay_approval()


### PR DESCRIPTION
Follow-up for https://github.com/mozilla/addons/issues/15780

There are some weird add-ons in auto-approval queue sometime that have a broken XPI and should be ignored to avoid messing with the rest of the add-ons waiting for auto-approval.