### PR TITLE
Only send API key user part in email, not string representation of object

### DIFF
--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -2104,7 +2104,7 @@ def api_key(request):
         if result.get('credentials_generated'):
             new_credentials = form.credentials
             log.info(f'new JWT key created: {new_credentials}')
-            send_key_change_email(request.user.email, new_credentials)
+            send_key_change_email(request.user.email, new_credentials.key)
 
         if result.get('confirmation_created'):
             form.confirmation.send_confirmation_email()


### PR DESCRIPTION
We weren't including the secret in the string representation so it wasn't a security issue, but it was confusing and looked bad because the `<` and `>` characters were being escaped.

Fixes https://github.com/mozilla/addons/issues/15839