### PR TITLE
Make configuration of scanner rules possible immediately at creation

### DIFF
--- a/src/olympia/constants/scanners.py
+++ b/src/olympia/constants/scanners.py
@@ -140,7 +140,7 @@ NARC_RULE_CONFIGURATION_SCHEMA = {
             'type': 'boolean',
             'default': True,
             'helpText': (
-                'For each string being examined, also examine homoglyphs variants',
+                'For each string being examined, also examine homoglyphs variants'
             ),
         },
     },

--- a/src/olympia/scanners/templates/django_jsonform/editor.html
+++ b/src/olympia/scanners/templates/django_jsonform/editor.html
@@ -1,0 +1,5 @@
+{%  load scanners %}
+{% scanners_configuration_schemas %}
+<div data-django-jsonform-container="true" {% include "django_jsonform/attrs.html" %}></div>
+
+<textarea cols="40" id="{{ widget.attrs.id }}" name="{{ widget.name }}" rows="10" {% if widget.attrs.disabled %}disabled{% endif %} style="display: none;" data-django-jsonform="{{ widget.config }}"></textarea>

--- a/src/olympia/scanners/templatetags/scanners.py
+++ b/src/olympia/scanners/templatetags/scanners.py
@@ -1,11 +1,33 @@
 from django import template
 from django.conf import settings
 from django.urls import reverse
-from django.utils.html import conditional_escape, format_html, format_html_join, urlize
+from django.utils.html import (
+    conditional_escape,
+    format_html,
+    format_html_join,
+    json_script,
+    urlize,
+)
 from django.utils.safestring import mark_safe
+
+from olympia.constants.scanners import SCANNERS
+from olympia.scanners.models import ScannerRule, rule_schema
+from olympia.scanners.utils import default_from_schema
 
 
 register = template.Library()
+
+
+@register.simple_tag
+def scanners_configuration_schemas():
+    schemas = {
+        scanner: {
+            'schema': rule_schema(ScannerRule(scanner=scanner)),
+            'default': default_from_schema(rule_schema(ScannerRule(scanner=scanner))),
+        }
+        for scanner in SCANNERS
+    }
+    return json_script(schemas, element_id='scanners-configuration-schemas')
 
 
 @register.filter

--- a/src/olympia/scanners/tests/test_templatetags.py
+++ b/src/olympia/scanners/tests/test_templatetags.py
@@ -1,4 +1,28 @@
-from olympia.scanners.templatetags.scanners import format_scanners_data
+import json
+
+from pyquery import PyQuery as pq
+
+from olympia.constants.scanners import SCANNERS
+from olympia.scanners.models import ScannerRule, rule_schema
+from olympia.scanners.templatetags.scanners import (
+    format_scanners_data,
+    scanners_configuration_schemas,
+)
+from olympia.scanners.utils import default_from_schema
+
+
+def test_scanners_configuration_schemas():
+    output = scanners_configuration_schemas()
+    assert output.startswith(
+        '<script id="scanners-configuration-schemas" type="application/json">{'
+    )
+    elm = pq(output)('#scanners-configuration-schemas')
+    data = json.loads(elm.text())
+    for scanner in SCANNERS:
+        assert data[str(scanner)] == {
+            'schema': rule_schema(ScannerRule(scanner=scanner)),
+            'default': default_from_schema(rule_schema(ScannerRule(scanner=scanner))),
+        }
 
 
 def test_format_scanners_data_simple_string():

--- a/static/js/scanners/scannerrule_change_form.js
+++ b/static/js/scanners/scannerrule_change_form.js
@@ -63,18 +63,35 @@ const showOrHideName = (select) => {
   }
 };
 
+const setInitialConfiguration = (select) => {
+  const selectedScanner = select.options[select.selectedIndex].value;
+  if (
+    selectedScanner &&
+    typeof scannersConfigurationSchemas[selectedScanner] !== 'undefined'
+  ) {
+    // We're changing scanner and we know the default configuration schema for
+    // this scanner, so re-initialize jsonForm, overriding the data and schema
+    // attributes.
+    // See https://github.com/bhch/django-jsonform/blob/master/django_jsonform/static/django_jsonform/index.js
+    const jsonFormConfig = JSON.parse(
+      configurationTextarea.dataset['djangoJsonform'],
+    );
+    jsonFormConfig.dataInputId = configurationTextarea.id;
+    jsonFormConfig.containerId = configurationTextarea.id + '_jsonform';
+    jsonFormConfig.schema =
+      scannersConfigurationSchemas[selectedScanner].schema;
+    jsonFormConfig.data = scannersConfigurationSchemas[selectedScanner].default;
+    const jsonForm = reactJsonForm.createForm(jsonFormConfig);
+    jsonForm.render();
+  }
+};
+
 const scannerSelect = document.querySelector('#id_scanner');
 const definitionTextarea = document.querySelector('#id_definition');
-
-// We listen to `scanner` changes to update the visibility of some fields in
-// the form. For instance, when the "yara" scanner is selected, we want to show
-// the `definition` field and hide the `name` field.
-scannerSelect.addEventListener('change', (event) => {
-  const select = event.target;
-
-  showOrHideDefinition(select);
-  showOrHideName(select);
-});
+const configurationTextarea = document.querySelector('#id_configuration');
+const scannersConfigurationSchemas = JSON.parse(
+  document.querySelector('#scanners-configuration-schemas').textContent,
+);
 
 // Update name field value on definition change. This is needed because the
 // field is hidden. We parse the name of the rule and, if successful, we update
@@ -93,7 +110,21 @@ definitionTextarea.addEventListener('input', (event) => {
   }
 });
 
-// It is likely that these two fields will be hidden by default because the
-// form does not have a pre-selected value for the `scanner` select.
-showOrHideName(scannerSelect);
-showOrHideDefinition(scannerSelect);
+// We listen to `scanner` changes to update the visibility of some fields in
+// the form. For instance, when the "yara" scanner is selected, we want to show
+// the `definition` field and hide the `name` field.
+if (scannerSelect) {
+  scannerSelect.addEventListener('change', (event) => {
+    const select = event.target;
+
+    showOrHideDefinition(select);
+    showOrHideName(select);
+    setInitialConfiguration(select);
+  });
+
+  // It is likely that these fields will be hidden by default because the
+  // form does not have a pre-selected value for the `scanner` select.
+  showOrHideName(scannerSelect);
+  showOrHideDefinition(scannerSelect);
+  setInitialConfiguration(scannerSelect);
+}

--- a/static/js/scanners/scannerrule_change_form.js
+++ b/static/js/scanners/scannerrule_change_form.js
@@ -81,6 +81,7 @@ const setInitialConfiguration = (select) => {
     jsonFormConfig.schema =
       scannersConfigurationSchemas[selectedScanner].schema;
     jsonFormConfig.data = scannersConfigurationSchemas[selectedScanner].default;
+    /* global reactJsonForm */
     const jsonForm = reactJsonForm.createForm(jsonFormConfig);
     jsonForm.render();
   }


### PR DESCRIPTION
(Only NARC has configuration for the moment, but this should work for any scanner in theory)

Fixes: mozilla/addons#16048

### Description

This allows admins to see and change configuration of scanner rules and scanner query rules directly at creation, rather than have to submit the form first.

### Context

django-jsonform is only initialized once by default, but we have dynamic scanner selection, so dynamic initialization is needed.

### Testing

- In the admin, go to the add a scanner rule page
- Change the scanner to NARC

Expected results:
- Configuration should appear

Saving the rule should correctly save the configuration and display it again on edit.

Note: configuration is reset if you change scanner back and forth.