### PR TITLE
Handle additional homoglyphs

### DIFF
--- a/src/olympia/addons/tests/test_utils_.py
+++ b/src/olympia/addons/tests/test_utils_.py
@@ -44,6 +44,8 @@ from ..utils import (
         ('F\u2800 i r \u0435 f o x', False, False),
         ('Fïrefox is great', False, False),
         ('Foobarfor Firefox!', False, False),
+        ('Mozilla', False, False),
+        ('Moziꙇꙇa', False, False),
         ('Better Privacy for Firefox!', True, False),
         ('Firefox awesome for Mozilla', False, False),
         ('Firefox awesome for Mozilla', True, True),

--- a/src/olympia/amo/utils.py
+++ b/src/olympia/amo/utils.py
@@ -506,8 +506,10 @@ def generate_lowercase_homoglyphs_variants_for_string(value):
     additional_replacements = {
         'e': ('Э', '℈', 'Є', '€', 'Ꞓ'),
         'k': ('ĸ', 'κ', 'к', 'қ', 'ҝ', 'ҟ', 'ҡ', 'ᴋ'),
+        'l': ('ꙇ'),
         'm': ('ʍ', 'м', 'ᴍ'),
         'o': ('Ѻ', 'ѻ'),
+        't': ('т', 'ᴛ', '𝛕', '𝜏', '𝝉', '𝞃', '𝞽', 'ꚍ', 'ꚑ', 'Ꚍ', 'Ꚑ'),
     }
     additional_replacement_table = dict(
         itertools.chain(

--- a/src/olympia/scanners/tests/test_tasks.py
+++ b/src/olympia/scanners/tests/test_tasks.py
@@ -430,7 +430,7 @@ class TestRunNarc(UploadMixin, TestCase):
 
     @mock.patch('olympia.scanners.tasks.statsd.incr')
     def test_run_homoglyph_match(self, incr_mock):
-        self.addon.name = 'My\u2800 Fäncy W\u0435bExtѐnsion addon'
+        self.addon.name = 'My\u2800 Fäncy W\u0435bEx\u0442ѐnsion addon'
         self.addon.save()
 
         rule = ScannerRule.objects.create(
@@ -454,7 +454,7 @@ class TestRunNarc(UploadMixin, TestCase):
             {
                 'meta': {
                     'locale': 'en-us',
-                    'original_string': 'My⠀ Fäncy WеbExtѐnsion addon',
+                    'original_string': 'My⠀ Fäncy WеbExтѐnsion addon',
                     'pattern': 'MyFancyWebExtensionAddon',
                     'source': 'db_addon',
                     'span': [


### PR DESCRIPTION
Another follow-up for https://github.com/mozilla/addons/issues/15802

### Context

We normalize aggressively each string removing symbols, punctuation, whitespace etc, before generating variants according to confusables characters using `homoglyph_fork` library and passing the results to NARC/trademark checks. Unfortunately that still misses a few non-officially confusable characters so we also have our own replacement list on top. This change simply adds a few characters to our own list.