### PR TITLE
Revert "Bump mozilla/addons-frontend from 2025.09.04-1 to 2025.09.19"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -179,7 +179,7 @@ services:
 
   addons-frontend:
     <<: *env
-    image: mozilla/addons-frontend:2025.09.19@sha256:3b47226d32c206fb4f15d6caded548f4c9a43cfd90fcc5f75ee9d7b68ef3f044
+    image: mozilla/addons-frontend:2025.09.04-1@sha256:742ea4b42378db0557b398f2be24427fe65af644498daf4c626aed5a34d63fe6
     platform: linux/amd64
     environment:
       # We change the proxy port (which is the main entrypoint) as well as the


### PR DESCRIPTION
Reverts mozilla/addons-server#23939

That image is still using Node 20.18 and causes issues locally.