### PR TITLE
Remove dependabot cooldown for docker/docker-compose/github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,26 +5,16 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 99
-  cooldown:
-    default-days: 7
 - package-ecosystem: "docker-compose"
   directory: "/"
   schedule:
     interval: weekly
   open-pull-requests-limit: 99
-  cooldown:
-    default-days: 7
-    exclude:
-      - "mozilla/*"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
     interval: weekly
   open-pull-requests-limit: 99
-  cooldown:
-    default-days: 7
-    exclude:
-      - "mozilla/*"
 - package-ecosystem: "npm"
   directory: "/"
   schedule:


### PR DESCRIPTION
See https://github.com/mozilla/addons/issues/15855