### PR TITLE
Ask dependabot to ignore elasticsearch 9.x in docker_compose

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,10 @@ updates:
     exclude:
       - addons-frontend
   open-pull-requests-limit: 99
+  ignore:
+  - dependency-name: elasticsearch
+    versions:
+    - ">= 9"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
We don't need it yet (and we already ignore elasticsearch 9.x python packages) and it generates errors when dependabot is pulling data from docker hub...

We already asked dependabot to ignore it on past PRs but it was using a different dependency name as we were using the image from `elastic.co`.