### PR TITLE
When re-running narc on name changes, use latest listed non-rejected version

### DIFF
--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -1395,7 +1395,9 @@ class AddonSerializer(AMOModelSerializer):
                 waffle.switch_is_active('enable-narc')
                 and 'name' in changes
                 and (
-                    version := instance.find_latest_version(channel=amo.CHANNEL_LISTED)
+                    version := instance.versions.filter(channel=amo.CHANNEL_LISTED)
+                    .not_rejected()
+                    .last()
                 )
             ):
                 run_narc_on_version.delay(version.pk)

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -2612,6 +2612,17 @@ class TestAddonViewSetUpdate(AddonViewSetCreateUpdateMixin, TestCase):
         assert run_narc_on_version_mock.delay.call_args[0] == (version.pk,)
 
     @mock.patch('olympia.addons.serializers.run_narc_on_version')
+    def test_trigger_narc_on_name_change_on_user_disabled_version(
+        self, run_narc_on_version_mock
+    ):
+        self.create_switch('enable-narc', active=True)
+        version = self.addon.current_version
+        self.addon.current_version.is_user_disabled = True  # auto-saves
+        self._test_metadata_content_review()
+        assert run_narc_on_version_mock.delay.call_count == 1
+        assert run_narc_on_version_mock.delay.call_args[0] == (version.pk,)
+
+    @mock.patch('olympia.addons.serializers.run_narc_on_version')
     def test_dont_trigger_narc_if_name_does_not_change(self, run_narc_on_version_mock):
         self.create_switch('enable-narc', active=True)
         response = self.request(

--- a/src/olympia/devhub/forms.py
+++ b/src/olympia/devhub/forms.py
@@ -154,9 +154,11 @@ class AddonFormBase(TranslationFormMixin, AMOModelForm):
                     waffle.switch_is_active('enable-narc')
                     and 'name' in self.metadata_changes
                     and (
-                        version := self.instance.find_latest_version(
+                        version := self.instance.versions.filter(
                             channel=amo.CHANNEL_LISTED
                         )
+                        .not_rejected()
+                        .last()
                     )
                 ):
                     run_narc_on_version.delay(version.pk)

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -29,6 +29,7 @@ from olympia.amo.decorators import use_primary_db
 from olympia.amo.fields import PositiveAutoField
 from olympia.amo.models import (
     BasePreview,
+    BaseQuerySet,
     LongNameIndex,
     ManagerBase,
     ModelBase,
@@ -82,7 +83,17 @@ VALID_SOURCE_EXTENSIONS = (
 )
 
 
+class VersionQuerySet(BaseQuerySet):
+    def not_rejected(self):
+        return self.exclude(
+            file__status=amo.STATUS_DISABLED,
+            file__status_disabled_reason=File.STATUS_DISABLED_REASONS.NONE,
+        )
+
+
 class VersionManager(ManagerBase):
+    _queryset_class = VersionQuerySet
+
     def __init__(self, include_deleted=False):
         ManagerBase.__init__(self)
         self.include_deleted = include_deleted


### PR DESCRIPTION
Fixes one of the scenarios found by QA in https://github.com/mozilla/addons/issues/15768#issuecomment-3206048112

### Context

`current_version` is not always available if the only listed version has been user-disabled.

### Testing

See scenario linked above, or unit tests included in this change.