### PR TITLE
Add is_signed to django admin FileInline

### DIFF
--- a/src/olympia/addons/admin.py
+++ b/src/olympia/addons/admin.py
@@ -106,6 +106,7 @@ class FileInline(admin.TabularInline):
         'version__channel',
         'version__deleted',
         'status',
+        'is_signed',
         'version__is_blocked',
         'version__needs_human_review',
     )


### PR DESCRIPTION
Fixes: mozilla/addons#15857

### Description

This adds the signed status of a file to its inline shown on the django admin add-ons detail page.

### Context

Useful for admins to identify signed but non-blocked files more quickly.

### Testing

1. Go to a django admin add-ons detail page, i.e. `/admin/models/addons/addon/<ID>/change/`
2. Scroll down to the "Files" section
3. Make sure you see an "IS SIGNED" column.


### Checklist

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
