### PR TITLE
AMOENG-2475 - Use the correct FxA endpoints for the contact support form (stage/prod)

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -115,7 +115,7 @@ DATABASES = {
 FXA_CONTENT_HOST = 'https://accounts.stage.mozaws.net'
 FXA_OAUTH_HOST = 'https://oauth.stage.mozaws.net/v1'
 FXA_PROFILE_HOST = 'https://profile.stage.mozaws.net/v1'
-FXA_SUPPORT_HOST = 'https://accounts.stage.mozaws.net/v1'
+FXA_SUPPORT_HOST = 'https://api-accounts.stage.mozaws.net/v1'
 
 # Set CSP like we do for dev/stage/prod, but also allow GA over http + www subdomain
 # for local development.

--- a/src/olympia/conf/dev/settings.py
+++ b/src/olympia/conf/dev/settings.py
@@ -69,7 +69,7 @@ FXA_CONFIG = {
 FXA_CONTENT_HOST = 'https://accounts.stage.mozaws.net'
 FXA_OAUTH_HOST = 'https://oauth.stage.mozaws.net/v1'
 FXA_PROFILE_HOST = 'https://profile.stage.mozaws.net/v1'
-FXA_SUPPORT_HOST = 'https://accounts.stage.mozaws.net/v1'
+FXA_SUPPORT_HOST = 'https://api-accounts.stage.mozaws.net/v1'
 
 SITEMAP_DEBUG_AVAILABLE = True
 

--- a/src/olympia/devhub/tasks.py
+++ b/src/olympia/devhub/tasks.py
@@ -713,8 +713,4 @@ def create_support_ticket(access_token, payload, **kw):
         json=payload,
         timeout=10,
     )
-    if response.status_code not in (200, 201):
-        log.warning(
-            'create_support_ticket: FxA support endpoint returned %s',
-            response.status_code,
-        )
+    response.raise_for_status()

--- a/src/olympia/devhub/tests/test_tasks.py
+++ b/src/olympia/devhub/tests/test_tasks.py
@@ -1065,6 +1065,7 @@ class TestCreateSupportTicket(TestCase):
     @mock.patch('olympia.devhub.tasks.requests.post')
     def test_success(self, mock_post):
         mock_post.return_value = mock.MagicMock(status_code=201)
+        mock_post.return_value.raise_for_status.return_value = None
         tasks.create_support_ticket('mytoken', self.payload)
         mock_post.assert_called_once_with(
             mock_post.call_args[0][0],
@@ -1074,11 +1075,13 @@ class TestCreateSupportTicket(TestCase):
         )
 
     @mock.patch('olympia.devhub.tasks.requests.post')
-    def test_fxa_error_logs_warning(self, mock_post):
+    def test_fxa_error_raises(self, mock_post):
+        import requests as req
+
         mock_post.return_value = mock.MagicMock(status_code=500)
-        # Should not raise, just log
-        tasks.create_support_ticket('mytoken', self.payload)
-        mock_post.assert_called_once()
+        mock_post.return_value.raise_for_status.side_effect = req.HTTPError('500')
+        with self.assertRaises(req.HTTPError):
+            tasks.create_support_ticket('mytoken', self.payload)
 
     @mock.patch('olympia.devhub.tasks.requests.post')
     def test_network_error_triggers_retry(self, mock_post):

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1411,7 +1411,7 @@ DEFAULT_FXA_CONFIG_NAME = 'default'
 FXA_CONTENT_HOST = 'https://accounts.firefox.com'
 FXA_OAUTH_HOST = 'https://oauth.accounts.firefox.com/v1'
 FXA_PROFILE_HOST = 'https://profile.accounts.firefox.com/v1'
-FXA_SUPPORT_HOST = 'https://accounts.firefox.com/v1'
+FXA_SUPPORT_HOST = 'https://api.accounts.firefox.com/v1'
 FXA_SUPPORT_BRAND_ID = 47184764139412  # Zendesk brand: "Firefox Add-on Support"
 
 USE_FAKE_FXA_AUTH = False  # Should only be True for local development envs.


### PR DESCRIPTION
Fixes: AMOENG-2475

### Description

Dev/Stage/Prod need to use the correct FxA endpoints in order to create zendesk tickets via the contact support form.

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.