### PR TITLE
When grabbing a version to re-scan for name, pick the last by pk

### DIFF
--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -1394,11 +1394,7 @@ class AddonSerializer(AMOModelSerializer):
             if (
                 waffle.switch_is_active('enable-narc')
                 and 'name' in changes
-                and (
-                    version := instance.versions.filter(channel=amo.CHANNEL_LISTED)
-                    .not_rejected()
-                    .last()
-                )
+                and (version := instance.find_latest_non_rejected_listed_version())
             ):
                 run_narc_on_version.delay(version.pk)
 

--- a/src/olympia/addons/tests/test_models.py
+++ b/src/olympia/addons/tests/test_models.py
@@ -2898,6 +2898,33 @@ class TestGetVersion(TestCase):
         # should still find the current one.
         assert self.addon.find_latest_public_listed_version() == self.version
 
+    def test_find_latest_non_rejected_listed_version(self):
+        assert (
+            self.addon.find_latest_non_rejected_listed_version()
+            == self.addon.current_version
+        )
+
+        new_version = version_factory(addon=self.addon)
+        assert self.addon.find_latest_non_rejected_listed_version() == new_version
+
+        new_version.is_user_disabled = True  # auto-saves
+        # No change
+        assert self.addon.find_latest_non_rejected_listed_version() == new_version
+
+        # If the version is rejected though, we skip it.
+        new_version.file.update(
+            status_disabled_reason=File.STATUS_DISABLED_REASONS.NONE
+        )
+        assert self.addon.find_latest_non_rejected_listed_version() == self.version
+
+    def test_find_latest_non_rejected_listed_version_no_deleted(self):
+        self.version.delete()
+        assert self.addon.find_latest_non_rejected_listed_version() is None
+
+    def test_find_latest_non_rejected_listed_version_no_listed(self):
+        self.make_addon_unlisted(self.addon)
+        assert self.addon.find_latest_non_rejected_listed_version() is None
+
 
 class TestAddonGetURLPath(TestCase):
     def test_get_url_path(self):

--- a/src/olympia/devhub/forms.py
+++ b/src/olympia/devhub/forms.py
@@ -154,11 +154,8 @@ class AddonFormBase(TranslationFormMixin, AMOModelForm):
                     waffle.switch_is_active('enable-narc')
                     and 'name' in self.metadata_changes
                     and (
-                        version := self.instance.versions.filter(
-                            channel=amo.CHANNEL_LISTED
-                        )
-                        .not_rejected()
-                        .last()
+                        version
+                        := self.instance.find_latest_non_rejected_listed_version()
                     )
                 ):
                     run_narc_on_version.delay(version.pk)


### PR DESCRIPTION
Default order for `Version` is by `-created, -modified`, so `last()` is actually the oldest one, which is not what we want here.

Fixes https://github.com/mozilla/addons/issues/15768#issuecomment-3206048112
