### PR TITLE
Move auto_approval prevention in rejection code to the ContentAction

### DIFF
--- a/src/olympia/abuse/actions.py
+++ b/src/olympia/abuse/actions.py
@@ -397,7 +397,17 @@ class ContentActionDisableAddon(ContentAction):
             .order_by('-pk')
         )
 
+    def prevent_auto_approval(self):
+        AddonReviewerFlags.objects.update_or_create(
+            addon=self.target,
+            defaults={
+                'auto_approval_disabled': True,
+                'auto_approval_disabled_unlisted': True,
+            },
+        )
+
     def process_action(self, release_hold=False):
+        self.prevent_auto_approval()
         if self.target.status != amo.STATUS_DISABLED:
             # Set target_versions before executing the action, since the
             # queryset depends on the file statuses.
@@ -407,6 +417,7 @@ class ContentActionDisableAddon(ContentAction):
         return None
 
     def hold_action(self):
+        self.prevent_auto_approval()
         if self.target.status != amo.STATUS_DISABLED:
             self.decision.target_versions.set(self.versions_force_disable_will_affect)
             return self.log_action(amo.LOG.HELD_ACTION_FORCE_DISABLE)
@@ -503,7 +514,9 @@ class ContentActionRejectVersion(ContentActionDisableAddon):
             message = template.render(context_dict)
             send_mail(subject, message, recipient_list=recipients)
 
-    def prevent_auto_approval_in_relevant_channels(self):
+    def prevent_auto_approval(self):
+        # For version rejection we only prevent auto-approval in relevant
+        # channel(s) until the next manual approval.
         channels = list(
             self.target_versions.values_list('channel', flat=True).distinct()
         )
@@ -550,7 +563,7 @@ class ContentActionRejectVersion(ContentActionDisableAddon):
                 },
             )
 
-        self.prevent_auto_approval_in_relevant_channels()
+        self.prevent_auto_approval()
         self.target.update_status()
         self.notify_stakeholders('Rejection')
         return self.log_action(
@@ -558,9 +571,9 @@ class ContentActionRejectVersion(ContentActionDisableAddon):
         )
 
     def hold_action(self):
-        # Even if the action is held, we want to alwas prevent auto-approval in
-        # relevant channels.
-        self.prevent_auto_approval_in_relevant_channels()
+        # Even if the action is held, we want to always prevent auto-approval
+        # in relevant channels.
+        self.prevent_auto_approval()
         return self.log_action(
             amo.LOG.HELD_ACTION_REJECT_CONTENT
             if self.content_review
@@ -636,7 +649,7 @@ class ContentActionRejectVersionDelayed(ContentActionRejectVersion):
                     'pending_content_rejection': self.content_review,
                 },
             )
-        self.prevent_auto_approval_in_relevant_channels()
+        self.prevent_auto_approval()
         # Developers should be notified again once the deadline is close.
         AddonReviewerFlags.objects.update_or_create(
             addon=self.target,
@@ -650,9 +663,9 @@ class ContentActionRejectVersionDelayed(ContentActionRejectVersion):
         )
 
     def hold_action(self):
-        # Even if the action is held, we want to alwas prevent auto-approval in
-        # relevant channels.
-        self.prevent_auto_approval_in_relevant_channels()
+        # Even if the action is held, we want to always prevent auto-approval
+        # in relevant channels.
+        self.prevent_auto_approval()
         return self.log_action(
             amo.LOG.HELD_ACTION_REJECT_CONTENT_DELAYED
             if self.content_review
@@ -713,6 +726,7 @@ class ContentActionBlockAddon(ContentActionDisableAddon):
             # For now this action should only be used automatically by scanners and
             # monitoring tasks, not cinder webhook
             raise NotImplementedError
+        self.prevent_auto_approval()
         versions = list(self.versions_block_will_affect)
         if versions:
             # Set target_versions before executing the action, since the
@@ -752,6 +766,7 @@ class ContentActionBlockAddon(ContentActionDisableAddon):
         return None
 
     def hold_action(self):
+        self.prevent_auto_approval()
         if versions := list(self.versions_block_will_affect):
             self.decision.target_versions.set(versions)
             return self.log_action(amo.LOG.HELD_ACTION_FORCE_DISABLE)

--- a/src/olympia/abuse/actions.py
+++ b/src/olympia/abuse/actions.py
@@ -503,6 +503,25 @@ class ContentActionRejectVersion(ContentActionDisableAddon):
             message = template.render(context_dict)
             send_mail(subject, message, recipient_list=recipients)
 
+    def prevent_auto_approval_in_relevant_channels(self):
+        channels = list(
+            self.target_versions.values_list('channel', flat=True).distinct()
+        )
+        channels_to_flags = {
+            amo.CHANNEL_LISTED: 'auto_approval_disabled_until_next_approval',
+            amo.CHANNEL_UNLISTED: 'auto_approval_disabled_until_next_approval_unlisted',
+        }
+        auto_approval_flags = {
+            channels_to_flags[channel]: True
+            for channel in channels
+            if channel in channels_to_flags
+        }
+        if auto_approval_flags:
+            AddonReviewerFlags.objects.update_or_create(
+                addon=self.target,
+                defaults=auto_approval_flags,
+            )
+
     def process_action(self, release_hold=False):
         if not self.decision.reviewer_user:
             # This action should only be used by reviewer tools, not cinder webhook
@@ -531,6 +550,7 @@ class ContentActionRejectVersion(ContentActionDisableAddon):
                 },
             )
 
+        self.prevent_auto_approval_in_relevant_channels()
         self.target.update_status()
         self.notify_stakeholders('Rejection')
         return self.log_action(
@@ -538,6 +558,9 @@ class ContentActionRejectVersion(ContentActionDisableAddon):
         )
 
     def hold_action(self):
+        # Even if the action is held, we want to alwas prevent auto-approval in
+        # relevant channels.
+        self.prevent_auto_approval_in_relevant_channels()
         return self.log_action(
             amo.LOG.HELD_ACTION_REJECT_CONTENT
             if self.content_review
@@ -613,6 +636,7 @@ class ContentActionRejectVersionDelayed(ContentActionRejectVersion):
                     'pending_content_rejection': self.content_review,
                 },
             )
+        self.prevent_auto_approval_in_relevant_channels()
         # Developers should be notified again once the deadline is close.
         AddonReviewerFlags.objects.update_or_create(
             addon=self.target,
@@ -626,6 +650,9 @@ class ContentActionRejectVersionDelayed(ContentActionRejectVersion):
         )
 
     def hold_action(self):
+        # Even if the action is held, we want to alwas prevent auto-approval in
+        # relevant channels.
+        self.prevent_auto_approval_in_relevant_channels()
         return self.log_action(
             amo.LOG.HELD_ACTION_REJECT_CONTENT_DELAYED
             if self.content_review

--- a/src/olympia/abuse/tests/test_actions.py
+++ b/src/olympia/abuse/tests/test_actions.py
@@ -1415,6 +1415,28 @@ class TestContentActionRejectVersion(TestContentActionDisableAddon):
 
     def test_execute_action(self):
         subject = self._test_reject_version(content_review=False)
+        flags = self.addon.reviewerflags.reload()
+        assert flags.auto_approval_disabled_until_next_approval
+        assert not flags.auto_approval_disabled_until_next_approval_unlisted
+        assert len(mail.outbox) == 3
+        self._test_reporter_takedown_email(subject)
+
+    def test_execute_action_unlisted(self):
+        self.decision.target_versions.update(channel=amo.CHANNEL_UNLISTED)
+        subject = self._test_reject_version(content_review=False)
+        flags = self.addon.reviewerflags.reload()
+        assert flags.auto_approval_disabled_until_next_approval_unlisted
+        assert not flags.auto_approval_disabled_until_next_approval
+        assert len(mail.outbox) == 3
+        self._test_reporter_takedown_email(subject)
+
+    def test_execute_action_both_channels(self):
+        # Only make one of the two versions targeted unlisted.
+        self.version.update(channel=amo.CHANNEL_UNLISTED)
+        subject = self._test_reject_version(content_review=False)
+        flags = self.addon.reviewerflags.reload()
+        assert flags.auto_approval_disabled_until_next_approval_unlisted
+        assert flags.auto_approval_disabled_until_next_approval
         assert len(mail.outbox) == 3
         self._test_reporter_takedown_email(subject)
 
@@ -1542,6 +1564,9 @@ class TestContentActionRejectVersion(TestContentActionDisableAddon):
 
     def test_execute_action_delayed(self, *, content_review=False):
         subject = self._test_reject_version_delayed(content_review=content_review)
+        flags = self.addon.reviewerflags.reload()
+        assert not flags.auto_approval_disabled_until_next_approval_unlisted
+        assert flags.auto_approval_disabled_until_next_approval
         assert len(mail.outbox) == 3
         assert mail.outbox[0].to == ['email@domain.com']
         assert mail.outbox[1].to == [self.abuse_report_auth.reporter.email]
@@ -1649,9 +1674,14 @@ class TestContentActionRejectVersion(TestContentActionDisableAddon):
             'human_review': False,
             'policy_texts': [self.policy.full_text()],
         }
+        flags = self.addon.reviewerflags.reload()
+        assert not flags.auto_approval_disabled_until_next_approval_unlisted
+        assert flags.auto_approval_disabled_until_next_approval
 
+    def test_hold_action_human(self):
         user = user_factory()
-        self.decision.update(reviewer_user=user)
+        self.decision.update(action=self.takedown_decision_action, reviewer_user=user)
+        action_helper = self.ActionClass(self.decision)
         activity = action_helper.hold_action()
         assert activity.arguments == [
             self.addon,
@@ -1666,6 +1696,9 @@ class TestContentActionRejectVersion(TestContentActionDisableAddon):
             'versions': [self.version.version, self.old_version.version],
             'human_review': True,
         }
+        flags = self.addon.reviewerflags.reload()
+        assert not flags.auto_approval_disabled_until_next_approval_unlisted
+        assert flags.auto_approval_disabled_until_next_approval
 
     def test_should_hold_action(self):
         self.decision.update(action=DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON)

--- a/src/olympia/abuse/tests/test_actions.py
+++ b/src/olympia/abuse/tests/test_actions.py
@@ -19,7 +19,12 @@ from olympia.activity.models import (
     ActivityLogToken,
     AttachmentLog,
 )
-from olympia.addons.models import Addon, AddonApprovalsCounter, AddonUser
+from olympia.addons.models import (
+    Addon,
+    AddonApprovalsCounter,
+    AddonReviewerFlags,
+    AddonUser,
+)
 from olympia.amo.tests import (
     TestCase,
     addon_factory,
@@ -706,6 +711,9 @@ class TestContentActionDisableAddon(BaseTestContentAction, TestCase):
     def test_execute_action(self):
         subject = self._process_action_and_notify()
         assert len(mail.outbox) == 3
+        flags = self.addon.reviewerflags.reload()
+        assert flags.auto_approval_disabled
+        assert flags.auto_approval_disabled_unlisted
         self._test_reporter_takedown_email(subject)
 
     def test_execute_action_after_reporter_appeal(self):
@@ -906,6 +914,9 @@ class TestContentActionDisableAddon(BaseTestContentAction, TestCase):
                 else {}
             ),
         }
+        flags = self.addon.reviewerflags.reload()
+        assert flags.auto_approval_disabled
+        assert flags.auto_approval_disabled_unlisted
 
     def test_forward_from_reviewers_no_job(self):
         self.decision.update(action=DECISION_ACTIONS.AMO_LEGAL_FORWARD, cinder_job=None)
@@ -1418,6 +1429,8 @@ class TestContentActionRejectVersion(TestContentActionDisableAddon):
         flags = self.addon.reviewerflags.reload()
         assert flags.auto_approval_disabled_until_next_approval
         assert not flags.auto_approval_disabled_until_next_approval_unlisted
+        assert not flags.auto_approval_disabled
+        assert not flags.auto_approval_disabled_unlisted
         assert len(mail.outbox) == 3
         self._test_reporter_takedown_email(subject)
 
@@ -1427,6 +1440,8 @@ class TestContentActionRejectVersion(TestContentActionDisableAddon):
         flags = self.addon.reviewerflags.reload()
         assert flags.auto_approval_disabled_until_next_approval_unlisted
         assert not flags.auto_approval_disabled_until_next_approval
+        assert not flags.auto_approval_disabled
+        assert not flags.auto_approval_disabled_unlisted
         assert len(mail.outbox) == 3
         self._test_reporter_takedown_email(subject)
 
@@ -1677,6 +1692,8 @@ class TestContentActionRejectVersion(TestContentActionDisableAddon):
         flags = self.addon.reviewerflags.reload()
         assert not flags.auto_approval_disabled_until_next_approval_unlisted
         assert flags.auto_approval_disabled_until_next_approval
+        assert not flags.auto_approval_disabled
+        assert not flags.auto_approval_disabled_unlisted
 
     def test_hold_action_human(self):
         user = user_factory()
@@ -1699,6 +1716,8 @@ class TestContentActionRejectVersion(TestContentActionDisableAddon):
         flags = self.addon.reviewerflags.reload()
         assert not flags.auto_approval_disabled_until_next_approval_unlisted
         assert flags.auto_approval_disabled_until_next_approval
+        assert not flags.auto_approval_disabled
+        assert not flags.auto_approval_disabled_unlisted
 
     def test_should_hold_action(self):
         self.decision.update(action=DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON)
@@ -2640,6 +2659,13 @@ class TestContentActionRejectListingContent(TestContentActionDisableAddon):
         action_helper.notify_owners()
         self._test_owner_restore_email(f'Mozilla Add-ons: {self.addon.name}')
 
+    def test_execute_action(self):
+        subject = self._process_action_and_notify()
+        assert len(mail.outbox) == 3
+        self._test_reporter_takedown_email(subject)
+        # Content-rejection doesn't affect auto-approval disabled flags.
+        assert not AddonReviewerFlags.objects.filter(addon=self.addon).exists()
+
     def test_hold_action(self):
         self.decision.update(action=self.takedown_decision_action)
         action_helper = self.ActionClass(self.decision)
@@ -2662,6 +2688,8 @@ class TestContentActionRejectListingContent(TestContentActionDisableAddon):
             'human_review': False,
             'policy_texts': [self.policy.full_text()],
         }
+        # Content-rejection doesn't affect auto-approval disabled flags.
+        assert not AddonReviewerFlags.objects.filter(addon=self.addon).exists()
 
     def test_addon_version_has_target_versions(self):
         # This type of action doesn't have any target_versions, so addon_version will

--- a/src/olympia/reviewers/tests/test_commands.py
+++ b/src/olympia/reviewers/tests/test_commands.py
@@ -708,7 +708,7 @@ class TestAutoApproveCommand(AutoApproveTestsMixin, TestCase):
     @mock.patch('olympia.reviewers.utils.sign_file')
     def test_run_actions_policy_reject(self, sign_file_mock):
         """Functional test making sure that the scanners rejecting a version
-        from a polic enforcement action doesn't allow that same version to
+        from a policy enforcement action doesn't allow that same version to
         be auto-approved."""
         responses.add_callback(
             responses.POST,
@@ -725,8 +725,7 @@ class TestAutoApproveCommand(AutoApproveTestsMixin, TestCase):
 
             assert self.version.file.status == amo.STATUS_DISABLED
 
-            self.addon.refresh_from_db()
-            flags = self.addon.reviewerflags
+            flags = self.addon.reviewerflags.reload()
             assert flags.auto_approval_disabled_until_next_approval
 
             assert not sign_file_mock.called
@@ -751,8 +750,60 @@ class TestAutoApproveCommand(AutoApproveTestsMixin, TestCase):
         call_command('auto_approve')
         check_assertions()
 
-        # call_command('auto_approve')  # Shouldn't matter if it's called twice.
-        # check_assertions()
+        call_command('auto_approve')  # Shouldn't matter if it's called twice.
+        check_assertions()
+
+    @mock.patch('olympia.reviewers.utils.sign_file')
+    def test_run_actions_policy_force_disable(self, sign_file_mock):
+        """Functional test making sure that the scanners force-disabling the
+        add-on from a policy enforcement action doesn't allow that version
+        to be auto-approved."""
+        responses.add_callback(
+            responses.POST,
+            f'{settings.CINDER_SERVER_URL}v1/create_decision',
+            callback=lambda r: (201, {}, json.dumps({'uuid': uuid.uuid4().hex})),
+        )
+
+        def check_assertions():
+            self.addon.reload()
+            self.version.reload()
+            self.version.file.reload()
+
+            assert self.addon.status == amo.STATUS_DISABLED
+
+            aps = self.version.autoapprovalsummary.reload()
+            assert aps.has_auto_approval_disabled
+
+            assert self.version.file.status == amo.STATUS_DISABLED
+
+            flags = self.addon.reviewerflags.reload()
+            assert flags.auto_approval_disabled
+            assert flags.auto_approval_disabled_unlisted
+
+            assert not sign_file_mock.called
+
+        self.create_switch('run-action-in-auto-approve', active=True)
+        reject_policy = CinderPolicy.objects.create(
+            enforcement_actions=[DECISION_ACTIONS.AMO_DISABLE_ADDON.api_value],
+            name='Disable Policy',
+            expose_in_reviewer_tools=True,
+            uuid=uuid.uuid4().hex,
+        )
+        ScannerRule.objects.create(
+            is_active=True, name='foo', policy=reject_policy, scanner=YARA
+        )
+        result = ScannerResult.objects.create(
+            scanner=YARA,
+            version=self.version,
+            results=[{'rule': 'foo', 'tags': [], 'meta': {}}],
+        )
+        assert result.has_matches
+
+        call_command('auto_approve')
+        check_assertions()
+
+        call_command('auto_approve')  # Shouldn't matter if it's called twice.
+        check_assertions()
 
     @mock.patch('olympia.reviewers.utils.sign_file')
     def test_run_actions_delay_approval_with_run_narc(self, sign_file_mock):

--- a/src/olympia/reviewers/tests/test_commands.py
+++ b/src/olympia/reviewers/tests/test_commands.py
@@ -675,10 +675,11 @@ class TestAutoApproveCommand(AutoApproveTestsMixin, TestCase):
 
     @mock.patch('olympia.reviewers.utils.sign_file')
     def test_run_actions_delay_approval(self, sign_file_mock):
-        # Functional test making sure that the scanners _delay_auto_approval()
-        # action properly delays auto-approval on the version it's applied to
+        """Functional test making sure that the scanners _delay_auto_approval()
+        action properly delays auto-approval on the version it's applied to"""
+
         def check_assertions():
-            aps = self.version.autoapprovalsummary
+            aps = self.version.autoapprovalsummary.reload()
             assert aps.has_auto_approval_disabled
 
             self.addon.refresh_from_db()
@@ -705,10 +706,60 @@ class TestAutoApproveCommand(AutoApproveTestsMixin, TestCase):
         check_assertions()
 
     @mock.patch('olympia.reviewers.utils.sign_file')
+    def test_run_actions_policy_reject(self, sign_file_mock):
+        """Functional test making sure that the scanners rejecting a version
+        from a polic enforcement action doesn't allow that same version to
+        be auto-approved."""
+        responses.add_callback(
+            responses.POST,
+            f'{settings.CINDER_SERVER_URL}v1/create_decision',
+            callback=lambda r: (201, {}, json.dumps({'uuid': uuid.uuid4().hex})),
+        )
+
+        def check_assertions():
+            self.version.reload()
+            self.version.file.reload()
+
+            aps = self.version.autoapprovalsummary.reload()
+            assert aps.has_auto_approval_disabled
+
+            assert self.version.file.status == amo.STATUS_DISABLED
+
+            self.addon.refresh_from_db()
+            flags = self.addon.reviewerflags
+            assert flags.auto_approval_disabled_until_next_approval
+
+            assert not sign_file_mock.called
+
+        self.create_switch('run-action-in-auto-approve', active=True)
+        reject_policy = CinderPolicy.objects.create(
+            enforcement_actions=[DECISION_ACTIONS.AMO_REJECT_VERSION_ADDON.api_value],
+            name='Reject Policy',
+            expose_in_reviewer_tools=True,
+            uuid=uuid.uuid4().hex,
+        )
+        ScannerRule.objects.create(
+            is_active=True, name='foo', policy=reject_policy, scanner=YARA
+        )
+        result = ScannerResult.objects.create(
+            scanner=YARA,
+            version=self.version,
+            results=[{'rule': 'foo', 'tags': [], 'meta': {}}],
+        )
+        assert result.has_matches
+
+        call_command('auto_approve')
+        check_assertions()
+
+        # call_command('auto_approve')  # Shouldn't matter if it's called twice.
+        # check_assertions()
+
+    @mock.patch('olympia.reviewers.utils.sign_file')
     def test_run_actions_delay_approval_with_run_narc(self, sign_file_mock):
-        # Functional test making sure that the scanners _delay_auto_approval()
-        # action properly delays auto-approval on the version it's applied to,
-        # including when the scanner is narc (which is run in auto-approve).
+        """Functional test making sure that the scanners _delay_auto_approval()
+        action properly delays auto-approval on the version it's applied to,
+        including when the scanner is narc (which is run in auto-approve)."""
+
         def check_assertions():
             assert self.version.scannerresults.count() == 1
             result = self.version.scannerresults.get()

--- a/src/olympia/reviewers/utils.py
+++ b/src/olympia/reviewers/utils.py
@@ -1568,7 +1568,6 @@ class ReviewBase:
         See auto_reject_multiple_versions also, that can handle delayed rejections from
         different reviewers"""
         assert self.human_review is True
-        channel = self.version.channel if self.version else None
         self.version = None
         self.file = None
         decision_metadata = {
@@ -1607,17 +1606,6 @@ class ReviewBase:
             self.clear_specific_needs_human_review_flags(version)
             self.set_human_review_date(version)
 
-        # A human rejection (delayed or not) implies the next version in the
-        # same channel should be manually reviewed.
-        auto_approval_disabled_until_next_approval_flag = (
-            'auto_approval_disabled_until_next_approval'
-            if channel == amo.CHANNEL_LISTED
-            else 'auto_approval_disabled_until_next_approval_unlisted'
-        )
-        AddonReviewerFlags.objects.update_or_create(
-            addon=self.addon,
-            defaults={auto_approval_disabled_until_next_approval_flag: True},
-        )
         log.info('Sending email for %s' % (self.addon))
         self.record_decision(
             action_id,


### PR DESCRIPTION
Scanners performing a reject version action should prevent approval until the next manual approval just like if it was done in reviewer tools: This is not just consistent, it also prevents auto-approval of the very version we just rejected, since actions are ran in auto_approve.

Fixes https://github.com/mozilla/addons/issues/16123

### Context

With `run-action-in-auto-approve` set (`True` in dev/stage/prod) we run scanner workflow and enforcement actions in `auto_approve()`, after having fetched versions to auto-approve, but before determining if the version can actually be auto-approved.

This means that we should ensure actions that affect the version negatively also prevent its auto-approval, otherwise we can execute the action and then proceed with auto-approval normally, leading to inconsistent states.

Even without taking this scenario into consideration, rejecting a version should prevent auto-approval of the next submission regardless of the source of the rejection.

### Testing

See `test_run_actions_policy_force_disable()` and `test_run_actions_policy_reject()`:
- Make sure `run-action-in-auto-approve` waffle switch is enabled
- Set up a policy that either rejects or force-disable as the enforcement action, available in reviewer tools
- Set up a scanner rule that always matches (you can use yara with `a `condition: true`) with that policy 
- Submit a new version (Make sure `INITIAL_AUTO_APPROVAL_DELAY_FOR_LISTED` and `INITIAL_DELAY_FOR_UNLISTED` config keys are set to 0 depending on what channel you are using, or submit a new version of an existing approved add-on to not affect results - otherwise that delay will accidentally work around the issue by preventing auto-approval)
- Run `auto_approve`

Expected results:
- The add-on should be disabled if the enforcement action was force disable
- The version should be rejected and not be approved.
