### PR TITLE
AMOENG-2486 throttling for the contact form submission + input fields max length

### DIFF
--- a/src/olympia/api/throttling.py
+++ b/src/olympia/api/throttling.py
@@ -208,3 +208,19 @@ file_upload_throttles = (
     BurstIPFileUploadThrottle,
     HourlyIPFileUploadThrottle,
 )
+
+
+class ContactSupportUserThrottle(GranularUserRateThrottle):
+    scope = 'user_contact_support'
+    rate = '10/day'
+
+
+class ContactSupportIPThrottle(GranularIPRateThrottle):
+    scope = 'ip_contact_support'
+    rate = '20/day'
+
+
+contact_support_throttles = (
+    ContactSupportUserThrottle,
+    ContactSupportIPThrottle,
+)

--- a/src/olympia/devhub/forms.py
+++ b/src/olympia/devhub/forms.py
@@ -47,7 +47,11 @@ from olympia.amo.messages import DoubleSafe
 from olympia.amo.utils import slug_validator, verify_no_urls
 from olympia.amo.validators import OneOrMoreLetterOrNumberCharacterValidator
 from olympia.api.models import APIKey, APIKeyConfirmation
-from olympia.api.throttling import CheckThrottlesFormMixin, addon_submission_throttles
+from olympia.api.throttling import (
+    CheckThrottlesFormMixin,
+    addon_submission_throttles,
+    contact_support_throttles,
+)
 from olympia.applications.models import AppVersion
 from olympia.constants.categories import CATEGORIES, CATEGORIES_BY_ID
 from olympia.devhub.widgets import CategoriesSelectMultiple, IconTypeSelect
@@ -1754,7 +1758,7 @@ class RollbackVersionForm(forms.Form):
         return self.has_listed or self.has_unlisted
 
 
-class SupportForm(forms.Form):
+class SupportForm(CheckThrottlesFormMixin, forms.Form):
     CATEGORY_CHOICES = [
         ('', _('Choose a category')),
         ('account', _('Account')),
@@ -1762,6 +1766,8 @@ class SupportForm(forms.Form):
         ('policy', _('Policies')),
         ('other', _('Other')),
     ]
+
+    throttle_classes = contact_support_throttles
 
     summary = forms.CharField(
         max_length=255,
@@ -1782,6 +1788,6 @@ class SupportForm(forms.Form):
     )
 
     def __init__(self, *args, **kwargs):
-        kwargs.pop('user')
+        self.request = kwargs.pop('request')
         super().__init__(*args, **kwargs)
         self.label_suffix = ''

--- a/src/olympia/devhub/forms.py
+++ b/src/olympia/devhub/forms.py
@@ -1781,6 +1781,7 @@ class SupportForm(CheckThrottlesFormMixin, forms.Form):
         label=_('Select category'),
     )
     body = forms.CharField(
+        max_length=10000,
         widget=forms.Textarea(
             attrs={'rows': 8, 'placeholder': _('Give us more details about the issue')}
         ),

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -34,6 +34,7 @@ from olympia.amo.templatetags.jinja_helpers import (
 from olympia.amo.tests import (
     TestCase,
     addon_factory,
+    get_random_ip,
     user_factory,
     version_factory,
 )
@@ -42,7 +43,7 @@ from olympia.api.models import SYMMETRIC_JWT_TYPE, APIKey, APIKeyConfirmation
 from olympia.applications.models import AppVersion
 from olympia.constants.promoted import PROMOTED_GROUP_CHOICES
 from olympia.devhub.decorators import dev_required
-from olympia.devhub.forms import APIKeyForm
+from olympia.devhub.forms import APIKeyForm, SupportForm
 from olympia.devhub.models import BlogPost, SurveyResponse
 from olympia.devhub.tasks import validate
 from olympia.devhub.views import get_next_version_number
@@ -2835,3 +2836,48 @@ class TestSupportView(TestCase):
         assert response.status_code == 200
         (payload,) = mock_task.call_args[0]
         assert payload['brand_id'] == 12345
+
+    def test_post_throttled_user(self):
+        self.client.force_login(self.user)
+        with time_machine.travel(datetime.now(), tick=False):
+            for _x in range(0, 10):
+                self._add_fake_throttling_action(
+                    view_class=SupportForm,
+                    url=self.url,
+                    user=self.user,
+                    remote_addr='1.2.3.4',
+                )
+            response = self._post()
+        assert response.status_code == 200
+        form = response.context['form']
+        assert form.non_field_errors() == [
+            'You have submitted this form too many times recently. '
+            'Please try again after some time.'
+        ]
+
+    def test_post_throttled_ip(self):
+        with time_machine.travel(datetime.now(), tick=False):
+            for _x in range(0, 20):
+                self._add_fake_throttling_action(
+                    view_class=SupportForm,
+                    url=self.url,
+                    user=user_factory(),
+                    remote_addr='5.6.7.8',
+                )
+            self.client.force_login(self.user)
+            response = self.client.post(
+                self.url,
+                {
+                    'summary': 'Something is broken',
+                    'category': 'technical',
+                    'body': 'Please help me fix this issue.',
+                },
+                REMOTE_ADDR='5.6.7.8',
+                HTTP_X_FORWARDED_FOR=f'5.6.7.8, {get_random_ip()}',
+            )
+        assert response.status_code == 200
+        form = response.context['form']
+        assert form.non_field_errors() == [
+            'You have submitted this form too many times recently. '
+            'Please try again after some time.'
+        ]

--- a/src/olympia/devhub/tests/test_views.py
+++ b/src/olympia/devhub/tests/test_views.py
@@ -2812,6 +2812,21 @@ class TestSupportView(TestCase):
         form = response.context['form']
         assert form.errors
 
+    def test_post_invalid_fields_too_long(self):
+        self.client.force_login(self.user)
+        response = self.client.post(
+            self.url,
+            {
+                'summary': 'x' * 256,
+                'category': 'technical',
+                'body': 'x' * 10001,
+            },
+        )
+        assert response.status_code == 200
+        form = response.context['form']
+        assert 'summary' in form.errors
+        assert 'body' in form.errors
+
     @mock.patch('olympia.devhub.tasks.create_support_ticket.delay')
     def test_post_success(self, mock_task):
         self.client.force_login(self.user)

--- a/src/olympia/devhub/views.py
+++ b/src/olympia/devhub/views.py
@@ -2304,7 +2304,7 @@ def support(request):
 
     form = forms.SupportForm(
         request.POST or None,
-        user=request.user,
+        request=request,
     )
     if request.method == 'POST' and form.is_valid():
         payload = {


### PR DESCRIPTION
### Description

two commits for 2 contact-form related issues:
* throttling
* max-length for the input fields

### Checklist

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
