### PR TITLE
Add 7 days cooldown to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,21 +5,29 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 99
+  cooldown:
+    default-days: 7
 - package-ecosystem: "docker-compose"
   directory: "/"
   schedule:
     interval: weekly
   open-pull-requests-limit: 99
+  cooldown:
+    default-days: 7
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
     interval: weekly
   open-pull-requests-limit: 99
+  cooldown:
+    default-days: 7
 - package-ecosystem: "npm"
   directory: "/"
   schedule:
     interval: daily
   open-pull-requests-limit: 99
+  cooldown:
+    default-days: 7
 - package-ecosystem: pip
   directory: "/requirements"
   schedule:
@@ -34,6 +42,8 @@ updates:
           - billiard
           - kombu
   open-pull-requests-limit: 99
+  cooldown:
+    default-days: 7
   ignore:
   - dependency-name: django
     versions:


### PR DESCRIPTION
Add a 7 days cooldown delay to dependabot, making us wait until the dependencies are a little more stable before updating.

TODO:
- Add an exception for the linter
- Consider different delay for some packages (would a 7 day cooldown mean we'll never see a dependency PR for the google deps for instance?)