### PR TITLE
Allow automated disable&block action to be appealed (and handle such appeals)

### DIFF
--- a/src/olympia/abuse/actions.py
+++ b/src/olympia/abuse/actions.py
@@ -801,8 +801,13 @@ class ContentActionTargetAppealApprove(
                 .order_by('-pk')
             )
             if self.previous_decisions.filter(
-                action=DECISION_ACTIONS.AMO_DISABLE_ADDON
+                action__in=(
+                    DECISION_ACTIONS.AMO_DISABLE_ADDON,
+                    DECISION_ACTIONS.AMO_BLOCK_ADDON,
+                )
             ).exists():
+                # FIXME: we should also automatically revert the block if the
+                # previous decision was AMO_BLOCK_ADDON.
                 target_versions = list(target_versions)
                 if target.status == amo.STATUS_DISABLED:
                     target.force_enable(skip_activity_log=True)

--- a/src/olympia/abuse/tests/test_actions.py
+++ b/src/olympia/abuse/tests/test_actions.py
@@ -1783,11 +1783,15 @@ class TestContentActionRejectVersion(TestContentActionDisableAddon):
 
 class TestContentActionBlockAddon(TestContentActionDisableAddon):
     ActionClass = ContentActionBlockAddon
-    takedown_decision_action = DECISION_ACTIONS.AMO_DISABLE_ADDON
+    takedown_decision_action = DECISION_ACTIONS.AMO_BLOCK_ADDON
 
     def setUp(self):
         super().setUp()
         self.decision.update(
+            reviewer_user=self.task_user,
+            metadata={ContentDecision.POLICY_DYNAMIC_VALUES: {}},
+        )
+        self.past_negative_decision.update(
             reviewer_user=self.task_user,
             metadata={ContentDecision.POLICY_DYNAMIC_VALUES: {}},
         )

--- a/src/olympia/constants/abuse.py
+++ b/src/olympia/constants/abuse.py
@@ -37,6 +37,10 @@ DECISION_ACTIONS.add_subset(
         'AMO_DELETE_RATING',
         'AMO_DELETE_COLLECTION',
         'AMO_REJECT_VERSION_ADDON',
+        # Note: AMO_BLOCK_ADDON is appealable, but at the moment the blocking
+        # part can't be automatically reverted by a successful appeal and has
+        # to be done manually.
+        'AMO_BLOCK_ADDON',
     ),
 )
 DECISION_ACTIONS.add_subset(


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/15800

### Description

`ContentActionBlockAddon` action is used to automatically disable and block the add-on when over the ratings/abuse threshold for the tier, or in the scanner action "Force-disable and block". It should allow appeals, but didn't before this change.

### Testing

Like testing https://github.com/mozilla/addons/issues/15769 or https://github.com/mozilla/addons/issues/15764 but also check that the author can then appeal, and that the appeal does re-enable the add-on (without unblocking, that's still a manual process for now)