### PR TITLE
Restrict future approvals in "Disable and block" scanner action

### DIFF
--- a/src/olympia/users/admin.py
+++ b/src/olympia/users/admin.py
@@ -147,6 +147,8 @@ class UserAdmin(AMOModelAdmin):
         'picture_img',
         'ratings_authorship',
         'restriction_history_for_this_user',
+        'currently_matching_exact_email_restrictions',
+        'currently_matching_exact_ip_restrictions',
     )
     fieldsets = (
         (
@@ -196,13 +198,22 @@ class UserAdmin(AMOModelAdmin):
                     'last_login',
                     'last_known_activity_time',
                     'activity',
-                    'restriction_history_for_this_user',
                     'last_login_ip',
                     'known_ip_adresses',
                     'banned',
                     'notes',
-                    'bypass_upload_restrictions',
                     'has_active_api_key',
+                )
+            },
+        ),
+        (
+            'Restrictions',
+            {
+                'fields': (
+                    'restriction_history_for_this_user',
+                    'currently_matching_exact_email_restrictions',
+                    'currently_matching_exact_ip_restrictions',
+                    'bypass_upload_restrictions',
                 )
             },
         ),
@@ -504,6 +515,17 @@ class UserAdmin(AMOModelAdmin):
 
     def restriction_history_for_this_user(self, obj):
         return related_content_link(obj, UserRestrictionHistory, 'user')
+
+    def currently_matching_exact_email_restrictions(self, obj):
+        return related_content_link(
+            None, EmailUserRestriction, 'email_pattern', identifier=obj.email
+        )
+
+    def currently_matching_exact_ip_restrictions(self, obj):
+        network = IPNetworkUserRestriction.network_from_ip(obj.last_login_ip)
+        return related_content_link(
+            None, IPNetworkUserRestriction, 'network', identifier=network
+        )
 
     def history_for_this_user(self, obj):
         return related_content_link(obj, UserHistory, 'user')

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -881,6 +881,21 @@ class IPNetworkUserRestriction(RestrictionAbstractBaseModel):
         return str(self.network)
 
     @classmethod
+    def network_from_ip(cls, ip):
+        """
+        Return the smallest meaningful network to restrict from an IP
+        """
+        ip_object = ipaddress.ip_address(ip)
+        # For IPv4, restrict the /32, i.e. the exact IP.
+        # For IPv6, restrict the /64, otherwise the restriction would be
+        # trivial to bypass. We pass strict=False to ip_network() to make the
+        # ipaddress module ignore the hosts bits from the ip after the prefix
+        # length is applied.
+        prefix_len = 32 if ip_object.version == 4 else 64
+        network = ipaddress.ip_network((ip, prefix_len), strict=False)
+        return network
+
+    @classmethod
     def allow_submission(cls, request):
         """
         Return whether the specified request should be allowed to submit add-ons.

--- a/src/olympia/users/tests/test_admin.py
+++ b/src/olympia/users/tests/test_admin.py
@@ -502,15 +502,17 @@ class TestUserAdmin(TestCase):
         # We want to see absolutely everything, so make our user a superadmin.
         self.grant_permission(user, '*:*')
         self.client.force_login(user)
-        with self.assertNumQueries(21):
+        with self.assertNumQueries(23):
             # - 4 savepoint/release
             # - 2 current logged in user & groups
             # - 2 target user & groups
             # - 1 banned user content instance
-            # - 8 related content counts
+            # - 6 related content counts
             #     (collections, addons, ratings, activity, abuse reports by
-            #      this user, abuse reports against this user,
-            #      restriction history, user history for email changes)
+            #      this user, abuse reports against this user)
+            # - 4 restrictions related counts
+            #     (restriction history, user history for email changes,
+            #      exact email restrictions, exact ip restrictions)
             # - 1 last activity date
             # - 1 known activity ips
             # - 1 api key

--- a/src/olympia/users/tests/test_models.py
+++ b/src/olympia/users/tests/test_models.py
@@ -1,6 +1,6 @@
 import os.path
 from datetime import date, datetime, timedelta
-from ipaddress import IPv4Address
+from ipaddress import IPv4Address, IPv4Network, IPv6Network
 from unittest import mock
 
 from django import forms
@@ -1156,6 +1156,20 @@ class TestIPNetworkUserRestriction(TestCase):
             channel=amo.CHANNEL_LISTED,
         )
         assert not IPNetworkUserRestriction.allow_auto_approval(upload)
+
+    def test_network_from_ip(self):
+        assert IPNetworkUserRestriction.network_from_ip('192.168.0.1') == IPv4Network(
+            '192.168.0.1/32'
+        )
+        assert IPNetworkUserRestriction.network_from_ip(
+            '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+        ) == IPv6Network('2001:0db8:85a3::/64')
+
+    def test_network_from_ip_blank(self):
+        with self.assertRaises(ValueError):
+            IPNetworkUserRestriction.network_from_ip(None)
+        with self.assertRaises(ValueError):
+            IPNetworkUserRestriction.network_from_ip('')
 
 
 class TestDisposableEmailDomainRestriction(TestCase):

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -570,9 +570,18 @@ class Version(OnChangeMixin, ModelBase):
                 else 'auto_approval_disabled_unlisted'
             )
             reviewer_flags_defaults[flag] = True
-
-            # FIXME: add activity log here indicating we disabled auto-approval
-            # because we hit a restriction.
+            activity.log_create(
+                amo.LOG.DISABLE_AUTO_APPROVAL,
+                addon,
+                details={
+                    'channel': version.channel,
+                    'comments': (
+                        f'{version.get_channel_display()} auto-approval automatically '
+                        'disabled because of a restriction'
+                    ),
+                },
+                user=get_task_user(),
+            )
 
         if reviewer_flags_defaults:
             AddonReviewerFlags.objects.update_or_create(

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -571,6 +571,9 @@ class Version(OnChangeMixin, ModelBase):
             )
             reviewer_flags_defaults[flag] = True
 
+            # FIXME: add activity log here indicating we disabled auto-approval
+            # because we hit a restriction.
+
         if reviewer_flags_defaults:
             AddonReviewerFlags.objects.update_or_create(
                 addon=addon, defaults=reviewer_flags_defaults

--- a/src/olympia/zadmin/admin.py
+++ b/src/olympia/zadmin/admin.py
@@ -11,7 +11,12 @@ from . import models
 
 
 def related_content_link(
-    obj, related_class, related_field, related_manager='objects', text=None
+    obj,
+    related_class,
+    related_field,
+    related_manager='objects',
+    text=None,
+    identifier=None,
 ):
     """
     Return a link to the admin changelist for the instances of related_class
@@ -20,11 +25,15 @@ def related_content_link(
     url = 'admin:{}_{}_changelist'.format(
         related_class._meta.app_label, related_class._meta.model_name
     )
+    if identifier is None:
+        identifier = obj.pk
     if text is None:
-        qs = getattr(related_class, related_manager).filter(**{related_field: obj})
+        qs = getattr(related_class, related_manager).filter(
+            **{related_field: identifier}
+        )
         text = qs.count()
     return format_html(
-        '<a href="{}?{}={}">{}</a>', reverse(url), related_field, obj.pk, text
+        '<a href="{}?{}={}">{}</a>', reverse(url), related_field, identifier, text
     )
 
 


### PR DESCRIPTION
Also to go with that:
- Link (exact) matching restrictions from the user admin to easily find automatically added restrictions when looking up a user in the admin, in order to make such restrictions easier to remove on successful appeals.
- Add activity log when automatically disabling auto-approval because of a restriction

Fixes https://github.com/mozilla/addons/issues/15833