### PR TITLE
scanners shouldn't block after successful appeal

### DIFF
--- a/src/olympia/scanners/tests/test_actions.py
+++ b/src/olympia/scanners/tests/test_actions.py
@@ -962,7 +962,8 @@ class TestActions(TestCase):
                 version=version, rule=None, scanner=CUSTOMS
             )
 
-    def test_disable_and_block(self):
+    def do_disable_and_block(self, addon):
+        existing_decision_count = ContentDecision.objects.count()
         responses.add_callback(
             responses.POST,
             f'{settings.CINDER_SERVER_URL}create_decision',
@@ -972,7 +973,6 @@ class TestActions(TestCase):
         UsageTier.objects.create(
             upper_adu_threshold=10000, disable_and_block_action_available=True
         )
-        addon = addon_factory(average_daily_users=4242)
         version1 = addon.current_version
         version2 = version_factory(addon=addon)
         _disable_and_block(version=version2, rule=None)
@@ -984,7 +984,10 @@ class TestActions(TestCase):
         assert version2.is_blocked
         assert version2.file.reload().status == amo.STATUS_DISABLED
         assert version2.blockversion.block_type == BlockType.SOFT_BLOCKED
-        assert ContentDecision.objects.count() == 1
+        assert ContentDecision.objects.count() == existing_decision_count + 1
+
+    def test_disable_and_block(self):
+        self.do_disable_and_block(addon_factory(average_daily_users=4242))
 
     @mock.patch('olympia.scanners.actions.reject_and_block_addons')
     def test_disable_and_block_with_mock(self, reject_and_block_addons_mock):
@@ -1090,6 +1093,44 @@ class TestActions(TestCase):
         addon.reviewerflags.reload()
         assert addon.auto_approval_delayed_until == datetime.max
         assert addon.auto_approval_delayed_until_unlisted == datetime.max
+
+    def test_disable_and_block_with_unsuccesful_appeal(self):
+        addon = addon_factory(average_daily_users=4242)
+        appeal_decision = ContentDecision.objects.create(
+            addon=addon,
+            action=DECISION_ACTIONS.AMO_DISABLE_ADDON,
+            cinder_job=CinderJob.objects.create(target_addon=addon),
+        )
+        ContentDecision.objects.create(
+            addon=addon,
+            action=DECISION_ACTIONS.AMO_BLOCK_ADDON,
+            appeal_job=appeal_decision.cinder_job,
+        )
+        self.do_disable_and_block(addon)
+
+    def test_disable_and_block_with_unresolved_appeal(self):
+        addon = addon_factory(average_daily_users=4242)
+        appeal_job = CinderJob.objects.create(target_addon=addon)
+        ContentDecision.objects.create(
+            addon=addon,
+            action=DECISION_ACTIONS.AMO_BLOCK_ADDON,
+            appeal_job=appeal_job,
+        )
+        self.do_disable_and_block(addon)
+
+    def test_disable_and_block_with_non_block_appeal(self):
+        addon = addon_factory(average_daily_users=4242)
+        appeal_decision = ContentDecision.objects.create(
+            addon=addon,
+            action=DECISION_ACTIONS.AMO_APPROVE,
+            cinder_job=CinderJob.objects.create(target_addon=addon),
+        )
+        ContentDecision.objects.create(
+            addon=addon,
+            action=DECISION_ACTIONS.AMO_DISABLE_ADDON,
+            appeal_job=appeal_decision.cinder_job,
+        )
+        self.do_disable_and_block(addon)
 
 
 class TestRunAction(TestCase):


### PR DESCRIPTION
Fixes: mozilla/addons#15815

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

If there was a successful appeal, don't disable and block in scanner action; fallback to disable auto approval and setting NHR instead.

### Testing

- Execute a narc scanner rule that blocks and disables an add-on
- Via the email we sent to the developer (in django admin fake mail), submit an appeal to that block&disable
- in reviewer tools process that appeal:
  - choose the re-enable add-on action, 
  - check the appeal cinder job to resolve it with that action
  - choosing a reviewer action reason that has AMO_APPROVE, AMO_APPROVE_VERSION, or AMO_IGNORE as the default action (you might need to create/edit a ReviewerActionReason)
  - _or_ chose a Cinder policy that has AMO_APPROVE, AMO_APPROVE_VERSION, or AMO_IGNORE as an enforcement action (e.g. the Approve policy).
- in django admin, create a blocklistsubmission that unblocks all the add-on versions
- in the reviewer tools:
  - confirm the add-on was successfully unblocked
  - clear any NHR; 
  - make sure the add-on has auto approval enabled
- Execute the narc scanner rule again
- in the reviewer tools:
 - confirm the add-on is _not_ blocked
 - there is a NHR for the latest version
 - auto approval is disabled

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
