### PR TITLE
Fix deletion of ScannerQueryRule with a lot of results

### DIFF
--- a/src/olympia/scanners/tests/test_admin.py
+++ b/src/olympia/scanners/tests/test_admin.py
@@ -1440,6 +1440,12 @@ class TestScannerQueryRuleAdmin(TestCase):
         assert response.status_code == 200
         doc = pq(response.content)
         assert doc('#content h1').text() == 'Are you sure?'
+        # Related objects (results) are not shown in the confirmation page to
+        # avoid issues when there are too many of them. So the lists in the
+        # response should only show the rule.
+        uls = doc('#content h2+ul')
+        assert uls[0].text_content().strip() == 'Scanner query rules: 1'
+        assert uls[1].text_content().strip() == 'Scanner query rule: bar'
 
         url = reverse('admin:scanners_scannerqueryrule_delete', args=(rule.pk,))
         response = self.client.post(url, {'post': 'yes'})


### PR DESCRIPTION
Uses the awkward but documented `get_deleted_objects()` Django hook to avoid displaying the related objects (in this case the results) which in turn makes the page load correctly.

Fixes https://github.com/mozilla/addons/issues/14918

### Testing

- Create and run a `ScannerQueryRule` that generates any number of results
- Once it's complete, delete it
- Confirmation page shouldn't show you the results (only the rule being deleted) and deletion should work
