### PR TITLE
Fix rollback with only one channel available

### DIFF
--- a/src/olympia/devhub/forms.py
+++ b/src/olympia/devhub/forms.py
@@ -1650,11 +1650,11 @@ class RollbackVersionForm(forms.Form):
         if not self.listed_count and self.unlisted_count:
             # if there is no listed option, we default to unlisted
             channel.initial = amo.CHANNEL_UNLISTED
-            channel.widget.attrs = {'disabled': True}
+            channel.disabled = True
         elif not self.unlisted_count and self.listed_count:
             # if there is a listed option, we default to that channel
             channel.initial = amo.CHANNEL_LISTED
-            channel.widget.attrs = {'disabled': True}
+            channel.disabled = True
         elif self.listed_count or self.unlisted_count:
             # otherwise we default to the most recently used channel
             channel.initial = self.addon.versions.first().channel

--- a/src/olympia/devhub/tests/test_forms.py
+++ b/src/olympia/devhub/tests/test_forms.py
@@ -1606,8 +1606,9 @@ class TestRollbackVersionForm(TestCase):
             'version': uv1,
         }
 
-        # and when we select listed but there is no listed version availble: error
+        # and when we select listed but there is no listed version available: error
         data['channel'] = amo.CHANNEL_LISTED
+        del data['unlisted_version']
         lv1.delete()
         form = forms.RollbackVersionForm(data, addon=addon)
         assert not form.is_valid()

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -616,6 +616,7 @@ function initVersions() {
     }
 
     let $channelInputs = $('#id_channel input'),
+        $hiddenChannelInput = $('input[name="channel"][type="hidden"]'),
         $listedVersionRow = $('#listed-version-row'),
         $unlistedVersionRow = $('#unlisted-version-row'),
         $listedVersionSelect = $('#id_listed_version'),
@@ -652,6 +653,14 @@ function initVersions() {
       });
     })
     .trigger('change');
+
+    if ($hiddenChannelInput) {
+      if ($hiddenChannelInput.val() == '1') {
+        $unlistedVersionSelect.trigger('change');
+      } else {
+        $listedVersionSelect.trigger('change');
+      }
+    }
   }
 
   function addToReviewHistory(json, historyContainer, reverseOrder) {

--- a/static/js/zamboni/devhub.js
+++ b/static/js/zamboni/devhub.js
@@ -608,6 +608,8 @@ function initVersions() {
   });
 
   if ($('#modal-rollback-version').length) {
+    const CHANNEL_UNLISTED = '1',
+          CHANNEL_LISTED = '2';
     let $modalRollback = $('#modal-rollback-version').modal('.version-rollback', {
       width: 600
     });
@@ -642,11 +644,11 @@ function initVersions() {
       $unlistedVersionRow.hide();
       $channelInputs.each(function (index, element) {
         const $radio = $(element);
-        if ($radio.val() == '2' && $radio.prop('checked')) {
+        if ($radio.val() == CHANNEL_LISTED && $radio.prop('checked')) {
           $listedVersionRow.show();
           $listedVersionSelect.trigger('change');
         }
-        if ($radio.val() == '1' && $radio.prop('checked')) {
+        if ($radio.val() == CHANNEL_UNLISTED && $radio.prop('checked')) {
           $unlistedVersionRow.show();
           $unlistedVersionSelect.trigger('change');
         }
@@ -655,9 +657,9 @@ function initVersions() {
     .trigger('change');
 
     if ($hiddenChannelInput) {
-      if ($hiddenChannelInput.val() == '1') {
+      if ($hiddenChannelInput.val() == CHANNEL_UNLISTED) {
         $unlistedVersionSelect.trigger('change');
-      } else {
+      } else if ($hiddenChannelInput.val() == CHANNEL_LISTED) {
         $listedVersionSelect.trigger('change');
       }
     }


### PR DESCRIPTION
Fixes: mozilla/addons#15804

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Fixes the scenario with an add-on with 2 channels, but only one channel available for rollback, where the channel selector was disabled.  Now the field on the form is disabled instead so the initial channel value is correctly used.

Also fixes a (separate) bug where the explanation label isn't available because there's no channel selector (and the javascript that sets it is on the channel selector)

### Context

I initially thought these two bugs were connected, but turns out they're for different scenarios (two channels, but only one channel available for rollback vs. only one channel)

### Testing

- Set-up an add-on with 2 or more approved versions in the unlisted channel (and nothing in the listed channel)
  - see the explanation text is present and changes with the version selection in the rollback form
  - rollback one of the versions
  - (refresh the versions page afterwards)
- upload and approve a listed version
  - now the channel selector should be present but disabled on the rollback form
  - rollback an unlisted version again

optional - repeat with listed
- upload and approve another listed version
- see the rollback form has a functional channel selector
- delete all but one unlisted version
- see the channel selector is disabled and defaulted to listed; the explanation text is there and correct
- rollback the latest listed version
- delete the remaining unlisted version
- see the channel selector is not present; the explanation text is there and correct

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
