### PR TITLE
rewrite RollbackVersionForm for less queries

### DIFF
--- a/src/olympia/devhub/templates/devhub/includes/modal_rollback_version.html
+++ b/src/olympia/devhub/templates/devhub/includes/modal_rollback_version.html
@@ -29,7 +29,7 @@
         {% if has_listed_versions %}
         <tr id="listed-version-row">
         <td><label for="id_listed_version">{{ _('Version') }}</label></td>
-        <td data-current-version="{{ addon.current_version.version }}">
+        <td data-current-version="{{ current_version.version }}">
             {{ rollback_form.listed_version }}
             {{ rollback_form.listed_version.errors }}
         </td>
@@ -38,7 +38,7 @@
         {% if has_unlisted_versions %}
         <tr id="unlisted-version-row">
         <td><label for="id_unlisted_version">{{ _('Version') }}</label></td>
-        <td data-current-version="{{ addon.find_latest_version(channel=amo.CHANNEL_UNLISTED).version }}">
+        <td data-current-version="{{ latest_approved_unlisted_version_number }}">
             {{ rollback_form.unlisted_version }}
             {{ rollback_form.unlisted_version.errors }}
         </td>

--- a/src/olympia/devhub/tests/test_forms.py
+++ b/src/olympia/devhub/tests/test_forms.py
@@ -1468,7 +1468,7 @@ class TestRollbackVersionForm(TestCase):
             v1.version,
         ]
         assert form.fields['listed_version'].choices == [
-            (None, 'No appropriate version available')
+            ('', 'No appropriate version available')
         ]
 
     def test_no_unlisted_version_choices(self):
@@ -1479,7 +1479,9 @@ class TestRollbackVersionForm(TestCase):
         version_factory(addon=addon)
         form = forms.RollbackVersionForm(addon=addon)
         assert form.fields['channel'].initial == amo.CHANNEL_LISTED
-        assert form.fields['listed_version'].choices == [(v2.id, v2)]
+        assert [str(lab) for _, lab in form.fields['listed_version'].choices] == [
+            v2.version,
+        ]
 
     def test_listed_and_unlisted_version_choices(self):
         """Both listed and unlisted version choices should be available."""
@@ -1491,7 +1493,9 @@ class TestRollbackVersionForm(TestCase):
         version_factory(addon=addon, channel=amo.CHANNEL_UNLISTED)
         form = forms.RollbackVersionForm(addon=addon)
         assert form.fields['channel'].initial is amo.CHANNEL_UNLISTED
-        assert form.fields['listed_version'].choices == [(lv2.id, lv2)]
+        assert [str(lab) for _, lab in form.fields['listed_version'].choices] == [
+            lv2.version,
+        ]
         assert [str(lab) for _, lab in form.fields['unlisted_version'].choices] == [
             'Choose version',
             uv2.version,
@@ -1524,6 +1528,7 @@ class TestRollbackVersionForm(TestCase):
 
         data = {
             'channel': amo.CHANNEL_LISTED,
+            'listed_version': lv2.id,
             'unlisted_version': uv2.id,
         }
         for version in (lv1, lv2, lv3, uv1, uv2, uv3):
@@ -1537,7 +1542,7 @@ class TestRollbackVersionForm(TestCase):
             version_kw={'version': '1.29'}, file_kw={'is_signed': True}
         )
         addon.current_version.delete()  # deleted shouldn't matter, just it was signed
-        version_factory(addon=addon)
+        lv2 = version_factory(addon=addon)
         version_factory(addon=addon, version='1.31.0')
         version_factory(
             addon=addon,
@@ -1552,6 +1557,7 @@ class TestRollbackVersionForm(TestCase):
         version_string = '1.3'
         data = {
             'channel': amo.CHANNEL_LISTED,
+            'listed_version': lv2.id,
             'unlisted_version': uv2.id,
             'new_version_string': version_string,
         }
@@ -1579,12 +1585,15 @@ class TestRollbackVersionForm(TestCase):
         version_factory(addon=addon, channel=amo.CHANNEL_UNLISTED)
         data = {
             'channel': amo.CHANNEL_LISTED,
+            'listed_version': lv1.id,
             'unlisted_version': uv1.id,
             'new_version_string': '111111',
         }
         # test we're selecting the listed channel
         form = forms.RollbackVersionForm(data, addon=addon)
-        assert form.fields['listed_version'].choices == [(lv1.id, lv1)]
+        assert [str(lab) for _, lab in form.fields['listed_version'].choices] == [
+            lv1.version,
+        ]
         assert form.is_valid(), form.errors
         # the listed version is added, and as the chosen version
         assert form.clean() == {
@@ -1604,6 +1613,7 @@ class TestRollbackVersionForm(TestCase):
         version_factory(addon=addon, channel=amo.CHANNEL_UNLISTED)
         data = {
             'channel': amo.CHANNEL_UNLISTED,
+            'listed_version': lv1.id,
             'unlisted_version': uv1.id,
             'new_version_string': '111111',
         }

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -1329,6 +1329,12 @@ def version_list(request, addon_id, addon):
         'can_rollback': rollback_form.can_rollback(),
         'can_submit': not addon.is_disabled,
         'comments_maxlength': CommentLog._meta.get_field('comments').max_length,
+        'latest_approved_unlisted_version_number': rollback_form.can_rollback()
+        and addon.versions.filter(
+            channel=amo.CHANNEL_UNLISTED, file__status=amo.STATUS_APPROVED
+        )
+        .values_list('version', flat=True)
+        .first(),
         'is_admin': is_admin,
         'rollback_form': rollback_form,
         'session_id': request.session.session_key,


### PR DESCRIPTION
Fixes: mozilla/addons#15828

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

rewrites RollbackVersion to limit and cache the version choices

### Context

The version list page is unfortunately quite unoptimized - and appears to produce a new query for every new version - along with numerous other seemingly duplicated queries.  Fixing all _that_ is out of scope, but it's now limited to 2 extra queries when the the form is unavailable (no applicable versions), i.e. the query per channel to discover if there are any applicable versions; and potentially an additional 2 when the form is available, for choosing the channel to default to, and for the latest unlisted version.

Adding `.only('id', 'version')` triggered _additional_ queries

### Testing

<!--
Your change must be related to an existing, open issue. This issue should contain testing instructions.
Often, the testing info in the issue is higher level, geared towards a user or QA experience.
Here you can provide information for a developer verifying this PR. Get technical.
If it is not relevant to your PR, remove this section.
-->

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [ ] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
