### PR TITLE
Raise error on broken locales when linting them

### DIFF
--- a/scripts/compile_locales.py
+++ b/scripts/compile_locales.py
@@ -2,7 +2,7 @@
 
 import os
 import subprocess
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 
@@ -16,11 +16,7 @@ def process_po_file(pofile, attempt=1):
 
     try:
         # Run dennis-cmd lint
-        subprocess.run(
-            ['dennis-cmd', 'lint', '--errorsonly', pofile],
-            capture_output=True,
-            check=False,
-        )
+        subprocess.run(['dennis-cmd', 'lint', '--errorsonly', pofile], check=True)
         # If lint passes, run msgfmt
         subprocess.run(['msgfmt', '-o', mo_path, pofile], check=True)
         return
@@ -41,20 +37,13 @@ def compile_locales():
 
     print(f'Compiling locales in {locale_dir}')
 
-    # Collect all files first
-    django_files = []
-    djangojs_files = []
-    for root, _, files in locale_dir.walk():
-        for file in files:
-            if file == 'django.po':
-                django_files.append(root / file)
-            elif file == 'djangojs.po':
-                djangojs_files.append(root / file)
-
-    # Process django.po files in parallel
+    futures = []
     with ThreadPoolExecutor() as executor:
-        executor.map(process_po_file, django_files + djangojs_files)
-
+        for root, _, files in locale_dir.walk():
+            for file in files:
+                if file.endswith('.po'):
+                    futures.append(executor.submit(process_po_file, root / file))
+    [future.result() for future in as_completed(futures)]
 
 if __name__ == '__main__':
     compile_locales()

--- a/scripts/compile_locales.py
+++ b/scripts/compile_locales.py
@@ -45,5 +45,6 @@ def compile_locales():
                     futures.append(executor.submit(process_po_file, root / file))
     [future.result() for future in as_completed(futures)]
 
+
 if __name__ == '__main__':
     compile_locales()

--- a/tests/make/test_compile_locales.py
+++ b/tests/make/test_compile_locales.py
@@ -23,26 +23,36 @@ class TestCompileLocales(TestCase):
         self.assertRaises(ImportError, compile_locales)
 
     @patch.dict(sys.modules, {'dennis': Mock()})
-    @patch('scripts.compile_locales.ThreadPoolExecutor')
-    def test_process_po_file(self, mock_executor):
+    @patch('scripts.compile_locales.process_po_file')
+    def test_process_po_file(self, process_po_file_mock):
         """Test that the script processes po files"""
         # Create po files
         django_po = self.home_dir / 'locale' / 'django.po'
         django_po.touch()
         djangojs_po = self.home_dir / 'locale' / 'djangojs.po'
         djangojs_po.touch()
-
-        # Setup ThreadPoolExecutor mock
-        mock_executor_instance = Mock()
-        mock_executor.return_value.__enter__.return_value = mock_executor_instance
+        extra_file = self.home_dir / 'locale' / 'django.pot'
+        extra_file.touch()
 
         with override_env(HOME=self.home_dir.as_posix()):
             compile_locales()
 
-        # Get the actual arguments passed to map
-        actual_args = mock_executor_instance.map.call_args[0]
-        self.assertEqual(actual_args[0], process_po_file)
-        self.assertEqual(list(actual_args[1]), [django_po, djangojs_po])
+        assert len(process_po_file_mock.call_args_list) == 2
+        assert process_po_file_mock.call_args_list[0][0][0] == django_po
+        assert process_po_file_mock.call_args_list[1][0][0] == djangojs_po
+
+    @patch.dict(sys.modules, {'dennis': Mock()})
+    @patch('scripts.compile_locales.process_po_file')
+    def test_with_failure(self, process_po_file_mock):
+        process_po_file_mock.side_effect = subprocess.CalledProcessError(
+            returncode=1, cmd='foo'
+        )
+
+        django_po = self.home_dir / 'locale' / 'django.po'
+        django_po.touch()
+
+        with override_env(HOME=self.home_dir.as_posix()):
+            self.assertRaises(subprocess.CalledProcessError, compile_locales)
 
 
 class TestProcessPoFile(TestCase):
@@ -60,8 +70,7 @@ class TestProcessPoFile(TestCase):
         assert self.mock_subprocess.call_args_list == [
             mock.call(
                 ['dennis-cmd', 'lint', '--errorsonly', self.pofile.as_posix()],
-                capture_output=True,
-                check=False,
+                check=True,
             ),
             mock.call(
                 [

--- a/tests/make/test_compile_locales.py
+++ b/tests/make/test_compile_locales.py
@@ -38,8 +38,12 @@ class TestCompileLocales(TestCase):
             compile_locales()
 
         assert len(process_po_file_mock.call_args_list) == 2
-        assert process_po_file_mock.call_args_list[0][0][0] == django_po
-        assert process_po_file_mock.call_args_list[1][0][0] == djangojs_po
+        expected = {djangojs_po, django_po}
+        actual = {
+            process_po_file_mock.call_args_list[0][0][0],
+            process_po_file_mock.call_args_list[1][0][0],
+        }
+        assert actual == expected
 
     @patch.dict(sys.modules, {'dennis': Mock()})
     @patch('scripts.compile_locales.process_po_file')


### PR DESCRIPTION
Since `check` was `False` and this was all executed by a `ThreadPoolExecutor` without checking the results, failures were silent.

Fixes https://github.com/mozilla/addons/issues/16209