### PR TITLE
update CheckConstraint to use condition kwarg over check

### DIFF
--- a/src/olympia/abuse/migrations/0001_initial_squashed_0010_cinderreport.py
+++ b/src/olympia/abuse/migrations/0001_initial_squashed_0010_cinderreport.py
@@ -81,7 +81,7 @@ class Migration(migrations.Migration):
         ),
         migrations.AddConstraint(
             model_name='abusereport',
-            constraint=models.CheckConstraint(check=models.Q(models.Q(models.Q(('guid', ''), _negated=True), ('guid__isnull', False), ('user__isnull', True)), models.Q(('guid__isnull', True), ('user__isnull', False)), _connector='OR'), name='just_one_of_guid_and_user_must_be_set'),
+            constraint=models.CheckConstraint(condition=models.Q(models.Q(models.Q(('guid', ''), _negated=True), ('guid__isnull', False), ('user__isnull', True)), models.Q(('guid__isnull', True), ('user__isnull', False)), _connector='OR'), name='just_one_of_guid_and_user_must_be_set'),
         ),
         migrations.AlterField(
             model_name='abusereport',

--- a/src/olympia/abuse/migrations/0007_auto_20220803_0948.py
+++ b/src/olympia/abuse/migrations/0007_auto_20220803_0948.py
@@ -29,6 +29,6 @@ class Migration(migrations.Migration):
         ),
         migrations.AddConstraint(
             model_name='abusereport',
-            constraint=models.CheckConstraint(check=models.Q(models.Q(models.Q(('guid', ''), _negated=True), ('guid__isnull', False), ('user__isnull', True)), models.Q(('guid__isnull', True), ('user__isnull', False)), _connector='OR'), name='just_one_of_guid_and_user_must_be_set'),
+            constraint=models.CheckConstraint(condition=models.Q(models.Q(models.Q(('guid', ''), _negated=True), ('guid__isnull', False), ('user__isnull', True)), models.Q(('guid__isnull', True), ('user__isnull', False)), _connector='OR'), name='just_one_of_guid_and_user_must_be_set'),
         ),
     ]

--- a/src/olympia/abuse/migrations/0015_remove_abusereport_just_one_of_guid_and_user_must_be_set_and_more.py
+++ b/src/olympia/abuse/migrations/0015_remove_abusereport_just_one_of_guid_and_user_must_be_set_and_more.py
@@ -28,7 +28,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name='abusereport',
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     models.Q(
                         models.Q(('guid', ''), _negated=True),
                         ('guid__isnull', False),

--- a/src/olympia/abuse/migrations/0016_remove_abusereport_just_one_of_guid_user_rating_must_be_set_and_more.py
+++ b/src/olympia/abuse/migrations/0016_remove_abusereport_just_one_of_guid_user_rating_must_be_set_and_more.py
@@ -50,7 +50,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="abusereport",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     models.Q(
                         models.Q(("guid", ""), _negated=True),
                         ("collection__isnull", True),

--- a/src/olympia/abuse/migrations/0027_add_cinderdecision.py
+++ b/src/olympia/abuse/migrations/0027_add_cinderdecision.py
@@ -58,6 +58,6 @@ class Migration(migrations.Migration):
         ),
         migrations.AddConstraint(
             model_name='cinderdecision',
-            constraint=models.CheckConstraint(check=models.Q(models.Q(('addon__isnull', False), ('collection__isnull', True), ('rating__isnull', True), ('user__isnull', True)), models.Q(('addon__isnull', True), ('collection__isnull', True), ('rating__isnull', True), ('user__isnull', False)), models.Q(('addon__isnull', True), ('collection__isnull', True), ('rating__isnull', False), ('user__isnull', True)), models.Q(('addon__isnull', True), ('collection__isnull', False), ('rating__isnull', True), ('user__isnull', True)), _connector='OR'), name='just_one_of_addon_user_rating_collection_must_be_set'),
+            constraint=models.CheckConstraint(condition=models.Q(models.Q(('addon__isnull', False), ('collection__isnull', True), ('rating__isnull', True), ('user__isnull', True)), models.Q(('addon__isnull', True), ('collection__isnull', True), ('rating__isnull', True), ('user__isnull', False)), models.Q(('addon__isnull', True), ('collection__isnull', True), ('rating__isnull', False), ('user__isnull', True)), models.Q(('addon__isnull', True), ('collection__isnull', False), ('rating__isnull', True), ('user__isnull', True)), _connector='OR'), name='just_one_of_addon_user_rating_collection_must_be_set'),
         ),
     ]

--- a/src/olympia/abuse/migrations/0057_remove_cinderjob_decision_alter_cinderjob_job_id.py
+++ b/src/olympia/abuse/migrations/0057_remove_cinderjob_decision_alter_cinderjob_job_id.py
@@ -22,7 +22,7 @@ class Migration(migrations.Migration):
         ),
         migrations.AddConstraint(
             model_name='cinderjob',
-            constraint=models.CheckConstraint(check=models.Q(('job_id', ''), _negated=True), name='no_empty_job_id'),
+            constraint=models.CheckConstraint(condition=models.Q(('job_id', ''), _negated=True), name='no_empty_job_id'),
         ),
         migrations.RemoveField(
             model_name='cinderjob',

--- a/src/olympia/abuse/models.py
+++ b/src/olympia/abuse/models.py
@@ -102,7 +102,7 @@ class CinderJob(ModelBase):
 
     class Meta:
         constraints = [
-            models.CheckConstraint(name='no_empty_job_id', check=~Q(job_id=''))
+            models.CheckConstraint(name='no_empty_job_id', condition=~Q(job_id=''))
         ]
 
     @property
@@ -798,7 +798,7 @@ class AbuseReport(ModelBase):
         constraints = [
             models.CheckConstraint(
                 name='just_one_of_guid_user_rating_collection_must_be_set',
-                check=(
+                condition=(
                     # Abuse is against...
                     # a guid
                     models.Q(
@@ -1056,7 +1056,7 @@ class ContentDecision(ModelBase):
                 name='just_one_of_addon_user_rating_collection_must_be_set',
                 # Decision is against...
                 # an addon
-                check=models.Q(
+                condition=models.Q(
                     addon__isnull=False,
                     user__isnull=True,
                     rating__isnull=True,

--- a/src/olympia/reviewers/migrations/0036_alter_needshumanreview_reason_and_more.py
+++ b/src/olympia/reviewers/migrations/0036_alter_needshumanreview_reason_and_more.py
@@ -23,6 +23,6 @@ class Migration(migrations.Migration):
         ),
         migrations.AddConstraint(
             model_name='reviewactionreason',
-            constraint=models.CheckConstraint(check=models.Q(models.Q(('canned_response', ''), _negated=True), models.Q(('canned_block_reason', ''), _negated=True), _connector='OR'), name='either_canned_response_or_canned_block_reason_must_be_set'),
+            constraint=models.CheckConstraint(condition=models.Q(models.Q(('canned_response', ''), _negated=True), models.Q(('canned_block_reason', ''), _negated=True), _connector='OR'), name='either_canned_response_or_canned_block_reason_must_be_set'),
         ),
     ]

--- a/src/olympia/reviewers/models.py
+++ b/src/olympia/reviewers/models.py
@@ -798,7 +798,7 @@ class ReviewActionReason(ModelBase):
         constraints = [
             models.CheckConstraint(
                 name='either_canned_response_or_canned_block_reason_must_be_set',
-                check=(
+                condition=(
                     ~models.Q(canned_response='') | ~models.Q(canned_block_reason='')
                 ),
             )

--- a/src/olympia/versions/migrations/0023_auto_20220204_1646.py
+++ b/src/olympia/versions/migrations/0023_auto_20220204_1646.py
@@ -12,6 +12,6 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AddConstraint(
             model_name='versionreviewerflags',
-            constraint=models.CheckConstraint(check=models.Q(models.Q(('pending_rejection__isnull', True), ('pending_rejection_by__isnull', True)), ('pending_rejection__isnull', False), _connector='OR'), name='pending_rejection_both_none'),
+            constraint=models.CheckConstraint(condition=models.Q(models.Q(('pending_rejection__isnull', True), ('pending_rejection_by__isnull', True)), ('pending_rejection__isnull', False), _connector='OR'), name='pending_rejection_both_none'),
         ),
     ]

--- a/src/olympia/versions/migrations/0026_auto_20220722_1704.py
+++ b/src/olympia/versions/migrations/0026_auto_20220722_1704.py
@@ -21,6 +21,6 @@ class Migration(migrations.Migration):
         ),
         migrations.AddConstraint(
             model_name='versionreviewerflags',
-            constraint=models.CheckConstraint(check=models.Q(models.Q(('pending_content_rejection__isnull', True), ('pending_rejection__isnull', True), ('pending_rejection_by__isnull', True)), ('pending_rejection__isnull', False), _connector='OR'), name='pending_rejection_all_none'),
+            constraint=models.CheckConstraint(condition=models.Q(models.Q(('pending_content_rejection__isnull', True), ('pending_rejection__isnull', True), ('pending_rejection_by__isnull', True)), ('pending_rejection__isnull', False), _connector='OR'), name='pending_rejection_all_none'),
         ),
     ]

--- a/src/olympia/versions/migrations/0027_auto_20220729_0932.py
+++ b/src/olympia/versions/migrations/0027_auto_20220729_0932.py
@@ -25,6 +25,6 @@ class Migration(migrations.Migration):
         migrations.RunPython(set_content_rejection_to_false),
         migrations.AddConstraint(
             model_name='versionreviewerflags',
-            constraint=models.CheckConstraint(check=models.Q(models.Q(('pending_content_rejection__isnull', True), ('pending_rejection__isnull', True), ('pending_rejection_by__isnull', True)), models.Q(('pending_content_rejection__isnull', False), ('pending_rejection__isnull', False), ('pending_rejection_by__isnull', False)), _connector='OR'), name='pending_rejection_all_none'),
+            constraint=models.CheckConstraint(condition=models.Q(models.Q(('pending_content_rejection__isnull', True), ('pending_rejection__isnull', True), ('pending_rejection_by__isnull', True)), models.Q(('pending_content_rejection__isnull', False), ('pending_rejection__isnull', False), ('pending_rejection_by__isnull', False)), _connector='OR'), name='pending_rejection_all_none'),
         ),
     ]

--- a/src/olympia/versions/models.py
+++ b/src/olympia/versions/models.py
@@ -1176,7 +1176,7 @@ class VersionReviewerFlags(ModelBase):
         constraints = [
             models.CheckConstraint(
                 name='pending_rejection_all_none',
-                check=(
+                condition=(
                     models.Q(
                         pending_rejection__isnull=True,
                         pending_rejection_by__isnull=True,


### PR DESCRIPTION
One of the items from mozilla/addons#16012

<!--
Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
-->

### Description

CheckConstraint's `check` arg is deprecated in favour of a `condition` kwarg.  

### Context

It apparently will be removed in django6.0, so this is to get ahead of that deprecation, and to silence some of the warnings that clutter up logging

### Testing

n/a

### Checklist

<!--
Here's a few guidelines as to what we need in your PR before we review it.
Please delete anything that isn't relevant to your patch.
-->

- [x] Add `#ISSUENUM` at the top of your PR to an existing open issue in the mozilla/addons repository.
- [x] Successfully verified the change locally.
- [ ] The change is covered by automated tests, or otherwise indicated why doing so is unnecessary/impossible.
- [ ] Add before and after screenshots (Only for changes that impact the UI).
- [ ] Add or update relevant [docs](../docs/) reflecting the changes made.
