### PR TITLE
Make various fields in django admin read-only

### DIFF
--- a/src/olympia/abuse/admin.py
+++ b/src/olympia/abuse/admin.py
@@ -149,6 +149,7 @@ class AbuseReportAdmin(AMOModelAdmin):
         'location',
         'illegal_category',
         'illegal_subcategory',
+        'reason',
     )
     fieldsets = (
         ('Abuse Report Core Information', {'fields': ('reason', 'message')}),

--- a/src/olympia/addons/admin.py
+++ b/src/olympia/addons/admin.py
@@ -46,7 +46,7 @@ class AddonListingInfoInline(admin.TabularInline):
     view_on_site = False
 
 
-class AddonUserInline(admin.TabularInline):
+class AddonUserBase:
     model = AddonUser
     raw_id_fields = (
         'addon',
@@ -66,6 +66,14 @@ class AddonUserInline(admin.TabularInline):
             return ''
 
     user_profile_link.short_description = 'User Profile'
+
+
+class AddonUserAdmin(AddonUserBase, AMOModelAdmin):
+    pass
+
+
+class AddonUserInline(AddonUserBase, admin.TabularInline):
+    pass
 
 
 class FileInlineChecks(admin.checks.InlineModelAdminChecks):
@@ -645,3 +653,4 @@ admin.site.register(models.DeniedGuid)
 admin.site.register(models.Addon, AddonAdmin)
 admin.site.register(models.FrozenAddon, FrozenAddonAdmin)
 admin.site.register(models.ReplacementAddon, ReplacementAddonAdmin)
+admin.site.register(models.AddonUser, AddonUserAdmin)

--- a/src/olympia/addons/admin.py
+++ b/src/olympia/addons/admin.py
@@ -256,6 +256,7 @@ class AddonAdmin(AMOModelAdmin):
     readonly_fields = (
         'id',
         'created',
+        'type',
         'activity',
         'discovery_addon',
         'average_rating',

--- a/src/olympia/addons/admin.py
+++ b/src/olympia/addons/admin.py
@@ -52,7 +52,14 @@ class AddonUserBase:
         'addon',
         'user',
     )
-    fields = ('addon', 'user', 'role', 'listed', 'position', 'user_profile_link',)
+    fields = (
+        'addon',
+        'user',
+        'role',
+        'listed',
+        'position',
+        'user_profile_link',
+    )
     readonly_fields = ('user_profile_link',)
     extra = 0
 
@@ -70,7 +77,10 @@ class AddonUserBase:
 
 
 class AddonUserAdmin(AddonUserBase, AMOModelAdmin):
-    readonly_fields = AddonUserBase.readonly_fields + ('addon', 'user',)
+    readonly_fields = AddonUserBase.readonly_fields + (
+        'addon',
+        'user',
+    )
 
 
 class AddonUserInline(AddonUserBase, admin.TabularInline):

--- a/src/olympia/addons/admin.py
+++ b/src/olympia/addons/admin.py
@@ -46,7 +46,7 @@ class AddonListingInfoInline(admin.TabularInline):
     view_on_site = False
 
 
-class AddonUserBase:
+class AddonUserInline(admin.TabularInline):
     model = AddonUser
     raw_id_fields = (
         'addon',
@@ -66,14 +66,6 @@ class AddonUserBase:
             return ''
 
     user_profile_link.short_description = 'User Profile'
-
-
-class AddonUserAdmin(AddonUserBase, AMOModelAdmin):
-    pass
-
-
-class AddonUserInline(AddonUserBase, admin.TabularInline):
-    pass
 
 
 class FileInlineChecks(admin.checks.InlineModelAdminChecks):
@@ -653,4 +645,3 @@ admin.site.register(models.DeniedGuid)
 admin.site.register(models.Addon, AddonAdmin)
 admin.site.register(models.FrozenAddon, FrozenAddonAdmin)
 admin.site.register(models.ReplacementAddon, ReplacementAddonAdmin)
-admin.site.register(models.AddonUser, AddonUserAdmin)

--- a/src/olympia/addons/admin.py
+++ b/src/olympia/addons/admin.py
@@ -52,6 +52,7 @@ class AddonUserBase:
         'addon',
         'user',
     )
+    fields = ('addon', 'user', 'role', 'listed', 'position', 'user_profile_link',)
     readonly_fields = ('user_profile_link',)
     extra = 0
 
@@ -69,7 +70,7 @@ class AddonUserBase:
 
 
 class AddonUserAdmin(AddonUserBase, AMOModelAdmin):
-    pass
+    readonly_fields = AddonUserBase.readonly_fields + ('addon', 'user',)
 
 
 class AddonUserInline(AddonUserBase, admin.TabularInline):

--- a/src/olympia/addons/tests/test_admin.py
+++ b/src/olympia/addons/tests/test_admin.py
@@ -542,15 +542,12 @@ class TestAddonAdmin(TestCase):
         post_data = self._get_full_post_data(addon, addonuser)
         post_data.update(
             **{
-                'type': amo.ADDON_STATICTHEME,  # update it.
                 'addonuser_set-0-user': user.pk,  # Different user than initial.
                 'files-0-status': amo.STATUS_AWAITING_REVIEW,  # Different status.
             }
         )
         response = self.client.post(self.detail_url, post_data, follow=True)
         assert response.status_code == 200
-        addon.reload()
-        assert addon.type == amo.ADDON_STATICTHEME
         addonuser.reload()
         assert addonuser.user == user
         file.reload()
@@ -623,15 +620,12 @@ class TestAddonAdmin(TestCase):
         post_data = self._get_full_post_data(addon, addonuser)
         post_data.update(
             **{
-                'type': amo.ADDON_STATICTHEME,  # update it.
                 'addonuser_set-0-user': user.pk,  # Different user than initial.
                 'files-0-status': amo.STATUS_AWAITING_REVIEW,  # Different status.
             }
         )
         response = self.client.post(self.detail_url, post_data, follow=True)
         assert response.status_code == 200
-        addon.reload()
-        assert addon.type == amo.ADDON_STATICTHEME
         addonuser.reload()
         assert addonuser.user != user
         file.reload()

--- a/src/olympia/files/admin.py
+++ b/src/olympia/files/admin.py
@@ -64,7 +64,19 @@ class FileAdmin(AMOModelAdmin):
     readonly_fields = (
         'id',
         'created',
+        'version',
+        'size',
+        'hash',
+        'original_hash',
         'file_download_url',
+        'manifest_version',
+        'cert_serial_num',
+        'original_status',
+        'status_disabled_reason',
+        'strict_compatibility',
+        'is_signed',
+        'is_experiment',
+        'is_mozilla_signed_extension',
     )
 
     fieldsets = (

--- a/src/olympia/files/tests/test_admin.py
+++ b/src/olympia/files/tests/test_admin.py
@@ -34,14 +34,14 @@ class TestFileAdmin(TestCase):
         assert response.status_code == 200
         assert str(file_.id) in force_str(response.content)
 
-        assert file_.manifest_version == 2
+        assert file_.status == 4
 
         post_data = {
             'version': file_.version.pk,
             'size': file_.size,
             'hash': 'xxx',
             'original_hash': 'xxx',
-            'status': file_.status,
+            'status': 5,
             'original_status': file_.original_status,
             'status_disabled_reason': file_.status_disabled_reason,
             'manifest_version': 3,
@@ -61,7 +61,7 @@ class TestFileAdmin(TestCase):
         response = self.client.post(detail_url, post_data, follow=True)
         assert response.status_code == 200
         file_.refresh_from_db()
-        assert file_.manifest_version == 3
+        assert file_.status == 5
 
     def test_can_not_list_without_admin_advanced_permission(self):
         user = user_factory(email='someone@mozilla.com')

--- a/src/olympia/reviewers/admin.py
+++ b/src/olympia/reviewers/admin.py
@@ -196,7 +196,7 @@ class NeedsHumanReviewAdmin(AMOModelAdmin):
     view_on_site = False
     list_select_related = ('version', 'version__addon')
     fields = ('created', 'modified', 'reason', 'version', 'is_active')
-    readonly_fields = ('reason', 'created', 'modified')
+    readonly_fields = ('reason', 'created', 'modified', 'version')
     list_filter = (
         'reason',
         'is_active',

--- a/src/olympia/users/admin.py
+++ b/src/olympia/users/admin.py
@@ -149,6 +149,7 @@ class UserAdmin(AMOModelAdmin):
         'restriction_history_for_this_user',
         'currently_matching_exact_email_restrictions',
         'currently_matching_exact_ip_restrictions',
+        'username',
     )
     fieldsets = (
         (
@@ -630,6 +631,7 @@ class UserRestrictionHistoryAdmin(AMOModelAdmin):
         'user_link',
         'last_login_ip',
         'created',
+        'user',
     )
     list_display = (
         'created',

--- a/src/olympia/users/tests/test_admin.py
+++ b/src/olympia/users/tests/test_admin.py
@@ -480,7 +480,8 @@ class TestUserAdmin(TestCase):
         assert self.user.reload().username != 'foo'
 
     def test_can_edit_with_users_edit_permission(self):
-        old_username = self.user.username
+        old_display_name = 'old-foo'
+        self.user.update(display_name=old_display_name)
         user = user_factory(email='someone@mozilla.com')
         self.grant_permission(user, 'Users:Edit')
         self.client.force_login(user)
@@ -488,14 +489,14 @@ class TestUserAdmin(TestCase):
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 200
         response = self.client.post(
-            self.detail_url, {'username': 'foo', 'email': self.user.email}, follow=True
+            self.detail_url, {'display_name': 'foo', 'email': self.user.email}, follow=True
         )
         assert response.status_code == 200
-        assert self.user.reload().username == 'foo'
+        assert self.user.reload().display_name == 'foo'
         alog = ActivityLog.objects.latest('pk')
         assert alog.action == amo.LOG.ADMIN_USER_EDITED.id
         assert alog.arguments == [self.user]
-        assert alog.details == {'username': [old_username, 'foo']}
+        assert alog.details == {'display_name': [old_display_name, 'foo']}
 
     def test_queries_detail(self):
         user = user_factory(email='someone@mozilla.com')

--- a/src/olympia/users/tests/test_admin.py
+++ b/src/olympia/users/tests/test_admin.py
@@ -489,7 +489,9 @@ class TestUserAdmin(TestCase):
         response = self.client.get(self.detail_url, follow=True)
         assert response.status_code == 200
         response = self.client.post(
-            self.detail_url, {'display_name': 'foo', 'email': self.user.email}, follow=True
+            self.detail_url,
+            {'display_name': 'foo', 'email': self.user.email},
+            follow=True,
         )
         assert response.status_code == 200
         assert self.user.reload().display_name == 'foo'

--- a/src/olympia/versions/admin.py
+++ b/src/olympia/versions/admin.py
@@ -80,7 +80,7 @@ class VersionAdmin(AMOModelAdmin):
         js = (vite_asset('js/admin-versions.js'),)
 
     view_on_site = False
-    readonly_fields = ('id', 'created', 'version', 'channel')
+    readonly_fields = ('id', 'created', 'addon', 'version', 'channel')
     list_display = (
         'id',
         'created',


### PR DESCRIPTION
Fixes: mozilla/addons#15843

### Description

This make some fields in django admin read-only. For the specific list of fields, see the patch or the issue description.

### Context

We want to avoid making accidental or unintended (potentially breaking) changes using those fields.

### Testing

Open each django admin detail page for the models listed in the issue and make sure the fields mentioned are read-only.

### Checklist

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
