### PR TITLE
allow addons viewer permission holder to download disabled files

### DIFF
--- a/src/olympia/versions/tests/test_views.py
+++ b/src/olympia/versions/tests/test_views.py
@@ -211,7 +211,7 @@ class TestDownloadsUnlistedVersions(TestDownloadsBase):
         super().setUp()
         self.make_addon_unlisted(self.addon)
 
-    @mock.patch.object(acl, 'is_reviewer', lambda user, addon: False)
+    @mock.patch.object(acl, 'is_listed_addons_viewer_or_reviewer', lambda user: False)
     @mock.patch.object(acl, 'is_unlisted_addons_viewer_or_reviewer', lambda user: False)
     @mock.patch.object(acl, 'check_addon_ownership', lambda *args, **kwargs: False)
     def test_download_for_unlisted_addon_returns_404(self):
@@ -227,7 +227,7 @@ class TestDownloadsUnlistedVersions(TestDownloadsBase):
             self.client.get(self.file_url, HTTP_X_COUNTRY_CODE='fr').status_code == 404
         )
 
-    @mock.patch.object(acl, 'is_reviewer', lambda user, addon: False)
+    @mock.patch.object(acl, 'is_listed_addons_viewer_or_reviewer', lambda user: False)
     @mock.patch.object(acl, 'is_unlisted_addons_viewer_or_reviewer', lambda user: False)
     @mock.patch.object(acl, 'check_addon_ownership', lambda *args, **kwargs: True)
     def test_download_for_unlisted_addon_owner(self):
@@ -252,7 +252,7 @@ class TestDownloadsUnlistedVersions(TestDownloadsBase):
         # Latest shouldn't work as it's only for latest public listed version.
         assert self.client.get(self.latest_url).status_code == 404
 
-    @mock.patch.object(acl, 'is_reviewer', lambda user, addon: True)
+    @mock.patch.object(acl, 'is_listed_addons_viewer_or_reviewer', lambda user: True)
     @mock.patch.object(acl, 'is_unlisted_addons_viewer_or_reviewer', lambda user: False)
     @mock.patch.object(acl, 'check_addon_ownership', lambda *args, **kwargs: False)
     def test_download_for_unlisted_addon_reviewer(self):
@@ -260,7 +260,7 @@ class TestDownloadsUnlistedVersions(TestDownloadsBase):
         assert self.client.get(self.file_url).status_code == 404
         assert self.client.get(self.latest_url).status_code == 404
 
-    @mock.patch.object(acl, 'is_reviewer', lambda user, addon: False)
+    @mock.patch.object(acl, 'is_listed_addons_viewer_or_reviewer', lambda user: False)
     @mock.patch.object(acl, 'is_unlisted_addons_viewer_or_reviewer', lambda user: True)
     @mock.patch.object(acl, 'check_addon_ownership', lambda *args, **kwargs: False)
     def test_download_for_unlisted_addon_unlisted_reviewer(self):
@@ -293,7 +293,7 @@ class TestDownloadsUnlistedAddonDeleted(TestDownloadsUnlistedVersions):
         super().setUp()
         self.addon.delete()
 
-    @mock.patch.object(acl, 'is_reviewer', lambda user, addon: False)
+    @mock.patch.object(acl, 'is_listed_addons_viewer_or_reviewer', lambda user: False)
     @mock.patch.object(acl, 'is_unlisted_addons_viewer_or_reviewer', lambda user: False)
     @mock.patch.object(acl, 'check_addon_ownership', lambda *args, **kwargs: True)
     def test_download_for_unlisted_addon_owner(self):
@@ -309,7 +309,7 @@ class TestDownloadsUnlistedAddonDeleted(TestDownloadsUnlistedVersions):
             self.client.get(self.file_url, HTTP_X_COUNTRY_CODE='fr').status_code == 404
         )
 
-    @mock.patch.object(acl, 'is_reviewer', lambda user, addon: False)
+    @mock.patch.object(acl, 'is_listed_addons_viewer_or_reviewer', lambda user: False)
     @mock.patch.object(acl, 'is_unlisted_addons_viewer_or_reviewer', lambda user: True)
     @mock.patch.object(acl, 'check_addon_ownership', lambda *args, **kwargs: False)
     def test_download_for_unlisted_addon_unlisted_reviewer(self):
@@ -864,7 +864,7 @@ class TestDownloadSource(TestCase):
         response = self.client.get(self.url)
         assert response.status_code == 404
 
-    @mock.patch.object(acl, 'is_reviewer', lambda user, addon: False)
+    @mock.patch.object(acl, 'is_listed_addons_viewer_or_reviewer', lambda user: False)
     @mock.patch.object(acl, 'is_unlisted_addons_viewer_or_reviewer', lambda user: False)
     @mock.patch.object(acl, 'check_addon_ownership', lambda *args, **kwargs: False)
     def test_download_for_unlisted_addon_returns_404(self):
@@ -872,7 +872,7 @@ class TestDownloadSource(TestCase):
         self.make_addon_unlisted(self.addon)
         assert self.client.get(self.url).status_code == 404
 
-    @mock.patch.object(acl, 'is_reviewer', lambda user, addon: False)
+    @mock.patch.object(acl, 'is_listed_addons_viewer_or_reviewer', lambda user: False)
     @mock.patch.object(acl, 'is_unlisted_addons_viewer_or_reviewer', lambda user: False)
     @mock.patch.object(acl, 'check_addon_ownership', lambda *args, **kwargs: True)
     def test_download_for_unlisted_addon_owner(self):
@@ -880,7 +880,7 @@ class TestDownloadSource(TestCase):
         self.make_addon_unlisted(self.addon)
         assert self.client.get(self.url).status_code == 200
 
-    @mock.patch.object(acl, 'is_reviewer', lambda user, addon: False)
+    @mock.patch.object(acl, 'is_listed_addons_viewer_or_reviewer', lambda user: False)
     @mock.patch.object(acl, 'is_unlisted_addons_viewer_or_reviewer', lambda user: False)
     @mock.patch.object(acl, 'check_addon_ownership', lambda *args, **kwargs: True)
     def test_download_for_addon_owner_deleted(self):
@@ -889,7 +889,7 @@ class TestDownloadSource(TestCase):
         self.make_addon_unlisted(self.addon)
         assert self.client.get(self.url).status_code == 404
 
-    @mock.patch.object(acl, 'is_reviewer', lambda user, addon: True)
+    @mock.patch.object(acl, 'is_listed_addons_viewer_or_reviewer', lambda user: True)
     @mock.patch.object(acl, 'is_unlisted_addons_viewer_or_reviewer', lambda user: True)
     @mock.patch.object(acl, 'check_addon_ownership', lambda *args, **kwargs: False)
     def test_download_for_unlisted_addon_reviewer(self):

--- a/src/olympia/versions/views.py
+++ b/src/olympia/versions/views.py
@@ -76,11 +76,14 @@ def download_file(request, file_id, download_type=None, **kwargs):
     """
 
     def is_appropriate_reviewer(addon, channel):
-        return (
-            acl.is_reviewer(request.user, addon)
-            if channel == amo.CHANNEL_LISTED
-            else acl.is_unlisted_addons_viewer_or_reviewer(request.user)
-        )
+        if channel == amo.CHANNEL_LISTED:
+            return (
+                acl.is_static_theme_reviewer(request.user)
+                if addon.type == amo.ADDON_STATICTHEME
+                else acl.is_listed_addons_viewer_or_reviewer(request.user)
+            )
+        else:
+            return acl.is_unlisted_addons_viewer_or_reviewer(request.user)
 
     file_ = get_object_or_404(File.objects, pk=file_id)
     # Include deleted add-ons in the queryset, we'll check for that below.


### PR DESCRIPTION
Fixes: mozilla/addons#1929

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Changes the permission check for listed disabled versions to include viewers too.
 
### Testing

With a user with an `Addons:Review` permission (i.e. normal, full, listed reviewer)
- try to download an xpi file from a link via the link in the reviewer tools
  - (no change, checking for no regression)
- disable the add-on
- try to download the file again
  - (no change, checking for no regression)
- change the permission to `ReviewerTools:View`
- try to download the file again
  - (this is what we're changing)

Further optional regression test cases:
- unlisted versions
- non-disabled versions
- deleted versions
- static themes
- (and combinations of above)

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
