### PR TITLE
Optimize update_addon_weekly_downloads and update_addon_average_daily_users tasks

### DIFF
--- a/docs/topics/runbooks/localdev/test_statistics_dashboard.md
+++ b/docs/topics/runbooks/localdev/test_statistics_dashboard.md
@@ -16,7 +16,7 @@ your local addon will need to use a matching `guid`.
 Open a django shell `make djshell` and run the following:
 
 - pk: the database id of the addon you want to use
-- guid: the guid from the [list][enabled_dev_guids] you want to use (e.g. `@facebook-container`)
+- guid: the guid from the [list][enabled_dev_guids] you want to use (e.g. `@contain-facebook`)
 
 ```python
 addon = Addon.objects.get(pk=<pg>)

--- a/src/olympia/addons/tasks.py
+++ b/src/olympia/addons/tasks.py
@@ -432,7 +432,7 @@ def update_addon_weekly_downloads(data):
     for hashed_guid, count in data:
         try:
             addon = (
-                Addon.unfiltered.all()
+                Addon.objects.all()
                 .no_transforms()
                 .get(addonguid__hashed_guid=hashed_guid)
             )


### PR DESCRIPTION
- No need to do transforms, that's extra queries we don't need here (bulk of the speed change will come from there)
- No need to update if the value hasn't changed

Fixes https://github.com/mozilla/addons/issues/15834

### Testing

There is no functionality change and this is covered by unit tests. If you want to test further:
- Set up an add-on that we have stats for by fixing its `guid`, and [follow procedure to have stats data working on local environments](https://mozilla.github.io/addons-server/topics/runbooks/localdev/bigquery_credentials_setup.html)
- Run `manage.py cron update_addon_average_daily_users`
- Check that your add-on its `average_daily_users` updated (should match dev since the values are fixed)
- Repeat with `manage.py cron update_addon_weekly_downloads`
