### PR TITLE
Allow admins to include a soft-blocked version in their add/change blocklistsubmission

### DIFF
--- a/src/olympia/blocklist/forms.py
+++ b/src/olympia/blocklist/forms.py
@@ -198,7 +198,7 @@ class BlocklistSubmissionForm(AMOModelForm):
         """Return whether or not the given version should be available as a
         choice for the action we're currently doing."""
         conditions = {
-            BlocklistSubmission.ACTIONS.ADDCHANGE: not version.is_blocked,
+            BlocklistSubmission.ACTIONS.ADDCHANGE: not version.is_hard_blocked,
             BlocklistSubmission.ACTIONS.DELETE: version.is_blocked,
             BlocklistSubmission.ACTIONS.HARDEN: version.is_soft_blocked,
             BlocklistSubmission.ACTIONS.SOFTEN: version.is_hard_blocked,

--- a/src/olympia/blocklist/tests/test_admin.py
+++ b/src/olympia/blocklist/tests/test_admin.py
@@ -481,20 +481,16 @@ class TestBlocklistSubmissionAdmin(TestCase):
         doc = pq(response.content.decode('utf-8'))
         checkboxes = doc('input[name=changed_version_ids]')
 
-        assert len(checkboxes) == 4
+        assert len(checkboxes) == 5
         check_checkbox(checkboxes[0], ver)
         check_checkbox(checkboxes[1], ver_deleted)
         check_checkbox(checkboxes[2], ver_add_subm)
         check_checkbox(checkboxes[3], ver_other)
+        check_checkbox(checkboxes[4], ver_soft_block)
 
         # not a checkbox because blocked already and this is an add action
         assert doc(f'li[data-version-id="{ver_block.id}"]').text() == (
             f'{ver_block.version} (🛑 Hard-Blocked)'
-        )
-
-        # not a checkbox because (soft-)blocked already and this is an add action
-        assert doc(f'li[data-version-id="{ver_soft_block.id}"]').text() == (
-            f'{ver_soft_block.version} (⚠️ Soft-Blocked)'
         )
 
         # Now with an existing submission


### PR DESCRIPTION
Hard-blocked versions remain read-only, they are only meant to be changed through a delete or soften action.

Fixes: mozilla/addons#16180