### PR TITLE
Keep continue-on-error in _test_check.yml for now

### DIFF
--- a/.github/workflows/_test_check.yml
+++ b/.github/workflows/_test_check.yml
@@ -67,6 +67,7 @@ jobs:
 
       - name: ${{ matrix.version == 'local' && 'Uncached Build' || 'Pull' }} Check
         id: build
+        continue-on-error: true
         uses: ./.github/actions/run-docker
         # Set environment variables that are expected to be ignored
         env:


### PR DESCRIPTION
Removing it in https://github.com/mozilla/addons-server/commit/3750d49fe4cabfc2881bc319a653a1cf053ed1ee broke the build on `master` because of the DOCKER_COMMIT and DOCKER_VERSION are set to 'not-expected' after... This is not happening in PRs...

I was hoping this issue would be a quick fix but we'll have to deal with it later.