### PR TITLE
Bump yara-x to 2024.04.20

### DIFF
--- a/requirements/yara-x.txt
+++ b/requirements/yara-x.txt
@@ -1,3 +1,3 @@
 # our own fork of yara-x
-https://github.com/mozilla/yara-x/releases/download/2026.03.30/yara_x-1.14.0-cp38-abi3-manylinux_2_34_x86_64.whl \
-    --hash=sha256:7373882d4865b20ee301ec968b9425e6ee2619fc5753af3520fccfd790586b9c
+https://github.com/mozilla/yara-x/releases/download/2026.04.20/yara_x-1.15.0-cp38-abi3-manylinux_2_34_x86_64.whl \
+    --hash=sha256:60de977a01d13bf7cf6d185d5b7e67101ec1de9079840de44fb6c9708011ea1e


### PR DESCRIPTION
See: https://github.com/mozilla/yara-x/releases/tag/2026.04.20