### PR TITLE
Refactor ReviewBase.set_promoted() to avoid calling promoted_groups() twice

### DIFF
--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -1057,19 +1057,19 @@ class ReviewBase:
 
     def set_promoted(self, versions=None):
         group = self.addon.promoted_groups(currently_approved=False)
-        if versions is None:
-            versions = [self.version]
-        elif not versions:
-            return
-        channel = versions[0].channel
-        if group and (
-            (channel == amo.CHANNEL_LISTED and any(group.listed_pre_review))
-            or (channel == amo.CHANNEL_UNLISTED and any(group.unlisted_pre_review))
-        ):
-            # These addons shouldn't be be attempted for auto approval anyway,
-            # but double check that the cron job isn't trying to approve it.
-            assert not self.user.id == settings.TASK_USER_ID
-        if self.addon.promoted_groups(currently_approved=False):
+        if group:
+            if versions is None:
+                versions = [self.version]
+            elif not versions:
+                return
+            channel = versions[0].channel
+            if (channel == amo.CHANNEL_LISTED and any(group.listed_pre_review)) or (
+                channel == amo.CHANNEL_UNLISTED and any(group.unlisted_pre_review)
+            ):
+                # These addons shouldn't be be attempted for auto approval
+                # anyway, but double check that the cron job isn't trying to
+                # approve it.
+                assert not self.user.id == settings.TASK_USER_ID
             for version in versions:
                 self.addon.approve_for_version(version)
 


### PR DESCRIPTION
See https://github.com/mozilla/addons-server/pull/24824#pullrequestreview-4229791364