### PR TITLE
Improve statsd pings sent by NARC scanner

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -53,7 +53,6 @@ from olympia.amo.utils import (
     send_mail,
     slugify,
     sorted_groupby,
-    timer,
     to_language,
 )
 from olympia.constants.browsers import BROWSERS

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1467,7 +1467,6 @@ class Addon(OnChangeMixin, ModelBase):
             ]
 
     @staticmethod
-    @timer
     def transformer(addons):
         if not addons:
             return

--- a/src/olympia/addons/tests/test_views.py
+++ b/src/olympia/addons/tests/test_views.py
@@ -587,20 +587,16 @@ class TestAddonViewSetDetail(AddonAndVersionViewSetDetailMixin, TestCase):
     @mock.patch('django_statsd.middleware.statsd.timing')
     def test_statsd_timings(self, statsd_timing_mock):
         self._test_url()
-        assert statsd_timing_mock.call_count == 4
+        assert statsd_timing_mock.call_count == 3
         assert (
             statsd_timing_mock.call_args_list[0][0][0]
-            == 'timer.olympia.addons.models.transformer'
-        )
-        assert (
-            statsd_timing_mock.call_args_list[1][0][0]
             == 'view.olympia.addons.views.AddonViewSet.GET'
         )
         assert (
-            statsd_timing_mock.call_args_list[2][0][0]
+            statsd_timing_mock.call_args_list[1][0][0]
             == 'view.olympia.addons.views.GET'
         )
-        assert statsd_timing_mock.call_args_list[3][0][0] == 'view.GET'
+        assert statsd_timing_mock.call_args_list[2][0][0] == 'view.GET'
 
     def test_detail_url_with_reviewers_in_the_url(self):
         self.addon.update(slug='something-reviewers')

--- a/src/olympia/scanners/tests/test_tasks.py
+++ b/src/olympia/scanners/tests/test_tasks.py
@@ -334,6 +334,13 @@ class TestRunNarc(UploadMixin, TestCase):
             ]
         )
 
+    @mock.patch('olympia.scanners.tasks.statsd.timer')
+    def test_calls_statsd_timer(self, timer_mock):
+        run_narc_on_version(self.version.pk)
+
+        assert timer_mock.call_count == 1
+        assert timer_mock.call_args[0] == ('devhub.narc',)
+
     @mock.patch('olympia.scanners.tasks.statsd.incr')
     def test_run_db_translation_match_only(self, incr_mock):
         self.addon.name = {
@@ -790,10 +797,10 @@ class TestRunNarc(UploadMixin, TestCase):
         assert incr_mock.call_count == 5
         incr_mock.assert_has_calls(
             [
-                mock.call('devhub.narc.has_matches'),
-                mock.call(f'devhub.narc.rule.{rules[0].id}.match'),
-                mock.call(f'devhub.narc.rule.{rules[1].id}.match'),
-                mock.call('devhub.narc.results_differ'),
+                mock.call('devhub.narc.rerun.has_matches'),
+                mock.call(f'devhub.narc.rerun.rule.{rules[0].id}.match'),
+                mock.call(f'devhub.narc.rerun.rule.{rules[1].id}.match'),
+                mock.call('devhub.narc.rerun.results_differ'),
                 mock.call('devhub.narc.success'),
             ]
         )
@@ -832,8 +839,8 @@ class TestRunNarc(UploadMixin, TestCase):
         assert incr_mock.call_count == 3
         incr_mock.assert_has_calls(
             [
-                mock.call('devhub.narc.has_matches'),
-                mock.call(f'devhub.narc.rule.{rule.id}.match'),
+                mock.call('devhub.narc.rerun.has_matches'),
+                mock.call(f'devhub.narc.rerun.rule.{rule.id}.match'),
                 mock.call('devhub.narc.success'),
             ]
         )


### PR DESCRIPTION
Differentiate between regular runs and re-runs, add timer (and remove an old statsd timer in Addon.transformer that we never used and was in my way for tests)

Fixes https://github.com/mozilla/addons/issues/15776