### PR TITLE
Allow triggering flag_high_rating_addons_according_to_review_tier task independently

### DIFF
--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1418,6 +1418,7 @@ VERIFY_FXA_ACCESS_TOKEN = True
 # syntax is: job_and_method_name: full.package.path
 CRON_JOBS = {
     'addon_last_updated': 'olympia.addons.cron',
+    'flag_high_rating_addons': 'olympia.ratings.cron',
     'gc': 'olympia.amo.cron',
     'process_blocklistsubmissions': 'olympia.blocklist.cron',
     'record_reviewer_queues_counts': 'olympia.reviewers.cron',

--- a/src/olympia/ratings/cron.py
+++ b/src/olympia/ratings/cron.py
@@ -1,0 +1,5 @@
+from olympia.ratings.tasks import flag_high_rating_addons_according_to_review_tier
+
+
+def flag_high_rating_addons():
+    flag_high_rating_addons_according_to_review_tier.delay()

--- a/src/olympia/ratings/tests/test_cron.py
+++ b/src/olympia/ratings/tests/test_cron.py
@@ -1,0 +1,9 @@
+from unittest import mock
+
+from django.core.management import call_command
+
+
+@mock.patch('olympia.ratings.tasks.flag_high_rating_addons_according_to_review_tier')
+def test_flag_high_ratings(flag_high_rating_addons_mock):
+    call_command('cron', 'flag_high_rating_addons')
+    assert flag_high_rating_addons_mock.delay.call_count == 1    

--- a/src/olympia/ratings/tests/test_cron.py
+++ b/src/olympia/ratings/tests/test_cron.py
@@ -3,7 +3,7 @@ from unittest import mock
 from django.core.management import call_command
 
 
-@mock.patch('olympia.ratings.tasks.flag_high_rating_addons_according_to_review_tier')
+@mock.patch('olympia.ratings.cron.flag_high_rating_addons_according_to_review_tier')
 def test_flag_high_ratings(flag_high_rating_addons_mock):
     call_command('cron', 'flag_high_rating_addons')
-    assert flag_high_rating_addons_mock.delay.call_count == 1    
+    assert flag_high_rating_addons_mock.delay.call_count == 1


### PR DESCRIPTION
Needed for mozilla/addons#15830

### Testing

See test added, you can try running `manage.py cron flag_high_rating_addons` yourself and verify in the logs or else that it triggered the task.