### PR TITLE
Always record Promoted Approval when approving add-on versions

### DIFF
--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -46,6 +46,7 @@ from olympia.lib.crypto.tests.test_signing import (
 )
 from olympia.promoted.models import (
     PromotedApproval,
+    PromotedGroup,
 )
 from olympia.reviewers.models import (
     AutoApprovalSummary,
@@ -3886,27 +3887,39 @@ class TestReviewHelper(TestReviewHelperBase):
         assert PROMOTED_GROUP_CHOICES.LINE in self.addon.promoted_groups().group_id
 
     def test_autoapprove_promoted(self):
+        group = PromotedGroup.objects.get(group_id=PROMOTED_GROUP_CHOICES.RECOMMENDED)
+        group.listed_pre_review = False
+        group.save()
         self.make_addon_promoted(self.addon, PROMOTED_GROUP_CHOICES.RECOMMENDED)
-        assert not self.addon.promoted_groups()
         self.user = UserProfile.objects.get(id=settings.TASK_USER_ID)
 
         self.test_nomination_to_public()
         assert PromotedApproval.objects.filter(
             version=self.addon.current_version
         ).exists()
-        assert self.addon.promoted_groups()
+        assert group in self.addon.promoted_groups()
+
+        group.listed_pre_review = True
+        group.save()
+        assert group in self.addon.promoted_groups()
 
     def test_autoapprove_promoted_notable(self):
         # as above with notable
+        group = PromotedGroup.objects.get(group_id=PROMOTED_GROUP_CHOICES.NOTABLE)
+        group.listed_pre_review = False
+        group.save()
         self.make_addon_promoted(self.addon, PROMOTED_GROUP_CHOICES.NOTABLE)
-        assert not self.addon.promoted_groups()
         self.user = UserProfile.objects.get(id=settings.TASK_USER_ID)
 
         self.test_nomination_to_public()
         assert PromotedApproval.objects.filter(
             version=self.addon.current_version
         ).exists()
-        assert self.addon.promoted_groups()
+        assert group in self.addon.promoted_groups()
+
+        group.listed_pre_review = True
+        group.save()
+        assert group in self.addon.promoted_groups()
 
     def _test_block_multiple_unlisted_versions(self, redirect_url):
         old_version = self.review_version

--- a/src/olympia/reviewers/tests/test_utils.py
+++ b/src/olympia/reviewers/tests/test_utils.py
@@ -45,7 +45,6 @@ from olympia.lib.crypto.tests.test_signing import (
     _get_signature_details,
 )
 from olympia.promoted.models import (
-    PromotedAddon,
     PromotedApproval,
 )
 from olympia.reviewers.models import (
@@ -3886,38 +3885,28 @@ class TestReviewHelper(TestReviewHelperBase):
         ).exists()
         assert PROMOTED_GROUP_CHOICES.LINE in self.addon.promoted_groups().group_id
 
-    def test_autoapprove_fails_for_promoted(self):
+    def test_autoapprove_promoted(self):
         self.make_addon_promoted(self.addon, PROMOTED_GROUP_CHOICES.RECOMMENDED)
         assert not self.addon.promoted_groups()
         self.user = UserProfile.objects.get(id=settings.TASK_USER_ID)
 
-        with self.assertRaises(AssertionError):
-            self.test_nomination_to_public()
-        assert not PromotedApproval.objects.filter(
-            version=self.addon.current_version
-        ).exists()
-        assert not self.addon.promoted_groups()
-
-        # change to other type of promoted; same should happen
-        PromotedAddon.objects.filter(addon=self.addon).delete()
-        self.make_addon_promoted(self.addon, PROMOTED_GROUP_CHOICES.LINE)
-        with self.assertRaises(AssertionError):
-            self.test_nomination_to_public()
-        assert not PromotedApproval.objects.filter(
-            version=self.addon.current_version
-        ).exists()
-        assert not self.addon.promoted_groups()
-
-        # except for a group that doesn't require prereview
-        PromotedAddon.objects.filter(addon=self.addon).delete()
-        self.make_addon_promoted(self.addon, PROMOTED_GROUP_CHOICES.STRATEGIC)
-        assert PROMOTED_GROUP_CHOICES.STRATEGIC in self.addon.promoted_groups().group_id
         self.test_nomination_to_public()
-        # But no PromotedApproval though
-        assert not PromotedApproval.objects.filter(
+        assert PromotedApproval.objects.filter(
             version=self.addon.current_version
         ).exists()
-        assert PROMOTED_GROUP_CHOICES.STRATEGIC in self.addon.promoted_groups().group_id
+        assert self.addon.promoted_groups()
+
+    def test_autoapprove_promoted_notable(self):
+        # as above with notable
+        self.make_addon_promoted(self.addon, PROMOTED_GROUP_CHOICES.NOTABLE)
+        assert not self.addon.promoted_groups()
+        self.user = UserProfile.objects.get(id=settings.TASK_USER_ID)
+
+        self.test_nomination_to_public()
+        assert PromotedApproval.objects.filter(
+            version=self.addon.current_version
+        ).exists()
+        assert self.addon.promoted_groups()
 
     def _test_block_multiple_unlisted_versions(self, redirect_url):
         old_version = self.review_version

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict, defaultdict
 from datetime import datetime
 
+from django.conf import settings
 from django.contrib.humanize.templatetags.humanize import naturaltime
 from django.core.files.base import ContentFile
 from django.urls import reverse
@@ -1055,10 +1056,19 @@ class ReviewBase:
         file.save()
 
     def set_promoted(self, versions=None):
+        group = self.addon.promoted_groups(currently_approved=False)
         if versions is None:
             versions = [self.version]
         elif not versions:
             return
+        channel = versions[0].channel
+        if group and (
+            (channel == amo.CHANNEL_LISTED and any(group.listed_pre_review))
+            or (channel == amo.CHANNEL_UNLISTED and any(group.unlisted_pre_review))
+        ):
+            # These addons shouldn't be be attempted for auto approval anyway,
+            # but double check that the cron job isn't trying to approve it.
+            assert not self.user.id == settings.TASK_USER_ID
         if self.addon.promoted_groups(currently_approved=False):
             for version in versions:
                 self.addon.approve_for_version(version)

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -1,7 +1,6 @@
 from collections import OrderedDict, defaultdict
 from datetime import datetime
 
-from django.conf import settings
 from django.contrib.humanize.templatetags.humanize import naturaltime
 from django.core.files.base import ContentFile
 from django.urls import reverse
@@ -1056,19 +1055,11 @@ class ReviewBase:
         file.save()
 
     def set_promoted(self, versions=None):
-        group = self.addon.promoted_groups(currently_approved=False)
         if versions is None:
             versions = [self.version]
         elif not versions:
             return
-        channel = versions[0].channel
-        if group and (
-            (channel == amo.CHANNEL_LISTED and any(group.listed_pre_review))
-            or (channel == amo.CHANNEL_UNLISTED and any(group.unlisted_pre_review))
-        ):
-            # These addons shouldn't be be attempted for auto approval anyway,
-            # but double check that the cron job isn't trying to approve it.
-            assert not self.user.id == settings.TASK_USER_ID
+        if self.addon.promoted_groups(currently_approved=False):
             for version in versions:
                 self.addon.approve_for_version(version)
 


### PR DESCRIPTION
This allows the `listed_pre_review` and `unlisted_pre_review` flags to be flipped back and forth for promoted group without any negative consequences for the versions approved while they are off: they would still have their approval recorded, so they would still be considered approved for the promoted group if the flags are turned back on.

Fixes https://github.com/mozilla/addons/issues/16165