### PR TITLE
Prevent the creation of a new service account when a webhook scanner name is changed

### DIFF
--- a/src/olympia/scanners/models.py
+++ b/src/olympia/scanners/models.py
@@ -332,19 +332,22 @@ class ScannerWebhook(ModelBase):
         db_table = 'scanners_webhooks'
 
     def save(self, *args, **kwargs):
-        service_account, created = UserProfile.objects.get_or_create_service_account(
-            name=f'webhook-{self.name}',
-            notes=(
-                'Service account automatically created for '
-                f'the "{self.name}" scanner webhook.'
-            ),
-        )
-        if created:
-            # Add service account to the scanner group.
-            group = Group.objects.get(name=SCANNER_SERVICE_ACCOUNTS_GROUP)
-            GroupUser.objects.get_or_create(group=group, user=service_account)
+        if not self.service_account:
+            service_account, created = (
+                UserProfile.objects.get_or_create_service_account(
+                    name=f'webhook-{self.name}',
+                    notes=(
+                        'Service account automatically created for '
+                        f'the "{self.name}" scanner webhook.'
+                    ),
+                )
+            )
+            if created:
+                # Add service account to the scanner group.
+                group = Group.objects.get(name=SCANNER_SERVICE_ACCOUNTS_GROUP)
+                GroupUser.objects.get_or_create(group=group, user=service_account)
 
-        self.service_account = service_account
+            self.service_account = service_account
         return super().save(*args, **kwargs)
 
     def __str__(self):

--- a/src/olympia/scanners/tests/test_models.py
+++ b/src/olympia/scanners/tests/test_models.py
@@ -36,6 +36,7 @@ from olympia.scanners.models import (
     ScannerWebhook,
     ScannerWebhookEvent,
 )
+from olympia.users.models import UserProfile
 
 
 class FakeYaraMatch:
@@ -793,3 +794,20 @@ class TestScannerWebhook(TestCase):
 
         scanner_group = Group.objects.get(name=SCANNER_SERVICE_ACCOUNTS_GROUP)
         assert GroupUser.objects.filter(group=scanner_group, user=user).count() == 1
+
+    def test_save_does_not_recreate_service_account_on_rename(self):
+        webhook = ScannerWebhook(
+            name='some-name',
+            url='https://example.com',
+            api_key='secret',
+        )
+        webhook.save()
+        original_account = webhook.service_account
+        assert original_account is not None
+        expected_count = UserProfile.objects.count()
+
+        webhook.name = 'some-new-name'
+        webhook.save()
+
+        assert webhook.service_account == original_account
+        assert UserProfile.objects.count() == expected_count


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/16215