### PR TITLE
Normalize emails before restricting them automatically in a scanner action

### DIFF
--- a/src/olympia/scanners/actions.py
+++ b/src/olympia/scanners/actions.py
@@ -101,7 +101,7 @@ def _restrict_future_approvals(*, version, rule, restriction_type):
     }
     for user in users:
         EmailUserRestriction.objects.get_or_create(
-            email_pattern=EmailUserRestriction.normalize_email(user.email),
+            email_pattern=user.email,
             restriction_type=restriction_type,
             defaults=restriction_defaults,
         )

--- a/src/olympia/users/models.py
+++ b/src/olympia/users/models.py
@@ -994,6 +994,15 @@ class NormalizeEmailMixin:
         return normalized_email
 
 
+class EmailUserRestrictionManager(ManagerBase):
+    def get_or_create(self, defaults=None, **kwargs):
+        if (email_pattern := kwargs.get('email_pattern')) and '@' in email_pattern:
+            kwargs['email_pattern'] = EmailUserRestriction.normalize_email(
+                email_pattern
+            )
+        return super().get_or_create(defaults=defaults, **kwargs)
+
+
 class EmailUserRestriction(RestrictionAbstractBaseModel, NormalizeEmailMixin):
     id = PositiveAutoField(primary_key=True)
     email_pattern = models.CharField(
@@ -1009,6 +1018,8 @@ class EmailUserRestriction(RestrictionAbstractBaseModel, NormalizeEmailMixin):
     error_message = _(
         'The email address used for your account is not allowed for submissions.'
     )
+
+    objects = EmailUserRestrictionManager()
 
     class Meta:
         db_table = 'users_user_email_restriction'

--- a/src/olympia/users/tests/test_models.py
+++ b/src/olympia/users/tests/test_models.py
@@ -1228,6 +1228,31 @@ class TestEmailUserRestriction(TestCase):
         obj = EmailUserRestriction.objects.create(email_pattern='fôo@bar.com')
         assert str(obj) == 'fôo@bar.com'
 
+    def test_get_or_create_normalization(self):
+        obj, created = EmailUserRestriction.objects.get_or_create(
+            email_pattern='foo+something@bar.com'
+        )
+        assert created
+        assert obj.email_pattern == 'foo@bar.com'
+
+        obj, created = EmailUserRestriction.objects.get_or_create(
+            email_pattern='foo@bar.com'
+        )
+        assert not created
+        assert obj.email_pattern == 'foo@bar.com'
+
+        obj, created = EmailUserRestriction.objects.get_or_create(
+            email_pattern='foo+else@bar.com'
+        )
+        assert not created
+        assert obj.email_pattern == 'foo@bar.com'
+
+        obj, created = EmailUserRestriction.objects.get_or_create(
+            email_pattern='different@bar.com'
+        )
+        assert created
+        assert obj.email_pattern == 'different@bar.com'
+
     def test_email_allowed(self):
         EmailUserRestriction.objects.create(email_pattern='foo@bar.com')
         request = RequestFactory().get('/')


### PR DESCRIPTION
We use `get_or_create()` but that's not enough as emails are normalized by the `save()` method.

Running the following will always raise in `get_or_create()`:
```python
EmailUserRestriction.objects.create(email_pattern='foo+variant@example.com')
# At this point we recorded a restriction for foo@example.com
EmailUserRestriction.objects.get_or_create(email_pattern='foo+variant@example.com')
```

The fix is to do this instead:
```python
EmailUserRestriction.objects.create(email_pattern='foo+variant@example.com')
# At this point we recorded a restriction for foo@example.com
EmailUserRestriction.objects.get_or_create(
    email_pattern=EmailUserRestriction.normalize_email('foo+variant@example.com')
)
```

Fixes https://github.com/mozilla/addons/issues/15833 (follow-up found by QA)