### PR TITLE
cache existing Blocks so reversing delayed block actions doesn't fail

### DIFF
--- a/src/olympia/abuse/actions.py
+++ b/src/olympia/abuse/actions.py
@@ -19,7 +19,7 @@ from olympia.addons.models import Addon, AddonApprovalsCounter, AddonReviewerFla
 from olympia.amo.templatetags.jinja_helpers import absolutify
 from olympia.amo.utils import send_mail
 from olympia.bandwagon.models import Collection
-from olympia.blocklist.models import BlocklistSubmission, BlockType
+from olympia.blocklist.models import Block, BlocklistSubmission, BlockType
 from olympia.blocklist.utils import delete_versions_from_blocks, save_versions_to_blocks
 from olympia.constants.abuse import DECISION_ACTIONS
 from olympia.constants.permissions import ADDONS_HIGH_IMPACT_APPROVE
@@ -742,6 +742,18 @@ class _ContentActionDelayedBlockAddon(ContentActionBlockAddon):
                 f'{self.__class__.__name__} requires delay_days to be set'
             )
 
+    @classmethod
+    def get_existing_blocks_from_decision(cls, decision):
+        """Get existing blocks for the decision's target and cache them on the decision.
+        We're caching them on the decision to avoid hitting the database multiple times
+        when reversing a decision, and because get_blocks_from_guids uses replicas, so
+        the data can be stale when we're running in a transaction"""
+        if not hasattr(decision, '_existing_blocks'):
+            decision._existing_blocks = Block.get_blocks_from_guids(
+                [decision.target.guid]
+            )
+        return decision._existing_blocks
+
     def process_action(self, release_hold=False):
         versions_qs = self.versions_block_will_affect
         # if this is a followup action, and the primary action is rejecting specific
@@ -795,7 +807,7 @@ class _ContentActionDelayedBlockAddon(ContentActionBlockAddon):
             )
         )
         delete_versions_from_blocks(
-            [guid],
+            cls.get_existing_blocks_from_decision(original_decision),
             BlocklistSubmission(
                 input_guids=guid,
                 action=BlocklistSubmission.ACTIONS.DELETE,

--- a/src/olympia/abuse/tests/test_actions.py
+++ b/src/olympia/abuse/tests/test_actions.py
@@ -2285,6 +2285,28 @@ class TestContentActionDelayedShortSoftBlockAddon(BaseTestContentAction, TestCas
         )
         self._test_approve_appeal_or_override(ContentActionTargetAppealApprove)
 
+    def test_approve_appeal_success_followup_with_multiple_followups(self):
+        self.past_negative_decision.update(
+            appeal_job=self.cinder_job, action=DECISION_ACTIONS.AMO_DISABLE_ADDON
+        )
+        ContentDecisionFollowupAction.objects.create(
+            decision=self.past_negative_decision,
+            action=self.takedown_decision_action,
+            action_date=datetime.now(),
+        )
+        # These follow-up actions are redundant, but shouldn't cause errors.
+        ContentDecisionFollowupAction.objects.create(
+            decision=self.past_negative_decision,
+            action=DECISION_ACTIONS.AMO_FU_DELAY_LONG_SOFT_BLOCK_ADDON,
+            action_date=datetime.now(),
+        )
+        ContentDecisionFollowupAction.objects.create(
+            decision=self.past_negative_decision,
+            action=DECISION_ACTIONS.AMO_FU_DELAY_LONG_HARD_BLOCK_ADDON,
+            action_date=datetime.now(),
+        )
+        self._test_approve_appeal_or_override(ContentActionTargetAppealApprove)
+
     def test_approve_override_success_followup(self):
         self.decision.update(override_of=self.past_negative_decision)
         self.past_negative_decision.update(action=DECISION_ACTIONS.AMO_DISABLE_ADDON)

--- a/src/olympia/blocklist/models.py
+++ b/src/olympia/blocklist/models.py
@@ -536,7 +536,8 @@ class BlocklistSubmission(ModelBase):
 
         for guids_chunk in chunked(all_guids_to_block, 100):
             # This function will remove BlockVersions and delete the Block if empty
-            delete_versions_from_blocks(guids_chunk, self)
+            blocks = Block.get_blocks_from_guids(guids_chunk)
+            delete_versions_from_blocks(blocks, self)
             self.save()
 
         self.update(signoff_state=self.SIGNOFF_STATES.PUBLISHED)

--- a/src/olympia/blocklist/tests/test_utils.py
+++ b/src/olympia/blocklist/tests/test_utils.py
@@ -430,7 +430,7 @@ class TestDeleteVersionsFromBlocks(TestCase):
         addon = addon_factory()
         version_factory(addon=addon)
         user = user_factory()
-        block_factory(guid=addon.guid, updated_by=self.task_user)
+        block = block_factory(guid=addon.guid, updated_by=self.task_user)
         changed_version_ids = list(
             addon.versions.values_list('pk', flat=True).order_by('pk')
         )
@@ -445,7 +445,7 @@ class TestDeleteVersionsFromBlocks(TestCase):
             signoff_state=BlocklistSubmission.SIGNOFF_STATES.PUBLISHED,
         )
         ActivityLog.objects.all().delete()
-        delete_versions_from_blocks([addon.guid], submission)
+        delete_versions_from_blocks([block], submission)
         for version in addon.versions.all():
             assert not version.is_blocked
 
@@ -468,7 +468,7 @@ class TestDeleteVersionsFromBlocks(TestCase):
         version_factory(addon=addon)
         user = user_factory()
         signoffer = user_factory()
-        block_factory(guid=addon.guid, updated_by=self.task_user)
+        block = block_factory(guid=addon.guid, updated_by=self.task_user)
         changed_version_ids = list(
             addon.versions.values_list('pk', flat=True).order_by('pk')
         )
@@ -484,7 +484,7 @@ class TestDeleteVersionsFromBlocks(TestCase):
             signoff_by=signoffer,
         )
         ActivityLog.objects.all().delete()
-        delete_versions_from_blocks([addon.guid], submission)
+        delete_versions_from_blocks([block], submission)
         for version in addon.versions.all():
             assert not version.is_blocked
 

--- a/src/olympia/blocklist/utils.py
+++ b/src/olympia/blocklist/utils.py
@@ -257,12 +257,11 @@ def save_versions_to_blocks(guids, submission):
     return blocks
 
 
-def delete_versions_from_blocks(guids, submission):
-    from .models import Block, BlockVersion
+def delete_versions_from_blocks(blocks, submission):
+    from .models import BlockVersion
 
     modified_datetime = datetime.now()
 
-    blocks = Block.get_blocks_from_guids(guids)
     should_override_block_metadata = not submission.preserve_block_metadata
     for block in blocks:
         if not block.id:


### PR DESCRIPTION
Fixes mozilla/addons#16204

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

Works around the replica query for Blocks being out of date when we're in a transaction on the primary by running the query once and caching the results, so the same Block instances can be operated on/over.

### Context

I'm not a massive fan of this solution, but I think it works - the loop in `delete_versions_from_blocks` will skip over Block instances where the id is `None`, and that's one of things that happens when an instance is deleted.  I added a test but it's not really complete as it's still running against a single database in tests.

### Testing

- set up a policy in Cinder with multiple follow-up enforcement actions, both for the same block type and other types.
- report an add-on
- make a decision that a job in Cinder with that policy, and playback that decision payload locally
- edit the blocklistsubmission instances to remove their delays, so they expand into Block and BlockVersion instances immediately
- override the decision in Cinder, and playback the override decision
- all the blocked versions should be removed, along with the Block instance itself, with no failures.

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [x] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
