### PR TITLE
Unblock addon versions from follow-up actions on appeal

### DIFF
--- a/src/olympia/abuse/actions.py
+++ b/src/olympia/abuse/actions.py
@@ -20,7 +20,7 @@ from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.amo.utils import send_mail
 from olympia.bandwagon.models import Collection
 from olympia.blocklist.models import BlocklistSubmission, BlockType
-from olympia.blocklist.utils import save_versions_to_blocks
+from olympia.blocklist.utils import delete_versions_from_blocks, save_versions_to_blocks
 from olympia.constants.abuse import DECISION_ACTIONS
 from olympia.constants.permissions import ADDONS_HIGH_IMPACT_APPROVE
 from olympia.files.models import File
@@ -634,8 +634,13 @@ class ContentActionRejectVersionDelayed(ContentActionRejectVersion):
 class ContentActionBlockAddon(ContentActionDisableAddon):
     description = 'Add-on has been (disabled and) blocked'
     block_type = BlockType.SOFT_BLOCKED
-    disable_too = True
     action = DECISION_ACTIONS.AMO_BLOCK_ADDON
+
+    @property
+    def updated_by_user_id(self):
+        # When the decision comes from Cinder it doesn't have a reviewer_user, so we use
+        # task user to avoid issues with null updated_by in Block save
+        return self.decision.reviewer_user_id or settings.TASK_USER_ID
 
     def should_hold_action(self):
         return bool(
@@ -677,7 +682,7 @@ class ContentActionBlockAddon(ContentActionDisableAddon):
                 [self.target.guid],
                 BlocklistSubmission(
                     block_type=self.block_type,
-                    updated_by=self.decision.reviewer_user,
+                    updated_by_id=self.updated_by_user_id,
                     reason=reason,
                     signoff_state=BlocklistSubmission.SIGNOFF_STATES.PUBLISHED,
                     changed_version_ids=[ver.pk for ver in versions],
@@ -718,7 +723,17 @@ class _ContentActionDelayedBlockAddon(ContentActionBlockAddon):
             )
 
     def process_action(self, release_hold=False):
-        versions = list(self.versions_block_will_affect)
+        versions_qs = self.versions_block_will_affect
+        # if this is a followup action, and the primary action is rejecting specific
+        # versions, we want to limit the blocking to those versions.
+        if self.decision.action in (
+            DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON,
+            DECISION_ACTIONS.AMO_REJECT_VERSION_WARNING_ADDON,
+        ):
+            versions_qs = versions_qs.filter(
+                id__in=self.decision.target_versions.values_list('id', flat=True)
+            )
+        versions = list(versions_qs)
         if versions:
             reason = (
                 "This add-on violates Mozilla's add-on policies by including or using "
@@ -728,7 +743,7 @@ class _ContentActionDelayedBlockAddon(ContentActionBlockAddon):
             submission = BlocklistSubmission(
                 input_guids=self.target.guid,
                 block_type=self.block_type,
-                updated_by=self.decision.reviewer_user,
+                updated_by_id=self.updated_by_user_id,
                 reason=reason,
                 signoff_state=BlocklistSubmission.SIGNOFF_STATES.AUTOAPPROVED,
                 changed_version_ids=[ver.pk for ver in versions],
@@ -740,6 +755,52 @@ class _ContentActionDelayedBlockAddon(ContentActionBlockAddon):
             submission.save()
 
         return None
+
+    @classmethod
+    def reverse_action(cls, original_decision):
+        # Note: when the original primary action was ContentDisableAddon, the versions
+        # blocked may have been more than target_versions, but we're leaving the other
+        # versions blocked.
+        guid = original_decision.target.guid
+        versions = original_decision.target_versions.all()
+        # First unblock any versions that have already been blocked
+        already_blocked_version_ids = list(
+            versions.filter(blockversion__block_type=cls.block_type).values_list(
+                'id', flat=True
+            )
+        )
+        not_blocked_version_ids = set(
+            versions.exclude(id__in=already_blocked_version_ids).values_list(
+                'id', flat=True
+            )
+        )
+        delete_versions_from_blocks(
+            [guid],
+            BlocklistSubmission(
+                input_guids=guid,
+                action=BlocklistSubmission.ACTIONS.DELETE,
+                updated_by_id=cls(original_decision).updated_by_user_id,
+                signoff_state=BlocklistSubmission.SIGNOFF_STATES.AUTOAPPROVED,
+                changed_version_ids=already_blocked_version_ids,
+                preserve_block_metadata=True,
+            ),
+        )
+        # Then cancel any upcoming BlocklistSubmissions that have yet to execute
+        upcoming_submissions = BlocklistSubmission.objects.filter(
+            input_guids=guid, block_type=cls.block_type
+        ).exclude(signoff_state=BlocklistSubmission.SIGNOFF_STATES.PUBLISHED)
+        for submission in upcoming_submissions:
+            submission_version_ids = set(submission.changed_version_ids)
+            if not_blocked_version_ids == submission_version_ids:
+                # all versions are in the submission, so we can just delete it.
+                submission.delete()
+            elif not_blocked_version_ids & submission_version_ids:
+                # otherwise, there's some crossover so remove offending versions.
+                submission.update(
+                    changed_version_ids=list(
+                        submission_version_ids - not_blocked_version_ids
+                    )
+                )
 
     def get_owners(self):
         # TODO: Define our own email strategy and template copy
@@ -922,9 +983,11 @@ class ContentActionTargetAppealApprove(
     @property
     def previous_decisions(self):
         """Queryset with previous decisions made that this action would revert."""
-        return self.decision.cinder_job.appealed_decisions
+        return self.decision.cinder_job.appealed_decisions.all()
 
     def process_action(self, release_hold=False):
+        from olympia.abuse.models import ContentDecisionFollowupAction
+
         target = self.target
         log_entry = None
         if isinstance(target, Addon):
@@ -943,11 +1006,20 @@ class ContentActionTargetAppealApprove(
                 or DECISION_ACTIONS.AMO_BLOCK_ADDON in previous_decision_actions
             ):
                 # FIXME: we should also automatically revert the block if the
-                # previous decision was AMO_BLOCK_ADDON.
+                # previous decision was AMO_BLOCK_ADDON. (i.e. reverse_action)
                 target_versions = list(target_versions)
                 if target.status == amo.STATUS_DISABLED:
                     target.force_enable(skip_activity_log=True)
                 activity_log_action = amo.LOG.FORCE_ENABLE
+
+            # TODO: rewrite the rest of this function to use per-class reverse_action.
+            for prev_decision in self.previous_decisions:
+                FollowUpActionClass = CONTENT_ACTION_FROM_DECISION_ACTION[
+                    prev_decision.action
+                ]
+                if hasattr(FollowUpActionClass, 'reverse_action'):
+                    FollowUpActionClass.reverse_action(prev_decision)
+
             if DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON in previous_decision_actions:
                 target_versions = list(
                     target_versions.filter(
@@ -1026,6 +1098,16 @@ class ContentActionTargetAppealApprove(
                     'is_flagged': target.ratingflag_set.exists(),
                 },
             )
+
+        # follow-up actions
+        followup_actions = ContentDecisionFollowupAction.objects.filter(
+            decision__in=self.previous_decisions, action_date__isnull=False
+        )
+        for followup_action in followup_actions:
+            FollowUpActionClass = CONTENT_ACTION_FROM_DECISION_ACTION[
+                followup_action.action
+            ]
+            FollowUpActionClass.reverse_action(followup_action.decision)
 
         return log_entry
 

--- a/src/olympia/abuse/tests/test_actions.py
+++ b/src/olympia/abuse/tests/test_actions.py
@@ -59,7 +59,14 @@ from ..actions import (
     ContentActionTargetAppealApprove,
     ContentActionTargetAppealRemovalAffirmation,
 )
-from ..models import AbuseReport, CinderAppeal, CinderJob, CinderPolicy, ContentDecision
+from ..models import (
+    AbuseReport,
+    CinderAppeal,
+    CinderJob,
+    CinderPolicy,
+    ContentDecision,
+    ContentDecisionFollowupAction,
+)
 
 
 class BaseTestContentAction:
@@ -2057,7 +2064,7 @@ class TestContentActionDelayedShortSoftBlockAddon(BaseTestContentAction, TestCas
             (self.version, self.old_version)
         )
 
-    def test_process_action(self):
+    def _test_process_action(self, version_ids):
         assert not BlocklistSubmission.objects.exists()
         action_helper = self.ActionClass(self.decision)
         assert action_helper.action == self.takedown_decision_action
@@ -2072,15 +2079,12 @@ class TestContentActionDelayedShortSoftBlockAddon(BaseTestContentAction, TestCas
                 'average_daily_users': self.addon.average_daily_users,
             }
         ]
-        assert submission.changed_version_ids == [
-            self.another_version.id,
-            self.version.id,
-        ]
+        assert submission.changed_version_ids == version_ids
         assert submission.block_type == self.block_type
         assert (
             submission.signoff_state == BlocklistSubmission.SIGNOFF_STATES.AUTOAPPROVED
         )
-        assert submission.updated_by == self.decision.reviewer_user
+        assert submission.updated_by == self.task_user
         assert submission.disable_addon is False
         assert submission.preserve_block_metadata is True
         assert submission.disable_versions is False
@@ -2089,9 +2093,36 @@ class TestContentActionDelayedShortSoftBlockAddon(BaseTestContentAction, TestCas
             submission.delayed_until,
             now=datetime.now() + timedelta(days=self.ActionClass.delay_days),
         )
+
+    def test_process_action_standalone(self):
+        # Note: this isn't currently a codepath that's possible - the class is only used
+        # as a follow-up action.
+        self.decision.update(action=self.takedown_decision_action)
+        assert not self.decision.target_versions.exists()
+        self._test_process_action([self.another_version.id, self.version.id])
+        # shouldn't change the addon or version.file statues.
         assert self.addon.status != amo.STATUS_DISABLED
         assert self.version.file.status != amo.STATUS_DISABLED
         assert self.old_version.file.status != amo.STATUS_DISABLED
+
+    def test_process_action_followup_from_disable_addon(self):
+        self.decision.update(action=DECISION_ACTIONS.AMO_DISABLE_ADDON)
+        self.addon.update(status=amo.STATUS_DISABLED)
+        # typically this _would_ be set, but it shouldn't be used anyway
+        assert not self.decision.target_versions.exists()
+        # we're expecting all the non-blocked versions to be blocked
+        self._test_process_action([self.another_version.id, self.version.id])
+
+    def test_process_action_followup_from_reject_version(self):
+        self.decision.update(action=DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON)
+        self.version.file.update(status=amo.STATUS_DISABLED)
+        self.old_version.file.update(status=amo.STATUS_DISABLED)
+        # we're setting it up as if ContentActionRejectVersion was rejecting version and
+        # old_version, but not another_version.
+        self.decision.target_versions.set((self.version, self.old_version))
+        # but we expect the follow-up action to ignore old_version since it's already
+        # blocked, (and another_version because it's not being rejected)
+        self._test_process_action([self.version.id])
 
     def test_owner_content_approve_report_email(self):
         pass  # Covered by TestContentApproveContentListing
@@ -2099,13 +2130,95 @@ class TestContentActionDelayedShortSoftBlockAddon(BaseTestContentAction, TestCas
     def test_reporter_ignore_invalid_report(self):
         pass  # Covered by TestContentApproveContentListing
 
+    def _test_approve_appeal_or_override(self, ActionClass):
+        yet_another_version = version_factory(addon=self.addon)
+        self.decision.update(action=DECISION_ACTIONS.AMO_APPROVE)
+        self.past_negative_decision.target_versions.set(
+            (self.version, self.another_version)
+        )
+        BlockVersion.objects.create(
+            block=self.existing_block,
+            version=self.version,
+            block_type=self.block_type,
+        )
+        BlocklistSubmission.objects.create(
+            input_guids=self.addon.guid,
+            block_type=self.block_type,
+            updated_by_id=self.task_user.id,
+            signoff_state=BlocklistSubmission.SIGNOFF_STATES.AUTOAPPROVED,
+            changed_version_ids=[self.another_version.id, yet_another_version.id],
+            disable_addon=False,
+            disable_versions=False,
+            delayed_until=datetime.now() + timedelta(days=1),
+            preserve_block_metadata=True,
+        )
+        assert (
+            BlockVersion.objects.filter(
+                block__guid=self.addon.guid, block_type=self.block_type
+            )
+            .exclude(version=self.old_version)
+            .count()
+            == 1
+        )
+        assert (
+            BlocklistSubmission.objects.filter(input_guids=self.addon.guid).count() == 1
+        )
+
+        action_helper = ActionClass(self.decision)
+        action_helper.process_action()
+
+        # Block was deleted
+        assert (
+            not BlockVersion.objects.filter(
+                block__guid=self.addon.guid, block_type=self.block_type
+            )
+            .exclude(version=self.old_version)
+            .exists()
+        )
+        # we didn't delete the blocklistsubmission
+        assert (
+            BlocklistSubmission.objects.filter(input_guids=self.addon.guid).count() == 1
+        )
+        # but modified it to remove the version
+        assert BlocklistSubmission.objects.get().changed_version_ids == [
+            yet_another_version.id
+        ]
+
     def test_approve_appeal_success(self):
-        self.past_negative_decision.update(appeal_job=self.cinder_job)
-        # TODO: we don't support appeals or overrides for follow-up actions yet
+        self.past_negative_decision.update(
+            appeal_job=self.cinder_job, action=self.takedown_decision_action
+        )
+        self._test_approve_appeal_or_override(ContentActionTargetAppealApprove)
+        # TODO: once we add support for emails, re-enable this?
+        # assert 'After reviewing your appeal' in mail.outbox[0].body
 
     def test_approve_override_success(self):
         self.decision.update(override_of=self.past_negative_decision)
-        # TODO: we don't support appeals or overrides for follow-up actions yet
+        self.past_negative_decision.update(action=self.takedown_decision_action)
+        self._test_approve_appeal_or_override(ContentActionOverrideApprove)
+        # TODO: once we add support for emails, re-enable this?
+        # assert 'After reviewing your appeal' not in mail.outbox[0].body
+
+    def test_approve_appeal_success_followup(self):
+        self.past_negative_decision.update(
+            appeal_job=self.cinder_job, action=DECISION_ACTIONS.AMO_DISABLE_ADDON
+        )
+        ContentDecisionFollowupAction.objects.create(
+            decision=self.past_negative_decision,
+            action=self.takedown_decision_action,
+            action_date=datetime.now(),
+        )
+        self._test_approve_appeal_or_override(ContentActionTargetAppealApprove)
+
+    def test_approve_override_success_followup(self):
+        self.decision.update(override_of=self.past_negative_decision)
+        self.past_negative_decision.update(action=DECISION_ACTIONS.AMO_DISABLE_ADDON)
+        ContentDecisionFollowupAction.objects.create(
+            decision=self.past_negative_decision,
+            action=self.takedown_decision_action,
+            action_date=datetime.now(),
+        )
+        self._test_approve_appeal_or_override(ContentActionOverrideApprove)
 
     def test_email_content_not_escaped(self):
         # TODO: If/when we support emails we should implement this

--- a/src/olympia/blocklist/utils.py
+++ b/src/olympia/blocklist/utils.py
@@ -263,6 +263,7 @@ def delete_versions_from_blocks(guids, submission):
     modified_datetime = datetime.now()
 
     blocks = Block.get_blocks_from_guids(guids)
+    should_override_block_metadata = not submission.preserve_block_metadata
     for block in blocks:
         if not block.id:
             continue
@@ -275,10 +276,11 @@ def delete_versions_from_blocks(guids, submission):
         if BlockVersion.objects.filter(block=block).exists():
             # if there are still other versions blocked update the metadata
             block.updated_by = submission.updated_by
-            if submission.reason is not None:
-                block.reason = submission.reason
-            if submission.url is not None:
-                block.url = submission.url
+            if should_override_block_metadata:
+                if submission.reason is not None:
+                    block.reason = submission.reason
+                if submission.url is not None:
+                    block.url = submission.url
             block.average_daily_users_snapshot = block.current_adu
             block.save()
             should_delete = False


### PR DESCRIPTION
Fixes: mozilla/addons#16119

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Adds appeal support for follow-up actions - which are (currently) delayed block actions.  Blocked versions are unblocked; pending BlocklistSubmissions are deleted or amended.

### Context

In this patch I added a `reverse_action` to the ContentActionDelayedXxxYyyBlockAddon classes, because I didn't like how `ContentActionTargetAppealApprove.process_action` was getting longer and longer. The thinking was that we can delegate the reversal of an action to the class that executed it.  If it seems like a good model we can rewrite the other actions to work the same way.  Though it's not without it's problems - we often want different functionality (e.g. target_versions; emails) for an appeal that reverses an action compared to the initial action.

Follow-up actions are always executed after a primary action.  The filtering in the view prevents any of `AMO_FU_DELAY_XXX_YYY_BLOCK_ADDON` decision actions from being primary actions, but I've attempted to write the action class support so if it _was_ executed as a primary action the appeal would still work.

### Testing

- report an add-on
- add or one more enforcement actions to a policy in Cinder
  - e.g. short soft block + mid hard block
- process the job in cinder using that policy
- replay the webhook locally
  - double check the payload that all the enforcement actions are there
  - existing functionality: 
    - you will have to 2nd level approve if the add-on is promoted
    - the add-on should be disabled
    - there should be follow-up actions executed - 2 pending (delayed) blocklistsubmissions if you followed the e.g.
- to test all the functionality (i.e. the block deletes too), edit one of the blocklistsubmissions to remove the delayed date and save, so the block is added immediately
  - check that block exists now in django admin
- appeal the decision with the link from the email in admin
- process the appeal in Cinder, overriding the decision, to Approve
- replay the webhook to process the appeal
- the add-on should be re-enabed
- the block should be removed
- the blocksubmission should be deleted

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [ ] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
