### PR TITLE
Allow scanner rule definition to wrap if necessary in readonly view

### DIFF
--- a/static/css/admin/scannerrule.css
+++ b/static/css/admin/scannerrule.css
@@ -8,3 +8,8 @@
     */
     visibility: hidden;
 }
+
+.field-formatted_definition .readonly pre {
+    overflow-wrap: anywhere;
+    white-space: pre-wrap;
+}


### PR DESCRIPTION
Only matters when viewing the rule (users with `ScannersRulesView` but without `ScannersRulesEdit`)

### Screenshot

With the patch:

<img width="3360" height="250" alt="Screenshot 2025-08-27 at 13-50-11 longtext View scanner rule Django site admin" src="https://github.com/user-attachments/assets/565e5603-9d4c-4b34-9f44-ef5c759de669" />

