### PR TITLE
Stop displaying computed number of add-ons in UsageTier, show SQL queries instead

### DIFF
--- a/src/olympia/reviewers/models.py
+++ b/src/olympia/reviewers/models.py
@@ -892,7 +892,7 @@ class UsageTier(ModelBase):
             .filter(
                 ~AbuseReport.objects.__class__.is_individually_actionable_q(),
                 guid=OuterRef('guid'),
-                created__gte=datetime.now() - timedelta(days=14),
+                created__gte=datetime.now().date() - timedelta(days=14),
             )
             .annotate(guid_abuse_reports_count=Count('*'))
             .values('guid_abuse_reports_count')
@@ -927,7 +927,7 @@ class UsageTier(ModelBase):
             Rating.without_replies.values('addon_id')
             .filter(
                 addon_id=OuterRef('id'),
-                created__gte=datetime.now() - timedelta(days=14),
+                created__gte=datetime.now().date() - timedelta(days=14),
             )
             .annotate(_ratings_count=Count('*'))
             .values('_ratings_count')


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/15786

### Context

Some of those queries take too long, the proper fix would be to optimize them and/or trigger those computations async, but in the meantime this should work around the issue: if the admin user looking at a `UsageTier` wants to see the number they can run the query in Redash.

### Screenshots

<img width="3376" height="1390" alt="Screenshot 2025-08-20 at 11-58-36 Garbage Change usage tier Django site admin" src="https://github.com/user-attachments/assets/0db2d410-9e10-4390-a6cb-4703c6afae72" />
