### PR TITLE
Limit content review triggers to extensions and dictionaries

### DIFF
--- a/src/olympia/addons/models.py
+++ b/src/olympia/addons/models.py
@@ -396,10 +396,7 @@ class AddonManager(ManagerBase):
             .valid()
             .filter(
                 _current_version__reviewerflags__pending_rejection__isnull=True,
-                # Only content review extensions and dictionaries. See
-                # https://github.com/mozilla/addons-server/issues/11796 &
-                # https://github.com/mozilla/addons-server/issues/12065
-                type__in=(amo.ADDON_EXTENSION, amo.ADDON_DICT),
+                type__in=amo.ADDON_CONTENT_REVIEW_TYPES,
             )
             .exclude(
                 addonapprovalscounter__content_review_status__in=(
@@ -2145,7 +2142,8 @@ def watch_status(old_attr=None, new_attr=None, instance=None, sender=None, **kwa
         return
 
     if (
-        new_status in amo.VALID_ADDON_STATUSES
+        instance.type in amo.ADDON_CONTENT_REVIEW_TYPES
+        and new_status in amo.VALID_ADDON_STATUSES
         and waffle.switch_is_active('content-review-in-cinder')
         and not AddonApprovalsCounter.objects.filter(addon_id=instance.id)
         .exclude(

--- a/src/olympia/addons/serializers.py
+++ b/src/olympia/addons/serializers.py
@@ -87,6 +87,7 @@ from .models import (
     ReplacementAddon,
 )
 from .tasks import resize_icon, resize_preview
+from .utils import trigger_content_review
 from .validators import (
     AddonDefaultLocaleValidator,
     AddonMetadataValidator,
@@ -1324,8 +1325,6 @@ class AddonSerializer(AMOModelSerializer):
             self.instance.update(icon_type='')
 
     def log(self, instance, validated_data, changes):
-        from olympia.abuse.tasks import submit_addon_change_for_content_review
-
         validated_data = {**validated_data}  # we want to modify it, so take a copy
         user = self.context['request'].user
 
@@ -1354,8 +1353,8 @@ class AddonSerializer(AMOModelSerializer):
                 json.dumps(addedremoved),
                 user=user,
             )
-            if waffle.switch_is_active('content-review-in-cinder'):
-                submit_addon_change_for_content_review.delay(activity_log_pk=alog.pk)
+            statsd.incr('addons.submission.metadata_content_review_triggered')
+            trigger_content_review(instance, alog)
             validated_data.pop(field)
         if validated_data:
             ActivityLog.objects.create(
@@ -1423,9 +1422,7 @@ class AddonSerializer(AMOModelSerializer):
         if old_metadata is not None and old_metadata != (
             new_metadata := fetch_translations_from_instance(instance, fields_to_review)
         ):
-            statsd.incr('addons.submission.metadata_content_review_triggered')
             changes = get_translation_differences(old_metadata, new_metadata)
-            AddonApprovalsCounter.reset_content_for_addon(addon=instance)
             AddonListingInfo.maybe_mark_as_noindexed(addon=instance)
 
             if waffle.switch_is_active('enable-narc') and (

--- a/src/olympia/addons/tests/test_utils_.py
+++ b/src/olympia/addons/tests/test_utils_.py
@@ -1,10 +1,15 @@
 from datetime import datetime, timedelta
+from unittest import mock
 
 from django.forms import ValidationError
 
 import pytest
 import time_machine
+from waffle.testutils import override_switch
 
+from olympia import amo
+from olympia.activity.models import ActivityLog
+from olympia.addons.models import AddonApprovalsCounter
 from olympia.amo.tests import TestCase, addon_factory, user_factory
 from olympia.users.models import Group, GroupUser
 
@@ -13,6 +18,8 @@ from ..utils import (
     DeleteTokenSigner,
     get_addon_recommendations,
     get_filtered_fallbacks,
+    request_content_review,
+    trigger_content_review,
     validate_addon_name,
     validate_addon_summary,
 )
@@ -181,3 +188,161 @@ def test_delete_token_signer():
         # but not after 60 seconds
         frozen_time.shift(timedelta(seconds=2))
         assert not signer.validate(token, addon_id)
+
+
+@pytest.mark.django_db
+def test_trigger_content_review():
+    addon = addon_factory()
+    activity_log = ActivityLog.objects.create(
+        amo.LOG.EDIT_ADDON_PROPERTY, user=user_factory()
+    )
+    AddonApprovalsCounter.approve_content_for_addon(addon)
+    assert (
+        addon.addonapprovalscounter.content_review_status
+        == AddonApprovalsCounter.CONTENT_REVIEW_STATUSES.PASS
+    )
+
+    with (
+        override_switch('content-review-in-cinder', active=True),
+        mock.patch('olympia.amo.celery.AMOTask.apply_async') as mock_apply_async,
+    ):
+        trigger_content_review(addon, activity_log)
+
+    assert (
+        addon.addonapprovalscounter.reload().content_review_status
+        == AddonApprovalsCounter.CONTENT_REVIEW_STATUSES.CHANGED
+    )
+    # And we should have triggered the content review task
+    mock_apply_async.assert_called_once()
+    assert mock_apply_async.call_args.args == ((), {'activity_log_pk': activity_log.pk})
+
+
+@pytest.mark.django_db
+def test_trigger_content_review_not_triggered_for_non_content_review_types():
+    addon = addon_factory(type=amo.ADDON_STATICTHEME)
+    activity_log = ActivityLog.objects.create(
+        amo.LOG.EDIT_ADDON_PROPERTY, user=user_factory()
+    )
+    AddonApprovalsCounter.approve_content_for_addon(addon)
+    assert (
+        addon.addonapprovalscounter.content_review_status
+        == AddonApprovalsCounter.CONTENT_REVIEW_STATUSES.PASS
+    )
+
+    with (
+        override_switch('content-review-in-cinder', active=True),
+        mock.patch('olympia.amo.celery.AMOTask.apply_async') as mock_apply_async,
+    ):
+        trigger_content_review(addon, activity_log)
+
+    assert (
+        addon.addonapprovalscounter.reload().content_review_status
+        == AddonApprovalsCounter.CONTENT_REVIEW_STATUSES.CHANGED
+    )
+    # We should not have triggered the content review task though
+    mock_apply_async.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_trigger_content_review_not_triggered_if_switch_inactive():
+    addon = addon_factory()
+    activity_log = ActivityLog.objects.create(
+        amo.LOG.EDIT_ADDON_PROPERTY, user=user_factory()
+    )
+    AddonApprovalsCounter.approve_content_for_addon(addon)
+    assert (
+        addon.addonapprovalscounter.content_review_status
+        == AddonApprovalsCounter.CONTENT_REVIEW_STATUSES.PASS
+    )
+
+    with (
+        override_switch('content-review-in-cinder', active=False),
+        mock.patch('olympia.amo.celery.AMOTask.apply_async') as mock_apply_async,
+    ):
+        trigger_content_review(addon, activity_log)
+
+    assert (
+        addon.addonapprovalscounter.reload().content_review_status
+        == AddonApprovalsCounter.CONTENT_REVIEW_STATUSES.CHANGED
+    )
+    # We should not have triggered the content review task though
+    mock_apply_async.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_request_content_review():
+    addon = addon_factory()
+    activity_log = ActivityLog.objects.create(
+        amo.LOG.EDIT_ADDON_PROPERTY, user=user_factory()
+    )
+    AddonApprovalsCounter.reject_content_for_addon(addon)
+    assert (
+        addon.addonapprovalscounter.content_review_status
+        == AddonApprovalsCounter.CONTENT_REVIEW_STATUSES.FAIL
+    )
+
+    with (
+        override_switch('content-review-in-cinder', active=True),
+        mock.patch('olympia.amo.celery.AMOTask.apply_async') as mock_apply_async,
+    ):
+        request_content_review(addon, activity_log)
+
+    assert (
+        addon.addonapprovalscounter.reload().content_review_status
+        == AddonApprovalsCounter.CONTENT_REVIEW_STATUSES.REQUESTED
+    )
+    # And we should have triggered the content review task
+    mock_apply_async.assert_called_once()
+    assert mock_apply_async.call_args.args == ((), {'activity_log_pk': activity_log.pk})
+
+
+@pytest.mark.django_db
+def test_request_content_review_not_triggered_for_non_content_review_types():
+    addon = addon_factory(type=amo.ADDON_STATICTHEME)
+    activity_log = ActivityLog.objects.create(
+        amo.LOG.EDIT_ADDON_PROPERTY, user=user_factory()
+    )
+    AddonApprovalsCounter.reject_content_for_addon(addon)
+    assert (
+        addon.addonapprovalscounter.content_review_status
+        == AddonApprovalsCounter.CONTENT_REVIEW_STATUSES.FAIL
+    )
+
+    with (
+        override_switch('content-review-in-cinder', active=True),
+        mock.patch('olympia.amo.celery.AMOTask.apply_async') as mock_apply_async,
+    ):
+        request_content_review(addon, activity_log)
+
+    assert (
+        addon.addonapprovalscounter.reload().content_review_status
+        == AddonApprovalsCounter.CONTENT_REVIEW_STATUSES.REQUESTED
+    )
+    # We should not have triggered the content review task though
+    mock_apply_async.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_request_content_review_not_triggered_if_switch_inactive():
+    addon = addon_factory()
+    activity_log = ActivityLog.objects.create(
+        amo.LOG.EDIT_ADDON_PROPERTY, user=user_factory()
+    )
+    AddonApprovalsCounter.reject_content_for_addon(addon)
+    assert (
+        addon.addonapprovalscounter.content_review_status
+        == AddonApprovalsCounter.CONTENT_REVIEW_STATUSES.FAIL
+    )
+
+    with (
+        override_switch('content-review-in-cinder', active=False),
+        mock.patch('olympia.amo.celery.AMOTask.apply_async') as mock_apply_async,
+    ):
+        request_content_review(addon, activity_log)
+
+    assert (
+        addon.addonapprovalscounter.reload().content_review_status
+        == AddonApprovalsCounter.CONTENT_REVIEW_STATUSES.REQUESTED
+    )
+    # We should not have triggered the content review task though
+    mock_apply_async.assert_not_called()

--- a/src/olympia/addons/utils.py
+++ b/src/olympia/addons/utils.py
@@ -5,6 +5,8 @@ from django.core.files.storage import default_storage as storage
 from django.core.signing import BadSignature, SignatureExpired, TimestampSigner
 from django.utils.translation import gettext
 
+import waffle
+
 from olympia import amo, core
 from olympia.access.acl import action_allowed_for
 from olympia.amo.utils import validate_name
@@ -135,3 +137,27 @@ def remove_icons(addon):
         filepath = addon.get_icon_path(size)
         if storage.exists(filepath):
             storage.delete(filepath)
+
+
+def trigger_content_review(addon, activity_log):
+    from olympia.abuse.tasks import submit_addon_change_for_content_review
+    from olympia.addons.models import AddonApprovalsCounter
+
+    AddonApprovalsCounter.reset_content_for_addon(addon=addon)
+
+    if addon.type in amo.ADDON_CONTENT_REVIEW_TYPES and waffle.switch_is_active(
+        'content-review-in-cinder'
+    ):
+        submit_addon_change_for_content_review.delay(activity_log_pk=activity_log.pk)
+
+
+def request_content_review(addon, activity_log):
+    from olympia.abuse.tasks import submit_addon_change_for_content_review
+    from olympia.addons.models import AddonApprovalsCounter
+
+    AddonApprovalsCounter.request_new_content_review_for_addon(addon=addon)
+
+    if addon.type in amo.ADDON_CONTENT_REVIEW_TYPES and waffle.switch_is_active(
+        'content-review-in-cinder'
+    ):
+        submit_addon_change_for_content_review.delay(activity_log_pk=activity_log.pk)

--- a/src/olympia/addons/views.py
+++ b/src/olympia/addons/views.py
@@ -82,7 +82,6 @@ from .decorators import addon_view_factory, require_submissions_enabled
 from .indexers import AddonIndexer
 from .models import (
     Addon,
-    AddonApprovalsCounter,
     AddonBrowserMapping,
     AddonUser,
     AddonUserPendingConfirmation,
@@ -112,6 +111,7 @@ from .utils import (
     RECOMMENDATION_OUTCOME_CURATED,
     DeleteTokenSigner,
     get_addon_recommendations,
+    request_content_review,
 )
 
 
@@ -435,24 +435,22 @@ class AddonViewSet(
 
     @listingcontentreview.mapping.patch
     def update_listingcontentreview(self, request, pk=None):
-        from olympia.abuse.tasks import submit_addon_change_for_content_review
-
         addon = self.get_object()
-        ouput = self.get_serializer(addon).data
+        output = self.get_serializer(addon).data
         if (
-            request.data.get('has_requested_review')
-            and not ouput.get('has_requested_review')
-            and ouput.get('can_request_review')
+            request.data.get('has_requested_review') is True
+            and not output.get('has_requested_review')
+            and output.get('can_request_review')
         ):
-            AddonApprovalsCounter.request_new_content_review_for_addon(addon)
-            addon.addonapprovalscounter.reload()
-            ouput = self.get_serializer(addon).data
             alog = ActivityLog.objects.create(
                 amo.LOG.REJECTED_LISTING_REVIEW_REQUEST, addon
             )
-            if waffle.switch_is_active('content-review-in-cinder'):
-                submit_addon_change_for_content_review.delay(activity_log_pk=alog.pk)
-        return Response(ouput, status=status.HTTP_202_ACCEPTED)
+
+            request_content_review(addon, alog)
+            addon.addonapprovalscounter.reload()
+            output = self.get_serializer(addon).data
+
+        return Response(output, status=status.HTTP_202_ACCEPTED)
 
 
 class AddonChildMixin:

--- a/src/olympia/constants/base.py
+++ b/src/olympia/constants/base.py
@@ -207,6 +207,11 @@ ADDON_TYPES_WITH_STATS = (
     ADDON_LPAPP,
 )
 
+# Only content review extensions and dictionaries. See
+# https://github.com/mozilla/addons-server/issues/11796 &
+# https://github.com/mozilla/addons-server/issues/12065
+ADDON_CONTENT_REVIEW_TYPES = (ADDON_EXTENSION, ADDON_DICT)
+
 # Edit addon information
 MAX_TAGS = 10
 MAX_CATEGORIES = 3

--- a/src/olympia/devhub/forms.py
+++ b/src/olympia/devhub/forms.py
@@ -21,7 +21,6 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import get_language, gettext, gettext_lazy as _, ngettext
 
 import waffle
-from django_statsd.clients import statsd
 
 from olympia import amo
 from olympia.access import acl
@@ -29,7 +28,6 @@ from olympia.activity.models import ActivityLog
 from olympia.addons import tasks as addons_tasks
 from olympia.addons.models import (
     Addon,
-    AddonApprovalsCounter,
     AddonCategory,
     AddonListingInfo,
     AddonUser,
@@ -159,9 +157,6 @@ class AddonFormBase(TranslationFormMixin, AMOModelForm):
                 self.metadata_changes = get_translation_differences(
                     existing_data, new_data
                 )
-                # flag for content review
-                statsd.incr('devhub.metadata_content_review_triggered')
-                AddonApprovalsCounter.reset_content_for_addon(addon=obj)
                 AddonListingInfo.maybe_mark_as_noindexed(addon=obj)
 
                 if waffle.switch_is_active('enable-narc') and (

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -2683,7 +2683,7 @@ class TestRequestContentReview(TestCase):
         assert entry.action == amo.LOG.REJECTED_LISTING_REVIEW_REQUEST.id
         assert str(self.addon.name) in entry.to_string()
 
-    @mock.patch('olympia.devhub.views.submit_addon_change_for_content_review.delay')
+    @mock.patch('olympia.abuse.tasks.submit_addon_change_for_content_review.delay')
     @override_switch('content-review-in-cinder', active=False)
     def test_owner_can_request_listing_content_review_cinder_switch_off(
         self, task_mock
@@ -2691,7 +2691,7 @@ class TestRequestContentReview(TestCase):
         self._test_owner_can_request_listing_content_review()
         task_mock.assert_not_called()
 
-    @mock.patch('olympia.devhub.views.submit_addon_change_for_content_review.delay')
+    @mock.patch('olympia.abuse.tasks.submit_addon_change_for_content_review.delay')
     @override_switch('content-review-in-cinder', active=True)
     def test_owner_can_request_listing_content_review_cinder_switch_on(self, task_mock):
         self._test_owner_can_request_listing_content_review()

--- a/src/olympia/devhub/tests/test_views_edit.py
+++ b/src/olympia/devhub/tests/test_views_edit.py
@@ -468,7 +468,7 @@ class BaseTestEditDescribe(BaseTestEdit):
     def test_metadata_change_triggers_content_review_cinder_switch_off(self):
         with (
             mock.patch(
-                'olympia.devhub.views.submit_addon_change_for_content_review'
+                'olympia.abuse.tasks.submit_addon_change_for_content_review'
             ) as view_task_mock,
             mock.patch(
                 'olympia.abuse.tasks.submit_addon_for_content_review'
@@ -482,7 +482,7 @@ class BaseTestEditDescribe(BaseTestEdit):
     def test_metadata_change_triggers_content_review_cinder_switch_on(self):
         with (
             mock.patch(
-                'olympia.devhub.views.submit_addon_change_for_content_review'
+                'olympia.abuse.tasks.submit_addon_change_for_content_review'
             ) as view_task_mock,
             mock.patch(
                 'olympia.abuse.tasks.submit_addon_for_content_review'
@@ -1839,6 +1839,22 @@ class TestEditDescribeStaticThemeListed(
         doc = pq(response.content)
         assert 'Preview' not in doc('h3').text()
         assert len(doc('div.edit-addon-section img')) == 0
+
+    @override_switch('content-review-in-cinder', active=True)
+    def test_metadata_change_triggers_content_review_cinder_switch_on(self):
+        """Themes don't have content review, so regardless of the switch, we shouldn't
+        trigger content review."""
+        with (
+            mock.patch(
+                'olympia.abuse.tasks.submit_addon_change_for_content_review'
+            ) as view_task_mock,
+            mock.patch(
+                'olympia.abuse.tasks.submit_addon_for_content_review'
+            ) as abuse_task_mock,
+        ):
+            self._test_metadata_change_triggers_content_review()
+            view_task_mock.delay.assert_not_called()
+            abuse_task_mock.delay.assert_not_called()
 
 
 class TestEditDescribeStaticThemeUnlisted(StaticMixin, TestEditDescribeUnlisted):

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -28,7 +28,6 @@ from django_statsd.clients import statsd
 
 import olympia.core.logger
 from olympia import amo
-from olympia.abuse.tasks import submit_addon_change_for_content_review
 from olympia.access import acl
 from olympia.accounts.decorators import two_factor_auth_required
 from olympia.accounts.utils import (
@@ -41,11 +40,11 @@ from olympia.activity.models import ActivityLog, CommentLog
 from olympia.addons.decorators import require_submissions_enabled
 from olympia.addons.models import (
     Addon,
-    AddonApprovalsCounter,
     AddonReviewerFlags,
     AddonUser,
     AddonUserPendingConfirmation,
 )
+from olympia.addons.utils import request_content_review, trigger_content_review
 from olympia.addons.views import BaseFilter
 from olympia.amo import messages, utils as amo_utils
 from olympia.amo.decorators import json_view, login_required, post_required
@@ -431,10 +430,8 @@ def disable(request, addon_id, addon):
 def rejected_review_request(request, addon_id, addon):
     if addon.status != amo.STATUS_REJECTED:
         raise http.Http404()
-    AddonApprovalsCounter.request_new_content_review_for_addon(addon)
     alog = ActivityLog.objects.create(amo.LOG.REJECTED_LISTING_REVIEW_REQUEST, addon)
-    if waffle.switch_is_active('content-review-in-cinder'):
-        submit_addon_change_for_content_review.delay(activity_log_pk=alog.pk)
+    request_content_review(addon, alog)
     messages.success(
         request,
         gettext('Request for a new review of listing content acknowledged.'),
@@ -946,10 +943,7 @@ def addons_section(request, addon_id, addon, section, editable=False):
                             field,
                             json.dumps(addedremoved),
                         )
-                        if waffle.switch_is_active('content-review-in-cinder'):
-                            submit_addon_change_for_content_review.delay(
-                                activity_log_pk=alog.pk
-                            )
+                        trigger_content_review(addon, alog)
 
                     ActivityLog.objects.create(amo.LOG.EDIT_PROPERTIES, addon)
 


### PR DESCRIPTION
Fixes: mozilla/addons#16167

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Limits sending content review events to Cinder for extensions and dictionaries.

### Context

Some extra refactoring because I wanted to tidy up the extra logic we were adding to gate the content review in 3 different places into a single utility function.

I didn't change the existing logic around [re]setting AddonApprovalsCounter for langpacks and themes - they're filtered out in the queue queryset instead - but I could?

### Testing

- enable `content-review-in-cinder` waffle switch (+ Cinder API key in settings)
- Submit a new theme; see it's not submitted for content review in Cinder
- Edit the name or summary for a theme;  see it's not submitted for content review in Cinder
- repeat with an extension or dictionary and see those events do trigger a content review job being created in Cinder

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
