### PR TITLE
Fix NARC scanning for add-ons w/ multiple authors including one with display_name=None

### DIFF
--- a/src/olympia/scanners/tasks.py
+++ b/src/olympia/scanners/tasks.py
@@ -230,7 +230,9 @@ def _run_narc(*, scanner_result, version, rules=None):
     attach_trans_dict(Addon, [addon], field_names=['name'])
     values_from_db = dict(addon.translations[addon.name_id])
     values_from_authors = list(
-        addon.authors.all().values_list('display_name', flat=True)
+        addon.authors.all()
+        .exclude(display_name=None)
+        .values_list('display_name', flat=True)
     )
 
     # Because we're running on a Version, not a FileUpload, we should already

--- a/src/olympia/scanners/tests/test_tasks.py
+++ b/src/olympia/scanners/tests/test_tasks.py
@@ -717,9 +717,11 @@ class TestRunNarc(UploadMixin, TestCase):
         user1 = user_factory(display_name='Foo')
         user2 = user_factory(display_name='FooBar')
         user3 = user_factory(display_name='Alice Foo')
+        user4 = user_factory(display_name=None)  # Shouldn't matter.
         self.addon.authors.add(user1)
         self.addon.authors.add(user2)
         self.addon.authors.add(user3)
+        self.addon.authors.add(user4)
         rule = ScannerRule.objects.create(
             name='match_the_fool',
             scanner=NARC,


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/15856

### Testing

- Create one add-on with 2 authors
- Set a `display_name` as normal for one, set the other one to `None` through a shell or something
- Run any NARC scanner query rule in the admin that would match this add-on in any way

Expected results:
- Your add-on should be found by the scan
- No errors should be seen in the celery logs

Actual results:
- The add-on is not found
- Errors are raised in the celery logs (in production this is also visible in Sentry)