### PR TITLE
increase REVIEWER_DELAYED_REJECTION_PERIOD_DAYS_DEFAULT to 30

### DIFF
--- a/src/olympia/constants/reviewers.py
+++ b/src/olympia/constants/reviewers.py
@@ -9,7 +9,7 @@ from .base import ADDON_ANY, ADDON_EXTENSION, ADDON_STATICTHEME
 REVIEWER_VIEWING_INTERVAL = 8  # How often we ping for "who's watching?"
 REVIEWER_REVIEW_LOCK_LIMIT = 3  # How many pages can a reviewer "watch"
 # Default delayed rejection period in days
-REVIEWER_DELAYED_REJECTION_PERIOD_DAYS_DEFAULT = 14
+REVIEWER_DELAYED_REJECTION_PERIOD_DAYS_DEFAULT = 30
 
 REVIEWER_STANDARD_REVIEW_TIME = 3  # How many (week)days we expect to review within
 REVIEWER_STANDARD_REPLY_TIME = 2  # How many (week)days we expect to reply within

--- a/src/olympia/reviewers/tests/test_forms.py
+++ b/src/olympia/reviewers/tests/test_forms.py
@@ -1122,7 +1122,7 @@ class TestReviewForm(TestCase):
             'readonly': 'readonly',
         }
         assert form.fields['delayed_rejection_date'].initial == datetime(
-            2025, 2, 24, 13, 9
+            2025, 3, 12, 13, 9
         )
         content = str(form['delayed_rejection'])
         doc = pq(content)
@@ -1157,7 +1157,7 @@ class TestReviewForm(TestCase):
             'min': '2025-01-24T12:52',
         }
         assert form.fields['delayed_rejection_date'].initial == datetime(
-            2025, 2, 6, 13, 52
+            2025, 2, 22, 13, 52
         )
         content = str(form['delayed_rejection'])
         doc = pq(content)


### PR DESCRIPTION
Fixes: mozilla/addons#15805

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

as per title, just changing the constant value

### Testing

Shouldn't be necessary, but you it you want to: look in reviewer tools for a review page of an add-on - if you choose the reject action, and to delay reject (rather than immediate) then the initial delayed rejection date should be 30 days from now.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
