### PR TITLE
Add logic to find actions that can be automatically executed from a list of policies

### DIFF
--- a/src/olympia/abuse/actions.py
+++ b/src/olympia/abuse/actions.py
@@ -822,13 +822,7 @@ class ContentActionRejectListingContent(ContentActionDisableAddon):
     @classmethod
     def should_be_skipped_by_automation(cls, *, addon, version, **kwargs):
         # Only consider this action in automation if the version is listed.
-        return (
-            super().should_be_skipped_by_automation(
-                addon=addon, version=version, **kwargs
-            )
-            if version.channel == amo.CHANNEL_LISTED
-            else True
-        )
+        return version.channel != amo.CHANNEL_LISTED
 
     def should_hold_action(self):
         return bool(

--- a/src/olympia/abuse/actions.py
+++ b/src/olympia/abuse/actions.py
@@ -103,6 +103,11 @@ class ContentAction:
         without further checks, and true if it should be held for further review."""
         return False
 
+    @classmethod
+    def should_be_skipped_by_automation(cls, **kwargs):
+        """Return True if the action should be skipped by automation for any reason."""
+        return False
+
     def process_action(self, release_hold=False):
         """This method should return an activity log instance for the action,
         if available."""
@@ -644,6 +649,24 @@ class ContentActionBlockAddon(ContentActionDisableAddon):
             and any(self.target.promoted_groups(currently_approved=False).high_profile)
         )
 
+    @classmethod
+    def should_be_skipped_by_automation(cls, *, addon, version, **kwargs):
+        from olympia.abuse.models import ContentDecision
+
+        # Because this action is very aggressive, we skip it if either:
+        # - There been a successful appeal against *any* "negative" decision
+        #   on this add-on before
+        # - The addon belong to a UsageTier where this action is not available
+        usage_tier = addon.get_usage_tier()
+        successful_appeal = ContentDecision.objects.filter(
+            addon=addon,
+            action__in=DECISION_ACTIONS.NON_OFFENDING.values,
+            cinder_job__appealed_decisions__action__in=DECISION_ACTIONS.REMOVING.values,
+        )
+        return successful_appeal or (
+            usage_tier and not usage_tier.disable_and_block_action_available
+        )
+
     @property
     def versions_block_will_affect(self):
         """Return all versions that will be blocked by this action."""
@@ -745,6 +768,12 @@ class _ContentActionDelayedBlockAddon(ContentActionBlockAddon):
         # TODO: Define our own email strategy and template copy
         return ()
 
+    @classmethod
+    def should_be_skipped_by_automation(cls, **kwargs):
+        # Follow-up blocks shouldn't be skipped by automation, they are not the
+        # main action.
+        return False
+
 
 class ContentActionDelayedShortSoftBlockAddon(_ContentActionDelayedBlockAddon):
     block_type = BlockType.SOFT_BLOCKED
@@ -789,6 +818,17 @@ class ContentActionRejectListingContent(ContentActionDisableAddon):
     @property
     def target_versions(self):
         return self.decision.target_versions.none()
+
+    @classmethod
+    def should_be_skipped_by_automation(cls, *, addon, version, **kwargs):
+        # Only consider this action in automation if the version is listed.
+        return (
+            super().should_be_skipped_by_automation(
+                addon=addon, version=version, **kwargs
+            )
+            if version.channel == amo.CHANNEL_LISTED
+            else True
+        )
 
     def should_hold_action(self):
         return bool(

--- a/src/olympia/abuse/admin.py
+++ b/src/olympia/abuse/admin.py
@@ -16,6 +16,7 @@ from olympia import amo
 from olympia.addons.models import Addon, AddonApprovalsCounter
 from olympia.amo.admin import AMOModelAdmin, DateRangeFilter, FakeChoicesMixin
 from olympia.amo.templatetags.jinja_helpers import vite_asset
+from olympia.constants.abuse import DECISION_ACTIONS
 from olympia.ratings.models import Rating
 from olympia.translations.utils import truncate_text
 
@@ -374,6 +375,7 @@ class CinderPolicyAdmin(AMOModelAdmin):
         'name',
         'text',
         'expose_in_reviewer_tools',
+        'pretty_enforcement_actions',
         'present_in_cinder',
     )
     list_display = (
@@ -383,7 +385,7 @@ class CinderPolicyAdmin(AMOModelAdmin):
         'linked_review_reasons',
         'expose_in_reviewer_tools',
         'present_in_cinder',
-        'enforcement_actions',
+        'pretty_enforcement_actions',
         'text',
     )
     readonly_fields = tuple(set(fields) - {'expose_in_reviewer_tools'})
@@ -396,6 +398,17 @@ class CinderPolicyAdmin(AMOModelAdmin):
 
     def has_delete_permission(self, request, obj=None):
         return False
+
+    @admin.display(description='Enforcement actions')
+    def pretty_enforcement_actions(self, obj):
+        return ', '.join(
+            [
+                DECISION_ACTIONS.from_api_value(action).label
+                if action in DECISION_ACTIONS.api_values
+                else f'Unknown ({action})'
+                for action in obj.enforcement_actions
+            ]
+        )
 
     @admin.display(ordering='reviewactionreason__name')
     def linked_review_reasons(self, obj):

--- a/src/olympia/abuse/tests/test_actions.py
+++ b/src/olympia/abuse/tests/test_actions.py
@@ -412,6 +412,11 @@ class BaseTestContentAction:
             mail.outbox[0].body
         )
 
+    def test_should_be_skipped_by_automation(self):
+        # should_be_skipped_by_automation is a classmethod, default is to
+        # return False.
+        assert not self.ActionClass.should_be_skipped_by_automation()
+
 
 class TestContentActionBanUser(BaseTestContentAction, TestCase):
     ActionClass = ContentActionBanUser
@@ -2023,6 +2028,80 @@ class TestContentActionBlockAddon(TestContentActionDisableAddon):
             'Parent Policy, specifically Bad policy: This is a Térrible thing'
         ]
 
+    def test_should_be_skipped_by_automation(self):
+        # ContentActionBlockAddon.should_be_skipped_by_automation() needs the
+        # addon and version to be passed.
+        assert not self.ActionClass.should_be_skipped_by_automation(
+            addon=self.addon, version=self.version
+        )
+
+        # Any successful appeal against negative decision on the add-on in the
+        # past causes it to return True.
+        appeal_decision = ContentDecision.objects.create(
+            addon=self.addon,
+            action=DECISION_ACTIONS.AMO_APPROVE,
+            cinder_job=CinderJob.objects.create(target_addon=self.addon),
+        )
+        original_decision = ContentDecision.objects.create(
+            addon=self.addon,
+            action=DECISION_ACTIONS.AMO_DISABLE_ADDON,
+            appeal_job=appeal_decision.cinder_job,
+        )
+        assert self.ActionClass.should_be_skipped_by_automation(
+            addon=self.addon, version=self.version
+        )
+
+        original_decision.update(action=DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON)
+        assert self.ActionClass.should_be_skipped_by_automation(
+            addon=self.addon, version=self.version
+        )
+
+        original_decision.update(action=DECISION_ACTIONS.AMO_BLOCK_ADDON)
+        assert self.ActionClass.should_be_skipped_by_automation(
+            addon=self.addon, version=self.version
+        )
+
+    def test_should_be_skipped_by_automation_non_negative_appeal(self):
+        appeal_decision = ContentDecision.objects.create(
+            addon=self.addon,
+            action=DECISION_ACTIONS.AMO_IGNORE,
+            cinder_job=CinderJob.objects.create(target_addon=self.addon),
+        )
+        ContentDecision.objects.create(
+            addon=self.addon,
+            action=DECISION_ACTIONS.AMO_APPROVE,
+            appeal_job=appeal_decision.cinder_job,
+        )
+        assert not self.ActionClass.should_be_skipped_by_automation(
+            addon=self.addon, version=self.version
+        )
+
+    def test_should_be_skipped_by_automation_unsuccessful_appeal(self):
+        appeal_decision = ContentDecision.objects.create(
+            addon=self.addon,
+            action=DECISION_ACTIONS.AMO_DISABLE_ADDON,
+            cinder_job=CinderJob.objects.create(target_addon=self.addon),
+        )
+        ContentDecision.objects.create(
+            addon=self.addon,
+            action=DECISION_ACTIONS.AMO_DISABLE_ADDON,
+            appeal_job=appeal_decision.cinder_job,
+        )
+        assert not self.ActionClass.should_be_skipped_by_automation(
+            addon=self.addon, version=self.version
+        )
+
+    def test_should_be_skipped_by_automation_unresolved_appeal(self):
+        appeal_job = CinderJob.objects.create(target_addon=self.addon)
+        ContentDecision.objects.create(
+            addon=self.addon,
+            action=DECISION_ACTIONS.AMO_DISABLE_ADDON,
+            appeal_job=appeal_job,
+        )
+        assert not self.ActionClass.should_be_skipped_by_automation(
+            addon=self.addon, version=self.version
+        )
+
 
 class TestContentActionDelayedShortSoftBlockAddon(BaseTestContentAction, TestCase):
     ActionClass = ContentActionDelayedShortSoftBlockAddon
@@ -2536,6 +2615,16 @@ class TestContentActionRejectListingContent(TestContentActionDisableAddon):
         self.cinder_job.notify_reporters(action_helper)
         action_helper.notify_owners()
         self._test_owner_affirmation_email(f'Mozilla Add-ons: {self.addon.name}')
+
+    def test_should_be_skipped_by_automation(self):
+        assert not self.ActionClass.should_be_skipped_by_automation(
+            addon=self.addon, version=self.version
+        )
+
+        self.version.update(channel=amo.CHANNEL_UNLISTED)
+        assert self.ActionClass.should_be_skipped_by_automation(
+            addon=self.addon, version=self.version
+        )
 
 
 class TestContentActionCollection(BaseTestContentAction, TestCase):

--- a/src/olympia/abuse/tests/test_utils.py
+++ b/src/olympia/abuse/tests/test_utils.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+from unittest import mock
 
 from django.conf import settings
 from django.core import mail
@@ -9,15 +10,22 @@ import responses
 
 from olympia import amo
 from olympia.activity.models import ActivityLog
-from olympia.amo.tests import addon_factory, user_factory, version_factory
+from olympia.amo.tests import TestCase, addon_factory, user_factory, version_factory
 from olympia.bandwagon.models import Collection
 from olympia.blocklist.models import Block, BlockType, BlockVersion
+from olympia.constants.abuse import DECISION_ACTIONS
 from olympia.constants.promoted import PROMOTED_GROUP_CHOICES
 from olympia.promoted.models import PromotedGroup
 from olympia.ratings.models import Rating
 
-from ..models import ContentDecision
-from ..utils import get_instance_from_entity, is_same_time, reject_and_block_addons
+from ..actions import ContentActionBlockAddon
+from ..models import CinderJob, CinderPolicy, ContentDecision
+from ..utils import (
+    find_automated_enforcement_actions_from_policies,
+    get_instance_from_entity,
+    is_same_time,
+    reject_and_block_addons,
+)
 
 
 @pytest.mark.django_db
@@ -130,3 +138,253 @@ def test_is_same_time():
     assert is_same_time(addon, str(addon.created))
     assert not is_same_time(addon, str(addon.created.replace(year=2000)))
     assert is_same_time(addon, str(addon.created.replace(microsecond=1234)))
+
+
+class TestFindAutomatedEnforcementActionsFromPolicies(TestCase):
+    def setUp(self):
+        self.addon = addon_factory()
+        self.version = self.addon.current_version
+
+    def test_find_nothing(self):
+        mild_things_policy = CinderPolicy.objects.create(
+            uuid=uuid.uuid4().hex,
+            name='Mild Things',
+            enforcement_actions=[],
+        )
+        invalid_action_policy = CinderPolicy.objects.create(
+            uuid=uuid.uuid4().hex,
+            name='Invalid Things',
+            enforcement_actions=['not-a-valid-action'],
+        )
+        actions, followup_actions = find_automated_enforcement_actions_from_policies(
+            policies=[mild_things_policy, invalid_action_policy],
+            addon=self.addon,
+            version=self.version,
+        )
+        assert actions == []
+        assert followup_actions == []
+
+    def test_basic(self):
+        bad_things_policy = CinderPolicy.objects.create(
+            uuid=uuid.uuid4().hex,
+            name='Very Bad Things',
+            enforcement_actions=[DECISION_ACTIONS.AMO_DISABLE_ADDON.api_value],
+        )
+        slightly_less_bad_things_policy = CinderPolicy.objects.create(
+            uuid=uuid.uuid4().hex,
+            name='Slightly Less Bad Things',
+            enforcement_actions=[DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON.api_value],
+        )
+        actions, followup_actions = find_automated_enforcement_actions_from_policies(
+            policies=[bad_things_policy, slightly_less_bad_things_policy],
+            addon=self.addon,
+            version=self.version,
+        )
+        assert actions == [DECISION_ACTIONS.AMO_DISABLE_ADDON]
+        assert followup_actions == []
+
+    def test_block_wins(self):
+        bad_things_policy = CinderPolicy.objects.create(
+            uuid=uuid.uuid4().hex,
+            name='Very Bad Things',
+            enforcement_actions=[DECISION_ACTIONS.AMO_DISABLE_ADDON.api_value],
+        )
+        extremely_bad_things_policy = CinderPolicy.objects.create(
+            uuid=uuid.uuid4().hex,
+            name='Extremely Bad Things',
+            enforcement_actions=['amo-block-addon'],
+        )
+        actions, followup_actions = find_automated_enforcement_actions_from_policies(
+            policies=[bad_things_policy, extremely_bad_things_policy],
+            addon=self.addon,
+            version=self.version,
+        )
+        assert actions == [DECISION_ACTIONS.AMO_BLOCK_ADDON]
+        assert followup_actions == []
+
+    def test_ordering_with_follow_up_action_against_not(self):
+        bad_things_policy = CinderPolicy.objects.create(
+            uuid=uuid.uuid4().hex,
+            name='Very Bad Things',
+            enforcement_actions=[DECISION_ACTIONS.AMO_DISABLE_ADDON.api_value],
+        )
+        bad_things_policy_with_more_aggressive_followup = CinderPolicy.objects.create(
+            uuid=uuid.uuid4().hex,
+            name='Very Bad Things, But Worse',
+            enforcement_actions=[
+                DECISION_ACTIONS.AMO_DISABLE_ADDON.api_value,
+                'amo-fu-delay-short-soft-block-addon',
+            ],
+        )
+        actions, followup_actions = find_automated_enforcement_actions_from_policies(
+            policies=[
+                bad_things_policy,
+                bad_things_policy_with_more_aggressive_followup,
+            ],
+            addon=self.addon,
+            version=self.version,
+        )
+        assert actions == [DECISION_ACTIONS.AMO_DISABLE_ADDON]
+        assert followup_actions == [
+            DECISION_ACTIONS.AMO_FU_DELAY_SHORT_SOFT_BLOCK_ADDON
+        ]
+
+    def test_ordering_with_two_follow_up_actions_compared(self):
+        bad_things_policy = CinderPolicy.objects.create(
+            uuid=uuid.uuid4().hex,
+            name='Very Bad Things',
+            enforcement_actions=[
+                DECISION_ACTIONS.AMO_DISABLE_ADDON.api_value,
+                'amo-fu-delay-short-soft-block-addon',
+            ],
+        )
+        bad_things_policy_with_more_aggressive_followup = CinderPolicy.objects.create(
+            uuid=uuid.uuid4().hex,
+            name='Very Bad Things, But Worse',
+            enforcement_actions=[
+                DECISION_ACTIONS.AMO_DISABLE_ADDON.api_value,
+                'amo-fu-delay-short-hard-block-addon',
+            ],
+        )
+        actions, followup_actions = find_automated_enforcement_actions_from_policies(
+            policies=[
+                bad_things_policy,
+                bad_things_policy_with_more_aggressive_followup,
+            ],
+            addon=self.addon,
+            version=self.version,
+        )
+        assert actions == [DECISION_ACTIONS.AMO_DISABLE_ADDON]
+        assert followup_actions == [
+            DECISION_ACTIONS.AMO_FU_DELAY_SHORT_HARD_BLOCK_ADDON
+        ]
+
+    def test_ordering_with_two_follow_up_actions_compared_different_delay(self):
+        bad_things_policy = CinderPolicy.objects.create(
+            uuid=uuid.uuid4().hex,
+            name='Very Bad Things',
+            enforcement_actions=[
+                DECISION_ACTIONS.AMO_DISABLE_ADDON.api_value,
+                'amo-fu-delay-short-soft-block-addon',
+            ],
+        )
+        bad_things_policy_with_less_delayed_followup = CinderPolicy.objects.create(
+            uuid=uuid.uuid4().hex,
+            name='Very Bad Things, But Slightly Worse',
+            enforcement_actions=[
+                DECISION_ACTIONS.AMO_DISABLE_ADDON.api_value,
+                'amo-fu-delay-mid-hard-block-addon',
+            ],
+        )
+        actions, followup_actions = find_automated_enforcement_actions_from_policies(
+            policies=[bad_things_policy, bad_things_policy_with_less_delayed_followup],
+            addon=self.addon,
+            version=self.version,
+        )
+        assert actions == [DECISION_ACTIONS.AMO_DISABLE_ADDON]
+        assert followup_actions == [
+            DECISION_ACTIONS.AMO_FU_DELAY_SHORT_SOFT_BLOCK_ADDON
+        ]
+
+    def test_ordering_with_multiple_followup_actions(self):
+        bad_things_policy = CinderPolicy.objects.create(
+            uuid=uuid.uuid4().hex,
+            name='Very Bad Things',
+            enforcement_actions=[
+                DECISION_ACTIONS.AMO_DISABLE_ADDON.api_value,
+                'amo-fu-delay-short-soft-block-addon',
+                'amo-fu-delay-mid-hard-block-addon',
+            ],
+        )
+        bad_things_policy_with_delayed_followup = CinderPolicy.objects.create(
+            uuid=uuid.uuid4().hex,
+            name='Very Bad Things, But Slightly Worse',
+            enforcement_actions=[
+                DECISION_ACTIONS.AMO_DISABLE_ADDON.api_value,
+                'amo-fu-delay-mid-hard-block-addon',
+            ],
+        )
+        actions, followup_actions = find_automated_enforcement_actions_from_policies(
+            policies=[bad_things_policy, bad_things_policy_with_delayed_followup],
+            addon=self.addon,
+            version=self.version,
+        )
+        assert actions == [DECISION_ACTIONS.AMO_DISABLE_ADDON]
+        assert followup_actions == [
+            DECISION_ACTIONS.AMO_FU_DELAY_SHORT_SOFT_BLOCK_ADDON,
+            DECISION_ACTIONS.AMO_FU_DELAY_MID_HARD_BLOCK_ADDON,
+        ]
+
+    @mock.patch.object(
+        ContentActionBlockAddon,
+        'should_be_skipped_by_automation',
+        lambda **kwargs: True,
+    )
+    def test_skip_action_that_should_be_skipped_by_automation(self):
+        bad_things_policy = CinderPolicy.objects.create(
+            uuid=uuid.uuid4().hex,
+            name='Very Bad Things',
+            enforcement_actions=[
+                DECISION_ACTIONS.AMO_DISABLE_ADDON.api_value,
+            ],
+        )
+        worse_things_policy_that_should_be_skipped = CinderPolicy.objects.create(
+            uuid=uuid.uuid4().hex,
+            name='Worse Things',
+            enforcement_actions=[
+                # ContentActionBlockAddon.should_be_skipped_by_automation()
+                # is mocked to return True so that should be skipped.
+                'amo-block-addon',
+            ],
+        )
+        actions, followup_actions = find_automated_enforcement_actions_from_policies(
+            policies=[bad_things_policy, worse_things_policy_that_should_be_skipped],
+            addon=self.addon,
+            version=self.version,
+        )
+        assert actions == [DECISION_ACTIONS.AMO_DISABLE_ADDON]
+        assert followup_actions == []
+
+    def test_skip_policy_with_multiple_primary_actions(self):
+        broken_policy = CinderPolicy.objects.create(
+            uuid=uuid.uuid4().hex,
+            name='Multiple Relevant Enforcement Actions Policy',
+            enforcement_actions=[
+                DECISION_ACTIONS.AMO_DISABLE_ADDON.api_value,
+                'amo-block-addon',
+            ],
+        )
+        actions, followup_actions = find_automated_enforcement_actions_from_policies(
+            policies=[broken_policy],
+            addon=self.addon,
+            version=self.version,
+        )
+        assert actions == []
+        assert followup_actions == []
+
+    def test_skip_policy_if_successful_appeal_for_it_in_the_past(self):
+        appealed_policy = CinderPolicy.objects.create(
+            uuid=uuid.uuid4().hex,
+            name='Policy that has been successfully appealed in the past',
+            enforcement_actions=[
+                DECISION_ACTIONS.AMO_DISABLE_ADDON.api_value,
+            ],
+        )
+        appeal_decision = ContentDecision.objects.create(
+            addon=self.addon,
+            action=DECISION_ACTIONS.AMO_APPROVE,
+            cinder_job=CinderJob.objects.create(target_addon=self.addon),
+        )
+        original_decision = ContentDecision.objects.create(
+            addon=self.addon,
+            action=DECISION_ACTIONS.AMO_DISABLE_ADDON,
+            appeal_job=appeal_decision.cinder_job,
+        )
+        original_decision.policies.add(appealed_policy)
+        actions, followup_actions = find_automated_enforcement_actions_from_policies(
+            policies=[appealed_policy],
+            addon=self.addon,
+            version=self.version,
+        )
+        assert actions == []
+        assert followup_actions == []

--- a/src/olympia/abuse/tests/test_views.py
+++ b/src/olympia/abuse/tests/test_views.py
@@ -39,7 +39,12 @@ from ..actions import (
     ContentActionTargetAppealRemovalAffirmation,
 )
 from ..models import AbuseReport, CinderAppeal, CinderJob, ContentDecision
-from ..views import CinderInboundPermission, cinder_webhook, filter_enforcement_actions
+from ..views import (
+    CinderInboundPermission,
+    cinder_webhook,
+    filter_enforcement_actions,
+    to_enforcement_actions,
+)
 
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -1235,16 +1240,25 @@ class TestCinderWebhook(TestCase):
             None,
         )
 
-    def test_filter_enforcement_actions(self):
+    def test_to_enforcement_actions_and_filter_enforcement_actions(self):
         addon = addon_factory()
         assert filter_enforcement_actions([], addon) == ([], [])
 
-        actions_from_json = [
-            'amo-disable-addon',
-            'amo-ban-user',
-            'amo-approve',
-            'not-amo-action',  # not a valid action at all
-            'amo-fu-delay-mid-soft-block-addon',  # valid, but not a supported action
+        actions_from_json = to_enforcement_actions(
+            [
+                'amo-disable-addon',
+                'amo-ban-user',
+                'amo-approve',
+                'not-amo-action',  # not a valid action at all
+                # valid, but not a primary action
+                'amo-fu-delay-mid-soft-block-addon',
+            ]
+        )
+        assert actions_from_json == [
+            DECISION_ACTIONS.AMO_DISABLE_ADDON,
+            DECISION_ACTIONS.AMO_BAN_USER,
+            DECISION_ACTIONS.AMO_APPROVE,
+            DECISION_ACTIONS.AMO_FU_DELAY_MID_SOFT_BLOCK_ADDON,
         ]
         assert filter_enforcement_actions(actions_from_json, addon) == (
             [
@@ -1252,6 +1266,8 @@ class TestCinderWebhook(TestCase):
                 # no AMO_BAN_USER action because not a user target
                 DECISION_ACTIONS.AMO_APPROVE,
             ],
+            # AMO_FU_DELAY_MID_SOFT_BLOCK_ADDON action is returned in the
+            # second list since it's a follow-up action
             [DECISION_ACTIONS.AMO_FU_DELAY_MID_SOFT_BLOCK_ADDON],
         )
 

--- a/src/olympia/abuse/utils.py
+++ b/src/olympia/abuse/utils.py
@@ -1,3 +1,4 @@
+import itertools
 from datetime import datetime
 
 from django.conf import settings
@@ -67,3 +68,94 @@ def is_same_time(instance, created_string):
     instance_time = instance.created.replace(microsecond=0)
     string_time = datetime.fromisoformat(created_string).replace(microsecond=0)
     return instance_time == string_time
+
+
+def filter_enforcement_actions(enforcement_actions, target):
+    """Filter enforcement action enums according to what is applicable to the
+    specified target. Return a list of primary actions, follow-up actions."""
+    from .actions import CONTENT_ACTION_FROM_DECISION_ACTION
+
+    if not target:
+        return [], []
+    primary_cinder_actions = []
+    followup_actions = []
+    for action in enforcement_actions:
+        if (
+            target.__class__
+            not in CONTENT_ACTION_FROM_DECISION_ACTION[action.value].valid_targets
+        ):
+            continue
+        if action.value in DECISION_ACTIONS.FOLLOWUP_CINDER_ACTIONS.values:
+            followup_actions.append(action)
+        else:
+            primary_cinder_actions.append(action)
+    return primary_cinder_actions, followup_actions
+
+
+def to_enforcement_actions(enforcement_actions_slugs):
+    """Convert enforcement action slugs into enforcement action enums."""
+    return [
+        action
+        for action_slug in enforcement_actions_slugs
+        if action_slug in DECISION_ACTIONS.api_values
+        and (action := DECISION_ACTIONS.from_api_value(action_slug))
+    ]
+
+
+def find_automated_enforcement_actions_from_policies(*, policies, addon, version):
+    """Function to return what enforcement actions automation should use based
+    on policies that were hit for a given add-on and version.
+
+    We remove policies for a decision that a successful appeal against, filter
+    out any non-applicable actions, and return the most aggressive
+    action + follow-up actions we are left with.
+
+    Return a list itself made of a list of actions and a list of follow-up actions."""
+    from .actions import CONTENT_ACTION_FROM_DECISION_ACTION
+    from .models import CinderPolicy, ContentDecision
+
+    def addon_negative_actions_priority_from_iterable(actions):
+        return [
+            DECISION_ACTIONS.ADDON_NEGATIVE_SORTED.values.index(action)
+            for action in itertools.chain.from_iterable(actions)
+        ]
+
+    # Default is to return no action + no follow-up actions
+    most_aggressive_actions = [[], []]
+    for policy in policies:
+        # Successful appeal for that same decision against the add-on (ignoring
+        # versions) means we should skip automation.
+        successful_appeal = ContentDecision.objects.filter(
+            addon=addon,
+            action__in=DECISION_ACTIONS.NON_OFFENDING.values,
+            cinder_job__appealed_decisions__policies=policy,
+        ).exists()
+        if successful_appeal:
+            continue
+
+        actions = CinderPolicy.get_decision_actions_from_policies(
+            [policy], for_entity=addon.__class__
+        )
+        primary_enforcement_actions, followup_actions = filter_enforcement_actions(
+            actions, addon
+        )
+        if len(primary_enforcement_actions) != 1:
+            # That shouldn't happen: scanner rules should only have policies
+            # that have relevant actions for add-ons (and only 1 primary action
+            # for add-ons should be set)
+            continue
+        action = primary_enforcement_actions[0]
+        ContentActionClass = CONTENT_ACTION_FROM_DECISION_ACTION[action]
+        if (
+            action not in DECISION_ACTIONS.ADDON_NEGATIVE_SORTED
+            or ContentActionClass.should_be_skipped_by_automation(
+                addon=addon, version=version
+            )
+        ):
+            continue
+
+        if addon_negative_actions_priority_from_iterable(
+            (primary_enforcement_actions, followup_actions)
+        ) > addon_negative_actions_priority_from_iterable(most_aggressive_actions):
+            most_aggressive_actions = [primary_enforcement_actions, followup_actions]
+    return most_aggressive_actions

--- a/src/olympia/abuse/views.py
+++ b/src/olympia/abuse/views.py
@@ -21,6 +21,7 @@ from rest_framework.viewsets import GenericViewSet
 
 import olympia.core.logger
 from olympia.abuse.tasks import appeal_to_cinder
+from olympia.abuse.utils import filter_enforcement_actions, to_enforcement_actions
 from olympia.accounts.utils import redirect_for_login
 from olympia.accounts.views import AccountViewSet
 from olympia.addons.views import AddonViewSet
@@ -31,7 +32,6 @@ from olympia.core import set_user
 from olympia.ratings.views import RatingViewSet
 from olympia.users.models import UserProfile
 
-from .actions import CONTENT_ACTION_FROM_DECISION_ACTION
 from .cinder import CinderAddon, CinderAddonContentReview
 from .forms import AbuseAppealEmailForm, AbuseAppealForm
 from .models import AbuseReport, CinderJob, ContentDecision
@@ -192,26 +192,6 @@ class CinderWebhookMissingIdError(CinderWebhookError):
         return settings.CINDER_UNIQUE_IDS
 
 
-def filter_enforcement_actions(enforcement_actions, target):
-    if not target:
-        return [], []
-    primary_cinder_actions = []
-    followup_actions = []
-    for action_slug in enforcement_actions:
-        if (
-            action_slug not in DECISION_ACTIONS.api_values
-            or not (action := DECISION_ACTIONS.from_api_value(action_slug))
-            or target.__class__
-            not in CONTENT_ACTION_FROM_DECISION_ACTION[action.value].valid_targets
-        ):
-            continue
-        if action.value in DECISION_ACTIONS.FOLLOWUP_CINDER_ACTIONS.values:
-            followup_actions.append(action)
-        else:
-            primary_cinder_actions.append(action)
-    return primary_cinder_actions, followup_actions
-
-
 def get_job_from_payload(payload):
     if job_id := payload.get('source', {}).get('job', {}).get('id'):
         try:
@@ -277,7 +257,7 @@ def process_webhook_payload_decision(payload):
     )
 
     cinder_actions, followup_actions = filter_enforcement_actions(
-        payload.get('enforcement_actions') or [],
+        to_enforcement_actions(payload.get('enforcement_actions')) or [],
         target,
     )
     policy_ids = [policy['id'] for policy in payload.get('policies', [])]

--- a/src/olympia/constants/abuse.py
+++ b/src/olympia/constants/abuse.py
@@ -94,6 +94,31 @@ DECISION_ACTIONS.add_subset(
         'AMO_FU_DELAY_LONG_HARD_BLOCK_ADDON',
     ),
 )
+DECISION_ACTIONS.add_subset(
+    # This subset holds all "negative" actions we can use against add-ons or
+    # their versions, ordered from least aggressive to most. Scanners will use
+    # this list and its ordering to determine which action and follow-up
+    # actions to automatically take when a policy violation is found.
+    'ADDON_NEGATIVE_SORTED',
+    (
+        # Follow-up actions also influence the order, because we might have
+        # the choice between an immediate reject and a short soft-block and
+        # an immediate reject and a short hard-block. We obviously consider a
+        # hard-block as more aggressive than a soft one, but also a short delay
+        # more aggressive than a mid or long one.
+        'AMO_FU_DELAY_LONG_SOFT_BLOCK_ADDON',
+        'AMO_FU_DELAY_LONG_HARD_BLOCK_ADDON',
+        'AMO_FU_DELAY_MID_SOFT_BLOCK_ADDON',
+        'AMO_FU_DELAY_MID_HARD_BLOCK_ADDON',
+        'AMO_FU_DELAY_SHORT_SOFT_BLOCK_ADDON',
+        'AMO_FU_DELAY_SHORT_HARD_BLOCK_ADDON',
+        'AMO_REJECT_VERSION_WARNING_ADDON',
+        'AMO_REJECT_VERSION_ADDON',
+        'AMO_REJECT_LISTING_CONTENT',
+        'AMO_DISABLE_ADDON',
+        'AMO_BLOCK_ADDON',
+    ),
+)
 
 
 # Illegal categories, only used when the reason is `illegal`. The constants


### PR DESCRIPTION
Needed for https://github.com/mozilla/addons/issues/16123

This is split from the larger PR that implements the whole thing to make it easier to review. It contains all the logic, but isn't used yet.

Changes:
- Moves and splits `filter_enforcement_actions()` so that it focuses on filtering action enums, adding another util, `to_enforcement_actions()` to transform a list of api values into the enums. 
- Adds `should_be_skipped_by_automation()` to scanner actions to determine whether automated action can use this action for the given add-on and version
- Adds `find_automated_enforcement_actions_from_policies()` to find the appropriate automated action to take for a given add-on, version and list of policies.

That last function is what the scanners automated enforcement actions code will use later (`ScannerRule` will gain a FK to `CinderPolicy`).