### PR TITLE
Allow multiple BlocklistSubmission in parallel for the same version

### DIFF
--- a/src/olympia/blocklist/admin.py
+++ b/src/olympia/blocklist/admin.py
@@ -277,6 +277,10 @@ class BlocklistSubmissionAdmin(AMOModelAdmin):
             int(self.get_value('action', request, obj=obj, default=0))
             == BlocklistSubmission.ACTIONS.DELETE
         )
+        is_softening_submission = (
+            int(self.get_value('action', request, obj=obj, default=0))
+            == BlocklistSubmission.ACTIONS.SOFTEN
+        )
 
         input_guids_section = (
             'Input Guids',
@@ -331,11 +335,15 @@ class BlocklistSubmissionAdmin(AMOModelAdmin):
             },
         )
 
-        delay_section = not is_delete_submission and (
-            'Delay',
-            {
-                'fields': (*(('delay_days',) if is_new else ()), 'delayed_until'),
-            },
+        delay_section = (
+            not is_softening_submission
+            and not is_delete_submission
+            and (
+                'Delay',
+                {
+                    'fields': (*(('delay_days',) if is_new else ()), 'delayed_until'),
+                },
+            )
         )
 
         sections = (
@@ -350,6 +358,10 @@ class BlocklistSubmissionAdmin(AMOModelAdmin):
         is_delete_submission = (
             int(self.get_value('action', request, obj=obj, default=0))
             == BlocklistSubmission.ACTIONS.DELETE
+        )
+        is_softening_submission = (
+            int(self.get_value('action', request, obj=obj, default=0))
+            == BlocklistSubmission.ACTIONS.SOFTEN
         )
         ro_fields = [
             'ro_changed_version_ids',
@@ -369,6 +381,8 @@ class BlocklistSubmissionAdmin(AMOModelAdmin):
                 )
         if obj or is_delete_submission:
             ro_fields += ['block_type', 'delay_days']
+        elif is_softening_submission:
+            ro_fields += ['delay_days']
 
         return ro_fields
 

--- a/src/olympia/blocklist/forms.py
+++ b/src/olympia/blocklist/forms.py
@@ -214,7 +214,6 @@ class BlocklistSubmissionForm(AMOModelForm):
                         (version.id, version.version)
                         for version in block.addon_versions
                         if self.should_version_be_available_for_action(version)
-                        and not version.blocklist_submission_id
                     ],
                 )
                 for block in self.blocks

--- a/src/olympia/blocklist/models.py
+++ b/src/olympia/blocklist/models.py
@@ -94,11 +94,8 @@ class Block(ModelBase):
             .annotate(**{GUID: models.F(GUID)})
             .select_related('blockversion')
         )
-        all_submission_versions = BlocklistSubmission.get_all_submission_versions()
-
         all_addon_versions = defaultdict(list)
         for version in qs:
-            version.blocklist_submission_id = all_submission_versions.get(version.id, 0)
             all_addon_versions[getattr(version, GUID)].append(version)
         for block in blocks:
             block.addon_versions = all_addon_versions[block.guid]
@@ -249,7 +246,6 @@ class BlocklistSubmission(ModelBase):
             'is_blocked',
             'is_hard_blocked',
             'is_soft_blocked',
-            'blocklist_submission_id',
         ),
     )
     FakeBlock = namedtuple(
@@ -346,19 +342,6 @@ class BlocklistSubmission(ModelBase):
     def has_version_changes(self):
         return bool(self.changed_version_ids)
 
-    def has_potential_conflicts(self, *, ignoring=None):
-        """Check whether or not this blocklistsubmission contains versions that
-        are part of another non-published blocklistsubmission.
-
-        An optional list of blocklistsubmissions to ignore when performing
-        the check can be passed."""
-        if ignoring is None:
-            ignoring = [self]
-        if self.pk not in ignoring:
-            ignoring = ignoring + [self]
-        submissions = self.get_all_submission_versions(ignoring=ignoring)
-        return set(self.changed_version_ids) & set(submissions)
-
     def update_signoff_for_auto_approval(self, *, ignoring=None):
         """Update signoff state to auto-approved if possible.
 
@@ -368,12 +351,7 @@ class BlocklistSubmission(ModelBase):
         is_pending = self.signoff_state == self.SIGNOFF_STATES.PENDING
         add_action = self.action == self.ACTIONS.ADDCHANGE
         if is_pending and (
-            (
-                self.all_adu_safe()
-                and not self.has_potential_conflicts(ignoring=ignoring)
-            )
-            or add_action
-            and not self.has_version_changes()
+            (self.all_adu_safe()) or add_action and not self.has_version_changes()
         ):
             self.update(signoff_state=self.SIGNOFF_STATES.AUTOAPPROVED)
 
@@ -437,8 +415,6 @@ class BlocklistSubmission(ModelBase):
                 named=True,
             )
         )
-        all_submission_versions = cls.get_all_submission_versions()
-
         all_addon_versions = defaultdict(list)
         for version in version_qs:
             all_addon_versions[version.addon__addonguid__guid].append(
@@ -448,7 +424,6 @@ class BlocklistSubmission(ModelBase):
                     version.blockversion__block_id is not None,
                     version.blockversion__block_type == BlockType.BLOCKED,
                     version.blockversion__block_type == BlockType.SOFT_BLOCKED,
-                    all_submission_versions.get(version.id, 0),
                 )
             )
 
@@ -571,14 +546,11 @@ class BlocklistSubmission(ModelBase):
         ).filter(changed_version_ids__contains=version_id)
 
     @classmethod
-    def get_all_submission_versions(cls, *, ignoring=None):
-        if ignoring is None:
-            ignoring = []
+    def get_all_submission_versions(cls):
         submission_qs = (
             cls.objects.exclude(
                 signoff_state__in=cls.SIGNOFF_STATES.STATES_FINISHED.values
             )
-            .exclude(id__in=[ignored.id for ignored in ignoring])
             .values_list('id', 'changed_version_ids')
             .order_by('id')
         )

--- a/src/olympia/blocklist/models.py
+++ b/src/olympia/blocklist/models.py
@@ -342,17 +342,23 @@ class BlocklistSubmission(ModelBase):
     def has_version_changes(self):
         return bool(self.changed_version_ids)
 
-    def update_signoff_for_auto_approval(self, *, ignoring=None):
+    def update_signoff_for_auto_approval(self):
         """Update signoff state to auto-approved if possible.
 
         An optional list of blocklistsubmissions to ignore when performing
         the check for conflicts can be passed.
         """
+        # To be auto-approved, the submission needs to be pending and:
+        # - Either an addchange action with no version changes (just metadata
+        #   tweaks to a pending submission)
+        # - Or "adu safe", with all add-ons having fewer users than the
+        #   dual-signoff threshold.
         is_pending = self.signoff_state == self.SIGNOFF_STATES.PENDING
-        add_action = self.action == self.ACTIONS.ADDCHANGE
-        if is_pending and (
-            (self.all_adu_safe()) or add_action and not self.has_version_changes()
-        ):
+        safe_change = (
+            self.action == self.ACTIONS.ADDCHANGE and not self.has_version_changes()
+        )
+        safe_adu = self.all_adu_safe()
+        if is_pending and (safe_adu or safe_change):
             self.update(signoff_state=self.SIGNOFF_STATES.AUTOAPPROVED)
 
     @property

--- a/src/olympia/blocklist/tasks.py
+++ b/src/olympia/blocklist/tasks.py
@@ -328,12 +328,7 @@ def block_addons_on_user_ban(addonusers_ids, *, user_responsible_id):
     for banned_blocklist_submission in banned_blocklist_submissions:
         submission = banned_blocklist_submission.blocklistsubmission
         submission.save()
-        submission.update_signoff_for_auto_approval(
-            # We ignore conflicts caused by other submissions in this ban, we
-            # want them to be recorded separately for each user so that it can
-            # be undone individually if only one of them gets unbanned.
-            ignoring=[bb.blocklistsubmission for bb in banned_blocklist_submissions]
-        )
+        submission.update_signoff_for_auto_approval()
         if submission.is_submission_ready:
             process_blocklistsubmission.delay(submission.id)
 

--- a/src/olympia/blocklist/tasks.py
+++ b/src/olympia/blocklist/tasks.py
@@ -348,7 +348,6 @@ def revert_published_blocklist_submissions(submission_ids, *, user_responsible_i
         pk__in=submission_ids,
         signoff_state=BlocklistSubmission.SIGNOFF_STATES.PUBLISHED,
     )
-    new_submissions = []
     for submission in submissions:
         if submission.action == BlocklistSubmission.ACTIONS.ADDCHANGE:
             submission.action = BlocklistSubmission.ACTIONS.DELETE

--- a/src/olympia/blocklist/tasks.py
+++ b/src/olympia/blocklist/tasks.py
@@ -370,9 +370,6 @@ def revert_published_blocklist_submissions(submission_ids, *, user_responsible_i
         submission.reason = f'Revert "{submission.reason}"'
         submission.signoff_state = BlocklistSubmission.SIGNOFF_STATES.PENDING
         submission.save()
-        new_submissions.append(submission)
-
-    for submission in new_submissions:
-        submission.update_signoff_for_auto_approval(ignoring=new_submissions)
+        submission.update_signoff_for_auto_approval()
         if submission.is_submission_ready:
             process_blocklistsubmission.delay(submission.id)

--- a/src/olympia/blocklist/templates/admin/blocklist/widgets/blocks.html
+++ b/src/olympia/blocklist/templates/admin/blocklist/widgets/blocks.html
@@ -34,9 +34,6 @@
           {% else %}
             <span>
               {{ version.version }} ({% if version.is_blocked %}{{ version.blockversion.get_block_type_display }}{% else %}&#x1F7E2; Not Blocked{% endif %})
-              {% if version.blocklist_submission_id %}
-                [<a href="{% url 'admin:blocklist_blocklistsubmission_change' version.blocklist_submission_id %}">Edit Submission</a>]
-              {% endif %}
             </span>
           {% endif %}
           </li>

--- a/src/olympia/blocklist/tests/test_admin.py
+++ b/src/olympia/blocklist/tests/test_admin.py
@@ -390,11 +390,12 @@ class TestBlocklistSubmissionAdmin(TestCase):
             file_kw={'status': amo.STATUS_DISABLED},
         )
         ver_unlisted = version_factory(addon=addon, channel=amo.CHANNEL_UNLISTED)
-        # these next two versions shouldn't be possible choices
+        # This version has a submission already but it shouldn't matter.
         ver_add_subm = version_factory(addon=addon)
         BlocklistSubmission.objects.create(
             input_guids=addon.guid, changed_version_ids=[ver_add_subm.id]
         )
+        # This next version shouldn't be a possible choice because it's already blocked.
         ver_block = version_factory(addon=addon)
         block_factory(addon=addon, version_ids=[ver_block.id], updated_by=user)
         response = self.client.get(
@@ -422,6 +423,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
                     (ver.id, ver.version),
                     (ver_deleted.id, ver_deleted.version),
                     (ver_unlisted.id, ver_unlisted.version),
+                    (ver_add_subm.id, ver_add_subm.version),
                 ],
             )
         ]
@@ -459,12 +461,12 @@ class TestBlocklistSubmissionAdmin(TestCase):
             deleted=True,
             file_kw={'status': amo.STATUS_DISABLED},
         )
-        # these next three versions shouldn't be possible choices
         ver_add_subm = version_factory(addon=addon)
-        add_submission = BlocklistSubmission.objects.create(
+        BlocklistSubmission.objects.create(
             input_guids=addon.guid, changed_version_ids=[ver_add_subm.id]
         )
         ver_other = addon_factory(average_daily_users=99).current_version
+        # These next versions shouldn't be possible choices
         ver_block = version_factory(addon=ver_other.addon)
         ver_soft_block = version_factory(addon=ver_other.addon)
         block_factory(
@@ -474,27 +476,16 @@ class TestBlocklistSubmissionAdmin(TestCase):
 
         response = self.client.get(
             self.submission_url,
-            {'guids': f'{addon.guid}\n {ver_block.addon.guid}\n'},
+            {'guids': f'{addon.guid}\n {ver_other.addon.guid}\n'},
         )
         doc = pq(response.content.decode('utf-8'))
         checkboxes = doc('input[name=changed_version_ids]')
 
-        assert len(checkboxes) == 3
+        assert len(checkboxes) == 4
         check_checkbox(checkboxes[0], ver)
         check_checkbox(checkboxes[1], ver_deleted)
-        check_checkbox(checkboxes[2], ver_other)
-
-        # not a checkbox because already part of a submission, green circle
-        # because not blocked yet technically.
-        assert doc(f'li[data-version-id="{ver_add_subm.id}"]').text() == (
-            f'{ver_add_subm.version} (🟢 Not Blocked) [Edit Submission]'
-        )
-        submission_link = doc(f'li[data-version-id="{ver_add_subm.id}"] a')
-        assert submission_link.text() == 'Edit Submission'
-        assert submission_link.attr['href'] == reverse(
-            'admin:blocklist_blocklistsubmission_change',
-            args=(add_submission.id,),
-        )
+        check_checkbox(checkboxes[2], ver_add_subm)
+        check_checkbox(checkboxes[3], ver_other)
 
         # not a checkbox because blocked already and this is an add action
         assert doc(f'li[data-version-id="{ver_block.id}"]').text() == (
@@ -535,10 +526,6 @@ class TestBlocklistSubmissionAdmin(TestCase):
             file_kw={'status': amo.STATUS_DISABLED},
         )
         # these next three versions shouldn't be possible choices
-        ver_add_subm = version_factory(addon=addon)
-        add_submission = BlocklistSubmission.objects.create(
-            input_guids=addon.guid, changed_version_ids=[ver_add_subm.id]
-        )
         ver_other = addon_factory(average_daily_users=99).current_version
         ver_block = version_factory(addon=ver_other.addon)
         ver_soft_block = version_factory(addon=ver_other.addon)
@@ -560,18 +547,6 @@ class TestBlocklistSubmissionAdmin(TestCase):
         assert len(checkboxes) == 1
         check_checkbox(checkboxes[0], ver_soft_block)
 
-        # not a checkbox because already part of a submission, green circle
-        # because not blocked yet technically.
-        assert doc(f'li[data-version-id="{ver_add_subm.id}"]').text() == (
-            f'{ver_add_subm.version} (🟢 Not Blocked) [Edit Submission]'
-        )
-        submission_link = doc(f'li[data-version-id="{ver_add_subm.id}"] a')
-        assert submission_link.text() == 'Edit Submission'
-        assert submission_link.attr['href'] == reverse(
-            'admin:blocklist_blocklistsubmission_change',
-            args=(add_submission.id,),
-        )
-
         # not a checkbox because hard-blocked already and this is an harden
         # action
         assert doc(f'li[data-version-id="{ver_block.id}"]').text() == (
@@ -591,10 +566,6 @@ class TestBlocklistSubmissionAdmin(TestCase):
             file_kw={'status': amo.STATUS_DISABLED},
         )
         # these next three versions shouldn't be possible choices
-        ver_add_subm = version_factory(addon=addon)
-        add_submission = BlocklistSubmission.objects.create(
-            input_guids=addon.guid, changed_version_ids=[ver_add_subm.id]
-        )
         ver_other = addon_factory(average_daily_users=99).current_version
         ver_block = version_factory(addon=ver_other.addon)
         ver_soft_block = version_factory(addon=ver_other.addon)
@@ -615,18 +586,6 @@ class TestBlocklistSubmissionAdmin(TestCase):
 
         assert len(checkboxes) == 1
         check_checkbox(checkboxes[0], ver_block)
-
-        # not a checkbox because already part of a submission, green circle
-        # because not blocked yet technically.
-        assert doc(f'li[data-version-id="{ver_add_subm.id}"]').text() == (
-            f'{ver_add_subm.version} (🟢 Not Blocked) [Edit Submission]'
-        )
-        submission_link = doc(f'li[data-version-id="{ver_add_subm.id}"] a')
-        assert submission_link.text() == 'Edit Submission'
-        assert submission_link.attr['href'] == reverse(
-            'admin:blocklist_blocklistsubmission_change',
-            args=(add_submission.id,),
-        )
 
         # not a checkbox because soft-blocked already and this is an soften
         # action
@@ -1183,8 +1142,10 @@ class TestBlocklistSubmissionAdmin(TestCase):
                 'action': str(BlocklistSubmission.ACTIONS.SOFTEN),
             },
         )
-        doc = pq(response.content)
+        content = str(response.content)
+        doc = pq(content)
         assert doc('#id_block_type').attr('value') == str(BlockType.SOFT_BLOCKED)
+        assert 'id_delay_days' not in content
 
         response = self.client.post(
             self.submission_url,
@@ -1499,7 +1460,7 @@ class TestBlocklistSubmissionAdmin(TestCase):
         other_addon = addon_factory(users=[user2, user1], average_daily_users=666)
         author_admin_url = reverse('admin:users_userprofile_changelist')
 
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(10):
             # - 2 savepoints (tests)
             # - user
             # - groups
@@ -1507,7 +1468,6 @@ class TestBlocklistSubmissionAdmin(TestCase):
             # - add-ons translations
             # - add-ons authors
             # - add-ons blocks
-            # - blocklist submission
             # - versions
             # - review action reasons
             response = self.client.get(
@@ -2946,12 +2906,12 @@ class TestBlockAdminDelete(TestCase):
         addon = addon_factory(guid='guid@', average_daily_users=100)
         ver = addon.current_version
         ver_add_subm = version_factory(addon=addon)
-        add_submission = BlocklistSubmission.objects.create(
+        BlocklistSubmission.objects.create(
             input_guids=addon.guid, changed_version_ids=[ver_add_subm.id]
         )
         other_addon = addon_factory(average_daily_users=99)
         ver_del_subm = other_addon.current_version
-        del_submission = BlocklistSubmission.objects.create(
+        BlocklistSubmission.objects.create(
             input_guids=other_addon.guid,
             changed_version_ids=[ver_del_subm.id],
             action=BlocklistSubmission.ACTIONS.DELETE,
@@ -2975,27 +2935,25 @@ class TestBlockAdminDelete(TestCase):
         doc = pq(response.content.decode('utf-8'))
         checkboxes = doc('input[name=changed_version_ids]')
 
-        assert len(checkboxes) == 2
+        assert len(checkboxes) == 3
 
-        check_checkbox(checkboxes[0], ver_block)
+        check_checkbox(checkboxes[0], ver_del_subm)
         assert (
             checkboxes[0].getparent().text_content().strip()
-            == f'Unblock {ver_block.version} (🛑 Hard-Blocked)'
+            == f'Unblock {ver_del_subm.version} (🛑 Hard-Blocked)'
         )
-        check_checkbox(checkboxes[1], ver_soft_block)
+
+        check_checkbox(checkboxes[1], ver_block)
         assert (
             checkboxes[1].getparent().text_content().strip()
+            == f'Unblock {ver_block.version} (🛑 Hard-Blocked)'
+        )
+        check_checkbox(checkboxes[2], ver_soft_block)
+        assert (
+            checkboxes[2].getparent().text_content().strip()
             == f'Unblock {ver_soft_block.version} (⚠️ Soft-Blocked)'
         )
 
-        # not a checkbox because in a submission, green circle because not blocked
-        assert doc(f'li[data-version-id="{ver_add_subm.id}"]').text() == (
-            f'{ver_add_subm.version} (🟢 Not Blocked) [Edit Submission]'
-        )
-        # not a checkbox because in a submission, red hexagon because hard blocked
-        assert doc(f'li[data-version-id="{ver_del_subm.id}"]').text() == (
-            f'{ver_del_subm.version} (🛑 Hard-Blocked) [Edit Submission]'
-        )
         # not a checkbox because not blocked, and this is a delete action
         assert doc(f'li[data-version-id="{ver.id}"]').text() == (
             f'{ver.version} (🟢 Not Blocked)'
@@ -3010,19 +2968,6 @@ class TestBlockAdminDelete(TestCase):
         # whether versions are soft or hard blocked in the checkboxes above.
         assert doc('.field-block_type').text() == ''
         assert not doc('.field-block_type select')
-
-        submission_link = doc(f'li[data-version-id="{ver_add_subm.id}"] a')
-        assert submission_link.text() == 'Edit Submission'
-        assert submission_link.attr['href'] == reverse(
-            'admin:blocklist_blocklistsubmission_change',
-            args=(add_submission.id,),
-        )
-        submission_link = doc(f'li[data-version-id="{ver_del_subm.id}"] a')
-        assert submission_link.text() == 'Edit Submission'
-        assert submission_link.attr['href'] == reverse(
-            'admin:blocklist_blocklistsubmission_change',
-            args=(del_submission.id,),
-        )
 
     def test_edit_with_delete_submission(self):
         threshold = settings.DUAL_SIGNOFF_AVERAGE_DAILY_USERS_THRESHOLD

--- a/src/olympia/blocklist/tests/test_models.py
+++ b/src/olympia/blocklist/tests/test_models.py
@@ -231,7 +231,7 @@ class TestBlocklistSubmission(TestCase):
         addon1 = addon_factory(guid='guid1@example')
         addon2 = addon_factory(guid='guid2@example')
         addon_factory(guid='guid3@example')
-        duplicate_submission = BlocklistSubmission.objects.create(
+        BlocklistSubmission.objects.create(
             input_guids='guid1@example\nguid2@example',
             signoff_state=BlocklistSubmission.SIGNOFF_STATES.APPROVED,
             action=BlocklistSubmission.ACTIONS.ADDCHANGE,
@@ -258,12 +258,6 @@ class TestBlocklistSubmission(TestCase):
         assert BlocklistSubmission.get_all_submission_versions() == {
             addon1.current_version.pk: submission.pk,
             addon2.current_version.pk: submission.pk,
-        }
-        assert BlocklistSubmission.get_all_submission_versions(
-            ignoring=[submission]
-        ) == {
-            addon1.current_version.pk: duplicate_submission.pk,
-            addon2.current_version.pk: duplicate_submission.pk,
         }
 
     def test_update_signoff_for_auto_approval(self):
@@ -317,13 +311,12 @@ class TestBlocklistSubmission(TestCase):
     def test_update_signoff_for_auto_approval_has_conflicts(self):
         addon1 = addon_factory(guid='guid1@example', average_daily_users=42)
         addon2 = addon_factory(guid='guid2@example', average_daily_users=43)
-        duplicate_submission = BlocklistSubmission.objects.create(
+        BlocklistSubmission.objects.create(
             input_guids='guid1@example\nguid2@example',
             signoff_state=BlocklistSubmission.SIGNOFF_STATES.PENDING,
             action=BlocklistSubmission.ACTIONS.ADDCHANGE,
             changed_version_ids=[addon1.current_version.pk, addon2.current_version.pk],
         )
-        # This duplicate is already finished and shouldn't matter.
         BlocklistSubmission.objects.create(
             input_guids='guid1@example\nguid2@example',
             signoff_state=BlocklistSubmission.SIGNOFF_STATES.REJECTED,
@@ -337,13 +330,8 @@ class TestBlocklistSubmission(TestCase):
             changed_version_ids=[addon1.current_version.pk, addon2.current_version.pk],
         )
 
+        # Conflict doesn't matter.
         submission.update_signoff_for_auto_approval()
-        assert (
-            submission.reload().signoff_state
-            == BlocklistSubmission.SIGNOFF_STATES.PENDING
-        )
-
-        submission.update_signoff_for_auto_approval(ignoring=[duplicate_submission])
         assert (
             submission.reload().signoff_state
             == BlocklistSubmission.SIGNOFF_STATES.AUTOAPPROVED

--- a/src/olympia/blocklist/tests/test_utils.py
+++ b/src/olympia/blocklist/tests/test_utils.py
@@ -233,6 +233,55 @@ class TestSaveVersionsToBlocks(TestCase):
             == BlockType.SOFT_BLOCKED
         )
 
+    def test_save_blocks_adding_soft_block_on_existing_does_nothing(self):
+        # A BlocklistSubmission that uses the ADDCHANGE action to add a
+        # soft-block on top of an existing hard one should not do anything:
+        # only an explicit soften action should do that.
+        user_new = user_factory()
+        addon = addon_factory()
+        block_factory(guid=addon.guid, updated_by=self.task_user)
+        assert addon.current_version.blockversion.block_type == BlockType.BLOCKED
+        submission = BlocklistSubmission.objects.create(
+            action=BlocklistSubmission.ACTIONS.ADDCHANGE,
+            input_guids=addon.guid,
+            reason='some reason',
+            url=None,
+            updated_by=user_new,
+            block_type=BlockType.SOFT_BLOCKED,
+            changed_version_ids=[addon.current_version.pk],
+            signoff_state=BlocklistSubmission.SIGNOFF_STATES.PUBLISHED,
+        )
+        save_versions_to_blocks([addon.guid], submission)
+        assert (
+            addon.current_version.blockversion.reload().block_type == BlockType.BLOCKED
+        )
+
+    def test_save_blocks_adding_hard_block_on_existing_soft(self):
+        # A BlocklistSubmission that uses the ADDCHANGE action to add a
+        # hard-block on top of an existing soft one should work.
+        user_new = user_factory()
+        addon = addon_factory()
+        block_factory(
+            guid=addon.guid,
+            updated_by=self.task_user,
+            block_type=BlockType.SOFT_BLOCKED,
+        )
+        assert addon.current_version.blockversion.block_type == BlockType.SOFT_BLOCKED
+        submission = BlocklistSubmission.objects.create(
+            action=BlocklistSubmission.ACTIONS.ADDCHANGE,
+            input_guids=addon.guid,
+            reason='some reason',
+            url=None,
+            updated_by=user_new,
+            block_type=BlockType.BLOCKED,
+            changed_version_ids=[addon.current_version.pk],
+            signoff_state=BlocklistSubmission.SIGNOFF_STATES.PUBLISHED,
+        )
+        save_versions_to_blocks([addon.guid], submission)
+        assert (
+            addon.current_version.blockversion.reload().block_type == BlockType.BLOCKED
+        )
+
     @mock.patch('olympia.reviewers.utils.ReviewBase')
     def test_reviewbase_human_review_is_true_if_block_was_updated_by_human(
         self, review_base_mock

--- a/src/olympia/blocklist/utils.py
+++ b/src/olympia/blocklist/utils.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 import olympia.core.logger
 from olympia import amo
 from olympia.activity import log_create
+from olympia.constants.blocklist import BlockType
 from olympia.users.utils import get_task_user
 from olympia.versions.models import Version
 
@@ -14,8 +15,6 @@ log = olympia.core.logger.getLogger('z.amo.blocklist')
 
 
 def block_activity_log_save(obj, *, change, submission_obj):
-    from .models import BlockType
-
     action = amo.LOG.BLOCKLIST_BLOCK_EDITED if change else amo.LOG.BLOCKLIST_BLOCK_ADDED
     action_version = amo.LOG.BLOCKLIST_VERSION_BLOCKED
     addon_versions = {ver.id: ver.version for ver in obj.addon_versions}
@@ -203,18 +202,27 @@ def save_versions_to_blocks(guids, submission, *, overwrite_block_metadata=True)
         block_versions_to_update = []
         for version in block.addon_versions:
             if version.id in submission.changed_version_ids:
-                if version.is_blocked:
-                    block_version = version.blockversion
-                    block_versions_to_update.append(block_version)
-                else:
-                    block_version = BlockVersion(block=block, version=version)
+                if not version.is_blocked:
+                    # Version is not currently blocked, we can just create a
+                    # BlockVersion with the block_type of the submission.
+                    block_version = BlockVersion(
+                        block=block, version=version, block_type=submission.block_type
+                    )
                     block_versions_to_create.append(block_version)
                     version.blockversion = block_version
-                block_version.block_type = submission.block_type
+                # Version is already blocked: we need to check, soft-blocking a
+                # version already blocked should only be possible through a
+                # soften action, otherwise we need to skip.
+                elif (
+                    submission.block_type == BlockType.SOFT_BLOCKED
+                    and submission.action == submission.ACTIONS.SOFTEN
+                ) or (submission.block_type == BlockType.BLOCKED):
+                    block_version = version.blockversion
+                    block_version.block_type = submission.block_type
+                    block_versions_to_update.append(block_version)
+
         if not block_versions_to_create and not change:
             # If we have no versions to block and it's a new Block don't do anything.
-            # Note: we shouldn't have gotten this far with such a guid - it would have
-            # been raised as a validation error in the form.
             continue
         block.save()
         # Update existing BlockVersion in bulk - the only field to update is
@@ -297,8 +305,6 @@ def get_mlbf_base_id_config_key(block_type, compat: bool = False):
     This allows us to migrate writes to the new plural key right now without
     losing access to the old existing key when deploying this patch.
     """
-    from olympia.blocklist.models import BlockType
-
     if compat and block_type == BlockType.BLOCKED:
         return amo.config_keys.BLOCKLIST_MLBF_BASE_ID
     return getattr(amo.config_keys, f'BLOCKLIST_MLBF_BASE_ID_{block_type.name.upper()}')

--- a/src/olympia/users/tests/test_models.py
+++ b/src/olympia/users/tests/test_models.py
@@ -646,7 +646,7 @@ class TestUserProfile(TestCase):
             != user2.content_disabled_on_ban.blocked_addons_submissions.all()
         )
 
-    def test_ban_and_disable_related_content_bulk_with_hard_block_conflict_hold(self):
+    def test_ban_and_disable_related_content_bulk_with_hard_block_existing_sub(self):
         user_factory(pk=settings.TASK_USER_ID)
         fake_admin = user_factory(display_name='Fake Admin')
         core.set_user(fake_admin)
@@ -668,19 +668,34 @@ class TestUserProfile(TestCase):
         version = addon.current_version
         addon.reload()
         assert addon.status == amo.STATUS_DISABLED
+        assert version.reload().is_blocked
         submission = (
             BlocklistSubmission.objects.exclude(id=existing_submission.id)
             .filter(input_guids=addon.guid)
             .get()
         )
         assert submission.changed_version_ids == [version.pk]
-        assert submission.signoff_state == BlocklistSubmission.SIGNOFF_STATES.PENDING
+        assert submission.signoff_state == BlocklistSubmission.SIGNOFF_STATES.PUBLISHED
         assert submission.updated_by == fake_admin
-        assert not Block.objects.exists()
-        # BlocklistSubmission is still linked to the ban
         assert (
             user.content_disabled_on_ban.blocked_addons_submissions.get() == submission
         )
+
+        assert (
+            ActivityLog.objects.filter(action=amo.LOG.BLOCKLIST_BLOCK_ADDED.id).count()
+            == 1
+        )
+        activity = (
+            ActivityLog.objects.for_addons(addon)
+            .filter(action=amo.LOG.BLOCKLIST_BLOCK_ADDED.id)
+            .get()
+        )
+        assert activity.user == fake_admin
+        assert activity.arguments == [
+            addon,
+            addon.guid,
+            Block.objects.get(guid=addon.guid),
+        ]
 
     @mock.patch('olympia.users.models.download_file_contents_from_backup_storage')
     @mock.patch('olympia.users.models.backup_storage_enabled', lambda: True)

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -1099,21 +1099,6 @@ class Version(OnChangeMixin, ModelBase):
             self.is_blocked and self.blockversion.block_type == BlockType.SOFT_BLOCKED
         )
 
-    @cached_property
-    def blocklist_submission_id(self):
-        from olympia.blocklist.models import BlocklistSubmission
-
-        return (
-            submission.id
-            if self.id
-            and (
-                submission := BlocklistSubmission.get_submissions_from_version_id(
-                    self.id
-                ).last()
-            )
-            else 0
-        )
-
     @property
     def pending_rejection(self):
         try:


### PR DESCRIPTION
Conflicts are resolved automatically when setting up the block depending on the BlocklistSubmission action: an ADDCHANGE action is never allowed to "downgrade" a block_type, only an expicit SOFTEN can do that. In addition, adding a delay on a SOFTEN action is disallowed.

Fixes https://github.com/mozilla/addons/issues/16117