### PR TITLE
AMOENG-2480 - Use a FxA secret instead of the access-token for the support API endpoint

### DIFF
--- a/src/olympia/devhub/tasks.py
+++ b/src/olympia/devhub/tasks.py
@@ -706,11 +706,17 @@ def send_api_key_revocation_email(emails):
     retry_backoff_max=300,
     retry_jitter=False,
 )
-def create_support_ticket(access_token, payload, **kw):
+def create_support_ticket(payload, **kw):
     response = requests.post(
         settings.FXA_SUPPORT_HOST + '/support/ticket',
-        headers={'Authorization': f'Bearer {access_token}'},
+        headers={'Authorization': f'Bearer {settings.FXA_SUPPORT_SECRET}'},
         json=payload,
         timeout=10,
     )
+    if not response.ok:
+        log.error(
+            'create_support_ticket: FxA returned %s: %s',
+            response.status_code,
+            response.text,
+        )
     response.raise_for_status()

--- a/src/olympia/devhub/tests/test_tasks.py
+++ b/src/olympia/devhub/tests/test_tasks.py
@@ -1066,10 +1066,11 @@ class TestCreateSupportTicket(TestCase):
     def test_success(self, mock_post):
         mock_post.return_value = mock.MagicMock(status_code=201)
         mock_post.return_value.raise_for_status.return_value = None
-        tasks.create_support_ticket('mytoken', self.payload)
+        with self.settings(FXA_SUPPORT_SECRET='mysecret'):
+            tasks.create_support_ticket(self.payload)
         mock_post.assert_called_once_with(
             mock_post.call_args[0][0],
-            headers={'Authorization': 'Bearer mytoken'},
+            headers={'Authorization': 'Bearer mysecret'},
             json=self.payload,
             timeout=10,
         )
@@ -1081,7 +1082,7 @@ class TestCreateSupportTicket(TestCase):
         mock_post.return_value = mock.MagicMock(status_code=500)
         mock_post.return_value.raise_for_status.side_effect = req.HTTPError('500')
         with self.assertRaises(req.HTTPError):
-            tasks.create_support_ticket('mytoken', self.payload)
+            tasks.create_support_ticket(self.payload)
 
     @mock.patch('olympia.devhub.tasks.requests.post')
     def test_network_error_triggers_retry(self, mock_post):
@@ -1089,4 +1090,4 @@ class TestCreateSupportTicket(TestCase):
 
         mock_post.side_effect = req.RequestException('timeout')
         with self.assertRaises(req.RequestException):
-            tasks.create_support_ticket('mytoken', self.payload)
+            tasks.create_support_ticket(self.payload)

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.core import mail
 from django.http import HttpResponseNotAllowed
 from django.template import defaultfilters
-from django.test import RequestFactory
+from django.test import RequestFactory, override_settings
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.encoding import force_str
@@ -2758,6 +2758,7 @@ class TestRequestContentReview(TestCase):
 
 
 @override_switch('enable-devhub-support-form', active=True)
+@override_settings(FXA_SUPPORT_SECRET='mysecret')
 class TestSupportView(TestCase):
     def setUp(self):
         super().setUp()
@@ -2766,6 +2767,12 @@ class TestSupportView(TestCase):
 
     @override_switch('enable-devhub-support-form', active=False)
     def test_switch_inactive_returns_404(self):
+        self.client.force_login(self.user)
+        assert self.client.get(self.url).status_code == 404
+        assert self.client.post(self.url, {}).status_code == 404
+
+    @override_settings(FXA_SUPPORT_SECRET='')
+    def test_no_secret_returns_404(self):
         self.client.force_login(self.user)
         assert self.client.get(self.url).status_code == 404
         assert self.client.post(self.url, {}).status_code == 404
@@ -2805,56 +2812,26 @@ class TestSupportView(TestCase):
         assert form.errors
 
     @mock.patch('olympia.devhub.tasks.create_support_ticket.delay')
-    @mock.patch('olympia.devhub.views.get_fxa_access_token')
-    def test_post_success(self, mock_token, mock_task):
-        mock_token.return_value = 'mytoken'
+    def test_post_success(self, mock_task):
         self.client.force_login(self.user)
         with self.settings(FXA_SUPPORT_BRAND_ID=None):
             response = self._post(follow=True)
         assert response.status_code == 200
         mock_task.assert_called_once()
-        access_token, payload = mock_task.call_args[0]
-        assert access_token == 'mytoken'
+        (payload,) = mock_task.call_args[0]
         assert payload['topic'] == 'technical'
         assert payload['subject'] == 'Something is broken'
+        assert payload['email'] == self.user.email
         assert 'brand_id' not in payload
         assert len(response.context['messages']) == 1
         msg = list(response.context['messages'])[0]
         assert msg.level_tag == 'success'
 
     @mock.patch('olympia.devhub.tasks.create_support_ticket.delay')
-    @mock.patch('olympia.devhub.views.get_fxa_access_token')
-    def test_post_success_with_brand_id(self, mock_token, mock_task):
-        mock_token.return_value = 'mytoken'
+    def test_post_success_with_brand_id(self, mock_task):
         self.client.force_login(self.user)
         with self.settings(FXA_SUPPORT_BRAND_ID=12345):
             response = self._post(follow=True)
         assert response.status_code == 200
-        _, payload = mock_task.call_args[0]
+        (payload,) = mock_task.call_args[0]
         assert payload['brand_id'] == 12345
-
-    @mock.patch('olympia.devhub.tasks.create_support_ticket.delay')
-    @mock.patch('olympia.devhub.views.get_fxa_access_token')
-    def test_post_no_access_token(self, mock_token, mock_task):
-        mock_token.return_value = None
-        self.client.force_login(self.user)
-        response = self._post(follow=True)
-        assert response.status_code == 200
-        mock_task.assert_not_called()
-        assert len(response.context['messages']) == 1
-        msg = list(response.context['messages'])[0]
-        assert msg.level_tag == 'error'
-
-    @mock.patch('olympia.devhub.tasks.create_support_ticket.delay')
-    @mock.patch('olympia.devhub.views.get_fxa_access_token')
-    def test_post_token_identification_error(self, mock_token, mock_task):
-        from olympia.accounts.verify import IdentificationError
-
-        mock_token.side_effect = IdentificationError('no token')
-        self.client.force_login(self.user)
-        response = self._post(follow=True)
-        assert response.status_code == 200
-        mock_task.assert_not_called()
-        assert len(response.context['messages']) == 1
-        msg = list(response.context['messages'])[0]
-        assert msg.level_tag == 'error'

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -35,7 +35,6 @@ from olympia.accounts.utils import (
     redirect_for_login,
     redirect_for_login_with_2fa_enforced,
 )
-from olympia.accounts.verify import IdentificationError, get_fxa_access_token
 from olympia.accounts.views import logout_user
 from olympia.activity.models import ActivityLog, CommentLog
 from olympia.addons.decorators import require_submissions_enabled
@@ -2303,7 +2302,10 @@ def email_verification(request):
 
 @login_required
 def support(request):
-    if not waffle.switch_is_active('enable-devhub-support-form'):
+    if (
+        not waffle.switch_is_active('enable-devhub-support-form')
+        or not settings.FXA_SUPPORT_SECRET
+    ):
         raise http.Http404
 
     form = forms.SupportForm(
@@ -2312,34 +2314,22 @@ def support(request):
     )
     if request.method == 'POST' and form.is_valid():
         payload = {
+            'productName': settings.FXA_SUPPORT_PRODUCT_NAME,
             'topic': form.cleaned_data['category'],
             'subject': form.cleaned_data['summary'],
             'message': form.cleaned_data['body'],
         }
         if settings.FXA_SUPPORT_BRAND_ID is not None:
             payload['brand_id'] = settings.FXA_SUPPORT_BRAND_ID
+        payload['email'] = request.user.email
 
-        try:
-            access_token = get_fxa_access_token(request)
-            if not access_token:
-                raise IdentificationError('No access token in session')
-        except IdentificationError:
-            log.warning(
-                'support: could not get FxA access token for user %s',
-                request.user.pk,
-            )
-            messages.error(
-                request,
-                gettext('Could not submit your support request. Please try again.'),
-            )
-        else:
-            tasks.create_support_ticket.delay(access_token, payload)
-            messages.success(
-                request,
-                gettext(
-                    'Your support request has been submitted. We will be in touch soon.'
-                ),
-            )
+        tasks.create_support_ticket.delay(payload)
+        messages.success(
+            request,
+            gettext(
+                'Your support request has been submitted. We will be in touch soon.'
+            ),
+        )
         return redirect('devhub.support')
 
     return TemplateResponse(request, 'devhub/support.html', {'form': form})

--- a/src/olympia/lib/settings_base.py
+++ b/src/olympia/lib/settings_base.py
@@ -1413,6 +1413,8 @@ FXA_OAUTH_HOST = 'https://oauth.accounts.firefox.com/v1'
 FXA_PROFILE_HOST = 'https://profile.accounts.firefox.com/v1'
 FXA_SUPPORT_HOST = 'https://api.accounts.firefox.com/v1'
 FXA_SUPPORT_BRAND_ID = 47184764139412  # Zendesk brand: "Firefox Add-on Support"
+FXA_SUPPORT_PRODUCT_NAME = 'Firefox Add-ons'
+FXA_SUPPORT_SECRET = env('FXA_SUPPORT_SECRET', default='')
 
 USE_FAKE_FXA_AUTH = False  # Should only be True for local development envs.
 VERIFY_FXA_ACCESS_TOKEN = True


### PR DESCRIPTION
Fixes: [AMOENG-2480](https://mozilla-hub.atlassian.net/browse/AMOENG-2480)

### Description

We have to switch to a secret instead of using the FxA user access token because of a missing scope.

### Checklist

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
