### PR TITLE
Instruct dependabot to search for requirements starting at the root

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -72,7 +72,7 @@ updates:
     exclude:
       - addons-linter
 - package-ecosystem: pip
-  directory: "/requirements"
+  directory: "/"
   schedule:
     interval: daily
   groups:


### PR DESCRIPTION
Ever since https://github.com/dependabot/dependabot-core/pull/14786 dependabot has been excluding all our requirement files (when experiment `python-requirements-file-name-filtering` is `true`).

Because we instructed dependabot to look under `/requirements` instead of `/`, it didn't use the full filename for each requirement file, and ended up filtering them out.
