### PR TITLE
Fix versions not being flagged for review after 2nd level approval requeue

### DIFF
--- a/src/olympia/abuse/cinder.py
+++ b/src/olympia/abuse/cinder.py
@@ -16,7 +16,6 @@ from olympia.amo.utils import (
     create_signed_url_for_file_backup,
 )
 from olympia.users.utils import get_task_user
-from olympia.versions.models import Version
 
 
 log = olympia.core.logger.getLogger('z.abuse')
@@ -494,12 +493,22 @@ class CinderAddonHandledByReviewers(CinderAddon):
     # This queue is not monitored on cinder - reports are resolved via AMO instead
     queue_suffix = 'addon-infringement'
 
-    def __init__(self, addon, *, version_string=None):
+    def __init__(self, addon, *, versions_strings=None):
         super().__init__(addon)
-        self.version_string = version_string
+        self.versions_strings = versions_strings
+
+    def get_versions(self):
+        """Return Version queryset corresponding to the versions strings on
+        this instance."""
+        qs = self.addon.versions(manager='unfiltered_for_relations')
+        if self.versions_strings:
+            qs = qs.filter(version__in=self.versions_strings).no_transforms()
+        else:
+            qs = qs.none()
+        return qs
 
     def flag_for_human_review(
-        self, *, related_versions, appeal=False, forwarded=False, second_level=False
+        self, *, versions, appeal=False, forwarded=False, second_level=False
     ):
         """Flag an appropriate version for needs human review so it appears in reviewers
         manual revew queue.
@@ -539,46 +548,33 @@ class CinderAddonHandledByReviewers(CinderAddon):
             else NeedsHumanReview.REASONS.ABUSE_ADDON_VIOLATION
         )
 
-        version_objs = (
-            set(
-                self.addon.versions(manager='unfiltered_for_relations')
-                .filter(version__in=related_versions)
-                .no_transforms()
-            )
-            if related_versions
-            else set()
-        )
-        # If we have more versions specified than versions we flagged, flag current
-        # to be safe. (Either because there was an unknown version, or a None)
-        if len(version_objs) != len(related_versions) or len(related_versions) == 0:
+        # If we don't have versions, flag current to be safe.
+        # (There were either no specific version reported, or an unknown one)
+        if not versions:
             latest_or_current = self.addon.current_version or (
                 # for an appeal there may not be a current version, so look for others.
                 appeal
-                and (
-                    self.addon.versions(manager='unfiltered_for_relations')
-                    .filter(channel=amo.CHANNEL_LISTED)
-                    .no_transforms()
-                    .first()
+                and self.addon.find_latest_version(
+                    channel=amo.CHANNEL_LISTED, exclude=(), deleted=True
                 )
             )
             if latest_or_current:
-                version_objs.add(latest_or_current)
-        version_objs = sorted(version_objs, key=lambda v: v.id)
+                versions = [latest_or_current]
         log.debug(
             'Found %s versions potentially needing NHR [%s]',
-            len(version_objs),
-            ','.join(v.version for v in version_objs),
+            len(versions),
+            ','.join(v.version for v in versions),
         )
         existing_nhrs = {
             nhr.version
             for nhr in NeedsHumanReview.objects.filter(
-                version__in=version_objs, is_active=True, reason=reason
+                version__in=versions, is_active=True, reason=reason
             )
         }
         # We need custom save() and post_save to be triggered, so we can't
         # optimize this via bulk_create().
         nhr = None
-        for version in version_objs:
+        for version in versions:
             if version in existing_nhrs:
                 # if there's already an active NHR for this reason, don't duplicate it
                 continue
@@ -588,41 +584,46 @@ class CinderAddonHandledByReviewers(CinderAddon):
         if nhr:
             activity.log_create(
                 amo.LOG.NEEDS_HUMAN_REVIEW_CINDER,
-                *version_objs,
+                *versions,
                 details={'comments': nhr.get_reason_display()},
                 user=core.get_user() or get_task_user(),
             )
 
     def post_report(self, job):
         if not job.is_appeal:
-            self.flag_for_human_review(
-                related_versions={self.version_string}, appeal=False
-            )
+            self.flag_for_human_review(versions=self.get_versions(), appeal=False)
         # If our report was added to an appeal job (i.e. an appeal was ongoing,
         # and a report was made against the add-on), don't flag the add-on for
         # human review again: we should already have one because of the appeal.
 
     def appeal(self, *, decision_cinder_id, **kwargs):
-        if self.version_string:
-            # if this was a reporter appeal we have version_string from the abuse report
-            related_versions = {self.version_string}
+        if self.versions_strings:
+            # if this was a reporter appeal we have versions_strings from the abuse
+            # report and versions is good to go.
+            versions = self.get_versions()
         else:
-            # otherwise get the affected versions from the activity log
-            related_versions = set(
-                Version.unfiltered.filter(
-                    versionlog__activity_log__contentdecisionlog__decision__cinder_id=decision_cinder_id
-                ).values_list('version', flat=True)
+            # otherwise filter with the affected versions from the activity log
+            versions = (
+                self.addon.versions(manager='unfiltered_for_relations')
+                .filter(
+                    versionlog__activity_log__contentdecisionlog__decision__cinder_id=(
+                        decision_cinder_id
+                    )
+                )
+                .no_transforms()
             )
-        self.flag_for_human_review(related_versions=related_versions, appeal=True)
+        self.flag_for_human_review(versions=versions, appeal=True)
         return super().appeal(decision_cinder_id=decision_cinder_id, **kwargs)
 
     def post_queue_move(self, *, job, from_2nd_level=False):
         # When the move is to AMO reviewers we need to flag versions for review
-        reported_versions = set(
-            job.abusereport_set.values_list('addon_version', flat=True)
+        self.versions_strings = set(
+            job.abusereport_set.exclude(addon_version=None).values_list(
+                'addon_version', flat=True
+            )
         )
         self.flag_for_human_review(
-            related_versions=reported_versions,
+            versions=self.get_versions(),
             appeal=job.is_appeal,
             forwarded=True,
             second_level=from_2nd_level,

--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -153,7 +153,7 @@ class CinderJob(ModelBase):
         if isinstance(target, Addon):
             if resolved_in_reviewer_tools:
                 return CinderAddonHandledByReviewers(
-                    target, version_string=addon_version_string
+                    target, versions_strings=[addon_version_string]
                 )
             else:
                 return CinderAddon(target)
@@ -1410,7 +1410,7 @@ class ContentDecision(ModelBase):
             self.target, resolved_in_reviewer_tools=True
         )
         entity_helper.flag_for_human_review(
-            related_versions=self.target_versions.all(),
+            versions=self.target_versions.all(),
             appeal=job.is_appeal,
             second_level=True,
         )

--- a/src/olympia/abuse/tests/test_cinder.py
+++ b/src/olympia/abuse/tests/test_cinder.py
@@ -1185,7 +1185,9 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
             guid=addon.guid, addon_version=other_version.version
         )
         report = CinderReport(abuse_report)
-        cinder_instance = self.CinderClass(addon, version_string=other_version.version)
+        cinder_instance = self.CinderClass(
+            addon, versions_strings=[other_version.version]
+        )
         assert cinder_instance.report(report=report, reporter=None)
         job = CinderJob.objects.create(job_id='1234-xyz')
         assert not addon.current_version.needshumanreview_set.exists()
@@ -1224,8 +1226,8 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
         assert addon.current_version.reload().due_date
 
     def test_appeal_specific_version_from_report(self):
-        """For an appeal from a reporter, version_string is set on the CinderClass
-        instance, from AbuseReport.addon_version_string. If version_string is defined,
+        """For an appeal from a reporter, versions_strings is set on the CinderClass
+        instance, from AbuseReport.addon_version_string. If versions_strings is defined,
         and the version exists, we should flag that version rather than current_version.
         """
         addon = self._create_dummy_target()
@@ -1237,7 +1239,7 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
         self._test_appeal(
             CinderUser(user_factory()),
             cinder_entity_instance=self.CinderClass(
-                addon, version_string=other_version.version
+                addon, versions_strings=[other_version.version]
             ),
         )
         assert not addon.current_version.needshumanreview_set.exists()
@@ -1249,9 +1251,9 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
         assert other_version.reload().due_date
 
     def test_appeal_specific_version_from_action(self):
-        """For an appeal from a developer, version_string will be None on the
-        CinderClass instance. If version_string is falsey we collect and flag the addon
-        versions from the appealled decision rather the current_version."""
+        """For an appeal from a developer, versions_strings will be None on the
+        CinderClass instance. If versions_strings is falsey we collect and flag the
+        addon versions from the appealled decision rather the current_version."""
         addon = self._create_dummy_target()
         flagged_version = version_factory(
             addon=addon,
@@ -1262,13 +1264,13 @@ class TestCinderAddonHandledByReviewers(TestCinderAddon):
             action=DECISION_ACTIONS.AMO_DISABLE_ADDON, cinder_id='some_id', addon=addon
         )
         # An activity log links the flagged_version to the decision, even though the
-        # version_string on the CinderClass below is set to None
+        # versions_strings on the CinderClass below is set to None
         ActivityLog.objects.create(
             amo.LOG.FORCE_DISABLE, addon, flagged_version, decision, user=user_factory()
         )
         self._test_appeal(
             CinderUser(user_factory()),
-            cinder_entity_instance=self.CinderClass(addon, version_string=None),
+            cinder_entity_instance=self.CinderClass(addon, versions_strings=None),
             appealed_decision_id=decision.cinder_id,
         )
         assert not addon.current_version.needshumanreview_set.exists()

--- a/src/olympia/abuse/tests/test_models.py
+++ b/src/olympia/abuse/tests/test_models.py
@@ -3894,6 +3894,26 @@ class TestContentDecision(TestCase):
         assert job.decision == decision
         self._check_requeue_decision(job.final_decision, job, decision, user)
 
+    def test_requeue_held_action_existing_job_unlisted(self):
+        addon = addon_factory()
+        self.make_addon_unlisted(addon)
+        user = user_factory()
+        job = CinderJob.objects.create(target_addon=addon)
+        decision = ContentDecision.objects.create(
+            addon=addon,
+            action=DECISION_ACTIONS.AMO_DISABLE_ADDON,
+            reviewer_user=self.reviewer_user,
+            cinder_job=job,
+            cinder_id='1234',
+        )
+        decision.target_versions.add(addon.versions.get())
+
+        decision.requeue_held_action(user=user, notes='go!')
+
+        assert job.reload().resolvable_in_reviewer_tools is True
+        assert job.decision == decision
+        self._check_requeue_decision(job.final_decision, job, decision, user)        
+
     def test_get_target_review_url(self):
         addon = addon_factory()
         decision = ContentDecision.objects.create(

--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -1151,7 +1151,7 @@ class Addon(OnChangeMixin, ModelBase):
         )
 
     def find_latest_version(
-        self, channel, exclude=((amo.STATUS_DISABLED,)), deleted=False
+        self, *, channel, exclude=((amo.STATUS_DISABLED,)), deleted=False
     ):
         """Retrieve the latest version of an add-on for the specified channel.
 


### PR DESCRIPTION
Fixes mozilla/addons#15822

### Description

This refactors how versions are passed when flagging for review in `CinderAddonHandledByReviewers`, always passing down a `Version` queryset

### Context

We were expecting version strings in `flag_for_human_review()` (which is inefficient and confusing) but the requeue method was passing a Version queryset directly.

Later inside `flag_for_human_review()` there was a fallback that worked for the listed channel that caused us to flag the `current_version` (with further handling for the case where it's an appeal and there is no `current_version` anymore). But for unlisted, nothing, so we didn't flag anything.

### Testing

- Enable all DSA waffle switches
- Submit an add-on as unlisted (do not have a listed version!)
- Make that add-on promoted so that negative decisions are held for 2nd level approval
- Force-disable that add-on - the decision should be held for 2nd level approval
- In second level approval, requeue the decision

Expected result:
- You should see that add-on in the reviewer queue ; in the review page, the version should be flagged as needing human review, there should be an activity log explaining that it was requeued, and the version should have a due date

Actual result before this patch:
- None of that ^^
